### PR TITLE
feat(connections): provider registry architecture + AgenticEndpoint

### DIFF
--- a/lionagi/service/connections/__init__.py
+++ b/lionagi/service/connections/__init__.py
@@ -1,18 +1,32 @@
 # Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
+from .agentic_endpoint import AgenticEndpoint
 from .api_calling import APICalling
 from .cli_endpoint import CLIEndpoint
 from .endpoint import Endpoint
 from .endpoint_config import EndpointConfig
 from .header_factory import HeaderFactory
 from .match_endpoint import match_endpoint
+from .mcp.wrapper import MCPConnectionPool, MCPSecurityConfig, create_mcp_tool
+from .provider_config import LazyType, ProviderConfig
+from .registry import EndpointMeta, EndpointRegistry, EndpointType, register_endpoint
 
 __all__ = (
-    "Endpoint",
+    "AgenticEndpoint",
+    "APICalling",
     "CLIEndpoint",
+    "Endpoint",
     "EndpointConfig",
     "HeaderFactory",
     "match_endpoint",
-    "APICalling",
+    "MCPConnectionPool",
+    "MCPSecurityConfig",
+    "create_mcp_tool",
+    "EndpointMeta",
+    "EndpointRegistry",
+    "EndpointType",
+    "LazyType",
+    "ProviderConfig",
+    "register_endpoint",
 )

--- a/lionagi/service/connections/agentic_endpoint.py
+++ b/lionagi/service/connections/agentic_endpoint.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import ClassVar
+
+from .endpoint import Endpoint
+from .endpoint_config import EndpointConfig
+
+__all__ = ("AgenticEndpoint",)
+
+
+class AgenticEndpoint(Endpoint):
+    """Base for agentic endpoints (CLI tools, in-process agent runtimes).
+
+    Agentic endpoints (Claude Code, AG2 GroupChat, Codex, Gemini CLI)
+    differ from HTTP API endpoints:
+    - They may spawn subprocesses or run agent loops in-process.
+    - Concurrency must be low (heavy per-invocation).
+    - They may maintain sessions with resumption.
+    - They manage their own context, tools, and actions.
+    - They stream via NDJSON, events, or in-process callbacks.
+
+    Subclasses must implement ``stream()`` yielding ``StreamChunk`` objects.
+    """
+
+    is_cli: ClassVar[bool] = True
+
+    DEFAULT_CONCURRENCY_LIMIT: ClassVar[int] = 3
+    DEFAULT_QUEUE_CAPACITY: ClassVar[int] = 10
+
+    def __init__(self, config: dict | EndpointConfig = None, **kwargs):
+        super().__init__(config=config, **kwargs)
+        self._session_id: str | None = None
+
+    @property
+    def provider_session_id(self) -> str | None:
+        return self._session_id
+
+    @property
+    def session_id(self) -> str | None:
+        return self._session_id
+
+    @session_id.setter
+    def session_id(self, value: str | None):
+        self._session_id = value
+
+    def _create_http_session(self):
+        raise NotImplementedError("Agentic endpoints do not use HTTP sessions")
+
+    async def _call_aiohttp(self, *a, **kw):
+        raise NotImplementedError("Agentic endpoints do not use aiohttp")
+
+    async def _stream_aiohttp(self, payload: dict, headers: dict, **kwargs):
+        raise NotImplementedError("Agentic endpoints do not use aiohttp streaming")

--- a/lionagi/service/connections/api_calling.py
+++ b/lionagi/service/connections/api_calling.py
@@ -12,6 +12,9 @@ from .endpoint import Endpoint
 logger = logging.getLogger(__name__)
 
 
+__all__ = ("APICalling",)
+
+
 class APICalling(HookedEvent):
     """Handles asynchronous API calls with automatic token usage tracking.
 

--- a/lionagi/service/connections/cli_endpoint.py
+++ b/lionagi/service/connections/cli_endpoint.py
@@ -1,55 +1,8 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import ClassVar
-
-from .endpoint import Endpoint
+# Re-export from agentic_endpoint for backward compatibility.
+from .agentic_endpoint import AgenticEndpoint as CLIEndpoint
 from .endpoint_config import EndpointConfig
 
-
-class CLIEndpoint(Endpoint):
-    """Base for CLI-based agentic endpoints (subprocess, not HTTP).
-
-    CLI endpoints (Claude Code, Gemini CLI, Codex CLI) differ from HTTP API
-    endpoints in fundamental ways:
-    - They spawn heavy subprocesses, so concurrency must be low.
-    - They may maintain sessions with resumption.
-    - They manage their own context and actions.
-    - They use subprocess + NDJSON streaming, not aiohttp + JSON.
-
-    Subclasses must implement ``stream()`` yielding ``StreamChunk`` objects.
-    """
-
-    is_cli: ClassVar[bool] = True
-
-    # Conservative defaults for CLI subprocess concurrency
-    DEFAULT_CONCURRENCY_LIMIT: ClassVar[int] = 3
-    DEFAULT_QUEUE_CAPACITY: ClassVar[int] = 10
-
-    def __init__(self, config: dict | EndpointConfig = None, **kwargs):
-        super().__init__(config=config, **kwargs)
-        self._session_id: str | None = None
-
-    @property
-    def provider_session_id(self) -> str | None:
-        """Current provider session ID for resume, if any."""
-        return self._session_id
-
-    # mark this as deprecated
-    @property
-    def session_id(self) -> str | None:
-        """Current session ID for resume, if any."""
-        return self._session_id
-
-    @session_id.setter
-    def session_id(self, value: str | None):
-        self._session_id = value
-
-    def _create_http_session(self):
-        raise NotImplementedError("CLI endpoints do not use HTTP sessions")
-
-    async def _call_aiohttp(self, *a, **kw):
-        raise NotImplementedError("CLI endpoints do not use aiohttp")
-
-    async def _stream_aiohttp(self, payload: dict, headers: dict, **kwargs):
-        raise NotImplementedError("CLI endpoints do not use aiohttp streaming")
+__all__ = ("CLIEndpoint",)

--- a/lionagi/service/connections/endpoint.py
+++ b/lionagi/service/connections/endpoint.py
@@ -15,35 +15,35 @@ from .header_factory import HeaderFactory
 logger = logging.getLogger(__name__)
 
 
+__all__ = ("Endpoint",)
+
+
 class Endpoint:
     is_cli: ClassVar[bool] = False
 
     def __init__(
         self,
-        config: dict | EndpointConfig,
+        config: dict | EndpointConfig | None = None,
         circuit_breaker: CircuitBreaker | None = None,
         retry_config: RetryConfig | None = None,
         **kwargs,
     ):
-        """
-        Initialize the endpoint.
-
-        This endpoint is designed to be stateless and thread-safe for parallel operations.
-        Each API call will create its own client session to avoid conflicts.
-
-        Args:
-            config: The endpoint configuration.
-            circuit_breaker: Optional circuit breaker for resilience.
-            retry_config: Optional retry configuration for resilience.
-            **kwargs: Additional keyword arguments to update the configuration.
-        """
-        if isinstance(config, dict):
+        if config is None:
+            meta = getattr(type(self), "_ENDPOINT_META", None)
+            if meta is not None:
+                _config = meta.create_config(**kwargs)
+            else:
+                raise ValueError(
+                    "No config provided and no _ENDPOINT_META on class. "
+                    "Either pass a config or use @register_endpoint."
+                )
+        elif isinstance(config, dict):
             _config = EndpointConfig(**config, **kwargs)
         elif isinstance(config, EndpointConfig):
             _config = config.model_copy(deep=True)
             _config.update(**kwargs)
         else:
-            raise ValueError("Config must be a dict or EndpointConfig instance")
+            raise ValueError("Config must be a dict, EndpointConfig, or None")
         self.config = _config
         self.circuit_breaker = circuit_breaker
         self.retry_config = retry_config

--- a/lionagi/service/connections/endpoint_config.py
+++ b/lionagi/service/connections/endpoint_config.py
@@ -22,6 +22,8 @@ logger = logging.getLogger(__name__)
 
 B = TypeVar("B", bound=type[BaseModel])
 
+__all__ = ("EndpointConfig",)
+
 
 class EndpointConfig(BaseModel):
     name: str

--- a/lionagi/service/connections/header_factory.py
+++ b/lionagi/service/connections/header_factory.py
@@ -8,6 +8,9 @@ from pydantic import SecretStr
 AUTH_TYPES = Literal["bearer", "x-api-key", "none"]
 
 
+__all__ = ("HeaderFactory",)
+
+
 class HeaderFactory:
     @staticmethod
     def get_content_type_header(

--- a/lionagi/service/connections/provider_config.py
+++ b/lionagi/service/connections/provider_config.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Mixin for per-provider config enums.
+
+Tuple format (positional by index)::
+
+    MEMBER = (endpoint, aliases, type, options, base_url, auth_type, content_type)
+    # idx:     0        1        2      3        4         5          6
+
+    # Short form (agentic — no HTTP config needed):
+    GROUP_CHAT = ("group_chat", ["chat"], EndpointType.AGENTIC, LazyType("...:Request"))
+
+    # Full form (API — HTTP config included):
+    CHAT = ("chat/completions", ["chat"], EndpointType.API, LazyType("...:Request"),
+            "https://api.openai.com/v1", "bearer", "application/json")
+
+Usage::
+
+    class OpenAIConfigs(ProviderConfig, Enum):
+        _ignore_ = ["_PROVIDER", "_PROVIDER_ALIASES"]
+        _PROVIDER = "openai"
+        _PROVIDER_ALIASES = []
+
+        CHAT = ("chat/completions", ["chat"], EndpointType.API,
+                LazyType("lionagi.providers.openai.chat.models:OpenAIChatCompletionsRequest"),
+                "https://api.openai.com/v1", "bearer")
+
+    @OpenAIConfigs.CHAT.register
+    class OpenaiChatEndpoint(Endpoint): ...
+    # config auto-created — no _get_config() needed
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+from pydantic import BaseModel
+
+from .registry import EndpointType, register_endpoint
+
+
+class LazyType:
+    """Deferred type import. Resolves on first access.
+
+    Usage in config enum::
+
+        CHAT = (..., LazyType("lionagi.providers.openai.chat.models:OpenAIChatCompletionsRequest"))
+
+    Hashable (required for Enum member tuples).
+    """
+
+    __slots__ = ("_ref", "_resolved")
+
+    def __init__(self, ref: str) -> None:
+        if ":" not in ref:
+            raise ValueError(f"LazyType ref must be 'module:Class', got {ref!r}")
+        self._ref = ref
+        self._resolved: type | None = None
+
+    def resolve(self) -> type[BaseModel]:
+        if self._resolved is None:
+            module_path, class_name = self._ref.rsplit(":", 1)
+            mod = importlib.import_module(module_path)
+            self._resolved = getattr(mod, class_name)
+        return self._resolved
+
+    def __hash__(self) -> int:
+        return hash(self._ref)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, LazyType):
+            return self._ref == other._ref
+        return NotImplemented
+
+    def __repr__(self) -> str:
+        status = "resolved" if self._resolved is not None else "pending"
+        return f"LazyType({self._ref!r}, {status})"
+
+
+def _get(value: tuple, idx: int, default=None):
+    return value[idx] if len(value) > idx else default
+
+
+class ProviderConfig:
+    """Mixin for provider endpoint Enum classes.
+
+    Concrete classes extend ``(ProviderConfig, Enum)`` and declare
+    members as tuples with 4-7 elements (see module docstring).
+    """
+
+    # --- Tuple accessors ---
+
+    @property
+    def endpoint_path(self) -> str:
+        return self.value[0]
+
+    @property
+    def aliases(self) -> list[str]:
+        return self.value[1]
+
+    @property
+    def endpoint_type(self) -> EndpointType:
+        return self.value[2]
+
+    @property
+    def options(self) -> type[BaseModel] | None:
+        raw = _get(self.value, 3)
+        if isinstance(raw, LazyType):
+            return raw.resolve()
+        return raw
+
+    @property
+    def base_url(self) -> str | None:
+        return _get(self.value, 4)
+
+    @property
+    def auth_type(self) -> str | None:
+        return _get(self.value, 5)
+
+    @property
+    def content_type(self) -> str | None:
+        return _get(self.value, 6, "application/json")
+
+    # --- Provider info (set via _ignore_ or post-definition) ---
+
+    @property
+    def provider(self) -> str:
+        return type(self)._PROVIDER
+
+    @property
+    def provider_aliases(self) -> list[str]:
+        return type(self)._PROVIDER_ALIASES
+
+    # --- Registry integration ---
+
+    def as_registry_kwargs(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "provider_aliases": self.provider_aliases,
+            "endpoint": self.endpoint_path,
+            "aliases": self.aliases,
+            "endpoint_type": self.endpoint_type,
+            "options": self.options,
+            "base_url": self.base_url,
+            "auth_type": self.auth_type,
+            "content_type": self.content_type,
+        }
+
+    def register(self, cls=None):
+        """Decorator: register an endpoint class for this config member.
+
+        Usage::
+
+            @OpenAIConfigs.CHAT.register
+            class OpenaiChatEndpoint(Endpoint): ...
+        """
+        decorator = register_endpoint(**self.as_registry_kwargs())
+        if cls is not None:
+            return decorator(cls)
+        return decorator
+
+    @classmethod
+    def available(cls) -> frozenset[str]:
+        return frozenset(m.endpoint_path for m in cls)

--- a/lionagi/service/connections/registry.py
+++ b/lionagi/service/connections/registry.py
@@ -1,0 +1,201 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, ClassVar
+
+from pydantic import BaseModel
+
+from lionagi.ln.types import Enum
+
+__all__ = (
+    "EndpointType",
+    "EndpointMeta",
+    "EndpointRegistry",
+    "register_endpoint",
+)
+
+
+class EndpointType(Enum):
+    API = "api"
+    AGENTIC = "agentic"
+
+
+@dataclass(frozen=True, slots=True)
+class EndpointMeta:
+    """Injected onto endpoint classes as ``_ENDPOINT_META``.
+
+    Carries enough info to auto-generate ``EndpointConfig`` —
+    individual endpoints no longer need ``_get_config()``.
+    """
+
+    provider: str
+    endpoint: str
+    endpoint_type: EndpointType
+    aliases: tuple[str, ...] = ()
+    provider_aliases: tuple[str, ...] = ()
+    options: type[BaseModel] | None = None
+    base_url: str | None = None
+    auth_type: str | None = None
+    content_type: str | None = None
+
+    def create_config(self, **overrides: Any):
+        from .endpoint_config import EndpointConfig
+
+        is_agentic = self.endpoint_type == EndpointType.AGENTIC
+        defaults = dict(
+            name=f"{self.provider}_{self.endpoint}",
+            provider=self.provider,
+            base_url=self.base_url or ("internal" if is_agentic else ""),
+            endpoint=self.endpoint,
+            api_key="internal" if is_agentic else None,
+            request_options=self.options,
+            timeout=3600 if is_agentic else 600,
+            auth_type=self.auth_type or ("bearer" if not is_agentic else "bearer"),
+            content_type=self.content_type or "application/json",
+            method="POST",
+        )
+        defaults.update(overrides)
+        return EndpointConfig(**defaults)
+
+
+class _RegistryEntry:
+    __slots__ = ("meta", "cls")
+
+    def __init__(self, meta: EndpointMeta, cls: type):
+        self.meta = meta
+        self.cls = cls
+
+
+class EndpointRegistry:
+    _entries: ClassVar[list[_RegistryEntry]] = []
+    _loaded: ClassVar[bool] = False
+
+    @classmethod
+    def register(
+        cls,
+        provider: str,
+        endpoint: str,
+        aliases: list[str] | None = None,
+        endpoint_type: EndpointType = EndpointType.API,
+        provider_aliases: list[str] | None = None,
+        options: type[BaseModel] | None = None,
+        base_url: str | None = None,
+        auth_type: str | None = None,
+        content_type: str | None = None,
+    ):
+        """Decorator that registers an endpoint and injects _ENDPOINT_META."""
+
+        def decorator(endpoint_cls: type) -> type:
+            meta = EndpointMeta(
+                provider=provider,
+                endpoint=endpoint,
+                endpoint_type=endpoint_type,
+                aliases=tuple(aliases or ()),
+                provider_aliases=tuple(provider_aliases or ()),
+                options=options,
+                base_url=base_url,
+                auth_type=auth_type,
+                content_type=content_type,
+            )
+            endpoint_cls._ENDPOINT_META = meta
+            cls._entries.append(_RegistryEntry(meta=meta, cls=endpoint_cls))
+            return endpoint_cls
+
+        return decorator
+
+    @classmethod
+    def match(cls, provider: str, endpoint: str = "", **kwargs) -> Any:
+        """Find and instantiate the best matching endpoint."""
+        cls._ensure_loaded()
+
+        first_for_provider = None
+        for entry in cls._entries:
+            m = entry.meta
+            if not (provider == m.provider or provider in m.provider_aliases):
+                continue
+            if first_for_provider is None:
+                first_for_provider = entry
+            if not endpoint or endpoint == m.endpoint or endpoint in m.aliases:
+                return entry.cls(None, **kwargs)
+
+        if first_for_provider is not None:
+            return first_for_provider.cls(None, **kwargs)
+
+        from .endpoint import Endpoint, EndpointConfig
+
+        config = EndpointConfig(
+            provider=provider,
+            endpoint=endpoint or "chat/completions",
+            name="openai_compatible_chat",
+            auth_type="bearer",
+            content_type="application/json",
+            method="POST",
+            requires_tokens=True,
+        )
+        return Endpoint(config, **kwargs)
+
+    @classmethod
+    def _ensure_loaded(cls):
+        if cls._loaded:
+            return
+        cls._loaded = True
+        _import_all_providers()
+
+    @classmethod
+    def list_providers(cls) -> list[dict[str, Any]]:
+        cls._ensure_loaded()
+        return [
+            {
+                "provider": e.meta.provider,
+                "endpoint": e.meta.endpoint,
+                "aliases": list(e.meta.aliases),
+                "type": e.meta.endpoint_type.value,
+                "class": e.cls.__name__,
+                "options": e.meta.options.__name__ if e.meta.options else None,
+            }
+            for e in cls._entries
+        ]
+
+
+def register_endpoint(
+    provider: str,
+    endpoint: str,
+    aliases: list[str] | None = None,
+    endpoint_type: EndpointType = EndpointType.API,
+    provider_aliases: list[str] | None = None,
+    options: type[BaseModel] | None = None,
+    base_url: str | None = None,
+    auth_type: str | None = None,
+    content_type: str | None = None,
+):
+    """Decorator that registers an endpoint and injects ``_ENDPOINT_META``."""
+    return EndpointRegistry.register(
+        provider=provider,
+        endpoint=endpoint,
+        aliases=aliases,
+        endpoint_type=endpoint_type,
+        provider_aliases=provider_aliases,
+        options=options,
+        base_url=base_url,
+        auth_type=auth_type,
+        content_type=content_type,
+    )
+
+
+def _import_all_providers():
+    """Import all provider modules to trigger registration decorators.
+
+    Populated by the provider reorganization PR — initially empty since
+    existing providers still use the legacy match_endpoint() router.
+    """
+    import importlib
+
+    _modules: list[str] = []
+    for mod in _modules:
+        try:
+            importlib.import_module(mod)
+        except ImportError:
+            pass

--- a/tests/service/connections/test_endpoint.py
+++ b/tests/service/connections/test_endpoint.py
@@ -60,7 +60,7 @@ class TestEndpoint:
 
     def test_endpoint_initialization_invalid_config_type(self):
         """Test endpoint initialization with invalid config type raises ValueError (line 47)."""
-        with pytest.raises(ValueError, match="Config must be a dict or EndpointConfig"):
+        with pytest.raises(ValueError, match="Config must be a dict, EndpointConfig, or None"):
             Endpoint(config="invalid_config_type")
 
     def test_request_options_setter(self, openai_config):


### PR DESCRIPTION
## Summary

- **EndpointRegistry** (`registry.py`): Decorator-based provider discovery with `@register`, lazy loading, provider-first fallback matching
- **ProviderConfig** (`provider_config.py`): Enum mixin for declaring endpoints as enum members with `LazyType` for deferred model imports
- **AgenticEndpoint** (`agentic_endpoint.py`): Base class for CLI/in-process endpoints (Claude Code, Codex, AG2) — low concurrency, session management, no HTTP

## Design

```python
# Provider declares endpoints as enum members
class OpenAIConfigs(ProviderConfig, Enum):
    CHAT = ("chat/completions", ["chat"], EndpointType.API,
            LazyType("...models:Request"), "https://api.openai.com/v1", "bearer")

# Endpoint registers with one decorator
@OpenAIConfigs.CHAT.register
class OpenaiChatEndpoint(Endpoint):
    ...

# Resolution: EndpointRegistry.match("openai", "chat") → OpenaiChatEndpoint
```

Existing `match_endpoint()` routing is **unchanged** — providers will migrate to `@register` in a follow-up PR. `_import_all_providers()` is intentionally empty.

10 files, +464 lines. 5796 tests pass, 0 failures.

## Test plan

- [x] Existing test suite passes (5796/5796)
- [x] Old match_endpoint() still works (no behavioral change)
- [ ] Registry unit tests (will be added with provider migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)