### PR TITLE
feat(studio/nav): ADR-0032 — top-bar navigation + admin reorg

### DIFF
--- a/apps/studio/frontend/app/admin/health/page.tsx
+++ b/apps/studio/frontend/app/admin/health/page.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import PageHeader from "@/components/PageHeader";
+import Timestamp from "@/components/Timestamp";
+import { getAdminDoctor } from "@/lib/api";
+import type { AdminDoctorResponse, PhantomReason } from "@/lib/api";
+
+function formatBytes(value: number): string {
+  if (value === 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB"];
+  const i = Math.floor(Math.log(value) / Math.log(1024));
+  return `${(value / Math.pow(1024, i)).toFixed(1)} ${units[i]}`;
+}
+
+function reasonLabel(reason: PhantomReason): string {
+  switch (reason) {
+    case "process_dead":
+      return "Process dead";
+    case "missing_artifacts":
+      return "Missing artifacts";
+    case "stale_lock":
+      return "Stale lock";
+  }
+}
+
+function DbHealthStrip({ doctor }: { doctor: AdminDoctorResponse }) {
+  const h = doctor.db_health;
+  return (
+    <div className="flex flex-wrap gap-x-5 gap-y-1 rounded border border-edge bg-surface-overlay px-4 py-2.5 text-meta text-content-muted">
+      <span className="uppercase tracking-[0.08em] text-content-muted">DB Health</span>
+      <span>
+        <span className="tabular-nums text-content-secondary">{formatBytes(h.size_bytes)}</span>{" "}
+        state DB
+      </span>
+      <span>
+        <span className="tabular-nums text-content-secondary">{formatBytes(h.wal_bytes)}</span> WAL
+      </span>
+      <span>
+        <span className="tabular-nums text-content-secondary">{formatBytes(h.wal_pending)}</span>{" "}
+        WAL pending
+      </span>
+      <span>
+        Checked <Timestamp value={doctor.diagnostic_run_at} exact />
+      </span>
+    </div>
+  );
+}
+
+export default function AdminHealthPage() {
+  const [doctor, setDoctor] = useState<AdminDoctorResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  async function refresh() {
+    try {
+      const d = await getAdminDoctor();
+      setDoctor(d);
+      setError(null);
+    } catch {
+      setError("Failed to load diagnostics");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- refresh() calls setState inside async callbacks, not synchronously in the effect body
+    void refresh();
+  }, []);
+
+  return (
+    <main className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-6 animate-page-enter">
+      <PageHeader title="Admin Health" subtitle="Read-only system diagnostics" density="tight" />
+
+      {error && (
+        <div className="rounded border border-status-error/30 bg-status-error-bg px-3 py-2 text-body text-content-primary">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="py-8 text-center text-meta text-content-muted">Loading...</div>
+      ) : (
+        doctor && <DbHealthStrip doctor={doctor} />
+      )}
+
+      {doctor && (
+        <section>
+          <div className="mb-2.5 flex items-center justify-between">
+            <h2 className="text-label font-semibold text-content-primary">
+              Phantom sessions
+              <span className="ml-2 rounded bg-surface-overlay px-1.5 py-0.5 font-mono text-meta tabular-nums text-content-muted">
+                {doctor.phantom_sessions.length}
+              </span>
+            </h2>
+            <Link
+              href="/admin/maintenance"
+              className="text-meta text-content-muted underline-offset-2 transition-colors duration-150 hover:text-content-primary hover:underline"
+            >
+              Manage in Maintenance →
+            </Link>
+          </div>
+          {doctor.phantom_sessions.length === 0 ? (
+            <div className="rounded border border-status-success/25 bg-status-success-bg px-4 py-4 text-body text-content-primary shadow-card">
+              No phantom sessions detected.
+            </div>
+          ) : (
+            <div className="overflow-x-auto rounded border border-edge bg-surface-raised shadow-card">
+              {/* Read-only mirror of the phantom table on /admin/maintenance.
+                  Health shows what's happening; Maintenance is where the
+                  mutating prune actions live (ADR-0032 §6). No checkboxes,
+                  no action buttons here. */}
+              <table className="w-full text-left text-body">
+                <thead>
+                  <tr className="border-b border-edge bg-surface-overlay text-meta uppercase tracking-[0.06em] text-content-muted">
+                    <th className="px-3 py-2.5 font-medium">Session</th>
+                    <th className="px-3 py-2.5 font-medium">Reason</th>
+                    <th className="px-3 py-2.5 font-medium">Started</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {doctor.phantom_sessions.map((p) => (
+                    <tr
+                      key={p.session_id}
+                      className="border-b border-edge-subtle text-content-secondary"
+                    >
+                      <td className="px-3 py-2">
+                        <div className="font-medium text-content-primary">{p.playbook ?? "—"}</div>
+                        <div className="font-mono text-meta text-content-muted">
+                          {p.session_id.slice(-8)}
+                        </div>
+                      </td>
+                      <td className="px-3 py-2">
+                        <span className="rounded border border-status-error/40 bg-status-error-bg px-1.5 py-0.5 text-meta text-content-primary">
+                          {reasonLabel(p.reason)}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2 text-meta text-content-muted">
+                        <Timestamp value={p.started_at ?? null} />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+      )}
+    </main>
+  );
+}

--- a/apps/studio/frontend/app/admin/maintenance/page.tsx
+++ b/apps/studio/frontend/app/admin/maintenance/page.tsx
@@ -5,7 +5,7 @@ import Button from "@/components/Button";
 import PageHeader from "@/components/PageHeader";
 import Timestamp from "@/components/Timestamp";
 import { getAdminDoctor, pruneAdmin } from "@/lib/api";
-import type { AdminDoctorResponse, PhantomReason, PhantomSession } from "@/lib/api";
+import type { AdminDoctorResponse, PhantomReason } from "@/lib/api";
 
 function formatBytes(value: number): string {
   if (value === 0) return "0 B";
@@ -16,9 +16,12 @@ function formatBytes(value: number): string {
 
 function reasonLabel(reason: PhantomReason): string {
   switch (reason) {
-    case "process_dead": return "Process dead";
-    case "missing_artifacts": return "Missing artifacts";
-    case "stale_lock": return "Stale lock";
+    case "process_dead":
+      return "Process dead";
+    case "missing_artifacts":
+      return "Missing artifacts";
+    case "stale_lock":
+      return "Stale lock";
   }
 }
 
@@ -32,8 +35,7 @@ function DbHealthStrip({ doctor }: { doctor: AdminDoctorResponse }) {
         state DB
       </span>
       <span>
-        <span className="tabular-nums text-content-secondary">{formatBytes(h.wal_bytes)}</span>{" "}
-        WAL
+        <span className="tabular-nums text-content-secondary">{formatBytes(h.wal_bytes)}</span> WAL
       </span>
       <span>
         <span className="tabular-nums text-content-secondary">{formatBytes(h.wal_pending)}</span>{" "}
@@ -46,7 +48,7 @@ function DbHealthStrip({ doctor }: { doctor: AdminDoctorResponse }) {
   );
 }
 
-export default function AdminPage() {
+export default function AdminMaintenancePage() {
   const [doctor, setDoctor] = useState<AdminDoctorResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -81,6 +83,14 @@ export default function AdminPage() {
 
   async function handlePruneSelected() {
     if (selected.size === 0) return;
+    const count = selected.size;
+    const noun = count === 1 ? "session" : "sessions";
+    const confirmed = window.confirm(
+      `Prune ${count} phantom ${noun}?\n\n` +
+        `Removes DB rows. Artifacts on disk are kept.\n` +
+        `Cannot be undone.`,
+    );
+    if (!confirmed) return;
     setPruning(true);
     try {
       await pruneAdmin({ session_ids: Array.from(selected) });
@@ -94,6 +104,14 @@ export default function AdminPage() {
   }
 
   async function handlePruneAll() {
+    const count = (doctor?.phantom_sessions ?? []).length;
+    const noun = count === 1 ? "session" : "sessions";
+    const confirmed = window.confirm(
+      `Prune all ${count} phantom ${noun}?\n\n` +
+        `Removes DB rows. Artifacts on disk are kept.\n` +
+        `Cannot be undone.`,
+    );
+    if (!confirmed) return;
     setPruning(true);
     try {
       await pruneAdmin({ all_phantom: true });
@@ -111,8 +129,8 @@ export default function AdminPage() {
   return (
     <main className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-6 animate-page-enter">
       <PageHeader
-        title="Admin"
-        subtitle="Studio maintenance and diagnostics"
+        title="Admin Maintenance"
+        subtitle="Prune phantom sessions and system maintenance"
         density="tight"
       />
 
@@ -184,9 +202,7 @@ export default function AdminPage() {
                       />
                     </td>
                     <td className="px-3 py-2">
-                      <div className="font-medium text-content-primary">
-                        {p.playbook ?? "—"}
-                      </div>
+                      <div className="font-medium text-content-primary">{p.playbook ?? "—"}</div>
                       <div className="font-mono text-meta text-content-muted">
                         {p.session_id.slice(-8)}
                       </div>

--- a/apps/studio/frontend/components/Shell.tsx
+++ b/apps/studio/frontend/components/Shell.tsx
@@ -1,41 +1,12 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { usePathname } from "next/navigation";
 import { Suspense, useEffect, useState, type ReactNode } from "react";
-import { listProjects } from "@/lib/api";
-import type { ProjectSummary } from "@/lib/types";
-
-type NavItem = {
-  label: string;
-  href: string;
-  match?: (pathname: string) => boolean;
-};
-
-const navItems: NavItem[] = [
-  { label: "Projects", href: "/projects" },
-  { label: "Schedules", href: "/schedules" },
-  { label: "Playbooks", href: "/playbooks" },
-  { label: "Agents", href: "/agents" },
-  { label: "Plugins", href: "/plugins" },
-  { label: "Shows", href: "/shows" },
-  { label: "Invocations", href: "/invocations" },
-  { label: "Runs", href: "/runs" },
-  { label: "Teams", href: "/teams" },
-  { label: "Admin", href: "/admin" },
-];
-
-function isActive(item: NavItem, pathname: string) {
-  if (item.match) {
-    return item.match(pathname);
-  }
-
-  if (item.href === "/") {
-    return pathname === "/";
-  }
-
-  return pathname === item.href || pathname.startsWith(`${item.href}/`);
-}
+import Breadcrumb from "@/components/nav/Breadcrumb";
+import NavGroup from "@/components/nav/NavGroup";
+import ProjectChip from "@/components/nav/ProjectChip";
+import { NAV_GROUPS } from "@/components/nav/types";
 
 export interface ShellProps {
   children: ReactNode;
@@ -112,56 +83,9 @@ function ThemeToggle() {
   );
 }
 
-// Global project selector — loads project list once and keeps it in sync with
-// the ?project= search param. Selecting a project sets the param on the current
-// page; clearing it removes the param entirely.
-function ProjectSelector() {
-  const router = useRouter();
-  const pathname = usePathname() ?? "/";
-  const searchParams = useSearchParams();
-  const currentProject = searchParams.get("project") ?? "";
-
-  const [projects, setProjects] = useState<ProjectSummary[]>([]);
-
-  useEffect(() => {
-    listProjects()
-      .then((data) => setProjects(data.projects))
-      .catch(() => {
-        /* silently ignore — selector degrades to empty list */
-      });
-  }, []);
-
-  function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
-    const value = e.target.value;
-    const params = new URLSearchParams(searchParams.toString());
-    if (value) {
-      params.set("project", value);
-    } else {
-      params.delete("project");
-    }
-    const qs = params.toString();
-    router.push(qs ? `${pathname}?${qs}` : pathname);
-  }
-
-  return (
-    <select
-      value={currentProject}
-      onChange={handleChange}
-      aria-label="Filter by project"
-      className="h-6 rounded border border-edge bg-surface-nav px-1.5 text-[11px] text-content-secondary focus:border-interactive-primary focus:outline-none hover:border-edge-strong transition-colors cursor-pointer"
-    >
-      <option value="">All Projects</option>
-      {projects.map((p) => (
-        <option key={p.name} value={p.name}>
-          {p.name}
-        </option>
-      ))}
-    </select>
-  );
-}
-
 export default function Shell({ children }: ShellProps) {
   const pathname = usePathname() ?? "/";
+  const [mobileOpen, setMobileOpen] = useState(false);
 
   return (
     <div className="min-h-screen bg-surface-base text-content-primary">
@@ -193,29 +117,11 @@ export default function Shell({ children }: ShellProps) {
             </span>
           </Link>
 
-          {/* Tab-style primary nav with underline */}
-          <nav aria-label="Primary" className="flex items-stretch gap-0.5">
-            {navItems.map((item) => {
-              const active = isActive(item, pathname);
-              return (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  aria-current={active ? "page" : undefined}
-                  className={[
-                    "relative flex items-center whitespace-nowrap px-2.5 text-[12px] font-medium transition-colors duration-150",
-                    active
-                      ? "text-content-primary"
-                      : "text-content-muted hover:text-content-secondary",
-                  ].join(" ")}
-                >
-                  {item.label}
-                  {active && (
-                    <span className="absolute inset-x-2.5 bottom-0 h-[2px] rounded-t bg-interactive-primary" />
-                  )}
-                </Link>
-              );
-            })}
+          {/* Desktop: 4-group primary nav */}
+          <nav aria-label="Primary" className="hidden items-stretch gap-0.5 md:flex">
+            {NAV_GROUPS.map((group) => (
+              <NavGroup key={group.label} group={group} pathname={pathname} />
+            ))}
           </nav>
 
           {/* Spacer */}
@@ -224,14 +130,66 @@ export default function Shell({ children }: ShellProps) {
           {/* Right cluster */}
           <div className="flex items-center gap-1.5 self-center">
             <Suspense fallback={null}>
-              <ProjectSelector />
+              <ProjectChip />
             </Suspense>
             <ThemeToggle />
+            {/* Hamburger: visible below 768px */}
+            <button
+              type="button"
+              aria-label="Open navigation menu"
+              aria-expanded={mobileOpen}
+              onClick={() => setMobileOpen((v) => !v)}
+              className="flex h-8 w-8 items-center justify-center rounded text-content-muted transition-colors hover:bg-interactive-secondary hover:text-content-primary md:hidden"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                {mobileOpen ? (
+                  <>
+                    <line x1="18" y1="6" x2="6" y2="18" />
+                    <line x1="6" y1="6" x2="18" y2="18" />
+                  </>
+                ) : (
+                  <>
+                    <line x1="3" y1="6" x2="21" y2="6" />
+                    <line x1="3" y1="12" x2="21" y2="12" />
+                    <line x1="3" y1="18" x2="21" y2="18" />
+                  </>
+                )}
+              </svg>
+            </button>
           </div>
         </div>
+
+        {/* Mobile drawer: vertical accordion of 4 groups */}
+        {mobileOpen && (
+          <div className="border-t border-edge bg-surface-nav shadow-card md:hidden">
+            {NAV_GROUPS.map((group) => (
+              <NavGroup
+                key={group.label}
+                group={group}
+                pathname={pathname}
+                mobile
+                onNavigate={() => setMobileOpen(false)}
+              />
+            ))}
+          </div>
+        )}
       </header>
 
-      <div id="main-content" tabIndex={-1} className="w-full">{children}</div>
+      <Breadcrumb />
+
+      <div id="main-content" tabIndex={-1} className="w-full">
+        {children}
+      </div>
     </div>
   );
 }

--- a/apps/studio/frontend/components/nav/Breadcrumb.tsx
+++ b/apps/studio/frontend/components/nav/Breadcrumb.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { NAV_GROUPS, isRouteActive } from "./types";
+
+export default function Breadcrumb() {
+  const pathname = usePathname() ?? "/";
+
+  // Dashboard root
+  if (pathname === "/") {
+    return (
+      <nav
+        aria-label="Breadcrumb"
+        className="flex h-6 items-center gap-1 border-b border-edge bg-surface-base px-4 text-meta text-content-muted"
+      >
+        <span>Dashboard</span>
+      </nav>
+    );
+  }
+
+  // Find matching group and item
+  let groupLabel: string | null = null;
+  let itemLabel: string | null = null;
+  let itemHref: string | null = null;
+
+  outer: for (const group of NAV_GROUPS) {
+    for (const item of group.items) {
+      if (isRouteActive(item, pathname)) {
+        groupLabel = group.label;
+        itemLabel = item.label;
+        itemHref = item.href;
+        break outer;
+      }
+    }
+  }
+
+  if (!groupLabel || !itemLabel || !itemHref) {
+    // Unknown route: show first decoded segment
+    const firstSegment = pathname.split("/").filter(Boolean)[0] ?? "";
+    return (
+      <nav
+        aria-label="Breadcrumb"
+        className="flex h-6 items-center gap-1 border-b border-edge bg-surface-base px-4 text-meta text-content-muted"
+      >
+        {firstSegment && <span>{decodeURIComponent(firstSegment)}</span>}
+      </nav>
+    );
+  }
+
+  // Determine detail segment beyond the section route
+  let detailSegment: string | null = null;
+  if (pathname !== itemHref && pathname.startsWith(`${itemHref}/`)) {
+    const remainder = pathname.slice(itemHref.length + 1);
+    const segment = remainder.split("/")[0];
+    if (segment) {
+      const decoded = decodeURIComponent(segment);
+      detailSegment = decoded.length > 12 ? decoded.slice(0, 12) : decoded;
+    }
+  }
+
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className="flex h-6 items-center gap-1 border-b border-edge bg-surface-base px-4 text-meta text-content-muted"
+    >
+      <span>{groupLabel}</span>
+      <span aria-hidden="true">›</span>
+      <Link href={itemHref} className="transition-colors duration-150 hover:text-content-secondary">
+        {itemLabel}
+      </Link>
+      {detailSegment && (
+        <>
+          <span aria-hidden="true">›</span>
+          <span>{detailSegment}</span>
+        </>
+      )}
+    </nav>
+  );
+}

--- a/apps/studio/frontend/components/nav/NavGroup.tsx
+++ b/apps/studio/frontend/components/nav/NavGroup.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import Link from "next/link";
+import { useRef, useState } from "react";
+import { type NavGroupDef, isRouteActive } from "./types";
+
+interface NavGroupProps {
+  group: NavGroupDef;
+  pathname: string;
+  mobile?: boolean;
+  onNavigate?: () => void;
+}
+
+export default function NavGroup({ group, pathname, mobile = false, onNavigate }: NavGroupProps) {
+  const [open, setOpen] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // closeTimerRef must be declared unconditionally at the top (React
+  // rules-of-hooks) even though only the desktop dropdown branch uses it.
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const groupActive = group.items.some((item) => isRouteActive(item, pathname));
+
+  // Dashboard single direct link — no submenu
+  if (group.items.length === 1 && group.items[0].href === "/") {
+    const item = group.items[0];
+    const active = isRouteActive(item, pathname);
+    if (mobile) {
+      return (
+        <div className="border-b border-edge">
+          <Link
+            href={item.href}
+            onClick={onNavigate}
+            className={[
+              "flex h-10 w-full items-center px-4 text-label transition-colors duration-150",
+              active ? "font-semibold text-content-primary" : "text-content-secondary",
+            ].join(" ")}
+          >
+            {group.label}
+          </Link>
+        </div>
+      );
+    }
+    return (
+      <div className="relative flex items-stretch">
+        <Link
+          href={item.href}
+          aria-current={active ? "page" : undefined}
+          className={[
+            "relative flex items-center whitespace-nowrap px-2.5 text-[12px] font-medium transition-colors duration-150",
+            active ? "text-content-primary" : "text-content-muted hover:text-content-secondary",
+          ].join(" ")}
+        >
+          {group.label}
+          {active && (
+            <span className="absolute inset-x-2.5 bottom-0 h-[2px] rounded-t bg-interactive-primary" />
+          )}
+        </Link>
+      </div>
+    );
+  }
+
+  // Mobile accordion
+  if (mobile) {
+    return (
+      <div className="border-b border-edge">
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-expanded={open}
+          className="flex h-10 w-full items-center justify-between px-4 text-label transition-colors duration-150"
+        >
+          <span
+            className={
+              groupActive ? "font-semibold text-content-primary" : "text-content-secondary"
+            }
+          >
+            {group.label}
+          </span>
+          <span
+            className={["transition-transform duration-150", open ? "rotate-180" : ""].join(" ")}
+          >
+            ▾
+          </span>
+        </button>
+        {open && (
+          <div className="flex flex-col bg-surface-overlay/50">
+            {group.items.map((item) => {
+              const active = isRouteActive(item, pathname);
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  onClick={onNavigate}
+                  className={[
+                    "px-6 py-2 text-body transition-colors duration-150",
+                    active
+                      ? "font-semibold text-content-primary"
+                      : "text-content-secondary hover:text-content-primary",
+                  ].join(" ")}
+                >
+                  {item.label}
+                </Link>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // Desktop dropdown: 200ms hover-open delay, 150ms close delay (the
+  // forgiveness window). Without the close delay the menu disappears
+  // the instant the cursor leaves the trigger, because the absolute-
+  // positioned dropdown sits below the parent's hit-test bounding box —
+  // mouseleave on the parent fires as soon as the cursor exits the
+  // trigger row, even if it's heading toward a menu item.
+  function handleMouseEnter() {
+    // Cancel any in-flight close so re-entering keeps the menu open.
+    if (closeTimerRef.current) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+    timerRef.current = setTimeout(() => setOpen(true), 200);
+  }
+
+  function handleMouseLeave() {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    closeTimerRef.current = setTimeout(() => setOpen(false), 150);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Escape") setOpen(false);
+  }
+
+  return (
+    <div
+      className="relative flex items-stretch"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      onKeyDown={handleKeyDown}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className={[
+          "relative flex items-center whitespace-nowrap px-2.5 text-[12px] font-medium transition-colors duration-150",
+          groupActive || open
+            ? "text-content-primary"
+            : "text-content-muted hover:text-content-secondary",
+        ].join(" ")}
+      >
+        {group.label} ▾
+        {(groupActive || open) && (
+          <span className="absolute inset-x-2.5 bottom-0 h-[2px] rounded-t bg-interactive-primary" />
+        )}
+      </button>
+
+      {open && (
+        <>
+          {/* Transparent hover bridge: covers the gap between the trigger
+              row and the dropdown so the cursor can traverse without
+              leaving the parent's hover descendant tree. Matches the
+              dropdown's width and positioning so a diagonal cursor
+              motion toward a menu item never falls into dead space. */}
+          <span aria-hidden="true" className="absolute left-0 top-full z-40 h-2 min-w-44" />
+          <div className="absolute left-0 top-full z-50 min-w-44 rounded border border-edge bg-surface-nav py-1 shadow-card">
+            {group.items.map((item) => {
+              const active = isRouteActive(item, pathname);
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  onClick={() => setOpen(false)}
+                  className={[
+                    "block whitespace-nowrap px-3 py-2 text-body transition-colors duration-150 hover:bg-surface-overlay",
+                    active ? "font-semibold text-content-primary" : "text-content-secondary",
+                  ].join(" ")}
+                >
+                  {item.label}
+                </Link>
+              );
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/studio/frontend/components/nav/ProjectChip.tsx
+++ b/apps/studio/frontend/components/nav/ProjectChip.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+import { listProjects } from "@/lib/api";
+import type { ProjectSummary } from "@/lib/types";
+
+export default function ProjectChip() {
+  const router = useRouter();
+  const pathname = usePathname() ?? "/";
+  const searchParams = useSearchParams();
+  const currentProject = searchParams.get("project") ?? "";
+
+  const [projects, setProjects] = useState<ProjectSummary[]>([]);
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    listProjects()
+      .then((data) => setProjects(data.projects))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    function handleOutsideClick(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function handleEscape(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    if (open) {
+      document.addEventListener("mousedown", handleOutsideClick);
+      document.addEventListener("keydown", handleEscape);
+    }
+    return () => {
+      document.removeEventListener("mousedown", handleOutsideClick);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [open]);
+
+  function selectProject(name: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (name) {
+      params.set("project", name);
+    } else {
+      params.delete("project");
+    }
+    const qs = params.toString();
+    router.push(qs ? `${pathname}?${qs}` : pathname);
+    setOpen(false);
+  }
+
+  const chipLabel = currentProject ? `[project: ${currentProject} ▾]` : "[All projects ▾]";
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-label="Filter by project"
+        aria-expanded={open}
+        className="h-6 rounded border border-edge bg-surface-nav px-1.5 text-[11px] text-content-secondary focus:border-interactive-primary focus:outline-none hover:border-edge-strong transition-colors cursor-pointer"
+      >
+        {chipLabel}
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-full z-50 mt-1 w-64 rounded border border-edge bg-surface-nav py-1 shadow-card">
+          <button
+            type="button"
+            onClick={() => selectProject("")}
+            className={[
+              "flex w-full items-center justify-between px-3 py-2 text-left text-body transition-colors duration-150 hover:bg-surface-overlay hover:text-content-primary",
+              currentProject === ""
+                ? "font-semibold text-content-primary"
+                : "text-content-secondary",
+            ].join(" ")}
+          >
+            All projects
+          </button>
+
+          {projects.map((p) => (
+            <button
+              key={p.name}
+              type="button"
+              onClick={() => selectProject(p.name)}
+              className={[
+                "flex w-full items-center justify-between px-3 py-2 text-left text-body transition-colors duration-150 hover:bg-surface-overlay hover:text-content-primary",
+                currentProject === p.name
+                  ? "font-semibold text-content-primary"
+                  : "text-content-secondary",
+              ].join(" ")}
+            >
+              <span>{p.name}</span>
+              {p.source && (
+                <span className="ml-2 shrink-0 text-meta text-content-muted">{p.source}</span>
+              )}
+            </button>
+          ))}
+
+          <div className="mt-1 border-t border-edge pt-1">
+            <Link
+              href="/projects"
+              onClick={() => setOpen(false)}
+              className="block px-3 py-2 text-body text-content-secondary transition-colors duration-150 hover:bg-surface-overlay hover:text-content-primary"
+            >
+              View all projects
+            </Link>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/studio/frontend/components/nav/types.ts
+++ b/apps/studio/frontend/components/nav/types.ts
@@ -1,0 +1,59 @@
+import type { ReactNode } from "react";
+
+export interface NavItem {
+  label: string;
+  href: string;
+  icon?: ReactNode;
+  match?: (pathname: string) => boolean;
+}
+
+export interface NavGroup {
+  label: string;
+  items: NavItem[];
+  isOpen?: boolean;
+}
+
+export type NavGroupDef = Omit<NavGroup, "isOpen">;
+
+export function isRouteActive(item: NavItem, pathname: string): boolean {
+  if (item.match) {
+    return item.match(pathname);
+  }
+  if (item.href === "/") {
+    return pathname === "/";
+  }
+  return pathname === item.href || pathname.startsWith(`${item.href}/`);
+}
+
+export const NAV_GROUPS: NavGroupDef[] = [
+  {
+    label: "Dashboard",
+    items: [{ label: "Dashboard", href: "/", match: (pathname) => pathname === "/" }],
+  },
+  {
+    label: "Work",
+    items: [
+      { label: "Shows", href: "/shows" },
+      { label: "Runs", href: "/runs" },
+      { label: "Teams", href: "/teams" },
+      { label: "Invocations", href: "/invocations" },
+      { label: "Schedules", href: "/schedules" },
+    ],
+  },
+  {
+    label: "Library",
+    items: [
+      { label: "Playbooks", href: "/playbooks" },
+      { label: "Agents", href: "/agents" },
+      { label: "Plugins", href: "/plugins" },
+      { label: "Skills", href: "/skills" },
+    ],
+  },
+  {
+    label: "Admin",
+    items: [
+      { label: "Health", href: "/admin/health" },
+      { label: "Maintenance", href: "/admin/maintenance" },
+    ],
+  },
+];

--- a/apps/studio/frontend/next.config.mjs
+++ b/apps/studio/frontend/next.config.mjs
@@ -1,4 +1,11 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  async redirects() {
+    return [
+      // ADR-0032: remove this one-release compatibility redirect in the next release.
+      { source: "/admin", destination: "/admin/health", permanent: true },
+    ];
+  },
+};
 
 export default nextConfig;

--- a/docs/adrs/ADR-0032-navigation-reorganization.md
+++ b/docs/adrs/ADR-0032-navigation-reorganization.md
@@ -201,12 +201,26 @@ The Admin page today bundles DB health (size, WAL, phantom sessions)
 with maintenance actions (prune, checkpoint, vacuum) on one screen.
 Split:
 
-- `/admin/health` — read-only view of current system state
-- `/admin/maintenance` — actions that mutate state (with
-  confirmations per ADR-0031's `EntityAction.requires_confirm`)
+- `/admin/health` — read-only view of current system state. Renders
+  the DB health strip and a read-only phantom sessions table (no
+  checkboxes, no action buttons). Includes a "Manage in Maintenance →"
+  link to the mutating surface.
+- `/admin/maintenance` — actions that mutate state (`prune selected`,
+  `prune all phantom`), each gated by a `window.confirm()` dialog
+  per the ADR-0031 `EntityAction.requires_confirm` pattern.
 
 The split clarifies which surface is "look" vs "act". Today the bundle
 makes routine inspection feel risky (the prune button is right there).
+
+**Scope clarification (v1):** Only `prune` lands as a maintenance
+action in v1 because the backend admin router currently exposes only
+`POST /api/admin/prune`. `checkpoint` and `vacuum` are deferred to a
+follow-up that first adds `POST /api/admin/checkpoint` and
+`POST /api/admin/vacuum` endpoints (today these operations exist as
+`li state checkpoint` / `li state vacuum` CLI subcommands, not as
+HTTP endpoints). When those endpoints land, this ADR is amended in
+place and the corresponding buttons join the Maintenance page with
+the same confirmation pattern.
 
 ### 7. Mobile / narrow-viewport behavior
 


### PR DESCRIPTION
## Summary

**Supersedes #1078 (ADR-0032 navigation reorganization).** Stacked on #1083 — depends on `PhantomSession` types added in `lib/api.ts` there.

- New `components/nav/` module: `NavGroup` (top-bar group with hover-bridge dropdown), `Breadcrumb` (U+203A separators), `ProjectChip`, shared types.
- `Shell.tsx` refactor: sidebar collapsed into 4-section top bar — Dashboard / Work / Library / Admin.
- `app/admin/page.tsx` renamed → `app/admin/maintenance/page.tsx` (prune phantom sessions + system maintenance).
- New `app/admin/health/page.tsx` — read-only health monitoring with "Manage in Maintenance →" link.
- `window.confirm()` before prune (inline strings — microcopy library lands in #PR-C).
- Dropdown UX fix: 150ms close delay + transparent hover bridge + flush-positioned dropdown so cursor traversal doesn't dismiss the menu.

## Test plan

- [x] `pnpm lint` 0 errors (3 pre-existing warnings in `app/runs/page.tsx`)
- [x] `pnpm typecheck` clean
- [x] Manual: nav dropdowns hover-stable, breadcrumb separators render correctly, /admin/health and /admin/maintenance load

## Stack

| Slice | PR | Status |
| --- | --- | --- |
| A — backend status + artifacts | #1083 | needs review |
| **B — frontend nav (this PR)** | **this** | — |
| C — frontend microcopy | next | depends on B |

🤖 Generated with [Claude Code](https://claude.com/claude-code)