### PR TITLE
docs(claude-md): remove li schedule reference until ADR-0027 ships

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,6 @@ Modules: chat, parse, operate, ReAct, select, interpret, communicate, run, act. 
 
 - `cli/agent.py` — `li agent`: one-shot or resumed turn
 - `cli/team.py` — `li team`: inbox (`~/.lionagi/teams/{id}.json`), concurrent writes via `fcntl.flock`
-- `cli/schedule.py` — `li schedule`: CRUD + manual trigger for scheduled runs (see ADR-0027)
 - `cli/_project.py` — `detect_project(cwd)`: returns `(project_name, project_source)` via detection cascade (see ADR-0026)
 - `cli/orchestrate/` — `li o fanout` / `li o flow`:
   - `flow.py` — FlowAgent + FlowOp DAG. `--team-mode` enables `li team` routing mid-pipeline.


### PR DESCRIPTION
## Summary

- Removes the `cli/schedule.py` / `li schedule` bullet from the CLI Architecture section of `CLAUDE.md`
- `lionagi/cli/schedule.py` does not exist and `add_schedule_subparser` is not registered in `cli/main.py`
- ADR-0027 is correctly marked **Proposed** — the drift was only in `CLAUDE.md`

Closes #1121. Re-add the reference when the feature actually ships.

## Test plan

- [ ] Verify `ls lionagi/cli/schedule*` returns no matches
- [ ] Verify `grep schedule lionagi/cli/main.py` returns nothing
- [ ] Confirm `CLAUDE.md` no longer mentions `cli/schedule.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)