### PR TITLE
feat(hooks): #915 decorator-style HookRegistry API

### DIFF
--- a/lionagi/service/hooks/hook_registry.py
+++ b/lionagi/service/hooks/hook_registry.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any, TypeVar
 
 from lionagi.ln.concurrency import get_cancelled_exc_class
@@ -13,6 +14,7 @@ from ._types import HookDict, HookEventTypes, StreamHandlers
 from ._utils import get_handler, validate_hooks, validate_stream_handlers
 
 E = TypeVar("E", bound=Event)
+F = TypeVar("F", bound=Callable)
 
 
 class HookRegistry:
@@ -34,6 +36,21 @@ class HookRegistry:
 
         self._hooks = _hooks
         self._stream_handlers = _stream_handlers
+
+    def pre_event_create_hook(self, fn: F) -> F:
+        """Decorator that registers *fn* as the pre_event_create hook."""
+        self._hooks[HookEventTypes.PreEventCreate] = fn
+        return fn
+
+    def pre_invoke(self, fn: F) -> F:
+        """Decorator that registers *fn* as the pre_invocation hook."""
+        self._hooks[HookEventTypes.PreInvocation] = fn
+        return fn
+
+    def post_invoke(self, fn: F) -> F:
+        """Decorator that registers *fn* as the post_invocation hook."""
+        self._hooks[HookEventTypes.PostInvocation] = fn
+        return fn
 
     async def _call(
         self,


### PR DESCRIPTION
## Summary

Add `@hooks.pre_invoke`, `@hooks.post_invoke`, and `@hooks.pre_event_create_hook` decorator methods to `HookRegistry`. Backward compatible — dict constructor still works. Decorators register the function and return it unchanged.

Closes #915.

## Context

This is slice 1 of 9 from the incremental split of PR #917 (`feat/control-nodes`). The original PR bundled too many concerns (control primitive, CLI rewrite, hooks, spec file, prompts, version bump); it is being broken into small, independently reviewable PRs landing on `main` one at a time.

## Diff stats

- 1 file changed, 17 insertions
- Additive API only; no behavior change for existing callers

## Test plan

- [x] \`uv run pre-commit run --files lionagi/service/hooks/hook_registry.py\` passes
- [x] \`uv run pytest tests/service/hooks/\` — 179 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)