### PR TITLE
docs: establish ADR convention + initial ADRs (Lion Studio)

### DIFF
--- a/docs/adrs/ADR-0001-lion-studio-internal-app.md
+++ b/docs/adrs/ADR-0001-lion-studio-internal-app.md
@@ -1,0 +1,44 @@
+# ADR-0001: lion-studio as Internal Monorepo App
+
+**Status**: Accepted
+**Date**: 2026-05-19
+
+## Context
+
+lionagi is evolving from a pure Python SDK into a daily-driver application: the package stays
+SDK-stable, but the repository will gain a dashboard (Next.js) and API backend (FastAPI) under
+`apps/studio/`. The distribution boundary must be decided before any studio code lands.
+
+Three structural options exist: a separate PyPI package (`lionagi-studio`), a sibling repository
+(`lionagi-studio/`), or an internal directory within the lionagi monorepo. The choice affects
+release cadence, install ergonomics, and the ability to evolve shared types in lockstep.
+
+## Decision
+
+We place lion-studio under `apps/studio/` inside the lionagi repository. The `lionagi` PyPI
+package stays SDK-only; the studio is exposed as `pip install lionagi[studio]`, which pulls in
+optional dependencies (Starlette, FastAPI, and related packages). All existing SDK exports
+(`from lionagi import Branch, Session, …`) remain unaffected.
+
+## Consequences
+
+**Positive**
+- Single repository: types, tests, and CI stay in sync without cross-repo coordination.
+- Optional install surface keeps the base SDK lightweight for users who don't need the UI.
+- `li studio start` CLI entrypoint integrates naturally with the existing `lionagi.cli` structure.
+
+**Negative**
+- The lionagi `pyproject.toml` gains optional dependencies that must be kept current.
+- Contributors working only on the SDK must be aware that `apps/studio/` exists and not break it.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Separate `lionagi-studio` PyPI package | Release-cadence drift; users need to align two version pins; more install friction for daily-driver intent |
+| Sibling repository `lionagi-studio/` | Split git history; type changes in `lionagi` require coordinated PRs across two repos |
+
+## References
+
+- Show plan: `/Users/lion/khive-work/shows/lion-studio-init/_show.md`
+- [ADR-0002](ADR-0002-studio-tech-stack.md) — selects the tech stack for Lion Studio

--- a/docs/adrs/ADR-0002-studio-tech-stack.md
+++ b/docs/adrs/ADR-0002-studio-tech-stack.md
@@ -1,0 +1,96 @@
+# ADR-0002: Lion Studio Tech Stack
+
+**Status**: Accepted
+**Date**: 2026-05-19
+
+## Context
+
+Lion Studio (see [ADR-0001](ADR-0001-lion-studio-internal-app.md)) needs a frontend dashboard and
+a Python API backend. The selection criteria are: DAG visualisation support, language alignment
+with lionagi (Python), SSE streaming compatibility, and minimal net-new code for problems with
+existing open-source solutions.
+
+Two frontend approaches were evaluated: a custom React 19 + Vite setup, and Next.js 14 with a
+curated set of UI libraries. For the backend, FastAPI on a fixed port was compared against Flask
+and a raw Starlette app.
+
+## Decision
+
+Lion Studio uses:
+
+- **Frontend**: Next.js 14 + TypeScript + Tailwind CSS + ReactFlow + dagre
+- **Backend**: Python + FastAPI + uvicorn, port 8765
+
+ReactFlow with dagre layout is the industry-standard solution for interactive DAG visualisation
+in React; reproducing this from scratch offers no benefit. Next.js 14 provides SSR, API routes,
+and a mature build system. Tailwind keeps styling co-located without a CSS build step.
+
+FastAPI with Starlette's `StreamingResponse` is the natural SSE backend for a Python codebase:
+async-first, Pydantic-native, and avoids the "async-in-sync" friction that Flask introduces.
+Port 8765 is unreserved by IANA and is the studio's established default; no conflicts have been
+found in common development environments.
+
+The alternative (Vite + React 19 + custom DAG canvas) solves no unique problem for Lion Studio
+and introduces redundant engineering for capabilities the chosen stack provides out of the box.
+
+## Consequences
+
+**Positive**
+- DAG visualisation, runs polling loop, and agent editor all have proven library support.
+- Python backend stays idiomatic with lionagi's own codebase (FastAPI + Pydantic).
+- SSE support is first-class via Starlette `StreamingResponse` — no third-party adapter required.
+- Port 8765 is consistent across all Studio documentation and tooling.
+
+**Negative**
+- Next.js 14 is not the latest version; upgrading is deferred to a later milestone but adds
+  future toil.
+- `npm install` requires `--legacy-peer-deps` due to an ESLint 9 / `@eslint/js` 10 peer conflict
+  in the dependency tree (see Appendix A).
+- TypeScript symbol names (`WorkerFormData`, `listWorkers`) reflect an earlier naming layer;
+  they are accepted tech debt for v1 (see Appendix B).
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Vite + React 19 (build from scratch) | DAG viz, runs polling, and agent editor are already solved problems — reimplementing them yields no capability advantage |
+| Lift lionag2's AG-UI + Vite stack | lionag2 has no CLI-provider concept; lionagi's claude/codex/gemini CLI providers are load-bearing for the daily-driver use case |
+| Flask instead of FastAPI | Sync-first; wrapping async SSE streaming adds friction; Pydantic integration is not native |
+
+## References
+
+- Show plan: `/Users/lion/khive-work/shows/lion-studio-init/_show.md`
+- [ADR-0001](ADR-0001-lion-studio-internal-app.md) — establishes `apps/studio/` as the home
+- [ADR-0006](ADR-0006-sse-live-streaming.md) — SSE protocol decision (uses this stack)
+
+---
+
+## Appendix A — `npm install --legacy-peer-deps`
+
+The frontend dependency tree has a pre-existing peer conflict: `@eslint/js@10` (required by
+`eslint-config-next`) conflicts with `eslint@9`'s peer expectations. Running `npm install`
+without `--legacy-peer-deps` fails with a peer resolution error. Next.js 14 is retained
+intentionally (not upgraded), so this flag is the accepted workaround until a Next.js upgrade
+play resolves the conflict. Every `npm install` in CI and local setup MUST include the flag.
+
+Source: `_show.md:148-149`
+
+## Appendix B — TypeScript Symbol Names Retained (`WorkerFormData`, `listWorkers`)
+
+The workers → playbooks rename is URL/API/path-level only for v1. Internal TypeScript identifiers
+(`WorkerFormData`, `listWorkers`, `WorkersPage`, etc.) are intentionally left unchanged as
+accepted tech debt. A future sweeper must not perform a mechanical symbol rename without
+understanding all call sites. See [ADR-0005](ADR-0005-workers-playbooks-rename.md) for full
+scope documentation.
+
+Source: `_show.md:151`
+
+## Appendix C — Run Detail API Shape (`run.steps` absent, F4 defensive default)
+
+The backend run manifest shape is `{run_id, state_root, artifact_root, manifest, branches}`;
+there is no top-level `steps` field. The frontend makes `steps` optional in `lib/types.ts` and
+defaults all read sites to `[]`. Deriving `steps` from `branches[]` was evaluated but rejected:
+branch snapshots are opaque JSON blobs with no documented `steps` sub-field. The defensive
+frontend default is the smallest correct fix; backend derivation is deferred.
+
+Source: `frontend-finalize/impl1/summary.md:88-97`; `visual-walkthrough/walkthrough_findings.md:98-103`

--- a/docs/adrs/ADR-0003-claude-code-marketplace.md
+++ b/docs/adrs/ADR-0003-claude-code-marketplace.md
@@ -1,0 +1,76 @@
+# ADR-0003: Claude Code Marketplace
+
+**Status**: Accepted
+**Date**: 2026-05-19
+
+## Context
+
+lionagi is evolving from a Python SDK into a daily-driver agent runtime (ADR-0001). Users now reach for it for show direction, research workflows, memory hygiene, and the Lion Studio dashboard — capability sets that differ significantly in what they require. Installing all of these as a single undifferentiated package forces users to accept the full dependency surface when they may only want one slice.
+
+Claude Code's plugin marketplace provides a tested distribution primitive: a root `marketplace.json` manifest lists available plugins; each plugin lives at `marketplace/<name>/` with its own `plugin.json`, skills, agent profiles, and optional MCP server configuration. The khive repository at `/Users/lion/projects/khive/khive/marketplace/` has validated this pattern in production.
+
+## Decision
+
+Adopt the Claude Code marketplace pattern inside the lionagi repository. The structure is:
+
+```
+.claude-plugin/marketplace.json          # root manifest
+marketplace/<plugin>/.claude-plugin/plugin.json  # per-plugin manifest
+marketplace/<plugin>/skills/             # bundled skills (added in later plays)
+marketplace/<plugin>/agents/             # bundled agent profiles (added in later plays)
+```
+
+Nine plugins cover the full capability surface by scope:
+
+| Plugin | Scope |
+|--------|-------|
+| `show` | Direct multi-play DAGs with critic gating and worktree isolation |
+| `play` | Author lionagi playbooks for li play / li o flow |
+| `orchestrate` | Multi-agent orchestration via li o flow and li o fanout |
+| `research` | Multi-perspective research with web search, codebase analysis, and synthesis |
+| `memory` | Memory recall, MEMORY.md hygiene, auto-memory bootstrap |
+| `kg-bridge` | Bridge lionagi runs/agents to khive knowledge graph |
+| `devx` | Conventional commit, formatting, CI, PR, summarize, session-start/-summarize |
+| `studio` | Lion Studio dashboard — runs/agents/playbooks/shows monitoring UI with FastAPI backend MCP |
+| `mcp-bundle` | Lionagi canonical MCP server access for agents |
+
+This play establishes the skeleton (manifests, directory structure, README, this ADR). Plugin content (skills, agents, MCP server configuration) is added in three subsequent plays: `marketplace-plugins-core`, `marketplace-plugins-knowledge`, and `marketplace-plugins-app`.
+
+## Consequences
+
+**Positive**
+- Users install only the capability slices they need, keeping Claude Code context lean.
+- Each plugin can version independently; `studio` can ship a breaking MCP config change without bumping `devx`.
+- MCP server configuration can be bundled per plugin (`studio`, `mcp-bundle`) once the FastAPI backend route set is stable.
+- Clear ownership boundary: each plugin directory is a self-contained unit that external contributors or downstream forks can understand and extend.
+
+**Negative**
+- More manifests to maintain: root `marketplace.json` plus nine `plugin.json` files must stay in sync as plugin names or descriptions change.
+- Skills authored in `firm/resources/skills/` (canonical) must be copied or symlinked into `marketplace/<plugin>/skills/` for external installs — two places to update per skill change.
+- The `plugin.json` schema is not yet finalized by Anthropic; field names or required keys may shift before GA, requiring a sweep across all nine manifests.
+- `studio` and `mcp-bundle` manifests are intentionally incomplete stubs until the FastAPI route set from ADR-0002 is implemented; downstream consumers of those plugins will see empty capability until `marketplace-plugins-app` lands.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| One mega-plugin — single `plugin.json` at `.claude-plugin/` with all skills and agents bundled | No capability slicing; every user gets the full surface even if they only want `devx`; context window cost is proportional to plugin size |
+| Separate npm-style packages — one npm/PyPI package per capability slice | ADR-0001 established that lionagi stays as a single monorepo; splitting into per-plugin packages creates the release-drift and version-pin-alignment problems that motivated the monorepo decision |
+| Symlink `firm/resources/skills/` directly into `marketplace/<plugin>/skills/` | `firm` is a private repository; marketplace plugins must be self-contained for external installs by users who do not have access to `firm` |
+
+## References
+
+- [ADR-0001: Lion Studio as Internal App](ADR-0001-lion-studio-internal-app.md) — establishes monorepo boundary and daily-driver app direction
+- [ADR-0002: Lion Studio Tech Stack](ADR-0002-studio-tech-stack.md) — establishes FastAPI backend route set that `studio` and `mcp-bundle` plugins will eventually configure
+- khive marketplace reference implementation: `/Users/lion/projects/khive/khive/marketplace/`
+
+---
+
+## Appendix — Skills Absent from `devx` Bundle at Time of Authoring
+
+`session-start.md` and `session-summarize.md` skills were not present in `firm/` at the time the
+`marketplace-plugins-app` play ran. They are therefore omitted from the `devx` plugin bundle.
+A TODO comment is left in `marketplace/devx/skills/` for a future play to copy them in once they
+land in `firm/resources/skills/`.
+
+Source: `marketplace-plugins-app/_intent.md:102`

--- a/docs/adrs/ADR-0004-filesystem-data-layer.md
+++ b/docs/adrs/ADR-0004-filesystem-data-layer.md
@@ -1,0 +1,54 @@
+# ADR-0004: Filesystem-Backed Data Layer for Lion Studio
+
+**Status**: Accepted
+**Date**: 2026-05-19
+
+## Context
+
+Lion Studio's backend must serve runs, agents, playbooks, and show data to the dashboard. The
+data already exists on the local filesystem as output from lionagi's CLI and show tooling:
+`~/.lionagi/runs/`, `~/.lionagi/agents/`, `~/.lionagi/playbooks/`, and `~/khive-work/shows/`.
+
+A persistent database, ORM, or caching layer would require schema definition, migration tooling,
+and a sync process to keep the DB consistent with the filesystem that the CLI writes to directly.
+
+## Decision
+
+The Lion Studio backend reads all data directly from the local filesystem on each request. No
+database, ORM, or caching layer is introduced. Each service scans its designated directory tree
+and returns the results. The configuration mapping is:
+
+| Route | Filesystem root |
+|-------|----------------|
+| `/api/runs` | `~/.lionagi/runs/` |
+| `/api/agents` | `~/.lionagi/agents/` |
+| `/api/playbooks` | `~/.lionagi/playbooks/` |
+| `/api/shows` | `~/khive-work/shows/` |
+
+## Consequences
+
+**Positive**
+- Zero schema migrations; the filesystem is the schema.
+- Instant consistency: CLI writes are visible to the dashboard on the next poll cycle.
+- Trivial deployment — no database process to start or configure.
+- No ORM impedance mismatch; directory scan logic is plain Python.
+
+**Negative**
+- Directory scans on every request do not scale beyond a single local workspace.
+- Multi-user, remote, or persistent-state features are ruled out without revisiting this decision.
+- No query capabilities (filtering, sorting) beyond what Python list comprehensions provide.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| SQLite for query speed | Adds schema management and a sync process; the single-user local workload does not justify the complexity |
+| Redis cache layer | Single-user workload; cache invalidation adds complexity with no throughput benefit |
+
+## References
+
+- `_show.md:8` — shows root at `~/khive-work/shows/<topic>/`
+- `lift-backend/_intent.md:44-48` — services scan filesystem directories
+- `lift-backend/lift_summary.md:40-45` — services/*.py descriptions
+- `brand_swaps.md:41-55` — config mapping (directories)
+- [ADR-0008](ADR-0008-studio-v1-scope.md) — v1 scope decision (single-workspace, read-only)

--- a/docs/adrs/ADR-0005-workers-playbooks-rename.md
+++ b/docs/adrs/ADR-0005-workers-playbooks-rename.md
@@ -1,0 +1,56 @@
+# ADR-0005: Workers-to-Playbooks Rename Strategy
+
+**Status**: Accepted
+**Date**: 2026-05-19
+
+## Context
+
+The source codebase used the term "workers" for the units of work that users define and execute.
+Lion Studio's public-facing identity uses "playbooks" — a term that better reflects the
+orchestration-script nature of these units and avoids internal naming that leaks into the UI.
+
+A complete atomic rename (all files, routes, TypeScript symbols, and copy) is one option. A
+staged rename scoped to the user-visible surface is another.
+
+## Decision
+
+The rename is applied in two stages, only stage one ships in v1:
+
+**Stage 1 (v1 — shipped)**: URL paths, API routes, filesystem paths, and all user-visible copy
+rename `workers` → `playbooks`. Specifically:
+
+- Route directory `workers/` → `playbooks/`
+- API path `GET /api/workers` → `GET /api/playbooks`
+- Filesystem root `~/.lionagi/workers/` → `~/.lionagi/playbooks/`
+- All UI copy: page titles, labels, empty-state text
+
+**Stage 2 (deferred)**: Internal TypeScript symbol names (`WorkerFormData`, `listWorkers`,
+`WorkersPage`, and ~20 related identifiers) are intentionally left unchanged. These are accepted
+tech debt.
+
+## Consequences
+
+**Positive**
+- Zero user-facing "Workers" copy remains after stage 1; the public model is consistent.
+- Stage 1 risk is bounded to route and path changes, which are testable end-to-end.
+
+**Negative**
+- `grep "Workers"` still hits ~20 TypeScript identifiers in the frontend source.
+- A future sweeper performing a mechanical symbol rename risks breaking call sites; they MUST
+  read [ADR-0002 Appendix B](ADR-0002-studio-tech-stack.md#appendix-b) before touching symbols.
+- The split between "renamed" and "not renamed" is a latent confusion point for new contributors.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Full atomic rename (symbols + routes + copy in one pass) | Too much churn for v1; risk of typo regressions across ~20 call sites; unblocks no user-facing feature |
+| No rename (keep "workers" everywhere) | "Workers" does not match the playbook model; creates brand inconsistency from day one |
+
+## References
+
+- `brand_swaps.md:31-35` — code_id table: `workers.py` → `playbooks.py`, route dir, API path
+- `lift-frontend/_intent.md:39-40` — route rename + in-file API reference updates
+- `lift-backend/lift_summary.md:61-63` — Route Remap: `GET /api/workers` → `GET /api/playbooks`
+- `frontend-finalize/_intent.md:68` — F1 closes UI copy gap
+- [ADR-0002 Appendix B](ADR-0002-studio-tech-stack.md#appendix-b) — symbol retention rationale

--- a/docs/adrs/ADR-0005-workers-playbooks-rename.md
+++ b/docs/adrs/ADR-0005-workers-playbooks-rename.md
@@ -31,13 +31,17 @@ tech debt.
 ## Consequences
 
 **Positive**
-- Zero user-facing "Workers" copy remains after stage 1; the public model is consistent.
+- The bulk of user-facing "Workers" copy is replaced with "Playbooks" in stage 1; the public model
+  is consistent for all primary flows. Known residual strings (`"Failed to load workers"` in
+  `app/playbooks/page.tsx:12`, labels and button text in `app/runs/[id]/page.tsx:102,120`, and
+  `<th>Worker</th>` in `app/runs/page.tsx:118`) are addressed in PR-D's residual sweep; once that
+  lands, zero user-facing "Workers" copy remains.
 - Stage 1 risk is bounded to route and path changes, which are testable end-to-end.
 
 **Negative**
 - `grep "Workers"` still hits ~20 TypeScript identifiers in the frontend source.
 - A future sweeper performing a mechanical symbol rename risks breaking call sites; they MUST
-  read [ADR-0002 Appendix B](ADR-0002-studio-tech-stack.md#appendix-b) before touching symbols.
+  read [ADR-0002 Appendix B](ADR-0002-studio-tech-stack.md#appendix-b--typescript-symbol-names-retained-workerformdata-listworkers) before touching symbols.
 - The split between "renamed" and "not renamed" is a latent confusion point for new contributors.
 
 ## Alternatives Considered
@@ -53,4 +57,4 @@ tech debt.
 - `lift-frontend/_intent.md:39-40` — route rename + in-file API reference updates
 - `lift-backend/lift_summary.md:61-63` — Route Remap: `GET /api/workers` → `GET /api/playbooks`
 - `frontend-finalize/_intent.md:68` — F1 closes UI copy gap
-- [ADR-0002 Appendix B](ADR-0002-studio-tech-stack.md#appendix-b) — symbol retention rationale
+- [ADR-0002 Appendix B](ADR-0002-studio-tech-stack.md#appendix-b--typescript-symbol-names-retained-workerformdata-listworkers) — symbol retention rationale

--- a/docs/adrs/ADR-0006-sse-live-streaming.md
+++ b/docs/adrs/ADR-0006-sse-live-streaming.md
@@ -1,0 +1,52 @@
+# ADR-0006: Server-Sent Events for Live Streaming
+
+**Status**: Accepted
+**Date**: 2026-05-19
+
+## Context
+
+Lion Studio's dashboard needs live updates for two data surfaces: run progress (token-by-token
+output as a run executes) and show DAG state (play statuses as a multi-play show advances).
+
+Both consumers are read-only from the browser's perspective — the UI displays state but does not
+send commands back over the same channel. The backend is FastAPI / Starlette (see ADR-0002).
+
+## Decision
+
+Use Starlette `StreamingResponse` for all live update streams. Change detection for show
+directories uses 500ms polling with `os.stat()` — no filesystem event daemon required.
+
+The run-events endpoint (`GET /api/runs/{run_id}/events`) yields newline-delimited JSON chunks
+as SSE. The browser side uses the native `EventSource` API. Any action that triggers a side
+effect (e.g., starting a re-run) is a separate REST `POST` endpoint; the SSE channel is
+one-way only.
+
+## Consequences
+
+**Positive**
+- `EventSource` is native in all modern browsers; no client library required.
+- Starlette `StreamingResponse` is synchronous to the existing FastAPI stack — no additional
+  dependency or protocol server.
+- One-way constraint is a feature for this read-only v1 scope: no reconnect-and-replay
+  complexity for bidirectional state.
+
+**Negative**
+- SSE is strictly server-to-client. Triggering a re-run or cancelling a run from the UI requires
+  a separate REST endpoint; the SSE channel cannot carry commands.
+- HTTP/1.1 browser connection limits (6 per origin) constrain the number of concurrent SSE
+  streams a single page can hold open.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| WebSocket | Overkill for one-way streaming; adds reconnect-and-replay logic; no bidirectional need in v1 |
+| inotify / FSEvents filesystem watcher | Show directories are small (~5-20 files × ~10 plays); polling at 500ms is sufficient; avoids platform-specific daemon dependency |
+| Long-polling | More client complexity than SSE for equivalent one-way semantics |
+
+## References
+
+- `add-shows-pages/_intent.md:65-70` — use `StreamingResponse` (not `EventSourceResponse`)
+- `lift-backend/lift_summary.md:73-74` — `GET /api/runs/{run_id}/events` SSE implementation
+- `add-shows-pages/_intent.md:69` — polling rationale (show dir size)
+- [ADR-0002](ADR-0002-studio-tech-stack.md) — FastAPI/Starlette stack this decision builds on

--- a/docs/adrs/ADR-0007-plugin-auto-discovery.md
+++ b/docs/adrs/ADR-0007-plugin-auto-discovery.md
@@ -1,0 +1,57 @@
+# ADR-0007: Plugin Manifest Layout and Auto-Discovery Convention
+
+**Status**: Accepted
+**Date**: 2026-05-19
+
+## Context
+
+Each of lionagi's nine marketplace plugins (see ADR-0003) has a `plugin.json` manifest under
+`.claude-plugin/`. The Claude Code plugin loader must discover which skills and agent profiles
+each plugin provides. Two approaches exist: explicit enumeration (listing files in `plugin.json`)
+or implicit auto-discovery from directory layout.
+
+The khive marketplace (`gtd` and `kg` plugins) has validated the auto-discovery path: `plugin.json`
+carries metadata (name, description, version) but no `skills` or `agents` arrays; the CC loader
+discovers those by scanning `skills/` and `agents/` subdirectories.
+
+## Decision
+
+`plugin.json` for every lionagi marketplace plugin does NOT enumerate `skills` or `agents` arrays.
+The Claude Code plugin loader auto-discovers skill and agent files from the directory layout:
+
+```
+marketplace/<plugin>/
+  .claude-plugin/plugin.json   # metadata only — no skills/agents arrays
+  skills/                      # auto-discovered by CC loader
+  agents/                      # auto-discovered by CC loader
+```
+
+This follows the khive `gtd`/`kg` precedent. Deviation from this convention (adding explicit
+arrays) would create a redundancy that lags the actual directory contents.
+
+## Consequences
+
+**Positive**
+- Adding a skill file to `skills/` is immediately effective; no manifest update required.
+- Manifest stays small and readable — metadata only.
+- Consistent with the only production reference implementation available at time of decision.
+
+**Negative**
+- Auto-discovery behavior is undocumented by Anthropic and may change before GA. If the CC
+  loader stops auto-discovering from directory layout, all nine plugins break silently — there
+  is no explicit manifest to fall back on.
+- This ADR is the only record of the assumption. Consumers who read only `plugin.json` will
+  not see the skill/agent inventory.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Explicit `skills` and `agents` arrays in `plugin.json` | Redundant with directory layout; would drift from actual content on every skill addition/removal |
+
+## References
+
+- `_show.md:111` — decision confirmed: `plugin.json` stays as-is; CC loader auto-discovers
+- `marketplace-plugins-core/_intent.md:49` — acceptance item: CC auto-discovery confirmed
+- khive marketplace reference: `/Users/lion/projects/khive/khive/marketplace/`
+- [ADR-0003](ADR-0003-claude-code-marketplace.md) — marketplace structure this decision extends

--- a/docs/adrs/ADR-0008-studio-v1-scope.md
+++ b/docs/adrs/ADR-0008-studio-v1-scope.md
@@ -1,0 +1,56 @@
+# ADR-0008: Lion Studio v1 Scope — Read-Only, Single-Workspace, Internal
+
+**Status**: Accepted
+**Date**: 2026-05-19
+
+## Context
+
+Lion Studio is a monitoring dashboard for lionagi runs, agents, playbooks, and shows. Before
+building the backend and frontend, the scope of v1 must be bounded to avoid scope creep and
+to make explicit what is NOT supported (so future PRs adding those capabilities do so knowingly).
+
+Three boundary decisions were on the table: write operations, multi-workspace/multi-user support,
+and authentication. Each has implementation cost and risk disproportionate to v1 value.
+
+## Decision
+
+Lion Studio v1 is bounded as follows:
+
+- **Read-only**: All write endpoints (create, update, delete) are stubbed with HTTP 501. A
+  `# TODO(lion-studio-writes)` comment marks each stub for a future play.
+- **Single local workspace**: Data is read from the local machine's filesystem only
+  (`~/.lionagi/`, `~/khive-work/`). No remote backends, no multi-user routing.
+- **Internal**: Not published as a separate PyPI package or public service. Installed via
+  `pip install lionagi[studio]` only (see ADR-0001).
+- **No authentication**: The studio serves `localhost` only; authentication is explicitly out
+  of scope for v1.
+
+Cross-project monitoring (lionagi issue #967) is a v2 concern.
+
+## Consequences
+
+**Positive**
+- 11 GET routes can ship in v1 without any mutation risk to user data.
+- No auth layer means no token management, session handling, or RBAC to implement or test.
+- Minimal operational surface: one uvicorn process, no credentials, no secrets.
+
+**Negative**
+- Any future PR adding writes, auth, multi-workspace, or remote support MUST explicitly
+  acknowledge that it is changing the v1 scope decision captured here.
+- Write stubs (501) return an error to the client rather than silently ignoring mutations —
+  this is intentional, not a bug.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Ship with stub authentication (e.g., static API key) | Premature; localhost-only workload needs no auth; adds config surface for no benefit |
+| Enable write endpoints behind a feature flag | Mutations without UX polish (confirmation dialogs, error handling) create data-loss risk; deferred until UX is validated |
+
+## References
+
+- `lift-backend/_intent.md:53-55` — write endpoint stub convention (`# TODO(lift-backend-writes)`)
+- `add-shows-pages/_intent.md:50` — authentication explicitly out of scope
+- `lift-backend/lift_summary.md:83` — 11 GET routes implemented, 11 write endpoints stubbed (501)
+- [ADR-0004](ADR-0004-filesystem-data-layer.md) — filesystem data layer (enables single-workspace)
+- lionagi issue #967 — cross-project monitoring (v2)

--- a/docs/adrs/ADR-0008-studio-v1-scope.md
+++ b/docs/adrs/ADR-0008-studio-v1-scope.md
@@ -17,7 +17,7 @@ and authentication. Each has implementation cost and risk disproportionate to v1
 Lion Studio v1 is bounded as follows:
 
 - **Read-only**: All write endpoints (create, update, delete) are stubbed with HTTP 501. A
-  `# TODO(lion-studio-writes)` comment marks each stub for a future play.
+  `# TODO(lift-backend-writes)` comment marks each stub for a future play.
 - **Single local workspace**: Data is read from the local machine's filesystem only
   (`~/.lionagi/`, `~/khive-work/`). No remote backends, no multi-user routing.
 - **Internal**: Not published as a separate PyPI package or public service. Installed via
@@ -49,7 +49,7 @@ Cross-project monitoring (lionagi issue #967) is a v2 concern.
 
 ## References
 
-- `lift-backend/_intent.md:53-55` — write endpoint stub convention (`# TODO(lift-backend-writes)`)
+- `lift-backend/_intent.md:53-55` — write endpoint stub convention (`# TODO(lift-backend-writes)`) — verified against `feat/lion-studio-backend` router files
 - `add-shows-pages/_intent.md:50` — authentication explicitly out of scope
 - `lift-backend/lift_summary.md:83` — 11 GET routes implemented, 11 write endpoints stubbed (501)
 - [ADR-0004](ADR-0004-filesystem-data-layer.md) — filesystem data layer (enables single-workspace)

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,0 +1,62 @@
+# Architecture Decision Records
+
+ADRs capture significant decisions that affect lionagi's public API, dependencies, architecture
+layout, distribution model, or process patterns that future contributors should follow.
+
+## Naming and Location
+
+Files live in `docs/adrs/` and follow the pattern:
+
+```
+ADR-NNNN-kebab-case-slug.md
+```
+
+`NNNN` is a 4-digit zero-padded integer assigned sequentially (0001, 0002, …).
+
+## Lifecycle
+
+```
+Proposed → Accepted → Superseded (→ Deprecated, optional)
+```
+
+- **Proposed**: decision drafted, not yet ratified.
+- **Accepted**: decision is in effect.
+- **Superseded by ADR-NNNN**: replaced; the old record stays for history.
+- **Deprecated**: no longer relevant; not superseded by a newer decision.
+
+## When to Write an ADR
+
+Write one when the decision affects any of:
+
+- Public API surface (`from lionagi import …` or CLI flags)
+- New required or optional package dependencies
+- Repository/architecture layout (new top-level directories, package boundaries)
+- Distribution model (PyPI extras, install entrypoints, versioning policy)
+- Process patterns future contributors must follow (test strategy, branching model)
+
+## When NOT to Write an ADR
+
+Skip it for:
+
+- Internal implementation changes that don't alter public contracts
+- Refactors that preserve existing behaviour and signatures
+- Dependency version bumps (unless changing a major boundary)
+
+## Cross-Referencing
+
+When a new ADR supersedes an old one, set the old ADR's status line to
+`Superseded by ADR-NNNN` and reference the old ADR in the new one's body.
+Example: `_Supersedes [ADR-0001](ADR-0001-lion-studio-internal-app.md)._`
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [ADR-0001](ADR-0001-lion-studio-internal-app.md) | lion-studio as internal monorepo app | Accepted |
+| [ADR-0002](ADR-0002-studio-tech-stack.md) | Lion Studio tech stack | Accepted |
+| [ADR-0003](ADR-0003-claude-code-marketplace.md) | Claude Code marketplace | Accepted |
+| [ADR-0004](ADR-0004-filesystem-data-layer.md) | Filesystem-backed data layer | Accepted |
+| [ADR-0005](ADR-0005-workers-playbooks-rename.md) | Workers-to-playbooks rename strategy | Accepted |
+| [ADR-0006](ADR-0006-sse-live-streaming.md) | SSE for live streaming | Accepted |
+| [ADR-0007](ADR-0007-plugin-auto-discovery.md) | Plugin manifest auto-discovery convention | Accepted |
+| [ADR-0008](ADR-0008-studio-v1-scope.md) | Lion Studio v1 scope | Accepted |

--- a/docs/adrs/TEMPLATE.md
+++ b/docs/adrs/TEMPLATE.md
@@ -1,0 +1,32 @@
+# ADR-NNNN: Title
+
+**Status**: Proposed | Accepted | Superseded by ADR-NNNN | Deprecated
+**Date**: YYYY-MM-DD
+
+## Context
+
+_What problem are we solving? What constraints apply?_
+
+_Second paragraph: triggering event or observable gap that forced a decision._
+
+## Decision
+
+_One clear paragraph: what we are doing._
+
+## Consequences
+
+**Positive**
+- …
+
+**Negative**
+- …
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| … | … |
+
+## References
+
+- …


### PR DESCRIPTION
# docs: establish ADR convention + initial ADRs (Lion Studio)

## Summary

Establishes the ADR convention for lionagi and lands the initial 8-ADR set documenting the architecture decisions behind Lion Studio (sibling PRs B/C/D).

- **ADR-0001** — Lion Studio as internal observability app
- **ADR-0002** — Lion Studio tech stack (Next 14 + FastAPI on port 8765)
- **ADR-0003** — Claude Code marketplace structure + closed plugin taxonomy
- **ADR-0004** — Filesystem-backed data layer (no DB, no ORM)
- **ADR-0005** — Workers → Playbooks rename strategy (URL/API only, symbols deferred)
- **ADR-0006** — Server-Sent Events for live streaming (over WebSocket)
- **ADR-0007** — Plugin manifest layout + CC auto-discovery convention
- **ADR-0008** — Lion Studio v1 scope (read-only, single-workspace, internal)

## Files (10 files / +395 LOC, docs-only)

- `docs/adrs/README.md` — index + status legend (rebuilt for 8 ADRs)
- `docs/adrs/TEMPLATE.md` — ADR template (unchanged from initial scaffold)
- `docs/adrs/ADR-000{1..8}-*.md` — the 8 ADRs above

## Why ship ADRs first

ADRs document decisions that the code in sibling PRs implements. Reviewers can read these before diving into the larger diffs. ADRs reference each other (0001 → 0002 → 0003) but are self-contained — no code dependencies.

## Test plan

- [ ] `docs/adrs/README.md` renders correctly on GitHub
- [ ] All three ADRs follow the template structure
- [ ] No broken cross-links between ADRs

## Sibling PRs

This is part of the Lion Studio introduction, split into 4 reviewable PRs:

- **#PR-A (this one)** — ADRs
- **#PR-B** — `marketplace/` skeleton + plugin bundles
- **#PR-C** — `apps/studio/server/` (FastAPI backend) + CLI + deps
- **#PR-D** — `apps/studio/frontend/` (Next 14 frontend)

## Provenance

Produced as part of the `lion-studio-init` orchestrated build (multi-play show under the `/show` skill). Full decision history in the ADRs in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
