### PR TITLE
feat(apps/studio/frontend): Lion Studio UI — Next 14 frontend + shows surface

### DIFF
--- a/apps/studio/frontend/.gitignore
+++ b/apps/studio/frontend/.gitignore
@@ -1,0 +1,27 @@
+# dependencies
+node_modules/
+
+# next.js
+.next/
+out/
+
+# build
+dist/
+build/
+
+# env
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# debug
+npm-debug.log*
+
+# typescript
+*.tsbuildinfo
+
+# misc
+.DS_Store
+*.pem

--- a/apps/studio/frontend/.prettierrc
+++ b/apps/studio/frontend/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "printWidth": 100
+}

--- a/apps/studio/frontend/README.md
+++ b/apps/studio/frontend/README.md
@@ -1,0 +1,58 @@
+# Lion Studio Frontend
+
+Next.js 14 frontend for [Lion Studio](https://github.com/khive-ai/lionagi),
+the internal observability dashboard for lionagi runs, agents, and playbooks.
+Talks to the Lion Studio backend at `process.env.NEXT_PUBLIC_API_BASE`
+(default `http://localhost:8765`).
+
+## Routes
+
+| Route                     | View                                                                                                           |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `/`                       | Redirects to `/playbooks`.                                                                                     |
+| `/playbooks`              | Playbook table sourced from `~/.lionagi/playbooks/*.playbook.yaml`, with status and metadata.                  |
+| `/playbooks/[name]`       | Playbook detail with YAML view and step DAG visualization.                                                     |
+| `/playbooks/[name]/edit`  | Edit an existing playbook YAML.                                                                                |
+| `/playbooks/new`          | Author a new playbook YAML.                                                                                    |
+| `/agents`                 | Agent profile table sourced from `~/.lionagi/agents/*.md`.                                                     |
+| `/agents/[name]`          | Agent profile detail with frontmatter, body, and edit link.                                                    |
+| `/agents/[name]/edit`     | Edit an existing agent profile.                                                                                |
+| `/agents/new`             | Author a new agent profile.                                                                                    |
+| `/runs`                   | Runs table from `~/.lionagi/runs/{id}/run.json`, with cost/duration/status filters.                            |
+| `/runs/[id]`              | Run detail with branch timelines, messages, API calls, DAG visualization, and live SSE stream for active runs. |
+
+## Foundation
+
+- `lib/types.ts` — data shapes returned by the Lion Studio backend (FastAPI on
+  port 8765 by default). Run state types match `~/.lionagi/runs/` manifest
+  fields; agent profile types match the YAML frontmatter schema.
+- `lib/api.ts` — typed fetch wrappers per backend endpoint using
+  `API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8765'`.
+- `lib/ws.ts` (if present) — reconnecting SSE/WebSocket hook for live run streams.
+- `components/` — shared UI on the dark neutral theme: `neutral-950` backgrounds,
+  `neutral-800` borders, `neutral-500` muted text, `neutral-200` primary text.
+- `components/canvas/` — ReactFlow + dagre DAG visualization reused for playbook
+  step DAGs and run branch DAGs.
+
+## Local development
+
+```bash
+# From repo root, install backend + studio deps
+uv pip install -e '.[studio]'
+
+# Start backend
+li studio start --frontend-mode none --port 8765
+
+# In another shell: start frontend (dev mode)
+cd apps/studio/frontend
+npm install --legacy-peer-deps   # pre-existing ESLint peer conflict, will resolve in a future cleanup
+npm run dev
+```
+
+Visit http://localhost:3000.
+
+## See also
+
+- [ADR-0001](../../../docs/adrs/ADR-0001-lion-studio-internal-app.md) — Lion Studio is an internal monorepo app
+- [ADR-0002](../../../docs/adrs/ADR-0002-studio-tech-stack.md) — Lion Studio tech stack selection
+- [ADR-0003](../../../docs/adrs/ADR-0003-claude-code-marketplace.md) — Claude Code marketplace pattern

--- a/apps/studio/frontend/README.md
+++ b/apps/studio/frontend/README.md
@@ -2,7 +2,7 @@
 
 Next.js 14 frontend for [Lion Studio](https://github.com/khive-ai/lionagi),
 the internal observability dashboard for lionagi runs, agents, and playbooks.
-Talks to the Lion Studio backend at `process.env.NEXT_PUBLIC_API_BASE`
+Talks to the Lion Studio backend at `process.env.NEXT_PUBLIC_STUDIO_API_BASE`
 (default `http://localhost:8765`).
 
 ## Routes
@@ -27,7 +27,7 @@ Talks to the Lion Studio backend at `process.env.NEXT_PUBLIC_API_BASE`
   port 8765 by default). Run state types match `~/.lionagi/runs/` manifest
   fields; agent profile types match the YAML frontmatter schema.
 - `lib/api.ts` — typed fetch wrappers per backend endpoint using
-  `API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8765'`.
+  `API_BASE = process.env.NEXT_PUBLIC_STUDIO_API_BASE || 'http://localhost:8765'`.
 - `lib/ws.ts` (if present) — reconnecting SSE/WebSocket hook for live run streams.
 - `components/` — shared UI on the dark neutral theme: `neutral-950` backgrounds,
   `neutral-800` borders, `neutral-500` muted text, `neutral-200` primary text.

--- a/apps/studio/frontend/__tests__/extractors.test.ts
+++ b/apps/studio/frontend/__tests__/extractors.test.ts
@@ -1,0 +1,249 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  extractAttending,
+  extractEmitting,
+  extractThinking,
+  type StreamChunk,
+} from "../lib/extractors";
+
+const goldenChunks: StreamChunk[] = [
+  {
+    id: 141,
+    flow_id: "20260420T183524-153e9455",
+    branch_id: "01d13d18-3c14-4919-bd7e-4ba0870b1d65",
+    api_call_id: "0edb6ea7-d867-4cb8-9b1d-a4ed72584447",
+    ts: 1776725055.926235914,
+    chunk_type: "text",
+    content: [
+      "Created the Phase 1 audit artifact at [audit.md](/Users/lion/projects/lionagi/.khive/flows/lion-studio-init/artifacts/audit.md).",
+      "",
+      "It includes P0/P1/P2 fix lists with absolute paths and line ranges, and it verifies the `flow_id` mismatch: `ingest_run` sets `flow_id = run_dir.name` at `persist.py:318`, then writes flow/manifest/branches/events under that id, with no `state_root` reconciliation before `flow_create`.",
+      "",
+      "I only wrote the audit artifact. No implementation files were changed.",
+      "",
+      "Next concrete follow-ups:",
+      "1. Start Phase 2 backend patch from the `persist.py` reconciliation item.",
+      "2. Start Phase 3 data population, with the audit note that current `li task new` writes JSON sessions, not the SQLite `tasks` table read by the monitor.",
+    ].join("\n"),
+    tool_name: null,
+    tool_id: null,
+    tool_input: null,
+    tool_output: null,
+    is_delta: 0,
+    is_error: 0,
+    metadata: "{}",
+  },
+  {
+    id: 166,
+    flow_id: "20260420T183524-153e9455",
+    branch_id: "42ed8221-3f86-47a5-aea2-90ade319bc8d",
+    api_call_id: "0da3868c-94db-40ca-8d7f-8007e42d5c72",
+    ts: 1776725287.229624987,
+    chunk_type: "text",
+    content: [
+      "Implemented Phase 4b in [CostChart.tsx](/Users/lion/projects/lionagi/apps/studio/frontend/components/CostChart.tsx:12) only.",
+      "",
+      "What changed:",
+      "- Added optional `cost_usd`, `tokens_in`, `tokens_out`, and `duration_ms` fields to `CostChartRow`, keeping the existing props API backwards-compatible.",
+      "- Rows with explicit `cost_usd: 0` or `cost_usd: null` now render a compact usage tile instead of a `$0` bar.",
+      "- Legacy zero-total rows also render the usage tile, so current callers do not show misleading `$0.00`.",
+      "- Non-zero cost rows still use the existing bar rendering path.",
+      "- The tile shows `tokens_in`, `tokens_out`, `duration_ms`, and the inline label `cost not reported by CLI`.",
+      "",
+      "Verification:",
+      "- Ran `npm run build` in `apps/studio/frontend`; build passed with type checking.",
+      "- No npm dependencies were added.",
+      "",
+      "Note: the Next build uses/leaves `apps/studio/frontend/.next/` as an untracked build artifact in this checkout. Source edits were limited to `apps/studio/frontend/components/CostChart.tsx`.",
+      "",
+      "Next useful step:",
+      "1. Have the flow detail integration pass aggregate `tokens_in`, `tokens_out`, and `duration_ms` into each `CostChartRow` so the new tiles show real branch metrics.",
+    ].join("\n"),
+    tool_name: null,
+    tool_id: null,
+    tool_input: null,
+    tool_output: null,
+    is_delta: 0,
+    is_error: 0,
+    metadata: "{}",
+  },
+  {
+    id: 184,
+    flow_id: "20260420T183524-153e9455",
+    branch_id: "79939d24-d096-4d39-a369-6861021b0891",
+    api_call_id: "31d928a4-c777-4560-a33c-2d41b29594cf",
+    ts: 1776725538.020176888,
+    chunk_type: "text",
+    content: [
+      "Implemented Phase 4c empty-state microcopy only, editing the four requested files:",
+      "",
+      '- [tasks/page.tsx](/Users/lion/projects/lionagi/apps/studio/frontend/app/tasks/page.tsx:164): added `li task new "your description" --check "your verification command"`',
+      "- [teams/page.tsx](/Users/lion/projects/lionagi/apps/studio/frontend/app/teams/page.tsx:200): noted there is no `li team` CLI and teams are created via `services/team/`",
+      "- [schedules/page.tsx](/Users/lion/projects/lionagi/apps/studio/frontend/app/schedules/page.tsx:187): added `li schedule add ... --lambda ... --instruction ... --every ...` with the exact CLI flags",
+      "- [api-calls/page.tsx](/Users/lion/projects/lionagi/apps/studio/frontend/app/api-calls/page.tsx:470): added `li o flow -p path/to/flow.yaml` and noted calls are recorded when flows run",
+      "",
+      "Verification passed with:",
+      "",
+      "```bash",
+      "cd /Users/lion/projects/lionagi/apps/studio/frontend",
+      "./node_modules/.bin/tsc --noEmit --incremental false --pretty false",
+      "```",
+      "",
+      "I did not run `npm run build` because it would write Next build artifacts; the no-emit typecheck kept the verification read-only. Next useful step: run the Phase 5 `npm run build` when you're ready for full monitor validation.",
+    ].join("\n"),
+    tool_name: null,
+    tool_id: null,
+    tool_input: null,
+    tool_output: null,
+    is_delta: 0,
+    is_error: 0,
+    metadata: "{}",
+  },
+  {
+    id: 185,
+    flow_id: "20260420T183524-153e9455",
+    branch_id: "682e31b0-d14d-41be-82a9-ef8af0912fc9",
+    api_call_id: "9950b6f7-2892-4061-abf8-b172473aebf0",
+    ts: 1776725626.334614038,
+    chunk_type: "text",
+    content: [
+      "Implemented Phase 4a in [page.tsx](/Users/lion/projects/lionagi/apps/studio/frontend/app/flows/[id]/page.tsx:283).",
+      "",
+      "Changes:",
+      "- Added DAG branch fallback: when the event-derived DAG has no nodes but branch/agent evidence exists, the page feeds `DagGraph` one node per branch with no edges.",
+      "- Updated flow cost display: reported positive costs still go through `CostChart`; CLI/unreported rows are shown separately with `tokens_in`, `tokens_out`, `duration_ms`, and `cost not reported by CLI endpoint`, so `$0.00` is no longer shown for missing CLI cost data.",
+      "- Added top section nav for `#dag`, `#cost`, `#timeline`, `#branches`, and `#messages`, with matching section ids and scroll margins.",
+      "",
+      "Verification:",
+      "- `cd apps/studio/frontend && npm run build` passed.",
+      "- I did not modify `CostChart.tsx` or any sibling-owned empty-state pages.",
+      "- `DagGraph.tsx` was read and its API was preserved; no internal change was needed because the fallback belongs at the caller data layer.",
+      "",
+      "One follow-up worth doing in Phase 5: run the monitor against a completed event-less flow and confirm the DAG panel shows branch nodes with no edges in the live UI.",
+    ].join("\n"),
+    tool_name: null,
+    tool_id: null,
+    tool_input: null,
+    tool_output: null,
+    is_delta: 0,
+    is_error: 0,
+    metadata: "{}",
+  },
+  {
+    id: 194,
+    flow_id: "20260420T183524-153e9455",
+    branch_id: "40d255da-1bc2-4c8a-bdc6-d9f358ef95aa",
+    api_call_id: "98f4dcbe-2584-4afd-a7d8-3573fb725f0e",
+    ts: 1776725793.938086986,
+    chunk_type: "text",
+    content: [
+      "Phase 5 verification is complete, with no application fixes attempted.",
+      "",
+      "Report artifact written: [.khive/flows/lion-studio-init/artifacts/test_report.md](/Users/lion/projects/lionagi/.khive/flows/lion-studio-init/artifacts/test_report.md:1)",
+      "",
+      "Results:",
+      "",
+      "- `cd /Users/lion/projects/lionagi/apps/studio/frontend && npm run build`",
+      "  - Exit code: `0`",
+      "  - Result: build passed; Next.js compiled successfully and generated all 11 static pages.",
+      "",
+      "- `curl -s http://localhost:8765/api/stats`",
+      "  - Exit code: `7`",
+      "  - Result: empty response; JSON parse failed with `Unexpected end of JSON input`.",
+      "  - Could not verify `tasks > 0` or `schedules > 0`.",
+      "",
+      "- `curl -s http://localhost:8765/api/flows`",
+      "  - Exit code: `7`",
+      "  - Result: empty response; JSON parse failed with `Unexpected end of JSON input`.",
+      "  - Could not confirm any flow has non-empty `messages` or `branches`.",
+      "",
+      "Based on the requested output, the build is good, but the API-backed P0 verification failed because `localhost:8765` was unreachable from the test shell.",
+      "",
+      "Concrete next steps:",
+      "",
+      "1. Start or restore the backend on `localhost:8765`, then rerun Phase 5.",
+      "2. Let the critic consume the current `test_report.md` as a failed API verification artifact.",
+    ].join("\n"),
+    tool_name: null,
+    tool_id: null,
+    tool_input: null,
+    tool_output: null,
+    is_delta: 0,
+    is_error: 0,
+    metadata: "{}",
+  },
+];
+
+describe("extractAttending", () => {
+  it("dedupes and ranks real file references by recency", () => {
+    const defaultItems = extractAttending(goldenChunks);
+
+    assert.equal(defaultItems.length, 5);
+    assert.equal(defaultItems[0].path.endsWith("test_report.md"), true);
+    assert.equal(defaultItems[0].lineStart, 1);
+    assert.equal(defaultItems[0].weight, 1);
+    assert.equal(defaultItems[1].weight < defaultItems[0].weight, true);
+
+    const wideItems = extractAttending(goldenChunks, { limit: 10 });
+    assert.equal(
+      wideItems.some((item) => item.path.endsWith("CostChart.tsx") && item.lineStart === 12),
+      true,
+    );
+    assert.equal(
+      wideItems.some((item) => item.path.endsWith("persist.py") && item.lineStart === 318),
+      true,
+    );
+  });
+});
+
+describe("extractThinking", () => {
+  it("extracts recent real decision lines as a completed timeline", () => {
+    const items = extractThinking(goldenChunks);
+    const texts = items.map((item) => item.text);
+
+    assert.equal(items.length, 4);
+    assert.equal(
+      items.every((item) => item.status === "complete"),
+      true,
+    );
+    assert.equal(
+      texts.some((text) => text.includes("Implemented Phase 4c")),
+      true,
+    );
+    assert.equal(
+      texts.some((text) => text.includes("Implemented Phase 4a")),
+      true,
+    );
+    assert.equal(
+      texts.some((text) => text.includes("Phase 5 verification is complete")),
+      true,
+    );
+  });
+});
+
+describe("extractEmitting", () => {
+  it("detects emitted artifacts and edited files from real chunk text", () => {
+    const items = extractEmitting(goldenChunks, undefined, { limit: 10 });
+
+    assert.equal(
+      items.some(
+        (item) => item.name === "audit.md" && item.kind === "artifact" && item.status === "done",
+      ),
+      true,
+    );
+    assert.equal(
+      items.some(
+        (item) =>
+          item.name === "test_report.md" && item.kind === "artifact" && item.status === "done",
+      ),
+      true,
+    );
+    assert.equal(
+      items.some(
+        (item) => item.name === "CostChart.tsx" && item.kind === "file" && item.status === "done",
+      ),
+      true,
+    );
+  });
+});

--- a/apps/studio/frontend/app/agents/[name]/edit/page.tsx
+++ b/apps/studio/frontend/app/agents/[name]/edit/page.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+import AgentProfileForm from "@/components/AgentProfileForm";
+import type { AgentProfile } from "@/lib/types";
+import { getAgent, updateAgent } from "@/lib/api";
+
+export default function EditAgentPage({ params }: { params: { name: string } }) {
+  const agentName = decodeURIComponent(params.name);
+  const router = useRouter();
+  const [initial, setInitial] = useState<AgentProfile | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [errors, setErrors] = useState<string[]>([]);
+
+  useEffect(() => {
+    let active = true;
+
+    async function load() {
+      try {
+        const data = await getAgent(agentName);
+        if (active) {
+          setInitial(data);
+        }
+      } catch (err) {
+        if (active) {
+          setLoadError(err instanceof Error ? err.message : "Failed to load agent");
+        }
+      }
+    }
+
+    void load();
+    return () => {
+      active = false;
+    };
+  }, [agentName]);
+
+  const handleSave = useCallback(
+    async (data: AgentProfile) => {
+      setSaving(true);
+      setErrors([]);
+
+      try {
+        await updateAgent(agentName, data);
+        router.push(`/agents/${encodeURIComponent(agentName)}`);
+      } catch (err) {
+        setErrors([err instanceof Error ? err.message : "Failed to update agent"]);
+        setSaving(false);
+      }
+    },
+    [router, agentName],
+  );
+
+  return (
+    <main className="mx-auto flex w-full max-w-4xl flex-col gap-4 px-4 py-6 text-neutral-200">
+      <header className="flex flex-col gap-2 border-b border-neutral-800 pb-4">
+        <Link
+          href={`/agents/${encodeURIComponent(agentName)}`}
+          className="text-sm text-neutral-500 hover:text-neutral-200"
+        >
+          / agents / {agentName}
+        </Link>
+        <h1 className="text-xl font-semibold">Edit: {agentName}</h1>
+      </header>
+
+      {loadError ? (
+        <div className="border border-red-800 bg-neutral-950 px-3 py-2 text-sm text-red-300">
+          {loadError}
+        </div>
+      ) : !initial ? (
+        <div className="py-10 text-center text-sm text-neutral-500">Loading...</div>
+      ) : (
+        <AgentProfileForm
+          initial={initial}
+          mode="edit"
+          onSave={handleSave}
+          saving={saving}
+          errors={errors}
+        />
+      )}
+    </main>
+  );
+}

--- a/apps/studio/frontend/app/agents/[name]/page.tsx
+++ b/apps/studio/frontend/app/agents/[name]/page.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import Badge from "@/components/Badge";
+import { getAgent } from "@/lib/api";
+import type { AgentProfile } from "@/lib/types";
+
+function messageFromError(error: unknown): string {
+  return error instanceof Error ? error.message : "Failed to load agent";
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-xs uppercase text-neutral-500">{label}</span>
+      <div className="text-sm text-neutral-300">{children}</div>
+    </div>
+  );
+}
+
+function CodeBlock({ value }: { value: string }) {
+  if (!value) {
+    return <span className="text-neutral-600">—</span>;
+  }
+  return (
+    <pre className="whitespace-pre-wrap break-words rounded border border-neutral-800 bg-neutral-900 p-3 font-mono text-xs text-neutral-300">
+      {value}
+    </pre>
+  );
+}
+
+export default function AgentDetailPage({ params }: { params: { name: string } }) {
+  const agentName = decodeURIComponent(params.name);
+  const [agent, setAgent] = useState<AgentProfile | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadAgent() {
+      try {
+        const data = await getAgent(agentName);
+        if (active) {
+          setAgent(data);
+          setError(null);
+        }
+      } catch (err) {
+        if (active) {
+          setError(messageFromError(err));
+        }
+      }
+    }
+
+    void loadAgent();
+
+    return () => {
+      active = false;
+    };
+  }, [agentName]);
+
+  return (
+    <main className="mx-auto flex w-full max-w-4xl flex-col gap-4 px-4 py-6 text-neutral-200">
+      {/* Header */}
+      <header className="flex flex-col gap-3 border-b border-neutral-800 pb-4">
+        <Link href="/agents" className="text-sm text-neutral-500 hover:text-neutral-200">
+          / agents
+        </Link>
+
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <h1 className="truncate text-xl font-semibold text-neutral-200">
+              {agent?.name ?? agentName}
+            </h1>
+            {agent?.description ? (
+              <p className="mt-1 text-sm text-neutral-400">{agent.description}</p>
+            ) : null}
+          </div>
+          <Link
+            href={`/agents/${encodeURIComponent(agentName)}/edit`}
+            className="shrink-0 rounded border border-neutral-700 bg-neutral-900 px-3 py-1 text-sm text-neutral-300 hover:border-neutral-500 hover:text-neutral-200"
+          >
+            Edit
+          </Link>
+        </div>
+      </header>
+
+      {error ? (
+        <div className="border border-red-800 bg-neutral-950 px-3 py-2 text-sm text-red-300">
+          {error}
+        </div>
+      ) : null}
+
+      {!agent && !error ? (
+        <div className="py-10 text-center text-sm text-neutral-500">Loading...</div>
+      ) : null}
+
+      {agent ? (
+        <div className="flex flex-col gap-5">
+          {/* Provider + Model badges */}
+          <section className="flex flex-col gap-3 rounded border border-neutral-800 bg-neutral-950 p-4">
+            <h2 className="text-sm font-semibold text-neutral-200">Model</h2>
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge tone="default">{agent.provider}</Badge>
+              <Badge tone="default">{agent.model}</Badge>
+              {agent.permission_mode ? <Badge tone="pending">{agent.permission_mode}</Badge> : null}
+              {agent.reasoning_effort ? (
+                <Badge tone="pending">effort: {agent.reasoning_effort}</Badge>
+              ) : null}
+            </div>
+          </section>
+
+          {/* System Prompt */}
+          <section className="flex flex-col gap-3 rounded border border-neutral-800 bg-neutral-950 p-4">
+            <h2 className="text-sm font-semibold text-neutral-200">System Prompt</h2>
+            <CodeBlock value={agent.system_prompt} />
+          </section>
+
+          {/* Guidance */}
+          <section className="flex flex-col gap-3 rounded border border-neutral-800 bg-neutral-950 p-4">
+            <h2 className="text-sm font-semibold text-neutral-200">Guidance</h2>
+            <CodeBlock value={agent.guidance} />
+          </section>
+        </div>
+      ) : null}
+    </main>
+  );
+}

--- a/apps/studio/frontend/app/agents/new/page.tsx
+++ b/apps/studio/frontend/app/agents/new/page.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useCallback, useState } from "react";
+import AgentProfileForm from "@/components/AgentProfileForm";
+import type { AgentProfile } from "@/lib/types";
+import { createAgent } from "@/lib/api";
+
+export default function NewAgentPage() {
+  const router = useRouter();
+  const [saving, setSaving] = useState(false);
+  const [errors, setErrors] = useState<string[]>([]);
+
+  const handleSave = useCallback(
+    async (data: AgentProfile) => {
+      setSaving(true);
+      setErrors([]);
+
+      try {
+        await createAgent(data.name, data);
+        router.push(`/agents/${encodeURIComponent(data.name)}`);
+      } catch (err) {
+        setErrors([err instanceof Error ? err.message : "Failed to create agent"]);
+        setSaving(false);
+      }
+    },
+    [router],
+  );
+
+  return (
+    <main className="mx-auto flex w-full max-w-4xl flex-col gap-4 px-4 py-6 text-neutral-200">
+      <header className="flex flex-col gap-2 border-b border-neutral-800 pb-4">
+        <Link href="/agents" className="text-sm text-neutral-500 hover:text-neutral-200">
+          / agents
+        </Link>
+        <h1 className="text-xl font-semibold">New Agent</h1>
+      </header>
+
+      <AgentProfileForm mode="create" onSave={handleSave} saving={saving} errors={errors} />
+    </main>
+  );
+}

--- a/apps/studio/frontend/app/agents/page.tsx
+++ b/apps/studio/frontend/app/agents/page.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import type { CSSProperties } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import Table, { type TableColumn } from "@/components/Table";
+import { listAgents } from "@/lib/api";
+import type { AgentProfileSummary } from "@/lib/types";
+
+function messageFromError(error: unknown): string {
+  return error instanceof Error ? error.message : "Failed to load agents";
+}
+
+export default function AgentsPage() {
+  const router = useRouter();
+  const [agents, setAgents] = useState<AgentProfileSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadAgents() {
+      try {
+        const response = await listAgents();
+        if (active) {
+          setAgents(response.agents);
+          setError(null);
+        }
+      } catch (err) {
+        if (active) {
+          setError(messageFromError(err));
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void loadAgents();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const columns = useMemo<Array<TableColumn<AgentProfileSummary>>>(
+    () => [
+      {
+        id: "name",
+        header: "name",
+        accessor: (row) => (
+          <div className="min-w-0">
+            <div className="truncate font-medium text-neutral-200">{row.name}</div>
+          </div>
+        ),
+        sortValue: (row) => row.name,
+        className: "w-[20rem]",
+        truncate: false,
+      },
+      {
+        id: "description",
+        header: "description",
+        accessor: (row) =>
+          row.description ? (
+            <span
+              className="text-neutral-400"
+              title={row.description}
+              style={
+                {
+                  display: "-webkit-box",
+                  WebkitBoxOrient: "vertical",
+                  WebkitLineClamp: 2,
+                  overflow: "hidden",
+                } as CSSProperties
+              }
+            >
+              {row.description}
+            </span>
+          ) : (
+            <span className="text-neutral-600">—</span>
+          ),
+        sortValue: (row) => row.description ?? "",
+        truncate: false,
+      },
+      {
+        id: "provider",
+        header: "provider",
+        accessor: (row) => (
+          <span className="font-mono text-xs text-neutral-400">{row.provider}</span>
+        ),
+        sortValue: (row) => row.provider,
+        className: "w-[10rem]",
+      },
+      {
+        id: "model",
+        header: "model",
+        accessor: (row) => <span className="font-mono text-xs text-neutral-400">{row.model}</span>,
+        sortValue: (row) => row.model,
+        className: "w-[10rem]",
+      },
+    ],
+    [],
+  );
+
+  return (
+    <main className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-6">
+      <header className="flex flex-col gap-3 border-b border-neutral-800 pb-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-xl font-semibold text-neutral-200">Agents</h1>
+            <p className="text-sm text-neutral-500">
+              {agents.length} agent profile{agents.length === 1 ? "" : "s"}
+            </p>
+          </div>
+          <Link
+            href="/agents/new"
+            className="rounded border border-green-700 bg-green-900/50 px-4 py-1.5 text-sm font-medium text-green-300 hover:bg-green-800/50"
+          >
+            + New Agent
+          </Link>
+        </div>
+      </header>
+
+      {error ? (
+        <div className="border border-red-800 bg-neutral-950 px-3 py-2 text-sm text-red-300">
+          {error}
+        </div>
+      ) : null}
+
+      <Table
+        columns={columns}
+        data={agents}
+        emptyMessage={loading ? "Loading agents..." : "No agent profiles found."}
+        getRowKey={(row) => row.name}
+        initialSort={{ columnId: "name", direction: "asc" }}
+        onRowClick={(row) => router.push(`/agents/${encodeURIComponent(row.name)}`)}
+      />
+    </main>
+  );
+}

--- a/apps/studio/frontend/app/globals.css
+++ b/apps/studio/frontend/app/globals.css
@@ -1,0 +1,79 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    /* ─── Surface (backgrounds, layered dark → light) ─── */
+    --surface-base: #0e0e0e; /* deepest — canvas, page bg */
+    --surface-raised: #171717; /* cards, panels */
+    --surface-overlay: #1c1c1c; /* side panels, dropdowns, modals */
+    --surface-nav: #1a1a1a; /* header, navigation bar */
+    --surface-input: #222222; /* form inputs, textareas */
+    --surface-input-hover: #2a2a2a;
+
+    /* ─── Content (text) ─── */
+    --content-primary: #e5e5e5; /* main text */
+    --content-secondary: #a3a3a3; /* descriptions, metadata */
+    --content-muted: #6b6b6b; /* placeholders, disabled, labels */
+    --content-inverse: #ffffff; /* text on colored backgrounds */
+
+    /* ─── Edge (borders, dividers) ─── */
+    --edge-default: #2e2e2e; /* standard borders */
+    --edge-subtle: #232323; /* very light separation */
+    --edge-strong: #404040; /* emphasized borders, hover */
+
+    /* ─── Interactive (buttons, links) ─── */
+    --interactive-primary: #22c55e; /* green — primary action */
+    --interactive-primary-hover: #16a34a;
+    --interactive-secondary: #333333; /* secondary buttons bg */
+    --interactive-secondary-hover: #3d3d3d;
+    --interactive-focus: rgba(34, 197, 94, 0.3); /* focus ring */
+
+    /* ─── Status ─── */
+    --status-success: #22c55e;
+    --status-success-bg: rgba(34, 197, 94, 0.12);
+    --status-running: #60a5fa;
+    --status-running-bg: rgba(96, 165, 250, 0.12);
+    --status-error: #ef4444;
+    --status-error-bg: rgba(239, 68, 68, 0.12);
+    --status-warning: #f59e0b;
+    --status-warning-bg: rgba(245, 158, 11, 0.12);
+    --status-selected: #a855f7;
+    --status-selected-bg: rgba(168, 85, 247, 0.12);
+
+    /* ─── Role colors ─── */
+    --role-researcher: #22c55e;
+    --role-implementer: #a855f7;
+    --role-reviewer: #14b8a6;
+    --role-critic: #f59e0b;
+    --role-analyst: #3b82f6;
+    --role-architect: #ec4899;
+    --role-tester: #06b6d4;
+  }
+}
+
+/* Dark scrollbars — webkit (Chrome/Safari) */
+*::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+*::-webkit-scrollbar-thumb {
+  background: var(--edge-default);
+  border-radius: 4px;
+}
+*::-webkit-scrollbar-thumb:hover {
+  background: var(--edge-strong);
+}
+*::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+/* Firefox */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--edge-default) transparent;
+}

--- a/apps/studio/frontend/app/layout.tsx
+++ b/apps/studio/frontend/app/layout.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import Shell from "@/components/Shell";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Lion Studio",
+  description: "Lion Studio orchestration observability",
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-neutral-950 font-mono text-neutral-200">
+        <Shell>{children}</Shell>
+      </body>
+    </html>
+  );
+}

--- a/apps/studio/frontend/app/page.tsx
+++ b/apps/studio/frontend/app/page.tsx
@@ -1,0 +1,4 @@
+import { redirect } from "next/navigation";
+export default function Home() {
+  redirect("/playbooks");
+}

--- a/apps/studio/frontend/app/playbooks/[name]/edit/page.tsx
+++ b/apps/studio/frontend/app/playbooks/[name]/edit/page.tsx
@@ -154,7 +154,7 @@ export default function EditWorkerPage({ params }: { params: { name: string } })
           type="text"
           value={description}
           onChange={(e) => setDescription(e.target.value)}
-          placeholder="Worker description..."
+          placeholder="Playbook description..."
           className="flex-1 rounded-md border border-transparent bg-transparent px-2 py-1 text-sm text-content-secondary placeholder-content-muted hover:border-edge focus:border-edge-strong focus:outline-none"
         />
 

--- a/apps/studio/frontend/app/playbooks/[name]/edit/page.tsx
+++ b/apps/studio/frontend/app/playbooks/[name]/edit/page.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import WorkerCanvas from "@/components/canvas/WorkerCanvas";
+import ModelConfigTable from "@/components/ModelConfigTable";
+import { getWorkerGraph, getWorkerRaw, listAgents, updateWorker, validateWorker } from "@/lib/api";
+import type {
+  AgentProfileSummary,
+  ModelConfig,
+  WorkerFormData,
+  WorkerGraph,
+  WorkerLinkEdge,
+  WorkerStepNode,
+} from "@/lib/types";
+
+export default function EditWorkerPage({ params }: { params: { name: string } }) {
+  const workerName = decodeURIComponent(params.name);
+  const router = useRouter();
+
+  const [graph, setGraph] = useState<WorkerGraph | null>(null);
+  const [description, setDescription] = useState("");
+  const [models, setModels] = useState<Record<string, ModelConfig>>({});
+  const [agentProfiles, setAgentProfiles] = useState<AgentProfileSummary[]>([]);
+
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [errors, setErrors] = useState<string[]>([]);
+  const [showModels, setShowModels] = useState(false);
+
+  const canvasNodesRef = useRef<WorkerStepNode[]>([]);
+  const canvasEdgesRef = useRef<WorkerLinkEdge[]>([]);
+
+  useEffect(() => {
+    Promise.all([
+      getWorkerGraph(workerName),
+      getWorkerRaw(workerName),
+      listAgents().catch(() => ({ agents: [] })),
+    ])
+      .then(([graphData, rawData, agentsData]) => {
+        setGraph(graphData);
+        setDescription(rawData.description || "");
+        setModels(rawData.use?.models || {});
+        setAgentProfiles(agentsData.agents);
+        canvasNodesRef.current = graphData.nodes;
+        canvasEdgesRef.current = graphData.edges;
+      })
+      .catch((err) => {
+        setLoadError(err instanceof Error ? err.message : "Failed to load");
+      });
+  }, [workerName]);
+
+  const allRoleNames = useMemo(() => {
+    const names = new Set<string>();
+    agentProfiles.forEach((p) => names.add(p.name));
+    Object.keys(models).forEach((k) => names.add(k));
+    return Array.from(names).sort();
+  }, [agentProfiles, models]);
+
+  const handleCanvasChange = useCallback((nodes: WorkerStepNode[], edges: WorkerLinkEdge[]) => {
+    canvasNodesRef.current = nodes;
+    canvasEdgesRef.current = edges;
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    setErrors([]);
+
+    const nodes = canvasNodesRef.current;
+    const edges = canvasEdgesRef.current;
+
+    const steps: Record<
+      string,
+      {
+        assignment: string;
+        role: string;
+        prompt: string;
+        capacity?: number;
+        timeout?: number | null;
+      }
+    > = {};
+    for (const n of nodes) {
+      steps[n.id] = {
+        assignment: n.assignment,
+        role: n.role,
+        prompt: n.prompt,
+        capacity: n.capacity,
+        timeout: n.timeout,
+      };
+    }
+
+    const links = edges.map((e) => ({
+      from: e.source,
+      to: e.target,
+      condition: e.condition,
+      map: e.map,
+      handler: e.handler,
+    }));
+
+    const data: WorkerFormData = {
+      name: workerName,
+      description,
+      use: { models },
+      steps,
+      links,
+    };
+
+    try {
+      const validation = await validateWorker(workerName, data);
+      if (!validation.ok) {
+        setErrors(validation.errors ?? ["Validation failed"]);
+        setSaving(false);
+        return;
+      }
+      await updateWorker(workerName, data);
+      router.push(`/playbooks/${encodeURIComponent(workerName)}`);
+    } catch (err) {
+      setErrors([err instanceof Error ? err.message : "Save failed"]);
+      setSaving(false);
+    }
+  }, [workerName, description, models, router]);
+
+  if (loadError) {
+    return (
+      <main className="mx-auto max-w-7xl px-4 py-6">
+        <div className="border border-red-800 bg-neutral-950 px-3 py-2 text-sm text-red-300">
+          {loadError}
+        </div>
+      </main>
+    );
+  }
+
+  if (!graph) {
+    return (
+      <main className="mx-auto max-w-7xl px-4 py-6">
+        <p className="text-sm text-neutral-500">Loading...</p>
+      </main>
+    );
+  }
+
+  return (
+    <div className="flex h-[calc(100vh-56px)] flex-col">
+      {/* Top bar */}
+      <div className="flex items-center gap-3 border-b border-edge bg-surface-nav px-4 py-2">
+        <Link
+          href={`/playbooks/${encodeURIComponent(workerName)}`}
+          className="text-xs text-content-secondary hover:text-content-primary"
+        >
+          &larr; {workerName}
+        </Link>
+
+        <input
+          type="text"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Worker description..."
+          className="flex-1 rounded-md border border-transparent bg-transparent px-2 py-1 text-sm text-content-secondary placeholder-content-muted hover:border-edge focus:border-edge-strong focus:outline-none"
+        />
+
+        <button
+          onClick={() => setShowModels((v) => !v)}
+          className="rounded-md bg-interactive-secondary px-3 py-1 text-xs text-content-secondary hover:text-content-primary hover:bg-interactive-secondary-hover"
+        >
+          Models {showModels ? "▴" : "▾"}
+        </button>
+
+        <button
+          onClick={handleSave}
+          disabled={saving}
+          className="rounded-md bg-interactive-primary px-4 py-1 text-sm font-medium text-content-inverse hover:bg-interactive-primary-hover disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {saving ? "Saving..." : "Save"}
+        </button>
+      </div>
+
+      {/* Errors */}
+      {errors.length > 0 && (
+        <div className="border-b border-status-error/30 bg-status-error-bg px-4 py-2">
+          {errors.map((err, i) => (
+            <p key={i} className="text-xs text-status-error">
+              {err}
+            </p>
+          ))}
+        </div>
+      )}
+
+      {/* Model overrides (collapsible) */}
+      {showModels && (
+        <div className="border-b border-edge bg-surface-raised px-4 py-3">
+          <div className="mx-auto max-w-3xl">
+            <h3 className="mb-2 text-xs font-semibold uppercase text-content-muted">
+              Model Overrides
+            </h3>
+            <ModelConfigTable models={models} onChange={setModels} />
+          </div>
+        </div>
+      )}
+
+      {/* Canvas */}
+      <div className="flex-1 min-h-0">
+        <WorkerCanvas
+          graph={graph}
+          editable={true}
+          roles={allRoleNames}
+          agentProfiles={agentProfiles}
+          modelOverrides={models}
+          onChange={handleCanvasChange}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/studio/frontend/app/playbooks/[name]/page.tsx
+++ b/apps/studio/frontend/app/playbooks/[name]/page.tsx
@@ -146,7 +146,7 @@ export default function WorkerDetailPage({ params }: { params: { name: string } 
           type="text"
           value={taskInput}
           onChange={(e) => setTaskInput(e.target.value)}
-          placeholder="Task — describe what the worker should do..."
+          placeholder="Task — describe what the playbook should do..."
           disabled={running}
           className="flex-1 rounded-md border border-edge bg-surface-input px-3 py-1.5 text-sm text-content-primary placeholder-content-muted focus:border-interactive-primary focus:outline-none disabled:opacity-50"
           onKeyDown={(e) => {

--- a/apps/studio/frontend/app/playbooks/[name]/page.tsx
+++ b/apps/studio/frontend/app/playbooks/[name]/page.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+import Badge from "@/components/Badge";
+import WorkerCanvas from "@/components/canvas/WorkerCanvas";
+import { getWorkerGraph, startRun, runEventsUrl } from "@/lib/api";
+import type { WorkerGraph } from "@/lib/types";
+
+export default function WorkerDetailPage({ params }: { params: { name: string } }) {
+  const workerName = decodeURIComponent(params.name);
+  const [graph, setGraph] = useState<WorkerGraph | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Execution state
+  const [taskInput, setTaskInput] = useState("");
+  const [cwdInput, setCwdInput] = useState("");
+  const [running, setRunning] = useState(false);
+  const [runStatus, setRunStatus] = useState<"idle" | "running" | "completed" | "failed">("idle");
+  const [execSteps, setExecSteps] = useState<
+    Array<{ step: string; status: string; result?: Record<string, unknown>; timestamp?: number }>
+  >([]);
+  const [currentStep, setCurrentStep] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    getWorkerGraph(workerName)
+      .then((data) => {
+        if (active) setGraph(data);
+      })
+      .catch((err) => {
+        if (active) setError(err instanceof Error ? err.message : "Failed to load");
+      });
+    return () => {
+      active = false;
+    };
+  }, [workerName]);
+
+  const handleRun = useCallback(async () => {
+    if (!graph || running || !taskInput.trim()) return;
+
+    setExecSteps([]);
+    setCurrentStep(null);
+    setRunStatus("running");
+    setRunning(true);
+
+    try {
+      const data = await startRun(workerName, taskInput.trim(), cwdInput.trim());
+      const evtSource = new EventSource(runEventsUrl(data.run_id));
+
+      evtSource.onmessage = (event) => {
+        const parsed = JSON.parse(event.data);
+
+        if (parsed.type === "run_started") {
+          setCurrentStep(parsed.entry_step);
+        } else if (parsed.type === "step_completed") {
+          setExecSteps((prev) => [
+            ...prev,
+            {
+              step: parsed.step,
+              status: "completed",
+              result: parsed.result,
+              timestamp: parsed.timestamp,
+            },
+          ]);
+          setCurrentStep(null);
+        } else if (parsed.type === "run_completed") {
+          setRunStatus("completed");
+          setRunning(false);
+          setCurrentStep(null);
+          evtSource.close();
+        } else if (parsed.type === "run_failed") {
+          setRunStatus("failed");
+          setRunning(false);
+          setCurrentStep(null);
+          evtSource.close();
+        } else if (parsed.type === "done" || parsed.type === "timeout") {
+          setRunning(false);
+          setCurrentStep(null);
+          evtSource.close();
+        }
+      };
+
+      evtSource.onerror = () => {
+        setRunning(false);
+        setCurrentStep(null);
+        setRunStatus("failed");
+        evtSource.close();
+      };
+    } catch {
+      setRunning(false);
+      setRunStatus("failed");
+    }
+  }, [graph, running, workerName, taskInput, cwdInput]);
+
+  if (error) {
+    return (
+      <main className="mx-auto max-w-7xl px-4 py-6">
+        <div className="border border-red-800 bg-neutral-950 px-3 py-2 text-sm text-red-300">
+          {error}
+        </div>
+      </main>
+    );
+  }
+
+  if (!graph) {
+    return (
+      <main className="mx-auto max-w-7xl px-4 py-6">
+        <p className="text-sm text-neutral-500">Loading...</p>
+      </main>
+    );
+  }
+
+  return (
+    <div className="flex h-[calc(100vh-56px)] flex-col">
+      {/* Top bar */}
+      <div className="flex items-center gap-3 border-b border-edge bg-surface-nav px-4 py-2">
+        <Link href="/playbooks" className="text-xs text-content-secondary hover:text-content-primary">
+          playbooks
+        </Link>
+        <span className="text-xs text-content-muted">/</span>
+        <span className="font-mono text-sm font-semibold text-content-primary">{graph.name}</span>
+        {graph.description && (
+          <span className="text-xs text-content-secondary truncate">— {graph.description}</span>
+        )}
+
+        <div className="ml-auto flex items-center gap-2">
+          {runStatus === "running" && (
+            <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-status-running" />
+          )}
+          {runStatus === "completed" && <Badge tone="ok">done</Badge>}
+          {runStatus === "failed" && <Badge tone="failed">failed</Badge>}
+
+          <Link
+            href={`/playbooks/${encodeURIComponent(workerName)}/edit`}
+            className="rounded-md bg-interactive-secondary px-3 py-1 text-xs font-medium text-content-primary hover:bg-interactive-secondary-hover"
+          >
+            Edit
+          </Link>
+        </div>
+      </div>
+
+      {/* Task input bar */}
+      <div className="flex items-center gap-2 border-b border-edge bg-surface-raised px-4 py-2">
+        <input
+          type="text"
+          value={taskInput}
+          onChange={(e) => setTaskInput(e.target.value)}
+          placeholder="Task — describe what the worker should do..."
+          disabled={running}
+          className="flex-1 rounded-md border border-edge bg-surface-input px-3 py-1.5 text-sm text-content-primary placeholder-content-muted focus:border-interactive-primary focus:outline-none disabled:opacity-50"
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              handleRun();
+            }
+          }}
+        />
+        <input
+          type="text"
+          value={cwdInput}
+          onChange={(e) => setCwdInput(e.target.value)}
+          placeholder="Working directory"
+          disabled={running}
+          className="w-52 rounded-md border border-edge bg-surface-input px-3 py-1.5 font-mono text-xs text-content-primary placeholder-content-muted focus:border-interactive-primary focus:outline-none disabled:opacity-50"
+        />
+        <button
+          onClick={handleRun}
+          disabled={running || !taskInput.trim()}
+          className={`shrink-0 rounded-md px-5 py-1.5 text-sm font-medium transition ${
+            running || !taskInput.trim()
+              ? "cursor-not-allowed bg-interactive-secondary text-content-muted"
+              : "bg-interactive-primary text-content-inverse hover:bg-interactive-primary-hover"
+          }`}
+        >
+          {running ? "Running..." : "Run"}
+        </button>
+      </div>
+
+      {/* Canvas fills remaining space */}
+      <div className="flex-1 min-h-0">
+        <WorkerCanvas
+          graph={graph}
+          editable={false}
+          execSteps={execSteps}
+          currentStep={currentStep}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/studio/frontend/app/playbooks/new/page.tsx
+++ b/apps/studio/frontend/app/playbooks/new/page.tsx
@@ -69,7 +69,7 @@ export default function NewWorkerPage() {
 
   const handleSave = useCallback(async () => {
     if (!name.trim()) {
-      setErrors(["Worker name is required"]);
+      setErrors(["Playbook name is required"]);
       return;
     }
 
@@ -142,7 +142,7 @@ export default function NewWorkerPage() {
           type="text"
           value={name}
           onChange={(e) => setName(e.target.value)}
-          placeholder="Worker name..."
+          placeholder="Playbook name..."
           className="w-48 rounded border border-neutral-700 bg-neutral-900 px-2 py-1 font-mono text-sm text-neutral-200 placeholder-neutral-600 focus:border-neutral-500 focus:outline-none"
         />
 

--- a/apps/studio/frontend/app/playbooks/new/page.tsx
+++ b/apps/studio/frontend/app/playbooks/new/page.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import WorkerCanvas from "@/components/canvas/WorkerCanvas";
+import ModelConfigTable from "@/components/ModelConfigTable";
+import { createWorker, listAgents, validateWorker } from "@/lib/api";
+import type {
+  AgentProfileSummary,
+  ModelConfig,
+  WorkerFormData,
+  WorkerGraph,
+  WorkerLinkEdge,
+  WorkerStepNode,
+} from "@/lib/types";
+
+const EMPTY_GRAPH: WorkerGraph = {
+  name: "",
+  description: "",
+  nodes: [
+    {
+      id: "step_1",
+      label: "step_1",
+      assignment: "",
+      role: "",
+      prompt: "",
+      capacity: 1,
+      timeout: null,
+      inputs: [],
+      outputs: [],
+    },
+  ],
+  edges: [],
+};
+
+export default function NewWorkerPage() {
+  const router = useRouter();
+
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [models, setModels] = useState<Record<string, ModelConfig>>({});
+  const [agentProfiles, setAgentProfiles] = useState<AgentProfileSummary[]>([]);
+
+  const [saving, setSaving] = useState(false);
+  const [errors, setErrors] = useState<string[]>([]);
+  const [showModels, setShowModels] = useState(false);
+
+  const canvasNodesRef = useRef<WorkerStepNode[]>(EMPTY_GRAPH.nodes);
+  const canvasEdgesRef = useRef<WorkerLinkEdge[]>([]);
+
+  useEffect(() => {
+    listAgents()
+      .then((data) => setAgentProfiles(data.agents))
+      .catch(() => {});
+  }, []);
+
+  const allRoleNames = useMemo(() => {
+    const names = new Set<string>();
+    agentProfiles.forEach((p) => names.add(p.name));
+    Object.keys(models).forEach((k) => names.add(k));
+    return Array.from(names).sort();
+  }, [agentProfiles, models]);
+
+  const handleCanvasChange = useCallback((nodes: WorkerStepNode[], edges: WorkerLinkEdge[]) => {
+    canvasNodesRef.current = nodes;
+    canvasEdgesRef.current = edges;
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (!name.trim()) {
+      setErrors(["Worker name is required"]);
+      return;
+    }
+
+    setSaving(true);
+    setErrors([]);
+
+    const nodes = canvasNodesRef.current;
+    const edges = canvasEdgesRef.current;
+
+    const steps: Record<
+      string,
+      {
+        assignment: string;
+        role: string;
+        prompt: string;
+        capacity?: number;
+        timeout?: number | null;
+      }
+    > = {};
+    for (const n of nodes) {
+      steps[n.id] = {
+        assignment: n.assignment,
+        role: n.role,
+        prompt: n.prompt,
+        capacity: n.capacity,
+        timeout: n.timeout,
+      };
+    }
+
+    const links = edges.map((e) => ({
+      from: e.source,
+      to: e.target,
+      condition: e.condition,
+      map: e.map,
+      handler: e.handler,
+    }));
+
+    const data: WorkerFormData = {
+      name: name.trim(),
+      description,
+      use: { models },
+      steps,
+      links,
+    };
+
+    try {
+      const validation = await validateWorker(data.name, data);
+      if (!validation.ok) {
+        setErrors(validation.errors ?? ["Validation failed"]);
+        setSaving(false);
+        return;
+      }
+      await createWorker(data.name, data);
+      router.push(`/playbooks/${encodeURIComponent(data.name)}`);
+    } catch (err) {
+      setErrors([err instanceof Error ? err.message : "Create failed"]);
+      setSaving(false);
+    }
+  }, [name, description, models, router]);
+
+  return (
+    <div className="flex h-[calc(100vh-56px)] flex-col">
+      {/* Top bar */}
+      <div className="flex items-center gap-3 border-b border-neutral-800 px-4 py-2">
+        <Link href="/playbooks" className="text-xs text-neutral-500 hover:text-neutral-300">
+          &larr; playbooks
+        </Link>
+
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Worker name..."
+          className="w-48 rounded border border-neutral-700 bg-neutral-900 px-2 py-1 font-mono text-sm text-neutral-200 placeholder-neutral-600 focus:border-neutral-500 focus:outline-none"
+        />
+
+        <input
+          type="text"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Description..."
+          className="flex-1 rounded border border-transparent bg-transparent px-2 py-1 text-sm text-neutral-400 placeholder-neutral-600 hover:border-neutral-700 focus:border-neutral-500 focus:outline-none"
+        />
+
+        <button
+          onClick={() => setShowModels((v) => !v)}
+          className="rounded border border-neutral-700 bg-neutral-900 px-3 py-1 text-xs text-neutral-400 hover:text-neutral-200"
+        >
+          Models {showModels ? "▴" : "▾"}
+        </button>
+
+        <button
+          onClick={handleSave}
+          disabled={saving || !name.trim()}
+          className="rounded border border-green-700 bg-green-900/50 px-4 py-1 text-sm font-medium text-green-300 hover:bg-green-800/50 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {saving ? "Creating..." : "Create"}
+        </button>
+      </div>
+
+      {/* Errors */}
+      {errors.length > 0 && (
+        <div className="border-b border-red-900 bg-red-950/40 px-4 py-2">
+          {errors.map((err, i) => (
+            <p key={i} className="text-xs text-red-300">
+              {err}
+            </p>
+          ))}
+        </div>
+      )}
+
+      {/* Model overrides (collapsible) */}
+      {showModels && (
+        <div className="border-b border-neutral-800 bg-neutral-950 px-4 py-3">
+          <div className="mx-auto max-w-3xl">
+            <h3 className="mb-2 text-xs font-semibold uppercase text-neutral-500">
+              Model Overrides
+            </h3>
+            <ModelConfigTable models={models} onChange={setModels} />
+          </div>
+        </div>
+      )}
+
+      {/* Canvas */}
+      <div className="flex-1 min-h-0">
+        <WorkerCanvas
+          graph={EMPTY_GRAPH}
+          editable={true}
+          roles={allRoleNames}
+          agentProfiles={agentProfiles}
+          modelOverrides={models}
+          onChange={handleCanvasChange}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/studio/frontend/app/playbooks/page.tsx
+++ b/apps/studio/frontend/app/playbooks/page.tsx
@@ -9,7 +9,7 @@ import { listWorkers } from "@/lib/api";
 import type { WorkerSummary } from "@/lib/types";
 
 function messageFromError(error: unknown): string {
-  return error instanceof Error ? error.message : "Failed to load workers";
+  return error instanceof Error ? error.message : "Failed to load playbooks";
 }
 
 export default function WorkersPage() {

--- a/apps/studio/frontend/app/playbooks/page.tsx
+++ b/apps/studio/frontend/app/playbooks/page.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import type { CSSProperties } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import Table, { type TableColumn } from "@/components/Table";
+import { listWorkers } from "@/lib/api";
+import type { WorkerSummary } from "@/lib/types";
+
+function messageFromError(error: unknown): string {
+  return error instanceof Error ? error.message : "Failed to load workers";
+}
+
+export default function WorkersPage() {
+  const router = useRouter();
+  const [workers, setWorkers] = useState<WorkerSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadWorkers() {
+      try {
+        const response = await listWorkers();
+        if (active) {
+          setWorkers(response.workers);
+          setError(null);
+        }
+      } catch (err) {
+        if (active) {
+          setError(messageFromError(err));
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void loadWorkers();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const columns = useMemo<Array<TableColumn<WorkerSummary>>>(
+    () => [
+      {
+        id: "name",
+        header: "name",
+        accessor: (row) => (
+          <div className="min-w-0">
+            <div className="truncate font-medium text-neutral-200">{row.name}</div>
+            {row.file ? <div className="truncate text-xs text-neutral-500">{row.file}</div> : null}
+          </div>
+        ),
+        sortValue: (row) => row.name,
+        className: "w-[20rem]",
+        truncate: false,
+      },
+      {
+        id: "description",
+        header: "description",
+        accessor: (row) =>
+          row.description ? (
+            <span
+              className="text-neutral-400"
+              title={row.description}
+              style={
+                {
+                  display: "-webkit-box",
+                  WebkitBoxOrient: "vertical",
+                  WebkitLineClamp: 2,
+                  overflow: "hidden",
+                } as CSSProperties
+              }
+            >
+              {row.description}
+            </span>
+          ) : (
+            <span className="text-neutral-600">—</span>
+          ),
+        sortValue: (row) => row.description ?? "",
+        truncate: false,
+      },
+      {
+        id: "steps",
+        header: "steps",
+        accessor: (row) => row.steps,
+        sortValue: (row) => row.steps,
+        align: "right",
+        className: "w-[5rem]",
+      },
+      {
+        id: "links",
+        header: "links",
+        accessor: (row) => row.links,
+        sortValue: (row) => row.links,
+        align: "right",
+        className: "w-[5rem]",
+      },
+    ],
+    [],
+  );
+
+  return (
+    <main className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-6">
+      <header className="flex flex-col gap-3 border-b border-neutral-800 pb-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-xl font-semibold text-neutral-200">Playbooks</h1>
+            <p className="text-sm text-neutral-500">
+              {workers.length} playbook definition{workers.length === 1 ? "" : "s"}
+            </p>
+          </div>
+          <Link
+            href="/playbooks/new"
+            className="rounded border border-green-700 bg-green-900/50 px-4 py-1.5 text-sm font-medium text-green-300 hover:bg-green-800/50"
+          >
+            + New Playbook
+          </Link>
+        </div>
+      </header>
+
+      {error ? (
+        <div className="border border-red-800 bg-neutral-950 px-3 py-2 text-sm text-red-300">
+          {error}
+        </div>
+      ) : null}
+
+      <Table
+        columns={columns}
+        data={workers}
+        emptyMessage={loading ? "Loading playbooks..." : "No playbook definitions found."}
+        getRowKey={(row) => row.name}
+        initialSort={{ columnId: "name", direction: "asc" }}
+        onRowClick={(row) => router.push(`/playbooks/${encodeURIComponent(row.name)}`)}
+      />
+    </main>
+  );
+}

--- a/apps/studio/frontend/app/runs/[id]/page.tsx
+++ b/apps/studio/frontend/app/runs/[id]/page.tsx
@@ -100,7 +100,7 @@ export default function RunDetailPage({ params }: { params: { id: string } }) {
             </div>
             {run && (
               <p className="mt-1 text-sm text-neutral-400">
-                Worker:{" "}
+                Playbook:{" "}
                 <Link
                   href={`/playbooks/${encodeURIComponent(run.worker_name)}`}
                   className="text-blue-400 hover:text-blue-300"
@@ -117,7 +117,7 @@ export default function RunDetailPage({ params }: { params: { id: string } }) {
                 href={`/playbooks/${encodeURIComponent(run.worker_name)}/edit`}
                 className="rounded border border-neutral-700 bg-neutral-900 px-3 py-1 text-sm text-neutral-300 hover:border-neutral-500 hover:text-neutral-200"
               >
-                Edit Worker
+                Edit Playbook
               </Link>
               <button
                 onClick={handleRerun}
@@ -141,7 +141,7 @@ export default function RunDetailPage({ params }: { params: { id: string } }) {
         <>
           {/* Metadata row */}
           <section className="grid grid-cols-2 gap-2 md:grid-cols-5">
-            <MetricCard label="Worker" value={run.worker_name} />
+            <MetricCard label="Playbook" value={run.worker_name} />
             <MetricCard label="Steps" value={steps.length} />
             <MetricCard label="Duration" value={formatDuration(run.started_at, run.finished_at)} />
             <MetricCard label="Started" value={formatTime(run.started_at)} />

--- a/apps/studio/frontend/app/runs/[id]/page.tsx
+++ b/apps/studio/frontend/app/runs/[id]/page.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import Badge from "@/components/Badge";
+import ExecutionDag from "@/components/ExecutionDag";
+import type { ExecutionStep } from "@/components/ExecutionDag";
+import { getRun, rerunRun } from "@/lib/api";
+import type { RunDetail } from "@/lib/types";
+
+function formatDuration(started: number | null, finished: number | null): string {
+  if (!started) return "—";
+  const end = finished ?? Date.now() / 1000;
+  const seconds = Math.round(end - started);
+  if (seconds < 60) return `${seconds}s`;
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${mins}m ${secs}s`;
+}
+
+function formatTime(ts: number | null): string {
+  if (!ts) return "—";
+  return new Date(ts * 1000).toLocaleString();
+}
+
+const STATUS_TONE: Record<string, "ok" | "pending" | "failed"> = {
+  completed: "ok",
+  running: "pending",
+  failed: "failed",
+};
+
+export default function RunDetailPage({ params }: { params: { id: string } }) {
+  const runId = params.id;
+  const router = useRouter();
+  const [run, setRun] = useState<RunDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [rerunning, setRerunning] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+
+    async function load() {
+      try {
+        const data = await getRun(runId);
+        if (active) {
+          setRun(data);
+          setError(null);
+        }
+      } catch (err) {
+        if (active) {
+          setError(err instanceof Error ? err.message : "Failed to load run");
+        }
+      }
+    }
+
+    void load();
+    const interval = setInterval(load, 3000);
+    return () => {
+      active = false;
+      clearInterval(interval);
+    };
+  }, [runId]);
+
+  const handleRerun = async () => {
+    if (!run || rerunning) return;
+    setRerunning(true);
+    try {
+      const data = await rerunRun(runId);
+      router.push(`/runs/${data.run_id}`);
+    } catch {
+      setRerunning(false);
+    }
+  };
+
+  const steps = run?.steps ?? [];
+  const execSteps: ExecutionStep[] = steps.map((s) => ({
+    step: s.step,
+    status: "completed" as const,
+    result: s.result,
+    timestamp: s.timestamp,
+  }));
+
+  const nodes = run?.graph?.nodes ?? [];
+  const edges = run?.graph?.edges ?? [];
+
+  return (
+    <main className="mx-auto flex w-full max-w-[1600px] flex-col gap-4 px-4 py-6 text-neutral-200">
+      {/* Header */}
+      <header className="flex flex-col gap-3 border-b border-neutral-800 pb-4">
+        <Link href="/runs" className="text-sm text-neutral-500 hover:text-neutral-200">
+          / runs
+        </Link>
+
+        <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+          <div className="min-w-0">
+            <div className="flex items-center gap-3">
+              <h1 className="font-mono text-xl font-semibold text-neutral-200">{runId}</h1>
+              {run && <Badge tone={STATUS_TONE[run.status] ?? "pending"}>{run.status}</Badge>}
+            </div>
+            {run && (
+              <p className="mt-1 text-sm text-neutral-400">
+                Worker:{" "}
+                <Link
+                  href={`/playbooks/${encodeURIComponent(run.worker_name)}`}
+                  className="text-blue-400 hover:text-blue-300"
+                >
+                  {run.worker_name}
+                </Link>
+              </p>
+            )}
+          </div>
+
+          {run && (
+            <div className="flex items-center gap-3">
+              <Link
+                href={`/playbooks/${encodeURIComponent(run.worker_name)}/edit`}
+                className="rounded border border-neutral-700 bg-neutral-900 px-3 py-1 text-sm text-neutral-300 hover:border-neutral-500 hover:text-neutral-200"
+              >
+                Edit Worker
+              </Link>
+              <button
+                onClick={handleRerun}
+                disabled={rerunning}
+                className="rounded border border-green-700 bg-green-900/50 px-3 py-1 text-sm text-green-300 hover:bg-green-800/50 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {rerunning ? "Starting..." : "Re-run"}
+              </button>
+            </div>
+          )}
+        </div>
+      </header>
+
+      {error && (
+        <div className="border border-red-800 bg-neutral-950 px-3 py-2 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+
+      {run && (
+        <>
+          {/* Metadata row */}
+          <section className="grid grid-cols-2 gap-2 md:grid-cols-5">
+            <MetricCard label="Worker" value={run.worker_name} />
+            <MetricCard label="Steps" value={steps.length} />
+            <MetricCard label="Duration" value={formatDuration(run.started_at, run.finished_at)} />
+            <MetricCard label="Started" value={formatTime(run.started_at)} />
+            <MetricCard label="CWD" value={run.cwd || "—"} />
+          </section>
+
+          {/* Task */}
+          {run.task && (
+            <section className="rounded border border-neutral-800 bg-neutral-950 p-3">
+              <div className="text-xs uppercase text-neutral-500">Task</div>
+              <p className="mt-1 whitespace-pre-wrap text-sm text-neutral-300">{run.task}</p>
+            </section>
+          )}
+
+          {/* Error */}
+          {run.error && (
+            <section className="rounded border border-red-800/50 bg-red-950/30 p-3">
+              <div className="text-xs uppercase text-red-400">Error</div>
+              <p className="mt-1 whitespace-pre-wrap font-mono text-sm text-red-300">{run.error}</p>
+            </section>
+          )}
+
+          {/* Split: DAG left, Results right */}
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            {/* LEFT: DAG */}
+            <section className="flex flex-col gap-2">
+              <h2 className="text-sm font-semibold text-neutral-200">Execution Graph</h2>
+              {nodes.length > 0 ? (
+                <ExecutionDag
+                  nodes={nodes}
+                  edges={edges}
+                  executionSteps={execSteps}
+                  currentStep={
+                    run.status === "running"
+                      ? steps.length > 0
+                        ? null
+                        : (nodes[0]?.id ?? null)
+                      : null
+                  }
+                />
+              ) : (
+                <div className="border border-neutral-800 bg-neutral-950 px-3 py-10 text-center text-sm text-neutral-500">
+                  No graph data
+                </div>
+              )}
+            </section>
+
+            {/* RIGHT: Step Results */}
+            <section className="flex flex-col gap-2">
+              <h2 className="text-sm font-semibold text-neutral-200">
+                Step Results ({steps.length})
+              </h2>
+              {steps.length === 0 ? (
+                <div className="border border-neutral-800 bg-neutral-950 px-3 py-10 text-center text-sm text-neutral-500">
+                  {run.status === "running" ? "Waiting for steps..." : "No steps recorded"}
+                </div>
+              ) : (
+                steps.map((step, i) => (
+                  <div key={i} className="rounded border border-neutral-800 bg-neutral-950 p-3">
+                    <div className="flex items-center gap-2">
+                      <span className="font-mono text-sm font-semibold text-green-400">
+                        {step.step}
+                      </span>
+                      <Badge tone="ok">{step.status}</Badge>
+                      <span className="ml-auto text-xs text-neutral-600">
+                        {formatTime(step.timestamp)}
+                      </span>
+                    </div>
+                    {step.result && Object.keys(step.result).length > 0 && (
+                      <div className="mt-2 flex flex-col gap-1">
+                        {Object.entries(step.result).map(([key, val]) => (
+                          <div key={key}>
+                            <span className="text-xs text-neutral-500">{key}:</span>
+                            <p className="mt-0.5 whitespace-pre-wrap break-words text-sm text-neutral-300">
+                              {typeof val === "string" ? val : JSON.stringify(val)}
+                            </p>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                ))
+              )}
+            </section>
+          </div>
+        </>
+      )}
+    </main>
+  );
+}
+
+function MetricCard({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="min-w-0 border border-neutral-800 bg-neutral-950 p-3">
+      <div className="truncate text-xs uppercase text-neutral-500">{label}</div>
+      <div className="mt-1 truncate text-sm font-medium text-neutral-200">{value}</div>
+    </div>
+  );
+}

--- a/apps/studio/frontend/app/runs/page.tsx
+++ b/apps/studio/frontend/app/runs/page.tsx
@@ -106,7 +106,7 @@ export default function RunsPage() {
       ) : runs.length === 0 ? (
         <div className="flex flex-1 items-center justify-center py-20">
           <p className="text-center text-sm text-content-muted">
-            No runs yet. Start a run from any worker&apos;s detail page.
+            No runs yet. Start a run from any playbook&apos;s detail page.
           </p>
         </div>
       ) : (
@@ -115,7 +115,7 @@ export default function RunsPage() {
             <thead>
               <tr className="border-b border-edge text-xs uppercase text-content-muted">
                 <th className="px-3 py-2">Run</th>
-                <th className="px-3 py-2">Worker</th>
+                <th className="px-3 py-2">Playbook</th>
                 <th className="px-3 py-2">Task</th>
                 <th className="px-3 py-2">Status</th>
                 <th className="px-3 py-2">Steps</th>

--- a/apps/studio/frontend/app/runs/page.tsx
+++ b/apps/studio/frontend/app/runs/page.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import Badge from "@/components/Badge";
+import { listRuns } from "@/lib/api";
+import type { RunSummary } from "@/lib/types";
+
+function formatDuration(started: number | null, finished: number | null): string {
+  if (!started) return "—";
+  const end = finished ?? Date.now() / 1000;
+  const seconds = Math.round(end - started);
+  if (seconds < 60) return `${seconds}s`;
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${mins}m ${secs}s`;
+}
+
+function formatTime(ts: number | null): string {
+  if (!ts) return "—";
+  return new Date(ts * 1000).toLocaleString();
+}
+
+const STATUS_TONE: Record<string, "ok" | "pending" | "failed"> = {
+  completed: "ok",
+  running: "pending",
+  failed: "failed",
+};
+
+export default function RunsPage() {
+  const [runs, setRuns] = useState<RunSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [workerFilter, setWorkerFilter] = useState("");
+  const [statusFilter, setStatusFilter] = useState("");
+
+  useEffect(() => {
+    let active = true;
+
+    async function load() {
+      try {
+        const params: Record<string, string> = {};
+        if (workerFilter) params.worker = workerFilter;
+        if (statusFilter) params.status = statusFilter;
+        const data = await listRuns(params);
+        if (active) setRuns(data.runs);
+      } catch {
+        if (active) setRuns([]);
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+
+    void load();
+    const interval = setInterval(load, 5000);
+    return () => {
+      active = false;
+      clearInterval(interval);
+    };
+  }, [workerFilter, statusFilter]);
+
+  const workerNames = Array.from(new Set(runs.map((r) => r.worker_name))).sort();
+
+  return (
+    <main className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-6">
+      <header className="flex flex-col gap-3 border-b border-edge pb-4">
+        <div>
+          <h1 className="text-xl font-semibold text-content-primary">Runs</h1>
+          <p className="text-sm text-content-muted">Execution history across all playbooks</p>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+            className="rounded border border-edge bg-surface-input px-2 py-1 text-sm text-content-secondary"
+          >
+            <option value="">All statuses</option>
+            <option value="completed">Completed</option>
+            <option value="running">Running</option>
+            <option value="failed">Failed</option>
+          </select>
+
+          <select
+            value={workerFilter}
+            onChange={(e) => setWorkerFilter(e.target.value)}
+            className="rounded border border-edge bg-surface-input px-2 py-1 text-sm text-content-secondary"
+          >
+            <option value="">All playbooks</option>
+            {workerNames.map((w) => (
+              <option key={w} value={w}>
+                {w}
+              </option>
+            ))}
+          </select>
+
+          <span className="ml-auto text-xs text-content-muted">
+            {runs.length} run{runs.length !== 1 ? "s" : ""}
+          </span>
+        </div>
+      </header>
+
+      {loading ? (
+        <div className="flex flex-1 items-center justify-center py-20">
+          <p className="text-sm text-content-muted">Loading runs...</p>
+        </div>
+      ) : runs.length === 0 ? (
+        <div className="flex flex-1 items-center justify-center py-20">
+          <p className="text-center text-sm text-content-muted">
+            No runs yet. Start a run from any worker&apos;s detail page.
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-sm">
+            <thead>
+              <tr className="border-b border-edge text-xs uppercase text-content-muted">
+                <th className="px-3 py-2">Run</th>
+                <th className="px-3 py-2">Worker</th>
+                <th className="px-3 py-2">Task</th>
+                <th className="px-3 py-2">Status</th>
+                <th className="px-3 py-2">Steps</th>
+                <th className="px-3 py-2">Duration</th>
+                <th className="px-3 py-2">Started</th>
+              </tr>
+            </thead>
+            <tbody>
+              {runs.map((run) => (
+                <tr key={run.run_id} className="border-b border-edge/50 hover:bg-surface-input/50">
+                  <td className="px-3 py-2">
+                    <Link
+                      href={`/runs/${run.run_id}`}
+                      className="font-mono text-xs text-blue-400 hover:text-blue-300"
+                    >
+                      {run.run_id}
+                    </Link>
+                  </td>
+                  <td className="px-3 py-2">
+                    <Link
+                      href={`/playbooks/${encodeURIComponent(run.worker_name)}`}
+                      className="text-content-secondary hover:text-neutral-100"
+                    >
+                      {run.worker_name}
+                    </Link>
+                  </td>
+                  <td className="max-w-xs truncate px-3 py-2 text-content-secondary">
+                    {run.task || "—"}
+                  </td>
+                  <td className="px-3 py-2">
+                    <Badge tone={STATUS_TONE[run.status] ?? "pending"}>{run.status}</Badge>
+                  </td>
+                  <td className="px-3 py-2 text-content-secondary">{run.step_count}</td>
+                  <td className="px-3 py-2 font-mono text-xs text-content-secondary">
+                    {formatDuration(run.started_at, run.finished_at)}
+                  </td>
+                  <td className="px-3 py-2 text-xs text-content-muted">
+                    {formatTime(run.started_at)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/apps/studio/frontend/app/shows/[topic]/components/PlayDag.tsx
+++ b/apps/studio/frontend/app/shows/[topic]/components/PlayDag.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useMemo } from "react";
+import ReactFlow, { Background, Controls, MarkerType } from "reactflow";
+import type { Edge, Node } from "reactflow";
+import "reactflow/dist/style.css";
+import { getLayoutedElements } from "@/components/canvas/useLayout";
+import type { ShowDetail } from "@/lib/types";
+
+type Play = ShowDetail["plays"][number];
+
+interface PlayDagProps {
+  plays: Play[];
+  showMd?: string | null;
+}
+
+function parseShowMdDeps(showMd: string | null | undefined): Map<string, string[]> {
+  const deps = new Map<string, string[]>();
+  if (!showMd) return deps;
+
+  let currentPlay: string | null = null;
+  for (const line of showMd.split("\n")) {
+    const playMatch = line.match(/\*\*([^*]+)\*\*/);
+    if (playMatch) {
+      currentPlay = playMatch[1].trim();
+    }
+    if (currentPlay) {
+      const depsMatch = line.match(/deps:\s*\[([^\]]*)\]/);
+      if (depsMatch) {
+        const list = depsMatch[1]
+          .split(",")
+          .map((d) => d.trim())
+          .filter(Boolean);
+        deps.set(currentPlay, list);
+        currentPlay = null;
+      }
+    }
+  }
+  return deps;
+}
+
+function statusColor(status: string): string {
+  if (status === "merged" || status === "completed" || status === "done") return "#22c55e";
+  if (status === "running" || status === "pending") return "#60a5fa";
+  if (status === "failed" || status === "error") return "#ef4444";
+  return "#555";
+}
+
+export default function PlayDag({ plays, showMd }: PlayDagProps) {
+  const { nodes, edges } = useMemo(() => {
+    const depsMap = parseShowMdDeps(showMd);
+    const playNames = new Set(plays.map((p) => p.name));
+
+    const rawNodes: Node[] = plays.map((play) => ({
+      id: play.name,
+      type: "default",
+      position: { x: 0, y: 0 },
+      data: { label: play.name },
+      style: {
+        background: "#111",
+        border: `1px solid ${statusColor(play.meta.status)}`,
+        color: "#ccc",
+        fontSize: 11,
+        fontFamily: "monospace",
+        width: 200,
+        borderRadius: 6,
+        padding: "6px 10px",
+      },
+    }));
+
+    let rawEdges: Edge[];
+    const hasDeps = depsMap.size > 0;
+
+    if (hasDeps) {
+      rawEdges = [];
+      plays.forEach((play) => {
+        const deps = depsMap.get(play.name) ?? [];
+        for (const dep of deps) {
+          if (playNames.has(dep)) {
+            rawEdges.push({
+              id: `e-${dep}-${play.name}`,
+              source: dep,
+              target: play.name,
+              markerEnd: { type: MarkerType.ArrowClosed },
+              style: { stroke: "#444" },
+            });
+          }
+        }
+      });
+    } else {
+      rawEdges = plays.slice(0, -1).map((play, i) => ({
+        id: `e-${i}`,
+        source: play.name,
+        target: plays[i + 1].name,
+        markerEnd: { type: MarkerType.ArrowClosed },
+        style: { stroke: "#444" },
+      }));
+    }
+
+    return getLayoutedElements(rawNodes, rawEdges, "LR");
+  }, [plays, showMd]);
+
+  return (
+    <div style={{ height: 280 }} className="rounded border border-neutral-800 bg-neutral-950">
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        fitView
+        fitViewOptions={{ padding: 0.3 }}
+        nodesDraggable={false}
+        nodesConnectable={false}
+        elementsSelectable={false}
+        proOptions={{ hideAttribution: true }}
+        className="bg-neutral-950"
+      >
+        <Background color="#222" gap={20} size={1} />
+        <Controls
+          showInteractive={false}
+          className="!bg-neutral-900 !border-neutral-700 !shadow-none [&>button]:!bg-neutral-800 [&>button]:!border-neutral-700 [&>button]:!text-neutral-400"
+        />
+      </ReactFlow>
+    </div>
+  );
+}

--- a/apps/studio/frontend/app/shows/[topic]/page.tsx
+++ b/apps/studio/frontend/app/shows/[topic]/page.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import Link from "next/link";
+import React, { useCallback, useEffect, useState } from "react";
+import Badge from "@/components/Badge";
+import { getShow, streamShow } from "@/lib/api";
+import type { PlayMeta, ShowDetail, ShowEvent } from "@/lib/types";
+import PlayDag from "./components/PlayDag";
+
+type Play = ShowDetail["plays"][number];
+
+function formatTime(ts: string | number | null | undefined): string {
+  if (!ts) return "—";
+  if (typeof ts === "number") return new Date(ts * 1000).toLocaleString();
+  return new Date(ts).toLocaleString();
+}
+
+function playTone(play: Play): "ok" | "failed" | "pending" | "default" {
+  if (play.verdict?.gate_passed === true) return "ok";
+  if (play.verdict?.gate_passed === false) return "failed";
+  if (play.meta.status === "running" || play.meta.status === "pending") return "pending";
+  if (play.meta.status === "merged") return "ok";
+  return "default";
+}
+
+function reconcileFlag(meta: PlayMeta): "exit_mismatch" | "missing_exit" | null {
+  if (typeof meta.exit_code === "number" && meta.exit_code !== 0) return "exit_mismatch";
+  if (meta.exit_code === undefined && Boolean(meta.merged_at)) return "missing_exit";
+  return null;
+}
+
+export default function ShowDetailPage({ params }: { params: { topic: string } }) {
+  const topic = decodeURIComponent(params.topic);
+  const [show, setShow] = useState<ShowDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [live, setLive] = useState(false);
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const data = await getShow(topic);
+      setShow(data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load show");
+    }
+  }, [topic]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    if (!live) return;
+    return streamShow(topic, (_event: ShowEvent) => {
+      void load();
+    });
+  }, [live, load, topic]);
+
+  const latestPlay = show?.plays.at(-1);
+  const latestStatus = latestPlay?.meta.status ?? "—";
+
+  return (
+    <main className="mx-auto flex w-full max-w-[1600px] flex-col gap-4 px-4 py-6 text-neutral-200">
+      <header className="flex flex-col gap-3 border-b border-neutral-800 pb-4">
+        <Link href="/shows" className="text-sm text-neutral-500 hover:text-neutral-200">
+          / shows
+        </Link>
+
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <h1 className="font-mono text-xl font-semibold">{topic}</h1>
+            <Badge value={latestStatus}>{latestStatus}</Badge>
+          </div>
+          <button
+            onClick={() => setLive((v) => !v)}
+            className={[
+              "rounded border px-3 py-1 text-sm font-medium transition",
+              live
+                ? "border-emerald-700 bg-emerald-900/50 text-emerald-300"
+                : "border-neutral-700 bg-neutral-900 text-neutral-400 hover:text-neutral-200",
+            ].join(" ")}
+          >
+            {live ? "Live: ON" : "Live: OFF"}
+          </button>
+        </div>
+      </header>
+
+      {error && (
+        <div className="border border-red-800 bg-neutral-950 px-3 py-2 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+
+      {!show && !error && (
+        <div className="py-10 text-center text-sm text-neutral-500">Loading...</div>
+      )}
+
+      {show && (
+        <>
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            {/* Left: _show.md */}
+            <section className="flex flex-col gap-2">
+              <h2 className="text-sm font-semibold text-neutral-200">_show.md</h2>
+              <div className="overflow-auto rounded border border-neutral-800 bg-neutral-950 p-3">
+                <pre className="whitespace-pre-wrap break-words text-sm leading-6 text-neutral-400">
+                  {show.show_md ?? "No _show.md found."}
+                </pre>
+              </div>
+            </section>
+
+            {/* Right: plays table */}
+            <section className="flex flex-col gap-2">
+              <h2 className="text-sm font-semibold text-neutral-200">
+                Plays ({show.plays.length})
+              </h2>
+              {show.plays.length === 0 ? (
+                <div className="border border-neutral-800 bg-neutral-950 px-3 py-10 text-center text-sm text-neutral-500">
+                  No plays recorded
+                </div>
+              ) : (
+                <div className="overflow-x-auto border border-neutral-800">
+                  <table className="w-full text-left text-sm">
+                    <thead className="border-b border-neutral-800 bg-neutral-900/70 text-xs uppercase text-neutral-500">
+                      <tr>
+                        <th className="px-3 py-2">Play</th>
+                        <th className="px-3 py-2">Status</th>
+                        <th className="px-3 py-2">Branch</th>
+                        <th className="px-3 py-2">Exit</th>
+                        <th className="px-3 py-2">Verdict</th>
+                        <th className="px-3 py-2">Updated</th>
+                        <th className="px-3 py-2 w-8"></th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {show.plays.map((play) => {
+                        const flag = reconcileFlag(play.meta);
+                        const isExpanded = expanded === play.name;
+                        return (
+                          <React.Fragment key={play.name}>
+                            <tr className="border-b border-neutral-900 text-neutral-300 hover:bg-neutral-900/50">
+                              <td className="max-w-[12rem] truncate px-3 py-2 font-mono text-xs">
+                                {play.name}
+                              </td>
+                              <td className="px-3 py-2">
+                                <Badge tone={playTone(play)}>{play.meta.status}</Badge>
+                              </td>
+                              <td className="max-w-[10rem] truncate px-3 py-2 font-mono text-xs text-neutral-400">
+                                {play.meta.branch}
+                              </td>
+                              <td className="px-3 py-2">
+                                <div className="flex flex-wrap items-center gap-1">
+                                  <span className="text-xs">{play.meta.exit_code ?? "—"}</span>
+                                  {flag === "exit_mismatch" && (
+                                    <Badge tone="failed">exit mismatch</Badge>
+                                  )}
+                                  {flag === "missing_exit" && (
+                                    <Badge tone="pending">missing exit</Badge>
+                                  )}
+                                </div>
+                              </td>
+                              <td className="px-3 py-2">
+                                {play.verdict ? (
+                                  <Badge tone={play.verdict.gate_passed ? "ok" : "failed"}>
+                                    {play.verdict.gate_passed ? "passed" : "failed"}
+                                  </Badge>
+                                ) : (
+                                  <span className="text-xs text-neutral-600">—</span>
+                                )}
+                              </td>
+                              <td className="px-3 py-2 text-xs text-neutral-500">
+                                {formatTime(
+                                  play.updated_at ??
+                                    play.meta.ended_at ??
+                                    play.meta.started_at,
+                                )}
+                              </td>
+                              <td className="px-3 py-2">
+                                <button
+                                  onClick={() =>
+                                    setExpanded(isExpanded ? null : play.name)
+                                  }
+                                  className="text-xs text-neutral-500 hover:text-neutral-200"
+                                >
+                                  {isExpanded ? "▴" : "▾"}
+                                </button>
+                              </td>
+                            </tr>
+
+                            {isExpanded && (
+                              <tr className="bg-neutral-950">
+                                <td colSpan={7} className="px-4 py-3">
+                                  <div className="flex flex-col gap-3">
+                                    {play.verdict?.feedback && (
+                                      <div>
+                                        <div className="text-xs uppercase text-neutral-500">
+                                          Feedback
+                                        </div>
+                                        <p className="mt-1 whitespace-pre-wrap text-sm text-neutral-300">
+                                          {play.verdict.feedback}
+                                        </p>
+                                      </div>
+                                    )}
+                                    {play.verdict?.notes && (
+                                      <div>
+                                        <div className="text-xs uppercase text-neutral-500">
+                                          Notes
+                                        </div>
+                                        <p className="mt-1 whitespace-pre-wrap text-sm text-neutral-300">
+                                          {play.verdict.notes}
+                                        </p>
+                                      </div>
+                                    )}
+                                    <div>
+                                      <div className="text-xs uppercase text-neutral-500">
+                                        Meta
+                                      </div>
+                                      <pre className="mt-1 overflow-auto rounded border border-neutral-800 bg-neutral-900 p-2 font-mono text-xs text-neutral-400">
+                                        {JSON.stringify(play.meta, null, 2)}
+                                      </pre>
+                                    </div>
+                                    {play.verdict && (
+                                      <div>
+                                        <div className="text-xs uppercase text-neutral-500">
+                                          Verdict
+                                        </div>
+                                        <pre className="mt-1 overflow-auto rounded border border-neutral-800 bg-neutral-900 p-2 font-mono text-xs text-neutral-400">
+                                          {JSON.stringify(play.verdict, null, 2)}
+                                        </pre>
+                                      </div>
+                                    )}
+                                  </div>
+                                </td>
+                              </tr>
+                            )}
+                          </React.Fragment>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </section>
+          </div>
+
+          {show.plays.length > 0 && (
+            <section className="flex flex-col gap-2">
+              <h2 className="text-sm font-semibold text-neutral-200">Play Graph</h2>
+              <PlayDag plays={show.plays} showMd={show.show_md} />
+            </section>
+          )}
+        </>
+      )}
+    </main>
+  );
+}

--- a/apps/studio/frontend/app/shows/page.tsx
+++ b/apps/studio/frontend/app/shows/page.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import Badge from "@/components/Badge";
+import Table, { type TableColumn } from "@/components/Table";
+import { listShows } from "@/lib/api";
+import type { ShowSummary } from "@/lib/types";
+
+function formatLastUpdate(ts: number | string | null): string {
+  if (!ts) return "—";
+  if (typeof ts === "number") return new Date(ts * 1000).toLocaleString();
+  return new Date(ts).toLocaleString();
+}
+
+export default function ShowsPage() {
+  const router = useRouter();
+  const [shows, setShows] = useState<ShowSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+
+    async function load() {
+      try {
+        const data = await listShows();
+        if (active) setShows(data);
+      } catch {
+        if (active) setShows([]);
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+
+    void load();
+    const interval = setInterval(load, 5000);
+    return () => {
+      active = false;
+      clearInterval(interval);
+    };
+  }, []);
+
+  const columns = useMemo<Array<TableColumn<ShowSummary>>>(
+    () => [
+      {
+        id: "topic",
+        header: "Topic",
+        accessor: (row) => (
+          <span className="font-mono text-xs text-blue-400">{row.topic}</span>
+        ),
+        sortValue: (row) => row.topic,
+        className: "w-[20rem]",
+        truncate: false,
+      },
+      {
+        id: "play_count",
+        header: "Plays",
+        key: "play_count",
+        sortValue: (row) => row.play_count,
+        align: "right",
+        className: "w-20",
+      },
+      {
+        id: "latest_status",
+        header: "Latest Status",
+        accessor: (row) => (
+          <Badge value={row.latest_status || "—"}>{row.latest_status || "—"}</Badge>
+        ),
+        sortValue: (row) => row.latest_status,
+        className: "w-[10rem]",
+      },
+      {
+        id: "last_update",
+        header: "Last Update",
+        accessor: (row) => (
+          <span className="text-xs text-neutral-500">
+            {formatLastUpdate(row.last_update)}
+          </span>
+        ),
+        sortValue: (row) =>
+          typeof row.last_update === "number"
+            ? row.last_update
+            : row.last_update
+              ? new Date(row.last_update).getTime() / 1000
+              : 0,
+        className: "w-[12rem]",
+      },
+    ],
+    [],
+  );
+
+  return (
+    <main className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-6">
+      <header className="flex flex-col gap-3 border-b border-neutral-800 pb-4">
+        <div>
+          <h1 className="text-xl font-semibold text-neutral-200">Shows</h1>
+          <p className="text-sm text-neutral-500">
+            {shows.length} show{shows.length !== 1 ? "s" : ""}
+          </p>
+        </div>
+      </header>
+
+      <Table
+        data={shows}
+        columns={columns}
+        emptyMessage={loading ? "Loading shows..." : "No shows found."}
+        getRowKey={(row) => row.topic}
+        onRowClick={(row) =>
+          router.push(`/shows/${encodeURIComponent(row.topic)}`)
+        }
+      />
+    </main>
+  );
+}

--- a/apps/studio/frontend/components/AgentProfileForm.tsx
+++ b/apps/studio/frontend/components/AgentProfileForm.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import type { AgentProfile } from "@/lib/types";
+
+interface AgentProfileFormProps {
+  initial?: AgentProfile;
+  mode: "create" | "edit";
+  onSave: (data: AgentProfile) => Promise<void>;
+  saving?: boolean;
+  errors?: string[];
+}
+
+const PROVIDER_OPTIONS = ["claude_code", "codex", "gemini_code"] as const;
+
+type Provider = (typeof PROVIDER_OPTIONS)[number];
+
+const MODEL_OPTIONS: Record<Provider, string[]> = {
+  claude_code: ["sonnet", "opus", "haiku"],
+  codex: ["gpt-5.4-mini", "gpt-5.4", "o3", "o4-mini"],
+  gemini_code: ["gemini-2.5-pro", "gemini-2.5-flash"],
+};
+
+const PERMISSION_OPTIONS = ["default", "bypassPermissions"] as const;
+const EFFORT_OPTIONS = ["none", "low", "medium", "high", "xhigh"] as const;
+
+const SECTION_LABEL = "text-sm font-semibold text-neutral-200";
+const SECTION_DESC = "text-xs text-neutral-500";
+const INPUT_CLS =
+  "w-full rounded border border-neutral-700 bg-neutral-900 px-3 py-1.5 text-sm text-neutral-200 placeholder-neutral-600 focus:border-green-700 focus:outline-none";
+const SELECT_CLS =
+  "w-full rounded border border-neutral-700 bg-neutral-900 px-3 py-1.5 text-sm text-neutral-200 focus:border-green-700 focus:outline-none";
+const TEXTAREA_CLS =
+  "w-full resize-y rounded border border-neutral-700 bg-neutral-900 px-3 py-2 font-mono text-sm text-neutral-200 placeholder-neutral-600 focus:border-green-700 focus:outline-none";
+
+function isProvider(value: string): value is Provider {
+  return (PROVIDER_OPTIONS as readonly string[]).includes(value);
+}
+
+function emptyForm(): AgentProfile {
+  return {
+    name: "",
+    description: "",
+    provider: "claude_code",
+    model: MODEL_OPTIONS.claude_code[0],
+    system_prompt: "",
+    guidance: "",
+  };
+}
+
+export default function AgentProfileForm({
+  initial,
+  mode,
+  onSave,
+  saving = false,
+  errors = [],
+}: AgentProfileFormProps) {
+  const [form, setForm] = useState<AgentProfile>(initial ?? emptyForm());
+
+  const provider = isProvider(form.provider) ? form.provider : "claude_code";
+  const availableModels = MODEL_OPTIONS[provider];
+
+  const handleProviderChange = useCallback((newProvider: string) => {
+    if (!isProvider(newProvider)) return;
+    const firstModel = MODEL_OPTIONS[newProvider][0];
+    setForm((prev) => ({
+      ...prev,
+      provider: newProvider,
+      model: firstModel,
+      // Clear provider-specific fields when switching
+      permission_mode: newProvider === "claude_code" ? prev.permission_mode : undefined,
+      reasoning_effort: newProvider === "codex" ? prev.reasoning_effort : undefined,
+    }));
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      await onSave(form);
+    },
+    [form, onSave],
+  );
+
+  const isValid = form.name.trim().length > 0 && form.provider.length > 0 && form.model.length > 0;
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-6">
+      {/* Section 1: Basics */}
+      <section className="flex flex-col gap-3">
+        <div>
+          <h2 className={SECTION_LABEL}>Basics</h2>
+          <p className={SECTION_DESC}>Agent name and description</p>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="text-xs uppercase text-neutral-500">Name</label>
+          <input
+            type="text"
+            value={form.name}
+            onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
+            placeholder="my_agent"
+            disabled={mode === "edit"}
+            className={`${INPUT_CLS} ${mode === "edit" ? "cursor-not-allowed opacity-60" : ""}`}
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="text-xs uppercase text-neutral-500">Description</label>
+          <input
+            type="text"
+            value={form.description}
+            onChange={(e) => setForm((prev) => ({ ...prev, description: e.target.value }))}
+            placeholder="What does this agent do?"
+            className={INPUT_CLS}
+          />
+        </div>
+      </section>
+
+      {/* Section 2: Provider & Model */}
+      <section className="flex flex-col gap-3">
+        <div>
+          <h2 className={SECTION_LABEL}>Model</h2>
+          <p className={SECTION_DESC}>Provider and model selection</p>
+        </div>
+
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <div className="flex flex-col gap-1">
+            <label className="text-xs uppercase text-neutral-500">Provider</label>
+            <select
+              value={provider}
+              onChange={(e) => handleProviderChange(e.target.value)}
+              className={SELECT_CLS}
+            >
+              {PROVIDER_OPTIONS.map((p) => (
+                <option key={p} value={p}>
+                  {p}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label className="text-xs uppercase text-neutral-500">Model</label>
+            <select
+              value={form.model}
+              onChange={(e) => setForm((prev) => ({ ...prev, model: e.target.value }))}
+              className={SELECT_CLS}
+            >
+              {availableModels.map((m) => (
+                <option key={m} value={m}>
+                  {m}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Permission Mode — claude_code only */}
+          {provider === "claude_code" ? (
+            <div className="flex flex-col gap-1">
+              <label className="text-xs uppercase text-neutral-500">Permission Mode</label>
+              <select
+                value={form.permission_mode ?? "default"}
+                onChange={(e) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    permission_mode: e.target.value === "default" ? undefined : e.target.value,
+                  }))
+                }
+                className={SELECT_CLS}
+              >
+                {PERMISSION_OPTIONS.map((p) => (
+                  <option key={p} value={p}>
+                    {p}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ) : null}
+
+          {/* Reasoning Effort — codex only */}
+          {provider === "codex" ? (
+            <div className="flex flex-col gap-1">
+              <label className="text-xs uppercase text-neutral-500">Reasoning Effort</label>
+              <select
+                value={form.reasoning_effort ?? "none"}
+                onChange={(e) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    reasoning_effort: e.target.value === "none" ? undefined : e.target.value,
+                  }))
+                }
+                className={SELECT_CLS}
+              >
+                {EFFORT_OPTIONS.map((e) => (
+                  <option key={e} value={e}>
+                    {e}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ) : null}
+        </div>
+      </section>
+
+      {/* Section 3: System Prompt */}
+      <section className="flex flex-col gap-3">
+        <div>
+          <h2 className={SECTION_LABEL}>System Prompt</h2>
+          <p className={SECTION_DESC}>Base identity and role instructions for this agent</p>
+        </div>
+        <textarea
+          value={form.system_prompt}
+          onChange={(e) => setForm((prev) => ({ ...prev, system_prompt: e.target.value }))}
+          placeholder="You are a specialized agent that..."
+          rows={6}
+          className={TEXTAREA_CLS}
+        />
+      </section>
+
+      {/* Section 4: Guidance */}
+      <section className="flex flex-col gap-3">
+        <div>
+          <h2 className={SECTION_LABEL}>Guidance</h2>
+          <p className={SECTION_DESC}>Task-specific instructions and constraints</p>
+        </div>
+        <textarea
+          value={form.guidance}
+          onChange={(e) => setForm((prev) => ({ ...prev, guidance: e.target.value }))}
+          placeholder="When working on this task, always..."
+          rows={4}
+          className={TEXTAREA_CLS}
+        />
+      </section>
+
+      {/* Errors */}
+      {errors.length > 0 ? (
+        <div className="rounded border border-red-900 bg-red-950/40 px-4 py-3">
+          <p className="text-xs font-semibold uppercase text-red-400">Validation errors</p>
+          <ul className="mt-1 list-inside list-disc text-sm text-red-300">
+            {errors.map((err, i) => (
+              <li key={i}>{err}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {/* Submit */}
+      <div className="flex items-center gap-3 border-t border-neutral-800 pt-4">
+        <button
+          type="submit"
+          disabled={saving || !isValid}
+          className={`rounded px-6 py-2 text-sm font-medium transition ${
+            saving || !isValid
+              ? "cursor-not-allowed border border-neutral-700 bg-neutral-800 text-neutral-500"
+              : "border border-green-700 bg-green-900/50 text-green-300 hover:bg-green-800/50"
+          }`}
+        >
+          {saving ? "Saving..." : mode === "create" ? "Create Agent" : "Save Changes"}
+        </button>
+        {!isValid ? (
+          <span className="text-xs text-neutral-500">Name, provider, and model required</span>
+        ) : null}
+      </div>
+    </form>
+  );
+}

--- a/apps/studio/frontend/components/Badge.tsx
+++ b/apps/studio/frontend/components/Badge.tsx
@@ -1,0 +1,75 @@
+import type { ReactNode } from "react";
+
+export type BadgeTone = "ok" | "running" | "failed" | "pending" | "blocked" | "default";
+
+export interface BadgeProps {
+  children: ReactNode;
+  tone?: BadgeTone;
+  value?: string | null;
+  className?: string;
+}
+
+const toneClasses: Record<BadgeTone, string> = {
+  ok: "border-emerald-800 bg-emerald-950/40 text-emerald-300",
+  running: "border-blue-800 bg-blue-950/40 text-blue-300",
+  failed: "border-red-800 bg-red-950/40 text-red-300",
+  pending: "border-amber-800 bg-amber-950/40 text-amber-300",
+  blocked: "border-fuchsia-800 bg-fuchsia-950/40 text-fuchsia-300",
+  default: "border-neutral-800 bg-neutral-950 text-neutral-300",
+};
+
+function toneFromValue(value: string | null | undefined): BadgeTone {
+  const normalized = value?.toLowerCase();
+
+  if (
+    normalized === "ok" ||
+    normalized === "done" ||
+    normalized === "success" ||
+    normalized === "completed" ||
+    normalized === "active"
+  ) {
+    return "ok";
+  }
+
+  if (normalized === "running" || normalized === "executing" || normalized === "open") {
+    return "running";
+  }
+
+  if (normalized === "failed" || normalized === "failure" || normalized === "error") {
+    return "failed";
+  }
+
+  if (
+    normalized === "pending" ||
+    normalized === "queued" ||
+    normalized === "planned" ||
+    normalized === "received"
+  ) {
+    return "pending";
+  }
+
+  if (normalized === "blocked" || normalized === "gated") {
+    return "blocked";
+  }
+
+  return "default";
+}
+
+export default function Badge({ children, tone, value, className }: BadgeProps) {
+  const resolvedTone =
+    tone ?? toneFromValue(value ?? (typeof children === "string" ? children : null));
+
+  return (
+    <span
+      className={[
+        "inline-flex max-w-full items-center rounded-full border px-2 py-0.5 text-xs font-medium",
+        toneClasses[resolvedTone],
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      <span className="truncate">{children}</span>
+    </span>
+  );
+}

--- a/apps/studio/frontend/components/ExecutionDag.tsx
+++ b/apps/studio/frontend/components/ExecutionDag.tsx
@@ -1,0 +1,288 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { WorkerStepNode, WorkerLinkEdge } from "@/lib/types";
+
+type StepStatus = "pending" | "running" | "completed" | "failed";
+
+export interface ExecutionStep {
+  step: string;
+  status: StepStatus;
+  result?: Record<string, unknown>;
+  timestamp?: number | null;
+}
+
+interface Props {
+  nodes: WorkerStepNode[];
+  edges: WorkerLinkEdge[];
+  executionSteps: ExecutionStep[];
+  currentStep: string | null;
+}
+
+const STATUS_COLORS: Record<StepStatus, { fill: string; stroke: string; text: string }> = {
+  pending: { fill: "#1a1a2e", stroke: "#333", text: "#555" },
+  running: { fill: "#1a1a3e", stroke: "#60a5fa", text: "#93c5fd" },
+  completed: { fill: "#0a2e1a", stroke: "#22c55e", text: "#86efac" },
+  failed: { fill: "#2e0a0a", stroke: "#ef4444", text: "#fca5a5" },
+};
+
+const ROLE_COLORS: Record<string, string> = {
+  researcher: "#22c55e",
+  implementer: "#a855f7",
+  reviewer: "#14b8a6",
+  critic: "#f59e0b",
+};
+
+export default function ExecutionDag({ nodes, edges, executionSteps, currentStep }: Props) {
+  const svgRef = useRef<SVGSVGElement>(null);
+
+  const completedSteps = new Set(
+    executionSteps.filter((s) => s.status === "completed").map((s) => s.step),
+  );
+
+  function getStatus(nodeId: string): StepStatus {
+    if (nodeId === currentStep) return "running";
+    if (completedSteps.has(nodeId)) return "completed";
+    const failed = executionSteps.find((s) => s.step === nodeId && s.status === "failed");
+    if (failed) return "failed";
+    return "pending";
+  }
+
+  const NODE_W = 200;
+  const NODE_H = 70;
+  const GAP_X = 80;
+  const GAP_Y = 30;
+  const PAD = 40;
+
+  const adj: Record<string, Set<string>> = {};
+  const inDeg: Record<string, number> = {};
+  for (const n of nodes) {
+    adj[n.id] = new Set();
+    inDeg[n.id] = 0;
+  }
+  for (const e of edges) {
+    if (adj[e.source] && !adj[e.source].has(e.target)) {
+      adj[e.source].add(e.target);
+      inDeg[e.target] = (inDeg[e.target] || 0) + 1;
+    }
+  }
+
+  const layers: string[][] = [];
+  const placed = new Set<string>();
+  let frontier = nodes.filter((n) => (inDeg[n.id] || 0) === 0).map((n) => n.id);
+  while (frontier.length > 0) {
+    layers.push(frontier);
+    frontier.forEach((id) => placed.add(id));
+    const next: string[] = [];
+    for (const id of frontier) {
+      for (const child of Array.from(adj[id] || [])) {
+        if (!placed.has(child) && !next.includes(child)) {
+          const allParentsPlaced = nodes.every(
+            (n) => !adj[n.id]?.has(child) || placed.has(n.id) || frontier.includes(n.id),
+          );
+          if (allParentsPlaced) next.push(child);
+        }
+      }
+    }
+    frontier = next;
+    if (layers.length > 50) break;
+  }
+  for (const n of nodes) {
+    if (!placed.has(n.id)) {
+      if (layers.length === 0) layers.push([]);
+      layers[layers.length - 1].push(n.id);
+    }
+  }
+
+  const pos: Record<string, { x: number; y: number }> = {};
+  const maxLayerH = Math.max(...layers.map((l) => l.length));
+  const totalW = layers.length * (NODE_W + GAP_X) - GAP_X + PAD * 2;
+  const totalH = maxLayerH * (NODE_H + GAP_Y) - GAP_Y + PAD * 2;
+
+  layers.forEach((layer, li) => {
+    const lx = PAD + li * (NODE_W + GAP_X);
+    const layerH = layer.length * (NODE_H + GAP_Y) - GAP_Y;
+    const offsetY = (totalH - layerH) / 2;
+    layer.forEach((id, ni) => {
+      pos[id] = { x: lx, y: offsetY + ni * (NODE_H + GAP_Y) };
+    });
+  });
+
+  const svgW = Math.max(totalW, 400);
+  const svgH = Math.max(totalH, 200);
+
+  return (
+    <div className="overflow-auto rounded border border-neutral-800 bg-neutral-950">
+      <svg
+        ref={svgRef}
+        viewBox={`0 0 ${svgW} ${svgH}`}
+        width={svgW}
+        height={svgH}
+        className="block"
+      >
+        <defs>
+          <marker id="exec-arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+            <polygon points="0 0, 8 3, 0 6" fill="#555" />
+          </marker>
+          <marker
+            id="exec-arrow-active"
+            markerWidth="8"
+            markerHeight="6"
+            refX="8"
+            refY="3"
+            orient="auto"
+          >
+            <polygon points="0 0, 8 3, 0 6" fill="#22c55e" />
+          </marker>
+        </defs>
+
+        {edges.map((e, i) => {
+          const from = pos[e.source];
+          const to = pos[e.target];
+          if (!from || !to) return null;
+
+          const sourceCompleted = completedSteps.has(e.source);
+          const x1 = from.x + NODE_W;
+          const y1 = from.y + NODE_H / 2;
+          const x2 = to.x;
+          const y2 = to.y + NODE_H / 2;
+
+          const mx = (x1 + x2) / 2;
+          const path = `M ${x1} ${y1} C ${mx} ${y1}, ${mx} ${y2}, ${x2} ${y2}`;
+
+          return (
+            <path
+              key={i}
+              d={path}
+              fill="none"
+              stroke={sourceCompleted ? "#22c55e" : "#333"}
+              strokeWidth={sourceCompleted ? 2 : 1}
+              strokeDasharray={e.mode === "code" ? "6 4" : undefined}
+              markerEnd={sourceCompleted ? "url(#exec-arrow-active)" : "url(#exec-arrow)"}
+              style={{ transition: "stroke 0.5s, stroke-width 0.5s" }}
+            />
+          );
+        })}
+
+        {nodes.map((node) => {
+          const p = pos[node.id];
+          if (!p) return null;
+          const status = getStatus(node.id);
+          const colors = STATUS_COLORS[status];
+          const roleColor = ROLE_COLORS[node.role] || "#666";
+
+          return (
+            <g key={node.id} style={{ transition: "opacity 0.3s" }}>
+              <rect
+                x={p.x}
+                y={p.y}
+                width={NODE_W}
+                height={NODE_H}
+                rx={6}
+                fill={colors.fill}
+                stroke={colors.stroke}
+                strokeWidth={status === "running" ? 2 : 1}
+              />
+
+              {status === "running" && (
+                <rect
+                  x={p.x}
+                  y={p.y}
+                  width={NODE_W}
+                  height={NODE_H}
+                  rx={6}
+                  fill="none"
+                  stroke={colors.stroke}
+                  strokeWidth={2}
+                  opacity={0.5}
+                >
+                  <animate
+                    attributeName="opacity"
+                    values="0.5;0.1;0.5"
+                    dur="1.5s"
+                    repeatCount="indefinite"
+                  />
+                </rect>
+              )}
+
+              {status === "completed" && (
+                <text
+                  x={p.x + NODE_W - 16}
+                  y={p.y + 16}
+                  fontSize={14}
+                  fill="#22c55e"
+                  textAnchor="middle"
+                >
+                  ✓
+                </text>
+              )}
+
+              {status === "failed" && (
+                <text
+                  x={p.x + NODE_W - 16}
+                  y={p.y + 16}
+                  fontSize={14}
+                  fill="#ef4444"
+                  textAnchor="middle"
+                >
+                  ✗
+                </text>
+              )}
+
+              <text
+                x={p.x + 10}
+                y={p.y + 20}
+                fontSize={13}
+                fontWeight={600}
+                fontFamily="monospace"
+                fill={colors.text}
+              >
+                {node.label}
+              </text>
+
+              {node.role && (
+                <rect
+                  x={p.x + NODE_W - 70}
+                  y={p.y + 28}
+                  width={60}
+                  height={16}
+                  rx={8}
+                  fill={roleColor}
+                  opacity={0.2}
+                />
+              )}
+              {node.role && (
+                <text
+                  x={p.x + NODE_W - 40}
+                  y={p.y + 40}
+                  fontSize={9}
+                  fill={roleColor}
+                  textAnchor="middle"
+                  fontFamily="monospace"
+                >
+                  {node.role}
+                </text>
+              )}
+
+              <text
+                x={p.x + 10}
+                y={p.y + 45}
+                fontSize={10}
+                fontFamily="monospace"
+                fill={status === "pending" ? "#444" : "#888"}
+              >
+                {node.assignment}
+              </text>
+
+              {status === "completed" && (
+                <text x={p.x + 10} y={p.y + 60} fontSize={9} fontFamily="monospace" fill="#4a9">
+                  done
+                </text>
+              )}
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}

--- a/apps/studio/frontend/components/LinkEditor.tsx
+++ b/apps/studio/frontend/components/LinkEditor.tsx
@@ -1,0 +1,335 @@
+"use client";
+
+import { useCallback } from "react";
+
+export interface LinkData {
+  from: string;
+  to: string;
+  condition?: string;
+  map?: Record<string, string>;
+  handler?: string;
+  /** Internal mode flag — not part of the persisted schema but needed for the editor. */
+  _mode?: "simple" | "code";
+}
+
+export interface LinkEditorProps {
+  links: LinkData[];
+  stepNames: string[];
+  onChange: (links: LinkData[]) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function effectiveMode(link: LinkData): "simple" | "code" {
+  if (link._mode) return link._mode;
+  return link.handler !== undefined && link.handler !== "" ? "code" : "simple";
+}
+
+function blankLink(stepNames: string[]): LinkData {
+  return {
+    from: stepNames[0] ?? "",
+    to: stepNames[1] ?? stepNames[0] ?? "",
+    condition: "",
+    map: {},
+    handler: undefined,
+    _mode: "simple",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Sub-component: FieldMapEditor
+// ---------------------------------------------------------------------------
+
+interface FieldMapEditorProps {
+  map: Record<string, string>;
+  onChange: (map: Record<string, string>) => void;
+}
+
+function FieldMapEditor({ map, onChange }: FieldMapEditorProps) {
+  const entries = Object.entries(map);
+
+  const updateKey = (oldKey: string, newKey: string) => {
+    const next: Record<string, string> = {};
+    for (const [k, v] of Object.entries(map)) {
+      next[k === oldKey ? newKey : k] = v;
+    }
+    onChange(next);
+  };
+
+  const updateValue = (key: string, value: string) => {
+    onChange({ ...map, [key]: value });
+  };
+
+  const removeEntry = (key: string) => {
+    const next = { ...map };
+    delete next[key];
+    onChange(next);
+  };
+
+  const addEntry = () => {
+    // Generate a unique blank key so multiple blank rows don't collide
+    let key = "";
+    let suffix = 0;
+    while (key in map) {
+      key = `key${suffix === 0 ? "" : suffix}`;
+      suffix++;
+    }
+    onChange({ ...map, [key]: "" });
+  };
+
+  return (
+    <div className="flex flex-col gap-1">
+      {entries.length > 0 ? (
+        <div className="mb-1 grid grid-cols-[1fr_1fr_auto] gap-1 text-xs text-neutral-500">
+          <span>from field</span>
+          <span>to field</span>
+          <span />
+        </div>
+      ) : null}
+
+      {entries.map(([key, value], idx) => (
+        <div key={idx} className="grid grid-cols-[1fr_1fr_auto] items-center gap-1">
+          <input
+            type="text"
+            value={key}
+            onChange={(e) => updateKey(key, e.target.value)}
+            placeholder="source_field"
+            className="rounded border border-neutral-700 bg-neutral-900 px-2 py-1 font-mono text-xs text-neutral-200 placeholder-neutral-600 focus:border-neutral-500 focus:outline-none"
+          />
+          <input
+            type="text"
+            value={value}
+            onChange={(e) => updateValue(key, e.target.value)}
+            placeholder="dest_field"
+            className="rounded border border-neutral-700 bg-neutral-900 px-2 py-1 font-mono text-xs text-neutral-200 placeholder-neutral-600 focus:border-neutral-500 focus:outline-none"
+          />
+          <button
+            type="button"
+            onClick={() => removeEntry(key)}
+            aria-label="Remove field mapping"
+            className="flex h-6 w-6 items-center justify-center rounded text-neutral-500 hover:bg-neutral-800 hover:text-neutral-300"
+          >
+            x
+          </button>
+        </div>
+      ))}
+
+      <button
+        type="button"
+        onClick={addEntry}
+        className="mt-1 self-start rounded border border-neutral-700 px-2 py-0.5 text-xs text-neutral-400 hover:border-neutral-500 hover:text-neutral-200"
+      >
+        + Add field
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sub-component: LinkCard
+// ---------------------------------------------------------------------------
+
+interface LinkCardProps {
+  link: LinkData;
+  index: number;
+  stepNames: string[];
+  onUpdate: (index: number, updated: LinkData) => void;
+  onDelete: (index: number) => void;
+}
+
+function LinkCard({ link, index, stepNames, onUpdate, onDelete }: LinkCardProps) {
+  const mode = effectiveMode(link);
+
+  const set = useCallback(
+    (patch: Partial<LinkData>) => {
+      onUpdate(index, { ...link, ...patch });
+    },
+    [index, link, onUpdate],
+  );
+
+  const switchMode = (next: "simple" | "code") => {
+    if (next === "code") {
+      set({ _mode: "code", condition: undefined, map: undefined });
+    } else {
+      set({ _mode: "simple", handler: undefined, condition: "", map: {} });
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3 rounded border border-neutral-800 bg-neutral-950 p-4">
+      {/* Header row: from → to + mode toggle + delete */}
+      <div className="flex flex-wrap items-center gap-3">
+        {/* From */}
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <label className="text-xs uppercase text-neutral-500">from</label>
+          <select
+            value={link.from}
+            onChange={(e) => set({ from: e.target.value })}
+            className="rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-sm text-neutral-200 focus:border-neutral-500 focus:outline-none"
+          >
+            {stepNames.map((name) => (
+              <option key={name} value={name}>
+                {name}
+              </option>
+            ))}
+            {stepNames.length === 0 ? <option value="">— no steps defined —</option> : null}
+          </select>
+        </div>
+
+        {/* Arrow */}
+        <span className="mt-4 shrink-0 text-neutral-600" aria-hidden>
+          →
+        </span>
+
+        {/* To */}
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <label className="text-xs uppercase text-neutral-500">to</label>
+          <select
+            value={link.to}
+            onChange={(e) => set({ to: e.target.value })}
+            className="rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-sm text-neutral-200 focus:border-neutral-500 focus:outline-none"
+          >
+            {stepNames.map((name) => (
+              <option key={name} value={name}>
+                {name}
+              </option>
+            ))}
+            {stepNames.length === 0 ? <option value="">— no steps defined —</option> : null}
+          </select>
+        </div>
+
+        {/* Mode toggle (segmented control) */}
+        <div className="mt-4 flex shrink-0 overflow-hidden rounded border border-neutral-700">
+          {(["simple", "code"] as const).map((m) => (
+            <label
+              key={m}
+              className={[
+                "cursor-pointer px-3 py-1 text-xs transition-colors",
+                mode === m
+                  ? "bg-neutral-700 text-neutral-100"
+                  : "bg-neutral-900 text-neutral-500 hover:bg-neutral-800 hover:text-neutral-300",
+              ].join(" ")}
+            >
+              <input
+                type="radio"
+                name={`link-mode-${index}`}
+                value={m}
+                checked={mode === m}
+                onChange={() => switchMode(m)}
+                className="sr-only"
+              />
+              {m}
+            </label>
+          ))}
+        </div>
+
+        {/* Delete */}
+        <button
+          type="button"
+          onClick={() => onDelete(index)}
+          aria-label={`Delete link ${link.from} → ${link.to}`}
+          className="mt-4 shrink-0 rounded border border-neutral-800 px-2 py-1 text-xs text-neutral-500 hover:border-red-900 hover:bg-red-950 hover:text-red-400"
+        >
+          Delete
+        </button>
+      </div>
+
+      {/* Simple mode body */}
+      {mode === "simple" ? (
+        <div className="flex flex-col gap-3">
+          {/* Condition */}
+          <div className="flex flex-col gap-1">
+            <label className="text-xs uppercase text-neutral-500">
+              condition
+              <span className="ml-1 normal-case text-neutral-600">(optional)</span>
+            </label>
+            <input
+              type="text"
+              value={link.condition ?? ""}
+              onChange={(e) => set({ condition: e.target.value })}
+              placeholder='e.g. "not approved"'
+              className="rounded border border-neutral-700 bg-neutral-900 px-2 py-1.5 text-sm text-neutral-200 placeholder-neutral-600 focus:border-neutral-500 focus:outline-none"
+            />
+          </div>
+
+          {/* Field map */}
+          <div className="flex flex-col gap-1">
+            <span className="text-xs uppercase text-neutral-500">field map</span>
+            <FieldMapEditor map={link.map ?? {}} onChange={(map) => set({ map })} />
+          </div>
+        </div>
+      ) : null}
+
+      {/* Code mode body */}
+      {mode === "code" ? (
+        <div className="flex flex-col gap-1">
+          <label className="text-xs uppercase text-neutral-500">handler</label>
+          <textarea
+            value={link.handler ?? ""}
+            onChange={(e) => set({ handler: e.target.value })}
+            rows={6}
+            spellCheck={false}
+            placeholder={"def handler(ctx):\n    return ctx"}
+            className="rounded border border-neutral-700 bg-neutral-900 px-3 py-2 font-mono text-xs leading-5 text-neutral-200 placeholder-neutral-600 focus:border-neutral-500 focus:outline-none"
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main export: LinkEditor
+// ---------------------------------------------------------------------------
+
+export default function LinkEditor({ links, stepNames, onChange }: LinkEditorProps) {
+  const handleUpdate = useCallback(
+    (index: number, updated: LinkData) => {
+      const next = links.map((link, i) => (i === index ? updated : link));
+      onChange(next);
+    },
+    [links, onChange],
+  );
+
+  const handleDelete = useCallback(
+    (index: number) => {
+      onChange(links.filter((_, i) => i !== index));
+    },
+    [links, onChange],
+  );
+
+  const handleAdd = () => {
+    onChange([...links, blankLink(stepNames)]);
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      {links.length === 0 ? (
+        <p className="rounded border border-neutral-800 px-4 py-6 text-center text-sm text-neutral-500">
+          No links defined. Add one below.
+        </p>
+      ) : null}
+
+      {links.map((link, index) => (
+        <LinkCard
+          key={index}
+          link={link}
+          index={index}
+          stepNames={stepNames}
+          onUpdate={handleUpdate}
+          onDelete={handleDelete}
+        />
+      ))}
+
+      <button
+        type="button"
+        onClick={handleAdd}
+        className="self-start rounded border border-neutral-700 px-3 py-1.5 text-sm text-neutral-400 hover:border-neutral-500 hover:text-neutral-200"
+      >
+        + Add Link
+      </button>
+    </div>
+  );
+}

--- a/apps/studio/frontend/components/LinkPanel.tsx
+++ b/apps/studio/frontend/components/LinkPanel.tsx
@@ -1,0 +1,70 @@
+import type { WorkerLinkEdge } from "@/lib/types";
+import Badge from "@/components/Badge";
+
+export interface LinkPanelProps {
+  edge: WorkerLinkEdge;
+}
+
+export default function LinkPanel({ edge }: LinkPanelProps) {
+  const isCode = edge.mode === "code";
+
+  return (
+    <div className="flex flex-col gap-3 border border-neutral-800 bg-neutral-950 p-4">
+      {/* Source → Target + mode badge */}
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="font-mono text-sm font-medium text-neutral-200">{edge.source}</span>
+        <span className="text-neutral-500" aria-hidden>
+          →
+        </span>
+        <span className="font-mono text-sm font-medium text-neutral-200">{edge.target}</span>
+        <Badge tone={isCode ? "pending" : "ok"}>{isCode ? "code" : "simple"}</Badge>
+      </div>
+
+      {/* Simple mode: condition + field map */}
+      {!isCode ? (
+        <>
+          {edge.condition ? (
+            <div>
+              <span className="text-xs uppercase text-neutral-500">condition</span>
+              <p className="mt-0.5 rounded border border-neutral-800 bg-neutral-900 px-2 py-1 font-mono text-xs text-neutral-300">
+                {edge.condition}
+              </p>
+            </div>
+          ) : null}
+
+          {edge.map && Object.keys(edge.map).length > 0 ? (
+            <div>
+              <span className="text-xs uppercase text-neutral-500">field map</span>
+              <table className="mt-1 w-full text-xs">
+                <thead>
+                  <tr className="border-b border-neutral-800 text-left text-neutral-500">
+                    <th className="pb-1 pr-3 font-normal">from</th>
+                    <th className="pb-1 font-normal">to</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {Object.entries(edge.map).map(([from, to]) => (
+                    <tr key={from} className="border-b border-neutral-900">
+                      <td className="py-1 pr-3 font-mono text-neutral-300">{from}</td>
+                      <td className="py-1 font-mono text-neutral-300">{to}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : null}
+        </>
+      ) : null}
+
+      {/* Code mode: handler code block */}
+      {isCode && edge.handler ? (
+        <div>
+          <span className="text-xs uppercase text-neutral-500">handler</span>
+          <pre className="mt-1 max-h-48 overflow-auto rounded border border-neutral-800 bg-neutral-900 p-3 text-xs leading-5 text-neutral-400 whitespace-pre-wrap">
+            {edge.handler}
+          </pre>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/studio/frontend/components/ModelConfigTable.tsx
+++ b/apps/studio/frontend/components/ModelConfigTable.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import type { ModelConfig } from "@/lib/types";
+
+const PROVIDER_OPTIONS = ["claude_code", "codex", "gemini_code"] as const;
+
+type Provider = (typeof PROVIDER_OPTIONS)[number];
+
+const MODEL_OPTIONS: Record<Provider, string[]> = {
+  claude_code: ["sonnet", "opus", "haiku"],
+  codex: ["gpt-5.4-mini", "gpt-5.4", "o3", "o4-mini"],
+  gemini_code: ["gemini-2.5-pro", "gemini-2.5-flash"],
+};
+
+const EFFORT_OPTIONS = ["none", "low", "medium", "high", "xhigh"] as const;
+
+const PERMISSION_OPTIONS = ["default", "bypassPermissions"] as const;
+
+export interface ModelConfigTableProps {
+  models: Record<string, ModelConfig>;
+  onChange: (models: Record<string, ModelConfig>) => void;
+}
+
+interface RowEntry {
+  role: string;
+  config: ModelConfig;
+}
+
+function toRows(models: Record<string, ModelConfig>): RowEntry[] {
+  return Object.entries(models).map(([role, config]) => ({ role, config }));
+}
+
+function fromRows(rows: RowEntry[]): Record<string, ModelConfig> {
+  const result: Record<string, ModelConfig> = {};
+  for (const { role, config } of rows) {
+    if (role.trim()) {
+      result[role] = config;
+    }
+  }
+  return result;
+}
+
+function nextDefaultRole(rows: RowEntry[]): string {
+  const existing = new Set(rows.map((r) => r.role));
+  let n = 1;
+  while (existing.has(`role_${n}`)) {
+    n++;
+  }
+  return `role_${n}`;
+}
+
+function isProvider(value: string): value is Provider {
+  return (PROVIDER_OPTIONS as readonly string[]).includes(value);
+}
+
+export default function ModelConfigTable({ models, onChange }: ModelConfigTableProps) {
+  const rows = toRows(models);
+
+  function updateRow(index: number, updated: RowEntry) {
+    const next = rows.map((row, i) => (i === index ? updated : row));
+    onChange(fromRows(next));
+  }
+
+  function handleRoleChange(index: number, newRole: string) {
+    const row = rows[index];
+    updateRow(index, { ...row, role: newRole });
+  }
+
+  function handleProviderChange(index: number, newProvider: string) {
+    if (!isProvider(newProvider)) return;
+    const row = rows[index];
+    const firstModel = MODEL_OPTIONS[newProvider][0];
+
+    const updatedConfig: ModelConfig = {
+      provider: newProvider,
+      model: firstModel,
+    };
+
+    // Carry over effort/permission only if the new provider supports them
+    if (newProvider === "codex" && row.config.reasoning_effort) {
+      updatedConfig.reasoning_effort = row.config.reasoning_effort;
+    }
+    if (newProvider === "claude_code" && row.config.permission_mode) {
+      updatedConfig.permission_mode = row.config.permission_mode;
+    }
+
+    updateRow(index, { ...row, config: updatedConfig });
+  }
+
+  function handleModelChange(index: number, newModel: string) {
+    const row = rows[index];
+    updateRow(index, { ...row, config: { ...row.config, model: newModel } });
+  }
+
+  function handleEffortChange(index: number, newEffort: string) {
+    const row = rows[index];
+    updateRow(index, {
+      ...row,
+      config: {
+        ...row.config,
+        reasoning_effort: newEffort === "none" ? undefined : newEffort,
+      },
+    });
+  }
+
+  function handlePermissionChange(index: number, newPermission: string) {
+    const row = rows[index];
+    updateRow(index, {
+      ...row,
+      config: {
+        ...row.config,
+        permission_mode: newPermission === "default" ? undefined : newPermission,
+      },
+    });
+  }
+
+  function handleAddRow() {
+    const newRole = nextDefaultRole(rows);
+    const newConfig: ModelConfig = {
+      provider: "claude_code",
+      model: MODEL_OPTIONS.claude_code[0],
+    };
+    const next = [...rows, { role: newRole, config: newConfig }];
+    onChange(fromRows(next));
+  }
+
+  function handleDeleteRow(index: number) {
+    const next = rows.filter((_, i) => i !== index);
+    onChange(fromRows(next));
+  }
+
+  const inputClass =
+    "rounded border border-neutral-700 bg-neutral-900 px-3 py-1.5 text-sm text-neutral-200 focus:border-neutral-500 focus:outline-none w-full";
+
+  const selectClass =
+    "rounded border border-neutral-700 bg-neutral-900 px-3 py-1.5 text-sm text-neutral-200 focus:border-neutral-500 focus:outline-none w-full";
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="overflow-x-auto border border-neutral-800">
+        <table className="min-w-full border-collapse text-sm">
+          <thead className="border-b border-neutral-800 bg-neutral-900/70 text-xs uppercase text-neutral-500">
+            <tr>
+              <th scope="col" className="px-3 py-2 text-left font-medium tracking-normal">
+                Role Name
+              </th>
+              <th scope="col" className="px-3 py-2 text-left font-medium tracking-normal">
+                Provider
+              </th>
+              <th scope="col" className="px-3 py-2 text-left font-medium tracking-normal">
+                Model
+              </th>
+              <th scope="col" className="px-3 py-2 text-left font-medium tracking-normal">
+                Effort
+              </th>
+              <th scope="col" className="px-3 py-2 text-left font-medium tracking-normal">
+                Permission
+              </th>
+              <th scope="col" className="w-12 px-3 py-2" />
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(({ role, config }, index) => {
+              const provider = isProvider(config.provider) ? config.provider : "claude_code";
+              const availableModels = MODEL_OPTIONS[provider];
+              const showEffort = provider === "codex";
+              const showPermission = provider === "claude_code";
+
+              return (
+                <tr key={index} className="border-b border-neutral-900 text-neutral-300">
+                  {/* Role Name */}
+                  <td className="px-3 py-2 align-middle">
+                    <input
+                      type="text"
+                      value={role}
+                      onChange={(e) => handleRoleChange(index, e.target.value)}
+                      placeholder="role_name"
+                      className={inputClass}
+                    />
+                  </td>
+
+                  {/* Provider */}
+                  <td className="px-3 py-2 align-middle">
+                    <select
+                      value={provider}
+                      onChange={(e) => handleProviderChange(index, e.target.value)}
+                      className={selectClass}
+                    >
+                      {PROVIDER_OPTIONS.map((p) => (
+                        <option key={p} value={p}>
+                          {p}
+                        </option>
+                      ))}
+                    </select>
+                  </td>
+
+                  {/* Model */}
+                  <td className="px-3 py-2 align-middle">
+                    <select
+                      value={config.model}
+                      onChange={(e) => handleModelChange(index, e.target.value)}
+                      className={selectClass}
+                    >
+                      {availableModels.map((m) => (
+                        <option key={m} value={m}>
+                          {m}
+                        </option>
+                      ))}
+                    </select>
+                  </td>
+
+                  {/* Effort (codex only) */}
+                  <td className="px-3 py-2 align-middle">
+                    {showEffort ? (
+                      <select
+                        value={config.reasoning_effort ?? "none"}
+                        onChange={(e) => handleEffortChange(index, e.target.value)}
+                        className={selectClass}
+                      >
+                        {EFFORT_OPTIONS.map((e) => (
+                          <option key={e} value={e}>
+                            {e}
+                          </option>
+                        ))}
+                      </select>
+                    ) : (
+                      <span className="px-1 text-neutral-600">—</span>
+                    )}
+                  </td>
+
+                  {/* Permission (claude_code only) */}
+                  <td className="px-3 py-2 align-middle">
+                    {showPermission ? (
+                      <select
+                        value={config.permission_mode ?? "default"}
+                        onChange={(e) => handlePermissionChange(index, e.target.value)}
+                        className={selectClass}
+                      >
+                        {PERMISSION_OPTIONS.map((p) => (
+                          <option key={p} value={p}>
+                            {p}
+                          </option>
+                        ))}
+                      </select>
+                    ) : (
+                      <span className="px-1 text-neutral-600">—</span>
+                    )}
+                  </td>
+
+                  {/* Delete */}
+                  <td className="px-3 py-2 align-middle">
+                    <button
+                      type="button"
+                      onClick={() => handleDeleteRow(index)}
+                      className="rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-xs text-neutral-400 hover:border-red-800 hover:bg-red-950/40 hover:text-red-300"
+                      aria-label={`Remove ${role || "row"}`}
+                    >
+                      remove
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
+
+            {rows.length === 0 ? (
+              <tr>
+                <td colSpan={6} className="px-3 py-8 text-center text-sm text-neutral-500">
+                  No model configurations. Add a role to get started.
+                </td>
+              </tr>
+            ) : null}
+          </tbody>
+        </table>
+      </div>
+
+      <div>
+        <button
+          type="button"
+          onClick={handleAddRow}
+          className="rounded border border-neutral-700 bg-neutral-900 px-3 py-1.5 text-sm text-neutral-300 hover:border-neutral-500 hover:text-neutral-200"
+        >
+          + add role
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/studio/frontend/components/Shell.tsx
+++ b/apps/studio/frontend/components/Shell.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import type { ReactNode } from "react";
+
+type NavItem = {
+  label: string;
+  href: string;
+  match?: (pathname: string) => boolean;
+};
+
+const navItems: NavItem[] = [
+  { label: "Playbooks", href: "/playbooks" },
+  { label: "Agents", href: "/agents" },
+  { label: "Runs", href: "/runs" },
+  { label: "Shows", href: "/shows" },
+];
+
+function isActive(item: NavItem, pathname: string) {
+  if (item.match) {
+    return item.match(pathname);
+  }
+
+  if (item.href === "/") {
+    return pathname === "/";
+  }
+
+  return pathname === item.href || pathname.startsWith(`${item.href}/`);
+}
+
+export interface ShellProps {
+  children: ReactNode;
+}
+
+export default function Shell({ children }: ShellProps) {
+  const pathname = usePathname() ?? "/";
+
+  return (
+    <div className="min-h-screen bg-surface-base text-content-primary">
+      <header className="sticky top-0 z-40 border-b border-edge bg-surface-nav/95 backdrop-blur">
+        <div className="mx-auto flex w-full max-w-7xl flex-col gap-3 px-4 py-2.5 lg:flex-row lg:items-center lg:justify-between">
+          <Link
+            href="/"
+            className="flex min-w-0 flex-col text-content-primary hover:text-content-inverse"
+          >
+            <span className="text-sm font-semibold uppercase tracking-wider">Lion Studio</span>
+            <span className="truncate text-[11px] text-content-muted">playbook orchestration</span>
+          </Link>
+
+          <nav aria-label="Primary" className="flex gap-1 overflow-x-auto pb-1 text-sm lg:pb-0">
+            {navItems.map((item) => {
+              const active = isActive(item, pathname);
+
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  aria-current={active ? "page" : undefined}
+                  className={[
+                    "whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+                    active
+                      ? "bg-interactive-secondary text-content-inverse"
+                      : "text-content-secondary hover:bg-interactive-secondary/50 hover:text-content-primary",
+                  ].join(" ")}
+                >
+                  {item.label}
+                </Link>
+              );
+            })}
+          </nav>
+        </div>
+      </header>
+
+      <div className="mx-auto w-full max-w-7xl px-4 py-6">{children}</div>
+    </div>
+  );
+}

--- a/apps/studio/frontend/components/StatCard.tsx
+++ b/apps/studio/frontend/components/StatCard.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from "react";
+
+export type StatDeltaTone = "neutral" | "up" | "down";
+
+export interface StatCardProps {
+  label: string;
+  value: ReactNode;
+  delta?: ReactNode;
+  deltaTone?: StatDeltaTone;
+  className?: string;
+}
+
+const deltaClasses: Record<StatDeltaTone, string> = {
+  neutral: "text-neutral-500",
+  up: "text-emerald-300",
+  down: "text-red-300",
+};
+
+export default function StatCard({
+  label,
+  value,
+  delta,
+  deltaTone = "neutral",
+  className,
+}: StatCardProps) {
+  return (
+    <section
+      className={["min-w-0 rounded border border-neutral-800 bg-neutral-950 p-4", className]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      <div className="truncate text-xs uppercase tracking-normal text-neutral-500">{label}</div>
+      <div className="mt-3 truncate text-3xl font-semibold text-neutral-200">{value}</div>
+      {delta !== undefined && delta !== null ? (
+        <div className={`mt-2 truncate text-sm ${deltaClasses[deltaTone]}`}>{delta}</div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/studio/frontend/components/StepEditor.tsx
+++ b/apps/studio/frontend/components/StepEditor.tsx
@@ -1,0 +1,344 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import type { AgentProfileSummary, ModelConfig } from "@/lib/types";
+
+export interface StepData {
+  assignment: string;
+  role: string;
+  prompt: string;
+  capacity?: number;
+  timeout?: number | null;
+}
+
+export interface StepEditorProps {
+  steps: Record<string, StepData>;
+  roles: string[];
+  agentProfiles?: AgentProfileSummary[];
+  modelOverrides?: Record<string, ModelConfig>;
+  onChange: (steps: Record<string, StepData>) => void;
+}
+
+const INPUT_CLS =
+  "w-full rounded border border-neutral-700 bg-neutral-900 px-3 py-1.5 text-sm text-neutral-200 placeholder-neutral-600 focus:border-neutral-500 focus:outline-none";
+
+const LABEL_CLS = "block text-xs uppercase tracking-wide text-neutral-500";
+
+function generateStepName(existing: Record<string, StepData>): string {
+  let n = 1;
+  while (Object.prototype.hasOwnProperty.call(existing, `step_${n}`)) {
+    n += 1;
+  }
+  return `step_${n}`;
+}
+
+interface StepCardProps {
+  stepKey: string;
+  data: StepData;
+  roles: string[];
+  agentProfiles?: AgentProfileSummary[];
+  modelOverrides?: Record<string, ModelConfig>;
+  onChangeName: (oldKey: string, newKey: string) => void;
+  onChangeField: (key: string, field: keyof StepData, value: StepData[keyof StepData]) => void;
+  onDelete: (key: string) => void;
+}
+
+function StepCard({
+  stepKey,
+  data,
+  roles,
+  agentProfiles = [],
+  modelOverrides = {},
+  onChangeName,
+  onChangeField,
+  onDelete,
+}: StepCardProps) {
+  const [expanded, setExpanded] = useState(true);
+  const [localName, setLocalName] = useState(stepKey);
+  const [nameError, setNameError] = useState<string | null>(null);
+
+  const handleNameBlur = useCallback(() => {
+    const trimmed = localName.trim();
+    if (!trimmed) {
+      setLocalName(stepKey);
+      setNameError(null);
+      return;
+    }
+    if (trimmed === stepKey) {
+      setNameError(null);
+      return;
+    }
+    setNameError(null);
+    onChangeName(stepKey, trimmed);
+  }, [localName, stepKey, onChangeName]);
+
+  const handleNameKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        e.currentTarget.blur();
+      } else if (e.key === "Escape") {
+        setLocalName(stepKey);
+        setNameError(null);
+        e.currentTarget.blur();
+      }
+    },
+    [stepKey],
+  );
+
+  return (
+    <div className="rounded border border-neutral-800 bg-neutral-950 p-4">
+      {/* Card header */}
+      <div className="flex items-center justify-between gap-3">
+        <button
+          type="button"
+          aria-label={expanded ? "Collapse step" : "Expand step"}
+          onClick={() => setExpanded((v) => !v)}
+          className="shrink-0 text-neutral-600 hover:text-neutral-300 focus:outline-none"
+        >
+          <span aria-hidden="true" className="font-mono text-sm">
+            {expanded ? "▾" : "▸"}
+          </span>
+        </button>
+
+        <input
+          type="text"
+          value={localName}
+          onChange={(e) => setLocalName(e.target.value)}
+          onBlur={handleNameBlur}
+          onKeyDown={handleNameKeyDown}
+          aria-label="Step name"
+          className="min-w-0 flex-1 rounded border border-transparent bg-transparent px-1 py-0.5 font-mono text-sm font-semibold text-neutral-200 hover:border-neutral-700 focus:border-neutral-500 focus:outline-none"
+        />
+
+        {nameError ? <span className="shrink-0 text-xs text-red-400">{nameError}</span> : null}
+
+        <button
+          type="button"
+          onClick={() => onDelete(stepKey)}
+          aria-label={`Delete step ${stepKey}`}
+          className="shrink-0 rounded px-2 py-0.5 text-xs text-neutral-600 hover:bg-neutral-800 hover:text-red-400 focus:outline-none"
+        >
+          delete
+        </button>
+      </div>
+
+      {/* Collapsible body */}
+      {expanded ? (
+        <div className="mt-4 flex flex-col gap-3">
+          {/* Role */}
+          <div className="flex flex-col gap-1">
+            <label className={LABEL_CLS}>Role</label>
+            {roles.length > 0 ? (
+              <select
+                value={data.role}
+                onChange={(e) => onChangeField(stepKey, "role", e.target.value)}
+                className={INPUT_CLS}
+              >
+                <option value="">— select role —</option>
+                {roles.map((r) => {
+                  const isProfile = agentProfiles.some((p) => p.name === r);
+                  const isOverride = r in modelOverrides;
+                  const suffix =
+                    isProfile && isOverride
+                      ? " (profile + override)"
+                      : isProfile
+                        ? " (profile)"
+                        : isOverride
+                          ? " (override)"
+                          : "";
+                  return (
+                    <option key={r} value={r}>
+                      {r}
+                      {suffix}
+                    </option>
+                  );
+                })}
+              </select>
+            ) : (
+              <input
+                type="text"
+                value={data.role}
+                onChange={(e) => onChangeField(stepKey, "role", e.target.value)}
+                placeholder="e.g. implementer"
+                className={INPUT_CLS}
+              />
+            )}
+
+            {/* Resolved config badge */}
+            {data.role &&
+              (() => {
+                const profile = agentProfiles.find((p) => p.name === data.role);
+                const override = modelOverrides[data.role];
+                if (!profile && !override) return null;
+
+                const provider = override?.provider ?? profile?.provider ?? "—";
+                const model = override?.model ?? profile?.model ?? "—";
+                const source = override ? (profile ? "override" : "worker") : "profile";
+
+                return (
+                  <div className="flex items-center gap-2 rounded border border-neutral-800 bg-neutral-900/50 px-2 py-1 text-xs text-neutral-400">
+                    <span className="text-neutral-500">via {source}:</span>
+                    <span className="font-mono text-neutral-300">
+                      {provider}/{model}
+                    </span>
+                  </div>
+                );
+              })()}
+          </div>
+
+          {/* Assignment */}
+          <div className="flex flex-col gap-1">
+            <label className={LABEL_CLS}>Assignment</label>
+            <input
+              type="text"
+              value={data.assignment}
+              onChange={(e) => onChangeField(stepKey, "assignment", e.target.value)}
+              placeholder="inputs -> outputs"
+              className={INPUT_CLS}
+            />
+          </div>
+
+          {/* Prompt template */}
+          <div className="flex flex-col gap-1">
+            <label className={LABEL_CLS}>Prompt Template</label>
+            <textarea
+              value={data.prompt}
+              onChange={(e) => onChangeField(stepKey, "prompt", e.target.value)}
+              placeholder={
+                "Use {field} syntax to reference inputs.\nExample: Analyze {task} and produce a {plan}."
+              }
+              rows={3}
+              className={`${INPUT_CLS} resize-y font-mono`}
+            />
+          </div>
+
+          {/* Capacity + Timeout row */}
+          <div className="flex gap-3">
+            <div className="flex flex-1 flex-col gap-1">
+              <label className={LABEL_CLS}>Capacity</label>
+              <input
+                type="number"
+                min={1}
+                value={data.capacity ?? 1}
+                onChange={(e) => {
+                  const v = e.target.value === "" ? 1 : Number(e.target.value);
+                  onChangeField(stepKey, "capacity", v);
+                }}
+                className={INPUT_CLS}
+              />
+            </div>
+
+            <div className="flex flex-1 flex-col gap-1">
+              <label className={LABEL_CLS}>Timeout (s)</label>
+              <input
+                type="number"
+                min={0}
+                value={data.timeout ?? ""}
+                placeholder="none"
+                onChange={(e) => {
+                  const v = e.target.value === "" ? null : Number(e.target.value);
+                  onChangeField(stepKey, "timeout", v);
+                }}
+                className={INPUT_CLS}
+              />
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default function StepEditor({
+  steps,
+  roles,
+  agentProfiles,
+  modelOverrides,
+  onChange,
+}: StepEditorProps) {
+  const handleChangeName = useCallback(
+    (oldKey: string, newKey: string) => {
+      if (newKey === oldKey) return;
+      if (Object.prototype.hasOwnProperty.call(steps, newKey)) {
+        // Silently ignore — duplicate name; StepCard resets to oldKey via blur logic
+        return;
+      }
+
+      // Preserve insertion order: rebuild object replacing oldKey with newKey at same position
+      const next: Record<string, StepData> = {};
+      for (const [k, v] of Object.entries(steps)) {
+        if (k === oldKey) {
+          next[newKey] = v;
+        } else {
+          next[k] = v;
+        }
+      }
+      onChange(next);
+    },
+    [steps, onChange],
+  );
+
+  const handleChangeField = useCallback(
+    (key: string, field: keyof StepData, value: StepData[keyof StepData]) => {
+      onChange({ ...steps, [key]: { ...steps[key], [field]: value } });
+    },
+    [steps, onChange],
+  );
+
+  const handleDelete = useCallback(
+    (key: string) => {
+      const next = { ...steps };
+      delete next[key];
+      onChange(next);
+    },
+    [steps, onChange],
+  );
+
+  const handleAddStep = useCallback(() => {
+    const name = generateStepName(steps);
+    onChange({
+      ...steps,
+      [name]: {
+        assignment: "",
+        role: roles.length > 0 ? roles[0] : "",
+        prompt: "",
+        capacity: 1,
+        timeout: null,
+      },
+    });
+  }, [steps, roles, onChange]);
+
+  const stepEntries = Object.entries(steps);
+
+  return (
+    <div className="flex flex-col gap-3">
+      {stepEntries.length === 0 ? (
+        <p className="rounded border border-dashed border-neutral-800 px-4 py-6 text-center text-sm text-neutral-600">
+          No steps defined. Add one below.
+        </p>
+      ) : (
+        stepEntries.map(([key, data]) => (
+          <StepCard
+            key={key}
+            stepKey={key}
+            data={data}
+            roles={roles}
+            agentProfiles={agentProfiles}
+            modelOverrides={modelOverrides}
+            onChangeName={handleChangeName}
+            onChangeField={handleChangeField}
+            onDelete={handleDelete}
+          />
+        ))
+      )}
+
+      <button
+        type="button"
+        onClick={handleAddStep}
+        className="self-start rounded border border-neutral-700 bg-neutral-900 px-4 py-1.5 text-sm text-neutral-300 hover:border-neutral-500 hover:bg-neutral-800 focus:outline-none"
+      >
+        + Add Step
+      </button>
+    </div>
+  );
+}

--- a/apps/studio/frontend/components/StepPanel.tsx
+++ b/apps/studio/frontend/components/StepPanel.tsx
@@ -1,0 +1,81 @@
+import type { WorkerStepNode } from "@/lib/types";
+import Badge from "@/components/Badge";
+
+const ROLE_TONE: Record<string, "ok" | "running" | "failed" | "pending" | "blocked" | "default"> = {
+  researcher: "running",
+  implementer: "ok",
+  reviewer: "blocked",
+  critic: "failed",
+  suggester: "pending",
+  analyst: "running",
+  tester: "ok",
+};
+
+function roleTone(
+  role: string | undefined | null,
+): "ok" | "running" | "failed" | "pending" | "blocked" | "default" {
+  if (!role) return "default";
+  return ROLE_TONE[role.toLowerCase()] ?? "default";
+}
+
+export interface StepPanelProps {
+  node: WorkerStepNode;
+}
+
+export default function StepPanel({ node }: StepPanelProps) {
+  return (
+    <div className="flex flex-col gap-3 border border-neutral-800 bg-neutral-950 p-4">
+      <div className="flex items-start justify-between gap-2">
+        <h3 className="font-semibold text-neutral-100">{node.label || node.id}</h3>
+        {node.role ? (
+          <Badge tone={roleTone(node.role)} className="shrink-0">
+            {node.role}
+          </Badge>
+        ) : null}
+      </div>
+
+      {node.assignment ? (
+        <div>
+          <span className="text-xs uppercase text-neutral-500">assignment</span>
+          <p className="mt-0.5 font-mono text-sm text-neutral-300">{node.assignment}</p>
+        </div>
+      ) : null}
+
+      {node.prompt ? (
+        <div>
+          <span className="text-xs uppercase text-neutral-500">prompt template</span>
+          <pre className="mt-1 max-h-48 overflow-auto rounded border border-neutral-800 bg-neutral-900 p-3 text-xs leading-5 text-neutral-400 whitespace-pre-wrap">
+            {node.prompt}
+          </pre>
+        </div>
+      ) : null}
+
+      <div className="flex flex-wrap gap-4 text-xs text-neutral-500">
+        {node.capacity !== undefined ? (
+          <span>
+            <span className="text-neutral-600">capacity:</span>{" "}
+            <span className="text-neutral-300">{node.capacity}</span>
+          </span>
+        ) : null}
+        {node.timeout !== null && node.timeout !== undefined ? (
+          <span>
+            <span className="text-neutral-600">timeout:</span>{" "}
+            <span className="text-neutral-300">{node.timeout}s</span>
+          </span>
+        ) : null}
+        {node.inputs?.length > 0 ? (
+          <span>
+            <span className="text-neutral-600">inputs:</span>{" "}
+            <span className="text-neutral-300">{node.inputs.join(", ")}</span>
+          </span>
+        ) : null}
+        {node.outputs?.length > 0 ? (
+          <span>
+            <span className="text-neutral-600">outputs:</span>{" "}
+            <span className="text-neutral-300">{node.outputs.join(", ")}</span>
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/studio/frontend/components/Table.tsx
+++ b/apps/studio/frontend/components/Table.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { Key, KeyboardEvent, ReactNode } from "react";
+
+export type SortDirection = "asc" | "desc";
+
+export interface TableColumn<T> {
+  id?: string;
+  key?: keyof T;
+  header: ReactNode;
+  accessor?: (row: T) => ReactNode;
+  sortValue?: (row: T) => string | number | null | undefined;
+  sortable?: boolean;
+  truncate?: boolean;
+  className?: string;
+  headerClassName?: string;
+  cellClassName?: string;
+  align?: "left" | "right";
+}
+
+export interface TableSort {
+  columnId: string;
+  direction: SortDirection;
+}
+
+export interface TableProps<T> {
+  data: T[];
+  columns: TableColumn<T>[];
+  emptyMessage?: string;
+  getRowKey?: (row: T, index: number) => Key;
+  onRowClick?: (row: T) => void;
+  initialSort?: TableSort;
+  rowClassName?: (row: T, index: number) => string;
+}
+
+function columnId<T>(column: TableColumn<T>) {
+  return column.id ?? String(column.key ?? column.header);
+}
+
+function rawValue<T>(row: T, column: TableColumn<T>): unknown {
+  if (!column.key) {
+    return undefined;
+  }
+
+  return row[column.key];
+}
+
+function sortValue<T>(row: T, column: TableColumn<T>) {
+  if (column.sortValue) {
+    return column.sortValue(row);
+  }
+
+  const value = rawValue(row, column);
+  return typeof value === "string" || typeof value === "number" ? value : undefined;
+}
+
+function compareValues(
+  left: string | number | null | undefined,
+  right: string | number | null | undefined,
+) {
+  if (left === right) {
+    return 0;
+  }
+
+  if (left === null || left === undefined) {
+    return 1;
+  }
+
+  if (right === null || right === undefined) {
+    return -1;
+  }
+
+  if (typeof left === "number" && typeof right === "number") {
+    return left - right;
+  }
+
+  return String(left).localeCompare(String(right));
+}
+
+function defaultRowKey<T>(row: T, index: number): Key {
+  const candidate = (row as { id?: Key }).id;
+  return candidate ?? index;
+}
+
+function titleFor(value: ReactNode) {
+  if (typeof value === "string" || typeof value === "number") {
+    return String(value);
+  }
+
+  return undefined;
+}
+
+export default function Table<T>({
+  data,
+  columns,
+  emptyMessage = "No rows recorded.",
+  getRowKey = defaultRowKey,
+  onRowClick,
+  initialSort,
+  rowClassName,
+}: TableProps<T>) {
+  const [sort, setSort] = useState<TableSort | null>(initialSort ?? null);
+
+  const sortedData = useMemo(() => {
+    if (!sort) {
+      return data;
+    }
+
+    const column = columns.find((candidate) => columnId(candidate) === sort.columnId);
+    if (!column) {
+      return data;
+    }
+
+    return [...data].sort((left, right) => {
+      const result = compareValues(sortValue(left, column), sortValue(right, column));
+      return sort.direction === "asc" ? result : -result;
+    });
+  }, [columns, data, sort]);
+
+  const toggleSort = (column: TableColumn<T>) => {
+    const id = columnId(column);
+
+    setSort((current) => {
+      if (current?.columnId !== id) {
+        return { columnId: id, direction: "asc" };
+      }
+
+      return {
+        columnId: id,
+        direction: current.direction === "asc" ? "desc" : "asc",
+      };
+    });
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLTableRowElement>, row: T) => {
+    if (!onRowClick) {
+      return;
+    }
+
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      onRowClick(row);
+    }
+  };
+
+  return (
+    <div className="overflow-x-auto border border-neutral-800">
+      <table className="min-w-full table-fixed border-collapse text-sm">
+        <thead className="border-b border-neutral-800 bg-neutral-900/70 text-xs uppercase text-neutral-500">
+          <tr>
+            {columns.map((column) => {
+              const id = columnId(column);
+              const active = sort?.columnId === id;
+              const sortable = column.sortable !== false;
+
+              return (
+                <th
+                  key={id}
+                  scope="col"
+                  className={[
+                    "px-3 py-2 font-medium tracking-normal",
+                    column.align === "right" ? "text-right" : "text-left",
+                    column.className,
+                    column.headerClassName,
+                  ]
+                    .filter(Boolean)
+                    .join(" ")}
+                >
+                  {sortable ? (
+                    <button
+                      type="button"
+                      onClick={() => toggleSort(column)}
+                      className="inline-flex max-w-full items-center gap-1 text-neutral-500 hover:text-neutral-200"
+                    >
+                      <span className="truncate">{column.header}</span>
+                      <span aria-hidden="true" className="shrink-0 text-[10px]">
+                        {active ? (sort.direction === "asc" ? "^" : "v") : "-"}
+                      </span>
+                    </button>
+                  ) : (
+                    <span className="truncate">{column.header}</span>
+                  )}
+                </th>
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody>
+          {sortedData.map((row, index) => (
+            <tr
+              key={getRowKey(row, index)}
+              onClick={onRowClick ? () => onRowClick(row) : undefined}
+              onKeyDown={(event) => handleKeyDown(event, row)}
+              role={onRowClick ? "button" : undefined}
+              tabIndex={onRowClick ? 0 : undefined}
+              className={[
+                "border-b border-neutral-900 text-neutral-300",
+                onRowClick ? "cursor-pointer hover:bg-neutral-900" : "",
+                rowClassName?.(row, index),
+              ]
+                .filter(Boolean)
+                .join(" ")}
+            >
+              {columns.map((column) => {
+                const id = columnId(column);
+                const value =
+                  column.accessor?.(row) ?? ((rawValue(row, column) ?? "-") as ReactNode);
+                const shouldTruncate = column.truncate !== false;
+
+                return (
+                  <td
+                    key={id}
+                    className={[
+                      "px-3 py-2 align-top",
+                      column.align === "right" ? "text-right" : "text-left",
+                      column.className,
+                      column.cellClassName,
+                    ]
+                      .filter(Boolean)
+                      .join(" ")}
+                  >
+                    <div
+                      title={shouldTruncate ? titleFor(value) : undefined}
+                      className={shouldTruncate ? "truncate" : undefined}
+                    >
+                      {value}
+                    </div>
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+
+          {sortedData.length === 0 ? (
+            <tr>
+              <td
+                colSpan={columns.length}
+                className="px-3 py-10 text-center text-sm text-neutral-500"
+              >
+                {emptyMessage}
+              </td>
+            </tr>
+          ) : null}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/studio/frontend/components/WorkerDag.tsx
+++ b/apps/studio/frontend/components/WorkerDag.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import { useId, useMemo } from "react";
+import type { WorkerLinkEdge, WorkerStepNode } from "@/lib/types";
+
+export type WorkerDagProps = {
+  nodes: WorkerStepNode[];
+  edges: WorkerLinkEdge[];
+};
+
+// Layout constants
+const NODE_W = 220;
+const NODE_H = 72;
+const X_GAP = 80;
+const Y_GAP = 28;
+const PAD = 32;
+
+type PlacedNode = WorkerStepNode & { x: number; y: number };
+type PlacedEdge = { source: PlacedNode; target: PlacedNode; edge: WorkerLinkEdge };
+
+const ROLE_COLORS: Record<string, { bg: string; text: string; border: string }> = {
+  researcher: { bg: "#172554", text: "#93c5fd", border: "#1e40af" },
+  implementer: { bg: "#052e24", text: "#6ee7b7", border: "#065f46" },
+  reviewer: { bg: "#4a044e", text: "#f0abfc", border: "#86198f" },
+  critic: { bg: "#450a0a", text: "#fca5a5", border: "#991b1b" },
+  suggester: { bg: "#451a03", text: "#fcd34d", border: "#92400e" },
+  analyst: { bg: "#0c1a2e", text: "#7dd3fc", border: "#0369a1" },
+  tester: { bg: "#052e16", text: "#86efac", border: "#166534" },
+};
+
+const DEFAULT_ROLE_COLOR = { bg: "#0a0a0a", text: "#a3a3a3", border: "#404040" };
+
+function roleColor(role: string | undefined | null) {
+  if (!role) return DEFAULT_ROLE_COLOR;
+  return ROLE_COLORS[role.toLowerCase()] ?? DEFAULT_ROLE_COLOR;
+}
+
+function trim(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max - 1)}…` : value;
+}
+
+// Compute topological layers for top-to-bottom layout
+function computeLayers(nodes: WorkerStepNode[], edges: WorkerLinkEdge[]): WorkerStepNode[][] {
+  const ids = new Set(nodes.map((n) => n.id));
+  const validEdges = edges.filter((e) => ids.has(e.source) && ids.has(e.target));
+
+  const inDegree = new Map(nodes.map((n) => [n.id, 0]));
+  const outAdj = new Map(nodes.map((n) => [n.id, [] as string[]]));
+
+  validEdges.forEach((e) => {
+    outAdj.get(e.source)?.push(e.target);
+    inDegree.set(e.target, (inDegree.get(e.target) ?? 0) + 1);
+  });
+
+  const layerOf = new Map<string, number>();
+  const queue = nodes.filter((n) => (inDegree.get(n.id) ?? 0) === 0).map((n) => n.id);
+  const visited = new Set<string>();
+
+  while (queue.length) {
+    const id = queue.shift() as string;
+    visited.add(id);
+    const currentLayer = layerOf.get(id) ?? 0;
+    (outAdj.get(id) ?? []).forEach((to) => {
+      layerOf.set(to, Math.max(layerOf.get(to) ?? 0, currentLayer + 1));
+      inDegree.set(to, (inDegree.get(to) ?? 1) - 1);
+      if (inDegree.get(to) === 0) queue.push(to);
+    });
+  }
+
+  // Fallback for nodes in cycles or disconnected
+  const maxLayer = Math.max(0, ...Array.from(layerOf.values()));
+  nodes.forEach((n) => {
+    if (!visited.has(n.id)) layerOf.set(n.id, maxLayer + 1);
+  });
+
+  const layerCount = Math.max(0, ...Array.from(layerOf.values())) + 1;
+  const layers: WorkerStepNode[][] = Array.from({ length: layerCount }, () => []);
+  nodes.forEach((n) => {
+    const l = layerOf.get(n.id) ?? 0;
+    layers[l]?.push(n);
+  });
+
+  return layers.filter((l) => l.length > 0);
+}
+
+function layoutNodes(
+  nodes: WorkerStepNode[],
+  edges: WorkerLinkEdge[],
+): { placed: Map<string, PlacedNode>; width: number; height: number } {
+  if (nodes.length === 0) {
+    return { placed: new Map(), width: 0, height: 0 };
+  }
+
+  const layers = computeLayers(nodes, edges);
+  const cols = layers.length;
+  const maxRows = Math.max(...layers.map((l) => l.length));
+
+  const width = PAD * 2 + cols * NODE_W + Math.max(0, cols - 1) * X_GAP;
+  const height = PAD * 2 + maxRows * NODE_H + Math.max(0, maxRows - 1) * Y_GAP;
+
+  const placed = new Map<string, PlacedNode>();
+
+  layers.forEach((layerNodes, colIndex) => {
+    const colHeight = layerNodes.length * NODE_H + Math.max(0, layerNodes.length - 1) * Y_GAP;
+    const startY = (height - colHeight) / 2;
+
+    layerNodes.forEach((node, rowIndex) => {
+      placed.set(node.id, {
+        ...node,
+        x: PAD + colIndex * (NODE_W + X_GAP),
+        y: startY + rowIndex * (NODE_H + Y_GAP),
+      });
+    });
+  });
+
+  return { placed, width, height };
+}
+
+function edgePath(from: PlacedNode, to: PlacedNode): string {
+  const x1 = from.x + NODE_W;
+  const y1 = from.y + NODE_H / 2;
+  const x2 = to.x;
+  const y2 = to.y + NODE_H / 2;
+  const bend = Math.max(40, Math.abs(x2 - x1) / 2);
+  return `M ${x1} ${y1} C ${x1 + bend} ${y1}, ${x2 - bend} ${y2}, ${x2} ${y2}`;
+}
+
+export default function WorkerDag({ nodes, edges }: WorkerDagProps) {
+  const markerId = useId().replace(/:/g, "");
+  const dashedMarkerId = `${markerId}_d`;
+
+  const { placed, width, height, placedEdges } = useMemo(() => {
+    const layout = layoutNodes(nodes, edges);
+    const pe: PlacedEdge[] = edges
+      .map((edge) => {
+        const src = layout.placed.get(edge.source);
+        const tgt = layout.placed.get(edge.target);
+        if (!src || !tgt) return null;
+        return { source: src, target: tgt, edge };
+      })
+      .filter((e): e is PlacedEdge => e !== null);
+    return { ...layout, placedEdges: pe };
+  }, [nodes, edges]);
+
+  if (nodes.length === 0) {
+    return (
+      <div className="border border-neutral-800 p-6 text-sm text-neutral-500">
+        No steps defined.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto border border-neutral-800 bg-neutral-950">
+      <svg
+        width={width}
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        aria-label="Worker step DAG"
+      >
+        <defs>
+          {/* Solid arrowhead for simple links */}
+          <marker id={markerId} markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <path d="M 0 0 L 8 4 L 0 8 z" fill="#3b82f6" />
+          </marker>
+          {/* Dashed arrowhead for code links */}
+          <marker
+            id={dashedMarkerId}
+            markerWidth="8"
+            markerHeight="8"
+            refX="7"
+            refY="4"
+            orient="auto"
+          >
+            <path d="M 0 0 L 8 4 L 0 8 z" fill="#f97316" />
+          </marker>
+        </defs>
+
+        {/* Edges */}
+        {placedEdges.map(({ source, target, edge }) => {
+          const isCode = edge.mode === "code";
+          const d = edgePath(source, target);
+          const labelX = (source.x + NODE_W + target.x) / 2;
+          const labelY = (source.y + target.y) / 2 + NODE_H / 2 - 6;
+
+          return (
+            <g key={edge.id}>
+              <path
+                d={d}
+                fill="none"
+                stroke={isCode ? "#f97316" : "#3b82f6"}
+                strokeWidth="1.5"
+                strokeDasharray={isCode ? "5,3" : undefined}
+                markerEnd={`url(#${isCode ? dashedMarkerId : markerId})`}
+              />
+              {!isCode && edge.condition ? (
+                <text x={labelX} y={labelY} fill="#6b7280" fontSize="10" textAnchor="middle">
+                  {trim(edge.condition, 24)}
+                </text>
+              ) : null}
+            </g>
+          );
+        })}
+
+        {/* Nodes */}
+        {Array.from(placed.values()).map((node) => {
+          const colors = roleColor(node.role);
+          const assignmentText = node.assignment ? trim(node.assignment, 28) : "";
+
+          return (
+            <g key={node.id} transform={`translate(${node.x} ${node.y})`}>
+              <rect
+                width={NODE_W}
+                height={NODE_H}
+                rx="6"
+                fill="#111827"
+                stroke="#374151"
+                strokeWidth="1"
+              />
+              {/* Header bar */}
+              <rect width={NODE_W} height="24" rx="6" fill="#1f2937" stroke="none" />
+              <rect width={NODE_W} height="8" y="16" fill="#1f2937" />
+
+              {/* Step name */}
+              <text x="10" y="16" fill="#e5e7eb" fontSize="12" fontWeight="600">
+                {trim(node.label || node.id, 22)}
+              </text>
+
+              {/* Role badge (top right) */}
+              {node.role ? (
+                <g>
+                  <rect
+                    x={NODE_W - 10 - Math.min(node.role.length, 12) * 6 - 8}
+                    y="2"
+                    width={Math.min(node.role.length, 12) * 6 + 8}
+                    height="16"
+                    rx="8"
+                    fill={colors.bg}
+                    stroke={colors.border}
+                  />
+                  <text
+                    x={NODE_W - 14 - Math.min(node.role.length, 12) * 3}
+                    y="14"
+                    fill={colors.text}
+                    fontSize="9"
+                    fontWeight="500"
+                    textAnchor="middle"
+                  >
+                    {trim(node.role, 12)}
+                  </text>
+                </g>
+              ) : null}
+
+              {/* Assignment */}
+              <text x="10" y="44" fill="#9ca3af" fontSize="11">
+                {assignmentText}
+              </text>
+
+              {/* Capacity / timeout indicators */}
+              {node.capacity > 1 ? (
+                <text x="10" y="62" fill="#6b7280" fontSize="9">
+                  {`cap:${node.capacity}`}
+                </text>
+              ) : null}
+              {node.timeout !== null ? (
+                <text x={node.capacity > 1 ? 52 : 10} y="62" fill="#6b7280" fontSize="9">
+                  {`t/o:${node.timeout}s`}
+                </text>
+              ) : null}
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}

--- a/apps/studio/frontend/components/WorkerForm.tsx
+++ b/apps/studio/frontend/components/WorkerForm.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { AgentProfileSummary, ModelConfig, WorkerFormData } from "@/lib/types";
+import { listAgents } from "@/lib/api";
+import ModelConfigTable from "./ModelConfigTable";
+import StepEditor from "./StepEditor";
+import type { StepData } from "./StepEditor";
+import LinkEditor from "./LinkEditor";
+import type { LinkData } from "./LinkEditor";
+
+interface WorkerFormProps {
+  initial?: WorkerFormData;
+  mode: "create" | "edit";
+  onSave: (data: WorkerFormData) => Promise<void>;
+  saving?: boolean;
+  errors?: string[];
+}
+
+const SECTION_LABEL = "text-sm font-semibold text-neutral-200";
+const SECTION_DESC = "text-xs text-neutral-500";
+const INPUT_CLS =
+  "w-full rounded border border-neutral-700 bg-neutral-900 px-3 py-1.5 text-sm text-neutral-200 placeholder-neutral-600 focus:border-green-700 focus:outline-none";
+
+function emptyForm(): WorkerFormData {
+  return {
+    name: "",
+    description: "",
+    use: { models: {} },
+    steps: {},
+    links: [],
+  };
+}
+
+export default function WorkerForm({
+  initial,
+  mode,
+  onSave,
+  saving = false,
+  errors = [],
+}: WorkerFormProps) {
+  const [form, setForm] = useState<WorkerFormData>(initial ?? emptyForm());
+  const [agentProfiles, setAgentProfiles] = useState<AgentProfileSummary[]>([]);
+
+  useEffect(() => {
+    listAgents()
+      .then((data) => setAgentProfiles(data.agents))
+      .catch(() => {});
+  }, []);
+
+  const allRoleNames = useMemo(() => {
+    const profileNames = agentProfiles.map((p) => p.name);
+    const overrideNames = Object.keys(form.use.models);
+    return Array.from(new Set([...profileNames, ...overrideNames])).sort();
+  }, [agentProfiles, form.use.models]);
+
+  const stepNames = useMemo(() => Object.keys(form.steps), [form.steps]);
+
+  const handleModelsChange = useCallback((models: Record<string, ModelConfig>) => {
+    setForm((prev) => ({ ...prev, use: { ...prev.use, models } }));
+  }, []);
+
+  const handleStepsChange = useCallback((steps: Record<string, StepData>) => {
+    setForm((prev) => ({ ...prev, steps }));
+  }, []);
+
+  const handleLinksChange = useCallback((links: LinkData[]) => {
+    // Strip internal _mode field before storing
+    const cleaned = links.map(({ _mode, ...rest }) => rest);
+    setForm((prev) => ({ ...prev, links: cleaned }));
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      await onSave(form);
+    },
+    [form, onSave],
+  );
+
+  const isValid = form.name.trim().length > 0 && Object.keys(form.steps).length > 0;
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-6">
+      {/* Section 1: Basics */}
+      <section className="flex flex-col gap-3">
+        <div>
+          <h2 className={SECTION_LABEL}>Basics</h2>
+          <p className={SECTION_DESC}>Worker name and description</p>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="text-xs uppercase text-neutral-500">Name</label>
+          <input
+            type="text"
+            value={form.name}
+            onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
+            placeholder="my_worker"
+            disabled={mode === "edit"}
+            className={`${INPUT_CLS} ${mode === "edit" ? "cursor-not-allowed opacity-60" : ""}`}
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="text-xs uppercase text-neutral-500">Description</label>
+          <input
+            type="text"
+            value={form.description}
+            onChange={(e) => setForm((prev) => ({ ...prev, description: e.target.value }))}
+            placeholder="What does this worker do?"
+            className={INPUT_CLS}
+          />
+        </div>
+      </section>
+
+      {/* Section 2: Model Overrides */}
+      <section className="flex flex-col gap-3">
+        <div>
+          <h2 className={SECTION_LABEL}>Model Overrides</h2>
+          <p className={SECTION_DESC}>
+            Per-role overrides — agent profiles provide defaults, these take priority
+          </p>
+        </div>
+        <ModelConfigTable models={form.use.models} onChange={handleModelsChange} />
+      </section>
+
+      {/* Section 3: Steps */}
+      <section className="flex flex-col gap-3">
+        <div>
+          <h2 className={SECTION_LABEL}>Steps</h2>
+          <p className={SECTION_DESC}>Work steps with assignments and prompt templates</p>
+        </div>
+        <StepEditor
+          steps={form.steps}
+          roles={allRoleNames}
+          agentProfiles={agentProfiles}
+          modelOverrides={form.use.models}
+          onChange={handleStepsChange}
+        />
+      </section>
+
+      {/* Section 4: Links */}
+      <section className="flex flex-col gap-3">
+        <div>
+          <h2 className={SECTION_LABEL}>Links</h2>
+          <p className={SECTION_DESC}>Connections between steps with conditions or code handlers</p>
+        </div>
+        <LinkEditor links={form.links} stepNames={stepNames} onChange={handleLinksChange} />
+      </section>
+
+      {/* Errors */}
+      {errors.length > 0 ? (
+        <div className="rounded border border-red-900 bg-red-950/40 px-4 py-3">
+          <p className="text-xs font-semibold uppercase text-red-400">Validation errors</p>
+          <ul className="mt-1 list-inside list-disc text-sm text-red-300">
+            {errors.map((err, i) => (
+              <li key={i}>{err}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {/* Submit */}
+      <div className="flex items-center gap-3 border-t border-neutral-800 pt-4">
+        <button
+          type="submit"
+          disabled={saving || !isValid}
+          className={`rounded px-6 py-2 text-sm font-medium transition ${
+            saving || !isValid
+              ? "cursor-not-allowed border border-neutral-700 bg-neutral-800 text-neutral-500"
+              : "border border-green-700 bg-green-900/50 text-green-300 hover:bg-green-800/50"
+          }`}
+        >
+          {saving ? "Saving..." : mode === "create" ? "Create Worker" : "Save Changes"}
+        </button>
+        {!isValid ? (
+          <span className="text-xs text-neutral-500">Name and at least one step required</span>
+        ) : null}
+      </div>
+    </form>
+  );
+}

--- a/apps/studio/frontend/components/canvas/ConditionEdge.tsx
+++ b/apps/studio/frontend/components/canvas/ConditionEdge.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { memo } from "react";
+import { getBezierPath, EdgeLabelRenderer } from "reactflow";
+import type { EdgeProps } from "reactflow";
+
+export interface ConditionEdgeData {
+  mode: "simple" | "code";
+  condition?: string;
+  map?: Record<string, string>;
+  handler?: string;
+  sourceCompleted?: boolean;
+}
+
+function ConditionEdgeComponent({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  data,
+  selected,
+}: EdgeProps<ConditionEdgeData>) {
+  const completed = data?.sourceCompleted ?? false;
+  const isCode = data?.mode === "code";
+
+  const [edgePath, labelX, labelY] = getBezierPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  });
+
+  const strokeColor = selected ? "#a855f7" : completed ? "#22c55e" : "#444";
+
+  return (
+    <>
+      <path
+        id={id}
+        d={edgePath}
+        fill="none"
+        stroke={strokeColor}
+        strokeWidth={selected ? 2.5 : completed ? 2 : 1.5}
+        strokeDasharray={isCode ? "6 4" : undefined}
+        style={{ transition: "stroke 0.3s, stroke-width 0.2s" }}
+        markerEnd={`url(#${completed ? "arrow-active" : "arrow"})`}
+      />
+
+      {data?.condition && (
+        <EdgeLabelRenderer>
+          <div
+            className="nodrag nopan pointer-events-auto cursor-pointer"
+            style={{
+              position: "absolute",
+              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+            }}
+          >
+            <span
+              className="rounded px-1.5 py-0.5 text-[10px] font-mono"
+              style={{
+                backgroundColor: selected ? "#2d1b69" : "#1a1a1a",
+                color: selected ? "#c4b5fd" : "#888",
+                border: `1px solid ${selected ? "#7c3aed" : "#333"}`,
+              }}
+            >
+              {data.condition}
+            </span>
+          </div>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  );
+}
+
+export default memo(ConditionEdgeComponent);

--- a/apps/studio/frontend/components/canvas/SidePanel.tsx
+++ b/apps/studio/frontend/components/canvas/SidePanel.tsx
@@ -1,0 +1,410 @@
+"use client";
+
+import { useCallback } from "react";
+import type { AgentProfileSummary, ModelConfig } from "@/lib/types";
+import type { StepNodeData } from "./StepNode";
+import type { ConditionEdgeData } from "./ConditionEdge";
+
+const INPUT_CLS =
+  "w-full rounded-md border border-edge bg-surface-input px-3 py-1.5 text-sm text-content-primary placeholder-content-muted focus:border-interactive-primary focus:outline-none";
+const LABEL_CLS = "block text-xs uppercase tracking-wide text-content-muted mb-1";
+
+// ─── Types ───────────────────────────────────────────────
+
+export type Selection =
+  | { type: "none" }
+  | { type: "node"; id: string; data: StepNodeData }
+  | { type: "edge"; id: string; data: ConditionEdgeData }
+  | { type: "exec-result"; id: string; data: StepNodeData; result: Record<string, unknown> };
+
+interface SidePanelProps {
+  selection: Selection;
+  editable: boolean;
+  roles: string[];
+  agentProfiles?: AgentProfileSummary[];
+  modelOverrides?: Record<string, ModelConfig>;
+  onNodeUpdate?: (id: string, data: Partial<StepNodeData>) => void;
+  onEdgeUpdate?: (id: string, data: Partial<ConditionEdgeData>) => void;
+  onDelete?: (type: "node" | "edge", id: string) => void;
+}
+
+// ─── Component ───────────────────────────────────────────
+
+export default function SidePanel({
+  selection,
+  editable,
+  roles,
+  agentProfiles = [],
+  modelOverrides = {},
+  onNodeUpdate,
+  onEdgeUpdate,
+  onDelete,
+}: SidePanelProps) {
+  if (selection.type === "none") {
+    return (
+      <div className="flex h-full items-center justify-center p-6">
+        <p className="text-center text-sm text-neutral-600">
+          Click a step or link to inspect or edit
+        </p>
+      </div>
+    );
+  }
+
+  if (selection.type === "exec-result") {
+    return <ExecResultPanel id={selection.id} data={selection.data} result={selection.result} />;
+  }
+
+  if (selection.type === "edge") {
+    return (
+      <EdgePanel
+        id={selection.id}
+        data={selection.data}
+        editable={editable}
+        onUpdate={onEdgeUpdate}
+        onDelete={onDelete}
+      />
+    );
+  }
+
+  return (
+    <NodePanel
+      id={selection.id}
+      data={selection.data}
+      editable={editable}
+      roles={roles}
+      agentProfiles={agentProfiles}
+      modelOverrides={modelOverrides}
+      onUpdate={onNodeUpdate}
+      onDelete={onDelete}
+    />
+  );
+}
+
+// ─── Node Panel ──────────────────────────────────────────
+
+function NodePanel({
+  id,
+  data,
+  editable,
+  roles,
+  agentProfiles,
+  modelOverrides,
+  onUpdate,
+  onDelete,
+}: {
+  id: string;
+  data: StepNodeData;
+  editable: boolean;
+  roles: string[];
+  agentProfiles: AgentProfileSummary[];
+  modelOverrides: Record<string, ModelConfig>;
+  onUpdate?: (id: string, data: Partial<StepNodeData>) => void;
+  onDelete?: (type: "node" | "edge", id: string) => void;
+}) {
+  const update = useCallback(
+    (field: string, value: unknown) => {
+      onUpdate?.(id, { [field]: value });
+    },
+    [id, onUpdate],
+  );
+
+  const profile = agentProfiles.find((p) => p.name === data.role);
+  const override = modelOverrides[data.role];
+
+  return (
+    <div className="flex flex-col gap-4 p-4 overflow-y-auto">
+      <div className="flex items-center justify-between">
+        <h3 className="font-mono text-sm font-semibold text-neutral-200">{data.label}</h3>
+        {editable && onDelete && (
+          <button
+            onClick={() => onDelete("node", id)}
+            className="text-xs text-neutral-600 hover:text-red-400"
+          >
+            delete
+          </button>
+        )}
+      </div>
+
+      {/* Role */}
+      <div>
+        <label className={LABEL_CLS}>Role</label>
+        {editable ? (
+          <select
+            value={data.role}
+            onChange={(e) => update("role", e.target.value)}
+            className={INPUT_CLS}
+          >
+            <option value="">— select —</option>
+            {roles.map((r) => {
+              const isP = agentProfiles.some((p) => p.name === r);
+              const isO = r in modelOverrides;
+              const tag =
+                isP && isO
+                  ? " (profile + override)"
+                  : isP
+                    ? " (profile)"
+                    : isO
+                      ? " (override)"
+                      : "";
+              return (
+                <option key={r} value={r}>
+                  {r}
+                  {tag}
+                </option>
+              );
+            })}
+          </select>
+        ) : (
+          <div className="text-sm text-neutral-300">{data.role || "—"}</div>
+        )}
+
+        {data.role && (profile || override) && (
+          <div className="mt-1 flex items-center gap-2 text-xs text-neutral-500">
+            <span>
+              via {override ? "override" : "profile"}:{" "}
+              <span className="font-mono text-neutral-400">
+                {(override?.provider ?? profile?.provider) || "?"}/
+                {(override?.model ?? profile?.model) || "?"}
+              </span>
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Assignment */}
+      <div>
+        <label className={LABEL_CLS}>Assignment</label>
+        {editable ? (
+          <input
+            type="text"
+            value={data.assignment}
+            onChange={(e) => update("assignment", e.target.value)}
+            placeholder="inputs -> outputs"
+            className={INPUT_CLS}
+          />
+        ) : (
+          <div className="font-mono text-sm text-neutral-300">{data.assignment || "—"}</div>
+        )}
+      </div>
+
+      {/* Prompt */}
+      <div>
+        <label className={LABEL_CLS}>Prompt Template</label>
+        {editable ? (
+          <textarea
+            value={data.prompt}
+            onChange={(e) => update("prompt", e.target.value)}
+            placeholder="Use {field} syntax for inputs"
+            rows={5}
+            className={`${INPUT_CLS} resize-y font-mono`}
+          />
+        ) : (
+          <pre className="whitespace-pre-wrap break-words rounded border border-neutral-800 bg-neutral-950 p-2 font-mono text-xs text-neutral-400">
+            {data.prompt || "—"}
+          </pre>
+        )}
+      </div>
+
+      {/* Capacity + Timeout */}
+      <div className="flex gap-3">
+        <div className="flex-1">
+          <label className={LABEL_CLS}>Capacity</label>
+          {editable ? (
+            <input
+              type="number"
+              min={1}
+              value={data.capacity ?? 1}
+              onChange={(e) => update("capacity", Number(e.target.value) || 1)}
+              className={INPUT_CLS}
+            />
+          ) : (
+            <div className="text-sm text-neutral-300">{data.capacity ?? 1}</div>
+          )}
+        </div>
+        <div className="flex-1">
+          <label className={LABEL_CLS}>Timeout (s)</label>
+          {editable ? (
+            <input
+              type="number"
+              min={0}
+              value={data.timeout ?? ""}
+              placeholder="none"
+              onChange={(e) =>
+                update("timeout", e.target.value === "" ? null : Number(e.target.value))
+              }
+              className={INPUT_CLS}
+            />
+          ) : (
+            <div className="text-sm text-neutral-300">{data.timeout ?? "none"}</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Edge Panel ──────────────────────────────────────────
+
+function EdgePanel({
+  id,
+  data,
+  editable,
+  onUpdate,
+  onDelete,
+}: {
+  id: string;
+  data: ConditionEdgeData;
+  editable: boolean;
+  onUpdate?: (id: string, data: Partial<ConditionEdgeData>) => void;
+  onDelete?: (type: "node" | "edge", id: string) => void;
+}) {
+  const update = useCallback(
+    (field: string, value: unknown) => {
+      onUpdate?.(id, { [field]: value });
+    },
+    [id, onUpdate],
+  );
+
+  return (
+    <div className="flex flex-col gap-4 p-4 overflow-y-auto">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-neutral-200">Link</h3>
+        {editable && onDelete && (
+          <button
+            onClick={() => onDelete("edge", id)}
+            className="text-xs text-neutral-600 hover:text-red-400"
+          >
+            delete
+          </button>
+        )}
+      </div>
+
+      {/* Mode toggle */}
+      <div>
+        <label className={LABEL_CLS}>Mode</label>
+        {editable ? (
+          <div className="flex gap-1">
+            {(["simple", "code"] as const).map((m) => (
+              <button
+                key={m}
+                onClick={() => update("mode", m)}
+                className={`rounded px-3 py-1 text-xs font-medium ${
+                  data.mode === m
+                    ? "bg-neutral-700 text-neutral-200"
+                    : "bg-neutral-900 text-neutral-500 hover:text-neutral-300"
+                }`}
+              >
+                {m}
+              </button>
+            ))}
+          </div>
+        ) : (
+          <div className="text-sm text-neutral-300">{data.mode}</div>
+        )}
+      </div>
+
+      {data.mode === "simple" ? (
+        <>
+          {/* Condition */}
+          <div>
+            <label className={LABEL_CLS}>Condition (optional)</label>
+            {editable ? (
+              <input
+                type="text"
+                value={data.condition ?? ""}
+                onChange={(e) => update("condition", e.target.value)}
+                placeholder='e.g. "not approved"'
+                className={INPUT_CLS}
+              />
+            ) : (
+              <div className="font-mono text-sm text-neutral-300">
+                {data.condition || "unconditional"}
+              </div>
+            )}
+          </div>
+
+          {/* Field map */}
+          <div>
+            <label className={LABEL_CLS}>Field Map</label>
+            {data.map && Object.keys(data.map).length > 0 ? (
+              <div className="flex flex-col gap-1">
+                {Object.entries(data.map).map(([k, v]) => (
+                  <div key={k} className="font-mono text-xs text-neutral-400">
+                    {k} &rarr; {v}
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="text-xs text-neutral-600">No field mapping</div>
+            )}
+          </div>
+        </>
+      ) : (
+        /* Code handler */
+        <div>
+          <label className={LABEL_CLS}>Handler</label>
+          {editable ? (
+            <textarea
+              value={data.handler ?? ""}
+              onChange={(e) => update("handler", e.target.value)}
+              placeholder="Python code snippet"
+              rows={6}
+              className={`${INPUT_CLS} resize-y font-mono`}
+            />
+          ) : (
+            <pre className="whitespace-pre-wrap break-words rounded border border-neutral-800 bg-neutral-950 p-2 font-mono text-xs text-neutral-400">
+              {data.handler || "—"}
+            </pre>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Exec Result Panel ───────────────────────────────────
+
+function ExecResultPanel({
+  id,
+  data,
+  result,
+}: {
+  id: string;
+  data: StepNodeData;
+  result: Record<string, unknown>;
+}) {
+  return (
+    <div className="flex flex-col gap-4 p-4 overflow-y-auto">
+      <div className="flex items-center gap-2">
+        <h3 className="font-mono text-sm font-semibold text-green-400">{data.label}</h3>
+        <span className="rounded-full bg-green-900/50 px-2 py-0.5 text-[10px] text-green-300">
+          completed
+        </span>
+      </div>
+
+      {data.role && (
+        <div className="text-xs text-neutral-500">
+          Role: <span className="text-neutral-400">{data.role}</span>
+        </div>
+      )}
+
+      <div>
+        <label className={LABEL_CLS}>Output</label>
+        {Object.keys(result).length > 0 ? (
+          <div className="flex flex-col gap-2">
+            {Object.entries(result).map(([key, val]) => (
+              <div key={key}>
+                <span className="text-xs text-neutral-500">{key}:</span>
+                <p className="mt-0.5 whitespace-pre-wrap break-words text-sm text-neutral-300">
+                  {typeof val === "string" ? val : JSON.stringify(val, null, 2)}
+                </p>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="text-xs text-neutral-600">No output</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/studio/frontend/components/canvas/StepNode.tsx
+++ b/apps/studio/frontend/components/canvas/StepNode.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { memo } from "react";
+import { Handle, Position } from "reactflow";
+import type { NodeProps } from "reactflow";
+
+const ROLE_COLORS: Record<string, string> = {
+  researcher: "#22c55e",
+  implementer: "#a855f7",
+  reviewer: "#14b8a6",
+  critic: "#f59e0b",
+  analyst: "#3b82f6",
+  architect: "#ec4899",
+  tester: "#06b6d4",
+};
+
+export interface StepNodeData {
+  label: string;
+  role: string;
+  assignment: string;
+  prompt: string;
+  capacity: number;
+  timeout: number | null;
+  inputs: string[];
+  outputs: string[];
+  execStatus?: "pending" | "running" | "completed" | "failed";
+}
+
+function StepNodeComponent({ data, selected }: NodeProps<StepNodeData>) {
+  const roleColor = ROLE_COLORS[data.role] || "#666";
+  const status = data.execStatus ?? "pending";
+
+  const borderColor =
+    status === "running"
+      ? "#60a5fa"
+      : status === "completed"
+        ? "#22c55e"
+        : status === "failed"
+          ? "#ef4444"
+          : selected
+            ? "#a855f7"
+            : "#333";
+
+  const bgColor =
+    status === "running"
+      ? "#1a1a3e"
+      : status === "completed"
+        ? "#0a2e1a"
+        : status === "failed"
+          ? "#2e0a0a"
+          : "#0d0d0d";
+
+  return (
+    <div
+      className="relative rounded-lg px-4 py-3"
+      style={{
+        background: bgColor,
+        border: `${selected || status === "running" ? 2 : 1}px solid ${borderColor}`,
+        minWidth: 180,
+        maxWidth: 240,
+        transition: "border-color 0.2s, background 0.2s",
+      }}
+    >
+      <Handle
+        type="target"
+        position={Position.Left}
+        className="!w-2.5 !h-2.5 !bg-neutral-600 !border-neutral-500 hover:!bg-neutral-400"
+      />
+
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-mono text-sm font-semibold text-neutral-200 truncate">
+          {data.label}
+        </span>
+        {status === "completed" && (
+          <span className="text-green-400 text-xs shrink-0">&#10003;</span>
+        )}
+        {status === "failed" && <span className="text-red-400 text-xs shrink-0">&#10007;</span>}
+      </div>
+
+      {data.role && (
+        <span
+          className="inline-block mt-1 px-2 py-0.5 rounded-full text-[10px] font-mono"
+          style={{
+            backgroundColor: `${roleColor}20`,
+            color: roleColor,
+          }}
+        >
+          {data.role}
+        </span>
+      )}
+
+      {data.assignment && (
+        <div className="mt-1.5 font-mono text-[11px] text-neutral-500 truncate">
+          {data.assignment}
+        </div>
+      )}
+
+      {status === "running" && (
+        <div
+          className="absolute inset-0 rounded-lg pointer-events-none"
+          style={{
+            border: "2px solid #60a5fa",
+            animation: "pulse 1.5s ease-in-out infinite",
+            opacity: 0.4,
+          }}
+        />
+      )}
+
+      <Handle
+        type="source"
+        position={Position.Right}
+        className="!w-2.5 !h-2.5 !bg-neutral-600 !border-neutral-500 hover:!bg-neutral-400"
+      />
+    </div>
+  );
+}
+
+export default memo(StepNodeComponent);

--- a/apps/studio/frontend/components/canvas/WorkerCanvas.tsx
+++ b/apps/studio/frontend/components/canvas/WorkerCanvas.tsx
@@ -1,0 +1,394 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import ReactFlow, {
+  Background,
+  Controls,
+  MiniMap,
+  addEdge,
+  useNodesState,
+  useEdgesState,
+  MarkerType,
+} from "reactflow";
+import type {
+  Connection,
+  Edge,
+  Node,
+  OnSelectionChangeParams,
+  NodeMouseHandler,
+  EdgeMouseHandler,
+} from "reactflow";
+import "reactflow/dist/style.css";
+
+import StepNodeComponent from "./StepNode";
+import type { StepNodeData } from "./StepNode";
+import ConditionEdgeComponent from "./ConditionEdge";
+import type { ConditionEdgeData } from "./ConditionEdge";
+import SidePanel from "./SidePanel";
+import type { Selection } from "./SidePanel";
+import { getLayoutedElements } from "./useLayout";
+
+import type {
+  AgentProfileSummary,
+  ModelConfig,
+  WorkerGraph,
+  WorkerStepNode,
+  WorkerLinkEdge,
+} from "@/lib/types";
+
+// ─── Types ───────────────────────────────────────────────
+
+interface WorkerCanvasProps {
+  graph: WorkerGraph;
+  editable?: boolean;
+  roles?: string[];
+  agentProfiles?: AgentProfileSummary[];
+  modelOverrides?: Record<string, ModelConfig>;
+  execSteps?: Array<{
+    step: string;
+    status: string;
+    result?: Record<string, unknown>;
+    timestamp?: number;
+  }>;
+  currentStep?: string | null;
+  onChange?: (nodes: WorkerStepNode[], edges: WorkerLinkEdge[]) => void;
+}
+
+// ─── Conversion helpers ─────────────────────────────────
+
+const nodeTypes = { step: StepNodeComponent };
+const edgeTypes = { condition: ConditionEdgeComponent };
+
+function toFlowNodes(nodes: WorkerStepNode[]): Node<StepNodeData>[] {
+  return nodes.map((n) => ({
+    id: n.id,
+    type: "step",
+    position: { x: 0, y: 0 },
+    data: {
+      label: n.label,
+      role: n.role,
+      assignment: n.assignment,
+      prompt: n.prompt,
+      capacity: n.capacity,
+      timeout: n.timeout,
+      inputs: n.inputs,
+      outputs: n.outputs,
+    },
+  }));
+}
+
+function toFlowEdges(edges: WorkerLinkEdge[]): Edge<ConditionEdgeData>[] {
+  return edges.map((e) => ({
+    id: e.id,
+    source: e.source,
+    target: e.target,
+    type: "condition",
+    data: {
+      mode: e.mode,
+      condition: e.condition,
+      map: e.map,
+      handler: e.handler,
+    },
+  }));
+}
+
+function fromFlowNodes(nodes: Node<StepNodeData>[]): WorkerStepNode[] {
+  return nodes.map((n) => ({
+    id: n.id,
+    label: n.data.label,
+    role: n.data.role,
+    assignment: n.data.assignment,
+    prompt: n.data.prompt,
+    capacity: n.data.capacity,
+    timeout: n.data.timeout,
+    inputs: n.data.inputs,
+    outputs: n.data.outputs,
+  }));
+}
+
+function fromFlowEdges(edges: Edge<ConditionEdgeData>[]): WorkerLinkEdge[] {
+  return edges.map((e) => ({
+    id: e.id,
+    source: e.source,
+    target: e.target,
+    mode: e.data?.mode ?? "simple",
+    condition: e.data?.condition,
+    map: e.data?.map,
+    handler: e.data?.handler,
+  }));
+}
+
+// ─── Canvas ──────────────────────────────────────────────
+
+export default function WorkerCanvas({
+  graph,
+  editable = false,
+  roles = [],
+  agentProfiles = [],
+  modelOverrides = {},
+  execSteps = [],
+  currentStep = null,
+  onChange,
+}: WorkerCanvasProps) {
+  const initialised = useRef(false);
+
+  const initialFlowNodes = useMemo(() => toFlowNodes(graph.nodes), [graph.nodes]);
+  const initialFlowEdges = useMemo(() => toFlowEdges(graph.edges), [graph.edges]);
+
+  const [nodes, setNodes, onNodesChange] = useNodesState([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState([]);
+  const [selection, setSelection] = useState<Selection>({ type: "none" });
+
+  // Layout on mount or when graph changes
+  useEffect(() => {
+    const { nodes: ln, edges: le } = getLayoutedElements(initialFlowNodes, initialFlowEdges, "LR");
+    setNodes(ln);
+    setEdges(le);
+    initialised.current = true;
+  }, [initialFlowNodes, initialFlowEdges, setNodes, setEdges]);
+
+  // Apply execution status to nodes
+  useEffect(() => {
+    if (execSteps.length === 0 && !currentStep) return;
+
+    const completedMap = new Map(
+      execSteps.filter((s) => s.status === "completed").map((s) => [s.step, s]),
+    );
+
+    setNodes((nds) =>
+      nds.map((n) => {
+        let status: StepNodeData["execStatus"] = "pending";
+        if (n.id === currentStep) status = "running";
+        else if (completedMap.has(n.id)) status = "completed";
+
+        return {
+          ...n,
+          data: { ...n.data, execStatus: status },
+        };
+      }),
+    );
+
+    setEdges((eds) =>
+      eds.map((e) => ({
+        ...e,
+        data: { ...e.data, sourceCompleted: completedMap.has(e.source) },
+      })),
+    );
+  }, [execSteps, currentStep, setNodes, setEdges]);
+
+  // Emit changes to parent
+  useEffect(() => {
+    if (!initialised.current || !onChange) return;
+    onChange(fromFlowNodes(nodes), fromFlowEdges(edges));
+  }, [nodes, edges, onChange]);
+
+  // Node click
+  const onNodeClick: NodeMouseHandler = useCallback(
+    (_event, node) => {
+      const typedNode = node as Node<StepNodeData>;
+      const execResult = execSteps.find((s) => s.step === typedNode.id && s.status === "completed");
+
+      if (execResult?.result) {
+        setSelection({
+          type: "exec-result",
+          id: typedNode.id,
+          data: typedNode.data,
+          result: execResult.result,
+        });
+      } else {
+        setSelection({ type: "node", id: typedNode.id, data: typedNode.data });
+      }
+    },
+    [execSteps],
+  );
+
+  // Edge click
+  const onEdgeClick: EdgeMouseHandler = useCallback((_event, edge) => {
+    const typedEdge = edge as Edge<ConditionEdgeData>;
+    if (typedEdge.data) {
+      setSelection({ type: "edge", id: typedEdge.id, data: typedEdge.data });
+    }
+  }, []);
+
+  // Pane click — deselect
+  const onPaneClick = useCallback(() => {
+    setSelection({ type: "none" });
+  }, []);
+
+  // Connect new edge
+  const onConnect = useCallback(
+    (connection: Connection) => {
+      if (!editable) return;
+      const newEdge: Edge<ConditionEdgeData> = {
+        ...connection,
+        id: `e-${connection.source}-${connection.target}`,
+        type: "condition",
+        data: { mode: "simple" },
+      } as Edge<ConditionEdgeData>;
+      setEdges((eds) => addEdge(newEdge, eds));
+    },
+    [editable, setEdges],
+  );
+
+  // Node update from side panel
+  const onNodeUpdate = useCallback(
+    (id: string, data: Partial<StepNodeData>) => {
+      setNodes((nds) => nds.map((n) => (n.id === id ? { ...n, data: { ...n.data, ...data } } : n)));
+      setSelection((prev) =>
+        prev.type === "node" && prev.id === id
+          ? { ...prev, data: { ...prev.data, ...data } }
+          : prev,
+      );
+    },
+    [setNodes],
+  );
+
+  // Edge update from side panel
+  const onEdgeUpdate = useCallback(
+    (id: string, data: Partial<ConditionEdgeData>) => {
+      setEdges((eds) => eds.map((e) => (e.id === id ? { ...e, data: { ...e.data, ...data } } : e)));
+      setSelection((prev) =>
+        prev.type === "edge" && prev.id === id
+          ? { ...prev, data: { ...prev.data, ...data } as ConditionEdgeData }
+          : prev,
+      );
+    },
+    [setEdges],
+  );
+
+  // Delete node or edge
+  const onDeleteElement = useCallback(
+    (type: "node" | "edge", id: string) => {
+      if (type === "node") {
+        setNodes((nds) => nds.filter((n) => n.id !== id));
+        setEdges((eds) => eds.filter((e) => e.source !== id && e.target !== id));
+      } else {
+        setEdges((eds) => eds.filter((e) => e.id !== id));
+      }
+      setSelection({ type: "none" });
+    },
+    [setNodes, setEdges],
+  );
+
+  // Add new step
+  const onAddStep = useCallback(() => {
+    const existing = nodes.map((n) => n.id);
+    let num = existing.length + 1;
+    while (existing.includes(`step_${num}`)) num++;
+    const name = `step_${num}`;
+
+    const newNode: Node<StepNodeData> = {
+      id: name,
+      type: "step",
+      position: { x: nodes.length * 290 + 40, y: 100 },
+      data: {
+        label: name,
+        role: "",
+        assignment: "",
+        prompt: "",
+        capacity: 1,
+        timeout: null,
+        inputs: [],
+        outputs: [],
+      },
+    };
+    setNodes((nds) => [...nds, newNode]);
+    setSelection({ type: "node", id: name, data: newNode.data });
+  }, [nodes, setNodes]);
+
+  // Auto layout
+  const handleAutoLayout = useCallback(() => {
+    const { nodes: ln, edges: le } = getLayoutedElements(nodes, edges, "LR");
+    setNodes(ln);
+    setEdges(le);
+  }, [nodes, edges, setNodes, setEdges]);
+
+  return (
+    <div className="flex h-full">
+      {/* Canvas */}
+      <div className="relative flex-1">
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          onNodesChange={editable ? onNodesChange : undefined}
+          onEdgesChange={editable ? onEdgesChange : undefined}
+          onConnect={onConnect}
+          onNodeClick={onNodeClick}
+          onEdgeClick={onEdgeClick}
+          onPaneClick={onPaneClick}
+          nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
+          nodesDraggable={true}
+          nodesConnectable={editable}
+          elementsSelectable={true}
+          fitView
+          fitViewOptions={{ padding: 0.3 }}
+          proOptions={{ hideAttribution: true }}
+          className="bg-neutral-950"
+        >
+          <Background color="#222" gap={20} size={1} />
+          <Controls
+            showInteractive={false}
+            className="!bg-neutral-900 !border-neutral-700 !shadow-none [&>button]:!bg-neutral-800 [&>button]:!border-neutral-700 [&>button]:!text-neutral-400 [&>button:hover]:!bg-neutral-700"
+          />
+          <MiniMap
+            nodeColor={() => "#333"}
+            maskColor="rgba(0, 0, 0, 0.7)"
+            className="!bg-neutral-900 !border-neutral-700"
+          />
+
+          {/* Custom SVG markers */}
+          <svg>
+            <defs>
+              <marker id="arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+                <polygon points="0 0, 8 3, 0 6" fill="#444" />
+              </marker>
+              <marker
+                id="arrow-active"
+                markerWidth="8"
+                markerHeight="6"
+                refX="8"
+                refY="3"
+                orient="auto"
+              >
+                <polygon points="0 0, 8 3, 0 6" fill="#22c55e" />
+              </marker>
+            </defs>
+          </svg>
+        </ReactFlow>
+
+        {/* Toolbar */}
+        {editable && (
+          <div className="absolute bottom-4 left-4 flex items-center gap-2 z-10">
+            <button
+              onClick={onAddStep}
+              className="rounded-md bg-interactive-secondary px-3 py-1.5 text-xs font-medium text-content-primary hover:bg-interactive-secondary-hover"
+            >
+              + Add Step
+            </button>
+            <button
+              onClick={handleAutoLayout}
+              className="rounded-md bg-interactive-secondary px-3 py-1.5 text-xs font-medium text-content-primary hover:bg-interactive-secondary-hover"
+            >
+              Auto Layout
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Side Panel */}
+      <div className="w-80 shrink-0 border-l border-edge bg-surface-overlay overflow-y-auto">
+        <SidePanel
+          selection={selection}
+          editable={editable}
+          roles={roles}
+          agentProfiles={agentProfiles}
+          modelOverrides={modelOverrides}
+          onNodeUpdate={onNodeUpdate}
+          onEdgeUpdate={onEdgeUpdate}
+          onDelete={onDeleteElement}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/studio/frontend/components/canvas/useLayout.ts
+++ b/apps/studio/frontend/components/canvas/useLayout.ts
@@ -1,0 +1,52 @@
+import { useCallback } from "react";
+import dagre from "dagre";
+import type { Node, Edge } from "reactflow";
+
+const NODE_WIDTH = 210;
+const NODE_HEIGHT = 80;
+
+export function getLayoutedElements(
+  nodes: Node[],
+  edges: Edge[],
+  direction: "LR" | "TB" = "LR",
+): { nodes: Node[]; edges: Edge[] } {
+  const g = new dagre.graphlib.Graph();
+  g.setDefaultEdgeLabel(() => ({}));
+  g.setGraph({
+    rankdir: direction,
+    nodesep: 60,
+    ranksep: 120,
+    marginx: 40,
+    marginy: 40,
+  });
+
+  for (const node of nodes) {
+    g.setNode(node.id, { width: NODE_WIDTH, height: NODE_HEIGHT });
+  }
+  for (const edge of edges) {
+    g.setEdge(edge.source, edge.target);
+  }
+
+  dagre.layout(g);
+
+  const layoutedNodes = nodes.map((node) => {
+    const pos = g.node(node.id);
+    return {
+      ...node,
+      position: {
+        x: pos.x - NODE_WIDTH / 2,
+        y: pos.y - NODE_HEIGHT / 2,
+      },
+    };
+  });
+
+  return { nodes: layoutedNodes, edges };
+}
+
+export function useAutoLayout() {
+  return useCallback(
+    (nodes: Node[], edges: Edge[], direction: "LR" | "TB" = "LR") =>
+      getLayoutedElements(nodes, edges, direction),
+    [],
+  );
+}

--- a/apps/studio/frontend/eslint.config.mjs
+++ b/apps/studio/frontend/eslint.config.mjs
@@ -1,0 +1,15 @@
+import nextConfig from "eslint-config-next";
+import prettierConfig from "eslint-config-prettier";
+
+const config = [
+  ...nextConfig,
+  {
+    ...prettierConfig,
+    rules: {
+      ...prettierConfig.rules,
+      "@next/next/no-img-element": "off",
+    },
+  },
+];
+
+export default config;

--- a/apps/studio/frontend/lib/api.ts
+++ b/apps/studio/frontend/lib/api.ts
@@ -1,0 +1,243 @@
+import type {
+  AgentProfile,
+  AgentProfileSummary,
+  RunDetail,
+  RunSummary,
+  ShowDetail,
+  ShowEvent,
+  ShowSummary,
+  WorkerFormData,
+  WorkerGraph,
+  WorkerRaw,
+  WorkerStepNode,
+  WorkerLinkEdge,
+  WorkerSummary,
+} from "./types";
+
+export const API_BASE =
+  process.env.NEXT_PUBLIC_STUDIO_API_BASE ?? "http://localhost:8765";
+
+async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`${API_BASE}${path}`, init);
+  if (!response.ok) {
+    throw new Error(`Request failed: ${response.status}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+// ─── Runs ─────────────────────────────────────────────────────────────────────
+
+export async function listRuns(
+  params?: Record<string, string>,
+): Promise<{ runs: RunSummary[] }> {
+  const query =
+    params && Object.keys(params).length > 0
+      ? `?${new URLSearchParams(params).toString()}`
+      : "";
+  return fetchJson<{ runs: RunSummary[] }>(`/api/runs${query}`);
+}
+
+export async function getRun(runId: string): Promise<RunDetail> {
+  return fetchJson<RunDetail>(`/api/runs/${encodeURIComponent(runId)}`);
+}
+
+export async function rerunRun(runId: string): Promise<{ run_id: string }> {
+  return fetchJson<{ run_id: string }>(
+    `/api/runs/${encodeURIComponent(runId)}/rerun`,
+    { method: "POST" },
+  );
+}
+
+export function runEventsUrl(runId: string): string {
+  return `${API_BASE}/api/runs/${encodeURIComponent(runId)}/events`;
+}
+
+// ─── Workers (playbooks) ──────────────────────────────────────────────────────
+
+interface PlaybookListEntry {
+  name: string;
+  path?: string;
+  description?: string;
+}
+
+interface PlaybookDetail {
+  name: string;
+  path?: string;
+  description?: string;
+  data?: Record<string, unknown>;
+  raw?: string;
+}
+
+function parseGraphFromPlaybook(pb: PlaybookDetail): WorkerGraph {
+  const data = pb.data ?? {};
+  const stepsRaw = (data.steps as Record<string, unknown>) ?? {};
+  const linksRaw = (data.links as Array<Record<string, unknown>>) ?? [];
+
+  const nodes: WorkerStepNode[] = Object.entries(stepsRaw).map(([id, raw]) => {
+    const s = (raw as Record<string, unknown>) ?? {};
+    return {
+      id,
+      label: id,
+      role: String(s.role ?? ""),
+      assignment: String(s.assignment ?? ""),
+      prompt: String(s.prompt ?? ""),
+      capacity: Number(s.capacity ?? 1),
+      timeout: s.timeout != null ? Number(s.timeout) : null,
+      inputs: (s.inputs as string[]) ?? [],
+      outputs: (s.outputs as string[]) ?? [],
+    };
+  });
+
+  const edges: WorkerLinkEdge[] = linksRaw.map((l, i) => {
+    const rawMode = String(l.mode ?? "simple");
+    const mode: "simple" | "code" = rawMode === "code" ? "code" : "simple";
+    return {
+      id: `e-${i}`,
+      source: String(l.from ?? ""),
+      target: String(l.to ?? ""),
+      mode,
+      condition: l.condition != null ? String(l.condition) : undefined,
+      map: (l.map as Record<string, string>) ?? undefined,
+      handler: l.handler != null ? String(l.handler) : undefined,
+    };
+  });
+
+  return {
+    name: pb.name,
+    description: String(data.description ?? pb.description ?? ""),
+    nodes,
+    edges,
+  };
+}
+
+export async function listWorkers(): Promise<{ workers: WorkerSummary[] }> {
+  const data = await fetchJson<{ playbooks: PlaybookListEntry[] }>(
+    "/api/playbooks",
+  );
+  return {
+    workers: (data.playbooks ?? []).map((p) => ({
+      name: p.name,
+      file: p.path,
+      description: p.description,
+      steps: 0,
+      links: 0,
+    })),
+  };
+}
+
+export async function getWorkerGraph(name: string): Promise<WorkerGraph> {
+  const data = await fetchJson<PlaybookDetail>(
+    `/api/playbooks/${encodeURIComponent(name)}`,
+  );
+  return parseGraphFromPlaybook(data);
+}
+
+export async function getWorkerRaw(name: string): Promise<WorkerRaw> {
+  return fetchJson<WorkerRaw>(`/api/playbooks/${encodeURIComponent(name)}`);
+}
+
+export async function createWorker(
+  name: string,
+  data: WorkerFormData,
+): Promise<unknown> {
+  return fetchJson<unknown>(`/api/playbooks/${encodeURIComponent(name)}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export async function updateWorker(
+  name: string,
+  data: WorkerFormData,
+): Promise<unknown> {
+  return fetchJson<unknown>(`/api/playbooks/${encodeURIComponent(name)}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export async function validateWorker(
+  name: string,
+  data: WorkerFormData,
+): Promise<{ ok: boolean; errors?: string[] }> {
+  return fetchJson<{ ok: boolean; errors?: string[] }>(
+    `/api/playbooks/${encodeURIComponent(name)}/validate`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    },
+  );
+}
+
+export async function startRun(
+  workerName: string,
+  task: string,
+  cwd: string,
+): Promise<{ run_id: string }> {
+  return fetchJson<{ run_id: string }>(
+    `/api/playbooks/${encodeURIComponent(workerName)}/run`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ task, cwd }),
+    },
+  );
+}
+
+// ─── Agents ───────────────────────────────────────────────────────────────────
+
+export async function listAgents(): Promise<{ agents: AgentProfileSummary[] }> {
+  return fetchJson<{ agents: AgentProfileSummary[] }>("/api/agents");
+}
+
+export async function getAgent(name: string): Promise<AgentProfile> {
+  return fetchJson<AgentProfile>(`/api/agents/${encodeURIComponent(name)}`);
+}
+
+export async function createAgent(
+  name: string,
+  data: AgentProfile,
+): Promise<unknown> {
+  return fetchJson<unknown>(`/api/agents/${encodeURIComponent(name)}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export async function updateAgent(
+  name: string,
+  data: AgentProfile,
+): Promise<unknown> {
+  return fetchJson<unknown>(`/api/agents/${encodeURIComponent(name)}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+// ─── Shows ────────────────────────────────────────────────────────────────────
+
+export async function listShows(): Promise<ShowSummary[]> {
+  return fetchJson<ShowSummary[]>("/api/shows");
+}
+
+export async function getShow(topic: string): Promise<ShowDetail> {
+  return fetchJson<ShowDetail>(`/api/shows/${encodeURIComponent(topic)}`);
+}
+
+export function streamShow(
+  topic: string,
+  onEvent: (event: ShowEvent) => void,
+): () => void {
+  const source = new EventSource(
+    `${API_BASE}/api/shows/${encodeURIComponent(topic)}/stream`,
+  );
+  source.onmessage = (message) => {
+    onEvent(JSON.parse(message.data) as ShowEvent);
+  };
+  return () => source.close();
+}

--- a/apps/studio/frontend/lib/extractors.ts
+++ b/apps/studio/frontend/lib/extractors.ts
@@ -98,15 +98,41 @@ export function extractAttending(
 
   if (byPath.size === 0) return [];
 
+  // Deduplicate by basename — when the same filename appears as a bare name
+  // and also as a full absolute path, keep only the most specific entry.
+  // Specificity order: full-path+lineStart > full-path > bare-name+lineStart > bare-name
+  const byBasename = new Map<string, { path: string; lineStart: number | null; chunkIndex: number }>();
+  for (const [path, { lineStart, chunkIndex }] of byPath) {
+    const basename = path.split("/").pop() ?? path;
+    const existing = byBasename.get(basename);
+    if (!existing) {
+      byBasename.set(basename, { path, lineStart, chunkIndex });
+    } else {
+      const isFullPath = path.includes("/");
+      const existingIsFullPath = existing.path.includes("/");
+      // Full paths always beat bare names regardless of recency
+      if (isFullPath && !existingIsFullPath) {
+        byBasename.set(basename, { path, lineStart, chunkIndex });
+      } else if (!isFullPath && existingIsFullPath) {
+        // Bare name cannot replace a full path — skip
+      } else {
+        // Same specificity level: prefer newer chunk > lineStart present > longer path
+        const betterChunk = chunkIndex > existing.chunkIndex;
+        const sameChunk = chunkIndex === existing.chunkIndex;
+        const betterLineStart = sameChunk && lineStart !== null && existing.lineStart === null;
+        const betterPath = sameChunk && lineStart === existing.lineStart && path.length > existing.path.length;
+        if (betterChunk || betterLineStart || betterPath) {
+          byBasename.set(basename, { path, lineStart, chunkIndex });
+        }
+      }
+    }
+  }
+
   // Assign weights: highest chunkIndex -> weight 1.0, linearly down to close to 0
-  const entries = Array.from(byPath.entries()).map(([path, { lineStart, chunkIndex }]) => ({
-    path,
-    lineStart,
-    chunkIndex,
-  }));
+  const entries = Array.from(byBasename.values());
 
   // Sort descending by chunkIndex (most recent first)
-  entries.sort((a, b) => b.chunkIndex - a.chunkIndex || b.lineStart! - a.lineStart!);
+  entries.sort((a, b) => b.chunkIndex - a.chunkIndex || (b.lineStart ?? -1) - (a.lineStart ?? -1));
 
   const maxIdx = entries[0].chunkIndex;
   const minIdx = entries[entries.length - 1].chunkIndex;

--- a/apps/studio/frontend/lib/extractors.ts
+++ b/apps/studio/frontend/lib/extractors.ts
@@ -1,0 +1,221 @@
+// ─── Stream chunk shape (matches DB schema from backend) ─────────────────────
+
+export interface StreamChunk {
+  id: number;
+  flow_id: string;
+  branch_id: string;
+  api_call_id: string;
+  ts: number;
+  chunk_type: string;
+  content: string;
+  tool_name: string | null;
+  tool_id: string | null;
+  tool_input: string | null;
+  tool_output: string | null;
+  is_delta: number;
+  is_error: number;
+  metadata: string;
+}
+
+// ─── Attending: file/artifact references the agent attended to ───────────────
+
+export interface AttendingItem {
+  path: string;
+  lineStart: number | null;
+  weight: number;
+}
+
+interface AttendingOptions {
+  limit?: number;
+}
+
+/** Parse a raw path string (possibly with :lineNumber suffix) into path + lineStart. */
+function parsePathRef(raw: string): { path: string; lineStart: number | null } | null {
+  if (raw.startsWith("http") || raw.startsWith("#")) return null;
+  const colonIdx = raw.lastIndexOf(":");
+  if (colonIdx > 0) {
+    const maybeNum = raw.slice(colonIdx + 1);
+    const n = parseInt(maybeNum, 10);
+    if (!isNaN(n) && String(n) === maybeNum) {
+      return { path: raw.slice(0, colonIdx), lineStart: n };
+    }
+  }
+  return { path: raw, lineStart: null };
+}
+
+/**
+ * Parse markdown link targets of the form [label](path) or [label](path:line)
+ * AND inline code references of the form `filename.ext:line` from all text
+ * chunks, dedupe by path, and rank by recency (most-recent chunk gets weight
+ * 1.0, earlier chunks get linearly decreasing weights).
+ */
+export function extractAttending(
+  chunks: StreamChunk[],
+  options: AttendingOptions = {},
+): AttendingItem[] {
+  const { limit = 5 } = options;
+
+  // Matches markdown links: [anything](/some/path:line)
+  const LINK_RE = /\[([^\]]*)\]\(([^)]+)\)/g;
+  // Matches inline code file refs: `some/file.ext:123` or `file.ext:123`
+  const CODE_REF_RE = /`([^`\s]+\.[a-zA-Z][a-zA-Z0-9]*(?::[0-9]+)?)`/g;
+
+  // Collect all references in order of appearance (chunk order = recency order)
+  // Later chunks = more recent = higher weight. We process oldest first, then
+  // overwrite on dedup so the most-recent occurrence wins.
+  const byPath = new Map<string, { lineStart: number | null; chunkIndex: number }>();
+
+  function recordRef(raw: string, chunkIndex: number): void {
+    const parsed = parsePathRef(raw);
+    if (!parsed) return;
+    const existing = byPath.get(parsed.path);
+    // Overwrite only if newer chunk, OR same chunk with a lineStart (prefer specific over vague)
+    if (
+      !existing ||
+      chunkIndex > existing.chunkIndex ||
+      (chunkIndex === existing.chunkIndex && parsed.lineStart !== null && existing.lineStart === null)
+    ) {
+      byPath.set(parsed.path, { lineStart: parsed.lineStart, chunkIndex });
+    }
+  }
+
+  chunks.forEach((chunk, chunkIndex) => {
+    if (chunk.chunk_type !== "text" || !chunk.content) return;
+
+    // Parse markdown links
+    LINK_RE.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = LINK_RE.exec(chunk.content)) !== null) {
+      recordRef(match[2], chunkIndex);
+    }
+
+    // Parse inline code file references (e.g. `persist.py:318`)
+    CODE_REF_RE.lastIndex = 0;
+    while ((match = CODE_REF_RE.exec(chunk.content)) !== null) {
+      recordRef(match[1], chunkIndex);
+    }
+  });
+
+  if (byPath.size === 0) return [];
+
+  // Assign weights: highest chunkIndex -> weight 1.0, linearly down to close to 0
+  const entries = Array.from(byPath.entries()).map(([path, { lineStart, chunkIndex }]) => ({
+    path,
+    lineStart,
+    chunkIndex,
+  }));
+
+  // Sort descending by chunkIndex (most recent first)
+  entries.sort((a, b) => b.chunkIndex - a.chunkIndex || b.lineStart! - a.lineStart!);
+
+  const maxIdx = entries[0].chunkIndex;
+  const minIdx = entries[entries.length - 1].chunkIndex;
+  const range = maxIdx - minIdx || 1;
+
+  const weighted = entries.map((e) => ({
+    path: e.path,
+    lineStart: e.lineStart,
+    weight: parseFloat(((e.chunkIndex - minIdx) / range).toFixed(6)) || 1,
+  }));
+
+  // Ensure the top item has weight exactly 1
+  if (weighted.length > 0) weighted[0].weight = 1;
+
+  return weighted.slice(0, limit);
+}
+
+// ─── Thinking: decision summary lines the agent committed to ─────────────────
+
+export interface ThinkingItem {
+  text: string;
+  ts: number;
+  status: "complete";
+}
+
+/**
+ * Extract the first line of each non-delta text chunk as a decision summary,
+ * filtering to chunks whose opening line begins with an imperative past-tense
+ * marker ("Implemented", "Phase N", etc.), then return in chronological order.
+ */
+export function extractThinking(chunks: StreamChunk[]): ThinkingItem[] {
+  const DECISION_RE = /^(Implemented|Phase\s+\d+|Created\s+Phase\s+\d+.*?implemented|Ran |Added |Updated |Fixed |Removed )/i;
+
+  const items: ThinkingItem[] = [];
+
+  for (const chunk of chunks) {
+    if (chunk.chunk_type !== "text" || chunk.is_delta !== 0) continue;
+    if (!chunk.content) continue;
+
+    const firstLine = chunk.content.split("\n")[0].trim();
+    if (!firstLine) continue;
+
+    // Include chunks whose first line describes an implementation or phase action
+    if (
+      firstLine.startsWith("Implemented") ||
+      /^Phase\s+\d+/.test(firstLine)
+    ) {
+      items.push({ text: firstLine, ts: chunk.ts, status: "complete" });
+    }
+  }
+
+  return items;
+}
+
+// ─── Emitting: artifacts and files the agent produced ────────────────────────
+
+export interface EmittingItem {
+  name: string;
+  path: string;
+  kind: "artifact" | "file";
+  status: "done";
+}
+
+interface EmittingOptions {
+  limit?: number;
+}
+
+/**
+ * Detect emitted artifacts (.khive/…/artifacts/ paths) and edited source files
+ * referenced via markdown links in text chunks. Dedupes by name, most-recent wins.
+ */
+export function extractEmitting(
+  chunks: StreamChunk[],
+  _unused?: unknown,
+  options: EmittingOptions = {},
+): EmittingItem[] {
+  const { limit = 5 } = options;
+
+  const LINK_RE = /\[([^\]]*)\]\(([^)]+)\)/g;
+  const ARTIFACT_RE = /\/artifacts\//;
+
+  const byName = new Map<string, EmittingItem>();
+
+  for (const chunk of chunks) {
+    if (chunk.chunk_type !== "text" || !chunk.content) continue;
+
+    let match: RegExpExecArray | null;
+    LINK_RE.lastIndex = 0;
+    while ((match = LINK_RE.exec(chunk.content)) !== null) {
+      const raw = match[2];
+      if (raw.startsWith("http") || raw.startsWith("#")) continue;
+
+      // Strip :lineNumber suffix
+      const colonIdx = raw.lastIndexOf(":");
+      let path: string = raw;
+      if (colonIdx > 0) {
+        const maybeNum = raw.slice(colonIdx + 1);
+        if (!isNaN(parseInt(maybeNum, 10)) && String(parseInt(maybeNum, 10)) === maybeNum) {
+          path = raw.slice(0, colonIdx);
+        }
+      }
+
+      const namePart = path.split("/").pop() ?? path;
+      if (!namePart) continue;
+
+      const kind: "artifact" | "file" = ARTIFACT_RE.test(path) ? "artifact" : "file";
+      byName.set(namePart, { name: namePart, path, kind, status: "done" });
+    }
+  }
+
+  return Array.from(byName.values()).slice(0, limit);
+}

--- a/apps/studio/frontend/lib/types.ts
+++ b/apps/studio/frontend/lib/types.ts
@@ -2,8 +2,10 @@
 
 export interface RunSummary {
   run_id: string;
+  state_root: string;
+  artifact_root: string;
   worker_name: string;
-  task: string | null;
+  task: string;
   status: string;
   step_count: number;
   started_at: number | null;
@@ -19,15 +21,19 @@ export interface RunStep {
 
 export interface RunDetail {
   run_id: string;
-  status: string;
+  state_root: string;
+  artifact_root: string;
   worker_name: string;
-  task: string | null;
+  task: string;
+  status: string;
   error: string | null;
   cwd: string | null;
   started_at: number | null;
   finished_at: number | null;
   steps?: RunStep[];
   graph: { nodes: WorkerStepNode[]; edges: WorkerLinkEdge[] };
+  manifest: Record<string, unknown>;
+  branches: unknown[];
 }
 
 // ─── Worker / Playbook types ──────────────────────────────────────────────────
@@ -112,10 +118,11 @@ export interface AgentProfileSummary {
 
 export interface AgentProfile {
   name: string;
+  path: string;
   provider: string;
   model: string;
-  system_prompt: string;
-  guidance: string;
+  system_prompt: string | null;
+  guidance: string | null;
   permission_mode?: string;
   reasoning_effort?: string;
   description?: string;

--- a/apps/studio/frontend/lib/types.ts
+++ b/apps/studio/frontend/lib/types.ts
@@ -1,0 +1,177 @@
+// ─── Run types ───────────────────────────────────────────────────────────────
+
+export interface RunSummary {
+  run_id: string;
+  worker_name: string;
+  task: string | null;
+  status: string;
+  step_count: number;
+  started_at: number | null;
+  finished_at: number | null;
+}
+
+export interface RunStep {
+  step: string;
+  status: string;
+  result?: Record<string, unknown>;
+  timestamp: number | null;
+}
+
+export interface RunDetail {
+  run_id: string;
+  status: string;
+  worker_name: string;
+  task: string | null;
+  error: string | null;
+  cwd: string | null;
+  started_at: number | null;
+  finished_at: number | null;
+  steps?: RunStep[];
+  graph: { nodes: WorkerStepNode[]; edges: WorkerLinkEdge[] };
+}
+
+// ─── Worker / Playbook types ──────────────────────────────────────────────────
+
+export interface WorkerSummary {
+  name: string;
+  file?: string;
+  description?: string;
+  steps: number;
+  links: number;
+}
+
+export interface WorkerStepNode {
+  id: string;
+  label: string;
+  role: string;
+  assignment: string;
+  prompt: string;
+  capacity: number;
+  timeout: number | null;
+  inputs: string[];
+  outputs: string[];
+}
+
+export interface WorkerLinkEdge {
+  id: string;
+  source: string;
+  target: string;
+  mode: "simple" | "code";
+  condition?: string;
+  map?: Record<string, string>;
+  handler?: string;
+}
+
+export interface WorkerGraph {
+  name: string;
+  description: string;
+  nodes: WorkerStepNode[];
+  edges: WorkerLinkEdge[];
+}
+
+export interface WorkerRaw {
+  name: string;
+  path?: string;
+  description?: string;
+  use?: { models?: Record<string, ModelConfig> };
+  data?: Record<string, unknown>;
+  raw?: string;
+}
+
+export interface WorkerFormData {
+  name: string;
+  description: string;
+  use: { models: Record<string, ModelConfig> };
+  steps: Record<
+    string,
+    {
+      assignment: string;
+      role: string;
+      prompt: string;
+      capacity?: number;
+      timeout?: number | null;
+    }
+  >;
+  links: Array<{
+    from: string;
+    to: string;
+    condition?: string;
+    map?: Record<string, string>;
+    handler?: string;
+  }>;
+}
+
+// ─── Agent types ──────────────────────────────────────────────────────────────
+
+export interface AgentProfileSummary {
+  name: string;
+  description?: string;
+  provider: string;
+  model: string;
+}
+
+export interface AgentProfile {
+  name: string;
+  provider: string;
+  model: string;
+  system_prompt: string;
+  guidance: string;
+  permission_mode?: string;
+  reasoning_effort?: string;
+  description?: string;
+}
+
+// ─── Model config ─────────────────────────────────────────────────────────────
+
+export interface ModelConfig {
+  provider: string;
+  model: string;
+  reasoning_effort?: string;
+  permission_mode?: string;
+}
+
+// ─── Show types ───────────────────────────────────────────────────────────────
+
+export interface ShowSummary {
+  topic: string;
+  play_count: number;
+  latest_status: string;
+  last_update: number | string | null;
+}
+
+export interface PlayMeta {
+  worktree?: string;
+  branch: string;
+  status: string;
+  attempt: number;
+  started_at: string;
+  ended_at?: string;
+  exit_code?: number;
+  merged_at?: string;
+  merge_sha?: string;
+  team_missing?: boolean;
+}
+
+export interface ShowVerdict {
+  gate_passed: boolean;
+  feedback?: string | null;
+  notes?: string | null;
+}
+
+export interface ShowDetail {
+  topic: string;
+  path?: string;
+  show_md: string | null;
+  plays: Array<{
+    name: string;
+    meta: PlayMeta;
+    verdict?: ShowVerdict | null;
+    updated_at?: number | string | null;
+  }>;
+}
+
+export interface ShowEvent {
+  type: "new" | "change" | "delete";
+  path: string;
+  size?: number;
+}

--- a/apps/studio/frontend/next-env.d.ts
+++ b/apps/studio/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/apps/studio/frontend/next.config.js
+++ b/apps/studio/frontend/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+module.exports = nextConfig;

--- a/apps/studio/frontend/package-lock.json
+++ b/apps/studio/frontend/package-lock.json
@@ -1,0 +1,6884 @@
+{
+  "name": "frontend",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@types/d3-force": "^3.0.10",
+        "@types/dagre": "^0.7.54",
+        "d3-drag": "^3.0.0",
+        "d3-force": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "dagre": "^0.8.5",
+        "next": "^14.2.0",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0",
+        "reactflow": "^11.11.4"
+      },
+      "devDependencies": {
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "^10.0.1",
+        "@types/node": "^20.12.0",
+        "@types/react": "^18.3.0",
+        "@types/react-dom": "^18.3.0",
+        "autoprefixer": "^10.4.19",
+        "eslint": "^9.39.4",
+        "eslint-config-next": "^16.2.4",
+        "eslint-config-prettier": "^10.1.8",
+        "postcss": "^8.4.38",
+        "prettier": "^3.8.3",
+        "tailwindcss": "^3.4.3",
+        "typescript": "^5.4.5"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
+      "integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==",
+      "license": "MIT"
+    },
+    "node_modules/@next/eslint-plugin-next": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.4.tgz",
+      "integrity": "sha512-tOX826JJ96gYK/go18sPUgMq9FK1tqxBFfUCEufJb5XIkWFFmpgU7mahJANKGkHs7F41ir3tReJ3Lv5La0RvhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "3.3.1"
+      }
+    },
+    "node_modules/@next/eslint-plugin-next/node_modules/fast-glob": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/@next/eslint-plugin-next/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
+      "integrity": "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
+      "integrity": "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
+      "integrity": "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
+      "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
+      "integrity": "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
+      "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
+      "integrity": "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nolyfill/is-core-module": {
+      "version": "1.0.39",
+      "resolved": "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz",
+      "integrity": "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@reactflow/background": {
+      "version": "11.3.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/background/-/background-11.3.14.tgz",
+      "integrity": "sha512-Gewd7blEVT5Lh6jqrvOgd4G6Qk17eGKQfsDXgyRSqM+CTwDqRldG2LsWN4sNeno6sbqVIC2fZ+rAUBFA9ZEUDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/controls": {
+      "version": "11.2.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/controls/-/controls-11.2.14.tgz",
+      "integrity": "sha512-MiJp5VldFD7FrqaBNIrQ85dxChrG6ivuZ+dcFhPQUwOK3HfYgX2RHdBua+gx+40p5Vw5It3dVNp/my4Z3jF0dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/core": {
+      "version": "11.11.4",
+      "resolved": "https://registry.npmjs.org/@reactflow/core/-/core-11.11.4.tgz",
+      "integrity": "sha512-H4vODklsjAq3AMq6Np4LE12i1I4Ta9PrDHuBR9GmL8uzTt2l2jh4CiQbEMpvMDcp7xi4be0hgXj+Ysodde/i7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3": "^7.4.0",
+        "@types/d3-drag": "^3.0.1",
+        "@types/d3-selection": "^3.0.3",
+        "@types/d3-zoom": "^3.0.1",
+        "classcat": "^5.0.3",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/minimap": {
+      "version": "11.7.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/minimap/-/minimap-11.7.14.tgz",
+      "integrity": "sha512-mpwLKKrEAofgFJdkhwR5UQ1JYWlcAAL/ZU/bctBkuNTT1yqV+y0buoNVImsRehVYhJwffSWeSHaBR5/GJjlCSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "@types/d3-selection": "^3.0.3",
+        "@types/d3-zoom": "^3.0.1",
+        "classcat": "^5.0.3",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/node-resizer": {
+      "version": "2.2.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-resizer/-/node-resizer-2.2.14.tgz",
+      "integrity": "sha512-fwqnks83jUlYr6OHcdFEedumWKChTHRGw/kbCxj0oqBd+ekfs+SIp4ddyNU0pdx96JIm5iNFS0oNrmEiJbbSaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.4",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/node-toolbar": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-toolbar/-/node-toolbar-1.3.14.tgz",
+      "integrity": "sha512-rbynXQnH/xFNu4P9H+hVqlEUafDCkEoCy0Dg9mG22Sg+rY/0ck6KkrAQrYrTgXusd+cEJOMK0uOOFCK2/5rSGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@rtsao/scc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
+      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/dagre": {
+      "version": "0.7.54",
+      "resolved": "https://registry.npmjs.org/@types/dagre/-/dagre-0.7.54.tgz",
+      "integrity": "sha512-QjcRY+adGbYvBFS7cwv5txhVIwX1XXIUswWl+kSQTbI6NjgZydrZkEKX/etzVd7i+bCsCb40Z/xlBY5eoFuvWQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.1.tgz",
+      "integrity": "sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.59.1",
+        "@typescript-eslint/type-utils": "8.59.1",
+        "@typescript-eslint/utils": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.59.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.1.tgz",
+      "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.59.1",
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.1.tgz",
+      "integrity": "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.59.1",
+        "@typescript-eslint/types": "^8.59.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.1.tgz",
+      "integrity": "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz",
+      "integrity": "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.1.tgz",
+      "integrity": "sha512-klWPBR2ciQHS3f++ug/mVnWKPjBUo7icEL3FAO1lhAR1Z1i5NQYZ1EannMSRYcq5qCv5wNALlXr6fksRHyYl7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1",
+        "@typescript-eslint/utils": "8.59.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
+      "integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz",
+      "integrity": "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.59.1",
+        "@typescript-eslint/tsconfig-utils": "8.59.1",
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.1.tgz",
+      "integrity": "sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.59.1",
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz",
+      "integrity": "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlastindex": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
+      "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-shim-unscopables": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
+      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001790",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
+      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.8.5.tgz",
+      "integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "graphlib": "^2.1.8",
+        "lodash": "^4.17.15"
+      }
+    },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.344",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
+      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-abstract": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.2.tgz",
+      "integrity": "sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.1.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.3.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.5",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-next": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.4.tgz",
+      "integrity": "sha512-A6ekXYFj/YQxBPMl45g3e+U8zJo+X2+ZQwcz34pPKjpc/3S4roBA2Rd9xWB4FKuSxhofo1/95WjzmUY+wHrOhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@next/eslint-plugin-next": "16.2.4",
+        "eslint-import-resolver-node": "^0.3.6",
+        "eslint-import-resolver-typescript": "^3.5.2",
+        "eslint-plugin-import": "^2.32.0",
+        "eslint-plugin-jsx-a11y": "^6.10.0",
+        "eslint-plugin-react": "^7.37.0",
+        "eslint-plugin-react-hooks": "^7.0.0",
+        "globals": "16.4.0",
+        "typescript-eslint": "^8.46.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=9.0.0",
+        "typescript": ">=3.3.1"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-config-next/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/eslint-import-resolver-typescript": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.10.1.tgz",
+      "integrity": "sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@nolyfill/is-core-module": "1.0.39",
+        "debug": "^4.4.0",
+        "get-tsconfig": "^4.10.0",
+        "is-bun-module": "^2.0.0",
+        "stable-hash": "^0.0.5",
+        "tinyglobby": "^0.2.13",
+        "unrs-resolver": "^1.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-resolver-typescript"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*",
+        "eslint-plugin-import-x": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-import": {
+          "optional": true
+        },
+        "eslint-plugin-import-x": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/eslint-plugin-import": {
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.9",
+        "array.prototype.findlastindex": "^1.2.6",
+        "array.prototype.flat": "^1.3.3",
+        "array.prototype.flatmap": "^1.3.3",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.12.1",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.16.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.1",
+        "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.9",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/eslint-plugin-react": {
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.2.1",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/resolve": {
+      "version": "2.0.0-next.6",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
+      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
+      "integrity": "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.16.1",
+        "resolve": "^2.0.0-next.6"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/resolve": {
+      "version": "2.0.0-next.6",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
+      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
+      "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz",
+      "integrity": "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/graphlib": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
+      "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      }
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bun-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+      "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.1"
+      }
+    },
+    "node_modules/is-bun-module/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/next": {
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
+      "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "14.2.35",
+        "@swc/helpers": "0.5.5",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001579",
+        "graceful-fs": "^4.2.11",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.1"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "14.2.33",
+        "@next/swc-darwin-x64": "14.2.33",
+        "@next/swc-linux-arm64-gnu": "14.2.33",
+        "@next/swc-linux-arm64-musl": "14.2.33",
+        "@next/swc-linux-x64-gnu": "14.2.33",
+        "@next/swc-linux-x64-musl": "14.2.33",
+        "@next/swc-win32-arm64-msvc": "14.2.33",
+        "@next/swc-win32-ia32-msvc": "14.2.33",
+        "@next/swc-win32-x64-msvc": "14.2.33"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.41.2",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next/node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-exports-info": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
+      "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.flatmap": "^1.3.3",
+        "es-errors": "^1.3.0",
+        "object.entries": "^1.1.9",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.groupby": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
+      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/reactflow": {
+      "version": "11.11.4",
+      "resolved": "https://registry.npmjs.org/reactflow/-/reactflow-11.11.4.tgz",
+      "integrity": "sha512-70FOtJkUWH3BAOsN+LU9lCrKoKbtOPnz2uq0CV2PLdNSwxTXOhCbsZr50GmZ+Rtw3jx8Uv7/vBFtCGixLfd4Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/background": "11.3.14",
+        "@reactflow/controls": "11.2.14",
+        "@reactflow/core": "11.11.4",
+        "@reactflow/minimap": "11.7.14",
+        "@reactflow/node-resizer": "2.2.14",
+        "@reactflow/node-toolbar": "1.3.14"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stable-hash": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
+      "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.1.tgz",
+      "integrity": "sha512-xqDcFVBmlrltH64lklOVp1wYxgJr6LVdg3NamBgH2OOQDLFdTKfIZXF5PfghrnXQKXZGTQs8tr1vL7fJvq8CTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.59.1",
+        "@typescript-eslint/parser": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1",
+        "@typescript-eslint/utils": "8.59.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+        "@unrs/resolver-binding-android-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-x64": "1.11.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/apps/studio/frontend/package.json
+++ b/apps/studio/frontend/package.json
@@ -1,0 +1,35 @@
+{
+  "private": true,
+  "scripts": {
+    "dev": "next dev -p 3000",
+    "build": "next build",
+    "start": "next start -p 3000"
+  },
+  "dependencies": {
+    "@types/d3-force": "^3.0.10",
+    "@types/dagre": "^0.7.54",
+    "d3-drag": "^3.0.0",
+    "d3-force": "^3.0.0",
+    "d3-selection": "^3.0.0",
+    "dagre": "^0.8.5",
+    "next": "^14.2.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
+    "reactflow": "^11.11.4"
+  },
+  "devDependencies": {
+    "@eslint/eslintrc": "^3.3.5",
+    "@eslint/js": "^10.0.1",
+    "@types/node": "^20.12.0",
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "autoprefixer": "^10.4.19",
+    "eslint": "^9.39.4",
+    "eslint-config-next": "^16.2.4",
+    "eslint-config-prettier": "^10.1.8",
+    "postcss": "^8.4.38",
+    "prettier": "^3.8.3",
+    "tailwindcss": "^3.4.3",
+    "typescript": "^5.4.5"
+  }
+}

--- a/apps/studio/frontend/package.json
+++ b/apps/studio/frontend/package.json
@@ -1,9 +1,11 @@
 {
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "next dev -p 3000",
     "build": "next build",
-    "start": "next start -p 3000"
+    "start": "next start -p 3000",
+    "test": "node --experimental-strip-types --test __tests__/**/*.test.ts"
   },
   "dependencies": {
     "@types/d3-force": "^3.0.10",

--- a/apps/studio/frontend/package.json
+++ b/apps/studio/frontend/package.json
@@ -5,7 +5,7 @@
     "dev": "next dev -p 3000",
     "build": "next build",
     "start": "next start -p 3000",
-    "test": "node --experimental-strip-types --test __tests__/**/*.test.ts"
+    "test": "node --experimental-strip-types --experimental-loader ./ts-loader.mjs --test __tests__/**/*.test.ts"
   },
   "dependencies": {
     "@types/d3-force": "^3.0.10",

--- a/apps/studio/frontend/postcss.config.js
+++ b/apps/studio/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/studio/frontend/tailwind.config.ts
+++ b/apps/studio/frontend/tailwind.config.ts
@@ -1,0 +1,60 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./app/**/*.{js,ts,jsx,tsx,mdx}", "./components/**/*.{js,ts,jsx,tsx,mdx}"],
+  theme: {
+    extend: {
+      colors: {
+        surface: {
+          base: "var(--surface-base)",
+          raised: "var(--surface-raised)",
+          overlay: "var(--surface-overlay)",
+          nav: "var(--surface-nav)",
+          input: "var(--surface-input)",
+          "input-hover": "var(--surface-input-hover)",
+        },
+        content: {
+          primary: "var(--content-primary)",
+          secondary: "var(--content-secondary)",
+          muted: "var(--content-muted)",
+          inverse: "var(--content-inverse)",
+        },
+        edge: {
+          DEFAULT: "var(--edge-default)",
+          subtle: "var(--edge-subtle)",
+          strong: "var(--edge-strong)",
+        },
+        interactive: {
+          primary: "var(--interactive-primary)",
+          "primary-hover": "var(--interactive-primary-hover)",
+          secondary: "var(--interactive-secondary)",
+          "secondary-hover": "var(--interactive-secondary-hover)",
+        },
+        status: {
+          success: "var(--status-success)",
+          "success-bg": "var(--status-success-bg)",
+          running: "var(--status-running)",
+          "running-bg": "var(--status-running-bg)",
+          error: "var(--status-error)",
+          "error-bg": "var(--status-error-bg)",
+          warning: "var(--status-warning)",
+          "warning-bg": "var(--status-warning-bg)",
+          selected: "var(--status-selected)",
+          "selected-bg": "var(--status-selected-bg)",
+        },
+        role: {
+          researcher: "var(--role-researcher)",
+          implementer: "var(--role-implementer)",
+          reviewer: "var(--role-reviewer)",
+          critic: "var(--role-critic)",
+          analyst: "var(--role-analyst)",
+          architect: "var(--role-architect)",
+          tester: "var(--role-tester)",
+        },
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/apps/studio/frontend/ts-loader.mjs
+++ b/apps/studio/frontend/ts-loader.mjs
@@ -1,0 +1,21 @@
+/**
+ * Node.js ESM loader that resolves extensionless TypeScript imports.
+ * Used by: node --experimental-strip-types --loader ./ts-loader.mjs --test ...
+ */
+import { existsSync } from "node:fs";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { resolve as resolvePath } from "node:path";
+
+export async function resolve(specifier, context, nextResolve) {
+  // If the specifier is a relative path without extension, try adding .ts
+  if (specifier.startsWith(".") && !specifier.match(/\.\w+$/)) {
+    const parentDir = context.parentURL
+      ? resolvePath(fileURLToPath(context.parentURL), "..")
+      : process.cwd();
+    const candidate = resolvePath(parentDir, specifier + ".ts");
+    if (existsSync(candidate)) {
+      return nextResolve(pathToFileURL(candidate).href, context);
+    }
+  }
+  return nextResolve(specifier, context);
+}

--- a/apps/studio/frontend/tsconfig.json
+++ b/apps/studio/frontend/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
# feat(apps/studio/frontend): Lion Studio UI — Next 14 frontend + shows surface

## Summary

Introduces the Next 14 frontend for Lion Studio at `apps/studio/frontend/` ("Lion Studio UI"). Consumes the FastAPI backend from PR-C. Includes the `/shows` monitoring surface (DAG view + live SSE updates) and the four-finding visual-walkthrough polish (copy sweep + React key + ReactFlow types + run-detail contract defense).

See **ADR-0001** (Lion Studio) and **ADR-0002** (tech stack) in sibling PR-A.

## What's inside

- **`apps/studio/frontend/`** — Next 14 + Tailwind app
  - `app/{playbooks,agents,runs,shows}/page.tsx` + `app/runs/[id]/page.tsx` + `app/shows/[topic]/page.tsx`
  - `app/shows/[topic]/components/PlayDag.tsx` — ReactFlow DAG view
  - `components/Shell.tsx` — top nav + branding
  - `lib/{api,types}.ts` — typed API client (matches PR-C contract)
  - Tests: `__tests__/extractors.test.ts`

(~53 files, +13,584 LOC — half is the lockfile + generated tailwind config.)

## Visual-walkthrough polish (folded in)

The frontend was end-to-end tested in a real browser via the `visual-walkthrough` play. Four findings surfaced + fixed in this PR:

| Finding | Fix |
|---|---|
| **F1 brand copy** | "Workers" → "Playbooks" across `Shell.tsx`, `app/playbooks/page.tsx`, `app/runs/page.tsx` (7 user-visible strings) |
| **F2 React `key` prop** | Already present in initial build (`key={w}` at `app/runs/page.tsx:90`) — confirmed in walkthrough, no edit needed |
| **F3 ReactFlow `nodeTypes`/`edgeTypes`** | Not applicable — `PlayDag.tsx` uses only built-in node types, no custom `nodeTypes` declared |
| **F4 run-detail contract drift** | Backend returns `{run_id, state_root, artifact_root, manifest, branches}` — no `steps`. Defensive default applied at every read site in `app/runs/[id]/page.tsx`; `Run.steps` made optional in `lib/types.ts`. |

## Test plan

- [ ] `cd apps/studio/frontend && npm install` succeeds
- [ ] `cd apps/studio/frontend && npm run build` succeeds (Next prod build)
- [ ] `cd apps/studio/frontend && npm run dev` boots on :3000
- [ ] Visit `/playbooks`, `/agents`, `/runs`, `/shows`, `/shows/lion-studio-init`, `/runs/<any-id>` — each renders without console errors
- [ ] No React `key` warnings on `/runs`
- [ ] No ReactFlow `nodeTypes/edgeTypes` warnings on `/shows/[topic]`
- [ ] `grep -rE "Workers|worker (orchestration|definitions)|All workers|New Worker" apps/studio/frontend/{components,app}/` returns zero matches outside `__tests__/`
- [ ] `npm run test` passes

## Known follow-ups (deliberately out of scope)

- `app/runs/[id]/page.tsx` still shows `Worker:` and `Edit Worker` labels (line 102, 119) — these reference the backend field `worker_name` which is by-design. A future minor brand sweep can address.
- `app/runs/page.tsx:118` table header `<th>Worker</th>` — same reason.
- Backend follow-up to derive `steps` from `run.branches[].steps` for richer detail (tracked, deferred).

## Sibling PRs

- **#PR-A** — ADRs
- **#PR-B** — Marketplace
- **#PR-C** — Backend (this PR consumes the contract)
- **#PR-D (this one)** — Frontend

## Provenance

Part of the Lion Studio introduction, split into 4 reviewable PRs (sibling PRs A/B/C). Built via the `lion-studio-init` orchestrated show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
