### PR TITLE
docs(show): clarify plugin scope and positioning

### DIFF
--- a/marketplace/show/README.md
+++ b/marketplace/show/README.md
@@ -1,6 +1,8 @@
 # show
 
-Structured content review orchestration with play-gate, show-final-gate, and critic gating.
+Direct multi-play DAGs of li play invocations with per-play gates, worktree isolation, and adaptive show-level synthesis. Use when a goal spans ≥3 plays where outputs cascade.
+
+For single-play multi-agent DAGs (one playbook, many workers), see the orchestrate plugin.
 
 ## What's inside
 


### PR DESCRIPTION
## Summary

Updated the show plugin README to better reflect the plugin's actual scope and positioning.

## Changes

* Replaced the use-case-focused description with a capability-focused description
* Clarified that show orchestrates multi-play DAG workflows
* Added guidance to use orchestrate for single-play multi-agent DAGs

## Impact

Improves discoverability and reduces confusion between show and orchestrate workflows.
