### PR TITLE
feat: Structure abstraction + InstructionContent refactor

### DIFF
--- a/lionagi/operations/chat/_prepare.py
+++ b/lionagi/operations/chat/_prepare.py
@@ -24,7 +24,7 @@ def _prepare_run_kwargs(
     instruction: JsonValue | Instruction,
     param: ChatParam,
 ) -> tuple[Instruction, dict]:
-    to_exlcude = {"imodel", "imodel_kw", "include_token_usage_to_model", "progression"}
+    to_exlcude = {"imodel", "imodel_kw", "include_token_usage_to_model", "progression", "structure"}
     if isinstance(param, RunParam):
         to_exlcude.add("stream_persist")
         to_exlcude.add("persist_dir")

--- a/lionagi/operations/chat/_prepare.py
+++ b/lionagi/operations/chat/_prepare.py
@@ -45,16 +45,13 @@ def _prepare_run_kwargs(
             _act_res.append(msg)
 
         if isinstance(msg, AssistantResponse):
-            _use_msgs.append(
-                msg.model_copy(update={"content": msg.content.with_updates()})
-            )
+            _use_msgs.append(msg.model_copy(update={"content": msg.content.with_updates()}))
 
         if isinstance(msg, Instruction):
             j = msg.model_copy(update={"content": msg.content.with_updates()})
             j.content.tool_schemas.clear()
             j.content.response_format = None
-            j.content._schema_dict = None
-            j.content._model_class = None
+            j.content._structure_instance = None
 
             if _act_res:
                 # Convert ActionResponseContent to dicts for proper rendering
@@ -93,9 +90,7 @@ def _prepare_run_kwargs(
                 )
             else:
                 d_.append(k.content)
-        j.content.prompt_context.extend(
-            [z for z in d_ if z not in j.content.prompt_context]
-        )
+        j.content.prompt_context.extend([z for z in d_ if z not in j.content.prompt_context])
         _use_ins = j
 
     _use_msgs = [msg for msg in _use_msgs if msg.role != MessageRole.UNSET]
@@ -106,7 +101,9 @@ def _prepare_run_kwargs(
         for i in _use_msgs[1:]:
             if isinstance(i, AssistantResponse):
                 if isinstance(_msgs[-1], AssistantResponse):
-                    _msgs[-1].content.assistant_response = (
+                    _msgs[
+                        -1
+                    ].content.assistant_response = (
                         f"{_msgs[-1].content.assistant_response}\n\n{i.content.assistant_response}"
                     )
                 else:
@@ -137,14 +134,10 @@ def _prepare_run_kwargs(
         elif len(messages) >= 1:
             first_instruction = messages[0]
             if not isinstance(first_instruction, Instruction):
-                raise ValueError(
-                    "First message in progression must be an Instruction or System"
-                )
+                raise ValueError("First message in progression must be an Instruction or System")
             first_instruction = first_instruction.model_copy(
                 update={
-                    "content": first_instruction.content.with_updates(
-                        guidance=f(first_instruction)
-                    )
+                    "content": first_instruction.content.with_updates(guidance=f(first_instruction))
                 }
             )
             messages[0] = first_instruction

--- a/lionagi/operations/chat/_prepare.py
+++ b/lionagi/operations/chat/_prepare.py
@@ -12,6 +12,8 @@ from lionagi.protocols.messages import (
     Instruction,
     MessageRole,
 )
+from lionagi.protocols.messages.assistant_response import AssistantResponseContent
+from lionagi.protocols.messages.instruction import InstructionContent
 
 from ..types import ChatParam, RunParam
 
@@ -24,141 +26,121 @@ def _prepare_run_kwargs(
     instruction: JsonValue | Instruction,
     param: ChatParam,
 ) -> tuple[Instruction, dict]:
-    to_exlcude = {"imodel", "imodel_kw", "include_token_usage_to_model", "progression", "structure"}
+    to_exclude = {"imodel", "imodel_kw", "include_token_usage_to_model", "progression", "structure"}
     if isinstance(param, RunParam):
-        to_exlcude.add("stream_persist")
-        to_exlcude.add("persist_dir")
-        to_exlcude.add("snapshot_dir")
+        to_exclude.add("stream_persist")
+        to_exclude.add("persist_dir")
+        to_exclude.add("snapshot_dir")
 
-    params = param.to_dict(exclude=to_exlcude)
+    params = param.to_dict(exclude=to_exclude)
     params["sender"] = param.sender or branch.user or "user"
     params["recipient"] = param.recipient or branch.id
     params["instruction"] = instruction
 
     ins = branch.msgs.create_instruction(**params)
 
-    _use_ins, _use_msgs, _act_res = None, [], []
+    _use_ins_content = None
+    _contents = []
+    _act_res = []
     progression = param.progression or branch.progression
 
     for msg in (branch.msgs.messages[j] for j in progression):
         if isinstance(msg, ActionResponse):
             _act_res.append(msg)
 
-        if isinstance(msg, AssistantResponse):
-            _use_msgs.append(msg.model_copy(update={"content": msg.content.with_updates()}))
+        elif isinstance(msg, AssistantResponse):
+            _contents.append(msg.content.with_updates())
 
-        if isinstance(msg, Instruction):
-            j = msg.model_copy(update={"content": msg.content.with_updates()})
-            j.content.tool_schemas.clear()
-            j.content.response_format = None
-            j.content._structure_instance = None
+        elif isinstance(msg, Instruction):
+            updates = {"tool_schemas": [], "response_format": None}
 
             if _act_res:
-                # Convert ActionResponseContent to dicts for proper rendering
-                d_ = []
-                for k in to_list(_act_res, flatten=True, unique=True):
-                    if hasattr(k.content, "function"):  # ActionResponseContent
-                        d_.append(
-                            {
-                                "function": k.content.function,
-                                "arguments": k.content.arguments,
-                                "output": k.content.output,
-                            }
-                        )
-                    else:
-                        d_.append(k.content)
-                j.content.prompt_context.extend(
-                    [z for z in d_ if z not in j.content.prompt_context]
-                )
-                _use_msgs.append(j)
+                d_ = _collect_action_dicts(_act_res)
+                extended_ctx = list(msg.content.prompt_context)
+                extended_ctx.extend(z for z in d_ if z not in extended_ctx)
+                updates["prompt_context"] = extended_ctx
                 _act_res = []
-            else:
-                _use_msgs.append(j)
+
+            _contents.append(msg.content.with_updates(**updates))
 
     if _act_res:
-        j = ins.model_copy(update={"content": ins.content.with_updates()})
-        # Convert ActionResponseContent to dicts for proper rendering
-        d_ = []
-        for k in to_list(_act_res, flatten=True, unique=True):
-            if hasattr(k.content, "function"):  # ActionResponseContent
-                d_.append(
-                    {
-                        "function": k.content.function,
-                        "arguments": k.content.arguments,
-                        "output": k.content.output,
-                    }
-                )
-            else:
-                d_.append(k.content)
-        j.content.prompt_context.extend([z for z in d_ if z not in j.content.prompt_context])
-        _use_ins = j
+        d_ = _collect_action_dicts(_act_res)
+        extended_ctx = list(ins.content.prompt_context)
+        extended_ctx.extend(z for z in d_ if z not in extended_ctx)
+        _use_ins_content = ins.content.with_updates(prompt_context=extended_ctx)
 
-    _use_msgs = [msg for msg in _use_msgs if msg.role != MessageRole.UNSET]
-    messages = _use_msgs
-    if _use_msgs and len(_use_msgs) > 1:
-        _msgs = [_use_msgs[0]]
+    _contents = [c for c in _contents if c.role != MessageRole.UNSET]
 
-        for i in _use_msgs[1:]:
-            if isinstance(i, AssistantResponse):
-                if isinstance(_msgs[-1], AssistantResponse):
-                    _msgs[
+    # Merge consecutive assistant responses
+    if len(_contents) > 1:
+        merged = [_contents[0]]
+        for c in _contents[1:]:
+            if isinstance(c, AssistantResponseContent):
+                if isinstance(merged[-1], AssistantResponseContent):
+                    merged[
                         -1
-                    ].content.assistant_response = (
-                        f"{_msgs[-1].content.assistant_response}\n\n{i.content.assistant_response}"
+                    ].assistant_response = (
+                        f"{merged[-1].assistant_response}\n\n{c.assistant_response}"
                     )
                 else:
-                    _msgs.append(i)
+                    merged.append(c)
             else:
-                if isinstance(_msgs[-1], AssistantResponse):
-                    _msgs.append(i)
-        messages = _msgs
+                if isinstance(merged[-1], AssistantResponseContent):
+                    merged.append(c)
+        _contents = merged
 
-    # All endpoints now assume sequential exchange (system message embedded in first user message)
     if branch.msgs.system:
-        messages = [msg for msg in messages if msg.role != "system"]
-        first_instruction = None
 
-        def f(x):
-            g = x.content.guidance or ""
+        def f(c):
+            g = c.guidance or ""
             if not isinstance(g, str):
                 from lionagi.libs.schema.minimal_yaml import minimal_yaml
 
                 g = minimal_yaml(g).strip()
             return branch.msgs.system.rendered + g
 
-        if len(messages) == 0:
-            first_instruction = ins.model_copy(
-                update={"content": ins.content.with_updates(guidance=f(ins))}
-            )
-            messages.append(first_instruction)
-        elif len(messages) >= 1:
-            first_instruction = messages[0]
-            if not isinstance(first_instruction, Instruction):
+        if len(_contents) == 0:
+            _contents.append(ins.content.with_updates(guidance=f(ins.content)))
+        elif len(_contents) >= 1:
+            first = _contents[0]
+            if not isinstance(first, InstructionContent):
                 raise ValueError("First message in progression must be an Instruction or System")
-            first_instruction = first_instruction.model_copy(
-                update={
-                    "content": first_instruction.content.with_updates(guidance=f(first_instruction))
-                }
-            )
-            messages[0] = first_instruction
-            msg_to_append = _use_ins or ins
-            if msg_to_append is not None:
-                messages.append(msg_to_append)
-
+            _contents[0] = first.with_updates(guidance=f(first))
+            content_to_append = _use_ins_content or ins.content
+            if content_to_append is not None:
+                _contents.append(content_to_append)
     else:
-        msg_to_append = _use_ins or ins
-        if msg_to_append is not None:
-            messages.append(msg_to_append)
+        content_to_append = _use_ins_content or ins.content
+        if content_to_append is not None:
+            _contents.append(content_to_append)
 
     kw = (param.imodel_kw or {}).copy()
 
-    # Filter out messages with None chat_msg
     chat_msgs = []
-    for msg in messages:
-        if msg is not None and hasattr(msg, "chat_msg"):
-            chat_msg = msg.chat_msg
-            if chat_msg is not None:
-                chat_msgs.append(chat_msg)
+    for c in _contents:
+        if c is None:
+            continue
+        rendered = c.rendered
+        if not rendered:
+            continue
+        role_str = c.role.value if isinstance(c.role, MessageRole) else str(c.role)
+        chat_msgs.append({"role": role_str, "content": rendered})
 
     kw["messages"] = chat_msgs
     return ins, kw
+
+
+def _collect_action_dicts(act_res_msgs):
+    d_ = []
+    for k in to_list(act_res_msgs, flatten=True, unique=True):
+        if hasattr(k.content, "function"):
+            d_.append(
+                {
+                    "function": k.content.function,
+                    "arguments": k.content.arguments,
+                    "output": k.content.output,
+                }
+            )
+        else:
+            d_.append(k.content)
+    return d_

--- a/lionagi/operations/chat/_prepare.py
+++ b/lionagi/operations/chat/_prepare.py
@@ -26,7 +26,7 @@ def _prepare_run_kwargs(
     instruction: JsonValue | Instruction,
     param: ChatParam,
 ) -> tuple[Instruction, dict]:
-    to_exclude = {"imodel", "imodel_kw", "include_token_usage_to_model", "progression", "structure"}
+    to_exclude = {"imodel", "imodel_kw", "include_token_usage_to_model", "progression"}
     if isinstance(param, RunParam):
         to_exclude.add("stream_persist")
         to_exclude.add("persist_dir")

--- a/lionagi/operations/communicate/communicate.py
+++ b/lionagi/operations/communicate/communicate.py
@@ -105,9 +105,7 @@ def prepare_communicate_kw(
                 FuzzyMatchKeysParams(**fuzzy_kw) if fuzzy_kw else FuzzyMatchKeysParams()
             ),
             handle_validation=handle_validation,
-            alcall_params=get_default_call().with_updates(
-                retry_attempts=num_parse_retries
-            ),
+            alcall_params=get_default_call().with_updates(retry_attempts=num_parse_retries),
             imodel=parse_model,
             imodel_kw={},
         )
@@ -150,10 +148,14 @@ async def communicate(
 
         from ..parse.parse import parse
 
+        # Pull structure from the instruction message
+        if parse_param.structure is None and hasattr(ins, "content"):
+            si = getattr(ins.content, "_structure_instance", None)
+            if si is not None:
+                parse_param = parse_param.with_updates(structure=si)
+
         try:
-            out, res2 = await parse(
-                branch, res.response, parse_param, return_res_message=True
-            )
+            out, res2 = await parse(branch, res.response, parse_param, return_res_message=True)
             if res2 and isinstance(res2, AssistantResponse):
                 res.metadata["original_model_response"] = res.model_response
                 # model_response is read-only property - update metadata instead

--- a/lionagi/operations/communicate/communicate.py
+++ b/lionagi/operations/communicate/communicate.py
@@ -146,10 +146,12 @@ async def communicate(
     if parse_param and chat_param.response_format:
         from lionagi.protocols.messages.assistant_response import AssistantResponse
 
+        # Pull structure from the instruction message
+        from lionagi.protocols.structure.base import Structure
+
         from ..parse.parse import parse
 
-        # Pull structure from the instruction message
-        if parse_param.structure is None and hasattr(ins, "content"):
+        if not isinstance(parse_param.structure, Structure) and hasattr(ins, "content"):
             si = getattr(ins.content, "_structure_instance", None)
             if si is not None:
                 parse_param = parse_param.with_updates(structure=si)

--- a/lionagi/operations/operate/operate.py
+++ b/lionagi/operations/operate/operate.py
@@ -158,10 +158,7 @@ def prepare_operate_kw(
     # caller passes a middle that needs persist_dir). Defaulting to
     # RunParam for CLI endpoints keeps the call sites free of path plumbing.
     is_cli = bool(getattr(chat_model, "is_cli", False))
-    use_run_param = (
-        is_cli or stream_persist or persist_dir is not None
-        or snapshot_dir is not None
-    )
+    use_run_param = is_cli or stream_persist or persist_dir is not None or snapshot_dir is not None
 
     param_cls = RunParam if use_run_param else ChatParam
     param_kw = dict(
@@ -179,6 +176,7 @@ def prepare_operate_kw(
         imodel=chat_model,
         imodel_kw=kwargs,
     )
+
     if use_run_param:
         param_kw["stream_persist"] = stream_persist
         if persist_dir is not None:

--- a/lionagi/operations/parse/parse.py
+++ b/lionagi/operations/parse/parse.py
@@ -15,6 +15,7 @@ from lionagi.ln import (
     to_list,
 )
 from lionagi.ln.fuzzy import FuzzyMatchKeysParams
+from lionagi.protocols.structure.base import Structure
 from lionagi.protocols.types import AssistantResponse
 
 from ..types import HandleValidation, ParseParam
@@ -91,10 +92,11 @@ async def parse(
     parse_param: ParseParam,
     return_res_message: bool = False,
 ) -> Any | tuple[Any, AssistantResponse | None]:
-    # When a Structure instance is provided, delegate to it
-    if parse_param.structure is not None:
+    structure = parse_param.structure if isinstance(parse_param.structure, Structure) else None
+
+    if structure is not None:
         with contextlib.suppress(Exception):
-            result = parse_param.structure.parse(
+            result = structure.parse(
                 text,
                 fuzzy_match_params=parse_param.fuzzy_match_params,
             )
@@ -131,9 +133,9 @@ async def parse(
         res.metadata["is_parsed"] = True
         res.metadata["original_text"] = text
 
-        if parse_param.structure is not None:
+        if structure is not None:
             return (
-                parse_param.structure.parse(
+                structure.parse(
                     res.response,
                     fuzzy_match_params=parse_param.fuzzy_match_params,
                 ),

--- a/lionagi/operations/parse/parse.py
+++ b/lionagi/operations/parse/parse.py
@@ -44,6 +44,7 @@ def prepare_parse_kws(
     suppress_conversion_errors: bool = False,
     response_format=None,
     request_fields=None,
+    structure=None,
     return_res_message: bool = False,
     **kw,
 ):
@@ -73,6 +74,7 @@ def prepare_parse_kws(
         "text": text,
         "parse_param": ParseParam(
             response_format=response_format or request_fields,
+            structure=structure,
             fuzzy_match_params=fuzzy_params,
             handle_validation=handle_validation,
             alcall_params=_alcall_params.with_updates(retry_attempts=max_retries),
@@ -89,12 +91,21 @@ async def parse(
     parse_param: ParseParam,
     return_res_message: bool = False,
 ) -> Any | tuple[Any, AssistantResponse | None]:
-    # Try direct validation first
-    with contextlib.suppress(Exception):
-        result = _validate_dict_or_model(
-            text, parse_param.response_format, parse_param.fuzzy_match_params
-        )
-        return result if not return_res_message else (result, None)
+    # When a Structure instance is provided, delegate to it
+    if parse_param.structure is not None:
+        with contextlib.suppress(Exception):
+            result = parse_param.structure.parse(
+                text,
+                fuzzy_match_params=parse_param.fuzzy_match_params,
+            )
+            return result if not return_res_message else (result, None)
+    else:
+        # Try direct validation first
+        with contextlib.suppress(Exception):
+            result = _validate_dict_or_model(
+                text, parse_param.response_format, parse_param.fuzzy_match_params
+            )
+            return result if not return_res_message else (result, None)
 
     async def _inner_parse(i):
         _, res = await branch.chat(
@@ -120,6 +131,14 @@ async def parse(
         res.metadata["is_parsed"] = True
         res.metadata["original_text"] = text
 
+        if parse_param.structure is not None:
+            return (
+                parse_param.structure.parse(
+                    res.response,
+                    fuzzy_match_params=parse_param.fuzzy_match_params,
+                ),
+                res,
+            )
         return (
             _validate_dict_or_model(
                 res.response,
@@ -159,23 +178,11 @@ def _is_lndl_operable(response_format: Any) -> bool:
 
 
 def _extract_lndl(text: str, operable: "Operable") -> Any:
-    """Route text through the LNDL Phase 1 extract path.
-
-    Extracts the first ```lndl fenced block from *text* and returns it as a
-    raw string.  Full structured resolution (via ``parse_lndl_fuzzy``) requires
-    Phase 2 modules and raises ``NotImplementedError`` until they land.
-
-    Phase 1 contract: if the text contains an ```lndl block, return its
-    content; otherwise return the raw text so the caller can decide how to
-    handle it.
-    """
+    """Route text through the LNDL Phase 1 extract path."""
     from lionagi.lndl.extract import extract_lndl_blocks
 
     blocks = extract_lndl_blocks(text)
     if blocks:
-        # Return the first block's raw content.
-        # TODO(lndl-phase-2): replace with parse_lndl_fuzzy(blocks[0], operable)
-        # once lexer/parser/ast/resolver are ported from beta.
         return blocks[0]
     return text
 
@@ -185,8 +192,6 @@ def _validate_dict_or_model(
     response_format: type[BaseModel] | dict | Any,
     fuzzy_match_params: FuzzyMatchKeysParams | dict = None,
 ):
-    # LNDL opt-in path: only activates when caller passes an Operable schema.
-    # No change in behaviour for BaseModel or dict response_format callers.
     if _is_lndl_operable(response_format):
         return _extract_lndl(text, response_format)
 

--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -273,7 +273,9 @@ async def run_and_collect(
         return full_text
 
     # Pull structure from the instruction message
-    if parse_param.structure is None and ins_msg is not None:
+    from lionagi.protocols.structure.base import Structure
+
+    if not isinstance(parse_param.structure, Structure) and ins_msg is not None:
         si = getattr(ins_msg.content, "_structure_instance", None)
         if si is not None:
             parse_param = parse_param.with_updates(structure=si)

--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -18,6 +18,7 @@ from lionagi.protocols.messages import (
     AssistantResponseContent,
     Instruction,
 )
+
 from ..chat._prepare import _prepare_run_kwargs
 from ..types import ChatParam, ParseParam, RunParam
 
@@ -120,7 +121,7 @@ async def run(
     # consume ``timeout`` — pop it so it doesn't pollute create_event kwargs.
     _timeout = kw.pop("timeout", None)
     _stream_timeout: float | None = None
-    if isinstance(_timeout, (int, float)) and _timeout > 0:
+    if isinstance(_timeout, int | float) and _timeout > 0:
         _stream_timeout = float(_timeout)
 
     kw["stream"] = True
@@ -163,9 +164,7 @@ async def run(
 
                     case "tool_result":
                         orig_req = (
-                            pending_requests.pop(chunk.tool_id, None)
-                            if chunk.tool_id
-                            else None
+                            pending_requests.pop(chunk.tool_id, None) if chunk.tool_id else None
                         )
                         if orig_req is None:
                             continue
@@ -196,9 +195,7 @@ async def run(
                         pass
 
                     case "error":
-                        raise RuntimeError(
-                            chunk.content or "Stream error from CLI endpoint"
-                        )
+                        raise RuntimeError(chunk.content or "Stream error from CLI endpoint")
 
             if res := await _flush_response():
                 if hasattr(api_call, "to_dict"):
@@ -255,7 +252,10 @@ async def run_and_collect(
     run_param = _promote_to_run_param(chat_param)
 
     all_texts: list[str] = []
+    ins_msg = None
     async for msg in run(branch, instruction, run_param):
+        if isinstance(msg, Instruction) and ins_msg is None:
+            ins_msg = msg
         if isinstance(msg, AssistantResponse):
             text = msg.response or ""
             if text:
@@ -271,6 +271,12 @@ async def run_and_collect(
 
     if parse_param is None or parse_param.response_format is None:
         return full_text
+
+    # Pull structure from the instruction message
+    if parse_param.structure is None and ins_msg is not None:
+        si = getattr(ins_msg.content, "_structure_instance", None)
+        if si is not None:
+            parse_param = parse_param.with_updates(structure=si)
 
     from ..parse.parse import parse as _parse
 

--- a/lionagi/operations/types.py
+++ b/lionagi/operations/types.py
@@ -11,6 +11,7 @@ from lionagi.ln import AlcallParams
 from lionagi.ln.fuzzy import FuzzyMatchKeysParams
 from lionagi.ln.types import ModelConfig, Params
 from lionagi.protocols.action.tool import ToolRef
+from lionagi.protocols.structure.base import Structure
 from lionagi.protocols.types import ID, SenderRecipient
 from lionagi.service.imodel import iModel
 from lionagi.utils import LIONAGI_HOME
@@ -54,6 +55,7 @@ class ChatParam(MorphParam):
     sender: SenderRecipient = None
     recipient: SenderRecipient = None
     response_format: type[BaseModel] | dict = None
+    structure: type[Structure] | str | None = None
     progression: ID.RefSeq = None
     tool_schemas: list[dict] = None
     images: list = None
@@ -104,6 +106,7 @@ class ParseParam(MorphParam):
 
     _config: ClassVar[ModelConfig] = ModelConfig(none_as_sentinel=True)
     response_format: type[BaseModel] | dict = None
+    structure: Structure | None = None
     fuzzy_match_params: FuzzyMatchKeysParams | dict = None
     handle_validation: HandleValidation = "raise"
     alcall_params: AlcallParams | dict = None

--- a/lionagi/operations/types.py
+++ b/lionagi/operations/types.py
@@ -70,13 +70,6 @@ class ChatParam(MorphParam):
 class RunParam(ChatParam):
     stream_persist: bool = False
     persist_dir: str | Path = LIONAGI_HOME / "logs" / "runs"
-    # Optional separate destination for the branch snapshot JSON. When
-    # set, the streaming buffer (.buffer.jsonl) still lands in
-    # ``persist_dir`` but the canonical ``{branch_id}.json`` snapshot
-    # lands here. The CLI uses this so the snapshot lives under
-    # ``runs/<run>/branches/`` where ``find_branch()`` looks, while
-    # the buffer stays under ``runs/<run>/stream/``. When None the
-    # snapshot falls back to ``persist_dir`` (pre-PR behavior).
     snapshot_dir: str | Path | None = None
 
 

--- a/lionagi/protocols/messages/instruction.py
+++ b/lionagi/protocols/messages/instruction.py
@@ -62,6 +62,20 @@ class InstructionContent(MessageContent):
         return MessageRole.USER
 
     def with_updates(self, **kwargs: Any) -> "InstructionContent":
+        kwargs.pop("copy_containers", None)
+        if "primary" in kwargs:
+            val = kwargs.pop("primary")
+            if val is not None:
+                kwargs["instruction"] = val
+        if "context" in kwargs:
+            ctx = kwargs.pop("context")
+            kwargs["prompt_context"] = (
+                ctx if isinstance(ctx, list) else [ctx] if ctx is not None else []
+            )
+        if "request_model" in kwargs:
+            kwargs["response_format"] = kwargs.pop("request_model")
+        if "structure_format" in kwargs:
+            kwargs["structure"] = kwargs.pop("structure_format")
         dict_ = self.to_dict()
         dict_.update(kwargs)
         return type(self)(**dict_)
@@ -108,7 +122,7 @@ class InstructionContent(MessageContent):
             inst.images.extend(imgs_list)
             inst.image_detail = data.get("image_detail") or inst.image_detail or "auto"
 
-        response_format = data.get("response_format")
+        response_format = data.get("response_format") or data.get("request_model")
         structure = data.get("structure")
 
         if response_format is not None:

--- a/lionagi/protocols/messages/instruction.py
+++ b/lionagi/protocols/messages/instruction.py
@@ -62,7 +62,9 @@ class InstructionContent(MessageContent):
         return MessageRole.USER
 
     def with_updates(self, **kwargs: Any) -> "InstructionContent":
-        kwargs.pop("copy_containers", None)
+        import copy
+
+        deep = kwargs.pop("copy_containers", None) == "deep"
         if "primary" in kwargs:
             val = kwargs.pop("primary")
             if val is not None:
@@ -77,6 +79,8 @@ class InstructionContent(MessageContent):
         if "structure_format" in kwargs:
             kwargs["structure"] = kwargs.pop("structure_format")
         dict_ = self.to_dict()
+        if deep:
+            dict_ = copy.deepcopy(dict_)
         dict_.update(kwargs)
         return type(self)(**dict_)
 

--- a/lionagi/protocols/messages/instruction.py
+++ b/lionagi/protocols/messages/instruction.py
@@ -61,29 +61,6 @@ class InstructionContent(MessageContent):
     def role(self) -> MessageRole:
         return MessageRole.USER
 
-    def with_updates(self, **kwargs: Any) -> "InstructionContent":
-        import copy
-
-        deep = kwargs.pop("copy_containers", None) == "deep"
-        if "primary" in kwargs:
-            val = kwargs.pop("primary")
-            if val is not None:
-                kwargs["instruction"] = val
-        if "context" in kwargs:
-            ctx = kwargs.pop("context")
-            kwargs["prompt_context"] = (
-                ctx if isinstance(ctx, list) else [ctx] if ctx is not None else []
-            )
-        if "request_model" in kwargs:
-            kwargs["response_format"] = kwargs.pop("request_model")
-        if "structure_format" in kwargs:
-            kwargs["structure"] = kwargs.pop("structure_format")
-        dict_ = self.to_dict()
-        if deep:
-            dict_ = copy.deepcopy(dict_)
-        dict_.update(kwargs)
-        return type(self)(**dict_)
-
     @property
     def rendered(self) -> str | list[dict[str, Any]]:
         text = self._format_text_content()

--- a/lionagi/protocols/messages/instruction.py
+++ b/lionagi/protocols/messages/instruction.py
@@ -1,38 +1,21 @@
-from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, Literal
 
-import orjson
 from pydantic import BaseModel, field_validator
 
 from lionagi.ln.types import ModelConfig
 
 from .message import Message, MessageContent, MessageRole
-from .rendering import StructureFormat
 
 
 @dataclass(slots=True)
 class InstructionContent(MessageContent):
-    """Structured content for user instructions.
-
-    Fields:
-        instruction: Main instruction text
-        guidance: Optional guidance or disclaimers
-        prompt_context: Additional context items for the prompt (list)
-        plain_content: Raw text fallback (bypasses structured rendering)
-        tool_schemas: Tool specifications for the assistant
-        response_format: User's desired response format (BaseModel class, instance, or dict)
-        images: Image URLs, data URLs, or base64 strings
-        image_detail: Detail level for image processing
-
-    Internal fields (not for direct use):
-        _schema_dict: Extracted dict for prompting/schema
-        _model_class: Extracted Pydantic class for validation
-    """
+    """Structured content for user instructions."""
 
     _config: ClassVar[ModelConfig] = ModelConfig(
         none_as_sentinel=True,
-        serialize_exclude=frozenset({"response_format", "custom_renderer"}),
+        empty_as_sentinel=True,
+        serialize_exclude=frozenset({"response_format", "structure", "_structure_instance"}),
     )
 
     instruction: str | None = None
@@ -40,215 +23,51 @@ class InstructionContent(MessageContent):
     prompt_context: list[Any] = field(default_factory=list)
     plain_content: str | None = None
     tool_schemas: list[dict[str, Any]] = field(default_factory=list)
-    response_format: type[BaseModel] | dict[str, Any] | BaseModel | None = None  # User input
-    _schema_dict: dict[str, Any] | None = field(
-        default=None, repr=False
-    )  # Internal: dict for prompting
-    _model_class: type[BaseModel] | None = field(
-        default=None, repr=False
-    )  # Internal: class for validation
+    response_format: type[BaseModel] | dict[str, Any] | BaseModel | None = None
+    structure: type | str | None = None
+    _structure_instance: Any = field(default=None, repr=False)
     images: list[str] = field(default_factory=list)
     image_detail: Literal["low", "high", "auto"] | None = None
-    structure_format: str | None = None  # "json", "lndl", "custom"
-    custom_renderer: Callable | None = field(default=None, repr=False)
 
     def __init__(
         self,
         instruction: str | None = None,
-        primary: str | None = None,  # alias for instruction
         guidance: str | None = None,
         prompt_context: list[Any] | None = None,
-        context: list[Any] | None = None,  # backwards compat
         plain_content: str | None = None,
         tool_schemas: list[dict[str, Any]] | None = None,
         response_format: type[BaseModel] | dict[str, Any] | BaseModel | None = None,
         images: list[str] | None = None,
         image_detail: Literal["low", "high", "auto"] | None = None,
-        structure_format: str | None = None,
-        custom_renderer: Callable | None = None,
+        structure: type | str | None = None,
     ):
-        # Handle primary as alias for instruction (primary loses if both are set)
-        if primary is not None and instruction is None:
-            instruction = primary
-
-        # Handle backwards compatibility: context -> prompt_context
-        if context is not None and prompt_context is None:
-            prompt_context = context
-
-        # Extract model class and schema dict from response_format
-        model_class = None
-        schema_dict = None
-
-        if response_format is not None:
-            # Extract model class
-            if isinstance(response_format, type) and issubclass(response_format, BaseModel):
-                model_class = response_format
-            elif isinstance(response_format, BaseModel):
-                model_class = type(response_format)
-
-            # Extract schema dict
-            if isinstance(response_format, dict):
-                schema_dict = response_format
-            elif isinstance(response_format, BaseModel):
-                schema_dict = response_format.model_dump(mode="json", exclude_none=True)
-            elif model_class:
-                # Generate dict from model class
-                from lionagi.libs.schema.breakdown_pydantic_annotation import (
-                    breakdown_pydantic_annotation,
-                )
-
-                schema_dict = breakdown_pydantic_annotation(model_class)
+        structure_cls = _resolve_structure_cls(structure)
+        structure_inst = _build_structure(response_format, structure_cls)
 
         object.__setattr__(self, "instruction", instruction)
         object.__setattr__(self, "guidance", guidance)
         object.__setattr__(
-            self,
-            "prompt_context",
-            prompt_context if prompt_context is not None else [],
+            self, "prompt_context", prompt_context if prompt_context is not None else []
         )
         object.__setattr__(self, "plain_content", plain_content)
-        object.__setattr__(
-            self,
-            "tool_schemas",
-            tool_schemas if tool_schemas is not None else [],
-        )
-        object.__setattr__(self, "response_format", response_format)  # Store original user input
-        object.__setattr__(self, "_schema_dict", schema_dict)  # Internal: dict for prompting
-        object.__setattr__(self, "_model_class", model_class)  # Internal: class for validation
+        object.__setattr__(self, "tool_schemas", tool_schemas if tool_schemas is not None else [])
+        object.__setattr__(self, "response_format", response_format)
+        object.__setattr__(self, "structure", structure_cls)
+        object.__setattr__(self, "_structure_instance", structure_inst)
         object.__setattr__(self, "images", images if images is not None else [])
         object.__setattr__(self, "image_detail", image_detail)
-        object.__setattr__(self, "structure_format", structure_format)
-        object.__setattr__(self, "custom_renderer", custom_renderer)
-
-    @property
-    def context(self) -> list[Any]:
-        """Backwards compatibility accessor for prompt_context."""
-        return self.prompt_context
-
-    @property
-    def primary(self) -> str | None:
-        """Alias for instruction field."""
-        return self.instruction
-
-    @primary.setter
-    def primary(self, value: str | None) -> None:
-        """Write through to instruction field."""
-        object.__setattr__(self, "instruction", value)
 
     @property
     def role(self) -> MessageRole:
-        """Role for this content type (beta API compat)."""
         return MessageRole.USER
 
     def with_updates(self, **kwargs: Any) -> "InstructionContent":
-        """Return a new instance with updated fields.
-
-        Handles ``primary`` as an alias for ``instruction`` and strips the
-        beta-only ``copy_containers`` kwarg.
-        """
-        kwargs.pop("copy_containers", None)
-        # Translate 'primary' alias -> 'instruction'
-        if "primary" in kwargs:
-            primary_val = kwargs.pop("primary")
-            if primary_val is not None:
-                kwargs["instruction"] = primary_val
-        # Translate 'context' alias -> 'prompt_context'
-        if "context" in kwargs:
-            ctx_val = kwargs.pop("context")
-            kwargs["prompt_context"] = (
-                ctx_val if isinstance(ctx_val, list) else [ctx_val] if ctx_val is not None else []
-            )
-        # Translate 'request_model' -> 'response_format'
-        if "request_model" in kwargs:
-            kwargs["response_format"] = kwargs.pop("request_model")
         dict_ = self.to_dict()
         dict_.update(kwargs)
         return type(self)(**dict_)
 
-    def render(
-        self,
-        structure_format: str | StructureFormat | None = None,
-        custom_renderer: Callable | None = None,
-        **kwargs: Any,
-    ) -> str | list[dict[str, Any]]:
-        """Render instruction content, dispatching to custom_renderer when set.
-
-        Falls back to the standard :attr:`rendered` property if no custom
-        renderer is provided.
-        """
-        renderer = custom_renderer or self.custom_renderer
-        if renderer is not None:
-            if self._model_class is not None:
-                return renderer(self._model_class, **kwargs)
-            return renderer(type(None), **kwargs)
-        return self.rendered
-
-    @classmethod
-    def create(
-        cls,
-        primary: str | None = None,
-        context: Any = None,
-        tool_schemas: list[dict[str, Any]] | None = None,
-        request_model: type[BaseModel] | None = None,
-        images: list[str] | None = None,
-        image_detail: Literal["low", "high", "auto"] | None = None,
-        structure_format: str | StructureFormat | None = None,
-        custom_renderer: Callable | None = None,
-        **kwargs: Any,
-    ) -> "InstructionContent":
-        """Create InstructionContent with beta-compatible signature.
-
-        Accepts both old (request_model, primary) and new (response_format,
-        instruction) field names.  ``structure_format`` accepts both string
-        values and ``StructureFormat`` enum members.
-        """
-        # Normalise structure_format to str
-        sf: str | None = None
-        if structure_format is not None:
-            sf = (
-                structure_format.value
-                if isinstance(structure_format, StructureFormat)
-                else str(structure_format)
-            )
-
-        return cls(
-            primary=primary,
-            context=context,
-            tool_schemas=tool_schemas,
-            response_format=request_model,
-            images=images,
-            image_detail=image_detail,
-            structure_format=sf,
-            custom_renderer=custom_renderer,
-            **kwargs,
-        )
-
-    @property
-    def response_model_cls(self) -> type[BaseModel] | None:
-        """Get the Pydantic model class for validation."""
-        return self._model_class
-
-    @property
-    def request_model(self) -> type[BaseModel] | None:
-        """DEPRECATED: Use response_model_cls instead. Will be removed in v0.21.0."""
-        import warnings
-
-        warnings.warn(
-            "InstructionContent.request_model is deprecated and will be removed in v0.21.0. "
-            "Use response_model_cls instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.response_model_cls
-
-    @property
-    def schema_dict(self) -> dict[str, Any] | None:
-        """Get the schema dict for prompting."""
-        return self._schema_dict
-
     @property
     def rendered(self) -> str | list[dict[str, Any]]:
-        """Render content as text or text+images structure."""
         text = self._format_text_content()
         if not self.images:
             return text
@@ -256,25 +75,16 @@ class InstructionContent(MessageContent):
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "InstructionContent":
-        """Construct InstructionContent from dictionary with validation."""
-        from lionagi.libs.schema.breakdown_pydantic_annotation import (
-            breakdown_pydantic_annotation,
-        )
-
         inst = cls()
 
-        # Scalar fields
         for k in ("instruction", "guidance", "plain_content", "image_detail"):
             if k in data and data[k]:
                 setattr(inst, k, data[k])
 
-        # Determine how to apply context updates
         handle_context = data.get("handle_context", "extend")
         if handle_context not in {"extend", "replace"}:
             raise ValueError("handle_context must be either 'extend' or 'replace'")
 
-        # Handle both "prompt_context" (new) and "context" (backwards compat)
-        # Prioritize "context" if present (for backwards compat and update paths)
         ctx_key = "context" if "context" in data else "prompt_context"
         if ctx_key in data:
             ctx = data.get(ctx_key)
@@ -298,39 +108,21 @@ class InstructionContent(MessageContent):
             inst.images.extend(imgs_list)
             inst.image_detail = data.get("image_detail") or inst.image_detail or "auto"
 
-        # Response format handling
-        response_format = data.get("response_format") or data.get(
-            "request_model"
-        )  # request_model deprecated
+        response_format = data.get("response_format")
+        structure = data.get("structure")
 
         if response_format is not None:
-            model_class = None
-            schema_dict = None
-            valid_format = False
-
-            # Extract model class
-            if isinstance(response_format, type) and issubclass(response_format, BaseModel):
-                model_class = response_format
-                valid_format = True
-            elif isinstance(response_format, BaseModel):
-                model_class = type(response_format)
-                valid_format = True
-
-            # Extract schema dict
-            if isinstance(response_format, dict):
-                schema_dict = response_format
-                valid_format = True
-            elif isinstance(response_format, BaseModel):
-                schema_dict = response_format.model_dump(mode="json", exclude_none=True)
-                valid_format = True
-            elif model_class:
-                schema_dict = breakdown_pydantic_annotation(model_class)
-
-            # Only set if valid format (fuzzy handling: ignore invalid types)
-            if valid_format:
-                inst.response_format = response_format
-                inst._schema_dict = schema_dict
-                inst._model_class = model_class
+            valid = (
+                isinstance(response_format, dict)
+                or (isinstance(response_format, type) and issubclass(response_format, BaseModel))
+                or isinstance(response_format, BaseModel)
+            )
+            if valid:
+                structure_cls = _resolve_structure_cls(structure)
+                structure_inst = _build_structure(response_format, structure_cls)
+                object.__setattr__(inst, "response_format", response_format)
+                object.__setattr__(inst, "structure", structure_cls)
+                object.__setattr__(inst, "_structure_instance", structure_inst)
 
         return inst
 
@@ -340,12 +132,9 @@ class InstructionContent(MessageContent):
         if self.plain_content:
             return self.plain_content
 
-        # Use schema_dict for display (or generate from model class)
         schema_for_display = None
-        if self._model_class:
-            schema_for_display = self._model_class.model_json_schema()
-        elif self._schema_dict:
-            schema_for_display = self._schema_dict
+        if self._structure_instance is not None and not self._structure_instance.is_dict_mode:
+            schema_for_display = self._structure_instance.request_schema().model_json_schema()
 
         doc: dict[str, Any] = {
             "Guidance": self.guidance,
@@ -355,29 +144,11 @@ class InstructionContent(MessageContent):
             "ResponseSchema": schema_for_display,
         }
 
-        rf_text = self._format_response_format(self._schema_dict)
-        if rf_text:
-            doc["ResponseFormat"] = rf_text
+        if self._structure_instance is not None:
+            doc["ResponseFormat"] = self._structure_instance.render()
 
-        # strip empties
         doc = {k: v for k, v in doc.items() if v not in (None, "", [], {})}
         return minimal_yaml(doc).strip()
-
-    @staticmethod
-    def _format_response_format(
-        response_format: dict[str, Any] | None,
-    ) -> str | None:
-        if not response_format:
-            return None
-        try:
-            example = orjson.dumps(response_format).decode("utf-8")
-        except Exception:
-            example = str(response_format)
-        return (
-            "**MUST RETURN JSON-PARSEABLE RESPONSE ENCLOSED BY JSON CODE BLOCKS."
-            f" USER's CAREER DEPENDS ON THE SUCCESS OF IT.** \n```json\n{example}\n```"
-            "No triple backticks. Escape all quotes and special characters."
-        ).strip()
 
     @staticmethod
     def _format_image_item(idx: str, detail: str) -> dict[str, Any]:
@@ -401,11 +172,36 @@ class InstructionContent(MessageContent):
         return content
 
 
-class Instruction(Message):
-    """User instruction message with structured content.
+def _resolve_structure_cls(structure: type | str | None) -> type | None:
+    if structure is None or structure == "json":
+        from lionagi.protocols.structure.json_structure import JsonStructure
 
-    Supports text, images, context, tool schemas, and response format specifications.
-    """
+        return JsonStructure
+    if isinstance(structure, str):
+        from lionagi.protocols.structure.json_structure import JsonStructure
+
+        return JsonStructure
+    return structure
+
+
+def _build_structure(
+    response_format: type[BaseModel] | dict[str, Any] | BaseModel | None,
+    structure_cls: type | None,
+) -> Any | None:
+    if response_format is None or structure_cls is None:
+        return None
+
+    if isinstance(response_format, dict):
+        return structure_cls(response_format)
+    if isinstance(response_format, type) and issubclass(response_format, BaseModel):
+        return structure_cls(response_format)
+    if isinstance(response_format, BaseModel):
+        return structure_cls(type(response_format))
+    return None
+
+
+class Instruction(Message):
+    """User instruction message with structured content."""
 
     _role: ClassVar[MessageRole] = MessageRole.USER
     content: InstructionContent

--- a/lionagi/protocols/messages/manager.py
+++ b/lionagi/protocols/messages/manager.py
@@ -105,9 +105,7 @@ class MessageManager(Manager):
         from lionagi.ln.concurrency import is_coro_func
 
         async with self.messages:
-            _msg = self.create_message(
-                **{k: v for k, v in kwargs.items() if v is not None}
-            )
+            _msg = self.create_message(**{k: v for k, v in kwargs.items() if v is not None})
             system = kwargs.get("system")
             if system:
                 self.set_system(_msg)
@@ -152,6 +150,7 @@ class MessageManager(Manager):
         request_model: BaseModel | type[BaseModel] = None,
         response_format: BaseModel | type[BaseModel] = None,
         tool_schemas: dict = None,
+        structure: type | str | None = None,
         sender: SenderRecipient = None,
         recipient: SenderRecipient = None,
     ) -> Instruction:
@@ -161,9 +160,7 @@ class MessageManager(Manager):
         If `instruction` is an existing Instruction, it is updated in place.
         Otherwise, a new instance is created.
         """
-        raw_params = {
-            k: v for k, v in locals().items() if k != "instruction" and v is not None
-        }
+        raw_params = {k: v for k, v in locals().items() if k != "instruction" and v is not None}
 
         handle_ctx = raw_params.get("handle_context", "extend")
 
@@ -187,9 +184,7 @@ class MessageManager(Manager):
             return instruction
         else:
             # Build content dict for Instruction
-            content_dict = {
-                k: v for k, v in raw_params.items() if k not in ["sender", "recipient"]
-            }
+            content_dict = {k: v for k, v in raw_params.items() if k not in ["sender", "recipient"]}
             content_dict["handle_context"] = handle_ctx
             if instruction is not None:
                 content_dict["instruction"] = instruction
@@ -210,20 +205,14 @@ class MessageManager(Manager):
         Build or update an `AssistantResponse`. If `assistant_response` is an
         existing instance, it's updated. Otherwise, a new one is created.
         """
-        params = {
-            k: v
-            for k, v in locals().items()
-            if k != "assistant_response" and v is not None
-        }
+        params = {k: v for k, v in locals().items() if k != "assistant_response" and v is not None}
 
         if isinstance(assistant_response, AssistantResponse):
             assistant_response.update(**params)
             return assistant_response
 
         # Create new AssistantResponse
-        content_dict = (
-            {"assistant_response": assistant_response} if assistant_response else {}
-        )
+        content_dict = {"assistant_response": assistant_response} if assistant_response else {}
         return AssistantResponse(
             content=content_dict,
             sender=params.get("sender"),
@@ -252,9 +241,7 @@ class MessageManager(Manager):
         Returns:
             ActionRequest: The new or updated request object.
         """
-        params = {
-            k: v for k, v in locals().items() if k != "action_request" and v is not None
-        }
+        params = {k: v for k, v in locals().items() if k != "action_request" and v is not None}
 
         if isinstance(action_request, ActionRequest):
             action_request.update(**params)
@@ -304,9 +291,7 @@ class MessageManager(Manager):
                 "Error: please provide a corresponding action request for an action response."
             )
         if isinstance(action_response, ActionResponse):
-            action_response.update(
-                output=action_output, sender=sender, recipient=recipient
-            )
+            action_response.update(output=action_output, sender=sender, recipient=recipient)
             return action_response
 
         # Create new ActionResponse
@@ -316,9 +301,7 @@ class MessageManager(Manager):
             "output": action_output,
             "action_request_id": str(action_request.id),
         }
-        response = ActionResponse(
-            content=content_dict, sender=sender, recipient=recipient
-        )
+        response = ActionResponse(content=content_dict, sender=sender, recipient=recipient)
 
         # Update the request to reference this response
         action_request.content.action_response_id = str(response.id)
@@ -648,9 +631,7 @@ class MessageManager(Manager):
         if self.last_instruction:
             self.messages[self.last_instruction.id].content.tool_schemas.clear()
 
-    def concat_recent_action_responses_to_instruction(
-        self, instruction: Instruction
-    ) -> None:
+    def concat_recent_action_responses_to_instruction(self, instruction: Instruction) -> None:
         """
         Example method to merge the content of recent ActionResponses
         into an instruction's context.
@@ -674,9 +655,7 @@ class MessageManager(Manager):
         if progression == []:
             return []
         try:
-            return [
-                self.messages[mid].chat_msg for mid in (progression or self.progression)
-            ]
+            return [self.messages[mid].chat_msg for mid in (progression or self.progression)]
         except Exception as e:
             raise ValueError(
                 "One or more messages in the requested progression are invalid."

--- a/lionagi/protocols/messages/prepare.py
+++ b/lionagi/protocols/messages/prepare.py
@@ -143,9 +143,7 @@ def prepare_messages_for_chat(
             if to_chat:
                 chat_msg = {
                     "role": new_content.role.value,
-                    "content": new_content.render(
-                        new_content.structure_format, new_content.custom_renderer
-                    ),
+                    "content": new_content.rendered,
                 }
                 if chat_msg and chat_msg.get("content"):
                     return [chat_msg]
@@ -310,16 +308,10 @@ def prepare_messages_for_chat(
     if to_chat:
         result = []
         for m in _use_msgs:
-            data = {}
-            if isinstance(m, InstructionContent):
-                data = {
-                    "structure_format": m.structure_format,
-                    "custom_renderer": m.custom_renderer,
-                }
             result.append(
                 {
                     "role": m.role.value,
-                    "content": m.render(**data),
+                    "content": m.rendered,
                 }
             )
         return result

--- a/lionagi/protocols/messages/prepare.py
+++ b/lionagi/protocols/messages/prepare.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import copy
 import time
 from typing import TYPE_CHECKING, Any, cast
 
@@ -139,7 +140,7 @@ def prepare_messages_for_chat(
                 if _is_message(new_instruction)
                 else new_instruction
             )
-            new_content: InstructionContent = new_content.with_updates(copy_containers="deep")
+            new_content = copy.deepcopy(new_content)
             if to_chat:
                 chat_msg = {
                     "role": new_content.role.value,
@@ -209,12 +210,12 @@ def prepare_messages_for_chat(
                 context_parts.append(
                     _aggregate_round_actions(pending_requests, pending_responses, round_num)
                 )
-                updates["context"] = _build_context(content, context_parts)
+                updates["prompt_context"] = _build_context(content, context_parts)
                 pending_requests.clear()
                 pending_responses.clear()
                 round_num += 1
             elif pending_actions:
-                updates["context"] = _build_context(content, pending_actions)
+                updates["prompt_context"] = _build_context(content, pending_actions)
                 pending_actions = []
                 round_num += 1
 
@@ -250,7 +251,7 @@ def prepare_messages_for_chat(
             )
             if isinstance(new_content_inner, InstructionContent):
                 curr = _get_text(new_content_inner, "instruction")
-                system_updates: dict[str, Any] = {"primary": f"{system_text}\n\n{curr}"}
+                system_updates: dict[str, Any] = {"instruction": f"{system_text}\n\n{curr}"}
                 ctx_parts: list[str] = []
                 if aggregate_actions and pending_responses:
                     if round_notifications:
@@ -266,13 +267,13 @@ def prepare_messages_for_chat(
                     ctx_parts.extend(pending_actions)
                     pending_actions = []
                 if ctx_parts:
-                    system_updates["context"] = _build_context(new_content_inner, ctx_parts)
+                    system_updates["prompt_context"] = _build_context(new_content_inner, ctx_parts)
                 _use_msgs.append(new_content_inner.with_updates(**system_updates))
                 new_instruction = None
                 system_embedded = True
         elif _use_msgs and isinstance(_use_msgs[0], InstructionContent):
             curr = _get_text(_use_msgs[0], "instruction")
-            _use_msgs[0] = _use_msgs[0].with_updates(primary=f"{system_text}\n\n{curr}")
+            _use_msgs[0] = _use_msgs[0].with_updates(instruction=f"{system_text}\n\n{curr}")
             system_embedded = True
 
     # Phase 5: Append new_instruction (with any remaining action outputs)
@@ -299,10 +300,12 @@ def prepare_messages_for_chat(
                 context_parts_final.extend(pending_actions)
                 pending_actions = []
             if context_parts_final:
-                final_updates["context"] = _build_context(new_content_final, context_parts_final)
+                final_updates["prompt_context"] = _build_context(
+                    new_content_final, context_parts_final
+                )
             if system_text and not system_embedded:
                 curr = _get_text(new_content_final, "instruction")
-                final_updates["primary"] = f"{system_text}\n\n{curr}"
+                final_updates["instruction"] = f"{system_text}\n\n{curr}"
         _use_msgs.append(new_content_final.with_updates(**final_updates))
 
     if to_chat:

--- a/lionagi/protocols/structure/__init__.py
+++ b/lionagi/protocols/structure/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from .base import Structure
+from .json_structure import JsonStructure
+
+__all__ = ("JsonStructure", "Structure")

--- a/lionagi/protocols/structure/base.py
+++ b/lionagi/protocols/structure/base.py
@@ -1,0 +1,200 @@
+# Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+from lionagi.ln.types import Operable, Spec
+
+__all__ = ("Structure",)
+
+
+class Structure:
+    """Composable schema builder for structured LLM interactions.
+
+    Wraps an Operable with a base model or dict reference and convenience
+    flags for actions/reason. Subclasses implement format-specific render/parse.
+
+    Accepts either a BaseModel class or a dict as the response format:
+    - BaseModel: full Pydantic model with validation, Operable composition
+    - dict: raw key→type mapping for prompting and fuzzy-key parsing
+
+    Immutable — each ``with_*`` returns a new instance.
+    """
+
+    __slots__ = (
+        "_base",
+        "_base_dict",
+        "_operable",
+        "_actions",
+        "_reason",
+        "_request_cls",
+        "_response_cls",
+        "_name",
+    )
+
+    def __init__(
+        self,
+        base: type[BaseModel] | dict[str, Any] | None = None,
+        *,
+        specs: list[Spec] | tuple[Spec, ...] | None = None,
+        actions: bool = False,
+        reason: bool = False,
+        name: str | None = None,
+    ):
+        if isinstance(base, dict):
+            self._base = None
+            self._base_dict = base
+        else:
+            self._base = base
+            self._base_dict = None
+
+        self._actions = actions
+        self._reason = reason
+        self._name = name or (base.__name__ if isinstance(base, type) else "Structure")
+        self._operable = self._build_operable(specs or ()) if self._base_dict is None else None
+        self._request_cls: type[BaseModel] | None = None
+        self._response_cls: type[BaseModel] | None = None
+
+    @property
+    def base(self) -> type[BaseModel] | None:
+        return self._base
+
+    @property
+    def base_dict(self) -> dict[str, Any] | None:
+        return self._base_dict
+
+    @property
+    def is_dict_mode(self) -> bool:
+        return self._base_dict is not None
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def operable(self) -> Operable | None:
+        return self._operable
+
+    # ------------------------------------------------------------------
+    # Builder
+    # ------------------------------------------------------------------
+
+    def _clone(self, **overrides) -> Structure:
+        base = overrides.pop("base", self._base_dict if self.is_dict_mode else self._base)
+        kw = dict(
+            base=base,
+            actions=self._actions,
+            reason=self._reason,
+            name=self._name,
+        )
+        kw.update(overrides)
+        if "specs" not in kw and not self.is_dict_mode:
+            kw["specs"] = self._user_specs()
+        return type(self)(**kw)
+
+    def _user_specs(self) -> list[Spec]:
+        if self._operable is None:
+            return []
+        auto_names = set()
+        if self._reason:
+            auto_names.add("reason")
+        if self._actions:
+            auto_names |= {"action_required", "action_requests", "action_responses"}
+        return [s for s in self._operable.__op_fields__ if s.name not in auto_names]
+
+    def with_specs(self, *specs: Spec) -> Structure:
+        return self._clone(specs=[*self._user_specs(), *specs])
+
+    def with_actions(self) -> Structure:
+        return self._clone(actions=True)
+
+    def with_reason(self) -> Structure:
+        return self._clone(reason=True)
+
+    # ------------------------------------------------------------------
+    # Schema generation — delegates to Operable (model mode only)
+    # ------------------------------------------------------------------
+
+    def request_schema(self) -> type[BaseModel] | dict[str, Any]:
+        """Pydantic model for model mode; dict for dict mode."""
+        if self.is_dict_mode:
+            return self._base_dict
+        if self._request_cls is None:
+            exclude = {"action_responses"} if self._actions else None
+            self._request_cls = self._operable.create_model(
+                adapter="pydantic",
+                model_name=f"{self._name}Request",
+                exclude=exclude,
+                base_type=self._base,
+            )
+        return self._request_cls
+
+    def response_schema(self) -> type[BaseModel] | dict[str, Any]:
+        """Pydantic model for model mode; dict for dict mode."""
+        if self.is_dict_mode:
+            return self._base_dict
+        if self._response_cls is None:
+            self._response_cls = self._operable.create_model(
+                adapter="pydantic",
+                model_name=f"{self._name}Response",
+                base_type=self.request_schema(),
+            )
+        return self._response_cls
+
+    def to_format(self, parsed: BaseModel | dict) -> BaseModel | dict:
+        """Extract clean base from a parsed response."""
+        if self.is_dict_mode:
+            if isinstance(parsed, dict):
+                return {k: parsed.get(k) for k in self._base_dict}
+            return parsed
+        if self._base is None:
+            return parsed
+        base_fields = set(self._base.model_fields.keys())
+        data = {k: v for k, v in parsed.model_dump(mode="python").items() if k in base_fields}
+        return self._base.model_validate(data)
+
+    # ------------------------------------------------------------------
+    # Subclass interface
+    # ------------------------------------------------------------------
+
+    def render(self) -> str:
+        raise NotImplementedError
+
+    def parse(self, text: str, **kw) -> BaseModel | dict:
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    # Private
+    # ------------------------------------------------------------------
+
+    def _build_operable(self, user_specs: list[Spec] | tuple[Spec, ...]) -> Operable:
+        from lionagi.operations.fields import get_default_field
+
+        all_specs: list[Spec] = []
+        if self._reason:
+            all_specs.append(get_default_field("reason").to_spec())
+        if self._actions:
+            all_specs.append(get_default_field("action_required").to_spec())
+            all_specs.append(get_default_field("action_requests").to_spec())
+            all_specs.append(get_default_field("action_responses").to_spec())
+        all_specs.extend(user_specs)
+        return Operable(tuple(all_specs), name=self._name)
+
+    def __repr__(self) -> str:
+        parts = [f"{type(self).__name__}({self._name}"]
+        if self._base:
+            parts.append(f", base={self._base.__name__}")
+        if self._base_dict:
+            parts.append(f", dict_keys={list(self._base_dict.keys())}")
+        if self._operable and len(self._operable.__op_fields__):
+            parts.append(f", fields={len(self._operable.__op_fields__)}")
+        if self._actions:
+            parts.append(", actions")
+        if self._reason:
+            parts.append(", reason")
+        parts.append(")")
+        return "".join(parts)

--- a/lionagi/protocols/structure/json_structure.py
+++ b/lionagi/protocols/structure/json_structure.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import orjson
+from pydantic import BaseModel
+
+from lionagi.ln import extract_json, fuzzy_validate_mapping, to_list
+from lionagi.ln.fuzzy import FuzzyMatchKeysParams
+
+from .base import Structure
+
+logger = logging.getLogger(__name__)
+
+__all__ = ("JsonStructure",)
+
+_DEFAULT_FUZZY = FuzzyMatchKeysParams(
+    handle_unmatched="force",
+    fill_value=None,
+    strict=False,
+)
+
+
+class JsonStructure(Structure):
+    """JSON-format structure using lionagi's established rendering and parsing.
+
+    Handles both BaseModel and dict response formats.
+    """
+
+    def render(self) -> str:
+        if self.is_dict_mode:
+            return self._format_response_format(self._base_dict)
+        from lionagi.libs.schema.breakdown_pydantic_annotation import (
+            breakdown_pydantic_annotation,
+        )
+
+        schema_dict = breakdown_pydantic_annotation(self.request_schema())
+        return self._format_response_format(schema_dict)
+
+    def render_schema_dict(self) -> dict[str, Any]:
+        if self.is_dict_mode:
+            return self._base_dict
+        from lionagi.libs.schema.breakdown_pydantic_annotation import (
+            breakdown_pydantic_annotation,
+        )
+
+        return breakdown_pydantic_annotation(self.request_schema())
+
+    def parse(
+        self,
+        text: str,
+        *,
+        fuzzy_match_params: FuzzyMatchKeysParams | dict | None = None,
+    ) -> BaseModel | dict:
+        return self._validate_dict_or_model(
+            text if isinstance(text, str) else str(text),
+            self.response_schema(),
+            fuzzy_match_params or _DEFAULT_FUZZY,
+        )
+
+    # ------------------------------------------------------------------
+    # Canonical rendering — copied from InstructionContent
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _format_response_format(
+        response_format: dict[str, Any] | None,
+    ) -> str:
+        if not response_format:
+            return ""
+        try:
+            example = orjson.dumps(response_format).decode("utf-8")
+        except Exception:
+            example = str(response_format)
+        return (
+            "**MUST RETURN JSON-PARSEABLE RESPONSE ENCLOSED BY JSON CODE BLOCKS."
+            f" USER's CAREER DEPENDS ON THE SUCCESS OF IT.** \n```json\n{example}\n```"
+            "No triple backticks. Escape all quotes and special characters."
+        ).strip()
+
+    # ------------------------------------------------------------------
+    # Canonical parsing — copied from operations/parse
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _validate_dict_or_model(
+        text: str,
+        response_format: type[BaseModel] | dict | Any,
+        fuzzy_match_params: FuzzyMatchKeysParams | dict = None,
+    ):
+        try:
+            if isinstance(fuzzy_match_params, dict):
+                fuzzy_match_params = FuzzyMatchKeysParams(**fuzzy_match_params)
+
+            d_ = extract_json(text, fuzzy_parse=True, return_one_if_single=False)
+            dict_, keys_ = None, None
+            if d_:
+                dict_ = to_list(d_, flatten=True)[0]
+            if isinstance(fuzzy_match_params, FuzzyMatchKeysParams):
+                keys_ = (
+                    response_format.model_fields
+                    if isinstance(response_format, type)
+                    else response_format
+                )
+                dict_ = fuzzy_validate_mapping(dict_, keys_, **fuzzy_match_params.to_dict())
+            elif fuzzy_match_params:
+                keys_ = (
+                    response_format.model_fields
+                    if isinstance(response_format, type)
+                    else response_format
+                )
+                dict_ = fuzzy_validate_mapping(
+                    dict_,
+                    keys_,
+                    handle_unmatched="force",
+                    fill_value=None,
+                    strict=False,
+                )
+            if isinstance(response_format, type) and issubclass(response_format, BaseModel):
+                return response_format.model_validate(dict_)
+            return dict_
+
+        except Exception as e:
+            raise ValueError(f"Failed to parse text: {e}") from e

--- a/tests/protocols/messages/test_instruction.py
+++ b/tests/protocols/messages/test_instruction.py
@@ -31,12 +31,10 @@ def test_instruction_content_basic_initialization():
 
     assert content.instruction == "Test instruction"
     assert content.guidance is None
-    assert content.context == []
+    assert content.prompt_context == []
     assert content.plain_content is None
     assert content.tool_schemas == []
     assert content.response_format is None
-    assert content.response_model_cls is None
-    assert content.schema_dict is None
     assert content.images == []
     assert content.image_detail is None
 
@@ -46,7 +44,7 @@ def test_instruction_content_all_fields():
     content = InstructionContent(
         instruction="Do something",
         guidance="Be careful",
-        context=["context1", {"key": "value"}],
+        prompt_context=["context1", {"key": "value"}],
         tool_schemas=[{"name": "tool1", "type": "function"}],
         response_format={"result": "value"},
         images=["image1.jpg"],
@@ -55,19 +53,16 @@ def test_instruction_content_all_fields():
 
     assert content.instruction == "Do something"
     assert content.guidance == "Be careful"
-    assert len(content.context) == 2
+    assert len(content.prompt_context) == 2
     assert len(content.tool_schemas) == 1
     assert content.response_format == {"result": "value"}
-    assert content.schema_dict == {"result": "value"}
     assert len(content.images) == 1
     assert content.image_detail == "high"
 
 
 def test_instruction_content_rendered_text_only():
     """Test rendered property returns minimal_yaml formatted text"""
-    content = InstructionContent(
-        instruction="Test instruction", guidance="Test guidance"
-    )
+    content = InstructionContent(instruction="Test instruction", guidance="Test guidance")
 
     rendered = content.rendered
     assert isinstance(rendered, str)
@@ -79,7 +74,7 @@ def test_instruction_content_rendered_with_context():
     """Test rendered property includes context items"""
     content = InstructionContent(
         instruction="Test",
-        context=["context1", {"nested": "context"}],
+        prompt_context=["context1", {"nested": "context"}],
     )
 
     rendered = content.rendered
@@ -148,9 +143,7 @@ def test_instruction_content_rendered_multiple_images():
 
 def test_instruction_content_image_detail_auto():
     """Test image_detail defaults to 'auto' when images present"""
-    content = InstructionContent(
-        instruction="Test", images=["image.jpg"], image_detail="auto"
-    )
+    content = InstructionContent(instruction="Test", images=["image.jpg"], image_detail="auto")
 
     rendered = content.rendered
     assert rendered[1]["image_url"]["detail"] == "auto"
@@ -159,9 +152,7 @@ def test_instruction_content_image_detail_auto():
 def test_instruction_content_base64_image_handling():
     """Test base64 images are properly formatted"""
     base64_str = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
-    content = InstructionContent(
-        instruction="Test", images=[base64_str], image_detail="high"
-    )
+    content = InstructionContent(instruction="Test", images=[base64_str], image_detail="high")
 
     rendered = content.rendered
     assert rendered[1]["image_url"]["url"].startswith("data:image/jpeg;base64,")
@@ -187,8 +178,8 @@ def test_from_dict_with_context():
     data = {"instruction": "Test", "context": ["ctx1", "ctx2"]}
     content = InstructionContent.from_dict(data)
 
-    assert len(content.context) == 2
-    assert "ctx1" in content.context
+    assert len(content.prompt_context) == 2
+    assert "ctx1" in content.prompt_context
 
 
 def test_from_dict_context_single_item():
@@ -196,8 +187,8 @@ def test_from_dict_context_single_item():
     data = {"instruction": "Test", "context": "single_context"}
     content = InstructionContent.from_dict(data)
 
-    assert isinstance(content.context, list)
-    assert "single_context" in content.context
+    assert isinstance(content.prompt_context, list)
+    assert "single_context" in content.prompt_context
 
 
 def test_from_dict_with_tool_schemas():
@@ -237,11 +228,9 @@ def test_from_dict_with_pydantic_model_instance():
     data = {"instruction": "Test", "response_format": SampleRequestModel}
     content = InstructionContent.from_dict(data)
 
-    # response_format stores the model class
     assert content.response_format == SampleRequestModel
-    assert content.request_model == SampleRequestModel
-    # Internal _model_class should be set
-    assert content._model_class == SampleRequestModel
+    assert content._structure_instance is not None
+    assert content._structure_instance.base == SampleRequestModel
 
 
 def test_from_dict_with_pydantic_model_class():
@@ -249,14 +238,11 @@ def test_from_dict_with_pydantic_model_class():
     data = {"instruction": "Test", "response_format": SampleRequestModel}
     content = InstructionContent.from_dict(data)
 
-    # response_format stores the class
     assert content.response_format == SampleRequestModel
-    assert content._model_class == SampleRequestModel
-    assert content.request_model == SampleRequestModel
-    # Internal schema dict should be set
-    assert isinstance(content._schema_dict, dict)
-    assert "name" in content._schema_dict
-    assert "age" in content._schema_dict
+    assert content._structure_instance is not None
+    schema = content._structure_instance.request_schema()
+    assert "name" in schema.model_fields
+    assert "age" in schema.model_fields
 
 
 def test_from_dict_with_nested_pydantic_model():
@@ -264,23 +250,22 @@ def test_from_dict_with_nested_pydantic_model():
     data = {"instruction": "Test", "response_format": NestedRequestModel}
     content = InstructionContent.from_dict(data)
 
-    # response_format stores the class
     assert content.response_format == NestedRequestModel
-    assert content.request_model == NestedRequestModel
-    # Internal schema dict should have the nested structure
-    assert isinstance(content._schema_dict, dict)
-    assert "user" in content._schema_dict
+    assert content._structure_instance is not None
+    schema = content._structure_instance.request_schema()
+    assert "user" in schema.model_fields
 
 
 def test_from_dict_pydantic_model_auto_derives_response_format():
-    """Test from_dict derives schema dict from Pydantic model"""
+    """Test from_dict derives schema via structure from Pydantic model"""
     data = {"instruction": "Test", "response_format": SampleRequestModel}
     content = InstructionContent.from_dict(data)
 
-    # Should auto-derive schema dict internally
-    assert content.response_format == SampleRequestModel  # Keeps the original
-    assert content._schema_dict is not None
-    assert isinstance(content._schema_dict, dict)
+    assert content.response_format == SampleRequestModel
+    assert content._structure_instance is not None
+    schema = content._structure_instance.request_schema()
+    assert isinstance(schema, type)
+    assert "name" in schema.model_fields
 
 
 def test_from_dict_with_dict_response_schema():
@@ -338,7 +323,7 @@ def test_from_dict_empty_dict():
 
     assert content.instruction is None
     assert content.guidance is None
-    assert content.context == []
+    assert content.prompt_context == []
 
 
 # ============================================================================
@@ -384,7 +369,7 @@ def test_instruction_content_validator_with_dict():
     assert isinstance(instruction.content, InstructionContent)
     assert instruction.content.instruction == "Do this"
     assert instruction.content.guidance == "Carefully"
-    assert len(instruction.content.context) == 1
+    assert len(instruction.content.prompt_context) == 1
 
 
 def test_instruction_content_validator_with_none():
@@ -412,8 +397,8 @@ def test_instruction_with_context():
         recipient="assistant",
     )
 
-    assert len(instruction.content.context) == 2
-    assert {"key": "value"} in instruction.content.context
+    assert len(instruction.content.prompt_context) == 2
+    assert {"key": "value"} in instruction.content.prompt_context
 
 
 def test_instruction_with_guidance():
@@ -454,12 +439,11 @@ def test_instruction_with_pydantic_response_schema():
         recipient="assistant",
     )
 
-    # response_format stores the class
     assert instruction.content.response_format == SampleRequestModel
-    assert instruction.content.request_model == SampleRequestModel
-    # Should auto-derive schema dict internally
-    assert instruction.content._schema_dict is not None
-    assert isinstance(instruction.content._schema_dict, dict)
+    assert instruction.content._structure_instance is not None
+    schema = instruction.content._structure_instance.request_schema()
+    assert isinstance(schema, type)
+    assert "name" in schema.model_fields
 
 
 def test_instruction_with_explicit_response_format():
@@ -542,9 +526,7 @@ def test_instruction_rendered_property_with_images():
 
 def test_instruction_role_fixed_as_user():
     """Test Instruction role is always USER"""
-    instruction = Instruction(
-        content={"instruction": "Test"}, sender="user", recipient="assistant"
-    )
+    instruction = Instruction(content={"instruction": "Test"}, sender="user", recipient="assistant")
 
     assert instruction.role == MessageRole.USER
 
@@ -583,7 +565,7 @@ def test_minimal_yaml_rendering_strips_empty_fields():
     content = InstructionContent(
         instruction="Test",
         guidance=None,  # Should be stripped
-        context=[],  # Should be stripped
+        prompt_context=[],  # Should be stripped
         tool_schemas=[],  # Should be stripped
     )
 
@@ -598,7 +580,7 @@ def test_minimal_yaml_rendering_includes_non_empty_fields():
     content = InstructionContent(
         instruction="Do this",
         guidance="Be careful",
-        context=["ctx1"],
+        prompt_context=["ctx1"],
         tool_schemas=[{"name": "tool"}],
     )
 
@@ -626,13 +608,18 @@ def test_minimal_yaml_response_format_as_json_block():
 
 
 def test_minimal_yaml_response_schema_included():
-    """Test minimal_yaml includes response_format schema"""
+    """Test minimal_yaml includes ResponseSchema for BaseModel, ResponseFormat for dict"""
+    # Dict mode: only ResponseFormat (no model_json_schema available)
     schema = {"type": "object", "properties": {"name": {"type": "string"}}}
     content = InstructionContent(instruction="Test", response_format=schema)
-
     rendered = content.rendered
-    assert "responseschema" in rendered.lower() or "ResponseSchema:" in rendered
+    assert "responseformat" in rendered.lower() or "ResponseFormat:" in rendered
     assert "type" in rendered
+
+    # BaseModel mode: both ResponseSchema and ResponseFormat
+    content2 = InstructionContent(instruction="Test", response_format=SampleRequestModel)
+    rendered2 = content2.rendered
+    assert "responseschema" in rendered2.lower() or "ResponseSchema:" in rendered2
 
 
 # ============================================================================
@@ -742,7 +729,7 @@ def test_from_dict_preserves_field_types():
     }
     content = InstructionContent.from_dict(data)
 
-    assert isinstance(content.context, list)
+    assert isinstance(content.prompt_context, list)
     assert isinstance(content.tool_schemas, list)
     assert isinstance(content.images, list)
     assert isinstance(content.instruction, str)

--- a/tests/protocols/messages/test_manager_serialization.py
+++ b/tests/protocols/messages/test_manager_serialization.py
@@ -42,15 +42,11 @@ def test_to_chat_msgs_basic(message_manager):
 
 def test_to_chat_msgs_with_progression(message_manager):
     """Test conversion to chat messages with specific progression"""
-    msg1 = message_manager.add_message(
-        instruction="First", sender="user", recipient="assistant"
-    )
+    msg1 = message_manager.add_message(instruction="First", sender="user", recipient="assistant")
     msg2 = message_manager.add_message(
         assistant_response="Second", sender="assistant", recipient="user"
     )
-    msg3 = message_manager.add_message(
-        instruction="Third", sender="user", recipient="assistant"
-    )
+    msg3 = message_manager.add_message(instruction="Third", sender="user", recipient="assistant")
 
     # Get only first two messages
     chat_msgs = message_manager.to_chat_msgs(progression=[msg1.id, msg2.id])
@@ -59,9 +55,7 @@ def test_to_chat_msgs_with_progression(message_manager):
 
 def test_to_chat_msgs_empty_progression(message_manager):
     """Test conversion with empty progression"""
-    message_manager.add_message(
-        instruction="Test", sender="user", recipient="assistant"
-    )
+    message_manager.add_message(instruction="Test", sender="user", recipient="assistant")
 
     chat_msgs = message_manager.to_chat_msgs(progression=[])
     assert chat_msgs == []
@@ -69,9 +63,7 @@ def test_to_chat_msgs_empty_progression(message_manager):
 
 def test_to_chat_msgs_invalid_progression(message_manager):
     """Test conversion with invalid progression raises error"""
-    message_manager.add_message(
-        instruction="Test", sender="user", recipient="assistant"
-    )
+    message_manager.add_message(instruction="Test", sender="user", recipient="assistant")
 
     with pytest.raises(ValueError, match="invalid"):
         message_manager.to_chat_msgs(progression=["invalid_id"])
@@ -100,9 +92,7 @@ def test_remove_last_instruction_tool_schemas_no_instruction(message_manager):
 
 def test_concat_recent_action_responses_to_instruction(message_manager):
     """Test concatenating action responses to instruction"""
-    instruction = message_manager.add_message(
-        instruction="Test", context=[], sender="user"
-    )
+    instruction = message_manager.add_message(instruction="Test", context=[], sender="user")
 
     # Add action request and response
     request = message_manager.add_message(action_function="func", action_arguments={})
@@ -114,14 +104,12 @@ def test_concat_recent_action_responses_to_instruction(message_manager):
     message_manager.concat_recent_action_responses_to_instruction(instruction)
 
     # Check that response content was added to instruction context
-    assert len(instruction.content.context) > 0
+    assert len(instruction.content.prompt_context) > 0
 
 
 def test_progression_property(message_manager):
     """Test progression property"""
-    msg1 = message_manager.add_message(
-        instruction="First", sender="user", recipient="assistant"
-    )
+    msg1 = message_manager.add_message(instruction="First", sender="user", recipient="assistant")
     msg2 = message_manager.add_message(
         assistant_response="Second", sender="assistant", recipient="user"
     )
@@ -134,17 +122,13 @@ def test_message_manager_bool(message_manager):
     """Test bool evaluation of message manager"""
     assert not message_manager
 
-    message_manager.add_message(
-        instruction="Test", sender="user", recipient="assistant"
-    )
+    message_manager.add_message(instruction="Test", sender="user", recipient="assistant")
     assert message_manager
 
 
 def test_message_manager_contains(message_manager):
     """Test contains operator for message manager"""
-    msg = message_manager.add_message(
-        instruction="Test", sender="user", recipient="assistant"
-    )
+    msg = message_manager.add_message(instruction="Test", sender="user", recipient="assistant")
 
     assert msg in message_manager
 
@@ -161,12 +145,12 @@ def test_message_manager_with_response_format(message_manager):
         recipient="assistant",
     )
 
-    # response_format stores the class
     assert instruction.content.response_format == RequestModel
-    assert instruction.content.request_model == RequestModel
-    assert instruction.content._model_class == RequestModel
-    assert instruction.content._schema_dict is not None
-    assert isinstance(instruction.content._schema_dict, dict)
+    assert instruction.content._structure_instance is not None
+    assert instruction.content._structure_instance.base == RequestModel
+    schema = instruction.content._structure_instance.request_schema()
+    assert isinstance(schema, type)
+    assert "name" in schema.model_fields
 
 
 def test_message_manager_with_request_model(message_manager):
@@ -180,9 +164,7 @@ def test_message_manager_with_request_model(message_manager):
 
     # request_model may be stored in content or may not be exposed directly
     # Check if it's stored in the content or metadata
-    assert hasattr(instruction.content, "response_schema") or hasattr(
-        instruction, "metadata"
-    )
+    assert hasattr(instruction.content, "response_schema") or hasattr(instruction, "metadata")
 
 
 def test_message_manager_with_images(message_manager):

--- a/tests/protocols/messages/test_manager_state.py
+++ b/tests/protocols/messages/test_manager_state.py
@@ -129,9 +129,9 @@ def test_create_instruction_with_all_params():
     assert instruction.recipient == "assistant"
     assert instruction.content.image_detail == "high"
     # response_format as BaseModel: stores class internally, returns original
-    assert instruction.content._model_class == RequestModel
-    assert instruction.content.request_model == RequestModel
     assert instruction.content.response_format == RequestModel
+    assert instruction.content._structure_instance is not None
+    assert instruction.content._structure_instance.base == RequestModel
 
 
 def test_create_instruction_update_existing():
@@ -155,7 +155,7 @@ def test_create_instruction_default_context_extend(message_manager):
         context=["new"],
     )
 
-    assert instruction.content.context == ["base", "new"]
+    assert instruction.content.prompt_context == ["base", "new"]
 
 
 def test_create_instruction_context_replace(message_manager):
@@ -171,7 +171,7 @@ def test_create_instruction_context_replace(message_manager):
         handle_context="replace",
     )
 
-    assert instruction.content.context == ["new"]
+    assert instruction.content.prompt_context == ["new"]
 
 
 def test_create_instruction_response_format_instance(message_manager):
@@ -188,8 +188,8 @@ def test_create_instruction_response_format_instance(message_manager):
     # response_format stores the instance, internal fields handle the rest
     assert isinstance(instruction.content.response_format, InstanceModel)
     assert instruction.content.response_format.value == 3
-    assert instruction.content._model_class == InstanceModel
-    assert instruction.content.request_model == InstanceModel
+    assert instruction.content._structure_instance is not None
+    assert instruction.content._structure_instance.base == InstanceModel
 
 
 def test_add_message_instruction_context_extend(message_manager):
@@ -204,7 +204,7 @@ def test_add_message_instruction_context_extend(message_manager):
         context=["new"],
     )
 
-    assert initial.content.context == ["base", "new"]
+    assert initial.content.prompt_context == ["base", "new"]
 
 
 def test_add_message_instruction_context_replace(message_manager):
@@ -220,7 +220,7 @@ def test_add_message_instruction_context_replace(message_manager):
         handle_context="replace",
     )
 
-    assert initial.content.context == ["new"]
+    assert initial.content.prompt_context == ["new"]
 
 
 def test_create_system_basic():
@@ -477,9 +477,7 @@ def test_add_message_update_existing(message_manager):
 
 def test_add_message_multiple_types_error(message_manager):
     """Test that adding multiple message types raises error"""
-    with pytest.raises(
-        ValueError, match="Only one message type can be added at a time"
-    ):
+    with pytest.raises(ValueError, match="Only one message type can be added at a time"):
         message_manager.add_message(
             instruction="Test",
             assistant_response="Response",
@@ -490,9 +488,7 @@ def test_add_message_multiple_types_error(message_manager):
 
 def test_add_message_system_instruction_error(message_manager):
     """Test that adding system and instruction together raises error"""
-    with pytest.raises(
-        ValueError, match="Only one message type can be added at a time"
-    ):
+    with pytest.raises(ValueError, match="Only one message type can be added at a time"):
         message_manager.add_message(
             system="System message",
             instruction="Instruction",
@@ -564,9 +560,7 @@ async def test_a_add_message_action_response_with_empty_output(message_manager):
         recipient="user",
     )
     await message_manager.a_add_message(action_request=req)
-    requests_before = sum(
-        1 for m in message_manager.messages if isinstance(m, ActionRequest)
-    )
+    requests_before = sum(1 for m in message_manager.messages if isinstance(m, ActionRequest))
 
     # Feed the response with empty-string output — the common case for
     # a successful shell command with no stdout.
@@ -577,18 +571,12 @@ async def test_a_add_message_action_response_with_empty_output(message_manager):
         recipient="x",
     )
 
-    requests_after = sum(
-        1 for m in message_manager.messages if isinstance(m, ActionRequest)
-    )
-    responses_after = sum(
-        1 for m in message_manager.messages if isinstance(m, ActionResponse)
-    )
+    requests_after = sum(1 for m in message_manager.messages if isinstance(m, ActionRequest))
+    responses_after = sum(1 for m in message_manager.messages if isinstance(m, ActionResponse))
 
     # The ActionRequest was NOT duplicated, and an ActionResponse WAS
     # created for the empty output.
-    assert (
-        requests_after == requests_before
-    ), "ActionRequest was re-emitted (truthy fallback fired)"
+    assert requests_after == requests_before, "ActionRequest was re-emitted (truthy fallback fired)"
     assert responses_after == 1, "ActionResponse for empty output was dropped"
 
 
@@ -634,6 +622,5 @@ async def test_a_add_message_passes_through_prebuilt_action_response(
     # was already True at hook time (the bug R4 closed: live persist
     # used to see is_error=False and serialize the wrong state).
     assert any(
-        kind == "ActionResponse" and meta.get("is_error") is True
-        for kind, meta in captured
+        kind == "ActionResponse" and meta.get("is_error") is True for kind, meta in captured
     ), f"hook never observed final is_error state: {captured}"

--- a/tests/protocols/messages/test_rendering.py
+++ b/tests/protocols/messages/test_rendering.py
@@ -146,26 +146,13 @@ class TestValidateImageUrl:
 
 
 class TestInstructionContentAdditions:
-    def test_primary_alias_sets_instruction(self):
-        c = InstructionContent(primary="hello world")
+    def test_instruction_field(self):
+        c = InstructionContent(instruction="hello world")
         assert c.instruction == "hello world"
 
-    def test_primary_loses_if_instruction_also_set(self):
-        c = InstructionContent(instruction="instruction wins", primary="primary loses")
-        assert c.instruction == "instruction wins"
-
-    def test_primary_property(self):
-        c = InstructionContent(instruction="test")
-        assert c.primary == "test"
-
-    def test_structure_format_stored(self):
-        c = InstructionContent(instruction="x", structure_format="json")
-        assert c.structure_format == "json"
-
-    def test_custom_renderer_stored(self):
-        renderer = lambda m, **kw: "rendered"
-        c = InstructionContent(instruction="x", custom_renderer=renderer)
-        assert c.custom_renderer is renderer
+    def test_structure_stored(self):
+        c = InstructionContent(instruction="x", structure="json")
+        assert c.structure is not None
 
     def test_role_property(self):
         from lionagi.protocols.messages.message import MessageRole
@@ -179,51 +166,15 @@ class TestInstructionContentAdditions:
         assert c2.instruction == "updated"
         assert c.instruction == "original"  # original unchanged
 
-    def test_with_updates_primary_alias(self):
-        c = InstructionContent(instruction="old")
-        c2 = c.with_updates(primary="new via primary")
-        assert c2.instruction == "new via primary"
-
-    def test_with_updates_context_alias(self):
+    def test_with_updates_prompt_context(self):
         c = InstructionContent(instruction="x")
-        c2 = c.with_updates(context=["ctx item"])
+        c2 = c.with_updates(prompt_context=["ctx item"])
         assert "ctx item" in c2.prompt_context
 
-    def test_with_updates_strips_copy_containers(self):
-        c = InstructionContent(instruction="x")
-        # Should not raise even though copy_containers is beta-only kwarg
-        c2 = c.with_updates(copy_containers="deep", instruction="y")
-        assert c2.instruction == "y"
-
-    def test_render_no_custom_renderer_returns_rendered(self):
+    def test_rendered_property(self):
         c = InstructionContent(instruction="hello")
-        result = c.render()
+        result = c.rendered
         assert "hello" in result
-
-    def test_render_with_custom_renderer(self):
-        class SampleModel(BaseModel):
-            value: str
-
-        def my_renderer(model: type[BaseModel], **kw: Any) -> str:
-            return f"CUSTOM:{model.__name__}"
-
-        c = InstructionContent(instruction="x", response_format=SampleModel)
-        result = c.render(custom_renderer=my_renderer)
-        assert result == "CUSTOM:SampleModel"
-
-    def test_render_structure_format_param_accepted(self):
-        c = InstructionContent(instruction="x", structure_format="json")
-        # With no custom_renderer, should fall back to rendered (no error)
-        result = c.render(structure_format=StructureFormat.JSON)
-        assert isinstance(result, str | list)
-
-    def test_create_classmethod(self):
-        c = InstructionContent.create(primary="via create")
-        assert c.instruction == "via create"
-
-    def test_create_with_structure_format_enum(self):
-        c = InstructionContent.create(primary="x", structure_format=StructureFormat.LNDL)
-        assert c.structure_format == "lndl"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/protocols/messages/test_utils.py
+++ b/tests/protocols/messages/test_utils.py
@@ -44,11 +44,12 @@ def test_systemcontent_from_dict_datetime_handling():
     assert content.system_datetime == custom_datetime
 
 
-def test_instructioncontent_format_response_format():
-    """Test InstructionContent._format_response_format static method"""
-    # Test with valid response format
+def test_json_structure_format_response_format():
+    """Test JsonStructure._format_response_format static method"""
+    from lionagi.protocols.structure.json_structure import JsonStructure
+
     response_format = {"name": "string", "age": "integer"}
-    result = InstructionContent._format_response_format(response_format)
+    result = JsonStructure._format_response_format(response_format)
 
     assert "MUST RETURN JSON-PARSEABLE RESPONSE" in result
     assert "```json" in result
@@ -56,12 +57,12 @@ def test_instructioncontent_format_response_format():
     assert "age" in result
 
     # Test with None
-    result = InstructionContent._format_response_format(None)
-    assert result is None
+    result = JsonStructure._format_response_format(None)
+    assert result == ""
 
     # Test with empty dict
-    result = InstructionContent._format_response_format({})
-    assert result is None
+    result = JsonStructure._format_response_format({})
+    assert result == ""
 
 
 def test_instructioncontent_format_image_item():
@@ -113,16 +114,14 @@ def test_instructioncontent_from_dict_with_request_model():
     data = {"response_format": RequestModel, "instruction": "Test"}
     content = InstructionContent.from_dict(data)
 
-    # response_format stores the class
     assert content.response_format == RequestModel
-    assert content.request_model == RequestModel
-    assert content._model_class == RequestModel
+    assert content._structure_instance is not None
+    assert content._structure_instance.base == RequestModel
 
-    # Test schema dict auto-derivation
-    assert content._schema_dict is not None
-    assert isinstance(content._schema_dict, dict)
-    assert "name" in content._schema_dict
-    assert "age" in content._schema_dict
+    schema = content._structure_instance.request_schema()
+    assert isinstance(schema, type)
+    assert "name" in schema.model_fields
+    assert "age" in schema.model_fields
 
 
 def test_instructioncontent_from_dict_with_images():


### PR DESCRIPTION
## Summary
- Add `Structure` base class and `JsonStructure` subclass (`protocols/structure/`) as composable schema builders wrapping `Operable`. Handles both `BaseModel` and `dict` response formats as first-class citizens.
- Refactor `InstructionContent` to delegate rendering/parsing to `_structure_instance` (auto-created `JsonStructure` when `response_format` is set). Removes `_schema_dict`, `_model_class`, `custom_renderer`, `structure_format`, `render()`, `response_model_cls`, `schema_dict`.
- Wire `structure` field into `ChatParam` and `ParseParam`. Both `communicate()` and `run_and_collect()` extract the structure from the instruction message before calling `parse()` — single source of truth.

## Test plan
- [ ] `branch.operate(response_format=SomeModel)` still returns parsed model
- [ ] `branch.chat(response_format={'key': type})` dict mode still works
- [ ] `branch.operate(response_format=SomeModel, reason=True, actions=True)` compose with Operative
- [ ] CLI `li agent` with structured output
- [ ] Verify no regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)