### PR TITLE
fix(hooks): accept documented string keys in HookRegistry constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,6 +169,7 @@ cython_debug/
 *.DS_Store
 .roomodes
 .khive/
+.claude/
 .roo/
 *logs/
 

--- a/lionagi/service/hooks/hook_registry.py
+++ b/lionagi/service/hooks/hook_registry.py
@@ -17,6 +17,33 @@ E = TypeVar("E", bound=Event)
 F = TypeVar("F", bound=Callable)
 
 
+def _normalize_hook_key(key: HookEventTypes | str) -> HookEventTypes | str:
+    """Accept the documented string aliases for hook keys.
+
+    ``HookDict`` is typed with string keys ("pre_invoke", "post_invoke",
+    "pre_event_create"), but ``validate_hooks`` requires
+    :class:`HookEventTypes` members. Callers that construct the
+    registry from a plain dict were rejected at validation despite the
+    advertised contract; this helper coerces known strings before
+    validation runs.
+    """
+    if isinstance(key, HookEventTypes):
+        return key
+    if isinstance(key, str):
+        aliases = {
+            "pre_invoke": HookEventTypes.PreInvocation,
+            "post_invoke": HookEventTypes.PostInvocation,
+            "pre_event_create_hook": HookEventTypes.PreEventCreate,
+        }
+        if key in aliases:
+            return aliases[key]
+        try:
+            return HookEventTypes(key)
+        except ValueError:
+            return key
+    return key
+
+
 class HookRegistry:
     def __init__(
         self,
@@ -27,6 +54,7 @@ class HookRegistry:
         _stream_handlers = {}
 
         if hooks is not None:
+            hooks = {_normalize_hook_key(k): v for k, v in hooks.items()}
             validate_hooks(hooks)
             _hooks.update(hooks)
 

--- a/tests/service/hooks/unit/test_registry_dispatch.py
+++ b/tests/service/hooks/unit/test_registry_dispatch.py
@@ -235,3 +235,40 @@ class TestMetadataContract:
         assert meta["event_id"] == "TEST"
         assert meta["event_created_at"] == 123.456
         assert len(meta) == 3
+
+
+class TestDictConstructorStringKeys:
+    """HookDict is typed with string keys; the constructor must accept them."""
+
+    def test_constructor_accepts_documented_string_aliases(self):
+        def dummy(*args, **kwargs):
+            return None
+
+        registry = HookRegistry(
+            {
+                "pre_invoke": dummy,
+                "post_invoke": dummy,
+                "pre_event_create_hook": dummy,
+            }
+        )
+        assert registry._hooks[HookEventTypes.PreInvocation] is dummy
+        assert registry._hooks[HookEventTypes.PostInvocation] is dummy
+        assert registry._hooks[HookEventTypes.PreEventCreate] is dummy
+
+    def test_constructor_accepts_raw_enum_values(self):
+        def dummy(*args, **kwargs):
+            return None
+
+        registry = HookRegistry(
+            {
+                HookEventTypes.PreInvocation.value: dummy,
+            }
+        )
+        assert registry._hooks[HookEventTypes.PreInvocation] is dummy
+
+    def test_constructor_still_accepts_enum_keys(self):
+        def dummy(*args, **kwargs):
+            return None
+
+        registry = HookRegistry({HookEventTypes.PreInvocation: dummy})
+        assert registry._hooks[HookEventTypes.PreInvocation] is dummy


### PR DESCRIPTION
## Summary

`HookDict` is typed with string keys (`"pre_invoke"`, `"post_invoke"`, `"pre_event_create"`), but `validate_hooks` required `HookEventTypes` members. Callers building the registry from a plain dict were rejected at validation despite the advertised contract. This normalizes known strings before validation runs.

Addresses finding F15 from the adversarial review of PR #917.

## Context

Slice 2 of 9 from the incremental split of PR #917. Ships a single, narrow fix with a targeted regression guard. Also adds `.claude/` to `.gitignore` to stop the local harness from leaking task-queue lock files into commits.

## Test plan

- [x] `TestDictConstructorStringKeys::test_constructor_accepts_documented_string_aliases` passes
- [x] `test_constructor_accepts_raw_enum_values` passes
- [x] `test_constructor_still_accepts_enum_keys` passes (backward compat guard)
- [x] `uv run pre-commit run --files lionagi/service/hooks/hook_registry.py tests/service/hooks/unit/test_registry_dispatch.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)