### PR TITLE
feat(cli): #919 li o flow -f spec.yaml file-based flow specification

### DIFF
--- a/lionagi/cli/orchestrate/__init__.py
+++ b/lionagi/cli/orchestrate/__init__.py
@@ -134,7 +134,23 @@ def add_orchestrate_subparser(subparsers: argparse._SubParsersAction) -> None:
         default=None,
         help="Orchestrator model spec. Optional when -a/--agent provides one.",
     )
-    fl.add_argument("prompt", help="Task for the orchestrator to plan and execute.")
+    fl.add_argument(
+        "prompt",
+        nargs="?",
+        default=None,
+        help="Task for the orchestrator to plan and execute.",
+    )
+    fl.add_argument(
+        "-f",
+        "--file",
+        metavar="PATH",
+        default=None,
+        help=(
+            "Load flow spec from YAML or JSON file. File values serve as "
+            "defaults; CLI flags override them. Prompt can come from the "
+            "file (prompt: key) or as a positional argument."
+        ),
+    )
     fl.add_argument(
         "-a",
         "--agent",
@@ -209,6 +225,39 @@ def add_orchestrate_subparser(subparsers: argparse._SubParsersAction) -> None:
     add_common_cli_args(fl)
 
 
+def _load_flow_spec(path: str) -> dict | int:
+    """Load a YAML or JSON flow spec file. Returns dict on success, int error code on failure."""
+    from pathlib import Path
+
+    p = Path(path).expanduser()
+    if not p.is_file():
+        log_error(f"spec file not found: {p}")
+        return 1
+    text = p.read_text()
+    suffix = p.suffix.lower()
+    try:
+        if suffix in (".yaml", ".yml"):
+            import yaml
+
+            return yaml.safe_load(text) or {}
+        elif suffix == ".json":
+            import json
+
+            return json.loads(text)
+        else:
+            import yaml
+
+            try:
+                return yaml.safe_load(text) or {}
+            except Exception:
+                import json
+
+                return json.loads(text)
+    except Exception as e:
+        log_error(f"failed to parse spec file {p}: {e}")
+        return 1
+
+
 def run_orchestrate(args: argparse.Namespace) -> int:
     """Dispatch orchestrate sub-commands."""
     if args.orch_command == "fanout":
@@ -252,9 +301,57 @@ def run_orchestrate(args: argparse.Namespace) -> int:
         return 0
 
     if args.orch_command == "flow":
+        # ── Load spec file if -f/--file was given ────────────────
+        file_spec = getattr(args, "file", None)
+        if file_spec:
+            spec = _load_flow_spec(file_spec)
+            if isinstance(spec, int):
+                return spec  # error code
+            if not isinstance(spec, dict):
+                log_error("spec file must contain a YAML/JSON object")
+                return 1
+            # If the file supplies the model/agent, argparse's lone positional
+            # is a prompt override, not a model override.
+            if (
+                args.model
+                and args.prompt is None
+                and (spec.get("model") or spec.get("agent"))
+            ):
+                args.prompt = args.model
+                args.model = None
+            # File values are defaults; CLI flags override.
+            if args.model is None and "model" in spec:
+                args.model = spec["model"]
+            if args.agent is None and spec.get("agent"):
+                args.agent = spec["agent"]
+            if args.prompt is None and spec.get("prompt"):
+                args.prompt = spec["prompt"]
+            if args.max_concurrent == 0 and spec.get("workers"):
+                args.max_concurrent = spec["workers"]
+            if args.effort is None and spec.get("effort"):
+                args.effort = spec["effort"]
+            if args.with_synthesis is False and spec.get("with_synthesis"):
+                args.with_synthesis = spec["with_synthesis"]
+            if args.team_mode is None and spec.get("team_mode"):
+                args.team_mode = spec["team_mode"]
+            if args.max_agents == 0 and spec.get("max_agents"):
+                args.max_agents = spec["max_agents"]
+            if not args.bare and spec.get("bare"):
+                args.bare = True
+            if not args.dry_run and spec.get("dry_run"):
+                args.dry_run = True
+            if args.save is None and spec.get("save"):
+                args.save = spec["save"]
+            if spec.get("critic_model"):
+                pass  # reserved for future use
+
         has_model = args.model is not None or args.agent is not None
         if not has_model:
             log_error("model or --agent is required")
+            return 1
+
+        if not args.prompt:
+            log_error("prompt is required (positional or via -f spec file)")
             return 1
 
         background = getattr(args, "background", False)

--- a/tests/test_flow_spec_file.py
+++ b/tests/test_flow_spec_file.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for #919: li o flow -f spec.yaml file-based flow specification."""
+
+import argparse
+import json
+from unittest.mock import AsyncMock, patch
+
+import yaml
+
+from lionagi.cli.orchestrate import (
+    _load_flow_spec,
+    add_orchestrate_subparser,
+    run_orchestrate,
+)
+
+
+def _parse_flow_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="li")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    add_orchestrate_subparser(subparsers)
+    return parser.parse_args(["o", "flow", *argv])
+
+
+class TestLoadFlowSpec:
+    def test_yaml_spec(self, tmp_path):
+        spec = {
+            "agent": "orchestrator",
+            "team_mode": "ws-terminal",
+            "workers": 8,
+            "effort": "xhigh",
+            "prompt": "Implement the terminal component",
+        }
+        p = tmp_path / "spec.yaml"
+        p.write_text(yaml.dump(spec))
+        result = _load_flow_spec(str(p))
+        assert result["agent"] == "orchestrator"
+        assert result["workers"] == 8
+        assert result["effort"] == "xhigh"
+        assert result["prompt"] == "Implement the terminal component"
+
+    def test_json_spec(self, tmp_path):
+        spec = {"model": "claude-code/opus-4-7", "prompt": "test task", "bare": True}
+        p = tmp_path / "spec.json"
+        p.write_text(json.dumps(spec))
+        result = _load_flow_spec(str(p))
+        assert result["model"] == "claude-code/opus-4-7"
+        assert result["prompt"] == "test task"
+        assert result["bare"] is True
+
+    def test_yml_extension(self, tmp_path):
+        spec = {"prompt": "hello"}
+        p = tmp_path / "spec.yml"
+        p.write_text(yaml.dump(spec))
+        result = _load_flow_spec(str(p))
+        assert result["prompt"] == "hello"
+
+    def test_missing_file(self):
+        result = _load_flow_spec("/nonexistent/path/spec.yaml")
+        assert result == 1
+
+    def test_invalid_yaml(self, tmp_path):
+        p = tmp_path / "bad.yaml"
+        p.write_text(": : : invalid")
+        result = _load_flow_spec(str(p))
+        assert result == 1
+
+    def test_empty_yaml(self, tmp_path):
+        p = tmp_path / "empty.yaml"
+        p.write_text("")
+        result = _load_flow_spec(str(p))
+        assert result == {}
+
+    def test_unknown_extension_tries_yaml_first(self, tmp_path):
+        spec = {"prompt": "detect format"}
+        p = tmp_path / "spec.txt"
+        p.write_text(yaml.dump(spec))
+        result = _load_flow_spec(str(p))
+        assert result["prompt"] == "detect format"
+
+    def test_full_spec_fields(self, tmp_path):
+        spec = {
+            "agent": "orchestrator",
+            "model": "claude-code/opus-4-7",
+            "team_mode": "ws-terminal",
+            "workers": 8,
+            "critic_model": "claude-code/opus-4-7",
+            "effort": "xhigh",
+            "max_agents": 12,
+            "bare": False,
+            "dry_run": False,
+            "save": "/tmp/flow-out",
+            "prompt": "Build a CLI tool",
+        }
+        p = tmp_path / "full.yaml"
+        p.write_text(yaml.dump(spec))
+        result = _load_flow_spec(str(p))
+        assert result == spec
+
+    def test_lone_positional_overrides_prompt_when_spec_supplies_model(
+        self, tmp_path, capsys
+    ):
+        p = tmp_path / "spec.yaml"
+        p.write_text(yaml.dump({"model": "claude-code/opus-4-7"}))
+        args = _parse_flow_args(["-f", str(p), "Write the thing"])
+
+        with patch(
+            "lionagi.cli.orchestrate._run_flow",
+            AsyncMock(return_value="flow output"),
+        ) as run_flow:
+            code = run_orchestrate(args)
+
+        assert code == 0
+        run_flow.assert_called_once()
+        assert run_flow.call_args.kwargs["model_spec"] == "claude-code/opus-4-7"
+        assert run_flow.call_args.kwargs["prompt"] == "Write the thing"
+        assert capsys.readouterr().out.strip() == "flow output"
+
+    def test_non_object_spec_fails_with_cli_error(self, tmp_path, caplog):
+        p = tmp_path / "list.yaml"
+        p.write_text("- item\n")
+        args = _parse_flow_args(["-f", str(p)])
+
+        code = run_orchestrate(args)
+
+        assert code == 1
+        assert "spec file must contain a YAML/JSON object" in caplog.text


### PR DESCRIPTION
## Summary

Add `-f/--file` flag to `li o flow` that loads defaults from a YAML or JSON spec file. CLI flags override file values. Prompt can come from the file (`prompt:` key) or as a positional argument.

Rejects non-object spec files with a clean CLI error (F6 from the adversarial review). When the spec supplies `model`/`agent` and the CLI is given a single positional, that positional is treated as the prompt, not as a model override (F5).

Closes #919.

## Context

Slice 4 of the incremental split of PR #917. Self-contained; no dependencies on other in-flight slices.

## Test plan

- [x] `uv run pytest tests/test_flow_spec_file.py` — 10 passed
- [x] `uv run pre-commit run --files lionagi/cli/orchestrate/__init__.py tests/test_flow_spec_file.py` clean
- [x] Manual: `li o flow -f spec.yaml "prompt"` with a model-providing spec correctly routes the positional to prompt
- [x] Manual: `li o flow -f list.yaml` (non-object YAML) returns exit code 1 with clean error

🤖 Generated with [Claude Code](https://claude.com/claude-code)