### PR TITLE
feat: update Claude Code & Codex CLI providers to latest API

### DIFF
--- a/lionagi/service/third_party/claude_code.py
+++ b/lionagi/service/third_party/claude_code.py
@@ -33,30 +33,21 @@ if (c := (shutil.which("claude") or "claude")) and shutil.which(c):
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger("claude-cli")
 
-# --------------------------------------------------------------------------- constants
-ClaudePermission = Literal[
+
+# --------------------------------------------------------------------------- types
+ClaudePermissionMode = Literal[
     "default",
     "acceptEdits",
+    "plan",
+    "dontAsk",
     "bypassPermissions",
-    "dangerously-skip-permissions",
 ]
+# Backward-compat alias
+ClaudePermission = ClaudePermissionMode
 
-CLAUDE_CODE_OPTION_PARAMS = {
-    "allowed_tools",
-    "max_thinking_tokens",
-    "mcp_tools",
-    "mcp_servers",
-    "permission_mode",
-    "continue_conversation",
-    "resume",
-    "max_turns",
-    "disallowed_tools",
-    "model",
-    "permission_prompt_tool_name",
-    "cwd",
-    "system_prompt",
-    "append_system_prompt",
-}
+ClaudeEffort = Literal["low", "medium", "high", "max"]
+ClaudeOutputFormat = Literal["text", "json", "stream-json"]
+ClaudeInputFormat = Literal["text", "stream-json"]
 
 
 __all__ = (
@@ -67,42 +58,242 @@ __all__ = (
 )
 
 
+# --------------------------------------------------------------------------- flag metadata
+#
+# Each CLI-mappable field carries a ``json_schema_extra`` dict produced by
+# ``_cli()``.  The generic ``_build_declarative_args()`` loop reads these
+# dicts (sorted by *order*) and emits the correct flag sequence.
+#
+# kind semantics:
+#   value      – ``--flag <str(val)>``
+#   bool       – ``--flag`` when truthy, omit otherwise
+#   bool_pair  – ``--flag`` when True, ``--neg-flag`` when False, omit when None
+#   list_args  – ``--flag arg1 arg2 …`` (one flag, many positional args)
+#   json_value – ``--flag '<json>'``   (dict/list serialised to JSON string)
+#   repeat     – ``--flag a --flag b`` (flag repeated per item)
+
+
+def _cli(
+    flag: str,
+    order: int,
+    kind: str = "value",
+    *,
+    neg_flag: str | None = None,
+) -> dict[str, Any]:
+    d: dict[str, Any] = {
+        "cli_flag": flag,
+        "cli_order": order,
+        "cli_kind": kind,
+    }
+    if neg_flag:
+        d["cli_neg_flag"] = neg_flag
+    return d
+
+
 # --------------------------------------------------------------------------- request model
 class ClaudeCodeRequest(BaseModel):
-    # -- conversational bits -------------------------------------------------
+    """Configuration + prompt for a Claude Code CLI invocation.
+
+    Every field annotated with ``_cli(...)`` metadata is automatically
+    assembled into CLI arguments by :meth:`as_cmd_args`, sorted by its
+    ``order`` value.  A handful of special cases (``permission_mode``,
+    ``max_turns``, ``worktree``, ``debug``, legacy ``mcp_servers``) are
+    handled with explicit logic after the declarative pass.
+
+    Adding a new CLI flag is one line: declare the field with ``_cli()``
+    metadata and the builder picks it up automatically.
+    """
+
+    # ── prompt (always required) ──────────────────────────────────
     prompt: str = Field(description="The prompt for Claude Code")
-    system_prompt: str | None = None
-    append_system_prompt: str | None = None
+
+    # ── session management (order 10–19) ──────────────────────────
+    continue_conversation: bool = Field(
+        default=False,
+        json_schema_extra=_cli("--continue", 10, "bool"),
+    )
+    resume: str | None = Field(
+        default=None,
+        json_schema_extra=_cli("--resume", 11),
+    )
+    session_id: str | None = Field(
+        default=None,
+        json_schema_extra=_cli("--session-id", 12),
+    )
+    name: str | None = Field(
+        default=None,
+        json_schema_extra=_cli("--name", 13),
+    )
+    fork_session: bool = Field(
+        default=False,
+        json_schema_extra=_cli("--fork-session", 14, "bool"),
+    )
+
+    # ── model & runtime (order 20–29) ─────────────────────────────
+    model: Literal["sonnet", "opus", "haiku"] | str | None = Field(
+        default="sonnet",
+        json_schema_extra=_cli("--model", 20),
+    )
+    effort: ClaudeEffort | None = Field(
+        default=None,
+        json_schema_extra=_cli("--effort", 21),
+    )
+    fallback_model: str | None = Field(
+        default=None,
+        json_schema_extra=_cli("--fallback-model", 22),
+    )
+    # max_turns is special-cased (+1 offset) — no _cli metadata
     max_turns: int | None = None
-    continue_conversation: bool = False
-    resume: str | None = None
+    max_budget_usd: float | None = Field(
+        default=None,
+        json_schema_extra=_cli("--max-budget-usd", 24),
+    )
 
-    # -- repo / workspace ----------------------------------------------------
+    # ── system prompt (order 30–39) ───────────────────────────────
+    system_prompt: str | None = Field(
+        default=None,
+        json_schema_extra=_cli("--system-prompt", 30),
+    )
+    system_prompt_file: str | Path | None = Field(
+        default=None,
+        json_schema_extra=_cli("--system-prompt-file", 31),
+    )
+    append_system_prompt: str | None = Field(
+        default=None,
+        json_schema_extra=_cli("--append-system-prompt", 32),
+    )
+    append_system_prompt_file: str | Path | None = Field(
+        default=None,
+        json_schema_extra=_cli("--append-system-prompt-file", 33),
+    )
+
+    # ── permissions (order 40–49) ─────────────────────────────────
+    # permission_mode is special-cased — no _cli metadata
+    permission_mode: ClaudePermissionMode | None = None
+    allow_dangerously_skip_permissions: bool = Field(
+        default=False,
+        json_schema_extra=_cli(
+            "--allow-dangerously-skip-permissions", 40, "bool"
+        ),
+    )
+    allowed_tools: list[str] | None = Field(
+        default=None,
+        json_schema_extra=_cli("--allowedTools", 42, "list_args"),
+    )
+    disallowed_tools: list[str] | None = Field(
+        default=None,
+        json_schema_extra=_cli("--disallowedTools", 43, "list_args"),
+    )
+    tools: str | None = Field(
+        default=None,
+        description="Restrict available tools (comma-separated or 'default')",
+        json_schema_extra=_cli("--tools", 44),
+    )
+    permission_prompt_tool_name: str | None = Field(
+        default=None,
+        json_schema_extra=_cli("--permission-prompt-tool", 45),
+    )
+
+    # ── MCP (order 50–59) ─────────────────────────────────────────
+    mcp_config: str | Path | None = Field(
+        default=None,
+        json_schema_extra=_cli("--mcp-config", 50),
+    )
+    strict_mcp_config: bool = Field(
+        default=False,
+        json_schema_extra=_cli("--strict-mcp-config", 51, "bool"),
+    )
+    # Legacy: if set and mcp_config is absent, serialised to --mcp-config JSON
+    mcp_servers: dict[str, Any] = Field(default_factory=dict, exclude=True)
+
+    # ── agents (order 60–69) ──────────────────────────────────────
+    agent: str | None = Field(
+        default=None,
+        json_schema_extra=_cli("--agent", 60),
+    )
+    agents: dict[str, Any] | None = Field(
+        default=None,
+        json_schema_extra=_cli("--agents", 61, "json_value"),
+    )
+
+    # ── workspace (order 70–79) ───────────────────────────────────
     repo: Path = Field(default_factory=Path.cwd, exclude=True)
-    ws: str | None = None  # sub-directory under repo
-    add_dir: str | None = None  # extra read-only mount
-    allowed_tools: list[str] | None = None
+    ws: str | None = Field(default=None, exclude=True)
+    add_dir: list[str] | None = Field(
+        default=None,
+        json_schema_extra=_cli("--add-dir", 70, "list_args"),
+    )
+    # worktree is special-cased (bool vs str) — no _cli metadata
+    worktree: str | bool | None = Field(default=None, exclude=True)
 
-    # -- runtime & safety ----------------------------------------------------
-    model: Literal["sonnet", "opus"] | str | None = "sonnet"
-    max_thinking_tokens: int | None = None
-    mcp_tools: list[str] = Field(default_factory=list)
-    mcp_servers: dict[str, Any] = Field(default_factory=dict)
-    mcp_config: str | Path | None = Field(None, exclude=True)
-    permission_mode: ClaudePermission | None = None
-    permission_prompt_tool_name: str | None = None
-    disallowed_tools: list[str] = Field(default_factory=list)
+    # ── features (order 80–89) ────────────────────────────────────
+    chrome: bool | None = Field(
+        default=None,
+        json_schema_extra=_cli(
+            "--chrome", 80, "bool_pair", neg_flag="--no-chrome"
+        ),
+    )
+    disable_slash_commands: bool = Field(
+        default=False,
+        json_schema_extra=_cli("--disable-slash-commands", 81, "bool"),
+    )
+    no_session_persistence: bool = Field(
+        default=False,
+        json_schema_extra=_cli("--no-session-persistence", 82, "bool"),
+    )
 
-    # -- internal use --------------------------------------------------------
+    # ── output (order 90–99) ──────────────────────────────────────
+    output_format: ClaudeOutputFormat = Field(
+        default="stream-json", exclude=True
+    )
+    input_format: ClaudeInputFormat | None = Field(
+        default=None,
+        json_schema_extra=_cli("--input-format", 91),
+    )
+    # Named json_schema_output to avoid shadowing Pydantic's json_schema
+    json_schema_output: dict[str, Any] | str | None = Field(
+        default=None,
+        json_schema_extra=_cli("--json-schema", 92, "json_value"),
+    )
+    include_partial_messages: bool = Field(
+        default=False,
+        json_schema_extra=_cli("--include-partial-messages", 93, "bool"),
+    )
+
+    # ── settings & debug (order 100–109) ──────────────────────────
+    settings: str | Path | None = Field(
+        default=None,
+        json_schema_extra=_cli("--settings", 100),
+    )
+    setting_sources: str | None = Field(
+        default=None,
+        json_schema_extra=_cli("--setting-sources", 101),
+    )
+    betas: list[str] | None = Field(
+        default=None,
+        json_schema_extra=_cli("--betas", 102, "list_args"),
+    )
+    # debug is special-cased (bool vs str) — no _cli metadata
+    debug: str | bool | None = Field(default=None, exclude=True)
+
+    # ── lionagi internal (never become CLI flags) ─────────────────
     auto_finish: bool = Field(
         default=False,
+        exclude=True,
         description="Automatically finish the conversation after the first response",
     )
-    verbose_output: bool = Field(default=False)
-    cli_display_theme: Literal["light", "dark"] = "dark"
-    cli_include_summary: bool = Field(default=False)
+    verbose_output: bool = Field(default=False, exclude=True)
+    cli_display_theme: Literal["light", "dark"] = Field(
+        default="dark", exclude=True
+    )
+    cli_include_summary: bool = Field(default=False, exclude=True)
 
-    # ------------------------ validators & helpers --------------------------
+    # Legacy fields (kept for backward compat, unused in CLI args)
+    mcp_tools: list[str] = Field(default_factory=list, exclude=True)
+    max_thinking_tokens: int | None = Field(default=None, exclude=True)
+
+    # ── validators ────────────────────────────────────────────────
+
     @field_validator("permission_mode", mode="before")
     def _norm_perm(cls, v):
         if v in {
@@ -110,6 +301,12 @@ class ClaudeCodeRequest(BaseModel):
             "--dangerously-skip-permissions",
         }:
             return "bypassPermissions"
+        return v
+
+    @field_validator("add_dir", mode="before")
+    def _norm_add_dir(cls, v):
+        if isinstance(v, str):
+            return [v]
         return v
 
     @model_validator(mode="before")
@@ -139,7 +336,9 @@ class ClaudeCodeRequest(BaseModel):
                 if message["role"] != "system":
                     content = message["content"]
                     prompts.append(
-                        ln.json_dumps(content) if isinstance(content, (dict, list)) else content
+                        ln.json_dumps(content)
+                        if isinstance(content, (dict, list))
+                        else content
                     )
 
             prompt = "\n".join(prompts)
@@ -156,31 +355,67 @@ class ClaudeCodeRequest(BaseModel):
             data_["system_prompt"] = msg[0]["content"]
 
         if "append_system_prompt" in data and data["append_system_prompt"]:
-            data_["append_system_prompt"] = str(data.get("append_system_prompt"))
+            data_["append_system_prompt"] = str(
+                data.get("append_system_prompt")
+            )
 
         data_.update(data)
         return data_
 
-    # Workspace path derived from repo + ws
+    @model_validator(mode="after")
+    def _check_constraints(self):
+        # Session flag constraints
+        if self.resume:
+            self.continue_conversation = False
+        if self.fork_session and not (
+            self.resume or self.continue_conversation
+        ):
+            raise ValueError(
+                "--fork-session requires --resume or --continue"
+            )
+
+        # System prompt mutual exclusivity
+        if self.system_prompt and self.system_prompt_file:
+            raise ValueError(
+                "--system-prompt and --system-prompt-file are mutually exclusive"
+            )
+
+        # Workspace bounds check for bypassPermissions
+        if self.permission_mode == "bypassPermissions":
+            repo_resolved = self.repo.resolve()
+            cwd_resolved = self.cwd().resolve()
+            try:
+                cwd_resolved.relative_to(repo_resolved)
+            except ValueError:
+                raise ValueError(
+                    f"With bypassPermissions, workspace must be within "
+                    f"repository bounds. Repository: {repo_resolved}, "
+                    f"Workspace: {cwd_resolved}"
+                ) from None
+
+        return self
+
+    # ── workspace path ────────────────────────────────────────────
+
     def cwd(self) -> Path:
         if not self.ws:
             return self.repo
 
-        # Convert to Path object for proper validation
         ws_path = Path(self.ws)
 
-        # Check for absolute paths or directory traversal attempts
         if ws_path.is_absolute():
-            raise ValueError(f"Workspace path must be relative, got absolute: {self.ws}")
+            raise ValueError(
+                f"Workspace path must be relative, got absolute: {self.ws}"
+            )
 
         if ".." in ws_path.parts:
-            raise ValueError(f"Directory traversal detected in workspace path: {self.ws}")
+            raise ValueError(
+                f"Directory traversal detected in workspace path: {self.ws}"
+            )
 
-        # Resolve paths to handle symlinks and normalize
         repo_resolved = self.repo.resolve()
         result = (self.repo / ws_path).resolve()
 
-        # Ensure the resolved path is within the repository bounds
         try:
             result.relative_to(repo_resolved)
         except ValueError:
@@ -191,63 +426,132 @@ class ClaudeCodeRequest(BaseModel):
 
         return result
 
-    @model_validator(mode="after")
-    def _check_perm_workspace(self):
-        if self.permission_mode == "bypassPermissions":
-            # Use secure path validation with resolved paths
-            repo_resolved = self.repo.resolve()
-            cwd_resolved = self.cwd().resolve()
+    # ── CLI command builder ───────────────────────────────────────
 
-            # Check if cwd is within repo bounds using proper path methods
-            try:
-                cwd_resolved.relative_to(repo_resolved)
-            except ValueError:
-                raise ValueError(
-                    f"With bypassPermissions, workspace must be within repository bounds. "
-                    f"Repository: {repo_resolved}, Workspace: {cwd_resolved}"
-                ) from None
-        return self
-
-    # ------------------------ CLI helpers -----------------------------------
     def as_cmd_args(self) -> list[str]:
-        """Build argument list for the *Node* `claude` CLI."""
-        args: list[str] = ["-p", self.prompt, "--output-format", "stream-json"]
-        if self.allowed_tools:
-            args.append("--allowedTools")
-            for tool in self.allowed_tools:
-                args.append(tool)
+        """Build argument list for the Claude Code CLI.
 
-        if self.disallowed_tools:
-            args.append("--disallowedTools")
-            for tool in self.disallowed_tools:
-                args.append(tool)
+        Flags are assembled in two passes:
 
-        if self.resume:
-            args += ["--resume", self.resume]
-        elif self.continue_conversation:
-            args.append("--continue")
+        1. **Declarative** – fields carrying ``_cli()`` metadata are
+           collected, sorted by ``order``, and emitted by ``kind``.
+        2. **Special cases** – ``permission_mode``, ``max_turns``,
+           ``worktree``, ``debug``, and legacy ``mcp_servers`` need
+           non-mechanical logic and are handled explicitly.
 
-        if self.max_turns:
-            # +1 because CLI counts *pairs*
-            args += ["--max-turns", str(self.max_turns + 1)]
+        The prompt (``-p``) and ``--output-format`` always come first;
+        ``--verbose`` is always appended last.
+        """
+        args: list[str] = [
+            "-p",
+            self.prompt,
+            "--output-format",
+            self.output_format,
+        ]
 
-        if self.permission_mode == "bypassPermissions":
-            args += ["--dangerously-skip-permissions"]
+        # ── pass 1: declarative flags ──
+        args.extend(self._build_declarative_args())
 
-        if self.add_dir:
-            args += ["--add-dir", self.add_dir]
+        # ── pass 2: special cases ──
 
-        if self.permission_prompt_tool_name:
-            args += [
-                "--permission-prompt-tool",
-                self.permission_prompt_tool_name,
-            ]
+        # permission_mode → --dangerously-skip-permissions OR --permission-mode
+        if self.permission_mode:
+            if self.permission_mode == "bypassPermissions":
+                args.append("--dangerously-skip-permissions")
+            else:
+                args.extend(["--permission-mode", self.permission_mode])
 
-        if self.mcp_config:
-            args += ["--mcp-config", str(self.mcp_config)]
+        # max_turns → +1 offset (CLI counts agentic turns differently)
+        if self.max_turns is not None:
+            args.extend(["--max-turns", str(self.max_turns + 1)])
 
-        args += ["--model", self.model or "sonnet", "--verbose"]
+        # worktree → True emits bare flag, str emits flag + name
+        if self.worktree is not None and self.worktree is not False:
+            if isinstance(self.worktree, str):
+                args.extend(["--worktree", self.worktree])
+            else:
+                args.append("--worktree")
+
+        # debug → True emits bare flag, str emits flag + categories
+        if self.debug:
+            if isinstance(self.debug, str):
+                args.extend(["--debug", self.debug])
+            else:
+                args.append("--debug")
+
+        # Legacy mcp_servers dict → serialise as --mcp-config JSON inline
+        if self.mcp_servers and not self.mcp_config:
+            args.extend(
+                [
+                    "--mcp-config",
+                    json.dumps({"mcpServers": self.mcp_servers}),
+                ]
+            )
+
+        # model default – always emit
+        if "--model" not in args:
+            args.extend(["--model", self.model or "sonnet"])
+
+        # always verbose for structured stream output
+        args.append("--verbose")
         return args
+
+    def _build_declarative_args(self) -> list[str]:
+        """Collect fields with ``_cli()`` metadata and emit flags."""
+        flagged: list[tuple[int, dict, Any]] = []
+        for field_name, field_info in type(self).model_fields.items():
+            extra = field_info.json_schema_extra
+            if not extra or "cli_flag" not in extra:
+                continue
+            val = getattr(self, field_name)
+            if val is None:
+                continue
+            if isinstance(val, list) and not val:
+                continue
+            if val is False and extra.get("cli_kind") != "bool_pair":
+                continue
+            flagged.append((extra["cli_order"], extra, val))
+
+        flagged.sort(key=lambda x: x[0])
+
+        args: list[str] = []
+        for _, extra, val in flagged:
+            flag = extra["cli_flag"]
+            kind = extra.get("cli_kind", "value")
+
+            if kind == "bool":
+                if val:
+                    args.append(flag)
+
+            elif kind == "bool_pair":
+                if val is True:
+                    args.append(flag)
+                elif val is False and extra.get("cli_neg_flag"):
+                    args.append(extra["cli_neg_flag"])
+
+            elif kind == "list_args":
+                args.append(flag)
+                args.extend(str(v) for v in val)
+
+            elif kind == "json_value":
+                serialized = (
+                    json.dumps(val)
+                    if isinstance(val, (dict, list))
+                    else str(val)
+                )
+                args.extend([flag, serialized])
+
+            elif kind == "repeat":
+                for v in val:
+                    args.extend([flag, str(v)])
+
+            else:  # "value"
+                args.extend([flag, str(val)])
+
+        return args
+
+
+# --------------------------------------------------------------------------- chunks & session
 
 
 @dataclass
@@ -309,7 +613,9 @@ def _extract_summary(session: ClaudeSession) -> dict[str, Any]:
         tool_counts[tool_name] = tool_counts.get(tool_name, 0) + 1
 
         # Store detailed info
-        tool_details.append({"tool": tool_name, "id": tool_id, "input": tool_input})
+        tool_details.append(
+            {"tool": tool_name, "id": tool_id, "input": tool_input}
+        )
 
         # Categorize file operations and actions
         if tool_name in ["Read", "read"]:
@@ -329,7 +635,9 @@ def _extract_summary(session: ClaudeSession) -> dict[str, Any]:
 
         elif tool_name in ["Bash", "bash"]:
             command = tool_input.get("command", "")
-            command_summary = command[:50] + "..." if len(command) > 50 else command
+            command_summary = (
+                command[:50] + "..." if len(command) > 50 else command
+            )
             key_actions.append(f"Ran: {command_summary}")
 
         elif tool_name in ["Glob", "glob"]:
@@ -340,12 +648,11 @@ def _extract_summary(session: ClaudeSession) -> dict[str, Any]:
             pattern = tool_input.get("pattern", "")
             key_actions.append(f"Searched content: {pattern}")
 
-        elif tool_name in ["Task", "task"]:
+        elif tool_name in ["Task", "task", "Agent"]:
             description = tool_input.get("description", "")
-            key_actions.append(f"Spawned task: {description}")
+            key_actions.append(f"Spawned agent: {description}")
 
         elif tool_name.startswith("mcp__"):
-            # MCP tool usage - extract the operation type
             operation = tool_name.replace("mcp__", "")
             key_actions.append(f"MCP {operation}")
 
@@ -358,15 +665,23 @@ def _extract_summary(session: ClaudeSession) -> dict[str, Any]:
 
     # Deduplicate key actions
     key_actions = (
-        list(dict.fromkeys(key_actions)) if key_actions else ["No specific actions detected"]
+        list(dict.fromkeys(key_actions))
+        if key_actions
+        else ["No specific actions detected"]
     )
 
     # Deduplicate file paths
     for op_type in file_operations:
-        file_operations[op_type] = list(dict.fromkeys(file_operations[op_type]))
+        file_operations[op_type] = list(
+            dict.fromkeys(file_operations[op_type])
+        )
 
     # Extract result summary (first 200 chars)
-    result_summary = (session.result[:200] + "...") if len(session.result) > 200 else session.result
+    result_summary = (
+        (session.result[:200] + "...")
+        if len(session.result) > 200
+        else session.result
+    )
 
     return {
         "tool_counts": tool_counts,
@@ -383,6 +698,9 @@ def _extract_summary(session: ClaudeSession) -> dict[str, Any]:
             **session.usage,
         },
     }
+
+
+# --------------------------------------------------------------------------- NDJSON stream
 
 
 async def _ndjson_from_cli(request: ClaudeCodeRequest):
@@ -444,9 +762,13 @@ async def _ndjson_from_cli(request: ClaudeCodeRequest):
                 try:
                     fixed = repair_json(buffer)
                     yield json.loads(fixed)
-                    log.warning("Repaired malformed JSON fragment at stream end")
+                    log.warning(
+                        "Repaired malformed JSON fragment at stream end"
+                    )
                 except Exception:
-                    log.error("Skipped unrecoverable JSON tail: %.120s…", buffer)
+                    log.error(
+                        "Skipped unrecoverable JSON tail: %.120s…", buffer
+                    )
 
         # 4) propagate non-zero exit code
         if await proc.wait() != 0:
@@ -468,7 +790,9 @@ async def _ndjson_from_cli(request: ClaudeCodeRequest):
 # --------------------------------------------------------------------------- SSE route
 async def stream_cc_cli_events(request: ClaudeCodeRequest):
     if not CLAUDE_CLI:
-        raise RuntimeError("Claude CLI binary not found (npm i -g @anthropic-ai/claude-code)")
+        raise RuntimeError(
+            "Claude CLI binary not found (npm i -g @anthropic-ai/claude-code)"
+        )
     async with contextlib.aclosing(_ndjson_from_cli(request)) as stream:
         async for obj in stream:
             yield obj
@@ -542,7 +866,7 @@ async def _maybe_await(func, *args, **kw):
 
 
 # --------------------------------------------------------------------------- main parser
-async def stream_claude_code_cli(  # noqa: C901  (complexity from branching is fine here)
+async def stream_claude_code_cli(  # noqa: C901
     request: ClaudeCodeRequest,
     session: ClaudeSession | None = None,
     *,
@@ -573,7 +897,9 @@ async def stream_claude_code_cli(  # noqa: C901  (complexity from branching is f
             # ------------------------ SYSTEM -----------------------------------
             if typ == "system":
                 data = obj
-                session.session_id = data.get("session_id", session.session_id)
+                session.session_id = data.get(
+                    "session_id", session.session_id
+                )
                 session.model = data.get("model", session.model)
                 await _maybe_await(on_system, data)
                 if request.verbose_output:

--- a/lionagi/service/third_party/claude_code.py
+++ b/lionagi/service/third_party/claude_code.py
@@ -352,8 +352,15 @@ class ClaudeCodeRequest(BaseModel):
         )
 
         # 4. extract system prompt if available
-        if (msg[0]["role"] == "system") and (resume or continue_conversation):
-            data_["system_prompt"] = msg[0]["content"]
+        if msg[0]["role"] == "system":
+            if resume or continue_conversation:
+                # Continued session: pass as system_prompt (--system-prompt)
+                data_["system_prompt"] = msg[0]["content"]
+            else:
+                # Fresh session: append to Claude Code's built-in prompt
+                data_.setdefault(
+                    "append_system_prompt", msg[0]["content"]
+                )
 
         if "append_system_prompt" in data and data["append_system_prompt"]:
             data_["append_system_prompt"] = str(

--- a/lionagi/service/third_party/claude_code.py
+++ b/lionagi/service/third_party/claude_code.py
@@ -375,6 +375,16 @@ class ClaudeCodeRequest(BaseModel):
                 "--fork-session requires --resume or --continue"
             )
 
+        # Permission flag mutual exclusivity
+        if (
+            self.allow_dangerously_skip_permissions
+            and self.permission_mode == "bypassPermissions"
+        ):
+            raise ValueError(
+                "allow_dangerously_skip_permissions and "
+                "permission_mode='bypassPermissions' are mutually exclusive"
+            )
+
         # System prompt mutual exclusivity
         if self.system_prompt and self.system_prompt_file:
             raise ValueError(
@@ -845,10 +855,11 @@ def _pp_tool_result(tr: dict[str, Any], theme) -> None:
 
 def _pp_final(sess: ClaudeSession, theme) -> None:
     usage = sess.usage or {}
+    cost_str = f"${sess.total_cost_usd:.4f}" if sess.total_cost_usd is not None else "N/A"
     txt = (
         f"### ✅ Session complete - {datetime.now(timezone.utc).isoformat(timespec='seconds')} UTC\n"
         f"**Result:**\n\n{sess.result or ''}\n\n"
-        f"- cost: **${sess.total_cost_usd:.4f}**  \n"
+        f"- cost: **{cost_str}**  \n"
         f"- turns: **{sess.num_turns}**  \n"
         f"- duration: **{sess.duration_ms} ms** (API {sess.duration_api_ms} ms)  \n"
         f"- tokens in/out: {usage.get('input_tokens', 0)}/{usage.get('output_tokens', 0)}"

--- a/lionagi/service/third_party/claude_code.py
+++ b/lionagi/service/third_party/claude_code.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import codecs
 import contextlib
+import inspect
 import json
 import logging
 import shutil
@@ -861,7 +862,7 @@ def _pp_final(sess: ClaudeSession, theme) -> None:
 async def _maybe_await(func, *args, **kw):
     """Call func which may be sync or async."""
     res = func(*args, **kw) if func else None
-    if ln.is_coro_func(res):
+    if inspect.iscoroutine(res):
         await res
 
 

--- a/lionagi/service/third_party/codex_models.py
+++ b/lionagi/service/third_party/codex_models.py
@@ -345,6 +345,13 @@ class CodexCodeRequest(BaseModel):
             if self.sandbox:
                 args.extend(["-s", self.sandbox])
 
+        # System prompt → -c developer_instructions=<val>
+        # (Codex CLI has no --system-prompt flag; uses developer_instructions)
+        if self.system_prompt:
+            args.extend(
+                ["-c", f"developer_instructions={self.system_prompt}"]
+            )
+
         # Reasoning effort → -c reasoning_effort=<val>
         if self.reasoning_effort:
             args.extend(["-c", f"reasoning_effort={self.reasoning_effort}"])

--- a/lionagi/service/third_party/codex_models.py
+++ b/lionagi/service/third_party/codex_models.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from textwrap import shorten
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from lionagi import ln
 
@@ -32,11 +32,29 @@ if (c := (shutil.which("codex") or "codex")) and shutil.which(c):
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger("codex-cli")
 
-# --------------------------------------------------------------------------- constants
+
+# --------------------------------------------------------------------------- types
 CodexSandboxMode = Literal[
     "read-only",
     "workspace-write",
     "danger-full-access",
+]
+
+CodexApprovalMode = Literal[
+    "untrusted",
+    "on-request",
+    "never",
+]
+
+CodexColorMode = Literal["always", "never", "auto"]
+
+CodexReasoningEffort = Literal[
+    "none",
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
 ]
 
 __all__ = (
@@ -47,47 +65,162 @@ __all__ = (
 )
 
 
+# --------------------------------------------------------------------------- flag metadata
+#
+# Same declarative pattern as claude_code.py.  Each field with _cli()
+# metadata is automatically assembled into CLI args by
+# _build_declarative_args(), sorted by order.
+#
+# kind semantics:
+#   value      – ``--flag <str(val)>``
+#   bool       – ``--flag`` when truthy, omit otherwise
+#   repeat     – ``--flag a --flag b`` (flag repeated per item)
+
+
+def _cli(
+    flag: str,
+    order: int,
+    kind: str = "value",
+) -> dict[str, Any]:
+    return {
+        "cli_flag": flag,
+        "cli_order": order,
+        "cli_kind": kind,
+    }
+
+
 # --------------------------------------------------------------------------- request model
 class CodexCodeRequest(BaseModel):
-    """Request model for OpenAI Codex CLI execution."""
+    """Configuration + prompt for an OpenAI Codex CLI invocation.
 
-    # -- conversational bits -------------------------------------------------
+    Fields annotated with ``_cli(...)`` metadata are automatically
+    assembled into CLI arguments by :meth:`as_cmd_args`, sorted by
+    ``order``.  Special cases (``bypass_approvals``, ``full_auto``,
+    ``sandbox``, ``config_overrides``, ``images``) are handled
+    explicitly after the declarative pass.
+
+    Adding a new CLI flag is one line: declare the field with ``_cli()``
+    metadata and the builder picks it up automatically.
+    """
+
+    # ── prompt (always required) ──────────────────────────────────
     prompt: str = Field(description="The prompt for Codex CLI")
-    system_prompt: str | None = None
 
-    # -- repo / workspace ----------------------------------------------------
-    repo: Path = Field(default_factory=Path.cwd, exclude=True)
-    ws: str | None = None  # sub-directory under repo
-
-    # -- runtime & safety ----------------------------------------------------
+    # ── model & runtime (order 10–19) ─────────────────────────────
     model: str | None = Field(
         default="gpt-5.3-codex",
-        description="Codex model to use (gpt-5.3-codex, o3, etc.)",
+        description="Codex model to use",
+        json_schema_extra=_cli("-m", 10),
+    )
+    profile: str | None = Field(
+        default=None,
+        description="Configuration profile from ~/.codex/config.toml",
+        json_schema_extra=_cli("-p", 11),
+    )
+    oss: bool = Field(
+        default=False,
+        description="Use local open-source model provider (Ollama)",
+        json_schema_extra=_cli("--oss", 12, "bool"),
+    )
+    search: bool = Field(
+        default=False,
+        description="Enable live web search",
+        json_schema_extra=_cli("--search", 13, "bool"),
+    )
+
+    # ── approval & sandbox (order 20–29) ──────────────────────────
+    # bypass_approvals, full_auto, sandbox are special-cased (mutual exclusivity)
+    ask_for_approval: CodexApprovalMode | None = Field(
+        default=None,
+        description="When Codex pauses for human approval",
     )
     full_auto: bool = Field(
         default=False,
-        description="Auto-approve with workspace-write sandbox (--full-auto)",
+        description="Auto-approve with workspace-write sandbox",
     )
     sandbox: CodexSandboxMode | None = Field(
         default=None,
-        description="Sandbox mode: read-only, workspace-write, danger-full-access",
+        description="Sandbox mode for shell commands",
     )
     bypass_approvals: bool = Field(
         default=False,
-        description="Skip all approvals and sandbox (--dangerously-bypass-approvals-and-sandbox)",
+        description="Skip ALL approvals and sandbox (DANGEROUS)",
     )
-    skip_git_repo_check: bool = Field(
-        default=False,
-        description="Allow running outside a git repository",
+
+    # ── workspace (order 30–39) ───────────────────────────────────
+    repo: Path = Field(default_factory=Path.cwd, exclude=True)
+    ws: str | None = Field(default=None, exclude=True)
+    add_dir: list[str] | None = Field(
+        default=None,
+        description="Additional directories to grant write access",
+        json_schema_extra=_cli("--add-dir", 30, "repeat"),
     )
+
+    # ── system prompt (order 40) ──────────────────────────────────
+    system_prompt: str | None = None
+
+    # ── output (order 50–59) ──────────────────────────────────────
     output_schema: str | Path | None = Field(
         default=None,
         description="Path to JSON Schema file for structured output",
+        json_schema_extra=_cli("--output-schema", 50),
+    )
+    output_last_message: str | Path | None = Field(
+        default=None,
+        description="Write the final message to a file",
+        json_schema_extra=_cli("--output-last-message", 51),
+    )
+    color: CodexColorMode | None = Field(
+        default=None,
+        description="ANSI color mode",
+        json_schema_extra=_cli("--color", 52),
+    )
+
+    # ── features (order 60–69) ────────────────────────────────────
+    skip_git_repo_check: bool = Field(
+        default=False,
+        description="Allow running outside a git repository",
+        json_schema_extra=_cli("--skip-git-repo-check", 60, "bool"),
+    )
+    ephemeral: bool = Field(
+        default=False,
+        description="Don't persist session to disk",
+        json_schema_extra=_cli("--ephemeral", 61, "bool"),
+    )
+    no_alt_screen: bool = Field(
+        default=False,
+        description="Disable alternate screen mode for TUI",
+        json_schema_extra=_cli("--no-alt-screen", 62, "bool"),
     )
     include_plan_tool: bool = Field(
         default=False,
         description="Include the plan tool in the conversation",
+        json_schema_extra=_cli("--include-plan-tool", 63, "bool"),
     )
+
+    # ── feature flags (order 70–79) ───────────────────────────────
+    enable_features: list[str] | None = Field(
+        default=None,
+        description="Feature flags to enable",
+        json_schema_extra=_cli("--enable", 70, "repeat"),
+    )
+    disable_features: list[str] | None = Field(
+        default=None,
+        description="Feature flags to disable",
+        json_schema_extra=_cli("--disable", 71, "repeat"),
+    )
+
+    # ── reasoning (order 75, emitted as -c overrides) ───────────
+    reasoning_effort: CodexReasoningEffort | None = Field(
+        default=None,
+        description="Reasoning effort level (emitted as -c reasoning_effort=<val>)",
+    )
+    plan_mode_reasoning_effort: CodexReasoningEffort | None = Field(
+        default=None,
+        description="Plan-mode reasoning effort (emitted as -c plan_mode_reasoning_effort=<val>)",
+    )
+
+    # ── images & config (special-cased) ───────────────────────────
     images: list[str] = Field(
         default_factory=list,
         description="Image file paths to attach to the prompt",
@@ -97,9 +230,17 @@ class CodexCodeRequest(BaseModel):
         description="Config overrides as key=value pairs (-c flag)",
     )
 
-    # -- internal use --------------------------------------------------------
-    verbose_output: bool = Field(default=False)
-    cli_include_summary: bool = Field(default=False)
+    # ── lionagi internal (no CLI flags) ───────────────────────────
+    verbose_output: bool = Field(default=False, exclude=True)
+    cli_include_summary: bool = Field(default=False, exclude=True)
+
+    # ── validators ────────────────────────────────────────────────
+
+    @field_validator("add_dir", mode="before")
+    def _norm_add_dir(cls, v):
+        if isinstance(v, str):
+            return [v]
+        return v
 
     @model_validator(mode="before")
     @classmethod
@@ -119,7 +260,9 @@ class CodexCodeRequest(BaseModel):
                     prompts.append(ln.json_dumps(content))
                 else:
                     prompts.append(content)
-            elif message["role"] == "system" and not data.get("system_prompt"):
+            elif message["role"] == "system" and not data.get(
+                "system_prompt"
+            ):
                 data["system_prompt"] = message["content"]
 
         data["prompt"] = "\n".join(prompts)
@@ -130,13 +273,15 @@ class CodexCodeRequest(BaseModel):
         """Emit security warnings for dangerous CLI settings."""
         if self.bypass_approvals:
             warnings.warn(
-                "CodexCodeRequest: bypass_approvals=True skips ALL approval prompts "
-                "and disables sandboxing. EXTREMELY DANGEROUS. Only use in "
-                "externally sandboxed environments.",
+                "CodexCodeRequest: bypass_approvals=True skips ALL approval "
+                "prompts and disables sandboxing. EXTREMELY DANGEROUS. Only "
+                "use in externally sandboxed environments.",
                 UserWarning,
                 stacklevel=4,
             )
         return self
+
+    # ── workspace path ────────────────────────────────────────────
 
     def cwd(self) -> Path:
         """Get working directory, validating workspace path."""
@@ -146,10 +291,14 @@ class CodexCodeRequest(BaseModel):
         ws_path = Path(self.ws)
 
         if ws_path.is_absolute():
-            raise ValueError(f"Workspace path must be relative, got absolute: {self.ws}")
+            raise ValueError(
+                f"Workspace path must be relative, got absolute: {self.ws}"
+            )
 
         if ".." in ws_path.parts:
-            raise ValueError(f"Directory traversal detected in workspace path: {self.ws}")
+            raise ValueError(
+                f"Directory traversal detected in workspace path: {self.ws}"
+            )
 
         repo_resolved = self.repo.resolve()
         result = (self.repo / ws_path).resolve()
@@ -164,42 +313,106 @@ class CodexCodeRequest(BaseModel):
 
         return result
 
+    # ── CLI command builder ───────────────────────────────────────
+
     def as_cmd_args(self) -> list[str]:
-        """Build argument list for `codex exec` subcommand."""
-        args: list[str] = ["exec", "--json", "--", self.prompt]
+        """Build argument list for ``codex exec`` subcommand.
 
-        if self.model:
-            args += ["-m", self.model]
+        Flags are assembled in two passes:
 
-        workspace = self.cwd()
-        args += ["-C", str(workspace)]
+        1. **Declarative** – fields with ``_cli()`` metadata, sorted by
+           ``order``.
+        2. **Special cases** – approval/sandbox (mutual exclusivity),
+           images (``-i`` repeat), config overrides (``-c key=val``).
 
+        Structure: ``exec --json [flags] -C <cwd> -- <prompt>``
+        """
+        args: list[str] = ["exec", "--json"]
+
+        # ── pass 1: declarative flags ──
+        args.extend(self._build_declarative_args())
+
+        # ── pass 2: special cases ──
+
+        # Approval & sandbox: mutually exclusive hierarchy
         if self.bypass_approvals:
             args.append("--dangerously-bypass-approvals-and-sandbox")
         elif self.full_auto:
             args.append("--full-auto")
-        elif self.sandbox:
-            args += ["-s", self.sandbox]
+        else:
+            if self.ask_for_approval:
+                args.extend(["-a", self.ask_for_approval])
+            if self.sandbox:
+                args.extend(["-s", self.sandbox])
 
-        if self.skip_git_repo_check:
-            args.append("--skip-git-repo-check")
+        # Reasoning effort → -c reasoning_effort=<val>
+        if self.reasoning_effort:
+            args.extend(["-c", f"reasoning_effort={self.reasoning_effort}"])
+        if self.plan_mode_reasoning_effort:
+            args.extend(
+                [
+                    "-c",
+                    f"plan_mode_reasoning_effort={self.plan_mode_reasoning_effort}",
+                ]
+            )
 
-        if self.output_schema:
-            args += ["--output-schema", str(self.output_schema)]
-
-        if self.include_plan_tool:
-            args.append("--include-plan-tool")
-
+        # Images (repeat -i per image)
         for image in self.images:
-            args += ["-i", image]
+            args.extend(["-i", image])
 
+        # Config overrides (-c key=value)
         for key, value in self.config_overrides.items():
-            args += [
-                "-c",
-                f"{key}={json.dumps(value) if not isinstance(value, str) else value}",
-            ]
+            serialized = (
+                json.dumps(value) if not isinstance(value, str) else value
+            )
+            args.extend(["-c", f"{key}={serialized}"])
+
+        # Working directory (always emit)
+        args.extend(["-C", str(self.cwd())])
+
+        # Prompt always last, after -- to prevent flag interpretation
+        args.extend(["--", self.prompt])
 
         return args
+
+    def _build_declarative_args(self) -> list[str]:
+        """Collect fields with ``_cli()`` metadata and emit flags."""
+        flagged: list[tuple[int, dict, Any]] = []
+        for field_name, field_info in type(self).model_fields.items():
+            extra = field_info.json_schema_extra
+            if not extra or "cli_flag" not in extra:
+                continue
+            val = getattr(self, field_name)
+            if val is None:
+                continue
+            if isinstance(val, list) and not val:
+                continue
+            if val is False:
+                continue
+            flagged.append((extra["cli_order"], extra, val))
+
+        flagged.sort(key=lambda x: x[0])
+
+        args: list[str] = []
+        for _, extra, val in flagged:
+            flag = extra["cli_flag"]
+            kind = extra.get("cli_kind", "value")
+
+            if kind == "bool":
+                if val:
+                    args.append(flag)
+
+            elif kind == "repeat":
+                for v in val:
+                    args.extend([flag, str(v)])
+
+            else:  # "value"
+                args.extend([flag, str(val)])
+
+        return args
+
+
+# --------------------------------------------------------------------------- chunks & session
 
 
 @dataclass
@@ -259,20 +472,28 @@ def _extract_summary(session: CodexSession) -> dict[str, Any]:
         tool_id = tool_use.get("id", "")
 
         tool_counts[tool_name] = tool_counts.get(tool_name, 0) + 1
-        tool_details.append({"tool": tool_name, "id": tool_id, "input": tool_input})
+        tool_details.append(
+            {"tool": tool_name, "id": tool_id, "input": tool_input}
+        )
 
         if tool_name in ("read_file", "Read", "read"):
-            file_path = tool_input.get("path", tool_input.get("file_path", "unknown"))
+            file_path = tool_input.get(
+                "path", tool_input.get("file_path", "unknown")
+            )
             file_operations["reads"].append(file_path)
             key_actions.append(f"Read {file_path}")
 
         elif tool_name in ("write_file", "create_file", "Write", "write"):
-            file_path = tool_input.get("path", tool_input.get("file_path", "unknown"))
+            file_path = tool_input.get(
+                "path", tool_input.get("file_path", "unknown")
+            )
             file_operations["writes"].append(file_path)
             key_actions.append(f"Wrote {file_path}")
 
         elif tool_name in ("edit_file", "patch", "Edit", "edit"):
-            file_path = tool_input.get("path", tool_input.get("file_path", "unknown"))
+            file_path = tool_input.get(
+                "path", tool_input.get("file_path", "unknown")
+            )
             file_operations["edits"].append(file_path)
             key_actions.append(f"Edited {file_path}")
 
@@ -284,7 +505,9 @@ def _extract_summary(session: CodexSession) -> dict[str, Any]:
             "bash",
         ):
             command = tool_input.get("command", tool_input.get("cmd", ""))
-            command_summary = command[:50] + "..." if len(command) > 50 else command
+            command_summary = (
+                command[:50] + "..." if len(command) > 50 else command
+            )
             key_actions.append(f"Ran: {command_summary}")
 
         elif tool_name.startswith("mcp_") or tool_name.startswith("mcp__"):
@@ -294,12 +517,22 @@ def _extract_summary(session: CodexSession) -> dict[str, Any]:
         else:
             key_actions.append(f"Used {tool_name}")
 
-    key_actions = list(dict.fromkeys(key_actions)) if key_actions else ["No specific actions"]
+    key_actions = (
+        list(dict.fromkeys(key_actions))
+        if key_actions
+        else ["No specific actions"]
+    )
 
     for op_type in file_operations:
-        file_operations[op_type] = list(dict.fromkeys(file_operations[op_type]))
+        file_operations[op_type] = list(
+            dict.fromkeys(file_operations[op_type])
+        )
 
-    result_summary = (session.result[:200] + "...") if len(session.result) > 200 else session.result
+    result_summary = (
+        (session.result[:200] + "...")
+        if len(session.result) > 200
+        else session.result
+    )
 
     return {
         "tool_counts": tool_counts,
@@ -317,6 +550,9 @@ def _extract_summary(session: CodexSession) -> dict[str, Any]:
     }
 
 
+# --------------------------------------------------------------------------- NDJSON stream
+
+
 async def _ndjson_from_cli(request: CodexCodeRequest):
     """
     Yields each JSON object emitted by the Codex CLI (JSONL mode).
@@ -324,7 +560,9 @@ async def _ndjson_from_cli(request: CodexCodeRequest):
     Robust against UTF-8 splits and uses json.JSONDecoder.raw_decode.
     """
     if CODEX_CLI is None:
-        raise RuntimeError("Codex CLI not found. Install with: npm i -g @openai/codex")
+        raise RuntimeError(
+            "Codex CLI not found. Install with: npm i -g @openai/codex"
+        )
 
     proc = await asyncio.create_subprocess_exec(
         CODEX_CLI,
@@ -367,7 +605,9 @@ async def _ndjson_from_cli(request: CodexCodeRequest):
                 obj, idx = json_decoder.raw_decode(buffer)
                 yield obj
             except json.JSONDecodeError:
-                log.error("Skipped unrecoverable JSON tail: %.120s...", buffer)
+                log.error(
+                    "Skipped unrecoverable JSON tail: %.120s...", buffer
+                )
 
         if await proc.wait() != 0:
             err = ""
@@ -385,6 +625,9 @@ async def _ndjson_from_cli(request: CodexCodeRequest):
                 proc.kill()
             with contextlib.suppress(Exception):
                 await proc.wait()
+
+
+# --------------------------------------------------------------------------- event stream
 
 
 async def stream_codex_cli_events(request: CodexCodeRequest):
@@ -414,14 +657,18 @@ def _pp_tool_use(tu: dict[str, Any]) -> None:
 
 
 def _pp_tool_result(tr: dict[str, Any]) -> None:
-    body_preview = shorten(str(tr.get("content", "")).replace("\n", " "), 130)
+    body_preview = shorten(
+        str(tr.get("content", "")).replace("\n", " "), 130
+    )
     status = "ERR" if tr.get("is_error") else "OK"
     print(f"- Tool Result - {status}: {body_preview}")
 
 
 def _pp_final(sess: CodexSession) -> None:
     usage = sess.usage or {}
-    cost_str = f"${sess.total_cost_usd:.4f}" if sess.total_cost_usd else "N/A"
+    cost_str = (
+        f"${sess.total_cost_usd:.4f}" if sess.total_cost_usd else "N/A"
+    )
     print(
         f"\n### Codex Session complete\n"
         f"**Result:** {sess.result or ''}\n"
@@ -430,6 +677,9 @@ def _pp_final(sess: CodexSession) -> None:
         f"- duration: {sess.duration_ms} ms\n"
         f"- tokens: {usage.get('input_tokens', 0)}/{usage.get('output_tokens', 0)}"
     )
+
+
+# --------------------------------------------------------------------------- main parser
 
 
 async def stream_codex_cli(
@@ -442,9 +692,11 @@ async def stream_codex_cli(
     on_final: Callable[[CodexSession], None] | None = None,
 ) -> AsyncIterator[CodexChunk | dict | CodexSession]:
     """
-    Consume the JSONL stream from Codex CLI and return a populated CodexSession.
+    Consume the JSONL stream from Codex CLI and return a populated
+    CodexSession.
 
-    Handles flexible event type names since Codex CLI output format may vary.
+    Handles flexible event type names since Codex CLI output format
+    may vary.
     """
     if session is None:
         session = CodexSession()
@@ -456,13 +708,16 @@ async def stream_codex_cli(
             chunk = CodexChunk(raw=obj, type=typ)
             session.chunks.append(chunk)
 
-            # -- thread / session start ------------------------------------------
+            # -- thread / session start --
             if typ in ("thread.started", "system", "init", "session.start"):
-                session.session_id = obj.get("thread_id", obj.get("session_id", obj.get("id")))
+                session.session_id = obj.get(
+                    "thread_id",
+                    obj.get("session_id", obj.get("id")),
+                )
                 session.model = obj.get("model")
                 yield obj
 
-            # -- item.completed (agent_message, reasoning, tool calls) -----------
+            # -- item.completed (agent_message, reasoning, tool calls) --
             elif typ == "item.completed":
                 item = obj.get("item", {})
                 item_type = item.get("type", "")
@@ -478,9 +733,16 @@ async def stream_codex_cli(
 
                 elif item_type in ("function_call", "tool_call"):
                     tu = {
-                        "id": item.get("id", item.get("call_id", "")),
-                        "name": item.get("name", item.get("function", "")),
-                        "input": item.get("arguments", item.get("input", item.get("args", {}))),
+                        "id": item.get(
+                            "id", item.get("call_id", "")
+                        ),
+                        "name": item.get(
+                            "name", item.get("function", "")
+                        ),
+                        "input": item.get(
+                            "arguments",
+                            item.get("input", item.get("args", {})),
+                        ),
                     }
                     chunk.tool_use = tu
                     session.tool_uses.append(tu)
@@ -491,8 +753,12 @@ async def stream_codex_cli(
 
                 elif item_type == "function_call_output":
                     tr = {
-                        "tool_use_id": item.get("call_id", item.get("id", "")),
-                        "content": item.get("output", item.get("content", "")),
+                        "tool_use_id": item.get(
+                            "call_id", item.get("id", "")
+                        ),
+                        "content": item.get(
+                            "output", item.get("content", "")
+                        ),
                         "is_error": item.get("is_error", False),
                     }
                     chunk.tool_result = tr
@@ -503,19 +769,20 @@ async def stream_codex_cli(
                     yield chunk
 
                 elif item_type == "reasoning":
-                    # reasoning traces — store but don't treat as result
                     yield chunk
 
                 else:
                     yield chunk
 
-            # -- turn.completed (usage stats) ------------------------------------
+            # -- turn.completed (usage stats) --
             elif typ == "turn.completed":
                 session.usage = obj.get("usage", {})
-                session.total_cost_usd = obj.get("total_cost_usd", obj.get("cost"))
+                session.total_cost_usd = obj.get(
+                    "total_cost_usd", obj.get("cost")
+                )
                 session.num_turns = (session.num_turns or 0) + 1
 
-            # -- turn.failed / error ---------------------------------------------
+            # -- turn.failed / error --
             elif typ in ("turn.failed", "error"):
                 session.is_error = True
                 err = obj.get("error", {})
@@ -525,7 +792,7 @@ async def stream_codex_cli(
                     else obj.get("message", str(err))
                 )
 
-            # -- legacy event types (older CLI versions) -------------------------
+            # -- legacy event types (older CLI versions) --
             elif typ in ("message", "assistant", "agent"):
                 msg = obj.get("message", obj)
                 session.messages.append(msg)
@@ -546,14 +813,22 @@ async def stream_codex_cli(
                                 await _maybe_await(on_text, text)
                                 if request.verbose_output:
                                     _pp_text(text)
-                            elif btype in ("tool_use", "function_call"):
+                            elif btype in (
+                                "tool_use",
+                                "function_call",
+                            ):
                                 tu = {
                                     "id": blk.get("id", ""),
                                     "name": blk.get(
                                         "name",
-                                        blk.get("function", {}).get("name", ""),
+                                        blk.get("function", {}).get(
+                                            "name", ""
+                                        ),
                                     ),
-                                    "input": blk.get("input", blk.get("arguments", {})),
+                                    "input": blk.get(
+                                        "input",
+                                        blk.get("arguments", {}),
+                                    ),
                                 }
                                 chunk.tool_use = tu
                                 session.tool_uses.append(tu)
@@ -563,12 +838,25 @@ async def stream_codex_cli(
                 yield chunk
 
             elif typ in ("result", "response", "session.end"):
-                session.result = obj.get("result", obj.get("response", obj.get("text", ""))).strip()
-                session.usage = obj.get("usage", obj.get("stats", {}))
-                session.total_cost_usd = obj.get("total_cost_usd", obj.get("cost"))
-                session.num_turns = obj.get("num_turns", obj.get("turns"))
-                session.duration_ms = obj.get("duration_ms", obj.get("duration"))
-                session.is_error = obj.get("is_error", obj.get("error") is not None)
+                session.result = obj.get(
+                    "result",
+                    obj.get("response", obj.get("text", "")),
+                ).strip()
+                session.usage = obj.get(
+                    "usage", obj.get("stats", {})
+                )
+                session.total_cost_usd = obj.get(
+                    "total_cost_usd", obj.get("cost")
+                )
+                session.num_turns = obj.get(
+                    "num_turns", obj.get("turns")
+                )
+                session.duration_ms = obj.get(
+                    "duration_ms", obj.get("duration")
+                )
+                session.is_error = obj.get(
+                    "is_error", obj.get("error") is not None
+                )
 
             elif typ == "done":
                 break


### PR DESCRIPTION
## Summary

- **Declarative CLI flag pattern**: Both `claude_code.py` and `codex_models.py` now use `_cli(flag, order, kind)` metadata on Pydantic fields. Adding a new CLI flag is one line — the generic `_build_declarative_args()` loop handles sorting and emission.
- **Claude Code**: 20+ new flags (`--effort`, `--json-schema`, `--max-budget-usd`, `--agent`/`--agents`, `--worktree`, `--session-id`, `--name`, `--fork-session`, `--fallback-model`, `--chrome`/`--no-chrome`, `--tools`, etc.), expanded permission modes (`plan`, `dontAsk`), fixed `--system-prompt` never being emitted
- **Codex**: 10+ new flags (`--ask-for-approval`, `--profile`, `--oss`, `--search`, `--add-dir`, `--ephemeral`, `--enable`/`--disable` feature flags, etc.), dedicated `reasoning_effort` field, **fixed flag ordering bug** where flags were placed after `--` separator
- Full backward compatibility — all 637 service tests pass

## Test plan

- [x] All 637 existing service tests pass (33 CLI-specific tests)
- [x] 11 inline tests for new Claude Code flags (effort, json-schema, agents JSON, worktree, ordering, fork_session validation, etc.)
- [x] 6 inline tests for new Codex flags (ordering fix, new flags, approval hierarchy, config overrides, reasoning_effort)
- [ ] Manual integration test with actual Claude Code CLI
- [ ] Manual integration test with actual Codex CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)