### PR TITLE
feat(cli): validate plan topology up front + argparse --agent positional swap

### DIFF
--- a/lionagi/cli/orchestrate/__init__.py
+++ b/lionagi/cli/orchestrate/__init__.py
@@ -345,6 +345,13 @@ def run_orchestrate(args: argparse.Namespace) -> int:
             if spec.get("critic_model"):
                 pass  # reserved for future use
 
+        # Argparse assigns a lone positional to `model`, leaving prompt
+        # None. When --agent supplies the model and the user passed a
+        # single positional, that positional is actually the prompt.
+        if args.model and not args.prompt and args.agent:
+            args.prompt = args.model
+            args.model = None
+
         has_model = args.model is not None or args.agent is not None
         if not has_model:
             log_error("model or --agent is required")

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -259,6 +259,45 @@ class FlowControlVerdict(HashableModel):
 FLOW_VERDICT_FIELDS = FieldModel(FlowControlVerdict, name="verdict")
 
 
+def _topo_sort_ops(ops: list[FlowOp]) -> list[FlowOp]:
+    """Topological sort of FlowOps so parents appear before children.
+
+    Raises
+    ------
+    ValueError
+        If any ``depends_on`` references an id that is not in ``ops``
+        (fail-closed on typos and hallucinated deps), or if the
+        dependency graph has a cycle.
+    """
+    by_id = {op.id: op for op in ops}
+
+    for op in ops:
+        for dep in op.depends_on or []:
+            if dep not in by_id:
+                raise ValueError(f"Op {op.id!r} declares unknown dependency {dep!r}")
+
+    visited: set[str] = set()
+    in_progress: set[str] = set()
+    order: list[FlowOp] = []
+
+    def _visit(op_id: str) -> None:
+        if op_id in visited:
+            return
+        if op_id in in_progress:
+            raise ValueError(f"Dependency cycle detected involving {op_id!r}")
+        in_progress.add(op_id)
+        op = by_id[op_id]
+        for dep in op.depends_on or []:
+            _visit(dep)
+        in_progress.discard(op_id)
+        visited.add(op_id)
+        order.append(op)
+
+    for op in ops:
+        _visit(op.id)
+    return order
+
+
 def _format_flow_result_text(
     agent_results: list[dict],
     synthesis_result: dict | None = None,
@@ -444,6 +483,14 @@ async def _run_flow_inner(
                 f"Invalid plan: op {op.id!r} references unknown agent "
                 f"{op.agent_id!r} (known: {sorted(agent_ids)})"
             )
+
+    # Validate topology and depends_on targets up front. Rejects plans
+    # with typo'd deps or dependency cycles before we spend any agent
+    # time executing them.
+    try:
+        _topo_sort_ops(plan.operations)
+    except ValueError as e:
+        return f"Invalid plan: {e}"
 
     # max_agents caps the total operation count — that is the real work
     # budget. Agent count is bounded implicitly by the op count since
@@ -841,6 +888,12 @@ async def _run_flow_inner(
 
             if not new_ops:
                 progress("Re-plan: no executable new ops; ending.")
+                continue
+
+            try:
+                new_ops = _topo_sort_ops(new_ops)
+            except ValueError as e:
+                progress(f"Re-plan rejected: {e}")
                 continue
 
             ids = ", ".join(o.id for o in new_ops)

--- a/tests/test_cli_flow_topology.py
+++ b/tests/test_cli_flow_topology.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for _topo_sort_ops (CLI plan validation)."""
+
+import pytest
+
+from lionagi.cli.orchestrate.flow import FlowOp, _topo_sort_ops
+
+
+def _op(oid: str, deps: list[str] | None = None) -> FlowOp:
+    return FlowOp(
+        id=oid,
+        agent_id="a1",
+        instruction="do the thing",
+        depends_on=deps,
+    )
+
+
+def test_topo_sort_already_sorted():
+    ops = [_op("a"), _op("b", ["a"]), _op("c", ["b"])]
+    sorted_ops = _topo_sort_ops(ops)
+    assert [o.id for o in sorted_ops] == ["a", "b", "c"]
+
+
+def test_topo_sort_unsorted_input_is_reordered_parent_before_child():
+    ops = [_op("c", ["b"]), _op("b", ["a"]), _op("a")]
+    sorted_ops = _topo_sort_ops(ops)
+    order = [o.id for o in sorted_ops]
+    assert order.index("a") < order.index("b") < order.index("c")
+
+
+def test_topo_sort_diamond():
+    # a -> b, a -> c, b -> d, c -> d
+    ops = [_op("d", ["b", "c"]), _op("b", ["a"]), _op("c", ["a"]), _op("a")]
+    sorted_ops = _topo_sort_ops(ops)
+    order = [o.id for o in sorted_ops]
+    assert order.index("a") < order.index("b")
+    assert order.index("a") < order.index("c")
+    assert order.index("b") < order.index("d")
+    assert order.index("c") < order.index("d")
+
+
+def test_topo_sort_rejects_unknown_dependency():
+    ops = [_op("a"), _op("b", ["nonexistent"])]
+    with pytest.raises(ValueError, match="unknown dependency"):
+        _topo_sort_ops(ops)
+
+
+def test_topo_sort_rejects_self_cycle():
+    ops = [_op("a", ["a"])]
+    with pytest.raises(ValueError, match="cycle detected"):
+        _topo_sort_ops(ops)
+
+
+def test_topo_sort_rejects_two_node_cycle():
+    ops = [_op("a", ["b"]), _op("b", ["a"])]
+    with pytest.raises(ValueError, match="cycle detected"):
+        _topo_sort_ops(ops)
+
+
+def test_topo_sort_rejects_three_node_cycle():
+    ops = [_op("a", ["c"]), _op("b", ["a"]), _op("c", ["b"])]
+    with pytest.raises(ValueError, match="cycle detected"):
+        _topo_sort_ops(ops)
+
+
+def test_topo_sort_empty_list():
+    assert _topo_sort_ops([]) == []
+
+
+def test_topo_sort_single_op_no_deps():
+    [only] = _topo_sort_ops([_op("solo")])
+    assert only.id == "solo"


### PR DESCRIPTION
## Summary

Two CLI safety fixes:

1. **`_topo_sort_ops` validates `FlowPlan.operations` before execution.** Rejects plans with unknown `depends_on` targets (typos, hallucinated ids) and detects dependency cycles. Fails closed with `"Invalid plan: ..."`. Applied to both the initial plan and each re-planned round — a bad re-plan is dropped with `"Re-plan rejected: ..."` rather than aborting the entire flow.
2. **Argparse `--agent` + single positional fix.** When `--agent` provides the model and the user passes a single positional, argparse binds it to `args.model` and leaves `args.prompt` empty. Detect that case and swap so the lone positional is treated as the prompt. Prevents the confusing `"prompt is required"` error when the user clearly provided one.

## Context

Slice 9 (final code slice) of the incremental split of PR #917. Self-contained. No dependencies on control-node work; these validators and the argparse swap apply to every flow today.

## Test plan

- [x] New `tests/test_cli_flow_topology.py` covers: already-sorted, unsorted re-ordering, diamond, unknown dependency, self-cycle, two-node cycle, three-node cycle, empty list, single op — 9 passed.
- [x] `uv run pytest tests/test_cli_flow_topology.py tests/test_flow_spec_file.py tests/session/ tests/operations/test_flow.py` — all pass
- [x] `uv run pre-commit run --files lionagi/cli/orchestrate/flow.py lionagi/cli/orchestrate/__init__.py tests/test_cli_flow_topology.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)