### PR TITLE
feat(messages): port custom render + parser protocols from beta (Phase 1)

### DIFF
--- a/lionagi/protocols/messages/__init__.py
+++ b/lionagi/protocols/messages/__init__.py
@@ -8,7 +8,10 @@ from .base import MESSAGE_FIELDS, MessageRole, SenderRecipient
 from .instruction import Instruction, InstructionContent
 from .manager import MessageManager, create_message
 from .message import Message, MessageContent, RoledMessage
+from .prepare import prepare_messages_for_chat
+from .rendering import CustomParser, CustomRenderer, StructureFormat
 from .system import System, SystemContent
+from .validators import validate_image_url
 
 __all__ = (
     "ActionRequest",
@@ -17,6 +20,8 @@ __all__ = (
     "ActionResponseContent",
     "AssistantResponse",
     "AssistantResponseContent",
+    "CustomParser",
+    "CustomRenderer",
     "Instruction",
     "InstructionContent",
     "MESSAGE_FIELDS",
@@ -26,7 +31,10 @@ __all__ = (
     "MessageRole",
     "RoledMessage",
     "SenderRecipient",
+    "StructureFormat",
     "System",
     "SystemContent",
     "create_message",
+    "prepare_messages_for_chat",
+    "validate_image_url",
 )

--- a/lionagi/protocols/messages/action_request.py
+++ b/lionagi/protocols/messages/action_request.py
@@ -37,6 +37,23 @@ class ActionRequestContent(MessageContent):
         }
         return minimal_yaml(doc).strip()
 
+    def render(self, *_args: Any, **_kwargs: Any) -> str:
+        """Render action request.  Delegates to :attr:`rendered` for beta API compat."""
+        return self.rendered
+
+    def render_compact(self) -> str:
+        """Function-call representation for round summaries."""
+        func = self.function or "unknown"
+        parts = [
+            f"{k}={v!r}" if isinstance(v, str) else f"{k}={v}" for k, v in self.arguments.items()
+        ]
+        return f"{func}({', '.join(parts)})"
+
+    @property
+    def role(self) -> MessageRole:
+        """Role for this content type (beta API compat)."""
+        return MessageRole.ACTION
+
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "ActionRequestContent":
         """Construct ActionRequestContent from dictionary."""

--- a/lionagi/protocols/messages/action_response.py
+++ b/lionagi/protocols/messages/action_response.py
@@ -24,6 +24,45 @@ class ActionResponseContent(MessageContent):
     arguments: dict[str, Any] = field(default_factory=dict)
     output: Any = None
     action_request_id: str | None = None
+    error: str | None = None
+
+    @property
+    def role(self) -> MessageRole:
+        """Role for this content type (beta API compat)."""
+        return MessageRole.ACTION
+
+    @property
+    def request_id(self) -> str | None:
+        """Alias for action_request_id (beta API compat)."""
+        return self.action_request_id
+
+    @property
+    def result(self) -> Any:
+        """Alias for output (beta API compat)."""
+        return self.output
+
+    @property
+    def success(self) -> bool:
+        """True when no error was recorded."""
+        return self.error is None
+
+    def render(self, *_args: Any, **_kwargs: Any) -> str:
+        """Render action response.  Delegates to :attr:`rendered` for beta API compat."""
+        return self.rendered
+
+    def render_summary(self) -> str:
+        """Render result content for round-level aggregation."""
+        from lionagi.libs.schema.minimal_yaml import minimal_yaml
+
+        if not self.success:
+            return f"error: {self.error or 'unknown'}"
+        if self.output is None:
+            return "ok"
+        if isinstance(self.output, str):
+            return self.output
+        if isinstance(self.output, dict | list):
+            return minimal_yaml(self.output)
+        return str(self.output)
 
     @property
     def rendered(self) -> str:

--- a/lionagi/protocols/messages/assistant_response.py
+++ b/lionagi/protocols/messages/assistant_response.py
@@ -66,10 +66,7 @@ def parse_assistant_response(
                         content = out.get("content", [])
                         if isinstance(content, list):
                             for c in content:
-                                if (
-                                    isinstance(c, dict)
-                                    and c.get("type") == "output_text"
-                                ):
+                                if isinstance(c, dict) and c.get("type") == "output_text":
                                     text_contents.append(c.get("text", ""))
                                 elif isinstance(c, str):
                                     text_contents.append(c)
@@ -82,9 +79,7 @@ def parse_assistant_response(
             text_contents.append(item)
 
     text = "".join(text_contents)
-    model_response = (
-        model_responses[0] if len(model_responses) == 1 else model_responses
-    )
+    model_response = model_responses[0] if len(model_responses) == 1 else model_responses
 
     return text, model_response
 
@@ -100,9 +95,23 @@ class AssistantResponseContent(MessageContent):
     assistant_response: str = ""
 
     @property
+    def role(self) -> MessageRole:
+        """Role for this content type (beta API compat)."""
+        return MessageRole.ASSISTANT
+
+    @property
+    def response(self) -> str:
+        """Alias for assistant_response (beta API compat)."""
+        return self.assistant_response
+
+    @property
     def rendered(self) -> str:
         """Render assistant response as plain text."""
         return self.assistant_response
+
+    def render(self, *_args: Any, **_kwargs: Any) -> str:
+        """Render assistant response.  Delegates to :attr:`rendered` for beta API compat."""
+        return self.rendered
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "AssistantResponseContent":

--- a/lionagi/protocols/messages/instruction.py
+++ b/lionagi/protocols/messages/instruction.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, Literal
 
@@ -7,6 +8,7 @@ from pydantic import BaseModel, field_validator
 from lionagi.ln.types import ModelConfig
 
 from .message import Message, MessageContent, MessageRole
+from .rendering import StructureFormat
 
 
 @dataclass(slots=True)
@@ -30,7 +32,7 @@ class InstructionContent(MessageContent):
 
     _config: ClassVar[ModelConfig] = ModelConfig(
         none_as_sentinel=True,
-        serialize_exclude=frozenset({"response_format"}),
+        serialize_exclude=frozenset({"response_format", "custom_renderer"}),
     )
 
     instruction: str | None = None
@@ -38,9 +40,7 @@ class InstructionContent(MessageContent):
     prompt_context: list[Any] = field(default_factory=list)
     plain_content: str | None = None
     tool_schemas: list[dict[str, Any]] = field(default_factory=list)
-    response_format: type[BaseModel] | dict[str, Any] | BaseModel | None = (
-        None  # User input
-    )
+    response_format: type[BaseModel] | dict[str, Any] | BaseModel | None = None  # User input
     _schema_dict: dict[str, Any] | None = field(
         default=None, repr=False
     )  # Internal: dict for prompting
@@ -49,10 +49,13 @@ class InstructionContent(MessageContent):
     )  # Internal: class for validation
     images: list[str] = field(default_factory=list)
     image_detail: Literal["low", "high", "auto"] | None = None
+    structure_format: str | None = None  # "json", "lndl", "custom"
+    custom_renderer: Callable | None = field(default=None, repr=False)
 
     def __init__(
         self,
         instruction: str | None = None,
+        primary: str | None = None,  # alias for instruction
         guidance: str | None = None,
         prompt_context: list[Any] | None = None,
         context: list[Any] | None = None,  # backwards compat
@@ -61,7 +64,13 @@ class InstructionContent(MessageContent):
         response_format: type[BaseModel] | dict[str, Any] | BaseModel | None = None,
         images: list[str] | None = None,
         image_detail: Literal["low", "high", "auto"] | None = None,
+        structure_format: str | None = None,
+        custom_renderer: Callable | None = None,
     ):
+        # Handle primary as alias for instruction (primary loses if both are set)
+        if primary is not None and instruction is None:
+            instruction = primary
+
         # Handle backwards compatibility: context -> prompt_context
         if context is not None and prompt_context is None:
             prompt_context = context
@@ -72,9 +81,7 @@ class InstructionContent(MessageContent):
 
         if response_format is not None:
             # Extract model class
-            if isinstance(response_format, type) and issubclass(
-                response_format, BaseModel
-            ):
+            if isinstance(response_format, type) and issubclass(response_format, BaseModel):
                 model_class = response_format
             elif isinstance(response_format, BaseModel):
                 model_class = type(response_format)
@@ -105,22 +112,116 @@ class InstructionContent(MessageContent):
             "tool_schemas",
             tool_schemas if tool_schemas is not None else [],
         )
-        object.__setattr__(
-            self, "response_format", response_format
-        )  # Store original user input
-        object.__setattr__(
-            self, "_schema_dict", schema_dict
-        )  # Internal: dict for prompting
-        object.__setattr__(
-            self, "_model_class", model_class
-        )  # Internal: class for validation
+        object.__setattr__(self, "response_format", response_format)  # Store original user input
+        object.__setattr__(self, "_schema_dict", schema_dict)  # Internal: dict for prompting
+        object.__setattr__(self, "_model_class", model_class)  # Internal: class for validation
         object.__setattr__(self, "images", images if images is not None else [])
         object.__setattr__(self, "image_detail", image_detail)
+        object.__setattr__(self, "structure_format", structure_format)
+        object.__setattr__(self, "custom_renderer", custom_renderer)
 
     @property
     def context(self) -> list[Any]:
         """Backwards compatibility accessor for prompt_context."""
         return self.prompt_context
+
+    @property
+    def primary(self) -> str | None:
+        """Alias for instruction field."""
+        return self.instruction
+
+    @primary.setter
+    def primary(self, value: str | None) -> None:
+        """Write through to instruction field."""
+        object.__setattr__(self, "instruction", value)
+
+    @property
+    def role(self) -> MessageRole:
+        """Role for this content type (beta API compat)."""
+        return MessageRole.USER
+
+    def with_updates(self, **kwargs: Any) -> "InstructionContent":
+        """Return a new instance with updated fields.
+
+        Handles ``primary`` as an alias for ``instruction`` and strips the
+        beta-only ``copy_containers`` kwarg.
+        """
+        kwargs.pop("copy_containers", None)
+        # Translate 'primary' alias -> 'instruction'
+        if "primary" in kwargs:
+            primary_val = kwargs.pop("primary")
+            if primary_val is not None:
+                kwargs["instruction"] = primary_val
+        # Translate 'context' alias -> 'prompt_context'
+        if "context" in kwargs:
+            ctx_val = kwargs.pop("context")
+            kwargs["prompt_context"] = (
+                ctx_val if isinstance(ctx_val, list) else [ctx_val] if ctx_val is not None else []
+            )
+        # Translate 'request_model' -> 'response_format'
+        if "request_model" in kwargs:
+            kwargs["response_format"] = kwargs.pop("request_model")
+        dict_ = self.to_dict()
+        dict_.update(kwargs)
+        return type(self)(**dict_)
+
+    def render(
+        self,
+        structure_format: str | StructureFormat | None = None,
+        custom_renderer: Callable | None = None,
+        **kwargs: Any,
+    ) -> str | list[dict[str, Any]]:
+        """Render instruction content, dispatching to custom_renderer when set.
+
+        Falls back to the standard :attr:`rendered` property if no custom
+        renderer is provided.
+        """
+        renderer = custom_renderer or self.custom_renderer
+        if renderer is not None:
+            if self._model_class is not None:
+                return renderer(self._model_class, **kwargs)
+            return renderer(type(None), **kwargs)
+        return self.rendered
+
+    @classmethod
+    def create(
+        cls,
+        primary: str | None = None,
+        context: Any = None,
+        tool_schemas: list[dict[str, Any]] | None = None,
+        request_model: type[BaseModel] | None = None,
+        images: list[str] | None = None,
+        image_detail: Literal["low", "high", "auto"] | None = None,
+        structure_format: str | StructureFormat | None = None,
+        custom_renderer: Callable | None = None,
+        **kwargs: Any,
+    ) -> "InstructionContent":
+        """Create InstructionContent with beta-compatible signature.
+
+        Accepts both old (request_model, primary) and new (response_format,
+        instruction) field names.  ``structure_format`` accepts both string
+        values and ``StructureFormat`` enum members.
+        """
+        # Normalise structure_format to str
+        sf: str | None = None
+        if structure_format is not None:
+            sf = (
+                structure_format.value
+                if isinstance(structure_format, StructureFormat)
+                else str(structure_format)
+            )
+
+        return cls(
+            primary=primary,
+            context=context,
+            tool_schemas=tool_schemas,
+            response_format=request_model,
+            images=images,
+            image_detail=image_detail,
+            structure_format=sf,
+            custom_renderer=custom_renderer,
+            **kwargs,
+        )
 
     @property
     def response_model_cls(self) -> type[BaseModel] | None:
@@ -208,9 +309,7 @@ class InstructionContent(MessageContent):
             valid_format = False
 
             # Extract model class
-            if isinstance(response_format, type) and issubclass(
-                response_format, BaseModel
-            ):
+            if isinstance(response_format, type) and issubclass(response_format, BaseModel):
                 model_class = response_format
                 valid_format = True
             elif isinstance(response_format, BaseModel):
@@ -283,11 +382,7 @@ class InstructionContent(MessageContent):
     @staticmethod
     def _format_image_item(idx: str, detail: str) -> dict[str, Any]:
         url = idx
-        if not (
-            idx.startswith("http://")
-            or idx.startswith("https://")
-            or idx.startswith("data:")
-        ):
+        if not (idx.startswith("http://") or idx.startswith("https://") or idx.startswith("data:")):
             url = f"data:image/jpeg;base64,{idx}"
         return {
             "type": "image_url",

--- a/lionagi/protocols/messages/prepare.py
+++ b/lionagi/protocols/messages/prepare.py
@@ -1,0 +1,338 @@
+# Copyright (c) 2025 - 2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any, cast
+
+from pydantic import JsonValue
+
+from lionagi.protocols.generic.pile import Pile
+from lionagi.protocols.generic.progression import Progression
+from lionagi.protocols.messages.action_request import ActionRequestContent
+from lionagi.protocols.messages.action_response import ActionResponseContent
+from lionagi.protocols.messages.assistant_response import AssistantResponseContent
+from lionagi.protocols.messages.instruction import InstructionContent
+from lionagi.protocols.messages.message import MessageContent
+from lionagi.protocols.messages.system import SystemContent
+
+if TYPE_CHECKING:
+    from lionagi.protocols.messages import Message
+
+__all__ = ("prepare_messages_for_chat",)
+
+# ---------------------------------------------------------------------------
+# Type aliases — production content types are canonical.
+# ---------------------------------------------------------------------------
+Instruction = InstructionContent
+System = SystemContent
+ActionRequest = ActionRequestContent
+ActionResponse = ActionResponseContent
+Assistant = AssistantResponseContent
+RoledContent = MessageContent
+
+
+def _get_text(content: MessageContent, attr: str) -> str:
+    """Get text from content attr, returning '' if None/missing."""
+    val = getattr(content, attr, None)
+    return "" if val is None else str(val)
+
+
+def _build_context(content: InstructionContent, action_outputs: list[str]) -> list[JsonValue]:
+    """Build context list by appending action outputs to existing context."""
+    existing = content.prompt_context
+    if not existing:
+        return cast("list[JsonValue]", list(action_outputs))
+    return cast("list[JsonValue]", list(cast("list[JsonValue]", existing)) + action_outputs)
+
+
+def _aggregate_round_actions(
+    requests: list[ActionRequestContent],
+    responses: list[ActionResponseContent],
+    round_num: int,
+) -> str:
+    """Aggregate action request/response pairs into a compact round summary."""
+    ts = int(time.time())
+    lines = [f"round: {round_num}", f"time: {ts}"]
+
+    if not responses:
+        return "\n".join(lines)
+
+    lines.append("actions:")
+    for i, resp in enumerate(responses):
+        req = requests[i] if i < len(requests) else None
+        call_str = req.render_compact() if req else "unknown()"
+        status = resp.render_summary()
+        lines.append(f"  - {call_str}: {status}")
+
+    return "\n".join(lines)
+
+
+def _build_round_notification(
+    progression: Progression | None,
+    round_num: int,
+    msg_count: int,
+    scratchpad: dict[str, str] | None = None,
+) -> str:
+    """Build system notification block for agent grounding between rounds."""
+    ts = int(time.time())
+
+    capabilities: set[str] = set()
+    resources: set[str] = set()
+
+    # Branch is session-layer; import lazily to avoid circular dependency.
+    try:
+        from lionagi.beta.session.session import Branch  # type: ignore[import]
+
+        if isinstance(progression, Branch):
+            capabilities = getattr(progression, "capabilities", set())
+            resources = getattr(progression, "resources", set())
+    except ImportError:
+        pass
+
+    parts = [f'<system round="{round_num}" time="{ts}">']
+    if capabilities:
+        parts.append(f"  tools: [{', '.join(sorted(capabilities))}]")
+    if resources:
+        parts.append(f"  resources: [{', '.join(sorted(resources))}]")
+    parts.append(f"  context: {msg_count} msgs | round {round_num}")
+    if scratchpad:
+        scratch_lines = ["  scratchpad:"]
+        for k, v in scratchpad.items():
+            v_str = str(v)
+            scratch_lines.append(f"    {k}: {v_str}")
+        parts.extend(scratch_lines)
+    parts.append("</system>")
+    return "\n".join(parts)
+
+
+def prepare_messages_for_chat(
+    messages: Pile[Message],
+    progression: Progression | None = None,
+    new_instruction: Message | InstructionContent | None = None,
+    to_chat: bool = True,
+    system_prefix: str | None = None,
+    aggregate_actions: bool = False,
+    round_notifications: bool = False,
+    scratchpad: dict[str, str] | None = None,
+) -> list[MessageContent] | list[dict[str, Any]]:
+    """Prepare messages for chat API with intelligent content organization.
+
+    Algorithm:
+    1. Auto-detect system message from first message (if SystemContent)
+    1b. Prepend system_prefix if provided (e.g., LNDL format instructions)
+    2. Collect action messages and embed into following instruction's context
+       - aggregate_actions=True: correlate requests/responses, produce compact summaries
+       - aggregate_actions=False: render each ActionResponse individually (legacy)
+    3. Merge consecutive AssistantResponses
+    4. Embed system into first instruction
+    5. Append new_instruction
+    """
+    # Resolve message sequence — apply progression ordering if provided.
+    to_use: Pile[Message] = messages if progression is None else messages[progression]
+
+    if len(to_use) == 0:
+        if new_instruction:
+            new_content = (
+                new_instruction.content  # type: ignore[union-attr]
+                if _is_message(new_instruction)
+                else new_instruction
+            )
+            new_content: InstructionContent = new_content.with_updates(copy_containers="deep")
+            if to_chat:
+                chat_msg = {
+                    "role": new_content.role.value,
+                    "content": new_content.render(
+                        new_content.structure_format, new_content.custom_renderer
+                    ),
+                }
+                if chat_msg and chat_msg.get("content"):
+                    return [chat_msg]
+                return []
+            return [new_content]
+        return []
+
+    # Phase 1: Extract system message (auto-detect from first message)
+    system_text: str | None = None
+    start_idx = 0
+
+    first_msg = to_use[0]
+    first_content = _get_content(first_msg)
+    if isinstance(first_content, SystemContent):
+        system_text = first_content.render()
+        start_idx = 1
+
+    # Phase 1b: Prepend system_prefix (e.g., LNDL prompt)
+    if system_prefix:
+        system_text = f"{system_prefix}\n\n{system_text}" if system_text else system_prefix
+
+    # Phase 2: Process messages — collect action outputs for next instruction
+    _use_msgs: list[MessageContent] = []
+    pending_actions: list[str] = []
+    pending_requests: list[ActionRequestContent] = []
+    pending_responses: list[ActionResponseContent] = []
+    round_num = 1
+    msg_count = len(to_use)
+
+    for i, msg in enumerate(to_use):
+        if i < start_idx:
+            continue
+
+        content: MessageContent = _get_content(msg)
+
+        if isinstance(content, ActionRequestContent):
+            if aggregate_actions:
+                pending_requests.append(content)
+            continue
+
+        if isinstance(content, ActionResponseContent):
+            if aggregate_actions:
+                pending_responses.append(content)
+            else:
+                pending_actions.append(content.render())
+            continue
+
+        # System in middle: skip
+        if isinstance(content, SystemContent):
+            continue
+
+        # Instruction: embed pending action outputs
+        if isinstance(content, InstructionContent):
+            # Clear tool_schemas and response_format from history messages
+            updates: dict[str, Any] = {"tool_schemas": None, "response_format": None}
+
+            if aggregate_actions and pending_responses:
+                context_parts: list[str] = []
+                if round_notifications:
+                    context_parts.append(
+                        _build_round_notification(progression, round_num, msg_count, scratchpad)
+                    )
+                context_parts.append(
+                    _aggregate_round_actions(pending_requests, pending_responses, round_num)
+                )
+                updates["context"] = _build_context(content, context_parts)
+                pending_requests.clear()
+                pending_responses.clear()
+                round_num += 1
+            elif pending_actions:
+                updates["context"] = _build_context(content, pending_actions)
+                pending_actions = []
+                round_num += 1
+
+            _use_msgs.append(content.with_updates(**updates))
+            continue
+
+        # Other (AssistantResponse, non-aggregated ActionRequest): copy as-is
+        _use_msgs.append(content.with_updates())
+
+    # Phase 3: Merge consecutive AssistantResponses
+    if len(_use_msgs) > 1:
+        merged: list[MessageContent] = [_use_msgs[0]]
+        for content in _use_msgs[1:]:
+            if isinstance(content, AssistantResponseContent) and isinstance(
+                merged[-1], AssistantResponseContent
+            ):
+                prev = _get_text(merged[-1], "assistant_response")
+                curr = _get_text(content, "assistant_response")
+                merged[-1] = AssistantResponseContent(assistant_response=f"{prev}\n\n{curr}")
+            else:
+                merged.append(content)
+        _use_msgs = merged
+
+    # Phase 4: Embed system message into first instruction
+    system_embedded = False
+    if system_text:
+        if len(_use_msgs) == 0 and new_instruction:
+            # No history: embed into new_instruction
+            new_content_inner = (
+                new_instruction.content  # type: ignore[union-attr]
+                if _is_message(new_instruction)
+                else new_instruction
+            )
+            if isinstance(new_content_inner, InstructionContent):
+                curr = _get_text(new_content_inner, "instruction")
+                system_updates: dict[str, Any] = {"primary": f"{system_text}\n\n{curr}"}
+                ctx_parts: list[str] = []
+                if aggregate_actions and pending_responses:
+                    if round_notifications:
+                        ctx_parts.append(
+                            _build_round_notification(progression, round_num, msg_count, scratchpad)
+                        )
+                    ctx_parts.append(
+                        _aggregate_round_actions(pending_requests, pending_responses, round_num)
+                    )
+                    pending_requests.clear()
+                    pending_responses.clear()
+                elif pending_actions:
+                    ctx_parts.extend(pending_actions)
+                    pending_actions = []
+                if ctx_parts:
+                    system_updates["context"] = _build_context(new_content_inner, ctx_parts)
+                _use_msgs.append(new_content_inner.with_updates(**system_updates))
+                new_instruction = None
+                system_embedded = True
+        elif _use_msgs and isinstance(_use_msgs[0], InstructionContent):
+            curr = _get_text(_use_msgs[0], "instruction")
+            _use_msgs[0] = _use_msgs[0].with_updates(primary=f"{system_text}\n\n{curr}")
+            system_embedded = True
+
+    # Phase 5: Append new_instruction (with any remaining action outputs)
+    if new_instruction:
+        final_updates: dict[str, Any] = {}
+        new_content_final = (
+            new_instruction.content  # type: ignore[union-attr]
+            if _is_message(new_instruction)
+            else new_instruction
+        )
+        if isinstance(new_content_final, InstructionContent):
+            context_parts_final: list[str] = []
+            if aggregate_actions and pending_responses:
+                if round_notifications:
+                    context_parts_final.append(
+                        _build_round_notification(progression, round_num, msg_count, scratchpad)
+                    )
+                context_parts_final.append(
+                    _aggregate_round_actions(pending_requests, pending_responses, round_num)
+                )
+                pending_requests.clear()
+                pending_responses.clear()
+            elif pending_actions:
+                context_parts_final.extend(pending_actions)
+                pending_actions = []
+            if context_parts_final:
+                final_updates["context"] = _build_context(new_content_final, context_parts_final)
+            if system_text and not system_embedded:
+                curr = _get_text(new_content_final, "instruction")
+                final_updates["primary"] = f"{system_text}\n\n{curr}"
+        _use_msgs.append(new_content_final.with_updates(**final_updates))
+
+    if to_chat:
+        result = []
+        for m in _use_msgs:
+            data = {}
+            if isinstance(m, InstructionContent):
+                data = {
+                    "structure_format": m.structure_format,
+                    "custom_renderer": m.custom_renderer,
+                }
+            result.append(
+                {
+                    "role": m.role.value,
+                    "content": m.render(**data),
+                }
+            )
+        return result
+    return _use_msgs
+
+
+def _is_message(obj: Any) -> bool:
+    """Check if obj is a session Message (duck-typed, no hard import)."""
+    return hasattr(obj, "content") and isinstance(getattr(obj, "content", None), MessageContent)
+
+
+def _get_content(msg: Any) -> MessageContent:
+    """Extract MessageContent from a Message or return as-is if already MessageContent."""
+    if isinstance(msg, MessageContent):
+        return msg
+    return msg.content  # type: ignore[union-attr]

--- a/lionagi/protocols/messages/rendering.py
+++ b/lionagi/protocols/messages/rendering.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2025 - 2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Rendering and parsing protocol types for the message layer."""
+
+from typing import Any, Protocol, runtime_checkable
+
+from pydantic import BaseModel
+
+from lionagi.ln.types import Enum
+
+__all__ = ("CustomRenderer", "CustomParser", "StructureFormat")
+
+
+@runtime_checkable
+class CustomRenderer(Protocol):
+    """Protocol for custom instruction renderers.
+
+    Implementations format request_model schema for custom output formats.
+
+    Args:
+        model: Pydantic model class defining expected response schema
+        **kwargs: Additional renderer-specific options
+
+    Returns:
+        Formatted instruction string for the custom output format
+    """
+
+    def __call__(self, model: type[BaseModel], **kwargs: Any) -> str: ...
+
+
+@runtime_checkable
+class CustomParser(Protocol):
+    """Protocol for custom output parsers (e.g., LNDL).
+
+    Implementations extract structured data from LLM text responses.
+
+    Args:
+        text: Raw LLM response text
+        target_keys: Expected field names for fuzzy matching
+        **kwargs: Additional parser-specific options
+
+    Returns:
+        Dict mapping field names to extracted values
+    """
+
+    def __call__(self, text: str, target_keys: list[str], **kwargs: Any) -> dict[str, Any]: ...
+
+
+class StructureFormat(Enum):
+    """Enumeration of structure formats for instruction rendering."""
+
+    JSON = "json"
+    CUSTOM = "custom"
+    LNDL = "lndl"

--- a/lionagi/protocols/messages/system.py
+++ b/lionagi/protocols/messages/system.py
@@ -32,6 +32,10 @@ class SystemContent(MessageContent):
         parts.append(self.system_message)
         return "\n\n".join(parts)
 
+    def render(self, *_args: Any, **_kwargs: Any) -> str:
+        """Render system message.  Delegates to :attr:`rendered` for beta API compat."""
+        return self.rendered
+
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "SystemContent":
         """Construct SystemContent from dictionary."""

--- a/lionagi/protocols/messages/validators.py
+++ b/lionagi/protocols/messages/validators.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2025 - 2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validation helpers for message layer."""
+
+from urllib.parse import urlparse
+
+__all__ = ("validate_image_url",)
+
+
+def validate_image_url(url: str) -> None:
+    """Validate image URL to prevent security vulnerabilities.
+
+    Security checks:
+        - Reject null bytes (path truncation attacks)
+        - Reject file:// URLs (local file access)
+        - Reject javascript: URLs (XSS attacks)
+        - Reject data:// URLs (DoS via large embedded images)
+        - Only allow http:// and https:// schemes
+        - Validate URL format
+
+    Raises:
+        ValueError: If URL is invalid or uses disallowed scheme.
+    """
+    if not url or not isinstance(url, str):
+        raise ValueError(f"Image URL must be non-empty string, got: {type(url).__name__}")
+
+    if "\x00" in url:
+        raise ValueError("Image URL contains null byte - potential path truncation attack")
+    if "%00" in url.lower():
+        raise ValueError(
+            "Image URL contains percent-encoded null byte (%00) - potential path truncation attack"
+        )
+
+    try:
+        parsed = urlparse(url)
+    except Exception as e:
+        raise ValueError(f"Malformed image URL '{url}': {e}") from e
+
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(
+            f"Image URL must use http:// or https:// scheme, got: {parsed.scheme}://"
+            f"\nRejected URL: {url}"
+            f"\nReason: Disallowed schemes (file://, javascript://, data://) pose "
+            f"security risks (local file access, XSS, DoS)"
+        )
+
+    if not parsed.netloc:
+        raise ValueError(f"Image URL missing domain: {url}")

--- a/tests/protocols/messages/test_rendering.py
+++ b/tests/protocols/messages/test_rendering.py
@@ -1,0 +1,412 @@
+# Copyright (c) 2025 - 2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for custom render/parser protocols (Phase 1 — #1092).
+
+Covers:
+- StructureFormat enum
+- CustomRenderer / CustomParser protocols (structural typing)
+- validate_image_url security guards
+- InstructionContent.with_updates / .render / .create additions
+- ActionRequestContent.render_compact / .render additions
+- ActionResponseContent.render_summary / .error / .success additions
+- prepare_messages_for_chat pipeline basics
+"""
+
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from lionagi.protocols.messages import (
+    ActionRequest,
+    ActionRequestContent,
+    ActionResponse,
+    ActionResponseContent,
+    AssistantResponse,
+    AssistantResponseContent,
+    Instruction,
+    InstructionContent,
+    prepare_messages_for_chat,
+)
+from lionagi.protocols.messages.rendering import CustomParser, CustomRenderer, StructureFormat
+from lionagi.protocols.messages.validators import validate_image_url
+
+# ---------------------------------------------------------------------------
+# StructureFormat
+# ---------------------------------------------------------------------------
+
+
+class TestStructureFormat:
+    def test_enum_values(self):
+        assert StructureFormat.JSON.value == "json"
+        assert StructureFormat.CUSTOM.value == "custom"
+        assert StructureFormat.LNDL.value == "lndl"
+
+    def test_three_members(self):
+        assert len(StructureFormat) == 3
+
+
+# ---------------------------------------------------------------------------
+# CustomRenderer protocol
+# ---------------------------------------------------------------------------
+
+
+class TestCustomRendererProtocol:
+    def test_callable_that_returns_str_satisfies_protocol(self):
+        """Any callable(model, **kwargs) -> str satisfies CustomRenderer."""
+
+        def my_renderer(model: type[BaseModel], **kwargs: Any) -> str:
+            return f"rendered:{model.__name__}"
+
+        assert isinstance(my_renderer, CustomRenderer)
+
+    def test_class_with_call_satisfies_protocol(self):
+        class UpperCaseRenderer:
+            def __call__(self, model: type[BaseModel], **kwargs: Any) -> str:
+                return model.__name__.upper()
+
+        assert isinstance(UpperCaseRenderer(), CustomRenderer)
+
+    def test_non_callable_does_not_satisfy(self):
+        """Non-callables don't satisfy CustomRenderer."""
+        assert not isinstance("not a callable", CustomRenderer)
+        assert not isinstance(42, CustomRenderer)
+        assert not isinstance(None, CustomRenderer)
+
+
+# ---------------------------------------------------------------------------
+# CustomParser protocol
+# ---------------------------------------------------------------------------
+
+
+class TestCustomParserProtocol:
+    def test_callable_satisfies_protocol(self):
+        def my_parser(text: str, target_keys: list[str], **kwargs: Any) -> dict[str, Any]:
+            return {k: text for k in target_keys}
+
+        assert isinstance(my_parser, CustomParser)
+
+    def test_class_with_call_satisfies_protocol(self):
+        class UpperCaseParser:
+            def __call__(self, text: str, target_keys: list[str], **kwargs: Any) -> dict[str, Any]:
+                return {k: text.upper() for k in target_keys}
+
+        assert isinstance(UpperCaseParser(), CustomParser)
+
+
+# ---------------------------------------------------------------------------
+# validate_image_url
+# ---------------------------------------------------------------------------
+
+
+class TestValidateImageUrl:
+    def test_valid_https_url(self):
+        validate_image_url("https://example.com/image.png")  # no raise
+
+    def test_valid_http_url(self):
+        validate_image_url("http://example.com/image.jpg")  # no raise
+
+    def test_rejects_empty_string(self):
+        with pytest.raises(ValueError, match="non-empty string"):
+            validate_image_url("")
+
+    def test_rejects_none(self):
+        with pytest.raises((ValueError, AttributeError)):
+            validate_image_url(None)  # type: ignore[arg-type]
+
+    def test_rejects_file_scheme(self):
+        with pytest.raises(ValueError, match="http"):
+            validate_image_url("file:///etc/passwd")
+
+    def test_rejects_javascript_scheme(self):
+        with pytest.raises(ValueError, match="http"):
+            validate_image_url("javascript:alert('xss')")
+
+    def test_rejects_data_scheme(self):
+        with pytest.raises(ValueError, match="http"):
+            validate_image_url("data:image/png;base64,abc123")
+
+    def test_rejects_null_byte(self):
+        with pytest.raises(ValueError, match="null byte"):
+            validate_image_url("https://example.com/img\x00.png")
+
+    def test_rejects_percent_encoded_null(self):
+        with pytest.raises(ValueError, match="null byte"):
+            validate_image_url("https://example.com/img%00.png")
+
+    def test_rejects_missing_domain(self):
+        with pytest.raises(ValueError, match="missing domain"):
+            validate_image_url("https://")
+
+
+# ---------------------------------------------------------------------------
+# InstructionContent additions
+# ---------------------------------------------------------------------------
+
+
+class TestInstructionContentAdditions:
+    def test_primary_alias_sets_instruction(self):
+        c = InstructionContent(primary="hello world")
+        assert c.instruction == "hello world"
+
+    def test_primary_loses_if_instruction_also_set(self):
+        c = InstructionContent(instruction="instruction wins", primary="primary loses")
+        assert c.instruction == "instruction wins"
+
+    def test_primary_property(self):
+        c = InstructionContent(instruction="test")
+        assert c.primary == "test"
+
+    def test_structure_format_stored(self):
+        c = InstructionContent(instruction="x", structure_format="json")
+        assert c.structure_format == "json"
+
+    def test_custom_renderer_stored(self):
+        renderer = lambda m, **kw: "rendered"
+        c = InstructionContent(instruction="x", custom_renderer=renderer)
+        assert c.custom_renderer is renderer
+
+    def test_role_property(self):
+        from lionagi.protocols.messages.message import MessageRole
+
+        c = InstructionContent(instruction="x")
+        assert c.role == MessageRole.USER
+
+    def test_with_updates_changes_instruction(self):
+        c = InstructionContent(instruction="original")
+        c2 = c.with_updates(instruction="updated")
+        assert c2.instruction == "updated"
+        assert c.instruction == "original"  # original unchanged
+
+    def test_with_updates_primary_alias(self):
+        c = InstructionContent(instruction="old")
+        c2 = c.with_updates(primary="new via primary")
+        assert c2.instruction == "new via primary"
+
+    def test_with_updates_context_alias(self):
+        c = InstructionContent(instruction="x")
+        c2 = c.with_updates(context=["ctx item"])
+        assert "ctx item" in c2.prompt_context
+
+    def test_with_updates_strips_copy_containers(self):
+        c = InstructionContent(instruction="x")
+        # Should not raise even though copy_containers is beta-only kwarg
+        c2 = c.with_updates(copy_containers="deep", instruction="y")
+        assert c2.instruction == "y"
+
+    def test_render_no_custom_renderer_returns_rendered(self):
+        c = InstructionContent(instruction="hello")
+        result = c.render()
+        assert "hello" in result
+
+    def test_render_with_custom_renderer(self):
+        class SampleModel(BaseModel):
+            value: str
+
+        def my_renderer(model: type[BaseModel], **kw: Any) -> str:
+            return f"CUSTOM:{model.__name__}"
+
+        c = InstructionContent(instruction="x", response_format=SampleModel)
+        result = c.render(custom_renderer=my_renderer)
+        assert result == "CUSTOM:SampleModel"
+
+    def test_render_structure_format_param_accepted(self):
+        c = InstructionContent(instruction="x", structure_format="json")
+        # With no custom_renderer, should fall back to rendered (no error)
+        result = c.render(structure_format=StructureFormat.JSON)
+        assert isinstance(result, str | list)
+
+    def test_create_classmethod(self):
+        c = InstructionContent.create(primary="via create")
+        assert c.instruction == "via create"
+
+    def test_create_with_structure_format_enum(self):
+        c = InstructionContent.create(primary="x", structure_format=StructureFormat.LNDL)
+        assert c.structure_format == "lndl"
+
+
+# ---------------------------------------------------------------------------
+# ActionRequestContent additions
+# ---------------------------------------------------------------------------
+
+
+class TestActionRequestContentAdditions:
+    def test_render_delegates_to_rendered(self):
+        c = ActionRequestContent(function="my_fn", arguments={"a": 1})
+        assert c.render() == c.rendered
+
+    def test_render_compact_no_args(self):
+        c = ActionRequestContent(function="search")
+        assert c.render_compact() == "search()"
+
+    def test_render_compact_with_args(self):
+        c = ActionRequestContent(function="read", arguments={"path": "/tmp/x"})
+        result = c.render_compact()
+        assert result.startswith("read(")
+        assert "path=" in result
+
+    def test_role_property(self):
+        from lionagi.protocols.messages.message import MessageRole
+
+        c = ActionRequestContent(function="f")
+        assert c.role == MessageRole.ACTION
+
+
+# ---------------------------------------------------------------------------
+# ActionResponseContent additions
+# ---------------------------------------------------------------------------
+
+
+class TestActionResponseContentAdditions:
+    def test_render_delegates_to_rendered(self):
+        c = ActionResponseContent(function="f", output="result text")
+        assert c.render() == c.rendered
+
+    def test_success_when_no_error(self):
+        c = ActionResponseContent(function="f", output="ok")
+        assert c.success is True
+
+    def test_success_false_when_error(self):
+        c = ActionResponseContent(function="f", error="something went wrong")
+        assert c.success is False
+
+    def test_render_summary_success_string(self):
+        c = ActionResponseContent(function="f", output="hello")
+        assert c.render_summary() == "hello"
+
+    def test_render_summary_success_none(self):
+        c = ActionResponseContent(function="f", output=None)
+        assert c.render_summary() == "ok"
+
+    def test_render_summary_error(self):
+        c = ActionResponseContent(function="f", error="timeout")
+        assert "error" in c.render_summary()
+        assert "timeout" in c.render_summary()
+
+    def test_render_summary_dict_output(self):
+        c = ActionResponseContent(function="f", output={"key": "val"})
+        summary = c.render_summary()
+        assert "key" in summary
+
+    def test_result_alias(self):
+        c = ActionResponseContent(function="f", output="data")
+        assert c.result == "data"
+
+    def test_request_id_alias(self):
+        c = ActionResponseContent(function="f", action_request_id="req-123")
+        assert c.request_id == "req-123"
+
+    def test_role_property(self):
+        from lionagi.protocols.messages.message import MessageRole
+
+        c = ActionResponseContent(function="f")
+        assert c.role == MessageRole.ACTION
+
+
+# ---------------------------------------------------------------------------
+# AssistantResponseContent additions
+# ---------------------------------------------------------------------------
+
+
+class TestAssistantResponseContentAdditions:
+    def test_render_delegates_to_rendered(self):
+        c = AssistantResponseContent(assistant_response="hello")
+        assert c.render() == "hello"
+
+    def test_role_property(self):
+        from lionagi.protocols.messages.message import MessageRole
+
+        c = AssistantResponseContent(assistant_response="hi")
+        assert c.role == MessageRole.ASSISTANT
+
+    def test_response_alias(self):
+        c = AssistantResponseContent(assistant_response="foo")
+        assert c.response == "foo"
+
+
+# ---------------------------------------------------------------------------
+# prepare_messages_for_chat basics
+# ---------------------------------------------------------------------------
+
+
+class TestPrepareMessagesForChat:
+    def _make_instruction_msg(self, text: str) -> "Instruction":
+        return Instruction(content=InstructionContent(instruction=text))
+
+    def _make_assistant_msg(self, text: str) -> "AssistantResponse":
+        return AssistantResponse(content=AssistantResponseContent(assistant_response=text))
+
+    def test_empty_pile_no_new_instruction_returns_empty(self):
+        from lionagi.protocols.generic.pile import Pile
+
+        pile: Pile = Pile()
+        result = prepare_messages_for_chat(pile)
+        assert result == []
+
+    def test_single_instruction_in_pile(self):
+        from lionagi.protocols.generic.pile import Pile
+
+        msg = self._make_instruction_msg("do something")
+        pile: Pile = Pile(collections=[msg])
+        result = prepare_messages_for_chat(pile)
+        assert len(result) == 1
+        assert isinstance(result[0], dict)
+        assert result[0]["role"] == "user"
+        assert "do something" in result[0]["content"]
+
+    def test_new_instruction_only(self):
+        from lionagi.protocols.generic.pile import Pile
+
+        pile: Pile = Pile()
+        new_msg = InstructionContent(instruction="brand new")
+        result = prepare_messages_for_chat(pile, new_instruction=new_msg)
+        assert len(result) == 1
+        assert "brand new" in result[0]["content"]
+
+    def test_to_chat_false_returns_content_objects(self):
+        from lionagi.protocols.generic.pile import Pile
+
+        msg = self._make_instruction_msg("test")
+        pile: Pile = Pile(collections=[msg])
+        result = prepare_messages_for_chat(pile, to_chat=False)
+        assert len(result) == 1
+        assert isinstance(result[0], InstructionContent)
+
+    def test_system_message_embedded_into_first_instruction(self):
+        """System content should be prepended to the first instruction text."""
+        from lionagi.protocols.generic.pile import Pile
+        from lionagi.protocols.messages import System, SystemContent
+
+        sys_msg = System(content=SystemContent(system_message="You are helpful."))
+        instr_msg = self._make_instruction_msg("Answer this.")
+        pile: Pile = Pile(collections=[sys_msg, instr_msg])
+        result = prepare_messages_for_chat(pile)
+        # First result must be user turn with both system text and instruction
+        combined_content = result[0]["content"]
+        assert "You are helpful." in combined_content
+        assert "Answer this." in combined_content
+
+    def test_consecutive_assistant_responses_merged(self):
+        """Consecutive AssistantResponse messages should be merged into one."""
+        from lionagi.protocols.generic.pile import Pile
+
+        instr = self._make_instruction_msg("ask")
+        asst1 = self._make_assistant_msg("part one")
+        asst2 = self._make_assistant_msg("part two")
+        pile: Pile = Pile(collections=[instr, asst1, asst2])
+        result = prepare_messages_for_chat(pile)
+        # Should have instruction + one merged assistant
+        assert len(result) == 2
+        asst_entry = next(r for r in result if r["role"] == "assistant")
+        assert "part one" in asst_entry["content"]
+        assert "part two" in asst_entry["content"]
+
+    def test_system_prefix_prepended(self):
+        from lionagi.protocols.generic.pile import Pile
+
+        msg = self._make_instruction_msg("main text")
+        pile: Pile = Pile(collections=[msg])
+        result = prepare_messages_for_chat(pile, system_prefix="## PREFIX")
+        assert "## PREFIX" in result[0]["content"]
+        assert "main text" in result[0]["content"]


### PR DESCRIPTION
## Summary

- Port `rendering.py` (new, verbatim from `feat/beta`) — `CustomRenderer`, `CustomParser` runtime-checkable protocols + `StructureFormat` enum
- Port `validators.py` (new, verbatim from `feat/beta`) — `validate_image_url` with security guards (null-byte, file://, javascript://, data://)
- Port `prepare.py` (new, verbatim from `feat/beta`) — pure-function `prepare_messages_for_chat` pipeline (system embed, action aggregation, consecutive-assistant merge, round notifications)
- Add additive methods to existing content types so `prepare.py` can call them without touching the hot-path `manager.py`:
  - `InstructionContent`: `primary` alias, `structure_format`/`custom_renderer` fields, `with_updates()`, `render()`, `create()`, `role` property
  - `ActionRequestContent`: `render()`, `render_compact()`, `role` property
  - `ActionResponseContent`: `error` field, `render()`, `render_summary()`, `success`, `result`/`request_id` aliases, `role` property
  - `AssistantResponseContent`: `render()`, `response` alias, `role` property
  - `SystemContent`: `render()` (needed by `prepare.py` to extract system text)
- Re-export all new symbols from `lionagi.protocols.messages.__init__`
- 56 new tests in `tests/protocols/messages/test_rendering.py` (343 total, all passing)

## Phase 2 deferred

`manager.py` refactor and per-message-type hooks are **not** included here. That's a hot-path change that deserves its own review cycle.

## Source

All three new files copied verbatim from `feat/beta`. The additive content-type methods are adapted from the same branch's diffs — no net-new logic invented.

## Test plan

- [x] `uv run pytest tests/protocols/messages/ --timeout=60` → 343 passed
- [x] `uv run ruff check` → clean
- [x] `uv run ruff format --check` → clean
- [x] Pre-commit hooks pass (all stages green)
- [x] Import smoke: `from lionagi.protocols.messages import CustomRenderer, CustomParser, StructureFormat, validate_image_url, prepare_messages_for_chat` → `ok`

Closes #1092 Phase 1. Phase 2 tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)