### PR TITLE
fix(tests): replace anyio.sleep sync points with Event in concurrency tests (#1090)

### DIFF
--- a/tests/fixtures/test_mock_factory.py
+++ b/tests/fixtures/test_mock_factory.py
@@ -39,9 +39,7 @@ def test_mock_factory_creates_imodel():
 @pytest.mark.asyncio
 async def test_async_branch_communication():
     """Test async communication with mocked branch."""
-    branch = LionAGIMockFactory.create_mocked_branch(
-        response="Async communication test"
-    )
+    branch = LionAGIMockFactory.create_mocked_branch(response="Async communication test")
 
     # Test async communication
     result = await branch.communicate("Test message", skip_validation=True)
@@ -82,9 +80,7 @@ async def test_async_helpers():
     task = asyncio.create_task(set_condition())
 
     # Wait for condition
-    await AsyncTestHelpers.assert_eventually(
-        check_condition, timeout=1.0, interval=0.01
-    )
+    await AsyncTestHelpers.assert_eventually(check_condition, timeout=5.0, interval=0.01)
 
     await task  # Ensure task completes
 
@@ -132,9 +128,7 @@ async def test_end_to_end_simple():
     assert result == "End-to-end test response"
 
     # Test that we can create multiple responses
-    imodel = LionAGIMockFactory.create_mocked_imodel(
-        responses=["First", "Second", "Third"]
-    )
+    imodel = LionAGIMockFactory.create_mocked_imodel(responses=["First", "Second", "Third"])
 
     # Test sequence of responses
     call1 = await imodel.invoke()

--- a/tests/libs/concurrency/test_cancel.py
+++ b/tests/libs/concurrency/test_cancel.py
@@ -19,9 +19,7 @@ async def test_fail_after_zero_deadline_raises_fast(anyio_backend):
     with pytest.raises(TimeoutError):
         with fail_after(0):
             await anyio.sleep(0.001)
-    assert (
-        time.perf_counter() - t0
-    ) < 0.5  # should trip reasonably quickly (CI-friendly)
+    assert (time.perf_counter() - t0) < 0.5  # should trip reasonably quickly (CI-friendly)
 
 
 @pytest.mark.anyio
@@ -105,19 +103,21 @@ async def test_effective_deadline_inside_fail_at(anyio_backend):
 async def test_none_timeout_still_cancellable(anyio_backend):
     """Test that None timeout doesn't shield from outer cancellation."""
     cancelled = False
+    work_started = anyio.Event()
 
     async def work():
         nonlocal cancelled
         try:
             with fail_after(None):  # No timeout
-                await anyio.sleep(1.0)  # Reduced from 10
+                work_started.set()
+                await anyio.sleep(1.0)
         except BaseException:
             cancelled = True
             raise
 
     async with anyio.create_task_group() as tg:
         tg.start_soon(work)
-        await anyio.sleep(0.005)  # Reduced from 0.01
+        await work_started.wait()  # deterministic: work is inside fail_after
         tg.cancel_scope.cancel()
 
     assert cancelled is True
@@ -127,12 +127,14 @@ async def test_none_timeout_still_cancellable(anyio_backend):
 async def test_none_move_on_after_still_cancellable(anyio_backend):
     """Test that move_on_after(None) doesn't shield from outer cancellation."""
     cancelled = False
+    work_started = anyio.Event()
 
     async def work():
         nonlocal cancelled
         try:
-            with move_on_after(None) as scope:
-                await anyio.sleep(1.0)  # Reduced from 10
+            with move_on_after(None) as scope:  # noqa: F841
+                work_started.set()
+                await anyio.sleep(1.0)
         except BaseException:
             cancelled = True
             raise
@@ -141,7 +143,7 @@ async def test_none_move_on_after_still_cancellable(anyio_backend):
 
     async with anyio.create_task_group() as tg:
         tg.start_soon(work)
-        await anyio.sleep(0.01)
+        await work_started.wait()  # deterministic: work is inside move_on_after
         tg.cancel_scope.cancel()
 
     assert cancelled is True
@@ -151,19 +153,21 @@ async def test_none_move_on_after_still_cancellable(anyio_backend):
 async def test_fail_at_none_still_cancellable(anyio_backend):
     """Test that fail_at(None) doesn't shield from outer cancellation."""
     cancelled = False
+    work_started = anyio.Event()
 
     async def work():
         nonlocal cancelled
         try:
             with fail_at(None):  # No deadline
-                await anyio.sleep(1.0)  # Reduced from 10
+                work_started.set()
+                await anyio.sleep(1.0)
         except BaseException:
             cancelled = True
             raise
 
     async with anyio.create_task_group() as tg:
         tg.start_soon(work)
-        await anyio.sleep(0.005)  # Reduced from 0.01
+        await work_started.wait()  # deterministic: work is inside fail_at
         tg.cancel_scope.cancel()
 
     assert cancelled is True
@@ -173,19 +177,21 @@ async def test_fail_at_none_still_cancellable(anyio_backend):
 async def test_move_on_at_none_still_cancellable(anyio_backend):
     """Test that move_on_at(None) doesn't shield from outer cancellation."""
     cancelled = False
+    work_started = anyio.Event()
 
     async def work():
         nonlocal cancelled
         try:
             with move_on_at(None):  # No deadline
-                await anyio.sleep(1.0)  # Reduced from 10
+                work_started.set()
+                await anyio.sleep(1.0)
         except BaseException:
             cancelled = True
             raise
 
     async with anyio.create_task_group() as tg:
         tg.start_soon(work)
-        await anyio.sleep(0.005)  # Reduced from 0.01
+        await work_started.wait()  # deterministic: work is inside move_on_at
         tg.cancel_scope.cancel()
 
     assert cancelled is True

--- a/tests/libs/concurrency/test_errors.py
+++ b/tests/libs/concurrency/test_errors.py
@@ -27,17 +27,19 @@ async def test_shield_does_not_block_internal_timeout(anyio_backend):
 @pytest.mark.anyio
 async def test_is_cancelled_true_for_backend_exception(anyio_backend):
     caught = {}
+    victim_started = anyio.Event()
 
     async def victim():
         try:
-            await anyio.sleep(0.1)  # Further reduced for faster tests
+            victim_started.set()
+            await anyio.sleep(0.1)
         except BaseException as e:
             caught["e"] = e
             raise
 
     async with anyio.create_task_group() as tg:
         tg.start_soon(victim)
-        await anyio.sleep(0.001)  # Small delay
+        await victim_started.wait()  # deterministic: victim is sleeping
         tg.cancel_scope.cancel()
 
     assert "e" in caught and is_cancelled(caught["e"])
@@ -55,10 +57,13 @@ async def test_shield_protects_from_external_cancellation(anyio_backend):
         completed = True
         return "done"
 
+    outer_started = anyio.Event()
+
     async def outer_work():
         nonlocal shield_worked
         try:
             # Shield protects the inner work
+            outer_started.set()
             result = await shield(protected_work)
             shield_worked = result == "done"
         except BaseException:
@@ -67,7 +72,7 @@ async def test_shield_protects_from_external_cancellation(anyio_backend):
 
     async with anyio.create_task_group() as tg:
         tg.start_soon(outer_work)
-        await anyio.sleep(0.001)  # Let work start
+        await outer_started.wait()  # deterministic: outer_work is running
         tg.cancel_scope.cancel()  # Cancel the group
 
     # Give shielded work time to complete

--- a/tests/libs/concurrency/test_patterns.py
+++ b/tests/libs/concurrency/test_patterns.py
@@ -9,6 +9,12 @@ from lionagi.ln.concurrency import bounded_map, fail_after, gather, race, retry
 @pytest.mark.slow
 @pytest.mark.anyio
 async def test_gather_first_error_cancels_peers(anyio_backend):
+    # peer_sleep is long enough that the test would hang near-forever if
+    # cancellation did NOT propagate, yet short enough to not slow CI.
+    # The elapsed bound is expressed relative to peer_sleep so that the
+    # test still proves "cancellation arrived long before the peer could
+    # have completed naturally."
+    peer_sleep = 10.0
     cancelled = anyio.Event()
 
     async def boom():
@@ -17,7 +23,7 @@ async def test_gather_first_error_cancels_peers(anyio_backend):
 
     async def peer():
         try:
-            await anyio.sleep(10)
+            await anyio.sleep(peer_sleep)
         except BaseException:
             cancelled.set()
             raise
@@ -26,8 +32,15 @@ async def test_gather_first_error_cancels_peers(anyio_backend):
     with pytest.raises(RuntimeError):
         await gather(boom(), peer(), return_exceptions=False)
     dt = time.perf_counter() - t0
-    assert cancelled.is_set()
-    assert dt < 2.0  # tolerance for CI scheduler load — see #1090
+
+    # Behavioral: peer must have been cancelled (not completed naturally).
+    assert cancelled.is_set(), "peer was not cancelled after gather error"
+    # Relative timing: gather must return well before the peer would have
+    # finished on its own — any value << peer_sleep catches the regression
+    # where cancellation is not propagated at all.
+    assert dt < peer_sleep / 2, (
+        f"gather took {dt:.2f}s — cancellation may not have propagated promptly"
+    )
 
 
 @pytest.mark.anyio

--- a/tests/libs/concurrency/test_patterns.py
+++ b/tests/libs/concurrency/test_patterns.py
@@ -27,7 +27,7 @@ async def test_gather_first_error_cancels_peers(anyio_backend):
         await gather(boom(), peer(), return_exceptions=False)
     dt = time.perf_counter() - t0
     assert cancelled.is_set()
-    assert dt < 0.5
+    assert dt < 2.0  # tolerance for CI scheduler load — see #1090
 
 
 @pytest.mark.anyio
@@ -109,9 +109,7 @@ async def test_gather_return_exceptions_true(anyio_backend):
         raise ValueError(f"error_{x}")
 
     # Mix successes and failures
-    results = await gather(
-        success(1), failure(2), success(3), failure(4), return_exceptions=True
-    )
+    results = await gather(success(1), failure(2), success(3), failure(4), return_exceptions=True)
 
     assert len(results) == 4
     assert results[0] == "result_1"
@@ -357,9 +355,7 @@ async def test_retry_eventual_success(anyio_backend):
             raise ConnectionError(f"Attempt {attempts['count']} failed")
         return "success"
 
-    result = await retry(
-        flaky, attempts=5, base_delay=0.001, retry_on=(ConnectionError,)
-    )
+    result = await retry(flaky, attempts=5, base_delay=0.001, retry_on=(ConnectionError,))
 
     assert result == "success"
     assert attempts["count"] == 3  # Succeeded on third attempt

--- a/tests/libs/concurrency/test_taskgroup.py
+++ b/tests/libs/concurrency/test_taskgroup.py
@@ -153,28 +153,30 @@ async def test_taskgroup_cancel_scope_propagation(anyio_backend):
     """Test that TaskGroup properly propagates its cancel scope."""
     outer_cancelled = False
     inner_cancelled = False
+    outer_started = anyio.Event()
+
+    async def inner_task():
+        nonlocal inner_cancelled
+        try:
+            await anyio.sleep(10)
+        except BaseException:
+            inner_cancelled = True
+            raise
 
     async def outer_task():
         nonlocal outer_cancelled
         try:
             async with create_task_group() as inner_tg:
                 inner_tg.start_soon(inner_task)
-                await anyio.sleep(0.1)
+                outer_started.set()  # signal: outer is inside inner task group
+                await anyio.sleep(10)
         except BaseException:
             outer_cancelled = True
             raise
 
-    async def inner_task():
-        nonlocal inner_cancelled
-        try:
-            await anyio.sleep(0.1)
-        except BaseException:
-            inner_cancelled = True
-            raise
-
     async with create_task_group() as tg:
         tg.start_soon(outer_task)
-        await anyio.sleep(0.01)
+        await outer_started.wait()  # deterministic: wait until outer is running
         tg.cancel_scope.cancel()
 
     assert outer_cancelled

--- a/tests/libs/concurrency/test_taskgroup.py
+++ b/tests/libs/concurrency/test_taskgroup.py
@@ -155,10 +155,11 @@ async def test_taskgroup_cancel_scope_propagation(anyio_backend):
     inner_cancelled = False
     outer_started = anyio.Event()
 
-    async def inner_task():
+    async def inner_task(*, task_status=anyio.TASK_STATUS_IGNORED):
         nonlocal inner_cancelled
+        task_status.started()  # unblocks outer_task's inner_tg.start() call
         try:
-            await anyio.sleep(10)
+            await anyio.sleep_forever()
         except BaseException:
             inner_cancelled = True
             raise
@@ -167,16 +168,18 @@ async def test_taskgroup_cancel_scope_propagation(anyio_backend):
         nonlocal outer_cancelled
         try:
             async with create_task_group() as inner_tg:
-                inner_tg.start_soon(inner_task)
-                outer_started.set()  # signal: outer is inside inner task group
-                await anyio.sleep(10)
+                # start() blocks until inner_task calls task_status.started(),
+                # guaranteeing inner_task is inside its try/except before we signal.
+                await inner_tg.start(inner_task)
+                outer_started.set()
+                await anyio.sleep_forever()
         except BaseException:
             outer_cancelled = True
             raise
 
     async with create_task_group() as tg:
         tg.start_soon(outer_task)
-        await outer_started.wait()  # deterministic: wait until outer is running
+        await outer_started.wait()  # deterministic: inner_task is running
         tg.cancel_scope.cancel()
 
     assert outer_cancelled

--- a/tests/operations/run/test_run.py
+++ b/tests/operations/run/test_run.py
@@ -426,21 +426,35 @@ async def test_run_honors_caller_timeout_on_slow_stream():
     would otherwise stream forever."""
     import time
 
-    model, _ = _make_slow_cli_model(chunk_delay=0.5, n_chunks=20)
+    # chunk_delay is large so that timeout (0.15s) fires before ANY chunk
+    # arrives.  Keeping it large (3.0s) also provides CI-tolerant headroom
+    # for the elapsed-time bound below.
+    chunk_delay = 3.0
+    caller_timeout = 0.15
+    model, _ = _make_slow_cli_model(chunk_delay=chunk_delay, n_chunks=20)
     branch = Branch()
     branch.chat_model = model
 
+    stream_responses: list = []
     started = time.monotonic()
-    # 0.15s ceiling — first chunk lands at 0.5s, so we MUST hit the timeout
-    # before any chunk arrives; safety budget 1s.
     with pytest.raises(TimeoutError):
-        async for _ in run(branch, "go", RunParam(imodel_kw={"timeout": 0.15})):
-            pass
+        async for msg in run(branch, "go", RunParam(imodel_kw={"timeout": caller_timeout})):
+            if isinstance(msg, AssistantResponse):
+                stream_responses.append(msg)
     elapsed = time.monotonic() - started
 
-    # Should fire close to 0.15s, well under the 0.5s first chunk delay.
-    # Ceiling is generous for CI scheduler load — see #1090.
-    assert elapsed < 3.0, f"timeout fired too late: {elapsed:.2f}s"
+    # Behavioral: timeout must fire before the stream produces any content.
+    # run() yields an Instruction first (always), then AssistantResponse per chunk.
+    # If timeout fires correctly, no AssistantResponse should be yielded.
+    assert stream_responses == [], (
+        f"timeout fired after {len(stream_responses)} stream response(s) — "
+        "timeout is not enforced before first chunk"
+    )
+    # Relative timing: elapsed must be less than one chunk interval,
+    # which proves the timeout tripped before the provider would have sent anything.
+    assert elapsed < chunk_delay, (
+        f"timeout fired at {elapsed:.2f}s but first chunk was due at {chunk_delay}s"
+    )
 
 
 async def test_run_no_timeout_when_kwarg_absent():
@@ -534,8 +548,13 @@ async def test_imodel_stream_propagates_cancellation():
     not swallow it via a yield-in-finally."""
     import anyio
 
-    from lionagi.protocols.generic.event import Event, EventStatus
+    from lionagi.protocols.generic.event import EventStatus
     from lionagi.service.connections.api_calling import APICalling
+
+    # chunk_delay is large so fail_after(cancel_after) fires before ANY chunk
+    # arrives.  Keeping it large also gives CI-tolerant headroom for elapsed bound.
+    chunk_delay = 3.0
+    cancel_after = 0.1
 
     m = iModel(provider="openai", model="gpt-4.1-mini", api_key="test_key")
 
@@ -546,7 +565,7 @@ async def test_imodel_stream_propagates_cancellation():
 
         async def stream(self, request=None, extra_headers=None, **kw):
             for _ in range(100):
-                await anyio.sleep(0.5)
+                await anyio.sleep(chunk_delay)
                 yield StreamChunk(type="text", content="x")
 
     m.endpoint = SlowEndpoint()
@@ -558,7 +577,7 @@ async def test_imodel_stream_propagates_cancellation():
 
     async def fake_core_stream():
         for _ in range(100):
-            await anyio.sleep(0.5)
+            await anyio.sleep(chunk_delay)
             yield StreamChunk(type="text", content="x")
 
     api_call.stream = fake_core_stream
@@ -574,11 +593,21 @@ async def test_imodel_stream_propagates_cancellation():
 
     import time
 
+    chunks_yielded: list = []
     started = time.monotonic()
     with pytest.raises(TimeoutError):
-        with anyio.fail_after(0.1):
-            async for _ in m.stream(api_call=api_call):
-                pass
+        with anyio.fail_after(cancel_after):
+            async for chunk in m.stream(api_call=api_call):
+                chunks_yielded.append(chunk)
     elapsed = time.monotonic() - started
-    # Generous ceiling for CI scheduler load — see #1090.
-    assert elapsed < 3.0, f"cancellation took too long: {elapsed:.2f}s"
+
+    # Behavioral: cancellation must propagate — no chunks should have been yielded.
+    assert chunks_yielded == [], (
+        f"stream yielded {len(chunks_yielded)} chunk(s) after cancellation — "
+        "CancelledError was swallowed instead of propagated"
+    )
+    # Relative timing: cancellation must surface before the first chunk interval,
+    # proving the generator did not block on a yield-in-finally.
+    assert elapsed < chunk_delay, (
+        f"cancellation surfaced at {elapsed:.2f}s but first chunk was due at {chunk_delay}s"
+    )

--- a/tests/operations/run/test_run.py
+++ b/tests/operations/run/test_run.py
@@ -273,9 +273,7 @@ async def test_run_stream_persist_snapshot_dir_routes_snapshot_separately(
     branch_snaps = list(branches_dir.glob("*.json"))
     stream_snaps = list(stream_dir.glob("*.json"))
     assert branch_snaps, "snapshot should be in branches_dir"
-    assert not stream_snaps, (
-        "no snapshot should land in stream_dir when snapshot_dir is set"
-    )
+    assert not stream_snaps, "no snapshot should land in stream_dir when snapshot_dir is set"
     # The snapshot is named after the branch id.
     assert branch_snaps[0].name == f"{branch.id}.json"
 
@@ -307,9 +305,7 @@ async def test_run_and_collect_clears_messages_and_joins_assistant_text(monkeypa
     """clear_messages=True clears branch before run; text chunks are joined."""
     branch = Branch()
     # Add a prior message so we can confirm it gets cleared
-    branch.msgs.add_message(
-        instruction=branch.msgs.create_instruction(instruction="prior")
-    )
+    branch.msgs.add_message(instruction=branch.msgs.create_instruction(instruction="prior"))
     assert len(branch.messages) == 1
 
     def make_ar(text: str) -> AssistantResponse:
@@ -443,7 +439,8 @@ async def test_run_honors_caller_timeout_on_slow_stream():
     elapsed = time.monotonic() - started
 
     # Should fire close to 0.15s, well under the 0.5s first chunk delay.
-    assert elapsed < 0.5, f"timeout fired too late: {elapsed:.2f}s"
+    # Ceiling is generous for CI scheduler load — see #1090.
+    assert elapsed < 3.0, f"timeout fired too late: {elapsed:.2f}s"
 
 
 async def test_run_no_timeout_when_kwarg_absent():
@@ -471,9 +468,7 @@ async def test_run_strips_timeout_from_create_event_kwargs():
     branch.chat_model = model
 
     await _collect(run(branch, "hi", RunParam(imodel_kw={"timeout": 5})))
-    assert "timeout" not in captured, (
-        f"timeout leaked into create_event kwargs: {captured!r}"
-    )
+    assert "timeout" not in captured, f"timeout leaked into create_event kwargs: {captured!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -503,9 +498,7 @@ async def test_branch_operate_forwards_timeout_to_run(monkeypatch):
 
     await branch.operate(instruction="test", timeout=42)
 
-    assert received_timeout == [42], (
-        f"timeout not forwarded correctly: {received_timeout}"
-    )
+    assert received_timeout == [42], f"timeout not forwarded correctly: {received_timeout}"
 
 
 async def test_branch_operate_forwards_extra_kwargs_to_run(monkeypatch):
@@ -587,4 +580,5 @@ async def test_imodel_stream_propagates_cancellation():
             async for _ in m.stream(api_call=api_call):
                 pass
     elapsed = time.monotonic() - started
-    assert elapsed < 1.0, f"cancellation took too long: {elapsed:.2f}s"
+    # Generous ceiling for CI scheduler load — see #1090.
+    assert elapsed < 3.0, f"cancellation took too long: {elapsed:.2f}s"

--- a/tests/service/hooks/integration/test_concurrency_timeouts.py
+++ b/tests/service/hooks/integration/test_concurrency_timeouts.py
@@ -110,9 +110,7 @@ class TestParallelInvocations:
         assert hook_event2._should_exit is False
 
     @pytest.mark.anyio
-    async def test_parallel_hooked_events_isolated(
-        self, patch_cancellation, patch_logger
-    ):
+    async def test_parallel_hooked_events_isolated(self, patch_cancellation, patch_logger):
         """Test that parallel HookedEvent invocations don't interfere."""
 
         async def pre_hook(ev, **kw):
@@ -304,13 +302,12 @@ class TestNoDeadlocks:
 
         # Run concurrently - should not deadlock
         start_time = anyio.current_time()
-        results = await asyncio.gather(
-            event1.invoke(), event2.invoke(), return_exceptions=True
-        )
+        results = await asyncio.gather(event1.invoke(), event2.invoke(), return_exceptions=True)
         end_time = anyio.current_time()
 
         # Should complete in reasonable time (not hang)
-        assert end_time - start_time < 1.0  # Should be much faster
+        # Generous ceiling for CI scheduler load — see #1090.
+        assert end_time - start_time < 3.0
 
         # Both should succeed
         assert len(results) == 2
@@ -442,9 +439,7 @@ class TestPerformanceSmoke:
                 raise RuntimeError("planned failure")
             return "success"
 
-        registry = HookRegistry(
-            hooks={HookEventTypes.PreInvocation: sometimes_failing_hook}
-        )
+        registry = HookRegistry(hooks={HookEventTypes.PreInvocation: sometimes_failing_hook})
 
         start_time = anyio.current_time()
 
@@ -466,9 +461,7 @@ class TestPerformanceSmoke:
         assert total_time < 2.0  # Generous allowance for error handling
 
         # Check that we got expected mix of success/failure
-        successes = sum(
-            1 for (res, se, st), _ in results if st == EventStatus.COMPLETED
-        )
+        successes = sum(1 for (res, se, st), _ in results if st == EventStatus.COMPLETED)
         failures = sum(1 for (res, se, st), _ in results if st == EventStatus.CANCELLED)
 
         assert successes == 25  # Half should succeed

--- a/tests/service/hooks/integration/test_concurrency_timeouts.py
+++ b/tests/service/hooks/integration/test_concurrency_timeouts.py
@@ -279,25 +279,35 @@ class TestNoDeadlocks:
     @pytest.mark.anyio
     async def test_nested_hook_calls_no_deadlock(self, patch_cancellation):
         """Test that hooks calling other hooks don't deadlock."""
+        hook_sleep = 0.01
+        invoke_delay = 0.01
+        # Upper bound: each event does hook + invoke (+ optional post-hook).
+        # Two events run concurrently, so worst-case sequential would be
+        # 2 * (hook_sleep + invoke_delay).  We multiply by 100 to give
+        # generous CI headroom while still catching a true deadlock (which
+        # would hang until the test runner's global timeout fires).
+        n_events = 2
+        per_event_max = hook_sleep + invoke_delay
+        deadlock_timeout = n_events * per_event_max * 100
 
         async def nested_hook(ev, **kw):
             # Simulate a hook that might call another hook
-            await anyio.sleep(0.01)
+            await anyio.sleep(hook_sleep)
             return "nested_result"
 
         async def calling_hook(ev, **kw):
             # This hook simulates calling another async operation
-            await anyio.sleep(0.01)
+            await anyio.sleep(hook_sleep)
             return "calling_result"
 
         registry1 = HookRegistry(hooks={HookEventTypes.PreInvocation: nested_hook})
         registry2 = HookRegistry(hooks={HookEventTypes.PostInvocation: calling_hook})
 
         # Create events that use different registries
-        event1 = ConcurrentTestEvent(invoke_delay=0.01)
+        event1 = ConcurrentTestEvent(invoke_delay=invoke_delay)
         event1.create_pre_invoke_hook(hook_registry=registry1, exit_hook=False)
 
-        event2 = ConcurrentTestEvent(invoke_delay=0.01)
+        event2 = ConcurrentTestEvent(invoke_delay=invoke_delay)
         event2.create_post_invoke_hook(hook_registry=registry2, exit_hook=False)
 
         # Run concurrently - should not deadlock
@@ -305,14 +315,19 @@ class TestNoDeadlocks:
         results = await asyncio.gather(event1.invoke(), event2.invoke(), return_exceptions=True)
         end_time = anyio.current_time()
 
-        # Should complete in reasonable time (not hang)
-        # Generous ceiling for CI scheduler load — see #1090.
-        assert end_time - start_time < 3.0
-
-        # Both should succeed
+        # Behavioral: both must complete successfully — an exception or a
+        # missing result indicates deadlock or hook-system failure.
         assert len(results) == 2
-        assert not isinstance(results[0], Exception)
-        assert not isinstance(results[1], Exception)
+        assert not isinstance(results[0], Exception), f"event1 failed: {results[0]}"
+        assert not isinstance(results[1], Exception), f"event2 failed: {results[1]}"
+
+        # Relative timing: must finish well under the deadlock-detection bound.
+        # A true deadlock would block until the global test timeout, not this bound.
+        elapsed = end_time - start_time
+        assert elapsed < deadlock_timeout, (
+            f"completed in {elapsed:.3f}s — exceeded {deadlock_timeout:.3f}s bound "
+            "(possible deadlock or extreme scheduler starvation)"
+        )
 
     @pytest.mark.anyio
     async def test_high_concurrency_no_resource_exhaustion(self, patch_cancellation):


### PR DESCRIPTION
## Summary

Replace timing-race patterns across two commits to eliminate CI flakes blocking multiple PRs.

**Commit 1** — Event-based sync (deterministic):
- Replace `await anyio.sleep(<small>)` used as task-start synchronization with `anyio.Event` in 7 tests across 3 concurrency test files
- Bump `test_async_helpers` `assert_eventually` deadline from 1.0 s to 5.0 s

**Commit 2** — CI-tolerant timing thresholds (expanded scope):
- Bump 4 hardcoded wall-clock assertions that fired prematurely under CI scheduler load

**Unblocks**: #1098, #1103, #1106, #1107, #1110

---

## Files changed

| File | Tests fixed | Change |
|------|-------------|--------|
| `tests/libs/concurrency/test_taskgroup.py` | `test_taskgroup_cancel_scope_propagation` | sleep→Event |
| `tests/libs/concurrency/test_cancel.py` | 4× `*_still_cancellable` tests | sleep→Event |
| `tests/libs/concurrency/test_errors.py` | `test_is_cancelled_true_for_backend_exception`, `test_shield_protects_from_external_cancellation` | sleep→Event |
| `tests/fixtures/test_mock_factory.py` | `test_async_helpers` | timeout 1.0→5.0 s |
| `tests/operations/run/test_run.py` | `test_run_honors_caller_timeout_on_slow_stream` | elapsed < 0.5→3.0 |
| `tests/operations/run/test_run.py` | `test_imodel_stream_propagates_cancellation` | elapsed < 1.0→3.0 |
| `tests/libs/concurrency/test_patterns.py` | `test_gather_first_error_cancels_peers` | dt < 0.5→2.0 |
| `tests/service/hooks/integration/test_concurrency_timeouts.py` | `test_nested_hook_calls_no_deadlock` | < 1.0→3.0 |

## Pattern applied (Event-based sync)

```python
# BEFORE (racy — scheduler may not have switched tasks yet):
async with create_task_group() as tg:
    tg.start_soon(some_task)
    await anyio.sleep(0.01)        # hope the task started
    tg.cancel_scope.cancel()

# AFTER (deterministic):
started = anyio.Event()
async def some_task():
    started.set()                  # signal: task is now running
    await anyio.sleep(1.0)

async with create_task_group() as tg:
    tg.start_soon(some_task)
    await started.wait()           # wait for the signal, not arbitrary time
    tg.cancel_scope.cancel()
```

## Test plan

- [x] Previously flaky tests (initial set) run 10/10 with `-xvs --timeout=120`
- [x] Previously flaky tests (expanded set) run 10/10 with `-xvs --timeout=120`
- [x] Full concurrency + fixtures suite: 203/203 passed with `-n auto`
- [x] Pre-commit hooks (ruff check, ruff format, pyupgrade): all passed

Closes #1090

🤖 Generated with [Claude Code](https://claude.com/claude-code)