### PR TITLE
test(lndl): regression guard for get_lndl_system_prompt structure (#1124)

### DIFF
--- a/tests/lndl/test_prompt.py
+++ b/tests/lndl/test_prompt.py
@@ -5,7 +5,14 @@
 
 from __future__ import annotations
 
+import hashlib
+
 from lionagi.lndl.prompt import get_lndl_system_prompt
+
+# SHA-256 of the prompt as of the tests being written. Any accidental edit to
+# LNDL_SYSTEM_PROMPT (whitespace, typo, truncation, marker removal) will flip
+# this hash and make test_prompt_snapshot fail immediately.
+_EXPECTED_SHA256 = "3a2020594e14e21de470e90403c3fe63ec4352f74dcb44ad82b7eb082cd27e0a"
 
 
 class TestGetLndlSystemPrompt:
@@ -29,3 +36,63 @@ class TestGetLndlSystemPrompt:
         r1 = get_lndl_system_prompt()
         r2 = get_lndl_system_prompt()
         assert r1 == r2
+
+    # ------------------------------------------------------------------
+    # Regression guard for #1124: DSL marker presence
+    # ------------------------------------------------------------------
+
+    def test_prompt_contains_lvar_marker(self):
+        """Prompt must contain the <lvar opening tag — lvar binding syntax."""
+        prompt = get_lndl_system_prompt()
+        assert "<lvar" in prompt, (
+            "LNDL prompt is missing <lvar marker; "
+            "every LNDL session will fail to parse variable bindings"
+        )
+
+    def test_prompt_contains_lact_marker(self):
+        """Prompt must contain the <lact opening tag — action invocation syntax."""
+        prompt = get_lndl_system_prompt()
+        assert "<lact" in prompt, (
+            "LNDL prompt is missing <lact marker; every LNDL session will fail to parse tool calls"
+        )
+
+    def test_prompt_contains_out_block_marker(self):
+        """Prompt must contain the OUT{ output-spec syntax."""
+        prompt = get_lndl_system_prompt()
+        assert "OUT{" in prompt, (
+            "LNDL prompt is missing OUT{ marker; every LNDL session will fail to commit outputs"
+        )
+
+    def test_prompt_minimum_length(self):
+        """Prompt must be at least 500 chars; shorter means truncation."""
+        prompt = get_lndl_system_prompt()
+        assert len(prompt) >= 500, (
+            f"LNDL prompt is suspiciously short ({len(prompt)} chars); "
+            "the constant was likely truncated or replaced with a stub"
+        )
+
+    def test_prompt_is_deterministic(self):
+        """Identical string on every call — no dynamic content injected."""
+        calls = [get_lndl_system_prompt() for _ in range(5)]
+        assert len(set(calls)) == 1, (
+            "get_lndl_system_prompt() returned different values across calls; "
+            "dynamic content must not be injected into the base system prompt"
+        )
+
+    def test_prompt_snapshot(self):
+        """SHA-256 snapshot guard: any accidental edit trips this test.
+
+        To intentionally update the prompt, recalculate the hash with:
+            python -c "import hashlib; from lionagi.lndl.prompt import \
+get_lndl_system_prompt; p = get_lndl_system_prompt(); \
+print(hashlib.sha256(p.encode()).hexdigest())"
+        and update _EXPECTED_SHA256 above.
+        """
+        prompt = get_lndl_system_prompt()
+        actual = hashlib.sha256(prompt.encode()).hexdigest()
+        assert actual == _EXPECTED_SHA256, (
+            f"LNDL system prompt has changed unexpectedly.\n"
+            f"  expected SHA-256: {_EXPECTED_SHA256}\n"
+            f"  actual   SHA-256: {actual}\n"
+            "If the change is intentional, update _EXPECTED_SHA256 in this file."
+        )


### PR DESCRIPTION
## Summary

- Adds 6 regression assertions to `tests/lndl/test_prompt.py` guarding against silent corruption of `LNDL_SYSTEM_PROMPT` in `lionagi/lndl/prompt.py`
- The existing 4 tests only checked type, emptiness, stripping, and idempotency — none verified DSL marker presence or caught truncation/accidental edits
- Verified all markers against the live prompt before writing tests (no guessing)

## New tests

| Test | What it catches |
|---|---|
| `test_prompt_contains_lvar_marker` | `<lvar` removed — variable binding syntax gone |
| `test_prompt_contains_lact_marker` | `<lact` removed — action invocation syntax gone |
| `test_prompt_contains_out_block_marker` | `OUT{` removed — output-commit syntax gone |
| `test_prompt_minimum_length` | Prompt truncated below 500 chars |
| `test_prompt_is_deterministic` | Dynamic content injected across 5 calls |
| `test_prompt_snapshot` | Any character-level change via SHA-256 (`3a2020594e14…`) |

## Actual markers keyed on

Read directly from `lionagi/lndl/prompt.py::LNDL_SYSTEM_PROMPT`:
- `<lvar` — opens variable binding tags (lines 9, 47, 49, 56, 70, 71)
- `<lact` — opens action invocation tags (lines 13, 14, 39, 40, 57–58, 67–68)
- `OUT{` — output-spec syntax (lines 17, 50, 61, 73)

Minimum length floor set at 500; actual prompt is 2 619 chars.

## Test plan

- [x] All 10 tests pass: `uv run pytest tests/lndl/test_prompt.py -xvs --timeout=60`
- [x] ruff-format passes (pre-commit reformatted, re-staged, committed clean)

Closes #1124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)