### PR TITLE
feat(cli): add --version flag

### DIFF
--- a/lionagi/cli/main.py
+++ b/lionagi/cli/main.py
@@ -24,6 +24,12 @@ from .orchestrate import add_orchestrate_subparser, run_orchestrate
 from .team import add_team_subparser, run_team
 
 
+def _get_version() -> str:
+    from lionagi.version import __version__
+
+    return __version__
+
+
 def main(argv: list[str] | None = None) -> int:
     signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
@@ -36,6 +42,11 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="li",
         description="lionagi command line — spawn subagents via any CLI-backed provider.",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {_get_version()}",
     )
     sub = parser.add_subparsers(dest="command", required=True)
 


### PR DESCRIPTION
## Summary

`li --version` now prints the installed lionagi version and exits.

```
$ li --version
li 0.22.7
```

One file changed, 11 insertions. Lazy import from `lionagi.version` to keep CLI startup fast.

## Test plan

- [x] `li --version` prints version and exits 0
- [x] `li agent ...` still works (no regression on subcommand routing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)