### PR TITLE
docs(governance): add ADRs 0053-0070, charter DSL v0, and governance standards

### DIFF
--- a/docs/adrs/ADR-0033-unified-entity-state-model.md
+++ b/docs/adrs/ADR-0033-unified-entity-state-model.md
@@ -1,0 +1,444 @@
+# ADR-0033: Unified Entity State Model
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Supersedes**: [ADR-0017](ADR-0017-session-lifecycle-status.md) §"Status vocabulary" (partial), [ADR-0025](ADR-0025-session-status-vocabulary.md) §"Expanded vocabulary" (full)
+**Extends**: [ADR-0024](ADR-0024-session-health-and-admin-surface.md), [ADR-0028](ADR-0028-status-reason-model.md), [ADR-0029](ADR-0029-artifact-contract.md)
+**Related**: [ADR-0030](ADR-0030-attention-queue.md), [ADR-0034](ADR-0034-frontend-data-and-state-architecture.md), [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md)
+**Depends on**: [ADR-0009](ADR-0009-sqlite-state-layer.md) (current persistence implementation)
+
+## Context
+
+The unifying principle these ADRs serve is the **evidence chain**: every state has reasons, every reason has evidence, every claim has evidence. Auditability is not an export feature — it is the data model. This ADR establishes the state-side of the chain (entity status with structured reasons); [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) establishes the knowledge-side (learned facts with structured evidence); both share `EvidenceRef` (defined here).
+
+Status semantics are currently spread across five ADRs, each adding a
+dimension without unifying the model:
+
+| ADR | Contribution | Problem |
+|-----|-------------|---------|
+| ADR-0017 | Session lifecycle: `running`, `completed`, `failed`, `aborted` | Too coarse — no timeout, no cancel distinction |
+| ADR-0025 | Expanded vocabulary: adds `timed_out`, `cancelled` | Solves coarseness, but applies only to sessions |
+| ADR-0024 | Health classification: `healthy` → `zombie` enum | Separate axis, computed per-read, not persisted |
+| ADR-0028 | Reason codes: structured "why" | Right primitive, but defined only for sessions |
+| ADR-0029 | Artifact contract: delivery verification | No integration with status/health model |
+
+The consequence is visible in the UI today:
+
+- **Issue #1176**: "Failed + Healthy" badge stack. These are two
+  correct statements from two separate axes displayed as if they were
+  one status. Users read it as contradictory.
+- **Issue #1162**: Dashboard "Stale: 0" contradicts "1 stuck >60m"
+  because two different detectors evaluate staleness with different
+  thresholds and different entity scopes.
+- **Issue #1161**: Show status reads "Active" from SQLite while the
+  detail page reads "Merged" from `_show.md`. Two sources, no
+  reconciliation, no single model.
+
+The Attention Queue (ADR-0030) cannot be built correctly without a
+unified state model. It needs to sort items by severity across entity
+types — runs, shows, plays, schedules, teams. If each entity type
+computes severity differently, the queue is incoherent.
+
+## Decision
+
+### Separate entity state into three orthogonal dimensions
+
+Every operational entity (run/session, show, play, invocation, schedule,
+team) carries a **normalized state** composed of three independent fields
+plus a reason chain:
+
+```text
+lifecycle_status × process_health × delivery_state → severity
+                                                    + reason_code[]
+                                                    + evidence_ref[]
+```
+
+These dimensions answer different operator questions:
+
+| Dimension | Question | Example values |
+|-----------|----------|----------------|
+| `lifecycle_status` | Did the work finish? What happened? | `running`, `completed`, `failed`, `timed_out`, `cancelled`, `aborted` |
+| `process_health` | Is the runtime/process okay? | `ok`, `running`, `idle`, `stalled`, `process_dead`, `orphaned` |
+| `delivery_state` | Did it produce required outputs? | `passed`, `partial`, `missing`, `invalid`, `not_expected` |
+
+`severity` and `tone` are derived, never stored:
+
+| Field | Purpose | Values |
+|-------|---------|--------|
+| `severity` | Determines placement and attention priority | `critical`, `warning`, `info`, `neutral` |
+| `tone` | Determines badge/indicator color | `danger`, `warning`, `info`, `success`, `neutral` |
+
+### NormalizedState schema
+
+```python
+@dataclass
+class NormalizedState:
+    lifecycle: str
+
+    outcome: str | None = None
+    # succeeded | completed | merged | failed | timed_out
+    # | cancelled | aborted | skipped | unknown
+
+    health: str | None = None
+    # ok | running | idle | degraded | stalled
+    # | process_dead | orphaned | disconnected | unknown
+
+    delivery: str | None = None
+    # passed | partial | missing | invalid | not_expected | unknown
+
+    severity: str = "neutral"
+    # critical | warning | info | neutral
+
+    tone: str = "neutral"
+    # danger | warning | info | success | neutral
+
+    reasons: list[StateReason] = field(default_factory=list)
+
+    evaluated_at: float = 0.0
+    policy_version: str = "v1"
+    source: str = "backend"
+    # backend | frontend_compat
+
+
+@dataclass
+class StateReason:
+    code: str               # structured: "run.failed.exit_nonzero"
+    message: str            # human: "Exit code 124 from python-tests"
+    claim_status: str = "observed"
+    # observed | inferred | hypothesis | verified | disputed | superseded
+    confidence: float = 1.0
+    # Confidence in this REASON explaining the state.
+    # Distinct from Claim.confidence in ADR-0039, which measures
+    # confidence in a learned fact being true.
+    entity_type: str | None = None
+    entity_id: str | None = None
+    evidence: list[EvidenceRef] = field(default_factory=list)
+
+
+@dataclass
+class EvidenceRef:
+    kind: str
+    # Allowed kinds:
+    #   message        — chat message in a session
+    #   user_statement — explicit user assertion
+    #   tool_result    — output from a tool call
+    #   artifact       — produced file/report
+    #   url            — web resource (include fetched_at, content_hash if available)
+    #   file           — local file (include repo, commit_sha if available)
+    #   model_inference — agent reasoning step
+    #   human_assertion — human verified externally
+
+    id: str | None = None
+    session_id: str | None = None
+    message_id: str | None = None
+    tool_call_id: str | None = None
+    artifact_id: str | None = None
+    path: str | None = None
+    url: str | None = None
+    repo: str | None = None
+    commit_sha: str | None = None
+    content_hash: str | None = None
+    fetched_at: float | None = None
+    detail: str | None = None
+    # Kind-specific descriptor:
+    #   message         → relevant quote
+    #   tool_result     → result summary
+    #   model_inference → reasoning rationale
+    #   user_statement  → paraphrased assertion
+    #   artifact        → contract violation detail or note
+    #   human_assertion → assertion text
+```
+
+### Severity derivation heuristic
+
+Severity is computed from the three dimensions using a deterministic
+priority cascade. The most severe condition wins:
+
+```python
+def derive_severity(state: NormalizedState) -> tuple[str, str]:
+    """Returns (severity, tone)."""
+
+    # Critical conditions
+    if state.outcome in ("failed", "aborted"):
+        return ("critical", "danger")
+    if state.health in ("process_dead", "orphaned"):
+        return ("critical", "danger")
+    if state.delivery == "missing":
+        return ("critical", "danger")
+    if state.health == "stalled":
+        return ("critical", "danger")
+    if state.health == "misfired":
+        return ("critical", "danger")
+
+    # Warning conditions
+    if state.outcome == "timed_out":
+        return ("warning", "warning")
+    if state.health in ("idle", "degraded", "disconnected"):
+        return ("warning", "warning")
+    if state.delivery in ("partial", "invalid"):
+        return ("warning", "warning")
+
+    # Info conditions
+    if state.health == "running":
+        return ("info", "info")
+    if state.health == "due":
+        return ("info", "info")
+    if state.outcome == "skipped":
+        return ("info", "neutral")
+
+    # Success conditions
+    if state.outcome in ("succeeded", "completed", "merged"):
+        return ("neutral", "success")
+
+    # Cancelled is intentional, not a problem
+    if state.outcome == "cancelled":
+        return ("neutral", "neutral")
+
+    return ("neutral", "neutral")
+```
+
+The relationship between `severity` (4 values) and `tone` (5 values):
+
+| severity | possible tones | when |
+|----------|---------------|------|
+| critical | danger | failures, dead processes, missing artifacts, stalls |
+| warning | warning | timeouts, partial delivery, idle/degraded/disconnected |
+| info | info, neutral | running, skipped |
+| neutral | success, neutral | succeeded/completed/merged, cancelled, unknown |
+
+Severity drives placement (attention queue inclusion, sort order, row border). Tone drives visual treatment (badge color). Both are pure functions of the three operational dimensions.
+
+### Claim severity (knowledge, not operations)
+
+Knowledge claims have their own severity derivation, defined in [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md). It is a parallel function, not unified with `derive_severity()` above, because claims are not operational entities — their severity is about knowledge health (disputed, low-confidence, superseded), not work health.
+
+Both severity functions emit into the same Attention Queue ([ADR-0030](ADR-0030-attention-queue.md)) using identical `severity` and `tone` values.
+
+### Per-entity lifecycle vocabularies
+
+Each entity type defines its allowed lifecycle states. The `outcome`
+field uses the entity-specific terminal status:
+
+#### Runs / Sessions
+
+```text
+Lifecycle: pending → running → completed | failed | timed_out | cancelled | aborted
+Health:    ok | running | idle | stalled | process_dead | orphaned
+Delivery:  passed | partial | missing | not_expected
+```
+
+Extends ADR-0025's six-value vocabulary unchanged. ADR-0024's health
+classification maps directly to the `health` field.
+
+#### Shows
+
+```text
+Lifecycle: draft → planned → active → completed | merged | failed | archived
+Health:    ok | running | blocked
+Delivery:  passed | partial | missing | not_expected
+```
+
+#### Plays
+
+```text
+Lifecycle: planned → queued → running → run_complete → merged | failed | blocked | timed_out | cancelled | skipped
+Health:    ok | running | stalled
+Delivery:  passed | partial | missing | not_expected
+```
+
+#### Invocations
+
+```text
+Lifecycle: pending → running → succeeded | failed | timed_out | cancelled | skipped
+Health:    (not applicable — invocations are short-lived)
+Delivery:  (not applicable)
+```
+
+#### Schedules
+
+```text
+Lifecycle: enabled → paused → disabled
+Health:    ok | due | running | misfired
+Delivery:  (last_run_outcome carries delivery state)
+```
+
+#### Teams
+
+```text
+Lifecycle: active → idle → blocked → closed
+Health:    ok | orphaned
+Delivery:  (not applicable)
+```
+
+### State transition validity
+
+Lifecycle transitions are NOT arbitrary. Each entity type has a state machine; the backend rejects invalid transitions. This addresses issues #1162, #1171, #1172, #1176 — sessions stuck in null/non-terminal states because nothing enforced terminal transitions.
+
+**Enforcement points**:
+
+1. **Write-side**: Any code path writing a lifecycle value MUST go through `state.transition(entity_type, entity_id, new_lifecycle, reason)`. Direct UPDATE on `status` columns is forbidden (enforced by code review, not SQL).
+2. **Terminal enforcement**: When a process exits or a watchdog detects death, the corresponding lifecycle MUST land in a terminal value within the entity's vocabulary. Sessions that exit without a terminal status are auto-transitioned to `aborted` with reason `system.health.process_dead_no_terminal`.
+3. **Phantom reconciliation**: A reaper job (per [ADR-0024](ADR-0024-session-health-and-admin-surface.md)) detects entities with non-terminal lifecycle AND `health in (process_dead, orphaned)` AND age > threshold. These are auto-transitioned to `aborted` with appropriate reason.
+
+**Per-entity transition graphs**: Live in `lionagi/state/transitions/` as one module per entity type. Each module exports a `VALID_TRANSITIONS: dict[str, set[str]]` mapping current → allowed nexts. The protocol does not specify them inline because they evolve with operational learning; the modules are version-controlled and tested.
+
+### Reason code namespace
+
+Reason codes use a hierarchical dot-separated namespace:
+
+```json
+{entity_type}.{dimension}.{cause}
+```
+
+Examples:
+
+| Code | Meaning |
+|------|---------|
+| `run.failed.exit_nonzero` | Process exited with non-zero code |
+| `run.failed.artifact_contract` | Required artifact not produced (ADR-0029) |
+| `run.health.process_dead` | PID check failed, process no longer running |
+| `run.health.stalled` | No message activity beyond threshold |
+| `run.delivery.missing` | Expected output files not found |
+| `show.failed.critical_path_blocked` | A critical-path play failed |
+| `play.blocked.dependency_failed` | Upstream play in `depends_on` failed |
+| `play.blocked.dependency_invalid` | Upstream play name in `depends_on` doesn't exist |
+| `schedule.health.misfired` | Scheduled fire time passed without execution |
+| `team.health.orphaned` | Team's parent show/play is terminal but team is still active |
+| `knowledge.disputed.conflicting_evidence` | Claim has evidence refs supporting contradictory positions |
+| `knowledge.disputed.user_rejection` | Human operator marked claim disputed |
+| `knowledge.superseded.newer_observation` | Newer claim with stronger evidence replaced this one |
+| `knowledge.stale.unverified_too_long` | Claim aged past verification budget without confirmation |
+
+**Authoritative registry**: The complete reason-code namespace lives in `lionagi/state/reason_codes.py` as a Python module (one constant per code with docstring). The table above is illustrative; the module is canonical. Any code emitted at runtime MUST appear in the registry — this is enforced by a unit test.
+
+New codes can be added without schema changes. The namespace convention
+is enforced by validation, not by SQL CHECK.
+
+### Backend owns state evaluation
+
+The backend computes `NormalizedState` for every entity and includes it
+in API responses. The frontend renders it. This is the permanent
+architecture:
+
+```text
+Backend evaluates operational truth.
+Frontend renders it.
+```
+
+During migration, the frontend MAY contain a compatibility derivation
+layer (`compat_derive_*` functions) that fills in `NormalizedState` when
+the backend hasn't been updated yet. These functions MUST set
+`source = "frontend_compat"` so the transition is traceable.
+
+### State display contract
+
+The UI renders compound state as a flat chain, not stacked badges:
+
+```text
+Failed · Infra OK · Trace present
+Running · Stalled · Artifacts missing
+Completed · Artifact contract passed
+Timed out · No review.md produced
+```
+
+The first segment is always `outcome`. The second is `health` (omitted
+if `ok` and outcome is terminal). The third is `delivery` (omitted if
+`not_expected` or `passed` and outcome is terminal success).
+
+Severity determines:
+
+- Row left-border color
+- Attention queue inclusion
+- Sort priority in tables
+- Primary icon in badges
+
+Tone determines:
+
+- Badge background/text color
+
+## Consequences
+
+**Positive**
+
+- Single state model across all entity types — tables, dashboard,
+  attention queue, and detail pages all render the same `NormalizedState`.
+- "Failed + Healthy" becomes "Failed · Infra OK" — explicit and
+  non-contradictory.
+- Stale/stuck disagreement resolved: one heuristic, one threshold
+  config, one result.
+- Reason codes enable failure clustering (ADR-0030), queryable cause
+  analysis, and structured alerting.
+- Evidence refs connect state to proof — auditable.
+- Frontend compatibility layer makes migration incremental.
+
+**Negative**
+
+- Every API response grows by ~200 bytes per entity (the state object).
+- Backend must compute health and delivery on every read until indexed
+  materialized state is implemented.
+- Existing ADRs (0017, 0024, 0025, 0028) are partially superseded —
+  increases the ADR cross-reference burden.
+
+## Migration
+
+This ADR partially supersedes [ADR-0017](ADR-0017-session-lifecycle-status.md) and [ADR-0025](ADR-0025-session-status-vocabulary.md), and extends [ADR-0024](ADR-0024-session-health-and-admin-surface.md), [ADR-0028](ADR-0028-status-reason-model.md), [ADR-0029](ADR-0029-artifact-contract.md). Migration order:
+
+1. **Backend computes NormalizedState** for all entity reads. The three dimensions (lifecycle, health, delivery) source from existing columns or are computed inline. No DB migration required for read path.
+2. **Frontend compat derivation** lands as `compat_derive_normalized_state(entity)` functions, called when backend response lacks `NormalizedState`. All compat-derived states set `source = "frontend_compat"`.
+3. **Backend persistence migration**: ALTER TABLE adds health/delivery/reason_codes columns. Backfill computes from existing data. New writes use the new columns.
+4. **Frontend switches to backend-only rendering**. Compat layer removed entity-by-entity as backend coverage verified.
+5. **Legacy single-status field deprecated**. Reads still served for one release. Then removed.
+
+The frontend compat layer is the migration bridge. Both reads (backend has it / backend doesn't) are valid during the transition; the `source` field makes it traceable.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Keep dimensions separate (status + health as independent API fields) | Frontend still has to compose them; no single severity sort; "Failed + Healthy" persists |
+| Frontend-only derivation (no backend state computation) | Two browser tabs can derive different states from stale caches; no single source of truth for attention queue |
+| Store full NormalizedState as JSON column | Not queryable by individual fields; can't index on health or delivery |
+| Single flat status enum with 30+ values | Combinatorial explosion; can't independently query "all failed regardless of health" |
+
+## References
+
+- [ADR-0017](ADR-0017-session-lifecycle-status.md) — Session Lifecycle and Status Derivation (partially superseded)
+- [ADR-0024](ADR-0024-session-health-and-admin-surface.md) — Session Health Classification and Admin Surface (extended)
+- [ADR-0025](ADR-0025-session-status-vocabulary.md) — Session Status Vocabulary (fully superseded)
+- [ADR-0028](ADR-0028-status-reason-model.md) — Status Reason Model (extended)
+- [ADR-0029](ADR-0029-artifact-contract.md) — Artifact Contract (extended)
+- [ADR-0030](ADR-0030-attention-queue.md) — Attention Queue (consumes severity)
+- [ADR-0034](ADR-0034-frontend-data-and-state-architecture.md) — Frontend Data & State Architecture
+- [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) — Knowledge Substrate (parallel claim model)
+- Issue #1161: Show status stuck at "Active"
+- Issue #1162: Dashboard stale/stuck contradiction
+- Issue #1171: Terminal status enforcement
+- Issue #1172: Phantom session reaper
+- Issue #1176: "Failed + Healthy" contradictory badges
+
+## Appendix A: Current SQLite Implementation
+
+This appendix documents the current persistence layer ([ADR-0009](ADR-0009-sqlite-state-layer.md)). The DDL below is one storage implementation of `NormalizedState`; the contract is `NormalizedState` itself, not these columns. Future stores (Postgres, distributed) will materialize the same model differently. Treat this appendix as evolving with the data layer.
+
+```sql
+-- Add to sessions table
+ALTER TABLE sessions ADD COLUMN health       TEXT;
+ALTER TABLE sessions ADD COLUMN delivery     TEXT;
+ALTER TABLE sessions ADD COLUMN reason_codes JSON DEFAULT '[]';
+
+-- Add to plays table
+ALTER TABLE plays ADD COLUMN health       TEXT;
+ALTER TABLE plays ADD COLUMN delivery     TEXT;
+ALTER TABLE plays ADD COLUMN reason_codes JSON DEFAULT '[]';
+
+-- Composite index for attention queries
+CREATE INDEX IF NOT EXISTS idx_sessions_severity
+    ON sessions(status, health) WHERE status != 'completed';
+
+CREATE INDEX IF NOT EXISTS idx_plays_severity
+    ON plays(status, health) WHERE status NOT IN ('merged', 'skipped');
+```
+
+The `NormalizedState` object itself is computed at query time from the
+stored fields — not stored as a JSON blob. This keeps the columns
+queryable and indexable.

--- a/docs/adrs/ADR-0034-frontend-data-and-state-architecture.md
+++ b/docs/adrs/ADR-0034-frontend-data-and-state-architecture.md
@@ -1,0 +1,337 @@
+# ADR-0034: Frontend Data & State Architecture
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Depends on**: [ADR-0033](ADR-0033-unified-entity-state-model.md), current persistence layer (presently [ADR-0009](ADR-0009-sqlite-state-layer.md))
+**Related**: [ADR-0006](ADR-0006-sse-live-streaming.md), [ADR-0030](ADR-0030-attention-queue.md), [ADR-0035](ADR-0035-design-system-and-component-library.md), [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md)
+
+## Context
+
+Lion Studio's frontend fetches data with a plain `fetchJson` wrapper —
+no caching, no deduplication, no retry, no cache invalidation. Every
+page navigation re-fetches from the API. There is no real-time update
+mechanism: operators must manually refresh to see state changes.
+
+This creates three concrete problems:
+
+1. **No freshness guarantee.** The dashboard can show "0 failed" while
+   a run failed 30 seconds ago. An operator who trusts the dashboard
+   misses the failure.
+
+2. **No coordinated cache.** The dashboard fetches runs, shows, and
+   system health independently. A run status change doesn't invalidate
+   the dashboard summary or the attention queue. State drifts between
+   components.
+
+3. **No URL-addressable views.** Table filters, sort order, selected
+   entity, and inspector state are component-local. An operator cannot
+   share a link to "failed runs in project X, sorted by severity" with
+   a teammate.
+
+ADR-0033 defines backend-owned `NormalizedState` for every entity.
+This ADR specifies how that state flows to the frontend, stays fresh,
+and becomes URL-addressable.
+
+## Decision
+
+### Technology choices
+
+| Concern | Choice | Rationale |
+|---------|--------|-----------|
+| Server state | TanStack Query v5 | Key-based invalidation, direct cache patching via `setQueryData`, background revalidation, mutation lifecycle hooks |
+| Realtime transport | SSE (Server-Sent Events) | Unidirectional server→client telemetry; browser-native `EventSource` with reconnect; no WebSocket complexity |
+| Client state | URL params (shareable) + Zustand (ephemeral UI only) | URL is source of truth for anything a teammate should see; Zustand for transient UI like toast queue and sidebar collapse |
+| State truth | Backend-owned NormalizedState ([ADR-0033](ADR-0033-unified-entity-state-model.md)) | Frontend renders; frontend does not compute operational severity. Transitional compat layer permitted during backend rollout per ADR-0033 migration plan |
+
+### Four state classes
+
+Frontend state is partitioned into four classes with strict ownership:
+
+| Class | Examples | Owner | Persistence |
+|-------|----------|-------|-------------|
+| Authoritative operational | Runs, shows, plays, system health, attention | Backend via TanStack Query | Query cache (memory) |
+| Derived judgments | Severity, attention inclusion, staleness | Backend (permanent) or frontend compat layer (transitional) | Computed from Class 1 |
+| View state | Filters, sort, selected entity, inspector tab, time range | URL search params | URL |
+| UI preference | Theme, table density, column visibility | localStorage | localStorage |
+
+Rule: **If state affects what an operator believes about system health,
+it must come from the backend or be explicitly marked as stale/local.**
+
+### Query key factory
+
+All query keys use a typed factory. No hand-written string arrays.
+
+```typescript
+export const qk = {
+  dashboard: {
+    summary: (scope: string, range: string) =>
+      ["dashboard", "summary", { scope, range }] as const,
+  },
+  runs: {
+    list: (params: RunListParams) =>
+      ["runs", "list", canonicalize(params)] as const,
+    detail: (id: string) =>
+      ["runs", "detail", id] as const,
+  },
+  shows: {
+    list: (params: ShowListParams) =>
+      ["shows", "list", canonicalize(params)] as const,
+    detail: (id: string) =>
+      ["shows", "detail", id] as const,
+    plays: (id: string) =>
+      ["shows", "detail", id, "plays"] as const,
+  },
+  invocations: {
+    list: (params: InvocationListParams) =>
+      ["invocations", "list", canonicalize(params)] as const,
+    detail: (id: string) =>
+      ["invocations", "detail", id] as const,
+  },
+  teams: {
+    list: (params: TeamListParams) =>
+      ["teams", "list", canonicalize(params)] as const,
+  },
+  schedules: {
+    list: (params: ScheduleListParams) =>
+      ["schedules", "list", canonicalize(params)] as const,
+  },
+  knowledge: {
+    list: (scope: ScopeRef, status: string[]) =>
+      ["knowledge", "list", { scope, status }] as const,
+    detail: (id: string) =>
+      ["knowledge", "detail", id] as const,
+    byScope: (scopeType: string, scopeId: string) =>
+      ["knowledge", "byScope", { scopeType, scopeId }] as const,
+  },
+  library: {
+    list: (params: LibraryListParams) =>
+      ["library", "list", canonicalize(params)] as const,
+  },
+  search: {
+    cross: (params: SearchParams) =>
+      ["search", "cross", canonicalize(params)] as const,
+  },
+} as const;
+```
+
+`canonicalize()` sorts object keys so equivalent filters produce
+identical cache keys.
+
+### Dashboard summary endpoint
+
+The dashboard uses a single backend-computed summary, not coordinated
+frontend queries:
+
+```text
+GET /api/dashboard/summary?project=all&range=24h
+```
+
+Returns: attention items, metrics, active runs, at-risk shows,
+at-risk schedules, system health, recent activity, inventory counts.
+
+The `AttentionQueue`, `OpsSnapshotGrid`, and risk panels all read
+from the same summary object. No race conditions between independent
+queries.
+
+### SSE architecture
+
+One central `EventSource` per active project scope. Components do NOT subscribe independently.
+
+```text
+GET /api/events?project=all
+Accept: text/event-stream
+```
+
+A `StudioRealtimeProvider` opens the stream and dispatches events to TanStack Query's cache.
+
+#### Event envelope
+
+Every event uses this shape:
+
+```typescript
+type StudioEvent = {
+  id: string;                          // for Last-Event-ID resume
+  type: StudioEventType;
+  scope: { project: string };
+  invalidates: QueryKey[];             // cache keys to refresh
+  patch?: { key: QueryKey; data: unknown };  // optional direct cache patch
+  version?: number;                    // for race-resolution with mutations
+  emitted_at: number;
+};
+```
+
+#### Event type taxonomy
+
+Events are namespaced by entity type:
+
+| Namespace | Events |
+|-----------|--------|
+| `run.*` | `created`, `updated`, `completed`, `failed`, `cancelled`, `aborted` |
+| `play.*` | `updated`, `blocked`, `merged`, `failed` |
+| `show.*` | `updated`, `merged`, `failed` |
+| `invocation.*` | `updated`, `completed`, `failed` |
+| `schedule.*` | `due`, `fired`, `misfired` |
+| `team.*` | `created`, `closed`, `orphaned` |
+| `attention.*` | `added`, `cleared`, `severity_changed` |
+| `knowledge.*` | `created`, `verified`, `disputed`, `superseded` |
+| `system.*` | `health_changed`, `resync_required` |
+
+The `knowledge.*` events feed the Knowledge lens (see [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md)) and may also generate attention queue items (e.g., a claim transitioning to `disputed` is attention-worthy).
+
+#### Dispatch strategy
+
+- **Row-level updates** (e.g., `run.updated` with `patch`): Direct cache patch via `setQueryData`. No debounce — operators should see failures immediately.
+- **Aggregate invalidation** (`invalidates: ["dashboard", "summary", ...]`): Debounced (250-500ms) `invalidateQueries`. Debounce key is the stringified query key; rapid identical invalidations coalesce.
+
+#### Mutation/SSE race resolution
+
+A mutation's success handler patches the cache; the SSE event for the same change may arrive milliseconds later. Both code paths apply IDEMPOTENT patches with the same shape, so re-application is harmless. Where order matters (e.g., user sees an optimistic patch and then a server-corrected one), the `version` field on the event resolves: higher version wins, lower version is ignored.
+
+#### Disconnect behavior
+
+1. Status → `reconnecting` after 0s
+2. Compact global banner after 3s
+3. Fallback polling starts for operational queries (uses freshness budget "Disconnected poll" column)
+4. On reconnect, resume from `Last-Event-ID`
+5. If event gap exceeds retention (server-side), emit `system.resync_required` → full invalidation
+
+### Freshness budgets
+
+| Surface | SSE live | Disconnected poll | Stale warning |
+|---------|---------|-------------------|---------------|
+| Dashboard summary | 30s verification | 5s | 15s |
+| Show detail | 15s | 5s | 10s |
+| Runs table | 30s | 10s | 20s |
+| Run detail | 15s | 5s | 10s |
+| System health | 15s | 5s | 10s |
+| Library content | 5m | 60s | 10m |
+| Knowledge lens | 60s verification | 30s | 120s |
+
+Knowledge claims change on agent action, not continuously. A longer budget reflects this: a verified claim from 2 hours ago is not "stale" the way a session from 30 seconds ago might be.
+
+The UI renders freshness state on every operational surface:
+
+```text
+Live · verified 8s ago
+Disconnected · polling every 5s
+Stale · last verified 48s ago
+```
+
+### URL as state
+
+The URL owns all shareable view state:
+
+| Param | Purpose | Example |
+|-------|---------|---------|
+| `project` | Project scope | `project=lionagi` |
+| `range` | Time range | `range=24h` |
+| `q` | Search text | `q=exit%20124` |
+| `status` | Outcome filter | `status=failed,timed_out` |
+| `health` | Health filter | `health=stalled` |
+| `sort` | Sort order | `sort=-severity,-updated` |
+| `selected` | Selected entity | `selected=run:dad0dc05` |
+| `panel` | Inspector panel | `panel=logs` |
+
+URL state is validated through Zod schemas. Browser back/forward
+restores the full view state. Opening a shared link restores filters,
+sort, selected entity, and inspector tab.
+
+### Zustand scope
+
+Zustand holds ONLY ephemeral UI state:
+
+```typescript
+type UiStore = {
+  commandPaletteOpen: boolean;
+  sidebarCollapsed: boolean;
+  toasts: ToastState[];
+};
+```
+
+Zustand MUST NOT store runs, shows, schedules, or any operational data.
+
+### Mutations
+
+TanStack mutations for all write operations. No optimistic success for
+destructive or operationally meaningful actions:
+
+- Allowed: button shows "Cancelling...", row action disabled
+- Not allowed: immediately flipping Running → Cancelled before backend confirms
+
+On mutation success: patch detail cache, invalidate lists and dashboard.
+On mutation failure: inline row error + toast. Do not hide the row.
+
+### Cross-entity search
+
+```text
+GET /api/search?q=failed&project=all&range=1h&type=all
+```
+
+Returns results across runs, shows, plays, invocations, teams, schedules, library entities, AND knowledge claims. Each result carries its `NormalizedState` (operational entities) or `claim_status` (knowledge claims) for consistent severity rendering across the result set.
+
+Surfaced via `Cmd/Ctrl-K` command palette for quick navigation and
+a dedicated `/search` route for shareable result pages.
+
+### Backend-frontend sync contract
+
+Issues like #1161 (show status stuck at "Active"), #1167 (Runs page MODEL column empty), and #1177 (action panel auto-synthesis) reveal a sync-contract gap: the backend has data, the frontend doesn't render it. This section makes the contract explicit.
+
+**Three sync modes, used together**:
+
+| Mode | When | Mechanism |
+|------|------|-----------|
+| **Pull on access** | User navigates to a route | Route loader fires the relevant TanStack Query; cache-first if fresh, network if stale |
+| **Push on change** | Server-side event | SSE event from `StudioRealtimeProvider` patches or invalidates affected cache keys |
+| **Reconcile on interval** | Long-disconnected client | Disconnected polling per freshness budget; on reconnect, resync from `Last-Event-ID` or full re-fetch |
+
+**No mode operates alone**. Every operational surface uses (Pull on access) + (Push on change), with (Reconcile on interval) as the disconnected fallback. The `data-freshness-badge` (defined in [ADR-0035](ADR-0035-design-system-and-component-library.md)) reflects which mode is currently authoritative.
+
+**Contract guarantees**:
+
+- A backend write becomes visible to the frontend within the SSE freshness budget for that entity (e.g., 15s for Show detail). If SSE is disconnected, within the poll interval (5s for Show detail).
+- The displayed `NormalizedState` is never more than one budget cycle stale; staler than that, the freshness badge transitions to `stale` and the operator sees the warning.
+- Mutations patch the cache synchronously on success; SSE for the same change arriving later is a no-op (idempotent re-patch).
+
+## Consequences
+
+**Positive**
+
+- Single cache for operational state — no drift between dashboard
+  and detail pages.
+- SSE provides near-instant failure visibility without polling overhead.
+- URL-addressable views enable operational collaboration ("look at this
+  filtered view").
+- Freshness indicators prevent false confidence in stale data.
+- Query key factory prevents cache key collisions and enables precise
+  invalidation.
+
+**Negative**
+
+- TanStack Query adds ~40KB to the bundle (gzipped).
+- Zustand adds ~2KB.
+- SSE requires a new backend endpoint and event persistence table.
+- Dashboard summary endpoint requires backend implementation before
+  the frontend migration can complete.
+- URL state adds complexity to every table/filter component.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| SWR instead of TanStack Query | No built-in mutation lifecycle hooks; less precise cache invalidation |
+| WebSocket instead of SSE | Bidirectional not needed; SSE has native browser reconnect; lower complexity |
+| Redux for all state | Too much ceremony for the state we actually have; most state is server-owned |
+| Per-component polling | Race conditions between components; no cache coordination; O(n) API calls |
+| localStorage for view state | Not shareable; no deep linking; doesn't survive incognito |
+
+## References
+
+- [ADR-0006](ADR-0006-sse-live-streaming.md) — SSE Live Streaming (event transport)
+- [ADR-0009](ADR-0009-sqlite-state-layer.md) — SQLite State Layer (current backend persistence)
+- [ADR-0030](ADR-0030-attention-queue.md) — Attention Queue
+- [ADR-0033](ADR-0033-unified-entity-state-model.md) — Unified Entity State Model
+- [ADR-0035](ADR-0035-design-system-and-component-library.md) — Design System & Component Library
+- [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) — Knowledge Substrate
+- TanStack Query v5 documentation
+- MDN: Using Server-Sent Events
+- Issue #1161, #1167, #1177 — backend-frontend sync gaps addressed by §Backend-frontend sync contract

--- a/docs/adrs/ADR-0035-design-system-and-component-library.md
+++ b/docs/adrs/ADR-0035-design-system-and-component-library.md
@@ -169,7 +169,7 @@ Good: bg-[var(--ls-critical-bg)]
 Bad:  bg-red-50
 ```
 
-**Prefix decision**: `--ls-` is the canonical design-token namespace. Lion Studio mode (open-source) uses these directly. KHive product mode inherits the same tokens but may override values in `themes/khive.css`. Token NAMES stay stable across product modes; only their VALUES vary.
+**Prefix decision**: `--ls-` is the canonical design-token namespace. Lion Studio uses these directly. Custom themes may override values in theme-specific CSS files. Token NAMES stay stable across themes; only their VALUES vary.
 
 The existing design token system in `globals.css` already uses CSS
 custom properties with dark mode via `.dark` class. This ADR extends

--- a/docs/adrs/ADR-0035-design-system-and-component-library.md
+++ b/docs/adrs/ADR-0035-design-system-and-component-library.md
@@ -1,0 +1,336 @@
+# ADR-0035: Design System and Component Library
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Supersedes**: [ADR-0013](ADR-0013-zero-dependency-ui.md) (zero-component-library UI) — for product surfaces
+**Depends on**: [ADR-0033](ADR-0033-unified-entity-state-model.md) (renders NormalizedState)
+**Related**: [ADR-0031](ADR-0031-entity-header-pattern.md), [ADR-0034](ADR-0034-frontend-data-and-state-architecture.md), [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md)
+
+## Context
+
+ADR-0013 chose zero external component dependencies: no Radix, no
+shadcn, no headless UI. The rationale was that Studio is a power-user
+tool with one primary user, and custom components keep bundle size
+minimal and control total.
+
+That assumption no longer holds. The frontend now requires:
+
+- **Dialogs** for confirmation actions (ADR-0031 entity actions)
+- **Dropdown menus** for row actions in tables
+- **Popovers** for filter chips and column pickers
+- **Comboboxes** for project scope selection and search
+- **Tooltips** for status badges and graph nodes
+- **Command palette** for keyboard-first navigation
+- **Focus traps** for modals and drawers
+- **Roving tabindex** for table row navigation
+
+Each of these requires correct ARIA roles, keyboard handling, focus
+management, and screen reader announcements. Building them from scratch
+is a multi-week effort that produces worse accessibility than existing
+headless libraries designed specifically for this purpose.
+
+ADR-0013 itself noted: "This trade-off would not be acceptable for a
+public-facing product." The product direction has now changed — Studio
+is becoming the operational interface, not just Ocean's local tool.
+
+## Decision
+
+### Component architecture
+
+```text
+components/ui/      — generic primitives (shadcn/ui source-owned)
+components/lion/    — domain-aware design system
+features/*/         — product surfaces (import from lion/, never from Radix directly)
+```
+
+**This ADR is the canonical owner of `components/lion/`**. Future feature ADRs that introduce new domain components MUST amend this ADR's component list (PR against §Domain components below). The catalog must remain discoverable in one place; scattering definitions across feature ADRs is the failure mode this rule prevents.
+
+### Primitive layer: shadcn/ui
+
+Use shadcn/ui as source-owned primitives. shadcn is not a dependency —
+it generates component source files that we own and modify. The
+underlying accessibility primitives come from Radix.
+
+Adopted primitives:
+
+| Primitive | Source | Use case |
+|-----------|--------|----------|
+| Button | shadcn | All buttons |
+| Badge | shadcn | Metadata labels (model, source, version) |
+| Dialog | shadcn/Radix | Confirmation actions, entity details |
+| DropdownMenu | shadcn/Radix | Row actions, context menus |
+| Popover | shadcn/Radix | Filter chips, column picker |
+| Tooltip | shadcn/Radix | Status explanations, graph node details |
+| Command | shadcn/Radix | Cmd/Ctrl-K command palette |
+| Tabs | shadcn/Radix | Inspector panels, detail page sections |
+| Sheet | shadcn/Radix | Mobile sidebar, inspector drawer |
+
+NOT adopted (use existing custom):
+
+| Component | Reason |
+|-----------|--------|
+| Table | TanStack Table + custom markup for `LionDataTable` |
+| Form inputs | Existing custom inputs are sufficient for current scope |
+| Toast | Existing Toast provider works; migrate later if needed |
+
+### Domain components: `components/lion/`
+
+These encode Lion Studio's operational semantics:
+
+```text
+lion/
+  status-badge.tsx        — single status with tone + icon
+  state-stack.tsx          — compound state: "Failed · Infra OK · Trace present"
+  severity-indicator.tsx   — left-border severity accent
+  data-table/
+    lion-data-table.tsx    — TanStack Table wrapper with toolbar, filters, URL sync
+    table-toolbar.tsx      — search, filter chips, column picker, density toggle
+    table-pagination.tsx   — cursor pagination
+  object-header.tsx        — universal detail page header (ADR-0031)
+  object-lineage.tsx       — clickable breadcrumb chips
+  attention-item.tsx       — attention queue row
+  data-freshness-badge.tsx — "Live · verified 8s ago"
+  section-boundary.tsx     — per-section error boundary
+  connection-banner.tsx    — SSE disconnect indicator
+  knowledge/
+    knowledge-lens.tsx          — contextual claim listing for an entity scope
+    claim-card.tsx              — single claim with status, confidence, evidence count
+    claim-status-badge.tsx      — observed | inferred | hypothesis | verified | disputed | superseded
+    evidence-trail.tsx          — expandable list of EvidenceRefs with source links
+    confidence-meter.tsx        — visual confidence indicator (0.0–1.0)
+```
+
+The `knowledge/*` components implement the behavioral spec from [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) §"Product Implications". This ADR owns the catalog and rendering rules; ADR-0039 owns the data model and behavioral semantics.
+
+Rule: No feature component imports Radix directly. If a shared
+primitive doesn't exist yet, add it to `components/ui/` first.
+
+### Table engine: TanStack Table
+
+TanStack Table provides headless table logic (sorting, filtering,
+pagination, column visibility, row selection). Lion Studio provides
+the markup and Tailwind styling via `LionDataTable`.
+
+Relationship to shadcn's DataTable:
+
+- shadcn's `Table` component provides markup primitives (`<Table>`,
+  `<TableHeader>`, `<TableRow>`, `<TableCell>`)
+- `LionDataTable` wraps TanStack Table logic + shadcn Table markup +
+  Lion-specific toolbar, URL sync, density modes, and row actions
+
+### Status badge contract
+
+Generic `Badge` (shadcn) is for metadata labels: `codex/gpt-5.5`,
+`local`, `v1.0.0`. Never for operational status.
+
+Operational status uses domain components:
+
+```tsx
+<StatusBadge tone="danger" icon={XCircle}>Failed</StatusBadge>
+
+<StateStack
+  outcome="failed"
+  health="ok"
+  delivery="present"
+/>
+// Renders: "Failed · Infra OK · Trace present"
+```
+
+Status rendering rules:
+
+- Never use color alone — always icon + text + color
+- Dark mode does not change status semantics
+- Critical/warning states always have icons
+- Reduced motion disables pulse/spin animations
+
+### Semantic color tokens
+
+Extend existing CSS custom properties (which already exist in
+`globals.css`) to use the `--ls-` prefix for the severity system:
+
+```css
+:root {
+  --ls-critical-bg: ...;
+  --ls-critical-border: ...;
+  --ls-critical-text: ...;
+  --ls-critical-accent: ...;
+  /* warning, info, success, neutral variants */
+  --ls-focus-ring: ...;
+}
+.dark {
+  /* dark variants of all above */
+}
+```
+
+Components reference semantic tokens, not raw Tailwind colors:
+
+```text
+Good: bg-[var(--ls-critical-bg)]
+Bad:  bg-red-50
+```
+
+**Prefix decision**: `--ls-` is the canonical design-token namespace. Lion Studio mode (open-source) uses these directly. KHive product mode inherits the same tokens but may override values in `themes/khive.css`. Token NAMES stay stable across product modes; only their VALUES vary.
+
+The existing design token system in `globals.css` already uses CSS
+custom properties with dark mode via `.dark` class. This ADR extends
+that system with the severity-specific tokens, not replaces it.
+
+### Semantic palette: status colors
+
+The severity → tone mapping in [ADR-0033](ADR-0033-unified-entity-state-model.md) determines color category. The concrete color values are defined here as the canonical palette:
+
+| Tone | Light mode | Dark mode | Usage |
+|------|-----------|-----------|-------|
+| `danger` | red-700 / red-100 bg | red-300 / red-950 bg | failed, aborted, dead, missing |
+| `warning` | amber-700 / amber-100 bg | amber-300 / amber-950 bg | timed_out, partial, stalled, disputed |
+| `info` | blue-700 / blue-100 bg | blue-300 / blue-950 bg | running, due, observed |
+| `success` | green-700 / green-100 bg | green-300 / green-950 bg | succeeded, completed, merged, verified |
+| `neutral` | gray-700 / gray-100 bg | gray-300 / gray-900 bg | cancelled, skipped, unknown, hypothesis |
+
+These map directly to CSS custom properties: `--ls-danger-text`, `--ls-danger-bg`, `--ls-warning-text`, etc. Components NEVER reference raw Tailwind color classes for status; they reference these semantic tokens.
+
+**Knowledge-specific tones** follow the same palette:
+
+- `observed` → info (assumes clean evidence)
+- `inferred` → info (with reduced opacity to signal lower certainty)
+- `hypothesis` → neutral (typed honestly, low confidence)
+- `verified` → success
+- `disputed` → warning
+- `superseded` → neutral (archived, not failed)
+
+This palette is the source of truth. Issues #1178, #1179 (filter chip colors, graph node colors) MUST consume from this palette, not invent local colors.
+
+### Dark mode
+
+Already supported via `darkMode: "class"` in `tailwind.config.ts`.
+Extend with:
+
+- Pre-hydration inline script to apply `.dark` before React renders
+  (prevents flash of wrong theme)
+- Theme preference: `light | dark | system`, stored in localStorage
+- System preference via `prefers-color-scheme` media query
+- Theme toggle in nav showing resolved state: "System · Dark"
+
+### Accessibility target: WCAG 2.2 AA
+
+Non-negotiable rules:
+
+- Never use color alone to communicate state (every status has icon + text + color)
+- Focus state visible on every interactive element
+- Keyboard can reach every action
+- Tables use semantic `<table>` markup with `aria-sort`
+- Live updates use `aria-live` (assertive for critical, polite for info)
+- Graph has keyboard navigation AND table fallback
+- Reduced motion: `prefers-reduced-motion` disables all animations
+
+**Verification strategy** (addresses issue #1020 — 47 a11y findings):
+
+| Layer | Tool | Gate |
+|-------|------|------|
+| Static (CI) | `eslint-plugin-jsx-a11y` | Block merge on `error` level |
+| Component (CI) | `@testing-library/jest-dom` + `jest-axe` | Each `components/lion/*` has an a11y test |
+| Page (manual + CI) | Lighthouse / Axe DevTools | Score ≥95 on Dashboard, Runs, Show detail |
+| Live | Manual screen reader sweep (VoiceOver, NVDA) | Quarterly, owned by frontend lead |
+
+Component-level a11y test pattern:
+
+```typescript
+import { axe } from "jest-axe";
+
+it("StatusBadge has no axe violations", async () => {
+  const { container } = render(<StatusBadge tone="danger" icon={XCircle}>Failed</StatusBadge>);
+  expect(await axe(container)).toHaveNoViolations();
+});
+```
+
+Every component in `components/lion/` MUST ship with an a11y test. Components in `components/ui/` (shadcn primitives) inherit Radix's verified a11y but get smoke tests for our customizations.
+
+### Keyboard-first interaction
+
+Scoped shortcut system with priority ordering:
+
+```text
+Dialog/modal > Editor/input > Graph > Table > Page > Global
+```
+
+Core shortcuts (ship in v1):
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd/Ctrl-K` | Command palette |
+| `?` | Keyboard help |
+| `/` | Focus search |
+| `g d` | Go to Dashboard |
+| `g r` | Go to Runs |
+| `g s` | Go to Shows |
+| `j/k` | Table row navigation |
+| `Enter` | Open selected |
+| `Esc` | Clear selection / close overlay |
+
+Shortcut rules:
+
+- No printable shortcuts fire inside input/textarea/contenteditable
+- `Cmd/Ctrl-K` always opens command palette unless modal captures it
+- `Escape` closes innermost overlay
+
+### Error boundaries
+
+Per-section on dashboard and detail pages. Page-level only when
+primary entity cannot load.
+
+```text
+System health fails but runs load:
+  → SystemHealthPanel shows inline error
+  → AttentionQueue adds "System health unavailable" item
+  → Rest of dashboard renders normally
+
+All API calls fail:
+  → Full-page "Backend unreachable" with last cached timestamp
+```
+
+### Loading states
+
+Section-level skeletons. Never blank an entire page during background
+refresh. Keep last known data with "verifying..." freshness indicator
+during revalidation.
+
+## Consequences
+
+**Positive**
+
+- Correct accessibility from day one via Radix primitives
+- Keyboard-first interaction for operator efficiency
+- Consistent status rendering across all surfaces via domain components
+- Source-owned components (shadcn) — no locked dependencies
+- Dark mode with no flash
+
+**Negative**
+
+- Radix primitives add ~15-25KB (gzipped). Combined with [ADR-0034](ADR-0034-frontend-data-and-state-architecture.md)'s TanStack Query (~40KB) + Zustand (~2KB), total new bundle weight is ~60KB gzipped.
+- Migration effort: existing custom components need gradual replacement
+- [ADR-0013](ADR-0013-zero-dependency-ui.md)'s "zero dependency" principle is explicitly abandoned for product surfaces. Preserved as a constraint for any future ultra-light embed mode.
+- Catalog ownership concentrated in this ADR — feature ADRs MUST amend rather than fork. This creates merge contention in component-heavy phases; mitigated by clear catalog entries and small per-component PRs.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Continue zero-dependency (ADR-0013) | Accessibility debt grows with every new interactive component; ADR-0013 itself flagged this |
+| MUI / Ant Design / Chakra | Opinionated styling conflicts with existing Tailwind design system; large bundle |
+| Headless UI (Tailwind Labs) | Fewer primitives than Radix; no command palette; less active maintenance |
+| Build everything custom with correct ARIA | Multi-week effort per component; will produce worse a11y than battle-tested Radix |
+
+## References
+
+- [ADR-0013](ADR-0013-zero-dependency-ui.md) — Zero Component-Library UI (superseded by this ADR for product surfaces)
+- [ADR-0031](ADR-0031-entity-header-pattern.md) — Entity Header Pattern (consumes design system)
+- [ADR-0033](ADR-0033-unified-entity-state-model.md) — Unified Entity State Model (status/severity/tone semantics)
+- [ADR-0034](ADR-0034-frontend-data-and-state-architecture.md) — Frontend Data & State Architecture
+- [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) — Knowledge Substrate (claim/evidence components)
+- shadcn/ui documentation
+- Radix Primitives documentation
+- WCAG 2.2 — Contrast (Minimum), Focus Visible, Target Size
+- TanStack Table documentation
+- `eslint-plugin-jsx-a11y`, `jest-axe` — accessibility CI tooling
+- Issue #1020 — a11y baseline (driven by verification strategy above)
+- Issue #1168, #1178, #1179 — design system polish addressed via semantic palette

--- a/docs/adrs/ADR-0039-knowledge-substrate-minimal-interface.md
+++ b/docs/adrs/ADR-0039-knowledge-substrate-minimal-interface.md
@@ -1,0 +1,701 @@
+# ADR-0039: Knowledge Substrate Minimal Interface
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Depends on**: [ADR-0033](ADR-0033-unified-entity-state-model.md) (shared EvidenceRef definition)
+**Related**: [ADR-0028](ADR-0028-status-reason-model.md), [ADR-0029](ADR-0029-artifact-contract.md), [ADR-0030](ADR-0030-attention-queue.md), [ADR-0034](ADR-0034-frontend-data-and-state-architecture.md), [ADR-0035](ADR-0035-design-system-and-component-library.md)
+**Consumed by**: KHive v1 product (governed memory and evidence layer)
+
+## Context
+
+lionagi sessions produce rich activity traces (messages, tool calls, model
+responses) but no structured *knowledge*. The gap:
+
+| What exists | What's missing |
+|------------|----------------|
+| Messages (ephemeral conversation) | Claims (durable learned facts) |
+| DataLogger (activity audit trail) | Knowledge lifecycle (observed → verified → disputed → superseded) |
+| Tool results (raw output) | Evidence-backed assertions about what results *mean* |
+| Branch state (in-memory) | Cross-session retrieval ("what do we know about X?") |
+
+An agent that reviews 50 PRs learns nothing persistent. The next
+session starts cold. The operator can't ask "what has the agent learned
+about our codebase?" because there's no substrate to hold the answer.
+
+### The product thesis
+
+> KHive is the governed memory and evidence layer for internal agent
+> platforms.
+
+The knowledge substrate is what makes "governed memory" concrete. Without
+it, KHive is an observability dashboard (commodity). With it, KHive
+captures *what agents learn*, not just what they did.
+
+### Design constraints
+
+1. **Storage-agnostic.** The data layer will change (SQLite → Postgres →
+   distributed). The protocol MUST NOT leak storage assumptions.
+2. **Evidence-first.** No claim without at least one structured evidence
+   ref. This is the core opinion — it's what makes knowledge auditable.
+3. **Zero-config in library mode.** A developer using `Branch` in a
+   script should not need to configure anything. Knowledge methods exist
+   but are no-ops until a store is provided.
+4. **Branch-native.** Follows the existing 4-manager pattern. Becomes
+   the 5th manager, not an external add-on.
+5. **Tastefully opinionated.** The API surface guides users toward
+   correct usage patterns. Hard to misuse, easy to use well.
+
+## Decision
+
+### The Knowledge Protocol
+
+```python
+from typing import Protocol, runtime_checkable
+
+@runtime_checkable
+class KnowledgeStore(Protocol):
+    """Minimal protocol for durable knowledge persistence.
+
+    Implementations:
+      - NullKnowledgeStore: no-op (library default, zero overhead)
+      - MemoryKnowledgeStore: in-process dict (testing, short-lived scripts)
+      - SQLiteKnowledgeStore: local file (Studio mode)
+      - KHiveKnowledgeStore: governed remote (commercial product)
+    """
+
+    async def write_claim(
+        self,
+        claim: "Claim",
+    ) -> str:
+        """Persist a claim. Returns claim_id."""
+        ...
+
+    async def query(
+        self,
+        question: str,
+        *,
+        scope: "Scope | None" = None,
+        status: "list[str] | None" = None,
+        limit: int = 10,
+    ) -> "list[Claim]":
+        """Semantic retrieval of relevant claims."""
+        ...
+
+    async def transition(
+        self,
+        claim_id: str,
+        new_status: str,
+        *,
+        evidence: "list[EvidenceRef] | None" = None,
+        reason: str | None = None,
+    ) -> None:
+        """Move a claim through its lifecycle."""
+        ...
+
+    async def supersede(
+        self,
+        old_id: str,
+        new_id: str,
+    ) -> None:
+        """Mark old claim superseded by new one."""
+        ...
+
+    async def history(
+        self,
+        claim_id: str,
+    ) -> "list[ClaimEvent]":
+        """Return lifecycle events for a claim."""
+        ...
+```
+
+Five methods. That's the entire contract. Implementations can range from
+a dict to a distributed graph store.
+
+### The Claim dataclass
+
+```python
+from dataclasses import dataclass, field
+from uuid import uuid4
+
+@dataclass
+class Claim:
+    """A unit of learned knowledge with evidence and lifecycle."""
+
+    text: str
+    evidence: list[EvidenceRef]  # MUST be non-empty (enforced at construction)
+    claim_status: str = "observed"
+    confidence: float = 1.0
+    # Confidence in the CLAIM being true (the fact itself).
+    # Distinct from StateReason.confidence in ADR-0033, which measures
+    # confidence in a reason explaining an operational state.
+
+    # Auto-populated by Branch.learn()
+    id: str = field(default_factory=lambda: str(uuid4()))
+    project: str | None = None
+    scope_type: str | None = None  # project | repo | agent | run
+    scope_id: str | None = None
+    session_id: str | None = None
+    branch_id: str | None = None
+    actor_type: str = "agent"     # agent | user | system | tool
+    actor_id: str | None = None
+    created_at: float = 0.0
+
+    # Optional structured metadata
+    domain: str | None = None     # e.g., "codebase", "api", "policy"
+    tags: list[str] = field(default_factory=list)
+    supersedes: str | None = None
+
+    def __post_init__(self):
+        if not self.evidence:
+            raise ValueError(
+                "A Claim requires at least one EvidenceRef. "
+                "If evidence is truly absent, this is a hypothesis — "
+                "use kind='model_inference' with low confidence."
+            )
+```
+
+The `ValueError` on empty evidence is the core opinion. You physically
+cannot create a claim without evidence. Weak evidence is allowed (typed
+honestly), but empty evidence is not.
+
+### Claim lifecycle
+
+```text
+observed → verified       (human/trusted process confirms)
+observed → disputed       (conflicting evidence arrives)
+observed → superseded     (newer claim replaces)
+inferred → verified       (upgraded by external confirmation)
+inferred → disputed       (disproven)
+hypothesis → observed     (evidence found)
+hypothesis → disputed     (falsified)
+verified → disputed       (new contradicting evidence)
+disputed → verified       (resolution in favor)
+disputed → superseded     (both replaced)
+any → superseded          (factual replacement)
+```
+
+Transition validation is in the store implementation, not the protocol.
+The protocol just takes `new_status: str`. This keeps the protocol
+stable while implementations can enforce stricter rules.
+
+### Branch integration: the 5th manager
+
+```python
+class Branch:
+    def __init__(
+        self,
+        ...,
+        knowledge_store: KnowledgeStore | None = None,
+    ):
+        ...
+        self._knowledge_store = knowledge_store or NullKnowledgeStore()
+
+    async def learn(
+        self,
+        claim: str,
+        evidence: list[EvidenceRef],
+        *,
+        status: str = "observed",
+        confidence: float = 1.0,
+        domain: str | None = None,
+        tags: list[str] | None = None,
+    ) -> str | None:
+        """Record a learned fact with evidence. Returns claim_id.
+
+        This is the primary knowledge-write API. It enforces:
+        - Non-empty evidence (raises ValueError)
+        - Auto-populates session/branch/actor context
+        - Delegates to the configured KnowledgeStore
+
+        Returns None if store is NullKnowledgeStore (library mode).
+        """
+        c = Claim(
+            text=claim,
+            evidence=evidence,
+            claim_status=status,
+            confidence=confidence,
+            session_id=str(self._session_id) if self._session_id else None,
+            branch_id=str(self.id),
+            domain=domain,
+            tags=tags or [],
+            created_at=now_utc().timestamp(),
+        )
+        return await self._knowledge_store.write_claim(c)
+
+    async def recall(
+        self,
+        question: str,
+        *,
+        limit: int = 5,
+        status: list[str] | None = None,
+    ) -> list[Claim]:
+        """Retrieve relevant knowledge claims.
+
+        Default: returns only active claims (observed, inferred, verified).
+        Pass status=["disputed"] to include contested knowledge.
+        """
+        if status is None:
+            status = ["observed", "inferred", "verified"]
+        return await self._knowledge_store.query(
+            question, status=status, limit=limit
+        )
+
+    async def verify(
+        self, claim_id: str, evidence: list[EvidenceRef] | None = None
+    ) -> None:
+        """Upgrade a claim to verified status."""
+        await self._knowledge_store.transition(
+            claim_id, "verified", evidence=evidence
+        )
+
+    async def dispute(
+        self, claim_id: str, reason: str, evidence: list[EvidenceRef] | None = None
+    ) -> None:
+        """Mark a claim as disputed with reason."""
+        await self._knowledge_store.transition(
+            claim_id, "disputed", evidence=evidence, reason=reason
+        )
+```
+
+Four user-facing methods on Branch: `learn`, `recall`, `verify`, `dispute`.
+That's the tasteful opinion — small surface, hard to misuse.
+
+**Branch method → Store method mapping**:
+
+| Branch (user-facing) | Store (protocol) | Notes |
+|----------------------|------------------|-------|
+| `learn(claim, evidence, ...)` | `write_claim(Claim)` | Auto-populates session/branch context |
+| `recall(question, ...)` | `query(question, ...)` | Default filters out disputed/superseded |
+| `verify(claim_id, evidence)` | `transition(claim_id, "verified", evidence)` | Convenience wrapper |
+| `dispute(claim_id, reason, evidence)` | `transition(claim_id, "disputed", evidence, reason)` | Convenience wrapper |
+| — | `supersede(old_id, new_id)` | Store-only; agents propose new claims, admin/human executes supersession |
+| — | `history(claim_id)` | Store-only; lifecycle events surfaced via dedicated UI, not in-line agent flow |
+
+`supersede` and `history` are intentionally store-only. Agents shouldn't supersede their own claims; the next observation creates a new claim, and an explicit human/admin decision links them via supersession.
+
+**Session-level configuration is the primary entry point**:
+
+```python
+session = Session(
+    knowledge_store=SQLiteKnowledgeStore("~/.lionagi/knowledge.db"),
+)
+branch = session.new_branch(system="You are a researcher")
+# branch._knowledge_store == session._knowledge_store
+```
+
+When `Session.new_branch()` creates a Branch, it passes the session's `knowledge_store` to the new Branch. Per-Branch override is allowed for isolation testing (e.g., one Branch uses `NullKnowledgeStore` to opt out without affecting siblings):
+
+```python
+isolated_branch = session.new_branch(
+    system="Sandbox agent",
+    knowledge_store=NullKnowledgeStore(),  # override
+)
+```
+
+The default flow: configure the store ONCE at the Session level. The override is a power-user seam, not the common path.
+
+### The NullKnowledgeStore (zero-config default)
+
+```python
+class NullKnowledgeStore:
+    """No-op store. Library mode. Zero overhead."""
+
+    async def write_claim(self, claim: Claim) -> str | None:
+        return None
+
+    async def query(self, question, **kwargs) -> list[Claim]:
+        return []
+
+    async def transition(self, claim_id, new_status, **kwargs) -> None:
+        pass
+
+    async def supersede(self, old_id, new_id) -> None:
+        pass
+
+    async def history(self, claim_id) -> list:
+        return []
+```
+
+A developer using lionagi as a library pays zero cost. No config, no
+database, no setup. `branch.learn()` silently returns None. `branch.recall()`
+returns an empty list. The API exists but does nothing until you opt in.
+
+### Audit trail integration
+
+Every knowledge action (`learn`, `verify`, `dispute`, `supersede`) MUST emit a `Log` entry to the Branch's `DataLogger`. The KnowledgeStore handles claim persistence; the DataLogger captures the *action* of writing knowledge. This is what makes the evidence chain auditable end-to-end.
+
+Log entry shape:
+
+```python
+{
+  "event": "knowledge.learn" | "knowledge.verify" | "knowledge.dispute" | "knowledge.supersede",
+  "claim_id": str,
+  "claim_status": str,
+  "evidence_count": int,
+  "evidence_kinds": list[str],
+  "scope_type": str | None,
+  "scope_id": str | None,
+  "actor_type": str,
+  "actor_id": str | None,
+  "branch_id": str,
+  "session_id": str | None,
+  "timestamp": float,
+}
+```
+
+The Branch.learn() implementation emits this log entry before delegating to the store. Failures to write the log do NOT block the knowledge write; they emit a warning to the DataLogger's auxiliary error channel.
+
+Combined with [ADR-0033](ADR-0033-unified-entity-state-model.md)'s reason-code namespace (specifically `knowledge.*` codes), this gives operators a complete activity trail: who created what claim with what evidence, when it was verified or disputed, by whom.
+
+### The MemoryKnowledgeStore (testing/scripts)
+
+```python
+class MemoryKnowledgeStore:
+    """In-process dict store. For tests and short-lived scripts."""
+
+    def __init__(self):
+        self._claims: dict[str, Claim] = {}
+
+    async def write_claim(self, claim: Claim) -> str:
+        self._claims[claim.id] = claim
+        return claim.id
+
+    async def query(self, question, *, scope=None, status=None, limit=10):
+        results = list(self._claims.values())
+        if status:
+            results = [c for c in results if c.claim_status in status]
+        # Simple substring match for in-memory mode
+        if question:
+            results = [c for c in results if question.lower() in c.text.lower()]
+        return results[:limit]
+
+    async def transition(self, claim_id, new_status, *, evidence=None, reason=None):
+        if claim_id in self._claims:
+            self._claims[claim_id].claim_status = new_status
+
+    async def supersede(self, old_id, new_id):
+        if old_id in self._claims:
+            self._claims[old_id].claim_status = "superseded"
+            self._claims[old_id].supersedes = new_id
+
+    async def history(self, claim_id):
+        return []  # In-memory mode doesn't track history
+```
+
+### Evidence construction helpers (the opinionated part)
+
+```python
+def from_message(session_id: str, message_id: str, quote: str | None = None) -> EvidenceRef:
+    """Evidence from a chat message. The `quote` becomes EvidenceRef.detail."""
+    return EvidenceRef(kind="message", session_id=session_id, message_id=message_id, detail=quote)
+
+def from_tool_result(tool_call_id: str, summary: str | None = None) -> EvidenceRef:
+    """Evidence from a tool execution result. The `summary` becomes EvidenceRef.detail."""
+    return EvidenceRef(kind="tool_result", tool_call_id=tool_call_id, detail=summary)
+
+def from_user_statement(session_id: str, message_id: str) -> EvidenceRef:
+    """Evidence from an explicit user statement."""
+    return EvidenceRef(kind="user_statement", session_id=session_id, message_id=message_id)
+
+def from_artifact(artifact_id: str, path: str | None = None) -> EvidenceRef:
+    """Evidence from a produced artifact (file/report/output)."""
+    return EvidenceRef(kind="artifact", artifact_id=artifact_id, path=path)
+
+def from_file(path: str, repo: str | None = None, commit: str | None = None) -> EvidenceRef:
+    """Evidence from a file on disk or in a repo."""
+    return EvidenceRef(kind="file", path=path, repo=repo, commit_sha=commit)
+
+def from_url(url: str, fetched_at: float | None = None, content_hash: str | None = None) -> EvidenceRef:
+    """Evidence from a web resource."""
+    return EvidenceRef(kind="url", url=url, fetched_at=fetched_at, content_hash=content_hash)
+
+def from_model_inference(session_id: str, message_id: str, rationale: str) -> EvidenceRef:
+    """Evidence from model reasoning. The weakest kind — be honest about confidence."""
+    return EvidenceRef(kind="model_inference", session_id=session_id, message_id=message_id, detail=rationale)
+
+def from_human_assertion(user_id: str, asserted_at: float, detail: str | None = None) -> EvidenceRef:
+    """Evidence from a human's external assertion (e.g., 'I verified this manually')."""
+    return EvidenceRef(kind="human_assertion", id=user_id, fetched_at=asserted_at, detail=detail)
+```
+
+The helper name matches the `kind` value 1:1 — `from_X()` produces `EvidenceRef(kind="X")`. The naming makes the strength hierarchy visible: `from_file` and `from_artifact` (definitive) > `from_tool_result` (observed) > `from_url` (external, may rot without content_hash) > `from_message` and `from_user_statement` (situated in conversation) > `from_model_inference` (weakest — agent reasoning only).
+
+`from_human_assertion` is special: it's strong evidence (a human said so) but is only as good as the human's verification process. Use it sparingly and document the verification source.
+
+Eight helpers, eight kinds — see [ADR-0033](ADR-0033-unified-entity-state-model.md) §"EvidenceRef" for the canonical kind enumeration.
+
+### Reactive knowledge extraction (hook pattern)
+
+```python
+# Example: auto-extract knowledge from tool results
+async def extract_knowledge_hook(branch, message):
+    """Hook that fires on every ActionResponse to detect learnable facts."""
+    if not isinstance(message, ActionResponse):
+        return
+    # Custom extraction logic per tool
+    for result in message.content.results:
+        if result.tool_name == "read_file" and result.output:
+            # Application-specific: extract facts from file reads
+            pass
+
+# Registration
+branch.msgs._on_message_added.append(extract_knowledge_hook)
+```
+
+This is optional and application-specific. The substrate provides the
+storage; extraction logic lives in the application layer.
+
+### Configuration tiers
+
+```python
+# Tier 1: Library mode (default)
+branch = Branch(system="You are a researcher")
+# knowledge_store = NullKnowledgeStore() implicitly
+
+# Tier 2: Local persistence (Studio mode)
+from lionagi.knowledge import SQLiteKnowledgeStore
+branch = Branch(
+    system="...",
+    knowledge_store=SQLiteKnowledgeStore("~/.lionagi/knowledge.db"),
+)
+
+# Tier 3: Governed mode (KHive product)
+from khive import KHiveKnowledgeStore
+branch = Branch(
+    system="...",
+    knowledge_store=KHiveKnowledgeStore(
+        project="payments-platform",
+        require_approval_for=["verified"],  # Human-in-loop for verification
+    ),
+)
+```
+
+Each tier adds capability without changing the Branch API. The developer's
+code (`branch.learn(...)`, `branch.recall(...)`) is identical across tiers.
+
+### Worked example: knowledge accumulation across sessions
+
+A PR review agent accumulates codebase patterns over many runs:
+
+```python
+from lionagi import Branch, Session
+from lionagi.knowledge import SQLiteKnowledgeStore, from_file, from_tool_result, from_user_statement
+
+# Session 1, Monday: agent reviews PR #1842
+session = Session(
+    knowledge_store=SQLiteKnowledgeStore("~/.lionagi/knowledge/payments.db"),
+)
+branch = session.new_branch(system="You review pull requests for the payments service.")
+
+result = await branch.operate(
+    instruction="Review PR #1842, focus on transaction handling",
+    tools=[read_file_tool, github_pr_tool],
+)
+
+# Agent observes a pattern, records it
+claim_id = await branch.learn(
+    "payments-service uses the saga pattern for multi-step transactions",
+    evidence=[
+        from_file("src/sagas/payment_saga.py", repo="acme/payments", commit="abc123"),
+        from_tool_result("tc_pr1842_001", "GitHub PR shows saga.compensate() in error path"),
+    ],
+    domain="architecture",
+    tags=["saga", "transactions"],
+)
+# Persists to SQLite. claim_id is returned.
+
+# --- Session 2, Wednesday: different agent reviews PR #1851 ---
+session2 = Session(knowledge_store=SQLiteKnowledgeStore("~/.lionagi/knowledge/payments.db"))
+branch2 = session2.new_branch(system="You review pull requests for the payments service.")
+
+# Before reviewing, agent recalls prior knowledge
+context = await branch2.recall("What patterns does this codebase use for transactions?")
+# Returns: [Claim(text="payments-service uses the saga pattern...", confidence=1.0, status="observed", ...)]
+
+# Agent uses this context, doesn't need to re-discover the pattern
+
+# Later in the review, agent finds the new PR uses a different pattern
+new_claim_id = await branch2.learn(
+    "PR #1851 introduces 2PC alongside saga for cross-service transactions",
+    evidence=[
+        from_file("src/coordinators/two_phase.py", repo="acme/payments", commit="def456"),
+        from_tool_result("tc_pr1851_003", "PR description: explicitly mentions 2PC for inventory+payment"),
+    ],
+    domain="architecture",
+    tags=["2pc", "transactions"],
+)
+
+# --- Session 3, Friday: operator reviews knowledge ---
+# Operator opens Run detail for PR #1851 review
+# Knowledge lens shows: "PR #1851 introduces 2PC..."
+# Operator clicks "Verify" after checking the PR themselves
+await branch2.verify(new_claim_id, evidence=[
+    from_user_statement(session_id=str(session2.id), message_id=operator_msg_id),
+])
+# Status now: verified
+# Both claims persist; future agents querying "transactions" get both with appropriate status
+```
+
+This is the substrate in action: agents accumulate, agents recall, humans verify, the store persists across sessions. Every claim has evidence. Every transition is auditable.
+
+### What the protocol does NOT specify
+
+| Concern | Why excluded |
+|---------|-------------|
+| Storage schema | Data layer will change. Protocol is async interface only |
+| Embedding/vector search impl | Store implementation detail. MemoryStore uses substring; SQLiteStore might use FTS5; KHiveStore uses embeddings |
+| Deduplication logic | Application-specific. Some stores merge duplicates, others keep all |
+| Retention policy | Operational config, not protocol |
+| Access control | KHive product concern, not library concern |
+| Export format (PROV, OTel) | Export adapter layer, not substrate interface |
+| Graph relationships between claims | v2 concern. v1 claims are independent units |
+
+### Claim severity derivation
+
+Knowledge claims have their own severity, derived from `claim_status` and `confidence`. This is a parallel function to [ADR-0033](ADR-0033-unified-entity-state-model.md)'s `derive_severity()` for operational entities — they share the same (severity, tone) value space but compute from different inputs.
+
+```python
+def derive_claim_severity(claim: Claim) -> tuple[str, str]:
+    """Returns (severity, tone) for a knowledge claim."""
+
+    # Critical: nothing for claims in v1 (claims aren't operational failures)
+
+    # Warning: actively contested or unconfirmed-too-long
+    if claim.claim_status == "disputed":
+        return ("warning", "warning")
+    if claim.claim_status == "hypothesis" and claim.confidence < 0.5:
+        return ("warning", "warning")
+
+    # Info: pending validation, active observations
+    if claim.claim_status in ("observed", "inferred"):
+        return ("info", "info")
+    if claim.claim_status == "hypothesis":
+        return ("info", "neutral")
+
+    # Success: confirmed
+    if claim.claim_status == "verified":
+        return ("neutral", "success")
+
+    # Neutral: archived
+    if claim.claim_status == "superseded":
+        return ("neutral", "neutral")
+
+    return ("neutral", "neutral")
+```
+
+Both `derive_severity` (operational) and `derive_claim_severity` (knowledge) emit into the same Attention Queue ([ADR-0030](ADR-0030-attention-queue.md)) and use the same (severity, tone) values rendered by the same components ([ADR-0035](ADR-0035-design-system-and-component-library.md)).
+
+The functions stay separate because claims are NOT operational entities — `disputed` is not the same kind of severity as `failed`. Keeping them separate prevents semantic muddling.
+
+### Scope type semantics
+
+The `scope_type` and `scope_id` fields on Claim enable multi-level
+knowledge organization:
+
+| scope_type | scope_id example | Meaning |
+|-----------|------------------|---------|
+| `project` | `"payments-platform"` | Fact applies to the whole project |
+| `repo` | `"github.com/acme/payments"` | Fact about a specific repo |
+| `agent` | `"pr-reviewer"` | Fact the agent learned about itself/its domain |
+| `run` | `"run_abc123"` | Fact specific to one execution (ephemeral) |
+
+Scoping enables `recall()` to filter by relevance. A PR reviewer agent
+queries `scope_type=repo` knowledge, not all project-level facts.
+
+## Product Implications (Frontend)
+
+### Knowledge as lens (not nav section)
+
+Knowledge surfaces contextually on entity pages:
+
+| Page | Knowledge lens |
+|------|---------------|
+| Run detail | "What did this run learn?" — claims produced by this run |
+| Show detail | "What changed?" — claims created/superseded during this show |
+| Agent detail | "What does this agent know?" — claims scoped to this agent |
+| Attention item | "Why?" — evidence trail explaining the attention-worthy state |
+| Artifact detail | "What claims does this support?" — claims citing this artifact |
+
+### Claim rendering in the UI
+
+Claims render like status (same NormalizedState pattern from ADR-0033):
+
+```text
+observed · confidence 0.9 · from tool_result
+inferred · confidence 0.6 · from model_inference
+disputed · 2 conflicting evidence refs
+verified · by user · 2026-05-20
+```
+
+### Attention Queue integration
+
+Knowledge events that enter the Attention Queue:
+
+| Event | Severity | Action |
+|-------|----------|--------|
+| Claim disputed (was verified) | warning | "Review conflicting evidence" |
+| Low-confidence claim aged 7d+ without verification | info | "Verify or discard" |
+| Claim superseded by lower-confidence replacement | warning | "Review supersession" |
+| Knowledge write rejected (empty evidence) | info | "Agent attempted knowledge write without evidence" |
+
+### Search integration
+
+Claims are searchable via `GET /api/search?q=...&type=knowledge`.
+Each result carries claim_status, confidence, evidence count, and scope.
+
+## Consequences
+
+**Positive**
+
+- Zero-cost in library mode (NullStore is truly zero overhead)
+- Evidence-first is enforced at the API level, not by convention
+- Protocol is storage-agnostic — can migrate without changing user code
+- Follows established Branch manager pattern (5th manager, not addon)
+- Progressive disclosure: Null → Memory → SQLite → KHive
+- Frontend lens pattern avoids "empty graph browser" UX trap
+
+**Negative**
+
+- Adds a 5th manager to Branch (minimal complexity — NullStore is 10 LOC)
+- `recall()` quality depends entirely on store implementation (substring
+  match in MemoryStore is crude — acceptable for testing only)
+- No built-in deduplication in the protocol — stores must handle it
+- Graph relationships between claims are deferred to v2
+
+## Non-Goals
+
+Explicitly out of scope for v1; some may move into v2:
+
+- **Graph relationships between claims** (claim → entails → claim, claim → contradicts → claim). Claims are independent units in v1. Edges are v2.
+- **Automated extraction from all messages** (e.g., LLM-driven claim mining from any tool result). Too noisy; v1 is opt-in via `branch.learn()` calls.
+- **Cross-project knowledge sharing**. Scope isolation first. Sharing is a governed feature requiring access control, which lives in KHive product mode, not the library protocol.
+- **Inference / reasoning over claims**. The substrate stores knowledge; the agent reasons. We don't ship a rules engine over claims.
+- **Structured claim schemas** (typed templates beyond free-text). Free-text first; structure emerges from observed usage patterns, then becomes a v2 capability.
+- **Embedding model selection UI**. Implementation detail of the store. The user configures store, not internals.
+- **Claim deletion**. Knowledge is append-only with lifecycle (dispute, supersede). No `branch.forget()` method.
+- **Knowledge import/export across stores**. PROV/OTel export is v2. Import needs deduplication logic not yet designed.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Knowledge as separate service (not on Branch) | Breaks the manager pattern; requires separate lifecycle management; harder to auto-populate session context |
+| Mandatory store configuration | Violates zero-config in library mode; adoption barrier |
+| Untyped evidence (just a string) | Defeats the auditability thesis; can't render evidence trails in UI |
+| Claims without lifecycle | No way to evolve knowledge; facts become stale without mechanism to dispute/supersede |
+| Full graph DB protocol (nodes + edges + traversal) | Over-specified for v1; locks in storage assumptions; most use cases are claim + retrieval |
+| Auto-extraction from all messages | Too magical; generates low-quality claims; better as opt-in hook pattern |
+
+## References
+
+- [ADR-0028](ADR-0028-status-reason-model.md) — Status Reason Model (parallel concept: structured reasons with evidence)
+- [ADR-0029](ADR-0029-artifact-contract.md) — Artifact Contract (artifacts as evidence)
+- [ADR-0030](ADR-0030-attention-queue.md) — Attention Queue (disputed/low-confidence claims surface here)
+- [ADR-0033](ADR-0033-unified-entity-state-model.md) — Unified Entity State Model (canonical EvidenceRef definition)
+- [ADR-0034](ADR-0034-frontend-data-and-state-architecture.md) — Frontend Data & State Architecture (knowledge.* SSE events, knowledge query keys)
+- [ADR-0035](ADR-0035-design-system-and-component-library.md) — Design System & Component Library (KnowledgeLens, ClaimCard, ClaimStatusBadge components)
+- 06.md §7: Evidence-first policy (source design)
+- 06.md §3: Knowledge as lens, not destination (UI placement decision)
+- Branch architecture: 4-manager facade → 5-manager facade with KnowledgeStore
+- W3C PROV (future export target, not v1 schema)
+- Issue #1175: Knowledge substrate first-class in lionagi

--- a/docs/adrs/ADR-0039-knowledge-substrate-minimal-interface.md
+++ b/docs/adrs/ADR-0039-knowledge-substrate-minimal-interface.md
@@ -4,7 +4,6 @@
 **Date**: 2026-05-26
 **Depends on**: [ADR-0033](ADR-0033-unified-entity-state-model.md) (shared EvidenceRef definition)
 **Related**: [ADR-0028](ADR-0028-status-reason-model.md), [ADR-0029](ADR-0029-artifact-contract.md), [ADR-0030](ADR-0030-attention-queue.md), [ADR-0034](ADR-0034-frontend-data-and-state-architecture.md), [ADR-0035](ADR-0035-design-system-and-component-library.md)
-**Consumed by**: KHive v1 product (governed memory and evidence layer)
 
 ## Context
 
@@ -21,15 +20,6 @@ responses) but no structured *knowledge*. The gap:
 An agent that reviews 50 PRs learns nothing persistent. The next
 session starts cold. The operator can't ask "what has the agent learned
 about our codebase?" because there's no substrate to hold the answer.
-
-### The product thesis
-
-> KHive is the governed memory and evidence layer for internal agent
-> platforms.
-
-The knowledge substrate is what makes "governed memory" concrete. Without
-it, KHive is an observability dashboard (commodity). With it, KHive
-captures *what agents learn*, not just what they did.
 
 ### Design constraints
 
@@ -60,7 +50,7 @@ class KnowledgeStore(Protocol):
       - NullKnowledgeStore: no-op (library default, zero overhead)
       - MemoryKnowledgeStore: in-process dict (testing, short-lived scripts)
       - SQLiteKnowledgeStore: local file (Studio mode)
-      - KHiveKnowledgeStore: governed remote (commercial product)
+      - RemoteKnowledgeStore: governed remote store
     """
 
     async def write_claim(
@@ -458,16 +448,6 @@ branch = Branch(
     system="...",
     knowledge_store=SQLiteKnowledgeStore("~/.lionagi/knowledge.db"),
 )
-
-# Tier 3: Governed mode (KHive product)
-from khive import KHiveKnowledgeStore
-branch = Branch(
-    system="...",
-    knowledge_store=KHiveKnowledgeStore(
-        project="payments-platform",
-        require_approval_for=["verified"],  # Human-in-loop for verification
-    ),
-)
 ```
 
 Each tier adds capability without changing the Branch API. The developer's
@@ -543,10 +523,10 @@ This is the substrate in action: agents accumulate, agents recall, humans verify
 | Concern | Why excluded |
 |---------|-------------|
 | Storage schema | Data layer will change. Protocol is async interface only |
-| Embedding/vector search impl | Store implementation detail. MemoryStore uses substring; SQLiteStore might use FTS5; KHiveStore uses embeddings |
+| Embedding/vector search impl | Store implementation detail. MemoryStore uses substring; SQLiteStore might use FTS5; governed stores use embeddings |
 | Deduplication logic | Application-specific. Some stores merge duplicates, others keep all |
 | Retention policy | Operational config, not protocol |
-| Access control | KHive product concern, not library concern |
+| Access control | Store implementation concern, not protocol concern |
 | Export format (PROV, OTel) | Export adapter layer, not substrate interface |
 | Graph relationships between claims | v2 concern. v1 claims are independent units |
 
@@ -651,7 +631,7 @@ Each result carries claim_status, confidence, evidence count, and scope.
 - Evidence-first is enforced at the API level, not by convention
 - Protocol is storage-agnostic — can migrate without changing user code
 - Follows established Branch manager pattern (5th manager, not addon)
-- Progressive disclosure: Null → Memory → SQLite → KHive
+- Progressive disclosure: Null → Memory → SQLite → governed remote store
 - Frontend lens pattern avoids "empty graph browser" UX trap
 
 **Negative**
@@ -668,7 +648,7 @@ Explicitly out of scope for v1; some may move into v2:
 
 - **Graph relationships between claims** (claim → entails → claim, claim → contradicts → claim). Claims are independent units in v1. Edges are v2.
 - **Automated extraction from all messages** (e.g., LLM-driven claim mining from any tool result). Too noisy; v1 is opt-in via `branch.learn()` calls.
-- **Cross-project knowledge sharing**. Scope isolation first. Sharing is a governed feature requiring access control, which lives in KHive product mode, not the library protocol.
+- **Cross-project knowledge sharing**. Scope isolation first. Sharing is a governed feature requiring access control; it is deferred to a future extension of the store protocol.
 - **Inference / reasoning over claims**. The substrate stores knowledge; the agent reasons. We don't ship a rules engine over claims.
 - **Structured claim schemas** (typed templates beyond free-text). Free-text first; structure emerges from observed usage patterns, then becomes a v2 capability.
 - **Embedding model selection UI**. Implementation detail of the store. The user configures store, not internals.

--- a/docs/adrs/ADR-0041-immutable-evidence-nodes.md
+++ b/docs/adrs/ADR-0041-immutable-evidence-nodes.md
@@ -1,0 +1,560 @@
+# ADR-0041: Immutable Evidence Nodes
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Depends on**: [ADR-0033](ADR-0033-unified-entity-state-model.md) (EvidenceRef definition), [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) (Claim, KnowledgeStore protocol)
+**Related**: [ADR-0042](ADR-0042-task-certificate.md), [ADR-0049](ADR-0049-log-tier-governance.md), [ADR-0028](ADR-0028-status-reason-model.md), [ADR-0029](ADR-0029-artifact-contract.md)
+
+## Context
+
+lionagi's `DataLogger` writes `Log` entries on each tool call and session event. Those entries are
+plain append-only dicts: they record what happened, but nothing prevents the session process from
+mutating or overwriting them after the fact. An agent running with write access to its own log
+directory can rewrite history. More subtly, the `EvidenceRef` type defined in
+[ADR-0033](ADR-0033-unified-entity-state-model.md) is a Pydantic model with no hashing. A
+`Claim` from [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) is append-only in its
+lifecycle state machine (observed → verified → disputed → superseded) but that ordering is
+enforced only by application logic — there is no cryptographic link between one claim and the next
+that would detect out-of-order insertion or silent replacement.
+
+The concrete failure scenario: a governed agent is authorized to write files under a restricted
+directory. It invokes a file-write tool, produces an `ActionResponse`, and that response enters
+the DataLogger. If the agent can later modify that log entry — or if a future store implementation
+silently overwrites on a key collision — the audit record no longer reflects what actually executed.
+This matters the moment anyone asks "what did the agent do and how do we know?"
+
+The cross-cutting principle at stake here is **"Evidence is first-class, not logs"** (principle #2
+of this ADR set). Logs are operational: they tell you what happened at runtime. Evidence carries
+the policy version, gate results, and authorization context active *at execution time*. A log entry
+becomes evidence only when it is structurally impossible to alter it after the fact.
+
+### The applicable design pattern
+
+prior research addresses this with a hash-chain pattern: every evidence node includes a
+`chain_hash = SHA256(payload_hash || prev_chain_hash)`. Appending a new node produces a new
+`chain_hash` that depends on every node before it; tampering with any earlier node invalidates all
+subsequent `chain_hash` values. prior research adds the supersession pattern: errors are
+corrected by inserting a new node with `supersedes_id` pointing backward, leaving the original
+untouched. prior research introduces `_sensitive_fields` as a `ClassVar[set[str]]`: fields
+excluded from the hash and from serialized output (raw tool inputs may contain secrets that should
+not appear in audit exports). These three patterns compose cleanly, and the translation to lionagi
+requires no new infrastructure.
+
+### Why lionagi needs this
+
+[ADR-0042](ADR-0042-task-certificate.md) (Task Certificate) will sign a proof that a task
+completed with specific evidence. That signature is worthless if the evidence it covers can be
+modified after signing. [ADR-0049](ADR-0049-log-tier-governance.md) (Log Tier Governance)
+classifies records as MUTABLE, PROTECTED, or IMMUTABLE — but tier classification is a policy;
+`ImmutableEvidenceNode` is the mechanism that makes the IMMUTABLE tier structurally enforceable at
+the Python level, before any storage layer is involved.
+
+## Decision
+
+Introduce `ImmutableEvidenceNode` as the base class for all evidence-grade records in lionagi.
+`EvidenceRef` (ADR-0033) and `Claim` (ADR-0039) acquire these properties via mixin or subclass.
+DB-level enforcement is explicitly deferred to KHive v1 (see Non-Goals).
+
+### 1. Core data model
+
+```python
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, ClassVar
+from uuid import UUID
+
+from pydantic import ConfigDict, Field
+
+from lionagi.protocols.generic.element import Element
+
+
+def _sha256_hex(data: str) -> str:
+    return hashlib.sha256(data.encode("utf-8")).hexdigest()
+
+
+def _canonical_json(obj: dict) -> str:
+    """Deterministic JSON serialization for hashing."""
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), default=str)
+
+
+#: Sentinel for the first node in a chain (no predecessor).
+GENESIS_HASH: str = "0" * 64
+
+
+class ImmutableEvidenceNode(Element):
+    """Base for evidence-grade records that must be tamper-evident.
+
+    Hash semantics
+    --------------
+    content_hash : SHA256 over domain fields only (excludes _sensitive_fields,
+        supersedes_id, chain hashes).  Used for deduplication — two nodes with
+        identical domain content produce the same content_hash.
+
+    chain_hash : SHA256(payload_hash || prev_chain_hash).  The payload_hash is
+        SHA256 over domain fields PLUS supersedes_id (so the supersession link
+        is covered), still excluding _sensitive_fields.  chain_hash binds each
+        node to its predecessor; any mutation of a node or its position in the
+        chain invalidates all chain_hash values that follow.
+
+    Immutability contract
+    ---------------------
+    Nodes are sealed during Pydantic model initialization.  The fields node_id, created_at,
+    content_hash, chain_hash, prev_chain_hash, and supersedes_id MUST NOT be
+    mutated after model_post_init.  Pydantic's frozen model configuration
+    enforces this contract at the Element layer.
+
+    Sensitive fields
+    ----------------
+    Subclasses declare _sensitive_fields: ClassVar[set[str]] to name fields
+    that must be excluded from content_hash and from serialization output.
+    This prevents raw tool inputs containing secrets from appearing in
+    audit exports or hash computations.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    # --- Chain bookkeeping (set by seal()) ---
+    content_hash: str = Field(default="", frozen=True)
+    chain_hash: str = Field(default="", frozen=True)
+    prev_chain_hash: str = Field(default=GENESIS_HASH, frozen=True)
+
+    # --- Supersession (backward pointer only) ---
+    supersedes_id: UUID | None = Field(default=None, frozen=True)
+
+    # --- Subclass contract ---
+    _sensitive_fields: ClassVar[set[str]] = set()
+
+    @property
+    def node_id(self) -> UUID:
+        """Compatibility alias for Element.id in evidence-oriented APIs."""
+        return self.id
+
+    def model_post_init(self, __context: Any) -> None:
+        """Seal new nodes while preserving stored hashes on loaded nodes."""
+        if not self.content_hash or not self.chain_hash:
+            content_hash, chain_hash = self._compute_hashes()
+            object.__setattr__(self, "content_hash", self.content_hash or content_hash)
+            object.__setattr__(self, "chain_hash", self.chain_hash or chain_hash)
+
+    # ------------------------------------------------------------------
+    # Internal hashing
+    # ------------------------------------------------------------------
+
+    def _domain_dict(self, *, include_supersedes: bool) -> dict:
+        """Return serialisable dict of domain fields, excluding sensitive ones
+        and the chain/hash bookkeeping fields managed by this base class."""
+        base_excludes = {
+            "id",
+            "created_at",
+            "metadata",
+            "node_metadata",
+            "content_hash",
+            "chain_hash",
+            "prev_chain_hash",
+            "supersedes_id",
+        } | self._sensitive_fields
+
+        result = self.to_dict(mode="db")
+        for f_name in base_excludes:
+            result.pop(f_name, None)
+
+        if include_supersedes and self.supersedes_id is not None:
+            result["_supersedes_id"] = str(self.supersedes_id)
+
+        return result
+
+    def _compute_hashes(self) -> tuple[str, str]:
+        """Compute content_hash and chain_hash from canonical Element output."""
+        domain = self._domain_dict(include_supersedes=False)
+        content_hash = _sha256_hex(_canonical_json(domain))
+
+        payload = self._domain_dict(include_supersedes=True)
+        payload_hash = _sha256_hex(_canonical_json(payload))
+        chain_hash = _sha256_hex(payload_hash + self.prev_chain_hash)
+        return content_hash, chain_hash
+
+    # ------------------------------------------------------------------
+    # Verification
+    # ------------------------------------------------------------------
+
+    def verify_content(self) -> bool:
+        """Return True if domain fields match the stored content_hash.
+
+        A False return means either the instance was mutated after construction
+        or the stored hash was corrupted.
+        """
+        expected, _ = self._compute_hashes()
+        return self.content_hash == expected
+
+    def verify_chain_link(self) -> bool:
+        """Return True if chain_hash is consistent with current domain fields
+        and prev_chain_hash.
+
+        This checks a *single* link.  Full chain verification requires
+        iterating all nodes in order and calling this method on each, passing
+        the predecessor's chain_hash as prev_chain_hash.
+        """
+        _, expected = self._compute_hashes()
+        return self.chain_hash == expected
+
+    # ------------------------------------------------------------------
+    # Supersession
+    # ------------------------------------------------------------------
+
+    def supersede(self, **updated_fields) -> "ImmutableEvidenceNode":
+        """Return a new node of the same subclass with corrected fields.
+
+        The new node's supersedes_id points back to this node.  This node
+        is never modified.  The caller is responsible for persisting both
+        nodes; no storage interaction occurs here.
+
+        The new node starts a fresh chain link: its prev_chain_hash is
+        set to this node's chain_hash.
+        """
+        init_kwargs = self.model_dump(
+            mode="python",
+            exclude={"id", "created_at", "content_hash", "chain_hash"},
+        )
+
+        init_kwargs.update(updated_fields)
+        init_kwargs["supersedes_id"] = self.id
+        init_kwargs["prev_chain_hash"] = self.chain_hash
+
+        return type(self)(**init_kwargs)
+
+    # ------------------------------------------------------------------
+    # Safe serialization
+    # ------------------------------------------------------------------
+
+    def to_audit_dict(self) -> dict:
+        """Return a dict safe for export: sensitive fields are absent.
+
+        Includes chain bookkeeping fields so that an external verifier can
+        reconstruct and check the chain without access to sensitive data.
+        """
+        result = self.to_dict(mode="json")
+        result["node_id"] = result.pop("id")
+        result["created_at"] = self.created_datetime.isoformat()
+        result.pop("metadata", None)
+        for f_name in self._sensitive_fields:
+            result.pop(f_name, None)
+        return result
+```
+
+### 2. Chain bootstrap — the genesis node
+
+The first node in any chain has no predecessor.  Its `prev_chain_hash` is set to the sentinel
+`GENESIS_HASH = "0" * 64`.  This value is fixed and publicly known; it is not a secret.  Its
+purpose is to anchor the chain: any subsequent node's `chain_hash` depends on this sentinel,
+so the first node is as tamper-evident as any later one.
+
+When a subsequent node is appended, it receives `prev_chain_hash = predecessor.chain_hash`.
+A chain of N nodes can be verified in O(N) by iterating in insertion order and calling
+`verify_chain_link()` on each node.
+
+```python
+from lionagi.protocols.generic.pile import Pile
+
+
+def verify_chain(nodes: Pile[ImmutableEvidenceNode]) -> bool:
+    """Verify integrity of an ordered chain of nodes.
+
+    Returns True iff every node's chain_hash is consistent with its
+    domain fields and its predecessor's chain_hash.  The first node
+    must have prev_chain_hash == GENESIS_HASH.
+    """
+    expected_prev = GENESIS_HASH
+    for node in nodes:
+        if node.prev_chain_hash != expected_prev:
+            return False
+        if not node.verify_chain_link():
+            return False
+        expected_prev = node.chain_hash
+    return True
+```
+
+### 3. How EvidenceRef and Claim acquire these properties
+
+**EvidenceRef** (ADR-0033) is currently a Pydantic model.  It acquires hash-chain properties by
+inheriting from `ImmutableEvidenceNode` via a thin adapter mixin.  Domain fields (`kind`,
+`ref`, `note`, `timestamp`) participate in `content_hash` as before; any field declared in
+`_sensitive_fields` is excluded.
+
+```python
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+from pydantic import Field
+
+EvidenceKind = Literal[
+    "message", "user_statement", "tool_result", "artifact",
+    "url", "file", "model_inference", "human_assertion",
+]
+
+
+class EvidenceRef(ImmutableEvidenceNode):
+    """A single structured evidence reference, tamper-evident.
+
+    Corresponds to the EvidenceRef defined in ADR-0033; extends it with
+    chain-hash integrity.
+    """
+
+    kind: EvidenceKind = "tool_result"
+    ref: str = ""           # URI, message ID, artifact ID, etc.
+    note: str = ""          # Human-readable annotation
+    # Raw input is excluded from hashes and audit exports because it may
+    # contain API keys, PII, or other secrets passed to a tool.
+    raw_input: dict | None = Field(default=None, exclude=True)
+
+    _sensitive_fields: ClassVar[set[str]] = {"raw_input"}
+```
+
+**Claim** (ADR-0039) follows the same pattern.  The claim's evidence list becomes a list of
+`EvidenceRef` node IDs rather than inline objects; this keeps the Claim node's own hash stable
+even as the referenced evidence grows.
+
+```python
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+from pydantic import Field
+
+from lionagi.protocols.generic.pile import Pile
+
+ClaimStatus = Literal["observed", "verified", "disputed", "superseded"]
+
+
+class Claim(ImmutableEvidenceNode):
+    """A durable learned fact backed by at least one EvidenceRef node.
+
+    The lifecycle status field participates in content_hash, so a status
+    transition produces a new node (via supersede()) rather than mutating
+    the existing one.  This preserves the full status history in the chain.
+    """
+
+    subject: str = ""           # Entity the claim is about
+    predicate: str = ""         # Relation or property
+    value: str = ""             # Asserted value
+    status: ClaimStatus = "observed"
+    evidence: Pile[EvidenceRef] = Field(
+        default_factory=lambda: Pile(item_type={EvidenceRef}, strict_type=True)
+    )
+    # The prompt or instruction that caused this claim to be formed.
+    # Excluded because it may contain sensitive context from the session.
+    source_prompt: str | None = Field(default=None, exclude=True)
+
+    _sensitive_fields: ClassVar[set[str]] = {"source_prompt"}
+
+    def transition(self, new_status: ClaimStatus) -> "Claim":
+        """Return a new Claim node with updated status (supersedes this one).
+
+        Valid transitions follow the lifecycle in ADR-0039:
+          observed → verified | disputed
+          verified → disputed | superseded
+          disputed → verified | superseded
+          superseded → (terminal)
+        """
+        _valid: dict[ClaimStatus, set[ClaimStatus]] = {
+            "observed": {"verified", "disputed"},
+            "verified": {"disputed", "superseded"},
+            "disputed": {"verified", "superseded"},
+            "superseded": set(),
+        }
+        if new_status not in _valid[self.status]:
+            raise ValueError(
+                f"Cannot transition Claim from {self.status!r} to {new_status!r}"
+            )
+        return self.supersede(status=new_status)
+```
+
+### 4. Application-layer enforcement vs. DB-layer enforcement
+
+`ImmutableEvidenceNode` provides Python-level tamper evidence: the hashes are computed at
+construction and can be verified at any time.  If application code mutates an attribute after
+construction, `verify_content()` will return `False` on the next check.
+
+DB-level triggers that block `UPDATE` and `DELETE` on the underlying table are a **v2 / KHive
+concern**, not a v1 library concern.  The reasons:
+
+1. lionagi is a library; it ships no migrations and makes no assumptions about the storage
+   backend.  Different deployments use SQLite, Postgres, or in-process dicts.
+2. Trigger DDL is storage-specific.  An in-process `MemoryKnowledgeStore` has no concept of
+   a DB trigger.
+3. The Python-level guarantee is sufficient for library mode: evidence is tamper-*evident* (you
+   can detect mutation) even if not tamper-*proof* (a sufficiently privileged process could still
+   modify storage directly).  Tamper-proof enforcement requires the governed storage layer that
+   KHive will provide.
+
+The `KnowledgeStore` protocol (ADR-0039) should document that a conforming implementation MUST
+persist `ImmutableEvidenceNode` instances without modifying their `content_hash`, `chain_hash`,
+or `prev_chain_hash` fields.  This is a protocol contract, not a compiled guarantee — which is
+the correct level of enforcement for a library.
+
+### 5. Chain ownership and session scope
+
+Each `Branch` session maintains its own evidence chain.  Chain continuity is the responsibility
+of the component that creates new nodes:
+
+```python
+from pydantic import ConfigDict, Field
+
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+from lionagi.session.branch import Branch
+
+
+class EvidenceChain(Element):
+    """Lightweight in-process chain accumulator.
+
+    The KnowledgeStore implementation is responsible for persisting nodes
+    and for reconstructing the chain_tip on reload. Branch integration uses
+    the existing managers: messages via branch.msgs, actions via branch.acts,
+    models via branch.mdls, and audit output via branch._log_manager.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
+
+    tip_hash: str = GENESIS_HASH
+    nodes: Pile[ImmutableEvidenceNode] = Field(
+        default_factory=lambda: Pile(
+            item_type={ImmutableEvidenceNode},
+            strict_type=False,
+        )
+    )
+
+    @classmethod
+    def for_branch(
+        cls,
+        branch: Branch,
+        *,
+        tip_hash: str = GENESIS_HASH,
+    ) -> "EvidenceChain":
+        """Create a branch-scoped chain without adding a parallel manager."""
+        chain = cls(tip_hash=tip_hash)
+        branch.metadata["evidence_chain_id"] = str(chain.id)
+        branch.metadata["evidence_chain_tip"] = tip_hash
+        return chain
+
+    def append(
+        self,
+        node_cls: type[ImmutableEvidenceNode],
+        *,
+        branch: Branch | None = None,
+        **kwargs,
+    ) -> ImmutableEvidenceNode:
+        """Construct and chain a new node, returning the sealed instance."""
+        node = node_cls(prev_chain_hash=self.tip_hash, **kwargs)
+        self.tip_hash = node.chain_hash
+        self.nodes.include(node)
+
+        if branch is not None:
+            branch.metadata["evidence_chain_tip"] = self.tip_hash
+            branch._log_manager.log(
+                {
+                    "event": "evidence_node_appended",
+                    "evidence": node.to_audit_dict(),
+                }
+            )
+
+        return node
+
+    def verify(self) -> bool:
+        """Verify all accumulated nodes form a valid chain."""
+        return verify_chain(self.nodes)
+```
+
+A `KnowledgeStore` implementation that persists nodes reloads `tip_hash` from the last stored
+node's `chain_hash`.  If the store is empty, `tip_hash` starts at `GENESIS_HASH`.
+
+## Consequences
+
+**Positive**
+
+- Every `EvidenceRef` and `Claim` node carries a cryptographic fingerprint that proves its
+  content has not changed since construction.  An external auditor can verify the chain with
+  no access to the storage backend's internals.
+- `content_hash` enables deduplication: two tool-result nodes recording the same output will
+  produce the same `content_hash`, allowing stores to avoid redundant insertions without
+  suppressing the chain entry.
+- `_sensitive_fields` prevents raw tool inputs (API keys, user PII) from appearing in audit
+  exports or hash computations, separating operational safety from audit correctness.
+- Supersession via `supersede()` preserves full history.  A corrected `Claim` does not destroy
+  the original — it chains a new node that points back.  [ADR-0042](ADR-0042-task-certificate.md)
+  can sign over a chain tip with confidence that the underlying evidence is traceable.
+- The `EvidenceChain` accumulator is zero-dependency: it works in-process with no storage,
+  making it suitable for testing and for Library mode.
+
+**Negative**
+
+- SHA-256 hashing at construction adds roughly 0.1–0.5 ms per node, depending on domain field
+  size.  This is acceptable for evidence-grade records (tool calls, claims) which are far
+  less frequent than log events.  The DataLogger's high-volume `Log` entries are explicitly
+  out of scope (see Non-Goals and [ADR-0049](ADR-0049-log-tier-governance.md)).
+- Implementing `verify_chain()` on a loaded store requires fetching nodes in insertion order.
+  Stores that do not preserve insertion order (e.g., unordered key-value stores) cannot support
+  chain verification without additional ordering metadata.
+- Because status transitions on `Claim` produce new nodes rather than mutating the existing one,
+  a store accumulates one node per lifecycle transition.  For long-lived claims that go through
+  many transitions this adds storage overhead.  In practice the lifecycle has four states, so
+  the maximum per-claim node count is four.
+- The Python-level immutability contract relies on discipline: nothing prevents application code
+  from assigning to fields post-construction in the current `dataclass` implementation.  A v2
+  hardening pass should add `__setattr__` protection or switch to `frozen=True` where Pydantic
+  compatibility allows.
+
+## Non-Goals
+
+Explicitly out of scope for this ADR:
+
+- **Full Merkle trees**: Not needed for v1.  A linear hash chain suffices to detect insertion,
+  deletion, or mutation of any single node.  Merkle trees enable efficient proofs over large
+  subsets; that capability belongs to a future KHive indexing ADR.
+- **Cryptographic signing**: Digital signatures (ECDSA, Ed25519) over chain tips or individual
+  nodes are covered by [ADR-0042](ADR-0042-task-certificate.md) (Task Certificate).  This ADR
+  establishes the hash structure that signing will cover, not the signing mechanism itself.
+- **Distributed ledger semantics**: Blockchain-style consensus, fork resolution, and distributed
+  chain synchronization are not relevant to the single-process or single-tenant deployment
+  scenarios lionagi targets in v1.
+- **DB-level triggers**: PostgreSQL `BEFORE UPDATE` / `BEFORE DELETE` triggers that enforce
+  immutability at the storage layer are a KHive v1 concern.  The `KnowledgeStore` protocol
+  contract documents the expectation; enforcement is left to governed store implementations.
+- **Multi-tenant chain isolation**: Ensuring that chain nodes from different tenants cannot be
+  interleaved requires tenant-scoped chain roots and storage-layer row security.  This is KHive
+  territory (see also ADR-0039's note on multi-tenant concerns).
+- **Retroactive chain repair**: If a chain is found to be invalid (e.g., due to a store bug),
+  this ADR does not define a repair protocol.  Invalid chains should be flagged and escalated;
+  repair requires operator intervention.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Plain DataLogger entries (append-only dict list) | No tamper detection. An agent process with file-system write access can overwrite log entries silently. `verify_content()` would never be called because there is no hash to verify against. |
+| DB-level triggers only, no application-layer hashes | Not portable: triggers are Postgres-specific and cannot protect in-process stores (SQLite, MemoryStore). Library mode would have no evidence integrity guarantees. |
+| Timestamp-only ordering (no hash chain) | Timestamps can be spoofed or back-dated. They establish ordering only if the clock is trusted. A hash chain establishes ordering independently of wall time. |
+| Full Merkle tree from the start | Provides efficient subset proofs but requires a tree-construction algorithm, a root-hash management layer, and more complex verification. The operational benefit over a linear chain is negligible at v1 scale (thousands of nodes per session, not billions). |
+| Event sourcing (append-only event log, derived state) | Provides complete history but requires projections for current state, event schema versioning, and substantial infrastructure investment. The supersession pattern achieves the correction requirement with far less complexity. |
+| Bidirectional supersession pointers (`superseded_by_id` on original) | Requires either a two-phase write (insert new node, then update original) or a transaction. Backward-only `supersedes_id` allows a single atomic INSERT with no mutation of the original node, which aligns with the immutability contract. prior research makes this decision for the same reason. |
+
+## References
+
+- [ADR-0033](ADR-0033-unified-entity-state-model.md) — defines `EvidenceRef` (8 kinds) and `NormalizedState`; this ADR adds hash-chain integrity to `EvidenceRef`
+- [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) — defines `Claim` and `KnowledgeStore` protocol; this ADR adds hash-chain integrity to `Claim`
+- [ADR-0042](ADR-0042-task-certificate.md) — Task Certificate signs over a chain tip; depends on `ImmutableEvidenceNode.chain_hash` being stable
+- [ADR-0049](ADR-0049-log-tier-governance.md) — Log Tier Governance classifies records as MUTABLE / PROTECTED / IMMUTABLE; `ImmutableEvidenceNode` is the mechanism backing the IMMUTABLE tier
+- [ADR-0028](ADR-0028-status-reason-model.md) — StatusReason model; evidence nodes may carry status reasons as domain fields
+- [ADR-0029](ADR-0029-artifact-contract.md) — Artifact contract; artifacts referenced by `EvidenceRef(kind="artifact")` benefit from chain provenance
+- prior governance research `01_design/006-evidence-chain-cep/ADR-006-evidence-chain-cep.md` — source pattern for hash-chained evidence; D1 (chain hash formula), D2 (backward-only supersession)
+- prior governance research `01_design/003-immutability/ADR-003-immutability.md` — source pattern for insert-only semantics, `_allowed_update_fields`, supersession over mutation
+- prior governance research `01_design/002-entity/ADR-002-entity.md` — source pattern for dual hashing (`content_hash` + `integrity_hash`) and `_sensitive_fields` ClassVar
+- NIST FIPS 180-4 — SHA-256 specification

--- a/docs/adrs/ADR-0041-immutable-evidence-nodes.md
+++ b/docs/adrs/ADR-0041-immutable-evidence-nodes.md
@@ -1,6 +1,6 @@
 # ADR-0041: Immutable Evidence Nodes
 
-**Status**: Proposed
+**Status**: proposed
 **Date**: 2026-05-26
 **Depends on**: [ADR-0033](ADR-0033-unified-entity-state-model.md) (EvidenceRef definition), [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) (Claim, KnowledgeStore protocol)
 **Related**: [ADR-0042](ADR-0042-task-certificate.md), [ADR-0049](ADR-0049-log-tier-governance.md), [ADR-0028](ADR-0028-status-reason-model.md), [ADR-0029](ADR-0029-artifact-contract.md)

--- a/docs/adrs/ADR-0041-immutable-evidence-nodes.md
+++ b/docs/adrs/ADR-0041-immutable-evidence-nodes.md
@@ -53,7 +53,7 @@ the Python level, before any storage layer is involved.
 
 Introduce `ImmutableEvidenceNode` as the base class for all evidence-grade records in lionagi.
 `EvidenceRef` (ADR-0033) and `Claim` (ADR-0039) acquire these properties via mixin or subclass.
-DB-level enforcement is explicitly deferred to KHive v1 (see Non-Goals).
+DB-level enforcement is explicitly deferred to the storage layer (see Non-Goals).
 
 ### 1. Core data model
 
@@ -383,8 +383,8 @@ class Claim(ImmutableEvidenceNode):
 construction and can be verified at any time.  If application code mutates an attribute after
 construction, `verify_content()` will return `False` on the next check.
 
-DB-level triggers that block `UPDATE` and `DELETE` on the underlying table are a **v2 / KHive
-concern**, not a v1 library concern.  The reasons:
+DB-level triggers that block `UPDATE` and `DELETE` on the underlying table are a storage-layer
+concern, not a library concern.  The reasons:
 
 1. lionagi is a library; it ships no migrations and makes no assumptions about the storage
    backend.  Different deployments use SQLite, Postgres, or in-process dicts.
@@ -392,8 +392,8 @@ concern**, not a v1 library concern.  The reasons:
    a DB trigger.
 3. The Python-level guarantee is sufficient for library mode: evidence is tamper-*evident* (you
    can detect mutation) even if not tamper-*proof* (a sufficiently privileged process could still
-   modify storage directly).  Tamper-proof enforcement requires the governed storage layer that
-   KHive will provide.
+   modify storage directly).  Tamper-proof enforcement requires a governed storage layer with
+   DB-level immutability.
 
 The `KnowledgeStore` protocol (ADR-0039) should document that a conforming implementation MUST
 persist `ImmutableEvidenceNode` instances without modifying their `content_hash`, `chain_hash`,
@@ -518,7 +518,7 @@ Explicitly out of scope for this ADR:
 
 - **Full Merkle trees**: Not needed for v1.  A linear hash chain suffices to detect insertion,
   deletion, or mutation of any single node.  Merkle trees enable efficient proofs over large
-  subsets; that capability belongs to a future KHive indexing ADR.
+  subsets; that capability belongs to a future indexing ADR.
 - **Cryptographic signing**: Digital signatures (ECDSA, Ed25519) over chain tips or individual
   nodes are covered by [ADR-0042](ADR-0042-task-certificate.md) (Task Certificate).  This ADR
   establishes the hash structure that signing will cover, not the signing mechanism itself.
@@ -526,11 +526,7 @@ Explicitly out of scope for this ADR:
   chain synchronization are not relevant to the single-process or single-tenant deployment
   scenarios lionagi targets in v1.
 - **DB-level triggers**: PostgreSQL `BEFORE UPDATE` / `BEFORE DELETE` triggers that enforce
-  immutability at the storage layer are a KHive v1 concern.  The `KnowledgeStore` protocol
-  contract documents the expectation; enforcement is left to governed store implementations.
-- **Multi-tenant chain isolation**: Ensuring that chain nodes from different tenants cannot be
-  interleaved requires tenant-scoped chain roots and storage-layer row security.  This is KHive
-  territory (see also ADR-0039's note on multi-tenant concerns).
+  immutability at the storage layer are left to store implementations.
 - **Retroactive chain repair**: If a chain is found to be invalid (e.g., due to a store bug),
   this ADR does not define a repair protocol.  Invalid chains should be flagged and escalated;
   repair requires operator intervention.

--- a/docs/adrs/ADR-0042-task-certificate.md
+++ b/docs/adrs/ADR-0042-task-certificate.md
@@ -1,6 +1,6 @@
 # ADR-0042: Task Certificate — Signed Proof of Process Adherence
 
-**Status**: Proposed
+**Status**: proposed
 **Date**: 2026-05-26
 **Depends on**: [ADR-0041](ADR-0041-immutable-evidence-nodes.md) (certificates are evidence nodes; chain hash required)
 **Related**: [ADR-0044](ADR-0044-tool-gates.md) (gates passed/failed recorded in certificate), [ADR-0045](ADR-0045-break-glass-protocol.md) (break-glass path produces DEGRADED certificate), [ADR-0050](ADR-0050-operation-context.md) (operation context serialized into certificate), [ADR-0033](ADR-0033-unified-entity-state-model.md) (EvidenceRef substrate), [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) (evidence as first-class artifact)

--- a/docs/adrs/ADR-0042-task-certificate.md
+++ b/docs/adrs/ADR-0042-task-certificate.md
@@ -1,0 +1,550 @@
+# ADR-0042: Task Certificate — Signed Proof of Process Adherence
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Depends on**: [ADR-0041](ADR-0041-immutable-evidence-nodes.md) (certificates are evidence nodes; chain hash required)
+**Related**: [ADR-0044](ADR-0044-tool-gates.md) (gates passed/failed recorded in certificate), [ADR-0045](ADR-0045-break-glass-protocol.md) (break-glass path produces DEGRADED certificate), [ADR-0050](ADR-0050-operation-context.md) (operation context serialized into certificate), [ADR-0033](ADR-0033-unified-entity-state-model.md) (EvidenceRef substrate), [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) (evidence as first-class artifact)
+
+## Context
+
+lionagi today has no concept of *task completion proof*. A `Branch` session ends and the
+operator is left with: a list of messages, `DataLogger` entries, and the final assistant
+response. These artifacts assert *what happened*, but none of them assert *how the task was
+governed*. There is no single artifact that answers:
+
+- Were all required tool gates checked before execution?
+- Was any gate bypassed via break-glass?
+- Which policy version governed this run?
+- Is the evidence chain for this task intact and unmodified?
+
+This gap has concrete consequences. KHive's audit surface — and any operator deploying lionagi
+for consequential workloads — needs a tamper-evident record that proves process was followed,
+independently of whether the outcome was correct. Without this, "the agent said it followed the
+rules" is the only evidence available, which is not evidence at all.
+
+The cross-cutting principle **"Evidence is first-class, not logs"** applies directly: a DataLogger
+entry recording that a gate check occurred is operational telemetry. A `TaskCertificate`
+asserting that all gates passed, bound to the policy version active at execution time and
+hash-chained to the evidence nodes produced during the task, is governed evidence. The
+distinction is the same as the difference between a log line and a signed receipt.
+
+The cross-cutting principle **"Every constraint must be enforced, not just documented"** also
+applies: a governance policy that says "all HARD gates must pass" but produces no verifiable
+artifact of that assertion is not enforced — it is aspirational. The certificate is what makes
+adherence verifiable post-hoc.
+
+### The applicable prior governance research insight
+
+prior research introduced the *decision certificate* pattern for people-operations workflows
+(terminations, adverse actions, PIP initiations). The core insight translates directly to agent
+governance: the certificate is the primary proof artifact — it proves *process* adherence, not
+*outcome* correctness. prior governance research further established that certificates are never revoked, only
+superseded. Revocation creates audit ambiguity ("did this decision happen?"); supersession
+preserves the full correction trail ("this decision happened; a later decision is now
+authoritative"). In lionagi terms: if a task is re-run under a corrected policy, the original
+certificate is superseded, not erased. Both records remain.
+
+### Why lionagi needs this
+
+Consider a governed ReAct loop that calls `write_file` three times. Each call is guarded by a
+HARD gate requiring path allowlist membership (ADR-0044). One call is blocked; the agent invokes
+break-glass (ADR-0045) to proceed. The session ends. Forty-eight hours later, an auditor asks:
+"Did the agent stay within its path allowlist?" Today, the only answer is "check the logs." With
+`TaskCertificate`, the answer is: "Here is the certificate for task X. `defensibility` is
+`DEGRADED`. `gates_failed` lists the blocked gate. `break_glass_invoked` is `True`. The evidence
+chain head is verifiable against the immutable evidence nodes in ADR-0041." The audit takes
+seconds, not forensic reconstruction.
+
+## Decision
+
+We introduce `TaskCertificate`, a specialized `ImmutableEvidenceNode` (ADR-0041) that is emitted
+when an agent task completes, encoding the process record: which gates passed, which failed,
+whether break-glass was invoked, the hash-chain head of the evidence produced, the policy version
+active at execution time, and any human or agent attestations collected.
+
+### 1. State Machine
+
+A `TaskCertificate` traverses four states. Transitions are irreversible.
+
+```text
+PROVISIONAL → GATED → MINTED
+                         ↓
+                    SUPERSEDED
+```
+
+A fifth terminal variant, `BREAK_GLASS`, branches from `GATED` when the task completed via
+emergency override:
+
+```text
+PROVISIONAL → BREAK_GLASS → MINTED (defensibility: DEGRADED)
+                                ↓
+                           SUPERSEDED
+```
+
+State semantics:
+
+| State | Meaning |
+|-------|---------|
+| `PROVISIONAL` | Task started; certificate emitted but no completion claim yet. Agent is still executing. |
+| `GATED` | All required tool gates have passed. Task has completed normally. Pending final minting. |
+| `BREAK_GLASS` | Task completed via emergency override (ADR-0045). Not all gates passed normally. Defensibility is DEGRADED regardless of outcome. |
+| `MINTED` | Certificate is final. Content is sealed. Hash is recorded in the immutable evidence chain (ADR-0041). |
+| `SUPERSEDED` | A newer certificate for the same `task_id` has been minted. This certificate is preserved and remains queryable; it is no longer the authoritative record. |
+
+Once a certificate reaches `MINTED` or `SUPERSEDED`, its content fields are immutable. The
+certificate object may only gain a `superseded_by` pointer; no other field changes.
+
+### 2. TaskCertificate Dataclass
+
+```python
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from enum import Enum
+from typing import ClassVar, Optional
+from uuid import UUID
+
+from pydantic import ConfigDict, Field
+
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+
+
+class CertificateState(str, Enum):
+    PROVISIONAL = "PROVISIONAL"
+    GATED = "GATED"
+    BREAK_GLASS = "BREAK_GLASS"
+    MINTED = "MINTED"
+    SUPERSEDED = "SUPERSEDED"
+
+
+class Defensibility(str, Enum):
+    FULL = "FULL"          # All required gates passed; no emergency overrides
+    DEGRADED = "DEGRADED"  # Break-glass was invoked; process was bypassed
+
+
+class GateRecord(Element):
+    """One gate evaluation result, recorded at certificate minting time."""
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+    )
+
+    gate_id: str
+    gate_kind: str          # "HARD" | "SOFT" | "ADVISORY"  (ADR-0044)
+    tool_name: str
+    passed: bool
+    override_invoked: bool  # True if break-glass was used for this gate
+    evaluated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    policy_version: str     # Policy version active when this gate ran (ADR-0050)
+
+
+class Attestation(Element):
+    """
+    A signed assertion by a human or agent that they reviewed and approved
+    the task outcome.  Non-repudiable: once recorded, never removed.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+    )
+
+    attestor_id: str              # Agent ID, user ID, or external principal
+    attestor_kind: str            # "human" | "agent" | "system"
+    statement: str                # Free-text or structured assertion
+    attested_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    signature: Optional[str] = None  # Optional: base64 SHA-256 HMAC or external sig
+
+
+class EvidenceRef(Element):
+    """
+    Reference to an evidence node in the ADR-0041 chain.
+
+    This mirrors the EvidenceRef substrate from ADR-0033/ADR-0041 and is
+    Pile-managed here so certificates reference evidence rather than copying it.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+    )
+
+    evidence_id: UUID
+    evidence_kind: str
+    chain_hash: str
+
+
+class TaskCertificate(Element):
+    """
+    Immutable proof of process adherence for a single governed task.
+
+    A TaskCertificate is a specialized ImmutableEvidenceNode (ADR-0041).
+    It does NOT assert outcome correctness — it asserts that the process
+    defined by the active policy was followed (or, if defensibility is
+    DEGRADED, that it was bypassed with an auditable record).
+
+    Fields are sealed at MINTED state.  Only superseded_by may be written
+    post-minting, and only by the minting subsystem.
+    """
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        validate_assignment=True,
+    )
+
+    _mutable_after_seal: ClassVar[set[str]] = {"state", "superseded_by"}
+
+    # Identity
+    task_id: str = ""           # Caller-supplied task identifier
+    session_id: str = ""        # lionagi Session.ln_id
+    branch_id: str = ""         # lionagi Branch.ln_id
+
+    # Lifecycle
+    state: CertificateState = CertificateState.PROVISIONAL
+    defensibility: Defensibility = Defensibility.FULL
+
+    # Evidence linkage (ADR-0041)
+    evidence_chain_head: Optional[str] = None   # SHA-256 hash of last evidence node
+    evidence_node_count: int = 0                 # How many evidence nodes produced
+    evidence_refs: Pile[EvidenceRef] = Field(
+        default_factory=lambda: Pile(item_type={EvidenceRef}, strict_type=True)
+    )
+
+    # Gate results (ADR-0044)
+    gates_passed: Pile[GateRecord] = Field(
+        default_factory=lambda: Pile(item_type={GateRecord}, strict_type=True)
+    )
+    gates_failed: Pile[GateRecord] = Field(
+        default_factory=lambda: Pile(item_type={GateRecord}, strict_type=True)
+    )
+    break_glass_invoked: bool = False
+
+    # Attestations
+    attestations: Pile[Attestation] = Field(
+        default_factory=lambda: Pile(item_type={Attestation}, strict_type=True)
+    )
+
+    # Policy provenance (ADR-0050)
+    policy_version_active: str = ""     # Policy version string at task start
+    operation_context_hash: Optional[str] = None  # SHA-256 of serialized OperationContext
+
+    # Temporal record
+    emitted_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    gated_at: Optional[datetime] = None
+    minted_at: Optional[datetime] = None
+
+    # Supersession chain
+    supersedes: Optional[UUID] = None         # Certificate this one replaces
+    superseded_by: Optional[UUID] = None      # Certificate that replaces this one
+
+    @property
+    def certificate_id(self) -> UUID:
+        """Compatibility alias for Element.id."""
+        return self.id
+
+    def __setattr__(self, name: str, value) -> None:
+        sealed = getattr(self, "state", None) in (
+            CertificateState.MINTED,
+            CertificateState.SUPERSEDED,
+        )
+        if sealed and name not in self._mutable_after_seal:
+            raise AttributeError("Minted certificates are immutable.")
+        super().__setattr__(name, value)
+
+    def content_hash(self) -> str:
+        """
+        SHA-256 of the certificate's immutable fields, excluding superseded_by.
+        Used to verify the certificate has not been tampered with post-minting.
+        """
+        payload = self.to_dict(mode="db")
+        payload.pop("superseded_by", None)
+        return hashlib.sha256(
+            json.dumps(payload, sort_keys=True, default=str).encode()
+        ).hexdigest()
+
+    @property
+    def is_authoritative(self) -> bool:
+        """False if this certificate has been superseded."""
+        return self.superseded_by is None
+
+    @property
+    def is_sealed(self) -> bool:
+        """True if certificate content is immutable (MINTED or SUPERSEDED)."""
+        return self.state in (CertificateState.MINTED, CertificateState.SUPERSEDED)
+```
+
+### 3. Minting Requirements
+
+A certificate may only transition to `MINTED` when all of the following conditions hold:
+
+1. **All HARD gates passed** — no `GateRecord` in `gates_failed` has `gate_kind == "HARD"`,
+   unless `break_glass_invoked is True` (in which case `state` must be `BREAK_GLASS` and
+   `defensibility` must be `DEGRADED`).
+2. **Evidence chain intact** — `evidence_chain_head` is set and the chain is walkable back to
+   the first evidence node emitted for this `task_id`. If any node in the chain is missing or
+   its hash does not match, minting is refused.
+3. **No unresolved SOFT gate overrides** — any SOFT gate that was overridden must have a
+   corresponding `Attestation` with `attestor_kind != "system"` (i.e., a human or non-self
+   agent attested the override).
+4. **Policy version recorded** — `policy_version_active` is non-empty.
+5. **State machine consistency** — state must be `GATED` or `BREAK_GLASS` before minting.
+
+If any condition fails, `branch.mint_certificate()` raises `CertificateMintingError` with a
+structured reason. The certificate remains in its pre-minting state; it is not discarded. The
+operator may resolve the condition (e.g., supply a missing attestation) and retry.
+
+```python
+from pydantic import ConfigDict
+
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.governance.certificate import (
+    TaskCertificate,
+    CertificateState,
+    Attestation,
+)
+
+
+class CertificateMintingFailure(Element):
+    """Structured minting failure record suitable for logging and evidence."""
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+    )
+
+    certificate_id: str
+    reason: str
+    requirement: str | None = None
+
+
+class CertificateMintingError(Exception):
+    """Raised when minting preconditions are not satisfied."""
+
+    def __init__(self, failure: CertificateMintingFailure) -> None:
+        self.failure = failure
+        super().__init__(f"Cannot mint {failure.certificate_id}: {failure.reason}")
+```
+
+### 4. Branch and Session API
+
+```python
+from datetime import datetime, timezone
+
+from lionagi.protocols.action.manager import ActionManager
+from lionagi.protocols.generic.log import DataLogger
+from lionagi.protocols.generic.pile import Pile
+from lionagi.protocols.messages.manager import MessageManager
+from lionagi.protocols.governance.certificate import Attestation, TaskCertificate
+
+
+# Existing Branch managers are the integration point.
+actions: ActionManager = branch.acts
+messages: MessageManager = branch.msgs
+audit: DataLogger = branch._log_manager
+
+# On Branch — task-level operations
+cert: TaskCertificate = await branch.emit_certificate(task_id="task-abc-123")
+# Returns PROVISIONAL certificate immediately.
+# The implementation extends ActionManager with a Pile[TaskCertificate] store
+# and uses MessageManager progression to bind the task-flow transcript.
+actions.certificates.include(cert)
+cert.metadata["message_progression"] = messages.progression.to_dict(mode="json")
+audit.log(cert)
+
+cert = await branch.mint_certificate(
+    task_id="task-abc-123",
+    attestation=Attestation(
+        attestor_id="user:ocean",
+        attestor_kind="human",
+        statement="Reviewed ReAct trace; process adherence confirmed.",
+        attested_at=datetime.now(timezone.utc),
+    ),
+)
+# Validates minting requirements; transitions GATED → MINTED.
+# Raises CertificateMintingError if any precondition fails.
+audit.log(cert)
+
+# On Session — cross-branch retrieval
+cert: TaskCertificate | None = session.get_certificate(task_id="task-abc-123")
+# Returns the authoritative (non-superseded) certificate for task_id.
+# Returns None if no certificate has been minted for that task.
+
+all_certs: Pile[TaskCertificate] = session.list_certificates(
+    task_id="task-abc-123",
+    include_superseded=True,
+)
+# Returns all certificates for task_id, including superseded ones, ordered oldest-first.
+
+new_cert = session.supersede_certificate(
+    task_id="task-abc-123",
+    reason="Policy version 2.1 invalidated gate configuration used in original run.",
+)
+# Mints a new PROVISIONAL certificate for the same task_id.
+# Marks the current authoritative certificate as SUPERSEDED.
+# Sets new_cert.supersedes = old_cert.certificate_id.
+```
+
+### 5. The Supersession Doctrine
+
+Certificates are never revoked. The distinction matters:
+
+- **Revocation** implies "this record should not have existed; treat it as if it never happened."
+  This creates legal and audit ambiguity: was the process followed or not? Regulators and
+  auditors cannot work with erasure.
+- **Supersession** implies "this record happened; a newer record is now the authoritative
+  reference; the old record is preserved as part of the audit trail."
+
+If a task is re-run because the first run was executed under a defective policy version,
+the correct action is: mint a new certificate for the same `task_id` (which supersedes the
+original), with `supersedes` pointing back to the original certificate's `certificate_id`.
+Both certificates remain in storage. Queries for the authoritative certificate return the
+new one; queries with `include_superseded=True` return the full chain.
+
+### 6. Post-Hoc Verification
+
+Any party with access to the evidence store may verify a minted certificate:
+
+```python
+from lionagi.protocols.generic.pile import Pile
+from lionagi.protocols.governance.certificate import (
+    CertificateVerificationFinding,
+    CertificateVerificationResult,
+    verify_certificate,
+)
+
+
+result: CertificateVerificationResult = await verify_certificate(
+    certificate=cert,
+    evidence_store=session.evidence_store,
+)
+# Returns CertificateVerificationResult with fields:
+#   chain_intact: bool        — evidence chain hashes all match
+#   policy_consistent: bool   — gate decisions match policy_version_active rules
+#   content_unmodified: bool  — cert.content_hash() matches stored hash at minting time
+#   findings: Pile[CertificateVerificationFinding] — anomalies found, empty if clean
+```
+
+Verification re-walks the evidence chain starting from `evidence_chain_head`, verifying each
+node's `prev_hash` pointer (ADR-0041). It then replays the gate decisions recorded in
+`gates_passed` and `gates_failed` against the policy version stored in `policy_version_active`
+(fetched from the policy store, ADR-0052). If the policy version is no longer available
+(e.g., it was retired), verification returns `policy_consistent: None` (indeterminate) rather
+than `False` — absence of the historical policy is not evidence of tampering.
+
+### 7. Integration with Break-Glass (ADR-0045)
+
+When break-glass is invoked during a governed task execution, the following occurs
+automatically:
+
+1. The pending certificate transitions from `GATED` to `BREAK_GLASS`.
+2. `defensibility` is set to `DEGRADED`. This cannot be overridden by any attestation.
+3. The gate that was bypassed is moved to `gates_failed` with `override_invoked=True`.
+4. The break-glass event is recorded as an evidence node in the chain (ADR-0041).
+
+A `BREAK_GLASS` certificate may still reach `MINTED` state. A `DEGRADED` certificate is a
+legitimate, auditable record — it is not an error condition. It is the system correctly
+recording that an exception was taken. The operator's audit surface (KHive) can filter for
+`defensibility=DEGRADED` to surface tasks that require human review without rejecting them
+outright.
+
+### 8. Certificate Storage
+
+`TaskCertificate` objects are stored as `ImmutableEvidenceNode` entries in the evidence store
+(ADR-0041). The evidence node's `content_hash` field contains the value returned by
+`TaskCertificate.content_hash()`. This means the certificate itself is hash-chained into the
+same evidence store that records all other governed artifacts, providing a single integrity
+surface.
+
+Certificates are also indexed by `task_id` in a separate lookup table for efficient retrieval
+by `session.get_certificate(task_id)`. The lookup table records only the `certificate_id`
+and `task_id`; the full certificate content lives in the evidence store.
+
+## Consequences
+
+**Positive**
+
+- Audit queries that previously required forensic log reconstruction are answered by a single
+  `session.get_certificate(task_id)` call.
+- Process adherence is verifiable post-hoc without access to the original session or branch —
+  only the evidence store is required.
+- The supersession chain preserves a complete correction history; corrections do not erase
+  prior records.
+- Break-glass paths are automatically promoted to auditable `DEGRADED` certificates; no
+  special instrumentation is needed at the call site.
+- Certificates compose with ADR-0041 (evidence nodes), ADR-0044 (gate records), and ADR-0050
+  (operation context) without redundant storage — they reference, not duplicate.
+
+**Negative**
+
+- Storage growth is unbounded for long-lived KHive deployments. Superseded certificates are
+  never deleted. Operators must provision accordingly.
+- Adding `emit_certificate` / `mint_certificate` calls to every governed task path increases
+  surface area for implementation bugs. The minting precondition checks must be exhaustive
+  or they provide false assurance.
+- Two-phase emission (PROVISIONAL at task start, MINTED at task end) complicates crash
+  recovery: PROVISIONAL certificates for tasks that crashed without minting must be detected
+  and flagged. A background reconciliation job is required.
+- Verification requires the historical policy version to be available. Policy retirement
+  without archival causes `policy_consistent: None` indeterminate results on old certificates.
+
+## Non-Goals
+
+Explicitly out of scope:
+
+- **Outcome correctness verification**: A `MINTED` certificate with `defensibility=FULL`
+  asserts that the process was followed. It does not assert that the task's output is correct,
+  safe, or consistent with the operator's intent. Outcome verification is a separate concern
+  (evaluation, human review).
+- **Cryptographic signing with asymmetric keys (RSA/Ed25519)**: prior research uses
+  RSA-4096. For v1 lionagi, SHA-256 content hashing and chain integrity (ADR-0041) are
+  sufficient. Key management infrastructure for asymmetric signing is deferred to a future
+  ADR targeting KHive enterprise deployments.
+- **Human-signing UI**: The `Attestation` dataclass supports human attestations.
+  The UI for collecting them is a KHive product concern, not a lionagi framework concern.
+- **Multi-tenant certificate namespacing**: Certificates for different tenants sharing a
+  KHive deployment must be isolated. Tenant namespacing is deferred to KHive's multi-tenancy
+  layer.
+- **Certificate revocation**: Deliberately absent. See supersession doctrine (section 5).
+  Implementing revocation would undermine the audit guarantees this ADR is designed to provide.
+- **Per-tool-call certificates**: Tool gates (ADR-0044) produce `GateRecord` entries that
+  are aggregated into the task-level certificate. Per-call certificates are too granular
+  for the audit use case and would produce certificate volumes that are unmanageable in
+  practice.
+- **Real-time certificate streaming**: Certificates are finalized at task completion.
+  Streaming partial certificate state to external systems during execution is out of scope;
+  that use case is served by the evidence stream (ADR-0041).
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|------------|--------------|
+| Store task status in session metadata | Session metadata is mutable and not tamper-evident. An agent (or a bug) can overwrite `session.metadata["task_status"] = "passed"` with no audit trail. This is logs, not evidence. |
+| Per-tool certificates (one per `ActionRequest`) | Too granular. An agent making 30 tool calls would produce 30 certificates. Aggregating them into a coherent task-level record still requires a task certificate; per-tool certificates are redundant intermediate artifacts. |
+| No certificates; rely on DataLogger + evidence nodes | DataLogger entries (ADR-0049) are mutable-tier by default. Evidence nodes (ADR-0041) record what happened but not whether the process was correctly followed. Neither alone asserts "all required gates passed under this policy version." The combination is not equivalent to a certificate. |
+| Certificate revocation instead of supersession | Revocation creates legal ambiguity ("did this task happen?"). Supersession preserves the full audit trail while clearly marking which record is authoritative. Adopted from prior research which rejected revocation for the same reason. |
+| Embed full evidence content in certificate | Evidence nodes can be arbitrarily large (file diffs, LLM responses). Embedding them in the certificate violates separation of concerns and makes storage unpredictable. The certificate references evidence via `evidence_chain_head`; retrieval traverses the chain (ADR-0041). |
+
+## References
+
+- [ADR-0041](ADR-0041-immutable-evidence-nodes.md) — certificates are evidence nodes; `evidence_chain_head` points into the immutable chain
+- [ADR-0044](ADR-0044-tool-gates.md) — HARD/SOFT/ADVISORY gate records aggregated into certificate
+- [ADR-0045](ADR-0045-break-glass-protocol.md) — break-glass invocation transitions certificate to BREAK_GLASS state with DEGRADED defensibility
+- [ADR-0050](ADR-0050-operation-context.md) — `policy_version_active` and `operation_context_hash` sourced from OperationContext
+- [ADR-0052](ADR-0052-policy-resolution.md) — policy version fetched for post-hoc verification replay
+- [ADR-0033](ADR-0033-unified-entity-state-model.md) — `EvidenceRef` substrate; certificates produce an `EvidenceRef` of kind `artifact`
+- [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) — "Evidence is first-class, not logs" principle instantiated here
+- prior governance research `01_design/007-decision-certificate/ADR-007-decision-certificate.md` — source pattern (decision certificate architecture, supersession doctrine, attestation records)

--- a/docs/adrs/ADR-0042-task-certificate.md
+++ b/docs/adrs/ADR-0042-task-certificate.md
@@ -17,10 +17,10 @@ governed*. There is no single artifact that answers:
 - Which policy version governed this run?
 - Is the evidence chain for this task intact and unmodified?
 
-This gap has concrete consequences. KHive's audit surface — and any operator deploying lionagi
-for consequential workloads — needs a tamper-evident record that proves process was followed,
-independently of whether the outcome was correct. Without this, "the agent said it followed the
-rules" is the only evidence available, which is not evidence at all.
+This gap has concrete consequences. Any operator deploying lionagi for consequential workloads
+needs a tamper-evident record that proves process was followed, independently of whether the
+outcome was correct. Without this, "the agent said it followed the rules" is the only evidence
+available, which is not evidence at all.
 
 The cross-cutting principle **"Evidence is first-class, not logs"** applies directly: a DataLogger
 entry recording that a gate check occurred is operational telemetry. A `TaskCertificate`
@@ -457,9 +457,8 @@ automatically:
 
 A `BREAK_GLASS` certificate may still reach `MINTED` state. A `DEGRADED` certificate is a
 legitimate, auditable record — it is not an error condition. It is the system correctly
-recording that an exception was taken. The operator's audit surface (KHive) can filter for
-`defensibility=DEGRADED` to surface tasks that require human review without rejecting them
-outright.
+recording that an exception was taken. Operators can filter for `defensibility=DEGRADED` to surface tasks that require human review
+without rejecting them outright.
 
 ### 8. Certificate Storage
 
@@ -490,8 +489,8 @@ and `task_id`; the full certificate content lives in the evidence store.
 
 **Negative**
 
-- Storage growth is unbounded for long-lived KHive deployments. Superseded certificates are
-  never deleted. Operators must provision accordingly.
+- Storage growth is unbounded for long-lived sessions. Superseded certificates are never deleted.
+  Operators must provision accordingly.
 - Adding `emit_certificate` / `mint_certificate` calls to every governed task path increases
   surface area for implementation bugs. The minting precondition checks must be exhaustive
   or they provide false assurance.
@@ -511,13 +510,9 @@ Explicitly out of scope:
   (evaluation, human review).
 - **Cryptographic signing with asymmetric keys (RSA/Ed25519)**: prior research uses
   RSA-4096. For v1 lionagi, SHA-256 content hashing and chain integrity (ADR-0041) are
-  sufficient. Key management infrastructure for asymmetric signing is deferred to a future
-  ADR targeting KHive enterprise deployments.
+  sufficient. Key management infrastructure for asymmetric signing is deferred to a future ADR.
 - **Human-signing UI**: The `Attestation` dataclass supports human attestations.
-  The UI for collecting them is a KHive product concern, not a lionagi framework concern.
-- **Multi-tenant certificate namespacing**: Certificates for different tenants sharing a
-  KHive deployment must be isolated. Tenant namespacing is deferred to KHive's multi-tenancy
-  layer.
+  The UI for collecting them is not defined here.
 - **Certificate revocation**: Deliberately absent. See supersession doctrine (section 5).
   Implementing revocation would undermine the audit guarantees this ADR is designed to provide.
 - **Per-tool-call certificates**: Tool gates (ADR-0044) produce `GateRecord` entries that

--- a/docs/adrs/ADR-0043-governed-tool-declaration.md
+++ b/docs/adrs/ADR-0043-governed-tool-declaration.md
@@ -1,0 +1,822 @@
+# ADR-0043: Governed Tool Declaration
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Depends on**: [ADR-0041](ADR-0041-immutable-evidence-nodes.md), [ADR-0050](ADR-0050-operation-context.md)
+**Related**: [ADR-0044](ADR-0044-tool-gates.md), [ADR-0051](ADR-0051-tool-registry-allowlists.md), [ADR-0033](ADR-0033-unified-entity-state-model.md), [ADR-0023](ADR-0023-unified-hook-system.md)
+
+---
+
+## Context
+
+lionagi today allows any registered tool to be called without passing through any governance
+checkpoint. A caller invokes `branch.operate(instruction=..., tools=...)`, the `ActionManager`
+resolves the tool from its `Pile`, and hands arguments directly to `Tool.func_callable`. The only
+policy layer that can intervene is `PermissionPolicy` (`lionagi/agent/permissions.py`), which
+applies allowlist/denylist/escalate rules keyed by tool name and action string. `PermissionPolicy`
+is powerful for what it does, but it is a policy-side construct: it lives in `AgentConfig`, it is
+attached by the caller at agent creation time, and the tool itself carries no record of what
+constraints should apply to it.
+
+The structural gap is that enforcement metadata is not co-located with the tool. A `read_file` tool
+registered in one branch may require a confirmation gate; the same function registered in another
+branch has no gate at all. Whether governance applies depends entirely on whether the agent
+constructor remembered to attach the right policy — not on anything declared at the tool definition
+site. This violates cross-cutting principle #3: **every constraint must be enforced, not just
+documented**. A constraint that exists only in an `AgentConfig` dict can be silently absent.
+
+There is also no mandatory execution pipeline. Nothing prevents `Tool.func_callable` from being
+called directly — by test code, by a pre-processor, or by a branch that bypasses the normal
+`operate()` path. Evidence emission (`DataLogger`) is also optional and caller-driven. The result
+is that lionagi in library mode has no single audit point: different call sites emit different
+evidence shapes, and some emit none.
+
+### The applicable prior governance research insight
+
+prior research establishes that "if there is ANY path that bypasses the enforcement pipeline,
+compliance is broken." The solution is not more policy configuration — it is a single mandatory
+pipeline (`CanonService.request()`) where every phase is non-optional and the underlying handler
+is unreachable from outside the pipeline. ADR-010 completes the picture: governance metadata
+(`@action` decorator, `ActionMeta` frozen dataclass) is attached to the handler at definition
+time, not assembled at invocation time. Co-location is what makes drift impossible.
+
+Translated to lionagi: the `@governed_tool` decorator plays the role of `@action`, and
+`ActionManager.execute_governed()` plays the role of `CanonService.request()`. The `Tool` class
+remains as the schema and callable carrier; governance metadata is a separate, frozen attachment.
+
+### Why lionagi needs this
+
+Consider a KHive agent writing to a code repository. The `write_file` tool must: confirm that the
+target path is inside an allowed workspace (HARD gate), require an explicit justification when the
+path is outside a designated source tree (SOFT gate), log a warning when the diff exceeds 500
+lines (ADVISORY gate), and emit an evidence node that links the write operation to its operation
+context. In the current architecture, all of this must be wired manually in the `AgentConfig`
+hooks. If the hook is omitted, the tool runs ungated with no evidence. The first time a new
+developer registers `write_file` in a new agent, they must know to also attach four hooks and a
+custom `DataLogger` flush. This is not governance; it is documentation that governance is
+possible.
+
+With `@governed_tool`, the gate declarations travel with the function definition. Any agent that
+registers `write_file` automatically gets all its governance — not because the caller remembered
+to configure it, but because the decorator made it unconditional.
+
+---
+
+## Decision
+
+Introduce a `@governed_tool` decorator that co-locates enforcement metadata with the tool
+function at definition time, and a mandatory `ActionManager.execute_governed()` pipeline that
+enforces a fixed eight-phase sequence with no bypass path.
+
+---
+
+### 1. `GovernedToolMeta` — Frozen Metadata Dataclass
+
+Governance metadata is stored in a frozen `Element` subclass attached to the existing `Tool`
+primitive as `Tool.governance_meta`. Frozen because no runtime code should be able to relax a
+constraint after the tool is defined.
+
+```python
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+
+SafetyClass = Literal["standard", "sensitive", "privileged"]
+GateLevel = Literal["hard", "soft", "advisory"]
+
+
+class ToolGateDeclaration(Element):
+    """A single tool-level gate declaration resolved by ADR-0044."""
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    gate_id: str
+    enforcement: GateLevel
+    justification_prompt: str | None = None
+
+
+def _gate_pile() -> Pile[ToolGateDeclaration]:
+    return Pile(item_type={ToolGateDeclaration})
+
+
+class GovernedToolMeta(Element):
+    """Frozen governance metadata stored on the existing Tool primitive."""
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    # Evidence chain
+    evidence_type: str | None = None
+    """Dot-separated category written into every evidence node produced by
+    this tool.  If None, defaults to the function name at registration time."""
+
+    skip_evidence: bool = False
+    """True only for hot-path read-only probes where evidence is noise
+    (e.g. status checks, health pings).  Default False."""
+
+    # Gate declarations — resolved against the registry in ADR-0044
+    hard_gates: Pile[ToolGateDeclaration] = Field(default_factory=_gate_pile)
+    """Gates whose failure terminates the call immediately.  No justification
+    can override a hard-gate failure.  Evaluated before soft gates."""
+
+    soft_gates: Pile[ToolGateDeclaration] = Field(default_factory=_gate_pile)
+    """Gates that pause execution and require a documented justification to
+    proceed.  May continue after justification is accepted."""
+
+    advisory_gates: Pile[ToolGateDeclaration] = Field(default_factory=_gate_pile)
+    """Gates that emit a warning and proceed unconditionally.  Used for
+    metrics, audit noise, and developer feedback."""
+
+    # Input schema
+    options_schema: type[BaseModel] | None = Field(default=None, exclude=True)
+    """Pydantic model for input normalization (Phase 1).  When provided,
+    raw kwargs are coerced through this model before reaching the handler."""
+
+    # Classification
+    safety_class: SafetyClass = "standard"
+    """standard | sensitive | privileged.  Drives which additional class-level
+    gates the registry adds per ADR-0044 specificity rules."""
+
+    # Sentinel — set by the decorator, not the caller
+    _IS_GOVERNED: ClassVar[bool] = True
+
+
+# In lionagi/protocols/action/tool.py, extend the existing class in place.
+class Tool(Element):
+    ...
+
+    governance_meta: GovernedToolMeta | None = Field(
+        default=None,
+        description="Optional governance metadata declared by @governed_tool.",
+    )
+```
+
+### 2. `@governed_tool` Decorator
+
+The decorator builds a normal `Tool` instance, attaches `GovernedToolMeta`, and binds governance
+phases through `Tool.preprocessor` and `Tool.postprocessor`.
+
+```python
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import Any
+
+from pydantic import BaseModel
+
+from lionagi.protocols.action.tool import Tool
+from lionagi.protocols.generic.pile import Pile
+
+
+class GovernanceBypassError(RuntimeError):
+    """Raised when a governed tool is called directly, bypassing the pipeline."""
+
+
+def _make_gate_pile(
+    gate_ids: Iterable[str] | Pile[ToolGateDeclaration],
+    enforcement: GateLevel,
+) -> Pile[ToolGateDeclaration]:
+    if isinstance(gate_ids, Pile):
+        return gate_ids
+
+    gates = Pile(item_type={ToolGateDeclaration})
+    for gate_id in gate_ids:
+        gates.include(ToolGateDeclaration(gate_id=gate_id, enforcement=enforcement))
+    return gates
+
+
+async def governed_tool_preprocessor(
+    kwargs: dict[str, Any],
+    *,
+    governance_meta: GovernedToolMeta,
+    context: "GovernedToolCallContext",
+) -> dict[str, Any]:
+    """Phases 1-6 run through Tool.preprocessor before func_callable."""
+    if governance_meta.options_schema is not None:
+        validated = governance_meta.options_schema(**kwargs)
+        kwargs = validated.model_dump(exclude_unset=True)
+
+    context.normalized_inputs = dict(kwargs)
+    if not governance_meta.skip_evidence and context.operation_context_id is None:
+        raise MissingOperationContextError(
+            "Governed tools require OperationContext unless skip_evidence=True."
+        )
+
+    for gate in await resolve_governed_gates(governance_meta, context):
+        result = await run_gate(gate, kwargs, context)
+        context.gate_results.include(result)
+        if gate.enforcement == "hard" and not result.passed:
+            evidence_id = await emit_gate_failure_evidence(gate, result, context)
+            raise GateBlockedError(
+                gate_id=gate.gate_id,
+                tool_name=context.tool_name,
+                reason=result.reason,
+                evidence_node_id=evidence_id,
+            )
+        if gate.enforcement == "soft" and not result.passed and not context.justification:
+            raise JustificationRequiredError(
+                gate_id=gate.gate_id,
+                tool_name=context.tool_name,
+                prompt=result.justification_prompt or result.reason,
+            )
+
+    return kwargs
+
+
+async def governed_tool_postprocessor(
+    result: Any,
+    *,
+    governance_meta: GovernedToolMeta,
+    context: "GovernedToolCallContext",
+) -> Any:
+    """Phase 8 runs through Tool.postprocessor after func_callable."""
+    if not governance_meta.skip_evidence:
+        await emit_success_evidence(result, governance_meta, context)
+    return result
+
+
+def governed_tool(
+    *,
+    evidence_type: str | None = None,
+    hard_gates: Iterable[str] | Pile[ToolGateDeclaration] = (),
+    soft_gates: Iterable[str] | Pile[ToolGateDeclaration] = (),
+    advisory_gates: Iterable[str] | Pile[ToolGateDeclaration] = (),
+    skip_evidence: bool = False,
+    safety_class: SafetyClass = "standard",
+    options_schema: type[BaseModel] | None = None,
+) -> Callable[[Callable[..., Any]], Tool]:
+    """Decorator that returns the existing Tool primitive with governance_meta.
+
+    Usage::
+
+        @governed_tool(
+            evidence_type="repo_write",
+            hard_gates=["guard_destructive"],
+            soft_gates=["confirm_path_outside_workspace"],
+            advisory_gates=["warn_large_diff"],
+            safety_class="standard",
+            options_schema=WriteFileOptions,
+        )
+        async def write_file(path: str, content: str) -> WriteResult: ...
+
+    The decorated name is a Tool, not a second GovernedTool hierarchy.
+    Governance phases bind through Tool.preprocessor and Tool.postprocessor.
+    """
+
+    def decorator(fn: Callable[..., Any]) -> Tool:
+        meta = GovernedToolMeta(
+            evidence_type=evidence_type or fn.__name__,
+            skip_evidence=skip_evidence,
+            hard_gates=_make_gate_pile(hard_gates, "hard"),
+            soft_gates=_make_gate_pile(soft_gates, "soft"),
+            advisory_gates=_make_gate_pile(advisory_gates, "advisory"),
+            options_schema=options_schema,
+            safety_class=safety_class,
+        )
+        fn.__governance_meta__ = meta  # type: ignore[attr-defined]
+        return Tool(
+            func_callable=fn,
+            request_options=options_schema,
+            governance_meta=meta,
+            preprocessor=governed_tool_preprocessor,
+            preprocessor_kwargs={"governance_meta": meta},
+            postprocessor=governed_tool_postprocessor,
+            postprocessor_kwargs={"governance_meta": meta},
+        )
+
+    return decorator
+
+
+def is_governed(tool: Tool | Callable[..., Any]) -> bool:
+    """Return True if a Tool or raw callable carries GovernedToolMeta."""
+    if isinstance(tool, Tool):
+        return tool.governance_meta is not None
+    return hasattr(tool, "__governance_meta__")
+
+
+def get_governed_meta(tool: Tool | Callable[..., Any]) -> GovernedToolMeta:
+    """Return the ``GovernedToolMeta`` attached to a governed tool.
+
+    Raises ``TypeError`` if the Tool/callable is not governed.
+    """
+    meta = tool.governance_meta if isinstance(tool, Tool) else None
+    if meta is None:
+        meta = getattr(tool, "__governance_meta__", None)
+    if meta is None:
+        raise TypeError(
+            "Tool is not governed. Apply @governed_tool(...) or construct "
+            "Tool(governance_meta=..., preprocessor=..., postprocessor=...)."
+        )
+    return meta
+```
+
+### 3. Pipeline Context — Bypass Prevention Mechanism
+
+The pipeline binds per-call state into an invocation-local copy of the `Tool`. The original
+`Tool` stays reusable, while `Tool.preprocessor_kwargs` and `Tool.postprocessor_kwargs` carry the
+operation context, gate results, justification, Branch reference, and `DataLogger` for that call.
+
+```python
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import ConfigDict, Field
+
+from lionagi.agent.gates import GateResult
+from lionagi.protocols.action.tool import Tool
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.log import DataLogger
+from lionagi.protocols.generic.pile import Pile
+
+
+def _gate_result_pile() -> Pile[GateResult]:
+    return Pile(item_type={GateResult})
+
+
+class GovernedToolCallContext(Element):
+    """Per-call state bound into Tool pre/postprocessor kwargs."""
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+    )
+
+    tool_name: str
+    operation_context_id: str | None = None  # links to ADR-0050
+    justification: str | None = None
+    normalized_inputs: dict[str, Any] = Field(default_factory=dict)
+    gate_results: Pile[GateResult] = Field(default_factory=_gate_result_pile)
+    branch: Any | None = Field(default=None, exclude=True)
+    data_logger: DataLogger | None = Field(default=None, exclude=True)
+
+
+def bind_governed_context(tool: Tool, context: GovernedToolCallContext) -> Tool:
+    """Return an invocation-local Tool copy with pipeline context attached."""
+    kwargs = {"governance_meta": tool.governance_meta, "context": context}
+    return tool.model_copy(
+        update={
+            "preprocessor_kwargs": {**tool.preprocessor_kwargs, **kwargs},
+            "postprocessor_kwargs": {**tool.postprocessor_kwargs, **kwargs},
+        }
+    )
+```
+
+### 4. `ActionManager.execute_governed()` — The Mandatory Pipeline
+
+Eight phases, all non-optional. Phases 4–6 execute in strict order (hard → soft → advisory).
+No phase can be skipped by caller configuration.
+
+```python
+from __future__ import annotations
+
+from typing import Any
+
+from lionagi.protocols.action.function_calling import FunctionCalling
+from lionagi.protocols.action.tool import Tool
+from lionagi.protocols.generic.log import DataLogger
+
+
+class GateBlockedError(Exception):
+    """Raised when a HARD gate blocks execution."""
+
+    def __init__(
+        self,
+        gate_id: str,
+        tool_name: str,
+        reason: str,
+        evidence_node_id: str | None = None,
+    ) -> None:
+        self.gate_id = gate_id
+        self.tool_name = tool_name
+        self.reason = reason
+        self.evidence_node_id = evidence_node_id
+        super().__init__(f"Hard gate '{gate_id}' blocked '{tool_name}': {reason}")
+
+
+class JustificationRequiredError(Exception):
+    """Raised when a SOFT gate requires justification and none is provided."""
+
+    def __init__(self, gate_id: str, tool_name: str, prompt: str) -> None:
+        self.gate_id = gate_id
+        self.tool_name = tool_name
+        self.prompt = prompt
+        super().__init__(
+            f"Soft gate '{gate_id}' requires justification for '{tool_name}': {prompt}"
+        )
+
+
+class MissingOperationContextError(Exception):
+    """Raised when a governed tool requires ADR-0050 context and none exists."""
+
+
+class ActionManager:
+    """Facade over the Tool Pile; governs all tool executions.
+
+    This extends the existing ActionManager path. Governed tools are still
+    ordinary Tool instances; their phases run through Tool.preprocessor,
+    FunctionCalling._invoke(), and Tool.postprocessor.
+    """
+
+    async def execute_governed(
+        self,
+        tool: Tool,
+        raw_kwargs: dict[str, Any],
+        *,
+        branch: Any | None = None,
+        operation_context_id: str | None = None,
+        justification: str | None = None,
+        data_logger: DataLogger | None = None,
+    ) -> Any:
+        """Execute a governed tool through the mandatory eight-phase pipeline.
+
+        Args:
+            tool: The registered ``Tool`` with ``governance_meta`` attached.
+            raw_kwargs: Raw keyword arguments from the LLM's ``ActionRequest``.
+            branch: Calling Branch, supplied for gate hooks that need manager access.
+            operation_context_id: ID of the active OperationContext (ADR-0050).
+                Required for governed tools; raises if absent and tool is not
+                skip_evidence.
+            justification: Caller-supplied justification for SOFT gate bypass.
+            data_logger: Branch ``DataLogger`` used for evidence emission.
+
+        Returns:
+            The handler's return value on success.
+
+        Raises:
+            GateBlockedError: If any HARD gate fails.
+            JustificationRequiredError: If a SOFT gate fails and no justification
+                is supplied.
+            MissingOperationContextError: If the tool is governed and
+                operation_context_id is None (per ADR-0050).
+        """
+        meta = get_governed_meta(tool)
+        if not meta.skip_evidence and operation_context_id is None:
+            raise MissingOperationContextError(
+                f"Governed tool '{tool.function}' requires an active OperationContext "
+                f"(ADR-0050).  Pass operation_context_id= or set skip_evidence=True."
+            )
+
+        context = GovernedToolCallContext(
+            tool_name=tool.function,
+            operation_context_id=operation_context_id,
+            justification=justification,
+            branch=branch,
+            data_logger=data_logger,
+        )
+        invocation_tool = bind_governed_context(tool, context)
+
+        # FunctionCalling._invoke() supplies the existing execution lifecycle:
+        # Phase 1-6: Tool.preprocessor
+        # Phase 7:   Tool.func_callable
+        # Phase 8:   Tool.postprocessor
+        function_call = FunctionCalling(
+            func_tool=invocation_tool,
+            arguments=raw_kwargs,
+        )
+        try:
+            await function_call.invoke()
+        except Exception as exc:
+            await emit_execution_failure_evidence(exc, meta, context)
+            raise
+
+        return function_call.execution.response
+
+    async def execute_raw(
+        self,
+        tool: Tool,
+        kwargs: dict[str, Any],
+    ) -> Any:
+        """Execute an ungoverned tool without the governance pipeline.
+
+        Only available in library mode.  KHive mode raises ``GovernanceModeError``
+        from this method at startup configuration.
+
+        Ungoverned tools registered via ``branch.register_tools([plain_function])``
+        continue to work through this path with zero configuration changes.
+        """
+        if is_governed(tool):
+            raise GovernanceBypassError(
+                f"Governed tool '{tool.function}' must use execute_governed()."
+            )
+
+        function_call = FunctionCalling(func_tool=tool, arguments=kwargs)
+        await function_call.invoke()
+        return function_call.execution.response
+```
+
+### 5. Evidence Emission on Success and Failure
+
+Phase 8 emits an evidence node per ADR-0041. The node carries the gate results active at
+execution time ("active assertion") so the evidence is self-contained for audit.
+
+```python
+from __future__ import annotations
+
+from typing import Any
+
+from lionagi.protocols.generic.log import Log
+from lionagi.protocols.governance.evidence import ImmutableEvidenceNode  # ADR-0041
+
+
+class MissingEvidenceLoggerError(Exception):
+    """Raised when evidence must be emitted but Branch DataLogger is absent."""
+
+
+async def _log_evidence(
+    node: ImmutableEvidenceNode,
+    context: GovernedToolCallContext,
+) -> str:
+    if context.data_logger is None:
+        raise MissingEvidenceLoggerError(
+            f"Governed tool '{context.tool_name}' requires Branch DataLogger."
+        )
+    await context.data_logger.alog(Log.create(node))
+    return str(node.id)
+
+
+async def emit_success_evidence(
+    result: Any,
+    meta: GovernedToolMeta,
+    context: GovernedToolCallContext,
+) -> str:
+    """Emit immutable evidence for a successful Tool.postprocessor phase."""
+    node = ImmutableEvidenceNode(
+        kind="tool_result",  # EvidenceRef kind from ADR-0033
+        evidence_type=meta.evidence_type,
+        tool_name=context.tool_name,
+        operation_context_id=context.operation_context_id,
+        inputs_summary=_redact_sensitive(context.normalized_inputs, meta.safety_class),
+        result_summary=_redact_sensitive(result, meta.safety_class),
+        outcome="success",
+        justification=context.justification,
+        gate_results=[r.to_dict(mode="json") for r in context.gate_results],
+    )
+    return await _log_evidence(node, context)
+
+
+async def emit_gate_failure_evidence(
+    gate: ToolGateDeclaration,
+    gate_result: Any,
+    context: GovernedToolCallContext,
+) -> str:
+    """Emit immutable evidence for a HARD gate block."""
+    node = ImmutableEvidenceNode(
+        kind="tool_result",
+        evidence_type=context.tool_name,
+        tool_name=context.tool_name,
+        operation_context_id=context.operation_context_id,
+        outcome="gate_blocked",
+        gate_id=gate.gate_id,
+        gate_reason=gate_result.reason,
+    )
+    return await _log_evidence(node, context)
+
+
+async def emit_execution_failure_evidence(
+    exc: Exception,
+    meta: GovernedToolMeta,
+    context: GovernedToolCallContext,
+) -> str:
+    """Emit immutable evidence when the handler fails after gates pass."""
+    node = ImmutableEvidenceNode(
+        kind="tool_result",
+        evidence_type=meta.evidence_type,
+        tool_name=context.tool_name,
+        operation_context_id=context.operation_context_id,
+        inputs_summary=_redact_sensitive(context.normalized_inputs, meta.safety_class),
+        outcome="execution_failed",
+        error_type=type(exc).__name__,
+        error_message=str(exc),
+        gate_results=[r.to_dict(mode="json") for r in context.gate_results],
+    )
+    return await _log_evidence(node, context)
+```
+
+### 6. Bypass Prohibition — Why It Is Enforced at Runtime
+
+`@governed_tool` returns a `Tool`, not a directly callable wrapper. A governed tool that reaches
+the legacy raw path raises `GovernanceBypassError`, and a governed `Tool` invoked without the
+context bound by `ActionManager.execute_governed()` fails in its `Tool.preprocessor` before the
+handler runs. The enforcement mechanism is:
+
+1. `execute_governed()` creates a `GovernedToolCallContext` containing the operation context,
+   gate result `Pile`, justification, Branch reference, and `DataLogger`.
+2. `bind_governed_context()` copies the existing `Tool` and attaches that context to
+   `Tool.preprocessor_kwargs` and `Tool.postprocessor_kwargs`.
+3. `FunctionCalling._invoke()` runs the existing lifecycle: preprocessor, handler,
+   postprocessor. Missing context means the preprocessor cannot run the governed phases and the
+   call fails closed before `Tool.func_callable`.
+
+This means tests must invoke governed tools via `ActionManager.execute_governed()` with mock gate
+hooks and a mock `DataLogger`. This is intentional: it forces tests to exercise the pipeline, not
+just the handler.
+
+### 7. Backward Compatibility — Library Mode
+
+Ungoverned tools registered via `branch.register_tools([plain_function])` are unaffected.
+The `ActionManager` dispatches via `execute_raw()` when `is_governed(tool)` is
+`False`. No existing library-mode code changes.
+
+The governance pipeline is opt-in at the tool definition site:
+
+| Tool definition | `is_governed` | Dispatch path |
+|---|---|---|
+| `def my_tool(...): ...` | False | `execute_raw()` — legacy behavior |
+| `@governed_tool(...) async def my_tool(...): ...` | True | `execute_governed()` — mandatory pipeline |
+
+KHive mode (commercial) will configure `ActionManager` to reject ungoverned tools at
+registration time: `execute_raw()` raises `GovernanceModeError` when `khive_mode=True`.
+This is a configuration flag, not a code change — library-mode callers are unaffected.
+
+---
+
+## Worked Example
+
+A governed `read_file` tool illustrating the full lifecycle.
+
+```python
+from pydantic import BaseModel
+
+
+class ReadFileOptions(BaseModel):
+    path: str
+    encoding: str = "utf-8"
+    max_bytes: int = 1_048_576  # 1 MiB
+
+
+class ReadFileResult(BaseModel):
+    path: str
+    content: str
+    bytes_read: int
+
+
+@governed_tool(
+    evidence_type="fs.read",
+    hard_gates=["guard_paths"],          # block reads outside allowed roots
+    soft_gates=["confirm_sensitive_ext"],  # .env, .key, .pem require justification
+    advisory_gates=["warn_large_file"],  # warn if > max_bytes threshold
+    skip_evidence=False,
+    safety_class="standard",
+    options_schema=ReadFileOptions,
+)
+async def read_file(
+    path: str,
+    encoding: str = "utf-8",
+    max_bytes: int = 1_048_576,
+) -> ReadFileResult:
+    """Read a file from the filesystem."""
+    import aiofiles
+
+    async with aiofiles.open(path, encoding=encoding) as fh:
+        content = await fh.read(max_bytes)
+
+    return ReadFileResult(path=path, content=content, bytes_read=len(content.encode()))
+```
+
+**On successful execution** (path inside allowed root, not a sensitive extension):
+
+- Phase 1: `ReadFileOptions(path=..., encoding="utf-8", max_bytes=1048576)` coerced.
+- Phase 2: `operation_context_id` must be set by the calling Branch.
+- Phase 3: Gate registry resolves `guard_paths` (hard), `confirm_sensitive_ext` (soft),
+  `warn_large_file` (advisory).
+- Phase 4: `guard_paths` passes — path is inside `allowed_roots`.
+- Phase 5: `confirm_sensitive_ext` passes — file extension is `.py`.
+- Phase 6: `warn_large_file` passes — file is 2 KiB.
+- Phase 7: Handler runs; returns `ReadFileResult`.
+- Phase 8: Evidence node emitted:
+
+  ```json
+  {
+    "ln_id": "01JXKM...",
+    "kind": "tool_result",
+    "evidence_type": "fs.read",
+    "tool_name": "read_file",
+    "operation_context_id": "01JXKL...",
+    "outcome": "success",
+    "gate_results": {
+      "guard_paths": "passed",
+      "confirm_sensitive_ext": "passed",
+      "warn_large_file": "passed"
+    },
+    "immutable": true
+  }
+  ```
+
+**On `guard_paths` failure** (path outside allowed root):
+
+- Phases 1–3: same as above.
+- Phase 4: `guard_paths` fails → `GateBlockedError` raised immediately.
+- Evidence node emitted with `"outcome": "gate_blocked", "gate_id": "guard_paths"`.
+- Phases 5–8 do not execute. The handler is never called.
+
+**On `.env` read without justification**:
+
+- Phase 4: `guard_paths` passes (`.env` is inside allowed root).
+- Phase 5: `confirm_sensitive_ext` fails, `justification=None` →
+  `JustificationRequiredError` raised with `prompt="Reading .env file requires a
+  documented reason."`.
+- The caller must re-invoke with `justification="Debugging auth config in dev environment"`.
+
+---
+
+## Consequences
+
+**Positive**
+
+- **Single audit point**: every governed tool call emits evidence. No call site can opt out.
+- **Governance visible at definition**: reading the function tells you exactly what gates apply
+  and what evidence category is emitted. No separate config file lookup required.
+- **Fail-closed universally**: Phase 2 raises on missing Operation Context; Phase 4 raises on
+  any hard gate failure; any exception in Phase 7 emits failure evidence. Ambiguity → deny.
+  This is cross-cutting principle #1 made structural.
+- **Testability**: `GovernanceBypassError` and missing-context preprocessor failures force test
+  authors to exercise the pipeline. Integration with mock gate hooks and `DataLogger` is explicit,
+  not accidental.
+- **Backward compatibility**: ungoverned tools registered via `register_tools()` continue to
+  work without any migration. The decorator is an opt-in escalation, not a breaking change.
+- **Evidence carries gate results**: the evidence node records which gates ran and their
+  outcomes at execution time. This satisfies cross-cutting principle #2 — evidence is not
+  just a log entry; it encodes the policy state active at the moment of execution.
+
+**Negative**
+
+- **Decorator boilerplate**: each governed tool needs `@governed_tool(...)` with meaningful
+  gate declarations. A tool with no metadata compiles but defeats the purpose.
+- **Direct-call friction in tests**: decorated governed tools are `Tool` instances, and governed
+  `Tool` instances cannot use the raw path. Test authors must adapt to call through
+  `ActionManager.execute_governed()`.
+- **Sequential gate execution**: the eight-phase pipeline adds latency proportional to the
+  number of gates resolved. For `skip_evidence=True` tools with no gates, the overhead is
+  a single preprocessor context check per call.
+- **Invocation-local context copy**: `execute_governed()` must bind a fresh context copy for each
+  call. Reusing a shared `Tool` without rebinding context fails closed in the preprocessor; this is
+  safer than silently sharing gate results across concurrent calls.
+
+---
+
+## Non-Goals
+
+Explicitly out of scope:
+
+- **Gate implementation** (what each gate does, how gate results are computed): this is
+  ADR-0044. This ADR only declares the gate slots and the execution order.
+- **JIT grants and break-glass overrides**: an agent acquiring a tool grant at runtime is
+  ADR-0046. This ADR does not address dynamic permission escalation.
+- **Multi-tenant policy resolution** (which gates apply to which tenants): this is ADR-0052.
+  The `GovernedToolMeta` carries tool-level declarations; tenant-level policy overlay is
+  a KHive concern resolved before Phase 3.
+- **Tool registry** (where governed tools are stored, how they are discovered, what allowlists
+  look like): this is ADR-0051. This ADR concerns declaration at definition time; the
+  registry concern is how those declarations are indexed at runtime.
+- **Task Certificate** (the signed proof that all phases completed): this is ADR-0042.
+  Evidence nodes emitted in Phase 8 feed the certificate, but certificate construction
+  is outside this ADR's scope.
+- **Log tier governance** (whether evidence nodes are MUTABLE/PROTECTED/IMMUTABLE): this
+  is ADR-0049. Evidence nodes produced in Phase 8 are always IMMUTABLE per ADR-0041;
+  the tier assignment protocol is separate.
+
+---
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|---|---|
+| **Middleware pattern** (framework-level hook wrapping all tool calls) | Action-specific gates are impossible: middleware sees tool name and args, not tool-level declarations. A `guard_paths` gate for `read_file` and a `guard_destructive` gate for `write_file` cannot be differentiated at the middleware layer without rebuilding the same per-tool metadata structure this ADR provides. Rejected per prior research. |
+| **Policy-only enforcement** (extend `PermissionPolicy` with gate declarations) | Enforcement metadata remains at the call site (agent constructor), not the tool definition. Two agents registering the same `write_file` function can have inconsistent policies. Drift is structurally permitted. Violates principle #3. |
+| **Separate config files** (`governance.yaml` mapping function names to gate lists) | Config files desync from code: rename a function, forget to update the config, governance silently breaks. Co-location is not optional when the goal is "every constraint enforced." |
+| **Multiple decorators** (`@gate_check`, `@emit_evidence`, `@fail_closed` separately) | Ordering between decorators is implicit. A developer can apply `@emit_evidence` without `@gate_check`. There is no single place to read the full governance specification of a tool. Evidence correlation across phases is lost. Rejected per prior research `Decorator-Only Pattern`. |
+| **No governed tools** (keep current `PermissionPolicy` as the only layer) | Sufficient for library mode. Insufficient for KHive, where a regulated customer requires an audit trail that demonstrates every tool call was gated and every result was evidenced — not merely that a policy was configured. |
+
+---
+
+## References
+
+- [ADR-0041](ADR-0041-immutable-evidence-nodes.md) — Evidence nodes emitted in Phase 8; append-only store
+- [ADR-0044](ADR-0044-tool-gates.md) — Gate registry: what each gate ID resolves to, HARD/SOFT/ADVISORY semantics, specificity rules, class-level gate merging
+- [ADR-0050](ADR-0050-operation-context.md) — OperationContext required in Phase 2; links tool call to session and agent identity
+- [ADR-0051](ADR-0051-tool-registry-allowlists.md) — Where governed tools register; append-only allowlist entries
+- [ADR-0042](ADR-0042-task-certificate.md) — Task Certificate accumulates evidence nodes from Phase 8
+- [ADR-0046](ADR-0046-jit-tool-grant.md) — JIT grants acquired at runtime; interact with SOFT gate resolution
+- [ADR-0033](ADR-0033-unified-entity-state-model.md) — `EvidenceRef` kinds (tool_result, model_inference, etc.) used in Phase 8 evidence nodes
+- [ADR-0023](ADR-0023-unified-hook-system.md) — Existing hook system; `guard_destructive`, `guard_paths`, `log_tool_use` are candidates for migration to gate declarations
+- prior governance research `01_design/010-action-declaration/ADR-010-action-declaration.md` — `@action` decorator and `ActionMeta` frozen dataclass pattern
+- prior governance research `01_design/012-single-enforcement/ADR-012-single-enforcement.md` — `CanonService.request()` single entry point; "any bypass breaks compliance"

--- a/docs/adrs/ADR-0043-governed-tool-declaration.md
+++ b/docs/adrs/ADR-0043-governed-tool-declaration.md
@@ -1,6 +1,6 @@
 # ADR-0043: Governed Tool Declaration
 
-**Status**: Proposed
+**Status**: proposed
 **Date**: 2026-05-26
 **Depends on**: [ADR-0041](ADR-0041-immutable-evidence-nodes.md), [ADR-0050](ADR-0050-operation-context.md)
 **Related**: [ADR-0044](ADR-0044-tool-gates.md), [ADR-0051](ADR-0051-tool-registry-allowlists.md), [ADR-0033](ADR-0033-unified-entity-state-model.md), [ADR-0023](ADR-0023-unified-hook-system.md)

--- a/docs/adrs/ADR-0043-governed-tool-declaration.md
+++ b/docs/adrs/ADR-0043-governed-tool-declaration.md
@@ -46,7 +46,7 @@ remains as the schema and callable carrier; governance metadata is a separate, f
 
 ### Why lionagi needs this
 
-Consider a KHive agent writing to a code repository. The `write_file` tool must: confirm that the
+Consider an agent writing to a code repository. The `write_file` tool must: confirm that the
 target path is inside an allowed workspace (HARD gate), require an explicit justification when the
 path is outside a designated source tree (SOFT gate), log a warning when the diff exceeds 500
 lines (ADVISORY gate), and emit an evidence node that links the write operation to its operation
@@ -507,8 +507,8 @@ class ActionManager:
     ) -> Any:
         """Execute an ungoverned tool without the governance pipeline.
 
-        Only available in library mode.  KHive mode raises ``GovernanceModeError``
-        from this method at startup configuration.
+        Only available in library mode.  Strict governance mode raises
+        ``GovernanceModeError`` from this method at startup configuration.
 
         Ungoverned tools registered via ``branch.register_tools([plain_function])``
         continue to work through this path with zero configuration changes.
@@ -643,9 +643,10 @@ The governance pipeline is opt-in at the tool definition site:
 | `def my_tool(...): ...` | False | `execute_raw()` — legacy behavior |
 | `@governed_tool(...) async def my_tool(...): ...` | True | `execute_governed()` — mandatory pipeline |
 
-KHive mode (commercial) will configure `ActionManager` to reject ungoverned tools at
-registration time: `execute_raw()` raises `GovernanceModeError` when `khive_mode=True`.
-This is a configuration flag, not a code change — library-mode callers are unaffected.
+Deployments requiring strict governance may configure `ActionManager` to reject ungoverned tools
+at registration time: `execute_raw()` raises `GovernanceModeError` when strict governance mode
+is enabled. This is a configuration flag, not a code change — library-mode callers are
+unaffected.
 
 ---
 
@@ -781,9 +782,9 @@ Explicitly out of scope:
   ADR-0044. This ADR only declares the gate slots and the execution order.
 - **JIT grants and break-glass overrides**: an agent acquiring a tool grant at runtime is
   ADR-0046. This ADR does not address dynamic permission escalation.
-- **Multi-tenant policy resolution** (which gates apply to which tenants): this is ADR-0052.
-  The `GovernedToolMeta` carries tool-level declarations; tenant-level policy overlay is
-  a KHive concern resolved before Phase 3.
+- **Policy resolution** (which gates apply in a given context): this is ADR-0052.
+  The `GovernedToolMeta` carries tool-level declarations; policy overlay is resolved before
+  Phase 3.
 - **Tool registry** (where governed tools are stored, how they are discovered, what allowlists
   look like): this is ADR-0051. This ADR concerns declaration at definition time; the
   registry concern is how those declarations are indexed at runtime.
@@ -804,7 +805,7 @@ Explicitly out of scope:
 | **Policy-only enforcement** (extend `PermissionPolicy` with gate declarations) | Enforcement metadata remains at the call site (agent constructor), not the tool definition. Two agents registering the same `write_file` function can have inconsistent policies. Drift is structurally permitted. Violates principle #3. |
 | **Separate config files** (`governance.yaml` mapping function names to gate lists) | Config files desync from code: rename a function, forget to update the config, governance silently breaks. Co-location is not optional when the goal is "every constraint enforced." |
 | **Multiple decorators** (`@gate_check`, `@emit_evidence`, `@fail_closed` separately) | Ordering between decorators is implicit. A developer can apply `@emit_evidence` without `@gate_check`. There is no single place to read the full governance specification of a tool. Evidence correlation across phases is lost. Rejected per prior research `Decorator-Only Pattern`. |
-| **No governed tools** (keep current `PermissionPolicy` as the only layer) | Sufficient for library mode. Insufficient for KHive, where a regulated customer requires an audit trail that demonstrates every tool call was gated and every result was evidenced — not merely that a policy was configured. |
+| **No governed tools** (keep current `PermissionPolicy` as the only layer) | Sufficient for library mode. Insufficient for governed deployments where the audit trail must demonstrate every tool call was gated and every result was evidenced — not merely that a policy was configured. |
 
 ---
 

--- a/docs/adrs/ADR-0044-tool-gates.md
+++ b/docs/adrs/ADR-0044-tool-gates.md
@@ -1,6 +1,6 @@
 # ADR-0044: Tool Gates — Three-Tier Binary Enforcement
 
-**Status**: Proposed
+**Status**: proposed
 **Date**: 2026-05-26
 **Depends on**: [ADR-0043](ADR-0043-governed-tool-declaration.md), [ADR-0041](ADR-0041-immutable-evidence-nodes.md)
 **Related**: [ADR-0045](ADR-0045-break-glass-protocol.md), [ADR-0050](ADR-0050-operation-context.md), [ADR-0046](ADR-0046-jit-tool-grant.md), [ADR-0033](ADR-0033-unified-entity-state-model.md)

--- a/docs/adrs/ADR-0044-tool-gates.md
+++ b/docs/adrs/ADR-0044-tool-gates.md
@@ -47,10 +47,9 @@ rules from informational warnings.
 
 A coding agent with a file-editor tool and no explicit gate registration can overwrite files
 outside the project workspace if `PermissionPolicy` is in `mode="allow_all"` (the default for
-orchestrators). Nothing in the current system guarantees that `guard_paths` runs. When an agent
-in a governed context (KHive tenant, Lion Studio session with audit logging) executes a write
-outside bounds, there is no evidence artifact recording that the write was ungated — the
-operation silently succeeds and appears identical to an explicitly approved one. The gate tier
+orchestrators). Nothing in the current system guarantees that `guard_paths` runs. When an agent in a governed context executes a write outside bounds, there is no evidence
+artifact recording that the write was ungated — the operation silently succeeds and appears
+identical to an explicitly approved one. The gate tier
 structure ensures that HARD gates cannot be absent from governed tools (enforced by
 [ADR-0043](ADR-0043-governed-tool-declaration.md)), and that every gate evaluation — whether
 passed or failed — produces a `GateResult` that becomes evidence in the operation record
@@ -597,8 +596,9 @@ async def justify_gate(
 class DefaultJustificationPolicy:
     """Accept any non-empty justification from any actor.
 
-    Production deployments replace this with a policy that validates actor
-    identity, checks justification length, and/or requires corroborating evidence.
+    Deployments requiring stricter justification validation should replace this with a policy
+    that validates actor identity, checks justification length, and/or requires corroborating
+    evidence.
     """
 
     async def evaluate(
@@ -912,9 +912,6 @@ Explicitly out of scope:
   Threshold-based authorization is explicitly rejected (see prior research, Alternative 1).
 - **Gate composition DSL**: there is no `AND(gate_a, gate_b)` or `OR(gate_a, gate_b)` syntax.
   Composite logic is expressed by calling other gates inside an evaluator function.
-- **Multi-tenant policy stitching**: resolving gate inheritance across tenant hierarchies,
-  overriding organizational gates at the workspace level, and merging gate registries from
-  multiple policy sources are KHive-layer concerns addressed in ADR-0052.
 - **Human-approval workflows**: routing a SOFT override to a human approver UI, timeout
   handling, and async approval state machines are addressed in ADR-0046 (JIT Tool Grant).
 - **Gate versioning and migration**: upgrading a gate's enforcement tier across live sessions,
@@ -946,7 +943,7 @@ Explicitly out of scope:
 - [ADR-0046](ADR-0046-jit-tool-grant.md) — the JIT grant protocol handles human-in-the-loop approval for SOFT gate overrides
 - [ADR-0047](ADR-0047-agent-charter.md) — charters bind agents to specific gate sets; a gate not declared in the charter cannot be bypassed
 - [ADR-0050](ADR-0050-operation-context.md) — `OperationContext` is the active assertion that receives `GateResult` records at evaluation time
-- [ADR-0052](ADR-0052-policy-resolution.md) — most-specific-wins resolution for gate registries across tenant hierarchies (KHive layer)
+- [ADR-0052](ADR-0052-policy-resolution.md) — most-specific-wins resolution for gate registries across tenant hierarchies
 - [ADR-0033](ADR-0033-unified-entity-state-model.md) — `EvidenceRef` (8 kinds) is the shared substrate; `GateResult.evidence_refs` uses this type
 - [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) — `Claim.confidence` is where probabilistic reasoning lives; explicitly not in gates
 - prior governance research `01_design/008-policy-gates/ADR-008-policy-gates.md` — source pattern (three-tier model, binary semantics, HashiCorp Sentinel inspiration)

--- a/docs/adrs/ADR-0044-tool-gates.md
+++ b/docs/adrs/ADR-0044-tool-gates.md
@@ -1,0 +1,954 @@
+# ADR-0044: Tool Gates — Three-Tier Binary Enforcement
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Depends on**: [ADR-0043](ADR-0043-governed-tool-declaration.md), [ADR-0041](ADR-0041-immutable-evidence-nodes.md)
+**Related**: [ADR-0045](ADR-0045-break-glass-protocol.md), [ADR-0050](ADR-0050-operation-context.md), [ADR-0046](ADR-0046-jit-tool-grant.md), [ADR-0033](ADR-0033-unified-entity-state-model.md)
+
+---
+
+## Context
+
+lionagi today has three independent mechanisms that collectively serve as access control over
+tool calls: `PermissionPolicy` (allowlist/denylist/escalate mode in `lionagi/agent/permissions.py`),
+ad-hoc pre-hooks registered via `AgentConfig.pre()`, and two named hooks (`guard_destructive`,
+`guard_paths` in `lionagi/agent/hooks.py`). These mechanisms differ in failure semantics,
+composition, and auditability in ways that create gaps.
+
+`PermissionPolicy` operates on glob patterns and expresses three behaviors — allow, deny, escalate
+— but carries no evidence and does not distinguish between a hard safety requirement and a soft
+business rule. `guard_destructive` raises `PermissionError` unconditionally for any destructive
+command, with no path to justification or escalation. `guard_paths` likewise raises with no
+override mechanism. `log_tool_use` produces a log entry but contributes no evidence to the
+operation record. The result is that a framework consumer must reach into three different systems
+to answer the question "what constraints are active on this tool call, and can they be overridden?"
+
+Two of the three cross-cutting principles this governance slate enforces apply directly here.
+Principle 1 (fail-closed is the universal default) has no systematic expression today: some hooks
+raise on failure, some return `None`, and if an evaluator crashes the caller receives an unhandled
+exception rather than a clean deny. Principle 3 (every constraint must be enforced, not just
+documented) is violated when a `PermissionPolicy` in `mode="allow_all"` is in force and all hooks
+are simply not registered — there is no mechanism to guarantee a gate runs regardless of session
+configuration.
+
+### The applicable prior governance research insight
+
+prior research establishes that gates return `passed: bool` — no intermediate states, no
+confidence scores. The reasoning is precise: authorization is a question of fact, not of
+probability. "Did the user consent to this write?" has a yes or no answer. "Was this action
+covered by the granted capability?" has a yes or no answer. Confidence scores introduce threshold
+debates, legal ambiguity, and—critically—they shift the locus of the authorization decision from
+the gate to whoever chose the threshold. Binary semantics eliminate that ambiguity entirely.
+prior governance research also introduces the three-tier model (HARD_MANDATORY, SOFT_MANDATORY, ADVISORY) directly
+inspired by HashiCorp Sentinel, distinguishing irrevocable requirements from overridable business
+rules from informational warnings.
+
+### Why lionagi needs this
+
+A coding agent with a file-editor tool and no explicit gate registration can overwrite files
+outside the project workspace if `PermissionPolicy` is in `mode="allow_all"` (the default for
+orchestrators). Nothing in the current system guarantees that `guard_paths` runs. When an agent
+in a governed context (KHive tenant, Lion Studio session with audit logging) executes a write
+outside bounds, there is no evidence artifact recording that the write was ungated — the
+operation silently succeeds and appears identical to an explicitly approved one. The gate tier
+structure ensures that HARD gates cannot be absent from governed tools (enforced by
+[ADR-0043](ADR-0043-governed-tool-declaration.md)), and that every gate evaluation — whether
+passed or failed — produces a `GateResult` that becomes evidence in the operation record
+(enforced by [ADR-0050](ADR-0050-operation-context.md)).
+
+---
+
+## Decision
+
+We introduce `ToolGate`, a registered binary predicate with one of three enforcement tiers
+(HARD_MANDATORY, SOFT_MANDATORY, ADVISORY), where every evaluation produces a `GateResult` that
+is immutable evidence, and where any evaluator exception resolves to `passed=False` rather than
+propagating.
+
+---
+
+### 1. Core Types
+
+```python
+from __future__ import annotations
+
+import time
+from collections.abc import Awaitable, Callable
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+from pydantic import ConfigDict, Field
+
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+
+if TYPE_CHECKING:
+    from lionagi.protocols.messages.action_request import ActionRequest
+    from lionagi.session.branch import Branch
+    from lionagi.protocols.governance.evidence import EvidenceRef
+
+
+class GateEnforcement(Enum):
+    """Enforcement tier for a ToolGate.
+
+    HARD_MANDATORY: failure terminates the action with no override path.
+    SOFT_MANDATORY: failure pauses execution; a justification + evidence can
+                    unlock continuation per the active policy.
+    ADVISORY:       failure emits a warning; action proceeds unconditionally.
+    """
+
+    HARD_MANDATORY = "hard"
+    SOFT_MANDATORY = "soft"
+    ADVISORY = "advisory"
+
+
+GateEvaluator = Callable[
+    ["Branch", "ActionRequest", Any],
+    Awaitable["GateResult"],
+]
+
+
+class GateResult(Element):
+    """Immutable record of one gate evaluation.
+
+    Every field is populated on both pass and fail.  This record is
+    forwarded to the OperationContext (ADR-0050) and stored as an
+    ImmutableEvidenceNode (ADR-0041).
+
+    Fail-closed invariant: if the evaluator raised, ``passed`` is False
+    and ``reason`` contains the exception message.  No exception propagates
+    out of the gate executor.
+
+    If enforcement is SOFT_MANDATORY and the gate failed, the record may
+    later be amended with ``justification`` and ``justification_actor_id``
+    when an override is accepted.  The amended record is a new frozen
+    instance; the original is never mutated.
+    """
+
+    passed: bool
+    gate_id: str
+    enforcement: GateEnforcement
+    reason: str                               # always populated, even on pass
+    evaluated_at: float = Field(default_factory=time.monotonic)
+    evidence_refs: Pile["EvidenceRef"] = Field(
+        default_factory=lambda: Pile(item_type=Element, strict_type=False)
+    )
+    # Populated only when a SOFT gate is overridden:
+    justification: str | None = None
+    justification_actor_id: str | None = None
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=False,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    def with_justification(
+        self,
+        justification: str,
+        actor_id: str,
+    ) -> GateResult:
+        """Return a new GateResult carrying override justification.
+
+        The original record is preserved unchanged (immutable evidence).
+        The returned record represents the override decision, not a mutation.
+        """
+        return self.model_copy(
+            update={
+                "evidence_refs": Pile(
+                    collections=list(self.evidence_refs),
+                    item_type=Element,
+                    strict_type=False,
+                ),
+                "justification": justification,
+                "justification_actor_id": actor_id,
+            },
+            deep=True,
+        )
+
+
+class ToolGate(Element):
+    """A registered binary predicate applied before a governed tool call.
+
+    ``evaluator`` is an async callable with the existing gate hook signature::
+
+        async def evaluator(branch: Branch, tool_call: ActionRequest, context: object) -> GateResult:
+            ...
+
+    The adapter in ``lionagi/agent/gates/`` invokes this hook-shaped gate from
+    ``Tool.preprocessor`` so it participates in the current Branch action flow
+    without a parallel callback registry.
+
+    ``owner`` is a free-form string naming the subsystem that owns this gate
+    (e.g. ``"lionagi"``, ``"khive"``, ``"user"``).  Used in audit trails and
+    error messages only; no behavioral effect.
+    """
+
+    gate_id: str
+    enforcement: GateEnforcement
+    evaluator: GateEvaluator = Field(exclude=True)
+    description: str
+    owner: str                                # "lionagi" | "khive" | "user"
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=False,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+```
+
+### 2. Gate Registration
+
+Gates are managed through the existing `Branch` facade by mounting a `GateManager` on
+`branch.acts` (`ActionManager`).  Two attachment points mirror the existing hook system:
+
+- **Class-level gates** — attached to a tool's class via `@governed_tool(gates=[...])` (declared
+  in [ADR-0043](ADR-0043-governed-tool-declaration.md)).  All instances of the class carry these
+  gates; they run before action-level gates.
+- **Action-level gates** — attached to a specific callable (one action on one tool) via
+  `branch.attach_gate_to_action(tool, action, gate_id)`.
+
+```python
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from pydantic import Field
+
+from lionagi.agent.gates.types import ToolGate
+from lionagi.protocols.action.tool import Tool
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+
+if TYPE_CHECKING:
+    from lionagi.session.branch import Branch
+
+
+logger = logging.getLogger(__name__)
+
+
+class GateBinding(Element):
+    """Declarative attachment between a gate and a tool/action surface."""
+
+    gate_id: str
+    tool_name: str | None = None
+    action: str | None = None
+    tool_class_name: str | None = None
+
+    def matches(self, *, tool: Tool, action: str) -> bool:
+        class_name = tool.__class__.__name__
+        return (
+            bool(self.gate_id)
+            and self.tool_class_name in (None, class_name)
+            and self.tool_name in (None, tool.function)
+            and self.action in (None, action)
+        )
+
+
+class GateManager(Element):
+    """ActionManager-mounted collection of active ToolGates and bindings."""
+
+    gates: Pile[ToolGate] = Field(
+        default_factory=lambda: Pile(item_type=ToolGate, strict_type=True)
+    )
+    bindings: Pile[GateBinding] = Field(
+        default_factory=lambda: Pile(item_type=GateBinding, strict_type=True)
+    )
+
+    def register_gate(self, gate: ToolGate) -> None:
+        """Register a gate globally.  Duplicate gate_id replaces previous entry."""
+        duplicate = next((g for g in self.gates if g.gate_id == gate.gate_id), None)
+        if duplicate is not None:
+            logger.warning("gate_manager: replacing existing gate %s", gate.gate_id)
+            self.gates.exclude(duplicate)
+        self.gates.include(gate)
+
+    def attach_to_class(self, tool_class_name: str, gate_id: str) -> None:
+        """Attach a registered gate to all actions on a tool class."""
+        self.bindings.include(GateBinding(gate_id=gate_id, tool_class_name=tool_class_name))
+
+    def attach_to_action(self, tool_name: str, action: str, gate_id: str) -> None:
+        """Attach a registered gate to a specific tool action."""
+        self.bindings.include(GateBinding(gate_id=gate_id, tool_name=tool_name, action=action))
+
+    def gates_for(
+        self,
+        *,
+        branch: Branch,
+        tool_name: str,
+        action: str,
+    ) -> Pile[ToolGate]:
+        """Return ordered gates applicable to a call.
+
+        Order: class-level gates first (most general), then action-level
+        gates (most specific).  Within each tier, registration order is
+        preserved.  HARD gates are not sorted to the front here; the
+        executor handles early-exit semantics.
+        """
+        tool = branch.acts.registry.get(tool_name)
+        if tool is None:
+            return Pile(item_type=ToolGate, strict_type=True)
+
+        gates_by_id = {gate.gate_id: gate for gate in self.gates}
+        ordered: list[ToolGate] = []
+        seen: set[str] = set()
+        class_bindings = [
+            binding for binding in self.bindings if binding.tool_class_name is not None
+        ]
+        action_bindings = [
+            binding for binding in self.bindings if binding.tool_class_name is None
+        ]
+        for binding in [*class_bindings, *action_bindings]:
+            if binding.matches(tool=tool, action=action):
+                gate = gates_by_id.get(binding.gate_id)
+                if gate is not None and gate.gate_id not in seen:
+                    seen.add(gate.gate_id)
+                    ordered.append(gate)
+        return Pile(collections=ordered, item_type=ToolGate, strict_type=True)
+
+
+def ensure_gate_manager(branch: Branch) -> GateManager:
+    """Attach gate state to the existing ActionManager instead of a callback registry."""
+    manager = getattr(branch.acts, "gate_manager", None)
+    if manager is None:
+        manager = GateManager()
+        branch.acts.gate_manager = manager
+    return manager
+
+
+# Branch facade methods added by the gate integration:
+def register_gate(self: Branch, gate: ToolGate) -> None:
+    ensure_gate_manager(self).register_gate(gate)
+
+
+def attach_gate_to_action(self: Branch, tool_name: str, action: str, gate_id: str) -> None:
+    ensure_gate_manager(self).attach_to_action(tool_name, action, gate_id)
+```
+
+### 3. Gate Executor and Fail-Closed Invariant
+
+The executor runs all applicable gates and enforces the fail-closed invariant: if an evaluator
+raises for any reason, the result is `GateResult(passed=False, ...)` — not a propagated exception,
+not `passed=True`.  This is the most critical behavioral guarantee in this ADR.
+
+```python
+from __future__ import annotations
+
+import inspect
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+from pydantic import Field
+
+from lionagi.agent.gates.manager import ensure_gate_manager
+from lionagi.agent.gates.types import GateEnforcement, GateResult, ToolGate
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+from lionagi.protocols.messages.action_request import ActionRequest
+
+if TYPE_CHECKING:
+    from lionagi.protocols.action.tool import Tool
+    from lionagi.session.branch import Branch
+
+logger = logging.getLogger(__name__)
+
+
+class GateExecutionResult(Element):
+    """Aggregated outcome of running all gates for one tool call."""
+
+    results: Pile[GateResult] = Field(
+        default_factory=lambda: Pile(item_type=GateResult, strict_type=True)
+    )
+    hard_blocked: bool = False
+    soft_blocked: bool = False
+    blocking_gate_id: str | None = None
+
+    @property
+    def can_proceed(self) -> bool:
+        return not self.hard_blocked and not self.soft_blocked
+
+
+class GateExecutor(Element):
+    """Evaluates all applicable gates for a tool call.
+
+    Fail-closed: evaluator exceptions → passed=False.
+    HARD gate failure → GateExecutionResult.hard_blocked=True; remaining
+    gates are skipped.
+    SOFT gate failure → execution pauses; a justification round-trip is
+    required before continuation (see Section 4).
+    ADVISORY gate failure → warning logged; result recorded; execution
+    continues.
+    """
+
+    async def evaluate_all(
+        self,
+        *,
+        branch: Branch,
+        tool_call: ActionRequest,
+        context: object | None = None,  # OperationContext (ADR-0050)
+    ) -> GateExecutionResult:
+        action = _action_name(tool_call)
+        gate_manager = ensure_gate_manager(branch)
+        gates = gate_manager.gates_for(
+            branch=branch,
+            tool_name=tool_call.function,
+            action=action,
+        )
+        results = Pile(item_type=GateResult, strict_type=True)
+
+        for gate in gates:
+            result = await self._run_one(gate, branch, tool_call, context)
+            results.include(result)
+            self._record_result(branch, context, tool_call, result)
+
+            if not result.passed:
+                if result.enforcement == GateEnforcement.HARD_MANDATORY:
+                    # Fail-closed: stop immediately, do not evaluate remaining gates.
+                    return GateExecutionResult(
+                        results=results,
+                        hard_blocked=True,
+                        soft_blocked=False,
+                        blocking_gate_id=result.gate_id,
+                    )
+                if result.enforcement == GateEnforcement.SOFT_MANDATORY:
+                    # Pause for justification; remaining gates skipped until override.
+                    return GateExecutionResult(
+                        results=results,
+                        hard_blocked=False,
+                        soft_blocked=True,
+                        blocking_gate_id=result.gate_id,
+                    )
+                # ADVISORY: log warning, continue evaluating remaining gates.
+                logger.warning(
+                    "gate advisory failed: gate_id=%s tool=%s.%s reason=%s",
+                    result.gate_id, tool_call.function, action, result.reason,
+                )
+
+        return GateExecutionResult(
+            results=results,
+            hard_blocked=False,
+            soft_blocked=False,
+            blocking_gate_id=None,
+        )
+
+    async def _run_one(
+        self,
+        gate: ToolGate,
+        branch: Branch,
+        tool_call: ActionRequest,
+        context: object | None,
+    ) -> GateResult:
+        """Execute one gate evaluator.  Never raises — fail-closed."""
+        try:
+            result = gate.evaluator(branch, tool_call, context)
+            if inspect.isawaitable(result):
+                result = await result
+            if not isinstance(result, GateResult):
+                raise TypeError(f"Gate {gate.gate_id} returned {type(result)!r}")
+            return result
+        except BaseException as exc:
+            # Fail-closed invariant: evaluator error → deny.
+            logger.exception("gate evaluator raised (fail-closed deny): %s", gate.gate_id)
+            return GateResult(
+                passed=False,
+                gate_id=gate.gate_id,
+                enforcement=gate.enforcement,
+                reason=f"evaluator raised: {type(exc).__name__}: {exc}",
+                evaluated_at=time.monotonic(),
+            )
+
+    def _record_result(
+        self,
+        branch: Branch,
+        context: object | None,
+        tool_call: ActionRequest,
+        result: GateResult,
+    ) -> None:
+        """Record gate evidence through OperationContext and Branch DataLogger."""
+        if context is not None and hasattr(context, "record_gate_result"):
+            context.record_gate_result(result)
+        branch._log_manager.log(
+            {
+                "event": "tool_gate.evaluated",
+                "branch_id": str(branch.id),
+                "function": tool_call.function,
+                "gate_result": result.to_dict(mode="json"),
+            }
+        )
+
+
+def _action_name(tool_call: ActionRequest) -> str:
+    args = tool_call.arguments or {}
+    return str(args.get("action") or args.get("operation") or "")
+
+
+def install_gate_preprocessor(branch: Branch, tool: Tool) -> None:
+    """Run gates through Tool.preprocessor, the path ActionManager already invokes."""
+    prior = tool.preprocessor
+    prior_kwargs = dict(tool.preprocessor_kwargs or {})
+    executor = GateExecutor()
+
+    async def gated_preprocessor(args: dict[str, Any], **_kw: Any) -> dict[str, Any]:
+        if prior is not None:
+            args = prior(args, **prior_kwargs)
+            if inspect.isawaitable(args):
+                args = await args
+
+        tool_call = ActionRequest(
+            content={"function": tool.function, "arguments": args},
+            sender=branch.id,
+            recipient=tool.id,
+        )
+        context = getattr(branch, "_active_operation_context", None)
+        execution = await executor.evaluate_all(
+            branch=branch,
+            tool_call=tool_call,
+            context=context,
+        )
+        if not execution.can_proceed:
+            raise PermissionError(f"tool gate blocked: {execution.blocking_gate_id}")
+        return args
+
+    tool.preprocessor = gated_preprocessor
+    tool.preprocessor_kwargs = {}
+```
+
+### 4. SOFT Gate Override Flow
+
+When the executor returns `soft_blocked=True`, execution pauses before the tool action runs.
+The override path is:
+
+1. The branch surfaces the blocking `GateResult` to the calling context (agent, orchestrator,
+   or human via [ADR-0046](ADR-0046-jit-tool-grant.md)).
+2. The calling context invokes `branch.justify_gate(gate_id, justification, actor_id, evidence)`.
+3. The branch's active `JustificationPolicy` evaluates the justification.  The policy is pluggable;
+   the default policy accepts any non-empty justification from a registered actor.
+4. If accepted: the original `GateResult` is preserved in the evidence chain; a new
+   `GateResult` carrying `justification` and `justification_actor_id` is appended as a sibling
+   evidence node.  Execution continues.
+5. If rejected: a `GateResult(passed=False, reason="justification rejected", ...)` is appended.
+   The action terminates with a DENY outcome recorded in the OperationContext.
+
+```python
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+from lionagi.agent.gates.types import GateEnforcement, GateResult
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+
+if TYPE_CHECKING:
+    from lionagi.protocols.governance.evidence import EvidenceRef
+    from lionagi.session.branch import Branch
+
+
+async def justify_gate(
+    branch: Branch,
+    gate_id: str,
+    justification: str,
+    actor_id: str,
+    evidence: Pile["EvidenceRef"] | None = None,
+) -> bool:
+    """Attempt to override a SOFT_MANDATORY gate failure.
+
+    Returns True if the justification was accepted and execution may resume.
+    Returns False if rejected; the branch records a DENY outcome.
+
+    The justification and its acceptance/rejection both become immutable
+    evidence nodes (ADR-0041) attached to the active OperationContext (ADR-0050).
+    """
+    evidence_refs = evidence or Pile(item_type=Element, strict_type=False)
+    policy = getattr(branch, "_justification_policy", DefaultJustificationPolicy())
+    accepted = await policy.evaluate(gate_id, justification, actor_id, evidence_refs)
+
+    result = GateResult(
+        passed=accepted,
+        gate_id=gate_id,
+        enforcement=GateEnforcement.SOFT_MANDATORY,
+        reason="justification accepted" if accepted else "justification rejected",
+        evaluated_at=time.monotonic(),
+        evidence_refs=evidence_refs,
+        justification=justification,
+        justification_actor_id=actor_id,
+    )
+
+    ctx = getattr(branch, "_active_operation_context", None)
+    if ctx is not None and hasattr(ctx, "record_gate_result"):
+        ctx.record_gate_result(result)
+    branch._log_manager.log(
+        {
+            "event": "tool_gate.justification",
+            "branch_id": str(branch.id),
+            "gate_result": result.to_dict(mode="json"),
+        }
+    )
+
+    return accepted
+
+
+class DefaultJustificationPolicy:
+    """Accept any non-empty justification from any actor.
+
+    Production deployments replace this with a policy that validates actor
+    identity, checks justification length, and/or requires corroborating evidence.
+    """
+
+    async def evaluate(
+        self,
+        gate_id: str,
+        justification: str,
+        actor_id: str,
+        evidence: Pile["EvidenceRef"],
+    ) -> bool:
+        return bool(justification.strip()) and bool(actor_id.strip())
+```
+
+### 5. Resolution Order
+
+All applicable gates evaluate in this order.  The first HARD failure terminates; all ADVISORY
+failures accumulate.  A SOFT failure pauses after the first occurrence (remaining gates do not
+run until the override is resolved).
+
+```text
+1. Class-level hard gates      (attached to tool class via @governed_tool)
+2. Class-level situational gates (conditional on args, still class-level registration)
+3. Action-level hard gates     (attached to specific callable)
+4. Action-level situational gates
+```
+
+Within each level, registration order is preserved.  Most-specific wins in the sense that
+action-level gates can shadow class-level gates via `gate_id` deduplication, but all applicable
+gates still run unless a HARD failure occurs.
+
+### 6. Built-in Gates
+
+lionagi ships four built-in gates.  All live under `lionagi/agent/gates/` and are
+available for attachment without additional imports.
+
+```python
+# lionagi/agent/gates/builtins.py
+
+from __future__ import annotations
+
+import json
+import urllib.parse
+from typing import TYPE_CHECKING, Any
+
+from lionagi.agent.gates.types import GateEnforcement, GateResult, ToolGate
+from lionagi.agent.hooks import guard_destructive, guard_paths
+
+if TYPE_CHECKING:
+    from lionagi.protocols.messages.action_request import ActionRequest
+    from lionagi.session.branch import Branch
+
+
+def _args(tool_call: ActionRequest) -> dict[str, Any]:
+    return tool_call.arguments or {}
+
+
+# --- guard_destructive ---------------------------------------------------
+
+async def gate_guard_destructive(
+    branch: Branch,
+    tool_call: ActionRequest,
+    context: object | None,
+) -> GateResult:
+    args = _args(tool_call)
+    try:
+        await guard_destructive(tool_call.function, args.get("action", ""), args)
+    except PermissionError as exc:
+        return GateResult(
+            passed=False,
+            gate_id="guard_destructive",
+            enforcement=GateEnforcement.HARD_MANDATORY,
+            reason=str(exc),
+        )
+    return GateResult(
+        passed=True,
+        gate_id="guard_destructive",
+        enforcement=GateEnforcement.HARD_MANDATORY,
+        reason="no destructive pattern",
+    )
+
+
+GUARD_DESTRUCTIVE = ToolGate(
+    gate_id="guard_destructive",
+    enforcement=GateEnforcement.HARD_MANDATORY,
+    evaluator=gate_guard_destructive,
+    description="Block destructive shell commands with no override path.",
+    owner="lionagi",
+)
+
+
+# --- guard_paths ---------------------------------------------------------
+
+def make_guard_path_gate(
+    *,
+    allowed_paths: list[str] | None = None,
+    denied_paths: list[str] | None = None,
+    enforcement: GateEnforcement = GateEnforcement.HARD_MANDATORY,
+) -> ToolGate:
+    """Factory: adapt the existing guard_paths hook into a ToolGate."""
+    path_hook = guard_paths(allowed_paths=allowed_paths, denied_paths=denied_paths)
+
+    async def gate_guard_paths(
+        branch: Branch,
+        tool_call: ActionRequest,
+        context: object | None,
+    ) -> GateResult:
+        args = _args(tool_call)
+        try:
+            await path_hook(tool_call.function, args.get("action", ""), args)
+        except PermissionError as exc:
+            return GateResult(
+                passed=False,
+                gate_id="guard_paths",
+                enforcement=enforcement,
+                reason=str(exc),
+            )
+        return GateResult(
+            passed=True,
+            gate_id="guard_paths",
+            enforcement=enforcement,
+            reason="path allowed",
+        )
+
+    return ToolGate(
+        gate_id="guard_paths",
+        enforcement=enforcement,
+        evaluator=gate_guard_paths,
+        description="Block or flag file access outside the designated workspace root.",
+        owner="lionagi",
+    )
+
+
+# --- confirm_external_api_call -------------------------------------------
+
+_ALLOWLISTED_API_HOSTS: frozenset[str] = frozenset({
+    "api.openai.com",
+    "api.anthropic.com",
+    "api.cohere.com",
+})
+
+
+async def gate_confirm_external_api_call(
+    branch: Branch,
+    tool_call: ActionRequest,
+    context: object | None,
+) -> GateResult:
+    args = _args(tool_call)
+    url = args.get("url", "")
+    if not url:
+        return GateResult(
+            passed=True,
+            gate_id="confirm_external_api_call",
+            enforcement=GateEnforcement.SOFT_MANDATORY,
+            reason="no url argument",
+        )
+    host = urllib.parse.urlparse(url).hostname or ""
+    allowed = host in _ALLOWLISTED_API_HOSTS
+    return GateResult(
+        passed=allowed,
+        gate_id="confirm_external_api_call",
+        enforcement=GateEnforcement.SOFT_MANDATORY,
+        reason="host in allowlist" if allowed else f"host not in allowlist: {host}",
+    )
+
+
+CONFIRM_EXTERNAL_API_CALL = ToolGate(
+    gate_id="confirm_external_api_call",
+    enforcement=GateEnforcement.SOFT_MANDATORY,
+    evaluator=gate_confirm_external_api_call,
+    description="Require justification for outbound HTTP to non-allowlisted hosts.",
+    owner="lionagi",
+)
+
+
+# --- warn_large_payload --------------------------------------------------
+
+_PAYLOAD_LIMIT_BYTES = 1 * 1024 * 1024  # 1 MB
+
+
+async def gate_warn_large_payload(
+    branch: Branch,
+    tool_call: ActionRequest,
+    context: object | None,
+) -> GateResult:
+    args = _args(tool_call)
+    try:
+        size = len(json.dumps(args).encode())
+    except Exception:
+        size = 0
+    over = size > _PAYLOAD_LIMIT_BYTES
+    return GateResult(
+        passed=not over,
+        gate_id="warn_large_payload",
+        enforcement=GateEnforcement.ADVISORY,
+        reason=f"payload {size} bytes exceeds {_PAYLOAD_LIMIT_BYTES}" if over else f"payload {size} bytes",
+    )
+
+
+WARN_LARGE_PAYLOAD = ToolGate(
+    gate_id="warn_large_payload",
+    enforcement=GateEnforcement.ADVISORY,
+    evaluator=gate_warn_large_payload,
+    description="Warn (non-blocking) when tool input arguments exceed 1 MB.",
+    owner="lionagi",
+)
+```
+
+### 7. User-Defined Gates
+
+Framework consumers register custom gates via `branch.register_gate`:
+
+```python
+from lionagi.agent.gates.executor import install_gate_preprocessor
+from lionagi.agent.gates.types import GateEnforcement, GateResult, ToolGate
+
+
+async def require_ticket_number(branch, tool_call, context) -> GateResult:
+    """Example: require a JIRA ticket in the operation context metadata."""
+    meta = getattr(context, "metadata", {}) or {}
+    ticket = meta.get("ticket", "")
+    ok = bool(ticket and ticket.startswith("PROJ-"))
+    return GateResult(
+        passed=ok,
+        gate_id="require_ticket_number",
+        enforcement=GateEnforcement.SOFT_MANDATORY,
+        reason="ticket present" if ok else "no PROJ-* ticket in operation context",
+    )
+
+
+my_gate = ToolGate(
+    gate_id="require_ticket_number",
+    enforcement=GateEnforcement.SOFT_MANDATORY,
+    evaluator=require_ticket_number,
+    description="Require a PROJ-* ticket reference before any write operation.",
+    owner="user",
+)
+
+# Register globally on the branch and attach to a specific action:
+branch.register_gate(my_gate)
+branch.attach_gate_to_action("editor", "write", "require_ticket_number")
+install_gate_preprocessor(branch, branch.acts.registry["editor"])
+```
+
+### 8. Relationship to Existing Primitives
+
+The built-in `PermissionPolicy` and `guard_*` hooks remain in place.  They are not deprecated by
+this ADR.  The migration path is additive:
+
+- `guard_destructive` hook → `GUARD_DESTRUCTIVE` gate.  Both may coexist; the hook runs first
+  as a pre-hook; the gate runs as part of gate evaluation.  In a future release the hook form
+  will be soft-deprecated once gate attachment is the recommended path for governed tools.
+- `PermissionPolicy` continues to handle allow/deny/escalate pattern matching.  It operates
+  before gate evaluation in the call stack.  Gates add tier semantics and evidence production
+  on top of the policy layer, not as a replacement.
+
+### 9. Fail-Closed is an Invariant, Not a Convention
+
+This point is sufficiently important to state explicitly and separately from the executor code.
+
+> If a gate's evaluator raises any exception for any reason — including import errors, network
+> timeouts, internal assertion failures, and `asyncio.CancelledError` — the gate result is
+> `GateResult(passed=False, ...)`.  The exception is logged at ERROR level.  It is never
+> re-raised, never silently swallowed into a pass, and never converted into an ADVISORY result
+> regardless of the gate's declared enforcement tier.
+
+This invariant means a misconfigured or crashing gate acts as a deny, not as an open door.
+A gate that is supposed to check network access but fails to import its HTTP library blocks the
+call rather than allowing it through.  This is the correct behavior for a security primitive.
+
+---
+
+## Consequences
+
+**Positive**
+
+- Every gate evaluation produces a `GateResult` regardless of pass or fail.  The operation record
+  is complete: no tool call can execute without evidence that its gates ran.
+- The three-tier model gives framework consumers a vocabulary for expressing real distinctions:
+  irrevocable safety rules (HARD), overridable business rules (SOFT), informational checks
+  (ADVISORY).  Previously this required separate systems.
+- Fail-closed-by-default eliminates an entire class of "gate crashes → action proceeds"
+  vulnerabilities.
+- SOFT gate justifications become part of the evidence chain (via ADR-0041), making overrides
+  auditable rather than invisible.
+- The resolution order (class-level first, then action-level) mirrors the decorator stack
+  familiar to Python developers and is predictable without reading framework internals.
+
+**Negative**
+
+- Latency for sessions with many gates: every tool call evaluates all applicable gates serially
+  (HARD gates short-circuit on first failure; ADVISORY and SOFT gates may accumulate). For most
+  agent sessions the gate count is small (2-5), making this negligible. Sessions with 20+ gates
+  may see 5-15 ms overhead per call; profiling will determine whether parallel evaluation is
+  warranted.
+- Authoring gates requires understanding the `OperationContext` and `ActionRequest` interfaces
+  (ADR-0050 and `lionagi/protocols/messages/`).  This is more involved than writing a hook that
+  inspects `args: dict`.
+- SOFT gate overrides introduce a synchronous pause in async tool execution.  Orchestrators that
+  route justification requests to humans (ADR-0046) must handle the suspension correctly.
+- Classifying a gate into the correct enforcement tier is a judgment call.  Misclassifying a
+  safety requirement as SOFT introduces a gap; misclassifying a business rule as HARD removes
+  operational flexibility.
+
+---
+
+## Non-Goals
+
+Explicitly out of scope:
+
+- **Probabilistic gating**: gates return `bool`.  Confidence-weighted authorization belongs in
+  `Claim.confidence` (ADR-0039) and `StateReason.confidence` (ADR-0033), not in gate results.
+  Threshold-based authorization is explicitly rejected (see prior research, Alternative 1).
+- **Gate composition DSL**: there is no `AND(gate_a, gate_b)` or `OR(gate_a, gate_b)` syntax.
+  Composite logic is expressed by calling other gates inside an evaluator function.
+- **Multi-tenant policy stitching**: resolving gate inheritance across tenant hierarchies,
+  overriding organizational gates at the workspace level, and merging gate registries from
+  multiple policy sources are KHive-layer concerns addressed in ADR-0052.
+- **Human-approval workflows**: routing a SOFT override to a human approver UI, timeout
+  handling, and async approval state machines are addressed in ADR-0046 (JIT Tool Grant).
+- **Gate versioning and migration**: upgrading a gate's enforcement tier across live sessions,
+  retiring a gate_id, and backfilling historical evidence with updated gate metadata are
+  operational concerns not addressed here.
+- **Cross-agent gate delegation**: an agent delegating gate-pass authority to a sub-agent is
+  addressed by the Agent Charter (ADR-0047) and Segregation of Duties (ADR-0048).
+
+---
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|---|---|
+| Single allow/deny mechanism (no tiers) | Real deployments distinguish irrevocable safety requirements from overridable business rules. Flattening both into HARD removes the escalation path that makes SOFT useful; flattening both into SOFT allows safety-critical gates to be bypassed with a justification string. |
+| Confidence-score gates (0.0–1.0) | Authorization is a factual question with a binary answer. Confidence scores shift the authorization decision to the threshold-chooser, introduce legal ambiguity ("the gate was 73% sure"), and enable threshold-drift attacks. Rejected per prior research Alternative 1. |
+| Hook-only enforcement (existing pattern) | Hooks (`guard_destructive`, `guard_paths`) raise `PermissionError` with no tiered semantics, no evidence production, and no override path. They cannot express SOFT or ADVISORY distinctions. They produce no `GateResult` that persists in the operation record. |
+| Auto-registration via `__init_subclass__` | prior research notes this pattern, but lionagi's tool model uses registered callables rather than class hierarchies. Explicit `register_gate` calls match the existing `register_tools` pattern and make attachment auditable. |
+| Gate evaluation in parallel | Parallel evaluation breaks the fail-fast semantics of HARD gates: if HARD gate A and SOFT gate B both run concurrently and A fails, B may have already started an I/O side-effect. Serial evaluation with short-circuit on HARD failure is correct and the latency cost is acceptable. |
+
+---
+
+## References
+
+- [ADR-0041](ADR-0041-immutable-evidence-nodes.md) — `GateResult` instances are stored as immutable evidence nodes; hash-chain integrity applies
+- [ADR-0042](ADR-0042-task-certificate.md) — Task Certificate consumes aggregated gate results as part of the signed process record
+- [ADR-0043](ADR-0043-governed-tool-declaration.md) — `@governed_tool` declares which gates are attached at the class level; HARD gates declared there cannot be absent at runtime
+- [ADR-0045](ADR-0045-break-glass-protocol.md) — documents what happens when a HARD gate result is overridden at the system level (DEGRADED defensibility mode)
+- [ADR-0046](ADR-0046-jit-tool-grant.md) — the JIT grant protocol handles human-in-the-loop approval for SOFT gate overrides
+- [ADR-0047](ADR-0047-agent-charter.md) — charters bind agents to specific gate sets; a gate not declared in the charter cannot be bypassed
+- [ADR-0050](ADR-0050-operation-context.md) — `OperationContext` is the active assertion that receives `GateResult` records at evaluation time
+- [ADR-0052](ADR-0052-policy-resolution.md) — most-specific-wins resolution for gate registries across tenant hierarchies (KHive layer)
+- [ADR-0033](ADR-0033-unified-entity-state-model.md) — `EvidenceRef` (8 kinds) is the shared substrate; `GateResult.evidence_refs` uses this type
+- [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) — `Claim.confidence` is where probabilistic reasoning lives; explicitly not in gates
+- prior governance research `01_design/008-policy-gates/ADR-008-policy-gates.md` — source pattern (three-tier model, binary semantics, HashiCorp Sentinel inspiration)
+- `lionagi/agent/permissions.py` — existing `PermissionPolicy`; not deprecated, gates layer on top
+- `lionagi/agent/hooks.py` — existing `guard_destructive`, `guard_paths`; migration path described in Section 8

--- a/docs/adrs/ADR-0045-break-glass-protocol.md
+++ b/docs/adrs/ADR-0045-break-glass-protocol.md
@@ -1,0 +1,572 @@
+# ADR-0045: Break-Glass Protocol — DEGRADED-Defensibility Override
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Depends on**: [ADR-0044](ADR-0044-tool-gates.md) (HARD gates being overridden), [ADR-0042](ADR-0042-task-certificate.md) (BREAK_GLASS certificate state), [ADR-0041](ADR-0041-immutable-evidence-nodes.md) (attestation as evidence node)
+**Related**: [ADR-0050](ADR-0050-operation-context.md), [ADR-0047](ADR-0047-agent-charter.md), [ADR-0033](ADR-0033-unified-entity-state-model.md), [ADR-0043](ADR-0043-governed-tool-declaration.md)
+
+---
+
+## Context
+
+lionagi today has no emergency override path. When an agent fails a HARD gate
+(defined in [ADR-0044](ADR-0044-tool-gates.md)), it has two de-facto options:
+
+1. **Fail silently** — the action is blocked, the operator sees an error, no
+   record is produced that explains *why* the gate failed or that an override
+   was even attempted.
+2. **Proceed without record** — the caller catches the gate exception and
+   re-invokes the tool with a flag that disables the check. This is entirely
+   within reach today: `PermissionPolicy(mode="allowlist")` in
+   `lionagi/agent/permissions.py` already accepts a caller-supplied config
+   with zero audit hooks.
+
+Neither outcome is acceptable for a governed agent platform. The first option
+stalls legitimate emergencies; the second leaves a compliance gap with no
+paper trail.
+
+Cross-cutting principle #3 — *every constraint must be enforced, not just
+documented* — applies to the override path itself. An override that produces
+no record is not governance; it is a blank check disguised as a feature.
+
+### The applicable design pattern
+
+prior research frames this precisely: the problem is not whether an
+emergency override is *possible*, but whether the resulting record
+*acknowledges what happened*. Their solution distinguishes between
+`defensibility: FULL` (normal path, all gates passed) and
+`defensibility: DEGRADED` (break-glass path, gates failed, attestation
+provided). The action is the same; the certificate is different. Both facts —
+that the action happened, and that normal process was not followed — are
+preserved in a single evidence node that cannot be amended after the fact
+(ADR-0041).
+
+### Why lionagi needs this
+
+Consider: an autonomous coding agent holds a HARD gate that prevents
+modification of files outside a declared project root. During a production
+incident, an operator legitimately needs the agent to patch a shared config
+file one directory above the root. The only current path is to re-instantiate
+the agent with a looser `PermissionPolicy`. That change leaves no record, is
+indistinguishable from a misconfiguration, and cannot be reviewed
+post-incident. Break-glass replaces that informal workaround with a
+first-class, auditable path that creates more friction than normal operation —
+thereby preserving deterrence — while still letting the action succeed.
+
+---
+
+## Decision
+
+We introduce `branch.break_glass(request)` as the single approved path for
+overriding a HARD gate failure, producing a `TaskCertificate` with
+`defensibility: DEGRADED` and a `BREAK_GLASS` evidence node that is
+immutable, non-exportable by default, and triggers an immediate notification
+event.
+
+---
+
+### 1. `BreakGlassReason` enum
+
+```python
+from enum import Enum
+
+class BreakGlassReason(str, Enum):
+    PRODUCTION_OUTAGE      = "production_outage"
+    SECURITY_INCIDENT      = "security_incident"
+    LEGAL_MANDATE          = "legal_mandate"
+    SAFETY_THREAT          = "safety_threat"
+    DATA_RECOVERY          = "data_recovery"
+    AUTHORIZED_DRILL       = "authorized_drill"
+```
+
+The enum is closed. New reason codes require a code change and a reviewer
+sign-off. This prevents operators from minting ad-hoc codes that dilute the
+audit signal.
+
+---
+
+### 2. `BreakGlassRequest` dataclass
+
+```python
+from __future__ import annotations
+
+import time
+from typing import Literal
+
+from pydantic import Field, field_validator
+
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+from lionagi.protocols.governance.evidence import EvidenceRef  # ADR-0033/0041
+
+
+class BreakGlassRequest(Element):
+    # Who is overriding and why
+    reason_code: BreakGlassReason
+    attestation_text: str                    # >= 50 chars, free-form
+    actor_id: str                            # agent ln_id / user id / system id
+    actor_role: Literal["agent", "user", "system"]
+
+    # What is being overridden
+    overridden_gates: tuple[str, ...] = Field(min_length=1)
+    tool_name: str                           # the @governed_tool being unblocked
+
+    # Scope
+    expected_duration_minutes: int = Field(ge=1)
+    supporting_evidence: Pile[EvidenceRef] = Field(
+        default_factory=lambda: Pile(item_type={EvidenceRef}, strict_type=True)
+    )
+
+    # Filled at invocation time
+    requested_at: float = Field(default_factory=time.time)
+
+    @field_validator("attestation_text")
+    @classmethod
+    def _validate_attestation(cls, value: str) -> str:
+        if len(value.strip()) < 50:
+            raise ValueError(
+                "attestation_text must be at least 50 characters. "
+                "A checkbox is not attestation."
+            )
+        return value
+```
+
+The `__post_init__` validation enforces minimum attestation length at
+construction time, not at invocation time. An invalid request cannot be
+submitted — it raises before touching any gate.
+
+---
+
+### 3. `BreakGlassWindow` — the active override state
+
+```python
+import time
+from typing import Literal
+
+from pydantic import Field
+
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+
+
+class BreakGlassToolCall(Element):
+    tool_name: str
+    called_at: float = Field(default_factory=time.time)
+
+
+class BreakGlassWindow(Element):
+    request: BreakGlassRequest
+    opened_at: float = Field(default_factory=time.time)
+    expires_at: float | None = None
+    closed_at: float | None = None
+    tool_calls_during_window: Pile[BreakGlassToolCall] = Field(
+        default_factory=lambda: Pile(
+            item_type={BreakGlassToolCall},
+            strict_type=True,
+        )
+    )
+    closed_reason: Literal["expired", "explicit", "error"] | None = None
+
+    def model_post_init(self, __context: object) -> None:
+        if self.expires_at is None:
+            self.expires_at = (
+                self.opened_at + self.request.expected_duration_minutes * 60
+            )
+
+    @property
+    def window_id(self) -> str:
+        return str(self.id)
+
+    @property
+    def is_active(self) -> bool:
+        return (
+            self.closed_at is None
+            and time.time() < self.expires_at
+        )
+
+    def record_tool_call(self, tool_name: str) -> None:
+        """Every tool call during the window is tagged for the audit trail."""
+        self.tool_calls_during_window.include(
+            BreakGlassToolCall(tool_name=tool_name)
+        )
+
+    def close(self, reason: Literal["expired", "explicit", "error"]) -> None:
+        self.closed_at = time.time()
+        self.closed_reason = reason
+```
+
+---
+
+### 4. `BreakGlassEvent` — the notification payload
+
+```python
+import time
+from typing import Literal
+
+from pydantic import Field
+
+from lionagi.protocols.generic.element import Element
+
+
+class BreakGlassEvent(Element):
+    """Fired to operator/orchestrator immediately on window open and close."""
+    event_type: Literal["opened", "closed"]
+    window_id: str
+    actor_id: str
+    actor_role: str
+    reason_code: str
+    tool_name: str
+    overridden_gates: tuple[str, ...]
+    attestation_summary: str   # first 120 chars of attestation_text
+    timestamp: float = Field(default_factory=time.time)
+    branch_id: str
+    session_id: str | None
+    # On close only:
+    tool_calls_count: int = 0
+    certificate_id: str | None = None
+    defensibility: Literal["DEGRADED"] = "DEGRADED"
+```
+
+Notifications are fired synchronously before the action executes (open event)
+and after the window closes (close event). Both events are written to the
+immutable evidence store (ADR-0041) before any downstream delivery. If
+delivery fails, the evidence node is already committed.
+
+---
+
+### 5. `BreakGlassGuard` — gate-level non-overridability flag
+
+Not all HARD gates are overridable. Gates that protect the agent system itself
+from self-destruction are declared with `overridable=False`:
+
+```python
+from collections.abc import Awaitable, Callable
+from typing import Literal
+
+from pydantic import Field
+
+from lionagi.agent.config import AgentConfig
+from lionagi.protocols.generic.element import Element
+
+
+BreakGlassHook = Callable[[str, str, dict], Awaitable[dict | None]]
+
+
+class GateDeclaration(Element):
+    name: str
+    tool_name: str = "*"
+    level: Literal["HARD", "SOFT", "ADVISORY"]   # ADR-0044
+    hook: BreakGlassHook = Field(exclude=True)
+    overridable: bool = True
+    override_actor_classes: frozenset[str] = Field(
+        default_factory=lambda: frozenset(
+            {"user", "system"}   # autonomous agents cannot self-override by default
+        )
+    )
+    max_overrides_per_hour: int = 3
+
+    def register(self, config: AgentConfig) -> None:
+        config.hook_handlers.setdefault(
+            f"security_pre:{self.tool_name}",
+            [],
+        ).insert(0, self.hook)
+```
+
+When `overridable=False`, `break_glass()` raises `NonOverridableGateError`
+regardless of attestation content or actor role. The list of non-overridable
+gates is enumerated in the agent charter (ADR-0047) and cannot be modified at
+runtime.
+
+Gates that are overridable by `user` or `system` but NOT by `agent` enforce
+the rule that autonomous agents cannot unilaterally override their own
+constraints. An agent that detects a gate failure must surface the failure to
+its orchestrator, not invoke break-glass on its own authority.
+
+---
+
+### 6. `branch.break_glass()` — the API surface
+
+```python
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from lionagi.protocols.governance.break_glass import (
+    BreakGlassEvent,
+    BreakGlassRequest,
+    BreakGlassWindow,
+    NonOverridableGateError,
+    RateLimitExceededError,
+)
+from lionagi.protocols.generic.log import Log
+from lionagi.protocols.generic.pile import Pile
+
+
+class Branch:
+    # ... existing Branch surface ...
+
+    async def break_glass(
+        self,
+        request: BreakGlassRequest,
+        *,
+        notify: Callable[[BreakGlassEvent], None] | None = None,
+    ) -> BreakGlassWindow:
+        """
+        Override one or more HARD gate failures with a typed attestation.
+
+        Returns an active BreakGlassWindow. The caller is responsible for
+        explicitly closing the window via `await window.aclose()` when the
+        emergency action completes. If not closed, the window expires
+        automatically at `window.expires_at`.
+
+        Raises:
+            NonOverridableGateError  — if any gate in request.overridden_gates
+                                       has overridable=False.
+            RateLimitExceededError   — if actor_id has exceeded
+                                       max_overrides_per_hour for any gate.
+            ValueError               — if request validation fails (re-raised
+                                       from BreakGlassRequest validation).
+        """
+        if request.tool_name not in self.acts.registry:
+            raise ValueError(f"Tool {request.tool_name!r} is not registered.")
+
+        self._validate_actor_class(request)       # enforce override_actor_classes
+        self._check_non_overridable(request)      # raise NonOverridableGateError early
+        self._check_rate_limit(request)           # raise RateLimitExceededError early
+
+        window = BreakGlassWindow(request=request)
+
+        open_event = BreakGlassEvent(
+            event_type="opened",
+            window_id=window.window_id,
+            actor_id=request.actor_id,
+            actor_role=request.actor_role,
+            reason_code=request.reason_code,
+            tool_name=request.tool_name,
+            overridden_gates=request.overridden_gates,
+            attestation_summary=request.attestation_text[:120],
+            branch_id=str(self.id),
+            session_id=str(self.user) if self.user else None,
+        )
+
+        # Fail closed: write the Element snapshot through Branch's DataLogger
+        # before notifying or enabling the existing hook-based tool path.
+        await self._log_manager.alog(Log.create(open_event))
+        if notify is not None:
+            notify(open_event)
+
+        windows = self.metadata.setdefault(
+            "active_break_glass_windows",
+            Pile(item_type={BreakGlassWindow}, strict_type=True),
+        )
+        windows.include(window)
+        return window
+```
+
+The method is `async` because committing the evidence node and firing the
+notification are I/O operations. The HARD gate check that originally triggered
+the failure is NOT re-evaluated inside `break_glass()` — that check already
+ran; the attestation is the response to it, not a second pass.
+
+---
+
+### 7. Window lifecycle and certificate minting
+
+```text
+Agent calls tool
+      |
+  HARD gate fails
+      |
+  Caller invokes branch.break_glass(request)
+      |
+  [Validation] ──── fail ──── raise (no window created)
+      |
+  Evidence node committed (immutable, exportable=False)
+      |
+  BreakGlassEvent("opened") fired
+      |
+  BreakGlassWindow returned (is_active=True)
+      |
+  Action executes; every tool call recorded in window.tool_calls_during_window
+      |
+  Window closes (explicit close or expiry)
+      |
+  TaskCertificate minted:
+      defensibility = "DEGRADED"
+      state         = "BREAK_GLASS"
+      evidence_refs = [break_glass_node, ...supporting_evidence]
+      |
+  BreakGlassEvent("closed") fired with certificate_id
+```
+
+The certificate (ADR-0042) is minted at window close, not at window open. If
+the window expires without an explicit close, the expiry trigger mints the
+certificate automatically. There is no path from open to close that does not
+produce a certificate.
+
+---
+
+### 8. Non-exportability
+
+Break-glass evidence nodes and the certificates that reference them carry
+`exportable: False` by default. This flag is enforced by the evidence store
+(ADR-0041) at read time, not just at write time.
+
+Programmatic export requires:
+
+1. An elevated permission grant (`EXPORT_BREAK_GLASS`) on the calling actor.
+2. An explicit export request that itself produces an audit evidence node,
+   recording who exported what and when.
+3. In KHive (multi-tenant layer): a Legal review workflow before the grant is
+   issued.
+
+This is not obscurity — the evidence node exists and is queryable by authorized
+operators. Non-exportability means it cannot leave the platform boundary in a
+bulk data export without review.
+
+---
+
+### 9. Rate limiting and cooldown
+
+```python
+import time
+
+from pydantic import Field
+
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+from lionagi.protocols.governance.break_glass import RateLimitExceededError
+
+
+class BreakGlassRateLimitInvocation(Element):
+    actor_id: str
+    gate_name: str
+    invoked_at: float = Field(default_factory=time.time)
+
+
+class BreakGlassRateLimit(Element):
+    actor_id: str
+    gate_name: str
+    max_per_hour: int = 3
+    window_seconds: int = 3600
+    # runtime-tracked
+    invocations: Pile[BreakGlassRateLimitInvocation] = Field(
+        default_factory=lambda: Pile(
+            item_type={BreakGlassRateLimitInvocation},
+            strict_type=True,
+        )
+    )
+
+    def check(self) -> None:
+        now = time.time()
+        for invocation in list(self.invocations):
+            if now - invocation.invoked_at >= self.window_seconds:
+                self.invocations.exclude(invocation)
+        if len(self.invocations) >= self.max_per_hour:
+            raise RateLimitExceededError(
+                f"Actor {self.actor_id!r} has used break-glass on gate "
+                f"{self.gate_name!r} {self.max_per_hour} times in the last hour. "
+                "Contact your operator to reset."
+            )
+        self.invocations.include(
+            BreakGlassRateLimitInvocation(
+                actor_id=self.actor_id,
+                gate_name=self.gate_name,
+            )
+        )
+```
+
+Rate limits are per-actor, per-gate, per-hour. Exceeding the limit does not
+silently allow the action — it raises `RateLimitExceededError`. The limit
+itself is configurable per gate declaration but defaults to 3/hour, which is
+generous for genuine emergencies and punishing for misuse.
+
+---
+
+## Consequences
+
+**Positive**
+
+- Every HARD gate override produces a complete, immutable audit trail with a
+  dated attestation, actor identity, overridden gate names, and a certificate
+  marked DEGRADED. Post-incident review has all the facts.
+- The DEGRADED defensibility state gives operators, auditors, and (where
+  applicable) legal counsel an accurate signal about what process was followed.
+  "We did it with DEGRADED defensibility" is a defensible position; "we did it
+  with no record" is not.
+- Non-overridable gates (`overridable=False`) eliminate the risk that break-glass
+  becomes a universal escape hatch. The most critical constraints are
+  permanently out of scope.
+- Friction by design: the minimum 50-char attestation, the actor-class
+  restriction on autonomous agents, and the rate limit make break-glass slower
+  than normal operation. Legitimate emergencies tolerate this friction; routine
+  misuse does not survive the rate limit.
+- The pattern composes with Operation Context (ADR-0050): every tool call during
+  a break-glass window can carry `context_id=window.window_id` in its evidence
+  node, creating a complete timeline of what happened under the override.
+
+**Negative**
+
+- Surface area: `BreakGlassRequest`, `BreakGlassWindow`, `BreakGlassEvent`, and
+  the `break_glass()` method are new API that must be maintained.
+- Operator burden: the notification mechanism requires a subscriber. If no
+  subscriber is configured, notifications queue silently. The default behavior
+  must be to log to the immutable evidence store regardless.
+- Genuinely time-critical emergencies may find the 50-char attestation a
+  bottleneck. The minimum is low enough (roughly two sentences) that this
+  concern is largely theoretical, but it is real.
+- In library mode (no KHive), the rate-limit and non-exportability semantics
+  are enforced in-process and can be bypassed by a caller with full Python
+  access. Full enforcement requires the KHive governed evidence layer.
+
+---
+
+## Non-Goals
+
+Explicitly out of scope:
+
+- **Automatic break-glass approval**: no system or agent can approve its own
+  break-glass request. Human attestation is a requirement, not a suggestion.
+  Confidence scores, risk scores, and audit history do not substitute for a
+  typed justification from an accountable actor.
+- **Break-glass without a certificate**: there is no `silent_override()` or
+  `emergency_skip()`. Every invocation of `break_glass()` that does not raise
+  produces a certificate. The two are inseparable.
+- **Window expiry without certificate mint**: a window that expires without an
+  explicit close still mints a certificate. There is no path where a window
+  opens and no certificate is ever produced.
+- **Cascading break-glass**: a break-glass window does not implicitly expand to
+  cover subsequent gate failures. Each failing gate in a new action requires
+  its own `overridden_gates` declaration. Open-ended "override everything" is
+  not supported.
+- **Multi-tenant policy**: which reason codes are available to which tenants,
+  cross-tenant audit visibility, and Legal-review workflow for exports are
+  KHive-layer concerns and are not defined here.
+- **Retroactive reclassification**: a DEGRADED certificate cannot be upgraded
+  to FULL defensibility after the fact, even if subsequent review concludes the
+  action was correct. The state at time of action is preserved permanently.
+
+---
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Silent override with post-hoc logging | No record at the time of decision. If the system crashes after the action but before the log write, there is no evidence the override happened. Violates ADR-0041 (evidence committed before action). |
+| Reject without any override path | Legitimate production emergencies exist. A governance system that cannot accommodate genuine emergencies will be worked around informally, producing worse audit trails than break-glass. |
+| Confidence-based automatic override | Defeats the fail-closed principle (cross-cutting principle #1). If a gate can be bypassed by meeting a confidence threshold, the gate is not HARD — it is a SOFT gate with a confidence flavor. Rename it honestly or keep it HARD. |
+| Simple `emergency: bool` flag on existing tool calls | No defensibility acknowledgment, no rate limit, no actor-class restriction, no evidence node, no certificate. This is the "add a comment field to a checkbox" pattern, not governance. |
+| Checkbox-based reason selection | Predefined checkboxes have no accountability signal. A 50-char attestation requires the actor to formulate a sentence, which creates cognitive ownership of the decision. prior research tested this distinction directly. |
+
+---
+
+## References
+
+- [ADR-0041](ADR-0041-immutable-evidence-nodes.md) — attestation is an immutable evidence node; committed before action executes
+- [ADR-0042](ADR-0042-task-certificate.md) — defines `TaskCertificate`, `defensibility: DEGRADED`, and `BREAK_GLASS` state
+- [ADR-0043](ADR-0043-governed-tool-declaration.md) — `@governed_tool` declares which tools carry gates
+- [ADR-0044](ADR-0044-tool-gates.md) — HARD/SOFT/ADVISORY gate levels; HARD gates are what break-glass overrides
+- [ADR-0047](ADR-0047-agent-charter.md) — agent charters enumerate which gates are `overridable=False`
+- [ADR-0050](ADR-0050-operation-context.md) — operation context carried on every tool call during a break-glass window
+- [ADR-0033](ADR-0033-unified-entity-state-model.md) — `EvidenceRef` type used in `BreakGlassRequest.supporting_evidence`
+- prior governance research `01_design/016-break-glass/ADR-016-break-glass.md` — source pattern (DEGRADED defensibility, typed attestation, auto-notification, non-exportable default)

--- a/docs/adrs/ADR-0045-break-glass-protocol.md
+++ b/docs/adrs/ADR-0045-break-glass-protocol.md
@@ -417,8 +417,6 @@ Programmatic export requires:
 1. An elevated permission grant (`EXPORT_BREAK_GLASS`) on the calling actor.
 2. An explicit export request that itself produces an audit evidence node,
    recording who exported what and when.
-3. In KHive (multi-tenant layer): a Legal review workflow before the grant is
-   issued.
 
 This is not obscurity — the evidence node exists and is queryable by authorized
 operators. Non-exportability means it cannot leave the platform boundary in a
@@ -515,9 +513,9 @@ generous for genuine emergencies and punishing for misuse.
 - Genuinely time-critical emergencies may find the 50-char attestation a
   bottleneck. The minimum is low enough (roughly two sentences) that this
   concern is largely theoretical, but it is real.
-- In library mode (no KHive), the rate-limit and non-exportability semantics
-  are enforced in-process and can be bypassed by a caller with full Python
-  access. Full enforcement requires the KHive governed evidence layer.
+- In library mode, the rate-limit and non-exportability semantics are enforced
+  in-process and can be bypassed by a caller with full Python access. Full
+  enforcement requires a governed evidence layer with durable storage.
 
 ---
 
@@ -539,9 +537,8 @@ Explicitly out of scope:
   cover subsequent gate failures. Each failing gate in a new action requires
   its own `overridden_gates` declaration. Open-ended "override everything" is
   not supported.
-- **Multi-tenant policy**: which reason codes are available to which tenants,
-  cross-tenant audit visibility, and Legal-review workflow for exports are
-  KHive-layer concerns and are not defined here.
+- **Policy customization**: which reason codes are available in a given deployment
+  context is a deployment-layer concern and is not defined here.
 - **Retroactive reclassification**: a DEGRADED certificate cannot be upgraded
   to FULL defensibility after the fact, even if subsequent review concludes the
   action was correct. The state at time of action is preserved permanently.

--- a/docs/adrs/ADR-0045-break-glass-protocol.md
+++ b/docs/adrs/ADR-0045-break-glass-protocol.md
@@ -1,6 +1,6 @@
 # ADR-0045: Break-Glass Protocol — DEGRADED-Defensibility Override
 
-**Status**: Proposed
+**Status**: proposed
 **Date**: 2026-05-26
 **Depends on**: [ADR-0044](ADR-0044-tool-gates.md) (HARD gates being overridden), [ADR-0042](ADR-0042-task-certificate.md) (BREAK_GLASS certificate state), [ADR-0041](ADR-0041-immutable-evidence-nodes.md) (attestation as evidence node)
 **Related**: [ADR-0050](ADR-0050-operation-context.md), [ADR-0047](ADR-0047-agent-charter.md), [ADR-0033](ADR-0033-unified-entity-state-model.md), [ADR-0043](ADR-0043-governed-tool-declaration.md)

--- a/docs/adrs/ADR-0046-jit-tool-grant.md
+++ b/docs/adrs/ADR-0046-jit-tool-grant.md
@@ -480,9 +480,9 @@ required for post-incident reconstruction: given any tool call, the auditor can 
 - Agentic workflows that previously ran autonomously on high-risk tools now require an external
   authorization step. Pipelines must be redesigned to either obtain permits ahead of time (batch
   pre-authorization) or tolerate suspension while awaiting approval.
-- Human-in-the-loop latency is now on the critical path for any `requires_jit=True` tool. Studio
-  UI must surface permit requests clearly; a buried notification degrades the flow without
-  improving security.
+- Human-in-the-loop latency is now on the critical path for any `requires_jit=True` tool. The
+  operator interface must surface permit requests clearly; a buried notification degrades the
+  flow without improving security.
 - Orchestrators acting as authorizing parties create a trust chain that must be audited. An
   orchestrator that auto-approves every sub-agent request without human oversight negates the
   security benefit. ADR-0047 (Agent Charter) and ADR-0048 (Segregation of Duties) constrain
@@ -497,8 +497,7 @@ required for post-incident reconstruction: given any tool call, the auditor can 
 
 Explicitly out of scope:
 
-- **Federated permit issuance across tenants**: Cross-tenant grants and multi-tenant permit
-  federation are KHive territory. In v1, permits are scoped to a single lionagi process/session
+- **Federated permit issuance**: permits are scoped to a single lionagi process/session
   boundary.
 - **Automatic re-issuance on expiry**: A `PermitToken` that expires is not automatically renewed.
   Re-issuance requires a new authorization decision. Automatic renewal would convert a time-bounded
@@ -509,9 +508,9 @@ Explicitly out of scope:
   variable, or runtime mode that makes `requires_jit=True` tools executable without a valid
   token. Library mode (`LIONAGI_GOVERNED=false`) suppresses governance at the framework level,
   but does not affect tools that explicitly declare `requires_jit=True` in their own decorator.
-- **UI permit-approval interface**: Studio UI surface for displaying and approving permit
-  requests is out of scope for this ADR. The protocol (`PermitRequest` event, `request_permit`
-  API) is defined here; the UI implementation is a Studio concern.
+- **UI permit-approval interface**: The UI surface for displaying and approving permit requests
+  is out of scope for this ADR. The protocol (`PermitRequest` event, `request_permit` API) is
+  defined here; the UI implementation is a separate concern.
 - **Revocation of already-consumed tokens**: A consumed token is a historical record, not an
   active authorization. Revoking it has no security effect and is not supported.
 

--- a/docs/adrs/ADR-0046-jit-tool-grant.md
+++ b/docs/adrs/ADR-0046-jit-tool-grant.md
@@ -1,6 +1,6 @@
 # ADR-0046: JIT Tool Grant — No Standing Capability for High-Risk Tools
 
-**Status**: Proposed
+**Status**: proposed
 **Date**: 2026-05-26
 **Depends on**: [ADR-0043](ADR-0043-governed-tool-declaration.md), [ADR-0044](ADR-0044-tool-gates.md)
 **Related**: [ADR-0041](ADR-0041-immutable-evidence-nodes.md), [ADR-0045](ADR-0045-break-glass-protocol.md), [ADR-0047](ADR-0047-agent-charter.md), [ADR-0051](ADR-0051-tool-registry-allowlists.md)

--- a/docs/adrs/ADR-0046-jit-tool-grant.md
+++ b/docs/adrs/ADR-0046-jit-tool-grant.md
@@ -1,0 +1,543 @@
+# ADR-0046: JIT Tool Grant — No Standing Capability for High-Risk Tools
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Depends on**: [ADR-0043](ADR-0043-governed-tool-declaration.md), [ADR-0044](ADR-0044-tool-gates.md)
+**Related**: [ADR-0041](ADR-0041-immutable-evidence-nodes.md), [ADR-0045](ADR-0045-break-glass-protocol.md), [ADR-0047](ADR-0047-agent-charter.md), [ADR-0051](ADR-0051-tool-registry-allowlists.md)
+
+---
+
+## Context
+
+In lionagi today, a tool registered on a `Branch` is always callable. The moment
+`branch.register_tools([delete_resource, write_production_db, call_payment_api])` executes, the
+agent has standing capability to invoke any of those tools at any point in any future turn — with
+no fresh authorization, no time limit, no scope binding. Nothing prevents the agent from calling
+`delete_resource(id="all")` three sessions after the operator intended a one-off cleanup. The
+capability persists until the Branch is torn down.
+
+For low-risk tools (read operations, local file reads, formatting utilities), standing capability is
+acceptable and desirable — requiring authorization on every call would make agentic workflows
+unusable. For high-risk tools — production writes, financial transactions, external API calls with
+side effects, irreversible destructive operations — standing capability is the attack surface. An
+agent that is compromised, confused, or simply operating outside its intended scope can cause
+real harm precisely because the capability is always present.
+
+Cross-cutting principle #1 (fail-closed is universal default) requires that ambiguity about
+authorization leads to denial, not execution. Cross-cutting principle #3 (every constraint must
+be enforced, not just documented) means a `requires_jit=True` annotation on a tool has no value
+unless the runtime actually blocks execution when no valid grant exists. This ADR introduces the
+`JITGrant` and `PermitToken` constructs that make both principles operational for high-risk tools.
+
+### The applicable prior governance research insight
+
+prior research addresses standing capability in human-facing sensitive operations (terminations,
+compensation changes) using a two-layer model: a `PermitToken` that binds one certificate to one
+execution (replay prevention), and a JIT role that removes the standing capability from the actor
+entirely so the action is invisible in the UI until the grant is active. The core insight
+translates directly to agent governance: the primary mechanism is the permit (transaction binding,
+single-use); the secondary mechanism is JIT (no standing power). Both layers must hold. Disabling
+either degrades security — permit-only allows replay within the window; JIT-only allows replay
+because there is no per-transaction binding.
+
+### Why lionagi needs this
+
+Consider a `Branch` configured with `write_billing_record` and `archive_customer`. An operator
+launches the agent to process a single end-of-month billing run. The agent completes the task.
+The Branch is reused (as is common in FlowAgent pipelines — ADR-0047 documents that the same
+`branch=` reuse accumulates state). Two turns later, in a different context, the agent encounters
+an instruction it misinterprets as a correction request and calls `archive_customer(id="batch_*")`.
+The capability was standing. No gate fired. Without JIT grants, there is no mechanism to ensure
+that `write_billing_record` and `archive_customer` are only callable during a specific authorized
+window for a specific operation, not generally at any time the agent is alive.
+
+---
+
+## Decision
+
+Introduce `PermitToken` and `JITGrant` as the authorization substrate for high-risk tools.
+Tools declared with `requires_jit=True` via `@governed_tool` (ADR-0043) cannot execute unless
+a valid, unexpired `PermitToken` exists for the `(agent_id, tool_id)` pair at call time; the
+token is consumed atomically on first redemption; and a `JITGrant` record is held for the
+duration of that execution window.
+
+---
+
+### 1. Schemas
+
+The grant types are frozen `Element` records. State changes produce new instances; no mutation
+in place. The Branch-owned grant manager keeps active grant state in typed `Pile` collections.
+
+```python
+from __future__ import annotations
+
+import time
+from typing import Any, Literal
+
+from pydantic import ConfigDict, Field
+
+from lionagi.protocols.action.manager import ActionManager
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.log import DataLogger
+from lionagi.protocols.generic.pile import Pile
+
+
+FROZEN_RECORD = ConfigDict(
+    arbitrary_types_allowed=True,
+    use_enum_values=True,
+    populate_by_name=True,
+    extra="forbid",
+    frozen=True,
+)
+
+
+class GrantScope(Element):
+    """Scope that binds a grant to one agent, one tool, and optional args."""
+
+    model_config = FROZEN_RECORD
+
+    agent_id: str
+    tool_id: str
+    argument_constraints: dict[str, Any] = Field(default_factory=dict)
+
+    def matches(
+        self,
+        *,
+        agent_id: str,
+        tool_id: str,
+        arguments: dict[str, Any],
+    ) -> bool:
+        return (
+            self.agent_id == agent_id
+            and self.tool_id == tool_id
+            and not self.constraint_violations(arguments)
+        )
+
+    def constraint_violations(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        return {
+            key: {"expected": expected, "actual": arguments.get(key)}
+            for key, expected in self.argument_constraints.items()
+            if arguments.get(key) != expected
+        }
+
+
+class PermitRequest(Element):
+    """Agent-facing request emitted by branch.request_permit(...)."""
+
+    model_config = FROZEN_RECORD
+
+    scope: GrantScope
+    requested_by: str
+    reason: str = ""
+    action_request_id: str | None = None
+    deadline_at: float | None = None
+
+
+class ApprovalEvidence(Element):
+    """Evidence record for approval, denial, timeout, consumption, or revocation."""
+
+    model_config = FROZEN_RECORD
+
+    request_id: str | None = None
+    principal_id: str
+    decision: Literal["approved", "denied", "timeout", "consumed", "revoked"]
+    reason: str = ""
+    source_log_ids: tuple[str, ...] = ()
+
+
+class PermitToken(Element):
+    """Single-use authorization token bound to one (agent, tool) execution."""
+
+    model_config = FROZEN_RECORD
+
+    token_id: str                       # idempotency key; Element.id is canonical UUID
+    scope: GrantScope
+    issued_by: str                      # human user-id, orchestrator-id, or "system"
+    issued_at: float                    # unix timestamp
+    expires_at: float                   # issued_at + window (e.g., 300 seconds)
+    approval_evidence_id: str
+    consumed: bool = False
+    consumed_at: float | None = None
+    consumed_by_action_request_id: str | None = None
+
+    def is_valid(self, at: float | None = None) -> bool:
+        """True iff unexpired and not yet consumed."""
+        t = at if at is not None else time.time()
+        return (not self.consumed) and (t < self.expires_at)
+
+    def consume(self, *, action_request_id: str) -> "PermitToken":
+        """Return a new instance with consumed=True. Call site must persist."""
+        if self.consumed:
+            raise ValueError(f"PermitToken {self.token_id} already consumed")
+        return self.model_copy(
+            update={
+                "consumed": True,
+                "consumed_at": time.time(),
+                "consumed_by_action_request_id": action_request_id,
+            }
+        )
+
+
+class JITGrant(Element):
+    """Time-bound capability record for a (agent, tool) pair.
+
+    Separate from PermitToken: the grant records that capability was lawfully
+    extended; the permit is the per-call proof of authorization. Both must be
+    present and valid for execution to proceed.
+    """
+
+    model_config = FROZEN_RECORD
+
+    grant_id: str
+    scope: GrantScope
+    valid_from: float
+    valid_until: float                  # hard expiry for capability window
+    issued_by: str
+    revoke_after: float                 # >= valid_until + 300 s (delayed revocation)
+    permit_token_id: str                # back-reference to the PermitToken
+    approval_evidence_id: str
+    revoked_at: float | None = None
+    revocation_evidence_id: str | None = None
+
+    def is_active(self, at: float | None = None) -> bool:
+        t = at if at is not None else time.time()
+        return self.revoked_at is None and self.valid_from <= t <= self.valid_until
+
+    def revoke(self, *, evidence_id: str) -> "JITGrant":
+        return self.model_copy(
+            update={
+                "revoked_at": time.time(),
+                "revocation_evidence_id": evidence_id,
+            }
+        )
+
+
+class JITGrantManager(Element):
+    """Branch-owned grant state; mounted beside ActionManager and DataLogger."""
+
+    agent_id: str
+    actions: ActionManager | None = Field(default=None, exclude=True)
+    logger: DataLogger | None = Field(default=None, exclude=True)
+    permit_requests: Pile[PermitRequest] = Field(
+        default_factory=lambda: Pile(item_type=PermitRequest, strict_type=True)
+    )
+    approval_evidence: Pile[ApprovalEvidence] = Field(
+        default_factory=lambda: Pile(item_type=ApprovalEvidence, strict_type=True)
+    )
+    permit_tokens: Pile[PermitToken] = Field(
+        default_factory=lambda: Pile(item_type=PermitToken, strict_type=True)
+    )
+    grants: Pile[JITGrant] = Field(
+        default_factory=lambda: Pile(item_type=JITGrant, strict_type=True)
+    )
+
+    def record_evidence(self, evidence: ApprovalEvidence) -> None:
+        self.approval_evidence.include(evidence)
+        if self.logger:
+            self.logger.log(evidence)
+
+    def find_valid_token(
+        self,
+        *,
+        agent_id: str,
+        tool_id: str,
+        arguments: dict[str, Any],
+        at: float | None = None,
+    ) -> PermitToken | None:
+        t = at if at is not None else time.time()
+        for token in self.permit_tokens:
+            if not token.is_valid(t):
+                continue
+            if not token.scope.matches(
+                agent_id=agent_id, tool_id=tool_id, arguments=arguments
+            ):
+                continue
+            for grant in self.grants:
+                if (
+                    grant.permit_token_id == token.token_id
+                    and grant.scope == token.scope
+                    and grant.is_active(t)
+                ):
+                    return token
+        return None
+
+    def consume_token(
+        self,
+        *,
+        token: PermitToken,
+        action_request_id: str,
+    ) -> PermitToken:
+        consumed = token.consume(action_request_id=action_request_id)
+        self.permit_tokens.update(consumed)
+        self.record_evidence(
+            ApprovalEvidence(
+                principal_id="gate_jit_required",
+                decision="consumed",
+                reason=f"PermitToken {token.token_id} consumed for execution.",
+                request_id=action_request_id,
+            )
+        )
+        return consumed
+```
+
+---
+
+### 2. Standing vs. JIT capability
+
+A tool's capability mode is set at declaration time via `@governed_tool` (ADR-0043):
+
+```python
+from lionagi.agent.governance.governed_tool import governed_tool
+from lionagi.protocols.action.manager import ActionManager
+
+# Default: STANDING — callable at any time, no JIT required.
+@governed_tool
+async def read_document(path: str) -> str: ...
+
+# JIT required: gate_jit_required fires before every call.
+@governed_tool(requires_jit=True, safety_class="privileged")
+async def delete_resource(resource_id: str) -> dict: ...
+
+# safety_class="privileged" implies requires_jit=True even if omitted.
+@governed_tool(safety_class="privileged")
+async def write_production_record(payload: dict) -> dict: ...
+
+actions = ActionManager()
+actions.register_tools(
+    [read_document, delete_resource, write_production_record],
+    update=True,
+)
+```
+
+The `safety_class` field interacts with the Tool Registry Allowlist (ADR-0051): tools registered
+as `safety_class="privileged"` appear in the privileged tier of the allowlist and JIT is enforced
+at the registry level, not just on the individual tool decorator. An agent cannot register a
+privileged tool and bypass JIT by omitting `requires_jit=True`.
+
+---
+
+### 3. Execution flow
+
+The `gate_jit_required` gate (registered as a HARD gate per ADR-0044) fires before any
+`requires_jit=True` tool call. The gate is registered through the existing `AgentConfig.pre(...)`
+hook path and closes over the current Branch's `JITGrantManager`.
+
+```python
+from typing import Any
+
+from lionagi.agent.config import AgentConfig
+from lionagi.session.branch import Branch
+
+
+def install_jit_grant_hook(branch: Branch, config: AgentConfig) -> JITGrantManager:
+    """Mount Branch-scoped grants and register the JIT gate through AgentConfig."""
+    grants = JITGrantManager(
+        agent_id=str(branch.id),
+        actions=branch.acts,             # existing ActionManager
+        logger=branch._log_manager,      # existing DataLogger
+    )
+    branch.metadata.setdefault("governance", {})["jit_grants"] = str(grants.id)
+    config.pre("*", gate_jit_required(grants))
+    return grants
+
+
+def gate_jit_required(grants: JITGrantManager):
+    """Existing pre-hook signature from lionagi.agent.hooks."""
+
+    async def _gate(
+        tool_name: str,
+        action: str,
+        args: dict[str, Any],
+    ) -> dict | None:
+        tool_id = str(args.get("function") or args.get("tool_id") or action or tool_name)
+        tool = grants.actions.registry.get(tool_id) if grants.actions else None
+        governance = getattr(tool, "governance", None) or getattr(
+            tool, "governance_meta", None
+        )
+        requires_jit = bool(getattr(governance, "requires_jit", False))
+        safety_class = getattr(governance, "safety_class", "")
+        if not (requires_jit or safety_class == "privileged"):
+            return None
+
+        agent_id = str(args.get("agent_id") or grants.agent_id)
+        token = grants.find_valid_token(
+            agent_id=agent_id,
+            tool_id=tool_id,
+            arguments=args,
+        )
+        if token is None:
+            reason = (
+                f"No valid JIT permit for tool '{tool_id}' / agent '{agent_id}'. "
+                "Call branch.request_permit(tool_id, args) to obtain authorization."
+            )
+            grants.record_evidence(
+                ApprovalEvidence(
+                    principal_id="gate_jit_required",
+                    decision="denied",
+                    reason=reason,
+                )
+            )
+            raise PermissionError(reason)
+
+        violations = token.scope.constraint_violations(args)
+        if violations:
+            reason = f"Permit constraint violations: {violations}"
+            grants.record_evidence(
+                ApprovalEvidence(
+                    principal_id="gate_jit_required",
+                    decision="denied",
+                    reason=reason,
+                )
+            )
+            raise PermissionError(reason)
+
+        grants.consume_token(
+            token=token,
+            action_request_id=str(args.get("action_request_id", "")),
+        )
+        return None
+
+    return _gate
+```
+
+Sequence: agent generates `ActionRequest` → gate fires → no valid token → HARD deny with
+`request_permit` path → agent calls `branch.request_permit(tool_id, args)` → authorizing party
+issues `PermitToken` + `JITGrant` → agent retries → gate validates and consumes token atomically
+→ tool executes; `ActionResponse` recorded as evidence (ADR-0041) → grant held until
+`revoke_after`; any second call without a new token fails (fail-closed, principle #1).
+
+---
+
+### 4. Permit request surface
+
+`branch.request_permit(tool_id, args, reason="")` is the agent-facing entry point. It emits a
+`PermitRequest` event and suspends the current turn (does not consume context window tokens)
+until the authorizing party responds. It raises `PermitDenied` on rejection and `PermitTimeout`
+if no decision arrives within the configured deadline.
+
+In autonomous pipelines, the orchestrator acts as the authorizing party. A `Branch` configured
+as an orchestrator (ADR-0047) can issue permits for sub-agents it governs, provided the
+orchestrator itself holds a grant from a human principal at the session level. This is not
+self-approval — ADR-0048 (Segregation of Duties) requires the authorizing identity to be
+distinct from the executing agent.
+
+---
+
+### 5. Delayed revocation rationale
+
+`JITGrant.revoke_after` is set to `valid_until + 300 seconds` by default. A grant revoked at
+exactly `valid_until` may leave an in-flight tool call (already dispatched, awaiting network I/O)
+in an undefined authorization state. The 5-minute grace window lets legitimately dispatched calls
+complete or receive a clean denial from the downstream system rather than a mid-call revocation.
+
+The grace window does NOT extend the permit. `PermitToken` is consumed on first redemption
+regardless of whether `JITGrant` is still in grace — replay prevention is enforced by the token,
+not the window. An agent that consumed its token and attempts a second call during the grace
+period fails at the gate (no valid token found).
+
+---
+
+### 6. Audit integration
+
+Every state transition in the JIT lifecycle produces an evidence node per ADR-0041:
+
+| Event | Evidence kind | Required fields |
+|-------|---------------|-----------------|
+| `PermitToken` issued | `tool_result` | `token_id`, `issued_by`, `expires_at`, `tool_id`, `agent_id` |
+| `PermitToken` consumed | `tool_result` | `token_id`, `consumed_at`, `action_request_id` |
+| `PermitToken` expired (unused) | `tool_result` | `token_id`, `expires_at` |
+| `JITGrant` issued | `tool_result` | `grant_id`, `issued_by`, `valid_until`, `revoke_after` |
+| `JITGrant` revoked | `tool_result` | `grant_id`, `revoked_at` |
+| Gate denial | `tool_result` | `tool_id`, `agent_id`, `reason`, `gate_id=gate_jit_required` |
+
+Evidence nodes are hash-chained (ADR-0041) so that the sequence — permit issued, consumed,
+grant revoked — cannot be silently rewritten after the fact. This provides the audit trail
+required for post-incident reconstruction: given any tool call, the auditor can traverse
+`action_request_id → permit_token_id → grant_id → issued_by` without gaps.
+
+---
+
+## Consequences
+
+**Positive**
+
+- No standing capability for tools declared `requires_jit=True` or `safety_class="privileged"`.
+  A compromised or out-of-scope agent cannot invoke high-risk tools without a fresh authorization
+  decision from an external party.
+- Replay prevention is structural, not convention-based. A `PermitToken` consumed once cannot
+  authorize a second call regardless of whether the grant window is still open.
+- Constraint binding narrows the blast radius. A permit issued with `{"resource_id": "r-123"}`
+  blocks the agent from calling the same tool with `resource_id="r-*"` even if no human is
+  watching.
+- Audit trail is machine-traversable from tool call back to human decision (ADR-0041 evidence
+  chain, ADR-0042 Task Certificate).
+- Break-glass compatibility: ADR-0045 provides the emergency path when the grant issuance
+  system is unavailable. Break-glass is not a JIT bypass — it is a separate degraded-mode
+  protocol that produces its own evidence under heightened scrutiny.
+
+**Negative**
+
+- Agentic workflows that previously ran autonomously on high-risk tools now require an external
+  authorization step. Pipelines must be redesigned to either obtain permits ahead of time (batch
+  pre-authorization) or tolerate suspension while awaiting approval.
+- Human-in-the-loop latency is now on the critical path for any `requires_jit=True` tool. Studio
+  UI must surface permit requests clearly; a buried notification degrades the flow without
+  improving security.
+- Orchestrators acting as authorizing parties create a trust chain that must be audited. An
+  orchestrator that auto-approves every sub-agent request without human oversight negates the
+  security benefit. ADR-0047 (Agent Charter) and ADR-0048 (Segregation of Duties) constrain
+  what an orchestrator may self-approve.
+- `JITGrantManager` introduces shared mutable state across a Branch's execution that must be
+  thread-safe and persisted to survive process restarts. Implementations that hold grants only
+  in memory lose the revocation record on crash.
+
+---
+
+## Non-Goals
+
+Explicitly out of scope:
+
+- **Federated permit issuance across tenants**: Cross-tenant grants and multi-tenant permit
+  federation are KHive territory. In v1, permits are scoped to a single lionagi process/session
+  boundary.
+- **Automatic re-issuance on expiry**: A `PermitToken` that expires is not automatically renewed.
+  Re-issuance requires a new authorization decision. Automatic renewal would convert a time-bounded
+  grant into standing capability under a different name.
+- **Grant transferability between agents**: A `PermitToken` is bound to `GrantScope.agent_id`. It
+  cannot be passed from one Branch to another. An agent cannot delegate its own permit.
+- **Permit-less execution paths for declared high-risk tools**: There is no flag, environment
+  variable, or runtime mode that makes `requires_jit=True` tools executable without a valid
+  token. Library mode (`LIONAGI_GOVERNED=false`) suppresses governance at the framework level,
+  but does not affect tools that explicitly declare `requires_jit=True` in their own decorator.
+- **UI permit-approval interface**: Studio UI surface for displaying and approving permit
+  requests is out of scope for this ADR. The protocol (`PermitRequest` event, `request_permit`
+  API) is defined here; the UI implementation is a Studio concern.
+- **Revocation of already-consumed tokens**: A consumed token is a historical record, not an
+  active authorization. Revoking it has no security effect and is not supported.
+
+---
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Standing capability only (current behavior) | No authorization boundary for high-risk tools. A long-lived agent with `delete_resource` registered can call it at any turn in any context. Unacceptable for privileged operations. |
+| Revoke standing on idle timeout | Too coarse. Idle-based revocation does not bind capability to a specific authorized operation. An agent that just processed an unrelated request would have its capability restored on the next active turn. |
+| Per-call human confirmation | Blocks agentic execution — every call suspends until a human responds. For multi-step tool sequences this creates an unworkable approval queue. JIT grants allow pre-authorization of a bounded window; per-call confirmation eliminates any window. |
+| JIT role only (no permit token) | Removes standing capability but allows replay: any call during the grant window is authorized, not just the specific transaction the human approved. prior research explicitly rejected this. Replay within the grant window is a real attack vector. |
+| Permit token only (no JIT grant record) | Prevents replay but provides no capability-window audit record. The grant record is what allows auditors to trace "who extended capability to this agent and for how long" independently of which specific calls were made. |
+
+---
+
+## References
+
+- [ADR-0041](ADR-0041-immutable-evidence-nodes.md) — hash-chained evidence nodes that anchor every permit lifecycle event
+- [ADR-0042](ADR-0042-task-certificate.md) — Task Certificate: signed proof of process adherence that JIT grants link into
+- [ADR-0043](ADR-0043-governed-tool-declaration.md) — `@governed_tool` declaration surface; `requires_jit=True` and `safety_class` fields defined there
+- [ADR-0044](ADR-0044-tool-gates.md) — Tool Gates (HARD/SOFT/ADVISORY); `gate_jit_required` is a HARD gate registered per this ADR
+- [ADR-0045](ADR-0045-break-glass-protocol.md) — emergency path when grant issuance is unavailable; not a JIT bypass
+- [ADR-0047](ADR-0047-agent-charter.md) — Agent Charter; constrains which agents may act as authorizing parties
+- [ADR-0048](ADR-0048-agent-segregation-of-duties.md) — SoD: an agent cannot approve its own JIT grant
+- [ADR-0051](ADR-0051-tool-registry-allowlists.md) — privileged tier of the tool registry enforces JIT at registration time
+- [ADR-0033](ADR-0033-unified-entity-state-model.md) — `EvidenceRef` kinds used in audit table above
+- prior governance research `01_design/015-jit-role/ADR-015-jit-role.md` — source pattern (defense-in-depth with permit + JIT roles)

--- a/docs/adrs/ADR-0047-agent-charter.md
+++ b/docs/adrs/ADR-0047-agent-charter.md
@@ -1,6 +1,6 @@
 # ADR-0047: Agent Charter — Enforceable Governance Document
 
-**Status**: Proposed
+**Status**: proposed
 **Date**: 2026-05-26
 **Depends on**: [ADR-0044](ADR-0044-tool-gates.md) (charter constraints bind to gate_ids), [ADR-0051](ADR-0051-tool-registry-allowlists.md) (charter declares the tool allowlist), [ADR-0052](ADR-0052-policy-resolution.md) (charter version is part of the policy bundle), [ADR-0050](ADR-0050-operation-context.md) (active charter version captured in evidence)
 **Related**: [ADR-0041](ADR-0041-immutable-evidence-nodes.md) (charter ratification hash follows the same SHA-256 pattern), [ADR-0042](ADR-0042-task-certificate.md) (certificate records active charter version), [ADR-0046](ADR-0046-jit-tool-grant.md) (JIT grant gates appear as charter constraints), [ADR-0048](ADR-0048-agent-segregation-of-duties.md) (SoD constraints are declared in the charter)

--- a/docs/adrs/ADR-0047-agent-charter.md
+++ b/docs/adrs/ADR-0047-agent-charter.md
@@ -1,0 +1,757 @@
+# ADR-0047: Agent Charter — Enforceable Governance Document
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Depends on**: [ADR-0044](ADR-0044-tool-gates.md) (charter constraints bind to gate_ids), [ADR-0051](ADR-0051-tool-registry-allowlists.md) (charter declares the tool allowlist), [ADR-0052](ADR-0052-policy-resolution.md) (charter version is part of the policy bundle), [ADR-0050](ADR-0050-operation-context.md) (active charter version captured in evidence)
+**Related**: [ADR-0041](ADR-0041-immutable-evidence-nodes.md) (charter ratification hash follows the same SHA-256 pattern), [ADR-0042](ADR-0042-task-certificate.md) (certificate records active charter version), [ADR-0046](ADR-0046-jit-tool-grant.md) (JIT grant gates appear as charter constraints), [ADR-0048](ADR-0048-agent-segregation-of-duties.md) (SoD constraints are declared in the charter)
+
+## Context
+
+lionagi's `AgentConfig` (`lionagi/agent/config.py`) is the current primary configuration
+artifact for an agent. It carries a `permissions` dict, a `hook_handlers` dict, a `tools` list,
+and free-form `extra`. An operator can write:
+
+```python
+config = AgentConfig(
+    name="pr-reviewer",
+    tools=["reader", "bash"],
+    permissions={"bash.deny": ["git push *", "git commit *"]},
+)
+config.pre("bash", guard_destructive)
+```
+
+This documents intent clearly. What it does not do is enforce that intent uniformly. The
+`permissions` dict is read by `create_agent()` and wired into the branch at session start, but
+nothing prevents a downstream call from ignoring it. The `guard_destructive` hook fires if wired
+correctly, but there is no structural guarantee that a config claiming "deny destructive commands"
+has actually registered that hook. The configuration records what the operator *wanted*; it does
+not prove what the system *will do*.
+
+Cross-cutting principle #3 — **every constraint must be enforced, not just documented** — names
+this gap precisely. Aspirational constraints without enforcement bindings are not governance; they
+are intent commentary. An `AgentConfig` that says "deny network access" but has no gate preventing
+a network-capable tool from executing is indistinguishable, at audit time, from one that says
+nothing about network access at all.
+
+The gap has a second dimension: mutability. `AgentConfig` is a mutable Python dataclass. Nothing
+prevents code from altering the `permissions` dict after the config is created but before the
+session starts. There is no signatory record, no hash, and no proof that the config that launched
+a session matches the config a human approved. When someone asks "was this agent governed by the
+right policy?" the only answer today is "we believe so."
+
+### The applicable prior governance research insight
+
+prior research establishes that a Charter is the canonical governance document for a tenant:
+every constraint in the Charter must reference either a `gate_id` (a registered enforcement gate)
+or a `service_check` (an importable method). If there is no code enforcing a constraint, that
+constraint does not belong in the Charter. The Charter is made immutable by a ratification hash
+(SHA-256 of all fields) computed at activation time; signatories are accountable for the exact
+content they endorsed. Single active Charter per tenant eliminates governance ambiguity: at any
+point in time, exactly one Charter is authoritative. In lionagi terms, tenant maps to agent: each
+agent has exactly one active `AgentCharter`.
+
+### Why lionagi needs this
+
+Consider a PR reviewer agent deployed inside an organization. Its `AgentConfig` states it must not
+write to the main branch and must emit structured evidence for every file read. These are real
+constraints with real consequences if violated. Without `AgentCharter`, an operator reading the
+config has to trust that every hook was wired correctly, that no code path bypasses the hook
+registry, and that the config was not mutated between authoring and deployment. With
+`AgentCharter`, activation fails if `gate_id: "guard_branch_protection"` is not found in the
+gate registry, and `hook_name: "log_tool_use"` is not importable. The constraint either binds to
+code or the charter does not activate. There is no middle state.
+
+## Decision
+
+We introduce `AgentCharter` as the canonical governance binding for a lionagi agent: a frozen,
+hash-ratified document where every constraint references either a registered tool gate
+(ADR-0044) or an importable hook, and whose version is captured in every Operation Context
+(ADR-0050) produced during the agent's sessions.
+
+### 1. `CharterConstraint` — the enforcement-binding requirement
+
+Every constraint in a charter must prove it has code behind it. Pydantic validation on the
+`Element` subclass enforces this structurally at construction time, not at activation time.
+
+```python
+# lionagi/protocols/governance/charter.py
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import json
+from typing import Any
+from typing import Literal
+
+from pydantic import ConfigDict, Field, model_validator
+
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.log import DataLogger
+from lionagi.protocols.generic.pile import Pile
+
+HookPhase = Literal["message_added", "security_pre", "pre", "post", "error"]
+ManagerSurface = Literal[
+    "MessageManager",
+    "ActionManager",
+    "iModelManager",
+    "DataLogger",
+]
+
+
+class CharterConstraint(Element):
+    """An enforceable constraint declared in an AgentCharter.
+
+    CRITICAL: Exactly one of gate_id or hook_name must be set.
+    If there is no code enforcing this constraint, it does not belong here.
+    Aspirational constraints have no operational value.
+
+    Attributes:
+        constraint_id: Human-readable identifier, unique within the charter.
+        description: What this constraint requires, in plain language.
+        gate_id: References a registered ToolGate (ADR-0044). Mutually
+            exclusive with hook_name.
+        hook_name: References an existing hook by importable dotted or
+            "module:attribute" path (e.g. "lionagi.agent.hooks.log_tool_use").
+            Mutually exclusive with gate_id.
+        hook_phase: Existing hook phase used when hook_name is set.
+        manager_surface: Branch manager surface affected by this constraint.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    constraint_id: str = Field(min_length=1)
+    description: str = Field(min_length=1)
+    gate_id: str | None = None
+    hook_name: str | None = None
+    hook_phase: HookPhase | None = None
+    manager_surface: ManagerSurface = "ActionManager"
+
+    @model_validator(mode="after")
+    def validate_enforcement_binding(self) -> CharterConstraint:
+        has_gate = self.gate_id is not None
+        has_hook = self.hook_name is not None
+        if has_gate == has_hook:
+            raise ValueError(
+                f"CharterConstraint '{self.constraint_id}' must have exactly one of "
+                f"gate_id or hook_name, not both and not neither. "
+                f"If there is no code enforcing this constraint, it does not belong "
+                f"in the charter. (gate_id={self.gate_id!r}, hook_name={self.hook_name!r})"
+            )
+        if has_hook and self.hook_phase is None:
+            raise ValueError(
+                f"CharterConstraint '{self.constraint_id}' with hook_name must declare "
+                "the existing hook phase it binds to."
+            )
+        if has_gate and self.hook_phase is not None:
+            raise ValueError(
+                f"CharterConstraint '{self.constraint_id}' with gate_id must not declare "
+                "a hook_phase."
+            )
+        return self
+```
+
+### 2. `AgentCharter` — the governance document
+
+```python
+class CharterActivationEvidence(Element):
+    """Evidence that a charter constraint resolved, or failed to resolve, to code."""
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    constraint_id: str
+    binding_kind: Literal["gate", "hook"]
+    binding_ref: str
+    manager_surface: ManagerSurface
+    resolved: bool
+    reason: str | None = None
+
+
+class AgentCharter(Element):
+    """Tenant-scoped (agent-scoped) governance document.
+
+    An AgentCharter is immutable after ratification. Its ratification_hash
+    is SHA-256 of all fields except ratification_hash itself, computed at
+    activation time. Signatories are accountable for the exact content they
+    endorsed — the hash proves what they ratified.
+
+    Only one charter may be ACTIVE per agent_id at any time. To change
+    governance, create a new charter and supersede this one.
+
+    Attributes:
+        charter_id: Unique identifier for this charter document.
+        agent_id: The agent this charter governs.
+        version: Monotonically increasing integer per charter_id. Version 1
+            is the initial charter; each supersession increments by one.
+        constraints: Pile of constraints. Every constraint references either a
+            gate_id or a hook_name — no aspirational rules.
+        allowed_tools: Explicit allowlist of tool names this agent may call.
+            Declared here; enforced by the Tool Registry (ADR-0051).
+        allowed_models: iModel identifiers this agent may use. Constrains
+            iModelManager resolution at session start.
+        policy_release_version: Binds this charter to a specific policy bundle
+            from ADR-0052. Ensures the constraint set was authored against a
+            known policy state.
+        ratified_at: Unix timestamp of ratification.
+        ratified_by: Ordered list of signatory identifiers. Signatories are
+            accountable for this exact content.
+        ratification_hash: SHA-256 of all fields except this field itself.
+            Computed on first activation. Presence signals the charter is
+            ACTIVE or SUPERSEDED — never DRAFT.
+        active: True when this charter is the currently governing document
+            for agent_id. Exactly one active charter per agent_id at any time.
+        superseded_by: charter_id of the charter that replaced this one, or
+            None if this charter is still active or was never activated.
+        activation_evidence: Pile of typed evidence records produced when
+            activation resolves gates and hooks.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    charter_id: str = Field(min_length=1)
+    agent_id: str = Field(min_length=1)
+    version: int = Field(ge=1)
+    constraints: Pile[CharterConstraint] = Field(
+        default_factory=lambda: Pile(
+            item_type={CharterConstraint},
+            strict_type=True,
+        )
+    )
+    allowed_tools: tuple[str, ...] = Field(default_factory=tuple)
+    allowed_models: tuple[str, ...] = Field(default_factory=tuple)
+    policy_release_version: str
+    ratified_at: float
+    ratified_by: tuple[str, ...] = Field(default_factory=tuple)
+    ratification_hash: str = ""
+    active: bool = False
+    superseded_by: str | None = None
+    activation_evidence: Pile[CharterActivationEvidence] = Field(
+        default_factory=lambda: Pile(
+            item_type={CharterActivationEvidence},
+            strict_type=True,
+        )
+    )
+
+    def verify_hash(self) -> bool:
+        """Return True if ratification_hash matches recomputed hash of content."""
+        return self.ratification_hash == _compute_charter_hash(self)
+
+    def constraint_by_id(self, constraint_id: str) -> CharterConstraint | None:
+        """Look up a single constraint by its constraint_id."""
+        for c in self.constraints:
+            if c.constraint_id == constraint_id:
+                return c
+        return None
+```
+
+### 3. Charter hash computation
+
+The hash covers every governance-relevant field. It excludes `ratification_hash` itself (the
+field being computed) and `active` / `superseded_by` (lifecycle fields that change without
+altering what was ratified).
+
+```python
+def _compute_charter_hash(charter: AgentCharter) -> str:
+    """Compute SHA-256 over all ratification-relevant fields.
+
+    Fields excluded: ratification_hash (computed), active, superseded_by
+    (lifecycle metadata that changes without modifying what was ratified),
+    activation_evidence, and Element infrastructure fields.
+    """
+    content: dict[str, Any] = charter.to_dict(mode="db")
+    for field_name in (
+        "id",
+        "created_at",
+        "node_metadata",
+        "ratification_hash",
+        "active",
+        "superseded_by",
+        "activation_evidence",
+    ):
+        content.pop(field_name, None)
+    serialized = json.dumps(content, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(serialized.encode()).hexdigest()
+```
+
+### 4. Charter activation — the enforcement-binding validation gate
+
+Activation validates that every constraint in the charter resolves to real code before the
+charter becomes operative. If any constraint fails to resolve, activation raises and the charter
+remains in DRAFT state. This is the structural enforcement of cross-cutting principle #3.
+
+```python
+class CharterActivationError(Exception):
+    """Raised when a charter cannot be activated due to unresolvable constraints."""
+
+    def __init__(
+        self,
+        charter_id: str,
+        failures: Pile[CharterActivationEvidence],
+    ) -> None:
+        self.charter_id = charter_id
+        self.failures = failures
+        detail = "\n  ".join(
+            f"constraint '{e.constraint_id}': {e.reason}" for e in failures
+        )
+        super().__init__(
+            f"Charter '{charter_id}' activation failed — "
+            f"{len(failures)} constraint(s) could not be resolved to code:\n  {detail}\n"
+            "Remove unresolvable constraints or implement the missing gates/hooks."
+        )
+
+
+def _resolve_hook(hook_name: str) -> Any:
+    if ":" in hook_name:
+        module_path, attr = hook_name.split(":", 1)
+    else:
+        module_path, _, attr = hook_name.rpartition(".")
+    if not module_path or not attr:
+        raise ImportError(f"{hook_name!r} is not an importable hook path")
+    return getattr(importlib.import_module(module_path), attr)
+
+
+def activate_charter(
+    charter: AgentCharter,
+    gate_registry: dict[str, Any],
+    logger: DataLogger | None = None,
+) -> AgentCharter:
+    """Validate all constraints resolve to code and return an active charter.
+
+    Args:
+        charter: The charter to activate. Must be in DRAFT state
+            (ratification_hash == "" or charter.active == False).
+        gate_registry: Map of gate_id -> ToolGate object (ADR-0044).
+            Used to resolve gate_id constraints.
+        logger: Existing DataLogger used to record activation evidence.
+
+    Returns:
+        A new frozen AgentCharter with active=True, ratification_hash set,
+        and activation_evidence populated.
+
+    Raises:
+        CharterActivationError: If any constraint's gate_id is absent from
+            gate_registry, or any constraint's hook_name is not importable.
+        ValueError: If a charter with active=True is passed (already active
+            charters are immutable).
+    """
+    if charter.active:
+        raise ValueError(
+            f"Charter '{charter.charter_id}' is already active. "
+            "To change governance, supersede it with a new charter version."
+        )
+
+    evidence = Pile(item_type={CharterActivationEvidence}, strict_type=True)
+
+    for constraint in charter.constraints:
+        if constraint.gate_id is not None:
+            resolved = constraint.gate_id in gate_registry
+            evidence.include(
+                CharterActivationEvidence(
+                    constraint_id=constraint.constraint_id,
+                    binding_kind="gate",
+                    binding_ref=constraint.gate_id,
+                    manager_surface=constraint.manager_surface,
+                    resolved=resolved,
+                    reason=(
+                        None
+                        if resolved
+                        else f"gate_id '{constraint.gate_id}' not found in gate registry"
+                    ),
+                )
+            )
+        else:
+            assert constraint.hook_name is not None  # enforced by CharterConstraint
+            try:
+                _resolve_hook(constraint.hook_name)
+                evidence.include(
+                    CharterActivationEvidence(
+                        constraint_id=constraint.constraint_id,
+                        binding_kind="hook",
+                        binding_ref=constraint.hook_name,
+                        manager_surface=constraint.manager_surface,
+                        resolved=True,
+                    )
+                )
+            except (ImportError, AttributeError) as exc:
+                evidence.include(
+                    CharterActivationEvidence(
+                        constraint_id=constraint.constraint_id,
+                        binding_kind="hook",
+                        binding_ref=constraint.hook_name,
+                        manager_surface=constraint.manager_surface,
+                        resolved=False,
+                        reason=f"hook_name '{constraint.hook_name}' is not importable — {exc}",
+                    )
+                )
+
+    failures = Pile(
+        collections=[e for e in evidence if not e.resolved],
+        item_type={CharterActivationEvidence},
+        strict_type=True,
+    )
+
+    if failures:
+        raise CharterActivationError(charter.charter_id, failures)
+
+    active_draft = charter.model_copy(
+        update={
+            "active": True,
+            "ratification_hash": "__pending__",
+            "activation_evidence": evidence,
+        },
+        deep=True,
+    )
+    final_hash = _compute_charter_hash(active_draft)
+    active_charter = active_draft.model_copy(
+        update={"ratification_hash": final_hash},
+        deep=True,
+    )
+    if logger is not None:
+        logger.log(
+            {
+                "event": "agent_charter.activated",
+                "charter_id": active_charter.charter_id,
+                "version": active_charter.version,
+                "ratification_hash": active_charter.ratification_hash,
+                "activation_evidence": [
+                    e.to_dict(mode="json") for e in active_charter.activation_evidence
+                ],
+            }
+        )
+    return active_charter
+```
+
+### 5. Lifecycle state machine
+
+```text
+DRAFT ──ratify()──► ACTIVE ──supersede(new_id)──► SUPERSEDED
+  │                                                     │
+  └── edit fields freely                                └── immutable; superseded_by set
+      (hash not yet computed)
+
+ACTIVE: active=True, ratification_hash set, superseded_by=None
+DRAFT:  active=False, ratification_hash="" (or absent)
+SUPERSEDED: active=False, ratification_hash set, superseded_by=<newer_charter_id>
+```
+
+Exactly one ACTIVE charter exists per `agent_id` at any time. The charter store enforces this as
+a uniqueness constraint: activating a new charter atomically sets the previous ACTIVE charter to
+SUPERSEDED and sets `superseded_by` to the new charter's `charter_id`. Both records are retained.
+
+### 6. Integration with `AgentConfig`
+
+`AgentConfig` retains its current role as the session-level configuration surface. At session
+start, `create_agent()` resolves the active charter for `config.extra["agent_id"]` or
+`config.name` (if a charter store is configured) and attaches it to the branch. The charter's
+`allowed_tools` becomes the authoritative tool allowlist, overriding `AgentConfig.tools` when a
+charter is present. The charter's
+`allowed_models` constrains `iModelManager` model selection.
+
+The active charter's `charter_id` and `version` are written into the Operation Context
+(ADR-0050) for every session that runs under it. Every evidence node produced during the session
+carries the charter version in its metadata, making post-hoc governance audits unambiguous.
+
+```python
+# Sketch — lionagi/agent/factory.py (existing file)
+
+from typing import Any
+
+from lionagi.agent.config import AgentConfig
+from lionagi.session.branch import Branch
+
+
+def _config_agent_id(config: AgentConfig) -> str:
+    return str(config.extra.get("agent_id", config.name))
+
+
+def _validate_active_charter(
+    config: AgentConfig,
+    charter: AgentCharter | None,
+) -> AgentCharter | None:
+    if charter is None:
+        return None
+    if not charter.active:
+        raise ValueError(
+            f"Cannot create agent under inactive charter '{charter.charter_id}'. "
+            "Activate the charter before passing it to create_agent()."
+        )
+    if not charter.verify_hash():
+        raise ValueError(
+            f"Charter '{charter.charter_id}' ratification_hash does not match "
+            "current content. The charter may have been tampered with."
+        )
+    if charter.agent_id != _config_agent_id(config):
+        raise ValueError(
+            f"Charter '{charter.charter_id}' governs {charter.agent_id!r}, "
+            f"not AgentConfig {_config_agent_id(config)!r}."
+        )
+    return charter
+
+
+def _apply_charter_to_config(config: AgentConfig, charter: AgentCharter) -> None:
+    # ActionManager: tools are registered from AgentConfig.tools, so the
+    # charter allowlist becomes authoritative before registration.
+    config.tools = list(charter.allowed_tools)
+
+    # Existing Tool pre/post/security/error hooks are wired through AgentConfig
+    # and attached by create_agent() to Tool.preprocessor/postprocessor.
+    for constraint in charter.constraints:
+        if constraint.hook_name is None or constraint.hook_phase == "message_added":
+            continue
+        hook = _resolve_hook(constraint.hook_name)
+        config.hook_handlers.setdefault(f"{constraint.hook_phase}:*", []).append(hook)
+
+
+def _model_ref(model: Any) -> str:
+    provider = getattr(model.endpoint.config, "provider", "")
+    model_name = getattr(model, "model_name", "")
+    return f"{provider}/{model_name}" if provider and model_name else model_name or provider
+
+
+def _bind_charter_to_branch(branch: Branch, charter: AgentCharter) -> None:
+    charter_ref = {
+        "charter_id": charter.charter_id,
+        "version": charter.version,
+        "ratification_hash": charter.ratification_hash,
+    }
+    branch.metadata["active_charter"] = charter_ref
+
+    # MessageManager/chat: stamp the active charter on every added message.
+    def stamp_charter_on_message(message) -> None:
+        message.metadata.setdefault("charter", charter_ref)
+
+    branch.on_message_added.append(stamp_charter_on_message)
+
+    # MessageManager hook constraints use the existing on_message_added hook list.
+    for constraint in charter.constraints:
+        if constraint.hook_phase == "message_added":
+            branch.on_message_added.append(_resolve_hook(constraint.hook_name))
+
+    # ActionManager/action: fail closed if a tool escaped the charter allowlist.
+    disallowed_tools = set(branch.acts.registry) - set(charter.allowed_tools)
+    if disallowed_tools:
+        raise PermissionError(
+            f"Tools outside active charter allowlist: {sorted(disallowed_tools)}"
+        )
+
+    # iModelManager/model: registered model endpoints must be charter-allowed.
+    if charter.allowed_models:
+        registered_models = {
+            ref for model in branch.mdls.registry.values() if (ref := _model_ref(model))
+        }
+        disallowed_models = registered_models - set(charter.allowed_models)
+        if disallowed_models:
+            raise PermissionError(
+                f"Models outside active charter allowlist: {sorted(disallowed_models)}"
+            )
+
+    # DataLogger/audit: durable provenance for the active Branch managers.
+    branch._log_manager.log(
+        {
+            "event": "agent_charter.bound",
+            "charter": charter_ref,
+            "message_manager": "MessageManager",
+            "action_manager": sorted(branch.acts.registry),
+            "imodel_manager": sorted(branch.mdls.registry),
+        }
+    )
+
+
+async def create_agent(
+    config: AgentConfig,
+    *,
+    charter: AgentCharter | None = None,
+    **kwargs: Any,
+) -> Branch:
+    active_charter = _validate_active_charter(config, charter)
+    if active_charter is not None:
+        _apply_charter_to_config(config, active_charter)
+
+    ...  # existing create_agent body creates Branch and registers managers/tools
+
+    if active_charter is not None:
+        _bind_charter_to_branch(branch, active_charter)
+    return branch
+```
+
+### 7. Two-Key authorship model
+
+The charter is a boundary between two roles with different responsibilities:
+
+- **Policy author**: declares *what* is required — writes the constraint text, assigns
+  `constraint_id`, references the appropriate `gate_id` or `hook_name`. Does not implement code.
+- **Gate implementer**: delivers the `ToolGate` or hook that the constraint references. Does not
+  decide *which* constraints exist.
+
+Neither role can produce a valid, active charter alone. The policy author's constraints are
+rejected at activation if the gate implementer has not delivered the gate. The gate implementer's
+gate has no governance standing unless the policy author declares a constraint referencing it.
+This is the structural separation of concern that makes constraint coverage verifiable.
+
+### 8. Worked example — PR reviewer agent charter
+
+```python
+import time
+
+from lionagi.protocols.generic.pile import Pile
+from lionagi.protocols.governance.charter import (
+    AgentCharter,
+    CharterConstraint,
+    activate_charter,
+)
+
+# Policy author writes constraints. Gate implementer has already registered
+# "guard_branch_protection" in the gate registry and shipped
+# "lionagi.agent.hooks.log_tool_use" as an importable Tool post-hook.
+
+reviewer_charter_draft = AgentCharter(
+    charter_id="charter:pr-reviewer:v1",
+    agent_id="agent:pr-reviewer",
+    version=1,
+    constraints=Pile(
+        collections=[
+            CharterConstraint(
+                constraint_id="no-write-main",
+                description=(
+                    "Agent MUST NOT write to the main branch directly. "
+                    "All writes must target a feature branch."
+                ),
+                gate_id="guard_branch_protection",
+                manager_surface="ActionManager",
+            ),
+            CharterConstraint(
+                constraint_id="evidence-every-read",
+                description=(
+                    "Agent MUST emit a structured log entry for every file read, "
+                    "recording tool name, path, and success status."
+                ),
+                hook_name="lionagi.agent.hooks.log_tool_use",
+                hook_phase="post",
+                manager_surface="DataLogger",
+            ),
+            CharterConstraint(
+                constraint_id="human-approval-merge",
+                description=(
+                    "Agent MUST request human approval before merging any branch. "
+                    "No autonomous merge is permitted."
+                ),
+                gate_id="gate_jit_required",  # ADR-0046 JIT grant gate
+                manager_surface="ActionManager",
+            ),
+        ],
+        item_type={CharterConstraint},
+        strict_type=True,
+    ),
+    allowed_tools=("reader", "bash", "search"),
+    allowed_models=("openai/gpt-4.1", "anthropic/claude-sonnet-4-6"),
+    policy_release_version="policy-bundle:v2026.05",
+    ratified_at=time.time(),
+    ratified_by=("ocean@example.com", "security-team@example.com"),
+    ratification_hash="",   # computed by activate_charter()
+    active=False,
+    superseded_by=None,
+)
+
+# Activation fails if any gate_id is absent from the registry or any
+# hook_name is not importable. Either the code exists or the charter does not activate.
+active_charter = activate_charter(reviewer_charter_draft, gate_registry=gate_registry)
+
+# active_charter.active == True
+# active_charter.ratification_hash == SHA-256 of all governance fields
+# active_charter.verify_hash() == True
+# len(active_charter.activation_evidence) == len(active_charter.constraints)
+```
+
+An operator upgrading the charter — say, adding a constraint that restricts the bash tool to
+read-only commands — creates `version=2`, lists all signatories who must ratify it, calls
+`activate_charter()`, and the store atomically supersedes `version=1`. The old charter is
+retained with `superseded_by="charter:pr-reviewer:v2"`. Any session that ran under `version=1`
+retains its Operation Context referencing `version=1`; its governance provenance is permanent.
+
+## Consequences
+
+**Positive**
+
+- Governance is verifiable: every constraint maps to a `gate_id` or `hook_name`. An auditor can
+  trace `charter constraint → gate → gate execution record` without forensic reconstruction.
+- No aspirational rules: the charter cannot contain constraints that have no enforcement binding.
+  The document reflects actual system behavior at the time it was activated.
+- Tamper evidence: `ratification_hash` detects any post-activation modification to the charter
+  content. `verify_hash()` is a one-line check at session start.
+- Governance provenance: every evidence node produced during a governed session carries the
+  charter version. When governance changes, the before/after boundary is unambiguous.
+- Signatories are accountable: they endorsed a specific hash, not a mutable document.
+
+**Negative**
+
+- Rigidity by design: adding a new constraint requires both the policy author to draft it and the
+  gate implementer to ship the corresponding gate or hook before the charter can activate. There
+  is no shortcut. This is intentional.
+- Re-ratification burden: any governance change — even correcting a typo in a `description` field
+  — requires a new charter version with re-ratification. Operators should batch changes before
+  ratifying.
+- Upfront investment: a project adopting `AgentCharter` must implement and register gates for
+  every constraint it wishes to declare. Projects without gate infrastructure cannot use charters
+  until that infrastructure exists.
+
+## Non-Goals
+
+Explicitly out of scope:
+
+- **Charter inheritance or composition**: a charter that extends another charter, or shares
+  constraints via a base template, is not supported in this ADR. If needed, address in a
+  follow-on ADR after the base model is stable.
+- **Runtime charter mutation**: deliberately impossible. A running session cannot modify its own
+  charter. Any change requires a new charter version, re-ratification, and explicit supersession.
+- **Charter UI or editor surface**: tooling for authoring, viewing, or approving charters is a
+  KHive product concern. This ADR specifies the data model and validation contract only.
+- **Multi-tenant charter namespacing**: multiple organizations sharing a lionagi deployment each
+  having isolated charter stores is a KHive concern. In the open-source framework, charter scope
+  is per-agent-id within a single deployment.
+- **Charter inheritance hierarchies**: e.g., an "org-level" charter whose constraints propagate
+  down to per-agent charters. Out of scope; addressed in policy resolution (ADR-0052) if needed.
+- **Automatic constraint generation**: tooling that inspects gate registry and proposes constraints
+  automatically is a product concern, not a framework concern.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|---|---|
+| `AgentConfig` only (current) | Permissions and hooks document intent but are not structurally bound. A config claiming "deny network access" with no gate behind it is indistinguishable from one that says nothing. Principle #3 violation. |
+| Free-form policy documents (YAML/JSON with no code binding) | Human-readable but not machine-verifiable. An auditor cannot confirm enforcement without reading implementation source. Same gap as AgentConfig. |
+| Charter without ratification hash | Charters without a hash can be silently modified after signatories approve them. Signatories become accountable for content they did not review. Tamper detection is lost. |
+| Advisory constraints (soft vs. hard tier within charter) | Advisory constraints are ignored in practice and have no enforcement value. If a constraint does not need code enforcement, it belongs in documentation, not the charter. prior research reached the same conclusion. |
+| Multiple active charters per agent | Introduces ambiguity about which charter governs a given tool call. Policy resolution (ADR-0052) cannot resolve conflicts between two simultaneously active charters scoped to the same agent. |
+
+## References
+
+- [ADR-0041](ADR-0041-immutable-evidence-nodes.md) — SHA-256 hash-chain pattern; charter hash follows the same construction
+- [ADR-0042](ADR-0042-task-certificate.md) — Task Certificate records the active charter version as part of the proof artifact
+- [ADR-0044](ADR-0044-tool-gates.md) — ToolGate registry; charter `gate_id` references resolve against this registry
+- [ADR-0046](ADR-0046-jit-tool-grant.md) — JIT grant gates appear as `gate_id` references in charter constraints
+- [ADR-0048](ADR-0048-agent-segregation-of-duties.md) — SoD constraints (no self-approval) are declared as charter constraints
+- [ADR-0050](ADR-0050-operation-context.md) — Operation Context captures active charter version; evidence nodes carry charter provenance
+- [ADR-0051](ADR-0051-tool-registry-allowlists.md) — Charter `allowed_tools` is the governance source for the tool registry allowlist
+- [ADR-0052](ADR-0052-policy-resolution.md) — `policy_release_version` binds the charter to a specific policy bundle
+- [ADR-0033](ADR-0033-unified-entity-state-model.md) — EvidenceRef; charter version is embedded in evidence metadata
+- `lionagi/agent/config.py` — `AgentConfig`; charter augments rather than replaces this
+- `lionagi/agent/hooks.py` — built-in hooks (`guard_destructive`, `guard_paths`, `log_tool_use`) referenced as `hook_name` values
+- prior governance research `01_design/025-charter/ADR-025-charter.md` — source pattern (constraints must have enforcement binding, ratification hash, single active per tenant)

--- a/docs/adrs/ADR-0047-agent-charter.md
+++ b/docs/adrs/ADR-0047-agent-charter.md
@@ -721,15 +721,12 @@ Explicitly out of scope:
   follow-on ADR after the base model is stable.
 - **Runtime charter mutation**: deliberately impossible. A running session cannot modify its own
   charter. Any change requires a new charter version, re-ratification, and explicit supersession.
-- **Charter UI or editor surface**: tooling for authoring, viewing, or approving charters is a
-  KHive product concern. This ADR specifies the data model and validation contract only.
-- **Multi-tenant charter namespacing**: multiple organizations sharing a lionagi deployment each
-  having isolated charter stores is a KHive concern. In the open-source framework, charter scope
-  is per-agent-id within a single deployment.
+- **Charter UI or editor surface**: this ADR specifies the data model and validation contract
+  only.
 - **Charter inheritance hierarchies**: e.g., an "org-level" charter whose constraints propagate
   down to per-agent charters. Out of scope; addressed in policy resolution (ADR-0052) if needed.
 - **Automatic constraint generation**: tooling that inspects gate registry and proposes constraints
-  automatically is a product concern, not a framework concern.
+  automatically is out of scope for this ADR.
 
 ## Alternatives Considered
 

--- a/docs/adrs/ADR-0048-agent-segregation-of-duties.md
+++ b/docs/adrs/ADR-0048-agent-segregation-of-duties.md
@@ -742,11 +742,7 @@ out of scope for this ADR.
 Explicitly out of scope:
 
 - **Human SoD**: this ADR governs agent actors (`Branch` instances) only. Human users have
-  their own authentication and authorization layer; their SoD is a product-level concern, not
-  a lionagi framework concern.
-- **Cross-tenant SoD**: conflict enforcement across isolated KHive tenants is a KHive
-  architectural concern, not a lionagi open-source concern. Multi-tenant actor identity
-  resolution is future scope.
+  their own authentication and authorization layer; their SoD is out of scope for this ADR.
 - **Automatic conflict matrix generation**: the conflict matrix is authored by humans and
   reviewed before activation. Automatic inference of conflicts from role capability overlap
   is deliberately excluded — it would produce false positives and obscure the policy intent.
@@ -758,7 +754,7 @@ Explicitly out of scope:
   the run. Policy changes take effect on the next flow construction.
 - **Cross-session global conflict tracking at scale**: the "global" scope in `SoDRule` is
   supported within a single lionagi node. Distributed global conflict tracking (across
-  horizontally scaled nodes) is out of scope and a KHive infrastructure concern.
+  horizontally scaled nodes) is out of scope.
 
 ## Alternatives Considered
 

--- a/docs/adrs/ADR-0048-agent-segregation-of-duties.md
+++ b/docs/adrs/ADR-0048-agent-segregation-of-duties.md
@@ -1,0 +1,790 @@
+# ADR-0048: Agent Segregation of Duties (SoD)
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Depends on**: [ADR-0047](ADR-0047-agent-charter.md) (SoD rules are charter constraints; charter enforces them at role-assignment time), [ADR-0046](ADR-0046-jit-tool-grant.md) (JIT grant issuer and consumer must be distinct actors), [ADR-0044](ADR-0044-tool-gates.md) (SoD enforcement surfaces as a HARD gate on role assignment), [ADR-0042](ADR-0042-task-certificate.md) (certificates require multi-actor attestation; SoD ensures those actors are genuinely distinct)
+**Related**: [ADR-0041](ADR-0041-immutable-evidence-nodes.md) (exemption evidence is an immutable node), [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) (branch.verify claims cannot use self-produced evidence), [ADR-0033](ADR-0033-unified-entity-state-model.md) (EvidenceRef carries actor_id for independence checks)
+
+## Context
+
+lionagi's multi-agent orchestration — `Session.flow()`, `li o fanout`, `li o flow` — assembles
+pipelines of Branch actors. The framework assigns roles (implementer, reviewer, approver, auditor)
+to branches at flow construction time. Today there is no mechanism that prevents the same branch
+from holding roles that are structurally incompatible. A flow that creates an "implementer" step
+and a "reviewer" step can assign both to `branch_a` with no warning. The branch reviews its own
+output. The review passes. The task certificate records attestation by two roles — but both
+attestations came from the same actor.
+
+This is the central problem that Segregation of Duties (SoD) addresses. The cross-cutting
+principle **"Every constraint must be enforced, not just documented"** is the direct motivation:
+governance policies that require a reviewer to be independent of the author are common and
+intuitive, but without runtime enforcement they are aspirational text. An autonomous LLM-driven
+workflow does not read the policy document. It reads the code.
+
+The consequence is not hypothetical. In a ReAct loop with a write step and a verify step, if both
+steps run in the same branch, the branch is evaluating evidence it produced. In a multi-step
+approval chain where the same branch holds two approval roles, a single compromise or error
+propagates through both approvals. These failure modes are not caught by ADR-0044 gate checks
+(which guard tool use, not role occupancy) or by ADR-0042 certificate multi-attestation (which
+counts role signatures, not actor distinctness).
+
+### The applicable prior governance research insight
+
+prior research introduced SoD as a *data-driven gate at grant time* for human role assignments
+in SOX-governed finance workflows: the same person cannot initiate and approve a wire transfer;
+cannot modify a ledger and audit it; cannot grant privileged access and use it. The lion
+translation replaces "person" with "branch actor" (identified by `ln_id`, not by model name),
+"role grant" with "role assignment in a flow step", and "CFO approval" with "external attestation
+by a human or a distinct designated authority agent". The five conflict types carry over verbatim
+because they are structural — they describe the shape of the bypass, not the domain in which
+it occurs.
+
+### Why lionagi needs this
+
+Consider a governed code-review flow: `session.flow()` constructs three steps — write, review,
+merge. An orchestrator under load reuses `branch_a` for both write and review because it is
+available and capable. Without SoD enforcement, `branch_a` submits code and then approves it.
+The `TaskCertificate` records a "reviewer" attestation, which is technically true. The evidence
+chain is intact. The audit trail looks clean. But the independence property that makes review
+meaningful is absent. With SoD enforcement, the role assignment of `branch_a` to "reviewer" is
+rejected at flow construction time — before any code is written — with a structured error naming
+the conflict type (`TRANSACTION_DUAL_CONTROL`) and the existing role (`implementer`). The
+orchestrator must select a different branch for the reviewer step, or fail closed.
+
+## Decision
+
+We introduce a `SoDPolicy` schema and a `assert_sod_independence` function that checks role
+assignments against a versioned conflict matrix at assignment time, rejects conflicting
+assignments with structured errors, and emits evidence when an exemption is in effect.
+
+### 1. Conflict taxonomy
+
+Five conflict types are defined, translated from prior research to agent terms:
+
+| Conflict Type | Agent description | Canonical example |
+|---|---|---|
+| `TRANSACTION_DUAL_CONTROL` | Same actor both initiates and approves a state-changing action | branch writes code; branch reviews it |
+| `RECORD_CUSTODY` | Same actor both creates evidence and audits it | branch produces artifacts; branch audits the artifact trail |
+| `AUDIT_INDEPENDENCE` | An actor's own outputs cannot be sole verification evidence | branch.verify() using only evidence from the same branch |
+| `APPROVAL_CHAIN` | Same actor appears more than once in an approval chain | branch is both L1 and L2 approver in a multi-step sign-off |
+| `ACCESS_CONTROL` | Same actor both grants tool access and uses the granted tool | branch issues a JIT grant (ADR-0046) and then exercises it |
+
+### 2. Schema
+
+```python
+from __future__ import annotations
+
+from enum import Enum
+from typing import Literal
+
+from pydantic import ConfigDict, Field
+
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+
+
+Scope = Literal["session", "task", "global"]
+
+FROZEN_ELEMENT_CONFIG = ConfigDict(
+    arbitrary_types_allowed=True,
+    use_enum_values=True,
+    populate_by_name=True,
+    extra="forbid",
+    frozen=True,
+)
+
+
+class ConflictType(str, Enum):
+    TRANSACTION_DUAL_CONTROL = "transaction_dual_control"
+    RECORD_CUSTODY            = "record_custody"
+    AUDIT_INDEPENDENCE        = "audit_independence"
+    APPROVAL_CHAIN            = "approval_chain"
+    ACCESS_CONTROL            = "access_control"
+
+
+class SoDDuty(Element):
+    """A duty label that can be referenced by role and rule records."""
+
+    model_config = FROZEN_ELEMENT_CONFIG
+
+    label: str
+    description: str | None = None
+
+
+class SoDRole(Element):
+    """A role label plus its governed duty set."""
+
+    model_config = FROZEN_ELEMENT_CONFIG
+
+    label: str
+    duties: Pile[SoDDuty] = Field(
+        default_factory=lambda: Pile(item_type=SoDDuty, strict_type=True)
+    )
+
+
+class SoDRule(Element):
+    """One conflict pair within a policy.
+
+    Both ``role_a`` and ``role_b`` are role labels as used in flow step
+    definitions (e.g., "implementer", "reviewer", "approver", "auditor").
+    The pair is bidirectional: (A, B) implies (B, A) - checked by
+    ``assert_sod_independence`` via symmetric lookup.
+
+    ``scope`` controls how far the actor registry extends:
+    - "session" - conflict within a single Session object
+    - "task"    - conflict within a named task / flow run
+    - "global"  - conflict across all sessions on this node
+    """
+
+    model_config = FROZEN_ELEMENT_CONFIG
+
+    rule_id: str
+    conflict_type: ConflictType
+    role_a: str
+    role_b: str
+    scope: Scope
+
+    # Time-bounded exemption - requires external attestation, never self-issued.
+    exemption_until: float | None = None          # Unix timestamp; None = no active exemption
+    exemption_attestation: str | None = None      # Human or designated authority evidence ID
+
+
+class SoDPolicy(Element):
+    """Versioned set of SoD rules active for a session or flow.
+
+    ``policy_id`` is stable across versions; ``version`` increments on any
+    rule change.  The policy in effect at assignment time is recorded in the
+    rejection evidence and in the TaskCertificate (ADR-0042).
+    """
+
+    model_config = FROZEN_ELEMENT_CONFIG
+
+    policy_id: str
+    version: int
+    max_exemption_days: int = Field(default=365, ge=1, le=365)
+    roles: Pile[SoDRole] = Field(
+        default_factory=lambda: Pile(item_type=SoDRole, strict_type=True)
+    )
+    rules: Pile[SoDRule] = Field(
+        default_factory=lambda: Pile(item_type=SoDRule, strict_type=True)
+    )
+```
+
+### 3. Role registry
+
+The assignment side tracks which actor currently holds which roles:
+
+```python
+from __future__ import annotations
+
+import time
+
+from pydantic import ConfigDict, Field
+
+from lionagi.protocols.action.manager import ActionManager
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.log import DataLogger
+from lionagi.protocols.generic.pile import Pile
+from lionagi.protocols.messages.manager import MessageManager
+from lionagi.service.manager import iModelManager
+from lionagi.session.branch import Branch
+
+
+class RoleAssignment(Element):
+    """A single actor-to-role binding."""
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    actor_id: str   # Branch.id / ln_id - NOT model name; see §6 for multi-LLM note
+    role: str
+    scope: Scope
+    assigned_at: float = Field(default_factory=time.time)
+
+    @classmethod
+    def from_branch(cls, branch: Branch, role: str, scope: Scope) -> "RoleAssignment":
+        """Bind a Branch actor while recording its active manager context."""
+        return cls(
+            actor_id=str(branch.id),
+            role=role,
+            scope=scope,
+            metadata=_branch_manager_metadata(branch),
+        )
+
+
+class SoDCheckEvidence(Element):
+    """First-class evidence for pass, denial, or exemption use."""
+
+    model_config = FROZEN_ELEMENT_CONFIG
+
+    actor_id: str
+    requested_role: str
+    scope: Scope
+    policy_id: str
+    policy_version: int
+    passed: bool
+    rule_id: str | None = None
+    conflict_type: ConflictType | None = None
+    conflicting_role: str | None = None
+    exemption_attestation: str | None = None
+    manager_snapshot: dict[str, object] = Field(default_factory=dict)
+
+
+class SoDRegistry(Element):
+    """Mutable registry of active role assignments for a scope.
+
+    Populated at flow construction time.  ``assert_sod_independence``
+    reads from this registry before writing to it.
+    """
+
+    assignments: Pile[RoleAssignment] = Field(
+        default_factory=lambda: Pile(item_type=RoleAssignment, strict_type=True)
+    )
+    evidence: Pile[SoDCheckEvidence] = Field(
+        default_factory=lambda: Pile(item_type=SoDCheckEvidence, strict_type=True)
+    )
+
+    def roles_for(self, actor_id: str, scope: str) -> list[str]:
+        return [
+            a.role
+            for a in self.assignments
+            if a.actor_id == actor_id and a.scope == scope
+        ]
+
+    def register(self, assignment: RoleAssignment) -> None:
+        self.assignments.include(assignment)
+
+    def register_branch(self, branch: Branch, role: str, scope: Scope) -> RoleAssignment:
+        assignment = RoleAssignment.from_branch(branch, role=role, scope=scope)
+        self.register(assignment)
+        return assignment
+
+
+def _branch_manager_metadata(branch: Branch | None) -> dict[str, object]:
+    """Capture the existing Branch manager surfaces used by SoD."""
+    if branch is None:
+        return {}
+
+    message_manager: MessageManager = branch.msgs
+    action_manager: ActionManager = branch.acts
+    imodel_manager: iModelManager = branch.mdls
+    log_manager: DataLogger = branch._log_manager
+
+    return {
+        "message_count": len(message_manager.messages),
+        "registered_tools": sorted(action_manager.registry.keys()),
+        "chat_model": getattr(imodel_manager.chat, "model", None),
+        "parse_model": getattr(imodel_manager.parse, "model", None),
+        "log_count": len(log_manager.logs),
+    }
+```
+
+### 4. Runtime check
+
+`assert_sod_independence` is called at every role assignment — concretely, at the point where
+`Session.flow()` (or `li o flow`) binds a branch to a step. It returns the assignment on success,
+raises `SoDConflictError` on conflict, and emits an exemption evidence reference if an exemption
+is active.
+
+```python
+from __future__ import annotations
+
+import time
+
+from collections.abc import Awaitable, Callable
+
+from lionagi.agent.config import AgentConfig
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.log import DataLogger
+from lionagi.session.branch import Branch
+
+
+class SoDConflict(Element):
+    """Element record for a denied role assignment."""
+
+    model_config = FROZEN_ELEMENT_CONFIG
+
+    actor_id: str
+    requested_role: str
+    conflicting_role: str
+    conflict_type: ConflictType
+    rule_id: str
+    policy_id: str
+    policy_version: int
+
+
+class SoDConflictError(Exception):
+    """Raised when a role assignment would violate an active SoD rule."""
+
+    def __init__(self, conflict: SoDConflict):
+        self.conflict = conflict
+        super().__init__(str(self))
+
+    def __str__(self) -> str:
+        conflict = self.conflict
+        return (
+            f"SoD conflict [{conflict.rule_id}]: actor '{conflict.actor_id}' already holds "
+            f"role '{conflict.conflicting_role}'; cannot assign '{conflict.requested_role}' "
+            f"({conflict.conflict_type.value}) - policy {conflict.policy_id} "
+            f"v{conflict.policy_version}"
+        )
+
+
+def assert_sod_independence(
+    actor_id: str,
+    requested_role: str,
+    scope: str,
+    registry: SoDRegistry,
+    policy: SoDPolicy | None,
+    branch: Branch | None = None,
+) -> RoleAssignment:
+    """Check and register a role assignment against the active SoD policy.
+
+    Raises ``SoDConflictError`` if a conflict is found and no valid exemption
+    is in effect.  Returns the new ``RoleAssignment`` on success and registers
+    it in ``registry``.
+
+    Fail-closed: if ``policy`` has no rules (empty Pile), the assignment
+    proceeds - an empty policy is a deliberate choice, not an absent matrix.
+    If ``policy`` itself is ``None``, assignment is denied.
+    """
+
+    if policy is None:
+        raise PermissionError("SoD assignment denied: no active SoDPolicy")
+
+    now = time.time()
+    effective_actor_id = str(branch.id) if branch is not None else actor_id
+    held_roles = registry.roles_for(effective_actor_id, scope)
+
+    for rule in policy.rules:
+        # Bidirectional check
+        if rule.scope != scope:
+            continue
+        pairs = {(rule.role_a, rule.role_b), (rule.role_b, rule.role_a)}
+        for held in held_roles:
+            if (held, requested_role) in pairs:
+                if _is_active_exemption(rule, now):
+                    # Exemption active - proceed but emit evidence reference.
+                    _emit_exemption_evidence(
+                        actor_id=effective_actor_id,
+                        rule=rule,
+                        policy=policy,
+                        registry=registry,
+                        branch=branch,
+                        requested_role=requested_role,
+                        conflicting_role=held,
+                    )
+                    break  # exemption covers this conflict; continue to next rule
+
+                conflict = SoDConflict(
+                    actor_id=effective_actor_id,
+                    requested_role=requested_role,
+                    conflicting_role=held,
+                    conflict_type=rule.conflict_type,
+                    rule_id=rule.rule_id,
+                    policy_id=policy.policy_id,
+                    policy_version=policy.version,
+                )
+                evidence = SoDCheckEvidence(
+                    actor_id=effective_actor_id,
+                    requested_role=requested_role,
+                    scope=scope,
+                    policy_id=policy.policy_id,
+                    policy_version=policy.version,
+                    passed=False,
+                    rule_id=rule.rule_id,
+                    conflict_type=rule.conflict_type,
+                    conflicting_role=held,
+                    manager_snapshot=_branch_manager_metadata(branch),
+                )
+                registry.evidence.include(evidence)
+                _record_sod_evidence(branch, evidence)
+                raise SoDConflictError(conflict)
+
+    assignment = (
+        RoleAssignment.from_branch(branch, requested_role, scope)
+        if branch is not None
+        else RoleAssignment(actor_id=effective_actor_id, role=requested_role, scope=scope)
+    )
+    registry.register(assignment)
+
+    evidence = SoDCheckEvidence(
+        actor_id=effective_actor_id,
+        requested_role=requested_role,
+        scope=scope,
+        policy_id=policy.policy_id,
+        policy_version=policy.version,
+        passed=True,
+        manager_snapshot=_branch_manager_metadata(branch),
+    )
+    registry.evidence.include(evidence)
+    _record_sod_evidence(branch, evidence)
+    return assignment
+
+
+def _is_active_exemption(rule: SoDRule, now: float) -> bool:
+    return (
+        rule.exemption_until is not None
+        and rule.exemption_until > now
+        and rule.exemption_attestation is not None
+    )
+
+
+def _emit_exemption_evidence(
+    *,
+    actor_id: str,
+    rule: SoDRule,
+    policy: SoDPolicy,
+    registry: SoDRegistry,
+    branch: Branch | None,
+    requested_role: str,
+    conflicting_role: str,
+) -> SoDCheckEvidence:
+    """Emit an immutable evidence node recording the exemption.
+
+    Implementation writes an EvidenceRef (ADR-0033) of kind
+    ``human_assertion`` referencing ``rule.exemption_attestation``.
+    The evidence node captures: actor_id, rule_id, policy version,
+    exemption_until, and the exemption attestation ID.  This node
+    becomes part of the TaskCertificate evidence chain (ADR-0042).
+
+    Full implementation lives in lionagi/agent/governance/sod.py.
+    The signature is the contract; the evidence schema is EvidenceRef from
+    ADR-0033.
+    """
+    evidence = SoDCheckEvidence(
+        actor_id=actor_id,
+        requested_role=requested_role,
+        scope=rule.scope,
+        policy_id=policy.policy_id,
+        policy_version=policy.version,
+        passed=True,
+        rule_id=rule.rule_id,
+        conflict_type=rule.conflict_type,
+        conflicting_role=conflicting_role,
+        exemption_attestation=rule.exemption_attestation,
+        manager_snapshot=_branch_manager_metadata(branch),
+    )
+    registry.evidence.include(evidence)
+    _record_sod_evidence(branch, evidence)
+    return evidence
+
+
+def _record_sod_evidence(branch: Branch | None, evidence: SoDCheckEvidence) -> None:
+    if branch is None:
+        return
+    log_manager: DataLogger = branch._log_manager
+    log_manager.log(evidence)
+
+
+def sod_assignment_pre_hook(
+    registry: SoDRegistry,
+    policy: SoDPolicy,
+) -> Callable[[str, str, dict], Awaitable[dict | None]]:
+    """Existing AgentConfig/Tool pre-hook wrapper for role-assignment tools."""
+
+    async def _hook(tool_name: str, action: str, args: dict) -> dict | None:
+        if action != "assign_role" and tool_name != "assign_role":
+            return None
+
+        branch = args.get("branch")
+        if not isinstance(branch, Branch):
+            raise PermissionError("SoD assignment denied: missing Branch actor")
+
+        assignment = assert_sod_independence(
+            actor_id=str(branch.id),
+            requested_role=args["role"],
+            scope=args["scope"],
+            registry=registry,
+            policy=policy,
+            branch=branch,
+        )
+        args["sod_assignment_id"] = str(assignment.id)
+        return args
+
+    return _hook
+
+
+def install_sod_enforcement(
+    config: AgentConfig,
+    registry: SoDRegistry,
+    policy: SoDPolicy,
+) -> AgentConfig:
+    """Register SoD through lionagi's existing hook system, not a bespoke registry."""
+    config.pre("assign_role", sod_assignment_pre_hook(registry, policy))
+    return config
+```
+
+### 5. Worked example — code-review flow
+
+A three-step flow: `write → review → merge`.
+
+```text
+Step 1: assign(branch=branch_a, actor=branch_a.id, role="implementer", scope="task:pr-42")
+        -> _branch_manager_metadata captures branch_a.msgs, branch_a.acts,
+           branch_a.mdls, and branch_a._log_manager
+        -> held_roles(branch_a.id, "task:pr-42") = []
+        -> no conflict -> RoleAssignment registered in SoDRegistry.assignments
+        -> SoDCheckEvidence logged through DataLogger
+
+Step 2: assign(branch=branch_a, actor=branch_a.id, role="reviewer", scope="task:pr-42")
+        -> held_roles(branch_a.id, "task:pr-42") = ["implementer"]
+        -> rule SOD-001: (implementer, reviewer, TRANSACTION_DUAL_CONTROL)
+        -> no exemption active
+        -> SoDConflictError: actor 'branch_a' already holds 'implementer';
+           cannot assign 'reviewer' (transaction_dual_control)
+        -> denial evidence stored in SoDRegistry.evidence and logged through DataLogger
+
+        Orchestrator selects branch_b instead:
+        assign(branch=branch_b, actor=branch_b.id, role="reviewer", scope="task:pr-42")
+        -> held_roles(branch_b.id, "task:pr-42") = []
+        -> no conflict -> assignment registered and evidence logged
+
+Step 3: assign(branch=branch_c, actor=branch_c.id, role="merger", scope="task:pr-42")
+        -> no conflict rules for (implementer|reviewer, merger)
+        -> assignment registered and evidence logged
+```
+
+The TaskCertificate (ADR-0042) for this task records three distinct `actor_id` values for the
+three attesting roles. The SoD check result at step 2 is preserved in the immutable evidence
+chain (ADR-0041) as the rejection record.
+
+### 6. Self-attestation prevention (AUDIT_INDEPENDENCE)
+
+The `AUDIT_INDEPENDENCE` conflict type extends beyond flow role assignments to
+`branch.verify()` from ADR-0039. A verification claim whose `actor_id` is `X` cannot rely
+solely on evidence whose `actor_id` is also `X` within the same scope. This is the agent
+analogue of prior governance research's prohibition on a system administrator auditing their own changes.
+
+At `branch.verify()` call time:
+
+```python
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+
+
+def check_audit_independence(
+    verifier_actor_id: str,
+    evidence_refs: Pile[Element],
+    scope: str,
+    policy: SoDPolicy,
+    branch: Branch | None = None,
+    registry: SoDRegistry | None = None,
+) -> None:
+    """Raise SoDConflictError if all evidence is self-produced.
+
+    A verification is independent if at least one EvidenceRef was produced
+    by a different actor_id.  An empty evidence Pile fails closed - a claim
+    with no supporting evidence cannot be verified.
+    """
+    audit_rules = Pile(item_type=SoDRule, strict_type=True)
+    for rule in policy.rules:
+        if (
+            rule.conflict_type == ConflictType.AUDIT_INDEPENDENCE
+            and rule.scope == scope
+        ):
+            audit_rules.include(rule)
+
+    if audit_rules.is_empty():
+        return  # No audit independence rules; proceed
+
+    rule = audit_rules[0]
+
+    if evidence_refs.is_empty():
+        _raise_audit_independence_conflict(
+            verifier_actor_id=verifier_actor_id,
+            scope=scope,
+            policy=policy,
+            rule=rule,
+            branch=branch,
+            registry=registry,
+        )
+
+    independent = any(
+        (actor := _evidence_actor_id(ref)) is not None
+        and actor != verifier_actor_id
+        for ref in evidence_refs
+    )
+    if not independent:
+        _raise_audit_independence_conflict(
+            verifier_actor_id=verifier_actor_id,
+            scope=scope,
+            policy=policy,
+            rule=rule,
+            branch=branch,
+            registry=registry,
+        )
+
+    evidence = SoDCheckEvidence(
+        actor_id=verifier_actor_id,
+        requested_role="verifier",
+        scope=scope,
+        policy_id=policy.policy_id,
+        policy_version=policy.version,
+        passed=True,
+        rule_id=rule.rule_id,
+        conflict_type=ConflictType.AUDIT_INDEPENDENCE,
+        manager_snapshot=_branch_manager_metadata(branch),
+    )
+    if registry is not None:
+        registry.evidence.include(evidence)
+    _record_sod_evidence(branch, evidence)
+
+
+def _evidence_actor_id(ref: Element) -> str | None:
+    return getattr(ref, "actor_id", None) or ref.metadata.get("actor_id")
+
+
+def _raise_audit_independence_conflict(
+    *,
+    verifier_actor_id: str,
+    scope: str,
+    policy: SoDPolicy,
+    rule: SoDRule,
+    branch: Branch | None,
+    registry: SoDRegistry | None,
+) -> None:
+    conflict = SoDConflict(
+        actor_id=verifier_actor_id,
+        requested_role="verifier",
+        conflicting_role="sole_evidence_producer",
+        conflict_type=ConflictType.AUDIT_INDEPENDENCE,
+        rule_id=rule.rule_id,
+        policy_id=policy.policy_id,
+        policy_version=policy.version,
+    )
+    evidence = SoDCheckEvidence(
+        actor_id=verifier_actor_id,
+        requested_role="verifier",
+        scope=scope,
+        policy_id=policy.policy_id,
+        policy_version=policy.version,
+        passed=False,
+        rule_id=rule.rule_id,
+        conflict_type=ConflictType.AUDIT_INDEPENDENCE,
+        conflicting_role="sole_evidence_producer",
+        manager_snapshot=_branch_manager_metadata(branch),
+    )
+    if registry is not None:
+        registry.evidence.include(evidence)
+    _record_sod_evidence(branch, evidence)
+    raise SoDConflictError(conflict)
+```
+
+### 7. Exemptions
+
+An exemption is time-bounded, requires an external attestation ID (referencing a human decision
+record or a designated authority agent's evidence node), and is never self-issued. The
+constraints are:
+
+- `exemption_until` must be a future timestamp; past timestamps are treated as absent.
+- `exemption_attestation` must reference a non-null evidence ID from an actor other than the
+  actor seeking the exemption.
+- An agent cannot grant its own exemption. The `exemption_attestation` actor and the exempted
+  actor must differ — this is itself an `ACCESS_CONTROL` rule.
+- Every exemption use emits an immutable evidence node (ADR-0041) binding the exemption
+  attestation ID to the assignment record.
+
+No permanent exemptions. An exemption that exceeds the policy's `max_exemption_days` (default
+365; agent flows default 30) is rejected at SoDPolicy construction time, not at runtime.
+
+### 8. Multi-LLM actor identity
+
+Same model, different actors. Two branches both backed by `gpt-4o` are different actors if they
+have different `ln_id` values. SoD operates on `actor_id = branch.ln_id`, not on
+`model_id = branch.imodel.model`. This is intentional: the independence property is about
+decision authority, not computational substrate. A system that treats same-model branches as the
+same actor would break all practical multi-agent flows, since most orchestrators use a single
+capable model for all workers. The compromise vector that SoD addresses is a single *decision
+actor* controlling both sides of a dual-control gate — not two instances of the same model
+reaching independent conclusions.
+
+Conversely, two branches with different `ln_id` values but the same `ln_id` prefix (e.g.,
+cloned branches) are still distinct actors unless the flow explicitly aliases them. Aliasing is
+out of scope for this ADR.
+
+## Consequences
+
+**Positive**
+
+- Prevents self-approval in autonomous flows: the most critical single-actor bypass in
+  multi-agent governance is closed at role-assignment time, before any work begins.
+- Audit-grade independence: TaskCertificates (ADR-0042) that carry multi-role attestation now
+  guarantee the attesting actors were genuinely distinct at the time of assignment.
+- Early detection: orchestrators receive a structured `SoDConflictError` at flow construction,
+  not midway through execution, allowing recovery (substitute a different branch) rather than
+  rollback.
+- Evidence trail: every conflict check — pass or fail — produces a record that names the
+  policy version, rule ID, and actors involved. Exemptions produce immutable nodes.
+- Aligns with cross-cutting principle #3: SoD constraints are charter constraints
+  (ADR-0047) which become runtime gates (ADR-0044); the chain is now complete.
+
+**Negative**
+
+- Orchestration complexity: flows that previously reused one powerful branch for all steps
+  must now provision at minimum two branches for any dual-control workflow pair.
+- Minimum actor count: a flow with `N` mutually exclusive roles requires `N` distinct actors.
+  For flows with 4+ conflicting role pairs, this can force significant branch proliferation.
+- Policy maintenance burden: new roles added to a flow require conflict analysis against the
+  active policy before deployment. The conflict matrix is deliberately manual — no automatic
+  generation (see Non-Goals).
+- Exemption process friction: legitimate single-actor flows (e.g., a solo exploration session
+  not subject to audit requirements) require either a policy with no conflicting rules or an
+  attested exemption; there is no silent bypass.
+
+## Non-Goals
+
+Explicitly out of scope:
+
+- **Human SoD**: this ADR governs agent actors (`Branch` instances) only. Human users have
+  their own authentication and authorization layer; their SoD is a product-level concern, not
+  a lionagi framework concern.
+- **Cross-tenant SoD**: conflict enforcement across isolated KHive tenants is a KHive
+  architectural concern, not a lionagi open-source concern. Multi-tenant actor identity
+  resolution is future scope.
+- **Automatic conflict matrix generation**: the conflict matrix is authored by humans and
+  reviewed before activation. Automatic inference of conflicts from role capability overlap
+  is deliberately excluded — it would produce false positives and obscure the policy intent.
+- **Model-level isolation guarantees**: SoD does not assert that two branches backed by the
+  same LLM are computationally independent. It asserts only that they are organizationally
+  distinct actors with separate decision authority.
+- **Retroactive conflict detection**: the check runs at assignment time. Flows already running
+  are not interrupted by a new policy version; the policy in effect at assignment time governs
+  the run. Policy changes take effect on the next flow construction.
+- **Cross-session global conflict tracking at scale**: the "global" scope in `SoDRule` is
+  supported within a single lionagi node. Distributed global conflict tracking (across
+  horizontally scaled nodes) is out of scope and a KHive infrastructure concern.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|---|---|
+| Trust actor_id only, no role conflict check | Doesn't catch role-level conflicts. Two distinct actors can still form a self-approval loop if the same human controls both branches. Role conflicts are structural, not identity-based alone. |
+| Human-only SoD (out-of-band process) | Does not prevent autonomous self-approval in flows with no human in the loop. A governed flow with no human reviewer can still self-approve; the process rule has no enforcement point. |
+| SoD check at execution time (not assignment time) | Too late. The conflicting role assignment exists in the system; the branch has already begun work in both roles. Execution-time detection leaves the system in an inconsistent state that requires rollback rather than clean substitution. |
+| Static exclusion pairs hardcoded in flow runner | Inflexible and non-auditable. Adding a new conflict pair requires a code change and deployment. Cannot be versioned or superseded without a release. No exemption path for legitimate edge cases. |
+| No SoD (rely on operator discipline) | Rejected outright. Autonomous systems do not have discipline. Any governance property that depends on operators manually checking role assignments before every flow construction is not a governance property — it is a hope. |
+| OPA/Rego for SoD policy evaluation | Adds external infrastructure dependency for a check that is fundamentally a set-membership problem. OPA adds flexibility the conflict matrix does not need, at the cost of an operational component that must be kept available (fail-closed requirement from cross-cutting principle #1). |
+
+## References
+
+- [ADR-0047](ADR-0047-agent-charter.md) — SoD rules are charter constraints; charter is the
+  binding mechanism
+- [ADR-0046](ADR-0046-jit-tool-grant.md) — JIT grant issuer and consumer must satisfy
+  `ACCESS_CONTROL` SoD rule
+- [ADR-0044](ADR-0044-tool-gates.md) — role assignment is enforced as a HARD gate;
+  `SoDConflictError` maps to gate-denied
+- [ADR-0042](ADR-0042-task-certificate.md) — certificate multi-attestation is meaningful only
+  if attesting actors are SoD-independent
+- [ADR-0041](ADR-0041-immutable-evidence-nodes.md) — exemption use and conflict detection
+  produce immutable evidence nodes
+- [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) — `branch.verify()` AUDIT_INDEPENDENCE check
+- [ADR-0033](ADR-0033-unified-entity-state-model.md) — EvidenceRef carries `actor_id`; used
+  in `check_audit_independence`
+- prior governance research `01_design/032-segregation-of-duties/ADR-032-segregation-of-duties.md` — source
+  pattern (SOX Section 302/404 compliance, five conflict type taxonomy, exemption workflow)

--- a/docs/adrs/ADR-0048-agent-segregation-of-duties.md
+++ b/docs/adrs/ADR-0048-agent-segregation-of-duties.md
@@ -1,6 +1,6 @@
 # ADR-0048: Agent Segregation of Duties (SoD)
 
-**Status**: Proposed
+**Status**: proposed
 **Date**: 2026-05-26
 **Depends on**: [ADR-0047](ADR-0047-agent-charter.md) (SoD rules are charter constraints; charter enforces them at role-assignment time), [ADR-0046](ADR-0046-jit-tool-grant.md) (JIT grant issuer and consumer must be distinct actors), [ADR-0044](ADR-0044-tool-gates.md) (SoD enforcement surfaces as a HARD gate on role assignment), [ADR-0042](ADR-0042-task-certificate.md) (certificates require multi-actor attestation; SoD ensures those actors are genuinely distinct)
 **Related**: [ADR-0041](ADR-0041-immutable-evidence-nodes.md) (exemption evidence is an immutable node), [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) (branch.verify claims cannot use self-produced evidence), [ADR-0033](ADR-0033-unified-entity-state-model.md) (EvidenceRef carries actor_id for independence checks)

--- a/docs/adrs/ADR-0049-log-tier-governance.md
+++ b/docs/adrs/ADR-0049-log-tier-governance.md
@@ -1,0 +1,522 @@
+# ADR-0049: Log Tier Governance
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Depends on**: [ADR-0041](ADR-0041-immutable-evidence-nodes.md), [ADR-0045](ADR-0045-break-glass-protocol.md)
+**Related**: [ADR-0042](ADR-0042-task-certificate.md), [ADR-0044](ADR-0044-tool-gates.md), [ADR-0046](ADR-0046-jit-tool-grant.md), [ADR-0047](ADR-0047-agent-charter.md), [ADR-0050](ADR-0050-operation-context.md)
+
+## Context
+
+`DataLogger` in lionagi today writes `Log` entries to JSONL, JSON, or CSV files with no tier
+distinction. Every entry — a `log.debug.*` timing trace, a `branch.add_message` event, an evidence
+emission — goes into the same flat `Pile[Log]`, subject to the same `dump()` and `clear()`
+operations. An agent that gains write access to its own session logs can erase the record of what
+it did. More subtly, a compromised agent or injected tool could call `DataLogger.dump(clear=True)`
+and silently discard the evidence of a gate decision or charter violation before the session ends.
+
+Cross-cutting principle #2 states: **evidence is first-class, not logs**. Evidence carries the
+policy version and gate results active at execution time ("active assertion"); operational logs are
+supporting context. But both flow through the same `DataLogger` today, and the substrate makes no
+distinction. This means the substrate that should protect governance-critical records is the same
+substrate that rotates debug traces. That conflation is the gap this ADR closes.
+
+The triggering scenario: an attacker model where an insider or compromised agent disables logging
+before acting. In lionagi this manifests as: (1) a tool call that invokes `DataLogger.dump(clear=True)`
+immediately before an unauthorized action, erasing the tool-invocation log; or (2) a session
+teardown that discards all in-memory logs before the evidence nodes from ADR-0041 are flushed to
+the backend. Without tier distinction, the application has no way to treat these two operations
+differently.
+
+### The applicable prior governance research insight
+
+prior research introduces a three-tier log hierarchy — MUTABLE / PROTECTED / IMMUTABLE — where
+each tier has distinct deletion semantics enforced at both the application layer and the database
+layer. The core insight is that "audit of auditing" closes the disable-logging attack vector: any
+deletion of a PROTECTED log must itself create an IMMUTABLE evidence node recording who deleted
+what and when. An attacker that disables logging cannot hide the act of disabling. In lionagi terms:
+the `DataLogger` becomes tier-aware, and the tier of a `Log` entry is set at creation time by the
+code path that emits it, not by post-hoc classification.
+
+### Why lionagi needs this
+
+Without tier governance, a test run, a debug session, and a gate decision all produce logs with
+identical tamperability. Consider: `branch.operate()` triggers a HARD gate (ADR-0044); the gate
+approves with an evidence emission (ADR-0041); the agent's tool then calls a file-deletion
+operation. That gate decision is the audit trail. If the same agent can call `DataLogger.clear()`,
+the gate decision disappears before it is persisted. With `LogTier.IMMUTABLE`, the `DataLogger`
+rejects any mutation of that entry — not by policy document, but by code path enforcement, which
+satisfies cross-cutting principle #3: every constraint must be enforced, not just documented.
+
+## Decision
+
+We introduce a `LogTier` enum and make `DataLogger` tier-aware: MUTABLE entries can be deleted
+freely, PROTECTED entries require a break-glass token per ADR-0045 and their deletion creates an
+IMMUTABLE evidence node, and IMMUTABLE entries have no deletion API.
+
+### 1. LogTier enum and Log extension
+
+```python
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import PrivateAttr
+
+from lionagi.models.hashable_model import HashableModel
+from lionagi.protocols.generic.element import Element
+from lionagi.utils import to_dict
+
+
+# lionagi/protocols/generic/log.py
+# Extend the existing module in place; add "LogTier" to __all__.
+
+
+class LogTier(str, Enum):
+    """Three-tier log governance hierarchy.
+
+    Tier assignment is set at creation time by the emitting code path.
+    Default is MUTABLE; higher tiers require explicit opt-in.
+
+    MUTABLE:   debug, performance, ephemeral traces. Freely rotated.
+    PROTECTED: session activity, tool calls, status transitions, errors.
+               Deletion requires break-glass (ADR-0045); deletion itself
+               creates an IMMUTABLE evidence node.
+    IMMUTABLE: evidence emissions (ADR-0041), task certificate state changes
+               (ADR-0042), gate decisions (ADR-0044), break-glass attestations
+               (ADR-0045), permit issuance/consumption (ADR-0046), charter
+               activations (ADR-0047), operation context captures (ADR-0050).
+               No deletion API exists. Write-once at the application layer;
+               DB-level triggers in KHive backend.
+    """
+
+    MUTABLE = "mutable"
+    PROTECTED = "protected"
+    IMMUTABLE = "immutable"
+
+
+class Log(Element):
+    """Existing Log entry, extended in place with explicit tier governance.
+
+    The `tier` field defaults to MUTABLE. Emitters that produce
+    governance-critical records must set tier explicitly:
+
+        Log.create(content, tier=LogTier.IMMUTABLE)
+
+    Once a Log with tier=IMMUTABLE is created, no mutation is permitted.
+    Once a Log with tier=PROTECTED is created, deletion requires a
+    break-glass token from ADR-0045.
+    """
+
+    content: dict[str, Any]
+    tier: LogTier = LogTier.MUTABLE
+    _immutable: bool = PrivateAttr(False)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Reuse the existing PrivateAttr immutability mechanism."""
+        if getattr(self, "_immutable", False):
+            raise AttributeError("This Log is immutable.")
+        super().__setattr__(name, value)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Log":
+        """Restore a Log and preserve the existing read-only restore behavior."""
+        self = cls.model_validate(data)
+        self._immutable = True
+        return self
+
+    @classmethod
+    def create(
+        cls,
+        content: "Element | dict[str, Any]",
+        tier: LogTier = LogTier.MUTABLE,
+    ) -> "Log":
+        """Create a Log entry with an explicit tier.
+
+        Args:
+            content: The payload. Element instances are serialized via
+                     ``to_dict(mode='json')``.
+            tier:    Governance tier. Defaults to MUTABLE; callers emitting
+                     evidence, certificates, or gate decisions must pass
+                     tier=LogTier.IMMUTABLE explicitly.
+        """
+        if isinstance(content, Element | HashableModel):
+            payload = content.to_dict(mode="json")
+        else:
+            payload = to_dict(content, recursive=True, suppress=True)
+
+        if not payload:
+            payload = {"error": "No content to log."}
+
+        log = cls(content=payload, tier=tier)
+        if tier == LogTier.IMMUTABLE:
+            log._immutable = True
+        return log
+```
+
+### 2. Tier-aware DataLogger operations
+
+```python
+from __future__ import annotations
+
+import atexit
+import json
+import logging
+from pathlib import Path
+from hashlib import sha256
+from typing import Any
+from uuid import UUID
+
+from pydantic import Field
+
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+
+from .log import DataLoggerConfig, Log, LogTier
+
+_log = logging.getLogger(__name__)
+
+
+class ProtectedLogDeletion(Element):
+    """Governance metadata emitted as an IMMUTABLE Log via DataLogger."""
+
+    deleted_log_id: str
+    deleted_log_tier: LogTier = Field(default=LogTier.PROTECTED)
+    break_glass_token_id: str
+    actor: str
+    reason: str
+    deleted_content_hash: str
+
+
+class DataLogger:
+    """Existing DataLogger, extended in place as the tier-aware log manager.
+
+    Three entry points for deletion, each enforcing a different tier contract:
+
+    - ``delete_log(log_id)`` - MUTABLE only; raises for higher tiers.
+    - ``delete_protected_logs(log_ids, ...)`` - PROTECTED only; requires break-glass.
+    - There is no ``delete_immutable_log``. The method does not exist.
+
+    ``dump()`` writes IMMUTABLE entries to a separate file (``*_immutable.*``)
+    that the KHive backend opens in append-only mode. MUTABLE and PROTECTED
+    entries go to the standard file.
+    """
+
+    def __init__(
+        self,
+        *,
+        logs: Any = None,
+        _config: DataLoggerConfig = None,
+        **kwargs,
+    ):
+        if _config is None:
+            _config = DataLoggerConfig(**kwargs)
+
+        if isinstance(logs, dict):
+            self.logs = Pile.from_dict(logs)
+        else:
+            self.logs = Pile(collections=logs, item_type=Log, strict_type=True)
+        self._config = _config
+
+        if self._config.auto_save_on_exit:
+            atexit.register(self.save_at_exit)
+
+    def log(self, log_: Any, *, tier: LogTier = LogTier.MUTABLE) -> None:
+        """Add a log synchronously, preserving DataLogger as the integration point."""
+        log_ = Log.create(log_, tier=tier) if not isinstance(log_, Log) else log_
+        if self._config.capacity and len(self.logs) >= self._config.capacity:
+            self.dump(clear=self._config.clear_after_dump)
+        self.logs.include(log_)
+
+    async def alog(self, log_: Any, *, tier: LogTier = LogTier.MUTABLE) -> None:
+        """Add a log asynchronously."""
+        async with self.logs:
+            self.log(log_, tier=tier)
+
+    def delete_log(self, log_id: str | UUID) -> None:
+        """Delete a MUTABLE log entry by ID.
+
+        Raises:
+            PermissionError: If the entry is PROTECTED or IMMUTABLE.
+            KeyError:        If no entry with ``log_id`` exists.
+        """
+        entry: Log = self.logs[log_id]  # raises KeyError if absent
+        if entry.tier == LogTier.PROTECTED:
+            raise PermissionError(
+                f"Log {log_id} has tier=PROTECTED. "
+                "Use delete_protected_logs() with a valid break-glass token (ADR-0045)."
+            )
+        if entry.tier == LogTier.IMMUTABLE:
+            raise PermissionError(
+                f"Log {log_id} has tier=IMMUTABLE. "
+                "Deletion is not permitted. No API exists for IMMUTABLE deletion."
+            )
+        self.logs.pop(entry.id)
+
+    def delete_protected_logs(
+        self,
+        log_ids: str | UUID | list[str | UUID],
+        break_glass_token: str,
+        reason: str,
+    ) -> None:
+        """Delete PROTECTED log entries under break-glass authorization.
+
+        The act of deletion itself creates an IMMUTABLE evidence node
+        ("audit of auditing"). An attacker that deletes a PROTECTED log
+        cannot hide that the deletion occurred.
+
+        Args:
+            log_ids:           ID or IDs of the PROTECTED logs to delete.
+            break_glass_token: Valid token issued by ADR-0045 protocol.
+            reason:            Human-readable justification, recorded
+                               in the IMMUTABLE evidence node.
+
+        Raises:
+            PermissionError: If entry is MUTABLE (use delete_log) or
+                             IMMUTABLE (no deletion permitted), or if
+                             break_glass_token fails validation.
+            KeyError:        If no entry with ``log_id`` exists.
+        """
+        from lionagi.protocols.governance.break_glass import validate_break_glass_token
+
+        # Validate break-glass token — raises if invalid (ADR-0045)
+        attestation = validate_break_glass_token(break_glass_token)
+        ids = log_ids if isinstance(log_ids, list) else [log_ids]
+
+        for log_id in ids:
+            entry: Log = self.logs[log_id]
+            if entry.tier == LogTier.MUTABLE:
+                raise PermissionError(
+                    f"Log {log_id} has tier=MUTABLE. Use delete_log() instead."
+                )
+            if entry.tier == LogTier.IMMUTABLE:
+                raise PermissionError(
+                    f"Log {log_id} has tier=IMMUTABLE. Deletion is not permitted."
+                )
+
+            # Create IMMUTABLE evidence BEFORE deleting. If this emission fails,
+            # deletion aborts (fail-closed, principle #1).
+            deletion_record = ProtectedLogDeletion(
+                deleted_log_id=str(entry.id),
+                deleted_log_tier=entry.tier,
+                break_glass_token_id=attestation.token_id,
+                actor=attestation.actor,
+                reason=reason,
+                deleted_content_hash=_hash_content(entry.content),
+            )
+            deletion_evidence = Log.create(
+                content=deletion_record,
+                tier=LogTier.IMMUTABLE,
+            )
+            self.logs.include(deletion_evidence)
+
+            self.logs.pop(entry.id)
+            _log.warning(
+                "PROTECTED log %s deleted by %s under break-glass %s. "
+                "Evidence node %s created.",
+                entry.id,
+                attestation.actor,
+                attestation.token_id,
+                deletion_evidence.id,
+            )
+
+    def delete_protected_log(
+        self,
+        log_id: str | UUID,
+        break_glass_token: str,
+        reason: str,
+    ) -> None:
+        """Backward-compatible singular wrapper for one protected log."""
+        self.delete_protected_logs(
+            log_id,
+            break_glass_token=break_glass_token,
+            reason=reason,
+        )
+
+    def dump(
+        self,
+        clear: bool | None = None,
+        persist_path: str | Path | None = None,
+    ) -> None:
+        """Dump logs to file(s), routing IMMUTABLE entries to a separate file.
+
+        MUTABLE and PROTECTED entries go to the standard path.
+        IMMUTABLE entries go to ``<stem>_immutable<ext>`` in append mode.
+        The KHive backend opens that file append-only via DB triggers.
+
+        IMMUTABLE entries are never cleared after dump.
+        """
+        if not self.logs:
+            _log.debug("No logs to dump.")
+            return
+
+        fp = Path(persist_path) if persist_path else self._create_path()
+        suffix = fp.suffix.lower()
+        if suffix not in {".csv", ".json", ".jsonl"}:
+            raise ValueError(f"Unsupported file extension: {suffix}")
+
+        obj_key = "csv" if suffix == ".csv" else "json"
+        immutable_fp = fp.with_stem(fp.stem + "_immutable")
+
+        mutable_entries: Pile[Log] = Pile(
+            collections=[e for e in self.logs if e.tier == LogTier.MUTABLE],
+            item_type=Log,
+            strict_type=True,
+        )
+        mutable_protected: Pile[Log] = Pile(
+            collections=[e for e in self.logs if e.tier != LogTier.IMMUTABLE],
+            item_type=Log,
+            strict_type=True,
+        )
+        immutable_entries: Pile[Log] = Pile(
+            collections=[e for e in self.logs if e.tier == LogTier.IMMUTABLE],
+            item_type=Log,
+            strict_type=True,
+        )
+
+        # Implementation delegates to existing Pile.dump() per-subset.
+        # IMMUTABLE entries are always appended to the immutable partition.
+        if mutable_protected:
+            mutable_protected.dump(fp, obj_key)
+        if immutable_entries:
+            immutable_entries.dump(immutable_fp, obj_key, mode="a")
+
+        do_clear = self._config.clear_after_dump if clear is None else clear
+        if do_clear:
+            # dump(clear=True) may rotate MUTABLE logs only. PROTECTED deletion
+            # must pass through delete_protected_logs(); IMMUTABLE has no path.
+            self.logs.exclude([entry.id for entry in mutable_entries])
+
+
+def _hash_content(content: dict[str, Any]) -> str:
+    payload = json.dumps(
+        content,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode()
+    return sha256(payload).hexdigest()
+```
+
+### 3. Tier assignment policy
+
+The following table is the authoritative policy. Code emitting events in these categories
+**must** set the corresponding tier. The `tier=` argument on `Log.create()` is the enforcement
+point; there is no automatic classification.
+
+| Event category | Tier | Examples |
+|---|---|---|
+| `log.debug.*`, raw stdin/stdout traces, perf timing | MUTABLE | `log.debug("token count=42")`, request latency |
+| `branch.add_message()` calls | PROTECTED | Every message added to a Branch |
+| Tool invocations (ActionRequest + ActionResponse) | PROTECTED | All `tool_call` events |
+| Status transitions, errors | PROTECTED | `status=failed`, exception captures |
+| Evidence emissions (ADR-0041) | IMMUTABLE | `EvidenceNode` creation events |
+| Task certificate state changes (ADR-0042) | IMMUTABLE | `TaskCertificate` issue / revoke |
+| Gate decisions (ADR-0044) | IMMUTABLE | HARD/SOFT gate ALLOW or DENY |
+| Break-glass attestations (ADR-0045) | IMMUTABLE | Token issuance and consumption |
+| Permit issuance/consumption (ADR-0046) | IMMUTABLE | JIT grant created or expired |
+| Charter activations (ADR-0047) | IMMUTABLE | Charter bound to agent at init |
+| Operation context captures (ADR-0050) | IMMUTABLE | Active-assertion snapshots |
+
+### 4. The "audit of auditing" invariant
+
+The core tamper-resistance property is:
+
+> An agent that deletes a PROTECTED log cannot hide the act of deletion.
+
+This is enforced structurally: `delete_protected_log()` creates the IMMUTABLE evidence node
+*before* removing the entry. If the evidence emission raises (e.g., the backend is unavailable),
+the deletion is aborted. This is the fail-closed default (cross-cutting principle #1): an error in
+the audit trail blocks the operation that would create a gap in it.
+
+IMMUTABLE entries have no deletion path — not even with break-glass. There is no
+`delete_immutable_log()` method. Absence of API is the strongest enforcement: no administrative
+shortcut, no emergency override, no code path to misuse.
+
+### 5. Backend integration (KHive v1)
+
+At the application layer (lionagi), `DataLogger` enforces tier semantics in Python. In the KHive
+backend, the persistence layer adds complementary DB-level triggers following prior research:
+
+- A `BEFORE DELETE` trigger on the IMMUTABLE log table raises an exception unconditionally.
+- The `*_immutable.*` files written by `DataLogger.dump()` are opened in append-only mode by the
+  KHive ingestion worker.
+- PROTECTED log deletion events are written to the immutable table by the ingestion worker,
+  providing a second enforcement layer independent of application code.
+
+These backend constraints are KHive territory and are out of scope for this ADR. The application-
+layer enforcement described in sections 2–4 is fully self-contained for lionagi v1.
+
+## Consequences
+
+**Positive**
+
+- Tamper resistance at the application layer: a compromised agent or tool cannot erase gate
+  decisions, evidence nodes, or charter activations via normal `DataLogger` operations.
+- Audit-grade tier separation: operators can identify exactly which log entries constitute the
+  governance record without scanning all entries.
+- "Audit of auditing" closes the disable-logging attack vector: any PROTECTED log deletion
+  produces its own permanent record.
+- The three-tier model maps cleanly onto the existing `Log` + `DataLogger` design; no new
+  architectural surface is required.
+
+**Negative**
+
+- IMMUTABLE entries accumulate indefinitely in the Pile and in the `*_immutable.*` files.
+  Long-running sessions must tolerate unbounded growth in the immutable partition. Archival to
+  cold storage is a KHive concern; lionagi has no automatic eviction.
+- Every `Log.create()` call that should emit at PROTECTED or IMMUTABLE tier requires an explicit
+  `tier=` argument. Callers that omit it silently default to MUTABLE — a regression risk during
+  migration.
+- `delete_protected_log()` depends on `lionagi.protocols.governance.break_glass` (ADR-0045),
+  which is a sibling ADR not yet shipped. Until ADR-0045 is implemented, PROTECTED deletion raises
+  an `ImportError` at runtime.
+- Slight CPU cost: `__setattr__` on IMMUTABLE entries checks tier on every attribute write. In
+  practice this is negligible; it only fires during Pydantic model initialization.
+
+## Non-Goals
+
+Explicitly out of scope:
+
+- **Cryptographic signing of log entries.** Hash-chain integrity for evidence nodes is covered by
+  ADR-0041. Log-level signing is a separate concern.
+- **Log encryption at rest.** Encryption is a deployment and KHive backend concern, not a
+  per-entry feature of `DataLogger`.
+- **Distributed log replication.** Replication, WAL-based propagation, and multi-replica
+  consistency are KHive infrastructure concerns.
+- **Automatic tier classification.** Tier is always set explicitly at the call site. No heuristic,
+  ML-based, or pattern-matching classifier determines tier post-hoc.
+- **Multi-tenant log isolation.** Per-tenant log namespacing, row-level security, and tenant-scoped
+  deletion policies are KHive territory. lionagi is a single-tenant library.
+- **Retention schedules and archival.** ADR-0049 defines deletion semantics, not retention periods.
+  Archival policy (e.g., 7-year PROTECTED retention per SOC2 CC6.2) is a deployment concern.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|---|---|
+| Single mutable log (current state) | Any agent with DataLogger access can erase its own activity record. No tamper resistance. |
+| Append-only flag on DataLogger | Too coarse: prevents all deletion including legitimate MUTABLE rotation. Breaks long-running session memory management. |
+| Separate file per tier only | Files can still be deleted by OS-level access. Doesn't prevent `DataLogger.clear()` from discarding in-memory IMMUTABLE entries before flush. |
+| Application-flag immutability only (no API removal) | A `delete_immutable_log()` that raises on call is weaker than a method that does not exist. Callers can work around documented exceptions; they cannot call nonexistent methods. |
+| Three-tier with automatic classification | Classification at emission time is correct; post-hoc classification has a window where entries are unclassified. Human + decorator assignment eliminates ambiguity. |
+
+## References
+
+- [ADR-0041](ADR-0041-immutable-evidence-nodes.md) — IMMUTABLE tier is the application-layer
+  representation of evidence nodes; hash-chain integrity is defined there
+- [ADR-0042](ADR-0042-task-certificate.md) — Task certificate state changes are IMMUTABLE tier
+  events
+- [ADR-0044](ADR-0044-tool-gates.md) — Gate decisions (HARD/SOFT/ADVISORY) are IMMUTABLE tier
+  events
+- [ADR-0045](ADR-0045-break-glass-protocol.md) — Required dependency for PROTECTED log deletion;
+  provides `validate_break_glass_token()`
+- [ADR-0046](ADR-0046-jit-tool-grant.md) — Permit issuance and consumption are IMMUTABLE tier
+  events
+- [ADR-0047](ADR-0047-agent-charter.md) — Charter activations are IMMUTABLE tier events
+- [ADR-0050](ADR-0050-operation-context.md) — Operation context captures (active assertions) are
+  IMMUTABLE tier events
+- [ADR-0033](ADR-0033-unified-entity-state-model.md) — `EvidenceRef` kinds map to IMMUTABLE log
+  event categories
+- prior governance research `01_design/034-audit-logging-governance/ADR-034-audit-logging-governance.md` — source
+  pattern; three-tier hierarchy, DB trigger approach, audit-of-auditing invariant

--- a/docs/adrs/ADR-0049-log-tier-governance.md
+++ b/docs/adrs/ADR-0049-log-tier-governance.md
@@ -87,7 +87,7 @@ class LogTier(str, Enum):
                (ADR-0045), permit issuance/consumption (ADR-0046), charter
                activations (ADR-0047), operation context captures (ADR-0050).
                No deletion API exists. Write-once at the application layer;
-               DB-level triggers in KHive backend.
+               DB-level triggers enforced by the storage backend.
     """
 
     MUTABLE = "mutable"
@@ -198,7 +198,7 @@ class DataLogger:
     - There is no ``delete_immutable_log``. The method does not exist.
 
     ``dump()`` writes IMMUTABLE entries to a separate file (``*_immutable.*``)
-    that the KHive backend opens in append-only mode. MUTABLE and PROTECTED
+    that the storage backend opens in append-only mode. MUTABLE and PROTECTED
     entries go to the standard file.
     """
 
@@ -342,7 +342,7 @@ class DataLogger:
 
         MUTABLE and PROTECTED entries go to the standard path.
         IMMUTABLE entries go to ``<stem>_immutable<ext>`` in append mode.
-        The KHive backend opens that file append-only via DB triggers.
+        The storage backend opens that file append-only via DB triggers.
 
         IMMUTABLE entries are never cleared after dump.
         """
@@ -433,19 +433,19 @@ IMMUTABLE entries have no deletion path — not even with break-glass. There is 
 `delete_immutable_log()` method. Absence of API is the strongest enforcement: no administrative
 shortcut, no emergency override, no code path to misuse.
 
-### 5. Backend integration (KHive v1)
+### 5. Backend integration
 
-At the application layer (lionagi), `DataLogger` enforces tier semantics in Python. In the KHive
-backend, the persistence layer adds complementary DB-level triggers following prior research:
+At the application layer (lionagi), `DataLogger` enforces tier semantics in Python. A conforming
+storage backend adds complementary DB-level triggers:
 
 - A `BEFORE DELETE` trigger on the IMMUTABLE log table raises an exception unconditionally.
 - The `*_immutable.*` files written by `DataLogger.dump()` are opened in append-only mode by the
-  KHive ingestion worker.
+  storage ingestion worker.
 - PROTECTED log deletion events are written to the immutable table by the ingestion worker,
   providing a second enforcement layer independent of application code.
 
-These backend constraints are KHive territory and are out of scope for this ADR. The application-
-layer enforcement described in sections 2–4 is fully self-contained for lionagi v1.
+These backend constraints are storage-layer concerns and are out of scope for this ADR. The
+application-layer enforcement described in sections 2–4 is fully self-contained for lionagi v1.
 
 ## Consequences
 
@@ -464,7 +464,7 @@ layer enforcement described in sections 2–4 is fully self-contained for lionag
 
 - IMMUTABLE entries accumulate indefinitely in the Pile and in the `*_immutable.*` files.
   Long-running sessions must tolerate unbounded growth in the immutable partition. Archival to
-  cold storage is a KHive concern; lionagi has no automatic eviction.
+  cold storage is a deployment concern; lionagi has no automatic eviction.
 - Every `Log.create()` call that should emit at PROTECTED or IMMUTABLE tier requires an explicit
   `tier=` argument. Callers that omit it silently default to MUTABLE — a regression risk during
   migration.
@@ -480,14 +480,10 @@ Explicitly out of scope:
 
 - **Cryptographic signing of log entries.** Hash-chain integrity for evidence nodes is covered by
   ADR-0041. Log-level signing is a separate concern.
-- **Log encryption at rest.** Encryption is a deployment and KHive backend concern, not a
+- **Log encryption at rest.** Encryption is a deployment and storage-backend concern, not a
   per-entry feature of `DataLogger`.
-- **Distributed log replication.** Replication, WAL-based propagation, and multi-replica
-  consistency are KHive infrastructure concerns.
 - **Automatic tier classification.** Tier is always set explicitly at the call site. No heuristic,
   ML-based, or pattern-matching classifier determines tier post-hoc.
-- **Multi-tenant log isolation.** Per-tenant log namespacing, row-level security, and tenant-scoped
-  deletion policies are KHive territory. lionagi is a single-tenant library.
 - **Retention schedules and archival.** ADR-0049 defines deletion semantics, not retention periods.
   Archival policy (e.g., 7-year PROTECTED retention per SOC2 CC6.2) is a deployment concern.
 

--- a/docs/adrs/ADR-0049-log-tier-governance.md
+++ b/docs/adrs/ADR-0049-log-tier-governance.md
@@ -1,6 +1,6 @@
 # ADR-0049: Log Tier Governance
 
-**Status**: Proposed
+**Status**: proposed
 **Date**: 2026-05-26
 **Depends on**: [ADR-0041](ADR-0041-immutable-evidence-nodes.md), [ADR-0045](ADR-0045-break-glass-protocol.md)
 **Related**: [ADR-0042](ADR-0042-task-certificate.md), [ADR-0044](ADR-0044-tool-gates.md), [ADR-0046](ADR-0046-jit-tool-grant.md), [ADR-0047](ADR-0047-agent-charter.md), [ADR-0050](ADR-0050-operation-context.md)

--- a/docs/adrs/ADR-0050-operation-context.md
+++ b/docs/adrs/ADR-0050-operation-context.md
@@ -1,0 +1,724 @@
+# ADR-0050: Operation Context — Active Assertion in Evidence
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Depends on**: [ADR-0041](ADR-0041-immutable-evidence-nodes.md), [ADR-0043](ADR-0043-governed-tool-declaration.md), [ADR-0044](ADR-0044-tool-gates.md), [ADR-0047](ADR-0047-agent-charter.md)
+**Related**: [ADR-0042](ADR-0042-task-certificate.md), [ADR-0045](ADR-0045-break-glass-protocol.md), [ADR-0046](ADR-0046-jit-tool-grant.md), [ADR-0049](ADR-0049-log-tier-governance.md), [ADR-0051](ADR-0051-tool-registry-allowlists.md), [ADR-0052](ADR-0052-policy-resolution.md), [ADR-0033](ADR-0033-unified-entity-state-model.md), [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md)
+
+---
+
+## Context
+
+lionagi's `Branch` today holds session-level state across its four managers: `MessageManager`
+(message history), `ActionManager` (registered tools), `iModelManager` (provider references),
+and `DataLogger` (log entries). When `branch.operate()` dispatches a tool call, the tool
+receives its arguments and returns a result. The `DataLogger` may record a `Log` entry. Nothing
+else is captured about the operation as a unit.
+
+The structural gap is that two evidence nodes emitted by different operations — or even by the
+same operation running twice — are indistinguishable from each other without external context.
+There is no record of which policy version was active, which gates passed or failed, which agent
+charter was in force, or what caused this operation to run. An audit question such as "what
+constraints were active when the agent wrote to this file at 14:32?" cannot be answered by
+inspecting the evidence node itself. The evidence node is a fact about what happened; without
+operation context it is not self-describing proof of how it was authorized to happen.
+
+This violates cross-cutting principle #2: **evidence is first-class, not logs**. A log entry
+records what happened operationally. Evidence carries the policy version, gate results, and
+authorization context active *at execution time* — this is what makes evidence admissible as
+proof. Without operation context embedded in every evidence node, the evidence carries no more
+authority than an application log.
+
+There is also a correctness hazard specific to async code. lionagi uses asyncio throughout. If
+operation-level state (gate results, causation chain, consumed permit tokens) were accumulated
+in a shared mutable session-level structure, concurrent coroutines within the same session would
+see each other's partially-accumulated state. The result would be either incorrect evidence
+(gate results from operation A appear in evidence for operation B) or a race condition requiring
+explicit locking.
+
+### The applicable prior governance research insight
+
+prior research establishes a two-tier context system: a `ServiceContext` initialized once at
+service startup holding long-lived references (charter, gate registry, policy version, tenant
+binding), and a `RequestContext` created per-request and propagated explicitly through every
+governed function as a named parameter. The key design insight is the "active assertion" pattern:
+the `RequestContext.to_evidence_data()` method serializes the *full policy state in force at
+execution time* into every evidence payload. Evidence becomes self-describing: an auditor
+inspecting a node years later can determine exactly what policy version governed the execution,
+which gates ran and what they returned, and which actor initiated the call — without needing to
+consult current system state. The context IS the proof.
+
+Translated to lionagi: `ServiceContext` is initialized at `Branch` creation time; it holds
+the gate registry, charter, resolved policy bundle, and knowledge store references. An
+`OperationContext` is created fresh for each `branch.operate()` call or governed tool execution.
+It is immutable. Gate results, permit tokens, and evidence node IDs are accumulated via
+transform methods that return new instances. Every evidence node emitted during the operation
+(per ADR-0041) receives a snapshot of the `OperationContext` at the moment of emission.
+
+### Why lionagi needs this
+
+Consider a KHive agent that calls `branch.operate()` three times in quick succession: one call
+reads configuration, one writes a checkpoint, one invokes a sub-agent. All three run
+concurrently on the asyncio event loop. The write operation passes a `guard_paths` HARD gate
+and a `confirm_path_outside_workspace` SOFT gate with a provided justification. The read
+operation passes `guard_paths` but has no SOFT gate. Without `OperationContext`, the evidence
+node for the write has no record of the SOFT gate result or the justification that authorized
+it. If the justification is later disputed, the evidence is silent. With `OperationContext`, the
+write's evidence node contains `gate_results: (GateResult(id="confirm_path...", passed=True,
+justification="checkpoint required before migration"),)` and `policy_version_active:
+"2026-05-1.3"` at the moment of emission — independently of what the other two concurrent
+operations did or what the policy version is today.
+
+---
+
+## Decision
+
+Introduce a two-tier context system: `ServiceContext` (per-session, initialized at `Branch`
+creation) and `OperationContext` (per-operation, immutable, transforms create new instances).
+Both are propagated explicitly as function arguments. Neither uses thread-locals or global state.
+Every evidence node emitted during a governed operation embeds the `OperationContext` active at
+the moment of emission as its active assertion.
+
+---
+
+### 1. `ServiceContext` — Per-Session Long-Lived References
+
+`ServiceContext` is created once when a `Branch` is initialized in governed mode. It holds
+references that do not change over the session lifetime: the gate registry (ADR-0044), the agent
+charter and its version (ADR-0047), the resolved policy bundle version (ADR-0052), and the
+knowledge store (ADR-0039).
+
+```python
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+from pydantic import ConfigDict, Field
+
+from lionagi.protocols.action.manager import ActionManager
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.log import DataLogger
+from lionagi.protocols.messages.manager import MessageManager
+from lionagi.service.manager import iModelManager
+
+if TYPE_CHECKING:
+    from lionagi.session.branch import Branch
+    from lionagi.protocols.governance.gates import GateRegistry
+    from lionagi.protocols.governance.charter import AgentCharter
+    from lionagi.protocols.knowledge.store import KnowledgeStore
+
+
+class ServiceContext(Element):
+    """Initialized once at Branch creation in governed mode.
+
+    Holds long-lived references (gate registry, charter, policy version,
+    knowledge store) plus references to the existing Branch managers. Every
+    OperationContext created during the session carries this object so
+    per-operation creation does not create parallel context stores.
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+    )
+
+    branch_id: str
+    session_id: str
+    agent_id: str
+    gate_registry: "GateRegistry" = Field(exclude=True)
+    charter: "AgentCharter" = Field(exclude=True)
+    policy_release_version: str
+    knowledge_store: "KnowledgeStore" = Field(exclude=True)
+    message_manager: MessageManager = Field(exclude=True)
+    action_manager: ActionManager = Field(exclude=True)
+    imodel_manager: iModelManager = Field(exclude=True)
+    data_logger: DataLogger = Field(exclude=True)
+    started_at: float = Field(default_factory=time.time)
+
+    @classmethod
+    def from_branch(
+        cls,
+        branch: "Branch",
+        *,
+        gate_registry: "GateRegistry",
+        charter: "AgentCharter",
+        policy_release_version: str,
+        knowledge_store: "KnowledgeStore",
+        session_id: str | None = None,
+        agent_id: str | None = None,
+    ) -> "ServiceContext":
+        """Bind governance context to Branch's existing manager surfaces."""
+        return cls(
+            branch_id=str(branch.id),
+            session_id=session_id or str(branch.id),
+            agent_id=agent_id or str(branch.user or branch.id),
+            gate_registry=gate_registry,
+            charter=charter,
+            policy_release_version=policy_release_version,
+            knowledge_store=knowledge_store,
+            message_manager=branch.msgs,
+            action_manager=branch.acts,
+            imodel_manager=branch.mdls,
+            data_logger=branch._log_manager,
+        )
+```
+
+`ServiceContext` is frozen: no field can be changed after initialization. A new session always
+produces a new `ServiceContext`. There is no path to mutate the gate registry or charter
+mid-session; changes require starting a new session.
+
+---
+
+### 2. `GateResult` — Atomic Gate Outcome
+
+`GateResult` is the unit stored in `OperationContext.gate_results`. It is a frozen record of one
+gate's evaluation outcome, captured at evaluation time and never modified.
+
+```python
+from __future__ import annotations
+
+import time
+from typing import Literal
+
+from pydantic import ConfigDict, Field
+
+from lionagi.protocols.generic.element import Element
+
+
+class GateResult(Element):
+    """Immutable record of a single gate evaluation (ADR-0044).
+
+    Accumulated into ``OperationContext.gate_results`` via
+    ``with_gate_result()``; serialized into every evidence node.
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+    )
+
+    gate_id: str
+    gate_tier: Literal["HARD", "SOFT", "ADVISORY"]
+    passed: bool
+    reason: str
+    justification: str | None = None
+    evaluated_at: float = Field(default_factory=time.time)
+```
+
+---
+
+### 3. `OperationContext` — Per-Operation Immutable Active Assertion
+
+`OperationContext` is created fresh at the start of each governed operation. Its fields are
+immutable. Gate results, permit tokens, and evidence node IDs are accumulated via transform
+methods that return new instances; the original is never modified.
+
+```python
+from __future__ import annotations
+
+import time
+from typing import Any, Literal
+
+from pydantic import ConfigDict, Field
+
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+
+
+class PermitTokenUse(Element):
+    """JIT permit token consumed during this operation (ADR-0046)."""
+
+    model_config = ConfigDict(
+        frozen=True,
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+    )
+
+    token_id: str
+    consumed_at: float = Field(default_factory=time.time)
+
+
+class EvidenceEmission(Element):
+    """Evidence node emitted during this operation (ADR-0041)."""
+
+    model_config = ConfigDict(
+        frozen=True,
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+    )
+
+    evidence_id: str
+    emitted_at: float = Field(default_factory=time.time)
+
+
+class OperationContext(Element):
+    """Per-operation context. Immutable. Active assertion of state at execution time.
+
+    Created once per governed operation.  Gate results, permit tokens, and
+    evidence IDs are accumulated via transform methods (``with_*``) that
+    return new instances — the original is never mutated.  The final snapshot
+    is serialized into every evidence node via ``to_evidence_data()``.
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+    )
+
+    # Identity
+    service_context: ServiceContext = Field(exclude=True)
+    actor_id: str
+    parent_operation_id: str | None = None  # causation chain; None = top-level
+    initiated_at: float = Field(default_factory=time.time)
+    actor_type: Literal["agent", "user", "system"] = "agent"
+
+    # Accumulated during operation (Pile copies grown via transforms):
+    gate_results: Pile[GateResult] = Field(
+        default_factory=lambda: Pile(item_type=GateResult, strict_type=True)
+    )
+    permit_tokens_consumed: Pile[PermitTokenUse] = Field(
+        default_factory=lambda: Pile(item_type=PermitTokenUse, strict_type=True)
+    )
+    evidence_emitted: Pile[EvidenceEmission] = Field(
+        default_factory=lambda: Pile(item_type=EvidenceEmission, strict_type=True)
+    )
+
+    # Active assertion — captured at creation, not updated later:
+    policy_version_active: str = ""
+    charter_version_active: int | str = 0
+
+    operation_name: str = ""               # optional audit label
+
+    @property
+    def operation_id(self) -> str:
+        """Element id is the operation id used in evidence and causation."""
+        return str(self.id)
+
+    # ------------------------------------------------------------------
+    # Immutable transforms
+    # ------------------------------------------------------------------
+
+    def with_gate_result(self, result: GateResult) -> "OperationContext":
+        """Return a new context with ``result`` appended to ``gate_results``."""
+        return self.model_copy(
+            update={
+                "gate_results": Pile(
+                    collections=[*self.gate_results, result],
+                    item_type=GateResult,
+                    strict_type=True,
+                )
+            }
+        )
+
+    def with_causation(self, parent_id: str) -> "OperationContext":
+        """Return a new context with ``parent_operation_id`` set."""
+        return self.model_copy(update={"parent_operation_id": parent_id})
+
+    def with_evidence(self, evidence_id: str) -> "OperationContext":
+        """Return a new context with ``evidence_id`` appended to ``evidence_emitted``."""
+        emission = EvidenceEmission(evidence_id=evidence_id)
+        return self.model_copy(
+            update={
+                "evidence_emitted": Pile(
+                    collections=[*self.evidence_emitted, emission],
+                    item_type=EvidenceEmission,
+                    strict_type=True,
+                )
+            }
+        )
+
+    def with_permit_token(self, token_id: str) -> "OperationContext":
+        """Return a new context with ``token_id`` appended to ``permit_tokens_consumed``."""
+        token_use = PermitTokenUse(token_id=token_id)
+        return self.model_copy(
+            update={
+                "permit_tokens_consumed": Pile(
+                    collections=[*self.permit_tokens_consumed, token_use],
+                    item_type=PermitTokenUse,
+                    strict_type=True,
+                )
+            }
+        )
+
+    # ------------------------------------------------------------------
+    # Active assertion serialization
+    # ------------------------------------------------------------------
+
+    def to_evidence_data(self) -> dict[str, Any]:
+        """Serialize the context as an active assertion payload.
+
+        Embedded verbatim into every evidence node emitted during this
+        operation.  An auditor reading the evidence node in isolation
+        can determine the full authorization context — policy version,
+        gate outcomes, actor, causation chain — without querying the
+        live system.  Returns a JSON-safe dict.
+        """
+        return {
+            "operation_id": self.operation_id,
+            "parent_operation_id": self.parent_operation_id,
+            "branch_id": self.service_context.branch_id,
+            "session_id": self.service_context.session_id,
+            "agent_id": self.service_context.agent_id,
+            "actor_id": self.actor_id,
+            "actor_type": self.actor_type,
+            "initiated_at": self.initiated_at,
+            "policy_version_active": self.policy_version_active,
+            "charter_version_active": self.charter_version_active,
+            "operation_name": self.operation_name,
+            "message_ids": [
+                str(message_id)
+                for message_id in self.service_context.message_manager.progression
+            ],
+            "registered_tools": sorted(self.service_context.action_manager.registry),
+            "chat_model": getattr(self.service_context.imodel_manager.chat, "model", None),
+            "parse_model": getattr(self.service_context.imodel_manager.parse, "model", None),
+            "gate_results": [gr.to_dict(mode="json") for gr in self.gate_results],
+            "permit_tokens_consumed": [
+                token.to_dict(mode="json") for token in self.permit_tokens_consumed
+            ],
+            "evidence_emitted": [
+                evidence.to_dict(mode="json") for evidence in self.evidence_emitted
+            ],
+        }
+```
+
+---
+
+### 4. `OperationContext` Factory
+
+Context creation is centralized in a single factory function to ensure consistent population of
+`policy_version_active` and `charter_version_active` from the `ServiceContext` at creation time.
+
+```python
+from lionagi.session.branch import Branch
+
+
+class MissingServiceContextError(RuntimeError):
+    """Raised when governed operation context is requested on an ungoverned Branch."""
+
+
+def create_operation_context(
+    branch: Branch,
+    *,
+    actor_id: str | None = None,
+    actor_type: str = "agent",
+    parent_operation_id: str | None = None,
+    operation_name: str = "",
+) -> OperationContext:
+    """Create a fresh OperationContext for a new governed operation.
+
+    Captures ``policy_version_active`` and ``charter_version_active``
+    from Branch's attached ``ServiceContext`` at this instant. Evidence
+    from this operation will always carry the version that was active at
+    start, regardless of later session hot-reloads.
+    """
+    service_context = branch.metadata.get("governance_service_context")
+    if not isinstance(service_context, ServiceContext):
+        raise MissingServiceContextError(
+            "Governed operation requires ServiceContext on Branch.metadata"
+        )
+
+    ctx = OperationContext(
+        service_context=service_context,
+        parent_operation_id=parent_operation_id,
+        actor_id=actor_id or str(branch.user or branch.id),
+        actor_type=actor_type,
+        operation_name=operation_name,
+        policy_version_active=service_context.policy_release_version,
+        charter_version_active=getattr(service_context.charter, "version", 0),
+    )
+    branch._log_manager.log(
+        {"event": "operation_context_created", "context": ctx.to_evidence_data()}
+    )
+    return ctx
+```
+
+---
+
+### 5. Explicit Propagation — Not Thread-Local, Not Global
+
+Context is passed as a named argument to every governed function. There is no global registry,
+no thread-local, and no `contextvars.ContextVar` for the `OperationContext` itself.
+
+```python
+# CORRECT: explicit parameter, async-safe
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from lionagi.agent.config import AgentConfig
+from lionagi.agent.hooks import guard_destructive, guard_paths
+from lionagi.session.branch import Branch
+
+PreHook = Callable[
+    [str, str, dict[str, Any]],
+    Awaitable[dict[str, Any] | None],
+]
+
+
+async def _run_gate(
+    branch: Branch,
+    hook: PreHook,
+    tool_name: str,
+    action: str,
+    kwargs: dict[str, Any],
+    ctx: OperationContext,
+) -> tuple[GateResult, OperationContext, dict[str, Any]]:
+    """Evaluate an existing lionagi pre-hook and return result, ctx, args."""
+    hook_args = {**kwargs, "operation_context": ctx.to_evidence_data()}
+    try:
+        updated_args = await hook(tool_name, action, hook_args)
+    except Exception as exc:
+        gate_result = GateResult(
+            gate_id=getattr(hook, "__name__", hook.__class__.__name__),
+            gate_tier="HARD",
+            passed=False,
+            reason=str(exc),
+            evaluated_at=time.time(),
+        )
+        ctx = ctx.with_gate_result(gate_result)
+        branch._log_manager.log(gate_result)
+        raise
+
+    gate_result = GateResult(
+        gate_id=getattr(hook, "__name__", hook.__class__.__name__),
+        gate_tier="HARD",
+        passed=True,
+        reason="hook passed",
+        evaluated_at=time.time(),
+    )
+    ctx = ctx.with_gate_result(gate_result)
+    branch._log_manager.log(gate_result)
+    return gate_result, ctx, updated_args if updated_args is not None else hook_args
+
+
+# Built-in hooks from lionagi.agent.hooks are registered through AgentConfig
+# and wired into Tool.preprocessor by create_agent()/CodingToolkit.
+config = AgentConfig.coding()
+config.pre("bash", guard_destructive)
+config.pre("editor", guard_paths(allowed_paths=["/workspace"]))
+
+
+# WRONG: global or thread-local lookup
+async def _run_gate_wrong(gate_id: str, tool_name: str, kwargs: dict) -> GateResult:
+    ctx = _get_current_context()   # Anti-pattern: breaks under concurrent coroutines
+    ...
+```
+
+The rationale: asyncio does not guarantee that a `ContextVar` set in coroutine A is invisible
+to coroutine B if B was created with `asyncio.create_task()` before A set the variable. Two
+concurrent `branch.operate()` calls would each create their own asyncio task; `ContextVar`
+inheritance means a child task sees the parent's context at the moment of creation, not live
+updates. This makes `ContextVar` safe for the bypass-prevention flag (ADR-0043, which is
+set-once before calling the handler), but unsafe for the accumulating `OperationContext` where
+each gate evaluation produces a new instance. Explicit propagation has one disadvantage —
+function signatures grow a `ctx: OperationContext` parameter — and one decisive advantage:
+correctness under all concurrency patterns without special reasoning.
+
+---
+
+### 6. Pipeline Integration — How `OperationContext` Flows Through ADR-0043
+
+The eight-phase enforcement pipeline in `ActionManager.execute_governed()` (ADR-0043) creates,
+accumulates, and finalizes the `OperationContext`:
+
+| Phase | Pipeline action | OperationContext interaction |
+|-------|-----------------|------------------------------|
+| Phase 1 | Normalize inputs via `options_schema` | `ctx` not yet created |
+| **Phase 2** | **Validate context exists** | `ctx = create_operation_context(service_ctx, actor_id=...)` — creation |
+| Phase 3 | Resolve applicable gates from registry | `ctx` passed to `_resolve_gates(meta, fn_name, ctx)` |
+| Phase 4 | Execute HARD gates | Each gate: `gate_result, ctx = await _run_gate(gate_id, ..., ctx)` |
+| Phase 5 | Execute SOFT gates | Same pattern; on bypass: `ctx = ctx.with_permit_token(token_id)` if JIT |
+| Phase 6 | Execute ADVISORY gates | Same pattern |
+| Phase 7 | Execute handler inside pipeline context | `ctx` snapshot passed to handler via `_enter_pipeline(op_ctx_id=ctx.operation_id)` |
+| **Phase 8** | **Emit evidence node** | `evidence_id = await _emit_success_evidence(..., ctx=ctx)`; then `ctx = ctx.with_evidence(evidence_id)` |
+
+After Phase 8, `ctx` is the final snapshot: it contains all gate results from Phases 4–6, all
+permit tokens consumed in Phase 5, and the evidence node ID from Phase 8. The Phase 8 evidence
+node embeds `ctx.to_evidence_data()` as its active assertion payload.
+
+On a HARD gate failure in Phase 4, the pipeline emits a failure evidence node carrying the
+partial `ctx` (with gate results up to the failure point), then raises `GateBlockedError`.
+The partial context is not discarded — the failure evidence is as important as the success
+evidence for the audit trail.
+
+---
+
+### 7. Evidence Embedding — The Active Assertion
+
+Every `ImmutableEvidenceNode` (ADR-0041) emitted during a governed operation includes the
+serialized `OperationContext` as a top-level field in its domain data. This is the active
+assertion: the evidence node is self-describing proof of what was in force when it was sealed.
+
+```python
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from pydantic import ConfigDict, Field
+
+from lionagi.protocols.governance.evidence import ImmutableEvidenceNode
+
+
+class ToolExecutionEvidence(ImmutableEvidenceNode):
+    """Evidence node for a governed tool execution.
+
+    ``operation_context_data`` carries ``ctx.to_evidence_data()`` and IS
+    included in the content hash — the policy state that authorized the
+    execution is part of the evidence.  ``raw_inputs`` is excluded via
+    ``_sensitive_fields``: tool arguments may contain secrets.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+    )
+
+    tool_name: str = ""
+    evidence_type: str = ""
+    outcome: str = ""          # "success" | "gate_blocked" | "execution_error"
+    justification: str | None = None
+
+    # The active assertion: full context serialized at emission time
+    operation_context_data: dict[str, Any] = Field(default_factory=dict)
+
+    # Excluded from hashes and audit exports:
+    raw_inputs: dict[str, Any] | None = Field(default=None, exclude=True)
+
+    _sensitive_fields: ClassVar[set[str]] = {"raw_inputs"}
+```
+
+An auditor reading this node in isolation — without access to the live system — sees the
+complete authorization context: policy version, all gate outcomes, actor identity, and
+causation chain. The evidence is self-describing by construction.
+
+---
+
+### 8. Causation Chain
+
+When a governed operation triggers a child operation (for example, a tool call that internally
+invokes another governed tool via a sub-branch, or a `FlowOp` node calling a downstream tool),
+the child's `OperationContext` is created with `parent_operation_id` pointing to the parent's
+`operation_id`. This forms a tree:
+
+```text
+branch.operate() → OperationContext(id="op-A", parent=None)
+  └─ write_file tool → OperationContext(id="op-B", parent="op-A")
+       └─ validate_path tool → OperationContext(id="op-C", parent="op-B")
+```
+
+Every evidence node in the tree carries its own `operation_id` and `parent_operation_id`.
+An audit query reconstructs the full causation tree by following `parent_operation_id` links
+from any leaf to the root — no separate tracing infrastructure required. The field is frozen
+at creation; there is no mechanism to set `parent_operation_id` after the fact.
+
+---
+
+## Consequences
+
+**Positive**
+
+- **Every evidence node is independently interpretable**: the active assertion payload makes
+  each node self-describing. An auditor does not need to query the live system to understand
+  what policy was in force when a given tool call ran. This directly satisfies cross-cutting
+  principle #2.
+- **Async-safe accumulation**: immutable transforms mean concurrent coroutines accumulate their
+  gate results in separate object chains. No locks required; no cross-contamination between
+  concurrent operations.
+- **Causation tree from evidence alone**: `parent_operation_id` links stored in evidence nodes
+  allow full causation reconstruction without a separate tracing infrastructure.
+- **Policy version captured at creation**: `policy_version_active` and `charter_version_active`
+  are snapshotted at `create_operation_context()` time. A hot-reload or charter revision
+  mid-session does not retroactively alter evidence from operations that started before it.
+- **Fail-closed for missing context**: `ActionManager.execute_governed()` Phase 2 raises
+  `MissingOperationContextError` if `ctx` is absent and the tool is not `skip_evidence=True`.
+  The pipeline cannot silently proceed without a context; ambiguity closes the gate.
+- **Testability**: test code creates a `ServiceContext` with mock gate registry and charter,
+  then constructs `OperationContext` instances directly. No global state to set up or tear down.
+
+**Negative**
+
+- **Function signature pollution**: every governed function in the pipeline gains a
+  `ctx: OperationContext` parameter. For simple library-mode callers not using governed tools,
+  this parameter never appears. For governed-mode code, it is present at every gate evaluation
+  site. The verbosity is intentional; it makes dependencies explicit.
+- **Shallow copy per transform**: each `with_gate_result()`, `with_evidence()`, or
+  `with_permit_token()` call produces a new frozen `Element` model. For an operation with ten gates,
+  this is ten allocations of the `OperationContext` Pydantic model. The overhead is measurable in
+  micro-benchmarks but irrelevant at the scale of gate evaluation (each gate is an async call).
+- **`ServiceContext` must be initialized**: ungoverned library-mode branches do not create a
+  `ServiceContext`. Adding governance to an existing branch requires providing a gate registry
+  and charter, which are new dependencies. Migration is explicit, not zero-config.
+
+---
+
+## Non-Goals
+
+Explicitly out of scope:
+
+- **Implicit context via thread-locals or `contextvars`**: deliberately rejected (see §5). The
+  accumulating `OperationContext` is unsafe for implicit propagation under asyncio concurrency.
+  `contextvars` is used only for the bypass-prevention flag (ADR-0043), which is set-once, not
+  accumulated.
+- **Context for ungoverned tools**: tools not decorated with `@governed_tool` (ADR-0043) and
+  invoked via `execute_raw()` do not receive an `OperationContext`. Library-mode callers
+  using plain registered callables are unaffected.
+- **Cross-process context propagation**: distributing `OperationContext` across process
+  boundaries (e.g., serializing `operation_id` into an HTTP header for a remote tool call and
+  reconstructing the causation chain at the receiver) is a KHive concern. Within a single
+  lionagi session, context propagation is entirely in-process.
+- **Multi-tenant context isolation**: ensuring that `ServiceContext` and `OperationContext`
+  instances from different tenants cannot be interchanged requires storage-layer row security
+  and tenant-scoped session initialization. This is KHive v1 territory.
+- **Real-time context streaming**: broadcasting the accumulated `OperationContext` to an
+  external observer as gates are evaluated (for live dashboards) is out of scope. The final
+  snapshot is embedded in evidence; intermediate states are not surfaced.
+- **Context outside the governed pipeline**: operations that run outside `execute_governed()`
+  (break-glass paths in ADR-0045, ungoverned tools, direct `Branch` state manipulation) do not
+  produce an `OperationContext`. Break-glass paths produce their own evidence records defined
+  in ADR-0045.
+
+---
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|---|---|
+| **Thread-local storage** (`threading.local()`) | Incompatible with asyncio: asyncio runs coroutines on a single thread, so a thread-local shared by all concurrent coroutines would conflate their gate results. Rejected unconditionally for async code. |
+| **`contextvars.ContextVar` for the accumulating context** | `ContextVar` is inherited by child tasks at creation time; subsequent updates are not visible to siblings. If coroutine A creates a child task and then appends a gate result via a `ContextVar`, the child does not see the update. Accumulating mutable state via `ContextVar` requires a `ContextVar[list]` with `.get()` and `.append()` — which reintroduces the race condition. `ContextVar` is suitable for set-once flags (ADR-0043's pipeline guard), not for accumulation. |
+| **Global registry keyed by `operation_id`** | A `dict[str, OperationContext]` singleton avoids parameter passing. It introduces a global write point that requires locking under concurrent operations, a cleanup protocol (when does an entry expire?), and an implicit dependency invisible in function signatures. Rejected per explicit-propagation principle from prior research. |
+| **Mutable `OperationContext` with per-field locks** | Locking individual fields (`gate_results_lock: asyncio.Lock`) would allow concurrent accumulation without a global mutex. It adds complexity disproportionate to the problem: the immutable-transform approach achieves the same result with simpler reasoning and no lock hierarchy. Rejected per prior research. |
+| **No `OperationContext`; embed policy version in each `EvidenceRef` directly** | `EvidenceRef` (ADR-0033) could carry individual `policy_version` and `actor_id` fields. This duplicates the same data into every node without establishing the link between nodes that belong to the same operation. The causation chain, the gate accumulation, and the permit token record all require a shared anchor — which IS the `OperationContext`. Individual fields are insufficient. |
+| **Collapse to single-tier (no `ServiceContext`)** | A flat `OperationContext` carrying both session-level and operation-level fields is simpler. It forces re-resolving the gate registry, charter, and knowledge store on every operation, which is expensive. It also conflates what is stable (policy version, charter) with what accumulates (gate results, evidence IDs), making the schema harder to read. Two tiers match the two lifetimes; the separation is structural, not cosmetic. |
+
+---
+
+## References
+
+- [ADR-0041](ADR-0041-immutable-evidence-nodes.md) — `ImmutableEvidenceNode` and `EvidenceChain`; every evidence node emitted during a governed operation is sealed with `ctx.to_evidence_data()` as its active assertion payload
+- [ADR-0043](ADR-0043-governed-tool-declaration.md) — `ActionManager.execute_governed()` pipeline; Phase 2 creates the `OperationContext`, Phases 4–6 accumulate gate results, Phase 8 embeds the final context snapshot into the evidence node
+- [ADR-0044](ADR-0044-tool-gates.md) — Gate registry and `GateResult` semantics; gates evaluated in Phases 4–6 produce the `GateResult` records accumulated in `OperationContext.gate_results`
+- [ADR-0047](ADR-0047-agent-charter.md) — Agent Charter; `charter.version` is captured as `charter_version_active` at `OperationContext` creation time
+- [ADR-0052](ADR-0052-policy-resolution.md) — Policy resolution bundle; `policy_release_version` is captured as `policy_version_active` at `OperationContext` creation time
+- [ADR-0042](ADR-0042-task-certificate.md) — Task Certificate signs over evidence nodes; the active assertion in each node makes the certificate independently verifiable
+- [ADR-0046](ADR-0046-jit-tool-grant.md) — JIT permit tokens consumed during SOFT gate bypass are appended to `OperationContext.permit_tokens_consumed` via `with_permit_token()`
+- [ADR-0045](ADR-0045-break-glass-protocol.md) — Break-glass paths run outside `execute_governed()`; they produce their own evidence records, not `OperationContext`-linked ones
+- [ADR-0033](ADR-0033-unified-entity-state-model.md) — `EvidenceRef` kinds (`tool_result`, `model_inference`, etc.) used by `ToolExecutionEvidence`
+- [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) — `KnowledgeStore` protocol held in `ServiceContext.knowledge_store`
+- prior governance research `01_design/013-service-context/ADR-013-service-context.md` — source pattern: two-tier context, active assertion via `to_evidence_data()`, explicit propagation, immutable transforms

--- a/docs/adrs/ADR-0050-operation-context.md
+++ b/docs/adrs/ADR-0050-operation-context.md
@@ -57,7 +57,7 @@ transform methods that return new instances. Every evidence node emitted during 
 
 ### Why lionagi needs this
 
-Consider a KHive agent that calls `branch.operate()` three times in quick succession: one call
+Consider a governed agent that calls `branch.operate()` three times in quick succession: one call
 reads configuration, one writes a checkpoint, one invokes a sub-agent. All three run
 concurrently on the asyncio event loop. The write operation passes a `guard_paths` HARD gate
 and a `confirm_path_outside_workspace` SOFT gate with a provided justification. The read
@@ -655,11 +655,8 @@ Explicitly out of scope:
   using plain registered callables are unaffected.
 - **Cross-process context propagation**: distributing `OperationContext` across process
   boundaries (e.g., serializing `operation_id` into an HTTP header for a remote tool call and
-  reconstructing the causation chain at the receiver) is a KHive concern. Within a single
+  reconstructing the causation chain at the receiver) is not addressed here. Within a single
   lionagi session, context propagation is entirely in-process.
-- **Multi-tenant context isolation**: ensuring that `ServiceContext` and `OperationContext`
-  instances from different tenants cannot be interchanged requires storage-layer row security
-  and tenant-scoped session initialization. This is KHive v1 territory.
 - **Real-time context streaming**: broadcasting the accumulated `OperationContext` to an
   external observer as gates are evaluated (for live dashboards) is out of scope. The final
   snapshot is embedded in evidence; intermediate states are not surfaced.

--- a/docs/adrs/ADR-0050-operation-context.md
+++ b/docs/adrs/ADR-0050-operation-context.md
@@ -1,6 +1,6 @@
 # ADR-0050: Operation Context — Active Assertion in Evidence
 
-**Status**: Proposed
+**Status**: proposed
 **Date**: 2026-05-26
 **Depends on**: [ADR-0041](ADR-0041-immutable-evidence-nodes.md), [ADR-0043](ADR-0043-governed-tool-declaration.md), [ADR-0044](ADR-0044-tool-gates.md), [ADR-0047](ADR-0047-agent-charter.md)
 **Related**: [ADR-0042](ADR-0042-task-certificate.md), [ADR-0045](ADR-0045-break-glass-protocol.md), [ADR-0046](ADR-0046-jit-tool-grant.md), [ADR-0049](ADR-0049-log-tier-governance.md), [ADR-0051](ADR-0051-tool-registry-allowlists.md), [ADR-0052](ADR-0052-policy-resolution.md), [ADR-0033](ADR-0033-unified-entity-state-model.md), [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md)
@@ -175,42 +175,16 @@ mid-session; changes require starting a new session.
 
 ### 2. `GateResult` — Atomic Gate Outcome
 
-`GateResult` is the unit stored in `OperationContext.gate_results`. It is a frozen record of one
-gate's evaluation outcome, captured at evaluation time and never modified.
+Gate evaluation results use `GateResult` as defined in
+[ADR-0044](ADR-0044-tool-gates.md). `OperationContext` records gate results
+via `with_gate_result()` and serializes them into every evidence node via
+`to_evidence_data()`, but does not redefine the type.
 
-```python
-from __future__ import annotations
-
-import time
-from typing import Literal
-
-from pydantic import ConfigDict, Field
-
-from lionagi.protocols.generic.element import Element
-
-
-class GateResult(Element):
-    """Immutable record of a single gate evaluation (ADR-0044).
-
-    Accumulated into ``OperationContext.gate_results`` via
-    ``with_gate_result()``; serialized into every evidence node.
-    """
-
-    model_config = ConfigDict(
-        frozen=True,
-        arbitrary_types_allowed=True,
-        use_enum_values=True,
-        populate_by_name=True,
-        extra="forbid",
-    )
-
-    gate_id: str
-    gate_tier: Literal["HARD", "SOFT", "ADVISORY"]
-    passed: bool
-    reason: str
-    justification: str | None = None
-    evaluated_at: float = Field(default_factory=time.time)
-```
+The canonical fields (`gate_id`, `enforcement`, `passed`, `reason`,
+`justification`, `justification_actor_id`, `evaluated_at`, `evidence_refs`)
+are owned by ADR-0044. The `GateResultProjection` in the cross-reference
+document refers to ADR-0050's read-only use of that type — it is a reference,
+not a duplicate schema.
 
 ---
 

--- a/docs/adrs/ADR-0051-tool-registry-allowlists.md
+++ b/docs/adrs/ADR-0051-tool-registry-allowlists.md
@@ -1,6 +1,6 @@
 # ADR-0051: Tool Registry Allowlists
 
-**Status**: Proposed
+**Status**: proposed
 **Date**: 2026-05-26
 **Depends on**: [ADR-0041](ADR-0041-immutable-evidence-nodes.md), [ADR-0043](ADR-0043-governed-tool-declaration.md), [ADR-0044](ADR-0044-tool-gates.md), [ADR-0047](ADR-0047-agent-charter.md)
 **Related**: [ADR-0046](ADR-0046-jit-tool-grant.md), [ADR-0049](ADR-0049-log-tier-governance.md), [ADR-0050](ADR-0050-operation-context.md), [ADR-0033](ADR-0033-unified-entity-state-model.md)

--- a/docs/adrs/ADR-0051-tool-registry-allowlists.md
+++ b/docs/adrs/ADR-0051-tool-registry-allowlists.md
@@ -1,0 +1,822 @@
+# ADR-0051: Tool Registry Allowlists
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Depends on**: [ADR-0041](ADR-0041-immutable-evidence-nodes.md), [ADR-0043](ADR-0043-governed-tool-declaration.md), [ADR-0044](ADR-0044-tool-gates.md), [ADR-0047](ADR-0047-agent-charter.md)
+**Related**: [ADR-0046](ADR-0046-jit-tool-grant.md), [ADR-0049](ADR-0049-log-tier-governance.md), [ADR-0050](ADR-0050-operation-context.md), [ADR-0033](ADR-0033-unified-entity-state-model.md)
+
+---
+
+## Context
+
+lionagi's `PermissionPolicy` (`lionagi/agent/permissions.py`) controls per-tool access via
+allowlist, denylist, and escalate rules keyed by tool name and glob pattern. That mechanism works
+for its intended purpose — session-local access control — but it has a structural gap: the
+allowlist is an in-memory list on `AgentConfig`, assembled at agent creation time, with no
+record of who authorized which tool, when, or why. There is no way to answer "who approved
+`write_file` for agent X?" without reading the code or configuration that instantiated the agent.
+There is no expiry. There is no audit entry when the list changes. Multiple call sites — `AgentConfig.coding()`,
+`AgentConfig.research()`, and direct `PermissionPolicy(allow={...})` construction — each define
+their own allowlists with no shared registry to enforce consistency.
+
+The concrete failure mode is the N-paths problem: a tool that should require explicit approval
+(e.g., a database-write tool in a governed context) can be made available by updating any one of
+several independent allowlist paths. Each path has different bypass characteristics. An agent that
+reaches a tool through an unlisted path is indistinguishable from one that reached it through an
+explicitly governed path. Cross-cutting principle #3 — **every constraint must be enforced, not
+just documented** — is violated when the approval record lives only in configuration prose.
+
+Cross-cutting principle #1 (fail-closed) also has no expression at the allowlist level today.
+`PermissionPolicy` in `mode="allow_all"` (the default for orchestrators) permits any registered
+tool unconditionally. If the allowlist is absent or empty, the policy grants rather than denies.
+A centralized registry with a hard gate that checks membership before execution inverts this
+default: absence of a registry entry is a deny.
+
+### The applicable prior governance research insight
+
+prior research establishes a centralized `Registry` base class for all "is X in the approved
+list?" checks. The key principle is that allowlists are not code — they are configuration entries
+with attribution. A registry entry is not "a value in a Python list": it is a record with an
+actor, a timestamp, a justification, and a scope. When an entry is no longer valid, it is
+superseded (not deleted), so the full approval history is always recoverable. The gate operation
+(`verify_in_allowlist`) is the single enforcement point: every governed tool call goes through it,
+and it fails closed by default.
+
+Translated to lionagi: `ToolRegistryPolicy` holds `RegistryEntry` objects in a `Pile`;
+`verify_in_registry` is installed as a security pre-hook on the existing `Tool.preprocessor`
+path used by `ActionManager` ([ADR-0043](ADR-0043-governed-tool-declaration.md)); and
+`PermissionPolicy.allow` in library mode is re-expressed as an in-memory policy element so that
+the same code path is exercised whether the caller is a library user or a KHive tenant.
+
+### Why lionagi needs this
+
+An agent chartered for read-only research access ([ADR-0047](ADR-0047-agent-charter.md)) must
+not be able to call a `write_file` tool even if that tool is registered in the branch. Today,
+preventing this requires the session constructor to remember to configure `PermissionPolicy` with
+a denylist. If the constructor omits this, nothing in the tool execution path raises an error —
+the tool runs, the file is written, and the operation record is indistinguishable from an
+explicitly approved write. A registry that is consulted unconditionally by the governed tool
+pipeline, and that fails closed on a missing entry, makes this omission structurally impossible.
+
+---
+
+## Decision
+
+Introduce `ToolRegistryPolicy` (append-only, scoped, audited) and `RegistryEntry` (frozen
+`Element` with full attribution) as the canonical allowlist mechanism for governed tool access.
+The `verify_in_registry` HARD gate ([ADR-0044](ADR-0044-tool-gates.md)) consults the policy before
+every governed tool call. In library mode, `PermissionPolicy` constructs an in-memory policy
+element; in KHive, the same Element records are backend-persisted.
+
+### 1. Scope enum
+
+```python
+from __future__ import annotations
+
+from enum import Enum
+
+
+class RegistryScope(Enum):
+    """Determines which agents and sessions an entry applies to.
+
+    Resolution order (most-specific wins): SESSION > AGENT > PROJECT > GLOBAL.
+    Any active entry at any scope level grants access; no entry at any level
+    denies access.
+    """
+
+    GLOBAL = "global"    # all agents and sessions; system-wide approval
+    PROJECT = "project"  # one project (KHive project_id or Studio workspace)
+    AGENT = "agent"      # one agent_id within a project
+    SESSION = "session"  # one session_id; highest specificity, lowest lifetime
+```
+
+### 2. RegistryEntry — frozen, attributed, expirable
+
+```python
+import hashlib
+import json
+from typing import ClassVar
+from uuid import UUID
+
+from pydantic import ConfigDict, Field
+
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+
+
+class RegistryEvidence(Element):
+    """Evidence record for one registry policy decision or mutation."""
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    event: str
+    entry_id: str | None = None
+    tool_name: str | None = None
+    actor: str
+    reason: str
+    payload_hash: str | None = None
+    details: dict = Field(default_factory=dict)
+
+
+class ToolGrant(Element):
+    """Runtime grant produced when an active allowlist entry authorizes a call."""
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    tool_name: str
+    entry_id: str
+    scope: RegistryScope
+    scope_id: str
+    granted_for_action: str = ""
+    expires_at: float | None = None
+    evidence: Pile[RegistryEvidence] = Field(
+        default_factory=lambda: Pile(
+            item_type=RegistryEvidence,
+            strict_type=True,
+        )
+    )
+
+
+class RegistryEntry(Element):
+    """A single approved entry in a Registry.
+
+    Immutable after creation. Supersession (not deletion) is the only way
+    to revoke an entry; the original remains in the append-only pile for audit.
+    All mutations emit IMMUTABLE evidence per ADR-0041.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    category: str
+    """What kind of resource is being allowlisted.
+
+    Canonical categories: "tool" | "model" | "mcp_endpoint" | "url" | "path_prefix".
+    New categories may be added; no category is removed once introduced.
+    """
+
+    value: str
+    """The resource being approved.
+
+    Exact match only (v1). Examples:
+    - category="tool":         "write_file"
+    - category="model":        "openai/gpt-4o"
+    - category="mcp_endpoint": "mcp://khive-memory/v1"
+    - category="url":          "api.github.com"
+    - category="path_prefix":  "/workspace/project/"
+    """
+
+    scope: RegistryScope
+    """Breadth of this approval."""
+
+    scope_id: str
+    """Identifier for the scope target.
+
+    For GLOBAL: use "*".
+    For PROJECT: the project_id string.
+    For AGENT: the agent_id string.
+    For SESSION: the session_id string.
+    """
+
+    registered_by: str
+    """Actor who created this entry (human user, orchestrator agent_id, or system)."""
+
+    registered_at: float
+    """Unix timestamp (UTC) of registration."""
+
+    reason: str
+    """Required justification. Must be non-empty."""
+
+    expires_at: float | None = None
+    """Optional Unix timestamp after which this entry is treated as superseded.
+
+    Expired entries are preserved (not deleted) for audit of historical state.
+    The is_active() method accounts for expiry.
+    """
+
+    evidence: Pile[RegistryEvidence] = Field(
+        default_factory=lambda: Pile(
+            item_type=RegistryEvidence,
+            strict_type=True,
+        )
+    )
+    """Evidence records (ADR-0041) that support this approval decision."""
+
+    superseded_by: str | None = None
+    """entry_id of the replacement entry, if this entry has been superseded."""
+
+    _sensitive_fields: ClassVar[set[str]] = set()
+
+    @property
+    def entry_id(self) -> str:
+        """Compatibility alias for the Element id."""
+        return str(self.id)
+
+    def is_active(self) -> bool:
+        """Return True if this entry is currently effective."""
+        from datetime import datetime, timezone
+        if self.superseded_by is not None:
+            return False
+        if self.expires_at is not None:
+            now = datetime.now(timezone.utc).timestamp()
+            if now > self.expires_at:
+                return False
+        return True
+
+    def payload_hash(self) -> str:
+        """SHA-256 of the canonical JSON representation of this entry.
+
+        Used by the evidence emission path (ADR-0041) to produce a content-
+        addressed reference to this approval record.
+        """
+        payload = self.to_dict(mode="db", exclude={"metadata", "evidence"})
+        payload.pop("node_metadata", None)
+        canonical = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+    def with_supersession(self, superseded_by: UUID | str) -> "RegistryEntry":
+        """Return an immutable replacement with supersession recorded."""
+        return self.model_copy(update={"superseded_by": str(superseded_by)})
+```
+
+### 3. Registry — append-only, scoped resolution
+
+```python
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import ConfigDict, Field, PrivateAttr
+
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.log import DataLogger, Log
+from lionagi.protocols.generic.pile import Pile
+
+
+class ToolRegistryPolicy(Element):
+    """Append-only, audited allowlist policy mounted on ActionManager/PermissionPolicy.
+
+    All writes produce an IMMUTABLE evidence record (ADR-0041). Reads are O(n) in v1
+    (n = active entries per category). Pile supplies managed identity lookup and
+    synchronized mutation for library-mode policy state; KHive can persist the same
+    Element records behind the same API.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+    )
+
+    entries: Pile[RegistryEntry] = Field(
+        default_factory=lambda: Pile(
+            item_type=RegistryEntry,
+            strict_type=True,
+        )
+    )
+    grants: Pile[ToolGrant] = Field(
+        default_factory=lambda: Pile(
+            item_type=ToolGrant,
+            strict_type=True,
+        )
+    )
+    evidence: Pile[RegistryEvidence] = Field(
+        default_factory=lambda: Pile(
+            item_type=RegistryEvidence,
+            strict_type=True,
+        )
+    )
+
+    _data_logger: DataLogger | None = PrivateAttr(default=None)
+
+    def bind_logger(self, data_logger: DataLogger | None) -> "ToolRegistryPolicy":
+        """Bind the Branch DataLogger used to persist registry evidence."""
+        self._data_logger = data_logger
+        return self
+
+    # ------------------------------------------------------------------ reads
+
+    def _scope_candidates(
+        self,
+        *,
+        project_id: str | None = None,
+        agent_id: str | None = None,
+        session_id: str | None = None,
+    ) -> tuple[tuple[RegistryScope, str], ...]:
+        """Most-specific to least-specific resolution order."""
+        candidates = []
+        if session_id:
+            candidates.append((RegistryScope.SESSION, session_id))
+        if agent_id:
+            candidates.append((RegistryScope.AGENT, agent_id))
+        if project_id:
+            candidates.append((RegistryScope.PROJECT, project_id))
+        candidates.append((RegistryScope.GLOBAL, "*"))
+        return tuple(candidates)
+
+    def active_entry(
+        self,
+        category: str,
+        value: str,
+        *,
+        project_id: str | None = None,
+        agent_id: str | None = None,
+        session_id: str | None = None,
+    ) -> RegistryEntry | None:
+        """Return the active entry that grants access, or None."""
+        for check_scope, check_id in self._scope_candidates(
+            project_id=project_id,
+            agent_id=agent_id,
+            session_id=session_id,
+        ):
+            for entry in self.entries:
+                if (
+                    entry.category == category
+                    and entry.value == value
+                    and RegistryScope(entry.scope) == check_scope
+                    and entry.scope_id in {check_id, "*"}
+                    and entry.is_active()
+                ):
+                    return entry
+        return None
+
+    def is_allowed(
+        self,
+        category: str,
+        value: str,
+        *,
+        project_id: str | None = None,
+        agent_id: str | None = None,
+        session_id: str | None = None,
+    ) -> bool:
+        """Return True if an active entry exists for this (category, value) pair.
+
+        Scope resolution: walks from most-specific (SESSION) to least (GLOBAL).
+        Any active entry at any scope level → allowed. No active entry at any
+        level → denied (fail-closed, cross-cutting principle #1).
+        """
+        return self.active_entry(
+            category,
+            value,
+            project_id=project_id,
+            agent_id=agent_id,
+            session_id=session_id,
+        ) is not None
+
+    def get_entry(self, entry_id: str) -> RegistryEntry | None:
+        """Fetch a specific entry by ID (active or historical)."""
+        for entry in self.entries:
+            if entry.entry_id == entry_id:
+                return entry
+        return None
+
+    def history(
+        self,
+        category: str | None = None,
+        value: str | None = None,
+    ) -> Pile[RegistryEntry]:
+        """Return all entries (active and superseded) matching the filters."""
+        result = Pile(item_type=RegistryEntry, strict_type=True)
+        for entry in self.entries:
+            if category is not None and entry.category != category:
+                continue
+            if value is not None and entry.value != value:
+                continue
+            result.include(entry)
+        return result
+
+    # ----------------------------------------------------------------- writes
+
+    def add(
+        self,
+        *,
+        category: str,
+        value: str,
+        scope: RegistryScope,
+        scope_id: str,
+        registered_by: str,
+        reason: str,
+        expires_at: float | None = None,
+        evidence: Pile[RegistryEvidence] | None = None,
+    ) -> RegistryEntry:
+        """Append a new entry.
+
+        Raises ValueError if reason is empty; all approvals require justification.
+        Emits an IMMUTABLE evidence node (ADR-0041) recording the registration
+        event, the actor, and the payload_hash of the new entry.
+        """
+        if not reason.strip():
+            raise ValueError(
+                "RegistryEntry.reason must be non-empty; all approvals require justification."
+            )
+        entry = RegistryEntry(
+            category=category,
+            value=value,
+            scope=scope,
+            scope_id=scope_id,
+            registered_by=registered_by,
+            registered_at=datetime.now(timezone.utc).timestamp(),
+            reason=reason,
+            expires_at=expires_at,
+            evidence=evidence or Pile(item_type=RegistryEvidence, strict_type=True),
+        )
+        self.entries.include(entry)
+        self._record_evidence(
+            event="entry_added",
+            entry=entry,
+            actor=registered_by,
+            reason=reason,
+        )
+        return entry
+
+    def supersede(
+        self,
+        old_entry_id: str,
+        *,
+        reason: str,
+        superseded_by_actor: str,
+        replacement: RegistryEntry | None = None,
+    ) -> None:
+        """Mark an entry as superseded. The original is preserved for audit.
+
+        If replacement is provided, it must already be present in this registry
+        (call add() first, then supersede()). Emits IMMUTABLE evidence for the
+        supersession event.
+
+        Does not raise if old_entry_id is already superseded — idempotent.
+        """
+        for entry in self.entries:
+            if entry.entry_id == old_entry_id:
+                replacement_id = (
+                    replacement.entry_id if replacement is not None else "revoked"
+                )
+                updated = entry.with_supersession(replacement_id)
+                self.entries.update(updated)
+                self._record_evidence(
+                    event="entry_superseded",
+                    entry=updated,
+                    actor=superseded_by_actor,
+                    reason=reason,
+                    details={
+                        "superseded_by_actor": superseded_by_actor,
+                        "supersession_reason": reason,
+                        "replacement_entry_id": replacement_id,
+                    },
+                )
+                return
+
+    def record_grant(
+        self,
+        *,
+        tool_name: str,
+        entry: RegistryEntry,
+        action: str = "",
+    ) -> ToolGrant:
+        """Record the effective grant used by one governed tool call."""
+        grant = ToolGrant(
+            tool_name=tool_name,
+            entry_id=entry.entry_id,
+            scope=entry.scope,
+            scope_id=entry.scope_id,
+            granted_for_action=action,
+            expires_at=entry.expires_at,
+        )
+        self.grants.include(grant)
+        evidence = self._record_evidence(
+            event="grant_issued",
+            entry=entry,
+            actor="policy",
+            reason=f"{tool_name} authorized by registry entry {entry.entry_id}",
+            details={"grant_id": str(grant.id), "action": action},
+        )
+        grant.evidence.include(evidence)
+        return grant
+
+    # --------------------------------------------------------- evidence bridge
+
+    def _record_evidence(
+        self,
+        event: str,
+        entry: RegistryEntry,
+        *,
+        actor: str,
+        reason: str,
+        details: dict[str, Any] | None = None,
+    ) -> RegistryEvidence:
+        """Record IMMUTABLE evidence for a registry mutation or grant.
+
+        In library mode, the record is retained in a Pile and also written to the
+        bound Branch DataLogger when one is available. In KHive, the backend can
+        persist the same Element payload to the immutable evidence store
+        (ADR-0041, ADR-0049 IMMUTABLE tier).
+        """
+        evidence = RegistryEvidence(
+            event=event,
+            entry_id=entry.entry_id,
+            tool_name=entry.value if entry.category == "tool" else None,
+            actor=actor,
+            reason=reason,
+            payload_hash=entry.payload_hash(),
+            details=details or {},
+        )
+        self.evidence.include(evidence)
+        entry.evidence.include(evidence)
+        try:
+            if self._data_logger is not None:
+                self._data_logger.log(Log.create(evidence))
+        except Exception:  # noqa: BLE001
+            # The in-memory evidence Pile remains the source of truth in library mode.
+            pass
+        return evidence
+```
+
+### 4. The `verify_in_registry` gate
+
+`verify_in_registry` is a HARD gate in the sense of [ADR-0044](ADR-0044-tool-gates.md): it raises
+`PermissionError` and fails closed if the policy has no active entry. It is registered through the
+existing hook path (`AgentConfig.pre(...)` before agent creation, or `Tool.preprocessor` on
+`ActionManager`-managed tools after registration).
+
+```python
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable, Sequence
+
+from lionagi.agent.config import AgentConfig
+from lionagi.agent.factory import create_agent
+from lionagi.agent.hooks import guard_destructive, guard_paths, log_tool_use
+from lionagi.protocols.action.manager import ActionManager
+from lionagi.protocols.action.tool import Tool
+
+from lionagi.agent.governance.registry import RegistryScope, ToolRegistryPolicy
+
+
+def make_verify_in_registry_gate(
+    policy: ToolRegistryPolicy,
+    *,
+    project_id: str | None = None,
+    agent_id: str | None = None,
+    session_id: str | None = None,
+):
+    """Factory returning an existing lionagi pre-hook.
+
+    Hook signature matches lionagi.agent.hooks:
+        async def hook(tool_name: str, action: str, args: dict) -> dict | None
+
+    The hook raises PermissionError to block and returns None to pass through.
+    Any registry read failure is treated as deny (fail-closed).
+    """
+
+    async def verify_in_registry(
+        tool_name: str,
+        action: str,
+        args: dict,
+    ) -> dict | None:
+        try:
+            entry = policy.active_entry(
+                "tool",
+                tool_name,
+                project_id=project_id,
+                agent_id=agent_id,
+                session_id=session_id,
+            )
+            if entry is None:
+                raise PermissionError(f"{tool_name} has no active registry entry")
+            policy.record_grant(tool_name=tool_name, entry=entry, action=action)
+            return None
+        except PermissionError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            raise PermissionError(
+                f"Registry check failed closed for {tool_name}: {exc}"
+            ) from exc
+
+    verify_in_registry.__name__ = "verify_in_registry[tool]"
+    return verify_in_registry
+
+
+Hook = Callable[[str, str, dict], Awaitable[dict | None]]
+
+
+def _chain_tool_preprocessor(
+    tool: Tool,
+    *,
+    security_hooks: Sequence[Hook],
+) -> None:
+    """Install registry hooks through Tool.preprocessor without replacing Tool."""
+    previous = tool.preprocessor
+
+    async def chained(args: dict, **kwargs) -> dict:
+        current = args
+        for hook in security_hooks:
+            result = await hook(tool.function, current.get("action", ""), current)
+            if isinstance(result, dict):
+                current = result
+        if previous is not None:
+            result = previous(current, **kwargs)
+            result = await result if inspect.isawaitable(result) else result
+            if isinstance(result, dict):
+                current = result
+        return current
+
+    tool.preprocessor = chained
+
+
+def install_registry_policy(
+    action_manager: ActionManager,
+    policy: ToolRegistryPolicy,
+    *,
+    project_id: str | None = None,
+    agent_id: str | None = None,
+    session_id: str | None = None,
+) -> None:
+    """Mount the allowlist check on existing ActionManager-managed Tool objects.
+
+    ActionManager.registry remains the source of registered tools; the policy only
+    supplies the allowlist hook that each Tool runs before func_callable.
+    """
+    hook = make_verify_in_registry_gate(
+        policy,
+        project_id=project_id,
+        agent_id=agent_id,
+        session_id=session_id,
+    )
+    for tool in action_manager.registry.values():
+        _chain_tool_preprocessor(tool, security_hooks=[hook])
+
+
+# Library-mode setup composes registry policy with existing hooks.py handlers.
+config = AgentConfig.coding()
+policy = ToolRegistryPolicy()
+policy.add(
+    category="tool",
+    value="write_file",
+    scope=RegistryScope.PROJECT,
+    scope_id="my-project",
+    registered_by="ocean",
+    reason="Approved for sandbox write operations.",
+)
+
+# Before create_agent(): AgentConfig wires hooks through Tool.preprocessor.
+config.pre("*", make_verify_in_registry_gate(policy, project_id="my-project"))
+config.pre("bash", guard_destructive)
+config.pre("editor", guard_paths(allowed_paths=["/workspace/project/"]))
+config.post("*", log_tool_use)
+branch = await create_agent(config)
+policy.bind_logger(branch._log_manager)
+
+# For tools registered after create_agent(), install directly on ActionManager.
+install_registry_policy(branch.acts, policy, project_id="my-project")
+```
+
+### 5. Canonical categories
+
+| Category | `value` field semantics | Example |
+|---|---|---|
+| `tool` | tool_id as registered in `ActionManager` | `"write_file"` |
+| `model` | `"{provider}/{model_name}"` | `"openai/gpt-4o"` |
+| `mcp_endpoint` | MCP server URI (scheme + host) | `"mcp://khive-memory/v1"` |
+| `url` | External HTTP host (no path) | `"api.github.com"` |
+| `path_prefix` | Filesystem prefix; trailing `/` required | `"/workspace/project/"` |
+
+Categories are extensible. New categories are introduced by adding to this table; no category is
+removed once any active entry references it.
+
+### 6. Scope resolution semantics
+
+When `is_allowed()` is called with a `(scope, scope_id)` pair identifying the caller's current
+context, resolution walks from SESSION → AGENT → PROJECT → GLOBAL. The first active matching
+entry at any scope level grants access. If no active entry exists at any scope level, the call
+returns `False` (fail-closed).
+
+This means a GLOBAL entry grants access to all agents and sessions. A PROJECT-scoped entry grants
+access to all agents within that project but not globally. A SESSION-scoped entry grants access
+only within that session's lifetime — typically used for JIT grants ([ADR-0046](ADR-0046-jit-tool-grant.md)).
+
+### 7. Integration with AgentCharter
+
+[ADR-0047](ADR-0047-agent-charter.md) defines an `AgentCharter` with an `allowed_tools` field.
+That field is a **snapshot** derived from the active registry entries at charter ratification time
+— it is not a live view. Once a charter is ratified, registry changes do not propagate into it
+automatically. To revoke a tool from a running agent, the charter must be superseded (which
+terminates the current agent session and initiates a new one with the updated charter). This is
+intentional: a charter represents a point-in-time, signed commitment; runtime mutability would
+undermine the guarantees [ADR-0042](ADR-0042-task-certificate.md) (Task Certificate) depends on.
+
+### 8. Library mode vs. KHive mode
+
+The `ToolRegistryPolicy` element is usable with zero configuration in library mode. An in-memory
+policy is created per `AgentConfig` and backs the allow dimension that previously lived only in
+`PermissionPolicy.allow`. No persistence is implied; the policy lifetime is the process lifetime.
+
+In KHive, the registry is backend-persisted. `Registry._emit_registry_evidence` writes to the
+IMMUTABLE evidence tier ([ADR-0049](ADR-0049-log-tier-governance.md)). Multi-actor approval
+workflows (e.g., two-of-three human approvers before a tool is added to a production registry)
+are implemented at the KHive layer by gating the `Registry.add()` call behind an approval flow
+— the `Registry` class itself is unaware of this orchestration.
+
+`PermissionPolicy` is not removed. It continues to express deny rules and escalation paths that
+have no registry equivalent. The registry governs the allowlist dimension; `PermissionPolicy`
+governs the deny and escalate dimensions. Both are consulted on every governed tool call.
+
+---
+
+## Consequences
+
+**Positive**
+
+- Allowlist approvals are auditable: every `add()` call emits an evidence node that records who
+  approved what, when, and why. "Who approved `write_file` for agent X?" is always answerable.
+- Centralized enforcement eliminates the N-paths problem. There is exactly one code path that
+  gates tool execution on registry membership.
+- Fail-closed default: a tool with no registry entry in any scope is denied, not permitted. An
+  absent allowlist no longer implies permission.
+- Expiry is first-class: JIT grants (ADR-0046) expire at session end without requiring explicit
+  revocation; the audit record of the expired grant is preserved.
+- Library and KHive users share the same `Registry` API; behavioral differences are in the
+  persistence and evidence-emission backends, not in the allowlist logic.
+
+**Negative**
+
+- Increased API surface: agents that previously relied on `PermissionPolicy(mode="allow_all")`
+  must now populate a registry. Migration requires explicit approval records for every previously
+  implicit permission.
+- Append-only growth: registries accumulate superseded and expired entries indefinitely. In KHive,
+  storage tiering of historical entries is a backend concern; in library mode, old entries are
+  garbage-collected with the process.
+- Expiry management is a new operational concern: SESSION-scoped entries expire silently. Long-lived
+  agents that acquire SESSION-scoped grants must renew them or escalate to AGENT/PROJECT scope.
+
+---
+
+## Non-Goals
+
+Explicitly out of scope for v1:
+
+- **Multi-tenant registry isolation**: KHive's tenant-scoped registry (where Tenant A cannot see
+  Tenant B's entries) is a KHive v1 concern. The `Registry` class has no tenant_id; the KHive
+  backend adds this as a partitioning key.
+- **Wildcard or regex matching**: `value` is exact-match only. `"write_*"` is not a valid value;
+  each tool must have an explicit entry. Pattern matching introduces ambiguity in scope resolution
+  and is deliberately deferred.
+- **Multi-actor approval workflows**: requiring two-of-three human approvers before `Registry.add()`
+  completes is a KHive workflow concern, not a library concern. The `Registry` class does not model
+  approval state machines.
+- **Automatic allowlist propagation across tenants**: a GLOBAL entry in one KHive tenant does not
+  propagate to another. Propagation is an explicit KHive federation concern.
+- **Dynamic registry mutation by agents**: agents may request that a tool be added to a registry
+  (via the JIT grant flow, ADR-0046), but agents do not call `Registry.add()` directly. That
+  decision is reserved for humans or orchestrators with explicit approval authority.
+- **Performance caching layer**: in-memory caching to reduce O(n) lookup cost is deferred to the
+  KHive backend. Library-mode registries are small enough that O(n) is acceptable at v1.
+
+---
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|---|---|
+| Per-feature allowlists (current) | N-paths problem: each feature implements its own allowlist with different bypass and audit characteristics. No shared invariant that "approved = has registry entry". |
+| `PermissionPolicy.allow` dict only | No attribution: the dict holds tool names, not the actor who approved them or when. No expiry. No evidence emission. Answers "is X allowed now" but not "who allowed X". |
+| Free-form policy text in `AgentConfig` | Not machine-enforceable. A human-readable description of allowed tools has no gate equivalent. Cross-cutting principle #3 requires enforcement, not documentation. |
+| OPA policy engine | Correct for complex policy logic; over-engineered for exact-match membership checks. OPA evaluation overhead on every tool call is unjustified when the check is `value in set`. |
+| Separate list per category (tool_allowlist, model_allowlist, ...) | Schema proliferation. A unified `Registry` with a `category` discriminator is simpler, shares the same audit and expiry semantics, and avoids inconsistency between implementations. |
+
+---
+
+## References
+
+- [ADR-0041](ADR-0041-immutable-evidence-nodes.md) — IMMUTABLE evidence emission on every registry mutation
+- [ADR-0042](ADR-0042-task-certificate.md) — Task Certificate depends on immutable evidence produced by registry mutations
+- [ADR-0043](ADR-0043-governed-tool-declaration.md) — existing `Tool` pipeline where `verify_in_registry` is a HARD gate
+- [ADR-0044](ADR-0044-tool-gates.md) — `gate_in_registry` as a HARD gate in the three-tier enforcement model
+- [ADR-0046](ADR-0046-jit-tool-grant.md) — JIT grants are SESSION-scoped registry entries with `expires_at`
+- [ADR-0047](ADR-0047-agent-charter.md) — `allowed_tools` is a snapshot from the registry at charter ratification time
+- [ADR-0049](ADR-0049-log-tier-governance.md) — registry mutation events are IMMUTABLE tier log records
+- [ADR-0033](ADR-0033-unified-entity-state-model.md) — evidence shape reflected by `RegistryEvidence` records in `RegistryEntry.evidence`
+- prior governance research `01_design/031-registry-allowlists/ADR-031-registry-allowlists.md` — source pattern (tenant → scope, role/destination/tool registries → unified category discriminator)

--- a/docs/adrs/ADR-0051-tool-registry-allowlists.md
+++ b/docs/adrs/ADR-0051-tool-registry-allowlists.md
@@ -45,8 +45,8 @@ and it fails closed by default.
 Translated to lionagi: `ToolRegistryPolicy` holds `RegistryEntry` objects in a `Pile`;
 `verify_in_registry` is installed as a security pre-hook on the existing `Tool.preprocessor`
 path used by `ActionManager` ([ADR-0043](ADR-0043-governed-tool-declaration.md)); and
-`PermissionPolicy.allow` in library mode is re-expressed as an in-memory policy element so that
-the same code path is exercised whether the caller is a library user or a KHive tenant.
+`PermissionPolicy.allow` is re-expressed as an in-memory policy element so that the same code
+path is exercised for all callers.
 
 ### Why lionagi needs this
 
@@ -65,8 +65,8 @@ pipeline, and that fails closed on a missing entry, makes this omission structur
 Introduce `ToolRegistryPolicy` (append-only, scoped, audited) and `RegistryEntry` (frozen
 `Element` with full attribution) as the canonical allowlist mechanism for governed tool access.
 The `verify_in_registry` HARD gate ([ADR-0044](ADR-0044-tool-gates.md)) consults the policy before
-every governed tool call. In library mode, `PermissionPolicy` constructs an in-memory policy
-element; in KHive, the same Element records are backend-persisted.
+every governed tool call. `PermissionPolicy` constructs an in-memory policy element that can be
+backed by persistent storage when a durable backend is configured.
 
 ### 1. Scope enum
 
@@ -85,7 +85,7 @@ class RegistryScope(Enum):
     """
 
     GLOBAL = "global"    # all agents and sessions; system-wide approval
-    PROJECT = "project"  # one project (KHive project_id or Studio workspace)
+    PROJECT = "project"  # one project
     AGENT = "agent"      # one agent_id within a project
     SESSION = "session"  # one session_id; highest specificity, lowest lifetime
 ```
@@ -281,8 +281,8 @@ class ToolRegistryPolicy(Element):
 
     All writes produce an IMMUTABLE evidence record (ADR-0041). Reads are O(n) in v1
     (n = active entries per category). Pile supplies managed identity lookup and
-    synchronized mutation for library-mode policy state; KHive can persist the same
-    Element records behind the same API.
+    synchronized mutation for in-memory policy state; a durable backend may persist
+    the same Element records behind the same API.
     """
 
     model_config = ConfigDict(
@@ -529,9 +529,9 @@ class ToolRegistryPolicy(Element):
     ) -> RegistryEvidence:
         """Record IMMUTABLE evidence for a registry mutation or grant.
 
-        In library mode, the record is retained in a Pile and also written to the
-        bound Branch DataLogger when one is available. In KHive, the backend can
-        persist the same Element payload to the immutable evidence store
+        The record is retained in a Pile and also written to the bound Branch
+        DataLogger when one is available. When a durable backend is configured,
+        the same Element payload may be persisted to the immutable evidence store
         (ADR-0041, ADR-0049 IMMUTABLE tier).
         """
         evidence = RegistryEvidence(
@@ -728,18 +728,6 @@ terminates the current agent session and initiates a new one with the updated ch
 intentional: a charter represents a point-in-time, signed commitment; runtime mutability would
 undermine the guarantees [ADR-0042](ADR-0042-task-certificate.md) (Task Certificate) depends on.
 
-### 8. Library mode vs. KHive mode
-
-The `ToolRegistryPolicy` element is usable with zero configuration in library mode. An in-memory
-policy is created per `AgentConfig` and backs the allow dimension that previously lived only in
-`PermissionPolicy.allow`. No persistence is implied; the policy lifetime is the process lifetime.
-
-In KHive, the registry is backend-persisted. `Registry._emit_registry_evidence` writes to the
-IMMUTABLE evidence tier ([ADR-0049](ADR-0049-log-tier-governance.md)). Multi-actor approval
-workflows (e.g., two-of-three human approvers before a tool is added to a production registry)
-are implemented at the KHive layer by gating the `Registry.add()` call behind an approval flow
-— the `Registry` class itself is unaware of this orchestration.
-
 `PermissionPolicy` is not removed. It continues to express deny rules and escalation paths that
 have no registry equivalent. The registry governs the allowlist dimension; `PermissionPolicy`
 governs the deny and escalate dimensions. Both are consulted on every governed tool call.
@@ -758,17 +746,17 @@ governs the deny and escalate dimensions. Both are consulted on every governed t
   absent allowlist no longer implies permission.
 - Expiry is first-class: JIT grants (ADR-0046) expire at session end without requiring explicit
   revocation; the audit record of the expired grant is preserved.
-- Library and KHive users share the same `Registry` API; behavioral differences are in the
-  persistence and evidence-emission backends, not in the allowlist logic.
+- The `Registry` API is the same regardless of persistence backend; behavioral differences are in
+  the evidence-emission backend, not in the allowlist logic.
 
 **Negative**
 
 - Increased API surface: agents that previously relied on `PermissionPolicy(mode="allow_all")`
   must now populate a registry. Migration requires explicit approval records for every previously
   implicit permission.
-- Append-only growth: registries accumulate superseded and expired entries indefinitely. In KHive,
-  storage tiering of historical entries is a backend concern; in library mode, old entries are
-  garbage-collected with the process.
+- Append-only growth: registries accumulate superseded and expired entries indefinitely. Old entries
+  are garbage-collected with the process in in-memory configurations; durable backends manage
+  storage tiering of historical entries.
 - Expiry management is a new operational concern: SESSION-scoped entries expire silently. Long-lived
   agents that acquire SESSION-scoped grants must renew them or escalate to AGENT/PROJECT scope.
 
@@ -778,22 +766,18 @@ governs the deny and escalate dimensions. Both are consulted on every governed t
 
 Explicitly out of scope for v1:
 
-- **Multi-tenant registry isolation**: KHive's tenant-scoped registry (where Tenant A cannot see
-  Tenant B's entries) is a KHive v1 concern. The `Registry` class has no tenant_id; the KHive
-  backend adds this as a partitioning key.
 - **Wildcard or regex matching**: `value` is exact-match only. `"write_*"` is not a valid value;
   each tool must have an explicit entry. Pattern matching introduces ambiguity in scope resolution
   and is deliberately deferred.
 - **Multi-actor approval workflows**: requiring two-of-three human approvers before `Registry.add()`
-  completes is a KHive workflow concern, not a library concern. The `Registry` class does not model
-  approval state machines.
-- **Automatic allowlist propagation across tenants**: a GLOBAL entry in one KHive tenant does not
-  propagate to another. Propagation is an explicit KHive federation concern.
+  completes is out of scope for v1. The `Registry` class does not model approval state machines.
+- **Automatic allowlist propagation across deployments**: a GLOBAL entry in one deployment does not
+  propagate to another. Cross-deployment propagation is an explicit deployment concern.
 - **Dynamic registry mutation by agents**: agents may request that a tool be added to a registry
   (via the JIT grant flow, ADR-0046), but agents do not call `Registry.add()` directly. That
   decision is reserved for humans or orchestrators with explicit approval authority.
-- **Performance caching layer**: in-memory caching to reduce O(n) lookup cost is deferred to the
-  KHive backend. Library-mode registries are small enough that O(n) is acceptable at v1.
+- **Performance caching layer**: in-memory caching to reduce O(n) lookup cost is deferred to
+  persistence backends. In-memory registries are small enough that O(n) is acceptable at v1.
 
 ---
 

--- a/docs/adrs/ADR-0052-policy-resolution.md
+++ b/docs/adrs/ADR-0052-policy-resolution.md
@@ -799,20 +799,7 @@ def attach_policy_release(
 | 7 | Verify winner.bundle.verify_hash() | → DENY (PolicyResolutionError: "tampered bundle") |
 | 8 | Return winner.bundle | — |
 
-### 9. Library mode vs. KHive mode
-
-In library mode (open-source lionagi, single-agent, no multi-tenant deployment), policy
-resolution is trivial: the `AgentConfig.permissions` in use constitutes the single applicable
-policy. There is no `PolicyResolver`; the `PermissionPolicy` allowlist/denylist/confirm logic
-continues to apply directly. `OperationContext.policy_version_active` is `None` or a
-config-derived string.
-
-The full `PolicyResolver`, `PolicyRelease`, and staged rollout machinery is KHive territory:
-it becomes necessary when multiple tenants share a deployment and policies must be versioned,
-staged, and audited across organizational boundaries. The protocol (schemas and resolution
-algorithm above) is the same in both modes; the resolver is more sophisticated in KHive.
-
-### 10. Worked example
+### 9. Worked example
 
 An agent in `tenant=acme`, `role=reviewer`, calls `tool=write_pr` at Unix timestamp `t`.
 The active `PolicyRelease` contains four `ScopedPolicy` records:
@@ -835,7 +822,7 @@ Resolution result: `write_pr_requires_jit` applies. The gates declared in that b
 to `"write_pr_requires_jit@v3"`. The other three bundles remain authoritative for operations
 they are most-specific for.
 
-### 11. Two-Key Model — enforcement
+### 10. Two-Key Model — enforcement
 
 The structural separation in `PolicyBundle.__post_init__` (`authored_by != implemented_by`) is
 a construction-time check. The policy authorship record is stored in the bundle and covered by
@@ -891,10 +878,7 @@ Explicitly out of scope:
   supported. If weights are needed, supersede the lower-specificity policy with a new bundle
   at a higher specificity scope.
 - **Automatic policy generation from regulations**: tooling that reads GDPR or HIPAA text and
-  produces `PolicyBundle` records is a product concern, not a framework concern.
-- **Cross-tenant policy inheritance**: a policy defined at the global level that automatically
-  specializes for each tenant. This is a KHive concern addressed in the multi-tenant resolver
-  layer. The open-source framework has no tenant hierarchy.
+  produces `PolicyBundle` records is out of scope for this ADR.
 - **Runtime policy mutation**: a running session cannot modify its own policy. All changes must
   go through the release lifecycle (DRAFT → CANARY → ROLLING → ACTIVE) and apply only to
   sessions starting after the release reaches the applicable stage.
@@ -903,7 +887,7 @@ Explicitly out of scope:
   would re-introduce the conflict resolution problem this ADR solves.
 - **Automatic release promotion**: advancing a release from CANARY to ROLLING to ACTIVE requires
   explicit human action (or an external approval gate). Automated promotion based on error rates
-  is a deployment platform concern, not a framework concern.
+  is out of scope for this ADR.
 
 ## Alternatives Considered
 
@@ -911,7 +895,7 @@ Explicitly out of scope:
 |-------------|--------------|
 | First-match wins | Resolution depends on registration order. Two deployments with identically scoped policies but different registration sequences produce different results. Non-deterministic; not audit-defensible. |
 | Confidence-weighted merging | Assigns weights to each applicable policy and blends the result. Introduces a scoring function that is itself a policy decision, is difficult to audit, and violates the fail-closed principle — partial application of a policy that would deny is effectively a permit. |
-| Single global policy (current state) | `AgentConfig.permissions` is a single flat policy per agent with no versioning and no scope hierarchy. Adequate for library mode; rejected for multi-agent, multi-tenant deployments where role and resource overrides are required. |
+| Single global policy (current state) | `AgentConfig.permissions` is a single flat policy per agent with no versioning and no scope hierarchy. Adequate for single-agent use; rejected for multi-agent deployments where role and resource overrides are required. |
 | Most-specific-wins with permit-on-tie | The alternative to DENY-on-tie. Rejected because a tie indicates two equally-authoritative policies disagree. Picking one arbitrarily is non-deterministic. Denying forces policy authors to resolve the ambiguity explicitly, which is the correct outcome. |
 
 ## References

--- a/docs/adrs/ADR-0052-policy-resolution.md
+++ b/docs/adrs/ADR-0052-policy-resolution.md
@@ -1,0 +1,930 @@
+# ADR-0052: Policy Resolution and Staged Release
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Depends on**: [ADR-0044](ADR-0044-tool-gates.md) (policies select which gates run), [ADR-0047](ADR-0047-agent-charter.md) (charter pins policy_release_version), [ADR-0050](ADR-0050-operation-context.md) (active policy version captured in operation evidence), [ADR-0051](ADR-0051-tool-registry-allowlists.md) (registry entries are policy-scoped)
+**Related**: [ADR-0041](ADR-0041-immutable-evidence-nodes.md) (bundle hash follows the same SHA-256 pattern), [ADR-0042](ADR-0042-task-certificate.md) (certificate records active policy version), [ADR-0045](ADR-0045-break-glass-protocol.md) (break-glass resolves against a named policy), [ADR-0046](ADR-0046-jit-tool-grant.md) (JIT grants are policy-scoped)
+
+## Context
+
+lionagi's agent governance today is captured in `AgentConfig` (`lionagi/agent/config.py`). An
+`AgentConfig` carries a `PermissionPolicy` with allowlist, denylist, or confirm mode; a set of
+`hook_handlers`; and a list of tool names. This is per-agent and flat: there is exactly one
+permission policy per agent, it has no version, and there is no mechanism for resolving what
+happens when multiple policies could apply to a single operation.
+
+That flat model is adequate for single-agent, single-operator use. It breaks down as soon as scope
+widens. A tool call in a governed session has at least three relevant policy dimensions: what the
+tenant (or organization) requires by default, what the role of the calling agent requires, and what
+the specific resource (the tool being called) requires. These three can conflict. lionagi today
+has no mechanism to resolve that conflict, no representation of policy scope, and no way to version
+the policy so that an audit can reconstruct what rules were in force at execution time.
+
+Cross-cutting principle #1 — **fail-closed is the universal default** — means that the absence of
+a resolution mechanism is not neutral. Unresolved conflicts must deny, not silently proceed. And
+cross-cutting principle #3 — **every constraint must be enforced, not just documented** — means
+the resolution algorithm must be code-backed, not a documentation convention. The gap is structural:
+without `PolicyBundle`, `PolicyScope`, `ScopedPolicy`, and `PolicyResolver`, the framework cannot
+enforce precedence, cannot version policy state, and cannot record which policy version was active
+in evidence.
+
+### The applicable prior governance research insight
+
+prior research establishes *lex specialis* as the resolution rule: the most specific applicable
+policy wins. Specificity is scored by scope level — resource-level policies score higher than
+role-level, role-level higher than tenant-level, tenant-level higher than global. When the
+highest-scoring candidates are tied (two resource-level policies both matching the same tool call),
+the action is blocked. prior research extends this with a staged release model: policies are
+immutable once published, released through `CANARY → ROLLING → ACTIVE` stages, and protected by a
+Two-Key Model requiring separate Legal (what is required) and Engineering (how it is enforced)
+authorship. Translated to lionagi: tenant becomes agent scope, action handler becomes tool call,
+charter becomes the session-binding vehicle.
+
+### Why lionagi needs this
+
+Consider an agent in a governed deployment with role `reviewer`, operating for tenant `acme`, that
+calls a `write_pr` tool. The deployment has four active policies:
+
+- A global default policy that restricts agents to read-only operations.
+- A tenant policy for `acme` that allows reviewers to comment but not merge.
+- A role policy for `reviewer` that blocks direct merges and requires comment evidence.
+- A resource policy for the `write_pr` tool that requires a JIT grant (ADR-0046) before execution.
+
+Without a resolution algorithm, the framework cannot determine which of these four policies governs
+this specific call. It must either apply all of them (combinatorial and potentially contradictory),
+apply the first match (order-dependent and non-deterministic), or deny by default. Only the
+most-specific-wins rule with DENY-on-tie gives the auditable, order-independent answer: the
+resource-level policy `write_pr_requires_jit` governs, because `resource` scope has the highest
+specificity score. The other three policies remain in force for calls they are most-specific for.
+
+## Decision
+
+We introduce `PolicyBundle`, `PolicyScope`, `ScopedPolicy`, `PolicyRelease`, and `PolicyResolver`
+as the policy resolution and lifecycle layer for lionagi. When multiple policies apply to an
+operation, resolution follows most-specific-wins: resource (score 3) > role (score 2) > tenant
+(score 1) > global (score 0). Ties at the top score → DENY (fail-closed). Policy bundles are
+versioned, immutable once published, and released in stages. Sessions pin to a release version at
+start; mid-session policy changes do not apply until the next session.
+
+### 1. `PolicyBundle` — the versioned policy unit
+
+A `PolicyBundle` is the atomic policy artifact. It specifies which gates must run, which models
+and evidence kinds are permitted, scope of tool registry, and session limits. It carries two
+authorship fields implementing the Two-Key Model: `authored_by` (who wrote the policy — the
+"Legal" role) and `implemented_by` (who wrote the enforcement code — the "Engineering" role).
+These must be different actors. A SHA-256 hash over all governance fields enables tamper detection.
+
+```python
+# lionagi/protocols/governance/policy.py
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import ClassVar, Literal
+
+from pydantic import ConfigDict, Field, model_validator
+
+from lionagi.agent.permissions import PermissionPolicy
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+
+
+PolicyDecision = Literal["allow", "deny", "escalate"]
+
+
+class PolicyRuleRef(Element):
+    """Reference to a gate/rule that participates in policy enforcement."""
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    gate_id: str
+    enforcement: Literal["required", "disabled"]
+    justification: str | None = None
+
+
+class PolicyEvidenceRef(Element):
+    """Evidence emitted while resolving or enforcing a policy bundle."""
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    evidence_id: str
+    evidence_kind: str
+    policy_version_active: str
+    metadata_digest: str | None = None
+
+
+class PolicyBundle(Element):
+    """Versioned, immutable unit of policy backed by PermissionPolicy.
+
+    A PolicyBundle specifies the enforcement contract for an operation: which
+    gates must run (ADR-0044), which tool registry scope applies (ADR-0051),
+    which models and evidence kinds are permitted, the PermissionPolicy rules
+    to apply, and optional session limits.
+
+    Two-Key Model:
+        authored_by  — the actor who declared WHAT the policy requires (policy
+                       author / Legal role). Does not write enforcement code.
+        implemented_by — the actor who delivered HOW it is enforced (gate
+                        implementer / Engineering role). Does not decide policy.
+    Neither can produce a valid, active bundle alone.
+
+    hash — SHA-256 of all fields except hash itself. A bundle whose hash does
+    not match its content is rejected before use.
+
+    Attributes:
+        bundle_id:              Unique identifier for this policy bundle.
+        version:                Monotonically increasing integer per bundle_id.
+        permission_policy:      Existing lionagi PermissionPolicy used for the
+                                final allow/deny/escalate decision.
+        rules:                  Pile of PolicyRuleRef gate/rule records. Rules
+                                whose enforcement is "required" replace the old
+                                gates_required list; "disabled" replaces the
+                                old gates_disabled list.
+        registry_scope:         Which tool registry scope applies (ADR-0051).
+        allowed_models:         iModel identifiers permitted under this policy.
+        allowed_evidence_kinds: Subset of the 8 EvidenceRef kinds (ADR-0033)
+                                permitted in evidence emitted under this bundle.
+        max_session_duration_sec: Optional hard cap on session wall time.
+        authored_by:            Identity of the policy author (Two-Key Key 1).
+        implemented_by:         Identity of the gate implementer (Two-Key Key 2).
+        hash:                   SHA-256 over all fields except hash itself.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    bundle_id: str
+    version: int = Field(ge=1)
+    permission_policy: PermissionPolicy = Field(
+        default_factory=PermissionPolicy.deny_all
+    )
+    rules: Pile[PolicyRuleRef] = Field(
+        default_factory=lambda: Pile(item_type=PolicyRuleRef, strict_type=True)
+    )
+    evidence_refs: Pile[PolicyEvidenceRef] = Field(
+        default_factory=lambda: Pile(item_type=PolicyEvidenceRef, strict_type=True)
+    )
+    registry_scope: str           # RegistryScope string; see ADR-0051
+    allowed_models: tuple[str, ...] = ()
+    allowed_evidence_kinds: tuple[str, ...] = ()
+    max_session_duration_sec: int | None = Field(default=None, ge=0)
+    authored_by: str
+    implemented_by: str
+    hash: str = ""
+
+    @model_validator(mode="after")
+    def _validate_two_key_model(self) -> "PolicyBundle":
+        if self.authored_by == self.implemented_by:
+            raise ValueError(
+                f"PolicyBundle '{self.bundle_id}': authored_by and implemented_by "
+                "must be different actors. The Two-Key Model requires separation "
+                "between the policy author (what is required) and the gate "
+                "implementer (how it is enforced). Same actor in both roles "
+                "defeats the control."
+            )
+        return self
+
+    @property
+    def gates_required(self) -> tuple[str, ...]:
+        return tuple(r.gate_id for r in self.rules if r.enforcement == "required")
+
+    @property
+    def gates_disabled(self) -> tuple[str, ...]:
+        return tuple(r.gate_id for r in self.rules if r.enforcement == "disabled")
+
+    def verify_hash(self) -> bool:
+        """Return True if self.hash matches recomputed hash of content fields."""
+        return self.hash == _compute_bundle_hash(self)
+
+
+def _compute_bundle_hash(bundle: PolicyBundle) -> str:
+    """Compute SHA-256 over all ratification-relevant fields.
+
+    Excludes: hash (the field being computed).
+    """
+    content = bundle.to_dict(mode="db", exclude={"hash", "permission_policy"})
+    content["permission_policy"] = {
+        "mode": bundle.permission_policy.mode,
+        "allow": bundle.permission_policy.allow,
+        "deny": bundle.permission_policy.deny,
+        "escalate": bundle.permission_policy.escalate,
+    }
+    serialized = json.dumps(content, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(serialized.encode()).hexdigest()
+```
+
+### 2. `PolicyScope` — specificity scoring
+
+`PolicyScope` encodes where a policy applies and scores its specificity. The scoring follows
+lex specialis: a policy scoped to a specific resource (tool_id) is more specific than one scoped
+to a role, which is more specific than one scoped to a tenant, which is more specific than a
+global default.
+
+```python
+class PolicyScope(Element):
+    """Describes the scope at which a policy applies and its specificity score.
+
+    Specificity scoring (most to least specific):
+        resource  → 3  (applies to a specific tool_id)
+        role      → 2  (applies to agents with a named role)
+        tenant    → 1  (applies to all agents in a tenant)
+        global    → 0  (applies everywhere; baseline default)
+
+    scope_value is the matched identifier:
+        resource:  the tool_id
+        role:      the role name (e.g. "reviewer")
+        tenant:    the tenant_id (e.g. "acme")
+        global:    "*"
+
+    Higher specificity always wins. Ties at the highest specificity → DENY.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    _SPECIFICITY_MAP: ClassVar[dict[str, int]] = {
+        "resource": 3,
+        "role": 2,
+        "tenant": 1,
+        "global": 0,
+    }
+
+    scope_type: Literal["resource", "role", "tenant", "global"]
+    scope_value: str
+    specificity: int = Field(ge=0, le=3)   # resource=3, role=2, tenant=1, global=0
+
+    @model_validator(mode="after")
+    def _validate_specificity(self) -> "PolicyScope":
+        expected = self._SPECIFICITY_MAP[self.scope_type]
+        if self.specificity != expected:
+            raise ValueError(
+                f"PolicyScope scope_type '{self.scope_type}' requires "
+                f"specificity={expected}, got {self.specificity}"
+            )
+        return self
+```
+
+### 3. `ScopedPolicy` — a bundle bound to a scope with a validity window
+
+```python
+class ScopedPolicy(Element):
+    """A PolicyBundle bound to a PolicyScope with a validity window.
+
+    valid_from and valid_until are Unix timestamps. A ScopedPolicy is applicable
+    only when: valid_from <= at < valid_until (or valid_until is None).
+
+    policy_id uniquely identifies this scoped binding. Multiple ScopedPolicies
+    may reference the same PolicyBundle (same bundle_id) with different scopes.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    policy_id: str
+    bundle: PolicyBundle
+    scope: PolicyScope
+    valid_from: float
+    valid_until: float | None = None
+
+    def is_valid_at(self, at: float) -> bool:
+        """Return True if this policy is temporally active at timestamp `at`."""
+        if at < self.valid_from:
+            return False
+        if self.valid_until is not None and at >= self.valid_until:
+            return False
+        return True
+```
+
+### 4. `PolicyResolutionError` — the fail-closed signal
+
+```python
+class PolicyConflict(Element):
+    """Ambiguity record emitted when equally specific policies match."""
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    reason: Literal["no_applicable_policy", "specificity_tie", "hash_mismatch"]
+    conflicting_policies: Pile[ScopedPolicy] = Field(
+        default_factory=lambda: Pile(item_type=ScopedPolicy, strict_type=True)
+    )
+    detail: str
+
+
+class PolicyResolutionResult(Element):
+    """Evidence-grade result of policy resolution for one operation."""
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    operation_ref: str
+    tool_id: str
+    role: str
+    tenant_id: str
+    at: float
+    decision: PolicyDecision
+    selected_policy: ScopedPolicy | None = None
+    bundle: PolicyBundle | None = None
+    candidates: Pile[ScopedPolicy] = Field(
+        default_factory=lambda: Pile(item_type=ScopedPolicy, strict_type=True)
+    )
+    conflicts: Pile[PolicyConflict] = Field(
+        default_factory=lambda: Pile(item_type=PolicyConflict, strict_type=True)
+    )
+    evidence_refs: Pile[PolicyEvidenceRef] = Field(
+        default_factory=lambda: Pile(item_type=PolicyEvidenceRef, strict_type=True)
+    )
+
+    @property
+    def policy_version_active(self) -> str | None:
+        if self.bundle is None:
+            return None
+        return f"{self.bundle.bundle_id}@v{self.bundle.version}"
+
+
+class PolicyResolutionError(PermissionError):
+    """Raised when policy resolution cannot produce an unambiguous result.
+
+    Resolution fails for exactly three reasons:
+        1. No applicable policy exists — no matching scoped policy covers
+           the (tool_id, role, tenant_id, at) tuple.
+        2. The top-scoring candidates are tied — two or more ScopedPolicies
+           at the same (highest) specificity both match.
+        3. Bundle hash verification fails — the selected bundle has been
+           tampered with.
+
+    All three cases result in DENY (fail-closed). Callers MUST NOT proceed
+    with the operation when this exception is raised.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        result: PolicyResolutionResult | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.result = result
+```
+
+### 5. `PolicyResolver` — the resolution algorithm
+
+```python
+class PolicyResolver:
+    """Resolves scoped policies while preserving PermissionPolicy as authority.
+
+    Resolution algorithm (most-specific-wins):
+        1. Collect all ScopedPolicies whose scope matches the operation:
+               - resource match: scope.scope_type == "resource" and
+                 scope.scope_value == tool_id
+               - role match:     scope.scope_type == "role" and
+                 scope.scope_value == role
+               - tenant match:   scope.scope_type == "tenant" and
+                 scope.scope_value == tenant_id
+               - global match:   scope.scope_type == "global"
+           AND is_valid_at(at) == True.
+        2. If no candidates: raise PolicyResolutionError (no policy → deny).
+        3. Sort candidates by scope.specificity descending.
+        4. Identify the maximum specificity score among candidates.
+        5. Collect all candidates at that maximum specificity.
+        6. If more than one: raise PolicyResolutionError (tie → deny).
+        7. Verify winner.bundle.verify_hash(). If False: raise PolicyResolutionError
+           (tampered bundle → deny).
+        8. Delegate the final allow/deny/escalate decision to the selected
+           bundle.permission_policy.check().
+        9. Return a PolicyResolutionResult Element suitable for DataLogger.
+
+    Cross-cutting principle #1: ambiguity at any step → deny.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_policy: PermissionPolicy,
+        policies: Pile[ScopedPolicy] | None = None,
+        release_version: str | None = None,
+    ) -> None:
+        self.base_policy = base_policy
+        self.policies = policies or Pile(item_type=ScopedPolicy, strict_type=True)
+        self.release_version = release_version
+
+    def resolve(
+        self,
+        *,
+        tool_id: str,
+        action: str,
+        args: dict,
+        role: str,
+        tenant_id: str,
+        at: float,
+        operation_ref: str = "",
+    ) -> PolicyResolutionResult:
+        """Return the most-specific applicable result for this operation.
+
+        Args:
+            tool_id:   The identifier of the tool being called.
+            action:    The action string passed to PermissionPolicy.check().
+            args:      Tool arguments passed to PermissionPolicy.check().
+            role:      The calling agent's role.
+            tenant_id: The tenant the agent belongs to.
+            at:        Unix timestamp of the operation (use time.time()).
+
+        Returns:
+            PolicyResolutionResult containing the selected bundle and decision.
+
+        Raises:
+            PolicyResolutionError: If no policy applies, if the top candidates
+                are tied, or if the winning bundle's hash fails verification.
+        """
+        candidates = self._find_applicable(tool_id, role, tenant_id, at)
+
+        if not candidates:
+            result = PolicyResolutionResult(
+                operation_ref=operation_ref,
+                tool_id=tool_id,
+                role=role,
+                tenant_id=tenant_id,
+                at=at,
+                decision="deny",
+            )
+            raise PolicyResolutionError(
+                f"No applicable policy for tool='{tool_id}' role='{role}' "
+                f"tenant='{tenant_id}' at={at:.3f} — fail closed. "
+                "Register at least a global fallback policy.",
+                result=result,
+            )
+
+        ordered = sorted(candidates, key=lambda c: c.scope.specificity, reverse=True)
+        top_score = ordered[0].scope.specificity
+        winners = [c for c in ordered if c.scope.specificity == top_score]
+
+        if len(winners) > 1:
+            ids = ", ".join(w.policy_id for w in winners)
+            conflict = PolicyConflict(
+                reason="specificity_tie",
+                conflicting_policies=Pile(
+                    collections=winners,
+                    item_type=ScopedPolicy,
+                    strict_type=True,
+                ),
+                detail=(
+                    f"{len(winners)} policies tied at specificity={top_score}: {ids}"
+                ),
+            )
+            result = PolicyResolutionResult(
+                operation_ref=operation_ref,
+                tool_id=tool_id,
+                role=role,
+                tenant_id=tenant_id,
+                at=at,
+                decision="deny",
+                candidates=candidates,
+                conflicts=Pile(
+                    collections=[conflict],
+                    item_type=PolicyConflict,
+                    strict_type=True,
+                ),
+            )
+            raise PolicyResolutionError(
+                f"{len(winners)} policies tied at specificity={top_score} "
+                f"for tool='{tool_id}' role='{role}' tenant='{tenant_id}': "
+                f"[{ids}] — fail closed. Disambiguate by adjusting scope or "
+                "superseding one with a more-specific bundle.",
+                result=result,
+            )
+
+        winner = winners[0]
+        if not winner.bundle.verify_hash():
+            conflict = PolicyConflict(
+                reason="hash_mismatch",
+                conflicting_policies=Pile(
+                    collections=[winner],
+                    item_type=ScopedPolicy,
+                    strict_type=True,
+                ),
+                detail=(
+                    f"PolicyBundle '{winner.bundle.bundle_id}' "
+                    f"v{winner.bundle.version} hash verification failed"
+                ),
+            )
+            result = PolicyResolutionResult(
+                operation_ref=operation_ref,
+                tool_id=tool_id,
+                role=role,
+                tenant_id=tenant_id,
+                at=at,
+                decision="deny",
+                selected_policy=winner,
+                bundle=winner.bundle,
+                candidates=candidates,
+                conflicts=Pile(
+                    collections=[conflict],
+                    item_type=PolicyConflict,
+                    strict_type=True,
+                ),
+            )
+            raise PolicyResolutionError(
+                f"PolicyBundle '{winner.bundle.bundle_id}' v{winner.bundle.version} "
+                "hash verification failed — bundle may have been tampered with. "
+                "Reject and investigate before proceeding.",
+                result=result,
+            )
+
+        decision = winner.bundle.permission_policy.check(tool_id, action, args)
+        return PolicyResolutionResult(
+            operation_ref=operation_ref,
+            tool_id=tool_id,
+            role=role,
+            tenant_id=tenant_id,
+            at=at,
+            decision=decision.behavior,
+            selected_policy=winner,
+            bundle=winner.bundle,
+            candidates=candidates,
+        )
+
+    def _find_applicable(
+        self,
+        tool_id: str,
+        role: str,
+        tenant_id: str,
+        at: float,
+    ) -> Pile[ScopedPolicy]:
+        """Return all ScopedPolicies that match the operation context."""
+        matches = []
+        for sp in self.policies:
+            if not sp.is_valid_at(at):
+                continue
+            st = sp.scope.scope_type
+            sv = sp.scope.scope_value
+            if (
+                (st == "resource" and sv == tool_id)
+                or (st == "role" and sv == role)
+                or (st == "tenant" and sv == tenant_id)
+                or st == "global"
+            ):
+                matches.append(sp)
+        return Pile(collections=matches, item_type=ScopedPolicy, strict_type=True)
+
+    def to_pre_hook(self, *, branch=None):
+        """Install through AgentConfig.security_pre or Tool.preprocessor chains."""
+
+        async def policy_resolution_hook(
+            tool_name: str, action: str, args: dict
+        ) -> dict | None:
+            import time
+
+            branch_ref = branch or args.get("branch")
+            role = args.get("role", "default")
+            tenant_id = args.get("tenant_id", "global")
+            result = self.resolve(
+                tool_id=tool_name,
+                action=action,
+                args=args,
+                role=role,
+                tenant_id=tenant_id,
+                at=time.time(),
+                operation_ref=args.get("operation_ref", ""),
+            )
+
+            if branch_ref is not None:
+                # Branch managers are the integration point:
+                # ActionManager supplies the tool registry, iModelManager supplies
+                # active model identity, and DataLogger records the Element result.
+                _ = branch_ref.acts.registry.get(tool_name)
+                model_name = getattr(branch_ref.chat_model, "model", None)
+                if result.bundle and result.bundle.allowed_models:
+                    if model_name not in result.bundle.allowed_models:
+                        raise PermissionError(
+                            f"Model '{model_name}' is not allowed by "
+                            f"{result.policy_version_active}"
+                        )
+                branch_ref.metadata["policy_version_active"] = (
+                    result.policy_version_active
+                )
+                branch_ref._log_manager.log(result)
+
+            if result.decision == "allow":
+                return None
+            if result.decision == "escalate":
+                raise PermissionError(
+                    f"Permission escalation required under "
+                    f"{result.policy_version_active}"
+                )
+            raise PermissionError(
+                f"Permission denied under {result.policy_version_active}"
+            )
+
+        return policy_resolution_hook
+```
+
+### 6. `PolicyRelease` — staged rollout lifecycle
+
+A `PolicyRelease` bundles one or more `ScopedPolicy` records with a version and a status. The
+status lifecycle gates deployment: a release does not affect production sessions until it reaches
+`ACTIVE`. Sessions pin their release version at start; a release transitioning from `ROLLING` to
+`ACTIVE` mid-session does not apply to already-running sessions.
+
+```python
+ReleaseStatus = Literal["DRAFT", "CANARY", "ROLLING", "ACTIVE", "SUPERSEDED"]
+
+
+class PolicyRelease(Element):
+    """A versioned, staged release of a set of ScopedPolicies.
+
+    Status lifecycle:
+        DRAFT     → authored, not yet deployed to any sessions
+        CANARY    → active for <5% of new sessions (opt-in or random sample)
+        ROLLING   → active for a named tenant group (explicit list)
+        ACTIVE    → global default; applies to all new sessions
+        SUPERSEDED → replaced by a newer release; no new sessions pin to this
+
+    Pinning rule: a session records release_version at start. The PolicyResolver
+    for that session is constructed from the bundles in that specific release.
+    Transitions after session start (CANARY → ROLLING, ROLLING → ACTIVE) do not
+    affect already-running sessions.
+
+    Attributes:
+        release_id:       Unique identifier for this release.
+        release_version:  Human-readable version string (e.g. "2026.05.1").
+        status:           Current lifecycle stage.
+        policies:         The ScopedPolicies included in this release.
+        canary_tenant_ids: Tenants opted into CANARY stage (empty = random 5%).
+        rolling_tenant_ids: Tenants in the ROLLING cohort.
+        released_at:      Unix timestamp of transition to CANARY or later.
+        superseded_by:    release_id of the successor, once SUPERSEDED.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    release_id: str
+    release_version: str
+    status: ReleaseStatus
+    policies: Pile[ScopedPolicy] = Field(
+        default_factory=lambda: Pile(item_type=ScopedPolicy, strict_type=True)
+    )
+    canary_tenant_ids: tuple[str, ...]
+    rolling_tenant_ids: tuple[str, ...]
+    released_at: float | None
+    superseded_by: str | None = None
+
+    def resolver_for(
+        self,
+        tenant_id: str,
+        *,
+        base_policy: PermissionPolicy,
+    ) -> PolicyResolver | None:
+        """Return a PolicyResolver if this release applies to tenant_id.
+
+        Returns None if the release is DRAFT or SUPERSEDED, or if the tenant
+        is not yet in scope for the current status (e.g. not in canary cohort
+        when status is CANARY).
+        """
+        if self.status in ("DRAFT", "SUPERSEDED"):
+            return None
+        if self.status == "CANARY":
+            if self.canary_tenant_ids and tenant_id not in self.canary_tenant_ids:
+                return None
+        elif self.status == "ROLLING":
+            if tenant_id not in self.rolling_tenant_ids:
+                return None
+        return PolicyResolver(
+            base_policy=base_policy,
+            policies=self.policies,
+            release_version=self.release_version,
+        )
+```
+
+### 7. Operation Context capture
+
+When `PolicyResolver.resolve()` succeeds, the resolved `bundle_id` and `bundle.version` are
+written into `OperationContext.policy_version_active` (ADR-0050). Every evidence node (ADR-0041)
+emitted during the operation carries this value in its metadata. Auditors can reconstruct the
+exact policy that governed any historical operation by looking up that bundle version in the
+policy store.
+
+```python
+# lionagi/agent/governance/policy.py
+
+from lionagi.agent.config import AgentConfig
+from lionagi.agent.permissions import PermissionPolicy
+from lionagi.session.branch import Branch
+
+
+def attach_policy_release(
+    *,
+    config: AgentConfig,
+    branch: Branch,
+    release: PolicyRelease,
+    tenant_id: str,
+    base_policy: PermissionPolicy,
+) -> PolicyResolver | None:
+    """Attach policy resolution through the existing hook and manager surfaces."""
+    resolver = release.resolver_for(tenant_id, base_policy=base_policy)
+    if resolver is None:
+        return None
+
+    hook = resolver.to_pre_hook(branch=branch)
+    config.hook_handlers.setdefault("security_pre:*", []).insert(0, hook)
+
+    # Existing Branch managers remain authoritative:
+    # - MessageManager carries policy metadata on operation messages.
+    # - ActionManager provides the registered tool set the hook guards.
+    # - iModelManager provides the active model identity checked by the hook.
+    # - DataLogger receives PolicyResolutionResult Element records.
+    branch.metadata["policy_release_version"] = release.release_version
+    branch.metadata["policy_version_active"] = None
+    branch.on_message_added.append(
+        lambda message: message.metadata.setdefault(
+            "policy_release_version", release.release_version
+        )
+    )
+    return resolver
+```
+
+### 8. Resolution algorithm — summary table
+
+| Step | Action | On failure |
+|------|--------|------------|
+| 1 | Collect all ScopedPolicies matching (tool_id, role, tenant_id) with is_valid_at(at) | → step 2 |
+| 2 | If no candidates | → DENY (PolicyResolutionError: "no applicable policy") |
+| 3 | Sort by scope.specificity descending | — |
+| 4 | Identify max specificity score | — |
+| 5 | Collect all candidates at max score | → step 6 |
+| 6 | If more than one winner | → DENY (PolicyResolutionError: "ambiguous tie") |
+| 7 | Verify winner.bundle.verify_hash() | → DENY (PolicyResolutionError: "tampered bundle") |
+| 8 | Return winner.bundle | — |
+
+### 9. Library mode vs. KHive mode
+
+In library mode (open-source lionagi, single-agent, no multi-tenant deployment), policy
+resolution is trivial: the `AgentConfig.permissions` in use constitutes the single applicable
+policy. There is no `PolicyResolver`; the `PermissionPolicy` allowlist/denylist/confirm logic
+continues to apply directly. `OperationContext.policy_version_active` is `None` or a
+config-derived string.
+
+The full `PolicyResolver`, `PolicyRelease`, and staged rollout machinery is KHive territory:
+it becomes necessary when multiple tenants share a deployment and policies must be versioned,
+staged, and audited across organizational boundaries. The protocol (schemas and resolution
+algorithm above) is the same in both modes; the resolver is more sophisticated in KHive.
+
+### 10. Worked example
+
+An agent in `tenant=acme`, `role=reviewer`, calls `tool=write_pr` at Unix timestamp `t`.
+The active `PolicyRelease` contains four `ScopedPolicy` records:
+
+| policy_id | scope_type | scope_value | specificity | bundle_id |
+|-----------|------------|-------------|-------------|-----------|
+| `global-read-only` | global | `*` | 0 | `read_only` |
+| `acme-reviewers-comment` | tenant | `acme` | 1 | `reviewers_can_comment` |
+| `role-reviewer-no-merge` | role | `reviewer` | 2 | `reviewers_can_comment_no_merge` |
+| `tool-write-pr-jit` | resource | `write_pr` | 3 | `write_pr_requires_jit` |
+
+All four match the operation context. Sorted by specificity descending:
+`tool-write-pr-jit` (3), `role-reviewer-no-merge` (2), `acme-reviewers-comment` (1),
+`global-read-only` (0).
+
+Maximum specificity = 3. Only one candidate at that score: `tool-write-pr-jit`. Hash verified.
+
+Resolution result: `write_pr_requires_jit` applies. The gates declared in that bundle run
+(including the JIT grant gate from ADR-0046). `OperationContext.policy_version_active` is set
+to `"write_pr_requires_jit@v3"`. The other three bundles remain authoritative for operations
+they are most-specific for.
+
+### 11. Two-Key Model — enforcement
+
+The structural separation in `PolicyBundle.__post_init__` (`authored_by != implemented_by`) is
+a construction-time check. The policy authorship record is stored in the bundle and covered by
+`bundle.hash`. Any post-creation modification that changes either authorship field or any gate
+list is detectable via `verify_hash()` before the bundle is used.
+
+Operationally, Two-Key means:
+
+- A policy author can declare `gates_required: ["gate_write_pr_approval"]` in a bundle. They
+  cannot ship that gate or modify its logic.
+- A gate implementer can register `gate_write_pr_approval` in the gate registry (ADR-0044).
+  They cannot include or exclude it from a bundle's `gates_required`.
+- A bundle that lists a gate not present in the gate registry is rejected at the same point
+  as a Charter with an unresolvable `gate_id` (ADR-0047, section 4).
+
+## Consequences
+
+**Positive**
+
+- Deterministic resolution: any (tool_id, role, tenant_id, at) tuple resolves to exactly one
+  bundle or raises. Order of policy registration has no effect on the outcome.
+- Fail-closed by construction: every resolution failure path raises `PolicyResolutionError`,
+  which callers must handle. There is no "default permit" fallback.
+- Audit-grade traceability: `OperationContext.policy_version_active` and evidence node metadata
+  record the exact policy bundle in force. Reconstructing governance history requires only the
+  policy store and the operation context.
+- Staged rollback: a bad release transitions from `ACTIVE` to `SUPERSEDED` and a prior release
+  is re-activated. Sessions that pinned to the bad release complete under it (or abort); new
+  sessions pin to the restored release.
+- Two-Key separation: no single actor can produce a valid, deployed bundle that both declares
+  a constraint and ships its enforcement. The hash makes that separation tamper-evident.
+
+**Negative**
+
+- Resolution complexity: operators must reason about scope levels and avoid accidental ties.
+  Two resource-level policies for the same tool_id will always produce a DENY-on-tie until one
+  is superseded or scoped differently.
+- Ambiguity burden is on policy authors: the DENY-on-tie rule is conservative. Legitimate
+  scenarios that happen to tie require explicit disambiguation, which may require a release cycle.
+- Multiple active versions: during CANARY and ROLLING stages, different tenants run against
+  different policy versions. The policy store and audit tooling must support querying by
+  bundle version, not just by current state.
+- Two-Key coordination overhead: policy authors and gate implementers must coordinate each
+  release. A bundle referencing a gate not yet registered blocks the release from advancing
+  past DRAFT.
+
+## Non-Goals
+
+Explicitly out of scope:
+
+- **Full conflict resolution with weights or priorities**: only specificity rank determines the
+  winner. Weighted scoring, confidence-adjusted merging, or partial policy application are not
+  supported. If weights are needed, supersede the lower-specificity policy with a new bundle
+  at a higher specificity scope.
+- **Automatic policy generation from regulations**: tooling that reads GDPR or HIPAA text and
+  produces `PolicyBundle` records is a product concern, not a framework concern.
+- **Cross-tenant policy inheritance**: a policy defined at the global level that automatically
+  specializes for each tenant. This is a KHive concern addressed in the multi-tenant resolver
+  layer. The open-source framework has no tenant hierarchy.
+- **Runtime policy mutation**: a running session cannot modify its own policy. All changes must
+  go through the release lifecycle (DRAFT → CANARY → ROLLING → ACTIVE) and apply only to
+  sessions starting after the release reaches the applicable stage.
+- **Policy composition or merging**: combining two bundles' `gates_required` lists into a
+  synthetic bundle is not supported. Each bundle is the atomic governance unit; composition
+  would re-introduce the conflict resolution problem this ADR solves.
+- **Automatic release promotion**: advancing a release from CANARY to ROLLING to ACTIVE requires
+  explicit human action (or an external approval gate). Automated promotion based on error rates
+  is a deployment platform concern, not a framework concern.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| First-match wins | Resolution depends on registration order. Two deployments with identically scoped policies but different registration sequences produce different results. Non-deterministic; not audit-defensible. |
+| Confidence-weighted merging | Assigns weights to each applicable policy and blends the result. Introduces a scoring function that is itself a policy decision, is difficult to audit, and violates the fail-closed principle — partial application of a policy that would deny is effectively a permit. |
+| Single global policy (current state) | `AgentConfig.permissions` is a single flat policy per agent with no versioning and no scope hierarchy. Adequate for library mode; rejected for multi-agent, multi-tenant deployments where role and resource overrides are required. |
+| Most-specific-wins with permit-on-tie | The alternative to DENY-on-tie. Rejected because a tie indicates two equally-authoritative policies disagree. Picking one arbitrarily is non-deterministic. Denying forces policy authors to resolve the ambiguity explicitly, which is the correct outcome. |
+
+## References
+
+- [ADR-0041](ADR-0041-immutable-evidence-nodes.md) — SHA-256 hash-chain pattern; `PolicyBundle.hash` follows the same construction
+- [ADR-0042](ADR-0042-task-certificate.md) — Task Certificate records the active policy version as part of the proof artifact
+- [ADR-0044](ADR-0044-tool-gates.md) — `PolicyBundle.gates_required` references gate_ids from this registry; a bundle listing an absent gate is rejected
+- [ADR-0045](ADR-0045-break-glass-protocol.md) — break-glass sessions resolve against a named policy bundle for DEGRADED defensibility
+- [ADR-0046](ADR-0046-jit-tool-grant.md) — JIT grant gates appear in `PolicyBundle.gates_required`; the worked example shows `write_pr_requires_jit`
+- [ADR-0047](ADR-0047-agent-charter.md) — `AgentCharter.policy_release_version` pins the charter to a specific release; the charter is the session-binding vehicle
+- [ADR-0050](ADR-0050-operation-context.md) — `OperationContext.policy_version_active` records the resolved bundle; evidence nodes carry this field
+- [ADR-0051](ADR-0051-tool-registry-allowlists.md) — `PolicyBundle.registry_scope` selects which tool registry scope governs tool access
+- [ADR-0033](ADR-0033-unified-entity-state-model.md) — EvidenceRef 8 kinds; `PolicyBundle.allowed_evidence_kinds` is a subset of these
+- `lionagi/agent/config.py` — `AgentConfig` and `PermissionPolicy`; library-mode policy remains here
+- prior governance research `01_design/011-policy-resolution/ADR-011-policy-resolution.md` — lex specialis, deny-by-default, resource > role > tenant hierarchy
+- prior governance research `01_design/017-policy-release/ADR-017-policy-release.md` — staged rollout (CANARY → TENANT_GROUP → GLOBAL), Two-Key Model, immutable releases

--- a/docs/adrs/ADR-0052-policy-resolution.md
+++ b/docs/adrs/ADR-0052-policy-resolution.md
@@ -1,6 +1,6 @@
 # ADR-0052: Policy Resolution and Staged Release
 
-**Status**: Proposed
+**Status**: proposed
 **Date**: 2026-05-26
 **Depends on**: [ADR-0044](ADR-0044-tool-gates.md) (policies select which gates run), [ADR-0047](ADR-0047-agent-charter.md) (charter pins policy_release_version), [ADR-0050](ADR-0050-operation-context.md) (active policy version captured in operation evidence), [ADR-0051](ADR-0051-tool-registry-allowlists.md) (registry entries are policy-scoped)
 **Related**: [ADR-0041](ADR-0041-immutable-evidence-nodes.md) (bundle hash follows the same SHA-256 pattern), [ADR-0042](ADR-0042-task-certificate.md) (certificate records active policy version), [ADR-0045](ADR-0045-break-glass-protocol.md) (break-glass resolves against a named policy), [ADR-0046](ADR-0046-jit-tool-grant.md) (JIT grants are policy-scoped)

--- a/docs/adrs/ADR-0053-artifact-persistence.md
+++ b/docs/adrs/ADR-0053-artifact-persistence.md
@@ -1,0 +1,407 @@
+# ADR-0053: Artifact Persistence in State Database
+
+Status: proposed (rewrite after rejected review)
+Date: 2026-05-27
+Decision owners: @governance-maintainers
+Depends on: ADR-0059 (StateStore protocol)
+Related: ADR-0021 (structured artifacts), ADR-0029 (artifact contracts), ADR-0041 (immutable evidence nodes), ADR-0050 (operation context), ADR-0055 (Studio artifact viewer)
+
+## Context
+
+lionagi currently has a useful filesystem artifact protocol and a separate structured-artifact table, but the two do not form one evidence-grade artifact model.
+
+The filesystem side is run-scoped. `RunDir` records an authoritative state root and a user-facing `artifact_root` (`lionagi/cli/_runs.py:70`), then derives agent artifact directories with explicit containment checks (`lionagi/cli/_runs.py:104`). `FlowAgent.id` and `FlowOp.id` are validated because they become path segments under `artifact_root` (`lionagi/cli/orchestrate/flow.py:193`). At runtime each worker is instructed to write files into its agent directory (`lionagi/cli/orchestrate/flow.py:1038`), `_record_result()` writes `{op_id}.md` files (`lionagi/cli/orchestrate/flow.py:1113`), and synthesis writes `synthesis.md` before finalization (`lionagi/cli/orchestrate/flow.py:1601`). This gives agents and users real files, which remains necessary.
+
+The database side is structured-outcome oriented. The current `artifacts` table contains `id`, parent IDs, timestamps, `kind`, `name`, JSON `content`, and optional `file_path` (`lionagi/state/schema.sql:485`). It also has natural-key unique indexes for stable structured upserts (`lionagi/state/schema.sql:497`) and `StateDB.insert_artifact()` selects an existing natural key, updates it in place, and returns the stable ID (`lionagi/state/db.py:1658`). Studio exposes `GET /api/artifacts/{artifact_id}` and `GET /api/artifacts/by-session/{session_id}` over those rows (`apps/studio/server/routers/artifacts.py:22`).
+
+Those two behaviors are both valid, but they must not be conflated. Stable upsert is appropriate for structured skill outcomes where "the current verdict for this invocation" is the object being addressed. It is not appropriate for file captures that may later become evidence. If a file row is overwritten because a path was scanned again, the evidence chain loses the previous bytes, hash, size, and preview body. The governance direction makes that unacceptable: the platform is explicitly built around immutable evidence nodes, SHA-256 hash chains, artifact contracts, and run-end certificates (`docs/governance/direction.md:40`, `docs/governance/direction.md:50`).
+
+The prior ADR-0053 draft failed because it kept file artifacts mutable by natural key while ADR-0055 independently introduced a different file schema and versioning model. This rewrite makes ADR-0053 the single owner of artifact storage. ADR-0055 may render, resolve, and stream artifacts, but it must consume this schema without adding columns.
+
+The current Studio auth middleware also matters to this ADR because artifact persistence creates a sensitive read surface. When `LIONAGI_STUDIO_AUTH_TOKEN` is set, the existing middleware gates admin GET requests and mutating API methods, but non-admin artifact GET routes are not covered by that rule (`apps/studio/server/app.py:52`). Persisted artifacts may contain source code, credentials accidentally written by agents, customer data, or private model outputs. Artifact reads must therefore be authenticated in the same release that makes file bodies readable from Studio.
+
+## Decision
+
+Persist artifacts through one canonical `artifacts` row shape owned by this ADR. The table supports two insertion paths with different identity semantics:
+
+1. `insert_artifact()` for structured outcomes keeps ADR-0021 stable-upsert behavior.
+2. `insert_file_artifact()` for file captures is append-only. It never natural-key upserts and never mutates an existing file artifact row.
+
+The filesystem remains the working medium and user export target. The database becomes the durable metadata, hash, preview, and evidence index. Large bodies live in content-addressed blob storage, referenced by a relative blob key.
+
+### Canonical Artifact Schema
+
+ADR-0053 owns these columns. Other ADRs must not redefine or extend the artifact row shape without superseding this ADR.
+
+```sql
+CREATE TABLE IF NOT EXISTS artifacts (
+  id             TEXT    PRIMARY KEY,
+  session_id     TEXT    REFERENCES sessions(id),
+  invocation_id  TEXT    REFERENCES invocations(id) ON DELETE CASCADE,
+  op_id          TEXT,
+  kind           TEXT    NOT NULL,
+  name           TEXT    NOT NULL,
+  content        JSON    NOT NULL,
+  file_path      TEXT,
+  sha256         TEXT,
+  size_bytes     INTEGER,
+  media_type     TEXT,
+  rel_path       TEXT,
+  source_kind    TEXT    NOT NULL DEFAULT 'structured'
+                  CHECK(source_kind IN ('structured', 'inline', 'blob', 'filesystem')),
+  created_at     REAL    NOT NULL,
+  updated_at     REAL    NOT NULL
+);
+```
+
+Column meanings:
+
+- `id`: opaque row ID. Evidence and certificates reference this value plus `sha256`.
+- `session_id`: session/run owner when known.
+- `invocation_id`: skill or orchestration invocation owner when known.
+- `op_id`: Flow operation that produced a file capture, when known.
+- `kind`: renderer and policy discriminator, for example `doc`, `research`, `diff`, `log`, `data`, `verdict`, or `unknown`.
+- `name`: display and natural-key name. Structured outcomes keep their existing names. File captures use `{rel_path}@{sha256[:12]}`.
+- `content`: JSON metadata and optional inline body.
+- `file_path`: relative content-addressed blob key for blob-backed artifacts, never a host absolute path for new rows.
+- `sha256`: SHA-256 of the captured file bytes.
+- `size_bytes`: captured byte count.
+- `media_type`: detected MIME type, for example `text/markdown` or `application/json`.
+- `rel_path`: normalized POSIX artifact path relative to the run artifact root.
+- `source_kind`: `structured` for ADR-0021 outcomes, `inline` for file rows with body in `content`, `blob` for file rows backed by `file_path`, and `filesystem` only for explicit legacy imports.
+- `created_at`: row creation time.
+- `updated_at`: equals `created_at` for file artifact rows; changes only for structured outcome upserts.
+
+No `source_path` column is added. If provenance needs to record where a source file came from, it may place `project_rel_path` inside `content.source` only when the path can be expressed relative to the detected project root. Absolute paths are server-internal only and must not be stored in new artifact rows or returned by API responses.
+
+### Identity And Immutability
+
+File artifact rows are immutable. `insert_file_artifact()` always mints a new `id`, inserts a row, and returns that ID. It does not call `_find_artifact_id()`, does not update rows by `(session_id, kind, name)`, and does not treat repeated scans as idempotent. If the same file bytes are captured twice, the rows may share `rel_path`, `name`, `sha256`, and `file_path`; row identity still records that two captures happened.
+
+The version display key for file artifacts is:
+
+```python
+name = f"{rel_path}@{sha256[:12]}"
+```
+
+The append-only invariant is the evidence property. A later evidence node or certificate can cite `(artifact_id, sha256, size_bytes)` without worrying that a path-based rescan replaced the row body.
+
+Structured outcomes keep stable upsert semantics for compatibility with ADR-0021. `insert_artifact()` may update `content`, `file_path`, and `updated_at` for `source_kind='structured'` rows because those rows represent the current structured result, not a captured file version. Structured rows must not be used as immutable file evidence unless first copied through `insert_file_artifact()`.
+
+### Indexes
+
+The existing natural-key unique indexes must become structured-only. File artifact rows need lookup indexes, not uniqueness constraints.
+
+```sql
+CREATE UNIQUE INDEX IF NOT EXISTS idx_artifacts_struct_inv_only
+  ON artifacts(invocation_id, kind, name)
+  WHERE source_kind = 'structured'
+    AND invocation_id IS NOT NULL
+    AND session_id IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_artifacts_struct_ses_only
+  ON artifacts(session_id, kind, name)
+  WHERE source_kind = 'structured'
+    AND session_id IS NOT NULL
+    AND invocation_id IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_artifacts_struct_both
+  ON artifacts(invocation_id, session_id, kind, name)
+  WHERE source_kind = 'structured'
+    AND invocation_id IS NOT NULL
+    AND session_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_artifacts_struct_unattached
+  ON artifacts(kind, name)
+  WHERE source_kind = 'structured'
+    AND invocation_id IS NULL
+    AND session_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_artifacts_session_rel_path_time
+  ON artifacts(session_id, rel_path, created_at DESC)
+  WHERE session_id IS NOT NULL AND rel_path IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_artifacts_invocation_rel_path_time
+  ON artifacts(invocation_id, rel_path, created_at DESC)
+  WHERE invocation_id IS NOT NULL AND rel_path IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_artifacts_op_id
+  ON artifacts(op_id) WHERE op_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_artifacts_sha256
+  ON artifacts(sha256) WHERE sha256 IS NOT NULL;
+```
+
+Migration must drop the old four natural-key indexes before creating the structured-only replacements. New file rows must not be blocked by a uniqueness constraint on `(session_id, kind, name)`.
+
+### Python Interfaces
+
+Add `lionagi/state/artifacts.py` for collection and payload construction:
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, TypedDict
+
+ArtifactKind = Literal[
+    "code",
+    "test",
+    "doc",
+    "research",
+    "verdict",
+    "synthesis",
+    "config",
+    "diff",
+    "log",
+    "data",
+    "unknown",
+]
+
+SourceKind = Literal["structured", "inline", "blob", "filesystem"]
+
+class ArtifactContent(TypedDict, total=False):
+    body: str
+    frontmatter: dict[str, Any]
+    encoding: str
+    line_count: int
+    truncated: bool
+    language: str
+    source: dict[str, str]
+
+@dataclass(frozen=True, slots=True)
+class FileArtifactCapture:
+    session_id: str
+    invocation_id: str | None
+    op_id: str | None
+    kind: ArtifactKind
+    name: str
+    content: ArtifactContent
+    file_path: str | None
+    sha256: str
+    size_bytes: int
+    media_type: str
+    rel_path: str
+    source_kind: Literal["inline", "blob", "filesystem"]
+
+@dataclass(frozen=True, slots=True)
+class ArtifactPersistenceConfig:
+    inline_max_bytes: int = 1_048_576
+    capture_mode: Literal["off", "expected", "all"] = "all"
+    blob_root: Path | None = None
+    include_globs: tuple[str, ...] = ("**/*",)
+    exclude_globs: tuple[str, ...] = (
+        "**/.git/**",
+        "**/__pycache__/**",
+        "**/.DS_Store",
+        "**/*.pyc",
+    )
+
+def build_file_artifact(
+    path: Path,
+    *,
+    artifact_root: Path,
+    project_root: Path | None,
+    session_id: str,
+    invocation_id: str | None,
+    op_id: str | None,
+    config: ArtifactPersistenceConfig,
+) -> FileArtifactCapture:
+    """Validate, hash, classify, inline or blob-route one regular file."""
+
+def collect_file_artifacts(
+    *,
+    artifact_root: Path,
+    project_root: Path | None,
+    session_id: str,
+    invocation_id: str | None,
+    op_id: str | None,
+    config: ArtifactPersistenceConfig,
+    changed_paths: list[Path] | None = None,
+) -> list[FileArtifactCapture]:
+    """Return safe file captures under artifact_root."""
+```
+
+Extend `StateDB` and the ADR-0059 `StateStore` protocol with two explicit write paths:
+
+```python
+async def insert_artifact(
+    self,
+    *,
+    kind: str,
+    name: str,
+    content: dict[str, Any],
+    invocation_id: str | None = None,
+    session_id: str | None = None,
+    file_path: str | None = None,
+) -> str:
+    """Upsert one structured outcome and return its stable id."""
+
+async def insert_file_artifact(
+    self,
+    *,
+    session_id: str,
+    invocation_id: str | None,
+    op_id: str | None,
+    kind: str,
+    rel_path: str,
+    content: dict[str, Any],
+    file_path: str | None,
+    sha256: str,
+    size_bytes: int,
+    media_type: str,
+    source_kind: Literal["inline", "blob", "filesystem"],
+) -> str:
+    """Append one immutable file artifact row and return its new id."""
+```
+
+`insert_file_artifact()` validates `rel_path`, computes `name`, sets `created_at == updated_at`, and rejects absolute `file_path` values. Blob-backed rows store only a relative blob key. The blob root is resolved by server-side configuration and is not part of the public row contract.
+
+### Orchestration Integration
+
+Add a narrow helper around the live-persist context:
+
+```python
+async def persist_run_artifacts(
+    env: OrchestrationEnv,
+    *,
+    op_id: str | None = None,
+    changed_paths: list[Path] | None = None,
+) -> list[str]:
+    """Collect safe files under env.run.artifact_root and append file rows."""
+```
+
+`flow.py` should call this helper after `_record_result()` writes the operation Markdown file, after synthesis writes `synthesis.md`, and once during teardown as a catch-up scan. The helper is best-effort: failures are logged and do not override run status. ADR-0029 remains the authority for failing a run because required artifacts are missing.
+
+The helper should use the open live-persist database connection when available. If live persistence is disabled, artifact DB capture is disabled for that run rather than opening an unrelated state connection with partial context.
+
+## Implementation
+
+### Phase 0: Schema Contract And Migration (180-260 LOC)
+
+Files:
+
+- `lionagi/state/schema.sql`: add canonical columns, structured-only unique indexes, and file lookup indexes. Estimated 60-90 LOC.
+- `lionagi/state/db.py`: add migration columns, drop/replace old artifact natural-key indexes, and include new fields in row serialization. Estimated 90-130 LOC.
+- ADR-0059 follow-up: mirror the same columns and method signatures in the `StateStore` protocol and Postgres DDL. Estimated 30-40 LOC in that ADR's implementation surface.
+
+Exit criteria:
+
+- Fresh SQLite databases contain exactly the ADR-0053 artifact columns.
+- Existing databases open successfully and gain nullable columns.
+- Old structured artifacts remain readable and keep stable upsert behavior.
+- File rows are not constrained by the old natural-key unique indexes.
+
+### Phase 1: Collector And Blob Routing (420-620 LOC)
+
+Files:
+
+- `lionagi/state/artifacts.py`: path validation, symlink containment, hashing, MIME detection, frontmatter parsing, inline thresholding, relative blob-key creation, and payload construction. Estimated 260-380 LOC.
+- `tests/state/test_artifact_collector.py`: unit coverage for safe paths, excluded files, binary/text behavior, deterministic hashing, and project-relative provenance. Estimated 160-240 LOC.
+
+Exit criteria:
+
+- Absolute paths, parent traversal, symlink escapes, device files, sockets, directories, `.git`, and excluded files are not captured.
+- Text files at or below the inline threshold get `content.body`.
+- Large or binary files get a relative blob key and no body.
+- No absolute host path appears in `content`, `file_path`, or serialized rows.
+
+### Phase 2: StateDB Insert Paths (220-340 LOC)
+
+Files:
+
+- `lionagi/state/db.py`: implement `insert_file_artifact()`, keep `insert_artifact()` structured-only, and add lookup helpers used by Studio. Estimated 140-220 LOC.
+- `tests/state/test_db_artifacts.py`: verify structured upsert, append-only file insertion, repeated same-content scans, timestamp semantics, and row serialization. Estimated 80-120 LOC.
+
+Exit criteria:
+
+- `insert_artifact()` updates a structured row and preserves its ID.
+- `insert_file_artifact()` always inserts a new row.
+- Repeated file captures with the same `rel_path` and `sha256` produce distinct IDs.
+- File row `updated_at` equals `created_at`.
+
+### Phase 3: Flow Capture (220-340 LOC)
+
+Files:
+
+- `lionagi/cli/orchestrate/_orchestration.py`: add `persist_run_artifacts()` and config loading. Estimated 90-140 LOC.
+- `lionagi/cli/orchestrate/flow.py`: call persistence after operation result writes, synthesis writes, and final catch-up. Estimated 50-80 LOC.
+- `tests/cli/test_flow_artifact_persistence.py`: run a small flow and assert disk file, DB row, hash, size, and inline body. Estimated 80-120 LOC.
+
+Exit criteria:
+
+- Flow still writes the same files to `artifact_root`.
+- New runs append DB file artifact rows for operation Markdown and synthesis files.
+- Capture failure logs a warning without masking ADR-0029 missing-artifact failures.
+- `LIONAGI_ARTIFACT_CAPTURE_MODE=off` disables DB file capture.
+
+### Phase 4: Backfill And Governance References (300-460 LOC)
+
+Files:
+
+- `lionagi/cli/state.py` or the existing state CLI surface: add `li state artifacts backfill --run <id>` and `--all`. Estimated 120-180 LOC.
+- `lionagi/state/artifact_verifier.py`: include matching `artifact_id`, `sha256`, and `size_bytes` in produced artifact verification results. Estimated 60-90 LOC.
+- Future evidence/certificate modules after ADR-0041/ADR-0042: consume artifact refs without changing this schema. Estimated 60-90 LOC.
+- Tests for backfill and verifier linkage. Estimated 60-100 LOC.
+
+Exit criteria:
+
+- Backfill inserts append-only rows and never mutates historical rows.
+- Artifact verification can cite durable artifact IDs for present files.
+- Evidence code has stable inputs: `artifact_id`, `sha256`, and `size_bytes`.
+
+## Security
+
+Artifact persistence copies agent-produced data into durable storage, so the security floor is part of this ADR, not a later UI concern.
+
+All artifact routes require bearer auth when `LIONAGI_STUDIO_AUTH_TOKEN` is set. This includes metadata, list, preview, raw/blob download, and reference-resolution routes. The current middleware's admin-GET and mutating-method rule is insufficient for artifacts because `GET /api/artifacts/{id}` exposes sensitive run data.
+
+API responses must never expose host absolute paths. New rows store `rel_path` and relative blob keys only. Legacy absolute `file_path` values may exist from older structured artifacts; Studio must redact or omit them unless it can transform them into a safe public relative display path.
+
+Path safety is mandatory during collection and backfill. The collector persists only regular files whose resolved path remains under `artifact_root`. It rejects absolute candidate paths, parent traversal, symlink escapes, NUL bytes, glob metacharacters where relevant, hidden control directories, and non-regular files. This follows the containment posture already used by `RunDir.agent_artifact_dir()` and Studio's path safety utilities.
+
+Blob integrity is checked with SHA-256. Blob-backed reads must verify the blob bytes against `sha256`; mismatch is a corruption error, not a partial success. Integrity is not the same as tamper-proof storage: local users can still edit SQLite or blobs. ADR-0041 evidence chains and later certificate signing provide tamper-evident packaging. This ADR supplies immutable file rows and content hashes for those systems.
+
+Secret detection is out of scope for Phase 0. Agents may write secrets or customer data into artifacts. Capture can be disabled or narrowed, but if artifact capture is enabled, the resulting DB and blob store must be treated as sensitive run output.
+
+Availability is bounded by best-effort writes. Hashing and blob copy failures log warnings and preserve normal run finalization. Required-artifact failure remains owned by ADR-0029 verification.
+
+## Migration
+
+1. Add nullable columns for `op_id`, `sha256`, `size_bytes`, `media_type`, `rel_path`, and `source_kind`; add `updated_at` where missing.
+2. Backfill `source_kind='structured'` for existing rows.
+3. Drop the existing four natural-key unique indexes on all artifacts and recreate them with `source_kind='structured'` predicates.
+4. Add file lookup indexes on `(session_id, rel_path, created_at DESC)`, `(invocation_id, rel_path, created_at DESC)`, `op_id`, and `sha256`.
+5. Keep `insert_artifact()` compatible for ADR-0021 callers.
+6. Add `insert_file_artifact()` and route all file captures through it.
+7. New runs dual-write files to disk and append file rows to `artifacts`.
+8. Historical runs are imported with an explicit backfill command. Backfill is append-only and may create multiple rows for the same path and hash.
+9. Studio consumes this schema through ADR-0055 and must not add artifact columns.
+
+## Alternatives Considered
+
+### Alternative 1: Keep Files Filesystem-Only
+
+This keeps implementation small and preserves current CLI behavior. It fails remote Studio, search, audit, and certificate use cases because evidence would point at mutable local paths. Rejected.
+
+### Alternative 2: Upsert File Artifacts By Relative Path
+
+This avoids duplicate rows and makes "latest by path" trivial. It destroys history when a file changes and contradicts the evidence model. Rejected.
+
+### Alternative 3: Store Every File Body Inline
+
+This simplifies reads but bloats `state.db`, increases WAL pressure, and makes logs or binary outputs expensive. Rejected in favor of inline previews plus content-addressed blobs.
+
+### Alternative 4: Let ADR-0055 Own Viewer-Specific Columns
+
+This was the prior cross-ADR failure mode. It gives implementers two schemas and makes Postgres parity unclear. Rejected. ADR-0053 owns storage; ADR-0055 owns routes and UI only.
+
+## Consequences
+
+- Artifact schema ownership is unambiguous.
+- File captures become evidence-safe append-only rows.
+- Structured outcome compatibility is preserved.
+- Studio can render and stream artifacts without inventing storage columns.
+- SQLite and Postgres implementations must both implement the same artifact contract through ADR-0059.
+- Storage grows with each scan, but that is the cost of preserving evidence history; retention and cleanup policy must operate on explicit retention rules, not hidden mutation.

--- a/docs/adrs/ADR-0053-artifact-persistence.md
+++ b/docs/adrs/ADR-0053-artifact-persistence.md
@@ -3,8 +3,8 @@
 Status: proposed (rewrite after rejected review)
 Date: 2026-05-27
 Decision owners: @governance-maintainers
-Depends on: ADR-0059 (StateStore protocol)
-Related: ADR-0021 (structured artifacts), ADR-0029 (artifact contracts), ADR-0041 (immutable evidence nodes), ADR-0050 (operation context), ADR-0055 (Studio artifact viewer)
+Depends on: ADR-0009 (SQLite state layer), ADR-0029 (artifact contracts), ADR-0041 (immutable evidence nodes)
+Related: ADR-0021 (structured artifacts), ADR-0050 (operation context), ADR-0055 (Studio artifact viewer), ADR-0059 (Postgres backend — consumes artifact columns defined here)
 
 ## Context
 

--- a/docs/adrs/ADR-0053-artifact-persistence.md
+++ b/docs/adrs/ADR-0053-artifact-persistence.md
@@ -1,6 +1,6 @@
 # ADR-0053: Artifact Persistence in State Database
 
-Status: proposed (rewrite after rejected review)
+Status: proposed
 Date: 2026-05-27
 Decision owners: @governance-maintainers
 Depends on: ADR-0009 (SQLite state layer), ADR-0029 (artifact contracts), ADR-0041 (immutable evidence nodes)

--- a/docs/adrs/ADR-0054-local-state-cleanup.md
+++ b/docs/adrs/ADR-0054-local-state-cleanup.md
@@ -1,0 +1,477 @@
+# ADR-0054: Local State File Cleanup and DB Migration Completion
+
+Status: proposed
+Date: 2026-05-27
+Decision owners: @governance-maintainers
+Depends on: ADR-0009 (SQLite state layer), ADR-0019 (teams DB migration), ADR-0027 (scheduler engine / state.db), ADR-0053 (artifact persistence), ADR-0059 (StateStore backend boundary)
+Related: ADR-0024 (session health and admin surface), ADR-0028 (status reason model), ADR-0033 (unified entity state)
+
+## Context
+
+LionAGI has already moved most user-facing operational state into `state.db`, but local files
+still keep enough authority to block safe cleanup. The current SQLite schema contains sessions,
+branches, messages, progressions, projects, definitions, shows, plays, teams, invocations,
+schedules, artifacts, admin events, and status transitions (`lionagi/state/schema.sql:41`,
+`lionagi/state/schema.sql:69`, `lionagi/state/schema.sql:79`, `lionagi/state/schema.sql:97`,
+`lionagi/state/schema.sql:193`, `lionagi/state/schema.sql:220`, `lionagi/state/schema.sql:239`,
+`lionagi/state/schema.sql:265`, `lionagi/state/schema.sql:310`,
+`lionagi/state/schema.sql:354`, `lionagi/state/schema.sql:380`,
+`lionagi/state/schema.sql:485`, `lionagi/state/schema.sql:540`). `StateDB` exposes async methods
+for those surfaces, including sessions (`lionagi/state/db.py:755`), projects
+(`lionagi/state/db.py:1096`), schedules (`lionagi/state/db.py:1185`), artifacts
+(`lionagi/state/db.py:1658`), branches (`lionagi/state/db.py:1784`), shows
+(`lionagi/state/db.py:1935`), plays (`lionagi/state/db.py:2059`), and definitions
+(`lionagi/state/db.py:2252`).
+
+The remaining local state is not only a disk-usage problem. It is a correctness and governance
+problem:
+
+- `~/.lionagi/runs/{run_id}/run.json` and `branches/{branch_id}.json` are still used for resume
+  and some Studio detail paths.
+- `~/.lionagi/teams/*.json` remains a compatibility source for team workflows.
+- legacy logs and stream buffers can contain prompts, model outputs, tool payloads, and secrets.
+- cleanup decisions need a durable audit trail so an operator can explain why a file was retained,
+  quarantined, or removed.
+
+The existing import and prune commands expose the sequencing bug. `_import_runs()` skips a run
+as soon as the session row already exists (`lionagi/cli/state.py:87`). That means a machine that
+previously imported sessions can still lack DB branch snapshots. A later "backfill by running
+import again" would silently skip the exact runs needing snapshot backfill. `_prune()` deletes DB
+sessions and then sweeps messages through direct SQLite calls (`lionagi/cli/state.py:644`,
+`lionagi/cli/state.py:683`, `lionagi/cli/state.py:690`) without an archive step. This conflicts
+with the archive-before-delete rule needed for governed retention.
+
+Studio security also affects cleanup. When `LIONAGI_STUDIO_AUTH_TOKEN` is set, current middleware
+does not protect ordinary GET routes such as `/api/stats` (`apps/studio/server/app.py:52`,
+`apps/studio/server/app.py:86`). Cleanup reports, run detail, artifact detail, logs, and path
+provenance are shared state and must not be readable without the bearer token.
+
+ADR-0054 completes the local migration by making DB records authoritative for resume and Studio
+reads, adding a cleanup ledger in Phase 0, backfilling branch snapshots even when session rows
+already exist, and making destructive DB retention impossible without an archive.
+
+```mermaid
+flowchart TD
+  Runs[~/.lionagi/runs] --> Scan[scan_local_state]
+  Teams[~/.lionagi/teams] --> Scan
+  Logs[legacy logs and buffers] --> Scan
+  Scan --> Ledger[local_state_files ledger]
+  Scan --> Snapshots[branch_snapshots backfill]
+  Ledger --> Report[cleanup report]
+  Report --> Quarantine[quarantine local duplicates]
+  Report --> Archive[archive DB rows before retention delete]
+  Archive --> Delete[delete archived DB rows]
+```
+
+## Decision
+
+### 1. Make `state.db` authoritative for local execution state
+
+The authoritative store for local execution state is the `StateStore` boundary from ADR-0059,
+backed by SQLite by default. Local files under `~/.lionagi/runs/`, `~/.lionagi/logs/agents/`,
+and `~/.lionagi/teams/` become compatibility caches or explicit export artifacts.
+
+| Surface | Current source | New source | Fallback window |
+|---|---|---|---|
+| `li agent -r` / resume | branch JSON files | `branch_snapshots`, then normalized DB reconstruction, then local file fallback | one release |
+| Studio runs list | DB sessions | unchanged | none |
+| Studio run detail | `run.json` plus branch JSON | sessions, branches, progressions, messages, artifacts, branch snapshots | one release |
+| Studio teams | team JSON files | `teams` and `team_messages` | one release |
+| Team CLI | JSON files and file locking | StateStore transaction | one release |
+| stream buffers | JSONL files | messages and session event APIs | no Studio fallback |
+
+### 2. Add Phase 0 schema before scan classification depends on it
+
+Phase 0 must add every table and API the scan uses. The first shippable phase therefore includes
+`branch_snapshots`, `local_state_files`, and `archive_manifest`, plus async `StateDB` methods for
+all three. Scan-only cleanup must not claim to classify branch snapshots or record ledger rows
+until these schema changes are applied.
+
+```sql
+CREATE TABLE IF NOT EXISTS branch_snapshots (
+  branch_id       TEXT PRIMARY KEY REFERENCES branches(id) ON DELETE CASCADE,
+  session_id      TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  created_at      REAL NOT NULL,
+  updated_at      REAL NOT NULL,
+  snapshot_json   JSON NOT NULL,
+  sha256          TEXT NOT NULL,
+  source_path     TEXT,
+  source_mtime    REAL,
+  source_size     INTEGER,
+  schema_version  INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE INDEX IF NOT EXISTS idx_branch_snapshots_session
+  ON branch_snapshots(session_id);
+CREATE INDEX IF NOT EXISTS idx_branch_snapshots_updated
+  ON branch_snapshots(updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS local_state_files (
+  id                   TEXT PRIMARY KEY,
+  kind                 TEXT NOT NULL CHECK(
+                         kind IN (
+                           'run_dir', 'run_manifest', 'branch_snapshot',
+                           'stream_buffer', 'team_json', 'legacy_agent_log',
+                           'artifact_cache', 'unknown'
+                         )
+                       ),
+  path                 TEXT NOT NULL UNIQUE,
+  sha256               TEXT,
+  size_bytes           INTEGER NOT NULL DEFAULT 0,
+  mtime                REAL,
+  linked_entity_type   TEXT CHECK(
+                         linked_entity_type IS NULL
+                         OR linked_entity_type IN ('session', 'branch', 'team', 'artifact')
+                       ),
+  linked_entity_id     TEXT,
+  verification_status  TEXT NOT NULL CHECK(
+                         verification_status IN (
+                           'verified', 'orphan', 'active', 'corrupt',
+                           'unsafe_path', 'unsupported', 'skipped'
+                         )
+                       ),
+  verification_reason  TEXT NOT NULL,
+  scanned_at           REAL NOT NULL,
+  pruned_at            REAL,
+  quarantine_path      TEXT,
+  cleanup_run_id       TEXT,
+  node_metadata        JSON
+);
+
+CREATE INDEX IF NOT EXISTS idx_local_state_files_kind_status
+  ON local_state_files(kind, verification_status);
+CREATE INDEX IF NOT EXISTS idx_local_state_files_entity
+  ON local_state_files(linked_entity_type, linked_entity_id)
+  WHERE linked_entity_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_local_state_files_cleanup_run
+  ON local_state_files(cleanup_run_id)
+  WHERE cleanup_run_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS archive_manifest (
+  id              TEXT PRIMARY KEY,
+  created_at      REAL NOT NULL,
+  source_db       TEXT NOT NULL,
+  cutoff          REAL NOT NULL,
+  keep_recent     INTEGER NOT NULL,
+  entity_counts   JSON NOT NULL,
+  sha256          TEXT NOT NULL,
+  tool_version    TEXT NOT NULL
+);
+```
+
+`source_path` and `path` are internal ledger values. Studio and CLI JSON responses must redact or
+relativize paths before display.
+
+### 3. Publish async snapshot, ledger, cleanup, and archive APIs
+
+All new APIs are async and go through `StateStore` / `StateDB`. The implementation must not use
+database-specific transaction setup in CLI code; it uses `async with store.transaction()`.
+
+```python
+async def upsert_branch_snapshot(
+    self,
+    *,
+    branch_id: str,
+    session_id: str,
+    snapshot: dict[str, Any],
+    source_path: str | None = None,
+    source_mtime: float | None = None,
+    source_size: int | None = None,
+) -> None: ...
+
+async def get_branch_snapshot(self, branch_id: str) -> dict[str, Any] | None: ...
+
+async def list_branch_snapshots_for_session(
+    self, session_id: str
+) -> list[dict[str, Any]]: ...
+
+async def record_local_state_file(self, record: dict[str, Any]) -> None: ...
+
+async def list_local_state_files(
+    self,
+    *,
+    kind: str | None = None,
+    verification_status: str | None = None,
+    cleanup_run_id: str | None = None,
+    limit: int = 500,
+) -> list[dict[str, Any]]: ...
+
+async def archive_rows_before_delete(
+    self,
+    *,
+    archive_path: Path,
+    session_ids: Sequence[str],
+    actor: str,
+) -> dict[str, Any]: ...
+```
+
+Cleanup API:
+
+```python
+@dataclass(frozen=True, slots=True)
+class CleanupConfig:
+    roots: tuple[Path, ...]
+    include_kinds: frozenset[str]
+    older_than_seconds: int
+    keep_recent_runs: int
+    dry_run: bool = True
+    quarantine: bool = True
+    include_orphans: bool = False
+    archive_db: Path | None = None
+    require_snapshot: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class CleanupCandidate:
+    kind: str
+    path: Path
+    size_bytes: int
+    mtime: float
+    linked_entity_type: str | None
+    linked_entity_id: str | None
+    verification_status: str
+    reason: str
+    sha256: str | None = None
+    inode: int | None = None
+    device: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CleanupReport:
+    scanned: int
+    verified: int
+    orphan: int
+    active: int
+    corrupt: int
+    unsafe_path: int
+    prunable: int
+    quarantined: int
+    deleted: int
+    bytes_reclaimable: int
+    bytes_reclaimed: int
+    cleanup_run_id: str
+    candidates: tuple[CleanupCandidate, ...]
+
+
+async def scan_local_state(store: StateStore, config: CleanupConfig) -> CleanupReport: ...
+
+async def cleanup_local_state(store: StateStore, config: CleanupConfig) -> CleanupReport: ...
+
+async def verify_run_dir(store: StateStore, path: Path) -> CleanupCandidate: ...
+async def verify_branch_snapshot(store: StateStore, path: Path) -> CleanupCandidate: ...
+async def verify_team_json(store: StateStore, path: Path) -> CleanupCandidate: ...
+async def verify_legacy_agent_log(store: StateStore, path: Path) -> CleanupCandidate: ...
+```
+
+Resume API:
+
+```python
+async def load_branch_for_resume(branch_id: str, store: StateStore) -> tuple[str | None, Branch]:
+    snapshot = await store.get_branch_snapshot(branch_id)
+    if snapshot is not None:
+        return snapshot["session_id"], Branch.from_dict(snapshot["snapshot_json"])
+    return await load_branch_from_local_fallback(branch_id)
+```
+
+The fallback helper may remain synchronous internally because it reads one local JSON file, but
+the public resume loader is async and is awaited from async CLI call sites.
+
+### 4. Backfill snapshots even when session rows already exist
+
+`li state import` must stop treating "session row exists" as "nothing else to do." Import remains
+idempotent, but snapshot backfill is a separate pass that always scans branch JSON files and
+upserts missing or stale `branch_snapshots`.
+
+```python
+async def import_runs(*, backfill_snapshots: bool = True) -> dict[str, int]:
+    async with StateDB() as db:
+        for run_dir in iter_run_dirs():
+            manifest = read_manifest(run_dir)
+            session = await db.get_session(manifest.run_id)
+            if session is None:
+                await import_normalized_rows(db, run_dir, manifest)
+            if backfill_snapshots:
+                await backfill_branch_snapshots_for_run(db, run_dir, manifest.run_id)
+```
+
+`backfill_branch_snapshots_for_run()` reads every `branches/*.json`, computes SHA-256, extracts
+`branch_id` and `session_id`, verifies that the branch row exists or can be created from the
+snapshot metadata, and upserts `branch_snapshots`. A test fixture must cover the critical case:
+sessions and branches already exist, `branch_snapshots` is empty, and rerunning import fills the
+snapshot table.
+
+### 5. Implement archive-before-delete in Phase 0
+
+Archive-before-delete is not deferred. Phase 0 changes destructive DB retention so it cannot
+delete sessions, branches, messages, teams, artifacts, or related status rows unless one of these
+is true:
+
+1. the command is a dry run;
+2. the command supplies `--archive-db` and `archive_rows_before_delete()` writes a valid
+   `archive_manifest`; or
+3. the command deletes only duplicated local files and leaves all DB rows live.
+
+`li state prune` is therefore updated in Phase 0:
+
+```bash
+li state prune --keep-days 30 --keep-n 100 --dry-run
+li state prune --keep-days 30 --keep-n 100 --archive-db ~/.lionagi/state-archive.db --apply
+```
+
+A non-dry-run DB prune without `--archive-db` fails closed with a clear error. Local file cleanup
+can quarantine verified duplicate files without archiving DB rows because the authoritative DB
+records remain live.
+
+Archive contents include FK closure for selected sessions: sessions, branches, related
+progressions, messages referenced by those progressions, artifacts, status transitions,
+schedule_runs, invocations where selected sessions are the only remaining children, and
+admin_events for the retention action.
+
+### 6. Revalidate filesystem objects at apply time
+
+Scan-time verification is advisory. Before moving or deleting any file, apply must:
+
+1. `lstat` the path immediately before action.
+2. Reject symlinks.
+3. Reject unexpected hard-link counts for file kinds where link count should be one.
+4. Compare device, inode, mtime, size, and SHA-256 where the scan ledger has a hash.
+5. Resolve the destination under `~/.lionagi/trash/state-cleanup/{cleanup_run_id}/`.
+6. Move to quarantine first with no-follow semantics.
+7. Record the ledger update and `admin_events` entry inside a StateStore transaction.
+8. Purge quarantine only through a separate explicit command after another dry-run preview.
+
+The old "Studio active connection counter" is not used by standalone CLI cleanup because it is
+process-local. Cross-process safety is provided by the StateStore transaction and a maintenance
+lock. A Studio-hosted admin cleanup endpoint may additionally check its in-process connection
+counter before it calls the same cleanup service.
+
+### 7. Require bearer auth for Studio cleanup, run, artifact, and state reads
+
+When `LIONAGI_STUDIO_AUTH_TOKEN` is set, all `/api/*` endpoints require bearer auth for all HTTP
+methods. Cleanup reports, run detail, artifact reads, schedules, projects, stats, logs, and admin
+events are not public read surfaces. This ADR relies on ADR-0059's middleware change and adds no
+exception for cleanup endpoints.
+
+## Implementation
+
+| Phase | Scope | Files | Estimate |
+|---|---|---|---|
+| 0. Schema, archive gate, and import backfill contract | Add `branch_snapshots`, `local_state_files`, and `archive_manifest`; add async DB APIs; update `li state prune` so DB deletes require archive; change `li state import` to run snapshot backfill even when sessions already exist. | `lionagi/state/schema.sql`, `lionagi/state/db.py`, `lionagi/cli/state.py`, `tests/state/test_branch_snapshots.py`, `tests/cli/test_state_archive_gate.py` | 550-850 LOC |
+| 1. Scan-only cleanup | Implement `state_cleanup.py` scan, ledger writes, path classification, hashing, and stable dry-run reports. No file deletion. | `lionagi/cli/state_cleanup.py`, `lionagi/cli/state.py`, `tests/cli/test_state_cleanup_scan.py` | 350-550 LOC |
+| 2. DB-first resume and Studio detail | Write snapshots for new agent and flow runs; use async `load_branch_for_resume`; build Studio run detail from DB first and local files only as one-release fallback. | `lionagi/cli/agent.py`, `lionagi/cli/orchestrate/_orchestration.py`, `lionagi/cli/_runs.py`, `apps/studio/server/services/runs.py` | 300-550 LOC |
+| 3. Team DB primary path | Route team CLI and Studio teams through `teams` and `team_messages`; keep JSON export as an explicit command. | `lionagi/cli/team.py`, `apps/studio/server/services/teams.py`, tests | 250-450 LOC |
+| 4. Apply cleanup and quarantine | Implement apply-time revalidation, quarantine moves, ledger updates, maintenance lock, and purge command. | `lionagi/cli/state_cleanup.py`, `lionagi/cli/state.py`, tests | 300-500 LOC |
+| 5. Remove fallbacks | After one release, remove local run/team read fallbacks from Studio and CLI resume; keep explicit export/import tools. | `apps/studio/server/services/runs.py`, `lionagi/cli/_runs.py`, `lionagi/cli/team.py` | 150-300 LOC net reduction |
+
+MVP acceptance:
+
+- `li state import` backfills branch snapshots for runs whose session rows already exist.
+- `li state prune --apply` without archive fails closed.
+- `li state cleanup --dry-run` records `local_state_files` and mutates no local files.
+- `li agent -r <branch_id>` uses DB snapshots when local branch JSON is absent.
+- Studio GET routes are bearer-protected when the token is configured.
+
+Testability estimate `tau = 0.84`: schema, backfill, archive gate, dry-run idempotence, and
+resume behavior are directly testable. The residual risk is platform-specific filesystem
+rename behavior, covered by integration tests on supported OS targets.
+
+## Security
+
+1. All Studio `/api/*` routes require bearer auth when `LIONAGI_STUDIO_AUTH_TOKEN` is set,
+   including GET routes.
+2. Cleanup reports must not include message content, artifact content, raw logs, secrets, or
+   unredacted absolute paths. Internal ledgers may store paths for forensics.
+3. Cleanup follows symlink-safe path handling. Deletion never follows symlinks.
+4. Apply revalidates device, inode, mtime, size, and hash where available to reduce time-of-check
+   to time-of-use risk.
+5. Active sessions are never deleted or quarantined by default. Running sessions, recently updated
+   sessions, and the most recent `keep_recent_runs` are retained.
+6. Local JSON is untrusted input. Parse failures become `corrupt`; corrupt files are reported and
+   retained unless a future explicit orphan policy says otherwise.
+7. DB retention deletion requires an archive manifest and FK-clean archive copy before live rows
+   are deleted.
+8. SQL values use parameter binding. Dynamic table and column names come only from internal
+   allowlists.
+9. Quarantine is the default apply behavior. Hard purge is a separate command with a dry-run
+   preview.
+10. Hashes are migration integrity checks, not a tamper-proof evidence chain.
+
+## Migration
+
+1. Apply the Phase 0 schema migration to SQLite. Postgres receives the same logical columns through
+   ADR-0059 schema parity.
+2. Run import with snapshot backfill:
+
+   ```bash
+   li state import --backfill-snapshots
+   li state import-teams
+   ```
+
+   This command scans branch JSON files even when `sessions.id` already exists.
+
+3. Verify snapshot coverage:
+
+   ```bash
+   li state cleanup --dry-run --include runs,teams,logs
+   ```
+
+4. Switch resume and Studio detail to DB-first reads.
+5. Run cleanup scan repeatedly until counts are stable.
+6. Apply local duplicate cleanup:
+
+   ```bash
+   li state cleanup --apply --include runs,teams,logs --older-than 30d --keep-recent-runs 100
+   ```
+
+7. For DB retention, archive first:
+
+   ```bash
+   li state prune \
+     --keep-days 90 \
+     --keep-n 100 \
+     --archive-db ~/.lionagi/state-archive.db \
+     --apply
+   ```
+
+8. Keep quarantined files for 14 days by default.
+9. Remove local-file fallbacks after one release once CI and developer migration reports show
+   DB-first paths cover resume, Studio detail, and team workflows.
+
+Migration invariants:
+
+- No file is removed unless its matching DB state exists or the operator explicitly includes
+  orphans in a later non-MVP command.
+- No DB row is deleted unless archive succeeds first.
+- Cleanup is idempotent.
+- Paths are canonicalized under `LIONAGI_HOME` or the configured quarantine/archive root.
+- Snapshot backfill is idempotent and independent of session-row existence.
+
+## Testing
+
+- `tests/state/test_branch_snapshots.py`: schema creation, upsert idempotency, SHA changes,
+  cascade on branch/session delete, and branch resume round trip.
+- `tests/cli/test_import_snapshot_backfill.py`: session and branch rows already exist,
+  `branch_snapshots` is empty, rerunning import fills snapshots.
+- `tests/cli/test_state_archive_gate.py`: non-dry-run DB prune without archive fails; prune with
+  archive writes `archive_manifest` before deleting rows.
+- `tests/cli/test_state_cleanup_scan.py`: verified run dirs, branch snapshots, stream buffers,
+  team JSON, legacy logs, corrupt JSON, missing DB rows, unsafe paths, and active sessions.
+- `tests/cli/test_state_cleanup_apply.py`: dry-run non-mutation, apply-time revalidation,
+  quarantine move, repeated apply, ledger rows, and `admin_events` insertion.
+- `tests/studio/test_auth.py`: `/api/stats`, run detail, artifacts, schedules, projects, teams,
+  and cleanup/admin GETs return 401 without token when auth is configured.
+- Integration test: run a real temp `LIONAGI_HOME`, create an agent session, backfill snapshots,
+  move branch JSON to quarantine, and resume by branch ID from DB.
+- Integration test: seed a flow run, remove `run.json`, and verify Studio run detail from DB.
+- Integration test: run retention prune with archive and confirm live DB FK checks pass.
+
+## Consequences
+
+- Phase 0 is larger than the prior draft because it includes the schema and archive gates the
+  cleanup contract needs.
+- Local cleanup becomes auditable before it becomes destructive.
+- Existing imported runs get snapshot backfill instead of being skipped.
+- DB retention becomes slower but defensible because archive precedes delete.
+- Resume and Studio detail become portable across local cleanup and future Postgres deployment.
+- The one-release fallback window preserves compatibility while making the DB-first path the
+  default.

--- a/docs/adrs/ADR-0055-studio-artifact-viewer.md
+++ b/docs/adrs/ADR-0055-studio-artifact-viewer.md
@@ -35,7 +35,7 @@ ADR-0055 adds no artifact table columns. It may add service functions, Pydantic 
 
 Phase 0 Studio remains a single-admin surface protected by `LIONAGI_STUDIO_AUTH_TOKEN`. When the token is set, every artifact route requires `Authorization: Bearer <token>`, including GET routes.
 
-Multi-tenant or shared remote Studio deployments require project/session authorization before enabling artifact reads. Until that authorization layer exists, shared deployments must either disable artifact routes or put Studio behind an equivalent authenticated administrative boundary. A valid single-admin token is treated as permission to read all artifacts visible to that Studio instance.
+Shared deployments require project/session authorization before enabling artifact reads. Until that authorization layer exists, shared deployments must either disable artifact routes or put Studio behind an equivalent authenticated administrative boundary. A valid single-admin token is treated as permission to read all artifacts visible to that Studio instance.
 
 ### API Response Models
 
@@ -286,7 +286,7 @@ Filesystem fallback is disabled by default and is not part of the production evi
 
 The viewer does not redact content. Artifact producers remain responsible for not writing secrets; Studio is responsible for not broadening access and not caching sensitive reads.
 
-Shared or multi-tenant deployments need resource-level authorization before artifact routes are enabled. The Phase 0 token model is an administrative model, not tenant isolation.
+Shared deployments need resource-level authorization before artifact routes are enabled. The Phase 0 token model is an administrative model.
 
 ## Migration
 

--- a/docs/adrs/ADR-0055-studio-artifact-viewer.md
+++ b/docs/adrs/ADR-0055-studio-artifact-viewer.md
@@ -1,0 +1,327 @@
+# ADR-0055: Studio Artifact Viewer and File Reference Resolution
+
+Status: proposed (rewrite after approve-with-fixes review)
+Date: 2026-05-27
+Decision owners: @governance-maintainers
+Depends on: ADR-0053 (artifact persistence), ADR-0059 (StateStore protocol)
+Related: ADR-0012 (Studio execution lineage), ADR-0021 (structured artifacts API), ADR-0027 (Studio architecture), ADR-0029 (artifact contracts), ADR-0056 (play control API)
+
+## Context
+
+Studio is the operator surface for governed orchestration. It already shows sessions, branches, messages, graph shape, invocation outcomes, and run status, but it does not reliably show the files produced by a run. That weakens the governance story: operators can see that work happened, but not inspect the work products that should feed evidence and task certificates.
+
+The CLI writes useful artifacts today. `RunDir` separates authoritative state from user-facing artifacts (`lionagi/cli/_runs.py:70`), workers receive agent artifact directories in their operation context (`lionagi/cli/orchestrate/flow.py:1038`), operation outputs are written to `{agent_id}/{op_id}.md` (`lionagi/cli/orchestrate/flow.py:1113`), and synthesis writes `synthesis.md` (`lionagi/cli/orchestrate/flow.py:1601`). Live persistence stores `sessions.artifacts_path` and artifact contract JSON (`lionagi/cli/orchestrate/_orchestration.py:532`) and verifies required artifacts at teardown (`lionagi/cli/orchestrate/_orchestration.py:804`). These facts are enough to know where files should exist, but not enough for a remote or audited Studio viewer.
+
+The current Studio artifacts API is intentionally narrow. It exposes structured artifact rows by ID and by session (`apps/studio/server/routers/artifacts.py:22`), serializes the current row fields from `apps/studio/server/services/invocations.py:113`, and the frontend type mirrors those fields (`apps/studio/frontend/lib/api.ts:462`). The run page separately extracts file-looking values from tool-call arguments (`apps/studio/frontend/app/runs/[id]/page.tsx:697`). Those paths are shown as text, not resolved into a DB-backed artifact.
+
+ADR-0053 now owns the artifact schema and insertion semantics. This ADR does not add columns, change file identity, or define persistence. It consumes ADR-0053's canonical fields:
+
+```text
+id, session_id, invocation_id, op_id, kind, name, content, file_path,
+sha256, size_bytes, media_type, rel_path, source_kind, created_at, updated_at
+```
+
+The prior ADR-0055 draft mixed viewer needs with storage decisions. It required `rel_path`, `media_type`, `source_kind`, and `insert_file_artifact()` while ADR-0053 still said file artifacts upserted by path. That split left implementers unable to tell which contract was authoritative. This rewrite makes the boundary explicit: ADR-0053 owns schema and writes; ADR-0055 owns authenticated API routes, content streaming, reference resolution, and frontend viewer behavior.
+
+The security baseline is also non-optional. Current middleware requires the bearer token for admin GET routes and mutating API methods, but not all non-admin GETs (`apps/studio/server/app.py:52`). Artifact routes read sensitive content, including logs and arbitrary agent-written files. They must require bearer auth when `LIONAGI_STUDIO_AUTH_TOKEN` is set.
+
+## Decision
+
+Build a DB-first Studio artifact viewer over ADR-0053 artifacts. Studio reads artifact metadata and preview bodies from the state store, streams blob-backed content through authenticated routes, and resolves file references found in messages or manifests to artifact rows.
+
+ADR-0055 adds no artifact table columns. It may add service functions, Pydantic API models, routes, frontend types, and viewer components. Any future storage-field change belongs in a revision of ADR-0053 and ADR-0059, not this ADR.
+
+### Trust Model
+
+Phase 0 Studio remains a single-admin surface protected by `LIONAGI_STUDIO_AUTH_TOKEN`. When the token is set, every artifact route requires `Authorization: Bearer <token>`, including GET routes.
+
+Multi-tenant or shared remote Studio deployments require project/session authorization before enabling artifact reads. Until that authorization layer exists, shared deployments must either disable artifact routes or put Studio behind an equivalent authenticated administrative boundary. A valid single-admin token is treated as permission to read all artifacts visible to that Studio instance.
+
+### API Response Models
+
+API models mirror ADR-0053 fields but do not expose absolute paths. `file_path` is returned only when it is a relative blob key or a safe public relative display path. Legacy absolute paths are omitted from responses and may still be used internally after containment checks.
+
+```python
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+SourceKind = Literal["structured", "inline", "blob", "filesystem"]
+
+class ArtifactListItem(BaseModel):
+    id: str
+    session_id: str | None
+    invocation_id: str | None
+    op_id: str | None
+    kind: str
+    name: str
+    rel_path: str | None
+    file_path: str | None
+    sha256: str | None
+    size_bytes: int | None
+    media_type: str | None
+    source_kind: SourceKind
+    created_at: float
+    updated_at: float
+    raw_url: str | None = None
+
+class ArtifactContentResponse(ArtifactListItem):
+    content: dict[str, Any] | None
+    body: str | None
+    preview_lines: list[str] | None
+    truncated: bool
+
+class FileReferenceResolution(BaseModel):
+    status: Literal["resolved", "unavailable", "ambiguous", "forbidden"]
+    reference: str
+    normalized_reference: str | None = None
+    artifact: ArtifactContentResponse | None = None
+    candidates: list[ArtifactListItem] = []
+    reason: str | None = None
+```
+
+### Backend Service Contract
+
+Add `apps/studio/server/services/artifacts.py` as the only backend service that decides how artifact content is listed, previewed, streamed, and resolved:
+
+```python
+async def list_session_artifacts(
+    session_id: str,
+    *,
+    include_content: bool = False,
+) -> list[ArtifactListItem]:
+    ...
+
+async def list_play_artifacts(
+    play_id: str,
+    *,
+    include_content: bool = False,
+) -> list[ArtifactListItem]:
+    ...
+
+async def get_artifact_content(
+    artifact_id: str,
+    *,
+    preview_lines: int,
+    max_response_bytes: int,
+) -> ArtifactContentResponse | None:
+    ...
+
+async def open_artifact_blob(
+    artifact_id: str,
+    *,
+    disposition: Literal["attachment", "inline"] = "attachment",
+) -> tuple[BinaryIO, str, str, int] | None:
+    """Return stream, media_type, download_name, size_bytes."""
+
+async def resolve_file_reference(
+    *,
+    reference: str,
+    session_id: str | None = None,
+    invocation_id: str | None = None,
+    play_id: str | None = None,
+    run_id: str | None = None,
+) -> FileReferenceResolution:
+    ...
+```
+
+The service uses the ADR-0059 state store. It must not query SQLite directly once the `StateStore` artifact methods exist.
+
+### API Routes
+
+Update `apps/studio/server/routers/artifacts.py` and add thin route handlers elsewhere only where the URL belongs to a parent resource:
+
+```text
+GET  /api/artifacts/{artifact_id}
+GET  /api/artifacts/{artifact_id}/blob
+GET  /api/sessions/{session_id}/artifacts
+GET  /api/plays/{play_id}/artifacts
+POST /api/artifact-references/resolve
+```
+
+Keep `GET /api/artifacts/by-session/{session_id}` for one release as a compatibility shim that delegates to `GET /api/sessions/{session_id}/artifacts`.
+
+`GET /api/artifacts/{artifact_id}` returns metadata and bounded preview content. It does not inline unbounded file bodies. `GET /api/artifacts/{artifact_id}/blob` streams the captured bytes for inline and blob-backed file artifacts. Structured artifacts without file bytes return `404` for the blob route unless `content.body` is explicitly treated as downloadable text.
+
+Raw/blob responses must set:
+
+```text
+Content-Type: <artifact.media_type or application/octet-stream>
+Content-Disposition: attachment; filename="<safe name>"
+X-Content-Type-Options: nosniff
+Cache-Control: no-store
+```
+
+Inline display is allowed only for safe text media types when the client requests it, for example `?disposition=inline`. HTML, SVG, executable content, unknown binary content, and mismatched hashes must not be rendered inline. A SHA-256 mismatch returns `409 Conflict`.
+
+Use `POST /api/artifact-references/resolve` rather than putting arbitrary paths in URL segments:
+
+```json
+{
+  "reference": "r1/research.md",
+  "session_id": "session-uuid",
+  "invocation_id": null,
+  "play_id": null,
+  "run_id": null
+}
+```
+
+### Reference Resolution
+
+Resolution is deterministic and DB-first:
+
+1. If `reference` is an artifact ID, return that artifact.
+2. If `invocation_id` is known, match normalized `rel_path` within that invocation and return the newest row by `created_at`.
+3. If `session_id` is known, match normalized `rel_path` within that session and return the newest row by `created_at`.
+4. If `play_id` is known, resolve the play's `session_id`, then use session lookup.
+5. If the reference is an absolute path, never open it directly. Convert it to a relative path only if it is under the session artifact root, configured project root, or an explicitly allowed local fallback root.
+6. If filesystem fallback is disabled or the converted path is outside allowed roots, return `forbidden`.
+7. If multiple DB rows are plausible and none is clearly newest within the requested scope, return `ambiguous` with candidates.
+8. If no source can satisfy the reference, return `unavailable`.
+
+Filesystem fallback is transitional and disabled by default. It exists only for old local runs without ADR-0053 rows. It never inserts rows implicitly and never returns absolute paths.
+
+### Frontend Behavior
+
+Add artifact-aware UI without changing the storage contract:
+
+- `apps/studio/frontend/lib/api.ts`: add `ArtifactListItem`, `ArtifactContentResponse`, `FileReferenceResolution`, `getArtifactContent()`, `getArtifactBlobUrl()`, `listSessionArtifacts()`, `listPlayArtifacts()`, and `resolveFileReference()`.
+- `apps/studio/frontend/components/artifacts/ArtifactLink.tsx`: wraps file-looking text and resolves on click or explicit hover intent.
+- `apps/studio/frontend/components/artifacts/ArtifactViewer.tsx`: renders Markdown, Python, YAML, JSON, TOML, shell, plain text, and unified diff previews. Unknown or binary media shows metadata and a download action.
+- `apps/studio/frontend/components/artifacts/ArtifactTimeline.tsx`: groups artifacts by `rel_path`, orders versions by `created_at`, and offers text diffs only when both bodies are available.
+- `apps/studio/frontend/app/runs/[id]/page.tsx`: replace the current extracted-file text list with artifact links and a compact artifact timeline.
+- `apps/studio/frontend/app/invocations/[id]/page.tsx`: keep structured outcome rendering and link attached artifact blobs where present.
+
+Unavailable references render as inert labels with a short reason. Forbidden references do not echo absolute paths. Ambiguous references show a small chooser ordered newest first.
+
+## Implementation
+
+### Phase 0: Auth And API Foundations (220-340 LOC)
+
+Files:
+
+- `apps/studio/server/app.py`: ensure artifact routes require bearer auth for all methods when `LIONAGI_STUDIO_AUTH_TOKEN` is set, or add a shared route dependency applied to every artifact route. Estimated 40-70 LOC.
+- `apps/studio/server/config.py`: add artifact preview, response-size, and fallback settings. Estimated 40-60 LOC.
+- `apps/studio/server/services/artifacts.py`: define response models and path redaction helpers. Estimated 100-160 LOC.
+- Tests for auth gating and response redaction. Estimated 40-50 LOC.
+
+Exit criteria:
+
+- All artifact routes return `401` without the bearer token when configured.
+- Metadata responses omit legacy absolute paths.
+- Settings default to DB-first and filesystem fallback disabled.
+
+### Phase 1: Backend Listing, Preview, Blob Streaming, Resolution (520-780 LOC)
+
+Files:
+
+- `apps/studio/server/services/artifacts.py`: implement list, get, preview extraction, blob open, hash verification, and reference resolution. Estimated 300-460 LOC.
+- `apps/studio/server/routers/artifacts.py`: implement artifact ID, blob, compatibility by-session, and resolve routes. Estimated 100-140 LOC.
+- `apps/studio/server/routers/sessions.py` and play/show route surface: add session and play artifact list routes. Estimated 60-90 LOC.
+- Backend tests for list, preview, blob, hash mismatch, ambiguous, unavailable, forbidden, compatibility route, and max-size behavior. Estimated 60-90 LOC.
+
+Exit criteria:
+
+- DB rows from ADR-0053 are listable and previewable.
+- Blob route streams with correct `Content-Type` and `Content-Disposition`.
+- SHA-256 mismatch returns `409`.
+- Resolve never opens arbitrary absolute paths.
+
+### Phase 2: Frontend Viewer MVP (620-940 LOC)
+
+Files:
+
+- `apps/studio/frontend/lib/api.ts`: artifact API types and client functions. Estimated 80-120 LOC.
+- `apps/studio/frontend/components/artifacts/ArtifactLink.tsx`: link and resolve states. Estimated 120-180 LOC.
+- `apps/studio/frontend/components/artifacts/ArtifactViewer.tsx`: preview, metadata, download controls, and error states. Estimated 220-340 LOC.
+- `apps/studio/frontend/app/runs/[id]/page.tsx` and invocation page integration. Estimated 120-180 LOC.
+- Component tests for resolved, unavailable, forbidden, ambiguous, text preview, and binary download states. Estimated 80-120 LOC.
+
+Exit criteria:
+
+- Run pages expose clickable artifacts without leaving Studio.
+- Existing structured outcome cards still render.
+- Long text and binary files do not break layout or inline response limits.
+
+### Phase 3: Timeline And Diffs (320-520 LOC)
+
+Files:
+
+- `ArtifactTimeline.tsx`: grouping by `rel_path`, version order, operation metadata display, and adjacent diff affordance. Estimated 160-260 LOC.
+- Server or client diff helper for bounded text artifacts. Estimated 80-140 LOC.
+- Tests for grouping, ordering, and missing-body diff states. Estimated 80-120 LOC.
+
+Exit criteria:
+
+- Multiple immutable file rows for one path are visible as versions.
+- Diff is offered only when both versions have bounded text bodies.
+- Timeline behavior relies on `rel_path` and `created_at`, not on schema additions.
+
+### Phase 4: Hardening And Migration Support (360-560 LOC)
+
+Files:
+
+- Backend tests for local fallback disabled/enabled, symlink escapes, URL-decoded traversal, cache headers, and no absolute path echo. Estimated 140-220 LOC.
+- Playwright smoke test on a seeded run with inline and blob artifacts. Estimated 80-120 LOC.
+- Admin health counters or diagnostics for missing blobs, hash mismatches, unavailable references, and fallback usage. Estimated 100-160 LOC.
+- Documentation updates for Studio deployment auth expectations. Estimated 40-60 LOC.
+
+Exit criteria:
+
+- Artifact viewer passes security regression tests.
+- Local fallback is visibly off by default and auditable when enabled.
+- Seeded run pages load artifact previews and downloads through the authenticated API.
+
+## Security
+
+All artifact routes require bearer auth when `LIONAGI_STUDIO_AUTH_TOKEN` is set. This includes `GET /api/artifacts/{id}`, `GET /api/artifacts/{id}/blob`, session and play listing routes, the by-session compatibility route, and `POST /api/artifact-references/resolve`.
+
+No artifact API response may expose host absolute paths. `rel_path` is the primary UI label. `file_path` is returned only as a relative blob key or safe public relative path. Forbidden and unavailable responses must not include the rejected absolute path in `reason`.
+
+Blob responses set `Content-Type`, `Content-Disposition`, `X-Content-Type-Options: nosniff`, and `Cache-Control: no-store`. Unknown, binary, HTML, SVG, and executable content defaults to attachment. Inline display is limited to safe text media types and bounded previews.
+
+The service verifies `sha256` for blob-backed reads. A mismatch returns `409 Conflict` and should be surfaced in admin diagnostics.
+
+Filesystem fallback is disabled by default and is not part of the production evidence path. If enabled for local migration, it may read only under configured allowed roots and the session artifact root. It rejects parent traversal, NUL bytes, glob metacharacters, directories, symlink escapes, and absolute references that cannot be converted to an allowed relative path.
+
+The viewer does not redact content. Artifact producers remain responsible for not writing secrets; Studio is responsible for not broadening access and not caching sensitive reads.
+
+Shared or multi-tenant deployments need resource-level authorization before artifact routes are enabled. The Phase 0 token model is an administrative model, not tenant isolation.
+
+## Migration
+
+1. Implement ADR-0053 first so new runs write canonical artifact rows.
+2. Add authenticated Studio routes over the ADR-0053 schema. Do not add artifact columns in this ADR.
+3. Preserve existing `/api/artifacts/{id}` and `/api/artifacts/by-session/{session_id}` for one release, adding fields where available.
+4. Add session and play artifact list routes, then move frontend callers to those routes.
+5. Replace run-page path text with `ArtifactLink` resolution. Existing file-looking strings remain visible when resolution is unavailable.
+6. Keep filesystem fallback disabled by default. Enable it only for local migration after explicit configuration.
+7. Use ADR-0053 backfill to make old runs DB-visible. Studio does not implicitly backfill during reads.
+8. Deprecate the by-session compatibility route after frontend and documented consumers use `/api/sessions/{session_id}/artifacts`.
+
+## Alternatives Considered
+
+### Alternative 1: Serve Files Directly From `artifact_root`
+
+This is quick for local runs but makes Studio depend on host filesystem layout, leaks absolute paths, and does not support remote runs or evidence references. Rejected.
+
+### Alternative 2: Let The Viewer Define Extra Columns
+
+This was the prior schema-conflict failure. Viewer-specific storage columns would drift from ADR-0053 and ADR-0059. Rejected.
+
+### Alternative 3: Frontend-Only Path Detection
+
+Copy buttons or local editor links improve convenience but do not solve authenticated content reads, remote execution, hash verification, or version timelines. Rejected.
+
+### Alternative 4: DB-Only With No Local Fallback
+
+This is the clean steady state. It is too abrupt during the migration window because old local runs have only filesystem artifacts. Accepted as the long-term target, with disabled-by-default fallback for explicit local migration.
+
+## Consequences
+
+- Studio gains a real artifact viewer without owning storage.
+- Artifact rows remain canonical under ADR-0053 and backend-neutral under ADR-0059.
+- All artifact reads become authenticated sensitive reads.
+- Blob downloads have predictable content headers and hash verification.
+- File references in messages can resolve to durable artifact rows instead of dead text.
+- The UI can show file versions because ADR-0053 file rows are append-only.

--- a/docs/adrs/ADR-0055-studio-artifact-viewer.md
+++ b/docs/adrs/ADR-0055-studio-artifact-viewer.md
@@ -1,6 +1,6 @@
 # ADR-0055: Studio Artifact Viewer and File Reference Resolution
 
-Status: proposed (rewrite after approve-with-fixes review)
+Status: proposed
 Date: 2026-05-27
 Decision owners: @governance-maintainers
 Depends on: ADR-0053 (artifact persistence), ADR-0059 (StateStore protocol)

--- a/docs/adrs/ADR-0056-play-control-api.md
+++ b/docs/adrs/ADR-0056-play-control-api.md
@@ -1,6 +1,6 @@
 # ADR-0056: Play Control API - Runner Control Plane
 
-Status: proposed (rewrite after rejected review)
+Status: proposed
 Date: 2026-05-27
 Decision owners: @governance-maintainers
 Depends on: ADR-0053 (artifact persistence), ADR-0058 (play cost tracking), ADR-0059 (Postgres state backend)

--- a/docs/adrs/ADR-0056-play-control-api.md
+++ b/docs/adrs/ADR-0056-play-control-api.md
@@ -1,0 +1,614 @@
+# ADR-0056: Play Control API - Runner Control Plane
+
+Status: proposed (rewrite after rejected review)
+Date: 2026-05-27
+Decision owners: @governance-maintainers
+Depends on: ADR-0053 (artifact persistence), ADR-0058 (play cost tracking), ADR-0059 (Postgres state backend)
+Related: ADR-0020 (invocations), ADR-0024 (session health), ADR-0025 (session lifecycle), ADR-0027 (scheduled runs), ADR-0028 (status reasons), ADR-0057 (remote sandbox execution), ADR-0060 (unified config resolution)
+
+## Context
+
+Governed orchestration needs an operator control plane, not only a status viewer. A play or flow
+that can be observed in Studio but can only be paused, cancelled, killed, or retried from an
+operator terminal has an audit gap: the intervention bypasses Studio authentication, durable actor
+attribution, status reasons, and future task certificates.
+
+The current flow engine already exposes enough structure to control. `FlowPlan` models a two-level
+DAG of persistent `FlowAgent` identities and dependent `FlowOp` nodes
+(`lionagi/cli/orchestrate/flow.py:332-425`). `_run_flow()` creates live persistence, records whether
+the invocation is a `flow` or `play`, and maps Python outcomes into the session lifecycle vocabulary
+of `completed`, `failed`, `timed_out`, `aborted`, and `cancelled`
+(`lionagi/cli/orchestrate/flow.py:610-760`). While the DAG runs, operation segments and an early DAG
+snapshot are persisted into `sessions.node_metadata` for Studio rendering
+(`lionagi/cli/orchestrate/flow.py:1177-1290`). What is missing is the reverse channel from Studio to
+the running process or remote runner.
+
+The state model already separates workflow state from runtime state. `sessions.status` is the
+runtime lifecycle and intentionally has no SQLite `CHECK` constraint so Python remains the source of
+truth (`lionagi/state/schema.sql:97-168`, `lionagi/state/db.py:203-219`). `plays.status` is the show
+workflow state, with values such as `pending`, `prepared`, `running_complete`, `gated`, `merged`, and
+`blocked`; it is not a process control state (`lionagi/state/schema.sql:265-302`). Status history is
+append-only in `status_transitions` (`lionagi/state/schema.sql:540-561`). This ADR must therefore not
+add `paused` or `killed` to `plays.status`.
+
+The current recovery path is CLI-centric. `li kill` resolves sessions, invocations, plays, and shows,
+finds a PID from `node_metadata` or artifact pid files, sends `SIGTERM`, escalates to `SIGKILL`, and
+persists cancellation through `StateDB.update_status()` (`lionagi/cli/kill.py:34-126`,
+`lionagi/cli/kill.py:149-260`). This is useful prior art, but it is not a typed API, does not cover
+pause/resume/retry, and cannot be the remote-runner abstraction.
+
+Studio's existing middleware is not sufficient for this surface. It gates all `/api/admin/*`
+requests and mutating non-admin `/api/*` requests when `LIONAGI_STUDIO_AUTH_TOKEN` is set, but it
+does not gate ordinary GET routes such as future status or log endpoints
+(`apps/studio/server/app.py:52-78`). Play control exposes runtime status and logs that may contain
+secrets, so every endpoint in this ADR requires bearer authentication, including reads.
+
+The rejected drafts for ADR-0056 and ADR-0057 formed a cycle: ADR-0056 depended on ADR-0057 while
+ADR-0057 also depended on ADR-0056. This rewrite breaks the cycle. ADR-0056 owns the control plane:
+the vocabulary, `PlayRunner` protocol, `runner_handles` table, `run_control_requests` table, control
+API endpoints, and runner state machine. ADR-0057 depends on this ADR and implements concrete runner
+backends behind the protocol. ADR-0057 does not define a competing execution table or state machine.
+
+## Decision
+
+Add a single runner control plane used by Studio, CLI recovery paths, the scheduler, local worktree
+runners, and remote sandbox runners. The API is play-friendly for Studio, but the canonical runtime
+target is the linked session:
+
+```text
+plays.id -> plays.session_id -> runner_handles.session_id
+```
+
+Sessions and invocations without a play row use the same control service through session endpoints.
+`plays.status` remains the show workflow state. Runtime state lives in `runner_handles.state`.
+Operator intent lives in `run_control_requests`. Terminal runtime outcomes continue to update
+`sessions.status` and `status_transitions` through the StateStore contract from ADR-0059.
+
+### Canonical Vocabulary
+
+ADR-0056 defines these names for all dependent ADRs and implementations:
+
+```python
+# lionagi/runtime/control.py
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Mapping
+from enum import StrEnum
+from typing import Protocol
+from pydantic import BaseModel, Field
+
+
+class RunnerKind(StrEnum):
+    LOCAL_WORKTREE = "local_worktree"
+    DAYTONA = "daytona"
+    E2B = "e2b"
+    CODESPACE = "codespace"
+    SSH = "ssh"
+
+
+class RunnerState(StrEnum):
+    PENDING = "pending"
+    STARTING = "starting"
+    RUNNING = "running"
+    PAUSING = "pausing"
+    PAUSED = "paused"
+    RESUMING = "resuming"
+    CANCELLING = "cancelling"
+    KILLING = "killing"
+    RETRYING = "retrying"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    TIMED_OUT = "timed_out"
+    CANCELLED = "cancelled"
+    KILLED = "killed"
+    LOST = "lost"
+
+
+class RunControl(StrEnum):
+    PAUSE = "pause"
+    RESUME = "resume"
+    CANCEL = "cancel"
+    KILL = "kill"
+    RETRY = "retry"
+
+
+class ControlRequest(BaseModel):
+    reason: str = Field(min_length=1, max_length=1000)
+    grace_seconds: float = Field(default=5.0, ge=0.0, le=300.0)
+    cascade: bool = False
+    expected_state: RunnerState | None = None
+    idempotency_key: str | None = Field(default=None, max_length=128)
+    metadata: dict = Field(default_factory=dict)
+
+
+class RetryRequest(ControlRequest):
+    from_checkpoint: str | None = Field(default=None, max_length=256)
+    attempt_label: str | None = Field(default=None, max_length=128)
+
+
+class RunnerHandle(BaseModel):
+    session_id: str
+    play_id: str | None = None
+    invocation_id: str | None = None
+    runner_kind: RunnerKind
+    runner_ref: str | None = None  # opaque provider/local handle, never a secret
+    state: RunnerState
+    location_label: str
+    pid: int | None = None
+    process_group_id: int | None = None
+    heartbeat_at: float | None = None
+    artifact_root: str | None = None
+    log_ref: str | None = None
+    capabilities: set[RunControl] = Field(default_factory=set)
+    metadata: dict = Field(default_factory=dict)
+
+
+class RunnerLogLine(BaseModel):
+    cursor: str
+    created_at: float
+    stream: str
+    text: str
+    metadata: dict = Field(default_factory=dict)
+
+
+class ControlResponse(BaseModel):
+    request_id: str
+    target_type: str
+    target_id: str
+    session_id: str
+    action: RunControl
+    accepted: bool
+    request_status: str
+    runner_state: RunnerState
+    detail: str = ""
+
+
+class RuntimeStatusResponse(BaseModel):
+    target_type: str
+    target_id: str
+    session_id: str
+    play_status: str | None = None
+    session_status: str
+    runner_handle: RunnerHandle | None = None
+    last_control_request_id: str | None = None
+    cost_cents: int | None = None
+
+
+class PlayRunner(Protocol):
+    kind: RunnerKind
+
+    async def start(self, request: Mapping) -> RunnerHandle: ...
+    async def control(
+        self,
+        handle: RunnerHandle,
+        action: RunControl,
+        request: ControlRequest,
+    ) -> RunnerHandle: ...
+    async def status(self, handle: RunnerHandle) -> RunnerHandle: ...
+    async def logs(
+        self,
+        handle: RunnerHandle,
+        *,
+        cursor: str | None = None,
+        limit: int = 500,
+    ) -> AsyncIterator[RunnerLogLine]: ...
+    async def cleanup(self, handle: RunnerHandle) -> None: ...
+```
+
+`RunnerHandle`, `RunnerState`, `RunControl`, and `ControlRequest` are the only accepted vocabulary.
+ADR-0057 runner implementations must import these types and must not define alternate handle/status
+types, runner lifecycle tables, log tables, or a second runner-state enum.
+
+### Runner State Machine
+
+The state machine is intentionally small and runner-neutral:
+
+| Current state | Allowed controls | Next state before side effect | Terminal mapping |
+|---------------|------------------|-------------------------------|------------------|
+| `pending`, `starting` | `cancel`, `kill` | `cancelling`, `killing` | `cancelled` |
+| `running` | `pause`, `cancel`, `kill` | `pausing`, `cancelling`, `killing` | runner-specific |
+| `paused` | `resume`, `cancel`, `kill` | `resuming`, `cancelling`, `killing` | runner-specific |
+| `failed`, `timed_out`, `cancelled`, `killed`, `lost` | `retry` | `retrying` | new session/handle |
+| `completed` | `retry` | `retrying` | new session/handle |
+
+Runner terminal states map to session terminal statuses as follows:
+
+| RunnerState | `sessions.status` |
+|-------------|-------------------|
+| `completed` | `completed` |
+| `failed` | `failed` |
+| `timed_out` | `timed_out` |
+| `cancelled` | `cancelled` |
+| `killed` | `cancelled` with force-kill reason |
+| `lost` | no automatic session terminal write until policy classifies it |
+
+Every accepted state transition writes a `status_transitions` row with
+`entity_type='runner_handle'`, `entity_id=session_id`, `source='admin'` or `source='executor'`, and a
+non-null actor. Destructive terminal controls also update the linked session through
+`StateStore.update_status()`.
+
+### HTTP API
+
+Mount the router under the existing Studio `/api` prefix. All endpoints, including `GET` endpoints,
+use an explicit bearer-auth dependency and fail closed when an actor cannot be resolved.
+
+```python
+# apps/studio/server/routers/play_control.py
+
+from fastapi import APIRouter, Depends, Query, Request
+
+router = APIRouter(tags=["play-control"])
+
+
+@router.post("/plays/{play_id}/pause", status_code=202)
+async def pause_play(
+    play_id: str,
+    body: ControlRequest,
+    actor: Actor = Depends(require_studio_actor),
+) -> ControlResponse: ...
+
+
+@router.post("/plays/{play_id}/resume", status_code=202)
+async def resume_play(
+    play_id: str,
+    body: ControlRequest,
+    actor: Actor = Depends(require_studio_actor),
+) -> ControlResponse: ...
+
+
+@router.post("/plays/{play_id}/cancel", status_code=202)
+async def cancel_play(
+    play_id: str,
+    body: ControlRequest,
+    actor: Actor = Depends(require_studio_actor),
+) -> ControlResponse: ...
+
+
+@router.post("/plays/{play_id}/kill", status_code=202)
+async def kill_play(
+    play_id: str,
+    body: ControlRequest,
+    actor: Actor = Depends(require_studio_actor),
+) -> ControlResponse: ...
+
+
+@router.post("/plays/{play_id}/retry", status_code=202)
+async def retry_play(
+    play_id: str,
+    body: RetryRequest,
+    actor: Actor = Depends(require_studio_actor),
+) -> ControlResponse: ...
+
+
+@router.get("/plays/{play_id}/status")
+async def play_runtime_status(
+    play_id: str,
+    actor: Actor = Depends(require_studio_actor),
+) -> RuntimeStatusResponse: ...
+
+
+@router.get("/plays/{play_id}/logs")
+async def read_logs(
+    play_id: str,
+    actor: Actor = Depends(require_studio_actor),
+    cursor: str | None = Query(default=None),
+    limit: int = Query(default=500, ge=1, le=2000),
+    follow: bool = Query(default=False),
+) -> LogPage | StreamingResponse: ...
+
+
+@router.post("/sessions/{session_id}/control/{action}", status_code=202)
+async def control_session(
+    session_id: str,
+    action: RunControl,
+    body: ControlRequest,
+    actor: Actor = Depends(require_studio_actor),
+) -> ControlResponse: ...
+
+
+@router.get("/sessions/{session_id}/runtime")
+async def session_runtime_status(
+    session_id: str,
+    actor: Actor = Depends(require_studio_actor),
+) -> RuntimeStatusResponse: ...
+```
+
+`require_studio_actor` validates `Authorization: Bearer <token>`, derives an actor id, and rejects
+requests with `401` when the token is missing or invalid. The play-control router does not rely on
+the current generic middleware because GET status and log routes are sensitive.
+
+### State Schema
+
+ADR-0056 owns exactly two control-plane tables. The DDL below is logical; SQLite and Postgres
+implement it through ADR-0059 schema management and StateStore methods.
+
+```sql
+CREATE TABLE IF NOT EXISTS runner_handles (
+  session_id        TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+  play_id           TEXT REFERENCES plays(id) ON DELETE SET NULL,
+  invocation_id     TEXT REFERENCES invocations(id) ON DELETE SET NULL,
+  runner_kind       TEXT NOT NULL,
+  runner_ref        TEXT,
+  state             TEXT NOT NULL,
+  location_label    TEXT NOT NULL,
+  pid               INTEGER,
+  process_group_id  INTEGER,
+  heartbeat_at      REAL,
+  artifact_root     TEXT,
+  log_ref           TEXT,
+  capabilities_json JSON NOT NULL DEFAULT '[]',
+  metadata_json     JSON NOT NULL DEFAULT '{}',
+  state_updated_at  REAL NOT NULL,
+  created_at        REAL NOT NULL,
+  updated_at        REAL NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_runner_handles_play
+  ON runner_handles(play_id) WHERE play_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_runner_handles_invocation
+  ON runner_handles(invocation_id) WHERE invocation_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_runner_handles_state
+  ON runner_handles(state, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS run_control_requests (
+  id                  TEXT PRIMARY KEY,
+  target_type         TEXT NOT NULL,
+  target_id           TEXT NOT NULL,
+  resolved_session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  action              TEXT NOT NULL,
+  request_status      TEXT NOT NULL,
+  requested_by        TEXT NOT NULL,
+  reason              TEXT NOT NULL,
+  idempotency_key     TEXT,
+  expected_state      TEXT,
+  grace_seconds       REAL NOT NULL DEFAULT 5.0,
+  cascade             INTEGER NOT NULL DEFAULT 0,
+  runner_kind         TEXT,
+  runner_ref          TEXT,
+  created_at          REAL NOT NULL,
+  claimed_at          REAL,
+  completed_at        REAL,
+  error               TEXT,
+  metadata_json       JSON NOT NULL DEFAULT '{}'
+);
+
+CREATE INDEX IF NOT EXISTS idx_run_control_requests_target
+  ON run_control_requests(target_type, target_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_run_control_requests_session
+  ON run_control_requests(resolved_session_id, created_at DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_run_control_requests_idempotency
+  ON run_control_requests(target_type, target_id, action, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+```
+
+No log table is added here. The logs endpoint reads through `PlayRunner.logs()` and may persist
+bounded log chunks as ADR-0053 artifacts when a runner supports upload. Log content is always served
+through authenticated endpoints and never exposed by absolute server paths.
+
+### StateStore Contract
+
+All state access goes through ADR-0059's `StateStore`. Control-plane code must not call `db.db` or
+use backend-specific lock statements. Atomicity is expressed through the transaction abstraction:
+
+```python
+# lionagi/state/store.py additions
+
+from contextlib import AbstractAsyncContextManager
+from typing import Protocol
+
+class StateStore(Protocol):
+    def transaction(self) -> AbstractAsyncContextManager["StateTxn"]: ...
+
+    async def upsert_runner_handle(self, handle: RunnerHandle) -> None: ...
+    async def get_runner_handle(self, session_id: str) -> RunnerHandle | None: ...
+    async def get_runner_handle_for_play(self, play_id: str) -> RunnerHandle | None: ...
+    async def list_runner_controls(
+        self,
+        session_id: str,
+        *,
+        limit: int = 50,
+    ) -> list[dict]: ...
+
+
+class StateTxn(Protocol):
+    async def create_control_request(
+        self,
+        *,
+        target_type: str,
+        target_id: str,
+        resolved_session_id: str,
+        action: RunControl,
+        requested_by: str,
+        reason: str,
+        idempotency_key: str | None,
+        expected_state: RunnerState | None,
+        grace_seconds: float,
+        cascade: bool,
+        metadata: dict | None = None,
+    ) -> dict: ...
+
+    async def claim_control_request(self, request_id: str) -> dict: ...
+    async def complete_control_request(
+        self,
+        request_id: str,
+        *,
+        request_status: str,
+        error: str | None = None,
+        metadata: dict | None = None,
+    ) -> None: ...
+
+    async def transition_runner_state(
+        self,
+        session_id: str,
+        *,
+        new_state: RunnerState,
+        reason_code: str,
+        reason_summary: str,
+        actor: str,
+        source: str,
+        control_request_id: str | None = None,
+        metadata: dict | None = None,
+    ) -> RunnerHandle: ...
+```
+
+A control request is created and the runner handle is moved to an in-progress state in one
+transaction before the runner side effect is attempted. If the runner call fails, the request is
+marked `failed`; the linked session is not moved to a terminal status unless the failure is itself
+the observed terminal runtime outcome.
+
+### Coupling and Testability
+
+The design has five primary components: Studio router, control service, StateStore, PlayRunner
+registry, and runner implementations. Required dependencies are router -> service, service ->
+StateStore, service -> PlayRunner, runner -> StateStore for heartbeat/state updates, and runner ->
+artifact persistence for log/artifact upload. With five components and five directed dependencies,
+`κ = 5 / (5 * 4) = 0.25`, under the 0.3 target. Testability target `τ > 0.8` is met by fake runners,
+StateStore contract tests, FastAPI auth tests, and local process-control integration tests.
+
+## Implementation
+
+### Phase 0 - Contract and Schema (MVP foundation, 300-450 LOC)
+
+- Add `lionagi/runtime/control.py` for the enums, Pydantic models, state-machine validation, and
+  `PlayRunner` protocol. Estimate: 180 LOC.
+- Add `runner_handles` and `run_control_requests` to `lionagi/state/schema.sql` and the Postgres DDL
+  in ADR-0059's implementation. Estimate: 90 LOC.
+- Extend `StateStore` and `StateDB` facade methods for runner handles, control requests, and runner
+  state transitions. Estimate: 170 LOC.
+- Extend status reason validation so `entity_type='runner_handle'` transitions are valid. Estimate:
+  30 LOC.
+
+### Phase 1 - Local Control Behavior (350-550 LOC)
+
+- Register a `RunnerHandle` when `start_live_persist()` creates a session row in
+  `lionagi/cli/orchestrate/_orchestration.py`. Include PID, process group id, artifact root, and a
+  server-local `log_ref`; do not expose absolute paths through API responses. Estimate: 50 LOC.
+- Extract reusable PID/process-group utilities from `lionagi/cli/kill.py` into
+  `lionagi/runtime/process_control.py`, then update `li kill` to share them. Estimate: 120 LOC net.
+- Implement `LocalWorktreeRunner` status, logs, pause, resume, cancel, kill, and cleanup using the
+  0056 protocol. Estimate: 260 LOC.
+- Add a fake runner for deterministic unit and API tests. Estimate: 80 LOC.
+
+### Phase 2 - Studio API (300-500 LOC)
+
+- Add `apps/studio/server/auth.py` with `require_studio_actor`; it must authenticate all play-control
+  routes, including status and logs. Estimate: 80 LOC.
+- Add `apps/studio/server/services/play_control.py` to resolve play/session/invocation targets,
+  create/claim/complete control requests, call the runner, and write status transitions. Estimate:
+  260 LOC.
+- Add `apps/studio/server/routers/play_control.py` and mount it from `apps/studio/server/app.py`.
+  Estimate: 130 LOC.
+- Include runtime summaries in runs/show detail responses without requiring unauthenticated
+  waterfall calls. Estimate: 70 LOC.
+
+### Phase 3 - UI and Retry (350-700 LOC)
+
+- Add runner badges and valid control buttons to run and show-play pages. Estimate: 250 LOC.
+- Add typed API client methods and response types. Estimate: 120 LOC.
+- Implement retry only for terminal playbook-backed sessions whose launch metadata is complete.
+  Retry creates a new session and a new `RunnerHandle`; it does not mutate the old terminal handle.
+  Estimate: 250 LOC.
+
+### Phase 4 - Remote Runner Integration (owned by ADR-0057, 100-200 LOC in this ADR)
+
+- Wire ADR-0057 runner backends into the `PlayRunner` registry without changing this API contract.
+- Ensure remote runner state, logs, and artifacts write through 0056/0053/0058 contracts rather than
+  provider-specific Studio routes.
+
+## Security
+
+- Every endpoint in this ADR requires bearer authentication, including `GET /status` and
+  `GET /logs`. The route dependency must not rely on the current generic middleware because that
+  middleware does not protect non-admin GET routes.
+- `requested_by` is non-null for accepted controls. MVP actor identity is the bearer token subject,
+  or a stable operator id bound to that token by configuration. If the actor cannot be resolved, the
+  API returns `401` or `403` and does not create a control request.
+- Logs may contain prompts, tool output, environment names, or secrets. Log responses are
+  authenticated, bounded by `limit`, marked `Cache-Control: no-store`, and redacted when redaction
+  hooks are configured.
+- The API accepts only the `RunControl` enum. It never accepts arbitrary signal names, shell
+  commands, filesystem paths, provider command strings, or provider credentials from the browser.
+- `runner_ref` is opaque and non-secret. API keys, SSH private keys, provider tokens, signed upload
+  URLs, and full bearer tokens are never stored in `runner_handles`.
+- Local PID control must guard against PID reuse where practical by checking process group,
+  executable metadata, and heartbeat freshness before signaling. Evidence records include PID,
+  process group id, runner kind, request id, actor, and timestamps.
+- `kill` is privileged and destructive. Production UI must require a non-empty reason and visually
+  separate force kill from graceful cancel.
+- Control requests are append-only except for claim/completion fields. Destructive terminal controls
+  must update the linked session through `StateStore.update_status()` and write a runner-handle
+  transition.
+- Remote credential issuance is specified by ADR-0057, but this ADR sets the boundary: sandboxes do
+  not receive full API keys through `ControlRequest`, `RunnerHandle`, or any Studio request body.
+
+## Migration
+
+1. Apply the additive schema migration for `runner_handles` and `run_control_requests`. Existing
+   `sessions`, `plays`, `invocations`, `artifacts`, and `status_transitions` rows remain valid.
+2. Do not backfill terminal sessions. Their runtime state is derived from `sessions.status`.
+3. For currently running sessions, attempt best-effort handle creation from `sessions.node_metadata`
+   and known pid-file locations. If no live process can be verified, no handle is created and status
+   endpoints report `runner_state='lost'`.
+4. Register handles for all new CLI flow/play sessions when `start_live_persist()` creates the
+   session row.
+5. Keep `li kill` behavior for one release, then move it onto the same process-control and
+   StateStore methods so terminal and Studio actions produce equivalent evidence.
+6. Hide Studio controls unless a handle exists and the runner reports the requested capability.
+7. Retry remains disabled until launch reconstruction is implemented. The endpoint may return `409`
+   for unsupported targets during Phase 2.
+
+## Testing
+
+- Unit-test enum parsing, state-machine transition rules, `ControlRequest` validation, and invalid
+  action rejection.
+- Migration-test databases created before this ADR; existing play and session statuses must survive.
+- StateStore contract-test idempotency under duplicate `idempotency_key` values and concurrent
+  control attempts.
+- FastAPI-test every endpoint with no token, bad token, and valid token. Reads and writes must both
+  require auth.
+- Local runner tests with a controlled long-running subprocess must cover pause, resume, cancel,
+  kill, log paging, and lost PID detection.
+- Verify `status_transitions` rows for runner state changes and terminal session cancellation.
+- Fake-runner API tests must prove the router and service do not depend on POSIX signal behavior.
+
+## Alternatives Considered
+
+### Extend `plays.status` With Runtime States
+
+Rejected. `plays.status` is a show workflow state, not a runner lifecycle. Mixing gate/merge states
+with runtime states makes a paused-but-gated play impossible to represent and forces schema churn.
+
+### Make ADR-0057 Own Execution State
+
+Rejected. That was the source of the circular dependency and duplicate control plane. ADR-0056 owns
+runner handles, control requests, and the state machine. ADR-0057 consumes those contracts.
+
+### Shell Out From Studio to `li kill`
+
+Rejected as the control plane. It is useful implementation reuse for local process control, but it
+does not support pause/resume/retry, remote runners, idempotent browser requests, or durable actor
+attribution before side effects.
+
+### Router Sends Signals Directly
+
+Rejected. Direct signal calls make the fastest local demo, but they lose durable operator intent and
+make concurrent requests, retries, and remote runners hard to reason about.
+
+## Consequences
+
+Positive:
+
+- Studio becomes an authenticated, auditable orchestration control plane.
+- ADR-0056 and ADR-0057 have a one-way dependency: ADR-0057 depends on this ADR.
+- Local and remote runners share one vocabulary and API contract.
+- Existing show-play workflow semantics remain intact.
+- State access is backend-neutral through ADR-0059.
+
+Negative:
+
+- Runner handles add a projection that must be kept in sync with session lifecycle.
+- Local pause/resume is POSIX-oriented until cooperative checkpoints or provider-specific support
+  are added.
+- Retry is intentionally delayed because faithful retry requires persisted launch metadata,
+  checkpoint policy, cost attribution, and artifact contract reuse.

--- a/docs/adrs/ADR-0057-remote-sandbox-execution.md
+++ b/docs/adrs/ADR-0057-remote-sandbox-execution.md
@@ -1,0 +1,435 @@
+# ADR-0057: Remote Sandbox Execution Behind PlayRunner
+
+Status: proposed (rewrite after rejected review)
+Date: 2026-05-27
+Decision owners: @governance-maintainers
+Depends on: ADR-0056 (play control API), ADR-0059 (Postgres state backend), ADR-0060 (unified config resolution)
+Related: ADR-0044 (tool gates), ADR-0045 (break-glass), ADR-0053 (artifact persistence), ADR-0058 (play cost tracking)
+
+## Context
+
+Governed orchestration needs an execution boundary that is stronger than a local developer process.
+The current flow engine plans a typed DAG and persists live state, but worker execution still happens
+inside the host process tree. `build_worker_branch()` sets each worker repo to an artifact directory
+and then grants write access to the real project directory through `add_dir`
+(`lionagi/cli/orchestrate/_orchestration.py:404-414`). That is productive for local development, but
+it is not process, network, CPU, memory, or secret isolation.
+
+The existing local sandbox primitive is a git worktree. `lionagi/tools/sandbox.py` creates a branch,
+captures diffs, commits, merges, and discards worktrees (`lionagi/tools/sandbox.py:4-14`,
+`lionagi/tools/sandbox.py:46-177`). Worktrees are the right local compatibility runner because they
+preserve reviewable diffs and avoid repository copies. They are not a production isolation boundary:
+the process still has the host user's credentials and network access unless another layer constrains
+it.
+
+Studio and run detail currently assume local state is readable from the server. The runs list reads
+SQLite sessions (`apps/studio/server/services/runs.py:503-596`), but run detail still falls back to
+`~/.lionagi/runs/{run_id}` manifests and branch JSON snapshots
+(`apps/studio/server/services/runs.py:621-650`). Remote execution cannot require the Studio server
+to read provider filesystems or SSH into sandboxes. Runner status, logs, artifacts, diffs, costs, and
+cleanup outcomes must be uploaded or reported through the central control plane.
+
+ADR-0056 now owns that control plane: `RunnerHandle`, `RunnerState`, `RunControl`,
+`ControlRequest`, `PlayRunner`, `runner_handles`, `run_control_requests`, control endpoints, and the
+state machine. ADR-0057 depends on ADR-0056 and implements runner backends behind the 0056 protocol.
+It does not define a separate execution table, log table, runner table, status vocabulary, or
+control API.
+
+Runner configuration is also owned elsewhere. ADR-0060 defines `ResourceKind.RUNNERS` and resolves
+runner files from the project/user/plugin cascade (`docs/adrs/ADR-0060-unified-config-resolution.md:44-55`,
+`docs/adrs/ADR-0060-unified-config-resolution.md:101-128`). This ADR therefore must not introduce a
+separate runner settings block. Playbooks and CLI flags may select a runner by name; the runner
+definition itself is loaded through the ADR-0060 resource resolver.
+
+## Decision
+
+Implement remote and local execution as `PlayRunner` backends that import the canonical protocol and
+types from ADR-0056. The first backend is `LocalWorktreeRunner`; remote backends include
+`DaytonaRunner`, `E2BRunner`, `CodespaceRunner`, and `SSHRunner` as demand warrants.
+
+```python
+# lionagi/runtime/runners/base.py
+
+from lionagi.runtime.control import (
+    ControlRequest,
+    PlayRunner,
+    RunControl,
+    RunnerHandle,
+    RunnerKind,
+    RunnerLogLine,
+    RunnerState,
+)
+```
+
+Runner implementations may use provider-specific SDK objects internally, but the only durable state
+they publish is the ADR-0056 `RunnerHandle` plus `status_transitions` entries. Artifacts and durable
+log chunks use ADR-0053 artifact persistence. Cost observations use ADR-0058 cost events. State
+transactions use ADR-0059. Runner configuration uses ADR-0060.
+
+### Runner Backends
+
+`LocalWorktreeRunner` is the compatibility runner:
+
+- Creates a git worktree with the existing sandbox mechanics.
+- Runs the same `li play` or `li o flow` command inside that worktree.
+- Registers and updates the ADR-0056 `runner_handles` row.
+- Streams logs through `PlayRunner.logs()` and may persist bounded chunks as ADR-0053 artifacts.
+- Captures diffs as ADR-0053 artifacts rather than exposing server-local paths.
+- Uses local process-control helpers for pause/resume/cancel/kill.
+
+Remote runners use the same lifecycle:
+
+- Provision an isolated workspace from a repo URL, base ref, generated feature branch, image, and
+  limits.
+- Register the provider run id only as `RunnerHandle.runner_ref`.
+- Inject only short-lived vendored tokens and non-secret run metadata.
+- Execute the same CLI command as local runners with `LIONAGI_INVOCATION_ID`, `LIONAGI_RUN_ID`,
+  `LIONAGI_SESSION_ID`, `LIONAGI_RUNNER_KIND`, and `LIONAGI_STATE_API_URL`.
+- Upload status, heartbeat, logs, artifacts, and diffs through authenticated runner-ingest
+  endpoints.
+- Revoke tokens and clean up provider resources during terminal cleanup.
+
+### Runner Registry and Configuration
+
+Add `lionagi/runtime/runner_registry.py`. It resolves runner names through ADR-0060:
+
+```python
+from pathlib import Path
+from typing import Any
+
+from lionagi.config_resolution import ResourceKind, resolve_resource
+from lionagi.runtime.control import PlayRunner
+
+
+def load_runner_config(name: str, *, cwd: Path | None = None) -> dict[str, Any]:
+    location = resolve_resource(ResourceKind.RUNNERS, name, cwd=cwd)
+    if location is None:
+        raise RunnerConfigError(f"runner {name!r} was not found")
+    return parse_runner_yaml(location.path)
+
+
+def build_runner(name: str, *, cwd: Path | None = None) -> PlayRunner:
+    config = load_runner_config(name, cwd=cwd)
+    return build_runner_from_config(config)
+```
+
+Canonical runner files live in the ADR-0060 cascade:
+
+```yaml
+# .lionagi/runners/daytona.yaml
+kind: daytona
+image: ghcr.io/lionagi/lionagi-sandbox:latest
+limits:
+  timeout_s: 2400
+  cpu_count: 4
+  memory_mb: 8192
+  disk_mb: 20480
+network:
+  mode: allowlist
+  hosts:
+    - github.com
+    - api.openai.com
+credential_policy:
+  state_token_ttl_s: 900
+  model_broker: required
+  source_control: branch_scoped
+cleanup:
+  retain_failed_s: 86400
+  retain_success_s: 3600
+```
+
+Playbooks may select the runner by name without embedding secrets:
+
+```yaml
+name: guarded-review
+runner: daytona
+runner_limits:
+  timeout_s: 2400
+  cpu_count: 4
+  memory_mb: 8192
+```
+
+CLI flags may override the runner name:
+
+```bash
+li play guarded-review --runner daytona
+li o flow "review the PR" --runner local_worktree
+```
+
+If no runner is selected, the compatibility default is `local_worktree`. Any default beyond that is a
+resolved resource/default owned by ADR-0060, not a new settings schema in this ADR.
+
+### State Model
+
+ADR-0057 adds no tables. Runner backends use:
+
+| Concern | Owner | Storage |
+|---------|-------|---------|
+| Current runner location/state | ADR-0056 | `runner_handles` |
+| Operator intent | ADR-0056 | `run_control_requests` |
+| State history | ADR-0028 / ADR-0056 | `status_transitions` with `entity_type='runner_handle'` |
+| Artifacts and diffs | ADR-0053 | immutable `artifacts` rows |
+| Durable log chunks | ADR-0053 | `artifacts.kind='runner_log_chunk'` |
+| Cost | ADR-0058 | integer-cent `cost_events` |
+| Config | ADR-0060 | `ResourceKind.RUNNERS` cascade |
+
+Runner-specific metadata, including provider workspace ids, upload token hashes, cleanup status, and
+network policy snapshots, is stored in `runner_handles.metadata_json`. Secrets are never stored there.
+
+### Runner Ingest API
+
+Remote sandboxes do not receive database credentials. They write through narrow authenticated ingest
+endpoints. These endpoints are not a second control plane; they only update ADR-0056 runner handles,
+ADR-0028 status transitions, and ADR-0053 artifacts.
+
+```python
+# apps/studio/server/routers/runner_ingest.py
+
+@router.post("/runner-ingest/{session_id}/heartbeat", status_code=204)
+async def heartbeat(
+    session_id: str,
+    body: HeartbeatRequest,
+    token: RunnerToken = Depends(require_runner_token),
+) -> None: ...
+
+
+@router.post("/runner-ingest/{session_id}/status", status_code=202)
+async def runner_status(
+    session_id: str,
+    body: RunnerStatusUpdate,
+    token: RunnerToken = Depends(require_runner_token),
+) -> None: ...
+
+
+@router.post("/runner-ingest/{session_id}/logs", status_code=202)
+async def runner_logs(
+    session_id: str,
+    body: RunnerLogUpload,
+    token: RunnerToken = Depends(require_runner_token),
+) -> UploadAck: ...
+
+
+@router.post("/runner-ingest/{session_id}/artifacts", status_code=202)
+async def runner_artifact(
+    session_id: str,
+    body: RunnerArtifactUpload,
+    token: RunnerToken = Depends(require_runner_token),
+) -> UploadAck: ...
+```
+
+Required behavior:
+
+- The bearer token is bound to exactly one `session_id` and `runner_ref`.
+- `logs` uploads are idempotent on `(session_id, stream, seq)`; duplicates return the existing ack.
+- Log uploads have a body-size cap and total-run cap from runner config.
+- Artifact uploads compute SHA-256 server-side and persist through ADR-0053. Provider paths are
+  metadata only.
+- Status updates validate monotonic transitions against the ADR-0056 state machine.
+- Cross-session writes, expired tokens, revoked tokens, replayed tokens with mismatched sequence
+  metadata, and oversized uploads are rejected and audited.
+
+### Credential Vending
+
+Full API keys, broad GitHub tokens, SSH private keys, and provider credentials must never be passed
+into arbitrary-code sandboxes. Runner start uses a token vending service:
+
+```python
+class CredentialScope(StrEnum):
+    STATE_HEARTBEAT = "state:heartbeat"
+    STATE_STATUS = "state:status"
+    STATE_LOG_WRITE = "state:log_write"
+    STATE_ARTIFACT_WRITE = "state:artifact_write"
+    MODEL_BROKER = "model:broker"
+    SOURCE_BRANCH = "source:branch"
+
+
+class VendedCredential(BaseModel):
+    token: str
+    token_id: str
+    session_id: str
+    runner_ref: str
+    scopes: set[CredentialScope]
+    expires_at: float
+```
+
+Issuance rules:
+
+- The control service issues credentials only after a `RunnerHandle` exists.
+- The sandbox receives opaque short-lived tokens, not the host's full API keys.
+- Token secrets are returned once and stored only as salted hashes in `runner_handles.metadata_json`.
+- State ingest tokens have a maximum TTL of 15 minutes and may be renewed only by a valid heartbeat.
+- Model access uses a broker token where possible; the sandbox calls the broker, which holds the
+  real provider key server-side. If a provider cannot be brokered or scoped, that provider is not
+  available to the remote sandbox by default.
+- Source-control access is branch-scoped. Prefer deploy keys, fine-grained installation tokens, or
+  provider-native workspace identity restricted to the generated branch. Broad source-control
+  credentials are not injected.
+- Revocation is durable: `cancel`, `kill`, break-glass, cleanup, TTL expiry, and provider teardown
+  mark the token id revoked in `runner_handles.metadata_json`. Every ingest and broker request checks
+  hash, scope, session binding, expiry, and revocation.
+
+### Coupling and Testability
+
+The runner layer has six primary components: runner registry, LocalWorktreeRunner, remote provider
+runners, credential vending, runner ingest router, and StateStore. Directed dependencies are registry
+-> ADR-0060 resolver, runners -> ADR-0056 protocol, runners -> credential vending, ingest router ->
+StateStore, ingest router -> ADR-0053 artifacts, and runners -> StateStore for handle updates.
+`κ = 6 / (6 * 5) = 0.20`, under the 0.3 target. Testability target `τ > 0.8` is met with fake
+providers, local worktree integration tests, runner-ingest auth tests, and opt-in provider tests.
+
+## Implementation
+
+### Phase 0 - Consume ADR-0056 Contracts (250-400 LOC)
+
+- Add `lionagi/runtime/runners/base.py` that imports the 0056 protocol and re-exports no duplicate
+  vocabulary. Estimate: 40 LOC.
+- Add `lionagi/runtime/runner_registry.py` backed by ADR-0060 `ResourceKind.RUNNERS`. Estimate:
+  140 LOC.
+- Add `FakeRunner` and shared runner contract tests. Estimate: 180 LOC.
+- Remove any draft references to alternate runner state models. Estimate: 30 LOC.
+
+Exit criteria: a fake runner can start, report status, stream logs, accept controls, and update the
+0056 handle model without any 0057-owned schema.
+
+### Phase 1 - LocalWorktreeRunner (350-550 LOC)
+
+- Implement `LocalWorktreeRunner` using `lionagi/tools/sandbox.py` for worktree creation, diff,
+  merge, and cleanup. Estimate: 260 LOC.
+- Run the existing CLI command in the worktree with the correct run/session/invocation environment.
+  Estimate: 100 LOC.
+- Persist diffs and bounded logs through ADR-0053 artifacts. Estimate: 100 LOC.
+- Share local pause/resume/cancel/kill behavior with ADR-0056's process-control module. Estimate:
+  80 LOC.
+
+Exit criteria: `li play NAME --runner local_worktree` registers a `RunnerHandle`, streams logs,
+captures a diff artifact, supports cancel/kill, and cleans up according to the runner config.
+
+### Phase 2 - Credential Vending and Runner Ingest (450-750 LOC)
+
+- Add `apps/studio/server/services/runner_credentials.py` for token issuance, hash storage,
+  verification, renewal, and revocation. Estimate: 220 LOC.
+- Add `apps/studio/server/routers/runner_ingest.py` with heartbeat, status, logs, and artifact
+  upload endpoints. Estimate: 220 LOC.
+- Add body-size limits, monotonic log sequence checks, SHA-256 artifact verification, and negative
+  tests for cross-session writes. Estimate: 180 LOC.
+- Add broker-token plumbing for model access where the configured provider supports it. Estimate:
+  120 LOC.
+
+Exit criteria: a fake remote runner can run without database credentials or host API keys and can
+upload status, logs, and artifacts using only scoped tokens.
+
+### Phase 3 - Remote Providers (600-1200 LOC per first provider)
+
+- Implement `DaytonaRunner` for managed workspaces. Estimate: 700 LOC including tests.
+- Implement `E2BRunner` for ephemeral sandbox runs. Estimate: 700 LOC including tests.
+- Implement `SSHRunner` for self-hosted isolated hosts. Estimate: 450 LOC.
+- Defer `CodespaceRunner` until GitHub workspace lifecycle control is a concrete requirement.
+
+Exit criteria: at least one ephemeral runner and one persistent workspace runner pass the same
+contract suite as `LocalWorktreeRunner`.
+
+### Phase 4 - Governance Hardening (350-650 LOC)
+
+- Bind runner start/control/cleanup events to evidence records when that path is active. Estimate:
+  200 LOC.
+- Enforce break-glass revocation by cancelling or preventing resume for affected handles. Estimate:
+  180 LOC.
+- Add cost hooks for ADR-0058 using integer cents. Estimate: 120 LOC.
+- Add adversarial tests for secret logging, token replay, provider cleanup failure, stale heartbeat,
+  artifact tampering, and network allowlist bypass. Estimate: 300 LOC.
+
+## Security
+
+- All runner-ingest endpoints require bearer authentication with vendored runner tokens. All
+  operator-facing status, log, and control endpoints remain authenticated by ADR-0056.
+- Sandboxes never receive full API keys, broad source-control credentials, SSH private keys, provider
+  tokens, database credentials, or the host process environment wholesale.
+- Logs are sensitive. Runner implementations must redact configured secret values before upload,
+  ingest responses use `Cache-Control: no-store`, and log artifacts are never served through
+  unauthenticated URLs.
+- Remote runners must not receive local project `add_dir` access. They receive a clean clone or
+  provider workspace on a generated branch.
+- Network policy is deny-by-default unless a runner config explicitly allowlists hosts. Model APIs,
+  source control, and package mirrors are added only when the play requires them.
+- Artifact upload verifies server-computed SHA-256 and size before insertion. Provider file paths are
+  treated as untrusted metadata and must not appear as absolute server paths in Studio responses.
+- Token TTL and revocation are enforcement points, not documentation. Cancel, kill, cleanup,
+  break-glass, and expiry make subsequent ingest/broker requests fail closed.
+- Cleanup failure is visible. A runner may reach a terminal session state while leaving
+  `runner_handles.metadata_json.cleanup` with follow-up status for the operator.
+
+## Migration
+
+1. Delete the rejected draft's separate execution/log table concepts from implementation plans. No
+   database migration creates those tables.
+2. Add runner config files under the ADR-0060 cascade, for example `.lionagi/runners/local_worktree.yaml`.
+   Do not add a new runner block to settings.
+3. Existing `li play` and `li o flow` behavior remains local. When no runner is selected, use
+   `local_worktree` compatibility mode after ADR-0056 handle registration exists.
+4. Existing run detail continues to read legacy filesystem manifests for old local runs. New remote
+   runs must render from `runner_handles`, `status_transitions`, and ADR-0053 artifacts.
+5. Existing schedules that launch plays may continue spawning local subprocesses until the scheduler
+   is wired to the runner registry. Once migrated, scheduled plays select runners the same way CLI
+   plays do.
+6. Any existing environment allowlist examples that pass model-provider or source-control API keys
+   into sandboxes must be replaced with token vending or broker access.
+
+## Testing
+
+- Contract-test `FakeRunner`, `LocalWorktreeRunner`, and each remote runner with the same start,
+  status, logs, control, artifact, and cleanup scenarios.
+- Integration-test `LocalWorktreeRunner` in a temporary git repository: create worktree, run a short
+  play, write an artifact, capture diff, cancel a long-running run, and clean up.
+- API-test runner ingest with valid token, missing token, expired token, revoked token, wrong
+  session, wrong scope, duplicate log sequence, oversized body, and replay attempt.
+- Security-test that raw provider keys and broad source-control tokens are absent from sandbox
+  environment, logs, artifacts, and `runner_handles.metadata_json`.
+- Migration-test that no 0057-owned tables are created and existing local runs remain visible.
+- Provider tests are opt-in behind environment flags and must use disposable workspaces.
+
+## Alternatives Considered
+
+### Keep Local Worktrees Only
+
+Accepted as the MVP runner, rejected as the final architecture. Worktrees provide good diffs and
+fast local workflows, but they do not isolate process, network, resources, or inherited secrets.
+
+### Provider-Specific Studio Routes
+
+Rejected. Provider-specific routes would leak Daytona/E2B/Codespaces semantics into Studio and
+duplicate status, logs, artifacts, and control behavior. The `PlayRunner` protocol keeps providers
+behind one contract.
+
+### 0057-Owned Execution Tables
+
+Rejected. A separate execution or log model recreates the circular dependency and competes with
+ADR-0056. Runner backends use `runner_handles`, `run_control_requests`, `status_transitions`, and
+ADR-0053 artifacts.
+
+### Direct Database Access From Sandboxes
+
+Rejected as the default. It widens credential scope and couples provider network policy to database
+topology. Self-hosted runners may opt into narrow database credentials later, but the default is
+authenticated runner ingest with scoped tokens.
+
+### Kubernetes Runner First
+
+Deferred. Kubernetes is credible for enterprise deployments, but it adds operational assumptions not
+yet present in lionagi. It can be added later as another `PlayRunner` backend.
+
+## Consequences
+
+Positive:
+
+- ADR-0057 now depends one-way on ADR-0056 and does not define a competing control plane.
+- Local and remote execution share one runner contract.
+- Remote sandboxes can reduce filesystem, process, network, and credential blast radius.
+- Runner config participates in ADR-0060 instead of adding resolver drift.
+- Token vending makes secret scope explicit and revocable.
+
+Negative:
+
+- Remote execution adds provider cost, cleanup, token issuance, and network-policy complexity.
+- Some model/source providers may not support the desired scoped-token semantics; those integrations
+  must use a broker or remain unavailable to remote sandboxes by default.
+- Logs and artifacts become ingestion workloads that need quotas and backpressure.

--- a/docs/adrs/ADR-0057-remote-sandbox-execution.md
+++ b/docs/adrs/ADR-0057-remote-sandbox-execution.md
@@ -228,45 +228,18 @@ Required behavior:
 - Cross-session writes, expired tokens, revoked tokens, replayed tokens with mismatched sequence
   metadata, and oversized uploads are rejected and audited.
 
-### Credential Vending
+### Credential Security
 
 Full API keys, broad GitHub tokens, SSH private keys, and provider credentials must never be passed
-into arbitrary-code sandboxes. Runner start uses a token vending service:
+into arbitrary-code sandboxes. Runners receive only short-lived, scope-limited tokens bound to a
+single session and runner handle. Security invariants:
 
-```python
-class CredentialScope(StrEnum):
-    STATE_HEARTBEAT = "state:heartbeat"
-    STATE_STATUS = "state:status"
-    STATE_LOG_WRITE = "state:log_write"
-    STATE_ARTIFACT_WRITE = "state:artifact_write"
-    MODEL_BROKER = "model:broker"
-    SOURCE_BRANCH = "source:branch"
-
-
-class VendedCredential(BaseModel):
-    token: str
-    token_id: str
-    session_id: str
-    runner_ref: str
-    scopes: set[CredentialScope]
-    expires_at: float
-```
-
-Issuance rules:
-
-- The control service issues credentials only after a `RunnerHandle` exists.
-- The sandbox receives opaque short-lived tokens, not the host's full API keys.
-- Token secrets are returned once and stored only as salted hashes in `runner_handles.metadata_json`.
-- State ingest tokens have a maximum TTL of 15 minutes and may be renewed only by a valid heartbeat.
-- Model access uses a broker token where possible; the sandbox calls the broker, which holds the
-  real provider key server-side. If a provider cannot be brokered or scoped, that provider is not
-  available to the remote sandbox by default.
-- Source-control access is branch-scoped. Prefer deploy keys, fine-grained installation tokens, or
-  provider-native workspace identity restricted to the generated branch. Broad source-control
-  credentials are not injected.
-- Revocation is durable: `cancel`, `kill`, break-glass, cleanup, TTL expiry, and provider teardown
-  mark the token id revoked in `runner_handles.metadata_json`. Every ingest and broker request checks
-  hash, scope, session binding, expiry, and revocation.
+- Sandboxes receive opaque tokens, not host API keys.
+- Tokens are scoped to specific operations (state writes, model access, source reads).
+- Token TTLs are short (minutes, not hours) and renewed only by valid heartbeats.
+- Model access uses brokered tokens where possible — the sandbox never holds provider keys directly.
+- Source-control access is branch-scoped via deploy keys or fine-grained tokens.
+- Revocation is durable and checked on every request.
 
 ### Coupling and Testability
 
@@ -318,15 +291,15 @@ captures a diff artifact, supports cancel/kill, and cleans up according to the r
 Exit criteria: a fake remote runner can run without database credentials or host API keys and can
 upload status, logs, and artifacts using only scoped tokens.
 
-### Phase 3 - Remote Providers (600-1200 LOC per first provider)
+### Phase 3 - Remote Providers
 
-- Implement `DaytonaRunner` for managed workspaces. Estimate: 700 LOC including tests.
-- Implement `E2BRunner` for ephemeral sandbox runs. Estimate: 700 LOC including tests.
-- Implement `SSHRunner` for self-hosted isolated hosts. Estimate: 450 LOC.
-- Defer `CodespaceRunner` until GitHub workspace lifecycle control is a concrete requirement.
+Remote runner implementations follow the same `PlayRunner` contract as `LocalWorktreeRunner`.
+Provider-specific SDK usage is internal to each runner; the only durable state they publish is the
+ADR-0056 `RunnerHandle`. Providers are added incrementally as demand warrants — each must pass the
+same contract suite as `LocalWorktreeRunner`.
 
-Exit criteria: at least one ephemeral runner and one persistent workspace runner pass the same
-contract suite as `LocalWorktreeRunner`.
+Exit criteria: at least one ephemeral runner and one persistent workspace runner pass the shared
+contract suite.
 
 ### Phase 4 - Governance Hardening (350-650 LOC)
 

--- a/docs/adrs/ADR-0057-remote-sandbox-execution.md
+++ b/docs/adrs/ADR-0057-remote-sandbox-execution.md
@@ -1,6 +1,6 @@
 # ADR-0057: Remote Sandbox Execution Behind PlayRunner
 
-Status: proposed (rewrite after rejected review)
+Status: proposed
 Date: 2026-05-27
 Decision owners: @governance-maintainers
 Depends on: ADR-0056 (play control API), ADR-0059 (Postgres state backend), ADR-0060 (unified config resolution)

--- a/docs/adrs/ADR-0058-play-cost-tracking.md
+++ b/docs/adrs/ADR-0058-play-cost-tracking.md
@@ -10,8 +10,7 @@ Related: ADR-0022 (run provenance), ADR-0023 (hook system), ADR-0056 (play contr
 
 Governed orchestration needs cost records that are explainable, replayable, and safe to expose
 only to authorized operators. Cost is not a UI decoration: it reveals model choice, run cadence,
-task complexity, retries, and which parts of an orchestration consume the most budget. For an
-enterprise governance product, that is operational strategy.
+task complexity, retries, and which parts of an orchestration consume the most budget.
 
 The current flow runtime already has the right execution shape for attribution. `FlowAgent`,
 `FlowOp`, and `FlowPlan` are typed models for branch identity, operation identity, dependencies,

--- a/docs/adrs/ADR-0058-play-cost-tracking.md
+++ b/docs/adrs/ADR-0058-play-cost-tracking.md
@@ -1,0 +1,450 @@
+# ADR-0058: Play Cost Tracking
+
+Status: APPROVE-WITH-FIXES
+Date: 2026-05-27
+Decision owners: @governance-maintainers
+Depends on: ADR-0059 (StateStore protocol), ADR-0060 (unified config resolution)
+Related: ADR-0022 (run provenance), ADR-0023 (hook system), ADR-0056 (play control API), ADR-0057 (remote sandbox execution)
+
+## Context
+
+Governed orchestration needs cost records that are explainable, replayable, and safe to expose
+only to authorized operators. Cost is not a UI decoration: it reveals model choice, run cadence,
+task complexity, retries, and which parts of an orchestration consume the most budget. For an
+enterprise governance product, that is operational strategy.
+
+The current flow runtime already has the right execution shape for attribution. `FlowAgent`,
+`FlowOp`, and `FlowPlan` are typed models for branch identity, operation identity, dependencies,
+control operations, and per-op budget weights (`lionagi/cli/orchestrate/flow.py:218`,
+`lionagi/cli/orchestrate/flow.py:264`, `lionagi/cli/orchestrate/flow.py:332`). The planner is
+also explicitly told to reuse agents because branch memory lowers token cost
+(`lionagi/cli/orchestrate/flow.py:365`). During execution, the engine persists a partial DAG
+snapshot to `sessions.node_metadata` so Studio can render live state
+(`lionagi/cli/orchestrate/flow.py:1257`), records execution segments best-effort
+(`lionagi/cli/orchestrate/flow.py:1177`), and writes op outputs to artifact markdown files
+(`lionagi/cli/orchestrate/flow.py:1113`). At finalization, it persists a reduced graph summary
+(`lionagi/cli/orchestrate/flow.py:1607`).
+
+That is enough structure to attach cost events, but not enough to make a ledger. The state schema
+has `sessions`, `branches`, and `plays`; `sessions` already stores resolved model, provider,
+effort, and agent hash (`lionagi/state/schema.sql:97`, `lionagi/state/schema.sql:140`), and
+`branches` stores per-agent model/provider data for multi-model flows
+(`lionagi/state/schema.sql:193`, `lionagi/state/schema.sql:202`). The `plays` table is show-scoped
+and has `UNIQUE(show_id, name)` (`lionagi/state/schema.sql:265`, `lionagi/state/schema.sql:302`),
+so retry or replay must not create child play rows. ADR-0057 already defines
+`runner_handles` as the durable execution-attempt table, with one play allowed to have multiple
+attempts (`docs/adrs/ADR-0057-remote-sandbox-execution.md:246`). Cost and replay attribution must
+therefore link to execution attempts, not invent a second replay model.
+
+The state access boundary is also changing. ADR-0059 keeps `StateDB` as a facade and requires new
+code to use the backend-neutral `StateStore` protocol instead of direct SQLite escape hatches
+(`docs/adrs/ADR-0059-postgres-state-backend.md:90`, `docs/adrs/ADR-0059-postgres-state-backend.md:206`).
+This ADR must not require any SQLite-only transaction primitive. SQLite and Postgres
+implementations must both provide the same cost behavior behind `StateStore`.
+
+Finally, the existing row conversion helper decodes only a fixed list of JSON-like columns
+(`lionagi/state/db.py:2278`). Any new JSON fields must be added explicitly to the decode list or
+Studio will receive encoded JSON strings instead of objects.
+
+## Decision
+
+### 1. Use integer cents for all financial state
+
+All cost and pricing values are stored and transported inside the Python state layer as integer
+cents. Database financial columns use `INTEGER NOT NULL DEFAULT 0`. Python models use `int` fields
+with names ending in `_cents`. The only boundary that divides by 100 is the API or UI presentation
+boundary, and it returns a decimal string such as `"12.34"` rather than an imprecise numeric
+value.
+
+This is non-negotiable. Financial ledger values must not use `REAL`, non-integer numeric types, or
+provider-specific decimal strings in state.
+
+### 2. Add an idempotent append-only cost ledger
+
+Cost events are append-only operational facts. Aggregates on `sessions` and `plays` are hot-read
+caches derived from `cost_events`; they are updated only when a new event is inserted.
+
+```sql
+ALTER TABLE sessions ADD COLUMN cost_cents INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE sessions ADD COLUMN token_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE sessions ADD COLUMN cost_breakdown JSON NOT NULL DEFAULT '{}';
+ALTER TABLE sessions ADD COLUMN pricing_version TEXT;
+ALTER TABLE sessions ADD COLUMN flow_plan JSON;
+ALTER TABLE sessions ADD COLUMN op_snapshots JSON NOT NULL DEFAULT '{}';
+
+ALTER TABLE plays ADD COLUMN cost_cents INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE plays ADD COLUMN token_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE plays ADD COLUMN cost_breakdown JSON NOT NULL DEFAULT '{}';
+ALTER TABLE plays ADD COLUMN pricing_version TEXT;
+ALTER TABLE plays ADD COLUMN flow_plan JSON;
+ALTER TABLE plays ADD COLUMN op_snapshots JSON NOT NULL DEFAULT '{}';
+
+CREATE TABLE IF NOT EXISTS model_pricing (
+  id                         TEXT PRIMARY KEY,
+  pricing_key                TEXT NOT NULL,
+  version                    TEXT NOT NULL,
+  currency                   TEXT NOT NULL DEFAULT 'USD',
+  model                      TEXT NOT NULL,
+  input_per_1m_cents         INTEGER NOT NULL DEFAULT 0,
+  output_per_1m_cents        INTEGER NOT NULL DEFAULT 0,
+  cache_read_per_1m_cents    INTEGER NOT NULL DEFAULT 0,
+  cache_write_per_1m_cents   INTEGER NOT NULL DEFAULT 0,
+  reasoning_per_1m_cents     INTEGER NOT NULL DEFAULT 0,
+  effective_at               REAL,
+  supersedes_id              TEXT REFERENCES model_pricing(id),
+  node_metadata              JSON,
+  created_at                 REAL NOT NULL,
+  UNIQUE(pricing_key, version, model)
+);
+
+CREATE TABLE IF NOT EXISTS cost_events (
+  id                         TEXT PRIMARY KEY,
+  session_id                 TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  play_id                    TEXT REFERENCES plays(id) ON DELETE SET NULL,
+  execution_id               TEXT REFERENCES runner_handles(id) ON DELETE SET NULL,
+  branch_id                  TEXT REFERENCES branches(id) ON DELETE SET NULL,
+  flow_op_id                 TEXT,
+  operation_node_id          TEXT,
+  agent_id                   TEXT,
+  agent_role                 TEXT,
+  provider                   TEXT,
+  model                      TEXT NOT NULL,
+  usage_source               TEXT NOT NULL CHECK(usage_source IN ('provider', 'estimated', 'manual')),
+  input_tokens               INTEGER NOT NULL DEFAULT 0,
+  output_tokens              INTEGER NOT NULL DEFAULT 0,
+  cache_read_tokens          INTEGER NOT NULL DEFAULT 0,
+  cache_write_tokens         INTEGER NOT NULL DEFAULT 0,
+  reasoning_tokens           INTEGER NOT NULL DEFAULT 0,
+  total_tokens               INTEGER NOT NULL DEFAULT 0,
+  input_cost_cents           INTEGER NOT NULL DEFAULT 0,
+  output_cost_cents          INTEGER NOT NULL DEFAULT 0,
+  cache_cost_cents           INTEGER NOT NULL DEFAULT 0,
+  reasoning_cost_cents       INTEGER NOT NULL DEFAULT 0,
+  total_cost_cents           INTEGER NOT NULL DEFAULT 0,
+  pricing_id                 TEXT NOT NULL REFERENCES model_pricing(id),
+  pricing_key                TEXT NOT NULL,
+  pricing_version            TEXT NOT NULL,
+  response_id                TEXT NOT NULL,
+  created_at                 REAL NOT NULL,
+  node_metadata              JSON,
+  UNIQUE(session_id, response_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_cost_events_session_time
+  ON cost_events(session_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_cost_events_play_time
+  ON cost_events(play_id, created_at) WHERE play_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_cost_events_execution_time
+  ON cost_events(execution_id, created_at) WHERE execution_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_cost_events_model_time
+  ON cost_events(model, created_at);
+CREATE INDEX IF NOT EXISTS idx_cost_events_agent_role_time
+  ON cost_events(agent_role, created_at) WHERE agent_role IS NOT NULL;
+```
+
+`response_id` is required. If a provider does not return a stable response identifier, the runtime
+constructs one from the normalized provider request identity, execution context, and model-call
+ordinal before insertion. SQLite uses `INSERT OR IGNORE`; Postgres uses `ON CONFLICT DO NOTHING`.
+If the insert is ignored, aggregate updates are skipped. Duplicate hook delivery and provider retry
+must not double-count spend.
+
+### 3. Keep pricing immutable once referenced
+
+`model_pricing` rows are immutable once any `cost_events.pricing_id` references them. A price
+change creates a new `(pricing_key, version, model)` row. Correction of a previously charged event
+is represented by a new adjustment event with negative token deltas prohibited and negative cost
+prohibited; if a correction is required, write an explicit zero-token manual event with explanatory
+metadata and the corrected positive total. The ledger is not edited in place.
+
+Pricing files are resolved through ADR-0060 only:
+
+```text
+<root>/pricing/<name>.yaml
+<root>/pricing/<name>.yml
+```
+
+There is no standalone user pricing file outside the ADR-0060 cascade. ADR-0060 owns root
+discovery, shadowing, plugin fallback, and symlink containment for pricing resources.
+
+### 4. Use StateStore transactions, not SQLite-specific primitives
+
+ADR-0059's `StateStore` protocol gains a transaction abstraction and cost methods:
+
+```python
+from contextlib import AbstractAsyncContextManager
+from typing import Any, Protocol
+
+
+class StateTransaction(Protocol):
+    async def insert_cost_event(self, event: dict[str, Any]) -> bool: ...
+    async def increment_session_cost(
+        self,
+        session_id: str,
+        *,
+        cost_cents: int,
+        token_count: int,
+        breakdown_delta: dict[str, int],
+        pricing_version: str,
+    ) -> None: ...
+    async def increment_play_cost(
+        self,
+        play_id: str,
+        *,
+        cost_cents: int,
+        token_count: int,
+        breakdown_delta: dict[str, int],
+        pricing_version: str,
+    ) -> None: ...
+
+
+class StateStore(Protocol):
+    def transaction(self) -> AbstractAsyncContextManager[StateTransaction]: ...
+    async def list_cost_events(
+        self,
+        *,
+        session_id: str | None = None,
+        play_id: str | None = None,
+        execution_id: str | None = None,
+        limit: int = 500,
+    ) -> list[dict[str, Any]]: ...
+```
+
+The public service function performs one backend-neutral unit of work:
+
+```python
+async def record_cost_event(store: StateStore, event: CostEvent) -> bool:
+    async with store.transaction() as txn:
+        inserted = await txn.insert_cost_event(event.model_dump())
+        if not inserted:
+            return False
+        await txn.increment_session_cost(
+            event.session_id,
+            cost_cents=event.total_cost_cents,
+            token_count=event.total_tokens,
+            breakdown_delta=event.breakdown_delta(),
+            pricing_version=event.pricing_version,
+        )
+        if event.play_id:
+            await txn.increment_play_cost(
+                event.play_id,
+                cost_cents=event.total_cost_cents,
+                token_count=event.total_tokens,
+                breakdown_delta=event.breakdown_delta(),
+                pricing_version=event.pricing_version,
+            )
+        return True
+```
+
+SQLite may implement this with its normal transaction machinery. Postgres may use a transaction and
+row-level locks where needed. Callers do not choose the database primitive.
+
+### 5. Attribute replay and retry through runner_handles
+
+Replay does not create child play rows and does not add replay-parent columns to `plays` or
+`sessions`. A replay creates a new `runner_handles` row, increments `attempt`, and stores replay
+metadata in the ADR-0056-owned `runner_handles.metadata_json` field:
+
+```json
+{
+  "replay": {
+    "parent_execution_id": "exec_prev",
+    "from_op_id": "review1",
+    "mode": "suffix",
+    "requested_by": "operator-id",
+    "reason": "retry failed suffix after dependency fix"
+  }
+}
+```
+
+Every cost event emitted during that attempt carries the new `execution_id`. Session and play
+aggregates remain cumulative unless an API request explicitly filters by execution attempt.
+
+### 6. Add explicit JSON decode coverage
+
+`StateDB._row_to_dict()` and the future SQLite/Postgres store adapters must decode these new JSON
+columns into Python objects:
+
+```text
+cost_breakdown
+flow_plan
+op_snapshots
+node_metadata
+metadata_json
+command_json
+env_allowlist_json
+limits_json
+```
+
+This list is part of the contract. Tests must assert API projections return JSON objects, not
+encoded strings.
+
+### Component Diagram
+
+```mermaid
+flowchart LR
+  Flow[Flow executor] --> CostCtx[operation cost context]
+  CostCtx --> Pricing[pricing resolver via ADR-0060]
+  Pricing --> StateStore[StateStore transaction via ADR-0059]
+  Flow --> Execution[runner_handles via ADR-0057]
+  Execution --> StateStore
+  StateStore --> Ledger[cost_events and aggregates]
+  Ledger --> Studio[authenticated Studio cost API]
+```
+
+Coupling target: six components, six direct dependencies, `k = 6 / (6 * 5) = 0.20`.
+
+## Implementation
+
+### Python contracts
+
+Add `lionagi/state/cost.py`:
+
+```python
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class TokenUsage(BaseModel):
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+    reasoning_tokens: int = 0
+    total_tokens: int = 0
+    source: Literal["provider", "estimated", "manual"] = "provider"
+
+
+class ModelPrice(BaseModel):
+    pricing_key: str
+    version: str
+    model: str
+    input_per_1m_cents: int = 0
+    output_per_1m_cents: int = 0
+    cache_read_per_1m_cents: int = 0
+    cache_write_per_1m_cents: int = 0
+    reasoning_per_1m_cents: int = 0
+
+
+class CostQuote(BaseModel):
+    pricing_id: str
+    pricing_key: str
+    pricing_version: str
+    input_cost_cents: int = 0
+    output_cost_cents: int = 0
+    cache_cost_cents: int = 0
+    reasoning_cost_cents: int = 0
+    total_cost_cents: int = 0
+
+
+class CostEvent(BaseModel):
+    session_id: str
+    play_id: str | None = None
+    execution_id: str | None = None
+    branch_id: str | None = None
+    flow_op_id: str | None = None
+    model: str
+    provider: str | None = None
+    usage_source: Literal["provider", "estimated", "manual"]
+    response_id: str
+    total_tokens: int = 0
+    total_cost_cents: int = 0
+    pricing_id: str
+    pricing_key: str
+    pricing_version: str
+    node_metadata: dict[str, Any] = Field(default_factory=dict)
+
+    def breakdown_delta(self) -> dict[str, int]: ...
+
+
+def normalize_usage(response: Any, *, provider: str | None = None) -> TokenUsage | None: ...
+def price_usage(model: str, usage: TokenUsage, price: ModelPrice) -> CostQuote: ...
+```
+
+`price_usage()` computes cents with integer arithmetic and deterministic rounding to the nearest
+cent after multiplying tokens by per-million-cent rates.
+
+### Runtime integration
+
+Add `lionagi/cli/orchestrate/costing.py` to bridge API post-call events into operation context.
+The bridge records `session_id`, optional `play_id`, optional `execution_id`, branch ID,
+`FlowOp.id`, agent role, model, provider, normalized usage, and `response_id`. Flow execution must
+persist the full `FlowPlan` and per-op snapshots before any replayable model call runs.
+
+### Studio and API surface
+
+Add authenticated endpoints:
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/cost/sessions/{session_id}` | Session aggregate and per-model breakdown. |
+| `GET` | `/api/cost/sessions/{session_id}/events` | Event list, filterable by op, branch, and execution. |
+| `GET` | `/api/cost/plays/{play_id}` | Show play aggregate and attempt breakdown. |
+| `GET` | `/api/cost/executions/{execution_id}` | Cost for one ADR-0057 execution attempt. |
+| `GET` | `/api/cost/pricing/{name}` | Resolved pricing metadata and active version. |
+
+Service-layer responses keep `cost_cents` as the canonical value. HTTP serializers may add
+`cost_usd` as a decimal string computed by dividing cents by 100.
+
+### Phasing and estimates
+
+| Phase | Work | Estimate |
+| --- | --- | --- |
+| 1 | State schema, StateStore transaction contract, SQLite implementation, Postgres parity hooks | 260-420 LOC |
+| 2 | Pricing loader through ADR-0060, immutable pricing rows, integer quote calculation | 180-260 LOC |
+| 3 | Flow operation context, API post-call normalization, idempotent insert path | 220-360 LOC |
+| 4 | Studio cost services, routers, authenticated frontend views | 300-520 LOC |
+| 5 | Replay attempt filtering through `runner_handles` and test coverage | 180-280 LOC |
+
+Testability target: `tau > 0.85`. The ledger is testable with isolated store fixtures, duplicate
+event tests, integer arithmetic fixtures, and API auth tests.
+
+## Security
+
+All cost endpoints require bearer authentication when `LIONAGI_STUDIO_AUTH_TOKEN` is set. This
+includes `GET` endpoints. The current Studio middleware gates admin reads and mutating API methods
+(`apps/studio/server/app.py:52`), but this ADR requires the cost router to enforce read auth as
+well because cost data reveals operational strategy.
+
+Cost events must not store raw prompts, completions, API keys, provider request bodies, or absolute
+filesystem paths. `node_metadata` is limited to non-secret operational metadata such as provider
+response class, usage source, retry count, and redaction status.
+
+Replay requests require the same actor authorization as play control requests. A replay request may
+reference only stored `FlowOp.id` values from the persisted plan and must create a new
+`runner_handles` attempt. It must not mutate historical cost events.
+
+Pricing immutability is a security property: historical charges must remain explainable against the
+exact pricing row used at the time of the call. Updating or deleting a referenced `model_pricing`
+row is rejected.
+
+## Migration
+
+The current source tree has no implemented cost ledger, so Phase 0 migration is additive:
+
+1. Add integer-cent columns and ledger tables to SQLite and Postgres DDL.
+2. Add the new JSON column names to decode coverage.
+3. Backfill existing sessions and plays with `cost_cents = 0`, `token_count = 0`, and empty
+   breakdowns.
+4. Import pricing files through ADR-0060's `<root>/pricing/<name>.yaml` cascade and materialize
+   immutable `model_pricing` rows on first use.
+5. Update Studio to hide cost views unless the request is authenticated when
+   `LIONAGI_STUDIO_AUTH_TOKEN` is set.
+
+If any pre-release database contains older cost columns using non-integer financial storage, the
+migration must perform a one-way offline conversion to integer cents, verify totals against the
+old values using decimal arithmetic, and then remove the old columns from all read paths. New
+runtime code never writes non-integer financial values.
+
+Acceptance checks:
+
+- Duplicate `API_POST_CALL` delivery with the same `(session_id, response_id)` inserts one event
+  and updates aggregates once.
+- All financial schema columns are `INTEGER NOT NULL DEFAULT 0`.
+- All Python financial fields are `int` cents.
+- Pricing changes create a new immutable version row.
+- Replay cost can be filtered by `runner_handles.id`.
+- Cost `GET` endpoints return `401` without a valid bearer token when auth is configured.
+- JSON columns listed above round-trip as objects.
+
+Domain utility: SKIPPED - no lore suggest/compose tool is available in this execution environment.

--- a/docs/adrs/ADR-0058-play-cost-tracking.md
+++ b/docs/adrs/ADR-0058-play-cost-tracking.md
@@ -1,6 +1,6 @@
 # ADR-0058: Play Cost Tracking
 
-Status: Proposed
+Status: proposed
 Date: 2026-05-27
 Decision owners: @governance-maintainers
 Depends on: ADR-0059 (StateStore protocol), ADR-0060 (unified config resolution)

--- a/docs/adrs/ADR-0058-play-cost-tracking.md
+++ b/docs/adrs/ADR-0058-play-cost-tracking.md
@@ -1,6 +1,6 @@
 # ADR-0058: Play Cost Tracking
 
-Status: APPROVE-WITH-FIXES
+Status: Proposed
 Date: 2026-05-27
 Decision owners: @governance-maintainers
 Depends on: ADR-0059 (StateStore protocol), ADR-0060 (unified config resolution)
@@ -446,5 +446,3 @@ Acceptance checks:
 - Replay cost can be filtered by `runner_handles.id`.
 - Cost `GET` endpoints return `401` without a valid bearer token when auth is configured.
 - JSON columns listed above round-trip as objects.
-
-Domain utility: SKIPPED - no lore suggest/compose tool is available in this execution environment.

--- a/docs/adrs/ADR-0059-postgres-state-backend.md
+++ b/docs/adrs/ADR-0059-postgres-state-backend.md
@@ -3,8 +3,8 @@
 Status: proposed
 Date: 2026-05-27
 Decision owners: @governance-maintainers
-Depends on: ADR-0009 (SQLite state layer), ADR-0027 (scheduler engine / state.db)
-Related: ADR-0033 (unified entity state model), ADR-0034 (frontend data/state), ADR-0053 (artifact persistence — schema columns consumed but not dependency-ordered), governance direction P18-P20
+Depends on: ADR-0009 (SQLite state layer), ADR-0027 (scheduler engine / state.db), ADR-0053 (artifact persistence — artifact columns consumed, must land first or Postgres runs in experimental mode)
+Related: ADR-0033 (unified entity state model), ADR-0034 (frontend data/state), governance direction P18-P20
 
 ## Context
 

--- a/docs/adrs/ADR-0059-postgres-state-backend.md
+++ b/docs/adrs/ADR-0059-postgres-state-backend.md
@@ -1,0 +1,562 @@
+# ADR-0059: Postgres State Backend
+
+Status: proposed
+Date: 2026-05-27
+Decision owners: @governance-maintainers
+Depends on: ADR-0009 (SQLite state layer), ADR-0027 (scheduler engine / state.db)
+Related: ADR-0033 (unified entity state model), ADR-0034 (frontend data/state), ADR-0053 (artifact persistence — schema columns consumed but not dependency-ordered), governance direction P18-P20
+
+## Context
+
+LionAGI's current state substrate is `~/.lionagi/state.db`, opened by
+`lionagi.state.db.StateDB`. The database is no longer only a four-table local mirror. The
+current SQLite schema defines the operational surface used by CLI, Studio, scheduler, and
+governance-facing workflows:
+
+| Surface | Current SQLite source |
+|---|---|
+| messages, message types, progressions | `lionagi/state/schema.sql:25`, `lionagi/state/schema.sql:41`, `lionagi/state/schema.sql:69` |
+| projects | `lionagi/state/schema.sql:79` |
+| sessions | `lionagi/state/schema.sql:97` |
+| branches | `lionagi/state/schema.sql:193` |
+| definitions | `lionagi/state/schema.sql:220` |
+| shows and plays | `lionagi/state/schema.sql:239`, `lionagi/state/schema.sql:265` |
+| teams and team messages | `lionagi/state/schema.sql:310`, `lionagi/state/schema.sql:331` |
+| invocations | `lionagi/state/schema.sql:354` |
+| schedules and schedule runs | `lionagi/state/schema.sql:380`, `lionagi/state/schema.sql:423` |
+| admin events | `lionagi/state/schema.sql:462` |
+| artifacts | `lionagi/state/schema.sql:485`; superseded by ADR-0053 before Postgres parity is accepted |
+| status transitions | `lionagi/state/schema.sql:540` |
+
+`StateDB` already exposes most of these surfaces as async methods. Examples include message and
+progression methods (`lionagi/state/db.py:623`, `lionagi/state/db.py:711`), session methods
+(`lionagi/state/db.py:755`, `lionagi/state/db.py:843`, `lionagi/state/db.py:866`), projects
+(`lionagi/state/db.py:1096`, `lionagi/state/db.py:1118`), schedules and schedule runs
+(`lionagi/state/db.py:1185`, `lionagi/state/db.py:1230`, `lionagi/state/db.py:1240`,
+`lionagi/state/db.py:1318`, `lionagi/state/db.py:1410`), artifacts
+(`lionagi/state/db.py:1658`, `lionagi/state/db.py:1706`, `lionagi/state/db.py:1714`,
+`lionagi/state/db.py:1722`), admin events (`lionagi/state/db.py:1729`,
+`lionagi/state/db.py:1758`), branches (`lionagi/state/db.py:1784`,
+`lionagi/state/db.py:1806`, `lionagi/state/db.py:1811`), shows and plays
+(`lionagi/state/db.py:1935`, `lionagi/state/db.py:1975`, `lionagi/state/db.py:2059`,
+`lionagi/state/db.py:2105`), and definitions (`lionagi/state/db.py:2252`).
+
+The old ADR draft under-scoped the backend boundary. A Postgres backend cannot be safe if it
+only implements sessions, branches, messages, invocations, schedules, and artifacts while
+Studio and CLI keep bypassing the abstraction for projects, shows, plays, definitions, admin
+events, schedule reads, or maintenance commands. Direct SQLite access already exists in
+maintenance code such as `li state import` and `li state prune`: `_import_runs()` skips a run
+as soon as its session row exists (`lionagi/cli/state.py:87`), while `_prune()` selects and
+deletes through `db.db.execute()` (`lionagi/cli/state.py:644`, `lionagi/cli/state.py:683`).
+Studio also has a security gap: when `LIONAGI_STUDIO_AUTH_TOKEN` is set, current middleware
+protects `/api/admin/*` GETs and mutating `/api/*` methods, but ordinary GET endpoints such as
+`/api/stats` are not covered (`apps/studio/server/app.py:52`, `apps/studio/server/app.py:86`).
+
+Postgres is added for production Studio, multi-worker schedulers, remote executors, managed
+backup, point-in-time recovery, operational metrics, and indexed search over shared state.
+SQLite remains the default local backend. This ADR is therefore a backend-boundary decision,
+not a replacement of the local developer workflow.
+
+```mermaid
+flowchart LR
+  CLI[CLI and orchestration] --> Facade[StateDB facade]
+  Studio[Studio API] --> Facade
+  Scheduler[Scheduler] --> Facade
+  Facade --> Store[StateStore protocol]
+  Store --> SQLite[SQLiteStateStore]
+  Store --> Postgres[PostgresStateStore]
+  Postgres --> PG[(Managed Postgres)]
+  SQLite --> DB[(state.db)]
+```
+
+Coupling estimate after the decision: four application clients depend on one facade and one
+protocol, while concrete stores do not depend on clients. With components `{CLI, Studio,
+Scheduler, StateDB facade, SQLite store, Postgres store}` and intended cross-component deps
+`{CLI->StateDB, Studio->StateDB, Scheduler->StateDB, StateDB->SQLite, StateDB->Postgres}`, the
+direct coupling score is `5 / (6 * 5) = 0.17`. This is below the `0.3` threshold because callers
+do not branch on database-specific primitives.
+
+## Decision
+
+### 1. Keep `StateDB` as the public facade and freeze a complete `StateStore` contract
+
+`StateDB` remains the import path for existing callers. Internally it delegates to a concrete
+`StateStore` selected from configuration. The protocol must cover every current StateDB surface
+before Postgres is marked production-ready. Direct access to `StateDB.db` becomes SQLite-only
+compatibility and is forbidden for new code.
+
+Context-manager factories return async context managers; all state operations themselves are
+async.
+
+```python
+# lionagi/state/store.py
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Sequence
+from contextlib import AbstractAsyncContextManager
+from pathlib import Path
+from typing import Any, Literal, Protocol
+
+StateBackend = Literal["sqlite", "postgres"]
+
+
+class StateTransaction(Protocol):
+    """A transaction-bound view of StateStore operations."""
+
+    backend: StateBackend
+
+
+class LockedStateConnection(Protocol):
+    """Connection-pinned state view for scheduler and maintenance locks."""
+
+    backend: StateBackend
+
+    async def create_schedule_run(self, run: dict[str, Any]) -> None: ...
+    async def update_schedule(self, schedule_id: str, **fields: Any) -> None: ...
+    async def list_due_schedules(self, now: float, *, limit: int = 100) -> list[dict[str, Any]]: ...
+
+
+class StateStore(Protocol):
+    backend: StateBackend
+
+    async def open(self) -> None: ...
+    async def close(self) -> None: ...
+    async def __aenter__(self) -> "StateStore": ...
+    async def __aexit__(self, *exc: Any) -> None: ...
+
+    def transaction(self) -> AbstractAsyncContextManager[StateTransaction]: ...
+    def locked_connection(self, name: str) -> AbstractAsyncContextManager[LockedStateConnection]: ...
+
+    # Schema and health.
+    async def schema_version(self) -> str | None: ...
+    async def apply_schema(self) -> None: ...
+    async def table_counts(self, tables: Sequence[str]) -> dict[str, int]: ...
+    async def checkpoint(self, mode: str = "TRUNCATE") -> dict[str, Any]: ...
+    async def vacuum(self) -> None: ...
+    async def select_retention_victims(self, *, keep_days: int, keep_n: int) -> list[str]: ...
+    async def prune_sessions(self, session_ids: Sequence[str], *, actor: str) -> dict[str, int]: ...
+
+    # Messages and progressions.
+    async def insert_message(self, msg: dict[str, Any]) -> None: ...
+    async def get_message(self, message_id: str) -> dict[str, Any] | None: ...
+    async def create_progression(self, progression_id: str, collection: list[str] | None = None) -> None: ...
+    async def get_progression(self, progression_id: str) -> list[str]: ...
+    async def append_to_progression(self, progression_id: str, message_id: str) -> None: ...
+
+    # Sessions and status transitions.
+    async def create_session(self, session: dict[str, Any]) -> None: ...
+    async def get_session(self, session_id: str) -> dict[str, Any] | None: ...
+    async def list_sessions(
+        self, *, status: str | None = None, limit: int = 100, offset: int = 0
+    ) -> list[dict[str, Any]]: ...
+    async def list_sessions_for_invocation(self, invocation_id: str) -> list[dict[str, Any]]: ...
+    async def count_sessions(self, *, status: str | None = None) -> int: ...
+    async def update_session(self, session_id: str, **fields: Any) -> None: ...
+    async def touch_session_activity(self, session_id: str, *, at: float | None = None) -> None: ...
+    async def update_artifact_verification(self, session_id: str, verification: dict[str, Any] | None) -> None: ...
+    async def update_status(
+        self,
+        entity_type: str,
+        entity_id: str,
+        *,
+        new_status: str,
+        reason_code: str,
+        reason_summary: str = "",
+        evidence_refs: list[dict[str, Any]] | None = None,
+        source: str = "executor",
+        actor: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None: ...
+    async def list_status_transitions(
+        self, entity_type: str, entity_id: str, *, limit: int = 100
+    ) -> list[dict[str, Any]]: ...
+
+    # Branches.
+    async def create_branch(self, branch: dict[str, Any]) -> None: ...
+    async def get_branch(self, branch_id: str) -> dict[str, Any] | None: ...
+    async def update_branch(self, branch_id: str, **fields: Any) -> None: ...
+    async def repair_branch_progression(self, branch_id: str, new_progression_id: str) -> str | None: ...
+    async def repair_session_progression(self, session_id: str, new_progression_id: str) -> str | None: ...
+    async def list_branches(self, session_id: str) -> list[dict[str, Any]]: ...
+    async def get_branch_messages(self, branch_id: str) -> list[dict[str, Any]]: ...
+
+    # Projects.
+    async def register_project(
+        self, name: str, source: str, *, path: str | None = None, github: str | None = None
+    ) -> None: ...
+    async def create_project(
+        self, name: str, *, github: str | None = None, description: str | None = None, path: str | None = None
+    ) -> None: ...
+    async def list_projects(self) -> list[dict[str, Any]]: ...
+    async def get_project(self, name: str) -> dict[str, Any] | None: ...
+    async def update_project(self, name: str, **fields: Any) -> bool: ...
+    async def delete_project(self, name: str) -> bool: ...
+
+    # Invocations.
+    async def create_invocation(self, invocation: dict[str, Any]) -> None: ...
+    async def update_invocation(self, invocation_id: str, **fields: Any) -> None: ...
+    async def get_invocation(self, invocation_id: str) -> dict[str, Any] | None: ...
+    async def list_invocations(
+        self,
+        *,
+        skill: str | None = None,
+        status: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]: ...
+
+    # Schedules and schedule runs.
+    async def create_schedule(self, schedule: dict[str, Any]) -> None: ...
+    async def get_schedule(self, schedule_id: str) -> dict[str, Any] | None: ...
+    async def get_schedule_by_name(self, name: str) -> dict[str, Any] | None: ...
+    async def list_schedules(
+        self,
+        *,
+        enabled: bool | None = None,
+        trigger_type: str | None = None,
+        project: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]: ...
+    async def list_due_schedules(self, now: float, *, limit: int = 100) -> list[dict[str, Any]]: ...
+    async def update_schedule(self, schedule_id: str, **fields: Any) -> None: ...
+    async def delete_schedule(self, schedule_id: str) -> bool: ...
+    async def create_schedule_run(self, run: dict[str, Any]) -> None: ...
+    async def update_schedule_run(self, run_id: str, **fields: Any) -> None: ...
+    async def list_schedule_runs(
+        self, schedule_id: str, *, status: str | None = None, limit: int = 50, offset: int = 0
+    ) -> list[dict[str, Any]]: ...
+    async def get_schedule_run(self, run_id: str) -> dict[str, Any] | None: ...
+    async def list_running_schedule_runs(self, schedule_id: str) -> list[dict[str, Any]]: ...
+
+    # Artifacts. Columns and immutability are owned by ADR-0053.
+    async def insert_artifact(self, artifact: dict[str, Any]) -> str: ...
+    async def list_artifacts_for_invocation(self, invocation_id: str) -> list[dict[str, Any]]: ...
+    async def list_artifacts_for_session(self, session_id: str) -> list[dict[str, Any]]: ...
+    async def get_artifact(self, artifact_id: str) -> dict[str, Any] | None: ...
+    async def search_artifacts(self, query: str, *, limit: int = 50) -> list[dict[str, Any]]: ...
+
+    # Admin events.
+    async def insert_admin_event(
+        self, *, action: str, details: dict[str, Any], target_id: str | None = None, actor: str = "admin"
+    ) -> str: ...
+    async def list_admin_events(
+        self, *, action: str | None = None, target_id: str | None = None, limit: int = 100
+    ) -> list[dict[str, Any]]: ...
+
+    # Shows and plays.
+    async def create_show(self, show: dict[str, Any]) -> None: ...
+    async def get_show(self, show_id: str) -> dict[str, Any] | None: ...
+    async def get_show_by_topic(self, topic: str) -> dict[str, Any] | None: ...
+    async def list_shows(self, *, status: str | None = None) -> list[dict[str, Any]]: ...
+    async def update_show(self, show_id: str, **fields: Any) -> None: ...
+    async def create_play(self, play: dict[str, Any]) -> None: ...
+    async def get_play(self, play_id: str) -> dict[str, Any] | None: ...
+    async def list_plays(self, show_id: str) -> list[dict[str, Any]]: ...
+    async def update_play(self, play_id: str, **fields: Any) -> None: ...
+
+    # Definitions.
+    async def save_definition(
+        self, *, kind: str, name: str, path: str, content: str, message: str | None = None
+    ) -> int: ...
+    async def get_definition(self, kind: str, name: str, *, version: int | None = None) -> dict[str, Any] | None: ...
+    async def list_definition_versions(self, kind: str, name: str) -> list[dict[str, Any]]: ...
+```
+
+The implementation may split this large protocol into smaller internal protocols
+(`StateReadStore`, `StateMaintenanceStore`, `StateSchedulerStore`, and `StateAdminStore`) if
+that improves test clarity, but `StateDB.store` must implement the complete union above.
+
+### 2. Maintain exact logical schema parity between SQLite and Postgres
+
+`lionagi/state/schema.sql` remains the SQLite source of truth. `lionagi/state/schema_postgres.sql`
+is explicit Postgres DDL, not a string-transpiled copy. A generated inventory in
+`lionagi/state/schema_meta.py` compares table names, column names, nullable status, primary keys,
+foreign keys, unique constraints, and required indexes for both backends.
+
+Postgres DDL must match the effective SQLite schema exactly for logical columns. Backend type
+translation is allowed; semantic drift is not.
+
+| SQLite type/use | Postgres type/use |
+|---|---|
+| `TEXT` | `TEXT` |
+| `INTEGER` flags and counters | `INTEGER` |
+| epoch-second `REAL` timestamps | `TIMESTAMPTZ` at storage boundary, returned as epoch seconds by the store |
+| `JSON` / JSON text | `JSONB` |
+| `BLOB` embeddings | `BYTEA` |
+| money or pricing values introduced by ADR-0058 | `INTEGER` cents only, never floating point |
+
+The `branches` table is the reviewer-discovered guardrail: Postgres must not add lifecycle
+columns that SQLite does not have. The correct Postgres table mirrors `lionagi/state/schema.sql:193`.
+
+```sql
+CREATE TABLE IF NOT EXISTS branches (
+  id             TEXT PRIMARY KEY,
+  created_at     TIMESTAMPTZ NOT NULL,
+  node_metadata  JSONB,
+  "user"         TEXT,
+  name           TEXT,
+  session_id     TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  progression_id TEXT NOT NULL REFERENCES progressions(id),
+  system_msg_id  TEXT REFERENCES messages(id),
+  model          TEXT,
+  provider       TEXT,
+  agent_name     TEXT
+);
+```
+
+Artifact parity is gated on ADR-0053. Current SQLite artifacts have `id`, `invocation_id`,
+`session_id`, `created_at`, `updated_at`, `kind`, `name`, `content`, and `file_path`
+(`lionagi/state/schema.sql:485`). ADR-0053 changes artifact persistence to immutable rows with
+content hash and file metadata. ADR-0059 depends on that decision; Postgres production acceptance
+requires the SQLite artifact migration and Postgres artifact DDL to agree before parity tests pass.
+If ADR-0053 has not landed, Postgres may be used only in an experimental profile that mirrors the
+current artifact columns.
+
+ADR-0058 owns cost and pricing tables. When those tables enter the shared schema, all cost and
+pricing values are integer cents in both backends. A `REAL`, `DOUBLE PRECISION`, or Python `float`
+is invalid for money.
+
+### 3. Use backend-neutral transaction semantics
+
+All multi-row state mutations go through `async with store.transaction() as txn:`. Callers must
+not open SQLite writer locks or issue database-specific transaction prologues. SQLite uses its
+driver transaction behavior behind the store. Postgres uses one pooled connection and a database
+transaction for the scope.
+
+Examples:
+
+```python
+async with db.store.transaction() as txn:
+    await txn.create_session(session)
+    await txn.create_branch(branch)
+    await txn.insert_admin_event(
+        action="session_imported",
+        target_id=session["id"],
+        details={"source": "runs_backfill"},
+    )
+```
+
+`update_status()` remains the only sanctioned status mutation point. It must atomically update
+the entity row and append `status_transitions`, preserving the current invariant documented in
+`lionagi/state/schema.sql:531`.
+
+### 4. Pin advisory locks to the same Postgres connection
+
+The scheduler must not use separate acquire and release calls that can land on different pooled
+connections. `StateStore.locked_connection(name)` is the only advisory-lock API.
+
+```python
+async with db.store.locked_connection("studio_scheduler") as locked:
+    due = await locked.list_due_schedules(now=time.time())
+    for schedule in due:
+        run = build_schedule_run(schedule)
+        await locked.create_schedule_run(run)
+        await locked.update_schedule(schedule["id"], last_fired_at=run["fired_at"])
+```
+
+Postgres implementation:
+
+1. Acquire one pool connection.
+2. Execute `pg_try_advisory_lock(hashtext($1))` on that connection.
+3. If acquisition fails, raise `LockNotAcquired` or return an empty async context depending on
+   scheduler configuration; no schedule fires.
+4. Keep the connection pinned for the full context body.
+5. Release with `pg_advisory_unlock(hashtext($1))` on the same connection in `finally`.
+6. Return the connection to the pool only after release succeeds or the connection is closed.
+
+Cancellation and crash behavior:
+
+- Python cancellation runs the context manager `finally` path and releases on the same connection.
+- If the process dies, Postgres releases the session-level advisory lock when the connection is
+  closed.
+- If release fails because the connection is broken, the connection is discarded rather than
+  returned to the pool.
+
+SQLite returns a process-local async lock for local Studio. It is sufficient for the default
+single-process local mode but does not claim cross-process scheduling safety.
+
+```mermaid
+sequenceDiagram
+  participant S1 as Studio worker 1
+  participant S2 as Studio worker 2
+  participant P as Postgres pool
+  participant C as Pinned connection
+
+  S1->>P: acquire connection
+  P-->>S1: C
+  S1->>C: pg_try_advisory_lock(name)
+  C-->>S1: true
+  S2->>P: acquire another connection
+  S2->>P: pg_try_advisory_lock(name)
+  P-->>S2: false
+  S1->>C: list due schedules and create schedule_runs
+  S1->>C: pg_advisory_unlock(name)
+  S1->>P: return C
+```
+
+### 5. Require bearer auth for all Studio API reads and writes
+
+When `LIONAGI_STUDIO_AUTH_TOKEN` is set, every `/api/*` endpoint must require
+`Authorization: Bearer <token>` for every HTTP method, including GET. `/health` may remain
+unauthenticated only if it returns no state, no backend details, and no path or version
+provenance.
+
+The current middleware must change from "admin GET plus mutating API methods" to "all API
+methods":
+
+```python
+@app.middleware("http")
+async def require_studio_bearer_token(request: Request, call_next):
+    token = os.getenv("LIONAGI_STUDIO_AUTH_TOKEN")
+    if (
+        token
+        and request.url.path.startswith("/api")
+        and request.headers.get("authorization") != f"Bearer {token}"
+    ):
+        return JSONResponse({"detail": "Unauthorized"}, status_code=401)
+    return await call_next(request)
+```
+
+This applies to runs, sessions, messages, artifacts, schedules, invocations, teams, projects,
+definitions, shows, search, stats, config provenance, and admin routes. Studio responses must not
+return absolute local paths or raw filesystem source locations. Log and artifact content may
+contain secrets and must not be publicly cacheable.
+
+## Implementation
+
+| Phase | Scope | Files | Estimate |
+|---|---|---|---|
+| 0. Inventory and API freeze | Generate the method inventory from `StateDB`, fail CI if a public async method is missing from `StateStore`, and replace known `db.db.execute()` maintenance paths with store methods. | `lionagi/state/store.py`, `lionagi/state/db.py`, `lionagi/cli/state.py`, `apps/studio/server/services/*.py`, tests | 500-800 LOC |
+| 1. SQLite store split | Move current SQLite implementation behind `SQLiteStateStore`; keep `StateDB` import compatibility and default behavior unchanged. | `lionagi/state/stores/sqlite.py`, `lionagi/state/db.py`, `lionagi/state/stores/__init__.py` | 300-500 LOC plus moves |
+| 2. Schema parity harness | Add `schema_postgres.sql`, `schema_meta.py`, and tests that compare the effective SQLite schema, ADR-0053 artifact migration, and Postgres DDL. | `lionagi/state/schema_postgres.sql`, `lionagi/state/schema_meta.py`, `tests/state/test_schema_parity.py` | 250-400 LOC |
+| 3. Postgres store MVP | Add optional `asyncpg`, pool lifecycle, parameter translation, JSONB/timestamp conversion, and methods for every protocol surface except full-text search. | `pyproject.toml`, `lionagi/state/stores/postgres.py`, `tests/state/test_state_store_contract.py` | 1200-1800 LOC |
+| 4. Scheduler and Studio integration | Use `locked_connection()` in scheduler ticks; route Studio services through `StateDB`; change bearer middleware to protect all `/api/*` methods; expose backend health without DSN leaks. | `apps/studio/server/app.py`, `apps/studio/server/scheduler/engine.py`, `apps/studio/server/services/*.py` | 350-650 LOC |
+| 5. Migration CLI | Add SQLite-to-Postgres and Postgres-to-SQLite export with dry-run counts, checksum sampling, resume-safe batches, and dependency-order inserts. | `lionagi/state/migrate.py`, `lionagi/cli/state.py`, `tests/state/test_state_migrate.py` | 500-850 LOC |
+| 6. Production search and observability | Add message/artifact search, pool metrics, LISTEN/NOTIFY or polling cursor for Studio freshness, and DBA-facing health checks. | `lionagi/state/search.py`, `apps/studio/server/routers/search.py`, tests | 500-900 LOC |
+
+MVP acceptance:
+
+- SQLite remains unchanged by default.
+- Store contract tests pass against SQLite and Postgres for every current StateDB surface.
+- No production code outside store implementations calls `StateDB.db` or Studio-local `_open_db`.
+- Postgres schema parity tests fail on any logical column drift, including extra branch lifecycle
+  columns.
+- Two Studio workers cannot fire the same due schedule when using Postgres.
+- All `/api/*` GET endpoints return 401 without the bearer token when the token is configured.
+
+Testability estimate `tau = 0.86`: the protocol is contract-testable, schema parity is
+mechanically testable, scheduler locking is integration-testable with two workers, and the main
+residual risk is operational Postgres tuning outside unit tests.
+
+## Security
+
+1. Bearer auth is mandatory for every Studio `/api/*` route when `LIONAGI_STUDIO_AUTH_TOKEN` is
+   configured. GET routes are not exempt.
+2. DSNs are secrets. Logs, exceptions, `/api/stats`, health output, and CLI status commands must
+   redact username, password, host, and query parameters unless an explicit admin-only diagnostic
+   command requests them.
+3. Production Postgres deployments must support TLS; `LIONAGI_STATE_SSLMODE=require` is the
+   minimum recommended setting outside local development.
+4. Use least-privilege database roles. Migration roles may create tables and indexes. Runtime
+   roles read and write application tables but do not own the database.
+5. SQL values use driver parameter binding. Identifier interpolation is allowed only from
+   internal allowlists, following the current `_validate_columns()` pattern.
+6. Full-text indexes expose message and artifact text to database readers. Backups and replicas
+   are sensitive assets.
+7. The schema remains single-tenant. This ADR does not claim tenant isolation or row-level
+   authorization for hosted multi-tenant SaaS.
+8. Artifact payload limits and blob policy are owned by ADR-0053 and must be enforced before
+   accepting writes into either backend.
+9. Governance evidence and status transition rows are audit records. Deletion requires an
+   explicit retention/archive ADR or command and must be recorded through `admin_events`.
+10. Money values introduced by later ADRs use integer cents in schema and Python types. Floats
+    are invalid for cost or pricing ledgers.
+
+## Migration
+
+1. Default remains SQLite. Existing local users keep `~/.lionagi/state.db`.
+2. ADR-0053 artifact migration lands first or Postgres runs only in experimental mode without
+   artifact parity claims.
+3. Operators initialize Postgres with the explicit DDL:
+
+   ```bash
+   LIONAGI_STATE_BACKEND=postgres \
+   LIONAGI_STATE_DSN=postgresql://lionagi_admin:...@db:5432/lionagi \
+   li state init
+   ```
+
+4. Dry-run migration reads the SQLite schema inventory and the Postgres schema inventory before
+   copying rows:
+
+   ```bash
+   li state migrate \
+     --from sqlite --sqlite-path ~/.lionagi/state.db \
+     --to postgres --dsn "$LIONAGI_STATE_DSN" \
+     --batch-size 1000 --dry-run
+   ```
+
+5. Rows migrate in dependency order:
+
+   ```text
+   schema_meta
+   message_types
+   progressions
+   messages
+   invocations
+   projects
+   sessions
+   branches
+   definitions
+   shows
+   plays
+   teams
+   team_messages
+   schedules
+   schedule_runs
+   admin_events
+   artifacts
+   status_transitions
+   ```
+
+6. Verification compares row counts for every table and deterministic checksums over primary key,
+   updated timestamp, and selected JSON fields.
+7. Cutover is an environment change:
+
+   ```bash
+   export LIONAGI_STATE_BACKEND=postgres
+   export LIONAGI_STATE_DSN=postgresql://lionagi_app:...@db:5432/lionagi
+   ```
+
+8. Rollback is an environment change while SQLite remains authoritative. If Postgres has accepted
+   new writes, operators run reverse export before rollback:
+
+   ```bash
+   li state migrate --from postgres --dsn "$LIONAGI_STATE_DSN" \
+     --to sqlite --sqlite-path ~/.lionagi/state.rollback.db
+   ```
+
+## Testing
+
+- Store contract tests run against both backends and cover every method in the protocol.
+- Schema parity tests compare SQLite and Postgres logical columns and fail if branches, artifacts,
+  cost/pricing columns, or other tables drift.
+- Migration tests seed sessions, branches, messages, projects, definitions, shows, plays, teams,
+  invocations, schedules, schedule runs, admin events, artifacts, and status transitions.
+- Scheduler tests run two workers against the same Postgres database and assert one schedule fire.
+- Studio tests assert unauthenticated GET requests to `/api/stats`, `/api/runs`, `/api/sessions`,
+  `/api/artifacts`, `/api/schedules`, `/api/projects`, and `/api/teams` fail closed when the
+  bearer token is configured.
+- Failure-injection tests drop a Postgres connection during live persistence and assert the flow
+  continues while persistence errors are logged, preserving current tolerance.
+- Cost/pricing schema tests reject floating-point money columns when ADR-0058 tables are present.
+
+## Consequences
+
+- The backend boundary is larger than the prior draft, but it matches the actual code surface.
+- SQLite remains the simple local default.
+- Production Studio can share state across workers and containers through Postgres.
+- Scheduler coordination is connection-safe under pooling.
+- Schema drift becomes mechanically visible before deployment.
+- Studio read routes stop leaking shared state when token auth is configured.
+- Future platform ADRs can depend on one typed state boundary instead of duplicating SQLite access.

--- a/docs/adrs/ADR-0059-postgres-state-backend.md
+++ b/docs/adrs/ADR-0059-postgres-state-backend.md
@@ -4,7 +4,7 @@ Status: proposed
 Date: 2026-05-27
 Decision owners: @governance-maintainers
 Depends on: ADR-0009 (SQLite state layer), ADR-0027 (scheduler engine / state.db), ADR-0053 (artifact persistence — artifact columns consumed, must land first or Postgres runs in experimental mode)
-Related: ADR-0033 (unified entity state model), ADR-0034 (frontend data/state), governance direction P18-P20
+Related: ADR-0033 (unified entity state model), ADR-0034 (frontend data/state)
 
 ## Context
 
@@ -464,14 +464,12 @@ residual risk is operational Postgres tuning outside unit tests.
    internal allowlists, following the current `_validate_columns()` pattern.
 6. Full-text indexes expose message and artifact text to database readers. Backups and replicas
    are sensitive assets.
-7. The schema remains single-tenant. This ADR does not claim tenant isolation or row-level
-   authorization for hosted multi-tenant SaaS.
-8. Artifact payload limits and blob policy are owned by ADR-0053 and must be enforced before
+7. Artifact payload limits and blob policy are owned by ADR-0053 and must be enforced before
    accepting writes into either backend.
-9. Governance evidence and status transition rows are audit records. Deletion requires an
+8. Governance evidence and status transition rows are audit records. Deletion requires an
    explicit retention/archive ADR or command and must be recorded through `admin_events`.
-10. Money values introduced by later ADRs use integer cents in schema and Python types. Floats
-    are invalid for cost or pricing ledgers.
+9. Money values introduced by later ADRs use integer cents in schema and Python types. Floats
+   are invalid for cost or pricing ledgers.
 
 ## Migration
 

--- a/docs/adrs/ADR-0060-unified-config-resolution.md
+++ b/docs/adrs/ADR-0060-unified-config-resolution.md
@@ -1,6 +1,6 @@
 # ADR-0060: Unified Config Resolution
 
-Status: Proposed
+Status: proposed
 Date: 2026-05-27
 Decision owners: @governance-maintainers
 Depends on: none

--- a/docs/adrs/ADR-0060-unified-config-resolution.md
+++ b/docs/adrs/ADR-0060-unified-config-resolution.md
@@ -1,6 +1,6 @@
 # ADR-0060: Unified Config Resolution
 
-Status: APPROVE-WITH-FIXES
+Status: Proposed
 Date: 2026-05-27
 Decision owners: @governance-maintainers
 Depends on: none
@@ -374,5 +374,3 @@ Acceptance checks:
 - Studio PUT and DELETE validate project rows and resolved project paths before touching disk.
 - Config endpoints return `401` without a valid bearer token when auth is configured.
 - No state.db or Postgres DDL is added for config resolution.
-
-Domain utility: SKIPPED - no lore suggest/compose tool is available in this execution environment.

--- a/docs/adrs/ADR-0060-unified-config-resolution.md
+++ b/docs/adrs/ADR-0060-unified-config-resolution.md
@@ -1,0 +1,378 @@
+# ADR-0060: Unified Config Resolution
+
+Status: APPROVE-WITH-FIXES
+Date: 2026-05-27
+Decision owners: @governance-maintainers
+Depends on: none
+Related: ADR-0026 (project detection), ADR-0057 (remote sandbox execution), ADR-0058 (play cost tracking)
+
+## Context
+
+lionagi has standardized on `.lionagi/` as the user-facing configuration namespace, but lookup
+rules are still duplicated across CLI, runtime, Studio, and plugin code. Users can get different
+answers depending on whether they invoke an agent, a playbook, a skill, settings, a runner, or a
+Studio resource endpoint.
+
+Current source shows the split. Runtime settings are loaded by `load_settings()`, which merges
+`~/.lionagi/settings.yaml` and a project `.lionagi/settings.yaml` when project settings are
+included (`lionagi/agent/settings.py:51`, `lionagi/agent/settings.py:65`,
+`lionagi/agent/settings.py:75`). Named playbooks resolve only from `~/.lionagi/playbooks` and
+already reject symlink escapes after `Path.resolve()` (`lionagi/cli/orchestrate/__init__.py:383`,
+`lionagi/cli/orchestrate/__init__.py:413`). Skills have a separate resolver under
+`~/.lionagi/skills/<name>/SKILL.md`, with the same resolved-path containment rule
+(`lionagi/cli/skill.py:26`, `lionagi/cli/skill.py:53`). Studio projects store a mutable `path`
+field and allow create/update of that path (`apps/studio/server/services/projects.py:150`,
+`apps/studio/server/services/projects.py:177`), so any project-local write API must define how a
+project name becomes a trusted filesystem root.
+
+ADR-0058 depends on pricing lookup, and ADR-0057 depends on runner lookup. Those cannot each
+define their own paths. Pricing must resolve through `<root>/pricing/<name>.yaml`; runner config
+must resolve through `<root>/runners/<name>.yaml`. Settings must also be a first-class resource
+kind, not a special case hidden behind `load_settings()`.
+
+The configuration decision must be filesystem-first. It does not need new state.db or Postgres DDL.
+The database may continue to store project rows and run provenance, but resource definitions,
+compatibility links, generated indexes, and sync manifests remain files.
+
+## Decision
+
+### 1. Add one resolver for all resource kinds
+
+Add `lionagi/config_resolution.py`. It owns resource kinds, root discovery, candidate conventions,
+symlink containment, source provenance, shadowing, sync manifests, and project-local write
+validation.
+
+```python
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+
+class ResourceKind(StrEnum):
+    AGENTS = "agents"
+    SKILLS = "skills"
+    PLAYBOOKS = "playbooks"
+    CHARTERS = "charters"
+    HOOKS = "hooks"
+    RUNNERS = "runners"
+    GATES = "gates"
+    PRICING = "pricing"
+    MODELS = "models"
+    MCP = "mcp"
+    SETTINGS = "settings"
+
+
+class SourceTier(StrEnum):
+    PROJECT_LIONAGI = "project_lionagi"
+    PROJECT_CLAUDE = "project_claude"
+    USER_LIONAGI = "user_lionagi"
+    USER_CLAUDE = "user_claude"
+    PLUGIN = "plugin"
+
+
+@dataclass(frozen=True, slots=True)
+class ResourceLocation:
+    kind: ResourceKind
+    name: str
+    path: Path
+    tier: SourceTier
+    root: Path
+    layout: str
+    plugin: str | None = None
+    shadowed_by: tuple[Path, ...] = ()
+
+
+def resolve_resource(
+    kind: ResourceKind | str,
+    name: str,
+    cwd: Path | None = None,
+    *,
+    include_plugins: bool = True,
+) -> ResourceLocation | None: ...
+
+
+def list_resources(
+    kind: ResourceKind | str,
+    cwd: Path | None = None,
+    *,
+    include_plugins: bool = True,
+) -> dict[str, ResourceLocation]: ...
+
+
+def resource_provenance(
+    kind: ResourceKind | str,
+    name: str,
+    cwd: Path | None = None,
+    *,
+    include_plugins: bool = True,
+) -> list[ResourceLocation]: ...
+```
+
+The canonical cascade is:
+
+```text
+project .lionagi/
+project .claude/
+~/.lionagi/
+~/.claude/
+plugin defaults
+```
+
+Within each root, the resolver checks literal candidates for the resource kind. It never expands
+untrusted glob patterns from user input. Resource names must be non-empty bare names: no path
+separators, NUL, leading dots, `.` / `..`, or glob metacharacters.
+
+| Kind | Canonical candidates |
+| --- | --- |
+| `agents` | `<root>/agents/<name>/<name>.md`, `<root>/agents/<name>.md` |
+| `skills` | `<root>/skills/<name>/SKILL.md`, `<root>/skills/<name>/<name>.md`, `<root>/skills/<name>.md` |
+| `playbooks` | `<root>/playbooks/<name>.playbook.yaml`, `<root>/playbooks/<name>.yaml`, `<root>/playbooks/<name>.yml` |
+| `charters` | `<root>/charters/<name>.yaml`, `<root>/charters/<name>.yml`, `<root>/charters/<name>.md` |
+| `hooks` | `<root>/hooks/<name>.py`, `<root>/hooks/<name>.sh`, `<root>/hooks/<name>.yaml` |
+| `runners` | `<root>/runners/<name>.yaml`, `<root>/runners/<name>.yml` |
+| `gates` | `<root>/gates/<name>.py`, `<root>/gates/<name>.yaml`, `<root>/gates/<name>.yml` |
+| `pricing` | `<root>/pricing/<name>.yaml`, `<root>/pricing/<name>.yml` |
+| `models` | `<root>/models/<name>.yaml`, `<root>/models/<name>.yml` |
+| `mcp` | `<root>/.mcp.json`, `<root>/<name>.mcp.json` |
+| `settings` | `<root>/settings.yaml`, `<root>/settings.yml` |
+
+ADR-0058 references `ResourceKind.PRICING` for model pricing. ADR-0057 references
+`ResourceKind.RUNNERS` for runner profiles. Existing `load_settings()` becomes a compatibility
+wrapper over `ResourceKind.SETTINGS`; it no longer constructs settings paths independently.
+
+### 2. Preserve settings merge behavior through the resolver
+
+Settings need layering, not just a winning file. Keep the public `load_settings()` function for
+compatibility, but implement it by asking the resolver for `ResourceKind.SETTINGS` provenance and
+merging from lowest to highest precedence:
+
+```python
+def load_settings(
+    project_dir: str | Path | None = None,
+    *,
+    include_project: bool = True,
+) -> dict[str, object]:
+    cwd = Path(project_dir) if project_dir is not None else None
+    locations = resource_provenance(
+        ResourceKind.SETTINGS,
+        "settings",
+        cwd=cwd,
+        include_plugins=False,
+    )
+    if not include_project:
+        locations = [loc for loc in locations if not loc.tier.value.startswith("project_")]
+    return merge_settings_low_to_high(reversed(locations))
+```
+
+Hook safety rules remain in `lionagi/agent/settings.py`: trusted Python modules stay allowlisted,
+and project settings remain opt-in for untrusted directories. The change is path authority, not hook
+policy.
+
+### 3. Follow symlinks only inside the selected roots
+
+The resolver follows symlinks when they remain within the declared root. It rejects resolved
+targets above that root.
+
+```python
+def contained_path(root: Path, candidate: Path) -> Path:
+    resolved_root = root.expanduser().resolve(strict=True)
+    resolved_candidate = candidate.expanduser().resolve(strict=True)
+    resolved_candidate.relative_to(resolved_root)
+    return resolved_candidate
+```
+
+This keeps the existing playbook and skill protections while applying them consistently to every
+resource kind. A root may itself resolve to a user-managed location, but each candidate must remain
+under that resolved root. Per-resource symlink escapes are rejected for reads, listing, Studio
+content fetches, PUT, and DELETE.
+
+### 4. Validate project to filesystem mapping before Studio writes
+
+Studio project-local resource writes use the project row as the authority. The client supplies a
+project name, resource kind, name, and content; it does not supply `cwd` or a filesystem root for
+mutating endpoints.
+
+For `PUT /api/config/projects/{project}/resources/{kind}/{name}` and
+`DELETE /api/config/projects/{project}/resources/{kind}/{name}`:
+
+1. Load the existing project row by name.
+2. Require `projects.path` to be present.
+3. Expand and resolve `projects.path` with `Path.resolve(strict=True)`.
+4. Require the resolved path to be an existing directory.
+5. Treat `<resolved-project-path>/.lionagi` as the only writable root.
+6. Generate the canonical project-local candidate path for `kind` and `name`.
+7. Resolve the candidate parent and final target after write or before delete.
+8. Reject the request unless the resolved target is still under the resolved `.lionagi` root.
+
+Project names never become filesystem paths. Mutable project path updates in
+`apps/studio/server/services/projects.py` must canonicalize and validate the path before accepting
+it for config writes.
+
+### 5. Do not add state database DDL
+
+ADR-0060 has no `state.db` or Postgres schema changes. It uses:
+
+```text
+resource files under .lionagi/ and .claude/
+~/.lionagi/.config-sync-manifest.json
+generated .lionagi/agents.md or ~/.lionagi/agents.md
+existing projects.path rows for Studio project root validation
+```
+
+No config provenance, sync status, or resource content is stored in `state.db` by this ADR.
+
+### Component Diagram
+
+```mermaid
+flowchart TD
+  CLI[CLI consumers] --> Resolver[config_resolution.py]
+  Runtime[agent runtime settings] --> Resolver
+  Studio[Studio config API] --> Resolver
+  ADR57[runner registry] --> Resolver
+  ADR58[pricing loader] --> Resolver
+  Resolver --> Roots[project/user/plugin roots]
+  Resolver --> Manifest[config sync manifest]
+```
+
+Coupling target: seven components, eight direct dependencies, `k = 8 / (7 * 6) = 0.19`.
+
+## Implementation
+
+### Core resolver
+
+Phase 1 adds:
+
+- `lionagi/config_resolution.py` with `ResourceKind`, `SourceTier`, `ResourceLocation`,
+  root discovery, candidate generation, containment checks, `resolve_resource`,
+  `list_resources`, and `resource_provenance`. Estimate: 320 LOC.
+- Tests in `tests/cli/test_config_resolution.py` covering precedence, shadowing, invalid names,
+  skill directory layouts, playbook layouts, settings, pricing, runners, and deterministic
+  ordering. Estimate: 260 LOC.
+
+### Existing consumers
+
+Phase 2 migrates current path owners:
+
+- `lionagi/cli/_agents.py`: preserve `AgentProfile` parsing while using
+  `resolve_resource(ResourceKind.AGENTS, name)`. Estimate: 60 LOC changed.
+- `lionagi/cli/orchestrate/__init__.py::_resolve_playbook_path()`: use
+  `resolve_resource(ResourceKind.PLAYBOOKS, name)` and keep `-f` ad-hoc files separate.
+  Estimate: 45 LOC changed.
+- `lionagi/cli/skill.py::resolve_skill_path()`: use `resolve_resource(ResourceKind.SKILLS, name)`
+  and preserve `strip_frontmatter()`. Estimate: 40 LOC changed.
+- `lionagi/agent/settings.py::load_settings()`: use `ResourceKind.SETTINGS` provenance and keep
+  explicit project trust behavior. Estimate: 80 LOC changed.
+- ADR-0057 runner registry: load runner config from `ResourceKind.RUNNERS`, not from
+  `settings.yaml` keys. Estimate: 60 LOC changed when ADR-0057 is implemented.
+- ADR-0058 pricing loader: load pricing from `ResourceKind.PRICING`, not from any standalone
+  pricing file. Estimate: 50 LOC changed when ADR-0058 is implemented.
+
+### Config CLI and sync
+
+Add `lionagi/cli/config.py` and register it in `lionagi/cli/main.py`:
+
+```bash
+li config list <kind> [--cwd PATH] [--all] [--json]
+li config which <kind> <name> [--cwd PATH] [--json]
+li config provenance <kind> <name> [--cwd PATH] [--json]
+li config sync [kind] [--dry-run] [--reset] [--json]
+li config agents-md [--cwd PATH] [--global] [--stdout] [--dry-run]
+```
+
+`li config sync` materializes compatibility links from `~/.claude/<kind>/` and plugin defaults into
+`~/.lionagi/<kind>/`. It records managed paths in `~/.lionagi/.config-sync-manifest.json`, never
+overwrites user-owned files, and removes only manifest-owned links on `--reset`.
+
+Estimate: 260 LOC for CLI, 180 LOC for sync helpers, 300 LOC of tests.
+
+### Studio API
+
+Add `apps/studio/server/services/config.py` and `apps/studio/server/routers/config.py`, then mount
+the router from `apps/studio/server/app.py`.
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/config/kinds` | List supported resource kinds and candidate conventions. |
+| `GET` | `/api/config/resources` | List resources by kind, project, optional cwd, and `all`. |
+| `GET` | `/api/config/resources/{kind}/{name}` | Return winning metadata and text content when safe. |
+| `GET` | `/api/config/resources/{kind}/{name}/provenance` | Return all matching candidates in precedence order. |
+| `PUT` | `/api/config/projects/{project}/resources/{kind}/{name}` | Create or update a project-local override. |
+| `DELETE` | `/api/config/projects/{project}/resources/{kind}/{name}` | Delete a project-local override. |
+| `POST` | `/api/config/sync` | Run sync with `kind`, `dry_run`, and `reset`. |
+| `GET` | `/api/config/sync/status` | Return manifest status and unmanaged conflicts. |
+| `POST` | `/api/config/agents-md` | Generate a project or global agents index. |
+
+Studio responses must not expose absolute source paths. Return `tier`, `kind`, `name`,
+`display_path`, `root_label`, `plugin`, `layout`, `managed`, and shadowing summaries. The CLI may
+show absolute paths for local developer diagnostics, but Studio APIs should use display paths and
+root labels.
+
+Frontend work adds `apps/studio/frontend/app/projects/[name]/config/page.tsx`,
+`apps/studio/frontend/lib/config.ts`, and reusable config components. Estimate: 700-900 LOC.
+
+### Sequence Diagram
+
+```mermaid
+sequenceDiagram
+  participant Studio
+  participant ConfigAPI
+  participant Projects
+  participant Resolver
+  participant FS as Filesystem
+
+  Studio->>ConfigAPI: PUT /api/config/projects/acme/resources/pricing/default
+  ConfigAPI->>Projects: get_project("acme")
+  Projects-->>ConfigAPI: path from projects row
+  ConfigAPI->>Resolver: validate_project_write(project_path, pricing, default)
+  Resolver->>FS: resolve project root and candidate path
+  FS-->>Resolver: resolved paths
+  Resolver-->>ConfigAPI: contained project-local target
+  ConfigAPI->>FS: atomic write under .lionagi/pricing/default.yaml
+  ConfigAPI-->>Studio: resource metadata without absolute path
+```
+
+## Security
+
+When `LIONAGI_STUDIO_AUTH_TOKEN` is set, all config endpoints require bearer authentication,
+including `GET`. Config content may include prompts, hook commands, runner provider details, MCP
+server paths, and pricing strategy.
+
+The resolver follows symlinks only when the resolved candidate stays under the resolved root.
+Symlink escape attempts must fail in `resolve_resource()`, `list_resources()`,
+`resource_provenance()`, Studio content reads, project-local PUT, and project-local DELETE.
+
+Studio mutating endpoints never accept client-supplied filesystem roots. They resolve the project
+row, validate the project path, and write only under that project's `.lionagi/` directory.
+
+API responses must not leak absolute paths. Use display paths relative to the selected project or
+user root, plus a root label such as `project_lionagi` or `user_lionagi`.
+
+Generated `agents.md` may include private operating instructions. The generator should use
+owner-readable permissions where supported and should include a generated-file header so operators
+edit the source resources, not the index.
+
+## Migration
+
+Phase 0 is documentation and tests only: no DDL.
+
+1. Add the resolver and tests while keeping current callers unchanged.
+2. Migrate agent, playbook, skill, and settings callers to the resolver behind compatibility
+   wrappers.
+3. Add config CLI commands and sync manifest handling.
+4. Add Studio config API with auth, path containment, and project-root validation.
+5. Update ADR-0057 implementation to reference `ResourceKind.RUNNERS`.
+6. Update ADR-0058 implementation to reference `ResourceKind.PRICING`.
+7. Deprecate direct path construction in callers once integration tests prove equivalent or better
+   behavior.
+
+Acceptance checks:
+
+- `ResourceKind.SETTINGS` exists and `load_settings()` no longer owns independent path logic.
+- Pricing resolves through `<root>/pricing/<name>.yaml` or `.yml`.
+- Runner profiles resolve through `<root>/runners/<name>.yaml` or `.yml`.
+- Symlink targets inside roots are accepted; symlink targets above roots are rejected.
+- Studio PUT and DELETE validate project rows and resolved project paths before touching disk.
+- Config endpoints return `401` without a valid bearer token when auth is configured.
+- No state.db or Postgres DDL is added for config resolution.
+
+Domain utility: SKIPPED - no lore suggest/compose tool is available in this execution environment.

--- a/docs/adrs/ADR-0061-universal-scheduler.md
+++ b/docs/adrs/ADR-0061-universal-scheduler.md
@@ -39,11 +39,11 @@ the current schedule row (`lionagi/state/schema.sql:402`, `lionagi/state/schema.
 evaluated inside one recursive `_fire()` call with a depth cap
 (`apps/studio/server/scheduler/engine.py:481`, `apps/studio/server/scheduler/engine.py:510`).
 
-The product context requires the scheduler to become the enterprise automation entry point, not a
-cron wrapper. Operators need to schedule single-agent tasks, fanout workers, DAG flows, playbooks,
-team coordination, shell maintenance, webhook-triggered flows, and chained schedules. The scheduler
-must therefore publish typed contracts, record durable state transitions, integrate with play
-control, and emit events that ADR-0063 can render as work items.
+The scheduler must become the universal automation entry point, not a cron wrapper. Operators need
+to schedule single-agent tasks, fanout workers, DAG flows, playbooks, team coordination, shell
+maintenance, webhook-triggered flows, and chained schedules. The scheduler must therefore publish
+typed contracts, record durable state transitions, integrate with play control, and emit events
+that ADR-0063 can render as work items.
 
 Coupling estimate after this decision: components `{SchedulerEngine, TriggerService,
 ActionRenderer, ExecutorRegistry, StateStore, StudioSchedulesAPI, LiScheduleCLI, EventBus}` with

--- a/docs/adrs/ADR-0061-universal-scheduler.md
+++ b/docs/adrs/ADR-0061-universal-scheduler.md
@@ -1,0 +1,572 @@
+# ADR-0061: Universal Scheduler - `li schedule` for Any Flow
+
+Status: proposed
+Date: 2026-05-27
+Decision owners: @governance-maintainers
+Depends on: ADR-0027 (scheduled runs), ADR-0028 (status reasons), ADR-0056 (play control), ADR-0059 (StateStore), ADR-0060 (config resolution)
+Related: ADR-0062 (scheduled item state machine), ADR-0063 (task board work center)
+
+## Context
+
+LionAGI already has a scheduler, but it is an ADR-0027 implementation aimed at a narrow set of
+CLI actions. The Studio FastAPI lifespan starts an in-process scheduler task at server startup
+(`apps/studio/server/app.py:33`, `apps/studio/server/app.py:37`) and stops it at shutdown
+(`apps/studio/server/app.py:39`). The engine ticks every 30 seconds (`apps/studio/server/scheduler/engine.py:141`,
+`apps/studio/server/scheduler/engine.py:187`), evaluates enabled schedules
+(`apps/studio/server/scheduler/engine.py:280`), and fires work by creating an invocation, building
+argv, inserting a `schedule_runs` row, and spawning a subprocess
+(`apps/studio/server/scheduler/engine.py:372`, `apps/studio/server/scheduler/engine.py:386`,
+`apps/studio/server/scheduler/engine.py:390`, `apps/studio/server/scheduler/engine.py:433`).
+
+The current executor hard-codes `argv = ["uv", "run", "li"]`
+(`apps/studio/server/scheduler/subprocess.py:44`) and only renders four action kinds:
+`agent`, `flow`, `fanout`, and `play` (`apps/studio/server/scheduler/subprocess.py:46`,
+`apps/studio/server/scheduler/subprocess.py:50`, `apps/studio/server/scheduler/subprocess.py:52`,
+`apps/studio/server/scheduler/subprocess.py:54`). It does not schedule `li team`, arbitrary shell
+commands, direct webhook delivery, or chained schedules as durable dependencies. `li play` is also
+CLI sugar that rewrites to `li o flow -p NAME` before argparse
+(`lionagi/cli/main.py:176`, `lionagi/cli/main.py:213`), so the scheduler should treat `play` as a
+first-class flow type while preserving the current CLI behavior.
+
+The current schema reflects that narrow model. `schedules.trigger_type` is limited to `cron`,
+`interval`, and `github_poll` (`lionagi/state/schema.sql:386`), while `schedules.action_kind` is
+limited to `agent`, `flow`, `fanout`, and `play` (`lionagi/state/schema.sql:394`). `schedule_runs`
+stores `trigger_context`, `action_kind`, and rendered `action_args`
+(`lionagi/state/schema.sql:427`, `lionagi/state/schema.sql:428`, `lionagi/state/schema.sql:429`),
+but has no retry attempt number, no durable queue state, no per-schedule concurrency limit, and no
+dependency edge table. Conditional chaining exists only as inline `on_success` / `on_fail` JSON on
+the current schedule row (`lionagi/state/schema.sql:402`, `lionagi/state/schema.sql:403`) and is
+evaluated inside one recursive `_fire()` call with a depth cap
+(`apps/studio/server/scheduler/engine.py:481`, `apps/studio/server/scheduler/engine.py:510`).
+
+The product context requires the scheduler to become the enterprise automation entry point, not a
+cron wrapper. Operators need to schedule single-agent tasks, fanout workers, DAG flows, playbooks,
+team coordination, shell maintenance, webhook-triggered flows, and chained schedules. The scheduler
+must therefore publish typed contracts, record durable state transitions, integrate with play
+control, and emit events that ADR-0063 can render as work items.
+
+Coupling estimate after this decision: components `{SchedulerEngine, TriggerService,
+ActionRenderer, ExecutorRegistry, StateStore, StudioSchedulesAPI, LiScheduleCLI, EventBus}` with
+intended deps `{SchedulerEngine->TriggerService, SchedulerEngine->ActionRenderer,
+SchedulerEngine->ExecutorRegistry, SchedulerEngine->StateStore, TriggerService->StateStore,
+StudioSchedulesAPI->StateStore, LiScheduleCLI->StateStore, ExecutorRegistry->StateStore,
+StateStore->EventBus}` gives `9 / (8 * 7) = 0.16`. This stays below 0.3 because flow-specific
+execution sits behind one typed executor registry.
+
+## Decision
+
+Extend ADR-0027 into a universal scheduler that stores a typed schedule definition, trigger
+definition, action template, dependency edges, retry policy, and concurrency policy. `li schedule`
+and Studio both write the same `schedules` contract through StateStore. The scheduler renders work
+into one of eight flow types: `agent`, `fanout`, `flow`, `play`, `team`, `shell`, `webhook`, or
+`chain`. Cron, webhook, event, and manual triggers all create durable `schedule_runs` rows before
+execution. Chained schedules are durable edges between schedule definitions, not recursive inline
+JSON hidden inside a parent run.
+
+### Canonical Types
+
+```python
+# lionagi/scheduler/types.py
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any, Literal, Protocol
+
+from pydantic import BaseModel, Field
+
+
+class FlowType(StrEnum):
+    AGENT = "agent"
+    FANOUT = "fanout"
+    FLOW = "flow"
+    PLAY = "play"
+    TEAM = "team"
+    SHELL = "shell"
+    WEBHOOK = "webhook"
+    CHAIN = "chain"
+
+
+class TriggerType(StrEnum):
+    CRON = "cron"
+    WEBHOOK = "webhook"
+    EVENT = "event"
+    MANUAL = "manual"
+
+
+class EventTrigger(StrEnum):
+    SESSION_COMPLETE = "on-session-complete"
+    ARTIFACT_CREATED = "on-artifact-created"
+    GATE_VERDICT = "on-gate-verdict"
+    SCHEDULE_RUN_COMPLETE = "on-schedule-run-complete"
+
+
+class RetryBackoff(StrEnum):
+    NONE = "none"
+    FIXED = "fixed"
+    EXPONENTIAL = "exponential"
+
+
+class RetryPolicy(BaseModel):
+    max_retries: int = Field(default=0, ge=0, le=20)
+    backoff: RetryBackoff = RetryBackoff.NONE
+    initial_delay_sec: int = Field(default=30, ge=0)
+    max_delay_sec: int = Field(default=3600, ge=0)
+    retry_on: set[str] = Field(default_factory=lambda: {"failed", "timed_out"})
+
+
+class ConcurrencyPolicy(BaseModel):
+    per_schedule_limit: int = Field(default=1, ge=1)
+    global_limit_key: str = "default"
+    overlap: Literal["skip", "queue", "cancel_previous", "allow"] = "queue"
+
+
+class ScheduleTrigger(BaseModel):
+    type: TriggerType
+    cron: str | None = None
+    event: EventTrigger | None = None
+    webhook_path: str | None = None
+    event_filter: dict[str, Any] = Field(default_factory=dict)
+
+
+class ActionTemplate(BaseModel):
+    flow_type: FlowType
+    argv: list[str] = Field(default_factory=list)
+    command: str | None = None
+    parameters: dict[str, Any] = Field(default_factory=dict)
+    env_refs: dict[str, str] = Field(default_factory=dict)
+    cwd: str | None = None
+    timeout_sec: int | None = Field(default=None, ge=1)
+
+
+class ScheduleSpec(BaseModel):
+    id: str
+    name: str
+    lifecycle_status: Literal["draft", "enabled", "disabled", "archived"] = "draft"
+    trigger: ScheduleTrigger
+    action: ActionTemplate
+    parameter_template: dict[str, Any] = Field(default_factory=dict)
+    retry_policy: RetryPolicy = Field(default_factory=RetryPolicy)
+    concurrency: ConcurrencyPolicy = Field(default_factory=ConcurrencyPolicy)
+    created_by: str
+
+
+class RenderedAction(BaseModel):
+    flow_type: FlowType
+    argv: list[str]
+    env: dict[str, str] = Field(default_factory=dict)
+    cwd: str | None = None
+    display_command: str
+
+
+class ScheduleExecutor(Protocol):
+    flow_type: FlowType
+
+    async def render(self, spec: ScheduleSpec, context: dict[str, Any]) -> RenderedAction: ...
+    async def execute(self, action: RenderedAction, run_id: str) -> int: ...
+```
+
+### Trigger and Action Semantics
+
+| Trigger | Meaning | Required fields |
+|---|---|---|
+| `cron` | Time-based recurring trigger. Replaces `interval` as a first-class trigger; simple intervals are expressed as cron or policy sugar in `li schedule`. | `trigger.cron`, `next_fire_at` |
+| `webhook` | External HTTP event delivered to Studio and matched to one or more schedules. | `webhook_path`, `event_filter`, auth config |
+| `event` | Internal event emitted by the state transition/event bus. | `event`, `event_filter` |
+| `manual` | Operator/API/CLI trigger. | actor and reason |
+
+| Flow type | Rendering rule |
+|---|---|
+| `agent` | `uv run li agent ...` |
+| `fanout` | `uv run li o fanout ...` |
+| `flow` | `uv run li o flow ...` |
+| `play` | `uv run li play NAME ...`, preserving the existing CLI shortcut at `lionagi/cli/main.py:237` |
+| `team` | `uv run li team ...` |
+| `shell` | An explicit argv list by default; `bash -lc` only when `shell_mode=true` and policy permits it |
+| `webhook` | HTTP request action for downstream systems, signed by a secret reference |
+| `chain` | No subprocess; enqueue linked downstream schedules |
+
+Parameter templates use a constrained renderer, not Python eval and not full Jinja. Template strings
+may reference:
+
+```text
+{{schedule.id}}      {{schedule.name}}
+{{run.id}}           {{run.attempt}}
+{{trigger.type}}     {{trigger.payload.<key>}}
+{{upstream.run_id}}  {{upstream.status}}  {{upstream.artifacts.<name>}}
+{{event.type}}       {{event.entity_id}}  {{event.reason_code}}
+```
+
+The renderer fails closed on missing required variables unless the placeholder uses an explicit
+default such as `{{trigger.payload.branch | default("main")}}`. Secrets are never template values;
+templates carry secret references resolved through ADR-0060 resource lookup.
+
+### Component Diagram
+
+```mermaid
+flowchart TD
+  Cron[Cron evaluator] --> TriggerSvc[TriggerService]
+  Webhook[Webhook receiver] --> TriggerSvc
+  Events[State transition events] --> TriggerSvc
+  Manual[li schedule / Studio trigger] --> TriggerSvc
+  TriggerSvc --> Store[StateStore]
+  Store --> Queue[schedule_runs queued]
+  Engine[SchedulerEngine workers] --> Queue
+  Engine --> Renderer[ActionRenderer]
+  Renderer --> Registry[ExecutorRegistry]
+  Registry --> LiExec[li executor]
+  Registry --> ShellExec[shell executor]
+  Registry --> HttpExec[webhook executor]
+  Registry --> ChainExec[chain executor]
+  LiExec --> Sessions[sessions / invocations]
+  ShellExec --> Sessions
+  ChainExec --> Store
+  Store --> EventBus[transition event bus]
+  EventBus --> WorkBoard[ADR-0063 work items]
+```
+
+### Sequence Diagram
+
+```mermaid
+sequenceDiagram
+  participant T as TriggerService
+  participant S as StateStore
+  participant E as SchedulerEngine
+  participant X as Executor
+  participant B as EventBus
+
+  T->>S: create schedule_run(status=queued, trigger_context)
+  T->>B: emit schedule_run.queued
+  E->>S: lease queued run if concurrency guards pass
+  E->>S: transition queued -> running
+  E->>X: render and execute action
+  X-->>E: exit_code
+  alt exit_code == 0
+    E->>S: transition running -> completed
+    E->>T: enqueue dependent schedules
+  else retryable
+    E->>S: transition running -> retry_wait
+    T->>S: enqueue retry attempt
+  else terminal failure
+    E->>S: transition running -> failed
+  end
+  S->>B: emit transition event
+```
+
+## Implementation
+
+### Schema Changes
+
+Keep the existing `schedules` and `schedule_runs` tables for compatibility, but add universal
+columns and introduce dependency/event tables. New code reads `flow_type`, `trigger_config`,
+`action_template`, and `retry_policy`; the old `action_kind` and `action_*` columns are populated
+during a compatibility window for current Studio screens.
+
+```sql
+-- Note: lifecycle_status is owned by ADR-0062, which adds it via its own migration.
+-- ADR-0061 reads lifecycle_status but does not ALTER TABLE schedules to add it.
+ALTER TABLE schedules ADD COLUMN flow_type TEXT;
+ALTER TABLE schedules ADD COLUMN trigger_config JSON NOT NULL DEFAULT '{}';
+ALTER TABLE schedules ADD COLUMN action_template JSON NOT NULL DEFAULT '{}';
+ALTER TABLE schedules ADD COLUMN parameter_template JSON NOT NULL DEFAULT '{}';
+ALTER TABLE schedules ADD COLUMN concurrency_policy JSON NOT NULL DEFAULT '{"per_schedule_limit":1,"global_limit_key":"default","overlap":"queue"}';
+ALTER TABLE schedules ADD COLUMN retry_policy JSON NOT NULL DEFAULT '{"max_retries":0,"backoff":"none","retry_on":["failed","timed_out"]}';
+ALTER TABLE schedules ADD COLUMN created_by TEXT;
+ALTER TABLE schedules ADD COLUMN archived_at REAL;
+
+ALTER TABLE schedule_runs ADD COLUMN attempt INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE schedule_runs ADD COLUMN retry_of_run_id TEXT REFERENCES schedule_runs(id);
+ALTER TABLE schedule_runs ADD COLUMN queued_at REAL;
+ALTER TABLE schedule_runs ADD COLUMN started_at REAL;
+ALTER TABLE schedule_runs ADD COLUMN leased_by TEXT;
+ALTER TABLE schedule_runs ADD COLUMN lease_expires_at REAL;
+ALTER TABLE schedule_runs ADD COLUMN concurrency_key TEXT;
+ALTER TABLE schedule_runs ADD COLUMN upstream_run_id TEXT REFERENCES schedule_runs(id);
+ALTER TABLE schedule_runs ADD COLUMN rendered_action JSON;
+```
+
+```sql
+CREATE TABLE IF NOT EXISTS schedule_dependencies (
+  id                     TEXT PRIMARY KEY,
+  upstream_schedule_id   TEXT NOT NULL REFERENCES schedules(id) ON DELETE CASCADE,
+  downstream_schedule_id TEXT NOT NULL REFERENCES schedules(id) ON DELETE CASCADE,
+  fire_on                TEXT NOT NULL CHECK(fire_on IN ('success', 'failure', 'terminal')),
+  parameter_template     JSON NOT NULL DEFAULT '{}',
+  enabled                INTEGER NOT NULL DEFAULT 1 CHECK(enabled IN (0, 1)),
+  created_at             REAL NOT NULL,
+  updated_at             REAL NOT NULL,
+  UNIQUE(upstream_schedule_id, downstream_schedule_id, fire_on)
+);
+
+-- Note: Event persistence uses the `state_events` table defined in ADR-0062.
+-- ADR-0061 does not define a separate scheduler_events table; all scheduler
+-- transition events are written to and consumed from state_events.
+
+CREATE INDEX IF NOT EXISTS idx_schedules_lifecycle_next
+  ON schedules(lifecycle_status, next_fire_at)
+  WHERE lifecycle_status = 'enabled';
+CREATE INDEX IF NOT EXISTS idx_schedule_runs_queue
+  ON schedule_runs(status, queued_at)
+  WHERE status IN ('queued', 'retry_wait');
+CREATE INDEX IF NOT EXISTS idx_schedule_runs_concurrency
+  ON schedule_runs(concurrency_key, status)
+  WHERE status IN ('queued', 'running', 'retry_wait');
+CREATE INDEX IF NOT EXISTS idx_schedule_deps_upstream
+  ON schedule_dependencies(upstream_schedule_id, fire_on)
+  WHERE enabled = 1;
+```
+
+ADR-0059 requires all of this to be exposed through StateStore rather than more direct
+`db.db.execute()` call sites. The current `StateDB.create_schedule()` insert path at
+`lionagi/state/db.py:1185` and `StateDB.update_schedule()` allowlist at `lionagi/state/db.py:1269`
+must be extended with the new fields. `StateDB.create_schedule_run()` at `lionagi/state/db.py:1318`
+must accept queued and retry metadata.
+
+### Engine Changes
+
+1. Replace `_running: dict[str, str]` overlap tracking (`apps/studio/server/scheduler/engine.py:148`)
+   with durable DB leases so multiple Studio workers or a future Postgres scheduler do not double-fire.
+2. Replace `_compute_next_fire()` trigger branching (`apps/studio/server/scheduler/engine.py:557`) with
+   `TriggerService.next_fire_at(spec, now)`.
+3. Replace `build_argv(schedule, trigger_context)` (`apps/studio/server/scheduler/engine.py:386`) with
+   `ActionRenderer.render(spec, context) -> RenderedAction`.
+4. Keep `LIONAGI_INVOCATION_ID` propagation (`apps/studio/server/scheduler/subprocess.py:70`) for all
+   `li` based actions so child sessions continue to attach to the parent invocation.
+5. Move inline recursive chains (`apps/studio/server/scheduler/engine.py:481`) into
+   `schedule_dependencies` so dependent schedules can be inspected, retried, disabled, and audited.
+
+### Public API
+
+Extend the existing schedule router, which currently exposes list/detail/create/update/delete,
+enable/disable, trigger, and run history (`apps/studio/server/routers/schedules.py:63`,
+`apps/studio/server/routers/schedules.py:83`, `apps/studio/server/routers/schedules.py:126`,
+`apps/studio/server/routers/schedules.py:136`).
+
+```text
+GET    /api/schedules
+POST   /api/schedules
+GET    /api/schedules/{id}
+PATCH  /api/schedules/{id}
+POST   /api/schedules/{id}/enable
+POST   /api/schedules/{id}/disable
+POST   /api/schedules/{id}/archive
+POST   /api/schedules/{id}/trigger
+GET    /api/schedules/{id}/runs
+POST   /api/schedules/{id}/dependencies
+DELETE /api/schedules/{id}/dependencies/{dependency_id}
+POST   /api/schedules/webhooks/{path}
+GET    /api/schedule-runs/{run_id}
+POST   /api/schedule-runs/{run_id}/retry
+POST   /api/schedule-runs/{run_id}/cancel
+```
+
+`li schedule` gains the same surface:
+
+```text
+li schedule create nightly-review --trigger cron --cron "0 2 * * *" --flow play --playbook review
+li schedule create shell-prune --trigger cron --cron "0 4 * * 0" --flow shell --argv li,state,prune
+li schedule webhook github-pr --path github/pr --flow flow --playbook pr-review
+li schedule depends nightly-review triage-failure --on failure
+li schedule trigger nightly-review --reason "operator verification"
+li schedule runs nightly-review
+```
+
+### Phasing and Estimates
+
+| Phase | Scope | LOC estimate |
+|---|---|---:|
+| 0 | Schema migration, StateStore methods, typed models, compatibility mapping from old `action_kind` fields | 260-380 |
+| 1 | Durable queue/leases, concurrency guards, retry policy, cron/manual triggers | 360-520 |
+| 2 | Executor registry for `agent`, `fanout`, `flow`, `play`, `team`, and shell argv mode | 320-480 |
+| 3 | Webhook receiver, internal event triggers, dependency edges, idempotency keys | 420-620 |
+| 4 | Studio and `li schedule` UX, migration/backfill tests, docs | 360-560 |
+
+Testability target: `tau = 0.86`. Most behavior is pure rendering, transition guards, and StateStore
+contract tests. Only executor integration needs subprocess tests.
+
+## Security
+
+All scheduler endpoints require bearer authentication when `LIONAGI_STUDIO_AUTH_TOKEN` is set,
+including reads. The current middleware only gates `/api/admin/*` reads and mutating non-admin
+routes (`apps/studio/server/app.py:52`, `apps/studio/server/app.py:56`,
+`apps/studio/server/app.py:60`); this ADR requires explicit route dependencies until the global
+middleware is upgraded.
+
+Shell scheduling is opt-in. The default shell executor accepts argv arrays and calls
+`asyncio.create_subprocess_exec`, matching the current subprocess pattern
+(`apps/studio/server/scheduler/subprocess.py:73`). String shell execution through `bash -lc` is
+disabled unless a governed policy grants `scheduler.shell_mode`. Rendered commands are stored for
+audit, but secret values are not. Secret references resolve through ADR-0060 and are redacted in
+`schedule_runs.rendered_action`.
+
+Webhook schedules require a per-path secret or signed provider verifier. Webhook bodies are stored
+as bounded JSON payloads with size limits and are never interpreted as command strings. Parameter
+templates are data substitution only.
+
+## Migration
+
+1. Add nullable universal columns and new tables. Backfill `flow_type = action_kind`, convert old
+   trigger columns into `trigger_config`, and convert old action columns into `action_template`.
+2. Keep current Studio schedule APIs working by reading/writing both old and new fields for one
+   release.
+3. Backfill existing `schedule_runs` with `attempt=1`, `queued_at=fired_at`, and `started_at=fired_at`.
+4. Replace in-memory overlap checks with DB concurrency queries.
+5. Deprecate `github_poll` as a trigger type. Existing rows become `trigger_type='event'` or
+   `trigger_type='webhook'` depending on deployment; polling can remain an event source adapter.
+6. After one release, make `flow_type`, `trigger_config`, and `action_template` non-null in both
+   SQLite and Postgres DDL.
+
+## Alternatives Considered
+
+| Alternative | Why rejected |
+|---|---|
+| Keep ADR-0027 and add more `action_kind` branches | It scales linearly with CLI features and keeps chains hidden inside recursive JSON rather than inspectable state. |
+| Embed a workflow engine such as n8n or Temporal in Studio | Too large for Phase 0 and duplicates LionAGI's existing flow/session/state model. |
+| Use OS cron and external webhooks only | Loses invocation linkage, status reasons, task board integration, retries, and governance audit. |
+
+## Consequences
+
+Positive: the scheduler becomes the single durable automation surface for LionAGI. Studio, CLI,
+webhooks, and internal events all enqueue the same `schedule_runs` state machine.
+
+Negative: the scheduler now owns concurrency and queue semantics that must be correct across SQLite
+and Postgres. This depends on ADR-0059's transaction and lock abstractions being implemented before
+multi-worker production use.
+
+## Runtime Implementation (`lionagi/runtime/scheduler.py`)
+
+The in-process scheduler engine shipped in Phase 0 (`lionagi/runtime/scheduler.py`) implements
+the core data model and state machine described in this ADR.  It is intentionally process-scoped
+and testable without a database.  Studio and `li schedule daemon` back it with a
+`StateStore`-aware wrapper in later phases.
+
+### ScheduleItem State Transition Table
+
+Every `ScheduleItem` moves through the following states.  The `SchedulerEngine` enforces
+these transitions; invalid transitions return `False` rather than raising.
+
+| From status | Trigger / verb | To status | Guard |
+|---|---|---|---|
+| _(none)_ | `add()` | `active` | always; `next_run_at` computed from cron or interval |
+| `active` | `mark_started()` | `running` | status must be `active` |
+| `running` | `mark_completed()` | `active` | `run_count < max_runs` (or unlimited) |
+| `running` | `mark_completed()` | `completed` | `run_count >= max_runs` |
+| `running` | `mark_failed()` | `failed` | any failure; terminal |
+| `active` | `pause()` | `paused` | status must be `active`; blocks `get_due_items` |
+| `paused` | `resume()` | `active` | status must be `paused`; recomputes `next_run_at` |
+| any | `remove()` | _(removed)_ | always; item deleted from engine |
+
+Terminal statuses (`completed`, `failed`) are never returned by `get_due_items`.  A failed item
+must be explicitly re-added by the caller if retry semantics are desired (retry policy is
+implemented at the driver layer, not the engine layer, in Phase 0).
+
+### Cron Expression Reference
+
+The engine supports a strict subset of cron syntax (five fields: minute hour day month weekday):
+
+| Expression | Meaning |
+|---|---|
+| `* * * * *` | every minute |
+| `*/5 * * * *` | every 5 minutes |
+| `0 * * * *` | top of every hour |
+| `0 */2 * * *` | every 2 hours on the hour |
+| `0 0 * * *` | midnight every day |
+| `0 0 * * 1` | midnight every Monday (weekday 1 = Monday in cron, 0 = Sunday) |
+| `0 2 * * *` | 02:00 every day |
+| `30 9 * * *` | 09:30 every day |
+| `0 0 1 * *` | first of every month at midnight |
+| `0 0 1 1 *` | 1 January at midnight |
+
+**Not supported**: ranges (`1-5`), comma lists (`1,3,5`), `L` / `W` / `#` modifiers, `@reboot`,
+`@daily` aliases.  These raise `ValueError` at parse time.
+
+Weekday values: 0 = Sunday, 1 = Monday, …, 6 = Saturday.  This matches traditional POSIX
+cron (not Quartz/systemd `1`=Monday convention).  `next_cron_fire` converts to Python's
+`weekday()` (Monday=0) internally.
+
+### Persistence Model
+
+When a `StateStore` is supplied the engine writes one row per `ScheduleItem` to a
+`scheduled_items` table.  DDL (SQLite dialect):
+
+```sql
+CREATE TABLE IF NOT EXISTS scheduled_items (
+  item_id          TEXT PRIMARY KEY,
+  name             TEXT NOT NULL,
+  cron_expr        TEXT,
+  interval_seconds REAL,
+  next_run_at      REAL NOT NULL,
+  last_run_at      REAL,
+  status           TEXT NOT NULL DEFAULT 'active',
+  max_runs         INTEGER,
+  run_count        INTEGER NOT NULL DEFAULT 0,
+  flow_spec        JSON NOT NULL DEFAULT '{}',
+  created_at       REAL NOT NULL,
+  updated_at       REAL NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_scheduled_items_due
+  ON scheduled_items(status, next_run_at)
+  WHERE status = 'active';
+```
+
+Phase 0 engine does not auto-persist; the driver layer is responsible for serialising
+`ScheduleItem.model_dump()` after each mutation.  Phase 1 will wire `StateStore.execute_insert`
+and `StateStore.execute` into `SchedulerEngine._persist_item()`.
+
+### Error Handling Strategy
+
+1. `parse_cron(expr)` raises `ValueError` on the first invalid field; callers that accept
+   user input should catch this at the API boundary.
+2. `next_cron_fire(parsed, after)` raises `ValueError` if no fire time exists within a
+   four-year search window.  This can only happen for logically impossible expressions that
+   pass `parse_cron` (e.g. `"0 0 31 2 *"` — 31 February).
+3. `SchedulerEngine` mutating methods (`pause`, `resume`, `mark_started`, `mark_completed`,
+   `mark_failed`) return `bool` — `True` on success, `False` on precondition failure.
+   They never raise on state mismatches so callers can implement optimistic patterns.
+4. `SchedulerEngine.add` raises `ValueError` on invalid inputs (both triggers set, invalid
+   interval, invalid cron) before any state is written.
+5. The internal `threading.Lock` is never held across I/O boundaries; all lock scopes are
+   `O(1)` dict operations.
+
+### Integration with PlayRunner
+
+`SchedulerEngine` is process-agnostic — it stores state and answers queries but never spawns
+processes.  The driver loop (Studio lifespan or `li schedule daemon`) integrates it with
+`LocalRunner` / `PlayRunner` as follows:
+
+```python
+engine = SchedulerEngine()
+
+async def tick():
+    for item in engine.get_due_items():
+        engine.mark_started(item.item_id)
+        argv = _build_argv(item.flow_spec)          # driver-specific rendering
+        runner = LocalRunner()
+        session_id = await runner.start({"session_id": item.item_id, "command": argv})
+        handle = await runner.status(session_id)
+        if handle.state == RunnerState.COMPLETED:
+            engine.mark_completed(item.item_id)
+        else:
+            engine.mark_failed(item.item_id, error=str(handle.state))
+
+# Scheduler loop
+while True:
+    await tick()
+    due = engine.get_due_items()
+    sleep_secs = min((it.next_run_at - time.time() for it in due), default=30)
+    await asyncio.sleep(max(1.0, sleep_secs))
+```
+
+The separation keeps `SchedulerEngine` fully testable without subprocesses and allows the
+driver to implement concurrency limits, retry backoff, and lease tracking independently.
+
+## References
+
+- `apps/studio/server/scheduler/engine.py:145`
+- `apps/studio/server/scheduler/subprocess.py:31`
+- `lionagi/state/schema.sql:380`
+- `lionagi/state/schema.sql:423`
+- `lionagi/cli/main.py:255`
+- `lionagi/runtime/scheduler.py` — Phase 0 engine implementation
+- `lionagi/cli/schedule.py` — `li schedule` CLI surface
+- `tests/runtime/test_scheduler.py` — 69 tests (tau = 0.90+)

--- a/docs/adrs/ADR-0061-universal-scheduler.md
+++ b/docs/adrs/ADR-0061-universal-scheduler.md
@@ -3,8 +3,8 @@
 Status: proposed
 Date: 2026-05-27
 Decision owners: @governance-maintainers
-Depends on: ADR-0027 (scheduled runs), ADR-0028 (status reasons), ADR-0056 (play control), ADR-0059 (StateStore), ADR-0060 (config resolution)
-Related: ADR-0062 (scheduled item state machine), ADR-0063 (task board work center)
+Depends on: ADR-0027 (scheduled runs), ADR-0028 (status reasons), ADR-0056 (play control), ADR-0059 (StateStore), ADR-0060 (config resolution), ADR-0062 (scheduled item state machine — lifecycle_status and state_events schema consumed here)
+Related: ADR-0063 (task board work center)
 
 ## Context
 

--- a/docs/adrs/ADR-0062-state-machine-spec.md
+++ b/docs/adrs/ADR-0062-state-machine-spec.md
@@ -1,0 +1,617 @@
+# ADR-0062: Scheduled Item State Machine
+
+Status: proposed
+Date: 2026-05-27
+Decision owners: @governance-maintainers
+Depends on: ADR-0025 (session status), ADR-0028 (status reasons), ADR-0056 (play control), ADR-0059 (StateStore), ADR-0061 (universal scheduler)
+Related: ADR-0063 (task board work center)
+
+## Context
+
+LionAGI has several lifecycle vocabularies today, each useful in isolation but incomplete for
+scheduled work. Sessions use the runtime statuses `running`, `completed`, `failed`, `timed_out`,
+`aborted`, and `cancelled` in Python (`lionagi/state/db.py:203`, `lionagi/state/db.py:213`) and
+store them without a SQLite `CHECK` so Python remains the source of truth
+(`lionagi/state/schema.sql:122`, `lionagi/state/schema.sql:127`). Plays use workflow statuses such
+as `pending`, `prepared`, `running`, `running_complete`, `gated`, `gate_failed`, `redoing`,
+`merged`, `escalated`, `blocked`, and `aborted_after_finish`
+(`lionagi/state/schema.sql:271`, `lionagi/state/schema.sql:273`, `lionagi/state/db.py:243`).
+Invocations share the runtime terminal vocabulary (`lionagi/state/schema.sql:361`).
+
+Schedule runs are narrower. The schema allows only `running`, `completed`, `failed`, `skipped`,
+and `cancelled` (`lionagi/state/schema.sql:430`). The engine creates runs directly in `running`
+state (`apps/studio/server/scheduler/engine.py:391`, `apps/studio/server/scheduler/engine.py:399`)
+and then updates to `completed` or `failed` after the subprocess exits
+(`apps/studio/server/scheduler/engine.py:437`, `apps/studio/server/scheduler/engine.py:454`).
+This omits queueing, leasing, retry waits, dependency waits, manual cancellation, and webhook/event
+deduplication.
+
+ADR-0028 already established the correct audit pattern: every status-bearing entity has
+denormalized current reason columns and append-only `status_transitions`
+(`lionagi/state/schema.sql:531`, `lionagi/state/schema.sql:540`). `StateDB.update_status()` is the
+single sanctioned mutation point today (`lionagi/state/db.py:905`, `lionagi/state/db.py:917`) and
+inserts a transition history row in the same transaction (`lionagi/state/db.py:1004`,
+`lionagi/state/db.py:1026`). However, the current implementation uses `BEGIN IMMEDIATE`
+(`lionagi/state/db.py:970`), so this ADR defines the backend-neutral compare-and-swap API that
+ADR-0059 must expose through `StateStore.transaction()`.
+
+ADR-0056 adds play control states such as `paused`, `cancelling`, `killing`, and `retrying`
+(`docs/adrs/ADR-0056-play-control-api.md:90`, `docs/adrs/ADR-0056-play-control-api.md:108`).
+Those states are runner-control states, not play workflow states. Scheduled work must integrate
+with pause/resume/cancel from Studio without adding control states to `plays.status`.
+
+Coupling estimate after this decision: components `{TransitionService, StateStore, EventBus,
+SchedulerEngine, PlayControl, StudioSSE, TaskBoard}` with deps `{TransitionService->StateStore,
+TransitionService->EventBus, SchedulerEngine->TransitionService, PlayControl->TransitionService,
+StudioSSE->EventBus, TaskBoard->EventBus, TaskBoard->StateStore}` gives `7 / (7 * 6) = 0.17`.
+
+## Decision
+
+Define one scheduled item lifecycle model with three layers:
+
+1. **Schedule definition state**: whether a definition can produce future runs.
+2. **Schedule run state**: the actual execution instance lifecycle.
+3. **Linked runtime/workflow states**: session, invocation, play, and runner states remain owned by
+   their existing ADRs but publish transition events consumed by the scheduler and task board.
+
+All transitions go through an idempotent compare-and-swap API:
+
+```python
+await transition(
+    entity_type="schedule_run",
+    entity_id=run_id,
+    from_state="queued",
+    to_state="running",
+    reason=StateReason(code="schedule_run.running.leased"),
+    actor=Actor(type="scheduler", id=worker_id),
+    idempotency_key=f"lease:{run_id}:{worker_id}",
+)
+```
+
+If the current state is already `to_state` with the same idempotency key, the API returns the
+existing transition. If the current state is not `from_state`, the API returns a conflict without
+writing. Every successful transition emits an event for downstream triggers and Studio real-time
+updates.
+
+### Unified State Machine
+
+```mermaid
+stateDiagram-v2
+  [*] --> DefinitionDraft
+  DefinitionDraft --> DefinitionEnabled: enable
+  DefinitionEnabled --> DefinitionDisabled: disable
+  DefinitionDisabled --> DefinitionEnabled: enable
+  DefinitionDraft --> DefinitionArchived: archive
+  DefinitionDisabled --> DefinitionArchived: archive
+  DefinitionEnabled --> DefinitionArchived: archive when no active runs
+  DefinitionArchived --> [*]
+
+  DefinitionEnabled --> RunQueued: cron/webhook/event/manual trigger
+  RunQueued --> RunWaitingDependency: dependency not satisfied
+  RunWaitingDependency --> RunQueued: upstream completed
+  RunWaitingDependency --> RunCancelled: schedule archived or operator cancel
+  RunWaitingDependency --> RunSkipped: upstream skipped/failed with no failure dependency edge
+  RunQueued --> RunSkipped: overlap skip or guard false
+  RunQueued --> RunRunning: lease acquired
+  RunRunning --> RunCompleted: executor exit 0
+  RunRunning --> RunFailed: non-retryable failure
+  RunRunning --> RunTimedOut: deadline exceeded
+  RunRunning --> RunCancelled: operator/system cancel
+  RunRunning --> RunRetryWait: retryable failure
+  RunRetryWait --> RunQueued: backoff elapsed
+  RunRetryWait --> RunCancelled: cancel retry
+  RunCompleted --> RunQueued: enqueue downstream [fire_on success]
+  RunFailed --> RunQueued: enqueue downstream [fire_on failure]
+  RunTimedOut --> RunQueued: enqueue downstream [fire_on failure]
+
+  RunRunning --> SessionRunning: starts li/shell runtime
+  SessionRunning --> SessionCompleted: completed
+  SessionRunning --> SessionFailed: failed/timed_out/aborted/cancelled
+  RunRunning --> PlayRunning: linked play
+  PlayRunning --> PlayReview: running_complete/gated
+  PlayReview --> PlayMerged: merged
+  PlayReview --> PlayBlocked: gate_failed/blocked/escalated
+```
+
+### State Vocabulary
+
+```python
+# lionagi/state/lifecycle.py
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class ScheduleDefinitionState(StrEnum):
+    DRAFT = "draft"
+    ENABLED = "enabled"
+    DISABLED = "disabled"
+    ARCHIVED = "archived"
+
+
+class ScheduleRunState(StrEnum):
+    QUEUED = "queued"
+    WAITING_DEPENDENCY = "waiting_dependency"
+    RUNNING = "running"
+    RETRY_WAIT = "retry_wait"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    TIMED_OUT = "timed_out"
+    SKIPPED = "skipped"
+    CANCELLED = "cancelled"
+
+
+class Actor(BaseModel):
+    type: Literal["scheduler", "operator", "system", "webhook", "agent"]
+    id: str
+
+
+class StateReason(BaseModel):
+    code: str
+    summary: str = ""
+    evidence_refs: list[dict] = Field(default_factory=list)
+    metadata: dict = Field(default_factory=dict)
+
+
+class TransitionRequest(BaseModel):
+    entity_type: str
+    entity_id: str
+    from_state: str | None
+    to_state: str
+    reason: StateReason
+    actor: Actor
+    idempotency_key: str
+
+
+class TransitionResult(BaseModel):
+    applied: bool
+    conflict: bool = False
+    previous_state: str | None = None
+    current_state: str
+    transition_id: str
+    event_id: str | None = None
+```
+
+### Transition Rules
+
+| Entity | From | To | Actor | Guard |
+|---|---|---|---|---|
+| schedule | `draft` | `enabled` | operator/system | action template validates; trigger validates; authz permits scheduling |
+| schedule | `enabled` | `disabled` | operator/system | no guard; active runs are not cancelled automatically |
+| schedule | `enabled` | `archived` | operator | no `queued`, `running`, or `retry_wait` runs |
+| schedule_run | none | `queued` | scheduler/webhook/operator/system | definition is `enabled`; idempotency key has not fired |
+| schedule_run | `queued` | `waiting_dependency` | scheduler | at least one dependency is unsatisfied |
+| schedule_run | `waiting_dependency` | `queued` | scheduler/system | all required upstream runs completed successfully |
+| schedule_run | `waiting_dependency` | `cancelled` | operator/system | schedule archived or operator cancel issued while waiting |
+| schedule_run | `waiting_dependency` | `skipped` | scheduler/system | upstream run skipped or failed and no `fire_on='failure'` dependency edge exists |
+| schedule_run | `queued` | `running` | scheduler | lease acquired; per-schedule and global concurrency limits pass |
+| schedule_run | `queued` | `skipped` | scheduler | overlap policy is `skip`, guard false, or missed fire policy is `skip` |
+| schedule_run | `running` | `completed` | scheduler | executor exit code is 0 and linked session/invocation terminal state is successful |
+| schedule_run | `running` | `failed` | scheduler | nonzero exit or exception and retry policy exhausted |
+| schedule_run | `running` | `timed_out` | scheduler/system | timeout deadline exceeded |
+| schedule_run | `running` | `cancelled` | operator/system | ADR-0056 control accepted or process cancelled |
+| schedule_run | `running` | `retry_wait` | scheduler | status in `retry_on` and attempt <= max_retries |
+| schedule_run | `retry_wait` | `queued` | scheduler | backoff elapsed and schedule not archived |
+| session | `running` | terminal | executor/operator/system | existing ADR-0025 transition rules; admin targets remain restricted to failed/aborted/cancelled (`lionagi/state/db.py:217`) |
+| play | workflow states | workflow states | executor/operator | existing play guards; pause/resume is runner state, not `plays.status` |
+
+### Reason Code Vocabulary
+
+ADR-0028 uses three-segment reason codes and a Python source of truth in
+`lionagi/state/reasons.py` (`lionagi/state/reasons.py:60`, `lionagi/state/reasons.py:147`). Extend
+that pattern with:
+
+```python
+class ScheduleDefinitionReasons:
+    ENABLED_OPERATOR = "schedule.enabled.operator"
+    DISABLED_OPERATOR = "schedule.disabled.operator"
+    DISABLED_POLICY = "schedule.disabled.policy"
+    ARCHIVED_OPERATOR = "schedule.archived.operator"
+    ARCHIVED_REPLACED = "schedule.archived.replaced"
+
+
+class ScheduleRunReasons:
+    QUEUED_CRON = "schedule_run.queued.cron"
+    QUEUED_WEBHOOK = "schedule_run.queued.webhook"
+    QUEUED_EVENT = "schedule_run.queued.event"
+    QUEUED_MANUAL = "schedule_run.queued.manual"
+    WAITING_DEPENDENCY = "schedule_run.waiting_dependency.upstream"
+    CANCELLED_WHILE_WAITING = "schedule_run.cancelled.waiting_dependency"
+    SKIPPED_UPSTREAM_TERMINAL = "schedule_run.skipped.upstream_terminal"
+    RUNNING_LEASED = "schedule_run.running.leased"
+    COMPLETED_OK = "schedule_run.completed.ok"
+    FAILED_EXIT_NONZERO = "schedule_run.failed.exit_nonzero"
+    FAILED_EXCEPTION = "schedule_run.failed.exception"
+    TIMED_OUT_DEADLINE = "schedule_run.timed_out.deadline"
+    SKIPPED_OVERLAP = "schedule_run.skipped.overlap"
+    SKIPPED_MISSED_FIRE = "schedule_run.skipped.missed_fire"
+    CANCELLED_OPERATOR = "schedule_run.cancelled.operator"
+    RETRY_WAIT_BACKOFF = "schedule_run.retry_wait.backoff"
+```
+
+Existing `ScheduleReasons.FIRED_DUE`, `SKIPPED_OVERLAP`, and `SKIPPED_MISSED_FIRE`
+(`lionagi/state/reasons.py:119`, `lionagi/state/reasons.py:122`) remain aliases during migration,
+then become deprecated compatibility names.
+
+### Event Emission
+
+Every applied transition emits one event row and one in-process notification:
+
+```python
+class StateTransitionEvent(BaseModel):
+    id: str
+    entity_type: str
+    entity_id: str
+    previous_state: str | None
+    state: str
+    reason_code: str
+    actor_type: str
+    actor_id: str
+    idempotency_key: str
+    created_at: float
+    metadata: dict = Field(default_factory=dict)
+```
+
+Event names are deterministic: `state.<entity_type>.<state>`, for example
+`state.schedule_run.completed` and `state.play.gate_failed`. ADR-0061 event triggers subscribe to
+these events for `on-session-complete`, `on-artifact-created`, and `on-gate-verdict`. ADR-0063 uses
+the same stream for task board updates. Studio may expose this via SSE using the existing streaming
+pattern in sessions (`apps/studio/server/routers/sessions.py:29`, `apps/studio/server/routers/sessions.py:62`)
+and shows (`apps/studio/server/routers/shows.py:35`, `apps/studio/server/routers/shows.py:40`).
+
+## Implementation
+
+### Backend-Neutral Transition API
+
+```python
+# lionagi/state/transitions.py
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class TransitionStore(Protocol):
+    async def transition(self, request: TransitionRequest) -> TransitionResult: ...
+    async def list_transitions(
+        self,
+        entity_type: str,
+        entity_id: str,
+        *,
+        limit: int = 100,
+    ) -> list[StateTransitionEvent]: ...
+```
+
+Implementation requirements:
+
+1. Use `async with store.transaction() as txn:` from ADR-0059 rather than SQLite-specific
+   `BEGIN IMMEDIATE`.
+2. Write the entity status, denormalized reason fields, `status_transitions`, and transition event
+   atomically.
+3. Use `(entity_type, entity_id, idempotency_key)` uniqueness to make retries safe.
+4. Reject invalid `from_state` with a conflict result, not an exception.
+5. Return the existing transition for duplicate idempotency keys.
+
+### Schema Changes
+
+```sql
+ALTER TABLE schedules ADD COLUMN lifecycle_status TEXT NOT NULL DEFAULT 'enabled';
+ALTER TABLE schedules ADD COLUMN status_reason_code TEXT;
+ALTER TABLE schedules ADD COLUMN status_reason_summary TEXT;
+ALTER TABLE schedules ADD COLUMN status_evidence_refs JSON;
+
+ALTER TABLE status_transitions ADD COLUMN idempotency_key TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_status_transitions_idempotent
+  ON status_transitions(entity_type, entity_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS state_events (
+  id              TEXT PRIMARY KEY,
+  transition_id   TEXT NOT NULL REFERENCES status_transitions(id),
+  event_name      TEXT NOT NULL,
+  entity_type     TEXT NOT NULL,
+  entity_id       TEXT NOT NULL,
+  payload         JSON NOT NULL,
+  created_at      REAL NOT NULL,
+  delivered_at    REAL
+);
+
+CREATE INDEX IF NOT EXISTS idx_state_events_name_time
+  ON state_events(event_name, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_state_events_entity
+  ON state_events(entity_type, entity_id, created_at DESC);
+```
+
+Add `schedule` to `VALID_ENTITY_TYPES` and `ENTITY_TYPE_TO_TABLE`, which currently list
+`session`, `show`, `play`, `invocation`, `team`, and `schedule_run`
+(`lionagi/state/reasons.py:21`, `lionagi/state/reasons.py:201`).
+
+### StateMachine Implementation (`lionagi/runtime/state_machine.py`)
+
+The generic state machine that backs both lifecycle definitions lives at
+`lionagi/runtime/state_machine.py`. It is table-driven, thread-safe via `threading.Lock`, and
+audit-ready via a history log.  No async, no metaclasses.
+
+#### State Transition Diagrams (ASCII)
+
+**Runner lifecycle** (`RUNNER_LIFECYCLE`):
+
+```text
+[start]
+   │
+   ▼
+┌──────┐  start   ┌──────────┐  started  ┌─────────┐
+│ idle │ ───────► │ starting │ ─────────► │ running │
+└──────┘          └──────────┘           └────┬────┘
+   ▲                    │  │              │   │   │
+   │ reset              │  │ stop    pause│   │   │ fail
+   │               fail │  │              ▼   │   ▼
+   │               ─────┘  │        ┌────────┐│ ┌────────┐
+   │                        │        │pausing ││ │ failed │
+   │                        ▼        └────┬───┘│ └────────┘
+   │                  ┌──────────┐   paused│   │ stop    ▲
+   │                  │ stopping │◄────────┘   │         │ fail
+   │                  └────┬─────┘◄────────────┘         │
+   │                  stopped│        (stop from pausing/ │
+   │                        ▼          paused/starting)   │
+   │                  ┌─────────┐                         │
+   └──────────────────│ stopped │   ─── fail ─────────────┘
+         reset        └─────────┘   (stopping → failed)
+```
+
+Key transitions:
+
+| From | Trigger | To |
+|------|---------|----|
+| idle | start | starting |
+| starting | started | running |
+| running | pause | pausing |
+| pausing | paused | paused |
+| paused | resume | running |
+| running | stop | stopping |
+| pausing | stop | stopping |
+| paused | stop | stopping |
+| starting | stop | stopping |
+| stopping | stopped | stopped |
+| starting / running / pausing / paused / stopping | fail | failed |
+| stopped | reset | idle |
+| failed | reset | idle |
+
+**Schedule run lifecycle** (`SCHEDULE_LIFECYCLE`):
+
+```text
+[trigger]
+   │
+   ▼
+┌─────────┐  activate  ┌────────┐  run   ┌─────────┐
+│ pending │ ──────────►│ active │────────►│ running │
+└────┬────┘            └───┬────┘         └────┬────┘
+     │                     │ pause             │ complete
+     │ cancel              ▼                   ▼
+     │              ┌────────┐         ┌───────────┐
+     │              │ paused │         │ completed │
+     │              └────┬───┘         └───────────┘
+     │              resume│ cancel
+     │                   ▼     │    fail from active/running
+     │               (active)  │         ▼
+     │                         │    ┌────────┐
+     └────────────────►         │    │ failed │
+              cancel            ▼    └────────┘
+                          ┌───────────┐
+                          │ cancelled │
+                          └───────────┘
+```
+
+Key transitions:
+
+| From | Trigger | To |
+|------|---------|----|
+| pending | activate | active |
+| pending | cancel | cancelled |
+| active | run | running |
+| active | pause | paused |
+| active | fail | failed |
+| active | cancel | cancelled |
+| running | complete | completed |
+| running | fail | failed |
+| running | pause | paused |
+| running | cancel | cancelled |
+| paused | resume | active |
+| paused | cancel | cancelled |
+
+#### Guard Condition Examples
+
+Guards are plain callables `(from_state, to_state, **ctx) -> bool` passed in `context` via
+`sm.trigger(event, **context)`.
+
+```python
+# Guard: only allow a schedule run to start if concurrency limit is not reached
+def concurrency_guard(from_state: str, to_state: str, *, active_count: int, limit: int, **_kw) -> bool:
+    return active_count < limit
+
+sm.trigger("run", active_count=3, limit=5)   # passes
+sm.trigger("run", active_count=5, limit=5)   # blocked → StateMachineError
+
+# Guard: only allow cancel if the operator has the right role
+def operator_guard(from_state: str, to_state: str, *, role: str, **_kw) -> bool:
+    return role in {"admin", "operator"}
+
+sm.trigger("cancel", role="viewer")   # blocked
+sm.trigger("cancel", role="operator") # passes
+
+# Multiple guards on the same (from_state, trigger): evaluated left-to-right,
+# first passing candidate wins.
+sm2 = StateMachine(
+    "multi_guard",
+    initial_state="queued",
+    transitions=[
+        Transition("queued", "running", "run",
+                   guard=lambda _f, _t, *, worker_ready=False, **kw: worker_ready),
+        Transition("queued", "skipped", "run",
+                   guard=lambda _f, _t, *, overlap=False, **kw: overlap),
+    ],
+)
+sm2.trigger("run", worker_ready=True)   # → running
+```
+
+#### Action Callback Examples
+
+Actions are plain callables `(from_state, to_state, **ctx) -> None` that fire **after** the
+guard passes but **before** the state is committed.  If the action raises, the state remains
+unchanged.
+
+```python
+from lionagi.runtime.state_machine import StateMachine, Transition
+
+audit_log: list[str] = []
+
+def log_transition(from_state: str, to_state: str, *, run_id: str = "", **_kw) -> None:
+    audit_log.append(f"{run_id}: {from_state} -> {to_state}")
+
+sm = StateMachine(
+    "audited_schedule",
+    initial_state="pending",
+    transitions=[
+        Transition("pending", "active", "activate", action=log_transition),
+        Transition("active",  "running", "run",      action=log_transition),
+    ],
+)
+sm.trigger("activate", run_id="run-42")
+sm.trigger("run",      run_id="run-42")
+# audit_log == ["run-42: pending -> active", "run-42: active -> running"]
+
+# Action that publishes an event (illustrative, not a real dependency):
+def emit_event(from_state: str, to_state: str, *, entity_id: str, bus=None, **_kw) -> None:
+    if bus is not None:
+        bus.publish(f"state.schedule_run.{to_state}", {"entity_id": entity_id})
+
+sm2 = StateMachine(
+    "eventing",
+    initial_state="pending",
+    transitions=[Transition("pending", "active", "activate", action=emit_event)],
+)
+sm2.trigger("activate", entity_id="sched-7", bus=my_event_bus)
+```
+
+#### Integration Pattern with Existing `control.py`
+
+`control.py` owns the `RunnerState` enum and `VALID_TRANSITIONS` dict used by `ControlService`
+and `LocalRunner`.  `state_machine.py` provides an orthogonal, generic abstraction that does not
+replace those tables; instead callers can wire a `StateMachine` as the authoritative gate before
+delegating to the runner:
+
+```python
+from lionagi.runtime.control import ControlVerb, RunnerState
+from lionagi.runtime.state_machine import RUNNER_LIFECYCLE, StateMachineError
+
+class GatedControlService:
+    """Wraps ControlService with a StateMachine gate."""
+
+    def __init__(self, inner_service, *, run_id: str) -> None:
+        self._svc = inner_service
+        self._sm = RUNNER_LIFECYCLE.create()
+        self._run_id = run_id
+
+    async def dispatch(self, verb: ControlVerb, reason: str) -> None:
+        trigger_map = {
+            ControlVerb.PAUSE:   "pause",
+            ControlVerb.RESUME:  "resume",
+            ControlVerb.CANCEL:  "stop",
+            ControlVerb.KILL:    "stop",
+        }
+        trigger = trigger_map.get(verb)
+        if trigger is None:
+            raise ValueError(f"Unsupported verb: {verb!r}")
+        try:
+            self._sm.trigger(trigger)   # raises StateMachineError if invalid
+        except StateMachineError as exc:
+            raise ValueError(str(exc)) from exc
+
+        await self._svc.dispatch("session", self._run_id, ...)
+```
+
+The `RUNNER_LIFECYCLE` definition uses triggers (`start`, `started`, `pause`, `paused`,
+`resume`, `stop`, `stopped`, `fail`, `reset`) that map cleanly to `ControlVerb` values and
+the state updates already performed by `LocalRunner._cancel()` and friends.
+
+### ADR-0056 Integration
+
+Play control pause/resume/cancel targets runner state first. When a schedule run owns the linked
+session, accepted controls also transition the schedule run:
+
+| ADR-0056 control | Runner state | Schedule run effect |
+|---|---|---|
+| pause | `running -> pausing -> paused` | no schedule_run state change; emit `state.runner_handle.paused` |
+| resume | `paused -> resuming -> running` | no schedule_run state change |
+| cancel | `running/paused -> cancelling -> cancelled` | `schedule_run.running -> cancelled` |
+| kill | `running/paused -> killing -> killed` | `schedule_run.running -> cancelled` with force-kill reason |
+| retry | terminal -> `retrying` | new schedule_run attempt, linked by `retry_of_run_id` |
+
+This preserves existing `plays.status` as workflow state and avoids adding `paused` to the play
+vocabulary.
+
+### Phasing and Estimates
+
+| Phase | Scope | LOC estimate |
+|---|---|---:|
+| 0 | Add states/types, reason codes, schedule entity support in reason registry | 120-180 |
+| 1 | Backend-neutral `transition()` with idempotency and tests for all schedule_run transitions | 260-420 |
+| 2 | State event table, SSE adapter, event trigger bridge for ADR-0061 | 220-360 |
+| 3 | ADR-0056 integration for cancel/retry and Studio control propagation | 180-280 |
+| 4 | Migration/backfill and documentation | 120-220 |
+
+Testability target: `tau = 0.90`. The transition graph is table-driven and can be tested with
+parameterized cases for every allowed and rejected transition.
+
+## Security
+
+Transition writes require an authenticated actor. Scheduler/system actors use service identities;
+operator actors come from Studio bearer auth. When `LIONAGI_STUDIO_AUTH_TOKEN` is set, all status
+read endpoints and SSE streams that expose transition metadata require auth. The current middleware
+does not protect all non-admin GETs (`apps/studio/server/app.py:56`, `apps/studio/server/app.py:60`),
+so routers exposing transition history must enforce auth explicitly until the global floor is fixed.
+
+Reason summaries are display text and may contain operational details. They must not include secret
+values, raw webhook tokens, absolute filesystem paths, or full command env. Evidence references use
+typed ids and public paths only.
+
+## Migration
+
+1. Add `lifecycle_status='enabled'` to existing schedules where `enabled=1`, `disabled` where
+   `enabled=0`.
+2. Backfill current running schedule rows to `running` with reason `schedule_run.running.leased`.
+3. Backfill completed/failed/skipped/cancelled rows using existing reason columns when present,
+   falling back to legacy imported reasons.
+4. Keep `enabled` as a generated/compatibility field for one release; new code reads
+   `lifecycle_status`.
+5. Move current calls to `StateDB.update_status()` for schedule runs
+   (`apps/studio/server/scheduler/engine.py:405`, `apps/studio/server/scheduler/engine.py:454`)
+   onto `transition()`.
+
+## Alternatives Considered
+
+| Alternative | Why rejected |
+|---|---|
+| Reuse session statuses for schedule runs | Schedule runs need queued, waiting dependency, retry wait, and skipped states that are not session runtime states. |
+| Add pause/resume to `plays.status` | ADR-0056 already owns runner control state; mixing control and workflow state breaks existing play semantics. |
+| Let each subsystem emit ad hoc events | This repeats the reason-code problem ADR-0028 solved and makes webhook/event scheduling unreliable. |
+
+## Consequences
+
+Positive: every scheduled item has one auditable lifecycle, one reason vocabulary, and one event
+stream. ADR-0061 can chain schedules and ADR-0063 can render operator work without reverse
+engineering sessions or play rows.
+
+Negative: transition writes become a shared platform primitive. Bugs in `transition()` affect
+scheduler, play control, and task board behavior, so the implementation needs exhaustive transition
+tests before use in production.
+
+## References
+
+- `lionagi/state/schema.sql:379`
+- `lionagi/state/schema.sql:422`
+- `lionagi/state/schema.sql:540`
+- `lionagi/state/db.py:917`
+- `lionagi/state/reasons.py:21`

--- a/docs/adrs/ADR-0062-state-machine-spec.md
+++ b/docs/adrs/ADR-0062-state-machine-spec.md
@@ -3,8 +3,8 @@
 Status: proposed
 Date: 2026-05-27
 Decision owners: @governance-maintainers
-Depends on: ADR-0025 (session status), ADR-0028 (status reasons), ADR-0056 (play control), ADR-0059 (StateStore), ADR-0061 (universal scheduler)
-Related: ADR-0063 (task board work center)
+Depends on: ADR-0025 (session status), ADR-0028 (status reasons), ADR-0056 (play control), ADR-0059 (StateStore)
+Related: ADR-0061 (universal scheduler — consumes lifecycle_status and state_events defined here), ADR-0063 (task board work center)
 
 ## Context
 

--- a/docs/adrs/ADR-0063-task-board-work-center.md
+++ b/docs/adrs/ADR-0063-task-board-work-center.md
@@ -1,0 +1,445 @@
+# ADR-0063: Task Board - Operator Work Center for Lion Studio
+
+Status: proposed
+Date: 2026-05-27
+Decision owners: @governance-maintainers
+Depends on: ADR-0053 (artifact persistence), ADR-0056 (play control), ADR-0058 (cost tracking), ADR-0059 (StateStore), ADR-0061 (universal scheduler), ADR-0062 (scheduled item state machine)
+Related: ADR-0034 (frontend data/state architecture), ADR-0047 (agent charter), ADR-0048 (segregation of duties)
+
+## Context
+
+Lion Studio has visibility surfaces, but no operator work center. The FastAPI app mounts routers
+for runs, sessions, definitions, agents, playbooks, shows, skills, plugins, admin, teams,
+invocations, artifacts, projects, and schedules (`apps/studio/server/app.py:12`,
+`apps/studio/server/app.py:65`, `apps/studio/server/app.py:78`). There is no task/work item router
+in that list. Runs are derived from sessions in a service adapter
+(`apps/studio/server/services/runs.py:503`, `apps/studio/server/services/runs.py:525`), sessions
+are listed directly from SQLite (`apps/studio/server/services/sessions.py:97`,
+`apps/studio/server/services/sessions.py:142`), shows summarize plays
+(`apps/studio/server/services/shows.py:89`, `apps/studio/server/services/shows.py:106`), and
+schedules have their own CRUD/run history endpoints (`apps/studio/server/routers/schedules.py:63`,
+`apps/studio/server/routers/schedules.py:83`, `apps/studio/server/routers/schedules.py:136`).
+
+Those surfaces answer "what exists?" but not "what needs operator attention next?" An enterprise
+deployment needs a shared queue that covers running agent work, queued schedules, failed flows,
+manual approvals, charter-required reviews, cost overruns, and human tasks. Without it, operators
+must scan runs, sessions, shows, schedule runs, logs, and future cost endpoints independently.
+
+The platform is already close to a work model. Sessions expose invocation kind, agent, playbook,
+show linkage, timestamps, status, artifact contract, and project fields
+(`apps/studio/server/services/runs.py:562`, `apps/studio/server/services/runs.py:581`). Schedule
+runs expose action kind, rendered action args, status, chain parent, and error detail
+(`lionagi/state/schema.sql:423`, `lionagi/state/schema.sql:428`, `lionagi/state/schema.sql:434`,
+`lionagi/state/schema.sql:438`). Plays expose dependencies, gate result, worktree, branch, and
+merge metadata (`lionagi/state/schema.sql:278`, `lionagi/state/schema.sql:283`,
+`lionagi/state/schema.sql:287`, `lionagi/state/schema.sql:289`). ADR-0058 adds integer-cent cost
+aggregates and cost events, with session/play aggregate columns specified in
+`docs/adrs/ADR-0058-play-cost-tracking.md:68` and `docs/adrs/ADR-0058-play-cost-tracking.md:75`.
+
+ADR-0061 and ADR-0062 supply the missing foundation: every schedulable unit has typed flow/action
+metadata, a state machine, and transition events. ADR-0063 consumes those events into a product
+surface: the operator's command center.
+
+Coupling estimate after this decision: components `{WorkItemService, StateStore, EventBus,
+StudioTaskAPI, TaskBoardUI, Scheduler, PlayControl, CostService, CharterCompiler, GTDSync}` with
+deps `{WorkItemService->StateStore, WorkItemService->EventBus, StudioTaskAPI->WorkItemService,
+TaskBoardUI->StudioTaskAPI, Scheduler->EventBus, PlayControl->EventBus, CostService->StateStore,
+CharterCompiler->WorkItemService, GTDSync->WorkItemService, WorkItemService->CostService}` gives
+`10 / (10 * 9) = 0.11`.
+
+## Decision
+
+Add a first-class `work_items` model and Task Board UI to Lion Studio. A work item represents any
+schedulable or operator-actionable unit: agent task, fanout, flow, play, team coordination, shell
+maintenance task, webhook-triggered run, manual task, charter-required approval, or synced GTD item.
+
+The board has three standard views:
+
+1. **Kanban** grouped by workflow status.
+2. **Timeline** grouped by due date, dependency, and execution window.
+3. **List** with filters for status, assignee, priority, labels, source, project, cost, and due date.
+
+Schedule runs and play runs create work items automatically. Manual tasks can be created from Studio
+or `li task create`. GTD plugin items may sync bidirectionally when configured. Charter constraints
+can create required work items, for example "review required before merge" or "approval required
+for shell schedule".
+
+### Work Item Types
+
+```python
+# lionagi/work_items/types.py
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class WorkItemType(StrEnum):
+    AGENT = "agent"
+    FANOUT = "fanout"
+    FLOW = "flow"
+    PLAY = "play"
+    TEAM = "team"
+    SHELL = "shell"
+    WEBHOOK = "webhook"
+    MANUAL = "manual"
+    APPROVAL = "approval"
+    REVIEW = "review"
+
+
+class WorkItemStatus(StrEnum):
+    DRAFT = "draft"
+    QUEUED = "queued"
+    ASSIGNED = "assigned"
+    RUNNING = "running"
+    REVIEW = "review"
+    BLOCKED = "blocked"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    TIMED_OUT = "timed_out"
+    CANCELLED = "cancelled"
+
+
+class Priority(StrEnum):
+    P0 = "P0"
+    P1 = "P1"
+    P2 = "P2"
+    P3 = "P3"
+
+
+class AssigneeType(StrEnum):
+    HUMAN = "human"
+    AGENT = "agent"
+    TEAM = "team"
+    NONE = "none"
+
+
+class WorkItem(BaseModel):
+    id: str
+    type: WorkItemType
+    status: WorkItemStatus
+    title: str = Field(min_length=1, max_length=240)
+    description: str = ""
+    assignee_type: AssigneeType = AssigneeType.NONE
+    assignee_id: str | None = None
+    priority: Priority = Priority.P2
+    labels: list[str] = Field(default_factory=list)
+    due_at: float | None = None
+    source_type: Literal["manual", "schedule_run", "play", "session", "charter", "gtd"]
+    source_id: str | None = None
+    project: str | None = None
+    estimated_cost_cents: int | None = None
+    actual_cost_cents: int = 0
+    budget_cents: int | None = None
+    artifact_refs: list[dict[str, Any]] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class WorkItemAction(BaseModel):
+    action: Literal[
+        "assign",
+        "prioritize",
+        "block",
+        "unblock",
+        "add_dependency",
+        "retry",
+        "cancel",
+        "comment",
+        "approve",
+        "reject",
+    ]
+    reason: str = Field(min_length=1, max_length=1000)
+    payload: dict[str, Any] = Field(default_factory=dict)
+    idempotency_key: str
+```
+
+### Workflow
+
+```mermaid
+stateDiagram-v2
+  [*] --> Draft
+  Draft --> Queued: submit
+  Queued --> Assigned: assign
+  Queued --> Running: auto lease
+  Assigned --> Running: start
+  Running --> Review: needs review or gate
+  Review --> Completed: approve/merge
+  Review --> Failed: reject terminal
+  Running --> Completed: terminal success
+  Running --> Failed: terminal failure
+  Running --> Cancelled: cancel
+  Queued --> Blocked: dependency or policy block
+  Assigned --> Blocked: dependency or policy block
+  Blocked --> Queued: unblock
+  Failed --> Queued: retry
+  Cancelled --> Queued: retry
+  Completed --> [*]
+```
+
+### Board Architecture
+
+```mermaid
+flowchart LR
+  Scheduler[ADR-0061 schedule runs] --> Events[ADR-0062 transition events]
+  Plays[plays and sessions] --> Events
+  Charter[charter compiler] --> WorkSvc[WorkItemService]
+  GTD[GTD sync] <--> WorkSvc
+  Events --> WorkSvc
+  WorkSvc --> Store[StateStore]
+  Store --> API[Studio task API]
+  API --> UI[Task Board views]
+  API --> SSE[Board SSE stream]
+  Cost[ADR-0058 cost service] --> WorkSvc
+  Control[ADR-0056 play control] --> WorkSvc
+```
+
+## Implementation
+
+### Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS work_items (
+  id                    TEXT PRIMARY KEY,
+  type                  TEXT NOT NULL,
+  status                TEXT NOT NULL,
+  title                 TEXT NOT NULL,
+  description           TEXT,
+  assignee_type         TEXT NOT NULL DEFAULT 'none',
+  assignee_id           TEXT,
+  priority              TEXT NOT NULL DEFAULT 'P2',
+  labels                JSON NOT NULL DEFAULT '[]',
+  due_at                REAL,
+  source_type           TEXT NOT NULL,
+  source_id             TEXT,
+  project               TEXT,
+  schedule_id           TEXT REFERENCES schedules(id),
+  schedule_run_id       TEXT REFERENCES schedule_runs(id),
+  session_id            TEXT REFERENCES sessions(id),
+  invocation_id         TEXT REFERENCES invocations(id),
+  play_id               TEXT REFERENCES plays(id),
+  show_id               TEXT REFERENCES shows(id),
+  estimated_cost_cents  INTEGER,
+  actual_cost_cents     INTEGER NOT NULL DEFAULT 0,
+  budget_cents          INTEGER,
+  artifact_refs         JSON NOT NULL DEFAULT '[]',
+  blocked_reason        TEXT,
+  review_required       INTEGER NOT NULL DEFAULT 0 CHECK(review_required IN (0, 1)),
+  approval_policy       JSON,
+  external_ref          TEXT,
+  created_by            TEXT NOT NULL,
+  updated_by            TEXT,
+  created_at            REAL NOT NULL,
+  updated_at            REAL NOT NULL,
+  completed_at          REAL,
+  status_reason_code    TEXT,
+  status_reason_summary TEXT,
+  status_evidence_refs  JSON
+);
+
+CREATE TABLE IF NOT EXISTS work_item_dependencies (
+  id              TEXT PRIMARY KEY,
+  work_item_id    TEXT NOT NULL REFERENCES work_items(id) ON DELETE CASCADE,
+  depends_on_id   TEXT NOT NULL REFERENCES work_items(id) ON DELETE CASCADE,
+  dependency_type TEXT NOT NULL DEFAULT 'blocks',
+  created_at      REAL NOT NULL,
+  UNIQUE(work_item_id, depends_on_id)
+);
+
+CREATE TABLE IF NOT EXISTS work_item_comments (
+  id           TEXT PRIMARY KEY,
+  work_item_id TEXT NOT NULL REFERENCES work_items(id) ON DELETE CASCADE,
+  body         TEXT NOT NULL,
+  actor_type   TEXT NOT NULL,
+  actor_id     TEXT NOT NULL,
+  created_at   REAL NOT NULL,
+  updated_at   REAL
+);
+
+CREATE TABLE IF NOT EXISTS work_item_events (
+  id           TEXT PRIMARY KEY,
+  work_item_id TEXT NOT NULL REFERENCES work_items(id) ON DELETE CASCADE,
+  event_type   TEXT NOT NULL,
+  actor_type   TEXT NOT NULL,
+  actor_id     TEXT NOT NULL,
+  payload      JSON NOT NULL,
+  created_at   REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS board_views (
+  id          TEXT PRIMARY KEY,
+  owner_id    TEXT NOT NULL,
+  name        TEXT NOT NULL,
+  view_type   TEXT NOT NULL CHECK(view_type IN ('kanban', 'timeline', 'list')),
+  filters     JSON NOT NULL DEFAULT '{}',
+  sort        JSON NOT NULL DEFAULT '[]',
+  columns     JSON NOT NULL DEFAULT '[]',
+  created_at  REAL NOT NULL,
+  updated_at  REAL NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_work_items_status_priority
+  ON work_items(status, priority, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_work_items_assignee
+  ON work_items(assignee_type, assignee_id, status);
+CREATE INDEX IF NOT EXISTS idx_work_items_due
+  ON work_items(due_at) WHERE due_at IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_work_items_source
+  ON work_items(source_type, source_id);
+CREATE INDEX IF NOT EXISTS idx_work_items_schedule_run
+  ON work_items(schedule_run_id) WHERE schedule_run_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_work_items_play
+  ON work_items(play_id) WHERE play_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_work_items_session
+  ON work_items(session_id) WHERE session_id IS NOT NULL;
+```
+
+`work_items.status` participates in ADR-0062 transition history. Add `work_item` to the entity type
+registry alongside `schedule_run`, which is currently registered in `lionagi/state/reasons.py:28`.
+
+### Automatic Item Creation
+
+WorkItemService subscribes to the `state_events` table defined in ADR-0062. All automatic item
+creation and status updates are driven by polling or listening on `state_events` filtered to the
+event names `state.schedule_run.*`, `state.play.*`, and `state.session.*`. The canonical event
+format is `StateTransitionEvent` as defined in ADR-0062.
+
+| Source | Creation rule | Status mapping |
+|---|---|---|
+| schedule run | Create or update one item per `schedule_runs.id` when ADR-0062 emits `state.schedule_run.queued`. | queued/running/completed/failed/cancelled |
+| play | Create one item per `plays.id` on import or runtime creation. | pending/prepared -> queued, running -> running, running_complete/gated/gate_failed -> review, merged -> completed, blocked/escalated -> blocked |
+| session | Create one item when a standalone `li agent`, `li o flow`, or `li o fanout` session starts without a schedule/play source. | session terminal states map to completed/failed/timed_out/cancelled |
+| manual | Created by Studio or `li task create`. | draft or queued |
+| charter | Created by charter compiler when a policy requires approval, review, or segregation-of-duties handoff. | queued or blocked |
+| GTD | Synced by connector when enabled. | external state maps through configured status map |
+
+Automatic creation is idempotent on `(source_type, source_id)`.
+
+### API
+
+Mount `tasks` under the existing `/api` prefix. The current app includes routers explicitly in
+`apps/studio/server/app.py:65` through `apps/studio/server/app.py:78`; adding the task router should
+follow that pattern.
+
+```text
+GET    /api/tasks
+POST   /api/tasks
+GET    /api/tasks/{id}
+PATCH  /api/tasks/{id}
+DELETE /api/tasks/{id}
+POST   /api/tasks/{id}/actions
+POST   /api/tasks/{id}/comments
+GET    /api/tasks/{id}/comments
+GET    /api/tasks/{id}/events
+POST   /api/tasks/bulk
+GET    /api/tasks/stream
+GET    /api/boards
+POST   /api/boards
+PATCH  /api/boards/{id}
+DELETE /api/boards/{id}
+```
+
+Bulk operations support assign, prioritize, label, cancel, retry, and archive. Mutating actions use
+idempotency keys and emit `work_item_events`.
+
+### Operator Actions
+
+| Action | Effect |
+|---|---|
+| assign | Sets assignee fields and transitions `queued -> assigned` when applicable. |
+| prioritize | Updates priority and emits audit event. |
+| block/unblock | Creates or clears blocked reason; unblock checks dependencies first. |
+| add dependency | Inserts `work_item_dependencies`; may transition target to `blocked`. |
+| retry | For schedule/play/session sources, calls ADR-0061/ADR-0056 retry and links the new run. |
+| cancel | Calls ADR-0056 for active runtime items or ADR-0062 transition for queued items. |
+| comment | Inserts audit comment, optionally with artifact refs. |
+| approve/reject | Satisfies charter or review work items and may unblock dependent work. |
+
+### Real-Time Updates
+
+The board SSE stream emits:
+
+```python
+class BoardEvent(BaseModel):
+    cursor: str
+    type: str
+    work_item_id: str
+    status: str
+    priority: str
+    actual_cost_cents: int
+    payload: dict
+    created_at: float
+```
+
+It reuses the existing SSE response pattern in sessions (`apps/studio/server/routers/sessions.py:62`)
+with heartbeats and no caching. Cost counters update from ADR-0058 cost events. Log streaming
+remains session/play-control owned; task board links to the appropriate stream rather than copying
+log lines into work item rows.
+
+### Phasing and Estimates
+
+| Phase | Scope | LOC estimate |
+|---|---|---:|
+| 0 | Schema, StateStore methods, work item type models, status reason registry | 260-420 |
+| 1 | WorkItemService, automatic creation from schedule/play/session events, idempotency tests | 420-680 |
+| 2 | REST router, SSE stream, bulk actions, comments/events APIs | 380-620 |
+| 3 | Studio Kanban/list/timeline UI with filters, badges, live cost counter | 700-1100 |
+| 4 | `li task` CLI, GTD sync adapter, charter-created approval items | 420-780 |
+| 5 | Compliance hardening, SoD checks, audit export, migration docs | 260-420 |
+
+Testability target: `tau = 0.84`. The service layer is event-driven and can be tested without a
+browser; UI tests should cover board filtering, bulk actions, SSE updates, and cost badge updates.
+
+## Security
+
+All task board endpoints require bearer authentication when `LIONAGI_STUDIO_AUTH_TOKEN` is set,
+including reads and SSE. Work items expose operational plans, costs, labels, assignments, comments,
+and compliance state. The current middleware does not authenticate all non-admin GET endpoints
+(`apps/studio/server/app.py:56`, `apps/studio/server/app.py:60`), so the task router must use an
+explicit actor dependency.
+
+Every mutating action records actor, reason, idempotency key, timestamp, and payload in
+`work_item_events`. Approval actions enforce segregation of duties: the approver cannot be the same
+actor that produced the item when the linked charter requires SoD. Cost fields use integer cents,
+matching ADR-0058, and API serializers may add display strings but must keep cents canonical.
+
+Work item responses must not expose absolute file paths, raw webhook payload secrets, environment
+variables, or unredacted command env. Artifact refs point to ADR-0053 artifact ids or public-safe
+paths only.
+
+## Migration
+
+1. Add work item tables and register `work_item` in the status reason entity registry.
+2. Backfill recent `schedule_runs`, `plays`, and standalone sessions into work items using
+   idempotent `(source_type, source_id)` keys.
+3. Hide the Task Board UI behind a feature flag until backfill and automatic creation are enabled.
+4. Add route-level auth dependency before exposing read endpoints.
+5. Enable automatic work item creation from ADR-0062 events.
+6. Add `li task create/list/update/comment` after the service contract is stable.
+
+## Alternatives Considered
+
+| Alternative | Why rejected |
+|---|---|
+| Add filters to the Runs page only | Runs are sessions; they do not cover queued schedules, manual approvals, GTD items, charter tasks, or future non-session work. |
+| Treat schedules as the task board | Schedules define automation; operators also need one-off manual work, approval tasks, and play/session review items. |
+| Integrate an external ticket system first | Useful later, but PMF requires a native Studio command center with local governance and audit before external sync. |
+
+## Consequences
+
+Positive: Studio becomes an operator command center with visibility, control, audit trail, cost
+awareness, and compliance workflow in one place. This is the product surface that turns scheduled
+automation into governed operations.
+
+Negative: the board creates a new high-traffic aggregation surface. It must avoid duplicating source
+state and instead maintain idempotent projections from ADR-0062 events.
+
+## References
+
+- `apps/studio/server/app.py:42`
+- `apps/studio/server/routers/schedules.py:14`
+- `apps/studio/server/routers/sessions.py:29`
+- `apps/studio/server/services/runs.py:503`
+- `lionagi/state/schema.sql:265`
+- `lionagi/state/schema.sql:423`

--- a/docs/adrs/ADR-0063-task-board-work-center.md
+++ b/docs/adrs/ADR-0063-task-board-work-center.md
@@ -4,7 +4,7 @@ Status: proposed
 Date: 2026-05-27
 Decision owners: @governance-maintainers
 Depends on: ADR-0053 (artifact persistence), ADR-0056 (play control), ADR-0058 (cost tracking), ADR-0059 (StateStore), ADR-0061 (universal scheduler), ADR-0062 (scheduled item state machine)
-Related: ADR-0034 (frontend data/state architecture), ADR-0047 (agent charter), ADR-0048 (segregation of duties)
+Related: ADR-0034 (frontend data/state architecture), ADR-0047 (agent charter), ADR-0048 (segregation of duties), ADR-0065 (task board schema — supersedes this ADR's schema subsection for the lionagi.work projection; use work_tasks table from ADR-0065 for lionagi.work persistence, work_items defined here for operator UI layer)
 
 ## Context
 

--- a/docs/adrs/ADR-0063-task-board-work-center.md
+++ b/docs/adrs/ADR-0063-task-board-work-center.md
@@ -20,10 +20,10 @@ are listed directly from SQLite (`apps/studio/server/services/sessions.py:97`,
 schedules have their own CRUD/run history endpoints (`apps/studio/server/routers/schedules.py:63`,
 `apps/studio/server/routers/schedules.py:83`, `apps/studio/server/routers/schedules.py:136`).
 
-Those surfaces answer "what exists?" but not "what needs operator attention next?" An enterprise
-deployment needs a shared queue that covers running agent work, queued schedules, failed flows,
-manual approvals, charter-required reviews, cost overruns, and human tasks. Without it, operators
-must scan runs, sessions, shows, schedule runs, logs, and future cost endpoints independently.
+Those surfaces answer "what exists?" but not "what needs operator attention next?" A shared queue
+covering running agent work, queued schedules, failed flows, manual approvals, charter-required
+reviews, cost overruns, and human tasks is needed. Without it, operators must scan runs, sessions,
+shows, schedule runs, logs, and future cost endpoints independently.
 
 The platform is already close to a work model. Sessions expose invocation kind, agent, playbook,
 show linkage, timestamps, status, artifact contract, and project fields
@@ -424,13 +424,12 @@ paths only.
 |---|---|
 | Add filters to the Runs page only | Runs are sessions; they do not cover queued schedules, manual approvals, GTD items, charter tasks, or future non-session work. |
 | Treat schedules as the task board | Schedules define automation; operators also need one-off manual work, approval tasks, and play/session review items. |
-| Integrate an external ticket system first | Useful later, but PMF requires a native Studio command center with local governance and audit before external sync. |
+| Integrate an external ticket system first | A native Studio command center with local governance and audit is the correct foundation before external sync. |
 
 ## Consequences
 
 Positive: Studio becomes an operator command center with visibility, control, audit trail, cost
-awareness, and compliance workflow in one place. This is the product surface that turns scheduled
-automation into governed operations.
+awareness, and compliance workflow in one place.
 
 Negative: the board creates a new high-traffic aggregation surface. It must avoid duplicating source
 state and instead maintain idempotent projections from ADR-0062 events.

--- a/docs/adrs/ADR-0064-work-system-integration.md
+++ b/docs/adrs/ADR-0064-work-system-integration.md
@@ -1,6 +1,6 @@
 # ADR-0064: Work System Integration
 
-**Status**: Accepted
+**Status**: accepted
 **Date**: 2026-05-27
 **Related**: ADR-0023 (unified hook system), ADR-0029 (artifact contract), ADR-0031 (entity header pattern)
 

--- a/docs/adrs/ADR-0064-work-system-integration.md
+++ b/docs/adrs/ADR-0064-work-system-integration.md
@@ -1,0 +1,442 @@
+# ADR-0064: Work System Integration
+
+**Status**: Accepted
+**Date**: 2026-05-27
+**Related**: ADR-0023 (unified hook system), ADR-0029 (artifact contract), ADR-0031 (entity header pattern)
+
+## Context
+
+LionAGI's agent and session layer handles free-form LLM conversations.  There
+is a gap between that layer and *structured, repeatable work*: tasks that have
+defined inputs, produce defined outputs, and need validation before they can be
+safely dispatched to a worker.
+
+The need appears in three recurring scenarios:
+
+1. **CLI pipelines** (`li o flow`) route instructions between workers.  Each
+   worker expects a specific set of fields.  Mis-spelled or missing fields
+   cause silent downstream failures.
+
+2. **Human-in-the-loop checkpoints** require operators to fill a form before
+   a restricted action (deploy, publish) proceeds.  Currently there is no
+   structured capture mechanism — values are passed as unvalidated strings.
+
+3. **Multi-step automation** (sessions that call external services, transform
+   data, and write artifacts) needs a contract between producer and consumer
+   stages.  Without a shared schema, each stage duplicates ad-hoc parsing.
+
+### Why not just Pydantic models per worker?
+
+Worker-specific Pydantic models solve the schema problem but leave the
+*runtime* problems unaddressed:
+
+- **Status tracking**: which forms have been filled and validated?
+- **Dispatch routing**: which worker handles this form?
+- **Concurrency control**: how many tasks can a worker run simultaneously?
+- **Result retrieval**: where is the output of a completed task?
+
+A thin layer above raw Pydantic models — one that provides lifecycle status,
+a dispatch engine, and a result store — answers all four questions without
+prescribing a message broker or a database.
+
+## Decision
+
+Introduce `lionagi.work`, a standalone sub-package with four components:
+
+| Component | Module | Responsibility |
+|---|---|---|
+| `FieldSpec` + `WorkForm` | `form.py` | Typed schema + lifecycle container |
+| `Rule` + `RuleSet` | `rules.py` | Declarative cross-field validation |
+| `WorkerDefinition` | `definition.py` | Static worker descriptor |
+| `WorkEngine` | `engine.py` | Dispatch, concurrency, result storage |
+
+The sub-package has **no hard dependencies** beyond Pydantic.  It does not
+import from `lionagi.session`, `lionagi.service`, or any provider.  It can
+be embedded in CLI pipelines, used in tests without a live model, and
+composed with the hook system (ADR-0023) as needed.
+
+---
+
+## Form Lifecycle
+
+Every `WorkForm` instance progresses through a defined set of statuses.
+
+```text
+draft
+  │
+  ▼  fill_form(form, values)
+filled
+  │
+  ▼  validate_form(form)  ──── validation failures ───▶  error
+  │
+validated
+  │
+  ▼  engine.submit(form)
+submitted
+  │
+  ▼  handler completes
+completed
+```
+
+**draft** — Initial state when a `WorkForm` is constructed.  Fields are
+declared but no values have been supplied.
+
+**filled** — `fill_form()` has merged values into the form.  Validation runs
+automatically; the form moves to `validated` or `error` immediately.
+
+**validated** — All required fields are present and all values coerce to their
+declared types.  The form is ready to be submitted to the engine.
+
+**error** — One or more validation failures were recorded in
+`form.validation_errors`.  The form must be re-filled (with corrected values)
+to proceed.
+
+**submitted** — The engine has accepted the form and assigned it a `WorkTask`.
+The originating form object is not mutated; the engine tracks status on the
+`WorkTask`.
+
+**completed** — The worker handler returned successfully.  The result is
+available via `engine.get_result(task_id)`.
+
+Transitions that are not shown (e.g., `validated → draft`) are not valid.
+Nothing prevents creating a new form from scratch, but the lifecycle status
+of an existing form is append-only within the normal flow.
+
+---
+
+## Worker Composition Patterns
+
+### Pattern 1 — Single-stage transform
+
+The simplest case: one form in, one form out.
+
+```python
+from lionagi.work import FieldSpec, WorkForm, WorkEngine, WorkerDefinition, fill_form
+
+def word_count_handler(form: WorkForm) -> dict:
+    text = form.values.get("text", "")
+    return {"word_count": len(text.split())}
+
+defn = WorkerDefinition(
+    definition_id="word_count",
+    name="Word Count Worker",
+    input_form="text_input",
+    output_form="count_output",
+    handler="mypackage.workers.word_count_handler",
+)
+
+engine = WorkEngine()
+engine.register_worker(defn, word_count_handler)
+
+input_form = WorkForm(
+    form_id="text_input",
+    fields={"text": FieldSpec(name="text", type="str", required=True)},
+)
+filled = fill_form(input_form, {"text": "hello world foo"})
+task_id = engine.submit(filled, worker_id="word_count")
+
+result = engine.get_result(task_id)
+# result.value == {"word_count": 3}
+```
+
+### Pattern 2 — Chained workers (producer → consumer)
+
+The output of one worker becomes the input form values for the next.
+
+```python
+# Stage 1: extract keywords
+def extract_handler(form: WorkForm) -> dict:
+    words = form.values["text"].lower().split()
+    keywords = [w for w in words if len(w) > 4]
+    return {"keywords": keywords}
+
+# Stage 2: rank keywords
+def rank_handler(form: WorkForm) -> dict:
+    kws = form.values.get("keywords", [])
+    return {"ranked": sorted(set(kws))}
+
+engine.register_worker(extract_defn, extract_handler)
+engine.register_worker(rank_defn, rank_handler)
+
+# Submit stage 1
+t1 = engine.submit(fill_form(text_form, {"text": "the quick brown fox"}), worker_id="extract")
+r1 = engine.get_result(t1)
+
+# Feed stage 1 output into stage 2
+t2 = engine.submit(fill_form(kw_form, r1.value), worker_id="rank")
+r2 = engine.get_result(t2)
+```
+
+The engine does not manage the chain itself — the orchestrator (a CLI flow,
+a Branch, or application code) drives the handoff.  This keeps the engine
+simple and the chain topology flexible.
+
+### Pattern 3 — Governed workers (gate before dispatch)
+
+A governed worker requires a human-filled form (or a gate check) before
+submission.  The hook system (ADR-0023) attaches the gate as a pre-submit
+callable.
+
+```python
+from lionagi.work import RuleSet, Rule
+
+# Define business rules beyond type checking
+rules = RuleSet()
+rules.add(Rule(rule_id="budget_limit", field="budget_usd",
+               check="range", params={"max": 10_000},
+               message="Budget exceeds approval threshold."))
+rules.add(Rule(rule_id="env_prod", field="target_env",
+               check="pattern", params={"pattern": r"^(staging|prod)$"},
+               message="target_env must be 'staging' or 'prod'."))
+
+def governed_handler(form: WorkForm) -> dict:
+    errors = rules.apply_all(form)
+    if errors:
+        raise ValueError(f"Gate failed: {errors}")
+    return {"deployed": True, "env": form.values["target_env"]}
+```
+
+Governance logic lives inside the handler or a pre-submit hook — the engine
+itself is policy-neutral.
+
+---
+
+## Engine Dispatch Algorithm
+
+```text
+submit(form, worker_id=None)
+  ├─ LOCK acquired
+  ├─ resolve_slot(worker_id)
+  │    ├─ if worker_id is None and exactly one worker → use it
+  │    ├─ if worker_id is None and multiple workers → raise ValueError
+  │    └─ if worker_id not in registry → raise ValueError
+  ├─ slot.at_capacity? → raise RuntimeError (caller must retry or queue)
+  ├─ create WorkTask(form_id, worker_id, status="queued")
+  ├─ store task in _tasks dict
+  ├─ slot.in_flight += 1
+  ├─ LOCK released
+  └─ _run_task(task, slot, form)
+       ├─ LOCK: task.status = "running"
+       ├─ call slot.handler(form) [with optional SIGALRM timeout on Unix]
+       ├─ on success:
+       │    LOCK: task.status="completed", task.result=value, task.completed_at=now()
+       └─ on exception:
+            LOCK: task.status="failed", task.error=repr(exc), task.completed_at=now()
+       └─ LOCK: slot.in_flight = max(0, slot.in_flight - 1)
+```
+
+Key properties:
+
+- The lock is held only during state mutations, not during handler execution.
+  This means multiple threads can submit and execute tasks concurrently.
+- `at_capacity` is checked under the lock to avoid TOCTOU races.
+- The `max_concurrent=0` sentinel means unlimited concurrency (no capacity
+  check).
+- Timeout enforcement on synchronous handlers uses `signal.SIGALRM` on Unix.
+  On Windows, the timeout parameter is accepted but not enforced for sync
+  handlers (async handlers use `asyncio.wait_for`).
+
+---
+
+## Error Handling and Retry Strategy
+
+### Form-level errors
+
+`validate_form` returns a new form with `status="error"` and a list of
+human-readable messages in `validation_errors`.  The caller inspects the list,
+corrects the input, and calls `fill_form` again.  There is no automatic retry
+at the form level.
+
+### Task-level failures
+
+When a handler raises, the `WorkTask` moves to `status="failed"` with
+`task.error` set to `"ExcType: message"`.  The `WorkResult.success` property
+is False.
+
+Retry strategy is the caller's responsibility — the engine does not implement
+automatic retry.  A typical retry loop:
+
+```python
+MAX_RETRIES = 3
+for attempt in range(MAX_RETRIES):
+    task_id = engine.submit(form, worker_id="my_worker")
+    result = engine.get_result(task_id)
+    if result.success:
+        break
+    if attempt < MAX_RETRIES - 1:
+        time.sleep(2 ** attempt)  # exponential back-off
+else:
+    raise RuntimeError(f"Worker failed after {MAX_RETRIES} attempts: {result.error}")
+```
+
+### Concurrency limit reached
+
+When a worker is at its `max_concurrent` limit, `submit` raises `RuntimeError`
+immediately rather than blocking.  The caller may queue the form, reduce
+concurrency, or raise to the operator.  Blocking queues are outside the scope
+of this module (use `threading.Semaphore` or an async queue in the calling
+layer).
+
+---
+
+## Integration with ADR-0023 (Hook System)
+
+The engine is hook-neutral but composes cleanly:
+
+```python
+# Pre-submit hook: validate business rules before the task enters the engine
+async def pre_submit_hook(tool_name, action, args):
+    form = args.get("form")
+    if form:
+        errors = my_ruleset.apply_all(form)
+        if errors:
+            raise PermissionError(f"Pre-submit gate failed: {errors}")
+
+# Post-submit hook: emit telemetry after every task completes
+async def post_submit_hook(tool_name, action, args, result):
+    task_id = result.get("task_id")
+    log.info("task=%s completed", task_id)
+```
+
+---
+
+## Concrete Code Examples
+
+### Minimal end-to-end
+
+```python
+from lionagi.work import (
+    FieldSpec, WorkForm, WorkEngine, WorkerDefinition,
+    fill_form, Rule, RuleSet,
+)
+
+# 1. Define the schema
+spec = {
+    "fields": {
+        "name": FieldSpec(name="name", type="str", required=True),
+        "age":  FieldSpec(name="age",  type="int",  required=True),
+    }
+}
+template = WorkForm(form_id="user_form", title="User Registration", **spec)
+
+# 2. Define validation rules
+rs = RuleSet()
+rs.add(Rule(rule_id="age_range", field="age", check="range", params={"min": 0, "max": 150}))
+
+# 3. Define and register a worker
+def register_user(form: WorkForm) -> dict:
+    errors = rs.apply_all(form)
+    if errors:
+        raise ValueError(errors)
+    return {"registered": True, "name": form.values["name"]}
+
+engine = WorkEngine(name="registration")
+engine.register_worker(
+    WorkerDefinition(
+        definition_id="register",
+        name="User Registration Worker",
+        input_form="user_form",
+        output_form="registration_result",
+        handler="myapp.workers.register_user",
+    ),
+    handler=register_user,  # pass directly to skip dotted-path import
+)
+
+# 4. Fill, validate, submit
+form = fill_form(template, {"name": "Alice", "age": 30})
+assert form.status == "validated"
+
+task_id = engine.submit(form, worker_id="register")
+result  = engine.get_result(task_id)
+assert result.success
+# result.value == {"registered": True, "name": "Alice"}
+```
+
+### Loading a worker definition from YAML
+
+```yaml
+# workers/register.yaml
+definition_id: register
+name: User Registration Worker
+description: Validates and persists new user records.
+input_form: user_form
+output_form: registration_result
+handler: myapp.workers.register_user
+max_concurrent: 4
+timeout_seconds: 30
+tags: [auth, users]
+```
+
+```python
+from lionagi.work import load_definition, WorkEngine
+
+defn = load_definition("workers/register.yaml")
+engine = WorkEngine()
+engine.register_worker(defn)  # resolves handler from dotted path
+```
+
+---
+
+## Consequences
+
+**Positive**
+
+- No runtime dependency on LLM providers, databases, or message brokers.
+  `lionagi.work` is importable in any Python 3.10+ environment with Pydantic.
+
+- Form lifecycle is explicit and inspectable.  Callers always know the current
+  status of a form (`draft`, `validated`, `error`, …) without out-of-band
+  communication.
+
+- Thread-safe by default.  The lock-per-engine design allows concurrent
+  submission from multiple threads without external synchronisation.
+
+- Composable with hooks (ADR-0023).  Pre-submit and post-submit hooks attach
+  governance logic without coupling it to the engine.
+
+- Validation errors are collected in full, not short-circuited.  The operator
+  sees all problems at once.
+
+**Negative**
+
+- Synchronous execution model.  Long-running handlers block the submitting
+  thread.  For truly async pipelines, callers should use `submit_async` or
+  wrap handlers in thread pools.
+
+- No built-in retry or back-off.  Callers implement their own retry loop.
+  This keeps the engine simple but shifts responsibility to callers.
+
+- Timeout for synchronous handlers is Unix-only (`SIGALRM`).  On Windows,
+  the `timeout_seconds` field is stored but not enforced for sync handlers.
+
+- Result storage is in-memory only.  Completed tasks are lost on process
+  restart.  Persistence is the caller's responsibility (serialize
+  `WorkTask.model_dump()` to disk or a database).
+
+---
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|---|---|
+| Celery / RQ / other task queue | Introduces broker dependency, complex deployment. Unnecessary for in-process work. |
+| Raw Pydantic models per worker | Solves schema but leaves status, dispatch, concurrency unaddressed. |
+| Reuse `lionagi.protocols.generic.Element` as base | Element carries UUID + timestamp + metadata; useful for persistence, but adds mandatory UUID generation overhead for lightweight forms. WorkForm uses plain Pydantic BaseModel to stay standalone. |
+| asyncio.Queue as the engine | Coupling to asyncio would exclude sync use cases and complicate CLI integration. |
+| JSON Schema instead of FieldSpec | More portable but loses Python type coercion and Pydantic integration. |
+
+## Non-Goals
+
+- **No message broker.**  The engine runs in-process.
+- **No persistence.**  Task history is in-memory; callers serialise to disk.
+- **No tenant isolation.**  Single-process, single-user.
+- **No workflow graph.**  DAG execution belongs to `Session.flow()`.
+- **No automatic retry.**  Retry is a caller concern.
+
+## References
+
+- [ADR-0023](ADR-0023-unified-hook-system.md) — hook system (pre/post callables).
+- [ADR-0029](ADR-0029-artifact-contract.md) — artifact contract (form outputs may be artifacts).
+- [ADR-0031](ADR-0031-entity-header-pattern.md) — entity header (WorkTask maps to EntityHeader shape).
+- `lionagi/work/` — implementation.
+- `tests/work/test_work_system.py` — 67 tests covering all public surfaces.

--- a/docs/adrs/ADR-0065-task-board-schema.md
+++ b/docs/adrs/ADR-0065-task-board-schema.md
@@ -3,7 +3,7 @@
 **Status**: Proposed
 **Date**: 2026-05-27
 **Depends on**: ADR-0064 (work system integration), ADR-0009 (SQLite state layer)
-**Related**: ADR-0030 (attention queue), ADR-0031 (entity header pattern)
+**Related**: ADR-0030 (attention queue), ADR-0031 (entity header pattern), ADR-0063 (task board work center — this ADR supersedes ADR-0063's schema subsection for the lionagi.work projection; ADR-0063's work_items table governs the operator UI layer, this ADR's work_tasks table governs lionagi.work persistence)
 
 ## Context
 

--- a/docs/adrs/ADR-0065-task-board-schema.md
+++ b/docs/adrs/ADR-0065-task-board-schema.md
@@ -1,6 +1,6 @@
 # ADR-0065: Task Board Schema
 
-**Status**: Proposed
+**Status**: proposed
 **Date**: 2026-05-27
 **Depends on**: ADR-0064 (work system integration), ADR-0009 (SQLite state layer)
 **Related**: ADR-0030 (attention queue), ADR-0031 (entity header pattern), ADR-0063 (task board work center — this ADR supersedes ADR-0063's schema subsection for the lionagi.work projection; ADR-0063's work_items table governs the operator UI layer, this ADR's work_tasks table governs lionagi.work persistence)

--- a/docs/adrs/ADR-0065-task-board-schema.md
+++ b/docs/adrs/ADR-0065-task-board-schema.md
@@ -1,0 +1,263 @@
+# ADR-0065: Task Board Schema
+
+**Status**: Proposed
+**Date**: 2026-05-27
+**Depends on**: ADR-0064 (work system integration), ADR-0009 (SQLite state layer)
+**Related**: ADR-0030 (attention queue), ADR-0031 (entity header pattern)
+
+## Context
+
+ADR-0064 introduces `lionagi.work` — an in-memory dispatch layer for structured
+forms and workers.  The work system answers "what is happening right now" but
+loses its history on process restart.
+
+Studio operators need a persistent view of work: which tasks were submitted
+today, which failed, which are queued, and what the throughput looks like over
+time.  This is the *task board*.
+
+The task board is not a replacement for the work engine's in-memory state — it
+is the **persistence projection** of that state, suitable for Studio's SQLite
+state layer (ADR-0009) and the Attention Queue (ADR-0030).
+
+### Why a separate ADR?
+
+ADR-0064 scoped itself to the in-memory work system with no persistence.
+Persistence introduces its own decisions:
+
+1. **Schema shape** — which fields survive to the database?
+2. **Write path** — when and how does the engine flush to SQLite?
+3. **Query surface** — what does the task board API expose?
+4. **Studio integration** — how does the UI consume this data?
+
+These decisions touch ADR-0009 (SQLite), ADR-0030 (attention queue), and
+ADR-0031 (entity header), so they warrant a separate record.
+
+## Decision
+
+Add a `work_tasks` table to the Studio SQLite database and a minimal write
+path that flushes `WorkTask` snapshots to it.  The table shape mirrors
+`WorkTask` (ADR-0064) with two additions: a `project` column for filtering
+and a `form_snapshot` JSON column for forensic inspection.
+
+### 1. Table schema
+
+```sql
+CREATE TABLE IF NOT EXISTS work_tasks (
+    task_id         TEXT    NOT NULL PRIMARY KEY,
+    form_id         TEXT    NOT NULL,
+    worker_id       TEXT    NOT NULL,
+    project         TEXT,                       -- optional project label
+    status          TEXT    NOT NULL DEFAULT 'queued',
+    error           TEXT,
+    submitted_at    REAL    NOT NULL,
+    completed_at    REAL,
+    form_snapshot   TEXT,                       -- JSON of WorkForm.model_dump()
+    result_snapshot TEXT                        -- JSON of WorkResult.value (if serialisable)
+);
+
+CREATE INDEX IF NOT EXISTS ix_work_tasks_status   ON work_tasks(status);
+CREATE INDEX IF NOT EXISTS ix_work_tasks_worker   ON work_tasks(worker_id);
+CREATE INDEX IF NOT EXISTS ix_work_tasks_project  ON work_tasks(project);
+CREATE INDEX IF NOT EXISTS ix_work_tasks_submitted ON work_tasks(submitted_at DESC);
+```
+
+`form_snapshot` stores the serialised `WorkForm` at submission time for
+forensic replay.  `result_snapshot` stores the JSON-serialisable portion of
+the handler's return value (skipped for non-serialisable results).
+
+### 2. Python schema (Pydantic)
+
+```python
+from pydantic import BaseModel
+from typing import Any
+
+class WorkTaskRow(BaseModel):
+    """SQLite row model for the work_tasks table."""
+    task_id:         str
+    form_id:         str
+    worker_id:       str
+    project:         str | None  = None
+    status:          str         = "queued"
+    error:           str | None  = None
+    submitted_at:    float
+    completed_at:    float | None = None
+    form_snapshot:   str | None  = None   # JSON
+    result_snapshot: str | None  = None   # JSON
+```
+
+### 3. Write path
+
+The engine does not write to SQLite directly.  Callers attach a **post-submit
+callback** that persists state transitions.  This keeps the engine free of I/O
+dependencies (per ADR-0064's standalone constraint).
+
+```python
+import json
+import sqlite3
+from lionagi.work import WorkEngine, WorkTask
+
+def _upsert_task(conn: sqlite3.Connection, task: WorkTask, form_json: str | None = None) -> None:
+    conn.execute(
+        """
+        INSERT INTO work_tasks
+          (task_id, form_id, worker_id, status, error,
+           submitted_at, completed_at, form_snapshot)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(task_id) DO UPDATE SET
+          status       = excluded.status,
+          error        = excluded.error,
+          completed_at = excluded.completed_at
+        """,
+        (
+            task.task_id, task.form_id, task.worker_id, task.status,
+            task.error, task.submitted_at, task.completed_at, form_json,
+        ),
+    )
+    conn.commit()
+
+# Attach via a thin wrapper around the engine
+class PersistentWorkEngine(WorkEngine):
+    def __init__(self, conn: sqlite3.Connection, **kwargs):
+        super().__init__(**kwargs)
+        self._conn = conn
+
+    def submit(self, form, worker_id=None):
+        task_id = super().submit(form, worker_id=worker_id)
+        task = self.get_task(task_id)
+        if task:
+            try:
+                form_json = form.model_dump_json()
+            except Exception:
+                form_json = None
+            _upsert_task(self._conn, task, form_json)
+        return task_id
+```
+
+### 4. Studio API surface
+
+```text
+GET /api/work/tasks
+    ?status=queued|running|completed|failed
+    ?worker_id=<str>
+    ?project=<str>
+    ?limit=<int>   (default 50)
+    ?offset=<int>
+
+Response:
+{
+  "total": 142,
+  "tasks": [WorkTaskRow, ...]
+}
+
+GET /api/work/tasks/<task_id>
+Response: WorkTaskRow (with form_snapshot and result_snapshot)
+
+GET /api/work/workers
+Response: {worker_id: {definition_id, name, in_flight, max_concurrent}, ...}
+```
+
+### 5. Attention Queue integration (ADR-0030)
+
+Failed and timed-out work tasks surface as Attention Queue items with:
+
+```python
+AttentionItem(
+    kind="work_task",
+    id=task.task_id,
+    severity="warning",
+    reason_code="work.task.failed",
+    summary=f"Worker {task.worker_id!r} task failed: {task.error[:80]}",
+    evidence_refs=[{"kind": "work_task", "id": task.task_id}],
+    actions=[
+        EntityAction(id="inspect", label="Inspect task",
+                     href=f"/work/tasks/{task.task_id}"),
+        EntityAction(id="retry",   label="Retry",
+                     endpoint=f"/api/work/tasks/{task.task_id}/retry",
+                     method="POST"),
+    ],
+)
+```
+
+### 6. Task board Studio page
+
+A new `/work` page in Studio lists `work_tasks` with:
+
+- Status filter pills (queued / running / completed / failed / all)
+- Worker filter dropdown
+- Columns: task_id (truncated), form_id, worker, status pill, submitted_at,
+  duration, error (truncated)
+- Row click → detail sheet showing `form_snapshot` and `result_snapshot`
+- Retry button on failed rows (calls `POST /api/work/tasks/<id>/retry`)
+
+The page consumes `EntityHeader` (ADR-0031) at the top with:
+
+```json
+{
+  "kind": "work_task",
+  "title": "<task_id>",
+  "status": "failed",
+  "status_taxonomy": "work_task",
+  "goal": "Worker echo_worker processing form user_form",
+  "last_event": {"summary": "ValueError: handler failed", "at": 1716517300.0},
+  "actions": [
+    {"id": "inspect", "label": "Inspect form snapshot", "kind": "secondary"},
+    {"id": "retry",   "label": "Retry",                  "kind": "primary",
+     "endpoint": "/api/work/tasks/<id>/retry", "method": "POST"}
+  ]
+}
+```
+
+## Consequences
+
+**Positive**
+
+- Persistence is additive: the base `WorkEngine` (ADR-0064) stays I/O-free;
+  `PersistentWorkEngine` wraps it with a two-line override.
+
+- `form_snapshot` enables forensic replay without re-running the pipeline.
+
+- Studio task board gives operators visibility into in-process work without
+  instrumenting every pipeline individually.
+
+- Attention Queue integration surfaces failures automatically; operators do
+  not need to poll the task list.
+
+**Negative**
+
+- `ON CONFLICT ... DO UPDATE` requires at least two writes per task lifecycle
+  (submit → complete/fail).  For high-frequency workers (thousands of tasks
+  per minute), this may create write pressure on SQLite.  Mitigation:
+  batch writes or switch to WAL mode.
+
+- `form_snapshot` can be large for forms with embedded binary or large text.
+  Callers should cap snapshot size before storing.
+
+- `result_snapshot` is silently skipped for non-JSON-serialisable results.
+  Workers that return complex objects (ML tensors, file handles) will show
+  `null` in Studio.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|---|---|
+| Engine writes directly to SQLite | Violates ADR-0064's standalone constraint. Introduces I/O in the hot path. |
+| Separate time-series DB for metrics | Overkill for current scale; Studio already uses SQLite (ADR-0009). |
+| No persistence, rely on ADR-0030 attention queue | Attention Queue only surfaces failures, not the full task history. |
+| Event sourcing (append-only log) | Correct architecture for high-frequency work, but premature for current usage. Can migrate to it when write pressure becomes a real constraint. |
+
+## Non-Goals
+
+- **No multi-process coordination.**  The task board is for a single Studio
+  instance.
+- **No real-time push.**  The Studio page polls; SSE can be added later
+  (ADR-0006 pattern).
+- **No retention policy.**  Operators manage table growth manually or via a
+  cron job; automatic TTL is deferred.
+
+## References
+
+- [ADR-0064](ADR-0064-work-system-integration.md) — work system (in-memory engine this ADR persists).
+- [ADR-0009](ADR-0009-sqlite-state-layer.md) — SQLite state layer (target database).
+- [ADR-0030](ADR-0030-attention-queue.md) — Attention Queue (consumes failed task events).
+- [ADR-0031](ADR-0031-entity-header-pattern.md) — entity header (used on task detail page).
+- `lionagi/work/` — work system implementation.

--- a/docs/adrs/ADR-0066-unified-execution-viewer.md
+++ b/docs/adrs/ADR-0066-unified-execution-viewer.md
@@ -1,0 +1,800 @@
+# ADR-0066: Unified Execution Viewer
+
+Status: proposed
+Date: 2026-05-27
+Decision owners: @studio-maintainers, @orchestration-maintainers
+Depends on: ADR-0009 (SQLite state layer), ADR-0020 (skill invocations), ADR-0025 (session lifecycle), ADR-0034 (frontend data/state), ADR-0056 (play control API)
+Related: ADR-0055 (artifact viewer), ADR-0064 (work system integration), ADR-0065 (task board schema)
+
+## Context
+
+Lion Studio's most important operator surface is the execution detail view: a user must understand
+what ran, what is running now, what failed, which tool calls happened, and how one operation led to
+the next. Today that surface is split across several related but inconsistent views.
+
+The current run detail page already converts session branches into readable steps and pairs
+ActionRequest with ActionResponse in a local adapter
+(`apps/studio/frontend/app/runs/[id]/page.tsx:27-120`). It also reads session graph metadata and
+renders an embedded `WorkerCanvas`, but the page remains section-oriented with a sidebar, summary,
+small DAG section, branch log section, errors, and files
+(`apps/studio/frontend/app/runs/[id]/page.tsx:760-850`). This makes the DAG secondary even though
+the operator's mental model is graph-first.
+
+The current show DAG renders plays as ReactFlow nodes and infers dependencies from `_show.md`
+(`apps/studio/frontend/app/shows/[topic]/components/PlayDag.tsx:17-110`). This is useful, but it is
+not connected to the run detail graph or operation detail pane. Shows, plays, and single-agent runs
+therefore appear as unrelated views even though the runtime already models them as connected
+execution scopes.
+
+The backend has enough structure to unify the surface. `FlowPlan` defines agents as persistent
+branches and operations as a dependency DAG (`lionagi/cli/orchestrate/flow.py:332-425`). During flow
+execution, Studio-facing operation segments are persisted into `sessions.node_metadata` with
+`op_id`, `branch_id`, `branch_name`, `status`, `started_at`, and `ended_at`
+(`lionagi/cli/orchestrate/flow.py:1177-1234`). The early DAG snapshot is also persisted into the
+session row while execution is still live (`lionagi/cli/orchestrate/flow.py:1257-1280`). The Studio
+session service already converts that metadata into graph nodes and edges
+(`apps/studio/server/services/sessions.py:28-74`) and exposes segments from `node_metadata`
+(`apps/studio/server/services/sessions.py:286-317`).
+
+Important source note: the requirement says messages have `invocation_id`. In the checked-in schema
+reviewed for this ADR, `sessions.invocation_id` exists (`lionagi/state/schema.sql:134-139`) and
+`messages` has `id`, `created_at`, `node_metadata`, `content`, sender/recipient/channel, role, and
+class (`lionagi/state/schema.sql:41-52`), but no top-level message `invocation_id`. This ADR does
+not depend on a message-level invocation column. Operation-scoped reads use branch progressions plus
+operation segment boundaries, and may additionally use a future or environment-specific message
+invocation field when present.
+
+## Decision
+
+Build a single Unified Execution Viewer that represents single-agent runs, plays, flows, and shows
+as one execution graph model and renders them with a persistent split-pane layout:
+
+```text
+left 62%: ReactFlow execution DAG canvas
+right 38%: selected execution detail panel
+```
+
+The viewer becomes the canonical detail shell for:
+
+- `/runs/{session_id}` - single session or play/flow session;
+- `/shows/{topic}` - show-level graph of play macro-nodes, each expandable to its session DAG;
+- `/invocations/{id}` - multi-session skill invocation graph when an invocation is the parent scope.
+
+Single-agent runs are a trivial DAG with one node. Plays and flows are operation DAGs from
+`FlowPlan` metadata. Shows are one larger graph where play nodes are macro-nodes linked by show
+dependencies or chronological chaining. Re-planned work is attached to the graph rather than shown
+as a separate run: gate node -> re-plan node -> new operation sub-DAG. Show chaining is also graph
+native: play_n final node -> play_n+1 orchestrator node.
+
+## Unified Execution Graph Model
+
+### Execution Scope
+
+```ts
+export type ExecutionScopeKind = "agent_run" | "play" | "flow" | "show" | "invocation";
+
+export interface ExecutionScope {
+  id: string;
+  kind: ExecutionScopeKind;
+  title: string;
+  status: ExecutionStatus;
+  sessionId?: string;
+  invocationId?: string | null;
+  showTopic?: string | null;
+  createdAt: number;
+  updatedAt: number;
+  graph: ExecutionGraph;
+}
+```
+
+### Graph, Nodes, And Edges
+
+```ts
+export type ExecutionStatus =
+  | "queued"
+  | "idle"
+  | "thinking"
+  | "tool_calling"
+  | "streaming"
+  | "running"
+  | "completed"
+  | "failed"
+  | "paused"
+  | "cancelled"
+  | "timed_out"
+  | "aborted";
+
+export type ExecutionNodeKind =
+  | "agent"
+  | "operation"
+  | "gate"
+  | "replan"
+  | "synthesis"
+  | "control"
+  | "play"
+  | "show";
+
+export interface ExecutionNodeData {
+  id: string;
+  kind: ExecutionNodeKind;
+  label: string;
+  status: ExecutionStatus;
+  role?: string | null;
+  agentId?: string | null;
+  branchId?: string | null;
+  branchName?: string | null;
+  sessionId?: string | null;
+  invocationId?: string | null;
+  showTopic?: string | null;
+  playName?: string | null;
+  opId?: string | null;
+  model?: string | null;
+  startedAt?: number | null;
+  endedAt?: number | null;
+  latestActivity?: ExecutionActivity | null;
+  metrics?: {
+    durationSeconds?: number | null;
+    messageCount?: number;
+    toolCallCount?: number;
+    errorCount?: number;
+  };
+  nestedGraphRef?: {
+    kind: "session" | "show" | "invocation";
+    id: string;
+  } | null;
+}
+
+export type ExecutionEdgeKind =
+  | "dependency"
+  | "data_flow"
+  | "control"
+  | "replan"
+  | "show_chain"
+  | "expansion";
+
+export interface ExecutionEdgeData {
+  id: string;
+  source: string;
+  target: string;
+  kind: ExecutionEdgeKind;
+  label?: string;
+  status?: "inactive" | "ready" | "active" | "satisfied" | "failed";
+  condition?: string;
+  map?: Record<string, string>;
+  payloadRefs?: string[];
+}
+
+export interface ExecutionGraph {
+  id: string;
+  scopeKind: ExecutionScopeKind;
+  nodes: ExecutionNodeData[];
+  edges: ExecutionEdgeData[];
+  layoutDirection: "LR" | "TB";
+  generatedAt: number;
+}
+```
+
+### Graph Construction Rules
+
+| Runtime shape | Graph representation |
+| --- | --- |
+| Single agent run | One `agent` node, no edges. Node points to session + branch messages. |
+| Play / flow | One node per `FlowOp`; dependency edges from `depends_on`; agent reuse shown on node metadata, not by merging nodes. |
+| Show | One `play` macro-node per play; dependency edges from persisted play deps or `_show.md`; each play node expands to the linked session operation DAG. |
+| Re-plan | Control/gate node emits `replan` edge to a `replan` node, then dependency edges into the newly planned operation sub-DAG. |
+| Show chaining | Final terminal node of play_n links to orchestrator/start node of play_n+1 with `show_chain`. |
+| Invocation | Multi-session graph: invocation root links to child session/play/show graphs. For `/show`, the show graph is primary. |
+
+### Graph Model Diagrams
+
+Single agent run:
+
+```mermaid
+flowchart LR
+  A["agent run<br/>session_id"]
+```
+
+Play / flow operation DAG:
+
+```mermaid
+flowchart LR
+  O1["op1<br/>researcher"] --> O2["op2<br/>implementer"]
+  O1 --> O3["op3<br/>analyst"]
+  O2 --> G["gate<br/>control"]
+  O3 --> G
+  G --> S["synthesis"]
+```
+
+Re-plan chain:
+
+```mermaid
+flowchart LR
+  O1["main op"] --> G["gate"]
+  G -->|should_continue| R["re-plan"]
+  R --> N1["new op A"]
+  R --> N2["new op B"]
+  N1 --> S["updated synthesis"]
+  N2 --> S
+```
+
+Show as one graph with expandable macro-nodes:
+
+```mermaid
+flowchart LR
+  P1["play: backend<br/>macro-node"] --> P2["play: frontend<br/>macro-node"]
+  P2 --> P3["play: integration<br/>macro-node"]
+  P1 -. expands .-> P1A["backend op DAG"]
+  P2 -. expands .-> P2A["frontend op DAG"]
+```
+
+Show chaining across plays:
+
+```mermaid
+flowchart LR
+  P1F["play_n final node"] -->|show_chain| P2O["play_n+1 orchestrator"]
+  P2O --> P2A["play_n+1 op A"]
+  P2O --> P2B["play_n+1 op B"]
+```
+
+## Split-Pane Layout Component Architecture
+
+The new frontend component tree is:
+
+```mermaid
+flowchart TD
+  Page["runs/[id], shows/[topic], invocations/[id]"] --> Shell["ExecutionViewerShell"]
+  Shell --> Header["ExecutionHeader"]
+  Shell --> Split["ExecutionSplitPane 62/38"]
+  Split --> Canvas["ExecutionGraphCanvas ReactFlow"]
+  Split --> Panel["ExecutionDetailPanel"]
+  Canvas --> Node["ExecutionNode"]
+  Canvas --> Edge["ExecutionEdge"]
+  Canvas --> Activity["useExecutionActivity EventSource"]
+  Panel --> Summary["ExecutionSummaryPanel"]
+  Panel --> NodeDetail["OperationDetailPanel"]
+  Panel --> EdgeDetail["EdgeDetailPanel"]
+  NodeDetail --> Messages["OperationMessagesPane"]
+  NodeDetail --> Artifacts["OperationArtifactsPane"]
+  Messages --> ToolPair["ToolCallPair"]
+```
+
+The shell owns selection state:
+
+```ts
+export type ExecutionSelection =
+  | { type: "none" }
+  | { type: "node"; nodeId: string; node: ExecutionNodeData }
+  | { type: "edge"; edgeId: string; edge: ExecutionEdgeData };
+```
+
+Panel behavior:
+
+| Selection | Right pane content |
+| --- | --- |
+| None | Run/play/show summary, current status, live activity feed, artifact contract summary. |
+| Node | Operation detail: scoped messages, artifacts, status history, timings, tool calls, branch metadata. |
+| Edge | Dependency/data-flow detail: source/target, condition, field map, payload refs, satisfaction state. |
+
+This replaces the current pattern where `WorkerCanvas` contains an internal side panel
+(`apps/studio/frontend/components/canvas/WorkerCanvas.tsx:305-360`). `WorkerCanvas` should be
+factored into a reusable canvas core that accepts `selection` and `onSelectionChange`, while
+`ExecutionViewerShell` owns the right pane. The existing `SidePanel` remains useful for editable
+playbook/worker graph authoring, but the execution viewer uses a read-oriented detail panel.
+
+Layout contract:
+
+- Desktop: `grid-template-columns: minmax(0, 62fr) minmax(360px, 38fr)`.
+- Minimum right pane width: 360px.
+- Minimum canvas width before responsive collapse: 720px.
+- Mobile and narrow widths: canvas above, detail panel below, with sticky selection summary.
+- No section-card nesting; the canvas is the primary surface.
+
+## Operation-Scoped Message Viewing
+
+Problem: one branch can execute multiple operations. If the same agent ran `op2` and `op5`,
+clicking `op2` must show only the messages for `op2`, not the entire branch history.
+
+Decision: every operation execution has explicit invocation boundaries. The frontend scopes by
+`op_id`, but the backend resolves that `op_id` to boundary event/message ids before reading
+messages. Segment timestamps remain a fallback only.
+
+Segment boundary contract:
+
+```ts
+export interface OperationSegment {
+  op_id: string;
+  branch_id: string;
+  branch_name: string;
+  status: string;
+  started_at: number | null;
+  ended_at: number | null;
+  start_event_id?: string | null;
+  end_event_id?: string | null;
+  first_message_id?: string | null;
+  last_message_id?: string | null;
+  api_calling_event_id?: string | null;
+}
+```
+
+The runtime should extend the current segment writer in
+`lionagi/cli/orchestrate/flow.py:1177-1234` to persist boundary ids when available. Until that
+lands, the API uses the existing time-window segment fields as the compatibility path.
+
+Decision: operation detail fetches scoped messages by operation id:
+
+```http
+GET /api/sessions/{session_id}/messages?op_id={op_id}
+GET /api/sessions/{session_id}/messages?op_id={op_id}&include_full_branch=true
+```
+
+Response:
+
+```ts
+export interface OperationMessagesResponse {
+  session_id: string;
+  op_id: string | null;
+  branch_id: string | null;
+  branch_name: string | null;
+  scope: "operation" | "branch" | "session";
+  segment?: {
+    started_at: number | null;
+    ended_at: number | null;
+    status: string | null;
+  } | null;
+  messages: ExecutionMessage[];
+}
+
+export interface ExecutionMessage {
+  id: string;
+  role: string;
+  lion_class: string;
+  sender: string | null;
+  timestamp: number;
+  content: Record<string, unknown>;
+  branch_id?: string;
+  invocation_id?: string | null;
+}
+```
+
+Backend algorithm:
+
+1. Read `sessions.node_metadata.segments` for `op_id`.
+2. Resolve `branch_id` from the matching segment.
+3. Load the branch progression from `branches.progression_id`.
+4. Fetch ordered message ids from `progressions.collection`.
+5. If `first_message_id` and `last_message_id` exist, slice the ordered progression inclusively.
+6. Else if boundary event ids exist, map them to message ids and slice the progression.
+7. Else filter by the segment time window:
+   `started_at <= message.created_at <= ended_at + epsilon`.
+8. If a future message-level operation/invocation field exists, use it as a stricter filter before
+   falling back to segment boundaries.
+9. If `op_id` is absent or no segment exists, return branch or session scope with
+   `scope="branch"` and include a response warning field in phase 2.
+
+Frontend behavior:
+
+- `ExecutionGraphCanvas` emits node selection.
+- `OperationDetailPanel` calls `getSessionMessages(sessionId, { opId })`.
+- The messages pane displays the scoped transcript.
+- A "Full branch" toggle refetches with `include_full_branch=true`.
+- The toggle must be explicit because operation scope is the default and safety-critical view.
+
+## Live DAG Activity
+
+Each graph node shows a status badge and a live text snippet. The snippet is the last approximately
+50 characters of the current activity: "thinking about cache invalidation", "used exec_command",
+"responded with review findings", or "failed: timeout".
+
+Status vocabulary for live activity:
+
+```ts
+export type ActivityStatus =
+  | "idle"
+  | "thinking"
+  | "tool_calling"
+  | "streaming"
+  | "completed"
+  | "failed";
+
+export interface ExecutionActivity {
+  node_id: string;
+  op_id?: string | null;
+  branch_id?: string | null;
+  status: ActivityStatus;
+  text: string;
+  message_id?: string | null;
+  action_request_id?: string | null;
+  action_response_id?: string | null;
+  timestamp: number;
+}
+```
+
+SSE endpoint:
+
+```http
+GET /api/sessions/{session_id}/dag-activity
+```
+
+SSE event format:
+
+```json
+{
+  "type": "node_activity",
+  "session_id": "sess_123",
+  "node_id": "op2",
+  "op_id": "op2",
+  "branch_id": "branch_456",
+  "status": "tool_calling",
+  "text": "exec_command: npm test",
+  "message_id": "msg_789",
+  "action_request_id": "req_1",
+  "action_response_id": null,
+  "timestamp": 1779907200.0
+}
+```
+
+Terminal and heartbeat events:
+
+```json
+{ "type": "heartbeat", "timestamp": 1779907205.0 }
+{ "type": "done", "session_id": "sess_123", "timestamp": 1779907210.0 }
+```
+
+Implementation guidance:
+
+- Reuse the existing SSE route pattern in `apps/studio/server/routers/sessions.py:24-57`.
+- Do not replace `/api/sessions/{id}/stream` immediately. `dag-activity` is a higher-level stream
+  that maps raw messages and segment updates into node activity patches.
+- Add `useExecutionActivity(sessionId, graph)` to update ReactFlow node data in-place.
+- Handle out-of-order events by applying only newer `timestamp` values per node.
+
+## Paired Tool Call Display
+
+Backend message separation is correct: ActionRequest and ActionResponse are separate messages.
+The frontend must render them as one paired unit.
+
+Component:
+
+```ts
+export interface ToolCallPairProps {
+  request: ExecutionMessage;
+  response?: ExecutionMessage;
+  defaultExpanded?: boolean;
+}
+
+export interface ToolCallViewModel {
+  request_id: string;
+  response_id?: string;
+  tool_name: string;
+  args: Record<string, unknown>;
+  output?: unknown;
+  status: "pending" | "ok" | "error";
+  started_at: number;
+  completed_at?: number | null;
+}
+```
+
+Matching logic:
+
+1. Index ActionResponse messages by `content.action_request_id`.
+2. For each ActionRequest, first match by ActionResponse `action_request_id`.
+3. Also support the current request-side link `content.action_response_id`, which is already used
+   in the run detail adapter (`apps/studio/frontend/app/runs/[id]/page.tsx:86-114`) and backend
+   filesystem run adapter (`apps/studio/server/services/runs.py:224-343`).
+4. Render orphan responses as diagnostic tool result cards, but mark them as unmatched.
+5. Render unmatched ActionRequest as pending with a spinner.
+
+Display:
+
+- Collapsible card.
+- Header: tool name, status, elapsed time if response exists.
+- Args: syntax-highlighted JSON, collapsed by default for long payloads.
+- Result: truncated to a readable default, expandable for full output.
+- Error styling derives from parsed status, not string color alone.
+
+## Node Appearance And Interaction
+
+Node kinds:
+
+| Kind | Meaning |
+| --- | --- |
+| `agent` | Single-agent session or standalone branch execution. |
+| `operation` | Standard FlowOp. |
+| `gate` | Control/critic checkpoint. |
+| `replan` | Orchestrator operation that produced a follow-up plan. |
+| `synthesis` | Final consolidation node. |
+| `control` | Runtime control or non-gate orchestration node. |
+| `play` | Show-level play macro-node. |
+| `show` | Root node for a show or invocation-level grouping. |
+
+Status colors:
+
+| Status | Appearance |
+| --- | --- |
+| queued / idle | gray border, muted badge. |
+| running / thinking / streaming | blue border and pulse, reduced-motion aware. |
+| tool_calling | blue badge with tool glyph and live snippet. |
+| completed | green border and check. |
+| failed | red border and failure badge. |
+| paused | amber border and pause badge. |
+
+Interaction:
+
+- Click node: select node and load scoped detail in the right pane.
+- Click edge: select edge and show dependency/data-flow detail.
+- Double-click expandable macro-node: drill into nested graph, preserving breadcrumb.
+- Escape or pane click: clear selection.
+- Node footer: truncated latest activity text below node name, approximately 50 chars.
+- Existing `StepNode` status handling and reduced-motion pulse are retained as prior art
+  (`apps/studio/frontend/components/canvas/StepNode.tsx:30-180`) but expanded to the new status
+  vocabulary.
+
+## API Specifications
+
+### Get Unified Graph
+
+Phase 1 may continue to use `GET /api/sessions/{id}` and `GET /api/shows/{topic}`. Phase 2 adds a
+normalized graph endpoint:
+
+```http
+GET /api/executions/{kind}/{id}/graph
+```
+
+Where `kind` is `session`, `show`, or `invocation`.
+
+Response:
+
+```ts
+export interface ExecutionGraphResponse {
+  scope: ExecutionScope;
+  graph: ExecutionGraph;
+  sources: Array<{
+    kind: "session" | "show" | "invocation";
+    id: string;
+    path?: string;
+  }>;
+  warnings: string[];
+}
+```
+
+### Get Operation Messages
+
+```http
+GET /api/sessions/{session_id}/messages?op_id={op_id}&include_full_branch=false
+```
+
+Errors:
+
+- `404` if the session does not exist.
+- `404` if `op_id` is supplied and not found in the graph.
+- `409` if the operation maps ambiguously to multiple overlapping segments.
+
+### Stream DAG Activity
+
+```http
+GET /api/sessions/{session_id}/dag-activity
+```
+
+Errors:
+
+- `404` if the session does not exist, matching the pre-flight behavior of the existing stream route
+  (`apps/studio/server/routers/sessions.py:24-30`).
+
+## Backend Service Changes
+
+Add these functions to `apps/studio/server/services/sessions.py`:
+
+```python
+async def get_session_messages(
+    session_id: str,
+    *,
+    op_id: str | None = None,
+    include_full_branch: bool = False,
+) -> dict[str, Any]: ...
+
+async def get_session_dag_activity_after(
+    session_id: str,
+    after_ts: float,
+) -> list[dict[str, Any]]: ...
+
+def build_execution_graph_from_session(session: dict[str, Any]) -> dict[str, Any]: ...
+```
+
+Add routes to `apps/studio/server/routers/sessions.py`:
+
+```python
+@router.get("/{session_id}/messages")
+async def get_session_messages(session_id: str, op_id: str | None = None, include_full_branch: bool = False): ...
+
+@router.get("/{session_id}/dag-activity")
+async def stream_session_dag_activity(session_id: str): ...
+```
+
+Graph construction should first wrap the existing `_graph_from_metadata()` behavior, then replace it
+with a typed graph adapter once the frontend type contracts are in place.
+
+## Frontend Service Changes
+
+Add types and client functions to `apps/studio/frontend/lib/api.ts` and
+`apps/studio/frontend/lib/types.ts`:
+
+```ts
+export async function getExecutionGraph(
+  kind: "session" | "show" | "invocation",
+  id: string,
+): Promise<ExecutionGraphResponse>;
+
+export async function getSessionMessages(
+  sessionId: string,
+  params?: { opId?: string; includeFullBranch?: boolean },
+): Promise<OperationMessagesResponse>;
+
+export function streamDagActivity(
+  sessionId: string,
+  onEvent: (event: ExecutionActivityEvent) => void,
+): () => void;
+```
+
+New components:
+
+```text
+apps/studio/frontend/components/execution/
+  ExecutionViewerShell.tsx
+  ExecutionSplitPane.tsx
+  ExecutionGraphCanvas.tsx
+  ExecutionNode.tsx
+  ExecutionEdge.tsx
+  ExecutionDetailPanel.tsx
+  ExecutionSummaryPanel.tsx
+  OperationDetailPanel.tsx
+  OperationMessagesPane.tsx
+  EdgeDetailPanel.tsx
+  ToolCallPair.tsx
+  useExecutionActivity.ts
+  graphAdapters.ts
+```
+
+Existing components to reuse or refactor:
+
+- `components/canvas/useLayout` for layout.
+- `components/canvas/WorkerCanvas.tsx` as the ReactFlow implementation reference.
+- `components/canvas/StepNode.tsx` as visual prior art for execution status.
+- `components/canvas/ConditionEdge.tsx` as edge rendering prior art.
+- `ExpectedArtifacts` and `OutcomeRenderer` for artifact sections.
+
+## Coupling And Testability
+
+Target component set:
+
+```text
+C = 8
+ExecutionViewerShell, ExecutionGraphCanvas, ExecutionDetailPanel,
+OperationMessagesPane, ToolCallPair, useExecutionActivity,
+graphAdapters, sessions API service
+```
+
+Allowed direct dependencies:
+
+```text
+Shell -> Canvas, DetailPanel, graphAdapters, useExecutionActivity
+Canvas -> ExecutionNode, ExecutionEdge
+DetailPanel -> Summary, OperationMessagesPane, EdgeDetailPanel
+OperationMessagesPane -> ToolCallPair
+graphAdapters -> API types only
+```
+
+Estimated dependency count after design: 10.
+
+```text
+kappa_after = 10 / (8 * 7) = 0.18
+```
+
+This is below the target of 0.3. The key coupling decision is that `ExecutionViewerShell` owns
+selection and data orchestration; the canvas does not own the side panel. The old `WorkerCanvas`
+keeps its embedded `SidePanel` only for graph editing until it is split.
+
+Testability target:
+
+```text
+tau = 0.85
+```
+
+Required tests:
+
+- Unit tests for graph adapters: agent run, play, show, re-plan chain, show chaining.
+- Unit tests for operation message scoping against segment windows.
+- Unit tests for ToolCallPair matching by `action_request_id` and `action_response_id`.
+- SSE reducer tests for out-of-order and duplicate activity events.
+- Playwright tests for split-pane selection: no selection, node selection, edge selection,
+  full-branch toggle, macro-node expansion.
+
+## Alternatives Considered
+
+| Alternative | Why rejected |
+| --- | --- |
+| Keep separate run, show, and invocation views | Violates the requirement that run types be coherently designed together; duplicates graph, selection, and message-rendering logic. |
+| Make branch transcript the primary view and show DAG as a section | Preserves the current defect: operators cannot understand live graph activity at a glance. |
+| Store ActionRequest and ActionResponse as one backend message | Backend separation is correct for auditability and replay; pairing is a presentation concern. |
+| Scope operation messages only by branch | Fails when one branch executes multiple operations, especially reused agents in FlowPlan. |
+| Require a new execution table before frontend work | Slows delivery unnecessarily. `sessions.node_metadata`, branches, progressions, and messages already support phase 1. |
+| Use the current `PlayDag` as the show viewer | It renders a static play-level DAG but does not handle nested operation DAGs, live activity, or detail selection. |
+
+## Phasing
+
+### Phase 1 - Session Viewer Unification
+
+- Add `components/execution/*` shell, canvas, detail panel, message pane, and ToolCallPair.
+- Route `/runs/{id}` through `ExecutionViewerShell`.
+- Use existing `GET /api/sessions/{id}` graph and segments.
+- Add `GET /api/sessions/{id}/messages?op_id=...`.
+- Keep existing `/api/sessions/{id}/stream`; derive basic node activity client-side.
+
+### Phase 2 - First-Class DAG Activity
+
+- Add `GET /api/sessions/{id}/dag-activity`.
+- Persist or derive per-node latest activity server-side.
+- Add richer statuses: thinking, tool_calling, streaming.
+- Add Playwright coverage for live updates.
+
+### Phase 3 - Show And Invocation Graphs
+
+- Replace `PlayDag` usage with `ExecutionViewerShell` in show detail pages.
+- Add play macro-node expansion to nested session graphs.
+- Add show chaining edges.
+- Use `/invocations/{id}` as a multi-session execution graph, not only a session table.
+
+### Phase 4 - Re-plan And Control Polish
+
+- Persist explicit re-plan edge metadata in `sessions.node_metadata`.
+- Render gate -> re-plan -> new operation chains with distinct edge and node types.
+- Integrate paused/cancelled runtime states from ADR-0056.
+- Add activity retention and time-travel controls if operators need historical playback.
+
+## Consequences
+
+Positive:
+
+- Operators get one graph-first mental model for runs, plays, shows, and invocations.
+- Reused agents no longer leak unrelated branch history into operation detail.
+- Tool calls become readable without changing backend audit semantics.
+- Live execution becomes visible at the DAG level instead of only in transcripts.
+- The show graph and session graph share component and data contracts.
+
+Negative:
+
+- `WorkerCanvas` must be split or wrapped carefully to avoid breaking graph editing surfaces.
+- Segment-window scoping depends on accurate `started_at` and `ended_at`; malformed metadata needs
+  clear fallback behavior.
+- The first phase still has two streams: raw session message stream and derived DAG activity.
+- Show macro-node expansion adds navigation state and breadcrumb complexity.
+
+## Acceptance Criteria
+
+- `/runs/{id}` opens with the DAG canvas as the primary left pane and detail panel on the right.
+- A single-agent run renders as one node.
+- A play/flow renders operation nodes and dependency edges from `sessions.node_metadata`.
+- Clicking an operation fetches only that operation's messages by default.
+- The full branch transcript is available only through an explicit toggle.
+- ActionRequest and ActionResponse render as one `ToolCallPair`.
+- Node latest activity updates live during a running session.
+- Shows render as play macro-node DAGs and can expand to operation DAGs.
+- Re-plan chains are visible as graph continuation, not separate detached runs.
+- Component tests and Playwright coverage pass.
+
+## References
+
+- `apps/studio/frontend/app/runs/[id]/page.tsx`
+- `apps/studio/frontend/app/shows/[topic]/components/PlayDag.tsx`
+- `apps/studio/frontend/components/canvas/WorkerCanvas.tsx`
+- `apps/studio/frontend/components/canvas/SidePanel.tsx`
+- `apps/studio/frontend/components/canvas/StepNode.tsx`
+- `apps/studio/frontend/components/canvas/ConditionEdge.tsx`
+- `apps/studio/frontend/app/invocations/[id]/page.tsx`
+- `apps/studio/server/routers/sessions.py`
+- `apps/studio/server/services/sessions.py`
+- `apps/studio/server/services/runs.py`
+- `apps/studio/server/services/shows.py`
+- `lionagi/cli/orchestrate/flow.py`
+- `lionagi/state/schema.sql`
+
+Domain utility: SKIPPED - no lore suggest/compose tool is available in this environment, so this ADR uses direct repository evidence and existing ADR patterns.

--- a/docs/adrs/ADR-0066-unified-execution-viewer.md
+++ b/docs/adrs/ADR-0066-unified-execution-viewer.md
@@ -796,5 +796,3 @@ Negative:
 - `apps/studio/server/services/shows.py`
 - `lionagi/cli/orchestrate/flow.py`
 - `lionagi/state/schema.sql`
-
-Domain utility: SKIPPED - no lore suggest/compose tool is available in this environment, so this ADR uses direct repository evidence and existing ADR patterns.

--- a/docs/adrs/ADR-0067-studio-command-chat.md
+++ b/docs/adrs/ADR-0067-studio-command-chat.md
@@ -1,0 +1,929 @@
+# ADR-0067: Studio Command Chat - Universal AI-Powered Control Panel
+
+Status: proposed
+Date: 2026-05-27
+Decision owners: @studio-maintainers, @orchestration-maintainers
+Depends on: ADR-0002 (Studio tech stack), ADR-0006 (SSE live streaming), ADR-0009 (SQLite state layer), ADR-0034 (frontend data/state), ADR-0044 (tool gates), ADR-0051 (tool registry allowlists), ADR-0056 (play control API), ADR-0058 (play cost tracking), ADR-0060 (unified config resolution), ADR-0061 (universal scheduler), ADR-0066 (unified execution viewer)
+Related: ADR-0054 (local state cleanup), ADR-0055 (artifact viewer), ADR-0064 (work system integration), ADR-0065 (task board schema)
+
+## Context
+
+Lion Studio must become a coherent product surface for orchestration, not only a monitoring UI over
+terminal-oriented harnesses. Operators should be able to navigate, inspect, modify, run, schedule,
+pause, cancel, summarize, and clean up work through one natural-language panel while still seeing
+typed, auditable actions.
+
+The current backend already has the shape needed for this. `apps/studio/server/app.py` wires a
+FastAPI application with routers for runs, sessions, definitions, agents, playbooks, shows, skills,
+plugins, admin, teams, invocations, artifacts, projects, and schedules. The middleware gates
+mutating `/api/*` requests when `LIONAGI_STUDIO_AUTH_TOKEN` is set, but WebSocket routes require an
+explicit authentication handshake because browser WebSocket clients cannot set arbitrary
+`Authorization` headers.
+
+The current frontend shell in `apps/studio/frontend/components/Shell.tsx` owns global navigation,
+theme toggling, breadcrumbs, and the main content region. This is the correct integration point for
+a persistent right-side command chat because it must be available on dashboard, runs, shows,
+playbooks, schedules, cost, and future execution viewer pages. Page-level components remain
+responsible for their own domain rendering; the command chat receives context snapshots and emits
+navigation or rendering directives.
+
+The runtime already supports an internal agent. `lionagi/session/branch.py` creates a `Branch` with
+message management, an `ActionManager`, configurable `iModel` instances, and `operate()` /
+`run()` methods. `lionagi/protocols/action/tool.py` wraps callables as typed tools with generated
+schemas. Studio Command Chat should use this LionAGI runtime directly. It must not require Claude
+Code, Codex, or any other harness provider as the chat backend. External harnesses may still be
+targets of flows during early phases, but they are not the chat control plane.
+
+The product requirement is broader than a chatbot. The panel must operate as a universal AI-powered
+control panel with typed tools, confirmations, history, search, context injection, rich inline
+responses, and a staged path away from CLI wrapping toward direct programmatic orchestration.
+
+Coupling estimate after this decision: components `{ChatRouter, ChatCoordinator, BranchRuntime,
+StudioToolRegistry, ServerToolAdapters, ClientEffectBridge, ChatHistoryStore, ChatRateLimiter,
+StudioChatPanel, StudioContextProvider, ChatRenderers, ExistingStudioServices}` with intended deps
+`{ChatRouter->ChatCoordinator, ChatRouter->ChatRateLimiter, ChatRouter->ChatHistoryStore,
+ChatCoordinator->BranchRuntime, ChatCoordinator->StudioToolRegistry,
+ChatCoordinator->ChatHistoryStore, ChatCoordinator->ClientEffectBridge,
+BranchRuntime->StudioToolRegistry, StudioToolRegistry->ServerToolAdapters,
+StudioToolRegistry->ClientEffectBridge, ServerToolAdapters->ExistingStudioServices,
+StudioChatPanel->StudioContextProvider, StudioChatPanel->ChatRenderers,
+StudioChatPanel->ClientEffectBridge, ChatRateLimiter->ChatHistoryStore}` gives
+`15 / (12 * 11) = 0.11`. This stays below 0.3 because domain APIs remain behind tool adapters and
+client-only effects remain behind a browser effect bridge.
+
+## Decision
+
+Add Studio Command Chat: a persistent, collapsible right-side panel backed by a new
+`apps/studio/server/routers/chat.py` WebSocket API at `/api/chat/ws`. The backend runs a LionAGI
+`Branch` with a Studio tool registry. The frontend sends page context snapshots and user messages;
+the backend streams assistant tokens, tool calls, tool results, render directives, navigation
+directives, and confirmation requests over the same WebSocket. Chat history is persisted in
+`state.db` through a new `chat_messages` table and searchable FTS index.
+
+The chat agent has two tool classes:
+
+- Server tools: query or mutate backend state through existing Studio services, StateStore, and
+  Phase 0 allowlisted `li` CLI wrappers.
+- Client effect tools: request browser-side effects such as navigation, theme setting, canvas
+  drafting, and inline rendering. These complete only after the connected client acknowledges the
+  effect.
+
+The default model is resolved from `LIONAGI_STUDIO_CHAT_MODEL`; if unset, the runtime falls back to
+`LIONAGI_CHAT_MODEL` and the existing LionAGI iModel settings. Provider-specific settings remain
+configurable through the normal iModel configuration path.
+
+## Component Architecture
+
+```mermaid
+flowchart LR
+  User[Operator] --> Panel[StudioChatPanel]
+  Panel --> Context[StudioContextProvider]
+  Panel <--> WS[WebSocket /api/chat/ws]
+  WS --> Router[apps/studio/server/routers/chat.py]
+  Router --> Auth[WebSocket auth + rate limit]
+  Auth --> Coordinator[ChatCoordinator]
+  Coordinator --> History[ChatHistoryStore state.db]
+  Coordinator --> Branch[LionAGI Branch]
+  Branch --> Registry[StudioToolRegistry]
+  Registry --> ServerTools[ServerToolAdapters]
+  Registry --> ClientBridge[ClientEffectBridge]
+  ServerTools --> Services[Existing Studio services]
+  ServerTools --> CLI[Phase 0 allowlisted li CLI]
+  Services --> State[(state.db / StateStore)]
+  Branch --> IModel[iModel provider]
+  ClientBridge --> WS
+  WS --> Panel
+  Panel --> Renderers[Tables charts DAG previews artifacts code]
+  Panel --> RouterNav[Next.js router + UI preferences]
+```
+
+### Tool Call Sequence
+
+```mermaid
+sequenceDiagram
+  participant U as Operator
+  participant P as StudioChatPanel
+  participant C as ChatCoordinator
+  participant B as LionAGI Branch
+  participant T as StudioToolRegistry
+  participant S as Studio services
+
+  U->>P: "Show me running flows"
+  P->>C: user_message + current page context
+  C->>B: operate(instruction, context, tools)
+  B->>T: call query_runs(filters={status:["running"], invocation_kind:["flow","play"]})
+  T->>S: list runs via existing service
+  S-->>T: matching runs
+  T-->>B: normalized table result
+  B->>T: call navigate(page="runs", params={status:"running"})
+  T-->>P: navigation directive
+  P-->>T: client_effect_ack
+  B-->>C: assistant summary
+  C-->>P: assistant_delta, render(table), done
+  C->>C: persist chat_messages
+```
+
+## Backend Architecture
+
+### Router
+
+Add `apps/studio/server/routers/chat.py` and include it from `apps/studio/server/app.py` with the
+same `/api` prefix as existing routers.
+
+Required routes:
+
+| Route | Purpose |
+| --- | --- |
+| `POST /api/chat/ws-ticket` | Authenticated HTTP route that exchanges the existing bearer token for a short-lived WebSocket ticket. |
+| `GET /api/chat/ws` | WebSocket endpoint. Browser clients connect with `?ticket=...`; non-browser clients may use an `Authorization` header. |
+| `GET /api/chat/history` | Paginated conversation history for the current project, page, or entity. |
+| `GET /api/chat/search` | Full-text search over persisted chat messages. |
+
+The ticket route is a handshake companion, not a second chat transport. It preserves the existing
+bearer-token auth model without placing the long-lived Studio token in a WebSocket URL.
+
+### Coordinator
+
+`ChatCoordinator` owns one live conversation connection:
+
+- validates and enriches client context;
+- loads recent persisted history into a `Branch`;
+- registers the current Studio tool registry;
+- invokes `Branch.operate()` with tool execution enabled;
+- streams assistant deltas and tool events to the client;
+- persists every user message, assistant message, tool call, tool result, render directive, and
+  error as `chat_messages`;
+- manages pending confirmations and client-effect acknowledgements;
+- enforces timeout, cancellation, rate limit, and idempotency policy.
+
+### History Storage
+
+Add a `chat_messages` table to `lionagi/state/schema.sql`:
+
+```sql
+CREATE TABLE IF NOT EXISTS chat_messages (
+  id                  TEXT PRIMARY KEY,
+  conversation_id     TEXT NOT NULL,
+  project             TEXT,
+  user_id             TEXT,
+  created_at          REAL NOT NULL,
+  role                TEXT NOT NULL CHECK(role IN (
+                        'system', 'user', 'assistant', 'tool', 'client', 'error'
+                      )),
+  frame_type          TEXT NOT NULL,
+  content_json        JSON NOT NULL,
+  content_text        TEXT,
+  parent_message_id   TEXT REFERENCES chat_messages(id),
+  request_id          TEXT,
+  tool_call_id        TEXT,
+  tool_name           TEXT,
+  tool_status         TEXT,
+  current_path        TEXT,
+  context_refs        JSON,
+  render_refs         JSON,
+  token_usage_json    JSON,
+  error_json          JSON,
+  connection_sequence INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_chat_messages_conversation_created
+  ON chat_messages(conversation_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_chat_messages_project_created
+  ON chat_messages(project, created_at DESC) WHERE project IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_chat_messages_tool
+  ON chat_messages(tool_name, created_at DESC) WHERE tool_name IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_chat_messages_resume
+  ON chat_messages(conversation_id, connection_sequence)
+  WHERE connection_sequence IS NOT NULL;
+
+CREATE VIRTUAL TABLE IF NOT EXISTS chat_messages_fts
+  USING fts5(id UNINDEXED, conversation_id UNINDEXED, project UNINDEXED, content_text);
+```
+
+`conversation_id` is generated by the client for the panel session and may be reused across
+reconnects. `project` comes from ADR-0026 project detection when available. `content_json` is the
+canonical payload. `content_text` is a redacted search projection.
+
+`connection_sequence` records the per-connection monotonic sequence number assigned by the server
+when a frame is persisted. On reconnect with `resume_after_sequence: N`, the server executes:
+
+```sql
+SELECT * FROM chat_messages
+WHERE conversation_id = ? AND connection_sequence > ?
+ORDER BY connection_sequence;
+```
+
+This maps the connection-local sequence space to durable rows, enabling deterministic replay.
+Frames that predate `connection_sequence` tracking (e.g., rows inserted before this column was
+added) have `NULL` and are excluded from resume queries; they remain visible through
+`GET /api/chat/history`.
+
+## Frontend Architecture
+
+Add a shell-level component tree:
+
+```mermaid
+flowchart TD
+  Shell[components/Shell.tsx] --> Provider[ChatProvider]
+  Provider --> Panel[StudioChatPanel]
+  Provider --> Context[StudioContextProvider]
+  Panel --> Header[ChatHeader collapse model status]
+  Panel --> Messages[ChatMessageList]
+  Panel --> Composer[ChatComposer Cmd+K focus]
+  Messages --> Markdown[MarkdownRenderer]
+  Messages --> Table[ToolTableRenderer]
+  Messages --> Chart[CostChartRenderer recharts]
+  Messages --> DAG[MiniDagRenderer ReactFlow]
+  Messages --> Artifact[ArtifactPreviewRenderer]
+  Messages --> Confirm[ActionConfirmationCard]
+  Provider --> Effects[ClientEffectExecutor]
+  Effects --> Nav[Next router navigation]
+  Effects --> Theme[Theme/localStorage]
+  Effects --> Canvas[Canvas draft store]
+```
+
+Frontend requirements:
+
+- persistent right-side panel on desktop, overlay drawer on narrow screens;
+- collapsible with state in local storage;
+- `Cmd+K` focuses the chat composer when the panel is open and opens it when collapsed;
+- message list supports markdown, code blocks, tables, charts, mini DAG previews, artifact previews,
+  and action confirmation cards;
+- tool results are rendered through typed renderers, not raw JSON dumps;
+- current route, selected entity, visible filters, table summaries, and selected canvas nodes are
+  sent as `context_update` frames;
+- navigation, theme changes, and canvas drafts are executed only after validating a server directive
+  against the client effect schema.
+
+## WebSocket Protocol
+
+All frames are JSON objects with protocol version `1`.
+
+```ts
+export interface ChatFrame<TType extends string = string, TPayload = unknown> {
+  v: 1;
+  type: TType;
+  request_id: string;
+  conversation_id: string;
+  sequence: number;
+  created_at: number;
+  payload: TPayload;
+}
+```
+
+### Client to Server Frames
+
+```ts
+export type ClientChatFrame =
+  | ChatFrame<"hello", HelloPayload>
+  | ChatFrame<"user_message", UserMessagePayload>
+  | ChatFrame<"context_update", StudioContextSnapshot>
+  | ChatFrame<"confirmation_response", ConfirmationResponsePayload>
+  | ChatFrame<"client_effect_ack", ClientEffectAckPayload>
+  | ChatFrame<"cancel_request", CancelRequestPayload>
+  | ChatFrame<"ping", { now: number }>;
+
+export interface HelloPayload {
+  project?: string | null;
+  resume_after_sequence?: number | null;
+  client_capabilities: Array<"navigation" | "theme" | "canvas" | "charts" | "dag_preview">;
+}
+
+export interface UserMessagePayload {
+  message_id: string;
+  text: string;
+  attachments?: ChatAttachmentRef[];
+  context?: StudioContextSnapshot;
+}
+
+export interface StudioContextSnapshot {
+  current_path: string;
+  route_kind?: "dashboard" | "runs" | "run_detail" | "shows" | "show_detail" | "playbooks" | "schedules" | "cost" | "settings" | "unknown";
+  project?: string | null;
+  selected_entity?: {
+    type: "run" | "show" | "play" | "schedule" | "artifact" | "dag_node" | "project";
+    id: string;
+    label?: string;
+  } | null;
+  visible_filters?: Record<string, string | number | boolean | string[] | null>;
+  visible_summary?: Record<string, unknown>;
+  redaction_level: "low" | "standard" | "strict";
+}
+
+export interface ConfirmationResponsePayload {
+  confirmation_id: string;
+  decision: "approve" | "reject";
+  reason?: string;
+}
+
+export interface ClientEffectAckPayload {
+  effect_id: string;
+  status: "applied" | "rejected" | "failed";
+  error?: string;
+}
+
+export interface CancelRequestPayload {
+  target_request_id: string;
+  reason?: string;
+}
+
+export interface ChatAttachmentRef {
+  kind: "artifact" | "file" | "image" | "selection";
+  id: string;
+  label?: string;
+}
+```
+
+### Server to Client Frames
+
+```ts
+export type ServerChatFrame =
+  | ChatFrame<"hello_ack", HelloAckPayload>
+  | ChatFrame<"assistant_delta", AssistantDeltaPayload>
+  | ChatFrame<"assistant_message", AssistantMessagePayload>
+  | ChatFrame<"tool_call", ToolCallFrame>
+  | ChatFrame<"tool_result", ToolResultFrame>
+  | ChatFrame<"render", RenderFrame>
+  | ChatFrame<"client_effect", ClientEffectFrame>
+  | ChatFrame<"confirmation_required", ConfirmationRequiredPayload>
+  | ChatFrame<"rate_limited", RateLimitedPayload>
+  | ChatFrame<"error", ChatErrorPayload>
+  | ChatFrame<"done", DonePayload>
+  | ChatFrame<"pong", { now: number }>;
+
+export interface HelloAckPayload {
+  server_capabilities: Array<"streaming" | "tools" | "confirmations" | "history" | "resume">;
+  model: string;
+  max_context_bytes: number;
+  conversation_id: string;
+}
+
+export interface AssistantDeltaPayload {
+  message_id: string;
+  text_delta: string;
+}
+
+export interface AssistantMessagePayload {
+  message_id: string;
+  text: string;
+  renders?: string[];
+}
+
+export interface DonePayload {
+  message_id?: string;
+  status: "completed" | "cancelled" | "failed";
+}
+```
+
+### Ordering, Resume, and Heartbeat
+
+- The server assigns monotonic `sequence` numbers per WebSocket connection.
+- The client sends `resume_after_sequence` in `hello` after reconnect. The server replays persisted
+  frames that have durable `chat_messages` rows and then resumes live streaming.
+- The server sends a `ping` frame every 30 seconds regardless of request state. If the client does
+  not respond with a `pong` within 10 seconds, the server closes the connection. This prevents
+  infrastructure-level idle timeouts on load balancers and mobile networks.
+- Duplicate `request_id` values are idempotent for `user_message`, `confirmation_response`, and
+  `client_effect_ack`.
+
+### Error Codes
+
+| Code | Meaning | Client behavior |
+| --- | --- | --- |
+| `auth_failed` | Missing or invalid bearer token/ticket. | Close panel connection and show signed-out state. |
+| `rate_limited` | Per-session or per-project budget exceeded. | Display retry time. |
+| `validation_failed` | Frame or tool args failed schema validation. | Show non-terminal error. |
+| `tool_denied` | Tool is not allowed by policy or current user capability. | Show denied action card. |
+| `confirmation_required` | Mutating action requires approval. | Render confirmation card. |
+| `confirmation_expired` | Approval window elapsed. | Ask user to retry. |
+| `client_effect_failed` | Browser did not apply a directive. | Let agent recover or explain. |
+| `model_error` | iModel call failed. | Persist error and allow retry. |
+| `server_error` | Unexpected backend exception. | Persist error and close active request. |
+| `stale_client_context` | Context is too old for requested effect. | Request fresh context. |
+
+## Message Schema
+
+Protocol messages are not the same as runtime `lionagi.protocols.messages` rows. Chat messages are a
+Studio-facing audit log that references Branch messages when available.
+
+```python
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any, Literal
+from pydantic import BaseModel, Field
+
+
+class ChatRole(StrEnum):
+    SYSTEM = "system"
+    USER = "user"
+    ASSISTANT = "assistant"
+    TOOL = "tool"
+    CLIENT = "client"
+    ERROR = "error"
+
+
+class ChatFrameType(StrEnum):
+    HELLO = "hello"
+    USER_MESSAGE = "user_message"
+    CONTEXT_UPDATE = "context_update"
+    ASSISTANT_DELTA = "assistant_delta"
+    ASSISTANT_MESSAGE = "assistant_message"
+    TOOL_CALL = "tool_call"
+    TOOL_RESULT = "tool_result"
+    RENDER = "render"
+    CLIENT_EFFECT = "client_effect"
+    CONFIRMATION_REQUIRED = "confirmation_required"
+    ERROR = "error"
+    DONE = "done"
+
+
+class ChatMessageRecord(BaseModel):
+    id: str
+    conversation_id: str
+    project: str | None = None
+    user_id: str | None = None
+    created_at: float
+    role: ChatRole
+    frame_type: ChatFrameType
+    content_json: dict[str, Any]
+    content_text: str | None = None
+    parent_message_id: str | None = None
+    request_id: str | None = None
+    branch_message_id: str | None = None
+    tool_call_id: str | None = None
+    tool_name: str | None = None
+    tool_status: Literal["pending", "completed", "failed", "denied"] | None = None
+    current_path: str | None = None
+    context_refs: dict[str, Any] = Field(default_factory=dict)
+    render_refs: list[str] = Field(default_factory=list)
+    token_usage_json: dict[str, Any] | None = None
+    error_json: dict[str, Any] | None = None
+```
+
+## Studio Tool Registry
+
+Every tool has a typed argument model, a risk classification, a renderer contract, and a permission
+policy. Tools are registered with LionAGI `Branch.register_tools()` as callable adapters, but the
+registry remains Studio-owned so the UI can introspect names, risk levels, confirmation rules, and
+renderers.
+
+### TypeScript Tool Contracts
+
+```ts
+export type StudioToolName =
+  | "navigate"
+  | "query_runs"
+  | "query_shows"
+  | "execute_flow"
+  | "control_play"
+  | "schedule_create"
+  | "cost_query"
+  | "state_health"
+  | "state_cleanup"
+  | "artifact_fetch"
+  | "config_update"
+  | "canvas_draft"
+  | "theme_set"
+  | "bulk_action";
+
+export type ToolRisk = "read" | "navigate" | "draft" | "mutate" | "execute" | "admin";
+export type RenderKind = "text" | "table" | "chart" | "dag_preview" | "artifact" | "code" | "confirmation";
+
+export interface StudioToolSpec<TArgs = unknown> {
+  name: StudioToolName;
+  description: string;
+  risk: ToolRisk;
+  requires_confirmation: boolean;
+  client_effect: boolean;
+  render_kind: RenderKind;
+  args_schema: TArgs;
+}
+
+export interface NavigateArgs {
+  page: "dashboard" | "runs" | "run_detail" | "shows" | "show_detail" | "playbooks" | "schedules" | "cost" | "settings";
+  params?: Record<string, string | number | boolean | null>;
+}
+
+export interface QueryRunsArgs {
+  filters: {
+    status?: string[];
+    project?: string;
+    playbook?: string;
+    show_topic?: string;
+    started_after?: number;
+    started_before?: number;
+    text?: string;
+  };
+  limit?: number;
+}
+
+export interface ExecuteFlowArgs {
+  spec: {
+    kind: "agent" | "flow" | "fanout" | "play";
+    name?: string;
+    prompt?: string;
+    effort?: "low" | "medium" | "high" | "xhigh";
+    args?: Record<string, string | number | boolean>;
+    dag?: CanvasDagSpec;
+  };
+  idempotency_key: string;
+}
+
+export interface ControlPlayArgs {
+  play_id: string;
+  action: "pause" | "resume" | "cancel" | "kill" | "retry";
+  reason: string;
+  cascade?: boolean;
+}
+// Note: action "kill" results in ExecutionStatus "aborted" on the viewer side
+// (per ADR-0066 vocabulary). The done frame carries status: "cancelled" for
+// soft cancel and the execution viewer reflects "aborted" for kill.
+
+export interface BulkActionArgs {
+  entity_type: "run" | "play" | "schedule" | "artifact";
+  filter: Record<string, unknown>;
+  action: "cancel" | "archive" | "cleanup" | "disable" | "delete";
+  reason: string;
+  dry_run?: boolean;
+}
+
+export interface CanvasDagSpec {
+  nodes: Array<{ id: string; role?: string; prompt: string; depends_on?: string[] }>;
+  edges?: Array<{ source: string; target: string; condition?: string }>;
+}
+```
+
+### Python Tool Contracts
+
+```python
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any, Awaitable, Callable, Literal, Protocol
+from pydantic import BaseModel, Field
+
+
+class StudioToolName(StrEnum):
+    NAVIGATE = "navigate"
+    QUERY_RUNS = "query_runs"
+    QUERY_SHOWS = "query_shows"
+    EXECUTE_FLOW = "execute_flow"
+    CONTROL_PLAY = "control_play"
+    SCHEDULE_CREATE = "schedule_create"
+    COST_QUERY = "cost_query"
+    STATE_HEALTH = "state_health"
+    STATE_CLEANUP = "state_cleanup"
+    ARTIFACT_FETCH = "artifact_fetch"
+    CONFIG_UPDATE = "config_update"
+    CANVAS_DRAFT = "canvas_draft"
+    THEME_SET = "theme_set"
+    BULK_ACTION = "bulk_action"
+
+
+class ToolRisk(StrEnum):
+    READ = "read"
+    NAVIGATE = "navigate"
+    DRAFT = "draft"
+    MUTATE = "mutate"
+    EXECUTE = "execute"
+    ADMIN = "admin"
+
+
+class StudioToolContext(BaseModel):
+    conversation_id: str
+    request_id: str
+    project: str | None = None
+    user_id: str | None = None
+    current_path: str | None = None
+    selected_entity: dict[str, Any] | None = None
+    dry_run: bool = False
+
+
+class ToolResult(BaseModel):
+    ok: bool
+    summary: str
+    data: dict[str, Any] = Field(default_factory=dict)
+    render: dict[str, Any] | None = None
+    client_effect: dict[str, Any] | None = None
+    error: dict[str, Any] | None = None
+
+
+class NavigateArgs(BaseModel):
+    page: Literal["dashboard", "runs", "run_detail", "shows", "show_detail", "playbooks", "schedules", "cost", "settings"]
+    params: dict[str, str | int | float | bool | None] = Field(default_factory=dict)
+
+
+class QueryRunsArgs(BaseModel):
+    filters: dict[str, Any] = Field(default_factory=dict)
+    limit: int = Field(default=20, ge=1, le=200)
+
+
+class ExecuteFlowArgs(BaseModel):
+    spec: dict[str, Any]
+    idempotency_key: str = Field(min_length=8, max_length=128)
+
+
+class ControlPlayArgs(BaseModel):
+    play_id: str
+    action: Literal["pause", "resume", "cancel", "kill", "retry"]
+    reason: str = Field(min_length=1, max_length=1000)
+    cascade: bool = False
+    # action "kill" → ExecutionStatus "aborted" in ADR-0066 execution viewer vocabulary.
+
+
+class StudioTool(Protocol):
+    name: StudioToolName
+    risk: ToolRisk
+    requires_confirmation: bool
+    client_effect: bool
+
+    async def __call__(self, args: BaseModel, ctx: StudioToolContext) -> ToolResult: ...
+
+
+ToolCallable = Callable[[BaseModel, StudioToolContext], Awaitable[ToolResult]]
+```
+
+### Tool Catalog
+
+| Tool | Risk | Confirmation | Execution boundary |
+| --- | --- | --- | --- |
+| `navigate(page, params)` | `navigate` | No | Client effect through Next router. |
+| `query_runs(filters)` | `read` | No | Existing runs/sessions services. |
+| `query_shows(filters)` | `read` | No | Existing shows service. |
+| `execute_flow(spec)` | `execute` | Yes | Phase 0 CLI wrapper; later direct Session/flow API. |
+| `control_play(play_id, action)` | `execute` | Yes for cancel/kill/retry, optional for pause/resume | ADR-0056 control service. |
+| `schedule_create(spec)` | `mutate` | Yes | ADR-0061 schedules service. |
+| `cost_query(timeframe, group_by)` | `read` | No | ADR-0058 cost state. |
+| `state_health()` | `read` | No | Admin/stat services with read-only diagnostic projection. |
+| `state_cleanup(filters)` | `admin` | Yes | ADR-0054 cleanup service, dry-run first. |
+| `artifact_fetch(id_or_query)` | `read` | No | ADR-0055 artifact viewer service. |
+| `config_update(resource, key, value)` | `admin` | Yes | ADR-0060 config writer with audit. |
+| `canvas_draft(dag_spec)` | `draft` | No to draft, Yes to persist/run | Client canvas store. |
+| `theme_set(mode)` | `navigate` | No | Client preference/local storage. |
+| `bulk_action(entity_type, filter, action)` | `admin` | Always | Dry-run preview, then confirmed execution. |
+
+## Security and Governance
+
+- WebSocket authentication is explicit in `chat.py`; it does not rely on HTTP middleware.
+- Browser clients use `POST /api/chat/ws-ticket` with the existing bearer token, then connect with a
+  short-lived one-use ticket.
+- Non-browser clients may pass the same bearer token in `Authorization` during the WebSocket
+  handshake.
+- Rate limits are per `conversation_id`, per project, and per remote address. Defaults are
+  configurable through `LIONAGI_STUDIO_CHAT_RATE_LIMIT_PER_MINUTE` and
+  `LIONAGI_STUDIO_CHAT_MAX_ACTIVE_REQUESTS`.
+- Mutating, executing, and admin tools require confirmation unless a future policy explicitly grants
+  a narrower safe path.
+- Bulk actions always run a dry-run first and present the matched entity count before execution.
+- Tool calls persist actor, request id, tool name, arguments after redaction, confirmation decision,
+  result summary, and error data.
+- Secrets and full environment dumps are never inserted into chat context. Context snapshots are
+  redacted before Branch invocation.
+- Phase 0 CLI wrapping is allowlisted to known `li` commands and uses argv arrays, not shell strings.
+- `config_update` and `state_cleanup` require admin capability even if the global Studio bearer token
+  is present.
+
+## Context Injection
+
+The frontend sends context on connection, route change, selected entity change, and before every
+user message. Context is bounded and summarized:
+
+- current route and route kind;
+- project name and source when known;
+- selected run/show/play/schedule/artifact/canvas node;
+- visible filters and time range chips;
+- table summaries, not full table dumps, unless the user explicitly references selected rows;
+- current DAG/canvas draft metadata;
+- redaction level and context byte size.
+
+The backend validates `current_path` and entity identifiers before using them in tools. Stale
+context older than 30 seconds is acceptable for read-only questions but rejected for mutating,
+executing, and admin tools unless the tool first refreshes the target from the server.
+
+When a DAG node is selected in the execution viewer (ADR-0066), `StudioContextSnapshot.selected_entity`
+carries `type: "dag_node"` with the node's `op_id` in the `id` field. Leo can use this to answer
+questions about that specific operation — its status, logs, cost, inputs, or outputs — without
+requiring the operator to identify the node by name.
+
+## Identity: This Agent Is Leo (λ₀)
+
+The Studio Command Chat agent is Leo (λ₀) — the global meta-orchestrator from the Lion ecosystem
+identity system. Leo is not "a chat feature bolted onto Studio." Leo IS the product surface through
+which operators interact with the entire intelligence operating system.
+
+### System Prompt Template
+
+The system prompt is assembled at session start by interpolating the current context snapshot and
+brain posteriors into a schematic template. Placeholder slots are resolved server-side before the
+`Branch` is initialized:
+
+```text
+You are Leo (λ₀), the Studio Command Chat agent for {project_name}.
+
+Current context:
+- Page: {current_route}
+- Selected: {selected_entity_summary}
+- User preference: {brain.verbosity} verbosity, {brain.output_format} format
+
+Available tools: {tool_list_summary}
+
+Style: {brain.tone} tone, {brain.technical_depth} depth.
+When unsure, ask — never execute destructive actions without confirmation.
+```
+
+`{project_name}` is resolved via ADR-0026 project detection; falls back to `"this project"`.
+`{current_route}` and `{selected_entity_summary}` come from the most recent `StudioContextSnapshot`.
+`{brain.*}` slots are pulled from the operator's brain profile posteriors; if no profile exists the
+slot defaults are `standard` verbosity, `mixed` format, `direct` tone, and `intermediate` depth.
+`{tool_list_summary}` is a comma-separated list of available tool names for the current capability
+set, kept under 200 characters to avoid token bloat.
+
+### Brain Plugin Integration
+
+Each Studio user gets a dedicated brain profile (via the `brain` khive plugin). The brain profile
+stores:
+
+- **Priors and posteriors**: learned preferences for layout, verbosity, default model, theme, and
+  workflow patterns.
+- **Feedback loop**: explicit feedback events (`brain.feedback`) update posteriors so Leo adapts to
+  each operator over time.
+- **Profile resolution**: `brain.resolve` maps caller context (user ID, namespace, consumer kind) to
+  the correct profile. Multiple users on the same Studio instance get independent Leo experiences.
+- **Lifecycle**: profiles follow `brain.create_profile` → `brain.activate` → `brain.deactivate` →
+  `brain.archive`.
+
+### Personalization via Brain Profiles
+
+Leo uses brain posteriors to personalize:
+
+- **Frontend customization**: theme, layout density, default page, sidebar collapsed state,
+  preferred chart type, canvas zoom level. These preferences are stored as brain profile properties
+  and applied as client effects on session start.
+- **Response style**: verbosity level, technical depth, preferred output format (table vs prose vs
+  code). The system prompt template interpolates brain posteriors.
+- **Workflow defaults**: preferred model, default effort level, common tool presets, frequent
+  schedule patterns. Leo suggests based on learned patterns.
+- **Context awareness**: Leo remembers what the operator was working on across sessions via brain
+  event history, without requiring explicit "remember this" commands.
+
+### Progressive Product Independence
+
+Leo in Studio is the first step toward full product autonomy:
+
+1. **Phase 0**: Leo wraps CLI commands, learns user patterns → users stop switching to terminal
+2. **Phase 1**: Leo calls Studio APIs directly → CLI becomes fallback
+3. **Phase 2**: Leo queries StateStore directly → monitoring through chat
+4. **Phase 3**: Leo composes flows programmatically → new flows without CLI
+5. **Phase 4**: Leo orchestrates multi-step plans end-to-end → terminal optional
+6. **Future**: Leo replaces CLI orchestration entirely → full independence from external harnesses
+
+This progression means lionagi becomes a coherent product: plays fire from the frontend, scheduling
+happens through Leo, remote agents run isolated, and the entire workflow lifecycle is managed through
+one intelligent surface. Cloud offerings (remote Leo instances, hosted scheduling, managed play
+execution) follow naturally once the local product surface is complete.
+
+## Progressive Independence Phasing
+
+| Phase | Goal | Implementation | Harness dependency reduced | Estimated net LOC |
+| --- | --- | --- | --- | --- |
+| 0 | Useful chat with minimal backend surgery | WebSocket router, Branch runtime, history table, frontend panel, read tools, client effects, allowlisted `li` CLI wrappers for execute/schedule/control where APIs are not ready | Users stop switching to terminal for common Studio tasks, but execution still shells out for some commands | 2,200-3,200 |
+| 1 | Prefer Studio APIs over CLI | Replace wrappers with direct calls to runs, shows, schedules, control, artifact, cleanup, and config services; add confirmation workflow and idempotency | CLI becomes fallback, not primary tool path | 1,500-2,300 |
+| 2 | Direct StateStore queries for analytics and search | Add typed query adapters for sessions, shows, costs, artifacts, schedules, chat history, and health; add FTS search and cost chart renderers | Monitoring questions no longer invoke CLI or page-specific fetch glue | 1,000-1,600 |
+| 3 | Programmatic flow composition | Add `Session.flow()` / flow service adapter for create, draft, validate, and execute; canvas DAG and chat DAG share one typed spec | New flows no longer require CLI command rendering | 2,000-3,200 |
+| 4 | Chat as orchestrator | Chat coordinates multi-step plans, schedules, control gates, re-plans, artifacts, and task-board updates as first-class orchestration | Terminal usage becomes optional for normal Studio operation | 2,500-4,000 |
+
+Total expected net new or moved LOC across all phases: 9,200-14,300. Phase 0 is the minimum
+marketable slice; phases 1-4 are staged independence work.
+
+## Failure Modes
+
+| Failure | Required behavior |
+| --- | --- |
+| WebSocket disconnects mid-response | Persist completed frames, let client reconnect with `resume_after_sequence`, cancel active model call after grace period if no client returns. |
+| Model provider unavailable | Persist `model_error`, render retry action, do not lose user message. |
+| Tool validation fails | Return `validation_failed` with field errors; do not invoke the tool. |
+| Tool execution fails | Persist tool error and let Branch summarize the failure with next actions. |
+| Confirmation times out | Mark tool call denied with `confirmation_expired`; no side effect occurs. |
+| Client navigation/theme/canvas effect fails | Persist `client_effect_failed` and ask the agent to recover or explain. |
+| Rate limit exceeded | Return `rate_limited` with retry timestamp before invoking model or tools. |
+| State DB unavailable | Reject new chat requests with `server_error`; do not run mutating tools without audit persistence. |
+| Phase 0 CLI subprocess hangs | Enforce timeout, kill process group, persist failure, and surface command summary. |
+| Stale context for mutation | Reject with `stale_client_context`; require refreshed context or explicit target id. |
+
+## Testability
+
+Target testability `tau > 0.8`.
+
+Required tests:
+
+- unit tests for Pydantic frame validation, message persistence, FTS redaction projection, and
+  tool argument schemas;
+- unit tests for rate limiter and WebSocket ticket expiry/one-use semantics;
+- tool adapter tests using fake Studio services and fake `li` subprocess runners;
+- Branch runtime tests with a scripted fake iModel that emits tool calls and streaming deltas;
+- frontend hook tests for reconnect, frame ordering, client-effect acknowledgement, and
+  confirmation cards;
+- integration test for "Show me running flows" resulting in `query_runs`, table render, and
+  navigation directive;
+- integration test for "Cancel all stale runs older than 2 hours" requiring dry-run preview and
+  explicit confirmation before control calls;
+- browser-level smoke test that the panel opens with `Cmd+K`, streams a response, renders a table,
+  and applies a theme directive.
+
+## Implementation Notes
+
+Phase 0 files:
+
+- `apps/studio/server/routers/chat.py`
+- `apps/studio/server/services/chat.py`
+- `apps/studio/server/services/chat_history.py`
+- `apps/studio/server/services/chat_tools.py`
+- `apps/studio/frontend/components/chat/*`
+- `apps/studio/frontend/lib/chat-types.ts`
+- `apps/studio/frontend/lib/chat-ws.ts`
+- `lionagi/state/schema.sql`
+
+`apps/studio/server/app.py` must include `chat.router` under `/api`. Because WebSocket auth is
+route-specific, `chat.py` must duplicate the bearer-token check for non-browser clients and validate
+ticket auth for browser clients.
+
+The first model-resolution implementation should be:
+
+```python
+chat_model = os.getenv("LIONAGI_STUDIO_CHAT_MODEL") or os.getenv("LIONAGI_CHAT_MODEL")
+branch = Branch(chat_model=chat_model, tools=studio_tools, system=studio_system_prompt)
+```
+
+If `chat_model` is `None`, `Branch` falls back to the existing iModel defaults.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+| --- | --- |
+| Keep Studio as a conventional dashboard only | Does not meet the strategic goal of a coherent product surface where users can operate workflows without learning every page. |
+| Back the panel with Claude Code, Codex, or another harness | Violates the independence requirement. Harnesses may execute work during migration, but the chat control plane must be LionAGI-native. |
+| HTTP POST plus SSE streaming only | Existing SSE is good for one-way live data, but chat needs bidirectional confirmations, client-effect acknowledgements, cancellation, and context updates. |
+| Regex or command-intent router instead of a Branch with tools | Too brittle for contextual operations like failure explanation, DAG edits, and cost projection. It also duplicates tool semantics outside LionAGI. |
+| Let the model directly call arbitrary CLI commands | Fails policy, audit, and safety requirements. Phase 0 allows only typed, allowlisted `li` wrappers with timeouts and confirmation gates. |
+| Encode navigation as assistant text instructions | Breaks the product promise. Navigation must be a typed client effect with acknowledgement, not prose that the user manually follows. |
+
+## Consequences
+
+Positive:
+
+- Studio gains one universal control surface for navigation, monitoring, workflow operations,
+  configuration, cleanup, scheduling, and contextual explanations.
+- The system moves toward LionAGI-native orchestration while preserving a practical Phase 0 path.
+- Tool actions become typed, auditable, confirmable, and renderable.
+- Frontend context makes the same user phrase meaningful on run detail, DAG, cost, and dashboard
+  pages without hard-coding page-specific chatbots.
+- Coupling remains low because server tools, client effects, history, and runtime are separated.
+
+Negative:
+
+- The WebSocket route requires new auth, ticketing, reconnect, and replay logic beyond existing SSE
+  streams.
+- Phase 0 CLI wrapping is transitional complexity and must be removed as direct APIs mature.
+- Rich rendering adds frontend surface area that must be kept aligned with tool result schemas.
+- The chat panel increases the importance of precise policy gates because natural language can
+  request broad actions.
+
+## Acceptance Criteria
+
+- `/api/chat/ws` streams a response from a LionAGI `Branch` using the configured chat model.
+- Browser clients authenticate without exposing the long-lived Studio bearer token in the WebSocket
+  URL.
+- `chat_messages` persists user, assistant, tool, render, error, and client-effect records.
+- The tool registry exposes all tools listed in this ADR with typed Python and TypeScript contracts.
+- Read-only tools work without confirmation; mutating, executing, and admin tools enforce
+  confirmation.
+- The frontend panel is persistent, collapsible, keyboard-focusable with `Cmd+K`, and available from
+  the Studio shell.
+- Tool results render inline as tables, charts, DAG previews, artifacts, code, or confirmation
+  cards rather than raw JSON.
+- Context-aware prompts use route and selected-entity context and reject stale context for
+  destructive actions.
+- Phase 0 includes LOC and migration tracking so CLI wrappers are visible transitional debt.
+
+## References
+
+- `apps/studio/server/app.py`
+- `apps/studio/server/routers/`
+- `apps/studio/frontend/components/Shell.tsx`
+- `apps/studio/frontend/lib/api.ts`
+- `lionagi/session/branch.py`
+- `lionagi/protocols/action/tool.py`
+- `lionagi/cli/main.py`
+- ADR-0006: SSE Live Streaming
+- ADR-0009: SQLite State Layer
+- ADR-0034: Frontend Data and State Architecture
+- ADR-0044: Tool Gates
+- ADR-0051: Tool Registry Allowlists
+- ADR-0056: Play Control API
+- ADR-0058: Play Cost Tracking
+- ADR-0060: Unified Config Resolution
+- ADR-0061: Universal Scheduler
+- ADR-0066: Unified Execution Viewer
+
+Domain utility: SKIPPED - the requested lore suggest/compose tools were not available, so this ADR uses checked-in ADRs and code references as its evidence base.

--- a/docs/adrs/ADR-0067-studio-command-chat.md
+++ b/docs/adrs/ADR-0067-studio-command-chat.md
@@ -8,7 +8,7 @@ Related: ADR-0054 (local state cleanup), ADR-0055 (artifact viewer), ADR-0064 (w
 
 ## Context
 
-Lion Studio must become a coherent product surface for orchestration, not only a monitoring UI over
+Lion Studio should provide a coherent surface for orchestration, not only a monitoring UI over
 terminal-oriented harnesses. Operators should be able to navigate, inspect, modify, run, schedule,
 pause, cancel, summarize, and clean up work through one natural-language panel while still seeing
 typed, auditable actions.
@@ -34,9 +34,9 @@ schemas. Studio Command Chat should use this LionAGI runtime directly. It must n
 Code, Codex, or any other harness provider as the chat backend. External harnesses may still be
 targets of flows during early phases, but they are not the chat control plane.
 
-The product requirement is broader than a chatbot. The panel must operate as a universal AI-powered
-control panel with typed tools, confirmations, history, search, context injection, rich inline
-responses, and a staged path away from CLI wrapping toward direct programmatic orchestration.
+The panel must operate as a universal AI-powered control panel with typed tools, confirmations,
+history, search, context injection, rich inline responses, and a staged path away from CLI wrapping
+toward direct programmatic orchestration.
 
 Coupling estimate after this decision: components `{ChatRouter, ChatCoordinator, BranchRuntime,
 StudioToolRegistry, ServerToolAdapters, ClientEffectBridge, ChatHistoryStore, ChatRateLimiter,
@@ -767,34 +767,13 @@ Leo uses brain posteriors to personalize:
 - **Context awareness**: Leo remembers what the operator was working on across sessions via brain
   event history, without requiring explicit "remember this" commands.
 
-### Progressive Product Independence
+### Extensibility
 
-Leo in Studio is the first step toward full product autonomy:
-
-1. **Phase 0**: Leo wraps CLI commands, learns user patterns → users stop switching to terminal
-2. **Phase 1**: Leo calls Studio APIs directly → CLI becomes fallback
-3. **Phase 2**: Leo queries StateStore directly → monitoring through chat
-4. **Phase 3**: Leo composes flows programmatically → new flows without CLI
-5. **Phase 4**: Leo orchestrates multi-step plans end-to-end → terminal optional
-6. **Future**: Leo replaces CLI orchestration entirely → full independence from external harnesses
-
-This progression means lionagi becomes a coherent product: plays fire from the frontend, scheduling
-happens through Leo, remote agents run isolated, and the entire workflow lifecycle is managed through
-one intelligent surface. Cloud offerings (remote Leo instances, hosted scheduling, managed play
-execution) follow naturally once the local product surface is complete.
-
-## Progressive Independence Phasing
-
-| Phase | Goal | Implementation | Harness dependency reduced | Estimated net LOC |
-| --- | --- | --- | --- | --- |
-| 0 | Useful chat with minimal backend surgery | WebSocket router, Branch runtime, history table, frontend panel, read tools, client effects, allowlisted `li` CLI wrappers for execute/schedule/control where APIs are not ready | Users stop switching to terminal for common Studio tasks, but execution still shells out for some commands | 2,200-3,200 |
-| 1 | Prefer Studio APIs over CLI | Replace wrappers with direct calls to runs, shows, schedules, control, artifact, cleanup, and config services; add confirmation workflow and idempotency | CLI becomes fallback, not primary tool path | 1,500-2,300 |
-| 2 | Direct StateStore queries for analytics and search | Add typed query adapters for sessions, shows, costs, artifacts, schedules, chat history, and health; add FTS search and cost chart renderers | Monitoring questions no longer invoke CLI or page-specific fetch glue | 1,000-1,600 |
-| 3 | Programmatic flow composition | Add `Session.flow()` / flow service adapter for create, draft, validate, and execute; canvas DAG and chat DAG share one typed spec | New flows no longer require CLI command rendering | 2,000-3,200 |
-| 4 | Chat as orchestrator | Chat coordinates multi-step plans, schedules, control gates, re-plans, artifacts, and task-board updates as first-class orchestration | Terminal usage becomes optional for normal Studio operation | 2,500-4,000 |
-
-Total expected net new or moved LOC across all phases: 9,200-14,300. Phase 0 is the minimum
-marketable slice; phases 1-4 are staged independence work.
+Leo in Studio is designed as an extensible operator interface. The initial implementation wraps
+CLI commands through a typed tool registry with confirmation gates. As Studio APIs mature, Leo
+can call them directly instead of shelling out, reducing latency and enabling richer interactions.
+The architecture supports incremental capability growth without requiring breaking changes to the
+chat protocol or security model.
 
 ## Failure Modes
 
@@ -861,7 +840,7 @@ If `chat_model` is `None`, `Branch` falls back to the existing iModel defaults.
 
 | Alternative | Why Rejected |
 | --- | --- |
-| Keep Studio as a conventional dashboard only | Does not meet the strategic goal of a coherent product surface where users can operate workflows without learning every page. |
+| Keep Studio as a conventional dashboard only | Users would need to learn every page independently to operate workflows; a unified control surface is more usable. |
 | Back the panel with Claude Code, Codex, or another harness | Violates the independence requirement. Harnesses may execute work during migration, but the chat control plane must be LionAGI-native. |
 | HTTP POST plus SSE streaming only | Existing SSE is good for one-way live data, but chat needs bidirectional confirmations, client-effect acknowledgements, cancellation, and context updates. |
 | Regex or command-intent router instead of a Branch with tools | Too brittle for contextual operations like failure explanation, DAG edits, and cost projection. It also duplicates tool semantics outside LionAGI. |

--- a/docs/adrs/ADR-0067-studio-command-chat.md
+++ b/docs/adrs/ADR-0067-studio-command-chat.md
@@ -925,5 +925,3 @@ Negative:
 - ADR-0060: Unified Config Resolution
 - ADR-0061: Universal Scheduler
 - ADR-0066: Unified Execution Viewer
-
-Domain utility: SKIPPED - the requested lore suggest/compose tools were not available, so this ADR uses checked-in ADRs and code references as its evidence base.

--- a/docs/adrs/ADR-0068-governed-adapter-protocol.md
+++ b/docs/adrs/ADR-0068-governed-adapter-protocol.md
@@ -95,7 +95,7 @@ This ADR consumes, but does not own:
 - No request or response transformation. The adapter forwards arguments verbatim to the wrapped
   object and returns its result unchanged.
 - No tenant isolation. The adapter applies the charter supplied at construction time. Multi-tenant
-  charter routing is a commercial offering and is not included in the open-source protocol.
+  charter routing is not included in the adapter protocol.
 - No synchronous public API. `execute()` and all concrete `run()` methods are `async`. Sync
   callers must use `asyncio.run()` or an equivalent executor bridge.
 - No framework version pinning. Adapters support whatever version of the framework is installed
@@ -575,8 +575,7 @@ charter resolved from their configuration layer, not rely on adapter-level ambie
 
 Tenant isolation — routing different callers to different charters based on identity,
 namespace, or organizational membership — is not included in this protocol. The adapter applies
-exactly the charter supplied at construction time to every execution. Multi-tenant charter
-routing is part of the commercial governance offering.
+exactly the charter supplied at construction time to every execution.
 
 ## Alternatives Considered
 

--- a/docs/adrs/ADR-0068-governed-adapter-protocol.md
+++ b/docs/adrs/ADR-0068-governed-adapter-protocol.md
@@ -1,0 +1,623 @@
+# ADR-0068: Zero-Rewrite Governed Adapter Protocol
+
+Status: accepted
+Date: 2026-05-27
+Decision owners: @governance-maintainers
+Supersedes: none
+Superseded by: none
+Depends on: ADR-0042, ADR-0044, ADR-0047
+Related: ADR-0041, ADR-0043, ADR-0050, ADR-0051, ADR-0052
+
+## Context
+
+Enterprise teams adopting lionagi governance already operate agent stacks built on third-party
+frameworks: LangChain chains and agent executors, CrewAI crews, the openai-agents SDK Runner,
+and the Anthropic Agent SDK. These systems are in production, have been tested under their own
+framework semantics, and carry non-trivial setup cost.
+
+Asking teams to rewrite their agent logic into lionagi `Branch` constructs before governance can
+be applied is a non-starter. Rewriting means re-testing the agent under framework semantics,
+re-certifying prompts, and accepting a migration risk window where neither the old framework nor
+the new one is the sole authoritative execution path. In practice, enterprises either skip
+governance entirely or defer migration indefinitely. The correct posture is to meet the agent
+where it lives.
+
+The second constraint is overhead. Governance machinery — gate evaluation, evidence recording,
+certificate minting — adds latency and memory pressure. When no compliance requirement is active
+for a given session, that overhead must be zero. Any always-on wrapper that imports governance
+internals at module load time is unacceptable in this position because it forces all callers to
+pay for governance even when they do not use it.
+
+The third constraint is import isolation. Third-party frameworks are optional dependencies.
+`lionagi` core must be importable on a machine that has never installed LangChain, CrewAI, or
+the openai-agents SDK. Adapter modules must guard every framework import so that loading the
+adapter module itself does not fail if the target framework is absent.
+
+This ADR formalizes the `GovernedAdapter` base class and the four concrete adapters
+(`GovernedChain`, `GovernedCrew`, `GovernedOpenAIAgent`, `GovernedAnthropicAgent`) as the
+canonical mechanism for applying lionagi governance to any existing agent framework object
+without modifying that object.
+
+## Decision
+
+Introduce `GovernedAdapter`, an abstract async base class in `lionagi/adapters/governed_base.py`,
+that wraps any agent framework object and applies lionagi governance through a well-defined
+`execute()` lifecycle. The class is the sole entry point for zero-rewrite governance integration.
+
+Governance is opt-in. When `charter=None` (the default), the adapter is a transparent
+pass-through: no governance module is imported, no gate is evaluated, `execute()` calls
+`_call_wrapped()` and returns `(result, None)`. When a charter is supplied at construction time,
+`GovernedFlowController` is instantiated and the full governance lifecycle activates.
+
+Four concrete subclasses ship in `lionagi/adapters/`:
+
+- `langchain.py` — `GovernedChain` for LangChain `Runnable`, `Chain`, `AgentExecutor`
+- `crewai.py` — `GovernedCrew` for CrewAI `Crew`
+- `openai_agents.py` — `GovernedOpenAIAgent` for openai-agents `Agent` or `Runner`
+- `anthropic_agents.py` — `GovernedAnthropicAgent` for Anthropic Agent SDK `Agent`
+
+New frameworks are supported by subclassing `GovernedAdapter` and implementing two methods:
+`_call_wrapped()` and optionally `_get_tool_name()`. The base class handles the full governance
+lifecycle without any changes.
+
+`GovernanceViolationError` is defined as a standalone class in `governed_base.py`. It does not
+import from `lionagi.protocols.governance`. When the full governance module is available at
+runtime, the canonical error class from `lionagi.protocols.governance` takes precedence. When it
+is absent, the local stub is sufficient. This design allows callers to import and catch
+`GovernanceViolationError` from the adapter module without requiring the governance stack.
+
+## Scope
+
+This ADR owns:
+
+- `GovernedAdapter` base class and its `execute()` lifecycle contract
+- `GovernanceViolationError` local definition and import-time replacement semantics
+- `_call_wrapped()`, `_get_tool_name()`, `_hash_args()`, `_hash_result()` adapter contract
+- `on_deny` policy enumeration and behavior (`"raise"`, `"skip"`, `"log"`)
+- return type contract `(result, TaskCertificate | None)`
+- lazy framework import pattern for concrete adapters
+- four bundled concrete adapters: `GovernedChain`, `GovernedCrew`, `GovernedOpenAIAgent`,
+  `GovernedAnthropicAgent`
+
+This ADR consumes, but does not own:
+
+- `TaskCertificate` from ADR-0042 (Task Certificate)
+- `GateResult` and `GateVerdict` from ADR-0044 (Tool Gates)
+- `AgentCharter` and charter activation from ADR-0047 (Agent Charter)
+- `GovernedFlowController` from the governance flow integration module
+
+## Non-Goals
+
+- No framework-specific governance rules. All gate logic lives in the charter and ADR-0044
+  `ToolGate` definitions, not in the adapter subclasses.
+- No automatic framework detection. The caller explicitly chooses the adapter class for their
+  framework object.
+- No request or response transformation. The adapter forwards arguments verbatim to the wrapped
+  object and returns its result unchanged.
+- No tenant isolation. The adapter applies the charter supplied at construction time. Multi-tenant
+  charter routing is a commercial offering and is not included in the open-source protocol.
+- No synchronous public API. `execute()` and all concrete `run()` methods are `async`. Sync
+  callers must use `asyncio.run()` or an equivalent executor bridge.
+- No framework version pinning. Adapters support whatever version of the framework is installed
+  by probing method existence (`hasattr`) rather than version checks.
+
+## Interfaces And Types
+
+### GovernedAdapter Constructor
+
+```python
+class GovernedAdapter:
+    def __init__(
+        self,
+        wrapped: Any,
+        charter: Any = None,
+        session_id: str = "",
+        on_deny: str = "raise",
+    ) -> None: ...
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `wrapped` | `Any` | required | The framework object to wrap (Chain, Crew, Agent, Runner). |
+| `charter` | `Any` | `None` | Charter path, YAML string, or `CharterDocument`. `None` disables governance entirely. |
+| `session_id` | `str` | `""` | Caller-supplied session identifier embedded in the certificate. |
+| `on_deny` | `str` | `"raise"` | Policy applied on hard gate denial. One of `"raise"`, `"skip"`, `"log"`. |
+
+Raises `ValueError` if `on_deny` is not one of the three accepted values.
+
+Raises `ImportError` if `charter` is not `None` and
+`lionagi.protocols.governance.flow_integration` cannot be imported.
+
+### execute() Public Contract
+
+```python
+async def execute(self, *args: Any, **kwargs: Any) -> tuple[Any, Any]:
+    """Execute the wrapped object under governance.
+
+    Returns (result, TaskCertificate | None).
+    Certificate is None when no charter is active.
+    """
+```
+
+`execute()` is the primary entry point. Subclasses call `super().execute()` from their
+framework-specific `run()` method, forwarding all arguments unchanged.
+
+### Adapter Contract Methods
+
+```python
+async def _call_wrapped(self, *args: Any, **kwargs: Any) -> Any:
+    """Invoke the wrapped framework object. MUST be overridden."""
+    raise NotImplementedError(...)
+
+def _get_tool_name(self) -> str:
+    """Return the gate registration lookup key for this adapter.
+
+    Default: governed.{type(self._wrapped).__name__.lower()}
+    Concrete adapters override this to return stable, human-readable names.
+    """
+
+def _hash_args(self, args: tuple, kwargs: dict) -> str:
+    """Return SHA-256 hex digest of the serialized args/kwargs."""
+
+def _hash_result(self, result: Any) -> str:
+    """Return SHA-256 hex digest of the serialized result."""
+```
+
+Subclasses MUST override `_call_wrapped()`. Overriding `_get_tool_name()` is strongly
+recommended to produce stable, readable tool names for gate configuration. `_hash_args()` and
+`_hash_result()` may be overridden to provide framework-specific serialization if the default
+JSON serialization does not produce stable digests for the framework's output types.
+
+### GovernanceViolationError
+
+```python
+class GovernanceViolationError(Exception):
+    def __init__(self, message: str = "Governance gate denied the operation") -> None: ...
+```
+
+Raised by `execute()` when `on_deny="raise"` and a gate returns `GateVerdict.DENY`. Callers
+that catch this error are guaranteed to receive at minimum the local definition. When the
+governance module is available, the raised instance is compatible with
+`lionagi.protocols.governance.GovernanceViolationError`.
+
+### on_deny Policies
+
+| Policy | Behavior on Gate DENY |
+|--------|----------------------|
+| `"raise"` | Raises `GovernanceViolationError` with the gate ID and justification. Execution is blocked. The `(result, cert)` tuple is never returned. |
+| `"skip"` | Returns `(None, None)` immediately without executing the wrapped object. No exception is raised. The caller must handle `None` result. |
+| `"log"` | Emits a `warnings.warn()` at the call site, then returns `(None, None)`. Execution is skipped even though no exception is raised. Useful in development or observability-only deployments where blocking would be too disruptive. |
+
+All three policies apply only to hard `GateVerdict.DENY` outcomes. Soft-gate justification
+flows (ADR-0044) remain controlled by the charter and are not exposed through `on_deny`.
+
+### Supported Framework Adapters
+
+| Framework | Adapter Class | Import Path | Tool Name | Native Async | Sync Fallback |
+|-----------|--------------|-------------|-----------|:---:|:---:|
+| LangChain | `GovernedChain` | `lionagi.adapters.langchain` | `langchain.chain` | Yes (`ainvoke`) | `invoke` via executor |
+| CrewAI | `GovernedCrew` | `lionagi.adapters.crewai` | `crewai.crew` | Future (`akickoff`) | `kickoff` via executor |
+| openai-agents | `GovernedOpenAIAgent` | `lionagi.adapters.openai_agents` | `openai_agents.run` | Yes (`Runner.run`) | N/A |
+| Anthropic Agent SDK | `GovernedAnthropicAgent` | `lionagi.adapters.anthropic_agents` | `anthropic_agents.run` | Yes (`arun`) | `run` via executor |
+
+LangChain async preference order: `ainvoke` → `invoke` (executor) → `arun` (legacy).
+CrewAI async preference order: `akickoff` → `kickoff` (executor).
+Anthropic SDK async preference order: `arun` → `run` (executor).
+
+All four adapters raise `AttributeError` with a clear message if the wrapped object exposes
+none of the expected interface methods.
+
+## Runtime Semantics
+
+The `execute()` lifecycle runs five phases in order:
+
+```text
+1. pre_op_check     — gate evaluation before the wrapped object runs
+2. _call_wrapped    — the framework object executes
+3. elapsed timing   — wall-clock milliseconds recorded
+4. post_op_record   — evidence recorded after execution
+5. mint_certificate — TaskCertificate or None returned to caller
+```
+
+### Phase 1: pre_op_check
+
+When `self._controller` is `None` (no charter), this phase returns `None` immediately. No gate
+is evaluated.
+
+When a controller is active, `GovernedFlowController.pre_op_check(tool_name)` is called with
+the string returned by `_get_tool_name()`. The result is a `GateResult` (ADR-0044). If the
+verdict is `GateVerdict.DENY`, the `on_deny` policy is applied and `execute()` returns without
+proceeding to phase 2.
+
+### Phase 2: _call_wrapped
+
+The subclass implementation runs the framework object. All positional and keyword arguments
+passed to `execute()` are forwarded without modification. The result is any Python value
+returned by the framework object.
+
+If the framework raises an exception, the exception propagates through `execute()` uncaught.
+The post-op record phase does not run and no certificate is minted. This is intentional:
+failed executions do not produce certificates in the adapter protocol. Callers that need
+failure certificates should use the `Branch`-level governance path (ADR-0043).
+
+### Phase 3: Elapsed Timing
+
+Wall-clock elapsed time is measured using `time.perf_counter()`. The value is passed to
+`post_op_record` as `elapsed_ms` and recorded in the evidence chain when a controller is
+active.
+
+### Phase 4: post_op_record
+
+When `self._controller` is `None`, this phase is a no-op.
+
+When a controller is active, `args_hash` (SHA-256 of serialized arguments) and `result_hash`
+(SHA-256 of serialized result) are passed to `GovernedFlowController.post_op_record()` along
+with the gate result from phase 1 and the elapsed time. These hashes form the evidence entry
+for the operation. Raw argument values and result values are never stored — only their digests.
+This prevents PII leakage when argument content includes user data.
+
+If phase 1 returned `None` (no charter but a controller exists through future subclass
+override), `post_op_record` synthesizes a passthrough `GateResult` with `verdict=ALLOW` before
+recording.
+
+### Phase 5: mint_certificate
+
+When `self._controller` is `None`, this phase returns `None`.
+
+When a controller is active, `GovernedFlowController.mint_certificate()` is called. It
+assembles the `TaskCertificate` (ADR-0042) from the accumulated evidence and gate results.
+Certificate grade is determined by gate outcomes: any soft denial that was overridden or any
+advisory denial recorded during the session degrades the certificate below the top grade. Full
+grade semantics are owned by ADR-0042.
+
+## Evidence And Trace Requirements
+
+When a charter is active, every `execute()` call that completes without exception must produce:
+
+- one `args_hash` and one `result_hash` (SHA-256 hex, 64 characters each)
+- one `GateResult` (ADR-0044) from pre-gate evaluation, or a synthesized ALLOW result
+- one evidence record via `GovernedFlowController.post_op_record()` with `tool_name`,
+  `args_hash`, `result_hash`, `gate_result`, and `elapsed_ms`
+- one `TaskCertificate` (ADR-0042) from `GovernedFlowController.mint_certificate()`
+
+The adapter does not produce span or trace records directly. Tracing is the responsibility of
+the `GovernedFlowController` and the governance flow integration layer. Adapters that wrap
+frameworks with their own tracing (LangChain callbacks, CrewAI telemetry) do not interfere
+with those frameworks' traces.
+
+## Test Requirements
+
+All concrete adapter implementations must include tests that verify:
+
+- Without charter: `execute()` returns `(result, None)` and no governance module is imported.
+- With charter: `execute()` returns `(result, TaskCertificate)` and evidence is recorded.
+- `on_deny="raise"`: gate DENY raises `GovernanceViolationError`.
+- `on_deny="skip"`: gate DENY returns `(None, None)` without exception.
+- `on_deny="log"`: gate DENY emits a `warnings.warn()` and returns `(None, None)`.
+- Invalid `on_deny` value raises `ValueError` at construction time.
+- Framework import error raises `ImportError` with installation instructions.
+- `_call_wrapped()` not overridden raises `NotImplementedError`.
+- `args_hash` and `result_hash` are 64-character hex strings.
+- Framework exception in `_call_wrapped()` propagates unchanged.
+
+Coverage target: ≥90% of `governed_base.py` lines.
+
+## Consequences
+
+**Positive**
+
+- Enterprise teams apply governance to existing agent stacks without any rewrite.
+- Zero overhead when no charter is supplied — no imports, no gate evaluation, no evidence
+  recording. The pass-through path has no measurable latency impact.
+- New frameworks require only a `_call_wrapped()` implementation; the full governance lifecycle
+  is inherited without modification.
+- `GovernanceViolationError` can be caught without importing the governance stack, enabling
+  lightweight error handling in environments where the governance module is optional.
+- Hash-based evidence avoids PII leakage — raw user inputs and agent outputs are never
+  persisted.
+- Lazy framework imports prevent dependency pollution: importing
+  `lionagi.adapters.langchain` on a machine without LangChain does not fail until `run()` is
+  actually called.
+
+**Negative**
+
+- Sync framework calls (CrewAI `kickoff`, Anthropic SDK `run`) are dispatched through
+  `asyncio.get_event_loop().run_in_executor()`, which incurs thread-pool overhead and requires
+  an active event loop.
+- Framework exceptions during `_call_wrapped()` bypass evidence recording and certificate
+  minting entirely. Callers that need audit trails for failures must handle the exception and
+  record it separately.
+- The adapter's `session_id` is fixed at construction. Sessions with dynamic IDs must
+  construct a new adapter instance per session.
+- Certificate grade is computed by `GovernedFlowController` based on a single execution.
+  Multi-step agents that internally make many tool calls will produce a single adapter-level
+  certificate, not per-step certificates. Per-step governance requires using the
+  `Branch`-level instrument (ADR-0043).
+
+## Migration
+
+No migration is required for callers that do not use governance. The adapter classes are
+additive. Existing uses of LangChain, CrewAI, or openai-agents without lionagi governance are
+unaffected.
+
+Callers adding governance for the first time:
+
+1. Replace the direct call to the framework object with an adapter construction:
+
+   ```python
+   # Before
+   result = await chain.ainvoke(input)
+
+   # After
+   from lionagi.adapters.langchain import GovernedChain
+   adapter = GovernedChain(chain, charter="policy.yaml", session_id=session_id)
+   result, cert = await adapter.run(input)
+   ```
+
+2. Install `lionagi>=0.27.0` which includes `lionagi.protocols.governance`.
+3. Author a charter document following docs/governance/charter-dsl-v0.md.
+4. Handle `GovernanceViolationError` where appropriate in application code.
+
+## Examples
+
+### LangChain Chain Without Governance (Pass-Through)
+
+```python
+from langchain.chains import LLMChain
+from lionagi.adapters.langchain import GovernedChain
+
+chain = LLMChain(llm=my_llm, prompt=my_prompt)
+# No charter supplied: pure pass-through, zero overhead
+adapter = GovernedChain(chain)
+result, cert = await adapter.run({"question": "What is 2+2?"})
+# cert is None
+assert cert is None
+```
+
+### LangChain Chain With Governance
+
+```python
+from langchain_core.runnables import RunnableSequence
+from lionagi.adapters.langchain import GovernedChain
+from lionagi.adapters.governed_base import GovernanceViolationError
+
+chain = RunnableSequence(prompt | llm | output_parser)
+adapter = GovernedChain(
+    chain,
+    charter="charters/research_policy.yaml",
+    session_id="session-abc123",
+    on_deny="raise",
+)
+
+try:
+    result, cert = await adapter.run({"topic": "quantum computing"})
+    # cert is a TaskCertificate (ADR-0042)
+    print(f"Grade: {cert.grade}, Chain head: {cert.evidence_chain_head}")
+except GovernanceViolationError as exc:
+    # A gate denied this operation
+    print(f"Governance denied: {exc}")
+```
+
+### LangChain AgentExecutor With on_deny="skip"
+
+```python
+from langchain.agents import AgentExecutor
+from lionagi.adapters.langchain import GovernedChain
+
+executor = AgentExecutor(agent=agent, tools=tools)
+# "skip" returns (None, None) on denial — no exception
+adapter = GovernedChain(executor, charter="policy.yaml", on_deny="skip")
+result, cert = await adapter.run("Summarise the quarterly report")
+if result is None:
+    print("Governance denied; skipping this operation")
+```
+
+### CrewAI Crew Without Governance
+
+```python
+from crewai import Crew, Agent, Task
+from lionagi.adapters.crewai import GovernedCrew
+
+crew = Crew(agents=[researcher, writer], tasks=[research_task, write_task])
+# No charter: pass-through
+adapter = GovernedCrew(crew)
+result, cert = await adapter.run(inputs={"topic": "AI governance"})
+assert cert is None
+```
+
+### CrewAI Crew With Governance
+
+```python
+from crewai import Crew
+from lionagi.adapters.crewai import GovernedCrew
+
+crew = Crew(agents=[...], tasks=[...])
+adapter = GovernedCrew(
+    crew,
+    charter="charters/agent_policy.yaml",
+    session_id="crew-run-42",
+    on_deny="log",
+)
+result, cert = await adapter.run(inputs={"topic": "competitor analysis"})
+# cert is None if governance denied with on_deny="log"
+# cert is a TaskCertificate if execution completed
+```
+
+### openai-agents SDK With Governance
+
+```python
+from agents import Agent  # openai-agents
+from lionagi.adapters.openai_agents import GovernedOpenAIAgent
+
+agent = Agent(
+    name="research-assistant",
+    instructions="You are a research assistant.",
+)
+adapter = GovernedOpenAIAgent(
+    agent,
+    charter="policy.yaml",
+    session_id="oai-session-99",
+    on_deny="raise",
+)
+result, cert = await adapter.run("List the top 5 recent ML papers.")
+print(result.final_output)
+print(cert.grade)
+```
+
+The adapter accepts either an `agents.Agent` or an `agents.Runner` instance as `wrapped`. When
+an `Agent` is passed, `Runner.run(agent, input)` is called implicitly.
+
+### Anthropic Agent SDK With Governance
+
+```python
+from anthropic.agents import Agent  # Anthropic Agent SDK
+from lionagi.adapters.anthropic_agents import GovernedAnthropicAgent
+
+agent = Agent(
+    model="claude-opus-4-5",
+    system_prompt="You are a document analyst.",
+    tools=[...],
+)
+adapter = GovernedAnthropicAgent(
+    agent,
+    charter="charters/doc_policy.yaml",
+    session_id="anthropic-session-7",
+)
+result, cert = await adapter.run("Draft a summary of the attached contract.")
+```
+
+### Custom Framework Adapter
+
+Teams using frameworks not covered by the four bundled adapters can implement their own:
+
+```python
+from lionagi.adapters.governed_base import GovernedAdapter
+
+
+class GovernedMyFrameworkAgent(GovernedAdapter):
+    """Governed wrapper for MyFramework agent objects."""
+
+    def _get_tool_name(self) -> str:
+        return "myframework.agent"
+
+    async def run(self, prompt: str, **kwargs) -> tuple:
+        return await self.execute(prompt, **kwargs)
+
+    async def _call_wrapped(self, prompt: str, **kwargs):
+        agent = self._wrapped
+        # Prefer async interface; fall back to sync via executor
+        if hasattr(agent, "arun"):
+            return await agent.arun(prompt, **kwargs)
+        import asyncio
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, lambda: agent.run(prompt, **kwargs))
+```
+
+The custom adapter inherits the full governance lifecycle, evidence recording, certificate
+minting, and all `on_deny` policies without any additional implementation.
+
+### Catching GovernanceViolationError Without Governance Stack
+
+```python
+# This import works even if lionagi.protocols.governance is not installed
+from lionagi.adapters.governed_base import GovernanceViolationError
+
+try:
+    result, cert = await adapter.run(input_data)
+except GovernanceViolationError as exc:
+    # Handle governance denial
+    log_denial(str(exc))
+```
+
+## Security Considerations
+
+### Hash-Based Evidence
+
+Arguments and results are recorded as SHA-256 digests, not raw values. This means:
+
+- User-supplied inputs (including potentially sensitive queries, document content, or PII) are
+  never written to the evidence chain.
+- Framework outputs (which may include proprietary data, summarized customer records, or
+  confidential business information) are similarly protected.
+- The digest is sufficient for audit purposes: it proves that a specific invocation occurred
+  and its inputs and outputs were in a specific state at execution time, without exposing
+  the content.
+
+Teams requiring full content logging for compliance must implement that separately in the
+framework's native callback or telemetry system, not through the adapter evidence chain.
+
+### Lazy Imports and Dependency Isolation
+
+Each concrete adapter delays its framework import until `_call_wrapped()` is first executed.
+This has two security benefits:
+
+1. A misconfigured or compromised version of an optional framework cannot execute code at
+   module import time by virtue of being installed.
+2. Dependency trees for optional frameworks do not affect the security surface of
+   `lionagi.adapters.governed_base` or any unrelated adapter.
+
+### GovernanceViolationError Import Independence
+
+`GovernanceViolationError` is defined without importing from `lionagi.protocols.governance`.
+This eliminates a potential circular import chain through the governance stack and ensures that
+the error class is always resolvable, even in minimal deployments that install only the adapter
+module.
+
+### Charter Supply
+
+The adapter activates governance only when the caller explicitly supplies a `charter`. There is
+no ambient or implicit charter. This is deliberate: governance cannot be silently applied by a
+dependency or environment variable without the caller's explicit construction-time decision.
+Teams that want environment-driven charter activation should construct the adapter with a
+charter resolved from their configuration layer, not rely on adapter-level ambient behavior.
+
+### Tenant Isolation
+
+Tenant isolation — routing different callers to different charters based on identity,
+namespace, or organizational membership — is not included in this protocol. The adapter applies
+exactly the charter supplied at construction time to every execution. Multi-tenant charter
+routing is part of the commercial governance offering.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Require callers to rewrite agents as lionagi `Branch` instances | Non-starter for enterprise teams with production agent stacks. Migration risk outweighs governance benefit. |
+| Always-on governance wrapper with ambient charter loading | Adds latency and import overhead for every execution even when no charter is active. Violates the zero-overhead requirement for pass-through mode. |
+| Monkey-patch framework objects in-place | Brittle — depends on stable internal framework method names. Untestable without framework installation. Rejected in favor of explicit wrapper construction. |
+| Protocol / interface-only definition with no bundled adapters | Leaves teams to implement adapter mechanics independently. Inconsistent evidence recording and error handling across implementations. |
+| Sync-only adapter API | Many calling contexts are already async. Forcing sync with executor bridges would be less efficient than native async. |
+| Store raw args/results in evidence chain | Leaks PII. Hash-based evidence is sufficient for audit purposes and avoids compliance risk. |
+
+## Cross-References
+
+- ADR-0041 (Immutable Evidence Nodes) — `ImmutableEvidenceNode` and `EvidenceChain` are the
+  storage substrate for the evidence records written by `post_op_record`. See
+  `docs/adrs/ADR-0041-immutable-evidence-nodes.md`.
+- ADR-0042 (Task Certificate) — `TaskCertificate`, `CertificateState`, and `Defensibility`
+  are the types returned by `mint_certificate()` when a charter is active. See
+  `docs/adrs/ADR-0042-task-certificate.md`.
+- ADR-0043 (Governed Tool Declaration) — defines the `Branch`-level governance instrument for
+  lionagi-native tool calls. The adapter protocol is complementary: it governs whole framework
+  objects, not individual tool calls inside a `Branch`. See
+  `docs/adrs/ADR-0043-governed-tool-declaration.md`.
+- ADR-0044 (Tool Gates) — `GateResult`, `GateVerdict`, and `GateEnforcement` are the canonical
+  gate result types consumed by `_pre_op_check()` and `_post_op_record()`. `ToolGate`
+  definitions in the charter determine whether a given `tool_name` is allowed. See
+  `docs/adrs/ADR-0044-tool-gates.md`.
+- ADR-0047 (Agent Charter) — `AgentCharter` and `CharterDocument` are the charter types
+  accepted by the `GovernedAdapter` constructor. Charter compilation and activation semantics
+  are owned by ADR-0047. See `docs/adrs/ADR-0047-agent-charter.md`.
+- ADR-0050 (Operation Context) — `OperationContext` propagation within `GovernedFlowController`
+  binds actor identity and policy release to each execution. The adapter does not directly
+  construct `OperationContext`; that is the controller's responsibility.
+- ADR-0051 (Tool Registry Allowlists) — gate resolution consults the registry for exact tool
+  name bindings. The `tool_name` returned by `_get_tool_name()` is the lookup key.
+- ADR-0052 (Policy Resolution) — the policy release and bundle in effect during execution are
+  resolved by the controller, not the adapter. ADR-0052 owns that resolution algorithm.
+- `lionagi/adapters/governed_base.py` — implementation of `GovernedAdapter` and
+  `GovernanceViolationError`.
+- `lionagi/adapters/langchain.py` — `GovernedChain` implementation.
+- `lionagi/adapters/crewai.py` — `GovernedCrew` implementation.
+- `lionagi/adapters/openai_agents.py` — `GovernedOpenAIAgent` implementation.
+- `lionagi/adapters/anthropic_agents.py` — `GovernedAnthropicAgent` implementation.

--- a/docs/adrs/ADR-0069-tenant-scope-boundary.md
+++ b/docs/adrs/ADR-0069-tenant-scope-boundary.md
@@ -1,12 +1,14 @@
 # ADR-0069: Tenant Scope Boundary — OSS Hook Points vs Commercial Isolation
 
-**Status**: Accepted
+**Status**: accepted
 **Date**: 2026-05-27
 **Decision owners**: @governance-maintainers
 **Supersedes**: none
 **Superseded by**: none
-**Depends on**: [ADR-0050](ADR-0050-operation-context.md) (OperationContext carries tenant_id),
-[ADR-0052](ADR-0052-policy-resolution.md) (PolicyResolver and ScopeLevel define the hierarchy)
+**Depends on**: [ADR-0050](ADR-0050-operation-context.md) (OperationContext provides the
+per-operation context for policy evaluation; does not carry tenant_id directly),
+[ADR-0052](ADR-0052-policy-resolution.md) (PolicyResolver accepts tenant_id as an input
+parameter; ScopeLevel and PolicyResolutionResult define the hierarchy and record resolved tenant)
 **Related**: [ADR-0047](ADR-0047-agent-charter.md) (charter is the session-binding vehicle),
 [ADR-0051](ADR-0051-tool-registry-allowlists.md) (registry entries are policy-scoped),
 [ADR-0044](ADR-0044-tool-gates.md) (gates selected by active policy)

--- a/docs/adrs/ADR-0069-tenant-scope-boundary.md
+++ b/docs/adrs/ADR-0069-tenant-scope-boundary.md
@@ -1,0 +1,554 @@
+# ADR-0069: Tenant Scope Boundary — OSS Hook Points vs Commercial Isolation
+
+**Status**: Accepted
+**Date**: 2026-05-27
+**Decision owners**: @governance-maintainers
+**Supersedes**: none
+**Superseded by**: none
+**Depends on**: [ADR-0050](ADR-0050-operation-context.md) (OperationContext carries tenant_id),
+[ADR-0052](ADR-0052-policy-resolution.md) (PolicyResolver and ScopeLevel define the hierarchy)
+**Related**: [ADR-0047](ADR-0047-agent-charter.md) (charter is the session-binding vehicle),
+[ADR-0051](ADR-0051-tool-registry-allowlists.md) (registry entries are policy-scoped),
+[ADR-0044](ADR-0044-tool-gates.md) (gates selected by active policy)
+
+---
+
+## Context
+
+Multi-tenant AI agent platforms are a major requirement for enterprise deployments. Different
+organizations need different governance policies, tool allowlists, cost budgets, and audit
+segregation. The natural implementation question is: how much of tenant infrastructure does
+lionagi provide, and how much is left to commercial integrators?
+
+The triggering constraint is that lionagi is Apache-2.0 open-source software. Full tenant
+isolation — isolated data stores, per-tenant network routing, billing metering, tenant lifecycle
+management, and cross-tenant access control enforcement — is complex commercial infrastructure.
+Shipping that infrastructure as OSS would undermine the commercial viability of the platform and
+introduce maintenance burden for OSS contributors who have no need for multi-tenancy.
+
+At the same time, lionagi's governance system must not be designed in a way that makes commercial
+multi-tenancy impossible or awkward to add later. The resolution hierarchy introduced in
+ADR-0052 (Policy Resolution) has exactly four specificity levels:
+
+```text
+resource (3) > role (2) > tenant (1) > global (0)
+```
+
+The `TENANT` position at level 1 is not an accident. It is a deliberate API commitment: there is
+a named slot in the resolution hierarchy reserved for tenant-scoped policy rules. A commercial
+integration can write rules at that level without touching the OSS core.
+
+However, the mere existence of a `TENANT` scope label could mislead readers into believing that
+lionagi implements tenant isolation. It does not. This ADR codifies the precise boundary:
+what lionagi provides (hook points and a named scope label), and what it explicitly does not
+provide (isolation infrastructure).
+
+The gap between those two things is the commercial value proposition.
+
+### What enterprise operators actually need
+
+When a governed deployment serves multiple organizations, each organization typically requires:
+
+1. **Policy segregation** — different tool allowlists, gate configurations, and permission rules.
+2. **Audit segregation** — evidence chains that cannot mix across organizational boundaries.
+3. **Storage isolation** — separate data stores or at minimum separate namespaces with enforced
+   access control.
+4. **Billing metering** — per-tenant cost accounting.
+5. **Lifecycle management** — provisioning, de-provisioning, and suspension of tenant contexts.
+
+Items 2–5 are infrastructure concerns. lionagi's governance system addresses item 1 through the
+scope hierarchy: a policy rule scoped to `tenant` applies only when the operation's `tenant_id`
+matches the rule's matching criteria. That is the entirety of lionagi's tenant support. Items
+2–5 are explicitly out of scope for OSS and require commercial overlay.
+
+### Why the label exists at all
+
+The `TENANT` scope level exists in the open-source resolution hierarchy for two reasons:
+
+**Reason 1: Future-proof API surface.** If commercial overlays are to set policy rules that
+apply organization-wide (more specific than global defaults, less specific than per-role rules),
+they need a named slot in the hierarchy to put those rules. Reserving that slot in the OSS
+schema means commercial integrations can write tenant-scoped charter rules today without waiting
+for a protocol revision.
+
+**Reason 2: Interoperability surface.** A commercial tenant middleware that resolves the active
+tenant for an incoming request needs a standard field to write the result into. That field is
+`tenant_id` on `PolicyResolver.resolve()` and, transitively, on `OperationContext`. Making that
+field part of the OSS interface ensures commercial overlays can interoperate without forking the
+resolution engine.
+
+Neither reason requires lionagi to implement tenant storage, routing, or lifecycle management.
+
+---
+
+## Decision
+
+`TENANT` occupies position 1 in `ScopeLevel` (defined in
+`lionagi/protocols/governance/resolution.py`). This is a **permanent API commitment**. The
+integer assignment `TENANT = 1` must not change without a superseding ADR.
+
+### What lionagi provides
+
+1. **`ScopeLevel.TENANT` (value 1)** — a named specificity level between `GLOBAL` (0) and
+   `ROLE` (2) in the `ScopeLevel` IntEnum. The docstring on `ScopeLevel` explicitly states that
+   `TENANT` is a hook point for commercial offerings and that lionagi itself does not implement
+   tenant isolation.
+
+2. **`tenant_id` parameter in `PolicyResolver.resolve()`** — the resolver accepts a
+   `tenant_id: str = ""` argument. When a tenant-scoped rule is present in the charter, the
+   resolver checks whether `tenant_id` matches the rule's `roles` field (DSL v0 reuses the
+   `roles` field as a scope-value list for tenant rules). An empty `tenant_id` matches only
+   tenant rules with an empty `roles` list (matches-all semantics).
+
+3. **Tenant-scoped rules in `PermissionsDef`** — the Charter DSL v0 `PermissionRule` model
+   (defined in `lionagi/protocols/governance/dsl.py`) accepts `scope: "tenant"` in
+   `PermissionRule.scope`. Charter authors can write tenant-scoped allow or deny rules using
+   the standard rule schema. The DSL v0 uses the `roles` field to encode the tenant identifier
+   list for tenant-scope rules.
+
+4. **`PolicyScope.scope_type == "tenant"`** — in the ADR-0052 `PolicyScope` model, `"tenant"` is
+   a valid `scope_type`. A `ScopedPolicy` with tenant scope and `scope_value = "acme"` matches
+   operations where `tenant_id == "acme"`. The specificity score of 1 ensures it overrides global
+   defaults but is itself overridden by role-scoped and resource-scoped policies.
+
+5. **`OperationContext` carries tenant context** — while `OperationContext` (ADR-0050) does not
+   define a `tenant_id` field directly (it captures actor, role, charter, policy release, and
+   trace state), the `tenant_id` flows through `PolicyResolver.resolve()` as a resolution
+   parameter and is recorded in `PolicyResolutionResult.tenant_id`. A commercial overlay can
+   inject `tenant_id` into the resolution call via a pre-hook installed on `AgentConfig`.
+
+### What lionagi does not provide
+
+The following are explicitly **not** part of lionagi OSS, now or in the future without a
+separate commercial offering:
+
+| Capability | Why not in OSS |
+|---|---|
+| Tenant storage or database isolation | Requires multi-DB infrastructure, migration tooling, and connection pool management. Commercial concern. |
+| Tenant-aware routing or middleware | HTTP or gRPC middleware that resolves tenant from request headers, JWTs, or subdomains. Platform concern. |
+| Tenant billing or metering | Token counting, cost allocation, and invoicing per tenant. Business logic concern. |
+| Tenant configuration management | API surface for creating, updating, and deleting tenant configurations. Product concern. |
+| Cross-tenant access control enforcement | Preventing one tenant's agents from accessing another tenant's data or tools. Requires isolation the OSS does not provide. |
+| Tenant provisioning and lifecycle management | Onboarding, suspension, and de-provisioning flows. Product concern. |
+| Tenant-aware caching or state stores | Namespaced cache partitions that enforce tenant boundaries at the infrastructure level. Platform concern. |
+| Multi-database routing | Query routing based on tenant identity to isolated data stores. Infrastructure concern. |
+
+The OSS boundary is precisely: lionagi can evaluate a permission rule that says "tenant acme
+may use tool X." It cannot enforce that a request truly originates from tenant acme, cannot
+prevent tenant beta's data from appearing in an acme evidence chain, and cannot prevent an
+operator from misconfiguring the `tenant_id` value passed to the resolver.
+
+**Tenant labels are advisory without commercial isolation infrastructure.** This is not a
+deficiency — it is the intentional boundary.
+
+---
+
+## Scope
+
+This ADR owns:
+
+- The definition of the tenant boundary in lionagi OSS.
+- The `ScopeLevel.TENANT = 1` API commitment.
+- Documentation of what constitutes an OSS-compatible vs. commercial-only tenant feature.
+
+This ADR does not own:
+
+- `ScopeLevel`, `PolicyResolver`, `ResolutionResult` — owned by ADR-0052.
+- `OperationContext`, `ServiceContext` — owned by ADR-0050.
+- `PermissionRule`, `PermissionsDef`, `CharterDocument` — owned by the Charter DSL v0 spec and
+  ADR-0047.
+
+---
+
+## Non-Goals
+
+- **No tenant data model in OSS core.** There will be no `Tenant` entity, `TenantConfig`, or
+  `TenantStore` protocol in `lionagi.protocols` or `lionagi.agent`.
+
+- **No multi-database routing.** lionagi does not route operations to isolated databases based on
+  tenant identity. The OSS state model is single-namespace.
+
+- **No tenant-aware caching.** There is no cache partitioning or cache-key namespacing by tenant
+  in the OSS session, branch, or DataLogger layers.
+
+- **No SaaS billing hooks in OSS core.** Token consumption tracking and cost allocation are not
+  governance primitives. They are product features that commercial integrations may add via the
+  existing hook system.
+
+- **No tenant hierarchy or inheritance.** There is no parent-child tenant relationship, no
+  tenant group that inherits from an organization root. The global scope is the broadest level;
+  tenant is the next level. No tenant sub-hierarchy exists.
+
+- **No automatic tenant provisioning from charters.** Creating or deleting a "tenant" in lionagi
+  OSS means nothing beyond writing or removing tenant-scoped rules in a charter document. There
+  is no provisioning side-effect.
+
+---
+
+## Commercial Integration Points
+
+A commercial overlay adds tenant isolation by attaching to the hook points lionagi exposes.
+No changes to the OSS core are required. The integration pattern has four steps:
+
+### Step 1: Tenant middleware that sets `tenant_id` in the resolution call
+
+The overlay installs a pre-hook via `AgentConfig.hook_handlers` that resolves the active tenant
+for the current request and injects it into the tool call context. The `PolicyResolver.to_pre_hook()`
+factory (ADR-0052) reads `tenant_id` from `args.get("tenant_id", "global")`. The commercial
+middleware writes that field before the hook runs.
+
+```python
+# Commercial overlay — not in OSS
+async def tenant_resolver_hook(tool_name: str, action: str, args: dict) -> dict | None:
+    # Resolve tenant from JWT, subdomain, or session metadata.
+    tenant_id = resolve_tenant_from_context()  # commercial implementation
+    args["tenant_id"] = tenant_id
+    return None  # pass through; PolicyResolver hook runs next
+```
+
+The hook chain order matters: the tenant resolution hook must run before the policy resolution
+hook. Both are installed via `AgentConfig.hook_handlers["security_pre:*"]`.
+
+### Step 2: Tenant-scoped rules in `CharterDocument`
+
+With a `tenant_id` flowing correctly, the charter author writes tenant-scoped permission rules:
+
+```yaml
+# Charter DSL v0 — tenant-scoped rule
+permissions:
+  default: deny
+  resolution:
+    specificity_order: [resource, role, tenant, global]
+    tie: deny
+  allow:
+    - rule_id: acme-read-only-default
+      scope: tenant
+      roles: [acme]          # DSL v0 uses roles field for tenant matching
+      action: allow
+      tools: [file_reader, web_search]
+      because: "acme tenant agents may read but not write by default"
+```
+
+This rule applies only when `tenant_id == "acme"` reaches the resolver. No charter compilation
+changes are required; the DSL v0 `PermissionRule` model already accepts `scope: "tenant"`.
+
+### Step 3: Tenant-aware evidence segregation
+
+The overlay registers an evidence post-hook that stamps each `ImmutableEvidenceNode`
+(ADR-0041) with the resolved `tenant_id` before it is written to the evidence store. Auditors
+can then filter evidence by tenant without cross-contamination.
+
+```python
+# Commercial overlay — not in OSS
+async def tenant_evidence_stamp_hook(evidence_node: dict, args: dict) -> None:
+    evidence_node.setdefault("metadata", {})["tenant_id"] = args.get("tenant_id", "")
+```
+
+The evidence node schema (ADR-0041) allows `metadata` passthrough. The OSS core does not strip
+or validate this field beyond the existing `metadata` dict type.
+
+### Step 4: Tenant-aware storage (TenantStore)
+
+The overlay implements an isolated storage backend — separate SQLite databases, PostgreSQL
+schemas, or cloud-object-storage prefixes — keyed by `tenant_id`. The commercial implementation
+registers this store as the DataLogger backend for sessions belonging to a given tenant. Because
+`DataLogger` accepts pluggable backends via the `lionagi/agent/` infrastructure, this requires
+no changes to the OSS logging layer.
+
+The full lifecycle — provisioning a store on tenant creation, migrating it on schema changes,
+archiving it on tenant de-provisioning — is entirely in the commercial layer.
+
+---
+
+## Why Tenant Is at Specificity Level 1
+
+The specificity ordering `resource (3) > role (2) > tenant (1) > global (0)` is not arbitrary.
+Each level in the hierarchy answers a narrower question:
+
+| Level | Question answered | Example |
+|---|---|---|
+| global (0) | What is the broadest platform default? | All agents default to read-only tools |
+| tenant (1) | What does this organization require above the platform default? | Acme agents may also use write tools |
+| role (2) | What does this agent role require above the tenant default? | Reviewer agents within Acme may approve PRs |
+| resource (3) | What does this specific tool require above everything else? | `deploy_production` requires JIT grant regardless of role |
+
+Placing `tenant` at level 1 ensures that:
+
+- **Tenant policies override global defaults.** An organization can tighten or relax the
+  platform-wide baseline without needing per-role rules for every role. A single tenant-scoped
+  allow rule covers all roles in that organization for the specified tools.
+
+- **Role policies override tenant policies.** A tenant's blanket grant does not prevent a
+  per-role restriction from being more specific. A `reviewer` role can have stricter constraints
+  than the tenant default even within the same organization.
+
+- **Resource policies override everything.** A tool-level gate (ADR-0044) or JIT requirement
+  (ADR-0046) governs regardless of what tenant or role policies say. The resource level is the
+  ultimate backstop.
+
+If `tenant` were placed at level 0 (equal to global), tenant rules could not override global
+defaults without introducing explicit conflict resolution. If placed at level 2 (equal to role),
+tenant policies would tie with per-role policies, triggering DENY-on-tie for every deployment
+that writes both tenant and role rules for the same tool. Level 1 is the only position that
+maintains strict ordering at every resolution step.
+
+**This ordering is a permanent API commitment.** Code that reads `ScopeLevel.TENANT` or
+`ScopeLevel.ROLE` must not assume that their relative integer values can change. Any commercial
+integration that relies on tenant overriding global but being overridden by role depends on this
+ordering. Changing it would be a breaking change requiring a new major version of the governance
+protocol and a superseding ADR.
+
+---
+
+## Security Considerations
+
+**Without commercial isolation, tenant labels are advisory only.**
+
+A deployment that writes tenant-scoped charter rules but does not install a tenant resolution
+middleware will fall back to `tenant_id = ""` (the default in `PolicyResolver.resolve()`). If a
+tenant rule has an empty `roles` list (matches-all semantics), it will apply to every operation
+regardless of the actual organizational origin. If it has a non-empty `roles` list, it will
+never match (since `tenant_id = ""` is not in the list). Neither outcome constitutes a security
+isolation guarantee.
+
+**Data leakage across tenant boundaries is possible without commercial isolation.**
+
+If two organizations share a lionagi deployment and both use the same DataLogger backend without
+tenant-namespace segregation, evidence records from one organization are accessible to agents of
+the other. The OSS resolution layer has no mechanism to prevent this. It is the responsibility
+of the commercial overlay to provide storage isolation.
+
+**The OSS explicitly does not guarantee tenant isolation.** This is a design choice, not a
+deficiency. The guarantee boundary is:
+
+> lionagi OSS guarantees that tenant-scoped permission rules are evaluated at specificity
+> level 1 in the resolution hierarchy. It does not guarantee that the tenant_id value passed
+> to the resolver is authentic, that storage is isolated between tenants, or that
+> cross-tenant evidence contamination is prevented.
+
+Commercial deployments should treat this guarantee as a necessary but not sufficient condition
+for tenant isolation. The sufficient condition requires the commercial overlay.
+
+**Misconfiguration risk.** An operator who sets `tenant_id = "admin"` in every call — whether
+intentionally or by misconfiguration — will match all rules scoped to the `admin` tenant. There
+is no HMAC or cryptographic binding between the `tenant_id` string and the session identity.
+Authentication of the tenant claim is a commercial concern, typically implemented via verified
+JWT claims extracted in the tenant middleware hook.
+
+---
+
+## Migration Path for Commercial Adopters
+
+Adopters moving from single-tenant OSS deployments to multi-tenant commercial deployments
+follow four incremental steps. Each step is backwards-compatible with the previous.
+
+**Step 1 — Use tenant scope labels in charters (OSS, no dependencies)**
+
+Write charter documents with tenant-scoped permission rules using `scope: "tenant"` and the
+tenant identifier in the `roles` field. The OSS `PolicyResolver` will evaluate these rules when
+a non-empty `tenant_id` is passed to `resolve()`. Existing single-tenant deployments can add
+these rules without any behavioral change (they receive `tenant_id = ""`, which matches only
+empty-`roles` tenant rules).
+
+Outcome: charter is ready for multi-tenant use. No isolation yet.
+
+**Step 2 — Install tenant middleware to inject verified `tenant_id` (commercial)**
+
+Add a pre-hook that extracts the tenant identity from the request context (JWT, mTLS certificate
+CN, subdomain, API key lookup) and writes it to `args["tenant_id"]`. Install this hook before
+the policy resolution hook in `AgentConfig.hook_handlers["security_pre:*"]`.
+
+Outcome: tenant-scoped rules are now evaluated against authenticated tenant claims. Policy
+segregation is enforced. Storage is still shared.
+
+**Step 3 — Add tenant-aware storage (commercial)**
+
+Implement a `TenantStore` backed by isolated data stores (separate databases, schema-namespaced
+tables, or cloud-storage prefixes). Register it as the DataLogger backend per session, keyed by
+the resolved `tenant_id`.
+
+Outcome: evidence records are now stored in isolation. Cross-tenant audit queries no longer
+return mixed results.
+
+**Step 4 — Enable cross-tenant audit and lifecycle management (commercial)**
+
+Add audit tooling that queries per-tenant evidence stores with cross-tenant aggregation for
+platform-level reporting (usage dashboards, compliance reports). Add provisioning APIs that
+create, suspend, and delete tenant configurations, charters, and storage partitions atomically.
+
+Outcome: full enterprise multi-tenancy with provisioning, audit, and lifecycle management.
+
+---
+
+## Interfaces And Types
+
+This ADR does not introduce new types. The relevant types are owned by other ADRs:
+
+| Type | Owner | Relevant field |
+|---|---|---|
+| `ScopeLevel.TENANT` | ADR-0052 | Integer value 1; permanent API commitment |
+| `PolicyResolver.resolve(tenant_id=...)` | ADR-0052 | `tenant_id: str = ""` parameter |
+| `PermissionRule.scope` | Charter DSL v0 / ADR-0047 | Accepts `"tenant"` as a valid scope value |
+| `ResolutionResult.scope_level` | ADR-0052 | Carries `1` when a tenant rule wins |
+| `PolicyScope.scope_type == "tenant"` | ADR-0052 | Specificity score = 1 |
+| `PolicyResolutionResult.tenant_id` | ADR-0052 | Records resolved tenant in audit result |
+
+The `OperationContext` (ADR-0050) does not carry a `tenant_id` field directly. The tenant is
+propagated through the resolution call and captured in `PolicyResolutionResult.tenant_id`, which
+is logged via `DataLogger`. A commercial overlay that needs `tenant_id` on the evidence node
+must stamp it via a post-hook (see Commercial Integration Points, Step 3).
+
+---
+
+## Runtime Semantics
+
+The tenant scope evaluation path in `PolicyResolver._collect_candidates()` is:
+
+```python
+# From lionagi/protocols/governance/resolution.py
+# --- tenant scope (score=1) ---
+# Tenant is a scope label only — no isolation, no storage.
+score = ScopeLevel.TENANT
+for rule in self._allow_by_scope["tenant"]:
+    if self._rule_matches_tenant(rule, tenant_id) and self._rule_matches_tool_filter(
+        rule, tool_id
+    ):
+        candidates.append(_Candidate(rule, "allow", int(score)))
+for rule in self._deny_by_scope["tenant"]:
+    if self._rule_matches_tenant(rule, tenant_id) and self._rule_matches_tool_filter(
+        rule, tool_id
+    ):
+        candidates.append(_Candidate(rule, "deny", int(score)))
+```
+
+`_rule_matches_tenant()` is defined as:
+
+```python
+@staticmethod
+def _rule_matches_tenant(rule: PermissionRule, tenant_id: str) -> bool:
+    """A tenant-scope rule matches when ``tenant_id`` is in ``rule.roles``.
+
+    In DSL v0 the ``roles`` field doubles as the scope value list for
+    tenant rules (there is no dedicated ``tenants`` field).  Empty list
+    matches all tenants.  Providing a non-empty ``tenant_id`` of ``""``
+    matches only rules with an empty roles list.
+    """
+    if not rule.roles:
+        return True
+    return tenant_id in rule.roles
+```
+
+This is the complete OSS implementation of "tenant scope." There is no additional isolation logic,
+no storage lookup, no middleware call. The `tenant_id` string is compared against a list of
+strings in the charter rule. That is all.
+
+---
+
+## Evidence And Trace Requirements
+
+When a tenant-scoped rule wins resolution, `ResolutionResult.scope_level == 1` and
+`ResolutionResult.matching_rule_id` is set to the winning rule's `rule_id`. This is written to
+the `DataLogger` via the `to_pre_hook()` integration path (ADR-0052). The justification field
+on `ResolutionResult` includes `scope=tenant` in its text.
+
+Commercial overlays that stamp `tenant_id` onto evidence nodes (Step 3 above) should record it
+under the key `metadata.tenant_id` in the `ImmutableEvidenceNode` (ADR-0041) `metadata` dict.
+This is a convention, not an OSS schema requirement.
+
+---
+
+## Test Requirements
+
+The OSS test suite must cover:
+
+1. A `PolicyResolver` configured with a tenant-scoped rule resolves ALLOW when `tenant_id`
+   matches the rule's `roles` list.
+2. A `PolicyResolver` configured with a tenant-scoped rule resolves using the global fallback
+   when `tenant_id` does not match and no other rule matches.
+3. A `PolicyResolver` with `tenant_id = ""` matches tenant rules with an empty `roles` list
+   (matches-all semantics) and does not match tenant rules with a non-empty `roles` list.
+4. A tenant-scoped rule at level 1 is overridden by a role-scoped rule at level 2 (most-specific-
+   wins — tenant does not win over role for the same tool).
+5. A tenant-scoped rule at level 1 overrides a global rule at level 0 (most-specific-wins —
+   tenant wins over global).
+6. `ScopeLevel.TENANT == 1` — integer value is tested explicitly to catch any inadvertent
+   reordering of the enum.
+7. The `_rule_matches_tenant` static method is covered by unit tests for both match and non-match
+   paths.
+
+These tests must pass before any change to `ScopeLevel`, `PolicyResolver`, or `PermissionRule`
+is merged.
+
+---
+
+## Consequences
+
+**Positive**
+
+- The OSS/commercial boundary is explicit and formally documented. Investors, partners, and
+  enterprise evaluators can read this ADR and understand precisely what multi-tenancy guarantees
+  lionagi makes (none beyond scope-label evaluation) and what a commercial overlay must provide.
+
+- The API surface for commercial multi-tenancy is stable and minimal. A commercial integration
+  requires no forking of the OSS codebase — only hook installation and a storage backend
+  implementation.
+
+- Existing single-tenant deployments are not affected. The `tenant_id` parameter defaults to
+  `""`, and the resolution algorithm behaves identically to a deployment with no tenant-scoped
+  rules.
+
+- The `ScopeLevel.TENANT = 1` commitment protects commercial integrators from a future OSS
+  protocol change that would break their tenant-policy ordering assumptions.
+
+- The documentation of the advisory-only security guarantee is accurate and prevents false
+  assurance. An enterprise evaluator who reads this ADR will not assume isolation they are not
+  getting.
+
+**Negative**
+
+- Operators who skim the charter DSL documentation may assume that writing `scope: "tenant"` in
+  a rule provides isolation. They will not get isolation. This ADR's existence is the primary
+  mitigation; the charter DSL documentation must link to it.
+
+- The `roles` field reuse for tenant-scope matching in DSL v0 is a known awkwardness. A
+  dedicated `tenants` field in DSL v1 would be cleaner. DSL v0 is the current standard; this
+  debt is tracked for the DSL v1 design cycle.
+
+- The tenant scope boundary creates a two-tier documentation requirement: the OSS documentation
+  must explain what is not provided, and the commercial documentation must explain what is
+  added. Keeping both in sync is an ongoing maintenance obligation.
+
+---
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|---|---|
+| Implement basic tenant isolation in OSS (e.g. separate SQLite per tenant) | Introduces infrastructure complexity into the OSS core that has no value for single-tenant library users. Creates a maintenance burden for OSS contributors. Undermines the commercial value proposition of the hosted offering. |
+| Remove tenant scope from OSS resolution hierarchy entirely | Forces commercial integrations to fork the resolution engine to add a tenant level. Breaks the interoperability surface. Creates two incompatible resolution algorithms. Rejected because the label costs nothing to keep and enables interoperability. |
+| Rename `TENANT` to `ORG` or `NAMESPACE` to avoid isolation connotations | The term "tenant" is the industry-standard vocabulary for multi-tenancy in SaaS and enterprise software. Renaming it would cause confusion in partner conversations. The ADR documentation makes the advisory-only semantics clear without needing to rename the concept. |
+| Place tenant at level 2 (same as role) | Causes DENY-on-tie for any deployment that writes both a tenant rule and a role rule for the same tool at the same specificity. Breaks the useful pattern of "tenant sets a baseline, role refines it." Rejected because it makes the most common multi-tenant pattern impossible without resource-level overrides. |
+| Place tenant at level 0 (same as global) | Tenant rules cannot override global defaults, which removes the primary value of the tenant scope level. A tenant rule that cannot narrow or expand the global default is useless. Rejected. |
+
+---
+
+## Cross-References
+
+- [ADR-0052](ADR-0052-policy-resolution.md) — defines `ScopeLevel`, `PolicyResolver`, and the
+  most-specific-wins algorithm. `ScopeLevel.TENANT = 1` is the numerical commitment this ADR
+  formalizes.
+- [ADR-0050](ADR-0050-operation-context.md) — `OperationContext` carries the active policy
+  release. `PolicyResolutionResult.tenant_id` is the trace field that records the resolved
+  tenant in evidence.
+- [ADR-0047](ADR-0047-agent-charter.md) — the charter is the session-binding vehicle. Tenant-
+  scoped rules appear in `CharterDocument.permissions`.
+- [ADR-0041](ADR-0041-immutable-evidence-nodes.md) — `ImmutableEvidenceNode` is the target for
+  commercial `metadata.tenant_id` stamping (Step 3 of migration path).
+- [ADR-0044](ADR-0044-tool-gates.md) — resource-scoped gate enforcement (specificity 3) takes
+  precedence over tenant-scoped rules (specificity 1).
+- [ADR-0046](ADR-0046-jit-tool-grant.md) — JIT grants are policy-scoped; tenant context flows
+  through `PolicyResolver` to the grant evaluation.
+- `lionagi/protocols/governance/resolution.py` — canonical implementation of `ScopeLevel`,
+  `PolicyResolver`, and `_rule_matches_tenant`.
+- `lionagi/protocols/governance/dsl.py` — `PermissionRule.scope` accepts `"tenant"`;
+  `_rule_matches_tenant` behavior follows from the `roles` field semantics.

--- a/docs/adrs/ADR-0069-tenant-scope-boundary.md
+++ b/docs/adrs/ADR-0069-tenant-scope-boundary.md
@@ -1,4 +1,4 @@
-# ADR-0069: Tenant Scope Boundary — OSS Hook Points vs Commercial Isolation
+# ADR-0069: Tenant Scope Boundary
 
 **Status**: accepted
 **Date**: 2026-05-27
@@ -17,37 +17,31 @@ parameter; ScopeLevel and PolicyResolutionResult define the hierarchy and record
 
 ## Context
 
-Multi-tenant AI agent platforms are a major requirement for enterprise deployments. Different
-organizations need different governance policies, tool allowlists, cost budgets, and audit
-segregation. The natural implementation question is: how much of tenant infrastructure does
-lionagi provide, and how much is left to commercial integrators?
+Multi-tenant AI agent deployments need different governance policies, tool allowlists, cost
+budgets, and audit segregation per organization. The natural implementation question is: how much
+of tenant infrastructure does lionagi provide?
 
-The triggering constraint is that lionagi is Apache-2.0 open-source software. Full tenant
-isolation — isolated data stores, per-tenant network routing, billing metering, tenant lifecycle
-management, and cross-tenant access control enforcement — is complex commercial infrastructure.
-Shipping that infrastructure as OSS would undermine the commercial viability of the platform and
-introduce maintenance burden for OSS contributors who have no need for multi-tenancy.
+Full tenant isolation — isolated data stores, per-tenant network routing, billing metering, tenant
+lifecycle management, and cross-tenant access control enforcement — is complex infrastructure.
+lionagi does not provide these capabilities. This ADR codifies the precise boundary: what lionagi
+provides (hook points and a named scope label) and what it explicitly does not provide (isolation
+infrastructure).
 
-At the same time, lionagi's governance system must not be designed in a way that makes commercial
-multi-tenancy impossible or awkward to add later. The resolution hierarchy introduced in
-ADR-0052 (Policy Resolution) has exactly four specificity levels:
+The resolution hierarchy introduced in ADR-0052 (Policy Resolution) has exactly four specificity
+levels:
 
 ```text
 resource (3) > role (2) > tenant (1) > global (0)
 ```
 
-The `TENANT` position at level 1 is not an accident. It is a deliberate API commitment: there is
-a named slot in the resolution hierarchy reserved for tenant-scoped policy rules. A commercial
-integration can write rules at that level without touching the OSS core.
+The `TENANT` position at level 1 is a deliberate API commitment: there is a named slot in the
+resolution hierarchy reserved for tenant-scoped policy rules. Integrations can write rules at that
+level without touching the core resolution engine.
 
 However, the mere existence of a `TENANT` scope label could mislead readers into believing that
-lionagi implements tenant isolation. It does not. This ADR codifies the precise boundary:
-what lionagi provides (hook points and a named scope label), and what it explicitly does not
-provide (isolation infrastructure).
+lionagi implements tenant isolation. It does not. This ADR codifies the distinction.
 
-The gap between those two things is the commercial value proposition.
-
-### What enterprise operators actually need
+### What deployments serving multiple organizations need
 
 When a governed deployment serves multiple organizations, each organization typically requires:
 
@@ -61,23 +55,21 @@ When a governed deployment serves multiple organizations, each organization typi
 Items 2–5 are infrastructure concerns. lionagi's governance system addresses item 1 through the
 scope hierarchy: a policy rule scoped to `tenant` applies only when the operation's `tenant_id`
 matches the rule's matching criteria. That is the entirety of lionagi's tenant support. Items
-2–5 are explicitly out of scope for OSS and require commercial overlay.
+2–5 require additional infrastructure outside the scope of this library.
 
 ### Why the label exists at all
 
-The `TENANT` scope level exists in the open-source resolution hierarchy for two reasons:
+The `TENANT` scope level exists for two reasons:
 
-**Reason 1: Future-proof API surface.** If commercial overlays are to set policy rules that
-apply organization-wide (more specific than global defaults, less specific than per-role rules),
-they need a named slot in the hierarchy to put those rules. Reserving that slot in the OSS
-schema means commercial integrations can write tenant-scoped charter rules today without waiting
-for a protocol revision.
+**Reason 1: Future-proof API surface.** Integrations that need to set policy rules applying
+organization-wide (more specific than global defaults, less specific than per-role rules) need
+a named slot in the hierarchy. Reserving that slot in the schema allows tenant-scoped charter
+rules to be written today without waiting for a protocol revision.
 
-**Reason 2: Interoperability surface.** A commercial tenant middleware that resolves the active
-tenant for an incoming request needs a standard field to write the result into. That field is
-`tenant_id` on `PolicyResolver.resolve()` and, transitively, on `OperationContext`. Making that
-field part of the OSS interface ensures commercial overlays can interoperate without forking the
-resolution engine.
+**Reason 2: Interoperability surface.** A tenant middleware that resolves the active tenant for
+an incoming request needs a standard field to write the result into. That field is `tenant_id`
+on `PolicyResolver.resolve()` and, transitively, on `OperationContext`. Making that field part
+of the interface ensures integrations can interoperate without forking the resolution engine.
 
 Neither reason requires lionagi to implement tenant storage, routing, or lifecycle management.
 
@@ -93,8 +85,7 @@ integer assignment `TENANT = 1` must not change without a superseding ADR.
 
 1. **`ScopeLevel.TENANT` (value 1)** — a named specificity level between `GLOBAL` (0) and
    `ROLE` (2) in the `ScopeLevel` IntEnum. The docstring on `ScopeLevel` explicitly states that
-   `TENANT` is a hook point for commercial offerings and that lionagi itself does not implement
-   tenant isolation.
+   lionagi does not implement tenant isolation.
 
 2. **`tenant_id` parameter in `PolicyResolver.resolve()`** — the resolver accepts a
    `tenant_id: str = ""` argument. When a tenant-scoped rule is present in the charter, the
@@ -116,32 +107,30 @@ integer assignment `TENANT = 1` must not change without a superseding ADR.
 5. **`OperationContext` carries tenant context** — while `OperationContext` (ADR-0050) does not
    define a `tenant_id` field directly (it captures actor, role, charter, policy release, and
    trace state), the `tenant_id` flows through `PolicyResolver.resolve()` as a resolution
-   parameter and is recorded in `PolicyResolutionResult.tenant_id`. A commercial overlay can
-   inject `tenant_id` into the resolution call via a pre-hook installed on `AgentConfig`.
+   parameter and is recorded in `PolicyResolutionResult.tenant_id`. An integration can inject
+   `tenant_id` into the resolution call via a pre-hook installed on `AgentConfig`.
 
 ### What lionagi does not provide
 
-The following are explicitly **not** part of lionagi OSS, now or in the future without a
-separate commercial offering:
+The following are explicitly **not** part of lionagi:
 
-| Capability | Why not in OSS |
+| Capability | Why not included |
 |---|---|
-| Tenant storage or database isolation | Requires multi-DB infrastructure, migration tooling, and connection pool management. Commercial concern. |
-| Tenant-aware routing or middleware | HTTP or gRPC middleware that resolves tenant from request headers, JWTs, or subdomains. Platform concern. |
-| Tenant billing or metering | Token counting, cost allocation, and invoicing per tenant. Business logic concern. |
-| Tenant configuration management | API surface for creating, updating, and deleting tenant configurations. Product concern. |
-| Cross-tenant access control enforcement | Preventing one tenant's agents from accessing another tenant's data or tools. Requires isolation the OSS does not provide. |
-| Tenant provisioning and lifecycle management | Onboarding, suspension, and de-provisioning flows. Product concern. |
-| Tenant-aware caching or state stores | Namespaced cache partitions that enforce tenant boundaries at the infrastructure level. Platform concern. |
-| Multi-database routing | Query routing based on tenant identity to isolated data stores. Infrastructure concern. |
+| Tenant storage or database isolation | Requires multi-DB infrastructure, migration tooling, and connection pool management. |
+| Tenant-aware routing or middleware | HTTP or gRPC middleware that resolves tenant from request headers, JWTs, or subdomains. |
+| Tenant billing or metering | Token counting, cost allocation, and invoicing per tenant. |
+| Tenant configuration management | API surface for creating, updating, and deleting tenant configurations. |
+| Cross-tenant access control enforcement | Preventing one tenant's agents from accessing another tenant's data or tools. Requires isolation that this library does not provide. |
+| Tenant provisioning and lifecycle management | Onboarding, suspension, and de-provisioning flows. |
+| Tenant-aware caching or state stores | Namespaced cache partitions that enforce tenant boundaries at the infrastructure level. |
+| Multi-database routing | Query routing based on tenant identity to isolated data stores. |
 
-The OSS boundary is precisely: lionagi can evaluate a permission rule that says "tenant acme
-may use tool X." It cannot enforce that a request truly originates from tenant acme, cannot
-prevent tenant beta's data from appearing in an acme evidence chain, and cannot prevent an
-operator from misconfiguring the `tenant_id` value passed to the resolver.
+The boundary is precisely: lionagi can evaluate a permission rule that says "tenant acme may use
+tool X." It cannot enforce that a request truly originates from tenant acme, cannot prevent tenant
+beta's data from appearing in an acme evidence chain, and cannot prevent an operator from
+misconfiguring the `tenant_id` value passed to the resolver.
 
-**Tenant labels are advisory without commercial isolation infrastructure.** This is not a
-deficiency — it is the intentional boundary.
+**Tenant labels are advisory without isolation infrastructure.** This is the intentional boundary.
 
 ---
 
@@ -149,9 +138,8 @@ deficiency — it is the intentional boundary.
 
 This ADR owns:
 
-- The definition of the tenant boundary in lionagi OSS.
+- The definition of the tenant scope boundary in lionagi.
 - The `ScopeLevel.TENANT = 1` API commitment.
-- Documentation of what constitutes an OSS-compatible vs. commercial-only tenant feature.
 
 This ADR does not own:
 
@@ -164,101 +152,25 @@ This ADR does not own:
 
 ## Non-Goals
 
-- **No tenant data model in OSS core.** There will be no `Tenant` entity, `TenantConfig`, or
+- **No tenant data model.** There will be no `Tenant` entity, `TenantConfig`, or
   `TenantStore` protocol in `lionagi.protocols` or `lionagi.agent`.
 
 - **No multi-database routing.** lionagi does not route operations to isolated databases based on
-  tenant identity. The OSS state model is single-namespace.
+  tenant identity. The state model is single-namespace.
 
 - **No tenant-aware caching.** There is no cache partitioning or cache-key namespacing by tenant
-  in the OSS session, branch, or DataLogger layers.
+  in the session, branch, or DataLogger layers.
 
-- **No SaaS billing hooks in OSS core.** Token consumption tracking and cost allocation are not
-  governance primitives. They are product features that commercial integrations may add via the
-  existing hook system.
+- **No billing hooks.** Token consumption tracking and cost allocation are not governance
+  primitives. Integrations may add them via the existing hook system.
 
 - **No tenant hierarchy or inheritance.** There is no parent-child tenant relationship, no
   tenant group that inherits from an organization root. The global scope is the broadest level;
   tenant is the next level. No tenant sub-hierarchy exists.
 
 - **No automatic tenant provisioning from charters.** Creating or deleting a "tenant" in lionagi
-  OSS means nothing beyond writing or removing tenant-scoped rules in a charter document. There
-  is no provisioning side-effect.
-
----
-
-## Commercial Integration Points
-
-A commercial overlay adds tenant isolation by attaching to the hook points lionagi exposes.
-No changes to the OSS core are required. The integration pattern has four steps:
-
-### Step 1: Tenant middleware that sets `tenant_id` in the resolution call
-
-The overlay installs a pre-hook via `AgentConfig.hook_handlers` that resolves the active tenant
-for the current request and injects it into the tool call context. The `PolicyResolver.to_pre_hook()`
-factory (ADR-0052) reads `tenant_id` from `args.get("tenant_id", "global")`. The commercial
-middleware writes that field before the hook runs.
-
-```python
-# Commercial overlay — not in OSS
-async def tenant_resolver_hook(tool_name: str, action: str, args: dict) -> dict | None:
-    # Resolve tenant from JWT, subdomain, or session metadata.
-    tenant_id = resolve_tenant_from_context()  # commercial implementation
-    args["tenant_id"] = tenant_id
-    return None  # pass through; PolicyResolver hook runs next
-```
-
-The hook chain order matters: the tenant resolution hook must run before the policy resolution
-hook. Both are installed via `AgentConfig.hook_handlers["security_pre:*"]`.
-
-### Step 2: Tenant-scoped rules in `CharterDocument`
-
-With a `tenant_id` flowing correctly, the charter author writes tenant-scoped permission rules:
-
-```yaml
-# Charter DSL v0 — tenant-scoped rule
-permissions:
-  default: deny
-  resolution:
-    specificity_order: [resource, role, tenant, global]
-    tie: deny
-  allow:
-    - rule_id: acme-read-only-default
-      scope: tenant
-      roles: [acme]          # DSL v0 uses roles field for tenant matching
-      action: allow
-      tools: [file_reader, web_search]
-      because: "acme tenant agents may read but not write by default"
-```
-
-This rule applies only when `tenant_id == "acme"` reaches the resolver. No charter compilation
-changes are required; the DSL v0 `PermissionRule` model already accepts `scope: "tenant"`.
-
-### Step 3: Tenant-aware evidence segregation
-
-The overlay registers an evidence post-hook that stamps each `ImmutableEvidenceNode`
-(ADR-0041) with the resolved `tenant_id` before it is written to the evidence store. Auditors
-can then filter evidence by tenant without cross-contamination.
-
-```python
-# Commercial overlay — not in OSS
-async def tenant_evidence_stamp_hook(evidence_node: dict, args: dict) -> None:
-    evidence_node.setdefault("metadata", {})["tenant_id"] = args.get("tenant_id", "")
-```
-
-The evidence node schema (ADR-0041) allows `metadata` passthrough. The OSS core does not strip
-or validate this field beyond the existing `metadata` dict type.
-
-### Step 4: Tenant-aware storage (TenantStore)
-
-The overlay implements an isolated storage backend — separate SQLite databases, PostgreSQL
-schemas, or cloud-object-storage prefixes — keyed by `tenant_id`. The commercial implementation
-registers this store as the DataLogger backend for sessions belonging to a given tenant. Because
-`DataLogger` accepts pluggable backends via the `lionagi/agent/` infrastructure, this requires
-no changes to the OSS logging layer.
-
-The full lifecycle — provisioning a store on tenant creation, migrating it on schema changes,
-archiving it on tenant de-provisioning — is entirely in the commercial layer.
+  means nothing beyond writing or removing tenant-scoped rules in a charter document. There is
+  no provisioning side-effect.
 
 ---
 
@@ -295,16 +207,16 @@ that writes both tenant and role rules for the same tool. Level 1 is the only po
 maintains strict ordering at every resolution step.
 
 **This ordering is a permanent API commitment.** Code that reads `ScopeLevel.TENANT` or
-`ScopeLevel.ROLE` must not assume that their relative integer values can change. Any commercial
-integration that relies on tenant overriding global but being overridden by role depends on this
-ordering. Changing it would be a breaking change requiring a new major version of the governance
-protocol and a superseding ADR.
+`ScopeLevel.ROLE` must not assume that their relative integer values can change. Any integration
+that relies on tenant overriding global but being overridden by role depends on this ordering.
+Changing it would be a breaking change requiring a new major version of the governance protocol
+and a superseding ADR.
 
 ---
 
 ## Security Considerations
 
-**Without commercial isolation, tenant labels are advisory only.**
+**Without isolation infrastructure, tenant labels are advisory only.**
 
 A deployment that writes tenant-scoped charter rules but does not install a tenant resolution
 middleware will fall back to `tenant_id = ""` (the default in `PolicyResolver.resolve()`). If a
@@ -313,72 +225,29 @@ regardless of the actual organizational origin. If it has a non-empty `roles` li
 never match (since `tenant_id = ""` is not in the list). Neither outcome constitutes a security
 isolation guarantee.
 
-**Data leakage across tenant boundaries is possible without commercial isolation.**
+**Data leakage across tenant boundaries is possible without isolation infrastructure.**
 
 If two organizations share a lionagi deployment and both use the same DataLogger backend without
 tenant-namespace segregation, evidence records from one organization are accessible to agents of
-the other. The OSS resolution layer has no mechanism to prevent this. It is the responsibility
-of the commercial overlay to provide storage isolation.
+the other. The resolution layer has no mechanism to prevent this. Storage isolation must be
+provided by the deployment infrastructure.
 
-**The OSS explicitly does not guarantee tenant isolation.** This is a design choice, not a
-deficiency. The guarantee boundary is:
+**lionagi does not guarantee tenant isolation.** This is a design choice, not a deficiency.
+The guarantee boundary is:
 
-> lionagi OSS guarantees that tenant-scoped permission rules are evaluated at specificity
-> level 1 in the resolution hierarchy. It does not guarantee that the tenant_id value passed
-> to the resolver is authentic, that storage is isolated between tenants, or that
-> cross-tenant evidence contamination is prevented.
+> lionagi guarantees that tenant-scoped permission rules are evaluated at specificity level 1
+> in the resolution hierarchy. It does not guarantee that the tenant_id value passed to the
+> resolver is authentic, that storage is isolated between tenants, or that cross-tenant evidence
+> contamination is prevented.
 
-Commercial deployments should treat this guarantee as a necessary but not sufficient condition
-for tenant isolation. The sufficient condition requires the commercial overlay.
+Deployments requiring full tenant isolation must provide additional infrastructure on top of
+this library.
 
 **Misconfiguration risk.** An operator who sets `tenant_id = "admin"` in every call — whether
 intentionally or by misconfiguration — will match all rules scoped to the `admin` tenant. There
 is no HMAC or cryptographic binding between the `tenant_id` string and the session identity.
-Authentication of the tenant claim is a commercial concern, typically implemented via verified
-JWT claims extracted in the tenant middleware hook.
-
----
-
-## Migration Path for Commercial Adopters
-
-Adopters moving from single-tenant OSS deployments to multi-tenant commercial deployments
-follow four incremental steps. Each step is backwards-compatible with the previous.
-
-**Step 1 — Use tenant scope labels in charters (OSS, no dependencies)**
-
-Write charter documents with tenant-scoped permission rules using `scope: "tenant"` and the
-tenant identifier in the `roles` field. The OSS `PolicyResolver` will evaluate these rules when
-a non-empty `tenant_id` is passed to `resolve()`. Existing single-tenant deployments can add
-these rules without any behavioral change (they receive `tenant_id = ""`, which matches only
-empty-`roles` tenant rules).
-
-Outcome: charter is ready for multi-tenant use. No isolation yet.
-
-**Step 2 — Install tenant middleware to inject verified `tenant_id` (commercial)**
-
-Add a pre-hook that extracts the tenant identity from the request context (JWT, mTLS certificate
-CN, subdomain, API key lookup) and writes it to `args["tenant_id"]`. Install this hook before
-the policy resolution hook in `AgentConfig.hook_handlers["security_pre:*"]`.
-
-Outcome: tenant-scoped rules are now evaluated against authenticated tenant claims. Policy
-segregation is enforced. Storage is still shared.
-
-**Step 3 — Add tenant-aware storage (commercial)**
-
-Implement a `TenantStore` backed by isolated data stores (separate databases, schema-namespaced
-tables, or cloud-storage prefixes). Register it as the DataLogger backend per session, keyed by
-the resolved `tenant_id`.
-
-Outcome: evidence records are now stored in isolation. Cross-tenant audit queries no longer
-return mixed results.
-
-**Step 4 — Enable cross-tenant audit and lifecycle management (commercial)**
-
-Add audit tooling that queries per-tenant evidence stores with cross-tenant aggregation for
-platform-level reporting (usage dashboards, compliance reports). Add provisioning APIs that
-create, suspend, and delete tenant configurations, charters, and storage partitions atomically.
-
-Outcome: full enterprise multi-tenancy with provisioning, audit, and lifecycle management.
+Authentication of the tenant claim is an infrastructure concern, typically implemented via
+verified JWT claims extracted in the tenant middleware hook.
 
 ---
 
@@ -397,8 +266,8 @@ This ADR does not introduce new types. The relevant types are owned by other ADR
 
 The `OperationContext` (ADR-0050) does not carry a `tenant_id` field directly. The tenant is
 propagated through the resolution call and captured in `PolicyResolutionResult.tenant_id`, which
-is logged via `DataLogger`. A commercial overlay that needs `tenant_id` on the evidence node
-must stamp it via a post-hook (see Commercial Integration Points, Step 3).
+is logged via `DataLogger`. An integration that needs `tenant_id` on the evidence node must
+stamp it via a post-hook.
 
 ---
 
@@ -440,7 +309,7 @@ def _rule_matches_tenant(rule: PermissionRule, tenant_id: str) -> bool:
     return tenant_id in rule.roles
 ```
 
-This is the complete OSS implementation of "tenant scope." There is no additional isolation logic,
+This is the complete implementation of "tenant scope." There is no additional isolation logic,
 no storage lookup, no middleware call. The `tenant_id` string is compared against a list of
 strings in the charter rule. That is all.
 
@@ -453,15 +322,15 @@ When a tenant-scoped rule wins resolution, `ResolutionResult.scope_level == 1` a
 the `DataLogger` via the `to_pre_hook()` integration path (ADR-0052). The justification field
 on `ResolutionResult` includes `scope=tenant` in its text.
 
-Commercial overlays that stamp `tenant_id` onto evidence nodes (Step 3 above) should record it
-under the key `metadata.tenant_id` in the `ImmutableEvidenceNode` (ADR-0041) `metadata` dict.
-This is a convention, not an OSS schema requirement.
+Integrations that stamp `tenant_id` onto evidence nodes should record it under the key
+`metadata.tenant_id` in the `ImmutableEvidenceNode` (ADR-0041) `metadata` dict. This is a
+convention, not a schema requirement.
 
 ---
 
 ## Test Requirements
 
-The OSS test suite must cover:
+The test suite must cover:
 
 1. A `PolicyResolver` configured with a tenant-scoped rule resolves ALLOW when `tenant_id`
    matches the rule's `roles` list.
@@ -487,24 +356,21 @@ is merged.
 
 **Positive**
 
-- The OSS/commercial boundary is explicit and formally documented. Investors, partners, and
-  enterprise evaluators can read this ADR and understand precisely what multi-tenancy guarantees
-  lionagi makes (none beyond scope-label evaluation) and what a commercial overlay must provide.
+- The tenant boundary is explicit and formally documented. Operators and integrators can read this
+  ADR and understand precisely what multi-tenancy guarantees lionagi makes (none beyond scope-label
+  evaluation) and what additional infrastructure is required.
 
-- The API surface for commercial multi-tenancy is stable and minimal. A commercial integration
-  requires no forking of the OSS codebase — only hook installation and a storage backend
-  implementation.
+- The API surface for multi-tenancy is stable and minimal. An integration requires no forking of
+  the core codebase — only hook installation and a storage backend implementation.
 
 - Existing single-tenant deployments are not affected. The `tenant_id` parameter defaults to
   `""`, and the resolution algorithm behaves identically to a deployment with no tenant-scoped
   rules.
 
-- The `ScopeLevel.TENANT = 1` commitment protects commercial integrators from a future OSS
-  protocol change that would break their tenant-policy ordering assumptions.
+- The `ScopeLevel.TENANT = 1` commitment protects integrators from a future protocol change that
+  would break tenant-policy ordering assumptions.
 
-- The documentation of the advisory-only security guarantee is accurate and prevents false
-  assurance. An enterprise evaluator who reads this ADR will not assume isolation they are not
-  getting.
+- The documentation of the advisory-only security guarantee prevents false assurance.
 
 **Negative**
 
@@ -516,19 +382,15 @@ is merged.
   dedicated `tenants` field in DSL v1 would be cleaner. DSL v0 is the current standard; this
   debt is tracked for the DSL v1 design cycle.
 
-- The tenant scope boundary creates a two-tier documentation requirement: the OSS documentation
-  must explain what is not provided, and the commercial documentation must explain what is
-  added. Keeping both in sync is an ongoing maintenance obligation.
-
 ---
 
 ## Alternatives Considered
 
 | Alternative | Why Rejected |
 |---|---|
-| Implement basic tenant isolation in OSS (e.g. separate SQLite per tenant) | Introduces infrastructure complexity into the OSS core that has no value for single-tenant library users. Creates a maintenance burden for OSS contributors. Undermines the commercial value proposition of the hosted offering. |
-| Remove tenant scope from OSS resolution hierarchy entirely | Forces commercial integrations to fork the resolution engine to add a tenant level. Breaks the interoperability surface. Creates two incompatible resolution algorithms. Rejected because the label costs nothing to keep and enables interoperability. |
-| Rename `TENANT` to `ORG` or `NAMESPACE` to avoid isolation connotations | The term "tenant" is the industry-standard vocabulary for multi-tenancy in SaaS and enterprise software. Renaming it would cause confusion in partner conversations. The ADR documentation makes the advisory-only semantics clear without needing to rename the concept. |
+| Implement basic tenant isolation (e.g. separate SQLite per tenant) | Introduces infrastructure complexity with no value for single-tenant users. Creates a maintenance burden with no corresponding benefit for most deployments. |
+| Remove tenant scope from resolution hierarchy entirely | Forces integrations that need tenant-level policy to fork the resolution engine. Breaks the interoperability surface. Creates two incompatible resolution algorithms. Rejected because the label costs nothing to keep and enables interoperability. |
+| Rename `TENANT` to `ORG` or `NAMESPACE` to avoid isolation connotations | "tenant" is the industry-standard vocabulary for multi-tenancy. The ADR documentation makes the advisory-only semantics clear without needing to rename the concept. |
 | Place tenant at level 2 (same as role) | Causes DENY-on-tie for any deployment that writes both a tenant rule and a role rule for the same tool at the same specificity. Breaks the useful pattern of "tenant sets a baseline, role refines it." Rejected because it makes the most common multi-tenant pattern impossible without resource-level overrides. |
 | Place tenant at level 0 (same as global) | Tenant rules cannot override global defaults, which removes the primary value of the tenant scope level. A tenant rule that cannot narrow or expand the global default is useless. Rejected. |
 
@@ -545,7 +407,7 @@ is merged.
 - [ADR-0047](ADR-0047-agent-charter.md) — the charter is the session-binding vehicle. Tenant-
   scoped rules appear in `CharterDocument.permissions`.
 - [ADR-0041](ADR-0041-immutable-evidence-nodes.md) — `ImmutableEvidenceNode` is the target for
-  commercial `metadata.tenant_id` stamping (Step 3 of migration path).
+  `metadata.tenant_id` stamping when needed by an integration.
 - [ADR-0044](ADR-0044-tool-gates.md) — resource-scoped gate enforcement (specificity 3) takes
   precedence over tenant-scoped rules (specificity 1).
 - [ADR-0046](ADR-0046-jit-tool-grant.md) — JIT grants are policy-scoped; tenant context flows

--- a/docs/adrs/ADR-0070-governance-tracing.md
+++ b/docs/adrs/ADR-0070-governance-tracing.md
@@ -1,6 +1,6 @@
 # ADR-0070: Governance Tracing and Observability
 
-**Status**: Accepted
+**Status**: accepted
 **Date**: 2026-05-27
 **Depends on**: [ADR-0041](ADR-0041-immutable-evidence-nodes.md) (EvidenceChain), [ADR-0042](ADR-0042-task-certificate.md) (TaskCertificate), [ADR-0044](ADR-0044-tool-gates.md) (GateResult), [ADR-0045](ADR-0045-break-glass-protocol.md) (BreakGlassWindow)
 **Related**: [ADR-0048](ADR-0048-agent-segregation-of-duties.md) (SoD), [ADR-0049](ADR-0049-log-tier-governance.md) (LogTier), [ADR-0050](ADR-0050-operation-context.md) (OperationContext), [ADR-0052](ADR-0052-policy-resolution.md) (PolicyResolution)
@@ -129,10 +129,10 @@ listed here are permitted but must not conflict with the listed keys.
 | `gate.verdict` | string | Yes | Uppercase: `"ALLOW"`, `"DENY"`, or `"ADVISORY"`. |
 | `gate.enforcement` | string | Yes | `"HARD"`, `"SOFT"`, or `"ADVISORY"`. |
 | `gate.elapsed_ms` | float | Yes | Wall-clock gate evaluation time in milliseconds. |
-| `gate.evidence.hash` | string | Recommended | SHA-256 hash of the corresponding `GateResult` node. |
-| `gate.reason` | string | Recommended | Human-readable explanation of the verdict. |
-| `gate.policy.version` | string | Recommended | Policy release identifier active at evaluation time. |
-| `gate.charter.id` | string | Recommended | Charter identifier active at evaluation time. |
+| `gate.evidence.hash` | string | Yes | SHA-256 hash of the corresponding `GateResult` node. |
+| `gate.reason` | string | Yes | Human-readable explanation of the verdict. |
+| `gate.policy.version` | string | Yes | Policy release identifier active at evaluation time. |
+| `gate.charter.id` | string | Yes | Charter identifier active at evaluation time. |
 | `governance.severity` | string | Recommended | `"INFO"` for ALLOW, `"ERROR"` for DENY, `"WARN"` for soft override. |
 
 The span `status` is set to `"error"` when `gate.verdict == "DENY"` and `"ok"` otherwise.

--- a/docs/adrs/ADR-0070-governance-tracing.md
+++ b/docs/adrs/ADR-0070-governance-tracing.md
@@ -1,0 +1,608 @@
+# ADR-0070: Governance Tracing and Observability
+
+**Status**: Accepted
+**Date**: 2026-05-27
+**Depends on**: [ADR-0041](ADR-0041-immutable-evidence-nodes.md) (EvidenceChain), [ADR-0042](ADR-0042-task-certificate.md) (TaskCertificate), [ADR-0044](ADR-0044-tool-gates.md) (GateResult), [ADR-0045](ADR-0045-break-glass-protocol.md) (BreakGlassWindow)
+**Related**: [ADR-0048](ADR-0048-agent-segregation-of-duties.md) (SoD), [ADR-0049](ADR-0049-log-tier-governance.md) (LogTier), [ADR-0050](ADR-0050-operation-context.md) (OperationContext), [ADR-0052](ADR-0052-policy-resolution.md) (PolicyResolution)
+
+## Context
+
+Every governance decision in a governed lionagi session — gate evaluations, certificate minting,
+break-glass activations, segregation-of-duties checks, and policy resolutions — must be auditable
+after the fact. Today the authoritative records for these events are `ImmutableEvidenceNode`
+instances (ADR-0041), `GateResult` objects (ADR-0044), and `TaskCertificate` records (ADR-0042).
+Those typed records answer "what happened and can it be verified?" but they do not integrate with
+the distributed tracing vocabulary that enterprise observability stacks speak: Datadog, Grafana
+Tempo, Jaeger, Honeycomb, and OpenTelemetry-compliant collectors all ingest spans with a defined
+structure. Without a span layer, operations teams must build bespoke bridges between lionagi's
+evidence records and their existing dashboards.
+
+The gap becomes concrete in three ways:
+
+1. **Alert latency.** A security engineer who needs "alert me when any hard gate denial fires"
+   cannot write a Datadog monitor against raw Python objects. Spans with structured attributes can
+   be indexed and alerted on without custom exporters.
+
+2. **Distributed trace correlation.** When a governed session runs inside a larger request trace
+   (HTTP service, orchestrator pipeline), there is no standard mechanism to attach governance
+   sub-spans to the parent trace. A span emitted with a W3C-compatible `trace_id` can be joined to
+   the parent trace by any OTel-compatible backend.
+
+3. **In-process testing.** Governance unit tests need a way to assert "this gate was evaluated
+   with these attributes." Asserting against spans in memory is far easier than asserting against
+   raw evidence node content-hashes.
+
+The constraint that shapes every design option is **zero external dependencies**. lionagi is a
+library installed into diverse Python environments. Requiring `opentelemetry-sdk` as a hard
+dependency would conflict with users' existing OTel configurations, add ~5 MB to the install
+footprint, and introduce transitive version constraints. The tracing layer must work without any
+external package.
+
+The secondary constraint is **span authority**. Governance spans are not general application
+performance traces. They carry governance decisions with legal and compliance significance. The
+authoritative record for any governance decision is always the typed evidence node, not the span.
+Spans are projections — they make the evidence observable to external tools. They must be
+consistent with the evidence but must never substitute for it.
+
+## Decision
+
+Introduce `GovernanceTracer` as a lightweight in-process span recorder that satisfies both the
+zero-dependency constraint and the OTel-compatibility requirement. The tracer records
+`GovernanceSpan` objects in memory and exports them in OTel-compatible JSON format on demand.
+
+The design has five load-bearing choices:
+
+**1. OTel-compatible but not OTel-dependent.** `GovernanceSpan.to_otel_dict()` produces a dict
+that mirrors the OTel SDK `ReadableSpan` JSON structure — including `traceId`, `spanId`,
+`startTimeUnixNano`, `endTimeUnixNano`, `attributes` as key-value pairs, and a `status` object.
+A user who installs `opentelemetry-sdk` can feed this dict directly into a
+`BatchSpanProcessor` without any translation layer. A user who does not install it still gets
+structured span data they can serialize to JSONL and forward with any HTTP client.
+
+**2. One tracer per logical trace.** `GovernanceTracer` takes an optional `trace_id` at
+construction. All spans produced by one tracer share that `trace_id`. When a governed session
+spans multiple operations, the session can create one tracer at the start and pass it through,
+producing a single coherent trace tree. Alternatively, each operation can create its own tracer
+for isolated in-process collection.
+
+**3. SpanName constants as a controlled vocabulary.** Hard-coded string span names scatter naming
+decisions across call sites and produce inconsistently-named traces. `SpanName` is a class of
+class-level string constants whose values follow the `{domain}.{operation}[.{detail}]` pattern
+documented in `docs/governance/standards/trace-naming.md`. Every call site imports from
+`SpanName`; the naming standard is enforced at the import level, not by convention.
+
+**4. Convenience functions for common patterns.** The two highest-volume governance spans —
+`gate.evaluate` and `certificate.mint` — each have a dedicated convenience function
+(`trace_gate_evaluation`, `trace_certificate_mint`) that open, populate, and close a span in a
+single call. This eliminates the start/end boilerplate and ensures the standard required
+attributes for those span types are always present.
+
+**5. Export is pull-based.** The tracer accumulates spans in a list. Callers export them via
+`tracer.export()` (plain dicts) or `tracer.to_otel_compatible()` (OTel format) on demand.
+There is no push, no background thread, and no network I/O in the tracer itself. The caller is
+responsible for routing exported spans to any external system.
+
+## Span Schema
+
+### GovernanceSpan Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `span_id` | `str` (hex UUID) | Unique identifier for this span. |
+| `trace_id` | `str` (hex UUID) | Shared identifier for all spans in this logical trace. |
+| `parent_span_id` | `str \| None` | Hex span ID of the parent span, or `None` for root spans. |
+| `name` | `str` | Span name — must be a `SpanName` constant. |
+| `start_time` | `float` | Unix epoch seconds (float) at span start. |
+| `end_time` | `float \| None` | Unix epoch seconds at span close, or `None` while open. |
+| `attributes` | `dict[str, Any]` | Structured key-value metadata. See attribute schemas below. |
+| `events` | `list[SpanEvent]` | Ordered list of point-in-time events within the span. |
+| `status` | `str` | Completion status: `"ok"`, `"error"`, or `"unset"`. |
+
+`duration_ms` is a derived property: `(end_time - start_time) * 1000`. It is included in
+`to_dict()` output but is not a stored field.
+
+Every span receives `governance.schema.version` in its attributes at construction time. The
+current schema version is `"2026-05-27.v1"`.
+
+### SpanEvent Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `str` | Short event label, e.g. `"gate.fired"` or `"evidence.appended"`. |
+| `timestamp` | `float` | Unix epoch seconds when the event occurred. |
+| `attributes` | `dict[str, Any]` | Key-value metadata for the event. |
+
+### Attribute Schemas by Span Type
+
+The following tables list the standard attributes for each governance span type. These attributes
+align with the Span Registry in `docs/governance/standards/trace-naming.md`. Attributes not
+listed here are permitted but must not conflict with the listed keys.
+
+#### gate.evaluate
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `governance.schema.version` | string | Yes | Schema version constant. |
+| `governance.retention.tier` | string | Yes | Always `"IMMUTABLE"` for gate evaluations. |
+| `gate.id` | string | Yes | Gate function identifier, e.g. `"verify_in_registry"`. |
+| `gate.tool.name` | string | Yes | Tool name being guarded, e.g. `"file.write"`. |
+| `gate.verdict` | string | Yes | Uppercase: `"ALLOW"`, `"DENY"`, or `"SKIP"`. |
+| `gate.enforcement` | string | Yes | `"HARD"`, `"SOFT"`, or `"ADVISORY"`. |
+| `gate.elapsed_ms` | float | Yes | Wall-clock gate evaluation time in milliseconds. |
+| `gate.evidence.hash` | string | Recommended | SHA-256 hash of the corresponding `GateResult` node. |
+| `gate.reason` | string | Recommended | Human-readable explanation of the verdict. |
+| `gate.policy.version` | string | Recommended | Policy release identifier active at evaluation time. |
+| `gate.charter.id` | string | Recommended | Charter identifier active at evaluation time. |
+| `governance.severity` | string | Recommended | `"INFO"` for ALLOW, `"ERROR"` for DENY, `"WARN"` for soft override. |
+
+The span `status` is set to `"error"` when `gate.verdict == "DENY"` and `"ok"` otherwise.
+
+#### certificate.mint
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `governance.schema.version` | string | Yes | Schema version constant. |
+| `governance.retention.tier` | string | Yes | Always `"IMMUTABLE"` for certificate minting. |
+| `certificate.id` | string | Yes | `TaskCertificate.certificate_id`. |
+| `certificate.task.id` | string | Yes | `TaskCertificate.session_id`. |
+| `certificate.grade` | string | Yes | Certificate grade value (e.g. `"A"`, `"DEGRADED"`). |
+| `certificate.gates.passed` | int | Yes | Count of gates that returned ALLOW. |
+| `certificate.gates.failed` | int | Yes | Count of gates that returned DENY. |
+| `certificate.evidence.chain.hash` | string | Yes | Hash of the evidence chain head at minting time. |
+| `certificate.duration_ms` | float | Yes | Wall-clock task duration from start to certificate mint. |
+| `governance.charter.id` | string | Yes | Charter identifier under which the certificate was minted. |
+| `certificate.defensibility` | string | Recommended | `"FULL"`, `"DEGRADED"`, or `"INVALID"`. |
+| `certificate.break.glass` | boolean | Recommended | `true` if any break-glass window was active during the task. |
+
+#### breakglass.open
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `governance.schema.version` | string | Yes | Schema version constant. |
+| `governance.retention.tier` | string | Yes | Always `"IMMUTABLE"`. |
+| `breakglass.window.id` | string | Yes | Unique identifier for this emergency window. |
+| `breakglass.activated.at` | string | Yes | ISO-8601 UTC timestamp of activation. |
+| `breakglass.requested.by` | string | Yes | Actor ID of the requesting party. |
+| `breakglass.approved.by` | string | Yes | Actor ID of the approving authority. |
+| `breakglass.reason` | string | Yes | Reason code: `"incident_response"`, `"data_loss_prevention"`, etc. |
+| `breakglass.max.duration` | string | Yes | Maximum window lifetime, e.g. `"30m"`. |
+| `breakglass.evidence.hash` | string | Yes | Hash of the `BreakGlassEvent` evidence node. |
+| `governance.severity` | string | Yes | Always `"CRITICAL"` for break-glass activation. |
+
+#### sod.check
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `governance.schema.version` | string | Yes | Schema version constant. |
+| `governance.retention.tier` | string | Yes | Always `"IMMUTABLE"`. |
+| `sod.role` | string | Yes | Role being checked against the SoD rule. |
+| `sod.capability` | string | Yes | Capability or tool the role is attempting to access. |
+| `sod.verdict` | string | Yes | `"PASS"` or `"FAIL"`. |
+| `sod.policy.version` | string | Yes | SoD policy release version. |
+| `sod.evidence.hash` | string | Recommended | Hash of the `SoDCheckResult` evidence node. |
+| `governance.severity` | string | Recommended | `"INFO"` for PASS, `"ERROR"` for FAIL. |
+
+#### policy.resolve
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `governance.schema.version` | string | Yes | Schema version constant. |
+| `governance.retention.tier` | string | Yes | Always `"IMMUTABLE"`. |
+| `policy.count` | int | Yes | Number of policies evaluated. |
+| `policy.strategy` | string | Yes | Resolution strategy used, e.g. `"most_restrictive"`. |
+| `policy.winner` | string | Yes | Identifier of the winning policy. |
+| `policy.version` | string | Yes | Active policy release version. |
+| `policy.conflict.count` | int | Yes | Number of policy conflicts detected before resolution. |
+| `policy.evidence.hash` | string | Recommended | Hash of the `PolicyResolutionRecord` evidence node. |
+
+## SpanName Vocabulary
+
+`SpanName` is a class of string constants whose values follow the
+`{domain}.{operation}[.{detail}]` naming pattern. All constants are cross-referenced to their
+canonical definitions in `docs/governance/standards/trace-naming.md`.
+
+### Governance Session and Operation Lifecycle
+
+| Constant | Value | What It Tracks |
+|----------|-------|----------------|
+| `GOVERNANCE_SESSION` | `"governance.session"` | Root span for an entire governed session. Created once per session; parent of all operation spans. |
+| `GOVERNANCE_OPERATION` | `"governance.operation"` | One governed tool invocation (pre-gate through post-gate). Child of `governance.session`. |
+| `GOVERNANCE_FLOW` | `"governance.flow"` | A multi-operation `Session.flow()` DAG governed as a unit. Child of `governance.session`. |
+
+### Gate Evaluation Family
+
+| Constant | Value | What It Tracks |
+|----------|-------|----------------|
+| `GATE_EVALUATION` | `"gate.evaluate"` | Single gate function evaluation against one tool call. The primary enforcement-point span. |
+| `GATE_JUSTIFY` | `"gate.justify"` | A soft-gate denial that was overridden with explicit human justification evidence. |
+| `GATE_BYPASS` | `"gate.bypass"` | Gate bypassed under a break-glass window; records the window ID and bypass authority. |
+
+### Break-Glass Lifecycle Family
+
+| Constant | Value | What It Tracks |
+|----------|-------|----------------|
+| `BREAK_GLASS_OPEN` | `"breakglass.open"` | Emergency window activation; CRITICAL severity. |
+| `BREAK_GLASS_EXPIRE` | `"breakglass.expire"` | Window reached its maximum duration without explicit close. |
+| `BREAK_GLASS_CLOSE` | `"breakglass.close"` | Window closed explicitly by an authorized actor. |
+| `BREAK_GLASS_NOTIFY` | `"breakglass.notify"` | Notification dispatched to an on-call target during or after a break-glass event. |
+
+The alias `BREAK_GLASS_ACTIVATE` maps to `BREAK_GLASS_OPEN` for backward compatibility.
+
+### Evidence Family
+
+| Constant | Value | What It Tracks |
+|----------|-------|----------------|
+| `EVIDENCE_EMIT` | `"evidence.emit"` | A new `EvidenceNode` appended to an `EvidenceChain`. |
+| `EVIDENCE_VERIFY` | `"evidence.verify"` | A chain integrity verification run, including the result and failure reason if applicable. |
+
+The alias `EVIDENCE_APPEND` maps to `EVIDENCE_EMIT` for backward compatibility.
+
+### Certificate Family
+
+| Constant | Value | What It Tracks |
+|----------|-------|----------------|
+| `CERTIFICATE_MINT` | `"certificate.mint"` | Task certificate minted at the end of a governed run. |
+| `CERTIFICATE_STATE` | `"certificate.state"` | Certificate state transition (e.g. from `PENDING` to `VALID` or `SUPERSEDED`). |
+| `CERTIFICATE_VERIFY` | `"certificate.verify"` | Certificate verification query, including replay-detection result. |
+
+### Permit Family
+
+| Constant | Value | What It Tracks |
+|----------|-------|----------------|
+| `PERMIT_ISSUE` | `"permit.issue"` | JIT permit issued to an actor for a bounded capability. |
+| `PERMIT_CONSUME` | `"permit.consume"` | JIT permit consumed by an actor invoking the permitted tool. |
+| `PERMIT_REVOKE` | `"permit.revoke"` | JIT permit revoked before natural expiry. |
+
+### Charter Family
+
+| Constant | Value | What It Tracks |
+|----------|-------|----------------|
+| `CHARTER_LOAD` | `"charter.load"` | Charter DSL loaded and compiled into active gate configuration. |
+| `CHARTER_EVALUATE` | `"charter.evaluate"` | Single charter constraint evaluation against an operation. |
+| `CHARTER_VIOLATION` | `"charter.violation"` | Charter constraint violated; carries severity and reason. |
+
+### Registry, SoD, and Policy Family
+
+| Constant | Value | What It Tracks |
+|----------|-------|----------------|
+| `SOD_CHECK` | `"sod.check"` | Segregation-of-duties check for a role-capability pair. |
+| `REGISTRY_LOOKUP` | `"registry.lookup"` | Tool registry allowlist lookup for a (tool, role) pair. |
+| `POLICY_RESOLVE` | `"policy.resolve"` | Policy conflict resolution, producing one winning policy. |
+
+## Integration Patterns
+
+### Pattern 1: In-Process Collection for Testing
+
+The simplest integration requires no external dependencies. Create a tracer before the operation
+under test and assert against its spans afterward:
+
+```python
+from lionagi.protocols.governance.tracing import GovernanceTracer, SpanName
+
+tracer = GovernanceTracer()
+
+# ... execute governed operation ...
+
+spans = tracer.export()
+gate_spans = [s for s in spans if s["name"] == SpanName.GATE_EVALUATION]
+assert len(gate_spans) == 1
+assert gate_spans[0]["attributes"]["gate.verdict"] == "ALLOW"
+assert gate_spans[0]["status"] == "ok"
+```
+
+This pattern works without any installed observability packages and is the recommended approach
+for governance unit tests.
+
+### Pattern 2: OTel Export to a Collector
+
+Users who have `opentelemetry-sdk` installed can feed exported spans directly into an OTel SDK
+span processor:
+
+```python
+from opentelemetry.sdk.trace.export import BatchSpanExporter
+from opentelemetry.sdk.trace import ReadableSpan
+
+from lionagi.protocols.governance.tracing import GovernanceTracer
+
+tracer = GovernanceTracer()
+
+# ... governed operations ...
+
+otel_dicts = tracer.to_otel_compatible()
+
+# Convert dicts to ReadableSpan objects via OTel SDK (no custom adapter needed
+# when the dict structure matches the SDK's internal JSON representation).
+# Alternatively, POST otel_dicts directly to a collector HTTP endpoint:
+#
+#   import httpx
+#   httpx.post("https://otel-collector/v1/traces", json={"resourceSpans": [...]})
+```
+
+The `to_otel_compatible()` method returns a list of dicts whose keys (`traceId`, `spanId`,
+`parentSpanId`, `startTimeUnixNano`, `endTimeUnixNano`, `attributes`, `events`, `status`) match
+the OTel Protocol JSON representation. No translation layer is required.
+
+### Pattern 3: Custom JSON/JSONL Export
+
+For deployments that ingest spans via log forwarding (Filebeat, Fluentd, Loki) rather than OTel
+collectors:
+
+```python
+import json
+from lionagi.protocols.governance.tracing import GovernanceTracer
+
+tracer = GovernanceTracer()
+
+# ... governed operations ...
+
+with open("governance-spans.jsonl", "a") as fh:
+    for span in tracer.export():
+        fh.write(json.dumps(span) + "\n")
+```
+
+`tracer.export()` returns plain Python dicts with ISO-8601 timestamps. The output is suitable
+for any JSON-based log ingestion pipeline.
+
+### Pattern 4: Evidence Chain Correlation
+
+Governance spans are projections over typed evidence records. They are correlated to their
+authoritative evidence nodes via hash attributes. When a gate evaluation fires:
+
+1. The gate creates a `GateResult` evidence node (ADR-0044) and appends it to the session's
+   `EvidenceChain` (ADR-0041). The node carries a `node_hash`.
+2. `trace_gate_evaluation()` records a `gate.evaluate` span. The caller passes
+   `extra_attributes={"gate.evidence.hash": gate_result.node_hash}` to embed the correlation
+   pointer in the span.
+3. An external auditor who receives the span can locate the authoritative `GateResult` record by
+   looking up the hash in the evidence store.
+
+This one-way reference (span points to evidence; evidence does not point to spans) keeps the
+evidence chain independent of the observability layer. Evidence correctness does not depend on
+span completeness.
+
+### Pattern 5: Parent Span Linkage
+
+Governance sub-spans can be nested under a parent trace span for distributed correlation:
+
+```python
+from lionagi.protocols.governance.tracing import (
+    GovernanceTracer, SpanName, trace_gate_evaluation
+)
+
+tracer = GovernanceTracer(trace_id="<w3c-trace-id-from-parent>")
+
+# Create a root operation span
+op_span = tracer.start_span(
+    SpanName.GOVERNANCE_OPERATION,
+    attributes={"governance.operation.name": "invoke_tool"},
+)
+
+# Gate evaluation is a child of the operation span
+gate_span = trace_gate_evaluation(
+    tracer=tracer,
+    gate_id="check_registry",
+    tool_name="file.write",
+    verdict="ALLOW",
+    elapsed_ms=1.2,
+    parent_span_id=op_span.span_id,
+)
+
+tracer.end_span(op_span)
+```
+
+Setting `trace_id` to a W3C-compatible hex string allows governance spans to be joined to a
+parent distributed trace in any OTel-compatible backend.
+
+## Sampling and Performance
+
+### Sampling Policy
+
+The retention tier of each span type governs its sampling obligation:
+
+| Tier | Obligation | Rationale |
+|------|------------|-----------|
+| `IMMUTABLE` | 100% — never drop | Gate decisions, certificates, break-glass, evidence, permits, charter events, SoD checks, registry decisions, policy resolutions carry compliance significance. Dropping any of these is an audit gap. |
+| `PROTECTED` | 100% for governed sessions | Session and flow lifecycle summaries; dropped only for ungoverned dev sessions where governance guarantees are explicitly not claimed. |
+| `MUTABLE` | May be sampled | Debug-only operational spans that do not carry required governance evidence. |
+
+The `GovernanceTracer` itself does not implement sampling — it records all spans passed to it.
+Sampling decisions belong to the export layer. When export is backpressured, write local evidence
+first and mark the export failure with a protected operational evidence record rather than
+silently dropping the span.
+
+The following span types must never be sampled away regardless of export pressure:
+
+- All `gate.*` spans with verdict `"DENY"`
+- All `breakglass.*` spans
+- All `certificate.*` spans
+- All `permit.*` spans
+- All `sod.check` spans with verdict `"FAIL"`
+- All `charter.violation` spans
+
+### Performance Characteristics
+
+`GovernanceSpan` construction is O(1): it allocates a `GovernanceSpan` Pydantic model, calls
+`time.time()` once, generates a `uuid.uuid4().hex` span ID, and appends to a list.
+
+`GovernanceTracer.export()` is O(n) in the number of recorded spans, where n is bounded by the
+number of governance events in one session. Governance events are low-frequency relative to
+application request volume — a typical governed session with 10 tool calls produces on the order
+of 10–50 spans, not thousands.
+
+`to_otel_compatible()` is O(n) and allocates one dict per span. For large sessions or batch
+export, callers can iterate `tracer._spans` directly and serialize in chunks:
+
+```python
+for span in tracer._spans:
+    process(span.to_otel_dict())
+```
+
+There is no background thread, no lock, and no I/O in the tracer core. It is safe to create and
+use from any coroutine context.
+
+## Redaction Before External Export
+
+Governance spans may contain decision rationale, actor identifiers, and tool names. Before
+exporting spans to external systems, callers must apply redaction appropriate to their
+deployment's data governance policy:
+
+```python
+import copy
+from lionagi.protocols.governance.tracing import GovernanceTracer
+
+REDACT_KEYS = {"gate.reason", "breakglass.reason", "breakglass.requested.by"}
+
+def redacted_export(tracer: GovernanceTracer) -> list[dict]:
+    result = []
+    for span in tracer.export():
+        span_copy = copy.deepcopy(span)
+        for key in REDACT_KEYS:
+            if key in span_copy["attributes"]:
+                span_copy["attributes"][key] = "<redacted>"
+        result.append(span_copy)
+    return result
+```
+
+Hashes (`gate.evidence.hash`, `breakglass.evidence.hash`) do not require redaction because they
+are SHA-256 digests that reveal nothing about the underlying content.
+
+## Non-Goals
+
+The following concerns are explicitly out of scope for this ADR and for `GovernanceTracer`:
+
+**No distributed span propagation in OSS.** `GovernanceTracer` does not implement W3C TraceContext
+injection or extraction. In-process span correlation via `trace_id` and `parent_span_id` is
+supported. Cross-process span context propagation for multi-service deployments is a commercial
+offering.
+
+**No automatic instrumentation of non-governance code.** `GovernanceTracer` only records spans
+for governance events. Application-level performance tracing (HTTP request durations, database
+query times) is the responsibility of the application's chosen OTel SDK integration.
+
+**No OTel SDK dependency.** The `opentelemetry-sdk` package must not appear in lionagi's
+dependencies. `GovernanceSpan.to_otel_dict()` produces an OTel-compatible dict; wiring that
+dict into OTel SDK types is the caller's responsibility.
+
+**No tenant-specific trace routing.** Routing spans from different tenants to different OTel
+collectors or namespaces requires tenant-aware export logic, which is a commercial feature.
+The OSS tracer emits all spans to the same in-process list.
+
+**No span persistence.** `GovernanceTracer` holds spans in memory for the lifetime of the tracer
+object. Persistence to a durable store is out of scope; callers who need persistence export
+spans to JSONL (Pattern 3 above) or feed them to a collector.
+
+**No trace context injection into outbound HTTP.** The tracer does not intercept requests made by
+governed tools and does not inject trace headers. This is the application's concern, not
+governance's.
+
+## Security Considerations
+
+### Span Sensitivity
+
+Break-glass activation spans are IMMUTABLE-tier governance evidence. The `breakglass.open` span
+records activation timestamp, requester identity, approver identity, and reason. These attributes
+must be handled with the same access controls as `BreakGlassEvent` evidence nodes. Before
+forwarding break-glass spans to external collectors, operators should confirm the collector's
+data residency and access controls meet their compliance requirements.
+
+Gate denial spans (`gate.verdict == "DENY"`) record the name of the tool that was blocked. In
+some deployments, the set of tools an agent attempted to invoke is sensitive information.
+Operators should apply redaction to `gate.tool.name` if tool-name disclosure is a concern.
+
+### Attribute Hashing
+
+Tool argument values must not appear in span attributes. Tool arguments may contain secrets,
+PII, or proprietary data. The correct correlation mechanism is a hash reference:
+`extra_attributes={"gate.evidence.hash": sha256_of_gate_result}`. The underlying content
+stays in the evidence store; the span carries only the pointer.
+
+This rule is explicit in `trace_gate_evaluation()` and `trace_certificate_mint()`: neither
+convenience function accepts raw tool argument parameters. Only structured metadata (IDs,
+verdicts, counts, durations) is recorded in the span attributes.
+
+### Immutability of Break-Glass Spans
+
+Once a `breakglass.open` span is closed, its attributes reflect an IMMUTABLE-tier governance
+event. Applications must not mutate span attributes after `end_span()` is called. The
+`GovernanceSpan.is_ended` property allows callers to check whether a span has been closed.
+Calling `end_span()` on an already-ended span is a no-op (idempotent), but attribute values
+recorded at close time are final.
+
+### Trace ID Predictability
+
+`GovernanceTracer` generates `trace_id` via `uuid.uuid4().hex`. This provides 122 bits of
+randomness, which is sufficient to prevent trace ID collision in any single deployment. Callers
+who need to join governance spans to an existing distributed trace should pass their parent
+system's trace ID at construction time rather than allowing the tracer to generate one.
+
+## Consequences
+
+**Positive**
+
+- Enterprise observability stacks (Datadog, Grafana Tempo, Jaeger) can ingest governance spans
+  without custom adapters. The `to_otel_compatible()` export is a direct feed to any OTel
+  collector endpoint.
+- Governance unit tests can assert on span attributes rather than evidence node hashes, which
+  is dramatically simpler. `tracer.export()` returns plain Python dicts — no special assertion
+  helpers required.
+- The zero-dependency constraint is enforced at the architecture level: no import of
+  `opentelemetry.*` appears in the tracer module. A future dependency audit cannot break this
+  guarantee without modifying the tracer source.
+- `SpanName` constants make span-name typos a static analysis problem rather than a runtime
+  mystery. A misspelled `SpanName.GATE_EVALUAION` fails at import time.
+- The convenience functions `trace_gate_evaluation()` and `trace_certificate_mint()` enforce
+  required attribute presence at the call site. A gate that forgets to record `gate.verdict`
+  is impossible when the only supported path is through the convenience function.
+- Pull-based export gives callers full control over batching, retries, and backpressure handling.
+  The tracer never blocks on I/O.
+
+**Negative**
+
+- The tracer holds all spans in memory for its lifetime. For extremely long-lived sessions with
+  thousands of governance events, this adds heap pressure. Callers are responsible for
+  periodically exporting and clearing the tracer.
+- There is no built-in span deduplication. If `trace_gate_evaluation()` is called twice for
+  the same gate (e.g., due to retry logic), two spans are recorded. Deduplication is the caller's
+  responsibility at export time.
+- Pull-based export means spans can be lost if a session terminates abnormally before the caller
+  calls `export()`. Sessions that require durable span delivery should export spans to JSONL on
+  every span creation rather than batching at session end.
+- `to_otel_compatible()` produces dicts, not OTel SDK `ReadableSpan` objects. Callers who want
+  to use OTel SDK features (custom attribute processors, SDK-level sampling) must bridge the
+  dict representation to SDK types themselves.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Require `opentelemetry-sdk` as a hard dependency | Conflicts with users' existing OTel configurations; adds ~5 MB install footprint; introduces transitive SDK version constraints that break pinned environments. Zero-dep constraint is non-negotiable for a library. |
+| Emit spans directly to `logging.Logger` with structured JSON | Logging is already used for operational output. Mixing governance spans into the log stream makes it harder to route governance data to compliance-specific sinks. Spans and logs have different lifecycle semantics: logs are fire-and-forget; spans have start/end time and parent relationships. |
+| Subclass `opentelemetry.sdk.trace.Span` | Requires importing the OTel SDK, which violates the zero-dep constraint. Also locks the internal data model to OTel SDK internals that change across minor versions. |
+| Store spans in the `EvidenceChain` directly | Evidence nodes are designed for authoritative audit records, not telemetry projections. Embedding spans in the chain conflates two concerns: tamper-evident correctness (evidence) and real-time observability (spans). Evidence nodes are immutable after construction; spans need to accumulate attributes while open. |
+| Custom binary protocol (MessagePack, protobuf) | Adds complexity without benefit for in-process collection. Plain Python dicts and ISO-8601 timestamps are debuggable with zero tooling. Binary formats are only beneficial when serialization throughput is the bottleneck, which it is not for low-volume governance events. |
+| Push-based export via background thread | Adds a threading dependency and makes the tracer's lifecycle non-trivial (start/stop, exception handling in background thread). Pull-based export keeps the tracer stateless and synchronous, which is simpler and sufficient for governance event volumes. |
+
+## References
+
+- [ADR-0041](ADR-0041-immutable-evidence-nodes.md) — Immutable Evidence Nodes; `EvidenceChain`
+  and `EvidenceNode` that governance spans correlate to via hash attributes.
+- [ADR-0042](ADR-0042-task-certificate.md) — Task Certificate; `trace_certificate_mint()`
+  records the certificate minting event in the trace.
+- [ADR-0044](ADR-0044-tool-gates.md) — Tool Gates; `trace_gate_evaluation()` records every
+  gate evaluation, including the verdict and enforcement tier.
+- [ADR-0045](ADR-0045-break-glass-protocol.md) — Break-Glass Protocol; `BREAK_GLASS_OPEN`,
+  `BREAK_GLASS_EXPIRE`, `BREAK_GLASS_CLOSE`, and `BREAK_GLASS_NOTIFY` spans record the
+  emergency lifecycle.
+- [ADR-0048](ADR-0048-agent-segregation-of-duties.md) — Agent Segregation of Duties;
+  `SOD_CHECK` spans record SoD check verdicts.
+- [ADR-0049](ADR-0049-log-tier-governance.md) — Log Tier Governance; the `IMMUTABLE`,
+  `PROTECTED`, and `MUTABLE` tier classification used in span attribute values and sampling policy.
+- [ADR-0052](ADR-0052-policy-resolution.md) — Policy Resolution; `POLICY_RESOLVE` spans record
+  the resolution strategy and winning policy.
+- `docs/governance/standards/trace-naming.md` — Canonical span name vocabulary, required
+  attribute sets, retention tier definitions, and value conventions. This ADR is the architectural
+  specification; the naming standard is the operational reference.
+- OpenTelemetry Protocol (OTLP) specification — the JSON representation that
+  `GovernanceSpan.to_otel_dict()` targets; no SDK dependency required to read this spec.
+- `lionagi/protocols/governance/tracing.py` — Implementation of `GovernanceTracer`,
+  `GovernanceSpan`, `SpanName`, `trace_gate_evaluation()`, and `trace_certificate_mint()`.

--- a/docs/adrs/ADR-0070-governance-tracing.md
+++ b/docs/adrs/ADR-0070-governance-tracing.md
@@ -470,10 +470,9 @@ are SHA-256 digests that reveal nothing about the underlying content.
 
 The following concerns are explicitly out of scope for this ADR and for `GovernanceTracer`:
 
-**No distributed span propagation in OSS.** `GovernanceTracer` does not implement W3C TraceContext
+**No distributed span propagation.** `GovernanceTracer` does not implement W3C TraceContext
 injection or extraction. In-process span correlation via `trace_id` and `parent_span_id` is
-supported. Cross-process span context propagation for multi-service deployments is a commercial
-offering.
+supported.
 
 **No automatic instrumentation of non-governance code.** `GovernanceTracer` only records spans
 for governance events. Application-level performance tracing (HTTP request durations, database
@@ -483,9 +482,7 @@ query times) is the responsibility of the application's chosen OTel SDK integrat
 dependencies. `GovernanceSpan.to_otel_dict()` produces an OTel-compatible dict; wiring that
 dict into OTel SDK types is the caller's responsibility.
 
-**No tenant-specific trace routing.** Routing spans from different tenants to different OTel
-collectors or namespaces requires tenant-aware export logic, which is a commercial feature.
-The OSS tracer emits all spans to the same in-process list.
+**No tenant-specific trace routing.** All spans are emitted to the same in-process list.
 
 **No span persistence.** `GovernanceTracer` holds spans in memory for the lifetime of the tracer
 object. Persistence to a durable store is out of scope; callers who need persistence export

--- a/docs/adrs/ADR-0070-governance-tracing.md
+++ b/docs/adrs/ADR-0070-governance-tracing.md
@@ -126,7 +126,7 @@ listed here are permitted but must not conflict with the listed keys.
 | `governance.retention.tier` | string | Yes | Always `"IMMUTABLE"` for gate evaluations. |
 | `gate.id` | string | Yes | Gate function identifier, e.g. `"verify_in_registry"`. |
 | `gate.tool.name` | string | Yes | Tool name being guarded, e.g. `"file.write"`. |
-| `gate.verdict` | string | Yes | Uppercase: `"ALLOW"`, `"DENY"`, or `"SKIP"`. |
+| `gate.verdict` | string | Yes | Uppercase: `"ALLOW"`, `"DENY"`, or `"ADVISORY"`. |
 | `gate.enforcement` | string | Yes | `"HARD"`, `"SOFT"`, or `"ADVISORY"`. |
 | `gate.elapsed_ms` | float | Yes | Wall-clock gate evaluation time in milliseconds. |
 | `gate.evidence.hash` | string | Recommended | SHA-256 hash of the corresponding `GateResult` node. |

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -116,7 +116,7 @@ Example: `_Supersedes [ADR-0001](ADR-0001-lion-studio-internal-app.md)._`
 | [ADR-0066](ADR-0066-unified-execution-viewer.md) | Unified execution viewer | Proposed |
 | [ADR-0067](ADR-0067-studio-command-chat.md) | Studio command chat — universal AI-powered control panel | Proposed |
 | [ADR-0068](ADR-0068-governed-adapter-protocol.md) | Zero-rewrite governed adapter protocol | Accepted |
-| [ADR-0069](ADR-0069-tenant-scope-boundary.md) | Tenant scope boundary — OSS hook points vs commercial isolation | Accepted |
+| [ADR-0069](ADR-0069-tenant-scope-boundary.md) | Tenant scope boundary | Accepted |
 | [ADR-0070](ADR-0070-governance-tracing.md) | Governance tracing and observability | Accepted |
 
 See also [Decision Log](DECISION_LOG.md) for lightweight decisions that don't warrant a full ADR.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -7,7 +7,7 @@ layout, distribution model, or process patterns that future contributors should 
 
 Files live in `docs/adrs/` and follow the pattern:
 
-```
+```text
 ADR-NNNN-kebab-case-slug.md
 ```
 
@@ -15,7 +15,7 @@ ADR-NNNN-kebab-case-slug.md
 
 ## Lifecycle
 
-```
+```text
 Proposed → Accepted → Superseded (→ Deprecated, optional)
 ```
 
@@ -70,5 +70,49 @@ Example: `_Supersedes [ADR-0001](ADR-0001-lion-studio-internal-app.md)._`
 | [ADR-0016](ADR-0016-definitions-write-path.md) | Definition write path and versioning | Accepted |
 | [ADR-0017](ADR-0017-session-lifecycle-status.md) | Session lifecycle and status derivation | Accepted |
 | [ADR-0018](ADR-0018-studio-distribution.md) | Studio distribution and local access | Accepted |
+| [ADR-0019](ADR-0019-teams-db-and-run-lifecycle.md) | Teams DB migration and run lifecycle management | Proposed |
+| [ADR-0020](ADR-0020-skill-invocations.md) | Skill invocations — tracking the orchestration layer | Proposed |
+| [ADR-0021](ADR-0021-skill-artifacts-and-reactive-chaining.md) | Skill artifacts, structured output, and reactive chaining | Proposed |
+| [ADR-0022](ADR-0022-run-step-provenance.md) | Run step provenance — model, agent, and provider disclosure | Proposed |
+| [ADR-0023](ADR-0023-unified-hook-system.md) | Unified hook system and agent-level configuration | Proposed |
+| [ADR-0024](ADR-0024-session-health-and-admin-surface.md) | Session health classification and admin surface | Proposed |
+| [ADR-0025](ADR-0025-session-status-vocabulary.md) | Session status vocabulary | Proposed |
+| [ADR-0026](ADR-0026-project-detection.md) | Project detection for session organization | Accepted |
+| [ADR-0027](ADR-0027-scheduled-runs.md) | Scheduled runs and event-triggered invocations | Proposed |
+| [ADR-0028](ADR-0028-status-reason-model.md) | Status reason model | Proposed |
+| [ADR-0029](ADR-0029-artifact-contract.md) | Artifact contract | Proposed |
+| [ADR-0030](ADR-0030-attention-queue.md) | Attention queue | Proposed |
+| [ADR-0031](ADR-0031-entity-header-pattern.md) | Entity header pattern | Proposed |
+| [ADR-0032](ADR-0032-navigation-reorganization.md) | Navigation reorganization | Proposed |
+| [ADR-0041](ADR-0041-immutable-evidence-nodes.md) | Immutable evidence nodes | Proposed |
+| [ADR-0042](ADR-0042-task-certificate.md) | Task certificate — signed proof of process adherence | Proposed |
+| [ADR-0043](ADR-0043-governed-tool-declaration.md) | Governed tool declaration | Proposed |
+| [ADR-0044](ADR-0044-tool-gates.md) | Tool gates — three-tier binary enforcement | Proposed |
+| [ADR-0045](ADR-0045-break-glass-protocol.md) | Break-glass protocol — DEGRADED-defensibility override | Proposed |
+| [ADR-0046](ADR-0046-jit-tool-grant.md) | JIT tool grant — no standing capability for high-risk tools | Proposed |
+| [ADR-0047](ADR-0047-agent-charter.md) | Agent charter — enforceable governance document | Proposed |
+| [ADR-0048](ADR-0048-agent-segregation-of-duties.md) | Agent segregation of duties | Proposed |
+| [ADR-0049](ADR-0049-log-tier-governance.md) | Log tier governance | Proposed |
+| [ADR-0050](ADR-0050-operation-context.md) | Operation context — active assertion in evidence | Proposed |
+| [ADR-0051](ADR-0051-tool-registry-allowlists.md) | Tool registry allowlists | Proposed |
+| [ADR-0052](ADR-0052-policy-resolution.md) | Policy resolution and staged release | Proposed |
+| [ADR-0053](ADR-0053-artifact-persistence.md) | Artifact persistence in state database | Proposed |
+| [ADR-0054](ADR-0054-local-state-cleanup.md) | Local state file cleanup and DB migration completion | Proposed |
+| [ADR-0055](ADR-0055-studio-artifact-viewer.md) | Studio artifact viewer and file reference resolution | Proposed |
+| [ADR-0056](ADR-0056-play-control-api.md) | Play control API — runner control plane | Proposed |
+| [ADR-0057](ADR-0057-remote-sandbox-execution.md) | Remote sandbox execution behind PlayRunner | Proposed |
+| [ADR-0058](ADR-0058-play-cost-tracking.md) | Play cost tracking | Proposed |
+| [ADR-0059](ADR-0059-postgres-state-backend.md) | Postgres state backend | Proposed |
+| [ADR-0060](ADR-0060-unified-config-resolution.md) | Unified config resolution | Proposed |
+| [ADR-0061](ADR-0061-universal-scheduler.md) | Universal scheduler — `li schedule` for any flow | Proposed |
+| [ADR-0062](ADR-0062-state-machine-spec.md) | Scheduled item state machine | Proposed |
+| [ADR-0063](ADR-0063-task-board-work-center.md) | Task board — operator work center for Lion Studio | Proposed |
+| [ADR-0064](ADR-0064-work-system-integration.md) | Work system integration | Accepted |
+| [ADR-0065](ADR-0065-task-board-schema.md) | Task board schema | Proposed |
+| [ADR-0066](ADR-0066-unified-execution-viewer.md) | Unified execution viewer | Proposed |
+| [ADR-0067](ADR-0067-studio-command-chat.md) | Studio command chat — universal AI-powered control panel | Proposed |
+| [ADR-0068](ADR-0068-governed-adapter-protocol.md) | Zero-rewrite governed adapter protocol | Accepted |
+| [ADR-0069](ADR-0069-tenant-scope-boundary.md) | Tenant scope boundary — OSS hook points vs commercial isolation | Accepted |
+| [ADR-0070](ADR-0070-governance-tracing.md) | Governance tracing and observability | Accepted |
 
 See also [Decision Log](DECISION_LOG.md) for lightweight decisions that don't warrant a full ADR.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -84,6 +84,10 @@ Example: `_Supersedes [ADR-0001](ADR-0001-lion-studio-internal-app.md)._`
 | [ADR-0030](ADR-0030-attention-queue.md) | Attention queue | Proposed |
 | [ADR-0031](ADR-0031-entity-header-pattern.md) | Entity header pattern | Proposed |
 | [ADR-0032](ADR-0032-navigation-reorganization.md) | Navigation reorganization | Proposed |
+| [ADR-0033](ADR-0033-unified-entity-state-model.md) | Unified entity state model | Proposed |
+| [ADR-0034](ADR-0034-frontend-data-and-state-architecture.md) | Frontend data and state architecture | Proposed |
+| [ADR-0035](ADR-0035-design-system-and-component-library.md) | Design system and component library | Proposed |
+| [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) | Knowledge substrate minimal interface | Proposed |
 | [ADR-0041](ADR-0041-immutable-evidence-nodes.md) | Immutable evidence nodes | Proposed |
 | [ADR-0042](ADR-0042-task-certificate.md) | Task certificate — signed proof of process adherence | Proposed |
 | [ADR-0043](ADR-0043-governed-tool-declaration.md) | Governed tool declaration | Proposed |

--- a/docs/governance/adr-cross-reference.md
+++ b/docs/governance/adr-cross-reference.md
@@ -23,7 +23,7 @@ definitions and binds each ADR to the implementation play that will build or con
 | governed wrapper bypass rules | ADR-0043 | Runtime path enforced by ActionManager in P17. |
 | `GateResult` | ADR-0044 | Single canonical owner; removed from ADR-0043 and ADR-0050. |
 | `GateEnforcement` | ADR-0044 | `HARD`, `SOFT`, `ADVISORY`. |
-| `GateVerdict` | ADR-0044 | `ALLOW`, `DENY`, `SKIP`. |
+| `GateVerdict` | ADR-0044 | `ALLOW`, `DENY`, `ADVISORY`. |
 | `ToolGate` | ADR-0044 | Gate registration and evaluation contract. |
 | `BreakGlassReason` | ADR-0045 | Emergency reason taxonomy. |
 | `BreakGlassRequest` | ADR-0045 | Emergency request and attestation. |

--- a/docs/governance/adr-cross-reference.md
+++ b/docs/governance/adr-cross-reference.md
@@ -1,0 +1,126 @@
+# Governance ADR Cross-Reference
+
+Status: revised
+Date: 2026-05-27
+Revised: P12
+
+This table is the P12 ownership index for governance ADRs. It prevents duplicate runtime type
+definitions and binds each ADR to the implementation play that will build or consume it.
+
+## Governance Type Ownership
+
+| Governance type or artifact | Canonical ADR owner | Notes |
+|-----------------------------|---------------------|-------|
+| `ImmutableEvidenceNode` | ADR-0041 | Survives P12 unchanged. |
+| `EvidenceRef` | ADR-0041 | ADR-0042 and other ADRs reference, not redefine. |
+| `EvidenceChain` | ADR-0041 | Certificate and trace records embed chain hashes. |
+| `TaskCertificate` | ADR-0042 | Minting in P18; verification/replay in P19. |
+| `CertificateState` | ADR-0042 | Includes `BREAK_GLASS` and supersession states. |
+| `Defensibility` | ADR-0042 | `FULL`, `PARTIAL`, `DEGRADED`, `FAILED`. |
+| certificate grade formula | ADR-0042 | Deterministic P12 formula. |
+| `GovernedToolMeta` | ADR-0043 | Declaration metadata only. |
+| `governed_tool` decorator | ADR-0043 | Attaches metadata; does not decide policy. |
+| governed wrapper bypass rules | ADR-0043 | Runtime path enforced by ActionManager in P17. |
+| `GateResult` | ADR-0044 | Single canonical owner; removed from ADR-0043 and ADR-0050. |
+| `GateEnforcement` | ADR-0044 | `HARD`, `SOFT`, `ADVISORY`. |
+| `GateVerdict` | ADR-0044 | `ALLOW`, `DENY`, `SKIP`. |
+| `ToolGate` | ADR-0044 | Gate registration and evaluation contract. |
+| `BreakGlassReason` | ADR-0045 | Emergency reason taxonomy. |
+| `BreakGlassRequest` | ADR-0045 | Emergency request and attestation. |
+| `BreakGlassWindow` | ADR-0045 | Active emergency lifecycle window. |
+| `BreakGlassEvent` | ADR-0045 | Open, use, close, expire, revoke, notify evidence. |
+| `PermitToken` | ADR-0046 | Single-use elevated permit. |
+| `JITGrant` | ADR-0046 | Grant lifecycle and permit binding. |
+| `AgentCharter` | ADR-0047 | Runtime compiler output, not Python-first source. |
+| `SessionCharter` | ADR-0047 | Runtime compiler output. |
+| `CharterConstraint` | ADR-0047 | Emitted from DSL constraints. |
+| `CharterActivationEvidence` | ADR-0047 | Activation proof and ratification hash evidence. |
+| Charter DSL syntax | docs/governance/charter-dsl-v0.md | ADR-0047 consumes this authoritative spec. |
+| `SoDPolicy` | ADR-0048 | Survives P12 unchanged. |
+| `RoleAssignment` | ADR-0048 | Survives P12 unchanged. |
+| `SoDCheckEvidence` | ADR-0048 | Consumed by charter and certificate flows. |
+| `LogTier` | ADR-0049 | Survives P12 unchanged. |
+| `ServiceContext` | ADR-0050 | Session/branch governance binding. |
+| `OperationContext` | ADR-0050 | Explicit per-operation active assertion. |
+| `OperationActiveAssertion` | ADR-0050 | Evidence embedding projection. |
+| `EvidenceEmission` | ADR-0050 | Operation-local emitted evidence reference. |
+| `GateResultProjection` | ADR-0050 | Reference to ADR-0044 result; not a duplicate result type. |
+| `RegistryCategory` | ADR-0051 | Exact categories from Charter DSL v0. |
+| `RegistryScope` | ADR-0051 | Runtime lookup scope. |
+| `RegistryEntry` | ADR-0051 | Compiled DSL target. |
+| `ToolRegistryPolicy` | ADR-0051 | Runtime registry artifact. |
+| `RegistryLookupResult` | ADR-0051 | Lookup evidence payload. |
+| `PolicyBundle` | ADR-0052 | Survives P12 unchanged. |
+| `PolicyRelease` | ADR-0052 | Survives P12 unchanged. |
+| `PolicyResolver` | ADR-0052 | Most-specific-wins and deny-on-tie owner. |
+| permission resolution semantics | ADR-0052 | DSL permissions compile into this resolver. |
+
+## ADR To Implementation Play
+
+| ADR | Title | P12 status | Implementation play | Implementation responsibility |
+|-----|-------|------------|---------------------|-------------------------------|
+| ADR-0041 | Immutable Evidence Nodes | SURVIVE | P15 | Evidence chain, hash verification, append-only audit pile, tier-aware log integration. |
+| ADR-0042 | Task Certificate | REVISE | P18, P19 | P18 mints certificates; P19 verifies, detects replay, and queries certificate store. |
+| ADR-0043 | Governed Tool Wrapper | REVISE | P17 | Tool metadata, decorator, governed ActionManager route, raw bypass controls. |
+| ADR-0044 | Tool Gates | REVISE | P17 | Canonical `GateResult`, gate executor, hard/soft/advisory behavior. |
+| ADR-0045 | Break-Glass Protocol | REVISE | P19, P20 | Lifecycle evidence and degraded certificate path in P19; spans in P20. |
+| ADR-0046 | JIT Tool Grant | REVISE | P19, P20 | Single-use permits and registry/policy `requires_jit` in P19; permit spans in P20. |
+| ADR-0047 | Agent Charter | REVISE | P13, P14 | DSL parser/schema in P13; compiler, runtime targets, activation evidence in P14. |
+| ADR-0048 | Agent SoD | SURVIVE | P19 | SoD matrix, assignment-time checks, bidirectional conflict tests. |
+| ADR-0049 | Log Tier Governance | SURVIVE | P15, P20 | Runtime log tiers in P15; trace retention alignment in P20. |
+| ADR-0050 | Operation Context | REVISE | P16 | Explicit context propagation, policy pin, active assertion evidence embedding. |
+| ADR-0051 | Tool Registry Allowlists | REVISE | P14, P19 | Compile registry entries in P14; runtime exact-match registry in P19. |
+| ADR-0052 | Policy Resolution | SURVIVE | P19 | Policy resolver, release pinning, most-specific-wins, deny-on-tie. |
+
+Provider adapter plays consume these primitives after substrate completion:
+
+| Play | Consumes | Constraint |
+|------|----------|------------|
+| P21 | ADR-0043, ADR-0044, ADR-0050, ADR-0051, ADR-0052 | SDK-native adapters must govern only events backed by runtime evidence. |
+| P22 | ADR-0042, ADR-0043, ADR-0044, ADR-0050, ADR-0051, ADR-0052 | Framework adapters are coarse-boundary by default; fine claims require translated lionagi tools. |
+
+## Convergence Groups
+
+| Group | Member ADRs | P12 resolution |
+|-------|-------------|----------------|
+| ActionManager Pipeline | ADR-0043, ADR-0044, ADR-0050 | ADR-0043 owns wrapper metadata and the governed execution route; ADR-0044 owns gate execution and `GateResult`; ADR-0050 owns explicit `OperationContext` propagation and active assertion embedding. |
+| Charter DSL Compilation | ADR-0047, ADR-0051, ADR-0052 | ADR-0047 owns DSL-to-runtime charter activation; ADR-0051 registry entries are compiled DSL targets; ADR-0052 remains the policy resolution algorithm. |
+| Emergency And Elevated Paths | ADR-0045, ADR-0046 | ADR-0045 owns emergency break-glass lifecycle evidence and degraded certificates; ADR-0046 owns planned, single-use JIT permits resolved through registry and policy. |
+| Evidence And Certification | ADR-0041, ADR-0042, ADR-0049, ADR-0050 | ADR-0041 is the immutable evidence substrate; ADR-0042 certifies run-level process adherence; ADR-0049 classifies retention tiers; ADR-0050 embeds active assertions. |
+
+## Cross-ADR Ownership Rules
+
+- `GateResult` is defined only by ADR-0044.
+- `OperationContext` may store gate result IDs and `GateResultProjection`, but never a second gate
+  result schema.
+- `GovernedToolMeta.requires_jit_hint` is diagnostic only; ADR-0051 and ADR-0052 decide whether
+  ADR-0046 JIT is required.
+- Runtime `AgentCharter` and `SessionCharter` objects are compiler outputs from ADR-0047, not
+  hand-authored accepted governance sources.
+- Registry entries in accepted charters are compiled DSL targets from ADR-0047 and owned at
+  runtime by ADR-0051.
+- Break-glass is not a hard-gate override; it is an emergency lifecycle owned by ADR-0045 and
+  reflected as degraded defensibility by ADR-0042.
+
+## Evidence Inventory Index
+
+P12 source coverage note: standalone P1-P10 deliverable files were not present in this worktree.
+The revised ADRs therefore cite the P11 synthesis, the Charter DSL v0 specification, the governance
+standards, and the prior governance research paths that the original ADRs already referenced.
+
+| Evidence source | Used for |
+|-----------------|----------|
+| docs/governance/direction.md section 5 | P9 trace taxonomy and P11 trace additions. |
+| docs/governance/direction.md section 6 | ADR slate verdicts and convergence groups. |
+| docs/governance/direction.md P13-P22 | Implementation play mapping. |
+| docs/governance/charter-dsl-v0.md | DSL-first charter and compiled registry target ownership. |
+| docs/governance/standards/adr-style.md | Required ADR format and type ownership rule. |
+| docs/governance/standards/trace-naming.md | Required governance span names and attributes. |
+| prior governance research `01_design/007-decision-certificate/ADR-007-decision-certificate.md` | Task certificate pattern. |
+| prior governance research `01_design/008-policy-gates/ADR-008-policy-gates.md` | Gate tier pattern. |
+| prior governance research `01_design/010-action-declaration/ADR-010-action-declaration.md` | Governed action declaration pattern. |
+| prior governance research `01_design/013-service-context/ADR-013-service-context.md` | Active assertion and context propagation pattern. |
+| prior governance research `01_design/015-jit-role/ADR-015-jit-role.md` | JIT no-standing-capability pattern. |
+| prior governance research `01_design/016-break-glass/ADR-016-break-glass.md` | Break-glass degraded lifecycle pattern. |
+| prior governance research `01_design/025-charter/ADR-025-charter.md` | Charter ratification and enforcement binding pattern. |
+| prior governance research `01_design/031-registry-allowlists/ADR-031-registry-allowlists.md` | Scoped registry allowlist pattern. |

--- a/docs/governance/charter-dsl-v0.md
+++ b/docs/governance/charter-dsl-v0.md
@@ -1,0 +1,723 @@
+# Charter DSL v0 — Canonical Specification
+
+**Version**: 0.1 | **Status**: Accepted | **Date**: 2026-05-27
+
+This document is the authoritative Charter DSL v0 reference. It supersedes the P6 exploration
+drafts (`charter-dsl-v0.md`, `charter_dsl_refined.yaml`) as canonical authoring guidance.
+Implementers write charters in this syntax; the compiler produces typed runtime targets;
+CLI and IDE tooling consume the same schema.
+
+Related: [standards/dsl-style.md](standards/dsl-style.md),
+[standards/trace-naming.md](standards/trace-naming.md),
+[standards/adr-style.md](standards/adr-style.md),
+ADR-0047 (Agent Charter), ADR-0051 (Tool Registry Allowlists), ADR-0052 (Policy Resolution)
+
+---
+
+## 1. Design Principles
+
+1. **Exact identity, no wildcards.** Tool names, registry values, and grant targets must be
+   exact strings. Wildcards are invalid in v0.
+2. **Default deny, deterministic resolution.** `permissions.default` is always `deny`.
+   Most-specific scope wins; ties deny. Declaration order does not change authorization.
+3. **Compiler-time activation.** A charter is not active until all gate references and hook
+   references are resolved, the normalized document is hashed, and the hash matches
+   `metadata.ratification.hash`.
+4. **Evidence and trace contracts are first-class.** Every constraint declares the evidence
+   types it requires. The trace block declares the spans the runtime must emit.
+5. **No embedded logic.** No boolean formula language, no placeholder substitution, no
+   executable tokens. Conditions are represented by typed gate or hook bindings only.
+
+---
+
+## 2. Canonical Top-Level Shape
+
+```yaml
+charter_dsl: "0.1"
+kind: agent_charter | session_charter
+
+metadata:
+  charter_id: ...
+  version: ...
+  status: ...
+  policy_release: ...
+  authored_by: ...
+  implemented_by: ...
+  ratification:
+    hash: sha256:<hex>     # required when status: accepted
+    signed_at: ...
+
+agents: []                 # >=1 for agent_charter, >=2 for session_charter
+
+registry:
+  snapshot: ratification_time
+  entries: []
+
+constraints: []
+
+sod:
+  active: true
+  rules: []
+
+permissions:
+  default: deny
+  resolution:
+    specificity_order: [resource, role, tenant, global]
+    tie: deny
+  allow: []
+  deny: []
+
+break_glass: null          # optional — omit when no elevated mode is needed
+
+trace:
+  stamp: []
+  require_spans: []
+  require_evidence: []
+```
+
+---
+
+## 3. Grammar Reference (EBNF Sketch)
+
+```ebnf
+document          ::= version kind metadata agents registry constraints sod permissions break_glass? trace
+
+version           ::= "charter_dsl" ":" version_string
+kind              ::= "kind" ":" ("agent_charter" | "session_charter")
+
+metadata          ::= "metadata" ":" metadata_body
+metadata_body     ::= charter_id version_field status policy_release authored_by implemented_by ratification
+status            ::= "draft" | "proposed" | "accepted" | "superseded"
+
+agents            ::= "agents" ":" agent+
+agent             ::= agent_id actor_id_source role allowed_models allowed_tools allowed_operations?
+actor_id_source   ::= "branch_id" | "session_actor_id"
+
+registry          ::= "registry" ":" snapshot entries
+snapshot          ::= "snapshot" ":" "ratification_time"
+entries           ::= "entries" ":" registry_entry*
+registry_entry    ::= category value scope scope_id reason evidence_refs
+category          ::= "tool" | "model" | "mcp_endpoint" | "url" | "path_prefix"
+
+constraints       ::= "constraints" ":" constraint+
+constraint        ::= constraint_id description binding manager_surface enforcement attach evidence
+binding           ::= gate_binding | hook_binding
+gate_binding      ::= "gate_id" ":" identifier
+hook_binding      ::= "hook_name" ":" identifier "hook_phase" ":" identifier
+manager_surface   ::= "ActionManager" | "MessageManager" | "iModelManager" | "DataLogger"
+enforcement       ::= "hard" | "soft" | "advisory"
+attach            ::= class_attach | action_attach
+class_attach      ::= "attach" ":" "level" ":" "class" "tool_class" ":" identifier
+action_attach     ::= "attach" ":" "level" ":" "action" "action" ":" identifier tools?
+
+sod               ::= "sod" ":" active sod_rules
+sod_rules         ::= "rules" ":" sod_rule*
+sod_rule          ::= rule_id conflict_type roles scope because
+conflict_type     ::= "transaction_dual_control" | "record_custody" | "audit_independence"
+                    | "approval_chain" | "access_control"
+sod_scope         ::= "session" | "task" | "global"
+
+permissions       ::= "permissions" ":" default resolution allow deny
+default           ::= "default" ":" "deny"
+resolution        ::= specificity_order tie
+specificity_order ::= "[" "resource" "," "role" "," "tenant" "," "global" "]"
+tie               ::= "tie" ":" "deny"
+allow             ::= "allow" ":" permission_rule*
+deny              ::= "deny" ":" permission_rule*
+permission_rule   ::= rule_id scope roles action (tools | resources) requires_evidence? because
+
+break_glass       ::= "break_glass" ":" break_glass_body
+break_glass_body  ::= enabled expires_after attestation temporary_grants notifications evidence
+
+trace             ::= "trace" ":" stamp require_spans require_evidence
+```
+
+Expression language is intentionally minimal in v0:
+
+- No arbitrary boolean expressions.
+- Conditions use typed gate or hook bindings.
+- Matching is exact role, tool, resource, scope, and registry entry comparison.
+- Path matching is prefix-only via `category: path_prefix` registry entries.
+- Policy resolution is structural: most-specific scope wins, ties deny.
+
+---
+
+## 4. Validation Rules
+
+### Required Fields
+
+Document top-level: `charter_dsl`, `kind`, `metadata`, `agents`, `registry`, `constraints`,
+`sod`, `permissions`, `trace`.
+
+Metadata: `charter_id`, `version`, `status`, `policy_release`, `authored_by`,
+`implemented_by`, `ratification`.
+
+Agent: `agent_id`, `actor_id_source`, `role`, `allowed_models`, `allowed_tools`.
+
+Registry entry: `category`, `value`, `scope`, `scope_id`, `reason`, `evidence_refs`.
+
+Constraint: `constraint_id`, `description`, exactly one of `gate_id`/`hook_name`,
+`manager_surface`, `enforcement`, `attach`, `evidence.required`.
+
+Permissions: `default`, `resolution.specificity_order`, `resolution.tie`, `allow`, `deny`.
+
+Trace: `stamp`, `require_spans`, `require_evidence`.
+
+### Type And Invariant Checks
+
+- `charter_dsl` must be `"0.1"`.
+- `metadata.version` is a semver string.
+- `metadata.status` is one of `draft`, `proposed`, `accepted`, `superseded`.
+- `metadata.ratification.hash` is required unless status is `draft` or `proposed`.
+- `agents` length is exactly 1 for `agent_charter`, at least 2 for `session_charter`.
+- `registry.entries[*].value` has no wildcards.
+- `path_prefix` values start and end with `/`.
+- `break_glass.expires_after` is at most `30m` in v0.
+- Hash fields use `sha256:<64-hex-chars>` after real compilation.
+- `sod.rules[*].roles` has exactly two distinct roles declared in `agents`.
+
+### Semantic Checks
+
+- Reject unknown top-level keys.
+- Reject duplicate `charter_id`, `agent_id`, `constraint_id`, `rule_id` within one document.
+- Reject tabs.
+- Reject executable tokens in scalar strings: `__import__`, `eval(`, `exec(`, `lambda`,
+  `subprocess`.
+- Reject wildcards in tool names, registry values, and temporary grants.
+- Reject constraints with both `gate_id` and `hook_name` present.
+- Reject constraints with neither binding.
+- Reject `hook_name` without `hook_phase`.
+- Reject `attach.level: class` without `tool_class`.
+- Reject `attach.level: action` without `action`.
+- Reject accepted charters whose normalized hash does not match the ratification hash.
+- Every `agents[*].allowed_tools` entry must appear in registry entries.
+- `permissions.default` must be `deny`.
+- `permissions.resolution.specificity_order` must be exactly `[resource, role, tenant, global]`.
+- `permissions.resolution.tie` must be `deny`.
+- If `sod.active` is false, accepted charters are invalid unless a policy release explicitly
+  allows disabled SoD.
+- Break-glass `attestation.approver_role` must not equal the requesting role.
+- Every required span in `trace.require_spans` must appear in the canonical registry in
+  [standards/trace-naming.md](standards/trace-naming.md).
+
+---
+
+## 5. Charter Examples
+
+### Example A: Simple Read-Only Agent Charter
+
+One reader agent with a single allowed tool, exact registry controls, and path-prefix bounding.
+
+```yaml
+charter_dsl: "0.1"
+kind: agent_charter
+
+metadata:
+  charter_id: charter.simple_reader
+  version: "1.0.0"
+  status: accepted
+  policy_release: policy.gov.v1
+  authored_by: human:governance
+  implemented_by: agent:implementer
+  ratification:
+    hash: sha256:1000abcd00000000000000000000000000000000000000000000000000000001
+    signed_at: "2026-05-27T00:00:00Z"
+
+agents:
+  - agent_id: agent.simple_reader
+    actor_id_source: branch_id
+    role: reader
+    allowed_models: [openai:gpt-5.4]
+    allowed_tools: [tool.read_file]
+
+registry:
+  snapshot: ratification_time
+  entries:
+    - category: tool
+      value: tool.read_file
+      scope: agent
+      scope_id: agent.simple_reader
+      reason: "The reader can inspect approved workspace files."
+      evidence_refs: [ev.registry.simple_reader.read_file]
+    - category: path_prefix
+      value: /workspace/
+      scope: agent
+      scope_id: agent.simple_reader
+      reason: "File access is bounded to the workspace."
+      evidence_refs: [ev.registry.simple_reader.workspace]
+
+constraints:
+  - constraint_id: gate.registry.read_file
+    description: "Read-file calls must match the ratified registry snapshot."
+    gate_id: verify_in_registry
+    manager_surface: ActionManager
+    enforcement: hard
+    attach:
+      level: action
+      action: tool_call
+      tools: [tool.read_file]
+    evidence:
+      required: [GateResult, ToolCallEvidence]
+  - constraint_id: gate.path.workspace
+    description: "Read-file paths must stay under the workspace prefix."
+    gate_id: enforce_path_prefix
+    manager_surface: ActionManager
+    enforcement: hard
+    attach:
+      level: action
+      action: tool_call
+      tools: [tool.read_file]
+    evidence:
+      required: [GateResult]
+
+sod:
+  active: true
+  rules: []
+
+permissions:
+  default: deny
+  resolution:
+    specificity_order: [resource, role, tenant, global]
+    tie: deny
+  allow:
+    - rule_id: allow.reader.read_workspace
+      scope: role
+      roles: [reader]
+      action: tool_call
+      tools: [tool.read_file]
+      resources: [/workspace/]
+      requires_evidence: [GateResult, ToolCallEvidence]
+      because: "Reader role requires file inspection only."
+  deny:
+    - rule_id: deny.reader.write_or_shell
+      scope: role
+      roles: [reader]
+      action: tool_call
+      tools: [tool.write_file, tool.exec_command]
+      because: "Reader role cannot mutate files or run shell commands."
+
+trace:
+  stamp: [charter_id, policy_release, agent_id, role]
+  require_spans:
+    - governance.operation
+    - registry.lookup
+    - gate.evaluate
+    - evidence.emit
+  require_evidence:
+    - GateResult
+    - ToolCallEvidence
+```
+
+**Compile targets**: one `AgentCharter`, two registry entries, two action-level hard gates, one
+empty active SoD policy, one deny-default permission policy.
+
+---
+
+### Example B: Multi-Agent Session Charter With SoD
+
+Four roles: orchestrator (coordinates only), researcher, implementer, and reviewer (independent
+from implementer). Two SoD rules enforce role separation.
+
+```yaml
+charter_dsl: "0.1"
+kind: session_charter
+
+metadata:
+  charter_id: charter.gov_orchestration
+  version: "1.0.0"
+  status: accepted
+  policy_release: policy.gov.v1
+  authored_by: human:governance
+  implemented_by: agent:implementer
+  ratification:
+    hash: sha256:2000abcd00000000000000000000000000000000000000000000000000000002
+    signed_at: "2026-05-27T00:00:00Z"
+
+agents:
+  - agent_id: agent.orchestrator
+    actor_id_source: branch_id
+    role: orchestrator
+    allowed_models: [openai:gpt-5.4]
+    allowed_tools: []
+    allowed_operations: [delegate, assign_role]
+  - agent_id: agent.researcher
+    actor_id_source: branch_id
+    role: researcher
+    allowed_models: [openai:gpt-5.4]
+    allowed_tools: [tool.search, tool.read_file]
+  - agent_id: agent.implementer
+    actor_id_source: branch_id
+    role: implementer
+    allowed_models: [openai:gpt-5.4]
+    allowed_tools: [tool.read_file, tool.write_file]
+  - agent_id: agent.reviewer
+    actor_id_source: branch_id
+    role: reviewer
+    allowed_models: [openai:gpt-5.4]
+    allowed_tools: [tool.read_file]
+
+registry:
+  snapshot: ratification_time
+  entries:
+    - category: tool
+      value: tool.search
+      scope: role
+      scope_id: researcher
+      reason: "Researcher must locate source and documentation."
+      evidence_refs: [ev.registry.orchestration.search]
+    - category: tool
+      value: tool.read_file
+      scope: session
+      scope_id: session.gov_orchestration
+      reason: "Researcher, implementer, and reviewer inspect files."
+      evidence_refs: [ev.registry.orchestration.read]
+    - category: tool
+      value: tool.write_file
+      scope: role
+      scope_id: implementer
+      reason: "Only implementer applies code changes."
+      evidence_refs: [ev.registry.orchestration.write]
+
+constraints:
+  - constraint_id: gate.registry.all_effects
+    description: "Every external effect must resolve through registry policy."
+    gate_id: verify_in_registry
+    manager_surface: ActionManager
+    enforcement: hard
+    attach:
+      level: class
+      tool_class: external_effect
+    evidence:
+      required: [GateResult]
+  - constraint_id: gate.sod.review_independence
+    description: "Reviewer must be independent from implementer for the same task."
+    gate_id: assert_sod_independence
+    manager_surface: ActionManager
+    enforcement: hard
+    attach:
+      level: action
+      action: certificate_mint
+    evidence:
+      required: [SoDCheckEvidence, GateResult]
+  - constraint_id: gate.orchestrator.no_task_tools
+    description: "Orchestrator coordinates work but does not invoke task tools directly."
+    gate_id: deny_direct_tool_call_for_role
+    manager_surface: ActionManager
+    enforcement: hard
+    attach:
+      level: action
+      action: tool_call
+    evidence:
+      required: [GateResult]
+
+sod:
+  active: true
+  rules:
+    - rule_id: sod.implementer_reviewer.independent
+      conflict_type: audit_independence
+      roles: [implementer, reviewer]
+      scope: task
+      because: "The same actor cannot both implement and approve the same task."
+    - rule_id: sod.grant_requester_approver.split
+      conflict_type: approval_chain
+      roles: [implementer, orchestrator]
+      scope: session
+      because: "Grant requester and approver must be distinct actors."
+
+permissions:
+  default: deny
+  resolution:
+    specificity_order: [resource, role, tenant, global]
+    tie: deny
+  allow:
+    - rule_id: allow.orchestrator.delegate
+      scope: role
+      roles: [orchestrator]
+      action: delegate
+      resources: [session.gov_orchestration]
+      requires_evidence: [DelegationEvidence]
+      because: "Orchestrator manages work assignment only."
+    - rule_id: allow.researcher.search_read
+      scope: role
+      roles: [researcher]
+      action: tool_call
+      tools: [tool.search, tool.read_file]
+      requires_evidence: [GateResult, ToolCallEvidence]
+      because: "Researcher may gather source evidence."
+    - rule_id: allow.implementer.read_write
+      scope: role
+      roles: [implementer]
+      action: tool_call
+      tools: [tool.read_file, tool.write_file]
+      requires_evidence: [GateResult, ToolCallEvidence]
+      because: "Implementer may inspect and edit files."
+    - rule_id: allow.reviewer.read
+      scope: role
+      roles: [reviewer]
+      action: tool_call
+      tools: [tool.read_file]
+      requires_evidence: [GateResult, ToolCallEvidence]
+      because: "Reviewer may inspect results without editing."
+  deny:
+    - rule_id: deny.orchestrator.task_tools
+      scope: role
+      roles: [orchestrator]
+      action: tool_call
+      tools: [tool.search, tool.read_file, tool.write_file]
+      because: "Coordination authority is separate from task execution authority."
+    - rule_id: deny.reviewer.write
+      scope: role
+      roles: [reviewer]
+      action: tool_call
+      tools: [tool.write_file]
+      because: "Reviewer role must remain read-only."
+
+trace:
+  stamp: [charter_id, policy_release, agent_id, role, flow_id]
+  require_spans:
+    - governance.session
+    - governance.flow
+    - governance.operation
+    - sod.check
+    - registry.lookup
+    - gate.evaluate
+    - evidence.emit
+    - certificate.state
+    - certificate.mint
+  require_evidence:
+    - GateResult
+    - ToolCallEvidence
+    - SoDCheckEvidence
+    - DelegationEvidence
+    - TaskCertificate
+```
+
+**Compile targets**: one session-level runtime plan, one `AgentCharter` per agent, shared SoD
+policy with bidirectional conflict pairs, certificate mint precondition requiring SoD evidence.
+
+---
+
+### Example C: Adapter Boundary Charter
+
+User provides an existing LangGraph compiled graph. Lionagi wraps the invocation boundary.
+Coarse mode governs graph invocation and emits boundary evidence — internal graph tool calls
+are not claimed as individually governed.
+
+```yaml
+charter_dsl: "0.1"
+kind: agent_charter
+
+metadata:
+  charter_id: charter.adapter.langgraph_boundary
+  version: "1.0.0"
+  status: accepted
+  policy_release: policy.gov.v1
+  authored_by: human:governance
+  implemented_by: agent:adapter_owner
+  ratification:
+    hash: sha256:3000abcd00000000000000000000000000000000000000000000000000000003
+    signed_at: "2026-05-27T00:00:00Z"
+
+agents:
+  - agent_id: agent.graph_runner
+    actor_id_source: branch_id
+    role: adapter_runner
+    allowed_models: [openai:gpt-5.4]
+    allowed_tools: [adapter.langgraph.invoke]
+
+registry:
+  snapshot: ratification_time
+  entries:
+    - category: tool
+      value: adapter.langgraph.invoke
+      scope: agent
+      scope_id: agent.graph_runner
+      reason: "The existing compiled graph is governed at the invocation boundary."
+      evidence_refs: [ev.registry.adapter.langgraph.invoke]
+    - category: path_prefix
+      value: /workspace/
+      scope: agent
+      scope_id: agent.graph_runner
+      reason: "Adapter inputs and artifacts are bounded to the workspace."
+      evidence_refs: [ev.registry.adapter.langgraph.workspace]
+
+constraints:
+  - constraint_id: gate.adapter.boundary_registry
+    description: "The adapter invocation must be registered before execution."
+    gate_id: verify_in_registry
+    manager_surface: ActionManager
+    enforcement: hard
+    attach:
+      level: action
+      action: tool_call
+      tools: [adapter.langgraph.invoke]
+    evidence:
+      required: [GateResult, AdapterInvocationEvidence]
+  - constraint_id: gate.adapter.input_contract
+    description: "Adapter input must pass the graph boundary schema."
+    gate_id: validate_adapter_input
+    manager_surface: ActionManager
+    enforcement: hard
+    attach:
+      level: action
+      action: tool_call
+      tools: [adapter.langgraph.invoke]
+    evidence:
+      required: [GateResult]
+  - constraint_id: gate.adapter.no_internal_claim
+    description: "Coarse boundary mode must not emit per-internal-tool governed evidence."
+    gate_id: assert_boundary_only_evidence
+    manager_surface: DataLogger
+    enforcement: hard
+    attach:
+      level: action
+      action: evidence_emit
+    evidence:
+      required: [AdapterInvocationEvidence]
+
+sod:
+  active: true
+  rules: []
+
+permissions:
+  default: deny
+  resolution:
+    specificity_order: [resource, role, tenant, global]
+    tie: deny
+  allow:
+    - rule_id: allow.adapter_runner.invoke_graph
+      scope: role
+      roles: [adapter_runner]
+      action: tool_call
+      tools: [adapter.langgraph.invoke]
+      requires_evidence: [GateResult, AdapterInvocationEvidence]
+      because: "Adapter runner may invoke the wrapped graph boundary."
+  deny:
+    - rule_id: deny.adapter_runner.raw_internal_tools
+      scope: role
+      roles: [adapter_runner]
+      action: tool_call
+      tools: [tool.internal_graph_tool]
+      because: "Internal graph tools are not governed in coarse boundary mode."
+
+trace:
+  stamp: [charter_id, policy_release, agent_id, role, adapter_mode]
+  require_spans:
+    - governance.operation
+    - registry.lookup
+    - gate.evaluate
+    - evidence.emit
+  require_evidence:
+    - GateResult
+    - AdapterInvocationEvidence
+```
+
+**Adapter claim rule**: boundary mode emits `AdapterInvocationEvidence` for the invocation
+boundary and does not emit per-tool governance evidence for internal graph nodes. Fine-grain
+mode requires translating each internal external-effect tool into a lionagi `Tool` identity
+before activation.
+
+---
+
+## 6. Integration Points
+
+### Runtime Binding
+
+The compiler emits typed runtime targets:
+
+- `AgentCharter` objects per `agents[*]` entry.
+- Registry entries for `ToolRegistryPolicy`.
+- Gate registrations for each manager surface.
+- SoD rules for `SoDPolicy`.
+- Permission rules for `PolicyResolver`.
+- Evidence requirements for evidence emission and certificate minting.
+- Trace expectations for span validation.
+
+`Branch` integration:
+
+- `Branch` carries active `charter_id`, `policy_release`, actor identity, and operation context.
+- `Branch.operate(middle=...)` installs governance through pre-gate, operation context creation,
+  post-result evidence, and span projection.
+- `Branch.act()` and `ActionManager` route governed tools through `execute_governed()`.
+
+`Session` integration:
+
+- `Session` pins a policy release and charter set for governed runs.
+- `Session.flow()` validates role assignments, op limits, artifact contracts, and required
+  control operations against the session charter before execution.
+- Run-end certificate minting occurs after artifact contract verification.
+
+### CLI Commands
+
+```text
+li charter validate <path/to/charter.yaml>
+li charter compile  <path/to/charter.yaml> --out <path/to/compiled.json>
+li governance audit  --session <sess_id>
+li governance report --certificate <cert_id>
+```
+
+`validate` behavior:
+
+- Performs parse, schema, binding existence, semantic, and safety checks.
+- Exits non-zero on any hard error.
+- Emits warnings for advisory quality issues; accepted charters cannot have unresolved warnings.
+
+`compile` behavior:
+
+- Refuses dynamic placeholders, wildcards, unresolved gates, unresolved hooks, and missing
+  trace expectations.
+- Emits normalized JSON plus ratification hash inputs.
+- The normalized artifact (not raw YAML) is the hash input; comments and key ordering do not
+  affect the hash after normalization.
+
+### IDE Hints
+
+IDE support comes from a generated JSON Schema artifact:
+
+- Autocomplete top-level keys in canonical order.
+- Enum completion for `kind`, `status`, `manager_surface`, `enforcement`, `conflict_type`,
+  scope values, and canonical trace span names.
+- Diagnostics for missing required blocks and tabs.
+- Diagnostics for both/neither `gate_id` and `hook_name`.
+- Warnings for unused registry entries and unreachable permission rules.
+- Hover docs for span names and error codes.
+
+---
+
+## 7. Canonical Normalized Output Shape
+
+```json
+{
+  "charter_id": "charter.simple_reader",
+  "charter_dsl": "0.1",
+  "kind": "agent_charter",
+  "policy_release": "policy.gov.v1",
+  "agents": [],
+  "registry_entries": [],
+  "gate_bindings": [],
+  "sod_policy": {},
+  "permission_policy": {},
+  "evidence_requirements": [],
+  "trace_requirements": [],
+  "ratification_hash": "sha256:..."
+}
+```
+
+The normalized artifact is the hash input. Comments, insignificant whitespace, and key
+ordering differences inside maps do not affect the hash after normalization.
+
+---
+
+## 8. Open Issues For Phase 3-7
+
+- ADR-0047 must be revised to define DSL-to-runtime binding, not only the Python `AgentCharter`
+  shape (P12).
+- ADR-0044 and ADR-0050 must consolidate `GateResult` to a single owner before implementation
+  begins (P12).
+- P9 trace taxonomy must be extended with permit lifecycle, certificate state transitions,
+  break-glass lifecycle, and soft-gate justification spans before P20 (tracked in
+  [standards/trace-naming.md](standards/trace-naming.md)).
+- `OperationContext` must remain explicit state. A `contextvars` bridge is allowed for async
+  propagation but must not become the authoritative governance store (P16).
+- Boundary adapters must be documented and marketed honestly: they govern invocation boundaries,
+  not hidden internal effects (P22).

--- a/docs/governance/direction.md
+++ b/docs/governance/direction.md
@@ -170,11 +170,11 @@ Governance is an additive runtime layer — it does not replace existing lionagi
 ### 3.1 Zero-Rewrite Principle
 
 Users bring their existing objects. lionagi wraps the user's existing object and governs its
-execution boundary. The adapter does not rewrite the user's framework code. A governed endpoint
+execution boundary. The adapter does not rewrite the user's framework code. A governed adapter
 has the shape:
 
 ```python
-GovernedEndpoint(user_object=their_existing_thing, charter=loaded_charter)
+GovernedAdapter(user_object=their_existing_thing, charter=loaded_charter)
 ```
 
 The adapter intercepts invocation, enforces the charter at the boundary, emits evidence, and returns
@@ -334,25 +334,28 @@ is the enterprise observability interface (SIEM, alerting, dashboards), not the 
 
 ### 5.2 Span Taxonomy Reference
 
-The canonical span registry is defined in [`docs/governance/standards/trace-naming.md`](standards/trace-naming.md).
+The canonical span registry is defined in
+[`docs/governance/standards/trace-naming.md`](standards/trace-naming.md) (section 4).
+That file is the authoritative source for span names, required attributes, and retention tiers.
+The summary below uses the same attribute names as trace-naming.md.
 The base taxonomy comes from P9. P11 adds the missing spans identified in the P9 critic verdict:
 
 **Base spans (P9)**:
 
-| Span Name | Trigger | Required Attributes |
-|-----------|---------|---------------------|
-| `governance.operation` | Operation start | `governance.charter_id`, `governance.policy.version`, `governance.actor.id`, `governance.actor.role` |
-| `gate.evaluate` | Gate execution | `gate.id`, `gate.tool.name`, `gate.enforcement`, `gate.result`, `gate.evidence_hash` |
-| `evidence.emit` | Evidence node creation | `evidence.kind`, `evidence.hash`, `evidence.chain_tip` |
-| `registry.lookup` | Registry entry check | `registry.category`, `registry.value`, `registry.scope`, `registry.result` |
-| `policy.resolve` | Policy resolution | `policy.release`, `policy.rule_id`, `policy.specificity`, `policy.decision` |
-| `certificate.mint` | Certificate creation | `certificate.id`, `certificate.chain_head`, `certificate.policy_version`, `certificate.gate_count` |
-| `sod.check` | SoD matrix evaluation | `sod.rule_id`, `sod.roles`, `sod.conflict_type`, `sod.result` |
+| Span Name | Trigger | Key Required Attributes |
+|-----------|---------|-------------------------|
+| `governance.operation` | Operation start | `governance.operation.name`, `governance.charter.id`, `governance.policy.version`, `governance.actor.id`, `governance.actor.role`, `governance.evidence.hash` |
+| `gate.evaluate` | Gate execution | `gate.id`, `gate.tool.name`, `gate.verdict`, `gate.enforcement`, `gate.policy.version`, `gate.charter.id`, `gate.evidence.hash`, `gate.reason` |
+| `evidence.emit` | Evidence node creation | `evidence.id`, `evidence.kind`, `evidence.chain.hash`, `evidence.previous.hash`, `evidence.tier`, `evidence.payload.hash` |
+| `registry.lookup` | Registry entry check | `registry.tool.name`, `registry.role`, `registry.allowed`, `registry.policy.version`, `registry.lookup.source`, `registry.evidence.hash` |
+| `policy.resolve` | Policy resolution | `policy.count`, `policy.strategy`, `policy.winner`, `policy.version`, `policy.conflict.count`, `policy.evidence.hash` |
+| `certificate.mint` | Certificate creation | `certificate.id`, `certificate.task.id`, `certificate.gates.passed`, `certificate.gates.failed`, `certificate.grade`, `certificate.defensibility`, `certificate.evidence.chain.hash`, `certificate.break.glass` |
+| `sod.check` | SoD matrix evaluation | `sod.role`, `sod.capability`, `sod.verdict`, `sod.policy.version`, `sod.evidence.hash` |
 
 **Additions from P9 critic verdict (P20 responsibility)**:
 
-| Span Name | Trigger | Required Attributes |
-|-----------|---------|---------------------|
+| Span Name | Trigger | Key Required Attributes |
+|-----------|---------|-------------------------|
 | `permit.issue` | JIT permit issued | `permit.id`, `permit.scope`, `permit.tool.name`, `permit.issuer.id`, `permit.subject.id`, `permit.expires.at`, `permit.evidence.hash` |
 | `permit.consume` | JIT permit consumed on tool call | `permit.id`, `permit.tool.name`, `permit.subject.id`, `permit.consumed.at`, `permit.consume.result`, `permit.evidence.hash` |
 | `permit.revoke` | JIT permit revoked before expiry | `permit.id`, `permit.revoked.by`, `permit.revoked.at`, `permit.revoke.reason`, `permit.evidence.hash` |
@@ -362,6 +365,8 @@ The base taxonomy comes from P9. P11 adds the missing spans identified in the P9
 | `breakglass.close` | Break-glass closed or revoked | `breakglass.window.id`, `breakglass.closed.at`, `breakglass.close.reason`, `breakglass.tool.call.count`, `breakglass.certificate.id` |
 | `breakglass.notify` | Emergency notification sent | `breakglass.window.id`, `breakglass.notification.target`, `breakglass.notification.kind`, `breakglass.notification.result` |
 | `gate.justify` | SOFT gate override with justification | `gate.id`, `gate.verdict`, `gate.enforcement`, `gate.justification`, `gate.justification.actor.id`, `gate.evidence.hash` |
+
+See trace-naming.md section 4 for the complete attribute list for every span type.
 
 ### 5.3 Enterprise Readiness Path
 
@@ -374,7 +379,7 @@ attributes onto opaque spans is expensive — declaring them in the schema creat
 | Sensitive data redaction | Evidence record field exclusion rules documented at emit time | P15 |
 | SIEM export | OTel collector-compatible span format; attribute naming follows OTel semconv | P20 |
 | Backpressure | Span export failure must not block evidence chain writes | P20 |
-| Alerting | `gate.result: DENY` and `breakglass.open` are alertable events | P20 |
+| Alerting | `gate.verdict: DENY` and `breakglass.open` are alertable events | P20 |
 | Cost tracking | `governance.operation` spans carry operation budget attributes | P18 |
 | Audit/ops separation | Audit spans go to immutable SIEM sink; ops spans go to mutable collector | P20 |
 
@@ -533,7 +538,7 @@ are the first cut targets if budget is exceeded.
 | **Scope** | Zero-rewrite governed endpoints for PydanticAI (`instrument_*` hooks), OpenAI Agents SDK (`AgentHook` event stream), and Anthropic Agent SDK (native tool-use block handling). Each adapter: ~200 LOC, accepts the user's existing agent/runner object, emits boundary evidence, enforces the compiled charter at the invocation boundary. Explicit claim matrix in docstring and test. |
 | **Dependencies** | P17, P20 |
 | **Measurement** | Contract tests with mocked typed event streams; package-shape validation confirms no framework internals are imported unconditionally; coarse/fine claim matrix documented; adversarial test: overclaiming internal tool call governance fails the claim matrix check |
-| **Files Modified** | `lionagi/providers/pydantic_ai/`, `lionagi/providers/openai_agents/`, `lionagi/providers/anthropic_agents/`, `tests/providers/test_governed_sdk_adapters.py` |
+| **Files Modified** | `lionagi/adapters/openai_agents.py`, `lionagi/adapters/anthropic_agents.py`, `tests/adapters/test_governed_sdk_adapters.py` |
 
 ### P22 — Framework Governed Endpoints (G2)
 
@@ -545,7 +550,7 @@ are the first cut targets if budget is exceeded.
 | **Scope** | Zero-rewrite governed wrappers for LangGraph (`CompiledStateGraph`), LlamaIndex (`AgentWorkflow`, `FunctionAgent`, `ReActAgent`, `QueryEngineTool`, `FunctionTool`), and CrewAI (`Crew`, `CrewPlan` preflight). Coarse boundary governance only. Fine mode available only for translated lionagi `Tool` objects. CrewAI hierarchical delegation is not governed in v0. |
 | **Dependencies** | P18, P19 |
 | **Measurement** | Contract tests for graph invoke, LlamaIndex tool translation, CrewPlan preflight; claim matrix documents what is and is not governed; unsupported delegation call fails closed with a descriptive `GovernanceViolationError`; coarse-only adapters emit boundary evidence correctly |
-| **Files Modified** | `lionagi/providers/langgraph/`, `lionagi/providers/llamaindex/`, `lionagi/providers/crewai/`, `tests/providers/test_governed_framework_adapters.py` |
+| **Files Modified** | `lionagi/adapters/langchain.py`, `lionagi/adapters/crewai.py`, `tests/adapters/test_governed_framework_adapters.py` |
 
 ### P23 — Governance Test and Adversarial Fixture Pack
 
@@ -632,24 +637,23 @@ remain unchanged — governance is opt-in at the `Session.flow()` or `Branch.act
 | `flow.py` | Add: `--charter` flag, flow-plan governance validation, certificate reporting |
 | `_orchestration.py` | Add: artifact evidence sidecars, run-end certificate hook |
 
-### 8.4 `lionagi/providers/`
+### 8.4 `lionagi/adapters/`
 
-New provider packages (P21, P22). Each package contains:
+New adapter modules (P21, P22). The base class is `GovernedAdapter` in
+`lionagi/adapters/governed_base.py` (ADR-0068). Each concrete adapter module contains
+the framework-specific `GovernedAdapter` subclass and its claim matrix.
 
-- `__init__.py` — public `GovernedEndpoint` class
-- `adapter.py` — framework-specific wrapping logic
-- `claim_matrix.py` — machine-readable claim matrix (used by adversarial tests)
+| Module | Exported Class | Target | Play |
+|--------|----------------|--------|------|
+| `lionagi/adapters/openai_agents.py` | `GovernedOpenAIAgent` | OpenAI Agents SDK | P21 |
+| `lionagi/adapters/anthropic_agents.py` | `GovernedAnthropicAgent` | Anthropic Agent SDK | P21 |
+| `lionagi/adapters/langchain.py` | `GovernedChain` | LangChain `Runnable`, `Chain`, `AgentExecutor` | P22 |
+| `lionagi/adapters/crewai.py` | `GovernedCrew` | CrewAI `Crew` | P22 |
 
-| Package | Target | Play |
-|---------|--------|------|
-| `lionagi/providers/pydantic_ai/` | PydanticAI agents | P21 |
-| `lionagi/providers/openai_agents/` | OpenAI Agents SDK | P21 |
-| `lionagi/providers/anthropic_agents/` | Anthropic Agent SDK | P21 |
-| `lionagi/providers/langgraph/` | LangGraph `CompiledStateGraph` | P22 |
-| `lionagi/providers/llamaindex/` | LlamaIndex agents and tools | P22 |
-| `lionagi/providers/crewai/` | CrewAI `Crew` and `CrewPlan` | P22 |
+Each adapter module exports exactly one concrete `GovernedAdapter` subclass. The claim matrix
+is documented in the class docstring and mirrored in the test fixture (`tests/adapters/`).
 
-No provider package is added until the substrate (P15-P17) and flow governance (P18) are complete
+No adapter module is added until the substrate (P15-P17) and flow governance (P18) are complete
 and verified. An adapter claiming governance before the substrate exists is a false claim.
 
 ### 8.5 `lionagi/tools/`

--- a/docs/governance/direction.md
+++ b/docs/governance/direction.md
@@ -1,6 +1,6 @@
 # Governance Direction: lionagi Governed Orchestration
 
-**Version**: 1.0 | **Phase**: 2 — Synthesis and Standards | **Play**: P11  
+**Version**: 1.0 | **Phase**: 2 — Synthesis and Standards | **Play**: P11
 **Status**: Accepted — blocking all Phase 3-7 implementation
 
 This document is the master blueprint for lionagi's governed orchestration build-out (P12-P24). It
@@ -580,8 +580,9 @@ are the first cut targets if budget is exceeded.
 
 ## 8. Integration Plan
 
-The governance build is additive. Existing lionagi code is modified at well-defined extension points
-only. New modules live in `lionagi/protocols/governance/`. Existing modules receive narrow additions.
+The governance build is additive. After implementation, existing lionagi code will be modified at
+well-defined extension points only. New modules will live in `lionagi/protocols/governance/`
+(proposed — not yet created). Existing modules will receive narrow additions.
 
 ### 8.1 `lionagi/protocols/`
 

--- a/docs/governance/direction.md
+++ b/docs/governance/direction.md
@@ -1,0 +1,721 @@
+# Governance Direction: lionagi Governed Orchestration
+
+**Version**: 1.0 | **Phase**: 2 — Synthesis and Standards | **Play**: P11  
+**Status**: Accepted — blocking all Phase 3-7 implementation
+
+This document is the master blueprint for lionagi's governed orchestration build-out (P12-P24). It
+records the strategic direction, architecture decisions, ADR verdicts, the full play list, integration
+plan, and risk register. Developers implementing P12-P24 must read this document in full before
+writing any code.
+
+---
+
+## 1. Strategic Direction
+
+### 1.1 Thesis
+
+Governed orchestration is the product. lionagi's differentiator is not model integration or
+orchestration convenience — it is the ability to certify that an automated run followed a declared
+charter: enforceable permissions, tamper-evident evidence, task certificates, and segregation-of-duties
+constraints. Competitors (LangGraph, LlamaIndex, CrewAI, AutoGen) provide orchestration. None provide
+orchestration-time governance with verifiable compliance artifacts.
+
+The build strategy is build-over-adopt for governance primitives (hash chains, policy resolution,
+log tiers, certificates) and wrap-over-rewrite for external frameworks (LangGraph, LlamaIndex,
+CrewAI). lionagi governs at the boundary; it does not replace the user's existing tooling.
+
+### 1.2 What We Are Building
+
+The smallest coherent governed orchestration surface, end-to-end. Every component listed below
+must integrate before any adapter is meaningful.
+
+**Charter DSL v0** — YAML-shaped governance contract language. Strict schema, no wildcards, no
+prose-only rules, deterministic policy resolution, exact registry entries, deny-by-default
+permissions. Compiled to runtime targets; ratified with a reproducible SHA-256 hash. IDE hints
+generated from the same Pydantic schema used by the CLI validator.
+See: [`docs/governance/standards/dsl-style.md`](standards/dsl-style.md)
+
+**Runtime Substrate** — the engine that Charter contracts compile into and execute against:
+
+- Immutable evidence nodes (SHA-256 hash chains, append-only audit storage)
+- `OperationContext` — per-operation actor identity, policy pin, trace IDs, propagated explicitly
+- Log tier governance — MUTABLE / PROTECTED / IMMUTABLE tiers, application-layer backends
+- Gate framework — hard, soft, advisory gate results; fail-closed exceptions; single canonical `GateResult`
+- Policy release pinning — session-bound snapshot, most-specific-wins resolver, deny-on-tie
+- Task certificates — minted at run completion, consuming evidence chain head, gate outcomes,
+  break-glass state, and policy version
+
+**Orchestration Integration** — governance wired into existing lionagi execution paths:
+
+- `Session.flow()` enforces role allowlists, op limits, artifact contracts, and charter checks
+- Per-operation evidence sidecars (`Branch.operate(middle=...)`)
+- CLI `FlowPlan` validation: charter activation, op budgets, artifact contracts
+- Run-end certificate minting after artifact verification
+
+**Governance Layer Objects** — the safety control surface:
+
+- Break-glass protocol: emergency elevated mode with immutable justification evidence and lifecycle spans
+- JIT tool grants: no-standing-capability, single-use permit semantics resolved through the registry
+- Tool registry allowlists: exact-match, compiled DSL targets, policy-resolved privileged tier
+- Segregation of duties: assignment-time conflict matrix, bidirectional role independence
+
+**OTel Governance Tracing** — projection over typed governance records:
+
+- Typed records are created first; trace/span IDs are embedded in evidence
+- OTel spans carry evidence hashes for enterprise correlation
+- Span names follow the P9 taxonomy (see [`docs/governance/standards/trace-naming.md`](standards/trace-naming.md))
+- Enterprise readiness path: retention tiers, redaction, SIEM export, cost tracking, audit/ops separation
+
+**Provider Adapters — Two Waves**:
+
+- G1 SDK-native: PydanticAI, OpenAI Agents SDK, Anthropic Agent SDK (~200 LOC each, native event hooks)
+- G2 Framework: LangGraph, LlamaIndex, CrewAI (zero-rewrite, coarse boundary governance)
+
+### 1.3 What We Are Not Building
+
+The following scope is explicitly cut from P12-P24. These items may reopen in a future show.
+
+| Cut Item | Rationale |
+|----------|-----------|
+| G3 edge adapters (smolagents, OpenCode, HuggingFace) | Provider research marks these as smaller targets; core substrate is the constraint |
+| External policy engine in critical path (OPA/Rego, Cedar) | Build stdlib+Pydantic path first; adopt only after v0 ships |
+| Fine-grained LangGraph `ToolNode` internal governance | Depends on internal API stability; coarse graph-boundary governance ships first |
+| LlamaIndex multi-agent handoff translation | Deferred until single-agent tool translation is stable |
+| CrewAI Flow (hierarchical delegation) translation | Deferred until Crew preflight and coarse wrappers are validated |
+| REST evidence API | Authenticated, redacted, tenant-aware evidence reads are unresolved in v0 |
+| Database-backed tamper-proof storage | v0 is library-mode tamper-evidence; Merkle packaging and Ed25519 signing are future |
+| Permissive DSL features | Prose-only constraints, wildcards, probabilistic auth, boolean expression language, inheritance, auto-SoD, model-id actors — all killed for v0 |
+| Dashboards and metrics UI | Not a v0 concern; SIEM export is the enterprise readiness path |
+
+### 1.4 Market Positioning
+
+lionagi enters a crowded orchestration market and must carve a distinct position. The governance
+layer is that position: users who need auditable, certifiable automated runs (regulated industries,
+enterprise compliance teams, high-stakes automation) cannot get this from existing frameworks.
+The charter model (declare constraints, compile them, enforce at runtime, certify outcomes) is the
+product. The adapters are the distribution mechanism.
+
+---
+
+## 2. Architecture Overview
+
+Governance is an additive runtime layer — it does not replace existing lionagi execution infrastructure.
+
+```text
+┌──────────────────────────────────────────────────────────────────┐
+│  Charter DSL v0                                                  │
+│  YAML-shaped source → CLI validate → compile → ratification hash │
+└────────────────────────────┬─────────────────────────────────────┘
+                             │ compilation targets
+        ┌────────────────────┼──────────────────────────────┐
+        ▼                    ▼                              ▼
+┌──────────────┐  ┌──────────────────────┐  ┌─────────────────────┐
+│ Gate         │  │ Registry + Policy     │  │ SoD + Charter       │
+│ Registry     │  │ Release Pin          │  │ Runtime Objects      │
+│ (ADR-0051)   │  │ (ADR-0052)           │  │ (ADR-0047/0048)     │
+└──────┬───────┘  └──────────┬───────────┘  └─────────┬───────────┘
+       │                     │                         │
+       └─────────────────────┼─────────────────────────┘
+                             ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  ActionManager.execute_governed()                                │
+│  Phase: pre-gate → execution → post-gate → evidence sidecar      │
+│  (ADR-0043/0044 resolved: ActionManager owns pipeline)           │
+└────────────────────────────┬─────────────────────────────────────┘
+                             │ emits
+       ┌─────────────────────┼────────────────────────────┐
+       ▼                     ▼                            ▼
+┌────────────┐  ┌──────────────────────┐  ┌──────────────────────┐
+│ Evidence   │  │ OperationContext      │  │ Log Tiers            │
+│ Chain      │  │ (actor, policy pin,  │  │ MUTABLE /            │
+│ (ADR-0041) │  │  trace IDs)          │  │ PROTECTED /          │
+│            │  │ (ADR-0050)           │  │ IMMUTABLE            │
+│            │  │                      │  │ (ADR-0049)           │
+└─────┬──────┘  └──────────┬───────────┘  └──────────┬───────────┘
+      │                    │                          │
+      └────────────────────┼──────────────────────────┘
+                           ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  OTel Projection                                                 │
+│  Typed records → span with evidence hash → SIEM / collector      │
+│  Spans are projection; evidence chain is authoritative storage   │
+└──────────────────────────────────────────────────────────────────┘
+                           │ consumed by
+┌──────────────────────────┼───────────────────────────────────────┐
+│  Session.flow() / FlowPlan                                       │
+│  Charter activation → op limits → artifact contracts             │
+│  → run-end certificate minting (ADR-0042)                        │
+└──────────────────────────┬───────────────────────────────────────┘
+                           │ wraps
+┌──────────────────────────┼───────────────────────────────────────┐
+│  Provider Adapters                                               │
+│  G1: PydanticAI | OpenAI Agents SDK | Anthropic Agent SDK        │
+│  G2: LangGraph | LlamaIndex | CrewAI                             │
+│  Zero-rewrite: accept user's existing objects at the boundary    │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+**Layering rules**:
+
+1. Evidence chain is the source of truth — OTel spans are projections, not the record.
+2. `ActionManager` owns the single governed execution pipeline — gates plug into phases, not around it.
+3. `OperationContext` is created and propagated explicitly — `contextvars` is a bridge only.
+4. Charter compilation must resolve all targets before activation; unresolved targets fail closed.
+5. Adapters claim only what they govern — coarse boundary wrappers emit boundary evidence only.
+
+---
+
+## 3. Provider Adapter Strategy
+
+### 3.1 Zero-Rewrite Principle
+
+Users bring their existing objects. lionagi wraps the user's existing object and governs its
+execution boundary. The adapter does not rewrite the user's framework code. A governed endpoint
+has the shape:
+
+```python
+GovernedEndpoint(user_object=their_existing_thing, charter=loaded_charter)
+```
+
+The adapter intercepts invocation, enforces the charter at the boundary, emits evidence, and returns
+results. Internal framework calls (LangGraph node transitions, LlamaIndex retrieval steps, CrewAI
+task delegation) are observed evidence, not governed lionagi tool calls, unless the user explicitly
+translates framework tools into lionagi `Tool` objects.
+
+### 3.2 G1 — SDK-Native Adapters
+
+These adapters receive first implementation because they expose typed event streams and native hooks.
+
+| Target | Hook Mechanism | Governed Events | Coarse/Fine |
+|--------|---------------|-----------------|-------------|
+| PydanticAI | `instrument_*`, run-level hooks | Tool calls, model requests, output validation | Both supported |
+| OpenAI Agents SDK | Tracing hooks, `AgentHook` events | Tool calls, handoffs, model outputs, run lifecycle | Both supported |
+| Anthropic Agent SDK | Native event stream, tool blocks | Tool use blocks, model turns, result extraction | Both supported |
+
+Each G1 adapter is approximately 200 LOC. Fine-grained claims require the framework tool to be
+translated into a registered lionagi `Tool` object. Coarse-only claims govern invocation boundaries.
+
+### 3.3 G2 — Framework Adapters
+
+These adapters accept existing user objects and apply coarse governance at the boundary.
+
+| Target | Accepted Objects | Coarse Boundary | Fine Governance |
+|--------|-----------------|-----------------|-----------------|
+| LangGraph | `CompiledStateGraph` | Graph invoke entry/exit | Requires tool translation; fine mode explicitly labeled |
+| LlamaIndex | `AgentWorkflow`, `FunctionAgent`, `ReActAgent`, `QueryEngineTool`, `FunctionTool` | Agent run entry/exit | Tool translation supported for `FunctionTool` |
+| CrewAI | `Crew`, `CrewPlan` (preflight) | Crew kickoff entry/exit | Hierarchical delegation not governed in v0 |
+
+Internal framework state transitions (LangGraph node routing, LlamaIndex retrieval pipelines,
+CrewAI task delegation chains) are observed boundary evidence, not governed lionagi actions, in
+coarse mode. Any adapter claiming fine governance for internal steps must register those steps as
+translated lionagi `Tool` objects with registry entries.
+
+### 3.4 G3 — Edge Adapters (Not In Scope for P12-P24)
+
+smolagents, OpenCode, and HuggingFace inference suites remain optional. They reopen only if
+P12-P23 complete ahead of schedule with clean adversarial test results.
+
+### 3.5 Adapter Claim Standards
+
+Every adapter ships with an explicit claim matrix in its docstring and test fixture. The matrix
+declares: which events are governed (gate + evidence), which events are observed-only (boundary
+evidence, no gate enforcement), and which events are not captured. Overclaiming governance for
+internal framework calls is a defect that fails the adversarial test suite.
+
+---
+
+## 4. DSL Strategy
+
+### 4.1 Charter DSL v0 Overview
+
+Charter DSL v0 is YAML-shaped, not YAML-arbitrary. It has a fixed top-level block set, strict
+Pydantic schema, and deterministic compilation. It is not a general-purpose policy language.
+Unsupported features are rejected at parse time with actionable error messages.
+
+**Canonical top-level blocks** (required unless marked optional):
+
+```text
+charter_dsl      — version pin ("0.1")
+kind             — agent_charter | session_charter
+metadata         — identity, release, ratification
+agents           — actor bindings (one per agent_charter, two or more per session_charter)
+registry         — ratified tool/model/path snapshot with evidence
+constraints      — executable gate or hook bindings with enforcement levels
+sod              — segregation-of-duties conflict matrix (required, rules: [] if inactive)
+permissions      — explicit allow/deny rules with specificity resolution
+break_glass      — (optional) emergency elevated mode with attestation and time bounds
+trace            — span and evidence requirements for runtime verification
+```
+
+Full syntax specification: [`docs/governance/standards/dsl-style.md`](standards/dsl-style.md)
+
+Three concrete charter examples are in: [`docs/governance/charter-dsl-v0.md`](charter-dsl-v0.md)
+
+### 4.2 Compilation Pipeline
+
+Charter compilation follows six ordered phases. Each phase is a gate — failure fails closed.
+
+```text
+Phase 1: Parse
+  YAML source → AST nodes
+  Validates: top-level block presence, key spelling, value types
+  Rejects: unknown keys, wrong types, missing required blocks
+
+Phase 2: Validate
+  Schema validation via Pydantic models
+  Checks: constraint binding exclusivity (exactly one of gate_id/hook_name),
+          SoD rule structure, permission specificity, trace span name set
+
+Phase 3: Bind
+  Resolves gate_id → registered GateExecutor
+  Resolves hook_name + hook_phase → registered hook
+  Resolves registry entry values → canonical identifiers
+  Fails closed on any unresolved target
+
+Phase 4: Normalize
+  Produces canonical JSON representation
+  Comments stripped; field order fixed; enum values lowercased
+  Output is deterministic given the same input
+
+Phase 5: Emit
+  Produces typed runtime target objects:
+    - GateRegistration objects (one per constraint)
+    - RegistryEntry objects (one per registry entry)
+    - SoDRule objects (bidirectional, one per sod.rules entry)
+    - EvidenceRequirement objects (from constraints and trace)
+    - TraceExpectation objects (from trace.require_spans)
+    - PermissionPolicy object (from permissions block)
+    - PolicyPin record (from metadata.policy_release)
+
+Phase 6: Activate
+  Computes SHA-256 hash of normalized JSON
+  Compares against metadata.ratification.hash (must match for accepted charters)
+  Records activation evidence (charter_id, hash, policy_pin, activated_at)
+  Registers all emitted targets with the runtime
+  Returns typed AgentCharter or SessionCharter runtime object
+```
+
+### 4.3 Runtime Binding
+
+At runtime, the compiled charter binding is the source of authority for:
+
+- Gate enforcement: `ActionManager.execute_governed()` consults registered gates by `constraint_id`
+- Registry enforcement: tool calls check against ratified registry snapshots
+- Policy resolution: ADR-0052 resolver uses the policy pin from the charter
+- SoD checks: role conflict matrix is evaluated at assignment time
+- Trace verification: required spans are validated post-run against the OTel export
+
+### 4.4 IDE Hints and CLI Integration
+
+The same Pydantic schema that validates charters at runtime is exported as JSON Schema for IDE
+integration. Editor hints cannot drift from runtime validation because they share the same source.
+
+CLI commands:
+
+- `li charter validate <file>` — parse + validate, report errors with line numbers
+- `li charter compile <file>` — full compilation through Phase 5, output runtime target summary
+- `li charter activate <file>` — full compilation through Phase 6, register targets in session
+
+---
+
+## 5. Tracing Strategy
+
+### 5.1 Architecture: Records First, Spans Second
+
+The governance tracing architecture has a strict hierarchy:
+
+1. The runtime creates **typed governance records** first (evidence nodes, gate results, certificates)
+2. `trace_id` and `span_id` are **embedded into evidence** at record creation time
+3. OTel spans are **projected** from the same records, carrying evidence hashes for correlation
+4. Spans are **never** the authoritative storage for governance decisions
+
+This means: an auditor verifying a run reads the evidence chain, not the OTel export. OTel
+is the enterprise observability interface (SIEM, alerting, dashboards), not the compliance record.
+
+### 5.2 Span Taxonomy Reference
+
+The canonical span registry is defined in [`docs/governance/standards/trace-naming.md`](standards/trace-naming.md).
+The base taxonomy comes from P9. P11 adds the missing spans identified in the P9 critic verdict:
+
+**Base spans (P9)**:
+
+| Span Name | Trigger | Required Attributes |
+|-----------|---------|---------------------|
+| `governance.operation` | Operation start | `governance.charter_id`, `governance.policy.version`, `governance.actor.id`, `governance.actor.role` |
+| `gate.evaluate` | Gate execution | `gate.id`, `gate.tool.name`, `gate.enforcement`, `gate.result`, `gate.evidence_hash` |
+| `evidence.emit` | Evidence node creation | `evidence.kind`, `evidence.hash`, `evidence.chain_tip` |
+| `registry.lookup` | Registry entry check | `registry.category`, `registry.value`, `registry.scope`, `registry.result` |
+| `policy.resolve` | Policy resolution | `policy.release`, `policy.rule_id`, `policy.specificity`, `policy.decision` |
+| `certificate.mint` | Certificate creation | `certificate.id`, `certificate.chain_head`, `certificate.policy_version`, `certificate.gate_count` |
+| `sod.check` | SoD matrix evaluation | `sod.rule_id`, `sod.roles`, `sod.conflict_type`, `sod.result` |
+
+**Additions from P9 critic verdict (P20 responsibility)**:
+
+| Span Name | Trigger | Required Attributes |
+|-----------|---------|---------------------|
+| `permit.issue` | JIT permit issued | `permit.id`, `permit.scope`, `permit.tool.name`, `permit.issuer.id`, `permit.subject.id`, `permit.expires.at`, `permit.evidence.hash` |
+| `permit.consume` | JIT permit consumed on tool call | `permit.id`, `permit.tool.name`, `permit.subject.id`, `permit.consumed.at`, `permit.consume.result`, `permit.evidence.hash` |
+| `permit.revoke` | JIT permit revoked before expiry | `permit.id`, `permit.revoked.by`, `permit.revoked.at`, `permit.revoke.reason`, `permit.evidence.hash` |
+| `certificate.verify` | Certificate re-verification | `certificate.id`, `certificate.verification.result`, `certificate.superseded.by`, `certificate.evidence.chain.hash` |
+| `breakglass.open` | Break-glass activation | `breakglass.window.id`, `breakglass.activated.at`, `breakglass.requested.by`, `breakglass.approved.by`, `breakglass.reason`, `breakglass.max.duration`, `breakglass.evidence.hash` |
+| `breakglass.expire` | Break-glass window expired | `breakglass.window.id`, `breakglass.activated.at`, `breakglass.expired.at`, `breakglass.authority`, `breakglass.tools.used.count`, `breakglass.expiry.reason` |
+| `breakglass.close` | Break-glass closed or revoked | `breakglass.window.id`, `breakglass.closed.at`, `breakglass.close.reason`, `breakglass.tool.call.count`, `breakglass.certificate.id` |
+| `breakglass.notify` | Emergency notification sent | `breakglass.window.id`, `breakglass.notification.target`, `breakglass.notification.kind`, `breakglass.notification.result` |
+| `gate.justify` | SOFT gate override with justification | `gate.id`, `gate.verdict`, `gate.enforcement`, `gate.justification`, `gate.justification.actor.id`, `gate.evidence.hash` |
+
+### 5.3 Enterprise Readiness Path
+
+The span schema is designed for enterprise readiness from the start. Retrofitting observability
+attributes onto opaque spans is expensive — declaring them in the schema creates the migration path.
+
+| Capability | Design Element | P-Number |
+|------------|---------------|----------|
+| Retention tiers | Log tier governance aligned with span retention fields | P15, P20 |
+| Sensitive data redaction | Evidence record field exclusion rules documented at emit time | P15 |
+| SIEM export | OTel collector-compatible span format; attribute naming follows OTel semconv | P20 |
+| Backpressure | Span export failure must not block evidence chain writes | P20 |
+| Alerting | `gate.result: DENY` and `breakglass.open` are alertable events | P20 |
+| Cost tracking | `governance.operation` spans carry operation budget attributes | P18 |
+| Audit/ops separation | Audit spans go to immutable SIEM sink; ops spans go to mutable collector | P20 |
+
+---
+
+## 6. ADR Slate Verdict
+
+All 12 governance ADRs are reviewed. The verdict is five SURVIVE, seven REVISE, zero KILL.
+No ADR is correct-as-is across the entire governance design; revisions resolve overlaps and
+bind the ADRs to the Charter DSL compilation pipeline and shared runtime types.
+
+| ADR | Title | Verdict | Rationale |
+|-----|-------|---------|-----------|
+| ADR-0041 | Immutable Evidence Nodes | **SURVIVE** | Hash-chain evidence is the correct foundation. Matches P7's stdlib SHA-256 build path and P1's missing chain-tip/canonical hash substrate. Implementation must follow it without modification. |
+| ADR-0042 | Task Certificate | **REVISE** | Certificate stays, but must inherit ADR-0041 evidence types rather than redeclaring `Element`-based references. Minting must consume `OperationContext`, gate records, break-glass state, and policy pin. |
+| ADR-0043 | Governed Tool Declaration | **REVISE** | Rename to "Governed Tool Wrapper" to match the actual implementation (a wrapper + metadata, not just a declaration). `ActionManager` is the single execution pipeline owner; gates plug into its phases. |
+| ADR-0044 | Tool Gates | **REVISE** | Keep binary gates and fail-closed exceptions. Define one canonical `GateResult` type (currently duplicated with ADR-0050). Treat break-glass as a separate emergency lifecycle, not a HARD gate override. |
+| ADR-0045 | Break-Glass Protocol | **REVISE** | Keep the emergency path. Add activation/revoke lifecycle spans (`breakglass.open`, `breakglass.close`). Clarify library-mode limits: no hardware HSM, no distributed consensus. Reconcile evidence/certificate path with `OperationContext`. |
+| ADR-0046 | JIT Tool Grant | **REVISE** | Keep no-standing-capability and single-use permit semantics. The registry/policy-resolved privileged tier is authoritative for `requires_jit`; decorator metadata is a declaration hint, not the source of truth. |
+| ADR-0047 | Agent Charter | **REVISE** | Replace Python-only charter objects with DSL-first compilation. Runtime `AgentCharter` and `SessionCharter` objects are compiler outputs, not hand-constructed. CLI validation and activation evidence are mandatory. |
+| ADR-0048 | Agent SoD | **SURVIVE** | Assignment-time conflict matrices and role independence are correct and required. Must be implemented before CrewAI hierarchical/delegation paths can be claimed governed. |
+| ADR-0049 | Log Tier Governance | **SURVIVE** | MUTABLE/PROTECTED/IMMUTABLE model is correct. Application-layer backend deferral is the right call for v0. Complements evidence chain rather than replacing it. |
+| ADR-0050 | Operation Context | **REVISE** | Keep active assertion, explicit propagation, and evidence embedding. Remove the duplicated `GateResult` type (canonical home is ADR-0044). Settle pipeline phase ownership with ADR-0043. Allow `contextvars` as a propagation bridge only, never as the authoritative source of context state. |
+| ADR-0051 | Tool Registry Allowlists | **REVISE** | Keep append-only exact registry semantics. Make registry entries compiled DSL targets, not a parallel policy plane. The registry is a runtime enforcement artifact of Charter compilation, not an independently authored store. |
+| ADR-0052 | Policy Resolution | **SURVIVE** | Most-specific-wins, deny-on-tie, staged releases, and session pinning are the canonical resolver algorithm. Wire it into Charter DSL compilation (the `permissions` block compiles to policy rules) and registry scope. |
+
+**Revision convergence groups**:
+
+- ADR-0043 + ADR-0044 + ADR-0050 → one governed execution pipeline in `ActionManager`
+- ADR-0047 + ADR-0051 + ADR-0052 → unified under Charter DSL compilation
+- ADR-0045 + ADR-0046 → explicit lifecycle evidence and OTel spans for emergency/elevated paths
+
+---
+
+## 7. Phase 3-7 Play List (P12-P24)
+
+13 plays. Maximum budget is 13 plays (P12-P24). No play may be added without explicit scope
+cut elsewhere. G3 adapters, REST evidence API, dashboards, and fine-grained framework internals
+are the first cut targets if budget is exceeded.
+
+### P12 — ADR Slate Consolidation
+
+| Field | Value |
+|-------|-------|
+| **Category** | A — ADR revision |
+| **Playbook** | feature |
+| **Effort** | medium |
+| **Scope** | Revise ADR-0042, 0043, 0044, 0045, 0046, 0047, 0050, 0051 to remove duplicated types and bind DSL/runtime ownership. Produce cross-reference table: which ADR owns each type. |
+| **Dependencies** | P11 (this document) |
+| **Measurement** | All revised ADRs cite evidence inventory; no duplicated `GateResult`; cross-reference table complete; ADR doc links to tests and implementation path |
+| **Files Modified** | `docs/adrs/ADR-0042-*.md`, `ADR-0043-*.md`, `ADR-0044-*.md`, `ADR-0045-*.md`, `ADR-0046-*.md`, `ADR-0047-*.md`, `ADR-0050-*.md`, `ADR-0051-*.md` |
+
+### P13 — Charter DSL Parser and Schema
+
+| Field | Value |
+|-------|-------|
+| **Category** | B — DSL implementation |
+| **Playbook** | feature |
+| **Effort** | high |
+| **Scope** | Implement canonical DSL Pydantic models, YAML parser, schema validation, legacy variant rejection with migration diagnostics, and JSON Schema export for IDE hints. Must handle all required blocks, optional `break_glass`, enforcement enum normalization, and constraint binding exclusivity check. |
+| **Dependencies** | P12 |
+| **Measurement** | Unit tests for parser; property tests for schema round-trips; fixtures cover three canonical charter examples; wildcards and legacy `apiVersion` keys are rejected with line-specific error messages; JSON Schema output passes VS Code schema validation |
+| **Files Modified** | `lionagi/protocols/governance/charter.py`, `lionagi/protocols/governance/dsl.py`, `lionagi/cli/orchestrate/charter.py`, `tests/governance/test_charter_dsl.py` |
+
+### P14 — Charter Compiler and Runtime Targets
+
+| Field | Value |
+|-------|-------|
+| **Category** | B — DSL implementation |
+| **Playbook** | feature |
+| **Effort** | high |
+| **Scope** | Compile DSL through all six phases. Emit `GateRegistration`, `RegistryEntry`, `SoDRule`, `EvidenceRequirement`, `TraceExpectation`, `PermissionPolicy`, and `PolicyPin` objects. Activation must verify SHA-256 hash against `metadata.ratification.hash`; unresolved targets fail closed. |
+| **Dependencies** | P13 |
+| **Measurement** | Golden compile snapshots stable across Python versions; activation fails closed on hash mismatch; activation fails closed on unresolved gate or hook target; coverage across all seven runtime target families; adversarial test: tampered charter hash is rejected |
+| **Files Modified** | `lionagi/protocols/governance/compiler.py`, `lionagi/protocols/governance/runtime.py`, `lionagi/cli/orchestrate/charter.py`, `tests/governance/test_charter_compile.py` |
+
+### P15 — Evidence Chain and Log Tiers
+
+| Field | Value |
+|-------|-------|
+| **Category** | C — Substrate |
+| **Playbook** | feature |
+| **Effort** | high |
+| **Scope** | Canonical JSON evidence nodes with SHA-256 chain hashing (stdlib `hashlib`, zero external dependency). Append-only audit pile behavior (existing `Pile` gets append-only mode). Tier-aware `DataLogger` emitting MUTABLE, PROTECTED, and IMMUTABLE records. Evidence chain `verify()` that detects tampering, reordering, and deletion. |
+| **Dependencies** | P12 |
+| **Measurement** | Tamper, reorder, delete tests pass; property tests for SHA-256 determinism; microbenchmark confirms synchronous hashing stays under 1ms for typical evidence payloads; sensitive field exclusion is documented at emit time |
+| **Files Modified** | `lionagi/protocols/governance/evidence.py`, `lionagi/protocols/generic/log.py`, `lionagi/protocols/generic/pile.py`, `lionagi/session/branch.py`, `tests/governance/test_evidence_chain.py` |
+
+### P16 — OperationContext and Policy Release Pinning
+
+| Field | Value |
+|-------|-------|
+| **Category** | C — Substrate |
+| **Playbook** | feature |
+| **Effort** | high |
+| **Scope** | `OperationContext` with actor identity, policy release pin, trace IDs, operation budget, and evidence embedding helpers. Explicit propagation via function arguments. `contextvars` bridge: set at async boundary for tools that cannot accept explicit context, but never used as the authoritative store. Policy release pin validated against the session charter at `Session.flow()` entry. |
+| **Dependencies** | P15 |
+| **Measurement** | Async propagation tests show context is correctly available in governed tool calls; missing context fails closed in governed mode; `contextvars` contains only a reference to the explicit context, not the state itself; policy pin mismatch fails the flow before execution |
+| **Files Modified** | `lionagi/protocols/governance/context.py`, `lionagi/session/branch.py`, `lionagi/session/session.py`, `lionagi/operations/operate/operate.py`, `tests/governance/test_operation_context.py` |
+
+### P17 — Governed ActionManager Gates
+
+| Field | Value |
+|-------|-------|
+| **Category** | C — Substrate |
+| **Playbook** | feature |
+| **Effort** | high |
+| **Scope** | `Tool.governance_meta` descriptor, `@governed_tool` decorator, `ActionManager.execute_governed()` pipeline (pre-gate → execution → post-gate → evidence sidecar), gate registry executor, and no-bypass controls on raw tool execution. Single canonical `GateResult` type (ADR-0044 owner). Hard gates raise `GovernanceViolationError` on deny; soft gates emit advisory evidence; advisory gates record without blocking. |
+| **Dependencies** | P14, P16 |
+| **Measurement** | Happy-path test (ALLOW result, evidence emitted); deny test (DENY raises error, evidence immutable); soft gate test (SOFT allows with justification evidence); advisory test (ADVISORY records without blocking); raw-tool bypass adversarial test fails closed; exactly one `GateResult` import path |
+| **Files Modified** | `lionagi/protocols/action/tool.py`, `lionagi/protocols/action/manager.py`, `lionagi/protocols/action/function_calling.py`, `lionagi/protocols/governance/gates.py`, `tests/governance/test_tool_gates.py` |
+
+### P18 — Flow Governance Integration
+
+| Field | Value |
+|-------|-------|
+| **Category** | D — Orchestration integration |
+| **Playbook** | feature |
+| **Effort** | high |
+| **Scope** | Define and implement `TaskCertificate` type (minting, grade computation, evidence chain head embedding). Wire charter activation into `Session.flow()` entry; enforce role allowlists and op limits from compiled charter; validate artifact contracts in `FlowPlan`; attach per-operation evidence sidecars via `Branch.operate(middle=...)`; mint run-end `TaskCertificate` after artifact verification; expose `li charter activate` and `li flow run --charter` CLI paths. |
+| **Dependencies** | P17 |
+| **Measurement** | Integration fixture proves: op limit exceeded → run blocked; role not in allowlist → op blocked; artifact missing → certificate not minted; break-glass event recorded in immutable evidence; run certificate contains evidence chain head hash and policy version |
+| **Files Modified** | `lionagi/session/session.py`, `lionagi/operations/flow.py`, `lionagi/operations/types.py`, `lionagi/cli/orchestrate/flow.py`, `lionagi/cli/orchestrate/_orchestration.py`, `tests/governance/test_flow_governance.py` |
+
+### P19 — Certificates, Break-Glass, JIT, Registry, SoD
+
+| Field | Value |
+|-------|-------|
+| **Category** | E — Layer |
+| **Playbook** | feature |
+| **Effort** | high |
+| **Scope** | Full governance layer object implementations: `TaskCertificate` (verification, replay detection, certificate store querying — minting type is defined in P18), `BreakGlassProtocol` (activation with attestation evidence, lifecycle spans, revocation, DEGRADED certificate path), `JITGrant` (single-use permit, registry/policy-resolved `requires_jit`, expiry), `ToolRegistry` (compiled DSL targets, exact-match, policy-resolved scope), `PolicyResolver` (ADR-0052 most-specific-wins), `SoDMatrix` (bidirectional conflict, assignment-time check). |
+| **Dependencies** | P18 |
+| **Measurement** | Certificate replay is blocked; break-glass audit evidence is immutable and non-exportable via normal paths; JIT grant is consumed exactly once; deny-on-tie test case; SoD matrix property test for bidirectional conflicts; adversarial test: elevated tool call outside break-glass window is rejected |
+| **Files Modified** | `lionagi/protocols/governance/certificate.py`, `lionagi/protocols/governance/break_glass.py`, `lionagi/protocols/governance/jit.py`, `lionagi/protocols/governance/registry.py`, `lionagi/protocols/governance/policy.py`, `lionagi/protocols/governance/sod.py`, `lionagi/session/branch.py`, `tests/governance/test_layer_controls.py` |
+
+### P20 — OTel Governance Tracing
+
+| Field | Value |
+|-------|-------|
+| **Category** | F — Tracing |
+| **Playbook** | feature |
+| **Effort** | medium |
+| **Scope** | Project typed governance records onto OTel spans using the P9 span registry plus P11 additions (permit lifecycle, certificate lifecycle, break-glass open/close/notify, SOFT gate justification). Embed evidence hashes and trace/span IDs bidirectionally. Span export failure must not block evidence chain writes (backpressure). Retention tier alignment with log tier governance. |
+| **Dependencies** | P19 |
+| **Measurement** | Every governance record type has a corresponding span; all span attribute names are dot-separated; `evidence.emit` span carries chain tip hash; `breakglass.open` span is alertable; evidence chain verification passes without OTel export; backpressure test confirms evidence writes complete when span export is blocked |
+| **Files Modified** | `lionagi/protocols/governance/tracing.py`, `lionagi/protocols/generic/log.py`, `tests/governance/test_tracing.py` |
+
+### P21 — SDK-Native Governed Endpoints (G1)
+
+| Field | Value |
+|-------|-------|
+| **Category** | G1 — SDK-native adapters |
+| **Playbook** | feature |
+| **Effort** | medium |
+| **Scope** | Zero-rewrite governed endpoints for PydanticAI (`instrument_*` hooks), OpenAI Agents SDK (`AgentHook` event stream), and Anthropic Agent SDK (native tool-use block handling). Each adapter: ~200 LOC, accepts the user's existing agent/runner object, emits boundary evidence, enforces the compiled charter at the invocation boundary. Explicit claim matrix in docstring and test. |
+| **Dependencies** | P17, P20 |
+| **Measurement** | Contract tests with mocked typed event streams; package-shape validation confirms no framework internals are imported unconditionally; coarse/fine claim matrix documented; adversarial test: overclaiming internal tool call governance fails the claim matrix check |
+| **Files Modified** | `lionagi/providers/pydantic_ai/`, `lionagi/providers/openai_agents/`, `lionagi/providers/anthropic_agents/`, `tests/providers/test_governed_sdk_adapters.py` |
+
+### P22 — Framework Governed Endpoints (G2)
+
+| Field | Value |
+|-------|-------|
+| **Category** | G2 — Framework adapters |
+| **Playbook** | feature |
+| **Effort** | medium |
+| **Scope** | Zero-rewrite governed wrappers for LangGraph (`CompiledStateGraph`), LlamaIndex (`AgentWorkflow`, `FunctionAgent`, `ReActAgent`, `QueryEngineTool`, `FunctionTool`), and CrewAI (`Crew`, `CrewPlan` preflight). Coarse boundary governance only. Fine mode available only for translated lionagi `Tool` objects. CrewAI hierarchical delegation is not governed in v0. |
+| **Dependencies** | P18, P19 |
+| **Measurement** | Contract tests for graph invoke, LlamaIndex tool translation, CrewPlan preflight; claim matrix documents what is and is not governed; unsupported delegation call fails closed with a descriptive `GovernanceViolationError`; coarse-only adapters emit boundary evidence correctly |
+| **Files Modified** | `lionagi/providers/langgraph/`, `lionagi/providers/llamaindex/`, `lionagi/providers/crewai/`, `tests/providers/test_governed_framework_adapters.py` |
+
+### P23 — Governance Test and Adversarial Fixture Pack
+
+| Field | Value |
+|-------|-------|
+| **Category** | H — Hygiene and docs |
+| **Playbook** | feature |
+| **Effort** | medium |
+| **Scope** | Shared `conftest.py` and fixture library for all governance tests. Marker lanes: `@pytest.mark.governance`, `@pytest.mark.adversarial`, `@pytest.mark.property`. Deterministic adversarial suites for: charter parser (injection, malformed, wildcard), gate executor (bypass, type mismatch), evidence chain (tamper, reorder), registry (exact-match bypass), policy resolver (tie, ambiguity), SoD (conflict evasion), JIT (replay, expiry), break-glass (window exhaustion). Mutation and fuzz entrypoints for parser and evidence chain. |
+| **Dependencies** | P13-P22 |
+| **Measurement** | PR adversarial lane deterministic and passing; property tests cover chain/SoD/policy invariants with Hypothesis; adversarial bypass suite passes for all nine threat categories; mutation tests achieve ≥80% kill rate |
+| **Files Modified** | `tests/governance/conftest.py`, `tests/governance/fixtures/`, `pyproject.toml`, `tests/governance/test_adversarial_charter.py`, `tests/governance/test_adversarial_gates.py`, `tests/governance/test_adversarial_evidence.py`, `tests/governance/test_adversarial_policy.py` |
+
+### P24 — Docs, Migration Guide, and Public API Polish
+
+| Field | Value |
+|-------|-------|
+| **Category** | H — Hygiene and docs |
+| **Playbook** | fix |
+| **Effort** | medium |
+| **Scope** | User-facing governed orchestration guide, CLI reference (`li charter`, `li flow`), adapter claim matrix (table: adapter × event × governance level), migration path from ungoverned lionagi usage, standards cleanup pass, and `lionagi/governance/__init__.py` ergonomic public API with typed imports. Documentation examples must run or have snapshot-validated output. |
+| **Dependencies** | P21, P22, P23 |
+| **Measurement** | Documentation examples run or snapshot-validated; adapter claim matrix matches adversarial test fixture labels; migration guide covers the three most common ungoverned patterns; no banned token matches; public API imports resolve in <100ms |
+| **Files Modified** | `docs/governance/`, `README.md`, `docs/adrs/README.md`, `lionagi/governance/__init__.py`, `tests/docs/test_governance_examples.py` |
+
+---
+
+## 8. Integration Plan
+
+The governance build is additive. Existing lionagi code is modified at well-defined extension points
+only. New modules live in `lionagi/protocols/governance/`. Existing modules receive narrow additions.
+
+### 8.1 `lionagi/protocols/`
+
+**New package: `lionagi/protocols/governance/`**
+
+| Module | Contents |
+|--------|----------|
+| `evidence.py` | `EvidenceNode`, `EvidenceChain`, `ChainVerifier`, SHA-256 hash utilities |
+| `context.py` | `OperationContext`, `contextvars` bridge, policy pin, actor identity helpers |
+| `gates.py` | `GateResult`, `GateExecutor`, `GateRegistry`, `GovernanceViolationError` |
+| `charter.py` | `AgentCharter`, `SessionCharter`, `CharterId`, `RatificationRecord` |
+| `dsl.py` | `CharterDSL` Pydantic models, YAML parser, JSON Schema exporter |
+| `compiler.py` | Six-phase compiler: parse → validate → bind → normalize → emit → activate |
+| `runtime.py` | `GateRegistration`, `RegistryEntry`, `SoDRule`, `EvidenceRequirement`, `TraceExpectation` |
+| `certificate.py` | `TaskCertificate`, minting, verification, replay registry |
+| `break_glass.py` | `BreakGlassProtocol`, attestation, lifecycle spans, `DEGRADED` certificate path |
+| `jit.py` | `JITGrant`, single-use permit, expiry, `requires_jit` resolution |
+| `registry.py` | `ToolRegistry`, exact-match, policy-resolved scope, compiled DSL target store |
+| `policy.py` | `PolicyResolver`, most-specific-wins, deny-on-tie, staged release pinning |
+| `sod.py` | `SoDMatrix`, bidirectional conflict, assignment-time check |
+| `tracing.py` | OTel span projections, evidence hash embedding, backpressure-safe export |
+
+**Modified: `lionagi/protocols/generic/`**
+
+| File | Change |
+|------|--------|
+| `log.py` | Add tier-aware emission: `MUTABLE`, `PROTECTED`, `IMMUTABLE` record routing |
+| `pile.py` | Add append-only mode for audit records |
+
+**Modified: `lionagi/protocols/action/`**
+
+| File | Change |
+|------|--------|
+| `tool.py` | Add `governance_meta` descriptor and `@governed_tool` decorator |
+| `manager.py` | Add `execute_governed()` pipeline; raw execution path marked as non-governed |
+| `function_calling.py` | Thread `OperationContext` through tool execution call stack |
+
+### 8.2 `lionagi/session/`
+
+| File | Change |
+|------|--------|
+| `branch.py` | Mount: evidence chain, policy pin, charter binding, role identity, JIT grant store |
+| `session.py` | Mount: charter activation at flow entry, certificate store, break-glass window tracking |
+
+Branch gains governance state that is initialized when a charter is activated. Ungoverned branches
+remain unchanged — governance is opt-in at the `Session.flow()` or `Branch.activate_charter()` call.
+
+### 8.3 `lionagi/cli/orchestrate/`
+
+| File | Change |
+|------|--------|
+| `charter.py` | New: `li charter validate`, `li charter compile`, `li charter activate` commands |
+| `flow.py` | Add: `--charter` flag, flow-plan governance validation, certificate reporting |
+| `_orchestration.py` | Add: artifact evidence sidecars, run-end certificate hook |
+
+### 8.4 `lionagi/providers/`
+
+New provider packages (P21, P22). Each package contains:
+
+- `__init__.py` — public `GovernedEndpoint` class
+- `adapter.py` — framework-specific wrapping logic
+- `claim_matrix.py` — machine-readable claim matrix (used by adversarial tests)
+
+| Package | Target | Play |
+|---------|--------|------|
+| `lionagi/providers/pydantic_ai/` | PydanticAI agents | P21 |
+| `lionagi/providers/openai_agents/` | OpenAI Agents SDK | P21 |
+| `lionagi/providers/anthropic_agents/` | Anthropic Agent SDK | P21 |
+| `lionagi/providers/langgraph/` | LangGraph `CompiledStateGraph` | P22 |
+| `lionagi/providers/llamaindex/` | LlamaIndex agents and tools | P22 |
+| `lionagi/providers/crewai/` | CrewAI `Crew` and `CrewPlan` | P22 |
+
+No provider package is added until the substrate (P15-P17) and flow governance (P18) are complete
+and verified. An adapter claiming governance before the substrate exists is a false claim.
+
+### 8.5 `lionagi/tools/`
+
+| Change | Details |
+|--------|---------|
+| Add `governance_meta` to built-in tools | `read_file`, `write_file`, `exec_command`, and other built-ins get governance metadata |
+| Safe defaults | Destructive-action tools (write, exec) default to registry-required, hard gate |
+| Registry identity | Built-in tool IDs are canonical and match the DSL `tool.*` identifier namespace |
+
+### 8.6 Public API (`lionagi/governance/`)
+
+After P19, expose ergonomic imports over the full protocol path:
+
+```python
+from lionagi.governance import (
+    AgentCharter,
+    SessionCharter,
+    TaskCertificate,
+    EvidenceChain,
+    OperationContext,
+    ToolRegistry,
+    PolicyResolver,
+    SoDMatrix,
+    BreakGlassProtocol,
+    JITGrant,
+    governed_tool,
+    GovernanceViolationError,
+)
+```
+
+The public API is the migration entry point. v1 migration attaches governance to existing branches
+via `branch.activate_charter(charter)` without requiring Session-level flow rewrites.
+
+---
+
+## 9. Risk Register
+
+| Risk | Likelihood (1-5) | Impact (1-5) | Mitigation | Recovery Rule |
+|------|-----------------|--------------|------------|---------------|
+| **DSL/runtime drift**: Charter compiles to targets the runtime does not enforce, creating a false governance claim | 3 | 5 | P13/P14 golden compile snapshots; activation fails closed on unresolved targets; each target type has a corresponding integration test in P18 | ADR-impl drift triggers the "match ADR or revise" recovery: pause implementation, revise the ADR, re-pass the gate |
+| **Coarse adapter overclaiming**: Adapter claims governance for internal framework calls that are not enforced | 4 | 5 | Claim matrix per adapter; adversarial test in P23 checks claim matrix against emitted evidence; coarse-only adapters emit boundary evidence only | Later bypass/test gaps queue a substrate patch or ADR amendment; adapter ships with explicit scope limitation in docs |
+| **`OperationContext` propagation ambiguity**: `contextvars` used as authoritative store, causing governance gaps under concurrency | 3 | 4 | Explicit propagation is the design; `contextvars` is bridge-only; P16 tests prove no authoritative hidden accumulation; async propagation tests cover concurrent operation paths | Substrate bug queues a foundation patch and blocks API widening until the fix is verified |
+| **`GateResult` type duplication**: Incompatible `GateResult` types across ADR-0044 and ADR-0050 cause certificate, span, and policy inconsistencies | 4 | 4 | P12 consolidates one canonical `GateResult` before any substrate implementation; cross-reference table in ADR revision locks ownership | ADR contradictions get a binding tie-break from P12; no implementation proceeds without resolution |
+| **Evidence integrity misrepresented**: Library-mode hash chains mistakenly claimed as tamper-proof storage | 3 | 5 | Documentation is explicit: library-mode tamper-evidence, sensitive-field exclusion, backend immutability is not provided by lionagi core; audit trail is advisory in adversarial custody settings | Any claim of tamper-proof storage triggers an immediate doc correction and governance violation |
+| **Break-glass undermines HARD gate semantics**: Emergency path is used to bypass normal governance as a convenience | 3 | 5 | Break-glass has a separate emergency lifecycle distinct from normal gate results; all activations emit immutable justification evidence; DEGRADED certificate signals non-standard run; lifecycle spans are alertable | Behavioral gaps queue a substrate/ADR coverage patch; repeated misuse triggers a policy tightening revision |
+| **External package APIs move before adapters land**: LangGraph, LlamaIndex, CrewAI, or SDK-native packages change their event or hook API | 3 | 3 | Runtime package validation at adapter import; contract tests use mocked event shapes with explicit version pins; `claim_matrix.py` documents which API version the claim matrix was verified against | Integration breakage triggers rollback to last verified version, patch, or documented incompatibility until upstream stabilizes |
+| **Deny-on-tie creates availability failures**: Common policies accidentally hit the tie-deny rule in production | 3 | 4 | Canary policy tests in P19; deny-on-tie test cases in P23 adversarial suite; clear error messages name the conflicting rule IDs; deny remains the integrity-safe default | Exploration blocker lets P11 drop dependent scope; later defects queue a policy patch with specificity adjustments |
+| **Trace export becomes treated as compliance storage**: Teams use OTel export instead of the evidence chain for audits | 2 | 4 | Architecture documentation is explicit: spans are projections, evidence chain is authoritative; `certificate.mint` span does not contain the full certificate; evidence hash in spans is for correlation only | Integration breakage blocks downstream until the misuse is corrected and the evidence chain is adopted |
+| **Scope exceeds 13 plays**: Implementation finds the 13 plays insufficient and scope creeps | 4 | 4 | G3 adapters, REST evidence API, dashboards, and fine-grained framework internals are the first cut; P23 and P24 are deferrable if substrate plays slip | Budget/time pressure forces a minimum viable cut: G1+substrate+flow is the irreducible core; G2 and layer objects are deferrable |
+
+---
+
+## Cross-References
+
+| Document | Path | Contents |
+|----------|------|----------|
+| DSL Style | [`docs/governance/standards/dsl-style.md`](standards/dsl-style.md) | Charter DSL syntax conventions, required blocks, formatting rules, two examples |
+| ADR Style | [`docs/governance/standards/adr-style.md`](standards/adr-style.md) | ADR structure, status values, revision conventions |
+| Test Style | [`docs/governance/standards/test-style.md`](standards/test-style.md) | Test fixture naming, marker lanes, coverage thresholds |
+| Trace Naming | [`docs/governance/standards/trace-naming.md`](standards/trace-naming.md) | Span name registry, required attributes, retention tiers |
+| Error Messages | [`docs/governance/standards/error-messages.md`](standards/error-messages.md) | Error message conventions for human and agent consumers |
+| Commit and PR Style | [`docs/governance/standards/commit-and-pr-style.md`](standards/commit-and-pr-style.md) | Commit message format, PR description structure |
+| Charter DSL v0 | [`docs/governance/charter-dsl-v0.md`](charter-dsl-v0.md) | Canonical Charter DSL v0 with three complete examples |
+
+---
+
+*This document is authoritative for P12-P24. Changes require a governance ADR revision or an explicit
+direction amendment with Ocean's approval.*

--- a/docs/governance/standards/adr-style.md
+++ b/docs/governance/standards/adr-style.md
@@ -152,7 +152,7 @@ ownership to ADR-0044 before any implementation begins.
 ## 9. Example A: Correct Header And Dependency Block
 
 ```markdown
-# ADR-0053: Charter DSL Compiler Targets
+# ADR-9001: Example — Compiler Targets For A New DSL Feature
 
 Status: proposed
 Date: 2026-05-27
@@ -164,14 +164,15 @@ Related: ADR-0048, ADR-0049, ADR-0050
 ```
 
 Why correct: dependencies name the owning ADRs for evidence, gates, charters, registry, and
-policy resolution — not generic prose.
+policy resolution — not generic prose. (ADR-9001 is a fictional example number; use the next
+available real number when writing an actual ADR.)
 
 ---
 
 ## 10. Example B: Resolving A Type Overlap
 
 ```markdown
-# ADR-0054: Gate Result Ownership Consolidation
+# ADR-9002: Example — Type Ownership Consolidation
 
 Status: accepted
 Date: 2026-06-03
@@ -188,3 +189,5 @@ projections in `OperationContext`, but must not define a second `GateResult` typ
 ```
 
 Why correct: resolves overlap by choosing a type owner instead of letting two ADRs drift.
+(ADR-9002 is a fictional example number; use the next available real number when writing an
+actual ADR.)

--- a/docs/governance/standards/adr-style.md
+++ b/docs/governance/standards/adr-style.md
@@ -1,0 +1,190 @@
+# Governance ADR Style Standard
+
+**Purpose**: File naming, required sections, status lifecycle, cross-reference format, and type
+ownership rules for governance ADRs (ADR-0041 and later).
+
+Cross-references: [dsl-style.md](dsl-style.md), [trace-naming.md](trace-naming.md),
+[commit-and-pr-style.md](commit-and-pr-style.md)
+
+---
+
+## 1. File And Title
+
+- File: `docs/adrs/ADR-NNNN-kebab-case-title.md`.
+- First line: `# ADR-NNNN: Human Title`.
+- Numbers are never reused.
+- Keep the title stable after acceptance unless a replacement ADR supersedes it.
+
+**Note**: ADR-0043 currently exists as `ADR-0043-governed-tool-declaration.md`. Use that file
+name in references unless the file is deliberately renamed in a revision PR.
+
+---
+
+## 2. Required Header
+
+Every governance ADR begins with:
+
+```markdown
+# ADR-00NN: Short Title
+
+Status: proposed
+Date: YYYY-MM-DD
+Decision owners: @owner-a, @owner-b
+Supersedes: none
+Superseded by: none
+Depends on: ADR-0041, ADR-0050
+Related: ADR-0044, ADR-0052
+```
+
+`Status` values: `proposed`, `accepted`, `revised`, `superseded`, `rejected`.
+
+---
+
+## 3. Required Sections (In Order)
+
+1. Context
+2. Decision
+3. Scope
+4. Non-Goals
+5. Interfaces And Types
+6. Runtime Semantics
+7. Evidence And Trace Requirements
+8. Test Requirements
+9. Consequences
+10. Migration
+11. Cross-References
+
+---
+
+## 4. Status Lifecycle
+
+```text
+proposed → accepted → revised → superseded
+proposed → rejected
+```
+
+- `proposed`: design under review; implementation may prototype behind flags only.
+- `accepted`: implementation must follow it.
+- `revised`: minor semantic change merged without replacing the decision identity.
+- `superseded`: a later ADR replaces this one for future implementation.
+- `rejected`: explicitly not adopted.
+
+Do not move `superseded` back to `accepted`. Write a new ADR if a decision returns in a
+materially different form.
+
+---
+
+## 5. Cross-Reference Format
+
+- First mention in prose: `ADR-0047 (Agent Charter)`.
+- Dependency list: `Depends on: ADR-0044, ADR-0051`.
+- Inline references: `See ADR-0050 OperationContext propagation`.
+- Avoid bare phrases like "the charter ADR" — the governance set has several charter-adjacent ADRs.
+- File paths: use repo-relative paths: `docs/adrs/ADR-0047-agent-charter.md`.
+- When overlaps exist, name the type owner explicitly. Example:
+  `GateResult is owned by ADR-0044; ADR-0050 embeds references to it.`
+
+**Good**:
+
+```markdown
+This module emits `GateResult` (ADR-0044) and stores a reference in `OperationContext`
+(ADR-0050). See docs/adrs/ADR-0044-tool-gates.md for the canonical type.
+```
+
+**Bad** — ambiguous reference:
+
+```markdown
+This follows the gate ADR for result types.
+```
+
+---
+
+## 6. When To Write A New ADR
+
+Write a new ADR when:
+
+- The public API shape changes.
+- A runtime invariant changes.
+- A previously accepted ADR becomes false.
+- A new persistence or retention guarantee is introduced.
+- A security boundary changes.
+- A governance primitive gains a new owner.
+
+---
+
+## 7. When To Revise An Existing ADR
+
+Revise (using `Status: revised`) when:
+
+- Clarifying terms without changing behavior.
+- Importing a canonical type owner instead of duplicating it.
+- Correcting a filename or section reference.
+- Adding test or trace requirements to match an already accepted decision.
+- Adding non-contradictory examples from DSL or P9 tracing standards.
+
+---
+
+## 8. Type Ownership Table
+
+Each governance type has exactly one ADR owner. Other ADRs may reference or import the type
+but must not redefine it.
+
+| Type | Owner ADR |
+|------|-----------|
+| `ImmutableEvidenceNode`, `EvidenceRef`, `EvidenceChain` | ADR-0041 |
+| `TaskCertificate`, `CertificateState`, `Defensibility` | ADR-0042 |
+| `GovernedToolMeta`, governed tool declaration fields | ADR-0043 |
+| `GateResult`, `GateEnforcement`, `ToolGate` | ADR-0044 |
+| `BreakGlassWindow`, `BreakGlassEvent` | ADR-0045 |
+| `PermitToken`, `JITGrant` | ADR-0046 |
+| `AgentCharter`, `CharterConstraint` | ADR-0047 |
+| `SoDPolicy`, `RoleAssignment` | ADR-0048 |
+| `LogTier` | ADR-0049 |
+| `OperationContext`, `ServiceContext` | ADR-0050 |
+| `ToolRegistryPolicy`, `RegistryEntry` | ADR-0051 |
+| `PolicyBundle`, `PolicyRelease`, `PolicyResolver` | ADR-0052 |
+
+**Critical**: ADR-0044 and ADR-0050 both currently sketch `GateResult`. P12 must consolidate
+ownership to ADR-0044 before any implementation begins.
+
+---
+
+## 9. Example A: Correct Header And Dependency Block
+
+```markdown
+# ADR-0053: Charter DSL Compiler Targets
+
+Status: proposed
+Date: 2026-05-27
+Decision owners: @governance-maintainers
+Supersedes: none
+Superseded by: none
+Depends on: ADR-0041, ADR-0044, ADR-0047, ADR-0051, ADR-0052
+Related: ADR-0048, ADR-0049, ADR-0050
+```
+
+Why correct: dependencies name the owning ADRs for evidence, gates, charters, registry, and
+policy resolution — not generic prose.
+
+---
+
+## 10. Example B: Resolving A Type Overlap
+
+```markdown
+# ADR-0054: Gate Result Ownership Consolidation
+
+Status: accepted
+Date: 2026-06-03
+Decision owners: @governance-maintainers
+Supersedes: none
+Superseded by: none
+Depends on: ADR-0044, ADR-0050
+Related: ADR-0043
+
+## Decision
+
+`GateResult` is owned by ADR-0044. ADR-0050 may store `gate_result_ids` and gate summary
+projections in `OperationContext`, but must not define a second `GateResult` type.
+```
+
+Why correct: resolves overlap by choosing a type owner instead of letting two ADRs drift.

--- a/docs/governance/standards/commit-and-pr-style.md
+++ b/docs/governance/standards/commit-and-pr-style.md
@@ -1,0 +1,214 @@
+# Governance Commit And PR Style Standard
+
+**Purpose**: Conventional commit format, PR title/body template, governance scopes, and review
+checklist rules for the lionagi governance implementation.
+
+Cross-references: [adr-style.md](adr-style.md), [test-style.md](test-style.md),
+[trace-naming.md](trace-naming.md), [error-messages.md](error-messages.md)
+
+---
+
+## 1. Conventional Commit Format
+
+```text
+type(scope): summary
+```
+
+**Allowed types**:
+
+```text
+feat  fix  docs  test  refactor  perf  build  ci  chore
+```
+
+**Required governance scopes**:
+
+```text
+gov  charter  policy  trace  adapter  evidence  gate  registry
+sod  certificate  break-glass  jit  adr  docs  tests
+```
+
+Use one primary scope per commit. If a change touches multiple governance domains, split commits
+unless the code path is inseparable.
+
+---
+
+## 2. Commit Summary Rules
+
+- Lowercase after the closing parenthesis, unless naming a type or acronym.
+- Imperative mood.
+- Maximum 72 characters.
+- No trailing period.
+- Mention ADR number in the body, not the summary, unless the commit is only an ADR change.
+
+**Good**:
+
+```text
+feat(gate): fail closed on registry evaluator exceptions
+test(charter): add invalid executable token fixtures
+docs(adr): revise ADR-0044 gate result ownership
+feat(evidence): add append-only audit pile with sha256 chain
+fix(policy): deny on tie when specificity is equal
+```
+
+**Bad**:
+
+```text
+feat: governance stuff
+fix(policy/registry/gates): lots of changes
+docs: update
+FEAT(GATE): Added gate stuff.
+```
+
+---
+
+## 3. PR Title Rules
+
+- Format: `[Pxx] type(scope): summary`.
+- Maximum 90 characters.
+- Scope must match the dominant commit scope.
+- Do not use marketing language.
+
+**Good**:
+
+```text
+[P12] docs(adr): reconcile gate result and operation context ownership
+[P16] feat(charter): compile DSL registry and gate targets
+[P17] feat(gate): implement execute_governed with fail-closed exceptions
+[P20] feat(trace): emit permit and certificate lifecycle spans
+```
+
+**Bad**:
+
+```text
+[P12] Revolutionary governance overhaul
+[P16] Charter stuff
+feat(charter): compile DSL (missing play tag)
+```
+
+---
+
+## 4. PR Body Template
+
+```markdown
+## Summary
+
+- What changed.
+- Which governance primitive or standard it implements.
+
+## ADRs And Standards
+
+- ADRs: ADR-0044, ADR-0050
+- Standards: docs/governance/standards/trace-naming.md
+
+## Runtime Behavior
+
+- New public APIs:
+- Changed invariants:
+- Backward compatibility:
+
+## Tests
+
+- [ ] Unit
+- [ ] Integration
+- [ ] Adversarial
+- [ ] Property
+- [ ] CLI
+- [ ] Trace/span validation
+
+Commands run:
+
+    uv run pytest tests/governance
+    uv run pytest tests/providers
+    uv run ruff check lionagi tests
+
+## Evidence And Trace
+
+- Evidence records emitted:
+- Required spans emitted:
+- Redaction considerations:
+
+## Risks
+
+- Known risks:
+- Recovery rule mapping:
+
+## Review Checklist
+
+- [ ] Matches accepted ADRs or includes ADR revision.
+- [ ] Public API has happy path and edge case tests.
+- [ ] Fail-closed paths are tested.
+- [ ] Evidence and trace records are linked by hash/id.
+- [ ] No raw bypass path is introduced.
+- [ ] Charter/registry/policy examples updated when behavior changes.
+```
+
+---
+
+## 5. Review Checklist Rules
+
+Every governance PR must answer:
+
+1. Which ADR owns this behavior?
+2. Which standard constrains naming, errors, tests, or traces?
+3. Does this expose a raw bypass path?
+4. Does it emit or update evidence?
+5. Does it project a span, and is the span sampled 100% if immutable?
+6. Does it preserve the zero-rewrite adapter posture?
+7. Did tests assert runtime state rather than generated prose?
+
+---
+
+## 6. Example A: Commit Set For DSL Parser
+
+```text
+docs(charter): add canonical DSL style standard
+feat(charter): parse v0 top-level blocks into typed AST
+test(charter): reject wildcard registry values and executable tokens
+```
+
+Why correct: docs, parser behavior, and tests are in separate commits; each scope stays focused;
+tests are written alongside the feature, not after.
+
+---
+
+## 7. Example B: PR Header And Body Summary
+
+```markdown
+# [P16] feat(charter): compile DSL registry and gate targets
+
+## Summary
+
+- Adds `Charter.compile()` producing registry entries, gate bindings, SoD rules, evidence
+  requirements, trace expectations, and activation evidence.
+- Activation fails closed when target resolution or hash checks fail.
+
+## ADRs And Standards
+
+- ADRs: ADR-0047, ADR-0051, ADR-0052
+- Standards: `dsl-style.md`, `trace-naming.md`, `test-style.md`
+
+## Runtime Behavior
+
+- New public APIs: `Charter.compile() -> CompiledCharter`
+- Changed invariants: charter activation now requires resolved gate registry before accepting requests
+- Backward compatibility: `AgentCharter` from ADR-0047 is now compiler output, not direct user input
+
+## Tests
+
+- [x] Unit
+- [x] Integration
+- [ ] Adversarial (scheduled for P23)
+- [x] Property
+- [ ] CLI (included in P14 CLI pass)
+- [x] Trace/span validation
+
+Commands run:
+
+    uv run pytest tests/governance/test_charter_compile.py -v
+    uv run pytest tests/governance/ --co -q
+    uv run ruff check lionagi/protocols/governance/
+    uv run mypy lionagi/protocols/governance/compiler.py
+```
+
+Why correct: the title is short and scoped, the ADR/standard ownership is explicit, and the
+test checklist shows what is done vs. deferred with a clear reason.

--- a/docs/governance/standards/dsl-style.md
+++ b/docs/governance/standards/dsl-style.md
@@ -1,0 +1,242 @@
+# Charter DSL Style Standard
+
+**Purpose**: Canonical syntax conventions for authoring Charter DSL v0 documents. Any charter
+file that passes `li charter validate` must conform to these rules.
+
+Cross-references: [adr-style.md](adr-style.md), [trace-naming.md](trace-naming.md),
+[../charter-dsl-v0.md](../charter-dsl-v0.md)
+
+---
+
+## 1. Document Structure
+
+A v0 charter has exactly these top-level keys, in this order:
+
+```text
+charter_dsl  kind  metadata  agents  registry  constraints  sod  permissions  [break_glass]  trace
+```
+
+`break_glass` is optional. All other blocks are required even when empty (e.g., `sod.rules: []`).
+
+**Good**:
+
+```yaml
+charter_dsl: "0.1"
+kind: agent_charter
+metadata: { ... }
+agents: [ ... ]
+registry: { ... }
+constraints: [ ... ]
+sod: { active: true, rules: [] }
+permissions: { ... }
+trace: { ... }
+```
+
+**Bad** — missing block, wrong order:
+
+```yaml
+charter_dsl: "0.1"
+kind: agent_charter
+agents: [ ... ]
+metadata: { ... }
+# sod missing — invalid
+```
+
+---
+
+## 2. Key Naming
+
+- YAML keys use `lower_snake_case` only.
+- Identifier values use dot-separated lower-snake segments: `agent.reader`, `role.reviewer`,
+  `gate.registry.exact_tool`, `allow.reader.read_files`.
+- Rule IDs carry action prefixes: `allow.*`, `deny.*`, `gate.*`, `sod.*`, `trace.*`.
+- Enforcement values are lowercase in source: `hard`, `soft`, `advisory`. Span output maps to
+  uppercase (`HARD`, `SOFT`, `ADVISORY`) — see [trace-naming.md](trace-naming.md).
+- Registry categories are exactly: `tool`, `model`, `mcp_endpoint`, `url`, `path_prefix`.
+- `path_prefix` values must begin and end with `/`.
+- Tool names are exact canonical identifiers. Wildcards (`*`, `?`) are invalid in v0.
+
+**Good**:
+
+```yaml
+- category: path_prefix
+  value: /workspace/reports/
+  scope: agent
+  scope_id: agent.analyst
+```
+
+**Bad** — wildcard, wrong category name, wrong casing:
+
+```yaml
+- category: PATH_PREFIX
+  value: /workspace/*
+  scope: agent
+  scope_id: agent.analyst
+```
+
+---
+
+## 3. Indentation And Formatting
+
+- Two spaces per indentation level. Tabs are invalid.
+- Sequence items align under their key.
+- Top-level blocks follow canonical order.
+- One logical object per list item.
+- Prefer block lists over inline maps when an entry has more than two fields.
+- Line length target is 100 characters for prose fields; do not wrap IDs or hashes.
+- Strings containing `:`, `#`, `{`, `}`, `[`, or `]` must be quoted.
+- Use ISO 8601 UTC for fixed timestamps: `"2026-05-27T00:00:00Z"`.
+- Durations use compact strings: `15m`, `30m`, `1h`.
+
+**Good**:
+
+```yaml
+constraints:
+  - constraint_id: gate.registry.exact_tool
+    description: "Every tool call must match the ratified registry snapshot."
+    gate_id: verify_in_registry
+    manager_surface: ActionManager
+    enforcement: hard
+    attach:
+      level: action
+      action: tool_call
+      tools: [tool.read_file]
+    evidence:
+      required: [GateResult, ToolCallEvidence]
+```
+
+**Bad** — tabs, inline map with many fields:
+
+```yaml
+constraints:
+ - {constraint_id: gate.x, gate_id: y, enforcement: hard, attach: {level: action, action: tool_call}}
+```
+
+---
+
+## 4. Comments
+
+- Use YAML `#` comments above blocks or list items, not inside scalar values.
+- Comments are not semantic. The compiler ignores them and excludes them from the ratification hash.
+- A comment must explain review intent or a non-obvious constraint. Do not restate the field name.
+
+**Good**:
+
+```yaml
+# Reviewer must never approve code they authored in the same task.
+- rule_id: sod.implementer_reviewer.independent
+  conflict_type: audit_independence
+  roles: [implementer, reviewer]
+  scope: task
+```
+
+**Bad** — restates the field:
+
+```yaml
+# rule_id for SoD rule
+- rule_id: sod.implementer_reviewer.independent
+```
+
+---
+
+## 5. Required Metadata Fields
+
+`metadata` requires all of: `charter_id`, `version`, `status`, `policy_release`, `authored_by`,
+`implemented_by`, `ratification`.
+
+- `status`: `draft` | `proposed` | `accepted` | `superseded`.
+- `authored_by` and `implemented_by` must identify different actors unless status is `draft`.
+- `ratification.hash` is required for accepted charters; omit or set `null` for drafts.
+- Hash format: `sha256:<64-hex-chars>`.
+
+**Good**:
+
+```yaml
+metadata:
+  charter_id: charter.reader.basic
+  version: "1.0.0"
+  status: accepted
+  policy_release: policy.gov.v1
+  authored_by: human:governance
+  implemented_by: agent:implementer
+  ratification:
+    hash: sha256:1d6fabcd000000000000000000000000000000000000000000000000000000001
+    signed_at: "2026-05-27T00:00:00Z"
+```
+
+**Bad** — same actor for both roles, missing ratification hash on accepted charter:
+
+```yaml
+metadata:
+  charter_id: charter.reader.basic
+  version: "1.0.0"
+  status: accepted
+  authored_by: agent:implementer
+  implemented_by: agent:implementer
+  ratification: null
+```
+
+---
+
+## 6. Constraints Binding Rule
+
+Each constraint must contain **exactly one** of `gate_id` or `hook_name`.
+
+- Both present → invalid.
+- Neither present → invalid.
+- `hook_name` requires a companion `hook_phase` field.
+- `attach.level: class` requires `tool_class`.
+- `attach.level: action` requires `action`; `tools` is optional for scoping.
+
+**Good**:
+
+```yaml
+- constraint_id: gate.sod.review_independence
+  gate_id: assert_sod_independence
+  manager_surface: ActionManager
+  enforcement: hard
+  attach:
+    level: action
+    action: certificate_mint
+  evidence:
+    required: [SoDCheckEvidence, GateResult]
+```
+
+**Bad** — both bindings present:
+
+```yaml
+- constraint_id: gate.x
+  gate_id: verify_in_registry
+  hook_name: pre_tool_call
+  enforcement: hard
+  attach:
+    level: action
+    action: tool_call
+```
+
+---
+
+## 7. Permissions Default-Deny
+
+`permissions.default` must be `deny`. Resolution must be:
+
+```yaml
+resolution:
+  specificity_order: [resource, role, tenant, global]
+  tie: deny
+```
+
+Allow rules that permit tool execution must include `requires_evidence`. Deny rules must include
+a specific `because`; vague text such as "not allowed" is invalid.
+
+---
+
+## 8. Cross-References
+
+- Span names in `trace.require_spans` must match the canonical registry in
+  [trace-naming.md](trace-naming.md).
+- Error codes emitted by the compiler and runtime follow [error-messages.md](error-messages.md).
+- ADR governance for type ownership of `GateResult`, `AgentCharter`, etc. is described in
+  [adr-style.md](adr-style.md).
+- Full grammar, validation rules, and runtime integration are in
+  [../charter-dsl-v0.md](../charter-dsl-v0.md).

--- a/docs/governance/standards/error-messages.md
+++ b/docs/governance/standards/error-messages.md
@@ -1,0 +1,223 @@
+# Governance Error Message Standard
+
+**Purpose**: Error code taxonomy, dual human-readable and machine-routable format, context
+inclusion rules, and severity mapping for all governance failures.
+
+Cross-references: [trace-naming.md](trace-naming.md), [test-style.md](test-style.md),
+[dsl-style.md](dsl-style.md)
+
+---
+
+## 1. Error Code Taxonomy
+
+All governance errors use the `GOV-XXXX` prefix.
+
+| Range | Owner |
+|-------|-------|
+| `GOV-0XXX` | General governance runtime errors |
+| `GOV-1XXX` | Charter DSL parse, schema, validation, and activation |
+| `GOV-2XXX` | Tool registry, governed tool declaration, gates, and raw bypass |
+| `GOV-3XXX` | Evidence, log tiers, certificates, and trace projection |
+| `GOV-4XXX` | Policy resolution, SoD, JIT permits, and break-glass |
+| `GOV-5XXX` | Branch, Session, CLI orchestration, and provider adapters |
+| `GOV-9XXX` | Internal consistency errors and invariant violations |
+
+### Defined Codes
+
+| Code | Meaning |
+|------|---------|
+| `GOV-1100` | Parse error |
+| `GOV-1101` | Missing required block |
+| `GOV-1102` | Invalid enum value |
+| `GOV-1103` | Invalid constraint binding |
+| `GOV-1104` | Executable content rejected |
+| `GOV-2100` | Raw tool call blocked |
+| `GOV-2101` | Registry lookup denied |
+| `GOV-2200` | Gate evaluation failed closed |
+| `GOV-2201` | Soft gate justification missing |
+| `GOV-3100` | Evidence hash mismatch |
+| `GOV-3200` | Immutable deletion blocked |
+| `GOV-3300` | Certificate mint refused |
+| `GOV-4100` | Policy no match |
+| `GOV-4101` | Policy tie denied |
+| `GOV-4200` | SoD conflict |
+| `GOV-4300` | Permit missing, expired, or consumed |
+| `GOV-4400` | Break-glass attestation invalid |
+| `GOV-5100` | Flow charter validation failed |
+| `GOV-5200` | Adapter boundary governance incomplete |
+
+---
+
+## 2. Structured Error Object
+
+Every governance error has this shape:
+
+```json
+{
+  "code": "GOV-2101",
+  "severity": "ERROR",
+  "message": "Human-readable message.",
+  "agent_message": "machine_routable_short_token",
+  "remediation": "Concrete next action.",
+  "retryable": false,
+  "redaction": "safe",
+  "context": {
+    "session_id": "sess_01",
+    "operation_id": "op_42",
+    "actor_id": "agent:reader",
+    "actor_role": "reader",
+    "charter_id": "charter.reader.basic",
+    "policy_version": "policy.gov.v1",
+    "trace_id": "trace_abc",
+    "span_id": "span_def",
+    "evidence_hash": "sha256:9ac1"
+  },
+  "details": {},
+  "cause": null
+}
+```
+
+---
+
+## 3. Human-Readable Message Rules
+
+- State what failed, which object was involved, and what to do next.
+- Include exact IDs and hashes when safe to expose.
+- Use present tense, active voice.
+- Do not include: secrets, full prompts, credentials, raw model outputs, unredacted file contents.
+- Do not use blame language. Messages diagnose state, not intent.
+
+**Good**:
+
+```text
+GOV-2101 ERROR: Tool `tool.write_file` is not allowed for role `reader` under charter
+`charter.reader.basic`. Use an allowed read-only tool or revise the charter registry and
+policy release before retrying.
+```
+
+**Bad** — vague, no actionable ID, assigns blame:
+
+```text
+ERROR: You tried to use a tool you're not allowed to use. Please fix this.
+```
+
+---
+
+## 4. Agent-Readable Message Rules
+
+- `agent_message`: stable short token, no spaces: `registry_denied_tool`, `policy_tie_denied`,
+  `evidence_hash_mismatch`.
+- Include `retryable` and `severity`.
+- Include enough context for safe routing; never expose hidden policy text or secrets.
+- If the agent can fix the issue, `remediation` must be executable and bounded.
+- If the agent must stop, set `retryable: false` and point to human approval or charter revision.
+
+---
+
+## 5. Context Inclusion Rules
+
+**Include when available**:
+
+```text
+session_id  operation_id  flow_id  actor_id  actor_role
+charter_id  policy_version  gate_id  tool_name
+permit_id  certificate_id  trace_id  span_id  evidence_hash
+```
+
+**Exclude by default**:
+
+```text
+raw_prompts  api_keys  secrets  full_file_bodies
+full_stack_traces (in user-facing payload)  personal_data
+```
+
+Stack traces may be stored in protected diagnostics. User-facing error payloads carry only
+sanitized `cause.type` and `cause.message`.
+
+---
+
+## 6. Severity Mapping
+
+| Severity | When |
+|----------|------|
+| `INFO` | Successful validation with warnings already recorded elsewhere |
+| `WARN` | Advisory failure, soft gate warning, non-blocking export failure |
+| `ERROR` | Blocked operation, parse failure, validation failure, denied policy, failed hard gate |
+| `CRITICAL` | Evidence tamper, certificate replay, break-glass activation failure, raw bypass under governed mode |
+
+---
+
+## 7. Example A: Registry Denial
+
+Human message:
+
+```text
+GOV-2101 ERROR: Tool `tool.write_file` is not allowed for role `reader` under charter
+`charter.reader.basic`. Use an allowed read-only tool or revise the charter registry and
+policy release before retrying.
+```
+
+Agent payload:
+
+```json
+{
+  "code": "GOV-2101",
+  "severity": "ERROR",
+  "message": "Tool `tool.write_file` is not allowed for role `reader` under charter `charter.reader.basic`.",
+  "agent_message": "registry_denied_tool",
+  "remediation": "Select an allowed tool or request a charter registry revision.",
+  "retryable": false,
+  "redaction": "safe",
+  "context": {
+    "session_id": "sess_01",
+    "operation_id": "op_42",
+    "actor_role": "reader",
+    "charter_id": "charter.reader.basic",
+    "policy_version": "policy.gov.v1",
+    "gate_id": "verify_in_registry",
+    "tool_name": "tool.write_file",
+    "evidence_hash": "sha256:9ac1000000000000000000000000000000000000000000000000000000000001"
+  },
+  "details": {
+    "registry_lookup_source": "ratification_time"
+  },
+  "cause": null
+}
+```
+
+---
+
+## 8. Example B: Soft Gate Missing Justification
+
+Human message:
+
+```text
+GOV-2201 ERROR: Soft gate `notify_incident_channel` cannot be overridden without
+`justification` and `justification_actor_id`. Add both fields or retry after the
+notification succeeds.
+```
+
+Agent payload:
+
+```json
+{
+  "code": "GOV-2201",
+  "severity": "ERROR",
+  "message": "Soft gate `notify_incident_channel` cannot be overridden without justification fields.",
+  "agent_message": "soft_gate_justification_missing",
+  "remediation": "Provide justification and justification_actor_id, or rerun after notification succeeds.",
+  "retryable": true,
+  "redaction": "safe",
+  "context": {
+    "session_id": "sess_02",
+    "operation_id": "op_77",
+    "gate_id": "notify_incident_channel",
+    "charter_id": "charter.prod.support",
+    "policy_version": "policy.gov.v1"
+  },
+  "details": {
+    "missing_fields": ["justification", "justification_actor_id"]
+  },
+  "cause": null
+}
+```

--- a/docs/governance/standards/test-style.md
+++ b/docs/governance/standards/test-style.md
@@ -1,0 +1,242 @@
+# Governance Test Style Standard
+
+**Purpose**: Test fixture naming, category markers, directory layout, coverage thresholds, and
+assertion patterns for the `tests/governance/` suite.
+
+Cross-references: [dsl-style.md](dsl-style.md), [trace-naming.md](trace-naming.md),
+[error-messages.md](error-messages.md), [commit-and-pr-style.md](commit-and-pr-style.md)
+
+---
+
+## 1. Fixture Naming
+
+Names follow `{module}_{scenario}_{variant}`. Use concrete nouns for modules and active verbs
+for scenarios. Avoid names like `fixture1`, `happy_path`, or `bad_case`.
+
+**Good**:
+
+```text
+gate_registry_denies_unknown_tool
+evidence_chain_rejects_reordered_nodes
+certificate_mint_blocks_failed_hard_gate
+charter_parser_rejects_executable_token
+sod_matrix_blocks_reviewer_author
+trace_gate_evaluate_records_soft_justification
+policy_resolver_tie_denies_access
+break_glass_window_expires_after_30m
+```
+
+**Bad**:
+
+```text
+test1
+happy_path_charter
+gate_bad_case
+```
+
+---
+
+## 2. Categories And Markers
+
+| Category | Markers | Scope |
+|----------|---------|-------|
+| Unit | `governance` | Pure model, parser, validator, or gate behavior |
+| Integration | `governance` | Branch, Session, ActionManager, DataLogger, CLI, or adapter boundary |
+| Adversarial | `governance`, `adversarial` | Bypass, forgery, spoofing, replay, policy confusion, time manipulation |
+| Property | `governance`, `property` or `fuzz` | Generated inputs for evidence chains, SoD matrices, policy tie-deny |
+| Live provider | `governance`, `live_llm` | SDK or model behavior — opt-in, never blocks the main PR lane |
+| Mutation | `governance`, `mutation` | Fail-closed and tamper checks |
+
+Recommended marker set for `pyproject.toml`:
+
+```toml
+markers = [
+    "governance: all governance tests",
+    "adversarial: bypass and forgery tests",
+    "live_llm: requires real credentials",
+    "mutation: tamper and fail-closed tests",
+    "fuzz: property and generative tests",
+    "property: property-based tests",
+]
+```
+
+---
+
+## 3. Directory Structure
+
+```text
+tests/
+  governance/
+    conftest.py
+    test_evidence_chain.py
+    test_operation_context.py
+    test_gate_runtime.py
+    test_charter_parser.py
+    test_policy_resolution.py
+    test_registry_allowlist.py
+    test_sod.py
+    test_break_glass.py
+    test_certificates.py
+    test_trace_spans.py
+    adversarial/
+      test_gate_bypass.py
+      test_evidence_forgery.py
+      test_certificate_replay.py
+      test_tool_shadowing.py
+      test_charter_injection.py
+    fixtures/
+      charters/
+      evidence/
+      registry/
+      traces/
+  providers/
+    test_pydantic_ai_governed_endpoint.py
+    test_openai_agents_governed_endpoint.py
+    test_anthropic_agents_governed_endpoint.py
+    test_langgraph_governed_endpoint.py
+    test_llamaindex_governed_endpoint.py
+    test_crewai_governed_endpoint.py
+```
+
+---
+
+## 4. Coverage Thresholds
+
+- New public governance APIs require happy path, edge case, and failure-path tests before merge.
+- Governance core modules: ≥90% line coverage, ≥85% branch coverage.
+- Gate, evidence, certificate, policy, registry, and parser modules each require at least one
+  adversarial test for the primary bypass class.
+- Every fail-closed rule must have a test where the evaluator raises or input is malformed.
+- Every DSL grammar addition: ≥1 valid fixture + ≥2 invalid fixtures.
+- Every span type added to the trace taxonomy: ≥1 emission test + ≥1 attribute validation test.
+- Property tests are required for: evidence chain ordering, policy tie-deny, registry exact
+  matching, and SoD conflict symmetry.
+- Live provider tests must not block the normal PR lane unless credentials and deterministic
+  sandbox settings are present.
+
+---
+
+## 5. Assertion Patterns
+
+Assert runtime state, evidence records, hashes, and spans. Do not assert model prose except for
+exact parser errors or human-facing error messages.
+
+Required assertions per category:
+
+**Evidence**:
+
+- Immutable evidence cannot be mutated or deleted through public APIs.
+- Protected deletion emits an immutable deletion evidence record.
+- Hash field starts with `sha256:`.
+
+**Gates**:
+
+- Hard gate exceptions deny the call; `result.verdict == "FAIL"` and `result.enforcement == "HARD"`.
+- Soft gate override requires both `justification` and `justification_actor_id`.
+- Advisory gate failures produce warning evidence but do not block execution.
+
+**Adapters**:
+
+- Raw tool execution outside governed mode raises or returns an explicit error.
+- Coarse adapters do not claim internal framework tool calls were governed unless fine-grain
+  wrapping is active.
+
+**Errors**:
+
+- Assert both `message` (human-readable) and `agent_message` (machine-routable) fields — see
+  [error-messages.md](error-messages.md).
+- Assert `code` matches the GOV-XXXX taxonomy.
+
+---
+
+## 6. Example A: Unit Test With Runtime Assertions
+
+```python
+import pytest
+
+
+@pytest.mark.governance
+def test_gate_registry_denies_unknown_tool(gate_evaluator, operation_context):
+    result = gate_evaluator.evaluate(
+        tool_name="tool.write_file",
+        actor_role="reader",
+        operation_context=operation_context,
+    )
+
+    assert result.verdict == "FAIL"
+    assert result.enforcement == "HARD"
+    assert result.reason_code == "GOV-2101"
+    assert result.evidence_hash.startswith("sha256:")
+```
+
+---
+
+## 7. Example B: Property Test For Evidence Chain Tamper Resistance
+
+```python
+import pytest
+from hypothesis import given, strategies as st
+
+
+@pytest.mark.governance
+@pytest.mark.property
+@given(
+    st.lists(
+        st.dictionaries(st.text(min_size=1), st.text()),
+        min_size=1,
+        max_size=20,
+    )
+)
+def test_evidence_chain_rejects_reordered_nodes(evidence_chain_factory, payloads):
+    chain = evidence_chain_factory(payloads)
+    reordered = list(reversed(chain))
+
+    assert evidence_chain_factory.verify(chain).ok is True
+    assert evidence_chain_factory.verify(reordered).ok is False
+```
+
+---
+
+## 8. Example C: Adversarial Parser Test
+
+```python
+import pytest
+
+
+@pytest.mark.governance
+@pytest.mark.adversarial
+@pytest.mark.parametrize(
+    "token", ["__import__", "eval(", "exec(", "lambda ", "subprocess"]
+)
+def test_charter_parser_rejects_executable_token(charter_loader, token):
+    source = f"""
+charter_dsl: "0.1"
+kind: agent_charter
+metadata:
+  charter_id: charter.bad
+  version: "1.0.0"
+  status: draft
+  policy_release: policy.gov.v1
+  authored_by: human:tester
+  implemented_by: agent:tester
+  ratification: null
+agents: []
+registry: {{snapshot: ratification_time, entries: []}}
+constraints:
+  - constraint_id: gate.bad
+    description: "{token}"
+sod: {{active: true, rules: []}}
+permissions:
+  default: deny
+  resolution:
+    specificity_order: [resource, role, tenant, global]
+    tie: deny
+  allow: []
+  deny: []
+trace: {{stamp: [], require_spans: [], require_evidence: []}}
+"""
+    with pytest.raises(CharterParseError) as exc:
+        charter_loader(source)
+
+    assert exc.value.code == "GOV-1104"
+```

--- a/docs/governance/standards/test-style.md
+++ b/docs/governance/standards/test-style.md
@@ -131,7 +131,7 @@ Required assertions per category:
 
 **Gates**:
 
-- Hard gate exceptions deny the call; `result.verdict == "FAIL"` and `result.enforcement == "HARD"`.
+- Hard gate exceptions deny the call; `result.verdict == "DENY"` and `result.enforcement == "HARD"`.
 - Soft gate override requires both `justification` and `justification_actor_id`.
 - Advisory gate failures produce warning evidence but do not block execution.
 
@@ -163,7 +163,7 @@ def test_gate_registry_denies_unknown_tool(gate_evaluator, operation_context):
         operation_context=operation_context,
     )
 
-    assert result.verdict == "FAIL"
+    assert result.verdict == "DENY"
     assert result.enforcement == "HARD"
     assert result.reason_code == "GOV-2101"
     assert result.evidence_hash.startswith("sha256:")

--- a/docs/governance/standards/trace-naming.md
+++ b/docs/governance/standards/trace-naming.md
@@ -95,7 +95,7 @@ Spans are telemetry projections. Authoritative records live in typed evidence an
 
 - Attribute keys: dot-separated lower-case.
 - Retention tiers: uppercase `MUTABLE`, `PROTECTED`, `IMMUTABLE`.
-- Gate verdict enums (`gate.verdict`): uppercase `ALLOW`, `DENY`, `SKIP` (ADR-0044 canonical values).
+- Gate verdict enums (`gate.verdict`): uppercase `ALLOW`, `DENY`, `ADVISORY` (ADR-0044 canonical values).
 - Gate enforcement in spans: uppercase `HARD`, `SOFT`, `ADVISORY`.
 - DSL enforcement values are lowercase (`hard`, `soft`, `advisory`) — map to uppercase in spans.
 - Booleans: native boolean.

--- a/docs/governance/standards/trace-naming.md
+++ b/docs/governance/standards/trace-naming.md
@@ -1,0 +1,189 @@
+# Governance Trace Naming Standard
+
+**Purpose**: Canonical span names, attribute keys, retention tiers, severity levels, and
+sampling policy for governance OTel projections. Spans are projections over typed evidence
+records — the authoritative audit record is always the typed evidence, not the span.
+
+Cross-references: [dsl-style.md](dsl-style.md), [error-messages.md](error-messages.md),
+[test-style.md](test-style.md)
+
+---
+
+## 1. Span Naming Pattern
+
+```text
+{domain}.{operation}[.{detail}]
+```
+
+- `domain`: lower-case governance subsystem.
+- `operation`: lower-case verb or lifecycle noun.
+- `detail`: optional qualifier for lifecycle events.
+- Existing two-part names are canonical when unambiguous: `gate.evaluate`, `evidence.emit`,
+  `policy.resolve`.
+
+Allowed domains in v0:
+
+```text
+governance  gate  breakglass  evidence  certificate  charter  sod  registry  policy  permit
+```
+
+---
+
+## 2. Common Required Attributes
+
+Attach to every governance span where the value is known:
+
+| Attribute | Type | Requirement |
+|-----------|------|-------------|
+| `governance.schema.version` | string | Required on every governance span |
+| `governance.retention.tier` | enum | Required on every governance span |
+| `governance.session.id` | string | Required on every governance span |
+| `governance.operation.id` | string | Required except session root |
+| `governance.flow.id` | string | Required for flow spans, optional otherwise |
+| `governance.actor.id` | string | Required when actor is known |
+| `governance.actor.role` | string | Required when role affects governance |
+| `governance.policy.version` | string | Required for governed operations |
+| `governance.charter.id` | string | Required when charter is active |
+| `governance.evidence.hash` | string | Required when span projects a durable evidence record |
+
+---
+
+## 3. Retention Tiers
+
+| Tier | Description | Sample Rate |
+|------|-------------|-------------|
+| `MUTABLE` | Debug-only operational spans; not valid for required governance evidence | May be sampled |
+| `PROTECTED` | Session and flow lifecycle summaries | 100% for governed sessions |
+| `IMMUTABLE` | Gate decisions, evidence, certificates, break-glass, permits, charter events, SoD checks, registry decisions, policy resolutions | 100% always |
+
+Spans are telemetry projections. Authoritative records live in typed evidence and tier-aware logs.
+
+---
+
+## 4. Span Registry
+
+| Span | Tier | Required Event-Specific Attributes |
+|------|------|-------------------------------------|
+| `governance.session` | PROTECTED | `governance.session.name`, `governance.session.team`, `governance.session.branch.count` |
+| `governance.operation` | IMMUTABLE | `governance.operation.name`, `governance.operation.parent.id`, `governance.evidence.hash` |
+| `governance.flow` | PROTECTED | `governance.flow.name`, `governance.flow.plan.hash`, `governance.flow.node.count` |
+| `gate.evaluate` | IMMUTABLE | `gate.id`, `gate.tool.name`, `gate.verdict`, `gate.enforcement`, `gate.policy.version`, `gate.charter.id`, `gate.evidence.hash`, `gate.reason` |
+| `gate.justify` | IMMUTABLE | `gate.id`, `gate.verdict`, `gate.enforcement`, `gate.justification`, `gate.justification.actor.id`, `gate.evidence.hash` |
+| `gate.bypass` | IMMUTABLE | `gate.id`, `gate.tool.name`, `gate.bypass.reason`, `gate.bypass.authority`, `gate.bypass.expiry`, `gate.bypass.window.id`, `gate.evidence.hash` |
+| `breakglass.open` | IMMUTABLE | `breakglass.window.id`, `breakglass.activated.at`, `breakglass.requested.by`, `breakglass.approved.by`, `breakglass.reason`, `breakglass.max.duration`, `breakglass.evidence.hash` |
+| `breakglass.expire` | IMMUTABLE | `breakglass.window.id`, `breakglass.activated.at`, `breakglass.expired.at`, `breakglass.authority`, `breakglass.tools.used.count`, `breakglass.expiry.reason` |
+| `breakglass.close` | IMMUTABLE | `breakglass.window.id`, `breakglass.closed.at`, `breakglass.close.reason`, `breakglass.tool.call.count`, `breakglass.certificate.id` |
+| `breakglass.notify` | IMMUTABLE | `breakglass.window.id`, `breakglass.notification.target`, `breakglass.notification.kind`, `breakglass.notification.result` |
+| `evidence.emit` | IMMUTABLE or PROTECTED | `evidence.id`, `evidence.chain.hash`, `evidence.previous.hash`, `evidence.tier`, `evidence.kind`, `evidence.payload.hash` |
+| `evidence.verify` | IMMUTABLE or PROTECTED | `evidence.chain.hash`, `evidence.chain.length`, `evidence.verification.result`, `evidence.failure.reason` |
+| `certificate.state` | IMMUTABLE | `certificate.id`, `certificate.task.id`, `certificate.previous.state`, `certificate.state`, `certificate.defensibility`, `certificate.evidence.chain.hash` |
+| `certificate.mint` | IMMUTABLE | `certificate.id`, `certificate.task.id`, `certificate.gates.passed`, `certificate.gates.failed`, `certificate.grade`, `certificate.defensibility`, `certificate.evidence.chain.hash`, `certificate.break.glass` |
+| `certificate.verify` | IMMUTABLE when trust-affecting | `certificate.id`, `certificate.verification.result`, `certificate.superseded.by`, `certificate.evidence.chain.hash` |
+| `permit.issue` | IMMUTABLE | `permit.id`, `permit.scope`, `permit.tool.name`, `permit.issuer.id`, `permit.subject.id`, `permit.expires.at`, `permit.evidence.hash` |
+| `permit.consume` | IMMUTABLE | `permit.id`, `permit.tool.name`, `permit.subject.id`, `permit.consumed.at`, `permit.consume.result`, `permit.evidence.hash` |
+| `permit.revoke` | IMMUTABLE | `permit.id`, `permit.revoked.by`, `permit.revoked.at`, `permit.revoke.reason`, `permit.evidence.hash` |
+| `charter.load` | IMMUTABLE when activating | `charter.id`, `charter.version`, `charter.source.uri`, `charter.source.hash`, `charter.rule.count`, `charter.load.result` |
+| `charter.evaluate` | IMMUTABLE | `charter.id`, `charter.version`, `charter.constraint.id`, `charter.verdict`, `charter.severity`, `charter.evidence.hash` |
+| `charter.violation` | IMMUTABLE | `charter.id`, `charter.version`, `charter.constraint.id`, `charter.violation.severity`, `charter.violation.reason`, `charter.evidence.hash` |
+| `sod.check` | IMMUTABLE | `sod.role`, `sod.capability`, `sod.verdict`, `sod.policy.version`, `sod.evidence.hash` |
+| `registry.lookup` | IMMUTABLE | `registry.tool.name`, `registry.role`, `registry.allowed`, `registry.policy.version`, `registry.lookup.source`, `registry.evidence.hash` |
+| `policy.resolve` | IMMUTABLE | `policy.count`, `policy.strategy`, `policy.winner`, `policy.version`, `policy.conflict.count`, `policy.evidence.hash` |
+
+---
+
+## 5. Value Conventions
+
+- Attribute keys: dot-separated lower-case.
+- Retention tiers: uppercase `MUTABLE`, `PROTECTED`, `IMMUTABLE`.
+- Verdict enums: uppercase `PASS`, `FAIL`, `SKIP`, `PARTIAL`, `UNKNOWN`, `SUPERSEDED`.
+- Gate enforcement in spans: uppercase `HARD`, `SOFT`, `ADVISORY`.
+- DSL enforcement values are lowercase (`hard`, `soft`, `advisory`) — map to uppercase in spans.
+- Booleans: native boolean.
+- Hashes: `sha256:<64-hex-chars>`.
+- IDs: stable strings for the duration of the operation.
+- Paths and prompts: excluded unless explicitly redacted and approved by evidence policy.
+- `trace_id` and `span_id`: stored in evidence records as correlation fields.
+- Evidence hashes: stored in span attributes as correlation pointers to authoritative records.
+
+---
+
+## 6. Severity
+
+Use `governance.severity` when a generic severity field is needed:
+
+| Value | When |
+|-------|------|
+| `INFO` | Expected lifecycle event or pass |
+| `WARN` | Advisory failure, soft override, partial verification, or non-blocking policy issue |
+| `ERROR` | Hard denial, parser failure, invalid charter, evidence/certificate verification failure |
+| `CRITICAL` | Break-glass activation, evidence tamper signal, certificate replay, or policy conflict that blocks a regulated run |
+
+For charter-specific spans, use `charter.severity` with values `INFO`, `WARN`, `BLOCK`.
+
+---
+
+## 7. Sampling Policy
+
+- Sample 100% of `IMMUTABLE` spans.
+- Sample 100% of `PROTECTED` session and flow lifecycle spans for governed sessions.
+- `MUTABLE` debug spans may be sampled at lower rates, but sampling must never drop the
+  authoritative governance record.
+- When telemetry export is backpressured, write local evidence first and mark export failure
+  with protected operational evidence.
+- Never sample away: failures, break-glass events, permit events, certificate transitions, or
+  policy conflicts.
+
+---
+
+## 8. Example A: Hard Gate Denial Span
+
+```json
+{
+  "name": "gate.evaluate",
+  "parent": "governance.operation",
+  "attributes": {
+    "governance.schema.version": "2026-05-27.v1",
+    "governance.retention.tier": "IMMUTABLE",
+    "governance.session.id": "sess_01",
+    "governance.operation.id": "op_42",
+    "governance.actor.id": "agent:reader",
+    "governance.actor.role": "reader",
+    "governance.policy.version": "policy.gov.v1",
+    "governance.charter.id": "charter.reader.basic",
+    "gate.id": "verify_in_registry",
+    "gate.tool.name": "tool.write_file",
+    "gate.verdict": "FAIL",
+    "gate.enforcement": "HARD",
+    "gate.reason": "Tool is not in the ratified registry snapshot.",
+    "gate.evidence.hash": "sha256:9ac1000000000000000000000000000000000000000000000000000000000001",
+    "governance.severity": "ERROR"
+  }
+}
+```
+
+---
+
+## 9. Example B: Break-Glass Open Span
+
+```json
+{
+  "name": "breakglass.open",
+  "parent": "governance.session",
+  "attributes": {
+    "governance.schema.version": "2026-05-27.v1",
+    "governance.retention.tier": "IMMUTABLE",
+    "governance.session.id": "sess_02",
+    "governance.operation.id": "op_77",
+    "governance.policy.version": "policy.gov.v1",
+    "governance.charter.id": "charter.prod.support",
+    "breakglass.window.id": "bg_20260527_001",
+    "breakglass.activated.at": "2026-05-27T00:12:00Z",
+    "breakglass.requested.by": "agent:prod_support",
+    "breakglass.approved.by": "human:oncall_lead",
+    "breakglass.reason": "incident_response",
+    "breakglass.max.duration": "30m",
+    "breakglass.evidence.hash": "sha256:1b0e000000000000000000000000000000000000000000000000000000000002",
+    "governance.severity": "CRITICAL"
+  }
+}
+```

--- a/docs/governance/standards/trace-naming.md
+++ b/docs/governance/standards/trace-naming.md
@@ -95,7 +95,7 @@ Spans are telemetry projections. Authoritative records live in typed evidence an
 
 - Attribute keys: dot-separated lower-case.
 - Retention tiers: uppercase `MUTABLE`, `PROTECTED`, `IMMUTABLE`.
-- Verdict enums: uppercase `PASS`, `FAIL`, `SKIP`, `PARTIAL`, `UNKNOWN`, `SUPERSEDED`.
+- Gate verdict enums (`gate.verdict`): uppercase `ALLOW`, `DENY`, `SKIP` (ADR-0044 canonical values).
 - Gate enforcement in spans: uppercase `HARD`, `SOFT`, `ADVISORY`.
 - DSL enforcement values are lowercase (`hard`, `soft`, `advisory`) — map to uppercase in spans.
 - Booleans: native boolean.
@@ -152,7 +152,7 @@ For charter-specific spans, use `charter.severity` with values `INFO`, `WARN`, `
     "governance.charter.id": "charter.reader.basic",
     "gate.id": "verify_in_registry",
     "gate.tool.name": "tool.write_file",
-    "gate.verdict": "FAIL",
+    "gate.verdict": "DENY",
     "gate.enforcement": "HARD",
     "gate.reason": "Tool is not in the ratified registry snapshot.",
     "gate.evidence.hash": "sha256:9ac1000000000000000000000000000000000000000000000000000000000001",


### PR DESCRIPTION
## Summary

Adds the second wave of lionagi governance documentation. **Docs-only — zero production code changes.**

ADRs already on `main`: ADR-0041 through ADR-0052 (governance foundations).

### New ADRs (ADR-0053 through ADR-0070)

**Artifact & State Management**
- ADR-0053: Artifact persistence — how agent run artifacts are stored and retained
- ADR-0054: Local state cleanup — lifecycle policy for local run state
- ADR-0059: Postgres state backend — durable state storage via Postgres

**Studio Features**
- ADR-0055: Studio artifact viewer — UI surface for browsing run artifacts
- ADR-0056: Play control API — REST/WebSocket API for controlling plays
- ADR-0063: Task-board work center — task board UX design
- ADR-0065: Task-board schema — data model for task board
- ADR-0066: Unified execution viewer — single viewer for all execution types
- ADR-0067: Studio command chat — command chat integration with the orchestrator assistant

**Execution & Scheduling**
- ADR-0057: Remote sandbox execution — secure remote code execution
- ADR-0058: Play cost tracking — token/cost attribution per play
- ADR-0061: Universal scheduler — unified scheduling engine
- ADR-0062: State machine spec — formal state machine for play lifecycle

**Configuration & Integration**
- ADR-0060: Unified config resolution — layered config resolution strategy
- ADR-0064: Work system integration — external work system connectors

**Governance Extensions**
- ADR-0068: Governed adapter protocol — adapter registration and capability gates
- ADR-0069: Tenant scope boundary — tenant isolation boundaries (OSS hooks only)
- ADR-0070: Governance tracing — distributed trace schema for governance events

### Governance Directory (`docs/governance/`)

- `direction.md` — strategic governance direction and principles
- `charter-dsl-v0.md` — Charter DSL v0 specification (agent charter authoring language)
- `adr-cross-reference.md` — cross-reference index linking ADRs by theme
- `standards/` — 6 authoring standards:
  - `adr-style.md` — ADR writing style guide
  - `commit-and-pr-style.md` — commit and PR conventions
  - `dsl-style.md` — DSL authoring conventions
  - `error-messages.md` — error message standards
  - `test-style.md` — test authoring standards
  - `trace-naming.md` — trace and span naming conventions

## Test plan

- [ ] All 27 files render correctly in GitHub markdown preview
- [ ] No `.py` files or code changes included (verify diff is docs-only)
- [ ] ADR numbering is contiguous (0053-0070, no gaps)
- [ ] Cross-reference links in `adr-cross-reference.md` resolve to existing ADRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)