### PR TITLE
feat(api): export lndl + adapters from package root via lazy __getattr__ (#1122)

### DIFF
--- a/lionagi/__init__.py
+++ b/lionagi/__init__.py
@@ -13,7 +13,30 @@ if TYPE_CHECKING:
     from pydantic import BaseModel, Field
 
     from . import _types as types
+    from .adapters import (
+        Adaptable,
+        AdapterError,
+        AdapterRegistry,
+        AsyncAdaptable,
+        AsyncAdapterRegistry,
+        CsvAdapter,
+        JsonAdapter,
+        TomlAdapter,
+    )
     from .ln import alcall, json_dumps, lcall, to_dict, to_list
+    from .lndl import (
+        AmbiguousMatchError,
+        InvalidConstructorError,
+        LNDLError,
+        LNDLOutput,
+        MissingFieldError,
+        MissingLvarError,
+        MissingOutBlockError,
+        TypeMismatchError,
+        extract_lndl_blocks,
+        get_lndl_system_prompt,
+        normalize_lndl_text,
+    )
     from .models.field_model import FieldModel
     from .models.operable_model import OperableModel
     from .operations.builder import OperationGraphBuilder as Builder
@@ -56,6 +79,27 @@ _LAZY_MAP: dict[str, tuple[str, str | None]] = {
     "to_list": ("ln", "to_list"),
     "to_dict": ("ln", "to_dict"),
     "json_dumps": ("ln", "json_dumps"),
+    # lndl — Lion Notation Definition Language
+    "LNDLOutput": ("lndl", "LNDLOutput"),
+    "LNDLError": ("lndl", "LNDLError"),
+    "MissingLvarError": ("lndl", "MissingLvarError"),
+    "MissingFieldError": ("lndl", "MissingFieldError"),
+    "TypeMismatchError": ("lndl", "TypeMismatchError"),
+    "InvalidConstructorError": ("lndl", "InvalidConstructorError"),
+    "MissingOutBlockError": ("lndl", "MissingOutBlockError"),
+    "AmbiguousMatchError": ("lndl", "AmbiguousMatchError"),
+    "get_lndl_system_prompt": ("lndl", "get_lndl_system_prompt"),
+    "extract_lndl_blocks": ("lndl", "extract_lndl_blocks"),
+    "normalize_lndl_text": ("lndl", "normalize_lndl_text"),
+    # adapters — inlined adapter stack
+    "AdapterRegistry": ("adapters", "AdapterRegistry"),
+    "AsyncAdapterRegistry": ("adapters", "AsyncAdapterRegistry"),
+    "Adaptable": ("adapters", "Adaptable"),
+    "AsyncAdaptable": ("adapters", "AsyncAdaptable"),
+    "AdapterError": ("adapters", "AdapterError"),
+    "JsonAdapter": ("adapters", "JsonAdapter"),
+    "CsvAdapter": ("adapters", "CsvAdapter"),
+    "TomlAdapter": ("adapters", "TomlAdapter"),
 }
 
 
@@ -76,10 +120,17 @@ def __getattr__(name: str):
 
 __all__ = (
     "__version__",
+    "Adaptable",
+    "AdapterError",
+    "AdapterRegistry",
+    "AmbiguousMatchError",
+    "AsyncAdaptable",
+    "AsyncAdapterRegistry",
     "BaseModel",
     "Branch",
     "Broadcaster",
     "Builder",
+    "CsvAdapter",
     "DataClass",
     "Edge",
     "Element",
@@ -89,7 +140,14 @@ __all__ = (
     "Graph",
     "HookRegistry",
     "HookedEvent",
+    "InvalidConstructorError",
+    "JsonAdapter",
+    "LNDLError",
+    "LNDLOutput",
     "Message",
+    "MissingFieldError",
+    "MissingLvarError",
+    "MissingOutBlockError",
     "Node",
     "Operable",
     "OperableModel",
@@ -99,16 +157,21 @@ __all__ = (
     "Progression",
     "Session",
     "Spec",
+    "TomlAdapter",
+    "TypeMismatchError",
     "Undefined",
     "Unset",
     "alcall",
     "create_message",
+    "extract_lndl_blocks",
+    "get_lndl_system_prompt",
     "iModel",
     "json_dumps",
     "lcall",
     "ln",
     "load_mcp_tools",
     "logger",
+    "normalize_lndl_text",
     "to_dict",
     "to_list",
     "types",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -12,13 +12,21 @@ from lionagi.ln import import_module
 class TestMainImports:
     """Tests for main lionagi package imports."""
 
-    # All exports from lionagi.__all__ (alphabetically sorted)
+    # All exports from lionagi.__all__ (dunders first, then alphabetical).
+    # Updated for PR #1122: lndl and adapters symbols added.
     EXPECTED_EXPORTS = (
         "__version__",
+        "Adaptable",
+        "AdapterError",
+        "AdapterRegistry",
+        "AmbiguousMatchError",
+        "AsyncAdaptable",
+        "AsyncAdapterRegistry",
         "BaseModel",
         "Branch",
         "Broadcaster",
         "Builder",
+        "CsvAdapter",
         "DataClass",
         "Edge",
         "Element",
@@ -28,7 +36,14 @@ class TestMainImports:
         "Graph",
         "HookRegistry",
         "HookedEvent",
+        "InvalidConstructorError",
+        "JsonAdapter",
+        "LNDLError",
+        "LNDLOutput",
         "Message",
+        "MissingFieldError",
+        "MissingLvarError",
+        "MissingOutBlockError",
         "Node",
         "Operable",
         "OperableModel",
@@ -38,16 +53,21 @@ class TestMainImports:
         "Progression",
         "Session",
         "Spec",
+        "TomlAdapter",
+        "TypeMismatchError",
         "Undefined",
         "Unset",
         "alcall",
         "create_message",
+        "extract_lndl_blocks",
+        "get_lndl_system_prompt",
         "iModel",
         "json_dumps",
         "lcall",
         "ln",
         "load_mcp_tools",
         "logger",
+        "normalize_lndl_text",
         "to_dict",
         "to_list",
         "types",
@@ -59,24 +79,23 @@ class TestMainImports:
         assert lionagi.__all__ == self.EXPECTED_EXPORTS
 
     def test_all_exports_alphabetically_sorted(self):
-        """Test that __all__ exports are alphabetically sorted.
-
-        Note: Dunder names (like __version__) come first by convention,
-        then regular names are sorted alphabetically.
-        """
-        # Separate dunder names from regular names
+        """Dunder names first, then all regular names alphabetically sorted."""
         dunder_names = [name for name in lionagi.__all__ if name.startswith("__")]
         regular_names = [name for name in lionagi.__all__ if not name.startswith("__")]
 
-        # Check dunder names are sorted
+        # Dunder names must be sorted among themselves
         assert tuple(dunder_names) == tuple(sorted(dunder_names))
 
-        # Check regular names are sorted
+        # Regular names must be globally sorted (not just per-group)
         assert tuple(regular_names) == tuple(sorted(regular_names))
 
-        # Check dunder names come before regular names
-        expected_exports = tuple(sorted(dunder_names)) + tuple(sorted(regular_names))
-        assert lionagi.__all__ == expected_exports
+        # Dunder names must appear before any regular name
+        if dunder_names and regular_names:
+            dunder_indices = [i for i, n in enumerate(lionagi.__all__) if n.startswith("__")]
+            regular_indices = [i for i, n in enumerate(lionagi.__all__) if not n.startswith("__")]
+            assert max(dunder_indices) < min(regular_indices), (
+                "All dunder names must precede regular names in __all__"
+            )
 
     @pytest.mark.parametrize("export_name", EXPECTED_EXPORTS)
     def test_import_all_exports(self, export_name):


### PR DESCRIPTION
## Summary

- Adds 19 new symbols to `lionagi/__init__.py`'s lazy `_LAZY_MAP` and `__all__`, making `lionagi.lndl` and `lionagi.adapters` importable directly from `from lionagi import X`
- **lndl** (11 symbols): `LNDLOutput`, `LNDLError`, `MissingLvarError`, `MissingFieldError`, `TypeMismatchError`, `InvalidConstructorError`, `MissingOutBlockError`, `AmbiguousMatchError`, `get_lndl_system_prompt`, `extract_lndl_blocks`, `normalize_lndl_text`
- **adapters** (8 symbols): `AdapterRegistry`, `AsyncAdapterRegistry`, `Adaptable`, `AsyncAdaptable`, `AdapterError`, `JsonAdapter`, `CsvAdapter`, `TomlAdapter`
- Updates `tests/test_init.py` `EXPECTED_EXPORTS` to match the expanded (flat-alphabetically sorted) `__all__`

Closes #1122.

## Test plan

- [x] Smoke test: `from lionagi import LNDLOutput, get_lndl_system_prompt, AdapterRegistry, Adaptable, JsonAdapter` — all pass
- [x] All 19 new symbols verified via `hasattr(lionagi, sym)` loop
- [x] `uv run pytest tests/ -x --timeout=60 -k "import or public" -q` — 303 passed, 0 failed
- [x] `test_all_sorted_dunders_first` and `test_all_exports_defined` pass with new flat-sorted `__all__`

🤖 Generated with [Claude Code](https://claude.com/claude-code)