### PR TITLE
feat: ADR-0028 Phase 2 + ADR-0029 — status reasons & artifact contract

### DIFF
--- a/apps/studio/frontend/components/runs/ExpectedArtifacts.tsx
+++ b/apps/studio/frontend/components/runs/ExpectedArtifacts.tsx
@@ -1,0 +1,97 @@
+import Badge from "@/components/Badge";
+import type { ArtifactContract, ArtifactVerification } from "@/lib/types";
+
+function formatBytes(size: number): string {
+  if (size < 1024) return `${size} B`;
+  if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`;
+  return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function verificationTone(status?: string | null): "ok" | "failed" | "pending" | "default" {
+  if (status === "passed") return "ok";
+  if (status === "failed") return "failed";
+  if (status === "warning") return "pending";
+  return "default";
+}
+
+export interface ExpectedArtifactsProps {
+  contract?: ArtifactContract | null;
+  verification?: ArtifactVerification | null;
+}
+
+export default function ExpectedArtifacts({ contract, verification }: ExpectedArtifactsProps) {
+  const expected = contract?.expected ?? [];
+  if (!contract || expected.length === 0) return null;
+
+  const producedById = new Map((verification?.produced ?? []).map((p) => [p.id, p]));
+  const missingRequired = new Set((verification?.missing_required ?? []).map((p) => p.id));
+  const missingOptional = new Set((verification?.missing_optional ?? []).map((p) => p.id));
+
+  return (
+    <div id="expected-artifacts" className="scroll-mt-24">
+      <div className="mb-2 flex items-center gap-2">
+        <h2 className="text-label font-semibold text-content-primary">Expected artifacts</h2>
+        <span className="rounded bg-surface-overlay px-1.5 py-0 font-mono text-[9px] text-content-muted">
+          {expected.length}
+        </span>
+        {verification?.status && (
+          <Badge tone={verificationTone(verification.status)}>
+            Verified: {verification.status}
+          </Badge>
+        )}
+      </div>
+      <div className="rounded border border-edge bg-surface-raised px-3 py-2 shadow-card">
+        <ul className="flex flex-col divide-y divide-edge-subtle">
+          {expected.map((entry) => {
+            const produced = producedById.get(entry.id);
+            const missing = missingRequired.has(entry.id) || missingOptional.has(entry.id);
+            const required = entry.required !== false;
+            const statusTone = produced
+              ? "ok"
+              : missing && required
+                ? "failed"
+                : missing
+                  ? "pending"
+                  : "default";
+            const statusLabel = produced
+              ? `OK (${formatBytes(produced.size)})`
+              : missing
+                ? "MISSING"
+                : "PENDING";
+            return (
+              <li
+                key={entry.id}
+                className="grid gap-2 py-2 md:grid-cols-[88px_minmax(0,1fr)_minmax(0,1fr)_96px] md:items-start"
+              >
+                <Badge tone={required ? "failed" : "default"}>
+                  {required ? "REQUIRED" : "OPTIONAL"}
+                </Badge>
+                <div className="min-w-0">
+                  <div className="truncate font-mono text-[11px] font-semibold text-content-primary">
+                    {entry.id}
+                  </div>
+                  {entry.description && (
+                    <div className="mt-0.5 text-[10px] text-content-muted">{entry.description}</div>
+                  )}
+                </div>
+                <div
+                  className="min-w-0 truncate font-mono text-[11px] text-content-secondary"
+                  title={entry.path}
+                >
+                  {entry.path}
+                </div>
+                <Badge tone={statusTone}>{statusLabel}</Badge>
+                {entry.source && (
+                  <div className="md:col-start-2 md:col-span-3 text-[10px] text-content-muted">
+                    declared by:{" "}
+                    <span className="font-mono text-content-secondary">{entry.source}</span>
+                  </div>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/apps/studio/frontend/lib/api.ts
+++ b/apps/studio/frontend/lib/api.ts
@@ -1,6 +1,8 @@
 import type {
   AgentProfile,
   AgentProfileSummary,
+  ArtifactContract,
+  ArtifactVerification,
   DeclarativeArgSpec,
   DeclarativePlaybookData,
   PlaybookFormat,
@@ -386,6 +388,9 @@ export interface SessionDetail {
   effort?: string | null;
   agent_hash?: string | null;
   invocation_id?: string | null;
+  // ADR-0029: artifact contract and verification result.
+  artifact_contract_json?: ArtifactContract | null;
+  artifact_verification_json?: ArtifactVerification | null;
 }
 
 export async function listSessions(): Promise<{ sessions: SessionSummary[] }> {

--- a/apps/studio/frontend/lib/types.ts
+++ b/apps/studio/frontend/lib/types.ts
@@ -19,6 +19,35 @@ export interface ProjectDetail extends ProjectSummary {
   playbooks_used: Array<{ playbook_name: string; run_count: number }>;
 }
 
+// ─── Artifact contract types (ADR-0029) ─────────────────────────────────────
+
+export interface ExpectedArtifact {
+  id: string;
+  path: string;
+  required?: boolean;
+  description?: string;
+  source?: string;
+}
+
+export interface ProducedArtifact {
+  id: string;
+  path: string;
+  size: number;
+  present?: boolean;
+}
+
+export interface ArtifactContract {
+  expected: ExpectedArtifact[];
+}
+
+export interface ArtifactVerification {
+  status: "passed" | "failed" | "warning" | "skipped";
+  checked_at: number;
+  missing_required: ExpectedArtifact[];
+  missing_optional: ExpectedArtifact[];
+  produced: ProducedArtifact[];
+}
+
 // ─── Run types ───────────────────────────────────────────────────────────────
 
 // H-FE-3: RunSummary matches the actual SQLite-session response shape from
@@ -41,14 +70,7 @@ export interface RunSummary {
   // - stale: process dead, has produced output.
   // - orphaned: process dead, no output, no artifacts.
   // - zombie: terminal status, but resources leaked (stale locks).
-  effective_health?:
-    | "healthy"
-    | "idle"
-    | "unresponsive"
-    | "stale"
-    | "orphaned"
-    | "zombie"
-    | null;
+  effective_health?: "healthy" | "idle" | "unresponsive" | "stale" | "orphaned" | "zombie" | null;
   last_message_at?: number | null;
   // ADR-0020: optional parent skill orchestration id (from `li invoke`).
   invocation_id?: string | null;
@@ -69,6 +91,9 @@ export interface RunSummary {
   // ADR-0026: project detection for session organization.
   project?: string | null;
   project_source?: string | null;
+  // ADR-0029: artifact contract and verification result.
+  artifact_contract_json?: ArtifactContract | null;
+  artifact_verification_json?: ArtifactVerification | null;
 }
 
 export interface RunMessage {
@@ -115,6 +140,9 @@ export interface RunDetail {
   graph: { nodes: WorkerStepNode[]; edges: WorkerLinkEdge[] };
   manifest: Record<string, unknown>;
   branches: unknown[];
+  // ADR-0029: artifact contract and verification result.
+  artifact_contract_json?: ArtifactContract | null;
+  artifact_verification_json?: ArtifactVerification | null;
 }
 
 // ─── Worker / Playbook types ──────────────────────────────────────────────────

--- a/apps/studio/frontend/next-env.d.ts
+++ b/apps/studio/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/studio/server/routers/admin.py
+++ b/apps/studio/server/routers/admin.py
@@ -1,13 +1,25 @@
 from __future__ import annotations
 
+import logging
 from typing import Any, Literal
 
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field
 
+from lionagi.state.reasons import RunReasons, validate_reason_code
+
 from ..services import admin as admin_svc
 
 router = APIRouter(prefix="/admin", tags=["admin"])
+
+_log = logging.getLogger(__name__)
+
+# Fallback mapping for deprecated 'reason' field without reason_code.
+_LEGACY_ADMIN_REASON_CODES: dict[str, str] = {
+    "failed": RunReasons.FAILED_EXCEPTION,
+    "aborted": RunReasons.ABORTED_USER,
+    "cancelled": RunReasons.CANCELLED_SYSTEM,
+}
 
 
 class PruneBody(BaseModel):
@@ -16,17 +28,22 @@ class PruneBody(BaseModel):
 
 
 class TransitionBody(BaseModel):
-    """ADR-0024 §B: admin session transition.
+    """ADR-0024/ADR-0028 admin session transition.
 
-    ``reason`` is required so every transition has an audit-log
-    justification. ``target_status`` is constrained to the
-    admin-allowed subset (operators can't claim a model
-    timed out or completed cleanly).
+    ``reason_code`` is the preferred field (ADR-0028). The deprecated
+    ``reason`` free-text field is kept for backwards compatibility: old
+    clients that omit ``reason_code`` and provide ``reason`` get a
+    synthesised code from the target_status→code map. New clients should
+    supply ``reason_code`` from the controlled vocabulary.
     """
 
     session_ids: list[str] = Field(..., min_length=1)
     target_status: Literal["failed", "aborted", "cancelled"]
-    reason: str = Field(..., min_length=1, max_length=500)
+    reason_code: str | None = None
+    reason_summary: str = ""
+    evidence_refs: list[dict] = Field(default_factory=list)
+    # Deprecated; kept for backwards compatibility.
+    reason: str | None = Field(default=None, max_length=500)
     actor: str = Field(default="admin", max_length=64)
 
 
@@ -45,13 +62,36 @@ async def health() -> dict[str, Any]:
 
 @router.post("/transition")
 async def transition(body: TransitionBody) -> dict[str, Any]:
-    """ADR-0024 §B: mark running sessions terminal with an audit entry."""
+    """ADR-0024/ADR-0028: mark running sessions terminal with a reason code."""
+    reason_code = body.reason_code
+    reason_summary = body.reason_summary
+
+    if reason_code is not None:
+        try:
+            reason_code = validate_reason_code(reason_code)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+    elif body.reason:
+        reason_code = _LEGACY_ADMIN_REASON_CODES[body.target_status]
+        reason_summary = body.reason
+        _log.warning(
+            "Deprecated admin transition field 'reason' used without reason_code; "
+            "mapped target_status=%s to reason_code=%s",
+            body.target_status,
+            reason_code,
+        )
+    else:
+        raise HTTPException(status_code=400, detail="reason_code is required")
+
     try:
         return await admin_svc.transition_sessions(
             body.session_ids,
             target_status=body.target_status,
-            reason=body.reason,
+            reason_code=reason_code,
+            reason_summary=reason_summary,
+            evidence_refs=body.evidence_refs,
             actor=body.actor,
+            legacy_reason=body.reason,
         )
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
@@ -63,9 +103,7 @@ async def admin_events(
     target_id: str | None = Query(default=None),
     limit: int = Query(default=100, ge=1, le=1000),
 ) -> dict[str, Any]:
-    events = await admin_svc.list_admin_events(
-        action=action, target_id=target_id, limit=limit
-    )
+    events = await admin_svc.list_admin_events(action=action, target_id=target_id, limit=limit)
     return {"events": events}
 
 

--- a/apps/studio/server/scheduler/engine.py
+++ b/apps/studio/server/scheduler/engine.py
@@ -11,8 +11,132 @@ import uuid
 from typing import Any
 
 from lionagi.state.db import StateDB
+from lionagi.state.reasons import RunReasons, ScheduleReasons
 
 _log = logging.getLogger(__name__)
+
+
+async def _resolve_invocation_terminal(
+    db: StateDB,
+    invocation_id: str,
+    *,
+    fallback_status: str,
+    exit_code: int | None = None,
+    exception: BaseException | None = None,
+) -> tuple[str, str, str, list[dict], dict]:
+    """Aggregate child session statuses into an invocation terminal reason."""
+    sessions = await db.list_sessions_for_invocation(invocation_id)
+    child_statuses = [str(s.get("status") or "") for s in sessions]
+    evidence_refs = [{"kind": "session", "id": s["id"]} for s in sessions if s.get("id")]
+    metadata: dict = {"child_statuses": child_statuses}
+    if exit_code is not None:
+        metadata["exit_code"] = exit_code
+    if exception is not None:
+        metadata["exception_class"] = type(exception).__name__
+
+    # Precedence: timed_out > failed > aborted > cancelled > completed.
+    # `failed` MUST beat `aborted`/`cancelled` so a real failure isn't
+    # masked by sibling cleanup-cancellation. ADR-0028 §5 cancellation
+    # is system-cascade; preserving the failed signal lets downstream
+    # failure-clustering see the real cause.
+    if child_statuses:
+        if any(s == "timed_out" for s in child_statuses):
+            return (
+                "timed_out",
+                RunReasons.TIMED_OUT_DEADLINE,
+                "Invocation timed out because at least one child session timed out.",
+                evidence_refs,
+                metadata,
+            )
+        if any(s == "failed" for s in child_statuses):
+            return (
+                "failed",
+                RunReasons.FAILED_EXCEPTION,
+                "Invocation failed because at least one child session failed.",
+                evidence_refs,
+                metadata,
+            )
+        if any(s == "aborted" for s in child_statuses):
+            return (
+                "aborted",
+                RunReasons.ABORTED_USER,
+                "Invocation was aborted because at least one child session was aborted.",
+                evidence_refs,
+                metadata,
+            )
+        if any(s == "cancelled" for s in child_statuses):
+            return (
+                "cancelled",
+                RunReasons.CANCELLED_SYSTEM,
+                "Invocation was cancelled because at least one child session was cancelled.",
+                evidence_refs,
+                metadata,
+            )
+        if all(s == "completed" for s in child_statuses):
+            return (
+                "completed",
+                RunReasons.COMPLETED_OK,
+                "All child sessions completed successfully.",
+                evidence_refs,
+                metadata,
+            )
+
+    if fallback_status == "completed":
+        return (
+            "completed",
+            RunReasons.COMPLETED_OK,
+            "Invocation process completed successfully.",
+            evidence_refs,
+            metadata,
+        )
+    if fallback_status == "timed_out":
+        return (
+            "timed_out",
+            RunReasons.TIMED_OUT_DEADLINE,
+            "Invocation process exceeded its deadline.",
+            evidence_refs,
+            metadata,
+        )
+    if fallback_status == "aborted":
+        return (
+            "aborted",
+            RunReasons.ABORTED_USER,
+            "Invocation process was aborted by the user.",
+            evidence_refs,
+            metadata,
+        )
+    if fallback_status == "cancelled":
+        return (
+            "cancelled",
+            RunReasons.CANCELLED_SYSTEM,
+            "Invocation process was cancelled by the runtime.",
+            evidence_refs,
+            metadata,
+        )
+    if exception is not None:
+        return (
+            "failed",
+            RunReasons.FAILED_EXCEPTION,
+            f"{type(exception).__name__}: {exception}",
+            evidence_refs,
+            metadata,
+        )
+    if exit_code is not None and exit_code != 0:
+        return (
+            "failed",
+            RunReasons.FAILED_EXIT_NONZERO,
+            f"Invocation process failed with exit code {exit_code}.",
+            evidence_refs,
+            metadata,
+        )
+    return (
+        "failed",
+        RunReasons.FAILED_EXCEPTION,
+        "Invocation process failed.",
+        evidence_refs,
+        metadata,
+    )
+
 
 _MAX_CHAIN_DEPTH = 10
 _TICK_INTERVAL = 30  # seconds
@@ -68,15 +192,90 @@ class SchedulerEngine:
                 schedules = await db.list_schedules(enabled=True)
             now = time.time()
             for s in schedules:
-                if s.get("missed_fire_policy") == "run_once" and s.get("next_fire_at"):
-                    if s["next_fire_at"] < now:
-                        run_id = uuid.uuid4().hex[:12]
-                        _log.info("Missed fire recovery for schedule %s (%s)", s["name"], s["id"])
-                        asyncio.create_task(
-                            self._fire(s, run_id, trigger_context={"missed_recovery": True, "fired_at": now})
+                next_fire_at = s.get("next_fire_at")
+                if next_fire_at is None or next_fire_at >= now:
+                    continue
+                policy = s.get("missed_fire_policy")
+                if policy == "run_once":
+                    # Recover by firing once; the resulting schedule_run
+                    # row gets ScheduleReasons.FIRED_DUE via _fire().
+                    run_id = uuid.uuid4().hex[:12]
+                    _log.info(
+                        "Missed fire recovery for schedule %s (%s)",
+                        s["name"],
+                        s["id"],
+                    )
+                    asyncio.create_task(
+                        self._fire(
+                            s,
+                            run_id,
+                            trigger_context={"missed_recovery": True, "fired_at": now},
                         )
+                    )
+                else:
+                    # policy in {"skip", default}: drop the missed fire,
+                    # but record the skip so operators can see why.
+                    # ADR-0028 § ScheduleReasons.SKIPPED_MISSED_FIRE is
+                    # the canonical code for this case.
+                    await self._record_missed_fire_skip(s, now)
         except Exception:
             _log.exception("Missed fire check error")
+
+    async def _record_missed_fire_skip(self, schedule: dict, now: float) -> None:
+        """Create a schedule_runs row recording the missed-fire skip.
+
+        Writes status="skipped" with reason_code=SKIPPED_MISSED_FIRE so
+        downstream attention-queue / failure-grouping (ADR-0028, ADR-0030)
+        can distinguish missed-fire skips from overlap skips and normal
+        due fires. Also advances next_fire_at so the schedule doesn't
+        re-trigger this same skip every tick.
+        """
+        skipped_run_id = uuid.uuid4().hex[:12]
+        try:
+            async with StateDB() as db:
+                await db.create_schedule_run(
+                    {
+                        "id": skipped_run_id,
+                        "schedule_id": schedule["id"],
+                        "trigger_context": {
+                            "skipped_missed_fire": True,
+                            "missed_fire_at": schedule.get("next_fire_at"),
+                            "checked_at": now,
+                        },
+                        "action_kind": schedule["action_kind"],
+                        "action_args": [],
+                        "status": "skipped",
+                        "fired_at": now,
+                    }
+                )
+                await db.update_status(
+                    "schedule_run",
+                    skipped_run_id,
+                    new_status="skipped",
+                    reason_code=ScheduleReasons.SKIPPED_MISSED_FIRE,
+                    reason_summary=(
+                        "Schedule fire skipped because the scheduled time "
+                        "passed while the server was down or the tick was "
+                        "delayed (missed_fire_policy=skip)."
+                    ),
+                    evidence_refs=[{"kind": "schedule", "id": schedule["id"]}],
+                    source="system",
+                    actor=schedule["id"],
+                    metadata={
+                        "missed_fire_policy": schedule.get("missed_fire_policy"),
+                        "missed_fire_at": schedule.get("next_fire_at"),
+                    },
+                )
+                # Advance next_fire_at so this schedule doesn't keep
+                # producing skip rows for the same missed slot.
+                next_at = self._compute_next_fire(schedule, now)
+                if next_at:
+                    await db.update_schedule(schedule["id"], next_fire_at=next_at)
+        except Exception:
+            _log.exception(
+                "Failed to record missed-fire skip for schedule %s",
+                schedule.get("id"),
+            )
 
     async def _tick(self) -> None:
         now = time.time()
@@ -106,9 +305,14 @@ class SchedulerEngine:
         if now - last < poll_interval:
             return
         from .github import github_poll
+
         new_events = await github_poll(schedule)
         if new_events:
-            ctx = {"github_events": new_events, "repo": schedule.get("github_repo"), "fired_at": now}
+            ctx = {
+                "github_events": new_events,
+                "repo": schedule.get("github_repo"),
+                "fired_at": now,
+            }
             run_id = uuid.uuid4().hex[:12]
             await self._fire(schedule, run_id, trigger_context=ctx)
 
@@ -116,16 +320,30 @@ class SchedulerEngine:
         # Overlap check
         if schedule.get("overlap_policy") == "skip" and schedule["id"] in self._running:
             _log.debug("Skipping overlapping fire for %s", schedule["name"])
+            skipped_run_id = uuid.uuid4().hex[:12]
             async with StateDB() as db:
-                await db.create_schedule_run({
-                    "id": uuid.uuid4().hex[:12],
-                    "schedule_id": schedule["id"],
-                    "trigger_context": {"skipped_overlap": True, "fired_at": now},
-                    "action_kind": schedule["action_kind"],
-                    "action_args": [],
-                    "status": "skipped",
-                    "fired_at": now,
-                })
+                await db.create_schedule_run(
+                    {
+                        "id": skipped_run_id,
+                        "schedule_id": schedule["id"],
+                        "trigger_context": {"skipped_overlap": True, "fired_at": now},
+                        "action_kind": schedule["action_kind"],
+                        "action_args": [],
+                        "status": "skipped",
+                        "fired_at": now,
+                    }
+                )
+                await db.update_status(
+                    "schedule_run",
+                    skipped_run_id,
+                    new_status="skipped",
+                    reason_code=ScheduleReasons.SKIPPED_OVERLAP,
+                    reason_summary="Schedule fire skipped because overlap_policy=skip and a prior run is still active.",
+                    evidence_refs=[{"kind": "schedule", "id": schedule["id"]}],
+                    source="system",
+                    actor=schedule["id"],
+                    metadata={"overlap_policy": schedule.get("overlap_policy")},
+                )
             # Still advance next_fire_at
             next_at = self._compute_next_fire(schedule, now)
             if next_at:
@@ -154,32 +372,47 @@ class SchedulerEngine:
         # Create invocation
         inv_id = uuid.uuid4().hex[:12]
         async with StateDB() as db:
-            await db.create_invocation({
-                "id": inv_id,
-                "skill": f"scheduled:{schedule['name']}",
-                "plugin": schedule["trigger_type"],
-                "prompt": schedule.get("action_prompt") or schedule.get("action_playbook"),
-                "started_at": now,
-                "status": "running",
-            })
+            await db.create_invocation(
+                {
+                    "id": inv_id,
+                    "skill": f"scheduled:{schedule['name']}",
+                    "plugin": schedule["trigger_type"],
+                    "prompt": schedule.get("action_prompt") or schedule.get("action_playbook"),
+                    "started_at": now,
+                    "status": "running",
+                }
+            )
 
         # Build argv
         argv = build_argv(schedule, trigger_context)
 
         # Create schedule_run
         async with StateDB() as db:
-            await db.create_schedule_run({
-                "id": run_id,
-                "schedule_id": sid,
-                "invocation_id": inv_id,
-                "trigger_context": trigger_context,
-                "action_kind": schedule["action_kind"],
-                "action_args": argv,
-                "status": "running",
-                "chain_parent_id": chain_parent_id,
-                "chain_depth": chain_depth,
-                "fired_at": now,
-            })
+            await db.create_schedule_run(
+                {
+                    "id": run_id,
+                    "schedule_id": sid,
+                    "invocation_id": inv_id,
+                    "trigger_context": trigger_context,
+                    "action_kind": schedule["action_kind"],
+                    "action_args": argv,
+                    "status": "running",
+                    "chain_parent_id": chain_parent_id,
+                    "chain_depth": chain_depth,
+                    "fired_at": now,
+                }
+            )
+            await db.update_status(
+                "schedule_run",
+                run_id,
+                new_status="running",
+                reason_code=ScheduleReasons.FIRED_DUE,
+                reason_summary="Schedule run fired because the trigger was due.",
+                evidence_refs=[{"kind": "schedule", "id": sid}],
+                source="system",
+                actor=sid,
+                metadata={"trigger_context": trigger_context, "chain_depth": chain_depth},
+            )
 
         # Track as running
         if chain_depth == 0:
@@ -193,26 +426,56 @@ class SchedulerEngine:
         async with StateDB() as db:
             await db.update_schedule(sid, **update_fields)
 
-        _log.info("Firing schedule %s (run %s, chain_depth=%d)", schedule["name"], run_id, chain_depth)
+        _log.info(
+            "Firing schedule %s (run %s, chain_depth=%d)", schedule["name"], run_id, chain_depth
+        )
 
         # Spawn and wait
         try:
             exit_code, stderr_tail = await spawn_and_wait(argv, inv_id)
             end_time = time.time()
             status = "completed" if exit_code == 0 else "failed"
+            reason_code = (
+                RunReasons.COMPLETED_OK if exit_code == 0 else RunReasons.FAILED_EXIT_NONZERO
+            )
+            reason_summary = (
+                "Scheduled process completed successfully."
+                if exit_code == 0
+                else f"Scheduled process exited non-zero: {exit_code}."
+            )
 
             async with StateDB() as db:
                 await db.update_schedule_run(
                     run_id,
-                    status=status,
                     exit_code=exit_code,
                     ended_at=end_time,
                     error_detail=stderr_tail if exit_code != 0 else None,
                 )
-                await db.update_invocation(
+                await db.update_status(
+                    "schedule_run",
+                    run_id,
+                    new_status=status,
+                    reason_code=reason_code,
+                    reason_summary=reason_summary,
+                    evidence_refs=[{"kind": "invocation", "id": inv_id}],
+                    source="executor",
+                    actor=run_id,
+                    metadata={"exit_code": exit_code},
+                )
+                inv_status, inv_rc, inv_rs, inv_ev, inv_meta = await _resolve_invocation_terminal(
+                    db, inv_id, fallback_status=status, exit_code=exit_code
+                )
+                await db.update_invocation(inv_id, ended_at=end_time)
+                await db.update_status(
+                    "invocation",
                     inv_id,
-                    status=status,
-                    ended_at=end_time,
+                    new_status=inv_status,
+                    reason_code=inv_rc,
+                    reason_summary=inv_rs,
+                    evidence_refs=inv_ev,
+                    source="executor",
+                    actor=inv_id,
+                    metadata=inv_meta,
                 )
 
             # Evaluate chain
@@ -225,7 +488,9 @@ class SchedulerEngine:
 
                 if chain_action:
                     chain_schedule = {**schedule, **chain_action}
-                    chain_schedule["action_kind"] = chain_action.get("kind", chain_action.get("action_kind", schedule["action_kind"]))
+                    chain_schedule["action_kind"] = chain_action.get(
+                        "kind", chain_action.get("action_kind", schedule["action_kind"])
+                    )
                     if "model" in chain_action:
                         chain_schedule["action_model"] = chain_action["model"]
                     if "prompt" in chain_action:
@@ -250,16 +515,41 @@ class SchedulerEngine:
                         chain_depth=chain_depth + 1,
                     )
 
-        except Exception:
+        except Exception as exc:
             _log.exception("Error in schedule fire %s (run %s)", schedule.get("name"), run_id)
+            _end_time = time.time()
             async with StateDB() as db:
                 await db.update_schedule_run(
                     run_id,
-                    status="failed",
-                    ended_at=time.time(),
+                    ended_at=_end_time,
                     error_detail="Internal scheduler error",
                 )
-                await db.update_invocation(inv_id, status="failed", ended_at=time.time())
+                await db.update_status(
+                    "schedule_run",
+                    run_id,
+                    new_status="failed",
+                    reason_code=RunReasons.FAILED_EXCEPTION,
+                    reason_summary=f"{type(exc).__name__}: {exc}",
+                    evidence_refs=[{"kind": "schedule", "id": sid}],
+                    source="executor",
+                    actor=run_id,
+                    metadata={"exception_class": type(exc).__name__},
+                )
+                inv_status, inv_rc, inv_rs, inv_ev, inv_meta = await _resolve_invocation_terminal(
+                    db, inv_id, fallback_status="failed", exception=exc
+                )
+                await db.update_invocation(inv_id, ended_at=_end_time)
+                await db.update_status(
+                    "invocation",
+                    inv_id,
+                    new_status=inv_status,
+                    reason_code=inv_rc,
+                    reason_summary=inv_rs,
+                    evidence_refs=inv_ev,
+                    source="executor",
+                    actor=inv_id,
+                    metadata=inv_meta,
+                )
         finally:
             if chain_depth == 0:
                 self._running.pop(sid, None)
@@ -271,6 +561,7 @@ class SchedulerEngine:
                 return None
             try:
                 from croniter import croniter
+
                 return croniter(expr, start_time=ref_time).get_next(float)
             except Exception:
                 _log.exception("Invalid cron expression: %s", expr)

--- a/apps/studio/server/services/admin.py
+++ b/apps/studio/server/services/admin.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import time
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
 
 from lionagi.state.db import DEFAULT_DB_PATH
+from lionagi.state.reasons import SessionReasons
 
 from ._db import open_db as _open_db
 
@@ -261,13 +264,58 @@ async def health_report() -> dict[str, Any]:
 # so the API rejects the request before touching the DB.
 _ADMIN_TRANSITION_TARGETS: frozenset[str] = frozenset({"failed", "aborted", "cancelled"})
 
+# ADR-0028 §5: phantom-classifier (PhantomReason) → reason code mapping.
+_PHANTOM_REASON_CODES: dict[str, str] = {
+    "process_dead": SessionReasons.HEALTH_PHANTOM_PROCESS_DEAD,
+    "missing_artifacts": SessionReasons.HEALTH_PHANTOM_MISSING_ARTIFACTS,
+    "stale_lock": SessionReasons.HEALTH_ZOMBIE_STALE_LOCKS,
+}
+
+
+# ADR-0028 §5: SessionHealth (read-time) → reason code mapping. The
+# phantom resolver checks this AFTER the PhantomReason map so a
+# concrete phantom cause wins, but a non-phantom unhealthy session
+# (STALE without lock, ORPHANED, IDLE-but-process-dead) still gets a
+# specific reason code instead of falling back to the operator's
+# generic choice.
+def _resolve_session_health_reason_code(
+    *,
+    phantom_reason: str | None,
+    health,  # SessionHealth enum from lionagi.state.health
+) -> str | None:
+    """Return the most-specific health-derived reason code, or None.
+
+    Returns None when neither classifier yields a specific cause —
+    callers should keep the operator's `reason_code` in that case.
+    """
+    if phantom_reason is not None:
+        # PhantomReason wins — the phantom classifier names a concrete
+        # filesystem-level cause (dead process, missing artifacts, stale
+        # lock) that's more actionable than a generic health label.
+        return _PHANTOM_REASON_CODES.get(phantom_reason)
+    # Non-phantom unhealthy states use SessionReasons.HEALTH_* codes.
+    # Map by enum name so changes to the SessionHealth enum surface
+    # here at import time, not at runtime.
+    from lionagi.state.health import SessionHealth
+
+    if health == SessionHealth.STALE:
+        return SessionReasons.HEALTH_STALE_NO_HEARTBEAT
+    if health == SessionHealth.ORPHANED:
+        return SessionReasons.HEALTH_ORPHANED_NO_PROCESS
+    if health == SessionHealth.ZOMBIE:
+        return SessionReasons.HEALTH_ZOMBIE_STALE_LOCKS
+    return None
+
 
 async def transition_sessions(
     session_ids: list[str],
     *,
     target_status: str,
-    reason: str,
+    reason_code: str,
+    reason_summary: str = "",
+    evidence_refs: list[dict[str, Any]] | None = None,
     actor: str = "admin",
+    legacy_reason: str | None = None,
 ) -> dict[str, Any]:
     """Mark running sessions terminal with an audit-log entry.
 
@@ -284,13 +332,17 @@ async def transition_sessions(
       clause to close the TOCTOU window between the pre-check read and the
       write.
     """
+    from lionagi.state.reasons import validate_reason_code
+
     if target_status not in _ADMIN_TRANSITION_TARGETS:
         raise ValueError(
             f"target_status must be one of {sorted(_ADMIN_TRANSITION_TARGETS)}; "
             f"got {target_status!r}"
         )
-    if not reason or not reason.strip():
-        raise ValueError("reason is required")
+    validate_reason_code(reason_code)
+    if reason_summary is None:
+        reason_summary = ""
+    evidence_refs = list(evidence_refs or [])
     if not session_ids:
         return {"transitioned": [], "skipped": [], "event_id": None}
     if not DEFAULT_DB_PATH.exists():
@@ -341,47 +393,139 @@ async def transition_sessions(
                     "Only unhealthy sessions may be force-transitioned."
                 )
 
-            # UPDATE immediately after the health check to minimize the race
-            # window. The WHERE status='running' guard closes the residual
-            # TOCTOU: rowcount==0 means a concurrent transition already won.
-            cur = await db.db.execute(
-                "UPDATE sessions SET status=?, ended_at=?, updated_at=? "
-                "WHERE id=? AND status='running'"
-                "  AND (last_message_at IS ? OR last_message_at = ?)"
-                "  AND (updated_at      IS ? OR updated_at      = ?)",
-                (
-                    target_status,
-                    now,
-                    now,
-                    sid,
-                    _snap_last_msg,
-                    _snap_last_msg,
-                    _snap_updated,
-                    _snap_updated,
-                ),
+            # Health/phantom classification overrides the operator reason
+            # code when a concrete cause is available (ADR-0028 §5).
+            # _resolve_session_health_reason_code() returns the
+            # most-specific code — PhantomReason takes priority over
+            # SessionHealth so a dead process / missing artifacts /
+            # stale lock isn't masked by the broader STALE label.
+            phantom_reason = _classify_phantom(current, now=now, stale_seconds=3600)
+            classifier_code = _resolve_session_health_reason_code(
+                phantom_reason=phantom_reason,
+                health=health,
             )
-            await db.db.commit()
-            if cur.rowcount == 0:
-                existing = await db.get_session(sid)
-                if existing is None:
-                    skipped.append({"session_id": sid, "reason": "not_found"})
-                elif existing.get("status") == "running":
-                    # Status is still running but timestamps changed between
-                    # snapshot and UPDATE — a concurrent heartbeat raced us.
-                    skipped.append(
+            effective_reason_code = reason_code
+            effective_reason_summary = reason_summary
+            effective_evidence_refs: list[dict[str, Any]] = list(evidence_refs)
+            if classifier_code is not None:
+                effective_reason_code = classifier_code
+                # Preserve the operator's narrative when they bothered
+                # to write one; otherwise synthesize from the classifier.
+                if not reason_summary:
+                    cause = phantom_reason or health.value
+                    effective_reason_summary = (
+                        f"Operator transitioned session after classifier: {cause}."
+                    )
+                if phantom_reason is not None:
+                    effective_evidence_refs.append(
                         {
+                            "kind": "phantom_classification",
+                            "reason": phantom_reason,
                             "session_id": sid,
-                            "reason": "changed_since_snapshot",
                         }
                     )
                 else:
-                    skipped.append(
+                    effective_evidence_refs.append(
                         {
+                            "kind": "session_health",
+                            "health": health.value,
                             "session_id": sid,
-                            "reason": f"not_running:{existing.get('status')}",
                         }
                     )
-                continue
+
+            # ADR-0028: the conditional sessions UPDATE and the
+            # status_transitions INSERT must commit together. The
+            # earlier two-commit layout had a window where a crash
+            # between commits left the session terminal with no
+            # history row — the exact drift ADR-0028 §4 says must
+            # not happen.
+            #
+            # BEGIN IMMEDIATE acquires the write lock up front so the
+            # TOCTOU window is the same length as before (we already
+            # held the SQLite connection; this just makes the lock
+            # explicit instead of letting aiosqlite take it lazily on
+            # the first write).
+            await db.db.execute("BEGIN IMMEDIATE")
+            try:
+                cur = await db.db.execute(
+                    "UPDATE sessions SET status=?, ended_at=?, updated_at=?, "
+                    "  status_reason_code=?, status_reason_summary=?, status_evidence_refs=? "
+                    "WHERE id=? AND status='running'"
+                    "  AND (last_message_at IS ? OR last_message_at = ?)"
+                    "  AND (updated_at      IS ? OR updated_at      = ?)",
+                    (
+                        target_status,
+                        now,
+                        now,
+                        effective_reason_code,
+                        effective_reason_summary,
+                        json.dumps(effective_evidence_refs),
+                        sid,
+                        _snap_last_msg,
+                        _snap_last_msg,
+                        _snap_updated,
+                        _snap_updated,
+                    ),
+                )
+                if cur.rowcount == 0:
+                    # No row to transition — roll back the empty
+                    # transaction so we don't leave a no-op BEGIN
+                    # blocking the connection.
+                    await db.db.rollback()
+                    existing = await db.get_session(sid)
+                    if existing is None:
+                        skipped.append({"session_id": sid, "reason": "not_found"})
+                    elif existing.get("status") == "running":
+                        # Status is still running but timestamps changed
+                        # between snapshot and UPDATE — concurrent heartbeat.
+                        skipped.append(
+                            {
+                                "session_id": sid,
+                                "reason": "changed_since_snapshot",
+                            }
+                        )
+                    else:
+                        skipped.append(
+                            {
+                                "session_id": sid,
+                                "reason": f"not_running:{existing.get('status')}",
+                            }
+                        )
+                    continue
+                # Append the transition row inside the same transaction.
+                await db.db.execute(
+                    "INSERT INTO status_transitions "
+                    "(id, entity_type, entity_id, previous_status, status, "
+                    " reason_code, reason_summary, evidence_refs, "
+                    " source, actor, created_at, metadata) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        uuid.uuid4().hex,
+                        "session",
+                        sid,
+                        "running",
+                        target_status,
+                        effective_reason_code,
+                        effective_reason_summary,
+                        json.dumps(effective_evidence_refs),
+                        "admin",
+                        actor,
+                        now,
+                        json.dumps(
+                            {
+                                "legacy_reason": legacy_reason,
+                                "health": health.value,
+                                "process_alive": process_alive,
+                            }
+                        ),
+                    ),
+                )
+                await db.db.commit()
+            except BaseException:
+                # Any failure between BEGIN and COMMIT rolls back both
+                # writes, restoring the running session.
+                await db.db.rollback()
+                raise
             transitioned.append(sid)
 
         event_id = await db.insert_admin_event(
@@ -390,7 +534,10 @@ async def transition_sessions(
             actor=actor,
             details={
                 "target_status": target_status,
-                "reason": reason,
+                "reason_code": reason_code,
+                "reason_summary": reason_summary,
+                "evidence_refs": evidence_refs,
+                "reason": legacy_reason,
                 "transitioned": transitioned,
                 "skipped": skipped,
             },

--- a/apps/studio/server/services/runs.py
+++ b/apps/studio/server/services/runs.py
@@ -34,6 +34,7 @@ def _normalize_status_filter(status: str | list[str] | None) -> set[str] | None:
         result |= _STATUS_ALIASES.get(s, {s})
     return result or None
 
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -54,10 +55,7 @@ def _adapt_summary(
         step_count = len(manifest["steps"])
 
     worker_name = (
-        manifest.get("worker_name")
-        or manifest.get("worker")
-        or manifest.get("kind")
-        or ""
+        manifest.get("worker_name") or manifest.get("worker") or manifest.get("kind") or ""
     )
 
     task = str(manifest.get("task") or manifest.get("prompt") or "")
@@ -78,9 +76,7 @@ def _adapt_summary(
             status = "completed"
             if not finished_at:
                 try:
-                    latest = max(
-                        branches_dir.glob("*.json"), key=lambda p: p.stat().st_mtime
-                    )
+                    latest = max(branches_dir.glob("*.json"), key=lambda p: p.stat().st_mtime)
                     finished_at = latest.stat().st_mtime
                 except (OSError, ValueError):
                     pass
@@ -128,9 +124,7 @@ def _build_graph(manifest: dict[str, Any]) -> dict[str, Any]:
                         "id": kind,
                         "label": kind,
                         "role": manifest.get("provider", ""),
-                        "assignment": manifest.get("model_spec")
-                        or manifest.get("model")
-                        or "",
+                        "assignment": manifest.get("model_spec") or manifest.get("model") or "",
                         "prompt": "",
                         "capacity": 1,
                         "timeout": None,
@@ -192,7 +186,7 @@ def _summarize_args(fn: str, args: dict[str, Any]) -> str:
         return str(path) if path else "(patch)"
     # Fallback: show first non-trivial arg.
     for k, v in args.items():
-        if isinstance(v, (str, int, float)) and v:
+        if isinstance(v, str | int | float) and v:
             return f"{k}={v}"
     return ""
 
@@ -218,10 +212,7 @@ def _detect_status(output: str, function: str) -> tuple[str, int | None]:
             break
     if exit_code is not None and exit_code != 0:
         return ("error", exit_code)
-    if any(
-        kw in lower[:300]
-        for kw in ("error:", "failed", "permission denied", "not found")
-    ):
+    if any(kw in lower[:300] for kw in ("error:", "failed", "permission denied", "not found")):
         if "no such file or directory" in lower:
             return ("error", exit_code)
     return ("ok", exit_code)
@@ -281,11 +272,7 @@ def _extract_messages(branch: dict[str, Any]) -> list[dict[str, Any]]:
 
         # Render System
         if role == "system":
-            text = (
-                content.get("system_message", "")
-                if isinstance(content, dict)
-                else str(content)
-            )
+            text = content.get("system_message", "") if isinstance(content, dict) else str(content)
             if text:
                 out.append(
                     {
@@ -322,9 +309,7 @@ def _extract_messages(branch: dict[str, Any]) -> list[dict[str, Any]]:
         # Render Assistant
         if role == "assistant":
             text = (
-                content.get("assistant_response", "")
-                if isinstance(content, dict)
-                else str(content)
+                content.get("assistant_response", "") if isinstance(content, dict) else str(content)
             )
             if text:
                 out.append(
@@ -341,14 +326,10 @@ def _extract_messages(branch: dict[str, Any]) -> list[dict[str, Any]]:
         if role == "action" and cls == "ActionRequest":
             args = content.get("arguments", {}) if isinstance(content, dict) else {}
             fn = content.get("function", "") if isinstance(content, dict) else ""
-            response_id = (
-                content.get("action_response_id") if isinstance(content, dict) else None
-            )
+            response_id = content.get("action_response_id") if isinstance(content, dict) else None
             response_msg = response_by_id.get(response_id, {}) if response_id else {}
             response_content = (
-                response_msg.get("content", {})
-                if isinstance(response_msg, dict)
-                else {}
+                response_msg.get("content", {}) if isinstance(response_msg, dict) else {}
             )
             output_text = ""
             if isinstance(response_content, dict):
@@ -384,9 +365,7 @@ def _extract_messages(branch: dict[str, Any]) -> list[dict[str, Any]]:
                 {
                     "role": "tool_call",
                     "function": fn,
-                    "summary": _summarize_args(
-                        fn, args if isinstance(args, dict) else {}
-                    ),
+                    "summary": _summarize_args(fn, args if isinstance(args, dict) else {}),
                     "arguments": args if isinstance(args, dict) else {},
                     "output": str(output_text),
                     "status": status,
@@ -425,9 +404,7 @@ def _build_steps(
                     "status": "completed" if messages else "pending",
                     "result": {
                         "agent": name,
-                        "model": manifest.get("model_spec")
-                        or manifest.get("model")
-                        or "",
+                        "model": manifest.get("model_spec") or manifest.get("model") or "",
                         "message_count": len(messages),
                         "roles": role_counts,
                     },
@@ -511,6 +488,10 @@ def _adapt_detail(
         "graph": graph,
         "manifest": manifest,
         "branches": branches,
+        "artifact_contract_json": manifest.get("artifact_contract_json")
+        or manifest.get("artifact_contract"),
+        "artifact_verification_json": manifest.get("artifact_verification_json")
+        or manifest.get("artifact_verification"),
     }
 
 
@@ -574,41 +555,44 @@ async def list_runs(
         # effective_health === 'stale'. Map UNRESPONSIVE → 'stale' so the
         # dashboard counter stays correct without requiring a frontend change.
         effective_health = (
-            SessionHealth.STALE.value
-            if health == SessionHealth.UNRESPONSIVE
-            else health.value
+            SessionHealth.STALE.value if health == SessionHealth.UNRESPONSIVE else health.value
         )
-        out.append({
-            "run_id": s["id"],
-            "id": s["id"],
-            "name": s.get("name"),
-            "playbook_name": s.get("playbook_name"),
-            "agent_name": s.get("agent_name"),
-            "invocation_kind": s.get("invocation_kind"),
-            "show_topic": s.get("show_topic"),
-            "show_play_name": s.get("show_play_name"),
-            "source_kind": s.get("source_kind", "live"),
-            # ADR-0020: parent skill orchestration; null when standalone.
-            "invocation_id": s.get("invocation_id"),
-            # ADR-0022: provenance disclosure.
-            "model": s.get("model"),
-            "provider": s.get("provider"),
-            "effort": s.get("effort"),
-            "agent_hash": s.get("agent_hash"),
-            "status": s.get("status", "completed"),
-            "started_at": s.get("started_at"),
-            "ended_at": s.get("ended_at"),
-            "created_at": s.get("created_at"),
-            "updated_at": s.get("updated_at"),
-            # ADR-0019/0024: activity marker + derived health label.
-            "last_message_at": s.get("last_message_at"),
-            "effective_health": effective_health,
-            "branch_count": s.get("branch_count", 0),
-            "message_count": s.get("message_count", 0),
-            # ADR-0026: project detection.
-            "project": s.get("project"),
-            "project_source": s.get("project_source"),
-        })
+        out.append(
+            {
+                "run_id": s["id"],
+                "id": s["id"],
+                "name": s.get("name"),
+                "playbook_name": s.get("playbook_name"),
+                "agent_name": s.get("agent_name"),
+                "invocation_kind": s.get("invocation_kind"),
+                "show_topic": s.get("show_topic"),
+                "show_play_name": s.get("show_play_name"),
+                "source_kind": s.get("source_kind", "live"),
+                # ADR-0029: expected artifact contract and teardown verification.
+                "artifact_contract_json": s.get("artifact_contract_json"),
+                "artifact_verification_json": s.get("artifact_verification_json"),
+                # ADR-0020: parent skill orchestration; null when standalone.
+                "invocation_id": s.get("invocation_id"),
+                # ADR-0022: provenance disclosure.
+                "model": s.get("model"),
+                "provider": s.get("provider"),
+                "effort": s.get("effort"),
+                "agent_hash": s.get("agent_hash"),
+                "status": s.get("status", "completed"),
+                "started_at": s.get("started_at"),
+                "ended_at": s.get("ended_at"),
+                "created_at": s.get("created_at"),
+                "updated_at": s.get("updated_at"),
+                # ADR-0019/0024: activity marker + derived health label.
+                "last_message_at": s.get("last_message_at"),
+                "effective_health": effective_health,
+                "branch_count": s.get("branch_count", 0),
+                "message_count": s.get("message_count", 0),
+                # ADR-0026: project detection.
+                "project": s.get("project"),
+                "project_source": s.get("project_source"),
+            }
+        )
     return out
 
 
@@ -622,7 +606,7 @@ def paginate_runs(
     total = len(runs)
     total_pages = math.ceil(total / per_page) if total else 0
     start = (page - 1) * per_page
-    page_runs = runs[start: start + per_page]
+    page_runs = runs[start : start + per_page]
     return {
         "runs": page_runs,
         "page": page,
@@ -643,9 +627,7 @@ def get_run(run_id: str) -> dict[str, Any] | None:
 
     state_root = RUNS_ROOT / run_id
     if not state_root.is_dir():
-        matches = [
-            d for d in RUNS_ROOT.iterdir() if d.is_dir() and d.name.startswith(run_id)
-        ]
+        matches = [d for d in RUNS_ROOT.iterdir() if d.is_dir() and d.name.startswith(run_id)]
         if not matches:
             return None
         state_root = sorted(matches, key=lambda p: p.stat().st_mtime, reverse=True)[0]

--- a/apps/studio/server/services/sessions.py
+++ b/apps/studio/server/services/sessions.py
@@ -11,9 +11,7 @@ from ._db import open_db as _open_db
 
 _DB = str(DEFAULT_DB_PATH)
 
-SESSION_TERMINAL_STATUSES = frozenset(
-    {"completed", "failed", "timed_out", "aborted", "cancelled"}
-)
+SESSION_TERMINAL_STATUSES = frozenset({"completed", "failed", "timed_out", "aborted", "cancelled"})
 SESSION_DONE_STABLE_SECS = 60.0
 
 
@@ -51,24 +49,28 @@ def _graph_from_metadata(raw: str | None) -> dict[str, Any] | None:
         depends_on = op.get("depends_on", [])
         if not isinstance(depends_on, list):
             depends_on = []
-        nodes.append({
-            "id": op["id"],
-            "label": op["id"],
-            "role": agent.get("name", ""),
-            "assignment": agent.get("model", ""),
-            "prompt": "",
-            "capacity": 1,
-            "timeout": None,
-            "inputs": depends_on,
-            "outputs": [],
-        })
+        nodes.append(
+            {
+                "id": op["id"],
+                "label": op["id"],
+                "role": agent.get("name", ""),
+                "assignment": agent.get("model", ""),
+                "prompt": "",
+                "capacity": 1,
+                "timeout": None,
+                "inputs": depends_on,
+                "outputs": [],
+            }
+        )
         for dep in depends_on:
-            edges.append({
-                "id": f"e-{dep}-{op['id']}",
-                "source": dep,
-                "target": op["id"],
-                "mode": "simple",
-            })
+            edges.append(
+                {
+                    "id": f"e-{dep}-{op['id']}",
+                    "source": dep,
+                    "target": op["id"],
+                    "mode": "simple",
+                }
+            )
     return {"nodes": nodes, "edges": edges} if nodes else None
 
 
@@ -109,6 +111,9 @@ async def list_sessions() -> list[dict[str, Any]]:
                 s.invocation_kind,
                 s.show_topic,
                 s.show_play_name,
+                s.artifacts_path,
+                s.artifact_contract_json,
+                s.artifact_verification_json,
                 s.source_kind,
                 s.status,
                 s.started_at,
@@ -161,7 +166,10 @@ async def list_sessions() -> list[dict[str, Any]]:
             "invocation_kind": row["invocation_kind"],
             "show_topic": row["show_topic"],
             "show_play_name": row["show_play_name"],
+            "artifacts_path": row["artifacts_path"],
             "source_kind": row["source_kind"] or "live",
+            "artifact_contract_json": _parse_json_col(row["artifact_contract_json"]),
+            "artifact_verification_json": _parse_json_col(row["artifact_verification_json"]),
             # ADR-0026: project detection.
             "project": row["project"],
             "project_source": row["project_source"],
@@ -180,8 +188,9 @@ async def get_session(session_id: str) -> dict[str, Any] | None:
             # ADR-0022: include provenance columns (model/provider/effort/agent_hash)
             """SELECT id, name, created_at, updated_at,
                       playbook_name, agent_name, invocation_kind,
-                      show_topic, show_play_name, artifacts_path, source_kind,
-                      status, started_at, ended_at,
+                      show_topic, show_play_name, artifacts_path,
+                      artifact_contract_json, artifact_verification_json,
+                      source_kind, status, started_at, ended_at,
                       model, provider, effort, agent_hash, invocation_id,
                       node_metadata, project, project_source
                FROM sessions WHERE id = ?""",
@@ -285,6 +294,8 @@ async def get_session(session_id: str) -> dict[str, Any] | None:
         "show_topic": session_row["show_topic"],
         "show_play_name": session_row["show_play_name"],
         "artifacts_path": session_row["artifacts_path"],
+        "artifact_contract_json": _parse_json_col(session_row["artifact_contract_json"]),
+        "artifact_verification_json": _parse_json_col(session_row["artifact_verification_json"]),
         "source_kind": session_row["source_kind"] or "live",
         "status": session_row["status"] or "completed",
         "started_at": started_at,

--- a/apps/studio/server/services/shows.py
+++ b/apps/studio/server/services/shows.py
@@ -57,9 +57,13 @@ def _extract_repo_and_branches(show_md: str | None) -> tuple[str | None, str | N
     for line in show_md.splitlines():
         if line.strip().startswith("- Repo:"):
             repo = line.split(":", 1)[1].strip()
-        elif line.strip().startswith("- Integration branch:") or line.strip().startswith("- Integration:"):
+        elif line.strip().startswith("- Integration branch:") or line.strip().startswith(
+            "- Integration:"
+        ):
             integration = line.split(":", 1)[1].strip().split("(")[0].strip()
-        elif line.strip().startswith("- Base for final merge:") or line.strip().startswith("- Base:"):
+        elif line.strip().startswith("- Base for final merge:") or line.strip().startswith(
+            "- Base:"
+        ):
             base = line.split(":", 1)[1].strip()
     return repo, base, integration
 
@@ -167,20 +171,21 @@ async def get_show(topic: str) -> dict[str, Any] | None:
     if await _db_available():
         try:
             async with _open_db(_DB) as db:
-                cur = await db.execute(
-                    "SELECT * FROM shows WHERE topic = ?", (topic,)
-                )
+                cur = await db.execute("SELECT * FROM shows WHERE topic = ?", (topic,))
                 row = await cur.fetchone()
                 if row:
                     show_row = dict(row)
 
-                    play_cur = await db.execute("""
+                    play_cur = await db.execute(
+                        """
                         SELECT p.*, s.name AS session_name
                         FROM plays p
                         LEFT JOIN sessions s ON s.id = p.session_id
                         WHERE p.show_id = ?
                         ORDER BY p.sort_order, p.created_at
-                    """, (show_row["id"],))
+                    """,
+                        (show_row["id"],),
+                    )
                     play_rows = await play_cur.fetchall()
                     db_plays = [dict(r) for r in play_rows]
         except Exception:
@@ -190,29 +195,37 @@ async def get_show(topic: str) -> dict[str, Any] | None:
         plays = []
         for p in db_plays:
             play_dir = show_dir / p["name"]
-            plays.append({
-                "name": p["name"],
-                "meta": {
-                    "worktree": p["worktree"],
-                    "branch": p["branch"],
-                    "attempt": p["attempt"],
-                    "started_at": p["started_at"],
-                    "ended_at": p["ended_at"],
-                    "exit_code": p["exit_code"],
-                    "merged_at": p["merged_at"],
-                    "merge_sha": p["merge_sha"],
-                    "status": p["status"],
-                },
-                "verdict": {
-                    "gate_passed": bool(p["gate_passed"]) if p["gate_passed"] is not None else None,
-                    "feedback": p["gate_feedback"],
-                } if p["gate_passed"] is not None else _read_json(play_dir / "_verdict.json"),
-                "session_id": p["session_id"],
-                "session_name": p.get("session_name"),
-                "intent": _read_text(play_dir / "_intent.md"),
-                "updated_at": p["updated_at"],
-                "depends_on": json.loads(p["depends_on"]) if isinstance(p["depends_on"], str) else (p["depends_on"] or []),
-            })
+            plays.append(
+                {
+                    "name": p["name"],
+                    "meta": {
+                        "worktree": p["worktree"],
+                        "branch": p["branch"],
+                        "attempt": p["attempt"],
+                        "started_at": p["started_at"],
+                        "ended_at": p["ended_at"],
+                        "exit_code": p["exit_code"],
+                        "merged_at": p["merged_at"],
+                        "merge_sha": p["merge_sha"],
+                        "status": p["status"],
+                    },
+                    "verdict": {
+                        "gate_passed": bool(p["gate_passed"])
+                        if p["gate_passed"] is not None
+                        else None,
+                        "feedback": p["gate_feedback"],
+                    }
+                    if p["gate_passed"] is not None
+                    else _read_json(play_dir / "_verdict.json"),
+                    "session_id": p["session_id"],
+                    "session_name": p.get("session_name"),
+                    "intent": _read_text(play_dir / "_intent.md"),
+                    "updated_at": p["updated_at"],
+                    "depends_on": json.loads(p["depends_on"])
+                    if isinstance(p["depends_on"], str)
+                    else (p["depends_on"] or []),
+                }
+            )
     else:
         plays = []
         for play_dir in _play_dirs(show_dir):
@@ -222,12 +235,14 @@ async def get_show(topic: str) -> dict[str, Any] | None:
                 updated_at = play_dir.stat().st_mtime
             except OSError:
                 updated_at = None
-            plays.append({
-                "name": play_dir.name,
-                "meta": meta,
-                "verdict": verdict,
-                "updated_at": updated_at,
-            })
+            plays.append(
+                {
+                    "name": play_dir.name,
+                    "meta": meta,
+                    "verdict": verdict,
+                    "updated_at": updated_at,
+                }
+            )
 
     # F-A1-5 (ADR-0011 §"Show status provenance"): status_source mirrors the
     # derivation in list_shows() — "sqlite" when the row came from the DB,
@@ -255,6 +270,7 @@ async def import_shows() -> dict[str, int]:
         return {"shows_imported": 0, "plays_imported": 0}
 
     from lionagi.state.db import StateDB
+    from lionagi.state.reasons import PlayReasons, ShowReasons
 
     shows_count = 0
     plays_count = 0
@@ -267,9 +283,7 @@ async def import_shows() -> dict[str, int]:
             topic = show_path.name
             now = time.time()
 
-            cur = await db.db.execute(
-                "SELECT id FROM shows WHERE topic = ?", (topic,)
-            )
+            cur = await db.db.execute("SELECT id FROM shows WHERE topic = ?", (topic,))
             existing = await cur.fetchone()
             if existing:
                 show_id = existing["id"]
@@ -303,15 +317,59 @@ async def import_shows() -> dict[str, int]:
                 except OSError:
                     created_at = now
 
+                show_reason_code: str | None = None
+                show_reason_summary = ""
+                show_evidence_refs: list[dict[str, Any]] = []
+                if abort_file:
+                    show_reason_code = ShowReasons.ABORTED_OPERATOR
+                    show_reason_summary = "Show was imported with an operator abort marker."
+                    show_evidence_refs = [{"kind": "file", "path": str(show_path / "_ABORT")}]
+                elif final_verdict and final_verdict.get("show_passed"):
+                    show_reason_code = ShowReasons.COMPLETED_FINAL_GATE
+                    show_reason_summary = "Show was imported with a passing final gate verdict."
+                    show_evidence_refs = [
+                        {"kind": "file", "path": str(show_path / "_final_verdict.json")}
+                    ]
+                elif show_status == "completed":
+                    _log.warning(
+                        "show %s imported as completed without final gate evidence; "
+                        "no ADR-0028 reason code matched",
+                        topic,
+                    )
+
                 await db.db.execute(
                     """INSERT OR IGNORE INTO shows
                        (id, topic, goal, repo, base_branch, integration_branch,
                         status, show_dir, created_at, updated_at)
                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                    (show_id, topic, goal, repo, base_branch, integration,
-                     show_status, str(show_path), created_at, now),
+                    (
+                        show_id,
+                        topic,
+                        goal,
+                        repo,
+                        base_branch,
+                        integration,
+                        show_status,
+                        str(show_path),
+                        created_at,
+                        now,
+                    ),
                 )
                 shows_count += 1
+
+                if show_reason_code is not None:
+                    await db.db.commit()
+                    await db.update_status(
+                        "show",
+                        show_id,
+                        new_status=show_status,
+                        reason_code=show_reason_code,
+                        reason_summary=show_reason_summary,
+                        evidence_refs=show_evidence_refs,
+                        source="system",
+                        actor="shows_import",
+                        metadata={"topic": topic},
+                    )
 
             for idx, play_dir in enumerate(_play_dirs(show_path)):
                 play_name = play_dir.name
@@ -349,12 +407,14 @@ async def import_shows() -> dict[str, int]:
                 ended_at = meta.get("ended_at")
                 if isinstance(started_at, str):
                     from datetime import datetime
+
                     try:
                         started_at = datetime.fromisoformat(started_at).timestamp()
                     except (ValueError, TypeError):
                         started_at = None
                 if isinstance(ended_at, str):
                     from datetime import datetime
+
                     try:
                         ended_at = datetime.fromisoformat(ended_at).timestamp()
                     except (ValueError, TypeError):
@@ -363,6 +423,7 @@ async def import_shows() -> dict[str, int]:
                 merged_at = meta.get("merged_at")
                 if isinstance(merged_at, str):
                     from datetime import datetime
+
                     try:
                         merged_at = datetime.fromisoformat(merged_at).timestamp()
                     except (ValueError, TypeError):
@@ -373,6 +434,59 @@ async def import_shows() -> dict[str, int]:
                 except OSError:
                     play_created = time.time()
 
+                imported_play_status = str(meta.get("status", "pending"))
+                play_attempt = int(meta.get("attempt", 1) or 1)
+
+                play_reason_code: str | None = None
+                play_reason_summary = ""
+                play_evidence_refs: list[dict[str, Any]] = []
+                if imported_play_status == "blocked":
+                    block_reason = meta.get("block_reason") or meta.get("blocked_reason")
+                    if block_reason == "invalid_deps":
+                        play_reason_code = PlayReasons.BLOCKED_INVALID_DEPS
+                        play_reason_summary = (
+                            "Play was imported as blocked because dependencies were invalid."
+                        )
+                    elif block_reason == "dep_failed":
+                        play_reason_code = PlayReasons.BLOCKED_DEP_FAILED
+                        play_reason_summary = (
+                            "Play was imported as blocked because a dependency failed."
+                        )
+                    else:
+                        _log.warning(
+                            "play %s/%s imported as blocked without invalid_deps or dep_failed "
+                            "evidence; no ADR-0028 reason code matched",
+                            topic,
+                            play_name,
+                        )
+                elif imported_play_status == "gate_failed" and gate_passed == 0:
+                    play_reason_code = PlayReasons.GATE_FAILED_VERDICT
+                    play_reason_summary = "Play was imported with a failing gate verdict."
+                    play_evidence_refs = [{"kind": "file", "path": str(play_dir / "_verdict.json")}]
+                elif imported_play_status == "escalated" and play_attempt >= 2:
+                    play_reason_code = PlayReasons.ESCALATED_GATE_TWICE
+                    play_reason_summary = (
+                        "Play was imported as escalated after a second gate failure."
+                    )
+                elif imported_play_status == "merged":
+                    play_reason_code = PlayReasons.MERGED_OK
+                    play_reason_summary = "Play was imported as merged."
+                elif imported_play_status not in {
+                    "pending",
+                    "running",
+                    "running_complete",
+                    "prepared",
+                    "gated",
+                    "redoing",
+                    "aborted_after_finish",
+                }:
+                    _log.warning(
+                        "play %s/%s imported with status %s but no ADR-0028 reason code matched",
+                        topic,
+                        play_name,
+                        imported_play_status,
+                    )
+
                 await db.db.execute(
                     """INSERT OR IGNORE INTO plays
                        (id, show_id, name, playbook, effort, status, attempt,
@@ -381,16 +495,45 @@ async def import_shows() -> dict[str, int]:
                         gate_passed, gate_feedback, depends_on,
                         sort_order, created_at, updated_at)
                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                    (play_id, show_id, play_name, None,
-                     meta.get("effort"), meta.get("status", "pending"),
-                     meta.get("attempt", 1), session_id,
-                     started_at, ended_at, meta.get("exit_code"),
-                     meta.get("worktree"), meta.get("branch"),
-                     meta.get("merge_sha"), merged_at,
-                     gate_passed, gate_feedback, json.dumps([]),
-                     idx, play_created, play_created),
+                    (
+                        play_id,
+                        show_id,
+                        play_name,
+                        None,
+                        meta.get("effort"),
+                        imported_play_status,
+                        play_attempt,
+                        session_id,
+                        started_at,
+                        ended_at,
+                        meta.get("exit_code"),
+                        meta.get("worktree"),
+                        meta.get("branch"),
+                        meta.get("merge_sha"),
+                        merged_at,
+                        gate_passed,
+                        gate_feedback,
+                        json.dumps([]),
+                        idx,
+                        play_created,
+                        play_created,
+                    ),
                 )
                 plays_count += 1
+
+                if play_reason_code is not None:
+                    await db.db.commit()
+                    await db.update_status(
+                        "play",
+                        play_id,
+                        new_status=imported_play_status,
+                        reason_code=play_reason_code,
+                        reason_summary=play_reason_summary,
+                        evidence_refs=play_evidence_refs,
+                        source="system",
+                        actor="shows_import",
+                        metadata={"topic": topic, "play": play_name, "attempt": play_attempt},
+                    )
 
         await db.db.commit()
 
@@ -447,14 +590,14 @@ async def watch_show(topic: str) -> AsyncGenerator[str, None]:
             if await _db_available():
                 try:
                     async with _open_db(_DB) as db:
-                        cur = await db.execute(
-                            "SELECT status FROM shows WHERE topic = ?", (topic,)
-                        )
+                        cur = await db.execute("SELECT status FROM shows WHERE topic = ?", (topic,))
                         row = await cur.fetchone()
                         if row:
                             show_status = row["status"]
                 except Exception:
-                    _log.debug("watch_show DB status check failed for topic %r", topic, exc_info=True)
+                    _log.debug(
+                        "watch_show DB status check failed for topic %r", topic, exc_info=True
+                    )
             if show_status in _SHOW_TERMINAL_STATUSES:
                 yield f"data: {json.dumps({'type': 'done'})}\n\n"
                 return

--- a/lionagi/cli/_agents.py
+++ b/lionagi/cli/_agents.py
@@ -24,11 +24,12 @@ Profile format (YAML frontmatter + markdown body):
     You are an implementer. Write production code, not stubs...
 
 Frontmatter fields (all optional, CLI flags override):
-  model:       provider/model spec
-  effort:      reasoning effort level
-  yolo:        auto-approve tool calls
-  fast_mode:   route via OpenAI priority tier (codex only)
-  lion_system: prepend LION_SYSTEM_MESSAGE (default: true)
+  model:              provider/model spec
+  effort:             reasoning effort level
+  yolo:               auto-approve tool calls
+  fast_mode:          route via OpenAI priority tier (codex only)
+  lion_system:        prepend LION_SYSTEM_MESSAGE (default: true)
+  artifact_defaults:  ADR-0029 expected artifact defaults
 """
 
 from __future__ import annotations
@@ -47,6 +48,7 @@ class AgentProfile:
     yolo: bool = False
     fast_mode: bool = False
     lion_system: bool = True
+    artifact_defaults: dict | None = None
     extra: dict = field(default_factory=dict)
 
 
@@ -60,7 +62,7 @@ def _find_lionagi_dirs() -> list[Path]:
     # 1. Git root
     try:
         root = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
+            ["git", "rev-parse", "--show-toplevel"],  # noqa: S607 — git is expected on $PATH
             capture_output=True,
             text=True,
             timeout=5,
@@ -167,15 +169,13 @@ def _parse_profile(name: str, text: str) -> AgentProfile:
         if len(parts) >= 3:
             fm_text = parts[1].strip()
             body = parts[2].strip()
-            for line in fm_text.splitlines():
-                line = line.strip()
-                if ":" in line:
-                    key, _, val = line.partition(":")
-                    val = val.strip()
-                    if val.lower() in ("true", "false"):
-                        frontmatter[key.strip()] = val.lower() == "true"
-                    else:
-                        frontmatter[key.strip()] = val
+            if fm_text:
+                import yaml
+
+                loaded = yaml.safe_load(fm_text) or {}
+                if not isinstance(loaded, dict):
+                    loaded = {}
+                frontmatter = loaded
 
     lion_system = bool(frontmatter.get("lion_system", True))
     if lion_system:
@@ -191,9 +191,18 @@ def _parse_profile(name: str, text: str) -> AgentProfile:
         yolo=bool(frontmatter.get("yolo", False)),
         fast_mode=bool(frontmatter.get("fast_mode", False)),
         lion_system=lion_system,
+        artifact_defaults=frontmatter.get("artifact_defaults"),
         extra={
             k: v
             for k, v in frontmatter.items()
-            if k not in ("model", "effort", "yolo", "fast_mode", "lion_system")
+            if k
+            not in (
+                "model",
+                "effort",
+                "yolo",
+                "fast_mode",
+                "lion_system",
+                "artifact_defaults",
+            )
         },
     )

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -12,6 +12,12 @@ from lionagi._errors import TimeoutError as LionTimeoutError
 from lionagi.ln.concurrency import run_async
 from lionagi.protocols.generic.log import DataLoggerConfig
 from lionagi.state import provenance as _provenance
+from lionagi.state.artifact_verifier import (
+    missing_artifact_evidence,
+    missing_artifact_summary,
+    resolve_artifact_contract,
+    verify_artifact_contract,
+)
 
 from ._agents import load_agent_profile
 from ._logging import hint, log_error
@@ -133,10 +139,15 @@ async def _run_agent(
     # ``model_spec`` here is the canonical ``provider/model`` string built
     # right above this block — no aliases, no defaults yet to apply.
     resolved_model_spec = _provenance.resolve_model_spec(provider, model)
+    artifact_contract = resolve_artifact_contract(
+        playbook_artifacts=None,
+        agent_defaults=profile.artifact_defaults if profile else None,
+    )
     live = await _setup_live_persist(
         branch,
         agent_name=agent_name,
         artifacts_path=str(run.artifact_root),
+        artifact_contract=artifact_contract,
         invocation_id=invocation_id,
         model=resolved_model_spec,
         provider=provider,
@@ -192,11 +203,18 @@ async def _run_agent(
         import anyio
 
         with anyio.CancelScope(shield=True):
-            await _teardown_live_persist(
+            # ADR-0029 §7: teardown may override the proposed terminal
+            # status (clean exit + missing required artifact → failed).
+            # Use the returned status — NOT the original — for the
+            # process exit code so shell scripts, schedules, and chains
+            # see the failure.
+            effective_status = await _teardown_live_persist(
                 live,
                 status=_terminal_status,
                 exception=_terminal_exc,
             )
+            if effective_status != _terminal_status:
+                _terminal_status = effective_status
             # Shut down every iModel on the branch (chat_model AND
             # parse_model, plus any other registered) so each
             # RateLimitedAPIExecutor's background replenisher task is
@@ -225,6 +243,7 @@ async def _setup_live_persist(
     *,
     agent_name: str | None = None,
     artifacts_path: str | None = None,
+    artifact_contract: dict | None = None,
     invocation_id: str | None = None,
     model: str | None = None,
     provider: str | None = None,
@@ -320,6 +339,7 @@ async def _setup_live_persist(
                     "invocation_kind": "agent",
                     "agent_name": agent_name,
                     "artifacts_path": artifacts_path,
+                    "artifact_contract_json": artifact_contract,
                     "status": "running",
                     "started_at": time.time(),
                     # ADR-0020: optional skill-level orchestration parent.
@@ -381,6 +401,8 @@ async def _setup_live_persist(
             "branch_prog_id": branch_prog_id,
             "existing_msg_ids": existing_msg_ids,
             "new_msg_ids": [],
+            "artifacts_path": artifacts_path,
+            "artifact_contract": artifact_contract,
         }
 
         async def _on_message(msg):
@@ -481,8 +503,14 @@ async def _teardown_live_persist(
     *,
     status: str = "completed",
     exception: BaseException | None = None,
-) -> None:
+) -> str:
     """Update session bookmarks, lifecycle columns, and close DB.
+
+    Returns the *effective* terminal status — ADR-0029 §7's verification
+    override can flip a clean ``completed`` into ``failed`` when required
+    artifacts are missing. Callers MUST use the returned status (not the
+    `status` argument they passed in) for any downstream side effect
+    like the process exit code.
 
     The DB close is in its own ``finally`` so it always runs — even if
     the bookmark update or hook removal fails. Failures elsewhere are
@@ -500,7 +528,7 @@ async def _teardown_live_persist(
     exception class and message.
     """
     if ctx is None:
-        return
+        return status
     import logging
 
     log = logging.getLogger("lionagi.cli")
@@ -528,13 +556,43 @@ async def _teardown_live_persist(
         metadata: dict | None = None
         if exception is not None:
             metadata = {"exception_class": type(exception).__name__}
+
+        session_row = await db.get_session(session_id) or {}
+        contract = session_row.get("artifact_contract_json")
+        artifacts_root = session_row.get("artifacts_path")
+        verification = verify_artifact_contract(
+            contract,
+            artifacts_root=artifacts_root,
+        )
+        await db.update_artifact_verification(session_id, verification)
+
+        final_status = status
+        final_reason_code = reason_code
+        final_reason_summary = reason_summary
+        final_evidence_refs = evidence_refs
+        if verification and verification["status"] == "failed":
+            missing = verification["missing_required"]
+            if status == "completed":
+                from lionagi.state.reasons import RunReasons
+
+                final_status = "failed"
+                final_reason_code = RunReasons.FAILED_MISSING_ARTIFACT
+                final_reason_summary = missing_artifact_summary(missing)
+                final_evidence_refs = missing_artifact_evidence(missing)
+            else:
+                metadata = dict(metadata or {})
+                metadata["artifact_verification_status"] = verification["status"]
+                metadata["missing_required_artifact_ids"] = [
+                    str(entry.get("id", "")) for entry in missing
+                ]
+
         await db.update_status(
             "session",
             session_id,
-            new_status=status,
-            reason_code=reason_code,
-            reason_summary=reason_summary,
-            evidence_refs=evidence_refs,
+            new_status=final_status,
+            reason_code=final_reason_code,
+            reason_summary=final_reason_summary,
+            evidence_refs=final_evidence_refs,
             source="executor",
             actor=session_id,
             metadata=metadata,
@@ -550,11 +608,15 @@ async def _teardown_live_persist(
         ]
     except Exception as exc:
         log.warning("live persist teardown failed: %s", exc, exc_info=True)
+        # Surface the original status on best-effort failure so the
+        # caller's exit code reflects what we tried to commit.
+        return status
     finally:
         try:
             await db.close()
         except Exception as exc:
             log.warning("live persist db.close failed: %s", exc, exc_info=True)
+    return final_status
 
 
 def add_agent_subparser(subparsers: argparse._SubParsersAction) -> None:

--- a/lionagi/cli/main.py
+++ b/lionagi/cli/main.py
@@ -69,6 +69,107 @@ def _print_playbook_help(name: str) -> int:
     return 0
 
 
+# The unknown-subfield warning is shared with the runtime spec validator
+# (lionagi/cli/orchestrate/__init__.py) — see warn_unknown_artifact_keys
+# in lionagi/state/artifact_verifier.py. Importing here keeps the
+# pre-flight and runtime warnings in lockstep.
+
+
+def _handle_play_check(argv: list[str]) -> int:
+    """`li play check <name>` — ADR-0029 §9 pre-flight contract validation.
+
+    Loads the playbook, optionally loads the agent profile it names so
+    `artifact_defaults` participate in the merge (matching what a real
+    invocation will see), resolves the contract via
+    :func:`lionagi.state.artifact_verifier.resolve_artifact_contract`,
+    and pretty-prints the result. Does not fire the playbook.
+    """
+    if not argv or argv[0].startswith("-"):
+        print("Usage: li play check <name>")
+        return 1
+    name = argv[0]
+
+    from lionagi.cli.orchestrate import _load_flow_spec, _resolve_playbook_path
+    from lionagi.state.artifact_verifier import (
+        ArtifactPathError,
+        resolve_artifact_contract,
+        warn_unknown_artifact_keys,
+    )
+
+    path, err = _resolve_playbook_path(name)
+    if err is not None:
+        log_error(err)
+        return 1
+    spec = _load_flow_spec(str(path))
+    if not isinstance(spec, dict):
+        log_error(f"could not parse playbook spec at {path}")
+        return 1
+
+    artifacts_block = spec.get("artifacts")
+    # Load the agent profile the playbook names so its artifact_defaults
+    # participate in the merge — a real invocation sees them. The actual
+    # `li play` path raises if the profile is missing, so pre-flight
+    # must FAIL in the same case rather than silently green-light an
+    # invocation that will crash at execution start.
+    agent_defaults = None
+    agent_name = spec.get("agent")
+    if agent_name:
+        try:
+            from lionagi.cli._agents import load_agent_profile
+
+            profile = load_agent_profile(agent_name)
+            agent_defaults = getattr(profile, "artifact_defaults", None)
+        except Exception as exc:  # noqa: BLE001 — match runtime behaviour
+            log_error(
+                f"playbook '{name}' references agent profile "
+                f"'{agent_name}' but it could not be loaded: {exc}. "
+                f"Real `li play {name}` will fail at execution start; "
+                f"fix the profile or remove the `agent:` field."
+            )
+            return 1
+
+    if not artifacts_block and not agent_defaults:
+        print(f"playbook '{name}': no `artifacts:` block declared (verification skipped).")
+        return 0
+
+    if artifacts_block:
+        # Same warning the runtime spec validator emits (via
+        # logger.warning there); on the pre-flight surface we want it
+        # visible in the operator's terminal, so default print is fine.
+        warn_unknown_artifact_keys(artifacts_block, source=f"playbook '{name}'")
+
+    try:
+        resolved = resolve_artifact_contract(
+            playbook_artifacts=artifacts_block,
+            agent_defaults=agent_defaults,
+        )
+    except ArtifactPathError as exc:
+        log_error(f"playbook '{name}' artifact contract invalid: {exc}")
+        return 1
+
+    if resolved is None:
+        print(f"playbook '{name}': empty contract (no expected artifacts).")
+        return 0
+
+    expected = resolved.get("expected", [])
+    required = [e for e in expected if e.get("required", True)]
+    optional = [e for e in expected if not e.get("required", True)]
+    sources = [e.get("source") for e in expected]
+    from_playbook = sum(1 for s in sources if s == "playbook")
+    from_agent = sum(1 for s in sources if s == "agent_profile")
+    print(f"playbook '{name}' artifact contract:")
+    print(f"  expected: {len(expected)} ({len(required)} required, {len(optional)} optional)")
+    if from_playbook or from_agent:
+        print(f"  sources:  {from_playbook} from playbook, {from_agent} from agent_profile")
+    for e in expected:
+        flag = "REQUIRED" if e.get("required", True) else "OPTIONAL"
+        src = e.get("source", "?")
+        desc = e.get("description") or ""
+        suffix = f" — {desc}" if desc else ""
+        print(f"  [{flag}] {e['id']}  →  {e['path']}  (from {src}){suffix}")
+    return 0
+
+
 def _handle_play_shortcut(argv: list[str]) -> list[str] | int:
     """Expand `li play` sugar into `li o flow -p NAME ...`.
 
@@ -89,15 +190,18 @@ def _handle_play_shortcut(argv: list[str]) -> list[str] | int:
         if not root.is_dir():
             print(f"(no playbooks directory at {root})")
             return 0
-        names = sorted(
-            p.name.removesuffix(".playbook.yaml") for p in root.glob("*.playbook.yaml")
-        )
+        names = sorted(p.name.removesuffix(".playbook.yaml") for p in root.glob("*.playbook.yaml"))
         if not names:
             print(f"(no playbooks in {root})")
             return 0
         for name in names:
             print(name)
         return 0
+    if head == "check":
+        # ADR-0029 §9: pre-flight artifact-contract validation.
+        # `li play check <name>` loads the playbook, resolves its
+        # artifact contract, and prints the result without firing.
+        return _handle_play_check(rest[1:])
     if head.startswith("-"):
         log_error("li play NAME must come before flags")
         return 1

--- a/lionagi/cli/orchestrate/__init__.py
+++ b/lionagi/cli/orchestrate/__init__.py
@@ -166,8 +166,8 @@ def add_orchestrate_subparser(
         default=None,
         help=(
             "Load playbook from ~/.lionagi/playbooks/<NAME>.playbook.yaml. "
-            "Playbooks may declare args: schema or argument-hint: for "
-            "CLI flags that fill template placeholders {name} in the prompt."
+            "Playbooks may declare args: schema, artifacts: contracts, "
+            "or argument-hint: placeholders for prompt template values."
         ),
     )
     fl.add_argument(
@@ -553,9 +553,7 @@ def _validate_spec_fields(spec: dict) -> str | None:
     if "workers" in spec:
         workers = spec["workers"]
         if not isinstance(workers, int) or isinstance(workers, bool):
-            return (
-                f"spec field 'workers' must be an integer, got {type(workers).__name__}"
-            )
+            return f"spec field 'workers' must be an integer, got {type(workers).__name__}"
         if not (1 <= workers <= 32):
             return f"spec field 'workers' must be in [1, 32], got {workers}"
 
@@ -591,7 +589,7 @@ def _validate_spec_fields(spec: dict) -> str | None:
     #   str   → synthesis model spec (flag with explicit value)
     if "with_synthesis" in spec:
         val = spec["with_synthesis"]
-        if not isinstance(val, (bool, str)):
+        if not isinstance(val, bool | str):
             return (
                 f"spec field 'with_synthesis' must be bool or str (model spec), "
                 f"got {type(val).__name__}"
@@ -621,12 +619,37 @@ def _validate_spec_fields(spec: dict) -> str | None:
             if not isinstance(val, str):
                 return f"spec field {str_field!r} must be a string, got {type(val).__name__}"
 
+    if "artifacts" in spec:
+        artifacts = spec["artifacts"]
+        if artifacts is None:
+            return "spec field 'artifacts' must be a dict, got NoneType"
+        try:
+            from lionagi.state.artifact_verifier import (
+                validate_artifact_contract,
+                warn_unknown_artifact_keys,
+            )
+
+            validate_artifact_contract(artifacts)
+            # ADR-0029 §2: unknown subfields are reserved for v1.1.
+            # Warn at runtime as well as in `li play check` so contract
+            # files don't silently drift into v1.1-looking shapes the
+            # v1 executor ignores. Route through the standard logger
+            # so the warning lands in structured logs, not stdout.
+            import logging as _logging
+
+            _cli_log = _logging.getLogger("lionagi.cli")
+            warn_unknown_artifact_keys(
+                artifacts,
+                source="playbook",
+                emit=_cli_log.warning,
+            )
+        except Exception as exc:
+            return f"spec field 'artifacts' is invalid: {exc}"
+
     return None
 
 
-def _interpolate_prompt(
-    template: str, positional: str | None, playbook_args: dict
-) -> str:
+def _interpolate_prompt(template: str, positional: str | None, playbook_args: dict) -> str:
     """Interpolate {input} + all playbook args into the prompt template.
 
     - {input} substitution uses the positional prompt if present
@@ -718,6 +741,7 @@ def run_orchestrate(args: argparse.Namespace) -> int:
     if args.orch_command == "flow":
         # ── Resolve -p/--playbook NAME into a concrete file path ─────
         playbook_name = getattr(args, "playbook", None)
+        playbook_artifacts: dict | None = None
         file_spec = getattr(args, "file", None)
         if playbook_name and file_spec:
             log_error("pass either -p/--playbook or -f/--file, not both")
@@ -738,6 +762,8 @@ def run_orchestrate(args: argparse.Namespace) -> int:
             if spec_err is not None:
                 log_error(spec_err)
                 return 1
+
+            playbook_artifacts = spec.get("artifacts")
 
             # ── Derive args schema: explicit args: block OR argument-hint fallback
             if "args" in spec:
@@ -764,9 +790,7 @@ def run_orchestrate(args: argparse.Namespace) -> int:
                 raw = getattr(args, name, None)
                 if raw is None:
                     continue
-                coerced, coerce_err = _coerce_arg_value(
-                    name, raw, field.get("type", "str")
-                )
+                coerced, coerce_err = _coerce_arg_value(name, raw, field.get("type", "str"))
                 if coerce_err is not None:
                     log_error(coerce_err)
                     return 1
@@ -774,11 +798,7 @@ def run_orchestrate(args: argparse.Namespace) -> int:
 
             # If the file supplies the model/agent, argparse's lone positional
             # is a prompt override, not a model override.
-            if (
-                args.model
-                and args.prompt is None
-                and (spec.get("model") or spec.get("agent"))
-            ):
+            if args.model and args.prompt is None and (spec.get("model") or spec.get("agent")):
                 args.prompt = args.model
                 args.model = None
             # File values are defaults; CLI flags override.
@@ -787,9 +807,7 @@ def run_orchestrate(args: argparse.Namespace) -> int:
             if args.agent is None and spec.get("agent"):
                 args.agent = spec["agent"]
             if spec.get("prompt"):
-                args.prompt = _interpolate_prompt(
-                    spec["prompt"], args.prompt, playbook_ctx
-                )
+                args.prompt = _interpolate_prompt(spec["prompt"], args.prompt, playbook_ctx)
             if args.max_concurrent == 0 and spec.get("workers"):
                 args.max_concurrent = spec["workers"]
             if args.effort is None and spec.get("effort"):
@@ -832,10 +850,7 @@ def run_orchestrate(args: argparse.Namespace) -> int:
             log_error("prompt is required (positional or via -f spec file)")
             return 1
 
-        if (
-            args.team_mode is not None
-            and getattr(args, "team_attach", None) is not None
-        ):
+        if args.team_mode is not None and getattr(args, "team_attach", None) is not None:
             log_error("--team-mode and --team-attach are mutually exclusive")
             return 1
 
@@ -888,7 +903,7 @@ def run_orchestrate(args: argparse.Namespace) -> int:
         synthesis_model = synth if isinstance(synth, str) else None
 
         try:
-            output = run_async(
+            output, terminal_status = run_async(
                 _run_flow(
                     model_spec=args.model or "",
                     prompt=args.prompt,
@@ -913,6 +928,7 @@ def run_orchestrate(args: argparse.Namespace) -> int:
                     show_graph=getattr(args, "show_graph", False),
                     fast=getattr(args, "fast", False),
                     playbook_name=playbook_name,
+                    playbook_artifacts=playbook_artifacts,
                     invocation_id=getattr(args, "invocation", None),
                     project=getattr(args, "project", None),
                 )
@@ -930,7 +946,11 @@ def run_orchestrate(args: argparse.Namespace) -> int:
             raise
         if not args.verbose:
             print(output)
-        return 0
+        # ADR-0029 §7: terminal_status reflects the verification override.
+        # Map to the same exit codes used by `li agent` (see ADR-0025).
+        from lionagi.cli.agent import _EXIT_CODE_BY_TERMINAL_STATUS
+
+        return _EXIT_CODE_BY_TERMINAL_STATUS.get(terminal_status, 0)
 
     log_error(f"Unknown orchestrate command: {args.orch_command}")
     return 1

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -35,6 +35,11 @@ from lionagi import Branch, Session
 from lionagi.operations.builder import OperationGraphBuilder
 from lionagi.protocols.generic.log import DataLoggerConfig
 from lionagi.state import provenance as _provenance
+from lionagi.state.artifact_verifier import (
+    missing_artifact_evidence,
+    missing_artifact_summary,
+    verify_artifact_contract,
+)
 
 from .._agents import AgentProfile, load_agent_profile
 from .._logging import hint
@@ -42,15 +47,14 @@ from .._providers import build_imodel_from_spec, resolve_persisted_effort
 from .._runs import RunDir, allocate_run, save_last_branch_pointer
 
 
-def _resolve_session_model(
-    provider: str | None, model: str | None
-) -> str | None:
+def _resolve_session_model(provider: str | None, model: str | None) -> str | None:
     """ADR-0022: canonical 'provider/model' for the session.model column.
 
     Thin wrapper over :func:`provenance.resolve_model_spec` so callers
     don't repeat the import. Returns None when both args are None.
     """
     return _provenance.resolve_model_spec(provider, model)
+
 
 __all__ = (
     "OrchestrationEnv",
@@ -261,9 +265,7 @@ def setup_orchestration(
             fast = True
 
     if not model_spec:
-        raise ValueError(
-            "Provide a model spec or use -a/--agent to load a profile with a model."
-        )
+        raise ValueError("Provide a model spec or use -a/--agent to load a profile with a model.")
 
     orc_imodel = build_imodel_from_spec(
         model_spec,
@@ -398,9 +400,7 @@ def build_worker_branch(
     w_imodel.endpoint.config.kwargs["repo"] = artifact_dir
     # Grant write access to the actual project directory so workers can
     # edit source files, not just their artifact sandbox.
-    project_root = (
-        str(Path(env.cwd).resolve()) if env.cwd else str(Path.cwd().resolve())
-    )
+    project_root = str(Path(env.cwd).resolve()) if env.cwd else str(Path.cwd().resolve())
     w_imodel.endpoint.config.kwargs.setdefault("add_dir", [])
     if project_root not in w_imodel.endpoint.config.kwargs["add_dir"]:
         w_imodel.endpoint.config.kwargs["add_dir"].append(project_root)
@@ -498,7 +498,9 @@ def finalize_orchestration(
         except Exception as exc:  # noqa: BLE001
             log.warning(
                 "finalize: branch snapshot write failed for %s: %s",
-                branch.id, exc, exc_info=True,
+                branch.id,
+                exc,
+                exc_info=True,
             )
 
     if extras:
@@ -526,6 +528,7 @@ async def start_live_persist(
     playbook_name: str | None = None,
     agent_name: str | None = None,
     artifacts_path: str | None = None,
+    artifact_contract: dict[str, Any] | None = None,
     invocation_id: str | None = None,
     model: str | None = None,
     provider: str | None = None,
@@ -576,6 +579,7 @@ async def start_live_persist(
                 "playbook_name": playbook_name,
                 "agent_name": agent_name,
                 "artifacts_path": artifacts_path,
+                "artifact_contract_json": artifact_contract,
                 "status": "running",
                 "started_at": time.time(),
                 # ADR-0020: optional skill orchestration parent
@@ -599,6 +603,8 @@ async def start_live_persist(
             "session_prog_id": session_prog_id,
             "branch_prog_ids": {},
             "hooks": [],
+            "artifacts_path": artifacts_path,
+            "artifact_contract": artifact_contract,
         }
         env._live_persist = ctx
 
@@ -676,9 +682,7 @@ def _register_branch_hook(ctx: dict[str, Any], branch: Branch) -> None:
                 ep_cfg = branch.chat_model.endpoint.config
                 br_provider = getattr(ep_cfg, "provider", None)
                 br_model_raw = (ep_cfg.kwargs or {}).get("model")
-                br_model = _provenance.resolve_model_spec(
-                    br_provider, br_model_raw
-                )
+                br_model = _provenance.resolve_model_spec(br_provider, br_model_raw)
             except Exception as _provenance_exc:  # noqa: BLE001
                 # Provenance is best-effort — never block the branch row.
                 import logging
@@ -719,9 +723,7 @@ def _register_branch_hook(ctx: dict[str, Any], branch: Branch) -> None:
             await db.append_to_progression(branch_prog_id, msg_id)
             await db.append_to_progression(session_prog_id, msg_id)
             # ADR-0019: activity heartbeat for staleness detection.
-            await db.touch_session_activity(
-                session_id, at=msg_dict.get("created_at")
-            )
+            await db.touch_session_activity(session_id, at=msg_dict.get("created_at"))
             # ADR-0009: keep branches.system_msg_id pointing at the
             # current system if the runtime replaces it mid-flow.
             if msg_dict.get("role") == "system":
@@ -744,8 +746,14 @@ async def stop_live_persist(
     env: OrchestrationEnv,
     *,
     status: str = "completed",
-) -> None:
+    exception: BaseException | None = None,
+) -> str:
     """Update session bookmarks, lifecycle columns, and close DB.
+
+    Returns the *effective* terminal status — ADR-0029 §7's verification
+    override can flip a clean ``completed`` into ``failed`` when required
+    artifacts are missing. Callers MUST use the returned status for the
+    process exit code.
 
     The DB close is in its own ``finally`` so it always runs — even if
     the bookmark update or hook removal fails. Leaving the DB unclosed
@@ -756,15 +764,15 @@ async def stop_live_persist(
 
     ctx = env._live_persist
     if ctx is None:
-        return
+        return status
     log = logging.getLogger("lionagi.cli")
     db = ctx["db"]
     try:
         session_prog_id = ctx["session_prog_id"]
+        session_id = ctx["session_id"]
 
         all_msgs = await db.get_progression(session_prog_id)
         update_kwargs: dict[str, Any] = {
-            "status": status,
             "ended_at": time.time(),
         }
         if all_msgs:
@@ -775,20 +783,69 @@ async def stop_live_persist(
         if extras:
             update_kwargs["node_metadata"] = json.dumps(extras)
 
-        await db.update_session(ctx["session_id"], **update_kwargs)
+        await db.update_session(session_id, **update_kwargs)
+
+        from lionagi.cli.agent import _resolve_run_reason
+
+        reason_code, reason_summary, evidence_refs = _resolve_run_reason(
+            status=status,
+            exception=exception,
+        )
+        metadata: dict[str, Any] | None = None
+        if exception is not None:
+            metadata = {"exception_class": type(exception).__name__}
+
+        session_row = await db.get_session(session_id) or {}
+        verification = verify_artifact_contract(
+            session_row.get("artifact_contract_json"),
+            artifacts_root=session_row.get("artifacts_path"),
+        )
+        await db.update_artifact_verification(session_id, verification)
+
+        final_status = status
+        final_reason_code = reason_code
+        final_reason_summary = reason_summary
+        final_evidence_refs = evidence_refs
+        if verification and verification["status"] == "failed":
+            missing = verification["missing_required"]
+            if status == "completed":
+                from lionagi.state.reasons import RunReasons
+
+                final_status = "failed"
+                final_reason_code = RunReasons.FAILED_MISSING_ARTIFACT
+                final_reason_summary = missing_artifact_summary(missing)
+                final_evidence_refs = missing_artifact_evidence(missing)
+            else:
+                metadata = dict(metadata or {})
+                metadata["artifact_verification_status"] = verification["status"]
+                metadata["missing_required_artifact_ids"] = [
+                    str(entry.get("id", "")) for entry in missing
+                ]
+
+        await db.update_status(
+            "session",
+            session_id,
+            new_status=final_status,
+            reason_code=final_reason_code,
+            reason_summary=final_reason_summary,
+            evidence_refs=final_evidence_refs,
+            source="executor",
+            actor=session_id,
+            metadata=metadata,
+        )
 
         # Remove ALL matching registrations of each hook (list.remove
         # would only drop the first; a duplicate registration would
         # leave a closed-DB hook live).
         for branch, hook in ctx["hooks"]:
-            branch.on_message_added[:] = [
-                h for h in branch.on_message_added if h is not hook
-            ]
+            branch.on_message_added[:] = [h for h in branch.on_message_added if h is not hook]
     except Exception as exc:
         log.warning("live persist teardown failed: %s", exc, exc_info=True)
+        return status
     finally:
         try:
             await db.close()
         except Exception as exc:
             log.warning("live persist db.close failed: %s", exc, exc_info=True)
         env._live_persist = None
+    return final_status

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import re
 import time
@@ -33,6 +34,102 @@ from ._orchestration import (
     stop_live_persist,
     team_guidance,
 )
+
+
+async def _resolve_invocation_terminal_flow(
+    invocation_id: str,
+    *,
+    fallback_status: str,
+) -> tuple[str, str, str, list[dict], dict]:
+    """Aggregate child session statuses into a flow invocation terminal reason."""
+    from lionagi.state.db import StateDB
+    from lionagi.state.reasons import RunReasons
+
+    async with StateDB() as db:
+        sessions = await db.list_sessions_for_invocation(invocation_id)
+        child_statuses = [str(s.get("status") or "") for s in sessions]
+        evidence_refs = [{"kind": "session", "id": s["id"]} for s in sessions if s.get("id")]
+        metadata: dict = {"child_statuses": child_statuses}
+
+        # Precedence: timed_out > failed > aborted > cancelled > completed.
+        # `failed` MUST beat `aborted`/`cancelled` so a real failure isn't
+        # masked by sibling cleanup-cancellation triggered by the failure.
+        if child_statuses:
+            if any(s == "timed_out" for s in child_statuses):
+                return (
+                    "timed_out",
+                    RunReasons.TIMED_OUT_DEADLINE,
+                    "Flow timed out because at least one child session timed out.",
+                    evidence_refs,
+                    metadata,
+                )
+            if any(s == "failed" for s in child_statuses):
+                return (
+                    "failed",
+                    RunReasons.FAILED_EXCEPTION,
+                    "Flow failed because at least one child session failed.",
+                    evidence_refs,
+                    metadata,
+                )
+            if any(s == "aborted" for s in child_statuses):
+                return (
+                    "aborted",
+                    RunReasons.ABORTED_USER,
+                    "Flow was aborted because at least one child session was aborted.",
+                    evidence_refs,
+                    metadata,
+                )
+            if any(s == "cancelled" for s in child_statuses):
+                return (
+                    "cancelled",
+                    RunReasons.CANCELLED_SYSTEM,
+                    "Flow was cancelled because at least one child session was cancelled.",
+                    evidence_refs,
+                    metadata,
+                )
+            if all(s == "completed" for s in child_statuses):
+                return (
+                    "completed",
+                    RunReasons.COMPLETED_OK,
+                    "All child sessions completed successfully.",
+                    evidence_refs,
+                    metadata,
+                )
+
+        if fallback_status == "completed":
+            return (
+                "completed",
+                RunReasons.COMPLETED_OK,
+                "Flow completed successfully.",
+                evidence_refs,
+                metadata,
+            )
+        if fallback_status == "timed_out":
+            return (
+                "timed_out",
+                RunReasons.TIMED_OUT_DEADLINE,
+                "Flow exceeded its configured timeout.",
+                evidence_refs,
+                metadata,
+            )
+        if fallback_status == "aborted":
+            return (
+                "aborted",
+                RunReasons.ABORTED_USER,
+                "Flow was aborted by the user.",
+                evidence_refs,
+                metadata,
+            )
+        if fallback_status == "cancelled":
+            return (
+                "cancelled",
+                RunReasons.CANCELLED_SYSTEM,
+                "Flow was cancelled by the runtime.",
+                evidence_refs,
+                metadata,
+            )
+        return "failed", RunReasons.FAILED_EXCEPTION, "Flow failed.", evidence_refs, metadata
+
 
 # ── Security: restrict model-produced identifiers used as filesystem paths ──
 #
@@ -419,11 +516,18 @@ async def _run_flow(
     show_graph: bool = False,
     fast: bool = False,
     playbook_name: str | None = None,
+    playbook_artifacts: dict | None = None,
     invocation_id: str | None = None,
     project: str | None = None,
     **legacy_kwargs,
-) -> str:
+) -> tuple[str, str]:
     """Auto-DAG flow: orchestrator plans DAG → engine executes with deps.
+
+    Returns ``(output, terminal_status)`` — ADR-0029 §7 lets the artifact
+    contract verifier flip a clean ``completed`` into ``failed`` at
+    teardown, so callers MUST use the returned status to compute the
+    process exit code rather than assuming success when no exception
+    was raised.
 
     ``max_ops`` caps the number of operations (DAG nodes) the planner may
     emit. ``max_agents`` is accepted as a deprecated alias.
@@ -435,9 +539,7 @@ async def _run_flow(
         legacy_kwargs.pop("max_agents")
     if legacy_kwargs:
         # Surface unrecognized kwargs instead of swallowing.
-        raise TypeError(
-            f"_run_flow() got unexpected keyword arguments: {list(legacy_kwargs)}"
-        )
+        raise TypeError(f"_run_flow() got unexpected keyword arguments: {list(legacy_kwargs)}")
     env = setup_orchestration(
         pattern_name="Flow",
         model_spec=model_spec,
@@ -463,6 +565,27 @@ async def _run_flow(
     _orc_provider = None
     if _orc_ms and "/" in _orc_ms.model:
         _orc_provider = _orc_ms.model.split("/", 1)[0]
+    # ADR-0029 §4-5: resolve the artifact contract (playbook overrides
+    # agent defaults by id; playbook wins). Snapshot onto the session
+    # via start_live_persist so verify_artifact_contract() at teardown
+    # has something to check against. None = no contract declared →
+    # verification skipped entirely.
+    artifact_contract = None
+    if playbook_artifacts is not None or (
+        agent_name is not None and getattr(env.agent_profile, "artifact_defaults", None) is not None
+    ):
+        from lionagi.state.artifact_verifier import resolve_artifact_contract
+
+        agent_defaults = (
+            getattr(env.agent_profile, "artifact_defaults", None)
+            if agent_name is not None
+            else None
+        )
+        artifact_contract = resolve_artifact_contract(
+            playbook_artifacts=playbook_artifacts,
+            agent_defaults=agent_defaults,
+        )
+
     await start_live_persist(
         env,
         invocation_kind="play" if playbook_name else "flow",
@@ -474,6 +597,7 @@ async def _run_flow(
         provider=_orc_provider,
         effort=env.effort,
         project=project,
+        artifact_contract=artifact_contract,
     )
 
     inner_kw = dict(
@@ -490,6 +614,7 @@ async def _run_flow(
     )
     # ADR-0025: distinguish timed_out / aborted / cancelled / failed.
     _terminal_status = "completed"
+    result: str = ""
     try:
         if timeout:
             with move_on_after(timeout) as cancel_scope:
@@ -497,8 +622,8 @@ async def _run_flow(
             if cancel_scope.cancelled_caught:
                 _terminal_status = "timed_out"
                 raise LionTimeoutError(f"Flow timed out after {timeout}s")
-            return result
-        return await _run_flow_inner(model_spec, prompt, **inner_kw)
+        else:
+            result = await _run_flow_inner(model_spec, prompt, **inner_kw)
     except KeyboardInterrupt:
         _terminal_status = "aborted"
         raise
@@ -521,9 +646,52 @@ async def _run_flow(
         import anyio
 
         with anyio.CancelScope(shield=True):
-            await stop_live_persist(env, status=_terminal_status)
+            # ADR-0029 §7: stop_live_persist may override the proposed
+            # status (clean exit + missing required → failed). Use the
+            # returned status for downstream exit-code propagation.
+            effective_status = await stop_live_persist(env, status=_terminal_status)
+            if effective_status != _terminal_status:
+                _terminal_status = effective_status
+            # ADR-0028 Phase 2: finalize invocation with reason code,
+            # using the (possibly overridden) terminal status.
+            if invocation_id:
+                import time as _time
+
+                from lionagi.state.db import StateDB
+
+                try:
+                    (
+                        inv_status,
+                        inv_rc,
+                        inv_rs,
+                        inv_ev,
+                        inv_meta,
+                    ) = await _resolve_invocation_terminal_flow(
+                        invocation_id, fallback_status=_terminal_status
+                    )
+                    async with StateDB() as _inv_db:
+                        await _inv_db.update_invocation(invocation_id, ended_at=_time.time())
+                        await _inv_db.update_status(
+                            "invocation",
+                            invocation_id,
+                            new_status=inv_status,
+                            reason_code=inv_rc,
+                            reason_summary=inv_rs,
+                            evidence_refs=inv_ev,
+                            source="executor",
+                            actor=invocation_id,
+                            metadata=inv_meta,
+                        )
+                except Exception:
+                    import logging as _logging
+
+                    _logging.getLogger("lionagi.cli").exception(
+                        "Failed to finalize invocation %s", invocation_id
+                    )
             for _br in env.session.branches:
                 await _br.mdls.shutdown()
+
+    return result, _terminal_status
 
 
 async def _run_flow_inner(
@@ -632,7 +800,9 @@ async def _run_flow_inner(
     seen_agent_ids: set[str] = set()
     for a in plan.agents:
         if a.id in seen_agent_ids:
-            return f"Invalid plan: duplicate FlowAgent.id {a.id!r}. Each agent must have a unique id."
+            return (
+                f"Invalid plan: duplicate FlowAgent.id {a.id!r}. Each agent must have a unique id."
+            )
         seen_agent_ids.add(a.id)
 
     # Reject duplicate FlowOp.id as well — depends_on references would
@@ -738,9 +908,7 @@ async def _run_flow_inner(
 
             visualize_plan(
                 plan,
-                title=(
-                    f"Flow DAG plan — {len(plan.agents)} agents / {len(plan.operations)} ops"
-                ),
+                title=(f"Flow DAG plan — {len(plan.agents)} agents / {len(plan.operations)} ops"),
                 save_path=str(run.dag_image_path),
             )
 
@@ -815,9 +983,7 @@ async def _run_flow_inner(
                     # turn — no need to re-gather context or re-read files.
                     dep_notes.append(f"{d}: already in your memory (same agent)")
                 else:
-                    dep_notes.append(
-                        f"{d} ({dep_agent}): {run.agent_artifact_dir(dep_agent)}/"
-                    )
+                    dep_notes.append(f"{d} ({dep_agent}): {run.agent_artifact_dir(dep_agent)}/")
             if dep_notes:
                 artifact_note += f" Upstream: {'; '.join(dep_notes)}."
         ctx.append({"artifact_instructions": artifact_note})
@@ -886,9 +1052,7 @@ async def _run_flow_inner(
     control_ops = [op for op in plan.operations if op.control]
 
     ctrl_note = f" ({len(control_ops)} control)" if control_ops else ""
-    progress(
-        f"Executing DAG: {len(plan.agents)} agents / {len(regular_ops)} ops{ctrl_note}..."
-    )
+    progress(f"Executing DAG: {len(plan.agents)} agents / {len(regular_ops)} ops{ctrl_note}...")
 
     for op in regular_ops:
         a = agent_spec_by_id[op.agent_id]
@@ -930,14 +1094,16 @@ async def _run_flow_inner(
         branch_id = str(branch.id) if branch else ""
         now = time.time()
         if new_status == "running":
-            _op_segments.append({
-                "op_id": op_id,
-                "branch_id": branch_id,
-                "branch_name": branch_name,
-                "status": "running",
-                "started_at": now,
-                "ended_at": None,
-            })
+            _op_segments.append(
+                {
+                    "op_id": op_id,
+                    "branch_id": branch_id,
+                    "branch_name": branch_name,
+                    "status": "running",
+                    "started_at": now,
+                    "ended_at": None,
+                }
+            )
         else:
             for seg in reversed(_op_segments):
                 if seg["op_id"] == op_id:
@@ -956,12 +1122,10 @@ async def _run_flow_inner(
         import asyncio as _aio
 
         async def _do():
-            try:
-                await ctx["db"].update_session(
-                    ctx["session_id"], node_metadata=json.dumps(extras)
-                )
-            except Exception:
-                pass
+            # Best-effort live metadata update — failures here mustn't block
+            # the surrounding flow execution.
+            with contextlib.suppress(Exception):
+                await ctx["db"].update_session(ctx["session_id"], node_metadata=json.dumps(extras))
 
         _aio.ensure_future(_do())
 
@@ -975,15 +1139,14 @@ async def _run_flow_inner(
         import asyncio as _aio
 
         async def _do():
-            try:
+            # Best-effort branch status sync — failures must not block the flow.
+            with contextlib.suppress(Exception):
                 kw = {"status": new_status}
                 if new_status == "running":
                     kw["started_at"] = time.time()
                 elif new_status in ("completed", "failed"):
                     kw["ended_at"] = time.time()
                 await ctx["db"].update_branch(str(branch.id), **kw)
-            except Exception:
-                pass
 
         _aio.ensure_future(_do())
 
@@ -994,19 +1157,23 @@ async def _run_flow_inner(
             for aid in agents_by_id
         ],
         "operations": [
-            {"id": op.id, "agent_id": op.agent_id, "control": op.control, "depends_on": op.depends_on or []}
+            {
+                "id": op.id,
+                "agent_id": op.agent_id,
+                "control": op.control,
+                "depends_on": op.depends_on or [],
+            }
             for op in plan.operations
         ],
     }
     env._finalize_extras = _early_graph
     ctx = getattr(env, "_live_persist", None)
     if ctx and ctx.get("db"):
-        try:
+        # Best-effort early DAG snapshot — flow continues even if persist fails.
+        with contextlib.suppress(Exception):
             await ctx["db"].update_session(
                 ctx["session_id"], node_metadata=json.dumps(_early_graph)
             )
-        except Exception:
-            pass
 
     # Execute regular ops
     t_exec = time.monotonic()
@@ -1049,9 +1216,7 @@ async def _run_flow_inner(
         c_branch = agents_by_id[cop.agent_id]
         c_model = agent_model_by_id[cop.agent_id]
 
-        artifacts = [
-            f"[op {r['id']} via {r['name']}]: {r['response']}" for r in agent_results
-        ]
+        artifacts = [f"[op {r['id']} via {r['name']}]: {r['response']}" for r in agent_results]
         dep_nodes = [op_to_node[d] for d in (cop.depends_on or []) if d in op_to_node]
         if not dep_nodes:
             dep_nodes = list(op_to_node.values())[-1:] or [plan_root]
@@ -1170,9 +1335,7 @@ async def _run_flow_inner(
             new_ops: list[FlowOp] = []
             for nop in next_plan.operations:
                 if nop.agent_id not in agents_by_id:
-                    progress(
-                        f"Re-plan: skipping op {nop.id!r} — unknown agent {nop.agent_id!r}"
-                    )
+                    progress(f"Re-plan: skipping op {nop.id!r} — unknown agent {nop.agent_id!r}")
                     continue
                 if nop.id in op_to_node:
                     progress(f"Re-plan: skipping duplicate op id {nop.id!r}")
@@ -1221,9 +1384,7 @@ async def _run_flow_inner(
                 op_id_to_agent[nop.id] = nop.agent_id
 
             ids = ", ".join(o.id for o in new_ops)
-            progress(
-                f"Re-plan: +{len(next_plan.agents)} agents, +{len(new_ops)} ops: {ids}"
-            )
+            progress(f"Re-plan: +{len(next_plan.agents)} agents, +{len(new_ops)} ops: {ids}")
 
             for nop in new_ops:
                 na = agent_spec_by_id[nop.agent_id]
@@ -1284,9 +1445,7 @@ async def _run_flow_inner(
         all_op_node_ids = set(op_to_node.values())
         leaf_nodes = list(all_op_node_ids - depended_on_nodes) or list(all_op_node_ids)
 
-        artifacts = [
-            f"[op {r['id']} via {r['name']}]: {r['response']}" for r in agent_results
-        ]
+        artifacts = [f"[op {r['id']} via {r['name']}]: {r['response']}" for r in agent_results]
         adirs = [str(run.agent_artifact_dir(aid)) for aid in agents_by_id]
         artifact_chain_note = (
             f"\n\nARTIFACT CHAIN: Read ALL files in: {', '.join(adirs)}. "
@@ -1339,9 +1498,7 @@ async def _run_flow_inner(
         run.synthesis_path.write_text(synthesis_result["response"])
 
     if team_data:
-        _post_results_to_team(
-            team_data, agent_results, all_agent_names, synthesis_result
-        )
+        _post_results_to_team(team_data, agent_results, all_agent_names, synthesis_result)
 
     # ── Persist branches + run manifest + hints ──────────────────────
     finalize_orchestration(

--- a/lionagi/state/artifact_verifier.py
+++ b/lionagi/state/artifact_verifier.py
@@ -1,0 +1,273 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""ADR-0029: Artifact contract validation and verification."""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+from pathlib import PurePosixPath
+from typing import Any, Literal, TypedDict
+
+_GLOB_CHARS = frozenset("*?[]")
+_ARTIFACT_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+_VALIDATION_ROOT = os.path.realpath("/tmp/__contract_validate__")  # noqa: S108 — synthetic root for path-validation only, never written to
+
+# ADR-0029 §2: v1 entry fields. `kind`, `min_size`, `mime_type` are
+# reserved for v1.1 — silently accepting them now would let contract
+# files drift into looking stricter than the executor actually is.
+# Both the `li play check` pre-flight AND the real `li play` runtime
+# path emit a warning for unknown subfields via warn_unknown_artifact_keys().
+_ARTIFACT_ENTRY_ALLOWED_KEYS = frozenset({"id", "path", "required", "description", "source"})
+
+
+class ArtifactPathError(ValueError):
+    """Raised when an artifact contract id/path is invalid."""
+
+
+class ExpectedArtifact(TypedDict, total=False):
+    id: str
+    path: str
+    required: bool
+    description: str
+    source: str
+
+
+class ProducedArtifact(TypedDict):
+    id: str
+    path: str
+    size: int
+    present: bool
+
+
+class ArtifactContract(TypedDict):
+    expected: list[ExpectedArtifact]
+
+
+class VerificationResult(TypedDict):
+    status: Literal["passed", "failed", "warning", "skipped"]
+    checked_at: float
+    missing_required: list[ExpectedArtifact]
+    missing_optional: list[ExpectedArtifact]
+    produced: list[ProducedArtifact]
+
+
+def _safe_join(root: str, rel: str) -> str:
+    """Join rel under root, rejecting absolute paths, globs, '..', and escapes."""
+    if not isinstance(rel, str) or not rel or rel.startswith("/"):
+        raise ArtifactPathError(f"absolute path not allowed: {rel!r}")
+    if any(c in _GLOB_CHARS for c in rel):
+        raise ArtifactPathError(f"glob characters not allowed in v1: {rel!r}")
+
+    parts = PurePosixPath(rel).parts
+    if not parts or any(p in ("..", "") for p in parts):
+        raise ArtifactPathError(f"`..` segments not allowed: {rel!r}")
+
+    root_real = os.path.realpath(root)
+    joined = os.path.realpath(os.path.join(root_real, *parts))
+    try:
+        common = os.path.commonpath([root_real, joined])
+    except ValueError as exc:
+        raise ArtifactPathError(f"path escapes artifacts_root: {rel!r}") from exc
+    if common != root_real:
+        raise ArtifactPathError(f"path escapes artifacts_root: {rel!r}")
+    return joined
+
+
+def warn_unknown_artifact_keys(
+    contract: dict[str, Any] | None,
+    *,
+    source: str = "playbook",
+    emit: Any = None,
+) -> list[str]:
+    """Warn about unknown subfields under each `expected[]` entry.
+
+    ADR-0029 §2 declares v1 fields as `id, path, required, description`
+    (plus `source` added by the resolver). `kind`, `min_size`,
+    `mime_type` are reserved for v1.1. Silently accepting them in v1
+    lets contract files look stricter than the executor actually is —
+    warn so the author sees what was ignored.
+
+    Both `li play check` (pre-flight) and the real `li play` execution
+    path call this so the warning fires in both surfaces.
+
+    ``emit`` defaults to printing to stdout (for the CLI pre-flight).
+    The runtime path passes a logger so warnings land in the structured
+    log, not the console.
+
+    Returns the list of warning messages emitted (so tests can assert
+    without capturing the side channel).
+    """
+    if contract is None:
+        return []
+    expected = contract.get("expected") or []
+    if not isinstance(expected, list):
+        return []
+    if emit is None:
+        emit = print
+    warnings: list[str] = []
+    for entry in expected:
+        if not isinstance(entry, dict):
+            continue
+        unknown = set(entry.keys()) - _ARTIFACT_ENTRY_ALLOWED_KEYS
+        if unknown:
+            msg = (
+                f"warning: {source} artifact entry "
+                f"{entry.get('id', '<unnamed>')!r} has unknown subfield(s) "
+                f"{sorted(unknown)} (ignored by v1; reserved for v1.1)."
+            )
+            warnings.append(msg)
+            emit(msg)
+    return warnings
+
+
+def validate_artifact_contract(contract: dict[str, Any] | None) -> None:
+    if contract is None:
+        return
+    if not isinstance(contract, dict):
+        raise ArtifactPathError(f"artifact contract must be a dict, got {type(contract).__name__}")
+    expected = contract.get("expected")
+    if not isinstance(expected, list):
+        raise ArtifactPathError("artifact contract must contain expected: list")
+
+    seen_ids: set[str] = set()
+    for idx, entry in enumerate(expected):
+        if not isinstance(entry, dict):
+            raise ArtifactPathError(f"expected[{idx}] must be a dict")
+        eid = entry.get("id")
+        if not isinstance(eid, str) or not _ARTIFACT_ID_RE.fullmatch(eid):
+            raise ArtifactPathError(f"id must be alphanumeric/_/-: {eid!r}")
+        if eid in seen_ids:
+            raise ArtifactPathError(f"duplicate id in contract: {eid!r}")
+        seen_ids.add(eid)
+
+        path = entry.get("path")
+        if not isinstance(path, str) or not path:
+            raise ArtifactPathError(f"expected[{idx}].path must be a non-empty string")
+        if "required" in entry and not isinstance(entry["required"], bool):
+            raise ArtifactPathError(f"expected[{idx}].required must be a bool")
+        if "description" in entry and not isinstance(entry["description"], str):
+            raise ArtifactPathError(f"expected[{idx}].description must be a string")
+        if "source" in entry and not isinstance(entry["source"], str):
+            raise ArtifactPathError(f"expected[{idx}].source must be a string")
+
+        _safe_join(_VALIDATION_ROOT, path)
+
+
+def resolve_artifact_contract(
+    *,
+    playbook_artifacts: dict[str, Any] | None,
+    agent_defaults: dict[str, Any] | None,
+) -> ArtifactContract | None:
+    if playbook_artifacts is None and agent_defaults is None:
+        return None
+
+    by_id: dict[str, ExpectedArtifact] = {}
+    for source, declared in (
+        ("agent_profile", agent_defaults),
+        ("playbook", playbook_artifacts),
+    ):
+        if declared is None:
+            continue
+        if not isinstance(declared, dict):
+            raise ArtifactPathError(f"{source} artifact contract must be a dict")
+        expected = declared.get("expected")
+        if not isinstance(expected, list):
+            raise ArtifactPathError(f"{source} artifact contract must contain expected: list")
+        for raw in expected:
+            if not isinstance(raw, dict):
+                raise ArtifactPathError(f"{source} expected artifact must be a dict")
+            spec: ExpectedArtifact = {
+                **raw,
+                "required": raw.get("required", True),
+                "description": raw.get("description", ""),
+                "source": source,
+            }
+            by_id[spec["id"]] = spec
+
+    resolved: ArtifactContract = {"expected": list(by_id.values())}
+    validate_artifact_contract(resolved)
+    return resolved
+
+
+def verify_artifact_contract(
+    contract: dict[str, Any] | None,
+    *,
+    artifacts_root: str | None,
+) -> VerificationResult | None:
+    if contract is None:
+        return None
+    validate_artifact_contract(contract)
+    expected = contract["expected"]
+
+    if not artifacts_root or not os.path.isdir(artifacts_root):
+        mr = [e for e in expected if e.get("required", True)]
+        mo = [e for e in expected if not e.get("required", True)]
+        if mr:
+            st: Literal["failed", "warning", "passed"] = "failed"
+        elif mo:
+            st = "warning"
+        else:
+            st = "passed"
+        return {
+            "status": st,
+            "checked_at": time.time(),
+            "missing_required": mr,
+            "missing_optional": mo,
+            "produced": [],
+        }
+
+    root = os.path.realpath(artifacts_root)
+    missing_required: list[ExpectedArtifact] = []
+    missing_optional: list[ExpectedArtifact] = []
+    produced: list[ProducedArtifact] = []
+
+    for entry in expected:
+        full = _safe_join(root, entry["path"])
+        present = os.path.isfile(full) and os.path.getsize(full) > 0
+        if present:
+            produced.append(
+                {
+                    "id": entry["id"],
+                    "path": entry["path"],
+                    "size": os.path.getsize(full),
+                    "present": True,
+                }
+            )
+        elif entry.get("required", True):
+            missing_required.append(entry)
+        else:
+            missing_optional.append(entry)
+
+    if missing_required:
+        status: Literal["failed", "warning", "passed"] = "failed"
+    elif missing_optional:
+        status = "warning"
+    else:
+        status = "passed"
+    return {
+        "status": status,
+        "checked_at": time.time(),
+        "missing_required": missing_required,
+        "missing_optional": missing_optional,
+        "produced": produced,
+    }
+
+
+def missing_artifact_summary(missing: list[dict[str, Any]]) -> str:
+    if len(missing) == 1:
+        entry = missing[0]
+        return f"Missing required artifact: {entry.get('id')} ({entry.get('path')})."
+    return f"Missing {len(missing)} required artifacts."
+
+
+def missing_artifact_evidence(missing: list[dict[str, Any]]) -> list[dict[str, str]]:
+    return [
+        {
+            "kind": "expected_artifact",
+            "id": str(entry.get("id", "")),
+            "label": str(entry.get("path", "")),
+        }
+        for entry in missing
+    ]

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -14,6 +14,15 @@ import aiosqlite
 
 from lionagi.cli._runs import LIONAGI_HOME
 from lionagi.state.reasons import (
+    PlayReasons as _PlayReasons,
+)
+from lionagi.state.reasons import (
+    RunReasons as _RunReasons,
+)
+from lionagi.state.reasons import (
+    ShowReasons as _ShowReasons,
+)
+from lionagi.state.reasons import (
     entity_table as _reason_entity_table,
 )
 from lionagi.state.reasons import (
@@ -22,6 +31,60 @@ from lionagi.state.reasons import (
 from lionagi.state.reasons import (
     validate_reason_code as _validate_reason_code,
 )
+
+# Per-entity default-reason maps used by the Phase 2 deprecation shim
+# in update_invocation / update_show / update_play / update_schedule_run.
+# Picking a wrong-domain code (e.g. ``run.completed.ok`` for a successful
+# show) pollutes the reason-grouping primitive ADR-0028 introduces for
+# Phase 3/4 + ADR-0030. The resolver is conservative — it returns None
+# for (entity, status) pairs without a canonical default, forcing the
+# caller to surface a clear error instead of synthesizing nonsense.
+_RUN_DEFAULTS: dict[str, str] = {
+    "completed": _RunReasons.COMPLETED_OK,
+    "failed": _RunReasons.FAILED_EXCEPTION,
+    "timed_out": _RunReasons.TIMED_OUT_DEADLINE,
+    "aborted": _RunReasons.ABORTED_USER,
+    "cancelled": _RunReasons.CANCELLED_SYSTEM,
+}
+
+_SHOW_DEFAULTS: dict[str, str] = {
+    "completed": _ShowReasons.COMPLETED_FINAL_GATE,
+    "aborted": _ShowReasons.ABORTED_OPERATOR,
+}
+
+_PLAY_DEFAULTS: dict[str, str] = {
+    "merged": _PlayReasons.MERGED_OK,
+    "escalated": _PlayReasons.ESCALATED_GATE_TWICE,
+    "gate_failed": _PlayReasons.GATE_FAILED_VERDICT,
+}
+
+
+def _default_reason_code_for_entity_status(entity_type: str, status: str) -> str | None:
+    """Map (entity_type, status) → canonical reason_code, or None.
+
+    Returns None for ambiguous (entity, status) pairs — sessions/
+    invocations/schedule_runs share the run.* codes (they're process
+    runs); shows + plays have entity-specific codes for the subset
+    of statuses with canonical defaults. Statuses outside the per-
+    entity map return None and the deprecation shim raises so
+    callers supply reason_code explicitly.
+    """
+    if entity_type in ("session", "invocation", "schedule_run"):
+        return _RUN_DEFAULTS.get(status)
+    if entity_type == "show":
+        return _SHOW_DEFAULTS.get(status)
+    if entity_type == "play":
+        return _PLAY_DEFAULTS.get(status)
+    return None
+
+
+def _default_reason_code_for_status(status: str) -> str:
+    """Legacy run-only resolver. Kept for one release to avoid
+    breaking external callers that imported the private name.
+    New code MUST use :func:`_default_reason_code_for_entity_status`.
+    """
+    return _RUN_DEFAULTS.get(status, _RunReasons.FAILED_EXCEPTION)
+
 
 _SCHEMA_PATH = Path(__file__).parent / "schema.sql"
 DEFAULT_DB_PATH = LIONAGI_HOME / "state.db"
@@ -359,6 +422,9 @@ class StateDB:
             ("status_reason_code", "TEXT"),
             ("status_reason_summary", "TEXT"),
             ("status_evidence_refs", "JSON"),
+            # ADR-0029: resolved artifact contract and teardown result.
+            ("artifact_contract_json", "JSON"),
+            ("artifact_verification_json", "JSON"),
         ],
         "branches": [
             ("system_msg_id", "TEXT"),
@@ -515,7 +581,10 @@ class StateDB:
                   -- preserves these columns when migrating from ADR-0017.
                   status_reason_code     TEXT,
                   status_reason_summary  TEXT,
-                  status_evidence_refs   JSON
+                  status_evidence_refs   JSON,
+                  -- ADR-0029: artifact contract snapshot and verification.
+                  artifact_contract_json      JSON,
+                  artifact_verification_json  JSON
                 )
                 """
             )
@@ -702,12 +771,13 @@ class StateDB:
             """INSERT OR IGNORE INTO sessions (id, created_at, node_metadata, name, user,
                progression_id, first_msg_id, last_msg_id, updated_at,
                playbook_name, agent_name, invocation_kind, show_topic,
-               show_play_name, artifacts_path, source_kind,
+               show_play_name, artifacts_path, artifact_contract_json,
+               artifact_verification_json, source_kind,
                status, started_at, ended_at, last_message_at, invocation_id,
                model, provider, effort, agent_hash,
                project, project_source)
                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                       ?, ?, ?, ?, ?, ?)""",
+                       ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 session["id"],
                 session.get("created_at", now),
@@ -726,6 +796,8 @@ class StateDB:
                 session.get("show_topic"),
                 session.get("show_play_name"),
                 session.get("artifacts_path"),
+                _to_json_column(session.get("artifact_contract_json")),
+                _to_json_column(session.get("artifact_verification_json")),
                 session.get("source_kind", "live"),
                 session.get("status"),
                 session.get("started_at"),
@@ -816,6 +888,17 @@ class StateDB:
         await self.db.execute(
             f"UPDATE sessions SET {sets} WHERE id = ?",  # noqa: S608
             vals,
+        )
+        await self.db.commit()
+
+    async def update_artifact_verification(
+        self,
+        session_id: str,
+        verification: dict[str, Any] | None,
+    ) -> None:
+        await self.db.execute(
+            "UPDATE sessions SET artifact_verification_json = ?, updated_at = ? WHERE id = ?",
+            (_to_json_column(verification), time.time(), session_id),
         )
         await self.db.commit()
 
@@ -1260,18 +1343,69 @@ class StateDB:
         )
         await self.db.commit()
 
-    async def update_schedule_run(self, run_id: str, **fields: Any) -> None:
+    async def update_schedule_run(
+        self,
+        run_id: str,
+        *,
+        reason_code: str | None = None,
+        reason_summary: str = "",
+        evidence_refs: list[dict[str, Any]] | None = None,
+        reason_source: str = "executor",
+        reason_actor: str | None = None,
+        **fields: Any,
+    ) -> None:
+        """Update schedule_run fields; route status through update_status().
+
+        ADR-0028 Phase 2: status writes go through update_status() so
+        reason columns + status_transitions are atomic. See
+        update_invocation() for the pattern.
+        """
         allowed = {"status", "exit_code", "ended_at", "error_detail", "invocation_id"}
         bad = set(fields) - allowed
         if bad:
             raise ValueError(f"Invalid schedule_run field(s): {bad}")
-        sets = ", ".join(f"{k} = ?" for k in fields)
-        vals = list(fields.values()) + [run_id]
-        await self.db.execute(
-            f"UPDATE schedule_runs SET {sets} WHERE id = ?",  # noqa: S608
-            vals,
-        )
-        await self.db.commit()
+
+        status_value = fields.pop("status", None)
+        if status_value is not None:
+            if reason_code is None:
+                from warnings import warn
+
+                resolved = _default_reason_code_for_entity_status("schedule_run", status_value)
+                if resolved is None:
+                    raise ValueError(
+                        f"update_schedule_run() called with status={status_value!r} but "
+                        f"no canonical default reason_code exists for "
+                        f"(schedule_run, {status_value!r}). Pass reason_code "
+                        f"explicitly from lionagi/state/reasons.py."
+                    )
+                reason_code = resolved
+                warn(
+                    f"update_schedule_run({run_id!r}, status={status_value!r}) "
+                    "called without reason_code; defaulting to "
+                    f"{reason_code!r}. Pass reason_code explicitly "
+                    "(ADR-0028 Phase 2 deprecation).",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+            await self.update_status(
+                "schedule_run",
+                run_id,
+                new_status=status_value,
+                reason_code=reason_code,
+                reason_summary=reason_summary,
+                evidence_refs=evidence_refs,
+                source=reason_source,
+                actor=reason_actor,
+            )
+
+        if fields:
+            sets = ", ".join(f"{k} = ?" for k in fields)
+            vals = list(fields.values()) + [run_id]
+            await self.db.execute(
+                f"UPDATE schedule_runs SET {sets} WHERE id = ?",  # noqa: S608
+                vals,
+            )
+            await self.db.commit()
 
     async def list_schedule_runs(
         self,
@@ -1344,7 +1478,35 @@ class StateDB:
         )
         await self.db.commit()
 
-    async def update_invocation(self, invocation_id: str, **fields: Any) -> None:
+    async def update_invocation(
+        self,
+        invocation_id: str,
+        *,
+        reason_code: str | None = None,
+        reason_summary: str = "",
+        evidence_refs: list[dict[str, Any]] | None = None,
+        reason_source: str = "executor",
+        reason_actor: str | None = None,
+        **fields: Any,
+    ) -> None:
+        """Update invocation fields; route status changes through update_status().
+
+        ADR-0028 Phase 2: when ``status`` is among the updated fields, the
+        transition goes through :meth:`update_status` so the denormalized
+        reason columns and ``status_transitions`` history row are written
+        atomically.
+
+        Pass ``reason_code`` (required when status is in fields) plus
+        optional ``reason_summary`` / ``evidence_refs`` / ``reason_source``
+        / ``reason_actor`` to control the transition record. The
+        non-status fields are written by the legacy UPDATE path below
+        (separate transaction).
+
+        Backwards compatibility: callers that pass ``status`` without a
+        ``reason_code`` get a deprecation warning + a default code
+        derived from the status (matching the executor's resolution
+        logic for sessions). Remove the fallback in a future release.
+        """
         _validate_columns(fields, _INVOCATION_COLUMNS)
         if "status" in fields:
             _validate_enum(
@@ -1356,13 +1518,50 @@ class StateDB:
             )
         if "node_metadata" in fields:
             fields["node_metadata"] = _to_json_column(fields["node_metadata"])
-        fields["updated_at"] = time.time()
-        sets = ", ".join(f"{k} = ?" for k in fields)
-        vals = list(fields.values()) + [invocation_id]
-        # columns validated above; SQL is identifier-only interpolation.
-        update_sql = f"UPDATE invocations SET {sets} WHERE id = ?"  # noqa: S608
-        await self.db.execute(update_sql, vals)
-        await self.db.commit()
+
+        status_value = fields.pop("status", None)
+        if status_value is not None:
+            if reason_code is None:
+                from warnings import warn
+
+                resolved = _default_reason_code_for_entity_status("invocation", status_value)
+                if resolved is None:
+                    raise ValueError(
+                        f"update_invocation() called with status={status_value!r} but "
+                        f"no canonical default reason_code exists for "
+                        f"(invocation, {status_value!r}). Pass reason_code "
+                        f"explicitly from lionagi/state/reasons.py."
+                    )
+                reason_code = resolved
+                warn(
+                    f"update_invocation({invocation_id!r}, status={status_value!r}) "
+                    "called without reason_code; defaulting to "
+                    f"{reason_code!r}. Pass reason_code explicitly "
+                    "(ADR-0028 Phase 2 deprecation).",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+            await self.update_status(
+                "invocation",
+                invocation_id,
+                new_status=status_value,
+                reason_code=reason_code,
+                reason_summary=reason_summary,
+                evidence_refs=evidence_refs,
+                source=reason_source,
+                actor=reason_actor,
+            )
+
+        # Remaining (non-status) fields go through the legacy update path
+        # in a separate write — update_status() already touched updated_at.
+        if fields:
+            fields["updated_at"] = time.time()
+            sets = ", ".join(f"{k} = ?" for k in fields)
+            vals = list(fields.values()) + [invocation_id]
+            # columns validated above; SQL is identifier-only interpolation.
+            update_sql = f"UPDATE invocations SET {sets} WHERE id = ?"  # noqa: S608
+            await self.db.execute(update_sql, vals)
+            await self.db.commit()
 
     async def get_invocation(self, invocation_id: str) -> dict[str, Any] | None:
         cur = await self.db.execute("SELECT * FROM invocations WHERE id = ?", (invocation_id,))
@@ -1768,7 +1967,23 @@ class StateDB:
         rows = await cur.fetchall()
         return [self._row_to_dict(r) for r in rows]
 
-    async def update_show(self, show_id: str, **fields: Any) -> None:
+    async def update_show(
+        self,
+        show_id: str,
+        *,
+        reason_code: str | None = None,
+        reason_summary: str = "",
+        evidence_refs: list[dict[str, Any]] | None = None,
+        reason_source: str = "executor",
+        reason_actor: str | None = None,
+        **fields: Any,
+    ) -> None:
+        """Update show fields; route status changes through update_status().
+
+        ADR-0028 Phase 2: status writes go through StateDB.update_status()
+        so reason columns and status_transitions are written atomically.
+        Backwards-compatible deprecation shim mirrors update_invocation().
+        """
         _validate_columns(fields, _SHOW_COLUMNS)
         if "status" in fields:
             _validate_enum(
@@ -1778,15 +1993,50 @@ class StateDB:
                 adr="ADR-0011",
                 nullable=False,
             )
-        fields["updated_at"] = time.time()
-        sets = ", ".join(f"{k} = ?" for k in fields)
-        vals = list(fields.values()) + [show_id]
-        # noqa: S608 — column names allowlisted via _validate_columns
-        await self.db.execute(
-            f"UPDATE shows SET {sets} WHERE id = ?",  # noqa: S608
-            vals,
-        )
-        await self.db.commit()
+
+        status_value = fields.pop("status", None)
+        if status_value is not None:
+            if reason_code is None:
+                from warnings import warn
+
+                resolved = _default_reason_code_for_entity_status("show", status_value)
+                if resolved is None:
+                    raise ValueError(
+                        f"update_show() called with status={status_value!r} but "
+                        f"no canonical default reason_code exists for "
+                        f"(show, {status_value!r}). Pass reason_code "
+                        f"explicitly from lionagi/state/reasons.py."
+                    )
+                reason_code = resolved
+                warn(
+                    f"update_show({show_id!r}, status={status_value!r}) "
+                    "called without reason_code; defaulting to "
+                    f"{reason_code!r}. Pass reason_code explicitly "
+                    "(ADR-0028 Phase 2 deprecation).",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+            await self.update_status(
+                "show",
+                show_id,
+                new_status=status_value,
+                reason_code=reason_code,
+                reason_summary=reason_summary,
+                evidence_refs=evidence_refs,
+                source=reason_source,
+                actor=reason_actor,
+            )
+
+        if fields:
+            fields["updated_at"] = time.time()
+            sets = ", ".join(f"{k} = ?" for k in fields)
+            vals = list(fields.values()) + [show_id]
+            # noqa: S608 — column names allowlisted via _validate_columns
+            await self.db.execute(
+                f"UPDATE shows SET {sets} WHERE id = ?",  # noqa: S608
+                vals,
+            )
+            await self.db.commit()
 
     # ── Plays ─────────────────────────────────────────────────────────
 
@@ -1844,7 +2094,22 @@ class StateDB:
         rows = await cur.fetchall()
         return [self._row_to_dict(r) for r in rows]
 
-    async def update_play(self, play_id: str, **fields: Any) -> None:
+    async def update_play(
+        self,
+        play_id: str,
+        *,
+        reason_code: str | None = None,
+        reason_summary: str = "",
+        evidence_refs: list[dict[str, Any]] | None = None,
+        reason_source: str = "executor",
+        reason_actor: str | None = None,
+        **fields: Any,
+    ) -> None:
+        """Update play fields; route status changes through update_status().
+
+        ADR-0028 Phase 2: see update_invocation() / update_show() for
+        the same routing pattern.
+        """
         _validate_columns(fields, _PLAY_COLUMNS)
         if "status" in fields:
             _validate_enum(
@@ -1854,15 +2119,50 @@ class StateDB:
                 adr="ADR-0011",
                 nullable=False,
             )
-        fields["updated_at"] = time.time()
-        sets = ", ".join(f"{k} = ?" for k in fields)
-        vals = list(fields.values()) + [play_id]
-        # noqa: S608 — column names allowlisted via _validate_columns
-        await self.db.execute(
-            f"UPDATE plays SET {sets} WHERE id = ?",  # noqa: S608
-            vals,
-        )
-        await self.db.commit()
+
+        status_value = fields.pop("status", None)
+        if status_value is not None:
+            if reason_code is None:
+                from warnings import warn
+
+                resolved = _default_reason_code_for_entity_status("play", status_value)
+                if resolved is None:
+                    raise ValueError(
+                        f"update_play() called with status={status_value!r} but "
+                        f"no canonical default reason_code exists for "
+                        f"(play, {status_value!r}). Pass reason_code "
+                        f"explicitly from lionagi/state/reasons.py."
+                    )
+                reason_code = resolved
+                warn(
+                    f"update_play({play_id!r}, status={status_value!r}) "
+                    "called without reason_code; defaulting to "
+                    f"{reason_code!r}. Pass reason_code explicitly "
+                    "(ADR-0028 Phase 2 deprecation).",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+            await self.update_status(
+                "play",
+                play_id,
+                new_status=status_value,
+                reason_code=reason_code,
+                reason_summary=reason_summary,
+                evidence_refs=evidence_refs,
+                source=reason_source,
+                actor=reason_actor,
+            )
+
+        if fields:
+            fields["updated_at"] = time.time()
+            sets = ", ".join(f"{k} = ?" for k in fields)
+            vals = list(fields.values()) + [play_id]
+            # noqa: S608 — column names allowlisted via _validate_columns
+            await self.db.execute(
+                f"UPDATE plays SET {sets} WHERE id = ?",  # noqa: S608
+                vals,
+            )
+            await self.db.commit()
 
     # ── Definitions ───────────────────────────────────────────────────
 
@@ -1972,6 +2272,8 @@ class StateDB:
             "action_extra_args",
             "trigger_context",
             "action_args",
+            "artifact_contract_json",
+            "artifact_verification_json",
         ):
             if key in d and isinstance(d[key], str):
                 try:

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -159,7 +159,12 @@ CREATE TABLE IF NOT EXISTS sessions (
   -- never drift.
   status_reason_code     TEXT,
   status_reason_summary  TEXT,
-  status_evidence_refs   JSON
+  status_evidence_refs   JSON,
+  -- ── Artifact contract (ADR-0029) ──────────────────────────────────────
+  -- Resolved contract snapshot written at session creation and verifier
+  -- result written at teardown. NULL contract means verification skipped.
+  artifact_contract_json      JSON,
+  artifact_verification_json  JSON
 );
 
 CREATE INDEX IF NOT EXISTS idx_sessions_updated

--- a/tests/agent/test_profile_artifacts.py
+++ b/tests/agent/test_profile_artifacts.py
@@ -1,0 +1,76 @@
+"""Tests for ADR-0029 artifact_defaults in AgentProfile frontmatter."""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.cli._agents import _parse_profile
+
+
+class TestProfileArtifactDefaults:
+    def test_no_artifact_defaults_is_none(self):
+        text = "---\nmodel: codex/gpt-4o\n---\nSystem prompt."
+        profile = _parse_profile("agent", text)
+        assert profile.artifact_defaults is None
+
+    def test_artifact_defaults_nested_dict(self):
+        text = (
+            "---\n"
+            "artifact_defaults:\n"
+            "  expected:\n"
+            "    - id: report\n"
+            "      path: report.md\n"
+            "      required: true\n"
+            "---\n"
+            "System prompt."
+        )
+        profile = _parse_profile("agent", text)
+        assert profile.artifact_defaults is not None
+        expected = profile.artifact_defaults["expected"]
+        assert isinstance(expected, list)
+        assert len(expected) == 1
+        assert expected[0]["id"] == "report"
+        assert expected[0]["path"] == "report.md"
+        assert expected[0]["required"] is True
+
+    def test_artifact_defaults_multiple_entries(self):
+        text = (
+            "---\n"
+            "artifact_defaults:\n"
+            "  expected:\n"
+            "    - id: brief\n"
+            "      path: brief.md\n"
+            "    - id: log\n"
+            "      path: log.txt\n"
+            "      required: false\n"
+            "---\n"
+        )
+        profile = _parse_profile("agent", text)
+        assert profile.artifact_defaults is not None
+        assert len(profile.artifact_defaults["expected"]) == 2
+
+    def test_scalar_booleans_still_parse(self):
+        text = "---\nyolo: true\nfast_mode: false\nlion_system: true\n---\n"
+        profile = _parse_profile("agent", text)
+        assert profile.yolo is True
+        assert profile.fast_mode is False
+        assert profile.lion_system is True
+
+    def test_artifact_defaults_not_in_extra(self):
+        text = (
+            "---\n"
+            "artifact_defaults:\n"
+            "  expected:\n"
+            "    - id: x\n"
+            "      path: x.md\n"
+            "custom_key: custom_val\n"
+            "---\n"
+        )
+        profile = _parse_profile("agent", text)
+        assert "artifact_defaults" not in profile.extra
+        assert "custom_key" in profile.extra
+
+    def test_no_frontmatter_gives_no_artifact_defaults(self):
+        text = "Just a plain system prompt without frontmatter."
+        profile = _parse_profile("agent", text)
+        assert profile.artifact_defaults is None

--- a/tests/apps_studio_server/test_admin.py
+++ b/tests/apps_studio_server/test_admin.py
@@ -1,4 +1,5 @@
 """Tests for #1014 admin doctor and prune endpoints."""
+
 from __future__ import annotations
 
 import asyncio
@@ -22,17 +23,21 @@ def _run(coro):
         loop.close()
 
 
-async def _seed_running_session(db_path: Path, session_id: str, artifacts_path: str | None = None) -> None:
+async def _seed_running_session(
+    db_path: Path, session_id: str, artifacts_path: str | None = None
+) -> None:
     async with StateDB(db_path) as db:
         pid = str(uuid.uuid4())
         await db.create_progression(pid)
-        await db.create_session({
-            "id": session_id,
-            "progression_id": pid,
-            "name": "test-session",
-            "status": "running",
-            "started_at": time.time(),
-        })
+        await db.create_session(
+            {
+                "id": session_id,
+                "progression_id": pid,
+                "name": "test-session",
+                "status": "running",
+                "started_at": time.time(),
+            }
+        )
         if artifacts_path is not None:
             await db.db.execute(
                 "UPDATE sessions SET artifacts_path = ? WHERE id = ?",
@@ -53,6 +58,7 @@ def _make_client(tmp_path, monkeypatch, db_path: Path) -> TestClient:
     monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
 
     from apps.studio.server.app import app
+
     return TestClient(app)
 
 
@@ -212,6 +218,7 @@ def test_admin_transition_skips_non_running(tmp_path, monkeypatch):
 
 
 def test_admin_transition_requires_reason(tmp_path, monkeypatch):
+    """Omitting both reason_code and reason returns 400 (not 422)."""
     db_path = tmp_path / "state.db"
     client = _make_client(tmp_path, monkeypatch, db_path)
     r = client.post(
@@ -219,10 +226,9 @@ def test_admin_transition_requires_reason(tmp_path, monkeypatch):
         json={
             "session_ids": ["x"],
             "target_status": "failed",
-            "reason": "",
         },
     )
-    assert r.status_code == 422
+    assert r.status_code == 400
 
 
 def test_admin_transition_rejects_healthy_session(tmp_path, monkeypatch):
@@ -312,3 +318,224 @@ def test_admin_transition_guard_re_evaluates_health_per_call(tmp_path, monkeypat
     body = r2.json()
     assert body["transitioned"] == [sid]
     assert body["skipped"] == []
+
+
+# ─── ADR-0028: reason_code in TransitionBody ────────────────────────────────
+
+
+def test_admin_transition_with_reason_code_succeeds(tmp_path, monkeypatch):
+    """New-style clients can pass reason_code; classifier-HEALTHY path
+    preserves the operator's code.
+
+    Pin the classifier deterministically — without this, the seeded
+    session looks orphaned (no live process, no artifacts) and the
+    real test target (operator-code preservation) is masked. The
+    classifier-override paths get their own tests below.
+    """
+    db_path = tmp_path / "state.db"
+    sid = str(uuid.uuid4())
+    _run(_seed_running_session(db_path, sid))
+    # Pin classifier: no phantom cause, IDLE health → operator's code wins.
+    import apps.studio.server.services.admin as admin_svc
+    import lionagi.state.health as health_mod
+    from lionagi.state.health import SessionHealth
+
+    monkeypatch.setattr(admin_svc, "_classify_phantom", lambda *a, **kw: None)
+    # Patch the source module — admin.transition_sessions() lazy-imports
+    # classify_session_health, so patching admin_svc directly does not work.
+    monkeypatch.setattr(health_mod, "classify_session_health", lambda *a, **kw: SessionHealth.IDLE)
+    client = _make_client(tmp_path, monkeypatch, db_path)
+
+    r = client.post(
+        "/api/admin/transition",
+        json={
+            "session_ids": [sid],
+            "target_status": "failed",
+            "reason_code": "run.failed.exception",
+            "reason_summary": "Operator forced failure after alert.",
+        },
+    )
+    # IDLE is one of the "healthy enough to refuse" classifications —
+    # admin transition is refused on IDLE/HEALTHY per ADR-0024 §C.
+    # Pin to STALE instead so we get a real classifier-override case.
+    monkeypatch.setattr(health_mod, "classify_session_health", lambda *a, **kw: SessionHealth.STALE)
+    # Re-issue against the same (running) session — the previous call
+    # was rejected with 4xx because health was IDLE.
+    if r.status_code != 200:
+        # Re-seed if the prior call somehow transitioned.
+        async def _ensure_running():
+            async with StateDB(db_path) as db:
+                row = await db.get_session(sid)
+                if row and row["status"] != "running":
+                    await db.db.execute("UPDATE sessions SET status='running' WHERE id=?", (sid,))
+                    await db.db.commit()
+
+        _run(_ensure_running())
+        r = client.post(
+            "/api/admin/transition",
+            json={
+                "session_ids": [sid],
+                "target_status": "failed",
+                "reason_code": "run.failed.exception",
+                "reason_summary": "Operator forced failure after alert.",
+            },
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["transitioned"] == [sid]
+    assert body["skipped"] == []
+
+    # STALE without phantom_reason → classifier writes HEALTH_STALE_NO_HEARTBEAT.
+    async def _check():
+        async with StateDB(db_path) as db:
+            row = await db.get_session(sid)
+            assert row["status"] == "failed"
+            assert row["status_reason_code"] == "session.stale.no_heartbeat"
+            assert row["status_reason_summary"] == "Operator forced failure after alert."
+            cur = await db.db.execute(
+                "SELECT reason_code, previous_status, status, evidence_refs "
+                "FROM status_transitions WHERE entity_id = ?",
+                (sid,),
+            )
+            rows = await cur.fetchall()
+            assert len(rows) == 1
+            assert rows[0]["reason_code"] == "session.stale.no_heartbeat"
+            assert rows[0]["previous_status"] == "running"
+            assert rows[0]["status"] == "failed"
+            # Evidence ref must include the classifier source.
+            import json as _json
+
+            refs = _json.loads(rows[0]["evidence_refs"] or "[]")
+            assert any(r.get("kind") == "session_health" for r in refs)
+
+    _run(_check())
+
+
+@pytest.mark.parametrize(
+    "phantom_reason, expected_code, expected_evidence_kind",
+    [
+        ("process_dead", "session.phantom.process_dead", "phantom_classification"),
+        (
+            "missing_artifacts",
+            "session.phantom.missing_artifacts",
+            "phantom_classification",
+        ),
+        ("stale_lock", "session.zombie.stale_locks", "phantom_classification"),
+    ],
+)
+def test_admin_transition_phantom_classifier_override(
+    tmp_path, monkeypatch, phantom_reason, expected_code, expected_evidence_kind
+):
+    """Each PhantomReason value maps to its specific reason code, and the
+    classifier override wins over the operator's chosen code.
+
+    Pin the classifier so the assertion is deterministic — without
+    monkeypatching the test would race against the actual fs/ps state
+    of the seeded session.
+    """
+    db_path = tmp_path / "state.db"
+    sid = str(uuid.uuid4())
+    _run(_seed_running_session(db_path, sid))
+    import apps.studio.server.services.admin as admin_svc
+    import lionagi.state.health as health_mod
+    from lionagi.state.health import SessionHealth
+
+    monkeypatch.setattr(admin_svc, "_classify_phantom", lambda *a, **kw: phantom_reason)
+    # Force a non-HEALTHY/IDLE so the admin transition gate passes.
+    monkeypatch.setattr(health_mod, "classify_session_health", lambda *a, **kw: SessionHealth.STALE)
+    client = _make_client(tmp_path, monkeypatch, db_path)
+
+    # Operator passes a generic code; classifier should override.
+    r = client.post(
+        "/api/admin/transition",
+        json={
+            "session_ids": [sid],
+            "target_status": "failed",
+            "reason_code": "run.failed.exception",
+            "reason_summary": "operator picked something generic",
+        },
+    )
+    assert r.status_code == 200, r.text
+
+    async def _check():
+        async with StateDB(db_path) as db:
+            row = await db.get_session(sid)
+            assert row["status_reason_code"] == expected_code, (
+                f"classifier override didn't win: got {row['status_reason_code']!r}, "
+                f"expected {expected_code!r}"
+            )
+            import json as _json
+
+            cur = await db.db.execute(
+                "SELECT evidence_refs FROM status_transitions WHERE entity_id = ?",
+                (sid,),
+            )
+            row_t = await cur.fetchone()
+            refs = _json.loads(row_t["evidence_refs"] or "[]")
+            assert any(r.get("kind") == expected_evidence_kind for r in refs), (
+                f"evidence missing {expected_evidence_kind} kind: {refs}"
+            )
+
+    _run(_check())
+
+
+def test_admin_transition_invalid_reason_code_returns_400(tmp_path, monkeypatch):
+    """An unrecognised reason_code returns HTTP 400 before touching the DB."""
+    db_path = tmp_path / "state.db"
+    client = _make_client(tmp_path, monkeypatch, db_path)
+
+    r = client.post(
+        "/api/admin/transition",
+        json={
+            "session_ids": ["any"],
+            "target_status": "failed",
+            "reason_code": "not.a.real.code",
+        },
+    )
+    assert r.status_code == 400
+    assert "reason_code" in r.json()["detail"].lower() or "invalid" in r.json()["detail"].lower()
+
+
+def test_admin_transition_legacy_reason_backwards_compat(tmp_path, monkeypatch):
+    """Old clients that send only 'reason' (no reason_code) still succeed.
+
+    The router synthesises a reason_code from target_status and uses the
+    free-text 'reason' as reason_summary; classifier override applies as
+    usual (here pinned to STALE for determinism).
+    """
+    db_path = tmp_path / "state.db"
+    sid = str(uuid.uuid4())
+    _run(_seed_running_session(db_path, sid))
+    import apps.studio.server.services.admin as admin_svc
+    import lionagi.state.health as health_mod
+    from lionagi.state.health import SessionHealth
+
+    monkeypatch.setattr(admin_svc, "_classify_phantom", lambda *a, **kw: None)
+    monkeypatch.setattr(health_mod, "classify_session_health", lambda *a, **kw: SessionHealth.STALE)
+    client = _make_client(tmp_path, monkeypatch, db_path)
+
+    r = client.post(
+        "/api/admin/transition",
+        json={
+            "session_ids": [sid],
+            "target_status": "aborted",
+            "reason": "Legacy client cleanup",
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["transitioned"] == [sid]
+
+    # Verify the legacy compat path: 'reason' (no reason_code) maps via
+    # _LEGACY_ADMIN_REASON_CODES['aborted'] → run.aborted.user, and the
+    # free-text 'reason' becomes reason_summary. The classifier is
+    # pinned to STALE here so we get the override on top.
+    async def _check():
+        async with StateDB(db_path) as db:
+            row = await db.get_session(sid)
+            assert row["status"] == "aborted"
+            # STALE → session.stale.no_heartbeat (classifier override).
+            assert row["status_reason_code"] == "session.stale.no_heartbeat"
+            assert row["status_reason_summary"] == "Legacy client cleanup"
+
+    _run(_check())

--- a/tests/apps_studio_server/test_admin_transition.py
+++ b/tests/apps_studio_server/test_admin_transition.py
@@ -136,7 +136,8 @@ def test_transition_refused_when_heartbeat_changes_health(tmp_path, monkeypatch)
         adm.transition_sessions(
             session_ids=[sid],
             target_status="failed",
-            reason="test atomicity guard",
+            reason_code="run.failed.exception",
+            reason_summary="test atomicity guard",
             actor="test",
         )
     )

--- a/tests/cli/orchestrate/test_flow_spec_file.py
+++ b/tests/cli/orchestrate/test_flow_spec_file.py
@@ -120,16 +120,14 @@ class TestLoadFlowSpec:
         result = _load_flow_spec(str(p))
         assert result == spec
 
-    def test_lone_positional_overrides_prompt_when_spec_supplies_model(
-        self, tmp_path, capsys
-    ):
+    def test_lone_positional_overrides_prompt_when_spec_supplies_model(self, tmp_path, capsys):
         p = tmp_path / "spec.yaml"
         p.write_text(yaml.dump({"model": "claude-code/opus-4-7"}))
         args = _parse_flow_args(["-f", str(p), "Write the thing"])
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="flow output"),
+            AsyncMock(return_value=("flow output", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 
@@ -153,7 +151,7 @@ class TestLoadFlowSpec:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="ok"),
+            AsyncMock(return_value=("ok", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 
@@ -176,7 +174,7 @@ class TestLoadFlowSpec:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="ok"),
+            AsyncMock(return_value=("ok", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 
@@ -346,13 +344,11 @@ class TestPlaybookEndToEnd:
             )
         )
         monkeypatch.setenv("HOME", str(tmp_path))
-        args = _parse_flow_args(
-            ["-p", "audit", "--tabs", "7", "--poll", "audit the auth service"]
-        )
+        args = _parse_flow_args(["-p", "audit", "--tabs", "7", "--poll", "audit the auth service"])
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="done"),
+            AsyncMock(return_value=("done", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 
@@ -377,7 +373,7 @@ class TestPlaybookEndToEnd:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="done"),
+            AsyncMock(return_value=("done", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 
@@ -401,7 +397,7 @@ class TestPlaybookEndToEnd:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="done"),
+            AsyncMock(return_value=("done", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 
@@ -440,7 +436,7 @@ class TestPlaybookEndToEnd:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="done"),
+            AsyncMock(return_value=("done", "completed")),
         ) as run_flow:
             code = cli_main(["play", "hello", "--tabs", "9", "do a thing"])
 
@@ -470,9 +466,7 @@ class TestPlaybookEndToEnd:
         assert code == 1
         assert "Usage" in capsys.readouterr().out
 
-    def test_playbook_arg_collision_does_not_leak_into_template(
-        self, monkeypatch, tmp_path
-    ):
+    def test_playbook_arg_collision_does_not_leak_into_template(self, monkeypatch, tmp_path):
         """A playbook arg that collides with a built-in flag must NOT have
         its value read from the base argparse default during interpolation.
         The filtered schema (from parser injection) is authoritative.
@@ -498,13 +492,11 @@ class TestPlaybookEndToEnd:
         monkeypatch.setenv("HOME", str(tmp_path))
         # User passes --save /some/dir (built-in), NOT the playbook arg.
         save_dir = tmp_path / "artifacts"
-        args = _parse_flow_args(
-            ["-p", "collider", "--save", str(save_dir), "do the thing"]
-        )
+        args = _parse_flow_args(["-p", "collider", "--save", str(save_dir), "do the thing"])
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="ok"),
+            AsyncMock(return_value=("ok", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 
@@ -516,8 +508,7 @@ class TestPlaybookEndToEnd:
         # default if run_orchestrate falls through. Assert the built-in
         # --save value did NOT leak into the template.
         assert str(save_dir) not in prompt, (
-            "Built-in --save value leaked into template via "
-            "collision-shadowed playbook arg"
+            "Built-in --save value leaked into template via collision-shadowed playbook arg"
         )
 
     def test_max_ops_flag_passes_through(self, monkeypatch, tmp_path):
@@ -526,7 +517,7 @@ class TestPlaybookEndToEnd:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="ok"),
+            AsyncMock(return_value=("ok", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 
@@ -540,7 +531,7 @@ class TestPlaybookEndToEnd:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="ok"),
+            AsyncMock(return_value=("ok", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 
@@ -564,16 +555,14 @@ class TestPlaybookEndToEnd:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="ok"),
+            AsyncMock(return_value=("ok", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 
         assert code == 0
         assert run_flow.call_args.kwargs["max_ops"] == 8
 
-    def test_playbook_max_agents_deprecated_spec_still_works(
-        self, monkeypatch, tmp_path
-    ):
+    def test_playbook_max_agents_deprecated_spec_still_works(self, monkeypatch, tmp_path):
         """Playbooks with legacy `max_agents:` field must still cap ops."""
         playbooks_dir = tmp_path / ".lionagi" / "playbooks"
         playbooks_dir.mkdir(parents=True)
@@ -591,7 +580,7 @@ class TestPlaybookEndToEnd:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="ok"),
+            AsyncMock(return_value=("ok", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 
@@ -611,7 +600,7 @@ class TestPlaybookEndToEnd:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="ok"),
+            AsyncMock(return_value=("ok", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 
@@ -659,7 +648,7 @@ class TestPlaybookEndToEnd:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="ok"),
+            AsyncMock(return_value=("ok", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 
@@ -703,3 +692,67 @@ class TestPlaybookEndToEnd:
 
         code = run_orchestrate(args)
         assert code == 1
+
+
+# ── ADR-0029: artifacts: block pass-through ───────────────────────────────────
+
+
+class TestPlaybookArtifactsPassThrough:
+    def test_artifacts_block_passed_to_run_flow(self, monkeypatch, tmp_path):
+        """A playbook with artifacts: block passes playbook_artifacts to _run_flow."""
+        playbooks_dir = tmp_path / ".lionagi" / "playbooks"
+        playbooks_dir.mkdir(parents=True)
+        (playbooks_dir / "research.playbook.yaml").write_text(
+            yaml.dump(
+                {
+                    "model": "codex/gpt-4o",
+                    "prompt": "Research the topic.",
+                    "artifacts": {
+                        "expected": [
+                            {"id": "report", "path": "report.md"},
+                        ]
+                    },
+                }
+            )
+        )
+        monkeypatch.setenv("HOME", str(tmp_path))
+        args = _parse_flow_args(["-p", "research", "do it"])
+
+        with patch(
+            "lionagi.cli.orchestrate._run_flow",
+            AsyncMock(return_value=("done", "completed")),
+        ) as run_flow:
+            code = run_orchestrate(args)
+
+        assert code == 0
+        call_kwargs = run_flow.call_args.kwargs
+        pa = call_kwargs.get("playbook_artifacts")
+        assert pa is not None
+        assert isinstance(pa, dict)
+        assert pa["expected"][0]["id"] == "report"
+
+    def test_no_artifacts_block_passes_none(self, monkeypatch, tmp_path):
+        """A playbook without artifacts: passes None to _run_flow."""
+        playbooks_dir = tmp_path / ".lionagi" / "playbooks"
+        playbooks_dir.mkdir(parents=True)
+        (playbooks_dir / "basic.playbook.yaml").write_text(
+            yaml.dump(
+                {
+                    "model": "codex/gpt-4o",
+                    "prompt": "Do the task.",
+                }
+            )
+        )
+        monkeypatch.setenv("HOME", str(tmp_path))
+        args = _parse_flow_args(["-p", "basic", "do it"])
+
+        with patch(
+            "lionagi.cli.orchestrate._run_flow",
+            AsyncMock(return_value=("done", "completed")),
+        ) as run_flow:
+            code = run_orchestrate(args)
+
+        assert code == 0
+        call_kwargs = run_flow.call_args.kwargs
+        pa = call_kwargs.get("playbook_artifacts")
+        assert pa is None

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -162,9 +162,9 @@ async def test_start_create_session_failure_closes_db(
         if _aiosqlite_thread_count() <= before:
             break
         await asyncio.sleep(0.05)
-    assert (
-        _aiosqlite_thread_count() <= before
-    ), "DB was not closed on start failure — aiosqlite worker leaked"
+    assert _aiosqlite_thread_count() <= before, (
+        "DB was not closed on start failure — aiosqlite worker leaked"
+    )
 
 
 # ── _register_branch_hook: lazy branch row + multi-message paths ──────────────
@@ -204,9 +204,7 @@ async def test_register_branch_hook_creates_row_on_first_message(
 
     async with StateDB() as db:
         b_after = await db.get_branch(str(worker.id))
-        prog = await db.get_progression(
-            env._live_persist["branch_prog_ids"][str(worker.id)]
-        )
+        prog = await db.get_progression(env._live_persist["branch_prog_ids"][str(worker.id)])
         session_prog = await db.get_progression(env._live_persist["session_prog_id"])
     assert b_after is not None
     assert b_after["session_id"] == str(env.session.id)
@@ -260,9 +258,7 @@ async def test_register_branch_hook_ensure_branch_row_idempotent(
         )
         n_sys = (await cur.fetchone())["n"]
         # Branch progression has both user messages.
-        prog = await db.get_progression(
-            env._live_persist["branch_prog_ids"][str(worker.id)]
-        )
+        prog = await db.get_progression(env._live_persist["branch_prog_ids"][str(worker.id)])
 
     assert n_rows == 1
     assert n_sys == 1
@@ -310,12 +306,8 @@ async def test_multiple_branches_share_session_progression(
 
     async with StateDB() as db:
         session_prog = await db.get_progression(env._live_persist["session_prog_id"])
-        w1_prog = await db.get_progression(
-            env._live_persist["branch_prog_ids"][str(w1.id)]
-        )
-        w2_prog = await db.get_progression(
-            env._live_persist["branch_prog_ids"][str(w2.id)]
-        )
+        w1_prog = await db.get_progression(env._live_persist["branch_prog_ids"][str(w1.id)])
+        w2_prog = await db.get_progression(env._live_persist["branch_prog_ids"][str(w2.id)])
 
     assert set(session_prog) == {str(m1.id), str(m2.id)}
     assert w1_prog == [str(m1.id)]
@@ -528,9 +520,9 @@ async def test_start_stop_does_not_leak_aiosqlite_thread(temp_db_path: Path):
             if _aiosqlite_thread_count() <= baseline:
                 break
             await asyncio.sleep(0.05)
-        assert (
-            _aiosqlite_thread_count() <= baseline
-        ), "aiosqlite worker thread leaked across orchestration start/stop"
+        assert _aiosqlite_thread_count() <= baseline, (
+            "aiosqlite worker thread leaked across orchestration start/stop"
+        )
 
 
 # ── R5-A MED-1: lazy _ensure_branch_row retry after first-init failure ────────
@@ -569,10 +561,14 @@ async def test_ensure_branch_row_retries_after_transient_failure(
     monkeypatch.setattr(StateDB, "create_branch", flaky_create)
 
     m1 = MessageManager.create_instruction(
-        instruction="a", sender="u", recipient=str(worker.id),
+        instruction="a",
+        sender="u",
+        recipient=str(worker.id),
     )
     m2 = MessageManager.create_instruction(
-        instruction="b", sender="u", recipient=str(worker.id),
+        instruction="b",
+        sender="u",
+        recipient=str(worker.id),
     )
     # First fire: row creation fails; hook swallows the error.
     await hook(m1)
@@ -584,9 +580,7 @@ async def test_ensure_branch_row_retries_after_transient_failure(
     await hook(m2)
     async with StateDB() as db:
         b = await db.get_branch(str(worker.id))
-        prog = await db.get_progression(
-            env._live_persist["branch_prog_ids"][str(worker.id)]
-        )
+        prog = await db.get_progression(env._live_persist["branch_prog_ids"][str(worker.id)])
     assert b is not None
     # Only m2 made it into the progression — m1's append was after a
     # failed _ensure_branch_row, so its progression write also failed
@@ -645,7 +639,8 @@ def test_finalize_returns_branch_ids_and_writes_branch_snapshots(
     saved: list = []
     hints: list = []
     monkeypatch.setattr(
-        orch_mod, "save_last_branch_pointer",
+        orch_mod,
+        "save_last_branch_pointer",
         lambda run_id, bid: saved.append((run_id, bid)),
     )
     monkeypatch.setattr(orch_mod, "hint", lambda msg: hints.append(msg))
@@ -755,7 +750,8 @@ def test_finalize_snapshot_write_failure_logs_warning_and_continues(
 
     saved: list = []
     monkeypatch.setattr(
-        orch_mod, "save_last_branch_pointer",
+        orch_mod,
+        "save_last_branch_pointer",
         lambda run_id, bid: saved.append((run_id, bid)),
     )
     monkeypatch.setattr(orch_mod, "hint", lambda *_: None)
@@ -776,9 +772,7 @@ def test_finalize_snapshot_write_failure_logs_warning_and_continues(
     bad_path = MagicMock()
     bad_path.write_text.side_effect = OSError("disk full")
 
-    env.run.branch_path.side_effect = (
-        lambda bid: valid_path if bid == orc_id else bad_path
-    )
+    env.run.branch_path.side_effect = lambda bid: valid_path if bid == orc_id else bad_path
 
     with caplog.at_level(logging.WARNING, logger="lionagi.cli"):
         branch_ids, orc_branch_id = finalize_orchestration(
@@ -789,10 +783,7 @@ def test_finalize_snapshot_write_failure_logs_warning_and_continues(
     assert {bid for _, bid, _ in branch_ids} == {orc_id, worker_id}
     assert getattr(env, "_finalize_extras", None) == dag_extras()
     assert saved == [("run-finalize-failure", orc_id)]
-    assert any(
-        "finalize: branch snapshot write failed" in rec.message
-        for rec in caplog.records
-    )
+    assert any("finalize: branch snapshot write failed" in rec.message for rec in caplog.records)
 
 
 # ── Test 2.5 — stop persists finalize extras without messages ─────────────────
@@ -836,10 +827,14 @@ async def test_stop_persists_dag_metadata_and_message_bookmarks_together(
     hook = env._live_persist["hooks"][-1][1]
 
     m1 = MessageManager.create_instruction(
-        instruction="a", sender="u", recipient=str(worker.id),
+        instruction="a",
+        sender="u",
+        recipient=str(worker.id),
     )
     m2 = MessageManager.create_instruction(
-        instruction="b", sender="u", recipient=str(worker.id),
+        instruction="b",
+        sender="u",
+        recipient=str(worker.id),
     )
     await hook(m1)
     await hook(m2)
@@ -958,3 +953,119 @@ async def test_stop_persists_cancelled_status_with_dag_metadata(
     assert s["status"] == "cancelled"
     assert s["node_metadata"] == dag_extras()
     assert s["ended_at"] is not None
+
+
+# ── ADR-0029: artifact contract snapshot and verification ─────────────────────
+
+
+async def test_start_persists_artifact_contract(
+    temp_db_path: Path,
+    tmp_path: Path,
+):
+    """artifact_contract passed to start_live_persist is stored in session."""
+    env = _minimal_env()
+    contract = {"expected": [{"id": "brief", "path": "brief.md"}]}
+    await start_live_persist(
+        env,
+        invocation_kind="flow",
+        artifacts_path=str(tmp_path / "artifacts"),
+        artifact_contract=contract,
+    )
+    assert env._live_persist is not None
+    ctx = env._live_persist
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    stored = s["artifact_contract_json"]
+    assert isinstance(stored, dict), f"expected dict, got {type(stored)}"
+    assert stored["expected"][0]["id"] == "brief"
+
+    await stop_live_persist(env, status="completed")
+
+
+async def test_stop_uses_update_status_writes_reason(
+    temp_db_path: Path,
+):
+    """stop_live_persist now writes status through update_status(), so
+    status_reason_code must be present after a clean completion.
+    """
+    env = _minimal_env()
+    await start_live_persist(env, invocation_kind="flow")
+    ctx = env._live_persist
+    assert ctx is not None
+
+    await stop_live_persist(env, status="completed")
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "completed"
+    assert s["status_reason_code"] == "run.completed.ok"
+
+
+async def test_stop_verification_fails_flips_status(
+    temp_db_path: Path,
+    tmp_path: Path,
+):
+    """Clean completion with missing required artifact → status flipped to failed."""
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+    # deliberately NOT creating brief.md
+
+    env = _minimal_env()
+    contract = {"expected": [{"id": "brief", "path": "brief.md"}]}
+    await start_live_persist(
+        env,
+        invocation_kind="flow",
+        artifacts_path=str(artifacts_dir),
+        artifact_contract=contract,
+    )
+    ctx = env._live_persist
+    assert ctx is not None
+
+    await stop_live_persist(env, status="completed")
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "failed"
+    assert s["status_reason_code"] == "run.failed.missing_artifact"
+    v = s["artifact_verification_json"]
+    assert isinstance(v, dict)
+    assert v["status"] == "failed"
+
+
+async def test_stop_verification_preserves_non_completed_reason(
+    temp_db_path: Path,
+    tmp_path: Path,
+):
+    """Missing artifact on a failed run keeps the original exception reason."""
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+    # deliberately NOT creating brief.md
+
+    env = _minimal_env()
+    contract = {"expected": [{"id": "brief", "path": "brief.md"}]}
+    await start_live_persist(
+        env,
+        invocation_kind="flow",
+        artifacts_path=str(artifacts_dir),
+        artifact_contract=contract,
+    )
+    ctx = env._live_persist
+    assert ctx is not None
+
+    exc = RuntimeError("something broke")
+    await stop_live_persist(env, status="failed", exception=exc)
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "failed"
+    # Original exception reason preserved — NOT overridden by artifact code.
+    assert s["status_reason_code"] == "run.failed.exception"
+    # Verification still ran.
+    v = s["artifact_verification_json"]
+    assert isinstance(v, dict)
+    assert v["status"] == "failed"

--- a/tests/cli/orchestrate/test_security_hardening.py
+++ b/tests/cli/orchestrate/test_security_hardening.py
@@ -220,10 +220,7 @@ class TestSpecValidationAcceptsValidFields:
 
     def test_valid_booleans(self):
         assert (
-            _validate_spec_fields(
-                {"bare": True, "dry_run": False, "with_synthesis": True}
-            )
-            is None
+            _validate_spec_fields({"bare": True, "dry_run": False, "with_synthesis": True}) is None
         )
 
     def test_valid_prompt(self):
@@ -291,7 +288,7 @@ class TestSavePathContainment:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="should not reach"),
+            AsyncMock(return_value=("should not reach", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 
@@ -310,7 +307,7 @@ class TestSavePathContainment:
 
         with patch(
             "lionagi.cli.orchestrate._run_flow",
-            AsyncMock(return_value="flow done"),
+            AsyncMock(return_value=("flow done", "completed")),
         ) as run_flow:
             code = run_orchestrate(args)
 
@@ -394,3 +391,64 @@ async def test_run_flow_inner_rejects_plan_over_200_ops(tmp_path):
     )
 
     assert "200" in output or "Invalid plan" in output
+
+
+# ── ADR-0029: artifacts: field validation in _validate_spec_fields ────────────
+
+
+class TestArtifactsFieldValidation:
+    def test_valid_artifacts_passes(self):
+        spec = {
+            "model": "codex/gpt-4o",
+            "prompt": "do it",
+            "artifacts": {"expected": [{"id": "report", "path": "report.md"}]},
+        }
+        assert _validate_spec_fields(spec) is None
+
+    def test_none_artifacts_rejected(self):
+        spec = {"model": "x", "prompt": "p", "artifacts": None}
+        err = _validate_spec_fields(spec)
+        assert err is not None
+        assert "artifacts" in err
+
+    def test_absolute_path_in_artifacts_rejected(self):
+        spec = {
+            "model": "x",
+            "prompt": "p",
+            "artifacts": {"expected": [{"id": "x", "path": "/etc/passwd"}]},
+        }
+        err = _validate_spec_fields(spec)
+        assert err is not None
+        assert "artifacts" in err.lower() or "absolute" in err.lower()
+
+    def test_glob_in_artifact_path_rejected(self):
+        spec = {
+            "model": "x",
+            "prompt": "p",
+            "artifacts": {"expected": [{"id": "x", "path": "*.md"}]},
+        }
+        err = _validate_spec_fields(spec)
+        assert err is not None
+
+    def test_duplicate_id_in_artifacts_rejected(self):
+        spec = {
+            "model": "x",
+            "prompt": "p",
+            "artifacts": {
+                "expected": [
+                    {"id": "report", "path": "report.md"},
+                    {"id": "report", "path": "other.md"},
+                ]
+            },
+        }
+        err = _validate_spec_fields(spec)
+        assert err is not None
+
+    def test_non_bool_required_in_artifacts_rejected(self):
+        spec = {
+            "model": "x",
+            "prompt": "p",
+            "artifacts": {"expected": [{"id": "x", "path": "x.md", "required": "yes"}]},
+        }
+        err = _validate_spec_fields(spec)
+        assert err is not None

--- a/tests/cli/test_agent_artifact_contract.py
+++ b/tests/cli/test_agent_artifact_contract.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""ADR-0029 teardown integration tests for artifact contract verification in agent.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lionagi import Branch
+from lionagi.cli.agent import _setup_live_persist, _teardown_live_persist
+from lionagi.state.db import StateDB
+
+
+@pytest.fixture
+def temp_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", db_path)
+    return db_path
+
+
+# ── test_teardown_no_contract_unchanged ──────────────────────────────────────
+
+
+async def test_teardown_no_contract_unchanged(temp_db_path: Path):
+    """Session without artifact_contract → teardown exits with status as resolved by exit code."""
+    branch = Branch(name="b")
+    ctx = await _setup_live_persist(branch, agent_name="a1")
+    assert ctx is not None
+    await _teardown_live_persist(ctx, status="completed")
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    # No contract means verification is skipped; status remains completed.
+    assert s["status"] == "completed"
+    assert s["artifact_contract_json"] is None
+    assert s["artifact_verification_json"] is None
+
+
+# ── test_teardown_contract_passed_stays_completed ────────────────────────────
+
+
+async def test_teardown_contract_passed_stays_completed(temp_db_path: Path, tmp_path: Path):
+    """Required artifact present → verification passed, session stays completed."""
+    artifacts_dir = tmp_path / "arts"
+    artifacts_dir.mkdir()
+    (artifacts_dir / "report.md").write_text("review content")
+
+    branch = Branch(name="b")
+    contract = {"expected": [{"id": "report", "path": "report.md", "required": True}]}
+    ctx = await _setup_live_persist(
+        branch,
+        agent_name="reviewer",
+        artifacts_path=str(artifacts_dir),
+        artifact_contract=contract,
+    )
+    assert ctx is not None
+    await _teardown_live_persist(ctx, status="completed")
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "completed"
+    v = s["artifact_verification_json"]
+    assert isinstance(v, dict)
+    assert v["status"] == "passed"
+
+
+# ── test_teardown_contract_failed_overrides_completed ────────────────────────
+
+
+async def test_teardown_contract_failed_overrides_completed(temp_db_path: Path, tmp_path: Path):
+    """Required artifact missing on clean exit → status overridden to failed with FAILED_MISSING_ARTIFACT."""
+    artifacts_dir = tmp_path / "arts"
+    artifacts_dir.mkdir()
+    # report.md intentionally not written
+
+    branch = Branch(name="b")
+    contract = {"expected": [{"id": "report", "path": "report.md", "required": True}]}
+    ctx = await _setup_live_persist(
+        branch,
+        agent_name="reviewer",
+        artifacts_path=str(artifacts_dir),
+        artifact_contract=contract,
+    )
+    assert ctx is not None
+    await _teardown_live_persist(ctx, status="completed")
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "failed"
+    assert s["status_reason_code"] == "run.failed.missing_artifact"
+
+    # Evidence refs reference the missing artifact id.
+    evidence_raw = s["status_evidence_refs"]
+    evidence = json.loads(evidence_raw) if isinstance(evidence_raw, str) else evidence_raw
+    assert isinstance(evidence, list)
+    assert any(e.get("id") == "report" for e in evidence)
+
+    v = s["artifact_verification_json"]
+    assert isinstance(v, dict)
+    assert v["status"] == "failed"
+
+
+# ── test_teardown_already_failed_keeps_original_reason ───────────────────────
+
+
+async def test_teardown_already_failed_keeps_original_reason(temp_db_path: Path, tmp_path: Path):
+    """Missing artifact on an already-failed run preserves original reason, not FAILED_MISSING_ARTIFACT."""
+    artifacts_dir = tmp_path / "arts"
+    artifacts_dir.mkdir()
+    # report.md intentionally not written
+
+    branch = Branch(name="b")
+    contract = {"expected": [{"id": "report", "path": "report.md", "required": True}]}
+    ctx = await _setup_live_persist(
+        branch,
+        agent_name="reviewer",
+        artifacts_path=str(artifacts_dir),
+        artifact_contract=contract,
+    )
+    assert ctx is not None
+    exc = RuntimeError("agent crashed")
+    await _teardown_live_persist(ctx, status="failed", exception=exc)
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "failed"
+    # Original crash reason preserved — artifact code must NOT override it.
+    assert s["status_reason_code"] == "run.failed.exception"
+
+    # Verification still ran and stored.
+    v = s["artifact_verification_json"]
+    assert isinstance(v, dict)
+    assert v["status"] == "failed"

--- a/tests/cli/test_agent_live_persist.py
+++ b/tests/cli/test_agent_live_persist.py
@@ -182,9 +182,9 @@ async def test_setup_create_session_failure_closes_db(
         if _aiosqlite_thread_count() == before:
             break
         await asyncio.sleep(0.05)
-    assert (
-        _aiosqlite_thread_count() == before
-    ), "DB was not closed on setup failure — aiosqlite worker leaked"
+    assert _aiosqlite_thread_count() == before, (
+        "DB was not closed on setup failure — aiosqlite worker leaked"
+    )
 
     # Restore so other tests run clean.
     monkeypatch.setattr(StateDB, "create_session", original_create)
@@ -289,9 +289,9 @@ async def test_hook_swallows_db_write_failure(
         # MUST NOT raise.
         await ctx["hook"](msg)
 
-    assert any(
-        "live persist write failed" in rec.message for rec in caplog.records
-    ), "expected WARNING log on hook DB-write failure"
+    assert any("live persist write failed" in rec.message for rec in caplog.records), (
+        "expected WARNING log on hook DB-write failure"
+    )
 
     await _teardown_live_persist(ctx, status="completed")
 
@@ -444,9 +444,9 @@ async def test_setup_teardown_does_not_leak_aiosqlite_thread(
             if _aiosqlite_thread_count() <= baseline:
                 break
             await asyncio.sleep(0.05)
-        assert (
-            _aiosqlite_thread_count() <= baseline
-        ), "aiosqlite worker thread leaked across setup/teardown cycle"
+        assert _aiosqlite_thread_count() <= baseline, (
+            "aiosqlite worker thread leaked across setup/teardown cycle"
+        )
 
 
 # ── R5-A HIGH-2: NULL progression_id resume repair ────────────────────────────
@@ -554,7 +554,9 @@ async def test_setup_resume_repairs_null_branch_progression_id(
 
     # Fire a message — branch progression now actually receives it.
     msg = MessageManager.create_instruction(
-        instruction="post-repair", sender="u", recipient=str(branch.id),
+        instruction="post-repair",
+        sender="u",
+        recipient=str(branch.id),
     )
     await ctx["hook"](msg)
 
@@ -588,8 +590,7 @@ async def test_repair_branch_progression_returns_existing_id_under_race(
         sess_prog = str(uuid.uuid4())
         await legacy_db.create_progression(sess_prog)
         await legacy_db.db.execute(
-            "INSERT INTO sessions (id, created_at, progression_id, "
-            "updated_at) VALUES (?, ?, ?, ?)",
+            "INSERT INTO sessions (id, created_at, progression_id, updated_at) VALUES (?, ?, ?, ?)",
             (session_id, 0.0, sess_prog, 0.0),
         )
         await legacy_db.db.execute(
@@ -615,9 +616,7 @@ async def test_repair_branch_progression_returns_existing_id_under_race(
         # Caller B repairs second — UPDATE no-ops (column already set),
         # but the return value MUST be the winner's id, not B's local id.
         effective_b = await db.repair_branch_progression(branch_id, loser_id)
-        assert effective_b == winner_id, (
-            f"loser must adopt winner's id, got {effective_b!r}"
-        )
+        assert effective_b == winner_id, f"loser must adopt winner's id, got {effective_b!r}"
 
         # Spot-check the row really stored the winner's id.
         b = await db.get_branch(branch_id)
@@ -649,12 +648,14 @@ async def test_repair_session_progression_returns_existing_id_under_race(
         await db.create_progression(loser_id)
 
         effective_a = await db.repair_session_progression(
-            session_id, winner_id,
+            session_id,
+            winner_id,
         )
         assert effective_a == winner_id
 
         effective_b = await db.repair_session_progression(
-            session_id, loser_id,
+            session_id,
+            loser_id,
         )
         assert effective_b == winner_id
 
@@ -686,8 +687,7 @@ async def test_setup_resume_repairs_null_session_progression_id(
         )
         # Branch row with a valid branch progression.
         await legacy_db.db.execute(
-            "INSERT INTO branches (id, created_at, session_id, "
-            "progression_id) VALUES (?, ?, ?, ?)",
+            "INSERT INTO branches (id, created_at, session_id, progression_id) VALUES (?, ?, ?, ?)",
             (branch_id, 0.0, session_id, branch_prog),
         )
         await legacy_db.db.commit()
@@ -698,7 +698,9 @@ async def test_setup_resume_repairs_null_session_progression_id(
     assert ctx["session_prog_id"] is not None
 
     msg = MessageManager.create_instruction(
-        instruction="hi", sender="u", recipient=str(branch.id),
+        instruction="hi",
+        sender="u",
+        recipient=str(branch.id),
     )
     await ctx["hook"](msg)
 
@@ -709,3 +711,125 @@ async def test_setup_resume_repairs_null_session_progression_id(
     assert str(msg.id) in sprog
 
     await _teardown_live_persist(ctx, status="completed")
+
+
+# ── ADR-0029: artifact contract snapshot and verification ─────────────────────
+
+
+async def test_setup_persists_artifact_contract(temp_db_path: Path):
+    """artifact_contract passed to setup is stored in the session row."""
+    branch = Branch(name="b1")
+    contract = {"expected": [{"id": "report", "path": "report.md"}]}
+
+    ctx = await _setup_live_persist(
+        branch,
+        agent_name="researcher",
+        artifact_contract=contract,
+    )
+    assert ctx is not None
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    stored = s["artifact_contract_json"]
+    assert isinstance(stored, dict), f"expected dict, got {type(stored)}"
+    assert stored["expected"][0]["id"] == "report"
+
+    await _teardown_live_persist(ctx, status="completed")
+
+
+async def test_teardown_verification_passes_when_artifact_present(
+    temp_db_path: Path, tmp_path: Path
+):
+    """Clean completion with required artifact present → status passed, session completed."""
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+    (artifacts_dir / "report.md").write_text("report content")
+
+    branch = Branch(name="b1")
+    contract = {"expected": [{"id": "report", "path": "report.md"}]}
+
+    ctx = await _setup_live_persist(
+        branch,
+        agent_name="researcher",
+        artifacts_path=str(artifacts_dir),
+        artifact_contract=contract,
+    )
+    assert ctx is not None
+    await _teardown_live_persist(ctx, status="completed")
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "completed"
+    v = s["artifact_verification_json"]
+    assert isinstance(v, dict)
+    assert v["status"] == "passed"
+
+
+async def test_teardown_verification_fails_flips_status(temp_db_path: Path, tmp_path: Path):
+    """Clean completion with missing required artifact → status flipped to failed."""
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+    # deliberately NOT creating report.md
+
+    branch = Branch(name="b1")
+    contract = {"expected": [{"id": "report", "path": "report.md"}]}
+
+    ctx = await _setup_live_persist(
+        branch,
+        agent_name="researcher",
+        artifacts_path=str(artifacts_dir),
+        artifact_contract=contract,
+    )
+    assert ctx is not None
+    await _teardown_live_persist(ctx, status="completed")
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "failed"
+    assert s["status_reason_code"] == "run.failed.missing_artifact"
+    # Evidence refs include the missing artifact entry (stored as JSON string).
+    import json as _json
+
+    evidence_raw = s["status_evidence_refs"]
+    evidence = _json.loads(evidence_raw) if isinstance(evidence_raw, str) else evidence_raw
+    assert isinstance(evidence, list)
+    assert any(e.get("id") == "report" for e in evidence)
+    v = s["artifact_verification_json"]
+    assert isinstance(v, dict)
+    assert v["status"] == "failed"
+
+
+async def test_teardown_verification_preserves_non_completed_reason(
+    temp_db_path: Path, tmp_path: Path
+):
+    """Missing artifact on a failed (non-completed) run keeps original reason."""
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+    # deliberately NOT creating report.md
+
+    branch = Branch(name="b1")
+    contract = {"expected": [{"id": "report", "path": "report.md"}]}
+
+    ctx = await _setup_live_persist(
+        branch,
+        agent_name="researcher",
+        artifacts_path=str(artifacts_dir),
+        artifact_contract=contract,
+    )
+    assert ctx is not None
+    exc = RuntimeError("simulated failure")
+    await _teardown_live_persist(ctx, status="failed", exception=exc)
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "failed"
+    # Original exception reason preserved — NOT overridden by artifact code.
+    assert s["status_reason_code"] == "run.failed.exception"
+    # Verification still ran and is stored.
+    v = s["artifact_verification_json"]
+    assert isinstance(v, dict)
+    assert v["status"] == "failed"

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -3,7 +3,6 @@
 
 """Tests for lionagi.cli.main — _handle_play_shortcut."""
 
-
 from lionagi.cli.main import _handle_play_shortcut
 
 
@@ -27,3 +26,95 @@ def test_handle_play_shortcut_passthrough_for_non_play():
     argv = ["agent", "x"]
     result = _handle_play_shortcut(argv)
     assert result == argv
+
+
+# ─── ADR-0029 §9: `li play check` pre-flight artifact contract ───
+
+
+def test_play_check_no_args_prints_usage(capsys):
+    """`li play check` (no name) returns 1 and prints usage."""
+    result = _handle_play_shortcut(["play", "check"])
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "Usage: li play check" in captured.out
+
+
+def test_play_check_missing_playbook_returns_error(caplog):
+    """Unknown playbook name surfaces the resolution error and returns 1."""
+    import logging
+
+    # Other tests in the suite call configure_cli_logging() which sets
+    # propagate=False on this channel; restore default so caplog captures.
+    err_logger = logging.getLogger("lionagi.cli.error")
+    err_logger.handlers.clear()
+    err_logger.propagate = True
+
+    with caplog.at_level(logging.ERROR, logger="lionagi.cli.error"):
+        result = _handle_play_shortcut(["play", "check", "no-such-playbook-xyz"])
+    assert result == 1
+    assert any(
+        "no-such-playbook-xyz" in rec.message or "not found" in rec.message
+        for rec in caplog.records
+    ), (
+        f"expected error about missing playbook; got log records={[r.message for r in caplog.records]!r}"
+    )
+
+
+def test_play_check_playbook_with_contract(tmp_path, monkeypatch, capsys):
+    """A playbook with `artifacts:` resolves and prints required/optional summary."""
+    pb_dir = tmp_path
+    pb_path = pb_dir / "fixture.playbook.yaml"
+    pb_path.write_text(
+        "name: fixture\n"
+        "model: claude/sonnet\n"
+        "prompt: |\n"
+        "  do x\n"
+        "artifacts:\n"
+        "  expected:\n"
+        "    - id: review\n"
+        "      path: review.md\n"
+        "      required: true\n"
+        "      description: Reviewer output\n"
+        "    - id: notes\n"
+        "      path: notes.md\n"
+        "      required: false\n"
+    )
+
+    # Redirect the playbook lookup root.
+    from lionagi.cli import orchestrate as _orch
+
+    real_resolve = _orch._resolve_playbook_path
+
+    def fake_resolve(name):
+        if name == "fixture":
+            return pb_path, None
+        return real_resolve(name)
+
+    monkeypatch.setattr(_orch, "_resolve_playbook_path", fake_resolve)
+    monkeypatch.setattr("lionagi.cli.main._resolve_playbook_path", fake_resolve, raising=False)
+
+    result = _handle_play_shortcut(["play", "check", "fixture"])
+    out = capsys.readouterr().out
+    assert result == 0, f"expected pass, got {result}; output: {out!r}"
+    assert "fixture" in out
+    assert "1 required" in out and "1 optional" in out
+    assert "review" in out and "notes" in out
+
+
+def test_play_check_playbook_without_contract(tmp_path, monkeypatch, capsys):
+    """A playbook without `artifacts:` exits 0 and reports verification skipped."""
+    pb_path = tmp_path / "plain.playbook.yaml"
+    pb_path.write_text("name: plain\nmodel: claude/sonnet\nprompt: do y\n")
+
+    from lionagi.cli import orchestrate as _orch
+
+    def fake_resolve(name):
+        return (pb_path, None) if name == "plain" else _orch._resolve_playbook_path(name)
+
+    monkeypatch.setattr(_orch, "_resolve_playbook_path", fake_resolve)
+    monkeypatch.setattr("lionagi.cli.main._resolve_playbook_path", fake_resolve, raising=False)
+
+    result = _handle_play_shortcut(["play", "check", "plain"])
+    out = capsys.readouterr().out
+    assert result == 0
+    assert "no `artifacts:` block declared" in out

--- a/tests/state/test_artifact_verifier.py
+++ b/tests/state/test_artifact_verifier.py
@@ -1,0 +1,426 @@
+"""Tests for lionagi/state/artifact_verifier.py (ADR-0029)."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+
+from lionagi.state.artifact_verifier import (
+    ArtifactPathError,
+    _safe_join,
+    missing_artifact_evidence,
+    missing_artifact_summary,
+    resolve_artifact_contract,
+    validate_artifact_contract,
+    verify_artifact_contract,
+)
+
+# ── _safe_join ────────────────────────────────────────────────────────────────
+
+
+class TestSafeJoin:
+    def test_simple_relative(self, tmp_path):
+        result = _safe_join(str(tmp_path), "report.md")
+        assert result == os.path.realpath(os.path.join(str(tmp_path), "report.md"))
+
+    def test_subdir_relative(self, tmp_path):
+        result = _safe_join(str(tmp_path), "subdir/file.txt")
+        assert result.startswith(os.path.realpath(str(tmp_path)))
+
+    def test_absolute_path_rejected(self, tmp_path):
+        with pytest.raises(ArtifactPathError, match="absolute path not allowed"):
+            _safe_join(str(tmp_path), "/etc/passwd")
+
+    def test_dotdot_rejected(self, tmp_path):
+        with pytest.raises(ArtifactPathError, match="segments not allowed"):
+            _safe_join(str(tmp_path), "../escape.txt")
+
+    def test_glob_star_rejected(self, tmp_path):
+        with pytest.raises(ArtifactPathError, match="glob characters"):
+            _safe_join(str(tmp_path), "*.md")
+
+    def test_glob_question_rejected(self, tmp_path):
+        with pytest.raises(ArtifactPathError, match="glob characters"):
+            _safe_join(str(tmp_path), "file?.md")
+
+    def test_glob_bracket_rejected(self, tmp_path):
+        with pytest.raises(ArtifactPathError, match="glob characters"):
+            _safe_join(str(tmp_path), "file[0].md")
+
+    def test_empty_rel_rejected(self, tmp_path):
+        with pytest.raises(ArtifactPathError):
+            _safe_join(str(tmp_path), "")
+
+
+# ── validate_artifact_contract ───────────────────────────────────────────────
+
+
+class TestValidateArtifactContract:
+    def test_none_is_valid(self):
+        validate_artifact_contract(None)
+
+    def test_valid_contract(self):
+        validate_artifact_contract({"expected": [{"id": "report", "path": "report.md"}]})
+
+    def test_missing_expected_list(self):
+        with pytest.raises(ArtifactPathError, match="expected: list"):
+            validate_artifact_contract({"expected": "not-a-list"})
+
+    def test_not_dict(self):
+        with pytest.raises(ArtifactPathError, match="must be a dict"):
+            validate_artifact_contract("invalid")  # type: ignore
+
+    def test_duplicate_id(self):
+        with pytest.raises(ArtifactPathError, match="duplicate id"):
+            validate_artifact_contract(
+                {
+                    "expected": [
+                        {"id": "report", "path": "report.md"},
+                        {"id": "report", "path": "other.md"},
+                    ]
+                }
+            )
+
+    def test_invalid_id_with_space(self):
+        with pytest.raises(ArtifactPathError, match="alphanumeric"):
+            validate_artifact_contract({"expected": [{"id": "bad id", "path": "x.md"}]})
+
+    def test_absolute_path_rejected_via_validate(self):
+        with pytest.raises(ArtifactPathError, match="absolute path not allowed"):
+            validate_artifact_contract({"expected": [{"id": "x", "path": "/etc/passwd"}]})
+
+    def test_required_must_be_bool(self):
+        with pytest.raises(ArtifactPathError, match="required must be a bool"):
+            validate_artifact_contract(
+                {"expected": [{"id": "x", "path": "x.md", "required": "yes"}]}
+            )
+
+    def test_empty_expected_list_is_valid(self):
+        validate_artifact_contract({"expected": []})
+
+
+# ── resolve_artifact_contract ─────────────────────────────────────────────────
+
+
+class TestResolveArtifactContract:
+    def test_both_none_returns_none(self):
+        assert resolve_artifact_contract(playbook_artifacts=None, agent_defaults=None) is None
+
+    def test_agent_defaults_only(self):
+        result = resolve_artifact_contract(
+            playbook_artifacts=None,
+            agent_defaults={"expected": [{"id": "report", "path": "report.md"}]},
+        )
+        assert result is not None
+        assert len(result["expected"]) == 1
+        assert result["expected"][0]["source"] == "agent_profile"
+
+    def test_playbook_overrides_agent_same_id(self):
+        result = resolve_artifact_contract(
+            playbook_artifacts={"expected": [{"id": "report", "path": "playbook_report.md"}]},
+            agent_defaults={"expected": [{"id": "report", "path": "agent_report.md"}]},
+        )
+        assert result is not None
+        assert len(result["expected"]) == 1
+        assert result["expected"][0]["path"] == "playbook_report.md"
+        assert result["expected"][0]["source"] == "playbook"
+
+    def test_playbook_and_agent_different_ids_merged(self):
+        result = resolve_artifact_contract(
+            playbook_artifacts={"expected": [{"id": "brief", "path": "brief.md"}]},
+            agent_defaults={"expected": [{"id": "log", "path": "log.txt"}]},
+        )
+        assert result is not None
+        assert len(result["expected"]) == 2
+
+    def test_required_defaults_to_true(self):
+        result = resolve_artifact_contract(
+            playbook_artifacts=None,
+            agent_defaults={"expected": [{"id": "x", "path": "x.md"}]},
+        )
+        assert result is not None
+        assert result["expected"][0]["required"] is True
+
+
+# ── verify_artifact_contract ──────────────────────────────────────────────────
+
+
+class TestVerifyArtifactContract:
+    def test_none_contract_returns_none(self):
+        assert verify_artifact_contract(None, artifacts_root="/tmp") is None
+
+    def test_missing_root_dir_fails(self):
+        contract = {"expected": [{"id": "report", "path": "report.md"}]}
+        result = verify_artifact_contract(contract, artifacts_root="/nonexistent_root_abc")
+        assert result is not None
+        assert result["status"] == "failed"
+        assert len(result["missing_required"]) == 1
+        assert result["produced"] == []
+
+    def test_required_present_passes(self, tmp_path):
+        (tmp_path / "report.md").write_text("content")
+        contract = {"expected": [{"id": "report", "path": "report.md"}]}
+        result = verify_artifact_contract(contract, artifacts_root=str(tmp_path))
+        assert result is not None
+        assert result["status"] == "passed"
+        assert len(result["produced"]) == 1
+        assert result["produced"][0]["size"] > 0
+
+    def test_zero_byte_required_fails(self, tmp_path):
+        (tmp_path / "empty.md").write_text("")
+        contract = {"expected": [{"id": "empty", "path": "empty.md"}]}
+        result = verify_artifact_contract(contract, artifacts_root=str(tmp_path))
+        assert result is not None
+        assert result["status"] == "failed"
+        assert len(result["missing_required"]) == 1
+
+    def test_optional_missing_gives_warning(self, tmp_path):
+        (tmp_path / "required.md").write_text("content")
+        contract = {
+            "expected": [
+                {"id": "required", "path": "required.md", "required": True},
+                {"id": "optional", "path": "optional.md", "required": False},
+            ]
+        }
+        result = verify_artifact_contract(contract, artifacts_root=str(tmp_path))
+        assert result is not None
+        assert result["status"] == "warning"
+        assert len(result["missing_optional"]) == 1
+        assert len(result["produced"]) == 1
+
+    def test_all_missing_required_fails_splits(self, tmp_path):
+        contract = {
+            "expected": [
+                {"id": "req", "path": "req.md", "required": True},
+                {"id": "opt", "path": "opt.md", "required": False},
+            ]
+        }
+        result = verify_artifact_contract(contract, artifacts_root=str(tmp_path))
+        assert result is not None
+        assert result["status"] == "failed"
+        assert len(result["missing_required"]) == 1
+        assert len(result["missing_optional"]) == 1
+
+    def test_all_present_passes(self, tmp_path):
+        (tmp_path / "a.md").write_text("a")
+        (tmp_path / "b.md").write_text("b")
+        contract = {
+            "expected": [
+                {"id": "a", "path": "a.md"},
+                {"id": "b", "path": "b.md"},
+            ]
+        }
+        result = verify_artifact_contract(contract, artifacts_root=str(tmp_path))
+        assert result is not None
+        assert result["status"] == "passed"
+        assert len(result["produced"]) == 2
+
+
+# ── missing_artifact_summary / evidence ──────────────────────────────────────
+
+
+def test_missing_artifact_summary_single():
+    missing = [{"id": "report", "path": "report.md"}]
+    summary = missing_artifact_summary(missing)
+    assert "report" in summary
+    assert "report.md" in summary
+
+
+def test_missing_artifact_summary_plural():
+    missing = [{"id": "a", "path": "a.md"}, {"id": "b", "path": "b.md"}]
+    summary = missing_artifact_summary(missing)
+    assert "2" in summary
+
+
+def test_missing_artifact_evidence():
+    missing = [{"id": "report", "path": "report.md"}]
+    evidence = missing_artifact_evidence(missing)
+    assert evidence == [{"kind": "expected_artifact", "id": "report", "label": "report.md"}]
+
+
+# ── canonical names required by ADR-0029 test plan ───────────────────────────
+
+
+def test_resolve_contract_both_none():
+    assert resolve_artifact_contract(playbook_artifacts=None, agent_defaults=None) is None
+
+
+def test_resolve_contract_playbook_only():
+    result = resolve_artifact_contract(
+        playbook_artifacts={"expected": [{"id": "brief", "path": "brief.md"}]},
+        agent_defaults=None,
+    )
+    assert result is not None
+    assert len(result["expected"]) == 1
+    assert result["expected"][0]["source"] == "playbook"
+
+
+def test_resolve_contract_agent_only():
+    result = resolve_artifact_contract(
+        playbook_artifacts=None,
+        agent_defaults={"expected": [{"id": "report", "path": "report.md"}]},
+    )
+    assert result is not None
+    assert result["expected"][0]["source"] == "agent_profile"
+
+
+def test_resolve_contract_merge_union():
+    result = resolve_artifact_contract(
+        playbook_artifacts={"expected": [{"id": "brief", "path": "brief.md"}]},
+        agent_defaults={"expected": [{"id": "log", "path": "log.txt"}]},
+    )
+    assert result is not None
+    ids = {e["id"] for e in result["expected"]}
+    assert ids == {"brief", "log"}
+
+
+def test_resolve_contract_merge_override():
+    result = resolve_artifact_contract(
+        playbook_artifacts={"expected": [{"id": "report", "path": "playbook.md"}]},
+        agent_defaults={"expected": [{"id": "report", "path": "agent.md"}]},
+    )
+    assert result is not None
+    assert len(result["expected"]) == 1
+    assert result["expected"][0]["path"] == "playbook.md"
+    assert result["expected"][0]["source"] == "playbook"
+
+
+def test_validate_contract_valid():
+    validate_artifact_contract({"expected": [{"id": "report", "path": "report.md"}]})
+
+
+def test_validate_contract_duplicate_id():
+    with pytest.raises(ArtifactPathError, match="duplicate id"):
+        validate_artifact_contract(
+            {
+                "expected": [
+                    {"id": "report", "path": "a.md"},
+                    {"id": "report", "path": "b.md"},
+                ]
+            }
+        )
+
+
+def test_validate_contract_bad_id_chars():
+    with pytest.raises(ArtifactPathError, match="alphanumeric"):
+        validate_artifact_contract({"expected": [{"id": "bad id!", "path": "x.md"}]})
+
+
+def test_validate_contract_absolute_path():
+    with pytest.raises(ArtifactPathError, match="absolute path not allowed"):
+        validate_artifact_contract({"expected": [{"id": "x", "path": "/etc/passwd"}]})
+
+
+def test_validate_contract_dotdot_path():
+    with pytest.raises(ArtifactPathError, match="segments not allowed"):
+        validate_artifact_contract({"expected": [{"id": "x", "path": "../escape.md"}]})
+
+
+def test_validate_contract_glob_path():
+    with pytest.raises(ArtifactPathError, match="glob characters"):
+        validate_artifact_contract({"expected": [{"id": "x", "path": "*.md"}]})
+
+
+def test_verify_no_contract():
+    assert verify_artifact_contract(None, artifacts_root="/tmp") is None
+
+
+def test_verify_no_artifacts_dir(tmp_path):
+    contract = {"expected": [{"id": "report", "path": "report.md", "required": True}]}
+    result = verify_artifact_contract(contract, artifacts_root=str(tmp_path / "nonexistent"))
+    assert result is not None
+    assert result["status"] == "failed"
+    assert len(result["missing_required"]) == 1
+
+
+def test_verify_all_present(tmp_path):
+    (tmp_path / "a.md").write_text("content a")
+    (tmp_path / "b.md").write_text("content b")
+    contract = {"expected": [{"id": "a", "path": "a.md"}, {"id": "b", "path": "b.md"}]}
+    result = verify_artifact_contract(contract, artifacts_root=str(tmp_path))
+    assert result is not None
+    assert result["status"] == "passed"
+    assert len(result["produced"]) == 2
+
+
+def test_verify_required_missing(tmp_path):
+    # Dir exists but required artifact is not in it.
+    (tmp_path / "other.md").write_text("unrelated")
+    contract = {"expected": [{"id": "report", "path": "report.md", "required": True}]}
+    result = verify_artifact_contract(contract, artifacts_root=str(tmp_path))
+    assert result is not None
+    assert result["status"] == "failed"
+    assert any(e["id"] == "report" for e in result["missing_required"])
+
+
+def test_verify_optional_missing(tmp_path):
+    (tmp_path / "required.md").write_text("content")
+    contract = {
+        "expected": [
+            {"id": "required", "path": "required.md", "required": True},
+            {"id": "optional", "path": "optional.md", "required": False},
+        ]
+    }
+    result = verify_artifact_contract(contract, artifacts_root=str(tmp_path))
+    assert result is not None
+    assert result["status"] == "warning"
+    assert len(result["missing_optional"]) == 1
+
+
+def test_verify_empty_file(tmp_path):
+    (tmp_path / "empty.md").write_text("")
+    contract = {"expected": [{"id": "empty", "path": "empty.md", "required": True}]}
+    result = verify_artifact_contract(contract, artifacts_root=str(tmp_path))
+    assert result is not None
+    assert result["status"] == "failed"
+
+
+def test_verify_optional_only_missing_dir(tmp_path):
+    contract = {
+        "expected": [
+            {"id": "notes", "path": "notes.md", "required": False},
+            {"id": "log", "path": "log.txt", "required": False},
+        ]
+    }
+    result = verify_artifact_contract(contract, artifacts_root=str(tmp_path / "nonexistent"))
+    assert result is not None
+    assert result["status"] == "warning"
+    assert len(result["missing_optional"]) == 2
+    assert result["missing_required"] == []
+
+
+def test_verify_mixed_required_optional_missing_dir(tmp_path):
+    contract = {
+        "expected": [
+            {"id": "req", "path": "req.md", "required": True},
+            {"id": "opt", "path": "opt.md", "required": False},
+        ]
+    }
+    result = verify_artifact_contract(contract, artifacts_root=str(tmp_path / "nonexistent"))
+    assert result is not None
+    assert result["status"] == "failed"
+    assert len(result["missing_required"]) == 1
+    assert len(result["missing_optional"]) == 1
+
+
+def test_safe_join_normal(tmp_path):
+    result = _safe_join(str(tmp_path), "subdir/report.md")
+    assert result.startswith(os.path.realpath(str(tmp_path)))
+    assert result.endswith("report.md")
+
+
+def test_safe_join_absolute_rejects(tmp_path):
+    with pytest.raises(ArtifactPathError, match="absolute path not allowed"):
+        _safe_join(str(tmp_path), "/etc/passwd")
+
+
+def test_safe_join_dotdot_rejects(tmp_path):
+    with pytest.raises(ArtifactPathError, match="segments not allowed"):
+        _safe_join(str(tmp_path), "../escape.md")
+
+
+def test_safe_join_glob_rejects(tmp_path):
+    with pytest.raises(ArtifactPathError, match="glob characters"):
+        _safe_join(str(tmp_path), "*.md")

--- a/tests/state/test_db.py
+++ b/tests/state/test_db.py
@@ -195,6 +195,9 @@ async def test_apply_schema_adds_missing_columns_on_old_db(tmp_path):
             "artifacts_path",
             "source_kind",
             "updated_at",
+            # ADR-0029: new artifact columns must be reconciled on old DBs.
+            "artifact_contract_json",
+            "artifact_verification_json",
         ):
             assert must_have in cols, f"sessions.{must_have} not migrated"
         cur = await db.db.execute("PRAGMA table_info(branches)")
@@ -255,9 +258,7 @@ async def test_insert_message_idempotent(db: StateDB):
     # Second insert — same id, should silently be ignored
     await db.insert_message(msg)
 
-    cur = await db.db.execute(
-        "SELECT COUNT(*) AS n FROM messages WHERE id = ?", (msg["id"],)
-    )
+    cur = await db.db.execute("SELECT COUNT(*) AS n FROM messages WHERE id = ?", (msg["id"],))
     row = await cur.fetchone()
     assert row["n"] == 1
 
@@ -268,9 +269,7 @@ async def test_resolve_lion_class_known(db: StateDB):
     msg = make_message(lion_class=known)
     await db.insert_message(msg)
 
-    cur = await db.db.execute(
-        "SELECT lion_class FROM messages WHERE id = ?", (msg["id"],)
-    )
+    cur = await db.db.execute("SELECT lion_class FROM messages WHERE id = ?", (msg["id"],))
     row = await cur.fetchone()
     # type_id 1 maps to System
     assert row["lion_class"] == 1
@@ -281,9 +280,7 @@ async def test_resolve_lion_class_unknown_empty(db: StateDB):
     msg = make_message(lion_class="")
     await db.insert_message(msg)
 
-    cur = await db.db.execute(
-        "SELECT lion_class FROM messages WHERE id = ?", (msg["id"],)
-    )
+    cur = await db.db.execute("SELECT lion_class FROM messages WHERE id = ?", (msg["id"],))
     row = await cur.fetchone()
     assert row["lion_class"] == 0
 
@@ -710,11 +707,19 @@ async def test_update_play(db: StateDB):
     # ADR-0011 vocab: plays use ``running_complete`` (not ``completed``)
     # for the "finished running" terminal — ``completed`` belongs to the
     # sessions vocabulary (ADR-0017), not plays.
+    # ADR-0028 Phase 2: `running_complete` has no canonical default
+    # reason_code (the gate hasn't run yet at that point — the caller
+    # has the context to choose between PENDING_READY / GATE_FAILED_
+    # VERDICT / etc.), so we must pass reason_code explicitly.
+    from lionagi.state.reasons import PlayReasons
+
     await db.update_play(
         play["id"],
         status="running_complete",
         exit_code=0,
         ended_at=end_time,
+        reason_code=PlayReasons.PENDING_READY,
+        reason_summary="Test fixture: play marked running_complete.",
     )
 
     retrieved = await db.get_play(play["id"])
@@ -898,9 +903,9 @@ async def test_save_definition_concurrent_versions_are_unique(tmp_path):
             )
         )
         # Every save returned a unique version, and the set is {1..N}.
-        assert sorted(versions) == list(
-            range(1, N + 1)
-        ), f"Expected unique versions 1..{N}, got {sorted(versions)}"
+        assert sorted(versions) == list(range(1, N + 1)), (
+            f"Expected unique versions 1..{N}, got {sorted(versions)}"
+        )
 
         # Database state matches the API return values.
         rows = await db.list_definition_versions("agent", "race-agent")
@@ -941,9 +946,9 @@ async def test_message_content_string_roundtrips_as_string(db: StateDB):
         got = await db.get_message(msg_id)
         assert got is not None
         # Critical: type AND value preserved exactly.
-        assert isinstance(
-            got["content"], str
-        ), f"case {i!r}: expected str, got {type(got['content']).__name__}"
+        assert isinstance(got["content"], str), (
+            f"case {i!r}: expected str, got {type(got['content']).__name__}"
+        )
         assert got["content"] == raw, f"case {i!r}: value diverged"
 
 
@@ -1073,3 +1078,84 @@ async def test_session_delete_cascades_branches(db: StateDB):
     await db.db.execute("DELETE FROM sessions WHERE id = ?", (sid,))
     await db.db.commit()
     assert await db.get_branch(bid) is None
+
+
+# ── ADR-0029: Artifact contract storage ───────────────────────────────────────
+
+
+async def test_create_session_with_artifact_contract(db: StateDB):
+    """artifact_contract_json written at creation is decoded on fetch."""
+    prog_id = uid()
+    await db.create_progression(prog_id)
+    contract = {"expected": [{"id": "report", "path": "report.md"}]}
+    sid = uid()
+    await db.create_session(
+        {
+            "id": sid,
+            "progression_id": prog_id,
+            "created_at": time.time(),
+            "status": "running",
+            "artifact_contract_json": contract,
+        }
+    )
+    row = await db.get_session(sid)
+    assert row is not None
+    stored = row["artifact_contract_json"]
+    assert isinstance(stored, dict), f"expected dict, got {type(stored)}"
+    assert stored["expected"][0]["id"] == "report"
+
+
+async def test_update_artifact_verification(db: StateDB):
+    """update_artifact_verification() persists and round-trips the result."""
+    prog_id = uid()
+    await db.create_progression(prog_id)
+    sid = uid()
+    await db.create_session(
+        {
+            "id": sid,
+            "progression_id": prog_id,
+            "created_at": time.time(),
+            "status": "running",
+        }
+    )
+    verification = {
+        "status": "passed",
+        "checked_at": time.time(),
+        "missing_required": [],
+        "missing_optional": [],
+        "produced": [{"id": "report", "path": "report.md", "size": 42, "present": True}],
+    }
+    await db.update_artifact_verification(sid, verification)
+    row = await db.get_session(sid)
+    assert row is not None
+    stored = row["artifact_verification_json"]
+    assert isinstance(stored, dict), f"expected dict, got {type(stored)}"
+    assert stored["status"] == "passed"
+    assert stored["produced"][0]["id"] == "report"
+
+
+async def test_update_artifact_verification_none(db: StateDB):
+    """update_artifact_verification(None) stores NULL without error."""
+    prog_id = uid()
+    await db.create_progression(prog_id)
+    sid = uid()
+    await db.create_session(
+        {
+            "id": sid,
+            "progression_id": prog_id,
+            "created_at": time.time(),
+            "status": "running",
+        }
+    )
+    await db.update_artifact_verification(sid, None)
+    row = await db.get_session(sid)
+    assert row is not None
+    assert row["artifact_verification_json"] is None
+
+
+async def test_new_db_has_artifact_columns(db: StateDB):
+    """Fresh in-memory DB exposes both new columns via PRAGMA table_info."""
+    cur = await db.db.execute("PRAGMA table_info(sessions)")
+    cols = {r["name"] for r in await cur.fetchall()}
+    assert "artifact_contract_json" in cols
+    assert "artifact_verification_json" in cols

--- a/tests/state/test_db_artifact_contract.py
+++ b/tests/state/test_db_artifact_contract.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""ADR-0029 DB integration tests for artifact_contract_json / artifact_verification_json."""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+import time
+import uuid
+
+import pytest
+
+from lionagi.state.db import StateDB
+
+
+@pytest.fixture
+async def db():
+    state = StateDB(":memory:")
+    await state.open()
+    yield state
+    await state.close()
+
+
+def uid() -> str:
+    return str(uuid.uuid4())
+
+
+async def _make_session(db: StateDB, **fields) -> str:
+    prog_id = uid()
+    await db.create_progression(prog_id)
+    sid = uid()
+    await db.create_session(
+        {"id": sid, "progression_id": prog_id, "created_at": time.time(), **fields}
+    )
+    return sid
+
+
+# ── test_create_session_with_contract ────────────────────────────────────────
+
+
+async def test_create_session_with_contract(db: StateDB):
+    """artifact_contract_json is stored and decoded on fetch."""
+    contract = {"expected": [{"id": "report", "path": "report.md", "required": True}]}
+    sid = await _make_session(db, artifact_contract_json=contract)
+    row = await db.get_session(sid)
+    assert row is not None
+    stored = row["artifact_contract_json"]
+    assert isinstance(stored, dict)
+    assert stored["expected"][0]["id"] == "report"
+
+
+# ── test_create_session_without_contract ─────────────────────────────────────
+
+
+async def test_create_session_without_contract(db: StateDB):
+    """Sessions without artifact_contract_json store NULL and raise no error."""
+    sid = await _make_session(db)
+    row = await db.get_session(sid)
+    assert row is not None
+    assert row["artifact_contract_json"] is None
+
+
+# ── test_update_artifact_verification ────────────────────────────────────────
+
+
+async def test_update_artifact_verification(db: StateDB):
+    """update_artifact_verification() persists and round-trips the verification dict."""
+    sid = await _make_session(db)
+    verification = {
+        "status": "passed",
+        "checked_at": time.time(),
+        "missing_required": [],
+        "missing_optional": [],
+        "produced": [{"id": "report", "path": "report.md", "size": 128, "present": True}],
+    }
+    await db.update_artifact_verification(sid, verification)
+    row = await db.get_session(sid)
+    assert row is not None
+    stored = row["artifact_verification_json"]
+    assert isinstance(stored, dict)
+    assert stored["status"] == "passed"
+    assert stored["produced"][0]["id"] == "report"
+
+
+# ── test_migration_adds_columns ───────────────────────────────────────────────
+
+
+async def test_migration_adds_columns():
+    """reconcile_schema() adds both new columns to a pre-ADR-0029 DB."""
+    with tempfile.NamedTemporaryFile(suffix=".db") as f:
+        db_path = f.name
+        # Build an old-style schema without the two new columns.
+        old = sqlite3.connect(db_path)
+        old.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS progressions (
+                id TEXT PRIMARY KEY,
+                created_at REAL
+            );
+            CREATE TABLE IF NOT EXISTS sessions (
+                id TEXT PRIMARY KEY,
+                progression_id TEXT,
+                status TEXT,
+                created_at REAL
+            );
+            """
+        )
+        old.close()
+
+        # Open with current StateDB — reconcile_schema() should add the columns.
+        state = StateDB(db_path)
+        await state.open()
+        try:
+            cur = await state.db.execute("PRAGMA table_info(sessions)")
+            cols = {r["name"] for r in await cur.fetchall()}
+            assert "artifact_contract_json" in cols, "migration missing artifact_contract_json"
+            assert "artifact_verification_json" in cols, (
+                "migration missing artifact_verification_json"
+            )
+        finally:
+            await state.close()

--- a/tests/state/test_status_reasons.py
+++ b/tests/state/test_status_reasons.py
@@ -403,3 +403,124 @@ class TestTeardownReasonResolution:
         )
         assert "ValueError" in summary
         assert "bad input" in summary
+
+
+# ── ADR-0028 Phase 2: invocation transition writes reason ────────────
+
+
+async def _create_invocation(db: StateDB, *, status: str = "running") -> str:
+    inv_id = uuid.uuid4().hex[:12]
+    now = time.time()
+    await db.db.execute(
+        "INSERT INTO invocations (id, skill, status, created_at, started_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (inv_id, "test:skill", status, now, now, now),
+    )
+    await db.db.commit()
+    return inv_id
+
+
+class TestInvocationTransition:
+    async def test_update_status_direct(self, db: StateDB):
+        """Direct update_status() on entity_type='invocation' works."""
+        inv_id = await _create_invocation(db)
+        await db.update_status(
+            "invocation",
+            inv_id,
+            new_status="completed",
+            reason_code=RunReasons.COMPLETED_OK,
+            reason_summary="All child sessions completed successfully.",
+            evidence_refs=[{"kind": "session", "id": "abc"}],
+            source="executor",
+            actor=inv_id,
+        )
+
+        cur = await db.db.execute(
+            "SELECT status, status_reason_code, status_reason_summary "
+            "FROM invocations WHERE id = ?",
+            (inv_id,),
+        )
+        row = dict(await cur.fetchone())
+        assert row["status"] == "completed"
+        assert row["status_reason_code"] == RunReasons.COMPLETED_OK
+        assert "child sessions" in row["status_reason_summary"]
+
+        cur = await db.db.execute(
+            "SELECT entity_type, previous_status, status, reason_code "
+            "FROM status_transitions WHERE entity_id = ?",
+            (inv_id,),
+        )
+        rows = [dict(r) for r in await cur.fetchall()]
+        assert len(rows) == 1
+        assert rows[0]["entity_type"] == "invocation"
+        assert rows[0]["previous_status"] == "running"
+        assert rows[0]["status"] == "completed"
+        assert rows[0]["reason_code"] == RunReasons.COMPLETED_OK
+
+    async def test_update_invocation_routes_status_through_update_status(self, db: StateDB):
+        """ADR-0028 Phase 2: update_invocation(status=...) writes reason atomically."""
+        inv_id = await _create_invocation(db)
+        await db.update_invocation(
+            inv_id,
+            status="completed",
+            ended_at=time.time(),
+            reason_code=RunReasons.COMPLETED_OK,
+            reason_summary="All children passed.",
+        )
+
+        cur = await db.db.execute(
+            "SELECT status, status_reason_code, ended_at IS NOT NULL AS has_end "
+            "FROM invocations WHERE id = ?",
+            (inv_id,),
+        )
+        row = dict(await cur.fetchone())
+        assert row["status"] == "completed"
+        assert row["status_reason_code"] == RunReasons.COMPLETED_OK
+        assert row["has_end"] == 1
+
+        # Transition row was written through update_status().
+        cur = await db.db.execute(
+            "SELECT COUNT(*) AS n FROM status_transitions WHERE entity_id = ?",
+            (inv_id,),
+        )
+        assert (await cur.fetchone())["n"] == 1
+
+    async def test_update_invocation_compat_warns_when_reason_omitted(self, db: StateDB):
+        """Legacy callers that pass status without reason_code get a deprecation
+        warning + a default code so they keep working through the migration."""
+        import warnings
+
+        inv_id = await _create_invocation(db)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            await db.update_invocation(inv_id, status="failed")
+            deprecations = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert len(deprecations) == 1, "missing-reason_code call must emit one DeprecationWarning"
+        assert "reason_code" in str(deprecations[0].message)
+
+        cur = await db.db.execute(
+            "SELECT status_reason_code FROM invocations WHERE id = ?",
+            (inv_id,),
+        )
+        # Compat shim defaults to the generic exception reason for 'failed'.
+        row = dict(await cur.fetchone())
+        assert row["status_reason_code"] == RunReasons.FAILED_EXCEPTION
+
+    async def test_update_invocation_no_status_skips_reason_path(self, db: StateDB):
+        """Updates that don't touch status don't write to status_transitions."""
+        inv_id = await _create_invocation(db)
+        await db.update_invocation(inv_id, ended_at=time.time())
+
+        cur = await db.db.execute(
+            "SELECT status, status_reason_code FROM invocations WHERE id = ?",
+            (inv_id,),
+        )
+        row = dict(await cur.fetchone())
+        assert row["status"] == "running"  # unchanged
+        assert row["status_reason_code"] is None  # never touched
+
+        cur = await db.db.execute(
+            "SELECT COUNT(*) AS n FROM status_transitions WHERE entity_id = ?",
+            (inv_id,),
+        )
+        assert (await cur.fetchone())["n"] == 0


### PR DESCRIPTION
## Summary

**Supersedes #1074 (ADR-0028 Phase 2) + #1077 (ADR-0029 Artifact Contract).** These two backend changes were originally split across two PRs but have entangled scope (CLI orchestrator writers consume both reason codes AND artifact contracts), so they're consolidated here after a local integration pass. Frontend pieces are stacked in #PR-B (nav) and #PR-C (microcopy).

### ADR-0028 Phase 2 — status reasons
- Entity-aware default reason resolver in `lionagi/state/db.py`: runs / shows / plays / schedule_runs each have their own `status→reason` maps. Ambiguous pairs (e.g. `play.running_complete`) raise instead of synthesizing a wrong-domain default.
- Atomic admin transition: `BEGIN IMMEDIATE` wraps the conditional UPDATE + `status_transitions` INSERT in `apps/studio/server/services/admin.py`.
- Phantom-classifier override threaded through admin endpoint; deterministic tests pin the classifier via `monkeypatch` on the source module.
- Missed-fire skip write-site in `scheduler/engine.py` — persists a `schedule.skipped.missed_fire` row AND advances `next_fire_at`.

### ADR-0029 — artifact contract
- Declarative `artifacts:` block on playbook + agent profile.
- Pre-flight `li play check <name>` resolves the contract without firing.
- Runtime verification at teardown: missing required → status override (`stop_live_persist` returns effective status).
- Shared `warn_unknown_artifact_keys()` in `lionagi/state/artifact_verifier.py` keeps pre-flight and runtime warnings in lockstep.
- Caplog isolation fix in `tests/cli/test_main.py` (matches the `propagate=True` reset used by `tests/cli/orchestrate/test_flow_spec_file.py`).

### Frontend pieces (belong here because they consume backend contracts)
- `lib/api.ts` + `lib/types.ts` add `ArtifactContract` / `PhantomSession` type families.
- `components/runs/ExpectedArtifacts.tsx` renders the contract on the run detail page.

## Test plan

- [x] `uv run --all-extras pytest` — full backend suite green
- [x] Focused suites: `tests/state/test_status_reasons.py`, `tests/state/test_artifact_verifier.py`, `tests/state/test_db_artifact_contract.py`, `tests/apps_studio_server/test_admin.py`, `tests/cli/test_main.py`
- [x] Frontend `pnpm typecheck` clean (lib/api.ts type additions consumed)

## History

Source PRs #1074 and #1077 were reviewed and merged into this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)