### PR TITLE
feat: ADR-0021 skill artifacts + outcome models (Layer 4a, chains deferred)

### DIFF
--- a/apps/studio/frontend/app/invocations/[id]/page.tsx
+++ b/apps/studio/frontend/app/invocations/[id]/page.tsx
@@ -7,6 +7,7 @@ import PageHeader from "@/components/PageHeader";
 import StatusPill from "@/components/StatusPill";
 import Timestamp from "@/components/Timestamp";
 import Duration from "@/components/Duration";
+import OutcomeRenderer from "@/components/outcomes/OutcomeRenderer";
 import { getInvocation } from "@/lib/api";
 import type { InvocationDetail } from "@/lib/api";
 
@@ -171,6 +172,19 @@ export default function InvocationDetailPage() {
           </table>
         </div>
       </section>
+
+      {data.artifacts.length > 0 ? (
+        <section>
+          <h2 className="mb-2 text-meta uppercase tracking-[0.06em] text-content-muted">
+            Outcomes ({data.artifacts.length})
+          </h2>
+          <div className="space-y-3">
+            {data.artifacts.map((a) => (
+              <OutcomeRenderer key={a.id} artifact={a} />
+            ))}
+          </div>
+        </section>
+      ) : null}
 
       {data.node_metadata && Object.keys(data.node_metadata).length > 0 ? (
         <section>

--- a/apps/studio/frontend/components/StatusPill.tsx
+++ b/apps/studio/frontend/components/StatusPill.tsx
@@ -80,6 +80,7 @@ const TONE_BY_VALUE: Record<string, StatusTone> = {
   // verdict
   passed: "ok",
   approved: "ok",
+  approve_with_suggestions: "ok",
   rejected: "failed",
   "approve-with-fixes": "pending",
   // integration
@@ -116,6 +117,7 @@ const TONE_BY_TAXONOMY: Record<StatusTaxonomy, Record<string, StatusTone>> = {
   verdict: {
     approve: "ok",
     approved: "ok",
+    approve_with_suggestions: "ok",
     "approve-with-fixes": "pending",
     request_changes: "pending",
     reject: "failed",
@@ -145,6 +147,7 @@ const LABEL_OVERRIDES: Record<string, string> = {
   running_complete: "Run complete",
   merged_and_pushed: "Merged + pushed",
   in_progress: "In progress",
+  approve_with_suggestions: "Approve w/ suggestions",
   "approve-with-fixes": "Approve w/ fixes",
   timed_out: "Timed out",
   needs_review: "Needs review",

--- a/apps/studio/frontend/components/outcomes/CIResultCard.tsx
+++ b/apps/studio/frontend/components/outcomes/CIResultCard.tsx
@@ -1,0 +1,152 @@
+// ADR-0021 §E: CIResultCard renders the lint/test/build/typecheck
+// matrix with per-command timings — the layout from the spec.
+
+import StatusPill from "@/components/StatusPill";
+
+interface CIRunCommand {
+  command: string;
+  duration_seconds: number;
+  passed: boolean;
+}
+
+interface CIResultContent {
+  lint_passed?: boolean | null;
+  tests_passed?: boolean | null;
+  build_passed?: boolean | null;
+  typecheck_passed?: boolean | null;
+  test_count?: number | null;
+  test_failures?: number | null;
+  failure_summary?: string | null;
+  commands?: CIRunCommand[];
+  summary?: string;
+  passed?: boolean | null;
+}
+
+interface CIResultCardProps {
+  name: string;
+  content: Record<string, unknown>;
+}
+
+function formatDuration(s: number): string {
+  if (s < 60) return `${s.toFixed(1)}s`;
+  const m = Math.floor(s / 60);
+  const r = Math.round(s - m * 60);
+  return r > 0 ? `${m}m ${r}s` : `${m}m`;
+}
+
+function CheckRow({
+  label,
+  passed,
+  detail,
+}: {
+  label: string;
+  passed: boolean | null | undefined;
+  detail?: string;
+}) {
+  if (passed == null) return null;
+  return (
+    <div className="flex items-center justify-between gap-3 py-1 text-body">
+      <span className="text-content-primary">{label}</span>
+      <span className="flex items-center gap-2">
+        {detail ? (
+          <span className="tabular-nums text-content-secondary">{detail}</span>
+        ) : null}
+        <span
+          className={
+            "tabular-nums " +
+            (passed ? "text-status-success" : "text-status-error")
+          }
+        >
+          {passed ? "passed" : "failed"}
+        </span>
+      </span>
+    </div>
+  );
+}
+
+export default function CIResultCard({ name, content }: CIResultCardProps) {
+  const c = content as unknown as CIResultContent;
+  const overall =
+    c.passed ??
+    [c.lint_passed, c.tests_passed, c.build_passed, c.typecheck_passed]
+      .filter((v) => v != null)
+      .every((v) => v === true);
+
+  return (
+    <div className="rounded border border-edge bg-surface-raised">
+      <header className="flex items-center justify-between gap-2 border-b border-edge px-3 py-2">
+        <div className="flex items-center gap-2">
+          <StatusPill
+            value={overall ? "approved" : "rejected"}
+            label={`CI: ${overall ? "PASSED" : "FAILED"}`}
+            taxonomy="verdict"
+          />
+          <span className="text-body text-content-primary">{name}</span>
+        </div>
+      </header>
+
+      {c.summary ? (
+        <div className="px-3 py-2 text-body text-content-secondary">
+          {c.summary}
+        </div>
+      ) : null}
+
+      <section className="border-t border-edge px-3 py-2">
+        <CheckRow
+          label="Tests"
+          passed={c.tests_passed}
+          detail={
+            c.test_count != null
+              ? c.test_failures != null
+                ? `${c.test_count - c.test_failures} / ${c.test_count}`
+                : `${c.test_count}`
+              : undefined
+          }
+        />
+        <CheckRow label="Lint" passed={c.lint_passed} />
+        <CheckRow label="Typecheck" passed={c.typecheck_passed} />
+        <CheckRow label="Build" passed={c.build_passed} />
+      </section>
+
+      {c.failure_summary ? (
+        <section className="border-t border-edge px-3 py-2">
+          <div className="mb-1 text-meta uppercase tracking-[0.06em] text-content-muted">
+            Failure summary
+          </div>
+          <div className="text-body text-content-primary whitespace-pre-wrap">
+            {c.failure_summary}
+          </div>
+        </section>
+      ) : null}
+
+      {c.commands && c.commands.length > 0 ? (
+        <section className="border-t border-edge px-3 py-2">
+          <div className="mb-1 text-meta uppercase tracking-[0.06em] text-content-muted">
+            Commands
+          </div>
+          <ul className="space-y-1 text-body">
+            {c.commands.map((cmd, i) => (
+              <li key={i} className="flex items-center justify-between gap-3">
+                <span className="font-mono text-content-primary truncate">
+                  {cmd.command}
+                </span>
+                <span className="flex items-center gap-2 shrink-0">
+                  <span className="tabular-nums text-content-secondary">
+                    {formatDuration(cmd.duration_seconds)}
+                  </span>
+                  <span
+                    className={
+                      cmd.passed ? "text-status-success" : "text-status-error"
+                    }
+                  >
+                    {cmd.passed ? "✓" : "✕"}
+                  </span>
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/studio/frontend/components/outcomes/GateVerdictCard.tsx
+++ b/apps/studio/frontend/components/outcomes/GateVerdictCard.tsx
@@ -1,0 +1,71 @@
+// ADR-0021 §E: GateVerdictCard renders the pass/fail outcome of a
+// gate (play-gate, show-gate, etc.) with feedback and notes surfaced
+// alongside, not buried in a text field.
+
+import StatusPill from "@/components/StatusPill";
+
+interface GateVerdictContent {
+  gate_passed?: boolean;
+  feedback?: string | null;
+  notes?: string | null;
+  summary?: string;
+  passed?: boolean | null;
+}
+
+interface GateVerdictCardProps {
+  name: string;
+  content: Record<string, unknown>;
+}
+
+export default function GateVerdictCard({
+  name,
+  content,
+}: GateVerdictCardProps) {
+  const c = content as unknown as GateVerdictContent;
+  const passed = c.gate_passed ?? c.passed ?? null;
+  const verdictLabel =
+    passed === true ? "ACCEPT" : passed === false ? "REJECT" : "PENDING";
+
+  return (
+    <div className="rounded border border-edge bg-surface-raised">
+      <header className="flex items-center justify-between gap-2 border-b border-edge px-3 py-2">
+        <div className="flex items-center gap-2">
+          <StatusPill
+            value={passed === true ? "approved" : passed === false ? "rejected" : ""}
+            label={`GATE: ${verdictLabel}`}
+            taxonomy="verdict"
+          />
+          <span className="text-body text-content-primary">{name}</span>
+        </div>
+      </header>
+
+      {c.summary ? (
+        <div className="px-3 py-2 text-body text-content-secondary">
+          {c.summary}
+        </div>
+      ) : null}
+
+      {c.feedback ? (
+        <section className="border-t border-edge px-3 py-2">
+          <div className="mb-1 text-meta uppercase tracking-[0.06em] text-content-muted">
+            Feedback
+          </div>
+          <div className="text-body text-content-primary whitespace-pre-wrap">
+            {c.feedback}
+          </div>
+        </section>
+      ) : null}
+
+      {c.notes ? (
+        <section className="border-t border-edge px-3 py-2">
+          <div className="mb-1 text-meta uppercase tracking-[0.06em] text-content-muted">
+            Notes
+          </div>
+          <div className="text-body text-content-secondary whitespace-pre-wrap">
+            {c.notes}
+          </div>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/studio/frontend/components/outcomes/OutcomeRenderer.tsx
+++ b/apps/studio/frontend/components/outcomes/OutcomeRenderer.tsx
@@ -1,0 +1,54 @@
+// ADR-0021 §E: kind-dispatched renderer for skill outcomes.
+// Falls back to a JSON viewer for unknown kinds so new outcome types
+// degrade gracefully until a dedicated card is added.
+
+import type { ArtifactSummary } from "@/lib/api";
+import ReviewVerdictCard from "./ReviewVerdictCard";
+import GateVerdictCard from "./GateVerdictCard";
+import CIResultCard from "./CIResultCard";
+
+export interface OutcomeRendererProps {
+  artifact: ArtifactSummary;
+}
+
+export default function OutcomeRenderer({ artifact }: OutcomeRendererProps) {
+  const content = artifact.content ?? {};
+  switch (artifact.kind) {
+    case "review_verdict":
+      return (
+        <ReviewVerdictCard
+          name={artifact.name}
+          content={content as Record<string, unknown>}
+        />
+      );
+    case "gate_verdict":
+      return (
+        <GateVerdictCard
+          name={artifact.name}
+          content={content as Record<string, unknown>}
+        />
+      );
+    case "ci_result":
+      return (
+        <CIResultCard
+          name={artifact.name}
+          content={content as Record<string, unknown>}
+        />
+      );
+    default:
+      return (
+        <div className="rounded border border-edge bg-surface-raised p-3">
+          <div className="mb-2 flex items-center justify-between text-meta uppercase tracking-[0.06em] text-content-muted">
+            <span>{artifact.kind}</span>
+            <span className="font-mono">{artifact.id.slice(0, 8)}</span>
+          </div>
+          <div className="mb-1 text-body text-content-primary">
+            {artifact.name}
+          </div>
+          <pre className="overflow-x-auto rounded bg-surface-base p-2 text-meta font-mono text-content-secondary">
+            {JSON.stringify(content, null, 2)}
+          </pre>
+        </div>
+      );
+  }
+}

--- a/apps/studio/frontend/components/outcomes/ReviewVerdictCard.tsx
+++ b/apps/studio/frontend/components/outcomes/ReviewVerdictCard.tsx
@@ -1,0 +1,187 @@
+// ADR-0021 §E: ReviewVerdictCard renders the structured verdict as a
+// severity/category breakdown with blocking findings highlighted, not
+// as raw text. Mirrors the spec layout in the ADR.
+
+import StatusPill from "@/components/StatusPill";
+
+interface Finding {
+  severity: "critical" | "high" | "medium" | "low" | "info";
+  category: string;
+  file?: string | null;
+  line?: number | null;
+  description: string;
+  suggestion?: string | null;
+}
+
+interface ReviewVerdictContent {
+  verdict?: string;
+  summary?: string;
+  findings?: Finding[];
+  round?: number;
+  passed?: boolean | null;
+}
+
+interface ReviewVerdictCardProps {
+  name: string;
+  content: Record<string, unknown>;
+}
+
+const SEVERITY_ORDER: Finding["severity"][] = [
+  "critical",
+  "high",
+  "medium",
+  "low",
+  "info",
+];
+const BLOCKING_SEVERITIES = new Set<Finding["severity"]>(["critical", "high"]);
+
+const SEVERITY_LABEL: Record<Finding["severity"], string> = {
+  critical: "Critical",
+  high: "Major",
+  medium: "Minor",
+  low: "Low",
+  info: "Info",
+};
+
+export default function ReviewVerdictCard({
+  name,
+  content,
+}: ReviewVerdictCardProps) {
+  const c = content as unknown as ReviewVerdictContent;
+  const verdict = c.verdict ?? "UNKNOWN";
+  const findings = c.findings ?? [];
+
+  // Severity counts (sorted descending by severity).
+  const counts: Record<Finding["severity"], number> = {
+    critical: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+    info: 0,
+  };
+  const categoryCounts: Record<string, number> = {};
+  for (const f of findings) {
+    counts[f.severity] += 1;
+    categoryCounts[f.category] = (categoryCounts[f.category] ?? 0) + 1;
+  }
+
+  const blocking = findings.filter((f) => BLOCKING_SEVERITIES.has(f.severity));
+  const minor = findings.filter((f) => !BLOCKING_SEVERITIES.has(f.severity));
+
+  return (
+    <div className="rounded border border-edge bg-surface-raised">
+      <header className="flex items-center justify-between gap-2 border-b border-edge px-3 py-2">
+        <div className="flex items-center gap-2">
+          <StatusPill value={verdict} taxonomy="verdict" />
+          <span className="text-body text-content-primary">{name}</span>
+          {c.round != null ? (
+            <span className="text-meta text-content-muted">
+              round {c.round}
+            </span>
+          ) : null}
+        </div>
+      </header>
+
+      {c.summary ? (
+        <div className="px-3 py-2 text-body text-content-secondary">
+          {c.summary}
+        </div>
+      ) : null}
+
+      <div className="grid grid-cols-2 gap-3 border-t border-edge px-3 py-2">
+        <div>
+          <div className="mb-1 text-meta uppercase tracking-[0.06em] text-content-muted">
+            Findings
+          </div>
+          <div className="flex flex-wrap gap-2 text-body">
+            {SEVERITY_ORDER.map((s) =>
+              counts[s] > 0 ? (
+                <span key={s} className="tabular-nums">
+                  <span className="text-content-primary">
+                    {SEVERITY_LABEL[s]}
+                  </span>{" "}
+                  <span className="text-content-secondary">{counts[s]}</span>
+                </span>
+              ) : null,
+            )}
+            {findings.length === 0 ? (
+              <span className="text-meta text-content-muted">
+                no findings
+              </span>
+            ) : null}
+          </div>
+        </div>
+        <div>
+          <div className="mb-1 text-meta uppercase tracking-[0.06em] text-content-muted">
+            Categories
+          </div>
+          <div className="flex flex-wrap gap-2 text-body">
+            {Object.entries(categoryCounts).map(([cat, n]) => (
+              <span key={cat} className="tabular-nums">
+                <span className="text-content-primary">{cat}</span>{" "}
+                <span className="text-content-secondary">{n}</span>
+              </span>
+            ))}
+            {Object.keys(categoryCounts).length === 0 ? (
+              <span className="text-meta text-content-muted">—</span>
+            ) : null}
+          </div>
+        </div>
+      </div>
+
+      {blocking.length > 0 ? (
+        <section className="border-t border-edge px-3 py-2">
+          <div className="mb-1 text-meta uppercase tracking-[0.06em] text-content-muted">
+            Blocking findings
+          </div>
+          <ul className="space-y-2">
+            {blocking.map((f, i) => (
+              <li key={i} className="rounded border border-status-error/30 bg-status-error-bg/40 p-2">
+                <div className="flex items-center gap-2">
+                  <span className="rounded bg-status-error/10 px-1.5 py-0.5 text-meta uppercase tracking-wide text-status-error">
+                    {SEVERITY_LABEL[f.severity]}
+                  </span>
+                  <span className="text-body text-content-primary">
+                    {f.description}
+                  </span>
+                </div>
+                {f.file ? (
+                  <div className="mt-1 font-mono text-meta text-content-muted">
+                    {f.file}
+                    {f.line != null ? `:${f.line}` : ""}
+                  </div>
+                ) : null}
+                {f.suggestion ? (
+                  <div className="mt-1 text-body text-content-secondary">
+                    <span className="text-meta uppercase tracking-[0.06em] text-content-muted">
+                      Suggestion
+                    </span>{" "}
+                    {f.suggestion}
+                  </div>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      {minor.length > 0 ? (
+        <details className="border-t border-edge px-3 py-2">
+          <summary className="cursor-pointer text-meta uppercase tracking-[0.06em] text-content-muted">
+            Suggestions ({minor.length})
+          </summary>
+          <ul className="mt-2 space-y-1 text-body text-content-secondary">
+            {minor.map((f, i) => (
+              <li key={i}>
+                <span className="text-meta uppercase tracking-[0.06em] text-content-muted">
+                  {SEVERITY_LABEL[f.severity]}
+                </span>{" "}
+                {f.description}
+              </li>
+            ))}
+          </ul>
+        </details>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/studio/frontend/lib/api.ts
+++ b/apps/studio/frontend/lib/api.ts
@@ -416,8 +416,36 @@ export interface InvocationSession {
   ended_at: number | null;
 }
 
+// ADR-0021: structured skill outputs. `kind` is the dispatch key for
+// the frontend renderer; `content` shape depends on the kind.
+export interface ArtifactSummary {
+  id: string;
+  invocation_id: string | null;
+  session_id: string | null;
+  kind: string;
+  name: string;
+  created_at: number;
+  content: Record<string, unknown> | null;
+  file_path: string | null;
+}
+
 export interface InvocationDetail extends InvocationSummary {
   sessions: InvocationSession[];
+  artifacts: ArtifactSummary[];
+}
+
+export async function getArtifact(id: string): Promise<ArtifactSummary> {
+  return fetchJson<ArtifactSummary>(
+    `/api/artifacts/${encodeURIComponent(id)}`,
+  );
+}
+
+export async function listArtifactsForSession(
+  sessionId: string,
+): Promise<{ artifacts: ArtifactSummary[] }> {
+  return fetchJson<{ artifacts: ArtifactSummary[] }>(
+    `/api/artifacts/by-session/${encodeURIComponent(sessionId)}`,
+  );
 }
 
 export interface InvocationListResponse {

--- a/apps/studio/server/app.py
+++ b/apps/studio/server/app.py
@@ -11,6 +11,7 @@ from .config import CORS_ORIGINS
 from .routers import (
     admin,
     agents,
+    artifacts,
     definitions,
     invocations,
     playbooks,
@@ -59,6 +60,7 @@ app.include_router(plugins.router, prefix="/api")
 app.include_router(admin.router, prefix="/api")
 app.include_router(teams.router, prefix="/api")
 app.include_router(invocations.router, prefix="/api")
+app.include_router(artifacts.router, prefix="/api")
 
 
 @app.get("/health")

--- a/apps/studio/server/routers/artifacts.py
+++ b/apps/studio/server/routers/artifacts.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""ADR-0021 artifacts API.
+
+Skill-produced structured outcomes (ReviewVerdict, GateVerdict,
+CIResult, ...). Most consumers fetch via /api/invocations/{id} which
+returns the artifact list inline; these endpoints exist for the cases
+where the caller has only a session id, or wants the artifact alone.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+
+from ..services import invocations as inv_svc
+
+router = APIRouter(prefix="/artifacts", tags=["artifacts"])
+
+
+@router.get("/{artifact_id}")
+async def get_artifact(artifact_id: str) -> dict[str, Any]:
+    data = await inv_svc.get_artifact(artifact_id)
+    if data is None:
+        raise HTTPException(
+            status_code=404, detail=f"Artifact '{artifact_id}' not found"
+        )
+    return data
+
+
+# Convenience: sessions don't have their own router-level artifacts endpoint
+# (sessions.router predates ADR-0021). This sub-route under /api/artifacts
+# keeps the artifact concern in one place.
+@router.get("/by-session/{session_id}")
+async def list_for_session(session_id: str) -> dict[str, Any]:
+    rows = await inv_svc.list_artifacts_for_session(session_id)
+    return {"artifacts": rows}

--- a/apps/studio/server/services/invocations.py
+++ b/apps/studio/server/services/invocations.py
@@ -67,6 +67,12 @@ async def get_invocation(invocation_id: str) -> dict[str, Any] | None:
             except json.JSONDecodeError:
                 node_meta = None
         sessions = await db.list_sessions_for_invocation(invocation_id)
+        # ADR-0021: surface structured outcomes alongside child sessions
+        # so the invocation detail page can render verdict / CI / gate
+        # cards inline. Filesystem blobs (file_path) are included by
+        # reference; the frontend renders them as JSON when the kind is
+        # unknown.
+        artifacts = await db.list_artifacts_for_invocation(invocation_id)
     return {
         "id": row["id"],
         "skill": row["skill"],
@@ -95,4 +101,48 @@ async def get_invocation(invocation_id: str) -> dict[str, Any] | None:
             }
             for s in sessions
         ],
+        "artifacts": [_serialize_artifact(a) for a in artifacts],
     }
+
+
+def _serialize_artifact(row: dict[str, Any]) -> dict[str, Any]:
+    """Common artifact projection for /api/invocations and /api/artifacts.
+
+    SQLite returns JSON columns as strings; decode here so the frontend
+    gets a real object instead of a doubly-encoded string.
+    """
+    content = row.get("content")
+    if isinstance(content, str):
+        try:
+            content = json.loads(content)
+        except json.JSONDecodeError:
+            content = None
+    return {
+        "id": row["id"],
+        "invocation_id": row.get("invocation_id"),
+        "session_id": row.get("session_id"),
+        "kind": row["kind"],
+        "name": row["name"],
+        "created_at": row["created_at"],
+        "content": content,
+        "file_path": row.get("file_path"),
+    }
+
+
+# ── Artifacts (ADR-0021) ──────────────────────────────────────────────────────
+
+
+async def list_artifacts_for_session(session_id: str) -> list[dict[str, Any]]:
+    if not DEFAULT_DB_PATH.exists():
+        return []
+    async with StateDB() as db:
+        rows = await db.list_artifacts_for_session(session_id)
+    return [_serialize_artifact(r) for r in rows]
+
+
+async def get_artifact(artifact_id: str) -> dict[str, Any] | None:
+    if not DEFAULT_DB_PATH.exists():
+        return None
+    async with StateDB() as db:
+        row = await db.get_artifact(artifact_id)
+    return _serialize_artifact(row) if row else None

--- a/lionagi/outcomes/__init__.py
+++ b/lionagi/outcomes/__init__.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""ADR-0021: structured outputs that skills produce and Studio renders.
+
+The shared contract between CLI skill runners (producers) and Studio
+(consumer). Outcomes are persisted as ``artifacts`` table rows with
+``kind = outcome_kind`` so the frontend's kind-dispatched renderer can
+pick the right card component.
+
+This package holds *domain* types (review verdicts, CI results, gate
+outcomes). Infrastructure types live in :mod:`lionagi.models`; the
+separation is deliberate so a future Studio-only consumer can import
+outcomes without pulling in framework machinery.
+"""
+
+from ._base import SkillOutcome
+from .ci import CIResult
+from .verdict import Finding, GateVerdict, ReviewVerdict
+
+__all__ = [
+    "SkillOutcome",
+    "ReviewVerdict",
+    "GateVerdict",
+    "Finding",
+    "CIResult",
+]

--- a/lionagi/outcomes/_base.py
+++ b/lionagi/outcomes/_base.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""ADR-0021 §A: SkillOutcome base type."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from lionagi.models import HashableModel
+
+
+class SkillOutcome(HashableModel):
+    """Base for all structured skill outputs.
+
+    Concrete subclasses set ``outcome_kind`` to a literal string. The
+    string ends up as ``artifacts.kind`` in the DB and as the dispatch
+    key for the frontend's kind-aware renderer.
+    """
+
+    outcome_kind: str = Field(
+        description=(
+            "Discriminator key for the kind-dispatched renderer. Subclasses "
+            "narrow this to a Literal[...] of one value."
+        )
+    )
+    summary: str = Field(
+        description=(
+            "One-line human-readable summary. Shown in list views before "
+            "the operator clicks through to the full structured outcome."
+        )
+    )
+    passed: bool | None = Field(
+        default=None,
+        description=(
+            "Tri-state pass/fail. True/False for binary outcomes (gate, CI); "
+            "None when not applicable (e.g. a research analysis with no "
+            "pass/fail semantics)."
+        ),
+    )

--- a/lionagi/outcomes/_base.py
+++ b/lionagi/outcomes/_base.py
@@ -23,11 +23,12 @@ class SkillOutcome(HashableModel):
             "narrow this to a Literal[...] of one value."
         )
     )
-    summary: str = Field(
+    summary: str | None = Field(
+        default=None,
         description=(
             "One-line human-readable summary. Shown in list views before "
             "the operator clicks through to the full structured outcome."
-        )
+        ),
     )
     passed: bool | None = Field(
         default=None,

--- a/lionagi/outcomes/ci.py
+++ b/lionagi/outcomes/ci.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""ADR-0021 §A: CI / lint / test outcome models."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field
+
+from lionagi.models import HashableModel
+
+from ._base import SkillOutcome
+
+
+class CIRunCommand(HashableModel):
+    """One executed CI command with timing.
+
+    The CIResultCard renders these in a "Commands" panel below the
+    pass/fail matrix.
+    """
+
+    command: str = Field(description="The shell command as executed.")
+    duration_seconds: float = Field(
+        ge=0,
+        description="Wall-clock seconds the command took.",
+    )
+    passed: bool = Field(description="Did the command exit 0?")
+
+
+class CIResult(SkillOutcome):
+    """Aggregated CI outcome — lint + typecheck + tests + build."""
+
+    outcome_kind: Literal["ci_result"] = "ci_result"
+    lint_passed: bool | None = Field(
+        default=None,
+        description="None when lint wasn't run; bool otherwise.",
+    )
+    tests_passed: bool | None = Field(
+        default=None,
+        description="None when tests weren't run; bool otherwise.",
+    )
+    build_passed: bool | None = Field(
+        default=None,
+        description="None when build wasn't run; bool otherwise.",
+    )
+    typecheck_passed: bool | None = Field(
+        default=None,
+        description="None when typecheck wasn't run; bool otherwise.",
+    )
+    test_count: int | None = Field(
+        default=None,
+        ge=0,
+        description="Total tests executed; None when tests weren't run.",
+    )
+    test_failures: int | None = Field(
+        default=None,
+        ge=0,
+        description="Test failure count; None when tests weren't run.",
+    )
+    failure_summary: str | None = Field(
+        default=None,
+        description="Human-readable failure narrative when any step failed.",
+    )
+    commands: list[CIRunCommand] = Field(
+        default_factory=list,
+        description="Per-command timing for the Commands panel.",
+    )

--- a/lionagi/outcomes/verdict.py
+++ b/lionagi/outcomes/verdict.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""ADR-0021 §A: review + gate verdicts.
+
+Produced by codex-pr-review (ReviewVerdict), play-gate (GateVerdict),
+or any skill that issues a binary or graded judgment.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field
+
+from lionagi.models import HashableModel
+
+from ._base import SkillOutcome
+
+Severity = Literal["critical", "high", "medium", "low", "info"]
+
+
+class Finding(HashableModel):
+    """One reviewer finding with optional file/line + suggestion."""
+
+    severity: Severity = Field(
+        description="Operator severity bucket (drives sort + render color).",
+    )
+    category: str = Field(
+        description=(
+            "Short free-text taxonomy: 'security', 'correctness', "
+            "'style', 'adr_consistency', 'scope', ..."
+        ),
+    )
+    file: str | None = Field(
+        default=None,
+        description="Repo-relative path the finding applies to, if any.",
+    )
+    line: int | None = Field(
+        default=None,
+        description="1-indexed line number when known.",
+    )
+    description: str = Field(
+        description="What the reviewer noticed (one sentence preferred).",
+    )
+    suggestion: str | None = Field(
+        default=None,
+        description=(
+            "Concrete fix the reviewer recommends. None when the finding "
+            "is informational only."
+        ),
+    )
+
+
+VerdictDecision = Literal[
+    "APPROVE",
+    "APPROVE_WITH_SUGGESTIONS",
+    "REQUEST_CHANGES",
+    "REJECT",
+]
+
+
+class ReviewVerdict(SkillOutcome):
+    """Reviewer judgment + findings list.
+
+    The frontend renders this as the ``ReviewVerdictCard`` (ADR-0021 §E)
+    — severity/category breakdown on top, blocking findings expanded,
+    minor suggestions collapsed.
+    """
+
+    outcome_kind: Literal["review_verdict"] = "review_verdict"
+    verdict: VerdictDecision = Field(
+        description="Top-level decision; drives card color + downstream chain conditions.",
+    )
+    findings: list[Finding] = Field(
+        default_factory=list,
+        description="Findings list — blocking-first ordering is the writer's responsibility.",
+    )
+    round: int = Field(
+        default=1,
+        ge=1,
+        description=(
+            "1-indexed iteration number for multi-round reviews. The "
+            "codex-pr-review skill writes one ReviewVerdict per round."
+        ),
+    )
+
+
+class GateVerdict(SkillOutcome):
+    """Acceptance-criteria gate outcome (play-gate, show-gate, etc.)."""
+
+    outcome_kind: Literal["gate_verdict"] = "gate_verdict"
+    gate_passed: bool = Field(
+        description="Did the gate pass? (Mirrors plays.gate_passed in the DB.)",
+    )
+    feedback: str | None = Field(
+        default=None,
+        description="Reviewer-facing rationale shown on the play detail page.",
+    )
+    notes: str | None = Field(
+        default=None,
+        description="Operator notes (free text). Often empty; rendered when present.",
+    )

--- a/lionagi/outcomes/verdict.py
+++ b/lionagi/outcomes/verdict.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from lionagi.models import HashableModel
 
@@ -71,6 +71,13 @@ class ReviewVerdict(SkillOutcome):
     verdict: VerdictDecision = Field(
         description="Top-level decision; drives card color + downstream chain conditions.",
     )
+
+    @field_validator("verdict", mode="before")
+    @classmethod
+    def _normalize_verdict(cls, v: object) -> object:
+        if isinstance(v, str):
+            return v.replace("-", "_").replace(" ", "_")
+        return v
     findings: list[Finding] = Field(
         default_factory=list,
         description="Findings list — blocking-first ordering is the writer's responsibility.",

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -873,7 +873,7 @@ class StateDB:
             raise ValueError("artifact name is required")
         art_id = uuid.uuid4().hex[:12]
         await self.db.execute(
-            "INSERT INTO artifacts (id, invocation_id, session_id, "
+            "INSERT OR REPLACE INTO artifacts (id, invocation_id, session_id, "
             "created_at, kind, name, content, file_path) "
             "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
             (

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -336,6 +336,11 @@ class StateDB:
         "shows": [
             ("status_source", "TEXT NOT NULL DEFAULT 'unknown'"),
         ],
+        "artifacts": [
+            # Nullable in ALTER TABLE because expressions aren't valid
+            # column defaults there; insert_artifact() always sets this.
+            ("updated_at", "REAL"),
+        ],
     }
 
     async def _reconcile_columns(self) -> None:
@@ -850,6 +855,42 @@ class StateDB:
 
     # ── Artifacts (ADR-0021) ─────────────────────────────────────────────
 
+    async def _find_artifact_id(
+        self,
+        *,
+        kind: str,
+        name: str,
+        invocation_id: str | None,
+        session_id: str | None,
+    ) -> str | None:
+        """Return the artifact id matching the natural key, or None."""
+        if invocation_id is not None and session_id is not None:
+            cur = await self.db.execute(
+                "SELECT id FROM artifacts "
+                "WHERE invocation_id = ? AND session_id = ? AND kind = ? AND name = ?",
+                (invocation_id, session_id, kind, name),
+            )
+        elif invocation_id is not None:
+            cur = await self.db.execute(
+                "SELECT id FROM artifacts "
+                "WHERE invocation_id = ? AND session_id IS NULL AND kind = ? AND name = ?",
+                (invocation_id, kind, name),
+            )
+        elif session_id is not None:
+            cur = await self.db.execute(
+                "SELECT id FROM artifacts "
+                "WHERE session_id = ? AND invocation_id IS NULL AND kind = ? AND name = ?",
+                (session_id, kind, name),
+            )
+        else:
+            cur = await self.db.execute(
+                "SELECT id FROM artifacts "
+                "WHERE invocation_id IS NULL AND session_id IS NULL AND kind = ? AND name = ?",
+                (kind, name),
+            )
+        row = await cur.fetchone()
+        return row["id"] if row else None
+
     async def insert_artifact(
         self,
         *,
@@ -860,32 +901,41 @@ class StateDB:
         session_id: str | None = None,
         file_path: str | None = None,
     ) -> str:
-        """Insert one structured skill artifact.
+        """Upsert one structured skill artifact; return its stable id.
 
         ``content`` is typically ``SkillOutcome.model_dump()``. Either
         ``invocation_id`` or ``session_id`` (or both) should be set so
         the artifact is reachable from a parent; the schema permits NULL
         on both for unattached blobs (rare; the API doesn't expose this).
+
+        INSERT OR REPLACE must not be used — it deletes then re-inserts,
+        generating a new id and silently breaking external FK references.
+        We SELECT the existing id first and UPDATE in place; a new id is
+        only minted when no matching row exists.
         """
         if not kind:
             raise ValueError("artifact kind is required")
         if not name:
             raise ValueError("artifact name is required")
+        now = time.time()
+        content_json = _to_json_column(content)
+        existing_id = await self._find_artifact_id(
+            kind=kind, name=name, invocation_id=invocation_id, session_id=session_id
+        )
+        if existing_id:
+            await self.db.execute(
+                "UPDATE artifacts SET content = ?, file_path = ?, updated_at = ? "
+                "WHERE id = ?",
+                (content_json, file_path, now, existing_id),
+            )
+            await self.db.commit()
+            return existing_id
         art_id = uuid.uuid4().hex[:12]
         await self.db.execute(
-            "INSERT OR REPLACE INTO artifacts (id, invocation_id, session_id, "
-            "created_at, kind, name, content, file_path) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            (
-                art_id,
-                invocation_id,
-                session_id,
-                time.time(),
-                kind,
-                name,
-                _to_json_column(content),
-                file_path,
-            ),
+            "INSERT INTO artifacts "
+            "(id, invocation_id, session_id, created_at, updated_at, kind, name, content, file_path) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (art_id, invocation_id, session_id, now, now, kind, name, content_json, file_path),
         )
         await self.db.commit()
         return art_id

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -848,6 +848,79 @@ class StateDB:
         rows = await cur.fetchall()
         return [self._row_to_dict(r) for r in rows]
 
+    # ── Artifacts (ADR-0021) ─────────────────────────────────────────────
+
+    async def insert_artifact(
+        self,
+        *,
+        kind: str,
+        name: str,
+        content: dict[str, Any],
+        invocation_id: str | None = None,
+        session_id: str | None = None,
+        file_path: str | None = None,
+    ) -> str:
+        """Insert one structured skill artifact.
+
+        ``content`` is typically ``SkillOutcome.model_dump()``. Either
+        ``invocation_id`` or ``session_id`` (or both) should be set so
+        the artifact is reachable from a parent; the schema permits NULL
+        on both for unattached blobs (rare; the API doesn't expose this).
+        """
+        if not kind:
+            raise ValueError("artifact kind is required")
+        if not name:
+            raise ValueError("artifact name is required")
+        art_id = uuid.uuid4().hex[:12]
+        await self.db.execute(
+            "INSERT INTO artifacts (id, invocation_id, session_id, "
+            "created_at, kind, name, content, file_path) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                art_id,
+                invocation_id,
+                session_id,
+                time.time(),
+                kind,
+                name,
+                _to_json_column(content),
+                file_path,
+            ),
+        )
+        await self.db.commit()
+        return art_id
+
+    async def list_artifacts_for_invocation(
+        self, invocation_id: str
+    ) -> list[dict[str, Any]]:
+        cur = await self.db.execute(
+            "SELECT * FROM artifacts WHERE invocation_id = ? "
+            "ORDER BY created_at ASC",
+            (invocation_id,),
+        )
+        rows = await cur.fetchall()
+        return [self._row_to_dict(r) for r in rows]
+
+    async def list_artifacts_for_session(
+        self, session_id: str
+    ) -> list[dict[str, Any]]:
+        cur = await self.db.execute(
+            "SELECT * FROM artifacts WHERE session_id = ? "
+            "ORDER BY created_at ASC",
+            (session_id,),
+        )
+        rows = await cur.fetchall()
+        return [self._row_to_dict(r) for r in rows]
+
+    async def get_artifact(
+        self, artifact_id: str
+    ) -> dict[str, Any] | None:
+        cur = await self.db.execute(
+            "SELECT * FROM artifacts WHERE id = ?", (artifact_id,)
+        )
+        row = await cur.fetchone()
+        return self._row_to_dict(row) if row else None
+
     # ── Admin events (ADR-0024) ─────────────────────────────────────────
 
     async def insert_admin_event(

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -329,16 +329,19 @@ CREATE TABLE IF NOT EXISTS artifacts (
   invocation_id   TEXT    REFERENCES invocations(id) ON DELETE CASCADE,
   session_id      TEXT    REFERENCES sessions(id),
   created_at      REAL    NOT NULL,
+  updated_at      REAL    NOT NULL DEFAULT (strftime('%s','now')),
   kind            TEXT    NOT NULL,
   name            TEXT    NOT NULL,
   content         JSON    NOT NULL,
   file_path       TEXT
 );
 
--- Natural uniqueness keys for idempotent inserts (INSERT OR REPLACE).
+-- Natural uniqueness keys for idempotent upserts. INSERT OR REPLACE must
+-- NOT be used — it deletes then re-inserts, generating a new id and
+-- breaking external references. Use ON CONFLICT DO UPDATE instead.
 -- SQLite treats NULLs as distinct in UNIQUE indexes, so a single
 -- 4-column index on (invocation_id, session_id, kind, name) fails
--- when either FK is NULL. Three partial indexes cover every reachable
+-- when either FK is NULL. Four partial indexes cover every reachable
 -- artifact shape without the NULL-distinctness pitfall.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_artifacts_natural_key_inv_only
   ON artifacts(invocation_id, kind, name)
@@ -349,6 +352,9 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_artifacts_natural_key_ses_only
 CREATE UNIQUE INDEX IF NOT EXISTS idx_artifacts_natural_key_both
   ON artifacts(invocation_id, session_id, kind, name)
   WHERE invocation_id IS NOT NULL AND session_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_artifacts_natural_key_unattached
+  ON artifacts(kind, name)
+  WHERE invocation_id IS NULL AND session_id IS NULL;
 
 CREATE INDEX IF NOT EXISTS idx_artifacts_invocation
   ON artifacts(invocation_id) WHERE invocation_id IS NOT NULL;

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -316,3 +316,29 @@ CREATE INDEX IF NOT EXISTS idx_admin_events_action
   ON admin_events(action);
 CREATE INDEX IF NOT EXISTS idx_admin_events_target
   ON admin_events(target_id) WHERE target_id IS NOT NULL;
+
+-- ── Artifacts (ADR-0021) ─────────────────────────────────────────────────
+-- Structured skill outputs (review verdicts, gate verdicts, CI results,
+-- ...). The split is DB-for-structured, filesystem-for-blobs: `content`
+-- holds the SkillOutcome.model_dump() JSON; `file_path` optionally
+-- points to a large blob (full log, generated artifact, worktree diff).
+-- `kind` is the discriminator the frontend renderer dispatches on.
+
+CREATE TABLE IF NOT EXISTS artifacts (
+  id              TEXT    PRIMARY KEY,
+  invocation_id   TEXT    REFERENCES invocations(id) ON DELETE CASCADE,
+  session_id      TEXT    REFERENCES sessions(id),
+  created_at      REAL    NOT NULL,
+  kind            TEXT    NOT NULL,
+  name            TEXT    NOT NULL,
+  content         JSON    NOT NULL,
+  file_path       TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_artifacts_invocation
+  ON artifacts(invocation_id) WHERE invocation_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_artifacts_session
+  ON artifacts(session_id) WHERE session_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_artifacts_kind ON artifacts(kind);
+CREATE INDEX IF NOT EXISTS idx_artifacts_created
+  ON artifacts(created_at DESC);

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -335,6 +335,21 @@ CREATE TABLE IF NOT EXISTS artifacts (
   file_path       TEXT
 );
 
+-- Natural uniqueness keys for idempotent inserts (INSERT OR REPLACE).
+-- SQLite treats NULLs as distinct in UNIQUE indexes, so a single
+-- 4-column index on (invocation_id, session_id, kind, name) fails
+-- when either FK is NULL. Three partial indexes cover every reachable
+-- artifact shape without the NULL-distinctness pitfall.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_artifacts_natural_key_inv_only
+  ON artifacts(invocation_id, kind, name)
+  WHERE invocation_id IS NOT NULL AND session_id IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_artifacts_natural_key_ses_only
+  ON artifacts(session_id, kind, name)
+  WHERE session_id IS NOT NULL AND invocation_id IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_artifacts_natural_key_both
+  ON artifacts(invocation_id, session_id, kind, name)
+  WHERE invocation_id IS NOT NULL AND session_id IS NOT NULL;
+
 CREATE INDEX IF NOT EXISTS idx_artifacts_invocation
   ON artifacts(invocation_id) WHERE invocation_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_artifacts_session
@@ -342,3 +357,9 @@ CREATE INDEX IF NOT EXISTS idx_artifacts_session
 CREATE INDEX IF NOT EXISTS idx_artifacts_kind ON artifacts(kind);
 CREATE INDEX IF NOT EXISTS idx_artifacts_created
   ON artifacts(created_at DESC);
+-- Composite indexes that match the ORDER BY shape of the two list
+-- queries — avoids a temp B-tree for the sort step.
+CREATE INDEX IF NOT EXISTS idx_artifacts_invocation_time
+  ON artifacts(invocation_id, created_at) WHERE invocation_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_artifacts_session_time
+  ON artifacts(session_id, created_at) WHERE session_id IS NOT NULL;

--- a/tests/outcomes/test_outcome_models.py
+++ b/tests/outcomes/test_outcome_models.py
@@ -53,6 +53,17 @@ def test_review_verdict_default_outcome_kind_pinned():
     assert v.findings == []
 
 
+def test_review_verdict_accepts_hyphenated_producer_string():
+    """Producer strings like APPROVE-WITH-SUGGESTIONS are normalized on ingest."""
+    v = ReviewVerdict.model_validate({"verdict": "APPROVE-WITH-SUGGESTIONS", "summary": "ok"})
+    assert v.verdict == "APPROVE_WITH_SUGGESTIONS"
+
+
+def test_review_verdict_accepts_spaced_producer_string():
+    v = ReviewVerdict.model_validate({"verdict": "REQUEST CHANGES", "summary": "ok"})
+    assert v.verdict == "REQUEST_CHANGES"
+
+
 def test_review_verdict_rejects_unknown_decision():
     with pytest.raises(ValidationError):
         ReviewVerdict(verdict="MEH", summary="?")
@@ -97,6 +108,14 @@ def test_review_verdict_dump_round_trips():
 
 
 # ── GateVerdict ───────────────────────────────────────────────────────────────
+
+
+def test_gate_verdict_without_summary():
+    """GateVerdict must validate raw play-gate JSON that has no summary field."""
+    g = GateVerdict.model_validate({"gate_passed": True, "passed": True})
+    assert g.summary is None
+    assert g.gate_passed is True
+    assert g.outcome_kind == "gate_verdict"
 
 
 def test_gate_verdict_dump_round_trips():

--- a/tests/outcomes/test_outcome_models.py
+++ b/tests/outcomes/test_outcome_models.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""ADR-0021 outcome model tests.
+
+The outcomes package is the contract between skill producers and Studio
+consumers. These tests pin the public schema so any breaking change
+shows up here, not in a downstream serialization mismatch.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from lionagi.outcomes import (
+    CIResult,
+    Finding,
+    GateVerdict,
+    ReviewVerdict,
+    SkillOutcome,
+)
+from lionagi.outcomes.ci import CIRunCommand
+
+# ── SkillOutcome base ─────────────────────────────────────────────────────────
+
+
+def test_skill_outcome_passed_defaults_to_none():
+    o = SkillOutcome(outcome_kind="x", summary="hello")
+    assert o.passed is None
+    assert o.outcome_kind == "x"
+    assert o.summary == "hello"
+
+
+def test_skill_outcome_dump_round_trips():
+    o = SkillOutcome(outcome_kind="x", summary="hello", passed=True)
+    dumped = o.model_dump()
+    again = SkillOutcome.model_validate(dumped)
+    assert again == o
+
+
+# ── ReviewVerdict ─────────────────────────────────────────────────────────────
+
+
+def test_review_verdict_default_outcome_kind_pinned():
+    """ADR-0021 promises kind='review_verdict' — frontend dispatch depends on it."""
+    v = ReviewVerdict(
+        verdict="APPROVE",
+        summary="LGTM",
+    )
+    assert v.outcome_kind == "review_verdict"
+    assert v.round == 1
+    assert v.findings == []
+
+
+def test_review_verdict_rejects_unknown_decision():
+    with pytest.raises(ValidationError):
+        ReviewVerdict(verdict="MEH", summary="?")
+
+
+def test_review_verdict_round_must_be_positive():
+    with pytest.raises(ValidationError):
+        ReviewVerdict(verdict="APPROVE", summary="ok", round=0)
+
+
+def test_finding_severity_constrained():
+    Finding(
+        severity="critical",
+        category="security",
+        description="rm -rf in user input",
+    )
+    with pytest.raises(ValidationError):
+        Finding(severity="hot", category="x", description="y")
+
+
+def test_review_verdict_dump_round_trips():
+    v = ReviewVerdict(
+        verdict="REQUEST_CHANGES",
+        summary="3 issues",
+        passed=False,
+        round=2,
+        findings=[
+            Finding(
+                severity="high",
+                category="correctness",
+                file="src/main.py",
+                line=42,
+                description="off-by-one",
+                suggestion="use range(n+1)",
+            )
+        ],
+    )
+    dumped = v.model_dump()
+    assert dumped["outcome_kind"] == "review_verdict"
+    again = ReviewVerdict.model_validate(dumped)
+    assert again == v
+
+
+# ── GateVerdict ───────────────────────────────────────────────────────────────
+
+
+def test_gate_verdict_dump_round_trips():
+    g = GateVerdict(
+        summary="gate failed: missing artifact",
+        gate_passed=False,
+        feedback="implementation_1012.md missing from artifact path",
+        passed=False,
+    )
+    dumped = g.model_dump()
+    assert dumped["outcome_kind"] == "gate_verdict"
+    assert dumped["gate_passed"] is False
+    assert GateVerdict.model_validate(dumped) == g
+
+
+# ── CIResult ──────────────────────────────────────────────────────────────────
+
+
+def test_ci_result_all_optional_when_step_skipped():
+    """A CIResult that ran only tests has None for lint/build/typecheck."""
+    r = CIResult(
+        summary="119/119",
+        passed=True,
+        tests_passed=True,
+        test_count=119,
+        test_failures=0,
+    )
+    assert r.lint_passed is None
+    assert r.build_passed is None
+    assert r.typecheck_passed is None
+
+
+def test_ci_run_command_rejects_negative_duration():
+    with pytest.raises(ValidationError):
+        CIRunCommand(command="pytest", duration_seconds=-1, passed=True)
+
+
+def test_ci_result_dump_round_trips():
+    r = CIResult(
+        summary="all green",
+        passed=True,
+        tests_passed=True,
+        lint_passed=True,
+        test_count=42,
+        test_failures=0,
+        commands=[
+            CIRunCommand(command="pytest", duration_seconds=12.5, passed=True),
+            CIRunCommand(command="ruff", duration_seconds=0.8, passed=True),
+        ],
+    )
+    dumped = r.model_dump()
+    assert dumped["outcome_kind"] == "ci_result"
+    again = CIResult.model_validate(dumped)
+    assert again == r
+
+
+# ── Kind dispatch contract ────────────────────────────────────────────────────
+
+
+def test_outcome_kinds_are_distinct():
+    """Each concrete outcome must have a unique outcome_kind string —
+    the frontend's switch dispatches on this value."""
+    kinds = {
+        ReviewVerdict(verdict="APPROVE", summary="x").outcome_kind,
+        GateVerdict(summary="x", gate_passed=True).outcome_kind,
+        CIResult(summary="x").outcome_kind,
+    }
+    assert len(kinds) == 3

--- a/tests/state/test_artifacts.py
+++ b/tests/state/test_artifacts.py
@@ -132,7 +132,7 @@ async def test_artifacts_cascade_when_invocation_deleted(db: StateDB):
 
 
 async def test_insert_artifact_is_idempotent(db: StateDB):
-    """INSERT OR REPLACE keeps count at 1 when the same natural key is reused."""
+    """Upsert keeps count at 1 when the same natural key is reused."""
     inv = await _make_invocation(db)
     for _ in range(2):
         await db.insert_artifact(
@@ -143,6 +143,24 @@ async def test_insert_artifact_is_idempotent(db: StateDB):
         )
     rows = await db.list_artifacts_for_invocation(inv["id"])
     assert len(rows) == 1
+
+
+async def test_insert_artifact_preserves_id_on_upsert(db: StateDB):
+    """Second insert with the same natural key must return the original id."""
+    inv = await _make_invocation(db)
+    first_id = await db.insert_artifact(
+        invocation_id=inv["id"],
+        kind="review_verdict",
+        name="Round 1",
+        content={"verdict": "REQUEST_CHANGES"},
+    )
+    second_id = await db.insert_artifact(
+        invocation_id=inv["id"],
+        kind="review_verdict",
+        name="Round 1",
+        content={"verdict": "APPROVE"},
+    )
+    assert first_id == second_id, "upsert must not generate a new id on conflict"
 
 
 async def test_insert_artifact_idempotent_updates_content(db: StateDB):

--- a/tests/state/test_artifacts.py
+++ b/tests/state/test_artifacts.py
@@ -128,6 +128,43 @@ async def test_artifacts_cascade_when_invocation_deleted(db: StateDB):
     assert await db.get_artifact(art_id) is None
 
 
+# ── Idempotency ───────────────────────────────────────────────────────────────
+
+
+async def test_insert_artifact_is_idempotent(db: StateDB):
+    """INSERT OR REPLACE keeps count at 1 when the same natural key is reused."""
+    inv = await _make_invocation(db)
+    for _ in range(2):
+        await db.insert_artifact(
+            invocation_id=inv["id"],
+            kind="review_verdict",
+            name="Round 1",
+            content={"verdict": "APPROVE"},
+        )
+    rows = await db.list_artifacts_for_invocation(inv["id"])
+    assert len(rows) == 1
+
+
+async def test_insert_artifact_idempotent_updates_content(db: StateDB):
+    """Second insert with the same key replaces the content."""
+    inv = await _make_invocation(db)
+    await db.insert_artifact(
+        invocation_id=inv["id"],
+        kind="review_verdict",
+        name="Round 1",
+        content={"verdict": "REQUEST_CHANGES"},
+    )
+    await db.insert_artifact(
+        invocation_id=inv["id"],
+        kind="review_verdict",
+        name="Round 1",
+        content={"verdict": "APPROVE"},
+    )
+    rows = await db.list_artifacts_for_invocation(inv["id"])
+    assert len(rows) == 1
+    assert rows[0]["content"]["verdict"] == "APPROVE"
+
+
 # ── Ordering ──────────────────────────────────────────────────────────────────
 
 

--- a/tests/state/test_artifacts.py
+++ b/tests/state/test_artifacts.py
@@ -1,0 +1,151 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""ADR-0021 artifacts table tests."""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import pytest
+
+from lionagi.outcomes import GateVerdict, ReviewVerdict
+from lionagi.state.db import StateDB
+
+
+@pytest.fixture
+async def db():
+    state = StateDB(":memory:")
+    await state.open()
+    yield state
+    await state.close()
+
+
+async def _make_invocation(db: StateDB, **fields) -> dict:
+    inv = {
+        "id": uuid.uuid4().hex[:12],
+        "skill": fields.pop("skill", "codex-pr-review"),
+        "started_at": fields.pop("started_at", time.time()),
+        **fields,
+    }
+    await db.create_invocation(inv)
+    return inv
+
+
+async def _make_session(db: StateDB, **fields) -> dict:
+    prog_id = str(uuid.uuid4())
+    await db.create_progression(prog_id)
+    s = {"id": str(uuid.uuid4()), "progression_id": prog_id, **fields}
+    await db.create_session(s)
+    return s
+
+
+# ── Insert + read ────────────────────────────────────────────────────────────
+
+
+async def test_insert_artifact_with_invocation_link(db: StateDB):
+    inv = await _make_invocation(db)
+    verdict = ReviewVerdict(
+        verdict="APPROVE",
+        summary="LGTM",
+        round=1,
+    )
+    art_id = await db.insert_artifact(
+        invocation_id=inv["id"],
+        kind=verdict.outcome_kind,
+        name="Round 1 verdict",
+        content=verdict.model_dump(),
+    )
+    assert isinstance(art_id, str) and len(art_id) == 12
+
+    rows = await db.list_artifacts_for_invocation(inv["id"])
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "review_verdict"
+    assert rows[0]["name"] == "Round 1 verdict"
+
+
+async def test_insert_artifact_with_session_link(db: StateDB):
+    s = await _make_session(db, status="completed")
+    gate = GateVerdict(
+        summary="ok", gate_passed=True, feedback="all green", passed=True
+    )
+    await db.insert_artifact(
+        session_id=s["id"],
+        kind=gate.outcome_kind,
+        name="play-gate",
+        content=gate.model_dump(),
+    )
+    rows = await db.list_artifacts_for_session(s["id"])
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "gate_verdict"
+
+
+async def test_get_artifact(db: StateDB):
+    inv = await _make_invocation(db)
+    art_id = await db.insert_artifact(
+        invocation_id=inv["id"],
+        kind="ci_result",
+        name="CI",
+        content={"summary": "all green", "passed": True},
+    )
+    row = await db.get_artifact(art_id)
+    assert row is not None
+    assert row["kind"] == "ci_result"
+
+
+async def test_get_artifact_missing_returns_none(db: StateDB):
+    assert await db.get_artifact("notarealid") is None
+
+
+# ── Validation ───────────────────────────────────────────────────────────────
+
+
+async def test_insert_artifact_requires_kind(db: StateDB):
+    with pytest.raises(ValueError, match="kind is required"):
+        await db.insert_artifact(kind="", name="x", content={})
+
+
+async def test_insert_artifact_requires_name(db: StateDB):
+    with pytest.raises(ValueError, match="name is required"):
+        await db.insert_artifact(kind="x", name="", content={})
+
+
+# ── FK cascade ────────────────────────────────────────────────────────────────
+
+
+async def test_artifacts_cascade_when_invocation_deleted(db: StateDB):
+    """Invocation FK uses ON DELETE CASCADE — orphan artifacts shouldn't linger."""
+    inv = await _make_invocation(db)
+    art_id = await db.insert_artifact(
+        invocation_id=inv["id"],
+        kind="review_verdict",
+        name="x",
+        content={"verdict": "APPROVE"},
+    )
+    await db.db.execute("DELETE FROM invocations WHERE id = ?", (inv["id"],))
+    await db.db.commit()
+    assert await db.get_artifact(art_id) is None
+
+
+# ── Ordering ──────────────────────────────────────────────────────────────────
+
+
+async def test_list_artifacts_ordered_by_created_at(db: StateDB):
+    import asyncio
+
+    inv = await _make_invocation(db)
+    ids = []
+    for i in range(3):
+        ids.append(
+            await db.insert_artifact(
+                invocation_id=inv["id"],
+                kind="review_verdict",
+                name=f"round-{i+1}",
+                content={"verdict": "APPROVE", "round": i + 1},
+            )
+        )
+        await asyncio.sleep(0.01)
+
+    rows = await db.list_artifacts_for_invocation(inv["id"])
+    assert [r["id"] for r in rows] == ids


### PR DESCRIPTION
## Summary

Implements **ADR-0021 steps 1-4** — the typed-output contract that lets skills produce structured outcomes (review verdicts, gate verdicts, CI results) and lets Studio render them as cards instead of opaque JSON.

**Steps 5-8 (chains layer) deferred to ADR-0021b fast-follow** per the ADR's own implementation order ("Steps 5-8 are the chaining layer, which can be built incrementally").

**Stacks on top of #1051 (ADR-0024).** Base branch is \`feat/adr-0024-session-health\`; rebases to main once the chain merges.

## What ships

### Outcome models (\`lionagi/outcomes/\`)
- \`SkillOutcome\` base: outcome_kind discriminator + summary + tri-state passed.
- \`ReviewVerdict\` + \`Finding\` — verdict ∈ {APPROVE, APPROVE_WITH_SUGGESTIONS, REQUEST_CHANGES, REJECT}, severity-tagged findings, round counter.
- \`GateVerdict\` — gate_passed + feedback + notes. Mirrors plays.gate_passed.
- \`CIResult\` + \`CIRunCommand\` — pass/fail matrix + per-command timings.

Each concrete outcome has a unique \`outcome_kind\` so the frontend switch-renderer dispatches unambiguously.

### Schema
- \`artifacts\` table: invocation_id + session_id FKs, kind (dispatch key), name, content (SkillOutcome JSON), optional file_path for the DB-vs-filesystem split.
- ON DELETE CASCADE on invocation_id.
- 4 indexes (invocation partial, session partial, kind, created_at DESC).

### DB helpers
- \`insert_artifact(*, kind, name, content, invocation_id, session_id, file_path)\` — validates kind + name non-empty, generates 12-char id.
- \`list_artifacts_for_invocation\`, \`list_artifacts_for_session\` — ordered by created_at ASC.
- \`get_artifact(artifact_id)\`.

### Studio API
- \`/api/invocations/{id}\` now returns sessions + artifacts inline.
- \`/api/artifacts/{id}\` — single artifact.
- \`/api/artifacts/by-session/{session_id}\` — session-scoped list.

### Studio frontend
- \`components/outcomes/OutcomeRenderer.tsx\` — kind-dispatched switch with JSON fallback so new kinds degrade gracefully.
- \`ReviewVerdictCard\` — severity counts + category breakdown + blocking findings (with file:line + suggestion) + collapsed minor suggestions. Mirrors the ADR layout.
- \`GateVerdictCard\` — ACCEPT/REJECT pill, feedback + notes panels.
- \`CIResultCard\` — tests/lint/typecheck/build matrix with skipped rows hidden, failure summary, per-command timings.
- \`/invocations/{id}\` page renders an "Outcomes (N)" section.

## Deferred to ADR-0021b
- \`chains\` + \`chain_runs\` tables and chain_run_id + step_index columns on invocations.
- \`li chain\` CLI (define, fire, check, list).
- Studio chains page.
- Schedule + manual trigger sources.
- codex-pr-review and play-gate retrofits to write typed artifacts (easier once chains exist to invoke them through).

## Test plan

- [x] \`uv run pytest tests/outcomes/\` — 13 tests pass (kind pinning, enum constraints, round-trip serialization, distinct-kinds contract)
- [x] \`uv run pytest tests/state/test_artifacts.py\` — 7 tests pass (insert, get, validation, FK cascade, ordering)
- [x] \`uv run pytest tests/state/ tests/cli/ tests/operations/ tests/apps_studio_server/ tests/outcomes/\` — 903 tests pass
- [x] \`uv run ruff check\` clean on every touched file
- [x] \`npx tsc --noEmit\` in \`apps/studio/frontend/\` clean
- [ ] Smoke test: insert a synthetic ReviewVerdict via Python, hit \`/api/invocations/{id}\`, verify it appears in the artifacts array
- [ ] Visual walkthrough: invocation detail page renders the three card types correctly when fed sample artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)