### PR TITLE
feat(models): Note model + nested utilities

### DIFF
--- a/lionagi/libs/__init__.py
+++ b/lionagi/libs/__init__.py
@@ -1,2 +1,22 @@
 # Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
+
+from .nested import (
+    deep_update,
+    flatten,
+    get_target_container,
+    nget,
+    npop,
+    nset,
+    unflatten,
+)
+
+__all__ = [
+    "get_target_container",
+    "nget",
+    "nset",
+    "npop",
+    "flatten",
+    "unflatten",
+    "deep_update",
+]

--- a/lionagi/libs/nested.py
+++ b/lionagi/libs/nested.py
@@ -120,12 +120,15 @@ def npop(
                     return default
                 raise KeyError(f"Key not found: {key!r}")
             current = current[key]
-        elif isinstance(current, list) and isinstance(key, int):
-            if key < 0 or key >= len(current):
+        elif isinstance(current, list):
+            if isinstance(key, str) and key.isdigit():
+                key = int(key)
+            if isinstance(key, int) and 0 <= key < len(current):
+                current = current[key]
+            else:
                 if default is not UNDEFINED:
                     return default
                 raise IndexError(f"List index out of range: {key}")
-            current = current[key]
         else:
             if default is not UNDEFINED:
                 return default
@@ -137,6 +140,8 @@ def npop(
                 return current.pop(last, default)
             return current.pop(last)
         elif isinstance(current, list):
+            if isinstance(last, str) and last.isdigit():
+                last = int(last)
             if not isinstance(last, int):
                 raise TypeError("Cannot use non-integer index on a list")
             if last < 0 or last >= len(current):

--- a/lionagi/libs/nested.py
+++ b/lionagi/libs/nested.py
@@ -1,0 +1,237 @@
+# Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from collections import deque
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from lionagi.utils import UNDEFINED
+
+
+def get_target_container(
+    data: list[Any] | dict[Any, Any],
+    indices: list[int | str],
+) -> list[Any] | dict[Any, Any]:
+    """Walk data to the container at indices path."""
+    current = data
+    for index in indices:
+        if isinstance(current, list):
+            if isinstance(index, str) and index.isdigit():
+                index = int(index)
+            if isinstance(index, int) and 0 <= index < len(current):
+                current = current[index]
+            else:
+                raise IndexError("List index is invalid or out of range")
+        elif isinstance(current, dict):
+            if index in current:
+                current = current[index]
+            else:
+                raise KeyError(f"Key not found in dictionary: {index!r}")
+        else:
+            raise TypeError("Current element is neither a list nor a dict")
+    return current
+
+
+def _ensure_list_index(lst: list[Any], index: int) -> None:
+    """Extend list with None values until index is valid."""
+    while len(lst) <= index:
+        lst.append(None)
+
+
+def nget(
+    data: dict[Any, Any] | list[Any],
+    indices: list[int | str],
+    default: Any = UNDEFINED,
+) -> Any:
+    """Safe nested get; walk data using indices, return default if path missing."""
+    if not indices:
+        raise ValueError("indices must not be empty")
+    try:
+        container = get_target_container(data, indices[:-1])
+        last = indices[-1]
+        if isinstance(container, list):
+            if isinstance(last, str) and last.isdigit():
+                last = int(last)
+            if isinstance(last, int) and 0 <= last < len(container):
+                return container[last]
+        elif isinstance(container, dict) and last in container:
+            return container[last]
+        if default is not UNDEFINED:
+            return default
+        raise KeyError(f"Path not found: {indices}")
+    except (IndexError, KeyError, TypeError) as exc:
+        if default is not UNDEFINED:
+            return default
+        raise KeyError(f"Path not found: {indices}") from exc
+
+
+def nset(
+    data: dict[str, Any] | list[Any],
+    indices: list[str | int],
+    value: Any,
+) -> None:
+    """Nested set; auto-creates intermediate dicts/lists based on next index type."""
+    if not indices:
+        raise ValueError("indices must not be empty")
+    current = data
+    for i, index in enumerate(indices[:-1]):
+        next_index = indices[i + 1]
+        if isinstance(current, list):
+            if not isinstance(index, int):
+                raise TypeError("Cannot use non-integer index on a list")
+            _ensure_list_index(current, index)
+            if current[index] is None:
+                current[index] = [] if isinstance(next_index, int) else {}
+        elif isinstance(current, dict):
+            if isinstance(index, int):
+                raise TypeError("Cannot use integer key on a dict")
+            if index not in current:
+                current[index] = [] if isinstance(next_index, int) else {}
+        else:
+            raise TypeError("Target container is not a list or dict")
+        current = current[index]
+    last = indices[-1]
+    if isinstance(current, list):
+        if not isinstance(last, int):
+            raise TypeError("Cannot use non-integer index on a list")
+        _ensure_list_index(current, last)
+        current[last] = value
+    elif isinstance(current, dict):
+        if not isinstance(last, str):
+            raise TypeError("Only string keys are allowed for dicts")
+        current[last] = value
+    else:
+        raise TypeError("Cannot set value on non-list/dict element")
+
+
+def npop(
+    data: dict[str, Any] | list[Any],
+    indices: list[str | int],
+    default: Any = UNDEFINED,
+) -> Any:
+    """Nested pop; walk to parent, pop final key."""
+    if not indices:
+        raise ValueError("indices must not be empty")
+    current = data
+    for key in indices[:-1]:
+        if isinstance(current, dict):
+            if key not in current:
+                if default is not UNDEFINED:
+                    return default
+                raise KeyError(f"Key not found: {key!r}")
+            current = current[key]
+        elif isinstance(current, list) and isinstance(key, int):
+            if key < 0 or key >= len(current):
+                if default is not UNDEFINED:
+                    return default
+                raise IndexError(f"List index out of range: {key}")
+            current = current[key]
+        else:
+            if default is not UNDEFINED:
+                return default
+            raise TypeError(f"Cannot traverse into {type(current).__name__}")
+    last = indices[-1]
+    try:
+        if isinstance(current, dict):
+            if default is not UNDEFINED:
+                return current.pop(last, default)
+            return current.pop(last)
+        elif isinstance(current, list):
+            if not isinstance(last, int):
+                raise TypeError("Cannot use non-integer index on a list")
+            if last < 0 or last >= len(current):
+                if default is not UNDEFINED:
+                    return default
+                raise IndexError(f"List index out of range: {last}")
+            return current.pop(last)
+        else:
+            raise TypeError(f"Cannot pop from {type(current).__name__}")
+    except (KeyError, IndexError):
+        if default is not UNDEFINED:
+            return default
+        raise
+
+
+def flatten(
+    data: Any,
+    *,
+    sep: str = "|",
+    max_depth: int | None = None,
+) -> dict[str, Any]:
+    """Flatten nested dict/list to flat dict with sep-joined path keys."""
+    result: dict[str, Any] = {}
+    stack: deque[tuple[Any, tuple[str, ...], int]] = deque([(data, (), 0)])
+    while stack:
+        obj, parent_key, depth = stack.pop()
+        if max_depth is not None and depth >= max_depth:
+            key_str = sep.join(parent_key)
+            result[key_str] = obj
+            continue
+        if isinstance(obj, Mapping):
+            for k, v in obj.items():
+                new_key = parent_key + (str(k),)
+                if isinstance(v, (Mapping, Sequence)) and not isinstance(
+                    v, (str, bytes, bytearray)
+                ):
+                    stack.appendleft((v, new_key, depth + 1))
+                else:
+                    result[sep.join(new_key)] = v
+        elif isinstance(obj, Sequence) and not isinstance(obj, (str, bytes, bytearray)):
+            for i, v in enumerate(obj):
+                new_key = parent_key + (str(i),)
+                if isinstance(v, (Mapping, Sequence)) and not isinstance(
+                    v, (str, bytes, bytearray)
+                ):
+                    stack.appendleft((v, new_key, depth + 1))
+                else:
+                    result[sep.join(new_key)] = v
+        else:
+            key_str = sep.join(parent_key) if parent_key else ""
+            result[key_str] = obj
+    return result
+
+
+def unflatten(data: dict[str, Any], sep: str = "|") -> dict[str, Any]:
+    """Reverse flatten; auto-detects list keys (consecutive integer strings)."""
+
+    def _convert(d: dict) -> dict | list:
+        if d and all(k.isdigit() for k in d):
+            if all(str(i) in d for i in range(len(d))):
+                return [
+                    _convert(d[str(i)]) if isinstance(d[str(i)], dict) else d[str(i)]
+                    for i in range(len(d))
+                ]
+            return {k: _convert(v) if isinstance(v, dict) else v for k, v in d.items()}
+        return {k: _convert(v) if isinstance(v, dict) else v for k, v in d.items()}
+
+    intermediate: dict[str, Any] = {}
+    for key, value in data.items():
+        parts = key.split(sep)
+        current = intermediate
+        for part in parts[:-1]:
+            if part not in current:
+                current[part] = {}
+            current = current[part]
+        current[parts[-1]] = value
+    return _convert(intermediate)
+
+
+def deep_update(original: dict[Any, Any], update: dict[Any, Any]) -> dict[Any, Any]:
+    """Recursive dict merge; nested dicts merge, other values overwrite."""
+    for key, value in update.items():
+        if isinstance(value, dict) and isinstance(original.get(key), dict):
+            original[key] = deep_update(original[key], value)
+        else:
+            original[key] = value
+    return original
+
+
+__all__ = [
+    "get_target_container",
+    "nget",
+    "nset",
+    "npop",
+    "flatten",
+    "unflatten",
+    "deep_update",
+]

--- a/lionagi/models/__init__.py
+++ b/lionagi/models/__init__.py
@@ -4,13 +4,15 @@
 from .field_model import FieldModel
 from .hashable_model import HashableModel
 from .model_params import ModelParams
+from .note import Note
 from .operable_model import OperableModel
 from .schema_model import SchemaModel
 
 __all__ = (
     "FieldModel",
+    "HashableModel",
     "ModelParams",
+    "Note",
     "OperableModel",
     "SchemaModel",
-    "HashableModel",
 )

--- a/lionagi/models/note.py
+++ b/lionagi/models/note.py
@@ -52,7 +52,10 @@ class Note(BaseModel):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__()
-        self.content = kwargs
+        if len(kwargs) == 1 and "content" in kwargs and isinstance(kwargs["content"], dict):
+            self.content = kwargs["content"]
+        else:
+            self.content = kwargs
 
     @field_serializer("content")
     def _serialize_content(self, value: Any) -> dict[str, Any]:

--- a/lionagi/models/note.py
+++ b/lionagi/models/note.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import ItemsView, Iterator, KeysView, ValuesView
+from functools import partial
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_serializer
+from typing_extensions import override
+
+from lionagi.libs.nested import deep_update, flatten, nget, npop, nset, unflatten
+from lionagi.ln import is_sentinel, to_dict
+from lionagi.utils import UNDEFINED, copy
+
+IndicesType = str | int | tuple[str | int, ...]
+
+
+def _strip_sentinels(obj: Any, none_as_sentinel=False, empty_as_sentinel=False) -> Any:
+    _is_sential = partial(
+        is_sentinel,
+        none_as_sentinel=none_as_sentinel,
+        empty_as_sentinel=empty_as_sentinel,
+    )
+
+    def _inner(obj: Any) -> Any:
+        if isinstance(obj, dict):
+            return {k: _inner(v) for k, v in obj.items() if not _is_sential(v)}
+        if isinstance(obj, list):
+            return [_inner(v) for v in obj if not _is_sential(v)]
+        return obj
+
+    return _inner(obj)
+
+
+def _to_indices(key: IndicesType) -> list[str | int]:
+    """Normalize a single key or tuple of keys to a list of indices."""
+    if isinstance(key, (str, int)):
+        return [key]
+    return list(key)
+
+
+class Note(BaseModel):
+    """Container for nested dict data with path-indexing sugar."""
+
+    content: dict[str, Any] = Field(default_factory=dict)
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+    )
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__()
+        self.content = kwargs
+
+    @field_serializer("content")
+    def _serialize_content(self, value: Any) -> dict[str, Any]:
+        return copy(value, deep=True)
+
+    # --- core path operations ---
+
+    def get(
+        self, indices: list[str | int] | str | int, /, default: Any = UNDEFINED
+    ) -> Any:
+        """Get value at path; return default if missing (raise KeyError if no default)."""
+        return nget(self.content, _to_indices(indices), default)
+
+    def set(self, indices: list[str | int] | str | int, value: Any, /) -> None:
+        """Deep set value at path; auto-creates intermediate containers."""
+        nset(self.content, _to_indices(indices), value)
+
+    def pop(
+        self, indices: list[str | int] | str | int, /, default: Any = UNDEFINED
+    ) -> Any:
+        """Remove and return value at path."""
+        return npop(self.content, _to_indices(indices), default)
+
+    def update(self, indices: list[str | int] | str | int, value: Any, /) -> None:
+        """Update nested structure at path (list: extend/append; dict: merge)."""
+        existing = self.get(indices, None)
+        if existing is None:
+            if not isinstance(value, (list, dict)):
+                value = [value]
+            self.set(indices, value)
+        elif isinstance(existing, list):
+            if isinstance(value, list):
+                existing.extend(value)
+            else:
+                existing.append(value)
+        elif isinstance(existing, dict):
+            if isinstance(value, Note):
+                value = value.content
+            if isinstance(value, dict):
+                deep_update(existing, value)
+            else:
+                raise ValueError("Cannot update a dict with a non-dict value.")
+        else:
+            raise TypeError(
+                f"Cannot update {type(existing).__name__} at {indices!r}; "
+                f"use set() to overwrite"
+            )
+
+    # --- flatten / unflatten ---
+
+    def flatten(self, sep: str = "|", max_depth: int | None = None) -> dict[str, Any]:
+        """Return flat dict with sep-joined path keys."""
+        return flatten(self.content, sep=sep, max_depth=max_depth)
+
+    @classmethod
+    def unflatten(cls, data: dict[str, Any], sep: str = "|") -> "Note":
+        """Reconstruct Note from a flattened dict."""
+        nested = unflatten(data, sep=sep)
+        if isinstance(nested, dict):
+            return cls(**nested)
+        return cls(**{"0": nested})
+
+    # --- serialization ---
+
+    def to_dict(
+        self,
+        mode: Literal["python", "json"] = "python",
+        exclude_none: bool = False,
+        exclude_empty: bool = False,
+    ) -> dict[str, Any]:
+        """Deep copy of content, sentinel values removed at all levels."""
+        out = _strip_sentinels(
+            copy(self.content, deep=True),
+            none_as_sentinel=exclude_none,
+            empty_as_sentinel=exclude_empty,
+        )
+        if mode == "json":
+            return to_dict(
+                out,
+                recursive=True,
+                recursive_python_only=False,
+                use_enum_values=True,
+                use_model_dump=True,
+            )
+        return out
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Note":
+        """Create Note from a plain dict."""
+        return cls(**data)
+
+    # --- dict-like interface ---
+
+    def keys(self, /, flat: bool = False, sep: str = "|", **kwargs: Any) -> KeysView:
+        """Return top-level keys, or flattened keys when flat=True."""
+        if flat:
+            return flatten(self.content, sep=sep, **kwargs).keys()
+        return self.content.keys()
+
+    def values(
+        self, /, flat: bool = False, sep: str = "|", **kwargs: Any
+    ) -> ValuesView:
+        """Return top-level values, or flattened values when flat=True."""
+        if flat:
+            return flatten(self.content, sep=sep, **kwargs).values()
+        return self.content.values()
+
+    def items(self, /, flat: bool = False, sep: str = "|", **kwargs: Any) -> ItemsView:
+        """Return top-level items, or flattened items when flat=True."""
+        if flat:
+            return flatten(self.content, sep=sep, **kwargs).items()
+        return self.content.items()
+
+    def clear(self) -> None:
+        """Clear all content."""
+        self.content.clear()
+
+    # --- operators ---
+
+    def __contains__(self, key: Any) -> bool:
+        """Check top-level key membership."""
+        return key in self.content
+
+    def __len__(self) -> int:
+        return len(self.content)
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.content)
+
+    def __getitem__(self, indices: IndicesType) -> Any:
+        """Single key: direct dict lookup. Tuple: deep path walk."""
+        if isinstance(indices, tuple):
+            return nget(self.content, list(indices))
+        return self.content[indices]
+
+    def __setitem__(self, indices: IndicesType, value: Any) -> None:
+        """Single key: direct dict set. Tuple: deep path set."""
+        if isinstance(indices, tuple):
+            nset(self.content, list(indices), value)
+        else:
+            self.content[indices] = value
+
+    @override
+    def __str__(self) -> str:
+        return str(self.content)
+
+    @override
+    def __repr__(self) -> str:
+        return repr(self.content)


### PR DESCRIPTION
## Summary

- **Note model** (`models/note.py`): Lightweight `BaseModel` wrapper over `dict[str, Any]` with path-indexed access, deep update, flatten/unflatten, and sentinel stripping
- **nested utilities** (`libs/nested.py`): `nget`/`nset`/`npop`, `flatten`/`unflatten`, `deep_update` — standalone functions for nested data manipulation

## Details

Note is designed as a transient metadata workspace for operations — used by `builder.py` and `flow.py` for accumulating context across operation DAGs. It is intentionally NOT an Element (no UUID, no timestamp) to stay lightweight.

Key design decisions:
- `update()` raises `TypeError` on scalar overwrite — use `set()` explicitly
- `unflatten()` guards non-contiguous integer keys (falls back to dict instead of KeyError)
- `nget()` coerces digit-strings to int at terminal step (matches intermediate traversal behavior)

4 files, +464 lines. 5796 tests pass, 0 failures.

## Test plan

- [x] Existing test suite passes (5796/5796)
- [ ] Dedicated tests for Note model edge cases
- [ ] Dedicated tests for nested.py utilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)