### PR TITLE
feat(studio/a11y): programmatic form labels for WCAG 4.1.2 (#1020 Track 1)

### DIFF
--- a/apps/studio/frontend/components/AgentProfileForm.tsx
+++ b/apps/studio/frontend/components/AgentProfileForm.tsx
@@ -120,7 +120,9 @@ export default function AgentProfileForm({
         </div>
 
         <div className="flex flex-col gap-1">
-          <label htmlFor="agent-name" className={FIELD_LABEL}>Name</label>
+          <label htmlFor="agent-name" className={FIELD_LABEL}>
+            Name
+          </label>
           <input
             id="agent-name"
             type="text"
@@ -133,7 +135,9 @@ export default function AgentProfileForm({
         </div>
 
         <div className="flex flex-col gap-1">
-          <label htmlFor="agent-description" className={FIELD_LABEL}>Description</label>
+          <label htmlFor="agent-description" className={FIELD_LABEL}>
+            Description
+          </label>
           <input
             id="agent-description"
             type="text"
@@ -154,7 +158,9 @@ export default function AgentProfileForm({
 
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           <div className="flex flex-col gap-1">
-            <label htmlFor="agent-provider" className={FIELD_LABEL}>Provider</label>
+            <label htmlFor="agent-provider" className={FIELD_LABEL}>
+              Provider
+            </label>
             <select
               id="agent-provider"
               value={provider}
@@ -170,7 +176,9 @@ export default function AgentProfileForm({
           </div>
 
           <div className="flex flex-col gap-1">
-            <label htmlFor="agent-model" className={FIELD_LABEL}>Model</label>
+            <label htmlFor="agent-model" className={FIELD_LABEL}>
+              Model
+            </label>
             <input
               id="agent-model"
               type="text"
@@ -190,7 +198,9 @@ export default function AgentProfileForm({
           {/* Permission Mode — claude_code only */}
           {provider === "claude_code" ? (
             <div className="flex flex-col gap-1">
-              <label htmlFor="agent-perm-mode" className={FIELD_LABEL}>Permission Mode</label>
+              <label htmlFor="agent-perm-mode" className={FIELD_LABEL}>
+                Permission Mode
+              </label>
               <select
                 id="agent-perm-mode"
                 value={form.permission_mode ?? "default"}
@@ -214,7 +224,9 @@ export default function AgentProfileForm({
           {/* Reasoning Effort — codex only */}
           {provider === "codex" ? (
             <div className="flex flex-col gap-1">
-              <label htmlFor="agent-reasoning-effort" className={FIELD_LABEL}>Reasoning Effort</label>
+              <label htmlFor="agent-reasoning-effort" className={FIELD_LABEL}>
+                Reasoning Effort
+              </label>
               <select
                 id="agent-reasoning-effort"
                 value={form.reasoning_effort ?? "none"}
@@ -240,11 +252,13 @@ export default function AgentProfileForm({
       {/* Section 3: System Prompt */}
       <section className="flex flex-col gap-3">
         <div>
-          <h2 className={SECTION_LABEL}>System Prompt</h2>
+          <label htmlFor="agent-system-prompt" className={SECTION_LABEL}>
+            System Prompt
+          </label>
           <p className={SECTION_DESC}>Base identity and role instructions for this agent</p>
         </div>
         <textarea
-          aria-label="System prompt"
+          id="agent-system-prompt"
           value={form.system_prompt ?? ""}
           onChange={(e) => setForm((prev) => ({ ...prev, system_prompt: e.target.value }))}
           placeholder="You are a specialized agent that..."
@@ -256,11 +270,13 @@ export default function AgentProfileForm({
       {/* Section 4: Guidance */}
       <section className="flex flex-col gap-3">
         <div>
-          <h2 className={SECTION_LABEL}>Guidance</h2>
+          <label htmlFor="agent-guidance" className={SECTION_LABEL}>
+            Guidance
+          </label>
           <p className={SECTION_DESC}>Task-specific instructions and constraints</p>
         </div>
         <textarea
-          aria-label="Guidance"
+          id="agent-guidance"
           value={form.guidance ?? ""}
           onChange={(e) => setForm((prev) => ({ ...prev, guidance: e.target.value }))}
           placeholder="When working on this task, always..."

--- a/apps/studio/frontend/components/ModelConfigTable.tsx
+++ b/apps/studio/frontend/components/ModelConfigTable.tsx
@@ -166,12 +166,14 @@ export default function ModelConfigTable({ models, onChange }: ModelConfigTableP
               const showEffort = provider === "codex";
               const showPermission = provider === "claude_code";
 
+              const rowLabel = role || `row ${index + 1}`;
               return (
                 <tr key={index} className="border-b border-neutral-900 text-neutral-300">
                   {/* Role Name */}
                   <td className="px-3 py-2 align-middle">
                     <input
                       type="text"
+                      aria-label={`Role name for row ${index + 1}`}
                       value={role}
                       onChange={(e) => handleRoleChange(index, e.target.value)}
                       placeholder="role_name"
@@ -182,6 +184,7 @@ export default function ModelConfigTable({ models, onChange }: ModelConfigTableP
                   {/* Provider */}
                   <td className="px-3 py-2 align-middle">
                     <select
+                      aria-label={`Provider for ${rowLabel}`}
                       value={provider}
                       onChange={(e) => handleProviderChange(index, e.target.value)}
                       className={selectClass}
@@ -197,6 +200,7 @@ export default function ModelConfigTable({ models, onChange }: ModelConfigTableP
                   {/* Model */}
                   <td className="px-3 py-2 align-middle">
                     <select
+                      aria-label={`Model for ${rowLabel}`}
                       value={config.model}
                       onChange={(e) => handleModelChange(index, e.target.value)}
                       className={selectClass}
@@ -213,6 +217,7 @@ export default function ModelConfigTable({ models, onChange }: ModelConfigTableP
                   <td className="px-3 py-2 align-middle">
                     {showEffort ? (
                       <select
+                        aria-label={`Reasoning effort for ${rowLabel}`}
                         value={config.reasoning_effort ?? "none"}
                         onChange={(e) => handleEffortChange(index, e.target.value)}
                         className={selectClass}
@@ -232,6 +237,7 @@ export default function ModelConfigTable({ models, onChange }: ModelConfigTableP
                   <td className="px-3 py-2 align-middle">
                     {showPermission ? (
                       <select
+                        aria-label={`Permission mode for ${rowLabel}`}
                         value={config.permission_mode ?? "default"}
                         onChange={(e) => handlePermissionChange(index, e.target.value)}
                         className={selectClass}

--- a/apps/studio/frontend/components/canvas/SidePanel.tsx
+++ b/apps/studio/frontend/components/canvas/SidePanel.tsx
@@ -127,9 +127,12 @@ function NodePanel({
 
       {/* Role */}
       <div>
-        <label className={LABEL_CLS}>Role</label>
+        <label htmlFor={`${id}-role`} className={LABEL_CLS}>
+          Role
+        </label>
         {editable ? (
           <select
+            id={`${id}-role`}
             value={data.role}
             onChange={(e) => update("role", e.target.value)}
             className={INPUT_CLS}
@@ -173,9 +176,12 @@ function NodePanel({
 
       {/* Assignment */}
       <div>
-        <label className={LABEL_CLS}>Assignment</label>
+        <label htmlFor={`${id}-assignment`} className={LABEL_CLS}>
+          Assignment
+        </label>
         {editable ? (
           <input
+            id={`${id}-assignment`}
             type="text"
             value={data.assignment}
             onChange={(e) => update("assignment", e.target.value)}
@@ -189,9 +195,12 @@ function NodePanel({
 
       {/* Prompt */}
       <div>
-        <label className={LABEL_CLS}>Prompt Template</label>
+        <label htmlFor={`${id}-prompt`} className={LABEL_CLS}>
+          Prompt Template
+        </label>
         {editable ? (
           <textarea
+            id={`${id}-prompt`}
             value={data.prompt}
             onChange={(e) => update("prompt", e.target.value)}
             placeholder="Use {field} syntax for inputs"
@@ -208,9 +217,12 @@ function NodePanel({
       {/* Capacity + Timeout */}
       <div className="flex gap-3">
         <div className="flex-1">
-          <label className={LABEL_CLS}>Capacity</label>
+          <label htmlFor={`${id}-capacity`} className={LABEL_CLS}>
+            Capacity
+          </label>
           {editable ? (
             <input
+              id={`${id}-capacity`}
               type="number"
               min={1}
               value={data.capacity ?? 1}
@@ -222,9 +234,12 @@ function NodePanel({
           )}
         </div>
         <div className="flex-1">
-          <label className={LABEL_CLS}>Timeout (s)</label>
+          <label htmlFor={`${id}-timeout`} className={LABEL_CLS}>
+            Timeout (s)
+          </label>
           {editable ? (
             <input
+              id={`${id}-timeout`}
               type="number"
               min={0}
               value={data.timeout ?? ""}
@@ -281,7 +296,7 @@ function EdgePanel({
 
       {/* Mode toggle */}
       <div>
-        <label className={LABEL_CLS}>Mode</label>
+        <p className={LABEL_CLS}>Mode</p>
         {editable ? (
           <div className="flex gap-1">
             {(["simple", "code"] as const).map((m) => (
@@ -307,9 +322,12 @@ function EdgePanel({
         <>
           {/* Condition */}
           <div>
-            <label className={LABEL_CLS}>Condition (optional)</label>
+            <label htmlFor={`${id}-condition`} className={LABEL_CLS}>
+              Condition (optional)
+            </label>
             {editable ? (
               <input
+                id={`${id}-condition`}
                 type="text"
                 value={data.condition ?? ""}
                 onChange={(e) => update("condition", e.target.value)}
@@ -325,7 +343,7 @@ function EdgePanel({
 
           {/* Field map */}
           <div>
-            <label className={LABEL_CLS}>Field Map</label>
+            <p className={LABEL_CLS}>Field Map</p>
             {data.map && Object.keys(data.map).length > 0 ? (
               <div className="flex flex-col gap-1">
                 {Object.entries(data.map).map(([k, v]) => (
@@ -342,9 +360,12 @@ function EdgePanel({
       ) : (
         /* Code handler */
         <div>
-          <label className={LABEL_CLS}>Handler</label>
+          <label htmlFor={`${id}-handler`} className={LABEL_CLS}>
+            Handler
+          </label>
           {editable ? (
             <textarea
+              id={`${id}-handler`}
               value={data.handler ?? ""}
               onChange={(e) => update("handler", e.target.value)}
               placeholder="Python code snippet"
@@ -389,7 +410,7 @@ function ExecResultPanel({
       )}
 
       <div>
-        <label className={LABEL_CLS}>Output</label>
+        <p className={LABEL_CLS}>Output</p>
         {Object.keys(result).length > 0 ? (
           <div className="flex flex-col gap-2">
             {Object.entries(result).map(([key, val]) => (


### PR DESCRIPTION
## Summary

- **AgentProfileForm** (2 inputs): convert floating `<h2>` to `<label htmlFor>` on system-prompt and guidance `<textarea>` elements
- **ModelConfigTable** (5 inputs × N rows): add `aria-label` to role-name input, provider/model/effort/permission selects — `htmlFor` cannot cross table row boundaries, so `aria-label` is the correct pattern here
- **SidePanel/canvas** (7 inputs): wire `htmlFor↔id` on NodePanel (role select, assignment, prompt, capacity, timeout) and EdgePanel (condition, handler); convert decorative `<label>` with no target (Mode, Field Map, Output) to `<p>` to avoid a11y false label associations

No visual changes. All labels were already visually present — this PR makes them programmatically associated per WCAG 4.1.2 (Name, Role, Value).

`WorkerForm.tsx` listed in the audit does not exist as a file; the worker form UI is embedded in `SidePanel` (canvas) which is covered above.

Tracks 2–6 of #1020 are tracked separately.

## Test plan

- [ ] TypeScript: `pnpm typecheck` — passes clean (verified locally)
- [ ] ESLint: `pnpm lint` — 0 errors, 1 pre-existing warning in unrelated `runs/page.tsx`
- [ ] Prettier: passes (pre-commit hook verified)
- [ ] Manual: open Agent create/edit form, verify screen reader announces "System Prompt" and "Guidance" labels when tabbing to those textareas
- [ ] Manual: open Graph Playbook editor, select a step node in the SidePanel, verify role/assignment/prompt/capacity/timeout inputs are announced with their labels
- [ ] Manual: open Model Config table, verify each row's inputs announce their labels (e.g. "Provider for role_1")

🤖 Generated with [Claude Code](https://claude.com/claude-code)