### PR TITLE
feat(cli): inject deadline preamble into agent prompt when --timeout set (#1087)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ li skill commit
 
 # Resume any run
 li agent -r <branch-id> "follow up on your findings"
+
+# Time-bounded run: injects a [DEADLINE] preamble so the agent paces its own reasoning
+li agent claude/sonnet --timeout 300 "Audit the auth module and produce a summary"
 ```
 
 Full reference → [docs/cli-reference.md](docs/cli-reference.md) · Installable

--- a/lionagi/cli/_agents.py
+++ b/lionagi/cli/_agents.py
@@ -39,6 +39,40 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 
+def build_deadline_preamble(timeout_seconds: int) -> str:
+    """Build a deadline-awareness preamble for the agent's first user message.
+
+    Injected when ``--timeout N`` is set so the agent knows its wall-clock
+    budget and can pace reasoning accordingly.  A leading user message is used
+    (rather than a system-prompt prefix) because it is the most reliably
+    visible position across codex, claude-code, and other CLI providers.
+
+    Args:
+        timeout_seconds: The ``--timeout`` value in seconds.
+
+    Returns:
+        The formatted ``[DEADLINE] … [/DEADLINE]`` block.
+    """
+    import time as _time
+    from datetime import datetime, timezone
+
+    minutes = max(1, int(timeout_seconds / 60))
+    deadline_ts = _time.time() + timeout_seconds
+    deadline_iso = datetime.fromtimestamp(deadline_ts, tz=timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    return (
+        f"[DEADLINE]\n"
+        f"You have {minutes} minute{'s' if minutes != 1 else ''} "
+        f"(until {deadline_iso}) to complete this task.\n"
+        f"Pace your reasoning accordingly. Prefer decisive verdicts over exhaustive\n"
+        f"deliberation. If you're more than 60% through your time budget and\n"
+        f"still in research mode, switch to writing the deliverable.\n\n"
+        f"You can check the current time with: `date -Iseconds`\n"
+        f"[/DEADLINE]\n"
+    )
+
+
 @dataclass
 class AgentProfile:
     name: str

--- a/lionagi/cli/_providers.py
+++ b/lionagi/cli/_providers.py
@@ -391,7 +391,12 @@ def add_common_cli_args(parser: argparse.ArgumentParser) -> None:
         metavar="SECONDS",
         type=int,
         default=None,
-        help="Timeout in seconds.",
+        help=(
+            "Hard wall-clock timeout in seconds. "
+            "When set, a [DEADLINE] preamble is injected into the agent's "
+            "prompt so the agent knows its time budget and can pace reasoning "
+            "accordingly (issue #1087)."
+        ),
     )
     # ADR-0020: opt-in skill-orchestration grouping. Set by a skill via
     # ``li invoke start``; threaded through to the session row so the

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -19,7 +19,7 @@ from lionagi.state.artifact_verifier import (
     verify_artifact_contract,
 )
 
-from ._agents import load_agent_profile
+from ._agents import build_deadline_preamble, load_agent_profile
 from ._logging import hint, log_error
 from ._providers import (
     PROVIDER_EFFORT_KWARG,
@@ -130,6 +130,14 @@ async def _run_agent(
     # Inject agent system prompt
     if profile and profile.system_prompt:
         branch.msgs.add_message(system=profile.system_prompt)
+
+    # Inject deadline preamble when --timeout is set so the agent can pace
+    # its own reasoning.  Prepended to the user's prompt as a leading user
+    # message — most reliable position across all CLI providers (codex,
+    # claude-code, gemini-code).  Issue #1087.
+    if timeout is not None:
+        preamble = build_deadline_preamble(timeout)
+        prompt = preamble + prompt
 
     run = allocate_run()
     branch_id = str(branch.id)

--- a/tests/cli/test_agent_timeout_deadline.py
+++ b/tests/cli/test_agent_timeout_deadline.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for --timeout deadline preamble injection (issue #1087).
+
+Verifies that ``build_deadline_preamble`` produces the expected format and
+that ``_run_agent`` prepends it to the user prompt when ``--timeout`` is set.
+No real API calls are made — the branch.operate() path is mocked.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+
+import pytest
+
+from lionagi.cli._agents import build_deadline_preamble
+
+# ── build_deadline_preamble unit tests ────────────────────────────────────────
+
+
+def test_preamble_contains_deadline_tags():
+    """Output is wrapped in [DEADLINE] … [/DEADLINE] markers."""
+    preamble = build_deadline_preamble(300)
+    assert preamble.startswith("[DEADLINE]\n")
+    assert "[/DEADLINE]\n" in preamble
+
+
+def test_preamble_contains_minutes():
+    """300 seconds → 5 minutes in preamble."""
+    preamble = build_deadline_preamble(300)
+    assert "5 minutes" in preamble
+
+
+def test_preamble_singular_minute():
+    """60 seconds → '1 minute' (not '1 minutes')."""
+    preamble = build_deadline_preamble(60)
+    assert "1 minute " in preamble
+    assert "1 minutes" not in preamble
+
+
+def test_preamble_deadline_iso_format():
+    """Preamble contains an ISO-8601 timestamp matching the expected pattern."""
+    preamble = build_deadline_preamble(300)
+    # Pattern: YYYY-MM-DDTHH:MM:SSZ
+    assert re.search(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", preamble), (
+        f"No ISO timestamp found in preamble: {preamble!r}"
+    )
+
+
+def test_preamble_deadline_approximately_correct():
+    """Deadline timestamp is within a few seconds of now + timeout."""
+    before = time.time()
+    preamble = build_deadline_preamble(300)
+    after = time.time()
+
+    # Extract the ISO timestamp
+    m = re.search(r"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)", preamble)
+    assert m, f"No timestamp in preamble: {preamble!r}"
+
+    from datetime import datetime, timezone
+
+    deadline_ts = (
+        datetime.strptime(m.group(1), "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc).timestamp()
+    )
+
+    # Allow 1 s below because strftime truncates sub-second fractions;
+    # allow 5 s above for slow test machines.
+    assert before + 300 - 1 <= deadline_ts <= after + 300 + 5, (
+        f"Deadline {deadline_ts} not in expected range [{before + 299}, {after + 305}]"
+    )
+
+
+def test_preamble_contains_date_command_hint():
+    """Preamble tells the agent how to check the current time."""
+    preamble = build_deadline_preamble(300)
+    assert "date -Iseconds" in preamble
+
+
+def test_preamble_no_timeout_not_called():
+    """When timeout is None, build_deadline_preamble is not called at all
+    (guard test — importing the function is idempotent)."""
+    # This is a trivial guard: the real test is in test_run_agent_* below.
+    # We just verify the function is importable and callable.
+    result = build_deadline_preamble(120)
+    assert result  # non-empty string
+
+
+def test_preamble_sub_minute_timeout_clamps_to_1():
+    """Timeouts < 60 s still produce '1 minute' (not '0 minutes')."""
+    preamble = build_deadline_preamble(30)
+    assert "1 minute " in preamble
+
+
+# ── Integration: preamble prepended to prompt in _run_agent ──────────────────
+#
+# Strategy: mock branch.operate at the *class* level using monkeypatch so we
+# avoid Pydantic's __setattr__ guard.  The spy records what instruction was
+# passed in before returning "done".
+
+
+def _make_agent_mocks(monkeypatch, tmp_path, captured_instruction):
+    """Wire all external-service stubs needed by _run_agent."""
+    from types import SimpleNamespace
+
+    import lionagi.cli.agent as agent_mod
+    from lionagi import Branch
+
+    # Spy on Branch.operate at the class level (avoids Pydantic __setattr__).
+    async def spy_operate(self, instruction=None, **kw):
+        captured_instruction.append(instruction or "")
+        return "done"
+
+    monkeypatch.setattr(Branch, "operate", spy_operate)
+
+    # Stub iModel shutdown (called in finally block).
+    from lionagi.service.manager import iModelManager
+
+    async def fake_shutdown(self):
+        pass
+
+    monkeypatch.setattr(iModelManager, "shutdown", fake_shutdown)
+
+    monkeypatch.setattr(
+        agent_mod,
+        "build_chat_model",
+        lambda *a, **kw: "claude_code/sonnet",
+    )
+    monkeypatch.setattr(agent_mod, "resolve_persisted_effort", lambda *a, **kw: None)
+
+    # _setup_live_persist returns None → _teardown_live_persist is a no-op.
+    async def fake_setup(*a, **kw):
+        return None
+
+    async def fake_teardown(ctx, *, status="completed", exception=None):
+        return status
+
+    monkeypatch.setattr(agent_mod, "_setup_live_persist", fake_setup)
+    monkeypatch.setattr(agent_mod, "_teardown_live_persist", fake_teardown)
+    monkeypatch.setattr(agent_mod, "save_last_branch_pointer", lambda *a, **kw: None)
+
+    fake_run = SimpleNamespace(
+        run_id="test-run",
+        artifact_root=tmp_path / "artifacts",
+        stream_dir=tmp_path / "stream",
+        branches_dir=tmp_path / "branches",
+    )
+    monkeypatch.setattr(agent_mod, "allocate_run", lambda: fake_run)
+    monkeypatch.setattr(
+        agent_mod,
+        "_provenance",
+        SimpleNamespace(
+            resolve_model_spec=lambda p, m: f"{p}/{m}",
+            agent_definition_hash=lambda n: "abc123",
+        ),
+    )
+    monkeypatch.setattr(
+        agent_mod,
+        "resolve_artifact_contract",
+        lambda **_: None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_agent_prepends_preamble_when_timeout_set(monkeypatch, tmp_path):
+    """_run_agent prepends the [DEADLINE] block to the user prompt."""
+    captured_instruction: list[str] = []
+    _make_agent_mocks(monkeypatch, tmp_path, captured_instruction)
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent(
+        "claude_code/sonnet",
+        "Write a function that adds two numbers.",
+        timeout=300,
+    )
+
+    assert captured_instruction, "operate() was never called"
+    instruction_text = captured_instruction[0]
+    assert instruction_text.startswith("[DEADLINE]\n"), (
+        f"Expected preamble prefix, got: {instruction_text[:120]!r}"
+    )
+    assert "Write a function that adds two numbers." in instruction_text
+
+
+@pytest.mark.asyncio
+async def test_run_agent_no_preamble_when_timeout_none(monkeypatch, tmp_path):
+    """_run_agent does NOT inject a preamble when timeout is None."""
+    captured_instruction: list[str] = []
+    _make_agent_mocks(monkeypatch, tmp_path, captured_instruction)
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent(
+        "claude_code/sonnet",
+        "Write a function.",
+        timeout=None,
+    )
+
+    assert captured_instruction, "operate() was never called"
+    instruction_text = captured_instruction[0]
+    assert not instruction_text.startswith("[DEADLINE]"), (
+        f"Unexpected preamble injected when timeout=None: {instruction_text[:120]!r}"
+    )


### PR DESCRIPTION
## Summary

- **Problem**: `--timeout N` was a silent guillotine — the spawned agent (codex, claude-code, etc.) had no visibility into its wall-clock budget and wasted tokens on exhaustive reasoning until the process was killed.
- **Fix**: When `--timeout N` is set, inject a `[DEADLINE]` preamble as the leading user message so the agent knows its time budget and can pace reasoning accordingly.
- **Scope**: `li agent --timeout` only. FlowOp budget propagation (issue #1091) is tracked separately — no changes to `orchestrate/`.

## Changes

| File | Change |
|------|--------|
| `lionagi/cli/_agents.py` | Add `build_deadline_preamble(timeout_seconds)` — returns `[DEADLINE]…[/DEADLINE]` block with minutes remaining, ISO-8601 deadline, and `date -Iseconds` hint |
| `lionagi/cli/agent.py` | Import and call `build_deadline_preamble`; prepend to user prompt when `timeout is not None` |
| `lionagi/cli/_providers.py` | Expand `--timeout` help text to document preamble injection |
| `README.md` | Add `--timeout` example to CLI quick-reference |
| `tests/cli/test_agent_timeout_deadline.py` | 10 tests: preamble format unit tests + 2 integration tests via `Branch.operate` monkeypatch |

## Preamble format

```
[DEADLINE]
You have 5 minutes (until 2026-05-24T15:30:00Z) to complete this task.
Pace your reasoning accordingly. Prefer decisive verdicts over exhaustive
deliberation. If you're more than 60% through your time budget and
still in research mode, switch to writing the deliverable.

You can check the current time with: `date -Iseconds`
[/DEADLINE]
```

## Why leading user message (not system prompt)?

System-prompt injection was considered but some CLI providers (notably codex) silently drop extra system messages or truncate the system context. A leading user message is visible in all provider contexts and is the position agents most reliably read at turn start.

## Test plan

- [x] `uv run pytest tests/cli/test_agent_timeout_deadline.py -v` — 10/10 pass
- [x] `uv run pytest tests/cli/ --timeout=60` — 257 passed, 1 skipped (pre-existing skip unrelated to this PR)
- [x] `uv run ruff check` and `uv run ruff format --check` on all changed files — clean
- [x] All pre-commit hooks passed on commit

## Acceptance criteria (from issue)

- [x] `li agent --timeout 300 ...` injects a deadline preamble into the agent's context
- [x] No preamble when `--timeout` is not set
- [x] `li agent --help` documents that `--timeout` is now agent-visible
- [x] README `--timeout` example added

Closes #1087.

🤖 Generated with [Claude Code](https://claude.com/claude-code)