### PR TITLE
fix(security): SSRF guard unmaps IPv4-compat IPv6 (CWE-918)

### DIFF
--- a/lionagi/ln/_ssrf.py
+++ b/lionagi/ln/_ssrf.py
@@ -15,14 +15,6 @@ short TTL could change (DNS rebinding).  This is an accepted residual risk for
 the current implementation.  If DNS rebinding becomes a concrete threat,
 implement a custom ``httpx.AsyncHTTPTransport`` that pins the resolved address.
 
-IPv4-compatible IPv6 residual risk
------------------------------------
-The deprecated IPv4-compatible IPv6 form ``::a.b.c.d`` (distinct from the
-IPv4-mapped form ``::ffff:a.b.c.d``) is not unmapped before checking and is
-therefore treated as a public IPv6 address by this guard.  ``::169.254.169.254``
-would pass the check.  This is the same risk class as DNS rebinding and is
-accepted for the current implementation.
-
 CWE reference: CWE-918.
 """
 
@@ -70,8 +62,9 @@ def is_ssrf_safe(hostname: str) -> bool:
     against :data:`_BLOCKED_NETS`.  Unresolvable hostnames are rejected
     (return False) so that DNS failures fail-closed.
 
-    IPv4-mapped IPv6 addresses (``::ffff:a.b.c.d``) are unmapped before
-    checking so they match IPv4 blocked networks correctly.
+    Both IPv4-mapped (``::ffff:a.b.c.d``) and IPv4-compatible (``::a.b.c.d``)
+    IPv6 addresses are unmapped to their IPv4 form before checking, so they
+    correctly match IPv4 blocked networks.
 
     Args:
         hostname: Hostname to validate.  Do NOT pass a full URL; extract the
@@ -90,6 +83,8 @@ def is_ssrf_safe(hostname: str) -> bool:
         >>> is_ssrf_safe("localhost")
         False
         >>> is_ssrf_safe("::ffff:169.254.169.254")
+        False
+        >>> is_ssrf_safe("::169.254.169.254")
         False
     """
     if not hostname:
@@ -117,6 +112,17 @@ def is_ssrf_safe(hostname: str) -> bool:
         # IPv4 blocked networks.
         if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
             ip = ip.ipv4_mapped
+
+        # Unmap IPv4-compatible IPv6 (::a.b.c.d → a.b.c.d) — the deprecated
+        # form where the IPv4 address is embedded directly without the 0xffff
+        # marker.  Python's ipv4_mapped returns None for this form, so we must
+        # detect it manually.  RFC 4291 §2.5.5.1: packed representation is
+        # 10 zero bytes + 2 zero bytes + 4 IPv4 bytes.
+        # Fix for CWE-918 / issue #1125: ::169.254.169.254 reached AWS IMDS.
+        if isinstance(ip, ipaddress.IPv6Address):
+            b = ip.packed
+            if b[:12] == b"\x00" * 12:
+                ip = ipaddress.IPv4Address(b[12:])
 
         if any(ip in net for net in _BLOCKED_NETS):
             return False

--- a/tests/ln/test_ssrf.py
+++ b/tests/ln/test_ssrf.py
@@ -128,6 +128,40 @@ def test_ipv4_mapped_public_safe():
 
 
 # ---------------------------------------------------------------------------
+# 4b. IPv4-compatible IPv6 (::a.b.c.d) — CRITICAL: must return False (#1125)
+# ---------------------------------------------------------------------------
+# IPv4-compatible IPv6 is the *deprecated* form where the IPv4 address is
+# embedded directly without the 0xffff marker.  ``::169.254.169.254`` is a
+# live IMDS bypass on IPv6-reachable cloud environments (CWE-918).
+# Python's ipaddress.IPv6Address.ipv4_mapped returns None for this form, so
+# the IPv4-mapped unmap path that covers ::ffff:a.b.c.d does NOT catch it.
+# These tests document the required behaviour after the fix.
+
+
+@pytest.mark.parametrize(
+    "ipv4_compat",
+    [
+        "::169.254.169.254",  # AWS/GCP IMDS — the live IMDS bypass (issue #1125)
+        "::10.0.0.1",  # RFC 1918 private via IPv4-compat
+        "::192.168.1.1",  # RFC 1918 private via IPv4-compat
+        "::127.0.0.1",  # Loopback via IPv4-compat
+        "::172.16.0.1",  # RFC 1918 private via IPv4-compat
+        "::100.64.0.1",  # CGN (RFC 6598) via IPv4-compat
+    ],
+)
+def test_ipv4_compatible_ipv6_blocked(ipv4_compat):
+    """IPv4-compatible IPv6 (::a.b.c.d) must not bypass IPv4 network checks."""
+    with patch("socket.getaddrinfo", return_value=_mock_getaddrinfo(ipv4_compat)):
+        assert is_ssrf_safe("evil.internal") is False
+
+
+def test_ipv4_compatible_public_safe():
+    """IPv4-compatible IPv6 wrapping a public IP should be safe."""
+    with patch("socket.getaddrinfo", return_value=_mock_getaddrinfo("::8.8.8.8")):
+        assert is_ssrf_safe("dns.example.com") is True
+
+
+# ---------------------------------------------------------------------------
 # 5. DNS resolution failure — must fail closed
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **Bug**: `is_ssrf_safe` returned `True` for IPv4-compatible IPv6 addresses like `::169.254.169.254`, enabling a live IMDS bypass on IPv6-reachable cloud environments (AWS/GCP metadata service)
- **Root cause**: Python's `IPv6Address.ipv4_mapped` returns `None` for the deprecated IPv4-compatible form (`::a.b.c.d`), so the existing IPv4-mapped unmap path (`::ffff:a.b.c.d`) did not catch it
- **Fix**: After the existing `ipv4_mapped` unmap, detect IPv4-compatible IPv6 via packed-byte check (`b[:12] == b'\x00' * 12`) and extract the IPv4 address from the last 4 bytes — same defensive pattern, same blocked-network check
- **Tests**: 7 new parametrized cases added (`::169.254.169.254`, `::10.0.0.1`, `::192.168.1.1`, `::127.0.0.1`, `::172.16.0.1`, `::100.64.0.1`) plus a safe-public case (`::8.8.8.8`); all 41 tests pass

Closes #1125. CWE-918.

## Test plan

- [x] `uv run pytest tests/ln/test_ssrf.py` — 41 passed
- [x] `uv run ruff check` — no issues
- [x] `uv run ruff format --check` — already formatted
- [x] All pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)