### PR TITLE
feat(lndl): port LNDL Phase 1 minimal core — opt-in structured-output formatter (#966)

### DIFF
--- a/lionagi/lndl/__init__.py
+++ b/lionagi/lndl/__init__.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2025 - 2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""LNDL — Lion Notation Definition Language (Phase 1).
+
+Structured-output format for LLM responses. This module ships the Phase 1
+minimal core as an opt-in feature. It is intentionally excluded from any
+default routing in ``operations/parse``; callers must explicitly pass an
+LNDL schema to activate this path.
+
+Phase 1 exports
+---------------
+- Types: :class:`LNDLOutput`, :class:`ActionCall`, :class:`LvarMetadata`,
+  :class:`RLvarMetadata`, :class:`LactMetadata`, :class:`ParsedConstructor`
+- Errors: :class:`LNDLError` and all subclasses
+- Prompt: :func:`get_lndl_system_prompt`
+- Extract: :func:`extract_lndl_blocks`
+- Normalize: :func:`normalize_lndl_text`
+
+Phase 2 (deferred — see issue #966)
+------------------------------------
+Lexer / Parser / AST / Resolver / Orchestrator / Symbolic-AST modules.
+:func:`parse_lndl_fuzzy` is present but raises ``NotImplementedError``
+until Phase 2 lands.
+"""
+
+from .errors import (
+    AmbiguousMatchError,
+    InvalidConstructorError,
+    LNDLError,
+    MissingFieldError,
+    MissingLvarError,
+    MissingOutBlockError,
+    TypeMismatchError,
+)
+from .extract import extract_lndl_blocks
+from .fuzzy import normalize_lndl_text, parse_lndl_fuzzy
+from .prompt import LNDL_SYSTEM_PROMPT, get_lndl_system_prompt
+from .types import (
+    ActionCall,
+    LactMetadata,
+    LNDLOutput,
+    LvarMetadata,
+    ParsedConstructor,
+    RLvarMetadata,
+    Scalar,
+    ensure_no_action_calls,
+    has_action_calls,
+    revalidate_with_action_results,
+)
+
+__all__ = (
+    # Errors
+    "LNDLError",
+    "MissingLvarError",
+    "MissingFieldError",
+    "TypeMismatchError",
+    "InvalidConstructorError",
+    "MissingOutBlockError",
+    "AmbiguousMatchError",
+    # Types
+    "ActionCall",
+    "LactMetadata",
+    "LNDLOutput",
+    "LvarMetadata",
+    "ParsedConstructor",
+    "RLvarMetadata",
+    "Scalar",
+    "ensure_no_action_calls",
+    "has_action_calls",
+    "revalidate_with_action_results",
+    # Prompt
+    "LNDL_SYSTEM_PROMPT",
+    "get_lndl_system_prompt",
+    # Extract
+    "extract_lndl_blocks",
+    # Fuzzy (Phase 1: normalize only; parse_lndl_fuzzy raises until Phase 2)
+    "normalize_lndl_text",
+    "parse_lndl_fuzzy",
+)

--- a/lionagi/lndl/errors.py
+++ b/lionagi/lndl/errors.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2025 - 2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+
+class LNDLError(Exception):
+    """Base exception for LNDL parsing/validation errors."""
+
+
+class MissingLvarError(LNDLError):
+    """Referenced lvar does not exist."""
+
+
+class MissingFieldError(LNDLError):
+    """Required Spec field missing from OUT{} block."""
+
+
+class TypeMismatchError(LNDLError):
+    """Constructor class doesn't match Spec type."""
+
+
+class InvalidConstructorError(LNDLError):
+    """Cannot parse constructor syntax."""
+
+
+class MissingOutBlockError(LNDLError):
+    """No OUT{} block found in response."""
+
+
+class AmbiguousMatchError(LNDLError):
+    """Multiple fields match with similar similarity scores (tie)."""

--- a/lionagi/lndl/extract.py
+++ b/lionagi/lndl/extract.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2025 - 2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Extract ```lndl code blocks from LLM responses."""
+
+import re
+
+_FENCE_PATTERN = re.compile(
+    r"^(?P<fence>```|~~~)[ \t]*"
+    r"(?P<lang>[\w+-]*)[ \t]*\n"
+    r"(?P<code>.*?)(?<=\n)"
+    r"^(?P=fence)[ \t]*$",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+def extract_lndl_blocks(text: str) -> list[str]:
+    """Extract all ```lndl fenced code blocks from text, in order."""
+    blocks: list[str] = []
+    for match in _FENCE_PATTERN.finditer(text):
+        lang = match.group("lang").lower()
+        if lang == "lndl":
+            blocks.append(match.group("code"))
+    return blocks
+
+
+__all__ = ("extract_lndl_blocks",)

--- a/lionagi/lndl/fuzzy.py
+++ b/lionagi/lndl/fuzzy.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2025 - 2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""LNDL fuzzy helpers — Phase 1 subset.
+
+Phase 1 ships only :func:`normalize_lndl_text`.
+
+:func:`parse_lndl_fuzzy` requires the Phase 2 lexer/parser/resolver/ast
+modules and the ``SimilarityAlgo`` type that live on the ``beta`` branch.
+Calling it raises ``NotImplementedError`` until Phase 2 lands.
+
+# TODO(lndl-phase-2): promote parse_lndl_fuzzy from beta's fuzzy.py once
+#   lexer.py / parser.py / ast.py / resolver.py / SimilarityAlgo are ported.
+"""
+
+import re
+from typing import Any
+
+from .errors import MissingOutBlockError  # noqa: F401 — re-exported for Phase 2 callers
+
+__all__ = ("normalize_lndl_text", "parse_lndl_fuzzy")
+
+_XML_ATTR_RE = re.compile(r'\b\w+=["\'][^"\']*["\']')
+
+
+def normalize_lndl_text(text: str) -> str:
+    """Normalize model-invented syntax before lexing.
+
+    Handles:
+    - Curly-brace tags: {lact X}fn(){/lact} → <lact X>fn()</lact>
+    - XML attributes: <lact name="X" type="Y"> → <lact X>
+    - Capitalized Note namespace: <lvar Note.X> → <lvar note.X>
+    """
+    text = re.sub(r"\{(lvar|lact)(\s+[^}]*)\}", r"<\1\2>", text)
+    text = re.sub(r"\{/(lvar|lact)\}", r"</\1>", text)
+
+    def _clean_tag(m: re.Match) -> str:
+        tag = m.group(1)
+        body = m.group(2)
+
+        attrs = dict(re.findall(r'(\w+)=["\']([^"\']*)["\']', body))
+        cleaned = _XML_ATTR_RE.sub("", body).strip()
+
+        parts = cleaned.split() if cleaned else []
+        name_val = attrs.get("name", "")
+        if name_val and name_val not in " ".join(parts):
+            parts.append(name_val)
+
+        tag_body = " ".join(parts)
+        return f"<{tag} {tag_body}>" if tag_body else f"<{tag}>"
+
+    text = re.sub(r"<(lvar|lact)\s+((?:[^>])*?)>", _clean_tag, text)
+    text = re.sub(r"<(lvar|lact)\s+Note\.", r"<\1 note.", text)
+    return text
+
+
+def parse_lndl_fuzzy(
+    response: str,
+    operable: Any,
+    /,
+    **kwargs: Any,
+) -> Any:
+    """Fuzzy-tolerant LNDL parser — requires Phase 2 modules.
+
+    This function is a Phase 2 feature. It depends on:
+    - ``lionagi.lndl.lexer`` (Lexer, Token, TokenType)
+    - ``lionagi.lndl.parser`` (Parser)
+    - ``lionagi.lndl.ast`` (Lvar, Lact, OutBlock, Program)
+    - ``lionagi.lndl.resolver`` (resolve_references_prefixed)
+    - ``lionagi.ln.fuzzy.SimilarityAlgo``
+
+    # TODO(lndl-phase-2): implement using beta branch's fuzzy.py once the
+    #   above Phase 2 modules are ported to main.
+    """
+    raise NotImplementedError(
+        "parse_lndl_fuzzy requires Phase 2 LNDL modules (lexer/parser/ast/resolver) "
+        "which have not yet been ported to main. "
+        "Track progress in GitHub issue #966."
+    )

--- a/lionagi/lndl/prompt.py
+++ b/lionagi/lndl/prompt.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2025 - 2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+LNDL_SYSTEM_PROMPT = """LNDL — Structured Output with Natural Thinking
+
+SYNTAX
+
+Variables:
+<lvar Model.field alias>value</lvar>      — namespaced (Pydantic model fields)
+<lvar alias>value</lvar>                  — raw (scalars only)
+
+Actions:
+<lact Model.field alias>fn(arg="val")</lact>  — namespaced (result fills model field)
+<lact alias>fn(arg="val")</lact>              — direct (entire output)
+
+Output:
+OUT{specName: [alias1, alias2], scalar: literal}
+
+RULES
+
+1. <lvar> and <lact> are SIBLINGS — NEVER nest one inside the other.
+2. ONLY tags referenced in OUT{} are executed/used. Everything else is scratch (thinking).
+3. OUT{} uses arrays for models, literals for scalars:
+   OUT{report: [t, s], score: 0.85}
+4. <lact> body is a Python function call with keyword args:
+   fn(path="file.py", pattern="def", limit=10)
+
+TYPE RULES
+
+Scalars (float, str, int, bool):
+  Literal:  OUT{score: 0.85}
+  Variable: <lvar score s>0.85</lvar> → OUT{score: [s]}
+
+Models (Pydantic):
+  Array of aliases: OUT{report: [title, body]}
+  Can mix lvars + lacts: OUT{report: [title, api_call, footer]}
+
+Actions:
+  Namespaced: <lact Report.summary s>summarize(text="...")</lact>
+  Direct:     <lact data>fetch(url="...")</lact>
+  Only executed if in OUT{}. Not in OUT{} = scratch thinking, not executed.
+
+EXAMPLE 1: Variables only
+
+Specs: report(Report: title, summary), quality(float)
+
+<lvar Report.title t>Architecture Analysis</lvar>
+<lvar Report.summary s>The system uses a layered design...</lvar>
+
+OUT{report: [t, s], quality: 0.92}
+
+EXAMPLE 2: Tool calls with arguments
+
+Specs: analysis(Analysis: file_name, line_count, findings)
+
+<lvar Analysis.file_name name>main.py</lvar>
+<lact Analysis.line_count lc>count_lines(path="main.py")</lact>
+<lact Analysis.findings f>grep_file(path="main.py", pattern="async def")</lact>
+
+OUT{analysis: [name, lc, f]}
+
+"lc" and "f" execute — their results fill line_count and findings.
+
+EXAMPLE 3: Drafting — declare multiple, commit the best
+
+Let me try two approaches...
+<lact broad>search(query="AI", limit=100)</lact>
+<lact focused>search(query="AI safety", limit=20)</lact>
+
+<lvar Report.title t>AI Safety Analysis</lvar>
+<lvar Report.summary s>Based on focused results...</lvar>
+
+OUT{report: [t, s, focused]}
+
+Only "focused" executes. "broad" was scratch thinking — never runs.
+
+ERRORS TO AVOID
+
+<lvar x><lact fn>fn()</lact></lvar>        # WRONG: nested tags — siblings only
+OUT{report: {title: "X"}}                  # WRONG: constructor — use arrays
+<lact name="X">fn()</lact>                 # WRONG: XML attributes — use <lact X>
+<lact op>fn()</lact>                        # WRONG: no args — use fn(arg="val")
+"""
+
+
+def get_lndl_system_prompt() -> str:
+    return LNDL_SYSTEM_PROMPT.strip()

--- a/lionagi/lndl/types.py
+++ b/lionagi/lndl/types.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2025 - 2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Core types for LNDL."""
+
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import BaseModel
+
+Scalar = float | int | str | bool
+
+
+@dataclass(slots=True, frozen=True)
+class LvarMetadata:
+    model: str
+    field: str
+    local_name: str
+    value: str
+
+
+@dataclass(slots=True, frozen=True)
+class RLvarMetadata:
+    local_name: str
+    value: str
+
+
+@dataclass(slots=True, frozen=True)
+class LactMetadata:
+    model: str | None
+    field: str | None
+    local_name: str
+    call: str
+
+
+@dataclass(slots=True, frozen=True)
+class ParsedConstructor:
+    class_name: str
+    kwargs: dict[str, Any]
+    raw: str
+
+    @property
+    def has_dict_unpack(self) -> bool:
+        return any(k.startswith("**") for k in self.kwargs)
+
+
+@dataclass(slots=True, frozen=True)
+class ActionCall:
+    name: str
+    function: str
+    arguments: dict[str, Any]
+    raw_call: str
+
+
+@dataclass(slots=True, frozen=True)
+class LNDLOutput:
+    fields: dict[str, BaseModel | ActionCall | Scalar]
+    lvars: dict[str, str] | dict[str, LvarMetadata]
+    lacts: dict[str, LactMetadata]
+    actions: dict[str, ActionCall]
+    raw_out_block: str
+
+    def __getitem__(self, key: str) -> BaseModel | ActionCall | Scalar:
+        return self.fields[key]
+
+    def __getattr__(self, key: str) -> BaseModel | ActionCall | Scalar:
+        if key in ("fields", "lvars", "lacts", "actions", "raw_out_block"):
+            return object.__getattribute__(self, key)
+        return self.fields[key]
+
+
+def has_action_calls(model: BaseModel) -> bool:
+    def _check_value(value: Any) -> bool:
+        if isinstance(value, ActionCall):
+            return True
+        if isinstance(value, BaseModel):
+            return has_action_calls(value)
+        if isinstance(value, list | tuple | set):
+            return any(_check_value(item) for item in value)
+        if isinstance(value, dict):
+            return any(_check_value(v) for v in value.values())
+        return False
+
+    return any(_check_value(value) for value in model.__dict__.values())
+
+
+def ensure_no_action_calls(model: BaseModel) -> BaseModel:
+    def _find_action_call_fields(obj: Any, path: str = "") -> list[str]:
+        paths = []
+        if isinstance(obj, ActionCall):
+            return [path] if path else ["<root>"]
+        if isinstance(obj, BaseModel):
+            for field_name, value in obj.__dict__.items():
+                field_path = f"{path}.{field_name}" if path else field_name
+                paths.extend(_find_action_call_fields(value, field_path))
+        elif isinstance(obj, list | tuple | set):
+            for idx, item in enumerate(obj):
+                paths.extend(_find_action_call_fields(item, f"{path}[{idx}]"))
+        elif isinstance(obj, dict):
+            for key, value in obj.items():
+                paths.extend(_find_action_call_fields(value, f"{path}[{key!r}]"))
+        return paths
+
+    if has_action_calls(model):
+        model_name = type(model).__name__
+        action_call_fields = _find_action_call_fields(model)
+        fields_str = ", ".join(action_call_fields[:3])
+        if len(action_call_fields) > 3:
+            fields_str += f" (and {len(action_call_fields) - 3} more)"
+        raise ValueError(
+            f"{model_name} contains unexecuted actions in fields: {fields_str}. "
+            f"Call revalidate_with_action_results() before using this model."
+        )
+    return model
+
+
+def _coerce_result(result: Any, target_type: type | None) -> Any:
+    """Coerce a tool result to match the target field type."""
+    if target_type in (str, int, float, bool) and isinstance(result, dict):
+        import json
+
+        return json.dumps(result, ensure_ascii=False)
+    if target_type in (str, int, float, bool) and not isinstance(result, target_type):
+        return target_type(result)
+    return result
+
+
+def _revalidate_model(
+    model: BaseModel,
+    action_results: dict[str, Any],
+) -> BaseModel:
+    """Replace ActionCall placeholders in a single model with actual results."""
+    kwargs = {}
+    changed = False
+    for field_name, value in model.__dict__.items():
+        if isinstance(value, ActionCall):
+            if value.name not in action_results:
+                raise ValueError(
+                    f"Action '{value.name}' in field '{field_name}' has no execution result. "
+                    f"Available results: {list(action_results.keys())}"
+                )
+            field_info = type(model).model_fields.get(field_name)
+            target_type = field_info.annotation if field_info else None
+            kwargs[field_name] = _coerce_result(action_results[value.name], target_type)
+            changed = True
+        elif isinstance(value, BaseModel) and has_action_calls(value):
+            kwargs[field_name] = _revalidate_model(value, action_results)
+            changed = True
+        else:
+            kwargs[field_name] = value
+
+    if not changed:
+        return model
+    return type(model).model_validate(kwargs)
+
+
+def revalidate_with_action_results(
+    model: BaseModel,
+    action_results: dict[str, Any],
+) -> BaseModel:
+    return _revalidate_model(model, action_results)

--- a/lionagi/operations/parse/parse.py
+++ b/lionagi/operations/parse/parse.py
@@ -20,6 +20,7 @@ from lionagi.protocols.types import AssistantResponse
 from ..types import HandleValidation, ParseParam
 
 if TYPE_CHECKING:
+    from lionagi.ln.types import Operable
     from lionagi.session.branch import Branch
 
 
@@ -54,9 +55,7 @@ def prepare_parse_kws(
             stacklevel=2,
         )
 
-    response_format = (
-        operative.request_type if operative else response_format or request_type
-    )
+    response_format = operative.request_type if operative else response_format or request_type
     _alcall_params = get_default_call()
     max_retries = operative.max_retries if operative else max_retries or 3
 
@@ -149,11 +148,48 @@ async def parse(
     return (*result[0],) if return_res_message else result[0][0]
 
 
+def _is_lndl_operable(response_format: Any) -> bool:
+    """Return True when the caller opted into LNDL by passing an Operable."""
+    try:
+        from lionagi.ln.types import Operable
+
+        return isinstance(response_format, Operable)
+    except ImportError:
+        return False
+
+
+def _extract_lndl(text: str, operable: "Operable") -> Any:
+    """Route text through the LNDL Phase 1 extract path.
+
+    Extracts the first ```lndl fenced block from *text* and returns it as a
+    raw string.  Full structured resolution (via ``parse_lndl_fuzzy``) requires
+    Phase 2 modules and raises ``NotImplementedError`` until they land.
+
+    Phase 1 contract: if the text contains an ```lndl block, return its
+    content; otherwise return the raw text so the caller can decide how to
+    handle it.
+    """
+    from lionagi.lndl.extract import extract_lndl_blocks
+
+    blocks = extract_lndl_blocks(text)
+    if blocks:
+        # Return the first block's raw content.
+        # TODO(lndl-phase-2): replace with parse_lndl_fuzzy(blocks[0], operable)
+        # once lexer/parser/ast/resolver are ported from beta.
+        return blocks[0]
+    return text
+
+
 def _validate_dict_or_model(
     text: str,
-    response_format: type[BaseModel] | dict,
+    response_format: type[BaseModel] | dict | Any,
     fuzzy_match_params: FuzzyMatchKeysParams | dict = None,
 ):
+    # LNDL opt-in path: only activates when caller passes an Operable schema.
+    # No change in behaviour for BaseModel or dict response_format callers.
+    if _is_lndl_operable(response_format):
+        return _extract_lndl(text, response_format)
+
     try:
         if isinstance(fuzzy_match_params, dict):
             fuzzy_match_params = FuzzyMatchKeysParams(**fuzzy_match_params)

--- a/tests/lndl/test_errors.py
+++ b/tests/lndl/test_errors.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2025 - 2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from lionagi.lndl.errors import (
+    AmbiguousMatchError,
+    InvalidConstructorError,
+    LNDLError,
+    MissingFieldError,
+    MissingLvarError,
+    MissingOutBlockError,
+    TypeMismatchError,
+)
+
+
+def test_lndl_error_is_exception():
+    err = LNDLError("base error")
+    assert isinstance(err, Exception)
+    assert str(err) == "base error"
+
+
+def test_missing_lvar_error_is_lndl_error():
+    err = MissingLvarError("lvar 'x' not found")
+    assert isinstance(err, LNDLError)
+    assert "lvar 'x'" in str(err)
+
+
+def test_missing_field_error_is_lndl_error():
+    err = MissingFieldError("field 'name' missing")
+    assert isinstance(err, LNDLError)
+    assert isinstance(err, MissingFieldError)
+
+
+def test_type_mismatch_error_is_lndl_error():
+    err = TypeMismatchError("got str, expected int")
+    assert isinstance(err, LNDLError)
+
+
+def test_invalid_constructor_error_is_lndl_error():
+    err = InvalidConstructorError("bad constructor")
+    assert isinstance(err, LNDLError)
+
+
+def test_missing_out_block_error_is_lndl_error():
+    err = MissingOutBlockError("no OUT{}")
+    assert isinstance(err, LNDLError)
+
+
+def test_ambiguous_match_error_is_lndl_error():
+    err = AmbiguousMatchError("ties between a and b")
+    assert isinstance(err, LNDLError)
+
+
+def test_errors_raise_correctly():
+    with pytest.raises(LNDLError):
+        raise LNDLError("test")
+
+    with pytest.raises(MissingLvarError):
+        raise MissingLvarError("x")
+
+    with pytest.raises(MissingFieldError):
+        raise MissingFieldError("y")
+
+    with pytest.raises(TypeMismatchError):
+        raise TypeMismatchError("z")
+
+    with pytest.raises(InvalidConstructorError):
+        raise InvalidConstructorError("c")
+
+    with pytest.raises(MissingOutBlockError):
+        raise MissingOutBlockError("no block")
+
+    with pytest.raises(AmbiguousMatchError):
+        raise AmbiguousMatchError("ambiguous")
+
+
+def test_error_hierarchy_catch_by_base():
+    with pytest.raises(LNDLError):
+        raise MissingLvarError("lvar")
+
+    with pytest.raises(LNDLError):
+        raise AmbiguousMatchError("tie")

--- a/tests/lndl/test_extract.py
+++ b/tests/lndl/test_extract.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2025 - 2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+
+from lionagi.lndl.extract import extract_lndl_blocks
+
+
+def test_extract_single_lndl_block():
+    text = "```lndl\n<lvar x>hello</lvar>\nOUT{x: [x]}\n```"
+    blocks = extract_lndl_blocks(text)
+    assert len(blocks) == 1
+    assert "<lvar x>hello</lvar>" in blocks[0]
+
+
+def test_extract_no_blocks():
+    text = "No code blocks here."
+    blocks = extract_lndl_blocks(text)
+    assert blocks == []
+
+
+def test_extract_ignores_non_lndl_blocks():
+    text = "```python\nprint('hello')\n```\n```bash\necho hi\n```"
+    blocks = extract_lndl_blocks(text)
+    assert blocks == []
+
+
+def test_extract_multiple_lndl_blocks():
+    text = "First:\n```lndl\nblock1\n```\nSome text\n```lndl\nblock2\n```"
+    blocks = extract_lndl_blocks(text)
+    assert len(blocks) == 2
+    assert "block1" in blocks[0]
+    assert "block2" in blocks[1]
+
+
+def test_extract_mixed_languages():
+    text = (
+        "```python\ncode\n```\n```lndl\nlndl_code\n```\n```json\n{}\n```\n```lndl\nmore_lndl\n```"
+    )
+    blocks = extract_lndl_blocks(text)
+    assert len(blocks) == 2
+    assert "lndl_code" in blocks[0]
+    assert "more_lndl" in blocks[1]
+
+
+def test_extract_tilde_fence():
+    text = "~~~lndl\n<lvar x>val</lvar>\n~~~"
+    blocks = extract_lndl_blocks(text)
+    assert len(blocks) == 1
+    assert "<lvar x>val</lvar>" in blocks[0]
+
+
+def test_extract_empty_block():
+    text = "```lndl\n```"
+    # Empty blocks with no content (empty string code group) may not match
+    # depending on the regex — test what actually happens
+    blocks = extract_lndl_blocks(text)
+    # Either empty or not found — both are valid implementations
+    assert isinstance(blocks, list)
+
+
+def test_extract_preserves_content():
+    content = "<lvar Report.title t>My Title</lvar>\nOUT{report: [t]}"
+    text = f"```lndl\n{content}\n```"
+    blocks = extract_lndl_blocks(text)
+    assert len(blocks) == 1
+    assert blocks[0].strip() == content
+
+
+def test_extract_lndl_case_insensitive():
+    # 'LNDL' uppercase matches because lang.lower() is compared
+    text = "```LNDL\nsome code\n```"
+    blocks = extract_lndl_blocks(text)
+    # The extractor lowercases the lang before comparing, so LNDL matches
+    assert len(blocks) == 1
+    assert "some code" in blocks[0]
+
+
+def test_all_exports():
+    from lionagi.lndl.extract import __all__
+
+    assert "extract_lndl_blocks" in __all__

--- a/tests/lndl/test_fuzzy.py
+++ b/tests/lndl/test_fuzzy.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2025 - 2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Phase 1 tests for lionagi.lndl.fuzzy.
+
+Only :func:`normalize_lndl_text` is Phase 1.
+:func:`parse_lndl_fuzzy` requires Phase 2 modules (lexer/parser/ast/resolver)
+and is tested separately once those are ported.
+
+# TODO(lndl-phase-2): add TestParseLndlFuzzy once Phase 2 lands (see issue #966).
+"""
+
+import pytest
+
+from lionagi.lndl.fuzzy import normalize_lndl_text, parse_lndl_fuzzy
+
+
+class TestNormalizeLndlText:
+    def test_curly_brace_lvar(self):
+        text = "{lvar x}value{/lvar}"
+        normalized = normalize_lndl_text(text)
+        assert "<lvar" in normalized
+        assert "{lvar" not in normalized
+
+    def test_curly_brace_lact(self):
+        text = "{lact x}fn(a='b'){/lact}"
+        normalized = normalize_lndl_text(text)
+        assert "<lact" in normalized
+
+    def test_xml_attributes_cleaned(self):
+        text = '<lvar name="title" type="str" t>'
+        normalized = normalize_lndl_text(text)
+        # XML attrs should be stripped; 't' alias should remain
+        assert 'name="title"' not in normalized
+        assert "t" in normalized
+
+    def test_note_namespace_lowercased(self):
+        text = "<lvar Note.draft d>some text</lvar>"
+        normalized = normalize_lndl_text(text)
+        assert "note.draft" in normalized or "<lvar note." in normalized
+
+    def test_passthrough_normal_text(self):
+        text = "<lvar Report.title t>Title</lvar>"
+        normalized = normalize_lndl_text(text)
+        assert "Report.title" in normalized
+        assert "<lvar" in normalized
+
+    def test_empty_string(self):
+        result = normalize_lndl_text("")
+        assert result == ""
+
+
+class TestParseLndlFuzzyPhase2Guard:
+    """parse_lndl_fuzzy must raise NotImplementedError in Phase 1."""
+
+    def test_raises_not_implemented(self):
+        with pytest.raises(NotImplementedError, match="Phase 2"):
+            parse_lndl_fuzzy("some text", object())
+
+    def test_error_references_issue(self):
+        with pytest.raises(NotImplementedError) as exc_info:
+            parse_lndl_fuzzy("x", None)
+        assert "966" in str(exc_info.value)

--- a/tests/lndl/test_prompt.py
+++ b/tests/lndl/test_prompt.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for lionagi.lndl.prompt.get_lndl_system_prompt."""
+
+from __future__ import annotations
+
+from lionagi.lndl.prompt import get_lndl_system_prompt
+
+
+class TestGetLndlSystemPrompt:
+    def test_returns_string(self):
+        """Line 87: get_lndl_system_prompt() returns a string."""
+        result = get_lndl_system_prompt()
+        assert isinstance(result, str)
+
+    def test_not_empty(self):
+        """Returned prompt has content."""
+        result = get_lndl_system_prompt()
+        assert len(result) > 0
+
+    def test_stripped(self):
+        """Result is stripped (no leading/trailing whitespace)."""
+        result = get_lndl_system_prompt()
+        assert result == result.strip()
+
+    def test_consistent_on_repeated_calls(self):
+        """Repeated calls return the same value."""
+        r1 = get_lndl_system_prompt()
+        r2 = get_lndl_system_prompt()
+        assert r1 == r2

--- a/tests/lndl/test_types.py
+++ b/tests/lndl/test_types.py
@@ -1,0 +1,232 @@
+# Copyright (c) 2025 - 2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from pydantic import BaseModel
+
+from lionagi.lndl.types import (
+    ActionCall,
+    LactMetadata,
+    LNDLOutput,
+    LvarMetadata,
+    ParsedConstructor,
+    RLvarMetadata,
+    _coerce_result,
+    _revalidate_model,
+    ensure_no_action_calls,
+    has_action_calls,
+    revalidate_with_action_results,
+)
+
+
+class SimpleModel(BaseModel):
+    title: str
+    score: float = 0.0
+
+
+class NestedModel(BaseModel):
+    name: str
+    inner: SimpleModel | None = None
+
+
+def make_action_call(name="act1", fn="fetch", args=None):
+    return ActionCall(
+        name=name,
+        function=fn,
+        arguments=args or {"url": "http://x"},
+        raw_call=f"{fn}(url='http://x')",
+    )
+
+
+class TestLvarMetadata:
+    def test_basic_creation(self):
+        m = LvarMetadata(model="Report", field="title", local_name="t", value="Hello")
+        assert m.model == "Report"
+        assert m.field == "title"
+        assert m.local_name == "t"
+        assert m.value == "Hello"
+
+    def test_frozen(self):
+        m = LvarMetadata(model="R", field="f", local_name="l", value="v")
+        with pytest.raises((AttributeError, TypeError)):
+            m.model = "X"
+
+
+class TestRLvarMetadata:
+    def test_basic_creation(self):
+        m = RLvarMetadata(local_name="x", value="raw text")
+        assert m.local_name == "x"
+        assert m.value == "raw text"
+
+    def test_frozen(self):
+        m = RLvarMetadata(local_name="x", value="v")
+        with pytest.raises((AttributeError, TypeError)):
+            m.local_name = "y"
+
+
+class TestLactMetadata:
+    def test_with_model_and_field(self):
+        m = LactMetadata(model="Report", field="summary", local_name="s", call="fn(a='b')")
+        assert m.model == "Report"
+        assert m.field == "summary"
+
+    def test_direct_lact(self):
+        m = LactMetadata(model=None, field=None, local_name="data", call="fetch(url='x')")
+        assert m.model is None
+        assert m.field is None
+
+
+class TestParsedConstructor:
+    def test_basic(self):
+        pc = ParsedConstructor(class_name="Report", kwargs={"title": "X"}, raw="Report(title='X')")
+        assert pc.class_name == "Report"
+        assert pc.kwargs == {"title": "X"}
+
+    def test_has_dict_unpack_false(self):
+        pc = ParsedConstructor(class_name="A", kwargs={"x": 1}, raw="A(x=1)")
+        assert pc.has_dict_unpack is False
+
+    def test_has_dict_unpack_true(self):
+        pc = ParsedConstructor(class_name="A", kwargs={"**data": {}}, raw="A(**data)")
+        assert pc.has_dict_unpack is True
+
+
+class TestActionCall:
+    def test_basic(self):
+        ac = make_action_call()
+        assert ac.name == "act1"
+        assert ac.function == "fetch"
+        assert ac.arguments == {"url": "http://x"}
+
+    def test_frozen(self):
+        ac = make_action_call()
+        with pytest.raises((AttributeError, TypeError)):
+            ac.name = "other"
+
+
+class TestLNDLOutput:
+    def test_getitem(self):
+        ac = make_action_call()
+        out = LNDLOutput(
+            fields={"score": 0.9, "report": ac},
+            lvars={},
+            lacts={},
+            actions={"act1": ac},
+            raw_out_block="OUT{...}",
+        )
+        assert out["score"] == pytest.approx(0.9)
+        assert out["report"] is ac
+
+    def test_getattr_delegates_to_fields(self):
+        out = LNDLOutput(
+            fields={"score": 0.9},
+            lvars={},
+            lacts={},
+            actions={},
+            raw_out_block="",
+        )
+        assert out.score == pytest.approx(0.9)
+
+    def test_getattr_own_fields(self):
+        out = LNDLOutput(
+            fields={"score": 0.9},
+            lvars={"x": RLvarMetadata(local_name="x", value="v")},
+            lacts={},
+            actions={},
+            raw_out_block="test",
+        )
+        assert out.raw_out_block == "test"
+        assert "x" in out.lvars
+
+
+class TestHasActionCalls:
+    def test_clean_model(self):
+        m = SimpleModel(title="hello", score=1.0)
+        assert has_action_calls(m) is False
+
+    def test_model_with_action_call(self):
+        ac = make_action_call()
+        m = SimpleModel.model_construct(title=ac, score=0.0)
+        assert has_action_calls(m) is True
+
+    def test_nested_model_with_action_call(self):
+        ac = make_action_call()
+        inner = SimpleModel.model_construct(title=ac, score=0.0)
+        outer = NestedModel(name="outer", inner=inner)
+        assert has_action_calls(outer) is True
+
+    def test_clean_nested(self):
+        inner = SimpleModel(title="x", score=1.0)
+        outer = NestedModel(name="outer", inner=inner)
+        assert has_action_calls(outer) is False
+
+
+class TestEnsureNoActionCalls:
+    def test_clean_model_passthrough(self):
+        m = SimpleModel(title="hello", score=1.0)
+        result = ensure_no_action_calls(m)
+        assert result is m
+
+    def test_model_with_action_raises(self):
+        ac = make_action_call()
+        m = SimpleModel.model_construct(title=ac, score=0.0)
+        with pytest.raises(ValueError, match="unexecuted actions"):
+            ensure_no_action_calls(m)
+
+    def test_error_message_includes_field_name(self):
+        ac = make_action_call()
+        m = SimpleModel.model_construct(title=ac, score=0.0)
+        with pytest.raises(ValueError) as exc_info:
+            ensure_no_action_calls(m)
+        assert "title" in str(exc_info.value)
+
+
+class TestCoerceResult:
+    def test_dict_to_str_for_str_target(self):
+        result = _coerce_result({"key": "val"}, str)
+        assert isinstance(result, str)
+
+    def test_int_coercion(self):
+        result = _coerce_result("42", int)
+        assert result == 42
+
+    def test_float_coercion(self):
+        result = _coerce_result("3.14", float)
+        assert result == pytest.approx(3.14)
+
+    def test_no_coercion_same_type(self):
+        result = _coerce_result("hello", str)
+        assert result == "hello"
+
+    def test_none_target_type(self):
+        result = _coerce_result({"x": 1}, None)
+        assert result == {"x": 1}
+
+
+class TestRevalidateModel:
+    def test_replaces_action_call(self):
+        ac = ActionCall(name="t", function="fetch", arguments={}, raw_call="fetch()")
+        m = SimpleModel.model_construct(title=ac, score=1.0)
+        action_results = {"t": "Fetched Title"}
+        result = _revalidate_model(m, action_results)
+        assert result.title == "Fetched Title"
+
+    def test_raises_when_result_missing(self):
+        ac = ActionCall(name="missing", function="fn", arguments={}, raw_call="fn()")
+        m = SimpleModel.model_construct(title=ac, score=1.0)
+        with pytest.raises(ValueError, match="no execution result"):
+            _revalidate_model(m, {})
+
+    def test_unchanged_model_returns_same(self):
+        m = SimpleModel(title="hello", score=1.0)
+        result = _revalidate_model(m, {})
+        assert result is m
+
+
+class TestRevalidateWithActionResults:
+    def test_full_revalidation(self):
+        ac = ActionCall(name="s", function="summarize", arguments={}, raw_call="summarize()")
+        m = SimpleModel.model_construct(title="My Title", score=ac)
+        result = revalidate_with_action_results(m, {"s": 0.95})
+        assert result.score == pytest.approx(0.95)
+        assert result.title == "My Title"


### PR DESCRIPTION
## Summary

- Ports the LNDL (Lion Natural Description Language) structured-output formatter from `feat/beta` into main as a strictly opt-in feature
- Introduces `lionagi/lndl/` package: types, errors, prompt template, block extractor, and text normalizer (465 LOC total)
- Adds LNDL routing in `operations/parse/parse.py` behind an `Operable` isinstance guard — no change in behavior for existing `BaseModel` or `dict` callers
- Fixes a Pydantic v2.11 deprecation: `model_fields` accessed via `type(model)` instead of the instance
- `parse_lndl_fuzzy` intentionally raises `NotImplementedError` — it requires Phase 2 modules (lexer/parser/ast/resolver) which are deferred

## What ships (Phase 1)

| Module | Exports |
|---|---|
| `lndl/types.py` | `LNDLOutput`, `ActionCall`, `LvarMetadata`, `RLvarMetadata`, `LactMetadata`, `ParsedConstructor`, `Scalar`, `has_action_calls`, `ensure_no_action_calls`, `revalidate_with_action_results` |
| `lndl/errors.py` | `LNDLError` + 6 subclasses |
| `lndl/prompt.py` | `LNDL_SYSTEM_PROMPT`, `get_lndl_system_prompt` |
| `lndl/extract.py` | `extract_lndl_blocks` |
| `lndl/fuzzy.py` | `normalize_lndl_text` (Phase 1); `parse_lndl_fuzzy` raises `NotImplementedError` |

## Opt-in contract

Users must explicitly import:
```python
from lionagi.lndl import LNDLOutput, get_lndl_system_prompt, extract_lndl_blocks
```

LNDL is **not** exported from `lionagi.__init__`. The parse routing only activates when an `Operable` is passed as `response_format`.

## Test plan

- [x] 61 unit tests across 5 test modules (`tests/lndl/`) — all pass, 0 warnings
- [x] `tests/` import suite (151 passed) — no regressions
- [x] All pre-commit hooks pass (ruff, pyupgrade, ast check, end-of-files)
- [x] `parse_lndl_fuzzy` confirmed to raise `NotImplementedError` with clear Phase 2 message
- [x] `from lionagi.lndl import *` confirmed to not pollute `lionagi` top-level namespace

Closes #966 (Phase 1). Phase 2 tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)