### PR TITLE
polish(studio): centralize microcopy in lib/copy.ts

### DIFF
--- a/apps/studio/frontend/app/admin/maintenance/page.tsx
+++ b/apps/studio/frontend/app/admin/maintenance/page.tsx
@@ -6,6 +6,7 @@ import PageHeader from "@/components/PageHeader";
 import Timestamp from "@/components/Timestamp";
 import { getAdminDoctor, pruneAdmin } from "@/lib/api";
 import type { AdminDoctorResponse, PhantomReason } from "@/lib/api";
+import { errors } from "@/lib/copy";
 
 function formatBytes(value: number): string {
   if (value === 0) return "0 B";
@@ -61,7 +62,7 @@ export default function AdminMaintenancePage() {
       setDoctor(d);
       setError(null);
     } catch {
-      setError("Failed to load diagnostics");
+      setError(errors.loadDiagnostics);
     } finally {
       setLoading(false);
     }
@@ -97,7 +98,7 @@ export default function AdminMaintenancePage() {
       setSelected(new Set());
       await refresh();
     } catch {
-      setError("Prune failed");
+      setError(errors.prune);
     } finally {
       setPruning(false);
     }
@@ -118,7 +119,7 @@ export default function AdminMaintenancePage() {
       setSelected(new Set());
       await refresh();
     } catch {
-      setError("Prune all failed");
+      setError(errors.pruneAll);
     } finally {
       setPruning(false);
     }

--- a/apps/studio/frontend/app/admin/maintenance/page.tsx
+++ b/apps/studio/frontend/app/admin/maintenance/page.tsx
@@ -6,7 +6,7 @@ import PageHeader from "@/components/PageHeader";
 import Timestamp from "@/components/Timestamp";
 import { getAdminDoctor, pruneAdmin } from "@/lib/api";
 import type { AdminDoctorResponse, PhantomReason } from "@/lib/api";
-import { errors } from "@/lib/copy";
+import { confirmPhantomPrune, empty, errors } from "@/lib/copy";
 
 function formatBytes(value: number): string {
   if (value === 0) return "0 B";
@@ -84,13 +84,7 @@ export default function AdminMaintenancePage() {
 
   async function handlePruneSelected() {
     if (selected.size === 0) return;
-    const count = selected.size;
-    const noun = count === 1 ? "session" : "sessions";
-    const confirmed = window.confirm(
-      `Prune ${count} phantom ${noun}?\n\n` +
-        `Removes DB rows. Artifacts on disk are kept.\n` +
-        `Cannot be undone.`,
-    );
+    const confirmed = window.confirm(confirmPhantomPrune(selected.size, false));
     if (!confirmed) return;
     setPruning(true);
     try {
@@ -106,12 +100,7 @@ export default function AdminMaintenancePage() {
 
   async function handlePruneAll() {
     const count = (doctor?.phantom_sessions ?? []).length;
-    const noun = count === 1 ? "session" : "sessions";
-    const confirmed = window.confirm(
-      `Prune all ${count} phantom ${noun}?\n\n` +
-        `Removes DB rows. Artifacts on disk are kept.\n` +
-        `Cannot be undone.`,
-    );
+    const confirmed = window.confirm(confirmPhantomPrune(count, true));
     if (!confirmed) return;
     setPruning(true);
     try {
@@ -175,7 +164,7 @@ export default function AdminMaintenancePage() {
           <div className="py-8 text-center text-meta text-content-muted">Loading...</div>
         ) : phantoms.length === 0 ? (
           <div className="rounded border border-status-success/25 bg-status-success-bg px-4 py-4 text-body text-content-primary shadow-card">
-            No phantom sessions detected.
+            {empty.phantomSessions}
           </div>
         ) : (
           <div className="overflow-x-auto rounded border border-edge bg-surface-raised shadow-card">

--- a/apps/studio/frontend/app/agents/page.tsx
+++ b/apps/studio/frontend/app/agents/page.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/lib/api";
 import type { DefinitionDetail, DefinitionVersion } from "@/lib/api";
 import type { AgentProfile, AgentProfileSummary } from "@/lib/types";
+import { empty, errors } from "@/lib/copy";
 
 // ─── Frontmatter parsing ──────────────────────────────────────────────────────
 
@@ -103,7 +104,7 @@ function FrontmatterEditForm({ content, onChange }: FrontmatterEditFormProps) {
     } else {
       onChange(body);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fm, body]);
 
   function setField(key: keyof ParsedFrontmatter, value: unknown) {
@@ -118,7 +119,9 @@ function FrontmatterEditForm({ content, onChange }: FrontmatterEditFormProps) {
           {/* Model + Effort group */}
           <div className="flex items-end gap-3">
             <label className="flex flex-col gap-1">
-              <span className="text-[10px] uppercase tracking-[0.08em] text-content-muted font-medium">Model</span>
+              <span className="text-[10px] uppercase tracking-[0.08em] text-content-muted font-medium">
+                Model
+              </span>
               <input
                 type="text"
                 value={typeof fm.model === "string" ? fm.model : ""}
@@ -128,7 +131,9 @@ function FrontmatterEditForm({ content, onChange }: FrontmatterEditFormProps) {
               />
             </label>
             <label className="flex flex-col gap-1">
-              <span className="text-[10px] uppercase tracking-[0.08em] text-content-muted font-medium">Effort</span>
+              <span className="text-[10px] uppercase tracking-[0.08em] text-content-muted font-medium">
+                Effort
+              </span>
               <select
                 value={typeof fm.effort === "string" ? fm.effort : ""}
                 onChange={(e) => setField("effort", e.target.value || undefined)}
@@ -149,7 +154,9 @@ function FrontmatterEditForm({ content, onChange }: FrontmatterEditFormProps) {
           {/* Permission + toggles group */}
           <div className="flex items-end gap-3">
             <label className="flex flex-col gap-1">
-              <span className="text-[10px] uppercase tracking-[0.08em] text-content-muted font-medium">Permission</span>
+              <span className="text-[10px] uppercase tracking-[0.08em] text-content-muted font-medium">
+                Permission
+              </span>
               <select
                 value={typeof fm.permission_mode === "string" ? fm.permission_mode : ""}
                 onChange={(e) => setField("permission_mode", e.target.value || undefined)}
@@ -169,7 +176,9 @@ function FrontmatterEditForm({ content, onChange }: FrontmatterEditFormProps) {
                 onChange={(e) => setField("yolo", e.target.checked || undefined)}
                 className="h-3.5 w-3.5 rounded border-edge accent-interactive-primary"
               />
-              <span className="text-[10px] uppercase tracking-[0.08em] text-content-muted font-medium">Yolo</span>
+              <span className="text-[10px] uppercase tracking-[0.08em] text-content-muted font-medium">
+                Yolo
+              </span>
             </label>
             <label className="flex items-center gap-1.5 h-[34px] cursor-pointer select-none">
               <input
@@ -178,7 +187,9 @@ function FrontmatterEditForm({ content, onChange }: FrontmatterEditFormProps) {
                 onChange={(e) => setField("lion_system", e.target.checked || undefined)}
                 className="h-3.5 w-3.5 rounded border-edge accent-interactive-primary"
               />
-              <span className="text-[10px] uppercase tracking-[0.08em] text-content-muted font-medium">Lion System</span>
+              <span className="text-[10px] uppercase tracking-[0.08em] text-content-muted font-medium">
+                Lion System
+              </span>
             </label>
           </div>
         </div>
@@ -276,7 +287,7 @@ function AgentList({
           <div className="px-3 py-4 text-meta text-content-muted">Loading...</div>
         ) : filtered.length === 0 ? (
           <div className="px-3 py-4 text-meta text-content-muted">
-            {searchQuery ? "No agents match filter." : "No agents found."}
+            {searchQuery ? empty.agentsFiltered : empty.agents}
           </div>
         ) : (
           filtered.map((agent) => {
@@ -552,10 +563,7 @@ function AgentDetail({ agentName, agentProfile }: AgentDetailProps) {
               Loading version...
             </div>
           ) : editing ? (
-            <FrontmatterEditForm
-              content={editContent}
-              onChange={setEditContent}
-            />
+            <FrontmatterEditForm content={editContent} onChange={setEditContent} />
           ) : (
             <StructuredContentView content={displayContent} />
           )}
@@ -640,7 +648,9 @@ function VersionHistory({
   const sorted = [...versions].sort((a, b) => b.version - a.version);
 
   return (
-    <div className={`flex shrink-0 flex-col border-l border-edge transition-all ${sorted.length === 0 ? "w-36" : "w-56"}`}>
+    <div
+      className={`flex shrink-0 flex-col border-l border-edge transition-all ${sorted.length === 0 ? "w-36" : "w-56"}`}
+    >
       <div className="border-b border-edge px-3 py-2">
         <span className="text-meta font-medium uppercase tracking-[0.06em] text-content-muted">
           Version History

--- a/apps/studio/frontend/app/invocations/[id]/page.tsx
+++ b/apps/studio/frontend/app/invocations/[id]/page.tsx
@@ -10,6 +10,7 @@ import Duration from "@/components/Duration";
 import OutcomeRenderer from "@/components/outcomes/OutcomeRenderer";
 import { getInvocation } from "@/lib/api";
 import type { InvocationDetail } from "@/lib/api";
+import { errors } from "@/lib/copy";
 
 function shortId(id: string): string {
   return id.slice(0, 8);
@@ -33,7 +34,7 @@ export default function InvocationDetailPage() {
           setError(null);
         }
       } catch {
-        if (active) setError("Failed to load invocation");
+        if (active) setError(errors.loadInvocation);
       } finally {
         if (active) setLoading(false);
       }
@@ -56,11 +57,7 @@ export default function InvocationDetailPage() {
   if (error || !data) {
     return (
       <main className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-6">
-        <PageHeader
-          title="Invocation"
-          subtitle={error ?? "Not found"}
-          density="tight"
-        />
+        <PageHeader title="Invocation" subtitle={error ?? "Not found"} density="tight" />
       </main>
     );
   }
@@ -78,36 +75,26 @@ export default function InvocationDetailPage() {
 
       <div className="grid grid-cols-2 gap-3 md:grid-cols-4 text-body">
         <div className="rounded border border-edge bg-surface-raised p-3">
-          <div className="text-meta uppercase tracking-[0.06em] text-content-muted">
-            Sessions
-          </div>
+          <div className="text-meta uppercase tracking-[0.06em] text-content-muted">Sessions</div>
           <div className="mt-1 text-2xl tabular-nums text-content-primary">
             {data.session_count}
           </div>
         </div>
         <div className="rounded border border-edge bg-surface-raised p-3">
-          <div className="text-meta uppercase tracking-[0.06em] text-content-muted">
-            Duration
-          </div>
+          <div className="text-meta uppercase tracking-[0.06em] text-content-muted">Duration</div>
           <div className="mt-1 text-2xl tabular-nums text-content-primary">
             <Duration value={dur} />
           </div>
         </div>
         <div className="rounded border border-edge bg-surface-raised p-3">
-          <div className="text-meta uppercase tracking-[0.06em] text-content-muted">
-            Started
-          </div>
+          <div className="text-meta uppercase tracking-[0.06em] text-content-muted">Started</div>
           <div className="mt-1 text-body text-content-primary">
             <Timestamp value={data.started_at} />
           </div>
         </div>
         <div className="rounded border border-edge bg-surface-raised p-3">
-          <div className="text-meta uppercase tracking-[0.06em] text-content-muted">
-            Plugin
-          </div>
-          <div className="mt-1 text-body text-content-primary">
-            {data.plugin ?? "—"}
-          </div>
+          <div className="text-meta uppercase tracking-[0.06em] text-content-muted">Plugin</div>
+          <div className="mt-1 text-body text-content-primary">{data.plugin ?? "—"}</div>
         </div>
       </div>
 
@@ -130,10 +117,7 @@ export default function InvocationDetailPage() {
             <tbody>
               {data.sessions.length === 0 ? (
                 <tr>
-                  <td
-                    colSpan={6}
-                    className="px-3 py-8 text-center text-meta text-content-muted"
-                  >
+                  <td colSpan={6} className="px-3 py-8 text-center text-meta text-content-muted">
                     No sessions spawned under this invocation yet.
                   </td>
                 </tr>
@@ -150,9 +134,7 @@ export default function InvocationDetailPage() {
                       >
                         {s.name || s.agent_name || s.playbook_name || shortId(s.id)}
                       </Link>
-                      <div className="text-meta text-content-muted font-mono">
-                        {shortId(s.id)}
-                      </div>
+                      <div className="text-meta text-content-muted font-mono">{shortId(s.id)}</div>
                     </td>
                     <td className="px-3 py-2 align-middle text-content-secondary">
                       {s.invocation_kind ?? "—"}
@@ -160,9 +142,7 @@ export default function InvocationDetailPage() {
                     <td className="px-3 py-2 align-middle font-mono text-meta text-content-secondary">
                       {s.model ?? "—"}
                       {s.effort ? (
-                        <span className="ml-1 text-content-muted">
-                          · {s.effort}
-                        </span>
+                        <span className="ml-1 text-content-muted">· {s.effort}</span>
                       ) : null}
                     </td>
                     <td className="px-3 py-2 align-middle">

--- a/apps/studio/frontend/app/invocations/page.tsx
+++ b/apps/studio/frontend/app/invocations/page.tsx
@@ -9,7 +9,7 @@ import Timestamp from "@/components/Timestamp";
 import Duration from "@/components/Duration";
 import { listInvocations } from "@/lib/api";
 import type { InvocationListResponse } from "@/lib/api";
-import { errors } from "@/lib/copy";
+import { empty, errors } from "@/lib/copy";
 
 const LIMIT = 25;
 
@@ -163,7 +163,7 @@ export default function InvocationsPage() {
               !error ? (
                 <tr>
                   <td colSpan={6} className="px-3 py-8 text-center text-meta text-content-muted">
-                    No invocations yet. Skills track here once they call{" "}
+                    {empty.invocations} Skills track here once they call{" "}
                     <code className="text-content-primary">li invoke start</code>.
                   </td>
                 </tr>

--- a/apps/studio/frontend/app/invocations/page.tsx
+++ b/apps/studio/frontend/app/invocations/page.tsx
@@ -9,6 +9,7 @@ import Timestamp from "@/components/Timestamp";
 import Duration from "@/components/Duration";
 import { listInvocations } from "@/lib/api";
 import type { InvocationListResponse } from "@/lib/api";
+import { errors } from "@/lib/copy";
 
 const LIMIT = 25;
 
@@ -16,11 +17,7 @@ function shortId(id: string): string {
   return id.slice(0, 8);
 }
 
-function durationSeconds(
-  startedAt: number,
-  endedAt: number | null,
-  nowSec: number,
-): number {
+function durationSeconds(startedAt: number, endedAt: number | null, nowSec: number): number {
   return (endedAt ?? nowSec) - startedAt;
 }
 
@@ -50,7 +47,7 @@ export default function InvocationsPage() {
           setError(null);
         }
       } catch {
-        if (active) setError("Failed to load invocations");
+        if (active) setError(errors.loadInvocations);
       } finally {
         if (active) setLoading(false);
       }
@@ -82,9 +79,7 @@ export default function InvocationsPage() {
 
       {/* Filter strip */}
       <div className="flex flex-wrap items-center gap-3 rounded border border-edge bg-surface-overlay px-3 py-2 text-body">
-        <span className="text-meta uppercase tracking-[0.06em] text-content-muted">
-          Filters
-        </span>
+        <span className="text-meta uppercase tracking-[0.06em] text-content-muted">Filters</span>
         <input
           type="text"
           placeholder="Filter by skill..."
@@ -160,20 +155,14 @@ export default function InvocationsPage() {
           <tbody>
             {loading ? (
               <tr>
-                <td
-                  colSpan={6}
-                  className="px-3 py-8 text-center text-meta text-content-muted"
-                >
+                <td colSpan={6} className="px-3 py-8 text-center text-meta text-content-muted">
                   Loading...
                 </td>
               </tr>
             ) : rows.length === 0 ? (
               !error ? (
                 <tr>
-                  <td
-                    colSpan={6}
-                    className="px-3 py-8 text-center text-meta text-content-muted"
-                  >
+                  <td colSpan={6} className="px-3 py-8 text-center text-meta text-content-muted">
                     No invocations yet. Skills track here once they call{" "}
                     <code className="text-content-primary">li invoke start</code>.
                   </td>
@@ -204,9 +193,7 @@ export default function InvocationsPage() {
                         {inv.prompt ?? "(no prompt)"}
                       </div>
                     </td>
-                    <td className="px-3 py-2 align-middle tabular-nums">
-                      {inv.session_count}
-                    </td>
+                    <td className="px-3 py-2 align-middle tabular-nums">{inv.session_count}</td>
                     <td className="px-3 py-2 align-middle tabular-nums">
                       <Duration value={dur} />
                     </td>
@@ -229,16 +216,10 @@ export default function InvocationsPage() {
           offset {offset} · showing {rows.length}
         </div>
         <div className="flex gap-2">
-          <Button
-            onClick={() => setOffset(Math.max(0, offset - LIMIT))}
-            disabled={offset === 0}
-          >
+          <Button onClick={() => setOffset(Math.max(0, offset - LIMIT))} disabled={offset === 0}>
             Prev
           </Button>
-          <Button
-            onClick={() => setOffset(offset + LIMIT)}
-            disabled={!data?.has_next}
-          >
+          <Button onClick={() => setOffset(offset + LIMIT)} disabled={!data?.has_next}>
             Next
           </Button>
         </div>

--- a/apps/studio/frontend/app/plugins/page.tsx
+++ b/apps/studio/frontend/app/plugins/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import Badge from "@/components/Badge";
 import { listPlugins, getPlugin, getPluginSkill } from "@/lib/api";
 import type { PluginSummary, PluginDetail, PluginSkillDetail } from "@/lib/api";
+import { empty } from "@/lib/copy";
 
 const Markdown = dynamic(() => import("@/components/Markdown"), { ssr: false });
 
@@ -63,7 +64,7 @@ function PluginList({
           <div className="px-3 py-4 text-body text-content-muted">Loading...</div>
         ) : filtered.length === 0 ? (
           <div className="px-3 py-4 text-body text-content-muted">
-            {filter ? "No matching plugins" : "No plugins found"}
+            {filter ? empty.pluginsFiltered : empty.plugins}
           </div>
         ) : (
           filtered.map((p) => (
@@ -409,7 +410,11 @@ function PluginDetailPane({ pluginName }: PluginDetailPaneProps) {
 
       {/* Tab bar */}
       {tabs.length > 0 && (
-        <div role="tablist" aria-label="Plugin details" className="flex shrink-0 items-center gap-0 border-b border-edge px-4">
+        <div
+          role="tablist"
+          aria-label="Plugin details"
+          className="flex shrink-0 items-center gap-0 border-b border-edge px-4"
+        >
           {tabs.map((tab) => (
             <button
               key={tab.id}
@@ -434,31 +439,51 @@ function PluginDetailPane({ pluginName }: PluginDetailPaneProps) {
       {/* Tab content */}
       <div className="flex min-h-0 flex-1 overflow-hidden">
         {visibleTab === "skills" && (
-          <div role="tabpanel" id={`plugin-${detail.name}-panel-skills`} className="flex flex-1 overflow-hidden">
+          <div
+            role="tabpanel"
+            id={`plugin-${detail.name}-panel-skills`}
+            className="flex flex-1 overflow-hidden"
+          >
             <SkillSubPane key={detail.name} pluginName={detail.name} skillNames={detail.skills} />
           </div>
         )}
         {visibleTab === "agents" && (
-          <div role="tabpanel" id={`plugin-${detail.name}-panel-agents`} className="flex flex-1 overflow-hidden">
+          <div
+            role="tabpanel"
+            id={`plugin-${detail.name}-panel-agents`}
+            className="flex flex-1 overflow-hidden"
+          >
             <AgentSubPane key={detail.name} agentRefs={detail.agents} />
           </div>
         )}
         {visibleTab === "hooks" && detail.hooks && (
-          <div role="tabpanel" id={`plugin-${detail.name}-panel-hooks`} className="flex-1 overflow-y-auto px-4 py-3">
+          <div
+            role="tabpanel"
+            id={`plugin-${detail.name}-panel-hooks`}
+            className="flex-1 overflow-y-auto px-4 py-3"
+          >
             <pre className="whitespace-pre-wrap break-words rounded border border-edge bg-surface-base p-4 font-mono text-body text-content-secondary leading-relaxed">
               {JSON.stringify(detail.hooks, null, 2)}
             </pre>
           </div>
         )}
         {visibleTab === "mcp" && detail.mcp && (
-          <div role="tabpanel" id={`plugin-${detail.name}-panel-mcp`} className="flex-1 overflow-y-auto px-4 py-3">
+          <div
+            role="tabpanel"
+            id={`plugin-${detail.name}-panel-mcp`}
+            className="flex-1 overflow-y-auto px-4 py-3"
+          >
             <pre className="whitespace-pre-wrap break-words rounded border border-edge bg-surface-base p-4 font-mono text-body text-content-secondary leading-relaxed">
               {JSON.stringify(detail.mcp, null, 2)}
             </pre>
           </div>
         )}
         {visibleTab === "readme" && detail.readme && (
-          <div role="tabpanel" id={`plugin-${detail.name}-panel-readme`} className="flex-1 overflow-y-auto px-4 py-4">
+          <div
+            role="tabpanel"
+            id={`plugin-${detail.name}-panel-readme`}
+            className="flex-1 overflow-y-auto px-4 py-4"
+          >
             <Markdown>{detail.readme}</Markdown>
           </div>
         )}

--- a/apps/studio/frontend/app/projects/[name]/page.tsx
+++ b/apps/studio/frontend/app/projects/[name]/page.tsx
@@ -6,28 +6,21 @@ import { useRouter } from "next/navigation";
 import Button from "@/components/Button";
 import PageHeader from "@/components/PageHeader";
 import Timestamp from "@/components/Timestamp";
-import {
-  deleteProject,
-  getProject,
-  updateProject,
-} from "@/lib/api";
+import { deleteProject, getProject, updateProject } from "@/lib/api";
 import type { ProjectDetail } from "@/lib/types";
+import { errors } from "@/lib/copy";
 
 // Source badge colours mirror the list page
 const SOURCE_CLASS: Record<string, string> = {
-  config:
-    "border-status-running/40 bg-status-running-bg text-status-running",
-  override:
-    "border-status-warning/40 bg-status-warning-bg text-status-warning",
+  config: "border-status-running/40 bg-status-running-bg text-status-running",
+  override: "border-status-warning/40 bg-status-warning-bg text-status-warning",
   git: "border-status-selected/40 bg-status-selected-bg text-status-selected",
-  studio:
-    "border-status-success/40 bg-status-success-bg text-status-success",
+  studio: "border-status-success/40 bg-status-success-bg text-status-success",
 };
 
 function SourceBadge({ source }: { source: string }) {
   const cls =
-    SOURCE_CLASS[source.toLowerCase()] ??
-    "border-edge bg-surface-overlay text-content-secondary";
+    SOURCE_CLASS[source.toLowerCase()] ?? "border-edge bg-surface-overlay text-content-secondary";
   return (
     <span
       className={[
@@ -52,18 +45,14 @@ function UsageTable({
   if (rows.length === 0) {
     return (
       <section className="flex flex-col gap-2">
-        <h2 className="font-mono text-[13px] font-semibold text-content-primary">
-          {title}
-        </h2>
+        <h2 className="font-mono text-[13px] font-semibold text-content-primary">{title}</h2>
         <p className="text-meta text-content-muted">None recorded.</p>
       </section>
     );
   }
   return (
     <section className="flex flex-col gap-2">
-      <h2 className="font-mono text-[13px] font-semibold text-content-primary">
-        {title}
-      </h2>
+      <h2 className="font-mono text-[13px] font-semibold text-content-primary">{title}</h2>
       <div className="overflow-x-auto rounded border border-edge bg-surface-raised">
         <table className="w-full text-left text-body">
           <thead>
@@ -78,9 +67,7 @@ function UsageTable({
                 key={r.name}
                 className="border-b border-edge-subtle text-content-secondary hover:bg-surface-overlay transition-colors duration-100"
               >
-                <td className="px-3 py-2 font-mono text-[12px] text-content-primary">
-                  {r.name}
-                </td>
+                <td className="px-3 py-2 font-mono text-[12px] text-content-primary">{r.name}</td>
                 <td className="px-3 py-2 tabular-nums">{r.count}</td>
               </tr>
             ))}
@@ -129,17 +116,13 @@ function EditForm({
 
   return (
     <section className="flex flex-col gap-3">
-      <h2 className="font-mono text-[13px] font-semibold text-content-primary">
-        Edit Project
-      </h2>
+      <h2 className="font-mono text-[13px] font-semibold text-content-primary">Edit Project</h2>
       <form
         onSubmit={(e) => void handleSubmit(e)}
         className="flex flex-col gap-3 rounded border border-edge bg-surface-raised p-4"
       >
         <label className="flex flex-col gap-1">
-          <span className="text-meta text-content-secondary font-medium">
-            GitHub URL
-          </span>
+          <span className="text-meta text-content-secondary font-medium">GitHub URL</span>
           <input
             type="url"
             value={github}
@@ -149,9 +132,7 @@ function EditForm({
           />
         </label>
         <label className="flex flex-col gap-1">
-          <span className="text-meta text-content-secondary font-medium">
-            Description
-          </span>
+          <span className="text-meta text-content-secondary font-medium">Description</span>
           <textarea
             value={description}
             onChange={(e) => setDescription(e.target.value)}
@@ -161,9 +142,7 @@ function EditForm({
           />
         </label>
         {error && <p className="text-meta text-status-error">{error}</p>}
-        {saved && (
-          <p className="text-meta text-status-success">Saved.</p>
-        )}
+        {saved && <p className="text-meta text-status-success">Saved.</p>}
         <div className="flex justify-end">
           <Button variant="primary" type="submit" disabled={submitting}>
             {submitting ? "Saving..." : "Save"}
@@ -174,13 +153,7 @@ function EditForm({
   );
 }
 
-function DeleteButton({
-  name,
-  onDeleted,
-}: {
-  name: string;
-  onDeleted: () => void;
-}) {
+function DeleteButton({ name, onDeleted }: { name: string; onDeleted: () => void }) {
   const [confirming, setConfirming] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -202,19 +175,10 @@ function DeleteButton({
     return (
       <div className="flex items-center gap-2">
         <span className="text-meta text-content-muted">Delete &ldquo;{name}&rdquo;?</span>
-        <Button
-          variant="danger"
-          size="sm"
-          disabled={deleting}
-          onClick={() => void handleDelete()}
-        >
+        <Button variant="danger" size="sm" disabled={deleting} onClick={() => void handleDelete()}>
           {deleting ? "Deleting..." : "Confirm"}
         </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => setConfirming(false)}
-        >
+        <Button variant="ghost" size="sm" onClick={() => setConfirming(false)}>
           Cancel
         </Button>
         {error && <span className="text-meta text-status-error">{error}</span>}
@@ -248,7 +212,7 @@ function ProjectDetailInner({ params }: { params: Promise<{ name: string }> }) {
           setError(null);
         }
       } catch {
-        if (active) setError("Failed to load project.");
+        if (active) setError(errors.loadProject);
       } finally {
         if (active) setLoading(false);
       }
@@ -277,10 +241,7 @@ function ProjectDetailInner({ params }: { params: Promise<{ name: string }> }) {
         <div className="rounded border border-status-error/30 bg-status-error-bg px-3 py-2 text-body text-status-error">
           {error ?? "Project not found."}
         </div>
-        <Link
-          href="/projects"
-          className="text-meta text-status-running hover:underline"
-        >
+        <Link href="/projects" className="text-meta text-status-running hover:underline">
           Back to Projects
         </Link>
       </main>
@@ -319,15 +280,11 @@ function ProjectDetailInner({ params }: { params: Promise<{ name: string }> }) {
         {/* Info card */}
         <div className="flex flex-col gap-3 rounded border border-edge bg-surface-raised p-4">
           {project.description && (
-            <p className="text-body text-content-secondary">
-              {project.description}
-            </p>
+            <p className="text-body text-content-secondary">{project.description}</p>
           )}
           {project.github && (
             <div className="flex flex-col gap-0.5">
-              <span className="text-meta text-content-muted font-medium">
-                GitHub
-              </span>
+              <span className="text-meta text-content-muted font-medium">GitHub</span>
               <a
                 href={project.github}
                 target="_blank"
@@ -340,18 +297,17 @@ function ProjectDetailInner({ params }: { params: Promise<{ name: string }> }) {
           )}
           {project.path && (
             <div className="flex flex-col gap-0.5">
-              <span className="text-meta text-content-muted font-medium">
-                Path
-              </span>
-              <span className="font-mono text-[11px] text-content-secondary truncate" title={project.path}>
+              <span className="text-meta text-content-muted font-medium">Path</span>
+              <span
+                className="font-mono text-[11px] text-content-secondary truncate"
+                title={project.path}
+              >
                 {project.path}
               </span>
             </div>
           )}
           <div className="flex flex-col gap-0.5">
-            <span className="text-meta text-content-muted font-medium">
-              Last seen
-            </span>
+            <span className="text-meta text-content-muted font-medium">Last seen</span>
             <span className="text-meta text-content-secondary">
               <Timestamp value={project.last_seen_at ?? project.updated_at} />
             </span>
@@ -361,9 +317,7 @@ function ProjectDetailInner({ params }: { params: Promise<{ name: string }> }) {
         {/* Stats card */}
         <div className="flex flex-col gap-3 rounded border border-edge bg-surface-raised p-4">
           <div className="flex flex-col gap-0.5">
-            <span className="text-meta text-content-muted font-medium">
-              Sessions
-            </span>
+            <span className="text-meta text-content-muted font-medium">Sessions</span>
             <Link
               href={`/runs?project=${encodeURIComponent(project.name)}`}
               className="text-xl font-semibold text-content-primary tabular-nums hover:text-status-running transition-colors"
@@ -373,18 +327,14 @@ function ProjectDetailInner({ params }: { params: Promise<{ name: string }> }) {
           </div>
           {project.running_count > 0 && (
             <div className="flex flex-col gap-0.5">
-              <span className="text-meta text-content-muted font-medium">
-                Running now
-              </span>
+              <span className="text-meta text-content-muted font-medium">Running now</span>
               <span className="text-xl font-semibold text-status-running tabular-nums">
                 {project.running_count}
               </span>
             </div>
           )}
           <div className="flex flex-col gap-0.5">
-            <span className="text-meta text-content-muted font-medium">
-              Created
-            </span>
+            <span className="text-meta text-content-muted font-medium">Created</span>
             <span className="text-meta text-content-secondary">
               <Timestamp value={project.created_at} />
             </span>
@@ -393,36 +343,20 @@ function ProjectDetailInner({ params }: { params: Promise<{ name: string }> }) {
       </div>
 
       {/* Usage tables */}
-      <UsageTable
-        title="Agents Used"
-        rows={agentRows}
-        nameLabel="Agent"
-      />
-      <UsageTable
-        title="Playbooks Used"
-        rows={playbookRows}
-        nameLabel="Playbook"
-      />
+      <UsageTable title="Agents Used" rows={agentRows} nameLabel="Agent" />
+      <UsageTable title="Playbooks Used" rows={playbookRows} nameLabel="Playbook" />
 
       {/* Editable controls */}
       {project.editable && (
-        <EditForm
-          project={project}
-          onSaved={(updated) => setProject(updated)}
-        />
+        <EditForm project={project} onSaved={(updated) => setProject(updated)} />
       )}
 
       {/* Delete (studio-managed only — source === "studio") */}
       {project.source === "studio" && (
         <section className="flex flex-col gap-2">
-          <h2 className="font-mono text-[13px] font-semibold text-content-primary">
-            Danger Zone
-          </h2>
+          <h2 className="font-mono text-[13px] font-semibold text-content-primary">Danger Zone</h2>
           <div className="rounded border border-status-error/30 bg-status-error-bg p-4">
-            <DeleteButton
-              name={project.name}
-              onDeleted={() => router.push("/projects")}
-            />
+            <DeleteButton name={project.name} onDeleted={() => router.push("/projects")} />
           </div>
         </section>
       )}
@@ -430,11 +364,7 @@ function ProjectDetailInner({ params }: { params: Promise<{ name: string }> }) {
   );
 }
 
-export default function ProjectDetailPage({
-  params,
-}: {
-  params: Promise<{ name: string }>;
-}) {
+export default function ProjectDetailPage({ params }: { params: Promise<{ name: string }> }) {
   return (
     <Suspense>
       <ProjectDetailInner params={params} />

--- a/apps/studio/frontend/app/projects/page.tsx
+++ b/apps/studio/frontend/app/projects/page.tsx
@@ -6,29 +6,22 @@ import { useRouter } from "next/navigation";
 import Button from "@/components/Button";
 import PageHeader from "@/components/PageHeader";
 import Timestamp from "@/components/Timestamp";
-import {
-  createProject,
-  listProjects,
-  type ProjectListResponse,
-} from "@/lib/api";
+import { createProject, listProjects, type ProjectListResponse } from "@/lib/api";
 import type { ProjectSummary } from "@/lib/types";
+import { errors } from "@/lib/copy";
 
 // Source badge colours follow the same design vocabulary as StatusPill
 // but are simpler (no icon, static colours per source type).
 const SOURCE_CLASS: Record<string, string> = {
-  config:
-    "border-status-running/40 bg-status-running-bg text-status-running",
-  override:
-    "border-status-warning/40 bg-status-warning-bg text-status-warning",
+  config: "border-status-running/40 bg-status-running-bg text-status-running",
+  override: "border-status-warning/40 bg-status-warning-bg text-status-warning",
   git: "border-status-selected/40 bg-status-selected-bg text-status-selected",
-  studio:
-    "border-status-success/40 bg-status-success-bg text-status-success",
+  studio: "border-status-success/40 bg-status-success-bg text-status-success",
 };
 
 function SourceBadge({ source }: { source: string }) {
   const cls =
-    SOURCE_CLASS[source.toLowerCase()] ??
-    "border-edge bg-surface-overlay text-content-secondary";
+    SOURCE_CLASS[source.toLowerCase()] ?? "border-edge bg-surface-overlay text-content-secondary";
   return (
     <span
       className={[
@@ -57,7 +50,7 @@ function CreateProjectModal({
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!name.trim()) {
-      setError("Name is required.");
+      setError(errors.nameRequired);
       return;
     }
     setSubmitting(true);
@@ -85,9 +78,7 @@ function CreateProjectModal({
       }}
     >
       <div className="w-full max-w-md rounded-lg border border-edge bg-surface-raised shadow-card p-5">
-        <h2 className="mb-4 font-mono text-base font-semibold text-content-primary">
-          New Project
-        </h2>
+        <h2 className="mb-4 font-mono text-base font-semibold text-content-primary">New Project</h2>
         <form onSubmit={(e) => void handleSubmit(e)} className="flex flex-col gap-3">
           <label className="flex flex-col gap-1">
             <span className="text-meta text-content-secondary font-medium">
@@ -102,9 +93,7 @@ function CreateProjectModal({
             />
           </label>
           <label className="flex flex-col gap-1">
-            <span className="text-meta text-content-secondary font-medium">
-              GitHub URL
-            </span>
+            <span className="text-meta text-content-secondary font-medium">GitHub URL</span>
             <input
               type="url"
               value={github}
@@ -114,9 +103,7 @@ function CreateProjectModal({
             />
           </label>
           <label className="flex flex-col gap-1">
-            <span className="text-meta text-content-secondary font-medium">
-              Description
-            </span>
+            <span className="text-meta text-content-secondary font-medium">Description</span>
             <textarea
               value={description}
               onChange={(e) => setDescription(e.target.value)}
@@ -125,9 +112,7 @@ function CreateProjectModal({
               className="rounded border border-edge bg-surface-base px-2.5 py-1.5 text-body text-content-primary placeholder:text-content-muted focus:border-interactive-primary focus:outline-none resize-none"
             />
           </label>
-          {error && (
-            <p className="text-meta text-status-error">{error}</p>
-          )}
+          {error && <p className="text-meta text-status-error">{error}</p>}
           <div className="flex justify-end gap-2 pt-1">
             <Button variant="ghost" onClick={onClose} type="button">
               Cancel
@@ -166,9 +151,7 @@ function ProjectCard({ project }: { project: ProjectSummary }) {
 
       {/* Description */}
       {project.description && (
-        <p className="text-meta text-content-secondary truncate">
-          {project.description}
-        </p>
+        <p className="text-meta text-content-secondary truncate">{project.description}</p>
       )}
 
       {/* GitHub link */}
@@ -194,15 +177,11 @@ function ProjectCard({ project }: { project: ProjectSummary }) {
       {/* Stats row */}
       <div className="flex items-center gap-3 text-meta text-content-muted">
         <span>
-          <span className="font-medium text-content-secondary">
-            {project.session_count}
-          </span>{" "}
+          <span className="font-medium text-content-secondary">{project.session_count}</span>{" "}
           session{project.session_count !== 1 ? "s" : ""}
         </span>
         {project.running_count > 0 && (
-          <span className="text-status-running font-medium">
-            {project.running_count} running
-          </span>
+          <span className="text-status-running font-medium">{project.running_count} running</span>
         )}
         <span className="ml-auto">
           <Timestamp value={project.last_seen_at ?? project.updated_at} />
@@ -224,9 +203,7 @@ function UnassignedCard({ count }: { count: number }) {
           {count}
         </span>
       </div>
-      <p className="text-meta">
-        Sessions not associated with any project.
-      </p>
+      <p className="text-meta">Sessions not associated with any project.</p>
     </Link>
   );
 }
@@ -253,7 +230,7 @@ function ProjectsPageInner() {
       setData(result);
       setError(null);
     } catch {
-      setError("Failed to load projects.");
+      setError(errors.loadProjects);
     } finally {
       setLoading(false);
     }
@@ -262,7 +239,6 @@ function ProjectsPageInner() {
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- async data fetch sets state in callback, not synchronously
     void load();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const projects = data?.projects ?? [];
@@ -305,8 +281,8 @@ function ProjectsPageInner() {
           <div className="col-span-full py-14 text-center text-body text-content-muted">
             <span className="block mb-1">No projects found.</span>
             <span className="text-meta">
-              Create one or run{" "}
-              <code className="font-mono">li agent</code> inside a project directory.
+              Create one or run <code className="font-mono">li agent</code> inside a project
+              directory.
             </span>
           </div>
         ) : (
@@ -320,10 +296,7 @@ function ProjectsPageInner() {
       </div>
 
       {showModal && (
-        <CreateProjectModal
-          onClose={() => setShowModal(false)}
-          onCreated={() => void load()}
-        />
+        <CreateProjectModal onClose={() => setShowModal(false)} onCreated={() => void load()} />
       )}
     </main>
   );

--- a/apps/studio/frontend/app/runs/[id]/page.tsx
+++ b/apps/studio/frontend/app/runs/[id]/page.tsx
@@ -9,6 +9,7 @@ import RunStepCard from "@/components/RunStepCard";
 import { getSession, streamSession } from "@/lib/api";
 import type { SessionDetail, SessionBranch, SessionMessage } from "@/lib/api";
 import type { RunMessage, RunStep, WorkerGraph } from "@/lib/types";
+import { empty } from "@/lib/copy";
 
 const WorkerCanvas = dynamic(() => import("@/components/canvas/WorkerCanvas"), { ssr: false });
 
@@ -355,7 +356,7 @@ function ErrorsSection({ errors }: { errors: ErrorEntry[] }) {
       <SectionHeader label="Errors" count={errors.length} errorTone={errors.length > 0} />
       {errors.length === 0 ? (
         <div className="flex items-center gap-2 rounded border border-edge bg-surface-raised px-4 py-3 text-sm text-status-success">
-          <span>No errors detected across all branches.</span>
+          <span>{empty.branchErrors}</span>
         </div>
       ) : (
         <div className="flex flex-col gap-1.5">

--- a/apps/studio/frontend/app/runs/[id]/page.tsx
+++ b/apps/studio/frontend/app/runs/[id]/page.tsx
@@ -4,6 +4,7 @@ import dynamic from "next/dynamic";
 import Link from "next/link";
 import { use, useEffect, useMemo, useRef, useState } from "react";
 import Badge from "@/components/Badge";
+import ExpectedArtifacts from "@/components/runs/ExpectedArtifacts";
 import RunStepCard from "@/components/RunStepCard";
 import { getSession, streamSession } from "@/lib/api";
 import type { SessionDetail, SessionBranch, SessionMessage } from "@/lib/api";
@@ -527,7 +528,12 @@ export default function RunDetailPage({ params }: { params: Promise<{ id: string
           | null
           | undefined;
         if (graph && graph.nodes && graph.nodes.length > 0) {
-          setRunGraph({ name: s.name || id, description: "", nodes: graph.nodes, edges: graph.edges });
+          setRunGraph({
+            name: s.name || id,
+            description: "",
+            nodes: graph.nodes,
+            edges: graph.edges,
+          });
         }
       })
       .catch((e: unknown) => setError(String(e)));
@@ -589,7 +595,7 @@ export default function RunDetailPage({ params }: { params: Promise<{ id: string
 
   // Track active section on scroll
   useEffect(() => {
-    const sectionIds = ["overview", "dag", "branches", "errors", "files"];
+    const sectionIds = ["overview", "expected-artifacts", "dag", "branches", "errors", "files"];
     const onScroll = () => {
       for (const sid of [...sectionIds].reverse()) {
         const el = document.getElementById(sid);
@@ -617,9 +623,24 @@ export default function RunDetailPage({ params }: { params: Promise<{ id: string
 
   // Segments from session metadata — maps op executions to branch time windows
   const segments = useMemo(() => {
-    if (!session) return [] as Array<{ op_id: string; branch_id: string; branch_name: string; status: string; started_at: number | null; ended_at: number | null }>;
+    if (!session)
+      return [] as Array<{
+        op_id: string;
+        branch_id: string;
+        branch_name: string;
+        status: string;
+        started_at: number | null;
+        ended_at: number | null;
+      }>;
     const raw = (session as unknown as Record<string, unknown>).segments;
-    return (Array.isArray(raw) ? raw : []) as Array<{ op_id: string; branch_id: string; branch_name: string; status: string; started_at: number | null; ended_at: number | null }>;
+    return (Array.isArray(raw) ? raw : []) as Array<{
+      op_id: string;
+      branch_id: string;
+      branch_name: string;
+      status: string;
+      started_at: number | null;
+      ended_at: number | null;
+    }>;
   }, [session]);
 
   const steps = useMemo(() => {
@@ -641,7 +662,11 @@ export default function RunDetailPage({ params }: { params: Promise<{ id: string
             const before = seg.ended_at == null || ts <= seg.ended_at + 1;
             return after && before;
           });
-          const segBranch = { ...b, messages: segMsgs, name: `${b.name || b.id.slice(0, 8)} [${seg.op_id}]` };
+          const segBranch = {
+            ...b,
+            messages: segMsgs,
+            name: `${b.name || b.id.slice(0, 8)} [${seg.op_id}]`,
+          };
           result.push(branchToRunStep(segBranch, seg.status || bStatus || sessionStatus));
         }
       }
@@ -751,8 +776,12 @@ export default function RunDetailPage({ params }: { params: Promise<{ id: string
       | undefined,
   };
 
+  const expectedArtifactsCount = session.artifact_contract_json?.expected?.length ?? 0;
   const navSections: NavSection[] = [
     { id: "overview", label: "Overview" },
+    ...(expectedArtifactsCount > 0
+      ? [{ id: "expected-artifacts", label: "Expected artifacts", count: expectedArtifactsCount }]
+      : []),
     ...(runGraph ? [{ id: "dag", label: "DAG", count: runGraph.nodes.length }] : []),
     { id: "branches", label: "Branches", count: session.branches.length },
     { id: "errors", label: "Errors", count: errors.length, errorTone: errors.length > 0 },
@@ -834,6 +863,10 @@ export default function RunDetailPage({ params }: { params: Promise<{ id: string
         <main className="min-w-0 flex-1">
           <div className="flex flex-col gap-8">
             <OverviewSection data={overviewData} />
+            <ExpectedArtifacts
+              contract={session.artifact_contract_json}
+              verification={session.artifact_verification_json}
+            />
             {runGraph && (
               <div id="dag" className="scroll-mt-24">
                 <SectionHeader label="Execution DAG" count={runGraph.nodes.length} />

--- a/apps/studio/frontend/app/runs/page.tsx
+++ b/apps/studio/frontend/app/runs/page.tsx
@@ -11,6 +11,7 @@ import Timestamp from "@/components/Timestamp";
 import { listRuns } from "@/lib/api";
 import type { RunListResponse } from "@/lib/api";
 import type { RunSummary } from "@/lib/types";
+import { errors } from "@/lib/copy";
 
 // ADR-0025: six-value session vocabulary (running/completed/failed/
 // timed_out/aborted/cancelled). "done" stays as an alias for completed
@@ -47,9 +48,10 @@ function groupByInvocation(runs: RunSummary[]): {
       ungrouped.push(run);
     }
   }
-  const groups: InvocationGroup[] = Array.from(map.entries()).map(
-    ([invocation_id, sessions]) => ({ invocation_id, sessions }),
-  );
+  const groups: InvocationGroup[] = Array.from(map.entries()).map(([invocation_id, sessions]) => ({
+    invocation_id,
+    sessions,
+  }));
   return { groups, ungrouped };
 }
 
@@ -83,8 +85,7 @@ function groupStatus(sessions: RunSummary[]): string {
   if (sessions.some((s) => s.status === "failed")) return "failed";
   if (sessions.some((s) => s.status === "timed_out")) return "timed_out";
   if (sessions.some((s) => s.status === "aborted")) return "aborted";
-  if (sessions.every((s) => s.status === "done" || s.status === "completed"))
-    return "done";
+  if (sessions.every((s) => s.status === "done" || s.status === "completed")) return "done";
   return sessions[0]?.status ?? "pending";
 }
 
@@ -161,9 +162,7 @@ function SessionRow({
           {displayName(run)}
         </Link>
         <div className="flex items-center gap-1.5">
-          <span className="font-mono text-meta text-content-muted">
-            {shortRunId(run)}
-          </span>
+          <span className="font-mono text-meta text-content-muted">{shortRunId(run)}</span>
           {run.project && (
             <span
               className="rounded px-1 py-0.5 font-mono text-[10px] border border-edge text-content-muted"
@@ -217,9 +216,7 @@ function RunsPageInner() {
   const [playbookInput, setPlaybookInput] = useState(playbook);
   const [now, setNow] = useState(() => Math.floor(Date.now() / 1000));
   const [viewMode, setViewMode] = useState<ViewMode>("sessions");
-  const [expandedInvocations, setExpandedInvocations] = useState<Set<string>>(
-    new Set(),
-  );
+  const [expandedInvocations, setExpandedInvocations] = useState<Set<string>>(new Set());
   const [knownProjects, setKnownProjects] = useState<string[]>([]);
 
   // eslint-disable-next-line react-hooks/set-state-in-effect -- sync URL→input: no external system involved, single derived state write
@@ -234,10 +231,8 @@ function RunsPageInner() {
     const params = new URLSearchParams();
     const nextPage = next.page ?? 1;
     const nextStatuses = next.status ?? statuses;
-    const nextPlaybook =
-      next.playbook !== undefined ? next.playbook : playbook;
-    const nextProject =
-      next.project !== undefined ? next.project : project;
+    const nextPlaybook = next.playbook !== undefined ? next.playbook : playbook;
+    const nextProject = next.project !== undefined ? next.project : project;
     if (nextPage > 1) params.set("page", String(nextPage));
     for (const s of nextStatuses) params.append("status", s);
     if (nextPlaybook) params.set("playbook", nextPlaybook);
@@ -280,7 +275,7 @@ function RunsPageInner() {
           }
         }
       } catch {
-        if (active) setError("Failed to load runs");
+        if (active) setError(errors.loadRuns);
       } finally {
         if (active) setLoading(false);
       }
@@ -296,17 +291,12 @@ function RunsPageInner() {
   }, [page, statuses.join(","), playbook, project, viewMode]);
 
   useEffect(() => {
-    const tick = setInterval(
-      () => setNow(Math.floor(Date.now() / 1000)),
-      30000,
-    );
+    const tick = setInterval(() => setNow(Math.floor(Date.now() / 1000)), 30000);
     return () => clearInterval(tick);
   }, []);
 
   function toggleStatus(s: string) {
-    const next = statuses.includes(s)
-      ? statuses.filter((x) => x !== s)
-      : [...statuses, s];
+    const next = statuses.includes(s) ? statuses.filter((x) => x !== s) : [...statuses, s];
     setQuery({ status: next, page: 1 });
   }
 
@@ -385,9 +375,7 @@ function RunsPageInner() {
                   size="sm"
                   variant="toggle"
                   active={project === p}
-                  onClick={() =>
-                    setQuery({ project: project === p ? "" : p, page: 1 })
-                  }
+                  onClick={() => setQuery({ project: project === p ? "" : p, page: 1 })}
                 >
                   {p}
                 </Button>
@@ -466,34 +454,24 @@ function RunsPageInner() {
             ) : viewMode === "invocations" ? (
               invocationGroups.length === 0 && ungroupedRuns.length === 0 ? (
                 <tr>
-                  <td
-                    colSpan={4}
-                    className="px-3 py-14 text-center text-body text-content-muted"
-                  >
+                  <td colSpan={4} className="px-3 py-14 text-center text-body text-content-muted">
                     <span className="block mb-1 text-[11px]">No runs found</span>
                     {(statuses.length > 0 || playbook) && (
-                      <span className="text-meta">
-                        Try adjusting your filters.
-                      </span>
+                      <span className="text-meta">Try adjusting your filters.</span>
                     )}
                   </td>
                 </tr>
               ) : (
                 <>
                   {invocationGroups.map((group) => {
-                    const isExpanded = expandedInvocations.has(
-                      group.invocation_id,
-                    );
+                    const isExpanded = expandedInvocations.has(group.invocation_id);
                     const st = groupStatus(group.sessions);
                     const health = worstHealth(group.sessions);
-                    const latestUpdated = group.sessions.reduce<number | null>(
-                      (acc, s) => {
-                        const u = s.updated_at ?? null;
-                        if (u === null) return acc;
-                        return acc === null || u > acc ? u : acc;
-                      },
-                      null,
-                    );
+                    const latestUpdated = group.sessions.reduce<number | null>((acc, s) => {
+                      const u = s.updated_at ?? null;
+                      if (u === null) return acc;
+                      return acc === null || u > acc ? u : acc;
+                    }, null);
                     return (
                       <Fragment key={group.invocation_id}>
                         <tr
@@ -531,12 +509,7 @@ function RunsPageInner() {
                         </tr>
                         {isExpanded &&
                           group.sessions.map((run) => (
-                            <SessionRow
-                              key={run.run_id}
-                              run={run}
-                              now={now}
-                              indent
-                            />
+                            <SessionRow key={run.run_id} run={run} now={now} indent />
                           ))}
                       </Fragment>
                     );
@@ -556,39 +529,39 @@ function RunsPageInner() {
                 </td>
               </tr>
             ) : (
-              runs.map((run) => (
-                <SessionRow key={run.run_id} run={run} now={now} />
-              ))
+              runs.map((run) => <SessionRow key={run.run_id} run={run} now={now} />)
             )}
           </tbody>
         </table>
       </div>
 
       {/* Pagination — hidden in invocations mode (full dataset loaded client-side) */}
-      {viewMode === "sessions" && <div className="flex items-center justify-between text-meta text-content-muted">
-        <span>
-          Page {page} of {totalPages || 1} &mdash; {total} run
-          {total !== 1 ? "s" : ""}
-        </span>
-        <div className="flex gap-2">
-          <Button
-            size="sm"
-            variant="secondary"
-            disabled={!data?.has_prev}
-            onClick={() => setQuery({ page: page - 1 })}
-          >
-            Previous
-          </Button>
-          <Button
-            size="sm"
-            variant="secondary"
-            disabled={!data?.has_next}
-            onClick={() => setQuery({ page: page + 1 })}
-          >
-            Next
-          </Button>
+      {viewMode === "sessions" && (
+        <div className="flex items-center justify-between text-meta text-content-muted">
+          <span>
+            Page {page} of {totalPages || 1} &mdash; {total} run
+            {total !== 1 ? "s" : ""}
+          </span>
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              variant="secondary"
+              disabled={!data?.has_prev}
+              onClick={() => setQuery({ page: page - 1 })}
+            >
+              Previous
+            </Button>
+            <Button
+              size="sm"
+              variant="secondary"
+              disabled={!data?.has_next}
+              onClick={() => setQuery({ page: page + 1 })}
+            >
+              Next
+            </Button>
+          </div>
         </div>
-      </div>}
+      )}
     </main>
   );
 }

--- a/apps/studio/frontend/app/runs/page.tsx
+++ b/apps/studio/frontend/app/runs/page.tsx
@@ -11,7 +11,7 @@ import Timestamp from "@/components/Timestamp";
 import { listRuns } from "@/lib/api";
 import type { RunListResponse } from "@/lib/api";
 import type { RunSummary } from "@/lib/types";
-import { errors } from "@/lib/copy";
+import { empty, errors } from "@/lib/copy";
 
 // ADR-0025: six-value session vocabulary (running/completed/failed/
 // timed_out/aborted/cancelled). "done" stays as an alias for completed
@@ -455,7 +455,7 @@ function RunsPageInner() {
               invocationGroups.length === 0 && ungroupedRuns.length === 0 ? (
                 <tr>
                   <td colSpan={4} className="px-3 py-14 text-center text-body text-content-muted">
-                    <span className="block mb-1 text-[11px]">No runs found</span>
+                    <span className="block mb-1 text-[11px]">{empty.runs}</span>
                     {(statuses.length > 0 || playbook) && (
                       <span className="text-meta">Try adjusting your filters.</span>
                     )}
@@ -522,7 +522,7 @@ function RunsPageInner() {
             ) : runs.length === 0 ? (
               <tr>
                 <td colSpan={6} className="px-3 py-14 text-center text-body text-content-muted">
-                  <span className="block mb-1 text-[11px]">No runs found</span>
+                  <span className="block mb-1 text-[11px]">{empty.runs}</span>
                   {(statuses.length > 0 || playbook) && (
                     <span className="text-meta">Try adjusting your filters.</span>
                   )}

--- a/apps/studio/frontend/app/schedules/page.tsx
+++ b/apps/studio/frontend/app/schedules/page.tsx
@@ -16,6 +16,7 @@ import {
   type ScheduleListResponse,
 } from "@/lib/api";
 import type { ScheduleRunSummary, ScheduleSummary } from "@/lib/types";
+import { empty, errors } from "@/lib/copy";
 
 // ─── Badge helpers ────────────────────────────────────────────────────────────
 
@@ -26,8 +27,7 @@ const TRIGGER_CLASS: Record<string, string> = {
 };
 
 function TriggerBadge({ type }: { type: string }) {
-  const cls =
-    TRIGGER_CLASS[type] ?? "border-edge bg-surface-overlay text-content-secondary";
+  const cls = TRIGGER_CLASS[type] ?? "border-edge bg-surface-overlay text-content-secondary";
   const label = type === "github_poll" ? "github" : type;
   return (
     <span
@@ -113,9 +113,7 @@ function EnabledToggle({
       title={enabled ? "Click to disable" : "Click to enable"}
       className={[
         "relative inline-flex h-4 w-7 shrink-0 items-center rounded-full border transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-interactive-primary focus:ring-offset-1 focus:ring-offset-surface-base",
-        enabled
-          ? "border-status-success/50 bg-status-success"
-          : "border-edge bg-surface-overlay",
+        enabled ? "border-status-success/50 bg-status-success" : "border-edge bg-surface-overlay",
         busy ? "opacity-60 cursor-not-allowed" : "cursor-pointer",
       ]
         .filter(Boolean)
@@ -162,10 +160,7 @@ function ScheduleCard({
   }
 
   const actionDetail =
-    schedule.action_model ??
-    schedule.action_playbook ??
-    schedule.action_agent ??
-    null;
+    schedule.action_model ?? schedule.action_playbook ?? schedule.action_agent ?? null;
 
   return (
     <div
@@ -183,16 +178,10 @@ function ScheduleCard({
             {schedule.name}
           </span>
           {schedule.description && (
-            <p className="truncate text-meta text-content-secondary">
-              {schedule.description}
-            </p>
+            <p className="truncate text-meta text-content-secondary">{schedule.description}</p>
           )}
         </div>
-        <EnabledToggle
-          scheduleId={schedule.id}
-          enabled={enabled}
-          onToggled={onRefresh}
-        />
+        <EnabledToggle scheduleId={schedule.id} enabled={enabled} onToggled={onRefresh} />
       </div>
 
       {/* Badge row */}
@@ -209,19 +198,14 @@ function ScheduleCard({
       {/* Trigger detail */}
       <div className="text-meta text-content-secondary">
         {schedule.trigger_type === "cron" && schedule.cron_expr && (
-          <span className="font-mono text-[11px] text-content-muted">
-            {schedule.cron_expr}
-          </span>
+          <span className="font-mono text-[11px] text-content-muted">{schedule.cron_expr}</span>
         )}
         {schedule.trigger_type === "interval" && schedule.interval_sec != null && (
           <span>Every {formatInterval(schedule.interval_sec)}</span>
         )}
         {schedule.trigger_type === "github_poll" && schedule.github_repo && (
           <span className="truncate text-[11px]">
-            Polling{" "}
-            <span className="font-mono text-content-primary">
-              {schedule.github_repo}
-            </span>
+            Polling <span className="font-mono text-content-primary">{schedule.github_repo}</span>
             {schedule.poll_interval_sec != null && (
               <span className="text-content-muted">
                 {" "}
@@ -250,11 +234,7 @@ function ScheduleCard({
 
       {/* Actions row */}
       <div className="flex items-center justify-between gap-2 border-t border-edge pt-2.5">
-        {triggerMsg ? (
-          <span className="text-meta text-content-muted">{triggerMsg}</span>
-        ) : (
-          <span />
-        )}
+        {triggerMsg ? <span className="text-meta text-content-muted">{triggerMsg}</span> : <span />}
         <Button
           variant="ghost"
           size="sm"
@@ -284,11 +264,7 @@ function SkeletonCard() {
 
 function RecentRunsTable({ runs }: { runs: ScheduleRunSummary[] }) {
   if (runs.length === 0) {
-    return (
-      <p className="py-6 text-center text-body text-content-muted">
-        No recent runs.
-      </p>
-    );
+    return <p className="py-6 text-center text-body text-content-muted">No recent runs.</p>;
   }
 
   return (
@@ -463,7 +439,7 @@ function CreateScheduleModal({
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!form.name.trim()) {
-      setError("Name is required.");
+      setError(errors.nameRequired);
       return;
     }
     setSubmitting(true);
@@ -490,9 +466,7 @@ function CreateScheduleModal({
       <div className="w-full max-w-lg rounded-lg border border-edge bg-surface-raised shadow-card mx-4">
         {/* Modal header */}
         <div className="flex items-center justify-between border-b border-edge px-5 py-4">
-          <h2 className="font-mono text-base font-semibold text-content-primary">
-            New Schedule
-          </h2>
+          <h2 className="font-mono text-base font-semibold text-content-primary">New Schedule</h2>
           <button
             type="button"
             onClick={onClose}
@@ -504,10 +478,7 @@ function CreateScheduleModal({
         </div>
 
         {/* Form body */}
-        <form
-          onSubmit={(e) => void handleSubmit(e)}
-          className="flex flex-col gap-3 px-5 py-4"
-        >
+        <form onSubmit={(e) => void handleSubmit(e)} className="flex flex-col gap-3 px-5 py-4">
           {/* — Basic info — */}
           <SectionHeading>Basic Info</SectionHeading>
 
@@ -769,9 +740,7 @@ function EmptyState({ onNew }: { onNew: () => void }) {
       <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full border border-edge bg-surface-raised text-content-muted text-xl">
         ◷
       </div>
-      <p className="mb-1 text-body font-medium text-content-secondary">
-        No schedules yet
-      </p>
+      <p className="mb-1 text-body font-medium text-content-secondary">{empty.schedules}</p>
       <p className="mb-4 text-meta text-content-muted">
         Create a schedule to automate agent runs on cron, interval, or GitHub events.
       </p>
@@ -818,7 +787,7 @@ function SchedulesPageInner() {
         setRunsLoading(false);
       }
     } catch {
-      setError("Failed to load schedules.");
+      setError(errors.loadSchedules);
     } finally {
       setLoading(false);
     }
@@ -827,7 +796,6 @@ function SchedulesPageInner() {
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- load() calls setState, but this is a data-fetch pattern matching the rest of the codebase
     void load();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const schedules = data?.schedules ?? [];
@@ -879,12 +847,8 @@ function SchedulesPageInner() {
       {!loading && schedules.length > 0 && (
         <section className="flex flex-col gap-3">
           <div className="flex items-center justify-between border-t border-edge pt-4">
-            <h2 className="font-mono text-sm font-semibold text-content-primary">
-              Recent Runs
-            </h2>
-            {runsLoading && (
-              <span className="text-meta text-content-muted">Loading...</span>
-            )}
+            <h2 className="font-mono text-sm font-semibold text-content-primary">Recent Runs</h2>
+            {runsLoading && <span className="text-meta text-content-muted">Loading...</span>}
           </div>
           <div className="rounded-lg border border-edge bg-surface-raised p-4 shadow-card">
             <RecentRunsTable runs={recentRuns} />
@@ -893,10 +857,7 @@ function SchedulesPageInner() {
       )}
 
       {showModal && (
-        <CreateScheduleModal
-          onClose={() => setShowModal(false)}
-          onCreated={() => void load()}
-        />
+        <CreateScheduleModal onClose={() => setShowModal(false)} onCreated={() => void load()} />
       )}
     </main>
   );

--- a/apps/studio/frontend/app/shows/[topic]/page.tsx
+++ b/apps/studio/frontend/app/shows/[topic]/page.tsx
@@ -10,6 +10,7 @@ import StatusPill from "@/components/StatusPill";
 import Timestamp from "@/components/Timestamp";
 import { getShow, streamShow } from "@/lib/api";
 import type { PlayMeta, ShowDetail, ShowEvent } from "@/lib/types";
+import { empty } from "@/lib/copy";
 
 const Markdown = dynamic(() => import("@/components/Markdown"), { ssr: false });
 const PlayDag = dynamic(() => import("./components/PlayDag"), { ssr: false });
@@ -538,7 +539,7 @@ function ShowSummaryPanel({
             />
           </dl>
         ) : (
-          <p className="mt-2 text-body text-content-muted">No plays yet.</p>
+          <p className="mt-2 text-body text-content-muted">{empty.plays}</p>
         )}
       </section>
 

--- a/apps/studio/frontend/app/shows/page.tsx
+++ b/apps/studio/frontend/app/shows/page.tsx
@@ -6,6 +6,7 @@ import Badge from "@/components/Badge";
 import Table, { type TableColumn } from "@/components/Table";
 import { listShows } from "@/lib/api";
 import type { ShowSummary } from "@/lib/types";
+import { empty } from "@/lib/copy";
 
 function formatLastUpdate(ts: number | string | null): string {
   if (!ts) return "—";
@@ -101,7 +102,7 @@ export default function ShowsPage() {
       <Table
         data={shows}
         columns={columns}
-        emptyMessage={loading ? "Loading shows..." : "No shows found."}
+        emptyMessage={loading ? empty.loadingShows : empty.shows}
         getRowKey={(row) => row.topic}
         onRowClick={(row) => router.push(`/shows/${encodeURIComponent(row.topic)}`)}
       />

--- a/apps/studio/frontend/app/skills/page.tsx
+++ b/apps/studio/frontend/app/skills/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import Badge from "@/components/Badge";
 import { listSkills, getSkill } from "@/lib/api";
 import type { SkillSummary, SkillDetail } from "@/lib/api";
+import { empty } from "@/lib/copy";
 
 export default function SkillsPage() {
   const [skills, setSkills] = useState<SkillSummary[]>([]);
@@ -91,7 +92,7 @@ export default function SkillsPage() {
             <div className="px-3 py-4 text-body text-content-muted">Loading...</div>
           ) : filtered.length === 0 ? (
             <div className="px-3 py-4 text-body text-content-muted">
-              {filter ? "No matching skills" : "No skills found"}
+              {filter ? empty.skillsFiltered : empty.skills}
             </div>
           ) : (
             filtered.map((s) => (

--- a/apps/studio/frontend/app/teams/[id]/page.tsx
+++ b/apps/studio/frontend/app/teams/[id]/page.tsx
@@ -6,6 +6,7 @@ import PageHeader from "@/components/PageHeader";
 import Timestamp from "@/components/Timestamp";
 import { getTeam } from "@/lib/api";
 import type { TeamDetail } from "@/lib/api";
+import { errors } from "@/lib/copy";
 
 function JsonTree({ value }: { value: unknown }) {
   return (
@@ -21,19 +22,14 @@ function TeamMessages({ messages }: { messages: unknown[] }) {
       {messages.map((msg, i) => {
         const m = msg as Record<string, unknown>;
         return (
-          <div
-            key={i}
-            className="rounded border border-edge bg-surface-overlay p-3 text-body"
-          >
+          <div key={i} className="rounded border border-edge bg-surface-overlay p-3 text-body">
             <div className="mb-1 flex items-center gap-3 text-meta text-content-muted">
               <span className="font-mono">{String(m.from ?? "?")}</span>
               <span>→</span>
               <span className="font-mono">{String(m.to ?? "?")}</span>
               {m.timestamp != null && <Timestamp value={m.timestamp as string | number | null} />}
             </div>
-            {m.content != null && (
-              <div className="text-content-secondary">{String(m.content)}</div>
-            )}
+            {m.content != null && <div className="text-content-secondary">{String(m.content)}</div>}
           </div>
         );
       })}
@@ -52,10 +48,21 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
   useEffect(() => {
     let active = true;
     getTeam(teamId)
-      .then((d) => { if (active) { setTeam(d); setError(null); } })
-      .catch(() => { if (active) setError("Team not found"); })
-      .finally(() => { if (active) setLoading(false); });
-    return () => { active = false; };
+      .then((d) => {
+        if (active) {
+          setTeam(d);
+          setError(null);
+        }
+      })
+      .catch(() => {
+        if (active) setError(errors.teamNotFound);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
   }, [teamId]);
 
   if (loading) {
@@ -84,11 +91,7 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
 
   return (
     <main className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-6 animate-page-enter">
-      <PageHeader
-        title={String(team.name ?? teamId)}
-        subtitle="Teams"
-        density="tight"
-      />
+      <PageHeader title={String(team.name ?? teamId)} subtitle="Teams" density="tight" />
 
       <div className="flex flex-wrap gap-x-5 gap-y-1 rounded border border-edge bg-surface-overlay px-4 py-2.5 text-meta text-content-muted">
         <span>
@@ -103,7 +106,9 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
           </span>
         )}
         {team.created_at != null && (
-          <span>Created <Timestamp value={team.created_at as string | number} /></span>
+          <span>
+            Created <Timestamp value={team.created_at as string | number} />
+          </span>
         )}
       </div>
 

--- a/apps/studio/frontend/app/teams/page.tsx
+++ b/apps/studio/frontend/app/teams/page.tsx
@@ -7,6 +7,7 @@ import PageHeader from "@/components/PageHeader";
 import Timestamp from "@/components/Timestamp";
 import { listTeams } from "@/lib/api";
 import type { TeamListResponse, TeamSummary } from "@/lib/api";
+import { empty, errors } from "@/lib/copy";
 
 const LIMIT = 20;
 
@@ -23,15 +24,20 @@ export default function TeamsPage() {
       setLoading(true);
       try {
         const d = await listTeams({ limit: LIMIT, offset });
-        if (active) { setData(d); setError(null); }
+        if (active) {
+          setData(d);
+          setError(null);
+        }
       } catch {
-        if (active) setError("Failed to load teams");
+        if (active) setError(errors.loadTeams);
       } finally {
         if (active) setLoading(false);
       }
     }
     void load();
-    return () => { active = false; };
+    return () => {
+      active = false;
+    };
   }, [offset]);
 
   const teams = data?.teams ?? [];
@@ -76,7 +82,7 @@ export default function TeamsPage() {
             ) : teams.length === 0 ? (
               <tr>
                 <td colSpan={3} className="px-3 py-8 text-center text-meta text-content-muted">
-                  No teams found.
+                  {empty.teamsNotFound}
                 </td>
               </tr>
             ) : (
@@ -110,7 +116,9 @@ export default function TeamsPage() {
       </div>
 
       <div className="flex items-center justify-between text-meta text-content-muted">
-        <span>{data?.total ?? 0} team{(data?.total ?? 0) !== 1 ? "s" : ""}</span>
+        <span>
+          {data?.total ?? 0} team{(data?.total ?? 0) !== 1 ? "s" : ""}
+        </span>
         <div className="flex gap-2">
           <Button
             size="sm"

--- a/apps/studio/frontend/lib/copy.ts
+++ b/apps/studio/frontend/lib/copy.ts
@@ -42,7 +42,7 @@ export function confirmPhantomPrune(count: number, all: boolean): string {
 export const empty = {
   // Zero-state — surface awaits its first entry.
   projects: "No projects yet.",
-  invocations: "No invocations yet. Skills track here once they call /invoke.",
+  invocations: "No invocations yet.",
   schedules: "No schedules yet.",
   versions: "No versions yet.",
   plays: "No plays yet.",

--- a/apps/studio/frontend/lib/copy.ts
+++ b/apps/studio/frontend/lib/copy.ts
@@ -1,0 +1,97 @@
+// Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+// SPDX-License-Identifier: Apache-2.0
+//
+// Studio microcopy — single source of truth for UI strings that
+// previously drifted across page files.
+//
+// Conventions (enforce here, not at the call site):
+//   • Sentence case. No exclamation, no emoji.
+//   • Every sentence ends with a period — including short ones.
+//   • Multi-line messages use real `\n`, not `<br>`.
+//   • Empty states: "No X yet." (zero-state, page awaits first entry)
+//                   "No matching X." (filter result is empty)
+//                   "No X found." (lookup miss / search result)
+//                   "No X detected." (diagnostic / health check result)
+//   • Errors: "Failed to <verb> <object>." — verb-first.
+//   • Confirmations: question + scope + permanence, three short lines.
+//   • Status pill labels live in StatusPill.tsx (taxonomy-keyed); not duplicated here.
+//
+// Adding a new string? Pick the category (confirm | empty | error),
+// follow the convention, and prefer reuse over a near-duplicate.
+//
+// i18n is NOT a goal of this module — it's a consistency gate. When
+// i18n becomes a roadmap item, this file is the natural extraction
+// point.
+
+// ── Destructive confirmations ────────────────────────────────────────
+
+/**
+ * Confirmation copy for pruning phantom sessions.
+ *
+ * @param count number of sessions to prune
+ * @param all true → "Prune all N phantom sessions?", false → "Prune N phantom sessions?"
+ */
+export function confirmPhantomPrune(count: number, all: boolean): string {
+  const noun = count === 1 ? "session" : "sessions";
+  const lead = all ? `Prune all ${count} phantom ${noun}?` : `Prune ${count} phantom ${noun}?`;
+  return `${lead}\n\nRemoves DB rows. Artifacts on disk are kept.\nCannot be undone.`;
+}
+
+// ── Empty states ────────────────────────────────────────────────────
+
+export const empty = {
+  // Zero-state — surface awaits its first entry.
+  projects: "No projects yet.",
+  invocations: "No invocations yet. Skills track here once they call /invoke.",
+  schedules: "No schedules yet.",
+  versions: "No versions yet.",
+  plays: "No plays yet.",
+  teams: "No teams yet.",
+
+  // Lookup misses — page loaded successfully but found nothing.
+  projectsNotFound: "No projects found.",
+  plugins: "No plugins found.",
+  agents: "No agents found.",
+  playbooks: "No playbooks found.",
+  skills: "No skills found.",
+  shows: "No shows found.",
+  runs: "No runs found.",
+  teamsNotFound: "No teams found.",
+
+  // Filter results — user typed a filter and nothing matched.
+  pluginsFiltered: "No matching plugins.",
+  agentsFiltered: "No matching agents.",
+  skillsFiltered: "No matching skills.",
+
+  // Diagnostic results — health check / detector ran and found nothing.
+  phantomSessions: "No phantom sessions detected.",
+  branchErrors: "No errors detected across all branches.",
+
+  // Loading bridges — async fetch in flight.
+  loadingShows: "Loading shows...",
+} as const;
+
+// ── Error toasts ────────────────────────────────────────────────────
+// Exported as `errors` (plural) to avoid shadowing local `error` state
+// variables that many page components use to hold the currently-
+// displayed error message.
+
+export const errors = {
+  // Validation — operator input invalid.
+  nameRequired: "Name is required.",
+
+  // Fetch failures — page or section couldn't load.
+  loadProjects: "Failed to load projects.",
+  loadProject: "Failed to load project.",
+  loadInvocations: "Failed to load invocations.",
+  loadInvocation: "Failed to load invocation.",
+  loadDiagnostics: "Failed to load diagnostics.",
+  loadSchedules: "Failed to load schedules.",
+  loadTeams: "Failed to load teams.",
+  loadRuns: "Failed to load runs.",
+  teamNotFound: "Team not found.",
+
+  // Action failures — operator tried to do something, it failed.
+  prune: "Failed to prune sessions.",
+  pruneAll: "Failed to prune all phantom sessions.",
+} as const;


### PR DESCRIPTION
## Summary

**Replaces #1085** (auto-closed when its base branch `slice/b-frontend-nav` was deleted on merge of #1086). Same content, rebased onto current `main`.

Adds `apps/studio/frontend/lib/copy.ts` with documented voice conventions (neutral, present-tense, no scolding) grouped by surface:
- `empty.*` — empty-state strings ("No runs yet", "No phantom sessions", …)
- `errors.*` — error toast strings ("Failed to load …", "Could not …")
- `confirmPhantomPrune(count, all)` — formats the prune confirmation body

Migrates 14 `app/*/page.tsx` files plus `app/admin/maintenance/page.tsx` to consume the centralized strings. Previously the same strings drifted across ~15 surfaces with subtle variations.

## Test plan

- [x] `pnpm lint` 0 errors (1 pre-existing warning in `app/runs/page.tsx`)
- [x] `pnpm typecheck` clean
- [x] Manual: empty states + error toasts render with new strings; prune dialog uses `confirmPhantomPrune()`

## Stack

| Slice | PR | Status |
| --- | --- | --- |
| A — backend status + artifacts | #1083 | ✅ merged |
| B — frontend nav (ADR-0032) | #1086 | ✅ merged |
| **C — frontend microcopy (this PR)** | **this** | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)