### PR TITLE
docs: Lion Studio ADRs — 16 architecture decision records

### DIFF
--- a/docs/adrs/ADR-0002-studio-tech-stack.md
+++ b/docs/adrs/ADR-0002-studio-tech-stack.md
@@ -75,22 +75,19 @@ play resolves the conflict. Every `npm install` in CI and local setup MUST inclu
 
 Source: `_show.md:148-149`
 
-## Appendix B — TypeScript Symbol Names Retained (`WorkerFormData`, `listWorkers`)
+## Appendix B — TypeScript Symbol Names
 
-The workers → playbooks rename is URL/API/path-level only for v1. Internal TypeScript identifiers
-(`WorkerFormData`, `listWorkers`, `WorkersPage`, etc.) are intentionally left unchanged as
-accepted tech debt. A future sweeper must not perform a mechanical symbol rename without
-understanding all call sites. See [ADR-0005](ADR-0005-workers-playbooks-rename.md) for full
-scope documentation.
+Some internal TypeScript types retain `Worker` prefix (`WorkerStepNode`, `WorkerLinkEdge`,
+`WorkerCanvas`) where they refer to graph-format playbook step/link data models. These are
+technical type names for the graph editing canvas, not user-facing labels. All user-facing
+surfaces use "playbooks." See [ADR-0005](ADR-0005-workers-playbooks-rename.md).
 
-Source: `_show.md:151`
+## Appendix C — Run Detail: Execution Graph from Playbook Context
 
-## Appendix C — Run Detail API Shape (`run.steps` absent, F4 defensive default)
-
-The backend run manifest shape is `{run_id, state_root, artifact_root, manifest, branches}`;
-there is no top-level `steps` field. The frontend makes `steps` optional in `lib/types.ts` and
-defaults all read sites to `[]`. Deriving `steps` from `branches[]` was evaluated but rejected:
-branch snapshots are opaque JSON blobs with no documented `steps` sub-field. The defensive
-frontend default is the smallest correct fix; backend derivation is deferred.
+The backend session API does not include a `steps` field. Execution graph visualization
+(`ExecutionDag.tsx`) derives its structure from the playbook's graph metadata (steps + links),
+not from the session. The graph is rendered only when playbook context is known — either by
+navigating from the playbook detail page or when the session's `playbook_name` field matches
+a graph-format playbook. See ADR-0012.
 
 Source: `frontend-finalize/impl1/summary.md:88-97`; `visual-walkthrough/walkthrough_findings.md:98-103`

--- a/docs/adrs/ADR-0003-claude-code-marketplace.md
+++ b/docs/adrs/ADR-0003-claude-code-marketplace.md
@@ -48,7 +48,7 @@ This play establishes the skeleton (manifests, directory structure, README, this
 - More manifests to maintain: root `marketplace.json` plus nine `plugin.json` files must stay in sync as plugin names or descriptions change.
 - Skills authored in `firm/resources/skills/` (canonical) must be copied or symlinked into `marketplace/<plugin>/skills/` for external installs — two places to update per skill change.
 - The `plugin.json` schema is not yet finalized by Anthropic; field names or required keys may shift before GA, requiring a sweep across all nine manifests.
-- `studio` and `mcp-bundle` manifests are intentionally incomplete stubs until the FastAPI route set from ADR-0002 is implemented; downstream consumers of those plugins will see empty capability until `marketplace-plugins-app` lands.
+- `studio` and `mcp-bundle` manifests are intentionally incomplete stubs until the FastAPI route contracts from ADR-0004 are implemented; downstream consumers of those plugins will see empty capability until `marketplace-plugins-app` lands.
 
 ## Alternatives Considered
 
@@ -61,7 +61,8 @@ This play establishes the skeleton (manifests, directory structure, README, this
 ## References
 
 - [ADR-0001: Lion Studio as Internal App](ADR-0001-lion-studio-internal-app.md) — establishes monorepo boundary and daily-driver app direction
-- [ADR-0002: Lion Studio Tech Stack](ADR-0002-studio-tech-stack.md) — establishes FastAPI backend route set that `studio` and `mcp-bundle` plugins will eventually configure
+- [ADR-0002: Lion Studio Tech Stack](ADR-0002-studio-tech-stack.md) — establishes FastAPI backend stack that the `studio` and `mcp-bundle` plugins depend on
+- [ADR-0004: Filesystem Data Layer](ADR-0004-filesystem-data-layer.md) — establishes the FastAPI backend route contracts that `studio` and `mcp-bundle` plugins will eventually configure
 - khive marketplace reference implementation: `/Users/lion/projects/khive/khive/marketplace/`
 
 ---

--- a/docs/adrs/ADR-0004-filesystem-data-layer.md
+++ b/docs/adrs/ADR-0004-filesystem-data-layer.md
@@ -46,6 +46,8 @@ content, SQLite for operational/query state.
 | `/api/shows/{topic}` | SQLite + filesystem (`_show.md`, `_intent.md`) |
 | `/api/stats` | Mixed — sessions from SQLite, definitions from filesystem |
 
+Note: the browser route is `/runs/{id}` (user-facing 'Runs' label per ADR-0012), while the API route is `/api/sessions/{id}` (matching the SQLite table). The frontend API client translates between these.
+
 ### Sync and drift
 
 SQLite and filesystem can drift if a write to one fails before the other completes.

--- a/docs/adrs/ADR-0004-filesystem-data-layer.md
+++ b/docs/adrs/ADR-0004-filesystem-data-layer.md
@@ -1,54 +1,74 @@
-# ADR-0004: Filesystem-Backed Data Layer for Lion Studio
+# ADR-0004: Data Layer — Filesystem + SQLite Hybrid
 
 **Status**: Accepted
-**Date**: 2026-05-19
+**Date**: 2026-05-19 (revised 2026-05-20)
 
 ## Context
 
-Lion Studio's backend must serve runs, agents, playbooks, and show data to the dashboard. The
-data already exists on the local filesystem as output from lionagi's CLI and show tooling:
-`~/.lionagi/runs/`, `~/.lionagi/agents/`, `~/.lionagi/playbooks/`, and `~/khive-work/shows/`.
+Lion Studio's backend serves runs, agents, playbooks, plugins, shows, and sessions.
+Data exists in two forms: authored files on the local filesystem (agent definitions,
+playbook YAML, show plans, skill markdown) and operational state in SQLite (sessions,
+branches, messages, shows, plays).
 
-A persistent database, ORM, or caching layer would require schema definition, migration tooling,
-and a sync process to keep the DB consistent with the filesystem that the CLI writes to directly.
+The original design read everything from filesystem. As the product evolved, SQLite
+became necessary for live monitoring, cross-session queries, and execution lineage
+(see ADR-0009, ADR-0011, ADR-0012).
 
 ## Decision
 
-The Lion Studio backend reads all data directly from the local filesystem on each request. No
-database, ORM, or caching layer is introduced. Each service scans its designated directory tree
-and returns the results. The configuration mapping is:
+Lion Studio uses a **hybrid data layer**: filesystem for authored definitions and
+content, SQLite for operational/query state.
 
-| Route | Filesystem root |
-|-------|----------------|
-| `/api/runs` | `~/.lionagi/runs/` |
-| `/api/agents` | `~/.lionagi/agents/` |
-| `/api/playbooks` | `~/.lionagi/playbooks/` |
-| `/api/shows` | `~/khive-work/shows/` |
+### Data authority matrix
+
+| Data | Location | Why |
+|------|----------|-----|
+| Agent definitions (`*.md`) | Filesystem `~/.lionagi/agents/` | Edited by humans, git-versioned, read by CLI/Claude Code |
+| Playbook definitions (`*.yaml`) | Filesystem `~/.lionagi/playbooks/` | Same — authored content |
+| Skill content (`SKILL.md`) | Filesystem (plugin dirs) | Read-only from disk, part of plugin packages |
+| Plugin structure | Filesystem (marketplace + cache) | Scanned by plugin discovery |
+| Show plans (`_show.md`, `_intent.md`) | Filesystem `~/khive-work/shows/` | Authored markdown, git-versioned, edited mid-show |
+| Artifacts (agent output files) | Filesystem (play dirs, worktrees) | Binary/large files, git-tracked |
+| Sessions, branches, messages | SQLite `~/.lionagi/state.db` | Queryable, FK-linked, live-updatable |
+| Shows, plays (structural state) | SQLite `~/.lionagi/state.db` | Queryable, cross-referenced to sessions |
+| Definition versions (edit history) | SQLite `definitions` table | Disk is source of truth; SQLite tracks edit history |
+
+### Route mapping
+
+| Route | Data source |
+|-------|-------------|
+| `/api/runs` | SQLite `sessions` (enriched with provenance) |
+| `/api/sessions/{id}` | SQLite sessions + branches + messages |
+| `/api/agents` | Filesystem scan + definitions API for versions |
+| `/api/playbooks` | Filesystem scan + definitions API for versions |
+| `/api/plugins` | Filesystem scan (marketplace + third-party cache) |
+| `/api/shows` | SQLite `shows` + `plays`, filesystem fallback |
+| `/api/shows/{topic}` | SQLite + filesystem (`_show.md`, `_intent.md`) |
+| `/api/stats` | Mixed — sessions from SQLite, definitions from filesystem |
+
+### Sync and drift
+
+SQLite and filesystem can drift if a write to one fails before the other completes.
+Mitigation: `li state import` and `li state import-shows` re-sync from filesystem
+into SQLite at any time. Filesystem is recoverable source; SQLite is the query cache.
 
 ## Consequences
 
 **Positive**
-- Zero schema migrations; the filesystem is the schema.
-- Instant consistency: CLI writes are visible to the dashboard on the next poll cycle.
-- Trivial deployment — no database process to start or configure.
-- No ORM impedance mismatch; directory scan logic is plain Python.
+- Authored content stays in git-friendly files editable by any tool.
+- Operational queries are fast (SQLite indexes, JOINs, aggregates).
+- No external database process — SQLite is embedded.
+- CLI and Studio share the same data without coordination protocol.
 
 **Negative**
-- Directory scans on every request do not scale beyond a single local workspace.
-- Multi-user, remote, or persistent-state features are ruled out without revisiting this decision.
-- No query capabilities (filtering, sorting) beyond what Python list comprehensions provide.
+- Two data sources means two things to keep in sync.
+- Import commands needed for historical data migration.
+- Contributors must know which data lives where.
 
 ## Alternatives Considered
 
 | Alternative | Why Rejected |
-|-------------|--------------|
-| SQLite for query speed | Adds schema management and a sync process; the single-user local workload does not justify the complexity |
-| Redis cache layer | Single-user workload; cache invalidation adds complexity with no throughput benefit |
-
-## References
-
-- `_show.md:8` — shows root at `~/khive-work/shows/<topic>/`
-- `lift-backend/_intent.md:44-48` — services scan filesystem directories
-- `lift-backend/lift_summary.md:40-45` — services/*.py descriptions
-- `brand_swaps.md:41-55` — config mapping (directories)
-- [ADR-0008](ADR-0008-studio-v1-scope.md) — v1 scope decision (single-workspace, read-only)
+|-------------|-------------|
+| Filesystem only | Cannot support live monitoring, cross-session queries, or execution lineage |
+| SQLite only | Agent/playbook definitions are authored markdown/YAML — git versioning and editor access matter more than query performance on content |
+| External database (Postgres, etc.) | Overkill for single-user local workload; adds ops burden |

--- a/docs/adrs/ADR-0005-workers-playbooks-rename.md
+++ b/docs/adrs/ADR-0005-workers-playbooks-rename.md
@@ -1,60 +1,42 @@
-# ADR-0005: Workers-to-Playbooks Rename Strategy
+# ADR-0005: Playbooks Naming Convention
 
 **Status**: Accepted
 **Date**: 2026-05-19
 
 ## Context
 
-The source codebase used the term "workers" for the units of work that users define and execute.
-Lion Studio's public-facing identity uses "playbooks" — a term that better reflects the
-orchestration-script nature of these units and avoids internal naming that leaks into the UI.
-
-A complete atomic rename (all files, routes, TypeScript symbols, and copy) is one option. A
-staged rename scoped to the user-visible surface is another.
+The initial Studio codebase used "workers" for the units of work that users define
+and execute. "Playbooks" better reflects the orchestration-script nature of these
+units and aligns with the product vocabulary.
 
 ## Decision
 
-The rename is applied in two stages, only stage one ships in v1:
+All user-visible surfaces, routes, filesystem paths, and API endpoints use
+"playbooks" consistently:
 
-**Stage 1 (v1 — shipped)**: URL paths, API routes, filesystem paths, and all user-visible copy
-rename `workers` → `playbooks`. Specifically:
+- Route: `/playbooks`, `/playbooks/{name}`
+- API: `GET /api/playbooks`
+- Filesystem: `~/.lionagi/playbooks/`
+- UI copy: page titles, labels, badges
 
-- Route directory `workers/` → `playbooks/`
-- API path `GET /api/workers` → `GET /api/playbooks`
-- Filesystem root `~/.lionagi/workers/` → `~/.lionagi/playbooks/`
-- All UI copy: page titles, labels, empty-state text
-
-**Stage 2 (deferred)**: Internal TypeScript symbol names (`WorkerFormData`, `listWorkers`,
-`WorkersPage`, and ~20 related identifiers) are intentionally left unchanged. These are accepted
-tech debt.
+The term "worker" does not appear in lionagi's Studio vocabulary. Internal
+TypeScript types (e.g., `WorkerStepNode`, `WorkerLinkEdge`, `WorkerCanvas`)
+retain "Worker" only where they refer to the graph-format playbook step/link
+data model — these are technical type names, not user-facing labels.
 
 ## Consequences
 
 **Positive**
-- The bulk of user-facing "Workers" copy is replaced with "Playbooks" in stage 1; the public model
-  is consistent for all primary flows. Known residual strings (`"Failed to load workers"` in
-  `app/playbooks/page.tsx:12`, labels and button text in `app/runs/[id]/page.tsx:102,120`, and
-  `<th>Worker</th>` in `app/runs/page.tsx:118`) are addressed in PR-D's residual sweep; once that
-  lands, zero user-facing "Workers" copy remains.
-- Stage 1 risk is bounded to route and path changes, which are testable end-to-end.
+- Consistent vocabulary across CLI, Studio, and documentation.
+- "Playbook" communicates orchestration intent better than "worker."
 
 **Negative**
-- `grep "Workers"` still hits ~20 TypeScript identifiers in the frontend source.
-- A future sweeper performing a mechanical symbol rename risks breaking call sites; they MUST
-  read [ADR-0002 Appendix B](ADR-0002-studio-tech-stack.md#appendix-b--typescript-symbol-names-retained-workerformdata-listworkers) before touching symbols.
-- The split between "renamed" and "not renamed" is a latent confusion point for new contributors.
+- Some TypeScript graph types retain "Worker" prefix — accepted tech debt for
+  types that describe the graph editing canvas, not user-facing concepts.
 
 ## Alternatives Considered
 
 | Alternative | Why Rejected |
-|-------------|--------------|
-| Full atomic rename (symbols + routes + copy in one pass) | Too much churn for v1; risk of typo regressions across ~20 call sites; unblocks no user-facing feature |
-| No rename (keep "workers" everywhere) | "Workers" does not match the playbook model; creates brand inconsistency from day one |
-
-## References
-
-- `brand_swaps.md:31-35` — code_id table: `workers.py` → `playbooks.py`, route dir, API path
-- `lift-frontend/_intent.md:39-40` — route rename + in-file API reference updates
-- `lift-backend/lift_summary.md:61-63` — Route Remap: `GET /api/workers` → `GET /api/playbooks`
-- `frontend-finalize/_intent.md:68` — F1 closes UI copy gap
-- [ADR-0002 Appendix B](ADR-0002-studio-tech-stack.md#appendix-b--typescript-symbol-names-retained-workerformdata-listworkers) — symbol retention rationale
+|-------------|-------------|
+| Keep "workers" everywhere | Does not match the playbook orchestration model |
+| Rename all TypeScript symbols too | Churn for internal types that don't surface in UI |

--- a/docs/adrs/ADR-0006-sse-live-streaming.md
+++ b/docs/adrs/ADR-0006-sse-live-streaming.md
@@ -1,52 +1,66 @@
-# ADR-0006: Server-Sent Events for Live Streaming
+# ADR-0006: Live Update Transport — SSE + Interval Refresh
 
 **Status**: Accepted
-**Date**: 2026-05-19
+**Date**: 2026-05-19 (revised 2026-05-20)
 
 ## Context
 
-Lion Studio's dashboard needs live updates for two data surfaces: run progress (token-by-token
-output as a run executes) and show DAG state (play statuses as a multi-play show advances).
+Lion Studio needs live updates for three surfaces: session message streams
+(new messages appearing during an active run), show DAG state (play statuses
+advancing), and dashboard metrics (counts and recent activity).
 
-Both consumers are read-only from the browser's perspective — the UI displays state but does not
-send commands back over the same channel. The backend is FastAPI / Starlette (see ADR-0002).
+All consumers are read-only from the browser's perspective — the UI displays
+state but does not send commands. The backend is FastAPI / Starlette (ADR-0002).
 
 ## Decision
 
-Use Starlette `StreamingResponse` for all live update streams. Change detection for show
-directories uses 500ms polling with `os.stat()` — no filesystem event daemon required.
+### Transport policy
 
-The run-events endpoint (`GET /api/runs/{run_id}/events`) yields newline-delimited JSON chunks
-as SSE. The browser side uses the native `EventSource` API. Any action that triggers a side
-effect (e.g., starting a re-run) is a separate REST `POST` endpoint; the SSE channel is
-one-way only.
+| Surface | Transport | Why |
+|---------|-----------|-----|
+| Session messages | SSE (`/api/sessions/{id}/stream`) | Real-time per-message push; EventSource API is native |
+| Show play state | SSE (`/api/shows/{topic}/stream`) | File change detection via 500ms `os.stat()` polling, pushed as SSE |
+| Dashboard metrics | Interval refresh (30s `setInterval` on `/api/stats`) | Dashboard is a snapshot, not a live stream; interval is cheaper |
+
+**SSE is the only push transport.** No WebSocket. The browser-to-server direction
+uses standard REST endpoints for any mutations (save definition, trigger run).
+
+### SSE implementation
+
+Starlette `StreamingResponse` with `text/event-stream` media type. Newline-delimited
+JSON chunks. The browser uses native `EventSource` API — no client library.
+
+Change detection for show directories uses 500ms polling with `os.stat()`. For
+sessions, new messages after a timestamp cursor are queried from SQLite.
+
+### Reconnect behavior
+
+SSE auto-reconnects via `EventSource`. The server sends a `{"type":"done"}` event
+when a session is no longer active (no updates for 60s), signaling the client to
+stop reconnecting.
 
 ## Consequences
 
 **Positive**
-- `EventSource` is native in all modern browsers; no client library required.
-- Starlette `StreamingResponse` is synchronous to the existing FastAPI stack — no additional
-  dependency or protocol server.
-- One-way constraint is a feature for this read-only v1 scope: no reconnect-and-replay
-  complexity for bidirectional state.
+- `EventSource` is native in all modern browsers; no client library.
+- Starlette `StreamingResponse` integrates with the existing FastAPI stack.
+- One-way constraint prevents bidirectional state complexity.
+- No WebSocket server, connection upgrade, or ping/pong management.
 
 **Negative**
-- SSE is strictly server-to-client. Triggering a re-run or cancelling a run from the UI requires
-  a separate REST endpoint; the SSE channel cannot carry commands.
-- HTTP/1.1 browser connection limits (6 per origin) constrain the number of concurrent SSE
-  streams a single page can hold open.
+- SSE is strictly server-to-client. Any client-to-server action requires a
+  separate REST endpoint.
+- HTTP/1.1 browser connection limits (6 per origin) constrain concurrent SSE
+  streams per page.
+- 500ms filesystem polling for shows is acceptable at 5-20 files but would need
+  replacement at scale. SQLite-backed show state (ADR-0011) reduces reliance on
+  filesystem polling.
 
 ## Alternatives Considered
 
 | Alternative | Why Rejected |
-|-------------|--------------|
-| WebSocket | Overkill for one-way streaming; adds reconnect-and-replay logic; no bidirectional need in v1 |
-| inotify / FSEvents filesystem watcher | Show directories are small (~5-20 files × ~10 plays); polling at 500ms is sufficient; avoids platform-specific daemon dependency |
+|-------------|-------------|
+| WebSocket | Overkill for one-way streaming; adds reconnect-and-replay logic; no bidirectional need |
+| inotify/FSEvents filesystem watcher | Platform-specific daemon dependency; polling at 500ms is sufficient for show dir sizes |
 | Long-polling | More client complexity than SSE for equivalent one-way semantics |
-
-## References
-
-- `add-shows-pages/_intent.md:65-70` — use `StreamingResponse` (not `EventSourceResponse`)
-- `lift-backend/lift_summary.md:73-74` — `GET /api/runs/{run_id}/events` SSE implementation
-- `add-shows-pages/_intent.md:69` — polling rationale (show dir size)
-- [ADR-0002](ADR-0002-studio-tech-stack.md) — FastAPI/Starlette stack this decision builds on
+| SSE for dashboard | Dashboard metrics are a snapshot, not an event stream; interval refresh is simpler |

--- a/docs/adrs/ADR-0006-sse-live-streaming.md
+++ b/docs/adrs/ADR-0006-sse-live-streaming.md
@@ -25,6 +25,8 @@ state but does not send commands. The backend is FastAPI / Starlette (ADR-0002).
 **SSE is the only push transport.** No WebSocket. The browser-to-server direction
 uses standard REST endpoints for any mutations (save definition, trigger run).
 
+Note: with shows structural state in SQLite (ADR-0011), the show stream can use `shows.updated_at` / `plays.updated_at` as a cursor instead of filesystem polling. Filesystem polling remains valid as a fallback for shows not yet imported to SQLite, or as a change trigger that causes a SQLite refetch.
+
 ### SSE implementation
 
 Starlette `StreamingResponse` with `text/event-stream` media type. Newline-delimited

--- a/docs/adrs/ADR-0008-studio-v1-scope.md
+++ b/docs/adrs/ADR-0008-studio-v1-scope.md
@@ -30,7 +30,7 @@ definitions, and debugging.
 | Capability | Why not | Where instead |
 |-----------|---------|---------------|
 | Run playbooks with parameters | CLI handles input binding, worktree setup, team coordination | `li play` |
-| Create agents from scratch | Primary authoring is text editor + CLI | `$EDITOR` + `li agent` |
+| Create agents from scratch (full authoring) | Full definition authoring is text editor + CLI; Studio scaffolding creates a skeleton file and opens it in the editor — see note below | `$EDITOR` + `li agent` |
 | Install/remove plugins | Claude Code manages plugin lifecycle | `claude plugin add/remove` |
 | Orchestrate shows | Show skill is a Claude Code agent skill | `/show topic` in Claude Code |
 | Authentication/RBAC | Localhost-only, single-user | Not needed |
@@ -43,6 +43,15 @@ The playbook detail page has a "Run" button — a convenience shortcut that shel
 out to the CLI with defaults. It is explicitly de-emphasized and does not support
 input binding, execution modes, or team configuration.
 
+### The "New Agent / New Playbook" scaffolding exception
+
+ADR-0014 introduces New Agent and New Playbook pages. These write a minimal
+skeleton file to `~/.lionagi/agents/` or `~/.lionagi/playbooks/` and immediately
+redirect to the editor view for that file. This is a convenience shortcut, not a
+full creation wizard. The scaffolding does not set provider, model, tools, or any
+runtime configuration — those are the user's responsibility in the editor. Full
+authoring from scratch remains the domain of `$EDITOR` + `li agent`.
+
 ### Write policy
 
 - **Writable**: agent definitions, playbook definitions (through definitions API
@@ -50,6 +59,17 @@ input binding, execution modes, or team configuration.
 - **Read-only**: plugin components (marketplace and third-party), skills, session
   data, show data, run data
 - **Import-only**: filesystem runs → SQLite sessions (via `li state import`)
+
+### Security posture
+
+- Binds to `127.0.0.1` only — never exposed to the network.
+- No CORS policy needed (same-origin: browser and server share localhost).
+- Definition writes are restricted to known config directories
+  (`~/.lionagi/agents/`, `~/.lionagi/playbooks/`); paths outside these roots
+  are rejected by the definitions API.
+- The Run button executes via `li play` — the same trust boundary as a terminal
+  command; no privilege escalation.
+- No authentication or RBAC: single-user, localhost workload.
 
 ## Consequences
 

--- a/docs/adrs/ADR-0008-studio-v1-scope.md
+++ b/docs/adrs/ADR-0008-studio-v1-scope.md
@@ -1,56 +1,75 @@
-# ADR-0008: Lion Studio v1 Scope — Read-Only, Single-Workspace, Internal
+# ADR-0008: Lion Studio Scope — CLI-Primary, Definition-Editable, Localhost
 
 **Status**: Accepted
-**Date**: 2026-05-19
+**Date**: 2026-05-19 (revised 2026-05-20)
 
 ## Context
 
-Lion Studio is a monitoring dashboard for lionagi runs, agents, playbooks, and shows. Before
-building the backend and frontend, the scope of v1 must be bounded to avoid scope creep and
-to make explicit what is NOT supported (so future PRs adding those capabilities do so knowingly).
+Lion Studio is a dashboard for observing, inspecting, editing, and debugging the
+lionagi runtime. Before building features, the scope must be bounded to prevent
+consumer-SaaS feature creep.
 
-Three boundary decisions were on the table: write operations, multi-workspace/multi-user support,
-and authentication. Each has implementation cost and risk disproportionate to v1 value.
+The governing principle is **CLI-primary, Studio-secondary** (ADR-0014): the CLI
+handles creation and execution; Studio handles observation, inspection, editing
+definitions, and debugging.
 
 ## Decision
 
-Lion Studio v1 is bounded as follows:
+### What Studio does
 
-- **Read-only**: All write endpoints (create, update, delete) are stubbed with HTTP 501. A
-  `# TODO(lift-backend-writes)` comment marks each stub for a future play.
-- **Single local workspace**: Data is read from the local machine's filesystem only
-  (`~/.lionagi/`, `~/khive-work/`). No remote backends, no multi-user routing.
-- **Internal**: Not published as a separate PyPI package or public service. Installed via
-  `pip install lionagi[studio]` only (see ADR-0001).
-- **No authentication**: The studio serves `localhost` only; authentication is explicitly out
-  of scope for v1.
+| Capability | Scope |
+|-----------|-------|
+| **Observe** | Dashboard metrics, session list, show progress, plugin catalog |
+| **Inspect** | Run detail with branches/messages/errors/files, show play details |
+| **Edit** | Agent definitions, playbook YAML — with version history and rollback |
+| **Debug** | Execution lineage drill-down: show → play → session → branch → messages |
+| **Browse** | Plugin/skill/agent catalog with source information and cross-links |
 
-Cross-project monitoring (lionagi issue #967) is a v2 concern.
+### What Studio does NOT do
+
+| Capability | Why not | Where instead |
+|-----------|---------|---------------|
+| Run playbooks with parameters | CLI handles input binding, worktree setup, team coordination | `li play` |
+| Create agents from scratch | Primary authoring is text editor + CLI | `$EDITOR` + `li agent` |
+| Install/remove plugins | Claude Code manages plugin lifecycle | `claude plugin add/remove` |
+| Orchestrate shows | Show skill is a Claude Code agent skill | `/show topic` in Claude Code |
+| Authentication/RBAC | Localhost-only, single-user | Not needed |
+| Multi-workspace/remote backends | Single local machine | Not needed |
+| Rich execution configuration | Parameters, team mode, worktree customization | CLI flags |
+
+### The "Run" button exception
+
+The playbook detail page has a "Run" button — a convenience shortcut that shells
+out to the CLI with defaults. It is explicitly de-emphasized and does not support
+input binding, execution modes, or team configuration.
+
+### Write policy
+
+- **Writable**: agent definitions, playbook definitions (through definitions API
+  with version history)
+- **Read-only**: plugin components (marketplace and third-party), skills, session
+  data, show data, run data
+- **Import-only**: filesystem runs → SQLite sessions (via `li state import`)
 
 ## Consequences
 
 **Positive**
-- 11 GET routes can ship in v1 without any mutation risk to user data.
-- No auth layer means no token management, session handling, or RBAC to implement or test.
-- Minimal operational surface: one uvicorn process, no credentials, no secrets.
+- Studio stays focused: observe + inspect + edit + debug.
+- No feature creep toward replicating CLI capabilities in the browser.
+- Simpler UI: no complex forms for run configuration.
+- The CLI evolves independently — new execution modes don't require Studio changes.
 
 **Negative**
-- Any future PR adding writes, auth, multi-workspace, or remote support MUST explicitly
-  acknowledge that it is changing the v1 scope decision captured here.
-- Write stubs (501) return an error to the client rather than silently ignoring mutations —
-  this is intentional, not a bug.
+- Collaborators who don't use the CLI cannot create or run things from Studio alone.
+- The Run button is a partial exception that may confuse expectations.
+- Some inspector features (e.g., "re-run this failed play") require switching to
+  the terminal.
 
 ## Alternatives Considered
 
 | Alternative | Why Rejected |
-|-------------|--------------|
-| Ship with stub authentication (e.g., static API key) | Premature; localhost-only workload needs no auth; adds config surface for no benefit |
-| Enable write endpoints behind a feature flag | Mutations without UX polish (confirmation dialogs, error handling) create data-loss risk; deferred until UX is validated |
-
-## References
-
-- `lift-backend/_intent.md:53-55` — write endpoint stub convention (`# TODO(lift-backend-writes)`) — verified against `feat/lion-studio-backend` router files
-- `add-shows-pages/_intent.md:50` — authentication explicitly out of scope
-- `lift-backend/lift_summary.md:83` — 11 GET routes implemented, 11 write endpoints stubbed (501)
-- [ADR-0004](ADR-0004-filesystem-data-layer.md) — filesystem data layer (enables single-workspace)
-- lionagi issue #967 — cross-project monitoring (v2)
+|-------------|-------------|
+| Full execution surface | Replicates CLI complexity; two execution surfaces means two places for bugs |
+| Read-only only (no editing) | Editing definitions with version history is genuinely useful |
+| Ship with auth | Localhost-only workload; adds config surface for no benefit |
+| Multi-workspace support | Single-user local tool; adds routing/state complexity for no benefit |

--- a/docs/adrs/ADR-0009-sqlite-state-layer.md
+++ b/docs/adrs/ADR-0009-sqlite-state-layer.md
@@ -1,0 +1,201 @@
+# ADR-0009: SQLite State Layer for Core Data Model
+
+**Status**: Accepted
+**Date**: 2026-05-20
+
+## Context
+
+Lion Studio's filesystem-only backend (ADR-0004) works for post-hoc review but
+cannot support live monitoring. A `li agent` run doesn't appear in the dashboard
+until after completion because `run.json` is written at the end. Polling the
+filesystem every 5 seconds gives no task/agent context for in-progress runs.
+
+Separately, lionagi's `Session` / `Branch` / `Message` / `Progression` data
+model needs a persistent representation that mirrors the runtime exactly, to
+support:
+
+1. Instantaneous monitoring via hooks + SSE push (not filesystem polling).
+2. Cross-session message exchange (replacing `li team`'s markdown-file
+   coordination with structured inbox/outbox).
+3. Branch forking and message sharing without content duplication.
+4. Vector similarity search on message embeddings.
+
+aiosqlite is already an optional dependency (`lionagi[sqlite]`).
+
+## Decision
+
+Introduce `~/.lionagi/state.db` (SQLite, WAL mode) with four core tables that
+map 1:1 to lionagi's runtime data model.  The schema lives at
+`lionagi/state/schema.sql`.
+
+### Data model — four tables
+
+**`messages`** — Atomic content.  Independent entities referenced by
+progressions, not owned by a branch or session.  Fields match
+`Message.model_dump()`:
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | TEXT PK | Message UUID |
+| `created_at` | REAL | unix timestamp |
+| `node_metadata` | JSON | `{lion_class: ...}`; renamed from runtime `metadata` to avoid SQL collision |
+| `content` | JSON | shape varies by message type |
+| `embedding` | BLOB | packed float32 vector; sqlite-vec indexes these when available |
+| `sender` | TEXT | UUID of branch/session/external |
+| `recipient` | TEXT | UUID for exchange routing |
+| `channel` | TEXT | named channel |
+| `role` | TEXT | `user`, `assistant`, `system`, `tool`, ... |
+| `lion_class` | INTEGER FK | references `message_types(type_id)` — int enum for space efficiency |
+
+**`message_types`** — lookup table mapping integer to full Python class path:
+
+| type_id | lion_class |
+|---------|-----------|
+| 1 | `lionagi.protocols.messages.system.System` |
+| 2 | `lionagi.protocols.messages.instruction.Instruction` |
+| 3 | `lionagi.protocols.messages.assistant_response.AssistantResponse` |
+| 4 | `lionagi.protocols.messages.action_request.ActionRequest` |
+| 5 | `lionagi.protocols.messages.action_response.ActionResponse` |
+
+**`progressions`** — `Progression[Message]`.  An ordered sequence of message
+IDs stored as a JSON array in `collection`.  Both sessions and branches own a
+progression.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | TEXT PK | Progression UUID |
+| `created_at` | REAL | |
+| `collection` | TEXT | JSON array of message id strings, ordered |
+
+**`sessions`** — The scope boundary.  A session owns a progression (the
+session-level message pool) and zero or more branches.  Maps 1:1 to
+`lionagi.session.Session`.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | TEXT PK | Session UUID |
+| `created_at` | REAL | |
+| `node_metadata` | JSON | |
+| `name` | TEXT | |
+| `user` | TEXT | |
+| `progression_id` | TEXT FK | session's message pool ordering |
+| `first_msg_id` | TEXT FK | convenience bookmark |
+| `last_msg_id` | TEXT FK | convenience bookmark |
+| `updated_at` | REAL | |
+
+Session is the **substrate**, not the invocation. Heavy run-level concerns
+(full manifest, cwd, provider, model, detailed lifecycle) are NOT on the
+session table. However, minimal provenance columns (`playbook_name`,
+`invocation_kind`, `show_topic`, `show_play_name`, `agent_name`,
+`artifacts_path`, `source_kind`) are added to sessions for execution lineage
+queries (see ADR-0012). These are lightweight hints for display and filtering,
+not authoritative execution state.
+
+**`branches`** — A progression with identity.  A branch IS a progression (an
+ordered cursor over the session's messages) with attached agent configuration.
+Branch config (provider, model, system_prompt, tools, effort) lives in
+`node_metadata` JSON.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | TEXT PK | Branch UUID |
+| `created_at` | REAL | |
+| `node_metadata` | JSON | agent config lives here |
+| `user` | TEXT | |
+| `name` | TEXT | |
+| `session_id` | TEXT FK | owning session |
+| `progression_id` | TEXT FK | branch's message ordering |
+
+### Key design decisions
+
+**1. Fork model: tree pointers, no message duplication.**
+A fork records `parent_branch_id` + `forked_at_ord` on the new branch.  Full
+history is reconstructed by walking up the ancestry tree.  Fork cost is one
+INSERT.  Messages are never copied.
+
+**2. No join table for branch→message ordering.**
+The progression's `collection` JSON array holds the ordered list of message IDs.
+At our scale (< 500 messages per branch), JSON append is fast and avoids an
+extra table.  The trade-off: no SQL-level reverse index ("which progressions
+contain message X?").  If needed later, a join table can be derived from the
+JSON arrays.
+
+**3. `node_metadata` instead of `metadata`.**
+The runtime field is `metadata` but `METADATA` is reserved in some SQL contexts.
+`Element.to_dict(mode="db")` renames it to `node_metadata` automatically
+(commit 7ac31109).
+
+**4. `lion_class` as integer enum.**
+Full class paths like `lionagi.protocols.messages.instruction.Instruction` are
+~60 bytes per row.  The `message_types` lookup table maps them to 4-byte
+integers.  New message types get the next ID on INSERT.
+
+**5. Embedding as BLOB, not TEXT.**
+Packed float32 vectors are compact and ready for sqlite-vec virtual table
+indexing.  The vec extension is optional — the core schema is plain SQLite.
+
+**6. Agent and playbook definitions stay as files.**
+`~/.lionagi/agents/*.md` and `~/.lionagi/playbooks/*.yaml` remain the source of
+truth.  They are the contract with external tools (Claude Code, codex CLI, vim,
+grep, git, symlinks).  ADR-0004 remains valid for these.
+
+### Supporting code changes (same session)
+
+**`Branch.to_dict()` streamlined** (commits 7ac31109, a36b5542):
+- Added `mode` parameter: `"python"` (default), `"json"`, `"db"`.
+- `mode="db"` renames `metadata` → `node_metadata`.
+- Optional flags: `include_logs`, `include_log_config`,
+  `include_processor_config`, `include_request_options`.
+- Metadata serializer handles `clone_from` branch references.
+- `parse_model` only included when it differs from `chat_model`.
+
+**`create_message()` extracted** (commit 8f6c6d94):
+- `MessageManager.create_message()` is now a `@staticmethod` — can be used
+  without a MessageManager instance.
+- Standalone `create_message()` function exported from
+  `lionagi.protocols.messages` and `lionagi.__init__`.
+- `add_message()` delegates to `create_message()` then handles progression
+  insertion and system message replacement.
+
+**`iModel.to_dict()` slimmed** (commits 7ac31109, a36b5542):
+- `request_options` excluded by default (bulk, not useful for persistence).
+- `processor_config` excluded by default.
+
+## Consequences
+
+**Positive**
+- Session/branch/message model has a persistent representation that mirrors the
+  runtime 1:1. Round-trip `to_dict(mode="db")` → INSERT → SELECT → `from_dict()`
+  is lossless.
+- Foundation for live monitoring (hooks → DB INSERT → SSE push) without
+  filesystem polling.
+- Foundation for cross-session message exchange (structured inbox/outbox via
+  recipient/sender fields + progression cursors).
+- Branch forking is O(1) with zero message duplication.
+- sqlite-vec ready for semantic search on message embeddings.
+- Agent/playbook file-based contract preserved.
+
+**Negative**
+- New dependency path: `lionagi[sqlite]` required for the state layer.
+- JSON array for progression ordering limits query-side operations (no
+  `WHERE message_id IN progression` without JSON parsing).
+- Schema migrations will be needed as the model evolves.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Keep filesystem only (ADR-0004) | Cannot support live monitoring, cross-session exchange, or structured queries |
+| khive as backend | Adds service dependency; lionagi should work standalone without a running server |
+| Join table for progression ordering | Extra table + extra rows; JSON array is sufficient at current scale |
+| Full class path string for lion_class | 60 bytes/row waste; int enum is 4 bytes |
+| TEXT for embeddings | Wastes space; BLOB is compact and sqlite-vec compatible |
+| Heavy run-level fields (full manifest, cwd, provider) on session | Session is substrate, not invocation; keep provenance lightweight (ADR-0012 adds minimal hints only) |
+
+## References
+
+- `lionagi/state/schema.sql` — the schema
+- `lionagi/protocols/generic/element.py` — `to_dict(mode="db")` rename
+- `lionagi/session/branch.py` — `to_dict()` streamlined serialization
+- `lionagi/protocols/messages/manager.py` — `create_message()` extraction
+- [ADR-0004](ADR-0004-filesystem-data-layer.md) — predecessor (still valid for agent/playbook files)

--- a/docs/adrs/ADR-0009-sqlite-state-layer.md
+++ b/docs/adrs/ADR-0009-sqlite-state-layer.md
@@ -90,8 +90,9 @@ session-level message pool) and zero or more branches.  Maps 1:1 to
 > hints for display and filtering — they are not authoritative execution state.
 
 Session is the **substrate**, not the invocation. Heavy run-level concerns
-(full manifest, cwd, provider, model, detailed lifecycle) are NOT on the
-session table. However, minimal provenance columns (`playbook_name`,
+(full manifest, cwd, provider, model, play-level lifecycle) are NOT on the
+session table. Minimal lifecycle columns (`status`, `started_at`, `ended_at`)
+are added by ADR-0017's v3→v4 migration for dashboard and runs-list queries. However, minimal provenance columns (`playbook_name`,
 `invocation_kind`, `show_topic`, `show_play_name`, `agent_name`,
 `artifacts_path`, `source_kind`) are added to sessions for execution lineage
 queries (see ADR-0012). These are lightweight hints for display and filtering,

--- a/docs/adrs/ADR-0009-sqlite-state-layer.md
+++ b/docs/adrs/ADR-0009-sqlite-state-layer.md
@@ -83,6 +83,12 @@ session-level message pool) and zero or more branches.  Maps 1:1 to
 | `last_msg_id` | TEXT FK | convenience bookmark |
 | `updated_at` | REAL | |
 
+> **Provenance columns (migration v2→v3):** `playbook_name`, `agent_name`,
+> `invocation_kind`, `show_topic`, `show_play_name`, `artifacts_path`, and
+> `source_kind` are added to the sessions table by the v2→v3 migration. See
+> ADR-0012 for the enrichment decision. These columns are nullable lightweight
+> hints for display and filtering — they are not authoritative execution state.
+
 Session is the **substrate**, not the invocation. Heavy run-level concerns
 (full manifest, cwd, provider, model, detailed lifecycle) are NOT on the
 session table. However, minimal provenance columns (`playbook_name`,
@@ -105,6 +111,11 @@ Branch config (provider, model, system_prompt, tools, effort) lives in
 | `name` | TEXT | |
 | `session_id` | TEXT FK | owning session |
 | `progression_id` | TEXT FK | branch's message ordering |
+
+> **Fork columns:** `parent_branch_id` (TEXT) and `forked_at_ord` (INTEGER) are
+> stored in `node_metadata` JSON on the branch row, not as top-level columns. A
+> dedicated branch fork protocol may promote these to first-class columns in a
+> future migration if query patterns require it.
 
 ### Key design decisions
 
@@ -179,7 +190,12 @@ grep, git, symlinks).  ADR-0004 remains valid for these.
 - New dependency path: `lionagi[sqlite]` required for the state layer.
 - JSON array for progression ordering limits query-side operations (no
   `WHERE message_id IN progression` without JSON parsing).
-- Schema migrations will be needed as the model evolves.
+- Schema migrations will be needed as the model evolves. **Migration protocol:**
+  a `schema_meta` table tracks the current version number. Migrations run
+  sequentially on database open (v1→v2, v2→v3, etc.). Each migration step is
+  idempotent — uses the `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` / try-except
+  pattern so re-runs are safe. The `db.py _migrate()` method is the canonical
+  migration runner.
 
 ## Alternatives Considered
 

--- a/docs/adrs/ADR-0010-plugin-aware-studio.md
+++ b/docs/adrs/ADR-0010-plugin-aware-studio.md
@@ -1,0 +1,155 @@
+# ADR-0010: Plugin-Aware Studio UI
+
+**Status**: Accepted
+**Date**: 2026-05-20
+**Extends**: ADR-0003 (marketplace), ADR-0007 (auto-discovery), ADR-0009 (SQLite state layer)
+
+## Context
+
+Lion Studio currently presents skills, agents, and playbooks as flat lists scanned
+from `~/.lionagi/{skills,agents,playbooks}/`. This ignores the plugin structure
+established in ADR-0003: nine marketplace plugins at `marketplace/` already group
+skills and agents by capability domain (devx, show, orchestrate, etc.).
+
+The Skills page (62 skills) has no grouping — users see `commit`, `fmt`, `ci` next
+to `flow-it`, `reprompt`, `write-playbook` with no indication they belong to
+different plugins. Agent and skill definitions are versioned through the definitions
+API (ADR-0009) but not associated with their parent plugin.
+
+Claude Code's plugin format provides a standard packaging unit: `plugin.json`
+manifest + `skills/`, `agents/`, `hooks/`, `.mcp.json`, `output-styles/`,
+`monitors/`, `themes/`, `bin/`, `settings.json`. Studio should present this
+structure faithfully — it becomes the visual management layer for what CC loads.
+
+## Decision
+
+### 1. Plugin discovery backend (`services/plugins.py`)
+
+A new service scans two locations for plugins:
+
+| Source | Path | Writeable |
+|--------|------|-----------|
+| Marketplace | `{LIONAGI_HOME}/../marketplace/` (repo-relative) | Yes |
+| Third-party | `~/.claude/plugins/cache/*/*/` | No (read-only) |
+
+For each plugin directory, the service:
+- Reads `.claude-plugin/plugin.json` for metadata (name, version, description)
+- Falls back to directory name if no manifest exists
+- Enumerates `skills/*/SKILL.md`, `agents/*.md`, `hooks/hooks.json`, `.mcp.json`
+- Returns component counts and lists per plugin
+
+The marketplace manifest (`.claude-plugin/marketplace.json`) provides the canonical
+list for repo plugins. Third-party plugins are discovered by directory scan.
+
+### 2. API surface
+
+```
+GET  /api/plugins/              → list all plugins with component counts
+GET  /api/plugins/{name}        → plugin detail: metadata + component lists
+GET  /api/plugins/{name}/skills/{skill}  → skill content (read-only)
+GET  /api/plugins/{name}/agents/{agent}  → agent content (read-only view; editing via Agents page)
+```
+
+The existing `/api/skills/`, `/api/agents/`, and `/api/definitions/` endpoints
+remain — the plugins API is the grouping/browsing layer, not an editing surface.
+
+### 3. Frontend: Plugins replaces Skills in nav
+
+Navigation changes from `Playbooks | Agents | Skills | Runs | Shows` to
+`Playbooks | Agents | Plugins | Shows | Runs`.
+
+**Plugin list page**: cards showing name, description, source badge (marketplace
+name or `Lion Marketplace`), component counts (N skills, M agents).
+
+**Plugin detail page**: tabbed layout:
+- **Skills** tab: two-pane list+detail, read-only SKILL.md viewer
+- **Agents** tab: agent names/descriptions with `Open in Agents →` cross-links
+- **Hooks** tab: `hooks.json` viewer (read-only)
+- **MCP** tab: `.mcp.json` viewer (read-only)
+- **README** tab: rendered markdown (proportional font for prose)
+
+### Editability matrix
+
+| Component | Source | Editable in Studio? | Where? |
+|-----------|--------|-------------------|--------|
+| Marketplace agent definition | `marketplace/*/agents/*.md` | Yes | Agents page (definitions API) |
+| Marketplace playbook | `marketplace/*/playbooks/*.yaml` | Yes | Playbooks page (definitions API) |
+| Marketplace skill | `marketplace/*/skills/*/SKILL.md` | No | Read-only in Plugins; edit in text editor |
+| Third-party plugin (any component) | `~/.claude/plugins/cache/` | No | Read-only everywhere |
+| Hooks, MCP config | Plugin dirs | No | Read-only; managed by Claude Code |
+
+Skills are **not** editable through the definitions API. They are Claude Code
+skill instructions, not lionagi definitions. The Plugins page is a read-only
+browser with cross-links to editable surfaces (Agents, Playbooks).
+
+### 4. Third-party plugins are read-only
+
+Plugins from `~/.claude/plugins/cache/` are displayed but not editable. The cache
+is managed by Claude Code's `plugin add/remove` commands. Studio surfaces them for
+visibility, not management.
+
+### 5. Cross-links and source badges (added post-review)
+
+Plugin components need explicit navigation to their editable counterparts and
+clear source/editability indicators:
+
+**Cross-links from plugin detail tabs**:
+- Agent tab: `Open in Agents →` link per agent (routes to `/agents/{name}`)
+- Skill tab: `View source` link, `Copy path` action
+- All tabs: `Open raw` for filesystem path
+
+**Source badges on plugin list and detail**:
+| Badge | Meaning |
+|-------|---------|
+| `Marketplace` | From `marketplace/`, writable |
+| `Third-party` | From `~/.claude/plugins/cache/`, read-only |
+| `Versioned` | Definition tracked in definitions API (agents, playbooks) |
+| `Read-only` | Filesystem artifact, not version-tracked |
+
+**Empty plugin stubs** (0 skills, 0 agents) are de-emphasized — muted row
+treatment, grouped under "Scaffolded" section — but not hidden, since hiding
+them complicates plugin discovery debugging.
+
+**Skill search**: Add a filter input inside the selected plugin's Skills tab,
+not just the plugin-level filter.
+
+**Markdown rendering**: README and skill docs render prose in proportional
+font with code fences in monospace, not the current all-monospace treatment.
+
+### 6. Deferred: CLI sync, monitors, themes, LSP
+
+These are not part of this ADR:
+- `li plugin sync` CLI (marketplace → CC plugin install) — separate feature
+- Monitors, themes, LSP components — surface in Studio when usage warrants
+- Model-agnostic abstraction — current format is CC-native; abstract later
+
+## Consequences
+
+**Positive**
+- Skills and agents gain context: users see which plugin provides each capability.
+- Editing flows through existing definitions versioning — no new persistence layer.
+- Third-party plugin visibility without management complexity.
+- Direct alignment with CC's plugin model — what you see in Studio is what CC loads.
+
+**Negative**
+- Plugin discovery adds startup scan cost (~50ms for 9 plugins, negligible).
+- Two navigation paths to the same skill (Plugins → devx → commit vs. direct URL).
+- `plugin.json` may not exist for all marketplace plugins yet — fallback to dir name.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|-------------|
+| Keep Skills as top-level, add plugin grouping filter | Doesn't surface the plugin concept; users still think in flat lists |
+| Replace both Skills and Agents nav with Plugins | Agents page has profile editing that doesn't map cleanly to plugin context; keep separate |
+| Add plugin management (install/remove/update) | Scope creep — CC handles lifecycle; Studio is the viewer/editor |
+
+## Implementation
+
+Two parallel agents:
+
+1. **Backend**: `services/plugins.py` + `routers/plugins.py` — plugin scanner, API endpoints
+2. **Frontend**: `/plugins` page (list + detail with tabs), Shell nav update, API client types
+
+Both build on existing patterns: `services/skills.py` for scanning, `app/agents/page.tsx`
+for two-pane layout, `lib/api.ts` for type-safe fetch wrappers.

--- a/docs/adrs/ADR-0010-plugin-aware-studio.md
+++ b/docs/adrs/ADR-0010-plugin-aware-studio.md
@@ -13,8 +13,8 @@ skills and agents by capability domain (devx, show, orchestrate, etc.).
 
 The Skills page (62 skills) has no grouping — users see `commit`, `fmt`, `ci` next
 to `flow-it`, `reprompt`, `write-playbook` with no indication they belong to
-different plugins. Agent and skill definitions are versioned through the definitions
-API (ADR-0009) but not associated with their parent plugin.
+different plugins. Agent and playbook definitions are versioned through the definitions
+API (ADR-0016) but not associated with their parent plugin.
 
 Claude Code's plugin format provides a standard packaging unit: `plugin.json`
 manifest + `skills/`, `agents/`, `hooks/`, `.mcp.json`, `output-styles/`,
@@ -101,8 +101,8 @@ clear source/editability indicators:
 **Source badges on plugin list and detail**:
 | Badge | Meaning |
 |-------|---------|
-| `Marketplace` | From `marketplace/`, writable |
-| `Third-party` | From `~/.claude/plugins/cache/`, read-only |
+| `Lion Marketplace` | From `marketplace/`, writable |
+| `{marketplace name}` | From third-party cache, title-cased directory name (e.g., `Anthropic Official`, `khive`). Read-only |
 | `Versioned` | Definition tracked in definitions API (agents, playbooks) |
 | `Read-only` | Filesystem artifact, not version-tracked |
 

--- a/docs/adrs/ADR-0011-shows-data-model.md
+++ b/docs/adrs/ADR-0011-shows-data-model.md
@@ -1,0 +1,277 @@
+# ADR-0011: Shows Data Model — Hybrid SQLite + Filesystem
+
+**Status**: Accepted
+**Date**: 2026-05-20
+**Extends**: ADR-0009 (SQLite state layer), ADR-0010 (plugin-aware Studio)
+
+## Context
+
+Shows (multi-play DAGs orchestrated by the `show` skill) currently exist only
+as filesystem trees under `~/khive-work/shows/{topic}/`. Each play writes
+`_meta.json`, `_verdict.json`, `_intent.md`, `_prompt.md`, and agent artifacts.
+Studio reads these files on every request.
+
+This creates three problems:
+
+1. **No cross-reference to sessions.** Each play IS a `li play` invocation that
+   creates a session in SQLite (via ADR-0009 hooks). But nothing links the show
+   DAG to those sessions. You can't drill from show → play → session → messages.
+
+2. **No query performance.** Listing shows requires `readdir` + parsing N JSON
+   files per show. With 2 shows × 12 plays average, this is ~24 file reads per
+   list request. Scales poorly.
+
+3. **No structural queries.** "Which plays are blocked?" "What's the critical
+   path?" "Show me all escalated plays across all shows" — impossible without
+   loading everything into memory.
+
+Meanwhile, the long-form content (`_show.md`, `_intent.md`, `_prompt.md`) is
+authored markdown that belongs on disk — it's edited by the director mid-show,
+versioned by git, and doesn't benefit from being in a database column.
+
+## Decision
+
+Add two tables to `~/.lionagi/state.db` for show-level orchestration state.
+Filesystem remains source of truth for markdown content; SQLite stores
+structural/status data and the critical `session_id` foreign key.
+
+### Schema
+
+```sql
+-- ── Shows ────────────────────────────────────────────────────────────────
+-- One row per show (multi-play DAG).
+
+CREATE TABLE IF NOT EXISTS shows (
+  id                  TEXT    PRIMARY KEY,
+  topic               TEXT    NOT NULL UNIQUE,
+  goal                TEXT,                       -- one-line summary from _show.md
+  repo                TEXT,                       -- absolute path to repo
+  base_branch         TEXT,                       -- e.g. 'main'
+  integration_branch  TEXT,                       -- e.g. 'show/topic/integration'
+  status              TEXT    NOT NULL DEFAULT 'active',  -- active|completed|aborted
+  show_dir            TEXT    NOT NULL,           -- absolute path to show directory
+  created_at          REAL    NOT NULL,
+  updated_at          REAL    NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_shows_topic ON shows(topic);
+CREATE INDEX IF NOT EXISTS idx_shows_status ON shows(status);
+CREATE INDEX IF NOT EXISTS idx_shows_updated ON shows(updated_at DESC);
+
+-- ── Plays ────────────────────────────────────────────────────────────────
+-- One row per play within a show. Links to sessions table via session_id.
+
+CREATE TABLE IF NOT EXISTS plays (
+  id              TEXT    PRIMARY KEY,
+  show_id         TEXT    NOT NULL REFERENCES shows(id) ON DELETE CASCADE,
+  name            TEXT    NOT NULL,
+  playbook        TEXT,                           -- which playbook was used
+  effort          TEXT,                           -- low|medium|high|xhigh
+  status          TEXT    NOT NULL DEFAULT 'pending',
+                  -- pending|prepared|running|running_complete|
+                  -- gated|gate_failed|redoing|merged|escalated|
+                  -- blocked|aborted_after_finish
+  attempt         INTEGER NOT NULL DEFAULT 1,
+  session_id      TEXT    REFERENCES sessions(id), -- THE KEY LINK
+  started_at      REAL,
+  ended_at        REAL,
+  exit_code       INTEGER,
+  worktree        TEXT,                           -- absolute path
+  branch          TEXT,                           -- git branch name
+  merge_sha       TEXT,
+  merged_at       REAL,
+  gate_passed     INTEGER,                        -- 0|1|NULL (not yet gated)
+  gate_feedback   TEXT,                           -- from _verdict.json
+  depends_on      JSON    DEFAULT '[]',           -- array of play names
+  sort_order      INTEGER NOT NULL DEFAULT 0,
+  created_at      REAL    NOT NULL,
+  updated_at      REAL    NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_plays_show ON plays(show_id);
+CREATE INDEX IF NOT EXISTS idx_plays_status ON plays(status);
+CREATE INDEX IF NOT EXISTS idx_plays_session ON plays(session_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_plays_show_name ON plays(show_id, name);
+```
+
+### What lives where
+
+| Data | Location | Why |
+|------|----------|-----|
+| Show goal summary, status, timestamps | SQLite `shows` | Queryable, fast list |
+| Play status, attempt, exit_code, gate result | SQLite `plays` | Queryable, cross-ref to sessions |
+| `plays.session_id` → `sessions.id` | SQLite FK | **Drill-down**: show → play → session → branches → messages |
+| `_show.md` (full plan, decisions log) | Filesystem | Long-form markdown, git-versioned, edited mid-show |
+| `_intent.md`, `_prompt.md` | Filesystem | Authored content, not status |
+| `_verdict.json` (full) | Filesystem | Gate feedback archived on disk; summary in `gate_feedback` column |
+| Agent artifacts (`{play}/{agent_id}/*`) | Filesystem | Binary/large files, git-tracked |
+
+### Write path
+
+The show skill's existing Steps already write `_meta.json` at lifecycle
+transitions (Step 0, 3, 4, 5). Each write point also upserts the SQLite row:
+
+| Show skill step | Filesystem write | SQLite write |
+|-----------------|-----------------|--------------|
+| Step 0 (plan) | `_show.md` | INSERT `shows` row |
+| Step 2 (worktree) | `_meta.json` {status:pending} | INSERT `plays` row |
+| Step 3 (fire) | `_meta.json` {status:running} | UPDATE `plays` status, started_at |
+| Step 3 (complete) | `_meta.json` {exit_code, ended_at} | UPDATE `plays` exit_code, ended_at, session_id |
+| Step 4 (gate) | `_verdict.json` | UPDATE `plays` gate_passed, gate_feedback |
+| Step 5a (merge) | `_meta.json` {merged_at, merge_sha} | UPDATE `plays` merged_at, merge_sha, status=merged |
+| Step 5b (redo) | `_meta.json` {attempt:2} | UPDATE `plays` attempt, status=redoing |
+| Step 5c (escalate) | `_meta.json` {status:escalated} | UPDATE `plays` status=escalated |
+| Step 7 (final gate) | `_final_verdict.json` | UPDATE `shows` status=completed\|aborted |
+
+### session_id resolution
+
+When a play fires via `li play ... --team-mode show_topic_play`, the session
+created by `li play` gets a deterministic name: `show_{topic}_{play}`. After
+the play subprocess exits, the director queries:
+
+```sql
+SELECT id FROM sessions WHERE name = ? ORDER BY created_at DESC LIMIT 1
+```
+
+This links the play row to the session. From there, the full message tree is
+accessible: `plays.session_id` → `sessions` → `branches` → `progressions` →
+`messages`.
+
+### Read path (Studio API)
+
+```
+GET /api/shows/           → SELECT from shows table (fast, no filesystem)
+GET /api/shows/{topic}    → shows row + plays rows + _show.md from disk
+GET /api/shows/{topic}/plays/{name}
+                          → play row + _intent.md + _verdict.json from disk
+                          → play.session_id for drill-down link to /runs/{session_id}
+```
+
+### Migration: `li state import-shows`
+
+One-time import of existing filesystem shows into SQLite:
+
+```python
+for show_dir in SHOWS_ROOT.iterdir():
+    # Parse _show.md for goal (first paragraph under ## Goal)
+    # Insert shows row
+    for play_dir in show_dir subdirs:
+        # Parse _meta.json → plays row
+        # Parse _verdict.json → gate_passed, gate_feedback
+        # Resolve session_id by name lookup
+        # Insert plays row
+```
+
+### Play detail accordion and session drill-down
+
+The `plays.session_id` FK enables the most important UI connection. The
+shows detail page surfaces this via **inline accordion** (not a drawer —
+a drawer competes with the DAG for horizontal space):
+
+1. **Play row click** expands the row vertically to show:
+   - Session link: `Open Session →` routes to `/runs/{session_id}` (first element)
+   - Intent (`_intent.md`)
+   - Duration, exit code, attempt count
+   - Gate verdict and feedback
+   - Raw data (meta JSON, verdict JSON) collapsed by default
+
+2. **Play DAG node click** scrolls to and expands the corresponding play row.
+
+3. **Reverse lookup**: run detail page queries
+   `SELECT show_id, name FROM plays WHERE session_id = ?` to show a
+   "Source: Show {topic} / Play {name}" backlink in the Overview section.
+
+Note: the UI route is `/runs/{session_id}` (user-facing "Runs" label per
+ADR-0012), not `/sessions/{session_id}`.
+
+### Play status display: structured multi-badge State cell
+
+The plays table uses a single **State** column with a primary lifecycle pill
+plus optional secondary badges for gate and integration:
+
+```
+[completed] [passed] [merged]      ← full provenance
+[completed]                        ← no gate, no merge
+[awaiting gate]                    ← running_complete
+[pending]                          ← no activity yet
+[failed] [gate failed]             ← gate rejection
+```
+
+This avoids three separate columns (too wide for the dense table) and avoids
+a single compound pill (hard to scan because dimensions aren't visually
+separable).
+
+**Badge colors**:
+- Lifecycle: pending (amber), running (blue), awaiting_gate (amber),
+  completed (green), failed (red), aborted (gray)
+- Gate: passed (green outline), failed (red outline), skipped (gray outline)
+- Integration: merged (green outline), local (gray outline)
+
+Raw status appears in expanded accordion details and tooltips.
+
+The raw `plays.status` values (`running_complete`, `gated`, `gate_failed`,
+`redoing`, `escalated`, `blocked`, `aborted_after_finish`) map to normalized
+lifecycle + gate + review badges per ADR-0012's status vocabulary.
+
+### PlayDag placement: compact strip above plays table
+
+The PlayDag renders as a **compact dependency graph strip above the plays
+table**, not a competing primary view:
+
+```
+Dependency graph                                        [Hide graph]
+┌────────────────────────────────────────────────────────────────────┐
+│  compact PlayDag, fitView, 150–170px tall                          │
+│  node hover → highlight table row                                  │
+│  row hover → highlight graph node                                  │
+│  node click → scroll to and expand play row                        │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+Height scales with play count:
+- ≤4 plays: 112px
+- 5–20 plays: 160px
+- 21+ plays: 220px with scroll/pan
+
+The graph is visible by default (not behind a toggle) because it is the only
+visual representation of dependency structure. Hiding it collapses shows into
+a plain status table and loses the orchestration identity of the page.
+
+### Show status provenance (added post-review)
+
+Show status includes provenance to address trust concerns:
+- `active` — at least one play running or pending
+- `completed` — all plays merged and final gate passed (or inferred from filesystem)
+- `aborted` — `_ABORT` file exists
+- `imported` — status inferred during `import_shows`, may not reflect `_show.md` decisions log
+
+The API includes `status_source: "sqlite" | "filesystem" | "imported"` to
+indicate confidence level.
+
+## Consequences
+
+**Positive**
+- Show → play → session → message drill-down via foreign keys.
+- Fast list/filter queries without filesystem scanning.
+- Structural queries: blocked plays, critical path, cross-show stats.
+- Filesystem content unchanged — git workflow, director editing, resume
+  protocol all work identically.
+- Play inline accordion provides full context without leaving the shows page.
+- Status normalization eliminates contradictory displays across pages.
+
+**Negative**
+- Dual write: every `_meta.json` update must also update SQLite. If the
+  show skill crashes between writes, they can drift. Mitigation: the
+  `li state import-shows` command can re-sync from filesystem at any time.
+- Schema migration: existing `state.db` instances need ALTER TABLE or
+  recreation. Use schema_meta version bump (1 → 2) with migration.
+- Status mapping adds a translation layer between raw play statuses and
+  normalized display vocabulary.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|-------------|
+| Pure filesystem (status quo) | No session cross-reference, no query performance, no structural queries |
+| Full SQLite (move all content to DB) | `_show.md` and `_intent.md` are authored markdown — git versioning and editor access matter more than query performance on content |
+| Separate shows.db | Unnecessary complexity — `state.db` already exists and the FK to sessions is the whole point |

--- a/docs/adrs/ADR-0011-shows-data-model.md
+++ b/docs/adrs/ADR-0011-shows-data-model.md
@@ -48,7 +48,8 @@ CREATE TABLE IF NOT EXISTS shows (
   repo                TEXT,                       -- absolute path to repo
   base_branch         TEXT,                       -- e.g. 'main'
   integration_branch  TEXT,                       -- e.g. 'show/topic/integration'
-  status              TEXT    NOT NULL DEFAULT 'active',  -- active|completed|aborted
+  status              TEXT    NOT NULL DEFAULT 'active',  -- active|completed|aborted|imported
+  status_source       TEXT,                       -- sqlite|filesystem|imported (confidence indicator)
   show_dir            TEXT    NOT NULL,           -- absolute path to show directory
   created_at          REAL    NOT NULL,
   updated_at          REAL    NOT NULL

--- a/docs/adrs/ADR-0012-studio-execution-lineage.md
+++ b/docs/adrs/ADR-0012-studio-execution-lineage.md
@@ -275,7 +275,8 @@ Other improvements:
 
 ## Implementation Phases
 
-**Done** (implemented in this session):
+**Phase 0 — Prerequisites** (implemented on `feat/studio-monitoring-polish`,
+pending merge):
 - Session schema enrichment + provenance columns (v2→v3 migration)
 - Show → Session drill-down (play accordion with session links)
 - Run detail anchored sections (Overview, Tool errors, Branches, Files)

--- a/docs/adrs/ADR-0012-studio-execution-lineage.md
+++ b/docs/adrs/ADR-0012-studio-execution-lineage.md
@@ -1,0 +1,344 @@
+# ADR-0012: Studio Execution Lineage & UX Redesign
+
+**Status**: Accepted
+**Date**: 2026-05-20
+**Extends**: ADR-0009 (SQLite state layer), ADR-0010 (plugins), ADR-0011 (shows data model)
+
+## Context
+
+Lion Studio does not have a UI naming problem. It has an **execution data-contract
+problem**. Users can see playbooks, agents, plugins, runs, and shows as isolated
+pages, but the causal chain between them is not surfaced:
+
+```
+Playbook / Agent → Show Play → Session → Branch → Messages / Tool Calls → Artifacts
+```
+
+Three rounds of design review (initial assessment, developer counterpoint, synthesis)
+converged on these findings:
+
+1. The app has two disconnected persistence layers: filesystem runs (549) and SQLite
+   sessions (376). They overlap partially, use different schemas, and are queried by
+   different pages. The dashboard counts filesystem runs; the list page shows sessions.
+2. Show plays have `session_id` in the database but the frontend ignores it entirely.
+3. Sessions do not store which playbook, show, or agent spawned them.
+4. Status vocabulary is inconsistent across pages (`Run complete`, `Merged + pushed`,
+   `completed`, `running_complete`).
+5. `ExecutionDag.tsx` (step-level execution graph) is disconnected — exists but not
+   imported anywhere.
+6. The run detail page has no structural organization — flat branch/message scroll.
+
+## Decision
+
+### 1. SQLite as canonical query layer; enrich sessions
+
+SQLite becomes the canonical source for all execution queries. Filesystem runs
+(`~/.lionagi/runs/`) become a legacy import source, not a query target.
+
+**Do not create a separate `executions` table.** At 376 sessions and 2 shows, an
+extra abstraction layer adds migration/API/query overhead without solving an
+immediate problem. Instead, enrich the `sessions` table with provenance columns:
+
+```sql
+ALTER TABLE sessions ADD COLUMN playbook_name  TEXT;
+ALTER TABLE sessions ADD COLUMN agent_name     TEXT;  -- agent/role that ran (e.g., "architect", "analyst")
+ALTER TABLE sessions ADD COLUMN invocation_kind TEXT;  -- agent|play|flow|fanout|show-play
+ALTER TABLE sessions ADD COLUMN show_topic     TEXT;
+ALTER TABLE sessions ADD COLUMN show_play_name TEXT;
+ALTER TABLE sessions ADD COLUMN artifacts_path TEXT;
+ALTER TABLE sessions ADD COLUMN source_kind    TEXT DEFAULT 'live';  -- live|imported_fs
+```
+
+The filesystem runs import (`li state import`) writes enriched session rows with
+these fields populated. Future CLI invocations (`li play`, `li agent`, `li o flow`)
+write provenance at session creation time.
+
+If the sessions table becomes unwieldy later, extracting an `executions` layer from
+enriched sessions is straightforward. Going the other direction is harder.
+
+### 2. Navigation: keep "Runs", reorder, no Dashboard item
+
+```
+Playbooks | Agents | Plugins | Shows | Runs
+```
+
+Changes from current (`Playbooks | Agents | Plugins | Runs | Shows`):
+- **Shows** moves before **Runs** — shows orchestrate plays that create sessions.
+  Left-to-right matches causality.
+- **"Runs"** stays as the nav label. Users think "I ran a playbook," not "I created
+  a session." The internal data model uses sessions; the user-facing concept is runs.
+- **No Dashboard nav item.** Logo-as-home is a universal convention. Adding it costs
+  nav space on a power-user tool with one primary user. Add a tooltip on logo hover.
+
+### 3. Status vocabulary: display mapping over raw statuses
+
+Keep raw statuses in the data layer (the show skill's state machine needs them for
+resume). Add a display mapping for the UI only.
+
+**Display vocabulary**:
+
+| Display Status | Raw Statuses | Color | Category |
+|---------------|-------------|-------|----------|
+| `pending` | pending, prepared | Amber | Lifecycle |
+| `running` | running | Blue | Lifecycle |
+| `awaiting_gate` | running_complete, gated | Purple | Lifecycle |
+| `completed` | completed, done, success, finished | Green | Lifecycle |
+| `failed` | failed, error, gate_failed | Red | Lifecycle |
+| `aborted` | aborted, aborted_after_finish, cancelled | Gray | Lifecycle |
+| `redoing` | redoing | Blue | Lifecycle |
+| `blocked` | blocked | Orange | Lifecycle |
+| `escalated` | escalated | Orange | Review |
+| `completed` | merged | Green | Lifecycle (+ integration badge `merged`) |
+
+**Gate badges** (plays only): `passed` (green), `failed` (red), `skipped` (gray).
+**Integration badges** (plays only): `merged` (green), `local` (gray).
+
+The shows detail page splits status into three columns: lifecycle | gate | integration.
+List views show the lifecycle pill as primary, with gate/integration as secondary badges.
+Detail views show the raw status in a metadata section.
+
+**"Completed with errors" pattern**: Tool errors are diagnostic, not
+status-changing. A completed session with intermediate tool failures displays as:
+
+```
+completed · 112 intermediate tool errors
+```
+
+Color: green status pill + amber diagnostic chip (not a different status). No
+`completed_with_errors` status — that would turn normal agent retry behavior
+into an apparent degraded lifecycle state.
+
+- **Runs list**: do not distinguish clean vs error-containing completed sessions
+  until error counts are precomputed. Same green pill for both.
+- **Dashboard metrics**: intermediate tool errors do not feed `Needs review` or
+  `Failed`. Dashboard cards mean: Running (active), Failed (terminal), Slow
+  (duration threshold), Needs review (human gate, critic escalation, blocked).
+- **Run detail Overview**: label as `TOOL ERRORS: 112 intermediate`. Section
+  renamed from "Errors" to "Tool errors" with explanatory copy: "These are
+  failed intermediate tool calls during a session that completed."
+- **Threshold**: no error-rate threshold yet. Do not flag high error rates as
+  `Needs review` until the system can distinguish exploratory failure from
+  actual degradation. A passing session is not degraded because it had many
+  intermediate tool failures.
+
+### 4. Run detail: anchored sections with sticky nav
+
+The run detail page restructures from a flat branch/message scroll to anchored
+sections with a sticky section nav. **Not tabs** — tabs hide information, which is
+wrong for a debugging tool.
+
+```
+Sticky section nav (dynamic ordering):
+[Overview] [Errors 112] [Branches 7] [Files 11] [Execution]
+
+When errors > 0: Errors appears second (before Branches).
+When errors = 0: Errors shows "No errors ✓" after Branches.
+All sections visible on one scroll.
+Heavy sections (branches, messages) are collapsible/lazy-rendered.
+Each branch is an accordion.
+```
+
+**Overview section** (new):
+- Verdict/outcome badge with error qualifier: `completed · 112 intermediate tool errors`
+- Duration with disambiguation: session duration vs branch duration when different
+- Branch count, message count, tool call count, error count (labeled "intermediate
+  tool errors" not just "errors")
+- Source provenance: show/play/playbook backlinks (from enriched session fields).
+  Show provenance block only when at least one field is populated — do not display
+  5 lines of "unlinked / unavailable" for every historical session.
+
+**Errors section**: failed tool calls grouped by tool function name, with count,
+branch, timestamp, excerpt, and expandable raw output. No inferred impact column —
+the final verdict is the impact signal. Add "collapse recovered failures" toggle
+when agents emit recovery metadata. Always present (shows "No errors" with check
+when empty — this is a positive signal, not dead weight).
+
+**Branches section**: each branch as a collapsible accordion showing messages.
+Tool failures use a red left border, not full red rows. Sequential failures of
+the same tool are grouped.
+
+**Files section**: list of touched/created files from tool call arguments.
+
+**Execution section**: `ExecutionDag` rendered here only when playbook context is
+known (navigated from playbook detail or session has `playbook_name`). Otherwise
+shows "Playbook context unknown — navigate from playbook detail for execution graph."
+
+### 5. ExecutionDag restoration: playbook-first
+
+Restore `ExecutionDag.tsx` starting from **playbook context**, not arbitrary session
+context. This sidesteps the session-to-playbook resolution problem.
+
+| Location | What it shows | Prerequisite |
+|----------|---------------|-------------|
+| Playbook detail → Executions section | Graph with latest execution status overlay | Playbook has steps/links (graph-format) |
+| Run detail → Execution section | Same graph with this run's status | Session has `playbook_name` matching a graph-format playbook |
+
+For **declarative playbooks** (no steps/links), do not synthesize a fake graph.
+Show a linear execution summary instead:
+
+```
+Agent: architect → 47 tool calls → 11 files → Verdict: PASS
+```
+
+**Provenance instrumentation starts now**: all CLI commands (`li play`, `li agent`,
+`li o flow`, `li o fanout`) write `playbook_name`, `agent_name`, `invocation_kind`,
+`show_topic`, `show_play_name` to the session at creation time. This is cheap and
+makes future ExecutionDag wiring automatic.
+
+### 6. Show → Session lineage
+
+Surface `plays.session_id` on the shows detail page:
+
+- **Inline accordion** for play details (not a drawer — preserves DAG/table visual
+  link). Clicking a play row expands it vertically to show: intent, agent/playbook,
+  session link (`Open Session →`), gate verdict, duration, artifacts.
+- **Reverse lookup**: run detail page queries `plays WHERE session_id = ?` to show
+  "Source: Show {topic} / Play {name}" backlink in the Overview section.
+- **Historical backfill**: one-time effort to match the 26 existing plays to sessions
+  by timestamp overlap or branch name similarity. Small effort, high payoff — the
+  shows page works fully for existing data, not just future data.
+
+### 7. Per-page filters (before global search)
+
+Complete the half-done per-page filtering:
+
+| Page | Current | Add |
+|------|---------|-----|
+| Playbooks | No filter | Search input in left pane |
+| Agents | Has search | Done |
+| Plugins | Has filter | Skill search within selected plugin |
+| Runs | No filter/search/pagination | Full redesign per ADR-0015: identity column, filter bar, pagination (100/page) |
+| Shows | No filter | Status filter chips |
+
+Global search / command palette deferred to a later phase. At ~500 entities, per-page
+filters give better ROI. Search becomes important when artifacts are indexed.
+
+### 8. Shows detail enhancements
+
+- **Layout: plays table is full-width primary.** `_show.md` moves below the plays
+  table as a collapsed full-width toggle, not a side-by-side column. Always collapsed
+  by default (no auto-open for active shows).
+- **PlayDag**: compact dependency graph strip above plays table (112-220px tall
+  depending on play count). Visible by default. See ADR-0011 for pixel guidance.
+- **DAG + table linked**: hover row highlights node, hover node highlights row,
+  click node scrolls to and expands play row.
+- **Play details as inline accordion.** Session link (`Open Session →`) is the
+  first element in the expanded area.
+- **State cell**: structured multi-badge — primary lifecycle pill + secondary gate
+  and integration badges in one column. See ADR-0011 for badge spec.
+
+### 9. Quick fixes
+
+- **Toast wiring**: Toast component exists. Wire into save (agents, playbooks),
+  create (new agent, new playbook), run (playbook Run button), and rollback actions.
+  This is the fastest UX win available — zero feedback on save is actively harmful.
+- **Plugin source display names**: map raw source slugs to human labels in the
+  frontend. `marketplace` → `Lion Marketplace`, `claude-plugins-official` →
+  `Anthropic Official`. Raw value in tooltip.
+- **Breadcrumbs**: on deep pages (`Shows / topic`, `Runs / session-name`).
+- **Cross-links**: `Open in Agents →` from plugin agent tab. `View source` from skills.
+- **Proportional font** for README/prose; monospace for YAML/paths/commands/logs.
+- **Diagnostic empty states**: plugins show scanned path + last scan time when 0 found.
+  Other pages use simple "No items" — no onboarding copy for a power-user tool.
+- **Version history**: move to drawer, hide sidebar when empty. `Versions (N)` button
+  in definition header.
+- **Playbook left-pane search** — now the only two-pane page without a filter,
+  inconsistent with Agents and Plugins.
+
+### 10. Dashboard source of truth and improvements
+
+**Dashboard queries SQLite sessions only.** The inventory strip shows the count
+of sessions the UI can actually list and open — not filesystem run directories.
+If the runs page shows 376 sessions, the dashboard shows 376 runs.
+
+```
+INVENTORY    20 playbooks    17 agents    376 runs    2 shows
+```
+
+The 549 filesystem run directories are visible on the runs page as import status,
+not on the dashboard:
+
+```
+Import status: 549 filesystem dirs detected · 376 indexed · 173 unindexed
+[Run import]
+```
+
+This separation keeps operational state on the dashboard and migration state where
+it is actionable.
+
+Other improvements:
+- Metric cards clickable, routing to filtered runs list (`/runs?status=failed`).
+- "Needs attention" surfaces slow/stale when count > 0. Does NOT include
+  intermediate tool errors (those are diagnostic, not operational).
+- Recent activity includes source context (show/playbook/agent from enriched sessions).
+- Interval refresh (30s `setInterval` on `/api/stats`), not SSE.
+
+## Implementation Phases
+
+**Done** (implemented in this session):
+- Session schema enrichment + provenance columns (v2→v3 migration)
+- Show → Session drill-down (play accordion with session links)
+- Run detail anchored sections (Overview, Tool errors, Branches, Files)
+- Nav reorder (Shows before Runs) + status display mapping
+- Toast component (not yet wired to actions)
+- Plugin marketplace name labels
+
+**Next** (implementation order per design review):
+
+| Phase | Scope | Priority | Effort | ADR |
+|-------|-------|----------|--------|-----|
+| 1 | Runs list redesign (identity column, filter bar, pagination) | P0 | Medium | ADR-0015 |
+| 2 | Dashboard sessions-only count + import status on runs page | P0 | Quick | ADR-0012 §10 |
+| 3 | Tool errors naming + "completed with intermediate errors" copy | P0 | Quick | ADR-0012 §3 |
+| 4 | Shows table State cell (lifecycle + gate + integration badges) | P1 | Medium | ADR-0011 |
+| 5 | Compact PlayDag strip above full-width plays table | P1 | Medium | ADR-0011 |
+| 6 | Wire toasts into save/create/run/rollback actions | P1 | Quick | ADR-0012 §9 |
+| 7 | Quick fixes (breadcrumbs, cross-links, playbook search, version drawer) | P1 | Quick | ADR-0012 §9 |
+| 8 | Shows layout: _show.md below plays, always collapsed | P1 | Quick | ADR-0012 §8 |
+| 9 | ExecutionDag on playbook detail (graph-format playbooks only) | P2 | Medium | ADR-0012 §5 |
+| 10 | Definition editor standardization (shared shell, version drawer) | P2 | Medium | — |
+
+## Consequences
+
+**Positive**
+- Full execution chain navigable: show → play → session → messages → artifacts.
+- Single query source (enriched sessions) eliminates count mismatches.
+- Status display mapping preserves raw state machine while showing consistent UI.
+- Anchored sections preserve debugging scanability (nothing hidden behind tabs).
+- Provenance instrumentation is cheap now, expensive to retrofit later.
+- Zero new tables — enriched sessions avoid premature abstraction.
+
+**Negative**
+- Session table gains 7 nullable columns — acceptable at current scale, may need
+  extraction to an `executions` table if the table becomes unwieldy.
+- Historical backfill for 26 plays requires manual/heuristic matching.
+- Anchored sections require lazy rendering for large branch/message counts.
+- Display status mapping adds a translation layer that must stay in sync with
+  the show skill's state machine.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|-------------|
+| Separate `executions` table | Premature abstraction at 376 sessions. Adds migration/API/FK overhead. Extract later if needed. |
+| Rename "Runs" to "Sessions" | Users think "I ran a playbook," not "I created a session." Label matches mental model, not data model. |
+| Add Dashboard nav item | Logo-as-home is universal convention. 6 nav items costs cognitive load. Add tooltip instead. |
+| Hard tabs on run detail | Tabs hide information. Debugging tool needs everything visible. Anchored sections with sticky nav is better. |
+| Drawer for show play details | Competes with DAG for horizontal space. Inline accordion preserves table/DAG visual link. |
+| Global search as priority | Per-page filters are half-done and cheaper. ~500 entities does not justify a command palette yet. |
+| Component library (Radix, etc.) | Zero-dependency pattern worth keeping. Custom toast is ~100 LOC. Revisit when dialogs proliferate. |
+
+## References
+
+- Design review round 1: ChatGPT executive assessment (2026-05-20)
+- Design review round 2: Developer counterpoint (`DESIGN_REVIEW_FOLLOWUP.txt`)
+- Design review round 3: Synthesis with final decisions
+- Design review round 4: Post-implementation visual review (confirmed anchored sections,
+  identified _show.md layout regression, error labeling gap)
+- ADR-0009: SQLite state layer
+- ADR-0010: Plugin-aware Studio (updated: cross-links, source badges)
+- ADR-0011: Shows data model (updated: play accordion, status split, provenance)
+- ADR-0013: Zero-dependency UI components
+- ADR-0014: CLI-primary, Studio-secondary
+- ADR-0015: Runs list design (identity, filters, pagination)
+- `apps/studio/frontend/components/ExecutionDag.tsx` (disconnected, to restore)

--- a/docs/adrs/ADR-0012-studio-execution-lineage.md
+++ b/docs/adrs/ADR-0012-studio-execution-lineage.md
@@ -297,7 +297,8 @@ pending merge):
 | 7 | Quick fixes (breadcrumbs, cross-links, playbook search, version drawer) | P1 | Quick | ADR-0012 §9 |
 | 8 | Shows layout: _show.md below plays, always collapsed | P1 | Quick | ADR-0012 §8 |
 | 9 | ExecutionDag on playbook detail (graph-format playbooks only) | P2 | Medium | ADR-0012 §5 |
-| 10 | Definition editor standardization (shared shell, version drawer) | P2 | Medium | — |
+| 10 | Definitions API + `definitions` table + save/rollback versioning | P1 | Medium | ADR-0016 |
+| 11 | Definition editor standardization (shared shell, version drawer) | P2 | Medium | — |
 
 ## Consequences
 

--- a/docs/adrs/ADR-0012-studio-execution-lineage.md
+++ b/docs/adrs/ADR-0012-studio-execution-lineage.md
@@ -2,7 +2,7 @@
 
 **Status**: Accepted
 **Date**: 2026-05-20
-**Extends**: ADR-0009 (SQLite state layer), ADR-0010 (plugins), ADR-0011 (shows data model)
+**Extends**: ADR-0009 (SQLite state layer), ADR-0010 (plugins), ADR-0011 (shows data model), ADR-0017 (session lifecycle)
 
 ## Context
 
@@ -81,7 +81,7 @@ resume). Add a display mapping for the UI only.
 |---------------|-------------|-------|----------|
 | `pending` | pending, prepared | Amber | Lifecycle |
 | `running` | running | Blue | Lifecycle |
-| `awaiting_gate` | running_complete, gated | Purple | Lifecycle |
+| `awaiting_gate` | running_complete, gated | Amber | Lifecycle |
 | `completed` | completed, done, success, finished | Green | Lifecycle |
 | `failed` | failed, error, gate_failed | Red | Lifecycle |
 | `aborted` | aborted, aborted_after_finish, cancelled | Gray | Lifecycle |
@@ -93,7 +93,7 @@ resume). Add a display mapping for the UI only.
 **Gate badges** (plays only): `passed` (green), `failed` (red), `skipped` (gray).
 **Integration badges** (plays only): `merged` (green), `local` (gray).
 
-The shows detail page splits status into three columns: lifecycle | gate | integration.
+The shows detail page uses a single State column with a primary lifecycle pill plus optional secondary gate and integration badges (see ADR-0011 for the badge spec).
 List views show the lifecycle pill as primary, with gate/integration as secondary badges.
 Detail views show the raw status in a metadata section.
 
@@ -337,8 +337,9 @@ Other improvements:
   identified _show.md layout regression, error labeling gap)
 - ADR-0009: SQLite state layer
 - ADR-0010: Plugin-aware Studio (updated: cross-links, source badges)
-- ADR-0011: Shows data model (updated: play accordion, status split, provenance)
+- ADR-0011: Shows data model (updated: play accordion, status badges, provenance)
 - ADR-0013: Zero-dependency UI components
 - ADR-0014: CLI-primary, Studio-secondary
 - ADR-0015: Runs list design (identity, filters, pagination)
+- ADR-0017: Session lifecycle and status derivation (status column, dashboard queries)
 - `apps/studio/frontend/components/ExecutionDag.tsx` (disconnected, to restore)

--- a/docs/adrs/ADR-0013-zero-dependency-ui.md
+++ b/docs/adrs/ADR-0013-zero-dependency-ui.md
@@ -1,0 +1,90 @@
+# ADR-0013: Zero Component-Library UI
+
+**Status**: Accepted
+**Date**: 2026-05-20
+
+## Context
+
+Lion Studio's frontend uses Next.js 14 + TypeScript + Tailwind CSS with no UI
+component library (no Radix, no shadcn, no Headless UI). All interactive
+components — Badge, StatusPill, Button, Toast, tabs, accordions, two-pane
+layouts, definition editors — are custom-built with Tailwind.
+
+Note: the app does use **visualization libraries** (ReactFlow for PlayDag and
+WorkerCanvas, dagre for layout). "Zero component-library" means no general-purpose
+UI primitive library, not zero frontend dependencies.
+
+This pattern emerged organically: the first components were simple enough that
+importing a library was unnecessary, and subsequent components followed the
+established style. The question arises with each new UI primitive: should we
+adopt a headless component library (Radix, Headless UI, Ark UI) or continue
+building custom?
+
+The decision was explicitly tested during the ADR-0012 design review. The toast
+system (~100 LOC custom) was the first component where a library (react-hot-toast,
+sonner) would have been materially simpler. We chose custom.
+
+## Decision
+
+**Continue building custom components. No UI component library.**
+
+The threshold for reconsidering: when the app needs **3+ of the following
+simultaneously**, adopting a headless primitive library becomes justified:
+
+1. Modal dialogs (not just toasts — actual blocking dialogs with focus trap)
+2. Popovers with positioning logic (dropdown menus, tooltips with arrows)
+3. Command palette / combobox with keyboard navigation and fuzzy search
+4. Multi-select / autocomplete inputs
+5. Accessible disclosure (tabs, accordions) with ARIA state management
+
+Currently the app needs 0 of these. The toast system and collapsible sections
+are simple enough to build correctly without a library. The command palette
+(deferred to a later phase in ADR-0012) would be the trigger — when it ships,
+evaluate whether adopting Radix or similar is warranted.
+
+### What "custom" means in practice
+
+- Layout primitives: flexbox/grid via Tailwind utility classes.
+- Interactive components: React state + event handlers + Tailwind transitions.
+- Theming: CSS custom properties in `globals.css`, class-based dark/light toggle.
+- Accessibility: manual ARIA attributes where needed (not systematically audited).
+- Animation: CSS transitions and Tailwind `animate-*` utilities. No Framer Motion.
+
+### What we accept as trade-offs
+
+- Accessibility coverage is best-effort, not systematic. This is acceptable for
+  a power-user tool with one primary user. It would not be acceptable for a
+  public-facing product.
+- Each new primitive costs ~50-150 LOC of implementation. At the current pace
+  (~1 new component per design phase), this is sustainable.
+- Focus management, portal rendering, and scroll locking are done ad-hoc per
+  component. If multiple components need these, a shared utility layer is
+  preferable to a full library adoption.
+
+## Consequences
+
+**Positive**
+- Zero dependency means zero upgrade churn, zero breaking changes from upstream,
+  zero style conflicts or specificity wars.
+- Every component matches the design system exactly — no overriding library
+  defaults or fighting opinionated styling.
+- Bundle size stays minimal. No tree-shaking concerns.
+- Full control over behavior: the toast system dismisses exactly when and how
+  we want, the status pills use exactly the tokens we define.
+
+**Negative**
+- Accessibility is incomplete. A screen reader user would have a degraded
+  experience on some interactive elements.
+- Some patterns (focus trap, click-outside-to-close, scroll lock on overlay)
+  get reimplemented per component instead of shared.
+- New contributors must learn the custom component patterns rather than
+  referring to a library's documentation.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|-------------|
+| Radix UI | Best headless option, but adds 10+ packages for primitives we don't need yet. Evaluate at command palette time. |
+| shadcn/ui | Copy-paste model is appealing but brings Radix as a dependency and imposes its own abstraction layer on top of Tailwind. |
+| Headless UI (Tailwind Labs) | Smaller surface area than Radix but less complete. Same "not needed yet" argument applies. |
+| React Aria (Adobe) | Excellent accessibility but heavyweight and opinionated about state management. Overkill for this app. |

--- a/docs/adrs/ADR-0013-zero-dependency-ui.md
+++ b/docs/adrs/ADR-0013-zero-dependency-ui.md
@@ -37,10 +37,7 @@ simultaneously**, adopting a headless primitive library becomes justified:
 4. Multi-select / autocomplete inputs
 5. Accessible disclosure (tabs, accordions) with ARIA state management
 
-Currently the app needs 0 of these. The toast system and collapsible sections
-are simple enough to build correctly without a library. The command palette
-(deferred to a later phase in ADR-0012) would be the trigger — when it ships,
-evaluate whether adopting Radix or similar is warranted.
+Currently the app uses custom tabs (plugin detail) and collapsible accordions (play details, branch sections) that work without library-grade ARIA state management. These existing components do not count toward the threshold because they are simple show/hide toggles without focus-trap, arrow-key navigation, or roving tabindex requirements. The threshold counts complex primitives that genuinely need a headless library's accessibility infrastructure. The command palette (deferred to a later phase in ADR-0012) would be the trigger — when it ships, evaluate whether adopting Radix or similar is warranted.
 
 ### What "custom" means in practice
 

--- a/docs/adrs/ADR-0014-cli-primary-studio-secondary.md
+++ b/docs/adrs/ADR-0014-cli-primary-studio-secondary.md
@@ -1,0 +1,110 @@
+# ADR-0014: CLI-Primary, Studio-Secondary
+
+**Status**: Accepted
+**Date**: 2026-05-20
+
+## Context
+
+Lion Studio coexists with the lionagi CLI (`li agent`, `li play`, `li o flow`,
+`li o fanout`). Both surfaces access the same data: playbooks, agents, sessions,
+shows, definitions. The question is which surface is primary for each operation.
+
+During the ADR-0012 design review, several recommendations assumed Studio was
+the primary creation and execution surface:
+
+- "Add a Run dialog with input variables and execution mode"
+- "Add 'Clone existing agent' as a secondary creation path"
+- "Empty states should explain what to do next"
+- "After creation, redirect to the new agent's detail and show clear next actions"
+
+These recommendations optimize for a user who lives in the browser. Lion Studio's
+actual user (Ocean) lives in the terminal. Playbooks are authored in an editor
+and run via `li play`. Agents are defined as markdown files. Shows are orchestrated
+by Claude Code agents using the show skill. The CLI is the creation and execution
+surface; Studio is the observation and editing surface.
+
+This distinction affects every feature decision.
+
+## Decision
+
+**The CLI is the primary interface for creation and execution. Studio is the
+primary interface for observation, inspection, editing, and debugging.**
+
+### What Studio is for
+
+| Capability | Example |
+|-----------|---------|
+| Observe | Dashboard metrics, session list, show progress |
+| Inspect | Run detail with branches/messages, error grouping, file lists |
+| Edit | Agent definitions, playbook YAML, with version history |
+| Debug | Drill from show → play → session → messages → tool calls |
+| Browse | Plugin/skill/agent catalog with source information |
+
+### What Studio is NOT for
+
+| Capability | Why not | Where instead |
+|-----------|---------|---------------|
+| Run a playbook with parameters | CLI handles input binding, worktree setup, team coordination | `li play playbook.yaml --input ...` |
+| Create agents from scratch | Agents are markdown files with frontmatter; a text editor is better | `$EDITOR .lionagi/agents/my-agent.md` |
+| Install/remove plugins | Claude Code manages plugin lifecycle | `claude plugin add/remove` |
+| Orchestrate shows | Show skill is a Claude Code agent skill, not a UI workflow | `/show topic` in Claude Code |
+| Manage CLI configuration | Settings are YAML files | `.lionagi/settings.yaml` |
+
+### The "Run" button exception
+
+The playbook detail page has a "Run" button. This is a convenience shortcut that
+shells out to the CLI, not a full execution surface. It does not support:
+- Input variable binding
+- Execution mode selection
+- Team mode configuration
+- Worktree customization
+
+If these are needed, use the CLI. The Run button is for "re-run this playbook
+with defaults" — a debugging convenience, not a production workflow.
+
+### Implications for UI design
+
+1. **Empty states are diagnostic, not onboarding.** "No sessions" means the data
+   hasn't been imported or nothing has run, not that the user doesn't know how to
+   create a session. Show scan paths and timestamps, not tutorial copy.
+
+2. **Creation flows are minimal.** New Agent and New Playbook pages exist for
+   quick scaffolding, not as the primary authoring surface. They create a file
+   and redirect to the editor.
+
+3. **The terminal is always one `!` away.** Users can type `! li play ...` in
+   Claude Code to execute from the same session. Studio doesn't need to replicate
+   CLI capabilities.
+
+4. **Navigation depth is acceptable.** The 3-click path to a skill (nav → plugin →
+   skill) is fine because Studio is for browsing, not for invoking. If you need
+   to invoke a skill, you type `/skill-name` in the terminal.
+
+5. **Search is for finding, not for doing.** When global search ships, it routes
+   to detail pages for inspection, not to execution dialogs.
+
+## Consequences
+
+**Positive**
+- Studio stays focused: observe + inspect + edit + debug. No feature creep toward
+  replicating CLI capabilities in the browser.
+- Simpler UI: no complex forms for run configuration, input binding, or team setup.
+- The CLI can evolve independently. New execution modes don't require Studio changes.
+- Correct mental model: Studio is a dashboard/IDE, not a control plane.
+
+**Negative**
+- Collaborators who don't use the CLI cannot create or run things from Studio alone.
+  This is acceptable for the current user base (Ocean + occasional collaborators).
+- The Run button on playbooks is a partial exception that may confuse expectations.
+  Mitigate by keeping it visually de-emphasized and not adding execution options.
+- Some inspector features (e.g., "re-run this failed play") require switching to
+  the terminal. A "copy CLI command" button could bridge this gap without making
+  Studio an execution surface.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|-------------|
+| Studio as full execution surface | Replicates CLI complexity in the browser. Two execution surfaces means two places for bugs, two configuration systems, two sets of edge cases. |
+| Studio as read-only dashboard (no editing) | Too restrictive. Editing definitions in the browser with version history is genuinely useful and doesn't conflict with CLI-primary. |
+| Remove the Run button entirely | The convenience of "quick re-run with defaults" is worth the minimal UI it requires. Just don't expand it. |

--- a/docs/adrs/ADR-0015-runs-list-design.md
+++ b/docs/adrs/ADR-0015-runs-list-design.md
@@ -1,0 +1,121 @@
+# ADR-0015: Runs List Design — Identity, Filters, Pagination
+
+**Status**: Accepted
+**Date**: 2026-05-20
+**Extends**: ADR-0012 (execution lineage), ADR-0004 (data authority)
+
+## Context
+
+The runs list page (`/runs`) shows 376 SQLite sessions in a flat table with
+minimal identity: name (often just "flow" or "agent"), branch count, message
+count, status (almost all "completed"), and timestamps. With enriched session
+provenance (ADR-0012: `playbook_name`, `agent_name`, `invocation_kind`,
+`show_topic`, `show_play_name`, `source_kind`), the list can become an
+operational execution index.
+
+The page currently has no search, no filters, no pagination, and no way to
+distinguish 376 rows that mostly share the same name and status.
+
+## Decision
+
+### 1. Two-line row with display name + meta line
+
+Each row has a primary display name (computed from provenance) and a secondary
+meta line (session ID + supplementary context):
+
+```
+unimpl-adr-sweep / closeout-audit        show play   completed   1 br · 24 msg   15h ago
+  session 20260520T0A7... · playbook show · agent orchestrator
+
+flow                                     flow        completed   6 br · 632 msg  1:33 PM
+  session 20260520T015... · started May 19 11:06 PM
+```
+
+### Display-name algorithm
+
+Fallthrough from most-specific to least-specific:
+
+```ts
+if (show_topic && show_play_name) → `${show_topic} / ${show_play_name}`
+else if (playbook_name)           → playbook_name
+else if (agent_name)              → agent_name
+else if (name)                    → name
+else                              → shortSessionId
+```
+
+Meta line: session ID + any provenance not already in the display name +
+start time. **No "unlinked" or "unavailable" labels** — if provenance is
+absent, the row simply falls back to session ID and timestamp.
+
+### 2. Default columns
+
+| Column | Width | Default | Content |
+|--------|-------|---------|---------|
+| Run / Origin | flex:1, min 420px | Visible | Display name + meta line |
+| Kind | 110px | Visible | `agent`, `play`, `flow`, `fanout`, `show play` |
+| Status | 120px | Visible | Normalized display status (ADR-0012 mapping) |
+| Activity | 140px | Visible | `N br · M msg` |
+| Updated | 150px | Visible | Relative timestamp, primary sort |
+
+Hidden columns (available via `[Columns]` toggle):
+- Started, Source kind, Playbook, Agent, Show topic, Show play, Session ID,
+  Branches (split), Messages (split)
+
+### 3. Filter bar
+
+Dense two-row filter bar above the table:
+
+```
+[ Search name, id, show, play, playbook, agent... ]      [Columns ▾]
+Status: [All] [Running] [Completed] [Failed] [Awaiting gate]
+Kind:   [All] [Agent] [Play] [Flow] [Fanout] [Show play]
+Source: [All] [Live] [Imported fs] [With show] [With playbook]   Rows: [100 ▾]
+```
+
+Search matches: `session.id`, `session.name`, `playbook_name`, `agent_name`,
+`invocation_kind`, `show_topic`, `show_play_name`, `source_kind`. Client-side
+filtering on the loaded session list (no server-side search endpoint needed at
+376 rows).
+
+### 4. Pagination at 100 rows/page
+
+| Row count | Strategy |
+|-----------|----------|
+| 0–200 | Render all, no pagination needed |
+| 200–2,000 | Paginate, default 100/page |
+| 2,000+ | Server-side pagination (add LIMIT/OFFSET to sessions query) |
+
+No virtual scroll. It complicates row heights, browser find, copy workflows,
+keyboard navigation, and future expandable rows. Pagination is simpler.
+
+### 5. Empty provenance handling
+
+During the transition period (most sessions have null provenance):
+- Rows with provenance get descriptive display names (show/play, playbook, agent)
+- Rows without provenance fall back to session name + timestamp
+- No "unlinked" labels, no "missing" indicators — absence is handled by
+  graceful fallback, not by calling attention to what's missing
+- As new sessions are created with provenance, they naturally stand out
+
+## Consequences
+
+**Positive**
+- Every row is identifiable even when 100+ share the same session name.
+- Filters enable targeted diagnosis (show me all failed show-plays).
+- Pagination prevents render performance degradation.
+- Column toggle lets power users expose raw metadata when needed.
+
+**Negative**
+- Two-line rows use more vertical space per row (~52px vs ~36px).
+- Display-name algorithm requires client-side computation per row.
+- Filter state is local (no URL query params yet — add when deep-linking needed).
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|-------------|
+| Virtual scroll instead of pagination | Complicates browser find, copy, keyboard nav; pagination is simpler |
+| Per-row error count column | Requires loading all messages for every session in the list query; too expensive |
+| "Unlinked" labels for missing provenance | Visual noise on 376 rows that ALL lack provenance; trains users to ignore the block |
+| Sidebar filters | Takes horizontal space from the table; above-table filter bar is denser |
+| Server-side search | Not needed at 376 rows; client-side filtering is sufficient |

--- a/docs/adrs/ADR-0015-runs-list-design.md
+++ b/docs/adrs/ADR-0015-runs-list-design.md
@@ -67,7 +67,7 @@ Dense two-row filter bar above the table:
 
 ```
 [ Search name, id, show, play, playbook, agent... ]      [Columns ▾]
-Status: [All] [Running] [Completed] [Failed] [Awaiting gate]
+Status: [All] [Running] [Completed] [Failed] [Aborted]
 Kind:   [All] [Agent] [Play] [Flow] [Fanout] [Show play]
 Source: [All] [Live] [Imported fs] [With show] [With playbook]   Rows: [100 ▾]
 ```

--- a/docs/adrs/ADR-0015-runs-list-design.md
+++ b/docs/adrs/ADR-0015-runs-list-design.md
@@ -108,7 +108,7 @@ During the transition period (most sessions have null provenance):
 **Negative**
 - Two-line rows use more vertical space per row (~52px vs ~36px).
 - Display-name algorithm requires client-side computation per row.
-- Filter state is local (no URL query params yet — add when deep-linking needed).
+- Filter state is local with one exception: the `?status=` query parameter is supported for dashboard deep links (ADR-0012). Other filter dimensions (kind, source, search) are local-only until deep-linking is needed.
 
 ## Alternatives Considered
 

--- a/docs/adrs/ADR-0016-definitions-write-path.md
+++ b/docs/adrs/ADR-0016-definitions-write-path.md
@@ -59,6 +59,8 @@ POST /api/definitions/{kind}/{name}
 
 Version numbers are monotonic per `(kind, name)`. Current version = `MAX(version)`.
 
+Definition identity is `(kind, name)`. This is unique because marketplace agents and playbooks are discovered at paths that resolve to the same namespace as local definitions (the plugin scanner contributes to the same agent/playbook registry). If a marketplace and local definition share the same name, the local definition takes precedence (closer to user). Collision detection is deferred — at current scale (20 playbooks, 17 agents), name conflicts have not occurred.
+
 ### Rollback semantics
 
 ```

--- a/docs/adrs/ADR-0016-definitions-write-path.md
+++ b/docs/adrs/ADR-0016-definitions-write-path.md
@@ -11,9 +11,11 @@ mutate local definitions — agent profiles and playbook YAML. This is the only
 sanctioned write path in Studio besides the convenience Run button. The
 invariants of this write path need a durable contract.
 
-The definitions API exists in code (`/api/definitions/`, `definitions` SQLite
-table) but its semantics are not formalized. Specifically: what is editable,
-what is the source of truth, how versioning works, and what rollback means.
+The definitions API is specified below. The agent and playbook write routes
+currently return 501 (unimplemented); the definitions SQLite table and
+versioning logic are part of the implementation phases in ADR-0012. This ADR
+formalizes the semantics: what is editable, what is the source of truth, how
+versioning works, and what rollback means.
 
 ## Decision
 

--- a/docs/adrs/ADR-0016-definitions-write-path.md
+++ b/docs/adrs/ADR-0016-definitions-write-path.md
@@ -1,0 +1,109 @@
+# ADR-0016: Definition Write Path and Versioning
+
+**Status**: Accepted
+**Date**: 2026-05-20
+**Extends**: ADR-0009 (SQLite state layer), ADR-0010 (plugin editability matrix), ADR-0014 (CLI-primary)
+
+## Context
+
+Studio is not the execution control plane (ADR-0014), but it is allowed to
+mutate local definitions — agent profiles and playbook YAML. This is the only
+sanctioned write path in Studio besides the convenience Run button. The
+invariants of this write path need a durable contract.
+
+The definitions API exists in code (`/api/definitions/`, `definitions` SQLite
+table) but its semantics are not formalized. Specifically: what is editable,
+what is the source of truth, how versioning works, and what rollback means.
+
+## Decision
+
+### What is editable
+
+| Item | Editable? | Where? |
+|------|-----------|--------|
+| Marketplace/local agent definitions (`*.md`) | Yes | Agents page |
+| Marketplace/local playbook definitions (`*.yaml`) | Yes | Playbooks page |
+| Skills (`SKILL.md`) | No | Read-only in Plugins page |
+| Third-party plugin components | No | Read-only everywhere |
+| Runtime artifacts (sessions, messages, shows, plays) | No | Read-only |
+| Plugin metadata (`plugin.json`, `hooks.json`, `.mcp.json`) | No | Read-only |
+
+### Source of truth
+
+**Disk content is canonical.** The file on disk (`~/.lionagi/agents/analyst.md`,
+`~/.lionagi/playbooks/review-flow.yaml`) is the authoritative version. SQLite's
+`definitions` table stores version history (content snapshots + metadata), not
+the current state.
+
+When Studio saves a definition:
+1. Write the new content to the file on disk.
+2. Insert a new row in `definitions` with the content, incremented version number,
+   and timestamp.
+
+When a file is edited outside Studio (in a text editor, by the CLI, by git):
+the disk version is current. Studio's version history may be behind — this is
+acceptable. The next Studio edit will create a new version from whatever is
+on disk.
+
+### Save semantics
+
+```
+POST /api/definitions/{kind}/{name}
+  body: { content: string, message?: string }
+  →
+  1. Write content to disk path
+  2. INSERT INTO definitions (kind, name, path, content, version, created_at, message)
+     VALUES (kind, name, path, content, max(version)+1, now(), message)
+  3. Return { version: N, saved_at: timestamp }
+```
+
+Version numbers are monotonic per `(kind, name)`. Current version = `MAX(version)`.
+
+### Rollback semantics
+
+```
+POST /api/definitions/{kind}/{name}/rollback?version=N
+  →
+  1. SELECT content FROM definitions WHERE kind=? AND name=? AND version=?
+  2. Write that content to disk
+  3. INSERT new definitions row with version = max(version)+1 and the restored content
+  4. Return { version: N+1, rolled_back_from: current, rolled_back_to: N }
+```
+
+Rollback creates a NEW version (not a delete). The version history is append-only.
+Version N+1's content equals version N's content, but it is a new entry with a
+new timestamp.
+
+### Conflict posture
+
+Single-user, localhost-only. No merge UI, no multi-writer conflict model, no
+file locking. If two tabs save the same definition concurrently, last write
+wins on disk and both versions exist in SQLite history.
+
+This is acceptable because: (1) one primary user, (2) CLI edits are rare while
+Studio is open, (3) git provides the ultimate conflict resolution layer.
+
+## Consequences
+
+**Positive**
+- Clear boundary: definitions are the only things Studio writes. Everything else
+  is read-only or import-only.
+- Disk-as-truth means git, grep, vim, and Claude Code all see the same file.
+- Append-only version history enables rollback without data loss.
+- Simple CRUD surface — no complex state machine or workflow engine.
+
+**Negative**
+- Disk and SQLite can drift if a write to one succeeds and the other fails.
+  Mitigation: disk write first (canonical), SQLite second (history). If SQLite
+  fails, the file is still saved — just version history is incomplete.
+- No notification when an external edit makes SQLite history stale. The next
+  Studio load shows disk content, which may differ from the latest SQLite version.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|-------------|
+| SQLite as source of truth (disk is derived) | Breaks the CLI/editor/git workflow — external tools expect to read/write files |
+| No version history (just save to disk) | Rollback is valuable; 1 INSERT per save is negligible cost |
+| File locking during edits | Single-user tool; locking adds complexity for a race condition that doesn't happen |
+| Make skills editable too | Skills are Claude Code instructions, not lionagi definitions; different authoring model |

--- a/docs/adrs/ADR-0017-session-lifecycle-status.md
+++ b/docs/adrs/ADR-0017-session-lifecycle-status.md
@@ -1,0 +1,173 @@
+# ADR-0017: Session Lifecycle and Status Derivation
+
+**Status**: Accepted
+**Date**: 2026-05-20
+**Extends**: ADR-0009 (SQLite state layer), ADR-0012 (execution lineage)
+
+## Context
+
+The `sessions` table (ADR-0009) stores identity, metadata, progression references,
+and provenance hints (ADR-0012). But it has no lifecycle columns — no `status`,
+no `started_at`, no `ended_at`. Yet the UI depends on session lifecycle:
+
+- **Runs list** (ADR-0015) requires a Status column per row.
+- **Dashboard** (ADR-0012 §10) requires cards for running, failed, slow, needs-review.
+- **Display mapping** (ADR-0012 §3) translates raw statuses to UI vocabulary — but
+  doesn't specify where the raw status *comes from* for sessions.
+
+For show-play sessions, status can be derived from `plays.status` via the
+`plays.session_id` FK. For standalone sessions (`li agent`, `li play` without
+show context), there is no external status source.
+
+Without a lifecycle contract, implementers must invent derivation logic — leading
+to inconsistent status computation across the runs list, dashboard, and detail page.
+
+## Decision
+
+### Add lifecycle columns to sessions
+
+```sql
+ALTER TABLE sessions ADD COLUMN status     TEXT DEFAULT 'running';
+  -- running|completed|failed|aborted
+ALTER TABLE sessions ADD COLUMN started_at REAL;
+ALTER TABLE sessions ADD COLUMN ended_at   REAL;
+```
+
+Migration: v3→v4, same idempotent `ALTER TABLE ADD COLUMN` pattern as prior
+migrations (ADR-0009 migration protocol).
+
+### Status vocabulary (sessions)
+
+Sessions use a minimal lifecycle — four terminal-capable states:
+
+| Status | Meaning | Set by |
+|--------|---------|--------|
+| `running` | Session is active, branch(es) in progress | CLI at session creation |
+| `completed` | Session finished normally | CLI at session close (exit code 0) |
+| `failed` | Session terminated with error | CLI at session close (exit code != 0) |
+| `aborted` | Session was interrupted or cancelled | CLI on SIGINT/SIGTERM or user abort |
+
+This is deliberately simpler than the play status vocabulary (ADR-0011 has 11 play
+statuses). Sessions don't need gate/merge/redo states — those belong to the play
+layer. A show-play session is just `completed` or `failed`; the richer lifecycle
+lives on `plays.status`.
+
+### Write points
+
+| Event | Who writes | What changes |
+|-------|-----------|--------------|
+| `li agent` / `li play` start | CLI session init | INSERT session with `status='running'`, `started_at=now()` |
+| Session close (success) | CLI session finalize | UPDATE `status='completed'`, `ended_at=now()` |
+| Session close (error) | CLI session finalize | UPDATE `status='failed'`, `ended_at=now()` |
+| Session interrupt | CLI signal handler | UPDATE `status='aborted'`, `ended_at=now()` |
+| `li state import` | Import command | INSERT with status derived from run.json manifest |
+| Show play links session | Show skill Step 3 | Session already created by `li play`; play links via `plays.session_id` |
+
+### Import status derivation
+
+For filesystem imports (`source_kind='imported_fs'`), status is derived from:
+
+1. If `run.json` has `"status"` field → use it (mapped to session vocabulary).
+2. If `run.json` has `"exit_code": 0` → `completed`.
+3. If `run.json` has `"exit_code"` != 0 → `failed`.
+4. If neither → `completed` (conservative default for legacy runs that finished
+   writing `run.json`).
+
+`started_at` and `ended_at` come from `run.json` timestamps or filesystem
+`ctime`/`mtime` as fallback.
+
+### Duration computation
+
+Duration is computed, not stored:
+
+```
+duration_ms = (ended_at - started_at) * 1000   -- if both present
+duration_ms = NULL                               -- if session still running
+```
+
+The API returns `duration_ms` as a computed field. No `duration_ms` column.
+
+### Dashboard status queries
+
+With an explicit `status` column, dashboard queries become simple aggregates:
+
+```sql
+-- Running sessions
+SELECT COUNT(*) FROM sessions WHERE status = 'running';
+
+-- Failed sessions (last 24h)
+SELECT COUNT(*) FROM sessions WHERE status = 'failed'
+  AND ended_at > unixepoch() - 86400;
+
+-- Slow sessions (running > 30 min)
+SELECT COUNT(*) FROM sessions WHERE status = 'running'
+  AND started_at < unixepoch() - 1800;
+
+-- Needs review (sessions linked to gated/escalated/blocked plays)
+SELECT COUNT(DISTINCT s.id) FROM sessions s
+  JOIN plays p ON p.session_id = s.id
+  WHERE p.status IN ('gated', 'escalated', 'blocked');
+```
+
+### Relationship to play status
+
+For sessions created by show plays, both the session and the play have status.
+They are independent:
+
+- **Session status**: did the CLI process complete? (`completed` / `failed`)
+- **Play status**: what happened in the show lifecycle? (`running_complete` →
+  `gated` → `merged` or `gate_failed` → `redoing`)
+
+A session can be `completed` while its play is `gate_failed` — the CLI process
+succeeded, but the gate reviewer rejected the output. The session status answers
+"did it run?" The play status answers "was the output accepted?"
+
+The display mapping (ADR-0012 §3) applies to sessions on the runs list. Play
+status uses the richer vocabulary on the shows detail page (ADR-0011).
+
+### "Completed with errors" — no separate status
+
+Per ADR-0012 §3, tool errors are diagnostic, not status-changing. A session with
+intermediate tool failures is `completed`, not `completed_with_errors`. Error
+counts are surfaced on the run detail page, not in the session status.
+
+Error counts are NOT precomputed on the sessions table. Computing
+`COUNT(*) FROM messages WHERE role='tool' AND content LIKE '%error%'` is
+expensive at list-query time. Instead:
+
+- **Runs list**: all completed sessions show green `completed` pill. No error
+  distinction until error counts are precomputed (deferred optimization).
+- **Run detail**: error count computed on page load from the session's messages.
+- **Dashboard**: intermediate tool errors do not feed any dashboard card.
+
+## Consequences
+
+**Positive**
+- Runs list and dashboard can query session status directly — no derivation logic.
+- Four-status vocabulary is simple and unambiguous.
+- Duration is computable from two timestamps without a stored column.
+- Import status derivation is well-defined for legacy filesystem runs.
+- Clean separation: session status = "did it run?", play status = "was output accepted?"
+
+**Negative**
+- Three new columns on the sessions table (v4 migration).
+- CLI session init and finalize must write status — requires hooks or explicit calls.
+- Imported sessions may have imprecise timestamps if run.json is sparse.
+- Error counts remain expensive to compute at list-query time.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|-------------|
+| Derive status from messages (no column) | Every list query scans messages; expensive and fragile (message patterns vary by provider) |
+| Derive from plays.status | Only works for show-play sessions; standalone sessions have no play |
+| Store error_count on sessions | Premature optimization; requires scanning all messages at session close; add when the runs list needs error distinction |
+| Rich session status (mirror play vocabulary) | Sessions don't have gates, merges, or redo cycles; forcing play lifecycle onto sessions is a category error |
+| Compute duration and store it | Derived from two timestamps; storing adds a column that can drift if ended_at is corrected |
+
+## References
+
+- [ADR-0009](ADR-0009-sqlite-state-layer.md) — sessions schema (extended by this ADR)
+- [ADR-0011](ADR-0011-shows-data-model.md) — play status vocabulary (richer, independent)
+- [ADR-0012](ADR-0012-studio-execution-lineage.md) — display mapping, dashboard cards, runs list
+- [ADR-0015](ADR-0015-runs-list-design.md) — runs list Status column (consumes this ADR)

--- a/docs/adrs/ADR-0017-session-lifecycle-status.md
+++ b/docs/adrs/ADR-0017-session-lifecycle-status.md
@@ -27,14 +27,24 @@ to inconsistent status computation across the runs list, dashboard, and detail p
 ### Add lifecycle columns to sessions
 
 ```sql
-ALTER TABLE sessions ADD COLUMN status     TEXT DEFAULT 'running';
+ALTER TABLE sessions ADD COLUMN status     TEXT;  -- NULL for existing rows
   -- running|completed|failed|aborted
 ALTER TABLE sessions ADD COLUMN started_at REAL;
 ALTER TABLE sessions ADD COLUMN ended_at   REAL;
+
+-- Backfill: existing sessions are historical (all completed or imported).
+-- New sessions get status='running' at INSERT time from the CLI.
+UPDATE sessions SET status = 'completed'
+  WHERE status IS NULL AND source_kind = 'imported_fs';
+UPDATE sessions SET status = 'completed'
+  WHERE status IS NULL;
 ```
 
 Migration: v3→v4, same idempotent `ALTER TABLE ADD COLUMN` pattern as prior
-migrations (ADR-0009 migration protocol).
+migrations (ADR-0009 migration protocol). The backfill conservatively marks all
+existing sessions as `completed` — the 376 historical sessions are all finished
+runs. New sessions get `status='running'` at INSERT time from the CLI, not from
+a column DEFAULT.
 
 ### Status vocabulary (sessions)
 

--- a/docs/adrs/DECISION_LOG.md
+++ b/docs/adrs/DECISION_LOG.md
@@ -11,6 +11,7 @@ boundary, plugin/editability semantics, transport/runtime, major UX architecture
 Decision: Use 100/page for runs list.
 Why: 376 sessions currently; 100 keeps render cost low without excessive paging.
 Revisit when: sessions exceed 2,000 or list render exceeds noticeable latency.
+See also ADR-0015 §4.
 
 ## 2026-05-20 — Plugin source badges show marketplace name, not "third-party"
 
@@ -35,6 +36,7 @@ react-hot-toast, sonner, or similar.
 Why: Zero component-library pattern (ADR-0013). Toast is simple enough that
 a custom implementation is cleaner than adding a dependency.
 Revisit when: ADR-0013's threshold (3+ complex primitives needed) is met.
+See also ADR-0013.
 
 ## 2026-05-20 — Errors section renamed to "Tool errors"
 
@@ -42,3 +44,4 @@ Decision: Run detail section labeled "Tool errors", not "Errors".
 Why: "Errors" implies session failure. "Tool errors" communicates that these are
 intermediate tool-level failures, not session-level outcomes. Paired with
 "intermediate tool errors" labeling on the Overview.
+See also ADR-0012 §3.

--- a/docs/adrs/DECISION_LOG.md
+++ b/docs/adrs/DECISION_LOG.md
@@ -1,0 +1,44 @@
+# Lion Studio Decision Log
+
+Lightweight decisions that don't warrant a full ADR. Full ADRs reserved for
+changes to: data authority, execution identity, persistence/schema, CLI-vs-Studio
+boundary, plugin/editability semantics, transport/runtime, major UX architecture.
+
+---
+
+## 2026-05-20 — Runs page pagination default is 100
+
+Decision: Use 100/page for runs list.
+Why: 376 sessions currently; 100 keeps render cost low without excessive paging.
+Revisit when: sessions exceed 2,000 or list render exceeds noticeable latency.
+
+## 2026-05-20 — Plugin source badges show marketplace name, not "third-party"
+
+Decision: Display actual marketplace directory name (e.g., `Anthropic Official`,
+`khive`) instead of generic "third-party" label. Raw slug in tooltip.
+Why: Multiple third-party sources exist; generic label hides provenance.
+Display mapping: `marketplace` → `Lion Marketplace`, `claude-plugins-official` →
+`Anthropic Official`, others → title-cased directory name.
+
+## 2026-05-20 — _show.md always collapsed on shows detail
+
+Decision: `_show.md` content collapsed by default on all shows (active, completed,
+imported). No auto-open.
+Why: Plays table + DAG + accordion are the primary surfaces. Two-column layout
+with open _show.md cramps the play accordion.
+Previous: auto-opened for active/running shows. Reverted after design review.
+
+## 2026-05-20 — Toast system is custom, not library
+
+Decision: Build custom Toast component (~155 LOC) instead of adopting
+react-hot-toast, sonner, or similar.
+Why: Zero component-library pattern (ADR-0013). Toast is simple enough that
+a custom implementation is cleaner than adding a dependency.
+Revisit when: ADR-0013's threshold (3+ complex primitives needed) is met.
+
+## 2026-05-20 — Errors section renamed to "Tool errors"
+
+Decision: Run detail section labeled "Tool errors", not "Errors".
+Why: "Errors" implies session failure. "Tool errors" communicates that these are
+intermediate tool-level failures, not session-level outcomes. Paired with
+"intermediate tool errors" labeling on the Overview.

--- a/docs/adrs/DECISION_LOG.md
+++ b/docs/adrs/DECISION_LOG.md
@@ -20,6 +20,7 @@ Decision: Display actual marketplace directory name (e.g., `Anthropic Official`,
 Why: Multiple third-party sources exist; generic label hides provenance.
 Display mapping: `marketplace` → `Lion Marketplace`, `claude-plugins-official` →
 `Anthropic Official`, others → title-cased directory name.
+See also ADR-0010 §5.
 
 ## 2026-05-20 — _show.md always collapsed on shows detail
 
@@ -28,6 +29,7 @@ imported). No auto-open.
 Why: Plays table + DAG + accordion are the primary surfaces. Two-column layout
 with open _show.md cramps the play accordion.
 Previous: auto-opened for active/running shows. Reverted after design review.
+See also ADR-0012 §8.
 
 ## 2026-05-20 — Toast system is custom, not library
 

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -52,11 +52,22 @@ Example: `_Supersedes [ADR-0001](ADR-0001-lion-studio-internal-app.md)._`
 
 | ADR | Title | Status |
 |-----|-------|--------|
-| [ADR-0001](ADR-0001-lion-studio-internal-app.md) | lion-studio as internal monorepo app | Accepted |
+| [ADR-0001](ADR-0001-lion-studio-internal-app.md) | Lion Studio as internal monorepo app | Accepted |
 | [ADR-0002](ADR-0002-studio-tech-stack.md) | Lion Studio tech stack | Accepted |
 | [ADR-0003](ADR-0003-claude-code-marketplace.md) | Claude Code marketplace | Accepted |
-| [ADR-0004](ADR-0004-filesystem-data-layer.md) | Filesystem-backed data layer | Accepted |
-| [ADR-0005](ADR-0005-workers-playbooks-rename.md) | Workers-to-playbooks rename strategy | Accepted |
-| [ADR-0006](ADR-0006-sse-live-streaming.md) | SSE for live streaming | Accepted |
+| [ADR-0004](ADR-0004-filesystem-data-layer.md) | Data layer — filesystem + SQLite hybrid | Accepted |
+| [ADR-0005](ADR-0005-workers-playbooks-rename.md) | Playbooks naming convention | Accepted |
+| [ADR-0006](ADR-0006-sse-live-streaming.md) | Live update transport — SSE + interval refresh | Accepted |
 | [ADR-0007](ADR-0007-plugin-auto-discovery.md) | Plugin manifest auto-discovery convention | Accepted |
-| [ADR-0008](ADR-0008-studio-v1-scope.md) | Lion Studio v1 scope | Accepted |
+| [ADR-0008](ADR-0008-studio-v1-scope.md) | Studio scope — CLI-primary, definition-editable, localhost | Accepted |
+| [ADR-0009](ADR-0009-sqlite-state-layer.md) | SQLite state layer for core data model | Accepted |
+| [ADR-0010](ADR-0010-plugin-aware-studio.md) | Plugin-aware Studio UI | Accepted |
+| [ADR-0011](ADR-0011-shows-data-model.md) | Shows data model — hybrid SQLite + filesystem | Accepted |
+| [ADR-0012](ADR-0012-studio-execution-lineage.md) | Studio execution lineage and UX redesign | Accepted |
+| [ADR-0013](ADR-0013-zero-dependency-ui.md) | Zero component-library UI | Accepted |
+| [ADR-0014](ADR-0014-cli-primary-studio-secondary.md) | CLI-primary, Studio-secondary | Accepted |
+| [ADR-0015](ADR-0015-runs-list-design.md) | Runs list design — identity, filters, pagination | Accepted |
+| [ADR-0016](ADR-0016-definitions-write-path.md) | Definition write path and versioning | Accepted |
+| [ADR-0017](ADR-0017-session-lifecycle-status.md) | Session lifecycle and status derivation | Accepted |
+
+See also [Decision Log](DECISION_LOG.md) for lightweight decisions that don't warrant a full ADR.


### PR DESCRIPTION
## Summary

Complete architecture decision record set for Lion Studio, covering all major design decisions from the initial monorepo structure through the execution lineage redesign.

- **16 ADRs** spanning architecture, data layer, plugins, scope, UX, and definitions
- **6 existing ADRs rewritten** to reflect current truth (0002, 0004, 0005, 0006, 0008, 0009)
- **10 new ADRs** for plugins (0010), shows data model (0011), execution lineage (0012), zero component-library UI (0013), CLI-primary scope (0014), runs list design (0015), definitions write path (0016)
- **Decision log** for lightweight non-structural decisions going forward

### ADR index

| ADR | Title |
|-----|-------|
| 0001 | Internal Monorepo App |
| 0002 | Tech Stack (updated appendices) |
| 0003 | Claude Code Marketplace |
| 0004 | Data Layer — Filesystem + SQLite Hybrid (rewritten) |
| 0005 | Playbooks Naming Convention (rewritten) |
| 0006 | Live Update Transport — SSE + Interval Refresh (rewritten) |
| 0007 | Plugin Auto-Discovery |
| 0008 | Studio Scope — CLI-Primary, Definition-Editable (rewritten) |
| 0009 | SQLite State Layer (amended: provenance, SSE) |
| 0010 | Plugin-Aware Studio UI + editability matrix |
| 0011 | Shows Data Model — hybrid SQLite + filesystem |
| 0012 | Execution Lineage & UX Redesign |
| 0013 | Zero Component-Library UI |
| 0014 | CLI-Primary, Studio-Secondary |
| 0015 | Runs List Design — identity, filters, pagination |
| 0016 | Definitions Write Path and Versioning |

## Test plan

- [ ] ADRs are documentation only — no code changes in this PR
- [ ] Verify no broken cross-references between ADRs
- [ ] Review for consistency with current codebase state

🤖 Generated with [Claude Code](https://claude.com/claude-code)