### PR TITLE
fix(cli): cache cancelled-exception class to survive teardown (#1082)

### DIFF
--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -9,7 +9,11 @@ import json
 
 from lionagi import Branch
 from lionagi._errors import TimeoutError as LionTimeoutError
-from lionagi.ln.concurrency import run_async
+from lionagi.ln.concurrency import (
+    cache_cancelled_exc_class,
+    cancelled_exc_classes,
+    run_async,
+)
 from lionagi.protocols.generic.log import DataLoggerConfig
 from lionagi.state import provenance as _provenance
 from lionagi.state.artifact_verifier import (
@@ -57,6 +61,24 @@ async def _run_agent(
     """
     if resume and continue_last:
         raise ValueError("--resume / -r and --continue-last / -c are mutually exclusive.")
+
+    # Cache the backend cancellation exception class *now*, while the event
+    # loop is running.  The ``except BaseException`` block in ``run_agent``
+    # executes after ``run_async`` returns (i.e. after the loop exits), so
+    # calling ``anyio.get_cancelled_exc_class()`` there raises
+    # ``NoEventLoopError``.  We pre-populate the module-level cache here so
+    # :func:`cancelled_exc_classes` in the error path is always safe.
+    try:
+        cache_cancelled_exc_class()
+    except Exception as _cache_err:
+        # Defensive: if for some reason we couldn't cache (shouldn't happen
+        # inside a running loop), the fallback in cancelled_exc_classes() is
+        # sufficient — don't let this shadow a real startup error.
+        import logging as _logging
+
+        _logging.getLogger("lionagi.cli").debug(
+            "cache_cancelled_exc_class() failed (non-fatal): %s", _cache_err
+        )
 
     # Load agent profile if specified — provides defaults for model/effort/yolo/fast_mode
     profile = None
@@ -707,9 +729,11 @@ def run_agent(args: argparse.Namespace) -> int:
         # ``status='aborted'`` under a shielded scope before re-raising.
         return _EXIT_CODE_BY_TERMINAL_STATUS["aborted"]
     except BaseException as exc:
-        from lionagi.ln.concurrency import get_cancelled_exc_class
-
-        if isinstance(exc, get_cancelled_exc_class()):
+        # Use the pre-cached tuple — ``get_cancelled_exc_class()`` would call
+        # ``anyio.get_cancelled_exc_class()`` here, which raises
+        # ``NoEventLoopError`` because ``run_async`` has already closed the
+        # event loop.  ``cancelled_exc_classes()`` is safe after loop exit.
+        if isinstance(exc, cancelled_exc_classes()):
             return _EXIT_CODE_BY_TERMINAL_STATUS["cancelled"]
         raise
 

--- a/lionagi/ln/concurrency/__init__.py
+++ b/lionagi/ln/concurrency/__init__.py
@@ -11,6 +11,8 @@ from .cancel import (
     move_on_at,
 )
 from .errors import (
+    cache_cancelled_exc_class,
+    cancelled_exc_classes,
     get_cancelled_exc_class,
     is_cancelled,
     non_cancel_subgroup,
@@ -32,6 +34,8 @@ __all__ = (
     "fail_at",
     "move_on_at",
     "effective_deadline",
+    "cache_cancelled_exc_class",
+    "cancelled_exc_classes",
     "get_cancelled_exc_class",
     "is_cancelled",
     "non_cancel_subgroup",

--- a/lionagi/ln/concurrency/errors.py
+++ b/lionagi/ln/concurrency/errors.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Awaitable, Callable
 from typing import ParamSpec, TypeVar
 
@@ -16,12 +17,59 @@ T = TypeVar("T")
 P = ParamSpec("P")
 
 __all__ = (
+    "cache_cancelled_exc_class",
+    "cancelled_exc_classes",
     "get_cancelled_exc_class",
     "is_cancelled",
     "non_cancel_subgroup",
     "shield",
     "split_cancellation",
 )
+
+# Module-level cache populated by ``cache_cancelled_exc_class()`` from inside
+# a running event loop.  Falls back to ``(asyncio.CancelledError,)`` when
+# called outside a loop (e.g. during teardown after the loop has stopped).
+_CANCELLED_EXC_CLASS: tuple[type[BaseException], ...] | None = None
+
+
+def cache_cancelled_exc_class() -> None:
+    """Cache the backend cancellation exception class for safe out-of-loop use.
+
+    Must be called from inside a running event loop (e.g. at the top of an
+    async entry point).  Subsequent calls to :func:`cancelled_exc_classes`
+    will return the cached tuple even after the loop has exited.
+
+    Safe to call multiple times; subsequent calls are no-ops.
+    """
+    global _CANCELLED_EXC_CLASS
+    if _CANCELLED_EXC_CLASS is not None:
+        return
+    try:
+        cls = anyio.get_cancelled_exc_class()
+        # Build a tuple that covers both asyncio and the backend-specific type
+        # (they may be the same, but de-dup to avoid CPython isinstance quirks).
+        _CANCELLED_EXC_CLASS = tuple({asyncio.CancelledError, cls})
+    except Exception:
+        # If anyio itself raises here (shouldn't happen inside a loop, but be
+        # defensive), record the asyncio baseline so the cache is populated.
+        _CANCELLED_EXC_CLASS = (asyncio.CancelledError,)
+
+
+def cancelled_exc_classes() -> tuple[type[BaseException], ...]:
+    """Return cached cancellation exception types, safe to call after loop exit.
+
+    Returns the tuple populated by :func:`cache_cancelled_exc_class`.  If the
+    cache was never populated (e.g. the function was not called inside a loop),
+    falls back to ``(asyncio.CancelledError,)`` so callers never raise
+    ``NoEventLoopError``.
+
+    Returns:
+        Tuple of exception types that represent cancellation.
+    """
+    if _CANCELLED_EXC_CLASS is not None:
+        return _CANCELLED_EXC_CLASS
+    # Graceful degradation: no cache yet → use asyncio baseline.
+    return (asyncio.CancelledError,)
 
 
 def get_cancelled_exc_class() -> type[BaseException]:
@@ -45,9 +93,7 @@ def is_cancelled(exc: BaseException) -> bool:
     return isinstance(exc, anyio.get_cancelled_exc_class())
 
 
-async def shield(
-    func: Callable[P, Awaitable[T]], *args: P.args, **kwargs: P.kwargs
-) -> T:
+async def shield(func: Callable[P, Awaitable[T]], *args: P.args, **kwargs: P.kwargs) -> T:
     """Execute async function protected from outer cancellation.
 
     Args:

--- a/tests/cli/test_agent_cancelled_exc.py
+++ b/tests/cli/test_agent_cancelled_exc.py
@@ -1,0 +1,253 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Regression tests for the anyio.NoEventLoopError fix (#1082).
+
+Root cause: ``lionagi/cli/agent.py`` called ``anyio.get_cancelled_exc_class()``
+inside an ``except BaseException`` block that executes *after* ``run_async``
+has torn down the event loop.  ``anyio.get_cancelled_exc_class()`` queries the
+running backend and raises ``NoEventLoopError`` when there is none.
+
+Fix: ``cache_cancelled_exc_class()`` captures the class from inside a live loop;
+``cancelled_exc_classes()`` returns the cached tuple (or a safe asyncio fallback)
+so it never touches anyio after the loop exits.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+
+import anyio
+import pytest
+
+# ---------------------------------------------------------------------------
+# Unit tests for lionagi.ln.concurrency.errors
+# ---------------------------------------------------------------------------
+
+
+class TestCacheAndReaderFunctions:
+    """Verify the new cache helpers in isolation."""
+
+    def setup_method(self) -> None:
+        """Reset module-level cache before each test."""
+        import lionagi.ln.concurrency.errors as errors_mod
+
+        errors_mod._CANCELLED_EXC_CLASS = None
+
+    def test_cancelled_exc_classes_returns_asyncio_fallback_when_no_cache(
+        self,
+    ) -> None:
+        """If cache was never populated, fallback must be asyncio.CancelledError."""
+        from lionagi.ln.concurrency.errors import cancelled_exc_classes
+
+        result = cancelled_exc_classes()
+        assert asyncio.CancelledError in result
+        # Must never raise NoEventLoopError — this is the core invariant.
+
+    def test_cancelled_exc_classes_never_calls_anyio_after_loop_exit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """cancelled_exc_classes() must not raise even when anyio would."""
+        import anyio as _anyio
+
+        import lionagi.ln.concurrency.errors as errors_mod
+
+        errors_mod._CANCELLED_EXC_CLASS = None
+
+        # Poison anyio.get_cancelled_exc_class so any call would explode.
+        def _bad_get_cancelled() -> None:
+            raise RuntimeError("anyio must not be called after loop exit")
+
+        monkeypatch.setattr(_anyio, "get_cancelled_exc_class", _bad_get_cancelled)
+
+        from lionagi.ln.concurrency.errors import cancelled_exc_classes
+
+        # Must NOT propagate the RuntimeError — fallback takes over.
+        result = cancelled_exc_classes()
+        assert asyncio.CancelledError in result
+
+    def test_cache_cancelled_exc_class_populates_cache(self) -> None:
+        """cache_cancelled_exc_class() must fill _CANCELLED_EXC_CLASS inside a loop."""
+        import lionagi.ln.concurrency.errors as errors_mod
+
+        errors_mod._CANCELLED_EXC_CLASS = None
+
+        async def _inner() -> None:
+            from lionagi.ln.concurrency.errors import cache_cancelled_exc_class
+
+            cache_cancelled_exc_class()
+
+        asyncio.run(_inner())
+
+        assert errors_mod._CANCELLED_EXC_CLASS is not None
+        assert asyncio.CancelledError in errors_mod._CANCELLED_EXC_CLASS
+
+    def test_cache_is_idempotent(self) -> None:
+        """Calling cache_cancelled_exc_class() twice must not change the cached value."""
+        import lionagi.ln.concurrency.errors as errors_mod
+
+        errors_mod._CANCELLED_EXC_CLASS = None
+
+        async def _inner() -> None:
+            from lionagi.ln.concurrency.errors import cache_cancelled_exc_class
+
+            cache_cancelled_exc_class()
+            first = errors_mod._CANCELLED_EXC_CLASS
+
+            cache_cancelled_exc_class()
+            second = errors_mod._CANCELLED_EXC_CLASS
+
+            assert first is second
+
+        asyncio.run(_inner())
+
+    def test_cancelled_exc_classes_returns_cached_after_loop_exit(self) -> None:
+        """After loop exit, cancelled_exc_classes() returns the cached tuple."""
+        import lionagi.ln.concurrency.errors as errors_mod
+
+        errors_mod._CANCELLED_EXC_CLASS = None
+
+        async def _inner() -> None:
+            from lionagi.ln.concurrency.errors import cache_cancelled_exc_class
+
+            cache_cancelled_exc_class()
+
+        asyncio.run(_inner())
+
+        # Simulate: loop is gone, anyio would raise NoEventLoopError if called.
+        # But cancelled_exc_classes() should use the cache.
+        from lionagi.ln.concurrency.errors import cancelled_exc_classes
+
+        result = cancelled_exc_classes()
+        assert asyncio.CancelledError in result
+
+    def test_asyncio_cancelled_error_isinstance_check_works(self) -> None:
+        """isinstance(exc, cancelled_exc_classes()) must catch CancelledError."""
+        import lionagi.ln.concurrency.errors as errors_mod
+
+        errors_mod._CANCELLED_EXC_CLASS = None
+
+        async def _inner() -> None:
+            from lionagi.ln.concurrency.errors import cache_cancelled_exc_class
+
+            cache_cancelled_exc_class()
+
+        asyncio.run(_inner())
+
+        from lionagi.ln.concurrency.errors import cancelled_exc_classes
+
+        exc = asyncio.CancelledError()
+        assert isinstance(exc, cancelled_exc_classes())
+
+
+# ---------------------------------------------------------------------------
+# Integration test: simulate the run_agent error path post-loop-exit
+# ---------------------------------------------------------------------------
+
+
+class TestRunAgentCancelledExcPath:
+    """
+    Simulate the exact failure scenario from issue #1082.
+
+    In production:
+      1. ``run_async(_run_agent(...))`` runs the coroutine to completion.
+      2. ``run_async`` tears down the event loop.
+      3. Inside the ``except BaseException`` block in ``run_agent``, the code
+         previously called ``anyio.get_cancelled_exc_class()`` — which raises
+         ``NoEventLoopError`` because the loop is gone.
+
+    Here we reproduce that by:
+      - Running a dummy coroutine with ``run_async`` (which starts + stops a loop).
+      - Verifying that a ``CancelledError`` raised *after* ``run_async`` returns
+        is still correctly classified by ``cancelled_exc_classes()``.
+    """
+
+    def setup_method(self) -> None:
+        """Reset module-level cache before each test."""
+        import lionagi.ln.concurrency.errors as errors_mod
+
+        errors_mod._CANCELLED_EXC_CLASS = None
+
+    def test_no_noeventloouperror_when_classifying_after_loop_exit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Classifying an exception after loop exit must not raise NoEventLoopError."""
+        import anyio as _anyio
+
+        import lionagi.ln.concurrency.errors as errors_mod
+        from lionagi.ln.concurrency import run_async
+
+        # Phase 1: run inside a loop and populate the cache.
+        async def _populate_cache() -> None:
+            from lionagi.ln.concurrency.errors import cache_cancelled_exc_class
+
+            cache_cancelled_exc_class()
+
+        run_async(_populate_cache())
+
+        # Phase 2: loop is now closed. Poison anyio to ensure it's not called.
+        def _raise_no_loop() -> type[BaseException]:
+            raise anyio.ClosedResourceError("no event loop (simulated)")
+
+        monkeypatch.setattr(_anyio, "get_cancelled_exc_class", _raise_no_loop)
+
+        # This is the critical assertion: the old code would hit the monkeypatched
+        # function and raise; the new code uses the cache and must succeed.
+        from lionagi.ln.concurrency.errors import cancelled_exc_classes
+
+        exc = asyncio.CancelledError()
+        # Must not raise, and must classify CancelledError correctly.
+        assert isinstance(exc, cancelled_exc_classes())
+
+    def test_run_agent_uses_cancelled_exc_classes_not_get_cancelled_exc_class(
+        self,
+    ) -> None:
+        """Verify the *sync* run_agent() no longer calls get_cancelled_exc_class.
+
+        There are two ``except BaseException`` handlers in agent.py:
+        - One inside ``_run_agent`` (async) — runs inside the event loop, safe.
+        - One inside ``run_agent`` (sync) — runs AFTER run_async() exits the loop;
+          calling anyio.get_cancelled_exc_class() there raises NoEventLoopError.
+
+        This test checks only the handler belonging to the *sync* ``run_agent``
+        function definition, so the safe in-loop usage in ``_run_agent`` does not
+        trigger a false positive.
+        """
+        import ast
+        import pathlib
+
+        agent_path = pathlib.Path(__file__).parent.parent.parent / "lionagi" / "cli" / "agent.py"
+        source = agent_path.read_text()
+        tree = ast.parse(source)
+
+        # Find the *sync* ``run_agent`` function definition (not ``_run_agent``).
+        run_agent_node: ast.FunctionDef | None = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "run_agent":
+                run_agent_node = node
+                break
+
+        assert run_agent_node is not None, "run_agent function not found in agent.py"
+
+        # Walk only the body of run_agent for BaseException handlers.
+        for node in ast.walk(run_agent_node):
+            if not isinstance(node, ast.ExceptHandler):
+                continue
+            if node.type is None:
+                continue
+            handler_type = ast.unparse(node.type)
+            if "BaseException" not in handler_type:
+                continue
+            # Collect all function calls within this handler body.
+            calls_in_handler = [
+                ast.unparse(n)
+                for n in ast.walk(ast.Module(body=node.body, type_ignores=[]))
+                if isinstance(n, ast.Call)
+            ]
+            for call_text in calls_in_handler:
+                assert "get_cancelled_exc_class" not in call_text, (
+                    f"run_agent() BaseException handler still calls get_cancelled_exc_class: "
+                    f"{call_text!r} — this triggers NoEventLoopError after loop exit (#1082)"
+                )


### PR DESCRIPTION
## Summary

Closes #1082.

- **Bug**: `run_agent()` called `anyio.get_cancelled_exc_class()` inside an `except BaseException` block that executes *after* `run_async()` has torn down the event loop. `anyio.get_cancelled_exc_class()` internally calls `anyio.get_async_backend()`, which raises `NoEventLoopError` when no backend is active — masking the real error and preventing the codex verdict file from being written.
- **Fix**: Added `cache_cancelled_exc_class()` (populates a module-level tuple from inside the live loop) and `cancelled_exc_classes()` (returns cached tuple or `asyncio.CancelledError` fallback) to `lionagi/ln/concurrency/errors.py`. `_run_agent` calls the cache function once at startup; the sync `run_agent` error handler uses the safe reader.
- **Verification**: New regression test suite in `tests/cli/test_agent_cancelled_exc.py` directly simulates the post-loop-exit classification path and poisons `anyio.get_cancelled_exc_class` to confirm it is never reached; all 255 existing CLI tests continue to pass.

## Test plan

- [x] New regression tests: `uv run pytest tests/cli/test_agent_cancelled_exc.py -xvs` — 8 passed
- [x] Full CLI suite: `uv run pytest tests/cli/ -x --timeout=60` — 255 passed, 1 skipped
- [x] Pre-commit hooks: ruff check, ruff format, pyupgrade — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)