### PR TITLE
feat: ADR-0020 skill invocations + li invoke + /invocations page (Layer 2b)

### DIFF
--- a/apps/studio/frontend/app/invocations/[id]/page.tsx
+++ b/apps/studio/frontend/app/invocations/[id]/page.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import PageHeader from "@/components/PageHeader";
+import StatusPill from "@/components/StatusPill";
+import Timestamp from "@/components/Timestamp";
+import Duration from "@/components/Duration";
+import { getInvocation } from "@/lib/api";
+import type { InvocationDetail } from "@/lib/api";
+
+function shortId(id: string): string {
+  return id.slice(0, 8);
+}
+
+export default function InvocationDetailPage() {
+  const params = useParams<{ id: string }>();
+  const id = params.id;
+  const [data, setData] = useState<InvocationDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [now, setNow] = useState(() => Math.floor(Date.now() / 1000));
+
+  useEffect(() => {
+    let active = true;
+    async function load() {
+      try {
+        const d = await getInvocation(id);
+        if (active) {
+          setData(d);
+          setError(null);
+        }
+      } catch {
+        if (active) setError("Failed to load invocation");
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+    void load();
+    const tick = setInterval(() => setNow(Math.floor(Date.now() / 1000)), 30000);
+    return () => {
+      active = false;
+      clearInterval(tick);
+    };
+  }, [id]);
+
+  if (loading) {
+    return (
+      <main className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-6">
+        <PageHeader title="Invocation" subtitle="loading…" density="tight" />
+      </main>
+    );
+  }
+  if (error || !data) {
+    return (
+      <main className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-6">
+        <PageHeader
+          title="Invocation"
+          subtitle={error ?? "Not found"}
+          density="tight"
+        />
+      </main>
+    );
+  }
+
+  const dur = (data.ended_at ?? now) - data.started_at;
+
+  return (
+    <main className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-6 animate-page-enter">
+      <PageHeader
+        title={`/${data.skill}`}
+        subtitle={data.prompt ?? "(no prompt)"}
+        density="tight"
+        badges={<StatusPill value={data.status} />}
+      />
+
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4 text-body">
+        <div className="rounded border border-edge bg-surface-raised p-3">
+          <div className="text-meta uppercase tracking-[0.06em] text-content-muted">
+            Sessions
+          </div>
+          <div className="mt-1 text-2xl tabular-nums text-content-primary">
+            {data.session_count}
+          </div>
+        </div>
+        <div className="rounded border border-edge bg-surface-raised p-3">
+          <div className="text-meta uppercase tracking-[0.06em] text-content-muted">
+            Duration
+          </div>
+          <div className="mt-1 text-2xl tabular-nums text-content-primary">
+            <Duration value={dur} />
+          </div>
+        </div>
+        <div className="rounded border border-edge bg-surface-raised p-3">
+          <div className="text-meta uppercase tracking-[0.06em] text-content-muted">
+            Started
+          </div>
+          <div className="mt-1 text-body text-content-primary">
+            <Timestamp value={data.started_at} />
+          </div>
+        </div>
+        <div className="rounded border border-edge bg-surface-raised p-3">
+          <div className="text-meta uppercase tracking-[0.06em] text-content-muted">
+            Plugin
+          </div>
+          <div className="mt-1 text-body text-content-primary">
+            {data.plugin ?? "—"}
+          </div>
+        </div>
+      </div>
+
+      <section>
+        <h2 className="mb-2 text-meta uppercase tracking-[0.06em] text-content-muted">
+          Sessions in this invocation
+        </h2>
+        <div className="overflow-x-auto rounded border border-edge bg-surface-raised shadow-card">
+          <table className="w-full text-left text-body">
+            <thead>
+              <tr className="border-b border-edge bg-surface-overlay text-meta uppercase tracking-[0.06em] text-content-muted">
+                <th className="px-3 py-2.5 font-medium">Session</th>
+                <th className="px-3 py-2.5 font-medium">Kind</th>
+                <th className="px-3 py-2.5 font-medium">Status</th>
+                <th className="px-3 py-2.5 font-medium">Started</th>
+                <th className="px-3 py-2.5 font-medium">Last activity</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.sessions.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={5}
+                    className="px-3 py-8 text-center text-meta text-content-muted"
+                  >
+                    No sessions spawned under this invocation yet.
+                  </td>
+                </tr>
+              ) : (
+                data.sessions.map((s) => (
+                  <tr
+                    key={s.id}
+                    className="border-b border-edge last:border-b-0 hover:bg-surface-overlay"
+                  >
+                    <td className="px-3 py-2 align-middle">
+                      <Link
+                        href={`/runs/${s.id}`}
+                        className="font-mono text-content-primary hover:underline"
+                      >
+                        {s.name || s.agent_name || s.playbook_name || shortId(s.id)}
+                      </Link>
+                      <div className="text-meta text-content-muted font-mono">
+                        {shortId(s.id)}
+                      </div>
+                    </td>
+                    <td className="px-3 py-2 align-middle text-content-secondary">
+                      {s.invocation_kind ?? "—"}
+                    </td>
+                    <td className="px-3 py-2 align-middle">
+                      <StatusPill value={s.status ?? "pending"} />
+                    </td>
+                    <td className="px-3 py-2 align-middle">
+                      <Timestamp value={s.started_at} />
+                    </td>
+                    <td className="px-3 py-2 align-middle">
+                      <Timestamp value={s.last_message_at} />
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {data.node_metadata && Object.keys(data.node_metadata).length > 0 ? (
+        <section>
+          <h2 className="mb-2 text-meta uppercase tracking-[0.06em] text-content-muted">
+            Skill metadata
+          </h2>
+          <pre className="overflow-x-auto rounded border border-edge bg-surface-raised p-3 text-meta font-mono text-content-secondary">
+            {JSON.stringify(data.node_metadata, null, 2)}
+          </pre>
+        </section>
+      ) : null}
+    </main>
+  );
+}

--- a/apps/studio/frontend/app/invocations/page.tsx
+++ b/apps/studio/frontend/app/invocations/page.tsx
@@ -30,6 +30,7 @@ export default function InvocationsPage() {
   const [error, setError] = useState<string | null>(null);
   const [offset, setOffset] = useState(0);
   const [skillFilter, setSkillFilter] = useState<string>("");
+  const [skillInput, setSkillInput] = useState<string>("");
   const [statusFilter, setStatusFilter] = useState<string>("");
   const [now, setNow] = useState(() => Math.floor(Date.now() / 1000));
 
@@ -63,10 +64,6 @@ export default function InvocationsPage() {
   }, [offset, skillFilter, statusFilter]);
 
   const rows = useMemo(() => data?.invocations ?? [], [data]);
-  const skills = useMemo(
-    () => Array.from(new Set(rows.map((r) => r.skill))).sort(),
-    [rows],
-  );
 
   return (
     <main className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-6 animate-page-enter">
@@ -88,21 +85,42 @@ export default function InvocationsPage() {
         <span className="text-meta uppercase tracking-[0.06em] text-content-muted">
           Filters
         </span>
-        <select
-          value={skillFilter}
-          onChange={(e) => {
-            setOffset(0);
-            setSkillFilter(e.target.value);
+        <input
+          type="text"
+          placeholder="Filter by skill..."
+          value={skillInput}
+          onChange={(e) => setSkillInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              setOffset(0);
+              setSkillFilter(skillInput);
+            }
           }}
           className="rounded border border-edge bg-surface-base px-2 py-1 text-body"
+        />
+        <Button
+          size="sm"
+          variant="secondary"
+          onClick={() => {
+            setOffset(0);
+            setSkillFilter(skillInput);
+          }}
         >
-          <option value="">all skills</option>
-          {skills.map((s) => (
-            <option key={s} value={s}>
-              {s}
-            </option>
-          ))}
-        </select>
+          Search
+        </Button>
+        {skillFilter && (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => {
+              setSkillInput("");
+              setSkillFilter("");
+              setOffset(0);
+            }}
+          >
+            Clear
+          </Button>
+        )}
         <select
           value={statusFilter}
           onChange={(e) => {
@@ -150,15 +168,17 @@ export default function InvocationsPage() {
                 </td>
               </tr>
             ) : rows.length === 0 ? (
-              <tr>
-                <td
-                  colSpan={6}
-                  className="px-3 py-8 text-center text-meta text-content-muted"
-                >
-                  No invocations yet. Skills track here once they call{" "}
-                  <code className="text-content-primary">li invoke start</code>.
-                </td>
-              </tr>
+              !error ? (
+                <tr>
+                  <td
+                    colSpan={6}
+                    className="px-3 py-8 text-center text-meta text-content-muted"
+                  >
+                    No invocations yet. Skills track here once they call{" "}
+                    <code className="text-content-primary">li invoke start</code>.
+                  </td>
+                </tr>
+              ) : null
             ) : (
               rows.map((inv) => {
                 const dur = durationSeconds(inv.started_at, inv.ended_at, now);

--- a/apps/studio/frontend/app/invocations/page.tsx
+++ b/apps/studio/frontend/app/invocations/page.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import Button from "@/components/Button";
+import PageHeader from "@/components/PageHeader";
+import StatusPill from "@/components/StatusPill";
+import Timestamp from "@/components/Timestamp";
+import Duration from "@/components/Duration";
+import { listInvocations } from "@/lib/api";
+import type { InvocationListResponse } from "@/lib/api";
+
+const LIMIT = 25;
+
+function shortId(id: string): string {
+  return id.slice(0, 8);
+}
+
+function durationSeconds(
+  startedAt: number,
+  endedAt: number | null,
+  nowSec: number,
+): number {
+  return (endedAt ?? nowSec) - startedAt;
+}
+
+export default function InvocationsPage() {
+  const [data, setData] = useState<InvocationListResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [offset, setOffset] = useState(0);
+  const [skillFilter, setSkillFilter] = useState<string>("");
+  const [statusFilter, setStatusFilter] = useState<string>("");
+  const [now, setNow] = useState(() => Math.floor(Date.now() / 1000));
+
+  useEffect(() => {
+    let active = true;
+    async function load() {
+      setLoading(true);
+      try {
+        const d = await listInvocations({
+          limit: LIMIT,
+          offset,
+          skill: skillFilter || undefined,
+          status: statusFilter || undefined,
+        });
+        if (active) {
+          setData(d);
+          setError(null);
+        }
+      } catch {
+        if (active) setError("Failed to load invocations");
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+    void load();
+    const tick = setInterval(() => setNow(Math.floor(Date.now() / 1000)), 30000);
+    return () => {
+      active = false;
+      clearInterval(tick);
+    };
+  }, [offset, skillFilter, statusFilter]);
+
+  const rows = useMemo(() => data?.invocations ?? [], [data]);
+  const skills = useMemo(
+    () => Array.from(new Set(rows.map((r) => r.skill))).sort(),
+    [rows],
+  );
+
+  return (
+    <main className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-6 animate-page-enter">
+      <PageHeader
+        title="Invocations"
+        subtitle="Skill-level orchestration (ADR-0020)"
+        density="tight"
+        badges={
+          data ? (
+            <span className="text-meta text-content-muted tabular-nums">
+              {rows.length} invocation{rows.length !== 1 ? "s" : ""}
+            </span>
+          ) : null
+        }
+      />
+
+      {/* Filter strip */}
+      <div className="flex flex-wrap items-center gap-3 rounded border border-edge bg-surface-overlay px-3 py-2 text-body">
+        <span className="text-meta uppercase tracking-[0.06em] text-content-muted">
+          Filters
+        </span>
+        <select
+          value={skillFilter}
+          onChange={(e) => {
+            setOffset(0);
+            setSkillFilter(e.target.value);
+          }}
+          className="rounded border border-edge bg-surface-base px-2 py-1 text-body"
+        >
+          <option value="">all skills</option>
+          {skills.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+        <select
+          value={statusFilter}
+          onChange={(e) => {
+            setOffset(0);
+            setStatusFilter(e.target.value);
+          }}
+          className="rounded border border-edge bg-surface-base px-2 py-1 text-body"
+        >
+          <option value="">all statuses</option>
+          <option value="running">running</option>
+          <option value="completed">completed</option>
+          <option value="failed">failed</option>
+          <option value="timed_out">timed_out</option>
+          <option value="aborted">aborted</option>
+          <option value="cancelled">cancelled</option>
+        </select>
+      </div>
+
+      {error && (
+        <div className="rounded border border-status-error/30 bg-status-error-bg px-3 py-2 text-body text-status-error">
+          {error}
+        </div>
+      )}
+
+      <div className="overflow-x-auto rounded border border-edge bg-surface-raised shadow-card">
+        <table className="w-full text-left text-body">
+          <thead>
+            <tr className="border-b border-edge bg-surface-overlay text-meta uppercase tracking-[0.06em] text-content-muted">
+              <th className="px-3 py-2.5 font-medium">Skill</th>
+              <th className="px-3 py-2.5 font-medium">Prompt</th>
+              <th className="px-3 py-2.5 font-medium tabular-nums">Sessions</th>
+              <th className="px-3 py-2.5 font-medium tabular-nums">Duration</th>
+              <th className="px-3 py-2.5 font-medium">Status</th>
+              <th className="px-3 py-2.5 font-medium">Started</th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              <tr>
+                <td
+                  colSpan={6}
+                  className="px-3 py-8 text-center text-meta text-content-muted"
+                >
+                  Loading...
+                </td>
+              </tr>
+            ) : rows.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={6}
+                  className="px-3 py-8 text-center text-meta text-content-muted"
+                >
+                  No invocations yet. Skills track here once they call{" "}
+                  <code className="text-content-primary">li invoke start</code>.
+                </td>
+              </tr>
+            ) : (
+              rows.map((inv) => {
+                const dur = durationSeconds(inv.started_at, inv.ended_at, now);
+                return (
+                  <tr
+                    key={inv.id}
+                    className="border-b border-edge last:border-b-0 hover:bg-surface-overlay"
+                  >
+                    <td className="px-3 py-2 align-middle">
+                      <Link
+                        href={`/invocations/${inv.id}`}
+                        className="font-mono text-content-primary hover:underline"
+                      >
+                        /{inv.skill}
+                      </Link>
+                      <div className="text-meta text-content-muted">
+                        {shortId(inv.id)}
+                        {inv.plugin ? ` · ${inv.plugin}` : ""}
+                      </div>
+                    </td>
+                    <td className="px-3 py-2 align-middle">
+                      <div className="max-w-md truncate text-content-secondary">
+                        {inv.prompt ?? "(no prompt)"}
+                      </div>
+                    </td>
+                    <td className="px-3 py-2 align-middle tabular-nums">
+                      {inv.session_count}
+                    </td>
+                    <td className="px-3 py-2 align-middle tabular-nums">
+                      <Duration value={dur} />
+                    </td>
+                    <td className="px-3 py-2 align-middle">
+                      <StatusPill value={inv.status} />
+                    </td>
+                    <td className="px-3 py-2 align-middle">
+                      <Timestamp value={inv.started_at} />
+                    </td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <div className="text-meta text-content-muted tabular-nums">
+          offset {offset} · showing {rows.length}
+        </div>
+        <div className="flex gap-2">
+          <Button
+            onClick={() => setOffset(Math.max(0, offset - LIMIT))}
+            disabled={offset === 0}
+          >
+            Prev
+          </Button>
+          <Button
+            onClick={() => setOffset(offset + LIMIT)}
+            disabled={!data?.has_next}
+          >
+            Next
+          </Button>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/studio/frontend/app/page.tsx
+++ b/apps/studio/frontend/app/page.tsx
@@ -111,12 +111,22 @@ export default function DashboardPage() {
       const d = durationSeconds(r, now);
       return d != null && d > STUCK_RUN_SECONDS;
     });
+    // ADR-0019: stale = running, but no message activity past the
+    // kind-aware threshold. Distinct from "stuck" (duration-based) — a
+    // 30-agent flow that's actively producing messages for 9 hours is
+    // stuck-eligible but not stale.
+    const stale = running.filter((r) => r.effective_health === "stale");
 
-    // Needs attention rows: failed / stuck / needs review / blocked
+    // Needs attention rows: failed / stale / stuck / needs review.
+    // Stale ranks above stuck because no-activity is a stronger signal
+    // than "running a long time."
     const attention = [
       ...failed,
-      ...stuck.filter((s) => !failed.includes(s)),
-      ...needsReview.filter((n) => !failed.includes(n) && !stuck.includes(n)),
+      ...stale.filter((s) => !failed.includes(s)),
+      ...stuck.filter((s) => !failed.includes(s) && !stale.includes(s)),
+      ...needsReview.filter(
+        (n) => !failed.includes(n) && !stale.includes(n) && !stuck.includes(n),
+      ),
     ]
       .sort((a, b) => (b.started_at ?? 0) - (a.started_at ?? 0))
       .slice(0, 8);
@@ -125,7 +135,7 @@ export default function DashboardPage() {
       .sort((a, b) => (b.started_at ?? 0) - (a.started_at ?? 0))
       .slice(0, 8);
 
-    return { scoped, running, failed, completed, needsReview, slow, stuck, attention, recent };
+    return { scoped, running, failed, completed, needsReview, slow, stuck, stale, attention, recent };
   }, [allRuns, windowSec, now]);
 
   const rangeLabel = range === "all" ? "all time" : range;
@@ -146,13 +156,24 @@ export default function DashboardPage() {
       )}
 
       {/* Operational stat cards */}
-      <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-5">
         <MetricCard
           label="Running now"
           value={buckets.running.length}
           hint={buckets.stuck.length > 0 ? `${buckets.stuck.length} stuck >${STUCK_RUN_SECONDS / 60}m` : `${rangeLabel}`}
           tone={buckets.running.length > 0 ? "running" : "neutral"}
           icon={buckets.running.length > 0 ? "◐" : "○"}
+        />
+        <MetricCard
+          label="Stale"
+          value={buckets.stale.length}
+          hint={
+            buckets.stale.length > 0
+              ? "no activity past threshold"
+              : "all running runs active"
+          }
+          tone={buckets.stale.length > 0 ? "pending" : "neutral"}
+          icon={buckets.stale.length > 0 ? "◴" : "·"}
         />
         <MetricCard
           label={`Failed (${rangeLabel})`}

--- a/apps/studio/frontend/app/runs/page.tsx
+++ b/apps/studio/frontend/app/runs/page.tsx
@@ -53,6 +53,31 @@ function groupByInvocation(runs: RunSummary[]): {
   return { groups, ungrouped };
 }
 
+// Health severity for invocation group rollup — worst-child wins.
+// Ranks match staleness_check() output + ADR-0024 vocabulary expansion.
+const HEALTH_RANK: Record<string, number> = {
+  idle: 1,
+  stale: 2,
+  unresponsive: 3,
+  orphaned: 4,
+  zombie: 5,
+};
+
+function worstHealth(sessions: RunSummary[]): string | null {
+  let worst: string | null = null;
+  let worstRank = 0;
+  for (const s of sessions) {
+    const h = s.effective_health ?? null;
+    if (h === null) continue;
+    const rank = HEALTH_RANK[h] ?? 1;
+    if (rank > worstRank) {
+      worst = h;
+      worstRank = rank;
+    }
+  }
+  return worst;
+}
+
 function groupStatus(sessions: RunSummary[]): string {
   if (sessions.some((s) => s.status === "running")) return "running";
   if (sessions.some((s) => s.status === "failed")) return "failed";
@@ -140,7 +165,12 @@ function SessionRow({
         </span>
       </td>
       <td className="px-3 py-2">
-        <StatusPill value={run.status} kind="lifecycle" />
+        <div className="flex items-center gap-1 flex-wrap">
+          <StatusPill value={run.status} kind="lifecycle" />
+          {run.effective_health && (
+            <StatusPill value={run.effective_health} kind="neutral" tone="pending" />
+          )}
+        </div>
       </td>
       <td className="px-3 py-2">
         <div className="flex items-center gap-2 flex-wrap">
@@ -204,10 +234,15 @@ function RunsPageInner() {
     let active = true;
 
     async function load() {
+      // TODO(ADR-0020): server-side invocation pagination — paginate by invocation
+      // parent (session_count aggregate) so page boundaries never split a group.
+      // Until then, fetch the full dataset in invocations mode and group client-side.
+      const effectivePage = viewMode === "invocations" ? 1 : page;
+      const effectivePerPage = viewMode === "invocations" ? 5000 : perPage;
       try {
         const result = await listRuns({
-          page,
-          per_page: perPage,
+          page: effectivePage,
+          per_page: effectivePerPage,
           status: statuses.length > 0 ? statuses : undefined,
           playbook: playbook || undefined,
         });
@@ -229,7 +264,7 @@ function RunsPageInner() {
       clearInterval(interval);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [page, statuses.join(","), playbook]);
+  }, [page, statuses.join(","), playbook, viewMode]);
 
   useEffect(() => {
     const tick = setInterval(
@@ -391,6 +426,7 @@ function RunsPageInner() {
                       group.invocation_id,
                     );
                     const st = groupStatus(group.sessions);
+                    const health = worstHealth(group.sessions);
                     const latestUpdated = group.sessions.reduce<number | null>(
                       (acc, s) => {
                         const u = s.updated_at ?? null;
@@ -419,7 +455,12 @@ function RunsPageInner() {
                             </div>
                           </td>
                           <td className="px-3 py-2">
-                            <StatusPill value={st} kind="lifecycle" />
+                            <div className="flex items-center gap-1 flex-wrap">
+                              <StatusPill value={st} kind="lifecycle" />
+                              {health && (
+                                <StatusPill value={health} kind="neutral" tone="pending" />
+                              )}
+                            </div>
                           </td>
                           <td className="px-3 py-2 text-content-secondary">
                             {group.sessions.length} session
@@ -467,8 +508,8 @@ function RunsPageInner() {
         </table>
       </div>
 
-      {/* Pagination */}
-      <div className="flex items-center justify-between text-meta text-content-muted">
+      {/* Pagination — hidden in invocations mode (full dataset loaded client-side) */}
+      {viewMode === "sessions" && <div className="flex items-center justify-between text-meta text-content-muted">
         <span>
           Page {page} of {totalPages || 1} &mdash; {total} run
           {total !== 1 ? "s" : ""}
@@ -491,7 +532,7 @@ function RunsPageInner() {
             Next
           </Button>
         </div>
-      </div>
+      </div>}
     </main>
   );
 }

--- a/apps/studio/frontend/app/runs/page.tsx
+++ b/apps/studio/frontend/app/runs/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { Suspense, useEffect, useMemo, useState } from "react";
+import { Fragment, Suspense, useEffect, useMemo, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import Button from "@/components/Button";
 import Duration from "@/components/Duration";
@@ -24,6 +24,44 @@ const STATUS_FILTERS = [
   "aborted",
   "cancelled",
 ] as const;
+
+type ViewMode = "sessions" | "invocations";
+
+interface InvocationGroup {
+  invocation_id: string;
+  sessions: RunSummary[];
+}
+
+function groupByInvocation(runs: RunSummary[]): {
+  groups: InvocationGroup[];
+  ungrouped: RunSummary[];
+} {
+  const map = new Map<string, RunSummary[]>();
+  const ungrouped: RunSummary[] = [];
+  for (const run of runs) {
+    if (run.invocation_id) {
+      const arr = map.get(run.invocation_id) ?? [];
+      arr.push(run);
+      map.set(run.invocation_id, arr);
+    } else {
+      ungrouped.push(run);
+    }
+  }
+  const groups: InvocationGroup[] = Array.from(map.entries()).map(
+    ([invocation_id, sessions]) => ({ invocation_id, sessions }),
+  );
+  return { groups, ungrouped };
+}
+
+function groupStatus(sessions: RunSummary[]): string {
+  if (sessions.some((s) => s.status === "running")) return "running";
+  if (sessions.some((s) => s.status === "failed")) return "failed";
+  if (sessions.some((s) => s.status === "timed_out")) return "timed_out";
+  if (sessions.some((s) => s.status === "aborted")) return "aborted";
+  if (sessions.every((s) => s.status === "done" || s.status === "completed"))
+    return "done";
+  return sessions[0]?.status ?? "pending";
+}
 
 function displayName(run: RunSummary): string {
   if (run.show_topic || run.show_play_name) {
@@ -77,6 +115,51 @@ function SkeletonRow() {
   );
 }
 
+function SessionRow({
+  run,
+  now,
+  indent = false,
+}: {
+  run: RunSummary;
+  now: number;
+  indent?: boolean;
+}) {
+  const prov = provenanceLabel(run);
+  const durSec = durationSeconds(run, now);
+  return (
+    <tr className="border-b border-edge-subtle text-content-secondary transition-colors duration-100 hover:bg-surface-overlay">
+      <td className={`px-3 py-2 ${indent ? "pl-8" : ""}`}>
+        <Link
+          href={`/runs/${run.run_id}`}
+          className="block font-medium text-content-primary transition-colors duration-100 hover:text-status-running"
+        >
+          {displayName(run)}
+        </Link>
+        <span className="font-mono text-meta text-content-muted">
+          {shortRunId(run)}
+        </span>
+      </td>
+      <td className="px-3 py-2">
+        <StatusPill value={run.status} kind="lifecycle" />
+      </td>
+      <td className="px-3 py-2">
+        <div className="flex items-center gap-2 flex-wrap">
+          <Duration value={durSec} />
+          <span
+            className="rounded px-1 py-0.5 font-mono text-[10px] border border-edge text-content-muted"
+            title={`Source: ${run.source_kind ?? "live"}`}
+          >
+            {prov}
+          </span>
+        </div>
+      </td>
+      <td className="px-3 py-2 text-meta text-content-muted">
+        <Timestamp value={run.updated_at ?? null} />
+      </td>
+    </tr>
+  );
+}
+
 function RunsPageInner() {
   const router = useRouter();
   const pathname = usePathname();
@@ -92,15 +175,24 @@ function RunsPageInner() {
   const [error, setError] = useState<string | null>(null);
   const [playbookInput, setPlaybookInput] = useState(playbook);
   const [now, setNow] = useState(() => Math.floor(Date.now() / 1000));
+  const [viewMode, setViewMode] = useState<ViewMode>("sessions");
+  const [expandedInvocations, setExpandedInvocations] = useState<Set<string>>(
+    new Set(),
+  );
 
   // eslint-disable-next-line react-hooks/set-state-in-effect -- sync URL→input: no external system involved, single derived state write
   useEffect(() => setPlaybookInput(playbook), [playbook]);
 
-  function setQuery(next: { page?: number; status?: string[]; playbook?: string }) {
+  function setQuery(next: {
+    page?: number;
+    status?: string[];
+    playbook?: string;
+  }) {
     const params = new URLSearchParams();
     const nextPage = next.page ?? 1;
     const nextStatuses = next.status ?? statuses;
-    const nextPlaybook = next.playbook !== undefined ? next.playbook : playbook;
+    const nextPlaybook =
+      next.playbook !== undefined ? next.playbook : playbook;
     if (nextPage > 1) params.set("page", String(nextPage));
     for (const s of nextStatuses) params.append("status", s);
     if (nextPlaybook) params.set("playbook", nextPlaybook);
@@ -140,7 +232,10 @@ function RunsPageInner() {
   }, [page, statuses.join(","), playbook]);
 
   useEffect(() => {
-    const tick = setInterval(() => setNow(Math.floor(Date.now() / 1000)), 30000);
+    const tick = setInterval(
+      () => setNow(Math.floor(Date.now() / 1000)),
+      30000,
+    );
     return () => clearInterval(tick);
   }, []);
 
@@ -155,9 +250,23 @@ function RunsPageInner() {
     setQuery({ playbook: playbookInput, page: 1 });
   }
 
+  function toggleExpand(id: string) {
+    setExpandedInvocations((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
   const runs = data?.runs ?? [];
   const total = data?.total ?? 0;
   const totalPages = data?.total_pages ?? 1;
+
+  const { groups: invocationGroups, ungrouped: ungroupedRuns } = useMemo(
+    () => groupByInvocation(runs),
+    [runs],
+  );
 
   return (
     <main className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-6 animate-page-enter">
@@ -174,38 +283,62 @@ function RunsPageInner() {
         }
       />
 
-      {/* Filter bar */}
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
-        <div className="flex items-center gap-1.5">
-          <input
-            type="text"
-            placeholder="Filter by playbook..."
-            value={playbookInput}
-            onChange={(e) => setPlaybookInput(e.target.value)}
-            onKeyDown={(e) => e.key === "Enter" && applyPlaybookFilter()}
-            className="h-7 rounded border border-edge bg-surface-raised px-2.5 text-meta text-content-primary placeholder:text-content-muted focus:border-interactive-primary focus:outline-none"
-          />
-          <Button size="sm" variant="secondary" onClick={applyPlaybookFilter}>
-            Search
+      {/* View toggle + Filter bar */}
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-1">
+          <Button
+            size="sm"
+            variant="toggle"
+            active={viewMode === "sessions"}
+            onClick={() => setViewMode("sessions")}
+          >
+            Sessions
           </Button>
-          {playbook && (
-            <Button size="sm" variant="ghost" onClick={() => {
-              setPlaybookInput("");
-              setQuery({ playbook: "", page: 1 });
-            }}>
-              Clear
-            </Button>
-          )}
+          <Button
+            size="sm"
+            variant="toggle"
+            active={viewMode === "invocations"}
+            onClick={() => setViewMode("invocations")}
+          >
+            Invocations
+          </Button>
         </div>
-        <div className="flex flex-wrap gap-1">
-          {STATUS_FILTERS.map((s) => (
-            <StatusFilterChip
-              key={s}
-              value={s}
-              active={statuses.includes(s)}
-              onClick={() => toggleStatus(s)}
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+          <div className="flex items-center gap-1.5">
+            <input
+              type="text"
+              placeholder="Filter by playbook..."
+              value={playbookInput}
+              onChange={(e) => setPlaybookInput(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && applyPlaybookFilter()}
+              className="h-7 rounded border border-edge bg-surface-raised px-2.5 text-meta text-content-primary placeholder:text-content-muted focus:border-interactive-primary focus:outline-none"
             />
-          ))}
+            <Button size="sm" variant="secondary" onClick={applyPlaybookFilter}>
+              Search
+            </Button>
+            {playbook && (
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => {
+                  setPlaybookInput("");
+                  setQuery({ playbook: "", page: 1 });
+                }}
+              >
+                Clear
+              </Button>
+            )}
+          </div>
+          <div className="flex flex-wrap gap-1">
+            {STATUS_FILTERS.map((s) => (
+              <StatusFilterChip
+                key={s}
+                value={s}
+                active={statuses.includes(s)}
+                onClick={() => toggleStatus(s)}
+              />
+            ))}
+          </div>
         </div>
       </div>
 
@@ -219,9 +352,13 @@ function RunsPageInner() {
         <table className="w-full text-left text-body">
           <thead>
             <tr className="border-b border-edge bg-surface-overlay text-meta uppercase tracking-[0.06em] text-content-muted">
-              <th className="px-3 py-2.5 font-medium">Run</th>
+              <th className="px-3 py-2.5 font-medium">
+                {viewMode === "invocations" ? "Invocation" : "Run"}
+              </th>
               <th className="px-3 py-2.5 font-medium">Status</th>
-              <th className="px-3 py-2.5 font-medium">Activity</th>
+              <th className="px-3 py-2.5 font-medium">
+                {viewMode === "invocations" ? "Sessions" : "Activity"}
+              </th>
               <th className="px-3 py-2.5 font-medium">Updated</th>
             </tr>
           </thead>
@@ -232,9 +369,89 @@ function RunsPageInner() {
                 <SkeletonRow />
                 <SkeletonRow />
               </>
+            ) : viewMode === "invocations" ? (
+              invocationGroups.length === 0 && ungroupedRuns.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={4}
+                    className="px-3 py-14 text-center text-body text-content-muted"
+                  >
+                    <span className="block mb-1 text-[11px]">No runs found</span>
+                    {(statuses.length > 0 || playbook) && (
+                      <span className="text-meta">
+                        Try adjusting your filters.
+                      </span>
+                    )}
+                  </td>
+                </tr>
+              ) : (
+                <>
+                  {invocationGroups.map((group) => {
+                    const isExpanded = expandedInvocations.has(
+                      group.invocation_id,
+                    );
+                    const st = groupStatus(group.sessions);
+                    const latestUpdated = group.sessions.reduce<number | null>(
+                      (acc, s) => {
+                        const u = s.updated_at ?? null;
+                        if (u === null) return acc;
+                        return acc === null || u > acc ? u : acc;
+                      },
+                      null,
+                    );
+                    return (
+                      <Fragment key={group.invocation_id}>
+                        <tr
+                          className="border-b border-edge-subtle bg-surface-overlay/50 text-content-primary cursor-pointer transition-colors duration-100 hover:bg-surface-overlay"
+                          onClick={() => toggleExpand(group.invocation_id)}
+                        >
+                          <td className="px-3 py-2">
+                            <div className="flex items-center gap-1.5">
+                              <span className="inline-block w-3 text-center font-mono text-[10px] text-content-muted select-none">
+                                {isExpanded ? "▼" : "▶"}
+                              </span>
+                              <span className="font-medium">
+                                Invocation{" "}
+                                <span className="font-mono text-meta text-content-muted">
+                                  {group.invocation_id.slice(-8)}
+                                </span>
+                              </span>
+                            </div>
+                          </td>
+                          <td className="px-3 py-2">
+                            <StatusPill value={st} kind="lifecycle" />
+                          </td>
+                          <td className="px-3 py-2 text-content-secondary">
+                            {group.sessions.length} session
+                            {group.sessions.length !== 1 ? "s" : ""}
+                          </td>
+                          <td className="px-3 py-2 text-meta text-content-muted">
+                            <Timestamp value={latestUpdated} />
+                          </td>
+                        </tr>
+                        {isExpanded &&
+                          group.sessions.map((run) => (
+                            <SessionRow
+                              key={run.run_id}
+                              run={run}
+                              now={now}
+                              indent
+                            />
+                          ))}
+                      </Fragment>
+                    );
+                  })}
+                  {ungroupedRuns.map((run) => (
+                    <SessionRow key={run.run_id} run={run} now={now} />
+                  ))}
+                </>
+              )
             ) : runs.length === 0 ? (
               <tr>
-                <td colSpan={4} className="px-3 py-14 text-center text-body text-content-muted">
+                <td
+                  colSpan={4}
+                  className="px-3 py-14 text-center text-body text-content-muted"
+                >
                   <span className="block mb-1 text-[11px]">No runs found</span>
                   {(statuses.length > 0 || playbook) && (
                     <span className="text-meta">Try adjusting your filters.</span>
@@ -242,45 +459,9 @@ function RunsPageInner() {
                 </td>
               </tr>
             ) : (
-              runs.map((run) => {
-                const prov = provenanceLabel(run);
-                const durSec = durationSeconds(run, now);
-                return (
-                  <tr
-                    key={run.run_id}
-                    className="border-b border-edge-subtle text-content-secondary transition-colors duration-100 hover:bg-surface-overlay"
-                  >
-                    <td className="px-3 py-2">
-                      <Link
-                        href={`/runs/${run.run_id}`}
-                        className="block font-medium text-content-primary transition-colors duration-100 hover:text-status-running"
-                      >
-                        {displayName(run)}
-                      </Link>
-                      <span className="font-mono text-meta text-content-muted">
-                        {shortRunId(run)}
-                      </span>
-                    </td>
-                    <td className="px-3 py-2">
-                      <StatusPill value={run.status} kind="lifecycle" />
-                    </td>
-                    <td className="px-3 py-2">
-                      <div className="flex items-center gap-2 flex-wrap">
-                        <Duration value={durSec} />
-                        <span
-                          className="rounded px-1 py-0.5 font-mono text-[10px] border border-edge text-content-muted"
-                          title={`Source: ${run.source_kind ?? "live"}`}
-                        >
-                          {prov}
-                        </span>
-                      </div>
-                    </td>
-                    <td className="px-3 py-2 text-meta text-content-muted">
-                      <Timestamp value={run.updated_at ?? null} />
-                    </td>
-                  </tr>
-                );
-              })
+              runs.map((run) => (
+                <SessionRow key={run.run_id} run={run} now={now} />
+              ))
             )}
           </tbody>
         </table>
@@ -289,7 +470,8 @@ function RunsPageInner() {
       {/* Pagination */}
       <div className="flex items-center justify-between text-meta text-content-muted">
         <span>
-          Page {page} of {totalPages || 1} &mdash; {total} run{total !== 1 ? "s" : ""}
+          Page {page} of {totalPages || 1} &mdash; {total} run
+          {total !== 1 ? "s" : ""}
         </span>
         <div className="flex gap-2">
           <Button

--- a/apps/studio/frontend/components/Shell.tsx
+++ b/apps/studio/frontend/components/Shell.tsx
@@ -15,6 +15,7 @@ const navItems: NavItem[] = [
   { label: "Agents", href: "/agents" },
   { label: "Plugins", href: "/plugins" },
   { label: "Shows", href: "/shows" },
+  { label: "Invocations", href: "/invocations" },
   { label: "Runs", href: "/runs" },
   { label: "Teams", href: "/teams" },
   { label: "Admin", href: "/admin" },

--- a/apps/studio/frontend/lib/api.ts
+++ b/apps/studio/frontend/lib/api.ts
@@ -388,6 +388,72 @@ export function streamSession(
   return () => source.close();
 }
 
+// ─── Invocations (ADR-0020) ───────────────────────────────────────────────────
+
+export interface InvocationSummary {
+  id: string;
+  skill: string;
+  plugin: string | null;
+  prompt: string | null;
+  started_at: number;
+  ended_at: number | null;
+  status: string;
+  session_count: number;
+  created_at: number;
+  updated_at: number;
+  node_metadata: Record<string, unknown> | null;
+}
+
+export interface InvocationSession {
+  id: string;
+  name: string | null;
+  agent_name: string | null;
+  playbook_name: string | null;
+  invocation_kind: string | null;
+  status: string | null;
+  last_message_at: number | null;
+  started_at: number | null;
+  ended_at: number | null;
+}
+
+export interface InvocationDetail extends InvocationSummary {
+  sessions: InvocationSession[];
+}
+
+export interface InvocationListResponse {
+  invocations: InvocationSummary[];
+  limit: number;
+  offset: number;
+  has_next: boolean;
+}
+
+export interface InvocationListParams {
+  skill?: string;
+  status?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export async function listInvocations(
+  params?: InvocationListParams,
+): Promise<InvocationListResponse> {
+  const query = new URLSearchParams();
+  if (params?.skill) query.set("skill", params.skill);
+  if (params?.status) query.set("status", params.status);
+  if (params?.limit !== undefined) query.set("limit", String(params.limit));
+  if (params?.offset !== undefined) query.set("offset", String(params.offset));
+  const qs = query.toString();
+  return fetchJson<InvocationListResponse>(
+    `/api/invocations/${qs ? `?${qs}` : ""}`,
+  );
+}
+
+export async function getInvocation(id: string): Promise<InvocationDetail> {
+  return fetchJson<InvocationDetail>(
+    `/api/invocations/${encodeURIComponent(id)}`,
+  );
+}
+
 // ─── Definitions (versioned md files via SQLite) ──────────────────────────────
 
 export interface DefinitionSummary {

--- a/apps/studio/frontend/lib/types.ts
+++ b/apps/studio/frontend/lib/types.ts
@@ -20,6 +20,8 @@ export interface RunSummary {
   // expand this with idle / unresponsive / orphaned / zombie.
   effective_health?: "stale" | null;
   last_message_at?: number | null;
+  // ADR-0020: optional parent skill orchestration id (from `li invoke`).
+  invocation_id?: string | null;
   started_at: number | null;
   ended_at?: number | null;
   created_at?: number | null;

--- a/apps/studio/frontend/lib/types.ts
+++ b/apps/studio/frontend/lib/types.ts
@@ -14,6 +14,12 @@ export interface RunSummary {
   show_play_name?: string | null;
   source_kind?: string;
   status: string;
+  // ADR-0019: derived health indicator computed at read time from
+  // `last_message_at` and a kind-aware threshold. Non-null only for
+  // `running` sessions that have crossed the threshold; ADR-0024 will
+  // expand this with idle / unresponsive / orphaned / zombie.
+  effective_health?: "stale" | null;
+  last_message_at?: number | null;
   started_at: number | null;
   ended_at?: number | null;
   created_at?: number | null;

--- a/apps/studio/server/app.py
+++ b/apps/studio/server/app.py
@@ -12,6 +12,7 @@ from .routers import (
     admin,
     agents,
     definitions,
+    invocations,
     playbooks,
     plugins,
     runs,
@@ -57,6 +58,7 @@ app.include_router(skills.router, prefix="/api")
 app.include_router(plugins.router, prefix="/api")
 app.include_router(admin.router, prefix="/api")
 app.include_router(teams.router, prefix="/api")
+app.include_router(invocations.router, prefix="/api")
 
 
 @app.get("/health")

--- a/apps/studio/server/routers/invocations.py
+++ b/apps/studio/server/routers/invocations.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""ADR-0020 invocations API routes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query
+
+from ..services import invocations as inv_svc
+
+router = APIRouter(prefix="/invocations", tags=["invocations"])
+
+
+@router.get("/")
+async def list_invocations(
+    skill: str | None = Query(default=None),
+    status: str | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+) -> dict[str, Any]:
+    rows = await inv_svc.list_invocations(
+        skill=skill, status=status, limit=limit, offset=offset
+    )
+    return {
+        "invocations": rows,
+        "limit": limit,
+        "offset": offset,
+        # We don't compute total separately — the page is the slice the
+        # client asked for. Studio's pagination uses has_next instead of
+        # absolute totals.
+        "has_next": len(rows) == limit,
+    }
+
+
+@router.get("/{invocation_id}")
+async def get_invocation(invocation_id: str) -> dict[str, Any]:
+    data = await inv_svc.get_invocation(invocation_id)
+    if data is None:
+        raise HTTPException(
+            status_code=404, detail=f"Invocation '{invocation_id}' not found"
+        )
+    return data

--- a/apps/studio/server/services/invocations.py
+++ b/apps/studio/server/services/invocations.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""ADR-0020 invocations service.
+
+Backs the /api/invocations endpoints. Reads from state.db's
+``invocations`` and ``sessions`` tables.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from lionagi.state.db import DEFAULT_DB_PATH, StateDB
+
+
+async def list_invocations(
+    *,
+    skill: str | None = None,
+    status: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> list[dict[str, Any]]:
+    if not DEFAULT_DB_PATH.exists():
+        return []
+    async with StateDB() as db:
+        rows = await db.list_invocations(
+            skill=skill, status=status, limit=limit, offset=offset
+        )
+    out: list[dict[str, Any]] = []
+    for r in rows:
+        node_meta = r.get("node_metadata")
+        if isinstance(node_meta, str):
+            try:
+                node_meta = json.loads(node_meta)
+            except json.JSONDecodeError:
+                node_meta = None
+        out.append(
+            {
+                "id": r["id"],
+                "skill": r["skill"],
+                "plugin": r.get("plugin"),
+                "prompt": r.get("prompt"),
+                "started_at": r["started_at"],
+                "ended_at": r.get("ended_at"),
+                "status": r["status"],
+                "session_count": r.get("session_count", 0),
+                "created_at": r["created_at"],
+                "updated_at": r["updated_at"],
+                "node_metadata": node_meta,
+            }
+        )
+    return out
+
+
+async def get_invocation(invocation_id: str) -> dict[str, Any] | None:
+    if not DEFAULT_DB_PATH.exists():
+        return None
+    async with StateDB() as db:
+        row = await db.get_invocation(invocation_id)
+        if row is None:
+            return None
+        node_meta = row.get("node_metadata")
+        if isinstance(node_meta, str):
+            try:
+                node_meta = json.loads(node_meta)
+            except json.JSONDecodeError:
+                node_meta = None
+        sessions = await db.list_sessions_for_invocation(invocation_id)
+    return {
+        "id": row["id"],
+        "skill": row["skill"],
+        "plugin": row.get("plugin"),
+        "prompt": row.get("prompt"),
+        "started_at": row["started_at"],
+        "ended_at": row.get("ended_at"),
+        "status": row["status"],
+        "session_count": row.get("session_count", 0),
+        "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
+        "node_metadata": node_meta,
+        # Sessions ordered by creation; minimal projection — Studio's
+        # session detail page is the authority for any single session.
+        "sessions": [
+            {
+                "id": s["id"],
+                "name": s.get("name"),
+                "agent_name": s.get("agent_name"),
+                "playbook_name": s.get("playbook_name"),
+                "invocation_kind": s.get("invocation_kind"),
+                "status": s.get("status"),
+                "last_message_at": s.get("last_message_at"),
+                "started_at": s.get("started_at"),
+                "ended_at": s.get("ended_at"),
+            }
+            for s in sessions
+        ],
+    }

--- a/apps/studio/server/services/runs.py
+++ b/apps/studio/server/services/runs.py
@@ -561,6 +561,8 @@ async def list_runs(
             "show_topic": s.get("show_topic"),
             "show_play_name": s.get("show_play_name"),
             "source_kind": s.get("source_kind", "live"),
+            # ADR-0020: parent skill orchestration; null when standalone.
+            "invocation_id": s.get("invocation_id"),
             "status": s.get("status", "completed"),
             "started_at": s.get("started_at"),
             "ended_at": s.get("ended_at"),

--- a/apps/studio/server/services/runs.py
+++ b/apps/studio/server/services/runs.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import math
+import time
 from pathlib import Path
 from typing import Any
 
@@ -537,8 +538,13 @@ async def list_runs(
     routers/sessions.py.  The /api/runs/{id}/events route in routers/runs.py
     is removed in the same commit.
     """
+    from lionagi.state.staleness import staleness_check
+
     sessions = await _sessions_svc.list_sessions()
     status_set = _normalize_status_filter(status)
+    # One shared "now" so two adjacent sessions can't disagree about
+    # whether the same elapsed time crossed the threshold.
+    now = time.time()
     out = []
     for s in sessions:
         if playbook and playbook.lower() not in (s.get("playbook_name") or "").lower():
@@ -560,6 +566,12 @@ async def list_runs(
             "ended_at": s.get("ended_at"),
             "created_at": s.get("created_at"),
             "updated_at": s.get("updated_at"),
+            # ADR-0019: stored marker + derived label. ``effective_health``
+            # is null for terminal sessions; ADR-0024 expands it with the
+            # full health vocabulary (idle / unresponsive / orphaned /
+            # zombie).
+            "last_message_at": s.get("last_message_at"),
+            "effective_health": staleness_check(s, now=now),
             "branch_count": s.get("branch_count", 0),
             "message_count": s.get("message_count", 0),
         })

--- a/apps/studio/server/services/sessions.py
+++ b/apps/studio/server/services/sessions.py
@@ -59,6 +59,7 @@ async def list_sessions() -> list[dict[str, Any]]:
                 s.started_at,
                 s.ended_at,
                 s.last_message_at,
+                s.invocation_id,
                 COUNT(DISTINCT b.id) AS branch_count,
                 COALESCE(SUM(
                     json_array_length(p.collection)
@@ -87,6 +88,8 @@ async def list_sessions() -> list[dict[str, Any]]:
             "ended_at": row["ended_at"],
             # ADR-0019: caller (runs service) feeds this to staleness_check.
             "last_message_at": row["last_message_at"],
+            # ADR-0020: optional parent skill orchestration.
+            "invocation_id": row["invocation_id"],
             "playbook_name": row["playbook_name"],
             "agent_name": row["agent_name"],
             "invocation_kind": row["invocation_kind"],

--- a/apps/studio/server/services/sessions.py
+++ b/apps/studio/server/services/sessions.py
@@ -58,6 +58,7 @@ async def list_sessions() -> list[dict[str, Any]]:
                 s.status,
                 s.started_at,
                 s.ended_at,
+                s.last_message_at,
                 COUNT(DISTINCT b.id) AS branch_count,
                 COALESCE(SUM(
                     json_array_length(p.collection)
@@ -84,6 +85,8 @@ async def list_sessions() -> list[dict[str, Any]]:
             "status": row["status"] or "completed",
             "started_at": row["started_at"],
             "ended_at": row["ended_at"],
+            # ADR-0019: caller (runs service) feeds this to staleness_check.
+            "last_message_at": row["last_message_at"],
             "playbook_name": row["playbook_name"],
             "agent_name": row["agent_name"],
             "invocation_kind": row["invocation_kind"],

--- a/lionagi/cli/_providers.py
+++ b/lionagi/cli/_providers.py
@@ -362,3 +362,16 @@ def add_common_cli_args(parser: argparse.ArgumentParser) -> None:
         default=None,
         help="Timeout in seconds.",
     )
+    # ADR-0020: opt-in skill-orchestration grouping. Set by a skill via
+    # ``li invoke start``; threaded through to the session row so the
+    # Studio /invocations page can show 14 sessions under one /show row.
+    parser.add_argument(
+        "--invocation",
+        dest="invocation",
+        metavar="ID",
+        default=None,
+        help=(
+            "Parent invocation id (from `li invoke start`). Groups this "
+            "session under a skill orchestration record. Optional."
+        ),
+    )

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -338,6 +338,12 @@ async def _setup_live_persist(
                     await db.append_to_progression(branch_prog_id, msg_id)
                     await db.append_to_progression(session_prog_id, msg_id)
                     ctx["new_msg_ids"].append(msg_id)
+                # ADR-0019: activity heartbeat for staleness detection.
+                # Done after the progression append so callers see the
+                # bump only once the message is committed.
+                await db.touch_session_activity(
+                    session_id, at=msg_dict.get("created_at")
+                )
                 # ADR-0009: branches.system_msg_id must track the CURRENT
                 # system message. If the runtime replaces the system mid-run
                 # (set_system), update the pointer so Studio's O(1) lookup

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -38,6 +38,7 @@ async def _run_agent(
     cwd: str | None = None,
     timeout: int | None = None,
     fast: bool = False,
+    invocation_id: str | None = None,
 ) -> tuple[str, str, str, str]:
     """Execute one agent turn (new or resumed).
 
@@ -128,6 +129,7 @@ async def _run_agent(
         branch,
         agent_name=agent_name,
         artifacts_path=str(run.artifact_root),
+        invocation_id=invocation_id,
     )
 
     # ADR-0025: distinguish timed_out / aborted / cancelled / failed so
@@ -200,6 +202,7 @@ async def _setup_live_persist(
     *,
     agent_name: str | None = None,
     artifacts_path: str | None = None,
+    invocation_id: str | None = None,
 ) -> dict | None:
     """Open DB, create session/branch rows, register live message hook.
 
@@ -284,6 +287,8 @@ async def _setup_live_persist(
                     "artifacts_path": artifacts_path,
                     "status": "running",
                     "started_at": time.time(),
+                    # ADR-0020: optional skill-level orchestration parent.
+                    "invocation_id": invocation_id,
                 }
             )
 
@@ -514,6 +519,7 @@ def run_agent(args: argparse.Namespace) -> int:
                 cwd=args.cwd,
                 timeout=args.timeout,
                 fast=args.fast,
+                invocation_id=getattr(args, "invocation", None),
             )
         )
     except KeyboardInterrupt:

--- a/lionagi/cli/invoke.py
+++ b/lionagi/cli/invoke.py
@@ -1,0 +1,232 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""`li invoke` — ADR-0020 skill-level orchestration tracking.
+
+Skills (Claude Code markdown files like ``/show`` or ``/codex-pr-review``)
+spawn many sessions over minutes-to-hours. ``li invoke`` is the
+opt-in handshake that lets them group those sessions into a single
+parent record so the Studio dashboard and the runs list can collapse
+"14 sessions" into one ``/show "resolve issues"`` row.
+
+Usage::
+
+    INV=$(li invoke start --skill show --prompt "resolve lionagi issues")
+    li play backend ... --invocation "$INV"
+    li play frontend ... --invocation "$INV"
+    li invoke end "$INV" --status completed
+
+Without ``--invocation`` the spawned sessions have ``invocation_id = NULL``,
+the same behavior as before this command existed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import uuid
+
+from ._logging import log_error
+
+# ── async helpers ─────────────────────────────────────────────────────────────
+
+
+async def _start_invocation(
+    *,
+    skill: str,
+    plugin: str | None,
+    prompt: str | None,
+    metadata: dict | None,
+) -> str:
+    from lionagi.state.db import StateDB
+
+    inv_id = uuid.uuid4().hex[:12]
+    async with StateDB() as db:
+        await db.create_invocation(
+            {
+                "id": inv_id,
+                "skill": skill,
+                "plugin": plugin,
+                "prompt": prompt,
+                "started_at": time.time(),
+                "status": "running",
+                "node_metadata": metadata,
+            }
+        )
+    return inv_id
+
+
+async def _end_invocation(
+    invocation_id: str, *, status: str, metadata: dict | None
+) -> dict | None:
+    from lionagi.state.db import StateDB
+
+    async with StateDB() as db:
+        existing = await db.get_invocation(invocation_id)
+        if existing is None:
+            return None
+        fields: dict = {"status": status, "ended_at": time.time()}
+        if metadata is not None:
+            # Merge: preserve any metadata the skill wrote during the
+            # run, overwrite per-key with the closer's payload.
+            current = existing.get("node_metadata") or {}
+            if isinstance(current, str):
+                try:
+                    current = json.loads(current)
+                except json.JSONDecodeError:
+                    current = {}
+            fields["node_metadata"] = {**current, **metadata}
+        await db.update_invocation(invocation_id, **fields)
+        return await db.get_invocation(invocation_id)
+
+
+async def _list_invocations(
+    *, skill: str | None, status: str | None, limit: int
+) -> list[dict]:
+    from lionagi.state.db import StateDB
+
+    async with StateDB() as db:
+        return await db.list_invocations(skill=skill, status=status, limit=limit)
+
+
+# ── parser + dispatch ────────────────────────────────────────────────────────
+
+
+def add_invoke_subparser(subparsers: argparse._SubParsersAction) -> None:
+    invoke = subparsers.add_parser(
+        "invoke",
+        help="Track a skill-level orchestration (ADR-0020).",
+        description=(
+            "Group sessions spawned by a skill (e.g. /show, /codex-pr-review) "
+            "into a single parent invocation record. Opt-in: sessions spawned "
+            "without --invocation continue to work exactly as before."
+        ),
+    )
+    inv_sub = invoke.add_subparsers(dest="invoke_command", required=True)
+
+    start = inv_sub.add_parser(
+        "start", help="Open a new invocation. Prints the id to stdout."
+    )
+    start.add_argument(
+        "--skill",
+        required=True,
+        help="Skill name: 'show', 'codex-pr-review', 'reprompt', etc.",
+    )
+    start.add_argument(
+        "--plugin",
+        default=None,
+        help="Marketplace plugin packaging the skill (optional).",
+    )
+    start.add_argument(
+        "--prompt",
+        default=None,
+        help="The user's input that triggered the skill (free text).",
+    )
+    start.add_argument(
+        "--metadata",
+        default=None,
+        help=(
+            "Skill-specific JSON to attach (e.g. show plan, review rounds). "
+            "Stored verbatim; rendered as-is on the invocation detail page."
+        ),
+    )
+
+    end = inv_sub.add_parser("end", help="Close an invocation.")
+    end.add_argument("invocation_id", help="The id printed by `li invoke start`.")
+    end.add_argument(
+        "--status",
+        default="completed",
+        choices=[
+            "completed", "failed", "timed_out", "aborted", "cancelled",
+        ],
+        help="Terminal status (ADR-0025 vocabulary).",
+    )
+    end.add_argument(
+        "--metadata",
+        default=None,
+        help="Optional JSON to merge into the invocation's node_metadata.",
+    )
+
+    ls = inv_sub.add_parser("list", help="List recent invocations.")
+    ls.add_argument("--skill", default=None, help="Filter by skill name.")
+    ls.add_argument(
+        "--status", default=None, help="Filter by status (one of the 6 values)."
+    )
+    ls.add_argument(
+        "--limit", type=int, default=20, help="Max rows to print (default 20)."
+    )
+
+
+def _parse_metadata(raw: str | None) -> dict | None:
+    if raw is None:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"--metadata: invalid JSON ({exc})") from exc
+    if not isinstance(parsed, dict):
+        raise SystemExit("--metadata must be a JSON object")
+    return parsed
+
+
+def run_invoke(args: argparse.Namespace) -> int:
+    from lionagi.ln.concurrency import run_async
+
+    if args.invoke_command == "start":
+        try:
+            metadata = _parse_metadata(args.metadata)
+        except SystemExit as exc:
+            log_error(str(exc))
+            return 1
+        inv_id = run_async(
+            _start_invocation(
+                skill=args.skill,
+                plugin=args.plugin,
+                prompt=args.prompt,
+                metadata=metadata,
+            )
+        )
+        # The id is the contract — print it on its own line to stdout so
+        # `$(li invoke start ...)` captures cleanly.
+        print(inv_id)
+        return 0
+
+    if args.invoke_command == "end":
+        try:
+            metadata = _parse_metadata(args.metadata)
+        except SystemExit as exc:
+            log_error(str(exc))
+            return 1
+        result = run_async(
+            _end_invocation(
+                args.invocation_id, status=args.status, metadata=metadata
+            )
+        )
+        if result is None:
+            log_error(f"invocation not found: {args.invocation_id}")
+            return 1
+        print(
+            f"{args.invocation_id}: {result['status']} "
+            f"({result['session_count']} session(s))"
+        )
+        return 0
+
+    if args.invoke_command == "list":
+        rows = run_async(
+            _list_invocations(
+                skill=args.skill, status=args.status, limit=args.limit
+            )
+        )
+        if not rows:
+            print("(no invocations)", file=sys.stderr)
+            return 0
+        for r in rows:
+            prompt = (r.get("prompt") or "").replace("\n", " ")[:60]
+            print(
+                f"{r['id']}  {r['skill']:<20}  {r['status']:<10}  "
+                f"{r['session_count']:>3}  {prompt}"
+            )
+        return 0
+
+    return 1

--- a/lionagi/cli/main.py
+++ b/lionagi/cli/main.py
@@ -20,6 +20,7 @@ import sys
 
 from ._logging import configure_cli_logging, log_error
 from .agent import add_agent_subparser, run_agent
+from .invoke import add_invoke_subparser, run_invoke
 from .orchestrate import (
     add_orchestrate_subparser,
     inject_playbook_schema_into_parser,
@@ -149,6 +150,7 @@ def main(argv: list[str] | None = None) -> int:
     add_team_subparser(sub)
     add_studio_subparser(sub)
     add_state_subparser(sub)
+    add_invoke_subparser(sub)
 
     # If the user is invoking `li o flow -p NAME`, inject the playbook's
     # declared args as flags on the flow sub-parser BEFORE argparse runs,
@@ -171,6 +173,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "state":
         return run_state(args)
+
+    if args.command == "invoke":
+        return run_invoke(args)
 
     parser.print_help()
     return 1

--- a/lionagi/cli/orchestrate/__init__.py
+++ b/lionagi/cli/orchestrate/__init__.py
@@ -696,6 +696,7 @@ def run_orchestrate(args: argparse.Namespace) -> int:
                     agent_name=args.agent,
                     fast=getattr(args, "fast", False),
                     playbook_name=getattr(args, "playbook", None),
+                    invocation_id=getattr(args, "invocation", None),
                 )
             )
         except (TimeoutError, LionTimeoutError) as e:
@@ -911,6 +912,7 @@ def run_orchestrate(args: argparse.Namespace) -> int:
                     show_graph=getattr(args, "show_graph", False),
                     fast=getattr(args, "fast", False),
                     playbook_name=playbook_name,
+                    invocation_id=getattr(args, "invocation", None),
                 )
             )
         except (TimeoutError, LionTimeoutError) as e:

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -508,6 +508,7 @@ async def start_live_persist(
     playbook_name: str | None = None,
     agent_name: str | None = None,
     artifacts_path: str | None = None,
+    invocation_id: str | None = None,
 ) -> None:
     """Open state.db, create session row, register hooks on existing branches.
 
@@ -549,6 +550,8 @@ async def start_live_persist(
                 "artifacts_path": artifacts_path,
                 "status": "running",
                 "started_at": time.time(),
+                # ADR-0020: optional skill orchestration parent
+                "invocation_id": invocation_id,
             }
         )
 

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -651,6 +651,10 @@ def _register_branch_hook(ctx: dict[str, Any], branch: Branch) -> None:
             await db.insert_message(msg_dict)
             await db.append_to_progression(branch_prog_id, msg_id)
             await db.append_to_progression(session_prog_id, msg_id)
+            # ADR-0019: activity heartbeat for staleness detection.
+            await db.touch_session_activity(
+                session_id, at=msg_dict.get("created_at")
+            )
             # ADR-0009: keep branches.system_msg_id pointing at the
             # current system if the runtime replaces it mid-flow.
             if msg_dict.get("role") == "system":

--- a/lionagi/cli/orchestrate/fanout.py
+++ b/lionagi/cli/orchestrate/fanout.py
@@ -55,6 +55,7 @@ async def _run_fanout(
     agent_name: str | None = None,
     fast: bool = False,
     playbook_name: str | None = None,
+    invocation_id: str | None = None,
 ) -> str:
     """Three-phase fan-out: decompose → fan out → synthesize."""
     env = setup_orchestration(
@@ -79,6 +80,7 @@ async def _run_fanout(
         playbook_name=playbook_name,
         agent_name=agent_name,
         artifacts_path=str(env.run.artifact_root),
+        invocation_id=invocation_id,
     )
 
     inner_kw = dict(

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -418,6 +418,7 @@ async def _run_flow(
     show_graph: bool = False,
     fast: bool = False,
     playbook_name: str | None = None,
+    invocation_id: str | None = None,
     **legacy_kwargs,
 ) -> str:
     """Auto-DAG flow: orchestrator plans DAG → engine executes with deps.
@@ -459,6 +460,7 @@ async def _run_flow(
         playbook_name=playbook_name,
         agent_name=agent_name,
         artifacts_path=str(env.run.artifact_root),
+        invocation_id=invocation_id,
     )
 
     inner_kw = dict(

--- a/lionagi/cli/state.py
+++ b/lionagi/cli/state.py
@@ -362,6 +362,113 @@ async def _import_one_run(
     return 1, total_branches, total_messages
 
 
+# ── teams import (ADR-0019) ─────────────────────────────────────────────────
+
+
+async def _import_teams() -> dict[str, int]:
+    """Backfill ~/.lionagi/teams/*.json into the teams + team_messages tables.
+
+    Idempotent: teams already present in ``teams`` (by id) are skipped along
+    with their messages. JSON files remain the runtime's primary write path
+    until the dual-write layer ships.
+    """
+    from lionagi.state.db import StateDB
+
+    teams_dir = (RUNS_ROOT.parent / "teams").resolve()
+    counts = {"teams": 0, "messages": 0, "skipped_teams": 0, "errors": 0}
+    if not teams_dir.exists():
+        return counts
+
+    json_files = sorted(teams_dir.glob("*.json"))
+    if not json_files:
+        return counts
+
+    async with StateDB() as db:
+        for path in json_files:
+            try:
+                data = json.loads(path.read_text())
+            except (OSError, json.JSONDecodeError):
+                counts["errors"] += 1
+                continue
+            team_id = data.get("id")
+            if not team_id:
+                counts["errors"] += 1
+                continue
+
+            # Idempotency: check before inserting.
+            cur = await db.db.execute(
+                "SELECT 1 FROM teams WHERE id = ? LIMIT 1", (team_id,)
+            )
+            if await cur.fetchone() is not None:
+                counts["skipped_teams"] += 1
+                continue
+
+            members = data.get("members") or []
+            created_at = _mtime_as_float(path)
+            await db.db.execute(
+                """INSERT INTO teams
+                   (id, name, created_at, updated_at, member_count, members, status)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    team_id,
+                    data.get("name") or team_id,
+                    created_at,
+                    created_at,
+                    len(members),
+                    json.dumps(members),
+                    "active",
+                ),
+            )
+            counts["teams"] += 1
+
+            for msg in data.get("messages") or []:
+                msg_id = msg.get("id") or uuid.uuid4().hex[:12]
+                to = msg.get("to") or []
+                recipient = "all" if to == ["*"] else ",".join(to) or "all"
+                content = msg.get("content") or ""
+                ts_raw = msg.get("timestamp")
+                # JSON stores ISO timestamps; the DB stores REAL epoch
+                # seconds. Best-effort parse; fall back to file mtime so
+                # ordering is at least monotonic per file.
+                try:
+                    from datetime import datetime
+
+                    created = datetime.fromisoformat(ts_raw).timestamp()
+                except (TypeError, ValueError):
+                    created = created_at
+                read_by = msg.get("read_by") or {}
+                if isinstance(read_by, dict):
+                    read_by_arr = sorted(read_by.keys())
+                elif isinstance(read_by, list):
+                    read_by_arr = list(read_by)
+                else:
+                    read_by_arr = []
+                await db.db.execute(
+                    """INSERT INTO team_messages
+                       (id, team_id, created_at, sender, recipient, content,
+                        summary, read_by, session_id)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        msg_id,
+                        team_id,
+                        created,
+                        msg.get("from") or "_unknown",
+                        recipient,
+                        content,
+                        # Only set summary for long content; leave NULL otherwise
+                        # so the Studio teams page knows to show raw inline.
+                        (content[:200] + "…") if len(content) > 200 else None,
+                        json.dumps(read_by_arr),
+                        None,
+                    ),
+                )
+                counts["messages"] += 1
+
+        await db.db.commit()
+
+    return counts
+
+
 # ── async ls logic ────────────────────────────────────────────────────────────
 
 
@@ -697,6 +804,19 @@ def add_state_subparser(subparsers: argparse._SubParsersAction) -> None:
         ),
     )
 
+    # li state import-teams (ADR-0019)
+    state_sub.add_parser(
+        "import-teams",
+        help="Backfill team JSON files (~/.lionagi/teams/*.json) into state.db.",
+        description=(
+            "Scan ~/.lionagi/teams/*.json and INSERT each team + its messages "
+            "into the `teams` and `team_messages` tables (ADR-0019). Idempotent: "
+            "existing rows (matched by team id) are left alone. Run once after "
+            "upgrading; the runtime can keep using JSON until the dual-write "
+            "path ships."
+        ),
+    )
+
     # li state ls
     ls = state_sub.add_parser(
         "ls",
@@ -828,6 +948,15 @@ def run_state(args: argparse.Namespace) -> int:
             f"{counts['branches']} branch(es), "
             f"{counts['messages']} message(s) "
             f"[skipped={counts['skipped']}, errors={counts['errors']}]"
+        )
+        return 0 if counts["errors"] == 0 else 1
+
+    if args.state_command == "import-teams":
+        counts = run_async(_import_teams())
+        print(
+            f"\nimported {counts['teams']} team(s), "
+            f"{counts['messages']} team message(s) "
+            f"[skipped_teams={counts['skipped_teams']}, errors={counts['errors']}]"
         )
         return 0 if counts["errors"] == 0 else 1
 

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -35,6 +35,10 @@ _SESSION_COLUMNS = frozenset(
         "status",
         "started_at",
         "ended_at",
+        # ADR-0019: activity marker for staleness detection. Bumped on
+        # every message INSERT so a session that hasn't produced output
+        # in N hours is detectably stale without scanning ``messages``.
+        "last_message_at",
     }
 )
 
@@ -297,6 +301,8 @@ class StateDB:
             ("status", "TEXT"),
             ("started_at", "REAL"),
             ("ended_at", "REAL"),
+            # ADR-0019: activity marker for staleness detection.
+            ("last_message_at", "REAL"),
         ],
         "branches": [
             ("system_msg_id", "TEXT"),
@@ -397,7 +403,8 @@ class StateDB:
                                   ),
                   status          TEXT,
                   started_at      REAL,
-                  ended_at        REAL
+                  ended_at        REAL,
+                  last_message_at REAL
                 )
                 """
             )
@@ -591,8 +598,8 @@ class StateDB:
                progression_id, first_msg_id, last_msg_id, updated_at,
                playbook_name, agent_name, invocation_kind, show_topic,
                show_play_name, artifacts_path, source_kind,
-               status, started_at, ended_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+               status, started_at, ended_at, last_message_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 session["id"],
                 session.get("created_at", now),
@@ -615,6 +622,10 @@ class StateDB:
                 session.get("status"),
                 session.get("started_at"),
                 session.get("ended_at"),
+                # ADR-0019: initialize last_message_at to session start so
+                # a freshly-created session that has produced no messages
+                # yet isn't immediately classified stale.
+                session.get("last_message_at", session.get("started_at", now)),
             ),
         )
         await self.db.commit()
@@ -625,6 +636,24 @@ class StateDB:
         )
         row = await cur.fetchone()
         return self._row_to_dict(row) if row else None
+
+    async def touch_session_activity(
+        self, session_id: str, *, at: float | None = None
+    ) -> None:
+        """Bump ``last_message_at`` (and ``updated_at``) for staleness signal.
+
+        ADR-0019: stored at write time so the runs list and dashboard can
+        compute staleness with one indexed read instead of scanning
+        messages. ``at`` lets the caller pass the message timestamp for
+        precision; callers without one let it default to ``time.time()``.
+        """
+        ts = at if at is not None else time.time()
+        await self.db.execute(
+            "UPDATE sessions SET last_message_at = ?, updated_at = ? "
+            "WHERE id = ?",
+            (ts, ts, session_id),
+        )
+        await self.db.commit()
 
     async def update_session(self, session_id: str, **fields: Any) -> None:
         _validate_columns(fields, _SESSION_COLUMNS)

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -39,6 +39,30 @@ _SESSION_COLUMNS = frozenset(
         # every message INSERT so a session that hasn't produced output
         # in N hours is detectably stale without scanning ``messages``.
         "last_message_at",
+        # ADR-0020: optional FK to the skill orchestration that spawned
+        # this session (e.g. a /show invocation grouping its plays).
+        "invocation_id",
+    }
+)
+
+# ADR-0020: invocation lifecycle vocabulary — narrower than session
+# status (no 'aborted_after_finish') but otherwise shares the ADR-0025
+# terminal set. The schema CHECK is in schema.sql; this set lets the
+# Python helpers validate updates symmetrically.
+_INVOCATION_STATUSES = frozenset(
+    {"running", "completed", "failed", "timed_out", "aborted", "cancelled"}
+)
+_INVOCATION_COLUMNS = frozenset(
+    {
+        "skill",
+        "plugin",
+        "prompt",
+        "started_at",
+        "ended_at",
+        "status",
+        "session_count",
+        "updated_at",
+        "node_metadata",
     }
 )
 
@@ -303,6 +327,8 @@ class StateDB:
             ("ended_at", "REAL"),
             # ADR-0019: activity marker for staleness detection.
             ("last_message_at", "REAL"),
+            # ADR-0020: optional FK to invocations table.
+            ("invocation_id", "TEXT"),
         ],
         "branches": [
             ("system_msg_id", "TEXT"),
@@ -404,7 +430,8 @@ class StateDB:
                   status          TEXT,
                   started_at      REAL,
                   ended_at        REAL,
-                  last_message_at REAL
+                  last_message_at REAL,
+                  invocation_id   TEXT
                 )
                 """
             )
@@ -598,8 +625,8 @@ class StateDB:
                progression_id, first_msg_id, last_msg_id, updated_at,
                playbook_name, agent_name, invocation_kind, show_topic,
                show_play_name, artifacts_path, source_kind,
-               status, started_at, ended_at, last_message_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+               status, started_at, ended_at, last_message_at, invocation_id)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 session["id"],
                 session.get("created_at", now),
@@ -626,8 +653,19 @@ class StateDB:
                 # a freshly-created session that has produced no messages
                 # yet isn't immediately classified stale.
                 session.get("last_message_at", session.get("started_at", now)),
+                # ADR-0020: optional FK to invocations(id). NULL when the
+                # session was spawned standalone (no `li invoke start`).
+                session.get("invocation_id"),
             ),
         )
+        # ADR-0020: keep invocations.session_count in sync so list queries
+        # don't need a JOIN.
+        if session.get("invocation_id"):
+            await self.db.execute(
+                "UPDATE invocations SET session_count = session_count + 1, "
+                "updated_at = ? WHERE id = ?",
+                (now, session["invocation_id"]),
+            )
         await self.db.commit()
 
     async def get_session(self, session_id: str) -> dict[str, Any] | None:
@@ -710,6 +748,112 @@ class StateDB:
             cur = await self.db.execute("SELECT COUNT(*) AS n FROM sessions")
         row = await cur.fetchone()
         return row["n"]
+
+    # ── Invocations (ADR-0020) ──────────────────────────────────────────
+
+    async def create_invocation(self, invocation: dict[str, Any]) -> None:
+        """Insert an invocation row (skill-level orchestration record).
+
+        Called by ``li invoke start``. Required keys: ``id``, ``skill``,
+        ``started_at``. Optional: ``plugin``, ``prompt``, ``status``,
+        ``node_metadata``.
+        """
+        status = invocation.get("status", "running")
+        _validate_enum(
+            "status",
+            status,
+            _INVOCATION_STATUSES,
+            adr="ADR-0020",
+            nullable=False,
+        )
+        now = time.time()
+        await self.db.execute(
+            """INSERT OR IGNORE INTO invocations
+               (id, skill, plugin, prompt, started_at, ended_at, status,
+                session_count, created_at, updated_at, node_metadata)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                invocation["id"],
+                invocation["skill"],
+                invocation.get("plugin"),
+                invocation.get("prompt"),
+                invocation["started_at"],
+                invocation.get("ended_at"),
+                status,
+                invocation.get("session_count", 0),
+                invocation.get("created_at", now),
+                invocation.get("updated_at", now),
+                _to_json_column(invocation.get("node_metadata")),
+            ),
+        )
+        await self.db.commit()
+
+    async def update_invocation(
+        self, invocation_id: str, **fields: Any
+    ) -> None:
+        _validate_columns(fields, _INVOCATION_COLUMNS)
+        if "status" in fields:
+            _validate_enum(
+                "status",
+                fields["status"],
+                _INVOCATION_STATUSES,
+                adr="ADR-0020",
+                nullable=False,
+            )
+        if "node_metadata" in fields:
+            fields["node_metadata"] = _to_json_column(fields["node_metadata"])
+        fields["updated_at"] = time.time()
+        sets = ", ".join(f"{k} = ?" for k in fields)
+        vals = list(fields.values()) + [invocation_id]
+        # columns validated above; SQL is identifier-only interpolation.
+        update_sql = f"UPDATE invocations SET {sets} WHERE id = ?"  # noqa: S608
+        await self.db.execute(update_sql, vals)
+        await self.db.commit()
+
+    async def get_invocation(
+        self, invocation_id: str
+    ) -> dict[str, Any] | None:
+        cur = await self.db.execute(
+            "SELECT * FROM invocations WHERE id = ?", (invocation_id,)
+        )
+        row = await cur.fetchone()
+        return self._row_to_dict(row) if row else None
+
+    async def list_invocations(
+        self,
+        *,
+        skill: str | None = None,
+        status: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        query = "SELECT * FROM invocations"
+        conds: list[str] = []
+        params: list[Any] = []
+        if skill:
+            conds.append("skill = ?")
+            params.append(skill)
+        if status:
+            conds.append("status = ?")
+            params.append(status)
+        if conds:
+            query += " WHERE " + " AND ".join(conds)
+        query += " ORDER BY updated_at DESC LIMIT ? OFFSET ?"
+        params.extend([limit, offset])
+        cur = await self.db.execute(query, params)
+        rows = await cur.fetchall()
+        return [self._row_to_dict(r) for r in rows]
+
+    async def list_sessions_for_invocation(
+        self, invocation_id: str
+    ) -> list[dict[str, Any]]:
+        cur = await self.db.execute(
+            "SELECT * FROM sessions WHERE invocation_id = ? "
+            "ORDER BY created_at ASC",
+            (invocation_id,),
+        )
+        rows = await cur.fetchall()
+        return [self._row_to_dict(r) for r in rows]
 
     # ── Branches ───────────────────────────────────────────────────────
 

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -112,7 +112,13 @@ CREATE TABLE IF NOT EXISTS sessions (
   -- ── Activity (ADR-0019) ────────────────────────────────────────────
   -- Bumped on every message INSERT so staleness_check() can answer
   -- "is this running session still active?" without scanning messages.
-  last_message_at REAL
+  last_message_at REAL,
+  -- ── Skill invocation (ADR-0020) ────────────────────────────────────
+  -- Optional FK to the higher-order skill orchestration (e.g. /show or
+  -- /codex-pr-review) that spawned this session. NULL when the CLI
+  -- ran standalone. Orthogonal to invocation_kind, which describes the
+  -- CLI primitive (agent / play / flow / fanout / show-play).
+  invocation_id   TEXT    REFERENCES invocations(id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_sessions_updated
@@ -121,6 +127,9 @@ CREATE INDEX IF NOT EXISTS idx_sessions_updated
 -- activity) skip the full table scan.
 CREATE INDEX IF NOT EXISTS idx_sessions_status_last_msg
   ON sessions(status, last_message_at) WHERE status = 'running';
+-- ADR-0020: grouped runs view fetches all sessions for an invocation.
+CREATE INDEX IF NOT EXISTS idx_sessions_invocation
+  ON sessions(invocation_id) WHERE invocation_id IS NOT NULL;
 
 -- ── Branches ──────────────────────────────────────────────────────────────
 -- A progression with identity.  Branch config (provider, model,
@@ -259,3 +268,30 @@ CREATE INDEX IF NOT EXISTS idx_team_msgs_team ON team_messages(team_id);
 CREATE INDEX IF NOT EXISTS idx_team_msgs_created ON team_messages(created_at);
 CREATE INDEX IF NOT EXISTS idx_team_msgs_session ON team_messages(session_id)
   WHERE session_id IS NOT NULL;
+
+-- ── Invocations (ADR-0020) ───────────────────────────────────────────────
+-- Skill-level orchestration records. One invocation row per /show,
+-- /codex-pr-review, etc., aggregating the N sessions that the skill
+-- spawned. invocation_id is FK'd from sessions; invocation_kind on
+-- sessions remains the CLI primitive (agent/play/flow/...).
+
+CREATE TABLE IF NOT EXISTS invocations (
+  id              TEXT    PRIMARY KEY,
+  skill           TEXT    NOT NULL,
+  plugin          TEXT,
+  prompt          TEXT,
+  started_at      REAL    NOT NULL,
+  ended_at        REAL,
+  status          TEXT    NOT NULL DEFAULT 'running' CHECK(
+                    status IN ('running', 'completed', 'failed',
+                               'timed_out', 'aborted', 'cancelled')
+                  ),
+  session_count   INTEGER NOT NULL DEFAULT 0,
+  created_at      REAL    NOT NULL,
+  updated_at      REAL    NOT NULL,
+  node_metadata   JSON
+);
+
+CREATE INDEX IF NOT EXISTS idx_invocations_skill ON invocations(skill);
+CREATE INDEX IF NOT EXISTS idx_invocations_status ON invocations(status);
+CREATE INDEX IF NOT EXISTS idx_invocations_updated ON invocations(updated_at DESC);

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -108,11 +108,19 @@ CREATE TABLE IF NOT EXISTS sessions (
   -- cancelled) can evolve without a SQLite table rebuild.
   status          TEXT,
   started_at      REAL,
-  ended_at        REAL
+  ended_at        REAL,
+  -- ── Activity (ADR-0019) ────────────────────────────────────────────
+  -- Bumped on every message INSERT so staleness_check() can answer
+  -- "is this running session still active?" without scanning messages.
+  last_message_at REAL
 );
 
 CREATE INDEX IF NOT EXISTS idx_sessions_updated
   ON sessions(updated_at DESC);
+-- ADR-0019: lets the staleness query (running sessions sorted by oldest
+-- activity) skip the full table scan.
+CREATE INDEX IF NOT EXISTS idx_sessions_status_last_msg
+  ON sessions(status, last_message_at) WHERE status = 'running';
 
 -- ── Branches ──────────────────────────────────────────────────────────────
 -- A progression with identity.  Branch config (provider, model,
@@ -211,3 +219,43 @@ CREATE INDEX IF NOT EXISTS idx_plays_show ON plays(show_id);
 CREATE INDEX IF NOT EXISTS idx_plays_status ON plays(status);
 CREATE INDEX IF NOT EXISTS idx_plays_session ON plays(session_id);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_plays_show_name ON plays(show_id, name);
+
+-- ── Teams (ADR-0019) ─────────────────────────────────────────────────────
+-- Mirrors the JSON files at ~/.lionagi/teams/{id}.json (still primary
+-- write path; populated via dual-write or `li state import-teams`).
+-- Storing teams in the DB unlocks queries, cross-session linkage, and
+-- replaces the file-only model that doesn't compose with async DB code.
+
+CREATE TABLE IF NOT EXISTS teams (
+  id              TEXT    PRIMARY KEY,
+  name            TEXT    NOT NULL,
+  created_at      REAL    NOT NULL,
+  updated_at      REAL    NOT NULL,
+  member_count    INTEGER NOT NULL DEFAULT 0,
+  members         JSON    NOT NULL DEFAULT '[]',
+  node_metadata   JSON,
+  status          TEXT    NOT NULL DEFAULT 'active' CHECK(
+                    status IN ('active', 'archived')
+                  )
+);
+
+CREATE INDEX IF NOT EXISTS idx_teams_name ON teams(name);
+CREATE INDEX IF NOT EXISTS idx_teams_updated ON teams(updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_teams_status ON teams(status);
+
+CREATE TABLE IF NOT EXISTS team_messages (
+  id              TEXT    PRIMARY KEY,
+  team_id         TEXT    NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  created_at      REAL    NOT NULL,
+  sender          TEXT    NOT NULL,
+  recipient       TEXT    NOT NULL DEFAULT 'all',
+  content         TEXT    NOT NULL,
+  summary         TEXT,
+  read_by         JSON    NOT NULL DEFAULT '[]',
+  session_id      TEXT    REFERENCES sessions(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_team_msgs_team ON team_messages(team_id);
+CREATE INDEX IF NOT EXISTS idx_team_msgs_created ON team_messages(created_at);
+CREATE INDEX IF NOT EXISTS idx_team_msgs_session ON team_messages(session_id)
+  WHERE session_id IS NOT NULL;

--- a/lionagi/state/staleness.py
+++ b/lionagi/state/staleness.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""ADR-0019: run staleness detection.
+
+Staleness is a **derived health indicator**, not a stored DB status.
+The runs list and dashboard compute it at read time from each session's
+``last_message_at`` and a kind-aware threshold. ADR-0024 layers the full
+health classification (idle / unresponsive / stale / orphaned / zombie)
+on top of this primitive.
+
+Why kind-aware: a single-agent run with zero messages for 6 hours is
+dead; a 10-agent flow legitimately runs that long. The thresholds let
+operators distinguish "actually stuck" from "still working."
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+# Per-invocation_kind activity thresholds (seconds). Single-shot runs
+# are tight; multi-agent flows get headroom.
+STALE_THRESHOLDS: dict[str, int] = {
+    "agent": 6 * 3600,        # 6h — single agent
+    "play": 6 * 3600,         # 6h — single-play run
+    "flow": 12 * 3600,        # 12h — multi-agent DAG
+    "fanout": 12 * 3600,      # 12h — parallel fanout
+    "show-play": 12 * 3600,   # 12h — show-managed plays
+}
+DEFAULT_STALE_THRESHOLD: int = 6 * 3600
+
+
+def staleness_check(
+    session: dict[str, Any], *, now: float | None = None
+) -> str | None:
+    """Return ``"stale"`` if ``session`` is running past its activity threshold.
+
+    Returns ``None`` for terminal sessions — ADR-0024's
+    ``classify_session_health`` handles those (a ``completed`` session
+    with stale locks is ``zombie``, not stale).
+
+    The threshold lookup keys on ``invocation_kind``; missing/unknown
+    kinds get :data:`DEFAULT_STALE_THRESHOLD`. ``last_message_at`` is
+    preferred over ``updated_at`` because metadata writes shouldn't
+    masquerade as activity. Both falling back to ``0`` means a session
+    with no activity columns is always stale relative to ``now`` —
+    the desired behavior for legacy rows that never wrote either.
+    """
+    if session.get("status") != "running":
+        return None
+    threshold = STALE_THRESHOLDS.get(
+        session.get("invocation_kind"), DEFAULT_STALE_THRESHOLD
+    )
+    last_activity = (
+        session.get("last_message_at")
+        or session.get("updated_at")
+        or 0
+    )
+    ts = now if now is not None else time.time()
+    if ts - last_activity > threshold:
+        return "stale"
+    return None
+
+
+def threshold_for_kind(invocation_kind: str | None) -> int:
+    """Public lookup so callers can show "stale > 6h" in tooltips."""
+    if invocation_kind is None:
+        return DEFAULT_STALE_THRESHOLD
+    return STALE_THRESHOLDS.get(invocation_kind, DEFAULT_STALE_THRESHOLD)

--- a/tests/state/test_invocations.py
+++ b/tests/state/test_invocations.py
@@ -1,0 +1,169 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""ADR-0020 invocations table tests.
+
+Covers: CRUD lifecycle, session_count denormalization, session ↔
+invocation linkage, validation of the status vocabulary, and list /
+filter behavior used by /api/invocations.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import pytest
+
+from lionagi.state.db import _INVOCATION_STATUSES, StateDB
+
+
+@pytest.fixture
+async def db():
+    state = StateDB(":memory:")
+    await state.open()
+    yield state
+    await state.close()
+
+
+def _uid() -> str:
+    return str(uuid.uuid4())
+
+
+def _short_id() -> str:
+    return uuid.uuid4().hex[:12]
+
+
+async def _make_invocation(db: StateDB, **fields) -> dict:
+    inv = {
+        "id": _short_id(),
+        "skill": fields.pop("skill", "show"),
+        "started_at": fields.pop("started_at", time.time()),
+        **fields,
+    }
+    await db.create_invocation(inv)
+    return inv
+
+
+async def _make_session(
+    db: StateDB, *, invocation_id: str | None = None, **fields
+) -> dict:
+    prog_id = _uid()
+    await db.create_progression(prog_id)
+    session = {
+        "id": _uid(),
+        "progression_id": prog_id,
+        "invocation_id": invocation_id,
+        **fields,
+    }
+    await db.create_session(session)
+    return session
+
+
+# ── Vocabulary ────────────────────────────────────────────────────────────────
+
+
+def test_invocation_status_vocabulary_matches_adr0025():
+    """Invocations share the ADR-0025 terminal set + 'running'."""
+    assert _INVOCATION_STATUSES == frozenset(
+        {"running", "completed", "failed", "timed_out", "aborted", "cancelled"}
+    )
+
+
+# ── CRUD ──────────────────────────────────────────────────────────────────────
+
+
+async def test_create_and_get_invocation(db: StateDB):
+    inv = await _make_invocation(
+        db,
+        skill="show",
+        plugin="show",
+        prompt="resolve lionagi issues",
+        node_metadata={"plays": []},
+    )
+    fetched = await db.get_invocation(inv["id"])
+    assert fetched["id"] == inv["id"]
+    assert fetched["skill"] == "show"
+    assert fetched["plugin"] == "show"
+    assert fetched["prompt"] == "resolve lionagi issues"
+    assert fetched["status"] == "running"
+    assert fetched["session_count"] == 0
+
+
+async def test_update_invocation_status_terminal(db: StateDB):
+    inv = await _make_invocation(db)
+    await db.update_invocation(inv["id"], status="completed", ended_at=time.time())
+    fetched = await db.get_invocation(inv["id"])
+    assert fetched["status"] == "completed"
+    assert fetched["ended_at"] is not None
+
+
+async def test_update_invocation_rejects_unknown_status(db: StateDB):
+    inv = await _make_invocation(db)
+    with pytest.raises(ValueError, match="ADR-0020"):
+        await db.update_invocation(inv["id"], status="stale")
+
+
+async def test_update_invocation_rejects_unknown_column(db: StateDB):
+    inv = await _make_invocation(db)
+    with pytest.raises(ValueError, match="Invalid column"):
+        await db.update_invocation(inv["id"], not_a_column="x")
+
+
+# ── Session linkage ───────────────────────────────────────────────────────────
+
+
+async def test_create_session_with_invocation_bumps_count(db: StateDB):
+    """ADR-0020: invocations.session_count tracks attached sessions
+    via the create_session denormalized increment."""
+    inv = await _make_invocation(db)
+    await _make_session(db, invocation_id=inv["id"], status="running")
+    await _make_session(db, invocation_id=inv["id"], status="running")
+    await _make_session(db, invocation_id=None, status="running")  # standalone
+
+    fetched = await db.get_invocation(inv["id"])
+    assert fetched["session_count"] == 2
+
+
+async def test_list_sessions_for_invocation_orders_by_created(db: StateDB):
+    inv = await _make_invocation(db)
+    s1 = await _make_session(
+        db, invocation_id=inv["id"], status="running",
+    )
+    s2 = await _make_session(
+        db, invocation_id=inv["id"], status="completed",
+    )
+    rows = await db.list_sessions_for_invocation(inv["id"])
+    assert [r["id"] for r in rows] == [s1["id"], s2["id"]]
+
+
+async def test_session_without_invocation_id_is_unaffected(db: StateDB):
+    """Sessions with no invocation_id continue to work — backward-compat."""
+    s = await _make_session(db, invocation_id=None, status="running")
+    fetched = await db.get_session(s["id"])
+    assert fetched["invocation_id"] is None
+
+
+# ── List + filter ─────────────────────────────────────────────────────────────
+
+
+async def test_list_invocations_filters_by_skill(db: StateDB):
+    await _make_invocation(db, skill="show")
+    await _make_invocation(db, skill="codex-pr-review")
+    await _make_invocation(db, skill="show")
+
+    only_show = await db.list_invocations(skill="show")
+    assert len(only_show) == 2
+    assert all(r["skill"] == "show" for r in only_show)
+
+
+async def test_list_invocations_filters_by_status(db: StateDB):
+    a = await _make_invocation(db)
+    b = await _make_invocation(db)
+    await db.update_invocation(a["id"], status="completed", ended_at=time.time())
+
+    running_only = await db.list_invocations(status="running")
+    assert {r["id"] for r in running_only} == {b["id"]}
+
+    done_only = await db.list_invocations(status="completed")
+    assert {r["id"] for r in done_only} == {a["id"]}

--- a/tests/state/test_staleness.py
+++ b/tests/state/test_staleness.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""ADR-0019 staleness detection tests.
+
+Covers: kind-aware thresholds, terminal sessions are non-stale,
+last_message_at preferred over updated_at, touch_session_activity()
+heartbeat.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import pytest
+
+from lionagi.state.db import StateDB
+from lionagi.state.staleness import (
+    DEFAULT_STALE_THRESHOLD,
+    STALE_THRESHOLDS,
+    staleness_check,
+    threshold_for_kind,
+)
+
+
+@pytest.fixture
+async def db():
+    state = StateDB(":memory:")
+    await state.open()
+    yield state
+    await state.close()
+
+
+def _uid() -> str:
+    return str(uuid.uuid4())
+
+
+async def _make_session(db: StateDB, **fields) -> dict:
+    prog_id = _uid()
+    await db.create_progression(prog_id)
+    session = {"id": _uid(), "progression_id": prog_id, **fields}
+    await db.create_session(session)
+    return session
+
+
+# ── staleness_check pure logic ─────────────────────────────────────────────────
+
+
+def test_running_under_threshold_is_active():
+    now = 1_000_000.0
+    session = {
+        "status": "running",
+        "invocation_kind": "agent",
+        "last_message_at": now - 1_000,  # ~17 minutes ago, well under 6h
+    }
+    assert staleness_check(session, now=now) is None
+
+
+def test_running_over_agent_threshold_is_stale():
+    now = 1_000_000.0
+    session = {
+        "status": "running",
+        "invocation_kind": "agent",
+        "last_message_at": now - (6 * 3600 + 60),  # 6h 1m
+    }
+    assert staleness_check(session, now=now) == "stale"
+
+
+def test_flow_threshold_is_more_lenient_than_agent():
+    """A 9h-quiet single agent is stale; a 9h-quiet flow is still active."""
+    now = 1_000_000.0
+    nine_hours_ago = now - (9 * 3600)
+    agent = {
+        "status": "running",
+        "invocation_kind": "agent",
+        "last_message_at": nine_hours_ago,
+    }
+    flow = {
+        "status": "running",
+        "invocation_kind": "flow",
+        "last_message_at": nine_hours_ago,
+    }
+    assert staleness_check(agent, now=now) == "stale"
+    assert staleness_check(flow, now=now) is None
+
+
+def test_terminal_status_is_not_stale():
+    """ADR-0019 defers terminal-session classification to ADR-0024's health."""
+    now = 1_000_000.0
+    for status in ("completed", "failed", "timed_out", "aborted", "cancelled"):
+        s = {
+            "status": status,
+            "invocation_kind": "agent",
+            "last_message_at": now - (100 * 3600),
+        }
+        assert staleness_check(s, now=now) is None, f"{status!r} should not be stale"
+
+
+def test_unknown_invocation_kind_falls_back_to_default():
+    now = 1_000_000.0
+    session = {
+        "status": "running",
+        "invocation_kind": "mystery-kind",
+        "last_message_at": now - (DEFAULT_STALE_THRESHOLD + 60),
+    }
+    assert staleness_check(session, now=now) == "stale"
+
+
+def test_missing_last_message_at_falls_back_to_updated_at():
+    now = 1_000_000.0
+    session = {
+        "status": "running",
+        "invocation_kind": "agent",
+        "last_message_at": None,
+        "updated_at": now - (6 * 3600 + 60),
+    }
+    assert staleness_check(session, now=now) == "stale"
+
+
+def test_session_with_no_activity_columns_is_stale():
+    """Legacy rows with neither last_message_at nor updated_at — definitely dead."""
+    now = 1_000_000.0
+    session = {"status": "running", "invocation_kind": "agent"}
+    assert staleness_check(session, now=now) == "stale"
+
+
+def test_threshold_for_kind_returns_expected_values():
+    assert threshold_for_kind("agent") == 6 * 3600
+    assert threshold_for_kind("flow") == 12 * 3600
+    assert threshold_for_kind(None) == DEFAULT_STALE_THRESHOLD
+    assert threshold_for_kind("mystery-kind") == DEFAULT_STALE_THRESHOLD
+
+
+# ── touch_session_activity DB heartbeat ────────────────────────────────────────
+
+
+async def test_touch_session_activity_bumps_last_message_at(db: StateDB):
+    s = await _make_session(db, status="running", invocation_kind="agent")
+    before = time.time()
+    await db.touch_session_activity(s["id"])
+    after = time.time()
+    row = await db.get_session(s["id"])
+    assert before <= row["last_message_at"] <= after
+
+
+async def test_touch_session_activity_with_explicit_at(db: StateDB):
+    s = await _make_session(db, status="running", invocation_kind="agent")
+    pinned = 1_700_000_000.0
+    await db.touch_session_activity(s["id"], at=pinned)
+    row = await db.get_session(s["id"])
+    assert row["last_message_at"] == pinned
+
+
+async def test_touch_updates_updated_at_too(db: StateDB):
+    """updated_at and last_message_at move together so list ordering stays
+    consistent with activity, not just lifecycle writes."""
+    s = await _make_session(db, status="running", invocation_kind="agent")
+    pinned = 1_700_000_000.0
+    await db.touch_session_activity(s["id"], at=pinned)
+    row = await db.get_session(s["id"])
+    assert row["updated_at"] == pinned
+
+
+# ── ADR scope check: thresholds dict shape ────────────────────────────────────
+
+
+def test_thresholds_cover_all_invocation_kinds():
+    """ADR-0012 invocation_kind vocabulary must all have explicit thresholds.
+
+    A missing kind silently falls back to DEFAULT_STALE_THRESHOLD, which
+    is correct *behavior* but indicates the ADR was updated without
+    updating thresholds. Catch the drift here.
+    """
+    from lionagi.state.db import _INVOCATION_KINDS
+
+    missing = _INVOCATION_KINDS - STALE_THRESHOLDS.keys()
+    assert not missing, f"invocation_kinds without explicit threshold: {missing}"

--- a/tests/state/test_teams_schema.py
+++ b/tests/state/test_teams_schema.py
@@ -1,0 +1,212 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""ADR-0019 teams + team_messages schema tests.
+
+The runtime still writes JSON; this PR adds the DB shape and the
+``li state import-teams`` backfill. Tests cover schema constraints,
+FK cascade behavior, and the import path.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+from lionagi.state.db import StateDB
+
+
+@pytest.fixture
+async def db():
+    state = StateDB(":memory:")
+    await state.open()
+    yield state
+    await state.close()
+
+
+# ── Schema invariants ─────────────────────────────────────────────────────────
+
+
+async def test_teams_table_exists_with_status_check(db: StateDB):
+    """Schema CHECK accepts 'active' / 'archived' and rejects others."""
+    await db.db.execute(
+        "INSERT INTO teams (id, name, created_at, updated_at, status) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("t1", "team-one", 1.0, 1.0, "active"),
+    )
+    await db.db.execute(
+        "INSERT INTO teams (id, name, created_at, updated_at, status) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("t2", "team-two", 1.0, 1.0, "archived"),
+    )
+
+    import sqlite3
+
+    with pytest.raises(sqlite3.IntegrityError):
+        await db.db.execute(
+            "INSERT INTO teams (id, name, created_at, updated_at, status) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("t3", "team-three", 1.0, 1.0, "frozen"),
+        )
+
+
+async def test_team_messages_cascade_on_team_delete(db: StateDB):
+    await db.db.execute(
+        "INSERT INTO teams (id, name, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?)",
+        ("t1", "team-one", 1.0, 1.0),
+    )
+    await db.db.execute(
+        "INSERT INTO team_messages (id, team_id, created_at, sender, content) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("m1", "t1", 1.0, "alice", "hello"),
+    )
+    await db.db.commit()
+
+    cur = await db.db.execute("SELECT COUNT(*) AS n FROM team_messages")
+    assert (await cur.fetchone())["n"] == 1
+
+    await db.db.execute("DELETE FROM teams WHERE id = ?", ("t1",))
+    await db.db.commit()
+
+    cur = await db.db.execute("SELECT COUNT(*) AS n FROM team_messages")
+    assert (await cur.fetchone())["n"] == 0, (
+        "team_messages should cascade-delete when their team is removed"
+    )
+
+
+async def test_team_messages_session_id_fk_to_sessions(db: StateDB):
+    """team_messages.session_id may reference a session row (optional FK)."""
+    prog_id = str(uuid.uuid4())
+    sess_id = str(uuid.uuid4())
+    await db.create_progression(prog_id)
+    await db.create_session(
+        {"id": sess_id, "progression_id": prog_id, "status": "running"}
+    )
+
+    await db.db.execute(
+        "INSERT INTO teams (id, name, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?)",
+        ("t1", "team-one", 1.0, 1.0),
+    )
+    await db.db.execute(
+        "INSERT INTO team_messages (id, team_id, created_at, sender, content, session_id) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        ("m1", "t1", 1.0, "alice", "hello", sess_id),
+    )
+    await db.db.commit()
+
+    cur = await db.db.execute(
+        "SELECT session_id FROM team_messages WHERE id = ?", ("m1",)
+    )
+    row = await cur.fetchone()
+    assert row["session_id"] == sess_id
+
+
+# ── import-teams CLI helper ───────────────────────────────────────────────────
+
+
+async def test_import_teams_loads_json_into_db(tmp_path: Path, monkeypatch):
+    """JSON file → row in teams + per-message rows in team_messages."""
+    teams_dir = tmp_path / "teams"
+    teams_dir.mkdir()
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    state_db = tmp_path / "state.db"
+
+    # Seed one JSON file mirroring the live li-team format.
+    team_doc = {
+        "id": "abc123",
+        "name": "review-team",
+        "members": ["alice", "bob"],
+        "messages": [
+            {
+                "id": "m1",
+                "from": "alice",
+                "to": ["bob"],
+                "content": "what's the verdict?",
+                "timestamp": "2026-05-21T15:00:00+00:00",
+                "read_by": {},
+            },
+            {
+                "id": "m2",
+                "from": "bob",
+                "to": ["*"],
+                "content": "approve",
+                "timestamp": "2026-05-21T15:05:00+00:00",
+                "read_by": {"alice": "2026-05-21T15:06:00+00:00"},
+            },
+        ],
+    }
+    (teams_dir / f"{team_doc['id']}.json").write_text(json.dumps(team_doc))
+
+    # Redirect RUNS_ROOT so _import_teams looks at the temp teams_dir
+    # (which is sibling to runs/ in the same temp parent).
+    from lionagi.cli import state as state_mod
+
+    monkeypatch.setattr(state_mod, "RUNS_ROOT", runs_dir)
+
+    # Use a temp DB path for the import.
+    from lionagi.state import db as db_mod
+
+    monkeypatch.setattr(db_mod, "DEFAULT_DB_PATH", state_db)
+
+    counts = await state_mod._import_teams()
+    assert counts["teams"] == 1
+    assert counts["messages"] == 2
+    assert counts["skipped_teams"] == 0
+    assert counts["errors"] == 0
+
+    # Verify rows landed correctly.
+    async with StateDB(state_db) as db:
+        cur = await db.db.execute(
+            "SELECT id, name, member_count, members, status FROM teams"
+        )
+        team_row = await cur.fetchone()
+        assert team_row["id"] == "abc123"
+        assert team_row["name"] == "review-team"
+        assert team_row["member_count"] == 2
+        assert json.loads(team_row["members"]) == ["alice", "bob"]
+        assert team_row["status"] == "active"
+
+        cur = await db.db.execute(
+            "SELECT id, sender, recipient, content FROM team_messages "
+            "ORDER BY created_at"
+        )
+        msgs = await cur.fetchall()
+        assert len(msgs) == 2
+        assert msgs[0]["sender"] == "alice"
+        assert msgs[0]["recipient"] == "bob"
+        assert msgs[1]["recipient"] == "all"  # ["*"] → "all"
+
+
+async def test_import_teams_is_idempotent(tmp_path: Path, monkeypatch):
+    """Running twice imports the team once; second run skips."""
+    teams_dir = tmp_path / "teams"
+    teams_dir.mkdir()
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    state_db = tmp_path / "state.db"
+
+    (teams_dir / "abc.json").write_text(
+        json.dumps(
+            {"id": "abc", "name": "t", "members": [], "messages": []}
+        )
+    )
+
+    from lionagi.cli import state as state_mod
+    from lionagi.state import db as db_mod
+
+    monkeypatch.setattr(state_mod, "RUNS_ROOT", runs_dir)
+    monkeypatch.setattr(db_mod, "DEFAULT_DB_PATH", state_db)
+
+    first = await state_mod._import_teams()
+    second = await state_mod._import_teams()
+
+    assert first["teams"] == 1
+    assert second["teams"] == 0
+    assert second["skipped_teams"] == 1


### PR DESCRIPTION
## Summary

Implements **ADR-0020 — Skill Invocations: Tracking the Orchestration Layer**. Adds a new persistence layer one notch above sessions: a row per skill orchestration (e.g. one /show "resolve issues" invocation grouping 14 sessions).

**Stacks on top of #1049 (ADR-0019).** Base branch is \`feat/adr-0019-teams-and-staleness\`; will rebase to main once the chain merges.

## Why

\`/show resolve lionagi issues\` spawns ~14 sessions over hours. Today they share \`show_topic\` provenance columns but no parent record — the runs list shows 14 rows with no grouping. ADR-0020 adds:

\`\`\`
invocation (skill="show", prompt="resolve lionagi issues", session_count=14)
  └─ session(invocation_kind="play", show_play_name="backend", invocation_id=...)
  └─ session(invocation_kind="play", show_play_name="frontend", invocation_id=...)
  └─ session(invocation_kind="agent", agent_name="play-gate", invocation_id=...)
  └─ ...
\`\`\`

\`invocation_kind\` stays as the CLI primitive (agent/play/flow/fanout/show-play). \`invocation_id\` is the higher-order grouping. They compose, they don't replace each other.

## What ships

### Backend
- **Schema**: \`invocations\` table + \`sessions.invocation_id\` FK with partial index. CHECK constraint on \`invocations.status\` uses the ADR-0025 6-value vocabulary.
- **DB helpers**: \`create_invocation\` / \`update_invocation\` (with status + column validation) / \`get_invocation\` / \`list_invocations\` (skill+status filters) / \`list_sessions_for_invocation\`. \`create_session\` auto-bumps \`invocations.session_count\` for linked sessions so list queries don't need a JOIN.

### CLI
- **\`li invoke start --skill SKILL [--plugin P] [--prompt "..."] [--metadata JSON]\`** — opens a new invocation, prints id to stdout (\`$(li invoke start ...)\` capture).
- **\`li invoke end ID --status STATUS [--metadata JSON]\`** — closes with ADR-0025 terminal status; metadata merges into \`node_metadata\`.
- **\`li invoke list [--skill S] [--status S] [--limit N]\`** — table view.
- **\`--invocation ID\`** added to the common CLI arg set (\`li agent\`, \`li play\`, \`li o flow\`, \`li o fanout\`). Threaded through to session creation. Opt-in: sessions without it work exactly as before.

### Studio API
- \`GET /api/invocations\` — paginated list with \`skill\` + \`status\` filters.
- \`GET /api/invocations/{id}\` — detail + child sessions array.
- Runs API: each row now includes \`invocation_id\` so the frontend can render the link.

### Studio frontend
- New nav item **Invocations** between Shows and Runs.
- \`/invocations\` — filterable list (skill dropdown, status dropdown, pagination).
- \`/invocations/{id}\` — stat cards, child sessions table, raw skill metadata viewer.
- TypeScript types: \`InvocationSummary\`, \`InvocationDetail\`, \`InvocationSession\`, \`InvocationListResponse\`.

## Deferred

- **Grouped runs view** (collapse 14 sessions under one /show row on /runs) — that's an ADR-0024 / fast-follow concern; the data is in place to build it.
- **Skill auto-attribution** — shipping skills (\`/show\`, \`/codex-pr-review\`, \`/reprompt\`) need updates to call \`li invoke start/end\` themselves so they show up without users manually wrapping the calls. One PR per skill, keep them small.
- **\`team_messages.session_id\` populated at write time** from \`li play --team-mode\` (still in ADR-0019b backlog).

## Test plan

- [x] \`uv run pytest tests/state/test_invocations.py\` — 10 new tests pass (vocabulary, CRUD, status enum, column validation, session_count bump, ordered listing, standalone passthrough, skill+status filters)
- [x] \`uv run pytest tests/state/ tests/cli/ tests/operations/ tests/apps_studio_server/\` — 858 tests pass
- [x] \`uv run ruff check\` on every touched file — clean
- [x] \`npx tsc --noEmit\` in \`apps/studio/frontend/\` — clean
- [ ] Smoke test: \`INV=\$(li invoke start --skill show --prompt test); li agent ... --invocation \$INV; li invoke end \$INV --status completed\` — verify rows in \`invocations\` and \`sessions.invocation_id\`
- [ ] Manual visual walkthrough: /invocations list and detail; navigate from a session back to its parent invocation; verify session_count bumps live

🤖 Generated with [Claude Code](https://claude.com/claude-code)