### PR TITLE
fix(tests): skip studio tests when fastapi not installed

### DIFF
--- a/tests/apps_studio_server/test_shows.py
+++ b/tests/apps_studio_server/test_shows.py
@@ -10,6 +10,8 @@ import json
 from pathlib import Path
 
 import pytest
+
+fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 from fastapi.testclient import TestClient
 
 # ---------------------------------------------------------------------------

--- a/tests/apps_studio_server/test_smoke.py
+++ b/tests/apps_studio_server/test_smoke.py
@@ -10,6 +10,8 @@ import json
 from pathlib import Path
 
 import pytest
+
+fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 from fastapi.testclient import TestClient
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
CI fix — pytest.importorskip for fastapi in studio test modules.