### PR TITLE
feat: add support for code executor in AG2GroupChatEndpoint

### DIFF
--- a/lionagi/providers/ag2/groupchat/endpoint.py
+++ b/lionagi/providers/ag2/groupchat/endpoint.py
@@ -85,6 +85,7 @@ class AG2GroupChatEndpoint(AgenticEndpoint):
         agent_configs = kwargs.get("agent_configs", self._agent_configs)
         llm_config = kwargs.get("llm_config", self._llm_config)
         tool_registry = kwargs.get("tool_registry", self._tool_registry)
+        code_executor = kwargs.get("code_executor")
 
         spec = GroupChatSpec(
             name="endpoint_chat",
@@ -108,9 +109,7 @@ class AG2GroupChatEndpoint(AgenticEndpoint):
         )
 
         user, pattern, agents_by_name = build_group_chat(
-            spec,
-            llm_config,
-            tool_registry,
+            spec, llm_config, tool_registry, code_executor
         )
 
         yield StreamChunk(
@@ -170,7 +169,9 @@ def _event_to_chunk(event) -> StreamChunk | None:
             metadata={"agent": sender},
         )
     if isinstance(event, GroupChatRunChatEvent):
-        speaker = getattr(inner, "speaker", "unknown") if inner is not None else "unknown"
+        speaker = (
+            getattr(inner, "speaker", "unknown") if inner is not None else "unknown"
+        )
         return StreamChunk(
             type="system",
             content=f"Speaker: {speaker}",

--- a/lionagi/providers/ag2/groupchat/models.py
+++ b/lionagi/providers/ag2/groupchat/models.py
@@ -87,13 +87,6 @@ class GroupChatSpec(BaseModel):
         default_factory=dict,
         description="Initial context variables shared across agents",
     )
-    sandbox: bool = Field(
-        default=False,
-        description=(
-            "Reserved for future Daytona sandbox integration. "
-            "Not yet implemented — has no effect on execution."
-        ),
-    )
 
 
 class ResearchPlan(BaseModel):
@@ -147,6 +140,7 @@ def build_group_chat(
     spec: GroupChatSpec,
     llm_config: Any,
     tool_registry: dict[str, Callable] | None = None,
+    code_executor: Any | None = None,
 ):
     """Build AG2 agents and DefaultPattern from a GroupChatSpec.
 
@@ -164,12 +158,15 @@ def build_group_chat(
     from autogen.agentchat.group.patterns import DefaultPattern
 
     tool_registry = tool_registry or {}
+    user_configs = {
+        "name": "User",
+        "human_input_mode": "NEVER",
+        "llm_config": False,
+    }
+    if code_executor:
+        user_configs["code_execution_config"] = {"executor": code_executor}
 
-    user = ConversableAgent(
-        name="User",
-        human_input_mode="NEVER",
-        llm_config=False,
-    )
+    user = ConversableAgent(**user_configs)
 
     agents_by_name: dict[str, ConversableAgent] = {}
     ordered: list[ConversableAgent] = []


### PR DESCRIPTION
This pull request updates the group chat endpoint and agent construction logic to support passing in a code executor, and removes an unused sandbox field from the group chat specification. The main focus is on enabling code execution capabilities for agents within group chats.

**Code execution support:**

* Added a `code_executor` parameter to the `stream` method in `endpoint.py`, and passed it through to `build_group_chat`, allowing group chat agents to be initialized with code execution capabilities if provided. [[1]](diffhunk://#diff-1a299d17e1a6545b301719452af4ab360c60391518097cf4db32a4189716e207R88) [[2]](diffhunk://#diff-1a299d17e1a6545b301719452af4ab360c60391518097cf4db32a4189716e207L111-R112) [[3]](diffhunk://#diff-521e9675ed14371f8c1b65d0c076b6f5a2fcdbc3b2884c91eaa56a26b200170bR143)
* Updated the construction of the `user` agent in `build_group_chat` to include `code_execution_config` when a code executor is supplied, enabling code execution for the user agent.

**Cleanup:**

* Removed the unused `sandbox` field from the `GroupChatSpec` model, as it was reserved for future use but not implemented.

**Minor refactoring:**

* Refactored variable assignment for the `speaker` in `_event_to_chunk` for improved readability.