### PR TITLE
fix(show): add bypass to li play team mode commands

### DIFF
--- a/marketplace/show/skills/show/SKILL.md
+++ b/marketplace/show/skills/show/SKILL.md
@@ -297,11 +297,11 @@ jq -n \
   --save "$SHOW_DIR/$PLAY" \
   --cwd "$WT" \
   --yolo \
+  --bypass \
   --effort <low|medium|high> \
   --team-mode "show_${TOPIC}_${PLAY}"
 EC=$?
 
-# Record exit + ended_at
 tmp=$(mktemp)
 jq --argjson ec "$EC" --arg t "$(date -Iseconds)" \
   '.exit_code=$ec | .ended_at=$t | .status="running_complete"' \
@@ -319,6 +319,7 @@ always recorded, even if the director's shell crashes between fire and wait.
     --save "$SHOW_DIR/$PLAY" \
     --cwd "$WT" \
     --yolo \
+    --bypass \
     --effort <low|medium|high> \
     --team-mode "show_${TOPIC}_${PLAY}"
   ec=$?


### PR DESCRIPTION
## Summary

Added the missing `--bypass` flag to `li play` commands executed in team mode.

## Changes

* Added `--bypass` after `--yolo`
* Updated all affected `li play` invocations

## Impact

Prevents approval stalls during team coordination writes and keeps execution flow consistent.
