### PR TITLE
test: apply integration marker to completion stream tests

### DIFF
--- a/tests/libs/concurrency/test_completion_stream.py
+++ b/tests/libs/concurrency/test_completion_stream.py
@@ -12,8 +12,11 @@ import pytest
 
 from lionagi.ln.concurrency.patterns import CompletionStream
 
-pytestmark = pytest.mark.anyio
-
+pytestmark = [
+    pytest.mark.anyio,
+    pytest.mark.integration,
+]
+# 
 
 # =============================================================================
 # Basic Lifecycle Tests


### PR DESCRIPTION
## Summary

Added the `integration` pytest marker to CompletionStream tests.

## Changes

* Added `pytest.mark.integration`
* Kept existing `pytest.mark.anyio`
* No functional test behavior changed

## Validation

* Ran targeted pytest execution locally
* Confirmed test collection still works

## Purpose

Improve test categorization and support separating integration tests from fast test runs.
