### PR TITLE
feat: ADR-0025 session status vocabulary (Layer 1)

### DIFF
--- a/apps/studio/frontend/app/page.tsx
+++ b/apps/studio/frontend/app/page.tsx
@@ -13,14 +13,14 @@ import type { DbStats, StudioStats } from "@/lib/api";
 import type { RunSummary, ShowSummary } from "@/lib/types";
 
 const RUNNING_STATES = new Set(["running", "executing", "in_progress", "director-managed", "open"]);
+// ADR-0025: timed_out / aborted / cancelled are NOT failures. Timeout is
+// a deliberate bound (amber, retry); aborted = Ctrl-C, cancelled = system
+// cancellation (both neutral). Keeping them out of FAILED_STATES so the
+// "Failed" dashboard card only counts actual errors.
 const FAILED_STATES = new Set([
   "failed",
   "error",
   "failure",
-  "timeout",
-  "timed_out",
-  "cancelled",
-  "canceled",
 ]);
 const COMPLETED_STATES = new Set([
   "completed",
@@ -32,11 +32,12 @@ const COMPLETED_STATES = new Set([
 ]);
 const NEEDS_REVIEW_STATES = new Set(["needs_review", "blocked", "gated"]);
 
-// Heuristic: a "slow" completed run is anything > 30 minutes. Tuned so the
-// metric flags actual outliers, not every routine multi-minute job.
-const SLOW_RUN_SECONDS = 30 * 60;
-// Heuristic: a "stuck" running run hasn't finished after 30 minutes from start.
-const STUCK_RUN_SECONDS = 30 * 60;
+// ADR-0025: thresholds tuned for actual operational reality. Typical
+// `li play` runs are 45-90 min; 30 min flagged nearly every flow as
+// "slow" — useless signal. 60 min flags only the real outliers.
+const SLOW_RUN_SECONDS = 60 * 60;
+// A "stuck" running run hasn't finished after 60 minutes from start.
+const STUCK_RUN_SECONDS = 60 * 60;
 
 function durationSeconds(run: RunSummary, nowSec: number): number | null {
   if (run.started_at == null) return null;

--- a/apps/studio/frontend/app/runs/page.tsx
+++ b/apps/studio/frontend/app/runs/page.tsx
@@ -12,7 +12,18 @@ import { listRuns } from "@/lib/api";
 import type { RunListResponse } from "@/lib/api";
 import type { RunSummary } from "@/lib/types";
 
-const STATUS_FILTERS = ["pending", "running", "done", "failed", "cancelled"] as const;
+// ADR-0025: six-value session vocabulary (running/completed/failed/
+// timed_out/aborted/cancelled). "done" stays as an alias for completed
+// for backward-compat with show + play rows.
+const STATUS_FILTERS = [
+  "pending",
+  "running",
+  "done",
+  "failed",
+  "timed_out",
+  "aborted",
+  "cancelled",
+] as const;
 
 function displayName(run: RunSummary): string {
   if (run.show_topic || run.show_play_name) {

--- a/apps/studio/frontend/components/StatusPill.tsx
+++ b/apps/studio/frontend/components/StatusPill.tsx
@@ -39,10 +39,16 @@ const TONE_BY_VALUE: Record<string, StatusTone> = {
   failed: "failed",
   failure: "failed",
   error: "failed",
-  timed_out: "failed",
-  timeout: "failed",
-  cancelled: "failed",
-  canceled: "failed",
+  // ADR-0025: timeout is a deliberate bound, not an error. Amber pill
+  // signals "retry with more time," not "investigate."
+  timed_out: "pending",
+  timeout: "pending",
+  // ADR-0025: aborted = user pressed Ctrl-C; cancelled = system/
+  // orchestrator killed the task. Both render neutral (gray) — the
+  // distinction matters for automation, not visual scanning.
+  aborted: "neutral",
+  cancelled: "neutral",
+  canceled: "neutral",
   // lifecycle (waiting)
   pending: "pending",
   queued: "pending",

--- a/apps/studio/server/services/runs.py
+++ b/apps/studio/server/services/runs.py
@@ -12,8 +12,13 @@ from ._path_safety import public_path, safe_path_join
 
 _STATUS_ALIASES: dict[str, set[str]] = {
     "done": {"done", "completed", "success", "finished"},
-    "cancelled": {"cancelled", "canceled", "aborted"},
-    "canceled": {"cancelled", "canceled", "aborted"},
+    # ADR-0025: cancelled (system/orchestrator) and aborted (Ctrl-C) are
+    # operationally distinct; only collapse the US/UK spelling.
+    "cancelled": {"cancelled", "canceled"},
+    "canceled": {"cancelled", "canceled"},
+    "aborted": {"aborted", "aborted_after_finish"},
+    "timed_out": {"timed_out", "timeout"},
+    "timeout": {"timed_out", "timeout"},
     "pending": {"pending", "prepared"},
 }
 

--- a/apps/studio/server/services/sessions.py
+++ b/apps/studio/server/services/sessions.py
@@ -11,7 +11,9 @@ from ._db import open_db as _open_db
 
 _DB = str(DEFAULT_DB_PATH)
 
-SESSION_TERMINAL_STATUSES = frozenset({"completed", "failed", "aborted"})
+SESSION_TERMINAL_STATUSES = frozenset(
+    {"completed", "failed", "timed_out", "aborted", "cancelled"}
+)
 SESSION_DONE_STABLE_SECS = 60.0
 
 

--- a/apps/studio/server/services/status_mapping.py
+++ b/apps/studio/server/services/status_mapping.py
@@ -10,23 +10,15 @@ Do not use this map for lifecycle validation or session state-machine transition
 
 from __future__ import annotations
 
-# F-A1-7 (ADR-0011, ADR-0017): DISPLAY_MAP must only contain values present
-# in the closed ADR vocabularies.
+# F-A1-7 (ADR-0011, ADR-0017, ADR-0025): DISPLAY_MAP must only contain
+# values present in the closed ADR vocabularies.
 #
 # ADR-0011 plays.status CHECK vocabulary (11 values):
 #   pending, prepared, running, running_complete, gated, gate_failed,
 #   redoing, merged, escalated, blocked, aborted_after_finish
 #
-# ADR-0017 sessions.status CHECK vocabulary (4 values):
-#   running, completed, failed, aborted
-#
-# Removed entries that appeared in neither ADR vocabulary:
-#   "done"      → not in any ADR CHECK constraint
-#   "success"   → not in any ADR CHECK constraint
-#   "finished"  → not in any ADR CHECK constraint
-#   "error"     → not in any ADR CHECK constraint
-#   "cancelled" → not in any ADR CHECK constraint (ADR uses "aborted")
-#   "canceled"  → not in any ADR CHECK constraint (ADR uses "aborted")
+# ADR-0025 sessions.status vocabulary (6 values; supersedes ADR-0017):
+#   running, completed, failed, timed_out, aborted, cancelled
 DISPLAY_MAP: dict[str, str] = {
     # play statuses (ADR-0011)
     "pending": "pending",
@@ -40,10 +32,12 @@ DISPLAY_MAP: dict[str, str] = {
     "escalated": "escalated",
     "blocked": "blocked",
     "aborted_after_finish": "aborted",
-    # session statuses (ADR-0017)
+    # session statuses (ADR-0025)
     "completed": "completed",
     "failed": "failed",
+    "timed_out": "timed_out",
     "aborted": "aborted",
+    "cancelled": "cancelled",
 }
 
 

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -8,6 +8,7 @@ import argparse
 import json
 
 from lionagi import Branch
+from lionagi._errors import TimeoutError as LionTimeoutError
 from lionagi.ln.concurrency import run_async
 from lionagi.protocols.generic.log import DataLoggerConfig
 
@@ -37,10 +38,12 @@ async def _run_agent(
     cwd: str | None = None,
     timeout: int | None = None,
     fast: bool = False,
-) -> tuple[str, str, str]:
+) -> tuple[str, str, str, str]:
     """Execute one agent turn (new or resumed).
 
-    Returns (result, provider, branch_id).
+    Returns (result, provider, branch_id, terminal_status). ``terminal_status``
+    is one of ``ADR-0025`` ``SESSION_TERMINAL_STATUSES`` and drives the CLI
+    exit-code mapping in :func:`run_agent`.
     """
     if resume and continue_last:
         raise ValueError(
@@ -127,6 +130,9 @@ async def _run_agent(
         artifacts_path=str(run.artifact_root),
     )
 
+    # ADR-0025: distinguish timed_out / aborted / cancelled / failed so
+    # operators can tell "retry with more time" from "investigate" from
+    # "user pressed Ctrl-C" from "orchestrator cascaded a cancel."
     _terminal_status = "completed"
     try:
         res = await branch.operate(
@@ -144,8 +150,8 @@ async def _run_agent(
     except KeyboardInterrupt:
         _terminal_status = "aborted"
         raise
-    except TimeoutError:
-        _terminal_status = "failed"
+    except (TimeoutError, LionTimeoutError):
+        _terminal_status = "timed_out"
         from lionagi.cli._logging import warn
         warn(f"agent timed out after {timeout}s")
         res = None
@@ -153,7 +159,7 @@ async def _run_agent(
         from lionagi.ln.concurrency import get_cancelled_exc_class
 
         if isinstance(exc, get_cancelled_exc_class()):
-            _terminal_status = "aborted"
+            _terminal_status = "cancelled"
         else:
             _terminal_status = "failed"
         raise
@@ -175,7 +181,18 @@ async def _run_agent(
     # Save branch pointer for --continue-last / -r resume
     save_last_branch_pointer(run.run_id, branch_id)
 
-    return res or "", provider, branch_id
+    return res or "", provider, branch_id, _terminal_status
+
+
+# ADR-0025 exit-code mapping. UNIX conventions: 124 matches GNU coreutils
+# ``timeout``; 130 / 143 = 128 + signal number (SIGINT / SIGTERM).
+_EXIT_CODE_BY_TERMINAL_STATUS: dict[str, int] = {
+    "completed": 0,
+    "failed": 1,
+    "timed_out": 124,
+    "aborted": 130,
+    "cancelled": 143,
+}
 
 
 async def _setup_live_persist(
@@ -464,7 +481,11 @@ def add_agent_subparser(subparsers: argparse._SubParsersAction) -> None:
 
 
 def run_agent(args: argparse.Namespace) -> int:
-    """Dispatch agent command."""
+    """Dispatch agent command.
+
+    Exit codes follow ADR-0025: 0 completed, 1 failed, 124 timed_out,
+    130 aborted (Ctrl-C), 143 cancelled (system / orchestrator).
+    """
     has_model = args.model is not None or args.agent is not None
     if not has_model and not (args.resume or args.continue_last):
         log_error(
@@ -472,25 +493,37 @@ def run_agent(args: argparse.Namespace) -> int:
         )
         return 1
 
-    result, provider, branch_id = run_async(
-        _run_agent(
-            args.model,
-            args.prompt,
-            yolo=args.yolo,
-            verbose=args.verbose,
-            theme=args.theme,
-            resume=args.resume,
-            continue_last=args.continue_last,
-            effort=args.effort,
-            agent_name=args.agent,
-            cwd=args.cwd,
-            timeout=args.timeout,
-            fast=args.fast,
+    try:
+        result, provider, branch_id, terminal_status = run_async(
+            _run_agent(
+                args.model,
+                args.prompt,
+                yolo=args.yolo,
+                verbose=args.verbose,
+                theme=args.theme,
+                resume=args.resume,
+                continue_last=args.continue_last,
+                effort=args.effort,
+                agent_name=args.agent,
+                cwd=args.cwd,
+                timeout=args.timeout,
+                fast=args.fast,
+            )
         )
-    )
+    except KeyboardInterrupt:
+        # Teardown inside ``_run_agent`` already recorded
+        # ``status='aborted'`` under a shielded scope before re-raising.
+        return _EXIT_CODE_BY_TERMINAL_STATUS["aborted"]
+    except BaseException as exc:
+        from lionagi.ln.concurrency import get_cancelled_exc_class
+
+        if isinstance(exc, get_cancelled_exc_class()):
+            return _EXIT_CODE_BY_TERMINAL_STATUS["cancelled"]
+        raise
+
     if not args.verbose:
         # The final response is user-facing result output — stdout, not a log.
         print(f"\n{result}" if result is not None else "", flush=True)
 
     hint(f'\n[to resume] li agent -r {branch_id} "..."')
-    return 0 if result is not None else 1
+    return _EXIT_CODE_BY_TERMINAL_STATUS.get(terminal_status, 1)

--- a/lionagi/cli/orchestrate/__init__.py
+++ b/lionagi/cli/orchestrate/__init__.py
@@ -698,7 +698,7 @@ def run_orchestrate(args: argparse.Namespace) -> int:
                     playbook_name=getattr(args, "playbook", None),
                 )
             )
-        except LionTimeoutError as e:
+        except (TimeoutError, LionTimeoutError) as e:
             log_error(str(e))
             return 124  # ADR-0025: timed_out exits with GNU `timeout` code
         except KeyboardInterrupt:
@@ -913,7 +913,7 @@ def run_orchestrate(args: argparse.Namespace) -> int:
                     playbook_name=playbook_name,
                 )
             )
-        except LionTimeoutError as e:
+        except (TimeoutError, LionTimeoutError) as e:
             log_error(str(e))
             return 124  # ADR-0025: timed_out exits with GNU `timeout` code
         except KeyboardInterrupt:

--- a/lionagi/cli/orchestrate/__init__.py
+++ b/lionagi/cli/orchestrate/__init__.py
@@ -700,7 +700,15 @@ def run_orchestrate(args: argparse.Namespace) -> int:
             )
         except LionTimeoutError as e:
             log_error(str(e))
-            return 1
+            return 124  # ADR-0025: timed_out exits with GNU `timeout` code
+        except KeyboardInterrupt:
+            return 130  # ADR-0025: aborted (SIGINT)
+        except BaseException as exc:
+            from lionagi.ln.concurrency import get_cancelled_exc_class
+
+            if isinstance(exc, get_cancelled_exc_class()):
+                return 143  # ADR-0025: cancelled (SIGTERM)
+            raise
         if not args.verbose:
             print(output)
         return 0
@@ -907,7 +915,15 @@ def run_orchestrate(args: argparse.Namespace) -> int:
             )
         except LionTimeoutError as e:
             log_error(str(e))
-            return 1
+            return 124  # ADR-0025: timed_out exits with GNU `timeout` code
+        except KeyboardInterrupt:
+            return 130  # ADR-0025: aborted (SIGINT)
+        except BaseException as exc:
+            from lionagi.ln.concurrency import get_cancelled_exc_class
+
+            if isinstance(exc, get_cancelled_exc_class()):
+                return 143  # ADR-0025: cancelled (SIGTERM)
+            raise
         if not args.verbose:
             print(output)
         return 0

--- a/lionagi/cli/orchestrate/fanout.py
+++ b/lionagi/cli/orchestrate/fanout.py
@@ -113,9 +113,9 @@ async def _run_fanout(
     except KeyboardInterrupt:
         _terminal_status = "aborted"
         raise
-    except LionTimeoutError:
+    except (TimeoutError, LionTimeoutError):
         # Catches both the move_on_after re-raise above and any
-        # LionTimeoutError from inside _run_fanout_inner itself.
+        # timeout from inside _run_fanout_inner itself.
         _terminal_status = "timed_out"
         raise
     except BaseException as exc:

--- a/lionagi/cli/orchestrate/fanout.py
+++ b/lionagi/cli/orchestrate/fanout.py
@@ -94,13 +94,14 @@ async def _run_fanout(
         _shared=_shared,
     )
 
+    # ADR-0025: distinguish timed_out / aborted / cancelled / failed.
     _terminal_status = "completed"
     try:
         if timeout:
             with move_on_after(timeout) as cancel_scope:
                 result = await _run_fanout_inner(model_spec, prompt, **inner_kw)
             if cancel_scope.cancelled_caught:
-                _terminal_status = "aborted"
+                _terminal_status = "timed_out"
                 n_saved = len(_shared.get("saved_workers", []))
                 msg = f"Fanout timed out after {timeout}s"
                 if n_saved:
@@ -112,11 +113,16 @@ async def _run_fanout(
     except KeyboardInterrupt:
         _terminal_status = "aborted"
         raise
+    except LionTimeoutError:
+        # Set in the move_on_after branch above; preserve through any
+        # re-raise so finally writes the correct terminal status.
+        _terminal_status = "timed_out"
+        raise
     except BaseException as exc:
         from lionagi.ln.concurrency import get_cancelled_exc_class
 
         if isinstance(exc, get_cancelled_exc_class()):
-            _terminal_status = "aborted"
+            _terminal_status = "cancelled"
         else:
             _terminal_status = "failed"
         raise

--- a/lionagi/cli/orchestrate/fanout.py
+++ b/lionagi/cli/orchestrate/fanout.py
@@ -114,8 +114,8 @@ async def _run_fanout(
         _terminal_status = "aborted"
         raise
     except LionTimeoutError:
-        # Set in the move_on_after branch above; preserve through any
-        # re-raise so finally writes the correct terminal status.
+        # Catches both the move_on_after re-raise above and any
+        # LionTimeoutError from inside _run_fanout_inner itself.
         _terminal_status = "timed_out"
         raise
     except BaseException as exc:

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -487,9 +487,9 @@ async def _run_flow(
     except KeyboardInterrupt:
         _terminal_status = "aborted"
         raise
-    except LionTimeoutError:
+    except (TimeoutError, LionTimeoutError):
         # Catches both the move_on_after re-raise above and any
-        # LionTimeoutError from inside _run_flow_inner itself.
+        # timeout from inside _run_flow_inner itself.
         _terminal_status = "timed_out"
         raise
     except BaseException as exc:

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -488,8 +488,8 @@ async def _run_flow(
         _terminal_status = "aborted"
         raise
     except LionTimeoutError:
-        # Set in the move_on_after branch above; preserve through any
-        # re-raise so finally writes the correct terminal status.
+        # Catches both the move_on_after re-raise above and any
+        # LionTimeoutError from inside _run_flow_inner itself.
         _terminal_status = "timed_out"
         raise
     except BaseException as exc:

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -473,24 +473,30 @@ async def _run_flow(
         dry_run=dry_run,
         show_graph=show_graph,
     )
+    # ADR-0025: distinguish timed_out / aborted / cancelled / failed.
     _terminal_status = "completed"
     try:
         if timeout:
             with move_on_after(timeout) as cancel_scope:
                 result = await _run_flow_inner(model_spec, prompt, **inner_kw)
             if cancel_scope.cancelled_caught:
-                _terminal_status = "aborted"
+                _terminal_status = "timed_out"
                 raise LionTimeoutError(f"Flow timed out after {timeout}s")
             return result
         return await _run_flow_inner(model_spec, prompt, **inner_kw)
     except KeyboardInterrupt:
         _terminal_status = "aborted"
         raise
+    except LionTimeoutError:
+        # Set in the move_on_after branch above; preserve through any
+        # re-raise so finally writes the correct terminal status.
+        _terminal_status = "timed_out"
+        raise
     except BaseException as exc:
         from lionagi.ln.concurrency import get_cancelled_exc_class
 
         if isinstance(exc, get_cancelled_exc_class()):
-            _terminal_status = "aborted"
+            _terminal_status = "cancelled"
         else:
             _terminal_status = "failed"
         raise

--- a/lionagi/cli/state.py
+++ b/lionagi/cli/state.py
@@ -111,21 +111,30 @@ _STATUS_MAP = {
     "completed": "completed",
     "failed": "failed",
     "aborted": "aborted",
+    "timed_out": "timed_out",
+    "cancelled": "cancelled",
+    "canceled": "cancelled",
     # common aliases that may appear in run.json
     "success": "completed",
     "error": "failed",
-    "cancelled": "aborted",
-    "canceled": "aborted",
+    "timeout": "timed_out",
+}
+
+_EXIT_CODE_STATUS_MAP = {
+    0: "completed",
+    1: "failed",
+    124: "timed_out",
+    130: "aborted",
+    143: "cancelled",
 }
 
 
 def _derive_import_status(manifest: dict[str, Any]) -> str:
-    """Derive session status from run.json per ADR-0017.
+    """Derive session status from run.json per ADR-0025.
 
     1. If manifest has "status" field → map to session vocabulary.
-    2. If manifest has "exit_code" == 0 → completed.
-    3. If manifest has "exit_code" != 0 → failed.
-    4. Otherwise → completed (conservative default).
+    2. If manifest has "exit_code" → map via ADR-0025 exit code table.
+    3. Otherwise → completed (conservative default).
     """
     raw_status = manifest.get("status")
     if raw_status is not None:
@@ -133,7 +142,7 @@ def _derive_import_status(manifest: dict[str, Any]) -> str:
 
     exit_code = manifest.get("exit_code")
     if exit_code is not None:
-        return "completed" if exit_code == 0 else "failed"
+        return _EXIT_CODE_STATUS_MAP.get(exit_code, "failed")
 
     return "completed"
 

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -84,10 +84,41 @@ _BRANCH_COLUMNS = frozenset(
     }
 )
 
-# ADR-0017: closed status vocabulary for sessions. Mirrored by the schema
-# CHECK constraint (lionagi/state/schema.sql); validated here so callers
-# get a clear ``ValueError`` instead of an opaque sqlite IntegrityError.
-_SESSION_STATUSES = frozenset({"running", "completed", "failed", "aborted"})
+# ADR-0025: expanded closed status vocabulary for sessions. The SQLite
+# CHECK constraint is removed (see schema.sql); Python is the source of
+# truth so we get a clear ``ValueError`` instead of an opaque sqlite
+# IntegrityError, and the vocabulary can evolve without table rebuilds.
+#
+# The six values distinguish operational follow-up actions:
+#   - timed_out: deliberate bound hit ("retry with more time")
+#   - failed:    unexpected error ("investigate")
+#   - aborted:   user pressed Ctrl-C (no follow-up needed)
+#   - cancelled: system/orchestrator cancelled (cascade or admin decision)
+VALID_SESSION_STATUSES = frozenset(
+    {"running", "completed", "failed", "timed_out", "aborted", "cancelled"}
+)
+SESSION_TERMINAL_STATUSES = frozenset(
+    {"completed", "failed", "timed_out", "aborted", "cancelled"}
+)
+# Admin/operator transitions cannot mark a session "completed" or
+# "timed_out" — those are system-determined outcomes.
+ADMIN_TRANSITION_TARGETS = frozenset({"failed", "aborted", "cancelled"})
+
+# Legacy alias retained for any internal call sites that still import the
+# private name. New code should use ``VALID_SESSION_STATUSES``.
+_SESSION_STATUSES = VALID_SESSION_STATUSES
+
+
+def can_transition(current: str | None, target: str) -> bool:
+    """Return True iff a session may move from ``current`` to ``target``.
+
+    Mirrors khive's GTD ``can_transition`` (Lean4-proven FSM properties):
+    transitions only originate from ``running``; terminal states have no
+    outgoing transitions.
+    """
+    if current != "running":
+        return False
+    return target in SESSION_TERMINAL_STATUSES
 
 # ADR-0012: closed provenance vocabularies. Validated alongside status
 # so dashboards/filters can't be polluted with arbitrary text.
@@ -144,10 +175,10 @@ def _to_json_column(value: Any) -> Any:
 def _validate_session_status(status: Any) -> None:
     if status is None:
         return
-    if status not in _SESSION_STATUSES:
+    if status not in VALID_SESSION_STATUSES:
         raise ValueError(
             f"Invalid session status {status!r}; "
-            f"ADR-0017 vocabulary is {sorted(_SESSION_STATUSES)}"
+            f"ADR-0025 vocabulary is {sorted(VALID_SESSION_STATUSES)}"
         )
 
 
@@ -235,6 +266,10 @@ class StateDB:
         # succeed. This is a forward-only migration; all migrated
         # columns are nullable or have an INSERT-time default.
         await self._reconcile_columns()
+        # ADR-0025: existing DBs created under ADR-0017 carry a 4-value
+        # CHECK on sessions.status. Drop the constraint via table rebuild
+        # before the new vocabulary (timed_out / cancelled) is written.
+        await self._drop_legacy_session_status_check()
         schema = _SCHEMA_PATH.read_text()
         lines = [
             ln
@@ -289,6 +324,98 @@ class StateDB:
                         f"ALTER TABLE {table} ADD COLUMN {name} {defn}"
                     )
         await self.db.commit()
+
+    # Substring that appears in the ADR-0017 CHECK clause but not in the
+    # ADR-0025 schema (the new schema has no CHECK on sessions.status).
+    _LEGACY_SESSION_STATUS_CHECK_MARKER = "'running', 'completed', 'failed', 'aborted'"
+
+    async def _drop_legacy_session_status_check(self) -> None:
+        """Rebuild ``sessions`` if it still carries the ADR-0017 CHECK.
+
+        SQLite cannot ``ALTER TABLE ... DROP CONSTRAINT``; the only path
+        is the documented "rename → CREATE new → INSERT SELECT → DROP
+        old" pattern. This runs at most once per database — subsequent
+        opens find no marker and skip the rebuild.
+        """
+        cur = await self.db.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='sessions'"
+        )
+        row = await cur.fetchone()
+        if row is None or row["sql"] is None:
+            # Table doesn't exist yet — schema.sql will CREATE it without
+            # the legacy CHECK. Nothing to migrate.
+            return
+        create_sql: str = row["sql"]
+        if self._LEGACY_SESSION_STATUS_CHECK_MARKER not in create_sql:
+            return
+
+        # Capture indexes so we can recreate them after the swap. SQLite
+        # auto-drops indexes attached to a dropped table.
+        idx_cur = await self.db.execute(
+            "SELECT sql FROM sqlite_master "
+            "WHERE type='index' AND tbl_name='sessions' AND sql IS NOT NULL"
+        )
+        index_sqls = [r["sql"] for r in await idx_cur.fetchall()]
+
+        # Discover the actual live columns (may include ALTER-added
+        # columns not present in any historical CREATE TABLE statement).
+        info_cur = await self.db.execute("PRAGMA table_info(sessions)")
+        cols = [r["name"] for r in await info_cur.fetchall()]
+        col_list = ", ".join(cols)
+
+        await self.db.execute("PRAGMA foreign_keys = OFF")
+        try:
+            await self.db.execute(
+                "ALTER TABLE sessions RENAME TO sessions__adr0025_old"
+            )
+            # Recreate without the CHECK. Column definitions intentionally
+            # match the new schema.sql; the executescript that follows
+            # _drop_legacy_session_status_check is a no-op for this table
+            # (CREATE TABLE IF NOT EXISTS).
+            await self.db.execute(
+                """
+                CREATE TABLE sessions (
+                  id              TEXT    PRIMARY KEY,
+                  created_at      REAL    NOT NULL,
+                  node_metadata   JSON,
+                  name            TEXT,
+                  user            TEXT,
+                  progression_id  TEXT    NOT NULL REFERENCES progressions(id),
+                  first_msg_id    TEXT    REFERENCES messages(id),
+                  last_msg_id     TEXT    REFERENCES messages(id),
+                  updated_at      REAL    NOT NULL,
+                  playbook_name   TEXT,
+                  agent_name      TEXT,
+                  invocation_kind TEXT CHECK(
+                                    invocation_kind IS NULL
+                                    OR invocation_kind IN
+                                      ('agent', 'play', 'flow', 'fanout', 'show-play')
+                                  ),
+                  show_topic      TEXT,
+                  show_play_name  TEXT,
+                  artifacts_path  TEXT,
+                  source_kind     TEXT    DEFAULT 'live' CHECK(
+                                    source_kind IS NULL
+                                    OR source_kind IN ('live', 'imported_fs')
+                                  ),
+                  status          TEXT,
+                  started_at      REAL,
+                  ended_at        REAL
+                )
+                """
+            )
+            # col_list is built from PRAGMA table_info(); identifiers only.
+            insert_sql = f"INSERT INTO sessions ({col_list}) SELECT {col_list} FROM sessions__adr0025_old"  # noqa: S608
+            await self.db.execute(insert_sql)
+            await self.db.execute("DROP TABLE sessions__adr0025_old")
+            for idx_sql in index_sqls:
+                # Some legacy index DDL uses "IF NOT EXISTS"; some
+                # doesn't. Either way the index was dropped with the old
+                # table, so re-CREATE always succeeds.
+                await self.db.execute(idx_sql)
+            await self.db.commit()
+        finally:
+            await self.db.execute("PRAGMA foreign_keys = ON")
 
     # ── Schema version ─────────────────────────────────────────────────
 

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -365,16 +365,13 @@ class StateDB:
 
         await self.db.execute("PRAGMA foreign_keys = OFF")
         try:
-            await self.db.execute(
-                "ALTER TABLE sessions RENAME TO sessions__adr0025_old"
-            )
-            # Recreate without the CHECK. Column definitions intentionally
-            # match the new schema.sql; the executescript that follows
-            # _drop_legacy_session_status_check is a no-op for this table
-            # (CREATE TABLE IF NOT EXISTS).
+            # Use sessions_new pattern to avoid FK rewrites: SQLite's
+            # ALTER TABLE RENAME rewrites child-table FK references
+            # (branches, plays) to point at the renamed table. Creating
+            # a _new table, copying, then swapping avoids that.
             await self.db.execute(
                 """
-                CREATE TABLE sessions (
+                CREATE TABLE sessions_new (
                   id              TEXT    PRIMARY KEY,
                   created_at      REAL    NOT NULL,
                   node_metadata   JSON,
@@ -404,14 +401,24 @@ class StateDB:
                 )
                 """
             )
-            # col_list is built from PRAGMA table_info(); identifiers only.
-            insert_sql = f"INSERT INTO sessions ({col_list}) SELECT {col_list} FROM sessions__adr0025_old"  # noqa: S608
+            # Build SELECT with COALESCE for updated_at — legacy DBs
+            # may have NULL values from _reconcile_columns additions.
+            select_cols = []
+            for c in cols:
+                if c == "updated_at":
+                    select_cols.append(
+                        "COALESCE(updated_at, created_at, strftime('%s','now')) AS updated_at"
+                    )
+                else:
+                    select_cols.append(c)
+            select_list = ", ".join(select_cols)
+            insert_sql = f"INSERT INTO sessions_new ({col_list}) SELECT {select_list} FROM sessions"  # noqa: S608
             await self.db.execute(insert_sql)
-            await self.db.execute("DROP TABLE sessions__adr0025_old")
+            await self.db.execute("DROP TABLE sessions")
+            await self.db.execute(
+                "ALTER TABLE sessions_new RENAME TO sessions"
+            )
             for idx_sql in index_sqls:
-                # Some legacy index DDL uses "IF NOT EXISTS"; some
-                # doesn't. Either way the index was dropped with the old
-                # table, so re-CREATE always succeeds.
                 await self.db.execute(idx_sql)
             await self.db.commit()
         finally:

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -101,11 +101,12 @@ CREATE TABLE IF NOT EXISTS sessions (
                     source_kind IS NULL
                     OR source_kind IN ('live', 'imported_fs')
                   ),
-  -- ── Lifecycle (ADR-0017) ───────────────────────────────────────────
-  status          TEXT CHECK(
-                    status IS NULL
-                    OR status IN ('running', 'completed', 'failed', 'aborted')
-                  ),
+  -- ── Lifecycle (ADR-0025, supersedes ADR-0017) ─────────────────────
+  -- No CHECK constraint: ADR-0025 makes Python the source of truth for
+  -- session.status (VALID_SESSION_STATUSES in lionagi/state/db.py). The
+  -- six-value vocabulary (running, completed, failed, timed_out, aborted,
+  -- cancelled) can evolve without a SQLite table rebuild.
+  status          TEXT,
   started_at      REAL,
   ended_at        REAL
 );

--- a/tests/state/test_session_status_vocabulary.py
+++ b/tests/state/test_session_status_vocabulary.py
@@ -1,0 +1,229 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""ADR-0025 session status vocabulary tests.
+
+Covers: six-value vocabulary, terminal set, FSM transitions, admin
+transitions, and the legacy ADR-0017 CHECK-constraint rebuild path.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import aiosqlite
+import pytest
+
+from lionagi.state.db import (
+    ADMIN_TRANSITION_TARGETS,
+    SESSION_TERMINAL_STATUSES,
+    VALID_SESSION_STATUSES,
+    StateDB,
+    can_transition,
+)
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+async def db():
+    state = StateDB(":memory:")
+    await state.open()
+    yield state
+    await state.close()
+
+
+def _uid() -> str:
+    return str(uuid.uuid4())
+
+
+async def _make_session(db: StateDB, *, status: str | None = None) -> dict:
+    prog_id = _uid()
+    await db.create_progression(prog_id)
+    session = {
+        "id": _uid(),
+        "progression_id": prog_id,
+        "status": status,
+    }
+    await db.create_session(session)
+    return session
+
+
+# ── Vocabulary ────────────────────────────────────────────────────────────────
+
+
+def test_vocabulary_has_six_values():
+    assert VALID_SESSION_STATUSES == frozenset(
+        {"running", "completed", "failed", "timed_out", "aborted", "cancelled"}
+    )
+
+
+def test_terminal_set_excludes_running():
+    assert "running" not in SESSION_TERMINAL_STATUSES
+    assert SESSION_TERMINAL_STATUSES == VALID_SESSION_STATUSES - {"running"}
+
+
+def test_admin_targets_exclude_completed_and_timed_out():
+    # Admins shouldn't backfill "the model timed out itself" — that is a
+    # system determination, not an operator decision.
+    assert "completed" not in ADMIN_TRANSITION_TARGETS
+    assert "timed_out" not in ADMIN_TRANSITION_TARGETS
+    assert ADMIN_TRANSITION_TARGETS == frozenset({"failed", "aborted", "cancelled"})
+
+
+# ── can_transition ────────────────────────────────────────────────────────────
+
+
+def test_can_transition_only_from_running():
+    for target in SESSION_TERMINAL_STATUSES:
+        assert can_transition("running", target)
+
+
+def test_can_transition_rejects_terminal_origin():
+    for current in SESSION_TERMINAL_STATUSES:
+        for target in SESSION_TERMINAL_STATUSES:
+            assert not can_transition(current, target), (
+                f"transition {current!r} → {target!r} should be rejected"
+            )
+
+
+def test_can_transition_rejects_unknown_target():
+    assert not can_transition("running", "in_progress")
+    assert not can_transition("running", "stale")  # stale = health, not status
+
+
+def test_can_transition_rejects_none_origin():
+    assert not can_transition(None, "completed")
+
+
+# ── DB-level validation ───────────────────────────────────────────────────────
+
+
+async def test_create_session_accepts_all_six_statuses(db: StateDB):
+    for status in VALID_SESSION_STATUSES:
+        s = await _make_session(db, status=status)
+        retrieved = await db.get_session(s["id"])
+        assert retrieved["status"] == status
+
+
+async def test_update_session_accepts_timed_out(db: StateDB):
+    s = await _make_session(db, status="running")
+    await db.update_session(s["id"], status="timed_out")
+    assert (await db.get_session(s["id"]))["status"] == "timed_out"
+
+
+async def test_update_session_accepts_cancelled(db: StateDB):
+    s = await _make_session(db, status="running")
+    await db.update_session(s["id"], status="cancelled")
+    assert (await db.get_session(s["id"]))["status"] == "cancelled"
+
+
+async def test_update_session_rejects_unknown_status(db: StateDB):
+    s = await _make_session(db, status="running")
+    with pytest.raises(ValueError, match="ADR-0025 vocabulary"):
+        await db.update_session(s["id"], status="stale")
+
+
+# ── Legacy CHECK constraint rebuild ───────────────────────────────────────────
+
+
+async def test_drop_legacy_check_rebuilds_table(tmp_path: Path):
+    """An existing DB with the ADR-0017 4-value CHECK is migrated on open."""
+    path = tmp_path / "legacy.db"
+
+    # Hand-build the legacy schema: ADR-0017 4-value CHECK on sessions.status.
+    async with aiosqlite.connect(str(path)) as old:
+        await old.execute(
+            """
+            CREATE TABLE progressions (
+              id          TEXT    PRIMARY KEY,
+              created_at  REAL    NOT NULL,
+              collection  TEXT    NOT NULL DEFAULT '[]'
+            )
+            """
+        )
+        await old.execute(
+            """
+            CREATE TABLE sessions (
+              id              TEXT    PRIMARY KEY,
+              created_at      REAL    NOT NULL,
+              node_metadata   JSON,
+              name            TEXT,
+              user            TEXT,
+              progression_id  TEXT    NOT NULL REFERENCES progressions(id),
+              first_msg_id    TEXT,
+              last_msg_id     TEXT,
+              updated_at      REAL,
+              status          TEXT CHECK(
+                                status IS NULL
+                                OR status IN ('running', 'completed', 'failed', 'aborted')
+                              )
+            )
+            """
+        )
+        # Seed one row to verify INSERT SELECT preserves data.
+        prog_id = _uid()
+        sess_id = _uid()
+        await old.execute(
+            "INSERT INTO progressions (id, created_at) VALUES (?, ?)",
+            (prog_id, 1.0),
+        )
+        await old.execute(
+            "INSERT INTO sessions (id, created_at, progression_id, updated_at, status) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (sess_id, 1.0, prog_id, 1.0, "running"),
+        )
+        await old.commit()
+
+    # Open via StateDB — migration should run, CHECK should disappear.
+    state = StateDB(path)
+    await state.open()
+    try:
+        # Row preserved.
+        retrieved = await state.get_session(sess_id)
+        assert retrieved is not None
+        assert retrieved["status"] == "running"
+
+        # The new vocabulary values now accepted — would have raised
+        # IntegrityError before the rebuild.
+        await state.update_session(sess_id, status="timed_out")
+        assert (await state.get_session(sess_id))["status"] == "timed_out"
+    finally:
+        await state.close()
+
+
+async def test_drop_legacy_check_is_idempotent(tmp_path: Path):
+    """Re-opening a migrated DB is a no-op (no further table rebuild)."""
+    path = tmp_path / "twice.db"
+
+    state1 = StateDB(path)
+    await state1.open()
+    s = await _make_session(state1, status="running")
+    await state1.update_session(s["id"], status="cancelled")
+    await state1.close()
+
+    # Second open — _drop_legacy_session_status_check should find no
+    # marker and return immediately.
+    state2 = StateDB(path)
+    await state2.open()
+    try:
+        assert (await state2.get_session(s["id"]))["status"] == "cancelled"
+    finally:
+        await state2.close()
+
+
+# ── CLI exit-code map ─────────────────────────────────────────────────────────
+
+
+def test_cli_exit_code_map_matches_adr0025():
+    from lionagi.cli.agent import _EXIT_CODE_BY_TERMINAL_STATUS
+
+    # ADR-0025 spec table: 0 / 1 / 124 / 130 / 143.
+    assert _EXIT_CODE_BY_TERMINAL_STATUS == {
+        "completed": 0,
+        "failed": 1,
+        "timed_out": 124,
+        "aborted": 130,
+        "cancelled": 143,
+    }


### PR DESCRIPTION
## Summary

Implements **ADR-0025 — Session Status Vocabulary**, the foundation layer of the seven-ADR Lion Studio v2 rollout (ADRs 0019–0025, merged in #1046).

Expands `sessions.status` from 4 values to 6, each with a distinct operational follow-up and UNIX exit code:

| Status | Meaning | Exit |
|--------|---------|------|
| `running` | in flight | — |
| `completed` | normal exit | 0 |
| `failed` | unexpected error → investigate | 1 |
| `timed_out` | `--timeout` deadline hit → retry with more time | 124 (GNU coreutils) |
| `aborted` | user pressed Ctrl-C (SIGINT) | 130 |
| `cancelled` | system / orchestrator cancellation (SIGTERM cascade) | 143 |

Before this PR, all four non-`completed` outcomes showed the same red "failed" pill, and shell scripts could not tell timeout from error.

## Why this is Layer 1

ADRs 0019, 0020, 0023, 0024 all reference the six-value vocabulary in their CHECK constraints, transition tables, and health classifier. Landing this first means the rest can build on a stable contract instead of every PR re-debating "should it be `cancelled` or `aborted`?"

## Backend

- `lionagi/state/db.py` — `VALID_SESSION_STATUSES` (6), `SESSION_TERMINAL_STATUSES`, `ADMIN_TRANSITION_TARGETS`, `can_transition()`. One-shot `_drop_legacy_session_status_check()` rebuild for DBs with the ADR-0017 4-value CHECK (detects marker in `sqlite_master`, rebuilds via documented rename → CREATE → INSERT SELECT → DROP pattern, recreates indexes, idempotent).
- `lionagi/state/schema.sql` — drop CHECK on `sessions.status`; Python is the source of truth.
- `lionagi/cli/agent.py` — `_run_agent` distinguishes the four terminal outcomes; returns terminal status; `run_agent` maps to exit codes via `_EXIT_CODE_BY_TERMINAL_STATUS`. KeyboardInterrupt / CancelledError caught at the dispatcher boundary.
- `lionagi/cli/orchestrate/flow.py` + `fanout.py` — same six-way teardown. `LionTimeoutError` now sets `timed_out` (was `aborted`).
- `lionagi/cli/orchestrate/__init__.py` — dispatcher returns 124 / 130 / 143.

## Studio

- `apps/studio/server/services/status_mapping.py` — `DISPLAY_MAP` adds `timed_out` + `cancelled`.
- `apps/studio/server/services/runs.py` — `_STATUS_ALIASES` no longer collapses `cancelled` and `aborted`; adds `timed_out` alias.
- `apps/studio/frontend/app/page.tsx` — `SLOW_RUN_SECONDS` / `STUCK_RUN_SECONDS` 30m → 60m; `FAILED_STATES` no longer includes `timed_out` / `cancelled` / `aborted`.
- `apps/studio/frontend/app/runs/page.tsx` — `STATUS_FILTERS` gains the three new statuses.
- `apps/studio/frontend/components/StatusPill.tsx` — `timed_out` is amber (pending), `aborted` / `cancelled` are neutral.

The full `StatusPill` taxonomy refactor (the `taxonomy` prop from ADR-0024) is deferred to the Layer 3 PR.

## Test plan

- [x] `uv run pytest tests/state/test_session_status_vocabulary.py` — 14 new tests pass
- [x] `uv run pytest tests/state/ tests/cli/ tests/operations/ tests/apps_studio_server/` — 831 tests pass
- [x] `uv run ruff check` on touched files — clean
- [x] `npx tsc --noEmit` in `apps/studio/frontend/` — clean
- [ ] Smoke test: `li agent --timeout 5 codex "sleep 999"` → exit 124, session row `status='timed_out'`
- [ ] Smoke test: `^C` during `li play` → exit 130, session row `status='aborted'`
- [ ] Visual walkthrough: `timed_out` pill renders amber; runs filter shows new statuses; dashboard `Slow runs` card flags >60m only

🤖 Generated with [Claude Code](https://claude.com/claude-code)