### PR TITLE
fix(event): as_fresh_event use model_dump + deepcopy excluded fields

### DIFF
--- a/lionagi/protocols/generic/event.py
+++ b/lionagi/protocols/generic/event.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import copy as _copy
 from enum import Enum as _Enum
 from typing import Any, ClassVar
 
@@ -446,14 +447,36 @@ class Event(Element):
             raise RuntimeError(f"Event did not complete successfully: {exec_dict}")
 
     def as_fresh_event(self, copy_meta: bool = False) -> Event:
-        """Creates a clone of this event with the same execution state."""
-        d_ = self.to_dict()
-        for i in ["execution", "created_at", "id", "metadata"]:
-            d_.pop(i, None)
+        """Creates a clone of this event with a fresh execution state.
+
+        - Uses ``model_dump`` rather than ``to_dict`` to avoid
+          unconditional key accesses on fields excluded from the dump.
+        - Re-attaches fields declared with ``exclude=True`` (e.g.
+          ``Operation.parameters``) so a retry clone keeps non-default
+          state that is invisible to ``model_dump``.
+        - Deep-copies excluded fields and metadata so the retry does not
+          share nested mutable state with the original. Falls back to a
+          reference copy when the value is not deep-copyable (closures,
+          file handles, etc.).
+        """
+        skip = {"execution", "created_at", "id", "metadata"}
+        d_ = self.model_dump(exclude=skip)
+        for name, field_info in self.__class__.model_fields.items():
+            if name in skip:
+                continue
+            if field_info.exclude and name not in d_:
+                val = getattr(self, name, None)
+                if val is not None:
+                    try:
+                        d_[name] = _copy.deepcopy(val)
+                    except Exception:
+                        d_[name] = val
         fresh = self.__class__(**d_)
         if copy_meta:
-            meta = self.metadata.copy()
-            fresh.metadata = meta
+            try:
+                fresh.metadata = _copy.deepcopy(self.metadata)
+            except Exception:
+                fresh.metadata = self.metadata.copy()
         fresh.metadata["original"] = {
             "id": str(self.id),
             "created_at": self.created_at,

--- a/tests/protocols/generic/test_as_fresh_event.py
+++ b/tests/protocols/generic/test_as_fresh_event.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for Event.as_fresh_event().
+
+Previously used ``to_dict()`` which unconditionally touched excluded
+keys (raising KeyError on ``metadata`` in some subclasses) and
+shallow-copied excluded fields so retry clones shared mutable state
+with the original.
+"""
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from lionagi.protocols.generic.event import Event, EventStatus
+
+
+class _EventWithExcluded(Event):
+    """Event subclass with an excluded field (mirrors Operation.parameters)."""
+
+    parameters: dict[str, Any] = Field(default_factory=dict, exclude=True)
+
+
+def test_as_fresh_event_returns_new_id_and_pending_execution():
+    orig = _EventWithExcluded()
+    orig.execution.status = EventStatus.COMPLETED
+    orig.execution.response = "done"
+
+    fresh = orig.as_fresh_event()
+
+    assert fresh.id != orig.id
+    assert fresh.execution.status == EventStatus.PENDING
+    assert fresh.execution.response is None
+
+
+def test_as_fresh_event_preserves_excluded_fields():
+    orig = _EventWithExcluded(parameters={"input": "x", "nested": [1, 2]})
+
+    fresh = orig.as_fresh_event()
+
+    assert fresh.parameters == {"input": "x", "nested": [1, 2]}
+
+
+def test_as_fresh_event_deepcopies_excluded_fields():
+    nested = {"a": [1, 2, 3]}
+    orig = _EventWithExcluded(parameters={"nested": nested})
+
+    fresh = orig.as_fresh_event()
+
+    fresh.parameters["nested"]["a"].append(99)
+    assert orig.parameters["nested"]["a"] == [1, 2, 3]
+
+
+def test_as_fresh_event_deepcopies_metadata_when_copy_meta():
+    orig = _EventWithExcluded()
+    orig.metadata["ctx"] = {"tag": "alpha"}
+
+    fresh = orig.as_fresh_event(copy_meta=True)
+
+    fresh.metadata["ctx"]["tag"] = "beta"
+    assert orig.metadata["ctx"]["tag"] == "alpha"
+
+
+def test_as_fresh_event_records_original_reference():
+    orig = _EventWithExcluded()
+
+    fresh = orig.as_fresh_event()
+
+    assert fresh.metadata["original"]["id"] == str(orig.id)
+    assert fresh.metadata["original"]["created_at"] == orig.created_at
+
+
+def test_as_fresh_event_falls_back_for_uncopyable_values():
+    # A closure captures state that copy.deepcopy cannot pickle cleanly;
+    # the helper should still succeed and retain a reference.
+    def _closure():
+        return 1
+
+    orig = _EventWithExcluded(parameters={"fn": _closure})
+
+    fresh = orig.as_fresh_event()
+
+    # The closure comes back intact (either copied or referenced).
+    assert fresh.parameters["fn"]() == 1
+
+
+def test_as_fresh_event_does_not_raise_on_event_without_metadata_subfield():
+    # Base Event has no extra excluded fields; prove the path does not
+    # require them to exist.
+    orig = Event()
+
+    fresh = orig.as_fresh_event()
+
+    assert fresh.id != orig.id


### PR DESCRIPTION
## Summary

Three related fixes to `Event.as_fresh_event()`:

1. Switch from `to_dict()` to `model_dump()` so subclasses that exclude fields (e.g. `Operation.parameters`) no longer crash with `KeyError` on the excluded keys.
2. Re-attach fields declared with `exclude=True` from the source model after construction. Without this, a retry clone drops non-default state that is invisible to `model_dump`.
3. Deep-copy excluded fields and metadata so the retry does not share nested mutable state with the original. Falls back to a reference copy for values that `copy.deepcopy` cannot handle (closures, handles).

Addresses review finding F9 and the KeyError / shallow-copy issues from earlier review rounds.

## Context

Slice 5 of the incremental split of PR #917. Self-contained; no dependencies on other slices. Every caller of `as_fresh_event()` benefits whether or not the rest of the control-node work lands.

## Test plan

- [x] New `tests/protocols/generic/test_as_fresh_event.py` covers:
  - fresh id + PENDING execution
  - excluded-field preservation
  - deepcopy of excluded fields (mutation of clone does not touch original)
  - deepcopy of metadata when `copy_meta=True`
  - `original` metadata reference
  - fallback path for uncopyable values (closures)
  - base `Event` (no excluded fields) still works
- [x] `uv run pytest tests/protocols/generic/` — full pre-existing event/protocol suite passes (except unrelated `test_pile_filter` xfail)
- [x] `uv run pre-commit run --files lionagi/protocols/generic/event.py tests/protocols/generic/test_as_fresh_event.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)