### PR TITLE
feat(studio): surface project chip on invocations list rows (#1081)

### DIFF
--- a/apps/studio/frontend/app/invocations/page.tsx
+++ b/apps/studio/frontend/app/invocations/page.tsx
@@ -183,9 +183,19 @@ export default function InvocationsPage() {
                       >
                         /{inv.skill}
                       </Link>
-                      <div className="text-meta text-content-muted">
-                        {shortId(inv.id)}
-                        {inv.plugin ? ` · ${inv.plugin}` : ""}
+                      <div className="flex items-center gap-1.5 text-meta text-content-muted">
+                        <span>
+                          {shortId(inv.id)}
+                          {inv.plugin ? ` · ${inv.plugin}` : ""}
+                        </span>
+                        {inv.project && (
+                          <span
+                            className="rounded px-1 py-0.5 font-mono text-[10px] border border-edge text-content-muted"
+                            title={`Project: ${inv.project} (${inv.project_source ?? "unknown"})`}
+                          >
+                            {inv.project}
+                          </span>
+                        )}
                       </div>
                     </td>
                     <td className="px-3 py-2 align-middle">

--- a/apps/studio/frontend/lib/api.ts
+++ b/apps/studio/frontend/lib/api.ts
@@ -436,6 +436,9 @@ export interface InvocationSummary {
   created_at: number;
   updated_at: number;
   node_metadata: Record<string, unknown> | null;
+  // ADR-0026: project provenance from the most-recently updated child session.
+  project?: string | null;
+  project_source?: string | null;
 }
 
 export interface InvocationSession {

--- a/apps/studio/server/services/invocations.py
+++ b/apps/studio/server/services/invocations.py
@@ -24,9 +24,7 @@ async def list_invocations(
     if not DEFAULT_DB_PATH.exists():
         return []
     async with StateDB() as db:
-        rows = await db.list_invocations(
-            skill=skill, status=status, limit=limit, offset=offset
-        )
+        rows = await db.list_invocations(skill=skill, status=status, limit=limit, offset=offset)
     out: list[dict[str, Any]] = []
     for r in rows:
         node_meta = r.get("node_metadata")
@@ -48,6 +46,10 @@ async def list_invocations(
                 "created_at": r["created_at"],
                 "updated_at": r["updated_at"],
                 "node_metadata": node_meta,
+                # ADR-0026: project provenance from the most-recently updated
+                # child session.  NULL when the invocation has no sessions yet.
+                "project": r.get("project"),
+                "project_source": r.get("project_source"),
             }
         )
     return out

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -1576,18 +1576,34 @@ class StateDB:
         limit: int = 100,
         offset: int = 0,
     ) -> list[dict[str, Any]]:
-        query = "SELECT * FROM invocations"
+        # ADR-0026: surface project/project_source from the most-recently
+        # updated child session so Studio can render project chips on the
+        # invocations list page.  The subquery picks one row per invocation
+        # by latest updated_at; NULL when the invocation has no sessions yet.
+        query = (
+            "SELECT inv.*, "
+            "  sq.project        AS project, "
+            "  sq.project_source AS project_source "
+            "FROM invocations inv "
+            "LEFT JOIN ( "
+            "  SELECT invocation_id, project, project_source "
+            "  FROM sessions "
+            "  WHERE invocation_id IS NOT NULL "
+            "  GROUP BY invocation_id "
+            "  HAVING MAX(updated_at) "
+            ") sq ON sq.invocation_id = inv.id"
+        )
         conds: list[str] = []
         params: list[Any] = []
         if skill:
-            conds.append("skill = ?")
+            conds.append("inv.skill = ?")
             params.append(skill)
         if status:
-            conds.append("status = ?")
+            conds.append("inv.status = ?")
             params.append(status)
         if conds:
             query += " WHERE " + " AND ".join(conds)
-        query += " ORDER BY updated_at DESC LIMIT ? OFFSET ?"
+        query += " ORDER BY inv.updated_at DESC LIMIT ? OFFSET ?"
         params.extend([limit, offset])
         cur = await self.db.execute(query, params)
         rows = await cur.fetchall()


### PR DESCRIPTION
## Summary

- `runs/page.tsx` and `schedules/page.tsx` already showed project chips inline with IDs. This PR brings the same chip to the **invocations** list page.
- **Shows** and **teams** list pages are filesystem-based (no `sessions` join, no `project` column in their data sources) — no change possible without a separate schema PR.

## Changes

**Backend (`lionagi/state/db.py`)**
- `StateDB.list_invocations()` now `LEFT JOIN`s the `sessions` table to pull `project` and `project_source` from the most-recently-updated child session. Returns `NULL` when the invocation has no sessions yet. No schema migration needed — sessions already has these columns from ADR-0026.

**Backend (`apps/studio/server/services/invocations.py`)**
- `list_invocations()` service passes `project` and `project_source` through to the API response dict.

**Frontend (`apps/studio/frontend/lib/api.ts`)**
- `InvocationSummary` interface gains optional `project?: string | null` and `project_source?: string | null` fields.

**Frontend (`apps/studio/frontend/app/invocations/page.tsx`)**
- Skill cell renders an inline project chip when `inv.project` is truthy, using the exact `span/className` pattern from `runs/page.tsx` lines 166-173.

## Test plan

- [x] `pnpm typecheck` — passes clean
- [x] `pnpm lint` — no new errors (pre-existing warning in runs/page.tsx only)
- [x] `uv run ruff check` — passes
- [x] `uv run pytest tests/apps_studio_server/ -x --timeout=30` — 24 passed, 15 skipped
- [x] `uv run pytest tests/ -k "invocation or db" -x --timeout=30` — all pass

## Pages status after this PR

| Page | Project chip | Notes |
|------|-------------|-------|
| runs | already had it | |
| schedules | already had it | |
| invocations | added here | JOINs sessions for project |
| shows | not applicable | filesystem-based, no session join |
| teams | not applicable | filesystem-based JSON files |

Closes #1081.

🤖 Generated with [Claude Code](https://claude.com/claude-code)