### PR TITLE
docs: ADRs 0019–0025 — Lion Studio v2 architecture

### DIFF
--- a/docs/adrs/ADR-0019-teams-db-and-run-lifecycle.md
+++ b/docs/adrs/ADR-0019-teams-db-and-run-lifecycle.md
@@ -210,10 +210,11 @@ The dashboard gains two new cards from these signals:
 
 ### Status vocabulary update
 
-The session `status` CHECK constraint is unchanged — `stale` is NOT a DB
-value. The base DB statuses (`running`, `completed`, `failed`, `aborted`)
-are extended by ADR-0025 with `timed_out` and `cancelled`. `stale` exists
-only in the API response as a derived health indicator (see ADR-0024).
+This ADR does not modify the session status vocabulary or CHECK
+constraint. `stale` is NOT a stored status — it is a derived health
+indicator computed at read time (see ADR-0024). The session status
+vocabulary and its validation strategy (including CHECK removal) are
+governed entirely by ADR-0025.
 
 The runs list API response shape adds:
 

--- a/docs/adrs/ADR-0019-teams-db-and-run-lifecycle.md
+++ b/docs/adrs/ADR-0019-teams-db-and-run-lifecycle.md
@@ -268,7 +268,7 @@ Frontend renders `effective_health` for the pill color. Tooltip shows raw
 - [ADR-0009](ADR-0009-sqlite-state-layer.md) — SQLite state layer (teams table extends this)
 - [ADR-0017](ADR-0017-session-lifecycle-status.md) — Session lifecycle (staleness extends this)
 - [ADR-0012](ADR-0012-studio-execution-lineage.md) — Execution lineage (team linkage extends this)
-- [ChatGPT frontend design review](.khive/workspaces/20260521/chatgpt-frontend-review.md) — Teams page redesign (section 9), member sidebar + activity timeline, message summary/collapse, linked sessions; 60m threshold confirmation (section 2)
+- ChatGPT frontend design review (external, not in repo) — Teams page redesign (section 9), member sidebar + activity timeline, message summary/collapse, linked sessions; 60m threshold confirmation (section 2)
 - `lionagi/cli/team.py` — Current file-based team implementation
 - `apps/studio/server/services/admin.py` — Current phantom session detection
 - `apps/studio/server/services/sessions.py` — Current session queries

--- a/docs/adrs/ADR-0019-teams-db-and-run-lifecycle.md
+++ b/docs/adrs/ADR-0019-teams-db-and-run-lifecycle.md
@@ -94,8 +94,11 @@ the DB is populated via a dual-write layer. This preserves backward
 compatibility during the transition:
 
 1. **Phase 1 (this ADR)**: Add tables. Studio reads from DB. `li team`
-   writes to both JSON and DB (dual-write in `_locked_team`). New
-   `li state import-teams` backfills existing JSON files into the DB.
+   writes to both JSON and DB. The JSON write stays synchronous
+   under `_locked_team`'s `fcntl.flock`; the DB write happens
+   after the lock release via a sync SQLite helper (not async
+   `StateDB`) to avoid mixing sync file locks with async DB.
+   New `li state import-teams` backfills existing JSON files into the DB.
 2. **Phase 2 (future)**: `li team` writes DB-only. JSON files become
    optional export (`li team export`). `fcntl.flock` replaced by DB
    transactions.
@@ -142,10 +145,15 @@ STALE_THRESHOLDS = {
 }
 DEFAULT_STALE_THRESHOLD = 6 * 3600  # 6h fallback
 
-def effective_health(session: dict, *, now: float) -> str:
-    raw = session["status"]
-    if raw != "running":
-        return raw
+def staleness_check(session: dict, *, now: float) -> str | None:
+    """Return 'stale' if a running session exceeds its activity threshold.
+
+    Returns None for terminal sessions (health classification is
+    handled by ADR-0024's classify_session_health). This function
+    only answers one question: is this running session still active?
+    """
+    if session["status"] != "running":
+        return None  # terminal — defer to ADR-0024 health classifier
 
     threshold = STALE_THRESHOLDS.get(
         session.get("invocation_kind"), DEFAULT_STALE_THRESHOLD
@@ -154,7 +162,7 @@ def effective_health(session: dict, *, now: float) -> str:
     if now - last_activity > threshold:
         return "stale"
 
-    return "running"
+    return None
 ```
 
 Key properties:

--- a/docs/adrs/ADR-0019-teams-db-and-run-lifecycle.md
+++ b/docs/adrs/ADR-0019-teams-db-and-run-lifecycle.md
@@ -130,7 +130,7 @@ transaction as the progression append). This is cheaper than computing
 #### B2. Staleness heuristic (computed, not stored)
 
 Staleness is a **derived status** computed at read time, not a stored
-column. The runs list and dashboard compute `effective_status` from:
+column. The runs list and dashboard compute `effective_health` from:
 
 ```python
 STALE_THRESHOLDS = {
@@ -142,7 +142,7 @@ STALE_THRESHOLDS = {
 }
 DEFAULT_STALE_THRESHOLD = 6 * 3600  # 6h fallback
 
-def effective_status(session: dict, *, now: float) -> str:
+def effective_health(session: dict, *, now: float) -> str:
     raw = session["status"]
     if raw != "running":
         return raw
@@ -180,7 +180,7 @@ async def transition_stale_sessions(
     """Mark stale running sessions as failed.
 
     Only transitions sessions where:
-    1. effective_status == 'stale' (no message activity past threshold)
+    1. effective_health == 'stale' (no message activity past threshold)
     2. Process is confirmed dead (PID check + ps scan)
 
     Returns list of transitioned session IDs with reason.
@@ -203,21 +203,22 @@ The dashboard gains two new cards from these signals:
 ### Status vocabulary update
 
 The session `status` CHECK constraint is unchanged — `stale` is NOT a DB
-value. The four DB statuses remain: `running`, `completed`, `failed`,
-`aborted`. `stale` exists only in the API response as `effective_status`.
+value. The base DB statuses (`running`, `completed`, `failed`, `aborted`)
+are extended by ADR-0025 with `timed_out` and `cancelled`. `stale` exists
+only in the API response as a derived health indicator (see ADR-0024).
 
 The runs list API response shape adds:
 
 ```json
 {
   "status": "running",
-  "effective_status": "stale",
+  "effective_health": "stale",
   "last_message_at": 1716300000.0,
   "message_count": 42
 }
 ```
 
-Frontend renders `effective_status` for the pill color. Tooltip shows raw
+Frontend renders `effective_health` for the pill color. Tooltip shows raw
 `status` for disambiguation.
 
 ## Consequences

--- a/docs/adrs/ADR-0019-teams-db-and-run-lifecycle.md
+++ b/docs/adrs/ADR-0019-teams-db-and-run-lifecycle.md
@@ -1,0 +1,264 @@
+# ADR-0019: Teams DB Migration and Run Lifecycle Management
+
+**Status**: Proposed
+**Date**: 2026-05-21
+**Extends**: ADR-0009 (SQLite state layer), ADR-0017 (session lifecycle)
+
+## Context
+
+Two operational gaps in Lion Studio:
+
+### 1. Teams are file-only
+
+`li team` stores all state in `~/.lionagi/teams/*.json` with `fcntl.flock`
+for concurrent writes. The Studio teams page (`services/teams.py`) reads
+these files directly — it has no DB backing, no history, no queryable
+metadata. This means:
+
+- No team activity timeline (who sent what, when).
+- No cross-reference between teams and the sessions/runs they coordinate.
+- No pruning, no archival — stale team files accumulate indefinitely.
+- The `flock`-based concurrency model doesn't compose with async DB
+  transactions that the rest of Studio uses.
+
+### 2. Runs have no stale detection
+
+ADR-0017 gave sessions a `status` column (`running`, `completed`, `failed`,
+`aborted`), but status transitions depend entirely on the CLI writing them
+at session close. When a process crashes, gets OOM-killed, or simply hangs
+indefinitely, the session stays `status = 'running'` forever.
+
+The admin `doctor` endpoint detects "phantom" sessions via PID checks and
+`updated_at` staleness, but this is:
+
+- **Reactive only** — requires an operator to hit `/api/admin/doctor`.
+- **Not surfaced on the runs list** — a dead run shows green "running" pill.
+- **Using a single staleness threshold** (`stale_hours`, default 1h) that
+  doesn't account for run type. A flow with 10 agents legitimately runs for
+  hours; a single-agent run with no message progression for 6 hours is dead.
+
+Observable failure mode: single-agent runs that crash show as "running"
+indefinitely. The signal is clear — no new messages for hours, process gone
+— but nothing acts on it.
+
+## Decision
+
+### Part A: Teams table in state.db
+
+Add a `teams` table and a `team_messages` table to the state schema:
+
+```sql
+CREATE TABLE IF NOT EXISTS teams (
+  id              TEXT    PRIMARY KEY,
+  name            TEXT    NOT NULL,
+  created_at      REAL    NOT NULL,
+  updated_at      REAL    NOT NULL,
+  member_count    INTEGER NOT NULL DEFAULT 0,
+  members         JSON    NOT NULL DEFAULT '[]',  -- array of member name strings
+  node_metadata   JSON,                           -- team config, coordination mode
+  status          TEXT    NOT NULL DEFAULT 'active' CHECK(
+                    status IN ('active', 'archived')
+                  )
+);
+
+CREATE INDEX IF NOT EXISTS idx_teams_name ON teams(name);
+CREATE INDEX IF NOT EXISTS idx_teams_updated ON teams(updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_teams_status ON teams(status);
+
+CREATE TABLE IF NOT EXISTS team_messages (
+  id              TEXT    PRIMARY KEY,
+  team_id         TEXT    NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  created_at      REAL    NOT NULL,
+  sender          TEXT    NOT NULL,                -- member name or "system"
+  recipient       TEXT    NOT NULL DEFAULT 'all',  -- member name or "all"
+  content         TEXT    NOT NULL,
+  summary         TEXT,                            -- one-line distillation for collapsed display
+  read_by         JSON    NOT NULL DEFAULT '[]',   -- array of member names
+  session_id      TEXT    REFERENCES sessions(id)  -- optional link to coordinating session
+  -- Note: the Studio teams page shows `summary` by default; full `content` is revealed
+  -- on "Expand raw message". Long raw messages are collapsed by default (see ChatGPT
+  -- frontend design review, section 9). Writers should populate `summary` when content
+  -- exceeds ~200 chars.
+);
+
+CREATE INDEX IF NOT EXISTS idx_team_msgs_team ON team_messages(team_id);
+CREATE INDEX IF NOT EXISTS idx_team_msgs_created ON team_messages(created_at);
+CREATE INDEX IF NOT EXISTS idx_team_msgs_session ON team_messages(session_id)
+  WHERE session_id IS NOT NULL;
+```
+
+#### Migration strategy
+
+The CLI (`li team`) continues to write JSON files as the primary path —
+the DB is populated via a dual-write layer. This preserves backward
+compatibility during the transition:
+
+1. **Phase 1 (this ADR)**: Add tables. Studio reads from DB. `li team`
+   writes to both JSON and DB (dual-write in `_locked_team`). New
+   `li state import-teams` backfills existing JSON files into the DB.
+2. **Phase 2 (future)**: `li team` writes DB-only. JSON files become
+   optional export (`li team export`). `fcntl.flock` replaced by DB
+   transactions.
+
+Phase 2 is gated on confirming no external tools depend on reading the
+JSON files directly.
+
+#### Team ↔ Session linkage
+
+`team_messages.session_id` is an optional FK that connects a team
+coordination message to the session that produced it. When `li team send`
+is called from within a `li play --team-mode` session, the session ID is
+available and recorded. This enables:
+
+- "Show me all runs that coordinated through team X."
+- "Show me the team inbox alongside the run's message timeline."
+
+### Part B: Run lifecycle management
+
+#### B1. Message-based staleness detection
+
+Add a `last_message_at` column to sessions:
+
+```sql
+ALTER TABLE sessions ADD COLUMN last_message_at REAL;
+```
+
+The CLI updates `last_message_at` on every message INSERT (in the same
+transaction as the progression append). This is cheaper than computing
+`MAX(created_at)` from messages at query time.
+
+#### B2. Staleness heuristic (computed, not stored)
+
+Staleness is a **derived status** computed at read time, not a stored
+column. The runs list and dashboard compute `effective_status` from:
+
+```python
+STALE_THRESHOLDS = {
+    "agent": 6 * 3600,       # 6h — single-agent runs
+    "play": 6 * 3600,        # 6h — single-play runs
+    "flow": 12 * 3600,       # 12h — multi-agent flows
+    "fanout": 12 * 3600,     # 12h — parallel fan-out
+    "show-play": 12 * 3600,  # 12h — show-managed plays
+}
+DEFAULT_STALE_THRESHOLD = 6 * 3600  # 6h fallback
+
+def effective_status(session: dict, *, now: float) -> str:
+    raw = session["status"]
+    if raw != "running":
+        return raw
+
+    threshold = STALE_THRESHOLDS.get(
+        session.get("invocation_kind"), DEFAULT_STALE_THRESHOLD
+    )
+    last_activity = session.get("last_message_at") or session.get("updated_at") or 0
+    if now - last_activity > threshold:
+        return "stale"
+
+    return "running"
+```
+
+Key properties:
+
+- **Non-destructive**: the DB `status` column stays `running`. The `stale`
+  label is display-only, computed per-read. No data mutation on read path.
+- **Kind-aware**: single-agent runs get a 6h threshold; flows get 12h.
+  Thresholds are tunable constants, not config.
+- **Message-based**: uses `last_message_at` (progression activity), not
+  `updated_at` (which can be bumped by metadata writes). A session with
+  0 messages for 6 hours and no process is dead.
+
+#### B3. Admin transition (destructive, explicit)
+
+The admin `doctor` endpoint gains a `transition_stale` option that
+**writes** `status = 'failed'` for stale sessions after confirming the
+process is dead:
+
+```python
+async def transition_stale_sessions(
+    *, stale_hours: float = 6.0
+) -> list[dict]:
+    """Mark stale running sessions as failed.
+
+    Only transitions sessions where:
+    1. effective_status == 'stale' (no message activity past threshold)
+    2. Process is confirmed dead (PID check + ps scan)
+
+    Returns list of transitioned session IDs with reason.
+    """
+```
+
+This is an explicit admin action, not automatic. The runs list shows
+`stale` as a warning; the admin page lets the operator confirm and
+transition.
+
+#### B4. Dashboard cards
+
+The dashboard gains two new cards from these signals:
+
+| Card | Query |
+|------|-------|
+| **Stale** | `status = 'running' AND last_message_at < now() - threshold` |
+| **Teams active** | `SELECT COUNT(*) FROM teams WHERE status = 'active'` |
+
+### Status vocabulary update
+
+The session `status` CHECK constraint is unchanged — `stale` is NOT a DB
+value. The four DB statuses remain: `running`, `completed`, `failed`,
+`aborted`. `stale` exists only in the API response as `effective_status`.
+
+The runs list API response shape adds:
+
+```json
+{
+  "status": "running",
+  "effective_status": "stale",
+  "last_message_at": 1716300000.0,
+  "message_count": 42
+}
+```
+
+Frontend renders `effective_status` for the pill color. Tooltip shows raw
+`status` for disambiguation.
+
+## Consequences
+
+**Positive**
+- Teams become queryable, linkable to sessions, and prunable.
+- Dead runs are visually distinguishable from active runs without operator
+  intervention.
+- Message-based staleness is a robust signal — no false positives from
+  legitimate long-running processes that are actively producing messages.
+- Non-destructive by default: stale is a display label, not a data mutation.
+- Admin retains explicit control over status transitions.
+
+**Negative**
+- Dual-write period (Phase 1) means two sources of truth for teams. Risk
+  of drift if a write path is missed. Mitigated by keeping JSON as
+  fallback read source during transition.
+- `last_message_at` requires a write on every message INSERT. At our scale
+  (< 500 messages/session) this is negligible, but it's an extra UPDATE
+  per message.
+- Staleness thresholds are heuristic. A legitimately idle agent (waiting
+  for user input for 7 hours) would show as stale. Acceptable because the
+  operator can inspect and dismiss.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Auto-transition stale → failed without admin | Risk of killing legitimately paused sessions; operator should confirm |
+| Store `stale` as a DB status | Mixes display concern with lifecycle state; `stale` is a view, not a transition |
+| Heartbeat column (process writes every N seconds) | Requires CLI changes to all run types; message activity is already a natural heartbeat |
+| Keep teams file-only, add DB index | Half-measure; still no history, no cross-referencing, no async-safe writes |
+| Merge team messages into the main `messages` table | Teams use a different addressing model (member names, not UUIDs); forcing them into the Element-based message table adds complexity for no query benefit |
+| Single staleness threshold for all run types | 6h is too aggressive for flows, too lenient for single agents. Kind-aware thresholds are simple and correct |
+
+## References
+
+- [ADR-0009](ADR-0009-sqlite-state-layer.md) — SQLite state layer (teams table extends this)
+- [ADR-0017](ADR-0017-session-lifecycle-status.md) — Session lifecycle (staleness extends this)
+- [ADR-0012](ADR-0012-studio-execution-lineage.md) — Execution lineage (team linkage extends this)
+- [ChatGPT frontend design review](.khive/workspaces/20260521/chatgpt-frontend-review.md) — Teams page redesign (section 9), member sidebar + activity timeline, message summary/collapse, linked sessions; 60m threshold confirmation (section 2)
+- `lionagi/cli/team.py` — Current file-based team implementation
+- `apps/studio/server/services/admin.py` — Current phantom session detection
+- `apps/studio/server/services/sessions.py` — Current session queries

--- a/docs/adrs/ADR-0020-skill-invocations.md
+++ b/docs/adrs/ADR-0020-skill-invocations.md
@@ -298,7 +298,7 @@ User-created skills (files in `~/.lionagi/skills/`) work the same way.
 - [ADR-0012](ADR-0012-studio-execution-lineage.md) — Execution lineage
 - [ADR-0017](ADR-0017-session-lifecycle-status.md) — Session lifecycle
 - [ADR-0019](ADR-0019-teams-db-and-run-lifecycle.md) — Teams DB + run staleness
-- [ChatGPT frontend design review](.khive/workspaces/20260521/chatgpt-frontend-review.md) — Nav restructure with Runs/Invocations/Sessions/Artifacts sub-tabs (section 1), grouped invocation row design with worst-health aggregation (section 5)
+- ChatGPT frontend design review (external, not in repo) — Nav restructure with Runs/Invocations/Sessions/Artifacts sub-tabs (section 1), grouped invocation row design with worst-health aggregation (section 5)
 - `lionagi/cli/agent.py` — Session creation with invocation_kind
 - `~/.lionagi/skills/show/SKILL.md` — Show skill (orchestrator pattern)
 - `~/.lionagi/skills/codex-pr-review/SKILL.md` — Review skill (round pattern)

--- a/docs/adrs/ADR-0020-skill-invocations.md
+++ b/docs/adrs/ADR-0020-skill-invocations.md
@@ -72,7 +72,7 @@ CREATE TABLE IF NOT EXISTS invocations (
   started_at      REAL    NOT NULL,
   ended_at        REAL,
   status          TEXT    NOT NULL DEFAULT 'running' CHECK(
-                    status IN ('running', 'completed', 'failed', 'aborted', 'stale')
+                    status IN ('running', 'completed', 'failed', 'aborted', 'timed_out', 'cancelled')
                   ),
   session_count   INTEGER NOT NULL DEFAULT 0, -- denormalized for list queries
   created_at      REAL    NOT NULL,
@@ -114,12 +114,12 @@ The two are orthogonal:
 | Skill completes | Skill runner | UPDATE `status='completed'`, `ended_at=now()` |
 | Skill fails | Skill runner | UPDATE `status='failed'`, `ended_at=now()` |
 | Skill interrupted | Signal handler | UPDATE `status='aborted'`, `ended_at=now()` |
-| Stale detection | Admin doctor (ADR-0019 §B) | UPDATE `status='stale'` when all child sessions are stale |
+| Timeout | Timeout handler | UPDATE `status='timed_out'`, `ended_at=now()` |
+| Cancelled | Orchestrator / admin | UPDATE `status='cancelled'`, `ended_at=now()` |
 
-Note: `stale` IS a stored status on invocations (unlike sessions where
-it's computed). An invocation whose child sessions are all stale/failed
-and whose process is dead is definitively stale — there's no ambiguity
-about thresholds because the invocation has explicit `ended_at` semantics.
+Note: `stale` is a **health indicator** on invocations (derived, same as
+sessions — see ADR-0024), not a stored status. An invocation whose child
+sessions are all stale/failed surfaces as health `stale` in the dashboard.
 
 ### Write path: who creates invocation records?
 

--- a/docs/adrs/ADR-0020-skill-invocations.md
+++ b/docs/adrs/ADR-0020-skill-invocations.md
@@ -92,6 +92,9 @@ Add an optional FK on sessions:
 ```sql
 ALTER TABLE sessions ADD COLUMN invocation_id TEXT
   REFERENCES invocations(id);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_invocation
+  ON sessions(invocation_id) WHERE invocation_id IS NOT NULL;
 ```
 
 This replaces the need to expand the `invocation_kind` CHECK constraint

--- a/docs/adrs/ADR-0020-skill-invocations.md
+++ b/docs/adrs/ADR-0020-skill-invocations.md
@@ -1,0 +1,301 @@
+# ADR-0020: Skill Invocations — Tracking the Orchestration Layer
+
+**Status**: Proposed
+**Date**: 2026-05-21
+**Extends**: ADR-0009 (SQLite state layer), ADR-0012 (execution lineage), ADR-0019 (run lifecycle)
+
+## Context
+
+Lion Studio traces execution from sessions down to messages, but has no
+record of what triggered those sessions. The causal chain today:
+
+```
+??? → Session → Branch → Messages → Tool Calls → Artifacts
+```
+
+The missing layer is **skill invocations**. When Ocean types `/show resolve
+lionagi issues`, that single command produces:
+
+- 6 `li play` sessions (one per play)
+- 6 `li agent -a play-gate` sessions (one gate per play)
+- 2+ `li agent -a reviewer` sessions (codex review rounds)
+- Team coordination messages across plays
+- Show-level artifacts (`_show.md`, verdicts, decisions log)
+
+These 14+ sessions share a common origin — the `/show` invocation — but
+nothing in the DB connects them. The `show_topic` and `show_play_name`
+provenance columns (ADR-0012) partially group show-play sessions, but:
+
+1. **No invocation record.** There's no "this `/show` started at 2:07 AM,
+   produced 14 sessions, and completed at 8:45 AM" entity.
+2. **Skills beyond `/show` are invisible.** `/codex-pr-review` fires 3
+   rounds of `li agent -a reviewer` — those sessions have
+   `invocation_kind='agent'` and no hint they're part of a review cycle.
+3. **Marketplace plugins fire skills.** The `show` plugin invokes `/show`;
+   the `devx` plugin invokes `/commit`, `/fmt`, `/ci`. These are
+   higher-order compositions with no trace.
+4. **`invocation_kind` is a closed enum.** Adding every skill to the CHECK
+   constraint doesn't scale — there are 60+ skills, and users can create
+   custom ones.
+
+### Skill taxonomy (what produces runs)
+
+Skills fall into three categories by how they interact with the run layer:
+
+| Category | Examples | Run pattern |
+|----------|----------|-------------|
+| **Orchestrators** | `/show`, `/codex-pr-review`, `/reprompt` | Spawn N sessions over minutes-to-hours, with gating and adaptation |
+| **Single-shot** | `/ci`, `/fmt`, `/commit`, `/pr` | Zero or one session; mostly shell commands, no `li play/agent` |
+| **Read-only** | `/status`, `/memory-recall`, `/summarize` | No sessions; pure query or text generation |
+
+Only **orchestrator** skills need invocation tracking. Single-shot and
+read-only skills don't produce session trees worth grouping.
+
+### Marketplace plugins as skill compositors
+
+Marketplace plugins (ADR-0010) are Claude Code plugins that expose skills.
+The `show` plugin contains the `/show` skill; `devx` contains `/commit`,
+`/fmt`, `/ci`. Plugins are the packaging unit; skills are the invocation
+unit. An invocation record should reference the skill, with the plugin
+as optional metadata.
+
+## Decision
+
+### Add an `invocations` table
+
+```sql
+CREATE TABLE IF NOT EXISTS invocations (
+  id              TEXT    PRIMARY KEY,
+  skill           TEXT    NOT NULL,           -- skill name: "show", "codex-pr-review", "reprompt"
+  plugin          TEXT,                       -- marketplace plugin: "show", "devx", NULL for user skills
+  prompt          TEXT,                       -- the user's input (e.g., "resolve lionagi issues")
+  started_at      REAL    NOT NULL,
+  ended_at        REAL,
+  status          TEXT    NOT NULL DEFAULT 'running' CHECK(
+                    status IN ('running', 'completed', 'failed', 'aborted', 'stale')
+                  ),
+  session_count   INTEGER NOT NULL DEFAULT 0, -- denormalized for list queries
+  created_at      REAL    NOT NULL,
+  updated_at      REAL    NOT NULL,
+  node_metadata   JSON                        -- skill-specific state (show plan, review rounds, etc.)
+);
+
+CREATE INDEX IF NOT EXISTS idx_invocations_skill ON invocations(skill);
+CREATE INDEX IF NOT EXISTS idx_invocations_status ON invocations(status);
+CREATE INDEX IF NOT EXISTS idx_invocations_updated ON invocations(updated_at DESC);
+```
+
+### Link sessions to invocations
+
+Add an optional FK on sessions:
+
+```sql
+ALTER TABLE sessions ADD COLUMN invocation_id TEXT
+  REFERENCES invocations(id);
+```
+
+This replaces the need to expand the `invocation_kind` CHECK constraint
+for every new skill. `invocation_kind` stays as-is (it describes the
+CLI primitive: `agent`, `play`, `flow`, `fanout`, `show-play`).
+`invocation_id` answers the higher-order question: "which skill
+orchestration spawned this session?"
+
+The two are orthogonal:
+- `invocation_kind = 'play'` — this session was created by `li play`
+- `invocation_id = 'abc123'` — it was spawned as part of the `/show`
+  invocation `abc123`
+
+### Invocation lifecycle
+
+| Event | Who writes | What changes |
+|-------|-----------|--------------|
+| Skill starts | Skill runner (Claude Code) | INSERT invocation with `status='running'` |
+| Session spawned | CLI (`li play`, `li agent`) | INSERT session with `invocation_id`; UPDATE invocation `session_count += 1` |
+| Skill completes | Skill runner | UPDATE `status='completed'`, `ended_at=now()` |
+| Skill fails | Skill runner | UPDATE `status='failed'`, `ended_at=now()` |
+| Skill interrupted | Signal handler | UPDATE `status='aborted'`, `ended_at=now()` |
+| Stale detection | Admin doctor (ADR-0019 §B) | UPDATE `status='stale'` when all child sessions are stale |
+
+Note: `stale` IS a stored status on invocations (unlike sessions where
+it's computed). An invocation whose child sessions are all stale/failed
+and whose process is dead is definitively stale — there's no ambiguity
+about thresholds because the invocation has explicit `ended_at` semantics.
+
+### Write path: who creates invocation records?
+
+The skill runner is Claude Code itself (the LLM + tool loop). Skills are
+markdown files loaded into context — they don't have their own process.
+The invocation record must be created by the **first CLI command** the
+skill fires, or by a lightweight `li invoke start` command that the skill
+calls before spawning sessions.
+
+Recommended approach — explicit `li invoke` lifecycle commands:
+
+```bash
+# Skill calls this at start
+INV_ID=$(li invoke start --skill show --prompt "resolve lionagi issues")
+
+# Each li play/agent gets the invocation ID
+li play feature "..." --invocation "$INV_ID" ...
+
+# Skill calls this at end
+li invoke end "$INV_ID" --status completed
+```
+
+This keeps invocation tracking opt-in and non-breaking. Skills that don't
+call `li invoke start` simply produce sessions with `invocation_id = NULL`
+— the same behavior as today.
+
+### Studio UI impact
+
+#### Runs list
+
+The runs list gains a **grouping mode**: when invocations exist, sessions
+can be grouped under their parent invocation. Default view is flat (current
+behavior); grouped view nests sessions under invocation headers:
+
+```
+▼ /show "resolve lionagi issues" — 14 sessions, 6h 38m, completed
+    play:backend — completed, 87 min
+    play-gate:backend — completed, 3 min
+    play:frontend — completed, 64 min
+    ...
+▼ /codex-pr-review PR #1039 — 3 sessions, 45 min, completed
+    reviewer round 1 — completed, 15 min
+    reviewer round 2 — completed, 12 min
+    reviewer round 3 (APPROVE) — completed, 8 min
+  agent "quick fix" — completed, 2 min        ← no invocation (standalone)
+```
+
+#### Grouped invocation row design (Runs page)
+
+The Runs page (`/runs/invocations`) uses a `View: Invocations | Sessions` toggle
+(see ChatGPT frontend design review, sections 1 and 5). The default view is grouped
+by invocation. Each parent row shows:
+
+```
+▾ /show lionagi-issue-sweep                              worst: stale
+  6 plays · 14 sessions · 9h elapsed · 7 artifacts · updated 10m ago
+  Models: codex/gpt-5.5 ×10 · claude-sonnet-4-6 ×4
+  Status: running 6 · completed 8 · failed 0
+```
+
+The `worst: stale` badge on the parent row reflects the worst **health level**
+among all child sessions — not the worst reported status. This prevents a
+grouped row from showing a clean "running" state when one child is stale.
+
+Expanded child rows show two columns — **Status** (reported) and **Health** (derived):
+
+```
+Run          Agent        Model             Status       Health     Dur
+f82488be     reviewer     codex/gpt-5.5     running      stale      1h 34m
+462bb5ed     play-gate    claude-sonnet     running      stale      9h 46m
+c3e69388     reviewer     codex/gpt-5.5     running      stale      17h 56m
+e37ff231     reviewer     codex/gpt-5.5     completed    healthy    5m 10s
+```
+
+Do not show a blue Running pill alone when the child's health is stale.
+Compact representation: `[stale running]` as a compound state pill.
+
+Standalone sessions without an `invocation_id` appear at the bottom under
+"Ungrouped sessions" when the toggle is set to Invocations view.
+
+#### Invocations page (new)
+
+A dedicated `/invocations` page showing skill-level orchestration history:
+
+| Skill | Prompt | Sessions | Duration | Status |
+|-------|--------|----------|----------|--------|
+| show | resolve lionagi issues | 14 | 6h 38m | completed |
+| codex-pr-review | PR #1039 | 3 | 45m | completed |
+| show | lattice kernel fusion | 8 | 3h 12m | running |
+
+Click-through to the invocation detail shows the session tree, timeline,
+and skill-specific metadata (show plan, review rounds, etc.).
+
+#### Dashboard
+
+New card: **Active skills** — count of invocations with `status = 'running'`.
+
+### Skill metadata conventions
+
+The `node_metadata` JSON on invocations carries skill-specific state.
+Each orchestrator skill defines its own schema:
+
+| Skill | Metadata shape |
+|-------|---------------|
+| `/show` | `{topic, goal, plays: [{name, status, attempt}], waves: [...]}` |
+| `/codex-pr-review` | `{pr_number, rounds: [{round, verdict, resume_id}]}` |
+| `/reprompt` | `{original_prompt, refined_prompt, agents_planned}` |
+
+This is unstructured JSON — no schema enforcement. Skills write what they
+need for resume and display. Studio renders it as best-effort JSON view
+on the invocation detail page.
+
+### Relationship to `invocation_kind`
+
+`invocation_kind` on sessions is NOT deprecated. It remains the CLI-level
+primitive type (`agent`, `play`, `flow`, `fanout`, `show-play`). The new
+`invocation_id` is the higher-order grouping.
+
+The two compose:
+
+```
+invocation (skill="show", prompt="resolve lionagi issues")
+  ├── session (invocation_kind="play", show_play_name="backend")
+  ├── session (invocation_kind="agent", agent_name="play-gate")
+  ├── session (invocation_kind="play", show_play_name="frontend")
+  ├── session (invocation_kind="agent", agent_name="play-gate")
+  └── session (invocation_kind="agent", agent_name="reviewer")
+```
+
+### Custom skills
+
+User-created skills (files in `~/.lionagi/skills/`) work the same way.
+`li invoke start --skill my-custom-skill` creates an invocation with
+`skill='my-custom-skill'` and `plugin=NULL`. No registration required.
+
+## Consequences
+
+**Positive**
+- The full execution tree is traceable: skill → invocation → sessions →
+  branches → messages.
+- Orchestrator skills get first-class lifecycle tracking without expanding
+  the `invocation_kind` enum.
+- Invocations page gives Ocean a single view of "what did my system do
+  overnight" at the right granularity — skill-level, not session-level.
+- Grouped runs view reduces visual noise from multi-session orchestrations.
+- `li invoke` is opt-in — zero breakage for existing skills and CLI usage.
+- Marketplace plugins get attribution via the `plugin` column.
+
+**Negative**
+- Skills must explicitly call `li invoke start/end` to get tracking. Skills
+  that don't are invisible at the invocation layer (sessions still tracked).
+- `node_metadata` is unstructured — no schema validation means skill-specific
+  metadata can drift or rot. Acceptable because it's display-only.
+- Adds a table and an FK column — migration in `_reconcile_columns()`.
+- Grouped runs view is a frontend complexity increase (collapsible groups,
+  mixed flat + grouped entries).
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Expand `invocation_kind` for each skill | Doesn't scale — 60+ skills, users can create custom ones. CHECK constraint becomes unwieldy |
+| Use `show_topic` for all skill grouping | Show-specific; doesn't generalize to codex-pr-review, reprompt, or custom skills |
+| Derive invocations from session timestamps | Fragile heuristic; overlapping skills would be mis-grouped |
+| Store invocation state in skill-local files | Same problem as teams — no queryable history, no cross-referencing |
+| Auto-create invocations from session patterns | Requires pattern recognition that's skill-specific; explicit is better than magic |
+| Make invocations a subclass of sessions | Category error — an invocation is not a conversation with an LLM; it's a coordination record |
+
+## References
+
+- [ADR-0009](ADR-0009-sqlite-state-layer.md) — SQLite state layer
+- [ADR-0010](ADR-0010-plugin-aware-studio.md) — Plugin system (marketplace)
+- [ADR-0012](ADR-0012-studio-execution-lineage.md) — Execution lineage
+- [ADR-0017](ADR-0017-session-lifecycle-status.md) — Session lifecycle
+- [ADR-0019](ADR-0019-teams-db-and-run-lifecycle.md) — Teams DB + run staleness
+- [ChatGPT frontend design review](.khive/workspaces/20260521/chatgpt-frontend-review.md) — Nav restructure with Runs/Invocations/Sessions/Artifacts sub-tabs (section 1), grouped invocation row design with worst-health aggregation (section 5)
+- `lionagi/cli/agent.py` — Session creation with invocation_kind
+- `~/.lionagi/skills/show/SKILL.md` — Show skill (orchestrator pattern)
+- `~/.lionagi/skills/codex-pr-review/SKILL.md` — Review skill (round pattern)

--- a/docs/adrs/ADR-0021-skill-artifacts-and-reactive-chaining.md
+++ b/docs/adrs/ADR-0021-skill-artifacts-and-reactive-chaining.md
@@ -39,7 +39,7 @@ between a skill producing output and Studio displaying it?"
 
 Skills produce typed results: codex review produces a verdict
 (`gate_passed`, `feedback`, `severity`). Flow control produces
-`FlowControlVerdict` (`should_continue`, `justification`). Research
+`FlowControlVerdict` (`should_continue`, `reason`, `next_steps`). Research
 produces a landscape analysis. But these models are scattered:
 
 - `FlowControlVerdict` → `lionagi/cli/orchestrate/flow.py`
@@ -81,8 +81,10 @@ from lionagi.models.hashable_model import HashableModel
 class SkillOutcome(HashableModel):
     """Base for all structured skill outputs.
 
-    Persisted in invocations.outcome (JSON) and artifacts.content (JSON).
-    Studio renderers dispatch on outcome_kind.
+    Persisted as an artifacts row (kind='outcome', content=JSON).
+    The primary outcome for an invocation is the latest artifact with
+    kind='outcome' linked via invocation_id. Studio renderers dispatch
+    on outcome_kind.
     """
     outcome_kind: str              # "review_verdict", "gate_verdict", "ci_result", ...
     summary: str                   # one-line human-readable result
@@ -284,7 +286,8 @@ CREATE TABLE IF NOT EXISTS chain_runs (
   invocation_id   TEXT    REFERENCES invocations(id),  -- root invocation
   status          TEXT    NOT NULL DEFAULT 'running' CHECK(
                     status IN ('running', 'completed', 'failed',
-                               'waiting_approval', 'aborted')
+                               'timed_out', 'aborted', 'cancelled',
+                               'waiting_approval')
                   ),
   current_step    INTEGER NOT NULL DEFAULT 0,
   step_outcomes   JSON    NOT NULL DEFAULT '[]',  -- array of SkillOutcome dicts
@@ -294,6 +297,8 @@ CREATE TABLE IF NOT EXISTS chain_runs (
 
 CREATE INDEX IF NOT EXISTS idx_chain_runs_chain ON chain_runs(chain_id);
 CREATE INDEX IF NOT EXISTS idx_chain_runs_status ON chain_runs(status);
+CREATE INDEX IF NOT EXISTS idx_chain_runs_invocation
+  ON chain_runs(invocation_id) WHERE invocation_id IS NOT NULL;
 ```
 
 #### Scheduling

--- a/docs/adrs/ADR-0021-skill-artifacts-and-reactive-chaining.md
+++ b/docs/adrs/ADR-0021-skill-artifacts-and-reactive-chaining.md
@@ -511,3 +511,11 @@ can be built incrementally.
 - `lionagi/cli/orchestrate/flow.py` — FlowControlVerdict (existing pattern)
 - `~/.lionagi/skills/codex-pr-review/SKILL.md` — Verdict production pattern
 - `~/.lionagi/skills/show/SKILL.md` — Gate verdict production pattern
+
+### Prior art
+
+- **autogen Watch Primitives** (`autogen/beta/watch.py`) — EventWatch,
+  CadenceWatch, CronWatch, DelayWatch with AllOf/AnyOf/Sequence composites.
+  The reactive chaining in Part D is sequential-only; Watch supports
+  conditional composition (AllOf = all triggers must fire). Consider
+  composite triggers as a future extension.

--- a/docs/adrs/ADR-0021-skill-artifacts-and-reactive-chaining.md
+++ b/docs/adrs/ADR-0021-skill-artifacts-and-reactive-chaining.md
@@ -524,7 +524,7 @@ can be built incrementally.
 - [ADR-0009](ADR-0009-sqlite-state-layer.md) — SQLite state layer
 - [ADR-0011](ADR-0011-shows-data-model.md) — Shows data model (plays table)
 - [ADR-0020](ADR-0020-skill-invocations.md) — Skill invocations
-- [ChatGPT frontend design review](.khive/workspaces/20260521/chatgpt-frontend-review.md) — Kind-based outcome rendering (section 4): ReviewVerdict card with severity/categories/blocking findings, GateVerdict checklist, CIResult matrix
+- ChatGPT frontend design review (external, not in repo) — Kind-based outcome rendering (section 4): ReviewVerdict card with severity/categories/blocking findings, GateVerdict checklist, CIResult matrix
 - `lionagi/models/hashable_model.py` — Base model infrastructure
 - `lionagi/cli/orchestrate/flow.py` — FlowControlVerdict (existing pattern)
 - `~/.lionagi/skills/codex-pr-review/SKILL.md` — Verdict production pattern

--- a/docs/adrs/ADR-0021-skill-artifacts-and-reactive-chaining.md
+++ b/docs/adrs/ADR-0021-skill-artifacts-and-reactive-chaining.md
@@ -81,10 +81,11 @@ from lionagi.models.hashable_model import HashableModel
 class SkillOutcome(HashableModel):
     """Base for all structured skill outputs.
 
-    Persisted as an artifacts row (kind='outcome', content=JSON).
-    The primary outcome for an invocation is the latest artifact with
-    kind='outcome' linked via invocation_id. Studio renderers dispatch
-    on outcome_kind.
+    Persisted as an artifacts row with kind=outcome_kind (e.g.,
+    'review_verdict', 'gate_verdict', 'ci_result'). The primary
+    outcome for an invocation is resolved by querying the latest
+    artifact whose kind is a registered outcome type. Studio
+    renderers dispatch on artifact.kind directly.
     """
     outcome_kind: str              # "review_verdict", "gate_verdict", "ci_result", ...
     summary: str                   # one-line human-readable result
@@ -261,9 +262,21 @@ Chains are **not** a workflow engine. They are a thin reactive layer:
    resumes when Ocean approves (via Studio UI or CLI).
 5. **Timeouts** abort a step if it exceeds the limit.
 
-Chains produce invocations — each step is an invocation linked to the
-chain. The chain itself is an invocation with `skill='chain'` and
+Chains produce invocations — each step creates an invocation with
+`chain_run_id` and `step_index` linking it back to the chain run.
+The chain itself is an invocation with `skill='chain'` and
 `node_metadata` holding the chain definition + execution state.
+
+Step-to-invocation linkage columns on `invocations`:
+
+```sql
+ALTER TABLE invocations ADD COLUMN chain_run_id TEXT
+  REFERENCES chain_runs(id);
+ALTER TABLE invocations ADD COLUMN step_index INTEGER;
+
+CREATE INDEX IF NOT EXISTS idx_invocations_chain_run
+  ON invocations(chain_run_id) WHERE chain_run_id IS NOT NULL;
+```
 
 #### Chain persistence
 

--- a/docs/adrs/ADR-0021-skill-artifacts-and-reactive-chaining.md
+++ b/docs/adrs/ADR-0021-skill-artifacts-and-reactive-chaining.md
@@ -1,0 +1,513 @@
+# ADR-0021: Skill Artifacts, Structured Output, and Reactive Chaining
+
+**Status**: Proposed
+**Date**: 2026-05-21
+**Extends**: ADR-0020 (skill invocations), ADR-0009 (SQLite state layer), ADR-0011 (shows)
+
+## Context
+
+ADR-0020 introduced the `invocations` table to track skill-level
+orchestration. But three deeper questions remain:
+
+### 1. Where does show data live?
+
+Shows currently have dual persistence:
+- **DB**: `shows` + `plays` tables (ADR-0011) — status, metadata, FKs.
+- **Filesystem**: `$HOME/khive-work/shows/<topic>/` — prompts, intents,
+  verdicts, logs, agent artifacts, worktrees.
+
+The filesystem holds the bulk: `_show.md` (plan), `_intent.md` (per-play),
+`_prompt.md` (per-play), `_verdict.json` (per-play gate), `.log` (stdout),
+and agent-produced files nested under `<agent_id>/`. These are large,
+unstructured, and numerous.
+
+But the **structured parts** — verdicts, play metadata, gate results — are
+queryable and displayable. They should be in the DB. The filesystem should
+hold only what's too large or too unstructured for a column.
+
+### 2. How do artifacts get into the DB?
+
+Today, `li play` writes `run.json` + `branches/*.json` to
+`~/.lionagi/runs/<id>/`. `li state import` backfills them into sessions.
+But skill-level artifacts (verdicts, reports, analysis results) have no
+ingestion path — they're files that Studio can't see.
+
+The question isn't just "does it need to" — it's "what's the contract
+between a skill producing output and Studio displaying it?"
+
+### 3. Where do structured output models live?
+
+Skills produce typed results: codex review produces a verdict
+(`gate_passed`, `feedback`, `severity`). Flow control produces
+`FlowControlVerdict` (`should_continue`, `justification`). Research
+produces a landscape analysis. But these models are scattered:
+
+- `FlowControlVerdict` → `lionagi/cli/orchestrate/flow.py`
+- Gate verdict → inline JSON in show skill markdown
+- Review verdict → untyped markdown file
+
+There's no shared location for "the Pydantic models that skills produce
+and Studio displays."
+
+### 4. How do skills chain reactively?
+
+The compelling use case: PR opens → codex review runs in a worktree →
+produces verdict artifact → if APPROVE, merge; if REQUEST_CHANGES, file
+issues. Today this requires a human (Ocean) reading the verdict and
+typing the next command. The pieces exist but don't connect.
+
+## Decision
+
+### Part A: Structured output models — `lionagi/outcomes/`
+
+Create `lionagi/outcomes/` as the shared location for skill result types.
+These are the **contract** between skill producers and Studio consumers.
+
+```
+lionagi/outcomes/
+  __init__.py
+  _base.py          # SkillOutcome base
+  verdict.py        # ReviewVerdict, GateVerdict
+  analysis.py       # ResearchAnalysis, ImpactReport
+  plan.py           # ShowPlan, FlowPlan (move from cli/orchestrate)
+  ci.py             # CIResult, LintResult, TestResult
+```
+
+Base type:
+
+```python
+from lionagi.models.hashable_model import HashableModel
+
+class SkillOutcome(HashableModel):
+    """Base for all structured skill outputs.
+
+    Persisted in invocations.outcome (JSON) and artifacts.content (JSON).
+    Studio renderers dispatch on outcome_kind.
+    """
+    outcome_kind: str              # "review_verdict", "gate_verdict", "ci_result", ...
+    summary: str                   # one-line human-readable result
+    passed: bool | None = None     # tri-state: True/False/None(not applicable)
+```
+
+Concrete types:
+
+```python
+class ReviewVerdict(SkillOutcome):
+    outcome_kind: Literal["review_verdict"] = "review_verdict"
+    verdict: Literal["APPROVE", "APPROVE_WITH_SUGGESTIONS",
+                     "REQUEST_CHANGES", "REJECT"]
+    findings: list[Finding]
+    round: int = 1
+
+class Finding(HashableModel):
+    severity: Literal["critical", "high", "medium", "low", "info"]
+    category: str           # "security", "correctness", "style", ...
+    file: str | None
+    line: int | None
+    description: str
+    suggestion: str | None
+
+class GateVerdict(SkillOutcome):
+    outcome_kind: Literal["gate_verdict"] = "gate_verdict"
+    gate_passed: bool
+    feedback: str | None
+    notes: str | None
+
+class CIResult(SkillOutcome):
+    outcome_kind: Literal["ci_result"] = "ci_result"
+    lint_passed: bool | None
+    tests_passed: bool | None
+    build_passed: bool | None
+    test_count: int | None
+    failure_summary: str | None
+```
+
+**Why `lionagi/outcomes/` and not `lionagi/models/`?** The `models/`
+package holds infrastructure types (HashableModel, FieldModel, Note).
+Outcomes are domain types — the result vocabulary of the skill system.
+Separate package, clear boundary.
+
+**Why not in `apps/studio/`?** Outcomes are produced by the CLI and
+consumed by Studio. They belong in the shared `lionagi` package, not
+in either consumer.
+
+### Part B: Artifact persistence — DB for structured, filesystem for blobs
+
+Add an `artifacts` table for structured skill outputs:
+
+```sql
+CREATE TABLE IF NOT EXISTS artifacts (
+  id              TEXT    PRIMARY KEY,
+  invocation_id   TEXT    REFERENCES invocations(id) ON DELETE CASCADE,
+  session_id      TEXT    REFERENCES sessions(id),
+  created_at      REAL    NOT NULL,
+  kind            TEXT    NOT NULL,         -- "review_verdict", "gate_verdict", "ci_result", ...
+  name            TEXT    NOT NULL,         -- human label: "Round 1 verdict", "CI lint"
+  content         JSON    NOT NULL,         -- SkillOutcome.model_dump()
+  file_path       TEXT                      -- optional: path to large blob on disk
+);
+
+CREATE INDEX IF NOT EXISTS idx_artifacts_invocation ON artifacts(invocation_id);
+CREATE INDEX IF NOT EXISTS idx_artifacts_session ON artifacts(session_id);
+CREATE INDEX IF NOT EXISTS idx_artifacts_kind ON artifacts(kind);
+```
+
+The split:
+- **DB (`content` JSON)**: structured outcomes — verdicts, results,
+  analyses. Queryable, displayable, chainable.
+- **Filesystem (`file_path`)**: large blobs — full logs, generated code,
+  worktree diffs, screenshots. Referenced by path, not stored in DB.
+
+Ingestion path:
+
+```python
+# In skill runner (CLI side), after producing a verdict:
+from lionagi.state.db import StateDB
+from lionagi.outcomes.verdict import ReviewVerdict
+
+verdict = ReviewVerdict(
+    verdict="REQUEST_CHANGES",
+    findings=[...],
+    round=1,
+    summary="3 high-severity issues found",
+    passed=False,
+)
+
+async with StateDB.open() as db:
+    await db.insert_artifact(
+        invocation_id=inv_id,
+        session_id=session_id,
+        kind=verdict.outcome_kind,
+        name="Round 1 verdict",
+        content=verdict.model_dump(),
+    )
+```
+
+No batch import needed — artifacts are written at production time, not
+backfilled. Legacy filesystem artifacts stay where they are; new skills
+write to both DB and filesystem.
+
+### Part C: Show data — split structured from bulk
+
+Shows already have DB tables (ADR-0011). The missing piece is persisting
+play-level structured outcomes. With the artifacts table, this becomes
+natural:
+
+| Show artifact | Where | Why |
+|---------------|-------|-----|
+| Play gate verdict | `artifacts` table | Structured, queryable, displayable |
+| Play metadata (`_meta.json`) | `plays` table columns | Already there (ADR-0011) |
+| Show plan (`_show.md`) | `invocations.node_metadata` | The plan is invocation-level state |
+| Play intent (`_intent.md`) | filesystem | Large text, rarely queried |
+| Play prompt (`_prompt.md`) | filesystem | Large text, skill-internal |
+| Agent logs (`.log`) | filesystem | Large, streaming, append-only |
+| Agent artifacts (`<agent_id>/`) | filesystem | Unstructured, varied |
+| Worktrees | filesystem | Ephemeral, disposable |
+
+The show skill writes gate verdicts as `GateVerdict` artifacts linked to
+both the invocation and the play's session. Studio renders them in the
+play detail view.
+
+### Part D: Reactive chaining — triggers and hooks
+
+A declarative way to chain skills based on outcomes and events:
+
+```yaml
+# ~/.lionagi/chains/pr-review.yaml
+name: pr-review-chain
+trigger:
+  event: pr.opened          # GitHub webhook or poll
+  filter:
+    base: main
+    draft: false
+
+steps:
+  - skill: codex-pr-review
+    with:
+      pr: "{{ trigger.pr_number }}"
+      effort: high
+    timeout: 30m
+
+  - skill: ci
+    condition: "{{ steps[0].outcome.verdict == 'APPROVE' }}"
+    with:
+      scope: full
+
+  - action: gh-merge
+    condition: "{{ steps[0].outcome.passed and steps[1].outcome.passed }}"
+    with:
+      pr: "{{ trigger.pr_number }}"
+      method: squash
+    requires_approval: true    # pause and ask Ocean
+
+  - action: gh-comment
+    condition: "{{ steps[0].outcome.verdict == 'REQUEST_CHANGES' }}"
+    with:
+      pr: "{{ trigger.pr_number }}"
+      body: "{{ steps[0].outcome.summary }}"
+```
+
+#### Chain execution model
+
+Chains are **not** a workflow engine. They are a thin reactive layer:
+
+1. **Triggers** fire from events (webhook, schedule, file watch, manual).
+2. **Steps** execute sequentially. Each step is a skill invocation or a
+   shell action.
+3. **Conditions** are Jinja2 expressions over prior step outcomes.
+4. **`requires_approval`** pauses the chain and notifies Ocean. The chain
+   resumes when Ocean approves (via Studio UI or CLI).
+5. **Timeouts** abort a step if it exceeds the limit.
+
+Chains produce invocations — each step is an invocation linked to the
+chain. The chain itself is an invocation with `skill='chain'` and
+`node_metadata` holding the chain definition + execution state.
+
+#### Chain persistence
+
+```sql
+CREATE TABLE IF NOT EXISTS chains (
+  id              TEXT    PRIMARY KEY,
+  name            TEXT    NOT NULL,
+  definition      JSON    NOT NULL,         -- the YAML parsed to JSON
+  status          TEXT    NOT NULL DEFAULT 'active' CHECK(
+                    status IN ('active', 'paused', 'disabled')
+                  ),
+  created_at      REAL    NOT NULL,
+  updated_at      REAL    NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS chain_runs (
+  id              TEXT    PRIMARY KEY,
+  chain_id        TEXT    NOT NULL REFERENCES chains(id),
+  trigger_event   JSON,                     -- the event that fired this run
+  invocation_id   TEXT    REFERENCES invocations(id),  -- root invocation
+  status          TEXT    NOT NULL DEFAULT 'running' CHECK(
+                    status IN ('running', 'completed', 'failed',
+                               'waiting_approval', 'aborted')
+                  ),
+  current_step    INTEGER NOT NULL DEFAULT 0,
+  step_outcomes   JSON    NOT NULL DEFAULT '[]',  -- array of SkillOutcome dicts
+  created_at      REAL    NOT NULL,
+  updated_at      REAL    NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_chain_runs_chain ON chain_runs(chain_id);
+CREATE INDEX IF NOT EXISTS idx_chain_runs_status ON chain_runs(status);
+```
+
+#### Scheduling
+
+Chains with `trigger.schedule` use cron syntax:
+
+```yaml
+trigger:
+  schedule: "0 2 * * *"     # 2 AM daily
+  # or
+  schedule: "every 6h"      # simplified syntax
+```
+
+The scheduler is a lightweight daemon (`li chain daemon`) or a system
+cron entry that runs `li chain check` periodically. It does NOT need to
+be always-on — `li chain check` evaluates all active chains' triggers
+and fires any that match.
+
+#### Event sources (incremental)
+
+Start with two event sources, add more as needed:
+
+| Source | Mechanism | Events |
+|--------|-----------|--------|
+| **Schedule** | `li chain check` on cron | `schedule.fired` |
+| **Manual** | `li chain fire <name>` | `manual.fired` |
+
+Future (not in this ADR):
+- GitHub webhooks (`pr.opened`, `pr.merged`, `issue.created`)
+- File watch (`file.changed` in a watched directory)
+- Invocation completion (`invocation.completed` with outcome filter)
+
+### Part E: Studio rendering — outcome-aware display
+
+Studio gains outcome-aware rendering for artifacts:
+
+```typescript
+// components/outcomes/OutcomeRenderer.tsx
+// Dispatches on artifact.kind to render structured outcomes
+
+switch (artifact.kind) {
+  case "review_verdict":
+    return <ReviewVerdictCard verdict={artifact.content} />;
+  case "gate_verdict":
+    return <GateVerdictCard verdict={artifact.content} />;
+  case "ci_result":
+    return <CIResultCard result={artifact.content} />;
+  default:
+    return <JsonViewer data={artifact.content} />;
+}
+```
+
+The run detail page shows artifacts inline with the message timeline.
+The invocations page shows the final outcome of each step.
+
+#### ReviewVerdict component specification
+
+The `ReviewVerdictCard` renders the structured verdict as a severity/category
+breakdown with blocking findings, not plain text:
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│ REQUEST CHANGES                                  reviewer · 5m 27s │
+├────────────────────────────────────────────────────────────────────┤
+│ Findings                                                           │
+│ Major 3   Minor 4   Info 0                                         │
+│                                                                    │
+│ Categories                                                         │
+│ ADR consistency 2 · Dependency claims 1 · Terminology 2 · Scope 2  │
+├────────────────────────────────────────────────────────────────────┤
+│ Blocking findings                                                  │
+│                                                                    │
+│ MAJOR  ADR-060 depends on wrong ADR                                │
+│        docs/adrs/ADR-060.md                                        │
+│        Evidence: adjacent ADRs define a different dependency chain. │
+│        Required: correct reference or explain exception.            │
+│                                                                    │
+│ MAJOR  Mis-scoped product verbs                                    │
+│        codex_r1_consistency.md                                     │
+│        Required: align product verbs with ADR vocabulary.           │
+├────────────────────────────────────────────────────────────────────┤
+│ Suggestions                                                        │
+│ MINOR  Rename "label packs" to match ADR terminology                │
+│ MINOR  Add missing cross-reference to ADR-059                       │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+Fields rendered: verdict label, reviewer + duration, finding counts by severity,
+category breakdown, blocking findings with file + evidence + required fix, and
+minor suggestions in a collapsed section.
+
+#### GateVerdict component specification
+
+The `GateVerdictCard` renders as an acceptance criteria checklist:
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ GATE VERDICT: REJECT                                                │
+├─────────────────────────────────────────────────────────────────────┤
+│ Acceptance criteria                                                  │
+│ ✓ backend tests pass                                                 │
+│ ✓ no forbidden scope touched                                         │
+│ ✕ implementation_1012.md missing from artifact path                  │
+│ ✓ lint clean                                                         │
+│                                                                     │
+│ Blocking reason                                                      │
+│ Required artifact was not produced.                                  │
+│                                                                     │
+│ Next action                                                          │
+│ Re-run implementer with artifact path constraint.                    │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+Each criterion shows pass/fail with checkmark or X. Blocking reason and
+next action are surfaced prominently, not buried in a text field.
+
+#### CIResult component specification
+
+The `CIResultCard` renders as a test/build/lint matrix with command timings:
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ CI RESULT: PASSED                                                   │
+├─────────────────────────────────────────────────────────────────────┤
+│ Backend tests     119 / 119                                         │
+│ Lint              passed                                            │
+│ Typecheck         passed                                            │
+│ Build             passed                                            │
+│                                                                     │
+│ Commands                                                            │
+│ pytest apps/studio/server         2m 14s                            │
+│ npm run build                     1m 02s                            │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+Each check type gets a row with a pass/fail indicator and count where
+applicable. Commands section shows the actual commands run with durations.
+
+### Summary: the full stack
+
+```
+Chain (pr-review-chain.yaml)
+  → Trigger (pr.opened / schedule / manual)
+    → Invocation (skill="codex-pr-review", ADR-0020)
+      → Sessions (invocation_kind="agent", ADR-0017)
+        → Branches → Messages
+      → Artifacts (ReviewVerdict, GateVerdict — this ADR)
+        → Structured outcome in DB (queryable, displayable)
+        → Large blobs on filesystem (referenced by path)
+    → Condition check (Jinja2 over prior outcomes)
+      → Next Invocation or requires_approval pause
+```
+
+## Consequences
+
+**Positive**
+- Skills have a typed output contract. Studio knows how to render a
+  `ReviewVerdict` vs a `CIResult` without parsing markdown.
+- Artifacts are queryable — "show me all failed reviews this week" is a
+  SQL query, not a filesystem walk.
+- Reactive chaining turns manual multi-skill workflows into declarative
+  pipelines while keeping `requires_approval` for safety.
+- `lionagi/outcomes/` is the single location for skill result types —
+  shared between CLI, Studio, and chains.
+- Show data split is explicit: structured → DB, bulk → filesystem.
+- Chains are thin — not a workflow engine, just trigger → condition →
+  skill invocation.
+
+**Negative**
+- New package (`lionagi/outcomes/`) adds to the import surface. Mitigated
+  by lazy imports and clear scope boundary.
+- Artifact writes add DB operations to skill execution paths. At our
+  scale (< 50 artifacts per invocation) this is negligible.
+- Chain YAML is another config format to maintain. Mitigated by keeping
+  the schema minimal and using Jinja2 (well-known).
+- `requires_approval` chains need a notification mechanism (Studio UI
+  poll, push notification, or CLI prompt). Deferred to implementation.
+- Scheduling requires either a daemon or system cron — neither is
+  zero-config. `li chain check` on cron is the simplest.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Store all artifacts in DB (including logs, diffs) | Large blobs degrade SQLite; filesystem is right for multi-MB files |
+| Store all artifacts on filesystem only | Structured outcomes lose queryability; Studio can't render without parsing |
+| Put outcome models in `lionagi/models/` | Conflates infrastructure types with domain types; separate package is cleaner |
+| Put outcome models in `apps/studio/` | CLI produces them; they must be in the shared package |
+| Full workflow engine (Airflow/Temporal-style) | Over-engineered for our scale; chains are sufficient for sequential reactive steps |
+| Event-driven architecture (pub/sub) | Adds infrastructure dependency; trigger → check → fire is simpler |
+| Python-based chain definitions | YAML is declarative and inspectable; Python chains blur the line between config and code |
+| Inline outcomes in `invocations.node_metadata` | Metadata is for invocation state; outcomes are first-class entities that multiple sessions contribute to |
+
+## Implementation order
+
+1. `lionagi/outcomes/` — base type + verdict + ci_result (pure models, no deps)
+2. `artifacts` table + `StateDB.insert_artifact()` (schema + write path)
+3. Studio artifact rendering (frontend components)
+4. Retrofit `/codex-pr-review` and `/show` gate to write typed artifacts
+5. `chains` + `chain_runs` tables (schema only)
+6. `li chain` CLI subcommand (define, fire, check, list)
+7. Studio chains page (view chain definitions and runs)
+8. Schedule trigger via `li chain check` on cron
+
+Steps 1-4 are immediate value. Steps 5-8 are the chaining layer, which
+can be built incrementally.
+
+## References
+
+- [ADR-0009](ADR-0009-sqlite-state-layer.md) — SQLite state layer
+- [ADR-0011](ADR-0011-shows-data-model.md) — Shows data model (plays table)
+- [ADR-0020](ADR-0020-skill-invocations.md) — Skill invocations
+- [ChatGPT frontend design review](.khive/workspaces/20260521/chatgpt-frontend-review.md) — Kind-based outcome rendering (section 4): ReviewVerdict card with severity/categories/blocking findings, GateVerdict checklist, CIResult matrix
+- `lionagi/models/hashable_model.py` — Base model infrastructure
+- `lionagi/cli/orchestrate/flow.py` — FlowControlVerdict (existing pattern)
+- `~/.lionagi/skills/codex-pr-review/SKILL.md` — Verdict production pattern
+- `~/.lionagi/skills/show/SKILL.md` — Gate verdict production pattern

--- a/docs/adrs/ADR-0022-run-step-provenance.md
+++ b/docs/adrs/ADR-0022-run-step-provenance.md
@@ -205,3 +205,13 @@ path can extract model from `run.json` → `manifest.model_spec` if present.
 - `lionagi/cli/agent.py` — Session + branch creation
 - `lionagi/cli/orchestrate/flow.py` — FlowOp agent model resolution
 - `lionagi/cli/_providers.py` — `parse_model_spec()` resolution chain
+
+### Prior art
+
+- **W3C PROV-DM** (2013) — The Entity-Activity-Agent triple maps to lionagi's
+  Session-Branch-Message model. Our provenance columns capture a simplified
+  form of the PROV derivation relation.
+- **Buneman-Khanna-Tan 2001** ("Why and Where: A Characterization of Data
+  Provenance", ICDT) — Distinguishes why-provenance (which inputs produced
+  this output) from where-provenance (which source contributed). `agent_hash`
+  captures where-provenance; the branch message chain captures why-provenance.

--- a/docs/adrs/ADR-0022-run-step-provenance.md
+++ b/docs/adrs/ADR-0022-run-step-provenance.md
@@ -1,0 +1,207 @@
+# ADR-0022: Run Step Provenance — Model, Agent, and Provider Disclosure
+
+**Status**: Proposed
+**Date**: 2026-05-21
+**Extends**: ADR-0009 (SQLite state layer), ADR-0012 (execution lineage), ADR-0017 (session lifecycle)
+
+## Context
+
+Individual run steps don't disclose what model, provider, or agent
+definition they used. The data is partially available but not persisted
+or surfaced:
+
+### What's missing
+
+**Sessions** have `agent_name` (TEXT) — the agent profile name from
+`-a reviewer`. But:
+- No `model` column. The resolved model spec (`claude/claude-sonnet-4-6`,
+  `openai/gpt-4.1`) is not stored.
+- No `provider` column. Whether the run used Claude Code, Codex, OpenAI
+  API, or Anthropic API is not recorded.
+- No `agent_definition_hash`. The agent profile (`~/.lionagi/agents/reviewer.md`)
+  can change between runs — there's no snapshot of which version was used.
+- `agent_name` is only set for `li agent -a` runs. Flow ops and play
+  agents get `NULL`.
+
+**Branches** have `node_metadata` JSON which *can* hold `chat_model`, but:
+- The write path in `agent.py` only copies `chat_model` if it's in
+  `branch_dict` — and it's frequently missing (empty in 5/5 sampled rows).
+- Flow ops create multiple branches with different models — the per-branch
+  model is the right place, but it's not reliably written.
+- No `provider` or `effort` in `node_metadata` either.
+
+**The runs list** shows agent name and status but not model. The run
+detail page shows messages but not which model produced them. For runs
+via pre-configured agents (`-a reviewer`, `-a architect`), the agent
+profile specifies the model — but the actual resolved model (after
+defaults, overrides, and fallbacks) is not captured.
+
+### Why this matters
+
+1. **Debugging**: "Why did this run produce bad output?" — was it using
+   sonnet when it should have been opus? Can't tell from the DB.
+2. **Cost tracking**: Model choice drives cost. Without model info per
+   session, cost attribution is impossible.
+3. **Agent evolution**: Agent profiles change. If `reviewer.md` switches
+   from sonnet to opus, historical runs should show what they actually
+   used, not what the profile currently says.
+4. **Compliance**: For future audit trails, knowing which model processed
+   which data is a hard requirement.
+
+## Decision
+
+### Add first-class provenance columns to sessions
+
+```sql
+ALTER TABLE sessions ADD COLUMN model       TEXT;  -- resolved model spec: "claude/claude-sonnet-4-6"
+ALTER TABLE sessions ADD COLUMN provider    TEXT;  -- provider name: "claude_code", "codex", "openai", "anthropic"
+ALTER TABLE sessions ADD COLUMN effort      TEXT;  -- effort level: "low", "medium", "high", "xhigh"
+ALTER TABLE sessions ADD COLUMN agent_hash  TEXT;  -- SHA-256 of agent definition file content at invocation time
+```
+
+These are **resolved values** — not what the config says, but what the
+runtime actually used after all defaults, overrides, and fallbacks.
+
+### Add first-class provenance to branches
+
+```sql
+ALTER TABLE branches ADD COLUMN model       TEXT;  -- branch-level model (may differ from session for multi-agent flows)
+ALTER TABLE branches ADD COLUMN provider    TEXT;
+ALTER TABLE branches ADD COLUMN agent_name  TEXT;  -- the agent role within a flow (e.g., "explorer", "analyst")
+```
+
+Branch-level provenance matters for flows where different agents use
+different models. A flow session might use sonnet for the explorer and
+opus for the critic — the session-level model is the "default" or
+"primary" model; branch-level is the actual.
+
+### Write points
+
+| Event | Who writes | What |
+|-------|-----------|------|
+| `li agent` start | `agent.py` | Session: `model`, `provider`, `effort`, `agent_hash`, `agent_name` |
+| `li play` start | `flow.py` | Session: `model` (default), `provider`, `effort`. Per-op branches: `model`, `provider`, `agent_name` |
+| `li o flow` start | `flow.py` | Same as play |
+| `li o fanout` start | `fanout.py` | Session: `model`, `provider`. Worker branches: `model`, `agent_name` |
+| Branch creation (any) | `_orchestration.py` | Branch: `model`, `provider`, `agent_name` from the agent config |
+
+### Agent hash computation
+
+```python
+import hashlib
+from pathlib import Path
+
+def agent_definition_hash(agent_name: str) -> str | None:
+    """SHA-256 of the agent profile file content at invocation time."""
+    from lionagi.utils import LIONAGI_HOME
+    path = LIONAGI_HOME / "agents" / f"{agent_name}.md"
+    if not path.exists():
+        return None
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+```
+
+16-char truncated SHA-256 is sufficient for "same or different" checks.
+Not a security hash — just a content fingerprint.
+
+### Model resolution disclosure
+
+The model string stored must be the **fully resolved** spec, not the
+input. Resolution chain:
+
+```
+User input: "sonnet"
+  → parse_model_spec(): ModelSpec(model="claude/claude-sonnet-4-6")
+  → agent profile override: (none, use parsed)
+  → effort override: (none)
+  → fast mode: (none)
+  → RESOLVED: "claude/claude-sonnet-4-6"  ← this is what gets stored
+```
+
+If the user passes `--model sonnet`, the DB stores
+`claude/claude-sonnet-4-6`, not `sonnet`. This ensures the column is
+stable and comparable across runs.
+
+### Studio display
+
+#### Runs list
+
+Add a **Model** column to the runs list:
+
+| Name | Agent | Model | Status | Duration |
+|------|-------|-------|--------|----------|
+| play:backend | architect | claude/claude-sonnet-4-6 | completed | 87m |
+| agent | reviewer | openai/codex-mini-latest | completed | 15m |
+| flow | — | claude/claude-sonnet-4-6 | running | 3h |
+
+The model column shows the session-level model. For multi-model flows,
+a badge or tooltip shows "2 models" with the breakdown.
+
+#### Run detail
+
+Each step/branch shows its own model and agent:
+
+```
+Step: explorer (claude/claude-sonnet-4-6, effort=high)
+  [messages...]
+
+Step: critic (claude/claude-opus-4-6, effort=high)
+  [messages...]
+```
+
+#### Agent reference
+
+When `agent_name` is set and the agent definition file exists, the run
+detail page shows a link to the agent profile. The `agent_hash` enables
+a "definition changed since this run" indicator:
+
+```
+Agent: reviewer (definition changed since this run)
+```
+
+### Backfill for existing sessions
+
+Existing sessions have `model = NULL`. No automated backfill — the
+resolved model is lost for historical runs. The model column is nullable;
+Studio renders NULL as "—" or "unknown."
+
+For imported filesystem runs (`source_kind = 'imported_fs'`), the import
+path can extract model from `run.json` → `manifest.model_spec` if present.
+
+## Consequences
+
+**Positive**
+- Every run discloses its model, provider, and effort level — no guessing.
+- Multi-model flows show per-branch model, not just the session default.
+- Agent definition snapshots via hash enable "drift since this run" detection.
+- Cost attribution becomes possible (model → pricing table → cost per run).
+- Fully resolved model specs are stable and comparable.
+
+**Negative**
+- Four new columns on sessions, three on branches. Reconciled via
+  `_reconcile_columns()` — no migration runner needed.
+- Write path changes in `agent.py`, `flow.py`, `fanout.py`,
+  `_orchestration.py`. Must ensure all paths write provenance.
+- Historical runs have NULL model — incomplete data for old runs.
+- `agent_hash` is a point-in-time snapshot; it doesn't store the actual
+  content. If the agent file is deleted, the hash is unverifiable.
+  Acceptable — the hash answers "same or different," not "what was it."
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Store model in `node_metadata` JSON only | Not queryable — "show all runs using opus" requires JSON parsing every row |
+| Store full agent definition content | Too large for a column; agent files can be multi-KB. Hash is sufficient for drift detection |
+| Derive model from branch `node_metadata` | Already attempted — write path is unreliable, data is missing in practice |
+| Store user-input model string (e.g., "sonnet") | Not stable — alias resolution changes over time. Resolved spec is canonical |
+| Store model on sessions only (not branches) | Loses per-agent model info for multi-model flows |
+| Automated backfill from filesystem runs | Model resolution is not deterministic from historical data — the agent profile and defaults may have changed since the run |
+
+## References
+
+- [ADR-0009](ADR-0009-sqlite-state-layer.md) — SQLite state layer (sessions + branches schema)
+- [ADR-0012](ADR-0012-studio-execution-lineage.md) — Execution lineage (provenance columns)
+- [ADR-0017](ADR-0017-session-lifecycle-status.md) — Session lifecycle
+- `lionagi/cli/agent.py` — Session + branch creation
+- `lionagi/cli/orchestrate/flow.py` — FlowOp agent model resolution
+- `lionagi/cli/_providers.py` — `parse_model_spec()` resolution chain

--- a/docs/adrs/ADR-0023-unified-hook-system.md
+++ b/docs/adrs/ADR-0023-unified-hook-system.md
@@ -381,3 +381,23 @@ window, it moves to `lionagi/hooks/_legacy/`.
 - `lionagi/agent/hooks.py` — Current tool-call hooks
 - `lionagi/agent/config.py` — Current AgentConfig hook registration
 - `lionagi/cli/agent.py` — Current `_on_message` closure
+
+### Prior art
+
+- **Claude Code Hook Registry** (`_references/claude-code/src/utils/hooks.ts`)
+  — Merges three config sources, uses `getMatchingHooks()` with regex pattern
+  matching and `deny>ask>allow` permission precedence. The HookBus design is
+  convergent with this architecture.
+- **autogen Stream** (`autogen/beta/stream.py::MemoryStream`) — Typed event
+  bus with publish/subscribe and condition filters. Per-stream turn lock
+  serializes concurrent calls. Validates the pub/sub event bus approach.
+
+### Open question: dual Middle Protocol
+
+The CLI subprocess path (`run_and_collect`) and the API path (`communicate`)
+are both hook emission sites. CLI agents spawned via `li agent -a reviewer`
+use `run_and_collect` (subprocess streaming); Python API agents use
+`communicate` (one-shot). The HookBus must emit on both paths — the current
+design specifies hook points for the API path but should explicitly address
+the CLI subprocess path where `API_PRE_CALL`/`API_POST_CALL` semantics differ
+(the "call" is a subprocess spawn, not an HTTP request).

--- a/docs/adrs/ADR-0023-unified-hook-system.md
+++ b/docs/adrs/ADR-0023-unified-hook-system.md
@@ -1,0 +1,383 @@
+# ADR-0023: Unified Hook System and Agent-Level Configuration
+
+**Status**: Proposed
+**Date**: 2026-05-21
+**Extends**: ADR-0009 (SQLite state layer), ADR-0022 (run step provenance)
+
+## Context
+
+Model, provider, and effort information is known at the iModel layer
+during API calls but never reaches the persistence layer. The reason is
+structural: three disconnected hook systems exist, and none bridge the
+gap between "what model am I calling?" and "write this to the DB."
+
+### Three hook systems today
+
+| System | Layer | What it sees | Where it lives |
+|--------|-------|-------------|----------------|
+| **iModel HookRegistry** | Service/API | Model, provider, payload, response, tokens, latency | `lionagi/service/hooks/` |
+| **Agent hook_handlers** | Tool execution | Tool name, args, result | `lionagi/agent/hooks.py` + `AgentConfig` |
+| **CLI `_on_message`** | Message persistence | Message content, role, sender | Ad-hoc closure in `lionagi/cli/agent.py` |
+
+Problems:
+
+1. **No data flows between them.** The iModel PostInvocation hook knows
+   the model and token count, but the message persistence hook doesn't.
+   To write `model` on the session (ADR-0022), the CLI persistence code
+   would need to reach into the iModel's state — which it can't.
+
+2. **Not configurable from agent definitions.** Agent profiles
+   (`~/.lionagi/agents/reviewer.md`) specify model and behavior, but
+   hooks are hard-coded in Python. An agent can't declare "on every API
+   call, log the model and tokens" or "on tool error, notify the team
+   inbox" without code changes.
+
+3. **No lifecycle hooks.** There's no hook for "session started" or
+   "session ending" — the CLI just does inline writes. Session-level
+   provenance (ADR-0022) requires a session-start hook that captures
+   the resolved model, provider, effort, and agent hash.
+
+4. **`_on_message` is a closure, not a hook.** It's defined inline in
+   `agent.py`, can't be reused, can't be extended, can't be disabled.
+
+### Where model/provider info actually lives
+
+The resolution chain:
+
+```
+agent.md → parse_model_spec() → iModel.__init__(endpoint=...) → iModel.invoke()
+                                  ↑                                ↑
+                              provider, model known            payload, response, tokens known
+                              at Branch creation               at API call time
+```
+
+The info exists at two points:
+- **Branch creation**: model spec, provider, effort are resolved and
+  passed to `iModel.__init__()`. This is when session-level provenance
+  should be captured.
+- **API call**: the actual request payload, response, token usage, and
+  latency. This is when per-call metrics should be captured.
+
+Neither point has a hook that writes to the session DB.
+
+## Decision
+
+### Consolidate into a single `HookBus`
+
+Replace three disjoint systems with one event bus that all layers emit to
+and any handler can subscribe to:
+
+```python
+# lionagi/hooks/bus.py
+
+from enum import Enum
+from collections.abc import Callable, Awaitable
+from typing import Any
+
+class HookPoint(str, Enum):
+    # Session lifecycle
+    SESSION_START = "session.start"
+    SESSION_END = "session.end"
+
+    # Branch lifecycle
+    BRANCH_CREATE = "branch.create"
+
+    # iModel (API calls)
+    API_PRE_CALL = "api.pre_call"
+    API_POST_CALL = "api.post_call"
+    API_STREAM_CHUNK = "api.stream_chunk"
+
+    # Tool execution
+    TOOL_PRE = "tool.pre"
+    TOOL_POST = "tool.post"
+    TOOL_ERROR = "tool.error"
+
+    # Message lifecycle
+    MESSAGE_ADD = "message.add"
+
+    # Artifact production
+    ARTIFACT_CREATED = "artifact.created"
+
+
+HookHandler = Callable[..., Awaitable[Any]]
+
+
+class HookBus:
+    """Central event bus for all hook points.
+
+    Handlers are registered by HookPoint. Multiple handlers per point.
+    Handlers run sequentially in registration order. A handler raising
+    StopHook aborts subsequent handlers for that point (not the operation).
+    """
+
+    def __init__(self):
+        self._handlers: dict[HookPoint, list[HookHandler]] = {}
+
+    def on(self, point: HookPoint, handler: HookHandler) -> None:
+        self._handlers.setdefault(point, []).append(handler)
+
+    def off(self, point: HookPoint, handler: HookHandler) -> None:
+        handlers = self._handlers.get(point, [])
+        if handler in handlers:
+            handlers.remove(handler)
+
+    async def emit(self, point: HookPoint, **kwargs) -> None:
+        for handler in self._handlers.get(point, []):
+            try:
+                await handler(**kwargs)
+            except StopHook:
+                break
+            except Exception:
+                # Hook failures MUST NOT abort the operation.
+                # Log and continue.
+                import logging
+                logging.getLogger("lionagi.hooks").exception(
+                    "Hook failed: %s", point.value
+                )
+
+
+class StopHook(Exception):
+    """Raised by a handler to prevent subsequent handlers from running."""
+```
+
+### Event payloads (what each hook point receives)
+
+| HookPoint | kwargs | Source |
+|-----------|--------|--------|
+| `SESSION_START` | `session_id`, `model`, `provider`, `effort`, `agent_name`, `agent_hash`, `invocation_kind`, `invocation_id` | CLI session init |
+| `SESSION_END` | `session_id`, `status`, `ended_at`, `error` | CLI session finalize |
+| `BRANCH_CREATE` | `branch_id`, `session_id`, `model`, `provider`, `agent_name` | Branch init |
+| `API_PRE_CALL` | `model`, `provider`, `payload`, `branch_id` | iModel.invoke() |
+| `API_POST_CALL` | `model`, `provider`, `response`, `tokens`, `latency_ms`, `branch_id`, `status_code` | iModel.invoke() |
+| `API_STREAM_CHUNK` | `chunk_type`, `chunk`, `branch_id` | iModel streaming |
+| `TOOL_PRE` | `tool_name`, `action`, `args`, `branch_id` | Branch tool dispatch |
+| `TOOL_POST` | `tool_name`, `action`, `args`, `result`, `branch_id` | Branch tool dispatch |
+| `TOOL_ERROR` | `tool_name`, `action`, `args`, `error`, `branch_id` | Branch tool dispatch |
+| `MESSAGE_ADD` | `message`, `branch_id`, `session_id`, `progression_id` | Branch.add_message() |
+| `ARTIFACT_CREATED` | `artifact`, `invocation_id`, `session_id` | Skill output |
+
+### Built-in handlers
+
+The consolidation replaces the three existing systems with built-in
+handlers registered on the bus:
+
+```python
+# lionagi/hooks/builtins.py
+
+async def persist_session_start(*, session_id, model, provider, effort,
+                                 agent_name, agent_hash, **kw):
+    """Write session provenance to state.db at session start."""
+    from lionagi.state.db import StateDB
+    async with StateDB.open() as db:
+        await db.update_session(session_id, {
+            "model": model,
+            "provider": provider,
+            "effort": effort,
+            "agent_name": agent_name,
+            "agent_hash": agent_hash,
+            "status": "running",
+            "started_at": time.time(),
+        })
+
+async def persist_message(*, message, session_id, branch_id,
+                           progression_id, **kw):
+    """Write message to state.db + update last_message_at."""
+    from lionagi.state.db import StateDB
+    async with StateDB.open() as db:
+        await db.insert_message(message)
+        await db.append_to_progression(progression_id, message["id"])
+        await db.update_session(session_id, {
+            "last_message_at": time.time(),
+        })
+
+async def persist_branch_provenance(*, branch_id, model, provider,
+                                     agent_name, **kw):
+    """Write per-branch model/provider to state.db."""
+    from lionagi.state.db import StateDB
+    async with StateDB.open() as db:
+        await db.update_branch(branch_id, {
+            "model": model,
+            "provider": provider,
+            "agent_name": agent_name,
+        })
+
+async def guard_destructive_tool(*, tool_name, args, **kw):
+    """Block destructive bash commands."""
+    # Moved from lionagi/agent/hooks.py
+    ...
+```
+
+### Agent-level hook configuration
+
+Agent profiles gain a `hooks` section:
+
+```yaml
+# ~/.lionagi/agents/reviewer.md (frontmatter)
+---
+name: reviewer
+model: claude/claude-sonnet-4-6
+effort: high
+hooks:
+  session.start:
+    - persist_session_start        # built-in
+  api.post_call:
+    - log_api_metrics              # built-in: logs model, tokens, latency
+  tool.pre:
+    - guard_destructive            # built-in
+  tool.post:
+    - log_tool_use                 # built-in
+  message.add:
+    - persist_message              # built-in
+---
+```
+
+Hook names in agent profiles reference **registered handlers** — either
+built-ins or user-defined. Custom handlers are Python callables registered
+at startup:
+
+```python
+# ~/.lionagi/hooks/my_hooks.py (user-defined, auto-loaded)
+
+from lionagi.hooks import hook
+
+@hook("api.post_call")
+async def notify_on_expensive_call(*, tokens, model, **kw):
+    if tokens.get("total", 0) > 10000:
+        logger.warning("Expensive call: %s tokens on %s", tokens["total"], model)
+```
+
+### Default hooks (no configuration needed)
+
+When no `hooks` section is in the agent profile, the bus registers a
+default set:
+
+```python
+DEFAULT_HOOKS = {
+    HookPoint.SESSION_START: [persist_session_start],
+    HookPoint.SESSION_END: [persist_session_end],
+    HookPoint.MESSAGE_ADD: [persist_message],
+    HookPoint.BRANCH_CREATE: [persist_branch_provenance],
+}
+```
+
+These ensure ADR-0022 provenance and ADR-0019 `last_message_at` work
+without any agent-level configuration. Agent profiles can **extend** or
+**override** defaults:
+
+```yaml
+hooks:
+  tool.pre:
+    - guard_destructive      # adds to defaults (no tool.pre default)
+  message.add: []            # overrides: disables message persistence
+```
+
+### Migration from existing systems
+
+| Old system | New equivalent | Migration |
+|-----------|---------------|-----------|
+| `HookRegistry.pre_invoke()` | `bus.on(API_PRE_CALL, ...)` | Adapter wraps old-style handlers |
+| `HookRegistry.post_invoke()` | `bus.on(API_POST_CALL, ...)` | Adapter wraps old-style handlers |
+| `AgentConfig.pre(tool, fn)` | `bus.on(TOOL_PRE, fn)` with tool filter | Tool name becomes a kwarg filter |
+| `AgentConfig.post(tool, fn)` | `bus.on(TOOL_POST, fn)` with tool filter | Same |
+| `_on_message` closure | `bus.on(MESSAGE_ADD, persist_message)` | Delete closure, use built-in |
+
+The old `HookRegistry` and `AgentConfig.hook_handlers` are kept as
+deprecated wrappers during the transition. They delegate to the bus
+internally. Removed in 0.28.0.
+
+### Bus lifecycle
+
+One `HookBus` per session. Created at session init, passed to all
+branches in the session. Branches emit to the bus; handlers respond.
+
+```python
+class Session:
+    def __init__(self, ...):
+        self.hooks = HookBus()
+        # Register defaults
+        for point, handlers in DEFAULT_HOOKS.items():
+            for h in handlers:
+                self.hooks.on(point, h)
+        # Register agent-specific hooks from profile
+        if agent_config and agent_config.hooks:
+            for point_str, handler_names in agent_config.hooks.items():
+                point = HookPoint(point_str)
+                for name in handler_names:
+                    self.hooks.on(point, resolve_handler(name))
+```
+
+### Hook isolation
+
+Hooks MUST NOT:
+- Block the operation they're observing (async with timeout, fire-and-forget on failure)
+- Modify the operation's data (hooks are observers, not interceptors — except `TOOL_PRE` which can raise to block)
+- Hold references to the bus after session end (GC-safe)
+
+The only hook that can **block** an operation is `TOOL_PRE` — raising
+`PermissionError` prevents the tool call. All other hooks are
+fire-and-observe.
+
+### Package structure
+
+```
+lionagi/hooks/
+  __init__.py          # exports HookBus, HookPoint, hook decorator
+  bus.py               # HookBus, HookPoint enum, StopHook
+  builtins.py          # persist_*, guard_*, log_* handlers
+  loader.py            # load hooks from agent profile YAML
+  _compat.py           # adapters for old HookRegistry + AgentConfig
+```
+
+`lionagi/service/hooks/` is NOT moved or deleted during transition — it
+continues to work via `_compat.py` adapter. After 0.28.0 deprecation
+window, it moves to `lionagi/hooks/_legacy/`.
+
+## Consequences
+
+**Positive**
+- Model/provider/tokens flow from iModel layer to DB persistence via
+  a single bus — no more data gap.
+- Agent profiles can configure hooks declaratively — no code changes for
+  "log token usage on this agent" or "guard destructive commands on that agent."
+- Session lifecycle hooks enable clean provenance writes (ADR-0022)
+  without inline CLI code.
+- `last_message_at` (ADR-0019) becomes a built-in handler, not a
+  custom persistence path.
+- User-defined hooks are auto-loaded from `~/.lionagi/hooks/` — extensible
+  without modifying lionagi source.
+- One bus per session = clean isolation. No global state, no cross-session
+  leaks.
+
+**Negative**
+- Deprecation period for `HookRegistry` and `AgentConfig.hook_handlers`
+  means two code paths temporarily coexist.
+- Hook handler names in agent YAML must be resolvable — typos fail silently
+  unless validated at load time. Mitigation: validate at session start,
+  warn on unresolvable handler names.
+- Async handlers add latency to hot paths (message add, API call).
+  Mitigation: handlers that do I/O (DB writes) are fire-and-forget with
+  timeout; the operation never waits.
+- Moving from "hooks can modify" (old `AgentConfig.pre` returns modified
+  args) to "hooks observe" (new bus) changes the contract. `TOOL_PRE` is
+  the exception — it can block but not modify.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Keep three separate hook systems, bridge with adapters | Complexity grows with each new hook point; unified bus is simpler long-term |
+| Global singleton bus | Cross-session leaks; per-session bus is cleaner |
+| Hooks modify operation data (interceptor pattern) | Debugging nightmares when hooks silently alter payloads; observer pattern is safer |
+| Configuration in Python only (no YAML) | Agent profiles are YAML/markdown; hooks should be configurable at the same level |
+| Event sourcing (persist all events, derive state) | Over-engineered for our scale; targeted hooks on specific points is sufficient |
+| Middleware chain (Express/Koa style) | Implies ordering dependencies between middleware; flat handler list is simpler |
+
+## References
+
+- [ADR-0009](ADR-0009-sqlite-state-layer.md) — SQLite state layer
+- [ADR-0019](ADR-0019-teams-db-and-run-lifecycle.md) — `last_message_at` column
+- [ADR-0022](ADR-0022-run-step-provenance.md) — Session/branch provenance columns
+- `lionagi/service/hooks/` — Current iModel hook system
+- `lionagi/agent/hooks.py` — Current tool-call hooks
+- `lionagi/agent/config.py` — Current AgentConfig hook registration
+- `lionagi/cli/agent.py` — Current `_on_message` closure

--- a/docs/adrs/ADR-0023-unified-hook-system.md
+++ b/docs/adrs/ADR-0023-unified-hook-system.md
@@ -18,6 +18,7 @@ gap between "what model am I calling?" and "write this to the DB."
 | **iModel HookRegistry** | Service/API | Model, provider, payload, response, tokens, latency | `lionagi/service/hooks/` |
 | **Agent hook_handlers** | Tool execution | Tool name, args, result | `lionagi/agent/hooks.py` + `AgentConfig` |
 | **CLI `_on_message`** | Message persistence | Message content, role, sender | Ad-hoc closure in `lionagi/cli/agent.py` |
+| **Orchestrate `_on_message`** | Message persistence (flow/fanout) | Same as above | `lionagi/cli/orchestrate/_orchestration.py` |
 
 Problems:
 
@@ -165,19 +166,23 @@ handlers registered on the bus:
 # lionagi/hooks/builtins.py
 
 async def persist_session_start(*, session_id, model, provider, effort,
-                                 agent_name, agent_hash, **kw):
-    """Write session provenance to state.db at session start."""
+                                 agent_name, agent_hash,
+                                 invocation_id=None, invocation_kind=None,
+                                 **kw):
+    """Write session provenance + invocation linkage to state.db."""
     from lionagi.state.db import StateDB
     async with StateDB.open() as db:
-        await db.update_session(session_id, {
-            "model": model,
-            "provider": provider,
-            "effort": effort,
-            "agent_name": agent_name,
-            "agent_hash": agent_hash,
-            "status": "running",
-            "started_at": time.time(),
-        })
+        await db.update_session(
+            session_id,
+            model=model,
+            provider=provider,
+            effort=effort,
+            agent_name=agent_name,
+            agent_hash=agent_hash,
+            invocation_id=invocation_id,
+            status="running",
+            started_at=time.time(),
+        )
 
 async def persist_message(*, message, session_id, branch_id,
                            progression_id, **kw):
@@ -186,20 +191,15 @@ async def persist_message(*, message, session_id, branch_id,
     async with StateDB.open() as db:
         await db.insert_message(message)
         await db.append_to_progression(progression_id, message["id"])
-        await db.update_session(session_id, {
-            "last_message_at": time.time(),
-        })
+        await db.update_session(session_id, last_message_at=time.time())
 
 async def persist_branch_provenance(*, branch_id, model, provider,
                                      agent_name, **kw):
     """Write per-branch model/provider to state.db."""
     from lionagi.state.db import StateDB
     async with StateDB.open() as db:
-        await db.update_branch(branch_id, {
-            "model": model,
-            "provider": provider,
-            "agent_name": agent_name,
-        })
+        await db.update_branch(branch_id, model=model,
+                               provider=provider, agent_name=agent_name)
 
 async def guard_destructive_tool(*, tool_name, args, **kw):
     """Block destructive bash commands."""

--- a/docs/adrs/ADR-0023-unified-hook-system.md
+++ b/docs/adrs/ADR-0023-unified-hook-system.md
@@ -294,14 +294,24 @@ branches in the session. Branches emit to the bus; handlers respond.
 class Session:
     def __init__(self, ...):
         self.hooks = HookBus()
-        # Register defaults
+        # Merge defaults with agent profile overrides.
+        # If a profile specifies a hook point, it REPLACES the default
+        # list for that point (e.g., message.add: [] disables persistence).
+        # Hook points not mentioned in the profile keep their defaults.
+        profile_hooks = (agent_config.hooks or {}) if agent_config else {}
         for point, handlers in DEFAULT_HOOKS.items():
-            for h in handlers:
-                self.hooks.on(point, h)
-        # Register agent-specific hooks from profile
-        if agent_config and agent_config.hooks:
-            for point_str, handler_names in agent_config.hooks.items():
-                point = HookPoint(point_str)
+            if point.value in profile_hooks:
+                # Profile overrides this hook point
+                for name in profile_hooks[point.value]:
+                    self.hooks.on(point, resolve_handler(name))
+            else:
+                # Keep defaults
+                for h in handlers:
+                    self.hooks.on(point, h)
+        # Register profile hooks for points that have no defaults
+        for point_str, handler_names in profile_hooks.items():
+            point = HookPoint(point_str)
+            if point not in DEFAULT_HOOKS:
                 for name in handler_names:
                     self.hooks.on(point, resolve_handler(name))
 ```

--- a/docs/adrs/ADR-0024-session-health-and-admin-surface.md
+++ b/docs/adrs/ADR-0024-session-health-and-admin-surface.md
@@ -89,7 +89,7 @@ def classify_session_health(
     status = session.get("status", "completed")
 
     # Terminal sessions
-    if status in ("completed", "failed", "aborted"):
+    if status in ("completed", "failed", "aborted", "timed_out", "cancelled"):
         if has_stale_locks or (has_artifacts and _has_temp_files(session)):
             return SessionHealth.ZOMBIE
         return SessionHealth.HEALTHY  # terminal = done, nothing wrong
@@ -236,7 +236,7 @@ GET  /api/admin/events          # Recent admin events log
 ```python
 class TransitionBody(BaseModel):
     session_ids: list[str]
-    target_status: Literal["failed", "aborted"]
+    target_status: Literal["failed", "aborted", "cancelled"]
     reason: str  # required: why are you transitioning?
 
 # POST /api/admin/transition
@@ -610,3 +610,12 @@ Transitions remain explicit admin actions.
 - `apps/studio/server/routers/admin.py` — Current admin endpoints
 - `apps/studio/frontend/app/admin/page.tsx` — Current admin page
 - `apps/studio/frontend/app/page.tsx` — Current dashboard (client-side health heuristics)
+
+### Prior art
+
+- **NIST SP 800-92** ("Guide to Computer Security Log Management") — The
+  `admin_events` table follows the append-only audit log pattern. Events are
+  insert-only with no UPDATE/DELETE, matching the immutable log architecture.
+- **khive GTD Task FSM** (ADR-003, Lean4-proven) — The `can_transition`
+  validation pattern for `TransitionBody` mirrors khive's `transition` verb
+  with formally verified state machine properties.

--- a/docs/adrs/ADR-0024-session-health-and-admin-surface.md
+++ b/docs/adrs/ADR-0024-session-health-and-admin-surface.md
@@ -605,7 +605,7 @@ Transitions remain explicit admin actions.
 - [ADR-0017](ADR-0017-session-lifecycle-status.md) — Session lifecycle status
 - [ADR-0019](ADR-0019-teams-db-and-run-lifecycle.md) — Run lifecycle + staleness
 - [ADR-0022](ADR-0022-run-step-provenance.md) — Session provenance (model, agent)
-- [ChatGPT frontend design review](.khive/workspaces/20260521/chatgpt-frontend-review.md) — Admin console layout (section 3): action button row, two-column layout, intervention queue columns, transition modal, Resources + Event log side-by-side; dashboard metric cards (section 2): Attention/Active Executions/Outcomes/Latency cards, legacy session chip, 60m threshold
+- ChatGPT frontend design review (external, not in repo) — Admin console layout (section 3): action button row, two-column layout, intervention queue columns, transition modal, Resources + Event log side-by-side; dashboard metric cards (section 2): Attention/Active Executions/Outcomes/Latency cards, legacy session chip, 60m threshold
 - `apps/studio/server/services/admin.py` — Current phantom classification
 - `apps/studio/server/routers/admin.py` — Current admin endpoints
 - `apps/studio/frontend/app/admin/page.tsx` — Current admin page

--- a/docs/adrs/ADR-0024-session-health-and-admin-surface.md
+++ b/docs/adrs/ADR-0024-session-health-and-admin-surface.md
@@ -107,11 +107,11 @@ def classify_session_health(
     threshold = STALE_THRESHOLDS.get(kind, DEFAULT_STALE_THRESHOLD)
 
     if not process_alive:
-        if idle_seconds > threshold:
-            return SessionHealth.STALE
+        # Orphan check first — no artifacts AND no messages means
+        # the session never produced output (regardless of age).
         if not has_artifacts and session.get("message_count", 0) == 0:
             return SessionHealth.ORPHANED
-        # Process just died (< threshold) — still stale, but fresh
+        # Process is dead with some output — stale.
         return SessionHealth.STALE
 
     # Process is alive

--- a/docs/adrs/ADR-0024-session-health-and-admin-surface.md
+++ b/docs/adrs/ADR-0024-session-health-and-admin-surface.md
@@ -1,0 +1,612 @@
+# ADR-0024: Session Health Classification and Admin Surface
+
+**Status**: Proposed
+**Date**: 2026-05-21
+**Extends**: ADR-0017 (session lifecycle), ADR-0019 (run lifecycle management)
+
+## Context
+
+### "Phantom session" is under-defined
+
+The admin `doctor` endpoint classifies sessions as phantom using three
+reasons:
+
+| Reason | Detection | What it actually means |
+|--------|-----------|----------------------|
+| `process_dead` | PID file check + `ps` scan + `updated_at` staleness | Process crashed or was killed |
+| `missing_artifacts` | `artifacts_path` exists but directory doesn't | Session's save path was deleted or never created |
+| `stale_lock` | `*.lock` files older than threshold | Lock file left behind by crashed process |
+
+Problems:
+
+1. **`process_dead` conflates two signals.** A session with a dead
+   process but recent messages (last 5 min) might have crashed *just now*
+   — that's a different urgency than one dead for 12 hours. The staleness
+   threshold (`stale_hours`, default 1h) treats both identically.
+
+2. **No message-activity signal.** The classification checks `updated_at`
+   (session metadata timestamp) but not message progression. A session
+   with `updated_at` from 2 hours ago but a message written 5 minutes
+   ago is not stale — something is still writing messages even if the
+   session metadata hasn't been updated. Conversely, a session with
+   `updated_at` bumped by a metadata write but no messages for 8 hours
+   is effectively dead.
+
+3. **`missing_artifacts` is noisy.** Sessions without `--save` don't
+   write to `artifacts_path`. The artifacts directory being absent is
+   normal for these — but the classifier flags it as phantom.
+
+4. **No graduated severity.** All three reasons produce the same UI:
+   a red "phantom" badge with a prune button. There's no distinction
+   between "probably safe to kill" and "might be a legitimate pause."
+
+5. **Prune is the only action.** The admin page offers prune (delete
+   the session row) but not transition (mark as failed), inspect (show
+   session detail), or recover (restart).
+
+### The admin page could do much more
+
+The admin page currently shows:
+- DB health strip (size, WAL size, WAL pending)
+- Phantom sessions table (checkbox + prune)
+
+It could be the operational control center:
+- Session health overview (not just phantoms)
+- Active resource usage (worktrees, disk, connections)
+- Maintenance actions (checkpoint, vacuum, import, prune)
+- Configuration view (agent profiles, chain status)
+- Event log (recent hook events, errors, transitions)
+
+## Decision
+
+### Part A: Precise session health classification
+
+Replace the binary "phantom or not" with a graduated health model:
+
+```python
+from enum import Enum
+
+class SessionHealth(str, Enum):
+    HEALTHY = "healthy"           # running, process alive, messages flowing
+    IDLE = "idle"                 # running, process alive, no messages for >1h
+    UNRESPONSIVE = "unresponsive" # running, process alive, no messages for >threshold
+    STALE = "stale"               # running, process dead, no messages for >threshold
+    ORPHANED = "orphaned"         # running, no process, no artifacts, no messages
+    ZOMBIE = "zombie"             # completed/failed but resources not cleaned up
+```
+
+Classification logic:
+
+```python
+def classify_session_health(
+    session: dict,
+    *,
+    now: float,
+    process_alive: bool,
+    has_artifacts: bool,
+    has_stale_locks: bool,
+) -> SessionHealth:
+    status = session.get("status", "completed")
+
+    # Terminal sessions
+    if status in ("completed", "failed", "aborted"):
+        if has_stale_locks or (has_artifacts and _has_temp_files(session)):
+            return SessionHealth.ZOMBIE
+        return SessionHealth.HEALTHY  # terminal = done, nothing wrong
+
+    # Running sessions only below
+    last_activity = (
+        session.get("last_message_at")
+        or session.get("updated_at")
+        or session.get("started_at")
+        or 0
+    )
+    idle_seconds = now - last_activity
+
+    kind = session.get("invocation_kind")
+    threshold = STALE_THRESHOLDS.get(kind, DEFAULT_STALE_THRESHOLD)
+
+    if not process_alive:
+        if idle_seconds > threshold:
+            return SessionHealth.STALE
+        if not has_artifacts and session.get("message_count", 0) == 0:
+            return SessionHealth.ORPHANED
+        # Process just died (< threshold) — still stale, but fresh
+        return SessionHealth.STALE
+
+    # Process is alive
+    if idle_seconds > threshold:
+        return SessionHealth.UNRESPONSIVE
+    if idle_seconds > 3600:  # 1 hour
+        return SessionHealth.IDLE
+
+    return SessionHealth.HEALTHY
+```
+
+#### Health → action mapping
+
+Color assignments adopt the review's token system (see ChatGPT frontend design
+review, section 3):
+
+| Health | Color | Available actions |
+|--------|-------|------------------|
+| `HEALTHY` | Green (calm) | Inspect |
+| `IDLE` | Neutral/blue (muted) | Inspect |
+| `UNRESPONSIVE` | Amber | Inspect, inspect logs |
+| `STALE` | Orange | Inspect, Transition to failed |
+| `ORPHANED` | Purple | Repair or transition |
+| `ZOMBIE` | Red | Cleanup/prune |
+
+#### Thresholds (kind-aware, from ADR-0019)
+
+```python
+STALE_THRESHOLDS = {
+    "agent": 6 * 3600,        # 6h
+    "play": 6 * 3600,         # 6h
+    "flow": 12 * 3600,        # 12h
+    "fanout": 12 * 3600,      # 12h
+    "show-play": 12 * 3600,   # 12h
+}
+DEFAULT_STALE_THRESHOLD = 6 * 3600
+```
+
+### Part B: Admin API expansion
+
+#### New endpoints
+
+```
+GET  /api/admin/health          # Full health report
+POST /api/admin/transition      # Change session status (with guard)
+POST /api/admin/checkpoint      # Force WAL checkpoint
+POST /api/admin/vacuum          # VACUUM the DB
+GET  /api/admin/resources       # Active resources (worktrees, disk)
+GET  /api/admin/events          # Recent admin events log
+```
+
+#### Health endpoint response
+
+```json
+{
+  "sessions": {
+    "total": 376,
+    "by_status": {
+      "running": 8,
+      "completed": 350,
+      "failed": 15,
+      "aborted": 3
+    },
+    "by_health": {
+      "healthy": 371,
+      "idle": 2,
+      "unresponsive": 1,
+      "stale": 3,
+      "orphaned": 1,
+      "zombie": 0
+    },
+    "unhealthy": [
+      {
+        "session_id": "abc123",
+        "name": "play:backend",
+        "health": "stale",
+        "status": "running",
+        "last_message_at": 1716250000.0,
+        "idle_seconds": 21600,
+        "process_alive": false,
+        "invocation_kind": "play",
+        "agent_name": "architect",
+        "model": "claude/claude-sonnet-4-6",
+        "message_count": 42
+      }
+    ]
+  },
+  "db": {
+    "size_bytes": 4521984,
+    "wal_bytes": 32768,
+    "page_count": 1100,
+    "freelist_count": 12,
+    "journal_mode": "wal",
+    "auto_checkpoint": 1000,
+    "foreign_keys": true,
+    "busy_timeout": 5000,
+    "schema_version": "1"
+  },
+  "resources": {
+    "worktrees": [
+      {
+        "path": "/Users/lion/khive-work/worktrees/lionagi-issue-sweep-backend",
+        "branch": "show/lionagi-issue-sweep/backend",
+        "status": "stale",
+        "last_modified": 1716250000.0,
+        "uncommitted_changes": false
+      }
+    ],
+    "disk": {
+      "state_db": 4521984,
+      "runs_dir": 125829120,
+      "teams_dir": 8192,
+      "total": 130359296
+    }
+  },
+  "diagnostic_run_at": "2026-05-21T16:45:00Z"
+}
+```
+
+#### Transition endpoint
+
+```python
+class TransitionBody(BaseModel):
+    session_ids: list[str]
+    target_status: Literal["failed", "aborted"]
+    reason: str  # required: why are you transitioning?
+
+# POST /api/admin/transition
+async def transition_sessions(body: TransitionBody) -> dict:
+    """Transition running sessions to a terminal status.
+
+    Guards:
+    1. Only running sessions can be transitioned.
+    2. Healthy/idle sessions are rejected (process still alive + messages flowing).
+    3. Transition writes an admin event log entry with reason.
+    """
+```
+
+This replaces the blunt "prune" (delete the row) with "transition"
+(mark as failed/aborted). The session and its messages are preserved
+for debugging. Prune remains available for cleanup after inspection.
+
+#### Checkpoint and vacuum endpoints
+
+```python
+# POST /api/admin/checkpoint
+async def checkpoint(mode: str = "TRUNCATE") -> dict:
+    """Force WAL checkpoint. Modes: PASSIVE, FULL, RESTART, TRUNCATE."""
+    # TRUNCATE reclaims the WAL file when no readers are active.
+
+# POST /api/admin/vacuum
+async def vacuum() -> dict:
+    """VACUUM the DB to reclaim freed pages. Holds exclusive lock."""
+    # Returns before/after size.
+```
+
+These expose `li state checkpoint` and `li state vacuum` via the API.
+
+### Part C: Admin page redesign
+
+The admin page becomes a full operational console with a top action row,
+two-column layout (Session health + Maintenance), an intervention queue,
+and side-by-side Resources + Event log panels.
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ Admin                                                    Checked 12:52 PM    │
+│ Studio maintenance and diagnostics                                          │
+│                                                                             │
+│ [Refresh] [Checkpoint WAL] [Vacuum DB] [Export snapshot]                    │
+├─────────────────────────────────────────────────────────────────────────────┤
+│ DB 847.3 MB · WAL 4.0 MB · WAL pending 4.0 MB · Conn 0 · Disk OK · SSE Live │
+├──────────────────────────────────┬──────────────────────────────────────────┤
+│ Session health                   │ Maintenance                              │
+│                                  │                                          │
+│ healthy          37              │ WAL checkpoint available                 │
+│ idle              2              │ Last checkpoint unavailable              │
+│ unresponsive      0              │ Vacuum recommended: no                   │
+│ stale             4              │ Export size estimate: 851 MB             │
+│ orphaned          0              │                                          │
+│ zombie            0              │ [Checkpoint] [Export]                    │
+├──────────────────────────────────┴──────────────────────────────────────────┤
+│ Intervention queue                                                          │
+│                                                                             │
+│ State       Session       Kind       Invocation         Last event   Action  │
+│ stale       f82488be      agent      /show issue-sweep  1h ago       Inspect │
+│ stale       462bb5ed      agent      /show issue-sweep  9h ago       Fail    │
+│ stale       c3e69388      agent      /show issue-sweep  17h ago      Fail    │
+│ stale       cf1b48f8      agent      /show issue-sweep  17h ago      Fail    │
+│                                                                             │
+│ Bulk: [Transition selected to failed] [Prune terminal only] [Export selected]│
+├──────────────────────────────────┬──────────────────────────────────────────┤
+│ Resources                        │ Admin event log                          │
+│                                  │                                          │
+│ Worktrees                        │ 12:48  checkpoint requested              │
+│ 9 total · 4 active · 2 stale     │ 12:48  checkpoint completed              │
+│                                  │ 12:31  session transitioned to failed    │
+│ Disk usage                       │        f82488be · missing artifacts      │
+│ DB          847 MB               │                                          │
+│ WAL           4 MB               │                                          │
+│ Artifacts     2.1 GB             │                                          │
+│ Worktrees     6.8 GB             │                                          │
+└──────────────────────────────────┴──────────────────────────────────────────┘
+```
+
+#### Transition modal
+
+Bulk transitions open a confirmation modal that preserves session records
+while marking them terminal:
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ Transition 4 sessions to failed?                                    │
+│                                                                     │
+│ This preserves session records and artifacts                        │
+│ while marking them terminal.                                        │
+│                                                                     │
+│ Reason                                                              │
+│ [ Missing artifacts / stale heartbeat                            v ]│
+│                                                                     │
+│ Note                                                                │
+│ [ optional operator note                                          ] │
+│                                                                     │
+│ Affected sessions                                                   │
+│ f82488be · 462bb5ed · c3e69388 · cf1b48f8                           │
+│                                                                     │
+│ [Cancel] [Transition to failed]                                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+Prune remains visually secondary and is disabled unless sessions are terminal
+or explicitly eligible:
+
+```
+Prune selected
+disabled: active sessions must be transitioned or exported first
+```
+
+#### Dashboard metric cards
+
+The dashboard (ADR-0019 §B4) replaces the four current cards with an
+operator-focused layout. Cards:
+
+```
+1. Attention
+2. Active Executions
+3. Outcomes
+4. Latency / SLA
+```
+
+**Attention** (most important card):
+
+```
+attention =
+  stale running sessions
+  + zombie sessions
+  + orphaned sessions
+  + failed/timed_out in current range
+  + request_changes / reject verdicts
+  + blocked shows / chains
+```
+
+Example card:
+```
+ATTENTION
+4
+4 stale · 0 failed · 0 needs review
+Oldest: 17h 56m
+```
+
+**Active Executions**: separates "active" from "healthy". A session can be
+reported as `running` but effectively `stale`:
+
+```
+ACTIVE EXECUTIONS
+6 invocations
+4 sessions · 6 plays
+Oldest active: 17h 56m
+```
+
+**Outcomes**: summarizes quality, not just completion. Shows structured outcome
+breakdown when verdicts exist:
+
+```
+OUTCOMES 24H
+37 completed
+0 failed · 1 request changes
+Pass rate: 97%
+```
+
+**Latency / SLA**: replaces the "Slow Runs" card with tail latency.
+Threshold is **60 minutes** (confirmed by ADR-0025):
+
+```
+LATENCY 24H
+P95 58m
+2 over 60m · median 5m 18s
+```
+
+| Signal | Meaning | Dashboard treatment |
+|--------|---------|---------------------|
+| Active run over 60m | needs intervention | included in Attention |
+| Completed run over 60m | performance trend | included in Latency |
+
+#### (Null) / legacy session handling on dashboard
+
+Do not show `(Null)` sessions in the main status breakdown. Rename to:
+
+```
+Legacy unclassified
+```
+
+Display as a muted data-hygiene chip in the system strip:
+
+```
+System: healthy · DB 847.3 MB · WAL 4.0 MB · Conn 0 · Legacy 376
+```
+
+Legacy sessions are excluded from live health, trend, and failure metrics.
+Tooltip: "Sessions created before the current status vocabulary. Excluded
+from live operational metrics."
+
+Admin provides: Backfill status | Archive legacy | Export legacy.
+
+#### Key changes from current admin page
+
+| Current | Proposed |
+|---------|----------|
+| Binary phantom/not | Graduated health (6 levels) |
+| Prune only | Transition + Prune + Inspect |
+| DB health strip (3 numbers) | Full DB stats + two-column maintenance panel |
+| No action row | Refresh / Checkpoint WAL / Vacuum DB / Export snapshot |
+| No resource view | Worktrees, disk usage (side-by-side with event log) |
+| No event log | Admin action history with timestamp + target + reason |
+| No context on phantom sessions | Intervention queue: State/Session/Kind/Invocation/Last event/Action columns |
+| No transition modal | Reason dropdown + optional note + affected session list |
+| No legacy session handling | Dashboard chip + admin bulk actions for null sessions |
+
+### Part D: Admin event log
+
+```sql
+CREATE TABLE IF NOT EXISTS admin_events (
+  id              TEXT    PRIMARY KEY,
+  created_at      REAL    NOT NULL,
+  action          TEXT    NOT NULL,  -- "transition", "prune", "checkpoint", "vacuum", "classify"
+  target_id       TEXT,              -- session_id, or NULL for DB-wide actions
+  details         JSON    NOT NULL,  -- action-specific data
+  actor           TEXT    NOT NULL DEFAULT 'admin'  -- "admin", "doctor_auto", "chain"
+);
+
+CREATE INDEX IF NOT EXISTS idx_admin_events_created ON admin_events(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_admin_events_action ON admin_events(action);
+```
+
+Every admin action (transition, prune, checkpoint, vacuum) writes an
+event. The event log provides an audit trail and feeds the admin page's
+event log section.
+
+Doctor scans also write events when they classify sessions, creating a
+timeline of health changes:
+
+```json
+{
+  "action": "classify",
+  "target_id": "abc123",
+  "details": {
+    "health": "stale",
+    "previous_health": "unresponsive",
+    "idle_seconds": 21600,
+    "process_alive": false,
+    "message_count": 42
+  },
+  "actor": "doctor_auto"
+}
+```
+
+### Part E: Resource tracking
+
+#### Worktrees
+
+```python
+async def list_worktrees() -> list[dict]:
+    """Scan known worktree roots for lionagi worktrees."""
+    worktrees = []
+    for root in [
+        Path.home() / "khive-work" / "worktrees",
+        Path.home() / "khive-work" / "shows",
+    ]:
+        if not root.exists():
+            continue
+        for wt in root.iterdir():
+            if not wt.is_dir():
+                continue
+            # Check if it's a git worktree
+            git_file = wt / ".git"
+            if not git_file.exists():
+                continue
+            worktrees.append({
+                "path": str(wt),
+                "branch": _get_worktree_branch(wt),
+                "last_modified": wt.stat().st_mtime,
+                "uncommitted_changes": _has_uncommitted(wt),
+                "status": _classify_worktree(wt),
+            })
+    return worktrees
+```
+
+#### Disk usage
+
+```python
+async def disk_usage() -> dict:
+    """Aggregate disk usage for lionagi-managed directories."""
+    return {
+        "state_db": _file_size(DEFAULT_DB_PATH),
+        "runs_dir": _dir_size(RUNS_ROOT),
+        "teams_dir": _dir_size(TEAMS_DIR),
+        "shows_dir": _dir_size(Path.home() / "khive-work" / "shows"),
+        "worktrees_dir": _dir_size(Path.home() / "khive-work" / "worktrees"),
+        "agents_dir": _dir_size(LIONAGI_HOME / "agents"),
+        "playbooks_dir": _dir_size(LIONAGI_HOME / "playbooks"),
+    }
+```
+
+### Part F: Auto-doctor (optional background scan)
+
+The Studio backend can run doctor scans periodically in the background:
+
+```python
+# In app.py lifespan
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Start background doctor scan every 5 minutes
+    task = asyncio.create_task(_periodic_doctor())
+    yield
+    task.cancel()
+
+async def _periodic_doctor():
+    while True:
+        await asyncio.sleep(300)  # 5 minutes
+        try:
+            await admin_svc.classify_all_running_sessions()
+        except Exception:
+            logger.exception("Background doctor scan failed")
+```
+
+This replaces the current reactive-only model. The admin page shows
+health that's at most 5 minutes stale, not only when someone clicks
+"Doctor."
+
+Auto-doctor does NOT auto-transition. It only classifies and logs.
+Transitions remain explicit admin actions.
+
+## Consequences
+
+**Positive**
+- Graduated health model gives precise language for session state —
+  "stale" and "orphaned" mean different things with different actions.
+- Transition preserves session data for debugging; prune is a separate
+  step after inspection.
+- Admin page becomes useful beyond "clean up phantoms" — it's a full
+  operational console.
+- Event log provides audit trail for admin actions.
+- Resource tracking surfaces worktrees and disk usage that currently
+  require manual `ls` and `du`.
+- Auto-doctor keeps health classifications fresh without operator
+  intervention.
+
+**Negative**
+- More complex classification logic — 6 health states instead of 3
+  phantom reasons. Mitigated by clear decision tree and tests.
+- Background doctor scan adds CPU/IO load every 5 minutes. At our
+  session count (< 400), the scan is sub-second.
+- Admin event log grows unbounded. Mitigated by periodic cleanup (prune
+  events older than 30 days, keep latest 1000).
+- Worktree scanning requires filesystem access — adds latency to the
+  health endpoint. Mitigated by caching with 60s TTL.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Keep binary phantom/not | Under-specified; different failure modes need different responses |
+| Auto-transition stale sessions | Risk of killing legitimate pauses; operator should confirm |
+| Store health as a DB column | Health is derived from multiple signals; storing it would require re-derivation triggers |
+| Separate admin app | Fragmentation; admin belongs in the same Studio UI |
+| Health checks via CLI only (`li state doctor`) | CLI is for operators; Studio is for monitoring. Both should work, but Studio is primary |
+| Event log in a separate file | DB is already the persistence layer; another file adds sync complexity |
+
+## References
+
+- [ADR-0017](ADR-0017-session-lifecycle-status.md) — Session lifecycle status
+- [ADR-0019](ADR-0019-teams-db-and-run-lifecycle.md) — Run lifecycle + staleness
+- [ADR-0022](ADR-0022-run-step-provenance.md) — Session provenance (model, agent)
+- [ChatGPT frontend design review](.khive/workspaces/20260521/chatgpt-frontend-review.md) — Admin console layout (section 3): action button row, two-column layout, intervention queue columns, transition modal, Resources + Event log side-by-side; dashboard metric cards (section 2): Attention/Active Executions/Outcomes/Latency cards, legacy session chip, 60m threshold
+- `apps/studio/server/services/admin.py` — Current phantom classification
+- `apps/studio/server/routers/admin.py` — Current admin endpoints
+- `apps/studio/frontend/app/admin/page.tsx` — Current admin page
+- `apps/studio/frontend/app/page.tsx` — Current dashboard (client-side health heuristics)

--- a/docs/adrs/ADR-0025-session-status-vocabulary.md
+++ b/docs/adrs/ADR-0025-session-status-vocabulary.md
@@ -61,23 +61,19 @@ The dashboard uses `SLOW_RUN_SECONDS = 30 * 60` (30 minutes) and
 
 ### Expanded session status vocabulary
 
-```sql
-ALTER TABLE sessions DROP CONSTRAINT IF EXISTS sessions_status_check;
--- SQLite doesn't support DROP CONSTRAINT; handled via schema migration
+The six-value status vocabulary replaces the four-value CHECK:
 
--- New CHECK:
-status TEXT CHECK(
-  status IS NULL
-  OR status IN (
-    'running',
-    'completed',
-    'failed',
-    'timed_out',
-    'aborted',
-    'cancelled'
-  )
-)
+```python
+# Python validation (source of truth — replaces SQLite CHECK,
+# see Schema Migration section below for rationale)
+VALID_SESSION_STATUSES = frozenset({
+    "running", "completed", "failed", "timed_out", "aborted", "cancelled"
+})
 ```
+
+The `schema.sql` CHECK constraint is **removed** and replaced with
+Python-only validation. See [Schema migration](#schema-migration) for
+the migration path.
 
 | Status | Meaning | Set by | Exit code |
 |--------|---------|--------|-----------|
@@ -118,18 +114,27 @@ The session status FSM is deterministic. All transitions originate from
 | `running` | `completed` | Normal completion | CLI teardown |
 | `running` | `failed` | Unhandled exception | CLI teardown |
 | `running` | `timed_out` | `TimeoutError` from `anyio.fail_after` | CLI teardown |
-| `running` | `aborted` | `KeyboardInterrupt` / `CancelledError` | CLI teardown |
-| `running` | `cancelled` | Orchestrator / admin decision | Skill runner or admin API |
+| `running` | `aborted` | `KeyboardInterrupt` (user Ctrl-C) | CLI teardown |
+| `running` | `cancelled` | `CancelledError` / orchestrator abort / admin decision | CLI teardown or admin API |
 
-No transitions between terminal statuses are permitted. The admin
-`TransitionBody` endpoint (ADR-0024) enforces this via
-`can_transition(current, target)` validation — modeled on khive's
-GTD `transition` verb with its Lean4-proven FSM properties.
+No transitions between terminal statuses are permitted.
+
+**CLI transition logic** uses the full terminal set:
 
 ```python
 def can_transition(current: str, target: str) -> bool:
     return current == "running" and target in SESSION_TERMINAL_STATUSES
 ```
+
+**Admin transitions** use a restricted subset — operators should not
+mark sessions as `completed` or `timed_out` (those are system-determined):
+
+```python
+ADMIN_TRANSITION_TARGETS = frozenset({"failed", "aborted", "cancelled"})
+```
+
+Both are modeled on khive's GTD `transition` verb with its Lean4-proven
+FSM properties (`can_transition` validation).
 
 ### Write points (updated from ADR-0017)
 

--- a/docs/adrs/ADR-0025-session-status-vocabulary.md
+++ b/docs/adrs/ADR-0025-session-status-vocabulary.md
@@ -1,0 +1,390 @@
+# ADR-0025: Session Status Vocabulary
+
+**Status**: Proposed
+**Date**: 2026-05-21
+**Supersedes**: ADR-0017 §"Status vocabulary (sessions)" (partially — extends the vocabulary)
+
+## Context
+
+ADR-0017 defined four session statuses: `running`, `completed`, `failed`,
+`aborted`. This was deliberately minimal. In practice, the vocabulary is
+too coarse:
+
+### 1. Timeout is invisible
+
+`li play --timeout 900` fires a `LionTimeoutError` when the 15-minute
+deadline hits. The CLI catches it and sets `_terminal_status = "failed"`.
+But "failed because the model returned an error" and "failed because we
+hit a deliberate timeout" are operationally different:
+
+- **Timeout**: expected behavior when bounding execution time. The work
+  may be partially complete. Retry with more time is the natural response.
+- **Failed**: unexpected error. The work is invalid. Retry may produce
+  the same error.
+
+The runs list shows both as red "failed" pills. An operator can't tell
+whether a "failed" run needs debugging or just a longer timeout.
+
+### 2. No distinction between crash and error
+
+A session can fail because:
+- The model returned a malformed response → **error** (recoverable)
+- The Python process segfaulted → **crash** (infrastructure)
+- A dependency raised an exception → **error** (potentially recoverable)
+- The process was OOM-killed → **crash** (resource limit)
+
+Today all of these are `failed`. The health classifier (ADR-0024) can
+distinguish post-hoc (process_dead = crash, process alive with error =
+error), but the status column doesn't record the distinction.
+
+### 3. "Aborted" conflates user-initiated and system-initiated
+
+`aborted` covers both:
+- User pressed Ctrl-C → **user cancelled** (intentional)
+- Anyio task group cancelled a child → **system cancelled** (cascade)
+- Show abort sentinel → **orchestrator cancelled** (intentional, higher level)
+
+These have different follow-up actions: user cancellation needs no
+follow-up; system cancellation may indicate a bug; orchestrator
+cancellation is normal lifecycle.
+
+### 4. Slow run threshold
+
+The dashboard uses `SLOW_RUN_SECONDS = 30 * 60` (30 minutes) and
+`STUCK_RUN_SECONDS = 30 * 60` (30 minutes). Both are too aggressive:
+
+- A typical `li play` run with 3-5 agents takes 45-90 minutes.
+- A `/show` play routinely runs 60-90 minutes.
+- 30 minutes flags nearly every flow as "slow" — useless signal.
+
+## Decision
+
+### Expanded session status vocabulary
+
+```sql
+ALTER TABLE sessions DROP CONSTRAINT IF EXISTS sessions_status_check;
+-- SQLite doesn't support DROP CONSTRAINT; handled via schema migration
+
+-- New CHECK:
+status TEXT CHECK(
+  status IS NULL
+  OR status IN (
+    'running',
+    'completed',
+    'failed',
+    'timed_out',
+    'aborted',
+    'cancelled'
+  )
+)
+```
+
+| Status | Meaning | Set by | Exit code |
+|--------|---------|--------|-----------|
+| `running` | Session is active | CLI at session creation | — |
+| `completed` | Finished normally | CLI at session close | 0 |
+| `failed` | Terminated with error | CLI on uncaught exception | != 0 |
+| `timed_out` | Killed by `--timeout` deadline | CLI on `LionTimeoutError` | 124 (UNIX convention) |
+| `aborted` | User-initiated interruption | CLI on KeyboardInterrupt / SIGINT | 130 (128 + SIGINT) |
+| `cancelled` | System/orchestrator-initiated cancellation | CLI on CancelledError / abort sentinel | 143 (128 + SIGTERM) |
+
+Key distinctions:
+
+- **`failed` vs `timed_out`**: timeout is a deliberate bound, not an error.
+  "Retry with more time" vs "investigate the error."
+- **`aborted` vs `cancelled`**: aborted = user pressed Ctrl-C (intentional).
+  cancelled = system killed the task (cascade, orchestrator decision, OOM).
+- **Exit codes**: follow UNIX convention. 124 for timeout (GNU coreutils
+  `timeout` uses 124). 130 for SIGINT (128 + 2). 143 for SIGTERM (128 + 15).
+
+### Terminal vs non-terminal
+
+```python
+SESSION_TERMINAL_STATUSES = frozenset({
+    "completed", "failed", "timed_out", "aborted", "cancelled"
+})
+```
+
+All non-`running` statuses are terminal. The SSE done-condition check
+(ADR-0017 `is_session_stream_done`) uses this set.
+
+### Write points (updated from ADR-0017)
+
+```python
+# lionagi/cli/agent.py — updated teardown
+_terminal_status = "completed"
+try:
+    res = await branch.operate(...)
+except KeyboardInterrupt:
+    _terminal_status = "aborted"
+    raise
+except BaseException as exc:
+    from lionagi._errors import TimeoutError as LionTimeoutError
+    from lionagi.ln.concurrency import get_cancelled_exc_class
+
+    if isinstance(exc, LionTimeoutError):
+        _terminal_status = "timed_out"
+    elif isinstance(exc, get_cancelled_exc_class()):
+        _terminal_status = "cancelled"
+    else:
+        _terminal_status = "failed"
+    raise
+finally:
+    await _teardown_live_persist(live, status=_terminal_status)
+```
+
+For flows and fanout:
+
+```python
+# lionagi/cli/orchestrate/flow.py
+except LionTimeoutError:
+    # Don't catch here — let it propagate to the session teardown
+    raise
+```
+
+The `LionTimeoutError` should propagate to the session-level handler
+rather than being caught in the orchestrate dispatcher (which currently
+catches it, logs, and returns exit code 1 without setting the session
+status).
+
+### Dashboard thresholds (updated)
+
+```python
+SLOW_RUN_SECONDS = 60 * 60    # 60 minutes (was 30)
+STUCK_RUN_SECONDS = 60 * 60   # 60 minutes (was 30)
+```
+
+Rationale: typical flow runs are 45-90 minutes. 60 minutes as the "slow"
+threshold flags only the actual outliers. The "stuck" threshold also
+moves to 60 minutes — a running session that hasn't finished after an
+hour warrants attention, but 30 minutes was flagging normal runs.
+
+### Status display mapping
+
+```python
+DISPLAY_MAP = {
+    "running": {"label": "Running", "tone": "running"},
+    "completed": {"label": "Completed", "tone": "ok"},
+    "failed": {"label": "Failed", "tone": "failed"},
+    "timed_out": {"label": "Timed out", "tone": "pending"},
+    "aborted": {"label": "Aborted", "tone": "neutral"},
+    "cancelled": {"label": "Cancelled", "tone": "neutral"},
+}
+```
+
+`timed_out` gets "pending" tone (amber/yellow) — it's not an error,
+it's a boundary. The operator's response is "retry with more time,"
+not "investigate an error."
+
+Color tokens use soft backgrounds with strong foreground text for accessibility
+at small label sizes (see ChatGPT frontend design review, section 6):
+
+| Semantic | Light bg | Light fg | Contrast | Dark bg | Dark fg | Contrast |
+|----------|----------|----------|----------|---------|---------|----------|
+| success | `#ECFDF3` | `#067647` | 5.4 | `#062C1B` | `#86EFAC` | 10.8 |
+| running | `#EFF6FF` | `#175CD3` | 5.5 | `#0B1E3D` | `#93C5FD` | 9.2 |
+| error | `#FEF3F2` | `#B42318` | 6.0 | `#3B0A0A` | `#FCA5A5` | 9.0 |
+| warning | `#FFFAEB` | `#B54708` | 5.2 | `#3A2604` | `#FCD34D` | 10.0 |
+| stale/orange | `#FFF7ED` | `#C2410C` | 4.9 | `#331C05` | `#FDBA74` | 9.5 |
+| neutral | `#F3F4F6` | `#374151` | 9.4 | `#1F2937` | `#D1D5DB` | 10.0 |
+| review/purple | `#F5F3FF` | `#6D28D9` | 6.5 | `#23153E` | `#C4B5FD` | 9.1 |
+
+Use color + icon + text together. Never rely on color alone.
+
+### Frontend pill colors
+
+| Status | Color token | Icon |
+|--------|-------------|------|
+| `running` | running (blue) | activity/spinner |
+| `completed` | success (green) | check |
+| `failed` | error (red) | x-circle |
+| `timed_out` | warning (amber) | hourglass |
+| `aborted` | neutral (gray) | stop |
+| `cancelled` | neutral (gray) | slash |
+| `legacy` | neutral, dotted border | dash |
+
+#### Pill anatomy
+
+```
+[ icon  label ]
+```
+
+Sizing:
+
+```
+height: 20px
+padding-x: 6px
+font-size: 10px or 11px
+font-weight: 600
+border-radius: 999px
+border: 1px solid semantic border
+```
+
+Dense table variant:
+
+```
+height: 18px
+font-size: 10px
+```
+
+The `StatusPill` component requires a `taxonomy` prop to prevent status
+values from different vocabularies drifting into inconsistent colors:
+
+```tsx
+<StatusPill taxonomy="session" value="running" />
+<StatusPill taxonomy="health" value="stale" />
+<StatusPill taxonomy="verdict" value="request_changes" />
+```
+
+#### The "legacy" pseudo-status
+
+Sessions with `status IS NULL` (created before the current status vocabulary
+was in place) are displayed as `legacy unclassified`:
+
+- Pill: gray, dotted border, dash icon
+- Label: "legacy"
+- Excluded from live metrics, trend calculations, and failure counts
+- Not treated as `running` or `failed` in the attention queue
+
+On the dashboard, legacy sessions appear only as a muted chip:
+
+```
+376 legacy sessions
+```
+
+Tooltip: "Sessions created before the current status vocabulary. Excluded
+from live operational metrics."
+
+#### Effective state display
+
+When the reported status is `running` but the derived health is `stale`,
+the UI must not show a blue Running pill alone. Show the compound state:
+
+```
+[stale running]
+```
+
+Rules:
+- **Do not show a blue Running pill alone when health is stale.**
+- In tables with separate Status and Health columns, show both:
+  `Status: running` / `Health: stale`
+- In dashboards and grouped rows, use the composed form: `stale running`
+- For `completed` sessions with `healthy` classification, show only the
+  status pill — health is not operationally relevant for terminal sessions.
+
+### Storing timeout metadata
+
+When a session times out, the timeout value that was configured should be
+recorded for context:
+
+```python
+# On timed_out, write timeout config to session
+await db.update_session(session_id, {
+    "status": "timed_out",
+    "ended_at": time.time(),
+    "node_metadata": {
+        **existing_metadata,
+        "timeout_seconds": timeout,
+        "timeout_elapsed": elapsed,
+    },
+})
+```
+
+The run detail page can then show: "Timed out after 900s (configured
+timeout: 900s)" — confirming the timeout hit the configured bound,
+not some other deadline.
+
+### Schema migration
+
+SQLite doesn't support `ALTER TABLE ... DROP CONSTRAINT`. The CHECK
+constraint lives in the table definition. Migration options:
+
+1. **Rebuild the table** (VACUUM-based migration): rename old table,
+   create new with updated CHECK, copy data, drop old. Heavy but clean.
+2. **Relaxed CHECK** at runtime: `_reconcile_columns()` can't modify
+   CHECKs. Instead, bypass the CHECK by storing the new values and
+   updating the schema on next `StateDB.open()`.
+3. **Remove CHECK entirely**, validate in Python: the CHECK is a
+   defense-in-depth measure, not the primary validation. The CLI
+   validates status before writing.
+
+Recommended: **option 3**. Remove the CHECK constraint from the schema,
+validate in Python at write time. The collapsed v1 schema (pre-release)
+can be updated directly since there are no external consumers depending
+on the CHECK. The Python validator is the source of truth:
+
+```python
+VALID_SESSION_STATUSES = frozenset({
+    "running", "completed", "failed", "timed_out", "aborted", "cancelled"
+})
+
+def validate_session_status(status: str) -> str:
+    if status not in VALID_SESSION_STATUSES:
+        raise ValueError(f"Invalid session status: {status}")
+    return status
+```
+
+### Relationship to health classification (ADR-0024)
+
+Status and health are orthogonal:
+
+- **Status**: what happened? (lifecycle state, written at transitions)
+- **Health**: what's happening now? (derived, computed at read time)
+
+A session can be `running` + `stale` (status is running, health says
+it's dead). Or `timed_out` + `healthy` (status is terminal, health is
+fine — nothing wrong, it just hit its deadline).
+
+Health classification uses status as an input:
+
+```python
+if status in SESSION_TERMINAL_STATUSES:
+    if has_stale_locks:
+        return SessionHealth.ZOMBIE
+    return SessionHealth.HEALTHY  # terminal = done
+
+# Only running sessions can be idle/unresponsive/stale/orphaned
+```
+
+## Consequences
+
+**Positive**
+- Timeout, user abort, and system cancellation are distinguishable in
+  the DB and UI — each has a clear follow-up action.
+- Exit codes follow UNIX convention — familiar to operators, parseable
+  by scripts.
+- Dashboard thresholds at 60 minutes flag actual outliers, not routine runs.
+- `timed_out` gets amber pill, not red — operators don't waste time
+  "investigating" a deliberate timeout.
+- Timeout metadata enables "retry with more time" workflow in Studio.
+- Python validation replaces SQLite CHECK — more flexible, same safety.
+
+**Negative**
+- Schema migration for CHECK constraint removal requires table rebuild
+  or constraint relaxation. Pre-release, so acceptable.
+- Six statuses instead of four — slightly more to understand. Each maps
+  to a clear operational meaning so cognitive load is manageable.
+- `cancelled` vs `aborted` distinction may be too fine for some users.
+  Mitigated by similar UI treatment (both gray pills) — the distinction
+  matters for automation, not for quick visual scanning.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Keep four statuses, add metadata for timeout | Status pill still shows red "failed" — the metadata helps only on the detail page, not the list |
+| Add `crashed` status for OOM/segfault | Can't reliably distinguish crash from error at the Python level; both look like uncaught exceptions. Health classifier handles this post-hoc |
+| More granular statuses (e.g., `partial`, `degraded`) | Premature — add when there's a concrete use case. Six is enough for now |
+| Timeout as a modifier on failed (`failed:timeout`) | Compound strings don't work with CHECK constraints or enum types |
+| Keep 30-minute slow threshold | Flags nearly every flow — useless signal |
+
+## References
+
+- [ADR-0017](ADR-0017-session-lifecycle-status.md) — Original four-status vocabulary (extended here)
+- [ADR-0024](ADR-0024-session-health-and-admin-surface.md) — Health classification (consumes status)
+- [ChatGPT frontend design review](.khive/workspaces/20260521/chatgpt-frontend-review.md) — Status pill system (section 6): color tokens with hex values and contrast ratios for light/dark mode, pill anatomy spec (height 20px, padding-x 6px, font-size 10-11px, border-radius 999px), legacy pseudo-status treatment, effective state display rules ("do not show blue Running when health is stale")
+- `lionagi/cli/agent.py` — Session teardown with `_terminal_status`
+- `lionagi/cli/orchestrate/__init__.py` — `LionTimeoutError` handling
+- `lionagi/cli/orchestrate/flow.py` — Flow timeout wrapper
+- `lionagi/state/schema.sql` — Current CHECK constraint
+- `apps/studio/frontend/app/page.tsx` — Dashboard `SLOW_RUN_SECONDS`

--- a/docs/adrs/ADR-0025-session-status-vocabulary.md
+++ b/docs/adrs/ADR-0025-session-status-vocabulary.md
@@ -108,6 +108,29 @@ SESSION_TERMINAL_STATUSES = frozenset({
 All non-`running` statuses are terminal. The SSE done-condition check
 (ADR-0017 `is_session_stream_done`) uses this set.
 
+### Legal transitions
+
+The session status FSM is deterministic. All transitions originate from
+`running`; terminal statuses have no outgoing transitions.
+
+| From | To | Trigger | Who writes |
+|------|----|---------|------------|
+| `running` | `completed` | Normal completion | CLI teardown |
+| `running` | `failed` | Unhandled exception | CLI teardown |
+| `running` | `timed_out` | `TimeoutError` from `anyio.fail_after` | CLI teardown |
+| `running` | `aborted` | `KeyboardInterrupt` / `CancelledError` | CLI teardown |
+| `running` | `cancelled` | Orchestrator / admin decision | Skill runner or admin API |
+
+No transitions between terminal statuses are permitted. The admin
+`TransitionBody` endpoint (ADR-0024) enforces this via
+`can_transition(current, target)` validation — modeled on khive's
+GTD `transition` verb with its Lean4-proven FSM properties.
+
+```python
+def can_transition(current: str, target: str) -> bool:
+    return current == "running" and target in SESSION_TERMINAL_STATUSES
+```
+
 ### Write points (updated from ADR-0017)
 
 ```python
@@ -388,3 +411,12 @@ if status in SESSION_TERMINAL_STATUSES:
 - `lionagi/cli/orchestrate/flow.py` — Flow timeout wrapper
 - `lionagi/state/schema.sql` — Current CHECK constraint
 - `apps/studio/frontend/app/page.tsx` — Dashboard `SLOW_RUN_SECONDS`
+
+### Prior art
+
+- **khive GTD Task FSM** (khive ADR-003) — 7-state FSM with 5 Lean4-proven
+  properties: fsm_validity, terminal_no_transitions, completed_reachable_from_pending,
+  failed/cancelled_reachable, transition_deterministic. The session status
+  transition table above mirrors this pattern.
+- **Claude Code Task Lifecycle** (`Task.ts`) — 5 statuses: pending, running,
+  completed, failed, killed. `killed` maps to our `cancelled` + `aborted`.

--- a/docs/adrs/ADR-0025-session-status-vocabulary.md
+++ b/docs/adrs/ADR-0025-session-status-vocabulary.md
@@ -410,7 +410,7 @@ if status in SESSION_TERMINAL_STATUSES:
 
 - [ADR-0017](ADR-0017-session-lifecycle-status.md) — Original four-status vocabulary (extended here)
 - [ADR-0024](ADR-0024-session-health-and-admin-surface.md) — Health classification (consumes status)
-- [ChatGPT frontend design review](.khive/workspaces/20260521/chatgpt-frontend-review.md) — Status pill system (section 6): color tokens with hex values and contrast ratios for light/dark mode, pill anatomy spec (height 20px, padding-x 6px, font-size 10-11px, border-radius 999px), legacy pseudo-status treatment, effective state display rules ("do not show blue Running when health is stale")
+- ChatGPT frontend design review (external, not in repo) — Status pill system (section 6): color tokens with hex values and contrast ratios for light/dark mode, pill anatomy spec (height 20px, padding-x 6px, font-size 10-11px, border-radius 999px), legacy pseudo-status treatment, effective state display rules ("do not show blue Running when health is stale")
 - `lionagi/cli/agent.py` — Session teardown with `_terminal_status`
 - `lionagi/cli/orchestrate/__init__.py` — `LionTimeoutError` handling
 - `lionagi/cli/orchestrate/flow.py` — Flow timeout wrapper


### PR DESCRIPTION
## Summary

Seven architecture decision records for the next phase of Lion Studio, covering the full stack from data persistence to frontend rendering.

- **ADR-0019**: Teams DB migration (file→SQLite) + run staleness detection via `last_message_at`
- **ADR-0020**: Skill invocations table — groups sessions under the skill that spawned them (`/show` → 14 sessions as one invocation)
- **ADR-0021**: `lionagi/outcomes/` package for typed skill results (ReviewVerdict, GateVerdict, CIResult), `artifacts` table, reactive chaining via YAML-defined trigger→step→condition pipelines
- **ADR-0022**: Model/agent/provider disclosure per session and per branch — resolves the gap where `chat_model` is empty on all branch rows
- **ADR-0023**: Unified `HookBus` replacing three disconnected hook systems (iModel HookRegistry, agent hook_handlers, CLI `_on_message` closure) — enables model/provider data to flow from API call to DB persistence
- **ADR-0024**: Graduated session health (healthy/idle/unresponsive/stale/orphaned/zombie), admin console redesign with transition modal, dashboard metric cards (Attention/Active/Outcomes/Latency)
- **ADR-0025**: Expanded session status vocabulary (adding `timed_out`, `cancelled`), WCAG color tokens with contrast ratios, pill anatomy spec, `legacy` pseudo-status for null sessions, 60m slow threshold

All ADRs incorporate feedback from the ChatGPT frontend design review (nav restructure, wireframes, component specs, color system).

## Test plan

- [x] Documentation only — no code changes
- [ ] Review each ADR for architectural soundness
- [ ] Confirm alignment with the ChatGPT frontend review

🤖 Generated with [Claude Code](https://claude.com/claude-code)