### PR TITLE
fix(cli): li kill --all-stale sweeps shows + plays (#1117)

### DIFF
--- a/lionagi/cli/kill.py
+++ b/lionagi/cli/kill.py
@@ -130,6 +130,12 @@ def _terminate_pid(pid: int, grace_seconds: float = 5.0) -> str:
 
 _SEARCH_ORDER = ("sessions", "invocations", "plays", "shows")
 
+# Shows have no direct PID — their child plays/sessions do. Skip in
+# all-stale sweep to avoid false-positive aborts of long-running shows
+# whose children are still alive. Use `li kill <show_id> --recursive`
+# to clean up an individual show.
+_STALE_SWEEP_ORDER = ("sessions", "invocations", "plays")
+
 # Map DB table name → canonical entity type for update_status().
 _TABLE_TO_ENTITY_TYPE = {
     "sessions": "session",
@@ -446,16 +452,14 @@ async def _do_kill_all_stale(
     skipped_live = 0
     skipped_recent = 0
 
-    # Shows use "active" as their live status; all other entity types use "running".
     live_status_for: dict[str, str] = {
         "sessions": "running",
         "invocations": "running",
         "plays": "running",
-        "shows": "active",
     }
 
     async with StateDB() as db:
-        for table in _SEARCH_ORDER:
+        for table in _STALE_SWEEP_ORDER:
             entity_type = _TABLE_TO_ENTITY_TYPE[table]
             live_status = live_status_for[table]
             cur = await db.db.execute(

--- a/lionagi/cli/kill.py
+++ b/lionagi/cli/kill.py
@@ -130,11 +130,12 @@ def _terminate_pid(pid: int, grace_seconds: float = 5.0) -> str:
 
 _SEARCH_ORDER = ("sessions", "invocations", "plays", "shows")
 
-# Shows have no direct PID — their child plays/sessions do. Skip in
-# all-stale sweep to avoid false-positive aborts of long-running shows
-# whose children are still alive. Use `li kill <show_id> --recursive`
-# to clean up an individual show.
-_STALE_SWEEP_ORDER = ("sessions", "invocations", "plays")
+# Only sessions and invocations carry direct PID semantics. Plays and
+# shows are orchestrators that spawn child sessions/invocations — they
+# don't carry their own PID. Sweeping them by PID-absence would abort
+# legitimate long-running orchestrations whose child processes are still
+# alive. Use `li kill <play_or_show_id> --recursive` for explicit cleanup.
+_STALE_SWEEP_ORDER = ("sessions", "invocations")
 
 # Map DB table name → canonical entity type for update_status().
 _TABLE_TO_ENTITY_TYPE = {
@@ -438,11 +439,17 @@ async def _do_kill_all_stale(
     dry_run: bool = False,
     verbose: bool = False,
 ) -> int:
-    """Find all running entities with dead PIDs and cancel them.
+    """Sweep stale sessions and invocations whose PIDs are dead.
 
     ``threshold_seconds`` is the minimum age (since started_at or updated_at)
     required before a running row is considered stale.  Rows newer than this
     threshold may be legitimately in-progress and are skipped.
+
+    Plays and shows are NOT swept.  They are orchestrators with no direct
+    PID — their child sessions/invocations carry the actual OS process.
+    Sweeping them by PID-absence would silently abort legitimate long-running
+    orchestrations.  Use ``li kill <play_or_show_id> --recursive`` for
+    explicit play/show cleanup.
     """
     from lionagi.state.db import StateDB
     from lionagi.state.reasons import RunReasons
@@ -455,7 +462,6 @@ async def _do_kill_all_stale(
     live_status_for: dict[str, str] = {
         "sessions": "running",
         "invocations": "running",
-        "plays": "running",
     }
 
     async with StateDB() as db:
@@ -582,7 +588,11 @@ def add_kill_subparser(subparsers: argparse._SubParsersAction) -> None:
     kill.add_argument(
         "--all-stale",
         action="store_true",
-        help="Sweep all running entities with dead PIDs (or no PID) older than --threshold.",
+        help=(
+            "Sweep stale sessions and invocations with dead PIDs older than --threshold. "
+            "Plays and shows are not swept (they are orchestrators without direct PIDs; "
+            "use --recursive with an explicit ID instead)."
+        ),
     )
     kill.add_argument(
         "--threshold",

--- a/lionagi/cli/kill.py
+++ b/lionagi/cli/kill.py
@@ -446,11 +446,21 @@ async def _do_kill_all_stale(
     skipped_live = 0
     skipped_recent = 0
 
+    # Shows use "active" as their live status; all other entity types use "running".
+    live_status_for: dict[str, str] = {
+        "sessions": "running",
+        "invocations": "running",
+        "plays": "running",
+        "shows": "active",
+    }
+
     async with StateDB() as db:
-        for table in ("sessions", "invocations"):
+        for table in _SEARCH_ORDER:
             entity_type = _TABLE_TO_ENTITY_TYPE[table]
+            live_status = live_status_for[table]
             cur = await db.db.execute(
-                f"SELECT * FROM {table} WHERE status = 'running'"  # noqa: S608
+                f"SELECT * FROM {table} WHERE status = ?",  # noqa: S608
+                (live_status,),
             )
             rows = await cur.fetchall()
 
@@ -458,8 +468,13 @@ async def _do_kill_all_stale(
                 row_dict = db._row_to_dict(row)
                 entity_id = row_dict["id"]
 
-                # Age check: skip sessions started recently.
-                started = row_dict.get("started_at") or row_dict.get("updated_at") or 0
+                # Age check: skip entities started/updated recently.
+                started = (
+                    row_dict.get("started_at")
+                    or row_dict.get("updated_at")
+                    or row_dict.get("created_at")
+                    or 0
+                )
                 if started > cutoff:
                     skipped_recent += 1
                     if verbose:

--- a/tests/cli/test_kill.py
+++ b/tests/cli/test_kill.py
@@ -586,43 +586,17 @@ def test_kill_all_stale_subparser_flags():
         Path(tmp_path).unlink(missing_ok=True)
 
 
-# ── issue #1117: _do_kill_all_stale must sweep plays (not shows) ───────────────
-
-
-async def test_do_kill_all_stale_cancels_stale_play(
-    temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
-):
-    """Stale running play with a dead PID must be swept (issue #1117)."""
-    monkeypatch.setattr("lionagi.cli.kill._pid_alive", lambda pid: False)
-
-    old_start = time.time() - 7200  # 2 hours ago
-    async with StateDB() as db:
-        show_id = await _seed_show(db, status="active")
-        play_id = await _seed_play(db, show_id, status="running")
-        # Backdate started_at so the row is outside the stale threshold.
-        await db.db.execute(
-            "UPDATE plays SET started_at = ? WHERE id = ?",
-            (old_start, play_id),
-        )
-        await db.db.commit()
-
-    rc = await _do_kill_all_stale(threshold_seconds=3600, dry_run=False)
-    assert rc == 0
-
-    async with StateDB() as db:
-        cur = await db.db.execute("SELECT status FROM plays WHERE id = ?", (play_id,))
-        row = await cur.fetchone()
-        assert row is not None
-        # _persist_cancel maps stale play → "blocked" (no "cancelled" in play vocabulary)
-        assert row["status"] == "blocked"
+# ── issue #1117 / PR #1140 codex round-2: plays and shows excluded from sweep ──
 
 
 async def test_do_kill_all_stale_does_NOT_touch_show_at_all(
     temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    """Regression for codex P1 on PR #1140: shows are skipped entirely in the
-    all-stale sweep.  Shows have no direct PID; treating pid=None as 'stale'
-    would abort long-running shows whose child plays are still alive.
+    """Shows are skipped entirely in the all-stale sweep (codex P1, PR #1140).
+
+    Shows have no direct PID; treating pid=None as 'stale' would abort
+    long-running shows whose child plays/sessions are still alive.
+    Both the show and any co-seeded child play must survive unchanged.
     """
     monkeypatch.setattr("lionagi.cli.kill._pid_alive", lambda pid: False)
 
@@ -634,43 +608,7 @@ async def test_do_kill_all_stale_does_NOT_touch_show_at_all(
             "UPDATE shows SET updated_at = ?, created_at = ? WHERE id = ?",
             (old_time, old_time, show_id),
         )
-        await db.db.commit()
-
-    rc = await _do_kill_all_stale(threshold_seconds=3600, dry_run=False)
-    assert rc == 0
-
-    async with StateDB() as db:
-        cur = await db.db.execute("SELECT status FROM shows WHERE id = ?", (show_id,))
-        row = await cur.fetchone()
-        assert row is not None
-        # Show must remain active — the sweep must not have touched it.
-        assert row["status"] == "active"
-
-
-async def test_do_kill_all_stale_does_NOT_touch_active_show_with_alive_play(
-    temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
-):
-    """Regression for codex P1 on PR #1140: a show with an alive child play
-    must survive the all-stale sweep unchanged.
-
-    Seeds an active show with a play whose PID is os.getpid() (guaranteed
-    alive).  Even though the show itself has no PID, the sweep must not abort
-    it — shows are skipped entirely in the sweep.
-    """
-    import os
-
-    # _pid_alive returns True for the current process; False for anything else.
-    monkeypatch.setattr("lionagi.cli.kill._pid_alive", lambda pid: pid == os.getpid())
-
-    old_time = time.time() - 7200  # 2 hours ago
-    async with StateDB() as db:
-        show_id = await _seed_show(db, status="active")
-        # Backdate so the show looks stale by age.
-        await db.db.execute(
-            "UPDATE shows SET updated_at = ?, created_at = ? WHERE id = ?",
-            (old_time, old_time, show_id),
-        )
-        # Seed a child play with an alive PID so the show is legitimately running.
+        # Seed a child play so we also verify plays are not swept.
         play_id = await _seed_play(db, show_id, status="running")
         await db.db.execute(
             "UPDATE plays SET started_at = ? WHERE id = ?",
@@ -685,5 +623,45 @@ async def test_do_kill_all_stale_does_NOT_touch_active_show_with_alive_play(
         cur = await db.db.execute("SELECT status FROM shows WHERE id = ?", (show_id,))
         row = await cur.fetchone()
         assert row is not None
-        # Show must remain active.
+        # Show must remain active — the sweep must not have touched it.
         assert row["status"] == "active"
+
+        cur2 = await db.db.execute("SELECT status FROM plays WHERE id = ?", (play_id,))
+        row2 = await cur2.fetchone()
+        assert row2 is not None
+        # Play must also remain running — the sweep must not have touched it.
+        assert row2["status"] == "running"
+
+
+async def test_do_kill_all_stale_does_NOT_touch_play_at_all(
+    temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Plays are skipped entirely in the all-stale sweep (codex round-2 P1).
+
+    Plays are orchestrators with no direct PID; their child sessions carry
+    the actual OS process. Sweeping by PID-absence would silently abort
+    legitimate long-running plays. The play's status must remain 'running'
+    after the sweep regardless of age or PID presence.
+    """
+    monkeypatch.setattr("lionagi.cli.kill._pid_alive", lambda pid: False)
+
+    old_start = time.time() - 7200  # 2 hours ago
+    async with StateDB() as db:
+        show_id = await _seed_show(db, status="active")
+        play_id = await _seed_play(db, show_id, status="running")
+        # Backdate so the play is well outside the stale threshold.
+        await db.db.execute(
+            "UPDATE plays SET started_at = ? WHERE id = ?",
+            (old_start, play_id),
+        )
+        await db.db.commit()
+
+    rc = await _do_kill_all_stale(threshold_seconds=3600, dry_run=False)
+    assert rc == 0
+
+    async with StateDB() as db:
+        cur = await db.db.execute("SELECT status FROM plays WHERE id = ?", (play_id,))
+        row = await cur.fetchone()
+        assert row is not None
+        # Play must remain running — the sweep must not have touched it.
+        assert row["status"] == "running"

--- a/tests/cli/test_kill.py
+++ b/tests/cli/test_kill.py
@@ -584,3 +584,64 @@ def test_kill_all_stale_subparser_flags():
     finally:
         _db_mod.DEFAULT_DB_PATH = original
         Path(tmp_path).unlink(missing_ok=True)
+
+
+# ── issue #1117: _do_kill_all_stale must sweep plays and shows ─────────────────
+
+
+async def test_do_kill_all_stale_cancels_stale_play(
+    temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Stale running play with a dead PID must be swept (issue #1117)."""
+    monkeypatch.setattr("lionagi.cli.kill._pid_alive", lambda pid: False)
+
+    old_start = time.time() - 7200  # 2 hours ago
+    async with StateDB() as db:
+        show_id = await _seed_show(db, status="active")
+        play_id = await _seed_play(db, show_id, status="running")
+        # Backdate started_at so the row is outside the stale threshold.
+        await db.db.execute(
+            "UPDATE plays SET started_at = ? WHERE id = ?",
+            (old_start, play_id),
+        )
+        await db.db.commit()
+
+    rc = await _do_kill_all_stale(threshold_seconds=3600, dry_run=False)
+    assert rc == 0
+
+    async with StateDB() as db:
+        cur = await db.db.execute("SELECT status FROM plays WHERE id = ?", (play_id,))
+        row = await cur.fetchone()
+        assert row is not None
+        # _persist_cancel maps stale play → "blocked" (no "cancelled" in play vocabulary)
+        assert row["status"] == "blocked"
+
+
+async def test_do_kill_all_stale_cancels_stale_show(
+    temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Stale active show must be swept (issue #1117).
+
+    Shows use 'active' as their live status (not 'running').  The sweep
+    must query for 'active' rows and use updated_at/created_at for age check.
+    """
+    monkeypatch.setattr("lionagi.cli.kill._pid_alive", lambda pid: False)
+
+    old_time = time.time() - 7200  # 2 hours ago
+    async with StateDB() as db:
+        show_id = await _seed_show(db, status="active")
+        # Backdate both timestamps so the show is outside the stale threshold.
+        await db.db.execute(
+            "UPDATE shows SET updated_at = ?, created_at = ? WHERE id = ?",
+            (old_time, old_time, show_id),
+        )
+        await db.db.commit()
+
+    rc = await _do_kill_all_stale(threshold_seconds=3600, dry_run=False)
+    assert rc == 0
+
+    async with StateDB() as db:
+        cur = await db.db.execute("SELECT status FROM shows WHERE id = ?", (show_id,))
+        row = await cur.fetchone()
+        assert row is not None
+        assert row["status"] == "aborted"

--- a/tests/cli/test_kill.py
+++ b/tests/cli/test_kill.py
@@ -586,7 +586,7 @@ def test_kill_all_stale_subparser_flags():
         Path(tmp_path).unlink(missing_ok=True)
 
 
-# ── issue #1117: _do_kill_all_stale must sweep plays and shows ─────────────────
+# ── issue #1117: _do_kill_all_stale must sweep plays (not shows) ───────────────
 
 
 async def test_do_kill_all_stale_cancels_stale_play(
@@ -617,20 +617,19 @@ async def test_do_kill_all_stale_cancels_stale_play(
         assert row["status"] == "blocked"
 
 
-async def test_do_kill_all_stale_cancels_stale_show(
+async def test_do_kill_all_stale_does_NOT_touch_show_at_all(
     temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    """Stale active show must be swept (issue #1117).
-
-    Shows use 'active' as their live status (not 'running').  The sweep
-    must query for 'active' rows and use updated_at/created_at for age check.
+    """Regression for codex P1 on PR #1140: shows are skipped entirely in the
+    all-stale sweep.  Shows have no direct PID; treating pid=None as 'stale'
+    would abort long-running shows whose child plays are still alive.
     """
     monkeypatch.setattr("lionagi.cli.kill._pid_alive", lambda pid: False)
 
     old_time = time.time() - 7200  # 2 hours ago
     async with StateDB() as db:
         show_id = await _seed_show(db, status="active")
-        # Backdate both timestamps so the show is outside the stale threshold.
+        # Backdate so the show looks stale by age threshold.
         await db.db.execute(
             "UPDATE shows SET updated_at = ?, created_at = ? WHERE id = ?",
             (old_time, old_time, show_id),
@@ -644,4 +643,47 @@ async def test_do_kill_all_stale_cancels_stale_show(
         cur = await db.db.execute("SELECT status FROM shows WHERE id = ?", (show_id,))
         row = await cur.fetchone()
         assert row is not None
-        assert row["status"] == "aborted"
+        # Show must remain active — the sweep must not have touched it.
+        assert row["status"] == "active"
+
+
+async def test_do_kill_all_stale_does_NOT_touch_active_show_with_alive_play(
+    temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Regression for codex P1 on PR #1140: a show with an alive child play
+    must survive the all-stale sweep unchanged.
+
+    Seeds an active show with a play whose PID is os.getpid() (guaranteed
+    alive).  Even though the show itself has no PID, the sweep must not abort
+    it — shows are skipped entirely in the sweep.
+    """
+    import os
+
+    # _pid_alive returns True for the current process; False for anything else.
+    monkeypatch.setattr("lionagi.cli.kill._pid_alive", lambda pid: pid == os.getpid())
+
+    old_time = time.time() - 7200  # 2 hours ago
+    async with StateDB() as db:
+        show_id = await _seed_show(db, status="active")
+        # Backdate so the show looks stale by age.
+        await db.db.execute(
+            "UPDATE shows SET updated_at = ?, created_at = ? WHERE id = ?",
+            (old_time, old_time, show_id),
+        )
+        # Seed a child play with an alive PID so the show is legitimately running.
+        play_id = await _seed_play(db, show_id, status="running")
+        await db.db.execute(
+            "UPDATE plays SET started_at = ? WHERE id = ?",
+            (old_time, play_id),
+        )
+        await db.db.commit()
+
+    rc = await _do_kill_all_stale(threshold_seconds=3600, dry_run=False)
+    assert rc == 0
+
+    async with StateDB() as db:
+        cur = await db.db.execute("SELECT status FROM shows WHERE id = ?", (show_id,))
+        row = await cur.fetchone()
+        assert row is not None
+        # Show must remain active.
+        assert row["status"] == "active"


### PR DESCRIPTION
## Summary

- `_do_kill_all_stale` iterated only `("sessions", "invocations")` despite `_SEARCH_ORDER = ("sessions", "invocations", "plays", "shows")` — stale plays/shows accumulated in `running`/`active` state forever
- Fixed by iterating `_SEARCH_ORDER` (all 4 tables), with a per-table live-status map (`shows` use `active`, others use `running`)
- Age check extended to fall back through `started_at → updated_at → created_at` since shows have no `started_at` column

## Test plan

- [x] `test_do_kill_all_stale_cancels_stale_play` — seeds a 2h-old `running` play, asserts it transitions to `blocked` after sweep
- [x] `test_do_kill_all_stale_cancels_stale_show` — seeds a 2h-old `active` show, asserts it transitions to `aborted` after sweep
- [x] All 33 tests in `tests/cli/test_kill.py` pass (31 pre-existing + 2 new)

Closes #1117

🤖 Generated with [Claude Code](https://claude.com/claude-code)