### PR TITLE
feat(graph): add replace_node + splice_after; Edge accepts any Condition

### DIFF
--- a/lionagi/protocols/graph/edge.py
+++ b/lionagi/protocols/graph/edge.py
@@ -58,7 +58,7 @@ class Edge(Element):
         self,
         head: ID[Relational].Ref,
         tail: ID[Relational].Ref,
-        condition: EdgeCondition | None = None,
+        condition: Condition | None = None,
         label: list[str] | None = None,
         **kwargs,
     ):
@@ -74,8 +74,11 @@ class Edge(Element):
                 starting point of the edge.
             tail (Relational | str): The tail node or its ID. This is the end
                 point of the edge.
-            condition (EdgeCondition | None): An optional condition that must
-                be satisfied for the edge to be traversed.
+            condition (Condition | None): An optional condition that must
+                be satisfied for the edge to be traversed. Any ``Condition``
+                subclass is accepted — :class:`EdgeCondition` is one such
+                subclass, but custom Conditions work as long as they
+                implement ``async def apply(...)``.
             label (list[str] | None): An optional list of labels that describe
                 the edge.
             kwargs: Optional additional properties for the edge.
@@ -83,8 +86,11 @@ class Edge(Element):
         head = ID.get_id(head)
         tail = ID.get_id(tail)
         if condition:
-            if not isinstance(condition, EdgeCondition):
-                raise ValueError("Condition must be an instance of EdgeCondition.")
+            if not isinstance(condition, Condition):
+                raise ValueError(
+                    "condition must be a Condition subclass "
+                    "(e.g. EdgeCondition or a custom async Condition)."
+                )
             kwargs["condition"] = condition
         if label:
             if isinstance(label, str):
@@ -109,13 +115,16 @@ class Edge(Element):
         return self.properties.get("label", None)
 
     @property
-    def condition(self) -> EdgeCondition | None:
+    def condition(self) -> Condition | None:
         return self.properties.get("condition", None)
 
     @condition.setter
-    def condition(self, value: EdgeCondition | None) -> None:
-        if not isinstance(value, EdgeCondition):
-            raise ValueError("Condition must be an instance of EdgeCondition.")
+    def condition(self, value: Condition | None) -> None:
+        if value is not None and not isinstance(value, Condition):
+            raise ValueError(
+                "condition must be a Condition subclass "
+                "(e.g. EdgeCondition or a custom async Condition)."
+            )
         self.properties["condition"] = value
 
     @label.setter

--- a/lionagi/protocols/graph/graph.py
+++ b/lionagi/protocols/graph/graph.py
@@ -448,6 +448,118 @@ class Graph(Element, Relational, Generic[T]):
 
         return None
 
+    @_graph_synchronized
+    def replace_node(self, old: Any, new_node: "Node") -> "Node":
+        """Replace a node, transferring all edges to the new node.
+
+        The new node inherits the old node's exact graph position —
+        all incoming edges now point to ``new_node``, all outgoing
+        edges now originate from ``new_node``. The old node is
+        removed from the graph and returned.
+
+        Args:
+            old: The node or node ID to replace.
+            new_node: The replacement node (must not already be in the graph).
+
+        Returns:
+            The removed old node.
+        """
+        old_id = ID.get_id(old)
+        if old_id not in self.internal_nodes:
+            raise RelationError(f"Node {old_id} not found in graph")
+
+        new_id = new_node.id
+        if new_id in self.internal_nodes:
+            raise RelationError(f"Replacement node {new_id} already in graph")
+
+        self.internal_nodes.insert(len(self.internal_nodes), new_node)
+        self.node_edge_mapping[new_id] = {"in": {}, "out": {}}
+
+        mapping = self.node_edge_mapping[old_id]
+
+        for edge_id, head_id in list(mapping["in"].items()):
+            edge = self.internal_edges[edge_id]
+            edge.tail = new_id
+            self.node_edge_mapping[new_id]["in"][edge_id] = head_id
+            self.node_edge_mapping[head_id]["out"][edge_id] = new_id
+
+        for edge_id, tail_id in list(mapping["out"].items()):
+            edge = self.internal_edges[edge_id]
+            edge.head = new_id
+            self.node_edge_mapping[new_id]["out"][edge_id] = tail_id
+            self.node_edge_mapping[tail_id]["in"][edge_id] = new_id
+
+        self.node_edge_mapping.pop(old_id)
+        return self.internal_nodes.pop(old_id)
+
+    @_graph_synchronized
+    def splice_after(self, anchor: Any, new_node: "Node") -> list[Edge]:
+        """Insert a node between ``anchor`` and all of its successors.
+
+        Before: ``anchor -> s1``, ``anchor -> s2``
+        After:  ``anchor -> new_node -> s1``, ``new_node -> s2``
+
+        The original edges from ``anchor`` to its successors are
+        removed; new edges are created to route through ``new_node``.
+        Edge ``condition``, ``label``, and any extra custom
+        ``properties`` on the original edges are preserved.
+
+        Args:
+            anchor: The node or node ID to splice after.
+            new_node: The node to insert (must not already be in the graph).
+
+        Returns:
+            List of newly created edges. The first entry is the
+            ``anchor -> new_node`` link; the rest are the
+            ``new_node -> successor`` edges.
+        """
+        anchor_id = ID.get_id(anchor)
+        if anchor_id not in self.internal_nodes:
+            raise RelationError(f"Node {anchor_id} not found in graph")
+
+        new_id = new_node.id
+        if new_id in self.internal_nodes:
+            raise RelationError(f"Node {new_id} already in graph")
+
+        self.internal_nodes.insert(len(self.internal_nodes), new_node)
+        self.node_edge_mapping[new_id] = {"in": {}, "out": {}}
+
+        out_edges = list(self.node_edge_mapping[anchor_id]["out"].items())
+
+        new_edges: list[Edge] = []
+        for edge_id, tail_id in out_edges:
+            old_edge = self.internal_edges[edge_id]
+            extra_properties = {
+                k: v
+                for k, v in old_edge.properties.items()
+                if k not in {"condition", "label"}
+            }
+
+            replacement = Edge(
+                head=new_id,
+                tail=tail_id,
+                condition=old_edge.condition,
+                label=old_edge.label,
+                **extra_properties,
+            )
+            self.internal_edges.insert(len(self.internal_edges), replacement)
+            self.node_edge_mapping[new_id]["out"][replacement.id] = tail_id
+            self.node_edge_mapping[tail_id]["in"][replacement.id] = new_id
+
+            self.node_edge_mapping[tail_id]["in"].pop(edge_id)
+            self.node_edge_mapping[anchor_id]["out"].pop(edge_id)
+            self.internal_edges.pop(edge_id)
+
+            new_edges.append(replacement)
+
+        link = Edge(head=anchor_id, tail=new_id)
+        self.internal_edges.insert(len(self.internal_edges), link)
+        self.node_edge_mapping[anchor_id]["out"][link.id] = new_id
+        self.node_edge_mapping[new_id]["in"][link.id] = anchor_id
+
+        new_edges.insert(0, link)
+        return new_edges
+
     def __contains__(self, item: object) -> bool:
         return item in self.internal_nodes or item in self.internal_edges
 

--- a/tests/operations/test_edge_conditions_tdd.py
+++ b/tests/operations/test_edge_conditions_tdd.py
@@ -513,9 +513,7 @@ async def test_validation_invalid_edge_condition_type():
     node1_id = uuid4()
     node2_id = uuid4()
 
-    with pytest.raises(
-        ValueError, match="Condition must be an instance of EdgeCondition"
-    ):
+    with pytest.raises(ValueError, match="Condition subclass"):
         edge = Edge(
             head=node1_id,
             tail=node2_id,

--- a/tests/protocols/graph/test_graph_primitives.py
+++ b/tests/protocols/graph/test_graph_primitives.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Graph.replace_node() and Graph.splice_after().
+
+Also exercises the Edge constructor's relaxation from ``EdgeCondition``
+to any ``Condition`` subclass.
+"""
+
+from uuid import uuid4
+
+import pytest
+
+from lionagi._errors import RelationError
+from lionagi.protocols._concepts import Condition
+from lionagi.protocols.graph.edge import Edge, EdgeCondition
+from lionagi.protocols.graph.graph import Graph
+from lionagi.protocols.graph.node import Node
+
+
+class _YesCondition(EdgeCondition):
+    """Concrete EdgeCondition subclass usable in tests."""
+
+    async def apply(self, *args, **kwargs) -> bool:
+        return True
+
+
+class _AsyncYesCondition(Condition):
+    """Custom Condition subclass that is not an EdgeCondition."""
+
+    def __init__(self, value: bool = True):
+        self.value = value
+
+    async def apply(self, *args, **kwargs) -> bool:
+        return self.value
+
+
+# ── replace_node ────────────────────────────────────────────────────────
+
+
+def test_replace_node_preserves_incoming_and_outgoing_edges():
+    g = Graph()
+    a, b, c = Node(), Node(), Node()
+    g.add_node(a)
+    g.add_node(b)
+    g.add_node(c)
+    g.add_edge(Edge(head=a.id, tail=b.id))
+    g.add_edge(Edge(head=b.id, tail=c.id))
+
+    new_b = Node()
+    removed = g.replace_node(b, new_b)
+
+    assert removed.id == b.id
+    assert new_b.id in g.internal_nodes
+    assert b.id not in g.internal_nodes
+    assert {n.id for n in g.get_successors(a)} == {new_b.id}
+    assert {n.id for n in g.get_successors(new_b)} == {c.id}
+    assert {n.id for n in g.get_predecessors(c)} == {new_b.id}
+
+
+def test_replace_node_preserves_edge_conditions_and_labels():
+    g = Graph()
+    a, b, c = Node(), Node(), Node()
+    g.add_node(a)
+    g.add_node(b)
+    g.add_node(c)
+    cond = _YesCondition(source="token")
+    g.add_edge(Edge(head=a.id, tail=b.id, condition=cond, label=["primary"]))
+    g.add_edge(Edge(head=b.id, tail=c.id, label=["downstream"]))
+
+    new_b = Node()
+    g.replace_node(b, new_b)
+
+    in_edges = [g.internal_edges[eid] for eid in g.node_edge_mapping[new_b.id]["in"]]
+    out_edges = [g.internal_edges[eid] for eid in g.node_edge_mapping[new_b.id]["out"]]
+    assert len(in_edges) == 1 and in_edges[0].condition is cond
+    assert in_edges[0].label == ["primary"]
+    assert len(out_edges) == 1 and out_edges[0].label == ["downstream"]
+
+
+def test_replace_node_rejects_missing_old_node():
+    g = Graph()
+    new_node = Node()
+    with pytest.raises(RelationError, match="not found in graph"):
+        g.replace_node(uuid4(), new_node)
+
+
+def test_replace_node_rejects_replacement_already_in_graph():
+    g = Graph()
+    a, b = Node(), Node()
+    g.add_node(a)
+    g.add_node(b)
+    with pytest.raises(RelationError, match="already in graph"):
+        g.replace_node(a, b)
+
+
+# ── splice_after ────────────────────────────────────────────────────────
+
+
+def test_splice_after_inserts_between_anchor_and_successors():
+    g = Graph()
+    a, s1, s2 = Node(), Node(), Node()
+    g.add_node(a)
+    g.add_node(s1)
+    g.add_node(s2)
+    g.add_edge(Edge(head=a.id, tail=s1.id))
+    g.add_edge(Edge(head=a.id, tail=s2.id))
+
+    new = Node()
+    new_edges = g.splice_after(a, new)
+
+    assert new.id in g.internal_nodes
+    # New edges: link + 2 replacement edges
+    assert len(new_edges) == 3
+    assert {n.id for n in g.get_successors(a)} == {new.id}
+    assert {n.id for n in g.get_successors(new)} == {s1.id, s2.id}
+
+
+def test_splice_after_preserves_custom_edge_properties():
+    g = Graph()
+    a, s = Node(), Node()
+    g.add_node(a)
+    g.add_node(s)
+    g.add_edge(Edge(head=a.id, tail=s.id, label=["hot"], weight=7, custom="keep"))
+
+    new = Node()
+    g.splice_after(a, new)
+
+    # The new-to-successor edge should carry extra properties forward.
+    successor_edges = [
+        g.internal_edges[eid] for eid in g.node_edge_mapping[new.id]["out"]
+    ]
+    assert len(successor_edges) == 1
+    e = successor_edges[0]
+    assert e.label == ["hot"]
+    assert e.properties.get("weight") == 7
+    assert e.properties.get("custom") == "keep"
+
+
+def test_splice_after_with_no_successors_just_links():
+    g = Graph()
+    a = Node()
+    g.add_node(a)
+
+    new = Node()
+    new_edges = g.splice_after(a, new)
+
+    assert len(new_edges) == 1
+    assert new_edges[0].head == a.id and new_edges[0].tail == new.id
+
+
+def test_splice_after_rejects_missing_anchor():
+    g = Graph()
+    new = Node()
+    with pytest.raises(RelationError, match="not found in graph"):
+        g.splice_after(uuid4(), new)
+
+
+def test_splice_after_rejects_new_already_in_graph():
+    g = Graph()
+    a, b = Node(), Node()
+    g.add_node(a)
+    g.add_node(b)
+    with pytest.raises(RelationError, match="already in graph"):
+        g.splice_after(a, b)
+
+
+# ── Edge accepts arbitrary Condition subclass ──────────────────────────
+
+
+def test_edge_accepts_custom_condition_subclass():
+    a, b = Node(), Node()
+    cond = _AsyncYesCondition()
+    # Must construct without error — previously required EdgeCondition.
+    e = Edge(head=a.id, tail=b.id, condition=cond)
+    assert e.condition is cond
+
+
+def test_edge_rejects_non_condition():
+    a, b = Node(), Node()
+
+    class _NotACondition:
+        async def apply(self, *args, **kwargs):
+            return True
+
+    with pytest.raises(ValueError, match="Condition subclass"):
+        Edge(head=a.id, tail=b.id, condition=_NotACondition())
+
+
+def test_edge_setter_accepts_custom_condition_subclass():
+    a, b = Node(), Node()
+    e = Edge(head=a.id, tail=b.id)
+    e.condition = _AsyncYesCondition()
+    assert isinstance(e.condition, _AsyncYesCondition)
+
+
+def test_edge_setter_rejects_non_condition():
+    a, b = Node(), Node()
+    e = Edge(head=a.id, tail=b.id)
+
+    class _NotACondition:
+        pass
+
+    with pytest.raises(ValueError, match="Condition subclass"):
+        e.condition = _NotACondition()


### PR DESCRIPTION
## Summary

Two mutation primitives on `Graph`:

- **`replace_node(old, new)`** — swap a node in-place, transferring all incoming and outgoing edges to the new node. Preserves edge ids, conditions, labels, and properties. Useful for retry-style patterns that need a fresh node at the same DAG position.
- **`splice_after(anchor, new)`** — insert a node between `anchor` and all of its successors: `anchor -> new -> s1`, `new -> s2`. Preserves the original edge conditions, labels, and any extra custom properties (e.g. `weight`, metadata) on the `new -> successor` edges.

`Edge` construction and the `condition` setter now accept any `Condition` subclass, not just `EdgeCondition`. `EdgeCondition` remains the common `BaseModel + Condition` subclass; custom async `Condition` subclasses work the same way.

Addresses review F8 (`splice_after` dropping edge properties).

## Context

Slice 6 of the incremental split of PR #917. Self-contained; no dependencies on other slices. The new primitives are generically useful for graph editing; they are not tied to any control-node work.

## Test plan

- [x] New `tests/protocols/graph/test_graph_primitives.py` covers:
  - `replace_node` edge preservation (incoming + outgoing, conditions, labels)
  - `replace_node` rejects missing old node
  - `replace_node` rejects replacement already in graph
  - `splice_after` inserts between anchor and successors
  - `splice_after` preserves label + weight + custom properties
  - `splice_after` with no successors just links
  - `splice_after` rejects missing anchor / already-in-graph new node
  - `Edge` accepts custom `Condition` subclass in constructor and setter
  - `Edge` rejects non-`Condition` objects with clear error
- [x] `uv run pytest tests/protocols/graph/` — 342 passed (329 pre-existing + 13 new). Unrelated postgres/sqlalchemy xfail deselected.
- [x] `uv run pre-commit run --files lionagi/protocols/graph/graph.py lionagi/protocols/graph/edge.py tests/protocols/graph/test_graph_primitives.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)