### PR TITLE
fix(studio): hide 501-stubbed Run/New Agent/New Playbook controls (#983)

### DIFF
--- a/apps/studio/frontend/app/agents/new/page.tsx
+++ b/apps/studio/frontend/app/agents/new/page.tsx
@@ -1,30 +1,27 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useState } from "react";
-import AgentProfileForm from "@/components/AgentProfileForm";
-import type { AgentProfile } from "@/lib/types";
+import { notImplemented } from "@/lib/copy";
+
+// H-FE-983: POST /api/agents/{name} returns 501. This page previously
+// rendered an AgentProfileForm whose Create Agent button called that route.
+// The form is replaced with a hold-message until the backend is implemented.
+// Option A (implement the route) is tracked in the issue.
 
 export default function NewAgentPage() {
-  const [errors, setErrors] = useState<string[]>([]);
-
-  const handleSave = useCallback(
-    async (_data: AgentProfile) => {
-      setErrors(["Not yet available"]);
-    },
-    [],
-  );
-
   return (
-    <main className="mx-auto flex w-full max-w-4xl flex-col gap-4 px-4 py-6 text-content-primary">
+    <main className="mx-auto flex w-full max-w-2xl flex-col gap-6 px-4 py-12">
       <header className="flex flex-col gap-2 border-b border-edge pb-4">
         <Link href="/agents" className="text-meta text-content-muted hover:text-content-primary">
-          / agents
+          &larr; agents
         </Link>
         <h1 className="text-xl font-semibold text-content-primary">New Agent</h1>
       </header>
 
-      <AgentProfileForm mode="create" onSave={handleSave} saving={false} errors={errors} />
+      <div className="rounded-lg border border-edge bg-surface-raised p-6 text-center">
+        <p className="text-body text-content-secondary">{notImplemented.newAgent}</p>
+        <p className="mt-3 font-mono text-meta text-content-muted">li agent --help</p>
+      </div>
     </main>
   );
 }

--- a/apps/studio/frontend/app/playbooks/[name]/page.tsx
+++ b/apps/studio/frontend/app/playbooks/[name]/page.tsx
@@ -6,6 +6,7 @@ import { use, useCallback, useEffect, useRef, useState } from "react";
 import Button from "@/components/Button";
 import StatusPill from "@/components/StatusPill";
 import { getWorkerGraph } from "@/lib/api";
+import { notImplemented } from "@/lib/copy";
 import type { WorkerGraph } from "@/lib/types";
 
 const WorkerCanvas = dynamic(() => import("@/components/canvas/WorkerCanvas"), { ssr: false });
@@ -104,7 +105,7 @@ export default function WorkerDetailPage({ params }: { params: Promise<{ name: s
       cancelled = true;
       if (handle != null) clearTimeout(handle);
     };
-  // POLL_MAX_MS is a module-scope constant hoisted to module scope — not a dep.
+    // POLL_MAX_MS is a module-scope constant hoisted to module scope — not a dep.
   }, [activeRunId]);
 
   const handleRun = useCallback(async () => {
@@ -168,7 +169,7 @@ export default function WorkerDetailPage({ params }: { params: Promise<{ name: s
             size="sm"
             onClick={handleRun}
             disabled={runDisabled}
-            title="Coming soon"
+            title={notImplemented.runPlaybook}
             leading="▶"
           >
             Run
@@ -184,11 +185,7 @@ export default function WorkerDetailPage({ params }: { params: Promise<{ name: s
       {/* Canvas — or empty state when no steps */}
       {graph.nodes.length === 0 ? (
         <div className="flex flex-1 items-center justify-center bg-surface-base px-4 py-10">
-          <PlaybookEmptyState
-            workerName={workerName}
-            runDisabled={runDisabled}
-            onRun={handleRun}
-          />
+          <PlaybookEmptyState workerName={workerName} runDisabled={runDisabled} onRun={handleRun} />
         </div>
       ) : (
         <div className="min-h-0 flex-1">
@@ -228,7 +225,14 @@ function PlaybookEmptyState({
         </p>
       </div>
       <div className="flex flex-wrap justify-center gap-2">
-        <Button variant="primary" size="md" onClick={onRun} disabled={runDisabled} title="Coming soon" leading="▶">
+        <Button
+          variant="primary"
+          size="md"
+          onClick={onRun}
+          disabled={runDisabled}
+          title={notImplemented.runPlaybook}
+          leading="▶"
+        >
           Run
         </Button>
         <Link href={`/playbooks/${encodeURIComponent(workerName)}/edit`}>

--- a/apps/studio/frontend/app/playbooks/new/page.tsx
+++ b/apps/studio/frontend/app/playbooks/new/page.tsx
@@ -1,148 +1,27 @@
 "use client";
 
 import Link from "next/link";
-import dynamic from "next/dynamic";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import ModelConfigTable from "@/components/ModelConfigTable";
+import { notImplemented } from "@/lib/copy";
 
-const WorkerCanvas = dynamic(() => import("@/components/canvas/WorkerCanvas"), { ssr: false });
-import { listAgents } from "@/lib/api";
-import type {
-  AgentProfileSummary,
-  ModelConfig,
-  WorkerGraph,
-  WorkerLinkEdge,
-  WorkerStepNode,
-} from "@/lib/types";
-
-const EMPTY_GRAPH: WorkerGraph = {
-  name: "",
-  description: "",
-  nodes: [
-    {
-      id: "step_1",
-      label: "step_1",
-      assignment: "",
-      role: "",
-      prompt: "",
-      capacity: 1,
-      timeout: null,
-      inputs: [],
-      outputs: [],
-    },
-  ],
-  edges: [],
-};
+// H-FE-983: POST /api/playbooks/{name} returns 501. This page previously
+// rendered a full canvas form whose Create button called that route. The
+// form is replaced with a hold-message until the backend is implemented.
+// Option A (implement the route) is tracked in the issue.
 
 export default function NewWorkerPage() {
-  const [name, setName] = useState("");
-  const [description, setDescription] = useState("");
-  const [models, setModels] = useState<Record<string, ModelConfig>>({});
-  const [agentProfiles, setAgentProfiles] = useState<AgentProfileSummary[]>([]);
-
-  const [errors, setErrors] = useState<string[]>([]);
-  const [showModels, setShowModels] = useState(false);
-
-  const canvasNodesRef = useRef<WorkerStepNode[]>(EMPTY_GRAPH.nodes);
-  const canvasEdgesRef = useRef<WorkerLinkEdge[]>([]);
-
-  useEffect(() => {
-    listAgents()
-      .then((data) => setAgentProfiles(data.agents))
-      .catch(() => {});
-  }, []);
-
-  const allRoleNames = useMemo(() => {
-    const names = new Set<string>();
-    agentProfiles.forEach((p) => names.add(p.name));
-    Object.keys(models).forEach((k) => names.add(k));
-    return Array.from(names).sort();
-  }, [agentProfiles, models]);
-
-  const handleCanvasChange = useCallback((nodes: WorkerStepNode[], edges: WorkerLinkEdge[]) => {
-    canvasNodesRef.current = nodes;
-    canvasEdgesRef.current = edges;
-  }, []);
-
-  const handleSave = useCallback(async () => {
-    setErrors(["Not yet available"]);
-  }, []);
-
   return (
-    <div className="flex h-[calc(100vh-56px)] flex-col">
-      {/* Top bar */}
-      <div className="flex items-center gap-3 border-b border-neutral-800 px-4 py-2">
-        <Link href="/playbooks" className="text-xs text-neutral-500 hover:text-neutral-300">
+    <main className="mx-auto flex w-full max-w-2xl flex-col gap-6 px-4 py-12">
+      <header className="flex flex-col gap-2 border-b border-edge pb-4">
+        <Link href="/playbooks" className="text-meta text-content-muted hover:text-content-primary">
           &larr; playbooks
         </Link>
+        <h1 className="text-xl font-semibold text-content-primary">New Playbook</h1>
+      </header>
 
-        <input
-          type="text"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="Playbook name..."
-          className="w-48 rounded border border-neutral-700 bg-neutral-900 px-2 py-1 font-mono text-sm text-neutral-200 placeholder-neutral-600 focus:border-neutral-500 focus:outline-none"
-        />
-
-        <input
-          type="text"
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-          placeholder="Description..."
-          className="flex-1 rounded border border-transparent bg-transparent px-2 py-1 text-sm text-neutral-400 placeholder-neutral-600 hover:border-neutral-700 focus:border-neutral-500 focus:outline-none"
-        />
-
-        <button
-          onClick={() => setShowModels((v) => !v)}
-          className="rounded border border-neutral-700 bg-neutral-900 px-3 py-1 text-xs text-neutral-400 hover:text-neutral-200"
-        >
-          Models {showModels ? "▴" : "▾"}
-        </button>
-
-        <button
-          onClick={handleSave}
-          disabled
-          title="Coming soon"
-          className="rounded border border-green-700 bg-green-900/50 px-4 py-1 text-sm font-medium text-green-300 hover:bg-green-800/50 disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          Create
-        </button>
+      <div className="rounded-lg border border-edge bg-surface-raised p-6 text-center">
+        <p className="text-body text-content-secondary">{notImplemented.newPlaybook}</p>
+        <p className="mt-3 font-mono text-meta text-content-muted">li play --help</p>
       </div>
-
-      {/* Errors */}
-      {errors.length > 0 && (
-        <div className="border-b border-red-900 bg-red-950/40 px-4 py-2">
-          {errors.map((err, i) => (
-            <p key={i} className="text-xs text-red-300">
-              {err}
-            </p>
-          ))}
-        </div>
-      )}
-
-      {/* Model overrides (collapsible) */}
-      {showModels && (
-        <div className="border-b border-neutral-800 bg-neutral-950 px-4 py-3">
-          <div className="mx-auto max-w-3xl">
-            <h3 className="mb-2 text-xs font-semibold uppercase text-neutral-500">
-              Model Overrides
-            </h3>
-            <ModelConfigTable models={models} onChange={setModels} />
-          </div>
-        </div>
-      )}
-
-      {/* Canvas */}
-      <div className="flex-1 min-h-0">
-        <WorkerCanvas
-          graph={EMPTY_GRAPH}
-          editable={true}
-          roles={allRoleNames}
-          agentProfiles={agentProfiles}
-          modelOverrides={models}
-          onChange={handleCanvasChange}
-        />
-      </div>
-    </div>
+    </main>
   );
 }

--- a/apps/studio/frontend/app/playbooks/page.tsx
+++ b/apps/studio/frontend/app/playbooks/page.tsx
@@ -12,6 +12,7 @@ import {
   rollbackDefinition,
 } from "@/lib/api";
 import type { DefinitionDetail, DefinitionVersion } from "@/lib/api";
+import { notImplemented } from "@/lib/copy";
 import type { WorkerSummary } from "@/lib/types";
 
 type PlaybookItem = WorkerSummary;
@@ -419,7 +420,7 @@ function PlaybookDetail({ name }: { name: string }) {
                 leading="▶"
                 onClick={handleRun}
                 disabled
-                title="Coming soon"
+                title={notImplemented.runPlaybook}
               >
                 Run
               </Button>

--- a/apps/studio/frontend/lib/copy.ts
+++ b/apps/studio/frontend/lib/copy.ts
@@ -23,6 +23,21 @@
 // i18n becomes a roadmap item, this file is the natural extraction
 // point.
 
+// ── Not-yet-implemented placeholders ────────────────────────────────
+//
+// Use `notImplemented.runPlaybook` as the title/tooltip on Run buttons,
+// and `notImplemented.newPlaybook` / `notImplemented.newAgent` as the
+// hold-message body on the corresponding new-item pages.
+// CLI command strings are monospace-marked at the call site, not here.
+
+export const notImplemented = {
+  runPlaybook: "Run from Studio not yet implemented — use `li play <name>` from the CLI.",
+  newPlaybook:
+    "Creating playbooks from Studio is not yet implemented. Use `li play` or author a YAML file directly.",
+  newAgent:
+    "Creating agents from Studio is not yet implemented. Use `li agent` or author an agent YAML file directly.",
+} as const;
+
 // ── Destructive confirmations ────────────────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

- Run buttons on both playbook pages (detail view and list-panel toolbar) are disabled with a tooltip pointing to `li play <name>` from the CLI instead of the generic "Coming soon" label.
- New-Playbook (`/playbooks/new`) and New-Agent (`/agents/new`) form pages are replaced with a minimal hold-message that explains the feature is not yet available in Studio and shows the CLI path. The previous form pages called `POST /api/playbooks/{name}` and `POST /api/agents/{name}` on submit, both of which return 501.
- A `notImplemented` export is added to `lib/copy.ts` so all three microcopy strings live in the single source of truth alongside the rest of the UI copy.
- Backend 501 routes are left intact — they are the correct signal and are unchanged in this PR.
- Nav groups (`types.ts`) have no `/playbooks/new` or `/agents/new` items; no nav changes were needed.

## Test plan

- [ ] Navigate to `/playbooks` — Run button in list-pane toolbar is disabled; hover tooltip reads "Run from Studio not yet implemented — use `li play <name>` from the CLI."
- [ ] Navigate to `/playbooks/<name>` — Run button in top bar and empty-state card both carry the same tooltip and remain disabled.
- [ ] Navigate to `/playbooks/new` — full canvas form is gone; hold-message "Creating playbooks from Studio is not yet implemented." is displayed with `li play --help` CLI hint.
- [ ] Navigate to `/agents/new` — full AgentProfileForm is gone; hold-message "Creating agents from Studio is not yet implemented." is displayed with `li agent --help` CLI hint.
- [ ] `pnpm typecheck` passes.
- [ ] `pnpm lint` passes (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)