### PR TITLE
fix: timeout enforcement for CLI subprocess agents

### DIFF
--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -493,4 +493,4 @@ def run_agent(args: argparse.Namespace) -> int:
         print(f"\n{result}" if result is not None else "", flush=True)
 
     hint(f'\n[to resume] li agent -r {branch_id} "..."')
-    return 0
+    return 0 if result is not None else 1

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -144,6 +144,11 @@ async def _run_agent(
     except KeyboardInterrupt:
         _terminal_status = "aborted"
         raise
+    except TimeoutError:
+        _terminal_status = "failed"
+        from lionagi.cli._logging import warn
+        warn(f"agent timed out after {timeout}s")
+        res = None
     except BaseException as exc:
         from lionagi.ln.concurrency import get_cancelled_exc_class
 

--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -18,8 +18,6 @@ from lionagi.protocols.messages import (
     AssistantResponseContent,
     Instruction,
 )
-from lionagi.service.connections import APICalling
-
 from ..chat._prepare import _prepare_run_kwargs
 from ..types import ChatParam, ParseParam, RunParam
 
@@ -112,7 +110,6 @@ async def run(
         return res
 
     pending_requests: dict[str, ActionRequest] = {}
-    api_call_event = None
 
     # Extract caller-supplied wall-clock timeout (seconds). The CLI-provider
     # stream loops are unbounded — without an outer fail_after the codex /
@@ -136,10 +133,6 @@ async def run(
         # context-manager cost rather than branching the stream loop.
         with anyio.fail_after(_stream_timeout):
             async for chunk in model.stream(api_call=api_call):
-                if isinstance(chunk, APICalling):
-                    api_call_event = chunk
-                    continue
-
                 match chunk.type:
                     case "system":
                         if sid := chunk.metadata.get("session_id"):
@@ -207,10 +200,9 @@ async def run(
                             chunk.content or "Stream error from CLI endpoint"
                         )
 
-            # Flush remaining text — attach APICalling metadata to final response
             if res := await _flush_response():
-                if api_call_event is not None:
-                    call_meta = Note.from_dict(api_call_event.to_dict())
+                if hasattr(api_call, "to_dict"):
+                    call_meta = Note.from_dict(api_call.to_dict())
                     call_meta.pop(["execution", "response"], None)
                     res.metadata["api_call_meta"] = call_meta.to_dict()
                 yield res

--- a/lionagi/service/imodel.py
+++ b/lionagi/service/imodel.py
@@ -352,22 +352,23 @@ class iModel:  # noqa: N801
                 try:
                     async for i in api_call.stream():
                         result = await self.process_chunk(i)
-                        # Yield processed result if available, otherwise yield raw chunk
                         yield result if result is not None else i
                 except Exception as e:
                     raise ValueError(f"Failed to stream API call: {e}") from e
                 finally:
-                    yield self.executor.pile.pop(api_call.id)
+                    # Pop without yielding — yield-in-finally swallows
+                    # CancelledError during generator cleanup, breaking
+                    # anyio.fail_after timeout enforcement.
+                    self.executor.pile.pop(api_call.id, None)
         else:
             try:
                 async for i in api_call.stream():
                     result = await self.process_chunk(i)
-                    # Yield processed result if available, otherwise yield raw chunk
                     yield result if result is not None else i
             except Exception as e:
                 raise ValueError(f"Failed to stream API call: {e}") from e
             finally:
-                yield self.executor.pile.pop(api_call.id)
+                self.executor.pile.pop(api_call.id, None)
 
     async def invoke(self, api_call: APICalling = None, **kw) -> APICalling:
         """Invokes a rate-limited API call with the given arguments.

--- a/lionagi/session/branch.py
+++ b/lionagi/session/branch.py
@@ -911,8 +911,10 @@ class Branch(Element, Relational):
         _pms = {
             k: v
             for k, v in locals().items()
-            if k not in ("self", "_pms") and v is not None
+            if k not in ("self", "_pms", "kwargs") and v is not None
         }
+        if kwargs:
+            _pms.update(kwargs)
         from lionagi.operations.operate.operate import operate, prepare_operate_kw
 
         return await operate(self, **prepare_operate_kw(self, **_pms))

--- a/tests/operations/run/test_run.py
+++ b/tests/operations/run/test_run.py
@@ -474,3 +474,117 @@ async def test_run_strips_timeout_from_create_event_kwargs():
     assert "timeout" not in captured, (
         f"timeout leaked into create_event kwargs: {captured!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Regression: Branch.operate() must flatten **kwargs so timeout reaches run()
+# ---------------------------------------------------------------------------
+
+
+async def test_branch_operate_forwards_timeout_to_run(monkeypatch):
+    """Branch.operate(**kwargs) must flatten kwargs before passing to
+    prepare_operate_kw, otherwise timeout arrives as a nested dict
+    {"kwargs": {"timeout": N}} and run() never sees it."""
+    received_timeout = []
+
+    original_run = run
+
+    async def spy_run(branch, instruction, param):
+        kw_copy = (param.imodel_kw or {}).copy()
+        received_timeout.append(kw_copy.get("timeout"))
+        async for msg in original_run(branch, instruction, param):
+            yield msg
+
+    monkeypatch.setattr("lionagi.operations.run.run.run", spy_run)
+
+    model, _ = _make_fake_cli_model([StreamChunk(type="text", content="ok")])
+    branch = Branch()
+    branch.chat_model = model
+
+    await branch.operate(instruction="test", timeout=42)
+
+    assert received_timeout == [42], (
+        f"timeout not forwarded correctly: {received_timeout}"
+    )
+
+
+async def test_branch_operate_forwards_extra_kwargs_to_run(monkeypatch):
+    """Arbitrary **kwargs on Branch.operate() reach run() via imodel_kw."""
+    received_kw = {}
+
+    original_run = run
+
+    async def spy_run(branch, instruction, param):
+        received_kw.update(param.imodel_kw or {})
+        async for msg in original_run(branch, instruction, param):
+            yield msg
+
+    monkeypatch.setattr("lionagi.operations.run.run.run", spy_run)
+
+    model, _ = _make_fake_cli_model([StreamChunk(type="text", content="ok")])
+    branch = Branch()
+    branch.chat_model = model
+
+    await branch.operate(instruction="test", repo="/tmp/test", timeout=99)
+
+    assert received_kw.get("timeout") == 99
+    assert received_kw.get("repo") == "/tmp/test"
+
+
+# ---------------------------------------------------------------------------
+# Regression: iModel.stream() must not yield in finally (swallows cancellation)
+# ---------------------------------------------------------------------------
+
+
+async def test_imodel_stream_propagates_cancellation():
+    """iModel.stream() must propagate CancelledError from the inner stream,
+    not swallow it via a yield-in-finally."""
+    import anyio
+
+    from lionagi.protocols.generic.event import Event, EventStatus
+    from lionagi.service.connections.api_calling import APICalling
+
+    m = iModel(provider="openai", model="gpt-4.1-mini", api_key="test_key")
+
+    class SlowEndpoint:
+        is_cli = True
+        session_id = None
+        DEFAULT_QUEUE_CAPACITY = 10
+
+        async def stream(self, request=None, extra_headers=None, **kw):
+            for _ in range(100):
+                await anyio.sleep(0.5)
+                yield StreamChunk(type="text", content="x")
+
+    m.endpoint = SlowEndpoint()
+
+    api_call = AsyncMock(spec=APICalling)
+    api_call.id = "test-api-call-id"
+    api_call.execution = AsyncMock()
+    api_call.execution.status = EventStatus.PENDING
+
+    async def fake_core_stream():
+        for _ in range(100):
+            await anyio.sleep(0.5)
+            yield StreamChunk(type="text", content="x")
+
+    api_call.stream = fake_core_stream
+    m.executor = types.SimpleNamespace(
+        append=AsyncMock(),
+        pile=types.SimpleNamespace(pop=lambda *a, **kw: None),
+        processor=types.SimpleNamespace(
+            _concurrency_sem=None,
+            is_stopped=lambda: False,
+        ),
+        config={},
+    )
+
+    import time
+
+    started = time.monotonic()
+    with pytest.raises(TimeoutError):
+        with anyio.fail_after(0.1):
+            async for _ in m.stream(api_call=api_call):
+                pass
+    elapsed = time.monotonic() - started
+    assert elapsed < 1.0, f"cancellation took too long: {elapsed:.2f}s"


### PR DESCRIPTION
## Summary

- **yield-in-finally bug**: `iModel.stream()` used `yield` inside `finally` blocks, which silently swallows `CancelledError` during async generator cleanup — making `anyio.fail_after` a complete no-op. Fixed by popping from executor pile without yielding.
- **kwargs nesting bug**: `Branch.operate()` captured `**kwargs` via `locals()`, which creates a nested dict. The timeout value never reached `run.py`. Fixed by flattening kwargs before passing to `prepare_operate_kw`.
- **Unhandled TimeoutError**: `TimeoutError` propagated as a raw traceback. Fixed by catching it in `_run_agent`, logging a warning, and persisting the session as `failed`.

## Test plan

- [x] `li agent codex "..." --timeout 10` exits cleanly after ~10s
- [x] Normal runs without timeout still work
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)