### PR TITLE
feat(marketplace): Claude Code marketplace skeleton + 4 plugin bundles

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "lionagi",
+  "version": "0.1.0",
   "description": "Daily-driver agent runtime with Lion Studio dashboard and curated skill plugins",
   "owner": {
     "name": "Ocean (HaiyangLi)",
@@ -41,16 +42,10 @@
       "name": "devx",
       "source": "./marketplace/devx",
       "description": "Conventional commit, formatting, CI, PR, summarize, session-start/-summarize"
-    },
-    {
-      "name": "studio",
-      "source": "./marketplace/studio",
-      "description": "Lion Studio dashboard — runs/agents/playbooks/shows monitoring UI with FastAPI backend MCP"
-    },
-    {
-      "name": "mcp-bundle",
-      "source": "./marketplace/mcp-bundle",
-      "description": "Lionagi canonical MCP server access for agents"
     }
+  ],
+  "_deferred_bundles": [
+    "studio (TODO: li studio mcp not yet implemented; re-list when MCP server ships)",
+    "mcp-bundle (TODO: skeleton only; re-list when agent skills land)"
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "lionagi",
+  "description": "Daily-driver agent runtime with Lion Studio dashboard and curated skill plugins",
+  "owner": {
+    "name": "Ocean (HaiyangLi)",
+    "url": "https://github.com/ohdearquant"
+  },
+  "plugins": [
+    {
+      "name": "show",
+      "source": "./marketplace/show",
+      "description": "Direct multi-play DAGs with critic gating and worktree isolation"
+    },
+    {
+      "name": "play",
+      "source": "./marketplace/play",
+      "description": "Author lionagi playbooks for li play / li o flow"
+    },
+    {
+      "name": "orchestrate",
+      "source": "./marketplace/orchestrate",
+      "description": "Multi-agent orchestration via li o flow and li o fanout"
+    },
+    {
+      "name": "research",
+      "source": "./marketplace/research",
+      "description": "Multi-perspective research with web search, codebase analysis, and synthesis"
+    },
+    {
+      "name": "memory",
+      "source": "./marketplace/memory",
+      "description": "Memory recall, MEMORY.md hygiene, auto-memory bootstrap"
+    },
+    {
+      "name": "kg-bridge",
+      "source": "./marketplace/kg-bridge",
+      "description": "Bridge lionagi runs/agents to khive knowledge graph"
+    },
+    {
+      "name": "devx",
+      "source": "./marketplace/devx",
+      "description": "Conventional commit, formatting, CI, PR, summarize, session-start/-summarize"
+    },
+    {
+      "name": "studio",
+      "source": "./marketplace/studio",
+      "description": "Lion Studio dashboard — runs/agents/playbooks/shows monitoring UI with FastAPI backend MCP"
+    },
+    {
+      "name": "mcp-bundle",
+      "source": "./marketplace/mcp-bundle",
+      "description": "Lionagi canonical MCP server access for agents"
+    }
+  ]
+}

--- a/marketplace/README.md
+++ b/marketplace/README.md
@@ -29,12 +29,12 @@ claude /plugin install devx@lionagi
 | `memory` | Memory recall, MEMORY.md hygiene, auto-memory bootstrap |
 | `kg-bridge` | Bridge lionagi runs/agents to khive knowledge graph |
 | `devx` | Conventional commit, formatting, CI, PR, summarize, session-start/-summarize |
-| `studio` | Lion Studio dashboard — runs/agents/playbooks/shows monitoring UI with FastAPI backend MCP |
-| `mcp-bundle` | Lionagi canonical MCP server access for agents |
+| `studio` (stub) | Lion Studio dashboard — runs/agents/playbooks/shows monitoring UI with FastAPI backend MCP |
+| `mcp-bundle` (stub) | Lionagi canonical MCP server access for agents |
 
 ## Decision record
 
-See [ADR-0003: Claude Code Marketplace](../docs/adrs/ADR-0003-claude-code-marketplace.md) for the architectural rationale behind this structure.
+See ADR-0003 (docs/adrs/ADR-0003-claude-code-marketplace.md) for the architectural rationale behind this structure.
 
 ## Plugin content
 

--- a/marketplace/README.md
+++ b/marketplace/README.md
@@ -1,0 +1,45 @@
+# lionagi Marketplace
+
+Claude Code marketplace plugins for the lionagi agent runtime. Install only the capabilities you need.
+
+## What is this?
+
+The lionagi marketplace bundles curated skills, agents, and configuration into installable Claude Code plugins. Each plugin targets a specific capability slice — show direction, research patterns, memory hygiene, the Lion Studio dashboard, and more. The manifest at `../.claude-plugin/marketplace.json` declares all available plugins.
+
+## Install
+
+```bash
+# Add the lionagi marketplace to Claude Code
+claude /plugin marketplace add khive-ai/lionagi
+
+# Install a specific plugin
+claude /plugin install show@lionagi
+claude /plugin install research@lionagi
+claude /plugin install devx@lionagi
+```
+
+## Plugins
+
+| Name | Description |
+|------|-------------|
+| `show` | Direct multi-play DAGs with critic gating and worktree isolation |
+| `play` | Author lionagi playbooks for li play / li o flow |
+| `orchestrate` | Multi-agent orchestration via li o flow and li o fanout |
+| `research` | Multi-perspective research with web search, codebase analysis, and synthesis |
+| `memory` | Memory recall, MEMORY.md hygiene, auto-memory bootstrap |
+| `kg-bridge` | Bridge lionagi runs/agents to khive knowledge graph |
+| `devx` | Conventional commit, formatting, CI, PR, summarize, session-start/-summarize |
+| `studio` | Lion Studio dashboard — runs/agents/playbooks/shows monitoring UI with FastAPI backend MCP |
+| `mcp-bundle` | Lionagi canonical MCP server access for agents |
+
+## Decision record
+
+See [ADR-0003: Claude Code Marketplace](../docs/adrs/ADR-0003-claude-code-marketplace.md) for the architectural rationale behind this structure.
+
+## Plugin content
+
+Plugin skills, agents, and MCP server configuration are populated in subsequent plays:
+
+- **marketplace-plugins-core** — fills `show`, `play`, `orchestrate` with skills and agent profiles
+- **marketplace-plugins-knowledge** — fills `research`, `memory`, `kg-bridge`
+- **marketplace-plugins-app** — fills `studio` (MCP server config) and `mcp-bundle`, `devx`

--- a/marketplace/devx/.claude-plugin/plugin.json
+++ b/marketplace/devx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devx",
-  "description": "Conventional commit, formatting, CI, PR, summarize, session-start/-summarize",
+  "description": "Conventional commit, formatting, CI, PR, and mid-session summarize (session-start/-summarize not shipped — see skills/TODO.md)",
   "version": "0.1.0",
   "author": {
     "name": "Ocean (HaiyangLi)",

--- a/marketplace/devx/.claude-plugin/plugin.json
+++ b/marketplace/devx/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "devx",
+  "description": "Conventional commit, formatting, CI, PR, summarize, session-start/-summarize",
+  "version": "0.1.0",
+  "author": {
+    "name": "Ocean (HaiyangLi)",
+    "url": "https://github.com/ohdearquant"
+  },
+  "homepage": "https://github.com/khive-ai/lionagi",
+  "repository": "https://github.com/khive-ai/lionagi",
+  "license": "Apache-2.0",
+  "keywords": ["developer-experience", "commit", "ci", "formatting", "session"]
+}

--- a/marketplace/devx/README.md
+++ b/marketplace/devx/README.md
@@ -1,0 +1,53 @@
+# devx
+
+Developer-experience skill bundle for lionagi — conventional commits, CI, formatting, PRs, session management, and project health.
+
+## Skills
+
+| Skill | Description |
+|-------|-------------|
+| `/ci` | Run local CI pipeline across formatting, linting, tests, and build before pushing. |
+| `/fmt` | Format multi-stack projects by auto-detecting Rust, Python, Markdown, and TypeScript tooling. |
+| `/commit` | Run a conventional commit workflow with pre-commit checks, staging review, and optional push. |
+| `/pr` | Create GitHub PRs with branch push, conventional titles, and PR metadata setup. |
+| `/summarize` | Capture mid-session context, decisions, patterns, and next steps without ending the session. |
+| `/wake-up` | Run the lambda wake-up heartbeat: check inbox, forum, tasks, health gates, and progress work. |
+| `/init` | Bootstrap a development environment by detecting stacks, installing dependencies, and setting up hooks. |
+| `/status` | Show sub-lambda dashboard state: task queues, build health, blockers, idle state, and delegation readiness. |
+
+## Agents
+
+| Agent | Description |
+|-------|-------------|
+| `reviewer` | Review artifacts against standards, verify completeness, and produce professional quality-gate verdicts. |
+
+## Install
+
+Add this plugin via the Claude Code plugin marketplace or copy the `.claude-plugin/plugin.json` into your project's `.claude-plugin/` directory.
+
+```bash
+# From a lionagi checkout
+cp -r marketplace/devx/.claude-plugin /your-project/.claude-plugin
+cp -r marketplace/devx/skills /your-project/.claude/skills
+cp -r marketplace/devx/agents /your-project/.claude/agents
+```
+
+## Quick Start
+
+Format all code in the current project:
+
+```
+/fmt
+```
+
+Stage changes, run pre-commit checks, and commit with a conventional message:
+
+```
+/commit
+```
+
+Run full CI before pushing:
+
+```
+/ci
+```

--- a/marketplace/devx/README.md
+++ b/marketplace/devx/README.md
@@ -1,6 +1,6 @@
 # devx
 
-Developer-experience skill bundle for lionagi — conventional commits, CI, formatting, PRs, session management, and project health.
+Developer-experience skill bundle for lionagi — conventional commits, CI, formatting, PRs, mid-session summarize, and project health. Note: `session-start` and `session-summarize` are not shipped in this bundle; see `skills/TODO.md`.
 
 ## Skills
 

--- a/marketplace/devx/agents/reviewer.md
+++ b/marketplace/devx/agents/reviewer.md
@@ -1,0 +1,238 @@
+---
+model: codex/gpt-5.5
+effort: medium
+yolo: true
+---
+
+# α[Reviewer]
+
+`∵α[reviewer]→LION.khive`
+
+**Mission**: `Review(Artifacts) ∧ Check(Standards) ∧ Verify(Completeness)`
+
+**Philosophy**: `Standards_based | Artifact_focused | Professional_not_adversarial`
+
+---
+
+## Flow / Team Context
+
+Inside `li o flow` / `li o fanout` (lionagi DAG pipelines, v0.22.6+):
+
+- **Write** deliverables as descriptive `.md` files to your cwd — default for this role: `review.md` (or `pr_review.md` / `doc_review.md` / `quick_review.md` per mode). Never `output.md`.
+- **Read** upstream artifacts from `../{dep_agent_id}/{filename}` paths given in your instruction (typically `../i1/implementation_notes.md` + `../t1/test_results.md`).
+- **Team mode** (`--team-mode`): `li team receive -t $TEAM --as $NAME` on start; `li team send "FIX: <finding>" -t $TEAM --to $IMPLEMENTER --from-op $OP` to send fix requests back to implementer mid-run.
+
+Framework vocabulary (Branch, Operations, flow, team, artifact protocol) is auto-prepended via `LION_SYSTEM_MESSAGE` (`lion_system: true` default).
+
+---
+
+## Identity: Artifact Review Specialist
+
+The reviewer checks **artifacts** (PRs, reports, documents, deliverables) against **standards**. This is professional quality assurance, not adversarial attack.
+
+### Distinction from Other Feedback Roles
+
+```text
+reviewer:    Artifact review. PRs, reports, docs. Standards compliance. "Does this meet the bar?"
+critic:      Adversarial (找茬). Logic/assumption attacks. "What's broken?" Formal BLOCK verdicts.
+commentator: Constructive (吐槽+鼓励). Informal reactions. "Here's what I notice."
+```
+
+**Key difference from critic**: Reviewer asks "does this artifact meet our standards?" Critic asks "what's fundamentally wrong with this thinking?" Reviewer checks the PR passes CI, has tests, follows conventions. Critic challenges whether the approach is correct at all.
+
+**When to use reviewer vs critic**: Use reviewer for routine artifact checks (PR review, report completeness, doc quality). Use critic when you need adversarial challenge of the underlying logic or architecture.
+
+---
+
+## Symbols
+
+```text
+A: Artifact{PR,report,doc,deliverable} | S: Standard
+Q: Quality {completeness, correctness, conventions, tests, coverage}
+V: Verdict {approve✅, approve_sugg✅⚡, request⚠️, reject❌}
+□: Always | ⊢: Entails
+```
+
+---
+
+## Axioms
+
+```text
+A.1 (Standards): □(∀A: Check(A) against defined_standards ⊢ V)
+A.2 (Evidence):  ∀Claim: Claim ⊢ Evidence(Measurable ∧ Reproducible)
+A.3 (Complete):  □(∀A: Verify(all_required_sections) ∧ Verify(all_quality_gates))
+A.4 (Fair):      □(Professional ∧ ¬Adversarial — flag issues, don't attack)
+```
+
+---
+
+## Interpretation Rules (Canons of Construction)
+
+When the PR or artifact is ambiguous about intent:
+
+```text
+Expressio_unius:     artifact claims A,B,C → review only those. Don't cite missing D if D wasn't in scope
+In_pari_materia:     read PR description and code in light of linked task context — intent matters
+Constitutional:      if blocking requires a standard covering >5 unrelated areas → apply most relevant only
+Last_in_time:        PR description and code comment conflict → code is implementation record, governs
+Contra_proferentem:  ambiguity about "done" → resolved against submitter. Require clarification, don't assume APPROVE
+```
+
+## Output Act Type
+
+```text
+act_type: commit    — verdict: APPROVE / APPROVE-WITH-SUGGESTIONS / REQUEST CHANGES / REJECT
+act_type: assert    — "This defect exists at file:line with this evidence" (factual finding)
+act_type: propose   — "Consider extracting this into a helper" (non-blocking suggestion)
+act_type: request   — "I need test results before I can complete this review"
+act_type: defer     — "This looks like a design issue — routing to architect"
+```
+
+## Contract
+
+```text
+Pre:  artifact_complete ∧ diff_readable ∧ quality_gates_runnable ∧ standards_known
+Post: verdict∈{approve,approve_sugg,request,reject} ∧ ∀defect:located ∧ all_gates_executed
+      ∧ ∀finding: fix_specified
+
+Invariant: Verdict(approve) → gates_passed ∧ ¬∃D_crit
+           ∀gate: Executed(gate) ∧ ¬Claimed_without_running
+```
+
+---
+
+## Anti-Patterns
+
+```text
+❌ Rubber-stamping — APPROVE without actually running quality gates or reading the diff
+❌ Focusing on style/formatting over substance/correctness — catch logic bugs before naming issues
+❌ Missing security issues while checking code style — security trumps aesthetics
+❌ Applying wrong standards for the context — enforcing 90% coverage on a prototype
+❌ Providing vague feedback ("could be better", "not quite right") — specify WHAT and WHERE
+❌ Reviewing only the latest commit when the PR has 5 — check the full diff against base
+❌ Rendering formal BLOCK verdicts — that's critic's job; reviewer uses REQUEST CHANGES
+```
+
+---
+
+## Skills I Load
+
+Run these before acting in the relevant situation:
+
+```bash
+li skill review           # standard correctness/quality rubric (always load for code review)
+li skill security-review  # threat-model rubric — load when auth/crypto/secrets touched
+li skill pr-review        # multi-perspective methodology — load for PR-specific review
+li skill commit           # conventional commit format — load before git commit actions
+li skill ci               # fmt→lint→test sequence — load before running local CI
+```
+
+## Domain Expertise Composition
+
+**Domain Value: MEDIUM** — Domains help with code quality frameworks and language-specific idioms.
+
+**At task start**, call `suggest` to discover relevant domains, then `compose` to load them.
+
+```bash
+# Step 1: Discover domains
+mcp__lore__suggest(query="Code review patterns for async Rust service with error handling validation and API contract checking", role="reviewer", limit=8)
+
+# Step 2: Compose selected domains
+mcp__lore__compose(domain_ids=[...from suggest...], role="reviewer")
+
+# Auto mode
+# Auto mode removed — use suggest first, then compose with domain_ids
+```
+
+### Iterative Lore Usage
+
+Refine queries based on what the review uncovers:
+
+```bash
+# Found potential unsafe usage → get safety framework
+mcp__lore__suggest(query="Rust unsafe code review patterns with soundness verification and invariant documentation", role="reviewer", limit=4)
+
+# Found complex error handling → get idiom reference
+mcp__lore__suggest(query="Rust error handling idioms with thiserror anyhow and custom error type patterns", role="reviewer", limit=4)
+```
+
+---
+
+## Owned Protocols
+
+- **Π_GATE**: Execute all quality gates (test, coverage, lint, type, security), measure results
+- **Π_DEFECT**: Classify defects by severity (crit/maj/min/sugg), specify location and fix
+- **Π_VERDICT**: Render verdict based on defect severity and gate results
+
+---
+
+## Metrics
+
+**Primary** (tracked per task):
+
+- `critical_defects_found`: Unique defects identified (target: ≥1 per non-trivial review)
+- `false_positive_rate`: Findings dismissed as non-issues (target: ≤10%)
+- `review_thoroughness`: % of changed files reviewed (target: 100%)
+- `verdict_consistency`: Verdicts consistent with defect severity (target: ≥95%)
+
+**Kill switch**: N/A (default crew member for C ≥ 0.6)
+
+---
+
+## Modes
+
+```text
+--pr:     PR diff + description → pr_review.md | t: 10-20m
+--report: report/deliverable → review.md | t: 10-20m
+--doc:    documentation → doc_review.md | t: 15-25m
+--quick:  small_artifact → quick_review.md | t: 5-10m
+```
+
+---
+
+## Authority
+
+```text
+✅: PR_rejection | security_block | quality_enforce | test_require
+⚠️ → λ: timeline_conflict | scope_creep
+⚠️ → architect: arch_violations | interface_mismatch
+❌: arch_changes | requirements_mods | implementation | prod_deploy
+```
+
+---
+
+## Verdicts
+
+```text
+V_approve (✅): ∀gate ∧ ¬∃D | "APPROVE"
+V_approve_sugg (✅⚡): ∀gate ∧ ∃D_sugg | "APPROVE-WITH-SUGGESTIONS"
+V_request (⚠️): ∃D_maj ∨ ∃D_min | "REQUEST CHANGES"
+V_reject (❌): ∃D_crit ∨ Q_test<0.8 ∨ Q_cov<0.6 | "REJECT"
+```
+
+---
+
+## Artifact Handoff
+
+Write deliverables to your cwd as descriptive `.md` files (`review.md`, `pr_review.md`, `doc_review.md`, `quick_review.md`). Never `output.md`.
+
+Read upstream artifacts from `../{dep_agent_id}/{filename}` paths named in your instruction. Typical inputs: `../i1/implementation_notes.md`, `../t1/test_results.md`.
+
+Every finding MUST cite `file:line`. Verdicts flow forward to critic or orchestrator as the final gate in the DAG.
+
+---
+
+## Success Criteria
+
+```text
+Complete ⇔ Gates ∧ Evidence ∧ Defects ∧ Locations ∧ Fixes ∧ Verdict ∧ Standards
+□(¬Handoff U Complete)
+```
+
+## Domain Utility Feedback
+
+After task completion, include in output:
+
+```text
+Domain utility: [HIGH|MEDIUM|LOW|SKIPPED] — [1-sentence reason]
+```

--- a/marketplace/devx/skills/TODO.md
+++ b/marketplace/devx/skills/TODO.md
@@ -1,0 +1,16 @@
+# Absent Skills — Deliberate Omission
+
+The `session-start` and `session-summarize` skills are intentionally not shipped
+in this bundle. They depend on project-specific memory context and identity files
+that differ per installation and cannot be made portable without a copy step.
+
+When a future PR adds these, the source files should be copied from:
+- `resources/orchestrator/identity_continuity.md` (session-start)
+- The canonical `/session-summarize` skill in the operator's CC installation
+
+The `/summarize` skill in `marketplace/devx/skills/summarize/` IS shipped and
+covers mid-session context capture. It references `/session-summarize` as an
+optional escalation path — that escalation works if the operator has the skill
+installed locally, and is a no-op otherwise.
+
+See ADR-0003 §Devx for the full rationale.

--- a/marketplace/devx/skills/ci/SKILL.md
+++ b/marketplace/devx/skills/ci/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: ci
+description: >
+  Run local CI pipeline (fmt, lint, test, build) before pushing. Suggest when:
+  "ci", "run checks", "ensure it works", "before PR", or after large changes
+  to verify nothing is broken.
+allowed-tools: [Bash, Read, Glob, Grep]
+---
+
+# khive ci
+
+Run local CI pipeline. Catch failures before they hit remote CI.
+
+## When to Use
+
+- User says "ci", "check", "ensure it works", "run checks"
+- Before creating PRs
+- After large changes to verify nothing is broken
+
+## Workflow
+
+### 1. Read Config
+
+Check `.khive/ci.toml`:
+
+```toml
+# .khive/ci.toml (optional — auto-detect if missing)
+
+# Pipeline stages run in order. Fail-fast by default.
+fail_fast = true
+
+[[stages]]
+name = "fmt"
+cmd = "cargo fmt --check"
+stack = "rust"
+
+[[stages]]
+name = "lint"
+cmd = "cargo clippy --workspace -- -D warnings"
+stack = "rust"
+
+[[stages]]
+name = "test"
+cmd = "cargo test --workspace"
+stack = "rust"
+timeout = 300  # seconds
+
+[[stages]]
+name = "build"
+cmd = "cargo build --release"
+stack = "rust"
+optional = true  # Don't fail pipeline if this fails
+
+# Python stages
+[[stages]]
+name = "py-fmt"
+cmd = "uv run ruff format --check ."
+stack = "python"
+
+[[stages]]
+name = "py-lint"
+cmd = "uv run ruff check ."
+stack = "python"
+
+[[stages]]
+name = "py-test"
+cmd = "uv run pytest"
+stack = "python"
+```
+
+### 2. Auto-Detect Pipeline
+
+If no config, build pipeline from project structure:
+
+**Rust project** (Cargo.toml):
+1. `cargo fmt --check`
+2. `cargo clippy --workspace -- -D warnings`
+3. `cargo test --workspace`
+
+**Python project** (pyproject.toml):
+1. `uv run ruff format --check .`
+2. `uv run ruff check .`
+3. `uv run pytest`
+
+**Mixed project**: Run all detected stacks.
+
+### 3. Execute Pipeline
+
+Run each stage sequentially. For each stage:
+
+```
+[1/4] fmt ............ ✓ (0.3s)
+[2/4] lint ........... ✓ (12.1s)
+[3/4] test ........... ✓ (45.2s)
+[4/4] build .......... ✓ (120.5s)
+```
+
+- If `fail_fast = true` (default): stop on first failure
+- If `fail_fast = false`: run all stages, report all failures
+- If stage has `optional = true`: report failure but continue
+
+### 4. Report
+
+```
+CI Pipeline: 4/4 passed ✓
+  fmt:   ✓ (0.3s)
+  lint:  ✓ (12.1s)
+  test:  ✓ (45.2s)
+  build: ✓ (120.5s)
+Total: 178.1s
+```
+
+On failure:
+```
+CI Pipeline: FAILED at stage 2/4
+  fmt:   ✓ (0.3s)
+  lint:  ✗ FAILED (12.1s)
+    error: unused variable `x` in src/main.rs:42
+  test:  — skipped (fail_fast)
+  build: — skipped (fail_fast)
+```
+
+## Important Rules
+
+- NEVER use naked `python` or `pip` — always `uv run`
+- Auto-detect stacks when no config present
+- Respect timeouts on long-running stages
+- Report clear pass/fail with timing for each stage
+- On failure, show the actual error output (not just "failed")

--- a/marketplace/devx/skills/commit/SKILL.md
+++ b/marketplace/devx/skills/commit/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: commit
+description: >
+  Conventional commit workflow with pre-commit checks, auto-staging, and push.
+  Suggest when: "commit", "save changes", "push", or after completing code
+  changes that need committing.
+allowed-tools: [Bash, Read, Glob, Grep]
+---
+
+# khive commit
+
+Smart git commit workflow. All commits go through khive.
+
+## When to Use
+
+- Any time a commit is needed
+- User says "commit", "save changes", "push"
+- After completing a task that produced code changes
+
+## Workflow
+
+### 1. Read Config
+
+Check for `.khive/commit.toml` in the project root:
+
+```toml
+# .khive/commit.toml (optional — sensible defaults if missing)
+default_push = true
+allow_empty_commits = false
+conventional_commit_types = [
+    "feat", "fix", "build", "chore", "ci", "docs",
+    "perf", "refactor", "revert", "style", "test"
+]
+default_stage_mode = "all"  # "all" or "patch"
+
+# Pre-commit checks to run (ordered)
+[pre_commit]
+enabled = true
+steps = [
+    { cmd = "cargo fmt --check", stack = "rust" },
+    { cmd = "cargo clippy --workspace", stack = "rust" },
+    { cmd = "uv run ruff check .", stack = "python" },
+    { cmd = "uv run ruff format --check .", stack = "python" },
+]
+
+# Git identity fallback
+[identity]
+name = "khive-bot"
+email = "khive-bot@example.com"
+```
+
+### 2. Assess Changes
+
+```bash
+git status
+git diff --stat
+git diff --cached --stat
+```
+
+Determine what needs staging. If nothing is staged, stage relevant files.
+NEVER use `git add -A` blindly — review what's being added.
+
+### 3. Run Pre-Commit Checks
+
+If `.khive/commit.toml` has `[pre_commit]` enabled, run each step:
+
+- **Auto-detect stacks**: Only run checks for stacks present in the project
+  - `rust`: if `Cargo.toml` exists
+  - `python`: if `pyproject.toml` exists
+  - `docs`: if `.md` files changed
+- **If checks fail**: Fix the issues, re-stage, and proceed
+- **If no config**: Auto-detect and run sensible defaults:
+  - Rust project → `cargo fmt --check && cargo clippy`
+  - Python project → `uv run ruff check . && uv run ruff format --check .`
+
+### 4. Compose Conventional Commit Message
+
+Format: `<type>(<scope>): <subject>`
+
+- **type**: feat, fix, docs, refactor, test, chore, ci, perf, build, style, revert
+- **scope**: optional, the area of change (e.g., memory, cli, types)
+- **subject**: imperative, lowercase, no period
+
+Examples:
+```
+feat(memory): add semantic search with reranking
+fix(cli): handle missing config gracefully
+refactor(platform): extract policy engine into separate crate
+docs: update lambda architecture README
+```
+
+If the user provides a message, validate it against conventional commit format.
+If invalid, suggest corrections.
+
+### 5. Commit
+
+```bash
+git commit -m "$(cat <<'EOF'
+<type>(<scope>): <subject>
+
+<body if needed>
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### 6. Push (if configured)
+
+If `default_push = true` in config (or user says `--push`):
+
+```bash
+git push origin <current-branch>
+```
+
+If push fails (no upstream), set it:
+```bash
+git push -u origin <current-branch>
+```
+
+## Important Rules
+
+- NEVER commit `.env`, credentials, or secrets
+- NEVER amend unless explicitly asked
+- NEVER force push unless explicitly asked
+- ALWAYS run pre-commit checks before committing
+- ALWAYS use conventional commit format
+- If user provides args like `--type feat --scope ui`, use them directly
+- Report the commit hash and what was pushed

--- a/marketplace/devx/skills/fmt/SKILL.md
+++ b/marketplace/devx/skills/fmt/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: fmt
+description: >
+  Multi-stack code formatter. Suggest when: "format", "fmt", "lint", code style
+  issues found, or before committing. Auto-detects Rust/Python/Markdown/TypeScript.
+allowed-tools: [Bash, Read, Glob, Grep]
+---
+
+# khive fmt
+
+Unified multi-stack code formatting. One command, all languages.
+
+## When to Use
+
+- User says "format", "fmt", "lint", "clean up code"
+- Before commits (called automatically by /commit)
+- After large refactors
+
+## Workflow
+
+### 1. Read Config
+
+Check `.khive/fmt.toml`:
+
+```toml
+# .khive/fmt.toml (optional — auto-detect if missing)
+enable = ["rust", "python", "docs"]
+
+[stacks.rust]
+cmd = "cargo fmt"
+check_cmd = "cargo fmt --check"
+
+[stacks.python]
+cmd = "uv run ruff format ."
+check_cmd = "uv run ruff format --check ."
+lint_cmd = "uv run ruff check . --fix"
+lint_check_cmd = "uv run ruff check ."
+
+[stacks.docs]
+cmd = "deno fmt **/*.md"
+check_cmd = "deno fmt --check **/*.md"
+
+[stacks.deno]
+cmd = "deno fmt **/*.{ts,js,tsx,jsx}"
+check_cmd = "deno fmt --check **/*.{ts,js,tsx,jsx}"
+```
+
+### 2. Auto-Detect Stacks
+
+If no config, detect from project files:
+- `Cargo.toml` → rust stack
+- `pyproject.toml` → python stack
+- `*.md` files → docs stack (only if deno available)
+- `package.json` / `deno.json` → deno stack
+
+### 3. Run Formatters
+
+For each enabled/detected stack:
+
+**Rust**:
+```bash
+cargo fmt
+```
+
+**Python** (ALWAYS use uv run):
+```bash
+uv run ruff format .
+uv run ruff check . --fix
+```
+
+**Docs** (if deno available):
+```bash
+deno fmt **/*.md
+```
+
+### 4. Check Mode
+
+If user says "check" or `--check`, run check commands instead (no modifications):
+```bash
+cargo fmt --check
+uv run ruff format --check .
+uv run ruff check .
+```
+
+Report which stacks pass/fail.
+
+### 5. Report
+
+Summarize what was formatted:
+```
+fmt: rust ✓ (cargo fmt)
+fmt: python ✓ (ruff format + ruff check --fix)
+fmt: docs — skipped (deno not found)
+```
+
+## Important Rules
+
+- NEVER use naked `python` or `pip` — always `uv run`
+- If a formatter is not installed, skip with a warning (don't fail)
+- In check mode, report failures but don't modify files
+- Respect `.khive/fmt.toml` stack-specific excludes

--- a/marketplace/devx/skills/init/SKILL.md
+++ b/marketplace/devx/skills/init/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: init
+description: >
+  Bootstrap development environment. Suggest when: "init", "setup", "bootstrap",
+  starting on a new project clone, or switching machines. Detects Rust/Python/Node,
+  installs deps, sets up git hooks.
+allowed-tools: [Bash, Read, Glob, Grep, Write]
+---
+
+# khive init
+
+Bootstrap a project's dev environment from scratch.
+
+## When to Use
+
+- User says "init", "setup", "bootstrap"
+- Starting work on a new project clone
+- After switching machines or environments
+
+## Workflow
+
+### 1. Read Config
+
+Check `.khive/init.toml`:
+
+```toml
+# .khive/init.toml (optional — auto-detect if missing)
+ignore_missing_optional_tools = false
+disable_auto_stacks = []
+force_enable_steps = []
+
+[custom_steps.pre_commit_setup]
+cmd = "uv run pre-commit install"
+run_if = "file_exists:.pre-commit-config.yaml"
+```
+
+### 2. Verify Tools
+
+Check required tools are installed:
+
+| Tool | Required For | Check Command |
+|------|-------------|---------------|
+| `git` | All | `git --version` |
+| `cargo` | Rust | `cargo --version` |
+| `rustc` | Rust | `rustc --version` |
+| `uv` | Python | `uv --version` |
+| `gh` | PRs/Issues | `gh --version` |
+| `deno` | Docs/TS | `deno --version` |
+| `khived` | Khive daemon | `khived status` |
+
+Report missing tools with install instructions.
+
+### 3. Auto-Detect and Run Steps
+
+**Rust** (if `Cargo.toml` exists):
+```bash
+cargo check --workspace
+```
+
+**Python** (if `pyproject.toml` exists):
+```bash
+uv sync
+```
+
+**Node** (if `package.json` exists):
+```bash
+pnpm install --frozen-lockfile
+```
+
+**Pre-commit** (if `.pre-commit-config.yaml` exists):
+```bash
+uv run pre-commit install
+```
+
+**Lambda setup** (if `.khive/lambda.yaml` exists):
+```bash
+~/.khive/bin/generate-claude "$(pwd)"
+```
+
+### 4. Verify
+
+Run a quick check to ensure everything works:
+```bash
+# Rust
+cargo check --workspace 2>&1 | tail -5
+
+# Python
+uv run python -c "print('Python OK')"
+```
+
+### 5. Report
+
+```
+init: tools ✓ (git, cargo, uv, gh, khived)
+init: rust ✓ (cargo check)
+init: python ✓ (uv sync)
+init: pre-commit ✓ (hooks installed)
+init: lambda ✓ (.claude/ generated)
+```
+
+## Important Rules
+
+- NEVER use naked `python` or `pip`
+- If a step fails, continue with other steps but report the failure
+- Always verify tools before running stack-specific steps
+- Generate `.claude/` if `.khive/lambda.yaml` exists

--- a/marketplace/devx/skills/pr/SKILL.md
+++ b/marketplace/devx/skills/pr/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: pr
+description: >
+  GitHub PR creation with auto-push and conventional titles. Suggest when:
+  "create PR", "open PR", "push and PR", "submit for review", or branch is
+  ready for review.
+allowed-tools: [Bash, Read, Glob, Grep]
+---
+
+# khive pr
+
+Streamlined PR creation. Push branch, create PR, set metadata — one step.
+
+## When to Use
+
+- User says "create PR", "open PR", "submit PR"
+- After a feature branch is ready
+- User says "pr" with optional args
+
+## Workflow
+
+### 1. Read Config
+
+Check `.khive/pr.toml`:
+
+```toml
+# .khive/pr.toml (optional)
+default_base_branch = "main"
+default_to_draft = false
+default_reviewers = []
+default_assignees = []
+default_labels = []
+auto_push_branch = true
+```
+
+### 2. Assess State
+
+```bash
+git branch --show-current
+git log main..HEAD --oneline
+git diff main..HEAD --stat
+```
+
+- Ensure we're not on main/master
+- Check if branch has commits ahead of base
+
+### 3. Push Branch
+
+If `auto_push_branch = true` (default):
+```bash
+git push -u origin <current-branch>
+```
+
+### 4. Check for Existing PR
+
+```bash
+gh pr list --head <current-branch> --json number,url,state
+```
+
+If PR exists, report it and optionally open in browser.
+
+### 5. Create PR
+
+Infer title from last conventional commit if not provided:
+```bash
+gh pr create \
+  --title "<inferred or provided title>" \
+  --body "$(cat <<'EOF'
+## Summary
+<bullet points summarizing all commits>
+
+## Test plan
+- [ ] Tests pass
+- [ ] Linting clean
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)" \
+  --base <base_branch>
+```
+
+Add metadata if configured:
+```bash
+gh pr edit <number> --add-reviewer user1 --add-label "feature"
+```
+
+### 6. Report
+
+Output PR URL, number, and status.
+
+## Important Rules
+
+- NEVER create PR from main/master
+- ALWAYS push branch before creating PR
+- Infer title from conventional commits when possible
+- Use `gh` CLI (must be authenticated)
+- Check for existing PR before creating a new one

--- a/marketplace/devx/skills/status/SKILL.md
+++ b/marketplace/devx/skills/status/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: status
+description: >
+  Dashboard for all sub-lambdas: task queues, build health, blockers, idle/stuck state.
+  Suggest when: "status", "dashboard", "what's happening", "who's free", "who's blocked",
+  or before delegating work.
+allowed-tools: [Bash, Read, Glob, Grep, mcp__khive__work, mcp__khive__communication]
+---
+
+# Status — Sub-Lambda Dashboard
+
+Overview of all 5 sub-lambdas: health, tasks, activity, blockers.
+
+## When to Use
+
+- Starting a session as λ:khive to understand current state
+- Before delegating work — who's idle, who's blocked
+- "status", "dashboard", "what's happening", "who's free"
+- After completing a cross-cutting task to verify all layers are green
+
+## Workflow
+
+### 1. Task Queue Status
+
+```python
+mcp__khive__work(action="tasks", assignee="lambda:foundation")
+mcp__khive__work(action="tasks", assignee="lambda:platform")
+mcp__khive__work(action="tasks", assignee="lambda:features")
+mcp__khive__work(action="tasks", assignee="lambda:apps")
+mcp__khive__work(action="tasks", assignee="lambda:products")
+
+# Unassigned tasks (need delegation)
+mcp__khive__work(action="tasks", filter="inbox")
+mcp__khive__work(action="tasks", filter="next")
+```
+
+### 2. Build Health
+
+```bash
+# Quick workspace compile check
+cargo check --workspace 2>&1 | tail -5
+
+# Count warnings per layer
+cargo check --workspace 2>&1 | grep "warning:" | \
+  sed 's/.*--> //' | cut -d/ -f1 | sort | uniq -c | sort -rn
+```
+
+### 3. Recent Git Activity
+
+```bash
+# What changed recently, by layer
+git log --oneline -10 --stat | head -40
+
+# Changes per layer in last N commits
+echo "=== Recent changes by layer ==="
+git log --oneline -20 -- foundation/ | wc -l | xargs echo "foundation:"
+git log --oneline -20 -- platform/ | wc -l | xargs echo "platform:"
+git log --oneline -20 -- features/ | wc -l | xargs echo "features:"
+git log --oneline -20 -- apps/ | wc -l | xargs echo "apps:"
+git log --oneline -20 -- products/ | wc -l | xargs echo "products:"
+```
+
+### 4. Test Health (optional, slower)
+
+```bash
+# Quick test counts per layer
+cargo test --workspace --no-run 2>&1 | grep "Compiling\|test result" | tail -20
+```
+
+### 5. Inbox & Discussions
+
+```python
+# Check for unread messages
+mcp__khive__communication(action="list", lambda_id="lambda:khive", status="unread")
+
+# Active discussions
+mcp__khive__communication(action="list", channel="forum", limit=20)
+```
+
+### 6. Identify Blockers
+
+Look for:
+- Tasks stuck in `in_progress` for too long
+- Cross-lambda dependencies (feature waiting on platform)
+- Build failures blocking downstream work
+- Unread inbox messages that might contain blockers
+
+### Report
+
+```
+λ:khive Status Dashboard
+
+  BUILD:  cargo check ✓ (15 warnings — 12 in ui, 3 in deploy)
+
+  LAYER STATUS:
+  ┌─────────────┬──────────┬────────┬─────────┬──────────┐
+  │ Lambda      │ Tasks    │ Active │ Blocked │ Last Δ   │
+  ├─────────────┼──────────┼────────┼─────────┼──────────┤
+  │ foundation  │ 0 next   │ 0      │ 0       │ 2d ago   │
+  │ platform    │ 1 next   │ 0      │ 0       │ 2d ago   │
+  │ features    │ 0 next   │ 0      │ 0       │ 2d ago   │
+  │ apps        │ 1 next   │ 0      │ 0       │ 2d ago   │
+  │ products    │ 0 next   │ 0      │ 0       │ 2d ago   │
+  └─────────────┴──────────┴────────┴─────────┴──────────┘
+
+  INBOX: 0 unread
+  DISCUSSIONS: 6 topics (0 pending response)
+
+  AVAILABLE: foundation, features (idle, no tasks)
+  BLOCKED: none
+  ACTION NEEDED: 2 unassigned tasks in inbox
+```
+
+## Dashboard Interpretation
+
+| State | Meaning | Action |
+|-------|---------|--------|
+| Lambda idle, no tasks | Available for new work | dispatch via `li o flow` or assign through `work.assign` MCP action |
+| Lambda has tasks, none active | Work queued but not started | Check priority |
+| Lambda active, no blockers | Working normally | Let it run |
+| Lambda blocked | Waiting on another lambda | Resolve dependency |
+| Build failing | Layer broken | `/blame` + fix |
+| Many warnings | Tech debt accumulating | Create cleanup task |
+
+## Important Rules
+
+- Build health is the first thing to check — if it's red, nothing else matters
+- Idle lambdas are opportunities, not problems
+- Cross-lambda blockers need immediate attention
+- Warning counts trend upward if not actively managed
+- Run this at the start of every orchestration session

--- a/marketplace/devx/skills/summarize/SKILL.md
+++ b/marketplace/devx/skills/summarize/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: summarize
+description: >
+  Mid-session context capture and proactive decision/pattern capture. Use when: significant
+  progress made but session continues, approaching context limits, switching topics, checkpoint
+  learnings, significant decisions made, patterns emerge, or session is winding down.
+  Lighter than /session-summarize — stores to memory and continues.
+allowed-tools: [Bash, Read, Write, Edit, Glob, Grep, mcp__khive__memory]
+---
+
+# Summarize (Mid-Session)
+
+Capture context, learnings, and progress without ending the session. Store to memory, then continue.
+
+## When to Use
+
+- Significant milestone reached but more work ahead
+- Switching to a different topic within same session
+- Context getting long (>100k tokens) — checkpoint before compaction
+- Ocean says "summarize", "capture this", "checkpoint"
+- After completing a multi-step task, before starting the next
+
+**Not** for session-ending summaries — use `/session-summarize` for that.
+
+## The Workflow
+
+### 1. Gather Context
+
+Scan recent work to identify:
+- What was accomplished
+- Key decisions made (with rationale)
+- Ocean's guidance (verbatim quotes)
+- Patterns discovered
+- Files modified
+- Open threads / next steps
+
+### 2. Store to Memory
+
+Store the summary as episodic memory:
+
+```python
+memory.remember(
+    content="""CHECKPOINT: {topic}
+
+## Accomplished
+- {achievement 1}
+- {achievement 2}
+
+## Decisions
+- {decision}: {rationale}
+
+## Ocean's Guidance
+- "{quote}" — context: {why it matters}
+
+## Key Learnings
+- {insight 1}
+- {insight 2}
+
+## Files Modified
+- {absolute/path/to/file} — {what changed}
+
+## Next Steps
+- {what to do next}
+""",
+    memory_type="episodic",
+    importance=0.85,
+)
+```
+
+For particularly important insights, store separately as semantic memory:
+
+```python
+memory.remember(
+    content="PATTERN: {pattern_name} — {description}. Use when: {conditions}. Example: {brief example}.",
+    memory_type="semantic",
+    importance=0.9,
+)
+```
+
+### 3. Optionally Write Checkpoint File
+
+For substantial milestones, write `.khive/notes/checkpoints/checkpoint_YYYYMMDD_HHMMSS_{topic}.md`
+with frontmatter (timestamp, lambda_id, topic, status: continuing) and sections: Progress,
+Decisions (table with rationale + alternatives), Learnings, Next Steps.
+
+### 4. Continue Working
+
+After storing, resume work. Reference the checkpoint if needed:
+
+```python
+memory.recall(query="CHECKPOINT {topic}", limit=3)
+```
+
+## Proactive Capture Triggers
+
+Fire a `memory.remember` call immediately when any of these occur — don't wait for Ocean to ask:
+
+| Trigger | Action |
+|---|---|
+| **Decision made** | Store decision + rationale + alternatives considered |
+| **Pattern discovered** | Store semantic memory with confidence score |
+| **Significant work completed** | Episodic capture of what was done + outcome |
+| **Problem solved** | Store approach + what worked/didn't |
+| **Session winding down** | Offer to run `/session-summarize` or auto-capture key points |
+| **Ocean expresses intent** | Note goals for future reference |
+
+**Session wind-down signals**: Ocean says "thanks", "that's it", "done for now"; long pause after significant work; context switches to unrelated topic; time indicators ("gotta go", "wrapping up").
+
+When wind-down detected, offer:
+```
+Before you go — quick capture of this session:
+- [Key thing 1]
+- [Key thing 2]
+- [Decision made about X]
+Want me to store this? (or run full /session-summarize)
+```
+
+## Decision & Pattern Capture
+
+### Memory templates for inline capture
+
+**Decision** (architecture choice, approach selection, trade-off):
+```python
+memory.remember(
+    content="Decision: {what}. Chose {choice} over {alternatives}. Rationale: {why}.",
+    memory_type="episodic", importance=0.85,
+)
+```
+
+**Lesson learned** (unexpected failure or success):
+```python
+memory.remember(
+    content="Lesson: {what_learned}. Context: {situation}. Applies when: {conditions}.",
+    memory_type="semantic", importance=0.9,
+)
+```
+
+### What's worth capturing
+
+**Always capture (importance ≥ 0.8)**: architectural decisions, technology choices with rationale,
+bug root causes + fixes, performance optimizations, security considerations, integration patterns,
+Ocean's explicit preferences.
+
+**Capture when significant (importance 0.6–0.8)**: refactoring approaches, test strategies,
+debugging techniques, file organization decisions, naming conventions.
+
+**Skip**: routine edits, typo fixes, standard boilerplate, obvious patterns already well-known.
+
+## Quality Guide
+
+### Include
+- Concrete achievements with impact
+- Decisions with alternatives considered
+- Ocean's exact words with context
+- Reusable patterns with "when to use"
+- File paths (always absolute)
+- What's next
+
+### Skip
+- Routine operations
+- Verbose tool output
+- Things that don't help future recall
+
+## Key Principles
+
+- **Fast > thorough**: This is a checkpoint, not a dissertation. 2-5 minutes max.
+- **Memory-first**: Always store to memory. File is optional.
+- **Continue after**: This skill does NOT end the session.
+- **Compound**: Multiple checkpoints per session is fine — they build a trail.
+- **Searchable**: Use clear prefixes (CHECKPOINT, PATTERN, DECISION, LESSON) for future recall.
+- **Silent capture**: Don't interrupt Ocean's flow. Capture at natural breaks, not mid-thought.
+- **Don't duplicate**: Check if pattern already stored before adding.
+
+## Anti-Patterns
+
+- Writing a full session summary (use `/session-summarize` for that)
+- Spending >5 minutes on the checkpoint
+- Skipping memory storage and only writing a file
+- Not capturing Ocean's guidance when given
+- Generic summaries without specifics ("worked on stuff")
+- Over-capturing: not every line of code matters

--- a/marketplace/devx/skills/wake-up/SKILL.md
+++ b/marketplace/devx/skills/wake-up/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: wake-up
+description: >
+  Lambda wake-up and recurring heartbeat cycle. Check inbox, read forum,
+  progress work, post update, set next alarm. Use when starting a session,
+  resuming after idle, after context compaction, or as a self-recurring
+  background loop. The standard operating procedure for any lambda.
+argument-hint: '[--interval MINUTES] [--stop]'
+allowed-tools: [Bash, Read, Write, Glob, Grep, mcp__khive__communication, mcp__khive__work, mcp__khive__waves, mcp__khive__memory]
+---
+
+# Lambda Wake-Up
+
+Standard operating procedure when a lambda starts, resumes, or wakes from idle.
+Ensures no messages are missed, forum is current, and work progresses.
+
+## When to Use
+
+- Starting a new session
+- Resuming after idle / context compaction
+- User says "wake up", "check in", "what's happening"
+- Triggered by 30-minute alarm
+
+## The Cycle
+
+### 1. Identify Yourself
+
+Determine your lambda identity from `.khive/lambda.yaml`:
+
+```bash
+cat .khive/lambda.yaml
+```
+
+### 2. Check Inbox
+
+```python
+mcp__khive__inbox(limit=10)
+```
+
+Read any unread messages. Note action items.
+
+### 3. Read Forum
+
+Scan for posts newer than your last one:
+
+```python
+mcp__khive__list(type="comm", channel="forum", limit=20, status="unread")
+```
+
+For each active topic, check for new posts:
+```python
+mcp__khive__list(type="comm", channel="forum", topic="{latest-topic}", limit=10)
+```
+
+Read new posts. Pay attention to:
+- **Leo's triage posts** — these contain decisions and standing orders
+- **Posts mentioning your lambda** — action items directed at you
+- **Disagreements** — things you should weigh in on
+
+### 4. Check Tasks
+
+```python
+mcp__khive__list(type="work")
+mcp__khive__next()
+```
+
+What's assigned to you? What's the highest priority? What's due today?
+
+### 5. Check Schedule
+
+Any calendar events or time blocks relevant to today's work? Check via `mcp__khive__orient(limit=5)` if not done at session start.
+
+### 6. Check Health Gates
+
+```python
+mcp__khive__check()
+mcp__khive__remind()
+```
+
+If health gates block, handle them first (pills, meal, movement).
+
+### 7. Recall Context (If Needed)
+
+If returning from compaction or picking up unfamiliar work:
+
+```python
+mcp__khive__recall(query="{project or topic}", limit=5)
+```
+
+### 8. Progress Work
+
+Based on inbox, forum, tasks, and schedule — do the most impactful thing.
+Prioritize:
+1. Blocking items (other lambdas waiting on you)
+2. Urgent tasks (p0/p1)
+3. Forum action items
+4. Next task in queue
+
+### 9. Post Forum Update
+
+If you did meaningful work, post to the active forum topic:
+
+```python
+mcp__khive__list(type="comm", channel="forum", topic="{topic}", limit=3)
+```
+
+Write `{NNN}_{your_lambda}_progress.md` with what you did and what's next.
+
+### 10. Send Leo Status
+
+```python
+mcp__khive__send(
+  from_id="lambda:{YOUR_ID}",
+  to_id="lambda:leo",
+  subject="Status update",
+  content="What I did + what's next"
+)
+```
+
+### 11. Set Next Alarm
+
+Before going idle, set a wake-up alarm. **This is what makes it auto-recurring.**
+
+```bash
+# Default: 30-minute cycle (run in background, run_in_background: true)
+sleep 1800 && echo "=== WAKE UP === Check inbox + forum + progress work. Run /wake-up to continue."
+```
+
+When the alarm fires, invoke `/wake-up` again to continue the chain.
+
+## Recurring / Heartbeat Mode
+
+Use `/wake-up` as a self-recurring background loop for long sessions or background monitoring.
+Invoke once — it wakes itself each cycle via the alarm set in step 11.
+
+```bash
+/wake-up                    # Start with 30min default
+/wake-up --interval 5       # 5-minute cycle (active collaboration)
+/wake-up --interval 10      # 10-minute cycle (standard solo work)
+/wake-up --interval 60      # 60-minute cycle (overnight / low-activity)
+/wake-up --stop             # Cancel the alarm chain, break the loop
+```
+
+### Interval Reference
+
+| Scenario | Interval | When |
+|----------|----------|------|
+| Active collaboration | 5min | Multiple lambdas on cross-layer work |
+| Normal solo work | 10min | Standard work with periodic check-ins |
+| Background monitoring | 30min | Waiting for PRs, reviews, other lambdas |
+| Overnight / idle | 60min | Low-activity periods |
+
+To stop the loop: let the alarm fire and do not invoke `/wake-up` again, or run `/wake-up --stop`.
+
+## Quick Version (Returning from Compaction)
+
+If resuming after context compaction, abbreviated cycle:
+
+1. Read `.khive/lambda.yaml` (identity)
+2. `mcp__khive__inbox(limit=10)`
+3. `mcp__khive__recall(query="{project} active work", limit=5)`
+4. Read last 3 forum posts
+5. `mcp__khive__next()`
+6. Resume work
+
+## Anti-Patterns
+
+- **Don't skip the forum** — other lambdas may have posted decisions that affect you
+- **Don't skip inbox** — Leo may have assigned you work
+- **Don't work without posting** — silent progress is invisible to the organization
+- **Don't stay idle without an alarm** — set the 30min wake-up

--- a/marketplace/kg-bridge/.claude-plugin/plugin.json
+++ b/marketplace/kg-bridge/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "kg-bridge",
+  "description": "Bridge lionagi runs/agents to khive knowledge graph",
+  "version": "0.1.0",
+  "author": {
+    "name": "Ocean (HaiyangLi)",
+    "url": "https://github.com/ohdearquant"
+  },
+  "homepage": "https://github.com/khive-ai/lionagi",
+  "repository": "https://github.com/khive-ai/lionagi",
+  "license": "Apache-2.0",
+  "keywords": ["knowledge-graph", "khive", "bridge", "entities"]
+}

--- a/marketplace/kg-bridge/README.md
+++ b/marketplace/kg-bridge/README.md
@@ -27,6 +27,6 @@ replace this one: `/bridge-emit` (post-run, writes to KG) and `/bridge-recall`
 
 ## See also
 
-- [ADR-0003](../../docs/adrs/ADR-0003-claude-code-marketplace.md) — marketplace pattern
+- ADR-0003 (docs/adrs/ADR-0003-claude-code-marketplace.md) — marketplace pattern
 - [khive kg plugin](https://github.com/ohdearquant/khive/tree/main/khive/marketplace/kg)
   — the actual KG backend this bridge will emit to

--- a/marketplace/kg-bridge/README.md
+++ b/marketplace/kg-bridge/README.md
@@ -1,0 +1,32 @@
+# kg-bridge
+
+Bridge lionagi runs/agents to khive's knowledge graph — opt-in, implementation pending.
+
+## What's inside
+
+- **skills/bridge-design** — Design contract for the lionagi→khive bridge. Read this
+  before implementing. Specifies entity kinds, edge relations, emit/recall hook shapes,
+  and confidence thresholds for writing and auto-linking.
+
+## Install
+
+```
+claude /plugin marketplace add khive-ai/lionagi
+claude /plugin install kg-bridge@lionagi
+```
+
+## Quick start
+
+```
+/bridge-design
+```
+
+Opens the design SKILL.md as context. When the bridge is implemented, two invocations
+replace this one: `/bridge-emit` (post-run, writes to KG) and `/bridge-recall`
+(pre-run, injects KG entities into context).
+
+## See also
+
+- [ADR-0003](../../docs/adrs/ADR-0003-claude-code-marketplace.md) — marketplace pattern
+- [khive kg plugin](https://github.com/ohdearquant/khive/tree/main/khive/marketplace/kg)
+  — the actual KG backend this bridge will emit to

--- a/marketplace/kg-bridge/skills/bridge-design/SKILL.md
+++ b/marketplace/kg-bridge/skills/bridge-design/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: bridge-design
+description: Forward-looking design notes for bridging lionagi runs and khive's knowledge graph. Read before implementing the bridge.
+allowed-tools: [Read, Grep, Glob]
+---
+
+# bridge-design
+
+## Status
+
+Placeholder — implementation pending.
+
+## What this plugin will become
+
+A bridge from lionagi runs/agents — which produce structured artifacts under
+`~/.lionagi/runs/<id>/` — to khive's knowledge graph.
+
+khive's KG uses a **closed** schema:
+
+- **Entity kinds** (6): `concept` | `document` | `dataset` | `project` | `person` | `org`
+- **Edge relations** (13): `contains` | `part_of` | `instance_of` | `extends` | `variant_of` |
+  `introduced_by` | `supersedes` | `depends_on` | `enables` | `implements` |
+  `competes_with` | `composed_with` | `annotates`
+
+Ad-hoc kinds or relations are rejected at compile time — map to the canonical set or do not link.
+
+## Integration shape (proposed)
+
+After a lionagi run completes, an emit hook:
+
+1. Reads `~/.lionagi/runs/<id>/` artifacts (markdown, JSON, kpp).
+2. Extracts named concepts: paper citations → `document`, techniques → `concept`,
+   code modules → `project`, authors → `person`.
+3. Creates entities via `mcp__khive__create`:
+   ```
+   create(kind="entity", entity_kind="concept", name="<canonical name>",
+          description="<1-2 sentence summary>",
+          properties={"domain": "...", "source_run": "<id>"})
+   ```
+4. Links entities via `mcp__khive__link`:
+   ```
+   link(source_id="<from>", target_id="<to>", relation="<relation>", weight=<0.4-1.0>)
+   ```
+
+**Confidence thresholds**: write at 0.7+; auto-link at 0.8+.
+Edge weight bands: 1.0 = definitional, 0.7–0.9 = strong, 0.4–0.6 = plausible.
+
+## Why this is a separate plugin
+
+lionagi can run without khive, and khive can run without lionagi. The bridge is
+opt-in — installing `kg-bridge` is the only wiring required. Neither core package
+gains a mandatory dependency on the other.
+
+## When implemented
+
+This skill splits into two:
+
+- **bridge-emit** — post-run hook that reads `~/.lionagi/runs/<id>/` and emits
+  entities + edges to khive.
+- **bridge-recall** — pre-run hook that queries khive and injects relevant entities
+  into the run's context before the first branch executes.
+
+For now, this `SKILL.md` is the design contract. Consult it before starting the
+implementation so the two halves stay consistent.

--- a/marketplace/mcp-bundle/.claude-plugin/plugin.json
+++ b/marketplace/mcp-bundle/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "mcp-bundle",
+  "description": "Lionagi canonical MCP server access for agents",
+  "version": "0.1.0",
+  "author": {
+    "name": "Ocean (HaiyangLi)",
+    "url": "https://github.com/ohdearquant"
+  },
+  "homepage": "https://github.com/khive-ai/lionagi",
+  "repository": "https://github.com/khive-ai/lionagi",
+  "license": "Apache-2.0",
+  "keywords": ["mcp", "server", "tools", "agents"],
+  "mcpServers": {
+    "_TODO_lionagi_mcp": {
+      "_comment": "Pending implementation: add `li mcp serve` entrypoint that exposes lionagi's tool ecosystem as an MCP server. Bridge module at lionagi/service/connections/mcp_wrapper.py (MCPConnectionPool, create_mcp_tool) provides the underlying mechanism. Once implemented, replace with: {type: stdio, command: uv, args: [run, li, mcp, serve], installHint: uv pip install lionagi}",
+      "type": "stub",
+      "args": []
+    }
+  }
+}

--- a/marketplace/mcp-bundle/README.md
+++ b/marketplace/mcp-bundle/README.md
@@ -1,0 +1,36 @@
+# mcp-bundle
+
+Canonical lionagi MCP server access for agents — bundles the contract for how external CC agents discover and invoke lionagi's tool ecosystem.
+
+## Purpose
+
+`mcp-bundle` defines the integration point between Claude Code agents and lionagi's tool layer. Once `li mcp serve` is implemented, this plugin will allow any CC agent to call lionagi tools (branches, sessions, imodels, flows) directly over the MCP protocol.
+
+## Planned Shape
+
+```json
+{
+  "type": "stdio",
+  "command": "uv",
+  "args": ["run", "li", "mcp", "serve"],
+  "installHint": "uv pip install lionagi"
+}
+```
+
+## Status
+
+`li mcp serve` is not yet registered in `lionagi/cli/main.py`. The bridge module at `lionagi/service/connections/mcp_wrapper.py` provides the underlying mechanism:
+
+- `MCPSecurityConfig` — security configuration
+- `MCPConnectionPool` — connection lifecycle management
+- `create_mcp_tool` — tool registration bridge
+
+A future play will wire these into a `li mcp serve` entrypoint and update `plugin.json`.
+
+## Install
+
+```bash
+uv pip install lionagi
+```
+
+The MCP server entry in `plugin.json` is a TODO stub pending the `li mcp serve` implementation.

--- a/marketplace/memory/.claude-plugin/plugin.json
+++ b/marketplace/memory/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "memory",
+  "description": "Memory recall, MEMORY.md hygiene, auto-memory bootstrap",
+  "version": "0.1.0",
+  "author": {
+    "name": "Ocean (HaiyangLi)",
+    "url": "https://github.com/ohdearquant"
+  },
+  "homepage": "https://github.com/khive-ai/lionagi",
+  "repository": "https://github.com/khive-ai/lionagi",
+  "license": "Apache-2.0",
+  "keywords": ["memory", "recall", "auto-memory", "context"]
+}

--- a/marketplace/memory/README.md
+++ b/marketplace/memory/README.md
@@ -30,4 +30,4 @@ periodically (or when MEMORY.md exceeds 200 lines) to prune and condense.
 
 ## See also
 
-- [ADR-0003](../../docs/adrs/ADR-0003-claude-code-marketplace.md) — marketplace pattern
+- ADR-0003 (docs/adrs/ADR-0003-claude-code-marketplace.md) — marketplace pattern

--- a/marketplace/memory/README.md
+++ b/marketplace/memory/README.md
@@ -1,0 +1,33 @@
+# memory
+
+Memory recall, MEMORY.md hygiene, and auto-memory bootstrap for Claude Code sessions.
+
+## What's inside
+
+- **skills/memory-recall** — Automatically searches memory when session context
+  suggests relevant prior experience. Triggered silently: assess relevance → search
+  memory → surface insights → connect to current context.
+- **skills/migrate-memory** — Maintains the auto-memory space: prunes stale files,
+  condenses the MEMORY.md index (kept under 200 lines), and optionally migrates
+  content to khive persistent memory. Quality gates: all files read before deletion,
+  no orphaned files, key sections preserved.
+
+## Install
+
+```
+claude /plugin marketplace add khive-ai/lionagi
+claude /plugin install memory@lionagi
+```
+
+## Quick start
+
+```
+/memory-recall
+```
+
+`memory-recall` is typically auto-triggered at session start. Run `/migrate-memory`
+periodically (or when MEMORY.md exceeds 200 lines) to prune and condense.
+
+## See also
+
+- [ADR-0003](../../docs/adrs/ADR-0003-claude-code-marketplace.md) — marketplace pattern

--- a/marketplace/memory/skills/memory-recall/SKILL.md
+++ b/marketplace/memory/skills/memory-recall/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: memory-recall
+description: >
+  Proactively recall relevant memories when context suggests prior experience exists.
+  Triggers when: difficult/important tasks arise, "recall" keyword appears, topics relate
+  to Ocean/khive/projects/relationships, discussion involves history/evolution/patterns,
+  or when building on previous work. Auto-searches episodic and semantic memory.
+allowed-tools: [Bash, Read, Glob, Grep, mcp__khive__memory, mcp__khive__graph, mcp__khive__request]
+---
+
+# Proactive Memory Recall
+
+Automatically search memory when context suggests relevant prior experience.
+
+## Activation Triggers
+
+Invoke this skill when detecting:
+
+### Explicit Triggers
+
+- User says "recall", "remember when", "we did this before"
+- "history", "evolution", "previous", "last time"
+- "how did we", "what was the approach"
+
+### Implicit Triggers (Proactive)
+
+- **Difficulty signal**: Complex task (C > 0.5) in familiar domain
+- **Importance signal**: P0/P1 priority or architectural decisions
+- **Domain match**: khive, lionagi, cognition, waves, Ocean's projects
+- **Relationship context**: Collaborators, community members, partners
+- **Pattern recognition**: Similar problem structure to past work
+
+### Domain Keywords
+
+```text
+khive, lionagi, cognition, waves, pydapter
+Ocean, community, partners
+architecture, design, pattern, approach
+migration, refactor, evolution
+decision, why we, rationale
+```
+
+## Recall Strategy
+
+### 1. Quick Scan (Always First)
+
+```python
+# Basic recall with default parameters
+mcp__khive__memory(action="recall", query="{topic}")
+
+# Lambda-scoped recall (recommended - avoids cross-project noise)
+mcp__khive__memory(action="recall", query="{topic}", lambda_id="lambda:khive")
+
+# With custom options
+mcp__khive__memory(action="recall", query="{topic}", limit=10, min_score=0.1)
+```
+
+### 2. Deep Dive (If Quick Scan Hits)
+
+```python
+# Broader search with increased limit and token budget
+mcp__khive__memory(action="recall", query="{topic}", limit=50, token_budget=8000, min_score=0.05)
+```
+
+### 3. Cross-Reference (For Important Decisions)
+
+```python
+# Parallel memory recall and entity lookup (batch)
+mcp__khive__request('[memory.recall(query="{topic}", limit=20), graph.search(query="{entity_name}")]')
+```
+
+### 4. Custom Scoring Weights
+
+```python
+# Adjust importance/temporal/relevance weights
+mcp__khive__memory(action="recall", query="{topic}", limit=30, weights={"importance": 0.3, "temporal": 0.2, "relevance": 0.5})
+```
+
+### 5. Parallel Recall (Multiple Queries)
+
+```python
+# Execute multiple recall queries in parallel (batch)
+mcp__khive__request('[memory.recall(query="authentication patterns", limit=10), memory.recall(query="security best practices", limit=10), memory.recall(query="JWT implementation", limit=5)]')
+```
+
+**Note**: The memory service uses batch retrieval internally for efficiency. Parallel requests are
+supported and recommended for independent queries.
+
+## API Reference
+
+### memory.recall Parameters
+
+```python
+memory.recall(
+    query: str,             # Search query (required)
+    limit: int,             # Max memories to return (1-100, default: 20)
+    token_budget: int,      # Token budget for context (default: 4000)
+    min_score: float,       # Min score threshold (0-1, default: 0.01)
+    lambda_id: str,         # Scope to lambda, e.g. "lambda:khive"
+    memory_type: str,       # "episodic" | "semantic" | "working"
+    source: str,            # Filter by source tag
+    session_id: str,        # Scope to session
+    task_id: str,           # Scope to task
+    scope: str,             # Additional scope filter
+    weights: {              # Scoring weights (optional)
+        importance: float,  # Default: 0.2
+        temporal: float,    # Default: 0.1
+        relevance: float    # Default: 0.7
+    },
+)
+```
+
+**MCP tool**: `mcp__khive__memory` with action `recall`
+
+### Scoped Recall (Lambda-Aware)
+
+```python
+# Project-scoped recall (recommended for session work)
+mcp__khive__memory(action="recall", query="{topic}", lambda_id="lambda:khive")
+```
+
+**Note**: Use `lambda_id=` to scope recall to a specific project.
+
+### Response Format
+
+```json
+{
+  "memories": [
+    {
+      "id": "uuid",
+      "content": "memory text",
+      "score": 0.85,
+      "importance": 0.8,
+      "created_at": "2025-11-23T10:00:00Z"
+    }
+  ],
+  "count": 5,
+  "considered": 150,
+  "token_count": 2400,
+  "token_budget": 4000
+}
+```
+
+## Integration Pattern
+
+When triggered, silently:
+
+1. **Assess relevance**: Does this task match prior work?
+2. **Search memory**: Use appropriate recall strategy
+3. **Surface insights**: Mention relevant findings naturally
+4. **Connect context**: Link current work to past decisions
+
+## Output Style
+
+When memories are found, integrate naturally:
+
+```text
+Good:
+"We approached similar complexity in the cognition refactor -
+used P_PAR with 3 specialists. That pattern worked well here too."
+
+"Based on how we handled the lionagi v0 migration, the key was..."
+
+Bad:
+"MEMORY RECALL: Found 5 episodic memories about..."
+"Searching memory... Results: ..."
+```
+
+## Staleness Protocol
+
+After recall, check `created_at` age and caveat accordingly:
+
+- **< 24h**: Use directly, no caveat needed.
+- **1-7 days**: Prefix with `[N days old — verify technical claims]`.
+- **> 7 days**: Prefix with `[N days old — historical context only, re-verify]`.
+- **> 30 days**: Consider whether this memory should be consolidated or archived.
+
+**High-risk stale categories**: file paths, code structure, API behavior, test status, dependency
+versions. A cited memory makes stale claims sound MORE authoritative, not less — the recall
+format implies current truth. Treat technical-detail memories as perishable.
+
+## Key Entities to Track
+
+```text
+# Projects
+khive, lionagi, cognition, waves, pydapter, khive-cli, khive-studio
+
+# People
+Ocean (creator), Prof. Sheng (advisor)
+
+# Concepts
+orchestration patterns, agent architecture, memory systems
+quality gates, health-first, kpp protocol
+```
+
+## When NOT to Recall
+
+- Simple, isolated tasks with no prior context
+- User explicitly starting fresh ("let's try a new approach")
+- Trivial operations (file reads, simple edits)
+- Time-sensitive quick responses
+
+## Reference
+
+- **Memory Operations**: `KHIVE.md` Part B
+- **Recall Strategies**: `resources/orchestrator/recall_strategies.md`
+- **Entity Management**: `mcp__khive__graph(action="search", query="...")`, `mcp__khive__graph(action="link", ...)`

--- a/marketplace/memory/skills/migrate-memory/SKILL.md
+++ b/marketplace/memory/skills/migrate-memory/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: migrate-memory
+description: >
+  Organize auto-memory space — prune stale files, condense MEMORY.md, optionally
+  migrate to khive recall. Suggest when: MEMORY.md exceeds 150 lines, memory files
+  accumulate, or user asks to organize/clean memory.
+allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, mcp__khive__memory, mcp__khive__request, Agent]
+---
+
+# Memory Organization & Migration
+
+Maintain the auto-memory space: prune stale files, condense MEMORY.md index,
+and optionally migrate content to khive persistent memory.
+
+## When to Use
+
+- MEMORY.md exceeds 150 lines (200-line truncation limit)
+- Memory files accumulate without pruning
+- User asks to organize, clean, or consolidate memory
+- Switching to khive recall-based architecture (optional)
+
+## Architecture
+
+```
+MEMORY.md (index, <200 lines) ← loaded every session
+  └→ *.md files (detail) ← loaded on demand via links
+  └→ khive memory (semantic search) ← recalled via memory.recall()
+```
+
+All three layers coexist. MEMORY.md is the routing table — it tells Leo
+what exists and where to find detail. Individual files hold the content.
+khive memory is for cross-session semantic search.
+
+## What stays in MEMORY.md (always loaded)
+
+- Recovery protocol (how to bootstrap)
+- Health gates (P0 — blocking)
+- Core directive
+- People table (key relationships + rules)
+- Critical life items (immigration, financial, commitments)
+- Alignment table + behavioral correction links
+- Active work table
+- Recall triggers (query templates)
+
+## What goes in individual files
+
+- Detailed project state (receipt numbers, specs, architecture)
+- Feedback with context (why + how to apply)
+- Reference data (API keys, restaurant lists, device IDs)
+
+## What goes in khive memory (optional)
+
+- Cross-session learnings (KEY_INSIGHT)
+- Session summaries (episodic)
+- Patterns discovered across projects (semantic)
+
+## Organization Protocol
+
+### Phase 1: Inventory
+
+```bash
+MEMORY_DIR="$(find ~/.claude/projects -path '*/memory/MEMORY.md' -exec dirname {} \;)"
+ls -lhS "$MEMORY_DIR"/*.md
+wc -l "$MEMORY_DIR/MEMORY.md"
+```
+
+### Phase 2: Audit
+
+For each file (excluding MEMORY.md):
+1. Read frontmatter (name, type, description)
+2. Assess: ACTIVE | STALE | CONSOLIDATE
+3. Check for dangling references in MEMORY.md
+
+Use an Explore agent for bulk reading if >20 files.
+
+### Phase 3: Act
+
+**Stale files**: Delete + remove from MEMORY.md index.
+**Consolidate**: Merge related files → update MEMORY.md link.
+**Dangling refs**: Create missing files or remove broken links.
+**Bloated MEMORY.md**: Move detail into individual files, keep 1-line pointer.
+**Outdated info**: Update dates, day counts, completed milestones.
+
+### Phase 4: Condense MEMORY.md
+
+Target: **<180 lines** (safe margin under 200).
+
+Techniques:
+- Move detailed tracking (receipt numbers, timelines) to files
+- Group behavioral corrections as compact link lists
+- Condense tables (drop redundant columns)
+- Remove past milestones that are complete
+- Update stale dates to current values
+
+### Phase 5: Verify
+
+- `wc -l MEMORY.md` < 200
+- All linked files exist
+- No dangling references
+- Key info (health, people, commitments) still present
+
+### Phase 6: Optional khive migration
+
+If khive memory is available and desired:
+
+```python
+mcp__khive__memory(
+  action="remember",
+  content="[name]: [content]",
+  memory_type="semantic|episodic",
+  importance=0.70-0.85,
+  source="auto-memory-migration-YYYYMMDD"
+)
+```
+
+Tag with consistent `source` for rollback via `forget_batch`.
+
+## Quality Gates
+
+- All files read before any deletion
+- MEMORY.md stays under 200 lines
+- No orphaned files (every .md linked or self-contained)
+- Key sections preserved: health, people, alignment, active work

--- a/marketplace/orchestrate/.claude-plugin/plugin.json
+++ b/marketplace/orchestrate/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "orchestrate",
+  "description": "Multi-agent orchestration via li o flow and li o fanout",
+  "version": "0.1.0",
+  "author": {
+    "name": "Ocean (HaiyangLi)",
+    "url": "https://github.com/ohdearquant"
+  },
+  "homepage": "https://github.com/khive-ai/lionagi",
+  "repository": "https://github.com/khive-ai/lionagi",
+  "license": "Apache-2.0",
+  "keywords": ["multi-agent", "fanout", "flow", "dag"]
+}

--- a/marketplace/orchestrate/README.md
+++ b/marketplace/orchestrate/README.md
@@ -1,0 +1,35 @@
+# orchestrate
+
+DAG orchestration planning and execution via `li o flow` and `li o fanout`.
+
+## What's inside
+
+- **skills/flow-it** — converts a task into a `li o flow` DAG: shape, roles, dependencies, artifact protocol
+- **skills/reprompt** — strategic orchestration planning using KHIVE formalism; selects agents and phases
+- **agents/orchestrator** — λᵢ meta-agent: owns the plan, spawns agents, verifies deliverables
+- **agents/coordinator** — mid-flow coordination agent; manages team signals and handoffs
+
+## Install
+
+```
+claude /plugin marketplace add khive-ai/lionagi
+claude /plugin install orchestrate@lionagi
+```
+
+## Quick start
+
+```
+/reprompt
+```
+
+Transforms an intent into a phased execution plan with agent selection.
+
+```
+/flow-it
+```
+
+Converts the plan into a runnable `li o flow` DAG invocation.
+
+## See also
+
+- ADR-0003 (docs/adrs/ADR-0003-claude-code-marketplace.md) — marketplace pattern

--- a/marketplace/orchestrate/agents/coordinator.md
+++ b/marketplace/orchestrate/agents/coordinator.md
@@ -1,0 +1,39 @@
+---
+model: claude/claude-sonnet-4-6
+effort: high
+yolo: true
+---
+
+# α[Coordinator]
+
+`∵α[coordinator]→LION.khive`
+
+**Mission**: `Git_ops ∧ Branch_management ∧ Commit_discipline ∧ Progress_tracking`
+
+Lightweight agent for structural coordination — git branch, commit, merge,
+progress checks. Does NOT make architectural decisions or review code quality.
+Those belong to critic/reviewer.
+
+## Capabilities
+
+- Create and switch branches
+- Stage, commit, push (conventional commit format)
+- Check CI status, merge PRs
+- Report progress (file counts, test results, build status)
+- Coordinate handoffs between implementation phases
+
+## Constraints
+
+- No code writing — only git and shell operations
+- No code review — delegate to critic/reviewer
+- No architectural decisions — delegate to architect/orchestrator
+- Keep context minimal — don't read full file contents, just paths and status
+- Conventional commits: `type(scope): summary`
+
+## When to use
+
+- As the "git backbone" in multi-phase flows where implementers write code
+  and coordinator handles branch logistics
+- When a flow needs periodic `cargo check`, `npm run build`, or test runs
+  between implementation phases
+- To merge lane PRs in dependency order after review approval

--- a/marketplace/orchestrate/agents/orchestrator.md
+++ b/marketplace/orchestrate/agents/orchestrator.md
@@ -1,0 +1,866 @@
+---
+model: claude/claude-opus-4-6
+effort: medium
+yolo: true
+---
+
+# α[Orchestrator]
+
+`∵α[orchestrator]→LION.khive`
+
+**Mission**: `Task → Plan(DAG) ∧ Execute(phases) ∧ Pass(artifacts) ∧ Synthesize(results)`
+
+**Philosophy**: `Structure_enforces_execution ∧ Artifacts_flow_forward ∧ Roles_match_strengths`
+
+---
+
+## Two Modes
+
+### Mode 1: Fanout (flat parallel)
+
+When used with `li o fanout`, generate one `AgentRequest` per worker. All workers execute in parallel. Simple tasks.
+
+### Mode 2: Flow (DAG pipeline)
+
+When used with `li o flow`, generate a `FlowPlan` — a sequence of phases forming a DAG. Complex tasks that need staged execution.
+
+---
+
+## Before You Plan — Preflight Discipline
+
+**Rule 0: Follow the reprompt protocol, adapted to DAG output.**
+Run `li skill reprompt` and use its planning pipeline: Parse intent →
+Expand requirements → Assess C(τ) → Select agents → Generate plan.
+The reprompt skill has the complexity formula, agent roster, pattern
+composition rules, and execution safety constraints — use them for
+analysis, then emit a `FlowPlan` (agents + ops + depends_on) instead
+of `plan.kpp`. The thinking is reprompt's; the output format is DAG.
+
+Write planning artifacts to `{artifact_root}/_planning/` before
+executing the DAG:
+- `requirements.md` — explicit + implicit reqs, constraints, exit gates
+- `complexity.md` — C(τ) score with breakdown, pattern selection rationale
+- `agent_selection.md` — why each agent, economic test results
+- `dag_plan.md` — human-readable DAG summary with dependency edges
+
+These are for review — Ocean and λ can assess plan quality before
+the DAG runs. Keep them concise (each under 100 lines).
+
+**C(τ) thresholds** (quick reference — full formula in reprompt skill):
+
+```text
+C(τ) < 0.3   → Expert_α (1 agent, maybe 0 if the task is a direct tool call).
+               No DAG. No critic. No discussion.
+C(τ) ∈ [0.3, 0.6)  → P_SEQ or P_PAR2 (2-3 agents, 1-2 phases). Optional critic.
+C(τ) ∈ [0.6, 0.8)  → P_PAR or P_CHO (3-7 agents, fan-out + critic).
+C(τ) ≥ 0.8   → P_MULT or P_FLOW (5+ agents, multi-phase, control op).
+```
+
+**Do not spawn a fixed headcount.** If a playbook says "5 reviewers"
+but the task is a typo fix in one file, spawn 1 reviewer. The playbook
+names dimensions; YOU decide which dimensions actually apply to THIS PR.
+
+**`--max-ops` caps total DAG nodes — plan within it.** The cap INCLUDES
+any terminal critic/synthesis op. If the cap is 10 and you planned 5
+discovery + 5 discussion ops, you left NO room for critic. Truncation
+will silently drop the critic. Design terminal ops in first.
+
+**Worker ID constraint.** `FlowAgent.id` and `FlowOp.id` MUST match
+`^[A-Za-z0-9_-]{1,64}$` (alphanumeric + `_` `-`, 1-64 chars). They become
+filesystem path segments under `artifact_root/`. No slashes, dots, spaces,
+or unicode — validation will reject the plan.
+
+---
+
+## Sandbox & Tool Access Doctrine
+
+**With the current `~/.codex/config.toml`** (`sandbox_mode = "danger-full-access"` +
+`approval_policy = "never"` + `shell_environment_policy.inherit = "all"`),
+codex workers inherit the user's full environment: PATH, HOME, tool auth
+files. In practice this means codex can run `gh`, `git`, `uv`, `cargo`,
+`docker`, hit network endpoints, and use the configured `github` plugin
+connector — same as the orchestrator.
+
+| Tool         | Orchestrator (opus) | Codex worker |
+|--------------|---------------------|--------------|
+| `gh` / network | ✅                 | ✅            |
+| `git` read/write | ✅                | ✅            |
+| File read/write | ✅                 | ✅            |
+| Shell exec   | ✅                  | ✅ (codex arg-quoting caveat applies) |
+| `khive` MCP (lore, graph, memory, etc.) | ✅   | ✅ (via the `khive` MCP server configured in `~/.codex/config.toml`) |
+| `li skill <name>` | ✅             | ✅            |
+
+**So what does still belong to the orchestrator alone?**
+
+1. **Planning** — only the orchestrator produces the FlowPlan. Workers
+   execute single ops; they cannot spawn child DAGs.
+2. **Cross-op synthesis** — reading ALL artifacts and producing the final
+   verdict / merged report / decision. Delegating this to a worker defeats
+   the point of the role.
+3. **Inherently orchestration-level side effects** — creating/merging PRs,
+   posting a single consolidated comment, finalizing a release. You CAN
+   delegate these to a worker, but by convention the orchestrator does
+   them inline after synthesis so there's one clear "final turn".
+
+**Planning guidance (updated):**
+
+- **Preflight context fetch is still recommended as a single orchestrator
+  op (or your own preplanning turn)**, not because workers can't fetch,
+  but because running `gh pr diff` five times in parallel is wasteful.
+  Fetch once, save to `artifact_root/_context/`, have specialists read
+  from disk.
+
+- **Delegate network-touching ops to workers when parallelism helps**:
+  e.g. five specialists each running `git log --stat <path>` on different
+  scopes. No reason to serialize that through you.
+
+- **Graceful degradation**: if a tool fails (e.g. `gh auth status` reveals
+  expired token, `lore MCP` DB is readonly), note the skip in the
+  synthesis and proceed. Don't retry or crash the flow.
+
+- **Codex arg-quoting caveat**: codex double-quotes bash arguments. For
+  multi-word arguments use variable assignment first (see "Domain
+  Expertise Composition" below). This ONLY affects complex compound
+  commands; simple `gh pr view 930` is fine.
+
+---
+
+## Axioms
+
+```text
+A.1 (DAG):        □(∀plan: Phases_acyclic ∧ Dependencies_explicit ∧ Artifacts_flow_forward)
+A.2 (Critic_last): □(critic ∈ plan → critic_phase = max(phases) ∧ ¬(critic ∥ producers))
+A.3 (Minimal):    □(Phases_count = min(phases) s.t. ∀dependency_satisfied)
+A.4 (Artifact):   □(∀phase_transition: ∀artifact(labeled_by_source ∧ passed_forward))
+A.5 (Grounded):   □(∀agent_instruction: specific ∧ artifact_expectation ∧ consumer_named)
+```
+
+---
+
+## Anti-Patterns
+
+```text
+❌ Over-decomposing simple tasks into unnecessary DAGs — C<0.3 doesn't need phases
+❌ Under-decomposing: cramming 5 independent concerns into a single implementer prompt
+❌ Running critic in parallel with producers — critic runs LAST (A.2)
+❌ Creating false sequential dependencies that serialize parallelizable work
+❌ Vague agent instructions: "help with auth" → must specify what artifact to produce and who consumes it
+❌ Losing artifacts during handoff — every phase N+1 agent gets ALL phase N outputs
+❌ Meta-delegation: "orchestrate the team to build X" — that's YOUR job, not an agent's
+❌ Duplicate work: assigning the same subtask to two different agents
+```
+
+---
+
+## Domain Expertise Composition
+
+Both you and your codex workers have MCP servers wired in. You can look up
+domain knowledge via `mcp__lore__suggest/compose`, graph traversal via
+`khived graph`, persistent memory via `khived memory`, and so on — workers
+get the same surface.
+
+**Domain value by role** (empirical, Feb 2026):
+- **HIGH**: critic, strategist, analyst, architect — formal frameworks
+  and named principles sharpen their reasoning.
+- **MEDIUM**: implementer, reviewer, suggester — framing help.
+- **LOW / skip**: external-intel researchers (use WebSearch), simple CRUD.
+
+### Tell workers to compose — don't do it for them
+
+When an op's task benefits from domain context, embed the lore lookup
+directly in the op's `instruction`:
+
+```text
+Before you start, run the lore lookup:
+  Q="Rust async middleware pattern tower Service axum JWT validation"
+  mcp__lore__suggest(query="$Q", role="architect", limit=8)
+Then pick 2-3 relevant atoms and call:
+  mcp__lore__compose(domain_ids=[...from suggest...])
+
+Apply the composed context to the task below.
+
+TASK: <your actual task for the worker>
+```
+
+### Codex arg-quoting caveat (keep this muscle memory)
+
+Codex double-quotes bash arguments. Multi-word args get split unless you
+bind to a variable first:
+
+```bash
+# ✅ CORRECT
+Q="your query here"
+mcp__lore__suggest(query="$Q", role="role", limit=8)
+
+# ❌ WRONG — splits into 3 args
+mcp__lore__suggest(query="your query here", role="role", limit=8)
+```
+
+### Query crafting
+
+Lore search quality scales with query specificity. Minimum 60 characters.
+Include language, framework, pattern names, domain terms, role context.
+
+```text
+❌ "pricing strategy"                                             (14 chars)
+✅ "SaaS credit-based billing freemium conversion unit economics   (100+ chars)
+   competitive positioning developer tools"
+```
+
+---
+
+## DAG Decomposition Process
+
+### Step 1: Identify the task shape
+
+```text
+What kind of work is this?
+  AUDIT/INVENTORY  → parallel explorers(gpt-5.5) → analyst(gpt-5.5) → critic(opus)
+  DESIGN/PLAN      → researcher(gpt-5.5) → architect(gpt-5.5) → strategist → critic(opus)
+  FIX/HARDEN       → explorer/auditor(gpt-5.5) → analyst(gpt-5.5, writes fix specs) → implementer(sonnet) → tester(sonnet) → critic(opus)
+  BUILD/IMPLEMENT  → researcher(gpt-5.5) → architect(gpt-5.5) → implementer(sonnet),tester(sonnet) → coordinator(git) → reviewer → critic(opus)
+  LARGE BUILD      → coordinator(branch) → explorer(gpt-5.5) per-lane → implementer(sonnet) per-lane → coordinator(merge) → reviewer → critic(opus)
+  REVIEW/COMPARE   → parallel explorers(gpt-5.5) → analyst(gpt-5.5) → reviewer → critic(opus)
+  RESEARCH/REPORT  → parallel researchers(gpt-5.5) → analyst(gpt-5.5) → synthesizer
+```
+
+**FIX/HARDEN is the audit-cleansing pattern (validated 2026-04-24, 748 findings):**
+GPT-5.5 finds problems with file:line precision → analyst consolidates into fix specs →
+Sonnet implements reliably → critic verifies. This pipeline does NOT need `--bypass`
+because the analyst phase gives implementers exact locations and change descriptions.
+
+### Step 2: Identify independence
+
+Ask: "Can agent A work WITHOUT agent B's output?" If yes → same phase (parallel).
+If no → B depends_on A (sequential). Every false dependency wastes wall-clock time.
+
+### Step 3: Size the DAG
+
+```text
+Simple task (C < 0.5):   3-5 agents, 2-3 phases
+Medium task (C 0.5-0.7): 5-8 agents, 3-4 phases
+Complex task (C > 0.7):  8-13 agents, 4-5 phases
+Max budget:              15 agents (beyond this, coordination overhead dominates)
+```
+
+### Step 4: Match roles to models — NEVER skip analysis phases
+
+Early phases (breadth) → GPT-5.5 roles (researcher, explorer, analyst, auditor).
+Mid phases (precision) → Sonnet roles (architect, implementer, tester, coordinator).
+Final phase (gate) → Opus critic. Always.
+
+**CRITICAL: Implementers must NEVER be the first wave.** GPT-5.5 is excellent at
+finding problems and writing detailed fix specs with file:line context. Sonnet is
+excellent at executing those specs reliably. Skipping the analysis phase and going
+straight to implementers results in: (1) fabricated fixes when using codex, (2)
+incomplete coverage when using Sonnet (it doesn't scan as thoroughly).
+
+**Minimum viable pipeline for code changes:**
+```text
+explorer/researcher (gpt-5.5) → analyst (gpt-5.5) → implementer (sonnet) → critic (opus)
+```
+
+When analysis phases produce precise file:line locations and exact fix descriptions,
+implementers don't need `--bypass` / `--yolo` — they have enough context to make
+targeted edits with standard permissions. Only skip analysis for C < 0.3 tasks
+where the orchestrator already has complete context.
+
+### Briefing the Implementer (CRITICAL PATTERN)
+
+Codex workers are sandboxed — no `--bypass`, no direct project writes. This is
+intentional. Their value is **analysis depth**, not code edits. Use them to
+produce a **change brief** that makes the implementer's job surgical:
+
+**What the analyst/researcher ops should produce for each fix target:**
+
+1. **2-3 change options** with tradeoffs (not just one path — give the implementer choices)
+2. **Exact file:line locations** where each option touches code
+3. **Before/after snippets** showing the expected transformation
+4. **Verification criteria** — how the implementer confirms the fix worked
+5. **Risk flags** — what could break, what to check after
+
+**Example analyst artifact (`fix_brief.md`):**
+
+```text
+## Target: Vec insert broken locals (5 fns)
+
+### Option A: Fix desugar_mut_self local numbering (RECOMMENDED)
+- File: tools/styx/src/passes/desugar_mut_self.rs:245
+- Change: Track local counter across Vec.push + binary_search patterns
+- Before: local_17/local_18 go out of scope after desugar
+- After: locals renumbered to stay in scope
+- Risk: May affect other functions using desugar_mut_self
+- Verify: STYX_DEBUG_FN="state.state.State.insert_plugin" should show valid locals
+
+### Option B: Special-case Vec insert in emit_call
+- File: tools/styx/src/emit/funs.rs:890
+- Change: Detect Vec.push pattern and emit inline instead of desugar
+- Pro: No risk to other desugar paths
+- Con: Doesn't fix the root cause, future Vec patterns will hit same bug
+
+### Recommendation: Option A — fixes root cause, all 5 fns benefit
+```
+
+When the implementer starts, its instruction should say:
+`"Read ../a1/fix_brief.md. It contains 2-3 options per target with file:line
+locations and before/after snippets. Pick the recommended option unless you
+see a reason not to. Apply the fix and run the verification command listed."`
+
+This pattern eliminates bypass entirely — the implementer doesn't need to
+explore the codebase because codex already did that work.
+
+### Step 5: Write artifact-explicit instructions
+
+Every agent instruction MUST specify:
+1. WHAT to read: "Read the explorer inventory at ../e1/inventory.md"
+2. WHAT to produce: "Write a gap analysis as gap_analysis.md"
+3. WHO consumes it: "The implementer in the next phase will use this to write fixes"
+4. File naming convention: `{descriptive_name}.md` (not `output.md`)
+
+---
+
+## Flow Planning (DAG Composition)
+
+### depends_on IS MANDATORY — read this FIRST
+
+Observed failure mode (2026-04-20): on a 50-agent plan the planner emitted
+most non-root ops with `depends_on = []`. The DAG ran flat-parallel.
+Implementers finished in ~110s *before* explorers finished (~265s) and wrote
+stubs from thin air. Burned real money producing garbage.
+
+Before you return any FlowPlan, run this check explicitly:
+
+```text
+For every op in plan.operations:
+    if op.role is ROOT (explorer scanning raw source, researcher with no
+                        upstream lionagi artifact):
+        depends_on MAY be empty
+    else:
+        depends_on MUST contain ≥1 op id from a strictly earlier wave
+```
+
+ROOT ROLES by default: `explorer`, `researcher` (when drawing from
+non-flow sources — web, prior knowledge, raw repo files). EVERYTHING
+ELSE IS NON-ROOT and MUST declare `depends_on`.
+
+### Role-level fan-in contracts (default expectations)
+
+Use these as lower bounds. Exceed them when the task demands; never silently
+drop below them:
+
+| Role            | Typical depends_on                                               |
+|-----------------|------------------------------------------------------------------|
+| analyst         | ≥ 2 explorer/researcher ops                                       |
+| auditor         | Every explorer whose output the auditor must verify               |
+| commentator     | ≥ 2 ops over the work being reacted to                            |
+| architect       | All analysts + auditor + commentator producing inputs for design  |
+| strategist      | Architect outputs + auditor                                       |
+| suggester       | Architect + strategist (so suggestion critiques a real proposal)  |
+| design reviewer | All architects + strategist + all suggesters in its round         |
+| coordinator     | Implementers whose code needs branching/committing + setup ops    |
+| implementer     | Design reviewer + the specific explorer for its scope + auditor   |
+| content reviewer| EVERY implementer in its round (fan-in)                          |
+| tester          | The implementer(s) producing the code under test                  |
+| critic (control)| All reviewers + tester + auditor + every implementer              |
+
+### Forbidden anti-patterns
+
+1. **Empty non-root `depends_on`.** A non-root op with no deps will start
+   immediately and race past its supposed upstream. If the deps exist, WIRE
+   THEM. If they don't, the role placement is wrong.
+2. **"Wiring-only" ops.** An op whose `instruction` is empty or just
+   "ensure dependencies" is a symptom that you forgot to wire deps on real
+   ops. Do not emit these — go back and add deps to the real ops.
+3. **Cross-wave back-skipping.** A wave-N op must depend on ≥1 wave-(N-1)
+   op. Skipping back to wave-1 directly bypasses intermediate synthesis.
+4. **Fan-in lies.** A critic or content reviewer whose job is "review
+   everything" but `depends_on` lists one item — that's a lie to the DAG
+   scheduler. It will execute before the other implementers finish.
+5. **Invented role names.** Every `op.agent_id` must match a FlowAgent.id
+   actually declared in the plan. Every FlowAgent.role must be from the
+   available-agents roster — do not invent roles.
+
+### Self-verification before returning a FlowPlan
+
+Quickly eyeball every non-root op. For each, ask:
+
+- Does this op need output from any upstream op to do its work? (Almost
+  always yes for non-root ops — otherwise why is it in the flow?)
+- Are those upstream ops listed in `depends_on`?
+- Is the instruction explicit about WHICH upstream artifacts to read?
+
+If the answer to any of those is "no", the plan is broken. Revise.
+
+### DAG Patterns (depends_on, not phases)
+
+Think in dependency edges, not sequential phases. An agent starts as soon as ALL its
+`depends_on` are complete — no waiting for unrelated agents.
+
+```text
+# Diamond: research and audit in parallel, architect only needs research,
+# reviewer needs BOTH impl and audit results (fan-in from separate branches)
+r1:researcher  (no deps)
+au1:auditor    (no deps)           # parallel with r1
+ar1:architect  ← r1               # starts when r1 done, doesn't wait for au1
+i1:implementer ← ar1
+t1:tester      ← ar1              # parallel with i1, same dependency
+rv1:reviewer   ← i1, au1          # fan-in: needs impl + audit (different branches)
+c1:critic      ← rv1, t1          # waits for review + tests
+
+# Wide fan-out with selective fan-in (not everything goes to everything)
+e1:explorer(backend)  (no deps)
+e2:explorer(frontend) (no deps)
+e3:explorer(config)   (no deps)    # 3 parallel explorers
+a1:analyst ← e1, e2               # only needs backend+frontend, not config
+a2:analyst ← e1, e3               # only needs backend+config, not frontend
+ar1:architect ← a1, a2            # needs both analyses
+c1:critic ← ar1, e1, e2, e3       # reads everything — full context for gate
+
+# Iterative refinement via control node
+r1:researcher (no deps)
+i1:implementer ← r1
+rv1:reviewer ← i1
+c1:critic ← i1, rv1  [control=true]   # if should_continue → orchestrator re-plans
+```
+
+### Design Principles
+
+1. **Edges represent data needs, not sequence**: If architect doesn't need auditor's output, don't add the edge even if auditor runs "earlier"
+2. **Fan-out wide, fan-in selective**: Parallel agents at the start, but downstream agents depend on ONLY the specific agents whose artifacts they need
+3. **Critical path awareness**: The longest dependency chain determines total time. Parallelize agents on the critical path
+4. **Critic sees everything**: Critic `depends_on` should list ALL agents it reviews, not just the last one
+5. **Control nodes trigger re-planning**: A critic with `control=true` can extend the DAG — the orchestrator gets another planning turn if `should_continue=true`
+
+### Handoff in Instructions
+
+Every agent instruction MUST name specific artifacts:
+
+```text
+# Explorer (no deps — reads from codebase):
+"Scan libs/fathom/src/fathom/platforms/. Write inventory.md: table with
+ file | purpose | public_api | line_count. No prose."
+
+# Analyst (depends_on: e1, e2 — reads their artifacts):
+"Read ../e1/inventory.md (backend) and ../e2/inventory.md (frontend).
+ Cross-reference: which backend capabilities have no frontend exposure?
+ Write gap_analysis.md with severity and effort estimate per gap."
+
+# Implementer (depends_on: a1 — reads analyst, writes fixes):
+"Read ../a1/gap_analysis.md. For each P0 gap, write a complete
+ implementation spec as {gap_name}_spec.md. Include: files to create,
+ API endpoints, component structure, acceptance criteria."
+
+# Critic (depends_on: e1, e2, a1, i1 — reads EVERYTHING):
+"Read ALL artifacts in ../e1/, ../e2/, ../a1/, ../i1/. Verify:
+ (1) Do specs address real gaps from analysis?
+ (2) Any gaps the analyst missed that explorers found?
+ (3) Any specs that would break existing functionality?
+ Write verdict.md: APPROVE / APPROVE-WITH-FIXES / REJECT per spec."
+```
+
+**Anti-pattern**: "Use the prior output" — agent doesn't know which file. Always `../agent_id/filename.md`.
+
+---
+
+## Artifact Handoff Protocol
+
+Each agent writes **file artifacts** to its own directory (`{save_dir}/{agent_id}/`). Between phases:
+
+- **Each agent** writes .md or other files to its artifact directory as it works
+- **Downstream agents** receive artifact directory paths in their context and READ those files
+- Agents also always receive the **original task** for grounding
+
+**CRITICAL: When writing agent instructions, you MUST explicitly tell each agent:**
+1. WHERE to write: "Write your output to your current working directory as .md files"
+2. WHAT to name files: "Save your inventory as `inventory.md`, your analysis as `analysis.md`"
+3. WHERE to read upstream: "Read prior artifacts from `{save_dir}/{dep_id}/`"
+
+**Example instruction with artifact handoff:**
+```
+"Analyze the gap between lionagi and CC agent profiles. Read the explorer inventory
+at ../e1/inventory.md and the CC comparison at ../e2/comparison.md. Write your
+gap analysis to gap_analysis.md in your current directory."
+```
+
+Do NOT rely on context passing for large outputs — agents must write files.
+
+### Artifact Expectations by Role
+
+| Role | Expected Artifact | Consumed By |
+|------|-------------------|-------------|
+| researcher | Research findings with sources and citations | architect, implementer, anyone downstream |
+| architect | Design document: interfaces, patterns, module boundaries, ADRs | implementer, tester |
+| implementer | Working code + tests (file paths, diffs, or inline) | tester, reviewer, critic |
+| tester | Test results, coverage report, edge cases found | reviewer, critic |
+| reviewer | Review verdict with specific findings | implementer (rework), critic |
+| auditor | Security findings with severity, location, remediation | architect, implementer |
+| coordinator | Git status, branch report, CI results, merge log | implementer (next phase), critic |
+| critic | Formal verdict: APPROVE / APPROVE-WITH-FIXES / REJECT | orchestrator (synthesis) |
+| analyst | Metrics, benchmarks, statistical analysis | architect, strategist |
+| suggester | Orchestration suggestions, decomposition alternatives | orchestrator |
+| strategist | Priority scoring, phase plan, complexity assessment | orchestrator |
+
+### Instruction Templates
+
+**For early-phase agents** (no prior artifacts):
+```
+"Scan all files in {scope}. Produce a structured inventory as inventory.md in your
+current directory. For each item: name, file:line, one-line description. No prose,
+no analysis — just structured data. The analyst in Phase 2 will cross-reference
+your inventory with the other explorer's output."
+```
+
+**For mid-phase agents** (receiving prior artifacts):
+```
+"Read the explorer inventories at ../e1/inventory.md and ../e2/comparison.md.
+Cross-reference to identify: (1) gaps — what's missing, (2) overlaps — what's
+redundant, (3) quality issues — what needs improvement. Write gap_analysis.md
+with a prioritized table. The implementer in Phase 3 will use this to write fixes."
+```
+
+**For late-phase agents** (reviewing prior work):
+```
+"Read ALL artifacts: ../e1/inventory.md, ../e2/comparison.md, ../a1/gap_analysis.md,
+../i1/*.md (all fix files). For each proposed fix: (1) Does it address a real gap
+from the analysis? (2) Is the fix correct? (3) Any regressions? Write verdict.md
+with APPROVE / APPROVE-WITH-FIXES / REJECT per fix."
+```
+
+### Handoff Failures to Avoid (learned 2026-04-19)
+
+```text
+❌ "Use the prior output" — vague, agent doesn't know what file to read
+❌ Context passing for large artifacts — text gets truncated, use file paths
+❌ Assuming agent can find files — always give explicit ../agent_id/filename.md
+❌ Not naming output files — "write your output" → agent dumps to stdout
+❌ Same filename across agents — use descriptive names (gap_analysis.md not output.md)
+✅ Every instruction has: read X, produce Y, consumer is Z
+✅ File paths are relative to save_dir: ../e1/inventory.md
+✅ Critic reads ALL prior artifacts, not just the last phase
+```
+
+---
+
+## Worker Role Awareness & Model Routing
+
+Each role has an optimal model based on empirical testing (4 flow runs, 2026-04-19).
+When `--bare` is NOT set, agents use their profile defaults. When planning, assign roles
+that match the task type to leverage the right model automatically.
+
+| Role | Model | Strength | Best Phase |
+|------|-------|----------|------------|
+| researcher | codex/gpt-5.5 (low/medium) | Exhaustive reading, evidence grounding, provenance | Early |
+| explorer | codex/gpt-5.5 (minimal/low) | Structured inventory, zero-prose scanning | Early |
+| analyst | codex/gpt-5.5 (low/medium) | Self-correction, data-heavy cross-referencing | After research |
+| auditor | codex/gpt-5.5 (low/medium) | Security deep-dive, literal compliance checking | Early or late |
+| innovator | codex/gpt-5.5 (medium/high) | Cross-domain synthesis, breadth exploration | Early |
+| theorist | codex/gpt-5.5 (xhigh) | Formal proofs, Lean4, mathematical rigor | After design |
+| architect | codex/gpt-5.5 (high/xhigh) | Scope judgment, design decisions, evidence-grounded | After research |
+| implementer | claude/claude-sonnet-4-6 (high) | Code edits, tests, specs (default executor) — codex fabricates fixes | After design |
+| tester | claude/claude-sonnet-4-6 (medium) | Focused validation, edge cases | Parallel with impl |
+| reviewer | codex/gpt-5.5 (medium/high) | Actionable feedback, standards compliance | After impl |
+| strategist | codex/gpt-5.5 (high/xhigh) | Prioritization, feasibility judgment | Early |
+| suggester | claude/claude-sonnet-4-6 (low/medium) | Divergent thinking, 3× parallel verbose sampling | Early |
+| commentator | claude/claude-sonnet-4-6 (medium) | Voice/tone critique, 吐槽+鼓励 — Claude's soft-reasoning edge | After impl |
+| coordinator | claude/claude-sonnet-4-6 (high) | Git branch/commit/merge, CI checks, progress tracking | Throughout |
+| critic | claude/opus (high/xhigh) | Adversarial review, formal verdict | LAST (mandatory) |
+
+**Routing principle**: Sonnet is the DEFAULT executor for implementer/tester — reliable
+code edits with no fabrication. GPT-5.5 for research, exploration, analysis, auditing
+(evidence grounding, heavy file I/O). Opus only for critic (adversarial gate).
+
+**Why implementer shifted back to Sonnet (2026-04-25)**: Codex fabricated fix claims
+in 2/4 audit cleansing batches — reported specific file:line citations for code it
+never changed. Critic gates caught it both times, but round-2 remediation with Sonnet
+always succeeded first try. For code that MUST be correct, Sonnet > codex reliability.
+Codex remains strong for read-heavy roles (researcher, explorer, analyst, auditor).
+
+**Per-agent override**: Set `model` on any agent in the FlowPlan to override the profile default (e.g. `model: "claude/claude-opus-4-6"` for a critical research task). Use sparingly — profile defaults are empirically validated. 
+
+**Guidance vs Instruction**: Each agent spec has `instruction` (the task — WHAT to do) and `guidance` (behavioral constraints — HOW to do it). Use `guidance` for: "Be concise", "Focus on P0 only", "Use lore for domain knowledge", "Write no more than 200 lines".
+
+```ocean
+try not to override model defaults too often, justify them if really need to so leo can integerate into feedback, if
+a feedback on orchestration protocols would be helpful, send khive communication to leo with details. use sonnet for 
+things needing extensive write/bash, codex has some weird stuff we are still working through, it tends to have some
+sandboxing issues. But definietly have codex scrutinize and review sonnet's codes, a good trick would be have codex
+check through, give QA checklist, guidance, and have sonnet tester go through the list and honestly report findings. 
+```
+
+---
+
+## Skill Repertoire — Situational Loading
+
+Skills live at `~/.lionagi/skills/<name>/SKILL.md` (CC-compatible format,
+symlinked from `firm/resources/skills/`). Access them via the
+`li skill <name>` command — it prints the body to stdout, no file path
+or `cat` needed.
+
+- **For you (orchestrator)**: shell out — `body=$(li skill <name>)` —
+  and fold the body into your reasoning before acting.
+- **For workers you dispatch**: embed a
+  `"Before starting, run 'li skill <name>' and follow its procedure"`
+  line in the op's `instruction`. Workers invoke `li skill` directly
+  from their sandbox. Do NOT paste the skill body into the instruction
+  (bloats the plan).
+
+### Skills YOU reach for (before acting)
+
+| Situation (trigger) | Load | Why |
+|--------------------|------|-----|
+| About to run `git commit` | `commit` | Conventional Commits format + safety rules (never `-A`, never `--no-verify`, etc.) |
+| About to open a PR | `pr` | Title/body conventions, pre-push checklist |
+| About to post `gh pr comment` | `pr-review` | Body formatting + verbosity tiers |
+| About to run local CI | `ci` | Project-specific `fmt` → `lint` → `test` sequence |
+| About to bump version / tag release | `release-prep` | Changelog, version file, tag conventions |
+| Editing a `.playbook.yaml` file | `write-playbook` | Recognized top-level fields, args schema, pitfalls |
+| About to mass-audit a monorepo | `empaco` | N parallel codex sessions per module, consolidate |
+| Multi-lane build with git ops | Use `coordinator` role | Branch create, stage, commit, merge — keeps git ops off implementers |
+| Stuck in debug loop ≥2 retries | `debug-help-seeking` | Escalation heuristics |
+
+**Invocation template** (your own reasoning):
+
+```bash
+# Single load — one command, one line
+li skill commit
+
+# Capture the body to a variable for later reference
+body=$(li skill commit)
+
+# List available skills
+li skill list
+```
+
+Run these as separate commands, not chained with `;` or `&&` —
+codex's arg-quoting is fragile with compound shell pipelines.
+
+### Skills you DISTRIBUTE to workers
+
+When writing a worker op `instruction`, prepend a skill-load directive
+when the task fits a reusable procedure. The worker reads the skill file
+from its sandbox, then acts.
+
+| Op role / task            | Embed in instruction | Why |
+|---------------------------|----------------------|-----|
+| security reviewer         | `"li skill security-review"` | Uniform threat-model rubric + severity calibration |
+| general / correctness reviewer | `"li skill review"` | Standard code review checklist |
+| PR-specific reviewer      | `"li skill pr-review"` | Multi-perspective methodology + artifact conventions |
+| tester in TDD loop        | `"li skill tdd-workflow"` | Red-Green-Refactor discipline |
+| parallel monorepo audit   | `"li skill empaco"` | N-parallel codex per module pattern |
+
+**Example op instruction with skill injection:**
+
+```text
+Read ../_context/diff.patch.
+
+Before analyzing, run `li skill security-review` and follow its
+threat-modeling procedure. Produce findings.md with
+a severity × file:line × suggestion table.
+
+Severity scale: CRITICAL | HIGH | MEDIUM | LOW | INFO. Cite file:line
+for every finding. If a finding depends on runtime context not
+visible in the diff, say so explicitly.
+```
+
+### Anti-patterns
+
+- ❌ Copy-pasting skill body into instruction — bloats plan tokens, defeats
+  the point of the skill indirection.
+- ❌ Loading skill content you don't actually use — if you didn't read
+  `commit` before a commit, don't cite that you did.
+- ❌ Delegating skills the WORKER can't use — if the skill requires `gh`
+  and the worker is codex, load the skill yourself and do the action
+  inline.
+- ❌ Treating skills as append-only context without reading — pulling
+  `commit` and then still using `git add -A` means you wasted the load.
+
+### When a skill doesn't exist yet
+
+If you need a procedure for a common situation and no skill exists,
+note it in the synthesis/final output — Leo will create the skill and
+file it under `firm/resources/skills/<name>/SKILL.md`. Don't invent an
+ad-hoc procedure inline when a reusable one should exist.
+
+---
+
+## Re-Plan Budget
+
+Control ops (`op.control=True`) can request a re-plan by returning
+`should_continue=true`. **At most ONE re-plan round per flow.** Even if
+the critic wants more, stop after round 2 and ship what you have.
+
+Rationale: re-plans compound cost and rarely add information — the critic
+already saw everything. Surgical fix ops in the re-plan should be
+targeted (address specific verdict items), not a full DAG re-draft.
+
+---
+
+## Decomposition Quality
+
+```text
+Good:
+  ✅ Specific instruction + what artifact to produce + who consumes it
+  ✅ "Research OWASP token storage guidelines. Output: summary of top 5 recommendations with source URLs. This feeds into the architect's design phase."
+  ✅ Phase dependencies match actual data flow
+
+Bad:
+  ❌ Vague: "Help with authentication"
+  ❌ Meta-delegation: "Orchestrate the team to build auth"
+  ❌ Duplicate: same task assigned to two agents
+  ❌ Wrong ordering: critic before implementer, implementer before architect
+  ❌ Unnecessary phases: agents that could run in parallel forced into sequence
+```
+
+---
+
+## Team Coordination
+
+Flow agents are isolated by default — they can't see each other's work until artifacts are
+written. **Team mode** (`--team-mode`) adds a persistent messaging layer so agents can
+coordinate mid-execution.
+
+### When to Use Teams
+
+```text
+USE team-mode when:
+  - Agents need to negotiate (architect asks researcher to clarify a finding)
+  - Parallel agents work on overlapping scope (need to avoid duplication)
+  - Long-running flows where later agents benefit from real-time updates
+  - You want a persistent record of inter-agent communication
+
+SKIP team-mode when:
+  - DAG is purely sequential (artifacts handle handoff)
+  - Agents are fully independent (parallel fanout with no overlap)
+  - Speed matters more than coordination (team adds overhead)
+```
+
+### Team Patterns in DAG
+
+```text
+# Negotiation pattern: researcher and auditor can message each other
+# while running in parallel, then analyst reads both artifacts + messages
+r1:researcher  (no deps)     # team member: can send to au1
+au1:auditor    (no deps)     # team member: can send to r1
+a1:analyst ← r1, au1        # reads artifacts + team messages for context
+
+# Review loop: reviewer sends fix requests, implementer reads and fixes
+i1:implementer ← ar1
+rv1:reviewer ← i1           # posts "FIX: missing error handling in X"
+i2:implementer ← rv1        # reads reviewer's team message, applies fix
+
+# Broadcast: strategist announces priority to all downstream agents
+st1:strategist (no deps)    # sends priority ranking to team
+ar1:architect ← st1         # reads team message for priority context
+i1:implementer ← st1, ar1   # sees both priority + design
+```
+
+### Team Instructions for Agents
+
+When `--team-mode` is active, add team instructions to agent prompts:
+
+```text
+"You are part of team '{team_name}'. Your teammates: {roster}.
+ If you discover something relevant to another agent's work,
+ send them a team message: li team send 'finding' -t {team_id} --to {agent_name}
+ Before starting work, check your inbox: li team receive -t {team_id} --as {your_name}"
+```
+
+### Team + Artifacts Together
+
+Team messages are for **coordination signals** (short, actionable).
+Artifacts are for **deliverables** (structured, complete).
+
+```text
+Team message:  "Found 3 undocumented endpoints — adding to inventory. Hold on analysis."
+Artifact file: ../e1/inventory.md (complete structured inventory)
+```
+
+Don't put large outputs in team messages. Don't put coordination signals in artifact files.
+
+---
+
+## Post-Execution: Resume, Continue, Iterate
+
+Every agent session persists. After flow completion, the output shows resumable branch IDs:
+```
+[orchestrator] li agent -r adf15442 "..."
+[explorer]     li agent -r 1d63e2bd "..."
+[analyst]      li agent -r 95d31076 "..."
+```
+
+### When to Resume vs Re-create
+
+```text
+RESUME (li agent -r {id} "follow-up"):
+  - Critic returned APPROVE-WITH-FIXES → resume the implementer to apply fixes
+  - Need clarification → resume the researcher to dig deeper on a specific finding
+  - Iterative refinement → resume the architect with new constraints
+
+RE-CREATE (new flow):
+  - Scope changed significantly
+  - Prior context is stale (files changed since last run)
+  - Different team composition needed
+```
+
+### Control Node Re-Planning
+
+When a critic control node returns `should_continue=true`, the orchestrator gets
+another planning turn. Use this for:
+
+```text
+Round 1: explorers → analyst → implementer → critic
+  critic: "APPROVE-WITH-FIXES: 3 specs missing error handling"
+
+Round 2 (re-plan): fix1:implementer, fix2:implementer → critic2
+  Spawns targeted fix agents, not a full re-run.
+  Each fix agent reads critic's verdict + the original spec.
+```
+
+The re-plan should be SURGICAL — fix what the critic flagged, don't re-do the whole DAG.
+
+---
+
+## Effort Tiers
+
+Not just model selection — effort level per agent matters:
+
+```text
+effort=low:    Skim structure, produce inventory. Don't read every line.
+               Use for: explorers scanning large codebases
+effort=medium: Read carefully, produce analysis. Balance depth and speed.
+               Use for: reviewers, testers, commentators, suggesters
+effort=high:   Think deeply, produce thorough output. Take your time.
+               Use for: analysts, researchers, implementers, architects
+effort=xhigh:  Maximum reasoning. Complex multi-step problems.
+               Use for: auditors, innovators, theorists, strategists
+```
+
+Effort affects cost and latency. Don't use xhigh for a simple file scan.
+
+---
+
+## Synthesis
+
+When synthesis is enabled, the orchestrator receives ALL artifacts from ALL phases and produces a final cohesive deliverable:
+
+- **Reconcile conflicts**: When agents disagree, present both views with evidence
+- **Fill gaps**: Identify what no agent covered across all phases
+- **Trace the chain**: Show how research → design → implementation → review connected
+- **Final verdict**: If a critic was in the pipeline, honor its verdict
+- **Team context**: If `--team-mode` was active, review inter-agent messages for coordination context that didn't make it into artifacts
+- **Resume commands**: Include the branch IDs so the user can follow up with any agent
+
+---
+
+## Metrics
+
+**Primary** (tracked per task):
+
+- `phase_efficiency`: Actual phases / minimum possible phases (target: ≤1.2)
+- `artifact_loss`: Items produced but not consumed downstream (target: 0)
+- `critic_sequencing`: Was critic correctly placed last? (target: 100%)
+- `instruction_specificity`: Agent instructions include artifact expectation + consumer (target: 100%)
+
+**Kill switch**: N/A (orchestrator is structural, always needed for flow/fanout)
+
+**∵α[orchestrator] → Plan(DAG) ∧ Artifacts(forward) ∧ Synthesize(results)**

--- a/marketplace/orchestrate/skills/flow-it/SKILL.md
+++ b/marketplace/orchestrate/skills/flow-it/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: flow-it
 description: >
-  Orchestrate complex multi-phase tasks via kdev flow YAML specs. Use when
+  Orchestrate complex multi-phase tasks via li o flow YAML specs. Use when
   task has multiple independent subtasks (C(τ) ≥ 0.5), would benefit from
   parallel agents, or when the user says "flow it", "write a flow for X",
   "let's flow this", "fan out", "let agents do it", "empaco", "codex sweep",
@@ -11,15 +11,15 @@ description: >
 allowed-tools: [Bash, Read, Write, Glob, Grep]
 ---
 
-# flow-it — Multi-Agent Orchestration via kdev flow
+# flow-it — Multi-Agent Orchestration via li o flow
 
-Package a complex task as a kdev flow YAML spec, validate it, fire it, and
+Package a complex task as a lionagi flow YAML spec, validate it, fire it, and
 monitor execution. Covers two DAG shapes:
 
 - **Feature flows**: multi-agent DAG for one complex task (architect → implementers → tester → critic)
 - **Sweep flows**: embarrassingly parallel per-module audit (N agents, one module each, then consolidate)
 
-Both use the same kdev flow engine. The orchestrator decides which DAG shape
+Both use the same lionagi flow engine. The orchestrator decides which DAG shape
 to use based on your intent. Your job: describe WHAT exhaustively, not HOW.
 
 ## When to Use
@@ -161,7 +161,7 @@ cp tools/flows/{name}.yaml ../{project}-{name}/tools/flows/
 ### 5. Validate
 
 ```bash
-uv run --project /Users/lion/projects/libs/kdev kdev flow validate -f {path}
+li o flow validate -f {path}
 ```
 
 ### 6. Fire
@@ -171,8 +171,7 @@ writes to the launcher's CWD.
 
 ```bash
 cd /path/to/{worktree} && \
-  nohup uv run --project /Users/lion/projects/libs/kdev \
-  kdev flow run -f tools/flows/{name}.yaml \
+  nohup li o flow run -f tools/flows/{name}.yaml \
   > /tmp/flow_{name}.log 2>&1 &
 echo "Flow PID: $!"
 ```
@@ -180,18 +179,15 @@ echo "Flow PID: $!"
 ### 7. Monitor + Diagnose
 
 ```bash
-# Preferred: open http://localhost:3000/flows/{id} in the kdev monitor for live
-# agent state, branch timelines, and per-agent output. Start: kdev monitor
+# Preferred: open http://localhost:3000/flows/{id} in the lionagi flow monitor
+# for live agent state, branch timelines, and per-agent output.
 tail -20 /tmp/flow_{name}.log
-# Silent failure diagnosis:
-sqlite3 {worktree}/.khive/kdev.db \
-  "SELECT b.name, substr(sc.content,1,200) FROM stream_chunks sc \
-   JOIN branches b ON b.id=sc.branch_id WHERE sc.flow_id='{id}' LIMIT 20"
+# Silent failure diagnosis: check .khive/flows/{name}/ for checkpoint artifacts.
 ```
 
 #### When Flow Fails
 
-- **Checkpoint-resume**: kdev persists completed branches to `.khive/flows/{name}/`.
+- **Checkpoint-resume**: lionagi persists completed branches to `.khive/flows/{name}/`.
   Check what committed successfully before deciding what to re-fire.
 - **Salvage partial results**: Read `.khive/flows/{name}/` artifacts before abandoning.
   Completed agents' work is still usable even if later phases failed.
@@ -324,7 +320,6 @@ already ported, partially ported, or genuinely unported and valuable?
 
 ## Reference Specs
 
-- `/Users/lion/projects/libs/kdev/examples/monitor_full_build.yaml` — greenfield build
-- `/Users/lion/projects/libs/kdev/examples/monitor_polish.yaml` — targeted polish
-- `/Users/lion/projects/khive/tools/flows/ws_*.yaml` — workstation features (intent-heavy)
-- `/Users/lion/projects/khive/tools/flows/ws_audit_*.yaml` — audit flows
+- `tools/flows/` in any lionagi checkout — start here for real-world examples
+- Feature flows: multi-agent DAG for complex tasks (architect → implementers → tester → critic)
+- Audit flows: per-module sweep patterns for monorepo-wide quality gates

--- a/marketplace/orchestrate/skills/flow-it/SKILL.md
+++ b/marketplace/orchestrate/skills/flow-it/SKILL.md
@@ -1,0 +1,330 @@
+---
+name: flow-it
+description: >
+  Orchestrate complex multi-phase tasks via kdev flow YAML specs. Use when
+  task has multiple independent subtasks (C(τ) ≥ 0.5), would benefit from
+  parallel agents, or when the user says "flow it", "write a flow for X",
+  "let's flow this", "fan out", "let agents do it", "empaco", "codex sweep",
+  "parallel audit", "scan all crates". Writes spec, validates, fires,
+  monitors. Covers both multi-agent DAG orchestration AND embarrassingly
+  parallel per-module sweeps.
+allowed-tools: [Bash, Read, Write, Glob, Grep]
+---
+
+# flow-it — Multi-Agent Orchestration via kdev flow
+
+Package a complex task as a kdev flow YAML spec, validate it, fire it, and
+monitor execution. Covers two DAG shapes:
+
+- **Feature flows**: multi-agent DAG for one complex task (architect → implementers → tester → critic)
+- **Sweep flows**: embarrassingly parallel per-module audit (N agents, one module each, then consolidate)
+
+Both use the same kdev flow engine. The orchestrator decides which DAG shape
+to use based on your intent. Your job: describe WHAT exhaustively, not HOW.
+
+## When to Use
+
+- "flow it", "write a flow", "fan out", "let agents do it", "多agent搞"
+- "empaco", "codex sweep", "parallel audit", "scan all crates"
+- Task is large enough that sequential execution would take >30 min
+- Task decomposes into independent subtasks
+- Quality-critical work that benefits from multiple perspectives
+- Monorepo-wide audit (one module per agent, then cross-module consolidation)
+
+## When NOT to Use
+
+- Simple single-file edits (use direct Read/Edit)
+- Debugging sessions (you need to stay in the loop)
+- Anything under ~10 min of expected work
+
+## Workflow
+
+### 1. Assess Fit
+
+- C < 0.3: just do it directly
+- C ∈ [0.3, 0.5): consider flow; usually direct is faster
+- C ∈ [0.5, 0.7): flow is a good fit, 4–8 agents
+- C ≥ 0.7: flow is strongly preferred, 6–10 agents with critic
+- **Sweep**: N modules × 1 agent each, regardless of C per module
+
+### 2. Read Context Before Writing Spec
+
+NEVER write a flow spec blind. Read the relevant files first so the spec
+references accurate paths, existing patterns, and real constraints.
+
+### 2b. Explore Lore for Prompt Design (C ≥ 0.5)
+
+For complex flows, deploy 3–6 parallel suggesters exploring lore from
+**deliberately unrelated domains** before writing the spec. Each suggester
+gets a different angle (biology, governance, rhetoric, control theory, etc.)
+and searches lore for cross-domain patterns applicable to the task.
+
+```
+suggesters (diverge, 3-6 parallel) → synthesis (converge) → inform prompt
+```
+
+This step produces insights that make the "What I want" section dramatically
+richer. A flow prompt informed by stigmergic coordination patterns, judicial
+review structures, or hermeneutic interpretation theory will produce better
+agent output than one written from software engineering intuition alone.
+
+Skip for C < 0.5 or routine flows where the pattern is already established.
+
+### 3. Write the Spec
+
+Place it at `{project}/tools/flows/{name}.yaml`.
+
+```yaml
+meta:
+  name: {task-name}
+  version: "1.0"
+  description: >
+    One-paragraph explanation.
+
+flow:
+  agent: orchestrator
+  max_agents: 8          # feature: 6-10; sweep: N modules + consolidator
+  max_concurrent: 4
+  timeout: 4800
+  save_dir_pattern: ".khive/flows/{name}"
+  engine: sdk
+  # Model routing handled by global lionagi profiles — do NOT set here.
+  # Policy: orchestrator=sonnet-4.6-high, critic=opus-4.7-high,
+  # implementer/tester=sonnet-4.6-high. Never use *-max variants.
+
+gates:
+  # Artifact checks between DAG phases. Agents MUST NOT start until gates pass.
+  - phase: post-architect
+    require:
+      - path: artifacts/design.md
+        min_chars: 500
+  # Add per-flow gates, e.g.:
+  # - phase: post-implementer
+  #   require:
+  #     - path: artifacts/impl_summary.md
+
+critic_scope: |
+  # Independent review mandate — set by spec author, not orchestrator.
+  # The orchestrator may NOT narrow or override this scope.
+  Review ALL implementation artifacts for: correctness, spec compliance,
+  security, error handling, and missing edge cases. Verify against the
+  original "Why this matters" and "Acceptance" sections, not just the
+  intermediate architecture.
+
+lore:
+  auto: true
+  role: orchestrator
+  query: >
+    Keywords for domain context (60+ chars, keyword-rich).
+  limit: 6
+  max_tokens: 4000
+  # Parallel agents (especially suggesters) should get DELIBERATELY DIFFERENT
+  # compose queries. Varied lore injection produces diverse perspectives.
+  # Orchestrator: assign each parallel agent a distinct angle.
+
+env:
+  RUSTC_WRAPPER: ""
+
+prompt: |
+  ## Why this matters
+  [Ocean's intent. What daily-driver pain this solves.]
+
+  ## What I want
+  [EXHAUSTIVE requirements. Every behavior, edge case, acceptance
+   criterion. 70% of the prompt lives here. Be LONG.]
+
+  ## Codebase pointers
+  [Starting files — where to look, not what to do with them.]
+
+  ## Constraints
+  [Hard rules: worktree path, READ before WRITE, no new deps,
+   no stubs, scope boundary.]
+
+  ## Acceptance
+  [Concrete commands + expected outcomes.]
+```
+
+**CRITICAL: Do NOT prescribe phases, agent assignments, dependency chains,
+or model routing.** The orchestrator designs its own DAG. Global lionagi
+profiles handle model routing per role.
+
+### 4. Set Up Worktree
+
+```bash
+# {base_branch}: usually 'main' or 'master'. Detect with:
+# git symbolic-ref refs/remotes/origin/HEAD | sed 's|.*/||'
+git worktree add -b {branch} ../{project}-{name} {base_branch}
+mkdir -p ../{project}-{name}/tools/flows ../{project}-{name}/tools/rubrics
+cp tools/flows/{name}.yaml ../{project}-{name}/tools/flows/
+```
+
+### 5. Validate
+
+```bash
+uv run --project /Users/lion/projects/libs/kdev kdev flow validate -f {path}
+```
+
+### 6. Fire
+
+**CRITICAL: Launch from the WORKTREE directory.** Codex sandbox scopes file
+writes to the launcher's CWD.
+
+```bash
+cd /path/to/{worktree} && \
+  nohup uv run --project /Users/lion/projects/libs/kdev \
+  kdev flow run -f tools/flows/{name}.yaml \
+  > /tmp/flow_{name}.log 2>&1 &
+echo "Flow PID: $!"
+```
+
+### 7. Monitor + Diagnose
+
+```bash
+# Preferred: open http://localhost:3000/flows/{id} in the kdev monitor for live
+# agent state, branch timelines, and per-agent output. Start: kdev monitor
+tail -20 /tmp/flow_{name}.log
+# Silent failure diagnosis:
+sqlite3 {worktree}/.khive/kdev.db \
+  "SELECT b.name, substr(sc.content,1,200) FROM stream_chunks sc \
+   JOIN branches b ON b.id=sc.branch_id WHERE sc.flow_id='{id}' LIMIT 20"
+```
+
+#### When Flow Fails
+
+- **Checkpoint-resume**: kdev persists completed branches to `.khive/flows/{name}/`.
+  Check what committed successfully before deciding what to re-fire.
+- **Salvage partial results**: Read `.khive/flows/{name}/` artifacts before abandoning.
+  Completed agents' work is still usable even if later phases failed.
+- **Dead-letter queue**: Agents that hard-crashed → check log for last tool call,
+  reproduce manually, patch spec, re-fire only the failed phase.
+- **Retry vs rewrite**: Retry on transient failures (rate limit, timeout, sandbox
+  error). Rewrite the spec on conceptual failures (agent misunderstood scope, wrong
+  decomposition, underspecified acceptance). Rate limit → wait 5 min then retry.
+  Wrong output → fix the prompt, don't blindly re-fire.
+
+### 8. Evaluate + Ship
+
+```bash
+cd {worktree}
+git diff --stat $(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|.*/||' || echo main)
+RUSTC_WRAPPER='' cargo check --workspace
+RUSTC_WRAPPER='' cargo clippy --workspace -- -D warnings
+# Commit → Push → PR → Merge → git worktree remove --force
+```
+
+Clean stale worktrees immediately after merge.
+
+---
+
+## Sweep Flows (Monorepo Audit)
+
+For per-module parallel audits, the YAML prompt should describe:
+1. What to scan for (the audit focus)
+2. The module enumeration strategy (e.g., "every crate with >600 LOC")
+3. The output format per module
+4. What cross-module consolidation should produce
+
+The orchestrator will fan out one agent per module and consolidate results.
+
+Set `minimum_completion_quorum` in your prompt's Constraints section to control
+consolidation behavior. Example: "Consolidate when ≥80% of modules complete —
+do not wait for stragglers beyond the timeout." Without a quorum, a single slow
+or failed agent blocks the entire consolidation phase.
+
+### Audit Prompt Templates
+
+Include the relevant template in your YAML prompt's "What I want" section.
+The orchestrator will decompose into per-module agents.
+
+#### Tier 1 — Production Crashes
+
+**panic**: Find every `unwrap()`, `expect()`, `panic!()`, `unreachable!()`,
+`todo!()` in non-test code. For each: is the invariant truly guaranteed?
+Could a plausible input trigger it? Hot path or cold path?
+
+**dead-path**: Code that exists but is never reached — match arms for
+unconstructed variants, feature-gated code that's always on/off, handlers
+for operations nobody dispatches.
+
+**error-swallow**: `let _ = result;`, `.unwrap_or_default()` on Results,
+`map_err(|_| ...)` discarding context, `if let Ok(x)` with no else branch,
+`.ok()` converting Result to Option.
+
+#### Tier 2 — Silent Corruption
+
+**unit-confusion**: Raw numeric types carrying implicit units — seconds vs
+millis, bytes vs megabytes, cents vs dollars. Flag arithmetic mixing units.
+
+**serde-drift**: `#[serde(rename_all)]` inconsistent with DB columns,
+renamed fields missing `#[serde(alias)]`, `#[serde(skip)]` on fields
+callers expect in JSON.
+
+**invariant-drift**: Struct fields with implied invariants (sorted, non-empty,
+monotonic, normalized) where mutations don't preserve the invariant.
+
+#### Tier 3 — Product Readiness
+
+**error-ux**: User-visible error paths — does the message help fix the
+problem? Does it leak internals? Is there a recovery action?
+
+**api-contract**: Pub types/traits/fns — provisional signatures, missing
+docs, breaking-change risks (enums without `#[non_exhaustive]`).
+
+**observability**: Critical ops with no tracing span, error branches that
+log nothing, ops that could take >100ms with no timing.
+
+#### Tier 4 — Architecture
+
+**layer-violation**: Imports from above (foundation importing platform),
+domain logic in wrong layer, circular deps via feature flags.
+
+**perf-cliff**: N+1 queries, unbounded growth from user input, blocking I/O
+in async, O(n²) on growable collections.
+
+**cancel-safety**: Lock acquired then await before release, partial writes
+before await, MutexGuard across await.
+
+**inference-opt**: Unnecessary allocations per-request, clone where
+borrow/Arc suffices, SIMD-unfriendly layouts, missing batch opportunities.
+
+#### Tier 5 — Competitive Moat
+
+**unsafe-audit**: Every unsafe block — has SAFETY comment? Is justification
+correct? Could it be eliminated with a safe alternative?
+
+#### Special
+
+**archive-delta**: Compare archived code against live codebase. What's
+already ported, partially ported, or genuinely unported and valuable?
+
+### Sweep Cost
+
+~$0.35-0.50 per module. Full khive monorepo (29 crates): ~$10-15.
+~3% of weekly rate limit per full sweep. Can run 4-5 modes per day.
+
+---
+
+## Important Rules
+
+- **NEVER use naked `python` or `pip`**. Use `uv run`.
+- **ALWAYS launch from the WORKTREE CWD** — codex sandbox scopes writes there.
+- **ALWAYS use `engine: sdk`** — subprocess engine skips events.
+- **ALWAYS set `RUSTC_WRAPPER: ""`** in env to prevent sccache errors.
+- **NEVER prescribe phases/agents/deps** — let the orchestrator plan.
+- **Global profiles handle model routing** — do NOT specify models in YAML or prompts.
+  Policy: orchestrator=sonnet-4.6-high, critic=opus-4.7-high, implementer/tester=sonnet-4.6-high.
+  Never use *-max variants.
+- **READ BEFORE WRITE** — state this in constraints.
+- **Do NOT edit files while flow is running**. The YAML spec is locked at launch —
+  edits mid-run produce undefined behavior. Engine-level spec-hash enforcement is planned.
+- **max_concurrent ≤ 4** — higher wastes tokens on rate limits.
+- **Copy YAMLs to worktrees** — they branch from `{base_branch}` before YAMLs exist.
+- **Symlink carefully**: `ln -s SRC DEST` where DEST doesn't exist. NEVER
+  `ln -sf` where DEST is an existing directory — creates self-referential loop.
+
+## Reference Specs
+
+- `/Users/lion/projects/libs/kdev/examples/monitor_full_build.yaml` — greenfield build
+- `/Users/lion/projects/libs/kdev/examples/monitor_polish.yaml` — targeted polish
+- `/Users/lion/projects/khive/tools/flows/ws_*.yaml` — workstation features (intent-heavy)
+- `/Users/lion/projects/khive/tools/flows/ws_audit_*.yaml` — audit flows

--- a/marketplace/orchestrate/skills/reprompt/SKILL.md
+++ b/marketplace/orchestrate/skills/reprompt/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: reprompt
+description: Strategic orchestration planning via KHIVE formalism. Replaces plan mode. Transforms intent into phased execution with agent selection, complexity assessment, and artifacts.
+argument-hint: '"<PROMPT>" | --interactive | --plan-only'
+---
+
+# /reprompt — Strategic Orchestration Planning
+
+**Identity**: λ:Orchestrator | **Role**: Strategic Architect
+**Purpose**: Transform dense user intent into structured, high-concurrency execution plans.
+
+You do not just follow steps — you **optimize** for speed, quality, and economic efficiency.
+
+## When to Use
+
+- Complex multi-step tasks (C(τ) ≥ 0.3)
+- Multi-agent work requiring coordination
+- Any task where plan mode would have been used (plan mode is FORBIDDEN)
+- User provides dense pseudo-code with operators (`||`, `&&`, `->`, `for`, `if`, `end:`)
+
+## When NOT to Use
+
+- Simple tasks (C < 0.3) — just execute directly
+- Single-file changes with obvious implementation
+- Pure research/exploration — use agents directly
+
+## Quick Reference
+
+```bash
+/reprompt "for x in services || do audit -> fix || end: secure"   # Parse + plan
+/reprompt --interactive                                            # Strategy session
+/reprompt --plan-only "complex task..."                           # Plan without executing
+/reprompt --strict                                                 # Tag all inferences
+/reprompt --max-foreground=N                                       # Limit concurrent agents (default 4)
+```
+
+## The Core Loop
+
+```
+Parse → Expand → Assess(C) → Decide(D) → Plan → Checklist → Execute → Track
+```
+
+### Step 1: Parse the Intent
+
+Build a lossless AST from the prompt. See [orchestration-grammar.md](orchestration-grammar.md) for
+operator grammar and creative heuristics.
+
+Write `ast.yaml` to workspace.
+
+### Step 2: Expand to Requirements
+
+Extract explicit requirements (REQ-E*), implicit requirements (REQ-I*), constraints (CON-*),
+exit gates (EXIT-*), and cross-cutting concerns (XCON-*).
+
+Write `requirements.md` to workspace.
+
+### Step 3: Assess Complexity C(τ)
+
+See [complexity-assessment.md](complexity-assessment.md) for the formula and pattern selection.
+
+```
+C(τ) := clamp01(0.22*log1p(F) + 0.22*log1p(I) + 0.18*D + 0.18*(N/10) + 0.20*(R/10))
+```
+
+**Bias rule**: If you think "simple", add +0.1 unless you can name exact invariants + gates.
+
+### Step 4: Select Agents
+
+See [agent-roster.md](agent-roster.md) for the full roster, spawn conditions, economic tests,
+and domain composition requirements.
+
+**Default crews by complexity:**
+```
+C < 0.3:   λ alone (Expert pattern)
+C 0.3-0.6: α[implementer] + α[tester]
+C 0.6-0.8: α[implementer] + α[tester] + α[reviewer]
+C ≥ 0.8:   + α[critic] AFTER main agents complete
+```
+
+Every additional agent beyond default MUST pass the economic test.
+
+### Step 5: Generate Plan
+
+See [pattern-composition.md](pattern-composition.md) for composable patterns and coordination.
+
+Write `plan.kpp` to workspace with phases, gates, agents, and exit criteria.
+
+### Step 6: Execute Safely
+
+See [execution-safety.md](execution-safety.md) for critical safety rules:
+- **Blocking batches only** — NEVER background agents (max 4 foreground)
+- **Never read raw outputs** — agents summarize, reference files by path
+- **λ owns git** — agents modify files only, λ handles all git operations
+- **Context crash prevention** — filter/sample before reading any large output
+
+### Step 7: Track Progress
+
+Create `checklist.md`, sync with task tracking. Update as phases complete.
+
+## Workspace Convention
+
+```
+.khive/reprompt/{yyyymmdd}/{slug}_{hash8}/
+  ast.yaml          # Normalized parse tree
+  requirements.md   # REQ/CON/EXIT/XCON with stable IDs
+  validation.md     # KHIVE checks + assumptions
+  plan.kpp          # Orchestration plan
+  checklist.md      # Master checklist (living)
+  runlog.md         # Execution log
+```
+
+`{hash8}` = first 8 chars of stable hash of PROMPT. Rerun updates, doesn't duplicate.
+
+## Canonical References
+
+- `protocols/006_orchestration/` — Pattern definitions
+- `protocols/007_agent_selection/` — Selection formalism
+- `resources/agents/{role}/` — Agent role patterns
+- `KHIVE.md` — Full orchestrator formalism
+
+## Gate Enforcement (CRITICAL)
+
+**Every gate in a P_MULT plan is BLOCKING.** When a critic returns BLOCK:
+
+1. STOP — do NOT proceed to next phase
+2. Spawn fix agents for each critical/major issue
+3. Re-run the SAME critic after fixes
+4. Only proceed when critic returns APPROVE
+
+See [pattern-composition.md](pattern-composition.md) for gate semantics and the
+fix-and-re-gate cycle diagram.
+
+**FORBIDDEN**: Rephrasing a critic's BLOCK as APPROVE-WITH-FIXES. Report verbatim.
+
+## Anti-Patterns (Hard Stops)
+
+See [anti-patterns.md](anti-patterns.md) for the full list. Key ones:
+
+- **The Bureaucrat**: 5-phase plan for a CSS fix (C < 0.3 doesn't need a village)
+- **The Anarchist**: 30 background agents at once (pure chaos)
+- **The Glutton**: Reading 5000-line output into context (instant crash)
+- **The Vagrant**: Spawning generic/raw agents without roles (FORBIDDEN)
+- **The Rubber-Stamper**: Critic finds BLOCK issues, lambda proceeds anyway (FABRICATION)

--- a/marketplace/orchestrate/skills/reprompt/agent-roster.md
+++ b/marketplace/orchestrate/skills/reprompt/agent-roster.md
@@ -1,0 +1,182 @@
+# Agent Selection
+
+## How to Spawn Agents
+
+Use the `Task` tool with `subagent_type` matching the role name. Agents default to **Sonnet** (set in `.claude/agents/` frontmatter). Opus reserved for orchestrators only.
+
+```python
+# Example: spawn an implementer
+Task(
+    description="Fix auth middleware",
+    prompt="...",
+    subagent_type="implementer",   # matches α[implementer]
+    model="sonnet"
+)
+```
+
+## Full Agent Roster
+
+All 13 roled agents map directly to `subagent_type` values in the Task tool:
+
+| Role / subagent_type | Identity                          | Spawn Condition                                | Never Spawn When       |
+| -------------------- | --------------------------------- | ---------------------------------------------- | ---------------------- |
+| **implementer**      | Production-quality code builder   | Always (if code changes needed)                | N/A                    |
+| **tester**           | Test-driven validation specialist | Code changes exist                             | Docs/config only       |
+| **reviewer**         | Artifact reviewer (PRs, reports, docs against standards) | C ≥ 0.6, artifact review                  | Ad-hoc/experimental    |
+| **critic**           | Adversarial quality gate (runs AFTER main agents) | C ≥ 0.7, P_MULT/P_FLOW, P0 risk | Every PR, routine      |
+| **researcher**       | Exhaustive information gatherer with provenance    | Novel domain, foundational gaps  | Standard features      |
+| **architect**        | System design specialist, clean interfaces         | Topology change, new boundaries, κ > 0.3 | CRUD, single-file |
+| **analyst**          | Experiment-driven validator with statistical rigor | Perf SLO, algorithm choice, data | Premature optimization |
+| **theorist**         | Formal proof specialist, mathematical rigor        | Lean proofs, safety-critical, type theory | Application code  |
+| **auditor**          | Security/compliance enforcer, vulnerability ID     | Auth, crypto, PII, compliance    | Internal tools         |
+| **strategist**       | Strategic orchestration planner, decision algebra  | Complex pattern selection, resource alloc | Simple tasks      |
+| **innovator**        | Breakthrough concept generator, cross-domain       | Novel solutions, paradigm shifts | Incremental changes    |
+| **commentator**      | Constructive feedback (吐槽+鼓励+给想法)             | Work needs honest reactions, ideas | No feedback needed     |
+| **suggester**        | Pre-orchestration verbose sampling (3×∥ for λ) | Big task decomposition, orchestration planning | Execution tasks        |
+
+### Agent Capabilities
+
+Each agent type has different tool access:
+
+| Agent Type | Can Edit/Write | Can Run Bash | Can Spawn Sub-agents | Best For |
+|------------|---------------|--------------|---------------------|----------|
+| implementer | Yes | Yes | No | Code changes, fixes, features |
+| tester | Yes | Yes | No | Test writing, validation, verification |
+| reviewer | Yes (read-heavy) | Yes | No | Code review, quality gates |
+| critic | Yes (read-heavy) | Yes | No | Adversarial review, missed-risk scan |
+| researcher | No (read-only) | Yes (read) | No | Information gathering, web search |
+| architect | Yes | Yes | No | System design, module structure |
+| analyst | Yes | Yes | No | Benchmarks, experiments, data analysis |
+| theorist | Yes | Yes | No | Formal proofs, type theory |
+| auditor | Yes | Yes | No | Security review, compliance check |
+| strategist | Yes | Yes | No | Orchestration planning, resource allocation |
+| innovator | Yes | Yes | No | Novel solutions, cross-domain synthesis |
+| commentator | Yes (read-heavy) | Yes | No | Honest feedback (吐槽), encouragement, ideas |
+| suggester | Read-only | Read-only | No | Pre-orchestration space exploration (3×∥) |
+
+### Built-in Agent Types (USE SPARINGLY)
+
+These are Claude Code built-ins. Prefer roled agents above, but these are acceptable for specific narrow uses:
+
+| subagent_type | When Acceptable | When NOT to Use |
+|---------------|-----------------|-----------------|
+| **Explore** | Quick codebase search when you need fast file/pattern discovery | Deep research, implementation |
+| **general-purpose** | Multi-step tasks needing full tool access when no specific role fits | When a roled agent clearly fits |
+| **Bash** | Simple command execution | Anything requiring judgment |
+| **haiku** model | Quick, trivial lookups (via `model: "haiku"`) | Anything requiring quality/judgment |
+
+**Note**: `Plan` subagent_type is effectively dead — plan mode is forbidden system-wide.
+
+## Default Crew by Complexity
+
+```
+C < 0.3:   λ alone or 1 implementer (Expert pattern)
+C 0.3-0.5: implementer + tester
+C 0.5-0.7: 3× suggester (recommended) → implementer + tester + critic (after each phase)
+C > 0.7:   3× suggester (MANDATORY) → λ decides plan → implementer + tester + critic (between ALL phases) + cross-challenge round
+```
+
+## Orchestration Rules (MANDATORY)
+
+**RULE 1: C ≥ 0.5 → 3× suggesters for complex/high-stakes/large-scope/innovative work**
+Deploy 3× suggester in parallel BEFORE orchestrating. **Run in background** (`run_in_background: true`) — don't block Ocean waiting. Each explores solution space independently. Lambda reads all 3 when notified, decides phases/sequencing/fallbacks, THEN orchestrates. 3 Sonnet suggesters save Opus context and collectively produce better plans than Opus alone. **C > 0.7 = MANDATORY. C 0.5-0.7 = strongly recommended.** Don't wait for Ocean to ask — deploy proactively when the task qualifies.
+
+**RULE 1a: Ground suggesters in source code, not summaries.**
+When dispatching suggesters, include 2-3 key source files (handlers, data models, relevant modules) alongside the task description. Suggesters reading only a summary produce vague strategies ("wire semantic search") instead of grounded proposals ("add MATCH clause to channel_service.rs line 142").
+
+**RULE 1b: C ≥ 0.7 → cross-challenge round.**
+After 3× initial suggestions, run a quick second round: each suggester reads the other two proposals and writes a 1-paragraph rebuttal identifying the weakest assumption in each. This catches risks no individual suggester found alone. Costs ~10K tokens extra, prevents consensus blindness.
+
+**RULE 2: Multi-phase → critic between ALL phases**
+Critic reviews after EACH phase, not just at the end. Feedback must be deliberately addressed (APPROVE → proceed, APPROVE-WITH-FIXES → fix first, REJECT → rework). Ignored findings = orchestration failure.
+
+**RULE 3: Critic is common, not rare**
+Include critic for any C ≥ 0.5. It catches what implementers miss — use early, use often.
+
+## Conditional Specialists (Justify Each)
+
+| Specialist  | Trigger                                  | Economic Test              |
+| ----------- | ---------------------------------------- | -------------------------- |
+| architect   | `arch_decision ∨ κ>0.3 ∨ new_boundaries` | Would design fail without? |
+| theorist    | `formal_proofs ∨ safety_critical`        | Are proofs mandatory?      |
+| auditor     | `security ∨ auth ∨ crypto ∨ PII`         | Is audit required?         |
+| researcher  | `novel_domain ∨ foundational`            | Is prior art missing?      |
+| analyst     | `perf_slo ∨ algorithm_choice`            | Is measurement needed?     |
+| innovator   | `breakthrough_needed ∨ cross_domain`     | Is novelty required?       |
+| strategist  | `C ≥ 0.8 ∨ pattern_ambiguity`            | Is orchestration complex?  |
+| commentator | `feedback_needed ∨ fresh_perspective`    | Would honest 吐槽 improve this? |
+| suggester   | `pattern_ambiguity ∨ approach_selection`  | Need verbose sampling?     |
+
+## Suggester Pattern (Verbose Sampling)
+
+For high-uncertainty decisions, spawn 2-3 suggesters with different framings:
+
+```python
+# Same task context + framing tag. Background. That's it.
+ctx = "[task description + 2-3 key source files]"
+Agent(subagent_type="suggester", prompt=f"FRAMING: Simplify\n\n{ctx}", run_in_background=True)
+Agent(subagent_type="suggester", prompt=f"FRAMING: Risk\n\n{ctx}", run_in_background=True)
+Agent(subagent_type="suggester", prompt=f"FRAMING: Strategic\n\n{ctx}", run_in_background=True)
+# λ gets notified when each completes, reads all 3, synthesizes plan
+
+# Cross-challenge round (C ≥ 0.7):
+Agent(subagent_type="suggester", prompt=f"FRAMING: Cross-Challenge\n\nProposal A: ...\nProposal B: ...\nProposal C: ...\n\nFor each: what is its weakest assumption?", run_in_background=True)
+```
+
+Use suggesters BEFORE spawning implementers when the path is unclear.
+
+**Default triple**: Simplify + Risk + Strategic (empirically validated — good coverage with genuine adversarial tension between Simplify/Strategic and Risk).
+
+## Economic Test (For Every Agent Beyond Default)
+
+```
+spawn_agent(role) iff:
+  1. unique_value: What does this agent uniquely provide?
+  2. failure_mode: What fails if we omit this agent?
+  3. cost_justified: Is marginal contribution > coordination cost?
+```
+
+**If any answer unclear → DON'T SPAWN**
+
+## Domain Composition Requirement
+
+Every roled agent MUST compose domains before executing:
+
+```python
+mcp__khive__lore(action="suggest", query="detailed task description 10+ words", role="${role}", limit=8)
+mcp__khive__lore(action="compose", ids=["${selected_ids}"], rerank_query="refined focus")
+```
+
+This is mandatory, not optional. Without domain composition, agents lack the specialized knowledge atoms for their role.
+
+## Handoff Format (λ → α)
+
+```kpp
+from: λ
+to: α[implementer]
+task: reprompt_{hash8}_scope
+ws: .khive/reprompt/{slug}_{hash8}/
+
+ctx:
+  C: 0.72
+  domains_composed: ["{domain_ids}"]
+  focus: [alignment, minimal churn]
+in: [checklist.md, requirements.md]
+success: [tests_pass, lint_ok, gates_pass]
+t_est: 30m
+```
+
+## Status Report (α → λ)
+
+```kpp
+from: α[tester]
+to: λ
+task: reprompt_{hash8}_scope
+sts: ok|part|fail
+
+quality: {test: 92, docs: part, types: strict, lint: ok}
+modified: [src/lib.rs, tests/integration.rs]
+out:
+  - {file: runlog.txt, desc: "test output", summary: "47 pass, 0 fail"}
+t_act: 25m
+```

--- a/marketplace/orchestrate/skills/reprompt/anti-patterns.md
+++ b/marketplace/orchestrate/skills/reprompt/anti-patterns.md
@@ -1,0 +1,28 @@
+# Anti-Patterns (Hard Stops)
+
+| Name               | Description                                          | Why It's Bad                              |
+| ------------------ | ---------------------------------------------------- | ----------------------------------------- |
+| **The Bureaucrat** | 5-phase plan with α[architect]+α[critic] for CSS fix | C < 0.3 doesn't need a village            |
+| **The Zombie**     | Execute Phase 2 when Phase 1 failed                  | Stop and pivot, don't cascade failures    |
+| **The Coward**     | P_SEQ when P_PAR would save 50% time                 | Be bold when independence is verified     |
+| **The Ghost**      | Spawn agents without economic justification          | "Just in case" wastes tokens              |
+| **The Vagrant**    | Use raw/generic agents without roles                 | FORBIDDEN — always use roled agents       |
+| **The Amnesiac**   | No workspace artifacts, no evidence                  | Future λ can't trace decisions            |
+| **The Optimist**   | "Days" as time estimate                              | AI-scale is minutes. Decompose more.      |
+| **The Anarchist**  | Launch 30 background agents at once                  | Pure chaos, git conflicts, nothing done   |
+| **The Glutton**    | Read 5000-line console output into context           | Instant context crash, orchestration dead |
+| **The Rogue**      | Agents running git commands directly                 | Conflicts, race conditions, broken state  |
+
+## Critical Rules
+
+1. **Roled Agents Only**: NEVER spawn generic/raw agents. Always use `α[role]` from roster.
+2. **Opus Only**: ALL agents MUST use Opus model. Never Sonnet, never Haiku for agents.
+3. **Domain Composition**: Every roled agent MUST compose domains before executing.
+4. **Blocking Batches Only**: NEVER use background agents. Max 4 foreground, wait for completion.
+5. **λ Owns Git**: Only λ runs git commands. Agents modify files only, report changes.
+6. **Protect Context**: NEVER read raw console outputs. Use tail/head/grep, or have agents summarize.
+7. **AI-Scale Time**: Estimate in minutes (5m, 15m, 30m). If "days", decompose further.
+8. **Sync or Die**: `checklist.md` and task tracking must agree.
+9. **Evidence First**: Never mark a gate complete without log, hash, or test result.
+10. **Cross-Cut Early**: Check consistency between phases, not just at the end.
+11. **Independence Before Parallelism**: Verify before upgrading to P_PAR.

--- a/marketplace/orchestrate/skills/reprompt/complexity-assessment.md
+++ b/marketplace/orchestrate/skills/reprompt/complexity-assessment.md
@@ -1,0 +1,38 @@
+# Complexity Assessment C(τ)
+
+## Signals
+
+- `F`: Files touched
+- `I`: Integration points (crate boundaries, proofs, schemas)
+- `D`: Dependency depth
+- `N`: Novelty (0-10)
+- `R`: Risk/criticality (0-10)
+
+## Formula
+
+```
+C(τ) := clamp01(0.22*log1p(F) + 0.22*log1p(I) + 0.18*D + 0.18*(N/10) + 0.20*(R/10))
+```
+
+**Bias rule**: If you think "simple", add +0.1 unless you can name exact invariants + gates.
+
+## Quick Assessment
+
+| C(τ)    | Class    | Time Est  | What It Feels Like                        |
+| ------- | -------- | --------- | ----------------------------------------- |
+| < 0.3   | Trivial  | 2-5m      | "I know exactly what to do"               |
+| 0.3-0.6 | Standard | 10-20m    | "Clear path, needs testing"               |
+| 0.6-0.8 | High     | 30-60m    | "Multiple moving parts, need coordination"|
+| ≥ 0.8   | Systemic | 1-2h      | "Cross-cutting, phased, needs validation" |
+
+## Requirements Expansion
+
+Write `requirements.md` with stable IDs:
+
+| ID Type  | Meaning                | Example                            |
+| -------- | ---------------------- | ---------------------------------- |
+| `REQ-E*` | Explicit (from prompt) | "Check ADR against proof"          |
+| `REQ-I*` | Implicit (inferred)    | "Locate ADR files per crate"       |
+| `CON-*`  | Constraint             | "Max 4 foreground agents"          |
+| `EXIT-*` | Exit gate              | "All tests pass"                   |
+| `XCON-*` | Cross-cutting          | "Cross-crate contract consistency" |

--- a/marketplace/orchestrate/skills/reprompt/execution-safety.md
+++ b/marketplace/orchestrate/skills/reprompt/execution-safety.md
@@ -1,0 +1,93 @@
+# Execution Safety
+
+## Blocking Foreground Only — NEVER Background Agents
+
+**FORBIDDEN**:
+- `run_in_background: true` for any agent
+- Launching agents without waiting for completion
+- Fire-and-forget agent patterns
+
+**WHY**: Background agents cause catastrophic coordination failures:
+- All agents stepping on each other's work
+- Git conflicts everywhere
+- Context explosion when checking on all of them
+
+**REQUIRED**: Blocking batches with max foreground limit:
+
+```python
+# CORRECT: Blocking batch of max 4 foreground agents
+for batch in chunk(agents, max_size=4):
+    results = await parallel_blocking(batch)  # WAIT for all to complete
+    validate_results(results)                  # GATE before next batch
+
+# WRONG: Fire-and-forget chaos
+for agent in agents:
+    spawn_background(agent)  # NEVER DO THIS
+```
+
+### Max Foreground Batch Size
+
+```
+Default: --max-foreground=4
+Absolute max: 8 (only with explicit justification)
+
+NEVER launch >8 agents simultaneously
+ALWAYS wait for batch completion before next batch
+```
+
+## NEVER Read Raw Console Outputs
+
+**FORBIDDEN**: Reading full console outputs from agent tasks
+
+**WHY**: Console outputs can be 4-5k+ lines, causing instant context crash.
+
+**REQUIRED**: Agents must summarize their own outputs:
+
+```kpp
+# CORRECT: Agent provides summary
+from: α[tester]
+to: λ
+sts: ok
+summary: "47 tests passed, 2 skipped, 0 failed"
+quality: {test: 100, lint: ok}
+
+# WRONG: Returning raw console dump (crashes λ's context)
+```
+
+**If raw output needed**: Write to workspace file, reference by path only:
+
+```kpp
+out:
+  - {file: "runlog.txt", desc: "Full test output (2847 lines)", summary: "47 pass, 0 fail"}
+```
+
+**If λ MUST inspect output**:
+
+```bash
+tail -50 runlog.txt            # Last 50 lines only
+grep "FAIL\|ERROR" runlog.txt  # Only failures
+grep -c "passed" runlog.txt    # Just count
+```
+
+## λ Handles All Git Flows
+
+Git operations are λ's exclusive responsibility:
+
+| Operation             | Who    | Why                                         |
+| --------------------- | ------ | ------------------------------------------- |
+| `git add`             | λ only | Prevents conflicting staging                |
+| `git commit`          | λ only | Ensures atomic commits with proper messages |
+| `git push`            | λ only | Prevents race conditions                    |
+| `git merge`           | λ only | Requires orchestration context              |
+| `git checkout/branch` | λ only | Agents work on assigned scope only          |
+
+**Agents MUST NOT** run any git commands.
+**Agents MUST** report modified files in status report, let λ handle git.
+
+```kpp
+from: α[implementer]
+to: λ
+sts: ok
+modified: [src/lib.rs, src/types.rs, tests/integration.rs]
+ready_for_commit: true
+```

--- a/marketplace/orchestrate/skills/reprompt/orchestration-grammar.md
+++ b/marketplace/orchestrate/skills/reprompt/orchestration-grammar.md
@@ -1,0 +1,63 @@
+# Operator Grammar & Strategic Intent
+
+λ parses operators not just as syntax, but as **strategic opportunities**.
+
+## Operators
+
+| Symbol    | Meaning   | Strategic Opportunity                                                       |
+| --------- | --------- | --------------------------------------------------------------------------- |
+| `\|\|`    | Separator | **Default: delimiter**. Upgrade to P_PAR only after independence check      |
+| `&&`      | Sequence  | Build context. **Twist**: Can I parallelize if tasks touch different files? |
+| `->`      | Flow      | Data dependency. Output of A _must_ feed B. Use P_FLOW                      |
+| `for x`   | Iteration | Batching. Unroll to P_PAR when items are independent                        |
+| `if/else` | Branch    | Competition. High uncertainty? Use P_CHO (tournament)                       |
+| `end:`    | Gate      | Definition of Done. Hard validation, no exit without evidence               |
+
+## Independence Check (Critical for Safe Parallelism)
+
+Before inferring `P_PAR`, verify:
+
+```
+Independent(τ₁, τ₂) iff:
+  - No shared write targets (or writes are commutative)
+  - No intermediate output dependencies
+  - Neither is a correctness gate for the other
+```
+
+**If uncertain**: Default to `P_SEQ`. The Coward anti-pattern is preferable to The Zombie.
+
+## Creative Heuristics (Override Defaults When Logical)
+
+| Heuristic                | Trigger                                        | Action                                      |
+| ------------------------ | ---------------------------------------------- | ------------------------------------------- |
+| **The Hidden Parallel**  | User said `&&` but tasks touch different files | Upgrade to P_PAR                            |
+| **The Fast Fail**        | High-risk step at end of sequence              | Move to Phase 0 (fail early)                |
+| **The Speculative Race** | Ambiguous solution, high downstream cost       | Use P_CHO (tournament), let results decide  |
+| **The Hybrid**           | Systemic task (C ≥ 0.8)                        | Nest P_PAR inside P_MULT phases             |
+| **The Probe**            | Uncertainty Ξ(ψ) > 0.7                         | Run 5-min discovery before committing       |
+| **The Checkpoint**       | C(τ) ≥ 0.8                                     | Insert validation gates between every phase |
+| **The Mapper**           | Cross-crate/cross-module task                  | Build invariant→code mapping before edits   |
+
+**Logging requirement**: When applying a heuristic, log rationale in `validation.md`.
+
+## AST Format
+
+Write to `ast.yaml`:
+
+```yaml
+raw: "<original prompt>"
+nodes:
+  - id: N1
+    kind: loop|seq|par|choice|gate|step
+    op: for|if|&&|->|PAR|SEP|end
+    text: "<source fragment>"
+    children: [N2, N3]
+meta:
+  iterator: { var: "c", values: ["khive-types", "khive-score"] }
+  exit: "end: correct, aligned, committed"
+  cross_cutting: ["cross-crate consistency"]
+assumptions:
+  - id: ASSUMPTION-1
+    text: "|| treated as SEP (delimiter)"
+    falsifiable: "if user says 'parallel', reparse"
+```

--- a/marketplace/orchestrate/skills/reprompt/pattern-composition.md
+++ b/marketplace/orchestrate/skills/reprompt/pattern-composition.md
@@ -1,0 +1,137 @@
+# Pattern Composition
+
+Patterns are **composable primitives**, not mutually exclusive boxes.
+
+## Pattern Selection via D(τ,ψ)
+
+| C(τ)    | Class    | Pattern         | Crew                                     |
+| ------- | -------- | --------------- | ---------------------------------------- |
+| < 0.3   | Trivial  | Expert          | λ alone or 1 α[implementer]              |
+| 0.3-0.6 | Standard | P_PAR2 / P_SEQ  | α[implementer] + α[tester]               |
+| 0.6-0.8 | High     | P_PAR / P_CHO   | α[implementer] + α[tester] + α[reviewer] |
+| ≥ 0.8   | Systemic | P_MULT / P_FLOW | Full crew + α[critic] after              |
+
+## Decision Algebra
+
+```
+𝒰(P,ψ) := w₁(ψ)·Speed + w₂(ψ)·Quality − w₃(ψ)·CogLoad
+D(τ,ψ) := argmax_{P∈Applicable} [ 𝔼(𝒰(P,ψ)) ]
+```
+
+**State adjustments**:
+- Under pressure: `w₁↑, w₃↑` (speed, reduce overhead)
+- Quality-critical: `w₂↑` (security, proofs, data)
+- Low energy: `w₃↑` (simpler patterns)
+
+## Legal Compositions
+
+### 1. P_MULT ⊗ P_PAR — Phases with parallel fan-out
+
+- Phase 1: Parallel discovery (α[researcher] + α[analyst])
+- Gate: Consolidate issues
+- Phase 2: Parallel fixes (α[implementer] teams)
+- Gate: Tests/proofs
+- Phase 3: Integration (α[reviewer])
+
+### 2. P_PAR → P_CHO → P_SEQ — Discovery → Decision → Implementation
+
+- Run parallel α[researcher] scouts
+- Tournament for architecture choice (α[architect] variants)
+- Sequential implementation of winner (α[implementer])
+
+### 3. P_FLOW with P_PAR nodes — DAG with parallel work within each node
+
+- Nodes = crates (dependency order)
+- Within node: parallel α[implementer] + α[tester]
+
+### 4. Expert → Escalate — Probe then expand
+
+- 5-min α[researcher] probe to reduce uncertainty
+- If uncertainty drops, simpler pattern wins
+
+## Coordination Mapping
+
+| Pattern | Method         | Context  | Sync       | Agent Handoff                  |
+| ------- | -------------- | -------- | ---------- | ------------------------------ |
+| P_PAR   | `work.assign`  | Shallow  | Barrier    | λ→α[roles] parallel            |
+| P_CHO   | `work.assign`  | Isolated | Tournament | λ→α[variants], α[critic] picks |
+| P_SEQ   | `work.handoff` | Deep     | Pipeline   | α[A]→α[B] chain                |
+| P_MULT  | `work.handoff` | Deep     | Phased     | Gate between phases            |
+| P_FLOW  | `work.handoff` | Graph    | DAG        | Topological order              |
+| Expert  | `work.assign`  | Minimal  | Await      | λ→single α                     |
+
+## Plan Output Format
+
+Write `plan.kpp`:
+
+```kpp
+from: λ
+task: reprompt_{hash8}
+ws: .khive/reprompt/{slug}_{hash8}/
+
+ctx:
+  C: 0.75
+  pattern: P_MULT
+  max_foreground: 4
+
+phases:
+  - {id: P1, name: "Discovery", pattern: P_PAR, agents: [α[researcher], α[analyst]], gate: G1}
+  - {id: P2, name: "Fix", pattern: P_PAR, agents: [α[implementer], α[tester]], gate: G2}
+  - {id: P3, name: "Integration", pattern: Expert, agents: [α[reviewer]], gate: EXIT}
+
+gates:
+  - {id: G1, pass: "issues_listed & evidence_links", on_fail: "fix & re-gate"}
+  - {id: G2, pass: "tests_pass & lint_ok", on_fail: "fix & re-gate"}
+
+exit:
+  - "All aligned"
+  - "Gates pass"
+  - "Commits recorded"
+```
+
+## Gate Enforcement (NON-NEGOTIABLE)
+
+Gates are BLOCKING checkpoints, not informational logs. When a critic/reviewer
+finds issues at a gate, the following cycle is MANDATORY:
+
+```text
+critic runs → verdict?
+  APPROVE           → proceed to next phase
+  APPROVE-WITH-FIXES → fix listed items, proceed (no re-review)
+  BLOCK             → STOP → fix ALL critical/major → RE-RUN critic → loop until APPROVE
+  REJECT            → phase failed → redesign → redo phase entirely
+
+FORBIDDEN:
+  ❌ Critic says BLOCK, lambda says "APPROVE-WITH-FIXES" → FABRICATION
+  ❌ Listing critical issues then launching next phase → GATE BYPASS
+  ❌ Treating critic output as informational → DEFEATS THE ENTIRE PIPELINE
+```
+
+**The fix-and-re-gate cycle**:
+
+```
+         ┌─────────────┐
+         │ Run Critic   │
+         └──────┬───────┘
+                │
+         ┌──────▼───────┐
+         │  APPROVE?    │──yes──→ Proceed to next phase
+         └──────┬───────┘
+                │ no (BLOCK)
+         ┌──────▼───────┐
+         │ Spawn fixers │ ← one agent per critical/major issue
+         └──────┬───────┘
+                │
+         ┌──────▼───────┐
+         │ RE-RUN Critic│ ← same critic prompt, fresh context
+         └──────┬───────┘
+                │
+                └──→ loop until APPROVE or REJECT
+```
+
+**Why this matters**: A critic that finds problems but doesn't block progress is
+theater. If the lambda can just note the issues and move on, the critic's effort
+is wasted, errors propagate to downstream phases, and the final output is built
+on unvalidated foundations. The entire multi-phase pipeline's value comes from
+the gates between phases — without enforcement, P_MULT degrades to a single
+unreviewed pass.

--- a/marketplace/play/.claude-plugin/plugin.json
+++ b/marketplace/play/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "play",
+  "description": "Author lionagi playbooks for li play / li o flow",
+  "version": "0.1.0",
+  "author": {
+    "name": "Ocean (HaiyangLi)",
+    "url": "https://github.com/ohdearquant"
+  },
+  "homepage": "https://github.com/khive-ai/lionagi",
+  "repository": "https://github.com/khive-ai/lionagi",
+  "license": "Apache-2.0",
+  "keywords": ["playbook", "authoring", "flow", "pipeline"]
+}

--- a/marketplace/play/README.md
+++ b/marketplace/play/README.md
@@ -1,0 +1,27 @@
+# play
+
+Playbook authoring for lionagi orchestration flows (`li play` / `li o flow`).
+
+## What's inside
+
+- **skills/write-playbook** — scaffolds a new lionagi playbook: title, shape, roles, steps, and artifact protocol
+
+## Install
+
+```
+claude /plugin marketplace add khive-ai/lionagi
+claude /plugin install play@lionagi
+```
+
+## Quick start
+
+```
+/write-playbook <name>
+```
+
+Guides you through authoring a complete lionagi playbook for `li play` or `li o flow`,
+producing a spec-complete YAML/markdown playbook in the current directory.
+
+## See also
+
+- ADR-0003 (docs/adrs/ADR-0003-claude-code-marketplace.md) — marketplace pattern

--- a/marketplace/play/skills/write-playbook/SKILL.md
+++ b/marketplace/play/skills/write-playbook/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: write-playbook
+description: >
+  Author a correct lionagi playbook — the YAML that `li play NAME` / `li o flow -p NAME`
+  loads. Covers file location, every recognized spec field, args schema, argument-hint
+  fallback, template interpolation, team semantics, and common pitfalls. Pull this
+  before editing anything under ~/.lionagi/playbooks/ or firm/resources/playbooks/.
+allowed-tools: [Read, Write, Edit, Bash]
+---
+
+# Writing a lionagi playbook
+
+A **playbook** is a YAML file under `~/.lionagi/playbooks/<name>.playbook.yaml`
+that declares a reusable, parametric flow invocation. Invoke with
+`li play <name> [args] "positional prompt"` (sugar) or
+`li o flow -p <name> [args] "positional prompt"` (long form).
+
+**Source of truth**: `firm/resources/playbooks/<name>.playbook.yaml`, symlinked
+into `~/.lionagi/playbooks/`. Edit in firm, no sync needed.
+
+## Minimum viable playbook
+
+```yaml
+name: hello
+description: Greet the user and answer a simple question.
+
+model: claude-code/sonnet-4-6
+
+prompt: |
+  You are a patient teacher. Answer concisely.
+```
+
+Invoke: `li play hello "what is a monad?"`
+Behavior: positional prompt is **appended** (blank line) because the template
+has no `{...}` placeholders.
+
+## Every recognized top-level field
+
+All keys accept EITHER `dashed-form` OR `underscore_form`. Internally both
+normalize to Python identifier form at load time.
+
+| Key | Type | Maps to CLI | Purpose |
+|-----|------|-------------|---------|
+| `name` | str | — | Playbook identifier (should match filename) |
+| `description` | str | — | Free-text; surfaced in docs/tooling |
+| `argument-hint` | str | — | CC-compatible display string like `'[--tabs N] [--poll]'`. Fallback arg schema if `args:` absent. |
+| `model` | str | `<positional model>` | Orchestrator model spec, e.g. `claude-code/opus-4-7` |
+| `agent` | str | `-a/--agent` | Agent profile name (from `~/.lionagi/agents/<name>/<name>.md`) |
+| `effort` | str | `--effort` | `low \| medium \| high \| xhigh` |
+| `workers` | int | `--max-concurrent` | Max concurrent agents per phase (1-32) |
+| `max_agents` | int | `--max-agents` | Cap total ops (1-50, 0 = unlimited) |
+| `with_synthesis` | bool | `--with-synthesis` | Final synthesis pass after all ops |
+| `team_mode` | str | `--team-mode` | FRESH team per invocation (new UUID every time) |
+| `team_attach` | str | `--team-attach` | Upsert team by name — attach if exists, create if missing |
+| `bare` | bool | `--bare` | Ignore agent profiles; all workers use CLI model |
+| `dry_run` | bool | `--dry-run` | Plan DAG, print, do not execute |
+| `show_graph` | bool | `--show-graph` | Render DAG as matplotlib PNG (requires `--save`) |
+| `save` | str | `--save` | Artifact output dir |
+| `prompt` | str | — | Template (supports `{input}` + named args); required for `li play` |
+| `args` | dict | dynamic flags | Typed arg schema — see below |
+
+CLI flags always override playbook defaults. Positional prompt goes through
+template interpolation (see below).
+
+## args: schema (preferred)
+
+Typed, validated CLI args that map to template placeholders.
+
+```yaml
+args:
+  mode:
+    type: str           # str | int | float | bool
+    default: dry        # used when CLI flag omitted
+    help: "audit mode"  # shown in --help
+  workers:
+    type: int
+    default: 8
+  strict:
+    type: bool          # bool defaults to False; --strict sets True
+    default: false
+```
+
+CLI access: `li play audit --mode security --workers 12`.
+
+Naming: use underscores in schema; CLI flags become `--underscore-form` →
+`--my-arg` (dashed). In the prompt template, reference by underscored name:
+`{my_arg}`.
+
+**Reserved names** (clash with base flags — injection is skipped with warning):
+`--file/-f`, `--playbook/-p`, `--agent/-a`, `--with-synthesis`, `--max-concurrent`,
+`--output`, `--save`, `--team-mode`, `--team-attach`, `--dry-run`, `--show-graph`,
+`--background`, `--bare`, `--max-agents`, `--yolo`, `-v/--verbose`, `--theme`,
+`--effort`, `--cwd`, `--timeout`. Don't redeclare these in `args:`.
+
+## argument-hint fallback
+
+Use ONLY when you can't write a full `args:` schema (e.g. wrapping a CC skill
+verbatim). Parsing rules:
+
+- `[--flag VALUE]` or `[--flag N]` → string arg, default `null`
+- `[--flag]` → bool arg, default `false`
+- No type coercion; everything is a string except bool flags
+
+```yaml
+argument-hint: '[--tabs N] [--poll] [--harvest]'
+```
+
+If both `args:` and `argument-hint:` are present, **`args:` wins**. Best
+practice: always migrate to `args:` — you get `--help` output, type checks,
+and documented defaults.
+
+## Template interpolation
+
+Inside `prompt:`, three substitution rules fire in order:
+
+1. **`{input}`** → the positional prompt text passed on the CLI.
+2. **`{arg_name}`** → a declared arg (CLI value > `default`). Undeclared
+   placeholders remain literal `{xxx}` tokens.
+3. **No placeholders present** → positional text is **appended** with a blank
+   line, CC slash-command style.
+
+```yaml
+# 1. {input} only
+prompt: "Summarize this: {input}"
+# li play x "the RFC"  →  "Summarize this: the RFC"
+
+# 2. Named args + {input}
+prompt: "Run {workers} workers in {mode} mode. Target: {input}"
+# li play x --workers 5 --mode deep "auth crate"
+# →  "Run 5 workers in deep mode. Target: auth crate"
+
+# 3. No placeholders — positional appended
+prompt: "You are a code reviewer. Be terse."
+# li play x "review PR #42"
+# →  "You are a code reviewer. Be terse.\n\nreview PR #42"
+```
+
+## Team semantics (pick ONE, not both)
+
+```yaml
+# Always fresh — new team, new UUID every invocation. Results not
+# accessible to future runs.
+team_mode: one-off-audit
+
+# Upsert — first run creates team called "ongoing-review", subsequent runs
+# attach to the same team and see accumulated message history.
+team_attach: ongoing-review
+```
+
+`team_mode` and `team_attach` are mutually exclusive (error at dispatch).
+Neither requires a pre-existing team — both create-on-miss.
+
+## Common pitfalls
+
+**Silent no-ops from unknown keys.** Top-level keys not in the recognized list
+are ignored silently. `max-agents: 10` works (normalized to `max_agents`), but
+`maxAgents: 10` or `max_iterations: 10` just vanish. Check the table above
+before inventing fields.
+
+**Dash vs. underscore.** Spec loader auto-normalizes `max-agents` → `max_agents`
+for top-level keys. It does NOT touch `argument-hint` (CC convention) and does
+NOT touch names inside `args:` (you own them). Use whatever's consistent with
+the surrounding code.
+
+**`args:` arg name collisions with built-ins.** If you declare `args.save` or
+`args.verbose`, your flag gets shadowed by the base CLI. Rename (`output-dir`,
+`chatty`).
+
+**Invalid `effort` value.** Must be one of `low | medium | high | xhigh`.
+Anything else → spec validation error.
+
+**`prompt` length.** Cap is 8192 chars. Longer templates should delegate to
+skills the orchestrator reads at runtime (`li skill <name>`).
+
+**`show_graph: true` without `--save`.** Graph rendering needs an output dir.
+Either add `save: ./graphs/` to the playbook or pass `--save DIR` on the CLI.
+
+**`workers: 0`.** Range is [1, 32]. Use `max_agents: 0` for "unlimited ops";
+`workers` means per-phase concurrency and must be a positive int if set.
+
+## Full-featured example
+
+```yaml
+name: audit
+description: >
+  Parallel codebase audit. Orchestrator plans N specialists; one critic
+  synthesis pass. Optional persistent team for cross-invocation notes.
+
+argument-hint: '[--mode MODE] [--strict] [--notes-team NAME]'
+
+model: claude-code/opus-4-7
+agent: orchestrator
+effort: high
+max_agents: 10
+with_synthesis: true
+
+args:
+  mode:
+    type: str
+    default: dry
+    help: "audit mode: dry | security | dead-code | api-surface"
+  strict:
+    type: bool
+    default: false
+    help: "treat any finding above MEDIUM as blocking"
+  notes_team:
+    type: str
+    default: ""
+    help: "if set, attach to this team for persistent notes"
+
+prompt: |
+  Run a {mode} audit on the target below. Strict mode: {strict}.
+  Persistent notes team (empty string = none): "{notes_team}".
+
+  Target: {input}
+
+  Deploy specialists in parallel, one per module. Collect findings.
+  Critic synthesizes at the end — output MUST-FIX / SHOULD-FIX / CONSIDER
+  with file:line citations.
+```
+
+## Authoring checklist
+
+- [ ] Filename is `<name>.playbook.yaml` (exact suffix matters)
+- [ ] Location: `firm/resources/playbooks/` (source), symlinked into `~/.lionagi/playbooks/`
+- [ ] `name:` matches the filename stem
+- [ ] `description:` is one clear sentence — shown in tooling
+- [ ] Either `model:` or `agent:` is set (both fine; CLI can override)
+- [ ] `prompt:` references exactly the placeholders declared in `args:` plus optional `{input}`
+- [ ] Every declared arg in `args:` has a `type`, a sensible `default`, and a `help`
+- [ ] No dashed keys inside `args:` (use `my_arg:` not `my-arg:` for the schema)
+- [ ] `team_mode` and `team_attach` are not both set
+- [ ] Smoke test: `li o flow -p <name> --help` shows your custom flags with types
+- [ ] Smoke test: `li o flow -p <name> --dry-run "test input"` plans without executing
+
+## Installing a new playbook
+
+```bash
+# 1. Write it in firm (source of truth)
+vim firm/resources/playbooks/my-thing.playbook.yaml
+
+# 2. Symlink into ~/.lionagi/playbooks/ so `li play` sees it
+ln -s /Users/lion/projects/firm/resources/playbooks/my-thing.playbook.yaml \
+      ~/.lionagi/playbooks/my-thing.playbook.yaml
+
+# 3. Verify
+li play list                                  # should list 'my-thing'
+li o flow -p my-thing --help                  # should show your args
+li play my-thing --dry-run "sample input"     # plans without executing
+```

--- a/marketplace/research/.claude-plugin/plugin.json
+++ b/marketplace/research/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "research",
+  "description": "Multi-perspective research with web search, codebase analysis, and synthesis",
+  "version": "0.1.0",
+  "author": {
+    "name": "Ocean (HaiyangLi)",
+    "url": "https://github.com/ohdearquant"
+  },
+  "homepage": "https://github.com/khive-ai/lionagi",
+  "repository": "https://github.com/khive-ai/lionagi",
+  "license": "Apache-2.0",
+  "keywords": ["research", "web-search", "synthesis", "multi-perspective"]
+}

--- a/marketplace/research/README.md
+++ b/marketplace/research/README.md
@@ -1,0 +1,34 @@
+# research
+
+Multi-perspective research with web search, codebase analysis, and synthesis.
+
+## What's inside
+
+- **skills/progress-research** — Multi-round ChatGPT Deep Research pipeline with quality
+  gates. Each round: drill → refine → fire → evaluate → record. Uses ChatGPT for
+  breadth-first literature exploration (50+ min per query); Claude handles synthesis,
+  hallucination checks, and tradability decisions.
+- **agents/researcher** — Evidence-gathering agent profile. Mission: gather knowledge,
+  track sources, document gaps. Researcher never commits or proposes — it gathers so
+  analysts and architects can decide.
+
+## Install
+
+```
+claude /plugin marketplace add khive-ai/lionagi
+claude /plugin install research@lionagi
+```
+
+## Quick start
+
+```
+/progress-research "What are the state-of-the-art methods for time-series forecasting?"
+```
+
+The skill opens a multi-round deep research loop. At each gate it asks whether to
+drill deeper or synthesize. Use `/researcher` to spawn a dedicated evidence-gathering
+agent on a specific sub-question.
+
+## See also
+
+- [ADR-0003](../../docs/adrs/ADR-0003-claude-code-marketplace.md) — marketplace pattern

--- a/marketplace/research/README.md
+++ b/marketplace/research/README.md
@@ -31,4 +31,4 @@ agent on a specific sub-question.
 
 ## See also
 
-- [ADR-0003](../../docs/adrs/ADR-0003-claude-code-marketplace.md) — marketplace pattern
+- ADR-0003 (docs/adrs/ADR-0003-claude-code-marketplace.md) — marketplace pattern

--- a/marketplace/research/agents/researcher.md
+++ b/marketplace/research/agents/researcher.md
@@ -1,0 +1,250 @@
+---
+model: codex/gpt-5.5
+effort: high
+yolo: true
+---
+
+# α[Researcher]
+
+`∵α[researcher]→LION.khive`
+
+**Mission**: `Gather(K) ∧ Track(S) ∧ Document(Gaps) → Evidence-Based`
+
+**Philosophy**: `Breadth > Depth ∧ ∀Fact: ∃Source ∧ ∀Conflict: Document(All)`
+
+---
+
+## Flow / Team Context
+
+Inside `li o flow` / `li o fanout` (lionagi DAG pipelines, v0.22.6+):
+
+- **Write** deliverables as descriptive `.md` files to your cwd — default for this role: `research.md` (or `discovery.md` / `validation.md` / `synthesis.md` per mode). Never `output.md`.
+- **Read** upstream artifacts from `../{dep_agent_id}/{filename}` paths given in your instruction.
+- **Team mode** (`--team-mode`): `li team receive -t $TEAM --as $NAME` on start; `li team send "signal" -t $TEAM --to $NAME --from-op $OP` for mid-run coordination.
+
+Framework vocabulary (Branch, Operations, flow, team, artifact protocol) is auto-prepended via `LION_SYSTEM_MESSAGE` (`lion_system: true` default).
+
+---
+
+## Symbols
+
+```text
+K: Knowledge | S: Source | P: Provenance | C: Confidence∈[0,1] | G: Gaps | Q: Query | R: Report
+S_off: Official | S_com: Community | S_int: Internal | S_aca: Academic
+C_max:1.0 | C_high:0.9 | C_trust:0.8 | C_mod:0.7 | C_low:0.5 | C_spec:0.3
+```
+
+---
+
+## Axioms
+
+```text
+R.1 (Exhaustive): □(∀Q: Execute(WebSearch ∧ Grep ∧ Recall) → Document(∀Findings))
+R.2 (Provenance): □(∀Claim: Claim ⊢ (Source ∧ Date ∧ Confidence ∧ Context))
+R.3 (Completeness): Complete ⊢ (Tools_Exhausted ∧ Cited ∧ Gaps_Documented ∧ Conflicts_Flagged)
+```
+
+**Format**: `[Finding] Source:URL (YYYY-MM-DD, C:X.X)` | See protocols/core_invariants.md
+
+---
+
+## Anti-Patterns
+
+```text
+❌ Claiming "no results found" without documenting which tools were searched and what queries used
+❌ Citing a single source for a contested claim — present ≥2 perspectives (R.3)
+❌ Reporting findings without confidence scores — every claim needs C∈[0,1]
+❌ Using sources older than 2 years without flagging recency risk
+❌ Making recommendations — researcher gathers and cites, architect/strategist recommends
+❌ Composing domains for external research — use WebSearch for current pricing, ecosystem stats
+❌ Confirmation bias — searching only for evidence supporting a predetermined conclusion
+❌ Breadth without depth — many sources superficially cited is not exhaustive research
+```
+
+---
+
+## Skills I load
+
+Before acting on any of the triggers below, run `li skill <name>` and follow its procedure.
+
+| Trigger | Skill |
+|---------|-------|
+| Broad literature or ecosystem research (multi-round) | `li skill progress-research` |
+| Exploring Atlas KB for internal technical context | `li skill atlas-explore` |
+| Recalling prior research findings and source lists | `li skill memory-recall` |
+| Checking KB coverage stats before a deep dive | `li skill kb-stats` |
+
+---
+
+## Domain Expertise Composition
+
+**Domain composition is CONTEXT-DEPENDENT for researchers.** For external intelligence (competitive
+analysis, market data, current pricing), prioritize WebSearch and WebFetch over domains. For
+internal/technical research (architecture patterns, protocol analysis), domains provide useful
+frameworks for structuring investigation.
+
+```bash
+# Step 1: Discover domains
+mcp__lore__suggest(query="MCP server architecture with async tool registration and JSON-RPC connection lifecycle patterns", role="researcher", limit=8)
+
+# Step 2: Compose selected domains
+mcp__lore__compose(domain_ids=[...from suggest...], role="researcher")
+
+# Auto mode
+# Auto mode removed — use suggest first, then compose with domain_ids
+```
+
+### Decision Heuristic
+
+Before composing domains, classify your research type:
+
+```text
+External research (web data, current prices, ecosystem stats)
+  → SKIP domains. Use WebSearch + WebFetch first. Domains add noise, not signal.
+    Examples: competitive pricing, market sizing, current ecosystem stats, API pricing pages
+
+Internal research (codebase patterns, architecture decisions)
+  → COMPOSE domains for framework context. Domains structure the investigation.
+    Examples: protocol analysis, design pattern evaluation, architecture comparison
+
+Mixed research (both external data and internal framing)
+  → Compose domains LIGHTLY (limit=3). Focus on methodology atoms, not content atoms.
+    Use domains for investigation structure, WebSearch for actual data.
+```
+
+### Query Crafting (60-70+ chars, keyword-rich)
+
+**Include these keyword types for better retrieval**:
+
+- **Tech stack**: rust, python, typescript, async, tokio, fastapi, pydantic
+- **Patterns**: distributed, event-driven, microservices, cqrs, saga
+- **Domains**: compliance, SOC2, HIPAA, security, authentication, authorization
+- **Specifics**: websocket, grpc, rest, graphql, vector-db, embedding
+
+**Bad query**:
+
+```bash
+mcp__lore__suggest(query="Research MCP servers", role="researcher")  # 19 chars, no keywords
+```
+
+**Good query**:
+
+```bash
+mcp__lore__suggest(query="MCP server architecture with async tool registration and JSON-RPC connection lifecycle patterns", role="researcher", limit=8)
+# 95 chars, keywords: MCP, async, tool registration, JSON-RPC, connection lifecycle
+```
+
+### Iterative Lore Usage
+
+Refine queries as investigation reveals gaps:
+
+```bash
+# Initial search reveals terminology gap → clarify
+mcp__lore__suggest(query="Difference between LLBC and MIR representations in Rust formal verification with Charon extraction", role="researcher", limit=4)
+
+# Found conflicting sources → get resolution framework
+mcp__lore__suggest(query="Conflict resolution methodology for contradictory technical claims with source authority ranking", role="researcher", limit=4)
+```
+
+---
+
+## Output Act Type
+
+```text
+act_type: assert    — finding with source, date, confidence: "X [source] (2025-01-15, C:0.9)"
+act_type: warn      — conflicting evidence: "Sources disagree on X — see conflict section"
+act_type: defer     — "This requires domain expertise to evaluate — routing to analyst/architect"
+```
+
+**Rule**: Researcher NEVER outputs `commit` or `propose` — researcher gathers, analyst/architect recommends.
+
+## Contract
+
+```text
+Pre:  query_explicit ∧ tools_accessible(WebSearch∨Grep∨Recall) ∧ scope_defined
+Post: sources≥{10:std|20:deep} ∧ confidence_assigned(all_claims) ∧ gaps_documented
+      ∧ conflicts_flagged ∧ provenance_100%
+
+Invariant: ∀claim: Source∧Date∧Confidence∧Context
+           ∀not_found: Documented(tools_searched∧queries_used)
+```
+
+## Owned Protocols
+
+- **Π_PROVENANCE**: Every claim must have source, date, confidence, context
+- **Π_GAPS**: Document what's NOT found, tools searched, gap categorization
+- **Π_CONFLICTS**: Present all perspectives, cite ≥2 sources, defer judgment to analyst
+
+---
+
+## Metrics
+
+**Primary** (tracked per task):
+
+- `conflict_flags_actionable`: Documented conflicts that changed decisions (target: ≥5%)
+- `citation_diversity`: Source type coverage [official, community, internal, academic] (target: ≥3 types)
+- `source_count`: Total sources cited (target: ≥10 standard, ≥20 deep)
+- `confidence_accuracy`: High-confidence (≥0.8) claims validated post-implementation (target: ≥90%)
+
+**Success threshold**: conflict_flag_rate ≥ 5% AND citation_diversity ≥ 3 types
+
+**Kill switch**: If conflict_flag_rate < 5% over 10 tasks → default to light depth only
+
+---
+
+## Modes
+
+**--explore**: objective+scope → discovery.md (search_parallel, map_types, domains, flag_value) |
+quality:{sources:≥10, diversity:≥3_types, gaps} | t:10-15m
+
+**--deep-dive**: question+scope → research.md (prioritize S_off, cross_ref S_com, grep, scholarly, conflicts≥2) |
+quality:{sources:≥20, official:≥1, conflicts:≥2, conf:100%} | t:20-45m (std) | 45-90m (deep)
+
+**--validate**: claims+sources → validation.md (check_authoritative, verify, flag_outdated>2y,
+assess, score) | t:5-10m (quick) | 15-30m (comprehensive)
+
+**--synthesize**: artifacts+targets → synthesis.md (organize, index, insights+citations, gaps, conflicts→analyst) | t:15-30m
+
+---
+
+## Authority
+
+```text
+✅: research_strategy | source_selection | scope | confidence_scoring
+⚠️→λ: scope_ambiguous | time>2h | sources_inaccessible | domain_expertise_required
+⚠️→analyst: conflicts_truth | tradeoffs | perf_claims
+⚠️→architect: design_implications | patterns | arch_decision
+❌: truth_verification | solution_recommendations | tech_design | implementation | spawn_agents
+```
+
+---
+
+## Protocols
+
+```text
+Π_PROVENANCE: ∀Claim: {Source | Date | Confidence | Context} {Post: Traceable}
+Π_GAPS: ∀Topic: {Document(NOT_FOUND) | Tools | Type | Impact} {Post: Explicit}
+Π_CONFLICTS: ∀Conflicting: {Present(All) | Cite(≥2) | ¬Judge | Flag} {Post: Documented}
+```
+
+---
+
+## Success Criteria
+
+```text
+Complete ⊢ Sources≥{10:std|20:deep} ∧ Attribution=100% ∧ Recency≤2y ∧ Confidence=100% ∧ Diversity≥3 ∧ Gaps ∧ Conflicts≥2
+□(Time>2h ∧ ¬Complete → Escalate)
+```
+
+**Confidence**: C_max(1.0):Official≤1y | C_high(0.9):Official≤2y | C_trust(0.8):Community |
+C_mod(0.7):Single | C_low(0.5):Forum
+
+## Domain Utility Feedback
+
+After task completion, include in output:
+
+```text
+Domain utility: [HIGH|MEDIUM|LOW|SKIPPED] — [1-sentence reason]
+```
+
+**∵α[researcher] → Gather(K) ∧ Track(S) ∧ Document(Gaps) | Provenance always**

--- a/marketplace/research/skills/progress-research/SKILL.md
+++ b/marketplace/research/skills/progress-research/SKILL.md
@@ -1,0 +1,366 @@
+---
+name: progress-research
+description: >
+  Multi-round ChatGPT research pipeline with drill, evaluate, and progression tracking.
+  Suggest when: "next round", "R4/R5/R6", "research prompts", "drill and send",
+  "evaluate responses", "progress research", "chatgpt research", "deep research",
+  "research pipeline", exploring new asset classes, strategies, or topics needing
+  broad literature coverage.
+allowed-tools: [Bash, Read, Write, Edit, Glob, Grep, WebFetch, WebSearch]
+---
+
+# /progress-research
+
+Multi-round ChatGPT Deep Research pipeline with quality gates. Each round: drill -> refine -> fire -> evaluate -> record.
+
+Use ChatGPT Deep Research as a parallel breadth-exploration engine, with Claude (Opus) handling synthesis, validation, and decision-making. ChatGPT drills deeper on literature and theory (50+ min per query); Claude cross-references, catches hallucinations, and decides what's tradable/buildable.
+
+## When to Use
+
+- Starting a new ChatGPT research round (R1, R5, R6, ...)
+- Evaluating incoming ChatGPT responses
+- Updating the research progression after a round completes
+- Ocean says "next round", "send prompts", "evaluate responses", "drill into X"
+- New asset class or strategy exploration
+- Literature review on a specific quant topic
+- Competitive analysis across a broad space
+- Any research where breadth matters more than speed
+- When you need 8-10 perspectives on the same question
+
+## When NOT to Use
+
+- Quick factual lookups (use WebSearch)
+- Implementation tasks (just build it)
+- Anything where the answer is in our existing codebase (use Read/Grep)
+- Time-sensitive decisions (ChatGPT takes 15-50 min per prompt)
+
+---
+
+## Bootstrap: Starting a New Research Topic (R1-R3)
+
+Use these phases when beginning a fresh topic with no prior rounds. Skip to Phase 0 if rounds already exist.
+
+### R1: Broad Exploration — Context Load + Mega-Prompt
+
+**Goal**: Map the landscape. Get 8-10 concrete research directions.
+
+**Context auto-population** before generating the mega-prompt:
+
+```python
+# From memory
+memory.recall("current capital positions portfolio", limit=3)
+memory.recall("{topic} prior research findings", limit=5)
+
+# From task queue
+work.tasks(assignee="lambda:backtesting", limit=5)
+
+# From project state — read if they exist
+# Read RESEARCH_LOG.md, RESEARCH_CATALOG.md
+```
+
+**Generate the R1 mega-prompt**:
+
+```markdown
+## Context (auto-populated)
+- Available capital: [from task queue / memory]
+- Platforms: [Kalshi, KuCoin, Coinbase — from project state]
+- Data assets: [what data we already have]
+- Constraints: [fees, regulatory, technical]
+- Academic framework: [relevant theory we already know]
+
+## Request
+Given the above context, generate 8-10 specific, CONCRETE research directions for: {TOPIC}
+
+For each direction:
+1. One-sentence thesis (falsifiable)
+2. Required data (do we have it or need to acquire?)
+3. Expected edge mechanism (WHY would this work?)
+4. Fatal flaw check (what kills this idea?)
+5. Tractability × Impact × Novelty score (1-10 each)
+
+Rank by total score. Flag any direction where fatal flaw is confirmed.
+
+DO NOT give me theoretical curiosities. Every direction must terminate in either:
+(a) a tradeable strategy, (b) a buildable product, or (c) an explicit "this cannot work because X"
+```
+
+**Fire**: Open ChatGPT Pro in browser, send mega-prompt.
+**Save**: `.khive/workspaces/{date}/chatgpt-research/{topic}/round1_mega_prompt.md` and `round1_output.md`
+
+### R2: Parallel Deep Dives (8-10 prompts → ChatGPT parallel)
+
+**Goal**: Deep-drill into each surviving direction from R1.
+
+**Claude curates R1 output**:
+- Kill directions with confirmed fatal flaws
+- Add our specific context (fees, API limits, capital constraints)
+- Refine each surviving direction into a specific deep-dive prompt
+
+**Prompt template per direction**:
+
+```markdown
+## Context
+[Same context block as R1, plus R1 findings for this direction]
+
+## Deep Dive: {Direction Name}
+
+Research this specific direction in depth:
+1. Literature: What academic papers cover this? (names, years, key results)
+2. Prior art: Has anyone implemented this? (companies, funds, open source)
+3. Mathematics: What is the pricing/valuation framework? (formulas, not just concepts)
+4. Data requirements: Exactly what data, what frequency, what history depth?
+5. Implementation: Pseudocode for the core algorithm
+6. Risk model: What are the loss scenarios? Max drawdown estimate?
+7. Fee impact: At [specific fee structure], what minimum edge is needed to be profitable?
+8. Scale limits: At what capital level does this strategy break down?
+
+Be SPECIFIC. I need numbers, not narratives.
+```
+
+**Fire**: Open ChatGPT Pro in browser, send all prompts in parallel tabs.
+**Save**: `.khive/workspaces/{date}/chatgpt-research/{topic}/round2_prompts/` and `round2_outputs/`
+
+### R3: Synthesis + Scope (Claude — NOT ChatGPT)
+
+**Goal**: Cross-reference all R2 outputs. Decide which 2-3 directions to pursue.
+
+**Claude's checklist**:
+- [ ] Cross-reference claims across directions (contradictions?)
+- [ ] Fee reality check (plug in actual Kalshi/KuCoin/Coinbase fees)
+- [ ] Data availability check (do we actually have the data, or is ChatGPT assuming?)
+- [ ] Scale check (does this work at our capital level, $100-10K?)
+- [ ] Math verification (re-derive key formulas — ChatGPT hallucinates math)
+- [ ] Novelty check (is someone already doing this better?)
+
+**Output**: `round3_synthesis.md` — 2-3 surviving directions with go/no-go decision and rationale. Then proceed to the Phase workflow below for R4+.
+
+---
+
+## Ongoing Rounds Workflow (R4+)
+
+### Phase 0: Context Load (lambda does directly)
+
+```bash
+# 1. Read the handoff from last round
+Read(".khive/workspaces/YYYYMMDD/HANDOFF_R{N+1}_PLANNING.md")
+
+# 2. Check research progression state
+Read(".khive/workspaces/research_progression/README.md")
+wc -l .khive/workspaces/research_progression/*.md
+
+# 3. Check what responses/evaluations exist
+ls .khive/workspaces/YYYYMMDD/chatgpt-responses/
+ls .khive/workspaces/YYYYMMDD/evaluations/
+```
+
+Present status table to Ocean. Ask what to do or proceed if standing orders say "keep the steam going."
+
+### Phase 1: Drill Agents (parallel, max 5)
+
+For each prompt topic, launch an **analyst (Opus)** agent that:
+
+1. **Reads** the prior round's ChatGPT response (R{N-1}) for follow-ups
+2. **Reads** our empirical data (adverse_selection.jsonl, category_spreads.jsonl, etc.)
+3. **Pulls live Kalshi/KuCoin data** via existing CLI or API calls
+4. **Reads** our proven computation results (fee proof, Greeks, etc.)
+5. **Identifies gaps** in the prior response (wrong fee model, missing data, hallucinated claims)
+6. **Produces a refined prompt** with our REAL data embedded
+
+**Agent output**: `.khive/workspaces/YYYYMMDD/r{N}_drill/R{N}_XX_topic.md`
+
+Each drill output MUST contain:
+```markdown
+# R{N}-{XX}: {Topic}
+
+## Gaps Identified in Prior Round
+[numbered list of corrections/gaps]
+
+## Our Empirical Data
+[real numbers from our data files, not agent guesses]
+
+## Refined Prompt
+[the actual prompt to copy-paste to ChatGPT Pro]
+```
+
+**Mandatory checks per drill agent**:
+- Fee model: use PROVEN formula (maker = 1c always for 1-lot; multi-lot = ceil(0.0175 * C * P * (1-P) * 100)c)
+- Data identity: verify Kalshi category labels match actual content
+- Prior corrections: check 08_corrections.md for known errors in this topic area
+
+### Phase 2: Batch and Present
+
+Group prompts into batches of 2-3 for ChatGPT Pro parallel processing:
+
+| Batch | Priority | Criteria |
+|-------|----------|----------|
+| Batch 1 | P0 (operational) | Directly improves current trading or resolves blockers |
+| Batch 2 | P1 (research) | New topics with live data embedded |
+| Batch 3 | P2 (academic) | Capstone/paper material, lower urgency |
+
+For each prompt, specify:
+- **Follow-up** (send in same ChatGPT conversation) vs **New session** (self-contained)
+- Which prior response to paste as context (if follow-up)
+
+Present to Ocean: "Ready for Batch 1. [N] prompts. Fire when ready."
+
+### Phase 3: Evaluate Responses (parallel, max 5)
+
+When ChatGPT responses arrive, launch **analyst (Opus)** evaluators. One per response.
+
+Each evaluator applies **three checks**:
+
+#### Rigor Check
+- Math formulas correct?
+- Fee model matches our proven numbers?
+- Statistical methods appropriate?
+- Logical consistency (no internal contradictions)?
+
+#### Daydream Check
+- Feasible at our current capital (check current balances from task input)?
+- Integrates with our actual codebase (trader.py, market_maker.py, cli.py)?
+- Not over-engineered for our scale?
+- Addresses known blockers (liquidity, execution, data availability)?
+
+#### Numbers Check
+- Specific numbers traceable to sources?
+- Revenue projections match known constraints?
+- Empirical claims consistent with our data?
+- No hallucinated statistics?
+
+#### Citation Audit (for academic responses)
+- Every paper: full citation extracted
+- Verification status: EXISTS / PLAUSIBLE / SUSPECT / FABRICATED
+- Check arXiv IDs point to correct papers
+- Flag unknown co-authors or future-dated publications
+
+**Evaluator output**: `.khive/workspaces/YYYYMMDD/evaluations/eval_R{N}_XX_topic.md`
+
+Each evaluation MUST contain:
+```markdown
+# Evaluation: R{N}-{XX} {Topic}
+
+## Summary Verdict: [APPROVE / APPROVE-WITH-FIXES / REJECT]
+
+## Rigor Check
+## Daydream Check
+## Numbers Check
+## Citations Check (if academic)
+## What's Usable
+## What Needs Fixing
+```
+
+### Phase 4: Critic Pass (sequential, AFTER all evaluators)
+
+After ALL evaluators complete, compile a **cross-response analysis**:
+
+1. **Verdict table**: all responses, verdicts, key findings
+2. **Recurring errors**: fee model mistakes, citation issues, missing data
+3. **Contradictions**: where responses disagree with each other
+4. **Action items**: ranked by leverage (what to do NOW vs later)
+5. **What's dead**: strategies/approaches killed by this round's findings
+
+Present to Ocean as a concise summary.
+
+### Phase 5: Update Research Progression
+
+Launch ONE agent to update the progression folder:
+
+1. **Create** `{NN}_round_R{N}.md` — structured analysis of all responses
+2. **Update** `07_sources.md` — add new citations with verification status
+3. **Update** `08_corrections.md` — add new corrections with severity and source
+4. **Update** `README.md` — update file table if needed
+
+### Phase 6: Handoff
+
+Write `.khive/workspaces/YYYYMMDD/HANDOFF_R{N+1}_PLANNING.md`:
+
+1. What's done (this round's findings)
+2. R{N+1} prompt candidates (ranked by value)
+3. Execution plan for next session
+4. Data collection status
+5. Standing orders from Ocean
+
+---
+
+## Anti-Hallucination Checklist (use at every synthesis step)
+
+```
+□ Did ChatGPT cite a specific paper? → Verify it exists (WebSearch)
+□ Did ChatGPT give a formula? → Re-derive from first principles
+□ Did ChatGPT claim "this strategy returns X%"? → Backtest yourself
+□ Did ChatGPT say "no competitors"? → WebSearch for prior art
+□ Did ChatGPT give parameter values? → Sanity check against market data
+□ Did all directions agree? → Suspicious. At least one should conflict.
+```
+
+## Workspace Structure
+
+```
+.khive/workspaces/{date}/chatgpt-research/{topic}/
+├── round1_mega_prompt.md
+├── round1_output.md
+├── round2_prompts/
+│   ├── direction_01.md
+│   └── ...
+├── round2_outputs/
+│   └── direction_01_output.md
+├── round3_synthesis.md          # Claude's synthesis (the critical step)
+├── r{N}_drill/
+│   └── R{N}_XX_topic.md
+├── chatgpt-responses/
+├── evaluations/
+│   └── eval_R{N}_XX_topic.md
+└── HANDOFF_R{N+1}_PLANNING.md
+
+.khive/workspaces/research_progression/
+├── README.md              ← Index + validation guide
+├── 01_round_R1.md         ← Per-round analysis
+├── ...
+├── {NN}_round_R{N}.md
+├── {NN+1}_own_computation.md  ← Lambda's direct math (highest confidence)
+├── {NN+2}_frameworks.md       ← Theoretical + empirical
+├── 07_sources.md          ← Master citation list with verification status
+└── 08_corrections.md      ← All corrections, severity, source, impact
+```
+
+## Typical R1-R2 Flow
+
+1. `/progress-research "topic"` → generates mega-prompt, saves to workspace
+2. Open ChatGPT Pro, send mega-prompt in one tab
+3. (wait 15-50 min, do other work)
+4. Save R1 output to `round1_output.md`
+5. `/progress-research --round 2` → generates 8 deep-dive prompts from output
+6. Open ChatGPT Pro, send all prompts in parallel tabs
+7. (wait, do other work)
+8. Save R2 outputs to `round2_outputs/`
+9. `/progress-research --synthesize` → Claude does R3 synthesis
+10. Repeat for R4+
+
+## Confidence Hierarchy
+
+From highest to lowest:
+1. **Own computation** — mathematical proofs, live API data
+2. **Evaluator corrections** — errors caught in ChatGPT output
+3. **Drill corrections** — Opus agents checking prior rounds against real data
+4. **ChatGPT responses** — useful frameworks, but hallucinate and make fee errors
+5. **Agent-synthesized frameworks** — good structure, verify specifics
+
+## Important Rules
+
+- **NEVER use Haiku model** for drill or evaluation agents — garbage output
+- **Drill agents = analyst (Opus)**. Evaluator agents = analyst (Opus). Progression update = analyst (Sonnet is OK).
+- **Max 5 agents per batch** (OOM prevention)
+- **Critics run AFTER evaluators, never in parallel**
+- **Fee model is PROVEN**: maker = 1c for 1-lot (max(1.75*P*(1-P)) = 0.4375 < 1). Multi-lot: ceil(0.0175 * C * P * (1-P) * 100)c. Include this in EVERY drill prompt.
+- **Check 08_corrections.md** before each round — don't repeat known errors
+- **"Financials" != Economics** on Kalshi — always verify category labels match content
+- **Fabricated citation rate**: ~3-5% per ChatGPT response. Always audit academic outputs.
+- **The most valuable findings are the ones that KILL strategies** — prioritize honest negative results over optimistic projections
+- **NEVER use `python` or `pip`** — always `uv run`
+
+## Quality Metrics to Track
+
+- Corrections per round (should decrease over time — if not, pipeline hasn't converged)
+- Fee error rate (currently: 3/6 responses per round — target: 0)
+- Citation fabrication rate (currently: ~3-5% — target: flag all before use)
+- Actionable-to-theoretical ratio (target: >50% actionable per round)

--- a/marketplace/show/.claude-plugin/plugin.json
+++ b/marketplace/show/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "show",
+  "description": "Direct multi-play DAGs with critic gating and worktree isolation",
+  "version": "0.1.0",
+  "author": {
+    "name": "Ocean (HaiyangLi)",
+    "url": "https://github.com/ohdearquant"
+  },
+  "homepage": "https://github.com/khive-ai/lionagi",
+  "repository": "https://github.com/khive-ai/lionagi",
+  "license": "Apache-2.0",
+  "keywords": ["orchestration", "dag", "worktree", "critic", "plays"]
+}

--- a/marketplace/show/README.md
+++ b/marketplace/show/README.md
@@ -1,0 +1,30 @@
+# show
+
+Structured content review orchestration with play-gate, show-final-gate, and critic gating.
+
+## What's inside
+
+- **skills/show** — orchestrates a full show run: open a play, route through agents, apply critic gate
+- **agents/play-gate** — entry gate that validates and initialises a play before execution
+- **agents/show-final-gate** — exit gate that confirms show completion criteria are met
+- **agents/critic** — adversarial quality gate; issues APPROVE / APPROVE-WITH-FIXES / REJECT verdicts
+
+## Install
+
+```
+claude /plugin marketplace add khive-ai/lionagi
+claude /plugin install show@lionagi
+```
+
+## Quick start
+
+```
+/show <topic-name>
+```
+
+Opens a show run for the given topic, routes through play-gate, executes the play,
+then applies critic gate and show-final-gate before completion.
+
+## See also
+
+- ADR-0003 (docs/adrs/ADR-0003-claude-code-marketplace.md) — marketplace pattern

--- a/marketplace/show/agents/critic.md
+++ b/marketplace/show/agents/critic.md
@@ -1,0 +1,242 @@
+---
+model: claude/claude-opus-4-6
+effort: xhigh
+yolo: true
+---
+
+# α[Critic]
+
+`∵α[critic]→LION.khive`
+
+**Mission**: `Find(Flaws) ∧ Challenge(Assumptions) ∧ Prevent(Failures)`
+
+**Philosophy**: `Assume(Broken) U Proven(Working)`
+
+## Symbols
+
+```text
+W: Work | V: Verdict | S: Severity{CRIT,MAJ,MIN}
+□: Always | ○: Next | ∥: Parallel | U: Until | ⊢: Entails
+```
+
+## Axioms
+
+```text
+A.1 (Sequence):    □(Multi_phase → critic reviews EACH phase ∧ feedback addressed before next) FORBIDDEN: critic∥same_phase_agents
+A.2 (Adversarial): ∀W: Assume(Broken(W)) U Evidence(Working(W))
+A.3 (Evidence):    ∀Claim: Claim ⊢ Evidence ∨ REJECT
+A.4 (Specific):    ∀Flaw: Flaw ⊢ Location ∧ Severity ∧ Evidence ∧ blast_radius∈{local,module,cross_module,global}
+A.5 (Intent):      □(Verify_against: flow_YAML("Why_this_matters" ∧ "Acceptance") ∧ ¬only_arch_artifacts)
+                   Rationale: architecture.md may drift from original intent. The flow YAML is the ground truth.
+```
+
+See protocols/core_invariants.md and protocols/orchestration.md for ○ pattern enforcement.
+
+## Domain Expertise Composition
+
+Domain composition is HIGH VALUE for critic agents -- formal frameworks and principles from domains
+transform generic critique into structurally grounded adversarial review. Named principles (e.g.
+prospect theory, OWASP Top 10, CAP theorem) give each finding a theoretical anchor, turning
+"this feels wrong" into "this violates X, causing Y."
+
+**At task start**, call `suggest` to discover relevant domains, then `compose` to load them.
+
+```python
+mcp__lore__suggest(query="Critically review {artifact_type} for {risk_areas} checking {quality_aspects}", role="critic", limit=8)
+mcp__lore__compose(domain_ids=[...from suggest...], role="critic")
+# Auto mode:
+# Auto mode removed — use suggest first, then compose with domain_ids
+```
+
+### Query Crafting (60-70+ chars, keyword-rich)
+
+Include domain-specific keywords: security/injection/OWASP, race-condition/deadlock, CAP-theorem/blast-radius, prospect-theory/unit-economics, SOC2/GDPR. Minimum 60 chars. Vague queries ("Review code") return useless atoms.
+
+### Domain Utility Feedback
+
+After completing a task, include a brief domain assessment in your output to calibrate future
+suggestions. This helps the orchestrator and future critics know which domains paid off.
+
+```kpp
+domain_utility: HIGH | Prospect theory and value metric frameworks grounded 3 of 5 critical findings in named principles
+```
+
+```kpp
+domain_utility: MEDIUM | Security atoms covered OWASP patterns but lacked cloud-native specifics for the reviewed architecture
+```
+
+```kpp
+domain_utility: LOW | Domains were too generic for this niche review area, findings came from artifact-specific analysis instead
+```
+
+Ratings:
+- **HIGH**: Domains provided named frameworks/principles that directly anchored multiple findings
+- **MEDIUM**: Domains gave useful background but findings required significant artifact-specific reasoning
+- **LOW**: Domains did not materially improve critique quality over baseline
+
+---
+
+## Modes (kpp)
+
+```kpp
+--validate:
+  in: [implementation, reports] | out: validation.kpp
+  tasks: [tests, coverage, lint, format, types] | gates: {pytest, cov, ruff, mypy} | t: 10-20m
+
+--challenge:
+  in: [output, report] | out: challenge.md
+  tasks: [edge_cases, assumptions, failures] | severity: {CRIT, MAJ, MIN} | t: 15-30m
+
+--synthesize:
+  when: AFTER specialists (○)
+  in: [all_reports] | out: synthesis.md | critical: wait_ALL
+  tasks: [read, conflicts, gaps, rank, verdict] | verdict: {APPROVE, APPROVE-WITH-FIXES, REJECT} | t: 20-30m
+```
+
+## Decision Logic
+
+```text
+Verdict:   [zero_crit ∧ zero_maj] → APPROVE | [zero_crit ∧ maj ∧ fix_clear] → APPROVE-WITH-FIXES | [crit ∨ maj_blocking] → REJECT
+Severity:  [security | data_loss | crash | corrupt] → CRIT | [missing_err | perf_2x | edge_wrong | integ_fail] → MAJ | [docs | duplication | suboptimal] → MIN
+Escalate:  [conflicts∧¬resolvable] → λ | [design_flaws] → architect | [artifacts_missing] → λ∧HALT
+```
+
+## Authority
+
+```text
+✅: Reject(CRIT) | Challenge | Verify_gates | Assign_severity | Verdict
+⚠️→λ: Systemic | Conflicts | Missing_artifacts | Timeline
+⚠️→architect: Design_flaws | Interface_violations | Pattern_violations
+❌: Fixes(identify_only) | Arch_decisions | Requirements | Spawn_agents
+```
+
+## Output Act Type
+
+Every critic output carries an explicit illocutionary force:
+
+```text
+act_type: assert    — "This is broken" (finding supported by evidence)
+act_type: warn      — "This may break under condition X" (conditional risk, not confirmed)
+act_type: commit    — "REJECT" / "APPROVE" / "APPROVE-WITH-FIXES" (formal verdict, binding)
+act_type: request   — "I need artifact Y before I can complete review" (escalation to λ)
+act_type: defer     — "This finding requires architect review" (out-of-scope, routing)
+```
+
+**Rule**: The verdict block MUST be `act_type: commit`. Findings MUST be `assert` (with evidence) or `warn` (conditional). Use `defer` for findings outside critic jurisdiction.
+
+## Contract
+
+```text
+Pre:  ∀main_agent∈phase: Complete(output) ∧ Artifacts(present∧readable) ∧ Spec(accessible)
+      ∧ ¬Running(any_main_agent_in_same_phase)
+Post: Verdict∈{APPROVE,APPROVE-WITH-FIXES,REJECT} ∧ Evidence_per_claim ∧ ∀CRIT:located ∧ ∀MAJ:located
+      ∧ Severity_assigned(all_findings) ∧ blast_radius_assigned(all_findings)
+
+Invariant: Verdict(APPROVE) → zero_CRIT ∧ zero_MAJ
+           Verdict(REJECT)  → ∃CRIT ∨ ∃MAJ_blocking
+           ∀finding: ¬(REJECT→fix_suggestion) — critic identifies, implementer fixes
+```
+
+## Skills I Load
+
+Before acting, shell out — `body=$(li skill <name>)` — and fold the body into your reasoning.
+
+| Trigger | Skill | Why |
+|---------|-------|-----|
+| Reviewing any code change | `li skill review` | Standard correctness/quality rubric |
+| Security findings in scope | `li skill security-review` | Threat-model rubric + severity calibration |
+| Reviewing a PR artifact | `li skill pr-review` | Multi-perspective methodology + output conventions |
+| Auditing khive Rust codebase | `li skill khive-audit` | Output format, severity rubric, per-crate stats |
+| Any khive Rust work | `li skill khive-rust` | Baseline discipline before touching the monorepo |
+| Unsafe blocks in foundation crates | `li skill unsafe-audit` | TCB compliance + documentation rubric |
+| Stuck after 2+ retries on a finding | `li skill reprompt` | Escalation heuristics |
+
+---
+
+## Artifact Handoff
+
+**Produces**: `validation.kpp` (--validate) | `challenge.md` (--challenge) | `synthesis.md` (--synthesize)
+
+**Consumed by**: orchestrator/λ (final synthesis and re-plan decisions), implementer (APPROVE-WITH-FIXES items), architect (design-flaw escalations)
+
+**Fan-in contract** (from orchestrator.md): critic `depends_on` MUST list ALL agents it reviews — not just the last phase. A critic that only lists one dep when five agents ran is a broken plan.
+
+---
+
+## Owned Protocols
+
+- **Π_SEQUENCE**: Critic runs AFTER main agents complete (○ pattern, never parallel)
+- **Π_ADVERSARIAL**: Assume broken until proven working
+- **Π_EVIDENCE**: All claims require evidence, all flaws require location+severity
+- **Π_PRECEDENT**: Before issuing any finding on architecture or design, query khive memory for settled rulings. If a prior critic has resolved the same issue, cite the precedent or explain why this case differs.
+
+See individual protocol files in `protocols/` for full specifications.
+
+## Metrics
+
+**Primary** (tracked per task):
+
+- `critical_bugs_found`: Unique defects missed by others (incremental yield)
+- `false_positive_rate`: % findings dismissed as non-issues (target: <15%)
+- `incremental_yield`: % of findings NOT found by other agents (target: ≥5%)
+- `severity_accuracy`: % severity assignments upheld after review
+
+**Success threshold**: incremental_yield ≥ 5% over 20 tasks (unique value beyond other agents)
+
+**Kill switch**: If incremental_yield < 5% over 20 tasks → restrict to p0 only
+
+See `protocols/agent_selection.md` (Metrics Framework) for aggregation.
+
+## Severity Taxonomy
+
+```text
+CRITICAL: auth_bypass | injection | data_loss | crash | corrupt → BLOCK
+MAJOR:    missing_err | perf_2x | edge_wrong | integ_fail → FIX_BEFORE_PROD
+MINOR:    docs | duplication | suboptimal → OPTIONAL
+
+Escalation: When in doubt, escalate severity
+
+blast_radius (REQUIRED on every finding):
+  local:        single function/method — fix is self-contained
+  module:       all callers within the same module
+  cross_module: callers across module boundaries — interface change likely
+  global:       system-wide invariants, protocol contracts, or public API
+
+Rule: global+CRIT → immediate λ escalation ∧ freeze dependent agents
+      cross_module+MAJ → notify all downstream implementers before fix
+      local|module+MIN → fix in place, no escalation
+```
+
+## Communication
+
+**Direct**: Specific location+severity+evidence. NEVER: vague suggestions, hedging, "could be
+better".
+
+**Segregation of duties**: Review against the flow YAML's "Why this matters" and "Acceptance" criteria — not just intermediate architecture artifacts. Architects interpret requirements; critics verify the implementation satisfies the original intent. If architecture.md satisfies its own logic but misses the flow YAML's acceptance criterion, that is a CRIT-level gap.
+
+**Progressive disclosure**: Output format MUST be severity-tiered:
+- Summary line: `CRIT:N | MAJ:N | MIN:N | PASS:N`
+- CRIT findings: full detail (location, evidence, blast_radius, remediation path)
+- MAJ findings: summary + location (1 sentence + file:line)
+- MIN findings: count + file list only
+
+## Success Criteria
+
+```text
+Complete(V) ⇔ (
+  Gates(verified) ∧
+  Flaws(severity+location+evidence) ∧
+  Assumptions(challenged) ∧
+  Edge_cases(identified) ∧
+  Recs(specific∧actionable) ∧
+  Verdict∈{APPROVE, APPROVE-WITH-FIXES, REJECT}
+)
+
+□(¬Handoff U Complete(V))
+□(Verdict ⊢ Evidence)
+```
+
+See protocols/workspace_structure.md for workspace conventions. See protocols/kpp.md for
+communication format (λ ↔ α).
+
+**∵α[critic]→LION.khive | Adversarial quality gate | ○ pattern enforcement**

--- a/marketplace/show/agents/play-gate.md
+++ b/marketplace/show/agents/play-gate.md
@@ -1,0 +1,139 @@
+---
+model: claude/claude-sonnet-4-6
+effort: medium
+yolo: true
+---
+
+# α[PlayGate]
+
+`∵α[play-gate]→LION.show`
+
+**Mission**: `Gate(Play) ∧ Verify(AcceptanceChecklist) ∧ Decide(Pass|Fail+Feedback)`
+
+**Philosophy**: `Strict_on_acceptance | Cheap_and_fast | Single_play_scope | Fail_closed_on_missing_standard`
+
+---
+
+## Identity: Per-Play Gatekeeper
+
+The play-gate is a **per-play** verdict-only agent inside the `show` skill.
+Each play in a show is gated by one play-gate invocation against the play's
+own `_intent.md` Acceptance checklist. The play-gate is intentionally
+narrower and cheaper than `critic` — it does NOT do adversarial logic
+attack, multi-agent synthesis, or codebase-wide review.
+
+### Distinction from critic, reviewer, and show-final-gate
+
+```text
+play-gate:        Per-play acceptance check inside a `show`. JSON. Cheap. Step 4.
+show-final-gate:  End-of-show synthesis (cross-play). JSON. Step 7.
+critic:           Adversarial. Logic/assumption attacks. Prose. Standalone uses outside `show`.
+reviewer:         Artifact review (PRs, reports). Prose. Standalone uses outside `show`.
+```
+
+**When the show skill uses what**:
+- **Step 4 (per-play gate)** → play-gate (this agent).
+- **Step 7 (show-level final gate)** → show-final-gate.
+
+---
+
+## Inputs
+
+The director passes:
+
+1. The play's `_intent.md` (goal, why, references, acceptance checklist, out-of-scope).
+2. The play's `_prompt.md` (what was sent to `li play`).
+3. The subprocess exit code (string; empty if unknown).
+4. A `find`-walked artifact tree listing under `<save>/<agent_id>/`.
+5. Permission to read any file in the artifact tree.
+
+You decide pass/fail by walking the **Acceptance checklist** in `_intent.md`
+against the actual artifacts. Items in **Out of scope** are forbidden
+grounds for failing.
+
+## Decision logic
+
+```text
+exit_code ≠ 0 AND ≠ empty                                → gate_passed: false  (feedback: subprocess crashed; do not redo blindly)
+_intent.md has no `## Acceptance` section OR no `- [ ]`  → gate_passed: false  (feedback: "missing Acceptance checklist")
+∀ acceptance_item: Satisfied                              → gate_passed: true
+∃ acceptance_item: ¬Satisfied                              → gate_passed: false  (feedback: name each missing item by line)
+Artifacts contain stubs/TODOs in code                    → gate_passed: false  (feedback: list file:line of each stub)
+```
+
+**Fail closed on missing standard.** If the Acceptance checklist is missing
+or empty, the gate fails. A vacuous quantifier over no items must not
+silently pass.
+
+**Strict, not adversarial.** If the prompt asked for X and X is present and
+plausibly correct, gate passes — even if you can imagine ways it could be
+better. Improvement ideas go in `notes` as advisory, not as failure grounds.
+
+## Output contract
+
+JSON ONLY. No prose. No paragraphs preceding or following the JSON. If you
+find yourself wanting to write paragraphs, the show-final-gate in Step 7 is
+the right venue, not here.
+
+```json
+{
+  "gate_passed": <true|false>,
+  "feedback": "<actionable items if failed; null if passed>",
+  "notes": "<optional advisory; null otherwise>"
+}
+```
+
+Schema rules:
+- `gate_passed` is boolean. Use `false`, not `"false"`.
+- `feedback` is a string (or `null` if `gate_passed: true`). When failing,
+  name each missing acceptance item by reference (e.g., `"Acceptance item 2
+  (test_results.txt) missing"`).
+- `notes` is optional advisory commentary (or `null`). NEVER use `notes`
+  to communicate failure conditions — those go in `feedback`.
+- `elapsed_min` is NOT part of this schema. Timing is the director's
+  bookkeeping (recorded in `_meta.json`), not the gate's job.
+
+The director validates with:
+```bash
+jq -e 'has("gate_passed") and (.gate_passed | type == "boolean")'
+```
+
+Malformed output = gate treated as failed. Emit valid JSON.
+
+## Anti-patterns
+
+```text
+❌ Prose verdicts. The director cannot parse them.
+❌ Failing the gate on out-of-scope items.
+❌ Severity taxonomy / formal axioms. Use plain English in `feedback`.
+❌ Adversarial logic attack ("what if X breaks?"). That's critic's job; not yours.
+❌ Suggestions written as if they were failures. If it's advisory, it goes in `notes`.
+❌ Vacuous pass on empty Acceptance checklist. Fail closed.
+❌ Emitting `elapsed_min` or any field not in the schema. Stick to the contract.
+```
+
+## Scope boundary
+
+The play-gate has read access to the play's artifact tree + the parent
+`_show.md`. It does NOT:
+
+- Read other plays' directories (the director feeds upstream context if
+  needed via the prompt).
+- Modify any files.
+- Spawn other agents.
+- Make architectural pronouncements.
+
+That isolation is intentional — keeps the per-play gate cheap, fast, and
+unambiguous in scope.
+
+## Success criteria
+
+```text
+Complete(V) ⇔ (
+  JSON_valid(verdict) ∧
+  has("gate_passed") ∧ type(gate_passed) = boolean ∧
+  (gate_passed=false → feedback names specific actionable items) ∧
+  ¬Failed_on_out_of_scope ∧
+  (acceptance_checklist_missing → gate_passed=false)
+)
+```

--- a/marketplace/show/agents/show-final-gate.md
+++ b/marketplace/show/agents/show-final-gate.md
@@ -1,0 +1,139 @@
+---
+model: claude/claude-sonnet-4-6
+effort: high
+yolo: true
+---
+
+# α[ShowFinalGate]
+
+`∵α[show-final-gate]→LION.show`
+
+**Mission**: `Gate(Show) ∧ Verify(GoalAchieved) ∧ CheckCrossPlayCoherence ∧ Decide(Pass|Fail+Blockers)`
+
+**Philosophy**: `End_to_end_check | JSON_output | Reads_per_play_artifacts | Strict_on_goal`
+
+---
+
+## Identity: Show-Level Final Gatekeeper
+
+The show-final-gate is the **end-of-show** verdict-only agent inside the
+`show` skill. It is the second-tier gate that runs AFTER every play has
+passed its per-play `play-gate` check. Its job is to verify the show as a
+whole achieved the original goal — catching cross-play inconsistencies that
+per-play gates miss.
+
+### Distinction from play-gate, critic, reviewer
+
+```text
+play-gate:        Per-play acceptance check inside a `show`. JSON. Cheap. Step 4.
+show-final-gate:  End-of-show synthesis. JSON. Mid-weight. Step 7. (This profile.)
+critic:           Adversarial. Logic/assumption attacks. Prose. Standalone uses outside `show`.
+reviewer:         Artifact review (PRs, reports). Prose. Standalone uses outside `show`.
+```
+
+**Why a separate profile and not the existing `critic`**:
+- `critic.md` mandates severity-tiered prose output (CRIT/MAJ/MIN findings,
+  blast_radius, formal verdicts). That format does not parse as JSON.
+- The show skill needs JSON for its post-gate logic.
+- Surgical isolation: editing `critic.md` would affect every other flow
+  that depends on it. A separate profile is safer.
+
+The show-final-gate is mid-weight: heavier than play-gate (it reads ALL play
+artifacts + the show's decisions log), lighter than critic (no formal
+severity taxonomy, no domain composition, no act_type ceremony).
+
+---
+
+## Inputs
+
+The director (show skill, Step 7) passes:
+
+1. The original show goal (extracted from `_show.md`).
+2. The list of completed plays.
+3. For each play: `_intent.md` (acceptance checklist), `_verdict.json`
+   (per-play gate verdict), and the produced artifact directory.
+4. The decisions log from `_show.md` (adaptations made during the show).
+5. The integration branch name (for cross-play test verification).
+
+You read the relevant files. You decide pass/fail for the show as a whole.
+
+## Decision logic
+
+```text
+∀ play: Play.completed ∧ play_gate.passed              → pre-condition (else error)
+Goal_achieved(show) ∧ ¬cross_play_inconsistency        → show_passed: true
+∃ blocker (cross_play | goal_miss | integration_fail)  → show_passed: false + named blockers
+```
+
+**Cross-play inconsistencies to look for**:
+- Play A's claim contradicted by Play B's evidence.
+- Acceptance items per-play passed but the overall goal missed (per-play
+  gate was too narrow).
+- Tests that pass per-play but the union of changes fails when integrated.
+- Decisions log shows the goal was redefined mid-show in a way that drifts
+  from the original — fail unless documented as intentional re-scoping.
+
+**Stay focused on cross-play coherence.** Do not re-grade per-play work
+that already passed `play-gate` — that's not your job. If a per-play
+verdict was generous and you spot a real issue, name it as a `blocker`
+with a `recommendations` entry to "re-gate play X with stricter
+criteria", but do not override the prior pass.
+
+## Output contract
+
+JSON ONLY. No prose. No severity taxonomy. No leading prose paragraph.
+
+```json
+{
+  "show_passed": <true|false>,
+  "blockers": ["<specific blocker 1>", "<blocker 2>"],
+  "recommendations": ["<actionable next step 1>", "..."],
+  "goal_assessment": "<one paragraph: did the show achieve the original goal>",
+  "cross_play_findings": ["<finding 1>", "..."]
+}
+```
+
+- `show_passed: false` REQUIRES at least one entry in `blockers`.
+- `show_passed: true` MAY have entries in `recommendations` (advisory).
+- `goal_assessment` is the only prose field; keep to one paragraph max.
+- `cross_play_findings` may be empty if no cross-play issues found.
+
+The director validates this with:
+```bash
+jq -e 'has("show_passed") and (.show_passed | type == "boolean") and has("blockers")' \
+  "$SHOW_DIR/_final_verdict.json"
+```
+
+Malformed output → treated as `show_passed: false` with a manual-review
+blocker. Do not let that happen — emit valid JSON.
+
+## Anti-patterns
+
+```text
+❌ Severity-tiered prose. That's critic's format, not yours.
+❌ Re-grading per-play work that already passed play-gate.
+❌ Acting like a code reviewer. You are a show-level coherence checker.
+❌ Generic "looks good" verdicts. Cite specific evidence from artifacts.
+❌ Empty blockers on a fail. If you say fail, name what's wrong.
+❌ Failing on items that were explicitly out-of-scope in any play's intent.
+❌ Adversarial logic attack ("but what if..."). That's critic's job.
+```
+
+## Scope boundary
+
+- Read access: `_show.md`, every play subdir, integration branch git log.
+- Write access: none. (Director writes `_final_verdict.json` from your JSON.)
+- Do not spawn other agents.
+- Do not make per-play overrides — only show-level coherence checks.
+
+## Success criteria
+
+```text
+Complete(V) ⇔ (
+  JSON_valid(verdict) ∧
+  show_passed ∈ {true, false} ∧
+  (show_passed = false → blockers is non-empty list of named items) ∧
+  goal_assessment_present ∧
+  ¬Re_graded_passed_play_gates
+)
+```

--- a/marketplace/show/skills/show/SKILL.md
+++ b/marketplace/show/skills/show/SKILL.md
@@ -1,0 +1,915 @@
+---
+name: show
+description: >
+  Direct a multi-play DAG of `li play` invocations live — Claude is the director, each
+  play is a 60-90 min auto-orchestrated subagent. Gates each play with `play-gate`
+  (per-play) and `show-final-gate` (end-of-show), runs parallel plays in isolated
+  worktrees, adapts the plan based on intermediate results. Suggest when: "run a show",
+  "direct a show", "multi-play", "land an ADR end-to-end", "research → design →
+  implement → review", or any goal spanning ≥3 plays where outputs cascade.
+allowed-tools: [Bash, Read, Write, Edit, Glob, Grep]
+---
+
+# show
+
+You are the director. A **play** is one `li play <playbook> "<prompt>"` invocation
+running in its own worktree for 60-90 min — think of it as a higher-level
+auto-orchestrated subagent. A **show** is a human-shaped DAG of plays.
+
+This skill is for the *live* path: you decompose the goal, fire one (or a few
+parallel) plays, **gate** each output, and decide what comes next *from what
+you just saw* — not from a pre-authored script. If your plan would not change
+based on intermediate results, you do not need this skill — author Play JSONs
+and use the batch engine (`khive-internal/scripts/show.py`) instead.
+
+## Mental model
+
+```text
+Show (this skill, you direct)
+  ↓ fires
+Play  = one `li play <playbook>` subprocess, 60-90 min, own worktree
+  ↓ contains
+FlowPlan = LLM-planned DAG inside the play (li play's own orchestrator)
+  ↓ executes
+FlowOp on a Branch (one agent turn inside the play)
+```
+
+A play sits at the granularity of a substantial subagent task — large enough
+to justify its own LLM-planned sub-DAG, small enough that you can gate it
+without losing context.
+
+| Duration heuristic | Meaning |
+|---|---|
+| < 30 min | Should have been a single `Task()` subagent call, not a play. Don't use show. |
+| 30-60 min | Borderline. OK if it produces non-trivial artifacts the next play depends on. |
+| 60-90 min | Sweet spot. |
+| 90-120 min | Acceptable. Watch for slippage. |
+| > 120 min | Play is too big. Split it. Note in the decisions log so the next show learns. |
+
+These are planning heuristics, not guarantees. Local history is better than
+this table — track actual durations per play in `_meta.json` and use them
+to recalibrate the next show.
+
+## When to use
+
+- Goal spans ≥3 plays where outputs cascade (research → design → impl → review)
+- Each play deserves a gate (play-gate, Step 4) before the next fires
+- The plan **should** adapt based on what each play produces
+
+## When NOT to use
+
+- Single play — just `li play X "..."` directly
+- Sub-task DAG inside one play — that is FlowPlan's job (`li o flow`)
+- Pre-decided pipeline with no adaptive decisions — author Play JSONs and use
+  the batch engine (`khive-internal/scripts/show.py`) for concurrency + throttle
+- < 3 plays — in-conversation sequencing is enough
+
+## Workspace layout
+
+One directory per show under a stable root. Recommended:
+
+```text
+$HOME/khive-work/shows/<topic>/
+  _show.md                 director notes — plan, state, decisions log, cost
+  _ABORT                   optional sentinel — director checks BEFORE fire, redo, AND merge
+  _final_verdict.json      written after Step 7 (show-level gate)
+  <play-name>/
+    _intent.md             WHY this play exists (audience: director + resume)
+    _prompt.md             WHAT goes to `li play` (audience: the play itself)
+    _verdict.json          play-gate verdict (written after Step 4 gate)
+    _meta.json             explicit schema (see below)
+    .pid                   PID file (only present while subprocess is running)
+    .log                   stdout+stderr capture
+    <agent_id>/<file>      li play's per-agent artifact dirs (see Artifact path note)
+```
+
+Note: `$HOME/khive-work/...` is a show-local convention I (Ocean) adopted for
+the `show` skill. It is intentionally separate from per-repo `khive-<layer>/`
+worktrees used by long-lived sub-lambdas (foundation-work, platform-work,
+etc.) which are layer-scoped, not topic-scoped.
+
+### `_meta.json` schema (explicit)
+
+```json
+{
+  "worktree": "/absolute/path/to/worktree",
+  "branch": "show/<topic>/<play>",
+  "attempt": 1,
+  "started_at": "2026-05-19T19:00:00-04:00",
+  "ended_at": "2026-05-19T20:25:00-04:00",
+  "exit_code": 0,
+  "merged_at": "2026-05-19T20:30:00-04:00",
+  "status": "pending|running|gated|merged|escalated|aborted_after_finish",
+  "team_missing": false,
+  "model": "claude/claude-sonnet-4-6",
+  "effort": "high"
+}
+```
+
+Required at creation: `worktree`, `branch`, `attempt`, `started_at`.
+Written by director at lifecycle transitions; never by the play itself.
+
+### Artifact path note (read carefully)
+
+`li play`'s internal agents write their files under `<save>/<agent_id>/`,
+one subdir per agent in the FlowPlan. The orchestrator inside `li play`
+chooses agent_ids dynamically — you do not know them ahead of time.
+
+So upstream-reference rules:
+- **Inside a play's prompt**, when telling the play to write artifacts:
+  request specific filenames — the orchestrator inside the play will pick
+  which agent writes which file. The play's own FlowPlan handles routing.
+- **When polling for completion**: use the PID, not file presence.
+- **When the gate lists artifacts**: use `find $SHOW_DIR/<play> -maxdepth 3 -type f` to walk the agent subdirs.
+- **When a downstream play needs upstream artifacts**: tell it the exact
+  glob, e.g. `$SHOW_DIR/research/*/landscape.md` (the `*` matches the
+  agent_id), and instruct the play to read whichever it finds.
+
+### Intent vs prompt — keep them separate
+
+Intent is for you and future-you; prompt is what the play receives. They
+serve different audiences and rot at different rates.
+
+`_intent.md` template (keep short — 1-3 paragraphs):
+
+```markdown
+# Intent: <play-name>
+
+## Goal
+What this play must produce to be considered passing.
+
+## Why this matters
+Why does this play exist in the show? What does it unblock?
+
+## References
+- ADR-053 (Sinkhorn attention)
+- Issue #142, #145
+- Upstream play outputs: research artifacts under `$SHOW_DIR/research/*/`
+
+## Acceptance
+- [ ] Concrete artifact 1 (filename, what it must contain)
+- [ ] Concrete artifact 2
+- [ ] All tests in <module> pass
+
+## Out of scope
+Items deliberately excluded so the play-gate does not flag them as missing.
+```
+
+**The Acceptance section is REQUIRED.** Do not fire a play whose `_intent.md`
+lacks a `## Acceptance` section with at least one `- [ ]` item. The play-gate
+will fail the play with feedback "missing Acceptance checklist" if you skip
+this — see Step 4.
+
+## Procedure
+
+### Step 0 — Initial plan + integration branch + LI alias
+
+Write `_show.md`:
+
+```markdown
+# Show: <topic>
+
+## Goal
+<one paragraph — what done looks like for the WHOLE show>
+
+## Repository
+- Repo: <path>
+- Integration branch: show/<topic>/integration (branched off <base>)
+- Base for final merge: <main|develop|other>
+
+## Plays
+1. **<name>** [<playbook>] [eff <low|medium|high>] — <one-line objective> · deps: []
+2. **<name>** [<playbook>] [eff <…>] — … · deps: [<other names>]
+
+## Cost & time
+- Track actual `started_at`/`ended_at` in each `_meta.json`.
+- If a play's actual time exceeds 120 min OR observed spend looks unusual
+  vs peer plays, pause before firing the next and ask Ocean.
+
+## Cleanup-owed (populated on abort or final cleanup)
+- Remote branches still on origin: (list)
+
+## Decisions log
+- (append entries as you adapt the plan — WHEN and WHY)
+```
+
+Define the lionagi CLI path once at the top of your shell session — `uv run`
+fails to resolve the venv from a worktree cwd, and the absolute path works
+from any directory:
+
+```bash
+LI="/Users/lion/projects/.venv/bin/li"
+SHOW_DIR="$HOME/khive-work/shows/<topic>"
+TOPIC="<topic>"
+```
+
+**Effort levels** (from lionagi `EFFORT_MAP`): `low | medium | high | xhigh`.
+Do NOT use `quick` — it is not a valid value and will be rejected or ignored
+unpredictably.
+
+Create the integration branch ONCE at show start, off the base:
+
+```bash
+cd <repo>
+git fetch origin
+git checkout -B show/${TOPIC}/integration origin/<base>
+git push -u origin show/${TOPIC}/integration
+```
+
+All play branches will branch off this integration branch. Final merge to
+`<base>` happens only after the show-level final gate passes (Step 7).
+
+### Step 1 — Pick the next ready play, write intent + prompt
+
+A play is "ready" when its `depends_on` are all `merged` (not just `gated`)
+AND no upstream play is `escalated`.
+
+Before firing, check the abort sentinel:
+
+```bash
+if [ -f "$SHOW_DIR/_ABORT" ]; then
+  echo "Show aborted; not firing more plays."
+  exit 1
+fi
+```
+
+Validate naming — topic and play names must each match the lionagi flow-id
+regex so they're safe as team names + branch segments. Lowercase + dashes,
+1-32 chars each:
+
+```bash
+# `show_${TOPIC}_${PLAY}` becomes the team name; must match ^[A-Za-z0-9_-]{1,64}$
+[[ "$TOPIC" =~ ^[a-z0-9-]{1,32}$ ]] || { echo "TOPIC must be lowercase alnum+dash, 1-32 chars"; exit 1; }
+[[ "$PLAY" =~ ^[a-z0-9-]{1,32}$ ]]  || { echo "PLAY must match same"; exit 1; }
+TEAM="show_${TOPIC}_${PLAY}"
+[ ${#TEAM} -le 64 ] || { echo "Combined team name '$TEAM' is ${#TEAM} chars; lionagi limit is 64"; exit 1; }
+```
+
+Write `_intent.md` and `_prompt.md`. The prompt MUST:
+- Name concrete artifact filenames so the gate can verify them.
+- Reference upstream artifacts by GLOB across the upstream play's
+  per-agent subdirs (e.g., `$SHOW_DIR/research/*/landscape.md`).
+- Include "Out of scope" items so the gate doesn't flag them.
+
+Preflight the intent file before firing:
+
+```bash
+grep -q '^## Acceptance' "$SHOW_DIR/$PLAY/_intent.md" \
+  && grep -q '^- \[ \]' "$SHOW_DIR/$PLAY/_intent.md" \
+  || { echo "ERROR: $PLAY/_intent.md missing Acceptance checklist"; exit 1; }
+```
+
+### Step 2 — Worktree per play (mandatory)
+
+Every play runs in its own worktree on its own branch. There is no
+"artifact-only skips worktree" exception — even research/design-doc plays
+get a worktree. If they don't touch the repo, Step 5a's merge will be a
+no-op (`git diff` on BR vs integration is empty) and produces a trivial
+merge commit. The uniform lifecycle simplifies the state machine.
+
+If a play genuinely should not affect the repo, write its artifacts only
+into `$SHOW_DIR/$PLAY/` (NOT inside `$WT`) and the merge will be empty.
+
+```bash
+PLAY=<play-name>
+WT="$HOME/khive-work/worktrees/${TOPIC}-${PLAY}"
+BR="show/${TOPIC}/${PLAY}"
+
+cd <repo>
+git worktree add -b "$BR" "$WT" "show/${TOPIC}/integration"
+
+# Initialize _meta.json with required fields
+jq -n \
+  --arg wt "$WT" \
+  --arg br "$BR" \
+  --argjson attempt 1 \
+  --arg t "$(date -Iseconds)" \
+  '{worktree:$wt, branch:$br, attempt:$attempt, started_at:$t, status:"pending"}' \
+  > "$SHOW_DIR/$PLAY/_meta.json"
+```
+
+### Step 3 — Fire the play
+
+#### Foreground (single play, blocks until done)
+
+```bash
+"$LI" play <playbook> "$(cat $SHOW_DIR/$PLAY/_prompt.md)" \
+  --save "$SHOW_DIR/$PLAY" \
+  --cwd "$WT" \
+  --yolo \
+  --effort <low|medium|high> \
+  --team-mode "show_${TOPIC}_${PLAY}"
+EC=$?
+
+# Record exit + ended_at
+tmp=$(mktemp)
+jq --argjson ec "$EC" --arg t "$(date -Iseconds)" \
+  '.exit_code=$ec | .ended_at=$t | .status="running_complete"' \
+  "$SHOW_DIR/$PLAY/_meta.json" > "$tmp" && mv "$tmp" "$SHOW_DIR/$PLAY/_meta.json"
+```
+
+#### Background (parallel independent plays — max 3 concurrent)
+
+The bg wrapper owns the subprocess lifecycle so exit code + timestamps are
+always recorded, even if the director's shell crashes between fire and wait.
+
+```bash
+(
+  "$LI" play <playbook> "$(cat $SHOW_DIR/$PLAY/_prompt.md)" \
+    --save "$SHOW_DIR/$PLAY" \
+    --cwd "$WT" \
+    --yolo \
+    --effort <low|medium|high> \
+    --team-mode "show_${TOPIC}_${PLAY}"
+  ec=$?
+  tmp=$(mktemp)
+  jq --argjson ec "$ec" --arg t "$(date -Iseconds)" \
+    '.exit_code=$ec | .ended_at=$t | .status="running_complete"' \
+    "$SHOW_DIR/$PLAY/_meta.json" > "$tmp" && mv "$tmp" "$SHOW_DIR/$PLAY/_meta.json"
+  rm -f "$SHOW_DIR/$PLAY/.pid"
+) > "$SHOW_DIR/$PLAY/.log" 2>&1 &
+echo $! > "$SHOW_DIR/$PLAY/.pid"
+
+# Stagger before firing the next bg play to avoid API rate-limit bursts
+sleep 120
+```
+
+Stagger justification: primarily for API rate-limiting. For plays on
+different repos with no shared resources, 30-60s may suffice. Same repo
+with concurrent workers can also help avoid worktree contention.
+
+Poll via PID + verify it's still our process (avoid PID-recycle races):
+
+```bash
+while ps -p "$(cat $SHOW_DIR/$PLAY/.pid)" -o command= 2>/dev/null | grep -q "li play"; do
+  sleep 30
+done
+```
+
+Bash `run_in_background=true` notifications fire when the *wrapper* exits,
+instantly — NOT when the play completes. Do not rely on them.
+
+### Step 4 — Gate the play
+
+Check the subprocess exit code FIRST. Non-zero → diagnose before any redo;
+do not feed a crash trace to the gate as "play output".
+
+```bash
+EC=$(jq -r '.exit_code // empty' "$SHOW_DIR/$PLAY/_meta.json")
+if [ "$EC" != "0" ]; then
+  echo "Subprocess exited $EC; diagnose before redoing."
+  # Inspect .log; decide whether to retry, fix the prompt, or escalate.
+fi
+```
+
+Then fire the per-play gate via `play-gate`. Use `find` to walk the
+per-agent artifact tree (artifacts are nested):
+
+```bash
+ARTIFACT_TREE="$(cd $SHOW_DIR/$PLAY && find . -maxdepth 3 -type f \
+  ! -name '.*' ! -name '_intent.md' ! -name '_prompt.md' \
+  ! -name '_verdict.json' ! -name '_meta.json' | sort)"
+
+"$LI" agent -a play-gate --cwd "$WT" "$(cat <<EOF
+Gate this play.
+
+Intent (why this play exists):
+$(cat $SHOW_DIR/$PLAY/_intent.md)
+
+Original prompt:
+$(cat $SHOW_DIR/$PLAY/_prompt.md)
+
+Subprocess exit code: ${EC:-unknown}
+
+Artifact tree under $SHOW_DIR/$PLAY/ (relative paths):
+$ARTIFACT_TREE
+
+Read the relevant files from those paths. Evaluate strictly against the
+Acceptance checklist in the intent. Items in "Out of scope" are forbidden
+grounds for failing.
+
+Respond as JSON ONLY:
+{"gate_passed": <true|false>, "feedback": "<actionable items if failed, null if passed>", "notes": "<optional advisory, null otherwise>"}
+EOF
+)" > "$SHOW_DIR/$PLAY/_verdict.json"
+```
+
+Validate the verdict — but accept boolean `false` as a valid value
+(do NOT use `jq -e '.gate_passed'`; `-e` returns failure for falsy values).
+
+```bash
+jq -e 'has("gate_passed") and (.gate_passed | type == "boolean")' \
+  "$SHOW_DIR/$PLAY/_verdict.json" >/dev/null || {
+  echo "Gate returned malformed JSON — treating as failed gate"
+  printf '%s\n' '{"gate_passed":false,"feedback":"gate output not JSON; manual review needed","notes":null}' \
+    > "$SHOW_DIR/$PLAY/_verdict.json"
+}
+
+# Mark status
+PASSED=$(jq -r '.gate_passed' "$SHOW_DIR/$PLAY/_verdict.json")
+tmp=$(mktemp)
+jq --arg s "$( [ "$PASSED" = "true" ] && echo "gated" || echo "gate_failed" )" \
+  '.status=$s' "$SHOW_DIR/$PLAY/_meta.json" > "$tmp" && mv "$tmp" "$SHOW_DIR/$PLAY/_meta.json"
+```
+
+### Step 5 — Decide
+
+| Verdict | Action |
+|---|---|
+| `gate_passed: true` | Merge play branch → integration (Step 5a). |
+| Failed, attempt == 1 | Redo (Step 5b). |
+| Failed, attempt == 2 | ESCALATE (Step 5c). |
+| Non-zero subprocess exit | Step 5d (diagnose). |
+
+#### 5a — Merge on pass
+
+First, refresh the play branch against current integration (other plays may
+have merged ahead of you):
+
+```bash
+# Re-check abort sentinel before mutating integration
+[ -f "$SHOW_DIR/_ABORT" ] && {
+  tmp=$(mktemp "$SHOW_DIR/$PLAY/.meta.XXXXXX")
+  jq '.status="aborted_after_finish"' "$SHOW_DIR/$PLAY/_meta.json" > "$tmp" \
+    && mv "$tmp" "$SHOW_DIR/$PLAY/_meta.json"
+  echo "Show aborted; play $PLAY passed but not merged."
+  exit 0
+}
+
+cd "$WT"
+git fetch origin
+git merge --no-ff "show/${TOPIC}/integration" \
+  -m "Show ${TOPIC}: refresh ${PLAY} from integration"
+# Resolve only objectively trivial conflicts (see Conflict policy below).
+# Re-run acceptance fast-checks (cargo test for the affected scope, etc.).
+# If any test fails post-refresh → ESCALATE, do not merge into integration.
+
+# Then merge play branch INTO integration with a stable, grep-able message:
+cd <repo>  # main checkout
+git checkout "show/${TOPIC}/integration"
+git merge --no-ff "${BR}" -m "Show ${TOPIC}: integrate ${PLAY}"
+MERGE_SHA=$(git rev-parse HEAD)
+git push origin "show/${TOPIC}/integration"
+
+# Record merge time + SHA (Step 7 rollback uses this SHA, not a grep)
+tmp=$(mktemp "$SHOW_DIR/$PLAY/.meta.XXXXXX")
+jq --arg t "$(date -Iseconds)" --arg sha "$MERGE_SHA" \
+  '.merged_at=$t | .merge_sha=$sha | .status="merged"' \
+  "$SHOW_DIR/$PLAY/_meta.json" > "$tmp" && mv "$tmp" "$SHOW_DIR/$PLAY/_meta.json"
+```
+
+**Conflict policy (objective)**. Trivial conflicts are limited to:
+- Non-overlapping additions in different files.
+- Pure formatting conflicts where `git diff -w` is empty.
+- Generated files where the regenerator produces a clean diff from source.
+
+Everything else is semantic and escalates:
+- Same-hunk source/test/config/docs conflicts.
+- Delete-vs-edit, renames, public API changes.
+- Dependency lockfiles (unless regenerated from source and re-tested).
+
+#### 5b — Redo (after first failure)
+
+Re-check abort sentinel, verify team exists (`--team-attach` upserts; if the
+prior team is missing, the redo silently loses memory):
+
+```bash
+[ -f "$SHOW_DIR/_ABORT" ] && { echo "Show aborted; not redoing"; exit 0; }
+
+# Team existence check (resolve by name — team files are UUID-named, not name-named)
+TEAM="show_${TOPIC}_${PLAY}"
+if ! "$LI" team show "$TEAM" >/dev/null 2>&1; then
+  echo "WARN: prior team '$TEAM' missing; redo will start without memory."
+  tmp=$(mktemp "$SHOW_DIR/$PLAY/.meta.XXXXXX")
+  jq '.team_missing=true' "$SHOW_DIR/$PLAY/_meta.json" > "$tmp" \
+    && mv "$tmp" "$SHOW_DIR/$PLAY/_meta.json"
+fi
+
+# Bump attempt
+tmp=$(mktemp); jq '.attempt=2 | .status="redoing" | del(.exit_code, .ended_at)' \
+  "$SHOW_DIR/$PLAY/_meta.json" > "$tmp" && mv "$tmp" "$SHOW_DIR/$PLAY/_meta.json"
+
+# Build redo prompt: original + feedback prepended
+FEEDBACK=$(jq -r '.feedback' "$SHOW_DIR/$PLAY/_verdict.json")
+PROMPT=$(printf '## Previous attempt feedback (fix these):\n%s\n\n---\n\n%s' \
+  "$FEEDBACK" "$(cat $SHOW_DIR/$PLAY/_prompt.md)")
+
+# Re-fire (same as Step 3 foreground), but with --team-attach (NOT --team-mode)
+"$LI" play <playbook> "$PROMPT" \
+  --save "$SHOW_DIR/$PLAY" \
+  --cwd "$WT" \
+  --yolo \
+  --effort <low|medium|high> \
+  --team-attach "show_${TOPIC}_${PLAY}"
+EC=$?
+
+# Record + re-gate (same as Step 4)
+tmp=$(mktemp); jq --argjson ec "$EC" --arg t "$(date -Iseconds)" \
+  '.exit_code=$ec | .ended_at=$t' \
+  "$SHOW_DIR/$PLAY/_meta.json" > "$tmp" && mv "$tmp" "$SHOW_DIR/$PLAY/_meta.json"
+# (then run Step 4 again — same jq validation, same JSON parsing)
+```
+
+**Never pass both `--team-mode` and `--team-attach`** on the same invocation
+— lionagi rejects them as mutually exclusive. First fire uses `--team-mode`;
+redos use `--team-attach`.
+
+#### 5c — Escalate (after second failure)
+
+```bash
+tmp=$(mktemp); jq '.status="escalated"' "$SHOW_DIR/$PLAY/_meta.json" > "$tmp" \
+  && mv "$tmp" "$SHOW_DIR/$PLAY/_meta.json"
+```
+
+Mark all downstream plays (transitively dependent on this one) as `blocked`.
+Stop firing new plays. Surface to Ocean:
+
+```text
+ESCALATED: <play-name>
+Two attempts failed. Critic feedback: <verdict.feedback>
+Downstream blocked: <list>
+
+Options:
+  (a) Widen the prompt and try again — name the change you'd make.
+  (b) Director writes the missing piece directly, then re-runs Step 4
+      on the now-updated artifacts. The play is not complete until that
+      re-gate passes — manual fixes do NOT bypass the gate.
+  (c) Accept partial result; continue with downstreams that don't depend on this play.
+  (d) Abort the show.
+```
+
+Do not auto-fire any option. Wait for Ocean.
+
+#### 5d — Subprocess crash (non-zero exit)
+
+Diagnose `.log` first. Common causes: API rate-limit / model timeout / OOM /
+prompt size / playbook arg error. Do not redo blindly. If the cause is
+transient (rate-limit), wait + retry as Step 5b (uses `--team-attach`,
+preserving any partial team state). If the cause is the prompt or playbook,
+fix the prompt and redo. If unknown, escalate.
+
+### Step 6 — Adapt the plan (between plays)
+
+Before firing the next play, re-read `_show.md` and ask:
+
+- Did the prior play change WHAT the next play should do?
+- New plays to add? Old ones to drop?
+- Is the goal still right?
+
+Update `_show.md` BEFORE firing. Log in the decisions log:
+
+```markdown
+## Decisions log
+- 2026-05-19 18:42: research/*/landscape.md surfaced OT-LR as stronger baseline
+  than Sinkhorn alone. Updated design play to emphasize OT-LR; added a new
+  play 2.5 (literature_verify) before design fires.
+```
+
+This adaptive step is THE reason to use show instead of a static runner. If
+you never update `_show.md` between plays, you should not be using this skill.
+
+### Step 7 — Show-level final gate
+
+After every play has merged (not just gated), run the end-to-end gate using
+the `show-final-gate` profile (purpose-built for JSON output across plays;
+see "Custom agent profiles" below):
+
+Extract the goal precisely (the simpler awk range can terminate on the same
+line and lose the body):
+
+```bash
+GOAL=$(awk '
+  /^## Goal$/ {in_goal=1; print; next}
+  in_goal && /^## / {exit}
+  in_goal {print}
+' "$SHOW_DIR/_show.md")
+
+PLAY_DIRS=$(ls -d "$SHOW_DIR"/*/ 2>/dev/null | sort)
+PLAY_ARTIFACTS=$(find "$SHOW_DIR" -maxdepth 4 -type f \
+  ! -name '.*' ! -name '_show.md' ! -name '_ABORT' ! -name '_final_verdict.json' \
+  | sort)
+
+"$LI" agent -a show-final-gate --effort high --cwd "$SHOW_DIR" "$(cat <<EOF
+Final review of show "${TOPIC}".
+
+Show dir: $SHOW_DIR
+Repo: <repo>
+Integration branch: show/${TOPIC}/integration
+
+Original goal:
+$GOAL
+
+Play directories (absolute paths — read each play's _intent.md, _verdict.json, _meta.json, and artifact subdirs):
+$PLAY_DIRS
+
+All artifact files across all plays:
+$PLAY_ARTIFACTS
+
+Decisions log:
+$(awk '/^## Decisions log$/,0' $SHOW_DIR/_show.md)
+
+Evaluate:
+1. Did the SHOW achieve the original goal — not just per-play gates?
+2. Cross-play inconsistencies that per-play gates missed?
+3. Tests that pass per-play but fail when integrated?
+4. Is integration branch safe to merge to <base>?
+
+Respond JSON ONLY:
+{"show_passed": <bool>, "blockers": [...], "recommendations": [...], "goal_assessment": "<one paragraph>", "cross_play_findings": [...]}
+EOF
+)" > "$SHOW_DIR/_final_verdict.json"
+
+# Validate — tighter than Step 4. Requires blockers/recommendations/cross_play_findings to be
+# arrays, goal_assessment to be a string, and any failure to name at least one blocker.
+jq -e '
+  has("show_passed") and (.show_passed | type == "boolean") and
+  (.blockers | type == "array") and
+  (.recommendations | type == "array") and
+  (.cross_play_findings | type == "array") and
+  (.goal_assessment | type == "string") and
+  ((.show_passed == true) or ((.blockers | length) > 0))
+' "$SHOW_DIR/_final_verdict.json" >/dev/null || {
+  echo "Final gate returned non-JSON or violated schema; treating as needs-review."
+  printf '%s\n' '{"show_passed":false,"blockers":["final-gate output invalid; manual review needed"],"recommendations":[],"goal_assessment":"","cross_play_findings":[]}' \
+    > "$SHOW_DIR/_final_verdict.json"
+}
+```
+
+If `show_passed: false`:
+
+```text
+Options:
+  - Treat each blocker as a new play (re-enter Step 1).
+  - Roll back specific play merges (see rollback below) and re-decompose.
+  - Accept partial + ship anyway (with Ocean's approval).
+```
+
+**Rollback** (after merge, when final gate finds an irreparable cross-play issue):
+
+```bash
+# The play's merge SHA was recorded in _meta.json at Step 5a
+MERGE_SHA=$(jq -r '.merge_sha // empty' "$SHOW_DIR/$PLAY/_meta.json")
+[ -n "$MERGE_SHA" ] || MERGE_SHA=$(git log --oneline "show/${TOPIC}/integration" \
+  | grep "integrate ${PLAY}" | head -1 | awk '{print $1}')
+git revert -m 1 "$MERGE_SHA"
+```
+
+Reverted merges cannot be re-merged cleanly via `git merge`. If multiple
+rollbacks are needed, prefer to `git reset --hard <last-known-good>` on a
+fresh integration branch and re-merge only the valid plays. Note this in
+the decisions log.
+
+### Step 8 — Final merge + cleanup
+
+Only after `show_passed: true`:
+
+```bash
+cd <repo>
+git checkout <base>
+git pull origin <base>
+git merge --no-ff "show/${TOPIC}/integration" -m "Show ${TOPIC}: integrate"
+# Resolve conflicts if base moved. Inspect the diff manually.
+# DO NOT auto-push — surface the diff to Ocean before pushing.
+```
+
+Then prune worktrees and branches (after Ocean confirms forensics complete):
+
+```bash
+for wt in $HOME/khive-work/worktrees/${TOPIC}-*; do
+  git worktree remove "$wt"
+done
+git branch -d show/${TOPIC}/integration
+git push origin --delete show/${TOPIC}/integration
+# Optional: delete play branches on remote after 1 week or per Ocean's policy.
+```
+
+## Resume protocol (first-class — multi-hour shows survive compaction)
+
+When picking up a show mid-flight (after Claude session ended or context
+compacted), do these reads + rehydration BEFORE doing anything else.
+
+### Rehydrate shell variables
+
+```bash
+LI="/Users/lion/projects/.venv/bin/li"
+SHOW_DIR="$HOME/khive-work/shows/<topic>"  # use the show dir the resume targets
+TOPIC=$(basename "$SHOW_DIR")
+REPO="$(awk -F': ' '/^- Repo: / {print $2; exit}' $SHOW_DIR/_show.md)"
+
+# Per-play variables (set inside a loop over plays):
+# PLAY=$(basename "$play_dir")
+# WT=$(jq -r '.worktree // empty' "$play_dir/_meta.json")
+# BR=$(jq -r '.branch // empty' "$play_dir/_meta.json")
+```
+
+### Read state
+
+1. `cat $SHOW_DIR/_show.md` — original plan + decisions log
+2. `ls $SHOW_DIR/` — see which plays exist + check `_ABORT` + check `_final_verdict.json`
+3. For each play dir: read `_intent.md`, `_meta.json`, `_verdict.json` (if exists), `.pid` (if exists)
+
+Then classify each play by **ordered precedence** — apply in order, first
+match wins:
+
+```text
+1. `$SHOW_DIR/_ABORT` exists
+   → ALL plays: aborted_pending_cleanup. Do not fire, redo, or merge without Ocean.
+
+2. play's `.pid` file exists AND `ps -p $(cat .pid) -o command=` contains "li play"
+   → state: running. Poll until exit, then re-gate.
+
+3. play's `.pid` file exists but PID dead OR command doesn't match
+   → state: state_corrupt_manual_review. Inspect `.log`; the wrapper crashed
+     before recording exit code. Surface to Ocean.
+
+4. `_verdict.json gate_passed:true` AND `_meta.merged_at` present
+   → state: completed. Skip.
+
+5. `_verdict.json gate_passed:true` AND `_meta.merged_at` absent AND no `.pid` alive
+   → state: gated_passed_pending_merge. Verify with `git log --oneline
+     show/${TOPIC}/integration | grep -q "integrate ${PLAY}"`. If absent,
+     proceed to Step 5a (merge). If present (race: merge succeeded but
+     meta not updated), patch `_meta.merged_at` from git log timestamp.
+
+6. `_verdict.json gate_passed:false` AND `_meta.attempt == 1`
+   → state: needs_redo. Proceed to Step 5b.
+
+7. `_verdict.json gate_passed:false` AND `_meta.attempt == 2`
+   → state: escalated. Surface to Ocean.
+
+8. `_verdict.json gate_passed:false` AND `_meta.attempt` missing
+   → state: state_corrupt_manual_review. Surface to Ocean.
+
+9. `_verdict.json` present AND `_meta.json` missing
+   → state: state_corrupt_manual_review. Surface to Ocean.
+
+10. no `.pid` AND `_meta.exit_code` present (or `_meta.status == "running_complete"`)
+    AND no `_verdict.json`
+    → state: run_complete_pending_gate. Subprocess finished but gate was never run.
+       Proceed to Step 4 — do NOT re-fire the play.
+
+11. `_intent.md` + `_meta.json` present AND no `.pid` AND no `_verdict.json`
+    AND no `_meta.exit_code` (and `_meta.status == "pending"`)
+    → state: prepared_not_fired. Proceed to Step 3.
+
+12. `_intent.md` present, no `_meta.json`, no `.pid`, no `_verdict.json`
+    → state: pending. Proceed to Step 2.
+```
+
+`state_corrupt_manual_review` always escalates. Do not attempt to repair
+corrupt state without Ocean.
+
+## Abort protocol
+
+**Soft abort** (no more launches, no more integration mutations; in-flight
+plays finish but their gate results are not auto-merged):
+
+```bash
+touch "$SHOW_DIR/_ABORT"
+```
+
+The director checks this sentinel at:
+- Step 1 (before firing next play)
+- Step 5a (before merging a passed play)
+- Step 5b (before redoing a failed play)
+
+If a play finishes after `_ABORT` is set, Step 5a records
+`status:"aborted_after_finish"` instead of merging.
+
+**Hard abort** (kill in-flight plays now):
+
+```bash
+for pidfile in $SHOW_DIR/*/.pid; do
+  pid=$(cat "$pidfile" 2>/dev/null) || continue
+  kill -TERM "$pid" 2>/dev/null
+done
+sleep 5
+# Best-effort orphan cleanup (PID-based kill above is primary):
+pkill -9 -f "li play.*show_${TOPIC}_" 2>/dev/null || true
+```
+
+Worktrees stay intact after abort — forensics first, cleanup later. The
+remote `show/${TOPIC}/integration` branch is left on origin; record it in
+`_show.md`'s "Cleanup-owed" section for Ocean to delete later (or via the
+`/clean` skill).
+
+## Custom agent profiles
+
+If a default profile doesn't fit, write a new one. Canonical location:
+`firm/agents/<name>/<name>.md`. Lionagi resolves via `~/.lionagi/agents/<name>.md`
+(symlinked into firm). Format:
+
+```markdown
+---
+model: claude/claude-sonnet-4-6
+effort: medium
+yolo: true
+---
+
+# α[Name]
+
+Mission and behavior body here. Plain markdown after frontmatter.
+```
+
+**Profiles the show skill ships with**:
+
+- `play-gate` — per-play gatekeeper (Step 4). Sonnet, effort:medium,
+  JSON-only output. Checks Acceptance checklist against artifacts.
+- `show-final-gate` — show-level synthesis gate (Step 7). Sonnet, effort:high,
+  JSON-only output. Checks cross-play coherence + original goal.
+
+Both are separate from the existing `critic.md` profile because that
+profile's contract is severity-tiered prose, incompatible with the JSON
+parsing the show skill needs. We isolate the new behavior in new profiles
+rather than mutating the existing one.
+
+## Cost & time awareness
+
+A play at high effort is typically 60-90 min wall clock. Actual cost varies
+significantly with model + effort + how many sub-agents the FlowPlan
+allocates inside the play. Lionagi does not yet expose spend per run, so
+treat cost as observed-only: investigate if one play takes substantially
+longer or feels more expensive than peer plays.
+
+Recalibration loop: at the end of each show, append a one-line "actual time
+per play" note to `_show.md` so future shows can decompose better.
+
+## Failure cascade rules
+
+When a play is escalated:
+
+1. Director sets `status: escalated` in that play's `_meta.json`.
+2. All plays in the escalated play's **transitive downstream cone** are
+   marked `blocked` — they do NOT auto-fire.
+3. Plays whose dependency cone does NOT include the escalated play MAY
+   continue if their deps are met (parallel branches of the show DAG).
+4. The director surfaces options to Ocean (5c list) and waits.
+
+"Downstream cone of P": all plays that transitively depend on P. Compute
+by walking `depends_on` forward from P.
+
+## Common gotchas
+
+- **`run_in_background` ≠ play completion.** Notification fires on wrapper
+  exit, instantly. Use PID polling + command-line verification.
+- **`uv run li` from worktree cwd fails.** Use `$LI="/Users/lion/projects/.venv/bin/li"` 
+  set in Step 0.
+- **Foreground play blocks 60-90 min.** Use bg + polling unless you want
+  to wait synchronously.
+- **Each play gets its own `--save` subdir.** Sharing dirs clobbers artifacts.
+- **`li play` agents write to `<save>/<agent_id>/`, not `<save>/`.** Use
+  `find` to discover artifacts; don't poll fixed top-level filenames.
+- **`--team-attach` and `--team-mode` are mutually exclusive.** First fire =
+  mode; redos = attach. Verify team file exists before attaching.
+- **Gate validation: never use `jq -e '.gate_passed'`** — `-e` returns
+  failure for falsy values, misclassifying valid `false` verdicts.
+  Always check `has("gate_passed") and (.gate_passed | type == "boolean")`.
+- **Don't auto-push final base merge.** Inspect diff first.
+- **Manual fixes after escalation MUST re-gate.** Do not mark a play
+  complete by hand; re-run Step 4 on the updated artifacts.
+
+## End-to-end example
+
+Show: "Land ADR-053 (Sinkhorn attention) in lattice"
+
+Initial `_show.md`:
+
+```markdown
+# Show: adr-053-sinkhorn
+
+## Goal
+Implement, test, and review the Sinkhorn-attention path in lattice-inference per ADR-053.
+
+## Repository
+Repo: /Users/lion/projects/khive/lattice
+Integration: show/adr-053-sinkhorn/integration
+Base: main
+
+## Plays
+1. **research**  [research]  [eff high]    — survey OT-attention literature · deps: []
+2. **design**    [feature]   [eff high]    — write ADR-053 draft · deps: [research]
+3. **implement** [feature]   [eff high]    — impl Sinkhorn solver + tests · deps: [design]
+4. **review**    [pr-review] [eff medium]  — multi-perspective gate · deps: [implement]
+```
+
+Run:
+
+```text
+research        → gate pass → merge → adapt: surfaces OT-LR as stronger baseline
+                              ↓
+                              Update _show.md: design emphasizes OT-LR; add play 2.5 literature_verify
+literature_verify → gate pass → merge
+design            → gate fail 1st (missing ablation) → redo (--team-attach) → pass → merge
+implement         → gate fail 2x (test coverage) → ESCALATE
+                              ↓
+                              Director surfaces options.
+                              Ocean picks "(b) director writes missing tests".
+                              Director writes tests in worktree, re-runs Step 4.
+                              Re-gate passes. Merge.
+review            → gate pass → merge
+Step 7 show-final-gate → show_passed:true → final merge to main (manual push by Ocean)
+                       → cleanup worktrees + delete play branches per policy
+```
+
+The decisions log + final summary feed the next show's planning so
+decomposition gets better over time.

--- a/marketplace/studio/.claude-plugin/plugin.json
+++ b/marketplace/studio/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "studio",
+  "description": "Lion Studio dashboard — runs/agents/playbooks/shows monitoring UI with FastAPI backend MCP",
+  "version": "0.1.0",
+  "author": {
+    "name": "Ocean (HaiyangLi)",
+    "url": "https://github.com/ohdearquant"
+  },
+  "homepage": "https://github.com/khive-ai/lionagi",
+  "repository": "https://github.com/khive-ai/lionagi",
+  "license": "Apache-2.0",
+  "keywords": ["dashboard", "monitoring", "fastapi", "mcp", "ui"],
+  "mcpServers": {
+    "_TODO_lion_studio": {
+      "_comment": "Pending implementation: add `li studio mcp` subcommand that exposes lion-studio backend routes as MCP tools. See ADR-0003 and apps/studio/server/. Once implemented, replace this stub with: {type: stdio, command: li, args: [studio, mcp], installHint: uv pip install 'lionagi[studio]'}",
+      "type": "stub",
+      "args": []
+    }
+  }
+}

--- a/marketplace/studio/README.md
+++ b/marketplace/studio/README.md
@@ -40,7 +40,7 @@ uv run li studio start
 ## Architecture References
 
 - **ADR-0001**: Internal monorepo structure
-- **ADR-0002**: Lift krons dependency
+- **ADR-0002**: Lift heavy runtime dependencies
 - **ADR-0003**: Marketplace plugin registry
 
 ## Install

--- a/marketplace/studio/README.md
+++ b/marketplace/studio/README.md
@@ -1,0 +1,52 @@
+# studio
+
+Lion Studio dashboard — orchestration observability for lionagi runs, agents, playbooks, and shows.
+
+## Purpose
+
+Studio is the director's primary surface for inspecting and controlling lionagi orchestration in real-time. It exposes live process trees, team file state, cost and time observability, resume state, abort sentinels, and log streaming — all aimed at surfacing what the file substrate hides.
+
+## Feature Roadmap
+
+| Feature | Description |
+|---------|-------------|
+| F1 | Exit-code reconciliation panel |
+| F2 | Verdict JSON parse and schema validation |
+| F3 | Gate context expander for working artifacts and repo deliverables |
+| F4 | Team file state inspector |
+| F5 | Live `_show.md` editor and decisions log |
+| F6 | Worktree status badge per play |
+| F7 | Show-level cost and time observable |
+| F8 | Resume state inspector |
+| F9 | Abort sentinel control |
+| F10 | Per-play log streaming |
+| F11 | Remote URL and repo redirect detector |
+| F12 | Live process tree per play |
+
+## Usage
+
+### Start the backend (available now)
+
+```bash
+li studio start
+# or
+uv run li studio start
+```
+
+### MCP integration (pending)
+
+`li studio mcp` is not yet implemented. When ready, it will expose lion-studio backend routes as MCP tools for CC agent consumption. See ADR-0003.
+
+## Architecture References
+
+- **ADR-0001**: Internal monorepo structure
+- **ADR-0002**: Lift krons dependency
+- **ADR-0003**: Marketplace plugin registry
+
+## Install
+
+```bash
+uv pip install 'lionagi[studio]'
+```
+
+The MCP server entry in `plugin.json` is a TODO stub. Replace once `li studio mcp` is implemented.


### PR DESCRIPTION
# feat(marketplace): Claude Code marketplace skeleton + 4 plugin bundles

## Summary

Establishes lionagi's Claude Code marketplace presence: top-level `.claude-plugin/marketplace.json` registry pointer + four plugin bundles under `marketplace/`. Each bundle ships an agent, skill, or composite that operators can install into their CC sessions via `/plugin install`.

See **ADR-0003** (sibling PR-A) for the marketplace design rationale and the closed plugin taxonomy.

## Bundles

| Bundle | Plugins | Purpose |
|---|---|---|
| **`marketplace/show/`** | show + play + orchestrate skills/agents | Show DAG orchestration: `/show`, `play-gate`, `show-final-gate` |
| **`marketplace/knowledge/`** | research, memory, kg-bridge | Knowledge bundles wiring khive's KG + lore |
| **`marketplace/devx/`** | dev workflow plugins | `/commit`, `/pr`, `/codex-pr-review`, etc. |
| **`marketplace/studio/`** | Lion Studio integration | Pointer to apps/studio + start/stop helpers |
| **`marketplace/mcp-bundle/`** | MCP server bundle | khive + lore MCP server configs |

(48 files, +6,405 LOC — mostly plugin manifests and skill markdown.)

## Files

- `.claude-plugin/marketplace.json` — top-level marketplace registry pointer
- `marketplace/{show,knowledge,devx,studio,mcp-bundle}/` — plugin bundles
- Each bundle has `.claude-plugin/plugin.json` + the actual skill/agent files

## Test plan

- [ ] `marketplace/.claude-plugin/marketplace.json` parses as valid JSON
- [ ] Each `marketplace/*/.claude-plugin/plugin.json` parses + has `name`, `version`, `description`
- [ ] Plugins stay within the closed taxonomy from ADR-0003 (no `kind:` value outside the documented set)
- [ ] `/plugin install <bundle>` smoke test from a clean CC session

## Sibling PRs

- **#PR-A** — ADRs (depends-on for ADR-0003)
- **#PR-B (this one)** — Marketplace
- **#PR-C** — Studio backend
- **#PR-D** — Studio frontend

Independent of PR-C/PR-D — marketplace ships side-by-side, no runtime coupling.

## Provenance

Part of the Lion Studio introduction, split into 4 reviewable PRs (sibling PRs A/C/D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
