### PR TITLE
docs(adrs): propose Studio frontend foundations (0028-0032)

### DIFF
--- a/docs/adrs/ADR-0028-status-reason-model.md
+++ b/docs/adrs/ADR-0028-status-reason-model.md
@@ -89,14 +89,30 @@ SQLite has no CHECK constraint on `reason_code`.
 
 ### 1. Schema additions
 
-Seven entity tables gain three columns each:
+Six entity tables gain three columns each:
 
 ```sql
--- sessions, shows, plays, invocations, schedule_runs, teams, chain_runs
+-- sessions, shows, plays, invocations, teams, schedule_runs
 ALTER TABLE <entity> ADD COLUMN status_reason_code TEXT;
 ALTER TABLE <entity> ADD COLUMN status_reason_summary TEXT;
 ALTER TABLE <entity> ADD COLUMN status_evidence_refs JSON;
 ```
+
+`schedule_runs` is the one entity table without a pre-existing
+`updated_at` column (see `lionagi/state/schema.sql:386-403`). The
+migration also adds it:
+
+```sql
+ALTER TABLE schedule_runs ADD COLUMN updated_at REAL;
+```
+
+`update_status()` (Section 4) always writes `updated_at`, so the
+column must exist on every target table.
+
+`chain_runs` is deferred. It is proposed in ADR-0021 but does not
+exist in the current `schema.sql`. When ADR-0021 lands, a follow-up
+ADR can extend the reason model to cover it (one ALTER per column,
+plus an entry in `VALID_ENTITY_TYPES`).
 
 One new table for transition history:
 
@@ -135,8 +151,26 @@ without schema migration.
 from __future__ import annotations
 from typing import Final
 
+# Canonical entity taxonomy. Singular nouns; consumed by ADR-0030
+# (queue), ADR-0031 (entity headers), and validated at write time
+# in update_status(). Frontend route names ("run") may alias an
+# entity_type ("session") — see "Route aliases" below.
+VALID_ENTITY_TYPES: Final = frozenset({
+    "session", "show", "play", "invocation", "team", "schedule_run",
+})
+
+# Route aliases — pure frontend convenience. The UI may render
+# /runs/<id> as a view over the `session` entity; the *entity_type*
+# stored in status_transitions and attention_dismissals is always
+# the canonical name above.
+ENTITY_ROUTE_ALIASES: Final = {
+    "run": "session",   # /runs/<id> is the frontend route for sessions
+}
+
 # Sentinel for rows that pre-date this ADR. Frontend renders as
-# "Reason tracking not yet enabled" with a muted treatment.
+# "Reason tracking not yet enabled" with a muted treatment. This is
+# the one allowed two-segment code; all other codes follow the
+# <domain>.<status_or_outcome>.<cause> three-segment format.
 LEGACY_IMPORTED: Final = "legacy.imported"
 
 # Format: <domain>.<status_or_outcome>.<cause>
@@ -180,17 +214,34 @@ class ScheduleReasons:
     SKIPPED_OVERLAP           = "schedule.skipped.overlap"
     SKIPPED_MISSED_FIRE       = "schedule.skipped.missed_fire"
 
-VALID_REASON_CODES: Final = frozenset({
-    LEGACY_IMPORTED,
-    *vars(RunReasons).values(),
-    *vars(SessionReasons).values(),
-    *vars(PlayReasons).values(),
-    *vars(ShowReasons).values(),
-    *vars(ScheduleReasons).values(),
-}) - {None}
+def _collect(*classes: type) -> frozenset[str]:
+    """Pull the str-valued public class attributes off each reason class.
 
-# Codes are filtered to strings (vars() includes dunder attrs)
+    Filters out dunders, descriptors, and any non-string values so the
+    frozenset is exactly the controlled vocabulary, not whatever Python
+    happens to put in __dict__.
+    """
+    out: set[str] = set()
+    for cls in classes:
+        for name, value in vars(cls).items():
+            if name.startswith("_"):
+                continue
+            if isinstance(value, str):
+                out.add(value)
+    return frozenset(out)
+
+VALID_REASON_CODES: Final = _collect(
+    RunReasons, SessionReasons, PlayReasons,
+    ShowReasons, ScheduleReasons,
+) | {LEGACY_IMPORTED}
 ```
+
+The `_collect()` helper enforces what `vars()` alone does not: only
+public string-valued attributes become part of the namespace. The
+ADR explicitly allows `legacy.imported` as the only two-segment
+sentinel; the validator (`_validate_reason_code()`, Section 4)
+accepts it as a member of `VALID_REASON_CODES` and the linter step
+that enforces the three-segment format skips this single code.
 
 The vocabulary is intentionally seeded small. Add codes when a real
 status transition needs one, not preemptively.
@@ -202,22 +253,23 @@ status transition needs one, not preemptively.
 
 ```json
 [
-  {"kind": "run",      "id": "e288a6e2493f"},
-  {"kind": "session",  "id": "0a1b2c3d", "label": "reviewer (round 2)"},
-  {"kind": "artifact", "id": "...", "label": "review.md"},
-  {"kind": "file",     "path": "artifacts/review.md"},
-  {"kind": "branch",   "id": "eebf8f19"},
-  {"kind": "play",     "id": "...", "label": "rust-cleanup"},
-  {"kind": "log",      "ref": "branch:eebf8f19:stderr"},
-  {"kind": "url",      "url": "https://github.com/.../pull/1070"}
+  {"kind": "session",          "id": "0a1b2c3d", "label": "reviewer (round 2)"},
+  {"kind": "artifact",         "id": "...", "label": "review.md"},
+  {"kind": "expected_artifact","id": "review", "label": "review.md"},
+  {"kind": "file",             "path": "artifacts/review.md"},
+  {"kind": "branch",           "id": "eebf8f19"},
+  {"kind": "play",             "id": "...", "label": "rust-cleanup"},
+  {"kind": "log",              "ref": "branch:eebf8f19:stderr"},
+  {"kind": "url",              "url": "https://github.com/.../pull/1070"}
 ]
 ```
 
 Renderer rules:
 
-- `kind: run|session|play|show|invocation|branch` — link to detail page
-- `kind: artifact` — link to artifact view (per ADR-0021)
-- `kind: file` — copy-to-clipboard, optionally open in editor
+- `kind: session|play|show|invocation|branch` — link to entity detail page (uses ENTITY_ROUTE_ALIASES for URL: `session` → `/runs/<id>`)
+- `kind: artifact` — link to artifact row in the existing `artifacts` table (per ADR-0021)
+- `kind: expected_artifact` — link into the Expected Artifacts section of the run detail page; `id` is the contract entry id from ADR-0029 (e.g. `review`)
+- `kind: file` — copy-to-clipboard; optionally open in editor
 - `kind: log` — open log tab on the relevant entity
 - `kind: url` — external link
 - Unknown `kind` — render as a labeled string, no link
@@ -338,10 +390,37 @@ def _resolve_reason(*, status, exception, exit_code):
 ```
 
 ADR-0029's contract verifier writes `run.failed.missing_artifact` with
-the unmet artifact IDs in `evidence_refs`. ADR-0024's doctor classifier
-writes `session.phantom.*` codes when it transitions a session. The
-admin transition API (per ADR-0025) requires a `reason_code` in the
-request body — no more bare status updates from the UI.
+the unmet artifact IDs in `evidence_refs`.
+
+Per ADR-0024, the health classifier (`doctor`) does **not**
+auto-transition sessions; it surfaces them as phantom in the admin UI.
+The operator initiates the transition via the admin API, whose body
+(per ADR-0025) is restricted to `target_status ∈ {failed, aborted,
+cancelled}`. This ADR extends that contract by replacing ADR-0024's
+free-text `reason` field with `reason_code` + `reason_summary`:
+
+```python
+class TransitionBody(BaseModel):
+    target_status: Literal["failed", "aborted", "cancelled"]
+    reason_code: str       # must be in VALID_REASON_CODES
+    reason_summary: str    # human-readable; defaults from a code-to-text map
+    evidence_refs: list[EvidenceRef] = []
+```
+
+When the operator transitions a phantom session, they choose:
+
+| Doctor classification | Operator target status | reason_code |
+|---|---|---|
+| `process_dead` | `failed` | `SessionReasons.HEALTH_PHANTOM_PROCESS_DEAD` |
+| `missing_artifacts` | `failed` | `SessionReasons.HEALTH_PHANTOM_MISSING_ARTIFACTS` |
+| `stale` (no heartbeat, process alive) | `cancelled` | `SessionReasons.HEALTH_STALE_NO_HEARTBEAT` |
+| `orphaned` | `cancelled` | `SessionReasons.HEALTH_ORPHANED_NO_PROCESS` |
+
+`phantom` is **not** a session status — it remains a derived health
+classification per ADR-0024. The reason code records *why the
+operator chose to transition*. The denormalized
+`status_reason_code` on the now-failed session preserves that
+attribution for the runs list.
 
 ### 6. Read path — entity API responses
 
@@ -452,7 +531,7 @@ apps/studio/server/services/admin.py      # health classifier writes reason on t
 apps/studio/server/services/shows.py      # play/show transitions write reason
 apps/studio/server/services/schedules.py  # schedule fire/skip writes reason
 apps/studio/server/routers/admin.py       # admin transition API requires reason_code
-apps/studio/frontend/components/status/StatusPill.tsx  # reason tooltip/popover
+apps/studio/frontend/components/StatusPill.tsx         # add `reason` prop + tooltip/popover
 apps/studio/frontend/lib/api.ts           # status_reason type + fetch
 ```
 

--- a/docs/adrs/ADR-0028-status-reason-model.md
+++ b/docs/adrs/ADR-0028-status-reason-model.md
@@ -1,0 +1,537 @@
+# ADR-0028: Status Reason Model
+
+**Status**: Proposed
+**Date**: 2026-05-23
+**Extends**: ADR-0024 (session health), ADR-0025 (session status vocabulary), ADR-0017 (session lifecycle)
+
+## Context
+
+Studio's entity statuses (`running`, `pending`, `failed`, `phantom`,
+`blocked`, ...) are accurate but unexplained. Every status answers *what*
+state the entity is in; none answer *why*.
+
+### 1. "Pending why?" is a real bug
+
+The plays table contains rows with `status='pending'` and a `depends_on`
+JSON array. The frontend renders these as yellow "Pending" pills. An
+operator looking at a show with 12 pending plays cannot tell:
+
+- Which plays are blocked by unmet dependencies (waiting normally)?
+- Which plays are blocked by *invalid* dependencies (typo in `depends_on`,
+  dependency removed from the plan, etc.)?
+
+- Which plays simply have not been launched yet (ready but unstarted)?
+
+`status='pending'` covers all three. The distinction lives nowhere — the
+frontend would have to reconstruct it from `plays.depends_on` ∩
+`plays.status` per row. That is a join-and-compute every render.
+
+### 2. Phantom session reasons are inline-and-cosmetic
+
+ADR-0024 introduced phantom classification with three reasons:
+`process_dead`, `missing_artifacts`, `stale_lock`. They live as enum
+strings the admin endpoint returns, not as durable state. Today the UI
+displays them as table rows but cannot answer "show me all sessions that
+went phantom because the process died in the last 24h" without a custom
+endpoint, because the classification is computed on every read.
+
+### 3. Failed runs lose their reason
+
+Per ADR-0025, sessions terminate with `failed`, `timed_out`, `aborted`,
+or `cancelled`. The vocabulary is good. But the *cause* of a `failed`
+session — exit code, exception class, "missing artifact contract"
+(ADR-0029), gate verdict — is scattered across `node_metadata`, branch
+errors, or just lost. The runs list shows a red pill; the user has to
+open the run, scroll the timeline, and infer.
+
+### 4. The Attention Queue (ADR-0030) cannot exist without this
+
+The Attention Queue must answer "why is this in attention" for every
+row. If the queue invents reasons inline (`"Stuck >60m"`, `"Missing
+artifact"`, `"Phantom: process dead"`), it duplicates the classification
+logic that ADR-0024 and ADR-0029 already encode and creates a third
+parallel namespace. Without a canonical reason model, the queue becomes
+a pile of frontend heuristics.
+
+### 5. Failed-by-cause grouping cannot exist without this
+
+The dashboard currently shows "6 reviewer failures in 24h" as a count.
+The natural follow-up — "are they failing for the same reason?" —
+requires a structured, queryable reason. Free-text status notes give
+display value but no grouping primitive.
+
+The triggering observation: every UI fix we discussed (Pending-why,
+phantom diagnostics, failure clustering, Attention Queue, decision logs)
+is a different rendering of the same missing primitive. Build the
+primitive once at the data layer; every UI feature becomes a query.
+
+## Decision
+
+Introduce a two-layer status reason model:
+
+1. **Hot path (denormalized current reason)** — three new columns
+   (`status_reason_code`, `status_reason_summary`, `status_evidence_refs`)
+   on every entity table that already has a `status` column. Read at the
+   speed of the existing status query; no JOIN.
+
+2. **Cold path (transition history)** — a new `status_transitions` table
+   appending one row per status change with full reason payload, source,
+   actor, and previous status. Read only when audit history is requested.
+
+The executor canonicalizes reasons. Agents may emit hints
+(`hint_reason_code`, `hint_summary`); the executor decides what to
+persist. Both writes happen in a single SQLite transaction.
+
+Reason codes are a controlled Python vocabulary in
+`lionagi/state/reasons.py`, following the same pattern as
+`VALID_SESSION_STATUSES` from ADR-0025: Python is the source of truth,
+SQLite has no CHECK constraint on `reason_code`.
+
+### 1. Schema additions
+
+Seven entity tables gain three columns each:
+
+```sql
+-- sessions, shows, plays, invocations, schedule_runs, teams, chain_runs
+ALTER TABLE <entity> ADD COLUMN status_reason_code TEXT;
+ALTER TABLE <entity> ADD COLUMN status_reason_summary TEXT;
+ALTER TABLE <entity> ADD COLUMN status_evidence_refs JSON;
+```
+
+One new table for transition history:
+
+```sql
+CREATE TABLE IF NOT EXISTS status_transitions (
+  id              TEXT    PRIMARY KEY,
+  entity_type     TEXT    NOT NULL,     -- 'session' | 'show' | 'play' | ...
+  entity_id       TEXT    NOT NULL,
+  previous_status TEXT,                 -- NULL for the first transition
+  status          TEXT    NOT NULL,
+  reason_code     TEXT    NOT NULL,
+  reason_summary  TEXT,
+  evidence_refs   JSON,                 -- list[{kind, id|path|ref, label?}]
+  source          TEXT    NOT NULL,     -- 'executor' | 'agent' | 'admin' | 'system'
+  actor           TEXT,                 -- session_id, user, 'doctor_auto', ...
+  created_at      REAL    NOT NULL,
+  metadata        JSON                  -- optional: timing, exit code, exc class
+);
+
+CREATE INDEX IF NOT EXISTS idx_status_transitions_entity
+  ON status_transitions(entity_type, entity_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_status_transitions_reason
+  ON status_transitions(reason_code, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_status_transitions_created
+  ON status_transitions(created_at DESC);
+```
+
+`entity_type` is validated in Python, not SQL — matches ADR-0025's
+"Python is the source of truth" pattern. New entity types can be added
+without schema migration.
+
+### 2. Reason code namespace
+
+```python
+# lionagi/state/reasons.py
+from __future__ import annotations
+from typing import Final
+
+# Sentinel for rows that pre-date this ADR. Frontend renders as
+# "Reason tracking not yet enabled" with a muted treatment.
+LEGACY_IMPORTED: Final = "legacy.imported"
+
+# Format: <domain>.<status_or_outcome>.<cause>
+# Three segments. Lowercase. snake_case for multi-word causes.
+# Compound conditions go in reason_summary, not in the code.
+
+class RunReasons:
+    COMPLETED_OK              = "run.completed.ok"
+    FAILED_EXIT_NONZERO       = "run.failed.exit_nonzero"
+    FAILED_EXCEPTION          = "run.failed.exception"
+    FAILED_MISSING_ARTIFACT   = "run.failed.missing_artifact"   # ADR-0029
+    TIMED_OUT_DEADLINE        = "run.timed_out.deadline"
+    ABORTED_USER              = "run.aborted.user"
+    CANCELLED_SYSTEM          = "run.cancelled.system"
+    CANCELLED_ORCHESTRATOR    = "run.cancelled.orchestrator"
+
+class SessionReasons:
+    # Health-derived (ADR-0024 SessionHealth states get a reason code each)
+    HEALTH_STALE_NO_HEARTBEAT     = "session.stale.no_heartbeat"
+    HEALTH_ORPHANED_NO_PROCESS    = "session.orphaned.no_process"
+    HEALTH_ZOMBIE_STALE_LOCKS     = "session.zombie.stale_locks"
+    HEALTH_PHANTOM_PROCESS_DEAD   = "session.phantom.process_dead"
+    HEALTH_PHANTOM_MISSING_ARTIFACTS = "session.phantom.missing_artifacts"
+
+class PlayReasons:
+    PENDING_WAITING_DEPS      = "play.pending.waiting_on_deps"
+    PENDING_READY             = "play.pending.ready"
+    BLOCKED_INVALID_DEPS      = "play.blocked.invalid_deps"
+    BLOCKED_DEP_FAILED        = "play.blocked.dep_failed"
+    GATE_FAILED_VERDICT       = "play.gate_failed.verdict"
+    ESCALATED_GATE_TWICE      = "play.escalated.gate_twice"
+    MERGED_OK                 = "play.merged.ok"
+
+class ShowReasons:
+    BLOCKED_NO_READY_PLAYS    = "show.blocked.no_ready_plays"
+    COMPLETED_FINAL_GATE      = "show.completed.final_gate"
+    ABORTED_OPERATOR          = "show.aborted.operator"
+
+class ScheduleReasons:
+    FIRED_DUE                 = "schedule.fired.due"
+    SKIPPED_OVERLAP           = "schedule.skipped.overlap"
+    SKIPPED_MISSED_FIRE       = "schedule.skipped.missed_fire"
+
+VALID_REASON_CODES: Final = frozenset({
+    LEGACY_IMPORTED,
+    *vars(RunReasons).values(),
+    *vars(SessionReasons).values(),
+    *vars(PlayReasons).values(),
+    *vars(ShowReasons).values(),
+    *vars(ScheduleReasons).values(),
+}) - {None}
+
+# Codes are filtered to strings (vars() includes dunder attrs)
+```
+
+The vocabulary is intentionally seeded small. Add codes when a real
+status transition needs one, not preemptively.
+
+### 3. Evidence reference shape
+
+`evidence_refs` is a list of typed references. The renderer dispatches on
+`kind`:
+
+```json
+[
+  {"kind": "run",      "id": "e288a6e2493f"},
+  {"kind": "session",  "id": "0a1b2c3d", "label": "reviewer (round 2)"},
+  {"kind": "artifact", "id": "...", "label": "review.md"},
+  {"kind": "file",     "path": "artifacts/review.md"},
+  {"kind": "branch",   "id": "eebf8f19"},
+  {"kind": "play",     "id": "...", "label": "rust-cleanup"},
+  {"kind": "log",      "ref": "branch:eebf8f19:stderr"},
+  {"kind": "url",      "url": "https://github.com/.../pull/1070"}
+]
+```
+
+Renderer rules:
+
+- `kind: run|session|play|show|invocation|branch` — link to detail page
+- `kind: artifact` — link to artifact view (per ADR-0021)
+- `kind: file` — copy-to-clipboard, optionally open in editor
+- `kind: log` — open log tab on the relevant entity
+- `kind: url` — external link
+- Unknown `kind` — render as a labeled string, no link
+
+### 4. Write path — atomic update
+
+A single `update_status()` method on `StateDB` is the only sanctioned
+mutation point. Direct UPDATE of `status` (without writing a reason) is
+considered a bug:
+
+```python
+# lionagi/state/db.py
+async def update_status(
+    self,
+    entity_type: str,
+    entity_id: str,
+    *,
+    new_status: str,
+    reason_code: str,
+    reason_summary: str = "",
+    evidence_refs: list[dict] | None = None,
+    source: str = "executor",
+    actor: str | None = None,
+    metadata: dict | None = None,
+) -> None:
+    """Atomically transition an entity's status and record the reason.
+
+    Raises:
+        ValueError: reason_code not in VALID_REASON_CODES.
+        ValueError: entity_type not in VALID_ENTITY_TYPES.
+        StateError: entity not found.
+    """
+    _validate_reason_code(reason_code)
+    _validate_entity_type(entity_type)
+    table = _entity_table(entity_type)
+    evidence_json = json.dumps(evidence_refs or [])
+
+    async with self.transaction():
+        prev = await self.fetchone(
+            f"SELECT status FROM {table} WHERE id = ?", (entity_id,)
+        )
+        if prev is None:
+            raise StateError(f"{entity_type} {entity_id!r} not found")
+        previous_status = prev["status"]
+        now = time.time()
+
+        await self.execute(
+            f"UPDATE {table} SET "
+            f"  status = ?, "
+            f"  status_reason_code = ?, "
+            f"  status_reason_summary = ?, "
+            f"  status_evidence_refs = ?, "
+            f"  updated_at = ? "
+            f"WHERE id = ?",
+            (new_status, reason_code, reason_summary,
+             evidence_json, now, entity_id),
+        )
+
+        await self.execute(
+            "INSERT INTO status_transitions "
+            "(id, entity_type, entity_id, previous_status, status, "
+            " reason_code, reason_summary, evidence_refs, "
+            " source, actor, created_at, metadata) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (uuid4().hex, entity_type, entity_id, previous_status, new_status,
+             reason_code, reason_summary, evidence_json,
+             source, actor, now,
+             json.dumps(metadata) if metadata else None),
+        )
+```
+
+Both writes are in the same SQLite transaction. Either both commit or
+neither does. The denormalized columns and the history row never drift.
+
+### 5. CLI write points (refactored from ADR-0025)
+
+```python
+# lionagi/cli/agent.py teardown — replace bare status update
+async def _teardown_live_persist(live, status, *, exception=None, exit_code=None):
+    reason_code, reason_summary, evidence = _resolve_reason(
+        status=status, exception=exception, exit_code=exit_code,
+    )
+    async with StateDB.open() as db:
+        await db.update_status(
+            entity_type="session",
+            entity_id=live.session_id,
+            new_status=status,
+            reason_code=reason_code,
+            reason_summary=reason_summary,
+            evidence_refs=evidence,
+            source="executor",
+            metadata={"exit_code": exit_code} if exit_code is not None else None,
+        )
+
+def _resolve_reason(*, status, exception, exit_code):
+    if status == "completed":
+        return RunReasons.COMPLETED_OK, "Run completed successfully.", []
+    if status == "timed_out":
+        return (RunReasons.TIMED_OUT_DEADLINE,
+                "Run exceeded the configured timeout.",
+                [])
+    if status == "aborted":
+        return RunReasons.ABORTED_USER, "User pressed Ctrl-C.", []
+    if status == "cancelled":
+        return (RunReasons.CANCELLED_SYSTEM,
+                "Task cancelled by the runtime (anyio CancelledError).",
+                [])
+    # status == "failed"
+    if exit_code not in (None, 0):
+        return (RunReasons.FAILED_EXIT_NONZERO,
+                f"Process exited with code {exit_code}.",
+                [])
+    if exception is not None:
+        return (RunReasons.FAILED_EXCEPTION,
+                f"{type(exception).__name__}: {exception}",
+                [])
+    return RunReasons.FAILED_EXCEPTION, "Run failed.", []
+```
+
+ADR-0029's contract verifier writes `run.failed.missing_artifact` with
+the unmet artifact IDs in `evidence_refs`. ADR-0024's doctor classifier
+writes `session.phantom.*` codes when it transitions a session. The
+admin transition API (per ADR-0025) requires a `reason_code` in the
+request body — no more bare status updates from the UI.
+
+### 6. Read path — entity API responses
+
+Every detail endpoint that returns a status returns the reason inline:
+
+```json
+{
+  "id": "play_a1b2c3d4",
+  "name": "test-coverage",
+  "status": "pending",
+  "status_reason": {
+    "code": "play.pending.waiting_on_deps",
+    "summary": "Waiting on rust-cleanup, runtime-usability, graph-fixes.",
+    "evidence_refs": [
+      {"kind": "play", "id": "...", "label": "rust-cleanup"},
+      {"kind": "play", "id": "...", "label": "runtime-usability"},
+      {"kind": "play", "id": "...", "label": "graph-fixes"}
+    ]
+  },
+  ...
+}
+```
+
+If the columns are NULL (legacy row), the response is:
+
+```json
+"status_reason": {
+  "code": "legacy.imported",
+  "summary": "Reason tracking not yet enabled for this row.",
+  "evidence_refs": []
+}
+```
+
+The transition history endpoint pages the cold path:
+
+```text
+GET /api/{entity_type}/{id}/status-history?limit=20&before=<created_at>
+```
+
+### 7. Frontend rendering
+
+The `StatusPill` component (ADR-0025) gains a paired `StatusReason`
+treatment for tooltip and popover:
+
+```tsx
+<StatusPill
+  taxonomy="play"
+  value="pending"
+  reason={{
+    code: "play.pending.waiting_on_deps",
+    summary: "Waiting on rust-cleanup, runtime-usability, graph-fixes.",
+    evidence_refs: [...],
+  }}
+/>
+```
+
+- **Hover** (>500ms): tooltip shows `summary`.
+- **Click**: popover shows `summary` + evidence_refs as clickable chips.
+- **No reason** (legacy.imported or null): pill renders unchanged; no
+  tooltip; no popover affordance. Consistent with how today's pills look.
+
+The `code` is a stable machine identifier — it never appears in the UI
+text. The UI shows `summary` (human-readable) and evidence chips. This
+means changing the *wording* of a reason summary in
+`SessionReasons.HEALTH_STALE_NO_HEARTBEAT` does not require a code
+rename — the code is the contract, the summary is the message.
+
+### 8. Migration
+
+SQLite supports `ALTER TABLE ... ADD COLUMN`. Migration via
+`StateDB._reconcile_columns()` (existing pattern from ADR-0025/0026):
+add three columns to each of the seven entity tables on next
+`StateDB.open()`. New `status_transitions` table created via `IF NOT
+EXISTS`.
+
+Existing rows have NULL reason columns. They render as
+`legacy.imported` per the read-path contract above. No backfill — the
+audit history for pre-ADR rows is genuinely lost; manufacturing reasons
+would be worse than honest silence.
+
+### 9. Relationship to existing ADRs
+
+| ADR | Relationship |
+|---|---|
+| ADR-0017 | Original session lifecycle; this ADR adds the reason layer. |
+| ADR-0024 | Phantom session classifier writes reason codes when transitioning a session via admin. The `SessionHealth` enum (computed) and `SessionReasons.HEALTH_*` (persisted on transition) are intentionally parallel: health is a read-time view, reasons are write-time records. |
+| ADR-0025 | Session status vocabulary stays as-is. `update_status()` enforces both the status validator and the reason validator. |
+| ADR-0029 | Artifact contract violations write `run.failed.missing_artifact` with evidence refs pointing to the unmet artifact IDs. |
+| ADR-0030 | Attention Queue groups by `reason_code` for clustering; pulls `summary` and `evidence_refs` directly from entity responses. |
+| ADR-0024 `admin_events` | Parallel append-only log. `admin_events` records the *action* (admin pruned X, admin classified Y); `status_transitions` records the *consequence* (X transitioned from running to phantom). Both rows get written when an admin action causes a transition. |
+
+### 10. File map
+
+New files:
+
+```text
+lionagi/state/reasons.py                  # Reason code namespace + validators
+```
+
+Modified files:
+
+```text
+lionagi/state/schema.sql                  # ALTER for 7 tables + status_transitions table
+lionagi/state/db.py                       # update_status() + reconcile_columns
+lionagi/cli/agent.py                      # teardown writes reason
+lionagi/cli/orchestrate/flow.py           # flow termination writes reason
+apps/studio/server/services/admin.py      # health classifier writes reason on transition
+apps/studio/server/services/shows.py      # play/show transitions write reason
+apps/studio/server/services/schedules.py  # schedule fire/skip writes reason
+apps/studio/server/routers/admin.py       # admin transition API requires reason_code
+apps/studio/frontend/components/status/StatusPill.tsx  # reason tooltip/popover
+apps/studio/frontend/lib/api.ts           # status_reason type + fetch
+```
+
+## Consequences
+
+**Positive**
+
+- One canonical primitive ("why is this state true") replaces five
+  scattered explanations (phantom enums, branch errors, node_metadata
+  exit codes, frontend heuristics, inline log scraping).
+
+- Attention Queue (ADR-0030), Pending-why, phantom diagnostics, failure
+  clustering, and decision-log surfacing all become queries over a
+  single shape instead of bespoke endpoints.
+
+- Reason codes are queryable — "show me all failures with
+  `run.failed.missing_artifact` in 24h" is one SQL query.
+
+- Transactional consistency guarantees the denormalized "current
+  reason" and the transition history never drift.
+
+- Evidence references give the UI structured navigation: the reason
+  always knows what to link to.
+
+- Python-validated namespace means adding a reason code is a code
+  change, not a schema migration.
+
+- Backfill is deliberately not attempted — historical silence is more
+  honest than fabricated reasons.
+
+**Negative**
+
+- Seven `ALTER TABLE` statements. Pre-release, so acceptable; still
+  three more columns × seven tables of schema width.
+
+- Every status mutation site in the codebase has to be updated to call
+  `update_status()` with a reason. The current pattern is to write
+  `status` directly. The transition is mechanical but touches many
+  files (see File Map).
+
+- Agents cannot write authoritative reasons. They can emit hints
+  (`hint_reason_code`), but the executor canonicalizes. This is
+  intentional but reduces agent autonomy by a degree.
+
+- `status_transitions` accumulates rows forever. At ~10 transitions per
+  session and ~1000 sessions/month, that is ~120k rows/year. Add a
+  retention policy in a follow-up ADR (or trim older than N days
+  during `vacuum`).
+
+- The reason code vocabulary is small at first. Codes that should
+  exist but don't will be filed as `run.failed.exception` with a free-
+  text summary; the curation gap shows up over time.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|---|---|
+| `status_note TEXT` column only (denormalized, no history, no code) | Gives the tooltip but loses grouping, filtering, dismissal stability, evidence linking, and audit history. ChatGPT proposed this as the "80% solution"; it is actually the 20% solution. The reason *code* is the load-bearing primitive. |
+| Single shared `status_reason_json` JSON column per entity table | Same schema sprawl (one column × seven tables) without indexable code. Filtering by reason becomes a JSON extract on every query. |
+| Status reasons only in a separate `status_transitions` table (no denormalization) | Every status pill render becomes a JOIN. Dashboard would N+1 across hundreds of entities per page. The 3-column denormalization on entities is the read-path optimization. |
+| Reuse `admin_events` for status transitions | `admin_events` is for admin actions (transition, prune, checkpoint, vacuum, classify). Most status transitions are runtime, not admin. Conflating them would mean every session completion writes to a table named "admin_events", which is semantically wrong. Both tables coexist. |
+| Agents write reasons directly | Agents can hallucinate reasons. The executor has authoritative process/exit-code/contract state. Agents emit hints; the executor canonicalizes. |
+| Full event stream (CloudEvents / event sourcing) | Premature. Studio needs a transition log, not a generalized event bus. Re-evaluate when chains (ADR-0021) and traces become first-class. |
+| Free-form `reason_code` string with no validator | Typos compound. Within six months the namespace becomes `run_failed`, `run.failed`, `run-failed`, `RunFailed` all in production. The Python validator costs ~2 lines and prevents this. |
+| Backfill historical rows with inferred reasons | Inferring reasons from `updated_at`, `node_metadata`, and branch errors produces guesses that look authoritative. `legacy.imported` is more honest. |
+
+## References
+
+- [ADR-0017](ADR-0017-session-lifecycle-status.md) — Session lifecycle status (foundation)
+- [ADR-0024](ADR-0024-session-health-and-admin-surface.md) — Session health classification (parallel: health is read-time, reasons are write-time)
+- [ADR-0025](ADR-0025-session-status-vocabulary.md) — Session status vocabulary (Python validation pattern)
+- [ADR-0029](ADR-0029-artifact-contract.md) — Artifact contract (writes `run.failed.missing_artifact`)
+- [ADR-0030](ADR-0030-attention-queue.md) — Attention Queue (consumer)
+- `lionagi/state/schema.sql` — `admin_events` table (parallel append-only log)
+- `lionagi/state/db.py` — `_reconcile_columns()` migration pattern
+- ChatGPT frontend design review (external) — proposed `status_history` table as part of ADR-A; this ADR adopts the table but adds the denormalized hot-path columns and Python-validated reason code namespace that the proposal missed.
+
+### Prior art
+
+- **PostgreSQL `pg_stat_*` views** — denormalized current state + cumulative counters, no JOIN required on read path. Same pattern.
+- **Kubernetes object conditions** — every K8s object has `.status.conditions[]` with `type`, `status`, `reason`, `message`, `lastTransitionTime`. The reason field is a stable machine-readable code; the message is human-readable. Direct inspiration.
+- **AWS CloudWatch alarms** — `StateReason` (free text) and `StateReasonData` (structured JSON). Their bifurcation into prose and structure mirrors our `reason_summary` and `evidence_refs`.

--- a/docs/adrs/ADR-0028-status-reason-model.md
+++ b/docs/adrs/ADR-0028-status-reason-model.md
@@ -573,9 +573,10 @@ apps/studio/frontend/lib/api.ts           # status_reason type + fetch
 
 **Negative**
 
-- Seven `ALTER TABLE` statements. Pre-release, so acceptable; still
-  three more columns × six status-bearing tables of schema width,
-  plus the `updated_at` ALTER on `schedule_runs`.
+- Nineteen `ALTER TABLE` statements (18 reason columns across six
+  status-bearing tables + 1 `updated_at` on `schedule_runs`).
+  Pre-release, so acceptable; still three more columns × six tables
+  of schema width plus the new history table.
 
 - Every status mutation site in the codebase has to be updated to call
   `update_status()` with a reason. The current pattern is to write

--- a/docs/adrs/ADR-0028-status-reason-model.md
+++ b/docs/adrs/ADR-0028-status-reason-model.md
@@ -411,10 +411,15 @@ When the operator transitions a phantom session, they choose:
 
 | Doctor classification | Operator target status | reason_code |
 |---|---|---|
-| `process_dead` | `failed` | `SessionReasons.HEALTH_PHANTOM_PROCESS_DEAD` |
-| `missing_artifacts` | `failed` | `SessionReasons.HEALTH_PHANTOM_MISSING_ARTIFACTS` |
+| `process_dead` (per `apps/studio/server/services/admin.py:93`) | `failed` | `SessionReasons.HEALTH_PHANTOM_PROCESS_DEAD` |
+| `missing_artifacts` (per `admin.py:93`) | `failed` | `SessionReasons.HEALTH_PHANTOM_MISSING_ARTIFACTS` |
+| `stale_lock` (per `admin.py:16`, `admin.py:93`) | `failed` | `SessionReasons.HEALTH_ZOMBIE_STALE_LOCKS` |
 | `stale` (no heartbeat, process alive) | `cancelled` | `SessionReasons.HEALTH_STALE_NO_HEARTBEAT` |
 | `orphaned` | `cancelled` | `SessionReasons.HEALTH_ORPHANED_NO_PROCESS` |
+
+The first three rows cover the live doctor `PhantomReason` enum
+exhaustively. The last two cover health states ADR-0024 surfaces
+through other classifier outputs.
 
 `phantom` is **not** a session status — it remains a derived health
 classification per ADR-0024. The reason code records *why the
@@ -492,7 +497,9 @@ rename — the code is the contract, the summary is the message.
 
 SQLite supports `ALTER TABLE ... ADD COLUMN`. Migration via
 `StateDB._reconcile_columns()` (existing pattern from ADR-0025/0026):
-add three columns to each of the seven entity tables on next
+add three columns to each of the six status-bearing entity tables
+plus `updated_at` to `schedule_runs` (19 ALTERs total — 18 reason
+columns + 1 timestamp) on next
 `StateDB.open()`. New `status_transitions` table created via `IF NOT
 EXISTS`.
 
@@ -510,7 +517,7 @@ would be worse than honest silence.
 | ADR-0025 | Session status vocabulary stays as-is. `update_status()` enforces both the status validator and the reason validator. |
 | ADR-0029 | Artifact contract violations write `run.failed.missing_artifact` with evidence refs pointing to the unmet artifact IDs. |
 | ADR-0030 | Attention Queue groups by `reason_code` for clustering; pulls `summary` and `evidence_refs` directly from entity responses. |
-| ADR-0024 `admin_events` | Parallel append-only log. `admin_events` records the *action* (admin pruned X, admin classified Y); `status_transitions` records the *consequence* (X transitioned from running to phantom). Both rows get written when an admin action causes a transition. |
+| ADR-0024 `admin_events` | Parallel append-only log. `admin_events` records the *action* (admin pruned X, admin classified Y); `status_transitions` records the *consequence* (X transitioned from running to failed with `reason_code=session.phantom.process_dead`). Both rows get written when an admin action causes a transition. `phantom` is never a *target_status* — it's the health input that motivates the operator's choice of `failed` or `cancelled`. |
 
 ### 10. File map
 
@@ -523,7 +530,9 @@ lionagi/state/reasons.py                  # Reason code namespace + validators
 Modified files:
 
 ```text
-lionagi/state/schema.sql                  # ALTER for 7 tables + status_transitions table
+lionagi/state/schema.sql                  # ALTER for 6 status-bearing tables (3 reason
+                                          # columns each) + ALTER schedule_runs ADD
+                                          # updated_at + new status_transitions table
 lionagi/state/db.py                       # update_status() + reconcile_columns
 lionagi/cli/agent.py                      # teardown writes reason
 lionagi/cli/orchestrate/flow.py           # flow termination writes reason
@@ -565,7 +574,8 @@ apps/studio/frontend/lib/api.ts           # status_reason type + fetch
 **Negative**
 
 - Seven `ALTER TABLE` statements. Pre-release, so acceptable; still
-  three more columns × seven tables of schema width.
+  three more columns × six status-bearing tables of schema width,
+  plus the `updated_at` ALTER on `schedule_runs`.
 
 - Every status mutation site in the codebase has to be updated to call
   `update_status()` with a reason. The current pattern is to write
@@ -590,7 +600,7 @@ apps/studio/frontend/lib/api.ts           # status_reason type + fetch
 | Alternative | Why Rejected |
 |---|---|
 | `status_note TEXT` column only (denormalized, no history, no code) | Gives the tooltip but loses grouping, filtering, dismissal stability, evidence linking, and audit history. ChatGPT proposed this as the "80% solution"; it is actually the 20% solution. The reason *code* is the load-bearing primitive. |
-| Single shared `status_reason_json` JSON column per entity table | Same schema sprawl (one column × seven tables) without indexable code. Filtering by reason becomes a JSON extract on every query. |
+| Single shared `status_reason_json` JSON column per entity table | Same schema sprawl (one column × six tables) without indexable code. Filtering by reason becomes a JSON extract on every query. |
 | Status reasons only in a separate `status_transitions` table (no denormalization) | Every status pill render becomes a JOIN. Dashboard would N+1 across hundreds of entities per page. The 3-column denormalization on entities is the read-path optimization. |
 | Reuse `admin_events` for status transitions | `admin_events` is for admin actions (transition, prune, checkpoint, vacuum, classify). Most status transitions are runtime, not admin. Conflating them would mean every session completion writes to a table named "admin_events", which is semantically wrong. Both tables coexist. |
 | Agents write reasons directly | Agents can hallucinate reasons. The executor has authoritative process/exit-code/contract state. Agents emit hints; the executor canonicalizes. |

--- a/docs/adrs/ADR-0029-artifact-contract.md
+++ b/docs/adrs/ADR-0029-artifact-contract.md
@@ -247,7 +247,7 @@ def verify_artifact_contract(
 
     missing_required, missing_optional, produced = [], [], []
     for entry in contract["expected"]:
-        full = os.path.join(artifacts_root, entry["path"])
+        full = _safe_join(artifacts_root, entry["path"])  # see below
         present = os.path.isfile(full) and os.path.getsize(full) > 0
         if present:
             produced.append({
@@ -279,7 +279,61 @@ def verify_artifact_contract(
 "Produced" requires the file to exist *and* be non-empty. A zero-byte
 `review.md` is not a delivery.
 
-Path resolution is `os.path.join(sessions.artifacts_path, entry.path)`.
+Path resolution uses a `_safe_join()` that enforces the rules declared
+in Section 2 ("No leading `/`, no `..`, no globs"). The verifier MUST
+NOT use bare `os.path.join`, which is permissive about absolute paths
+and `..` escapes:
+
+```python
+import os
+from pathlib import PurePosixPath
+
+_GLOB_CHARS = frozenset("*?[]")
+
+class ArtifactPathError(ValueError):
+    pass
+
+def _safe_join(root: str, rel: str) -> str:
+    """Join ``rel`` under ``root``, rejecting paths that escape the root.
+
+    Rejects absolute paths, `..` segments, glob metacharacters, and
+    any final path that does not have ``root`` as its prefix after
+    realpath resolution. ``root`` itself is expected to already be
+    realpath-resolved and absolute.
+    """
+    if not rel or rel.startswith("/"):
+        raise ArtifactPathError(f"absolute path not allowed: {rel!r}")
+    if any(c in _GLOB_CHARS for c in rel):
+        raise ArtifactPathError(f"glob characters not allowed in v1: {rel!r}")
+    parts = PurePosixPath(rel).parts
+    if any(p in ("..", "") for p in parts):
+        raise ArtifactPathError(f"`..` segments not allowed: {rel!r}")
+    joined = os.path.realpath(os.path.join(root, *parts))
+    if joined != root and not joined.startswith(root + os.sep):
+        raise ArtifactPathError(f"path escapes artifacts_root: {rel!r}")
+    return joined
+```
+
+The same validation runs at session start as `validate_artifact_contract(contract)`,
+so a bad path fails fast rather than at teardown:
+
+```python
+def validate_artifact_contract(contract: dict | None) -> None:
+    if contract is None:
+        return
+    seen_ids: set[str] = set()
+    for entry in contract["expected"]:
+        eid = entry["id"]
+        if not eid.replace("-", "").replace("_", "").isalnum():
+            raise ArtifactPathError(f"id must be alphanumeric/_/-: {eid!r}")
+        if eid in seen_ids:
+            raise ArtifactPathError(f"duplicate id in contract: {eid!r}")
+        seen_ids.add(eid)
+        # Pre-flight path check: realpath against a dummy root catches
+        # the rule violations without needing the live artifacts_path.
+        _safe_join("/tmp/__contract_validate__", entry["path"])
+```
+
 `artifacts_path` is the existing column on `sessions` (ADR-0012). No
 new path concept introduced.
 
@@ -303,7 +357,7 @@ if verification and verification["status"] == "failed":
         final_reason_code = RunReasons.FAILED_MISSING_ARTIFACT
         final_reason_summary = _format_missing(verification["missing_required"])
         final_evidence = [
-            {"kind": "artifact_id", "id": e["id"], "label": e["path"]}
+            {"kind": "expected_artifact", "id": e["id"], "label": e["path"]}
             for e in verification["missing_required"]
         ]
     else:
@@ -429,7 +483,10 @@ lionagi/state/db.py                       # create_session(artifact_contract=...
 lionagi/cli/orchestrate/__init__.py       # parse playbook artifacts block
 lionagi/cli/orchestrate/_orchestration.py # snapshot contract at session start
 lionagi/cli/agent.py                      # teardown runs verifier before status update
-lionagi/cli/_project.py                   # resolve agent profile frontmatter
+lionagi/cli/_agents.py                    # AgentProfile parser exposes
+                                          # `artifact_defaults` from frontmatter
+                                          # (see lionagi/cli/_agents.py:160 for
+                                          # current frontmatter dispatch)
 apps/studio/server/services/sessions.py   # include contract+verification in API
 apps/studio/server/routers/runs.py        # detail endpoint exposes both
 apps/studio/frontend/components/runs/ExpectedArtifacts.tsx  # new UI section

--- a/docs/adrs/ADR-0029-artifact-contract.md
+++ b/docs/adrs/ADR-0029-artifact-contract.md
@@ -1,0 +1,548 @@
+# ADR-0029: Artifact Contract
+
+**Status**: Proposed
+**Date**: 2026-05-23
+**Extends**: ADR-0021 (skill artifacts, structured outcomes), ADR-0012 (run-step provenance)
+**Related**: ADR-0028 (status reasons — writes `run.failed.missing_artifact`)
+
+## Context
+
+A session that exits cleanly is not the same as a session that delivered
+what it was asked to deliver. The runs list currently treats "process
+exited with code 0" as success, but several recurring failure classes
+look like success at the OS level:
+
+### 1. The reviewer-with-no-output pattern
+
+The recent /codex-pr-review failures had this signature: codex started,
+read a few files, returned a short text response, and exited cleanly —
+but never wrote `codex_review_pr<N>.md`. The session shows
+`status='completed'`, `exit_code=0`. There is no failure to investigate,
+because by Studio's current model, nothing failed. The Attention Queue
+draft (ADR-0030) calls this "Run failed: No file operations detected"
+and surfaces it as a critical row. That phrasing reverse-engineers a
+*contract* from a *symptom*. The contract should be explicit.
+
+### 2. Show plays without deliverables
+
+The show skill expects each play to write a verdict and an
+implementation brief into `<show>/<play>/`. When an agent finishes early
+without writing them, the gate downstream has no input to grade. The
+play merges anyway (because gate verdict defaults are permissive), then
+the next play in the DAG breaks because the artifact it depended on
+never existed.
+
+### 3. The phantom-session "missing_artifacts" reason
+
+ADR-0024's phantom classifier flags sessions whose `artifacts_path`
+directory was deleted or never created. This is the post-hoc detection
+of the same problem: there was an implicit expectation that artifacts
+would be produced, and the cleanup logic doesn't know it should have
+checked, so the user sees a phantom badge after the fact instead of a
+contract failure at completion.
+
+### 4. ADR-0021 set up the storage; we never set up the contract
+
+ADR-0021 introduced the `artifacts` table for structured `SkillOutcome`
+JSON (review verdicts, gate verdicts, CI results) and `file_path` for
+large blobs. That ADR is about *storage*: where do artifacts live once
+produced. It is silent on the prior question: which artifacts *must*
+this session produce, declared up front?
+
+The triggering observation: every Studio surface that needs to detect
+"this run was supposed to do X but didn't" is reverse-engineering an
+implicit contract. Make the contract explicit at the playbook layer,
+snapshot it onto the session at start, verify it at completion, and the
+failure mode becomes a first-class status reason instead of a phantom
+diagnosis.
+
+## Decision
+
+Add a declarative artifact contract that:
+
+1. Lives in playbook YAML (`artifacts:` block) and optionally in agent
+   profile frontmatter (`artifact_defaults:`).
+
+2. Is *resolved* at session start (playbook overlays agent defaults) and
+   *snapshotted* onto the session in `artifact_contract_json`.
+
+3. Is *verified* at session teardown by the executor; the verification
+   result is written to `artifact_verification_json`.
+
+4. On missing-required failure, the contract *overrides exit code*: the
+   session becomes `failed` with reason `run.failed.missing_artifact`
+   per ADR-0028, regardless of process exit status.
+
+Existing playbooks with no `artifacts:` block opt out of verification —
+no implicit "must produce at least one artifact" default. The contract
+is something playbook authors declare deliberately.
+
+### 1. Schema additions
+
+Two columns on `sessions`:
+
+```sql
+ALTER TABLE sessions ADD COLUMN artifact_contract_json JSON;
+ALTER TABLE sessions ADD COLUMN artifact_verification_json JSON;
+```
+
+No new tables. The existing `artifacts` table (ADR-0021) is referenced
+for outcome-kind contract checks (deferred to v1.1; see Non-Goals).
+
+`artifact_contract_json` is immutable for the session's lifetime —
+written at session creation, never updated. Editing the playbook
+mid-run does not retroactively change what was expected.
+
+### 2. Playbook contract shape
+
+```yaml
+# ~/.lionagi/playbooks/code-review.playbook.yaml
+name: code-review
+model: claude/sonnet
+prompt: |
+  Review the changes in {target} and produce review.md with findings.
+
+artifacts:
+  expected:
+    - id: review
+      path: review.md
+      required: true
+      description: "Reviewer verdict and findings"
+    - id: notes
+      path: notes.md
+      required: false
+      description: "Optional supplementary observations"
+```
+
+Fields per expected artifact:
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `id` | str | — | Stable identifier (kebab-case). Used as the merge key and as the evidence reference for status reasons. |
+| `path` | str | — | Path *relative to* `sessions.artifacts_path`. No leading `/`, no `..`, no globs (v1). |
+| `required` | bool | `true` | Missing required ⇒ run becomes `failed`. Missing optional ⇒ warning, no status change. |
+| `description` | str | `""` | Free-text shown in Studio's run detail and in the status reason evidence panel. |
+
+Reserved for v1.1 (see Non-Goals): `kind`, `min_size`, `mime_type`,
+`outcome_kind`, glob patterns.
+
+### 3. Agent profile defaults
+
+Agent profiles in `~/.lionagi/agents/<name>/<name>.md` can declare
+`artifact_defaults` in frontmatter:
+
+```yaml
+---
+name: reviewer
+model: codex/gpt-5.5
+artifact_defaults:
+  expected:
+    - id: report
+      path: report.md
+      required: false
+---
+
+# Reviewer agent body here…
+```
+
+Defaults are role-based ("a reviewer typically produces a report") and
+weakly required. Playbooks (which know the task) usually override or
+narrow them.
+
+### 4. Resolution rules
+
+At session creation:
+
+```python
+def resolve_artifact_contract(
+    *, playbook_artifacts: dict | None,
+    agent_defaults: dict | None,
+) -> dict | None:
+    """Merge playbook + agent_profile artifact expectations.
+
+    Returns the resolved contract or None if neither side declares one.
+    Verification is skipped entirely when the result is None.
+    """
+    if not playbook_artifacts and not agent_defaults:
+        return None
+
+    by_id: dict[str, dict] = {}
+
+    # Start with agent defaults (lower precedence)
+    for spec in (agent_defaults or {}).get("expected", []):
+        by_id[spec["id"]] = {**spec, "source": "agent_profile"}
+
+    # Playbook overrides by id; same id wins entirely
+    for spec in (playbook_artifacts or {}).get("expected", []):
+        by_id[spec["id"]] = {**spec, "source": "playbook"}
+
+    return {"expected": list(by_id.values())}
+```
+
+Merge semantics:
+
+- Union by `id`.
+- On id collision: the playbook entry replaces the agent default
+  entirely (not a deep merge — replacing `required: false` with
+  `required: true` is a common case that deep merge would surprise).
+
+- `source` is recorded so the UI can show "expected by playbook" vs
+  "expected by agent default" in the run detail view.
+
+### 5. Snapshot at session start
+
+The session creation code in `lionagi/cli/agent.py` and the orchestrate
+modules call:
+
+```python
+contract = resolve_artifact_contract(
+    playbook_artifacts=playbook_spec.get("artifacts"),
+    agent_defaults=agent_profile.get("artifact_defaults"),
+)
+await db.create_session(
+    ...,
+    artifact_contract=contract,  # serialized to JSON in StateDB
+)
+```
+
+The session row carries the resolved contract for the rest of the run.
+`artifact_verification_json` stays NULL until teardown.
+
+### 6. Verification at teardown
+
+After the user code finishes (success, exception, timeout — all paths),
+the CLI teardown runs the verifier *before* the status transition:
+
+```python
+# lionagi/state/artifact_verifier.py
+import os, time
+from typing import TypedDict
+
+class VerificationResult(TypedDict):
+    status: str                    # "passed" | "failed" | "warning" | "skipped"
+    checked_at: float
+    missing_required: list[dict]   # entries from the contract
+    missing_optional: list[dict]
+    produced: list[dict]           # {id, path, size, present: True}
+
+def verify_artifact_contract(
+    contract: dict | None,
+    *,
+    artifacts_root: str | None,
+) -> VerificationResult | None:
+    if contract is None:
+        return None  # nothing declared → nothing to check
+    if not artifacts_root or not os.path.isdir(artifacts_root):
+        return {
+            "status": "failed",
+            "checked_at": time.time(),
+            "missing_required": [
+                e for e in contract["expected"] if e.get("required", True)
+            ],
+            "missing_optional": [
+                e for e in contract["expected"] if not e.get("required", True)
+            ],
+            "produced": [],
+        }
+
+    missing_required, missing_optional, produced = [], [], []
+    for entry in contract["expected"]:
+        full = os.path.join(artifacts_root, entry["path"])
+        present = os.path.isfile(full) and os.path.getsize(full) > 0
+        if present:
+            produced.append({
+                "id": entry["id"],
+                "path": entry["path"],
+                "size": os.path.getsize(full),
+            })
+        elif entry.get("required", True):
+            missing_required.append(entry)
+        else:
+            missing_optional.append(entry)
+
+    if missing_required:
+        status = "failed"
+    elif missing_optional:
+        status = "warning"
+    else:
+        status = "passed"
+
+    return {
+        "status": status,
+        "checked_at": time.time(),
+        "missing_required": missing_required,
+        "missing_optional": missing_optional,
+        "produced": produced,
+    }
+```
+
+"Produced" requires the file to exist *and* be non-empty. A zero-byte
+`review.md` is not a delivery.
+
+Path resolution is `os.path.join(sessions.artifacts_path, entry.path)`.
+`artifacts_path` is the existing column on `sessions` (ADR-0012). No
+new path concept introduced.
+
+### 7. Failure precedence vs exit code
+
+The contract verifier runs first; its outcome may change the status the
+CLI was about to set:
+
+```python
+# lionagi/cli/agent.py teardown, simplified
+proposed_status, proposed_reason = _resolve_status(exception, exit_code)
+verification = verify_artifact_contract(
+    contract=session.artifact_contract,
+    artifacts_root=session.artifacts_path,
+)
+
+if verification and verification["status"] == "failed":
+    if proposed_status == "completed":
+        # Override: a clean exit without required artifacts is still a failure
+        final_status = "failed"
+        final_reason_code = RunReasons.FAILED_MISSING_ARTIFACT
+        final_reason_summary = _format_missing(verification["missing_required"])
+        final_evidence = [
+            {"kind": "artifact_id", "id": e["id"], "label": e["path"]}
+            for e in verification["missing_required"]
+        ]
+    else:
+        # Already failing — keep the original cause, note the contract
+        # violation in metadata only. Don't overwrite a more specific cause.
+        final_status = proposed_status
+        final_reason_code = proposed_reason["code"]
+        final_reason_summary = proposed_reason["summary"]
+        final_evidence = proposed_reason["evidence_refs"]
+else:
+    final_status = proposed_status
+    final_reason_code = proposed_reason["code"]
+    final_reason_summary = proposed_reason["summary"]
+    final_evidence = proposed_reason["evidence_refs"]
+
+await db.update_artifact_verification(session_id, verification)
+await db.update_status(
+    entity_type="session",
+    entity_id=session_id,
+    new_status=final_status,
+    reason_code=final_reason_code,
+    reason_summary=final_reason_summary,
+    evidence_refs=final_evidence,
+    source="executor",
+)
+```
+
+Precedence rules:
+
+1. If the run was already going to fail (exception, timeout, abort,
+   non-zero exit), the *original* cause is preserved in the status
+   reason. The verification result is recorded in
+   `artifact_verification_json` for the UI to surface but does not
+   overwrite the reason. A run that crashed and *also* missed
+   artifacts is still primarily "crashed".
+
+2. If the run was going to be `completed` but verification failed on a
+   required artifact, the status flips to `failed` with reason
+   `run.failed.missing_artifact`. This is the case the contract
+   primarily exists to catch.
+
+3. Optional artifacts never change the status. They produce a
+   `warning` verification result; the UI surfaces it as a yellow chip
+   on the run detail page.
+
+### 8. Studio rendering
+
+Run detail page gains an "Expected artifacts" section that shows the
+contract + verification side by side:
+
+```text
+Expected artifacts                          Verified: failed
+
+  REQUIRED  review        review.md         MISSING
+            description: Reviewer verdict and findings
+            declared by: playbook
+
+  REQUIRED  report        report.md         OK (1.2 KB)
+            declared by: agent_profile
+
+  OPTIONAL  notes         notes.md          MISSING
+            description: Supplementary observations
+            declared by: playbook
+```
+
+Each row links to:
+
+- the file if produced (`file_path` opens the editor / artifact viewer)
+- the status reason if missing (the entry's `id` matches the
+  `evidence_refs.id` from ADR-0028, so clicking jumps to the failure
+  reason)
+
+When no contract was declared, the section is hidden entirely (no
+"contract: none" placeholder — silence beats noise).
+
+### 9. CLI tooling
+
+A pre-flight check helps playbook authors:
+
+```text
+li play check code-review
+  → contract resolved (3 expected: 2 required, 1 optional)
+  → all paths relative-OK
+  → no id collisions with agent_profile defaults
+```
+
+A post-run summary appears in the CLI on `failed` due to contract:
+
+```text
+Run failed: missing required artifacts.
+  review (review.md) — playbook
+  report (report.md) — agent_profile
+
+Run completed cleanly otherwise. Inspect with:
+  li state show-session <id>
+```
+
+### 10. Migration
+
+- `ALTER TABLE sessions ADD COLUMN artifact_contract_json JSON;`
+- `ALTER TABLE sessions ADD COLUMN artifact_verification_json JSON;`
+- Existing rows: both NULL. The verifier reads NULL contract as
+  "skipped", so historical runs behave exactly as before.
+
+- Playbooks without `artifacts:` are unchanged in behaviour.
+- Agent profiles without `artifact_defaults` in frontmatter are
+  unchanged in behaviour.
+
+### 11. File map
+
+New files:
+
+```text
+lionagi/state/artifact_verifier.py        # resolve + verify functions
+```
+
+Modified files:
+
+```text
+lionagi/state/schema.sql                  # 2 ALTERs on sessions
+lionagi/state/db.py                       # create_session(artifact_contract=...),
+                                          # update_artifact_verification()
+lionagi/cli/orchestrate/__init__.py       # parse playbook artifacts block
+lionagi/cli/orchestrate/_orchestration.py # snapshot contract at session start
+lionagi/cli/agent.py                      # teardown runs verifier before status update
+lionagi/cli/_project.py                   # resolve agent profile frontmatter
+apps/studio/server/services/sessions.py   # include contract+verification in API
+apps/studio/server/routers/runs.py        # detail endpoint exposes both
+apps/studio/frontend/components/runs/ExpectedArtifacts.tsx  # new UI section
+```
+
+## Consequences
+
+**Positive**
+
+- The reviewer-with-no-output pattern becomes a first-class failure with
+  a stable reason code, not a phantom diagnosis after the fact.
+
+- Playbook authors can declare deliverables explicitly; agents have
+  permission to ignore optional ones; required ones are enforced
+  uniformly without each playbook re-implementing checks in its prompt.
+
+- The "Missing artifacts" phantom-session class collapses: contract
+  failures are caught at completion, so the cleanup heuristic doesn't
+  have to detect them post-hoc.
+
+- The status reason `run.failed.missing_artifact` (ADR-0028) carries
+  the exact list of unmet artifact IDs as `evidence_refs` — Studio can
+  link directly to "what's missing" instead of "something is missing".
+
+- Backwards-compatible by default. Existing playbooks behave exactly as
+  before until they opt in.
+
+- The `artifacts` table from ADR-0021 still does what it did (structured
+  outcome storage); this ADR adds the *contract* layer that ADR-0021
+  was missing.
+
+**Negative**
+
+- Two new columns on `sessions` table. Already a wide table; the
+  alternative was a separate table that would have required a JOIN on
+  every session detail render.
+
+- Path-based verification is conservative — it only checks file
+  existence and non-emptiness. A 1-byte `review.md` containing just
+  "X" passes, even though it is clearly garbage. Content validation is
+  deferred to v1.1.
+
+- Glob patterns deferred. `notes/*.md` won't match anything in v1. A
+  playbook that needs "any number of notes files" has to list them or
+  wait for v1.1.
+
+- Outcome-kind contracts deferred. A playbook can't say "must produce
+  a `review_verdict` artifact row" — only "must produce a file at this
+  path". Outcome-kind verification needs ADR-0021's artifact writers
+  to be standardized first.
+
+- Agent-default declarations require editing the agent profile
+  frontmatter, which is markdown YAML — easy to typo. The pre-flight
+  check (Section 9) is the safety net.
+
+- The 1-line precedence rule ("contract failure overrides clean exit
+  but not a more specific failure") will be a small learning curve.
+  The fix is to make the UI show both signals when they disagree:
+  status reason + verification banner.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|---|---|
+| Default to "must produce at least one artifact" when no contract declared | Many existing playbooks are legitimately diagnostic (research, exploration, dry-run). Defaulting to artifacts-required would break the marketplace's `research.playbook.yaml`, `pr-review.playbook.yaml`, and others. Opt-in is the right default. |
+| Contract lives only in playbooks (no agent defaults) | Agent roles like reviewer, auditor, analyst have stable output expectations. Letting an agent profile declare its default deliverables lets a generic playbook just say "use the reviewer agent" and inherit a sensible contract. |
+| Contract lives only on agent profiles (no playbook) | Playbooks know the task; agents are reusable across tasks. Task-specific deliverables (a specific `pr-1070-review.md`) belong on the playbook. Agent defaults are role-based; playbooks are task-based. |
+| Verify in a separate process / service | Adds infra. Completion-time verification in the executor is simpler, runs in the same Python process that knows the contract and the artifacts path, and lets us write the verification result transactionally with the status reason. |
+| Store contract as a row per artifact in a new `artifact_contracts` table | A session has 1-5 expected artifacts. A row per artifact would multiply session rows × ~3. JSON column on the session row keeps the snapshot local, single-fetch, and matches how `plays.depends_on` is stored. |
+| Glob patterns from v1 | Glob raises hard questions: any-of-match vs all-of-match, count constraints, ordering. Concrete paths cover the 80% case. Add glob in v1.1 once the contract shape has settled. |
+| Verify at gate-time instead of completion-time | Gates already run per-play in `show` and don't run at all in regular `li agent` / `li play`. Completion-time verification works for every CLI surface. Gate-time verification can be added in v1.1 (gate inputs would include `verification.passed`). |
+| Treat all missing artifacts as warnings | Defeats the point. The whole reason this ADR exists is to *fail* runs that didn't deliver. Required must be enforceable. |
+
+## Non-Goals
+
+- **No glob patterns.** v1 supports concrete paths only.
+- **No content validation.** The verifier checks existence and non-zero
+  size; it does not validate markdown structure, JSON schema, or file
+  type by mime.
+
+- **No `kind: outcome` contracts.** Declaring "must produce a
+  `review_verdict` artifact row in the `artifacts` table" is deferred
+  to v1.1, after ADR-0021 outcome writers are standardized.
+
+- **No gate-time verification.** v1 verifies once, at session
+  teardown.
+
+- **No retroactive backfill.** Sessions created before this ADR have
+  NULL contract and are unverified.
+
+- **No quality scoring.** A file that exists passes. Quality (length,
+  structure, validity) is out of scope.
+
+- **No automatic artifact discovery.** The contract is declared, not
+  inferred. There is no "scan all .md files in artifacts_path and treat
+  them as produced" — playbooks declare what they expect.
+
+- **No artifact diffing or version history.** ADR-0021's `artifacts`
+  table holds versions; the contract just verifies "exists, non-empty".
+
+## References
+
+- [ADR-0012](ADR-0012-studio-execution-lineage.md) — Source of `sessions.artifacts_path` column.
+- [ADR-0021](ADR-0021-skill-artifacts-and-reactive-chaining.md) — Existing `artifacts` table for structured skill outcomes; this ADR adds the contract layer.
+- [ADR-0024](ADR-0024-session-health-and-admin-surface.md) — The `missing_artifacts` phantom reason collapses into this contract's `missing_required` outcome.
+- [ADR-0028](ADR-0028-status-reason-model.md) — Writes `run.failed.missing_artifact` with `evidence_refs` pointing at unmet artifact IDs.
+- [ADR-0030](ADR-0030-attention-queue.md) — Consumes contract-failure attention items.
+- `lionagi/cli/agent.py` — Session teardown (modify to call verifier before status update).
+- `lionagi/cli/orchestrate/__init__.py` — Playbook spec parsing (add `artifacts:` field).
+- ChatGPT frontend design review (external) — proposed an artifact contract; this ADR grounds the proposal in the existing `sessions.artifacts_path` and `artifacts` infrastructure (which the proposal didn't know about).
+
+### Prior art
+
+- **GitHub Actions `actions/upload-artifact`** — declares expected artifacts at workflow level; the workflow fails if `if-no-files-found: error` and the artifact path is empty. Direct inspiration for the required/optional split.
+- **Docker `HEALTHCHECK`** — completion-time check that runs after the container's main process, declares the contract that "the service is up", failure flips the container state. Same shape: declared contract, runtime verifier, status flip on miss.
+- **pytest `--require-pyx`-style fixtures** — declarative "this test requires X to exist" with explicit failure when the precondition isn't met. Conceptually parallel.

--- a/docs/adrs/ADR-0030-attention-queue.md
+++ b/docs/adrs/ADR-0030-attention-queue.md
@@ -253,30 +253,37 @@ the entity tables:
 
 ```python
 # apps/studio/server/services/attention.py — sketch
-async def _phantom_items(db) -> list[AttentionItem]:
-    classified = await admin_service.classify_phantoms(db)
-    out = []
-    for entry in classified:  # PhantomEntry: {session_id, reason, ...}
-        reason_code = _PHANTOM_TO_REASON_CODE[entry.reason]
-        # entry.reason ∈ {"process_dead", "missing_artifacts", "stale_lock"}
+# Consumes the existing public admin API
+# (apps/studio/server/services/admin.py:104) which returns a list of
+# dicts shaped { "id", "reason", "started_at", "updated_at",
+# "artifacts_path", ... }. `reason` is a PhantomReason literal
+# defined at apps/studio/server/services/admin.py:16.
+async def _phantom_items(stale_hours: float = 1.0) -> list[AttentionItem]:
+    phantoms = await admin_service.list_phantom_sessions(stale_hours=stale_hours)
+    out: list[AttentionItem] = []
+    for entry in phantoms:
+        reason_code = _PHANTOM_TO_REASON_CODE[entry["reason"]]
+        # entry["reason"] ∈ {"process_dead", "missing_artifacts", "stale_lock"}
         out.append(AttentionItem(
             entity_type="session",
-            entity_id=entry.session_id,
-            status=entry.status,           # whatever status the row still has
+            entity_id=entry["id"],
+            status="running",  # phantom items are still pre-transition
             reason=StatusReason(
                 code=reason_code,
-                summary=_PHANTOM_TO_SUMMARY[entry.reason],
-                evidence_refs=entry.evidence,
+                summary=_PHANTOM_TO_SUMMARY[entry["reason"]],
+                evidence_refs=[
+                    {"kind": "session", "id": entry["id"]},
+                ],
             ),
-            fingerprint=f"session:{entry.session_id}:{reason_code}",
+            fingerprint=f"session:{entry['id']}:{reason_code}",
             severity="warning",
         ))
     return out
 
 _PHANTOM_TO_REASON_CODE = {
-    "process_dead":     SessionReasons.HEALTH_PHANTOM_PROCESS_DEAD,
-    "missing_artifacts":SessionReasons.HEALTH_PHANTOM_MISSING_ARTIFACTS,
-    "stale_lock":       SessionReasons.HEALTH_ZOMBIE_STALE_LOCKS,
+    "process_dead":      SessionReasons.HEALTH_PHANTOM_PROCESS_DEAD,
+    "missing_artifacts": SessionReasons.HEALTH_PHANTOM_MISSING_ARTIFACTS,
+    "stale_lock":        SessionReasons.HEALTH_ZOMBIE_STALE_LOCKS,
 }
 ```
 

--- a/docs/adrs/ADR-0030-attention-queue.md
+++ b/docs/adrs/ADR-0030-attention-queue.md
@@ -90,7 +90,7 @@ Response:
         "code": "run.failed.missing_artifact",
         "summary": "Required artifact review.md was not produced.",
         "evidence_refs": [
-          {"kind": "artifact_id", "id": "review", "label": "review.md"}
+          {"kind": "expected_artifact", "id": "review", "label": "review.md"}
         ]
       },
       "impact": "Blocks /codex-pr-review pipeline for PR #1064.",
@@ -169,7 +169,8 @@ an attention-worthy condition (see severity table). Sample query for
 sessions:
 
 ```sql
--- failed sessions in last 24h, not dismissed for THIS reason code
+-- failed sessions in last 24h, not dismissed for THIS reason code,
+-- AND status hasn't changed since the dismissal was recorded
 SELECT
   'session' AS entity_type,
   s.id AS entity_id,
@@ -185,12 +186,19 @@ WHERE s.status = 'failed'
         'session:' || s.id || ':' || COALESCE(s.status_reason_code, '')
       )
       AND (d.snoozed_until IS NULL OR d.snoozed_until > ?)
+      -- clear_on_status_change=1 dismissals stop hiding the item as
+      -- soon as the entity's status changes from what it was at
+      -- dismissal time. clear_on_status_change=0 dismissals ignore
+      -- status drift entirely.
+      AND (d.clear_on_status_change = 0 OR d.status_at_dismissal = s.status)
   );
 ```
 
 Filtering matches the *fingerprint*, not just `entity_id` — so a
 dismissal of `session:X:session.phantom.process_dead` does not hide
-a later `session:X:session.phantom.missing_artifacts` item.
+a later `session:X:session.phantom.missing_artifacts` item. The
+`status_at_dismissal` comparison makes `clear_on_status_change=1`
+behavior immediate at read time, not deferred until vacuum.
 
 The Python aggregator runs these queries (one per entity type), applies
 severity scoring, computes cluster ids, and returns the merged list.
@@ -220,8 +228,9 @@ a full scan.
 | Session `timed_out` (last 24h) | `status='timed_out'` AND `updated_at >= now - 24h` | `warning` |
 | Session stuck (`running` >60m, no heartbeat) | `status='running'` AND `now - last_message_at > 3600` | `critical` |
 | Session slow (`running`, alive, >60m) | `status='running'` AND `60m < age < 3h` AND has recent heartbeat | `info` |
-| Session went phantom (process_dead, operator hasn't transitioned) | per ADR-0024 the doctor classifies; the operator must still transition. Detected by joining the live doctor classification — see Section 6. | `warning` |
-| Session went phantom (missing_artifacts, operator hasn't transitioned) | doctor classification = `missing_artifacts`. The artifact contract from ADR-0029 already would have set `run.failed.missing_artifact` at teardown; this row catches sessions that pre-date the contract or had no contract declared. | `warning` |
+| Session went phantom (process_dead, operator hasn't transitioned) | doctor classification (see "Live doctor-derived items" below) | `warning` |
+| Session went phantom (missing_artifacts, operator hasn't transitioned) | doctor classification `missing_artifacts` — catches sessions that pre-date ADR-0029's contract or had no contract declared | `warning` |
+| Session went phantom (stale_lock, operator hasn't transitioned) | doctor classification `stale_lock` | `warning` |
 | Play `blocked` (invalid deps) | `status_reason_code='play.blocked.invalid_deps'` | `warning` |
 | Play `blocked` (dep failed) | `status_reason_code='play.blocked.dep_failed'` | `warning` |
 | Play `escalated` | `status='escalated'` | `critical` |
@@ -231,6 +240,51 @@ a full scan.
 
 Sessions with `status_reason_code = 'legacy.imported'` are excluded —
 they are pre-ADR-0028 and have no useful reason to surface.
+
+#### Live doctor-derived items
+
+The three "Session went phantom" rows above are *not* generated from
+the entity-table status × status_reason_code query path. Phantom
+classifications are derived at read time by the doctor service per
+ADR-0024 (`apps/studio/server/services/admin.py:_classify_phantom`),
+and the operator may not yet have transitioned the session. The
+attention aggregator therefore queries the doctor service alongside
+the entity tables:
+
+```python
+# apps/studio/server/services/attention.py — sketch
+async def _phantom_items(db) -> list[AttentionItem]:
+    classified = await admin_service.classify_phantoms(db)
+    out = []
+    for entry in classified:  # PhantomEntry: {session_id, reason, ...}
+        reason_code = _PHANTOM_TO_REASON_CODE[entry.reason]
+        # entry.reason ∈ {"process_dead", "missing_artifacts", "stale_lock"}
+        out.append(AttentionItem(
+            entity_type="session",
+            entity_id=entry.session_id,
+            status=entry.status,           # whatever status the row still has
+            reason=StatusReason(
+                code=reason_code,
+                summary=_PHANTOM_TO_SUMMARY[entry.reason],
+                evidence_refs=entry.evidence,
+            ),
+            fingerprint=f"session:{entry.session_id}:{reason_code}",
+            severity="warning",
+        ))
+    return out
+
+_PHANTOM_TO_REASON_CODE = {
+    "process_dead":     SessionReasons.HEALTH_PHANTOM_PROCESS_DEAD,
+    "missing_artifacts":SessionReasons.HEALTH_PHANTOM_MISSING_ARTIFACTS,
+    "stale_lock":       SessionReasons.HEALTH_ZOMBIE_STALE_LOCKS,
+}
+```
+
+Once the operator transitions the session (per ADR-0028 Section 5,
+the admin transition API), the row's persisted `status_reason_code`
+matches the same code; the entity-table query path picks it up; the
+doctor-derived path stops returning the same session because it is
+no longer classified as phantom.
 
 **Deferred to v1.1** (see Non-Goals): chain-run `waiting_approval`
 attention items wait for the `chain_runs` table (ADR-0021 proposed,

--- a/docs/adrs/ADR-0030-attention-queue.md
+++ b/docs/adrs/ADR-0030-attention-queue.md
@@ -1,0 +1,436 @@
+# ADR-0030: Attention Queue
+
+**Status**: Proposed
+**Date**: 2026-05-23
+**Depends on**: ADR-0028 (status reason model) — without persisted reason codes, the queue's grouping and dismissal logic become frontend heuristics
+**Related**: ADR-0029 (artifact contract), ADR-0024 (session health), ADR-0031 (entity actions reuse)
+
+## Context
+
+Studio's dashboard surfaces counts: "Running: 6 / Failed: 6 / Slow: 3 /
+Needs review: 0". This is accurate, but it is a *table of contents*,
+not a *work queue*. To act on any of those numbers, the operator opens
+a different page, scans rows, infers severity from context, and decides
+which item to address first. The dashboard does not say which of the
+six failures matters more, or whether any of them are duplicates of
+each other.
+
+### 1. The state across entity types is fragmented
+
+Items that need attention live in:
+
+- `sessions` (failed, stuck, timed_out, phantom)
+- `shows` (active with no ready plays)
+- `plays` (blocked, escalated, gate_failed)
+- `schedule_runs` (skipped, failed)
+- `chain_runs` (waiting_approval — from ADR-0021)
+- system-level conditions (WAL pressure, DB health)
+
+There is no single page that aggregates these. The closest surface is
+the dashboard's failure cards, but they only show sessions and only
+the last 24h. A failed schedule run from this morning, a play blocked
+by a missing dependency since yesterday, and a phantom session from
+last week sit on three different pages.
+
+### 2. Failure clustering doesn't exist
+
+When `/codex-pr-review` failed six times last week, the dashboard
+showed "6 failures" as six separate red rows. They were all the same
+failure (missing artifact contract — see ADR-0029). Grouping them by
+cause turns six rows of work into one.
+
+### 3. The operator needs a place to dismiss
+
+Some attention items are real but not urgent. Phantom sessions older
+than 30 days can be pruned later. A blocked play with a known
+workaround can be deferred. Without a snooze/dismiss mechanism, the
+queue grows until the operator ignores it entirely — banner blindness.
+
+### 4. ADR-0028 makes this finally cheap to build
+
+With status reason codes persisted on each entity, the queue endpoint
+becomes a union over entity tables filtered by status × reason_code,
+sorted by a severity heuristic. Without ADR-0028, this endpoint would
+have to recompute "why is this in attention" inline for every row —
+exactly the duplication that ADR-0028 exists to prevent.
+
+## Decision
+
+Add a single backend endpoint, `GET /api/attention`, that returns a
+flat list of attention items aggregated across entity types. Severity
+is server-computed from a heuristic table (Section 4). Fingerprint-
+based dismissals live in a new `attention_dismissals` table. Refresh
+uses polling (5-15s) in v1; SSE deferred until Studio has real event
+semantics.
+
+### 1. Endpoint shape
+
+```text
+GET /api/attention?severity=critical,warning&limit=50&include_dismissed=false
+```
+
+Response:
+
+```json
+{
+  "generated_at": 1716517632.4,
+  "total": 14,
+  "by_severity": {"critical": 4, "warning": 7, "info": 3},
+  "items": [
+    {
+      "id": "attn_<uuid>",
+      "fingerprint": "session:e288a6e2493f:run.failed.missing_artifact",
+      "severity": "critical",
+      "entity": {
+        "type": "session",
+        "id": "e288a6e2493f",
+        "label": "reviewer run for /codex-pr-review"
+      },
+      "status": "failed",
+      "reason": {
+        "code": "run.failed.missing_artifact",
+        "summary": "Required artifact review.md was not produced.",
+        "evidence_refs": [
+          {"kind": "artifact_id", "id": "review", "label": "review.md"}
+        ]
+      },
+      "impact": "Blocks /codex-pr-review pipeline for PR #1064.",
+      "cluster_id": "cluster_run.failed.missing_artifact",
+      "cluster_size": 6,
+      "first_seen_at": 1716517000.0,
+      "last_updated_at": 1716517630.0,
+      "actions": [
+        {"id": "inspect", "label": "Open", "kind": "primary", "href": "/runs/e288a6e2493f"},
+        {"id": "retry",   "label": "Retry", "kind": "secondary", "endpoint": "/api/runs/e288a6e2493f/retry", "method": "POST"},
+        {"id": "snooze",  "label": "Snooze 1d", "kind": "secondary", "endpoint": "/api/attention/snooze", "method": "POST", "requires_confirm": false}
+      ]
+    }
+  ]
+}
+```
+
+Notes on fields:
+
+- `fingerprint` is the stable identity used for snooze/dismiss. Format:
+  `<entity_type>:<entity_id>:<reason_code>`. When the reason code
+  changes, the fingerprint changes, so a dismissal does not silently
+  hide a new condition.
+
+- `cluster_id` groups items with the same `reason_code` (cross-entity).
+  `cluster_size` is the number of items in that cluster server-side
+  (not just on this page).
+
+- `actions` reuses the shape defined in ADR-0031 (`EntityAction`).
+  Same descriptor type, same renderer.
+
+- `entity.label` is server-rendered. For sessions, it is
+  `playbook_name` + agent role; for plays, `<show.topic>/<play.name>`;
+  for shows, `topic`. The frontend never has to reconstruct labels.
+
+### 2. Schema additions
+
+```sql
+CREATE TABLE IF NOT EXISTS attention_dismissals (
+  id                     TEXT    PRIMARY KEY,
+  fingerprint            TEXT    NOT NULL,
+  entity_type            TEXT    NOT NULL,
+  entity_id              TEXT    NOT NULL,
+  reason_code            TEXT,
+  snoozed_until          REAL,                  -- NULL = permanent dismiss (until status change)
+  dismissed_at           REAL    NOT NULL,
+  dismissed_by           TEXT    DEFAULT 'operator',
+  clear_on_status_change INTEGER NOT NULL DEFAULT 1
+                         CHECK(clear_on_status_change IN (0, 1)),
+  created_at             REAL    NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_attention_dismissals_fp
+  ON attention_dismissals(fingerprint);
+CREATE INDEX IF NOT EXISTS idx_attention_dismissals_snoozed
+  ON attention_dismissals(snoozed_until) WHERE snoozed_until IS NOT NULL;
+```
+
+The unique index on `fingerprint` lets snooze be an upsert — `POST
+/api/attention/snooze` with the same fingerprint extends the snooze.
+
+### 3. Item generation
+
+The endpoint runs SQL queries per entity type and merges the results.
+Each query selects rows whose `status` × `status_reason_code` matches
+an attention-worthy condition (see severity table). Sample query for
+sessions:
+
+```sql
+-- failed sessions in last 24h not dismissed
+SELECT
+  'session' AS entity_type,
+  id AS entity_id,
+  status, status_reason_code, status_reason_summary, status_evidence_refs,
+  updated_at,
+  COALESCE(playbook_name, agent_name, 'agent') AS label_root
+FROM sessions
+WHERE status = 'failed'
+  AND updated_at >= ?  -- now - 86400
+  AND id NOT IN (
+    SELECT entity_id FROM attention_dismissals
+    WHERE entity_type = 'session' AND clear_on_status_change = 1
+      AND (snoozed_until IS NULL OR snoozed_until > ?)
+  );
+```
+
+The Python aggregator runs these queries (one per entity type), applies
+severity scoring, computes cluster ids, and returns the merged list.
+
+For the v1 scale (single-user Studio with hundreds of sessions),
+running ~7 queries on every poll is well within budget. The
+`sessions(status)` and `plays(status)` indexes already exist; one new
+index on `attention_dismissals(fingerprint)` suffices.
+
+### 4. Severity heuristic
+
+| Condition | Detection | Severity |
+|---|---|---|
+| Session `failed` | `status='failed'` AND `updated_at >= now - 24h` | `critical` |
+| Session `timed_out` | `status='timed_out'` AND `updated_at >= now - 24h` | `warning` |
+| Session phantom (process_dead) | `status_reason_code='session.phantom.process_dead'` | `warning` |
+| Session phantom (missing_artifacts) tied to a required contract | `status_reason_code='session.phantom.missing_artifacts'` AND `artifact_verification_json` shows `missing_required` non-empty | `critical` |
+| Session phantom (missing_artifacts) without contract | same code, contract is NULL | `warning` |
+| Session stuck (`running` >60m, no heartbeat) | `status='running'` AND `now - last_message_at > 3600` | `critical` |
+| Session slow (>60m, alive) | `status='running'` AND `60m < age < 3h` AND has recent heartbeat | `info` |
+| Play `blocked` (invalid deps) | `status_reason_code='play.blocked.invalid_deps'` | `warning` |
+| Play `blocked` (dep failed) | `status_reason_code='play.blocked.dep_failed'` | `warning` |
+| Play `escalated` | `status='escalated'` | `critical` |
+| Play `gate_failed` attempt 2 | `status='gate_failed'` AND `attempt=2` | `critical` |
+| Show `active` with 0 ready plays | computed: no play has status in `{pending, prepared}` with deps resolved | `warning` |
+| Schedule run `failed` | `status='failed'` AND `fired_at >= now - 24h` | `warning` |
+| Chain run `waiting_approval` (ADR-0021) | `status='waiting_approval'` | `warning` |
+| DB/WAL health degraded | admin classifier flag set | `critical` |
+
+Sessions with `status_reason_code = 'legacy.imported'` are excluded —
+they are pre-ADR-0028 and have no useful reason to surface.
+
+### 5. Clustering
+
+Items with the same `reason_code` (across entity types) cluster:
+
+```python
+def cluster_items(items: list[dict]) -> list[dict]:
+    by_code = defaultdict(list)
+    for item in items:
+        code = item["reason"]["code"]
+        by_code[code].append(item)
+    for items_in_cluster in by_code.values():
+        cluster_id = f"cluster_{items_in_cluster[0]['reason']['code']}"
+        for item in items_in_cluster:
+            item["cluster_id"] = cluster_id
+            item["cluster_size"] = len(items_in_cluster)
+    return items
+```
+
+The frontend can render the queue grouped by cluster (`{ cluster_id ->
+items[] }`) or flat. Default in v1: grouped by cluster when
+`cluster_size > 1`.
+
+This is the cheapest possible clustering. More sophisticated taxonomy
+(e.g., grouping `run.failed.exception:TimeoutError` with
+`run.failed.exception:CancelledError`) is deferred — once we see real
+data, we can promote shared substrings to first-class reason codes.
+
+### 6. Dismissal semantics
+
+- `POST /api/attention/snooze` with `{fingerprint, until}` upserts a
+  row with `snoozed_until=until`. The next attention poll filters
+  snoozed items.
+
+- `POST /api/attention/dismiss` with `{fingerprint}` upserts with
+  `snoozed_until=NULL` (permanent until status change).
+
+- `clear_on_status_change=1` (default): when the entity's *status*
+  enum changes (`running -> failed`), the dismissal is invalidated.
+  When only the *reason code* changes (`session.phantom.process_dead
+  -> session.phantom.missing_artifacts`), the fingerprint changes (it
+  encodes the reason code), so a new attention item appears and the
+  old dismissal stays — correct, because the underlying signal
+  changed.
+
+- `clear_on_status_change=0`: the dismissal persists until the entity
+  is deleted. For "I never want to see this again" cases.
+
+The cleanup query runs nightly:
+
+```sql
+DELETE FROM attention_dismissals
+WHERE clear_on_status_change = 1
+  AND EXISTS (
+    SELECT 1 FROM <entity_table>
+    WHERE id = attention_dismissals.entity_id
+      AND status != <recorded_status>
+  );
+```
+
+In v1, this runs on `li state vacuum` (existing maintenance entrypoint).
+
+### 7. Refresh model
+
+Polling. The dashboard re-fetches `/api/attention` every 10 seconds
+when the tab is active. When the tab is hidden, polling pauses (uses
+the existing `Page Visibility API` pattern in the frontend).
+
+SSE is deferred. Real-time push only matters when items appear
+faster than humans can read them. At Studio's scale (single user,
+~tens of items/hour), polling is sufficient.
+
+### 8. Frontend rendering
+
+The Attention Queue lives at the top of the Dashboard (ADR-0032
+groups it under `Dashboard`). Layout:
+
+```text
+ATTENTION QUEUE                                    14 items
+  
+  CRITICAL · 4 items
+    [▼ run.failed.missing_artifact · 6 items]
+       reviewer e288a... · 2m ago · review.md not produced
+         [Open] [Retry] [Snooze 1d]
+       reviewer 3def... · 14m ago · review.md not produced
+         [Open] [Retry] [Snooze 1d]
+       ...
+    [▼ play.escalated · 1 item]
+       sweep/test-coverage · 1h ago · gate failed twice
+         [Open] [Reassign] [Snooze 1d]
+
+  WARNING · 7 items
+    ...
+
+  INFO · 3 items
+    ...
+```
+
+Clusters with `cluster_size > 1` collapse by default. Each row gets
+its `actions[]` rendered as buttons via the same `EntityAction`
+component from ADR-0031.
+
+The "[Snooze 1d]" button is shown by default; "[Dismiss]" hidden in a
+menu (heavier consequences). Dismiss popup confirms with the item
+summary.
+
+### 9. File map
+
+New files:
+
+```text
+apps/studio/server/services/attention.py     # query aggregator + clustering
+apps/studio/server/routers/attention.py      # GET endpoint + snooze/dismiss
+apps/studio/frontend/components/dashboard/AttentionQueue.tsx
+apps/studio/frontend/components/dashboard/AttentionCluster.tsx
+apps/studio/frontend/components/dashboard/AttentionItem.tsx
+```
+
+Modified files:
+
+```text
+lionagi/state/schema.sql                     # attention_dismissals table
+lionagi/state/db.py                          # snooze/dismiss CRUD
+apps/studio/server/app.py                    # register attention router
+apps/studio/frontend/app/page.tsx            # mount AttentionQueue at top of dashboard
+apps/studio/frontend/lib/api.ts              # fetchAttention(), snoozeItem()
+```
+
+## Consequences
+
+**Positive**
+
+- Operators get a single page that answers "what should I look at first"
+  instead of scanning four entity-type pages and inferring priority.
+
+- Clustering by reason code turns six identical failures into one row
+  with cluster_size=6, fixing the noise that the dashboard currently
+  generates for repeated failures.
+
+- Dismissal is a real primitive, not a frontend localStorage hack.
+  Survives reloads, clears correctly on status change, persists across
+  sessions.
+
+- Server-side severity scoring means the frontend stays a renderer.
+  Adding a new attention condition is a backend change with a single
+  responsibility (extend the severity table).
+
+- Reuses ADR-0031's `EntityAction` descriptor — no duplicate action UI
+  schema for the queue vs entity detail pages.
+
+- Direct beneficiary of ADR-0028: every item has a stable reason code,
+  human summary, and evidence refs without any extra work.
+
+**Negative**
+
+- Polling load. At 10s intervals × 7 entity-type queries × a single
+  user, the impact is negligible. If Studio scales to multi-user (it
+  is currently single-user only — see ADR-0008), polling will need
+  reconsideration.
+
+- The severity table is opinionated. Conditions and thresholds are
+  judgment calls; some operators may want different defaults
+  ("phantom: process_dead" as critical vs warning). Override hooks are
+  deferred — start opinionated, soften based on feedback.
+
+- Clustering is intentionally simple (same reason_code). More
+  sophisticated grouping (e.g., shared file path, same agent role)
+  would require a real classifier and is out of scope.
+
+- Dismissal can become a debt magnet. An operator who snoozes
+  everything ends up with a quiet queue and a broken system. The
+  "clear on status change" default mitigates this for the common case.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|---|---|
+| Aggregate per-entity endpoints client-side | Severity, dedup, snooze, and clustering become inconsistent across pages. Each entity page would re-implement filtering and sorting. One endpoint owning the queue is the cheapest correct path. |
+| SSE / WebSocket push from v1 | Polling at 10s is sufficient for the data freshness Studio needs. SSE introduces connection management, reconnect logic, backpressure — not free. Defer until events become first-class. |
+| Materialized view / persistent attention items table | Cache invalidation problem on every status change. Re-running ~7 indexed queries per poll is cheaper than maintaining a materialized table whose freshness depends on every entity write touching it. |
+| Embed Attention Queue inside each entity page | Operator would have to navigate to find their queue. The point of the queue is to *avoid* navigation — one stop, prioritized list. |
+| No dismissal at all | Queue grows until it's banner-blindness. The "I'll deal with this later" affordance is necessary. |
+| Severity inferred client-side from status alone | Status doesn't carry enough information (e.g., `failed` covers both "missing artifact" and "exception" — different severities). Need server-side rules with access to reason codes. |
+| Cluster by entity type instead of reason code | Reason code clusters surface the actual repeated failure mode. Entity-type clustering would put unrelated session failures together. |
+
+## Non-Goals
+
+- **No pagination beyond `limit`.** The queue should never have more
+  than ~100 items at steady state; if it does, the system is broken,
+  not the UI. Pagination is deferred.
+
+- **No filtering UI in v1.** Filter by severity is supported via the
+  endpoint query string; an in-UI filter dropdown is deferred. The
+  default view shows all severities, clustered.
+
+- **No assignment / ownership.** Studio is single-user (ADR-0008).
+  Multi-user assignment is deferred to whenever multi-user becomes a
+  goal.
+
+- **No notification system.** No emails, Slack pings, or browser
+  notifications when new items appear. The queue is pull-only.
+
+- **No automatic remediation.** No "Auto-retry up to 3 times when
+  this reason code appears." Retry is operator-initiated, by design.
+
+- **No root-cause analysis.** The cluster just groups by code;
+  Studio does not infer or display deeper causality.
+
+- **No external integrations.** Linear / GitHub Issues escalation is
+  deferred. The queue lives in Studio.
+
+## References
+
+- [ADR-0024](ADR-0024-session-health-and-admin-surface.md) — Phantom session classifier feeds attention items.
+- [ADR-0028](ADR-0028-status-reason-model.md) — Persisted reason codes are the queue's primary input.
+- [ADR-0029](ADR-0029-artifact-contract.md) — Contract failures become `run.failed.missing_artifact` attention items.
+- [ADR-0031](ADR-0031-entity-header-pattern.md) — `EntityAction` descriptor shape reused for queue actions.
+- [ADR-0032](ADR-0032-navigation-reorganization.md) — Queue lives at the top of Dashboard.
+- `apps/studio/server/services/admin.py` — Existing health classifier (already detects phantom; this ADR wires its output into the queue).
+- ChatGPT frontend design review (external) — proposed the Attention Queue as Phase 1; this ADR delays it until ADR-0028 lands so the queue can sit on persisted reason codes rather than inline heuristics.
+
+### Prior art
+
+- **PagerDuty / Opsgenie alert queues** — severity-based grouping with snooze and acknowledge. The fingerprint mechanism is borrowed directly.
+- **Sentry issue grouping** — clusters errors by stack-trace fingerprint, surfaces "X occurrences" rather than X separate rows. Same shape, different signal.
+- **Inbox Zero / GTD attention triage** — the queue is structured to support "process to inbox zero" cadence: open, action, snooze, or dismiss each item.

--- a/docs/adrs/ADR-0030-attention-queue.md
+++ b/docs/adrs/ADR-0030-attention-queue.md
@@ -19,12 +19,11 @@ each other.
 
 Items that need attention live in:
 
-- `sessions` (failed, stuck, timed_out, phantom)
+- `sessions` (failed, stuck, timed_out, plus operator action needed on phantom classifications)
 - `shows` (active with no ready plays)
 - `plays` (blocked, escalated, gate_failed)
 - `schedule_runs` (skipped, failed)
-- `chain_runs` (waiting_approval — from ADR-0021)
-- system-level conditions (WAL pressure, DB health)
+- (deferred — see Non-Goals) `chain_runs` waiting_approval, system-level DB/WAL conditions
 
 There is no single page that aggregates these. The closest surface is
 the dashboard's failure cards, but they only show sessions and only
@@ -135,7 +134,9 @@ CREATE TABLE IF NOT EXISTS attention_dismissals (
   fingerprint            TEXT    NOT NULL,
   entity_type            TEXT    NOT NULL,
   entity_id              TEXT    NOT NULL,
-  reason_code            TEXT,
+  reason_code            TEXT    NOT NULL,      -- the reason at dismissal time
+  status_at_dismissal    TEXT    NOT NULL,      -- the entity status at dismissal time
+                                                -- used by clear_on_status_change cleanup
   snoozed_until          REAL,                  -- NULL = permanent dismiss (until status change)
   dismissed_at           REAL    NOT NULL,
   dismissed_by           TEXT    DEFAULT 'operator',
@@ -148,10 +149,17 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_attention_dismissals_fp
   ON attention_dismissals(fingerprint);
 CREATE INDEX IF NOT EXISTS idx_attention_dismissals_snoozed
   ON attention_dismissals(snoozed_until) WHERE snoozed_until IS NOT NULL;
+
+-- Compensating index for queries that JOIN by (entity_type, entity_id)
+-- when computing the live fingerprint client-side.
+CREATE INDEX IF NOT EXISTS idx_attention_dismissals_entity
+  ON attention_dismissals(entity_type, entity_id);
 ```
 
-The unique index on `fingerprint` lets snooze be an upsert — `POST
-/api/attention/snooze` with the same fingerprint extends the snooze.
+`fingerprint` is the dismissal's identity (`<entity_type>:<entity_id>:<reason_code>`).
+Snooze is an upsert keyed by fingerprint — re-snoozing the same condition
+extends the deadline; a *different* reason on the same entity gets a new
+fingerprint and surfaces fresh.
 
 ### 3. Item generation
 
@@ -161,53 +169,74 @@ an attention-worthy condition (see severity table). Sample query for
 sessions:
 
 ```sql
--- failed sessions in last 24h not dismissed
+-- failed sessions in last 24h, not dismissed for THIS reason code
 SELECT
   'session' AS entity_type,
-  id AS entity_id,
-  status, status_reason_code, status_reason_summary, status_evidence_refs,
-  updated_at,
-  COALESCE(playbook_name, agent_name, 'agent') AS label_root
-FROM sessions
-WHERE status = 'failed'
-  AND updated_at >= ?  -- now - 86400
-  AND id NOT IN (
-    SELECT entity_id FROM attention_dismissals
-    WHERE entity_type = 'session' AND clear_on_status_change = 1
-      AND (snoozed_until IS NULL OR snoozed_until > ?)
+  s.id AS entity_id,
+  s.status, s.status_reason_code, s.status_reason_summary, s.status_evidence_refs,
+  s.updated_at,
+  COALESCE(s.playbook_name, s.agent_name, 'agent') AS label_root
+FROM sessions s
+WHERE s.status = 'failed'
+  AND s.updated_at >= ?  -- now - 86400
+  AND NOT EXISTS (
+    SELECT 1 FROM attention_dismissals d
+    WHERE d.fingerprint = (
+        'session:' || s.id || ':' || COALESCE(s.status_reason_code, '')
+      )
+      AND (d.snoozed_until IS NULL OR d.snoozed_until > ?)
   );
 ```
+
+Filtering matches the *fingerprint*, not just `entity_id` — so a
+dismissal of `session:X:session.phantom.process_dead` does not hide
+a later `session:X:session.phantom.missing_artifacts` item.
 
 The Python aggregator runs these queries (one per entity type), applies
 severity scoring, computes cluster ids, and returns the merged list.
 
 For the v1 scale (single-user Studio with hundreds of sessions),
-running ~7 queries on every poll is well within budget. The
-`sessions(status)` and `plays(status)` indexes already exist; one new
-index on `attention_dismissals(fingerprint)` suffices.
+running ~6 queries on every poll is well within budget. The
+existing `plays(status)` index (`lionagi/state/schema.sql:271`)
+covers the play queries; the existing
+`idx_sessions_status_last_msg` (`lionagi/state/schema.sql:159`) is
+a partial index for `status='running'` only and does **not** cover
+`failed`/`timed_out` lookups. This ADR therefore adds:
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_sessions_status_updated
+  ON sessions(status, updated_at DESC);
+```
+
+so the failed/timed_out queries (severity table rows 1-2) avoid
+a full scan.
 
 ### 4. Severity heuristic
 
 | Condition | Detection | Severity |
 |---|---|---|
-| Session `failed` | `status='failed'` AND `updated_at >= now - 24h` | `critical` |
-| Session `timed_out` | `status='timed_out'` AND `updated_at >= now - 24h` | `warning` |
-| Session phantom (process_dead) | `status_reason_code='session.phantom.process_dead'` | `warning` |
-| Session phantom (missing_artifacts) tied to a required contract | `status_reason_code='session.phantom.missing_artifacts'` AND `artifact_verification_json` shows `missing_required` non-empty | `critical` |
-| Session phantom (missing_artifacts) without contract | same code, contract is NULL | `warning` |
+| Run failed (missing required artifact) | `status_reason_code='run.failed.missing_artifact'` | `critical` |
+| Session `failed` (any other cause, last 24h) | `status='failed'` AND `updated_at >= now - 24h` AND `status_reason_code != 'run.failed.missing_artifact'` | `critical` |
+| Session `timed_out` (last 24h) | `status='timed_out'` AND `updated_at >= now - 24h` | `warning` |
 | Session stuck (`running` >60m, no heartbeat) | `status='running'` AND `now - last_message_at > 3600` | `critical` |
-| Session slow (>60m, alive) | `status='running'` AND `60m < age < 3h` AND has recent heartbeat | `info` |
+| Session slow (`running`, alive, >60m) | `status='running'` AND `60m < age < 3h` AND has recent heartbeat | `info` |
+| Session went phantom (process_dead, operator hasn't transitioned) | per ADR-0024 the doctor classifies; the operator must still transition. Detected by joining the live doctor classification — see Section 6. | `warning` |
+| Session went phantom (missing_artifacts, operator hasn't transitioned) | doctor classification = `missing_artifacts`. The artifact contract from ADR-0029 already would have set `run.failed.missing_artifact` at teardown; this row catches sessions that pre-date the contract or had no contract declared. | `warning` |
 | Play `blocked` (invalid deps) | `status_reason_code='play.blocked.invalid_deps'` | `warning` |
 | Play `blocked` (dep failed) | `status_reason_code='play.blocked.dep_failed'` | `warning` |
 | Play `escalated` | `status='escalated'` | `critical` |
 | Play `gate_failed` attempt 2 | `status='gate_failed'` AND `attempt=2` | `critical` |
-| Show `active` with 0 ready plays | computed: no play has status in `{pending, prepared}` with deps resolved | `warning` |
-| Schedule run `failed` | `status='failed'` AND `fired_at >= now - 24h` | `warning` |
-| Chain run `waiting_approval` (ADR-0021) | `status='waiting_approval'` | `warning` |
-| DB/WAL health degraded | admin classifier flag set | `critical` |
+| Show `active` with 0 ready plays | `status_reason_code='show.blocked.no_ready_plays'` | `warning` |
+| Schedule run `failed` (last 24h) | `status='failed'` AND `fired_at >= now - 24h` | `warning` |
 
 Sessions with `status_reason_code = 'legacy.imported'` are excluded —
 they are pre-ADR-0028 and have no useful reason to surface.
+
+**Deferred to v1.1** (see Non-Goals): chain-run `waiting_approval`
+attention items wait for the `chain_runs` table (ADR-0021 proposed,
+not landed). System-level DB/WAL attention items require a `system`
+entity_type with synthetic `entity_id` (e.g. `system:db`) and matching
+reason codes (`system.db.wal_degraded`) — separate ADR.
 
 ### 5. Clustering
 
@@ -239,11 +268,14 @@ data, we can promote shared substrings to first-class reason codes.
 ### 6. Dismissal semantics
 
 - `POST /api/attention/snooze` with `{fingerprint, until}` upserts a
-  row with `snoozed_until=until`. The next attention poll filters
+  row keyed on `fingerprint`. The endpoint stores the entity's
+  current status as `status_at_dismissal` so the cleanup query has
+  something to compare against. The next attention poll filters
   snoozed items.
 
 - `POST /api/attention/dismiss` with `{fingerprint}` upserts with
-  `snoozed_until=NULL` (permanent until status change).
+  `snoozed_until=NULL` and records `status_at_dismissal` (permanent
+  until status change).
 
 - `clear_on_status_change=1` (default): when the entity's *status*
   enum changes (`running -> failed`), the dismissal is invalidated.
@@ -254,9 +286,11 @@ data, we can promote shared substrings to first-class reason codes.
   changed.
 
 - `clear_on_status_change=0`: the dismissal persists until the entity
-  is deleted. For "I never want to see this again" cases.
+  is deleted. For "I never want to see this again" cases. The query
+  filter still applies, but cleanup never runs on these rows.
 
-The cleanup query runs nightly:
+The cleanup query runs as a step in `li state vacuum` (per ADR-0024's
+maintenance flow):
 
 ```sql
 DELETE FROM attention_dismissals
@@ -264,7 +298,7 @@ WHERE clear_on_status_change = 1
   AND EXISTS (
     SELECT 1 FROM <entity_table>
     WHERE id = attention_dismissals.entity_id
-      AND status != <recorded_status>
+      AND status != attention_dismissals.status_at_dismissal
   );
 ```
 
@@ -363,7 +397,7 @@ apps/studio/frontend/lib/api.ts              # fetchAttention(), snoozeItem()
 
 **Negative**
 
-- Polling load. At 10s intervals × 7 entity-type queries × a single
+- Polling load. At 10s intervals × 6 entity-type queries × a single
   user, the impact is negligible. If Studio scales to multi-user (it
   is currently single-user only — see ADR-0008), polling will need
   reconsideration.
@@ -418,6 +452,19 @@ apps/studio/frontend/lib/api.ts              # fetchAttention(), snoozeItem()
 
 - **No external integrations.** Linear / GitHub Issues escalation is
   deferred. The queue lives in Studio.
+
+- **No system-level attention items in v1.** DB/WAL pressure, disk
+  exhaustion, and other non-entity conditions would require a
+  synthetic `entity_type='system'` with no row in any entity table,
+  which the schema (entity_id NOT NULL) does not accommodate cleanly.
+  Deferred to a follow-up that introduces `system` reason codes
+  (e.g. `system.db.wal_degraded`) and either a `system_entities`
+  table or a documented synthetic-id convention.
+
+- **No chain-run attention items in v1.** Chain runs are proposed in
+  ADR-0021 but `chain_runs` is not in the current schema. When
+  ADR-0021 lands, a follow-up extends the queue with
+  `chain_run.waiting_approval`.
 
 ## References
 

--- a/docs/adrs/ADR-0030-attention-queue.md
+++ b/docs/adrs/ADR-0030-attention-queue.md
@@ -255,27 +255,28 @@ the entity tables:
 # apps/studio/server/services/attention.py — sketch
 # Consumes the existing public admin API
 # (apps/studio/server/services/admin.py:104) which returns a list of
-# dicts shaped { "id", "reason", "started_at", "updated_at",
-# "artifacts_path", ... }. `reason` is a PhantomReason literal
-# defined at apps/studio/server/services/admin.py:16.
+# dicts shaped { "session_id", "reason", "name", "playbook_name",
+# "started_at", "updated_at", "artifacts_path", "status", ... }.
+# `reason` is a PhantomReason literal defined at admin.py:16.
 async def _phantom_items(stale_hours: float = 1.0) -> list[AttentionItem]:
     phantoms = await admin_service.list_phantom_sessions(stale_hours=stale_hours)
     out: list[AttentionItem] = []
     for entry in phantoms:
+        session_id = entry["session_id"]   # admin.py:125 yields session_id
         reason_code = _PHANTOM_TO_REASON_CODE[entry["reason"]]
         # entry["reason"] ∈ {"process_dead", "missing_artifacts", "stale_lock"}
         out.append(AttentionItem(
             entity_type="session",
-            entity_id=entry["id"],
+            entity_id=session_id,
             status="running",  # phantom items are still pre-transition
             reason=StatusReason(
                 code=reason_code,
                 summary=_PHANTOM_TO_SUMMARY[entry["reason"]],
                 evidence_refs=[
-                    {"kind": "session", "id": entry["id"]},
+                    {"kind": "session", "id": session_id},
                 ],
             ),
-            fingerprint=f"session:{entry['id']}:{reason_code}",
+            fingerprint=f"session:{session_id}:{reason_code}",
             severity="warning",
         ))
     return out

--- a/docs/adrs/ADR-0031-entity-header-pattern.md
+++ b/docs/adrs/ADR-0031-entity-header-pattern.md
@@ -78,11 +78,21 @@ Pydantic models in `apps/studio/server/schemas/entity_header.py`:
 from typing import Literal, Optional
 from pydantic import BaseModel
 
+# Mirrors ADR-0028's VALID_ENTITY_TYPES plus the library/config kinds
+# the frontend renders headers for. Storage-backed entity kinds
+# (left column) match ADR-0028 exactly; library/config kinds (right
+# column) live on disk and don't participate in status_transitions.
+#
+# `run` is NOT in this list — /runs/<id> is a frontend route over the
+# `session` entity, per ENTITY_ROUTE_ALIASES in ADR-0028.
 EntityKind = Literal[
-    "project", "show", "play", "run", "session",
-    "team", "invocation", "agent", "playbook", "plugin",
-    "schedule", "schedule_run", "chain", "chain_run",
+    # Storage entities (have rows, status, status_reason; see ADR-0028)
+    "session", "show", "play", "invocation", "team", "schedule_run",
+    # Library / config (filesystem-backed; no status_transitions)
+    "project", "agent", "playbook", "plugin", "schedule",
 ]
+
+# Deferred until ADR-0021 (chain_runs) lands: "chain", "chain_run".
 
 ActionKind = Literal["primary", "secondary", "danger"]
 
@@ -90,7 +100,6 @@ ActionId = Literal[
     "open", "inspect", "retry", "prune", "edit", "abort",
     "open_artifacts", "open_logs", "open_workspace",
     "reassign", "snooze", "dismiss",
-    "approve", "reject",          # for chain waiting_approval
     "manual_trigger",              # for schedules
 ]
 
@@ -219,8 +228,12 @@ at no cost.
 
 ```tsx
 // apps/studio/frontend/components/entity/EntityHeader.tsx
-import { StatusPill } from "@/components/status/StatusPill";
-import { StatusReasonTooltip } from "@/components/status/StatusReasonTooltip";
+// StatusPill is the existing component at apps/studio/frontend/components/StatusPill.tsx
+// (default export). ADR-0028 adds a `reason` prop to it; this header
+// passes the prop, NOT a tooltip child, so the API stays consistent
+// with what ADR-0028 specifies and with the current component's
+// prop-based API surface (see apps/studio/frontend/components/StatusPill.tsx:17).
+import StatusPill from "@/components/StatusPill";
 import { ActionButton } from "@/components/entity/ActionButton";
 import type { EntityHeader as TEntityHeader } from "@/lib/types";
 
@@ -229,11 +242,11 @@ export function EntityHeader({ header }: { header: TEntityHeader }) {
     <header className="entity-header">
       <div className="entity-header__title-row">
         <h1>{header.title}</h1>
-        <StatusPill taxonomy={header.status_taxonomy} value={header.status}>
-          {header.status_reason && (
-            <StatusReasonTooltip reason={header.status_reason} />
-          )}
-        </StatusPill>
+        <StatusPill
+          taxonomy={header.status_taxonomy}
+          value={header.status}
+          reason={header.status_reason ?? undefined}
+        />
         {header.next_action && (
           <ActionButton action={header.next_action} prominent />
         )}
@@ -315,9 +328,10 @@ state-to-action mapping in one place.
 ### 5. Graceful degradation when ADR-0028 not landed
 
 If a backend service has not yet been updated to populate
-`status_reason`, the header renders without the reason tooltip — just
-the status pill. The frontend's `<StatusReasonTooltip />` returns
-null when its `reason` prop is undefined. No errors, no broken UI.
+`status_reason`, the header passes `reason={undefined}` to
+`<StatusPill>`. ADR-0028 specifies that the pill renders unchanged
+when `reason` is undefined (no tooltip affordance, no popover). No
+errors, no broken UI.
 
 Per-entity rollout order:
 
@@ -352,7 +366,6 @@ apps/studio/frontend/components/entity/EntityHeader.tsx
 apps/studio/frontend/components/entity/ActionButton.tsx
 apps/studio/frontend/components/entity/EntityOwnerChip.tsx
 apps/studio/frontend/components/entity/EntityRelatedChip.tsx
-apps/studio/frontend/components/status/StatusReasonTooltip.tsx
 apps/studio/frontend/lib/types/entity_header.ts   # mirror Pydantic via TS interfaces
 ```
 
@@ -363,6 +376,7 @@ apps/studio/server/routers/runs.py              # include header on detail
 apps/studio/server/routers/shows.py             # include header on detail
 apps/studio/server/routers/sessions.py          # include header on detail
 apps/studio/server/routers/projects.py          # include header on detail
+apps/studio/frontend/components/StatusPill.tsx  # add `reason` prop (per ADR-0028)
 apps/studio/frontend/app/runs/[id]/page.tsx     # mount EntityHeader
 apps/studio/frontend/app/shows/[topic]/page.tsx # mount EntityHeader
 apps/studio/frontend/app/sessions/[id]/page.tsx # mount EntityHeader
@@ -457,7 +471,7 @@ apps/studio/frontend/app/projects/[name]/page.tsx # mount EntityHeader
 - [ADR-0028](ADR-0028-status-reason-model.md) — `status_reason` field surfaced in tooltip / popover.
 - [ADR-0030](ADR-0030-attention-queue.md) — Reuses `EntityAction` shape and `ActionButton` component.
 - [ADR-0024](ADR-0024-session-health-and-admin-surface.md) — Phantom session reasons feed Session header actions (Prune).
-- `apps/studio/frontend/components/status/StatusPill.tsx` — Existing pill component.
+- `apps/studio/frontend/components/StatusPill.tsx` — Existing pill component (default export; this ADR + ADR-0028 add a `reason` prop).
 - ChatGPT frontend design review (external) — proposed an entity header on every page; this ADR scopes the rollout to four pages first, defers the rest, and pins the `EntityAction` shape so the Attention Queue and entity headers share one descriptor.
 
 ### Prior art

--- a/docs/adrs/ADR-0031-entity-header-pattern.md
+++ b/docs/adrs/ADR-0031-entity-header-pattern.md
@@ -1,0 +1,476 @@
+# ADR-0031: Entity Header Pattern
+
+**Status**: Proposed
+**Date**: 2026-05-23
+**Related**: ADR-0028 (status reasons surfaced in header), ADR-0030 (reuses EntityAction shape)
+
+## Context
+
+Studio's entity detail pages (`/shows/<topic>`, `/runs/<id>`,
+`/projects/<name>`, `/sessions/<id>`, etc.) each tell a different
+story in a different shape. The Run page leads with metric cards. The
+Show page leads with the plan text. The Session page leads with a
+branches table. The Project page is sparse — mostly counts.
+
+This inconsistency is operational debt:
+
+### 1. Operators relearn each page
+
+Every page has its own visual hierarchy. The user has to figure out
+where "current status" is, where "what to do next" is, and where the
+raw evidence sits — separately for each entity type. The cost is not
+the time per page; it's the *cognitive switching cost* between pages
+during triage.
+
+### 2. The "answer in 5 seconds" target is unmet
+
+A well-designed entity page should answer in five seconds:
+
+- What is this thing? (goal / purpose)
+- What state is it in? (status)
+- Why is it in that state? (reason — from ADR-0028)
+- What's the last thing that happened? (last event)
+- What action is available? (primary verb)
+
+Today most pages bury at least three of these. The reviewer crash from
+last week (`session.phantom.process_dead`) required clicking through
+to the branches tab, scrolling logs, and inferring "this needs
+pruning". That inference should be a button.
+
+### 3. Action buttons drift across pages
+
+The Run page has "Open", "Inspect". The Session page has different
+verbs. The Show page has yet others. There is no shared catalogue of
+actions and no shared decision about which actions are enabled in
+which state. A consistent set of action descriptors — owned by the
+backend, rendered by the frontend — is the simplest way to keep
+action vocabulary aligned with entity state semantics.
+
+### 4. The header pattern is the *primitive* the redesign needs
+
+ChatGPT's frontend critique proposes redesigning every page. That is
+many separate decisions. The header is a single primitive that
+provides 60% of the consistency improvement and lets each page-level
+redesign happen incrementally without re-litigating the structure
+each time.
+
+## Decision
+
+Introduce a reusable `EntityHeader` frontend component, backed by a
+backend-computed `header` field included in every entity *detail*
+endpoint response. The backend owns the data shape and action
+eligibility; the frontend owns presentation, confirmation UX, and
+route transitions.
+
+Initial rollout targets four pages: **Show, Run, Project, Session**.
+Other entity pages (Play, Team, Invocation, Schedule, Agent, Playbook,
+Plugin) migrate incrementally.
+
+When ADR-0028 (status reasons) has not yet landed for a particular
+entity type, the header degrades gracefully — it renders the status
+pill alone without a reason tooltip. No blocker dependency.
+
+### 1. Backend `header` field shape
+
+Pydantic models in `apps/studio/server/schemas/entity_header.py`:
+
+```python
+from typing import Literal, Optional
+from pydantic import BaseModel
+
+EntityKind = Literal[
+    "project", "show", "play", "run", "session",
+    "team", "invocation", "agent", "playbook", "plugin",
+    "schedule", "schedule_run", "chain", "chain_run",
+]
+
+ActionKind = Literal["primary", "secondary", "danger"]
+
+ActionId = Literal[
+    "open", "inspect", "retry", "prune", "edit", "abort",
+    "open_artifacts", "open_logs", "open_workspace",
+    "reassign", "snooze", "dismiss",
+    "approve", "reject",          # for chain waiting_approval
+    "manual_trigger",              # for schedules
+]
+
+class EvidenceRef(BaseModel):
+    kind: str
+    id: Optional[str] = None
+    path: Optional[str] = None
+    ref: Optional[str] = None
+    url: Optional[str] = None
+    label: Optional[str] = None
+
+class StatusReasonView(BaseModel):
+    code: str
+    summary: str
+    evidence_refs: list[EvidenceRef] = []
+
+class EntityAction(BaseModel):
+    id: ActionId
+    label: str
+    kind: ActionKind = "secondary"
+    method: Optional[Literal["GET", "POST", "DELETE", "PATCH"]] = None
+    href: Optional[str] = None       # for navigation actions
+    endpoint: Optional[str] = None   # for API actions
+    requires_confirm: bool = False
+    confirm_label: Optional[str] = None   # custom confirm prompt
+    disabled: bool = False
+    disabled_reason: Optional[str] = None
+
+class EntityHeader(BaseModel):
+    kind: EntityKind
+    id: str
+    title: str
+    subtitle: Optional[str] = None
+    goal: Optional[str] = None
+    status: str
+    status_taxonomy: str           # 'session', 'show', 'play', etc. — picks the StatusPill scheme from ADR-0025
+    status_reason: Optional[StatusReasonView] = None
+    status_source: Optional[str] = None   # e.g. shows.status_source from ADR-0011
+    last_event: Optional["LastEvent"] = None
+    next_action: Optional[EntityAction] = None
+    owner: Optional["EntityOwner"] = None
+    related: list["EntityLink"] = []
+    actions: list[EntityAction] = []
+    updated_at: Optional[float] = None
+    created_at: Optional[float] = None
+
+class LastEvent(BaseModel):
+    summary: str
+    at: float
+    actor: Optional[str] = None        # session_id, user, doctor_auto, etc.
+    href: Optional[str] = None
+
+class EntityOwner(BaseModel):
+    kind: Literal["agent", "user", "system"]
+    id: Optional[str] = None
+    label: str
+
+class EntityLink(BaseModel):
+    kind: EntityKind
+    id: str
+    label: str
+    href: str
+```
+
+`next_action` is a duplicate pointer into `actions[]` for emphasis —
+the header renders it prominently. If `next_action` is set, its `id`
+must appear in `actions[]`. The duplication is deliberate: the
+backend declares its judgment about the primary verb, the frontend
+honors it.
+
+### 2. Endpoint contract
+
+Every detail endpoint includes `header` in its response:
+
+```json
+GET /api/shows/sweep
+
+{
+  "header": {
+    "kind": "show",
+    "id": "sweep",
+    "title": "sweep",
+    "subtitle": "marketplace OSS discovery",
+    "goal": "Resolve 81 OSS discovery issues by merging implementations and bug fixes.",
+    "status": "active",
+    "status_taxonomy": "show",
+    "status_reason": {
+      "code": "show.blocked.no_ready_plays",
+      "summary": "All 12 plays are pending; no play has its dependencies resolved.",
+      "evidence_refs": [
+        {"kind": "play", "id": "...", "label": "rust-cleanup"},
+        {"kind": "play", "id": "...", "label": "ci-fixes"}
+      ]
+    },
+    "last_event": {
+      "summary": "Plan committed at sweep/_show.md",
+      "at": 1716517000.0,
+      "actor": "operator"
+    },
+    "next_action": {
+      "id": "edit", "label": "Edit plan", "kind": "primary",
+      "href": "/shows/sweep/plan/edit"
+    },
+    "owner": {"kind": "user", "label": "operator"},
+    "related": [
+      {"kind": "project", "id": "lionagi", "label": "lionagi", "href": "/projects/lionagi"}
+    ],
+    "actions": [
+      {"id": "edit", "label": "Edit plan", "kind": "primary", "href": "..."},
+      {"id": "open_workspace", "label": "Open workspace", "kind": "secondary", "href": "..."},
+      {"id": "abort", "label": "Abort show", "kind": "danger", "endpoint": "/api/shows/sweep/abort", "method": "POST", "requires_confirm": true, "confirm_label": "Abort the sweep show? Pending plays will be cancelled."}
+    ],
+    "updated_at": 1716517300.0,
+    "created_at": 1716000000.0
+  },
+  "plays": [...],
+  ...rest of the existing detail payload
+}
+```
+
+The detail payload itself is unchanged — `header` is *added* alongside
+existing fields. Pages that don't yet render `EntityHeader` ignore it
+at no cost.
+
+### 3. Frontend component
+
+```tsx
+// apps/studio/frontend/components/entity/EntityHeader.tsx
+import { StatusPill } from "@/components/status/StatusPill";
+import { StatusReasonTooltip } from "@/components/status/StatusReasonTooltip";
+import { ActionButton } from "@/components/entity/ActionButton";
+import type { EntityHeader as TEntityHeader } from "@/lib/types";
+
+export function EntityHeader({ header }: { header: TEntityHeader }) {
+  return (
+    <header className="entity-header">
+      <div className="entity-header__title-row">
+        <h1>{header.title}</h1>
+        <StatusPill taxonomy={header.status_taxonomy} value={header.status}>
+          {header.status_reason && (
+            <StatusReasonTooltip reason={header.status_reason} />
+          )}
+        </StatusPill>
+        {header.next_action && (
+          <ActionButton action={header.next_action} prominent />
+        )}
+      </div>
+
+      {header.goal && <p className="entity-header__goal">{header.goal}</p>}
+
+      <div className="entity-header__meta">
+        {header.last_event && <LastEventLine event={header.last_event} />}
+        {header.owner && <OwnerChip owner={header.owner} />}
+        {header.related.map((link) => (
+          <RelatedChip key={link.id} link={link} />
+        ))}
+      </div>
+
+      <div className="entity-header__actions">
+        {header.actions
+          .filter((a) => a.id !== header.next_action?.id)
+          .map((action) => (
+            <ActionButton key={action.id} action={action} />
+          ))}
+      </div>
+    </header>
+  );
+}
+```
+
+The `ActionButton` component (reused from ADR-0030's Attention Queue
+items) handles:
+
+- `href`-only actions → `<a>` / Next.js `Link`
+- `endpoint` + `method` actions → fetch + toast + refresh
+- `requires_confirm` → modal with `confirm_label`
+- `disabled` → grayed out with tooltip showing `disabled_reason`
+
+### 4. Action eligibility — backend decides
+
+Backend computes `actions[]` from entity state. Examples:
+
+```python
+def compute_show_actions(show: ShowRow) -> list[EntityAction]:
+    actions = [
+        EntityAction(id="edit", label="Edit plan", kind="primary",
+                     href=f"/shows/{show.topic}/plan/edit"),
+        EntityAction(id="open_workspace", label="Open workspace",
+                     href=f"/shows/{show.topic}/workspace"),
+    ]
+    if show.status == "active":
+        actions.append(EntityAction(
+            id="abort", label="Abort show", kind="danger",
+            endpoint=f"/api/shows/{show.topic}/abort", method="POST",
+            requires_confirm=True,
+            confirm_label="Abort the show? Pending plays will be cancelled.",
+        ))
+    return actions
+
+def compute_session_actions(s: SessionRow) -> list[EntityAction]:
+    actions = [EntityAction(id="open", label="Open run",
+                            kind="primary", href=f"/runs/{s.id}")]
+    if s.status == "failed" and s.invocation_kind in ("play", "agent"):
+        actions.append(EntityAction(
+            id="retry", label="Retry", kind="secondary",
+            endpoint=f"/api/runs/{s.id}/retry", method="POST",
+        ))
+    if s.status_reason_code and s.status_reason_code.startswith("session.phantom"):
+        actions.append(EntityAction(
+            id="prune", label="Prune", kind="danger",
+            endpoint=f"/api/admin/sessions/{s.id}", method="DELETE",
+            requires_confirm=True,
+            confirm_label="Prune this phantom session? This deletes the session row and any associated artifacts directory.",
+        ))
+    return actions
+```
+
+The frontend never decides "should this entity show a Retry button" —
+it just renders what the backend gave it. This keeps the
+state-to-action mapping in one place.
+
+### 5. Graceful degradation when ADR-0028 not landed
+
+If a backend service has not yet been updated to populate
+`status_reason`, the header renders without the reason tooltip — just
+the status pill. The frontend's `<StatusReasonTooltip />` returns
+null when its `reason` prop is undefined. No errors, no broken UI.
+
+Per-entity rollout order:
+
+1. ADR-0028 columns added (schema migration)
+2. CLI / executor writes reasons for one entity type (say, sessions)
+3. Session detail endpoint includes `status_reason` in its header
+4. Repeat for next entity type
+
+Pages migrate to `EntityHeader` independently of reason rollout. The
+header is useful even with `status_reason = None`.
+
+### 6. Initial rollout: 4 pages
+
+| Page | Existing struct | Why first |
+|---|---|---|
+| **Run detail** (`/runs/<id>`) | Metric cards + tabs | Most-visited; current page hides "why this failed" |
+| **Show detail** (`/shows/<topic>`) | Plan text + plays table | Needs the goal + next-action clarity most |
+| **Session detail** (`/sessions/<id>`) | Branches table | Phantom diagnostics need reason + prune action in the header |
+| **Project detail** (`/projects/<name>`) | Sparse counts | Currently weakest page; header alone gives it shape |
+
+Second iteration: Play, Team, Invocation. Third iteration: Agent,
+Playbook, Plugin, Schedule (library + admin items).
+
+### 7. File map
+
+New files:
+
+```text
+apps/studio/server/schemas/entity_header.py     # Pydantic models
+apps/studio/server/services/entity_header.py    # compute_*_header() per entity
+apps/studio/frontend/components/entity/EntityHeader.tsx
+apps/studio/frontend/components/entity/ActionButton.tsx
+apps/studio/frontend/components/entity/EntityOwnerChip.tsx
+apps/studio/frontend/components/entity/EntityRelatedChip.tsx
+apps/studio/frontend/components/status/StatusReasonTooltip.tsx
+apps/studio/frontend/lib/types/entity_header.ts   # mirror Pydantic via TS interfaces
+```
+
+Modified files:
+
+```text
+apps/studio/server/routers/runs.py              # include header on detail
+apps/studio/server/routers/shows.py             # include header on detail
+apps/studio/server/routers/sessions.py          # include header on detail
+apps/studio/server/routers/projects.py          # include header on detail
+apps/studio/frontend/app/runs/[id]/page.tsx     # mount EntityHeader
+apps/studio/frontend/app/shows/[topic]/page.tsx # mount EntityHeader
+apps/studio/frontend/app/sessions/[id]/page.tsx # mount EntityHeader
+apps/studio/frontend/app/projects/[name]/page.tsx # mount EntityHeader
+```
+
+## Consequences
+
+**Positive**
+
+- Every adopted page answers "what / status / why / last / next /
+  evidence" in the same place, with the same component, styled the
+  same way.
+
+- Backend-computed `actions[]` keeps state-to-action eligibility in
+  one place per entity, not duplicated across pages.
+
+- `ActionButton` and `EntityAction` are reused by ADR-0030's Attention
+  Queue — one descriptor shape, two consumers.
+
+- Migration is per-page, not big-bang. Pages without the header keep
+  working; pages with the header look consistent.
+
+- Graceful degradation when ADR-0028 hasn't reached a given entity
+  type — the header renders the status pill alone. No blocker
+  dependency.
+
+- Frontend stays a renderer. Adding a new entity-type page in the
+  future means writing one `compute_<entity>_header()` function and
+  mounting `<EntityHeader />`.
+
+**Negative**
+
+- Adds a backend-computed payload to every detail response. For the
+  initial 4 endpoints this is a few hundred bytes; negligible.
+
+- Pages in transition will look inconsistent — half have the header,
+  half don't. Acceptable for a few weeks of rollout.
+
+- The `EntityAction` enum (`ActionId`) is a closed set in v1.
+  Adding a new action verb is a backend + frontend change. Trade-off:
+  open string would mean drift. Closed set keeps the action vocabulary
+  curated.
+
+- Backend has to know about routes (`href: "/runs/<id>"`). This
+  couples server logic to frontend URL structure. The mitigation: a
+  single `apps/studio/server/services/routes.py` module that owns the
+  route mapping, used by every `compute_*_header()`.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|---|---|
+| Compute the header entirely client-side from existing fields | Duplicates business logic. The frontend would have to know what `status='gate_failed' AND attempt=2` means and which actions to offer — that's domain semantics, not presentation. |
+| New `GET /api/entities/<kind>/<id>/header` endpoint | Forces two round trips per page (header + detail). Embedding `header` in the existing detail endpoint costs nothing extra and removes the loading-state coordination problem. |
+| Hardcode action buttons per page component | What we have today. Drift is inevitable. The whole reason for this ADR. |
+| Redesign every entity page in one iteration | Too much surface in one PR; couples the primitive's design to every page's design simultaneously. Per-page rollout is safer. |
+| Use a generic CRUD framework (e.g., react-admin) | Wrong shape — Studio's entities are not CRUD records, they are operational state. The header is curated, not generated from a schema. |
+| Server-rendered HTML for the header (skip the API field) | Mixes server-rendered HTML into a Next.js client-rendered app. Would need a separate render path and break SSR consistency. |
+| Skip the `next_action` duplication, derive in frontend ("first primary action wins") | Loses backend's ability to pick a *contextual* primary action that isn't always position-0. Cheap to keep both. |
+
+## Non-Goals
+
+- **No role-specific layouts.** Studio is single-user (ADR-0008). When
+  multi-user becomes a goal, role-specific defaults can plug into the
+  same `EntityHeader` via props.
+
+- **No general redesign of entity pages.** This ADR adds a header, not
+  a page redesign. Tabs, tables, log panels, raw markdown viewers all
+  stay where they are.
+
+- **No hiding of raw internals.** The header sits on top; existing
+  internals stay accessible below it. Studio's users are technical;
+  hiding state is the wrong move.
+
+- **No header on list pages.** `EntityHeader` is for detail pages. List
+  rows have their own (much smaller) summary chip rendered by a
+  separate component.
+
+- **No theming / customization of action verbs by users.** Action
+  vocabulary is fixed; localization is out of scope for v1.
+
+- **No undo for executed actions.** Confirmations are the only safety
+  net. Undo is a separate, larger design.
+
+- **No keyboard shortcuts on headers in v1.** Command palette /
+  shortcuts are deferred per ADR-0032's non-goal list.
+
+## References
+
+- [ADR-0025](ADR-0025-session-status-vocabulary.md) — `StatusPill` component (reused via `status_taxonomy`).
+- [ADR-0028](ADR-0028-status-reason-model.md) — `status_reason` field surfaced in tooltip / popover.
+- [ADR-0030](ADR-0030-attention-queue.md) — Reuses `EntityAction` shape and `ActionButton` component.
+- [ADR-0024](ADR-0024-session-health-and-admin-surface.md) — Phantom session reasons feed Session header actions (Prune).
+- `apps/studio/frontend/components/status/StatusPill.tsx` — Existing pill component.
+- ChatGPT frontend design review (external) — proposed an entity header on every page; this ADR scopes the rollout to four pages first, defers the rest, and pins the `EntityAction` shape so the Attention Queue and entity headers share one descriptor.
+
+### Prior art
+
+- **Stripe Dashboard entity headers** — every object (Customer,
+  Payment, Subscription) has a top-of-page header with object id,
+  status pill, primary action button, last event line, related links.
+  The pattern is so consistent that operators can scan an unfamiliar
+  object type and orient in seconds. Direct visual influence.
+
+- **GitHub Issue header** — title + status pill (open/closed/merged)
+  - primary action (close/reopen) + assignees + labels — same shape,
+  same intent. The header is the page; everything below is evidence.
+
+- **Linear ticket detail** — header with title, status, owner,
+  related cycle/project links, then the body below. Same model.

--- a/docs/adrs/ADR-0032-navigation-reorganization.md
+++ b/docs/adrs/ADR-0032-navigation-reorganization.md
@@ -6,18 +6,23 @@
 
 ## Context
 
-Studio's top navigation currently lists ten entity types as siblings
-at the same visual weight:
+Studio's top navigation today lists ten entity types as siblings at
+the same visual weight (see `apps/studio/frontend/components/Shell.tsx:15`):
 
 ```text
-Dashboard | Projects | Schedules | Playbooks | Agents | Plugins | Shows | Invocations | Runs | Teams | Admin
+Projects | Schedules | Playbooks | Agents | Plugins | Shows | Invocations | Runs | Teams | Admin
 ```
+
+There is no `Dashboard` entry in the live nav — `/` renders the
+dashboard, but it is reachable only via the project chip or by
+typing the URL.
 
 This mirrors the backend ontology accurately. But operationally, the
 ten items are not equivalent — they answer different questions and are
 visited at different cadences. The current flat structure gives
 "Plugins" (browsed weekly) the same visual prominence as "Runs"
-(opened many times per day). The cost is scan time on every page load.
+(opened many times per day). The cost is scan time on every page load,
+plus the dashboard's invisibility.
 
 ### 1. Flat nav is not grouped by intent
 
@@ -123,29 +128,40 @@ Breadcrumbs above the page content show `Group › Section › Item`
 (e.g., `Work › Runs › e288a6e2493f`), giving an always-visible "where
 am I" that the flat nav currently lacks.
 
-### 3. Routes stay stable
+### 3. Route changes
 
-Direct URLs are unchanged:
+Most direct URLs are unchanged; two need transitions:
 
-| URL | Group | Old nav | New nav |
-|---|---|---|---|
-| `/` | Dashboard | Dashboard | Dashboard |
-| `/projects` | (selector) | Projects | Project chip (top-right) |
-| `/shows` | Work | Shows | Work › Shows |
-| `/shows/<topic>` | Work | (deep) | Work › Shows › `<topic>` |
-| `/runs` | Work | Runs | Work › Runs |
-| `/runs/<id>` | Work | (deep) | Work › Runs › `<id>` |
-| `/teams` | Work | Teams | Work › Teams |
-| `/invocations` | Work | Invocations | Work › Invocations |
-| `/schedules` | Work | Schedules | Work › Schedules |
-| `/playbooks` | Library | Playbooks | Library › Playbooks |
-| `/agents` | Library | Agents | Library › Agents |
-| `/plugins` | Library | Plugins | Library › Plugins |
-| `/skills` | Library | (none — new) | Library › Skills |
-| `/admin/health` | Admin | Admin | Admin › Health |
-| `/admin/maintenance` | Admin | (under Admin) | Admin › Maintenance |
+| URL | Group | Old reachability | New nav | Migration |
+|---|---|---|---|---|
+| `/` | Dashboard | URL-only, no nav | Dashboard (now visible in nav) | — |
+| `/projects` | (selector) | top nav | Project chip + popover; full list reachable via "View all projects" | — |
+| `/shows` | Work | top nav | Work › Shows | — |
+| `/shows/<topic>` | Work | (deep) | Work › Shows › `<topic>` | — |
+| `/runs` | Work | top nav | Work › Runs | — |
+| `/runs/<id>` | Work | (deep) | Work › Runs › `<id>` | — |
+| `/teams` | Work | top nav | Work › Teams | — |
+| `/invocations` | Work | top nav | Work › Invocations | — |
+| `/schedules` | Work | top nav | Work › Schedules | — |
+| `/playbooks` | Library | top nav | Library › Playbooks | — |
+| `/agents` | Library | top nav | Library › Agents | — |
+| `/plugins` | Library | top nav | Library › Plugins | — |
+| `/skills` | Library | exists (`apps/studio/frontend/app/skills/page.tsx`) but not in top nav | Library › Skills | promote to nav |
+| `/admin` | — | top nav lands at combined page | replaced | **301** → `/admin/health` for one release |
+| `/admin/health` | Admin | (new) | Admin › Health | new route (extracted from `/admin`) |
+| `/admin/maintenance` | Admin | (new) | Admin › Maintenance | new route (extracted from `/admin`) |
 
-No 301 redirects needed. Routes are untouched.
+Two real route changes:
+
+1. **`/admin` splits.** The combined page becomes two routes
+   (`/admin/health` and `/admin/maintenance`). A 301 redirect from
+   `/admin` → `/admin/health` lives in `next.config.mjs` for one
+   release; the redirect can be removed in the release after.
+2. **`/skills` becomes nav-promoted.** The page already exists, so
+   this is not a new route — only a nav visibility change.
+
+All other URLs are byte-stable. Bookmarks and CLI URL output continue
+to work without changes.
 
 ### 4. Projects: chip, not nav item
 
@@ -166,18 +182,18 @@ This matches the operator mental model: project is *context*, not
 *navigation*. You don't navigate *to* a project — you work within a
 project and navigate to its work / library / admin.
 
-### 5. Skills added under Library
+### 5. Skills promoted to nav-level
 
-`/skills` becomes a new surface listing individual skill files from
-the marketplace plugins. Currently skills are only reachable via
+`/skills` already exists as a page (`apps/studio/frontend/app/skills/page.tsx`)
+but is not currently reachable from the top nav — users find skills via
 `/plugins/<name>` detail pages. Promoting Skills to a sibling of
 Plugins matches the user mental model (skills are the thing they
 invoke; plugins are the delivery mechanism).
 
-The Skills list is read-only in v1 — it points to the underlying
-`SKILL.md` files in `~/.claude/plugins/` and the marketplace
-directory. CRUD is owned by the marketplace plugin tooling, not
-Studio.
+This ADR is a nav change, not a new page. The existing Skills list
+keeps its current behaviour (read-only listing of `SKILL.md` files
+from `~/.claude/plugins/` and the marketplace directory). CRUD is
+owned by the marketplace plugin tooling, not Studio.
 
 ### 6. Admin: separate Health from Maintenance
 
@@ -244,10 +260,14 @@ renders SKILL.md frontmatter — similar to the existing Playbooks page.
   Linear, Stripe) and frees the top nav for *what to do*, not *whose
   project you're in*.
 
-- Skills become a discoverable surface for the first time.
+- Skills become discoverable in the nav for the first time (the page
+  itself already exists).
+
 - No backend changes; entirely a frontend reshuffle.
-- Direct URLs stay stable — bookmarks, deep links, and existing CLI
-  output that prints URLs all continue to work.
+
+- Most direct URLs are byte-stable. The only exception is `/admin`,
+  which 301-redirects to `/admin/health` for one release before being
+  removed. Bookmarks and CLI URL output continue to work.
 
 **Negative**
 

--- a/docs/adrs/ADR-0032-navigation-reorganization.md
+++ b/docs/adrs/ADR-0032-navigation-reorganization.md
@@ -228,11 +228,18 @@ apps/studio/frontend/components/nav/TopNav.tsx          # group structure
 apps/studio/frontend/components/nav/NavGroup.tsx        # new: group with submenu
 apps/studio/frontend/components/nav/ProjectChip.tsx     # new: top-right chip
 apps/studio/frontend/components/nav/Breadcrumb.tsx      # new: above page content
-apps/studio/frontend/app/layout.tsx                     # nav composition
-apps/studio/frontend/app/admin/page.tsx                 # split into health/maintenance
-apps/studio/frontend/app/admin/maintenance/page.tsx     # new (extracted)
-apps/studio/frontend/app/skills/page.tsx                # new
 apps/studio/frontend/components/nav/types.ts            # NavGroup, NavItem types
+apps/studio/frontend/components/Shell.tsx               # consume new nav structure
+apps/studio/frontend/app/layout.tsx                     # nav composition
+apps/studio/frontend/app/admin/page.tsx                 # delete: replaced by 301
+apps/studio/frontend/app/admin/health/page.tsx          # new: extracted health view
+apps/studio/frontend/app/admin/maintenance/page.tsx     # new: extracted maintenance view
+apps/studio/frontend/app/skills/page.tsx                # existing — no code change,
+                                                        # only nav-level promotion
+apps/studio/frontend/next.config.mjs                    # add 301 redirect:
+                                                        #   /admin -> /admin/health
+                                                        # (remove the redirect one
+                                                        #  release later)
 ```
 
 No backend changes.

--- a/docs/adrs/ADR-0032-navigation-reorganization.md
+++ b/docs/adrs/ADR-0032-navigation-reorganization.md
@@ -1,0 +1,330 @@
+# ADR-0032: Navigation Reorganization
+
+**Status**: Proposed
+**Date**: 2026-05-23
+**Related**: ADR-0031 (entity header pattern lands inside this nav structure)
+
+## Context
+
+Studio's top navigation currently lists ten entity types as siblings
+at the same visual weight:
+
+```text
+Dashboard | Projects | Schedules | Playbooks | Agents | Plugins | Shows | Invocations | Runs | Teams | Admin
+```
+
+This mirrors the backend ontology accurately. But operationally, the
+ten items are not equivalent — they answer different questions and are
+visited at different cadences. The current flat structure gives
+"Plugins" (browsed weekly) the same visual prominence as "Runs"
+(opened many times per day). The cost is scan time on every page load.
+
+### 1. Flat nav is not grouped by intent
+
+The user thinks in workflows: *check the queue → open a failing run →
+inspect the show that spawned it → maybe edit a playbook*. Not:
+*navigate to the seventh item in the bar*. Grouping by operational
+intent (work / library / admin) lets the operator predict where to
+click without reading every label.
+
+### 2. Schedules is mis-located if we keep flat nav
+
+`Schedules` was added in ADR-0027 as a CRUD page for cron / interval /
+github-poll triggers that fire agent runs. Schedules belong with
+*work* (they create work) — not with *admin* (DB health, prune,
+vacuum). The current flat nav doesn't force a decision; a grouped nav
+does.
+
+### 3. "Observability" looks tempting but is a junk drawer today
+
+The ChatGPT review proposed an `Observability` top-level group for
+logs, traces, metrics, artifacts. Studio has none of these as
+first-class surfaces yet. Traces are not modelled; logs live on
+individual runs; metrics are inline on the dashboard; artifacts are
+already split between `runs/<id>/artifacts/` and the `artifacts`
+table (ADR-0021). Creating an `Observability` group now would either
+be empty or would silo features that already live (correctly) on
+their parent entity. Defer.
+
+### 4. Power users still need direct URLs
+
+The current routes (`/runs`, `/shows`, `/schedules`, ...) are stable
+and bookmarkable. A nav redesign must not change the underlying
+routes — only how they are *grouped* in the menu.
+
+## Decision
+
+Replace the flat top nav with a four-group structure:
+
+```text
+Dashboard | Work ▾ | Library ▾ | Admin ▾
+```
+
+| Group | Contents |
+|---|---|
+| **Dashboard** | (single page, no submenu) |
+| **Work** | Shows, Runs, Teams, Invocations, Schedules |
+| **Library** | Playbooks, Agents, Plugins, Skills |
+| **Admin** | Health, Maintenance |
+
+`Observability` is *not* created. `Projects` is the project selector
+(top-right or persistent global filter), not a nav item — see Section
+4.
+
+### 1. Group rationale
+
+**Dashboard**: single most-visited surface. Stays at the top level.
+This is where the Attention Queue (ADR-0030) lives.
+
+**Work**: things currently happening or recently happened.
+
+- *Shows* — orchestrated multi-play workflows
+- *Runs* — individual agent runs / sessions
+- *Teams* — collaborative multi-agent sessions
+- *Invocations* — skill-level groupings of runs
+- *Schedules* — definitions that produce future runs (ADR-0027). They
+  belong here because their output *is* work. The contrast: pruning
+  is admin; producing is work.
+
+**Library**: capabilities, not instances. Browse-mode surfaces.
+
+- *Playbooks* — reusable orchestration definitions
+- *Agents* — reusable agent role profiles
+- *Plugins* — marketplace plugins
+- *Skills* — individual skill files from plugins
+
+**Admin**: maintenance and system health. Lower frequency, higher
+consequence.
+
+- *Health* — DB health, phantom sessions, WAL pressure
+- *Maintenance* — checkpoint, vacuum, prune, classify
+
+### 2. Visual treatment
+
+The four groups render as top-level menu items with hover-to-expand
+submenus (or click-to-expand on touch devices). The current `tabs +
+icon` layout is replaced with a thinner nav row:
+
+```text
+┌─ Dashboard ─ Work ▾ ─ Library ▾ ─ Admin ▾ ─────────── [project: lionagi ▾] ─ [≡]
+│
+│  (Page header / breadcrumb here, e.g. Work › Shows › sweep)
+│
+│  page content...
+```
+
+Submenu items reveal on hover (200ms delay) or click. The expanded
+group is highlighted, the current page is bolded. The visual styling
+otherwise matches the existing nav (same fonts, same colors, same
+icons per item — borrowed from ADR-0025's color tokens for the
+hover-active states).
+
+Breadcrumbs above the page content show `Group › Section › Item`
+(e.g., `Work › Runs › e288a6e2493f`), giving an always-visible "where
+am I" that the flat nav currently lacks.
+
+### 3. Routes stay stable
+
+Direct URLs are unchanged:
+
+| URL | Group | Old nav | New nav |
+|---|---|---|---|
+| `/` | Dashboard | Dashboard | Dashboard |
+| `/projects` | (selector) | Projects | Project chip (top-right) |
+| `/shows` | Work | Shows | Work › Shows |
+| `/shows/<topic>` | Work | (deep) | Work › Shows › `<topic>` |
+| `/runs` | Work | Runs | Work › Runs |
+| `/runs/<id>` | Work | (deep) | Work › Runs › `<id>` |
+| `/teams` | Work | Teams | Work › Teams |
+| `/invocations` | Work | Invocations | Work › Invocations |
+| `/schedules` | Work | Schedules | Work › Schedules |
+| `/playbooks` | Library | Playbooks | Library › Playbooks |
+| `/agents` | Library | Agents | Library › Agents |
+| `/plugins` | Library | Plugins | Library › Plugins |
+| `/skills` | Library | (none — new) | Library › Skills |
+| `/admin/health` | Admin | Admin | Admin › Health |
+| `/admin/maintenance` | Admin | (under Admin) | Admin › Maintenance |
+
+No 301 redirects needed. Routes are untouched.
+
+### 4. Projects: chip, not nav item
+
+`/projects` becomes the project list page (existing), but the *nav
+slot* it currently occupies disappears. The active project is
+represented as a chip in the top-right corner of the nav bar:
+
+```text
+[project: lionagi ▾]
+```
+
+Clicking the chip opens a project switcher (popover with project
+list + "View all projects" link to `/projects`). The chosen project
+becomes a global filter applied to list pages (`/runs`, `/shows`,
+etc.).
+
+This matches the operator mental model: project is *context*, not
+*navigation*. You don't navigate *to* a project — you work within a
+project and navigate to its work / library / admin.
+
+### 5. Skills added under Library
+
+`/skills` becomes a new surface listing individual skill files from
+the marketplace plugins. Currently skills are only reachable via
+`/plugins/<name>` detail pages. Promoting Skills to a sibling of
+Plugins matches the user mental model (skills are the thing they
+invoke; plugins are the delivery mechanism).
+
+The Skills list is read-only in v1 — it points to the underlying
+`SKILL.md` files in `~/.claude/plugins/` and the marketplace
+directory. CRUD is owned by the marketplace plugin tooling, not
+Studio.
+
+### 6. Admin: separate Health from Maintenance
+
+The Admin page today bundles DB health (size, WAL, phantom sessions)
+with maintenance actions (prune, checkpoint, vacuum) on one screen.
+Split:
+
+- `/admin/health` — read-only view of current system state
+- `/admin/maintenance` — actions that mutate state (with
+  confirmations per ADR-0031's `EntityAction.requires_confirm`)
+
+The split clarifies which surface is "look" vs "act". Today the bundle
+makes routine inspection feel risky (the prune button is right there).
+
+### 7. Mobile / narrow-viewport behavior
+
+The nav collapses into a hamburger menu (`≡`) on viewports under
+768px. The four groups become a vertical accordion in the drawer.
+This matches the existing dashboard responsive breakpoint.
+
+This is not a fully-designed mobile experience — Studio is
+desktop-first (ADR-0008 §"Studio v1 scope"). The hamburger ensures
+nothing is *unreachable* on a narrow viewport, not that the
+experience is delightful.
+
+### 8. File map
+
+Modified files:
+
+```text
+apps/studio/frontend/components/nav/TopNav.tsx          # group structure
+apps/studio/frontend/components/nav/NavGroup.tsx        # new: group with submenu
+apps/studio/frontend/components/nav/ProjectChip.tsx     # new: top-right chip
+apps/studio/frontend/components/nav/Breadcrumb.tsx      # new: above page content
+apps/studio/frontend/app/layout.tsx                     # nav composition
+apps/studio/frontend/app/admin/page.tsx                 # split into health/maintenance
+apps/studio/frontend/app/admin/maintenance/page.tsx     # new (extracted)
+apps/studio/frontend/app/skills/page.tsx                # new
+apps/studio/frontend/components/nav/types.ts            # NavGroup, NavItem types
+```
+
+No backend changes.
+
+### 9. Effort
+
+One PR, 1-2 days. The Skills page is the only net-new surface; it's a
+file-listing component that reads from the marketplace directory and
+renders SKILL.md frontmatter — similar to the existing Playbooks page.
+
+## Consequences
+
+**Positive**
+
+- Operators scan a 4-item top bar instead of an 11-item bar. The
+  cognitive scan cost drops on every page navigation.
+
+- Schedules sits with its operational siblings (Runs, Shows) instead
+  of among system maintenance.
+
+- Admin splits cleanly into "look" (Health) and "act" (Maintenance),
+  reducing accidental-click risk on the maintenance actions.
+
+- The project chip pattern matches industry convention (GitHub,
+  Linear, Stripe) and frees the top nav for *what to do*, not *whose
+  project you're in*.
+
+- Skills become a discoverable surface for the first time.
+- No backend changes; entirely a frontend reshuffle.
+- Direct URLs stay stable — bookmarks, deep links, and existing CLI
+  output that prints URLs all continue to work.
+
+**Negative**
+
+- Hover-expand submenus are a new interaction on Studio. Need to
+  ensure click-to-expand also works (accessibility, touch devices).
+
+- The breadcrumb adds a row of vertical pixels above every page.
+  Roughly 24px taller content area on every page. Acceptable.
+
+- The four-group taxonomy is opinionated. Some users might want
+  Schedules in Admin or Invocations in its own slot. The grouping is
+  reversible — promote / demote a section if usage data shows it's
+  wrong.
+
+- Splitting Admin requires URL changes for `/admin` → `/admin/health`
+  - `/admin/maintenance`. Old `/admin` URL needs a redirect to
+  `/admin/health` for one release.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|---|---|
+| Keep the flat nav | Maximum object visibility, worst scan cost. The whole reason this ADR exists. |
+| Add `Observability` as a fifth group | Junk drawer until traces/logs/events are first-class. Better to wait. |
+| Put Schedules under Admin | Schedules produce *work*; Admin should stay focused on system maintenance. Schedules are operationally closer to Shows than to Vacuum. |
+| Keep `Projects` as a nav item | Project is context, not navigation. The chip pattern (top-right) matches user mental model and frees the top bar. |
+| Five groups: Dashboard / Work / Library / Observability / Admin | Premature; see above. |
+| Role-specific nav (Operator / Author / Admin views) | Studio is single-user (ADR-0008). All roles inhabit one person. Defer. |
+| Hide low-traffic pages entirely | Power users need direct access. Hidden ≠ removed; hiding makes them harder to reach without removing the surface area. |
+| Sidebar nav instead of top nav | Sidebar takes 200px of horizontal real estate permanently. The four-group top nav fits in a 56px row and leaves the page width unconstrained. |
+| Drop submenus, use one click to a group landing page | Two-click navigation to reach any list. Submenus give one-click access while preserving the group as a meaningful container (the landing page exists too — `/work` could show the work overview). |
+
+## Non-Goals
+
+- **No command palette in v1.** Keyboard-driven navigation (`Cmd+K`)
+  is a separate, larger design. Defer.
+
+- **No saved views / filtering UI.** "My failed runs", "schedules I
+  own", etc. — deferred until the basic structure is in place.
+
+- **No customizable nav.** Operators cannot rearrange groups or pin
+  items in v1.
+
+- **No notification badges on nav items.** Attention Queue surfaces
+  counts; nav stays clean.
+
+- **No tabs within the page header above the breadcrumb.** Existing
+  page-level tabs (e.g., `Summary / Timeline / Artifacts` on Run
+  detail) stay intact below the breadcrumb.
+
+- **No multi-project filtering.** The project chip selects exactly
+  one project at a time (matches existing `/api/...?project=X`
+  filter behavior).
+
+- **No mobile-first redesign.** Mobile gets a working hamburger; the
+  desktop layout is the primary target.
+
+## References
+
+- [ADR-0008](ADR-0008-studio-v1-scope.md) — Studio is single-user, desktop-first.
+- [ADR-0026](ADR-0026-project-detection.md) — Project is per-session context; the chip pattern matches this model.
+- [ADR-0027](ADR-0027-scheduled-runs.md) — Schedules feature being relocated under Work.
+- [ADR-0030](ADR-0030-attention-queue.md) — Attention Queue lives at the top of the Dashboard.
+- [ADR-0031](ADR-0031-entity-header-pattern.md) — Entity headers render inside the page body, below the breadcrumb.
+- ChatGPT frontend design review (external) — proposed the 4-group structure; this ADR adopts it with the Observability deferral, project-as-chip, and Admin split.
+
+### Prior art
+
+- **GitHub navigation** (`Code / Issues / Pull requests / Actions /
+  Projects / Wiki / Security / Insights / Settings`) — nine top-level
+  items, but visually grouped by frequency. Studio's four-group
+  approach achieves the same end with less width.
+
+- **Linear navigation** — left sidebar with `Inbox / My Issues /
+  Active / Backlog` (work) and `Views / Projects / Members` (library).
+  Same intent split.
+
+- **Stripe Dashboard** — `Home / Payments / Customers / Products /
+  Reports / More` with a workspace switcher chip in the top-right.
+  Direct precedent for the project chip pattern.


### PR DESCRIPTION
## Summary

Five ADRs proposing the foundational primitives for the Studio frontend overhaul. Grounded in the existing schema (`lionagi/state/schema.sql`), ADR-0021 `artifacts` table, ADR-0024 health classifier, and ADR-0025 status vocabulary.

| ADR | Title | Dependencies |
|---|---|---|
| 0028 | Status Reason Model | foundational |
| 0029 | Artifact Contract | foundational, independent of 0028 |
| 0030 | Attention Queue | depends on 0028 |
| 0031 | Entity Header Pattern | shares EntityAction with 0030 |
| 0032 | Navigation Reorganization | pure frontend, no deps |

### ADR-0028 — Status Reason Model
Two-layer: denormalized `status_reason_code/summary/evidence_refs` columns on six status-bearing entity tables (hot path) plus `status_transitions` table (cold path). Python-validated reason code namespace in `lionagi/state/reasons.py`. Single `update_status()` write point with transactional consistency. Executor canonicalizes; agents emit hints.

### ADR-0029 — Artifact Contract
Declarative expected artifacts in playbook YAML and agent-profile frontmatter. Resolved + snapshotted onto session at start. Verified at teardown against `sessions.artifacts_path` using `_safe_join()` that rejects absolute paths / `..` / globs. Missing required overrides clean exit → `failed` with reason `run.failed.missing_artifact`. Leverages existing `artifacts` table.

### ADR-0030 — Attention Queue
Single `GET /api/attention` endpoint aggregating runs/plays/shows/sessions/schedule_runs by status × reason_code. Server-side severity scoring. Fingerprint-based snooze/dismiss in `attention_dismissals` table with `status_at_dismissal` for read-time invalidation. Polling refresh in v1. Clusters by reason_code across entity types. Live phantom items derived from `admin_service.list_phantom_sessions()`.

### ADR-0031 — Entity Header Pattern
Reusable `EntityHeader` component backed by backend-computed header payload on detail endpoints. Pydantic models for `EntityHeader`, `EntityAction`, `StatusReasonView`. Initial rollout: Show, Run, Session, Project. Graceful degradation when 0028 not yet landed. `EntityAction` shape reused by ADR-0030 queue items. `StatusPill` gains a `reason` prop.

### ADR-0032 — Navigation Reorganization
Dashboard / Work / Library / Admin grouping. Schedules under Work (they produce work). Projects as top-right chip (not nav item). Admin split into Health vs Maintenance. No Observability tab yet. `/admin` → `/admin/health` 301 redirect for one release; all other routes stable.

## Suggested merge order

1. ADR-0028 and ADR-0029 in parallel (independent foundations)
2. ADR-0031 alongside 0028 (graceful degradation built in)
3. ADR-0030 after 0028 (otherwise queue is inline heuristics)
4. ADR-0032 any time (no dependencies)

## Test plan

- [ ] Review each ADR for internal consistency and groundedness in the existing codebase
- [ ] Validate that ADR-0029 doesn't conflict with ADR-0021's `artifacts` table semantics
- [ ] Confirm ADR-0028's reason code namespace covers the phantom-session reasons from ADR-0024
- [ ] Confirm ADR-0030's severity heuristic table matches operational reality
- [ ] Confirm ADR-0031's initial 4-page rollout (Show/Run/Session/Project) is the right set
- [ ] Confirm ADR-0032's nav grouping doesn't strand any current page