### PR TITLE
fix(concurrency): signal-aware SIGINT handler in run_async — shielded teardown for phantom sessions (#1055)

### DIFF
--- a/lionagi/ln/concurrency/utils.py
+++ b/lionagi/ln/concurrency/utils.py
@@ -2,8 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import inspect
+import signal
 import threading
 from collections.abc import Awaitable, Callable
+from concurrent.futures import Future as _ThreadFuture
 from functools import cache, partial
 from typing import Any, ParamSpec, TypeVar
 
@@ -54,12 +56,49 @@ async def run_sync(func: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R
     return await anyio.to_thread.run_sync(func, *args)
 
 
+# ── SIGINT-aware run_async ────────────────────────────────────────────────────
+# SIGINT (Ctrl-C) is delivered to the MAIN thread by the OS.  The default
+# CPython handler raises KeyboardInterrupt in whatever bytecode the main
+# thread is currently executing — including threading.Thread.join().  When
+# that happens the join() call aborts immediately, the child thread is
+# orphaned with a live event loop, and the session row is never transitioned
+# away from "running" (the phantom-session bug, issue #1055).
+#
+# Fix: install a SIGINT handler in the parent thread *before* spawning the
+# child.  The handler shares the child's asyncio task reference (via a
+# Future) and calls task.cancel() through call_soon_threadsafe(), which
+# schedules the cancellation inside the running event loop.  The child's
+# coroutine then unwinds through its ``finally`` / ``with CancelScope(shield=True)``
+# teardown, closes the DB, transitions the session, and exits cleanly.
+# The parent blocks on thread.join() the whole time (join() is only
+# interrupted if KeyboardInterrupt arrives *outside* our handler, which
+# cannot happen while our handler is installed).
+#
+# Platform notes:
+# - signal.signal() requires the main thread; we guard with a
+#   threading.current_thread() check so nested/worker-thread callers are
+#   completely unaffected.
+# - This is tested on macOS (darwin).  On Linux the behaviour is identical
+#   because both use POSIX signals with the same CPython handler semantics.
+#   Windows does not have SIGINT in the POSIX sense; signal.SIGINT maps to
+#   a Ctrl-C event that Python also routes to the main thread, so the guard
+#   is compatible but untested on Windows.
+# - signal.getsignal() is safe from any thread; only signal.signal() is
+#   main-thread-only.
+
+
 def run_async(coro: Awaitable[T]) -> T:
     """Execute an async coroutine from a synchronous context.
 
     Creates an isolated thread with its own event loop to run the coroutine,
     avoiding conflicts with any existing event loop in the current thread.
     Thread-safe and blocks until completion.
+
+    When called from the main thread, installs a temporary SIGINT handler so
+    that Ctrl-C cancels the inner coroutine through its structured teardown
+    path (``finally`` / ``anyio.CancelScope(shield=True)``) instead of
+    orphaning the child thread.  The previous SIGINT handler is always
+    restored before this function returns.
 
     Args:
         coro: Awaitable to execute (coroutine, Task, or Future).
@@ -68,7 +107,11 @@ def run_async(coro: Awaitable[T]) -> T:
         The result of the awaited coroutine.
 
     Raises:
-        BaseException: Any exception raised by the coroutine is re-raised.
+        KeyboardInterrupt: If SIGINT was received while the coroutine was
+            running.  By the time this is raised the inner coroutine's
+            teardown has already completed and the child thread has exited.
+        BaseException: Any other exception raised by the coroutine is
+            re-raised.
         RuntimeError: If the coroutine completes without producing a result.
 
     Example:
@@ -85,20 +128,83 @@ def run_async(coro: Awaitable[T]) -> T:
     result_container: list[Any] = []
     exception_container: list[BaseException] = []
 
+    # Shared state between parent and child threads.
+    # _loop_and_task_future: child resolves with (loop, task) so the parent's
+    #   SIGINT handler can cancel the task via call_soon_threadsafe.
+    # _cancel_requested: set by the SIGINT handler so run_async knows to raise KBI.
+    _loop_and_task_future: _ThreadFuture[tuple[Any, Any]] = _ThreadFuture()
+    _cancel_requested = threading.Event()
+
     def run_in_thread() -> None:
+        import asyncio
+
         try:
 
             async def _runner() -> T:
+                # Capture (loop, task) from INSIDE the coroutine — this is the
+                # actual event loop that anyio.run() created, not any loop we
+                # might create manually before calling anyio.run().  We expose
+                # both to the parent's SIGINT handler BEFORE awaiting ``coro``
+                # so the handler can cancel the task while we're running.
+                _loop_and_task_future.set_result((asyncio.get_event_loop(), asyncio.current_task()))
                 return await coro
 
             result = anyio.run(_runner)
             result_container.append(result)
         except BaseException as e:
             exception_container.append(e)
+        finally:
+            # If _runner never ran (e.g. anyio setup failed before it was
+            # scheduled), the future would block the parent's SIGINT handler.
+            # Cancel the future with a sentinel so the handler gets a quick
+            # "no task available" signal and falls back gracefully.
+            if not _loop_and_task_future.done():
+                _loop_and_task_future.cancel()
 
     thread = threading.Thread(target=run_in_thread, daemon=False)
+
+    # Only install the SIGINT handler when we are in the main thread.
+    # signal.signal() raises ValueError from non-main threads.
+    in_main_thread = threading.current_thread() is threading.main_thread()
+
+    if in_main_thread:
+        old_sigint_handler = signal.getsignal(signal.SIGINT)
+
+        def _sigint_handler(signum: int, frame: Any) -> None:  # noqa: ARG001
+            """Cancel the inner task instead of raising KBI in the parent thread."""
+            _cancel_requested.set()
+            # Try to get the (loop, task) pair.  Use a short timeout: if the
+            # child hasn't set it yet (startup race), fall back to the previous
+            # handler so the process can still be interrupted.
+            try:
+                child_loop, task = _loop_and_task_future.result(timeout=0.5)
+            except Exception:  # noqa: BLE001
+                # Pair unavailable (startup race or already done) — fall back.
+                if callable(old_sigint_handler):
+                    old_sigint_handler(signum, frame)
+                return
+            if task is not None and child_loop is not None:
+                child_loop.call_soon_threadsafe(task.cancel)
+
+        signal.signal(signal.SIGINT, _sigint_handler)
+
     thread.start()
-    thread.join()
+    try:
+        # This join() will now NOT be interrupted by KeyboardInterrupt because
+        # our handler above intercepts SIGINT and schedules task cancellation
+        # instead.  The child thread runs teardown and exits normally, then
+        # join() returns here.
+        thread.join()
+    finally:
+        if in_main_thread:
+            # Always restore the previous handler before we raise anything.
+            signal.signal(signal.SIGINT, old_sigint_handler)
+
+    if _cancel_requested.is_set():
+        # The inner coroutine's teardown has already completed (thread.join()
+        # returned).  Now raise KeyboardInterrupt so callers (e.g. run_agent)
+        # see the expected signal-interrupted exit path.
+        raise KeyboardInterrupt
 
     if exception_container:
         raise exception_container[0]

--- a/lionagi/state/reasons.py
+++ b/lionagi/state/reasons.py
@@ -72,6 +72,7 @@ class RunReasons:
     FAILED_MISSING_ARTIFACT = "run.failed.missing_artifact"  # ADR-0029
     TIMED_OUT_DEADLINE = "run.timed_out.deadline"
     ABORTED_USER = "run.aborted.user"
+    CANCELLED_SIGINT = "run.cancelled.sigint"  # issue #1055
     CANCELLED_SYSTEM = "run.cancelled.system"
     CANCELLED_ORCHESTRATOR = "run.cancelled.orchestrator"
 

--- a/tests/libs/concurrency/test_sigint_teardown.py
+++ b/tests/libs/concurrency/test_sigint_teardown.py
@@ -1,0 +1,245 @@
+# Copyright (c) 2025-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Integration tests for SIGINT-shielded teardown in run_async (issue #1055).
+
+These tests use a subprocess + real SIGINT signal to verify that when Ctrl-C
+arrives while run_async is blocking on thread.join():
+
+1. The inner coroutine's structured teardown (finally / CancelScope) RUNS.
+2. The subprocess exits with code 130 (128 + SIGINT signal number).
+3. The child thread is not left orphaned.
+
+We cannot test this in-process because installing a custom SIGINT handler in
+the test suite's main thread would interfere with pytest's own signal handling.
+The subprocess approach gives true OS-level signal delivery.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import textwrap
+import time
+
+# The script run in the subprocess.  It:
+# 1. Writes a "ready" file so the parent knows the event loop is running.
+# 2. Defines a coroutine with a structured finalizer that writes a sentinel file.
+# 3. Calls run_async() which blocks the main thread.
+# 4. The parent test waits for the ready file, then sends SIGINT.
+# 5. Expected outcome: sentinel file written (teardown ran) + exit code 130.
+_SUBPROCESS_SCRIPT = textwrap.dedent("""\
+    import sys
+    import anyio as _anyio
+    from lionagi.ln.concurrency import run_async
+
+    SENTINEL = sys.argv[1]
+    READY    = sys.argv[2]
+
+    async def long_running():
+        # Signal to the parent that we are inside the event loop and sleeping.
+        with open(READY, "w") as f:
+            f.write("ready")
+        try:
+            # Sleep long enough that SIGINT will arrive before we finish.
+            await _anyio.sleep(30)
+            return "done"
+        finally:
+            # Shielded teardown: must run even on cancellation.
+            with _anyio.CancelScope(shield=True):
+                # Write the sentinel file to prove teardown ran.
+                with open(SENTINEL, "w") as f:
+                    f.write("teardown_ran")
+                # Simulate a brief async DB write.
+                await _anyio.sleep(0.05)
+
+    try:
+        result = run_async(long_running())
+        sys.exit(0)
+    except KeyboardInterrupt:
+        # run_async re-raises KeyboardInterrupt after teardown completes.
+        # Exit 130 = 128 + SIGINT (Unix convention for signal-terminated processes).
+        sys.exit(130)
+""")
+
+
+def _run_subprocess_with_sigint(
+    script: str,
+    sentinel_path: str,
+    ready_path: str,
+    *,
+    startup_timeout_s: float = 10.0,
+    join_timeout_s: float = 15.0,
+) -> int:
+    """Run ``script`` in a subprocess, wait for ready signal, send SIGINT, return exit code.
+
+    The script is expected to accept two arguments:
+    1. sentinel_path — file to create in the structured teardown (proves teardown ran).
+    2. ready_path    — file the script creates once it is inside the event loop and
+                       sleeping, so we know SIGINT will interrupt an actual coroutine
+                       rather than fire during import/startup.
+    """
+    proc = subprocess.Popen(
+        [sys.executable, "-c", script, sentinel_path, ready_path],
+        # Do NOT use PIPE for stdout/stderr — reading them with proc.wait()
+        # (not communicate()) can deadlock when the pipe buffer fills.
+        # Suppress output so tests are quiet.
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        # New process group so we can send SIGINT only to the child,
+        # not to the test runner's own process group.
+        start_new_session=True,
+    )
+
+    # Wait until the subprocess is inside the event loop (ready file appears),
+    # instead of using a fixed sleep.  This removes flakiness under load.
+    deadline = time.monotonic() + startup_timeout_s
+    while not os.path.exists(ready_path):
+        if time.monotonic() > deadline:
+            proc.kill()
+            proc.wait()
+            raise AssertionError(
+                f"Subprocess did not write ready file within {startup_timeout_s}s — "
+                "startup failed or event loop never started."
+            )
+        time.sleep(0.02)
+
+    # Give the event loop a brief moment to actually enter the sleep() call
+    # after writing the ready file.
+    time.sleep(0.05)
+
+    # Send SIGINT to the subprocess (not our own process group).
+    os.kill(proc.pid, signal.SIGINT)
+
+    # Wait for the subprocess to exit.  It should finish within join_timeout_s
+    # (teardown is ~50ms, then the process exits).
+    try:
+        proc.wait(timeout=join_timeout_s)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+        raise AssertionError(
+            f"Subprocess did not exit within {join_timeout_s}s after SIGINT — "
+            "possible orphaned child thread / deadlock."
+        )
+
+    return proc.returncode
+
+
+def test_sigint_runs_shielded_teardown():
+    """Teardown (finally block) executes even when SIGINT cancels run_async."""
+    with tempfile.NamedTemporaryFile(suffix=".sentinel", delete=False) as f:
+        sentinel = f.name
+    with tempfile.NamedTemporaryFile(suffix=".ready", delete=False) as f:
+        ready = f.name
+    # Remove both files so we can detect them being created.
+    os.unlink(sentinel)
+    os.unlink(ready)
+
+    try:
+        exit_code = _run_subprocess_with_sigint(_SUBPROCESS_SCRIPT, sentinel, ready)
+
+        # 1. Teardown ran: the sentinel file must exist.
+        assert os.path.exists(sentinel), (
+            "Sentinel file was NOT written — shielded teardown did not run.  "
+            "The inner coroutine's finally block was skipped, indicating the child "
+            "thread was orphaned by SIGINT (phantom-session regression, issue #1055)."
+        )
+        with open(sentinel) as fh:
+            content = fh.read()
+        assert content == "teardown_ran", f"Unexpected sentinel content: {content!r}"
+
+        # 2. Process exited with 130 (SIGINT convention).
+        assert exit_code == 130, (
+            f"Expected exit code 130 (SIGINT), got {exit_code}.  "
+            "run_async should re-raise KeyboardInterrupt after teardown completes."
+        )
+    finally:
+        for path in (sentinel, ready):
+            if os.path.exists(path):
+                os.unlink(path)
+
+
+def test_sigint_does_not_orphan_thread():
+    """Subprocess exits within the grace period (no orphaned background thread)."""
+    with tempfile.NamedTemporaryFile(suffix=".sentinel2", delete=False) as f:
+        sentinel = f.name
+    with tempfile.NamedTemporaryFile(suffix=".ready2", delete=False) as f:
+        ready = f.name
+    os.unlink(sentinel)
+    os.unlink(ready)
+    try:
+        # If the thread is orphaned, proc.wait() would time out.
+        exit_code = _run_subprocess_with_sigint(
+            _SUBPROCESS_SCRIPT,
+            sentinel,
+            ready,
+            join_timeout_s=15.0,
+        )
+        # Any exit code is acceptable here — the important thing is that
+        # the subprocess exited at all (no timeout / orphaned thread).
+        assert exit_code is not None  # always true if we got here without timeout
+    finally:
+        for path in (sentinel, ready):
+            if os.path.exists(path):
+                os.unlink(path)
+
+
+def test_run_async_normal_completion_unaffected():
+    """Regression guard: normal run_async usage (no SIGINT) still works."""
+    import anyio
+
+    from lionagi.ln.concurrency import run_async
+
+    async def simple():
+        await anyio.sleep(0)
+        return 42
+
+    result = run_async(simple())
+    assert result == 42
+
+
+def test_run_async_exception_still_propagates():
+    """Exceptions from the coroutine still bubble up through run_async."""
+    import anyio
+    import pytest
+
+    from lionagi.ln.concurrency import run_async
+
+    async def raises():
+        await anyio.sleep(0)
+        raise ValueError("expected error")
+
+    with pytest.raises(ValueError, match="expected error"):
+        run_async(raises())
+
+
+def test_run_async_in_non_main_thread_no_signal_handler():
+    """run_async called from a non-main thread: no signal handler, still works."""
+    import threading
+
+    import anyio
+
+    from lionagi.ln.concurrency import run_async
+
+    results: list = []
+    errors: list = []
+
+    def worker():
+        try:
+
+            async def coro():
+                await anyio.sleep(0)
+                return "from_thread"
+
+            results.append(run_async(coro()))
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join(timeout=5)
+    assert not errors, f"run_async in non-main thread raised: {errors}"
+    assert results == ["from_thread"]


### PR DESCRIPTION
## Summary

- **Root cause**: SIGINT during `thread.join()` raised `KeyboardInterrupt` in the main thread, aborting the join and orphaning the child thread + its event loop. The session row was never transitioned away from `running` — the phantom-session bug.
- **Fix** (`lionagi/ln/concurrency/utils.py`): Before spawning the child thread, `run_async()` installs a temporary SIGINT handler. On Ctrl-C, the handler cancels the asyncio root task via `call_soon_threadsafe()`. The anyio `CancelScope(shield=True)` teardown in `_run_agent` unwinds normally (DB close, status transition), `thread.join()` completes, then `KeyboardInterrupt` is re-raised so callers get the expected exit-130 path.
- **New reason code** (`lionagi/state/reasons.py`): `RunReasons.CANCELLED_SIGINT = "run.cancelled.sigint"` — reserved for future use to distinguish SIGINT-triggered cancellation from a system-level `CancelledError`.
- **Integration test** (`tests/libs/concurrency/test_sigint_teardown.py`): Subprocess-level tests that send real OS SIGINT and verify (a) the shielded teardown sentinel file is written and (b) the subprocess exits 130.

## Conflict note — PR #1082

PR #1082 (`fix/issue-1082-anyio-noeventlooperror`) also touches `lionagi/cli/agent.py` to fix `NoEventLoopError` after the event loop closes. These are **complementary** fixes — #1082 patches the `get_cancelled_exc_class()` call-after-loop-exit; this PR prevents the loop from being abandoned in the first place. No merge conflict on `utils.py` (different files), but reviewers should merge both and verify the interaction.

## Platform notes

- Tested on **macOS (darwin)**. Linux behavior is identical (same POSIX `signal.signal` semantics).
- A `threading.current_thread() is threading.main_thread()` guard ensures calls from worker threads are completely unaffected (`signal.signal()` requires the main thread).
- Windows: `signal.SIGINT` maps to Ctrl-C and is routed to the main thread by Python — the guard is compatible but untested on Windows.

## Test plan

- [x] `uv run pytest tests/libs/concurrency/test_sigint_teardown.py -xvs` — 5 new tests pass
- [x] `uv run pytest tests/libs/concurrency/` — 199 tests pass (0 failures)
- [x] `uv run pytest tests/cli/` — 247 passed, 1 skipped (pre-existing skip)
- [x] `ruff check` and `ruff format --check` on modified files — clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)