### PR TITLE
chore(marketplace): add gitignore for local artifacts

### DIFF
--- a/marketplace/.gitignore
+++ b/marketplace/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+*.swp
+__pycache__/
+.venv/
+*.bak


### PR DESCRIPTION
## Summary

Added a dedicated `.gitignore` for marketplace files to avoid committing local artifacts and editor-generated files.

## Changes

* Added `marketplace/.gitignore`
* Ignored common local files and temporary artifacts:

  * `.DS_Store`
  * `*.swp`
  * `__pycache__/`
  * `.venv/`
  * `*.bak`

## Impact

Helps keep marketplace installs and contributor changes clean by preventing accidental commits of local environment files.
