### PR TITLE
fix(operations): enforce caller-supplied timeout on CLI streaming runs

### DIFF
--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -114,90 +114,106 @@ async def run(
     pending_requests: dict[str, ActionRequest] = {}
     api_call_event = None
 
+    # Extract caller-supplied wall-clock timeout (seconds). The CLI-provider
+    # stream loops are unbounded — without an outer fail_after the codex /
+    # claude_code subprocess can run indefinitely even when the caller
+    # passed ``Branch.operate(timeout=N)`` or ``li agent --timeout N``.
+    # ``None`` / 0 / negative disables enforcement (back-compat with existing
+    # callers that never set a timeout). The downstream provider does NOT
+    # consume ``timeout`` — pop it so it doesn't pollute create_event kwargs.
+    _timeout = kw.pop("timeout", None)
+    _stream_timeout: float | None = None
+    if isinstance(_timeout, (int, float)) and _timeout > 0:
+        _stream_timeout = float(_timeout)
+
     kw["stream"] = True
     api_call = await model.create_event(**kw)
     await model.executor.append(api_call)
 
     try:
-        async for chunk in model.stream(api_call=api_call):
-            if isinstance(chunk, APICalling):
-                api_call_event = chunk
-                continue
+        # ``anyio.fail_after(None)`` is a no-op context, so we can wrap
+        # unconditionally and let the no-timeout case pay the (small)
+        # context-manager cost rather than branching the stream loop.
+        with anyio.fail_after(_stream_timeout):
+            async for chunk in model.stream(api_call=api_call):
+                if isinstance(chunk, APICalling):
+                    api_call_event = chunk
+                    continue
 
-            match chunk.type:
-                case "system":
-                    if sid := chunk.metadata.get("session_id"):
-                        endpoint.session_id = sid
+                match chunk.type:
+                    case "system":
+                        if sid := chunk.metadata.get("session_id"):
+                            endpoint.session_id = sid
 
-                case "thinking":
-                    if chunk.content:
-                        thinking_parts.append(chunk.content)
+                    case "thinking":
+                        if chunk.content:
+                            thinking_parts.append(chunk.content)
 
-                case "text":
-                    if chunk.content:
-                        text_parts.append(chunk.content)
+                    case "text":
+                        if chunk.content:
+                            text_parts.append(chunk.content)
 
-                case "tool_use":
-                    if res := await _flush_response():
-                        yield res
+                    case "tool_use":
+                        if res := await _flush_response():
+                            yield res
 
-                    act_req = branch.msgs.create_action_request(
-                        function=chunk.tool_name or "",
-                        arguments=chunk.tool_input or {},
-                        sender=branch.id,
-                        recipient=branch.user or "user",
-                    )
-                    if chunk.tool_id:
-                        pending_requests[chunk.tool_id] = act_req
-                    await branch.msgs.a_add_message(action_request=act_req)
-                    yield act_req
+                        act_req = branch.msgs.create_action_request(
+                            function=chunk.tool_name or "",
+                            arguments=chunk.tool_input or {},
+                            sender=branch.id,
+                            recipient=branch.user or "user",
+                        )
+                        if chunk.tool_id:
+                            pending_requests[chunk.tool_id] = act_req
+                        await branch.msgs.a_add_message(action_request=act_req)
+                        yield act_req
 
-                case "tool_result":
-                    orig_req = (
-                        pending_requests.pop(chunk.tool_id, None)
-                        if chunk.tool_id
-                        else None
-                    )
-                    if orig_req is None:
-                        continue
+                    case "tool_result":
+                        orig_req = (
+                            pending_requests.pop(chunk.tool_id, None)
+                            if chunk.tool_id
+                            else None
+                        )
+                        if orig_req is None:
+                            continue
 
-                    # Build the ActionResponse and attach is_error BEFORE
-                    # a_add_message so the live-persist hook (and any other
-                    # on_message_added callback) observes the final state.
-                    # Doing it after the await would let the hook serialize
-                    # an incomplete row that omits the error marker.
-                    act_res = branch.msgs.create_action_response(
-                        action_request=orig_req,
-                        action_output=chunk.tool_output,
-                        sender=branch.user or "user",
-                        recipient=branch.id,
-                    )
-                    if chunk.is_error:
-                        act_res.metadata["is_error"] = True
-                    await branch.msgs.a_add_message(
-                        action_request=orig_req,
-                        action_output=chunk.tool_output,
-                        action_response=act_res,
-                        sender=branch.user or "user",
-                        recipient=branch.id,
-                    )
-                    yield act_res
+                        # Build the ActionResponse and attach is_error BEFORE
+                        # a_add_message so the live-persist hook (and any other
+                        # on_message_added callback) observes the final state.
+                        # Doing it after the await would let the hook serialize
+                        # an incomplete row that omits the error marker.
+                        act_res = branch.msgs.create_action_response(
+                            action_request=orig_req,
+                            action_output=chunk.tool_output,
+                            sender=branch.user or "user",
+                            recipient=branch.id,
+                        )
+                        if chunk.is_error:
+                            act_res.metadata["is_error"] = True
+                        await branch.msgs.a_add_message(
+                            action_request=orig_req,
+                            action_output=chunk.tool_output,
+                            action_response=act_res,
+                            sender=branch.user or "user",
+                            recipient=branch.id,
+                        )
+                        yield act_res
 
-                case "result":
-                    pass
+                    case "result":
+                        pass
 
-                case "error":
-                    raise RuntimeError(
-                        chunk.content or "Stream error from CLI endpoint"
-                    )
+                    case "error":
+                        raise RuntimeError(
+                            chunk.content or "Stream error from CLI endpoint"
+                        )
 
-        # Flush remaining text — attach APICalling metadata to final response
-        if res := await _flush_response():
-            if api_call_event is not None:
-                call_meta = Note.from_dict(api_call_event.to_dict())
-                call_meta.pop(["execution", "response"], None)
-                res.metadata["api_call_meta"] = call_meta.to_dict()
-            yield res
+            # Flush remaining text — attach APICalling metadata to final response
+            if res := await _flush_response():
+                if api_call_event is not None:
+                    call_meta = Note.from_dict(api_call_event.to_dict())
+                    call_meta.pop(["execution", "response"], None)
+                    res.metadata["api_call_meta"] = call_meta.to_dict()
+                yield res
     finally:
         # Restore original streaming func
         model.streaming_process_func = prev_stream_func

--- a/tests/operations/run/test_run.py
+++ b/tests/operations/run/test_run.py
@@ -381,3 +381,98 @@ async def test_run_and_collect_parses_when_response_format_is_set(monkeypatch):
     assert result.value == 42
     assert len(parse_calls) == 1
     assert parse_calls[0] == '{"value": 42}'
+
+
+# ---------------------------------------------------------------------------
+# Timeout enforcement tests — regression for the "timeout silently ignored"
+# bug where ``branch.operate(timeout=N)`` / ``li agent --timeout N`` flowed
+# through ``imodel_kw`` into ``model.create_event(**kw)`` but the streaming
+# loop never wrapped the consumer with ``anyio.fail_after``, so CLI
+# subprocesses (codex, claude_code) ran unbounded.
+# ---------------------------------------------------------------------------
+
+
+def _make_slow_cli_model(chunk_delay: float, n_chunks: int = 100):
+    """A CLI iModel whose stream sleeps between each chunk. Use a long delay
+    + many chunks so the total runtime exceeds any test timeout."""
+    import anyio
+    from lionagi.service.types.stream_chunk import StreamChunk
+
+    m = iModel(provider="openai", model="gpt-4.1-mini", api_key="test_key")
+    endpoint_ns = types.SimpleNamespace(
+        is_cli=True,
+        session_id=None,
+        to_dict=lambda: {"type": "fake_cli", "session_id": None},
+    )
+    m.endpoint = endpoint_ns
+    m.streaming_process_func = None
+    captured: dict = {}
+
+    async def create_event(**kw):
+        captured.update(kw)
+        return object()
+
+    m.create_event = create_event
+    m.executor = types.SimpleNamespace(append=AsyncMock(), config={})
+
+    async def stream(api_call=None):
+        for _ in range(n_chunks):
+            await anyio.sleep(chunk_delay)
+            yield StreamChunk(type="text", content="x")
+
+    m.stream = stream
+    return m, captured
+
+
+async def test_run_honors_caller_timeout_on_slow_stream():
+    """When the caller passes ``timeout=N`` via imodel_kw, the stream loop
+    raises TimeoutError once N seconds elapse, even if the upstream provider
+    would otherwise stream forever."""
+    import time
+
+    model, _ = _make_slow_cli_model(chunk_delay=0.5, n_chunks=20)
+    branch = Branch()
+    branch.chat_model = model
+
+    started = time.monotonic()
+    # 0.15s ceiling — first chunk lands at 0.5s, so we MUST hit the timeout
+    # before any chunk arrives; safety budget 1s.
+    with pytest.raises(TimeoutError):
+        async for _ in run(branch, "go", RunParam(imodel_kw={"timeout": 0.15})):
+            pass
+    elapsed = time.monotonic() - started
+
+    # Should fire close to 0.15s, well under the 0.5s first chunk delay.
+    assert elapsed < 0.5, f"timeout fired too late: {elapsed:.2f}s"
+
+
+async def test_run_no_timeout_when_kwarg_absent():
+    """Back-compat: callers that don't supply timeout get the legacy
+    unbounded behaviour (subject to chunk count, not wall clock)."""
+    from lionagi.service.types.stream_chunk import StreamChunk
+
+    model, _ = _make_slow_cli_model(chunk_delay=0.0, n_chunks=3)
+    branch = Branch()
+    branch.chat_model = model
+
+    results = await _collect(run(branch, "go", RunParam()))
+    text_msgs = [r for r in results if isinstance(r, AssistantResponse)]
+    # 3 chunks of "x" → single flushed AssistantResponse with "xxx".
+    assert len(text_msgs) == 1
+    assert text_msgs[0].response == "xxx"
+
+
+async def test_run_strips_timeout_from_create_event_kwargs():
+    """The provider does NOT consume ``timeout``; verify it is popped from
+    kw before create_event sees it (otherwise codex would receive an
+    unexpected kwarg and may crash)."""
+    from lionagi.service.types.stream_chunk import StreamChunk
+
+    model, captured = _make_slow_cli_model(chunk_delay=0.0, n_chunks=1)
+    branch = Branch()
+    branch.chat_model = model
+
+    await _collect(run(branch, "hi", RunParam(imodel_kw={"timeout": 5})))
+    assert "timeout" not in captured, (
+        f"timeout leaked into create_event kwargs: {captured!r}"
+    )


### PR DESCRIPTION
## The bug

\`Branch.operate(timeout=N)\` and \`li agent --timeout N\` were silently
ignored on CLI agentic providers (codex, claude_code).

The timeout flowed through \`imodel_kw\` → \`model.create_event(**kw)\` →
\`model.stream(api_call=api_call)\`, but the consumer loop in
\`lionagi/operations/run/run.py:122\` never wrapped that consumption in
any cancellation context. So the wrapping CLI subprocess could run
indefinitely.

Observed: a codex review run with \`li agent --effort high --timeout 900\`
chewed for 24+ minutes after the requested 15-minute ceiling.

## The fix

1. Extract \`timeout\` from \`kw\` before \`create_event(**kw)\` — the codex
   provider doesn't consume \`timeout\` and leaving it in kwargs is at
   best dead weight, at worst a kwarg conflict.
2. Wrap the \`async for chunk in model.stream(...)\` block in
   \`anyio.fail_after(_stream_timeout)\`. \`anyio.fail_after(None)\` is
   documented as a no-op, so callers that never set a timeout get the
   pre-existing unbounded behaviour.
3. On timeout, anyio raises \`TimeoutError\`, which propagates through
   the existing \`finally\` block. For codex, \`_ndjson_from_cli\` already
   calls \`os.killpg(pgid, SIGTERM)\` on its process group, so the codex
   CLI subtree gets cleaned up correctly when the cancel fires.

## Regression tests

3 new tests in \`tests/operations/run/test_run.py\`:

- \`test_run_honors_caller_timeout_on_slow_stream\` — slow stream
  (0.5s/chunk) with \`timeout=0.15\` must raise \`TimeoutError\` before
  the first chunk lands
- \`test_run_no_timeout_when_kwarg_absent\` — back-compat: no timeout
  kwarg → no enforcement, stream completes normally
- \`test_run_strips_timeout_from_create_event_kwargs\` — \`timeout\` must
  be popped from \`kw\` before \`create_event(**kw)\`

## Test plan

- [x] \`uv run pytest tests/operations/run/test_run.py -o addopts=''\` — 14/14 passed
- [x] \`uv run pytest tests/operations/ tests/cli/ -o addopts=''\` — 618 passed, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)