### PR TITLE
feat: ADR-0022 run-step provenance — model/provider/effort/agent_hash (Layer 4b)

### DIFF
--- a/apps/studio/frontend/app/invocations/[id]/page.tsx
+++ b/apps/studio/frontend/app/invocations/[id]/page.tsx
@@ -121,6 +121,7 @@ export default function InvocationDetailPage() {
               <tr className="border-b border-edge bg-surface-overlay text-meta uppercase tracking-[0.06em] text-content-muted">
                 <th className="px-3 py-2.5 font-medium">Session</th>
                 <th className="px-3 py-2.5 font-medium">Kind</th>
+                <th className="px-3 py-2.5 font-medium">Model</th>
                 <th className="px-3 py-2.5 font-medium">Status</th>
                 <th className="px-3 py-2.5 font-medium">Started</th>
                 <th className="px-3 py-2.5 font-medium">Last activity</th>
@@ -130,7 +131,7 @@ export default function InvocationDetailPage() {
               {data.sessions.length === 0 ? (
                 <tr>
                   <td
-                    colSpan={5}
+                    colSpan={6}
                     className="px-3 py-8 text-center text-meta text-content-muted"
                   >
                     No sessions spawned under this invocation yet.
@@ -155,6 +156,14 @@ export default function InvocationDetailPage() {
                     </td>
                     <td className="px-3 py-2 align-middle text-content-secondary">
                       {s.invocation_kind ?? "—"}
+                    </td>
+                    <td className="px-3 py-2 align-middle font-mono text-meta text-content-secondary">
+                      {s.model ?? "—"}
+                      {s.effort ? (
+                        <span className="ml-1 text-content-muted">
+                          · {s.effort}
+                        </span>
+                      ) : null}
                     </td>
                     <td className="px-3 py-2 align-middle">
                       <StatusPill value={s.status ?? "pending"} />

--- a/apps/studio/frontend/app/runs/[id]/page.tsx
+++ b/apps/studio/frontend/app/runs/[id]/page.tsx
@@ -132,7 +132,8 @@ function branchToRunStep(branch: SessionBranch, status: string): RunStep {
     step: branch.name || branch.id.slice(0, 8),
     status,
     result: {
-      agent: branch.name || branch.id.slice(0, 8),
+      agent: branch.agent_name ?? branch.name ?? branch.id.slice(0, 8),
+      model: branch.model ?? branch.provider ?? null,
       message_count: runMessages.length,
       roles: rolesCounts,
     },

--- a/apps/studio/frontend/app/runs/page.tsx
+++ b/apps/studio/frontend/app/runs/page.tsx
@@ -390,6 +390,7 @@ function RunsPageInner() {
               <th className="px-3 py-2.5 font-medium">
                 {viewMode === "invocations" ? "Invocation" : "Run"}
               </th>
+              <th className="px-3 py-2.5 font-medium">Model</th>
               <th className="px-3 py-2.5 font-medium">Status</th>
               <th className="px-3 py-2.5 font-medium">Health</th>
               <th className="px-3 py-2.5 font-medium">
@@ -490,7 +491,7 @@ function RunsPageInner() {
               )
             ) : runs.length === 0 ? (
               <tr>
-                <td colSpan={5} className="px-3 py-14 text-center text-body text-content-muted">
+                <td colSpan={6} className="px-3 py-14 text-center text-body text-content-muted">
                   <span className="block mb-1 text-[11px]">No runs found</span>
                   {(statuses.length > 0 || playbook) && (
                     <span className="text-meta">Try adjusting your filters.</span>

--- a/apps/studio/frontend/lib/api.ts
+++ b/apps/studio/frontend/lib/api.ts
@@ -414,6 +414,9 @@ export interface InvocationSession {
   last_message_at: number | null;
   started_at: number | null;
   ended_at: number | null;
+  // ADR-0022: per-child-session model + effort disclosure.
+  model?: string | null;
+  effort?: string | null;
 }
 
 // ADR-0021: structured skill outputs. `kind` is the dispatch key for

--- a/apps/studio/frontend/lib/api.ts
+++ b/apps/studio/frontend/lib/api.ts
@@ -357,6 +357,12 @@ export interface SessionDetail {
   created_at: number;
   updated_at: number;
   branches: SessionBranch[];
+  // ADR-0022: provenance disclosure — mirrors what list_sessions() exposes.
+  model?: string | null;
+  provider?: string | null;
+  effort?: string | null;
+  agent_hash?: string | null;
+  invocation_id?: string | null;
 }
 
 export async function listSessions(): Promise<{ sessions: SessionSummary[] }> {

--- a/apps/studio/frontend/lib/api.ts
+++ b/apps/studio/frontend/lib/api.ts
@@ -349,6 +349,9 @@ export interface SessionBranch {
   name: string;
   created_at: number;
   messages: SessionMessage[];
+  model?: string | null;
+  provider?: string | null;
+  agent_name?: string | null;
 }
 
 export interface SessionDetail {

--- a/apps/studio/frontend/lib/types.ts
+++ b/apps/studio/frontend/lib/types.ts
@@ -31,6 +31,14 @@ export interface RunSummary {
   last_message_at?: number | null;
   // ADR-0020: optional parent skill orchestration id (from `li invoke`).
   invocation_id?: string | null;
+  // ADR-0022: provenance disclosure. `model` is the resolved
+  // "provider/name" spec, `provider` is the raw provider key, `effort`
+  // is the run's effort level (low/medium/high/xhigh), `agent_hash` is
+  // a 16-char fingerprint of the agent profile content at run time.
+  model?: string | null;
+  provider?: string | null;
+  effort?: string | null;
+  agent_hash?: string | null;
   started_at: number | null;
   ended_at?: number | null;
   created_at?: number | null;

--- a/apps/studio/server/services/invocations.py
+++ b/apps/studio/server/services/invocations.py
@@ -98,6 +98,9 @@ async def get_invocation(invocation_id: str) -> dict[str, Any] | None:
                 "last_message_at": s.get("last_message_at"),
                 "started_at": s.get("started_at"),
                 "ended_at": s.get("ended_at"),
+                # ADR-0022: model disclosure on the child sessions list.
+                "model": s.get("model"),
+                "effort": s.get("effort"),
             }
             for s in sessions
         ],

--- a/apps/studio/server/services/runs.py
+++ b/apps/studio/server/services/runs.py
@@ -587,6 +587,11 @@ async def list_runs(
             "source_kind": s.get("source_kind", "live"),
             # ADR-0020: parent skill orchestration; null when standalone.
             "invocation_id": s.get("invocation_id"),
+            # ADR-0022: provenance disclosure.
+            "model": s.get("model"),
+            "provider": s.get("provider"),
+            "effort": s.get("effort"),
+            "agent_hash": s.get("agent_hash"),
             "status": s.get("status", "completed"),
             "started_at": s.get("started_at"),
             "ended_at": s.get("ended_at"),

--- a/apps/studio/server/services/sessions.py
+++ b/apps/studio/server/services/sessions.py
@@ -117,10 +117,12 @@ async def get_session(session_id: str) -> dict[str, Any] | None:
     async with _open_db(_DB) as db:
         cur = await db.execute(
             # F-A1-4 (ADR-0017): include lifecycle columns in session detail
+            # ADR-0022: include provenance columns (model/provider/effort/agent_hash)
             """SELECT id, name, created_at, updated_at,
                       playbook_name, agent_name, invocation_kind,
                       show_topic, show_play_name, artifacts_path, source_kind,
-                      status, started_at, ended_at
+                      status, started_at, ended_at,
+                      model, provider, effort, agent_hash, invocation_id
                FROM sessions WHERE id = ?""",
             (session_id,),
         )
@@ -218,6 +220,12 @@ async def get_session(session_id: str) -> dict[str, Any] | None:
         "duration_ms": duration_ms,
         "source_show": source_show,
         "branches": branches,
+        # ADR-0022: provenance disclosure — same fields exposed on list_sessions().
+        "model": session_row["model"],
+        "provider": session_row["provider"],
+        "effort": session_row["effort"],
+        "agent_hash": session_row["agent_hash"],
+        "invocation_id": session_row["invocation_id"],
     }
 
 

--- a/apps/studio/server/services/sessions.py
+++ b/apps/studio/server/services/sessions.py
@@ -60,6 +60,10 @@ async def list_sessions() -> list[dict[str, Any]]:
                 s.ended_at,
                 s.last_message_at,
                 s.invocation_id,
+                s.model,
+                s.provider,
+                s.effort,
+                s.agent_hash,
                 COUNT(DISTINCT b.id) AS branch_count,
                 COALESCE(SUM(
                     json_array_length(p.collection)
@@ -90,6 +94,11 @@ async def list_sessions() -> list[dict[str, Any]]:
             "last_message_at": row["last_message_at"],
             # ADR-0020: optional parent skill orchestration.
             "invocation_id": row["invocation_id"],
+            # ADR-0022: provenance disclosure — resolved values.
+            "model": row["model"],
+            "provider": row["provider"],
+            "effort": row["effort"],
+            "agent_hash": row["agent_hash"],
             "playbook_name": row["playbook_name"],
             "agent_name": row["agent_name"],
             "invocation_kind": row["invocation_kind"],

--- a/apps/studio/server/services/sessions.py
+++ b/apps/studio/server/services/sessions.py
@@ -147,7 +147,7 @@ async def get_session(session_id: str) -> dict[str, Any] | None:
         )
 
         branch_cur = await db.execute(
-            "SELECT id, name, created_at, progression_id FROM branches WHERE session_id = ? ORDER BY created_at",
+            "SELECT id, name, created_at, progression_id, model, provider, agent_name FROM branches WHERE session_id = ? ORDER BY created_at",
             (session_id,),
         )
         branch_rows = await branch_cur.fetchall()
@@ -190,6 +190,9 @@ async def get_session(session_id: str) -> dict[str, Any] | None:
                     "name": br["name"],
                     "created_at": br["created_at"],
                     "messages": messages,
+                    "model": br["model"],
+                    "provider": br["provider"],
+                    "agent_name": br["agent_name"],
                 }
             )
 
@@ -197,9 +200,7 @@ async def get_session(session_id: str) -> dict[str, Any] | None:
     started_at = session_row["started_at"]
     ended_at = session_row["ended_at"]
     duration_ms = (
-        (ended_at - started_at) * 1000
-        if started_at is not None and ended_at is not None
-        else None
+        (ended_at - started_at) * 1000 if started_at is not None and ended_at is not None else None
     )
 
     return {
@@ -229,9 +230,7 @@ async def get_session(session_id: str) -> dict[str, Any] | None:
     }
 
 
-async def get_session_messages_after(
-    session_id: str, after_ts: float
-) -> list[dict[str, Any]]:
+async def get_session_messages_after(session_id: str, after_ts: float) -> list[dict[str, Any]]:
     if not DEFAULT_DB_PATH.exists():
         return []
 

--- a/docs/adrs/ADR-0023-unified-hook-system.md
+++ b/docs/adrs/ADR-0023-unified-hook-system.md
@@ -154,7 +154,7 @@ class StopHook(Exception):
 | `TOOL_PRE` | `tool_name`, `action`, `args`, `branch_id` | Branch tool dispatch |
 | `TOOL_POST` | `tool_name`, `action`, `args`, `result`, `branch_id` | Branch tool dispatch |
 | `TOOL_ERROR` | `tool_name`, `action`, `args`, `error`, `branch_id` | Branch tool dispatch |
-| `MESSAGE_ADD` | `message`, `branch_id`, `session_id`, `progression_id` | Branch.add_message() |
+| `MESSAGE_ADD` | `message`, `session_id`, `branch_id`, `branch_progression_id`, `session_progression_id` | Branch.add_message() |
 | `ARTIFACT_CREATED` | `artifact`, `invocation_id`, `session_id` | Skill output |
 
 ### Built-in handlers
@@ -184,14 +184,23 @@ async def persist_session_start(*, session_id, model, provider, effort,
             started_at=time.time(),
         )
 
-async def persist_message(*, message, session_id, branch_id,
-                           progression_id, **kw):
-    """Write message to state.db + update last_message_at."""
+async def persist_message(*, message, session_id, branch_id=None,
+                           branch_progression_id=None,
+                           session_progression_id=None,
+                           progression_id=None,  # legacy alias
+                           **kw):
+    """Write message to state.db, append to both progressions, update system_msg_id."""
     from lionagi.state.db import StateDB
-    async with StateDB.open() as db:
+    effective_branch_prog = branch_progression_id or progression_id
+    async with StateDB() as db:
         await db.insert_message(message)
-        await db.append_to_progression(progression_id, message["id"])
-        await db.update_session(session_id, last_message_at=time.time())
+        if effective_branch_prog is not None:
+            await db.append_to_progression(effective_branch_prog, message["id"])
+        if session_progression_id is not None:
+            await db.append_to_progression(session_progression_id, message["id"])
+        if message.get("role") == "system" and branch_id is not None:
+            await db.update_branch(branch_id, system_msg_id=message["id"])
+        await db.touch_session_activity(session_id)
 
 async def persist_branch_provenance(*, branch_id, model, provider,
                                      agent_name, **kw):

--- a/lionagi/cli/_providers.py
+++ b/lionagi/cli/_providers.py
@@ -53,6 +53,7 @@ def _clamp_claude_effort(effort: str, model: str) -> str:
 
 # provider name → kwarg name for effort
 PROVIDER_EFFORT_KWARG: dict[str, str] = {
+    "claude-code": "effort",
     "claude_code": "effort",
     "claude": "effort",
     "codex": "reasoning_effort",
@@ -172,11 +173,7 @@ def _normalize_model_name(model: str, provider_hint: str | None = None) -> str:
     """Normalize bare model name (no provider prefix)."""
     if provider_hint and provider_hint in _CLAUDE_PROVIDER_NAMES:
         for prefix in _CLAUDE_MODEL_PREFIXES:
-            if (
-                model.startswith(prefix)
-                and model != prefix
-                and not model.startswith("claude-")
-            ):
+            if model.startswith(prefix) and model != prefix and not model.startswith("claude-"):
                 return f"claude-{model}"
     return model
 
@@ -210,9 +207,7 @@ def parse_model_spec(spec: str) -> ModelSpec:
                 f"Provider '{provider_raw}' does not support effort levels. "
                 f"Remove '-{effort}' from '{spec}'."
             )
-        return ModelSpec(
-            model=_normalize_model(model_clean, provider_raw), effort=effort
-        )
+        return ModelSpec(model=_normalize_model(model_clean, provider_raw), effort=effort)
 
     return ModelSpec(model=_normalize_model(spec, provider_raw), effort=None)
 
@@ -333,12 +328,8 @@ def add_common_cli_args(parser: argparse.ArgumentParser) -> None:
             "Does not change model or reasoning effort."
         ),
     )
-    parser.add_argument(
-        "-v", "--verbose", action="store_true", help="Stream real-time output."
-    )
-    parser.add_argument(
-        "--theme", choices=("light", "dark"), default=None, help="Terminal theme."
-    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="Stream real-time output.")
+    parser.add_argument("--theme", choices=("light", "dark"), default=None, help="Terminal theme.")
     parser.add_argument(
         "--effort",
         metavar="LEVEL",

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -11,6 +11,7 @@ from lionagi import Branch
 from lionagi._errors import TimeoutError as LionTimeoutError
 from lionagi.ln.concurrency import run_async
 from lionagi.protocols.generic.log import DataLoggerConfig
+from lionagi.state import provenance as _provenance
 
 from ._agents import load_agent_profile
 from ._logging import hint, log_error
@@ -125,11 +126,18 @@ async def _run_agent(
     branch_id = str(branch.id)
 
     # Set up live SQLite persist (messages stream into DB as they're added)
+    # ADR-0022: pass the *resolved* provider + model spec for provenance.
+    # ``model_spec`` here is the canonical ``provider/model`` string built
+    # right above this block — no aliases, no defaults yet to apply.
+    resolved_model_spec = _provenance.resolve_model_spec(provider, model)
     live = await _setup_live_persist(
         branch,
         agent_name=agent_name,
         artifacts_path=str(run.artifact_root),
         invocation_id=invocation_id,
+        model=resolved_model_spec,
+        provider=provider,
+        effort=effort,
     )
 
     # ADR-0025: distinguish timed_out / aborted / cancelled / failed so
@@ -203,6 +211,9 @@ async def _setup_live_persist(
     agent_name: str | None = None,
     artifacts_path: str | None = None,
     invocation_id: str | None = None,
+    model: str | None = None,
+    provider: str | None = None,
+    effort: str | None = None,
 ) -> dict | None:
     """Open DB, create session/branch rows, register live message hook.
 
@@ -289,6 +300,14 @@ async def _setup_live_persist(
                     "started_at": time.time(),
                     # ADR-0020: optional skill-level orchestration parent.
                     "invocation_id": invocation_id,
+                    # ADR-0022: resolved provenance — captured at the
+                    # session boundary so historical runs disclose the
+                    # exact model + provider + effort + agent fingerprint
+                    # they used, even if the agent profile changes later.
+                    "model": model,
+                    "provider": provider,
+                    "effort": effort,
+                    "agent_hash": _provenance.agent_definition_hash(agent_name),
                 }
             )
 
@@ -316,6 +335,14 @@ async def _setup_live_persist(
                     "session_id": session_id,
                     "progression_id": branch_prog_id,
                     "system_msg_id": system_msg_id,
+                    # ADR-0022: branch-level provenance — for `li agent`
+                    # the branch shares the session's model/provider,
+                    # but write them on the branch too so flow ops
+                    # (which may differ per-branch) can be queried
+                    # uniformly via the branches table.
+                    "model": model,
+                    "provider": provider,
+                    "agent_name": agent_name,
                 }
             )
 

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import argparse
 import json
 
-from lionagi import Branch
+from lionagi import Branch, iModel
 from lionagi._errors import TimeoutError as LionTimeoutError
 from lionagi.ln.concurrency import run_async
 from lionagi.protocols.generic.log import DataLoggerConfig
@@ -96,6 +96,13 @@ async def _run_agent(
         chat_model = build_chat_model(
             provider, model, yolo, verbose, theme, effort, fast
         )
+        # Extract the post-clamp effort so sessions.effort stores the value
+        # that was actually sent to the provider (e.g. "max"→"xhigh" for codex).
+        if isinstance(chat_model, iModel):
+            _ep_kwargs = chat_model.endpoint.config.kwargs or {}
+            _kwarg = PROVIDER_EFFORT_KWARG.get(provider)
+            if _kwarg and _kwarg in _ep_kwargs:
+                effort = _ep_kwargs[_kwarg]
         branch = Branch(
             chat_model=chat_model,
             log_config=DataLoggerConfig(auto_save_on_exit=False),

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -38,7 +38,7 @@ from lionagi.state import provenance as _provenance
 
 from .._agents import AgentProfile, load_agent_profile
 from .._logging import hint
-from .._providers import build_imodel_from_spec
+from .._providers import PROVIDER_EFFORT_KWARG, build_imodel_from_spec
 from .._runs import RunDir, allocate_run, save_last_branch_pointer
 
 
@@ -273,6 +273,13 @@ def setup_orchestration(
         theme=theme,
         fast=fast,
     )
+    # Extract the post-clamp effort so env.effort (and thus sessions.effort)
+    # stores the value actually sent to the provider (e.g. "max"→"xhigh" for codex).
+    _orc_ep_kwargs = orc_imodel.endpoint.config.kwargs or {}
+    _orc_provider = orc_imodel.endpoint.config.provider
+    _orc_effort_kwarg = PROVIDER_EFFORT_KWARG.get(_orc_provider)
+    if _orc_effort_kwarg and _orc_effort_kwarg in _orc_ep_kwargs:
+        effort = _orc_ep_kwargs[_orc_effort_kwarg]
     if cwd:
         orc_imodel.endpoint.config.kwargs.setdefault("repo", Path(cwd))
 

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -34,11 +34,23 @@ from typing import Any
 from lionagi import Branch, Session
 from lionagi.operations.builder import OperationGraphBuilder
 from lionagi.protocols.generic.log import DataLoggerConfig
+from lionagi.state import provenance as _provenance
 
 from .._agents import AgentProfile, load_agent_profile
 from .._logging import hint
 from .._providers import build_imodel_from_spec
 from .._runs import RunDir, allocate_run, save_last_branch_pointer
+
+
+def _resolve_session_model(
+    provider: str | None, model: str | None
+) -> str | None:
+    """ADR-0022: canonical 'provider/model' for the session.model column.
+
+    Thin wrapper over :func:`provenance.resolve_model_spec` so callers
+    don't repeat the import. Returns None when both args are None.
+    """
+    return _provenance.resolve_model_spec(provider, model)
 
 __all__ = (
     "OrchestrationEnv",
@@ -509,6 +521,9 @@ async def start_live_persist(
     agent_name: str | None = None,
     artifacts_path: str | None = None,
     invocation_id: str | None = None,
+    model: str | None = None,
+    provider: str | None = None,
+    effort: str | None = None,
 ) -> None:
     """Open state.db, create session row, register hooks on existing branches.
 
@@ -552,6 +567,13 @@ async def start_live_persist(
                 "started_at": time.time(),
                 # ADR-0020: optional skill orchestration parent
                 "invocation_id": invocation_id,
+                # ADR-0022: orchestrator-level provenance. For multi-model
+                # flows the per-branch model is the actual; this is the
+                # "primary" / "default" that the runs list shows.
+                "model": _resolve_session_model(provider, model),
+                "provider": provider,
+                "effort": effort,
+                "agent_hash": _provenance.agent_definition_hash(agent_name),
             }
         )
 
@@ -629,6 +651,27 @@ def _register_branch_hook(ctx: dict[str, Any], branch: Branch) -> None:
                 system_msg_id = sys_dict["id"]
                 await db.insert_message(sys_dict)
 
+            # ADR-0022: per-branch provenance — pulled from the runtime
+            # endpoint config so multi-model flows correctly disclose what
+            # *each* branch actually used, not the orchestrator default.
+            br_model: str | None = None
+            br_provider: str | None = None
+            try:
+                ep_cfg = branch.chat_model.endpoint.config
+                br_provider = getattr(ep_cfg, "provider", None)
+                br_model_raw = (ep_cfg.kwargs or {}).get("model")
+                br_model = _provenance.resolve_model_spec(
+                    br_provider, br_model_raw
+                )
+            except Exception as _provenance_exc:  # noqa: BLE001
+                # Provenance is best-effort — never block the branch row.
+                import logging
+
+                logging.getLogger("lionagi.cli").debug(
+                    "branch provenance lookup failed for %s: %s",
+                    branch_id,
+                    _provenance_exc,
+                )
             await db.create_branch(
                 {
                     "id": branch_id,
@@ -639,6 +682,11 @@ def _register_branch_hook(ctx: dict[str, Any], branch: Branch) -> None:
                     "session_id": session_id,
                     "progression_id": branch_prog_id,
                     "system_msg_id": system_msg_id,
+                    "model": br_model,
+                    "provider": br_provider,
+                    # branch.name is the agent role within the flow
+                    # ("r1", "critic", "explorer", ...).
+                    "agent_name": branch_dict.get("name"),
                 }
             )
             initialized["done"] = True

--- a/lionagi/cli/orchestrate/fanout.py
+++ b/lionagi/cli/orchestrate/fanout.py
@@ -74,6 +74,15 @@ async def _run_fanout(
     )
     _shared: dict = {}
 
+    # ADR-0022: orchestrator default model + effort on the session row.
+    # Per-worker model is written branch-side when build_worker_branch runs.
+    from .._providers import parse_model_spec as _parse_model_spec
+    _orc_ms = (
+        _parse_model_spec(env.default_model_spec) if env.default_model_spec else None
+    )
+    _orc_provider = None
+    if _orc_ms and "/" in _orc_ms.model:
+        _orc_provider = _orc_ms.model.split("/", 1)[0]
     await start_live_persist(
         env,
         invocation_kind="fanout",
@@ -81,6 +90,9 @@ async def _run_fanout(
         agent_name=agent_name,
         artifacts_path=str(env.run.artifact_root),
         invocation_id=invocation_id,
+        model=_orc_ms.model if _orc_ms else None,
+        provider=_orc_provider,
+        effort=env.effort,
     )
 
     inner_kw = dict(

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -454,6 +454,13 @@ async def _run_flow(
     # ADR-0012: `flow` and `play` are distinct invocation kinds. A playbook
     # run (li play NAME, or li o flow -p NAME) is `play`; an ad-hoc DAG flow
     # without a playbook is `flow`.
+    # ADR-0022: surface the orchestrator's default model + effort on the
+    # session row. Per-branch (per-agent) model is written by
+    # _register_branch_hook → create_branch when each worker spawns.
+    _orc_ms = parse_model_spec(env.default_model_spec) if env.default_model_spec else None
+    _orc_provider = None
+    if _orc_ms and "/" in _orc_ms.model:
+        _orc_provider = _orc_ms.model.split("/", 1)[0]
     await start_live_persist(
         env,
         invocation_kind="play" if playbook_name else "flow",
@@ -461,6 +468,9 @@ async def _run_flow(
         agent_name=agent_name,
         artifacts_path=str(env.run.artifact_root),
         invocation_id=invocation_id,
+        model=_orc_ms.model if _orc_ms else None,
+        provider=_orc_provider,
+        effort=env.effort,
     )
 
     inner_kw = dict(

--- a/lionagi/hooks/__init__.py
+++ b/lionagi/hooks/__init__.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""ADR-0023: unified hook system.
+
+The :class:`HookBus` consolidates three previously-disjoint hook systems
+(iModel ``HookRegistry``, agent ``hook_handlers``, CLI ``_on_message``
+closures) into one event bus. Migration of those systems is staged —
+this package ships the bus, the hook-point vocabulary, and the
+declarative agent-YAML loader. The CLI / service / agent wiring lands
+in follow-up PRs (ADR-0023b/c) so the existing hot paths aren't
+disturbed mid-flight.
+
+Public surface:
+
+* :class:`HookPoint` — the enumerated event vocabulary.
+* :class:`HookBus` — per-session pub/sub registry.
+* :func:`hook` — decorator for registering custom handlers.
+* :class:`StopHook` — handler may raise to abort siblings on the same point.
+* :func:`load_hooks_for_agent` — build a HookBus from an agent profile.
+"""
+
+from .bus import HookBus, HookPoint, StopHook, hook
+from .loader import (
+    DEFAULT_HOOKS,
+    build_session_bus,
+    load_hooks_for_agent,
+    register_handler,
+    resolve_handler,
+)
+
+__all__ = [
+    "HookBus",
+    "HookPoint",
+    "StopHook",
+    "hook",
+    "DEFAULT_HOOKS",
+    "build_session_bus",
+    "load_hooks_for_agent",
+    "register_handler",
+    "resolve_handler",
+]

--- a/lionagi/hooks/builtins.py
+++ b/lionagi/hooks/builtins.py
@@ -1,0 +1,174 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""ADR-0023 built-in handlers.
+
+These adapt the new HookBus to the persistence helpers that already
+land via ADR-0019 / 0020 / 0022. The CLI hot paths still call those
+helpers directly in this PR — wiring the bus into ``_setup_live_persist``
+and ``start_live_persist`` is intentionally deferred to ADR-0023b so
+the existing message-add path isn't disrupted while the bus is being
+proven out.
+
+Each handler is name-addressable via the loader's registry so agent
+profiles can reference them as strings (``hooks.session.start:
+[persist_session_start]``).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+logger = logging.getLogger("lionagi.hooks.builtins")
+
+
+async def persist_session_start(
+    *,
+    session_id: str,
+    model: str | None = None,
+    provider: str | None = None,
+    effort: str | None = None,
+    agent_name: str | None = None,
+    agent_hash: str | None = None,
+    invocation_id: str | None = None,
+    **_unused: Any,
+) -> None:
+    """Write the ADR-0022 provenance set + open the lifecycle window."""
+    from lionagi.state.db import StateDB
+
+    async with StateDB() as db:
+        await db.update_session(
+            session_id,
+            model=model,
+            provider=provider,
+            effort=effort,
+            agent_name=agent_name,
+            agent_hash=agent_hash,
+            invocation_id=invocation_id,
+            status="running",
+            started_at=time.time(),
+        )
+
+
+async def persist_session_end(
+    *,
+    session_id: str,
+    status: str = "completed",
+    error: str | None = None,
+    **_unused: Any,
+) -> None:
+    """Stamp the terminal status + ended_at on the session row."""
+    from lionagi.state.db import StateDB
+
+    fields: dict[str, Any] = {"status": status, "ended_at": time.time()}
+    if error is not None:
+        # node_metadata is JSON — overwriting is destructive, so keep the
+        # error in a dedicated field and let the caller merge if needed.
+        fields["node_metadata"] = {"error": error}
+    async with StateDB() as db:
+        await db.update_session(session_id, **fields)
+
+
+async def persist_branch_provenance(
+    *,
+    branch_id: str,
+    model: str | None = None,
+    provider: str | None = None,
+    agent_name: str | None = None,
+    **_unused: Any,
+) -> None:
+    """ADR-0022 per-branch model / provider / agent_name."""
+    from lionagi.state.db import StateDB
+
+    async with StateDB() as db:
+        await db.update_branch(
+            branch_id,
+            model=model,
+            provider=provider,
+            agent_name=agent_name,
+        )
+
+
+async def persist_message(
+    *,
+    message: dict[str, Any],
+    session_id: str,
+    branch_id: str | None = None,
+    branch_progression_id: str | None = None,
+    session_progression_id: str | None = None,
+    # Legacy alias kept for callers predating the dual-progression split.
+    progression_id: str | None = None,
+    **_unused: Any,
+) -> None:
+    """ADR-0019 + ADR-0009 message persistence path.
+
+    Appends to both ``branch_progression_id`` and
+    ``session_progression_id`` when provided. For system messages
+    (``message["role"] == "system"``) also updates the branch row's
+    ``system_msg_id`` pointer so the branch always knows its current
+    system prompt.
+
+    ``progression_id`` is a legacy alias for ``branch_progression_id``
+    kept for backward compatibility.
+    """
+    from lionagi.state.db import StateDB
+
+    effective_branch_prog = branch_progression_id or progression_id
+
+    async with StateDB() as db:
+        await db.insert_message(message)
+        if effective_branch_prog is not None:
+            await db.append_to_progression(effective_branch_prog, message["id"])
+        if session_progression_id is not None:
+            await db.append_to_progression(session_progression_id, message["id"])
+        if message.get("role") == "system" and branch_id is not None:
+            await db.update_branch(branch_id, system_msg_id=message["id"])
+        await db.touch_session_activity(session_id)
+
+
+async def log_api_metrics(
+    *,
+    model: str | None = None,
+    provider: str | None = None,
+    tokens: dict[str, int] | None = None,
+    latency_ms: float | None = None,
+    **_unused: Any,
+) -> None:
+    """Cheap structured log line for ad-hoc observability.
+
+    Real metrics emission (Prometheus, OTel, etc.) is out of scope for
+    this PR; this exists so the agent YAML loader can demonstrate
+    declarative hook wiring against a non-DB handler.
+    """
+    if tokens:
+        logger.info(
+            "api.post_call model=%s provider=%s tokens=%s latency_ms=%s",
+            model,
+            provider,
+            tokens.get("total"),
+            latency_ms,
+        )
+    else:
+        logger.info(
+            "api.post_call model=%s provider=%s latency_ms=%s",
+            model,
+            provider,
+            latency_ms,
+        )
+
+
+async def log_tool_use(
+    *,
+    tool_name: str,
+    action: str | None = None,
+    args: dict[str, Any] | None = None,
+    **_unused: Any,
+) -> None:
+    """Structured log for tool dispatch — readable but not metric-y."""
+    logger.info(
+        "tool.pre tool=%s action=%s args=%s",
+        tool_name,
+        action,
+        list(args.keys()) if args else [],
+    )

--- a/lionagi/hooks/bus.py
+++ b/lionagi/hooks/bus.py
@@ -1,0 +1,200 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""ADR-0023: HookBus + HookPoint vocabulary.
+
+The bus is intentionally minimal. Handlers register against a
+:class:`HookPoint`, the bus dispatches sequentially, and a handler
+exception is logged but never aborts the user-facing operation. The one
+exception is :class:`StopHook`, which the handler may raise to short-
+circuit subsequent handlers on the same point (but still doesn't fail
+the surrounding operation).
+
+Isolation invariants (enforced by convention, not code):
+
+* Handlers MUST NOT mutate the kwargs they receive — pass-by-reference
+  observers only.
+* DB-writing handlers MUST be tolerant of in-flight failure (the bus
+  keeps going).
+* ``TOOL_PRE`` is the one hook point where a handler may legitimately
+  raise to block the underlying operation (e.g., destructive-command
+  guard). The bus enforces this via :meth:`HookBus.blocking_emit`, which
+  propagates handler exceptions to the caller instead of swallowing them.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from collections.abc import Awaitable, Callable
+from enum import Enum
+from typing import Any
+
+logger = logging.getLogger("lionagi.hooks")
+
+
+class HookPoint(str, Enum):
+    """ADR-0023 §"Event payloads" — closed vocabulary of hook points."""
+
+    # Session lifecycle
+    SESSION_START = "session.start"
+    SESSION_END = "session.end"
+
+    # Branch lifecycle
+    BRANCH_CREATE = "branch.create"
+
+    # iModel (API calls)
+    API_PRE_CALL = "api.pre_call"
+    API_POST_CALL = "api.post_call"
+    API_STREAM_CHUNK = "api.stream_chunk"
+
+    # Tool execution
+    TOOL_PRE = "tool.pre"
+    TOOL_POST = "tool.post"
+    TOOL_ERROR = "tool.error"
+
+    # Message lifecycle
+    MESSAGE_ADD = "message.add"
+
+    # Artifact production (ADR-0021)
+    ARTIFACT_CREATED = "artifact.created"
+
+
+HookHandler = Callable[..., Awaitable[Any]]
+
+
+class StopHook(Exception):  # noqa: N818 — control-flow signal, not an error
+    """Raised by a handler to skip remaining handlers on this point.
+
+    Does NOT abort the underlying operation — only stops the bus from
+    invoking later handlers for the same emit call. Named without the
+    ``Error`` suffix on purpose: this is the StopIteration-style control
+    flow signal of the hook bus, not a failure indication.
+    """
+
+
+def _normalize_point(point: HookPoint | str) -> HookPoint:
+    """Coerce ``point`` to a :class:`HookPoint`, raising ``ValueError`` for unknowns."""
+    if isinstance(point, HookPoint):
+        return point
+    return HookPoint(point)  # raises ValueError for unknown values
+
+
+class HookBus:
+    """Per-session pub/sub bus for the eleven :class:`HookPoint` events.
+
+    Handlers are dispatched sequentially in registration order. A handler
+    raising any exception other than :class:`StopHook` is logged and
+    skipped — the user-facing operation is never blocked. This trades
+    strict error propagation for the operational invariant that
+    persistence side-effects must never break the agent loop.
+
+    ``TOOL_PRE`` is the exception: emit() routes it through
+    :meth:`blocking_emit` so that a guard handler raising (e.g.
+    ``PermissionError``) actually blocks the tool call.
+    """
+
+    def __init__(self) -> None:
+        self._handlers: dict[HookPoint, list[HookHandler]] = {}
+
+    def on(self, point: HookPoint | str, handler: HookHandler) -> None:
+        """Register ``handler`` to fire on ``point``. Order preserved.
+
+        Accepts a string hook-point value (e.g. ``"session.start"``) and
+        normalises it to a :class:`HookPoint`. Raises ``ValueError`` for
+        unrecognised strings.
+        """
+        point = _normalize_point(point)
+        self._handlers.setdefault(point, []).append(handler)
+
+    def off(self, point: HookPoint | str, handler: HookHandler) -> None:
+        """Unregister ``handler``. No-op if not registered."""
+        point = _normalize_point(point)
+        handlers = self._handlers.get(point, [])
+        if handler in handlers:
+            handlers.remove(handler)
+
+    def handlers_for(self, point: HookPoint | str) -> list[HookHandler]:
+        """Public read of the registered handlers for ``point``.
+
+        Useful for testing / introspection. Returns a shallow copy so
+        callers can't mutate the bus by mutating the returned list.
+        """
+        point = _normalize_point(point)
+        return list(self._handlers.get(point, []))
+
+    async def blocking_emit(self, point: HookPoint | str, /, **kwargs: Any) -> None:
+        """Fire all handlers for ``point``, propagating exceptions.
+
+        Unlike :meth:`emit`, handler exceptions are NOT swallowed —
+        they propagate to the caller. Intended for ``TOOL_PRE`` where a
+        guard handler raising ``PermissionError`` (or similar) should
+        actually abort the tool call.
+
+        :class:`StopHook` still short-circuits remaining handlers without
+        propagating as an error.
+        """
+        point = _normalize_point(point)
+        handlers = list(self._handlers.get(point, []))
+        for handler in handlers:
+            try:
+                result = handler(**kwargs)
+                if inspect.isawaitable(result):
+                    await result
+            except StopHook:
+                return
+            # All other exceptions propagate — no except clause here.
+
+    async def emit(self, point: HookPoint | str, /, **kwargs: Any) -> None:
+        """Fire all handlers for ``point`` sequentially with ``kwargs``.
+
+        Handler exceptions are logged + swallowed. ``StopHook`` short-
+        circuits remaining handlers on this point only.
+
+        ``TOOL_PRE`` is routed through :meth:`blocking_emit` so guard
+        handlers can block the operation by raising.
+        """
+        point = _normalize_point(point)
+        if point is HookPoint.TOOL_PRE:
+            await self.blocking_emit(point, **kwargs)
+            return
+        # Snapshot handlers before dispatch so a handler registered during
+        # this emit cycle does not fire in the current cycle.
+        handlers = list(self._handlers.get(point, []))
+        for handler in handlers:
+            try:
+                result = handler(**kwargs)
+                # Allow sync handlers too — await only if needed.
+                if inspect.isawaitable(result):
+                    await result
+            except StopHook:
+                return
+            except Exception:  # noqa: BLE001 — hook isolation invariant
+                logger.exception("Hook failed: %s", point.value)
+
+
+# ── Decorator for user-defined handlers ───────────────────────────────────────
+
+
+def hook(point: HookPoint | str) -> Callable[[HookHandler], HookHandler]:
+    """Tag a callable as a handler for ``point`` (registered at load time).
+
+    The decorator only marks the function — registration into a bus is
+    the loader's job (see :func:`lionagi.hooks.loader.register_handler`).
+    This separation lets a single module define multiple handlers without
+    side effects at import time.
+
+    Usage::
+
+        @hook(HookPoint.API_POST_CALL)
+        async def notify_on_expensive_call(*, tokens, model, **kw):
+            ...
+    """
+    point_enum = point if isinstance(point, HookPoint) else HookPoint(point)
+
+    def _wrap(fn: HookHandler) -> HookHandler:
+        # Attribute is consulted by the loader to bind by HookPoint without
+        # requiring the user to import the bus.
+        fn.__lionagi_hook_point__ = point_enum  # type: ignore[attr-defined]
+        return fn
+
+    return _wrap

--- a/lionagi/hooks/loader.py
+++ b/lionagi/hooks/loader.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""ADR-0023 hook registry + agent-YAML loader.
+
+The loader maintains a name → handler registry so agent profiles can
+reference handlers as strings::
+
+    hooks:
+      session.start:
+        - persist_session_start
+      api.post_call:
+        - log_api_metrics
+
+The registry is pre-populated with the built-ins from
+:mod:`lionagi.hooks.builtins`. User-defined handlers (decorated with
+:func:`lionagi.hooks.bus.hook`) register via :func:`register_handler`.
+
+:func:`build_session_bus` implements the override semantics from the
+ADR: when a profile mentions a hook point, the profile's list REPLACES
+the default for that point (so ``message.add: []`` actually disables
+the built-in persistence). Hook points the profile doesn't mention keep
+their defaults.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from . import builtins as _builtins
+from .bus import HookBus, HookHandler, HookPoint
+
+logger = logging.getLogger("lionagi.hooks.loader")
+
+# Default wiring per ADR-0023 §"Default hooks (no configuration needed)".
+DEFAULT_HOOKS: dict[HookPoint, list[HookHandler]] = {
+    HookPoint.SESSION_START: [_builtins.persist_session_start],
+    HookPoint.SESSION_END: [_builtins.persist_session_end],
+    HookPoint.MESSAGE_ADD: [_builtins.persist_message],
+    HookPoint.BRANCH_CREATE: [_builtins.persist_branch_provenance],
+}
+
+
+_REGISTRY: dict[str, HookHandler] = {
+    "persist_session_start": _builtins.persist_session_start,
+    "persist_session_end": _builtins.persist_session_end,
+    "persist_branch_provenance": _builtins.persist_branch_provenance,
+    "persist_message": _builtins.persist_message,
+    "log_api_metrics": _builtins.log_api_metrics,
+    "log_tool_use": _builtins.log_tool_use,
+}
+
+
+def register_handler(
+    name: str, handler: Callable[..., Awaitable[Any]]
+) -> None:
+    """Register a callable under ``name`` for agent-YAML lookup.
+
+    Re-registration overrides — last writer wins. User-defined handlers
+    decorated with :func:`bus.hook` typically come in via
+    :func:`load_user_handlers` (not yet wired; that's the auto-load path
+    deferred to ADR-0023b).
+    """
+    _REGISTRY[name] = handler
+
+
+def resolve_handler(name: str) -> HookHandler:
+    """Look up ``name`` in the registry. Raises KeyError if missing.
+
+    The bus catches and logs handler exceptions, but a *missing* handler
+    is a configuration error — failing loudly at session start is the
+    right time.
+    """
+    try:
+        return _REGISTRY[name]
+    except KeyError as exc:
+        raise KeyError(
+            f"Unknown hook handler {name!r}. "
+            f"Registered: {sorted(_REGISTRY)}"
+        ) from exc
+
+
+def registered_handlers() -> list[str]:
+    """Sorted list of registered handler names (for diagnostics)."""
+    return sorted(_REGISTRY)
+
+
+def load_hooks_for_agent(
+    agent_hooks: dict[str, list[str]] | None,
+) -> dict[HookPoint, list[HookHandler]]:
+    """Resolve an agent profile's ``hooks`` section to a (point → handlers) map.
+
+    Returns the *override* set, NOT merged with defaults — pass through
+    :func:`build_session_bus` to get the merged result. Unknown hook
+    point strings raise ``ValueError`` so typos surface at load time
+    instead of at first emit.
+    """
+    if not agent_hooks:
+        return {}
+    resolved: dict[HookPoint, list[HookHandler]] = {}
+    for point_str, handler_names in agent_hooks.items():
+        try:
+            point = HookPoint(point_str)
+        except ValueError as exc:
+            raise ValueError(
+                f"Unknown hook point {point_str!r}; "
+                f"valid: {sorted(p.value for p in HookPoint)}"
+            ) from exc
+        if not isinstance(handler_names, list):
+            raise ValueError(
+                f"hooks.{point_str} must be a list of handler names; "
+                f"got {type(handler_names).__name__}"
+            )
+        resolved[point] = [resolve_handler(n) for n in handler_names]
+    return resolved
+
+
+def build_session_bus(
+    agent_hooks: dict[str, list[str]] | None = None,
+) -> HookBus:
+    """Construct a per-session bus with defaults + profile overrides.
+
+    Override semantics: if ``agent_hooks`` mentions a point, the profile's
+    list *replaces* the default for that point. Empty list disables the
+    default (e.g., ``message.add: []`` turns off persistence). Points the
+    profile doesn't mention keep the default.
+
+    ADR-0023 §"Bus lifecycle" — one bus per session, created at session
+    init, passed to all branches.
+    """
+    bus = HookBus()
+    overrides = load_hooks_for_agent(agent_hooks)
+
+    for point, handlers in DEFAULT_HOOKS.items():
+        if point in overrides:
+            for handler in overrides[point]:
+                bus.on(point, handler)
+        else:
+            for handler in handlers:
+                bus.on(point, handler)
+
+    for point, handlers in overrides.items():
+        if point in DEFAULT_HOOKS:
+            continue
+        for handler in handlers:
+            bus.on(point, handler)
+
+    return bus

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -42,6 +42,12 @@ _SESSION_COLUMNS = frozenset(
         # ADR-0020: optional FK to the skill orchestration that spawned
         # this session (e.g. a /show invocation grouping its plays).
         "invocation_id",
+        # ADR-0022: provenance disclosure — resolved model spec, provider,
+        # effort, and the agent profile content hash at invocation time.
+        "model",
+        "provider",
+        "effort",
+        "agent_hash",
     }
 )
 
@@ -109,6 +115,10 @@ _BRANCH_COLUMNS = frozenset(
         "user",
         "node_metadata",
         "system_msg_id",
+        # ADR-0022: per-branch provenance for multi-model flows.
+        "model",
+        "provider",
+        "agent_name",
     }
 )
 
@@ -329,9 +339,18 @@ class StateDB:
             ("last_message_at", "REAL"),
             # ADR-0020: optional FK to invocations table.
             ("invocation_id", "TEXT"),
+            # ADR-0022: provenance disclosure columns.
+            ("model", "TEXT"),
+            ("provider", "TEXT"),
+            ("effort", "TEXT"),
+            ("agent_hash", "TEXT"),
         ],
         "branches": [
             ("system_msg_id", "TEXT"),
+            # ADR-0022: per-branch provenance.
+            ("model", "TEXT"),
+            ("provider", "TEXT"),
+            ("agent_name", "TEXT"),
         ],
         "shows": [
             ("status_source", "TEXT NOT NULL DEFAULT 'unknown'"),
@@ -436,7 +455,11 @@ class StateDB:
                   started_at      REAL,
                   ended_at        REAL,
                   last_message_at REAL,
-                  invocation_id   TEXT
+                  invocation_id   TEXT,
+                  model           TEXT,
+                  provider        TEXT,
+                  effort          TEXT,
+                  agent_hash      TEXT
                 )
                 """
             )
@@ -630,8 +653,10 @@ class StateDB:
                progression_id, first_msg_id, last_msg_id, updated_at,
                playbook_name, agent_name, invocation_kind, show_topic,
                show_play_name, artifacts_path, source_kind,
-               status, started_at, ended_at, last_message_at, invocation_id)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+               status, started_at, ended_at, last_message_at, invocation_id,
+               model, provider, effort, agent_hash)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                       ?, ?, ?, ?)""",
             (
                 session["id"],
                 session.get("created_at", now),
@@ -661,6 +686,14 @@ class StateDB:
                 # ADR-0020: optional FK to invocations(id). NULL when the
                 # session was spawned standalone (no `li invoke start`).
                 session.get("invocation_id"),
+                # ADR-0022: resolved provenance — model/provider/effort
+                # are the values the runtime actually used, not the user
+                # input. agent_hash is the SHA-256 of the agent profile
+                # content at invocation time (drift detection).
+                session.get("model"),
+                session.get("provider"),
+                session.get("effort"),
+                session.get("agent_hash"),
             ),
         )
         # ADR-0020: keep invocations.session_count in sync so list queries
@@ -1038,8 +1071,8 @@ class StateDB:
     async def create_branch(self, branch: dict[str, Any]) -> None:
         await self.db.execute(
             """INSERT OR IGNORE INTO branches (id, created_at, node_metadata, user, name,
-               session_id, progression_id, system_msg_id)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+               session_id, progression_id, system_msg_id, model, provider, agent_name)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 branch["id"],
                 branch.get("created_at", time.time()),
@@ -1049,6 +1082,10 @@ class StateDB:
                 branch["session_id"],
                 branch["progression_id"],
                 branch.get("system_msg_id"),
+                # ADR-0022: per-branch resolved provenance.
+                branch.get("model"),
+                branch.get("provider"),
+                branch.get("agent_name"),
             ),
         )
         await self.db.commit()

--- a/lionagi/state/provenance.py
+++ b/lionagi/state/provenance.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""ADR-0022: provenance helpers.
+
+These are tiny one-shot utilities that the CLI call sites use to write
+the resolved model / provider / effort / agent_hash columns at session
+creation time. Keeping them in one file makes the write-side responsibilities
+easy to audit (every CLI entry point should pass through here).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+# Length matches what the ADR pins for the column comment: 16 chars is
+# enough for "same or different" comparisons without storing the whole
+# 64-char digest.
+_AGENT_HASH_LEN = 16
+
+
+def agent_definition_hash(agent_name: str | None) -> str | None:
+    """Return a short SHA-256 fingerprint of an agent profile's content.
+
+    Searches the standard locations (``~/.lionagi/agents/<name>/<name>.md``
+    then ``~/.lionagi/agents/<name>.md``) — same lookup order as
+    :func:`lionagi.cli._agents.load_agent_profile`. Returns ``None`` when
+    the agent name is missing or no profile is found; callers should
+    write ``None`` to ``sessions.agent_hash`` in that case.
+    """
+    if not agent_name:
+        return None
+    from lionagi.cli._runs import LIONAGI_HOME
+
+    base = LIONAGI_HOME / "agents"
+    candidates = (
+        base / agent_name / f"{agent_name}.md",
+        base / f"{agent_name}.md",
+    )
+    for path in candidates:
+        if path.exists():
+            return _hash_file(path)
+    return None
+
+
+def _hash_file(path: Path) -> str:
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return ""
+    return hashlib.sha256(data).hexdigest()[:_AGENT_HASH_LEN]
+
+
+def resolve_model_spec(
+    provider: str | None, model: str | None
+) -> str | None:
+    """Produce the canonical ``"provider/model"`` string for storage.
+
+    ADR-0022 requires the stored value to be the resolved spec, not the
+    user input. The CLI already does the parsing — this helper just
+    re-joins the parts so callers don't need to remember the separator.
+    Returns ``None`` when neither part is known.
+    """
+    if not provider and not model:
+        return None
+    if provider and model:
+        # Already-qualified inputs ("claude/claude-sonnet-4-6") slip
+        # through with their original prefix preserved.
+        if "/" in model:
+            return model
+        return f"{provider}/{model}"
+    return provider or model

--- a/lionagi/state/provenance.py
+++ b/lionagi/state/provenance.py
@@ -22,23 +22,20 @@ _AGENT_HASH_LEN = 16
 def agent_definition_hash(agent_name: str | None) -> str | None:
     """Return a short SHA-256 fingerprint of an agent profile's content.
 
-    Searches the standard locations (``~/.lionagi/agents/<name>/<name>.md``
-    then ``~/.lionagi/agents/<name>.md``) — same lookup order as
-    :func:`lionagi.cli._agents.load_agent_profile`. Returns ``None`` when
-    the agent name is missing or no profile is found; callers should
-    write ``None`` to ``sessions.agent_hash`` in that case.
+    Uses the same resolution order as
+    :func:`lionagi.cli._agents.load_agent_profile`: project-local
+    ``.lionagi/agents/`` directories first (git root, then cwd walk),
+    then ``~/.lionagi/agents/``. Returns ``None`` when the agent name is
+    missing or no profile is found; callers should write ``None`` to
+    ``sessions.agent_hash`` in that case.
     """
     if not agent_name:
         return None
-    from lionagi.cli._runs import LIONAGI_HOME
+    from lionagi.cli._agents import _find_lionagi_dirs, _resolve_profile_path
 
-    base = LIONAGI_HOME / "agents"
-    candidates = (
-        base / agent_name / f"{agent_name}.md",
-        base / f"{agent_name}.md",
-    )
-    for path in candidates:
-        if path.exists():
+    for d in _find_lionagi_dirs():
+        path = _resolve_profile_path(d / "agents", agent_name)
+        if path is not None:
             return _hash_file(path)
     return None
 

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -118,7 +118,17 @@ CREATE TABLE IF NOT EXISTS sessions (
   -- /codex-pr-review) that spawned this session. NULL when the CLI
   -- ran standalone. Orthogonal to invocation_kind, which describes the
   -- CLI primitive (agent / play / flow / fanout / show-play).
-  invocation_id   TEXT    REFERENCES invocations(id)
+  invocation_id   TEXT    REFERENCES invocations(id),
+  -- ── Provenance disclosure (ADR-0022) ────────────────────────────────
+  -- Resolved values — what the runtime actually used after defaults,
+  -- overrides, and fallbacks. ``model`` is the canonical spec ("claude/
+  -- claude-sonnet-4-6"), not the user input ("sonnet"). ``agent_hash``
+  -- is a 16-char SHA-256 fingerprint of the agent profile content at
+  -- invocation time for drift detection.
+  model           TEXT,
+  provider        TEXT,
+  effort          TEXT,
+  agent_hash      TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_sessions_updated
@@ -143,7 +153,16 @@ CREATE TABLE IF NOT EXISTS branches (
   name            TEXT,
   session_id      TEXT    NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
   progression_id  TEXT    NOT NULL REFERENCES progressions(id),
-  system_msg_id   TEXT    REFERENCES messages(id)   -- system prompt; just a reference to the message
+  system_msg_id   TEXT    REFERENCES messages(id),  -- system prompt; just a reference to the message
+  -- ── Provenance disclosure (ADR-0022) ────────────────────────────────
+  -- Per-branch (per-agent) resolved model + provider + agent role name.
+  -- For multi-agent flows the session-level model is the "default" and
+  -- per-branch model is the actual model that produced messages on this
+  -- branch. agent_name here is the *role* within the flow (e.g., "r1"
+  -- or "critic"), not the agent_profile name on sessions.
+  model           TEXT,
+  provider        TEXT,
+  agent_name      TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_branches_session

--- a/tests/hooks/test_builtins.py
+++ b/tests/hooks/test_builtins.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ADR-0023 built-in handlers (FIX 4: persist_message dual progressions)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from lionagi.hooks.builtins import persist_message
+
+# StateDB is imported lazily inside persist_message, so we patch the module
+# it lives in — not lionagi.hooks.builtins.
+_STATEDB_PATH = "lionagi.state.db.StateDB"
+
+
+def _make_mock_db_ctx():
+    mock_db = AsyncMock()
+    mock_ctx = MagicMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_db)
+    mock_ctx.__aexit__ = AsyncMock(return_value=None)
+    return mock_db, mock_ctx
+
+
+# ── persist_message: dual progressions ───────────────────────────────────────
+
+
+async def test_persist_message_appends_to_branch_progression():
+    msg = {"id": "msg1", "role": "user", "content": "hi"}
+    mock_db, mock_ctx = _make_mock_db_ctx()
+
+    with patch(_STATEDB_PATH, return_value=mock_ctx):
+        await persist_message(
+            message=msg,
+            session_id="sess1",
+            branch_progression_id="bp1",
+        )
+
+    mock_db.insert_message.assert_awaited_once_with(msg)
+    mock_db.append_to_progression.assert_any_await("bp1", "msg1")
+    mock_db.touch_session_activity.assert_awaited_once_with("sess1")
+
+
+async def test_persist_message_appends_to_session_progression():
+    msg = {"id": "msg2", "role": "user", "content": "hi"}
+    mock_db, mock_ctx = _make_mock_db_ctx()
+
+    with patch(_STATEDB_PATH, return_value=mock_ctx):
+        await persist_message(
+            message=msg,
+            session_id="sess1",
+            session_progression_id="sp1",
+        )
+
+    mock_db.append_to_progression.assert_any_await("sp1", "msg2")
+
+
+async def test_persist_message_appends_to_both_progressions():
+    msg = {"id": "msg3", "role": "assistant", "content": "reply"}
+    mock_db, mock_ctx = _make_mock_db_ctx()
+
+    with patch(_STATEDB_PATH, return_value=mock_ctx):
+        await persist_message(
+            message=msg,
+            session_id="sess1",
+            branch_progression_id="bp1",
+            session_progression_id="sp1",
+        )
+
+    calls = mock_db.append_to_progression.await_args_list
+    progression_ids = [c.args[0] for c in calls]
+    assert "bp1" in progression_ids
+    assert "sp1" in progression_ids
+
+
+async def test_persist_message_updates_system_msg_id_for_system_role():
+    msg = {"id": "sys1", "role": "system", "content": "You are helpful."}
+    mock_db, mock_ctx = _make_mock_db_ctx()
+
+    with patch(_STATEDB_PATH, return_value=mock_ctx):
+        await persist_message(
+            message=msg,
+            session_id="sess1",
+            branch_id="branch1",
+        )
+
+    mock_db.update_branch.assert_awaited_once_with("branch1", system_msg_id="sys1")
+
+
+async def test_persist_message_no_system_msg_update_for_non_system_role():
+    msg = {"id": "usr1", "role": "user", "content": "hello"}
+    mock_db, mock_ctx = _make_mock_db_ctx()
+
+    with patch(_STATEDB_PATH, return_value=mock_ctx):
+        await persist_message(
+            message=msg,
+            session_id="sess1",
+            branch_id="branch1",
+        )
+
+    mock_db.update_branch.assert_not_awaited()
+
+
+async def test_persist_message_legacy_progression_id_still_works():
+    """Backward compat: progression_id acts as branch_progression_id."""
+    msg = {"id": "msg_legacy", "role": "user", "content": "hi"}
+    mock_db, mock_ctx = _make_mock_db_ctx()
+
+    with patch(_STATEDB_PATH, return_value=mock_ctx):
+        await persist_message(
+            message=msg,
+            session_id="sess1",
+            progression_id="legacy_prog",
+        )
+
+    mock_db.append_to_progression.assert_any_await("legacy_prog", "msg_legacy")

--- a/tests/hooks/test_bus.py
+++ b/tests/hooks/test_bus.py
@@ -1,0 +1,308 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""ADR-0023 HookBus tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.hooks import HookBus, HookPoint, StopHook, hook
+
+# ── Basic dispatch ────────────────────────────────────────────────────────────
+
+
+async def test_emit_calls_registered_handlers_in_order():
+    bus = HookBus()
+    calls: list[str] = []
+
+    async def h1(**kw):
+        calls.append("h1")
+
+    async def h2(**kw):
+        calls.append("h2")
+
+    bus.on(HookPoint.SESSION_START, h1)
+    bus.on(HookPoint.SESSION_START, h2)
+    await bus.emit(HookPoint.SESSION_START, session_id="s")
+
+    assert calls == ["h1", "h2"]
+
+
+async def test_emit_with_no_handlers_is_silent():
+    bus = HookBus()
+    # Should not raise.
+    await bus.emit(HookPoint.SESSION_END, session_id="s", status="completed")
+
+
+async def test_off_removes_handler():
+    bus = HookBus()
+    calls: list[str] = []
+
+    async def h(**kw):
+        calls.append("fired")
+
+    bus.on(HookPoint.MESSAGE_ADD, h)
+    bus.off(HookPoint.MESSAGE_ADD, h)
+    await bus.emit(HookPoint.MESSAGE_ADD, message={}, session_id="s")
+    assert calls == []
+
+
+async def test_off_unregistered_handler_is_noop():
+    bus = HookBus()
+
+    async def h(**kw):
+        pass
+
+    # Should not raise even though h was never registered.
+    bus.off(HookPoint.MESSAGE_ADD, h)
+
+
+# ── Sync handlers accepted ────────────────────────────────────────────────────
+
+
+async def test_sync_handler_runs_without_await():
+    bus = HookBus()
+    calls: list[int] = []
+
+    def sync_handler(**kw):
+        calls.append(1)
+
+    bus.on(HookPoint.SESSION_END, sync_handler)
+    await bus.emit(HookPoint.SESSION_END, session_id="s", status="completed")
+    assert calls == [1]
+
+
+# ── Isolation: handler errors do NOT abort ───────────────────────────────────
+
+
+async def test_handler_exception_is_logged_and_swallowed():
+    bus = HookBus()
+    fired_after: list[str] = []
+
+    async def boom(**kw):
+        raise RuntimeError("explode")
+
+    async def after(**kw):
+        fired_after.append("after")
+
+    bus.on(HookPoint.MESSAGE_ADD, boom)
+    bus.on(HookPoint.MESSAGE_ADD, after)
+    # No exception should propagate.
+    await bus.emit(HookPoint.MESSAGE_ADD, message={}, session_id="s")
+    # Subsequent handlers still ran.
+    assert fired_after == ["after"]
+
+
+async def test_sync_handler_exception_is_also_swallowed():
+    bus = HookBus()
+    fired_after: list[str] = []
+
+    def boom(**kw):
+        raise RuntimeError("sync boom")
+
+    async def after(**kw):
+        fired_after.append("after")
+
+    bus.on(HookPoint.MESSAGE_ADD, boom)
+    bus.on(HookPoint.MESSAGE_ADD, after)
+    await bus.emit(HookPoint.MESSAGE_ADD, message={}, session_id="s")
+    assert fired_after == ["after"]
+
+
+# ── StopHook short-circuits remaining handlers ───────────────────────────────
+
+
+async def test_stop_hook_aborts_siblings_but_not_operation():
+    bus = HookBus()
+    calls: list[str] = []
+
+    async def stopper(**kw):
+        calls.append("stopper")
+        raise StopHook
+
+    async def never(**kw):  # pragma: no cover
+        calls.append("never")
+
+    bus.on(HookPoint.MESSAGE_ADD, stopper)
+    bus.on(HookPoint.MESSAGE_ADD, never)
+    await bus.emit(HookPoint.MESSAGE_ADD, message={}, session_id="s")
+    assert calls == ["stopper"]
+
+
+# ── Read introspection ──────────────────────────────────────────────────────
+
+
+async def test_handlers_for_returns_copy_not_internal_list():
+    bus = HookBus()
+
+    async def h(**kw):
+        pass
+
+    bus.on(HookPoint.SESSION_START, h)
+    snapshot = bus.handlers_for(HookPoint.SESSION_START)
+    snapshot.clear()  # Should not affect the bus.
+
+    assert bus.handlers_for(HookPoint.SESSION_START) == [h]
+
+
+# ── @hook decorator ──────────────────────────────────────────────────────────
+
+
+def test_hook_decorator_tags_function_with_point():
+    @hook(HookPoint.API_POST_CALL)
+    async def my_handler(**kw):
+        pass
+
+    assert my_handler.__lionagi_hook_point__ is HookPoint.API_POST_CALL
+
+
+def test_hook_decorator_accepts_string_point():
+    @hook("api.pre_call")
+    async def my_handler(**kw):
+        pass
+
+    assert my_handler.__lionagi_hook_point__ is HookPoint.API_PRE_CALL
+
+
+def test_hook_decorator_rejects_unknown_point():
+    with pytest.raises(ValueError):
+
+        @hook("not.a.real.point")
+        async def _handler(**kw):
+            pass
+
+
+# ── HookPoint vocabulary pinned ──────────────────────────────────────────────
+
+
+def test_hook_point_vocabulary():
+    """Pin the 11-event vocabulary so a removal is visible in this test."""
+    values = {p.value for p in HookPoint}
+    assert values == {
+        "session.start",
+        "session.end",
+        "branch.create",
+        "api.pre_call",
+        "api.post_call",
+        "api.stream_chunk",
+        "tool.pre",
+        "tool.post",
+        "tool.error",
+        "message.add",
+        "artifact.created",
+    }
+
+
+# ── FIX 1: on() validates HookPoint ─────────────────────────────────────────
+
+
+def test_on_string_valid_point_registers():
+    bus = HookBus()
+    calls: list[str] = []
+
+    async def h(**kw):
+        calls.append("fired")
+
+    bus.on("session.start", h)
+    assert bus.handlers_for(HookPoint.SESSION_START) == [h]
+
+
+def test_on_invalid_string_raises_value_error():
+    bus = HookBus()
+
+    async def h(**kw):
+        pass
+
+    with pytest.raises(ValueError):
+        bus.on("session.starts", h)  # typo — not a valid HookPoint
+
+
+def test_off_invalid_string_raises_value_error():
+    bus = HookBus()
+
+    async def h(**kw):
+        pass
+
+    with pytest.raises(ValueError):
+        bus.off("session.starts", h)
+
+
+def test_handlers_for_invalid_string_raises_value_error():
+    bus = HookBus()
+
+    with pytest.raises(ValueError):
+        bus.handlers_for("session.starts")
+
+
+# ── FIX 2: blocking_emit propagates exceptions for TOOL_PRE ──────────────────
+
+
+async def test_blocking_emit_propagates_exception():
+    bus = HookBus()
+
+    async def guard(**kw):
+        raise PermissionError("blocked")
+
+    bus.on(HookPoint.TOOL_PRE, guard)
+
+    with pytest.raises(PermissionError, match="blocked"):
+        await bus.blocking_emit(HookPoint.TOOL_PRE, tool_name="rm")
+
+
+async def test_emit_tool_pre_propagates_exception():
+    """emit() on TOOL_PRE must propagate — it routes through blocking_emit."""
+    bus = HookBus()
+
+    async def guard(**kw):
+        raise PermissionError("blocked via emit")
+
+    bus.on(HookPoint.TOOL_PRE, guard)
+
+    with pytest.raises(PermissionError, match="blocked via emit"):
+        await bus.emit(HookPoint.TOOL_PRE, tool_name="rm")
+
+
+async def test_blocking_emit_stop_hook_short_circuits_without_error():
+    bus = HookBus()
+    calls: list[str] = []
+
+    async def stopper(**kw):
+        calls.append("stopper")
+        raise StopHook
+
+    async def never(**kw):  # pragma: no cover
+        calls.append("never")
+
+    bus.on(HookPoint.TOOL_PRE, stopper)
+    bus.on(HookPoint.TOOL_PRE, never)
+    # StopHook must not propagate out of blocking_emit.
+    await bus.blocking_emit(HookPoint.TOOL_PRE, tool_name="ls")
+    assert calls == ["stopper"]
+
+
+# ── FIX 3: handlers snapshotted before dispatch ───────────────────────────────
+
+
+async def test_emit_handler_registered_during_emit_does_not_fire():
+    """A handler registered *during* an emit cycle must not fire that cycle."""
+    bus = HookBus()
+    calls: list[str] = []
+
+    async def first(**kw):
+        calls.append("first")
+        # Register a new handler mid-dispatch.
+        bus.on(HookPoint.SESSION_START, late)
+
+    async def late(**kw):
+        calls.append("late")
+
+    bus.on(HookPoint.SESSION_START, first)
+    await bus.emit(HookPoint.SESSION_START, session_id="s")
+
+    # Only "first" fired; "late" was registered after the snapshot.
+    assert calls == ["first"]
+
+    # On the NEXT emit, "late" should fire.
+    await bus.emit(HookPoint.SESSION_START, session_id="s")
+    assert "late" in calls

--- a/tests/hooks/test_loader.py
+++ b/tests/hooks/test_loader.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""ADR-0023 loader tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.hooks import (
+    DEFAULT_HOOKS,
+    HookBus,
+    HookPoint,
+    build_session_bus,
+    load_hooks_for_agent,
+    register_handler,
+    resolve_handler,
+)
+
+# ── Registry ──────────────────────────────────────────────────────────────────
+
+
+def test_builtins_resolvable_by_name():
+    """ADR-0023 §"Built-in handlers" — names must be agent-YAML addressable."""
+    for name in (
+        "persist_session_start",
+        "persist_session_end",
+        "persist_branch_provenance",
+        "persist_message",
+        "log_api_metrics",
+        "log_tool_use",
+    ):
+        assert callable(resolve_handler(name)), f"{name!r} not registered"
+
+
+def test_resolve_unknown_handler_raises_descriptively():
+    with pytest.raises(KeyError, match="not_a_real_handler"):
+        resolve_handler("not_a_real_handler")
+
+
+def test_register_handler_makes_it_addressable():
+    async def my_custom(**kw):
+        pass
+
+    register_handler("my_custom_handler_for_test", my_custom)
+    try:
+        assert resolve_handler("my_custom_handler_for_test") is my_custom
+    finally:
+        # Cleanup: re-registration with the same name acts as remove +
+        # add, so register a sentinel to "free" the slot for the next
+        # test run (avoids cross-test pollution).
+        from lionagi.hooks.loader import _REGISTRY
+
+        _REGISTRY.pop("my_custom_handler_for_test", None)
+
+
+# ── load_hooks_for_agent ─────────────────────────────────────────────────────
+
+
+def test_load_hooks_resolves_string_names_to_callables():
+    resolved = load_hooks_for_agent(
+        {
+            "session.start": ["persist_session_start"],
+            "api.post_call": ["log_api_metrics"],
+        }
+    )
+    assert set(resolved) == {HookPoint.SESSION_START, HookPoint.API_POST_CALL}
+    assert len(resolved[HookPoint.SESSION_START]) == 1
+    assert len(resolved[HookPoint.API_POST_CALL]) == 1
+
+
+def test_load_hooks_rejects_unknown_hook_point():
+    with pytest.raises(ValueError, match="Unknown hook point"):
+        load_hooks_for_agent({"session.bogus": ["persist_session_start"]})
+
+
+def test_load_hooks_rejects_non_list_value():
+    with pytest.raises(ValueError, match="must be a list"):
+        load_hooks_for_agent({"session.start": "persist_session_start"})
+
+
+def test_load_hooks_empty_or_none_returns_empty_map():
+    assert load_hooks_for_agent(None) == {}
+    assert load_hooks_for_agent({}) == {}
+
+
+# ── build_session_bus override semantics ─────────────────────────────────────
+
+
+def test_build_session_bus_uses_defaults_when_no_profile():
+    bus = build_session_bus(None)
+    for point, handlers in DEFAULT_HOOKS.items():
+        assert bus.handlers_for(point) == handlers
+
+
+def test_build_session_bus_profile_overrides_defaults():
+    """Profile listing a hook point REPLACES the default for that point."""
+    bus = build_session_bus(
+        {"session.start": ["log_api_metrics"]}  # bogus mapping; just testing override
+    )
+    # session.start now has only log_api_metrics, NOT persist_session_start.
+    handlers = bus.handlers_for(HookPoint.SESSION_START)
+    assert len(handlers) == 1
+    # Other defaults are untouched.
+    assert bus.handlers_for(HookPoint.SESSION_END) == DEFAULT_HOOKS[HookPoint.SESSION_END]
+    assert bus.handlers_for(HookPoint.MESSAGE_ADD) == DEFAULT_HOOKS[HookPoint.MESSAGE_ADD]
+
+
+def test_build_session_bus_empty_list_disables_default():
+    """``message.add: []`` is the documented way to turn off persistence."""
+    bus = build_session_bus({"message.add": []})
+    assert bus.handlers_for(HookPoint.MESSAGE_ADD) == []
+    # Defaults at other points still present.
+    assert bus.handlers_for(HookPoint.SESSION_START) != []
+
+
+def test_build_session_bus_adds_handlers_for_non_default_points():
+    """Profile may register handlers on points that have no default."""
+    bus = build_session_bus(
+        {"api.post_call": ["log_api_metrics"], "tool.pre": ["log_tool_use"]}
+    )
+    assert len(bus.handlers_for(HookPoint.API_POST_CALL)) == 1
+    assert len(bus.handlers_for(HookPoint.TOOL_PRE)) == 1
+
+
+def test_default_hooks_only_cover_session_lifecycle_and_persistence():
+    """ADR-0023 §"Default hooks" — pinned set."""
+    assert set(DEFAULT_HOOKS) == {
+        HookPoint.SESSION_START,
+        HookPoint.SESSION_END,
+        HookPoint.MESSAGE_ADD,
+        HookPoint.BRANCH_CREATE,
+    }
+
+
+def test_build_session_bus_returns_fresh_instance_each_call():
+    """Each session gets its own bus — no shared state."""
+    a = build_session_bus(None)
+    b = build_session_bus(None)
+    assert a is not b
+    assert isinstance(a, HookBus)
+    assert isinstance(b, HookBus)

--- a/tests/state/test_provenance.py
+++ b/tests/state/test_provenance.py
@@ -1,0 +1,194 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""ADR-0022 provenance tests.
+
+Covers: agent_definition_hash() lookup + hashing, resolve_model_spec()
+canonicalization, and the DB write path (model/provider/effort/agent_hash
+columns on sessions, model/provider/agent_name on branches).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from pathlib import Path
+
+import pytest
+
+from lionagi.state.db import StateDB
+from lionagi.state.provenance import (
+    agent_definition_hash,
+    resolve_model_spec,
+)
+
+
+@pytest.fixture
+async def db():
+    state = StateDB(":memory:")
+    await state.open()
+    yield state
+    await state.close()
+
+
+def _uid() -> str:
+    return str(uuid.uuid4())
+
+
+# ── resolve_model_spec ────────────────────────────────────────────────────────
+
+
+def test_resolve_combines_provider_and_model():
+    assert resolve_model_spec("claude", "claude-sonnet-4-6") == "claude/claude-sonnet-4-6"
+
+
+def test_resolve_passes_already_qualified_model_through():
+    assert (
+        resolve_model_spec("claude", "claude/claude-sonnet-4-6")
+        == "claude/claude-sonnet-4-6"
+    )
+
+
+def test_resolve_returns_only_arg_when_one_missing():
+    assert resolve_model_spec(None, "claude/claude-sonnet-4-6") == "claude/claude-sonnet-4-6"
+    assert resolve_model_spec("claude", None) == "claude"
+
+
+def test_resolve_none_for_both_none():
+    assert resolve_model_spec(None, None) is None
+
+
+# ── agent_definition_hash ────────────────────────────────────────────────────
+
+
+def test_hash_none_for_missing_agent(tmp_path: Path, monkeypatch):
+    """Unknown agent name → None (caller writes NULL to agent_hash)."""
+    import lionagi.cli._runs as _runs_mod
+
+    monkeypatch.setattr(_runs_mod, "LIONAGI_HOME", tmp_path / "lionagi-home")
+    assert agent_definition_hash("never-existed") is None
+
+
+def test_hash_none_for_empty_name():
+    assert agent_definition_hash(None) is None
+    assert agent_definition_hash("") is None
+
+
+def test_hash_finds_nested_md(tmp_path: Path, monkeypatch):
+    """ADR-0022 lookup order: ``agents/<name>/<name>.md`` first."""
+    import lionagi.cli._runs as _runs_mod
+
+    home = tmp_path / "lionagi-home"
+    monkeypatch.setattr(_runs_mod, "LIONAGI_HOME", home)
+    agents = home / "agents"
+    nested = agents / "reviewer"
+    nested.mkdir(parents=True)
+    body = b"# reviewer\nbe thorough.\n"
+    (nested / "reviewer.md").write_bytes(body)
+
+    expected = hashlib.sha256(body).hexdigest()[:16]
+    assert agent_definition_hash("reviewer") == expected
+
+
+def test_hash_falls_back_to_flat_md(tmp_path: Path, monkeypatch):
+    """When no nested dir exists, fall back to ``agents/<name>.md``."""
+    import lionagi.cli._runs as _runs_mod
+
+    home = tmp_path / "lionagi-home"
+    monkeypatch.setattr(_runs_mod, "LIONAGI_HOME", home)
+    agents = home / "agents"
+    agents.mkdir(parents=True)
+    body = b"# analyst\n"
+    (agents / "analyst.md").write_bytes(body)
+
+    expected = hashlib.sha256(body).hexdigest()[:16]
+    assert agent_definition_hash("analyst") == expected
+
+
+def test_hash_is_16_chars():
+    """Pin the truncation length so storage size stays predictable."""
+    h = hashlib.sha256(b"x").hexdigest()[:16]
+    assert len(h) == 16
+
+
+# ── DB write path ────────────────────────────────────────────────────────────
+
+
+async def test_create_session_persists_provenance(db: StateDB):
+    prog_id = _uid()
+    sid = _uid()
+    await db.create_progression(prog_id)
+    await db.create_session(
+        {
+            "id": sid,
+            "progression_id": prog_id,
+            "status": "running",
+            "model": "claude/claude-sonnet-4-6",
+            "provider": "claude",
+            "effort": "high",
+            "agent_hash": "abc123def456",
+        }
+    )
+    row = await db.get_session(sid)
+    assert row["model"] == "claude/claude-sonnet-4-6"
+    assert row["provider"] == "claude"
+    assert row["effort"] == "high"
+    assert row["agent_hash"] == "abc123def456"
+
+
+async def test_create_session_provenance_nullable(db: StateDB):
+    """Legacy callers that don't supply provenance keys must not crash."""
+    prog_id = _uid()
+    sid = _uid()
+    await db.create_progression(prog_id)
+    await db.create_session(
+        {"id": sid, "progression_id": prog_id, "status": "running"}
+    )
+    row = await db.get_session(sid)
+    assert row["model"] is None
+    assert row["provider"] is None
+    assert row["effort"] is None
+    assert row["agent_hash"] is None
+
+
+async def test_create_branch_persists_per_branch_provenance(db: StateDB):
+    prog_id = _uid()
+    sid = _uid()
+    bprog = _uid()
+    bid = _uid()
+    await db.create_progression(prog_id)
+    await db.create_progression(bprog)
+    await db.create_session(
+        {"id": sid, "progression_id": prog_id, "status": "running"}
+    )
+    await db.create_branch(
+        {
+            "id": bid,
+            "session_id": sid,
+            "progression_id": bprog,
+            "model": "claude/claude-opus-4-7",
+            "provider": "claude",
+            "agent_name": "critic",
+        }
+    )
+    row = await db.get_branch(bid)
+    assert row["model"] == "claude/claude-opus-4-7"
+    assert row["provider"] == "claude"
+    assert row["agent_name"] == "critic"
+
+
+async def test_update_session_allows_provenance_columns(db: StateDB):
+    """Backfill from filesystem runs can set provenance after the fact."""
+    prog_id = _uid()
+    sid = _uid()
+    await db.create_progression(prog_id)
+    await db.create_session(
+        {"id": sid, "progression_id": prog_id, "status": "running"}
+    )
+    await db.update_session(
+        sid, model="openai/gpt-4.1", provider="openai", effort="medium"
+    )
+    row = await db.get_session(sid)
+    assert row["model"] == "openai/gpt-4.1"
+    assert row["provider"] == "openai"
+    assert row["effort"] == "medium"

--- a/tests/state/test_provenance.py
+++ b/tests/state/test_provenance.py
@@ -63,9 +63,9 @@ def test_resolve_none_for_both_none():
 
 def test_hash_none_for_missing_agent(tmp_path: Path, monkeypatch):
     """Unknown agent name → None (caller writes NULL to agent_hash)."""
-    import lionagi.cli._runs as _runs_mod
+    import lionagi.cli._agents as _agents_mod
 
-    monkeypatch.setattr(_runs_mod, "LIONAGI_HOME", tmp_path / "lionagi-home")
+    monkeypatch.setattr(_agents_mod, "_find_lionagi_dirs", lambda: [tmp_path / "empty"])
     assert agent_definition_hash("never-existed") is None
 
 
@@ -76,33 +76,61 @@ def test_hash_none_for_empty_name():
 
 def test_hash_finds_nested_md(tmp_path: Path, monkeypatch):
     """ADR-0022 lookup order: ``agents/<name>/<name>.md`` first."""
-    import lionagi.cli._runs as _runs_mod
+    import lionagi.cli._agents as _agents_mod
 
     home = tmp_path / "lionagi-home"
-    monkeypatch.setattr(_runs_mod, "LIONAGI_HOME", home)
     agents = home / "agents"
     nested = agents / "reviewer"
     nested.mkdir(parents=True)
     body = b"# reviewer\nbe thorough.\n"
     (nested / "reviewer.md").write_bytes(body)
 
+    monkeypatch.setattr(_agents_mod, "_find_lionagi_dirs", lambda: [home])
     expected = hashlib.sha256(body).hexdigest()[:16]
     assert agent_definition_hash("reviewer") == expected
 
 
 def test_hash_falls_back_to_flat_md(tmp_path: Path, monkeypatch):
     """When no nested dir exists, fall back to ``agents/<name>.md``."""
-    import lionagi.cli._runs as _runs_mod
+    import lionagi.cli._agents as _agents_mod
 
     home = tmp_path / "lionagi-home"
-    monkeypatch.setattr(_runs_mod, "LIONAGI_HOME", home)
     agents = home / "agents"
     agents.mkdir(parents=True)
     body = b"# analyst\n"
     (agents / "analyst.md").write_bytes(body)
 
+    monkeypatch.setattr(_agents_mod, "_find_lionagi_dirs", lambda: [home])
     expected = hashlib.sha256(body).hexdigest()[:16]
     assert agent_definition_hash("analyst") == expected
+
+
+def test_hash_finds_project_local_profile(tmp_path: Path, monkeypatch):
+    """Project-local .lionagi takes priority over global ~/.lionagi."""
+    import lionagi.cli._agents as _agents_mod
+
+    # Project-local profile
+    local_home = tmp_path / "project" / ".lionagi"
+    local_agents = local_home / "agents" / "coder"
+    local_agents.mkdir(parents=True)
+    local_body = b"---\nmodel: claude\n---\n# Coder (project-local)\n"
+    (local_agents / "coder.md").write_bytes(local_body)
+
+    # Global profile with different content — must NOT be chosen
+    global_home = tmp_path / "home" / ".lionagi"
+    global_agents = global_home / "agents" / "coder"
+    global_agents.mkdir(parents=True)
+    (global_agents / "coder.md").write_bytes(b"# Coder (global)\n")
+
+    # Project-local dir comes first, matching load_agent_profile() semantics
+    monkeypatch.setattr(
+        _agents_mod,
+        "_find_lionagi_dirs",
+        lambda: [local_home, global_home],
+    )
+
+    expected = hashlib.sha256(local_body).hexdigest()[:16]
+    assert agent_definition_hash("coder") == expected
 
 
 def test_hash_is_16_chars():


### PR DESCRIPTION
## Summary

Implements **ADR-0022 — Run Step Provenance**. Every session and branch now discloses the resolved model spec, provider, effort level, and a fingerprint of the agent profile content at run time. "Was this run on sonnet or opus?" becomes a SQL query, not a guess.

**Stacks on top of #1052 (ADR-0021).** Base branch is \`feat/adr-0021-artifacts-chaining\`; rebases to main once the chain merges.

## What ships

### Schema
- \`sessions\`: + \`model\`, \`provider\`, \`effort\`, \`agent_hash\` (all nullable; legacy rows stay NULL per ADR §Backfill — no automated backfill).
- \`branches\`: + \`model\`, \`provider\`, \`agent_name\` (per-branch for multi-model flows where the orchestrator default differs from individual workers).
- All 7 columns added to \`_MIGRATION_COLUMNS\` so existing DBs reconcile on next \`StateDB.open()\`.

### Provenance helpers (\`lionagi/state/provenance.py\`)
- \`agent_definition_hash(name)\` — searches \`~/.lionagi/agents/<name>/<name>.md\` then \`agents/<name>.md\` (matches \`load_agent_profile\` lookup order), returns 16-char SHA-256 prefix.
- \`resolve_model_spec(provider, model)\` — canonicalizes to \`"provider/model"\` for the column.

### Write points
- \`lionagi/cli/agent.py\` — \`_setup_live_persist\` gains \`model/provider/effort\` kwargs; \`_run_agent\` passes post-profile-resolution values. **Note**: when only \`-a <name>\` is passed (no \`--model\`), \`profile.model\` is loaded into \`model_str\` at agent.py:60, so resolved values correctly reflect the agent config.
- \`lionagi/cli/orchestrate/_orchestration.py\`
  - \`start_live_persist\` accepts \`model/provider/effort\` and writes them on the session row + computes \`agent_hash\`.
  - \`_register_branch_hook\` → \`create_branch\` reads each branch's runtime endpoint config (provider + model) so multi-model flows correctly disclose per-worker models. \`agent_name\` on the branch captures the role within the flow ("r1", "critic", ...). Best-effort with a debug log on failure so provenance reads can never abort the branch row write.
- \`lionagi/cli/orchestrate/flow.py\` + \`fanout.py\` — parse \`env.default_model_spec\` once and pass qualified provider/model + \`env.effort\` to \`start_live_persist\`.

### Studio
- \`services/sessions\` + \`services/runs\` — surface all 4 provenance fields per row.
- \`services/invocations\` — child sessions include \`model + effort\`.
- \`frontend/lib/types.ts\` — \`RunSummary\` gains the fields.
- \`frontend/app/runs/page.tsx\` — new **Model** column (6-col table). Renders \`claude/claude-sonnet-4-6 · high\`; \`—\` for legacy rows.
- \`frontend/app/invocations/[id]/page.tsx\` — **Model** column on child sessions table.

## Test plan

- [x] \`uv run pytest tests/state/test_provenance.py\` — 13 tests pass
- [x] \`uv run pytest tests/state/ tests/cli/ tests/operations/ tests/apps_studio_server/ tests/outcomes/\` — 916 tests pass
- [x] \`uv run ruff check\` clean
- [x] \`npx tsc --noEmit\` in \`apps/studio/frontend/\` clean
- [ ] Smoke test: run \`li agent -a reviewer "test"\`, query the new session row, verify \`model\` / \`agent_hash\` populated
- [ ] Smoke test: run \`li play --bare claude/sonnet ...\`, verify per-branch \`model\` differs from session-level for flows using multiple models
- [ ] Manual verification: /runs page Model column; /invocations/{id} child sessions show per-session model

🤖 Generated with [Claude Code](https://claude.com/claude-code)