### PR TITLE
Fix/wire in formatter

### DIFF
--- a/lionagi/operations/communicate/communicate.py
+++ b/lionagi/operations/communicate/communicate.py
@@ -110,6 +110,7 @@ def prepare_communicate_kw(
             ),
             imodel=parse_model,
             imodel_kw={},
+            formatter=chat_param.formatter,
         )
 
     return {

--- a/lionagi/operations/operate/operate.py
+++ b/lionagi/operations/operate/operate.py
@@ -192,6 +192,7 @@ def prepare_operate_kw(
             alcall_params=get_default_call(),
             imodel=parse_model,
             imodel_kw={},
+            formatter=chat_param.formatter,
         )
 
     action_param = None
@@ -262,6 +263,7 @@ async def operate(
             response_format=chat_param.response_format,
             imodel=branch.parse_model,
             handle_validation="return_value",
+            formatter=chat_param.formatter,
         )
     )
 

--- a/lionagi/operations/parse/parse.py
+++ b/lionagi/operations/parse/parse.py
@@ -1,25 +1,22 @@
 # Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import contextlib
 import warnings
 from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel
 
-from lionagi.ln import (
-    AlcallParams,
-    extract_json,
-    fuzzy_validate_mapping,
-    get_cancelled_exc_class,
-    to_list,
-)
+from lionagi.ln import AlcallParams, get_cancelled_exc_class
 from lionagi.ln.fuzzy import FuzzyMatchKeysParams
 from lionagi.protocols.types import AssistantResponse
 
 from ..types import HandleValidation, ParseParam
 
 if TYPE_CHECKING:
+    from lionagi.protocols.messages._helpers import Formatter
     from lionagi.session.branch import Branch
 
 
@@ -27,7 +24,7 @@ _CALL = None  # type: ignore
 
 
 def prepare_parse_kws(
-    branch: "Branch",
+    branch: Branch,
     text: str,
     handle_validation: HandleValidation = "return_value",
     max_retries: int = 3,
@@ -44,6 +41,7 @@ def prepare_parse_kws(
     response_format=None,
     request_fields=None,
     return_res_message: bool = False,
+    formatter: Formatter | None = None,
     **kw,
 ):
     if suppress_conversion_errors:
@@ -79,13 +77,14 @@ def prepare_parse_kws(
             alcall_params=_alcall_params.with_updates(retry_attempts=max_retries),
             imodel=branch.parse_model,
             imodel_kw=kw,
+            formatter=formatter,
         ),
         "return_res_message": return_res_message,
     }
 
 
 async def parse(
-    branch: "Branch",
+    branch: Branch,
     text: str,
     parse_param: ParseParam,
     return_res_message: bool = False,
@@ -93,7 +92,10 @@ async def parse(
     # Try direct validation first
     with contextlib.suppress(Exception):
         result = _validate_dict_or_model(
-            text, parse_param.response_format, parse_param.fuzzy_match_params
+            text,
+            parse_param.response_format,
+            parse_param.fuzzy_match_params,
+            formatter=parse_param.formatter,
         )
         return result if not return_res_message else (result, None)
 
@@ -126,6 +128,7 @@ async def parse(
                 res.response,
                 parse_param.response_format,
                 parse_param.fuzzy_match_params,
+                formatter=parse_param.formatter,
             ),
             res,
         )
@@ -152,39 +155,22 @@ async def parse(
 def _validate_dict_or_model(
     text: str,
     response_format: type[BaseModel] | dict,
-    fuzzy_match_params: FuzzyMatchKeysParams | dict = None,
+    fuzzy_match_params: FuzzyMatchKeysParams | dict | None = None,
+    formatter=None,
 ):
     try:
         if isinstance(fuzzy_match_params, dict):
             fuzzy_match_params = FuzzyMatchKeysParams(**fuzzy_match_params)
 
-        d_ = extract_json(text, fuzzy_parse=True, return_one_if_single=False)
-        dict_, keys_ = None, None
-        if d_:
-            dict_ = to_list(d_, flatten=True)[0]
-        if isinstance(fuzzy_match_params, FuzzyMatchKeysParams):
-            keys_ = (
-                response_format.model_fields
-                if isinstance(response_format, type)
-                else response_format
-            )
-            dict_ = fuzzy_validate_mapping(dict_, keys_, **fuzzy_match_params.to_dict())
-        elif fuzzy_match_params:
-            keys_ = (
-                response_format.model_fields
-                if isinstance(response_format, type)
-                else response_format
-            )
-            dict_ = fuzzy_validate_mapping(
-                dict_,
-                keys_,
-                handle_unmatched="force",
-                fill_value=None,
-                strict=False,
-            )
-        if isinstance(response_format, type) and issubclass(response_format, BaseModel):
-            return response_format.model_validate(dict_)
-        return dict_
+        from lionagi.ln.types import is_sentinel
+        from lionagi.protocols.messages._helpers import JsonFormatter
+
+        if is_sentinel(formatter, none_as_sentinel=True):
+            formatter = JsonFormatter
+
+        return formatter.parse(
+            text, response_format, fuzzy_match_params=fuzzy_match_params
+        )
 
     except Exception as e:
         raise ValueError(f"Failed to parse text: {e}") from e

--- a/lionagi/operations/types.py
+++ b/lionagi/operations/types.py
@@ -49,11 +49,13 @@ class ChatParam(MorphParam):
     """
 
     _config: ClassVar[ModelConfig] = ModelConfig(none_as_sentinel=True)
+
     guidance: JsonValue = None
     context: JsonValue = None
     sender: SenderRecipient = None
     recipient: SenderRecipient = None
     response_format: type[BaseModel] | dict = None
+    formatter: Any = None
     progression: ID.RefSeq = None
     tool_schemas: list[dict] = None
     images: list = None
@@ -101,6 +103,7 @@ class ParseParam(MorphParam):
     alcall_params: AlcallParams | dict = None
     imodel: iModel = None
     imodel_kw: dict = None
+    formatter: Any = None
 
 
 @dataclass(slots=True, frozen=True, init=False)

--- a/lionagi/protocols/messages/__init__.py
+++ b/lionagi/protocols/messages/__init__.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
+from ._helpers import Formatter, JsonFormatter
 from .action_request import ActionRequest, ActionRequestContent
 from .action_response import ActionResponse, ActionResponseContent
 from .assistant_response import AssistantResponse, AssistantResponseContent
@@ -28,4 +29,6 @@ __all__ = (
     "SenderRecipient",
     "System",
     "SystemContent",
+    "Formatter",
+    "JsonFormatter",
 )

--- a/lionagi/protocols/messages/_helpers.py
+++ b/lionagi/protocols/messages/_helpers.py
@@ -324,7 +324,7 @@ def _tool_schemas_display(tool_schemas: list[dict[str, Any]]) -> str | None:
 
 
 # ---------------------------------------------------------------------------
-# Formatter protocol + JsonTransformer
+# Formatter protocol + JsonFormatter
 # ---------------------------------------------------------------------------
 
 
@@ -345,7 +345,7 @@ class Formatter(Protocol):
     def parse(text: str, format: ResponseFormat, **kw) -> Any: ...
 
 
-class JsonTransformer:
+class JsonFormatter:
 
     @staticmethod
     def render_schema(format: ResponseFormat) -> str | None:
@@ -365,11 +365,14 @@ class JsonTransformer:
         response_format: ResponseFormat,
         fuzzy_match_params: FuzzyMatchKeysParams | dict | None = None,
     ) -> Any:
+        from lionagi.ln import to_list
+
         d_ = extract_json(text, fuzzy_parse=True, return_one_if_single=False)
         if not d_:
             raise ValueError("Failed to extract JSON from text")
 
-        d_ = to_dict(d_[0], recursive=True)
+        d_ = to_list(d_, flatten=True)[0]
+        d_ = to_dict(d_, recursive=True)
 
         if isinstance(fuzzy_match_params, dict):
             fuzzy_match_params = FuzzyMatchKeysParams(**fuzzy_match_params)
@@ -395,7 +398,8 @@ class JsonTransformer:
             d = fuzzy_validate_mapping(
                 d_, response_format, **fuzzy_match_params.to_dict()
             )
-            for k, v in response_format.items():
-                d[k] = _parse_one(d[k], v)
+            for k in list(d.keys()):
+                if k in response_format:
+                    d[k] = _parse_one(d[k], response_format[k])
             return d
         return _parse_one(d_, response_format)

--- a/lionagi/protocols/messages/instruction.py
+++ b/lionagi/protocols/messages/instruction.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, field_validator
 
 from lionagi.ln.types import ModelConfig
 
-from ._helpers import Formatter, JsonTransformer
+from ._helpers import Formatter, JsonFormatter
 from .message import Message, MessageContent, MessageRole
 
 
@@ -20,14 +20,14 @@ class InstructionContent(MessageContent):
         plain_content: Raw text fallback (bypasses structured rendering)
         tool_schemas: Tool specifications for the assistant
         response_format: User's desired response format (BaseModel class, instance, or dict)
-        prompt_transformer: Renderer/parser for the response format (default: JsonTransformer)
+        formatter: Renderer/parser for the response format (default: JsonFormatter)
         images: Image URLs, data URLs, or base64 strings
         image_detail: Detail level for image processing
     """
 
     _config: ClassVar[ModelConfig] = ModelConfig(
         none_as_sentinel=True,
-        serialize_exclude=frozenset({"response_format", "prompt_transformer"}),
+        serialize_exclude=frozenset({"response_format", "formatter"}),
     )
 
     instruction: str | None = None
@@ -36,7 +36,7 @@ class InstructionContent(MessageContent):
     plain_content: str | None = None
     tool_schemas: list[dict[str, Any]] = field(default_factory=list)
     response_format: type[BaseModel] | dict[str, Any] | BaseModel | None = None
-    prompt_transformer: type[Formatter] = field(default=JsonTransformer, repr=False)
+    formatter: type[Formatter] = field(default=None, repr=False)
     images: list[str] = field(default_factory=list)
     image_detail: Literal["low", "high", "auto"] | None = None
 
@@ -49,34 +49,31 @@ class InstructionContent(MessageContent):
         plain_content: str | None = None,
         tool_schemas: list[dict[str, Any]] | None = None,
         response_format: type[BaseModel] | dict[str, Any] | BaseModel | None = None,
-        prompt_transformer: type[Formatter] | None = None,
+        formatter: type[Formatter] | None = None,
         images: list[str] | None = None,
         image_detail: Literal["low", "high", "auto"] | None = None,
     ):
         if context is not None and prompt_context is None:
             prompt_context = context
 
-        object.__setattr__(self, "instruction", instruction)
-        object.__setattr__(self, "guidance", guidance)
-        object.__setattr__(
-            self,
-            "prompt_context",
-            prompt_context if prompt_context is not None else [],
-        )
-        object.__setattr__(self, "plain_content", plain_content)
-        object.__setattr__(
-            self,
-            "tool_schemas",
-            tool_schemas if tool_schemas is not None else [],
-        )
-        object.__setattr__(self, "response_format", response_format)
-        object.__setattr__(
-            self,
-            "prompt_transformer",
-            prompt_transformer or JsonTransformer,
-        )
-        object.__setattr__(self, "images", images if images is not None else [])
-        object.__setattr__(self, "image_detail", image_detail)
+        if response_format is not None and formatter is None:
+            formatter = JsonFormatter
+
+        data = {
+            "instruction": instruction,
+            "guidance": guidance,
+            "prompt_context": prompt_context if prompt_context is not None else [],
+            "plain_content": plain_content,
+            "tool_schemas": tool_schemas if tool_schemas is not None else [],
+            "response_format": response_format,
+            "formatter": formatter,
+            "images": images if images is not None else [],
+            "image_detail": image_detail,
+            "formatter": formatter,
+        }
+
+        for key, value in data.items():
+            object.__setattr__(self, key, value)
 
     @property
     def context(self) -> list[Any]:
@@ -116,7 +113,7 @@ class InstructionContent(MessageContent):
 
     @property
     def schema_dict(self) -> dict[str, Any] | None:
-        """DEPRECATED: Will be removed in v1.0. Use prompt_transformer.render() instead."""
+        """DEPRECATED: Will be removed in v1.0. Use formatter.render() instead."""
         import warnings
 
         from lionagi.libs.schema.breakdown_pydantic_annotation import (
@@ -125,7 +122,7 @@ class InstructionContent(MessageContent):
 
         warnings.warn(
             "InstructionContent.schema_dict is deprecated and will be removed in v1.0. "
-            "Use prompt_transformer.render(response_format) instead.",
+            "Use formatter.render(response_format) instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -197,8 +194,10 @@ class InstructionContent(MessageContent):
             if valid:
                 inst.response_format = response_format
 
-        if pt := data.get("prompt_transformer"):
-            inst.prompt_transformer = pt
+        if pt := data.get("formatter"):
+            inst.formatter = pt
+        elif inst.response_format is not None and inst.formatter is None:
+            inst.formatter = JsonFormatter
 
         return inst
 
@@ -209,7 +208,7 @@ class InstructionContent(MessageContent):
             return self.plain_content
 
         parts: list[str] = []
-        tf = self.prompt_transformer
+        tf = self.formatter
 
         if self.guidance:
             parts.append(f"## Guidance\n{self.guidance}")
@@ -222,11 +221,15 @@ class InstructionContent(MessageContent):
             parts.append(f"## Context\n{ctx_yaml}")
 
         if self.tool_schemas:
-            tools_display = tf.render_tools(self.tool_schemas)
-            if tools_display:
-                parts.append(f"## Tools\n{tools_display}")
+            from ._helpers import _tool_schemas_display
+
+            if all(isinstance(t, str) for t in self.tool_schemas):
+                parts.append(f"## Tools\n" + "\n".join(self.tool_schemas))
             else:
-                parts.append(f"## Tools\n{minimal_yaml(self.tool_schemas).strip()}")
+                tools_display = _tool_schemas_display(self.tool_schemas)
+                parts.append(
+                    f"## Tools\n{tools_display or minimal_yaml(self.tool_schemas).strip()}"
+                )
 
         if not self._is_sentinel(self.response_format):
             schema = tf.render_schema(self.response_format)

--- a/lionagi/protocols/messages/manager.py
+++ b/lionagi/protocols/messages/manager.py
@@ -96,6 +96,7 @@ class MessageManager(Manager):
         request_model: BaseModel | type[BaseModel] = None,
         response_format: BaseModel | type[BaseModel] = None,
         tool_schemas: dict = None,
+        formatter=None,
         sender: SenderRecipient = None,
         recipient: SenderRecipient = None,
     ) -> Instruction:

--- a/tests/protocols/messages/test_utils.py
+++ b/tests/protocols/messages/test_utils.py
@@ -45,11 +45,11 @@ def test_systemcontent_from_dict_datetime_handling():
 
 
 def test_instructioncontent_format_response_format():
-    """Test JsonTransformer.render_format produces expected output"""
-    from lionagi.protocols.messages._helpers import JsonTransformer
+    """Test JsonFormatter.render_format produces expected output"""
+    from lionagi.protocols.messages._helpers import JsonFormatter
 
     response_format = {"name": "string", "age": "integer"}
-    result = JsonTransformer.render_format(response_format)
+    result = JsonFormatter.render_format(response_format)
 
     assert "JSON-PARSEABLE RESPONSE" in result
     assert "```json" in result


### PR DESCRIPTION
This pull request introduces a more flexible and unified approach to formatting and parsing structured data throughout the codebase by replacing the previous `JsonTransformer` with a new `JsonFormatter` class and adopting a generic `formatter` parameter. This change affects how response formats are rendered and parsed, and standardizes the use of formatters across message types, operation parameters, and parsing logic. Additionally, several code paths and type annotations have been updated to support this new approach, and relevant tests have been adjusted accordingly.

**Formatter and Parsing Refactor**

- Replaced all usages of `JsonTransformer` with `JsonFormatter` and updated related imports, class names, and docstrings to reflect this new unified formatter. [[1]](diffhunk://#diff-94ae3af6da25676fd0a3d0ab86d3caf58166c431823b5fd5919e66986d1b33e2L327-R327) [[2]](diffhunk://#diff-f797cf640c45d1dfdcc768e28b7202f033b12e49d4901b9b737dd7203de787b1L8-R8) [[3]](diffhunk://#diff-f797cf640c45d1dfdcc768e28b7202f033b12e49d4901b9b737dd7203de787b1L23-R30) [[4]](diffhunk://#diff-5c86fbe5c7d8feb451227728869251de400a1dfd3b54ac32e1230556b94a0192L48-R52)
- Introduced a generic `formatter` parameter (defaulting to `JsonFormatter` when a response format is present) in `InstructionContent`, `ChatParam`, and `ParseParam`, and ensured it is passed through operation and parsing functions (`prepare_parse_kws`, `prepare_communicate_kw`, `prepare_operate_kw`, and `operate`). [[1]](diffhunk://#diff-9e95291623329b495f3518dfac57b82547e904ab8d897fc8e8179ed8231d59d6R52-R58) [[2]](diffhunk://#diff-9e95291623329b495f3518dfac57b82547e904ab8d897fc8e8179ed8231d59d6R106) [[3]](diffhunk://#diff-916a93229a35fc16ad2bc1c0d362361a1003f39188337354ff51348a90fd85ebR44) [[4]](diffhunk://#diff-916a93229a35fc16ad2bc1c0d362361a1003f39188337354ff51348a90fd85ebR80-R98) [[5]](diffhunk://#diff-6a593d82f06cacb254735fe290a99946df3a693672817148ade24905f7147569R113) [[6]](diffhunk://#diff-ba1499287619e4bad3bdd49c323de8767b1730827bd5c113de5cce291aa01decR195) [[7]](diffhunk://#diff-ba1499287619e4bad3bdd49c323de8767b1730827bd5c113de5cce291aa01decR266) [[8]](diffhunk://#diff-9edbbdd42f233b93fec09d9043e0b9d0a82097aba6cfc21b5e5d30855116f908R99) [[9]](diffhunk://#diff-f797cf640c45d1dfdcc768e28b7202f033b12e49d4901b9b737dd7203de787b1L39-R39) [[10]](diffhunk://#diff-f797cf640c45d1dfdcc768e28b7202f033b12e49d4901b9b737dd7203de787b1L52-R76) [[11]](diffhunk://#diff-f797cf640c45d1dfdcc768e28b7202f033b12e49d4901b9b737dd7203de787b1L200-R200)
- Updated the parsing logic to delegate parsing to the formatter's `parse()` method, allowing for future extensibility and cleaner code separation. [[1]](diffhunk://#diff-916a93229a35fc16ad2bc1c0d362361a1003f39188337354ff51348a90fd85ebL155-L187) [[2]](diffhunk://#diff-916a93229a35fc16ad2bc1c0d362361a1003f39188337354ff51348a90fd85ebR4-R27) [[3]](diffhunk://#diff-916a93229a35fc16ad2bc1c0d362361a1003f39188337354ff51348a90fd85ebR131) [[4]](diffhunk://#diff-94ae3af6da25676fd0a3d0ab86d3caf58166c431823b5fd5919e66986d1b33e2R368-R375) [[5]](diffhunk://#diff-94ae3af6da25676fd0a3d0ab86d3caf58166c431823b5fd5919e66986d1b33e2L398-R403)

**InstructionContent and Serialization Updates**

- Changed all references from `prompt_transformer` to `formatter` in `InstructionContent`, including serialization, initialization, and property methods. Updated deprecation warnings and serialization exclusion accordingly. [[1]](diffhunk://#diff-f797cf640c45d1dfdcc768e28b7202f033b12e49d4901b9b737dd7203de787b1L23-R30) [[2]](diffhunk://#diff-f797cf640c45d1dfdcc768e28b7202f033b12e49d4901b9b737dd7203de787b1L39-R39) [[3]](diffhunk://#diff-f797cf640c45d1dfdcc768e28b7202f033b12e49d4901b9b737dd7203de787b1L52-R76) [[4]](diffhunk://#diff-f797cf640c45d1dfdcc768e28b7202f033b12e49d4901b9b737dd7203de787b1L119-R116) [[5]](diffhunk://#diff-f797cf640c45d1dfdcc768e28b7202f033b12e49d4901b9b737dd7203de787b1L128-R125) [[6]](diffhunk://#diff-f797cf640c45d1dfdcc768e28b7202f033b12e49d4901b9b737dd7203de787b1L200-R200) [[7]](diffhunk://#diff-f797cf640c45d1dfdcc768e28b7202f033b12e49d4901b9b737dd7203de787b1L212-R211)
- Improved the `_format_text_content` method to handle tool schemas more robustly and use the new formatter infrastructure.

**Protocol and Import Clean-Up**

- Updated `lionagi/protocols/messages/__init__.py` to export `Formatter` and `JsonFormatter` for easier and more consistent usage throughout the codebase. [[1]](diffhunk://#diff-60e694ed61aff4367f5f9adea7cc829893ba8c6013591b3cb2f1e96e70a26bc2R4) [[2]](diffhunk://#diff-60e694ed61aff4367f5f9adea7cc829893ba8c6013591b3cb2f1e96e70a26bc2R32-R33)

**Test Adjustments**

- Updated tests to use `JsonFormatter` instead of `JsonTransformer` and to verify the new formatter-based rendering logic.

These changes collectively modernize and unify the handling of response format parsing and rendering, making the system more extensible and easier to maintain.