### PR TITLE
refactor(state): extract LIONAGI_HOME to _paths.py leaf to break dep inversion

### DIFF
--- a/lionagi/_paths.py
+++ b/lionagi/_paths.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Path constants — leaf module, no lionagi deps. Imported by state, cli, etc."""
+
+import os
+from pathlib import Path
+
+LIONAGI_HOME: Path = Path(os.environ.get("LIONAGI_HOME", Path.home() / ".lionagi")).expanduser()

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -11,8 +11,8 @@ from typing import Any
 
 import aiosqlite
 
+from lionagi._paths import LIONAGI_HOME
 from lionagi.ln.concurrency import Lock
-from lionagi.cli._runs import LIONAGI_HOME
 from lionagi.state.reasons import (
     PlayReasons as _PlayReasons,
 )

--- a/lionagi/utils.py
+++ b/lionagi/utils.py
@@ -10,6 +10,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Annotated, Any, TypeVar, Union, get_args, get_origin
 
+from lionagi._paths import LIONAGI_HOME
+
 from .ln import (
     get_bins,
     hash_dict,
@@ -206,11 +208,6 @@ def create_path(
     # Check if file or directory existence
     full_path.parent.mkdir(parents=True, exist_ok=dir_exist_ok)
     if full_path.exists() and not file_exist_ok:
-        raise FileExistsError(
-            f"File {full_path} already exists and file_exist_ok is False."
-        )
+        raise FileExistsError(f"File {full_path} already exists and file_exist_ok is False.")
 
     return full_path
-
-
-LIONAGI_HOME = Path.home() / ".lionagi"


### PR DESCRIPTION
## Summary

Closes #1119.

`lionagi/state/db.py` had a layering inversion: it imported `LIONAGI_HOME` from `lionagi.cli._runs`, meaning any consumer of `state.db` transitively loaded CLI code. State should sit *below* CLI in the dependency graph.

### Changes

- **New** `lionagi/_paths.py` — leaf module with zero internal lionagi deps. Defines `LIONAGI_HOME` with env-var override support (`LIONAGI_HOME` env var → `~/.lionagi` fallback).
- **`lionagi/utils.py`** — re-exports `LIONAGI_HOME` from `_paths` (was a direct `Path.home() / ".lionagi"` expression). Back-compat preserved.
- **`lionagi/state/db.py`** — imports `LIONAGI_HOME` from `lionagi._paths` instead of `lionagi.cli._runs`.

`cli/_runs.py` is unchanged — it still imports via `utils`, which chains to `_paths`.

### Dep graph verification

```
$ python -c "import lionagi.state.db; import sys; cli_loaded = any('cli' in m for m in sys.modules); print(f'CLI loaded by state.db: {cli_loaded}')"
CLI loaded by state.db: False
```

### Test results

- Baseline: 280 state tests passed
- Post-refactor: 6630 passed, 1 skipped (config.toml absent in worktree — expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)