### PR TITLE
feat: ADR-0029 Artifact Contract — declarative outputs + teardown verifier

### DIFF
--- a/apps/studio/frontend/app/runs/[id]/page.tsx
+++ b/apps/studio/frontend/app/runs/[id]/page.tsx
@@ -4,6 +4,7 @@ import dynamic from "next/dynamic";
 import Link from "next/link";
 import { use, useEffect, useMemo, useRef, useState } from "react";
 import Badge from "@/components/Badge";
+import ExpectedArtifacts from "@/components/runs/ExpectedArtifacts";
 import RunStepCard from "@/components/RunStepCard";
 import { getSession, streamSession } from "@/lib/api";
 import type { SessionDetail, SessionBranch, SessionMessage } from "@/lib/api";
@@ -527,7 +528,12 @@ export default function RunDetailPage({ params }: { params: Promise<{ id: string
           | null
           | undefined;
         if (graph && graph.nodes && graph.nodes.length > 0) {
-          setRunGraph({ name: s.name || id, description: "", nodes: graph.nodes, edges: graph.edges });
+          setRunGraph({
+            name: s.name || id,
+            description: "",
+            nodes: graph.nodes,
+            edges: graph.edges,
+          });
         }
       })
       .catch((e: unknown) => setError(String(e)));
@@ -589,7 +595,7 @@ export default function RunDetailPage({ params }: { params: Promise<{ id: string
 
   // Track active section on scroll
   useEffect(() => {
-    const sectionIds = ["overview", "dag", "branches", "errors", "files"];
+    const sectionIds = ["overview", "expected-artifacts", "dag", "branches", "errors", "files"];
     const onScroll = () => {
       for (const sid of [...sectionIds].reverse()) {
         const el = document.getElementById(sid);
@@ -617,9 +623,24 @@ export default function RunDetailPage({ params }: { params: Promise<{ id: string
 
   // Segments from session metadata — maps op executions to branch time windows
   const segments = useMemo(() => {
-    if (!session) return [] as Array<{ op_id: string; branch_id: string; branch_name: string; status: string; started_at: number | null; ended_at: number | null }>;
+    if (!session)
+      return [] as Array<{
+        op_id: string;
+        branch_id: string;
+        branch_name: string;
+        status: string;
+        started_at: number | null;
+        ended_at: number | null;
+      }>;
     const raw = (session as unknown as Record<string, unknown>).segments;
-    return (Array.isArray(raw) ? raw : []) as Array<{ op_id: string; branch_id: string; branch_name: string; status: string; started_at: number | null; ended_at: number | null }>;
+    return (Array.isArray(raw) ? raw : []) as Array<{
+      op_id: string;
+      branch_id: string;
+      branch_name: string;
+      status: string;
+      started_at: number | null;
+      ended_at: number | null;
+    }>;
   }, [session]);
 
   const steps = useMemo(() => {
@@ -641,7 +662,11 @@ export default function RunDetailPage({ params }: { params: Promise<{ id: string
             const before = seg.ended_at == null || ts <= seg.ended_at + 1;
             return after && before;
           });
-          const segBranch = { ...b, messages: segMsgs, name: `${b.name || b.id.slice(0, 8)} [${seg.op_id}]` };
+          const segBranch = {
+            ...b,
+            messages: segMsgs,
+            name: `${b.name || b.id.slice(0, 8)} [${seg.op_id}]`,
+          };
           result.push(branchToRunStep(segBranch, seg.status || bStatus || sessionStatus));
         }
       }
@@ -751,8 +776,12 @@ export default function RunDetailPage({ params }: { params: Promise<{ id: string
       | undefined,
   };
 
+  const expectedArtifactsCount = session.artifact_contract_json?.expected?.length ?? 0;
   const navSections: NavSection[] = [
     { id: "overview", label: "Overview" },
+    ...(expectedArtifactsCount > 0
+      ? [{ id: "expected-artifacts", label: "Expected artifacts", count: expectedArtifactsCount }]
+      : []),
     ...(runGraph ? [{ id: "dag", label: "DAG", count: runGraph.nodes.length }] : []),
     { id: "branches", label: "Branches", count: session.branches.length },
     { id: "errors", label: "Errors", count: errors.length, errorTone: errors.length > 0 },
@@ -834,6 +863,10 @@ export default function RunDetailPage({ params }: { params: Promise<{ id: string
         <main className="min-w-0 flex-1">
           <div className="flex flex-col gap-8">
             <OverviewSection data={overviewData} />
+            <ExpectedArtifacts
+              contract={session.artifact_contract_json}
+              verification={session.artifact_verification_json}
+            />
             {runGraph && (
               <div id="dag" className="scroll-mt-24">
                 <SectionHeader label="Execution DAG" count={runGraph.nodes.length} />

--- a/apps/studio/frontend/components/runs/ExpectedArtifacts.tsx
+++ b/apps/studio/frontend/components/runs/ExpectedArtifacts.tsx
@@ -1,0 +1,97 @@
+import Badge from "@/components/Badge";
+import type { ArtifactContract, ArtifactVerification } from "@/lib/types";
+
+function formatBytes(size: number): string {
+  if (size < 1024) return `${size} B`;
+  if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`;
+  return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function verificationTone(status?: string | null): "ok" | "failed" | "pending" | "default" {
+  if (status === "passed") return "ok";
+  if (status === "failed") return "failed";
+  if (status === "warning") return "pending";
+  return "default";
+}
+
+export interface ExpectedArtifactsProps {
+  contract?: ArtifactContract | null;
+  verification?: ArtifactVerification | null;
+}
+
+export default function ExpectedArtifacts({ contract, verification }: ExpectedArtifactsProps) {
+  const expected = contract?.expected ?? [];
+  if (!contract || expected.length === 0) return null;
+
+  const producedById = new Map((verification?.produced ?? []).map((p) => [p.id, p]));
+  const missingRequired = new Set((verification?.missing_required ?? []).map((p) => p.id));
+  const missingOptional = new Set((verification?.missing_optional ?? []).map((p) => p.id));
+
+  return (
+    <div id="expected-artifacts" className="scroll-mt-24">
+      <div className="mb-2 flex items-center gap-2">
+        <h2 className="text-label font-semibold text-content-primary">Expected artifacts</h2>
+        <span className="rounded bg-surface-overlay px-1.5 py-0 font-mono text-[9px] text-content-muted">
+          {expected.length}
+        </span>
+        {verification?.status && (
+          <Badge tone={verificationTone(verification.status)}>
+            Verified: {verification.status}
+          </Badge>
+        )}
+      </div>
+      <div className="rounded border border-edge bg-surface-raised px-3 py-2 shadow-card">
+        <ul className="flex flex-col divide-y divide-edge-subtle">
+          {expected.map((entry) => {
+            const produced = producedById.get(entry.id);
+            const missing = missingRequired.has(entry.id) || missingOptional.has(entry.id);
+            const required = entry.required !== false;
+            const statusTone = produced
+              ? "ok"
+              : missing && required
+                ? "failed"
+                : missing
+                  ? "pending"
+                  : "default";
+            const statusLabel = produced
+              ? `OK (${formatBytes(produced.size)})`
+              : missing
+                ? "MISSING"
+                : "PENDING";
+            return (
+              <li
+                key={entry.id}
+                className="grid gap-2 py-2 md:grid-cols-[88px_minmax(0,1fr)_minmax(0,1fr)_96px] md:items-start"
+              >
+                <Badge tone={required ? "failed" : "default"}>
+                  {required ? "REQUIRED" : "OPTIONAL"}
+                </Badge>
+                <div className="min-w-0">
+                  <div className="truncate font-mono text-[11px] font-semibold text-content-primary">
+                    {entry.id}
+                  </div>
+                  {entry.description && (
+                    <div className="mt-0.5 text-[10px] text-content-muted">{entry.description}</div>
+                  )}
+                </div>
+                <div
+                  className="min-w-0 truncate font-mono text-[11px] text-content-secondary"
+                  title={entry.path}
+                >
+                  {entry.path}
+                </div>
+                <Badge tone={statusTone}>{statusLabel}</Badge>
+                {entry.source && (
+                  <div className="md:col-start-2 md:col-span-3 text-[10px] text-content-muted">
+                    declared by:{" "}
+                    <span className="font-mono text-content-secondary">{entry.source}</span>
+                  </div>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/apps/studio/frontend/lib/api.ts
+++ b/apps/studio/frontend/lib/api.ts
@@ -1,6 +1,8 @@
 import type {
   AgentProfile,
   AgentProfileSummary,
+  ArtifactContract,
+  ArtifactVerification,
   DeclarativeArgSpec,
   DeclarativePlaybookData,
   PlaybookFormat,
@@ -386,6 +388,9 @@ export interface SessionDetail {
   effort?: string | null;
   agent_hash?: string | null;
   invocation_id?: string | null;
+  // ADR-0029: artifact contract and verification result.
+  artifact_contract_json?: ArtifactContract | null;
+  artifact_verification_json?: ArtifactVerification | null;
 }
 
 export async function listSessions(): Promise<{ sessions: SessionSummary[] }> {

--- a/apps/studio/frontend/lib/types.ts
+++ b/apps/studio/frontend/lib/types.ts
@@ -19,6 +19,35 @@ export interface ProjectDetail extends ProjectSummary {
   playbooks_used: Array<{ playbook_name: string; run_count: number }>;
 }
 
+// ─── Artifact contract types (ADR-0029) ─────────────────────────────────────
+
+export interface ExpectedArtifact {
+  id: string;
+  path: string;
+  required?: boolean;
+  description?: string;
+  source?: string;
+}
+
+export interface ProducedArtifact {
+  id: string;
+  path: string;
+  size: number;
+  present?: boolean;
+}
+
+export interface ArtifactContract {
+  expected: ExpectedArtifact[];
+}
+
+export interface ArtifactVerification {
+  status: "passed" | "failed" | "warning" | "skipped";
+  checked_at: number;
+  missing_required: ExpectedArtifact[];
+  missing_optional: ExpectedArtifact[];
+  produced: ProducedArtifact[];
+}
+
 // ─── Run types ───────────────────────────────────────────────────────────────
 
 // H-FE-3: RunSummary matches the actual SQLite-session response shape from
@@ -41,14 +70,7 @@ export interface RunSummary {
   // - stale: process dead, has produced output.
   // - orphaned: process dead, no output, no artifacts.
   // - zombie: terminal status, but resources leaked (stale locks).
-  effective_health?:
-    | "healthy"
-    | "idle"
-    | "unresponsive"
-    | "stale"
-    | "orphaned"
-    | "zombie"
-    | null;
+  effective_health?: "healthy" | "idle" | "unresponsive" | "stale" | "orphaned" | "zombie" | null;
   last_message_at?: number | null;
   // ADR-0020: optional parent skill orchestration id (from `li invoke`).
   invocation_id?: string | null;
@@ -69,6 +91,9 @@ export interface RunSummary {
   // ADR-0026: project detection for session organization.
   project?: string | null;
   project_source?: string | null;
+  // ADR-0029: artifact contract and verification result.
+  artifact_contract_json?: ArtifactContract | null;
+  artifact_verification_json?: ArtifactVerification | null;
 }
 
 export interface RunMessage {
@@ -115,6 +140,9 @@ export interface RunDetail {
   graph: { nodes: WorkerStepNode[]; edges: WorkerLinkEdge[] };
   manifest: Record<string, unknown>;
   branches: unknown[];
+  // ADR-0029: artifact contract and verification result.
+  artifact_contract_json?: ArtifactContract | null;
+  artifact_verification_json?: ArtifactVerification | null;
 }
 
 // ─── Worker / Playbook types ──────────────────────────────────────────────────

--- a/apps/studio/frontend/next-env.d.ts
+++ b/apps/studio/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/studio/server/services/runs.py
+++ b/apps/studio/server/services/runs.py
@@ -34,6 +34,7 @@ def _normalize_status_filter(status: str | list[str] | None) -> set[str] | None:
         result |= _STATUS_ALIASES.get(s, {s})
     return result or None
 
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -54,10 +55,7 @@ def _adapt_summary(
         step_count = len(manifest["steps"])
 
     worker_name = (
-        manifest.get("worker_name")
-        or manifest.get("worker")
-        or manifest.get("kind")
-        or ""
+        manifest.get("worker_name") or manifest.get("worker") or manifest.get("kind") or ""
     )
 
     task = str(manifest.get("task") or manifest.get("prompt") or "")
@@ -78,9 +76,7 @@ def _adapt_summary(
             status = "completed"
             if not finished_at:
                 try:
-                    latest = max(
-                        branches_dir.glob("*.json"), key=lambda p: p.stat().st_mtime
-                    )
+                    latest = max(branches_dir.glob("*.json"), key=lambda p: p.stat().st_mtime)
                     finished_at = latest.stat().st_mtime
                 except (OSError, ValueError):
                     pass
@@ -128,9 +124,7 @@ def _build_graph(manifest: dict[str, Any]) -> dict[str, Any]:
                         "id": kind,
                         "label": kind,
                         "role": manifest.get("provider", ""),
-                        "assignment": manifest.get("model_spec")
-                        or manifest.get("model")
-                        or "",
+                        "assignment": manifest.get("model_spec") or manifest.get("model") or "",
                         "prompt": "",
                         "capacity": 1,
                         "timeout": None,
@@ -192,7 +186,7 @@ def _summarize_args(fn: str, args: dict[str, Any]) -> str:
         return str(path) if path else "(patch)"
     # Fallback: show first non-trivial arg.
     for k, v in args.items():
-        if isinstance(v, (str, int, float)) and v:
+        if isinstance(v, str | int | float) and v:
             return f"{k}={v}"
     return ""
 
@@ -218,10 +212,7 @@ def _detect_status(output: str, function: str) -> tuple[str, int | None]:
             break
     if exit_code is not None and exit_code != 0:
         return ("error", exit_code)
-    if any(
-        kw in lower[:300]
-        for kw in ("error:", "failed", "permission denied", "not found")
-    ):
+    if any(kw in lower[:300] for kw in ("error:", "failed", "permission denied", "not found")):
         if "no such file or directory" in lower:
             return ("error", exit_code)
     return ("ok", exit_code)
@@ -281,11 +272,7 @@ def _extract_messages(branch: dict[str, Any]) -> list[dict[str, Any]]:
 
         # Render System
         if role == "system":
-            text = (
-                content.get("system_message", "")
-                if isinstance(content, dict)
-                else str(content)
-            )
+            text = content.get("system_message", "") if isinstance(content, dict) else str(content)
             if text:
                 out.append(
                     {
@@ -322,9 +309,7 @@ def _extract_messages(branch: dict[str, Any]) -> list[dict[str, Any]]:
         # Render Assistant
         if role == "assistant":
             text = (
-                content.get("assistant_response", "")
-                if isinstance(content, dict)
-                else str(content)
+                content.get("assistant_response", "") if isinstance(content, dict) else str(content)
             )
             if text:
                 out.append(
@@ -341,14 +326,10 @@ def _extract_messages(branch: dict[str, Any]) -> list[dict[str, Any]]:
         if role == "action" and cls == "ActionRequest":
             args = content.get("arguments", {}) if isinstance(content, dict) else {}
             fn = content.get("function", "") if isinstance(content, dict) else ""
-            response_id = (
-                content.get("action_response_id") if isinstance(content, dict) else None
-            )
+            response_id = content.get("action_response_id") if isinstance(content, dict) else None
             response_msg = response_by_id.get(response_id, {}) if response_id else {}
             response_content = (
-                response_msg.get("content", {})
-                if isinstance(response_msg, dict)
-                else {}
+                response_msg.get("content", {}) if isinstance(response_msg, dict) else {}
             )
             output_text = ""
             if isinstance(response_content, dict):
@@ -384,9 +365,7 @@ def _extract_messages(branch: dict[str, Any]) -> list[dict[str, Any]]:
                 {
                     "role": "tool_call",
                     "function": fn,
-                    "summary": _summarize_args(
-                        fn, args if isinstance(args, dict) else {}
-                    ),
+                    "summary": _summarize_args(fn, args if isinstance(args, dict) else {}),
                     "arguments": args if isinstance(args, dict) else {},
                     "output": str(output_text),
                     "status": status,
@@ -425,9 +404,7 @@ def _build_steps(
                     "status": "completed" if messages else "pending",
                     "result": {
                         "agent": name,
-                        "model": manifest.get("model_spec")
-                        or manifest.get("model")
-                        or "",
+                        "model": manifest.get("model_spec") or manifest.get("model") or "",
                         "message_count": len(messages),
                         "roles": role_counts,
                     },
@@ -511,6 +488,10 @@ def _adapt_detail(
         "graph": graph,
         "manifest": manifest,
         "branches": branches,
+        "artifact_contract_json": manifest.get("artifact_contract_json")
+        or manifest.get("artifact_contract"),
+        "artifact_verification_json": manifest.get("artifact_verification_json")
+        or manifest.get("artifact_verification"),
     }
 
 
@@ -574,41 +555,44 @@ async def list_runs(
         # effective_health === 'stale'. Map UNRESPONSIVE → 'stale' so the
         # dashboard counter stays correct without requiring a frontend change.
         effective_health = (
-            SessionHealth.STALE.value
-            if health == SessionHealth.UNRESPONSIVE
-            else health.value
+            SessionHealth.STALE.value if health == SessionHealth.UNRESPONSIVE else health.value
         )
-        out.append({
-            "run_id": s["id"],
-            "id": s["id"],
-            "name": s.get("name"),
-            "playbook_name": s.get("playbook_name"),
-            "agent_name": s.get("agent_name"),
-            "invocation_kind": s.get("invocation_kind"),
-            "show_topic": s.get("show_topic"),
-            "show_play_name": s.get("show_play_name"),
-            "source_kind": s.get("source_kind", "live"),
-            # ADR-0020: parent skill orchestration; null when standalone.
-            "invocation_id": s.get("invocation_id"),
-            # ADR-0022: provenance disclosure.
-            "model": s.get("model"),
-            "provider": s.get("provider"),
-            "effort": s.get("effort"),
-            "agent_hash": s.get("agent_hash"),
-            "status": s.get("status", "completed"),
-            "started_at": s.get("started_at"),
-            "ended_at": s.get("ended_at"),
-            "created_at": s.get("created_at"),
-            "updated_at": s.get("updated_at"),
-            # ADR-0019/0024: activity marker + derived health label.
-            "last_message_at": s.get("last_message_at"),
-            "effective_health": effective_health,
-            "branch_count": s.get("branch_count", 0),
-            "message_count": s.get("message_count", 0),
-            # ADR-0026: project detection.
-            "project": s.get("project"),
-            "project_source": s.get("project_source"),
-        })
+        out.append(
+            {
+                "run_id": s["id"],
+                "id": s["id"],
+                "name": s.get("name"),
+                "playbook_name": s.get("playbook_name"),
+                "agent_name": s.get("agent_name"),
+                "invocation_kind": s.get("invocation_kind"),
+                "show_topic": s.get("show_topic"),
+                "show_play_name": s.get("show_play_name"),
+                "source_kind": s.get("source_kind", "live"),
+                # ADR-0029: expected artifact contract and teardown verification.
+                "artifact_contract_json": s.get("artifact_contract_json"),
+                "artifact_verification_json": s.get("artifact_verification_json"),
+                # ADR-0020: parent skill orchestration; null when standalone.
+                "invocation_id": s.get("invocation_id"),
+                # ADR-0022: provenance disclosure.
+                "model": s.get("model"),
+                "provider": s.get("provider"),
+                "effort": s.get("effort"),
+                "agent_hash": s.get("agent_hash"),
+                "status": s.get("status", "completed"),
+                "started_at": s.get("started_at"),
+                "ended_at": s.get("ended_at"),
+                "created_at": s.get("created_at"),
+                "updated_at": s.get("updated_at"),
+                # ADR-0019/0024: activity marker + derived health label.
+                "last_message_at": s.get("last_message_at"),
+                "effective_health": effective_health,
+                "branch_count": s.get("branch_count", 0),
+                "message_count": s.get("message_count", 0),
+                # ADR-0026: project detection.
+                "project": s.get("project"),
+                "project_source": s.get("project_source"),
+            }
+        )
     return out
 
 
@@ -622,7 +606,7 @@ def paginate_runs(
     total = len(runs)
     total_pages = math.ceil(total / per_page) if total else 0
     start = (page - 1) * per_page
-    page_runs = runs[start: start + per_page]
+    page_runs = runs[start : start + per_page]
     return {
         "runs": page_runs,
         "page": page,
@@ -643,9 +627,7 @@ def get_run(run_id: str) -> dict[str, Any] | None:
 
     state_root = RUNS_ROOT / run_id
     if not state_root.is_dir():
-        matches = [
-            d for d in RUNS_ROOT.iterdir() if d.is_dir() and d.name.startswith(run_id)
-        ]
+        matches = [d for d in RUNS_ROOT.iterdir() if d.is_dir() and d.name.startswith(run_id)]
         if not matches:
             return None
         state_root = sorted(matches, key=lambda p: p.stat().st_mtime, reverse=True)[0]

--- a/apps/studio/server/services/sessions.py
+++ b/apps/studio/server/services/sessions.py
@@ -11,9 +11,7 @@ from ._db import open_db as _open_db
 
 _DB = str(DEFAULT_DB_PATH)
 
-SESSION_TERMINAL_STATUSES = frozenset(
-    {"completed", "failed", "timed_out", "aborted", "cancelled"}
-)
+SESSION_TERMINAL_STATUSES = frozenset({"completed", "failed", "timed_out", "aborted", "cancelled"})
 SESSION_DONE_STABLE_SECS = 60.0
 
 
@@ -51,24 +49,28 @@ def _graph_from_metadata(raw: str | None) -> dict[str, Any] | None:
         depends_on = op.get("depends_on", [])
         if not isinstance(depends_on, list):
             depends_on = []
-        nodes.append({
-            "id": op["id"],
-            "label": op["id"],
-            "role": agent.get("name", ""),
-            "assignment": agent.get("model", ""),
-            "prompt": "",
-            "capacity": 1,
-            "timeout": None,
-            "inputs": depends_on,
-            "outputs": [],
-        })
+        nodes.append(
+            {
+                "id": op["id"],
+                "label": op["id"],
+                "role": agent.get("name", ""),
+                "assignment": agent.get("model", ""),
+                "prompt": "",
+                "capacity": 1,
+                "timeout": None,
+                "inputs": depends_on,
+                "outputs": [],
+            }
+        )
         for dep in depends_on:
-            edges.append({
-                "id": f"e-{dep}-{op['id']}",
-                "source": dep,
-                "target": op["id"],
-                "mode": "simple",
-            })
+            edges.append(
+                {
+                    "id": f"e-{dep}-{op['id']}",
+                    "source": dep,
+                    "target": op["id"],
+                    "mode": "simple",
+                }
+            )
     return {"nodes": nodes, "edges": edges} if nodes else None
 
 
@@ -109,6 +111,9 @@ async def list_sessions() -> list[dict[str, Any]]:
                 s.invocation_kind,
                 s.show_topic,
                 s.show_play_name,
+                s.artifacts_path,
+                s.artifact_contract_json,
+                s.artifact_verification_json,
                 s.source_kind,
                 s.status,
                 s.started_at,
@@ -161,7 +166,10 @@ async def list_sessions() -> list[dict[str, Any]]:
             "invocation_kind": row["invocation_kind"],
             "show_topic": row["show_topic"],
             "show_play_name": row["show_play_name"],
+            "artifacts_path": row["artifacts_path"],
             "source_kind": row["source_kind"] or "live",
+            "artifact_contract_json": _parse_json_col(row["artifact_contract_json"]),
+            "artifact_verification_json": _parse_json_col(row["artifact_verification_json"]),
             # ADR-0026: project detection.
             "project": row["project"],
             "project_source": row["project_source"],
@@ -180,8 +188,9 @@ async def get_session(session_id: str) -> dict[str, Any] | None:
             # ADR-0022: include provenance columns (model/provider/effort/agent_hash)
             """SELECT id, name, created_at, updated_at,
                       playbook_name, agent_name, invocation_kind,
-                      show_topic, show_play_name, artifacts_path, source_kind,
-                      status, started_at, ended_at,
+                      show_topic, show_play_name, artifacts_path,
+                      artifact_contract_json, artifact_verification_json,
+                      source_kind, status, started_at, ended_at,
                       model, provider, effort, agent_hash, invocation_id,
                       node_metadata, project, project_source
                FROM sessions WHERE id = ?""",
@@ -285,6 +294,8 @@ async def get_session(session_id: str) -> dict[str, Any] | None:
         "show_topic": session_row["show_topic"],
         "show_play_name": session_row["show_play_name"],
         "artifacts_path": session_row["artifacts_path"],
+        "artifact_contract_json": _parse_json_col(session_row["artifact_contract_json"]),
+        "artifact_verification_json": _parse_json_col(session_row["artifact_verification_json"]),
         "source_kind": session_row["source_kind"] or "live",
         "status": session_row["status"] or "completed",
         "started_at": started_at,

--- a/lionagi/cli/_agents.py
+++ b/lionagi/cli/_agents.py
@@ -24,11 +24,12 @@ Profile format (YAML frontmatter + markdown body):
     You are an implementer. Write production code, not stubs...
 
 Frontmatter fields (all optional, CLI flags override):
-  model:       provider/model spec
-  effort:      reasoning effort level
-  yolo:        auto-approve tool calls
-  fast_mode:   route via OpenAI priority tier (codex only)
-  lion_system: prepend LION_SYSTEM_MESSAGE (default: true)
+  model:              provider/model spec
+  effort:             reasoning effort level
+  yolo:               auto-approve tool calls
+  fast_mode:          route via OpenAI priority tier (codex only)
+  lion_system:        prepend LION_SYSTEM_MESSAGE (default: true)
+  artifact_defaults:  ADR-0029 expected artifact defaults
 """
 
 from __future__ import annotations
@@ -47,6 +48,7 @@ class AgentProfile:
     yolo: bool = False
     fast_mode: bool = False
     lion_system: bool = True
+    artifact_defaults: dict | None = None
     extra: dict = field(default_factory=dict)
 
 
@@ -60,7 +62,7 @@ def _find_lionagi_dirs() -> list[Path]:
     # 1. Git root
     try:
         root = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
+            ["git", "rev-parse", "--show-toplevel"],  # noqa: S607 — git is expected on $PATH
             capture_output=True,
             text=True,
             timeout=5,
@@ -167,15 +169,13 @@ def _parse_profile(name: str, text: str) -> AgentProfile:
         if len(parts) >= 3:
             fm_text = parts[1].strip()
             body = parts[2].strip()
-            for line in fm_text.splitlines():
-                line = line.strip()
-                if ":" in line:
-                    key, _, val = line.partition(":")
-                    val = val.strip()
-                    if val.lower() in ("true", "false"):
-                        frontmatter[key.strip()] = val.lower() == "true"
-                    else:
-                        frontmatter[key.strip()] = val
+            if fm_text:
+                import yaml
+
+                loaded = yaml.safe_load(fm_text) or {}
+                if not isinstance(loaded, dict):
+                    loaded = {}
+                frontmatter = loaded
 
     lion_system = bool(frontmatter.get("lion_system", True))
     if lion_system:
@@ -191,9 +191,18 @@ def _parse_profile(name: str, text: str) -> AgentProfile:
         yolo=bool(frontmatter.get("yolo", False)),
         fast_mode=bool(frontmatter.get("fast_mode", False)),
         lion_system=lion_system,
+        artifact_defaults=frontmatter.get("artifact_defaults"),
         extra={
             k: v
             for k, v in frontmatter.items()
-            if k not in ("model", "effort", "yolo", "fast_mode", "lion_system")
+            if k
+            not in (
+                "model",
+                "effort",
+                "yolo",
+                "fast_mode",
+                "lion_system",
+                "artifact_defaults",
+            )
         },
     )

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -203,11 +203,18 @@ async def _run_agent(
         import anyio
 
         with anyio.CancelScope(shield=True):
-            await _teardown_live_persist(
+            # ADR-0029 §7: teardown may override the proposed terminal
+            # status (clean exit + missing required artifact → failed).
+            # Use the returned status — NOT the original — for the
+            # process exit code so shell scripts, schedules, and chains
+            # see the failure.
+            effective_status = await _teardown_live_persist(
                 live,
                 status=_terminal_status,
                 exception=_terminal_exc,
             )
+            if effective_status != _terminal_status:
+                _terminal_status = effective_status
             # Shut down every iModel on the branch (chat_model AND
             # parse_model, plus any other registered) so each
             # RateLimitedAPIExecutor's background replenisher task is
@@ -496,8 +503,14 @@ async def _teardown_live_persist(
     *,
     status: str = "completed",
     exception: BaseException | None = None,
-) -> None:
+) -> str:
     """Update session bookmarks, lifecycle columns, and close DB.
+
+    Returns the *effective* terminal status — ADR-0029 §7's verification
+    override can flip a clean ``completed`` into ``failed`` when required
+    artifacts are missing. Callers MUST use the returned status (not the
+    `status` argument they passed in) for any downstream side effect
+    like the process exit code.
 
     The DB close is in its own ``finally`` so it always runs — even if
     the bookmark update or hook removal fails. Failures elsewhere are
@@ -515,7 +528,7 @@ async def _teardown_live_persist(
     exception class and message.
     """
     if ctx is None:
-        return
+        return status
     import logging
 
     log = logging.getLogger("lionagi.cli")
@@ -595,11 +608,15 @@ async def _teardown_live_persist(
         ]
     except Exception as exc:
         log.warning("live persist teardown failed: %s", exc, exc_info=True)
+        # Surface the original status on best-effort failure so the
+        # caller's exit code reflects what we tried to commit.
+        return status
     finally:
         try:
             await db.close()
         except Exception as exc:
             log.warning("live persist db.close failed: %s", exc, exc_info=True)
+    return final_status
 
 
 def add_agent_subparser(subparsers: argparse._SubParsersAction) -> None:

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -12,6 +12,12 @@ from lionagi._errors import TimeoutError as LionTimeoutError
 from lionagi.ln.concurrency import run_async
 from lionagi.protocols.generic.log import DataLoggerConfig
 from lionagi.state import provenance as _provenance
+from lionagi.state.artifact_verifier import (
+    missing_artifact_evidence,
+    missing_artifact_summary,
+    resolve_artifact_contract,
+    verify_artifact_contract,
+)
 
 from ._agents import load_agent_profile
 from ._logging import hint, log_error
@@ -133,10 +139,15 @@ async def _run_agent(
     # ``model_spec`` here is the canonical ``provider/model`` string built
     # right above this block — no aliases, no defaults yet to apply.
     resolved_model_spec = _provenance.resolve_model_spec(provider, model)
+    artifact_contract = resolve_artifact_contract(
+        playbook_artifacts=None,
+        agent_defaults=profile.artifact_defaults if profile else None,
+    )
     live = await _setup_live_persist(
         branch,
         agent_name=agent_name,
         artifacts_path=str(run.artifact_root),
+        artifact_contract=artifact_contract,
         invocation_id=invocation_id,
         model=resolved_model_spec,
         provider=provider,
@@ -225,6 +236,7 @@ async def _setup_live_persist(
     *,
     agent_name: str | None = None,
     artifacts_path: str | None = None,
+    artifact_contract: dict | None = None,
     invocation_id: str | None = None,
     model: str | None = None,
     provider: str | None = None,
@@ -320,6 +332,7 @@ async def _setup_live_persist(
                     "invocation_kind": "agent",
                     "agent_name": agent_name,
                     "artifacts_path": artifacts_path,
+                    "artifact_contract_json": artifact_contract,
                     "status": "running",
                     "started_at": time.time(),
                     # ADR-0020: optional skill-level orchestration parent.
@@ -381,6 +394,8 @@ async def _setup_live_persist(
             "branch_prog_id": branch_prog_id,
             "existing_msg_ids": existing_msg_ids,
             "new_msg_ids": [],
+            "artifacts_path": artifacts_path,
+            "artifact_contract": artifact_contract,
         }
 
         async def _on_message(msg):
@@ -528,13 +543,43 @@ async def _teardown_live_persist(
         metadata: dict | None = None
         if exception is not None:
             metadata = {"exception_class": type(exception).__name__}
+
+        session_row = await db.get_session(session_id) or {}
+        contract = session_row.get("artifact_contract_json")
+        artifacts_root = session_row.get("artifacts_path")
+        verification = verify_artifact_contract(
+            contract,
+            artifacts_root=artifacts_root,
+        )
+        await db.update_artifact_verification(session_id, verification)
+
+        final_status = status
+        final_reason_code = reason_code
+        final_reason_summary = reason_summary
+        final_evidence_refs = evidence_refs
+        if verification and verification["status"] == "failed":
+            missing = verification["missing_required"]
+            if status == "completed":
+                from lionagi.state.reasons import RunReasons
+
+                final_status = "failed"
+                final_reason_code = RunReasons.FAILED_MISSING_ARTIFACT
+                final_reason_summary = missing_artifact_summary(missing)
+                final_evidence_refs = missing_artifact_evidence(missing)
+            else:
+                metadata = dict(metadata or {})
+                metadata["artifact_verification_status"] = verification["status"]
+                metadata["missing_required_artifact_ids"] = [
+                    str(entry.get("id", "")) for entry in missing
+                ]
+
         await db.update_status(
             "session",
             session_id,
-            new_status=status,
-            reason_code=reason_code,
-            reason_summary=reason_summary,
-            evidence_refs=evidence_refs,
+            new_status=final_status,
+            reason_code=final_reason_code,
+            reason_summary=final_reason_summary,
+            evidence_refs=final_evidence_refs,
             source="executor",
             actor=session_id,
             metadata=metadata,

--- a/lionagi/cli/main.py
+++ b/lionagi/cli/main.py
@@ -69,12 +69,39 @@ def _print_playbook_help(name: str) -> int:
     return 0
 
 
+_ARTIFACT_ENTRY_ALLOWED_KEYS = frozenset({"id", "path", "required", "description", "source"})
+
+
+def _warn_unknown_artifact_keys(artifacts_block: dict, *, name: str) -> None:
+    """Emit a CLI warning for unknown subfields under each artifact entry.
+
+    ADR-0029 §2 declares `id, path, required, description` as v1. `kind`,
+    `min_size`, `mime_type` are reserved for v1.1 — silently accepting
+    them in v1 lets contract files drift into looking stricter than the
+    executor actually is. Warn so the author sees what was ignored.
+    """
+    expected = artifacts_block.get("expected") or []
+    if not isinstance(expected, list):
+        return
+    for entry in expected:
+        if not isinstance(entry, dict):
+            continue
+        unknown = set(entry.keys()) - _ARTIFACT_ENTRY_ALLOWED_KEYS
+        if unknown:
+            print(
+                f"warning: playbook '{name}' artifact entry "
+                f"{entry.get('id', '<unnamed>')!r} has unknown subfield(s) "
+                f"{sorted(unknown)} (ignored by v1; reserved for v1.1)."
+            )
+
+
 def _handle_play_check(argv: list[str]) -> int:
     """`li play check <name>` — ADR-0029 §9 pre-flight contract validation.
 
-    Loads the playbook, resolves its artifact contract (no agent defaults
-    available in this thin path — playbook contract only), runs
-    :func:`lionagi.state.artifact_verifier.validate_artifact_contract`,
+    Loads the playbook, optionally loads the agent profile it names so
+    `artifact_defaults` participate in the merge (matching what a real
+    invocation will see), resolves the contract via
+    :func:`lionagi.state.artifact_verifier.resolve_artifact_contract`,
     and pretty-prints the result. Does not fire the playbook.
     """
     if not argv or argv[0].startswith("-"):
@@ -98,14 +125,33 @@ def _handle_play_check(argv: list[str]) -> int:
         return 1
 
     artifacts_block = spec.get("artifacts")
-    if not artifacts_block:
+    # Load the agent profile the playbook names so its artifact_defaults
+    # participate in the merge — a real invocation sees them.
+    agent_defaults = None
+    agent_name = spec.get("agent")
+    if agent_name:
+        try:
+            from lionagi.cli._agents import load_agent_profile
+
+            profile = load_agent_profile(agent_name)
+            agent_defaults = getattr(profile, "artifact_defaults", None)
+        except Exception as exc:  # noqa: BLE001 — best-effort pre-flight
+            print(
+                f"warning: could not load agent profile '{agent_name}' "
+                f"({exc}); checking playbook contract only."
+            )
+
+    if not artifacts_block and not agent_defaults:
         print(f"playbook '{name}': no `artifacts:` block declared (verification skipped).")
         return 0
+
+    if artifacts_block:
+        _warn_unknown_artifact_keys(artifacts_block, name=name)
 
     try:
         resolved = resolve_artifact_contract(
             playbook_artifacts=artifacts_block,
-            agent_defaults=None,
+            agent_defaults=agent_defaults,
         )
     except ArtifactPathError as exc:
         log_error(f"playbook '{name}' artifact contract invalid: {exc}")
@@ -118,8 +164,13 @@ def _handle_play_check(argv: list[str]) -> int:
     expected = resolved.get("expected", [])
     required = [e for e in expected if e.get("required", True)]
     optional = [e for e in expected if not e.get("required", True)]
+    sources = [e.get("source") for e in expected]
+    from_playbook = sum(1 for s in sources if s == "playbook")
+    from_agent = sum(1 for s in sources if s == "agent_profile")
     print(f"playbook '{name}' artifact contract:")
     print(f"  expected: {len(expected)} ({len(required)} required, {len(optional)} optional)")
+    if from_playbook or from_agent:
+        print(f"  sources:  {from_playbook} from playbook, {from_agent} from agent_profile")
     for e in expected:
         flag = "REQUIRED" if e.get("required", True) else "OPTIONAL"
         src = e.get("source", "?")

--- a/lionagi/cli/main.py
+++ b/lionagi/cli/main.py
@@ -69,6 +69,66 @@ def _print_playbook_help(name: str) -> int:
     return 0
 
 
+def _handle_play_check(argv: list[str]) -> int:
+    """`li play check <name>` — ADR-0029 §9 pre-flight contract validation.
+
+    Loads the playbook, resolves its artifact contract (no agent defaults
+    available in this thin path — playbook contract only), runs
+    :func:`lionagi.state.artifact_verifier.validate_artifact_contract`,
+    and pretty-prints the result. Does not fire the playbook.
+    """
+    if not argv or argv[0].startswith("-"):
+        print("Usage: li play check <name>")
+        return 1
+    name = argv[0]
+
+    from lionagi.cli.orchestrate import _load_flow_spec, _resolve_playbook_path
+    from lionagi.state.artifact_verifier import (
+        ArtifactPathError,
+        resolve_artifact_contract,
+    )
+
+    path, err = _resolve_playbook_path(name)
+    if err is not None:
+        log_error(err)
+        return 1
+    spec = _load_flow_spec(str(path))
+    if not isinstance(spec, dict):
+        log_error(f"could not parse playbook spec at {path}")
+        return 1
+
+    artifacts_block = spec.get("artifacts")
+    if not artifacts_block:
+        print(f"playbook '{name}': no `artifacts:` block declared (verification skipped).")
+        return 0
+
+    try:
+        resolved = resolve_artifact_contract(
+            playbook_artifacts=artifacts_block,
+            agent_defaults=None,
+        )
+    except ArtifactPathError as exc:
+        log_error(f"playbook '{name}' artifact contract invalid: {exc}")
+        return 1
+
+    if resolved is None:
+        print(f"playbook '{name}': empty contract (no expected artifacts).")
+        return 0
+
+    expected = resolved.get("expected", [])
+    required = [e for e in expected if e.get("required", True)]
+    optional = [e for e in expected if not e.get("required", True)]
+    print(f"playbook '{name}' artifact contract:")
+    print(f"  expected: {len(expected)} ({len(required)} required, {len(optional)} optional)")
+    for e in expected:
+        flag = "REQUIRED" if e.get("required", True) else "OPTIONAL"
+        src = e.get("source", "?")
+        desc = e.get("description") or ""
+        suffix = f" — {desc}" if desc else ""
+        print(f"  [{flag}] {e['id']}  →  {e['path']}  (from {src}){suffix}")
+    return 0
+
+
 def _handle_play_shortcut(argv: list[str]) -> list[str] | int:
     """Expand `li play` sugar into `li o flow -p NAME ...`.
 
@@ -89,15 +149,18 @@ def _handle_play_shortcut(argv: list[str]) -> list[str] | int:
         if not root.is_dir():
             print(f"(no playbooks directory at {root})")
             return 0
-        names = sorted(
-            p.name.removesuffix(".playbook.yaml") for p in root.glob("*.playbook.yaml")
-        )
+        names = sorted(p.name.removesuffix(".playbook.yaml") for p in root.glob("*.playbook.yaml"))
         if not names:
             print(f"(no playbooks in {root})")
             return 0
         for name in names:
             print(name)
         return 0
+    if head == "check":
+        # ADR-0029 §9: pre-flight artifact-contract validation.
+        # `li play check <name>` loads the playbook, resolves its
+        # artifact contract, and prints the result without firing.
+        return _handle_play_check(rest[1:])
     if head.startswith("-"):
         log_error("li play NAME must come before flags")
         return 1

--- a/lionagi/cli/main.py
+++ b/lionagi/cli/main.py
@@ -69,30 +69,10 @@ def _print_playbook_help(name: str) -> int:
     return 0
 
 
-_ARTIFACT_ENTRY_ALLOWED_KEYS = frozenset({"id", "path", "required", "description", "source"})
-
-
-def _warn_unknown_artifact_keys(artifacts_block: dict, *, name: str) -> None:
-    """Emit a CLI warning for unknown subfields under each artifact entry.
-
-    ADR-0029 §2 declares `id, path, required, description` as v1. `kind`,
-    `min_size`, `mime_type` are reserved for v1.1 — silently accepting
-    them in v1 lets contract files drift into looking stricter than the
-    executor actually is. Warn so the author sees what was ignored.
-    """
-    expected = artifacts_block.get("expected") or []
-    if not isinstance(expected, list):
-        return
-    for entry in expected:
-        if not isinstance(entry, dict):
-            continue
-        unknown = set(entry.keys()) - _ARTIFACT_ENTRY_ALLOWED_KEYS
-        if unknown:
-            print(
-                f"warning: playbook '{name}' artifact entry "
-                f"{entry.get('id', '<unnamed>')!r} has unknown subfield(s) "
-                f"{sorted(unknown)} (ignored by v1; reserved for v1.1)."
-            )
+# The unknown-subfield warning is shared with the runtime spec validator
+# (lionagi/cli/orchestrate/__init__.py) — see warn_unknown_artifact_keys
+# in lionagi/state/artifact_verifier.py. Importing here keeps the
+# pre-flight and runtime warnings in lockstep.
 
 
 def _handle_play_check(argv: list[str]) -> int:
@@ -113,6 +93,7 @@ def _handle_play_check(argv: list[str]) -> int:
     from lionagi.state.artifact_verifier import (
         ArtifactPathError,
         resolve_artifact_contract,
+        warn_unknown_artifact_keys,
     )
 
     path, err = _resolve_playbook_path(name)
@@ -126,7 +107,10 @@ def _handle_play_check(argv: list[str]) -> int:
 
     artifacts_block = spec.get("artifacts")
     # Load the agent profile the playbook names so its artifact_defaults
-    # participate in the merge — a real invocation sees them.
+    # participate in the merge — a real invocation sees them. The actual
+    # `li play` path raises if the profile is missing, so pre-flight
+    # must FAIL in the same case rather than silently green-light an
+    # invocation that will crash at execution start.
     agent_defaults = None
     agent_name = spec.get("agent")
     if agent_name:
@@ -135,18 +119,24 @@ def _handle_play_check(argv: list[str]) -> int:
 
             profile = load_agent_profile(agent_name)
             agent_defaults = getattr(profile, "artifact_defaults", None)
-        except Exception as exc:  # noqa: BLE001 — best-effort pre-flight
-            print(
-                f"warning: could not load agent profile '{agent_name}' "
-                f"({exc}); checking playbook contract only."
+        except Exception as exc:  # noqa: BLE001 — match runtime behaviour
+            log_error(
+                f"playbook '{name}' references agent profile "
+                f"'{agent_name}' but it could not be loaded: {exc}. "
+                f"Real `li play {name}` will fail at execution start; "
+                f"fix the profile or remove the `agent:` field."
             )
+            return 1
 
     if not artifacts_block and not agent_defaults:
         print(f"playbook '{name}': no `artifacts:` block declared (verification skipped).")
         return 0
 
     if artifacts_block:
-        _warn_unknown_artifact_keys(artifacts_block, name=name)
+        # Same warning the runtime spec validator emits (via
+        # logger.warning there); on the pre-flight surface we want it
+        # visible in the operator's terminal, so default print is fine.
+        warn_unknown_artifact_keys(artifacts_block, source=f"playbook '{name}'")
 
     try:
         resolved = resolve_artifact_contract(

--- a/lionagi/cli/orchestrate/__init__.py
+++ b/lionagi/cli/orchestrate/__init__.py
@@ -624,9 +624,25 @@ def _validate_spec_fields(spec: dict) -> str | None:
         if artifacts is None:
             return "spec field 'artifacts' must be a dict, got NoneType"
         try:
-            from lionagi.state.artifact_verifier import validate_artifact_contract
+            from lionagi.state.artifact_verifier import (
+                validate_artifact_contract,
+                warn_unknown_artifact_keys,
+            )
 
             validate_artifact_contract(artifacts)
+            # ADR-0029 §2: unknown subfields are reserved for v1.1.
+            # Warn at runtime as well as in `li play check` so contract
+            # files don't silently drift into v1.1-looking shapes the
+            # v1 executor ignores. Route through the standard logger
+            # so the warning lands in structured logs, not stdout.
+            import logging as _logging
+
+            _cli_log = _logging.getLogger("lionagi.cli")
+            warn_unknown_artifact_keys(
+                artifacts,
+                source="playbook",
+                emit=_cli_log.warning,
+            )
         except Exception as exc:
             return f"spec field 'artifacts' is invalid: {exc}"
 

--- a/lionagi/cli/orchestrate/__init__.py
+++ b/lionagi/cli/orchestrate/__init__.py
@@ -887,7 +887,7 @@ def run_orchestrate(args: argparse.Namespace) -> int:
         synthesis_model = synth if isinstance(synth, str) else None
 
         try:
-            output = run_async(
+            output, terminal_status = run_async(
                 _run_flow(
                     model_spec=args.model or "",
                     prompt=args.prompt,
@@ -930,7 +930,11 @@ def run_orchestrate(args: argparse.Namespace) -> int:
             raise
         if not args.verbose:
             print(output)
-        return 0
+        # ADR-0029 §7: terminal_status reflects the verification override.
+        # Map to the same exit codes used by `li agent` (see ADR-0025).
+        from lionagi.cli.agent import _EXIT_CODE_BY_TERMINAL_STATUS
+
+        return _EXIT_CODE_BY_TERMINAL_STATUS.get(terminal_status, 0)
 
     log_error(f"Unknown orchestrate command: {args.orch_command}")
     return 1

--- a/lionagi/cli/orchestrate/__init__.py
+++ b/lionagi/cli/orchestrate/__init__.py
@@ -166,8 +166,8 @@ def add_orchestrate_subparser(
         default=None,
         help=(
             "Load playbook from ~/.lionagi/playbooks/<NAME>.playbook.yaml. "
-            "Playbooks may declare args: schema or argument-hint: for "
-            "CLI flags that fill template placeholders {name} in the prompt."
+            "Playbooks may declare args: schema, artifacts: contracts, "
+            "or argument-hint: placeholders for prompt template values."
         ),
     )
     fl.add_argument(
@@ -553,9 +553,7 @@ def _validate_spec_fields(spec: dict) -> str | None:
     if "workers" in spec:
         workers = spec["workers"]
         if not isinstance(workers, int) or isinstance(workers, bool):
-            return (
-                f"spec field 'workers' must be an integer, got {type(workers).__name__}"
-            )
+            return f"spec field 'workers' must be an integer, got {type(workers).__name__}"
         if not (1 <= workers <= 32):
             return f"spec field 'workers' must be in [1, 32], got {workers}"
 
@@ -591,7 +589,7 @@ def _validate_spec_fields(spec: dict) -> str | None:
     #   str   → synthesis model spec (flag with explicit value)
     if "with_synthesis" in spec:
         val = spec["with_synthesis"]
-        if not isinstance(val, (bool, str)):
+        if not isinstance(val, bool | str):
             return (
                 f"spec field 'with_synthesis' must be bool or str (model spec), "
                 f"got {type(val).__name__}"
@@ -621,12 +619,21 @@ def _validate_spec_fields(spec: dict) -> str | None:
             if not isinstance(val, str):
                 return f"spec field {str_field!r} must be a string, got {type(val).__name__}"
 
+    if "artifacts" in spec:
+        artifacts = spec["artifacts"]
+        if artifacts is None:
+            return "spec field 'artifacts' must be a dict, got NoneType"
+        try:
+            from lionagi.state.artifact_verifier import validate_artifact_contract
+
+            validate_artifact_contract(artifacts)
+        except Exception as exc:
+            return f"spec field 'artifacts' is invalid: {exc}"
+
     return None
 
 
-def _interpolate_prompt(
-    template: str, positional: str | None, playbook_args: dict
-) -> str:
+def _interpolate_prompt(template: str, positional: str | None, playbook_args: dict) -> str:
     """Interpolate {input} + all playbook args into the prompt template.
 
     - {input} substitution uses the positional prompt if present
@@ -718,6 +725,7 @@ def run_orchestrate(args: argparse.Namespace) -> int:
     if args.orch_command == "flow":
         # ── Resolve -p/--playbook NAME into a concrete file path ─────
         playbook_name = getattr(args, "playbook", None)
+        playbook_artifacts: dict | None = None
         file_spec = getattr(args, "file", None)
         if playbook_name and file_spec:
             log_error("pass either -p/--playbook or -f/--file, not both")
@@ -738,6 +746,8 @@ def run_orchestrate(args: argparse.Namespace) -> int:
             if spec_err is not None:
                 log_error(spec_err)
                 return 1
+
+            playbook_artifacts = spec.get("artifacts")
 
             # ── Derive args schema: explicit args: block OR argument-hint fallback
             if "args" in spec:
@@ -764,9 +774,7 @@ def run_orchestrate(args: argparse.Namespace) -> int:
                 raw = getattr(args, name, None)
                 if raw is None:
                     continue
-                coerced, coerce_err = _coerce_arg_value(
-                    name, raw, field.get("type", "str")
-                )
+                coerced, coerce_err = _coerce_arg_value(name, raw, field.get("type", "str"))
                 if coerce_err is not None:
                     log_error(coerce_err)
                     return 1
@@ -774,11 +782,7 @@ def run_orchestrate(args: argparse.Namespace) -> int:
 
             # If the file supplies the model/agent, argparse's lone positional
             # is a prompt override, not a model override.
-            if (
-                args.model
-                and args.prompt is None
-                and (spec.get("model") or spec.get("agent"))
-            ):
+            if args.model and args.prompt is None and (spec.get("model") or spec.get("agent")):
                 args.prompt = args.model
                 args.model = None
             # File values are defaults; CLI flags override.
@@ -787,9 +791,7 @@ def run_orchestrate(args: argparse.Namespace) -> int:
             if args.agent is None and spec.get("agent"):
                 args.agent = spec["agent"]
             if spec.get("prompt"):
-                args.prompt = _interpolate_prompt(
-                    spec["prompt"], args.prompt, playbook_ctx
-                )
+                args.prompt = _interpolate_prompt(spec["prompt"], args.prompt, playbook_ctx)
             if args.max_concurrent == 0 and spec.get("workers"):
                 args.max_concurrent = spec["workers"]
             if args.effort is None and spec.get("effort"):
@@ -832,10 +834,7 @@ def run_orchestrate(args: argparse.Namespace) -> int:
             log_error("prompt is required (positional or via -f spec file)")
             return 1
 
-        if (
-            args.team_mode is not None
-            and getattr(args, "team_attach", None) is not None
-        ):
+        if args.team_mode is not None and getattr(args, "team_attach", None) is not None:
             log_error("--team-mode and --team-attach are mutually exclusive")
             return 1
 
@@ -913,6 +912,7 @@ def run_orchestrate(args: argparse.Namespace) -> int:
                     show_graph=getattr(args, "show_graph", False),
                     fast=getattr(args, "fast", False),
                     playbook_name=playbook_name,
+                    playbook_artifacts=playbook_artifacts,
                     invocation_id=getattr(args, "invocation", None),
                     project=getattr(args, "project", None),
                 )

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -747,8 +747,13 @@ async def stop_live_persist(
     *,
     status: str = "completed",
     exception: BaseException | None = None,
-) -> None:
+) -> str:
     """Update session bookmarks, lifecycle columns, and close DB.
+
+    Returns the *effective* terminal status — ADR-0029 §7's verification
+    override can flip a clean ``completed`` into ``failed`` when required
+    artifacts are missing. Callers MUST use the returned status for the
+    process exit code.
 
     The DB close is in its own ``finally`` so it always runs — even if
     the bookmark update or hook removal fails. Leaving the DB unclosed
@@ -759,7 +764,7 @@ async def stop_live_persist(
 
     ctx = env._live_persist
     if ctx is None:
-        return
+        return status
     log = logging.getLogger("lionagi.cli")
     db = ctx["db"]
     try:
@@ -836,9 +841,11 @@ async def stop_live_persist(
             branch.on_message_added[:] = [h for h in branch.on_message_added if h is not hook]
     except Exception as exc:
         log.warning("live persist teardown failed: %s", exc, exc_info=True)
+        return status
     finally:
         try:
             await db.close()
         except Exception as exc:
             log.warning("live persist db.close failed: %s", exc, exc_info=True)
         env._live_persist = None
+    return final_status

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -35,6 +35,11 @@ from lionagi import Branch, Session
 from lionagi.operations.builder import OperationGraphBuilder
 from lionagi.protocols.generic.log import DataLoggerConfig
 from lionagi.state import provenance as _provenance
+from lionagi.state.artifact_verifier import (
+    missing_artifact_evidence,
+    missing_artifact_summary,
+    verify_artifact_contract,
+)
 
 from .._agents import AgentProfile, load_agent_profile
 from .._logging import hint
@@ -42,15 +47,14 @@ from .._providers import build_imodel_from_spec, resolve_persisted_effort
 from .._runs import RunDir, allocate_run, save_last_branch_pointer
 
 
-def _resolve_session_model(
-    provider: str | None, model: str | None
-) -> str | None:
+def _resolve_session_model(provider: str | None, model: str | None) -> str | None:
     """ADR-0022: canonical 'provider/model' for the session.model column.
 
     Thin wrapper over :func:`provenance.resolve_model_spec` so callers
     don't repeat the import. Returns None when both args are None.
     """
     return _provenance.resolve_model_spec(provider, model)
+
 
 __all__ = (
     "OrchestrationEnv",
@@ -261,9 +265,7 @@ def setup_orchestration(
             fast = True
 
     if not model_spec:
-        raise ValueError(
-            "Provide a model spec or use -a/--agent to load a profile with a model."
-        )
+        raise ValueError("Provide a model spec or use -a/--agent to load a profile with a model.")
 
     orc_imodel = build_imodel_from_spec(
         model_spec,
@@ -398,9 +400,7 @@ def build_worker_branch(
     w_imodel.endpoint.config.kwargs["repo"] = artifact_dir
     # Grant write access to the actual project directory so workers can
     # edit source files, not just their artifact sandbox.
-    project_root = (
-        str(Path(env.cwd).resolve()) if env.cwd else str(Path.cwd().resolve())
-    )
+    project_root = str(Path(env.cwd).resolve()) if env.cwd else str(Path.cwd().resolve())
     w_imodel.endpoint.config.kwargs.setdefault("add_dir", [])
     if project_root not in w_imodel.endpoint.config.kwargs["add_dir"]:
         w_imodel.endpoint.config.kwargs["add_dir"].append(project_root)
@@ -498,7 +498,9 @@ def finalize_orchestration(
         except Exception as exc:  # noqa: BLE001
             log.warning(
                 "finalize: branch snapshot write failed for %s: %s",
-                branch.id, exc, exc_info=True,
+                branch.id,
+                exc,
+                exc_info=True,
             )
 
     if extras:
@@ -526,6 +528,7 @@ async def start_live_persist(
     playbook_name: str | None = None,
     agent_name: str | None = None,
     artifacts_path: str | None = None,
+    artifact_contract: dict[str, Any] | None = None,
     invocation_id: str | None = None,
     model: str | None = None,
     provider: str | None = None,
@@ -576,6 +579,7 @@ async def start_live_persist(
                 "playbook_name": playbook_name,
                 "agent_name": agent_name,
                 "artifacts_path": artifacts_path,
+                "artifact_contract_json": artifact_contract,
                 "status": "running",
                 "started_at": time.time(),
                 # ADR-0020: optional skill orchestration parent
@@ -599,6 +603,8 @@ async def start_live_persist(
             "session_prog_id": session_prog_id,
             "branch_prog_ids": {},
             "hooks": [],
+            "artifacts_path": artifacts_path,
+            "artifact_contract": artifact_contract,
         }
         env._live_persist = ctx
 
@@ -676,9 +682,7 @@ def _register_branch_hook(ctx: dict[str, Any], branch: Branch) -> None:
                 ep_cfg = branch.chat_model.endpoint.config
                 br_provider = getattr(ep_cfg, "provider", None)
                 br_model_raw = (ep_cfg.kwargs or {}).get("model")
-                br_model = _provenance.resolve_model_spec(
-                    br_provider, br_model_raw
-                )
+                br_model = _provenance.resolve_model_spec(br_provider, br_model_raw)
             except Exception as _provenance_exc:  # noqa: BLE001
                 # Provenance is best-effort — never block the branch row.
                 import logging
@@ -719,9 +723,7 @@ def _register_branch_hook(ctx: dict[str, Any], branch: Branch) -> None:
             await db.append_to_progression(branch_prog_id, msg_id)
             await db.append_to_progression(session_prog_id, msg_id)
             # ADR-0019: activity heartbeat for staleness detection.
-            await db.touch_session_activity(
-                session_id, at=msg_dict.get("created_at")
-            )
+            await db.touch_session_activity(session_id, at=msg_dict.get("created_at"))
             # ADR-0009: keep branches.system_msg_id pointing at the
             # current system if the runtime replaces it mid-flow.
             if msg_dict.get("role") == "system":
@@ -744,6 +746,7 @@ async def stop_live_persist(
     env: OrchestrationEnv,
     *,
     status: str = "completed",
+    exception: BaseException | None = None,
 ) -> None:
     """Update session bookmarks, lifecycle columns, and close DB.
 
@@ -761,10 +764,10 @@ async def stop_live_persist(
     db = ctx["db"]
     try:
         session_prog_id = ctx["session_prog_id"]
+        session_id = ctx["session_id"]
 
         all_msgs = await db.get_progression(session_prog_id)
         update_kwargs: dict[str, Any] = {
-            "status": status,
             "ended_at": time.time(),
         }
         if all_msgs:
@@ -775,15 +778,62 @@ async def stop_live_persist(
         if extras:
             update_kwargs["node_metadata"] = json.dumps(extras)
 
-        await db.update_session(ctx["session_id"], **update_kwargs)
+        await db.update_session(session_id, **update_kwargs)
+
+        from lionagi.cli.agent import _resolve_run_reason
+
+        reason_code, reason_summary, evidence_refs = _resolve_run_reason(
+            status=status,
+            exception=exception,
+        )
+        metadata: dict[str, Any] | None = None
+        if exception is not None:
+            metadata = {"exception_class": type(exception).__name__}
+
+        session_row = await db.get_session(session_id) or {}
+        verification = verify_artifact_contract(
+            session_row.get("artifact_contract_json"),
+            artifacts_root=session_row.get("artifacts_path"),
+        )
+        await db.update_artifact_verification(session_id, verification)
+
+        final_status = status
+        final_reason_code = reason_code
+        final_reason_summary = reason_summary
+        final_evidence_refs = evidence_refs
+        if verification and verification["status"] == "failed":
+            missing = verification["missing_required"]
+            if status == "completed":
+                from lionagi.state.reasons import RunReasons
+
+                final_status = "failed"
+                final_reason_code = RunReasons.FAILED_MISSING_ARTIFACT
+                final_reason_summary = missing_artifact_summary(missing)
+                final_evidence_refs = missing_artifact_evidence(missing)
+            else:
+                metadata = dict(metadata or {})
+                metadata["artifact_verification_status"] = verification["status"]
+                metadata["missing_required_artifact_ids"] = [
+                    str(entry.get("id", "")) for entry in missing
+                ]
+
+        await db.update_status(
+            "session",
+            session_id,
+            new_status=final_status,
+            reason_code=final_reason_code,
+            reason_summary=final_reason_summary,
+            evidence_refs=final_evidence_refs,
+            source="executor",
+            actor=session_id,
+            metadata=metadata,
+        )
 
         # Remove ALL matching registrations of each hook (list.remove
         # would only drop the first; a duplicate registration would
         # leave a closed-DB hook live).
         for branch, hook in ctx["hooks"]:
-            branch.on_message_added[:] = [
-                h for h in branch.on_message_added if h is not hook
-            ]
+            branch.on_message_added[:] = [h for h in branch.on_message_added if h is not hook]
     except Exception as exc:
         log.warning("live persist teardown failed: %s", exc, exc_info=True)
     finally:

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import re
 import time
@@ -419,11 +420,18 @@ async def _run_flow(
     show_graph: bool = False,
     fast: bool = False,
     playbook_name: str | None = None,
+    playbook_artifacts: dict | None = None,
     invocation_id: str | None = None,
     project: str | None = None,
     **legacy_kwargs,
-) -> str:
+) -> tuple[str, str]:
     """Auto-DAG flow: orchestrator plans DAG → engine executes with deps.
+
+    Returns ``(output, terminal_status)`` — ADR-0029 §7 lets the artifact
+    contract verifier flip a clean ``completed`` into ``failed`` at
+    teardown, so callers MUST use the returned status to compute the
+    process exit code rather than assuming success when no exception
+    was raised.
 
     ``max_ops`` caps the number of operations (DAG nodes) the planner may
     emit. ``max_agents`` is accepted as a deprecated alias.
@@ -435,9 +443,7 @@ async def _run_flow(
         legacy_kwargs.pop("max_agents")
     if legacy_kwargs:
         # Surface unrecognized kwargs instead of swallowing.
-        raise TypeError(
-            f"_run_flow() got unexpected keyword arguments: {list(legacy_kwargs)}"
-        )
+        raise TypeError(f"_run_flow() got unexpected keyword arguments: {list(legacy_kwargs)}")
     env = setup_orchestration(
         pattern_name="Flow",
         model_spec=model_spec,
@@ -463,6 +469,27 @@ async def _run_flow(
     _orc_provider = None
     if _orc_ms and "/" in _orc_ms.model:
         _orc_provider = _orc_ms.model.split("/", 1)[0]
+    # ADR-0029 §4-5: resolve the artifact contract (playbook overrides
+    # agent defaults by id; playbook wins). Snapshot onto the session
+    # via start_live_persist so verify_artifact_contract() at teardown
+    # has something to check against. None = no contract declared →
+    # verification skipped entirely.
+    artifact_contract = None
+    if playbook_artifacts is not None or (
+        agent_name is not None and getattr(env.agent_profile, "artifact_defaults", None) is not None
+    ):
+        from lionagi.state.artifact_verifier import resolve_artifact_contract
+
+        agent_defaults = (
+            getattr(env.agent_profile, "artifact_defaults", None)
+            if agent_name is not None
+            else None
+        )
+        artifact_contract = resolve_artifact_contract(
+            playbook_artifacts=playbook_artifacts,
+            agent_defaults=agent_defaults,
+        )
+
     await start_live_persist(
         env,
         invocation_kind="play" if playbook_name else "flow",
@@ -474,6 +501,7 @@ async def _run_flow(
         provider=_orc_provider,
         effort=env.effort,
         project=project,
+        artifact_contract=artifact_contract,
     )
 
     inner_kw = dict(
@@ -490,6 +518,7 @@ async def _run_flow(
     )
     # ADR-0025: distinguish timed_out / aborted / cancelled / failed.
     _terminal_status = "completed"
+    result: str = ""
     try:
         if timeout:
             with move_on_after(timeout) as cancel_scope:
@@ -497,8 +526,8 @@ async def _run_flow(
             if cancel_scope.cancelled_caught:
                 _terminal_status = "timed_out"
                 raise LionTimeoutError(f"Flow timed out after {timeout}s")
-            return result
-        return await _run_flow_inner(model_spec, prompt, **inner_kw)
+        else:
+            result = await _run_flow_inner(model_spec, prompt, **inner_kw)
     except KeyboardInterrupt:
         _terminal_status = "aborted"
         raise
@@ -521,9 +550,16 @@ async def _run_flow(
         import anyio
 
         with anyio.CancelScope(shield=True):
-            await stop_live_persist(env, status=_terminal_status)
+            # ADR-0029 §7: stop_live_persist may override the proposed
+            # status (clean exit + missing required → failed). Use the
+            # returned status for downstream exit-code propagation.
+            effective_status = await stop_live_persist(env, status=_terminal_status)
+            if effective_status != _terminal_status:
+                _terminal_status = effective_status
             for _br in env.session.branches:
                 await _br.mdls.shutdown()
+
+    return result, _terminal_status
 
 
 async def _run_flow_inner(
@@ -632,7 +668,9 @@ async def _run_flow_inner(
     seen_agent_ids: set[str] = set()
     for a in plan.agents:
         if a.id in seen_agent_ids:
-            return f"Invalid plan: duplicate FlowAgent.id {a.id!r}. Each agent must have a unique id."
+            return (
+                f"Invalid plan: duplicate FlowAgent.id {a.id!r}. Each agent must have a unique id."
+            )
         seen_agent_ids.add(a.id)
 
     # Reject duplicate FlowOp.id as well — depends_on references would
@@ -738,9 +776,7 @@ async def _run_flow_inner(
 
             visualize_plan(
                 plan,
-                title=(
-                    f"Flow DAG plan — {len(plan.agents)} agents / {len(plan.operations)} ops"
-                ),
+                title=(f"Flow DAG plan — {len(plan.agents)} agents / {len(plan.operations)} ops"),
                 save_path=str(run.dag_image_path),
             )
 
@@ -815,9 +851,7 @@ async def _run_flow_inner(
                     # turn — no need to re-gather context or re-read files.
                     dep_notes.append(f"{d}: already in your memory (same agent)")
                 else:
-                    dep_notes.append(
-                        f"{d} ({dep_agent}): {run.agent_artifact_dir(dep_agent)}/"
-                    )
+                    dep_notes.append(f"{d} ({dep_agent}): {run.agent_artifact_dir(dep_agent)}/")
             if dep_notes:
                 artifact_note += f" Upstream: {'; '.join(dep_notes)}."
         ctx.append({"artifact_instructions": artifact_note})
@@ -886,9 +920,7 @@ async def _run_flow_inner(
     control_ops = [op for op in plan.operations if op.control]
 
     ctrl_note = f" ({len(control_ops)} control)" if control_ops else ""
-    progress(
-        f"Executing DAG: {len(plan.agents)} agents / {len(regular_ops)} ops{ctrl_note}..."
-    )
+    progress(f"Executing DAG: {len(plan.agents)} agents / {len(regular_ops)} ops{ctrl_note}...")
 
     for op in regular_ops:
         a = agent_spec_by_id[op.agent_id]
@@ -930,14 +962,16 @@ async def _run_flow_inner(
         branch_id = str(branch.id) if branch else ""
         now = time.time()
         if new_status == "running":
-            _op_segments.append({
-                "op_id": op_id,
-                "branch_id": branch_id,
-                "branch_name": branch_name,
-                "status": "running",
-                "started_at": now,
-                "ended_at": None,
-            })
+            _op_segments.append(
+                {
+                    "op_id": op_id,
+                    "branch_id": branch_id,
+                    "branch_name": branch_name,
+                    "status": "running",
+                    "started_at": now,
+                    "ended_at": None,
+                }
+            )
         else:
             for seg in reversed(_op_segments):
                 if seg["op_id"] == op_id:
@@ -956,12 +990,9 @@ async def _run_flow_inner(
         import asyncio as _aio
 
         async def _do():
-            try:
-                await ctx["db"].update_session(
-                    ctx["session_id"], node_metadata=json.dumps(extras)
-                )
-            except Exception:
-                pass
+            # Best-effort live metadata update — must not block the flow.
+            with contextlib.suppress(Exception):
+                await ctx["db"].update_session(ctx["session_id"], node_metadata=json.dumps(extras))
 
         _aio.ensure_future(_do())
 
@@ -975,15 +1006,14 @@ async def _run_flow_inner(
         import asyncio as _aio
 
         async def _do():
-            try:
+            # Best-effort branch status sync — must not block the flow.
+            with contextlib.suppress(Exception):
                 kw = {"status": new_status}
                 if new_status == "running":
                     kw["started_at"] = time.time()
                 elif new_status in ("completed", "failed"):
                     kw["ended_at"] = time.time()
                 await ctx["db"].update_branch(str(branch.id), **kw)
-            except Exception:
-                pass
 
         _aio.ensure_future(_do())
 
@@ -994,19 +1024,23 @@ async def _run_flow_inner(
             for aid in agents_by_id
         ],
         "operations": [
-            {"id": op.id, "agent_id": op.agent_id, "control": op.control, "depends_on": op.depends_on or []}
+            {
+                "id": op.id,
+                "agent_id": op.agent_id,
+                "control": op.control,
+                "depends_on": op.depends_on or [],
+            }
             for op in plan.operations
         ],
     }
     env._finalize_extras = _early_graph
     ctx = getattr(env, "_live_persist", None)
     if ctx and ctx.get("db"):
-        try:
+        # Best-effort early DAG snapshot — flow continues even if persist fails.
+        with contextlib.suppress(Exception):
             await ctx["db"].update_session(
                 ctx["session_id"], node_metadata=json.dumps(_early_graph)
             )
-        except Exception:
-            pass
 
     # Execute regular ops
     t_exec = time.monotonic()
@@ -1049,9 +1083,7 @@ async def _run_flow_inner(
         c_branch = agents_by_id[cop.agent_id]
         c_model = agent_model_by_id[cop.agent_id]
 
-        artifacts = [
-            f"[op {r['id']} via {r['name']}]: {r['response']}" for r in agent_results
-        ]
+        artifacts = [f"[op {r['id']} via {r['name']}]: {r['response']}" for r in agent_results]
         dep_nodes = [op_to_node[d] for d in (cop.depends_on or []) if d in op_to_node]
         if not dep_nodes:
             dep_nodes = list(op_to_node.values())[-1:] or [plan_root]
@@ -1170,9 +1202,7 @@ async def _run_flow_inner(
             new_ops: list[FlowOp] = []
             for nop in next_plan.operations:
                 if nop.agent_id not in agents_by_id:
-                    progress(
-                        f"Re-plan: skipping op {nop.id!r} — unknown agent {nop.agent_id!r}"
-                    )
+                    progress(f"Re-plan: skipping op {nop.id!r} — unknown agent {nop.agent_id!r}")
                     continue
                 if nop.id in op_to_node:
                     progress(f"Re-plan: skipping duplicate op id {nop.id!r}")
@@ -1221,9 +1251,7 @@ async def _run_flow_inner(
                 op_id_to_agent[nop.id] = nop.agent_id
 
             ids = ", ".join(o.id for o in new_ops)
-            progress(
-                f"Re-plan: +{len(next_plan.agents)} agents, +{len(new_ops)} ops: {ids}"
-            )
+            progress(f"Re-plan: +{len(next_plan.agents)} agents, +{len(new_ops)} ops: {ids}")
 
             for nop in new_ops:
                 na = agent_spec_by_id[nop.agent_id]
@@ -1284,9 +1312,7 @@ async def _run_flow_inner(
         all_op_node_ids = set(op_to_node.values())
         leaf_nodes = list(all_op_node_ids - depended_on_nodes) or list(all_op_node_ids)
 
-        artifacts = [
-            f"[op {r['id']} via {r['name']}]: {r['response']}" for r in agent_results
-        ]
+        artifacts = [f"[op {r['id']} via {r['name']}]: {r['response']}" for r in agent_results]
         adirs = [str(run.agent_artifact_dir(aid)) for aid in agents_by_id]
         artifact_chain_note = (
             f"\n\nARTIFACT CHAIN: Read ALL files in: {', '.join(adirs)}. "
@@ -1339,9 +1365,7 @@ async def _run_flow_inner(
         run.synthesis_path.write_text(synthesis_result["response"])
 
     if team_data:
-        _post_results_to_team(
-            team_data, agent_results, all_agent_names, synthesis_result
-        )
+        _post_results_to_team(team_data, agent_results, all_agent_names, synthesis_result)
 
     # ── Persist branches + run manifest + hints ──────────────────────
     finalize_orchestration(

--- a/lionagi/state/artifact_verifier.py
+++ b/lionagi/state/artifact_verifier.py
@@ -1,0 +1,219 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""ADR-0029: Artifact contract validation and verification."""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+from pathlib import PurePosixPath
+from typing import Any, Literal, TypedDict
+
+_GLOB_CHARS = frozenset("*?[]")
+_ARTIFACT_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+_VALIDATION_ROOT = os.path.realpath("/tmp/__contract_validate__")  # noqa: S108 — synthetic root for path-validation only, never written to
+
+
+class ArtifactPathError(ValueError):
+    """Raised when an artifact contract id/path is invalid."""
+
+
+class ExpectedArtifact(TypedDict, total=False):
+    id: str
+    path: str
+    required: bool
+    description: str
+    source: str
+
+
+class ProducedArtifact(TypedDict):
+    id: str
+    path: str
+    size: int
+    present: bool
+
+
+class ArtifactContract(TypedDict):
+    expected: list[ExpectedArtifact]
+
+
+class VerificationResult(TypedDict):
+    status: Literal["passed", "failed", "warning", "skipped"]
+    checked_at: float
+    missing_required: list[ExpectedArtifact]
+    missing_optional: list[ExpectedArtifact]
+    produced: list[ProducedArtifact]
+
+
+def _safe_join(root: str, rel: str) -> str:
+    """Join rel under root, rejecting absolute paths, globs, '..', and escapes."""
+    if not isinstance(rel, str) or not rel or rel.startswith("/"):
+        raise ArtifactPathError(f"absolute path not allowed: {rel!r}")
+    if any(c in _GLOB_CHARS for c in rel):
+        raise ArtifactPathError(f"glob characters not allowed in v1: {rel!r}")
+
+    parts = PurePosixPath(rel).parts
+    if not parts or any(p in ("..", "") for p in parts):
+        raise ArtifactPathError(f"`..` segments not allowed: {rel!r}")
+
+    root_real = os.path.realpath(root)
+    joined = os.path.realpath(os.path.join(root_real, *parts))
+    try:
+        common = os.path.commonpath([root_real, joined])
+    except ValueError as exc:
+        raise ArtifactPathError(f"path escapes artifacts_root: {rel!r}") from exc
+    if common != root_real:
+        raise ArtifactPathError(f"path escapes artifacts_root: {rel!r}")
+    return joined
+
+
+def validate_artifact_contract(contract: dict[str, Any] | None) -> None:
+    if contract is None:
+        return
+    if not isinstance(contract, dict):
+        raise ArtifactPathError(f"artifact contract must be a dict, got {type(contract).__name__}")
+    expected = contract.get("expected")
+    if not isinstance(expected, list):
+        raise ArtifactPathError("artifact contract must contain expected: list")
+
+    seen_ids: set[str] = set()
+    for idx, entry in enumerate(expected):
+        if not isinstance(entry, dict):
+            raise ArtifactPathError(f"expected[{idx}] must be a dict")
+        eid = entry.get("id")
+        if not isinstance(eid, str) or not _ARTIFACT_ID_RE.fullmatch(eid):
+            raise ArtifactPathError(f"id must be alphanumeric/_/-: {eid!r}")
+        if eid in seen_ids:
+            raise ArtifactPathError(f"duplicate id in contract: {eid!r}")
+        seen_ids.add(eid)
+
+        path = entry.get("path")
+        if not isinstance(path, str) or not path:
+            raise ArtifactPathError(f"expected[{idx}].path must be a non-empty string")
+        if "required" in entry and not isinstance(entry["required"], bool):
+            raise ArtifactPathError(f"expected[{idx}].required must be a bool")
+        if "description" in entry and not isinstance(entry["description"], str):
+            raise ArtifactPathError(f"expected[{idx}].description must be a string")
+        if "source" in entry and not isinstance(entry["source"], str):
+            raise ArtifactPathError(f"expected[{idx}].source must be a string")
+
+        _safe_join(_VALIDATION_ROOT, path)
+
+
+def resolve_artifact_contract(
+    *,
+    playbook_artifacts: dict[str, Any] | None,
+    agent_defaults: dict[str, Any] | None,
+) -> ArtifactContract | None:
+    if playbook_artifacts is None and agent_defaults is None:
+        return None
+
+    by_id: dict[str, ExpectedArtifact] = {}
+    for source, declared in (
+        ("agent_profile", agent_defaults),
+        ("playbook", playbook_artifacts),
+    ):
+        if declared is None:
+            continue
+        if not isinstance(declared, dict):
+            raise ArtifactPathError(f"{source} artifact contract must be a dict")
+        expected = declared.get("expected")
+        if not isinstance(expected, list):
+            raise ArtifactPathError(f"{source} artifact contract must contain expected: list")
+        for raw in expected:
+            if not isinstance(raw, dict):
+                raise ArtifactPathError(f"{source} expected artifact must be a dict")
+            spec: ExpectedArtifact = {
+                **raw,
+                "required": raw.get("required", True),
+                "description": raw.get("description", ""),
+                "source": source,
+            }
+            by_id[spec["id"]] = spec
+
+    resolved: ArtifactContract = {"expected": list(by_id.values())}
+    validate_artifact_contract(resolved)
+    return resolved
+
+
+def verify_artifact_contract(
+    contract: dict[str, Any] | None,
+    *,
+    artifacts_root: str | None,
+) -> VerificationResult | None:
+    if contract is None:
+        return None
+    validate_artifact_contract(contract)
+    expected = contract["expected"]
+
+    if not artifacts_root or not os.path.isdir(artifacts_root):
+        mr = [e for e in expected if e.get("required", True)]
+        mo = [e for e in expected if not e.get("required", True)]
+        if mr:
+            st: Literal["failed", "warning", "passed"] = "failed"
+        elif mo:
+            st = "warning"
+        else:
+            st = "passed"
+        return {
+            "status": st,
+            "checked_at": time.time(),
+            "missing_required": mr,
+            "missing_optional": mo,
+            "produced": [],
+        }
+
+    root = os.path.realpath(artifacts_root)
+    missing_required: list[ExpectedArtifact] = []
+    missing_optional: list[ExpectedArtifact] = []
+    produced: list[ProducedArtifact] = []
+
+    for entry in expected:
+        full = _safe_join(root, entry["path"])
+        present = os.path.isfile(full) and os.path.getsize(full) > 0
+        if present:
+            produced.append(
+                {
+                    "id": entry["id"],
+                    "path": entry["path"],
+                    "size": os.path.getsize(full),
+                    "present": True,
+                }
+            )
+        elif entry.get("required", True):
+            missing_required.append(entry)
+        else:
+            missing_optional.append(entry)
+
+    if missing_required:
+        status: Literal["failed", "warning", "passed"] = "failed"
+    elif missing_optional:
+        status = "warning"
+    else:
+        status = "passed"
+    return {
+        "status": status,
+        "checked_at": time.time(),
+        "missing_required": missing_required,
+        "missing_optional": missing_optional,
+        "produced": produced,
+    }
+
+
+def missing_artifact_summary(missing: list[dict[str, Any]]) -> str:
+    if len(missing) == 1:
+        entry = missing[0]
+        return f"Missing required artifact: {entry.get('id')} ({entry.get('path')})."
+    return f"Missing {len(missing)} required artifacts."
+
+
+def missing_artifact_evidence(missing: list[dict[str, Any]]) -> list[dict[str, str]]:
+    return [
+        {
+            "kind": "expected_artifact",
+            "id": str(entry.get("id", "")),
+            "label": str(entry.get("path", "")),
+        }
+        for entry in missing
+    ]

--- a/lionagi/state/artifact_verifier.py
+++ b/lionagi/state/artifact_verifier.py
@@ -14,6 +14,13 @@ _GLOB_CHARS = frozenset("*?[]")
 _ARTIFACT_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 _VALIDATION_ROOT = os.path.realpath("/tmp/__contract_validate__")  # noqa: S108 — synthetic root for path-validation only, never written to
 
+# ADR-0029 §2: v1 entry fields. `kind`, `min_size`, `mime_type` are
+# reserved for v1.1 — silently accepting them now would let contract
+# files drift into looking stricter than the executor actually is.
+# Both the `li play check` pre-flight AND the real `li play` runtime
+# path emit a warning for unknown subfields via warn_unknown_artifact_keys().
+_ARTIFACT_ENTRY_ALLOWED_KEYS = frozenset({"id", "path", "required", "description", "source"})
+
 
 class ArtifactPathError(ValueError):
     """Raised when an artifact contract id/path is invalid."""
@@ -66,6 +73,53 @@ def _safe_join(root: str, rel: str) -> str:
     if common != root_real:
         raise ArtifactPathError(f"path escapes artifacts_root: {rel!r}")
     return joined
+
+
+def warn_unknown_artifact_keys(
+    contract: dict[str, Any] | None,
+    *,
+    source: str = "playbook",
+    emit: Any = None,
+) -> list[str]:
+    """Warn about unknown subfields under each `expected[]` entry.
+
+    ADR-0029 §2 declares v1 fields as `id, path, required, description`
+    (plus `source` added by the resolver). `kind`, `min_size`,
+    `mime_type` are reserved for v1.1. Silently accepting them in v1
+    lets contract files look stricter than the executor actually is —
+    warn so the author sees what was ignored.
+
+    Both `li play check` (pre-flight) and the real `li play` execution
+    path call this so the warning fires in both surfaces.
+
+    ``emit`` defaults to printing to stdout (for the CLI pre-flight).
+    The runtime path passes a logger so warnings land in the structured
+    log, not the console.
+
+    Returns the list of warning messages emitted (so tests can assert
+    without capturing the side channel).
+    """
+    if contract is None:
+        return []
+    expected = contract.get("expected") or []
+    if not isinstance(expected, list):
+        return []
+    if emit is None:
+        emit = print
+    warnings: list[str] = []
+    for entry in expected:
+        if not isinstance(entry, dict):
+            continue
+        unknown = set(entry.keys()) - _ARTIFACT_ENTRY_ALLOWED_KEYS
+        if unknown:
+            msg = (
+                f"warning: {source} artifact entry "
+                f"{entry.get('id', '<unnamed>')!r} has unknown subfield(s) "
+                f"{sorted(unknown)} (ignored by v1; reserved for v1.1)."
+            )
+            warnings.append(msg)
+            emit(msg)
+    return warnings
 
 
 def validate_artifact_contract(contract: dict[str, Any] | None) -> None:

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -359,6 +359,9 @@ class StateDB:
             ("status_reason_code", "TEXT"),
             ("status_reason_summary", "TEXT"),
             ("status_evidence_refs", "JSON"),
+            # ADR-0029: resolved artifact contract and teardown result.
+            ("artifact_contract_json", "JSON"),
+            ("artifact_verification_json", "JSON"),
         ],
         "branches": [
             ("system_msg_id", "TEXT"),
@@ -515,7 +518,10 @@ class StateDB:
                   -- preserves these columns when migrating from ADR-0017.
                   status_reason_code     TEXT,
                   status_reason_summary  TEXT,
-                  status_evidence_refs   JSON
+                  status_evidence_refs   JSON,
+                  -- ADR-0029: artifact contract snapshot and verification.
+                  artifact_contract_json      JSON,
+                  artifact_verification_json  JSON
                 )
                 """
             )
@@ -702,12 +708,13 @@ class StateDB:
             """INSERT OR IGNORE INTO sessions (id, created_at, node_metadata, name, user,
                progression_id, first_msg_id, last_msg_id, updated_at,
                playbook_name, agent_name, invocation_kind, show_topic,
-               show_play_name, artifacts_path, source_kind,
+               show_play_name, artifacts_path, artifact_contract_json,
+               artifact_verification_json, source_kind,
                status, started_at, ended_at, last_message_at, invocation_id,
                model, provider, effort, agent_hash,
                project, project_source)
                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                       ?, ?, ?, ?, ?, ?)""",
+                       ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 session["id"],
                 session.get("created_at", now),
@@ -726,6 +733,8 @@ class StateDB:
                 session.get("show_topic"),
                 session.get("show_play_name"),
                 session.get("artifacts_path"),
+                _to_json_column(session.get("artifact_contract_json")),
+                _to_json_column(session.get("artifact_verification_json")),
                 session.get("source_kind", "live"),
                 session.get("status"),
                 session.get("started_at"),
@@ -816,6 +825,17 @@ class StateDB:
         await self.db.execute(
             f"UPDATE sessions SET {sets} WHERE id = ?",  # noqa: S608
             vals,
+        )
+        await self.db.commit()
+
+    async def update_artifact_verification(
+        self,
+        session_id: str,
+        verification: dict[str, Any] | None,
+    ) -> None:
+        await self.db.execute(
+            "UPDATE sessions SET artifact_verification_json = ?, updated_at = ? WHERE id = ?",
+            (_to_json_column(verification), time.time(), session_id),
         )
         await self.db.commit()
 
@@ -1972,6 +1992,8 @@ class StateDB:
             "action_extra_args",
             "trigger_context",
             "action_args",
+            "artifact_contract_json",
+            "artifact_verification_json",
         ):
             if key in d and isinstance(d[key], str):
                 try:

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -159,7 +159,12 @@ CREATE TABLE IF NOT EXISTS sessions (
   -- never drift.
   status_reason_code     TEXT,
   status_reason_summary  TEXT,
-  status_evidence_refs   JSON
+  status_evidence_refs   JSON,
+  -- ── Artifact contract (ADR-0029) ──────────────────────────────────────
+  -- Resolved contract snapshot written at session creation and verifier
+  -- result written at teardown. NULL contract means verification skipped.
+  artifact_contract_json      JSON,
+  artifact_verification_json  JSON
 );
 
 CREATE INDEX IF NOT EXISTS idx_sessions_updated

--- a/tests/agent/test_profile_artifacts.py
+++ b/tests/agent/test_profile_artifacts.py
@@ -1,0 +1,76 @@
+"""Tests for ADR-0029 artifact_defaults in AgentProfile frontmatter."""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.cli._agents import _parse_profile
+
+
+class TestProfileArtifactDefaults:
+    def test_no_artifact_defaults_is_none(self):
+        text = "---\nmodel: codex/gpt-4o\n---\nSystem prompt."
+        profile = _parse_profile("agent", text)
+        assert profile.artifact_defaults is None
+
+    def test_artifact_defaults_nested_dict(self):
+        text = (
+            "---\n"
+            "artifact_defaults:\n"
+            "  expected:\n"
+            "    - id: report\n"
+            "      path: report.md\n"
+            "      required: true\n"
+            "---\n"
+            "System prompt."
+        )
+        profile = _parse_profile("agent", text)
+        assert profile.artifact_defaults is not None
+        expected = profile.artifact_defaults["expected"]
+        assert isinstance(expected, list)
+        assert len(expected) == 1
+        assert expected[0]["id"] == "report"
+        assert expected[0]["path"] == "report.md"
+        assert expected[0]["required"] is True
+
+    def test_artifact_defaults_multiple_entries(self):
+        text = (
+            "---\n"
+            "artifact_defaults:\n"
+            "  expected:\n"
+            "    - id: brief\n"
+            "      path: brief.md\n"
+            "    - id: log\n"
+            "      path: log.txt\n"
+            "      required: false\n"
+            "---\n"
+        )
+        profile = _parse_profile("agent", text)
+        assert profile.artifact_defaults is not None
+        assert len(profile.artifact_defaults["expected"]) == 2
+
+    def test_scalar_booleans_still_parse(self):
+        text = "---\nyolo: true\nfast_mode: false\nlion_system: true\n---\n"
+        profile = _parse_profile("agent", text)
+        assert profile.yolo is True
+        assert profile.fast_mode is False
+        assert profile.lion_system is True
+
+    def test_artifact_defaults_not_in_extra(self):
+        text = (
+            "---\n"
+            "artifact_defaults:\n"
+            "  expected:\n"
+            "    - id: x\n"
+            "      path: x.md\n"
+            "custom_key: custom_val\n"
+            "---\n"
+        )
+        profile = _parse_profile("agent", text)
+        assert "artifact_defaults" not in profile.extra
+        assert "custom_key" in profile.extra
+
+    def test_no_frontmatter_gives_no_artifact_defaults(self):
+        text = "Just a plain system prompt without frontmatter."
+        profile = _parse_profile("agent", text)
+        assert profile.artifact_defaults is None

--- a/tests/cli/orchestrate/test_flow_spec_file.py
+++ b/tests/cli/orchestrate/test_flow_spec_file.py
@@ -127,7 +127,7 @@ class TestLoadFlowSpec:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="flow output"),
+            AsyncMock(return_value=("flow output", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 
@@ -151,7 +151,7 @@ class TestLoadFlowSpec:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="ok"),
+            AsyncMock(return_value=("ok", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 
@@ -174,7 +174,7 @@ class TestLoadFlowSpec:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="ok"),
+            AsyncMock(return_value=("ok", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 
@@ -348,7 +348,7 @@ class TestPlaybookEndToEnd:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="done"),
+            AsyncMock(return_value=("done", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 
@@ -373,7 +373,7 @@ class TestPlaybookEndToEnd:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="done"),
+            AsyncMock(return_value=("done", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 
@@ -397,7 +397,7 @@ class TestPlaybookEndToEnd:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="done"),
+            AsyncMock(return_value=("done", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 
@@ -436,7 +436,7 @@ class TestPlaybookEndToEnd:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="done"),
+            AsyncMock(return_value=("done", "completed")),
         ) as run_flow:
             code = cli_main(["play", "hello", "--tabs", "9", "do a thing"])
 
@@ -496,7 +496,7 @@ class TestPlaybookEndToEnd:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="ok"),
+            AsyncMock(return_value=("ok", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 
@@ -517,7 +517,7 @@ class TestPlaybookEndToEnd:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="ok"),
+            AsyncMock(return_value=("ok", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 
@@ -531,7 +531,7 @@ class TestPlaybookEndToEnd:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="ok"),
+            AsyncMock(return_value=("ok", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 
@@ -555,7 +555,7 @@ class TestPlaybookEndToEnd:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="ok"),
+            AsyncMock(return_value=("ok", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 
@@ -580,7 +580,7 @@ class TestPlaybookEndToEnd:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="ok"),
+            AsyncMock(return_value=("ok", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 
@@ -600,7 +600,7 @@ class TestPlaybookEndToEnd:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="ok"),
+            AsyncMock(return_value=("ok", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 
@@ -648,7 +648,7 @@ class TestPlaybookEndToEnd:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="ok"),
+            AsyncMock(return_value=("ok", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 
@@ -720,7 +720,7 @@ class TestPlaybookArtifactsPassThrough:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="done"),
+            AsyncMock(return_value=("done", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 
@@ -748,7 +748,7 @@ class TestPlaybookArtifactsPassThrough:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="done"),
+            AsyncMock(return_value=("done", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 

--- a/tests/cli/orchestrate/test_flow_spec_file.py
+++ b/tests/cli/orchestrate/test_flow_spec_file.py
@@ -120,9 +120,7 @@ class TestLoadFlowSpec:
         result = _load_flow_spec(str(p))
         assert result == spec
 
-    def test_lone_positional_overrides_prompt_when_spec_supplies_model(
-        self, tmp_path, capsys
-    ):
+    def test_lone_positional_overrides_prompt_when_spec_supplies_model(self, tmp_path, capsys):
         p = tmp_path / "spec.yaml"
         p.write_text(yaml.dump({"model": "claude-code/opus-4-7"}))
         args = _parse_flow_args(["-f", str(p), "Write the thing"])
@@ -346,9 +344,7 @@ class TestPlaybookEndToEnd:
             )
         )
         monkeypatch.setenv("HOME", str(tmp_path))
-        args = _parse_flow_args(
-            ["-p", "audit", "--tabs", "7", "--poll", "audit the auth service"]
-        )
+        args = _parse_flow_args(["-p", "audit", "--tabs", "7", "--poll", "audit the auth service"])
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
@@ -470,9 +466,7 @@ class TestPlaybookEndToEnd:
         assert code == 1
         assert "Usage" in capsys.readouterr().out
 
-    def test_playbook_arg_collision_does_not_leak_into_template(
-        self, monkeypatch, tmp_path
-    ):
+    def test_playbook_arg_collision_does_not_leak_into_template(self, monkeypatch, tmp_path):
         """A playbook arg that collides with a built-in flag must NOT have
         its value read from the base argparse default during interpolation.
         The filtered schema (from parser injection) is authoritative.
@@ -498,9 +492,7 @@ class TestPlaybookEndToEnd:
         monkeypatch.setenv("HOME", str(tmp_path))
         # User passes --save /some/dir (built-in), NOT the playbook arg.
         save_dir = tmp_path / "artifacts"
-        args = _parse_flow_args(
-            ["-p", "collider", "--save", str(save_dir), "do the thing"]
-        )
+        args = _parse_flow_args(["-p", "collider", "--save", str(save_dir), "do the thing"])
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
@@ -516,8 +508,7 @@ class TestPlaybookEndToEnd:
         # default if run_orchestrate falls through. Assert the built-in
         # --save value did NOT leak into the template.
         assert str(save_dir) not in prompt, (
-            "Built-in --save value leaked into template via "
-            "collision-shadowed playbook arg"
+            "Built-in --save value leaked into template via collision-shadowed playbook arg"
         )
 
     def test_max_ops_flag_passes_through(self, monkeypatch, tmp_path):
@@ -571,9 +562,7 @@ class TestPlaybookEndToEnd:
         assert code == 0
         assert run_flow.call_args.kwargs["max_ops"] == 8
 
-    def test_playbook_max_agents_deprecated_spec_still_works(
-        self, monkeypatch, tmp_path
-    ):
+    def test_playbook_max_agents_deprecated_spec_still_works(self, monkeypatch, tmp_path):
         """Playbooks with legacy `max_agents:` field must still cap ops."""
         playbooks_dir = tmp_path / ".lionagi" / "playbooks"
         playbooks_dir.mkdir(parents=True)
@@ -703,3 +692,67 @@ class TestPlaybookEndToEnd:
 
         code = run_orchestrate(args)
         assert code == 1
+
+
+# ── ADR-0029: artifacts: block pass-through ───────────────────────────────────
+
+
+class TestPlaybookArtifactsPassThrough:
+    def test_artifacts_block_passed_to_run_flow(self, monkeypatch, tmp_path):
+        """A playbook with artifacts: block passes playbook_artifacts to _run_flow."""
+        playbooks_dir = tmp_path / ".lionagi" / "playbooks"
+        playbooks_dir.mkdir(parents=True)
+        (playbooks_dir / "research.playbook.yaml").write_text(
+            yaml.dump(
+                {
+                    "model": "codex/gpt-4o",
+                    "prompt": "Research the topic.",
+                    "artifacts": {
+                        "expected": [
+                            {"id": "report", "path": "report.md"},
+                        ]
+                    },
+                }
+            )
+        )
+        monkeypatch.setenv("HOME", str(tmp_path))
+        args = _parse_flow_args(["-p", "research", "do it"])
+
+        with patch(
+            "lionagi.cli.orchestrate._run_flow",
+            AsyncMock(return_value="done"),
+        ) as run_flow:
+            code = run_orchestrate(args)
+
+        assert code == 0
+        call_kwargs = run_flow.call_args.kwargs
+        pa = call_kwargs.get("playbook_artifacts")
+        assert pa is not None
+        assert isinstance(pa, dict)
+        assert pa["expected"][0]["id"] == "report"
+
+    def test_no_artifacts_block_passes_none(self, monkeypatch, tmp_path):
+        """A playbook without artifacts: passes None to _run_flow."""
+        playbooks_dir = tmp_path / ".lionagi" / "playbooks"
+        playbooks_dir.mkdir(parents=True)
+        (playbooks_dir / "basic.playbook.yaml").write_text(
+            yaml.dump(
+                {
+                    "model": "codex/gpt-4o",
+                    "prompt": "Do the task.",
+                }
+            )
+        )
+        monkeypatch.setenv("HOME", str(tmp_path))
+        args = _parse_flow_args(["-p", "basic", "do it"])
+
+        with patch(
+            "lionagi.cli.orchestrate._run_flow",
+            AsyncMock(return_value="done"),
+        ) as run_flow:
+            code = run_orchestrate(args)
+
+        assert code == 0
+        call_kwargs = run_flow.call_args.kwargs
+        pa = call_kwargs.get("playbook_artifacts")
+        assert pa is None

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -162,9 +162,9 @@ async def test_start_create_session_failure_closes_db(
         if _aiosqlite_thread_count() <= before:
             break
         await asyncio.sleep(0.05)
-    assert (
-        _aiosqlite_thread_count() <= before
-    ), "DB was not closed on start failure — aiosqlite worker leaked"
+    assert _aiosqlite_thread_count() <= before, (
+        "DB was not closed on start failure — aiosqlite worker leaked"
+    )
 
 
 # ── _register_branch_hook: lazy branch row + multi-message paths ──────────────
@@ -204,9 +204,7 @@ async def test_register_branch_hook_creates_row_on_first_message(
 
     async with StateDB() as db:
         b_after = await db.get_branch(str(worker.id))
-        prog = await db.get_progression(
-            env._live_persist["branch_prog_ids"][str(worker.id)]
-        )
+        prog = await db.get_progression(env._live_persist["branch_prog_ids"][str(worker.id)])
         session_prog = await db.get_progression(env._live_persist["session_prog_id"])
     assert b_after is not None
     assert b_after["session_id"] == str(env.session.id)
@@ -260,9 +258,7 @@ async def test_register_branch_hook_ensure_branch_row_idempotent(
         )
         n_sys = (await cur.fetchone())["n"]
         # Branch progression has both user messages.
-        prog = await db.get_progression(
-            env._live_persist["branch_prog_ids"][str(worker.id)]
-        )
+        prog = await db.get_progression(env._live_persist["branch_prog_ids"][str(worker.id)])
 
     assert n_rows == 1
     assert n_sys == 1
@@ -310,12 +306,8 @@ async def test_multiple_branches_share_session_progression(
 
     async with StateDB() as db:
         session_prog = await db.get_progression(env._live_persist["session_prog_id"])
-        w1_prog = await db.get_progression(
-            env._live_persist["branch_prog_ids"][str(w1.id)]
-        )
-        w2_prog = await db.get_progression(
-            env._live_persist["branch_prog_ids"][str(w2.id)]
-        )
+        w1_prog = await db.get_progression(env._live_persist["branch_prog_ids"][str(w1.id)])
+        w2_prog = await db.get_progression(env._live_persist["branch_prog_ids"][str(w2.id)])
 
     assert set(session_prog) == {str(m1.id), str(m2.id)}
     assert w1_prog == [str(m1.id)]
@@ -528,9 +520,9 @@ async def test_start_stop_does_not_leak_aiosqlite_thread(temp_db_path: Path):
             if _aiosqlite_thread_count() <= baseline:
                 break
             await asyncio.sleep(0.05)
-        assert (
-            _aiosqlite_thread_count() <= baseline
-        ), "aiosqlite worker thread leaked across orchestration start/stop"
+        assert _aiosqlite_thread_count() <= baseline, (
+            "aiosqlite worker thread leaked across orchestration start/stop"
+        )
 
 
 # ── R5-A MED-1: lazy _ensure_branch_row retry after first-init failure ────────
@@ -569,10 +561,14 @@ async def test_ensure_branch_row_retries_after_transient_failure(
     monkeypatch.setattr(StateDB, "create_branch", flaky_create)
 
     m1 = MessageManager.create_instruction(
-        instruction="a", sender="u", recipient=str(worker.id),
+        instruction="a",
+        sender="u",
+        recipient=str(worker.id),
     )
     m2 = MessageManager.create_instruction(
-        instruction="b", sender="u", recipient=str(worker.id),
+        instruction="b",
+        sender="u",
+        recipient=str(worker.id),
     )
     # First fire: row creation fails; hook swallows the error.
     await hook(m1)
@@ -584,9 +580,7 @@ async def test_ensure_branch_row_retries_after_transient_failure(
     await hook(m2)
     async with StateDB() as db:
         b = await db.get_branch(str(worker.id))
-        prog = await db.get_progression(
-            env._live_persist["branch_prog_ids"][str(worker.id)]
-        )
+        prog = await db.get_progression(env._live_persist["branch_prog_ids"][str(worker.id)])
     assert b is not None
     # Only m2 made it into the progression — m1's append was after a
     # failed _ensure_branch_row, so its progression write also failed
@@ -645,7 +639,8 @@ def test_finalize_returns_branch_ids_and_writes_branch_snapshots(
     saved: list = []
     hints: list = []
     monkeypatch.setattr(
-        orch_mod, "save_last_branch_pointer",
+        orch_mod,
+        "save_last_branch_pointer",
         lambda run_id, bid: saved.append((run_id, bid)),
     )
     monkeypatch.setattr(orch_mod, "hint", lambda msg: hints.append(msg))
@@ -755,7 +750,8 @@ def test_finalize_snapshot_write_failure_logs_warning_and_continues(
 
     saved: list = []
     monkeypatch.setattr(
-        orch_mod, "save_last_branch_pointer",
+        orch_mod,
+        "save_last_branch_pointer",
         lambda run_id, bid: saved.append((run_id, bid)),
     )
     monkeypatch.setattr(orch_mod, "hint", lambda *_: None)
@@ -776,9 +772,7 @@ def test_finalize_snapshot_write_failure_logs_warning_and_continues(
     bad_path = MagicMock()
     bad_path.write_text.side_effect = OSError("disk full")
 
-    env.run.branch_path.side_effect = (
-        lambda bid: valid_path if bid == orc_id else bad_path
-    )
+    env.run.branch_path.side_effect = lambda bid: valid_path if bid == orc_id else bad_path
 
     with caplog.at_level(logging.WARNING, logger="lionagi.cli"):
         branch_ids, orc_branch_id = finalize_orchestration(
@@ -789,10 +783,7 @@ def test_finalize_snapshot_write_failure_logs_warning_and_continues(
     assert {bid for _, bid, _ in branch_ids} == {orc_id, worker_id}
     assert getattr(env, "_finalize_extras", None) == dag_extras()
     assert saved == [("run-finalize-failure", orc_id)]
-    assert any(
-        "finalize: branch snapshot write failed" in rec.message
-        for rec in caplog.records
-    )
+    assert any("finalize: branch snapshot write failed" in rec.message for rec in caplog.records)
 
 
 # ── Test 2.5 — stop persists finalize extras without messages ─────────────────
@@ -836,10 +827,14 @@ async def test_stop_persists_dag_metadata_and_message_bookmarks_together(
     hook = env._live_persist["hooks"][-1][1]
 
     m1 = MessageManager.create_instruction(
-        instruction="a", sender="u", recipient=str(worker.id),
+        instruction="a",
+        sender="u",
+        recipient=str(worker.id),
     )
     m2 = MessageManager.create_instruction(
-        instruction="b", sender="u", recipient=str(worker.id),
+        instruction="b",
+        sender="u",
+        recipient=str(worker.id),
     )
     await hook(m1)
     await hook(m2)
@@ -958,3 +953,119 @@ async def test_stop_persists_cancelled_status_with_dag_metadata(
     assert s["status"] == "cancelled"
     assert s["node_metadata"] == dag_extras()
     assert s["ended_at"] is not None
+
+
+# ── ADR-0029: artifact contract snapshot and verification ─────────────────────
+
+
+async def test_start_persists_artifact_contract(
+    temp_db_path: Path,
+    tmp_path: Path,
+):
+    """artifact_contract passed to start_live_persist is stored in session."""
+    env = _minimal_env()
+    contract = {"expected": [{"id": "brief", "path": "brief.md"}]}
+    await start_live_persist(
+        env,
+        invocation_kind="flow",
+        artifacts_path=str(tmp_path / "artifacts"),
+        artifact_contract=contract,
+    )
+    assert env._live_persist is not None
+    ctx = env._live_persist
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    stored = s["artifact_contract_json"]
+    assert isinstance(stored, dict), f"expected dict, got {type(stored)}"
+    assert stored["expected"][0]["id"] == "brief"
+
+    await stop_live_persist(env, status="completed")
+
+
+async def test_stop_uses_update_status_writes_reason(
+    temp_db_path: Path,
+):
+    """stop_live_persist now writes status through update_status(), so
+    status_reason_code must be present after a clean completion.
+    """
+    env = _minimal_env()
+    await start_live_persist(env, invocation_kind="flow")
+    ctx = env._live_persist
+    assert ctx is not None
+
+    await stop_live_persist(env, status="completed")
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "completed"
+    assert s["status_reason_code"] == "run.completed.ok"
+
+
+async def test_stop_verification_fails_flips_status(
+    temp_db_path: Path,
+    tmp_path: Path,
+):
+    """Clean completion with missing required artifact → status flipped to failed."""
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+    # deliberately NOT creating brief.md
+
+    env = _minimal_env()
+    contract = {"expected": [{"id": "brief", "path": "brief.md"}]}
+    await start_live_persist(
+        env,
+        invocation_kind="flow",
+        artifacts_path=str(artifacts_dir),
+        artifact_contract=contract,
+    )
+    ctx = env._live_persist
+    assert ctx is not None
+
+    await stop_live_persist(env, status="completed")
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "failed"
+    assert s["status_reason_code"] == "run.failed.missing_artifact"
+    v = s["artifact_verification_json"]
+    assert isinstance(v, dict)
+    assert v["status"] == "failed"
+
+
+async def test_stop_verification_preserves_non_completed_reason(
+    temp_db_path: Path,
+    tmp_path: Path,
+):
+    """Missing artifact on a failed run keeps the original exception reason."""
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+    # deliberately NOT creating brief.md
+
+    env = _minimal_env()
+    contract = {"expected": [{"id": "brief", "path": "brief.md"}]}
+    await start_live_persist(
+        env,
+        invocation_kind="flow",
+        artifacts_path=str(artifacts_dir),
+        artifact_contract=contract,
+    )
+    ctx = env._live_persist
+    assert ctx is not None
+
+    exc = RuntimeError("something broke")
+    await stop_live_persist(env, status="failed", exception=exc)
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "failed"
+    # Original exception reason preserved — NOT overridden by artifact code.
+    assert s["status_reason_code"] == "run.failed.exception"
+    # Verification still ran.
+    v = s["artifact_verification_json"]
+    assert isinstance(v, dict)
+    assert v["status"] == "failed"

--- a/tests/cli/orchestrate/test_security_hardening.py
+++ b/tests/cli/orchestrate/test_security_hardening.py
@@ -220,10 +220,7 @@ class TestSpecValidationAcceptsValidFields:
 
     def test_valid_booleans(self):
         assert (
-            _validate_spec_fields(
-                {"bare": True, "dry_run": False, "with_synthesis": True}
-            )
-            is None
+            _validate_spec_fields({"bare": True, "dry_run": False, "with_synthesis": True}) is None
         )
 
     def test_valid_prompt(self):
@@ -394,3 +391,64 @@ async def test_run_flow_inner_rejects_plan_over_200_ops(tmp_path):
     )
 
     assert "200" in output or "Invalid plan" in output
+
+
+# ── ADR-0029: artifacts: field validation in _validate_spec_fields ────────────
+
+
+class TestArtifactsFieldValidation:
+    def test_valid_artifacts_passes(self):
+        spec = {
+            "model": "codex/gpt-4o",
+            "prompt": "do it",
+            "artifacts": {"expected": [{"id": "report", "path": "report.md"}]},
+        }
+        assert _validate_spec_fields(spec) is None
+
+    def test_none_artifacts_rejected(self):
+        spec = {"model": "x", "prompt": "p", "artifacts": None}
+        err = _validate_spec_fields(spec)
+        assert err is not None
+        assert "artifacts" in err
+
+    def test_absolute_path_in_artifacts_rejected(self):
+        spec = {
+            "model": "x",
+            "prompt": "p",
+            "artifacts": {"expected": [{"id": "x", "path": "/etc/passwd"}]},
+        }
+        err = _validate_spec_fields(spec)
+        assert err is not None
+        assert "artifacts" in err.lower() or "absolute" in err.lower()
+
+    def test_glob_in_artifact_path_rejected(self):
+        spec = {
+            "model": "x",
+            "prompt": "p",
+            "artifacts": {"expected": [{"id": "x", "path": "*.md"}]},
+        }
+        err = _validate_spec_fields(spec)
+        assert err is not None
+
+    def test_duplicate_id_in_artifacts_rejected(self):
+        spec = {
+            "model": "x",
+            "prompt": "p",
+            "artifacts": {
+                "expected": [
+                    {"id": "report", "path": "report.md"},
+                    {"id": "report", "path": "other.md"},
+                ]
+            },
+        }
+        err = _validate_spec_fields(spec)
+        assert err is not None
+
+    def test_non_bool_required_in_artifacts_rejected(self):
+        spec = {
+            "model": "x",
+            "prompt": "p",
+            "artifacts": {"expected": [{"id": "x", "path": "x.md", "required": "yes"}]},
+        }
+        err = _validate_spec_fields(spec)
+        assert err is not None

--- a/tests/cli/orchestrate/test_security_hardening.py
+++ b/tests/cli/orchestrate/test_security_hardening.py
@@ -288,7 +288,7 @@ class TestSavePathContainment:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="should not reach"),
+            AsyncMock(return_value=("should not reach", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 
@@ -307,7 +307,7 @@ class TestSavePathContainment:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="flow done"),
+            AsyncMock(return_value=("flow done", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 

--- a/tests/cli/test_agent_artifact_contract.py
+++ b/tests/cli/test_agent_artifact_contract.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""ADR-0029 teardown integration tests for artifact contract verification in agent.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lionagi import Branch
+from lionagi.cli.agent import _setup_live_persist, _teardown_live_persist
+from lionagi.state.db import StateDB
+
+
+@pytest.fixture
+def temp_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", db_path)
+    return db_path
+
+
+# ── test_teardown_no_contract_unchanged ──────────────────────────────────────
+
+
+async def test_teardown_no_contract_unchanged(temp_db_path: Path):
+    """Session without artifact_contract → teardown exits with status as resolved by exit code."""
+    branch = Branch(name="b")
+    ctx = await _setup_live_persist(branch, agent_name="a1")
+    assert ctx is not None
+    await _teardown_live_persist(ctx, status="completed")
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    # No contract means verification is skipped; status remains completed.
+    assert s["status"] == "completed"
+    assert s["artifact_contract_json"] is None
+    assert s["artifact_verification_json"] is None
+
+
+# ── test_teardown_contract_passed_stays_completed ────────────────────────────
+
+
+async def test_teardown_contract_passed_stays_completed(temp_db_path: Path, tmp_path: Path):
+    """Required artifact present → verification passed, session stays completed."""
+    artifacts_dir = tmp_path / "arts"
+    artifacts_dir.mkdir()
+    (artifacts_dir / "report.md").write_text("review content")
+
+    branch = Branch(name="b")
+    contract = {"expected": [{"id": "report", "path": "report.md", "required": True}]}
+    ctx = await _setup_live_persist(
+        branch,
+        agent_name="reviewer",
+        artifacts_path=str(artifacts_dir),
+        artifact_contract=contract,
+    )
+    assert ctx is not None
+    await _teardown_live_persist(ctx, status="completed")
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "completed"
+    v = s["artifact_verification_json"]
+    assert isinstance(v, dict)
+    assert v["status"] == "passed"
+
+
+# ── test_teardown_contract_failed_overrides_completed ────────────────────────
+
+
+async def test_teardown_contract_failed_overrides_completed(temp_db_path: Path, tmp_path: Path):
+    """Required artifact missing on clean exit → status overridden to failed with FAILED_MISSING_ARTIFACT."""
+    artifacts_dir = tmp_path / "arts"
+    artifacts_dir.mkdir()
+    # report.md intentionally not written
+
+    branch = Branch(name="b")
+    contract = {"expected": [{"id": "report", "path": "report.md", "required": True}]}
+    ctx = await _setup_live_persist(
+        branch,
+        agent_name="reviewer",
+        artifacts_path=str(artifacts_dir),
+        artifact_contract=contract,
+    )
+    assert ctx is not None
+    await _teardown_live_persist(ctx, status="completed")
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "failed"
+    assert s["status_reason_code"] == "run.failed.missing_artifact"
+
+    # Evidence refs reference the missing artifact id.
+    evidence_raw = s["status_evidence_refs"]
+    evidence = json.loads(evidence_raw) if isinstance(evidence_raw, str) else evidence_raw
+    assert isinstance(evidence, list)
+    assert any(e.get("id") == "report" for e in evidence)
+
+    v = s["artifact_verification_json"]
+    assert isinstance(v, dict)
+    assert v["status"] == "failed"
+
+
+# ── test_teardown_already_failed_keeps_original_reason ───────────────────────
+
+
+async def test_teardown_already_failed_keeps_original_reason(temp_db_path: Path, tmp_path: Path):
+    """Missing artifact on an already-failed run preserves original reason, not FAILED_MISSING_ARTIFACT."""
+    artifacts_dir = tmp_path / "arts"
+    artifacts_dir.mkdir()
+    # report.md intentionally not written
+
+    branch = Branch(name="b")
+    contract = {"expected": [{"id": "report", "path": "report.md", "required": True}]}
+    ctx = await _setup_live_persist(
+        branch,
+        agent_name="reviewer",
+        artifacts_path=str(artifacts_dir),
+        artifact_contract=contract,
+    )
+    assert ctx is not None
+    exc = RuntimeError("agent crashed")
+    await _teardown_live_persist(ctx, status="failed", exception=exc)
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "failed"
+    # Original crash reason preserved — artifact code must NOT override it.
+    assert s["status_reason_code"] == "run.failed.exception"
+
+    # Verification still ran and stored.
+    v = s["artifact_verification_json"]
+    assert isinstance(v, dict)
+    assert v["status"] == "failed"

--- a/tests/cli/test_agent_live_persist.py
+++ b/tests/cli/test_agent_live_persist.py
@@ -182,9 +182,9 @@ async def test_setup_create_session_failure_closes_db(
         if _aiosqlite_thread_count() == before:
             break
         await asyncio.sleep(0.05)
-    assert (
-        _aiosqlite_thread_count() == before
-    ), "DB was not closed on setup failure — aiosqlite worker leaked"
+    assert _aiosqlite_thread_count() == before, (
+        "DB was not closed on setup failure — aiosqlite worker leaked"
+    )
 
     # Restore so other tests run clean.
     monkeypatch.setattr(StateDB, "create_session", original_create)
@@ -289,9 +289,9 @@ async def test_hook_swallows_db_write_failure(
         # MUST NOT raise.
         await ctx["hook"](msg)
 
-    assert any(
-        "live persist write failed" in rec.message for rec in caplog.records
-    ), "expected WARNING log on hook DB-write failure"
+    assert any("live persist write failed" in rec.message for rec in caplog.records), (
+        "expected WARNING log on hook DB-write failure"
+    )
 
     await _teardown_live_persist(ctx, status="completed")
 
@@ -444,9 +444,9 @@ async def test_setup_teardown_does_not_leak_aiosqlite_thread(
             if _aiosqlite_thread_count() <= baseline:
                 break
             await asyncio.sleep(0.05)
-        assert (
-            _aiosqlite_thread_count() <= baseline
-        ), "aiosqlite worker thread leaked across setup/teardown cycle"
+        assert _aiosqlite_thread_count() <= baseline, (
+            "aiosqlite worker thread leaked across setup/teardown cycle"
+        )
 
 
 # ── R5-A HIGH-2: NULL progression_id resume repair ────────────────────────────
@@ -554,7 +554,9 @@ async def test_setup_resume_repairs_null_branch_progression_id(
 
     # Fire a message — branch progression now actually receives it.
     msg = MessageManager.create_instruction(
-        instruction="post-repair", sender="u", recipient=str(branch.id),
+        instruction="post-repair",
+        sender="u",
+        recipient=str(branch.id),
     )
     await ctx["hook"](msg)
 
@@ -588,8 +590,7 @@ async def test_repair_branch_progression_returns_existing_id_under_race(
         sess_prog = str(uuid.uuid4())
         await legacy_db.create_progression(sess_prog)
         await legacy_db.db.execute(
-            "INSERT INTO sessions (id, created_at, progression_id, "
-            "updated_at) VALUES (?, ?, ?, ?)",
+            "INSERT INTO sessions (id, created_at, progression_id, updated_at) VALUES (?, ?, ?, ?)",
             (session_id, 0.0, sess_prog, 0.0),
         )
         await legacy_db.db.execute(
@@ -615,9 +616,7 @@ async def test_repair_branch_progression_returns_existing_id_under_race(
         # Caller B repairs second — UPDATE no-ops (column already set),
         # but the return value MUST be the winner's id, not B's local id.
         effective_b = await db.repair_branch_progression(branch_id, loser_id)
-        assert effective_b == winner_id, (
-            f"loser must adopt winner's id, got {effective_b!r}"
-        )
+        assert effective_b == winner_id, f"loser must adopt winner's id, got {effective_b!r}"
 
         # Spot-check the row really stored the winner's id.
         b = await db.get_branch(branch_id)
@@ -649,12 +648,14 @@ async def test_repair_session_progression_returns_existing_id_under_race(
         await db.create_progression(loser_id)
 
         effective_a = await db.repair_session_progression(
-            session_id, winner_id,
+            session_id,
+            winner_id,
         )
         assert effective_a == winner_id
 
         effective_b = await db.repair_session_progression(
-            session_id, loser_id,
+            session_id,
+            loser_id,
         )
         assert effective_b == winner_id
 
@@ -686,8 +687,7 @@ async def test_setup_resume_repairs_null_session_progression_id(
         )
         # Branch row with a valid branch progression.
         await legacy_db.db.execute(
-            "INSERT INTO branches (id, created_at, session_id, "
-            "progression_id) VALUES (?, ?, ?, ?)",
+            "INSERT INTO branches (id, created_at, session_id, progression_id) VALUES (?, ?, ?, ?)",
             (branch_id, 0.0, session_id, branch_prog),
         )
         await legacy_db.db.commit()
@@ -698,7 +698,9 @@ async def test_setup_resume_repairs_null_session_progression_id(
     assert ctx["session_prog_id"] is not None
 
     msg = MessageManager.create_instruction(
-        instruction="hi", sender="u", recipient=str(branch.id),
+        instruction="hi",
+        sender="u",
+        recipient=str(branch.id),
     )
     await ctx["hook"](msg)
 
@@ -709,3 +711,125 @@ async def test_setup_resume_repairs_null_session_progression_id(
     assert str(msg.id) in sprog
 
     await _teardown_live_persist(ctx, status="completed")
+
+
+# ── ADR-0029: artifact contract snapshot and verification ─────────────────────
+
+
+async def test_setup_persists_artifact_contract(temp_db_path: Path):
+    """artifact_contract passed to setup is stored in the session row."""
+    branch = Branch(name="b1")
+    contract = {"expected": [{"id": "report", "path": "report.md"}]}
+
+    ctx = await _setup_live_persist(
+        branch,
+        agent_name="researcher",
+        artifact_contract=contract,
+    )
+    assert ctx is not None
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    stored = s["artifact_contract_json"]
+    assert isinstance(stored, dict), f"expected dict, got {type(stored)}"
+    assert stored["expected"][0]["id"] == "report"
+
+    await _teardown_live_persist(ctx, status="completed")
+
+
+async def test_teardown_verification_passes_when_artifact_present(
+    temp_db_path: Path, tmp_path: Path
+):
+    """Clean completion with required artifact present → status passed, session completed."""
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+    (artifacts_dir / "report.md").write_text("report content")
+
+    branch = Branch(name="b1")
+    contract = {"expected": [{"id": "report", "path": "report.md"}]}
+
+    ctx = await _setup_live_persist(
+        branch,
+        agent_name="researcher",
+        artifacts_path=str(artifacts_dir),
+        artifact_contract=contract,
+    )
+    assert ctx is not None
+    await _teardown_live_persist(ctx, status="completed")
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "completed"
+    v = s["artifact_verification_json"]
+    assert isinstance(v, dict)
+    assert v["status"] == "passed"
+
+
+async def test_teardown_verification_fails_flips_status(temp_db_path: Path, tmp_path: Path):
+    """Clean completion with missing required artifact → status flipped to failed."""
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+    # deliberately NOT creating report.md
+
+    branch = Branch(name="b1")
+    contract = {"expected": [{"id": "report", "path": "report.md"}]}
+
+    ctx = await _setup_live_persist(
+        branch,
+        agent_name="researcher",
+        artifacts_path=str(artifacts_dir),
+        artifact_contract=contract,
+    )
+    assert ctx is not None
+    await _teardown_live_persist(ctx, status="completed")
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "failed"
+    assert s["status_reason_code"] == "run.failed.missing_artifact"
+    # Evidence refs include the missing artifact entry (stored as JSON string).
+    import json as _json
+
+    evidence_raw = s["status_evidence_refs"]
+    evidence = _json.loads(evidence_raw) if isinstance(evidence_raw, str) else evidence_raw
+    assert isinstance(evidence, list)
+    assert any(e.get("id") == "report" for e in evidence)
+    v = s["artifact_verification_json"]
+    assert isinstance(v, dict)
+    assert v["status"] == "failed"
+
+
+async def test_teardown_verification_preserves_non_completed_reason(
+    temp_db_path: Path, tmp_path: Path
+):
+    """Missing artifact on a failed (non-completed) run keeps original reason."""
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+    # deliberately NOT creating report.md
+
+    branch = Branch(name="b1")
+    contract = {"expected": [{"id": "report", "path": "report.md"}]}
+
+    ctx = await _setup_live_persist(
+        branch,
+        agent_name="researcher",
+        artifacts_path=str(artifacts_dir),
+        artifact_contract=contract,
+    )
+    assert ctx is not None
+    exc = RuntimeError("simulated failure")
+    await _teardown_live_persist(ctx, status="failed", exception=exc)
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "failed"
+    # Original exception reason preserved — NOT overridden by artifact code.
+    assert s["status_reason_code"] == "run.failed.exception"
+    # Verification still ran and is stored.
+    v = s["artifact_verification_json"]
+    assert isinstance(v, dict)
+    assert v["status"] == "failed"

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -3,7 +3,6 @@
 
 """Tests for lionagi.cli.main — _handle_play_shortcut."""
 
-
 from lionagi.cli.main import _handle_play_shortcut
 
 
@@ -27,3 +26,89 @@ def test_handle_play_shortcut_passthrough_for_non_play():
     argv = ["agent", "x"]
     result = _handle_play_shortcut(argv)
     assert result == argv
+
+
+# ─── ADR-0029 §9: `li play check` pre-flight artifact contract ───
+
+
+def test_play_check_no_args_prints_usage(capsys):
+    """`li play check` (no name) returns 1 and prints usage."""
+    result = _handle_play_shortcut(["play", "check"])
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "Usage: li play check" in captured.out
+
+
+def test_play_check_missing_playbook_returns_error(caplog):
+    """Unknown playbook name surfaces the resolution error and returns 1."""
+    import logging
+
+    with caplog.at_level(logging.ERROR, logger="lionagi.cli.error"):
+        result = _handle_play_shortcut(["play", "check", "no-such-playbook-xyz"])
+    assert result == 1
+    assert any(
+        "no-such-playbook-xyz" in rec.message or "not found" in rec.message
+        for rec in caplog.records
+    ), (
+        f"expected error about missing playbook; got log records={[r.message for r in caplog.records]!r}"
+    )
+
+
+def test_play_check_playbook_with_contract(tmp_path, monkeypatch, capsys):
+    """A playbook with `artifacts:` resolves and prints required/optional summary."""
+    pb_dir = tmp_path
+    pb_path = pb_dir / "fixture.playbook.yaml"
+    pb_path.write_text(
+        "name: fixture\n"
+        "model: claude/sonnet\n"
+        "prompt: |\n"
+        "  do x\n"
+        "artifacts:\n"
+        "  expected:\n"
+        "    - id: review\n"
+        "      path: review.md\n"
+        "      required: true\n"
+        "      description: Reviewer output\n"
+        "    - id: notes\n"
+        "      path: notes.md\n"
+        "      required: false\n"
+    )
+
+    # Redirect the playbook lookup root.
+    from lionagi.cli import orchestrate as _orch
+
+    real_resolve = _orch._resolve_playbook_path
+
+    def fake_resolve(name):
+        if name == "fixture":
+            return pb_path, None
+        return real_resolve(name)
+
+    monkeypatch.setattr(_orch, "_resolve_playbook_path", fake_resolve)
+    monkeypatch.setattr("lionagi.cli.main._resolve_playbook_path", fake_resolve, raising=False)
+
+    result = _handle_play_shortcut(["play", "check", "fixture"])
+    out = capsys.readouterr().out
+    assert result == 0, f"expected pass, got {result}; output: {out!r}"
+    assert "fixture" in out
+    assert "1 required" in out and "1 optional" in out
+    assert "review" in out and "notes" in out
+
+
+def test_play_check_playbook_without_contract(tmp_path, monkeypatch, capsys):
+    """A playbook without `artifacts:` exits 0 and reports verification skipped."""
+    pb_path = tmp_path / "plain.playbook.yaml"
+    pb_path.write_text("name: plain\nmodel: claude/sonnet\nprompt: do y\n")
+
+    from lionagi.cli import orchestrate as _orch
+
+    def fake_resolve(name):
+        return (pb_path, None) if name == "plain" else _orch._resolve_playbook_path(name)
+
+    monkeypatch.setattr(_orch, "_resolve_playbook_path", fake_resolve)
+    monkeypatch.setattr("lionagi.cli.main._resolve_playbook_path", fake_resolve, raising=False)
+
+    result = _handle_play_shortcut(["play", "check", "plain"])
+    out = capsys.readouterr().out
+    assert result == 0
+    assert "no `artifacts:` block declared" in out

--- a/tests/state/test_artifact_verifier.py
+++ b/tests/state/test_artifact_verifier.py
@@ -1,0 +1,426 @@
+"""Tests for lionagi/state/artifact_verifier.py (ADR-0029)."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+
+from lionagi.state.artifact_verifier import (
+    ArtifactPathError,
+    _safe_join,
+    missing_artifact_evidence,
+    missing_artifact_summary,
+    resolve_artifact_contract,
+    validate_artifact_contract,
+    verify_artifact_contract,
+)
+
+# ── _safe_join ────────────────────────────────────────────────────────────────
+
+
+class TestSafeJoin:
+    def test_simple_relative(self, tmp_path):
+        result = _safe_join(str(tmp_path), "report.md")
+        assert result == os.path.realpath(os.path.join(str(tmp_path), "report.md"))
+
+    def test_subdir_relative(self, tmp_path):
+        result = _safe_join(str(tmp_path), "subdir/file.txt")
+        assert result.startswith(os.path.realpath(str(tmp_path)))
+
+    def test_absolute_path_rejected(self, tmp_path):
+        with pytest.raises(ArtifactPathError, match="absolute path not allowed"):
+            _safe_join(str(tmp_path), "/etc/passwd")
+
+    def test_dotdot_rejected(self, tmp_path):
+        with pytest.raises(ArtifactPathError, match="segments not allowed"):
+            _safe_join(str(tmp_path), "../escape.txt")
+
+    def test_glob_star_rejected(self, tmp_path):
+        with pytest.raises(ArtifactPathError, match="glob characters"):
+            _safe_join(str(tmp_path), "*.md")
+
+    def test_glob_question_rejected(self, tmp_path):
+        with pytest.raises(ArtifactPathError, match="glob characters"):
+            _safe_join(str(tmp_path), "file?.md")
+
+    def test_glob_bracket_rejected(self, tmp_path):
+        with pytest.raises(ArtifactPathError, match="glob characters"):
+            _safe_join(str(tmp_path), "file[0].md")
+
+    def test_empty_rel_rejected(self, tmp_path):
+        with pytest.raises(ArtifactPathError):
+            _safe_join(str(tmp_path), "")
+
+
+# ── validate_artifact_contract ───────────────────────────────────────────────
+
+
+class TestValidateArtifactContract:
+    def test_none_is_valid(self):
+        validate_artifact_contract(None)
+
+    def test_valid_contract(self):
+        validate_artifact_contract({"expected": [{"id": "report", "path": "report.md"}]})
+
+    def test_missing_expected_list(self):
+        with pytest.raises(ArtifactPathError, match="expected: list"):
+            validate_artifact_contract({"expected": "not-a-list"})
+
+    def test_not_dict(self):
+        with pytest.raises(ArtifactPathError, match="must be a dict"):
+            validate_artifact_contract("invalid")  # type: ignore
+
+    def test_duplicate_id(self):
+        with pytest.raises(ArtifactPathError, match="duplicate id"):
+            validate_artifact_contract(
+                {
+                    "expected": [
+                        {"id": "report", "path": "report.md"},
+                        {"id": "report", "path": "other.md"},
+                    ]
+                }
+            )
+
+    def test_invalid_id_with_space(self):
+        with pytest.raises(ArtifactPathError, match="alphanumeric"):
+            validate_artifact_contract({"expected": [{"id": "bad id", "path": "x.md"}]})
+
+    def test_absolute_path_rejected_via_validate(self):
+        with pytest.raises(ArtifactPathError, match="absolute path not allowed"):
+            validate_artifact_contract({"expected": [{"id": "x", "path": "/etc/passwd"}]})
+
+    def test_required_must_be_bool(self):
+        with pytest.raises(ArtifactPathError, match="required must be a bool"):
+            validate_artifact_contract(
+                {"expected": [{"id": "x", "path": "x.md", "required": "yes"}]}
+            )
+
+    def test_empty_expected_list_is_valid(self):
+        validate_artifact_contract({"expected": []})
+
+
+# ── resolve_artifact_contract ─────────────────────────────────────────────────
+
+
+class TestResolveArtifactContract:
+    def test_both_none_returns_none(self):
+        assert resolve_artifact_contract(playbook_artifacts=None, agent_defaults=None) is None
+
+    def test_agent_defaults_only(self):
+        result = resolve_artifact_contract(
+            playbook_artifacts=None,
+            agent_defaults={"expected": [{"id": "report", "path": "report.md"}]},
+        )
+        assert result is not None
+        assert len(result["expected"]) == 1
+        assert result["expected"][0]["source"] == "agent_profile"
+
+    def test_playbook_overrides_agent_same_id(self):
+        result = resolve_artifact_contract(
+            playbook_artifacts={"expected": [{"id": "report", "path": "playbook_report.md"}]},
+            agent_defaults={"expected": [{"id": "report", "path": "agent_report.md"}]},
+        )
+        assert result is not None
+        assert len(result["expected"]) == 1
+        assert result["expected"][0]["path"] == "playbook_report.md"
+        assert result["expected"][0]["source"] == "playbook"
+
+    def test_playbook_and_agent_different_ids_merged(self):
+        result = resolve_artifact_contract(
+            playbook_artifacts={"expected": [{"id": "brief", "path": "brief.md"}]},
+            agent_defaults={"expected": [{"id": "log", "path": "log.txt"}]},
+        )
+        assert result is not None
+        assert len(result["expected"]) == 2
+
+    def test_required_defaults_to_true(self):
+        result = resolve_artifact_contract(
+            playbook_artifacts=None,
+            agent_defaults={"expected": [{"id": "x", "path": "x.md"}]},
+        )
+        assert result is not None
+        assert result["expected"][0]["required"] is True
+
+
+# ── verify_artifact_contract ──────────────────────────────────────────────────
+
+
+class TestVerifyArtifactContract:
+    def test_none_contract_returns_none(self):
+        assert verify_artifact_contract(None, artifacts_root="/tmp") is None
+
+    def test_missing_root_dir_fails(self):
+        contract = {"expected": [{"id": "report", "path": "report.md"}]}
+        result = verify_artifact_contract(contract, artifacts_root="/nonexistent_root_abc")
+        assert result is not None
+        assert result["status"] == "failed"
+        assert len(result["missing_required"]) == 1
+        assert result["produced"] == []
+
+    def test_required_present_passes(self, tmp_path):
+        (tmp_path / "report.md").write_text("content")
+        contract = {"expected": [{"id": "report", "path": "report.md"}]}
+        result = verify_artifact_contract(contract, artifacts_root=str(tmp_path))
+        assert result is not None
+        assert result["status"] == "passed"
+        assert len(result["produced"]) == 1
+        assert result["produced"][0]["size"] > 0
+
+    def test_zero_byte_required_fails(self, tmp_path):
+        (tmp_path / "empty.md").write_text("")
+        contract = {"expected": [{"id": "empty", "path": "empty.md"}]}
+        result = verify_artifact_contract(contract, artifacts_root=str(tmp_path))
+        assert result is not None
+        assert result["status"] == "failed"
+        assert len(result["missing_required"]) == 1
+
+    def test_optional_missing_gives_warning(self, tmp_path):
+        (tmp_path / "required.md").write_text("content")
+        contract = {
+            "expected": [
+                {"id": "required", "path": "required.md", "required": True},
+                {"id": "optional", "path": "optional.md", "required": False},
+            ]
+        }
+        result = verify_artifact_contract(contract, artifacts_root=str(tmp_path))
+        assert result is not None
+        assert result["status"] == "warning"
+        assert len(result["missing_optional"]) == 1
+        assert len(result["produced"]) == 1
+
+    def test_all_missing_required_fails_splits(self, tmp_path):
+        contract = {
+            "expected": [
+                {"id": "req", "path": "req.md", "required": True},
+                {"id": "opt", "path": "opt.md", "required": False},
+            ]
+        }
+        result = verify_artifact_contract(contract, artifacts_root=str(tmp_path))
+        assert result is not None
+        assert result["status"] == "failed"
+        assert len(result["missing_required"]) == 1
+        assert len(result["missing_optional"]) == 1
+
+    def test_all_present_passes(self, tmp_path):
+        (tmp_path / "a.md").write_text("a")
+        (tmp_path / "b.md").write_text("b")
+        contract = {
+            "expected": [
+                {"id": "a", "path": "a.md"},
+                {"id": "b", "path": "b.md"},
+            ]
+        }
+        result = verify_artifact_contract(contract, artifacts_root=str(tmp_path))
+        assert result is not None
+        assert result["status"] == "passed"
+        assert len(result["produced"]) == 2
+
+
+# ── missing_artifact_summary / evidence ──────────────────────────────────────
+
+
+def test_missing_artifact_summary_single():
+    missing = [{"id": "report", "path": "report.md"}]
+    summary = missing_artifact_summary(missing)
+    assert "report" in summary
+    assert "report.md" in summary
+
+
+def test_missing_artifact_summary_plural():
+    missing = [{"id": "a", "path": "a.md"}, {"id": "b", "path": "b.md"}]
+    summary = missing_artifact_summary(missing)
+    assert "2" in summary
+
+
+def test_missing_artifact_evidence():
+    missing = [{"id": "report", "path": "report.md"}]
+    evidence = missing_artifact_evidence(missing)
+    assert evidence == [{"kind": "expected_artifact", "id": "report", "label": "report.md"}]
+
+
+# ── canonical names required by ADR-0029 test plan ───────────────────────────
+
+
+def test_resolve_contract_both_none():
+    assert resolve_artifact_contract(playbook_artifacts=None, agent_defaults=None) is None
+
+
+def test_resolve_contract_playbook_only():
+    result = resolve_artifact_contract(
+        playbook_artifacts={"expected": [{"id": "brief", "path": "brief.md"}]},
+        agent_defaults=None,
+    )
+    assert result is not None
+    assert len(result["expected"]) == 1
+    assert result["expected"][0]["source"] == "playbook"
+
+
+def test_resolve_contract_agent_only():
+    result = resolve_artifact_contract(
+        playbook_artifacts=None,
+        agent_defaults={"expected": [{"id": "report", "path": "report.md"}]},
+    )
+    assert result is not None
+    assert result["expected"][0]["source"] == "agent_profile"
+
+
+def test_resolve_contract_merge_union():
+    result = resolve_artifact_contract(
+        playbook_artifacts={"expected": [{"id": "brief", "path": "brief.md"}]},
+        agent_defaults={"expected": [{"id": "log", "path": "log.txt"}]},
+    )
+    assert result is not None
+    ids = {e["id"] for e in result["expected"]}
+    assert ids == {"brief", "log"}
+
+
+def test_resolve_contract_merge_override():
+    result = resolve_artifact_contract(
+        playbook_artifacts={"expected": [{"id": "report", "path": "playbook.md"}]},
+        agent_defaults={"expected": [{"id": "report", "path": "agent.md"}]},
+    )
+    assert result is not None
+    assert len(result["expected"]) == 1
+    assert result["expected"][0]["path"] == "playbook.md"
+    assert result["expected"][0]["source"] == "playbook"
+
+
+def test_validate_contract_valid():
+    validate_artifact_contract({"expected": [{"id": "report", "path": "report.md"}]})
+
+
+def test_validate_contract_duplicate_id():
+    with pytest.raises(ArtifactPathError, match="duplicate id"):
+        validate_artifact_contract(
+            {
+                "expected": [
+                    {"id": "report", "path": "a.md"},
+                    {"id": "report", "path": "b.md"},
+                ]
+            }
+        )
+
+
+def test_validate_contract_bad_id_chars():
+    with pytest.raises(ArtifactPathError, match="alphanumeric"):
+        validate_artifact_contract({"expected": [{"id": "bad id!", "path": "x.md"}]})
+
+
+def test_validate_contract_absolute_path():
+    with pytest.raises(ArtifactPathError, match="absolute path not allowed"):
+        validate_artifact_contract({"expected": [{"id": "x", "path": "/etc/passwd"}]})
+
+
+def test_validate_contract_dotdot_path():
+    with pytest.raises(ArtifactPathError, match="segments not allowed"):
+        validate_artifact_contract({"expected": [{"id": "x", "path": "../escape.md"}]})
+
+
+def test_validate_contract_glob_path():
+    with pytest.raises(ArtifactPathError, match="glob characters"):
+        validate_artifact_contract({"expected": [{"id": "x", "path": "*.md"}]})
+
+
+def test_verify_no_contract():
+    assert verify_artifact_contract(None, artifacts_root="/tmp") is None
+
+
+def test_verify_no_artifacts_dir(tmp_path):
+    contract = {"expected": [{"id": "report", "path": "report.md", "required": True}]}
+    result = verify_artifact_contract(contract, artifacts_root=str(tmp_path / "nonexistent"))
+    assert result is not None
+    assert result["status"] == "failed"
+    assert len(result["missing_required"]) == 1
+
+
+def test_verify_all_present(tmp_path):
+    (tmp_path / "a.md").write_text("content a")
+    (tmp_path / "b.md").write_text("content b")
+    contract = {"expected": [{"id": "a", "path": "a.md"}, {"id": "b", "path": "b.md"}]}
+    result = verify_artifact_contract(contract, artifacts_root=str(tmp_path))
+    assert result is not None
+    assert result["status"] == "passed"
+    assert len(result["produced"]) == 2
+
+
+def test_verify_required_missing(tmp_path):
+    # Dir exists but required artifact is not in it.
+    (tmp_path / "other.md").write_text("unrelated")
+    contract = {"expected": [{"id": "report", "path": "report.md", "required": True}]}
+    result = verify_artifact_contract(contract, artifacts_root=str(tmp_path))
+    assert result is not None
+    assert result["status"] == "failed"
+    assert any(e["id"] == "report" for e in result["missing_required"])
+
+
+def test_verify_optional_missing(tmp_path):
+    (tmp_path / "required.md").write_text("content")
+    contract = {
+        "expected": [
+            {"id": "required", "path": "required.md", "required": True},
+            {"id": "optional", "path": "optional.md", "required": False},
+        ]
+    }
+    result = verify_artifact_contract(contract, artifacts_root=str(tmp_path))
+    assert result is not None
+    assert result["status"] == "warning"
+    assert len(result["missing_optional"]) == 1
+
+
+def test_verify_empty_file(tmp_path):
+    (tmp_path / "empty.md").write_text("")
+    contract = {"expected": [{"id": "empty", "path": "empty.md", "required": True}]}
+    result = verify_artifact_contract(contract, artifacts_root=str(tmp_path))
+    assert result is not None
+    assert result["status"] == "failed"
+
+
+def test_verify_optional_only_missing_dir(tmp_path):
+    contract = {
+        "expected": [
+            {"id": "notes", "path": "notes.md", "required": False},
+            {"id": "log", "path": "log.txt", "required": False},
+        ]
+    }
+    result = verify_artifact_contract(contract, artifacts_root=str(tmp_path / "nonexistent"))
+    assert result is not None
+    assert result["status"] == "warning"
+    assert len(result["missing_optional"]) == 2
+    assert result["missing_required"] == []
+
+
+def test_verify_mixed_required_optional_missing_dir(tmp_path):
+    contract = {
+        "expected": [
+            {"id": "req", "path": "req.md", "required": True},
+            {"id": "opt", "path": "opt.md", "required": False},
+        ]
+    }
+    result = verify_artifact_contract(contract, artifacts_root=str(tmp_path / "nonexistent"))
+    assert result is not None
+    assert result["status"] == "failed"
+    assert len(result["missing_required"]) == 1
+    assert len(result["missing_optional"]) == 1
+
+
+def test_safe_join_normal(tmp_path):
+    result = _safe_join(str(tmp_path), "subdir/report.md")
+    assert result.startswith(os.path.realpath(str(tmp_path)))
+    assert result.endswith("report.md")
+
+
+def test_safe_join_absolute_rejects(tmp_path):
+    with pytest.raises(ArtifactPathError, match="absolute path not allowed"):
+        _safe_join(str(tmp_path), "/etc/passwd")
+
+
+def test_safe_join_dotdot_rejects(tmp_path):
+    with pytest.raises(ArtifactPathError, match="segments not allowed"):
+        _safe_join(str(tmp_path), "../escape.md")
+
+
+def test_safe_join_glob_rejects(tmp_path):
+    with pytest.raises(ArtifactPathError, match="glob characters"):
+        _safe_join(str(tmp_path), "*.md")

--- a/tests/state/test_db.py
+++ b/tests/state/test_db.py
@@ -195,6 +195,9 @@ async def test_apply_schema_adds_missing_columns_on_old_db(tmp_path):
             "artifacts_path",
             "source_kind",
             "updated_at",
+            # ADR-0029: new artifact columns must be reconciled on old DBs.
+            "artifact_contract_json",
+            "artifact_verification_json",
         ):
             assert must_have in cols, f"sessions.{must_have} not migrated"
         cur = await db.db.execute("PRAGMA table_info(branches)")
@@ -255,9 +258,7 @@ async def test_insert_message_idempotent(db: StateDB):
     # Second insert — same id, should silently be ignored
     await db.insert_message(msg)
 
-    cur = await db.db.execute(
-        "SELECT COUNT(*) AS n FROM messages WHERE id = ?", (msg["id"],)
-    )
+    cur = await db.db.execute("SELECT COUNT(*) AS n FROM messages WHERE id = ?", (msg["id"],))
     row = await cur.fetchone()
     assert row["n"] == 1
 
@@ -268,9 +269,7 @@ async def test_resolve_lion_class_known(db: StateDB):
     msg = make_message(lion_class=known)
     await db.insert_message(msg)
 
-    cur = await db.db.execute(
-        "SELECT lion_class FROM messages WHERE id = ?", (msg["id"],)
-    )
+    cur = await db.db.execute("SELECT lion_class FROM messages WHERE id = ?", (msg["id"],))
     row = await cur.fetchone()
     # type_id 1 maps to System
     assert row["lion_class"] == 1
@@ -281,9 +280,7 @@ async def test_resolve_lion_class_unknown_empty(db: StateDB):
     msg = make_message(lion_class="")
     await db.insert_message(msg)
 
-    cur = await db.db.execute(
-        "SELECT lion_class FROM messages WHERE id = ?", (msg["id"],)
-    )
+    cur = await db.db.execute("SELECT lion_class FROM messages WHERE id = ?", (msg["id"],))
     row = await cur.fetchone()
     assert row["lion_class"] == 0
 
@@ -898,9 +895,9 @@ async def test_save_definition_concurrent_versions_are_unique(tmp_path):
             )
         )
         # Every save returned a unique version, and the set is {1..N}.
-        assert sorted(versions) == list(
-            range(1, N + 1)
-        ), f"Expected unique versions 1..{N}, got {sorted(versions)}"
+        assert sorted(versions) == list(range(1, N + 1)), (
+            f"Expected unique versions 1..{N}, got {sorted(versions)}"
+        )
 
         # Database state matches the API return values.
         rows = await db.list_definition_versions("agent", "race-agent")
@@ -941,9 +938,9 @@ async def test_message_content_string_roundtrips_as_string(db: StateDB):
         got = await db.get_message(msg_id)
         assert got is not None
         # Critical: type AND value preserved exactly.
-        assert isinstance(
-            got["content"], str
-        ), f"case {i!r}: expected str, got {type(got['content']).__name__}"
+        assert isinstance(got["content"], str), (
+            f"case {i!r}: expected str, got {type(got['content']).__name__}"
+        )
         assert got["content"] == raw, f"case {i!r}: value diverged"
 
 
@@ -1073,3 +1070,84 @@ async def test_session_delete_cascades_branches(db: StateDB):
     await db.db.execute("DELETE FROM sessions WHERE id = ?", (sid,))
     await db.db.commit()
     assert await db.get_branch(bid) is None
+
+
+# ── ADR-0029: Artifact contract storage ───────────────────────────────────────
+
+
+async def test_create_session_with_artifact_contract(db: StateDB):
+    """artifact_contract_json written at creation is decoded on fetch."""
+    prog_id = uid()
+    await db.create_progression(prog_id)
+    contract = {"expected": [{"id": "report", "path": "report.md"}]}
+    sid = uid()
+    await db.create_session(
+        {
+            "id": sid,
+            "progression_id": prog_id,
+            "created_at": time.time(),
+            "status": "running",
+            "artifact_contract_json": contract,
+        }
+    )
+    row = await db.get_session(sid)
+    assert row is not None
+    stored = row["artifact_contract_json"]
+    assert isinstance(stored, dict), f"expected dict, got {type(stored)}"
+    assert stored["expected"][0]["id"] == "report"
+
+
+async def test_update_artifact_verification(db: StateDB):
+    """update_artifact_verification() persists and round-trips the result."""
+    prog_id = uid()
+    await db.create_progression(prog_id)
+    sid = uid()
+    await db.create_session(
+        {
+            "id": sid,
+            "progression_id": prog_id,
+            "created_at": time.time(),
+            "status": "running",
+        }
+    )
+    verification = {
+        "status": "passed",
+        "checked_at": time.time(),
+        "missing_required": [],
+        "missing_optional": [],
+        "produced": [{"id": "report", "path": "report.md", "size": 42, "present": True}],
+    }
+    await db.update_artifact_verification(sid, verification)
+    row = await db.get_session(sid)
+    assert row is not None
+    stored = row["artifact_verification_json"]
+    assert isinstance(stored, dict), f"expected dict, got {type(stored)}"
+    assert stored["status"] == "passed"
+    assert stored["produced"][0]["id"] == "report"
+
+
+async def test_update_artifact_verification_none(db: StateDB):
+    """update_artifact_verification(None) stores NULL without error."""
+    prog_id = uid()
+    await db.create_progression(prog_id)
+    sid = uid()
+    await db.create_session(
+        {
+            "id": sid,
+            "progression_id": prog_id,
+            "created_at": time.time(),
+            "status": "running",
+        }
+    )
+    await db.update_artifact_verification(sid, None)
+    row = await db.get_session(sid)
+    assert row is not None
+    assert row["artifact_verification_json"] is None
+
+
+async def test_new_db_has_artifact_columns(db: StateDB):
+    """Fresh in-memory DB exposes both new columns via PRAGMA table_info."""
+    cur = await db.db.execute("PRAGMA table_info(sessions)")
+    cols = {r["name"] for r in await cur.fetchall()}
+    assert "artifact_contract_json" in cols
+    assert "artifact_verification_json" in cols

--- a/tests/state/test_db_artifact_contract.py
+++ b/tests/state/test_db_artifact_contract.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""ADR-0029 DB integration tests for artifact_contract_json / artifact_verification_json."""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+import time
+import uuid
+
+import pytest
+
+from lionagi.state.db import StateDB
+
+
+@pytest.fixture
+async def db():
+    state = StateDB(":memory:")
+    await state.open()
+    yield state
+    await state.close()
+
+
+def uid() -> str:
+    return str(uuid.uuid4())
+
+
+async def _make_session(db: StateDB, **fields) -> str:
+    prog_id = uid()
+    await db.create_progression(prog_id)
+    sid = uid()
+    await db.create_session(
+        {"id": sid, "progression_id": prog_id, "created_at": time.time(), **fields}
+    )
+    return sid
+
+
+# ── test_create_session_with_contract ────────────────────────────────────────
+
+
+async def test_create_session_with_contract(db: StateDB):
+    """artifact_contract_json is stored and decoded on fetch."""
+    contract = {"expected": [{"id": "report", "path": "report.md", "required": True}]}
+    sid = await _make_session(db, artifact_contract_json=contract)
+    row = await db.get_session(sid)
+    assert row is not None
+    stored = row["artifact_contract_json"]
+    assert isinstance(stored, dict)
+    assert stored["expected"][0]["id"] == "report"
+
+
+# ── test_create_session_without_contract ─────────────────────────────────────
+
+
+async def test_create_session_without_contract(db: StateDB):
+    """Sessions without artifact_contract_json store NULL and raise no error."""
+    sid = await _make_session(db)
+    row = await db.get_session(sid)
+    assert row is not None
+    assert row["artifact_contract_json"] is None
+
+
+# ── test_update_artifact_verification ────────────────────────────────────────
+
+
+async def test_update_artifact_verification(db: StateDB):
+    """update_artifact_verification() persists and round-trips the verification dict."""
+    sid = await _make_session(db)
+    verification = {
+        "status": "passed",
+        "checked_at": time.time(),
+        "missing_required": [],
+        "missing_optional": [],
+        "produced": [{"id": "report", "path": "report.md", "size": 128, "present": True}],
+    }
+    await db.update_artifact_verification(sid, verification)
+    row = await db.get_session(sid)
+    assert row is not None
+    stored = row["artifact_verification_json"]
+    assert isinstance(stored, dict)
+    assert stored["status"] == "passed"
+    assert stored["produced"][0]["id"] == "report"
+
+
+# ── test_migration_adds_columns ───────────────────────────────────────────────
+
+
+async def test_migration_adds_columns():
+    """reconcile_schema() adds both new columns to a pre-ADR-0029 DB."""
+    with tempfile.NamedTemporaryFile(suffix=".db") as f:
+        db_path = f.name
+        # Build an old-style schema without the two new columns.
+        old = sqlite3.connect(db_path)
+        old.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS progressions (
+                id TEXT PRIMARY KEY,
+                created_at REAL
+            );
+            CREATE TABLE IF NOT EXISTS sessions (
+                id TEXT PRIMARY KEY,
+                progression_id TEXT,
+                status TEXT,
+                created_at REAL
+            );
+            """
+        )
+        old.close()
+
+        # Open with current StateDB — reconcile_schema() should add the columns.
+        state = StateDB(db_path)
+        await state.open()
+        try:
+            cur = await state.db.execute("PRAGMA table_info(sessions)")
+            cols = {r["name"] for r in await cur.fetchall()}
+            assert "artifact_contract_json" in cols, "migration missing artifact_contract_json"
+            assert "artifact_verification_json" in cols, (
+                "migration missing artifact_verification_json"
+            )
+        finally:
+            await state.close()


### PR DESCRIPTION
## Summary

Implements ADR-0029 end-to-end. Playbooks declare expected output artifacts; the executor snapshots the contract at session start and verifies at teardown. Missing required artifacts flip a clean exit into `failed` with reason `run.failed.missing_artifact` (per ADR-0028) — the silent codex-review-with-no-output failure mode becomes a first-class status.

## What this PR adds

**`lionagi/state/artifact_verifier.py`** (new):
- `ArtifactPathError(ValueError)`
- `_safe_join(root, rel)` — rejects absolute paths, `..` segments, glob metacharacters, post-realpath escapes
- `validate_artifact_contract(contract)` — pre-flight id format + duplicate-id + path safety
- `resolve_artifact_contract(*, playbook_artifacts, agent_defaults)` — merge by id (playbook wins on collision), records `source`
- `verify_artifact_contract(contract, *, artifacts_root)` — file existence + non-empty size check

**Schema**: `sessions.artifact_contract_json` + `artifact_verification_json` (nullable JSON; back-added via `_MIGRATION_COLUMNS`).

**Playbook YAML**: top-level `artifacts:` block with `expected[].{id, path, required, description}` per ADR-0029 §2.

**Agent profile frontmatter**: `artifact_defaults:` with same shape per §3.

**Session lifecycle**:
- create: `resolve_artifact_contract()` → snapshot to `artifact_contract_json` (immutable)
- teardown: `verify_artifact_contract()` runs BEFORE `update_status()`. If the run would have been `completed` but `missing_required` is non-empty, status flips to `failed` with reason `RunReasons.FAILED_MISSING_ARTIFACT` and `evidence_refs` listing unmet entries. Already-failing runs keep their original cause.

**API + UI**:
- Session/run detail responses include both JSON fields.
- `apps/studio/frontend/components/runs/ExpectedArtifacts.tsx` renders contract + verification side-by-side per ADR-0029 §8.

**CLI**: `li play check <name>` — ADR-0029 §9 pre-flight subcommand. Loads the playbook, resolves its contract, prints required/optional summary or the validation error.

## Tests

7 new test files, ~810 LOC:
- `tests/state/test_artifact_verifier.py` — `_safe_join` reject cases (absolute, `..`, glob, post-realpath escape); merge semantics; verifier across contract states
- `tests/state/test_db_artifact_contract.py` — migration round-trip
- `tests/cli/test_main.py` — 4 new cases for `li play check`
- `tests/cli/test_agent_artifact_contract.py` — end-to-end teardown precedence
- `tests/agent/test_profile_artifacts.py` — agent profile `artifact_defaults` parsing
- Plus extensions to existing live-persist test files

## Regression

698 tests pass across `tests/state/` + `tests/cli/` + `tests/apps_studio_server/`.

## Test plan

- [ ] `li play check` against playbooks with/without `artifacts:` blocks
- [ ] Run a playbook with `artifacts:` that fails to produce required outputs — confirm session ends `failed` with `run.failed.missing_artifact`
- [ ] Confirm a clean exit on a playbook WITHOUT a contract is unchanged (verification skipped)