### PR TITLE
fix: TOCTOU prune, multiline yolo lint, manifest validation

### DIFF
--- a/apps/studio/server/services/admin.py
+++ b/apps/studio/server/services/admin.py
@@ -127,6 +127,8 @@ async def list_phantom_sessions(*, stale_hours: float = 1.0) -> list[dict[str, A
                     "session_id": row["id"],
                     "playbook": row["playbook_name"] or row["name"],
                     "started_at": row["started_at"],
+                    "updated_at": row["updated_at"] or 0.0,
+                    "artifacts_path": row["artifacts_path"],
                     "reason": reason,
                 }
             )
@@ -198,11 +200,14 @@ async def prune_phantom_sessions(*, stale_hours: float = 1.0) -> int:
         if p.get("reason") in ("process_dead", "stale_lock")
     ]
     artifact_entries = [
-        (p["session_id"], p.get("started_at", 0))
+        {
+            "id": p["session_id"],
+            "classified_updated_at": p.get("updated_at", 0),
+            "artifacts_path": p.get("artifacts_path"),
+        }
         for p in phantoms
         if p.get("reason") == "missing_artifacts"
     ]
-    artifact_ids = [e[0] for e in artifact_entries]
 
     pruned = 0
     async with _open_db(_DB) as db:
@@ -216,13 +221,15 @@ async def prune_phantom_sessions(*, stale_hours: float = 1.0) -> int:
             await db.commit()
             pruned += cur.rowcount or 0
 
-        if artifact_ids:
-            placeholders = ",".join("?" * len(artifact_ids))
+        for entry in artifact_entries:
+            ap = Path(entry["artifacts_path"]) if entry["artifacts_path"] else None
+            if ap and ap.exists():
+                continue
             cur = await db.execute(
-                f"DELETE FROM sessions WHERE id IN ({placeholders})"  # noqa: S608
+                "DELETE FROM sessions WHERE id = ?"
                 " AND status = 'running'"
                 " AND (updated_at IS NULL OR updated_at <= ?)",
-                (*artifact_ids, stale_cutoff),
+                (entry["id"], entry["classified_updated_at"]),
             )
             await db.commit()
             pruned += cur.rowcount or 0

--- a/marketplace/scripts/validate_manifests.py
+++ b/marketplace/scripts/validate_manifests.py
@@ -8,7 +8,9 @@ from pathlib import Path
 
 PLUGIN_REQUIRED = ["name", "source", "description"]
 TOP_REQUIRED = ["name", "version", "description"]
-PER_PLUGIN_REQUIRED = ["name", "version"]
+PER_PLUGIN_REQUIRED = ["name", "version", "description"]
+PER_PLUGIN_STRING_FIELDS = ["name", "version", "description"]
+PER_PLUGIN_OPTIONAL_STRINGS = ["repository", "license", "homepage"]
 
 
 def main() -> int:
@@ -102,6 +104,28 @@ def main() -> int:
                             print(f"FAIL [{name}]: plugin.json missing required field '{field}'")
                             plugin_ok = False
                             failures += 1
+                    for field in PER_PLUGIN_STRING_FIELDS:
+                        val = per_plugin.get(field)
+                        if val is not None and not isinstance(val, str):
+                            print(f"FAIL [{name}]: plugin.json '{field}' must be a string, got {type(val).__name__}")
+                            plugin_ok = False
+                            failures += 1
+                    for field in PER_PLUGIN_OPTIONAL_STRINGS:
+                        val = per_plugin.get(field)
+                        if val is not None and not isinstance(val, str):
+                            print(f"FAIL [{name}]: plugin.json '{field}' must be a string, got {type(val).__name__}")
+                            plugin_ok = False
+                            failures += 1
+                    author = per_plugin.get("author")
+                    if author is not None and not isinstance(author, dict):
+                        print(f"FAIL [{name}]: plugin.json 'author' must be an object, got {type(author).__name__}")
+                        plugin_ok = False
+                        failures += 1
+                    mcp = per_plugin.get("mcpServers")
+                    if mcp is not None and not isinstance(mcp, dict):
+                        print(f"FAIL [{name}]: plugin.json 'mcpServers' must be an object, got {type(mcp).__name__}")
+                        plugin_ok = False
+                        failures += 1
                     # Reject stub mcpServers entries
                     for server_cfg in per_plugin.get("mcpServers", {}).values():
                         if server_cfg.get("type") == "stub":

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -127,21 +127,45 @@ lint-marketplace() {
   echo "==> marketplace content lint"
   cd "$REPO_ROOT"
   local rc=0
+  local SCAN_PATHS="marketplace/ .claude-plugin/ README.md"
 
   echo "  checking absolute paths..."
-  if rg --hidden "/Users/lion" marketplace/ .claude-plugin/ README.md 2>/dev/null; then
+  if rg --hidden "/Users/lion" $SCAN_PATHS 2>/dev/null; then
     echo "  FAIL: absolute paths found"; rc=1
   fi
 
   echo "  checking stale repo refs..."
-  if rg --hidden "khive-ai/lionagi" marketplace/ .claude-plugin/ README.md 2>/dev/null; then
+  if rg --hidden "khive-ai/lionagi" $SCAN_PATHS 2>/dev/null; then
     echo "  FAIL: stale khive-ai/lionagi refs found"; rc=1
   fi
 
   echo "  checking yolo without bypass..."
-  # NOTE: line-based check; multiline li play commands may need manual review
-  if rg --hidden 'li play.*--yolo' marketplace/ .claude-plugin/ 2>/dev/null | grep -v -- '--bypass' | grep -q .; then
-    echo "  FAIL: --yolo without --bypass found"; rc=1
+  # Multiline-aware: join backslash-continued lines before checking
+  # for --yolo without --bypass.
+  if _has_cmd python3 || _has_cmd python; then
+    local py=$(_has_cmd python3 && echo python3 || echo python)
+    local yolo_files
+    yolo_files=$(rg -l --hidden 'li play' $SCAN_PATHS 2>/dev/null || true)
+    if [ -n "$yolo_files" ]; then
+      if ! echo "$yolo_files" | xargs "$py" -c "
+import sys, re
+rc = 0
+for path in sys.argv[1:]:
+    text = open(path).read()
+    joined = re.sub(r'\\\\\n\s*', ' ', text)
+    for m in re.finditer(r'li play[^\n]*--yolo[^\n]*', joined):
+        if '--bypass' not in m.group():
+            print(f'{path}: {m.group().strip()[:120]}')
+            rc = 1
+sys.exit(rc)
+"; then
+        echo "  FAIL: --yolo without --bypass found"; rc=1
+      fi
+    fi
+  else
+    if rg --hidden 'li play.*--yolo' $SCAN_PATHS 2>/dev/null | grep -v -- '--bypass' | grep -q .; then
+      echo "  FAIL: --yolo without --bypass found"; rc=1
+    fi
   fi
 
   echo "  validating manifests..."


### PR DESCRIPTION
## Summary

Fixes two remaining bugs found during design review: a backend TOCTOU issue and a marketplace lint gap.

- **Backend TOCTOU** (`admin.py`): the `missing_artifacts` phantom prune path guarded on `status = 'running'` but not on the row's `updated_at` at classification time. A session that created its artifacts directory and heartbeated after classification would still be deleted. Fixed by: (1) capturing `updated_at` per phantom at classification time, (2) re-checking artifact absence before delete, (3) guarding with `updated_at <= classified_updated_at`.
- **Marketplace lint** (`ci.sh`): `--yolo` without `--bypass` check was line-based, missing multiline commands with backslash continuation. Replaced with a Python checker that joins continued lines before matching. Also centralized `SCAN_PATHS` so `README.md` is included in all content checks.
- **Manifest validation** (`validate_manifests.py`): expanded required fields from `name+version` to `name+version+description`. Added type validation for string fields, author as object, mcpServers as object.

## Test plan

- [x] `pytest tests/apps_studio_server/test_admin.py` — 4 passed
- [x] `pytest tests/apps_studio_server/test_security_batch1.py` — 16 passed (20 total)
- [x] `ruff check` on changed Python files — clean
- [x] `scripts/ci.sh lint-marketplace` — PASS
- [x] `marketplace/scripts/validate_manifests.py` — all 9 plugins pass
- [x] Multiline yolo detection verified with synthetic test cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)