### PR TITLE
fix(docs): markdown lint errors

### DIFF
--- a/docs/api/imodel.md
+++ b/docs/api/imodel.md
@@ -102,13 +102,14 @@ endpoint. Pass `base_url=` to point at your custom host.
 
 ## Endpoint matching
 
-```
+```text
 iModel(provider="openai", endpoint="chat")
   → match_endpoint("openai", "chat")
   → OpenaiChatEndpoint
 ```
 
 `match_endpoint()` dispatches on `(provider, endpoint)` string containment:
+
 - Default `endpoint="chat"` resolves to the provider's chat class.
 - Single-endpoint providers (`claude_code`, `codex`, `gemini_code`, `pi`) ignore
   the `endpoint` argument and always return their only class.

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -120,7 +120,7 @@ async for chunk in endpoint.stream({"prompt": "Build a Fibonacci function"}):
 Each provider is a directory under `lionagi/providers/{company}/`. The subdirectories are
 capabilities — the directory listing is the capability map.
 
-```
+```text
 lionagi/providers/
 ├── openai/
 │   ├── _config.py          # OpenAIConfigs + CodexConfigs enums
@@ -192,7 +192,7 @@ type, options class, base URL, and auth type.
 
 **Step 1 — create the folder tree**
 
-```
+```text
 lionagi/providers/{name}/
     _config.py
     {endpoint_type}/


### PR DESCRIPTION
## Summary

- Add `text` language tag to 3 fenced code blocks (MD040)
- Add blank line before list in imodel.md (MD032)

## Test plan

- [x] `markdownlint-cli2` passes on all affected files

🤖 Generated with [Claude Code](https://claude.com/claude-code)