### PR TITLE
feat: ADR-0024 session health classifier + admin transition API (Layer 3)

### DIFF
--- a/apps/studio/frontend/app/invocations/[id]/page.tsx
+++ b/apps/studio/frontend/app/invocations/[id]/page.tsx
@@ -7,6 +7,7 @@ import PageHeader from "@/components/PageHeader";
 import StatusPill from "@/components/StatusPill";
 import Timestamp from "@/components/Timestamp";
 import Duration from "@/components/Duration";
+import OutcomeRenderer from "@/components/outcomes/OutcomeRenderer";
 import { getInvocation } from "@/lib/api";
 import type { InvocationDetail } from "@/lib/api";
 
@@ -171,6 +172,19 @@ export default function InvocationDetailPage() {
           </table>
         </div>
       </section>
+
+      {data.artifacts.length > 0 ? (
+        <section>
+          <h2 className="mb-2 text-meta uppercase tracking-[0.06em] text-content-muted">
+            Outcomes ({data.artifacts.length})
+          </h2>
+          <div className="space-y-3">
+            {data.artifacts.map((a) => (
+              <OutcomeRenderer key={a.id} artifact={a} />
+            ))}
+          </div>
+        </section>
+      ) : null}
 
       {data.node_metadata && Object.keys(data.node_metadata).length > 0 ? (
         <section>

--- a/apps/studio/frontend/app/runs/page.tsx
+++ b/apps/studio/frontend/app/runs/page.tsx
@@ -391,6 +391,7 @@ function RunsPageInner() {
                 {viewMode === "invocations" ? "Invocation" : "Run"}
               </th>
               <th className="px-3 py-2.5 font-medium">Status</th>
+              <th className="px-3 py-2.5 font-medium">Health</th>
               <th className="px-3 py-2.5 font-medium">
                 {viewMode === "invocations" ? "Sessions" : "Activity"}
               </th>
@@ -489,10 +490,7 @@ function RunsPageInner() {
               )
             ) : runs.length === 0 ? (
               <tr>
-                <td
-                  colSpan={4}
-                  className="px-3 py-14 text-center text-body text-content-muted"
-                >
+                <td colSpan={5} className="px-3 py-14 text-center text-body text-content-muted">
                   <span className="block mb-1 text-[11px]">No runs found</span>
                   {(statuses.length > 0 || playbook) && (
                     <span className="text-meta">Try adjusting your filters.</span>

--- a/apps/studio/frontend/components/StatusPill.tsx
+++ b/apps/studio/frontend/components/StatusPill.tsx
@@ -80,6 +80,7 @@ const TONE_BY_VALUE: Record<string, StatusTone> = {
   // verdict
   passed: "ok",
   approved: "ok",
+  approve_with_suggestions: "ok",
   rejected: "failed",
   "approve-with-fixes": "pending",
   // integration
@@ -116,6 +117,7 @@ const TONE_BY_TAXONOMY: Record<StatusTaxonomy, Record<string, StatusTone>> = {
   verdict: {
     approve: "ok",
     approved: "ok",
+    approve_with_suggestions: "ok",
     "approve-with-fixes": "pending",
     request_changes: "pending",
     reject: "failed",
@@ -145,6 +147,7 @@ const LABEL_OVERRIDES: Record<string, string> = {
   running_complete: "Run complete",
   merged_and_pushed: "Merged + pushed",
   in_progress: "In progress",
+  approve_with_suggestions: "Approve w/ suggestions",
   "approve-with-fixes": "Approve w/ fixes",
   timed_out: "Timed out",
   needs_review: "Needs review",

--- a/apps/studio/frontend/components/StatusPill.tsx
+++ b/apps/studio/frontend/components/StatusPill.tsx
@@ -3,11 +3,26 @@ import type { ReactNode } from "react";
 export type StatusKind = "lifecycle" | "verdict" | "integration" | "role" | "neutral";
 export type StatusTone = "ok" | "running" | "failed" | "pending" | "blocked" | "neutral";
 
+// ADR-0024 §C: explicit taxonomy so different vocabularies can't drift
+// into the same tone. "session" = ADR-0025 status; "health" = ADR-0024
+// derived health; "verdict" = critic/review verdicts; "play" = ADR-0011
+// play vocabulary; "neutral" = catch-all.
+export type StatusTaxonomy =
+  | "session"
+  | "health"
+  | "verdict"
+  | "play"
+  | "neutral";
+
 export interface StatusPillProps {
   // Raw machine string (e.g. "director-managed-complete"). Used to derive
   // tone and human label when those aren't passed explicitly.
   value?: string | null;
   kind?: StatusKind;
+  // ADR-0024 §C: explicit vocabulary marker. When set, tone resolution
+  // looks up the value in the taxonomy-specific table so e.g. a session
+  // status "running" and a play status "running" can stay distinct.
+  taxonomy?: StatusTaxonomy;
   // Override the displayed label
   label?: ReactNode;
   // Override the tone resolution
@@ -74,9 +89,52 @@ const TONE_BY_VALUE: Record<string, StatusTone> = {
   draft: "pending",
 };
 
-function toneFromValue(value: string | null | undefined): StatusTone {
+// ADR-0024 §C: per-taxonomy overrides. The shared TONE_BY_VALUE table
+// covers the common case; these dictionaries narrow specific values
+// when the taxonomy makes the intent clear. E.g. "stale" in the health
+// taxonomy is amber (pending), not a generic blocked.
+const TONE_BY_TAXONOMY: Record<StatusTaxonomy, Record<string, StatusTone>> = {
+  session: {
+    // ADR-0025: session lifecycle statuses.
+    running: "running",
+    completed: "ok",
+    failed: "failed",
+    timed_out: "pending",  // deliberate bound — amber, not red
+    aborted: "neutral",    // user Ctrl-C
+    cancelled: "neutral",  // system / orchestrator cancellation
+  },
+  health: {
+    // ADR-0024: six-level derived health. Pre-sorted by severity for the
+    // worst-of-group calculation in the grouped runs view.
+    healthy: "ok",
+    idle: "neutral",
+    unresponsive: "pending",  // amber — alive but past threshold
+    stale: "pending",         // amber/orange — process dead, has output
+    orphaned: "blocked",      // purple — never produced output
+    zombie: "failed",         // red — terminal, but resources leaked
+  },
+  verdict: {
+    approve: "ok",
+    approved: "ok",
+    "approve-with-fixes": "pending",
+    request_changes: "pending",
+    reject: "failed",
+    rejected: "failed",
+  },
+  play: {},
+  neutral: {},
+};
+
+function toneFromValue(
+  value: string | null | undefined,
+  taxonomy?: StatusTaxonomy,
+): StatusTone {
   if (!value) return "neutral";
-  return TONE_BY_VALUE[value.toLowerCase().trim()] ?? "neutral";
+  const key = value.toLowerCase().trim();
+  if (taxonomy && TONE_BY_TAXONOMY[taxonomy][key]) {
+    return TONE_BY_TAXONOMY[taxonomy][key];
+  }
+  return TONE_BY_VALUE[key] ?? "neutral";
 }
 
 // ─── Label humanization ─────────────────────────────────────────────────────
@@ -90,6 +148,10 @@ const LABEL_OVERRIDES: Record<string, string> = {
   "approve-with-fixes": "Approve w/ fixes",
   timed_out: "Timed out",
   needs_review: "Needs review",
+  // ADR-0024 health levels
+  unresponsive: "Unresponsive",
+  orphaned: "Orphaned",
+  zombie: "Zombie",
 };
 
 function humanize(value: string): string {
@@ -139,12 +201,13 @@ const TONE_CLASS: Record<StatusTone, string> = {
 export default function StatusPill({
   value,
   kind = "lifecycle",
+  taxonomy,
   label,
   tone,
   icon,
   className,
 }: StatusPillProps) {
-  const resolvedTone = tone ?? toneFromValue(value);
+  const resolvedTone = tone ?? toneFromValue(value, taxonomy);
   const resolvedLabel = label ?? (value ? humanize(value) : "");
   const resolvedIcon = icon === null ? null : (icon ?? ICON_BY_KIND[kind][resolvedTone] ?? null);
 

--- a/apps/studio/frontend/components/outcomes/CIResultCard.tsx
+++ b/apps/studio/frontend/components/outcomes/CIResultCard.tsx
@@ -1,0 +1,152 @@
+// ADR-0021 §E: CIResultCard renders the lint/test/build/typecheck
+// matrix with per-command timings — the layout from the spec.
+
+import StatusPill from "@/components/StatusPill";
+
+interface CIRunCommand {
+  command: string;
+  duration_seconds: number;
+  passed: boolean;
+}
+
+interface CIResultContent {
+  lint_passed?: boolean | null;
+  tests_passed?: boolean | null;
+  build_passed?: boolean | null;
+  typecheck_passed?: boolean | null;
+  test_count?: number | null;
+  test_failures?: number | null;
+  failure_summary?: string | null;
+  commands?: CIRunCommand[];
+  summary?: string;
+  passed?: boolean | null;
+}
+
+interface CIResultCardProps {
+  name: string;
+  content: Record<string, unknown>;
+}
+
+function formatDuration(s: number): string {
+  if (s < 60) return `${s.toFixed(1)}s`;
+  const m = Math.floor(s / 60);
+  const r = Math.round(s - m * 60);
+  return r > 0 ? `${m}m ${r}s` : `${m}m`;
+}
+
+function CheckRow({
+  label,
+  passed,
+  detail,
+}: {
+  label: string;
+  passed: boolean | null | undefined;
+  detail?: string;
+}) {
+  if (passed == null) return null;
+  return (
+    <div className="flex items-center justify-between gap-3 py-1 text-body">
+      <span className="text-content-primary">{label}</span>
+      <span className="flex items-center gap-2">
+        {detail ? (
+          <span className="tabular-nums text-content-secondary">{detail}</span>
+        ) : null}
+        <span
+          className={
+            "tabular-nums " +
+            (passed ? "text-status-success" : "text-status-error")
+          }
+        >
+          {passed ? "passed" : "failed"}
+        </span>
+      </span>
+    </div>
+  );
+}
+
+export default function CIResultCard({ name, content }: CIResultCardProps) {
+  const c = content as unknown as CIResultContent;
+  const overall =
+    c.passed ??
+    [c.lint_passed, c.tests_passed, c.build_passed, c.typecheck_passed]
+      .filter((v) => v != null)
+      .every((v) => v === true);
+
+  return (
+    <div className="rounded border border-edge bg-surface-raised">
+      <header className="flex items-center justify-between gap-2 border-b border-edge px-3 py-2">
+        <div className="flex items-center gap-2">
+          <StatusPill
+            value={overall ? "approved" : "rejected"}
+            label={`CI: ${overall ? "PASSED" : "FAILED"}`}
+            taxonomy="verdict"
+          />
+          <span className="text-body text-content-primary">{name}</span>
+        </div>
+      </header>
+
+      {c.summary ? (
+        <div className="px-3 py-2 text-body text-content-secondary">
+          {c.summary}
+        </div>
+      ) : null}
+
+      <section className="border-t border-edge px-3 py-2">
+        <CheckRow
+          label="Tests"
+          passed={c.tests_passed}
+          detail={
+            c.test_count != null
+              ? c.test_failures != null
+                ? `${c.test_count - c.test_failures} / ${c.test_count}`
+                : `${c.test_count}`
+              : undefined
+          }
+        />
+        <CheckRow label="Lint" passed={c.lint_passed} />
+        <CheckRow label="Typecheck" passed={c.typecheck_passed} />
+        <CheckRow label="Build" passed={c.build_passed} />
+      </section>
+
+      {c.failure_summary ? (
+        <section className="border-t border-edge px-3 py-2">
+          <div className="mb-1 text-meta uppercase tracking-[0.06em] text-content-muted">
+            Failure summary
+          </div>
+          <div className="text-body text-content-primary whitespace-pre-wrap">
+            {c.failure_summary}
+          </div>
+        </section>
+      ) : null}
+
+      {c.commands && c.commands.length > 0 ? (
+        <section className="border-t border-edge px-3 py-2">
+          <div className="mb-1 text-meta uppercase tracking-[0.06em] text-content-muted">
+            Commands
+          </div>
+          <ul className="space-y-1 text-body">
+            {c.commands.map((cmd, i) => (
+              <li key={i} className="flex items-center justify-between gap-3">
+                <span className="font-mono text-content-primary truncate">
+                  {cmd.command}
+                </span>
+                <span className="flex items-center gap-2 shrink-0">
+                  <span className="tabular-nums text-content-secondary">
+                    {formatDuration(cmd.duration_seconds)}
+                  </span>
+                  <span
+                    className={
+                      cmd.passed ? "text-status-success" : "text-status-error"
+                    }
+                  >
+                    {cmd.passed ? "✓" : "✕"}
+                  </span>
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/studio/frontend/components/outcomes/GateVerdictCard.tsx
+++ b/apps/studio/frontend/components/outcomes/GateVerdictCard.tsx
@@ -1,0 +1,71 @@
+// ADR-0021 §E: GateVerdictCard renders the pass/fail outcome of a
+// gate (play-gate, show-gate, etc.) with feedback and notes surfaced
+// alongside, not buried in a text field.
+
+import StatusPill from "@/components/StatusPill";
+
+interface GateVerdictContent {
+  gate_passed?: boolean;
+  feedback?: string | null;
+  notes?: string | null;
+  summary?: string;
+  passed?: boolean | null;
+}
+
+interface GateVerdictCardProps {
+  name: string;
+  content: Record<string, unknown>;
+}
+
+export default function GateVerdictCard({
+  name,
+  content,
+}: GateVerdictCardProps) {
+  const c = content as unknown as GateVerdictContent;
+  const passed = c.gate_passed ?? c.passed ?? null;
+  const verdictLabel =
+    passed === true ? "ACCEPT" : passed === false ? "REJECT" : "PENDING";
+
+  return (
+    <div className="rounded border border-edge bg-surface-raised">
+      <header className="flex items-center justify-between gap-2 border-b border-edge px-3 py-2">
+        <div className="flex items-center gap-2">
+          <StatusPill
+            value={passed === true ? "approved" : passed === false ? "rejected" : ""}
+            label={`GATE: ${verdictLabel}`}
+            taxonomy="verdict"
+          />
+          <span className="text-body text-content-primary">{name}</span>
+        </div>
+      </header>
+
+      {c.summary ? (
+        <div className="px-3 py-2 text-body text-content-secondary">
+          {c.summary}
+        </div>
+      ) : null}
+
+      {c.feedback ? (
+        <section className="border-t border-edge px-3 py-2">
+          <div className="mb-1 text-meta uppercase tracking-[0.06em] text-content-muted">
+            Feedback
+          </div>
+          <div className="text-body text-content-primary whitespace-pre-wrap">
+            {c.feedback}
+          </div>
+        </section>
+      ) : null}
+
+      {c.notes ? (
+        <section className="border-t border-edge px-3 py-2">
+          <div className="mb-1 text-meta uppercase tracking-[0.06em] text-content-muted">
+            Notes
+          </div>
+          <div className="text-body text-content-secondary whitespace-pre-wrap">
+            {c.notes}
+          </div>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/studio/frontend/components/outcomes/OutcomeRenderer.tsx
+++ b/apps/studio/frontend/components/outcomes/OutcomeRenderer.tsx
@@ -1,0 +1,54 @@
+// ADR-0021 §E: kind-dispatched renderer for skill outcomes.
+// Falls back to a JSON viewer for unknown kinds so new outcome types
+// degrade gracefully until a dedicated card is added.
+
+import type { ArtifactSummary } from "@/lib/api";
+import ReviewVerdictCard from "./ReviewVerdictCard";
+import GateVerdictCard from "./GateVerdictCard";
+import CIResultCard from "./CIResultCard";
+
+export interface OutcomeRendererProps {
+  artifact: ArtifactSummary;
+}
+
+export default function OutcomeRenderer({ artifact }: OutcomeRendererProps) {
+  const content = artifact.content ?? {};
+  switch (artifact.kind) {
+    case "review_verdict":
+      return (
+        <ReviewVerdictCard
+          name={artifact.name}
+          content={content as Record<string, unknown>}
+        />
+      );
+    case "gate_verdict":
+      return (
+        <GateVerdictCard
+          name={artifact.name}
+          content={content as Record<string, unknown>}
+        />
+      );
+    case "ci_result":
+      return (
+        <CIResultCard
+          name={artifact.name}
+          content={content as Record<string, unknown>}
+        />
+      );
+    default:
+      return (
+        <div className="rounded border border-edge bg-surface-raised p-3">
+          <div className="mb-2 flex items-center justify-between text-meta uppercase tracking-[0.06em] text-content-muted">
+            <span>{artifact.kind}</span>
+            <span className="font-mono">{artifact.id.slice(0, 8)}</span>
+          </div>
+          <div className="mb-1 text-body text-content-primary">
+            {artifact.name}
+          </div>
+          <pre className="overflow-x-auto rounded bg-surface-base p-2 text-meta font-mono text-content-secondary">
+            {JSON.stringify(content, null, 2)}
+          </pre>
+        </div>
+      );
+  }
+}

--- a/apps/studio/frontend/components/outcomes/ReviewVerdictCard.tsx
+++ b/apps/studio/frontend/components/outcomes/ReviewVerdictCard.tsx
@@ -1,0 +1,187 @@
+// ADR-0021 §E: ReviewVerdictCard renders the structured verdict as a
+// severity/category breakdown with blocking findings highlighted, not
+// as raw text. Mirrors the spec layout in the ADR.
+
+import StatusPill from "@/components/StatusPill";
+
+interface Finding {
+  severity: "critical" | "high" | "medium" | "low" | "info";
+  category: string;
+  file?: string | null;
+  line?: number | null;
+  description: string;
+  suggestion?: string | null;
+}
+
+interface ReviewVerdictContent {
+  verdict?: string;
+  summary?: string;
+  findings?: Finding[];
+  round?: number;
+  passed?: boolean | null;
+}
+
+interface ReviewVerdictCardProps {
+  name: string;
+  content: Record<string, unknown>;
+}
+
+const SEVERITY_ORDER: Finding["severity"][] = [
+  "critical",
+  "high",
+  "medium",
+  "low",
+  "info",
+];
+const BLOCKING_SEVERITIES = new Set<Finding["severity"]>(["critical", "high"]);
+
+const SEVERITY_LABEL: Record<Finding["severity"], string> = {
+  critical: "Critical",
+  high: "Major",
+  medium: "Minor",
+  low: "Low",
+  info: "Info",
+};
+
+export default function ReviewVerdictCard({
+  name,
+  content,
+}: ReviewVerdictCardProps) {
+  const c = content as unknown as ReviewVerdictContent;
+  const verdict = c.verdict ?? "UNKNOWN";
+  const findings = c.findings ?? [];
+
+  // Severity counts (sorted descending by severity).
+  const counts: Record<Finding["severity"], number> = {
+    critical: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+    info: 0,
+  };
+  const categoryCounts: Record<string, number> = {};
+  for (const f of findings) {
+    counts[f.severity] += 1;
+    categoryCounts[f.category] = (categoryCounts[f.category] ?? 0) + 1;
+  }
+
+  const blocking = findings.filter((f) => BLOCKING_SEVERITIES.has(f.severity));
+  const minor = findings.filter((f) => !BLOCKING_SEVERITIES.has(f.severity));
+
+  return (
+    <div className="rounded border border-edge bg-surface-raised">
+      <header className="flex items-center justify-between gap-2 border-b border-edge px-3 py-2">
+        <div className="flex items-center gap-2">
+          <StatusPill value={verdict} taxonomy="verdict" />
+          <span className="text-body text-content-primary">{name}</span>
+          {c.round != null ? (
+            <span className="text-meta text-content-muted">
+              round {c.round}
+            </span>
+          ) : null}
+        </div>
+      </header>
+
+      {c.summary ? (
+        <div className="px-3 py-2 text-body text-content-secondary">
+          {c.summary}
+        </div>
+      ) : null}
+
+      <div className="grid grid-cols-2 gap-3 border-t border-edge px-3 py-2">
+        <div>
+          <div className="mb-1 text-meta uppercase tracking-[0.06em] text-content-muted">
+            Findings
+          </div>
+          <div className="flex flex-wrap gap-2 text-body">
+            {SEVERITY_ORDER.map((s) =>
+              counts[s] > 0 ? (
+                <span key={s} className="tabular-nums">
+                  <span className="text-content-primary">
+                    {SEVERITY_LABEL[s]}
+                  </span>{" "}
+                  <span className="text-content-secondary">{counts[s]}</span>
+                </span>
+              ) : null,
+            )}
+            {findings.length === 0 ? (
+              <span className="text-meta text-content-muted">
+                no findings
+              </span>
+            ) : null}
+          </div>
+        </div>
+        <div>
+          <div className="mb-1 text-meta uppercase tracking-[0.06em] text-content-muted">
+            Categories
+          </div>
+          <div className="flex flex-wrap gap-2 text-body">
+            {Object.entries(categoryCounts).map(([cat, n]) => (
+              <span key={cat} className="tabular-nums">
+                <span className="text-content-primary">{cat}</span>{" "}
+                <span className="text-content-secondary">{n}</span>
+              </span>
+            ))}
+            {Object.keys(categoryCounts).length === 0 ? (
+              <span className="text-meta text-content-muted">—</span>
+            ) : null}
+          </div>
+        </div>
+      </div>
+
+      {blocking.length > 0 ? (
+        <section className="border-t border-edge px-3 py-2">
+          <div className="mb-1 text-meta uppercase tracking-[0.06em] text-content-muted">
+            Blocking findings
+          </div>
+          <ul className="space-y-2">
+            {blocking.map((f, i) => (
+              <li key={i} className="rounded border border-status-error/30 bg-status-error-bg/40 p-2">
+                <div className="flex items-center gap-2">
+                  <span className="rounded bg-status-error/10 px-1.5 py-0.5 text-meta uppercase tracking-wide text-status-error">
+                    {SEVERITY_LABEL[f.severity]}
+                  </span>
+                  <span className="text-body text-content-primary">
+                    {f.description}
+                  </span>
+                </div>
+                {f.file ? (
+                  <div className="mt-1 font-mono text-meta text-content-muted">
+                    {f.file}
+                    {f.line != null ? `:${f.line}` : ""}
+                  </div>
+                ) : null}
+                {f.suggestion ? (
+                  <div className="mt-1 text-body text-content-secondary">
+                    <span className="text-meta uppercase tracking-[0.06em] text-content-muted">
+                      Suggestion
+                    </span>{" "}
+                    {f.suggestion}
+                  </div>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      {minor.length > 0 ? (
+        <details className="border-t border-edge px-3 py-2">
+          <summary className="cursor-pointer text-meta uppercase tracking-[0.06em] text-content-muted">
+            Suggestions ({minor.length})
+          </summary>
+          <ul className="mt-2 space-y-1 text-body text-content-secondary">
+            {minor.map((f, i) => (
+              <li key={i}>
+                <span className="text-meta uppercase tracking-[0.06em] text-content-muted">
+                  {SEVERITY_LABEL[f.severity]}
+                </span>{" "}
+                {f.description}
+              </li>
+            ))}
+          </ul>
+        </details>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/studio/frontend/lib/api.ts
+++ b/apps/studio/frontend/lib/api.ts
@@ -416,8 +416,36 @@ export interface InvocationSession {
   ended_at: number | null;
 }
 
+// ADR-0021: structured skill outputs. `kind` is the dispatch key for
+// the frontend renderer; `content` shape depends on the kind.
+export interface ArtifactSummary {
+  id: string;
+  invocation_id: string | null;
+  session_id: string | null;
+  kind: string;
+  name: string;
+  created_at: number;
+  content: Record<string, unknown> | null;
+  file_path: string | null;
+}
+
 export interface InvocationDetail extends InvocationSummary {
   sessions: InvocationSession[];
+  artifacts: ArtifactSummary[];
+}
+
+export async function getArtifact(id: string): Promise<ArtifactSummary> {
+  return fetchJson<ArtifactSummary>(
+    `/api/artifacts/${encodeURIComponent(id)}`,
+  );
+}
+
+export async function listArtifactsForSession(
+  sessionId: string,
+): Promise<{ artifacts: ArtifactSummary[] }> {
+  return fetchJson<{ artifacts: ArtifactSummary[] }>(
+    `/api/artifacts/by-session/${encodeURIComponent(sessionId)}`,
+  );
 }
 
 export interface InvocationListResponse {

--- a/apps/studio/frontend/lib/types.ts
+++ b/apps/studio/frontend/lib/types.ts
@@ -14,11 +14,20 @@ export interface RunSummary {
   show_play_name?: string | null;
   source_kind?: string;
   status: string;
-  // ADR-0019: derived health indicator computed at read time from
-  // `last_message_at` and a kind-aware threshold. Non-null only for
-  // `running` sessions that have crossed the threshold; ADR-0024 will
-  // expand this with idle / unresponsive / orphaned / zombie.
-  effective_health?: "stale" | null;
+  // ADR-0024: derived health indicator computed at read time.
+  // - healthy / idle: alive and active (or quietly waiting).
+  // - unresponsive: alive but past kind-aware threshold.
+  // - stale: process dead, has produced output.
+  // - orphaned: process dead, no output, no artifacts.
+  // - zombie: terminal status, but resources leaked (stale locks).
+  effective_health?:
+    | "healthy"
+    | "idle"
+    | "unresponsive"
+    | "stale"
+    | "orphaned"
+    | "zombie"
+    | null;
   last_message_at?: number | null;
   // ADR-0020: optional parent skill orchestration id (from `li invoke`).
   invocation_id?: string | null;

--- a/apps/studio/server/app.py
+++ b/apps/studio/server/app.py
@@ -11,6 +11,7 @@ from .config import CORS_ORIGINS
 from .routers import (
     admin,
     agents,
+    artifacts,
     definitions,
     invocations,
     playbooks,
@@ -59,6 +60,7 @@ app.include_router(plugins.router, prefix="/api")
 app.include_router(admin.router, prefix="/api")
 app.include_router(teams.router, prefix="/api")
 app.include_router(invocations.router, prefix="/api")
+app.include_router(artifacts.router, prefix="/api")
 
 
 @app.get("/health")

--- a/apps/studio/server/routers/admin.py
+++ b/apps/studio/server/routers/admin.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from fastapi import APIRouter, HTTPException, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from ..services import admin as admin_svc
 
@@ -15,11 +15,58 @@ class PruneBody(BaseModel):
     all_phantom: bool = False
 
 
+class TransitionBody(BaseModel):
+    """ADR-0024 §B: admin session transition.
+
+    ``reason`` is required so every transition has an audit-log
+    justification. ``target_status`` is constrained to the
+    admin-allowed subset (operators can't claim a model
+    timed out or completed cleanly).
+    """
+
+    session_ids: list[str] = Field(..., min_length=1)
+    target_status: Literal["failed", "aborted", "cancelled"]
+    reason: str = Field(..., min_length=1, max_length=500)
+    actor: str = Field(default="admin", max_length=64)
+
+
 @router.get("/doctor")
 async def doctor(
     stale_hours: float = Query(default=1.0, gt=0),
 ) -> dict[str, Any]:
     return await admin_svc.doctor(stale_hours=stale_hours)
+
+
+@router.get("/health")
+async def health() -> dict[str, Any]:
+    """ADR-0024 §B: composite session health report."""
+    return await admin_svc.health_report()
+
+
+@router.post("/transition")
+async def transition(body: TransitionBody) -> dict[str, Any]:
+    """ADR-0024 §B: mark running sessions terminal with an audit entry."""
+    try:
+        return await admin_svc.transition_sessions(
+            body.session_ids,
+            target_status=body.target_status,
+            reason=body.reason,
+            actor=body.actor,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@router.get("/events")
+async def admin_events(
+    action: str | None = Query(default=None),
+    target_id: str | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=1000),
+) -> dict[str, Any]:
+    events = await admin_svc.list_admin_events(
+        action=action, target_id=target_id, limit=limit
+    )
+    return {"events": events}
 
 
 @router.post("/prune")

--- a/apps/studio/server/routers/artifacts.py
+++ b/apps/studio/server/routers/artifacts.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""ADR-0021 artifacts API.
+
+Skill-produced structured outcomes (ReviewVerdict, GateVerdict,
+CIResult, ...). Most consumers fetch via /api/invocations/{id} which
+returns the artifact list inline; these endpoints exist for the cases
+where the caller has only a session id, or wants the artifact alone.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+
+from ..services import invocations as inv_svc
+
+router = APIRouter(prefix="/artifacts", tags=["artifacts"])
+
+
+@router.get("/{artifact_id}")
+async def get_artifact(artifact_id: str) -> dict[str, Any]:
+    data = await inv_svc.get_artifact(artifact_id)
+    if data is None:
+        raise HTTPException(
+            status_code=404, detail=f"Artifact '{artifact_id}' not found"
+        )
+    return data
+
+
+# Convenience: sessions don't have their own router-level artifacts endpoint
+# (sessions.router predates ADR-0021). This sub-route under /api/artifacts
+# keeps the artifact concern in one place.
+@router.get("/by-session/{session_id}")
+async def list_for_session(session_id: str) -> dict[str, Any]:
+    rows = await inv_svc.list_artifacts_for_session(session_id)
+    return {"artifacts": rows}

--- a/apps/studio/server/services/admin.py
+++ b/apps/studio/server/services/admin.py
@@ -143,6 +143,217 @@ async def doctor(*, stale_hours: float = 1.0) -> dict[str, Any]:
     }
 
 
+# ─── ADR-0024: graduated health + transition (additive) ──────────────────────
+
+
+async def health_report() -> dict[str, Any]:
+    """Composite session health snapshot for the admin console.
+
+    Layers ADR-0024's ``classify_session_health`` over the existing
+    phantom checks: process liveness comes from the same PID/ps scan
+    that ``doctor`` uses; artifacts/locks come from the run directory.
+    Terminal sessions are classified too (so we can spot zombies left
+    behind by past crashes).
+    """
+    from collections import Counter
+
+    from lionagi.state.health import (
+        SessionHealth,
+        classify_session_health,
+    )
+
+    if not DEFAULT_DB_PATH.exists():
+        return {
+            "sessions": {"total": 0, "by_status": {}, "by_health": {}, "unhealthy": []},
+            "db": db_health(),
+            "diagnostic_run_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+    now = time.time()
+    async with _open_db(_DB) as db:
+        cur = await db.execute(
+            """
+            SELECT s.id, s.name, s.status, s.invocation_kind, s.agent_name,
+                   s.playbook_name, s.started_at, s.ended_at, s.updated_at,
+                   s.last_message_at, s.artifacts_path,
+                   COALESCE(SUM(json_array_length(p.collection)), 0) AS message_count
+            FROM sessions s
+            LEFT JOIN branches b ON b.session_id = s.id
+            LEFT JOIN progressions p ON p.id = b.progression_id
+            GROUP BY s.id
+            ORDER BY s.updated_at DESC
+            """
+        )
+        rows = await cur.fetchall()
+
+    by_status: Counter[str] = Counter()
+    by_health: Counter[str] = Counter()
+    unhealthy: list[dict[str, Any]] = []
+
+    for row in rows:
+        # Convert sqlite3.Row to dict for the pure classifier.
+        sess = {k: row[k] for k in row.keys()}
+        status = sess.get("status") or "completed"
+        by_status[status] += 1
+
+        artifacts = _artifacts_path(row)
+        has_artifacts = artifacts is not None and artifacts.exists()
+        has_stale_locks = False
+        if artifacts is not None and artifacts.exists():
+            # Lock check is cheap (one glob) but only matters for
+            # candidate-zombie terminal sessions and stale-process
+            # running ones. Skip for clearly-healthy active ones.
+            cutoff = now - 3600
+            has_stale_locks = (
+                _find_stale_lock(artifacts, cutoff=cutoff) is not None
+            )
+
+        if status == "running":
+            process_alive = _live_process_matches(row["id"], artifacts)
+        else:
+            # Terminal session — process_alive is moot; classifier only
+            # uses it on the running branch.
+            process_alive = False
+
+        health = classify_session_health(
+            sess,
+            now=now,
+            process_alive=process_alive,
+            has_artifacts=has_artifacts,
+            has_stale_locks=has_stale_locks,
+        )
+        by_health[health.value] += 1
+
+        # "Unhealthy" = anything that warrants operator attention.
+        if health not in (SessionHealth.HEALTHY, SessionHealth.IDLE):
+            last_activity = (
+                sess.get("last_message_at")
+                or sess.get("updated_at")
+                or sess.get("started_at")
+                or 0
+            )
+            unhealthy.append(
+                {
+                    "session_id": row["id"],
+                    "name": sess.get("name") or sess.get("playbook_name")
+                    or sess.get("agent_name") or "",
+                    "health": health.value,
+                    "status": status,
+                    "invocation_kind": sess.get("invocation_kind"),
+                    "agent_name": sess.get("agent_name"),
+                    "playbook_name": sess.get("playbook_name"),
+                    "last_message_at": sess.get("last_message_at"),
+                    "idle_seconds": now - last_activity if last_activity else None,
+                    "process_alive": process_alive,
+                    "message_count": sess.get("message_count") or 0,
+                }
+            )
+
+    return {
+        "sessions": {
+            "total": sum(by_status.values()),
+            "by_status": dict(by_status),
+            "by_health": dict(by_health),
+            "unhealthy": unhealthy,
+        },
+        "db": db_health(),
+        "diagnostic_run_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+# ADR-0025: admin operators cannot mark sessions completed/timed_out —
+# those are system-determined. Mirror the Python guard from db.py here
+# so the API rejects the request before touching the DB.
+_ADMIN_TRANSITION_TARGETS: frozenset[str] = frozenset(
+    {"failed", "aborted", "cancelled"}
+)
+
+
+async def transition_sessions(
+    session_ids: list[str],
+    *,
+    target_status: str,
+    reason: str,
+    actor: str = "admin",
+) -> dict[str, Any]:
+    """Mark running sessions terminal with an audit-log entry.
+
+    ADR-0024 §B replaces the blunt "prune" with "transition": the session
+    row + messages + artifacts are preserved for debugging. Guards:
+
+    * ``target_status`` must be in ``ADMIN_TRANSITION_TARGETS``.
+    * Only ``running`` sessions are touched; already-terminal ones are
+      reported in ``skipped`` so the caller can warn the operator.
+    """
+    if target_status not in _ADMIN_TRANSITION_TARGETS:
+        raise ValueError(
+            f"target_status must be one of {sorted(_ADMIN_TRANSITION_TARGETS)}; "
+            f"got {target_status!r}"
+        )
+    if not reason or not reason.strip():
+        raise ValueError("reason is required")
+    if not session_ids:
+        return {"transitioned": [], "skipped": [], "event_id": None}
+    if not DEFAULT_DB_PATH.exists():
+        return {"transitioned": [], "skipped": session_ids, "event_id": None}
+
+    from lionagi.state.db import StateDB
+
+    transitioned: list[str] = []
+    skipped: list[dict[str, str]] = []
+    now = time.time()
+
+    async with StateDB() as db:
+        for sid in session_ids:
+            current = await db.get_session(sid)
+            if current is None:
+                skipped.append({"session_id": sid, "reason": "not_found"})
+                continue
+            if current.get("status") != "running":
+                skipped.append(
+                    {"session_id": sid, "reason": f"not_running:{current.get('status')}"}
+                )
+                continue
+            await db.update_session(
+                sid, status=target_status, ended_at=now
+            )
+            transitioned.append(sid)
+
+        event_id = await db.insert_admin_event(
+            action="transition",
+            target_id=None,
+            actor=actor,
+            details={
+                "target_status": target_status,
+                "reason": reason,
+                "transitioned": transitioned,
+                "skipped": skipped,
+            },
+        )
+
+    return {
+        "transitioned": transitioned,
+        "skipped": skipped,
+        "event_id": event_id,
+    }
+
+
+async def list_admin_events(
+    *,
+    action: str | None = None,
+    target_id: str | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    if not DEFAULT_DB_PATH.exists():
+        return []
+    from lionagi.state.db import StateDB
+
+    async with StateDB() as db:
+        return await db.list_admin_events(
+            action=action, target_id=target_id, limit=limit
+        )
+
+
 async def prune_sessions(session_ids: list[str]) -> int:
     """Delete sessions by explicit ID list (intentional admin action; unconditional)."""
     seen: dict[str, None] = {}

--- a/apps/studio/server/services/admin.py
+++ b/apps/studio/server/services/admin.py
@@ -284,6 +284,12 @@ async def transition_sessions(
     * ``target_status`` must be in ``ADMIN_TRANSITION_TARGETS``.
     * Only ``running`` sessions are touched; already-terminal ones are
       reported in ``skipped`` so the caller can warn the operator.
+    * HEALTHY and IDLE sessions are refused with ValueError (→ 422) to
+      prevent accidental termination of active sessions (ADR-0024 health
+      guard).
+    * The DB update is conditional on ``status='running'`` in the WHERE
+      clause to close the TOCTOU window between the pre-check read and the
+      write.
     """
     if target_status not in _ADMIN_TRANSITION_TARGETS:
         raise ValueError(
@@ -298,25 +304,63 @@ async def transition_sessions(
         return {"transitioned": [], "skipped": session_ids, "event_id": None}
 
     from lionagi.state.db import StateDB
+    from lionagi.state.health import SessionHealth, classify_session_health
 
     transitioned: list[str] = []
     skipped: list[dict[str, str]] = []
     now = time.time()
 
     async with StateDB() as db:
+        # Health guard: refuse to transition sessions that are still healthy
+        # or merely idle — those should be left to complete normally.
         for sid in session_ids:
             current = await db.get_session(sid)
-            if current is None:
-                skipped.append({"session_id": sid, "reason": "not_found"})
+            if current is None or current.get("status") != "running":
                 continue
-            if current.get("status") != "running":
-                skipped.append(
-                    {"session_id": sid, "reason": f"not_running:{current.get('status')}"}
-                )
-                continue
-            await db.update_session(
-                sid, status=target_status, ended_at=now
+            artifacts = _artifacts_path(current)
+            has_artifacts = artifacts is not None and artifacts.exists()
+            has_stale_locks = (
+                _find_stale_lock(artifacts, cutoff=now - 3600) is not None
+                if artifacts is not None and artifacts.exists()
+                else False
             )
+            process_alive = _live_process_matches(current["id"], artifacts)
+            health = classify_session_health(
+                current,
+                now=now,
+                process_alive=process_alive,
+                has_artifacts=has_artifacts,
+                has_stale_locks=has_stale_locks,
+            )
+            if health in (SessionHealth.HEALTHY, SessionHealth.IDLE):
+                raise ValueError(
+                    f"Session {sid!r} is {health.value} — transition refused. "
+                    "Only unhealthy sessions may be force-transitioned."
+                )
+
+        # Atomic UPDATE: the WHERE clause guards against a concurrent
+        # terminal transition that races between the health pre-check and
+        # this write.  rowcount==0 means the session was never running (or
+        # was already transitioned) — look up the current state to explain.
+        for sid in session_ids:
+            cur = await db.db.execute(
+                "UPDATE sessions SET status=?, ended_at=?, updated_at=? "
+                "WHERE id=? AND status='running'",
+                (target_status, now, now, sid),
+            )
+            await db.db.commit()
+            if cur.rowcount == 0:
+                existing = await db.get_session(sid)
+                if existing is None:
+                    skipped.append({"session_id": sid, "reason": "not_found"})
+                else:
+                    skipped.append(
+                        {
+                            "session_id": sid,
+                            "reason": f"not_running:{existing.get('status')}",
+                        }
+                    )
+                continue
             transitioned.append(sid)
 
         event_id = await db.insert_admin_event(

--- a/apps/studio/server/services/admin.py
+++ b/apps/studio/server/services/admin.py
@@ -311,11 +311,18 @@ async def transition_sessions(
     now = time.time()
 
     async with StateDB() as db:
-        # Health guard: refuse to transition sessions that are still healthy
-        # or merely idle — those should be left to complete normally.
+        # Health guard + UPDATE merged into one loop per session.
+        # Re-classify each session immediately before the UPDATE to minimize
+        # the TOCTOU window between the guard read and the destructive write.
         for sid in session_ids:
             current = await db.get_session(sid)
-            if current is None or current.get("status") != "running":
+            if current is None:
+                skipped.append({"session_id": sid, "reason": "not_found"})
+                continue
+            if current.get("status") != "running":
+                skipped.append(
+                    {"session_id": sid, "reason": f"not_running:{current.get('status')}"}
+                )
                 continue
             artifacts = _artifacts_path(current)
             has_artifacts = artifacts is not None and artifacts.exists()
@@ -338,11 +345,9 @@ async def transition_sessions(
                     "Only unhealthy sessions may be force-transitioned."
                 )
 
-        # Atomic UPDATE: the WHERE clause guards against a concurrent
-        # terminal transition that races between the health pre-check and
-        # this write.  rowcount==0 means the session was never running (or
-        # was already transitioned) — look up the current state to explain.
-        for sid in session_ids:
+            # UPDATE immediately after the health check to minimize the race
+            # window. The WHERE status='running' guard closes the residual
+            # TOCTOU: rowcount==0 means a concurrent transition already won.
             cur = await db.db.execute(
                 "UPDATE sessions SET status=?, ended_at=?, updated_at=? "
                 "WHERE id=? AND status='running'",

--- a/apps/studio/server/services/invocations.py
+++ b/apps/studio/server/services/invocations.py
@@ -67,6 +67,12 @@ async def get_invocation(invocation_id: str) -> dict[str, Any] | None:
             except json.JSONDecodeError:
                 node_meta = None
         sessions = await db.list_sessions_for_invocation(invocation_id)
+        # ADR-0021: surface structured outcomes alongside child sessions
+        # so the invocation detail page can render verdict / CI / gate
+        # cards inline. Filesystem blobs (file_path) are included by
+        # reference; the frontend renders them as JSON when the kind is
+        # unknown.
+        artifacts = await db.list_artifacts_for_invocation(invocation_id)
     return {
         "id": row["id"],
         "skill": row["skill"],
@@ -95,4 +101,48 @@ async def get_invocation(invocation_id: str) -> dict[str, Any] | None:
             }
             for s in sessions
         ],
+        "artifacts": [_serialize_artifact(a) for a in artifacts],
     }
+
+
+def _serialize_artifact(row: dict[str, Any]) -> dict[str, Any]:
+    """Common artifact projection for /api/invocations and /api/artifacts.
+
+    SQLite returns JSON columns as strings; decode here so the frontend
+    gets a real object instead of a doubly-encoded string.
+    """
+    content = row.get("content")
+    if isinstance(content, str):
+        try:
+            content = json.loads(content)
+        except json.JSONDecodeError:
+            content = None
+    return {
+        "id": row["id"],
+        "invocation_id": row.get("invocation_id"),
+        "session_id": row.get("session_id"),
+        "kind": row["kind"],
+        "name": row["name"],
+        "created_at": row["created_at"],
+        "content": content,
+        "file_path": row.get("file_path"),
+    }
+
+
+# ── Artifacts (ADR-0021) ──────────────────────────────────────────────────────
+
+
+async def list_artifacts_for_session(session_id: str) -> list[dict[str, Any]]:
+    if not DEFAULT_DB_PATH.exists():
+        return []
+    async with StateDB() as db:
+        rows = await db.list_artifacts_for_session(session_id)
+    return [_serialize_artifact(r) for r in rows]
+
+
+async def get_artifact(artifact_id: str) -> dict[str, Any] | None:
+    if not DEFAULT_DB_PATH.exists():
+        return None
+    async with StateDB() as db:
+        row = await db.get_artifact(artifact_id)
+    return _serialize_artifact(row) if row else None

--- a/apps/studio/server/services/runs.py
+++ b/apps/studio/server/services/runs.py
@@ -538,7 +538,7 @@ async def list_runs(
     routers/sessions.py.  The /api/runs/{id}/events route in routers/runs.py
     is removed in the same commit.
     """
-    from lionagi.state.staleness import staleness_check
+    from lionagi.state.health import classify_session_health
 
     sessions = await _sessions_svc.list_sessions()
     status_set = _normalize_status_filter(status)
@@ -551,6 +551,20 @@ async def list_runs(
             continue
         if status_set and s.get("status") not in status_set:
             continue
+        # ADR-0024: process liveness + artifact / lock signals would be
+        # checked here for full classification. Studio reads come from
+        # SQLite only — process/FS checks happen in admin endpoints
+        # where they're explicitly opted into. For the runs list we
+        # assume process_alive=True (we'd have heard otherwise via the
+        # CLI teardown), and fall back to the activity-only signal that
+        # gives stale / unresponsive / idle / healthy + zombie.
+        health = classify_session_health(
+            s,
+            now=now,
+            process_alive=True,
+            has_artifacts=bool(s.get("artifacts_path")),
+            has_stale_locks=False,
+        )
         out.append({
             "run_id": s["id"],
             "id": s["id"],
@@ -568,12 +582,9 @@ async def list_runs(
             "ended_at": s.get("ended_at"),
             "created_at": s.get("created_at"),
             "updated_at": s.get("updated_at"),
-            # ADR-0019: stored marker + derived label. ``effective_health``
-            # is null for terminal sessions; ADR-0024 expands it with the
-            # full health vocabulary (idle / unresponsive / orphaned /
-            # zombie).
+            # ADR-0019/0024: activity marker + derived health label.
             "last_message_at": s.get("last_message_at"),
-            "effective_health": staleness_check(s, now=now),
+            "effective_health": health.value,
             "branch_count": s.get("branch_count", 0),
             "message_count": s.get("message_count", 0),
         })

--- a/apps/studio/server/services/runs.py
+++ b/apps/studio/server/services/runs.py
@@ -538,7 +538,7 @@ async def list_runs(
     routers/sessions.py.  The /api/runs/{id}/events route in routers/runs.py
     is removed in the same commit.
     """
-    from lionagi.state.health import classify_session_health
+    from lionagi.state.health import SessionHealth, classify_session_health
 
     sessions = await _sessions_svc.list_sessions()
     status_set = _normalize_status_filter(status)
@@ -565,6 +565,16 @@ async def list_runs(
             has_artifacts=bool(s.get("artifacts_path")),
             has_stale_locks=False,
         )
+        # UNRESPONSIVE and STALE both mean "past activity threshold, needs
+        # operator attention". The runs list assumes process_alive=True so
+        # it never emits STALE naturally; the dashboard frontend counts
+        # effective_health === 'stale'. Map UNRESPONSIVE → 'stale' so the
+        # dashboard counter stays correct without requiring a frontend change.
+        effective_health = (
+            SessionHealth.STALE.value
+            if health == SessionHealth.UNRESPONSIVE
+            else health.value
+        )
         out.append({
             "run_id": s["id"],
             "id": s["id"],
@@ -584,7 +594,7 @@ async def list_runs(
             "updated_at": s.get("updated_at"),
             # ADR-0019/0024: activity marker + derived health label.
             "last_message_at": s.get("last_message_at"),
-            "effective_health": health.value,
+            "effective_health": effective_health,
             "branch_count": s.get("branch_count", 0),
             "message_count": s.get("message_count", 0),
         })

--- a/lionagi/outcomes/__init__.py
+++ b/lionagi/outcomes/__init__.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""ADR-0021: structured outputs that skills produce and Studio renders.
+
+The shared contract between CLI skill runners (producers) and Studio
+(consumer). Outcomes are persisted as ``artifacts`` table rows with
+``kind = outcome_kind`` so the frontend's kind-dispatched renderer can
+pick the right card component.
+
+This package holds *domain* types (review verdicts, CI results, gate
+outcomes). Infrastructure types live in :mod:`lionagi.models`; the
+separation is deliberate so a future Studio-only consumer can import
+outcomes without pulling in framework machinery.
+"""
+
+from ._base import SkillOutcome
+from .ci import CIResult
+from .verdict import Finding, GateVerdict, ReviewVerdict
+
+__all__ = [
+    "SkillOutcome",
+    "ReviewVerdict",
+    "GateVerdict",
+    "Finding",
+    "CIResult",
+]

--- a/lionagi/outcomes/_base.py
+++ b/lionagi/outcomes/_base.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""ADR-0021 §A: SkillOutcome base type."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from lionagi.models import HashableModel
+
+
+class SkillOutcome(HashableModel):
+    """Base for all structured skill outputs.
+
+    Concrete subclasses set ``outcome_kind`` to a literal string. The
+    string ends up as ``artifacts.kind`` in the DB and as the dispatch
+    key for the frontend's kind-aware renderer.
+    """
+
+    outcome_kind: str = Field(
+        description=(
+            "Discriminator key for the kind-dispatched renderer. Subclasses "
+            "narrow this to a Literal[...] of one value."
+        )
+    )
+    summary: str | None = Field(
+        default=None,
+        description=(
+            "One-line human-readable summary. Shown in list views before "
+            "the operator clicks through to the full structured outcome."
+        ),
+    )
+    passed: bool | None = Field(
+        default=None,
+        description=(
+            "Tri-state pass/fail. True/False for binary outcomes (gate, CI); "
+            "None when not applicable (e.g. a research analysis with no "
+            "pass/fail semantics)."
+        ),
+    )

--- a/lionagi/outcomes/ci.py
+++ b/lionagi/outcomes/ci.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""ADR-0021 §A: CI / lint / test outcome models."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field
+
+from lionagi.models import HashableModel
+
+from ._base import SkillOutcome
+
+
+class CIRunCommand(HashableModel):
+    """One executed CI command with timing.
+
+    The CIResultCard renders these in a "Commands" panel below the
+    pass/fail matrix.
+    """
+
+    command: str = Field(description="The shell command as executed.")
+    duration_seconds: float = Field(
+        ge=0,
+        description="Wall-clock seconds the command took.",
+    )
+    passed: bool = Field(description="Did the command exit 0?")
+
+
+class CIResult(SkillOutcome):
+    """Aggregated CI outcome — lint + typecheck + tests + build."""
+
+    outcome_kind: Literal["ci_result"] = "ci_result"
+    lint_passed: bool | None = Field(
+        default=None,
+        description="None when lint wasn't run; bool otherwise.",
+    )
+    tests_passed: bool | None = Field(
+        default=None,
+        description="None when tests weren't run; bool otherwise.",
+    )
+    build_passed: bool | None = Field(
+        default=None,
+        description="None when build wasn't run; bool otherwise.",
+    )
+    typecheck_passed: bool | None = Field(
+        default=None,
+        description="None when typecheck wasn't run; bool otherwise.",
+    )
+    test_count: int | None = Field(
+        default=None,
+        ge=0,
+        description="Total tests executed; None when tests weren't run.",
+    )
+    test_failures: int | None = Field(
+        default=None,
+        ge=0,
+        description="Test failure count; None when tests weren't run.",
+    )
+    failure_summary: str | None = Field(
+        default=None,
+        description="Human-readable failure narrative when any step failed.",
+    )
+    commands: list[CIRunCommand] = Field(
+        default_factory=list,
+        description="Per-command timing for the Commands panel.",
+    )

--- a/lionagi/outcomes/verdict.py
+++ b/lionagi/outcomes/verdict.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""ADR-0021 §A: review + gate verdicts.
+
+Produced by codex-pr-review (ReviewVerdict), play-gate (GateVerdict),
+or any skill that issues a binary or graded judgment.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field, field_validator
+
+from lionagi.models import HashableModel
+
+from ._base import SkillOutcome
+
+Severity = Literal["critical", "high", "medium", "low", "info"]
+
+
+class Finding(HashableModel):
+    """One reviewer finding with optional file/line + suggestion."""
+
+    severity: Severity = Field(
+        description="Operator severity bucket (drives sort + render color).",
+    )
+    category: str = Field(
+        description=(
+            "Short free-text taxonomy: 'security', 'correctness', "
+            "'style', 'adr_consistency', 'scope', ..."
+        ),
+    )
+    file: str | None = Field(
+        default=None,
+        description="Repo-relative path the finding applies to, if any.",
+    )
+    line: int | None = Field(
+        default=None,
+        description="1-indexed line number when known.",
+    )
+    description: str = Field(
+        description="What the reviewer noticed (one sentence preferred).",
+    )
+    suggestion: str | None = Field(
+        default=None,
+        description=(
+            "Concrete fix the reviewer recommends. None when the finding "
+            "is informational only."
+        ),
+    )
+
+
+VerdictDecision = Literal[
+    "APPROVE",
+    "APPROVE_WITH_SUGGESTIONS",
+    "REQUEST_CHANGES",
+    "REJECT",
+]
+
+
+class ReviewVerdict(SkillOutcome):
+    """Reviewer judgment + findings list.
+
+    The frontend renders this as the ``ReviewVerdictCard`` (ADR-0021 §E)
+    — severity/category breakdown on top, blocking findings expanded,
+    minor suggestions collapsed.
+    """
+
+    outcome_kind: Literal["review_verdict"] = "review_verdict"
+    verdict: VerdictDecision = Field(
+        description="Top-level decision; drives card color + downstream chain conditions.",
+    )
+
+    @field_validator("verdict", mode="before")
+    @classmethod
+    def _normalize_verdict(cls, v: object) -> object:
+        if isinstance(v, str):
+            return v.replace("-", "_").replace(" ", "_")
+        return v
+    findings: list[Finding] = Field(
+        default_factory=list,
+        description="Findings list — blocking-first ordering is the writer's responsibility.",
+    )
+    round: int = Field(
+        default=1,
+        ge=1,
+        description=(
+            "1-indexed iteration number for multi-round reviews. The "
+            "codex-pr-review skill writes one ReviewVerdict per round."
+        ),
+    )
+
+
+class GateVerdict(SkillOutcome):
+    """Acceptance-criteria gate outcome (play-gate, show-gate, etc.)."""
+
+    outcome_kind: Literal["gate_verdict"] = "gate_verdict"
+    gate_passed: bool = Field(
+        description="Did the gate pass? (Mirrors plays.gate_passed in the DB.)",
+    )
+    feedback: str | None = Field(
+        default=None,
+        description="Reviewer-facing rationale shown on the play detail page.",
+    )
+    notes: str | None = Field(
+        default=None,
+        description="Operator notes (free text). Often empty; rendered when present.",
+    )

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -336,6 +336,11 @@ class StateDB:
         "shows": [
             ("status_source", "TEXT NOT NULL DEFAULT 'unknown'"),
         ],
+        "artifacts": [
+            # Nullable in ALTER TABLE because expressions aren't valid
+            # column defaults there; insert_artifact() always sets this.
+            ("updated_at", "REAL"),
+        ],
     }
 
     async def _reconcile_columns(self) -> None:
@@ -854,6 +859,124 @@ class StateDB:
         )
         rows = await cur.fetchall()
         return [self._row_to_dict(r) for r in rows]
+
+    # ── Artifacts (ADR-0021) ─────────────────────────────────────────────
+
+    async def _find_artifact_id(
+        self,
+        *,
+        kind: str,
+        name: str,
+        invocation_id: str | None,
+        session_id: str | None,
+    ) -> str | None:
+        """Return the artifact id matching the natural key, or None."""
+        if invocation_id is not None and session_id is not None:
+            cur = await self.db.execute(
+                "SELECT id FROM artifacts "
+                "WHERE invocation_id = ? AND session_id = ? AND kind = ? AND name = ?",
+                (invocation_id, session_id, kind, name),
+            )
+        elif invocation_id is not None:
+            cur = await self.db.execute(
+                "SELECT id FROM artifacts "
+                "WHERE invocation_id = ? AND session_id IS NULL AND kind = ? AND name = ?",
+                (invocation_id, kind, name),
+            )
+        elif session_id is not None:
+            cur = await self.db.execute(
+                "SELECT id FROM artifacts "
+                "WHERE session_id = ? AND invocation_id IS NULL AND kind = ? AND name = ?",
+                (session_id, kind, name),
+            )
+        else:
+            cur = await self.db.execute(
+                "SELECT id FROM artifacts "
+                "WHERE invocation_id IS NULL AND session_id IS NULL AND kind = ? AND name = ?",
+                (kind, name),
+            )
+        row = await cur.fetchone()
+        return row["id"] if row else None
+
+    async def insert_artifact(
+        self,
+        *,
+        kind: str,
+        name: str,
+        content: dict[str, Any],
+        invocation_id: str | None = None,
+        session_id: str | None = None,
+        file_path: str | None = None,
+    ) -> str:
+        """Upsert one structured skill artifact; return its stable id.
+
+        ``content`` is typically ``SkillOutcome.model_dump()``. Either
+        ``invocation_id`` or ``session_id`` (or both) should be set so
+        the artifact is reachable from a parent; the schema permits NULL
+        on both for unattached blobs (rare; the API doesn't expose this).
+
+        INSERT OR REPLACE must not be used — it deletes then re-inserts,
+        generating a new id and silently breaking external FK references.
+        We SELECT the existing id first and UPDATE in place; a new id is
+        only minted when no matching row exists.
+        """
+        if not kind:
+            raise ValueError("artifact kind is required")
+        if not name:
+            raise ValueError("artifact name is required")
+        now = time.time()
+        content_json = _to_json_column(content)
+        existing_id = await self._find_artifact_id(
+            kind=kind, name=name, invocation_id=invocation_id, session_id=session_id
+        )
+        if existing_id:
+            await self.db.execute(
+                "UPDATE artifacts SET content = ?, file_path = ?, updated_at = ? "
+                "WHERE id = ?",
+                (content_json, file_path, now, existing_id),
+            )
+            await self.db.commit()
+            return existing_id
+        art_id = uuid.uuid4().hex[:12]
+        await self.db.execute(
+            "INSERT INTO artifacts "
+            "(id, invocation_id, session_id, created_at, updated_at, kind, name, content, file_path) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (art_id, invocation_id, session_id, now, now, kind, name, content_json, file_path),
+        )
+        await self.db.commit()
+        return art_id
+
+    async def list_artifacts_for_invocation(
+        self, invocation_id: str
+    ) -> list[dict[str, Any]]:
+        cur = await self.db.execute(
+            "SELECT * FROM artifacts WHERE invocation_id = ? "
+            "ORDER BY created_at ASC",
+            (invocation_id,),
+        )
+        rows = await cur.fetchall()
+        return [self._row_to_dict(r) for r in rows]
+
+    async def list_artifacts_for_session(
+        self, session_id: str
+    ) -> list[dict[str, Any]]:
+        cur = await self.db.execute(
+            "SELECT * FROM artifacts WHERE session_id = ? "
+            "ORDER BY created_at ASC",
+            (session_id,),
+        )
+        rows = await cur.fetchall()
+        return [self._row_to_dict(r) for r in rows]
+
+    async def get_artifact(
+        self, artifact_id: str
+    ) -> dict[str, Any] | None:
+        cur = await self.db.execute(
+            "SELECT * FROM artifacts WHERE id = ?", (artifact_id,)
+        )
+        row = await cur.fetchone()
+        return self._row_to_dict(row) if row else None
 
     # ── Admin events (ADR-0024) ─────────────────────────────────────────
 

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -855,6 +855,61 @@ class StateDB:
         rows = await cur.fetchall()
         return [self._row_to_dict(r) for r in rows]
 
+    # ── Admin events (ADR-0024) ─────────────────────────────────────────
+
+    async def insert_admin_event(
+        self,
+        *,
+        action: str,
+        details: dict[str, Any],
+        target_id: str | None = None,
+        actor: str = "admin",
+    ) -> str:
+        """Append one row to the admin event log (NIST SP 800-92 pattern).
+
+        Insert-only; the cleanup job is the only allowed deleter. Returns
+        the generated event id so callers can correlate follow-up writes.
+        """
+        event_id = uuid.uuid4().hex[:12]
+        await self.db.execute(
+            "INSERT INTO admin_events (id, created_at, action, target_id, "
+            "details, actor) VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                event_id,
+                time.time(),
+                action,
+                target_id,
+                _to_json_column(details),
+                actor,
+            ),
+        )
+        await self.db.commit()
+        return event_id
+
+    async def list_admin_events(
+        self,
+        *,
+        action: str | None = None,
+        target_id: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        query = "SELECT * FROM admin_events"
+        conds: list[str] = []
+        params: list[Any] = []
+        if action:
+            conds.append("action = ?")
+            params.append(action)
+        if target_id:
+            conds.append("target_id = ?")
+            params.append(target_id)
+        if conds:
+            query += " WHERE " + " AND ".join(conds)
+        query += " ORDER BY created_at DESC LIMIT ?"
+        params.append(limit)
+        cur = await self.db.execute(query, params)
+        rows = await cur.fetchall()
+        return [self._row_to_dict(r) for r in rows]
+
     # ── Branches ───────────────────────────────────────────────────────
 
     async def create_branch(self, branch: dict[str, Any]) -> None:

--- a/lionagi/state/health.py
+++ b/lionagi/state/health.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""ADR-0024: graduated session health classification.
+
+Replaces the binary "phantom / not" with a six-level health model. Each
+level maps to a clear operational action: stale → transition to failed;
+orphaned → repair or delete; zombie → cleanup. Status and health are
+orthogonal — a session can be ``status='running'`` + ``health=stale``
+(reported as running but actually dead).
+
+Health is derived at read time from three signals:
+1. ``status`` (ADR-0025) — what the CLI last wrote.
+2. ``last_message_at`` vs the kind-aware threshold (ADR-0019) — activity.
+3. Process liveness — does the OS still own the PID we recorded?
+
+Terminal sessions (``completed`` / ``failed`` / ``timed_out`` /
+``aborted`` / ``cancelled``) are ``HEALTHY`` unless they left resources
+behind, in which case they're ``ZOMBIE``. Running sessions classify
+along the live/dead × active/idle axes.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from .staleness import DEFAULT_STALE_THRESHOLD, STALE_THRESHOLDS
+
+# An idle session is alive and quiet; an unresponsive one is alive and
+# past the kind-aware threshold. The 1h floor here is the "quiet"
+# boundary — anything below is HEALTHY regardless of activity.
+IDLE_THRESHOLD: int = 3600
+
+
+class SessionHealth(str, Enum):
+    """Six-level derived health (ADR-0024 §A)."""
+
+    HEALTHY = "healthy"
+    IDLE = "idle"
+    UNRESPONSIVE = "unresponsive"
+    STALE = "stale"
+    ORPHANED = "orphaned"
+    ZOMBIE = "zombie"
+
+
+# Pre-sorted by severity so the dashboard "worst of group" calculation
+# is a max-by-index. Keep aligned with the dashboard color tokens.
+HEALTH_SEVERITY: dict[SessionHealth, int] = {
+    SessionHealth.HEALTHY: 0,
+    SessionHealth.IDLE: 1,
+    SessionHealth.UNRESPONSIVE: 2,
+    SessionHealth.STALE: 3,
+    SessionHealth.ORPHANED: 4,
+    SessionHealth.ZOMBIE: 5,
+}
+
+
+def classify_session_health(
+    session: dict[str, Any],
+    *,
+    now: float,
+    process_alive: bool,
+    has_artifacts: bool,
+    has_stale_locks: bool,
+) -> SessionHealth:
+    """Classify a session's effective health.
+
+    Returns :class:`SessionHealth`. Pure function — caller supplies the
+    side-effecting signals (PID liveness, filesystem checks). This makes
+    the classifier trivially testable and lets the Studio backend cache
+    expensive process / FS lookups separately from the decision logic.
+    """
+    status = session.get("status") or "completed"
+
+    # Terminal sessions: done means done, unless they left litter.
+    if status in {"completed", "failed", "timed_out", "aborted", "cancelled"}:
+        if has_stale_locks:
+            return SessionHealth.ZOMBIE
+        # ``has_artifacts`` alone isn't enough to mark zombie — artifacts
+        # are a *good* outcome. Stale locks are the operational signal.
+        return SessionHealth.HEALTHY
+
+    # Below here: status == 'running' (or legacy NULL → treated as
+    # completed above). Active sessions classify along live/dead axes.
+
+    last_activity = (
+        session.get("last_message_at")
+        or session.get("updated_at")
+        or session.get("started_at")
+        or 0
+    )
+    idle_seconds = now - last_activity
+
+    kind = session.get("invocation_kind")
+    threshold = STALE_THRESHOLDS.get(kind, DEFAULT_STALE_THRESHOLD)
+
+    if not process_alive:
+        # Orphan check first: the session was advertised but never
+        # produced a single message AND no artifacts on disk. This is
+        # a session that crashed before doing anything; transitioning
+        # it to failed is harmless, deleting it is also safe.
+        if (
+            not has_artifacts
+            and (session.get("message_count") or 0) == 0
+        ):
+            return SessionHealth.ORPHANED
+        return SessionHealth.STALE
+
+    # Process alive — classify by activity gap.
+    if idle_seconds > threshold:
+        return SessionHealth.UNRESPONSIVE
+    if idle_seconds > IDLE_THRESHOLD:
+        return SessionHealth.IDLE
+    return SessionHealth.HEALTHY
+
+
+def worst_health(values: list[SessionHealth]) -> SessionHealth:
+    """Aggregate child healths to a single "worst" badge.
+
+    Used by the grouped runs view to render the parent invocation row's
+    badge. Empty list returns ``HEALTHY`` — no children means nothing
+    to worry about yet.
+    """
+    if not values:
+        return SessionHealth.HEALTHY
+    return max(values, key=lambda h: HEALTH_SEVERITY[h])

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -316,3 +316,56 @@ CREATE INDEX IF NOT EXISTS idx_admin_events_action
   ON admin_events(action);
 CREATE INDEX IF NOT EXISTS idx_admin_events_target
   ON admin_events(target_id) WHERE target_id IS NOT NULL;
+
+-- ── Artifacts (ADR-0021) ─────────────────────────────────────────────────
+-- Structured skill outputs (review verdicts, gate verdicts, CI results,
+-- ...). The split is DB-for-structured, filesystem-for-blobs: `content`
+-- holds the SkillOutcome.model_dump() JSON; `file_path` optionally
+-- points to a large blob (full log, generated artifact, worktree diff).
+-- `kind` is the discriminator the frontend renderer dispatches on.
+
+CREATE TABLE IF NOT EXISTS artifacts (
+  id              TEXT    PRIMARY KEY,
+  invocation_id   TEXT    REFERENCES invocations(id) ON DELETE CASCADE,
+  session_id      TEXT    REFERENCES sessions(id),
+  created_at      REAL    NOT NULL,
+  updated_at      REAL    NOT NULL DEFAULT (strftime('%s','now')),
+  kind            TEXT    NOT NULL,
+  name            TEXT    NOT NULL,
+  content         JSON    NOT NULL,
+  file_path       TEXT
+);
+
+-- Natural uniqueness keys for idempotent upserts. INSERT OR REPLACE must
+-- NOT be used — it deletes then re-inserts, generating a new id and
+-- breaking external references. Use ON CONFLICT DO UPDATE instead.
+-- SQLite treats NULLs as distinct in UNIQUE indexes, so a single
+-- 4-column index on (invocation_id, session_id, kind, name) fails
+-- when either FK is NULL. Four partial indexes cover every reachable
+-- artifact shape without the NULL-distinctness pitfall.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_artifacts_natural_key_inv_only
+  ON artifacts(invocation_id, kind, name)
+  WHERE invocation_id IS NOT NULL AND session_id IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_artifacts_natural_key_ses_only
+  ON artifacts(session_id, kind, name)
+  WHERE session_id IS NOT NULL AND invocation_id IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_artifacts_natural_key_both
+  ON artifacts(invocation_id, session_id, kind, name)
+  WHERE invocation_id IS NOT NULL AND session_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_artifacts_natural_key_unattached
+  ON artifacts(kind, name)
+  WHERE invocation_id IS NULL AND session_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_artifacts_invocation
+  ON artifacts(invocation_id) WHERE invocation_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_artifacts_session
+  ON artifacts(session_id) WHERE session_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_artifacts_kind ON artifacts(kind);
+CREATE INDEX IF NOT EXISTS idx_artifacts_created
+  ON artifacts(created_at DESC);
+-- Composite indexes that match the ORDER BY shape of the two list
+-- queries — avoids a temp B-tree for the sort step.
+CREATE INDEX IF NOT EXISTS idx_artifacts_invocation_time
+  ON artifacts(invocation_id, created_at) WHERE invocation_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_artifacts_session_time
+  ON artifacts(session_id, created_at) WHERE session_id IS NOT NULL;

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -295,3 +295,24 @@ CREATE TABLE IF NOT EXISTS invocations (
 CREATE INDEX IF NOT EXISTS idx_invocations_skill ON invocations(skill);
 CREATE INDEX IF NOT EXISTS idx_invocations_status ON invocations(status);
 CREATE INDEX IF NOT EXISTS idx_invocations_updated ON invocations(updated_at DESC);
+
+-- ── Admin event log (ADR-0024) ───────────────────────────────────────────
+-- Append-only audit log following NIST SP 800-92 pattern. Every admin
+-- mutation (transition, prune, checkpoint, vacuum, classify) inserts
+-- one row; no UPDATE / DELETE except the bounded cleanup job.
+
+CREATE TABLE IF NOT EXISTS admin_events (
+  id          TEXT    PRIMARY KEY,
+  created_at  REAL    NOT NULL,
+  action      TEXT    NOT NULL,    -- transition|prune|checkpoint|vacuum|classify
+  target_id   TEXT,                -- session_id, or NULL for DB-wide actions
+  details     JSON    NOT NULL,
+  actor       TEXT    NOT NULL DEFAULT 'admin'  -- admin|doctor_auto|chain
+);
+
+CREATE INDEX IF NOT EXISTS idx_admin_events_created
+  ON admin_events(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_admin_events_action
+  ON admin_events(action);
+CREATE INDEX IF NOT EXISTS idx_admin_events_target
+  ON admin_events(target_id) WHERE target_id IS NOT NULL;

--- a/tests/apps_studio_server/test_admin.py
+++ b/tests/apps_studio_server/test_admin.py
@@ -223,3 +223,28 @@ def test_admin_transition_requires_reason(tmp_path, monkeypatch):
         },
     )
     assert r.status_code == 422
+
+
+def test_admin_transition_rejects_healthy_session(tmp_path, monkeypatch):
+    """ADR-0024 health guard: fresh running session with recent activity → 422."""
+    import apps.studio.server.services.admin as admin_mod
+
+    db_path = tmp_path / "state.db"
+    sid = str(uuid.uuid4())
+    _run(_seed_running_session(db_path, sid))
+
+    # Simulate a live process so the classifier returns HEALTHY
+    # (idle_seconds ≈ 0, process alive → HEALTHY).
+    monkeypatch.setattr(admin_mod, "_live_process_matches", lambda *_: True)
+
+    client = _make_client(tmp_path, monkeypatch, db_path)
+    r = client.post(
+        "/api/admin/transition",
+        json={
+            "session_ids": [sid],
+            "target_status": "failed",
+            "reason": "cleanup attempt",
+        },
+    )
+    assert r.status_code == 422
+    assert "healthy" in r.json()["detail"].lower()

--- a/tests/apps_studio_server/test_admin.py
+++ b/tests/apps_studio_server/test_admin.py
@@ -248,3 +248,67 @@ def test_admin_transition_rejects_healthy_session(tmp_path, monkeypatch):
     )
     assert r.status_code == 422
     assert "healthy" in r.json()["detail"].lower()
+
+
+# ─── ADR-0024/FIX-2: health guard re-evaluated per session, not pre-computed ──
+
+
+def test_admin_transition_guard_re_evaluates_health_per_call(tmp_path, monkeypatch):
+    """Health guard reads current session state on each transition_sessions call.
+
+    Bumping last_message_at between two calls changes the health classification;
+    the guard must use the freshest DB state each time (not a pre-computed snapshot).
+    This verifies the merged per-session classify+UPDATE loop correctly re-reads
+    state, minimizing the TOCTOU window between health check and destructive write.
+    """
+    import apps.studio.server.services.admin as admin_mod
+
+    db_path = tmp_path / "state.db"
+    sid = str(uuid.uuid4())
+    _run(_seed_running_session(db_path, sid))
+
+    # Simulate a live process so health is driven by activity threshold.
+    monkeypatch.setattr(admin_mod, "_live_process_matches", lambda *_: True)
+
+    # Set last_message_at to ~2h ago and kind=agent (threshold=6h).
+    # idle_seconds=2h > IDLE_THRESHOLD(1h) but < 6h → IDLE → refused.
+    async def _set_idle():
+        async with StateDB(db_path) as db:
+            await db.db.execute(
+                "UPDATE sessions SET last_message_at = ?, invocation_kind = ? WHERE id = ?",
+                (time.time() - 7200, "agent", sid),
+            )
+            await db.db.commit()
+
+    _run(_set_idle())
+
+    client = _make_client(tmp_path, monkeypatch, db_path)
+
+    # First call: IDLE → refused.
+    r1 = client.post(
+        "/api/admin/transition",
+        json={"session_ids": [sid], "target_status": "failed", "reason": "cleanup"},
+    )
+    assert r1.status_code == 422
+    assert "idle" in r1.json()["detail"].lower()
+
+    # Bump last_message_at past the 6h agent threshold → UNRESPONSIVE → allowed.
+    async def _bump_past_threshold():
+        async with StateDB(db_path) as db:
+            await db.db.execute(
+                "UPDATE sessions SET last_message_at = ? WHERE id = ?",
+                (time.time() - 7 * 3600, sid),
+            )
+            await db.db.commit()
+
+    _run(_bump_past_threshold())
+
+    # Second call: guard re-evaluates from current DB state → succeeds.
+    r2 = client.post(
+        "/api/admin/transition",
+        json={"session_ids": [sid], "target_status": "failed", "reason": "cleanup"},
+    )
+    assert r2.status_code == 200
+    body = r2.json()
+    assert body["transitioned"] == [sid]
+    assert body["skipped"] == []

--- a/tests/apps_studio_server/test_admin.py
+++ b/tests/apps_studio_server/test_admin.py
@@ -113,3 +113,113 @@ def test_admin_prune_rejects_empty_body(tmp_path, monkeypatch):
     client = _make_client(tmp_path, monkeypatch, db_path)
     r = client.post("/api/admin/prune", json={})
     assert r.status_code == 422
+
+
+# ─── ADR-0024: /api/admin/health + /api/admin/transition ─────────────────────
+
+
+def test_admin_health_reports_status_and_health_buckets(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _run(_seed_running_session(db_path, str(uuid.uuid4())))
+    client = _make_client(tmp_path, monkeypatch, db_path)
+    r = client.get("/api/admin/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert "sessions" in body
+    sess = body["sessions"]
+    assert "by_status" in sess
+    assert "by_health" in sess
+    # Seeded one running session.
+    assert sess["by_status"].get("running") == 1
+    # All ADR-0024 health buckets sum to total.
+    assert sum(sess["by_health"].values()) == sess["total"]
+
+
+def test_admin_transition_marks_running_session_failed(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    sid = str(uuid.uuid4())
+    _run(_seed_running_session(db_path, sid))
+    client = _make_client(tmp_path, monkeypatch, db_path)
+
+    r = client.post(
+        "/api/admin/transition",
+        json={
+            "session_ids": [sid],
+            "target_status": "failed",
+            "reason": "manual cleanup after restart",
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["transitioned"] == [sid]
+    assert body["skipped"] == []
+    assert body["event_id"]  # admin_events row written
+
+    # Verify DB state changed.
+    async def _check():
+        async with StateDB(db_path) as db:
+            row = await db.get_session(sid)
+            assert row["status"] == "failed"
+            assert row["ended_at"] is not None
+            events = await db.list_admin_events(action="transition")
+            assert len(events) == 1
+            assert events[0]["actor"] == "admin"
+
+    _run(_check())
+
+
+def test_admin_transition_rejects_invalid_target(tmp_path, monkeypatch):
+    """ADR-0025: admin operators cannot mark sessions completed or timed_out."""
+    db_path = tmp_path / "state.db"
+    client = _make_client(tmp_path, monkeypatch, db_path)
+    r = client.post(
+        "/api/admin/transition",
+        json={
+            "session_ids": ["any"],
+            "target_status": "completed",  # not in admin-allowed set
+            "reason": "test",
+        },
+    )
+    assert r.status_code == 422
+
+
+def test_admin_transition_skips_non_running(tmp_path, monkeypatch):
+    """Already-terminal sessions are reported as skipped, not silently no-op."""
+    db_path = tmp_path / "state.db"
+    sid = str(uuid.uuid4())
+    _run(_seed_running_session(db_path, sid))
+
+    async def _terminal():
+        async with StateDB(db_path) as db:
+            await db.update_session(sid, status="completed")
+
+    _run(_terminal())
+
+    client = _make_client(tmp_path, monkeypatch, db_path)
+    r = client.post(
+        "/api/admin/transition",
+        json={
+            "session_ids": [sid],
+            "target_status": "failed",
+            "reason": "test",
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["transitioned"] == []
+    assert len(body["skipped"]) == 1
+    assert body["skipped"][0]["session_id"] == sid
+
+
+def test_admin_transition_requires_reason(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    client = _make_client(tmp_path, monkeypatch, db_path)
+    r = client.post(
+        "/api/admin/transition",
+        json={
+            "session_ids": ["x"],
+            "target_status": "failed",
+            "reason": "",
+        },
+    )
+    assert r.status_code == 422

--- a/tests/apps_studio_server/test_runs_list.py
+++ b/tests/apps_studio_server/test_runs_list.py
@@ -109,3 +109,51 @@ def test_runs_list_invalid_page_rejected(tmp_path, monkeypatch):
     client = _make_client(tmp_path, monkeypatch, db_path)
     r = client.get("/api/runs?page=0")
     assert r.status_code == 422
+
+
+# ─── ADR-0024/FIX-1: UNRESPONSIVE maps to 'stale' in runs list ───────────────
+
+
+async def _seed_running_session_with_activity(
+    db_path: Path, session_id: str, last_message_at: float, invocation_kind: str = "agent"
+) -> None:
+    async with StateDB(db_path) as db:
+        pid = str(uuid.uuid4())
+        await db.create_progression(pid)
+        await db.create_session({
+            "id": session_id,
+            "progression_id": pid,
+            "name": "test-stale",
+            "status": "running",
+            "invocation_kind": invocation_kind,
+            "started_at": last_message_at,
+            "last_message_at": last_message_at,
+        })
+
+
+def test_runs_list_threshold_crossing_session_reports_stale_not_unresponsive(
+    tmp_path, monkeypatch
+):
+    """Running session past its kind-aware threshold → effective_health='stale'.
+
+    The full ADR-0024 classifier returns UNRESPONSIVE (process alive + past
+    threshold), but the dashboard frontend counts effective_health==='stale'.
+    The runs list MUST map UNRESPONSIVE → 'stale' so the dashboard counter
+    stays correct.
+    """
+    db_path = tmp_path / "state.db"
+    sid = str(uuid.uuid4())
+    # last_message_at = 7h ago; agent threshold = 6h → UNRESPONSIVE without fix
+    old_activity = time.time() - 7 * 3600
+    _run(_seed_running_session_with_activity(db_path, sid, last_message_at=old_activity))
+    client = _make_client(tmp_path, monkeypatch, db_path)
+
+    r = client.get("/api/runs")
+    assert r.status_code == 200
+    runs = r.json()["runs"]
+    target = next((run for run in runs if run["id"] == sid), None)
+    assert target is not None, "seeded session not found in runs list"
+    assert target["effective_health"] == "stale", (
+        f"expected 'stale', got {target['effective_health']!r}; "
+        "UNRESPONSIVE must be mapped to 'stale' for dashboard compatibility"
+    )

--- a/tests/outcomes/test_outcome_models.py
+++ b/tests/outcomes/test_outcome_models.py
@@ -1,0 +1,186 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""ADR-0021 outcome model tests.
+
+The outcomes package is the contract between skill producers and Studio
+consumers. These tests pin the public schema so any breaking change
+shows up here, not in a downstream serialization mismatch.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from lionagi.outcomes import (
+    CIResult,
+    Finding,
+    GateVerdict,
+    ReviewVerdict,
+    SkillOutcome,
+)
+from lionagi.outcomes.ci import CIRunCommand
+
+# ── SkillOutcome base ─────────────────────────────────────────────────────────
+
+
+def test_skill_outcome_passed_defaults_to_none():
+    o = SkillOutcome(outcome_kind="x", summary="hello")
+    assert o.passed is None
+    assert o.outcome_kind == "x"
+    assert o.summary == "hello"
+
+
+def test_skill_outcome_dump_round_trips():
+    o = SkillOutcome(outcome_kind="x", summary="hello", passed=True)
+    dumped = o.model_dump()
+    again = SkillOutcome.model_validate(dumped)
+    assert again == o
+
+
+# ── ReviewVerdict ─────────────────────────────────────────────────────────────
+
+
+def test_review_verdict_default_outcome_kind_pinned():
+    """ADR-0021 promises kind='review_verdict' — frontend dispatch depends on it."""
+    v = ReviewVerdict(
+        verdict="APPROVE",
+        summary="LGTM",
+    )
+    assert v.outcome_kind == "review_verdict"
+    assert v.round == 1
+    assert v.findings == []
+
+
+def test_review_verdict_accepts_hyphenated_producer_string():
+    """Producer strings like APPROVE-WITH-SUGGESTIONS are normalized on ingest."""
+    v = ReviewVerdict.model_validate({"verdict": "APPROVE-WITH-SUGGESTIONS", "summary": "ok"})
+    assert v.verdict == "APPROVE_WITH_SUGGESTIONS"
+
+
+def test_review_verdict_accepts_spaced_producer_string():
+    v = ReviewVerdict.model_validate({"verdict": "REQUEST CHANGES", "summary": "ok"})
+    assert v.verdict == "REQUEST_CHANGES"
+
+
+def test_review_verdict_rejects_unknown_decision():
+    with pytest.raises(ValidationError):
+        ReviewVerdict(verdict="MEH", summary="?")
+
+
+def test_review_verdict_round_must_be_positive():
+    with pytest.raises(ValidationError):
+        ReviewVerdict(verdict="APPROVE", summary="ok", round=0)
+
+
+def test_finding_severity_constrained():
+    Finding(
+        severity="critical",
+        category="security",
+        description="rm -rf in user input",
+    )
+    with pytest.raises(ValidationError):
+        Finding(severity="hot", category="x", description="y")
+
+
+def test_review_verdict_dump_round_trips():
+    v = ReviewVerdict(
+        verdict="REQUEST_CHANGES",
+        summary="3 issues",
+        passed=False,
+        round=2,
+        findings=[
+            Finding(
+                severity="high",
+                category="correctness",
+                file="src/main.py",
+                line=42,
+                description="off-by-one",
+                suggestion="use range(n+1)",
+            )
+        ],
+    )
+    dumped = v.model_dump()
+    assert dumped["outcome_kind"] == "review_verdict"
+    again = ReviewVerdict.model_validate(dumped)
+    assert again == v
+
+
+# ── GateVerdict ───────────────────────────────────────────────────────────────
+
+
+def test_gate_verdict_without_summary():
+    """GateVerdict must validate raw play-gate JSON that has no summary field."""
+    g = GateVerdict.model_validate({"gate_passed": True, "passed": True})
+    assert g.summary is None
+    assert g.gate_passed is True
+    assert g.outcome_kind == "gate_verdict"
+
+
+def test_gate_verdict_dump_round_trips():
+    g = GateVerdict(
+        summary="gate failed: missing artifact",
+        gate_passed=False,
+        feedback="implementation_1012.md missing from artifact path",
+        passed=False,
+    )
+    dumped = g.model_dump()
+    assert dumped["outcome_kind"] == "gate_verdict"
+    assert dumped["gate_passed"] is False
+    assert GateVerdict.model_validate(dumped) == g
+
+
+# ── CIResult ──────────────────────────────────────────────────────────────────
+
+
+def test_ci_result_all_optional_when_step_skipped():
+    """A CIResult that ran only tests has None for lint/build/typecheck."""
+    r = CIResult(
+        summary="119/119",
+        passed=True,
+        tests_passed=True,
+        test_count=119,
+        test_failures=0,
+    )
+    assert r.lint_passed is None
+    assert r.build_passed is None
+    assert r.typecheck_passed is None
+
+
+def test_ci_run_command_rejects_negative_duration():
+    with pytest.raises(ValidationError):
+        CIRunCommand(command="pytest", duration_seconds=-1, passed=True)
+
+
+def test_ci_result_dump_round_trips():
+    r = CIResult(
+        summary="all green",
+        passed=True,
+        tests_passed=True,
+        lint_passed=True,
+        test_count=42,
+        test_failures=0,
+        commands=[
+            CIRunCommand(command="pytest", duration_seconds=12.5, passed=True),
+            CIRunCommand(command="ruff", duration_seconds=0.8, passed=True),
+        ],
+    )
+    dumped = r.model_dump()
+    assert dumped["outcome_kind"] == "ci_result"
+    again = CIResult.model_validate(dumped)
+    assert again == r
+
+
+# ── Kind dispatch contract ────────────────────────────────────────────────────
+
+
+def test_outcome_kinds_are_distinct():
+    """Each concrete outcome must have a unique outcome_kind string —
+    the frontend's switch dispatches on this value."""
+    kinds = {
+        ReviewVerdict(verdict="APPROVE", summary="x").outcome_kind,
+        GateVerdict(summary="x", gate_passed=True).outcome_kind,
+        CIResult(summary="x").outcome_kind,
+    }
+    assert len(kinds) == 3

--- a/tests/state/test_admin_events.py
+++ b/tests/state/test_admin_events.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""ADR-0024 admin event log tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.state.db import StateDB
+
+
+@pytest.fixture
+async def db():
+    state = StateDB(":memory:")
+    await state.open()
+    yield state
+    await state.close()
+
+
+async def test_insert_and_list_admin_event(db: StateDB):
+    eid = await db.insert_admin_event(
+        action="transition",
+        target_id="abc",
+        actor="admin",
+        details={"target_status": "failed", "reason": "manual cleanup"},
+    )
+    assert isinstance(eid, str) and len(eid) == 12
+
+    events = await db.list_admin_events()
+    assert len(events) == 1
+    e = events[0]
+    assert e["action"] == "transition"
+    assert e["target_id"] == "abc"
+    assert e["actor"] == "admin"
+
+
+async def test_list_filters_by_action(db: StateDB):
+    await db.insert_admin_event(action="transition", details={})
+    await db.insert_admin_event(action="prune", details={})
+    await db.insert_admin_event(action="checkpoint", details={})
+
+    transitions = await db.list_admin_events(action="transition")
+    assert len(transitions) == 1
+    assert transitions[0]["action"] == "transition"
+
+
+async def test_list_filters_by_target_id(db: StateDB):
+    await db.insert_admin_event(action="classify", target_id="s1", details={})
+    await db.insert_admin_event(action="classify", target_id="s2", details={})
+
+    only_s1 = await db.list_admin_events(target_id="s1")
+    assert {r["target_id"] for r in only_s1} == {"s1"}
+
+
+async def test_events_returned_newest_first(db: StateDB):
+    import asyncio
+
+    a = await db.insert_admin_event(action="a", details={})
+    await asyncio.sleep(0.01)
+    b = await db.insert_admin_event(action="b", details={})
+
+    events = await db.list_admin_events()
+    assert [e["id"] for e in events][0] == b
+    assert [e["id"] for e in events][1] == a

--- a/tests/state/test_artifacts.py
+++ b/tests/state/test_artifacts.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""ADR-0021 artifacts table tests."""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import pytest
+
+from lionagi.outcomes import GateVerdict, ReviewVerdict
+from lionagi.state.db import StateDB
+
+
+@pytest.fixture
+async def db():
+    state = StateDB(":memory:")
+    await state.open()
+    yield state
+    await state.close()
+
+
+async def _make_invocation(db: StateDB, **fields) -> dict:
+    inv = {
+        "id": uuid.uuid4().hex[:12],
+        "skill": fields.pop("skill", "codex-pr-review"),
+        "started_at": fields.pop("started_at", time.time()),
+        **fields,
+    }
+    await db.create_invocation(inv)
+    return inv
+
+
+async def _make_session(db: StateDB, **fields) -> dict:
+    prog_id = str(uuid.uuid4())
+    await db.create_progression(prog_id)
+    s = {"id": str(uuid.uuid4()), "progression_id": prog_id, **fields}
+    await db.create_session(s)
+    return s
+
+
+# ── Insert + read ────────────────────────────────────────────────────────────
+
+
+async def test_insert_artifact_with_invocation_link(db: StateDB):
+    inv = await _make_invocation(db)
+    verdict = ReviewVerdict(
+        verdict="APPROVE",
+        summary="LGTM",
+        round=1,
+    )
+    art_id = await db.insert_artifact(
+        invocation_id=inv["id"],
+        kind=verdict.outcome_kind,
+        name="Round 1 verdict",
+        content=verdict.model_dump(),
+    )
+    assert isinstance(art_id, str) and len(art_id) == 12
+
+    rows = await db.list_artifacts_for_invocation(inv["id"])
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "review_verdict"
+    assert rows[0]["name"] == "Round 1 verdict"
+
+
+async def test_insert_artifact_with_session_link(db: StateDB):
+    s = await _make_session(db, status="completed")
+    gate = GateVerdict(
+        summary="ok", gate_passed=True, feedback="all green", passed=True
+    )
+    await db.insert_artifact(
+        session_id=s["id"],
+        kind=gate.outcome_kind,
+        name="play-gate",
+        content=gate.model_dump(),
+    )
+    rows = await db.list_artifacts_for_session(s["id"])
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "gate_verdict"
+
+
+async def test_get_artifact(db: StateDB):
+    inv = await _make_invocation(db)
+    art_id = await db.insert_artifact(
+        invocation_id=inv["id"],
+        kind="ci_result",
+        name="CI",
+        content={"summary": "all green", "passed": True},
+    )
+    row = await db.get_artifact(art_id)
+    assert row is not None
+    assert row["kind"] == "ci_result"
+
+
+async def test_get_artifact_missing_returns_none(db: StateDB):
+    assert await db.get_artifact("notarealid") is None
+
+
+# ── Validation ───────────────────────────────────────────────────────────────
+
+
+async def test_insert_artifact_requires_kind(db: StateDB):
+    with pytest.raises(ValueError, match="kind is required"):
+        await db.insert_artifact(kind="", name="x", content={})
+
+
+async def test_insert_artifact_requires_name(db: StateDB):
+    with pytest.raises(ValueError, match="name is required"):
+        await db.insert_artifact(kind="x", name="", content={})
+
+
+# ── FK cascade ────────────────────────────────────────────────────────────────
+
+
+async def test_artifacts_cascade_when_invocation_deleted(db: StateDB):
+    """Invocation FK uses ON DELETE CASCADE — orphan artifacts shouldn't linger."""
+    inv = await _make_invocation(db)
+    art_id = await db.insert_artifact(
+        invocation_id=inv["id"],
+        kind="review_verdict",
+        name="x",
+        content={"verdict": "APPROVE"},
+    )
+    await db.db.execute("DELETE FROM invocations WHERE id = ?", (inv["id"],))
+    await db.db.commit()
+    assert await db.get_artifact(art_id) is None
+
+
+# ── Idempotency ───────────────────────────────────────────────────────────────
+
+
+async def test_insert_artifact_is_idempotent(db: StateDB):
+    """Upsert keeps count at 1 when the same natural key is reused."""
+    inv = await _make_invocation(db)
+    for _ in range(2):
+        await db.insert_artifact(
+            invocation_id=inv["id"],
+            kind="review_verdict",
+            name="Round 1",
+            content={"verdict": "APPROVE"},
+        )
+    rows = await db.list_artifacts_for_invocation(inv["id"])
+    assert len(rows) == 1
+
+
+async def test_insert_artifact_preserves_id_on_upsert(db: StateDB):
+    """Second insert with the same natural key must return the original id."""
+    inv = await _make_invocation(db)
+    first_id = await db.insert_artifact(
+        invocation_id=inv["id"],
+        kind="review_verdict",
+        name="Round 1",
+        content={"verdict": "REQUEST_CHANGES"},
+    )
+    second_id = await db.insert_artifact(
+        invocation_id=inv["id"],
+        kind="review_verdict",
+        name="Round 1",
+        content={"verdict": "APPROVE"},
+    )
+    assert first_id == second_id, "upsert must not generate a new id on conflict"
+
+
+async def test_insert_artifact_idempotent_updates_content(db: StateDB):
+    """Second insert with the same key replaces the content."""
+    inv = await _make_invocation(db)
+    await db.insert_artifact(
+        invocation_id=inv["id"],
+        kind="review_verdict",
+        name="Round 1",
+        content={"verdict": "REQUEST_CHANGES"},
+    )
+    await db.insert_artifact(
+        invocation_id=inv["id"],
+        kind="review_verdict",
+        name="Round 1",
+        content={"verdict": "APPROVE"},
+    )
+    rows = await db.list_artifacts_for_invocation(inv["id"])
+    assert len(rows) == 1
+    assert rows[0]["content"]["verdict"] == "APPROVE"
+
+
+# ── Ordering ──────────────────────────────────────────────────────────────────
+
+
+async def test_list_artifacts_ordered_by_created_at(db: StateDB):
+    import asyncio
+
+    inv = await _make_invocation(db)
+    ids = []
+    for i in range(3):
+        ids.append(
+            await db.insert_artifact(
+                invocation_id=inv["id"],
+                kind="review_verdict",
+                name=f"round-{i+1}",
+                content={"verdict": "APPROVE", "round": i + 1},
+            )
+        )
+        await asyncio.sleep(0.01)
+
+    rows = await db.list_artifacts_for_invocation(inv["id"])
+    assert [r["id"] for r in rows] == ids

--- a/tests/state/test_health.py
+++ b/tests/state/test_health.py
@@ -1,0 +1,273 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""ADR-0024 session health classifier tests.
+
+Pure-function classifier — caller passes process / artifact / lock
+signals so tests don't need real PIDs or filesystems.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.state.health import (
+    HEALTH_SEVERITY,
+    IDLE_THRESHOLD,
+    SessionHealth,
+    classify_session_health,
+    worst_health,
+)
+
+NOW = 1_000_000.0
+
+
+# ── Terminal sessions ────────────────────────────────────────────────────────
+
+
+def test_completed_session_with_clean_resources_is_healthy():
+    s = {"status": "completed"}
+    assert (
+        classify_session_health(
+            s,
+            now=NOW,
+            process_alive=False,
+            has_artifacts=True,
+            has_stale_locks=False,
+        )
+        == SessionHealth.HEALTHY
+    )
+
+
+def test_terminal_session_with_stale_locks_is_zombie():
+    """Stale locks left after a terminal session = leaked resources."""
+    for status in ("completed", "failed", "timed_out", "aborted", "cancelled"):
+        s = {"status": status}
+        h = classify_session_health(
+            s,
+            now=NOW,
+            process_alive=False,
+            has_artifacts=True,
+            has_stale_locks=True,
+        )
+        assert h == SessionHealth.ZOMBIE, f"{status!r} with locks should be zombie"
+
+
+def test_terminal_session_artifacts_alone_not_zombie():
+    """Artifacts are a *good* outcome — not the zombie signal."""
+    s = {"status": "completed"}
+    h = classify_session_health(
+        s,
+        now=NOW,
+        process_alive=False,
+        has_artifacts=True,
+        has_stale_locks=False,
+    )
+    assert h == SessionHealth.HEALTHY
+
+
+# ── Running, process alive ────────────────────────────────────────────────────
+
+
+def test_running_with_recent_messages_is_healthy():
+    s = {
+        "status": "running",
+        "invocation_kind": "agent",
+        "last_message_at": NOW - 60,
+    }
+    h = classify_session_health(
+        s,
+        now=NOW,
+        process_alive=True,
+        has_artifacts=True,
+        has_stale_locks=False,
+    )
+    assert h == SessionHealth.HEALTHY
+
+
+def test_running_quiet_under_2h_is_idle_not_unresponsive():
+    """Quiet for >1h but under the kind-aware threshold = idle."""
+    s = {
+        "status": "running",
+        "invocation_kind": "agent",
+        "last_message_at": NOW - (IDLE_THRESHOLD + 60),  # ~1h 1m
+    }
+    h = classify_session_health(
+        s,
+        now=NOW,
+        process_alive=True,
+        has_artifacts=True,
+        has_stale_locks=False,
+    )
+    assert h == SessionHealth.IDLE
+
+
+def test_running_past_threshold_alive_is_unresponsive():
+    """Process alive but past kind-aware threshold (6h for agent)."""
+    s = {
+        "status": "running",
+        "invocation_kind": "agent",
+        "last_message_at": NOW - (6 * 3600 + 60),
+    }
+    h = classify_session_health(
+        s,
+        now=NOW,
+        process_alive=True,
+        has_artifacts=True,
+        has_stale_locks=False,
+    )
+    assert h == SessionHealth.UNRESPONSIVE
+
+
+def test_flow_threshold_more_lenient_than_agent():
+    """Same 9h gap → unresponsive for agent, idle for flow."""
+    nine_hours_ago = NOW - (9 * 3600)
+    agent = {
+        "status": "running",
+        "invocation_kind": "agent",
+        "last_message_at": nine_hours_ago,
+    }
+    flow = {
+        "status": "running",
+        "invocation_kind": "flow",
+        "last_message_at": nine_hours_ago,
+    }
+    assert (
+        classify_session_health(
+            agent,
+            now=NOW,
+            process_alive=True,
+            has_artifacts=True,
+            has_stale_locks=False,
+        )
+        == SessionHealth.UNRESPONSIVE
+    )
+    assert (
+        classify_session_health(
+            flow,
+            now=NOW,
+            process_alive=True,
+            has_artifacts=True,
+            has_stale_locks=False,
+        )
+        == SessionHealth.IDLE
+    )
+
+
+# ── Running, process dead ────────────────────────────────────────────────────
+
+
+def test_running_process_dead_with_messages_is_stale():
+    s = {
+        "status": "running",
+        "invocation_kind": "agent",
+        "last_message_at": NOW - 200,
+        "message_count": 5,
+    }
+    h = classify_session_health(
+        s,
+        now=NOW,
+        process_alive=False,
+        has_artifacts=True,
+        has_stale_locks=False,
+    )
+    assert h == SessionHealth.STALE
+
+
+def test_running_process_dead_no_output_is_orphaned():
+    """Never wrote a message, never produced artifacts, process gone."""
+    s = {
+        "status": "running",
+        "invocation_kind": "agent",
+        "last_message_at": None,
+        "message_count": 0,
+    }
+    h = classify_session_health(
+        s,
+        now=NOW,
+        process_alive=False,
+        has_artifacts=False,
+        has_stale_locks=False,
+    )
+    assert h == SessionHealth.ORPHANED
+
+
+def test_running_process_dead_no_messages_but_has_artifacts_is_stale():
+    """Artifacts present means the session produced *something* — not orphaned."""
+    s = {
+        "status": "running",
+        "invocation_kind": "agent",
+        "last_message_at": NOW - 200,
+        "message_count": 0,
+    }
+    h = classify_session_health(
+        s,
+        now=NOW,
+        process_alive=False,
+        has_artifacts=True,
+        has_stale_locks=False,
+    )
+    assert h == SessionHealth.STALE
+
+
+# ── Edge cases ────────────────────────────────────────────────────────────────
+
+
+def test_null_status_treated_as_completed():
+    """ADR-0017 legacy rows with NULL status fall through the terminal branch."""
+    s = {"status": None}
+    h = classify_session_health(
+        s,
+        now=NOW,
+        process_alive=False,
+        has_artifacts=False,
+        has_stale_locks=False,
+    )
+    assert h == SessionHealth.HEALTHY
+
+
+def test_missing_invocation_kind_uses_default_threshold():
+    """Unknown kinds fall back to DEFAULT_STALE_THRESHOLD (6h)."""
+    s = {
+        "status": "running",
+        "invocation_kind": "mystery-kind",
+        "last_message_at": NOW - (6 * 3600 + 60),
+    }
+    h = classify_session_health(
+        s,
+        now=NOW,
+        process_alive=True,
+        has_artifacts=True,
+        has_stale_locks=False,
+    )
+    assert h == SessionHealth.UNRESPONSIVE
+
+
+# ── worst_health aggregator (grouped runs view) ──────────────────────────────
+
+
+def test_worst_health_picks_highest_severity():
+    inputs = [
+        SessionHealth.HEALTHY,
+        SessionHealth.STALE,
+        SessionHealth.IDLE,
+    ]
+    assert worst_health(inputs) == SessionHealth.STALE
+
+
+def test_worst_health_empty_is_healthy():
+    """Nothing to worry about yet."""
+    assert worst_health([]) == SessionHealth.HEALTHY
+
+
+def test_worst_health_zombie_beats_orphaned():
+    """Zombie sits at the top of the severity scale."""
+    assert (
+        worst_health([SessionHealth.ORPHANED, SessionHealth.ZOMBIE])
+        == SessionHealth.ZOMBIE
+    )
+
+
+def test_severity_table_covers_all_health_levels():
+    """Catch drift between SessionHealth and HEALTH_SEVERITY."""
+    assert set(HEALTH_SEVERITY) == set(SessionHealth)


### PR DESCRIPTION
## Summary

Implements **ADR-0024 — Session Health Classification and Admin Surface**. Adds the six-level derived health vocabulary, the admin transition endpoint, and the StatusPill taxonomy refactor.

**Stacks on top of #1050 (ADR-0020).** Base branch is \`feat/adr-0020-skill-invocations\`; will rebase to main once the chain merges.

## What ships

### Health classifier (\`lionagi/state/health.py\`)
- \`SessionHealth\` enum: HEALTHY / IDLE / UNRESPONSIVE / STALE / ORPHANED / ZOMBIE.
- \`classify_session_health(...)\` — pure function so it's trivially testable.
- \`worst_health()\` aggregator for the grouped runs view's "worst of group" badge.

Decision matrix:

| Status | Process alive | Activity | Result |
|--------|---------------|----------|--------|
| terminal | — | — | HEALTHY (or ZOMBIE if stale locks) |
| running | yes | < 1h quiet | HEALTHY |
| running | yes | 1h-threshold quiet | IDLE |
| running | yes | past threshold | UNRESPONSIVE |
| running | no | has output | STALE |
| running | no | no messages, no artifacts | ORPHANED |

### Schema
- \`admin_events\` table — append-only NIST SP 800-92 audit log. Insert-only writes; cleanup is the only allowed deleter. 3 indexes (created_at DESC, action, target_id partial).

### Admin API (additive — old \`doctor\` + \`prune\` untouched)
- \`GET /api/admin/health\` — composite report: by_status + by_health + unhealthy list. Uses existing PID/ps + stale-lock checks for classifier signals.
- \`POST /api/admin/transition\` — mark running sessions terminal. Targets: failed / aborted / cancelled (ADR-0025 admin subset). \`reason\` required. Writes audit log row.
- \`GET /api/admin/events\` — paginated audit log read.

### Frontend
- \`StatusPill.tsx\` — new \`taxonomy\` prop with per-taxonomy tone overrides. ADR-0024 health mappings: healthy→ok, idle→neutral, unresponsive→pending (amber), stale→pending (amber/orange), orphaned→blocked (purple), zombie→failed (red).
- \`/runs/page.tsx\` — new **Health** column. When session is running + health degraded, Status pill renders neutral so the operator's eye lands on Health (implements §C "do not show a blue Running pill alone when health is stale").

## Deferred to ADR-0024b fast-follow
- Full admin page redesign: intervention queue UI, transition modal, Resources + Event log panels.
- Dashboard metric card refresh: Attention / Active / Outcomes / Latency.
- Worktree resource tracking + disk usage endpoint.
- Auto-doctor background scan.
- Process-liveness + stale-lock checks in the runs list (currently activity-only; full classification only in \`/api/admin/health\`).

## Test plan

- [x] \`uv run pytest tests/state/test_health.py\` — 15 tests pass
- [x] \`uv run pytest tests/state/test_admin_events.py\` — 4 tests pass
- [x] \`uv run pytest tests/apps_studio_server/test_admin.py\` — +5 new tests (health endpoint, transition writes DB + audit, rejects invalid target, skips non-running, requires reason)
- [x] Full regression: 883 tests pass across state/cli/operations/apps_studio_server
- [x] \`uv run ruff check\` clean; \`npx tsc --noEmit\` clean
- [ ] Smoke test: \`curl http://localhost:8765/api/admin/health | jq\` — verify by_health bucket sums match by_status total
- [ ] Smoke test: \`curl -X POST http://localhost:8765/api/admin/transition -d '{...}'\` against a real running session
- [ ] Visual walkthrough: /runs page Health column; degraded running rows show neutral Status + active Health pill; StatusPill tones match ADR-0024 color spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)