### PR TITLE
chore(marketplace): update repository references

### DIFF
--- a/marketplace/README.md
+++ b/marketplace/README.md
@@ -10,7 +10,7 @@ The lionagi marketplace bundles curated skills, agents, and configuration into i
 
 ```bash
 # Add the lionagi marketplace to Claude Code
-claude /plugin marketplace add khive-ai/lionagi
+claude /plugin marketplace add ohdearquant/lionagi
 
 # Install a specific plugin
 claude /plugin install show@lionagi

--- a/marketplace/devx/.claude-plugin/plugin.json
+++ b/marketplace/devx/.claude-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "Ocean (HaiyangLi)",
     "url": "https://github.com/ohdearquant"
   },
-  "homepage": "https://github.com/khive-ai/lionagi",
-  "repository": "https://github.com/khive-ai/lionagi",
+  "homepage": "https://github.com/ohdearquant/lionagi",
+  "repository": "https://github.com/ohdearquant/lionagi",
   "license": "Apache-2.0",
   "keywords": ["developer-experience", "commit", "ci", "formatting", "session"]
 }

--- a/marketplace/kg-bridge/.claude-plugin/plugin.json
+++ b/marketplace/kg-bridge/.claude-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "Ocean (HaiyangLi)",
     "url": "https://github.com/ohdearquant"
   },
-  "homepage": "https://github.com/khive-ai/lionagi",
-  "repository": "https://github.com/khive-ai/lionagi",
+  "homepage": "https://github.com/ohdearquant/lionagi",
+  "repository": "https://github.com/ohdearquant/lionagi",
   "license": "Apache-2.0",
   "keywords": ["knowledge-graph", "khive", "bridge", "entities"]
 }

--- a/marketplace/kg-bridge/README.md
+++ b/marketplace/kg-bridge/README.md
@@ -11,7 +11,7 @@ Bridge lionagi runs/agents to khive's knowledge graph — opt-in, implementation
 ## Install
 
 ```
-claude /plugin marketplace add khive-ai/lionagi
+claude /plugin marketplace add ohdearquant/lionagi
 claude /plugin install kg-bridge@lionagi
 ```
 

--- a/marketplace/mcp-bundle/.claude-plugin/plugin.json
+++ b/marketplace/mcp-bundle/.claude-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "Ocean (HaiyangLi)",
     "url": "https://github.com/ohdearquant"
   },
-  "homepage": "https://github.com/khive-ai/lionagi",
-  "repository": "https://github.com/khive-ai/lionagi",
+  "homepage": "https://github.com/ohdearquant/lionagi",
+  "repository": "https://github.com/ohdearquant/lionagi",
   "license": "Apache-2.0",
   "keywords": ["mcp", "server", "tools", "agents"],
   "mcpServers": {

--- a/marketplace/memory/.claude-plugin/plugin.json
+++ b/marketplace/memory/.claude-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "Ocean (HaiyangLi)",
     "url": "https://github.com/ohdearquant"
   },
-  "homepage": "https://github.com/khive-ai/lionagi",
-  "repository": "https://github.com/khive-ai/lionagi",
+  "homepage": "https://github.com/ohdearquant/lionagi",
+  "repository": "https://github.com/ohdearquant/lionagi",
   "license": "Apache-2.0",
   "keywords": ["memory", "recall", "auto-memory", "context"]
 }

--- a/marketplace/memory/README.md
+++ b/marketplace/memory/README.md
@@ -15,7 +15,7 @@ Memory recall, MEMORY.md hygiene, and auto-memory bootstrap for Claude Code sess
 ## Install
 
 ```
-claude /plugin marketplace add khive-ai/lionagi
+claude /plugin marketplace add ohdearquant/lionagi
 claude /plugin install memory@lionagi
 ```
 

--- a/marketplace/orchestrate/.claude-plugin/plugin.json
+++ b/marketplace/orchestrate/.claude-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "Ocean (HaiyangLi)",
     "url": "https://github.com/ohdearquant"
   },
-  "homepage": "https://github.com/khive-ai/lionagi",
-  "repository": "https://github.com/khive-ai/lionagi",
+  "homepage": "https://github.com/ohdearquant/lionagi",
+  "repository": "https://github.com/ohdearquant/lionagi",
   "license": "Apache-2.0",
   "keywords": ["multi-agent", "fanout", "flow", "dag"]
 }

--- a/marketplace/orchestrate/README.md
+++ b/marketplace/orchestrate/README.md
@@ -12,7 +12,7 @@ DAG orchestration planning and execution via `li o flow` and `li o fanout`.
 ## Install
 
 ```
-claude /plugin marketplace add khive-ai/lionagi
+claude /plugin marketplace add ohdearquant/lionagi
 claude /plugin install orchestrate@lionagi
 ```
 

--- a/marketplace/play/.claude-plugin/plugin.json
+++ b/marketplace/play/.claude-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "Ocean (HaiyangLi)",
     "url": "https://github.com/ohdearquant"
   },
-  "homepage": "https://github.com/khive-ai/lionagi",
-  "repository": "https://github.com/khive-ai/lionagi",
+  "homepage": "https://github.com/ohdearquant/lionagi",
+  "repository": "https://github.com/ohdearquant/lionagi",
   "license": "Apache-2.0",
   "keywords": ["playbook", "authoring", "flow", "pipeline"]
 }

--- a/marketplace/play/README.md
+++ b/marketplace/play/README.md
@@ -9,7 +9,7 @@ Playbook authoring for lionagi orchestration flows (`li play` / `li o flow`).
 ## Install
 
 ```
-claude /plugin marketplace add khive-ai/lionagi
+claude /plugin marketplace add ohdearquant/lionagi
 claude /plugin install play@lionagi
 ```
 

--- a/marketplace/research/.claude-plugin/plugin.json
+++ b/marketplace/research/.claude-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "Ocean (HaiyangLi)",
     "url": "https://github.com/ohdearquant"
   },
-  "homepage": "https://github.com/khive-ai/lionagi",
-  "repository": "https://github.com/khive-ai/lionagi",
+  "homepage": "https://github.com/ohdearquant/lionagi",
+  "repository": "https://github.com/ohdearquant/lionagi",
   "license": "Apache-2.0",
   "keywords": ["research", "web-search", "synthesis", "multi-perspective"]
 }

--- a/marketplace/research/README.md
+++ b/marketplace/research/README.md
@@ -15,7 +15,7 @@ Multi-perspective research with web search, codebase analysis, and synthesis.
 ## Install
 
 ```
-claude /plugin marketplace add khive-ai/lionagi
+claude /plugin marketplace add ohdearquant/lionagi
 claude /plugin install research@lionagi
 ```
 

--- a/marketplace/show/.claude-plugin/plugin.json
+++ b/marketplace/show/.claude-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "Ocean (HaiyangLi)",
     "url": "https://github.com/ohdearquant"
   },
-  "homepage": "https://github.com/khive-ai/lionagi",
-  "repository": "https://github.com/khive-ai/lionagi",
+  "homepage": "https://github.com/ohdearquant/lionagi",
+  "repository": "https://github.com/ohdearquant/lionagi",
   "license": "Apache-2.0",
   "keywords": ["orchestration", "dag", "worktree", "critic", "plays"]
 }

--- a/marketplace/show/README.md
+++ b/marketplace/show/README.md
@@ -12,7 +12,7 @@ Structured content review orchestration with play-gate, show-final-gate, and cri
 ## Install
 
 ```
-claude /plugin marketplace add khive-ai/lionagi
+claude /plugin marketplace add ohdearquant/lionagi
 claude /plugin install show@lionagi
 ```
 

--- a/marketplace/studio/.claude-plugin/plugin.json
+++ b/marketplace/studio/.claude-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "Ocean (HaiyangLi)",
     "url": "https://github.com/ohdearquant"
   },
-  "homepage": "https://github.com/khive-ai/lionagi",
-  "repository": "https://github.com/khive-ai/lionagi",
+  "homepage": "https://github.com/ohdearquant/lionagi",
+  "repository": "https://github.com/ohdearquant/lionagi",
   "license": "Apache-2.0",
   "keywords": ["dashboard", "monitoring", "fastapi", "mcp", "ui"],
   "mcpServers": {


### PR DESCRIPTION
## Summary

Updated marketplace repository and install references to use the current repository owner.

## Changes

* Replaced `khive-ai/lionagi` with `ohdearquant/lionagi`
* Updated plugin metadata fields
* Updated marketplace installation examples

## Impact

Keeps marketplace metadata and onboarding instructions aligned with the current repository location.
