### PR TITLE
feat: add work system (forms, rules, engine) and CLI enhancements

### DIFF
--- a/docs/adrs/ADR-0003-claude-code-marketplace.md
+++ b/docs/adrs/ADR-0003-claude-code-marketplace.md
@@ -14,7 +14,7 @@ Claude Code's plugin marketplace provides a tested distribution primitive: a roo
 
 Adopt the Claude Code marketplace pattern inside the lionagi repository. The structure is:
 
-```
+```text
 .claude-plugin/marketplace.json          # root manifest
 marketplace/<plugin>/.claude-plugin/plugin.json  # per-plugin manifest
 marketplace/<plugin>/skills/             # bundled skills (added in later plays)
@@ -75,12 +75,14 @@ shipped in Phase 0 and why the remaining four were removed or deferred.
 ## Consequences
 
 **Positive**
+
 - Users install only the capability slices they need, keeping Claude Code context lean.
 - Each plugin can version independently; `studio` can ship a breaking MCP config change without bumping `devx`.
 - MCP server configuration can be bundled per plugin (`studio`, `mcp-bundle`) once the FastAPI backend route set is stable.
 - Clear ownership boundary: each plugin directory is a self-contained unit that external contributors or downstream forks can understand and extend.
 
 **Negative**
+
 - More manifests to maintain: root `marketplace.json` plus four `plugin.json` files (v2) must stay in sync as plugin names or descriptions change.
 - Skills authored in `firm/resources/skills/` (canonical) must be copied or symlinked into `marketplace/<plugin>/skills/` for external installs — two places to update per skill change.
 - The `plugin.json` schema is not yet finalized by Anthropic; field names or required keys may shift before GA, requiring a sweep across all four manifests.

--- a/docs/adrs/ADR-0004-filesystem-data-layer.md
+++ b/docs/adrs/ADR-0004-filesystem-data-layer.md
@@ -3,6 +3,12 @@
 **Status**: Accepted
 **Date**: 2026-05-19 (revised 2026-05-20)
 
+---
+
+> **Related update**: [ADR-0033](ADR-0033-unified-entity-state-model.md) and [ADR-0034](ADR-0034-frontend-data-and-state-architecture.md) formalize how data flows from the filesystem layer through SQLite into the frontend. The hybrid filesystem-as-source-of-truth model here remains accurate; ADR-0033 adds `NormalizedState` as the read-side projection, and ADR-0034 specifies the sync contract for frontend consumption.
+
+---
+
 ## Context
 
 Lion Studio's backend serves runs, agents, playbooks, plugins, shows, and sessions.
@@ -100,12 +106,14 @@ into SQLite at any time.
 ## Consequences
 
 **Positive**
+
 - Authored content stays in git-friendly files editable by any tool.
 - Operational queries are fast (SQLite indexes, JOINs, aggregates).
 - No external database process — SQLite is embedded.
 - CLI and Studio share the same data without coordination protocol.
 
 **Negative**
+
 - Two data sources means two things to keep in sync.
 - Import commands needed for historical data migration.
 - Contributors must know which data lives where.

--- a/docs/adrs/ADR-0006-sse-live-streaming.md
+++ b/docs/adrs/ADR-0006-sse-live-streaming.md
@@ -3,6 +3,12 @@
 **Status**: Accepted
 **Date**: 2026-05-19 (revised 2026-05-20)
 
+---
+
+> **Related update**: This ADR defines the SSE transport. [ADR-0034](ADR-0034-frontend-data-and-state-architecture.md) §"SSE architecture" defines the higher-level event taxonomy, dispatch strategy, and integration with TanStack Query cache. ADR-0034 is the canonical owner of event names and envelope structure; this ADR remains authoritative for the wire protocol and reconnect mechanics.
+
+---
+
 ## Context
 
 Lion Studio needs live updates for three surfaces: session message streams
@@ -81,12 +87,14 @@ stop reconnecting.
 ## Consequences
 
 **Positive**
+
 - `EventSource` is native in all modern browsers; no client library.
 - Starlette `StreamingResponse` integrates with the existing FastAPI stack.
 - One-way constraint prevents bidirectional state complexity.
 - No WebSocket server, connection upgrade, or ping/pong management.
 
 **Negative**
+
 - SSE is strictly server-to-client. Any client-to-server action requires a
   separate REST endpoint.
 - HTTP/1.1 browser connection limits (6 per origin) constrain concurrent SSE

--- a/docs/adrs/ADR-0007-plugin-auto-discovery.md
+++ b/docs/adrs/ADR-0007-plugin-auto-discovery.md
@@ -19,7 +19,7 @@ discovers those by scanning `skills/` and `agents/` subdirectories.
 `plugin.json` for every lionagi marketplace plugin does NOT enumerate `skills` or `agents` arrays.
 The Claude Code plugin loader auto-discovers skill and agent files from the directory layout:
 
-```
+```text
 marketplace/<plugin>/
   .claude-plugin/plugin.json   # metadata only — no skills/agents arrays
   skills/                      # auto-discovered by CC loader
@@ -32,11 +32,13 @@ arrays) would create a redundancy that lags the actual directory contents.
 ## Consequences
 
 **Positive**
+
 - Adding a skill file to `skills/` is immediately effective; no manifest update required.
 - Manifest stays small and readable — metadata only.
 - Consistent with the only production reference implementation available at time of decision.
 
 **Negative**
+
 - Auto-discovery behavior is undocumented by Anthropic and may change before GA. If the CC
   loader stops auto-discovering from directory layout, all four plugins break silently — there
   is no explicit manifest to fall back on.

--- a/docs/adrs/ADR-0009-sqlite-state-layer.md
+++ b/docs/adrs/ADR-0009-sqlite-state-layer.md
@@ -3,6 +3,12 @@
 **Status**: Accepted
 **Date**: 2026-05-20
 
+---
+
+> **Related update**: This ADR establishes SQLite as the current persistent state layer. [ADR-0033](ADR-0033-unified-entity-state-model.md) introduces `NormalizedState` (lifecycle × health × delivery) as the contract for entity state; the SQLite schema here is the current materialization of that contract. [ADR-0034](ADR-0034-frontend-data-and-state-architecture.md) §"Backend-frontend sync contract" specifies how this layer's reads flow to the frontend. The schema extensions for the new dimensions are in ADR-0033 Appendix A. SQLite-specific details remain authoritative; future stores (Postgres, distributed) will materialize the same NormalizedState model differently.
+
+---
+
 ## Context
 
 Lion Studio's filesystem-only backend (ADR-0004) works for post-hoc review but
@@ -129,7 +135,7 @@ Branch config (provider, model, system_prompt, tools, effort) lives in
 > stored in `node_metadata` JSON on the branch row, not as top-level columns. A
 > dedicated branch fork protocol may promote these to first-class columns in a
 > future migration if query patterns require it.
-
+>
 > **`system_msg_id` is first-class.** Unlike fork pointers, the system prompt
 > reference is promoted to a top-level column because (a) every live persist
 > path writes it during branch initialization, (b) the Studio inbox/branch view
@@ -174,6 +180,7 @@ grep, git, symlinks).  ADR-0004 remains valid for these.
 ### Supporting code changes (same session)
 
 **`Branch.to_dict()` streamlined** (commits 7ac31109, a36b5542):
+
 - Added `mode` parameter: `"python"` (default), `"json"`, `"db"`.
 - `mode="db"` renames `metadata` → `node_metadata`.
 - Optional flags: `include_logs`, `include_log_config`,
@@ -182,6 +189,7 @@ grep, git, symlinks).  ADR-0004 remains valid for these.
 - `parse_model` only included when it differs from `chat_model`.
 
 **`create_message()` extracted** (commit 8f6c6d94):
+
 - `MessageManager.create_message()` is now a `@staticmethod` — can be used
   without a MessageManager instance.
 - Standalone `create_message()` function exported from
@@ -190,6 +198,7 @@ grep, git, symlinks).  ADR-0004 remains valid for these.
   insertion and system message replacement.
 
 **`iModel.to_dict()` slimmed** (commits 7ac31109, a36b5542):
+
 - `request_options` excluded by default (bulk, not useful for persistence).
 - `processor_config` excluded by default.
 
@@ -218,6 +227,7 @@ on legacy versions) can drop the autocheckpoint setting or run
 ## Consequences
 
 **Positive**
+
 - Session/branch/message model has a persistent representation that mirrors the
   runtime 1:1. Round-trip `to_dict(mode="db")` → INSERT → SELECT → `from_dict()`
   is lossless.
@@ -230,6 +240,7 @@ on legacy versions) can drop the autocheckpoint setting or run
 - Agent/playbook file-based contract preserved.
 
 **Negative**
+
 - `aiosqlite` is now a mandatory dependency (promoted from `lionagi[sqlite]` optional).
 - JSON array for progression ordering limits query-side operations (no
   `WHERE message_id IN progression` without JSON parsing).

--- a/docs/adrs/ADR-0010-plugin-aware-studio.md
+++ b/docs/adrs/ADR-0010-plugin-aware-studio.md
@@ -33,6 +33,7 @@ A new service scans two locations for plugins:
 | Third-party | `~/.claude/plugins/cache/*/*/` | No (read-only) |
 
 For each plugin directory, the service:
+
 - Reads `.claude-plugin/plugin.json` for metadata (name, version, description)
 - Falls back to directory name if no manifest exists
 - Enumerates `skills/*/SKILL.md`, `agents/*.md`, `hooks/hooks.json`, `.mcp.json`
@@ -43,7 +44,7 @@ list for repo plugins. Third-party plugins are discovered by directory scan.
 
 ### 2. API surface
 
-```
+```text
 GET  /api/plugins/              → list all plugins with component counts
 GET  /api/plugins/{name}        → plugin detail: metadata + component lists
 GET  /api/plugins/{name}/skills/{skill}  → skill content (read-only)
@@ -62,6 +63,7 @@ Navigation changes from `Playbooks | Agents | Skills | Runs | Shows` to
 name or `Lion Marketplace`), component counts (N skills, M agents).
 
 **Plugin detail page**: tabbed layout:
+
 - **Skills** tab: two-pane list+detail, read-only SKILL.md viewer
 - **Agents** tab: agent names/descriptions with `Open in Agents →` cross-links
 - **Hooks** tab: `hooks.json` viewer (read-only)
@@ -94,11 +96,13 @@ Plugin components need explicit navigation to their editable counterparts and
 clear source/editability indicators:
 
 **Cross-links from plugin detail tabs**:
+
 - Agent tab: `Open in Agents →` link per agent (routes to `/agents/{name}`)
 - Skill tab: `View source` link, `Copy path` action
 - All tabs: `Open raw` for filesystem path
 
 **Source badges on plugin list and detail**:
+
 | Badge | Meaning |
 |-------|---------|
 | `Lion Marketplace` | From `marketplace/`, writable |
@@ -119,6 +123,7 @@ font with code fences in monospace, not the current all-monospace treatment.
 ### 6. Deferred: CLI sync, monitors, themes, LSP
 
 These are not part of this ADR:
+
 - `li plugin sync` CLI (marketplace → CC plugin install) — separate feature
 - Monitors, themes, LSP components — surface in Studio when usage warrants
 - Model-agnostic abstraction — current format is CC-native; abstract later
@@ -126,12 +131,14 @@ These are not part of this ADR:
 ## Consequences
 
 **Positive**
+
 - Skills and agents gain context: users see which plugin provides each capability.
 - Editing flows through existing definitions versioning — no new persistence layer.
 - Third-party plugin visibility without management complexity.
 - Direct alignment with CC's plugin model — what you see in Studio is what CC loads.
 
 **Negative**
+
 - Plugin discovery adds startup scan cost (~22ms for 4 plugins, negligible).
 - Two navigation paths to the same skill (Plugins → devx → commit vs. direct URL).
 - `plugin.json` may not exist for all marketplace plugins yet — fallback to dir name.

--- a/docs/adrs/ADR-0011-shows-data-model.md
+++ b/docs/adrs/ADR-0011-shows-data-model.md
@@ -4,6 +4,12 @@
 **Date**: 2026-05-20
 **Extends**: ADR-0009 (SQLite state layer), ADR-0010 (plugin-aware Studio)
 
+---
+
+> **Related update**: The shows/plays schema defined here stores structural and operational state. [ADR-0033](ADR-0033-unified-entity-state-model.md) adds `NormalizedState` columns (health, delivery, reason_codes) additively to these tables. The lifecycle vocabularies for Shows and Plays in ADR-0033 §"Per-entity lifecycle vocabularies" are derived from this ADR's status enums. This ADR remains authoritative for the table structure and cardinality; ADR-0033 governs the meaning of state values written to those tables.
+
+---
+
 ## Context
 
 Shows (multi-play DAGs orchestrated by the `show` skill) currently exist only
@@ -140,7 +146,7 @@ accessible: `plays.session_id` → `sessions` → `branches` → `progressions` 
 
 ### Read path (Studio API)
 
-```
+```text
 GET /api/shows/           → SELECT from shows table (fast, no filesystem)
 GET /api/shows/{topic}    → shows row + plays rows + _show.md from disk
 GET /api/shows/{topic}/plays/{name}
@@ -250,7 +256,7 @@ ADR-0012), not `/sessions/{session_id}`.
 The plays table uses a single **State** column with a primary lifecycle pill
 plus optional secondary badges for gate and integration:
 
-```
+```json
 [completed] [passed] [merged]      ← full provenance
 [completed]                        ← no gate, no merge
 [awaiting gate]                    ← running_complete
@@ -263,6 +269,7 @@ a single compound pill (hard to scan because dimensions aren't visually
 separable).
 
 **Badge colors**:
+
 - Lifecycle: pending (amber), running (blue), awaiting_gate (amber),
   completed (green), failed (red), aborted (gray)
 - Gate: passed (green outline), failed (red outline), skipped (gray outline)
@@ -279,7 +286,7 @@ lifecycle + gate + review badges per ADR-0012's status vocabulary.
 The PlayDag renders as a **compact dependency graph strip above the plays
 table**, not a competing primary view:
 
-```
+```text
 Dependency graph                                        [Hide graph]
 ┌────────────────────────────────────────────────────────────────────┐
 │  compact PlayDag, fitView, 150–170px tall                          │
@@ -290,6 +297,7 @@ Dependency graph                                        [Hide graph]
 ```
 
 Height scales with play count:
+
 - ≤4 plays: 112px
 - 5–20 plays: 160px
 - 21+ plays: 220px with scroll/pan
@@ -301,6 +309,7 @@ a plain status table and loses the orchestration identity of the page.
 ### Show status provenance (added post-review)
 
 Show status includes provenance to address trust concerns:
+
 - `active` — at least one play running or pending
 - `completed` — all plays merged and final gate passed (or inferred from filesystem)
 - `aborted` — `_ABORT` file exists
@@ -317,6 +326,7 @@ indicate confidence level.
 ## Consequences
 
 **Positive**
+
 - Show → play → session → message drill-down via foreign keys.
 - Fast list/filter queries without filesystem scanning.
 - Structural queries: blocked plays, critical path, cross-show stats.
@@ -326,6 +336,7 @@ indicate confidence level.
 - Status normalization eliminates contradictory displays across pages.
 
 **Negative**
+
 - Dual write: every `_meta.json` update must also update SQLite. If the
   show skill crashes between writes, they can drift. Mitigation: the
   `li state import-shows` command can re-sync from filesystem at any time.

--- a/docs/adrs/ADR-0012-studio-execution-lineage.md
+++ b/docs/adrs/ADR-0012-studio-execution-lineage.md
@@ -4,13 +4,19 @@
 **Date**: 2026-05-20
 **Extends**: ADR-0009 (SQLite state layer), ADR-0010 (plugins), ADR-0011 (shows data model), ADR-0017 (session lifecycle)
 
+---
+
+> **Related update**: This ADR defines execution lineage and status display vocabulary. [ADR-0033](ADR-0033-unified-entity-state-model.md) formalizes the backend-owned `NormalizedState` that drives all status display, severity computation, and reason-code attachment. The display mappings here are preserved for backwards compatibility; new display code should consume `NormalizedState` directly. The lineage relationships (run → invocation → tool_call) remain authoritative for execution provenance.
+
+---
+
 ## Context
 
 Lion Studio does not have a UI naming problem. It has an **execution data-contract
 problem**. Users can see playbooks, agents, plugins, runs, and shows as isolated
 pages, but the causal chain between them is not surfaced:
 
-```
+```text
 Playbook / Agent → Show Play → Session → Branch → Messages / Tool Calls → Artifacts
 ```
 
@@ -58,11 +64,12 @@ enriched sessions is straightforward. Going the other direction is harder.
 
 ### 2. Navigation: keep "Runs", reorder, no Dashboard item
 
-```
+```text
 Playbooks | Agents | Plugins | Shows | Runs
 ```
 
 Changes from current (`Playbooks | Agents | Plugins | Runs | Shows`):
+
 - **Shows** moves before **Runs** — shows orchestrate plays that create sessions.
   Left-to-right matches causality.
 - **"Runs"** stays as the nav label. Users think "I ran a playbook," not "I created
@@ -100,7 +107,7 @@ Detail views show the raw status in a metadata section.
 **"Completed with errors" pattern**: Tool errors are diagnostic, not
 status-changing. A completed session with intermediate tool failures displays as:
 
-```
+```text
 completed · 112 intermediate tool errors
 ```
 
@@ -127,7 +134,7 @@ The run detail page restructures from a flat branch/message scroll to anchored
 sections with a sticky section nav. **Not tabs** — tabs hide information, which is
 wrong for a debugging tool.
 
-```
+```text
 Sticky section nav (dynamic ordering):
 [Overview] [Errors 112] [Branches 7] [Files 11] [Execution]
 
@@ -139,6 +146,7 @@ Each branch is an accordion.
 ```
 
 **Overview section** (new):
+
 - Verdict/outcome badge with error qualifier: `completed · 112 intermediate tool errors`
 - Duration with disambiguation: session duration vs branch duration when different
 - Branch count, message count, tool call count, error count (labeled "intermediate
@@ -176,7 +184,7 @@ context. This sidesteps the session-to-playbook resolution problem.
 For **declarative playbooks** (no steps/links), do not synthesize a fake graph.
 Show a linear execution summary instead:
 
-```
+```text
 Agent: architect → 47 tool calls → 11 files → Verdict: PASS
 ```
 
@@ -259,14 +267,14 @@ filters give better ROI. Search becomes important when artifacts are indexed.
 of sessions the UI can actually list and open — not filesystem run directories.
 If the runs page shows 376 sessions, the dashboard shows 376 runs.
 
-```
+```text
 INVENTORY    20 playbooks    17 agents    376 runs    2 shows
 ```
 
 The 549 filesystem run directories are visible on the runs page as import status,
 not on the dashboard:
 
-```
+```text
 Import status: 549 filesystem dirs detected · 376 indexed · 173 unindexed
 [Run import]
 ```
@@ -275,6 +283,7 @@ This separation keeps operational state on the dashboard and migration state whe
 it is actionable.
 
 Other improvements:
+
 - Metric cards clickable, routing to filtered runs list (`/runs?status=failed`).
 - "Needs attention" surfaces slow/stale when count > 0. Does NOT include
   intermediate tool errors (those are diagnostic, not operational).
@@ -285,6 +294,7 @@ Other improvements:
 
 **Phase 0 — Prerequisites** (implemented on `feat/studio-monitoring-polish`,
 pending merge):
+
 - Session schema enrichment + provenance columns (v2→v3 migration)
 - Show → Session drill-down (play accordion with session links)
 - Run detail anchored sections (Overview, Tool errors, Branches, Files)
@@ -311,6 +321,7 @@ pending merge):
 ## Consequences
 
 **Positive**
+
 - Full execution chain navigable: show → play → session → messages → artifacts.
 - Single query source (enriched sessions) eliminates count mismatches.
 - Status display mapping preserves raw state machine while showing consistent UI.
@@ -319,6 +330,7 @@ pending merge):
 - Zero new tables — enriched sessions avoid premature abstraction.
 
 **Negative**
+
 - Session table gains 7 nullable columns — acceptable at current scale, may need
   extraction to an `executions` table if the table becomes unwieldy.
 - Historical backfill for 26 plays requires manual/heuristic matching.

--- a/docs/adrs/ADR-0013-zero-dependency-ui.md
+++ b/docs/adrs/ADR-0013-zero-dependency-ui.md
@@ -1,7 +1,13 @@
 # ADR-0013: Zero Component-Library UI
 
-**Status**: Accepted
+**Status**: Superseded by [ADR-0035](ADR-0035-design-system-and-component-library.md) for product surfaces
 **Date**: 2026-05-20
+
+---
+
+> **Supersession notice**: This ADR's "no external component library" decision is superseded by [ADR-0035](ADR-0035-design-system-and-component-library.md) for all product surfaces (Dashboard, tables, modals, dropdowns, etc.). ADR-0035 adopts shadcn/ui + Radix primitives because the threshold conditions documented below (3+ of: modals, popovers, combobox, multi-select, ARIA tabs) have all been met. The zero-dependency principle remains valid for content rendering (markdown) and visualization (ReactFlow/dagre) — see ADR-0035 §"NOT adopted" for the preserved scope.
+
+---
 
 ## Context
 
@@ -87,6 +93,7 @@ data display still follow the zero-library rule.
 ## Consequences
 
 **Positive**
+
 - Zero dependency means zero upgrade churn, zero breaking changes from upstream,
   zero style conflicts or specificity wars.
 - Every component matches the design system exactly — no overriding library
@@ -96,6 +103,7 @@ data display still follow the zero-library rule.
   we want, the status pills use exactly the tokens we define.
 
 **Negative**
+
 - Accessibility is incomplete. A screen reader user would have a degraded
   experience on some interactive elements.
 - Some patterns (focus trap, click-outside-to-close, scroll lock on overlay)

--- a/docs/adrs/ADR-0015-runs-list-design.md
+++ b/docs/adrs/ADR-0015-runs-list-design.md
@@ -23,7 +23,7 @@ distinguish 376 rows that mostly share the same name and status.
 Each row has a primary display name (computed from provenance) and a secondary
 meta line (session ID + supplementary context):
 
-```
+```text
 unimpl-adr-sweep / closeout-audit        show play   completed   1 br · 24 msg   15h ago
   session 20260520T0A7... · playbook show · agent orchestrator
 
@@ -58,6 +58,7 @@ absent, the row simply falls back to session ID and timestamp.
 | Updated | 150px | Visible | Relative timestamp, primary sort |
 
 Hidden columns (available via `[Columns]` toggle):
+
 - Started, Source kind, Playbook, Agent, Show topic, Show play, Session ID,
   Branches (split), Messages (split)
 
@@ -65,7 +66,7 @@ Hidden columns (available via `[Columns]` toggle):
 
 Dense two-row filter bar above the table:
 
-```
+```json
 [ Search name, id, show, play, playbook, agent... ]      [Columns ▾]
 Status: [All] [Running] [Completed] [Failed] [Aborted]
 Kind:   [All] [Agent] [Play] [Flow] [Fanout] [Show play]
@@ -91,6 +92,7 @@ keyboard navigation, and future expandable rows. Pagination is simpler.
 ### 5. Empty provenance handling
 
 During the transition period (most sessions have null provenance):
+
 - Rows with provenance get descriptive display names (show/play, playbook, agent)
 - Rows without provenance fall back to session name + timestamp
 - No "unlinked" labels, no "missing" indicators — absence is handled by
@@ -100,12 +102,14 @@ During the transition period (most sessions have null provenance):
 ## Consequences
 
 **Positive**
+
 - Every row is identifiable even when 100+ share the same session name.
 - Filters enable targeted diagnosis (show me all failed show-plays).
 - Pagination prevents render performance degradation.
 - Column toggle lets power users expose raw metadata when needed.
 
 **Negative**
+
 - Two-line rows use more vertical space per row (~52px vs ~36px).
 - Display-name algorithm requires client-side computation per row.
 - Filter state is local with one exception: the `?status=` query parameter is supported for dashboard deep links (ADR-0012). Other filter dimensions (kind, source, search) are local-only until deep-linking is needed.

--- a/docs/adrs/ADR-0016-definitions-write-path.md
+++ b/docs/adrs/ADR-0016-definitions-write-path.md
@@ -38,6 +38,7 @@ versioning works, and what rollback means.
 the current state.
 
 When Studio saves a definition:
+
 1. Validate `kind` and `name` (see "Route parameter validation" below).
 2. Acquire the per-`(kind, name)` in-process lock (`_DEFINITION_LOCKS`).
 3. Insert a new row in `definitions` with the content, incremented version number,
@@ -63,6 +64,7 @@ operation. Invalid values return **422 Unprocessable Entity**.
 `kind` must be one of the supported definition kinds: `agent`, `playbook`.
 
 `name` must be a non-empty single path component. The following are rejected:
+
 - Path separators: `/`, `\`
 - NUL byte: `\x00`
 - Dot components: `.`, `..`
@@ -79,7 +81,7 @@ not on restricting symlink targets.
 
 ### Save semantics
 
-```
+```text
 POST /api/definitions/{kind}/{name}
   body: { content: string, message?: string }
   →
@@ -104,7 +106,7 @@ Definition identity is `(kind, name)`. This is unique because marketplace agents
 
 ### Rollback semantics
 
-```
+```text
 POST /api/definitions/{kind}/{name}/rollback?version=N
   →
   1. SELECT content FROM definitions WHERE kind=? AND name=? AND version=?
@@ -135,6 +137,7 @@ Studio is open, (3) git provides the ultimate conflict resolution layer.
 ## Consequences
 
 **Positive**
+
 - Clear boundary: definitions are the only things Studio writes. Everything else
   is read-only or import-only.
 - Disk-as-truth means git, grep, vim, and Claude Code all see the same file.
@@ -142,6 +145,7 @@ Studio is open, (3) git provides the ultimate conflict resolution layer.
 - Simple CRUD surface — no complex state machine or workflow engine.
 
 **Negative**
+
 - Disk and SQLite can drift if a write to one succeeds and the other fails.
   Mitigation: DB write first (data integrity gate). If the DB write fails the
   exception propagates and disk is not touched. If the disk write fails after a

--- a/docs/adrs/ADR-0017-session-lifecycle-status.md
+++ b/docs/adrs/ADR-0017-session-lifecycle-status.md
@@ -1,8 +1,14 @@
 # ADR-0017: Session Lifecycle and Status Derivation
 
-**Status**: Accepted
+**Status**: Partially superseded by [ADR-0033](ADR-0033-unified-entity-state-model.md) — see Supersession Notice
 **Date**: 2026-05-20
 **Extends**: ADR-0009 (SQLite state layer), ADR-0012 (execution lineage)
+
+---
+
+> **Supersession notice**: [ADR-0033](ADR-0033-unified-entity-state-model.md) supersedes ADR-0017's "Status vocabulary" section (replaced by the unified `NormalizedState.lifecycle` axis) and the single-axis status derivation. ADR-0017's lifecycle enum is preserved as one of three orthogonal axes in NormalizedState (lifecycle × health × delivery). Read this ADR for historical context; treat [ADR-0033](ADR-0033-unified-entity-state-model.md) as authoritative for status semantics going forward.
+
+---
 
 ## Context
 
@@ -92,7 +98,7 @@ For filesystem imports (`source_kind='imported_fs'`), status is derived from:
 
 Duration is computed, not stored:
 
-```
+```text
 duration_ms = (ended_at - started_at) * 1000   -- if both present
 duration_ms = NULL                               -- if session still running
 ```
@@ -178,6 +184,7 @@ re-running the message sweep.
 ## Consequences
 
 **Positive**
+
 - Runs list and dashboard can query session status directly — no derivation logic.
 - Four-status vocabulary is simple and unambiguous.
 - Duration is computable from two timestamps without a stored column.
@@ -185,6 +192,7 @@ re-running the message sweep.
 - Clean separation: session status = "did it run?", play status = "was output accepted?"
 
 **Negative**
+
 - Three new columns on the sessions table (part of the collapsed v1 schema; reconciled into pre-release DBs by `StateDB._reconcile_columns()`).
 - CLI session init and finalize must write status — requires hooks or explicit calls.
 - Imported sessions may have imprecise timestamps if run.json is sparse.

--- a/docs/adrs/ADR-0018-studio-distribution.md
+++ b/docs/adrs/ADR-0018-studio-distribution.md
@@ -41,7 +41,7 @@ The React frontend is built at CI/release time. The built static files
 are included in the Python package under `lionagi/studio/static/`. The
 FastAPI server serves them directly.
 
-```
+```text
 pip install lionagi[studio]    # or: pip install lionagi (if studio becomes default)
 li studio                      # starts uvicorn, serves frontend + API on 127.0.0.1:8765
 ```
@@ -187,6 +187,7 @@ embed the same uvicorn server and open a webview to `127.0.0.1:8765`.
 ## Consequences
 
 **Positive**
+
 - One-command install and start (`pip install lionagi[studio] && li studio`).
 - Full host access — no Docker isolation getting in the way of local dev tooling.
 - No frontend toolchain required for users (Node.js, npm stay in CI only).
@@ -194,6 +195,7 @@ embed the same uvicorn server and open a webview to `127.0.0.1:8765`.
 - Compatible with future desktop wrapper without architecture changes.
 
 **Negative**
+
 - CI must build the frontend and include it in the wheel. Adds a build step.
 - `lionagi[studio]` wheel is larger (~2-5 MB for built React assets).
 - Docker mode has documented limitations around host access — users who expect

--- a/docs/adrs/ADR-0020-skill-invocations.md
+++ b/docs/adrs/ADR-0020-skill-invocations.md
@@ -9,7 +9,7 @@
 Lion Studio traces execution from sessions down to messages, but has no
 record of what triggered those sessions. The causal chain today:
 
-```
+```text
 ??? → Session → Branch → Messages → Tool Calls → Artifacts
 ```
 
@@ -104,6 +104,7 @@ CLI primitive: `agent`, `play`, `flow`, `fanout`, `show-play`).
 orchestration spawned this session?"
 
 The two are orthogonal:
+
 - `invocation_kind = 'play'` — this session was created by `li play`
 - `invocation_id = 'abc123'` — it was spawned as part of the `/show`
   invocation `abc123`
@@ -157,7 +158,7 @@ The runs list gains a **grouping mode**: when invocations exist, sessions
 can be grouped under their parent invocation. Default view is flat (current
 behavior); grouped view nests sessions under invocation headers:
 
-```
+```text
 ▼ /show "resolve lionagi issues" — 14 sessions, 6h 38m, completed
     play:backend — completed, 87 min
     play-gate:backend — completed, 3 min
@@ -176,7 +177,7 @@ The Runs page (`/runs/invocations`) uses a `View: Invocations | Sessions` toggle
 (see ChatGPT frontend design review, sections 1 and 5). The default view is grouped
 by invocation. Each parent row shows:
 
-```
+```text
 ▾ /show lionagi-issue-sweep                              worst: stale
   6 plays · 14 sessions · 9h elapsed · 7 artifacts · updated 10m ago
   Models: codex/gpt-5.5 ×10 · claude-sonnet-4-6 ×4
@@ -189,7 +190,7 @@ grouped row from showing a clean "running" state when one child is stale.
 
 Expanded child rows show two columns — **Status** (reported) and **Health** (derived):
 
-```
+```text
 Run          Agent        Model             Status       Health     Dur
 f82488be     reviewer     codex/gpt-5.5     running      stale      1h 34m
 462bb5ed     play-gate    claude-sonnet     running      stale      9h 46m
@@ -243,7 +244,7 @@ primitive type (`agent`, `play`, `flow`, `fanout`, `show-play`). The new
 
 The two compose:
 
-```
+```text
 invocation (skill="show", prompt="resolve lionagi issues")
   ├── session (invocation_kind="play", show_play_name="backend")
   ├── session (invocation_kind="agent", agent_name="play-gate")
@@ -261,6 +262,7 @@ User-created skills (files in `~/.lionagi/skills/`) work the same way.
 ## Consequences
 
 **Positive**
+
 - The full execution tree is traceable: skill → invocation → sessions →
   branches → messages.
 - Orchestrator skills get first-class lifecycle tracking without expanding
@@ -272,6 +274,7 @@ User-created skills (files in `~/.lionagi/skills/`) work the same way.
 - Marketplace plugins get attribution via the `plugin` column.
 
 **Negative**
+
 - Skills must explicitly call `li invoke start/end` to get tracking. Skills
   that don't are invisible at the invocation layer (sessions still tracked).
 - `node_metadata` is unstructured — no schema validation means skill-specific

--- a/docs/adrs/ADR-0021-skill-artifacts-and-reactive-chaining.md
+++ b/docs/adrs/ADR-0021-skill-artifacts-and-reactive-chaining.md
@@ -12,6 +12,7 @@ orchestration. But three deeper questions remain:
 ### 1. Where does show data live?
 
 Shows currently have dual persistence:
+
 - **DB**: `shows` + `plays` tables (ADR-0011) — status, metadata, FKs.
 - **Filesystem**: `$HOME/khive-work/shows/<topic>/` — prompts, intents,
   verdicts, logs, agent artifacts, worktrees.
@@ -63,7 +64,7 @@ typing the next command. The pieces exist but don't connect.
 Create `lionagi/outcomes/` as the shared location for skill result types.
 These are the **contract** between skill producers and Studio consumers.
 
-```
+```text
 lionagi/outcomes/
   __init__.py
   _base.py          # SkillOutcome base
@@ -156,6 +157,7 @@ CREATE INDEX IF NOT EXISTS idx_artifacts_kind ON artifacts(kind);
 ```
 
 The split:
+
 - **DB (`content` JSON)**: structured outcomes — verdicts, results,
   analyses. Queryable, displayable, chainable.
 - **Filesystem (`file_path`)**: large blobs — full logs, generated code,
@@ -340,6 +342,7 @@ Start with two event sources, add more as needed:
 | **Manual** | `li chain fire <name>` | `manual.fired` |
 
 Future (not in this ADR):
+
 - GitHub webhooks (`pr.opened`, `pr.merged`, `issue.created`)
 - File watch (`file.changed` in a watched directory)
 - Invocation completion (`invocation.completed` with outcome filter)
@@ -372,7 +375,7 @@ The invocations page shows the final outcome of each step.
 The `ReviewVerdictCard` renders the structured verdict as a severity/category
 breakdown with blocking findings, not plain text:
 
-```
+```text
 ┌────────────────────────────────────────────────────────────────────┐
 │ REQUEST CHANGES                                  reviewer · 5m 27s │
 ├────────────────────────────────────────────────────────────────────┤
@@ -407,7 +410,7 @@ minor suggestions in a collapsed section.
 
 The `GateVerdictCard` renders as an acceptance criteria checklist:
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────────┐
 │ GATE VERDICT: REJECT                                                │
 ├─────────────────────────────────────────────────────────────────────┤
@@ -432,7 +435,7 @@ next action are surfaced prominently, not buried in a text field.
 
 The `CIResultCard` renders as a test/build/lint matrix with command timings:
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────────┐
 │ CI RESULT: PASSED                                                   │
 ├─────────────────────────────────────────────────────────────────────┤
@@ -452,7 +455,7 @@ applicable. Commands section shows the actual commands run with durations.
 
 ### Summary: the full stack
 
-```
+```text
 Chain (pr-review-chain.yaml)
   → Trigger (pr.opened / schedule / manual)
     → Invocation (skill="codex-pr-review", ADR-0020)
@@ -468,6 +471,7 @@ Chain (pr-review-chain.yaml)
 ## Consequences
 
 **Positive**
+
 - Skills have a typed output contract. Studio knows how to render a
   `ReviewVerdict` vs a `CIResult` without parsing markdown.
 - Artifacts are queryable — "show me all failed reviews this week" is a
@@ -481,6 +485,7 @@ Chain (pr-review-chain.yaml)
   skill invocation.
 
 **Negative**
+
 - New package (`lionagi/outcomes/`) adds to the import surface. Mitigated
   by lazy imports and clear scope boundary.
 - Artifact writes add DB operations to skill execution paths. At our

--- a/docs/adrs/ADR-0022-run-step-provenance.md
+++ b/docs/adrs/ADR-0022-run-step-provenance.md
@@ -14,6 +14,7 @@ or surfaced:
 
 **Sessions** have `agent_name` (TEXT) — the agent profile name from
 `-a reviewer`. But:
+
 - No `model` column. The resolved model spec (`claude/claude-sonnet-4-6`,
   `openai/gpt-4.1`) is not stored.
 - No `provider` column. Whether the run used Claude Code, Codex, OpenAI
@@ -24,6 +25,7 @@ or surfaced:
   agents get `NULL`.
 
 **Branches** have `node_metadata` JSON which *can* hold `chat_model`, but:
+
 - The write path in `agent.py` only copies `chat_model` if it's in
   `branch_dict` — and it's frequently missing (empty in 5/5 sampled rows).
 - Flow ops create multiple branches with different models — the per-branch
@@ -108,7 +110,7 @@ Not a security hash — just a content fingerprint.
 The model string stored must be the **fully resolved** spec, not the
 input. Resolution chain:
 
-```
+```text
 User input: "sonnet"
   → parse_model_spec(): ModelSpec(model="claude/claude-sonnet-4-6")
   → agent profile override: (none, use parsed)
@@ -140,7 +142,7 @@ a badge or tooltip shows "2 models" with the breakdown.
 
 Each step/branch shows its own model and agent:
 
-```
+```text
 Step: explorer (claude/claude-sonnet-4-6, effort=high)
   [messages...]
 
@@ -154,7 +156,7 @@ When `agent_name` is set and the agent definition file exists, the run
 detail page shows a link to the agent profile. The `agent_hash` enables
 a "definition changed since this run" indicator:
 
-```
+```text
 Agent: reviewer (definition changed since this run)
 ```
 
@@ -170,6 +172,7 @@ path can extract model from `run.json` → `manifest.model_spec` if present.
 ## Consequences
 
 **Positive**
+
 - Every run discloses its model, provider, and effort level — no guessing.
 - Multi-model flows show per-branch model, not just the session default.
 - Agent definition snapshots via hash enable "drift since this run" detection.
@@ -177,6 +180,7 @@ path can extract model from `run.json` → `manifest.model_spec` if present.
 - Fully resolved model specs are stable and comparable.
 
 **Negative**
+
 - Four new columns on sessions, three on branches. Reconciled via
   `_reconcile_columns()` — no migration runner needed.
 - Write path changes in `agent.py`, `flow.py`, `fanout.py`,

--- a/docs/adrs/ADR-0023-unified-hook-system.md
+++ b/docs/adrs/ADR-0023-unified-hook-system.md
@@ -45,7 +45,7 @@ Problems:
 
 The resolution chain:
 
-```
+```text
 agent.md → parse_model_spec() → iModel.__init__(endpoint=...) → iModel.invoke()
                                   ↑                                ↑
                               provider, model known            payload, response, tokens known
@@ -53,6 +53,7 @@ agent.md → parse_model_spec() → iModel.__init__(endpoint=...) → iModel.inv
 ```
 
 The info exists at two points:
+
 - **Branch creation**: model spec, provider, effort are resolved and
   passed to `iModel.__init__()`. This is when session-level provenance
   should be captured.
@@ -328,6 +329,7 @@ class Session:
 ### Hook isolation
 
 Hooks MUST NOT:
+
 - Block the operation they're observing (async with timeout, fire-and-forget on failure)
 - Modify the operation's data (hooks are observers, not interceptors — except `TOOL_PRE` which can raise to block)
 - Hold references to the bus after session end (GC-safe)
@@ -338,7 +340,7 @@ fire-and-observe.
 
 ### Package structure
 
-```
+```text
 lionagi/hooks/
   __init__.py          # exports HookBus, HookPoint, hook decorator
   bus.py               # HookBus, HookPoint enum, StopHook
@@ -354,6 +356,7 @@ window, it moves to `lionagi/hooks/_legacy/`.
 ## Consequences
 
 **Positive**
+
 - Model/provider/tokens flow from iModel layer to DB persistence via
   a single bus — no more data gap.
 - Agent profiles can configure hooks declaratively — no code changes for
@@ -368,6 +371,7 @@ window, it moves to `lionagi/hooks/_legacy/`.
   leaks.
 
 **Negative**
+
 - Deprecation period for `HookRegistry` and `AgentConfig.hook_handlers`
   means two code paths temporarily coexist.
 - Hook handler names in agent YAML must be resolvable — typos fail silently

--- a/docs/adrs/ADR-0024-session-health-and-admin-surface.md
+++ b/docs/adrs/ADR-0024-session-health-and-admin-surface.md
@@ -1,8 +1,14 @@
 # ADR-0024: Session Health Classification and Admin Surface
 
-**Status**: Proposed
+**Status**: Proposed — extended by [ADR-0033](ADR-0033-unified-entity-state-model.md)
 **Date**: 2026-05-21
 **Extends**: ADR-0017 (session lifecycle), ADR-0019 (run lifecycle management)
+
+---
+
+> **Extension notice**: [ADR-0033](ADR-0033-unified-entity-state-model.md) integrates this ADR's SessionHealth enum as the `process_health` dimension of the unified `NormalizedState`. The six health values defined here (`healthy, idle, unresponsive, stale, orphaned, zombie`) are preserved and feed into the central severity computation. The admin doctor endpoint described here is preserved as the operational interface; the underlying health classification now flows through NormalizedState across all entity reads, not just admin queries.
+
+---
 
 ## Context
 
@@ -47,10 +53,12 @@ Problems:
 ### The admin page could do much more
 
 The admin page currently shows:
+
 - DB health strip (size, WAL size, WAL pending)
 - Phantom sessions table (checkbox + prune)
 
 It could be the operational control center:
+
 - Session health overview (not just phantoms)
 - Active resource usage (worktrees, disk, connections)
 - Maintenance actions (checkpoint, vacuum, import, prune)
@@ -154,7 +162,7 @@ DEFAULT_STALE_THRESHOLD = 6 * 3600
 
 #### New endpoints
 
-```
+```text
 GET  /api/admin/health          # Full health report
 POST /api/admin/transition      # Change session status (with guard)
 POST /api/admin/checkpoint      # Force WAL checkpoint
@@ -276,7 +284,7 @@ The admin page becomes a full operational console with a top action row,
 two-column layout (Session health + Maintenance), an intervention queue,
 and side-by-side Resources + Event log panels.
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │ Admin                                                    Checked 12:52 PM    │
 │ Studio maintenance and diagnostics                                          │
@@ -322,7 +330,7 @@ and side-by-side Resources + Event log panels.
 Bulk transitions open a confirmation modal that preserves session records
 while marking them terminal:
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────────┐
 │ Transition 4 sessions to failed?                                    │
 │                                                                     │
@@ -345,7 +353,7 @@ while marking them terminal:
 Prune remains visually secondary and is disabled unless sessions are terminal
 or explicitly eligible:
 
-```
+```text
 Prune selected
 disabled: active sessions must be transitioned or exported first
 ```
@@ -355,7 +363,7 @@ disabled: active sessions must be transitioned or exported first
 The dashboard (ADR-0019 §B4) replaces the four current cards with an
 operator-focused layout. Cards:
 
-```
+```text
 1. Attention
 2. Active Executions
 3. Outcomes
@@ -364,7 +372,7 @@ operator-focused layout. Cards:
 
 **Attention** (most important card):
 
-```
+```text
 attention =
   stale running sessions
   + zombie sessions
@@ -375,7 +383,8 @@ attention =
 ```
 
 Example card:
-```
+
+```text
 ATTENTION
 4
 4 stale · 0 failed · 0 needs review
@@ -385,7 +394,7 @@ Oldest: 17h 56m
 **Active Executions**: separates "active" from "healthy". A session can be
 reported as `running` but effectively `stale`:
 
-```
+```text
 ACTIVE EXECUTIONS
 6 invocations
 4 sessions · 6 plays
@@ -395,7 +404,7 @@ Oldest active: 17h 56m
 **Outcomes**: summarizes quality, not just completion. Shows structured outcome
 breakdown when verdicts exist:
 
-```
+```text
 OUTCOMES 24H
 37 completed
 0 failed · 1 request changes
@@ -405,7 +414,7 @@ Pass rate: 97%
 **Latency / SLA**: replaces the "Slow Runs" card with tail latency.
 Threshold is **60 minutes** (confirmed by ADR-0025):
 
-```
+```text
 LATENCY 24H
 P95 58m
 2 over 60m · median 5m 18s
@@ -420,13 +429,13 @@ P95 58m
 
 Do not show `(Null)` sessions in the main status breakdown. Rename to:
 
-```
+```text
 Legacy unclassified
 ```
 
 Display as a muted data-hygiene chip in the system strip:
 
-```
+```text
 System: healthy · DB 847.3 MB · WAL 4.0 MB · Conn 0 · Legacy 376
 ```
 
@@ -567,6 +576,7 @@ Transitions remain explicit admin actions.
 ## Consequences
 
 **Positive**
+
 - Graduated health model gives precise language for session state —
   "stale" and "orphaned" mean different things with different actions.
 - Transition preserves session data for debugging; prune is a separate
@@ -580,6 +590,7 @@ Transitions remain explicit admin actions.
   intervention.
 
 **Negative**
+
 - More complex classification logic — 6 health states instead of 3
   phantom reasons. Mitigated by clear decision tree and tests.
 - Background doctor scan adds CPU/IO load every 5 minutes. At our

--- a/docs/adrs/ADR-0025-session-status-vocabulary.md
+++ b/docs/adrs/ADR-0025-session-status-vocabulary.md
@@ -1,8 +1,14 @@
 # ADR-0025: Session Status Vocabulary
 
-**Status**: Proposed
+**Status**: Superseded by [ADR-0033](ADR-0033-unified-entity-state-model.md)
 **Date**: 2026-05-21
 **Supersedes**: ADR-0017 §"Status vocabulary (sessions)" (partially — extends the vocabulary)
+
+---
+
+> **Supersession notice**: [ADR-0033](ADR-0033-unified-entity-state-model.md) fully supersedes this ADR. ADR-0025's six-value vocabulary (`running, completed, failed, timed_out, cancelled, aborted`) is preserved verbatim as `NormalizedState.lifecycle` for sessions/runs, but now sits alongside two new orthogonal axes (health and delivery). The standalone status field as defined here is deprecated; the unified `NormalizedState` object is authoritative. Read this ADR for the rationale behind the six terminal values; consult ADR-0033 for current state semantics.
+
+---
 
 ## Context
 
@@ -28,6 +34,7 @@ whether a "failed" run needs debugging or just a longer timeout.
 ### 2. No distinction between crash and error
 
 A session can fail because:
+
 - The model returned a malformed response → **error** (recoverable)
 - The Python process segfaulted → **crash** (infrastructure)
 - A dependency raised an exception → **error** (potentially recoverable)
@@ -40,6 +47,7 @@ error), but the status column doesn't record the distinction.
 ### 3. "Aborted" conflates user-initiated and system-initiated
 
 `aborted` covers both:
+
 - User pressed Ctrl-C → **user cancelled** (intentional)
 - Anyio task group cancelled a child → **system cancelled** (cascade)
 - Show abort sentinel → **orchestrator cancelled** (intentional, higher level)
@@ -233,13 +241,13 @@ Use color + icon + text together. Never rely on color alone.
 
 #### Pill anatomy
 
-```
+```json
 [ icon  label ]
 ```
 
 Sizing:
 
-```
+```text
 height: 20px
 padding-x: 6px
 font-size: 10px or 11px
@@ -250,7 +258,7 @@ border: 1px solid semantic border
 
 Dense table variant:
 
-```
+```text
 height: 18px
 font-size: 10px
 ```
@@ -276,7 +284,7 @@ was in place) are displayed as `legacy unclassified`:
 
 On the dashboard, legacy sessions appear only as a muted chip:
 
-```
+```text
 376 legacy sessions
 ```
 
@@ -288,11 +296,12 @@ from live operational metrics."
 When the reported status is `running` but the derived health is `stale`,
 the UI must not show a blue Running pill alone. Show the compound state:
 
-```
+```json
 [stale running]
 ```
 
 Rules:
+
 - **Do not show a blue Running pill alone when health is stale.**
 - In tables with separate Status and Health columns, show both:
   `Status: running` / `Health: stale`
@@ -377,6 +386,7 @@ if status in SESSION_TERMINAL_STATUSES:
 ## Consequences
 
 **Positive**
+
 - Timeout, user abort, and system cancellation are distinguishable in
   the DB and UI — each has a clear follow-up action.
 - Exit codes follow UNIX convention — familiar to operators, parseable
@@ -388,6 +398,7 @@ if status in SESSION_TERMINAL_STATUSES:
 - Python validation replaces SQLite CHECK — more flexible, same safety.
 
 **Negative**
+
 - Schema migration for CHECK constraint removal requires table rebuild
   or constraint relaxation. Pre-release, so acceptable.
 - Six statuses instead of four — slightly more to understand. Each maps

--- a/docs/adrs/ADR-0027-scheduled-runs.md
+++ b/docs/adrs/ADR-0027-scheduled-runs.md
@@ -96,6 +96,7 @@ can define `on_fail` and/or `on_success` as action definitions that are themselv
 ```
 
 When an action completes, exit code determines which edge to follow:
+
 - `exit_code == 0` → `on_success` (if defined)
 - `exit_code != 0` → `on_fail` (if defined)
 
@@ -193,6 +194,7 @@ async def lifespan(app: FastAPI):
 ```
 
 The engine is a single `asyncio.Task` that:
+
 1. Queries `schedules WHERE enabled=1 AND next_fire_at <= now` every 30 seconds
 2. For GitHub schedules: polls the API, fires only when new events are found
 3. Fires due schedules (subject to overlap check)
@@ -201,7 +203,7 @@ The engine is a single `asyncio.Task` that:
 
 ### 8. API Endpoints
 
-```
+```text
 GET    /api/schedules/                  List schedules
 POST   /api/schedules/                  Create schedule
 GET    /api/schedules/{id}              Get schedule detail
@@ -226,7 +228,7 @@ scheduled run — zero new UI work for session grouping.
 
 Schedule management from the terminal, without requiring Studio UI:
 
-```
+```text
 li schedule list                          # List all schedules (enabled/disabled)
 li schedule create <name> --trigger cron --cron "0 0 * * *" \
     --action play --playbook perf-opt     # Create a cron schedule
@@ -269,7 +271,8 @@ have in SQLite and asyncio.
 ### 13. File Map
 
 New files:
-```
+
+```text
 apps/studio/server/scheduler/__init__.py
 apps/studio/server/scheduler/engine.py       # SchedulerEngine, tick loop
 apps/studio/server/scheduler/github.py       # GitHub polling, ETag, auth
@@ -282,7 +285,8 @@ lionagi/tools/schedule.py                    # Agent-accessible schedule tools
 ```
 
 Modified files:
-```
+
+```text
 apps/studio/server/app.py                    # Add lifespan hook, register router
 lionagi/state/schema.sql                     # Add schedules + schedule_runs tables
 lionagi/state/db.py                          # Add migration columns + schedule CRUD
@@ -293,6 +297,7 @@ pyproject.toml                               # Add croniter dependency
 ## Consequences
 
 **Positive**
+
 - Studio becomes an active operator, not just a passive monitor
 - DAG conditional chains (on_fail/on_success, recursive) are a differentiator vs. every competitor
 - Subprocess isolation means schedule failures cannot crash the Studio server
@@ -303,6 +308,7 @@ pyproject.toml                               # Add croniter dependency
 - DAG of DAG composition: schedule → flow → operations, all graphs
 
 **Negative**
+
 - In-process scheduler means Studio server must be running for schedules to fire
 - GitHub polling is less responsive than webhooks (min ~60s latency vs instant)
 - `croniter` is a new dependency (though minimal)

--- a/docs/adrs/ADR-0028-status-reason-model.md
+++ b/docs/adrs/ADR-0028-status-reason-model.md
@@ -1,8 +1,14 @@
 # ADR-0028: Status Reason Model
 
-**Status**: Proposed
+**Status**: Proposed — extended by [ADR-0033](ADR-0033-unified-entity-state-model.md)
 **Date**: 2026-05-23
 **Extends**: ADR-0024 (session health), ADR-0025 (session status vocabulary), ADR-0017 (session lifecycle)
+
+---
+
+> **Extension notice**: [ADR-0033](ADR-0033-unified-entity-state-model.md) generalizes this ADR's reason-code chain to apply uniformly across ALL entity types (sessions, shows, plays, schedules, teams, invocations, knowledge claims). The `StateReason` dataclass in ADR-0033 directly implements this ADR's hot-path/cold-path model. The reason-code namespace defined here is extended with `knowledge.*` codes in ADR-0033 §"Reason code namespace". Implementations follow this ADR's mechanics; the canonical schema lives in ADR-0033.
+
+---
 
 ## Context
 

--- a/docs/adrs/ADR-0029-artifact-contract.md
+++ b/docs/adrs/ADR-0029-artifact-contract.md
@@ -1,9 +1,15 @@
 # ADR-0029: Artifact Contract
 
-**Status**: Proposed
+**Status**: Proposed — extended by [ADR-0033](ADR-0033-unified-entity-state-model.md) and referenced by [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md)
 **Date**: 2026-05-23
 **Extends**: ADR-0021 (skill artifacts, structured outcomes), ADR-0012 (run-step provenance)
 **Related**: ADR-0028 (status reasons — writes `run.failed.missing_artifact`)
+
+---
+
+> **Extension notice**: [ADR-0033](ADR-0033-unified-entity-state-model.md) integrates this ADR's contract verification result into the `delivery` dimension of `NormalizedState`: artifact verification outcomes map to `passed` (all required present), `partial` (some present), `missing` (required absent), or `invalid` (present but failing contract). The evidence captured from verification feeds NormalizedState.reasons[] as structured proof. [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) treats artifacts as a first-class evidence kind (`kind="artifact"` in EvidenceRef) for knowledge claims. The artifact contract mechanics defined here remain authoritative; the contract result is consumed by two downstream systems.
+
+---
 
 ## Context
 

--- a/docs/adrs/ADR-0030-attention-queue.md
+++ b/docs/adrs/ADR-0030-attention-queue.md
@@ -1,9 +1,15 @@
 # ADR-0030: Attention Queue
 
-**Status**: Proposed
+**Status**: Proposed — depends on [ADR-0033](ADR-0033-unified-entity-state-model.md), extended to include knowledge events per [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md)
 **Date**: 2026-05-23
 **Depends on**: ADR-0028 (status reason model) — without persisted reason codes, the queue's grouping and dismissal logic become frontend heuristics
 **Related**: ADR-0029 (artifact contract), ADR-0024 (session health), ADR-0031 (entity actions reuse)
+
+---
+
+> **Extension notice**: [ADR-0033](ADR-0033-unified-entity-state-model.md) provides the canonical severity computation (`derive_severity()`) and reason-code chain that the Attention Queue consumes. The Queue's severity values (`critical, warning, info, neutral`) now have uniform semantics across entity types because they all derive from NormalizedState. [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) adds knowledge-related items to the Queue (disputed claims, low-confidence aged hypotheses, supersession anomalies) via a parallel `derive_claim_severity()` function emitting into the same Queue. The Queue's mechanics defined here are preserved; the sources of severity are now plural and unified.
+
+---
 
 ## Context
 

--- a/docs/adrs/ADR-0031-entity-header-pattern.md
+++ b/docs/adrs/ADR-0031-entity-header-pattern.md
@@ -4,6 +4,12 @@
 **Date**: 2026-05-23
 **Related**: ADR-0028 (status reasons surfaced in header), ADR-0030 (reuses EntityAction shape)
 
+---
+
+> **Related update**: [ADR-0035](ADR-0035-design-system-and-component-library.md) specifies the shadcn/Radix primitives (Dialog, DropdownMenu, Button) used to implement the entity actions defined here. The header's universal status display now renders [ADR-0033](ADR-0033-unified-entity-state-model.md)'s `NormalizedState` via the `StateStack` component in `components/lion/`. This ADR remains authoritative for the header's information architecture and action set; the rendering details flow through ADR-0035.
+
+---
+
 ## Context
 
 Studio's entity detail pages (`/shows/<topic>`, `/runs/<id>`,

--- a/docs/adrs/ADR-0032-navigation-reorganization.md
+++ b/docs/adrs/ADR-0032-navigation-reorganization.md
@@ -4,6 +4,12 @@
 **Date**: 2026-05-23
 **Related**: ADR-0031 (entity header pattern lands inside this nav structure)
 
+---
+
+> **Related update**: This ADR's navigation structure (Dashboard | Work | Library | Admin) is preserved. [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) introduces knowledge as a "lens" pattern rather than a top-level nav section — knowledge surfaces contextually on entity detail pages (Run detail, Show detail) and via search/command palette. Promotion to top-level nav is deferred until curation workflows exist; this ADR's structure remains canonical for v1.
+
+---
+
 ## Context
 
 Studio's top navigation today lists ten entity types as siblings at

--- a/docs/adrs/ADR-0033-unified-entity-state-model.md
+++ b/docs/adrs/ADR-0033-unified-entity-state-model.md
@@ -1,0 +1,444 @@
+# ADR-0033: Unified Entity State Model
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Supersedes**: [ADR-0017](ADR-0017-session-lifecycle-status.md) §"Status vocabulary" (partial), [ADR-0025](ADR-0025-session-status-vocabulary.md) §"Expanded vocabulary" (full)
+**Extends**: [ADR-0024](ADR-0024-session-health-and-admin-surface.md), [ADR-0028](ADR-0028-status-reason-model.md), [ADR-0029](ADR-0029-artifact-contract.md)
+**Related**: [ADR-0030](ADR-0030-attention-queue.md), [ADR-0034](ADR-0034-frontend-data-and-state-architecture.md), [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md)
+**Depends on**: [ADR-0009](ADR-0009-sqlite-state-layer.md) (current persistence implementation)
+
+## Context
+
+The unifying principle these ADRs serve is the **evidence chain**: every state has reasons, every reason has evidence, every claim has evidence. Auditability is not an export feature — it is the data model. This ADR establishes the state-side of the chain (entity status with structured reasons); [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) establishes the knowledge-side (learned facts with structured evidence); both share `EvidenceRef` (defined here).
+
+Status semantics are currently spread across five ADRs, each adding a
+dimension without unifying the model:
+
+| ADR | Contribution | Problem |
+|-----|-------------|---------|
+| ADR-0017 | Session lifecycle: `running`, `completed`, `failed`, `aborted` | Too coarse — no timeout, no cancel distinction |
+| ADR-0025 | Expanded vocabulary: adds `timed_out`, `cancelled` | Solves coarseness, but applies only to sessions |
+| ADR-0024 | Health classification: `healthy` → `zombie` enum | Separate axis, computed per-read, not persisted |
+| ADR-0028 | Reason codes: structured "why" | Right primitive, but defined only for sessions |
+| ADR-0029 | Artifact contract: delivery verification | No integration with status/health model |
+
+The consequence is visible in the UI today:
+
+- **Issue #1176**: "Failed + Healthy" badge stack. These are two
+  correct statements from two separate axes displayed as if they were
+  one status. Users read it as contradictory.
+- **Issue #1162**: Dashboard "Stale: 0" contradicts "1 stuck >60m"
+  because two different detectors evaluate staleness with different
+  thresholds and different entity scopes.
+- **Issue #1161**: Show status reads "Active" from SQLite while the
+  detail page reads "Merged" from `_show.md`. Two sources, no
+  reconciliation, no single model.
+
+The Attention Queue (ADR-0030) cannot be built correctly without a
+unified state model. It needs to sort items by severity across entity
+types — runs, shows, plays, schedules, teams. If each entity type
+computes severity differently, the queue is incoherent.
+
+## Decision
+
+### Separate entity state into three orthogonal dimensions
+
+Every operational entity (run/session, show, play, invocation, schedule,
+team) carries a **normalized state** composed of three independent fields
+plus a reason chain:
+
+```text
+lifecycle_status × process_health × delivery_state → severity
+                                                    + reason_code[]
+                                                    + evidence_ref[]
+```
+
+These dimensions answer different operator questions:
+
+| Dimension | Question | Example values |
+|-----------|----------|----------------|
+| `lifecycle_status` | Did the work finish? What happened? | `running`, `completed`, `failed`, `timed_out`, `cancelled`, `aborted` |
+| `process_health` | Is the runtime/process okay? | `ok`, `running`, `idle`, `stalled`, `process_dead`, `orphaned` |
+| `delivery_state` | Did it produce required outputs? | `passed`, `partial`, `missing`, `invalid`, `not_expected` |
+
+`severity` and `tone` are derived, never stored:
+
+| Field | Purpose | Values |
+|-------|---------|--------|
+| `severity` | Determines placement and attention priority | `critical`, `warning`, `info`, `neutral` |
+| `tone` | Determines badge/indicator color | `danger`, `warning`, `info`, `success`, `neutral` |
+
+### NormalizedState schema
+
+```python
+@dataclass
+class NormalizedState:
+    lifecycle: str
+
+    outcome: str | None = None
+    # succeeded | completed | merged | failed | timed_out
+    # | cancelled | aborted | skipped | unknown
+
+    health: str | None = None
+    # ok | running | idle | degraded | stalled
+    # | process_dead | orphaned | disconnected | unknown
+
+    delivery: str | None = None
+    # passed | partial | missing | invalid | not_expected | unknown
+
+    severity: str = "neutral"
+    # critical | warning | info | neutral
+
+    tone: str = "neutral"
+    # danger | warning | info | success | neutral
+
+    reasons: list[StateReason] = field(default_factory=list)
+
+    evaluated_at: float = 0.0
+    policy_version: str = "v1"
+    source: str = "backend"
+    # backend | frontend_compat
+
+
+@dataclass
+class StateReason:
+    code: str               # structured: "run.failed.exit_nonzero"
+    message: str            # human: "Exit code 124 from python-tests"
+    claim_status: str = "observed"
+    # observed | inferred | hypothesis | verified | disputed | superseded
+    confidence: float = 1.0
+    # Confidence in this REASON explaining the state.
+    # Distinct from Claim.confidence in ADR-0039, which measures
+    # confidence in a learned fact being true.
+    entity_type: str | None = None
+    entity_id: str | None = None
+    evidence: list[EvidenceRef] = field(default_factory=list)
+
+
+@dataclass
+class EvidenceRef:
+    kind: str
+    # Allowed kinds:
+    #   message        — chat message in a session
+    #   user_statement — explicit user assertion
+    #   tool_result    — output from a tool call
+    #   artifact       — produced file/report
+    #   url            — web resource (include fetched_at, content_hash if available)
+    #   file           — local file (include repo, commit_sha if available)
+    #   model_inference — agent reasoning step
+    #   human_assertion — human verified externally
+
+    id: str | None = None
+    session_id: str | None = None
+    message_id: str | None = None
+    tool_call_id: str | None = None
+    artifact_id: str | None = None
+    path: str | None = None
+    url: str | None = None
+    repo: str | None = None
+    commit_sha: str | None = None
+    content_hash: str | None = None
+    fetched_at: float | None = None
+    detail: str | None = None
+    # Kind-specific descriptor:
+    #   message         → relevant quote
+    #   tool_result     → result summary
+    #   model_inference → reasoning rationale
+    #   user_statement  → paraphrased assertion
+    #   artifact        → contract violation detail or note
+    #   human_assertion → assertion text
+```
+
+### Severity derivation heuristic
+
+Severity is computed from the three dimensions using a deterministic
+priority cascade. The most severe condition wins:
+
+```python
+def derive_severity(state: NormalizedState) -> tuple[str, str]:
+    """Returns (severity, tone)."""
+
+    # Critical conditions
+    if state.outcome in ("failed", "aborted"):
+        return ("critical", "danger")
+    if state.health in ("process_dead", "orphaned"):
+        return ("critical", "danger")
+    if state.delivery == "missing":
+        return ("critical", "danger")
+    if state.health == "stalled":
+        return ("critical", "danger")
+    if state.health == "misfired":
+        return ("critical", "danger")
+
+    # Warning conditions
+    if state.outcome == "timed_out":
+        return ("warning", "warning")
+    if state.health in ("idle", "degraded", "disconnected"):
+        return ("warning", "warning")
+    if state.delivery in ("partial", "invalid"):
+        return ("warning", "warning")
+
+    # Info conditions
+    if state.health == "running":
+        return ("info", "info")
+    if state.health == "due":
+        return ("info", "info")
+    if state.outcome == "skipped":
+        return ("info", "neutral")
+
+    # Success conditions
+    if state.outcome in ("succeeded", "completed", "merged"):
+        return ("neutral", "success")
+
+    # Cancelled is intentional, not a problem
+    if state.outcome == "cancelled":
+        return ("neutral", "neutral")
+
+    return ("neutral", "neutral")
+```
+
+The relationship between `severity` (4 values) and `tone` (5 values):
+
+| severity | possible tones | when |
+|----------|---------------|------|
+| critical | danger | failures, dead processes, missing artifacts, stalls |
+| warning | warning | timeouts, partial delivery, idle/degraded/disconnected |
+| info | info, neutral | running, skipped |
+| neutral | success, neutral | succeeded/completed/merged, cancelled, unknown |
+
+Severity drives placement (attention queue inclusion, sort order, row border). Tone drives visual treatment (badge color). Both are pure functions of the three operational dimensions.
+
+### Claim severity (knowledge, not operations)
+
+Knowledge claims have their own severity derivation, defined in [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md). It is a parallel function, not unified with `derive_severity()` above, because claims are not operational entities — their severity is about knowledge health (disputed, low-confidence, superseded), not work health.
+
+Both severity functions emit into the same Attention Queue ([ADR-0030](ADR-0030-attention-queue.md)) using identical `severity` and `tone` values.
+
+### Per-entity lifecycle vocabularies
+
+Each entity type defines its allowed lifecycle states. The `outcome`
+field uses the entity-specific terminal status:
+
+#### Runs / Sessions
+
+```text
+Lifecycle: pending → running → completed | failed | timed_out | cancelled | aborted
+Health:    ok | running | idle | stalled | process_dead | orphaned
+Delivery:  passed | partial | missing | not_expected
+```
+
+Extends ADR-0025's six-value vocabulary unchanged. ADR-0024's health
+classification maps directly to the `health` field.
+
+#### Shows
+
+```text
+Lifecycle: draft → planned → active → completed | merged | failed | archived
+Health:    ok | running | blocked
+Delivery:  passed | partial | missing | not_expected
+```
+
+#### Plays
+
+```text
+Lifecycle: planned → queued → running → run_complete → merged | failed | blocked | timed_out | cancelled | skipped
+Health:    ok | running | stalled
+Delivery:  passed | partial | missing | not_expected
+```
+
+#### Invocations
+
+```text
+Lifecycle: pending → running → succeeded | failed | timed_out | cancelled | skipped
+Health:    (not applicable — invocations are short-lived)
+Delivery:  (not applicable)
+```
+
+#### Schedules
+
+```text
+Lifecycle: enabled → paused → disabled
+Health:    ok | due | running | misfired
+Delivery:  (last_run_outcome carries delivery state)
+```
+
+#### Teams
+
+```text
+Lifecycle: active → idle → blocked → closed
+Health:    ok | orphaned
+Delivery:  (not applicable)
+```
+
+### State transition validity
+
+Lifecycle transitions are NOT arbitrary. Each entity type has a state machine; the backend rejects invalid transitions. This addresses issues #1162, #1171, #1172, #1176 — sessions stuck in null/non-terminal states because nothing enforced terminal transitions.
+
+**Enforcement points**:
+
+1. **Write-side**: Any code path writing a lifecycle value MUST go through `state.transition(entity_type, entity_id, new_lifecycle, reason)`. Direct UPDATE on `status` columns is forbidden (enforced by code review, not SQL).
+2. **Terminal enforcement**: When a process exits or a watchdog detects death, the corresponding lifecycle MUST land in a terminal value within the entity's vocabulary. Sessions that exit without a terminal status are auto-transitioned to `aborted` with reason `system.health.process_dead_no_terminal`.
+3. **Phantom reconciliation**: A reaper job (per [ADR-0024](ADR-0024-session-health-and-admin-surface.md)) detects entities with non-terminal lifecycle AND `health in (process_dead, orphaned)` AND age > threshold. These are auto-transitioned to `aborted` with appropriate reason.
+
+**Per-entity transition graphs**: Live in `lionagi/state/transitions/` as one module per entity type. Each module exports a `VALID_TRANSITIONS: dict[str, set[str]]` mapping current → allowed nexts. The protocol does not specify them inline because they evolve with operational learning; the modules are version-controlled and tested.
+
+### Reason code namespace
+
+Reason codes use a hierarchical dot-separated namespace:
+
+```json
+{entity_type}.{dimension}.{cause}
+```
+
+Examples:
+
+| Code | Meaning |
+|------|---------|
+| `run.failed.exit_nonzero` | Process exited with non-zero code |
+| `run.failed.artifact_contract` | Required artifact not produced (ADR-0029) |
+| `run.health.process_dead` | PID check failed, process no longer running |
+| `run.health.stalled` | No message activity beyond threshold |
+| `run.delivery.missing` | Expected output files not found |
+| `show.failed.critical_path_blocked` | A critical-path play failed |
+| `play.blocked.dependency_failed` | Upstream play in `depends_on` failed |
+| `play.blocked.dependency_invalid` | Upstream play name in `depends_on` doesn't exist |
+| `schedule.health.misfired` | Scheduled fire time passed without execution |
+| `team.health.orphaned` | Team's parent show/play is terminal but team is still active |
+| `knowledge.disputed.conflicting_evidence` | Claim has evidence refs supporting contradictory positions |
+| `knowledge.disputed.user_rejection` | Human operator marked claim disputed |
+| `knowledge.superseded.newer_observation` | Newer claim with stronger evidence replaced this one |
+| `knowledge.stale.unverified_too_long` | Claim aged past verification budget without confirmation |
+
+**Authoritative registry**: The complete reason-code namespace lives in `lionagi/state/reason_codes.py` as a Python module (one constant per code with docstring). The table above is illustrative; the module is canonical. Any code emitted at runtime MUST appear in the registry — this is enforced by a unit test.
+
+New codes can be added without schema changes. The namespace convention
+is enforced by validation, not by SQL CHECK.
+
+### Backend owns state evaluation
+
+The backend computes `NormalizedState` for every entity and includes it
+in API responses. The frontend renders it. This is the permanent
+architecture:
+
+```text
+Backend evaluates operational truth.
+Frontend renders it.
+```
+
+During migration, the frontend MAY contain a compatibility derivation
+layer (`compat_derive_*` functions) that fills in `NormalizedState` when
+the backend hasn't been updated yet. These functions MUST set
+`source = "frontend_compat"` so the transition is traceable.
+
+### State display contract
+
+The UI renders compound state as a flat chain, not stacked badges:
+
+```text
+Failed · Infra OK · Trace present
+Running · Stalled · Artifacts missing
+Completed · Artifact contract passed
+Timed out · No review.md produced
+```
+
+The first segment is always `outcome`. The second is `health` (omitted
+if `ok` and outcome is terminal). The third is `delivery` (omitted if
+`not_expected` or `passed` and outcome is terminal success).
+
+Severity determines:
+
+- Row left-border color
+- Attention queue inclusion
+- Sort priority in tables
+- Primary icon in badges
+
+Tone determines:
+
+- Badge background/text color
+
+## Consequences
+
+**Positive**
+
+- Single state model across all entity types — tables, dashboard,
+  attention queue, and detail pages all render the same `NormalizedState`.
+- "Failed + Healthy" becomes "Failed · Infra OK" — explicit and
+  non-contradictory.
+- Stale/stuck disagreement resolved: one heuristic, one threshold
+  config, one result.
+- Reason codes enable failure clustering (ADR-0030), queryable cause
+  analysis, and structured alerting.
+- Evidence refs connect state to proof — auditable.
+- Frontend compatibility layer makes migration incremental.
+
+**Negative**
+
+- Every API response grows by ~200 bytes per entity (the state object).
+- Backend must compute health and delivery on every read until indexed
+  materialized state is implemented.
+- Existing ADRs (0017, 0024, 0025, 0028) are partially superseded —
+  increases the ADR cross-reference burden.
+
+## Migration
+
+This ADR partially supersedes [ADR-0017](ADR-0017-session-lifecycle-status.md) and [ADR-0025](ADR-0025-session-status-vocabulary.md), and extends [ADR-0024](ADR-0024-session-health-and-admin-surface.md), [ADR-0028](ADR-0028-status-reason-model.md), [ADR-0029](ADR-0029-artifact-contract.md). Migration order:
+
+1. **Backend computes NormalizedState** for all entity reads. The three dimensions (lifecycle, health, delivery) source from existing columns or are computed inline. No DB migration required for read path.
+2. **Frontend compat derivation** lands as `compat_derive_normalized_state(entity)` functions, called when backend response lacks `NormalizedState`. All compat-derived states set `source = "frontend_compat"`.
+3. **Backend persistence migration**: ALTER TABLE adds health/delivery/reason_codes columns. Backfill computes from existing data. New writes use the new columns.
+4. **Frontend switches to backend-only rendering**. Compat layer removed entity-by-entity as backend coverage verified.
+5. **Legacy single-status field deprecated**. Reads still served for one release. Then removed.
+
+The frontend compat layer is the migration bridge. Both reads (backend has it / backend doesn't) are valid during the transition; the `source` field makes it traceable.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Keep dimensions separate (status + health as independent API fields) | Frontend still has to compose them; no single severity sort; "Failed + Healthy" persists |
+| Frontend-only derivation (no backend state computation) | Two browser tabs can derive different states from stale caches; no single source of truth for attention queue |
+| Store full NormalizedState as JSON column | Not queryable by individual fields; can't index on health or delivery |
+| Single flat status enum with 30+ values | Combinatorial explosion; can't independently query "all failed regardless of health" |
+
+## References
+
+- [ADR-0017](ADR-0017-session-lifecycle-status.md) — Session Lifecycle and Status Derivation (partially superseded)
+- [ADR-0024](ADR-0024-session-health-and-admin-surface.md) — Session Health Classification and Admin Surface (extended)
+- [ADR-0025](ADR-0025-session-status-vocabulary.md) — Session Status Vocabulary (fully superseded)
+- [ADR-0028](ADR-0028-status-reason-model.md) — Status Reason Model (extended)
+- [ADR-0029](ADR-0029-artifact-contract.md) — Artifact Contract (extended)
+- [ADR-0030](ADR-0030-attention-queue.md) — Attention Queue (consumes severity)
+- [ADR-0034](ADR-0034-frontend-data-and-state-architecture.md) — Frontend Data & State Architecture
+- [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) — Knowledge Substrate (parallel claim model)
+- Issue #1161: Show status stuck at "Active"
+- Issue #1162: Dashboard stale/stuck contradiction
+- Issue #1171: Terminal status enforcement
+- Issue #1172: Phantom session reaper
+- Issue #1176: "Failed + Healthy" contradictory badges
+
+## Appendix A: Current SQLite Implementation
+
+This appendix documents the current persistence layer ([ADR-0009](ADR-0009-sqlite-state-layer.md)). The DDL below is one storage implementation of `NormalizedState`; the contract is `NormalizedState` itself, not these columns. Future stores (Postgres, distributed) will materialize the same model differently. Treat this appendix as evolving with the data layer.
+
+```sql
+-- Add to sessions table
+ALTER TABLE sessions ADD COLUMN health       TEXT;
+ALTER TABLE sessions ADD COLUMN delivery     TEXT;
+ALTER TABLE sessions ADD COLUMN reason_codes JSON DEFAULT '[]';
+
+-- Add to plays table
+ALTER TABLE plays ADD COLUMN health       TEXT;
+ALTER TABLE plays ADD COLUMN delivery     TEXT;
+ALTER TABLE plays ADD COLUMN reason_codes JSON DEFAULT '[]';
+
+-- Composite index for attention queries
+CREATE INDEX IF NOT EXISTS idx_sessions_severity
+    ON sessions(status, health) WHERE status != 'completed';
+
+CREATE INDEX IF NOT EXISTS idx_plays_severity
+    ON plays(status, health) WHERE status NOT IN ('merged', 'skipped');
+```
+
+The `NormalizedState` object itself is computed at query time from the
+stored fields — not stored as a JSON blob. This keeps the columns
+queryable and indexable.

--- a/docs/adrs/ADR-0034-frontend-data-and-state-architecture.md
+++ b/docs/adrs/ADR-0034-frontend-data-and-state-architecture.md
@@ -1,0 +1,337 @@
+# ADR-0034: Frontend Data & State Architecture
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Depends on**: [ADR-0033](ADR-0033-unified-entity-state-model.md), current persistence layer (presently [ADR-0009](ADR-0009-sqlite-state-layer.md))
+**Related**: [ADR-0006](ADR-0006-sse-live-streaming.md), [ADR-0030](ADR-0030-attention-queue.md), [ADR-0035](ADR-0035-design-system-and-component-library.md), [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md)
+
+## Context
+
+Lion Studio's frontend fetches data with a plain `fetchJson` wrapper —
+no caching, no deduplication, no retry, no cache invalidation. Every
+page navigation re-fetches from the API. There is no real-time update
+mechanism: operators must manually refresh to see state changes.
+
+This creates three concrete problems:
+
+1. **No freshness guarantee.** The dashboard can show "0 failed" while
+   a run failed 30 seconds ago. An operator who trusts the dashboard
+   misses the failure.
+
+2. **No coordinated cache.** The dashboard fetches runs, shows, and
+   system health independently. A run status change doesn't invalidate
+   the dashboard summary or the attention queue. State drifts between
+   components.
+
+3. **No URL-addressable views.** Table filters, sort order, selected
+   entity, and inspector state are component-local. An operator cannot
+   share a link to "failed runs in project X, sorted by severity" with
+   a teammate.
+
+ADR-0033 defines backend-owned `NormalizedState` for every entity.
+This ADR specifies how that state flows to the frontend, stays fresh,
+and becomes URL-addressable.
+
+## Decision
+
+### Technology choices
+
+| Concern | Choice | Rationale |
+|---------|--------|-----------|
+| Server state | TanStack Query v5 | Key-based invalidation, direct cache patching via `setQueryData`, background revalidation, mutation lifecycle hooks |
+| Realtime transport | SSE (Server-Sent Events) | Unidirectional server→client telemetry; browser-native `EventSource` with reconnect; no WebSocket complexity |
+| Client state | URL params (shareable) + Zustand (ephemeral UI only) | URL is source of truth for anything a teammate should see; Zustand for transient UI like toast queue and sidebar collapse |
+| State truth | Backend-owned NormalizedState ([ADR-0033](ADR-0033-unified-entity-state-model.md)) | Frontend renders; frontend does not compute operational severity. Transitional compat layer permitted during backend rollout per ADR-0033 migration plan |
+
+### Four state classes
+
+Frontend state is partitioned into four classes with strict ownership:
+
+| Class | Examples | Owner | Persistence |
+|-------|----------|-------|-------------|
+| Authoritative operational | Runs, shows, plays, system health, attention | Backend via TanStack Query | Query cache (memory) |
+| Derived judgments | Severity, attention inclusion, staleness | Backend (permanent) or frontend compat layer (transitional) | Computed from Class 1 |
+| View state | Filters, sort, selected entity, inspector tab, time range | URL search params | URL |
+| UI preference | Theme, table density, column visibility | localStorage | localStorage |
+
+Rule: **If state affects what an operator believes about system health,
+it must come from the backend or be explicitly marked as stale/local.**
+
+### Query key factory
+
+All query keys use a typed factory. No hand-written string arrays.
+
+```typescript
+export const qk = {
+  dashboard: {
+    summary: (scope: string, range: string) =>
+      ["dashboard", "summary", { scope, range }] as const,
+  },
+  runs: {
+    list: (params: RunListParams) =>
+      ["runs", "list", canonicalize(params)] as const,
+    detail: (id: string) =>
+      ["runs", "detail", id] as const,
+  },
+  shows: {
+    list: (params: ShowListParams) =>
+      ["shows", "list", canonicalize(params)] as const,
+    detail: (id: string) =>
+      ["shows", "detail", id] as const,
+    plays: (id: string) =>
+      ["shows", "detail", id, "plays"] as const,
+  },
+  invocations: {
+    list: (params: InvocationListParams) =>
+      ["invocations", "list", canonicalize(params)] as const,
+    detail: (id: string) =>
+      ["invocations", "detail", id] as const,
+  },
+  teams: {
+    list: (params: TeamListParams) =>
+      ["teams", "list", canonicalize(params)] as const,
+  },
+  schedules: {
+    list: (params: ScheduleListParams) =>
+      ["schedules", "list", canonicalize(params)] as const,
+  },
+  knowledge: {
+    list: (scope: ScopeRef, status: string[]) =>
+      ["knowledge", "list", { scope, status }] as const,
+    detail: (id: string) =>
+      ["knowledge", "detail", id] as const,
+    byScope: (scopeType: string, scopeId: string) =>
+      ["knowledge", "byScope", { scopeType, scopeId }] as const,
+  },
+  library: {
+    list: (params: LibraryListParams) =>
+      ["library", "list", canonicalize(params)] as const,
+  },
+  search: {
+    cross: (params: SearchParams) =>
+      ["search", "cross", canonicalize(params)] as const,
+  },
+} as const;
+```
+
+`canonicalize()` sorts object keys so equivalent filters produce
+identical cache keys.
+
+### Dashboard summary endpoint
+
+The dashboard uses a single backend-computed summary, not coordinated
+frontend queries:
+
+```text
+GET /api/dashboard/summary?project=all&range=24h
+```
+
+Returns: attention items, metrics, active runs, at-risk shows,
+at-risk schedules, system health, recent activity, inventory counts.
+
+The `AttentionQueue`, `OpsSnapshotGrid`, and risk panels all read
+from the same summary object. No race conditions between independent
+queries.
+
+### SSE architecture
+
+One central `EventSource` per active project scope. Components do NOT subscribe independently.
+
+```text
+GET /api/events?project=all
+Accept: text/event-stream
+```
+
+A `StudioRealtimeProvider` opens the stream and dispatches events to TanStack Query's cache.
+
+#### Event envelope
+
+Every event uses this shape:
+
+```typescript
+type StudioEvent = {
+  id: string;                          // for Last-Event-ID resume
+  type: StudioEventType;
+  scope: { project: string };
+  invalidates: QueryKey[];             // cache keys to refresh
+  patch?: { key: QueryKey; data: unknown };  // optional direct cache patch
+  version?: number;                    // for race-resolution with mutations
+  emitted_at: number;
+};
+```
+
+#### Event type taxonomy
+
+Events are namespaced by entity type:
+
+| Namespace | Events |
+|-----------|--------|
+| `run.*` | `created`, `updated`, `completed`, `failed`, `cancelled`, `aborted` |
+| `play.*` | `updated`, `blocked`, `merged`, `failed` |
+| `show.*` | `updated`, `merged`, `failed` |
+| `invocation.*` | `updated`, `completed`, `failed` |
+| `schedule.*` | `due`, `fired`, `misfired` |
+| `team.*` | `created`, `closed`, `orphaned` |
+| `attention.*` | `added`, `cleared`, `severity_changed` |
+| `knowledge.*` | `created`, `verified`, `disputed`, `superseded` |
+| `system.*` | `health_changed`, `resync_required` |
+
+The `knowledge.*` events feed the Knowledge lens (see [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md)) and may also generate attention queue items (e.g., a claim transitioning to `disputed` is attention-worthy).
+
+#### Dispatch strategy
+
+- **Row-level updates** (e.g., `run.updated` with `patch`): Direct cache patch via `setQueryData`. No debounce — operators should see failures immediately.
+- **Aggregate invalidation** (`invalidates: ["dashboard", "summary", ...]`): Debounced (250-500ms) `invalidateQueries`. Debounce key is the stringified query key; rapid identical invalidations coalesce.
+
+#### Mutation/SSE race resolution
+
+A mutation's success handler patches the cache; the SSE event for the same change may arrive milliseconds later. Both code paths apply IDEMPOTENT patches with the same shape, so re-application is harmless. Where order matters (e.g., user sees an optimistic patch and then a server-corrected one), the `version` field on the event resolves: higher version wins, lower version is ignored.
+
+#### Disconnect behavior
+
+1. Status → `reconnecting` after 0s
+2. Compact global banner after 3s
+3. Fallback polling starts for operational queries (uses freshness budget "Disconnected poll" column)
+4. On reconnect, resume from `Last-Event-ID`
+5. If event gap exceeds retention (server-side), emit `system.resync_required` → full invalidation
+
+### Freshness budgets
+
+| Surface | SSE live | Disconnected poll | Stale warning |
+|---------|---------|-------------------|---------------|
+| Dashboard summary | 30s verification | 5s | 15s |
+| Show detail | 15s | 5s | 10s |
+| Runs table | 30s | 10s | 20s |
+| Run detail | 15s | 5s | 10s |
+| System health | 15s | 5s | 10s |
+| Library content | 5m | 60s | 10m |
+| Knowledge lens | 60s verification | 30s | 120s |
+
+Knowledge claims change on agent action, not continuously. A longer budget reflects this: a verified claim from 2 hours ago is not "stale" the way a session from 30 seconds ago might be.
+
+The UI renders freshness state on every operational surface:
+
+```text
+Live · verified 8s ago
+Disconnected · polling every 5s
+Stale · last verified 48s ago
+```
+
+### URL as state
+
+The URL owns all shareable view state:
+
+| Param | Purpose | Example |
+|-------|---------|---------|
+| `project` | Project scope | `project=lionagi` |
+| `range` | Time range | `range=24h` |
+| `q` | Search text | `q=exit%20124` |
+| `status` | Outcome filter | `status=failed,timed_out` |
+| `health` | Health filter | `health=stalled` |
+| `sort` | Sort order | `sort=-severity,-updated` |
+| `selected` | Selected entity | `selected=run:dad0dc05` |
+| `panel` | Inspector panel | `panel=logs` |
+
+URL state is validated through Zod schemas. Browser back/forward
+restores the full view state. Opening a shared link restores filters,
+sort, selected entity, and inspector tab.
+
+### Zustand scope
+
+Zustand holds ONLY ephemeral UI state:
+
+```typescript
+type UiStore = {
+  commandPaletteOpen: boolean;
+  sidebarCollapsed: boolean;
+  toasts: ToastState[];
+};
+```
+
+Zustand MUST NOT store runs, shows, schedules, or any operational data.
+
+### Mutations
+
+TanStack mutations for all write operations. No optimistic success for
+destructive or operationally meaningful actions:
+
+- Allowed: button shows "Cancelling...", row action disabled
+- Not allowed: immediately flipping Running → Cancelled before backend confirms
+
+On mutation success: patch detail cache, invalidate lists and dashboard.
+On mutation failure: inline row error + toast. Do not hide the row.
+
+### Cross-entity search
+
+```text
+GET /api/search?q=failed&project=all&range=1h&type=all
+```
+
+Returns results across runs, shows, plays, invocations, teams, schedules, library entities, AND knowledge claims. Each result carries its `NormalizedState` (operational entities) or `claim_status` (knowledge claims) for consistent severity rendering across the result set.
+
+Surfaced via `Cmd/Ctrl-K` command palette for quick navigation and
+a dedicated `/search` route for shareable result pages.
+
+### Backend-frontend sync contract
+
+Issues like #1161 (show status stuck at "Active"), #1167 (Runs page MODEL column empty), and #1177 (action panel auto-synthesis) reveal a sync-contract gap: the backend has data, the frontend doesn't render it. This section makes the contract explicit.
+
+**Three sync modes, used together**:
+
+| Mode | When | Mechanism |
+|------|------|-----------|
+| **Pull on access** | User navigates to a route | Route loader fires the relevant TanStack Query; cache-first if fresh, network if stale |
+| **Push on change** | Server-side event | SSE event from `StudioRealtimeProvider` patches or invalidates affected cache keys |
+| **Reconcile on interval** | Long-disconnected client | Disconnected polling per freshness budget; on reconnect, resync from `Last-Event-ID` or full re-fetch |
+
+**No mode operates alone**. Every operational surface uses (Pull on access) + (Push on change), with (Reconcile on interval) as the disconnected fallback. The `data-freshness-badge` (defined in [ADR-0035](ADR-0035-design-system-and-component-library.md)) reflects which mode is currently authoritative.
+
+**Contract guarantees**:
+
+- A backend write becomes visible to the frontend within the SSE freshness budget for that entity (e.g., 15s for Show detail). If SSE is disconnected, within the poll interval (5s for Show detail).
+- The displayed `NormalizedState` is never more than one budget cycle stale; staler than that, the freshness badge transitions to `stale` and the operator sees the warning.
+- Mutations patch the cache synchronously on success; SSE for the same change arriving later is a no-op (idempotent re-patch).
+
+## Consequences
+
+**Positive**
+
+- Single cache for operational state — no drift between dashboard
+  and detail pages.
+- SSE provides near-instant failure visibility without polling overhead.
+- URL-addressable views enable operational collaboration ("look at this
+  filtered view").
+- Freshness indicators prevent false confidence in stale data.
+- Query key factory prevents cache key collisions and enables precise
+  invalidation.
+
+**Negative**
+
+- TanStack Query adds ~40KB to the bundle (gzipped).
+- Zustand adds ~2KB.
+- SSE requires a new backend endpoint and event persistence table.
+- Dashboard summary endpoint requires backend implementation before
+  the frontend migration can complete.
+- URL state adds complexity to every table/filter component.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| SWR instead of TanStack Query | No built-in mutation lifecycle hooks; less precise cache invalidation |
+| WebSocket instead of SSE | Bidirectional not needed; SSE has native browser reconnect; lower complexity |
+| Redux for all state | Too much ceremony for the state we actually have; most state is server-owned |
+| Per-component polling | Race conditions between components; no cache coordination; O(n) API calls |
+| localStorage for view state | Not shareable; no deep linking; doesn't survive incognito |
+
+## References
+
+- [ADR-0006](ADR-0006-sse-live-streaming.md) — SSE Live Streaming (event transport)
+- [ADR-0009](ADR-0009-sqlite-state-layer.md) — SQLite State Layer (current backend persistence)
+- [ADR-0030](ADR-0030-attention-queue.md) — Attention Queue
+- [ADR-0033](ADR-0033-unified-entity-state-model.md) — Unified Entity State Model
+- [ADR-0035](ADR-0035-design-system-and-component-library.md) — Design System & Component Library
+- [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) — Knowledge Substrate
+- TanStack Query v5 documentation
+- MDN: Using Server-Sent Events
+- Issue #1161, #1167, #1177 — backend-frontend sync gaps addressed by §Backend-frontend sync contract

--- a/docs/adrs/ADR-0035-design-system-and-component-library.md
+++ b/docs/adrs/ADR-0035-design-system-and-component-library.md
@@ -1,0 +1,336 @@
+# ADR-0035: Design System and Component Library
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Supersedes**: [ADR-0013](ADR-0013-zero-dependency-ui.md) (zero-component-library UI) — for product surfaces
+**Depends on**: [ADR-0033](ADR-0033-unified-entity-state-model.md) (renders NormalizedState)
+**Related**: [ADR-0031](ADR-0031-entity-header-pattern.md), [ADR-0034](ADR-0034-frontend-data-and-state-architecture.md), [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md)
+
+## Context
+
+ADR-0013 chose zero external component dependencies: no Radix, no
+shadcn, no headless UI. The rationale was that Studio is a power-user
+tool with one primary user, and custom components keep bundle size
+minimal and control total.
+
+That assumption no longer holds. The frontend now requires:
+
+- **Dialogs** for confirmation actions (ADR-0031 entity actions)
+- **Dropdown menus** for row actions in tables
+- **Popovers** for filter chips and column pickers
+- **Comboboxes** for project scope selection and search
+- **Tooltips** for status badges and graph nodes
+- **Command palette** for keyboard-first navigation
+- **Focus traps** for modals and drawers
+- **Roving tabindex** for table row navigation
+
+Each of these requires correct ARIA roles, keyboard handling, focus
+management, and screen reader announcements. Building them from scratch
+is a multi-week effort that produces worse accessibility than existing
+headless libraries designed specifically for this purpose.
+
+ADR-0013 itself noted: "This trade-off would not be acceptable for a
+public-facing product." The product direction has now changed — Studio
+is becoming the operational interface, not just Ocean's local tool.
+
+## Decision
+
+### Component architecture
+
+```text
+components/ui/      — generic primitives (shadcn/ui source-owned)
+components/lion/    — domain-aware design system
+features/*/         — product surfaces (import from lion/, never from Radix directly)
+```
+
+**This ADR is the canonical owner of `components/lion/`**. Future feature ADRs that introduce new domain components MUST amend this ADR's component list (PR against §Domain components below). The catalog must remain discoverable in one place; scattering definitions across feature ADRs is the failure mode this rule prevents.
+
+### Primitive layer: shadcn/ui
+
+Use shadcn/ui as source-owned primitives. shadcn is not a dependency —
+it generates component source files that we own and modify. The
+underlying accessibility primitives come from Radix.
+
+Adopted primitives:
+
+| Primitive | Source | Use case |
+|-----------|--------|----------|
+| Button | shadcn | All buttons |
+| Badge | shadcn | Metadata labels (model, source, version) |
+| Dialog | shadcn/Radix | Confirmation actions, entity details |
+| DropdownMenu | shadcn/Radix | Row actions, context menus |
+| Popover | shadcn/Radix | Filter chips, column picker |
+| Tooltip | shadcn/Radix | Status explanations, graph node details |
+| Command | shadcn/Radix | Cmd/Ctrl-K command palette |
+| Tabs | shadcn/Radix | Inspector panels, detail page sections |
+| Sheet | shadcn/Radix | Mobile sidebar, inspector drawer |
+
+NOT adopted (use existing custom):
+
+| Component | Reason |
+|-----------|--------|
+| Table | TanStack Table + custom markup for `LionDataTable` |
+| Form inputs | Existing custom inputs are sufficient for current scope |
+| Toast | Existing Toast provider works; migrate later if needed |
+
+### Domain components: `components/lion/`
+
+These encode Lion Studio's operational semantics:
+
+```text
+lion/
+  status-badge.tsx        — single status with tone + icon
+  state-stack.tsx          — compound state: "Failed · Infra OK · Trace present"
+  severity-indicator.tsx   — left-border severity accent
+  data-table/
+    lion-data-table.tsx    — TanStack Table wrapper with toolbar, filters, URL sync
+    table-toolbar.tsx      — search, filter chips, column picker, density toggle
+    table-pagination.tsx   — cursor pagination
+  object-header.tsx        — universal detail page header (ADR-0031)
+  object-lineage.tsx       — clickable breadcrumb chips
+  attention-item.tsx       — attention queue row
+  data-freshness-badge.tsx — "Live · verified 8s ago"
+  section-boundary.tsx     — per-section error boundary
+  connection-banner.tsx    — SSE disconnect indicator
+  knowledge/
+    knowledge-lens.tsx          — contextual claim listing for an entity scope
+    claim-card.tsx              — single claim with status, confidence, evidence count
+    claim-status-badge.tsx      — observed | inferred | hypothesis | verified | disputed | superseded
+    evidence-trail.tsx          — expandable list of EvidenceRefs with source links
+    confidence-meter.tsx        — visual confidence indicator (0.0–1.0)
+```
+
+The `knowledge/*` components implement the behavioral spec from [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) §"Product Implications". This ADR owns the catalog and rendering rules; ADR-0039 owns the data model and behavioral semantics.
+
+Rule: No feature component imports Radix directly. If a shared
+primitive doesn't exist yet, add it to `components/ui/` first.
+
+### Table engine: TanStack Table
+
+TanStack Table provides headless table logic (sorting, filtering,
+pagination, column visibility, row selection). Lion Studio provides
+the markup and Tailwind styling via `LionDataTable`.
+
+Relationship to shadcn's DataTable:
+
+- shadcn's `Table` component provides markup primitives (`<Table>`,
+  `<TableHeader>`, `<TableRow>`, `<TableCell>`)
+- `LionDataTable` wraps TanStack Table logic + shadcn Table markup +
+  Lion-specific toolbar, URL sync, density modes, and row actions
+
+### Status badge contract
+
+Generic `Badge` (shadcn) is for metadata labels: `codex/gpt-5.5`,
+`local`, `v1.0.0`. Never for operational status.
+
+Operational status uses domain components:
+
+```tsx
+<StatusBadge tone="danger" icon={XCircle}>Failed</StatusBadge>
+
+<StateStack
+  outcome="failed"
+  health="ok"
+  delivery="present"
+/>
+// Renders: "Failed · Infra OK · Trace present"
+```
+
+Status rendering rules:
+
+- Never use color alone — always icon + text + color
+- Dark mode does not change status semantics
+- Critical/warning states always have icons
+- Reduced motion disables pulse/spin animations
+
+### Semantic color tokens
+
+Extend existing CSS custom properties (which already exist in
+`globals.css`) to use the `--ls-` prefix for the severity system:
+
+```css
+:root {
+  --ls-critical-bg: ...;
+  --ls-critical-border: ...;
+  --ls-critical-text: ...;
+  --ls-critical-accent: ...;
+  /* warning, info, success, neutral variants */
+  --ls-focus-ring: ...;
+}
+.dark {
+  /* dark variants of all above */
+}
+```
+
+Components reference semantic tokens, not raw Tailwind colors:
+
+```text
+Good: bg-[var(--ls-critical-bg)]
+Bad:  bg-red-50
+```
+
+**Prefix decision**: `--ls-` is the canonical design-token namespace. Lion Studio mode (open-source) uses these directly. KHive product mode inherits the same tokens but may override values in `themes/khive.css`. Token NAMES stay stable across product modes; only their VALUES vary.
+
+The existing design token system in `globals.css` already uses CSS
+custom properties with dark mode via `.dark` class. This ADR extends
+that system with the severity-specific tokens, not replaces it.
+
+### Semantic palette: status colors
+
+The severity → tone mapping in [ADR-0033](ADR-0033-unified-entity-state-model.md) determines color category. The concrete color values are defined here as the canonical palette:
+
+| Tone | Light mode | Dark mode | Usage |
+|------|-----------|-----------|-------|
+| `danger` | red-700 / red-100 bg | red-300 / red-950 bg | failed, aborted, dead, missing |
+| `warning` | amber-700 / amber-100 bg | amber-300 / amber-950 bg | timed_out, partial, stalled, disputed |
+| `info` | blue-700 / blue-100 bg | blue-300 / blue-950 bg | running, due, observed |
+| `success` | green-700 / green-100 bg | green-300 / green-950 bg | succeeded, completed, merged, verified |
+| `neutral` | gray-700 / gray-100 bg | gray-300 / gray-900 bg | cancelled, skipped, unknown, hypothesis |
+
+These map directly to CSS custom properties: `--ls-danger-text`, `--ls-danger-bg`, `--ls-warning-text`, etc. Components NEVER reference raw Tailwind color classes for status; they reference these semantic tokens.
+
+**Knowledge-specific tones** follow the same palette:
+
+- `observed` → info (assumes clean evidence)
+- `inferred` → info (with reduced opacity to signal lower certainty)
+- `hypothesis` → neutral (typed honestly, low confidence)
+- `verified` → success
+- `disputed` → warning
+- `superseded` → neutral (archived, not failed)
+
+This palette is the source of truth. Issues #1178, #1179 (filter chip colors, graph node colors) MUST consume from this palette, not invent local colors.
+
+### Dark mode
+
+Already supported via `darkMode: "class"` in `tailwind.config.ts`.
+Extend with:
+
+- Pre-hydration inline script to apply `.dark` before React renders
+  (prevents flash of wrong theme)
+- Theme preference: `light | dark | system`, stored in localStorage
+- System preference via `prefers-color-scheme` media query
+- Theme toggle in nav showing resolved state: "System · Dark"
+
+### Accessibility target: WCAG 2.2 AA
+
+Non-negotiable rules:
+
+- Never use color alone to communicate state (every status has icon + text + color)
+- Focus state visible on every interactive element
+- Keyboard can reach every action
+- Tables use semantic `<table>` markup with `aria-sort`
+- Live updates use `aria-live` (assertive for critical, polite for info)
+- Graph has keyboard navigation AND table fallback
+- Reduced motion: `prefers-reduced-motion` disables all animations
+
+**Verification strategy** (addresses issue #1020 — 47 a11y findings):
+
+| Layer | Tool | Gate |
+|-------|------|------|
+| Static (CI) | `eslint-plugin-jsx-a11y` | Block merge on `error` level |
+| Component (CI) | `@testing-library/jest-dom` + `jest-axe` | Each `components/lion/*` has an a11y test |
+| Page (manual + CI) | Lighthouse / Axe DevTools | Score ≥95 on Dashboard, Runs, Show detail |
+| Live | Manual screen reader sweep (VoiceOver, NVDA) | Quarterly, owned by frontend lead |
+
+Component-level a11y test pattern:
+
+```typescript
+import { axe } from "jest-axe";
+
+it("StatusBadge has no axe violations", async () => {
+  const { container } = render(<StatusBadge tone="danger" icon={XCircle}>Failed</StatusBadge>);
+  expect(await axe(container)).toHaveNoViolations();
+});
+```
+
+Every component in `components/lion/` MUST ship with an a11y test. Components in `components/ui/` (shadcn primitives) inherit Radix's verified a11y but get smoke tests for our customizations.
+
+### Keyboard-first interaction
+
+Scoped shortcut system with priority ordering:
+
+```text
+Dialog/modal > Editor/input > Graph > Table > Page > Global
+```
+
+Core shortcuts (ship in v1):
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd/Ctrl-K` | Command palette |
+| `?` | Keyboard help |
+| `/` | Focus search |
+| `g d` | Go to Dashboard |
+| `g r` | Go to Runs |
+| `g s` | Go to Shows |
+| `j/k` | Table row navigation |
+| `Enter` | Open selected |
+| `Esc` | Clear selection / close overlay |
+
+Shortcut rules:
+
+- No printable shortcuts fire inside input/textarea/contenteditable
+- `Cmd/Ctrl-K` always opens command palette unless modal captures it
+- `Escape` closes innermost overlay
+
+### Error boundaries
+
+Per-section on dashboard and detail pages. Page-level only when
+primary entity cannot load.
+
+```text
+System health fails but runs load:
+  → SystemHealthPanel shows inline error
+  → AttentionQueue adds "System health unavailable" item
+  → Rest of dashboard renders normally
+
+All API calls fail:
+  → Full-page "Backend unreachable" with last cached timestamp
+```
+
+### Loading states
+
+Section-level skeletons. Never blank an entire page during background
+refresh. Keep last known data with "verifying..." freshness indicator
+during revalidation.
+
+## Consequences
+
+**Positive**
+
+- Correct accessibility from day one via Radix primitives
+- Keyboard-first interaction for operator efficiency
+- Consistent status rendering across all surfaces via domain components
+- Source-owned components (shadcn) — no locked dependencies
+- Dark mode with no flash
+
+**Negative**
+
+- Radix primitives add ~15-25KB (gzipped). Combined with [ADR-0034](ADR-0034-frontend-data-and-state-architecture.md)'s TanStack Query (~40KB) + Zustand (~2KB), total new bundle weight is ~60KB gzipped.
+- Migration effort: existing custom components need gradual replacement
+- [ADR-0013](ADR-0013-zero-dependency-ui.md)'s "zero dependency" principle is explicitly abandoned for product surfaces. Preserved as a constraint for any future ultra-light embed mode.
+- Catalog ownership concentrated in this ADR — feature ADRs MUST amend rather than fork. This creates merge contention in component-heavy phases; mitigated by clear catalog entries and small per-component PRs.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Continue zero-dependency (ADR-0013) | Accessibility debt grows with every new interactive component; ADR-0013 itself flagged this |
+| MUI / Ant Design / Chakra | Opinionated styling conflicts with existing Tailwind design system; large bundle |
+| Headless UI (Tailwind Labs) | Fewer primitives than Radix; no command palette; less active maintenance |
+| Build everything custom with correct ARIA | Multi-week effort per component; will produce worse a11y than battle-tested Radix |
+
+## References
+
+- [ADR-0013](ADR-0013-zero-dependency-ui.md) — Zero Component-Library UI (superseded by this ADR for product surfaces)
+- [ADR-0031](ADR-0031-entity-header-pattern.md) — Entity Header Pattern (consumes design system)
+- [ADR-0033](ADR-0033-unified-entity-state-model.md) — Unified Entity State Model (status/severity/tone semantics)
+- [ADR-0034](ADR-0034-frontend-data-and-state-architecture.md) — Frontend Data & State Architecture
+- [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) — Knowledge Substrate (claim/evidence components)
+- shadcn/ui documentation
+- Radix Primitives documentation
+- WCAG 2.2 — Contrast (Minimum), Focus Visible, Target Size
+- TanStack Table documentation
+- `eslint-plugin-jsx-a11y`, `jest-axe` — accessibility CI tooling
+- Issue #1020 — a11y baseline (driven by verification strategy above)
+- Issue #1168, #1178, #1179 — design system polish addressed via semantic palette

--- a/docs/adrs/ADR-0039-knowledge-substrate-minimal-interface.md
+++ b/docs/adrs/ADR-0039-knowledge-substrate-minimal-interface.md
@@ -1,0 +1,701 @@
+# ADR-0039: Knowledge Substrate Minimal Interface
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Depends on**: [ADR-0033](ADR-0033-unified-entity-state-model.md) (shared EvidenceRef definition)
+**Related**: [ADR-0028](ADR-0028-status-reason-model.md), [ADR-0029](ADR-0029-artifact-contract.md), [ADR-0030](ADR-0030-attention-queue.md), [ADR-0034](ADR-0034-frontend-data-and-state-architecture.md), [ADR-0035](ADR-0035-design-system-and-component-library.md)
+**Consumed by**: KHive v1 product (governed memory and evidence layer)
+
+## Context
+
+lionagi sessions produce rich activity traces (messages, tool calls, model
+responses) but no structured *knowledge*. The gap:
+
+| What exists | What's missing |
+|------------|----------------|
+| Messages (ephemeral conversation) | Claims (durable learned facts) |
+| DataLogger (activity audit trail) | Knowledge lifecycle (observed → verified → disputed → superseded) |
+| Tool results (raw output) | Evidence-backed assertions about what results *mean* |
+| Branch state (in-memory) | Cross-session retrieval ("what do we know about X?") |
+
+An agent that reviews 50 PRs learns nothing persistent. The next
+session starts cold. The operator can't ask "what has the agent learned
+about our codebase?" because there's no substrate to hold the answer.
+
+### The product thesis
+
+> KHive is the governed memory and evidence layer for internal agent
+> platforms.
+
+The knowledge substrate is what makes "governed memory" concrete. Without
+it, KHive is an observability dashboard (commodity). With it, KHive
+captures *what agents learn*, not just what they did.
+
+### Design constraints
+
+1. **Storage-agnostic.** The data layer will change (SQLite → Postgres →
+   distributed). The protocol MUST NOT leak storage assumptions.
+2. **Evidence-first.** No claim without at least one structured evidence
+   ref. This is the core opinion — it's what makes knowledge auditable.
+3. **Zero-config in library mode.** A developer using `Branch` in a
+   script should not need to configure anything. Knowledge methods exist
+   but are no-ops until a store is provided.
+4. **Branch-native.** Follows the existing 4-manager pattern. Becomes
+   the 5th manager, not an external add-on.
+5. **Tastefully opinionated.** The API surface guides users toward
+   correct usage patterns. Hard to misuse, easy to use well.
+
+## Decision
+
+### The Knowledge Protocol
+
+```python
+from typing import Protocol, runtime_checkable
+
+@runtime_checkable
+class KnowledgeStore(Protocol):
+    """Minimal protocol for durable knowledge persistence.
+
+    Implementations:
+      - NullKnowledgeStore: no-op (library default, zero overhead)
+      - MemoryKnowledgeStore: in-process dict (testing, short-lived scripts)
+      - SQLiteKnowledgeStore: local file (Studio mode)
+      - KHiveKnowledgeStore: governed remote (commercial product)
+    """
+
+    async def write_claim(
+        self,
+        claim: "Claim",
+    ) -> str:
+        """Persist a claim. Returns claim_id."""
+        ...
+
+    async def query(
+        self,
+        question: str,
+        *,
+        scope: "Scope | None" = None,
+        status: "list[str] | None" = None,
+        limit: int = 10,
+    ) -> "list[Claim]":
+        """Semantic retrieval of relevant claims."""
+        ...
+
+    async def transition(
+        self,
+        claim_id: str,
+        new_status: str,
+        *,
+        evidence: "list[EvidenceRef] | None" = None,
+        reason: str | None = None,
+    ) -> None:
+        """Move a claim through its lifecycle."""
+        ...
+
+    async def supersede(
+        self,
+        old_id: str,
+        new_id: str,
+    ) -> None:
+        """Mark old claim superseded by new one."""
+        ...
+
+    async def history(
+        self,
+        claim_id: str,
+    ) -> "list[ClaimEvent]":
+        """Return lifecycle events for a claim."""
+        ...
+```
+
+Five methods. That's the entire contract. Implementations can range from
+a dict to a distributed graph store.
+
+### The Claim dataclass
+
+```python
+from dataclasses import dataclass, field
+from uuid import uuid4
+
+@dataclass
+class Claim:
+    """A unit of learned knowledge with evidence and lifecycle."""
+
+    text: str
+    evidence: list[EvidenceRef]  # MUST be non-empty (enforced at construction)
+    claim_status: str = "observed"
+    confidence: float = 1.0
+    # Confidence in the CLAIM being true (the fact itself).
+    # Distinct from StateReason.confidence in ADR-0033, which measures
+    # confidence in a reason explaining an operational state.
+
+    # Auto-populated by Branch.learn()
+    id: str = field(default_factory=lambda: str(uuid4()))
+    project: str | None = None
+    scope_type: str | None = None  # project | repo | agent | run
+    scope_id: str | None = None
+    session_id: str | None = None
+    branch_id: str | None = None
+    actor_type: str = "agent"     # agent | user | system | tool
+    actor_id: str | None = None
+    created_at: float = 0.0
+
+    # Optional structured metadata
+    domain: str | None = None     # e.g., "codebase", "api", "policy"
+    tags: list[str] = field(default_factory=list)
+    supersedes: str | None = None
+
+    def __post_init__(self):
+        if not self.evidence:
+            raise ValueError(
+                "A Claim requires at least one EvidenceRef. "
+                "If evidence is truly absent, this is a hypothesis — "
+                "use kind='model_inference' with low confidence."
+            )
+```
+
+The `ValueError` on empty evidence is the core opinion. You physically
+cannot create a claim without evidence. Weak evidence is allowed (typed
+honestly), but empty evidence is not.
+
+### Claim lifecycle
+
+```text
+observed → verified       (human/trusted process confirms)
+observed → disputed       (conflicting evidence arrives)
+observed → superseded     (newer claim replaces)
+inferred → verified       (upgraded by external confirmation)
+inferred → disputed       (disproven)
+hypothesis → observed     (evidence found)
+hypothesis → disputed     (falsified)
+verified → disputed       (new contradicting evidence)
+disputed → verified       (resolution in favor)
+disputed → superseded     (both replaced)
+any → superseded          (factual replacement)
+```
+
+Transition validation is in the store implementation, not the protocol.
+The protocol just takes `new_status: str`. This keeps the protocol
+stable while implementations can enforce stricter rules.
+
+### Branch integration: the 5th manager
+
+```python
+class Branch:
+    def __init__(
+        self,
+        ...,
+        knowledge_store: KnowledgeStore | None = None,
+    ):
+        ...
+        self._knowledge_store = knowledge_store or NullKnowledgeStore()
+
+    async def learn(
+        self,
+        claim: str,
+        evidence: list[EvidenceRef],
+        *,
+        status: str = "observed",
+        confidence: float = 1.0,
+        domain: str | None = None,
+        tags: list[str] | None = None,
+    ) -> str | None:
+        """Record a learned fact with evidence. Returns claim_id.
+
+        This is the primary knowledge-write API. It enforces:
+        - Non-empty evidence (raises ValueError)
+        - Auto-populates session/branch/actor context
+        - Delegates to the configured KnowledgeStore
+
+        Returns None if store is NullKnowledgeStore (library mode).
+        """
+        c = Claim(
+            text=claim,
+            evidence=evidence,
+            claim_status=status,
+            confidence=confidence,
+            session_id=str(self._session_id) if self._session_id else None,
+            branch_id=str(self.id),
+            domain=domain,
+            tags=tags or [],
+            created_at=now_utc().timestamp(),
+        )
+        return await self._knowledge_store.write_claim(c)
+
+    async def recall(
+        self,
+        question: str,
+        *,
+        limit: int = 5,
+        status: list[str] | None = None,
+    ) -> list[Claim]:
+        """Retrieve relevant knowledge claims.
+
+        Default: returns only active claims (observed, inferred, verified).
+        Pass status=["disputed"] to include contested knowledge.
+        """
+        if status is None:
+            status = ["observed", "inferred", "verified"]
+        return await self._knowledge_store.query(
+            question, status=status, limit=limit
+        )
+
+    async def verify(
+        self, claim_id: str, evidence: list[EvidenceRef] | None = None
+    ) -> None:
+        """Upgrade a claim to verified status."""
+        await self._knowledge_store.transition(
+            claim_id, "verified", evidence=evidence
+        )
+
+    async def dispute(
+        self, claim_id: str, reason: str, evidence: list[EvidenceRef] | None = None
+    ) -> None:
+        """Mark a claim as disputed with reason."""
+        await self._knowledge_store.transition(
+            claim_id, "disputed", evidence=evidence, reason=reason
+        )
+```
+
+Four user-facing methods on Branch: `learn`, `recall`, `verify`, `dispute`.
+That's the tasteful opinion — small surface, hard to misuse.
+
+**Branch method → Store method mapping**:
+
+| Branch (user-facing) | Store (protocol) | Notes |
+|----------------------|------------------|-------|
+| `learn(claim, evidence, ...)` | `write_claim(Claim)` | Auto-populates session/branch context |
+| `recall(question, ...)` | `query(question, ...)` | Default filters out disputed/superseded |
+| `verify(claim_id, evidence)` | `transition(claim_id, "verified", evidence)` | Convenience wrapper |
+| `dispute(claim_id, reason, evidence)` | `transition(claim_id, "disputed", evidence, reason)` | Convenience wrapper |
+| — | `supersede(old_id, new_id)` | Store-only; agents propose new claims, admin/human executes supersession |
+| — | `history(claim_id)` | Store-only; lifecycle events surfaced via dedicated UI, not in-line agent flow |
+
+`supersede` and `history` are intentionally store-only. Agents shouldn't supersede their own claims; the next observation creates a new claim, and an explicit human/admin decision links them via supersession.
+
+**Session-level configuration is the primary entry point**:
+
+```python
+session = Session(
+    knowledge_store=SQLiteKnowledgeStore("~/.lionagi/knowledge.db"),
+)
+branch = session.new_branch(system="You are a researcher")
+# branch._knowledge_store == session._knowledge_store
+```
+
+When `Session.new_branch()` creates a Branch, it passes the session's `knowledge_store` to the new Branch. Per-Branch override is allowed for isolation testing (e.g., one Branch uses `NullKnowledgeStore` to opt out without affecting siblings):
+
+```python
+isolated_branch = session.new_branch(
+    system="Sandbox agent",
+    knowledge_store=NullKnowledgeStore(),  # override
+)
+```
+
+The default flow: configure the store ONCE at the Session level. The override is a power-user seam, not the common path.
+
+### The NullKnowledgeStore (zero-config default)
+
+```python
+class NullKnowledgeStore:
+    """No-op store. Library mode. Zero overhead."""
+
+    async def write_claim(self, claim: Claim) -> str | None:
+        return None
+
+    async def query(self, question, **kwargs) -> list[Claim]:
+        return []
+
+    async def transition(self, claim_id, new_status, **kwargs) -> None:
+        pass
+
+    async def supersede(self, old_id, new_id) -> None:
+        pass
+
+    async def history(self, claim_id) -> list:
+        return []
+```
+
+A developer using lionagi as a library pays zero cost. No config, no
+database, no setup. `branch.learn()` silently returns None. `branch.recall()`
+returns an empty list. The API exists but does nothing until you opt in.
+
+### Audit trail integration
+
+Every knowledge action (`learn`, `verify`, `dispute`, `supersede`) MUST emit a `Log` entry to the Branch's `DataLogger`. The KnowledgeStore handles claim persistence; the DataLogger captures the *action* of writing knowledge. This is what makes the evidence chain auditable end-to-end.
+
+Log entry shape:
+
+```python
+{
+  "event": "knowledge.learn" | "knowledge.verify" | "knowledge.dispute" | "knowledge.supersede",
+  "claim_id": str,
+  "claim_status": str,
+  "evidence_count": int,
+  "evidence_kinds": list[str],
+  "scope_type": str | None,
+  "scope_id": str | None,
+  "actor_type": str,
+  "actor_id": str | None,
+  "branch_id": str,
+  "session_id": str | None,
+  "timestamp": float,
+}
+```
+
+The Branch.learn() implementation emits this log entry before delegating to the store. Failures to write the log do NOT block the knowledge write; they emit a warning to the DataLogger's auxiliary error channel.
+
+Combined with [ADR-0033](ADR-0033-unified-entity-state-model.md)'s reason-code namespace (specifically `knowledge.*` codes), this gives operators a complete activity trail: who created what claim with what evidence, when it was verified or disputed, by whom.
+
+### The MemoryKnowledgeStore (testing/scripts)
+
+```python
+class MemoryKnowledgeStore:
+    """In-process dict store. For tests and short-lived scripts."""
+
+    def __init__(self):
+        self._claims: dict[str, Claim] = {}
+
+    async def write_claim(self, claim: Claim) -> str:
+        self._claims[claim.id] = claim
+        return claim.id
+
+    async def query(self, question, *, scope=None, status=None, limit=10):
+        results = list(self._claims.values())
+        if status:
+            results = [c for c in results if c.claim_status in status]
+        # Simple substring match for in-memory mode
+        if question:
+            results = [c for c in results if question.lower() in c.text.lower()]
+        return results[:limit]
+
+    async def transition(self, claim_id, new_status, *, evidence=None, reason=None):
+        if claim_id in self._claims:
+            self._claims[claim_id].claim_status = new_status
+
+    async def supersede(self, old_id, new_id):
+        if old_id in self._claims:
+            self._claims[old_id].claim_status = "superseded"
+            self._claims[old_id].supersedes = new_id
+
+    async def history(self, claim_id):
+        return []  # In-memory mode doesn't track history
+```
+
+### Evidence construction helpers (the opinionated part)
+
+```python
+def from_message(session_id: str, message_id: str, quote: str | None = None) -> EvidenceRef:
+    """Evidence from a chat message. The `quote` becomes EvidenceRef.detail."""
+    return EvidenceRef(kind="message", session_id=session_id, message_id=message_id, detail=quote)
+
+def from_tool_result(tool_call_id: str, summary: str | None = None) -> EvidenceRef:
+    """Evidence from a tool execution result. The `summary` becomes EvidenceRef.detail."""
+    return EvidenceRef(kind="tool_result", tool_call_id=tool_call_id, detail=summary)
+
+def from_user_statement(session_id: str, message_id: str) -> EvidenceRef:
+    """Evidence from an explicit user statement."""
+    return EvidenceRef(kind="user_statement", session_id=session_id, message_id=message_id)
+
+def from_artifact(artifact_id: str, path: str | None = None) -> EvidenceRef:
+    """Evidence from a produced artifact (file/report/output)."""
+    return EvidenceRef(kind="artifact", artifact_id=artifact_id, path=path)
+
+def from_file(path: str, repo: str | None = None, commit: str | None = None) -> EvidenceRef:
+    """Evidence from a file on disk or in a repo."""
+    return EvidenceRef(kind="file", path=path, repo=repo, commit_sha=commit)
+
+def from_url(url: str, fetched_at: float | None = None, content_hash: str | None = None) -> EvidenceRef:
+    """Evidence from a web resource."""
+    return EvidenceRef(kind="url", url=url, fetched_at=fetched_at, content_hash=content_hash)
+
+def from_model_inference(session_id: str, message_id: str, rationale: str) -> EvidenceRef:
+    """Evidence from model reasoning. The weakest kind — be honest about confidence."""
+    return EvidenceRef(kind="model_inference", session_id=session_id, message_id=message_id, detail=rationale)
+
+def from_human_assertion(user_id: str, asserted_at: float, detail: str | None = None) -> EvidenceRef:
+    """Evidence from a human's external assertion (e.g., 'I verified this manually')."""
+    return EvidenceRef(kind="human_assertion", id=user_id, fetched_at=asserted_at, detail=detail)
+```
+
+The helper name matches the `kind` value 1:1 — `from_X()` produces `EvidenceRef(kind="X")`. The naming makes the strength hierarchy visible: `from_file` and `from_artifact` (definitive) > `from_tool_result` (observed) > `from_url` (external, may rot without content_hash) > `from_message` and `from_user_statement` (situated in conversation) > `from_model_inference` (weakest — agent reasoning only).
+
+`from_human_assertion` is special: it's strong evidence (a human said so) but is only as good as the human's verification process. Use it sparingly and document the verification source.
+
+Eight helpers, eight kinds — see [ADR-0033](ADR-0033-unified-entity-state-model.md) §"EvidenceRef" for the canonical kind enumeration.
+
+### Reactive knowledge extraction (hook pattern)
+
+```python
+# Example: auto-extract knowledge from tool results
+async def extract_knowledge_hook(branch, message):
+    """Hook that fires on every ActionResponse to detect learnable facts."""
+    if not isinstance(message, ActionResponse):
+        return
+    # Custom extraction logic per tool
+    for result in message.content.results:
+        if result.tool_name == "read_file" and result.output:
+            # Application-specific: extract facts from file reads
+            pass
+
+# Registration
+branch.msgs._on_message_added.append(extract_knowledge_hook)
+```
+
+This is optional and application-specific. The substrate provides the
+storage; extraction logic lives in the application layer.
+
+### Configuration tiers
+
+```python
+# Tier 1: Library mode (default)
+branch = Branch(system="You are a researcher")
+# knowledge_store = NullKnowledgeStore() implicitly
+
+# Tier 2: Local persistence (Studio mode)
+from lionagi.knowledge import SQLiteKnowledgeStore
+branch = Branch(
+    system="...",
+    knowledge_store=SQLiteKnowledgeStore("~/.lionagi/knowledge.db"),
+)
+
+# Tier 3: Governed mode (KHive product)
+from khive import KHiveKnowledgeStore
+branch = Branch(
+    system="...",
+    knowledge_store=KHiveKnowledgeStore(
+        project="payments-platform",
+        require_approval_for=["verified"],  # Human-in-loop for verification
+    ),
+)
+```
+
+Each tier adds capability without changing the Branch API. The developer's
+code (`branch.learn(...)`, `branch.recall(...)`) is identical across tiers.
+
+### Worked example: knowledge accumulation across sessions
+
+A PR review agent accumulates codebase patterns over many runs:
+
+```python
+from lionagi import Branch, Session
+from lionagi.knowledge import SQLiteKnowledgeStore, from_file, from_tool_result, from_user_statement
+
+# Session 1, Monday: agent reviews PR #1842
+session = Session(
+    knowledge_store=SQLiteKnowledgeStore("~/.lionagi/knowledge/payments.db"),
+)
+branch = session.new_branch(system="You review pull requests for the payments service.")
+
+result = await branch.operate(
+    instruction="Review PR #1842, focus on transaction handling",
+    tools=[read_file_tool, github_pr_tool],
+)
+
+# Agent observes a pattern, records it
+claim_id = await branch.learn(
+    "payments-service uses the saga pattern for multi-step transactions",
+    evidence=[
+        from_file("src/sagas/payment_saga.py", repo="acme/payments", commit="abc123"),
+        from_tool_result("tc_pr1842_001", "GitHub PR shows saga.compensate() in error path"),
+    ],
+    domain="architecture",
+    tags=["saga", "transactions"],
+)
+# Persists to SQLite. claim_id is returned.
+
+# --- Session 2, Wednesday: different agent reviews PR #1851 ---
+session2 = Session(knowledge_store=SQLiteKnowledgeStore("~/.lionagi/knowledge/payments.db"))
+branch2 = session2.new_branch(system="You review pull requests for the payments service.")
+
+# Before reviewing, agent recalls prior knowledge
+context = await branch2.recall("What patterns does this codebase use for transactions?")
+# Returns: [Claim(text="payments-service uses the saga pattern...", confidence=1.0, status="observed", ...)]
+
+# Agent uses this context, doesn't need to re-discover the pattern
+
+# Later in the review, agent finds the new PR uses a different pattern
+new_claim_id = await branch2.learn(
+    "PR #1851 introduces 2PC alongside saga for cross-service transactions",
+    evidence=[
+        from_file("src/coordinators/two_phase.py", repo="acme/payments", commit="def456"),
+        from_tool_result("tc_pr1851_003", "PR description: explicitly mentions 2PC for inventory+payment"),
+    ],
+    domain="architecture",
+    tags=["2pc", "transactions"],
+)
+
+# --- Session 3, Friday: operator reviews knowledge ---
+# Operator opens Run detail for PR #1851 review
+# Knowledge lens shows: "PR #1851 introduces 2PC..."
+# Operator clicks "Verify" after checking the PR themselves
+await branch2.verify(new_claim_id, evidence=[
+    from_user_statement(session_id=str(session2.id), message_id=operator_msg_id),
+])
+# Status now: verified
+# Both claims persist; future agents querying "transactions" get both with appropriate status
+```
+
+This is the substrate in action: agents accumulate, agents recall, humans verify, the store persists across sessions. Every claim has evidence. Every transition is auditable.
+
+### What the protocol does NOT specify
+
+| Concern | Why excluded |
+|---------|-------------|
+| Storage schema | Data layer will change. Protocol is async interface only |
+| Embedding/vector search impl | Store implementation detail. MemoryStore uses substring; SQLiteStore might use FTS5; KHiveStore uses embeddings |
+| Deduplication logic | Application-specific. Some stores merge duplicates, others keep all |
+| Retention policy | Operational config, not protocol |
+| Access control | KHive product concern, not library concern |
+| Export format (PROV, OTel) | Export adapter layer, not substrate interface |
+| Graph relationships between claims | v2 concern. v1 claims are independent units |
+
+### Claim severity derivation
+
+Knowledge claims have their own severity, derived from `claim_status` and `confidence`. This is a parallel function to [ADR-0033](ADR-0033-unified-entity-state-model.md)'s `derive_severity()` for operational entities — they share the same (severity, tone) value space but compute from different inputs.
+
+```python
+def derive_claim_severity(claim: Claim) -> tuple[str, str]:
+    """Returns (severity, tone) for a knowledge claim."""
+
+    # Critical: nothing for claims in v1 (claims aren't operational failures)
+
+    # Warning: actively contested or unconfirmed-too-long
+    if claim.claim_status == "disputed":
+        return ("warning", "warning")
+    if claim.claim_status == "hypothesis" and claim.confidence < 0.5:
+        return ("warning", "warning")
+
+    # Info: pending validation, active observations
+    if claim.claim_status in ("observed", "inferred"):
+        return ("info", "info")
+    if claim.claim_status == "hypothesis":
+        return ("info", "neutral")
+
+    # Success: confirmed
+    if claim.claim_status == "verified":
+        return ("neutral", "success")
+
+    # Neutral: archived
+    if claim.claim_status == "superseded":
+        return ("neutral", "neutral")
+
+    return ("neutral", "neutral")
+```
+
+Both `derive_severity` (operational) and `derive_claim_severity` (knowledge) emit into the same Attention Queue ([ADR-0030](ADR-0030-attention-queue.md)) and use the same (severity, tone) values rendered by the same components ([ADR-0035](ADR-0035-design-system-and-component-library.md)).
+
+The functions stay separate because claims are NOT operational entities — `disputed` is not the same kind of severity as `failed`. Keeping them separate prevents semantic muddling.
+
+### Scope type semantics
+
+The `scope_type` and `scope_id` fields on Claim enable multi-level
+knowledge organization:
+
+| scope_type | scope_id example | Meaning |
+|-----------|------------------|---------|
+| `project` | `"payments-platform"` | Fact applies to the whole project |
+| `repo` | `"github.com/acme/payments"` | Fact about a specific repo |
+| `agent` | `"pr-reviewer"` | Fact the agent learned about itself/its domain |
+| `run` | `"run_abc123"` | Fact specific to one execution (ephemeral) |
+
+Scoping enables `recall()` to filter by relevance. A PR reviewer agent
+queries `scope_type=repo` knowledge, not all project-level facts.
+
+## Product Implications (Frontend)
+
+### Knowledge as lens (not nav section)
+
+Knowledge surfaces contextually on entity pages:
+
+| Page | Knowledge lens |
+|------|---------------|
+| Run detail | "What did this run learn?" — claims produced by this run |
+| Show detail | "What changed?" — claims created/superseded during this show |
+| Agent detail | "What does this agent know?" — claims scoped to this agent |
+| Attention item | "Why?" — evidence trail explaining the attention-worthy state |
+| Artifact detail | "What claims does this support?" — claims citing this artifact |
+
+### Claim rendering in the UI
+
+Claims render like status (same NormalizedState pattern from ADR-0033):
+
+```text
+observed · confidence 0.9 · from tool_result
+inferred · confidence 0.6 · from model_inference
+disputed · 2 conflicting evidence refs
+verified · by user · 2026-05-20
+```
+
+### Attention Queue integration
+
+Knowledge events that enter the Attention Queue:
+
+| Event | Severity | Action |
+|-------|----------|--------|
+| Claim disputed (was verified) | warning | "Review conflicting evidence" |
+| Low-confidence claim aged 7d+ without verification | info | "Verify or discard" |
+| Claim superseded by lower-confidence replacement | warning | "Review supersession" |
+| Knowledge write rejected (empty evidence) | info | "Agent attempted knowledge write without evidence" |
+
+### Search integration
+
+Claims are searchable via `GET /api/search?q=...&type=knowledge`.
+Each result carries claim_status, confidence, evidence count, and scope.
+
+## Consequences
+
+**Positive**
+
+- Zero-cost in library mode (NullStore is truly zero overhead)
+- Evidence-first is enforced at the API level, not by convention
+- Protocol is storage-agnostic — can migrate without changing user code
+- Follows established Branch manager pattern (5th manager, not addon)
+- Progressive disclosure: Null → Memory → SQLite → KHive
+- Frontend lens pattern avoids "empty graph browser" UX trap
+
+**Negative**
+
+- Adds a 5th manager to Branch (minimal complexity — NullStore is 10 LOC)
+- `recall()` quality depends entirely on store implementation (substring
+  match in MemoryStore is crude — acceptable for testing only)
+- No built-in deduplication in the protocol — stores must handle it
+- Graph relationships between claims are deferred to v2
+
+## Non-Goals
+
+Explicitly out of scope for v1; some may move into v2:
+
+- **Graph relationships between claims** (claim → entails → claim, claim → contradicts → claim). Claims are independent units in v1. Edges are v2.
+- **Automated extraction from all messages** (e.g., LLM-driven claim mining from any tool result). Too noisy; v1 is opt-in via `branch.learn()` calls.
+- **Cross-project knowledge sharing**. Scope isolation first. Sharing is a governed feature requiring access control, which lives in KHive product mode, not the library protocol.
+- **Inference / reasoning over claims**. The substrate stores knowledge; the agent reasons. We don't ship a rules engine over claims.
+- **Structured claim schemas** (typed templates beyond free-text). Free-text first; structure emerges from observed usage patterns, then becomes a v2 capability.
+- **Embedding model selection UI**. Implementation detail of the store. The user configures store, not internals.
+- **Claim deletion**. Knowledge is append-only with lifecycle (dispute, supersede). No `branch.forget()` method.
+- **Knowledge import/export across stores**. PROV/OTel export is v2. Import needs deduplication logic not yet designed.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Knowledge as separate service (not on Branch) | Breaks the manager pattern; requires separate lifecycle management; harder to auto-populate session context |
+| Mandatory store configuration | Violates zero-config in library mode; adoption barrier |
+| Untyped evidence (just a string) | Defeats the auditability thesis; can't render evidence trails in UI |
+| Claims without lifecycle | No way to evolve knowledge; facts become stale without mechanism to dispute/supersede |
+| Full graph DB protocol (nodes + edges + traversal) | Over-specified for v1; locks in storage assumptions; most use cases are claim + retrieval |
+| Auto-extraction from all messages | Too magical; generates low-quality claims; better as opt-in hook pattern |
+
+## References
+
+- [ADR-0028](ADR-0028-status-reason-model.md) — Status Reason Model (parallel concept: structured reasons with evidence)
+- [ADR-0029](ADR-0029-artifact-contract.md) — Artifact Contract (artifacts as evidence)
+- [ADR-0030](ADR-0030-attention-queue.md) — Attention Queue (disputed/low-confidence claims surface here)
+- [ADR-0033](ADR-0033-unified-entity-state-model.md) — Unified Entity State Model (canonical EvidenceRef definition)
+- [ADR-0034](ADR-0034-frontend-data-and-state-architecture.md) — Frontend Data & State Architecture (knowledge.* SSE events, knowledge query keys)
+- [ADR-0035](ADR-0035-design-system-and-component-library.md) — Design System & Component Library (KnowledgeLens, ClaimCard, ClaimStatusBadge components)
+- 06.md §7: Evidence-first policy (source design)
+- 06.md §3: Knowledge as lens, not destination (UI placement decision)
+- Branch architecture: 4-manager facade → 5-manager facade with KnowledgeStore
+- W3C PROV (future export target, not v1 schema)
+- Issue #1175: Knowledge substrate first-class in lionagi

--- a/docs/adrs/ADR-0041-immutable-evidence-nodes.md
+++ b/docs/adrs/ADR-0041-immutable-evidence-nodes.md
@@ -1,0 +1,560 @@
+# ADR-0041: Immutable Evidence Nodes
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Depends on**: [ADR-0033](ADR-0033-unified-entity-state-model.md) (EvidenceRef definition), [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) (Claim, KnowledgeStore protocol)
+**Related**: [ADR-0042](ADR-0042-task-certificate.md), [ADR-0049](ADR-0049-log-tier-governance.md), [ADR-0028](ADR-0028-status-reason-model.md), [ADR-0029](ADR-0029-artifact-contract.md)
+
+## Context
+
+lionagi's `DataLogger` writes `Log` entries on each tool call and session event. Those entries are
+plain append-only dicts: they record what happened, but nothing prevents the session process from
+mutating or overwriting them after the fact. An agent running with write access to its own log
+directory can rewrite history. More subtly, the `EvidenceRef` type defined in
+[ADR-0033](ADR-0033-unified-entity-state-model.md) is a Pydantic model with no hashing. A
+`Claim` from [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) is append-only in its
+lifecycle state machine (observed → verified → disputed → superseded) but that ordering is
+enforced only by application logic — there is no cryptographic link between one claim and the next
+that would detect out-of-order insertion or silent replacement.
+
+The concrete failure scenario: a governed agent is authorized to write files under a restricted
+directory. It invokes a file-write tool, produces an `ActionResponse`, and that response enters
+the DataLogger. If the agent can later modify that log entry — or if a future store implementation
+silently overwrites on a key collision — the audit record no longer reflects what actually executed.
+This matters the moment anyone asks "what did the agent do and how do we know?"
+
+The cross-cutting principle at stake here is **"Evidence is first-class, not logs"** (principle #2
+of this ADR set). Logs are operational: they tell you what happened at runtime. Evidence carries
+the policy version, gate results, and authorization context active *at execution time*. A log entry
+becomes evidence only when it is structurally impossible to alter it after the fact.
+
+### The applicable design pattern
+
+prior research addresses this with a hash-chain pattern: every evidence node includes a
+`chain_hash = SHA256(payload_hash || prev_chain_hash)`. Appending a new node produces a new
+`chain_hash` that depends on every node before it; tampering with any earlier node invalidates all
+subsequent `chain_hash` values. prior research adds the supersession pattern: errors are
+corrected by inserting a new node with `supersedes_id` pointing backward, leaving the original
+untouched. prior research introduces `_sensitive_fields` as a `ClassVar[set[str]]`: fields
+excluded from the hash and from serialized output (raw tool inputs may contain secrets that should
+not appear in audit exports). These three patterns compose cleanly, and the translation to lionagi
+requires no new infrastructure.
+
+### Why lionagi needs this
+
+[ADR-0042](ADR-0042-task-certificate.md) (Task Certificate) will sign a proof that a task
+completed with specific evidence. That signature is worthless if the evidence it covers can be
+modified after signing. [ADR-0049](ADR-0049-log-tier-governance.md) (Log Tier Governance)
+classifies records as MUTABLE, PROTECTED, or IMMUTABLE — but tier classification is a policy;
+`ImmutableEvidenceNode` is the mechanism that makes the IMMUTABLE tier structurally enforceable at
+the Python level, before any storage layer is involved.
+
+## Decision
+
+Introduce `ImmutableEvidenceNode` as the base class for all evidence-grade records in lionagi.
+`EvidenceRef` (ADR-0033) and `Claim` (ADR-0039) acquire these properties via mixin or subclass.
+DB-level enforcement is explicitly deferred to KHive v1 (see Non-Goals).
+
+### 1. Core data model
+
+```python
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, ClassVar
+from uuid import UUID
+
+from pydantic import ConfigDict, Field
+
+from lionagi.protocols.generic.element import Element
+
+
+def _sha256_hex(data: str) -> str:
+    return hashlib.sha256(data.encode("utf-8")).hexdigest()
+
+
+def _canonical_json(obj: dict) -> str:
+    """Deterministic JSON serialization for hashing."""
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), default=str)
+
+
+#: Sentinel for the first node in a chain (no predecessor).
+GENESIS_HASH: str = "0" * 64
+
+
+class ImmutableEvidenceNode(Element):
+    """Base for evidence-grade records that must be tamper-evident.
+
+    Hash semantics
+    --------------
+    content_hash : SHA256 over domain fields only (excludes _sensitive_fields,
+        supersedes_id, chain hashes).  Used for deduplication — two nodes with
+        identical domain content produce the same content_hash.
+
+    chain_hash : SHA256(payload_hash || prev_chain_hash).  The payload_hash is
+        SHA256 over domain fields PLUS supersedes_id (so the supersession link
+        is covered), still excluding _sensitive_fields.  chain_hash binds each
+        node to its predecessor; any mutation of a node or its position in the
+        chain invalidates all chain_hash values that follow.
+
+    Immutability contract
+    ---------------------
+    Nodes are sealed during Pydantic model initialization.  The fields node_id, created_at,
+    content_hash, chain_hash, prev_chain_hash, and supersedes_id MUST NOT be
+    mutated after model_post_init.  Pydantic's frozen model configuration
+    enforces this contract at the Element layer.
+
+    Sensitive fields
+    ----------------
+    Subclasses declare _sensitive_fields: ClassVar[set[str]] to name fields
+    that must be excluded from content_hash and from serialization output.
+    This prevents raw tool inputs containing secrets from appearing in
+    audit exports or hash computations.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    # --- Chain bookkeeping (set by seal()) ---
+    content_hash: str = Field(default="", frozen=True)
+    chain_hash: str = Field(default="", frozen=True)
+    prev_chain_hash: str = Field(default=GENESIS_HASH, frozen=True)
+
+    # --- Supersession (backward pointer only) ---
+    supersedes_id: UUID | None = Field(default=None, frozen=True)
+
+    # --- Subclass contract ---
+    _sensitive_fields: ClassVar[set[str]] = set()
+
+    @property
+    def node_id(self) -> UUID:
+        """Compatibility alias for Element.id in evidence-oriented APIs."""
+        return self.id
+
+    def model_post_init(self, __context: Any) -> None:
+        """Seal new nodes while preserving stored hashes on loaded nodes."""
+        if not self.content_hash or not self.chain_hash:
+            content_hash, chain_hash = self._compute_hashes()
+            object.__setattr__(self, "content_hash", self.content_hash or content_hash)
+            object.__setattr__(self, "chain_hash", self.chain_hash or chain_hash)
+
+    # ------------------------------------------------------------------
+    # Internal hashing
+    # ------------------------------------------------------------------
+
+    def _domain_dict(self, *, include_supersedes: bool) -> dict:
+        """Return serialisable dict of domain fields, excluding sensitive ones
+        and the chain/hash bookkeeping fields managed by this base class."""
+        base_excludes = {
+            "id",
+            "created_at",
+            "metadata",
+            "node_metadata",
+            "content_hash",
+            "chain_hash",
+            "prev_chain_hash",
+            "supersedes_id",
+        } | self._sensitive_fields
+
+        result = self.to_dict(mode="db")
+        for f_name in base_excludes:
+            result.pop(f_name, None)
+
+        if include_supersedes and self.supersedes_id is not None:
+            result["_supersedes_id"] = str(self.supersedes_id)
+
+        return result
+
+    def _compute_hashes(self) -> tuple[str, str]:
+        """Compute content_hash and chain_hash from canonical Element output."""
+        domain = self._domain_dict(include_supersedes=False)
+        content_hash = _sha256_hex(_canonical_json(domain))
+
+        payload = self._domain_dict(include_supersedes=True)
+        payload_hash = _sha256_hex(_canonical_json(payload))
+        chain_hash = _sha256_hex(payload_hash + self.prev_chain_hash)
+        return content_hash, chain_hash
+
+    # ------------------------------------------------------------------
+    # Verification
+    # ------------------------------------------------------------------
+
+    def verify_content(self) -> bool:
+        """Return True if domain fields match the stored content_hash.
+
+        A False return means either the instance was mutated after construction
+        or the stored hash was corrupted.
+        """
+        expected, _ = self._compute_hashes()
+        return self.content_hash == expected
+
+    def verify_chain_link(self) -> bool:
+        """Return True if chain_hash is consistent with current domain fields
+        and prev_chain_hash.
+
+        This checks a *single* link.  Full chain verification requires
+        iterating all nodes in order and calling this method on each, passing
+        the predecessor's chain_hash as prev_chain_hash.
+        """
+        _, expected = self._compute_hashes()
+        return self.chain_hash == expected
+
+    # ------------------------------------------------------------------
+    # Supersession
+    # ------------------------------------------------------------------
+
+    def supersede(self, **updated_fields) -> "ImmutableEvidenceNode":
+        """Return a new node of the same subclass with corrected fields.
+
+        The new node's supersedes_id points back to this node.  This node
+        is never modified.  The caller is responsible for persisting both
+        nodes; no storage interaction occurs here.
+
+        The new node starts a fresh chain link: its prev_chain_hash is
+        set to this node's chain_hash.
+        """
+        init_kwargs = self.model_dump(
+            mode="python",
+            exclude={"id", "created_at", "content_hash", "chain_hash"},
+        )
+
+        init_kwargs.update(updated_fields)
+        init_kwargs["supersedes_id"] = self.id
+        init_kwargs["prev_chain_hash"] = self.chain_hash
+
+        return type(self)(**init_kwargs)
+
+    # ------------------------------------------------------------------
+    # Safe serialization
+    # ------------------------------------------------------------------
+
+    def to_audit_dict(self) -> dict:
+        """Return a dict safe for export: sensitive fields are absent.
+
+        Includes chain bookkeeping fields so that an external verifier can
+        reconstruct and check the chain without access to sensitive data.
+        """
+        result = self.to_dict(mode="json")
+        result["node_id"] = result.pop("id")
+        result["created_at"] = self.created_datetime.isoformat()
+        result.pop("metadata", None)
+        for f_name in self._sensitive_fields:
+            result.pop(f_name, None)
+        return result
+```
+
+### 2. Chain bootstrap — the genesis node
+
+The first node in any chain has no predecessor.  Its `prev_chain_hash` is set to the sentinel
+`GENESIS_HASH = "0" * 64`.  This value is fixed and publicly known; it is not a secret.  Its
+purpose is to anchor the chain: any subsequent node's `chain_hash` depends on this sentinel,
+so the first node is as tamper-evident as any later one.
+
+When a subsequent node is appended, it receives `prev_chain_hash = predecessor.chain_hash`.
+A chain of N nodes can be verified in O(N) by iterating in insertion order and calling
+`verify_chain_link()` on each node.
+
+```python
+from lionagi.protocols.generic.pile import Pile
+
+
+def verify_chain(nodes: Pile[ImmutableEvidenceNode]) -> bool:
+    """Verify integrity of an ordered chain of nodes.
+
+    Returns True iff every node's chain_hash is consistent with its
+    domain fields and its predecessor's chain_hash.  The first node
+    must have prev_chain_hash == GENESIS_HASH.
+    """
+    expected_prev = GENESIS_HASH
+    for node in nodes:
+        if node.prev_chain_hash != expected_prev:
+            return False
+        if not node.verify_chain_link():
+            return False
+        expected_prev = node.chain_hash
+    return True
+```
+
+### 3. How EvidenceRef and Claim acquire these properties
+
+**EvidenceRef** (ADR-0033) is currently a Pydantic model.  It acquires hash-chain properties by
+inheriting from `ImmutableEvidenceNode` via a thin adapter mixin.  Domain fields (`kind`,
+`ref`, `note`, `timestamp`) participate in `content_hash` as before; any field declared in
+`_sensitive_fields` is excluded.
+
+```python
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+from pydantic import Field
+
+EvidenceKind = Literal[
+    "message", "user_statement", "tool_result", "artifact",
+    "url", "file", "model_inference", "human_assertion",
+]
+
+
+class EvidenceRef(ImmutableEvidenceNode):
+    """A single structured evidence reference, tamper-evident.
+
+    Corresponds to the EvidenceRef defined in ADR-0033; extends it with
+    chain-hash integrity.
+    """
+
+    kind: EvidenceKind = "tool_result"
+    ref: str = ""           # URI, message ID, artifact ID, etc.
+    note: str = ""          # Human-readable annotation
+    # Raw input is excluded from hashes and audit exports because it may
+    # contain API keys, PII, or other secrets passed to a tool.
+    raw_input: dict | None = Field(default=None, exclude=True)
+
+    _sensitive_fields: ClassVar[set[str]] = {"raw_input"}
+```
+
+**Claim** (ADR-0039) follows the same pattern.  The claim's evidence list becomes a list of
+`EvidenceRef` node IDs rather than inline objects; this keeps the Claim node's own hash stable
+even as the referenced evidence grows.
+
+```python
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+from pydantic import Field
+
+from lionagi.protocols.generic.pile import Pile
+
+ClaimStatus = Literal["observed", "verified", "disputed", "superseded"]
+
+
+class Claim(ImmutableEvidenceNode):
+    """A durable learned fact backed by at least one EvidenceRef node.
+
+    The lifecycle status field participates in content_hash, so a status
+    transition produces a new node (via supersede()) rather than mutating
+    the existing one.  This preserves the full status history in the chain.
+    """
+
+    subject: str = ""           # Entity the claim is about
+    predicate: str = ""         # Relation or property
+    value: str = ""             # Asserted value
+    status: ClaimStatus = "observed"
+    evidence: Pile[EvidenceRef] = Field(
+        default_factory=lambda: Pile(item_type={EvidenceRef}, strict_type=True)
+    )
+    # The prompt or instruction that caused this claim to be formed.
+    # Excluded because it may contain sensitive context from the session.
+    source_prompt: str | None = Field(default=None, exclude=True)
+
+    _sensitive_fields: ClassVar[set[str]] = {"source_prompt"}
+
+    def transition(self, new_status: ClaimStatus) -> "Claim":
+        """Return a new Claim node with updated status (supersedes this one).
+
+        Valid transitions follow the lifecycle in ADR-0039:
+          observed → verified | disputed
+          verified → disputed | superseded
+          disputed → verified | superseded
+          superseded → (terminal)
+        """
+        _valid: dict[ClaimStatus, set[ClaimStatus]] = {
+            "observed": {"verified", "disputed"},
+            "verified": {"disputed", "superseded"},
+            "disputed": {"verified", "superseded"},
+            "superseded": set(),
+        }
+        if new_status not in _valid[self.status]:
+            raise ValueError(
+                f"Cannot transition Claim from {self.status!r} to {new_status!r}"
+            )
+        return self.supersede(status=new_status)
+```
+
+### 4. Application-layer enforcement vs. DB-layer enforcement
+
+`ImmutableEvidenceNode` provides Python-level tamper evidence: the hashes are computed at
+construction and can be verified at any time.  If application code mutates an attribute after
+construction, `verify_content()` will return `False` on the next check.
+
+DB-level triggers that block `UPDATE` and `DELETE` on the underlying table are a **v2 / KHive
+concern**, not a v1 library concern.  The reasons:
+
+1. lionagi is a library; it ships no migrations and makes no assumptions about the storage
+   backend.  Different deployments use SQLite, Postgres, or in-process dicts.
+2. Trigger DDL is storage-specific.  An in-process `MemoryKnowledgeStore` has no concept of
+   a DB trigger.
+3. The Python-level guarantee is sufficient for library mode: evidence is tamper-*evident* (you
+   can detect mutation) even if not tamper-*proof* (a sufficiently privileged process could still
+   modify storage directly).  Tamper-proof enforcement requires the governed storage layer that
+   KHive will provide.
+
+The `KnowledgeStore` protocol (ADR-0039) should document that a conforming implementation MUST
+persist `ImmutableEvidenceNode` instances without modifying their `content_hash`, `chain_hash`,
+or `prev_chain_hash` fields.  This is a protocol contract, not a compiled guarantee — which is
+the correct level of enforcement for a library.
+
+### 5. Chain ownership and session scope
+
+Each `Branch` session maintains its own evidence chain.  Chain continuity is the responsibility
+of the component that creates new nodes:
+
+```python
+from pydantic import ConfigDict, Field
+
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+from lionagi.session.branch import Branch
+
+
+class EvidenceChain(Element):
+    """Lightweight in-process chain accumulator.
+
+    The KnowledgeStore implementation is responsible for persisting nodes
+    and for reconstructing the chain_tip on reload. Branch integration uses
+    the existing managers: messages via branch.msgs, actions via branch.acts,
+    models via branch.mdls, and audit output via branch._log_manager.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
+
+    tip_hash: str = GENESIS_HASH
+    nodes: Pile[ImmutableEvidenceNode] = Field(
+        default_factory=lambda: Pile(
+            item_type={ImmutableEvidenceNode},
+            strict_type=False,
+        )
+    )
+
+    @classmethod
+    def for_branch(
+        cls,
+        branch: Branch,
+        *,
+        tip_hash: str = GENESIS_HASH,
+    ) -> "EvidenceChain":
+        """Create a branch-scoped chain without adding a parallel manager."""
+        chain = cls(tip_hash=tip_hash)
+        branch.metadata["evidence_chain_id"] = str(chain.id)
+        branch.metadata["evidence_chain_tip"] = tip_hash
+        return chain
+
+    def append(
+        self,
+        node_cls: type[ImmutableEvidenceNode],
+        *,
+        branch: Branch | None = None,
+        **kwargs,
+    ) -> ImmutableEvidenceNode:
+        """Construct and chain a new node, returning the sealed instance."""
+        node = node_cls(prev_chain_hash=self.tip_hash, **kwargs)
+        self.tip_hash = node.chain_hash
+        self.nodes.include(node)
+
+        if branch is not None:
+            branch.metadata["evidence_chain_tip"] = self.tip_hash
+            branch._log_manager.log(
+                {
+                    "event": "evidence_node_appended",
+                    "evidence": node.to_audit_dict(),
+                }
+            )
+
+        return node
+
+    def verify(self) -> bool:
+        """Verify all accumulated nodes form a valid chain."""
+        return verify_chain(self.nodes)
+```
+
+A `KnowledgeStore` implementation that persists nodes reloads `tip_hash` from the last stored
+node's `chain_hash`.  If the store is empty, `tip_hash` starts at `GENESIS_HASH`.
+
+## Consequences
+
+**Positive**
+
+- Every `EvidenceRef` and `Claim` node carries a cryptographic fingerprint that proves its
+  content has not changed since construction.  An external auditor can verify the chain with
+  no access to the storage backend's internals.
+- `content_hash` enables deduplication: two tool-result nodes recording the same output will
+  produce the same `content_hash`, allowing stores to avoid redundant insertions without
+  suppressing the chain entry.
+- `_sensitive_fields` prevents raw tool inputs (API keys, user PII) from appearing in audit
+  exports or hash computations, separating operational safety from audit correctness.
+- Supersession via `supersede()` preserves full history.  A corrected `Claim` does not destroy
+  the original — it chains a new node that points back.  [ADR-0042](ADR-0042-task-certificate.md)
+  can sign over a chain tip with confidence that the underlying evidence is traceable.
+- The `EvidenceChain` accumulator is zero-dependency: it works in-process with no storage,
+  making it suitable for testing and for Library mode.
+
+**Negative**
+
+- SHA-256 hashing at construction adds roughly 0.1–0.5 ms per node, depending on domain field
+  size.  This is acceptable for evidence-grade records (tool calls, claims) which are far
+  less frequent than log events.  The DataLogger's high-volume `Log` entries are explicitly
+  out of scope (see Non-Goals and [ADR-0049](ADR-0049-log-tier-governance.md)).
+- Implementing `verify_chain()` on a loaded store requires fetching nodes in insertion order.
+  Stores that do not preserve insertion order (e.g., unordered key-value stores) cannot support
+  chain verification without additional ordering metadata.
+- Because status transitions on `Claim` produce new nodes rather than mutating the existing one,
+  a store accumulates one node per lifecycle transition.  For long-lived claims that go through
+  many transitions this adds storage overhead.  In practice the lifecycle has four states, so
+  the maximum per-claim node count is four.
+- The Python-level immutability contract relies on discipline: nothing prevents application code
+  from assigning to fields post-construction in the current `dataclass` implementation.  A v2
+  hardening pass should add `__setattr__` protection or switch to `frozen=True` where Pydantic
+  compatibility allows.
+
+## Non-Goals
+
+Explicitly out of scope for this ADR:
+
+- **Full Merkle trees**: Not needed for v1.  A linear hash chain suffices to detect insertion,
+  deletion, or mutation of any single node.  Merkle trees enable efficient proofs over large
+  subsets; that capability belongs to a future KHive indexing ADR.
+- **Cryptographic signing**: Digital signatures (ECDSA, Ed25519) over chain tips or individual
+  nodes are covered by [ADR-0042](ADR-0042-task-certificate.md) (Task Certificate).  This ADR
+  establishes the hash structure that signing will cover, not the signing mechanism itself.
+- **Distributed ledger semantics**: Blockchain-style consensus, fork resolution, and distributed
+  chain synchronization are not relevant to the single-process or single-tenant deployment
+  scenarios lionagi targets in v1.
+- **DB-level triggers**: PostgreSQL `BEFORE UPDATE` / `BEFORE DELETE` triggers that enforce
+  immutability at the storage layer are a KHive v1 concern.  The `KnowledgeStore` protocol
+  contract documents the expectation; enforcement is left to governed store implementations.
+- **Multi-tenant chain isolation**: Ensuring that chain nodes from different tenants cannot be
+  interleaved requires tenant-scoped chain roots and storage-layer row security.  This is KHive
+  territory (see also ADR-0039's note on multi-tenant concerns).
+- **Retroactive chain repair**: If a chain is found to be invalid (e.g., due to a store bug),
+  this ADR does not define a repair protocol.  Invalid chains should be flagged and escalated;
+  repair requires operator intervention.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Plain DataLogger entries (append-only dict list) | No tamper detection. An agent process with file-system write access can overwrite log entries silently. `verify_content()` would never be called because there is no hash to verify against. |
+| DB-level triggers only, no application-layer hashes | Not portable: triggers are Postgres-specific and cannot protect in-process stores (SQLite, MemoryStore). Library mode would have no evidence integrity guarantees. |
+| Timestamp-only ordering (no hash chain) | Timestamps can be spoofed or back-dated. They establish ordering only if the clock is trusted. A hash chain establishes ordering independently of wall time. |
+| Full Merkle tree from the start | Provides efficient subset proofs but requires a tree-construction algorithm, a root-hash management layer, and more complex verification. The operational benefit over a linear chain is negligible at v1 scale (thousands of nodes per session, not billions). |
+| Event sourcing (append-only event log, derived state) | Provides complete history but requires projections for current state, event schema versioning, and substantial infrastructure investment. The supersession pattern achieves the correction requirement with far less complexity. |
+| Bidirectional supersession pointers (`superseded_by_id` on original) | Requires either a two-phase write (insert new node, then update original) or a transaction. Backward-only `supersedes_id` allows a single atomic INSERT with no mutation of the original node, which aligns with the immutability contract. prior research makes this decision for the same reason. |
+
+## References
+
+- [ADR-0033](ADR-0033-unified-entity-state-model.md) — defines `EvidenceRef` (8 kinds) and `NormalizedState`; this ADR adds hash-chain integrity to `EvidenceRef`
+- [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) — defines `Claim` and `KnowledgeStore` protocol; this ADR adds hash-chain integrity to `Claim`
+- [ADR-0042](ADR-0042-task-certificate.md) — Task Certificate signs over a chain tip; depends on `ImmutableEvidenceNode.chain_hash` being stable
+- [ADR-0049](ADR-0049-log-tier-governance.md) — Log Tier Governance classifies records as MUTABLE / PROTECTED / IMMUTABLE; `ImmutableEvidenceNode` is the mechanism backing the IMMUTABLE tier
+- [ADR-0028](ADR-0028-status-reason-model.md) — StatusReason model; evidence nodes may carry status reasons as domain fields
+- [ADR-0029](ADR-0029-artifact-contract.md) — Artifact contract; artifacts referenced by `EvidenceRef(kind="artifact")` benefit from chain provenance
+- prior governance research `01_design/006-evidence-chain-cep/ADR-006-evidence-chain-cep.md` — source pattern for hash-chained evidence; D1 (chain hash formula), D2 (backward-only supersession)
+- prior governance research `01_design/003-immutability/ADR-003-immutability.md` — source pattern for insert-only semantics, `_allowed_update_fields`, supersession over mutation
+- prior governance research `01_design/002-entity/ADR-002-entity.md` — source pattern for dual hashing (`content_hash` + `integrity_hash`) and `_sensitive_fields` ClassVar
+- NIST FIPS 180-4 — SHA-256 specification

--- a/docs/adrs/ADR-0042-task-certificate.md
+++ b/docs/adrs/ADR-0042-task-certificate.md
@@ -1,0 +1,550 @@
+# ADR-0042: Task Certificate — Signed Proof of Process Adherence
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Depends on**: [ADR-0041](ADR-0041-immutable-evidence-nodes.md) (certificates are evidence nodes; chain hash required)
+**Related**: [ADR-0044](ADR-0044-tool-gates.md) (gates passed/failed recorded in certificate), [ADR-0045](ADR-0045-break-glass-protocol.md) (break-glass path produces DEGRADED certificate), [ADR-0050](ADR-0050-operation-context.md) (operation context serialized into certificate), [ADR-0033](ADR-0033-unified-entity-state-model.md) (EvidenceRef substrate), [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) (evidence as first-class artifact)
+
+## Context
+
+lionagi today has no concept of *task completion proof*. A `Branch` session ends and the
+operator is left with: a list of messages, `DataLogger` entries, and the final assistant
+response. These artifacts assert *what happened*, but none of them assert *how the task was
+governed*. There is no single artifact that answers:
+
+- Were all required tool gates checked before execution?
+- Was any gate bypassed via break-glass?
+- Which policy version governed this run?
+- Is the evidence chain for this task intact and unmodified?
+
+This gap has concrete consequences. KHive's audit surface — and any operator deploying lionagi
+for consequential workloads — needs a tamper-evident record that proves process was followed,
+independently of whether the outcome was correct. Without this, "the agent said it followed the
+rules" is the only evidence available, which is not evidence at all.
+
+The cross-cutting principle **"Evidence is first-class, not logs"** applies directly: a DataLogger
+entry recording that a gate check occurred is operational telemetry. A `TaskCertificate`
+asserting that all gates passed, bound to the policy version active at execution time and
+hash-chained to the evidence nodes produced during the task, is governed evidence. The
+distinction is the same as the difference between a log line and a signed receipt.
+
+The cross-cutting principle **"Every constraint must be enforced, not just documented"** also
+applies: a governance policy that says "all HARD gates must pass" but produces no verifiable
+artifact of that assertion is not enforced — it is aspirational. The certificate is what makes
+adherence verifiable post-hoc.
+
+### The applicable prior governance research insight
+
+prior research introduced the *decision certificate* pattern for people-operations workflows
+(terminations, adverse actions, PIP initiations). The core insight translates directly to agent
+governance: the certificate is the primary proof artifact — it proves *process* adherence, not
+*outcome* correctness. prior governance research further established that certificates are never revoked, only
+superseded. Revocation creates audit ambiguity ("did this decision happen?"); supersession
+preserves the full correction trail ("this decision happened; a later decision is now
+authoritative"). In lionagi terms: if a task is re-run under a corrected policy, the original
+certificate is superseded, not erased. Both records remain.
+
+### Why lionagi needs this
+
+Consider a governed ReAct loop that calls `write_file` three times. Each call is guarded by a
+HARD gate requiring path allowlist membership (ADR-0044). One call is blocked; the agent invokes
+break-glass (ADR-0045) to proceed. The session ends. Forty-eight hours later, an auditor asks:
+"Did the agent stay within its path allowlist?" Today, the only answer is "check the logs." With
+`TaskCertificate`, the answer is: "Here is the certificate for task X. `defensibility` is
+`DEGRADED`. `gates_failed` lists the blocked gate. `break_glass_invoked` is `True`. The evidence
+chain head is verifiable against the immutable evidence nodes in ADR-0041." The audit takes
+seconds, not forensic reconstruction.
+
+## Decision
+
+We introduce `TaskCertificate`, a specialized `ImmutableEvidenceNode` (ADR-0041) that is emitted
+when an agent task completes, encoding the process record: which gates passed, which failed,
+whether break-glass was invoked, the hash-chain head of the evidence produced, the policy version
+active at execution time, and any human or agent attestations collected.
+
+### 1. State Machine
+
+A `TaskCertificate` traverses four states. Transitions are irreversible.
+
+```text
+PROVISIONAL → GATED → MINTED
+                         ↓
+                    SUPERSEDED
+```
+
+A fifth terminal variant, `BREAK_GLASS`, branches from `GATED` when the task completed via
+emergency override:
+
+```text
+PROVISIONAL → BREAK_GLASS → MINTED (defensibility: DEGRADED)
+                                ↓
+                           SUPERSEDED
+```
+
+State semantics:
+
+| State | Meaning |
+|-------|---------|
+| `PROVISIONAL` | Task started; certificate emitted but no completion claim yet. Agent is still executing. |
+| `GATED` | All required tool gates have passed. Task has completed normally. Pending final minting. |
+| `BREAK_GLASS` | Task completed via emergency override (ADR-0045). Not all gates passed normally. Defensibility is DEGRADED regardless of outcome. |
+| `MINTED` | Certificate is final. Content is sealed. Hash is recorded in the immutable evidence chain (ADR-0041). |
+| `SUPERSEDED` | A newer certificate for the same `task_id` has been minted. This certificate is preserved and remains queryable; it is no longer the authoritative record. |
+
+Once a certificate reaches `MINTED` or `SUPERSEDED`, its content fields are immutable. The
+certificate object may only gain a `superseded_by` pointer; no other field changes.
+
+### 2. TaskCertificate Dataclass
+
+```python
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from enum import Enum
+from typing import ClassVar, Optional
+from uuid import UUID
+
+from pydantic import ConfigDict, Field
+
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+
+
+class CertificateState(str, Enum):
+    PROVISIONAL = "PROVISIONAL"
+    GATED = "GATED"
+    BREAK_GLASS = "BREAK_GLASS"
+    MINTED = "MINTED"
+    SUPERSEDED = "SUPERSEDED"
+
+
+class Defensibility(str, Enum):
+    FULL = "FULL"          # All required gates passed; no emergency overrides
+    DEGRADED = "DEGRADED"  # Break-glass was invoked; process was bypassed
+
+
+class GateRecord(Element):
+    """One gate evaluation result, recorded at certificate minting time."""
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+    )
+
+    gate_id: str
+    gate_kind: str          # "HARD" | "SOFT" | "ADVISORY"  (ADR-0044)
+    tool_name: str
+    passed: bool
+    override_invoked: bool  # True if break-glass was used for this gate
+    evaluated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    policy_version: str     # Policy version active when this gate ran (ADR-0050)
+
+
+class Attestation(Element):
+    """
+    A signed assertion by a human or agent that they reviewed and approved
+    the task outcome.  Non-repudiable: once recorded, never removed.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+    )
+
+    attestor_id: str              # Agent ID, user ID, or external principal
+    attestor_kind: str            # "human" | "agent" | "system"
+    statement: str                # Free-text or structured assertion
+    attested_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    signature: Optional[str] = None  # Optional: base64 SHA-256 HMAC or external sig
+
+
+class EvidenceRef(Element):
+    """
+    Reference to an evidence node in the ADR-0041 chain.
+
+    This mirrors the EvidenceRef substrate from ADR-0033/ADR-0041 and is
+    Pile-managed here so certificates reference evidence rather than copying it.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+    )
+
+    evidence_id: UUID
+    evidence_kind: str
+    chain_hash: str
+
+
+class TaskCertificate(Element):
+    """
+    Immutable proof of process adherence for a single governed task.
+
+    A TaskCertificate is a specialized ImmutableEvidenceNode (ADR-0041).
+    It does NOT assert outcome correctness — it asserts that the process
+    defined by the active policy was followed (or, if defensibility is
+    DEGRADED, that it was bypassed with an auditable record).
+
+    Fields are sealed at MINTED state.  Only superseded_by may be written
+    post-minting, and only by the minting subsystem.
+    """
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        validate_assignment=True,
+    )
+
+    _mutable_after_seal: ClassVar[set[str]] = {"state", "superseded_by"}
+
+    # Identity
+    task_id: str = ""           # Caller-supplied task identifier
+    session_id: str = ""        # lionagi Session.ln_id
+    branch_id: str = ""         # lionagi Branch.ln_id
+
+    # Lifecycle
+    state: CertificateState = CertificateState.PROVISIONAL
+    defensibility: Defensibility = Defensibility.FULL
+
+    # Evidence linkage (ADR-0041)
+    evidence_chain_head: Optional[str] = None   # SHA-256 hash of last evidence node
+    evidence_node_count: int = 0                 # How many evidence nodes produced
+    evidence_refs: Pile[EvidenceRef] = Field(
+        default_factory=lambda: Pile(item_type={EvidenceRef}, strict_type=True)
+    )
+
+    # Gate results (ADR-0044)
+    gates_passed: Pile[GateRecord] = Field(
+        default_factory=lambda: Pile(item_type={GateRecord}, strict_type=True)
+    )
+    gates_failed: Pile[GateRecord] = Field(
+        default_factory=lambda: Pile(item_type={GateRecord}, strict_type=True)
+    )
+    break_glass_invoked: bool = False
+
+    # Attestations
+    attestations: Pile[Attestation] = Field(
+        default_factory=lambda: Pile(item_type={Attestation}, strict_type=True)
+    )
+
+    # Policy provenance (ADR-0050)
+    policy_version_active: str = ""     # Policy version string at task start
+    operation_context_hash: Optional[str] = None  # SHA-256 of serialized OperationContext
+
+    # Temporal record
+    emitted_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    gated_at: Optional[datetime] = None
+    minted_at: Optional[datetime] = None
+
+    # Supersession chain
+    supersedes: Optional[UUID] = None         # Certificate this one replaces
+    superseded_by: Optional[UUID] = None      # Certificate that replaces this one
+
+    @property
+    def certificate_id(self) -> UUID:
+        """Compatibility alias for Element.id."""
+        return self.id
+
+    def __setattr__(self, name: str, value) -> None:
+        sealed = getattr(self, "state", None) in (
+            CertificateState.MINTED,
+            CertificateState.SUPERSEDED,
+        )
+        if sealed and name not in self._mutable_after_seal:
+            raise AttributeError("Minted certificates are immutable.")
+        super().__setattr__(name, value)
+
+    def content_hash(self) -> str:
+        """
+        SHA-256 of the certificate's immutable fields, excluding superseded_by.
+        Used to verify the certificate has not been tampered with post-minting.
+        """
+        payload = self.to_dict(mode="db")
+        payload.pop("superseded_by", None)
+        return hashlib.sha256(
+            json.dumps(payload, sort_keys=True, default=str).encode()
+        ).hexdigest()
+
+    @property
+    def is_authoritative(self) -> bool:
+        """False if this certificate has been superseded."""
+        return self.superseded_by is None
+
+    @property
+    def is_sealed(self) -> bool:
+        """True if certificate content is immutable (MINTED or SUPERSEDED)."""
+        return self.state in (CertificateState.MINTED, CertificateState.SUPERSEDED)
+```
+
+### 3. Minting Requirements
+
+A certificate may only transition to `MINTED` when all of the following conditions hold:
+
+1. **All HARD gates passed** — no `GateRecord` in `gates_failed` has `gate_kind == "HARD"`,
+   unless `break_glass_invoked is True` (in which case `state` must be `BREAK_GLASS` and
+   `defensibility` must be `DEGRADED`).
+2. **Evidence chain intact** — `evidence_chain_head` is set and the chain is walkable back to
+   the first evidence node emitted for this `task_id`. If any node in the chain is missing or
+   its hash does not match, minting is refused.
+3. **No unresolved SOFT gate overrides** — any SOFT gate that was overridden must have a
+   corresponding `Attestation` with `attestor_kind != "system"` (i.e., a human or non-self
+   agent attested the override).
+4. **Policy version recorded** — `policy_version_active` is non-empty.
+5. **State machine consistency** — state must be `GATED` or `BREAK_GLASS` before minting.
+
+If any condition fails, `branch.mint_certificate()` raises `CertificateMintingError` with a
+structured reason. The certificate remains in its pre-minting state; it is not discarded. The
+operator may resolve the condition (e.g., supply a missing attestation) and retry.
+
+```python
+from pydantic import ConfigDict
+
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.governance.certificate import (
+    TaskCertificate,
+    CertificateState,
+    Attestation,
+)
+
+
+class CertificateMintingFailure(Element):
+    """Structured minting failure record suitable for logging and evidence."""
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+    )
+
+    certificate_id: str
+    reason: str
+    requirement: str | None = None
+
+
+class CertificateMintingError(Exception):
+    """Raised when minting preconditions are not satisfied."""
+
+    def __init__(self, failure: CertificateMintingFailure) -> None:
+        self.failure = failure
+        super().__init__(f"Cannot mint {failure.certificate_id}: {failure.reason}")
+```
+
+### 4. Branch and Session API
+
+```python
+from datetime import datetime, timezone
+
+from lionagi.protocols.action.manager import ActionManager
+from lionagi.protocols.generic.log import DataLogger
+from lionagi.protocols.generic.pile import Pile
+from lionagi.protocols.messages.manager import MessageManager
+from lionagi.protocols.governance.certificate import Attestation, TaskCertificate
+
+
+# Existing Branch managers are the integration point.
+actions: ActionManager = branch.acts
+messages: MessageManager = branch.msgs
+audit: DataLogger = branch._log_manager
+
+# On Branch — task-level operations
+cert: TaskCertificate = await branch.emit_certificate(task_id="task-abc-123")
+# Returns PROVISIONAL certificate immediately.
+# The implementation extends ActionManager with a Pile[TaskCertificate] store
+# and uses MessageManager progression to bind the task-flow transcript.
+actions.certificates.include(cert)
+cert.metadata["message_progression"] = messages.progression.to_dict(mode="json")
+audit.log(cert)
+
+cert = await branch.mint_certificate(
+    task_id="task-abc-123",
+    attestation=Attestation(
+        attestor_id="user:ocean",
+        attestor_kind="human",
+        statement="Reviewed ReAct trace; process adherence confirmed.",
+        attested_at=datetime.now(timezone.utc),
+    ),
+)
+# Validates minting requirements; transitions GATED → MINTED.
+# Raises CertificateMintingError if any precondition fails.
+audit.log(cert)
+
+# On Session — cross-branch retrieval
+cert: TaskCertificate | None = session.get_certificate(task_id="task-abc-123")
+# Returns the authoritative (non-superseded) certificate for task_id.
+# Returns None if no certificate has been minted for that task.
+
+all_certs: Pile[TaskCertificate] = session.list_certificates(
+    task_id="task-abc-123",
+    include_superseded=True,
+)
+# Returns all certificates for task_id, including superseded ones, ordered oldest-first.
+
+new_cert = session.supersede_certificate(
+    task_id="task-abc-123",
+    reason="Policy version 2.1 invalidated gate configuration used in original run.",
+)
+# Mints a new PROVISIONAL certificate for the same task_id.
+# Marks the current authoritative certificate as SUPERSEDED.
+# Sets new_cert.supersedes = old_cert.certificate_id.
+```
+
+### 5. The Supersession Doctrine
+
+Certificates are never revoked. The distinction matters:
+
+- **Revocation** implies "this record should not have existed; treat it as if it never happened."
+  This creates legal and audit ambiguity: was the process followed or not? Regulators and
+  auditors cannot work with erasure.
+- **Supersession** implies "this record happened; a newer record is now the authoritative
+  reference; the old record is preserved as part of the audit trail."
+
+If a task is re-run because the first run was executed under a defective policy version,
+the correct action is: mint a new certificate for the same `task_id` (which supersedes the
+original), with `supersedes` pointing back to the original certificate's `certificate_id`.
+Both certificates remain in storage. Queries for the authoritative certificate return the
+new one; queries with `include_superseded=True` return the full chain.
+
+### 6. Post-Hoc Verification
+
+Any party with access to the evidence store may verify a minted certificate:
+
+```python
+from lionagi.protocols.generic.pile import Pile
+from lionagi.protocols.governance.certificate import (
+    CertificateVerificationFinding,
+    CertificateVerificationResult,
+    verify_certificate,
+)
+
+
+result: CertificateVerificationResult = await verify_certificate(
+    certificate=cert,
+    evidence_store=session.evidence_store,
+)
+# Returns CertificateVerificationResult with fields:
+#   chain_intact: bool        — evidence chain hashes all match
+#   policy_consistent: bool   — gate decisions match policy_version_active rules
+#   content_unmodified: bool  — cert.content_hash() matches stored hash at minting time
+#   findings: Pile[CertificateVerificationFinding] — anomalies found, empty if clean
+```
+
+Verification re-walks the evidence chain starting from `evidence_chain_head`, verifying each
+node's `prev_hash` pointer (ADR-0041). It then replays the gate decisions recorded in
+`gates_passed` and `gates_failed` against the policy version stored in `policy_version_active`
+(fetched from the policy store, ADR-0052). If the policy version is no longer available
+(e.g., it was retired), verification returns `policy_consistent: None` (indeterminate) rather
+than `False` — absence of the historical policy is not evidence of tampering.
+
+### 7. Integration with Break-Glass (ADR-0045)
+
+When break-glass is invoked during a governed task execution, the following occurs
+automatically:
+
+1. The pending certificate transitions from `GATED` to `BREAK_GLASS`.
+2. `defensibility` is set to `DEGRADED`. This cannot be overridden by any attestation.
+3. The gate that was bypassed is moved to `gates_failed` with `override_invoked=True`.
+4. The break-glass event is recorded as an evidence node in the chain (ADR-0041).
+
+A `BREAK_GLASS` certificate may still reach `MINTED` state. A `DEGRADED` certificate is a
+legitimate, auditable record — it is not an error condition. It is the system correctly
+recording that an exception was taken. The operator's audit surface (KHive) can filter for
+`defensibility=DEGRADED` to surface tasks that require human review without rejecting them
+outright.
+
+### 8. Certificate Storage
+
+`TaskCertificate` objects are stored as `ImmutableEvidenceNode` entries in the evidence store
+(ADR-0041). The evidence node's `content_hash` field contains the value returned by
+`TaskCertificate.content_hash()`. This means the certificate itself is hash-chained into the
+same evidence store that records all other governed artifacts, providing a single integrity
+surface.
+
+Certificates are also indexed by `task_id` in a separate lookup table for efficient retrieval
+by `session.get_certificate(task_id)`. The lookup table records only the `certificate_id`
+and `task_id`; the full certificate content lives in the evidence store.
+
+## Consequences
+
+**Positive**
+
+- Audit queries that previously required forensic log reconstruction are answered by a single
+  `session.get_certificate(task_id)` call.
+- Process adherence is verifiable post-hoc without access to the original session or branch —
+  only the evidence store is required.
+- The supersession chain preserves a complete correction history; corrections do not erase
+  prior records.
+- Break-glass paths are automatically promoted to auditable `DEGRADED` certificates; no
+  special instrumentation is needed at the call site.
+- Certificates compose with ADR-0041 (evidence nodes), ADR-0044 (gate records), and ADR-0050
+  (operation context) without redundant storage — they reference, not duplicate.
+
+**Negative**
+
+- Storage growth is unbounded for long-lived KHive deployments. Superseded certificates are
+  never deleted. Operators must provision accordingly.
+- Adding `emit_certificate` / `mint_certificate` calls to every governed task path increases
+  surface area for implementation bugs. The minting precondition checks must be exhaustive
+  or they provide false assurance.
+- Two-phase emission (PROVISIONAL at task start, MINTED at task end) complicates crash
+  recovery: PROVISIONAL certificates for tasks that crashed without minting must be detected
+  and flagged. A background reconciliation job is required.
+- Verification requires the historical policy version to be available. Policy retirement
+  without archival causes `policy_consistent: None` indeterminate results on old certificates.
+
+## Non-Goals
+
+Explicitly out of scope:
+
+- **Outcome correctness verification**: A `MINTED` certificate with `defensibility=FULL`
+  asserts that the process was followed. It does not assert that the task's output is correct,
+  safe, or consistent with the operator's intent. Outcome verification is a separate concern
+  (evaluation, human review).
+- **Cryptographic signing with asymmetric keys (RSA/Ed25519)**: prior research uses
+  RSA-4096. For v1 lionagi, SHA-256 content hashing and chain integrity (ADR-0041) are
+  sufficient. Key management infrastructure for asymmetric signing is deferred to a future
+  ADR targeting KHive enterprise deployments.
+- **Human-signing UI**: The `Attestation` dataclass supports human attestations.
+  The UI for collecting them is a KHive product concern, not a lionagi framework concern.
+- **Multi-tenant certificate namespacing**: Certificates for different tenants sharing a
+  KHive deployment must be isolated. Tenant namespacing is deferred to KHive's multi-tenancy
+  layer.
+- **Certificate revocation**: Deliberately absent. See supersession doctrine (section 5).
+  Implementing revocation would undermine the audit guarantees this ADR is designed to provide.
+- **Per-tool-call certificates**: Tool gates (ADR-0044) produce `GateRecord` entries that
+  are aggregated into the task-level certificate. Per-call certificates are too granular
+  for the audit use case and would produce certificate volumes that are unmanageable in
+  practice.
+- **Real-time certificate streaming**: Certificates are finalized at task completion.
+  Streaming partial certificate state to external systems during execution is out of scope;
+  that use case is served by the evidence stream (ADR-0041).
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|------------|--------------|
+| Store task status in session metadata | Session metadata is mutable and not tamper-evident. An agent (or a bug) can overwrite `session.metadata["task_status"] = "passed"` with no audit trail. This is logs, not evidence. |
+| Per-tool certificates (one per `ActionRequest`) | Too granular. An agent making 30 tool calls would produce 30 certificates. Aggregating them into a coherent task-level record still requires a task certificate; per-tool certificates are redundant intermediate artifacts. |
+| No certificates; rely on DataLogger + evidence nodes | DataLogger entries (ADR-0049) are mutable-tier by default. Evidence nodes (ADR-0041) record what happened but not whether the process was correctly followed. Neither alone asserts "all required gates passed under this policy version." The combination is not equivalent to a certificate. |
+| Certificate revocation instead of supersession | Revocation creates legal ambiguity ("did this task happen?"). Supersession preserves the full audit trail while clearly marking which record is authoritative. Adopted from prior research which rejected revocation for the same reason. |
+| Embed full evidence content in certificate | Evidence nodes can be arbitrarily large (file diffs, LLM responses). Embedding them in the certificate violates separation of concerns and makes storage unpredictable. The certificate references evidence via `evidence_chain_head`; retrieval traverses the chain (ADR-0041). |
+
+## References
+
+- [ADR-0041](ADR-0041-immutable-evidence-nodes.md) — certificates are evidence nodes; `evidence_chain_head` points into the immutable chain
+- [ADR-0044](ADR-0044-tool-gates.md) — HARD/SOFT/ADVISORY gate records aggregated into certificate
+- [ADR-0045](ADR-0045-break-glass-protocol.md) — break-glass invocation transitions certificate to BREAK_GLASS state with DEGRADED defensibility
+- [ADR-0050](ADR-0050-operation-context.md) — `policy_version_active` and `operation_context_hash` sourced from OperationContext
+- [ADR-0052](ADR-0052-policy-resolution.md) — policy version fetched for post-hoc verification replay
+- [ADR-0033](ADR-0033-unified-entity-state-model.md) — `EvidenceRef` substrate; certificates produce an `EvidenceRef` of kind `artifact`
+- [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) — "Evidence is first-class, not logs" principle instantiated here
+- prior governance research `01_design/007-decision-certificate/ADR-007-decision-certificate.md` — source pattern (decision certificate architecture, supersession doctrine, attestation records)

--- a/docs/adrs/ADR-0043-governed-tool-declaration.md
+++ b/docs/adrs/ADR-0043-governed-tool-declaration.md
@@ -1,0 +1,822 @@
+# ADR-0043: Governed Tool Declaration
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Depends on**: [ADR-0041](ADR-0041-immutable-evidence-nodes.md), [ADR-0050](ADR-0050-operation-context.md)
+**Related**: [ADR-0044](ADR-0044-tool-gates.md), [ADR-0051](ADR-0051-tool-registry-allowlists.md), [ADR-0033](ADR-0033-unified-entity-state-model.md), [ADR-0023](ADR-0023-unified-hook-system.md)
+
+---
+
+## Context
+
+lionagi today allows any registered tool to be called without passing through any governance
+checkpoint. A caller invokes `branch.operate(instruction=..., tools=...)`, the `ActionManager`
+resolves the tool from its `Pile`, and hands arguments directly to `Tool.func_callable`. The only
+policy layer that can intervene is `PermissionPolicy` (`lionagi/agent/permissions.py`), which
+applies allowlist/denylist/escalate rules keyed by tool name and action string. `PermissionPolicy`
+is powerful for what it does, but it is a policy-side construct: it lives in `AgentConfig`, it is
+attached by the caller at agent creation time, and the tool itself carries no record of what
+constraints should apply to it.
+
+The structural gap is that enforcement metadata is not co-located with the tool. A `read_file` tool
+registered in one branch may require a confirmation gate; the same function registered in another
+branch has no gate at all. Whether governance applies depends entirely on whether the agent
+constructor remembered to attach the right policy — not on anything declared at the tool definition
+site. This violates cross-cutting principle #3: **every constraint must be enforced, not just
+documented**. A constraint that exists only in an `AgentConfig` dict can be silently absent.
+
+There is also no mandatory execution pipeline. Nothing prevents `Tool.func_callable` from being
+called directly — by test code, by a pre-processor, or by a branch that bypasses the normal
+`operate()` path. Evidence emission (`DataLogger`) is also optional and caller-driven. The result
+is that lionagi in library mode has no single audit point: different call sites emit different
+evidence shapes, and some emit none.
+
+### The applicable prior governance research insight
+
+prior research establishes that "if there is ANY path that bypasses the enforcement pipeline,
+compliance is broken." The solution is not more policy configuration — it is a single mandatory
+pipeline (`CanonService.request()`) where every phase is non-optional and the underlying handler
+is unreachable from outside the pipeline. ADR-010 completes the picture: governance metadata
+(`@action` decorator, `ActionMeta` frozen dataclass) is attached to the handler at definition
+time, not assembled at invocation time. Co-location is what makes drift impossible.
+
+Translated to lionagi: the `@governed_tool` decorator plays the role of `@action`, and
+`ActionManager.execute_governed()` plays the role of `CanonService.request()`. The `Tool` class
+remains as the schema and callable carrier; governance metadata is a separate, frozen attachment.
+
+### Why lionagi needs this
+
+Consider a KHive agent writing to a code repository. The `write_file` tool must: confirm that the
+target path is inside an allowed workspace (HARD gate), require an explicit justification when the
+path is outside a designated source tree (SOFT gate), log a warning when the diff exceeds 500
+lines (ADVISORY gate), and emit an evidence node that links the write operation to its operation
+context. In the current architecture, all of this must be wired manually in the `AgentConfig`
+hooks. If the hook is omitted, the tool runs ungated with no evidence. The first time a new
+developer registers `write_file` in a new agent, they must know to also attach four hooks and a
+custom `DataLogger` flush. This is not governance; it is documentation that governance is
+possible.
+
+With `@governed_tool`, the gate declarations travel with the function definition. Any agent that
+registers `write_file` automatically gets all its governance — not because the caller remembered
+to configure it, but because the decorator made it unconditional.
+
+---
+
+## Decision
+
+Introduce a `@governed_tool` decorator that co-locates enforcement metadata with the tool
+function at definition time, and a mandatory `ActionManager.execute_governed()` pipeline that
+enforces a fixed eight-phase sequence with no bypass path.
+
+---
+
+### 1. `GovernedToolMeta` — Frozen Metadata Dataclass
+
+Governance metadata is stored in a frozen `Element` subclass attached to the existing `Tool`
+primitive as `Tool.governance_meta`. Frozen because no runtime code should be able to relax a
+constraint after the tool is defined.
+
+```python
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+
+SafetyClass = Literal["standard", "sensitive", "privileged"]
+GateLevel = Literal["hard", "soft", "advisory"]
+
+
+class ToolGateDeclaration(Element):
+    """A single tool-level gate declaration resolved by ADR-0044."""
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    gate_id: str
+    enforcement: GateLevel
+    justification_prompt: str | None = None
+
+
+def _gate_pile() -> Pile[ToolGateDeclaration]:
+    return Pile(item_type={ToolGateDeclaration})
+
+
+class GovernedToolMeta(Element):
+    """Frozen governance metadata stored on the existing Tool primitive."""
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    # Evidence chain
+    evidence_type: str | None = None
+    """Dot-separated category written into every evidence node produced by
+    this tool.  If None, defaults to the function name at registration time."""
+
+    skip_evidence: bool = False
+    """True only for hot-path read-only probes where evidence is noise
+    (e.g. status checks, health pings).  Default False."""
+
+    # Gate declarations — resolved against the registry in ADR-0044
+    hard_gates: Pile[ToolGateDeclaration] = Field(default_factory=_gate_pile)
+    """Gates whose failure terminates the call immediately.  No justification
+    can override a hard-gate failure.  Evaluated before soft gates."""
+
+    soft_gates: Pile[ToolGateDeclaration] = Field(default_factory=_gate_pile)
+    """Gates that pause execution and require a documented justification to
+    proceed.  May continue after justification is accepted."""
+
+    advisory_gates: Pile[ToolGateDeclaration] = Field(default_factory=_gate_pile)
+    """Gates that emit a warning and proceed unconditionally.  Used for
+    metrics, audit noise, and developer feedback."""
+
+    # Input schema
+    options_schema: type[BaseModel] | None = Field(default=None, exclude=True)
+    """Pydantic model for input normalization (Phase 1).  When provided,
+    raw kwargs are coerced through this model before reaching the handler."""
+
+    # Classification
+    safety_class: SafetyClass = "standard"
+    """standard | sensitive | privileged.  Drives which additional class-level
+    gates the registry adds per ADR-0044 specificity rules."""
+
+    # Sentinel — set by the decorator, not the caller
+    _IS_GOVERNED: ClassVar[bool] = True
+
+
+# In lionagi/protocols/action/tool.py, extend the existing class in place.
+class Tool(Element):
+    ...
+
+    governance_meta: GovernedToolMeta | None = Field(
+        default=None,
+        description="Optional governance metadata declared by @governed_tool.",
+    )
+```
+
+### 2. `@governed_tool` Decorator
+
+The decorator builds a normal `Tool` instance, attaches `GovernedToolMeta`, and binds governance
+phases through `Tool.preprocessor` and `Tool.postprocessor`.
+
+```python
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import Any
+
+from pydantic import BaseModel
+
+from lionagi.protocols.action.tool import Tool
+from lionagi.protocols.generic.pile import Pile
+
+
+class GovernanceBypassError(RuntimeError):
+    """Raised when a governed tool is called directly, bypassing the pipeline."""
+
+
+def _make_gate_pile(
+    gate_ids: Iterable[str] | Pile[ToolGateDeclaration],
+    enforcement: GateLevel,
+) -> Pile[ToolGateDeclaration]:
+    if isinstance(gate_ids, Pile):
+        return gate_ids
+
+    gates = Pile(item_type={ToolGateDeclaration})
+    for gate_id in gate_ids:
+        gates.include(ToolGateDeclaration(gate_id=gate_id, enforcement=enforcement))
+    return gates
+
+
+async def governed_tool_preprocessor(
+    kwargs: dict[str, Any],
+    *,
+    governance_meta: GovernedToolMeta,
+    context: "GovernedToolCallContext",
+) -> dict[str, Any]:
+    """Phases 1-6 run through Tool.preprocessor before func_callable."""
+    if governance_meta.options_schema is not None:
+        validated = governance_meta.options_schema(**kwargs)
+        kwargs = validated.model_dump(exclude_unset=True)
+
+    context.normalized_inputs = dict(kwargs)
+    if not governance_meta.skip_evidence and context.operation_context_id is None:
+        raise MissingOperationContextError(
+            "Governed tools require OperationContext unless skip_evidence=True."
+        )
+
+    for gate in await resolve_governed_gates(governance_meta, context):
+        result = await run_gate(gate, kwargs, context)
+        context.gate_results.include(result)
+        if gate.enforcement == "hard" and not result.passed:
+            evidence_id = await emit_gate_failure_evidence(gate, result, context)
+            raise GateBlockedError(
+                gate_id=gate.gate_id,
+                tool_name=context.tool_name,
+                reason=result.reason,
+                evidence_node_id=evidence_id,
+            )
+        if gate.enforcement == "soft" and not result.passed and not context.justification:
+            raise JustificationRequiredError(
+                gate_id=gate.gate_id,
+                tool_name=context.tool_name,
+                prompt=result.justification_prompt or result.reason,
+            )
+
+    return kwargs
+
+
+async def governed_tool_postprocessor(
+    result: Any,
+    *,
+    governance_meta: GovernedToolMeta,
+    context: "GovernedToolCallContext",
+) -> Any:
+    """Phase 8 runs through Tool.postprocessor after func_callable."""
+    if not governance_meta.skip_evidence:
+        await emit_success_evidence(result, governance_meta, context)
+    return result
+
+
+def governed_tool(
+    *,
+    evidence_type: str | None = None,
+    hard_gates: Iterable[str] | Pile[ToolGateDeclaration] = (),
+    soft_gates: Iterable[str] | Pile[ToolGateDeclaration] = (),
+    advisory_gates: Iterable[str] | Pile[ToolGateDeclaration] = (),
+    skip_evidence: bool = False,
+    safety_class: SafetyClass = "standard",
+    options_schema: type[BaseModel] | None = None,
+) -> Callable[[Callable[..., Any]], Tool]:
+    """Decorator that returns the existing Tool primitive with governance_meta.
+
+    Usage::
+
+        @governed_tool(
+            evidence_type="repo_write",
+            hard_gates=["guard_destructive"],
+            soft_gates=["confirm_path_outside_workspace"],
+            advisory_gates=["warn_large_diff"],
+            safety_class="standard",
+            options_schema=WriteFileOptions,
+        )
+        async def write_file(path: str, content: str) -> WriteResult: ...
+
+    The decorated name is a Tool, not a second GovernedTool hierarchy.
+    Governance phases bind through Tool.preprocessor and Tool.postprocessor.
+    """
+
+    def decorator(fn: Callable[..., Any]) -> Tool:
+        meta = GovernedToolMeta(
+            evidence_type=evidence_type or fn.__name__,
+            skip_evidence=skip_evidence,
+            hard_gates=_make_gate_pile(hard_gates, "hard"),
+            soft_gates=_make_gate_pile(soft_gates, "soft"),
+            advisory_gates=_make_gate_pile(advisory_gates, "advisory"),
+            options_schema=options_schema,
+            safety_class=safety_class,
+        )
+        fn.__governance_meta__ = meta  # type: ignore[attr-defined]
+        return Tool(
+            func_callable=fn,
+            request_options=options_schema,
+            governance_meta=meta,
+            preprocessor=governed_tool_preprocessor,
+            preprocessor_kwargs={"governance_meta": meta},
+            postprocessor=governed_tool_postprocessor,
+            postprocessor_kwargs={"governance_meta": meta},
+        )
+
+    return decorator
+
+
+def is_governed(tool: Tool | Callable[..., Any]) -> bool:
+    """Return True if a Tool or raw callable carries GovernedToolMeta."""
+    if isinstance(tool, Tool):
+        return tool.governance_meta is not None
+    return hasattr(tool, "__governance_meta__")
+
+
+def get_governed_meta(tool: Tool | Callable[..., Any]) -> GovernedToolMeta:
+    """Return the ``GovernedToolMeta`` attached to a governed tool.
+
+    Raises ``TypeError`` if the Tool/callable is not governed.
+    """
+    meta = tool.governance_meta if isinstance(tool, Tool) else None
+    if meta is None:
+        meta = getattr(tool, "__governance_meta__", None)
+    if meta is None:
+        raise TypeError(
+            "Tool is not governed. Apply @governed_tool(...) or construct "
+            "Tool(governance_meta=..., preprocessor=..., postprocessor=...)."
+        )
+    return meta
+```
+
+### 3. Pipeline Context — Bypass Prevention Mechanism
+
+The pipeline binds per-call state into an invocation-local copy of the `Tool`. The original
+`Tool` stays reusable, while `Tool.preprocessor_kwargs` and `Tool.postprocessor_kwargs` carry the
+operation context, gate results, justification, Branch reference, and `DataLogger` for that call.
+
+```python
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import ConfigDict, Field
+
+from lionagi.agent.gates import GateResult
+from lionagi.protocols.action.tool import Tool
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.log import DataLogger
+from lionagi.protocols.generic.pile import Pile
+
+
+def _gate_result_pile() -> Pile[GateResult]:
+    return Pile(item_type={GateResult})
+
+
+class GovernedToolCallContext(Element):
+    """Per-call state bound into Tool pre/postprocessor kwargs."""
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+    )
+
+    tool_name: str
+    operation_context_id: str | None = None  # links to ADR-0050
+    justification: str | None = None
+    normalized_inputs: dict[str, Any] = Field(default_factory=dict)
+    gate_results: Pile[GateResult] = Field(default_factory=_gate_result_pile)
+    branch: Any | None = Field(default=None, exclude=True)
+    data_logger: DataLogger | None = Field(default=None, exclude=True)
+
+
+def bind_governed_context(tool: Tool, context: GovernedToolCallContext) -> Tool:
+    """Return an invocation-local Tool copy with pipeline context attached."""
+    kwargs = {"governance_meta": tool.governance_meta, "context": context}
+    return tool.model_copy(
+        update={
+            "preprocessor_kwargs": {**tool.preprocessor_kwargs, **kwargs},
+            "postprocessor_kwargs": {**tool.postprocessor_kwargs, **kwargs},
+        }
+    )
+```
+
+### 4. `ActionManager.execute_governed()` — The Mandatory Pipeline
+
+Eight phases, all non-optional. Phases 4–6 execute in strict order (hard → soft → advisory).
+No phase can be skipped by caller configuration.
+
+```python
+from __future__ import annotations
+
+from typing import Any
+
+from lionagi.protocols.action.function_calling import FunctionCalling
+from lionagi.protocols.action.tool import Tool
+from lionagi.protocols.generic.log import DataLogger
+
+
+class GateBlockedError(Exception):
+    """Raised when a HARD gate blocks execution."""
+
+    def __init__(
+        self,
+        gate_id: str,
+        tool_name: str,
+        reason: str,
+        evidence_node_id: str | None = None,
+    ) -> None:
+        self.gate_id = gate_id
+        self.tool_name = tool_name
+        self.reason = reason
+        self.evidence_node_id = evidence_node_id
+        super().__init__(f"Hard gate '{gate_id}' blocked '{tool_name}': {reason}")
+
+
+class JustificationRequiredError(Exception):
+    """Raised when a SOFT gate requires justification and none is provided."""
+
+    def __init__(self, gate_id: str, tool_name: str, prompt: str) -> None:
+        self.gate_id = gate_id
+        self.tool_name = tool_name
+        self.prompt = prompt
+        super().__init__(
+            f"Soft gate '{gate_id}' requires justification for '{tool_name}': {prompt}"
+        )
+
+
+class MissingOperationContextError(Exception):
+    """Raised when a governed tool requires ADR-0050 context and none exists."""
+
+
+class ActionManager:
+    """Facade over the Tool Pile; governs all tool executions.
+
+    This extends the existing ActionManager path. Governed tools are still
+    ordinary Tool instances; their phases run through Tool.preprocessor,
+    FunctionCalling._invoke(), and Tool.postprocessor.
+    """
+
+    async def execute_governed(
+        self,
+        tool: Tool,
+        raw_kwargs: dict[str, Any],
+        *,
+        branch: Any | None = None,
+        operation_context_id: str | None = None,
+        justification: str | None = None,
+        data_logger: DataLogger | None = None,
+    ) -> Any:
+        """Execute a governed tool through the mandatory eight-phase pipeline.
+
+        Args:
+            tool: The registered ``Tool`` with ``governance_meta`` attached.
+            raw_kwargs: Raw keyword arguments from the LLM's ``ActionRequest``.
+            branch: Calling Branch, supplied for gate hooks that need manager access.
+            operation_context_id: ID of the active OperationContext (ADR-0050).
+                Required for governed tools; raises if absent and tool is not
+                skip_evidence.
+            justification: Caller-supplied justification for SOFT gate bypass.
+            data_logger: Branch ``DataLogger`` used for evidence emission.
+
+        Returns:
+            The handler's return value on success.
+
+        Raises:
+            GateBlockedError: If any HARD gate fails.
+            JustificationRequiredError: If a SOFT gate fails and no justification
+                is supplied.
+            MissingOperationContextError: If the tool is governed and
+                operation_context_id is None (per ADR-0050).
+        """
+        meta = get_governed_meta(tool)
+        if not meta.skip_evidence and operation_context_id is None:
+            raise MissingOperationContextError(
+                f"Governed tool '{tool.function}' requires an active OperationContext "
+                f"(ADR-0050).  Pass operation_context_id= or set skip_evidence=True."
+            )
+
+        context = GovernedToolCallContext(
+            tool_name=tool.function,
+            operation_context_id=operation_context_id,
+            justification=justification,
+            branch=branch,
+            data_logger=data_logger,
+        )
+        invocation_tool = bind_governed_context(tool, context)
+
+        # FunctionCalling._invoke() supplies the existing execution lifecycle:
+        # Phase 1-6: Tool.preprocessor
+        # Phase 7:   Tool.func_callable
+        # Phase 8:   Tool.postprocessor
+        function_call = FunctionCalling(
+            func_tool=invocation_tool,
+            arguments=raw_kwargs,
+        )
+        try:
+            await function_call.invoke()
+        except Exception as exc:
+            await emit_execution_failure_evidence(exc, meta, context)
+            raise
+
+        return function_call.execution.response
+
+    async def execute_raw(
+        self,
+        tool: Tool,
+        kwargs: dict[str, Any],
+    ) -> Any:
+        """Execute an ungoverned tool without the governance pipeline.
+
+        Only available in library mode.  KHive mode raises ``GovernanceModeError``
+        from this method at startup configuration.
+
+        Ungoverned tools registered via ``branch.register_tools([plain_function])``
+        continue to work through this path with zero configuration changes.
+        """
+        if is_governed(tool):
+            raise GovernanceBypassError(
+                f"Governed tool '{tool.function}' must use execute_governed()."
+            )
+
+        function_call = FunctionCalling(func_tool=tool, arguments=kwargs)
+        await function_call.invoke()
+        return function_call.execution.response
+```
+
+### 5. Evidence Emission on Success and Failure
+
+Phase 8 emits an evidence node per ADR-0041. The node carries the gate results active at
+execution time ("active assertion") so the evidence is self-contained for audit.
+
+```python
+from __future__ import annotations
+
+from typing import Any
+
+from lionagi.protocols.generic.log import Log
+from lionagi.protocols.governance.evidence import ImmutableEvidenceNode  # ADR-0041
+
+
+class MissingEvidenceLoggerError(Exception):
+    """Raised when evidence must be emitted but Branch DataLogger is absent."""
+
+
+async def _log_evidence(
+    node: ImmutableEvidenceNode,
+    context: GovernedToolCallContext,
+) -> str:
+    if context.data_logger is None:
+        raise MissingEvidenceLoggerError(
+            f"Governed tool '{context.tool_name}' requires Branch DataLogger."
+        )
+    await context.data_logger.alog(Log.create(node))
+    return str(node.id)
+
+
+async def emit_success_evidence(
+    result: Any,
+    meta: GovernedToolMeta,
+    context: GovernedToolCallContext,
+) -> str:
+    """Emit immutable evidence for a successful Tool.postprocessor phase."""
+    node = ImmutableEvidenceNode(
+        kind="tool_result",  # EvidenceRef kind from ADR-0033
+        evidence_type=meta.evidence_type,
+        tool_name=context.tool_name,
+        operation_context_id=context.operation_context_id,
+        inputs_summary=_redact_sensitive(context.normalized_inputs, meta.safety_class),
+        result_summary=_redact_sensitive(result, meta.safety_class),
+        outcome="success",
+        justification=context.justification,
+        gate_results=[r.to_dict(mode="json") for r in context.gate_results],
+    )
+    return await _log_evidence(node, context)
+
+
+async def emit_gate_failure_evidence(
+    gate: ToolGateDeclaration,
+    gate_result: Any,
+    context: GovernedToolCallContext,
+) -> str:
+    """Emit immutable evidence for a HARD gate block."""
+    node = ImmutableEvidenceNode(
+        kind="tool_result",
+        evidence_type=context.tool_name,
+        tool_name=context.tool_name,
+        operation_context_id=context.operation_context_id,
+        outcome="gate_blocked",
+        gate_id=gate.gate_id,
+        gate_reason=gate_result.reason,
+    )
+    return await _log_evidence(node, context)
+
+
+async def emit_execution_failure_evidence(
+    exc: Exception,
+    meta: GovernedToolMeta,
+    context: GovernedToolCallContext,
+) -> str:
+    """Emit immutable evidence when the handler fails after gates pass."""
+    node = ImmutableEvidenceNode(
+        kind="tool_result",
+        evidence_type=meta.evidence_type,
+        tool_name=context.tool_name,
+        operation_context_id=context.operation_context_id,
+        inputs_summary=_redact_sensitive(context.normalized_inputs, meta.safety_class),
+        outcome="execution_failed",
+        error_type=type(exc).__name__,
+        error_message=str(exc),
+        gate_results=[r.to_dict(mode="json") for r in context.gate_results],
+    )
+    return await _log_evidence(node, context)
+```
+
+### 6. Bypass Prohibition — Why It Is Enforced at Runtime
+
+`@governed_tool` returns a `Tool`, not a directly callable wrapper. A governed tool that reaches
+the legacy raw path raises `GovernanceBypassError`, and a governed `Tool` invoked without the
+context bound by `ActionManager.execute_governed()` fails in its `Tool.preprocessor` before the
+handler runs. The enforcement mechanism is:
+
+1. `execute_governed()` creates a `GovernedToolCallContext` containing the operation context,
+   gate result `Pile`, justification, Branch reference, and `DataLogger`.
+2. `bind_governed_context()` copies the existing `Tool` and attaches that context to
+   `Tool.preprocessor_kwargs` and `Tool.postprocessor_kwargs`.
+3. `FunctionCalling._invoke()` runs the existing lifecycle: preprocessor, handler,
+   postprocessor. Missing context means the preprocessor cannot run the governed phases and the
+   call fails closed before `Tool.func_callable`.
+
+This means tests must invoke governed tools via `ActionManager.execute_governed()` with mock gate
+hooks and a mock `DataLogger`. This is intentional: it forces tests to exercise the pipeline, not
+just the handler.
+
+### 7. Backward Compatibility — Library Mode
+
+Ungoverned tools registered via `branch.register_tools([plain_function])` are unaffected.
+The `ActionManager` dispatches via `execute_raw()` when `is_governed(tool)` is
+`False`. No existing library-mode code changes.
+
+The governance pipeline is opt-in at the tool definition site:
+
+| Tool definition | `is_governed` | Dispatch path |
+|---|---|---|
+| `def my_tool(...): ...` | False | `execute_raw()` — legacy behavior |
+| `@governed_tool(...) async def my_tool(...): ...` | True | `execute_governed()` — mandatory pipeline |
+
+KHive mode (commercial) will configure `ActionManager` to reject ungoverned tools at
+registration time: `execute_raw()` raises `GovernanceModeError` when `khive_mode=True`.
+This is a configuration flag, not a code change — library-mode callers are unaffected.
+
+---
+
+## Worked Example
+
+A governed `read_file` tool illustrating the full lifecycle.
+
+```python
+from pydantic import BaseModel
+
+
+class ReadFileOptions(BaseModel):
+    path: str
+    encoding: str = "utf-8"
+    max_bytes: int = 1_048_576  # 1 MiB
+
+
+class ReadFileResult(BaseModel):
+    path: str
+    content: str
+    bytes_read: int
+
+
+@governed_tool(
+    evidence_type="fs.read",
+    hard_gates=["guard_paths"],          # block reads outside allowed roots
+    soft_gates=["confirm_sensitive_ext"],  # .env, .key, .pem require justification
+    advisory_gates=["warn_large_file"],  # warn if > max_bytes threshold
+    skip_evidence=False,
+    safety_class="standard",
+    options_schema=ReadFileOptions,
+)
+async def read_file(
+    path: str,
+    encoding: str = "utf-8",
+    max_bytes: int = 1_048_576,
+) -> ReadFileResult:
+    """Read a file from the filesystem."""
+    import aiofiles
+
+    async with aiofiles.open(path, encoding=encoding) as fh:
+        content = await fh.read(max_bytes)
+
+    return ReadFileResult(path=path, content=content, bytes_read=len(content.encode()))
+```
+
+**On successful execution** (path inside allowed root, not a sensitive extension):
+
+- Phase 1: `ReadFileOptions(path=..., encoding="utf-8", max_bytes=1048576)` coerced.
+- Phase 2: `operation_context_id` must be set by the calling Branch.
+- Phase 3: Gate registry resolves `guard_paths` (hard), `confirm_sensitive_ext` (soft),
+  `warn_large_file` (advisory).
+- Phase 4: `guard_paths` passes — path is inside `allowed_roots`.
+- Phase 5: `confirm_sensitive_ext` passes — file extension is `.py`.
+- Phase 6: `warn_large_file` passes — file is 2 KiB.
+- Phase 7: Handler runs; returns `ReadFileResult`.
+- Phase 8: Evidence node emitted:
+
+  ```json
+  {
+    "ln_id": "01JXKM...",
+    "kind": "tool_result",
+    "evidence_type": "fs.read",
+    "tool_name": "read_file",
+    "operation_context_id": "01JXKL...",
+    "outcome": "success",
+    "gate_results": {
+      "guard_paths": "passed",
+      "confirm_sensitive_ext": "passed",
+      "warn_large_file": "passed"
+    },
+    "immutable": true
+  }
+  ```
+
+**On `guard_paths` failure** (path outside allowed root):
+
+- Phases 1–3: same as above.
+- Phase 4: `guard_paths` fails → `GateBlockedError` raised immediately.
+- Evidence node emitted with `"outcome": "gate_blocked", "gate_id": "guard_paths"`.
+- Phases 5–8 do not execute. The handler is never called.
+
+**On `.env` read without justification**:
+
+- Phase 4: `guard_paths` passes (`.env` is inside allowed root).
+- Phase 5: `confirm_sensitive_ext` fails, `justification=None` →
+  `JustificationRequiredError` raised with `prompt="Reading .env file requires a
+  documented reason."`.
+- The caller must re-invoke with `justification="Debugging auth config in dev environment"`.
+
+---
+
+## Consequences
+
+**Positive**
+
+- **Single audit point**: every governed tool call emits evidence. No call site can opt out.
+- **Governance visible at definition**: reading the function tells you exactly what gates apply
+  and what evidence category is emitted. No separate config file lookup required.
+- **Fail-closed universally**: Phase 2 raises on missing Operation Context; Phase 4 raises on
+  any hard gate failure; any exception in Phase 7 emits failure evidence. Ambiguity → deny.
+  This is cross-cutting principle #1 made structural.
+- **Testability**: `GovernanceBypassError` and missing-context preprocessor failures force test
+  authors to exercise the pipeline. Integration with mock gate hooks and `DataLogger` is explicit,
+  not accidental.
+- **Backward compatibility**: ungoverned tools registered via `register_tools()` continue to
+  work without any migration. The decorator is an opt-in escalation, not a breaking change.
+- **Evidence carries gate results**: the evidence node records which gates ran and their
+  outcomes at execution time. This satisfies cross-cutting principle #2 — evidence is not
+  just a log entry; it encodes the policy state active at the moment of execution.
+
+**Negative**
+
+- **Decorator boilerplate**: each governed tool needs `@governed_tool(...)` with meaningful
+  gate declarations. A tool with no metadata compiles but defeats the purpose.
+- **Direct-call friction in tests**: decorated governed tools are `Tool` instances, and governed
+  `Tool` instances cannot use the raw path. Test authors must adapt to call through
+  `ActionManager.execute_governed()`.
+- **Sequential gate execution**: the eight-phase pipeline adds latency proportional to the
+  number of gates resolved. For `skip_evidence=True` tools with no gates, the overhead is
+  a single preprocessor context check per call.
+- **Invocation-local context copy**: `execute_governed()` must bind a fresh context copy for each
+  call. Reusing a shared `Tool` without rebinding context fails closed in the preprocessor; this is
+  safer than silently sharing gate results across concurrent calls.
+
+---
+
+## Non-Goals
+
+Explicitly out of scope:
+
+- **Gate implementation** (what each gate does, how gate results are computed): this is
+  ADR-0044. This ADR only declares the gate slots and the execution order.
+- **JIT grants and break-glass overrides**: an agent acquiring a tool grant at runtime is
+  ADR-0046. This ADR does not address dynamic permission escalation.
+- **Multi-tenant policy resolution** (which gates apply to which tenants): this is ADR-0052.
+  The `GovernedToolMeta` carries tool-level declarations; tenant-level policy overlay is
+  a KHive concern resolved before Phase 3.
+- **Tool registry** (where governed tools are stored, how they are discovered, what allowlists
+  look like): this is ADR-0051. This ADR concerns declaration at definition time; the
+  registry concern is how those declarations are indexed at runtime.
+- **Task Certificate** (the signed proof that all phases completed): this is ADR-0042.
+  Evidence nodes emitted in Phase 8 feed the certificate, but certificate construction
+  is outside this ADR's scope.
+- **Log tier governance** (whether evidence nodes are MUTABLE/PROTECTED/IMMUTABLE): this
+  is ADR-0049. Evidence nodes produced in Phase 8 are always IMMUTABLE per ADR-0041;
+  the tier assignment protocol is separate.
+
+---
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|---|---|
+| **Middleware pattern** (framework-level hook wrapping all tool calls) | Action-specific gates are impossible: middleware sees tool name and args, not tool-level declarations. A `guard_paths` gate for `read_file` and a `guard_destructive` gate for `write_file` cannot be differentiated at the middleware layer without rebuilding the same per-tool metadata structure this ADR provides. Rejected per prior research. |
+| **Policy-only enforcement** (extend `PermissionPolicy` with gate declarations) | Enforcement metadata remains at the call site (agent constructor), not the tool definition. Two agents registering the same `write_file` function can have inconsistent policies. Drift is structurally permitted. Violates principle #3. |
+| **Separate config files** (`governance.yaml` mapping function names to gate lists) | Config files desync from code: rename a function, forget to update the config, governance silently breaks. Co-location is not optional when the goal is "every constraint enforced." |
+| **Multiple decorators** (`@gate_check`, `@emit_evidence`, `@fail_closed` separately) | Ordering between decorators is implicit. A developer can apply `@emit_evidence` without `@gate_check`. There is no single place to read the full governance specification of a tool. Evidence correlation across phases is lost. Rejected per prior research `Decorator-Only Pattern`. |
+| **No governed tools** (keep current `PermissionPolicy` as the only layer) | Sufficient for library mode. Insufficient for KHive, where a regulated customer requires an audit trail that demonstrates every tool call was gated and every result was evidenced — not merely that a policy was configured. |
+
+---
+
+## References
+
+- [ADR-0041](ADR-0041-immutable-evidence-nodes.md) — Evidence nodes emitted in Phase 8; append-only store
+- [ADR-0044](ADR-0044-tool-gates.md) — Gate registry: what each gate ID resolves to, HARD/SOFT/ADVISORY semantics, specificity rules, class-level gate merging
+- [ADR-0050](ADR-0050-operation-context.md) — OperationContext required in Phase 2; links tool call to session and agent identity
+- [ADR-0051](ADR-0051-tool-registry-allowlists.md) — Where governed tools register; append-only allowlist entries
+- [ADR-0042](ADR-0042-task-certificate.md) — Task Certificate accumulates evidence nodes from Phase 8
+- [ADR-0046](ADR-0046-jit-tool-grant.md) — JIT grants acquired at runtime; interact with SOFT gate resolution
+- [ADR-0033](ADR-0033-unified-entity-state-model.md) — `EvidenceRef` kinds (tool_result, model_inference, etc.) used in Phase 8 evidence nodes
+- [ADR-0023](ADR-0023-unified-hook-system.md) — Existing hook system; `guard_destructive`, `guard_paths`, `log_tool_use` are candidates for migration to gate declarations
+- prior governance research `01_design/010-action-declaration/ADR-010-action-declaration.md` — `@action` decorator and `ActionMeta` frozen dataclass pattern
+- prior governance research `01_design/012-single-enforcement/ADR-012-single-enforcement.md` — `CanonService.request()` single entry point; "any bypass breaks compliance"

--- a/docs/adrs/ADR-0044-tool-gates.md
+++ b/docs/adrs/ADR-0044-tool-gates.md
@@ -1,0 +1,954 @@
+# ADR-0044: Tool Gates — Three-Tier Binary Enforcement
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Depends on**: [ADR-0043](ADR-0043-governed-tool-declaration.md), [ADR-0041](ADR-0041-immutable-evidence-nodes.md)
+**Related**: [ADR-0045](ADR-0045-break-glass-protocol.md), [ADR-0050](ADR-0050-operation-context.md), [ADR-0046](ADR-0046-jit-tool-grant.md), [ADR-0033](ADR-0033-unified-entity-state-model.md)
+
+---
+
+## Context
+
+lionagi today has three independent mechanisms that collectively serve as access control over
+tool calls: `PermissionPolicy` (allowlist/denylist/escalate mode in `lionagi/agent/permissions.py`),
+ad-hoc pre-hooks registered via `AgentConfig.pre()`, and two named hooks (`guard_destructive`,
+`guard_paths` in `lionagi/agent/hooks.py`). These mechanisms differ in failure semantics,
+composition, and auditability in ways that create gaps.
+
+`PermissionPolicy` operates on glob patterns and expresses three behaviors — allow, deny, escalate
+— but carries no evidence and does not distinguish between a hard safety requirement and a soft
+business rule. `guard_destructive` raises `PermissionError` unconditionally for any destructive
+command, with no path to justification or escalation. `guard_paths` likewise raises with no
+override mechanism. `log_tool_use` produces a log entry but contributes no evidence to the
+operation record. The result is that a framework consumer must reach into three different systems
+to answer the question "what constraints are active on this tool call, and can they be overridden?"
+
+Two of the three cross-cutting principles this governance slate enforces apply directly here.
+Principle 1 (fail-closed is the universal default) has no systematic expression today: some hooks
+raise on failure, some return `None`, and if an evaluator crashes the caller receives an unhandled
+exception rather than a clean deny. Principle 3 (every constraint must be enforced, not just
+documented) is violated when a `PermissionPolicy` in `mode="allow_all"` is in force and all hooks
+are simply not registered — there is no mechanism to guarantee a gate runs regardless of session
+configuration.
+
+### The applicable prior governance research insight
+
+prior research establishes that gates return `passed: bool` — no intermediate states, no
+confidence scores. The reasoning is precise: authorization is a question of fact, not of
+probability. "Did the user consent to this write?" has a yes or no answer. "Was this action
+covered by the granted capability?" has a yes or no answer. Confidence scores introduce threshold
+debates, legal ambiguity, and—critically—they shift the locus of the authorization decision from
+the gate to whoever chose the threshold. Binary semantics eliminate that ambiguity entirely.
+prior governance research also introduces the three-tier model (HARD_MANDATORY, SOFT_MANDATORY, ADVISORY) directly
+inspired by HashiCorp Sentinel, distinguishing irrevocable requirements from overridable business
+rules from informational warnings.
+
+### Why lionagi needs this
+
+A coding agent with a file-editor tool and no explicit gate registration can overwrite files
+outside the project workspace if `PermissionPolicy` is in `mode="allow_all"` (the default for
+orchestrators). Nothing in the current system guarantees that `guard_paths` runs. When an agent
+in a governed context (KHive tenant, Lion Studio session with audit logging) executes a write
+outside bounds, there is no evidence artifact recording that the write was ungated — the
+operation silently succeeds and appears identical to an explicitly approved one. The gate tier
+structure ensures that HARD gates cannot be absent from governed tools (enforced by
+[ADR-0043](ADR-0043-governed-tool-declaration.md)), and that every gate evaluation — whether
+passed or failed — produces a `GateResult` that becomes evidence in the operation record
+(enforced by [ADR-0050](ADR-0050-operation-context.md)).
+
+---
+
+## Decision
+
+We introduce `ToolGate`, a registered binary predicate with one of three enforcement tiers
+(HARD_MANDATORY, SOFT_MANDATORY, ADVISORY), where every evaluation produces a `GateResult` that
+is immutable evidence, and where any evaluator exception resolves to `passed=False` rather than
+propagating.
+
+---
+
+### 1. Core Types
+
+```python
+from __future__ import annotations
+
+import time
+from collections.abc import Awaitable, Callable
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+from pydantic import ConfigDict, Field
+
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+
+if TYPE_CHECKING:
+    from lionagi.protocols.messages.action_request import ActionRequest
+    from lionagi.session.branch import Branch
+    from lionagi.protocols.governance.evidence import EvidenceRef
+
+
+class GateEnforcement(Enum):
+    """Enforcement tier for a ToolGate.
+
+    HARD_MANDATORY: failure terminates the action with no override path.
+    SOFT_MANDATORY: failure pauses execution; a justification + evidence can
+                    unlock continuation per the active policy.
+    ADVISORY:       failure emits a warning; action proceeds unconditionally.
+    """
+
+    HARD_MANDATORY = "hard"
+    SOFT_MANDATORY = "soft"
+    ADVISORY = "advisory"
+
+
+GateEvaluator = Callable[
+    ["Branch", "ActionRequest", Any],
+    Awaitable["GateResult"],
+]
+
+
+class GateResult(Element):
+    """Immutable record of one gate evaluation.
+
+    Every field is populated on both pass and fail.  This record is
+    forwarded to the OperationContext (ADR-0050) and stored as an
+    ImmutableEvidenceNode (ADR-0041).
+
+    Fail-closed invariant: if the evaluator raised, ``passed`` is False
+    and ``reason`` contains the exception message.  No exception propagates
+    out of the gate executor.
+
+    If enforcement is SOFT_MANDATORY and the gate failed, the record may
+    later be amended with ``justification`` and ``justification_actor_id``
+    when an override is accepted.  The amended record is a new frozen
+    instance; the original is never mutated.
+    """
+
+    passed: bool
+    gate_id: str
+    enforcement: GateEnforcement
+    reason: str                               # always populated, even on pass
+    evaluated_at: float = Field(default_factory=time.monotonic)
+    evidence_refs: Pile["EvidenceRef"] = Field(
+        default_factory=lambda: Pile(item_type=Element, strict_type=False)
+    )
+    # Populated only when a SOFT gate is overridden:
+    justification: str | None = None
+    justification_actor_id: str | None = None
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=False,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    def with_justification(
+        self,
+        justification: str,
+        actor_id: str,
+    ) -> GateResult:
+        """Return a new GateResult carrying override justification.
+
+        The original record is preserved unchanged (immutable evidence).
+        The returned record represents the override decision, not a mutation.
+        """
+        return self.model_copy(
+            update={
+                "evidence_refs": Pile(
+                    collections=list(self.evidence_refs),
+                    item_type=Element,
+                    strict_type=False,
+                ),
+                "justification": justification,
+                "justification_actor_id": actor_id,
+            },
+            deep=True,
+        )
+
+
+class ToolGate(Element):
+    """A registered binary predicate applied before a governed tool call.
+
+    ``evaluator`` is an async callable with the existing gate hook signature::
+
+        async def evaluator(branch: Branch, tool_call: ActionRequest, context: object) -> GateResult:
+            ...
+
+    The adapter in ``lionagi/agent/gates/`` invokes this hook-shaped gate from
+    ``Tool.preprocessor`` so it participates in the current Branch action flow
+    without a parallel callback registry.
+
+    ``owner`` is a free-form string naming the subsystem that owns this gate
+    (e.g. ``"lionagi"``, ``"khive"``, ``"user"``).  Used in audit trails and
+    error messages only; no behavioral effect.
+    """
+
+    gate_id: str
+    enforcement: GateEnforcement
+    evaluator: GateEvaluator = Field(exclude=True)
+    description: str
+    owner: str                                # "lionagi" | "khive" | "user"
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=False,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+```
+
+### 2. Gate Registration
+
+Gates are managed through the existing `Branch` facade by mounting a `GateManager` on
+`branch.acts` (`ActionManager`).  Two attachment points mirror the existing hook system:
+
+- **Class-level gates** — attached to a tool's class via `@governed_tool(gates=[...])` (declared
+  in [ADR-0043](ADR-0043-governed-tool-declaration.md)).  All instances of the class carry these
+  gates; they run before action-level gates.
+- **Action-level gates** — attached to a specific callable (one action on one tool) via
+  `branch.attach_gate_to_action(tool, action, gate_id)`.
+
+```python
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from pydantic import Field
+
+from lionagi.agent.gates.types import ToolGate
+from lionagi.protocols.action.tool import Tool
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+
+if TYPE_CHECKING:
+    from lionagi.session.branch import Branch
+
+
+logger = logging.getLogger(__name__)
+
+
+class GateBinding(Element):
+    """Declarative attachment between a gate and a tool/action surface."""
+
+    gate_id: str
+    tool_name: str | None = None
+    action: str | None = None
+    tool_class_name: str | None = None
+
+    def matches(self, *, tool: Tool, action: str) -> bool:
+        class_name = tool.__class__.__name__
+        return (
+            bool(self.gate_id)
+            and self.tool_class_name in (None, class_name)
+            and self.tool_name in (None, tool.function)
+            and self.action in (None, action)
+        )
+
+
+class GateManager(Element):
+    """ActionManager-mounted collection of active ToolGates and bindings."""
+
+    gates: Pile[ToolGate] = Field(
+        default_factory=lambda: Pile(item_type=ToolGate, strict_type=True)
+    )
+    bindings: Pile[GateBinding] = Field(
+        default_factory=lambda: Pile(item_type=GateBinding, strict_type=True)
+    )
+
+    def register_gate(self, gate: ToolGate) -> None:
+        """Register a gate globally.  Duplicate gate_id replaces previous entry."""
+        duplicate = next((g for g in self.gates if g.gate_id == gate.gate_id), None)
+        if duplicate is not None:
+            logger.warning("gate_manager: replacing existing gate %s", gate.gate_id)
+            self.gates.exclude(duplicate)
+        self.gates.include(gate)
+
+    def attach_to_class(self, tool_class_name: str, gate_id: str) -> None:
+        """Attach a registered gate to all actions on a tool class."""
+        self.bindings.include(GateBinding(gate_id=gate_id, tool_class_name=tool_class_name))
+
+    def attach_to_action(self, tool_name: str, action: str, gate_id: str) -> None:
+        """Attach a registered gate to a specific tool action."""
+        self.bindings.include(GateBinding(gate_id=gate_id, tool_name=tool_name, action=action))
+
+    def gates_for(
+        self,
+        *,
+        branch: Branch,
+        tool_name: str,
+        action: str,
+    ) -> Pile[ToolGate]:
+        """Return ordered gates applicable to a call.
+
+        Order: class-level gates first (most general), then action-level
+        gates (most specific).  Within each tier, registration order is
+        preserved.  HARD gates are not sorted to the front here; the
+        executor handles early-exit semantics.
+        """
+        tool = branch.acts.registry.get(tool_name)
+        if tool is None:
+            return Pile(item_type=ToolGate, strict_type=True)
+
+        gates_by_id = {gate.gate_id: gate for gate in self.gates}
+        ordered: list[ToolGate] = []
+        seen: set[str] = set()
+        class_bindings = [
+            binding for binding in self.bindings if binding.tool_class_name is not None
+        ]
+        action_bindings = [
+            binding for binding in self.bindings if binding.tool_class_name is None
+        ]
+        for binding in [*class_bindings, *action_bindings]:
+            if binding.matches(tool=tool, action=action):
+                gate = gates_by_id.get(binding.gate_id)
+                if gate is not None and gate.gate_id not in seen:
+                    seen.add(gate.gate_id)
+                    ordered.append(gate)
+        return Pile(collections=ordered, item_type=ToolGate, strict_type=True)
+
+
+def ensure_gate_manager(branch: Branch) -> GateManager:
+    """Attach gate state to the existing ActionManager instead of a callback registry."""
+    manager = getattr(branch.acts, "gate_manager", None)
+    if manager is None:
+        manager = GateManager()
+        branch.acts.gate_manager = manager
+    return manager
+
+
+# Branch facade methods added by the gate integration:
+def register_gate(self: Branch, gate: ToolGate) -> None:
+    ensure_gate_manager(self).register_gate(gate)
+
+
+def attach_gate_to_action(self: Branch, tool_name: str, action: str, gate_id: str) -> None:
+    ensure_gate_manager(self).attach_to_action(tool_name, action, gate_id)
+```
+
+### 3. Gate Executor and Fail-Closed Invariant
+
+The executor runs all applicable gates and enforces the fail-closed invariant: if an evaluator
+raises for any reason, the result is `GateResult(passed=False, ...)` — not a propagated exception,
+not `passed=True`.  This is the most critical behavioral guarantee in this ADR.
+
+```python
+from __future__ import annotations
+
+import inspect
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+from pydantic import Field
+
+from lionagi.agent.gates.manager import ensure_gate_manager
+from lionagi.agent.gates.types import GateEnforcement, GateResult, ToolGate
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+from lionagi.protocols.messages.action_request import ActionRequest
+
+if TYPE_CHECKING:
+    from lionagi.protocols.action.tool import Tool
+    from lionagi.session.branch import Branch
+
+logger = logging.getLogger(__name__)
+
+
+class GateExecutionResult(Element):
+    """Aggregated outcome of running all gates for one tool call."""
+
+    results: Pile[GateResult] = Field(
+        default_factory=lambda: Pile(item_type=GateResult, strict_type=True)
+    )
+    hard_blocked: bool = False
+    soft_blocked: bool = False
+    blocking_gate_id: str | None = None
+
+    @property
+    def can_proceed(self) -> bool:
+        return not self.hard_blocked and not self.soft_blocked
+
+
+class GateExecutor(Element):
+    """Evaluates all applicable gates for a tool call.
+
+    Fail-closed: evaluator exceptions → passed=False.
+    HARD gate failure → GateExecutionResult.hard_blocked=True; remaining
+    gates are skipped.
+    SOFT gate failure → execution pauses; a justification round-trip is
+    required before continuation (see Section 4).
+    ADVISORY gate failure → warning logged; result recorded; execution
+    continues.
+    """
+
+    async def evaluate_all(
+        self,
+        *,
+        branch: Branch,
+        tool_call: ActionRequest,
+        context: object | None = None,  # OperationContext (ADR-0050)
+    ) -> GateExecutionResult:
+        action = _action_name(tool_call)
+        gate_manager = ensure_gate_manager(branch)
+        gates = gate_manager.gates_for(
+            branch=branch,
+            tool_name=tool_call.function,
+            action=action,
+        )
+        results = Pile(item_type=GateResult, strict_type=True)
+
+        for gate in gates:
+            result = await self._run_one(gate, branch, tool_call, context)
+            results.include(result)
+            self._record_result(branch, context, tool_call, result)
+
+            if not result.passed:
+                if result.enforcement == GateEnforcement.HARD_MANDATORY:
+                    # Fail-closed: stop immediately, do not evaluate remaining gates.
+                    return GateExecutionResult(
+                        results=results,
+                        hard_blocked=True,
+                        soft_blocked=False,
+                        blocking_gate_id=result.gate_id,
+                    )
+                if result.enforcement == GateEnforcement.SOFT_MANDATORY:
+                    # Pause for justification; remaining gates skipped until override.
+                    return GateExecutionResult(
+                        results=results,
+                        hard_blocked=False,
+                        soft_blocked=True,
+                        blocking_gate_id=result.gate_id,
+                    )
+                # ADVISORY: log warning, continue evaluating remaining gates.
+                logger.warning(
+                    "gate advisory failed: gate_id=%s tool=%s.%s reason=%s",
+                    result.gate_id, tool_call.function, action, result.reason,
+                )
+
+        return GateExecutionResult(
+            results=results,
+            hard_blocked=False,
+            soft_blocked=False,
+            blocking_gate_id=None,
+        )
+
+    async def _run_one(
+        self,
+        gate: ToolGate,
+        branch: Branch,
+        tool_call: ActionRequest,
+        context: object | None,
+    ) -> GateResult:
+        """Execute one gate evaluator.  Never raises — fail-closed."""
+        try:
+            result = gate.evaluator(branch, tool_call, context)
+            if inspect.isawaitable(result):
+                result = await result
+            if not isinstance(result, GateResult):
+                raise TypeError(f"Gate {gate.gate_id} returned {type(result)!r}")
+            return result
+        except BaseException as exc:
+            # Fail-closed invariant: evaluator error → deny.
+            logger.exception("gate evaluator raised (fail-closed deny): %s", gate.gate_id)
+            return GateResult(
+                passed=False,
+                gate_id=gate.gate_id,
+                enforcement=gate.enforcement,
+                reason=f"evaluator raised: {type(exc).__name__}: {exc}",
+                evaluated_at=time.monotonic(),
+            )
+
+    def _record_result(
+        self,
+        branch: Branch,
+        context: object | None,
+        tool_call: ActionRequest,
+        result: GateResult,
+    ) -> None:
+        """Record gate evidence through OperationContext and Branch DataLogger."""
+        if context is not None and hasattr(context, "record_gate_result"):
+            context.record_gate_result(result)
+        branch._log_manager.log(
+            {
+                "event": "tool_gate.evaluated",
+                "branch_id": str(branch.id),
+                "function": tool_call.function,
+                "gate_result": result.to_dict(mode="json"),
+            }
+        )
+
+
+def _action_name(tool_call: ActionRequest) -> str:
+    args = tool_call.arguments or {}
+    return str(args.get("action") or args.get("operation") or "")
+
+
+def install_gate_preprocessor(branch: Branch, tool: Tool) -> None:
+    """Run gates through Tool.preprocessor, the path ActionManager already invokes."""
+    prior = tool.preprocessor
+    prior_kwargs = dict(tool.preprocessor_kwargs or {})
+    executor = GateExecutor()
+
+    async def gated_preprocessor(args: dict[str, Any], **_kw: Any) -> dict[str, Any]:
+        if prior is not None:
+            args = prior(args, **prior_kwargs)
+            if inspect.isawaitable(args):
+                args = await args
+
+        tool_call = ActionRequest(
+            content={"function": tool.function, "arguments": args},
+            sender=branch.id,
+            recipient=tool.id,
+        )
+        context = getattr(branch, "_active_operation_context", None)
+        execution = await executor.evaluate_all(
+            branch=branch,
+            tool_call=tool_call,
+            context=context,
+        )
+        if not execution.can_proceed:
+            raise PermissionError(f"tool gate blocked: {execution.blocking_gate_id}")
+        return args
+
+    tool.preprocessor = gated_preprocessor
+    tool.preprocessor_kwargs = {}
+```
+
+### 4. SOFT Gate Override Flow
+
+When the executor returns `soft_blocked=True`, execution pauses before the tool action runs.
+The override path is:
+
+1. The branch surfaces the blocking `GateResult` to the calling context (agent, orchestrator,
+   or human via [ADR-0046](ADR-0046-jit-tool-grant.md)).
+2. The calling context invokes `branch.justify_gate(gate_id, justification, actor_id, evidence)`.
+3. The branch's active `JustificationPolicy` evaluates the justification.  The policy is pluggable;
+   the default policy accepts any non-empty justification from a registered actor.
+4. If accepted: the original `GateResult` is preserved in the evidence chain; a new
+   `GateResult` carrying `justification` and `justification_actor_id` is appended as a sibling
+   evidence node.  Execution continues.
+5. If rejected: a `GateResult(passed=False, reason="justification rejected", ...)` is appended.
+   The action terminates with a DENY outcome recorded in the OperationContext.
+
+```python
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+from lionagi.agent.gates.types import GateEnforcement, GateResult
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+
+if TYPE_CHECKING:
+    from lionagi.protocols.governance.evidence import EvidenceRef
+    from lionagi.session.branch import Branch
+
+
+async def justify_gate(
+    branch: Branch,
+    gate_id: str,
+    justification: str,
+    actor_id: str,
+    evidence: Pile["EvidenceRef"] | None = None,
+) -> bool:
+    """Attempt to override a SOFT_MANDATORY gate failure.
+
+    Returns True if the justification was accepted and execution may resume.
+    Returns False if rejected; the branch records a DENY outcome.
+
+    The justification and its acceptance/rejection both become immutable
+    evidence nodes (ADR-0041) attached to the active OperationContext (ADR-0050).
+    """
+    evidence_refs = evidence or Pile(item_type=Element, strict_type=False)
+    policy = getattr(branch, "_justification_policy", DefaultJustificationPolicy())
+    accepted = await policy.evaluate(gate_id, justification, actor_id, evidence_refs)
+
+    result = GateResult(
+        passed=accepted,
+        gate_id=gate_id,
+        enforcement=GateEnforcement.SOFT_MANDATORY,
+        reason="justification accepted" if accepted else "justification rejected",
+        evaluated_at=time.monotonic(),
+        evidence_refs=evidence_refs,
+        justification=justification,
+        justification_actor_id=actor_id,
+    )
+
+    ctx = getattr(branch, "_active_operation_context", None)
+    if ctx is not None and hasattr(ctx, "record_gate_result"):
+        ctx.record_gate_result(result)
+    branch._log_manager.log(
+        {
+            "event": "tool_gate.justification",
+            "branch_id": str(branch.id),
+            "gate_result": result.to_dict(mode="json"),
+        }
+    )
+
+    return accepted
+
+
+class DefaultJustificationPolicy:
+    """Accept any non-empty justification from any actor.
+
+    Production deployments replace this with a policy that validates actor
+    identity, checks justification length, and/or requires corroborating evidence.
+    """
+
+    async def evaluate(
+        self,
+        gate_id: str,
+        justification: str,
+        actor_id: str,
+        evidence: Pile["EvidenceRef"],
+    ) -> bool:
+        return bool(justification.strip()) and bool(actor_id.strip())
+```
+
+### 5. Resolution Order
+
+All applicable gates evaluate in this order.  The first HARD failure terminates; all ADVISORY
+failures accumulate.  A SOFT failure pauses after the first occurrence (remaining gates do not
+run until the override is resolved).
+
+```text
+1. Class-level hard gates      (attached to tool class via @governed_tool)
+2. Class-level situational gates (conditional on args, still class-level registration)
+3. Action-level hard gates     (attached to specific callable)
+4. Action-level situational gates
+```
+
+Within each level, registration order is preserved.  Most-specific wins in the sense that
+action-level gates can shadow class-level gates via `gate_id` deduplication, but all applicable
+gates still run unless a HARD failure occurs.
+
+### 6. Built-in Gates
+
+lionagi ships four built-in gates.  All live under `lionagi/agent/gates/` and are
+available for attachment without additional imports.
+
+```python
+# lionagi/agent/gates/builtins.py
+
+from __future__ import annotations
+
+import json
+import urllib.parse
+from typing import TYPE_CHECKING, Any
+
+from lionagi.agent.gates.types import GateEnforcement, GateResult, ToolGate
+from lionagi.agent.hooks import guard_destructive, guard_paths
+
+if TYPE_CHECKING:
+    from lionagi.protocols.messages.action_request import ActionRequest
+    from lionagi.session.branch import Branch
+
+
+def _args(tool_call: ActionRequest) -> dict[str, Any]:
+    return tool_call.arguments or {}
+
+
+# --- guard_destructive ---------------------------------------------------
+
+async def gate_guard_destructive(
+    branch: Branch,
+    tool_call: ActionRequest,
+    context: object | None,
+) -> GateResult:
+    args = _args(tool_call)
+    try:
+        await guard_destructive(tool_call.function, args.get("action", ""), args)
+    except PermissionError as exc:
+        return GateResult(
+            passed=False,
+            gate_id="guard_destructive",
+            enforcement=GateEnforcement.HARD_MANDATORY,
+            reason=str(exc),
+        )
+    return GateResult(
+        passed=True,
+        gate_id="guard_destructive",
+        enforcement=GateEnforcement.HARD_MANDATORY,
+        reason="no destructive pattern",
+    )
+
+
+GUARD_DESTRUCTIVE = ToolGate(
+    gate_id="guard_destructive",
+    enforcement=GateEnforcement.HARD_MANDATORY,
+    evaluator=gate_guard_destructive,
+    description="Block destructive shell commands with no override path.",
+    owner="lionagi",
+)
+
+
+# --- guard_paths ---------------------------------------------------------
+
+def make_guard_path_gate(
+    *,
+    allowed_paths: list[str] | None = None,
+    denied_paths: list[str] | None = None,
+    enforcement: GateEnforcement = GateEnforcement.HARD_MANDATORY,
+) -> ToolGate:
+    """Factory: adapt the existing guard_paths hook into a ToolGate."""
+    path_hook = guard_paths(allowed_paths=allowed_paths, denied_paths=denied_paths)
+
+    async def gate_guard_paths(
+        branch: Branch,
+        tool_call: ActionRequest,
+        context: object | None,
+    ) -> GateResult:
+        args = _args(tool_call)
+        try:
+            await path_hook(tool_call.function, args.get("action", ""), args)
+        except PermissionError as exc:
+            return GateResult(
+                passed=False,
+                gate_id="guard_paths",
+                enforcement=enforcement,
+                reason=str(exc),
+            )
+        return GateResult(
+            passed=True,
+            gate_id="guard_paths",
+            enforcement=enforcement,
+            reason="path allowed",
+        )
+
+    return ToolGate(
+        gate_id="guard_paths",
+        enforcement=enforcement,
+        evaluator=gate_guard_paths,
+        description="Block or flag file access outside the designated workspace root.",
+        owner="lionagi",
+    )
+
+
+# --- confirm_external_api_call -------------------------------------------
+
+_ALLOWLISTED_API_HOSTS: frozenset[str] = frozenset({
+    "api.openai.com",
+    "api.anthropic.com",
+    "api.cohere.com",
+})
+
+
+async def gate_confirm_external_api_call(
+    branch: Branch,
+    tool_call: ActionRequest,
+    context: object | None,
+) -> GateResult:
+    args = _args(tool_call)
+    url = args.get("url", "")
+    if not url:
+        return GateResult(
+            passed=True,
+            gate_id="confirm_external_api_call",
+            enforcement=GateEnforcement.SOFT_MANDATORY,
+            reason="no url argument",
+        )
+    host = urllib.parse.urlparse(url).hostname or ""
+    allowed = host in _ALLOWLISTED_API_HOSTS
+    return GateResult(
+        passed=allowed,
+        gate_id="confirm_external_api_call",
+        enforcement=GateEnforcement.SOFT_MANDATORY,
+        reason="host in allowlist" if allowed else f"host not in allowlist: {host}",
+    )
+
+
+CONFIRM_EXTERNAL_API_CALL = ToolGate(
+    gate_id="confirm_external_api_call",
+    enforcement=GateEnforcement.SOFT_MANDATORY,
+    evaluator=gate_confirm_external_api_call,
+    description="Require justification for outbound HTTP to non-allowlisted hosts.",
+    owner="lionagi",
+)
+
+
+# --- warn_large_payload --------------------------------------------------
+
+_PAYLOAD_LIMIT_BYTES = 1 * 1024 * 1024  # 1 MB
+
+
+async def gate_warn_large_payload(
+    branch: Branch,
+    tool_call: ActionRequest,
+    context: object | None,
+) -> GateResult:
+    args = _args(tool_call)
+    try:
+        size = len(json.dumps(args).encode())
+    except Exception:
+        size = 0
+    over = size > _PAYLOAD_LIMIT_BYTES
+    return GateResult(
+        passed=not over,
+        gate_id="warn_large_payload",
+        enforcement=GateEnforcement.ADVISORY,
+        reason=f"payload {size} bytes exceeds {_PAYLOAD_LIMIT_BYTES}" if over else f"payload {size} bytes",
+    )
+
+
+WARN_LARGE_PAYLOAD = ToolGate(
+    gate_id="warn_large_payload",
+    enforcement=GateEnforcement.ADVISORY,
+    evaluator=gate_warn_large_payload,
+    description="Warn (non-blocking) when tool input arguments exceed 1 MB.",
+    owner="lionagi",
+)
+```
+
+### 7. User-Defined Gates
+
+Framework consumers register custom gates via `branch.register_gate`:
+
+```python
+from lionagi.agent.gates.executor import install_gate_preprocessor
+from lionagi.agent.gates.types import GateEnforcement, GateResult, ToolGate
+
+
+async def require_ticket_number(branch, tool_call, context) -> GateResult:
+    """Example: require a JIRA ticket in the operation context metadata."""
+    meta = getattr(context, "metadata", {}) or {}
+    ticket = meta.get("ticket", "")
+    ok = bool(ticket and ticket.startswith("PROJ-"))
+    return GateResult(
+        passed=ok,
+        gate_id="require_ticket_number",
+        enforcement=GateEnforcement.SOFT_MANDATORY,
+        reason="ticket present" if ok else "no PROJ-* ticket in operation context",
+    )
+
+
+my_gate = ToolGate(
+    gate_id="require_ticket_number",
+    enforcement=GateEnforcement.SOFT_MANDATORY,
+    evaluator=require_ticket_number,
+    description="Require a PROJ-* ticket reference before any write operation.",
+    owner="user",
+)
+
+# Register globally on the branch and attach to a specific action:
+branch.register_gate(my_gate)
+branch.attach_gate_to_action("editor", "write", "require_ticket_number")
+install_gate_preprocessor(branch, branch.acts.registry["editor"])
+```
+
+### 8. Relationship to Existing Primitives
+
+The built-in `PermissionPolicy` and `guard_*` hooks remain in place.  They are not deprecated by
+this ADR.  The migration path is additive:
+
+- `guard_destructive` hook → `GUARD_DESTRUCTIVE` gate.  Both may coexist; the hook runs first
+  as a pre-hook; the gate runs as part of gate evaluation.  In a future release the hook form
+  will be soft-deprecated once gate attachment is the recommended path for governed tools.
+- `PermissionPolicy` continues to handle allow/deny/escalate pattern matching.  It operates
+  before gate evaluation in the call stack.  Gates add tier semantics and evidence production
+  on top of the policy layer, not as a replacement.
+
+### 9. Fail-Closed is an Invariant, Not a Convention
+
+This point is sufficiently important to state explicitly and separately from the executor code.
+
+> If a gate's evaluator raises any exception for any reason — including import errors, network
+> timeouts, internal assertion failures, and `asyncio.CancelledError` — the gate result is
+> `GateResult(passed=False, ...)`.  The exception is logged at ERROR level.  It is never
+> re-raised, never silently swallowed into a pass, and never converted into an ADVISORY result
+> regardless of the gate's declared enforcement tier.
+
+This invariant means a misconfigured or crashing gate acts as a deny, not as an open door.
+A gate that is supposed to check network access but fails to import its HTTP library blocks the
+call rather than allowing it through.  This is the correct behavior for a security primitive.
+
+---
+
+## Consequences
+
+**Positive**
+
+- Every gate evaluation produces a `GateResult` regardless of pass or fail.  The operation record
+  is complete: no tool call can execute without evidence that its gates ran.
+- The three-tier model gives framework consumers a vocabulary for expressing real distinctions:
+  irrevocable safety rules (HARD), overridable business rules (SOFT), informational checks
+  (ADVISORY).  Previously this required separate systems.
+- Fail-closed-by-default eliminates an entire class of "gate crashes → action proceeds"
+  vulnerabilities.
+- SOFT gate justifications become part of the evidence chain (via ADR-0041), making overrides
+  auditable rather than invisible.
+- The resolution order (class-level first, then action-level) mirrors the decorator stack
+  familiar to Python developers and is predictable without reading framework internals.
+
+**Negative**
+
+- Latency for sessions with many gates: every tool call evaluates all applicable gates serially
+  (HARD gates short-circuit on first failure; ADVISORY and SOFT gates may accumulate). For most
+  agent sessions the gate count is small (2-5), making this negligible. Sessions with 20+ gates
+  may see 5-15 ms overhead per call; profiling will determine whether parallel evaluation is
+  warranted.
+- Authoring gates requires understanding the `OperationContext` and `ActionRequest` interfaces
+  (ADR-0050 and `lionagi/protocols/messages/`).  This is more involved than writing a hook that
+  inspects `args: dict`.
+- SOFT gate overrides introduce a synchronous pause in async tool execution.  Orchestrators that
+  route justification requests to humans (ADR-0046) must handle the suspension correctly.
+- Classifying a gate into the correct enforcement tier is a judgment call.  Misclassifying a
+  safety requirement as SOFT introduces a gap; misclassifying a business rule as HARD removes
+  operational flexibility.
+
+---
+
+## Non-Goals
+
+Explicitly out of scope:
+
+- **Probabilistic gating**: gates return `bool`.  Confidence-weighted authorization belongs in
+  `Claim.confidence` (ADR-0039) and `StateReason.confidence` (ADR-0033), not in gate results.
+  Threshold-based authorization is explicitly rejected (see prior research, Alternative 1).
+- **Gate composition DSL**: there is no `AND(gate_a, gate_b)` or `OR(gate_a, gate_b)` syntax.
+  Composite logic is expressed by calling other gates inside an evaluator function.
+- **Multi-tenant policy stitching**: resolving gate inheritance across tenant hierarchies,
+  overriding organizational gates at the workspace level, and merging gate registries from
+  multiple policy sources are KHive-layer concerns addressed in ADR-0052.
+- **Human-approval workflows**: routing a SOFT override to a human approver UI, timeout
+  handling, and async approval state machines are addressed in ADR-0046 (JIT Tool Grant).
+- **Gate versioning and migration**: upgrading a gate's enforcement tier across live sessions,
+  retiring a gate_id, and backfilling historical evidence with updated gate metadata are
+  operational concerns not addressed here.
+- **Cross-agent gate delegation**: an agent delegating gate-pass authority to a sub-agent is
+  addressed by the Agent Charter (ADR-0047) and Segregation of Duties (ADR-0048).
+
+---
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|---|---|
+| Single allow/deny mechanism (no tiers) | Real deployments distinguish irrevocable safety requirements from overridable business rules. Flattening both into HARD removes the escalation path that makes SOFT useful; flattening both into SOFT allows safety-critical gates to be bypassed with a justification string. |
+| Confidence-score gates (0.0–1.0) | Authorization is a factual question with a binary answer. Confidence scores shift the authorization decision to the threshold-chooser, introduce legal ambiguity ("the gate was 73% sure"), and enable threshold-drift attacks. Rejected per prior research Alternative 1. |
+| Hook-only enforcement (existing pattern) | Hooks (`guard_destructive`, `guard_paths`) raise `PermissionError` with no tiered semantics, no evidence production, and no override path. They cannot express SOFT or ADVISORY distinctions. They produce no `GateResult` that persists in the operation record. |
+| Auto-registration via `__init_subclass__` | prior research notes this pattern, but lionagi's tool model uses registered callables rather than class hierarchies. Explicit `register_gate` calls match the existing `register_tools` pattern and make attachment auditable. |
+| Gate evaluation in parallel | Parallel evaluation breaks the fail-fast semantics of HARD gates: if HARD gate A and SOFT gate B both run concurrently and A fails, B may have already started an I/O side-effect. Serial evaluation with short-circuit on HARD failure is correct and the latency cost is acceptable. |
+
+---
+
+## References
+
+- [ADR-0041](ADR-0041-immutable-evidence-nodes.md) — `GateResult` instances are stored as immutable evidence nodes; hash-chain integrity applies
+- [ADR-0042](ADR-0042-task-certificate.md) — Task Certificate consumes aggregated gate results as part of the signed process record
+- [ADR-0043](ADR-0043-governed-tool-declaration.md) — `@governed_tool` declares which gates are attached at the class level; HARD gates declared there cannot be absent at runtime
+- [ADR-0045](ADR-0045-break-glass-protocol.md) — documents what happens when a HARD gate result is overridden at the system level (DEGRADED defensibility mode)
+- [ADR-0046](ADR-0046-jit-tool-grant.md) — the JIT grant protocol handles human-in-the-loop approval for SOFT gate overrides
+- [ADR-0047](ADR-0047-agent-charter.md) — charters bind agents to specific gate sets; a gate not declared in the charter cannot be bypassed
+- [ADR-0050](ADR-0050-operation-context.md) — `OperationContext` is the active assertion that receives `GateResult` records at evaluation time
+- [ADR-0052](ADR-0052-policy-resolution.md) — most-specific-wins resolution for gate registries across tenant hierarchies (KHive layer)
+- [ADR-0033](ADR-0033-unified-entity-state-model.md) — `EvidenceRef` (8 kinds) is the shared substrate; `GateResult.evidence_refs` uses this type
+- [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) — `Claim.confidence` is where probabilistic reasoning lives; explicitly not in gates
+- prior governance research `01_design/008-policy-gates/ADR-008-policy-gates.md` — source pattern (three-tier model, binary semantics, HashiCorp Sentinel inspiration)
+- `lionagi/agent/permissions.py` — existing `PermissionPolicy`; not deprecated, gates layer on top
+- `lionagi/agent/hooks.py` — existing `guard_destructive`, `guard_paths`; migration path described in Section 8

--- a/docs/adrs/ADR-0045-break-glass-protocol.md
+++ b/docs/adrs/ADR-0045-break-glass-protocol.md
@@ -1,0 +1,572 @@
+# ADR-0045: Break-Glass Protocol — DEGRADED-Defensibility Override
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Depends on**: [ADR-0044](ADR-0044-tool-gates.md) (HARD gates being overridden), [ADR-0042](ADR-0042-task-certificate.md) (BREAK_GLASS certificate state), [ADR-0041](ADR-0041-immutable-evidence-nodes.md) (attestation as evidence node)
+**Related**: [ADR-0050](ADR-0050-operation-context.md), [ADR-0047](ADR-0047-agent-charter.md), [ADR-0033](ADR-0033-unified-entity-state-model.md), [ADR-0043](ADR-0043-governed-tool-declaration.md)
+
+---
+
+## Context
+
+lionagi today has no emergency override path. When an agent fails a HARD gate
+(defined in [ADR-0044](ADR-0044-tool-gates.md)), it has two de-facto options:
+
+1. **Fail silently** — the action is blocked, the operator sees an error, no
+   record is produced that explains *why* the gate failed or that an override
+   was even attempted.
+2. **Proceed without record** — the caller catches the gate exception and
+   re-invokes the tool with a flag that disables the check. This is entirely
+   within reach today: `PermissionPolicy(mode="allowlist")` in
+   `lionagi/agent/permissions.py` already accepts a caller-supplied config
+   with zero audit hooks.
+
+Neither outcome is acceptable for a governed agent platform. The first option
+stalls legitimate emergencies; the second leaves a compliance gap with no
+paper trail.
+
+Cross-cutting principle #3 — *every constraint must be enforced, not just
+documented* — applies to the override path itself. An override that produces
+no record is not governance; it is a blank check disguised as a feature.
+
+### The applicable design pattern
+
+prior research frames this precisely: the problem is not whether an
+emergency override is *possible*, but whether the resulting record
+*acknowledges what happened*. Their solution distinguishes between
+`defensibility: FULL` (normal path, all gates passed) and
+`defensibility: DEGRADED` (break-glass path, gates failed, attestation
+provided). The action is the same; the certificate is different. Both facts —
+that the action happened, and that normal process was not followed — are
+preserved in a single evidence node that cannot be amended after the fact
+(ADR-0041).
+
+### Why lionagi needs this
+
+Consider: an autonomous coding agent holds a HARD gate that prevents
+modification of files outside a declared project root. During a production
+incident, an operator legitimately needs the agent to patch a shared config
+file one directory above the root. The only current path is to re-instantiate
+the agent with a looser `PermissionPolicy`. That change leaves no record, is
+indistinguishable from a misconfiguration, and cannot be reviewed
+post-incident. Break-glass replaces that informal workaround with a
+first-class, auditable path that creates more friction than normal operation —
+thereby preserving deterrence — while still letting the action succeed.
+
+---
+
+## Decision
+
+We introduce `branch.break_glass(request)` as the single approved path for
+overriding a HARD gate failure, producing a `TaskCertificate` with
+`defensibility: DEGRADED` and a `BREAK_GLASS` evidence node that is
+immutable, non-exportable by default, and triggers an immediate notification
+event.
+
+---
+
+### 1. `BreakGlassReason` enum
+
+```python
+from enum import Enum
+
+class BreakGlassReason(str, Enum):
+    PRODUCTION_OUTAGE      = "production_outage"
+    SECURITY_INCIDENT      = "security_incident"
+    LEGAL_MANDATE          = "legal_mandate"
+    SAFETY_THREAT          = "safety_threat"
+    DATA_RECOVERY          = "data_recovery"
+    AUTHORIZED_DRILL       = "authorized_drill"
+```
+
+The enum is closed. New reason codes require a code change and a reviewer
+sign-off. This prevents operators from minting ad-hoc codes that dilute the
+audit signal.
+
+---
+
+### 2. `BreakGlassRequest` dataclass
+
+```python
+from __future__ import annotations
+
+import time
+from typing import Literal
+
+from pydantic import Field, field_validator
+
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+from lionagi.protocols.governance.evidence import EvidenceRef  # ADR-0033/0041
+
+
+class BreakGlassRequest(Element):
+    # Who is overriding and why
+    reason_code: BreakGlassReason
+    attestation_text: str                    # >= 50 chars, free-form
+    actor_id: str                            # agent ln_id / user id / system id
+    actor_role: Literal["agent", "user", "system"]
+
+    # What is being overridden
+    overridden_gates: tuple[str, ...] = Field(min_length=1)
+    tool_name: str                           # the @governed_tool being unblocked
+
+    # Scope
+    expected_duration_minutes: int = Field(ge=1)
+    supporting_evidence: Pile[EvidenceRef] = Field(
+        default_factory=lambda: Pile(item_type={EvidenceRef}, strict_type=True)
+    )
+
+    # Filled at invocation time
+    requested_at: float = Field(default_factory=time.time)
+
+    @field_validator("attestation_text")
+    @classmethod
+    def _validate_attestation(cls, value: str) -> str:
+        if len(value.strip()) < 50:
+            raise ValueError(
+                "attestation_text must be at least 50 characters. "
+                "A checkbox is not attestation."
+            )
+        return value
+```
+
+The `__post_init__` validation enforces minimum attestation length at
+construction time, not at invocation time. An invalid request cannot be
+submitted — it raises before touching any gate.
+
+---
+
+### 3. `BreakGlassWindow` — the active override state
+
+```python
+import time
+from typing import Literal
+
+from pydantic import Field
+
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+
+
+class BreakGlassToolCall(Element):
+    tool_name: str
+    called_at: float = Field(default_factory=time.time)
+
+
+class BreakGlassWindow(Element):
+    request: BreakGlassRequest
+    opened_at: float = Field(default_factory=time.time)
+    expires_at: float | None = None
+    closed_at: float | None = None
+    tool_calls_during_window: Pile[BreakGlassToolCall] = Field(
+        default_factory=lambda: Pile(
+            item_type={BreakGlassToolCall},
+            strict_type=True,
+        )
+    )
+    closed_reason: Literal["expired", "explicit", "error"] | None = None
+
+    def model_post_init(self, __context: object) -> None:
+        if self.expires_at is None:
+            self.expires_at = (
+                self.opened_at + self.request.expected_duration_minutes * 60
+            )
+
+    @property
+    def window_id(self) -> str:
+        return str(self.id)
+
+    @property
+    def is_active(self) -> bool:
+        return (
+            self.closed_at is None
+            and time.time() < self.expires_at
+        )
+
+    def record_tool_call(self, tool_name: str) -> None:
+        """Every tool call during the window is tagged for the audit trail."""
+        self.tool_calls_during_window.include(
+            BreakGlassToolCall(tool_name=tool_name)
+        )
+
+    def close(self, reason: Literal["expired", "explicit", "error"]) -> None:
+        self.closed_at = time.time()
+        self.closed_reason = reason
+```
+
+---
+
+### 4. `BreakGlassEvent` — the notification payload
+
+```python
+import time
+from typing import Literal
+
+from pydantic import Field
+
+from lionagi.protocols.generic.element import Element
+
+
+class BreakGlassEvent(Element):
+    """Fired to operator/orchestrator immediately on window open and close."""
+    event_type: Literal["opened", "closed"]
+    window_id: str
+    actor_id: str
+    actor_role: str
+    reason_code: str
+    tool_name: str
+    overridden_gates: tuple[str, ...]
+    attestation_summary: str   # first 120 chars of attestation_text
+    timestamp: float = Field(default_factory=time.time)
+    branch_id: str
+    session_id: str | None
+    # On close only:
+    tool_calls_count: int = 0
+    certificate_id: str | None = None
+    defensibility: Literal["DEGRADED"] = "DEGRADED"
+```
+
+Notifications are fired synchronously before the action executes (open event)
+and after the window closes (close event). Both events are written to the
+immutable evidence store (ADR-0041) before any downstream delivery. If
+delivery fails, the evidence node is already committed.
+
+---
+
+### 5. `BreakGlassGuard` — gate-level non-overridability flag
+
+Not all HARD gates are overridable. Gates that protect the agent system itself
+from self-destruction are declared with `overridable=False`:
+
+```python
+from collections.abc import Awaitable, Callable
+from typing import Literal
+
+from pydantic import Field
+
+from lionagi.agent.config import AgentConfig
+from lionagi.protocols.generic.element import Element
+
+
+BreakGlassHook = Callable[[str, str, dict], Awaitable[dict | None]]
+
+
+class GateDeclaration(Element):
+    name: str
+    tool_name: str = "*"
+    level: Literal["HARD", "SOFT", "ADVISORY"]   # ADR-0044
+    hook: BreakGlassHook = Field(exclude=True)
+    overridable: bool = True
+    override_actor_classes: frozenset[str] = Field(
+        default_factory=lambda: frozenset(
+            {"user", "system"}   # autonomous agents cannot self-override by default
+        )
+    )
+    max_overrides_per_hour: int = 3
+
+    def register(self, config: AgentConfig) -> None:
+        config.hook_handlers.setdefault(
+            f"security_pre:{self.tool_name}",
+            [],
+        ).insert(0, self.hook)
+```
+
+When `overridable=False`, `break_glass()` raises `NonOverridableGateError`
+regardless of attestation content or actor role. The list of non-overridable
+gates is enumerated in the agent charter (ADR-0047) and cannot be modified at
+runtime.
+
+Gates that are overridable by `user` or `system` but NOT by `agent` enforce
+the rule that autonomous agents cannot unilaterally override their own
+constraints. An agent that detects a gate failure must surface the failure to
+its orchestrator, not invoke break-glass on its own authority.
+
+---
+
+### 6. `branch.break_glass()` — the API surface
+
+```python
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from lionagi.protocols.governance.break_glass import (
+    BreakGlassEvent,
+    BreakGlassRequest,
+    BreakGlassWindow,
+    NonOverridableGateError,
+    RateLimitExceededError,
+)
+from lionagi.protocols.generic.log import Log
+from lionagi.protocols.generic.pile import Pile
+
+
+class Branch:
+    # ... existing Branch surface ...
+
+    async def break_glass(
+        self,
+        request: BreakGlassRequest,
+        *,
+        notify: Callable[[BreakGlassEvent], None] | None = None,
+    ) -> BreakGlassWindow:
+        """
+        Override one or more HARD gate failures with a typed attestation.
+
+        Returns an active BreakGlassWindow. The caller is responsible for
+        explicitly closing the window via `await window.aclose()` when the
+        emergency action completes. If not closed, the window expires
+        automatically at `window.expires_at`.
+
+        Raises:
+            NonOverridableGateError  — if any gate in request.overridden_gates
+                                       has overridable=False.
+            RateLimitExceededError   — if actor_id has exceeded
+                                       max_overrides_per_hour for any gate.
+            ValueError               — if request validation fails (re-raised
+                                       from BreakGlassRequest validation).
+        """
+        if request.tool_name not in self.acts.registry:
+            raise ValueError(f"Tool {request.tool_name!r} is not registered.")
+
+        self._validate_actor_class(request)       # enforce override_actor_classes
+        self._check_non_overridable(request)      # raise NonOverridableGateError early
+        self._check_rate_limit(request)           # raise RateLimitExceededError early
+
+        window = BreakGlassWindow(request=request)
+
+        open_event = BreakGlassEvent(
+            event_type="opened",
+            window_id=window.window_id,
+            actor_id=request.actor_id,
+            actor_role=request.actor_role,
+            reason_code=request.reason_code,
+            tool_name=request.tool_name,
+            overridden_gates=request.overridden_gates,
+            attestation_summary=request.attestation_text[:120],
+            branch_id=str(self.id),
+            session_id=str(self.user) if self.user else None,
+        )
+
+        # Fail closed: write the Element snapshot through Branch's DataLogger
+        # before notifying or enabling the existing hook-based tool path.
+        await self._log_manager.alog(Log.create(open_event))
+        if notify is not None:
+            notify(open_event)
+
+        windows = self.metadata.setdefault(
+            "active_break_glass_windows",
+            Pile(item_type={BreakGlassWindow}, strict_type=True),
+        )
+        windows.include(window)
+        return window
+```
+
+The method is `async` because committing the evidence node and firing the
+notification are I/O operations. The HARD gate check that originally triggered
+the failure is NOT re-evaluated inside `break_glass()` — that check already
+ran; the attestation is the response to it, not a second pass.
+
+---
+
+### 7. Window lifecycle and certificate minting
+
+```text
+Agent calls tool
+      |
+  HARD gate fails
+      |
+  Caller invokes branch.break_glass(request)
+      |
+  [Validation] ──── fail ──── raise (no window created)
+      |
+  Evidence node committed (immutable, exportable=False)
+      |
+  BreakGlassEvent("opened") fired
+      |
+  BreakGlassWindow returned (is_active=True)
+      |
+  Action executes; every tool call recorded in window.tool_calls_during_window
+      |
+  Window closes (explicit close or expiry)
+      |
+  TaskCertificate minted:
+      defensibility = "DEGRADED"
+      state         = "BREAK_GLASS"
+      evidence_refs = [break_glass_node, ...supporting_evidence]
+      |
+  BreakGlassEvent("closed") fired with certificate_id
+```
+
+The certificate (ADR-0042) is minted at window close, not at window open. If
+the window expires without an explicit close, the expiry trigger mints the
+certificate automatically. There is no path from open to close that does not
+produce a certificate.
+
+---
+
+### 8. Non-exportability
+
+Break-glass evidence nodes and the certificates that reference them carry
+`exportable: False` by default. This flag is enforced by the evidence store
+(ADR-0041) at read time, not just at write time.
+
+Programmatic export requires:
+
+1. An elevated permission grant (`EXPORT_BREAK_GLASS`) on the calling actor.
+2. An explicit export request that itself produces an audit evidence node,
+   recording who exported what and when.
+3. In KHive (multi-tenant layer): a Legal review workflow before the grant is
+   issued.
+
+This is not obscurity — the evidence node exists and is queryable by authorized
+operators. Non-exportability means it cannot leave the platform boundary in a
+bulk data export without review.
+
+---
+
+### 9. Rate limiting and cooldown
+
+```python
+import time
+
+from pydantic import Field
+
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+from lionagi.protocols.governance.break_glass import RateLimitExceededError
+
+
+class BreakGlassRateLimitInvocation(Element):
+    actor_id: str
+    gate_name: str
+    invoked_at: float = Field(default_factory=time.time)
+
+
+class BreakGlassRateLimit(Element):
+    actor_id: str
+    gate_name: str
+    max_per_hour: int = 3
+    window_seconds: int = 3600
+    # runtime-tracked
+    invocations: Pile[BreakGlassRateLimitInvocation] = Field(
+        default_factory=lambda: Pile(
+            item_type={BreakGlassRateLimitInvocation},
+            strict_type=True,
+        )
+    )
+
+    def check(self) -> None:
+        now = time.time()
+        for invocation in list(self.invocations):
+            if now - invocation.invoked_at >= self.window_seconds:
+                self.invocations.exclude(invocation)
+        if len(self.invocations) >= self.max_per_hour:
+            raise RateLimitExceededError(
+                f"Actor {self.actor_id!r} has used break-glass on gate "
+                f"{self.gate_name!r} {self.max_per_hour} times in the last hour. "
+                "Contact your operator to reset."
+            )
+        self.invocations.include(
+            BreakGlassRateLimitInvocation(
+                actor_id=self.actor_id,
+                gate_name=self.gate_name,
+            )
+        )
+```
+
+Rate limits are per-actor, per-gate, per-hour. Exceeding the limit does not
+silently allow the action — it raises `RateLimitExceededError`. The limit
+itself is configurable per gate declaration but defaults to 3/hour, which is
+generous for genuine emergencies and punishing for misuse.
+
+---
+
+## Consequences
+
+**Positive**
+
+- Every HARD gate override produces a complete, immutable audit trail with a
+  dated attestation, actor identity, overridden gate names, and a certificate
+  marked DEGRADED. Post-incident review has all the facts.
+- The DEGRADED defensibility state gives operators, auditors, and (where
+  applicable) legal counsel an accurate signal about what process was followed.
+  "We did it with DEGRADED defensibility" is a defensible position; "we did it
+  with no record" is not.
+- Non-overridable gates (`overridable=False`) eliminate the risk that break-glass
+  becomes a universal escape hatch. The most critical constraints are
+  permanently out of scope.
+- Friction by design: the minimum 50-char attestation, the actor-class
+  restriction on autonomous agents, and the rate limit make break-glass slower
+  than normal operation. Legitimate emergencies tolerate this friction; routine
+  misuse does not survive the rate limit.
+- The pattern composes with Operation Context (ADR-0050): every tool call during
+  a break-glass window can carry `context_id=window.window_id` in its evidence
+  node, creating a complete timeline of what happened under the override.
+
+**Negative**
+
+- Surface area: `BreakGlassRequest`, `BreakGlassWindow`, `BreakGlassEvent`, and
+  the `break_glass()` method are new API that must be maintained.
+- Operator burden: the notification mechanism requires a subscriber. If no
+  subscriber is configured, notifications queue silently. The default behavior
+  must be to log to the immutable evidence store regardless.
+- Genuinely time-critical emergencies may find the 50-char attestation a
+  bottleneck. The minimum is low enough (roughly two sentences) that this
+  concern is largely theoretical, but it is real.
+- In library mode (no KHive), the rate-limit and non-exportability semantics
+  are enforced in-process and can be bypassed by a caller with full Python
+  access. Full enforcement requires the KHive governed evidence layer.
+
+---
+
+## Non-Goals
+
+Explicitly out of scope:
+
+- **Automatic break-glass approval**: no system or agent can approve its own
+  break-glass request. Human attestation is a requirement, not a suggestion.
+  Confidence scores, risk scores, and audit history do not substitute for a
+  typed justification from an accountable actor.
+- **Break-glass without a certificate**: there is no `silent_override()` or
+  `emergency_skip()`. Every invocation of `break_glass()` that does not raise
+  produces a certificate. The two are inseparable.
+- **Window expiry without certificate mint**: a window that expires without an
+  explicit close still mints a certificate. There is no path where a window
+  opens and no certificate is ever produced.
+- **Cascading break-glass**: a break-glass window does not implicitly expand to
+  cover subsequent gate failures. Each failing gate in a new action requires
+  its own `overridden_gates` declaration. Open-ended "override everything" is
+  not supported.
+- **Multi-tenant policy**: which reason codes are available to which tenants,
+  cross-tenant audit visibility, and Legal-review workflow for exports are
+  KHive-layer concerns and are not defined here.
+- **Retroactive reclassification**: a DEGRADED certificate cannot be upgraded
+  to FULL defensibility after the fact, even if subsequent review concludes the
+  action was correct. The state at time of action is preserved permanently.
+
+---
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Silent override with post-hoc logging | No record at the time of decision. If the system crashes after the action but before the log write, there is no evidence the override happened. Violates ADR-0041 (evidence committed before action). |
+| Reject without any override path | Legitimate production emergencies exist. A governance system that cannot accommodate genuine emergencies will be worked around informally, producing worse audit trails than break-glass. |
+| Confidence-based automatic override | Defeats the fail-closed principle (cross-cutting principle #1). If a gate can be bypassed by meeting a confidence threshold, the gate is not HARD — it is a SOFT gate with a confidence flavor. Rename it honestly or keep it HARD. |
+| Simple `emergency: bool` flag on existing tool calls | No defensibility acknowledgment, no rate limit, no actor-class restriction, no evidence node, no certificate. This is the "add a comment field to a checkbox" pattern, not governance. |
+| Checkbox-based reason selection | Predefined checkboxes have no accountability signal. A 50-char attestation requires the actor to formulate a sentence, which creates cognitive ownership of the decision. prior research tested this distinction directly. |
+
+---
+
+## References
+
+- [ADR-0041](ADR-0041-immutable-evidence-nodes.md) — attestation is an immutable evidence node; committed before action executes
+- [ADR-0042](ADR-0042-task-certificate.md) — defines `TaskCertificate`, `defensibility: DEGRADED`, and `BREAK_GLASS` state
+- [ADR-0043](ADR-0043-governed-tool-declaration.md) — `@governed_tool` declares which tools carry gates
+- [ADR-0044](ADR-0044-tool-gates.md) — HARD/SOFT/ADVISORY gate levels; HARD gates are what break-glass overrides
+- [ADR-0047](ADR-0047-agent-charter.md) — agent charters enumerate which gates are `overridable=False`
+- [ADR-0050](ADR-0050-operation-context.md) — operation context carried on every tool call during a break-glass window
+- [ADR-0033](ADR-0033-unified-entity-state-model.md) — `EvidenceRef` type used in `BreakGlassRequest.supporting_evidence`
+- prior governance research `01_design/016-break-glass/ADR-016-break-glass.md` — source pattern (DEGRADED defensibility, typed attestation, auto-notification, non-exportable default)

--- a/docs/adrs/ADR-0046-jit-tool-grant.md
+++ b/docs/adrs/ADR-0046-jit-tool-grant.md
@@ -1,0 +1,543 @@
+# ADR-0046: JIT Tool Grant — No Standing Capability for High-Risk Tools
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Depends on**: [ADR-0043](ADR-0043-governed-tool-declaration.md), [ADR-0044](ADR-0044-tool-gates.md)
+**Related**: [ADR-0041](ADR-0041-immutable-evidence-nodes.md), [ADR-0045](ADR-0045-break-glass-protocol.md), [ADR-0047](ADR-0047-agent-charter.md), [ADR-0051](ADR-0051-tool-registry-allowlists.md)
+
+---
+
+## Context
+
+In lionagi today, a tool registered on a `Branch` is always callable. The moment
+`branch.register_tools([delete_resource, write_production_db, call_payment_api])` executes, the
+agent has standing capability to invoke any of those tools at any point in any future turn — with
+no fresh authorization, no time limit, no scope binding. Nothing prevents the agent from calling
+`delete_resource(id="all")` three sessions after the operator intended a one-off cleanup. The
+capability persists until the Branch is torn down.
+
+For low-risk tools (read operations, local file reads, formatting utilities), standing capability is
+acceptable and desirable — requiring authorization on every call would make agentic workflows
+unusable. For high-risk tools — production writes, financial transactions, external API calls with
+side effects, irreversible destructive operations — standing capability is the attack surface. An
+agent that is compromised, confused, or simply operating outside its intended scope can cause
+real harm precisely because the capability is always present.
+
+Cross-cutting principle #1 (fail-closed is universal default) requires that ambiguity about
+authorization leads to denial, not execution. Cross-cutting principle #3 (every constraint must
+be enforced, not just documented) means a `requires_jit=True` annotation on a tool has no value
+unless the runtime actually blocks execution when no valid grant exists. This ADR introduces the
+`JITGrant` and `PermitToken` constructs that make both principles operational for high-risk tools.
+
+### The applicable prior governance research insight
+
+prior research addresses standing capability in human-facing sensitive operations (terminations,
+compensation changes) using a two-layer model: a `PermitToken` that binds one certificate to one
+execution (replay prevention), and a JIT role that removes the standing capability from the actor
+entirely so the action is invisible in the UI until the grant is active. The core insight
+translates directly to agent governance: the primary mechanism is the permit (transaction binding,
+single-use); the secondary mechanism is JIT (no standing power). Both layers must hold. Disabling
+either degrades security — permit-only allows replay within the window; JIT-only allows replay
+because there is no per-transaction binding.
+
+### Why lionagi needs this
+
+Consider a `Branch` configured with `write_billing_record` and `archive_customer`. An operator
+launches the agent to process a single end-of-month billing run. The agent completes the task.
+The Branch is reused (as is common in FlowAgent pipelines — ADR-0047 documents that the same
+`branch=` reuse accumulates state). Two turns later, in a different context, the agent encounters
+an instruction it misinterprets as a correction request and calls `archive_customer(id="batch_*")`.
+The capability was standing. No gate fired. Without JIT grants, there is no mechanism to ensure
+that `write_billing_record` and `archive_customer` are only callable during a specific authorized
+window for a specific operation, not generally at any time the agent is alive.
+
+---
+
+## Decision
+
+Introduce `PermitToken` and `JITGrant` as the authorization substrate for high-risk tools.
+Tools declared with `requires_jit=True` via `@governed_tool` (ADR-0043) cannot execute unless
+a valid, unexpired `PermitToken` exists for the `(agent_id, tool_id)` pair at call time; the
+token is consumed atomically on first redemption; and a `JITGrant` record is held for the
+duration of that execution window.
+
+---
+
+### 1. Schemas
+
+The grant types are frozen `Element` records. State changes produce new instances; no mutation
+in place. The Branch-owned grant manager keeps active grant state in typed `Pile` collections.
+
+```python
+from __future__ import annotations
+
+import time
+from typing import Any, Literal
+
+from pydantic import ConfigDict, Field
+
+from lionagi.protocols.action.manager import ActionManager
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.log import DataLogger
+from lionagi.protocols.generic.pile import Pile
+
+
+FROZEN_RECORD = ConfigDict(
+    arbitrary_types_allowed=True,
+    use_enum_values=True,
+    populate_by_name=True,
+    extra="forbid",
+    frozen=True,
+)
+
+
+class GrantScope(Element):
+    """Scope that binds a grant to one agent, one tool, and optional args."""
+
+    model_config = FROZEN_RECORD
+
+    agent_id: str
+    tool_id: str
+    argument_constraints: dict[str, Any] = Field(default_factory=dict)
+
+    def matches(
+        self,
+        *,
+        agent_id: str,
+        tool_id: str,
+        arguments: dict[str, Any],
+    ) -> bool:
+        return (
+            self.agent_id == agent_id
+            and self.tool_id == tool_id
+            and not self.constraint_violations(arguments)
+        )
+
+    def constraint_violations(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        return {
+            key: {"expected": expected, "actual": arguments.get(key)}
+            for key, expected in self.argument_constraints.items()
+            if arguments.get(key) != expected
+        }
+
+
+class PermitRequest(Element):
+    """Agent-facing request emitted by branch.request_permit(...)."""
+
+    model_config = FROZEN_RECORD
+
+    scope: GrantScope
+    requested_by: str
+    reason: str = ""
+    action_request_id: str | None = None
+    deadline_at: float | None = None
+
+
+class ApprovalEvidence(Element):
+    """Evidence record for approval, denial, timeout, consumption, or revocation."""
+
+    model_config = FROZEN_RECORD
+
+    request_id: str | None = None
+    principal_id: str
+    decision: Literal["approved", "denied", "timeout", "consumed", "revoked"]
+    reason: str = ""
+    source_log_ids: tuple[str, ...] = ()
+
+
+class PermitToken(Element):
+    """Single-use authorization token bound to one (agent, tool) execution."""
+
+    model_config = FROZEN_RECORD
+
+    token_id: str                       # idempotency key; Element.id is canonical UUID
+    scope: GrantScope
+    issued_by: str                      # human user-id, orchestrator-id, or "system"
+    issued_at: float                    # unix timestamp
+    expires_at: float                   # issued_at + window (e.g., 300 seconds)
+    approval_evidence_id: str
+    consumed: bool = False
+    consumed_at: float | None = None
+    consumed_by_action_request_id: str | None = None
+
+    def is_valid(self, at: float | None = None) -> bool:
+        """True iff unexpired and not yet consumed."""
+        t = at if at is not None else time.time()
+        return (not self.consumed) and (t < self.expires_at)
+
+    def consume(self, *, action_request_id: str) -> "PermitToken":
+        """Return a new instance with consumed=True. Call site must persist."""
+        if self.consumed:
+            raise ValueError(f"PermitToken {self.token_id} already consumed")
+        return self.model_copy(
+            update={
+                "consumed": True,
+                "consumed_at": time.time(),
+                "consumed_by_action_request_id": action_request_id,
+            }
+        )
+
+
+class JITGrant(Element):
+    """Time-bound capability record for a (agent, tool) pair.
+
+    Separate from PermitToken: the grant records that capability was lawfully
+    extended; the permit is the per-call proof of authorization. Both must be
+    present and valid for execution to proceed.
+    """
+
+    model_config = FROZEN_RECORD
+
+    grant_id: str
+    scope: GrantScope
+    valid_from: float
+    valid_until: float                  # hard expiry for capability window
+    issued_by: str
+    revoke_after: float                 # >= valid_until + 300 s (delayed revocation)
+    permit_token_id: str                # back-reference to the PermitToken
+    approval_evidence_id: str
+    revoked_at: float | None = None
+    revocation_evidence_id: str | None = None
+
+    def is_active(self, at: float | None = None) -> bool:
+        t = at if at is not None else time.time()
+        return self.revoked_at is None and self.valid_from <= t <= self.valid_until
+
+    def revoke(self, *, evidence_id: str) -> "JITGrant":
+        return self.model_copy(
+            update={
+                "revoked_at": time.time(),
+                "revocation_evidence_id": evidence_id,
+            }
+        )
+
+
+class JITGrantManager(Element):
+    """Branch-owned grant state; mounted beside ActionManager and DataLogger."""
+
+    agent_id: str
+    actions: ActionManager | None = Field(default=None, exclude=True)
+    logger: DataLogger | None = Field(default=None, exclude=True)
+    permit_requests: Pile[PermitRequest] = Field(
+        default_factory=lambda: Pile(item_type=PermitRequest, strict_type=True)
+    )
+    approval_evidence: Pile[ApprovalEvidence] = Field(
+        default_factory=lambda: Pile(item_type=ApprovalEvidence, strict_type=True)
+    )
+    permit_tokens: Pile[PermitToken] = Field(
+        default_factory=lambda: Pile(item_type=PermitToken, strict_type=True)
+    )
+    grants: Pile[JITGrant] = Field(
+        default_factory=lambda: Pile(item_type=JITGrant, strict_type=True)
+    )
+
+    def record_evidence(self, evidence: ApprovalEvidence) -> None:
+        self.approval_evidence.include(evidence)
+        if self.logger:
+            self.logger.log(evidence)
+
+    def find_valid_token(
+        self,
+        *,
+        agent_id: str,
+        tool_id: str,
+        arguments: dict[str, Any],
+        at: float | None = None,
+    ) -> PermitToken | None:
+        t = at if at is not None else time.time()
+        for token in self.permit_tokens:
+            if not token.is_valid(t):
+                continue
+            if not token.scope.matches(
+                agent_id=agent_id, tool_id=tool_id, arguments=arguments
+            ):
+                continue
+            for grant in self.grants:
+                if (
+                    grant.permit_token_id == token.token_id
+                    and grant.scope == token.scope
+                    and grant.is_active(t)
+                ):
+                    return token
+        return None
+
+    def consume_token(
+        self,
+        *,
+        token: PermitToken,
+        action_request_id: str,
+    ) -> PermitToken:
+        consumed = token.consume(action_request_id=action_request_id)
+        self.permit_tokens.update(consumed)
+        self.record_evidence(
+            ApprovalEvidence(
+                principal_id="gate_jit_required",
+                decision="consumed",
+                reason=f"PermitToken {token.token_id} consumed for execution.",
+                request_id=action_request_id,
+            )
+        )
+        return consumed
+```
+
+---
+
+### 2. Standing vs. JIT capability
+
+A tool's capability mode is set at declaration time via `@governed_tool` (ADR-0043):
+
+```python
+from lionagi.agent.governance.governed_tool import governed_tool
+from lionagi.protocols.action.manager import ActionManager
+
+# Default: STANDING — callable at any time, no JIT required.
+@governed_tool
+async def read_document(path: str) -> str: ...
+
+# JIT required: gate_jit_required fires before every call.
+@governed_tool(requires_jit=True, safety_class="privileged")
+async def delete_resource(resource_id: str) -> dict: ...
+
+# safety_class="privileged" implies requires_jit=True even if omitted.
+@governed_tool(safety_class="privileged")
+async def write_production_record(payload: dict) -> dict: ...
+
+actions = ActionManager()
+actions.register_tools(
+    [read_document, delete_resource, write_production_record],
+    update=True,
+)
+```
+
+The `safety_class` field interacts with the Tool Registry Allowlist (ADR-0051): tools registered
+as `safety_class="privileged"` appear in the privileged tier of the allowlist and JIT is enforced
+at the registry level, not just on the individual tool decorator. An agent cannot register a
+privileged tool and bypass JIT by omitting `requires_jit=True`.
+
+---
+
+### 3. Execution flow
+
+The `gate_jit_required` gate (registered as a HARD gate per ADR-0044) fires before any
+`requires_jit=True` tool call. The gate is registered through the existing `AgentConfig.pre(...)`
+hook path and closes over the current Branch's `JITGrantManager`.
+
+```python
+from typing import Any
+
+from lionagi.agent.config import AgentConfig
+from lionagi.session.branch import Branch
+
+
+def install_jit_grant_hook(branch: Branch, config: AgentConfig) -> JITGrantManager:
+    """Mount Branch-scoped grants and register the JIT gate through AgentConfig."""
+    grants = JITGrantManager(
+        agent_id=str(branch.id),
+        actions=branch.acts,             # existing ActionManager
+        logger=branch._log_manager,      # existing DataLogger
+    )
+    branch.metadata.setdefault("governance", {})["jit_grants"] = str(grants.id)
+    config.pre("*", gate_jit_required(grants))
+    return grants
+
+
+def gate_jit_required(grants: JITGrantManager):
+    """Existing pre-hook signature from lionagi.agent.hooks."""
+
+    async def _gate(
+        tool_name: str,
+        action: str,
+        args: dict[str, Any],
+    ) -> dict | None:
+        tool_id = str(args.get("function") or args.get("tool_id") or action or tool_name)
+        tool = grants.actions.registry.get(tool_id) if grants.actions else None
+        governance = getattr(tool, "governance", None) or getattr(
+            tool, "governance_meta", None
+        )
+        requires_jit = bool(getattr(governance, "requires_jit", False))
+        safety_class = getattr(governance, "safety_class", "")
+        if not (requires_jit or safety_class == "privileged"):
+            return None
+
+        agent_id = str(args.get("agent_id") or grants.agent_id)
+        token = grants.find_valid_token(
+            agent_id=agent_id,
+            tool_id=tool_id,
+            arguments=args,
+        )
+        if token is None:
+            reason = (
+                f"No valid JIT permit for tool '{tool_id}' / agent '{agent_id}'. "
+                "Call branch.request_permit(tool_id, args) to obtain authorization."
+            )
+            grants.record_evidence(
+                ApprovalEvidence(
+                    principal_id="gate_jit_required",
+                    decision="denied",
+                    reason=reason,
+                )
+            )
+            raise PermissionError(reason)
+
+        violations = token.scope.constraint_violations(args)
+        if violations:
+            reason = f"Permit constraint violations: {violations}"
+            grants.record_evidence(
+                ApprovalEvidence(
+                    principal_id="gate_jit_required",
+                    decision="denied",
+                    reason=reason,
+                )
+            )
+            raise PermissionError(reason)
+
+        grants.consume_token(
+            token=token,
+            action_request_id=str(args.get("action_request_id", "")),
+        )
+        return None
+
+    return _gate
+```
+
+Sequence: agent generates `ActionRequest` → gate fires → no valid token → HARD deny with
+`request_permit` path → agent calls `branch.request_permit(tool_id, args)` → authorizing party
+issues `PermitToken` + `JITGrant` → agent retries → gate validates and consumes token atomically
+→ tool executes; `ActionResponse` recorded as evidence (ADR-0041) → grant held until
+`revoke_after`; any second call without a new token fails (fail-closed, principle #1).
+
+---
+
+### 4. Permit request surface
+
+`branch.request_permit(tool_id, args, reason="")` is the agent-facing entry point. It emits a
+`PermitRequest` event and suspends the current turn (does not consume context window tokens)
+until the authorizing party responds. It raises `PermitDenied` on rejection and `PermitTimeout`
+if no decision arrives within the configured deadline.
+
+In autonomous pipelines, the orchestrator acts as the authorizing party. A `Branch` configured
+as an orchestrator (ADR-0047) can issue permits for sub-agents it governs, provided the
+orchestrator itself holds a grant from a human principal at the session level. This is not
+self-approval — ADR-0048 (Segregation of Duties) requires the authorizing identity to be
+distinct from the executing agent.
+
+---
+
+### 5. Delayed revocation rationale
+
+`JITGrant.revoke_after` is set to `valid_until + 300 seconds` by default. A grant revoked at
+exactly `valid_until` may leave an in-flight tool call (already dispatched, awaiting network I/O)
+in an undefined authorization state. The 5-minute grace window lets legitimately dispatched calls
+complete or receive a clean denial from the downstream system rather than a mid-call revocation.
+
+The grace window does NOT extend the permit. `PermitToken` is consumed on first redemption
+regardless of whether `JITGrant` is still in grace — replay prevention is enforced by the token,
+not the window. An agent that consumed its token and attempts a second call during the grace
+period fails at the gate (no valid token found).
+
+---
+
+### 6. Audit integration
+
+Every state transition in the JIT lifecycle produces an evidence node per ADR-0041:
+
+| Event | Evidence kind | Required fields |
+|-------|---------------|-----------------|
+| `PermitToken` issued | `tool_result` | `token_id`, `issued_by`, `expires_at`, `tool_id`, `agent_id` |
+| `PermitToken` consumed | `tool_result` | `token_id`, `consumed_at`, `action_request_id` |
+| `PermitToken` expired (unused) | `tool_result` | `token_id`, `expires_at` |
+| `JITGrant` issued | `tool_result` | `grant_id`, `issued_by`, `valid_until`, `revoke_after` |
+| `JITGrant` revoked | `tool_result` | `grant_id`, `revoked_at` |
+| Gate denial | `tool_result` | `tool_id`, `agent_id`, `reason`, `gate_id=gate_jit_required` |
+
+Evidence nodes are hash-chained (ADR-0041) so that the sequence — permit issued, consumed,
+grant revoked — cannot be silently rewritten after the fact. This provides the audit trail
+required for post-incident reconstruction: given any tool call, the auditor can traverse
+`action_request_id → permit_token_id → grant_id → issued_by` without gaps.
+
+---
+
+## Consequences
+
+**Positive**
+
+- No standing capability for tools declared `requires_jit=True` or `safety_class="privileged"`.
+  A compromised or out-of-scope agent cannot invoke high-risk tools without a fresh authorization
+  decision from an external party.
+- Replay prevention is structural, not convention-based. A `PermitToken` consumed once cannot
+  authorize a second call regardless of whether the grant window is still open.
+- Constraint binding narrows the blast radius. A permit issued with `{"resource_id": "r-123"}`
+  blocks the agent from calling the same tool with `resource_id="r-*"` even if no human is
+  watching.
+- Audit trail is machine-traversable from tool call back to human decision (ADR-0041 evidence
+  chain, ADR-0042 Task Certificate).
+- Break-glass compatibility: ADR-0045 provides the emergency path when the grant issuance
+  system is unavailable. Break-glass is not a JIT bypass — it is a separate degraded-mode
+  protocol that produces its own evidence under heightened scrutiny.
+
+**Negative**
+
+- Agentic workflows that previously ran autonomously on high-risk tools now require an external
+  authorization step. Pipelines must be redesigned to either obtain permits ahead of time (batch
+  pre-authorization) or tolerate suspension while awaiting approval.
+- Human-in-the-loop latency is now on the critical path for any `requires_jit=True` tool. Studio
+  UI must surface permit requests clearly; a buried notification degrades the flow without
+  improving security.
+- Orchestrators acting as authorizing parties create a trust chain that must be audited. An
+  orchestrator that auto-approves every sub-agent request without human oversight negates the
+  security benefit. ADR-0047 (Agent Charter) and ADR-0048 (Segregation of Duties) constrain
+  what an orchestrator may self-approve.
+- `JITGrantManager` introduces shared mutable state across a Branch's execution that must be
+  thread-safe and persisted to survive process restarts. Implementations that hold grants only
+  in memory lose the revocation record on crash.
+
+---
+
+## Non-Goals
+
+Explicitly out of scope:
+
+- **Federated permit issuance across tenants**: Cross-tenant grants and multi-tenant permit
+  federation are KHive territory. In v1, permits are scoped to a single lionagi process/session
+  boundary.
+- **Automatic re-issuance on expiry**: A `PermitToken` that expires is not automatically renewed.
+  Re-issuance requires a new authorization decision. Automatic renewal would convert a time-bounded
+  grant into standing capability under a different name.
+- **Grant transferability between agents**: A `PermitToken` is bound to `GrantScope.agent_id`. It
+  cannot be passed from one Branch to another. An agent cannot delegate its own permit.
+- **Permit-less execution paths for declared high-risk tools**: There is no flag, environment
+  variable, or runtime mode that makes `requires_jit=True` tools executable without a valid
+  token. Library mode (`LIONAGI_GOVERNED=false`) suppresses governance at the framework level,
+  but does not affect tools that explicitly declare `requires_jit=True` in their own decorator.
+- **UI permit-approval interface**: Studio UI surface for displaying and approving permit
+  requests is out of scope for this ADR. The protocol (`PermitRequest` event, `request_permit`
+  API) is defined here; the UI implementation is a Studio concern.
+- **Revocation of already-consumed tokens**: A consumed token is a historical record, not an
+  active authorization. Revoking it has no security effect and is not supported.
+
+---
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Standing capability only (current behavior) | No authorization boundary for high-risk tools. A long-lived agent with `delete_resource` registered can call it at any turn in any context. Unacceptable for privileged operations. |
+| Revoke standing on idle timeout | Too coarse. Idle-based revocation does not bind capability to a specific authorized operation. An agent that just processed an unrelated request would have its capability restored on the next active turn. |
+| Per-call human confirmation | Blocks agentic execution — every call suspends until a human responds. For multi-step tool sequences this creates an unworkable approval queue. JIT grants allow pre-authorization of a bounded window; per-call confirmation eliminates any window. |
+| JIT role only (no permit token) | Removes standing capability but allows replay: any call during the grant window is authorized, not just the specific transaction the human approved. prior research explicitly rejected this. Replay within the grant window is a real attack vector. |
+| Permit token only (no JIT grant record) | Prevents replay but provides no capability-window audit record. The grant record is what allows auditors to trace "who extended capability to this agent and for how long" independently of which specific calls were made. |
+
+---
+
+## References
+
+- [ADR-0041](ADR-0041-immutable-evidence-nodes.md) — hash-chained evidence nodes that anchor every permit lifecycle event
+- [ADR-0042](ADR-0042-task-certificate.md) — Task Certificate: signed proof of process adherence that JIT grants link into
+- [ADR-0043](ADR-0043-governed-tool-declaration.md) — `@governed_tool` declaration surface; `requires_jit=True` and `safety_class` fields defined there
+- [ADR-0044](ADR-0044-tool-gates.md) — Tool Gates (HARD/SOFT/ADVISORY); `gate_jit_required` is a HARD gate registered per this ADR
+- [ADR-0045](ADR-0045-break-glass-protocol.md) — emergency path when grant issuance is unavailable; not a JIT bypass
+- [ADR-0047](ADR-0047-agent-charter.md) — Agent Charter; constrains which agents may act as authorizing parties
+- [ADR-0048](ADR-0048-agent-segregation-of-duties.md) — SoD: an agent cannot approve its own JIT grant
+- [ADR-0051](ADR-0051-tool-registry-allowlists.md) — privileged tier of the tool registry enforces JIT at registration time
+- [ADR-0033](ADR-0033-unified-entity-state-model.md) — `EvidenceRef` kinds used in audit table above
+- prior governance research `01_design/015-jit-role/ADR-015-jit-role.md` — source pattern (defense-in-depth with permit + JIT roles)

--- a/docs/adrs/ADR-0047-agent-charter.md
+++ b/docs/adrs/ADR-0047-agent-charter.md
@@ -1,0 +1,757 @@
+# ADR-0047: Agent Charter — Enforceable Governance Document
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Depends on**: [ADR-0044](ADR-0044-tool-gates.md) (charter constraints bind to gate_ids), [ADR-0051](ADR-0051-tool-registry-allowlists.md) (charter declares the tool allowlist), [ADR-0052](ADR-0052-policy-resolution.md) (charter version is part of the policy bundle), [ADR-0050](ADR-0050-operation-context.md) (active charter version captured in evidence)
+**Related**: [ADR-0041](ADR-0041-immutable-evidence-nodes.md) (charter ratification hash follows the same SHA-256 pattern), [ADR-0042](ADR-0042-task-certificate.md) (certificate records active charter version), [ADR-0046](ADR-0046-jit-tool-grant.md) (JIT grant gates appear as charter constraints), [ADR-0048](ADR-0048-agent-segregation-of-duties.md) (SoD constraints are declared in the charter)
+
+## Context
+
+lionagi's `AgentConfig` (`lionagi/agent/config.py`) is the current primary configuration
+artifact for an agent. It carries a `permissions` dict, a `hook_handlers` dict, a `tools` list,
+and free-form `extra`. An operator can write:
+
+```python
+config = AgentConfig(
+    name="pr-reviewer",
+    tools=["reader", "bash"],
+    permissions={"bash.deny": ["git push *", "git commit *"]},
+)
+config.pre("bash", guard_destructive)
+```
+
+This documents intent clearly. What it does not do is enforce that intent uniformly. The
+`permissions` dict is read by `create_agent()` and wired into the branch at session start, but
+nothing prevents a downstream call from ignoring it. The `guard_destructive` hook fires if wired
+correctly, but there is no structural guarantee that a config claiming "deny destructive commands"
+has actually registered that hook. The configuration records what the operator *wanted*; it does
+not prove what the system *will do*.
+
+Cross-cutting principle #3 — **every constraint must be enforced, not just documented** — names
+this gap precisely. Aspirational constraints without enforcement bindings are not governance; they
+are intent commentary. An `AgentConfig` that says "deny network access" but has no gate preventing
+a network-capable tool from executing is indistinguishable, at audit time, from one that says
+nothing about network access at all.
+
+The gap has a second dimension: mutability. `AgentConfig` is a mutable Python dataclass. Nothing
+prevents code from altering the `permissions` dict after the config is created but before the
+session starts. There is no signatory record, no hash, and no proof that the config that launched
+a session matches the config a human approved. When someone asks "was this agent governed by the
+right policy?" the only answer today is "we believe so."
+
+### The applicable prior governance research insight
+
+prior research establishes that a Charter is the canonical governance document for a tenant:
+every constraint in the Charter must reference either a `gate_id` (a registered enforcement gate)
+or a `service_check` (an importable method). If there is no code enforcing a constraint, that
+constraint does not belong in the Charter. The Charter is made immutable by a ratification hash
+(SHA-256 of all fields) computed at activation time; signatories are accountable for the exact
+content they endorsed. Single active Charter per tenant eliminates governance ambiguity: at any
+point in time, exactly one Charter is authoritative. In lionagi terms, tenant maps to agent: each
+agent has exactly one active `AgentCharter`.
+
+### Why lionagi needs this
+
+Consider a PR reviewer agent deployed inside an organization. Its `AgentConfig` states it must not
+write to the main branch and must emit structured evidence for every file read. These are real
+constraints with real consequences if violated. Without `AgentCharter`, an operator reading the
+config has to trust that every hook was wired correctly, that no code path bypasses the hook
+registry, and that the config was not mutated between authoring and deployment. With
+`AgentCharter`, activation fails if `gate_id: "guard_branch_protection"` is not found in the
+gate registry, and `hook_name: "log_tool_use"` is not importable. The constraint either binds to
+code or the charter does not activate. There is no middle state.
+
+## Decision
+
+We introduce `AgentCharter` as the canonical governance binding for a lionagi agent: a frozen,
+hash-ratified document where every constraint references either a registered tool gate
+(ADR-0044) or an importable hook, and whose version is captured in every Operation Context
+(ADR-0050) produced during the agent's sessions.
+
+### 1. `CharterConstraint` — the enforcement-binding requirement
+
+Every constraint in a charter must prove it has code behind it. Pydantic validation on the
+`Element` subclass enforces this structurally at construction time, not at activation time.
+
+```python
+# lionagi/protocols/governance/charter.py
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import json
+from typing import Any
+from typing import Literal
+
+from pydantic import ConfigDict, Field, model_validator
+
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.log import DataLogger
+from lionagi.protocols.generic.pile import Pile
+
+HookPhase = Literal["message_added", "security_pre", "pre", "post", "error"]
+ManagerSurface = Literal[
+    "MessageManager",
+    "ActionManager",
+    "iModelManager",
+    "DataLogger",
+]
+
+
+class CharterConstraint(Element):
+    """An enforceable constraint declared in an AgentCharter.
+
+    CRITICAL: Exactly one of gate_id or hook_name must be set.
+    If there is no code enforcing this constraint, it does not belong here.
+    Aspirational constraints have no operational value.
+
+    Attributes:
+        constraint_id: Human-readable identifier, unique within the charter.
+        description: What this constraint requires, in plain language.
+        gate_id: References a registered ToolGate (ADR-0044). Mutually
+            exclusive with hook_name.
+        hook_name: References an existing hook by importable dotted or
+            "module:attribute" path (e.g. "lionagi.agent.hooks.log_tool_use").
+            Mutually exclusive with gate_id.
+        hook_phase: Existing hook phase used when hook_name is set.
+        manager_surface: Branch manager surface affected by this constraint.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    constraint_id: str = Field(min_length=1)
+    description: str = Field(min_length=1)
+    gate_id: str | None = None
+    hook_name: str | None = None
+    hook_phase: HookPhase | None = None
+    manager_surface: ManagerSurface = "ActionManager"
+
+    @model_validator(mode="after")
+    def validate_enforcement_binding(self) -> CharterConstraint:
+        has_gate = self.gate_id is not None
+        has_hook = self.hook_name is not None
+        if has_gate == has_hook:
+            raise ValueError(
+                f"CharterConstraint '{self.constraint_id}' must have exactly one of "
+                f"gate_id or hook_name, not both and not neither. "
+                f"If there is no code enforcing this constraint, it does not belong "
+                f"in the charter. (gate_id={self.gate_id!r}, hook_name={self.hook_name!r})"
+            )
+        if has_hook and self.hook_phase is None:
+            raise ValueError(
+                f"CharterConstraint '{self.constraint_id}' with hook_name must declare "
+                "the existing hook phase it binds to."
+            )
+        if has_gate and self.hook_phase is not None:
+            raise ValueError(
+                f"CharterConstraint '{self.constraint_id}' with gate_id must not declare "
+                "a hook_phase."
+            )
+        return self
+```
+
+### 2. `AgentCharter` — the governance document
+
+```python
+class CharterActivationEvidence(Element):
+    """Evidence that a charter constraint resolved, or failed to resolve, to code."""
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    constraint_id: str
+    binding_kind: Literal["gate", "hook"]
+    binding_ref: str
+    manager_surface: ManagerSurface
+    resolved: bool
+    reason: str | None = None
+
+
+class AgentCharter(Element):
+    """Tenant-scoped (agent-scoped) governance document.
+
+    An AgentCharter is immutable after ratification. Its ratification_hash
+    is SHA-256 of all fields except ratification_hash itself, computed at
+    activation time. Signatories are accountable for the exact content they
+    endorsed — the hash proves what they ratified.
+
+    Only one charter may be ACTIVE per agent_id at any time. To change
+    governance, create a new charter and supersede this one.
+
+    Attributes:
+        charter_id: Unique identifier for this charter document.
+        agent_id: The agent this charter governs.
+        version: Monotonically increasing integer per charter_id. Version 1
+            is the initial charter; each supersession increments by one.
+        constraints: Pile of constraints. Every constraint references either a
+            gate_id or a hook_name — no aspirational rules.
+        allowed_tools: Explicit allowlist of tool names this agent may call.
+            Declared here; enforced by the Tool Registry (ADR-0051).
+        allowed_models: iModel identifiers this agent may use. Constrains
+            iModelManager resolution at session start.
+        policy_release_version: Binds this charter to a specific policy bundle
+            from ADR-0052. Ensures the constraint set was authored against a
+            known policy state.
+        ratified_at: Unix timestamp of ratification.
+        ratified_by: Ordered list of signatory identifiers. Signatories are
+            accountable for this exact content.
+        ratification_hash: SHA-256 of all fields except this field itself.
+            Computed on first activation. Presence signals the charter is
+            ACTIVE or SUPERSEDED — never DRAFT.
+        active: True when this charter is the currently governing document
+            for agent_id. Exactly one active charter per agent_id at any time.
+        superseded_by: charter_id of the charter that replaced this one, or
+            None if this charter is still active or was never activated.
+        activation_evidence: Pile of typed evidence records produced when
+            activation resolves gates and hooks.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    charter_id: str = Field(min_length=1)
+    agent_id: str = Field(min_length=1)
+    version: int = Field(ge=1)
+    constraints: Pile[CharterConstraint] = Field(
+        default_factory=lambda: Pile(
+            item_type={CharterConstraint},
+            strict_type=True,
+        )
+    )
+    allowed_tools: tuple[str, ...] = Field(default_factory=tuple)
+    allowed_models: tuple[str, ...] = Field(default_factory=tuple)
+    policy_release_version: str
+    ratified_at: float
+    ratified_by: tuple[str, ...] = Field(default_factory=tuple)
+    ratification_hash: str = ""
+    active: bool = False
+    superseded_by: str | None = None
+    activation_evidence: Pile[CharterActivationEvidence] = Field(
+        default_factory=lambda: Pile(
+            item_type={CharterActivationEvidence},
+            strict_type=True,
+        )
+    )
+
+    def verify_hash(self) -> bool:
+        """Return True if ratification_hash matches recomputed hash of content."""
+        return self.ratification_hash == _compute_charter_hash(self)
+
+    def constraint_by_id(self, constraint_id: str) -> CharterConstraint | None:
+        """Look up a single constraint by its constraint_id."""
+        for c in self.constraints:
+            if c.constraint_id == constraint_id:
+                return c
+        return None
+```
+
+### 3. Charter hash computation
+
+The hash covers every governance-relevant field. It excludes `ratification_hash` itself (the
+field being computed) and `active` / `superseded_by` (lifecycle fields that change without
+altering what was ratified).
+
+```python
+def _compute_charter_hash(charter: AgentCharter) -> str:
+    """Compute SHA-256 over all ratification-relevant fields.
+
+    Fields excluded: ratification_hash (computed), active, superseded_by
+    (lifecycle metadata that changes without modifying what was ratified),
+    activation_evidence, and Element infrastructure fields.
+    """
+    content: dict[str, Any] = charter.to_dict(mode="db")
+    for field_name in (
+        "id",
+        "created_at",
+        "node_metadata",
+        "ratification_hash",
+        "active",
+        "superseded_by",
+        "activation_evidence",
+    ):
+        content.pop(field_name, None)
+    serialized = json.dumps(content, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(serialized.encode()).hexdigest()
+```
+
+### 4. Charter activation — the enforcement-binding validation gate
+
+Activation validates that every constraint in the charter resolves to real code before the
+charter becomes operative. If any constraint fails to resolve, activation raises and the charter
+remains in DRAFT state. This is the structural enforcement of cross-cutting principle #3.
+
+```python
+class CharterActivationError(Exception):
+    """Raised when a charter cannot be activated due to unresolvable constraints."""
+
+    def __init__(
+        self,
+        charter_id: str,
+        failures: Pile[CharterActivationEvidence],
+    ) -> None:
+        self.charter_id = charter_id
+        self.failures = failures
+        detail = "\n  ".join(
+            f"constraint '{e.constraint_id}': {e.reason}" for e in failures
+        )
+        super().__init__(
+            f"Charter '{charter_id}' activation failed — "
+            f"{len(failures)} constraint(s) could not be resolved to code:\n  {detail}\n"
+            "Remove unresolvable constraints or implement the missing gates/hooks."
+        )
+
+
+def _resolve_hook(hook_name: str) -> Any:
+    if ":" in hook_name:
+        module_path, attr = hook_name.split(":", 1)
+    else:
+        module_path, _, attr = hook_name.rpartition(".")
+    if not module_path or not attr:
+        raise ImportError(f"{hook_name!r} is not an importable hook path")
+    return getattr(importlib.import_module(module_path), attr)
+
+
+def activate_charter(
+    charter: AgentCharter,
+    gate_registry: dict[str, Any],
+    logger: DataLogger | None = None,
+) -> AgentCharter:
+    """Validate all constraints resolve to code and return an active charter.
+
+    Args:
+        charter: The charter to activate. Must be in DRAFT state
+            (ratification_hash == "" or charter.active == False).
+        gate_registry: Map of gate_id -> ToolGate object (ADR-0044).
+            Used to resolve gate_id constraints.
+        logger: Existing DataLogger used to record activation evidence.
+
+    Returns:
+        A new frozen AgentCharter with active=True, ratification_hash set,
+        and activation_evidence populated.
+
+    Raises:
+        CharterActivationError: If any constraint's gate_id is absent from
+            gate_registry, or any constraint's hook_name is not importable.
+        ValueError: If a charter with active=True is passed (already active
+            charters are immutable).
+    """
+    if charter.active:
+        raise ValueError(
+            f"Charter '{charter.charter_id}' is already active. "
+            "To change governance, supersede it with a new charter version."
+        )
+
+    evidence = Pile(item_type={CharterActivationEvidence}, strict_type=True)
+
+    for constraint in charter.constraints:
+        if constraint.gate_id is not None:
+            resolved = constraint.gate_id in gate_registry
+            evidence.include(
+                CharterActivationEvidence(
+                    constraint_id=constraint.constraint_id,
+                    binding_kind="gate",
+                    binding_ref=constraint.gate_id,
+                    manager_surface=constraint.manager_surface,
+                    resolved=resolved,
+                    reason=(
+                        None
+                        if resolved
+                        else f"gate_id '{constraint.gate_id}' not found in gate registry"
+                    ),
+                )
+            )
+        else:
+            assert constraint.hook_name is not None  # enforced by CharterConstraint
+            try:
+                _resolve_hook(constraint.hook_name)
+                evidence.include(
+                    CharterActivationEvidence(
+                        constraint_id=constraint.constraint_id,
+                        binding_kind="hook",
+                        binding_ref=constraint.hook_name,
+                        manager_surface=constraint.manager_surface,
+                        resolved=True,
+                    )
+                )
+            except (ImportError, AttributeError) as exc:
+                evidence.include(
+                    CharterActivationEvidence(
+                        constraint_id=constraint.constraint_id,
+                        binding_kind="hook",
+                        binding_ref=constraint.hook_name,
+                        manager_surface=constraint.manager_surface,
+                        resolved=False,
+                        reason=f"hook_name '{constraint.hook_name}' is not importable — {exc}",
+                    )
+                )
+
+    failures = Pile(
+        collections=[e for e in evidence if not e.resolved],
+        item_type={CharterActivationEvidence},
+        strict_type=True,
+    )
+
+    if failures:
+        raise CharterActivationError(charter.charter_id, failures)
+
+    active_draft = charter.model_copy(
+        update={
+            "active": True,
+            "ratification_hash": "__pending__",
+            "activation_evidence": evidence,
+        },
+        deep=True,
+    )
+    final_hash = _compute_charter_hash(active_draft)
+    active_charter = active_draft.model_copy(
+        update={"ratification_hash": final_hash},
+        deep=True,
+    )
+    if logger is not None:
+        logger.log(
+            {
+                "event": "agent_charter.activated",
+                "charter_id": active_charter.charter_id,
+                "version": active_charter.version,
+                "ratification_hash": active_charter.ratification_hash,
+                "activation_evidence": [
+                    e.to_dict(mode="json") for e in active_charter.activation_evidence
+                ],
+            }
+        )
+    return active_charter
+```
+
+### 5. Lifecycle state machine
+
+```text
+DRAFT ──ratify()──► ACTIVE ──supersede(new_id)──► SUPERSEDED
+  │                                                     │
+  └── edit fields freely                                └── immutable; superseded_by set
+      (hash not yet computed)
+
+ACTIVE: active=True, ratification_hash set, superseded_by=None
+DRAFT:  active=False, ratification_hash="" (or absent)
+SUPERSEDED: active=False, ratification_hash set, superseded_by=<newer_charter_id>
+```
+
+Exactly one ACTIVE charter exists per `agent_id` at any time. The charter store enforces this as
+a uniqueness constraint: activating a new charter atomically sets the previous ACTIVE charter to
+SUPERSEDED and sets `superseded_by` to the new charter's `charter_id`. Both records are retained.
+
+### 6. Integration with `AgentConfig`
+
+`AgentConfig` retains its current role as the session-level configuration surface. At session
+start, `create_agent()` resolves the active charter for `config.extra["agent_id"]` or
+`config.name` (if a charter store is configured) and attaches it to the branch. The charter's
+`allowed_tools` becomes the authoritative tool allowlist, overriding `AgentConfig.tools` when a
+charter is present. The charter's
+`allowed_models` constrains `iModelManager` model selection.
+
+The active charter's `charter_id` and `version` are written into the Operation Context
+(ADR-0050) for every session that runs under it. Every evidence node produced during the session
+carries the charter version in its metadata, making post-hoc governance audits unambiguous.
+
+```python
+# Sketch — lionagi/agent/factory.py (existing file)
+
+from typing import Any
+
+from lionagi.agent.config import AgentConfig
+from lionagi.session.branch import Branch
+
+
+def _config_agent_id(config: AgentConfig) -> str:
+    return str(config.extra.get("agent_id", config.name))
+
+
+def _validate_active_charter(
+    config: AgentConfig,
+    charter: AgentCharter | None,
+) -> AgentCharter | None:
+    if charter is None:
+        return None
+    if not charter.active:
+        raise ValueError(
+            f"Cannot create agent under inactive charter '{charter.charter_id}'. "
+            "Activate the charter before passing it to create_agent()."
+        )
+    if not charter.verify_hash():
+        raise ValueError(
+            f"Charter '{charter.charter_id}' ratification_hash does not match "
+            "current content. The charter may have been tampered with."
+        )
+    if charter.agent_id != _config_agent_id(config):
+        raise ValueError(
+            f"Charter '{charter.charter_id}' governs {charter.agent_id!r}, "
+            f"not AgentConfig {_config_agent_id(config)!r}."
+        )
+    return charter
+
+
+def _apply_charter_to_config(config: AgentConfig, charter: AgentCharter) -> None:
+    # ActionManager: tools are registered from AgentConfig.tools, so the
+    # charter allowlist becomes authoritative before registration.
+    config.tools = list(charter.allowed_tools)
+
+    # Existing Tool pre/post/security/error hooks are wired through AgentConfig
+    # and attached by create_agent() to Tool.preprocessor/postprocessor.
+    for constraint in charter.constraints:
+        if constraint.hook_name is None or constraint.hook_phase == "message_added":
+            continue
+        hook = _resolve_hook(constraint.hook_name)
+        config.hook_handlers.setdefault(f"{constraint.hook_phase}:*", []).append(hook)
+
+
+def _model_ref(model: Any) -> str:
+    provider = getattr(model.endpoint.config, "provider", "")
+    model_name = getattr(model, "model_name", "")
+    return f"{provider}/{model_name}" if provider and model_name else model_name or provider
+
+
+def _bind_charter_to_branch(branch: Branch, charter: AgentCharter) -> None:
+    charter_ref = {
+        "charter_id": charter.charter_id,
+        "version": charter.version,
+        "ratification_hash": charter.ratification_hash,
+    }
+    branch.metadata["active_charter"] = charter_ref
+
+    # MessageManager/chat: stamp the active charter on every added message.
+    def stamp_charter_on_message(message) -> None:
+        message.metadata.setdefault("charter", charter_ref)
+
+    branch.on_message_added.append(stamp_charter_on_message)
+
+    # MessageManager hook constraints use the existing on_message_added hook list.
+    for constraint in charter.constraints:
+        if constraint.hook_phase == "message_added":
+            branch.on_message_added.append(_resolve_hook(constraint.hook_name))
+
+    # ActionManager/action: fail closed if a tool escaped the charter allowlist.
+    disallowed_tools = set(branch.acts.registry) - set(charter.allowed_tools)
+    if disallowed_tools:
+        raise PermissionError(
+            f"Tools outside active charter allowlist: {sorted(disallowed_tools)}"
+        )
+
+    # iModelManager/model: registered model endpoints must be charter-allowed.
+    if charter.allowed_models:
+        registered_models = {
+            ref for model in branch.mdls.registry.values() if (ref := _model_ref(model))
+        }
+        disallowed_models = registered_models - set(charter.allowed_models)
+        if disallowed_models:
+            raise PermissionError(
+                f"Models outside active charter allowlist: {sorted(disallowed_models)}"
+            )
+
+    # DataLogger/audit: durable provenance for the active Branch managers.
+    branch._log_manager.log(
+        {
+            "event": "agent_charter.bound",
+            "charter": charter_ref,
+            "message_manager": "MessageManager",
+            "action_manager": sorted(branch.acts.registry),
+            "imodel_manager": sorted(branch.mdls.registry),
+        }
+    )
+
+
+async def create_agent(
+    config: AgentConfig,
+    *,
+    charter: AgentCharter | None = None,
+    **kwargs: Any,
+) -> Branch:
+    active_charter = _validate_active_charter(config, charter)
+    if active_charter is not None:
+        _apply_charter_to_config(config, active_charter)
+
+    ...  # existing create_agent body creates Branch and registers managers/tools
+
+    if active_charter is not None:
+        _bind_charter_to_branch(branch, active_charter)
+    return branch
+```
+
+### 7. Two-Key authorship model
+
+The charter is a boundary between two roles with different responsibilities:
+
+- **Policy author**: declares *what* is required — writes the constraint text, assigns
+  `constraint_id`, references the appropriate `gate_id` or `hook_name`. Does not implement code.
+- **Gate implementer**: delivers the `ToolGate` or hook that the constraint references. Does not
+  decide *which* constraints exist.
+
+Neither role can produce a valid, active charter alone. The policy author's constraints are
+rejected at activation if the gate implementer has not delivered the gate. The gate implementer's
+gate has no governance standing unless the policy author declares a constraint referencing it.
+This is the structural separation of concern that makes constraint coverage verifiable.
+
+### 8. Worked example — PR reviewer agent charter
+
+```python
+import time
+
+from lionagi.protocols.generic.pile import Pile
+from lionagi.protocols.governance.charter import (
+    AgentCharter,
+    CharterConstraint,
+    activate_charter,
+)
+
+# Policy author writes constraints. Gate implementer has already registered
+# "guard_branch_protection" in the gate registry and shipped
+# "lionagi.agent.hooks.log_tool_use" as an importable Tool post-hook.
+
+reviewer_charter_draft = AgentCharter(
+    charter_id="charter:pr-reviewer:v1",
+    agent_id="agent:pr-reviewer",
+    version=1,
+    constraints=Pile(
+        collections=[
+            CharterConstraint(
+                constraint_id="no-write-main",
+                description=(
+                    "Agent MUST NOT write to the main branch directly. "
+                    "All writes must target a feature branch."
+                ),
+                gate_id="guard_branch_protection",
+                manager_surface="ActionManager",
+            ),
+            CharterConstraint(
+                constraint_id="evidence-every-read",
+                description=(
+                    "Agent MUST emit a structured log entry for every file read, "
+                    "recording tool name, path, and success status."
+                ),
+                hook_name="lionagi.agent.hooks.log_tool_use",
+                hook_phase="post",
+                manager_surface="DataLogger",
+            ),
+            CharterConstraint(
+                constraint_id="human-approval-merge",
+                description=(
+                    "Agent MUST request human approval before merging any branch. "
+                    "No autonomous merge is permitted."
+                ),
+                gate_id="gate_jit_required",  # ADR-0046 JIT grant gate
+                manager_surface="ActionManager",
+            ),
+        ],
+        item_type={CharterConstraint},
+        strict_type=True,
+    ),
+    allowed_tools=("reader", "bash", "search"),
+    allowed_models=("openai/gpt-4.1", "anthropic/claude-sonnet-4-6"),
+    policy_release_version="policy-bundle:v2026.05",
+    ratified_at=time.time(),
+    ratified_by=("ocean@example.com", "security-team@example.com"),
+    ratification_hash="",   # computed by activate_charter()
+    active=False,
+    superseded_by=None,
+)
+
+# Activation fails if any gate_id is absent from the registry or any
+# hook_name is not importable. Either the code exists or the charter does not activate.
+active_charter = activate_charter(reviewer_charter_draft, gate_registry=gate_registry)
+
+# active_charter.active == True
+# active_charter.ratification_hash == SHA-256 of all governance fields
+# active_charter.verify_hash() == True
+# len(active_charter.activation_evidence) == len(active_charter.constraints)
+```
+
+An operator upgrading the charter — say, adding a constraint that restricts the bash tool to
+read-only commands — creates `version=2`, lists all signatories who must ratify it, calls
+`activate_charter()`, and the store atomically supersedes `version=1`. The old charter is
+retained with `superseded_by="charter:pr-reviewer:v2"`. Any session that ran under `version=1`
+retains its Operation Context referencing `version=1`; its governance provenance is permanent.
+
+## Consequences
+
+**Positive**
+
+- Governance is verifiable: every constraint maps to a `gate_id` or `hook_name`. An auditor can
+  trace `charter constraint → gate → gate execution record` without forensic reconstruction.
+- No aspirational rules: the charter cannot contain constraints that have no enforcement binding.
+  The document reflects actual system behavior at the time it was activated.
+- Tamper evidence: `ratification_hash` detects any post-activation modification to the charter
+  content. `verify_hash()` is a one-line check at session start.
+- Governance provenance: every evidence node produced during a governed session carries the
+  charter version. When governance changes, the before/after boundary is unambiguous.
+- Signatories are accountable: they endorsed a specific hash, not a mutable document.
+
+**Negative**
+
+- Rigidity by design: adding a new constraint requires both the policy author to draft it and the
+  gate implementer to ship the corresponding gate or hook before the charter can activate. There
+  is no shortcut. This is intentional.
+- Re-ratification burden: any governance change — even correcting a typo in a `description` field
+  — requires a new charter version with re-ratification. Operators should batch changes before
+  ratifying.
+- Upfront investment: a project adopting `AgentCharter` must implement and register gates for
+  every constraint it wishes to declare. Projects without gate infrastructure cannot use charters
+  until that infrastructure exists.
+
+## Non-Goals
+
+Explicitly out of scope:
+
+- **Charter inheritance or composition**: a charter that extends another charter, or shares
+  constraints via a base template, is not supported in this ADR. If needed, address in a
+  follow-on ADR after the base model is stable.
+- **Runtime charter mutation**: deliberately impossible. A running session cannot modify its own
+  charter. Any change requires a new charter version, re-ratification, and explicit supersession.
+- **Charter UI or editor surface**: tooling for authoring, viewing, or approving charters is a
+  KHive product concern. This ADR specifies the data model and validation contract only.
+- **Multi-tenant charter namespacing**: multiple organizations sharing a lionagi deployment each
+  having isolated charter stores is a KHive concern. In the open-source framework, charter scope
+  is per-agent-id within a single deployment.
+- **Charter inheritance hierarchies**: e.g., an "org-level" charter whose constraints propagate
+  down to per-agent charters. Out of scope; addressed in policy resolution (ADR-0052) if needed.
+- **Automatic constraint generation**: tooling that inspects gate registry and proposes constraints
+  automatically is a product concern, not a framework concern.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|---|---|
+| `AgentConfig` only (current) | Permissions and hooks document intent but are not structurally bound. A config claiming "deny network access" with no gate behind it is indistinguishable from one that says nothing. Principle #3 violation. |
+| Free-form policy documents (YAML/JSON with no code binding) | Human-readable but not machine-verifiable. An auditor cannot confirm enforcement without reading implementation source. Same gap as AgentConfig. |
+| Charter without ratification hash | Charters without a hash can be silently modified after signatories approve them. Signatories become accountable for content they did not review. Tamper detection is lost. |
+| Advisory constraints (soft vs. hard tier within charter) | Advisory constraints are ignored in practice and have no enforcement value. If a constraint does not need code enforcement, it belongs in documentation, not the charter. prior research reached the same conclusion. |
+| Multiple active charters per agent | Introduces ambiguity about which charter governs a given tool call. Policy resolution (ADR-0052) cannot resolve conflicts between two simultaneously active charters scoped to the same agent. |
+
+## References
+
+- [ADR-0041](ADR-0041-immutable-evidence-nodes.md) — SHA-256 hash-chain pattern; charter hash follows the same construction
+- [ADR-0042](ADR-0042-task-certificate.md) — Task Certificate records the active charter version as part of the proof artifact
+- [ADR-0044](ADR-0044-tool-gates.md) — ToolGate registry; charter `gate_id` references resolve against this registry
+- [ADR-0046](ADR-0046-jit-tool-grant.md) — JIT grant gates appear as `gate_id` references in charter constraints
+- [ADR-0048](ADR-0048-agent-segregation-of-duties.md) — SoD constraints (no self-approval) are declared as charter constraints
+- [ADR-0050](ADR-0050-operation-context.md) — Operation Context captures active charter version; evidence nodes carry charter provenance
+- [ADR-0051](ADR-0051-tool-registry-allowlists.md) — Charter `allowed_tools` is the governance source for the tool registry allowlist
+- [ADR-0052](ADR-0052-policy-resolution.md) — `policy_release_version` binds the charter to a specific policy bundle
+- [ADR-0033](ADR-0033-unified-entity-state-model.md) — EvidenceRef; charter version is embedded in evidence metadata
+- `lionagi/agent/config.py` — `AgentConfig`; charter augments rather than replaces this
+- `lionagi/agent/hooks.py` — built-in hooks (`guard_destructive`, `guard_paths`, `log_tool_use`) referenced as `hook_name` values
+- prior governance research `01_design/025-charter/ADR-025-charter.md` — source pattern (constraints must have enforcement binding, ratification hash, single active per tenant)

--- a/docs/adrs/ADR-0048-agent-segregation-of-duties.md
+++ b/docs/adrs/ADR-0048-agent-segregation-of-duties.md
@@ -1,0 +1,790 @@
+# ADR-0048: Agent Segregation of Duties (SoD)
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Depends on**: [ADR-0047](ADR-0047-agent-charter.md) (SoD rules are charter constraints; charter enforces them at role-assignment time), [ADR-0046](ADR-0046-jit-tool-grant.md) (JIT grant issuer and consumer must be distinct actors), [ADR-0044](ADR-0044-tool-gates.md) (SoD enforcement surfaces as a HARD gate on role assignment), [ADR-0042](ADR-0042-task-certificate.md) (certificates require multi-actor attestation; SoD ensures those actors are genuinely distinct)
+**Related**: [ADR-0041](ADR-0041-immutable-evidence-nodes.md) (exemption evidence is an immutable node), [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) (branch.verify claims cannot use self-produced evidence), [ADR-0033](ADR-0033-unified-entity-state-model.md) (EvidenceRef carries actor_id for independence checks)
+
+## Context
+
+lionagi's multi-agent orchestration — `Session.flow()`, `li o fanout`, `li o flow` — assembles
+pipelines of Branch actors. The framework assigns roles (implementer, reviewer, approver, auditor)
+to branches at flow construction time. Today there is no mechanism that prevents the same branch
+from holding roles that are structurally incompatible. A flow that creates an "implementer" step
+and a "reviewer" step can assign both to `branch_a` with no warning. The branch reviews its own
+output. The review passes. The task certificate records attestation by two roles — but both
+attestations came from the same actor.
+
+This is the central problem that Segregation of Duties (SoD) addresses. The cross-cutting
+principle **"Every constraint must be enforced, not just documented"** is the direct motivation:
+governance policies that require a reviewer to be independent of the author are common and
+intuitive, but without runtime enforcement they are aspirational text. An autonomous LLM-driven
+workflow does not read the policy document. It reads the code.
+
+The consequence is not hypothetical. In a ReAct loop with a write step and a verify step, if both
+steps run in the same branch, the branch is evaluating evidence it produced. In a multi-step
+approval chain where the same branch holds two approval roles, a single compromise or error
+propagates through both approvals. These failure modes are not caught by ADR-0044 gate checks
+(which guard tool use, not role occupancy) or by ADR-0042 certificate multi-attestation (which
+counts role signatures, not actor distinctness).
+
+### The applicable prior governance research insight
+
+prior research introduced SoD as a *data-driven gate at grant time* for human role assignments
+in SOX-governed finance workflows: the same person cannot initiate and approve a wire transfer;
+cannot modify a ledger and audit it; cannot grant privileged access and use it. The lion
+translation replaces "person" with "branch actor" (identified by `ln_id`, not by model name),
+"role grant" with "role assignment in a flow step", and "CFO approval" with "external attestation
+by a human or a distinct designated authority agent". The five conflict types carry over verbatim
+because they are structural — they describe the shape of the bypass, not the domain in which
+it occurs.
+
+### Why lionagi needs this
+
+Consider a governed code-review flow: `session.flow()` constructs three steps — write, review,
+merge. An orchestrator under load reuses `branch_a` for both write and review because it is
+available and capable. Without SoD enforcement, `branch_a` submits code and then approves it.
+The `TaskCertificate` records a "reviewer" attestation, which is technically true. The evidence
+chain is intact. The audit trail looks clean. But the independence property that makes review
+meaningful is absent. With SoD enforcement, the role assignment of `branch_a` to "reviewer" is
+rejected at flow construction time — before any code is written — with a structured error naming
+the conflict type (`TRANSACTION_DUAL_CONTROL`) and the existing role (`implementer`). The
+orchestrator must select a different branch for the reviewer step, or fail closed.
+
+## Decision
+
+We introduce a `SoDPolicy` schema and a `assert_sod_independence` function that checks role
+assignments against a versioned conflict matrix at assignment time, rejects conflicting
+assignments with structured errors, and emits evidence when an exemption is in effect.
+
+### 1. Conflict taxonomy
+
+Five conflict types are defined, translated from prior research to agent terms:
+
+| Conflict Type | Agent description | Canonical example |
+|---|---|---|
+| `TRANSACTION_DUAL_CONTROL` | Same actor both initiates and approves a state-changing action | branch writes code; branch reviews it |
+| `RECORD_CUSTODY` | Same actor both creates evidence and audits it | branch produces artifacts; branch audits the artifact trail |
+| `AUDIT_INDEPENDENCE` | An actor's own outputs cannot be sole verification evidence | branch.verify() using only evidence from the same branch |
+| `APPROVAL_CHAIN` | Same actor appears more than once in an approval chain | branch is both L1 and L2 approver in a multi-step sign-off |
+| `ACCESS_CONTROL` | Same actor both grants tool access and uses the granted tool | branch issues a JIT grant (ADR-0046) and then exercises it |
+
+### 2. Schema
+
+```python
+from __future__ import annotations
+
+from enum import Enum
+from typing import Literal
+
+from pydantic import ConfigDict, Field
+
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+
+
+Scope = Literal["session", "task", "global"]
+
+FROZEN_ELEMENT_CONFIG = ConfigDict(
+    arbitrary_types_allowed=True,
+    use_enum_values=True,
+    populate_by_name=True,
+    extra="forbid",
+    frozen=True,
+)
+
+
+class ConflictType(str, Enum):
+    TRANSACTION_DUAL_CONTROL = "transaction_dual_control"
+    RECORD_CUSTODY            = "record_custody"
+    AUDIT_INDEPENDENCE        = "audit_independence"
+    APPROVAL_CHAIN            = "approval_chain"
+    ACCESS_CONTROL            = "access_control"
+
+
+class SoDDuty(Element):
+    """A duty label that can be referenced by role and rule records."""
+
+    model_config = FROZEN_ELEMENT_CONFIG
+
+    label: str
+    description: str | None = None
+
+
+class SoDRole(Element):
+    """A role label plus its governed duty set."""
+
+    model_config = FROZEN_ELEMENT_CONFIG
+
+    label: str
+    duties: Pile[SoDDuty] = Field(
+        default_factory=lambda: Pile(item_type=SoDDuty, strict_type=True)
+    )
+
+
+class SoDRule(Element):
+    """One conflict pair within a policy.
+
+    Both ``role_a`` and ``role_b`` are role labels as used in flow step
+    definitions (e.g., "implementer", "reviewer", "approver", "auditor").
+    The pair is bidirectional: (A, B) implies (B, A) - checked by
+    ``assert_sod_independence`` via symmetric lookup.
+
+    ``scope`` controls how far the actor registry extends:
+    - "session" - conflict within a single Session object
+    - "task"    - conflict within a named task / flow run
+    - "global"  - conflict across all sessions on this node
+    """
+
+    model_config = FROZEN_ELEMENT_CONFIG
+
+    rule_id: str
+    conflict_type: ConflictType
+    role_a: str
+    role_b: str
+    scope: Scope
+
+    # Time-bounded exemption - requires external attestation, never self-issued.
+    exemption_until: float | None = None          # Unix timestamp; None = no active exemption
+    exemption_attestation: str | None = None      # Human or designated authority evidence ID
+
+
+class SoDPolicy(Element):
+    """Versioned set of SoD rules active for a session or flow.
+
+    ``policy_id`` is stable across versions; ``version`` increments on any
+    rule change.  The policy in effect at assignment time is recorded in the
+    rejection evidence and in the TaskCertificate (ADR-0042).
+    """
+
+    model_config = FROZEN_ELEMENT_CONFIG
+
+    policy_id: str
+    version: int
+    max_exemption_days: int = Field(default=365, ge=1, le=365)
+    roles: Pile[SoDRole] = Field(
+        default_factory=lambda: Pile(item_type=SoDRole, strict_type=True)
+    )
+    rules: Pile[SoDRule] = Field(
+        default_factory=lambda: Pile(item_type=SoDRule, strict_type=True)
+    )
+```
+
+### 3. Role registry
+
+The assignment side tracks which actor currently holds which roles:
+
+```python
+from __future__ import annotations
+
+import time
+
+from pydantic import ConfigDict, Field
+
+from lionagi.protocols.action.manager import ActionManager
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.log import DataLogger
+from lionagi.protocols.generic.pile import Pile
+from lionagi.protocols.messages.manager import MessageManager
+from lionagi.service.manager import iModelManager
+from lionagi.session.branch import Branch
+
+
+class RoleAssignment(Element):
+    """A single actor-to-role binding."""
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    actor_id: str   # Branch.id / ln_id - NOT model name; see §6 for multi-LLM note
+    role: str
+    scope: Scope
+    assigned_at: float = Field(default_factory=time.time)
+
+    @classmethod
+    def from_branch(cls, branch: Branch, role: str, scope: Scope) -> "RoleAssignment":
+        """Bind a Branch actor while recording its active manager context."""
+        return cls(
+            actor_id=str(branch.id),
+            role=role,
+            scope=scope,
+            metadata=_branch_manager_metadata(branch),
+        )
+
+
+class SoDCheckEvidence(Element):
+    """First-class evidence for pass, denial, or exemption use."""
+
+    model_config = FROZEN_ELEMENT_CONFIG
+
+    actor_id: str
+    requested_role: str
+    scope: Scope
+    policy_id: str
+    policy_version: int
+    passed: bool
+    rule_id: str | None = None
+    conflict_type: ConflictType | None = None
+    conflicting_role: str | None = None
+    exemption_attestation: str | None = None
+    manager_snapshot: dict[str, object] = Field(default_factory=dict)
+
+
+class SoDRegistry(Element):
+    """Mutable registry of active role assignments for a scope.
+
+    Populated at flow construction time.  ``assert_sod_independence``
+    reads from this registry before writing to it.
+    """
+
+    assignments: Pile[RoleAssignment] = Field(
+        default_factory=lambda: Pile(item_type=RoleAssignment, strict_type=True)
+    )
+    evidence: Pile[SoDCheckEvidence] = Field(
+        default_factory=lambda: Pile(item_type=SoDCheckEvidence, strict_type=True)
+    )
+
+    def roles_for(self, actor_id: str, scope: str) -> list[str]:
+        return [
+            a.role
+            for a in self.assignments
+            if a.actor_id == actor_id and a.scope == scope
+        ]
+
+    def register(self, assignment: RoleAssignment) -> None:
+        self.assignments.include(assignment)
+
+    def register_branch(self, branch: Branch, role: str, scope: Scope) -> RoleAssignment:
+        assignment = RoleAssignment.from_branch(branch, role=role, scope=scope)
+        self.register(assignment)
+        return assignment
+
+
+def _branch_manager_metadata(branch: Branch | None) -> dict[str, object]:
+    """Capture the existing Branch manager surfaces used by SoD."""
+    if branch is None:
+        return {}
+
+    message_manager: MessageManager = branch.msgs
+    action_manager: ActionManager = branch.acts
+    imodel_manager: iModelManager = branch.mdls
+    log_manager: DataLogger = branch._log_manager
+
+    return {
+        "message_count": len(message_manager.messages),
+        "registered_tools": sorted(action_manager.registry.keys()),
+        "chat_model": getattr(imodel_manager.chat, "model", None),
+        "parse_model": getattr(imodel_manager.parse, "model", None),
+        "log_count": len(log_manager.logs),
+    }
+```
+
+### 4. Runtime check
+
+`assert_sod_independence` is called at every role assignment — concretely, at the point where
+`Session.flow()` (or `li o flow`) binds a branch to a step. It returns the assignment on success,
+raises `SoDConflictError` on conflict, and emits an exemption evidence reference if an exemption
+is active.
+
+```python
+from __future__ import annotations
+
+import time
+
+from collections.abc import Awaitable, Callable
+
+from lionagi.agent.config import AgentConfig
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.log import DataLogger
+from lionagi.session.branch import Branch
+
+
+class SoDConflict(Element):
+    """Element record for a denied role assignment."""
+
+    model_config = FROZEN_ELEMENT_CONFIG
+
+    actor_id: str
+    requested_role: str
+    conflicting_role: str
+    conflict_type: ConflictType
+    rule_id: str
+    policy_id: str
+    policy_version: int
+
+
+class SoDConflictError(Exception):
+    """Raised when a role assignment would violate an active SoD rule."""
+
+    def __init__(self, conflict: SoDConflict):
+        self.conflict = conflict
+        super().__init__(str(self))
+
+    def __str__(self) -> str:
+        conflict = self.conflict
+        return (
+            f"SoD conflict [{conflict.rule_id}]: actor '{conflict.actor_id}' already holds "
+            f"role '{conflict.conflicting_role}'; cannot assign '{conflict.requested_role}' "
+            f"({conflict.conflict_type.value}) - policy {conflict.policy_id} "
+            f"v{conflict.policy_version}"
+        )
+
+
+def assert_sod_independence(
+    actor_id: str,
+    requested_role: str,
+    scope: str,
+    registry: SoDRegistry,
+    policy: SoDPolicy | None,
+    branch: Branch | None = None,
+) -> RoleAssignment:
+    """Check and register a role assignment against the active SoD policy.
+
+    Raises ``SoDConflictError`` if a conflict is found and no valid exemption
+    is in effect.  Returns the new ``RoleAssignment`` on success and registers
+    it in ``registry``.
+
+    Fail-closed: if ``policy`` has no rules (empty Pile), the assignment
+    proceeds - an empty policy is a deliberate choice, not an absent matrix.
+    If ``policy`` itself is ``None``, assignment is denied.
+    """
+
+    if policy is None:
+        raise PermissionError("SoD assignment denied: no active SoDPolicy")
+
+    now = time.time()
+    effective_actor_id = str(branch.id) if branch is not None else actor_id
+    held_roles = registry.roles_for(effective_actor_id, scope)
+
+    for rule in policy.rules:
+        # Bidirectional check
+        if rule.scope != scope:
+            continue
+        pairs = {(rule.role_a, rule.role_b), (rule.role_b, rule.role_a)}
+        for held in held_roles:
+            if (held, requested_role) in pairs:
+                if _is_active_exemption(rule, now):
+                    # Exemption active - proceed but emit evidence reference.
+                    _emit_exemption_evidence(
+                        actor_id=effective_actor_id,
+                        rule=rule,
+                        policy=policy,
+                        registry=registry,
+                        branch=branch,
+                        requested_role=requested_role,
+                        conflicting_role=held,
+                    )
+                    break  # exemption covers this conflict; continue to next rule
+
+                conflict = SoDConflict(
+                    actor_id=effective_actor_id,
+                    requested_role=requested_role,
+                    conflicting_role=held,
+                    conflict_type=rule.conflict_type,
+                    rule_id=rule.rule_id,
+                    policy_id=policy.policy_id,
+                    policy_version=policy.version,
+                )
+                evidence = SoDCheckEvidence(
+                    actor_id=effective_actor_id,
+                    requested_role=requested_role,
+                    scope=scope,
+                    policy_id=policy.policy_id,
+                    policy_version=policy.version,
+                    passed=False,
+                    rule_id=rule.rule_id,
+                    conflict_type=rule.conflict_type,
+                    conflicting_role=held,
+                    manager_snapshot=_branch_manager_metadata(branch),
+                )
+                registry.evidence.include(evidence)
+                _record_sod_evidence(branch, evidence)
+                raise SoDConflictError(conflict)
+
+    assignment = (
+        RoleAssignment.from_branch(branch, requested_role, scope)
+        if branch is not None
+        else RoleAssignment(actor_id=effective_actor_id, role=requested_role, scope=scope)
+    )
+    registry.register(assignment)
+
+    evidence = SoDCheckEvidence(
+        actor_id=effective_actor_id,
+        requested_role=requested_role,
+        scope=scope,
+        policy_id=policy.policy_id,
+        policy_version=policy.version,
+        passed=True,
+        manager_snapshot=_branch_manager_metadata(branch),
+    )
+    registry.evidence.include(evidence)
+    _record_sod_evidence(branch, evidence)
+    return assignment
+
+
+def _is_active_exemption(rule: SoDRule, now: float) -> bool:
+    return (
+        rule.exemption_until is not None
+        and rule.exemption_until > now
+        and rule.exemption_attestation is not None
+    )
+
+
+def _emit_exemption_evidence(
+    *,
+    actor_id: str,
+    rule: SoDRule,
+    policy: SoDPolicy,
+    registry: SoDRegistry,
+    branch: Branch | None,
+    requested_role: str,
+    conflicting_role: str,
+) -> SoDCheckEvidence:
+    """Emit an immutable evidence node recording the exemption.
+
+    Implementation writes an EvidenceRef (ADR-0033) of kind
+    ``human_assertion`` referencing ``rule.exemption_attestation``.
+    The evidence node captures: actor_id, rule_id, policy version,
+    exemption_until, and the exemption attestation ID.  This node
+    becomes part of the TaskCertificate evidence chain (ADR-0042).
+
+    Full implementation lives in lionagi/agent/governance/sod.py.
+    The signature is the contract; the evidence schema is EvidenceRef from
+    ADR-0033.
+    """
+    evidence = SoDCheckEvidence(
+        actor_id=actor_id,
+        requested_role=requested_role,
+        scope=rule.scope,
+        policy_id=policy.policy_id,
+        policy_version=policy.version,
+        passed=True,
+        rule_id=rule.rule_id,
+        conflict_type=rule.conflict_type,
+        conflicting_role=conflicting_role,
+        exemption_attestation=rule.exemption_attestation,
+        manager_snapshot=_branch_manager_metadata(branch),
+    )
+    registry.evidence.include(evidence)
+    _record_sod_evidence(branch, evidence)
+    return evidence
+
+
+def _record_sod_evidence(branch: Branch | None, evidence: SoDCheckEvidence) -> None:
+    if branch is None:
+        return
+    log_manager: DataLogger = branch._log_manager
+    log_manager.log(evidence)
+
+
+def sod_assignment_pre_hook(
+    registry: SoDRegistry,
+    policy: SoDPolicy,
+) -> Callable[[str, str, dict], Awaitable[dict | None]]:
+    """Existing AgentConfig/Tool pre-hook wrapper for role-assignment tools."""
+
+    async def _hook(tool_name: str, action: str, args: dict) -> dict | None:
+        if action != "assign_role" and tool_name != "assign_role":
+            return None
+
+        branch = args.get("branch")
+        if not isinstance(branch, Branch):
+            raise PermissionError("SoD assignment denied: missing Branch actor")
+
+        assignment = assert_sod_independence(
+            actor_id=str(branch.id),
+            requested_role=args["role"],
+            scope=args["scope"],
+            registry=registry,
+            policy=policy,
+            branch=branch,
+        )
+        args["sod_assignment_id"] = str(assignment.id)
+        return args
+
+    return _hook
+
+
+def install_sod_enforcement(
+    config: AgentConfig,
+    registry: SoDRegistry,
+    policy: SoDPolicy,
+) -> AgentConfig:
+    """Register SoD through lionagi's existing hook system, not a bespoke registry."""
+    config.pre("assign_role", sod_assignment_pre_hook(registry, policy))
+    return config
+```
+
+### 5. Worked example — code-review flow
+
+A three-step flow: `write → review → merge`.
+
+```text
+Step 1: assign(branch=branch_a, actor=branch_a.id, role="implementer", scope="task:pr-42")
+        -> _branch_manager_metadata captures branch_a.msgs, branch_a.acts,
+           branch_a.mdls, and branch_a._log_manager
+        -> held_roles(branch_a.id, "task:pr-42") = []
+        -> no conflict -> RoleAssignment registered in SoDRegistry.assignments
+        -> SoDCheckEvidence logged through DataLogger
+
+Step 2: assign(branch=branch_a, actor=branch_a.id, role="reviewer", scope="task:pr-42")
+        -> held_roles(branch_a.id, "task:pr-42") = ["implementer"]
+        -> rule SOD-001: (implementer, reviewer, TRANSACTION_DUAL_CONTROL)
+        -> no exemption active
+        -> SoDConflictError: actor 'branch_a' already holds 'implementer';
+           cannot assign 'reviewer' (transaction_dual_control)
+        -> denial evidence stored in SoDRegistry.evidence and logged through DataLogger
+
+        Orchestrator selects branch_b instead:
+        assign(branch=branch_b, actor=branch_b.id, role="reviewer", scope="task:pr-42")
+        -> held_roles(branch_b.id, "task:pr-42") = []
+        -> no conflict -> assignment registered and evidence logged
+
+Step 3: assign(branch=branch_c, actor=branch_c.id, role="merger", scope="task:pr-42")
+        -> no conflict rules for (implementer|reviewer, merger)
+        -> assignment registered and evidence logged
+```
+
+The TaskCertificate (ADR-0042) for this task records three distinct `actor_id` values for the
+three attesting roles. The SoD check result at step 2 is preserved in the immutable evidence
+chain (ADR-0041) as the rejection record.
+
+### 6. Self-attestation prevention (AUDIT_INDEPENDENCE)
+
+The `AUDIT_INDEPENDENCE` conflict type extends beyond flow role assignments to
+`branch.verify()` from ADR-0039. A verification claim whose `actor_id` is `X` cannot rely
+solely on evidence whose `actor_id` is also `X` within the same scope. This is the agent
+analogue of prior governance research's prohibition on a system administrator auditing their own changes.
+
+At `branch.verify()` call time:
+
+```python
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+
+
+def check_audit_independence(
+    verifier_actor_id: str,
+    evidence_refs: Pile[Element],
+    scope: str,
+    policy: SoDPolicy,
+    branch: Branch | None = None,
+    registry: SoDRegistry | None = None,
+) -> None:
+    """Raise SoDConflictError if all evidence is self-produced.
+
+    A verification is independent if at least one EvidenceRef was produced
+    by a different actor_id.  An empty evidence Pile fails closed - a claim
+    with no supporting evidence cannot be verified.
+    """
+    audit_rules = Pile(item_type=SoDRule, strict_type=True)
+    for rule in policy.rules:
+        if (
+            rule.conflict_type == ConflictType.AUDIT_INDEPENDENCE
+            and rule.scope == scope
+        ):
+            audit_rules.include(rule)
+
+    if audit_rules.is_empty():
+        return  # No audit independence rules; proceed
+
+    rule = audit_rules[0]
+
+    if evidence_refs.is_empty():
+        _raise_audit_independence_conflict(
+            verifier_actor_id=verifier_actor_id,
+            scope=scope,
+            policy=policy,
+            rule=rule,
+            branch=branch,
+            registry=registry,
+        )
+
+    independent = any(
+        (actor := _evidence_actor_id(ref)) is not None
+        and actor != verifier_actor_id
+        for ref in evidence_refs
+    )
+    if not independent:
+        _raise_audit_independence_conflict(
+            verifier_actor_id=verifier_actor_id,
+            scope=scope,
+            policy=policy,
+            rule=rule,
+            branch=branch,
+            registry=registry,
+        )
+
+    evidence = SoDCheckEvidence(
+        actor_id=verifier_actor_id,
+        requested_role="verifier",
+        scope=scope,
+        policy_id=policy.policy_id,
+        policy_version=policy.version,
+        passed=True,
+        rule_id=rule.rule_id,
+        conflict_type=ConflictType.AUDIT_INDEPENDENCE,
+        manager_snapshot=_branch_manager_metadata(branch),
+    )
+    if registry is not None:
+        registry.evidence.include(evidence)
+    _record_sod_evidence(branch, evidence)
+
+
+def _evidence_actor_id(ref: Element) -> str | None:
+    return getattr(ref, "actor_id", None) or ref.metadata.get("actor_id")
+
+
+def _raise_audit_independence_conflict(
+    *,
+    verifier_actor_id: str,
+    scope: str,
+    policy: SoDPolicy,
+    rule: SoDRule,
+    branch: Branch | None,
+    registry: SoDRegistry | None,
+) -> None:
+    conflict = SoDConflict(
+        actor_id=verifier_actor_id,
+        requested_role="verifier",
+        conflicting_role="sole_evidence_producer",
+        conflict_type=ConflictType.AUDIT_INDEPENDENCE,
+        rule_id=rule.rule_id,
+        policy_id=policy.policy_id,
+        policy_version=policy.version,
+    )
+    evidence = SoDCheckEvidence(
+        actor_id=verifier_actor_id,
+        requested_role="verifier",
+        scope=scope,
+        policy_id=policy.policy_id,
+        policy_version=policy.version,
+        passed=False,
+        rule_id=rule.rule_id,
+        conflict_type=ConflictType.AUDIT_INDEPENDENCE,
+        conflicting_role="sole_evidence_producer",
+        manager_snapshot=_branch_manager_metadata(branch),
+    )
+    if registry is not None:
+        registry.evidence.include(evidence)
+    _record_sod_evidence(branch, evidence)
+    raise SoDConflictError(conflict)
+```
+
+### 7. Exemptions
+
+An exemption is time-bounded, requires an external attestation ID (referencing a human decision
+record or a designated authority agent's evidence node), and is never self-issued. The
+constraints are:
+
+- `exemption_until` must be a future timestamp; past timestamps are treated as absent.
+- `exemption_attestation` must reference a non-null evidence ID from an actor other than the
+  actor seeking the exemption.
+- An agent cannot grant its own exemption. The `exemption_attestation` actor and the exempted
+  actor must differ — this is itself an `ACCESS_CONTROL` rule.
+- Every exemption use emits an immutable evidence node (ADR-0041) binding the exemption
+  attestation ID to the assignment record.
+
+No permanent exemptions. An exemption that exceeds the policy's `max_exemption_days` (default
+365; agent flows default 30) is rejected at SoDPolicy construction time, not at runtime.
+
+### 8. Multi-LLM actor identity
+
+Same model, different actors. Two branches both backed by `gpt-4o` are different actors if they
+have different `ln_id` values. SoD operates on `actor_id = branch.ln_id`, not on
+`model_id = branch.imodel.model`. This is intentional: the independence property is about
+decision authority, not computational substrate. A system that treats same-model branches as the
+same actor would break all practical multi-agent flows, since most orchestrators use a single
+capable model for all workers. The compromise vector that SoD addresses is a single *decision
+actor* controlling both sides of a dual-control gate — not two instances of the same model
+reaching independent conclusions.
+
+Conversely, two branches with different `ln_id` values but the same `ln_id` prefix (e.g.,
+cloned branches) are still distinct actors unless the flow explicitly aliases them. Aliasing is
+out of scope for this ADR.
+
+## Consequences
+
+**Positive**
+
+- Prevents self-approval in autonomous flows: the most critical single-actor bypass in
+  multi-agent governance is closed at role-assignment time, before any work begins.
+- Audit-grade independence: TaskCertificates (ADR-0042) that carry multi-role attestation now
+  guarantee the attesting actors were genuinely distinct at the time of assignment.
+- Early detection: orchestrators receive a structured `SoDConflictError` at flow construction,
+  not midway through execution, allowing recovery (substitute a different branch) rather than
+  rollback.
+- Evidence trail: every conflict check — pass or fail — produces a record that names the
+  policy version, rule ID, and actors involved. Exemptions produce immutable nodes.
+- Aligns with cross-cutting principle #3: SoD constraints are charter constraints
+  (ADR-0047) which become runtime gates (ADR-0044); the chain is now complete.
+
+**Negative**
+
+- Orchestration complexity: flows that previously reused one powerful branch for all steps
+  must now provision at minimum two branches for any dual-control workflow pair.
+- Minimum actor count: a flow with `N` mutually exclusive roles requires `N` distinct actors.
+  For flows with 4+ conflicting role pairs, this can force significant branch proliferation.
+- Policy maintenance burden: new roles added to a flow require conflict analysis against the
+  active policy before deployment. The conflict matrix is deliberately manual — no automatic
+  generation (see Non-Goals).
+- Exemption process friction: legitimate single-actor flows (e.g., a solo exploration session
+  not subject to audit requirements) require either a policy with no conflicting rules or an
+  attested exemption; there is no silent bypass.
+
+## Non-Goals
+
+Explicitly out of scope:
+
+- **Human SoD**: this ADR governs agent actors (`Branch` instances) only. Human users have
+  their own authentication and authorization layer; their SoD is a product-level concern, not
+  a lionagi framework concern.
+- **Cross-tenant SoD**: conflict enforcement across isolated KHive tenants is a KHive
+  architectural concern, not a lionagi open-source concern. Multi-tenant actor identity
+  resolution is future scope.
+- **Automatic conflict matrix generation**: the conflict matrix is authored by humans and
+  reviewed before activation. Automatic inference of conflicts from role capability overlap
+  is deliberately excluded — it would produce false positives and obscure the policy intent.
+- **Model-level isolation guarantees**: SoD does not assert that two branches backed by the
+  same LLM are computationally independent. It asserts only that they are organizationally
+  distinct actors with separate decision authority.
+- **Retroactive conflict detection**: the check runs at assignment time. Flows already running
+  are not interrupted by a new policy version; the policy in effect at assignment time governs
+  the run. Policy changes take effect on the next flow construction.
+- **Cross-session global conflict tracking at scale**: the "global" scope in `SoDRule` is
+  supported within a single lionagi node. Distributed global conflict tracking (across
+  horizontally scaled nodes) is out of scope and a KHive infrastructure concern.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|---|---|
+| Trust actor_id only, no role conflict check | Doesn't catch role-level conflicts. Two distinct actors can still form a self-approval loop if the same human controls both branches. Role conflicts are structural, not identity-based alone. |
+| Human-only SoD (out-of-band process) | Does not prevent autonomous self-approval in flows with no human in the loop. A governed flow with no human reviewer can still self-approve; the process rule has no enforcement point. |
+| SoD check at execution time (not assignment time) | Too late. The conflicting role assignment exists in the system; the branch has already begun work in both roles. Execution-time detection leaves the system in an inconsistent state that requires rollback rather than clean substitution. |
+| Static exclusion pairs hardcoded in flow runner | Inflexible and non-auditable. Adding a new conflict pair requires a code change and deployment. Cannot be versioned or superseded without a release. No exemption path for legitimate edge cases. |
+| No SoD (rely on operator discipline) | Rejected outright. Autonomous systems do not have discipline. Any governance property that depends on operators manually checking role assignments before every flow construction is not a governance property — it is a hope. |
+| OPA/Rego for SoD policy evaluation | Adds external infrastructure dependency for a check that is fundamentally a set-membership problem. OPA adds flexibility the conflict matrix does not need, at the cost of an operational component that must be kept available (fail-closed requirement from cross-cutting principle #1). |
+
+## References
+
+- [ADR-0047](ADR-0047-agent-charter.md) — SoD rules are charter constraints; charter is the
+  binding mechanism
+- [ADR-0046](ADR-0046-jit-tool-grant.md) — JIT grant issuer and consumer must satisfy
+  `ACCESS_CONTROL` SoD rule
+- [ADR-0044](ADR-0044-tool-gates.md) — role assignment is enforced as a HARD gate;
+  `SoDConflictError` maps to gate-denied
+- [ADR-0042](ADR-0042-task-certificate.md) — certificate multi-attestation is meaningful only
+  if attesting actors are SoD-independent
+- [ADR-0041](ADR-0041-immutable-evidence-nodes.md) — exemption use and conflict detection
+  produce immutable evidence nodes
+- [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) — `branch.verify()` AUDIT_INDEPENDENCE check
+- [ADR-0033](ADR-0033-unified-entity-state-model.md) — EvidenceRef carries `actor_id`; used
+  in `check_audit_independence`
+- prior governance research `01_design/032-segregation-of-duties/ADR-032-segregation-of-duties.md` — source
+  pattern (SOX Section 302/404 compliance, five conflict type taxonomy, exemption workflow)

--- a/docs/adrs/ADR-0049-log-tier-governance.md
+++ b/docs/adrs/ADR-0049-log-tier-governance.md
@@ -1,0 +1,522 @@
+# ADR-0049: Log Tier Governance
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Depends on**: [ADR-0041](ADR-0041-immutable-evidence-nodes.md), [ADR-0045](ADR-0045-break-glass-protocol.md)
+**Related**: [ADR-0042](ADR-0042-task-certificate.md), [ADR-0044](ADR-0044-tool-gates.md), [ADR-0046](ADR-0046-jit-tool-grant.md), [ADR-0047](ADR-0047-agent-charter.md), [ADR-0050](ADR-0050-operation-context.md)
+
+## Context
+
+`DataLogger` in lionagi today writes `Log` entries to JSONL, JSON, or CSV files with no tier
+distinction. Every entry — a `log.debug.*` timing trace, a `branch.add_message` event, an evidence
+emission — goes into the same flat `Pile[Log]`, subject to the same `dump()` and `clear()`
+operations. An agent that gains write access to its own session logs can erase the record of what
+it did. More subtly, a compromised agent or injected tool could call `DataLogger.dump(clear=True)`
+and silently discard the evidence of a gate decision or charter violation before the session ends.
+
+Cross-cutting principle #2 states: **evidence is first-class, not logs**. Evidence carries the
+policy version and gate results active at execution time ("active assertion"); operational logs are
+supporting context. But both flow through the same `DataLogger` today, and the substrate makes no
+distinction. This means the substrate that should protect governance-critical records is the same
+substrate that rotates debug traces. That conflation is the gap this ADR closes.
+
+The triggering scenario: an attacker model where an insider or compromised agent disables logging
+before acting. In lionagi this manifests as: (1) a tool call that invokes `DataLogger.dump(clear=True)`
+immediately before an unauthorized action, erasing the tool-invocation log; or (2) a session
+teardown that discards all in-memory logs before the evidence nodes from ADR-0041 are flushed to
+the backend. Without tier distinction, the application has no way to treat these two operations
+differently.
+
+### The applicable prior governance research insight
+
+prior research introduces a three-tier log hierarchy — MUTABLE / PROTECTED / IMMUTABLE — where
+each tier has distinct deletion semantics enforced at both the application layer and the database
+layer. The core insight is that "audit of auditing" closes the disable-logging attack vector: any
+deletion of a PROTECTED log must itself create an IMMUTABLE evidence node recording who deleted
+what and when. An attacker that disables logging cannot hide the act of disabling. In lionagi terms:
+the `DataLogger` becomes tier-aware, and the tier of a `Log` entry is set at creation time by the
+code path that emits it, not by post-hoc classification.
+
+### Why lionagi needs this
+
+Without tier governance, a test run, a debug session, and a gate decision all produce logs with
+identical tamperability. Consider: `branch.operate()` triggers a HARD gate (ADR-0044); the gate
+approves with an evidence emission (ADR-0041); the agent's tool then calls a file-deletion
+operation. That gate decision is the audit trail. If the same agent can call `DataLogger.clear()`,
+the gate decision disappears before it is persisted. With `LogTier.IMMUTABLE`, the `DataLogger`
+rejects any mutation of that entry — not by policy document, but by code path enforcement, which
+satisfies cross-cutting principle #3: every constraint must be enforced, not just documented.
+
+## Decision
+
+We introduce a `LogTier` enum and make `DataLogger` tier-aware: MUTABLE entries can be deleted
+freely, PROTECTED entries require a break-glass token per ADR-0045 and their deletion creates an
+IMMUTABLE evidence node, and IMMUTABLE entries have no deletion API.
+
+### 1. LogTier enum and Log extension
+
+```python
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import PrivateAttr
+
+from lionagi.models.hashable_model import HashableModel
+from lionagi.protocols.generic.element import Element
+from lionagi.utils import to_dict
+
+
+# lionagi/protocols/generic/log.py
+# Extend the existing module in place; add "LogTier" to __all__.
+
+
+class LogTier(str, Enum):
+    """Three-tier log governance hierarchy.
+
+    Tier assignment is set at creation time by the emitting code path.
+    Default is MUTABLE; higher tiers require explicit opt-in.
+
+    MUTABLE:   debug, performance, ephemeral traces. Freely rotated.
+    PROTECTED: session activity, tool calls, status transitions, errors.
+               Deletion requires break-glass (ADR-0045); deletion itself
+               creates an IMMUTABLE evidence node.
+    IMMUTABLE: evidence emissions (ADR-0041), task certificate state changes
+               (ADR-0042), gate decisions (ADR-0044), break-glass attestations
+               (ADR-0045), permit issuance/consumption (ADR-0046), charter
+               activations (ADR-0047), operation context captures (ADR-0050).
+               No deletion API exists. Write-once at the application layer;
+               DB-level triggers in KHive backend.
+    """
+
+    MUTABLE = "mutable"
+    PROTECTED = "protected"
+    IMMUTABLE = "immutable"
+
+
+class Log(Element):
+    """Existing Log entry, extended in place with explicit tier governance.
+
+    The `tier` field defaults to MUTABLE. Emitters that produce
+    governance-critical records must set tier explicitly:
+
+        Log.create(content, tier=LogTier.IMMUTABLE)
+
+    Once a Log with tier=IMMUTABLE is created, no mutation is permitted.
+    Once a Log with tier=PROTECTED is created, deletion requires a
+    break-glass token from ADR-0045.
+    """
+
+    content: dict[str, Any]
+    tier: LogTier = LogTier.MUTABLE
+    _immutable: bool = PrivateAttr(False)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Reuse the existing PrivateAttr immutability mechanism."""
+        if getattr(self, "_immutable", False):
+            raise AttributeError("This Log is immutable.")
+        super().__setattr__(name, value)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Log":
+        """Restore a Log and preserve the existing read-only restore behavior."""
+        self = cls.model_validate(data)
+        self._immutable = True
+        return self
+
+    @classmethod
+    def create(
+        cls,
+        content: "Element | dict[str, Any]",
+        tier: LogTier = LogTier.MUTABLE,
+    ) -> "Log":
+        """Create a Log entry with an explicit tier.
+
+        Args:
+            content: The payload. Element instances are serialized via
+                     ``to_dict(mode='json')``.
+            tier:    Governance tier. Defaults to MUTABLE; callers emitting
+                     evidence, certificates, or gate decisions must pass
+                     tier=LogTier.IMMUTABLE explicitly.
+        """
+        if isinstance(content, Element | HashableModel):
+            payload = content.to_dict(mode="json")
+        else:
+            payload = to_dict(content, recursive=True, suppress=True)
+
+        if not payload:
+            payload = {"error": "No content to log."}
+
+        log = cls(content=payload, tier=tier)
+        if tier == LogTier.IMMUTABLE:
+            log._immutable = True
+        return log
+```
+
+### 2. Tier-aware DataLogger operations
+
+```python
+from __future__ import annotations
+
+import atexit
+import json
+import logging
+from pathlib import Path
+from hashlib import sha256
+from typing import Any
+from uuid import UUID
+
+from pydantic import Field
+
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+
+from .log import DataLoggerConfig, Log, LogTier
+
+_log = logging.getLogger(__name__)
+
+
+class ProtectedLogDeletion(Element):
+    """Governance metadata emitted as an IMMUTABLE Log via DataLogger."""
+
+    deleted_log_id: str
+    deleted_log_tier: LogTier = Field(default=LogTier.PROTECTED)
+    break_glass_token_id: str
+    actor: str
+    reason: str
+    deleted_content_hash: str
+
+
+class DataLogger:
+    """Existing DataLogger, extended in place as the tier-aware log manager.
+
+    Three entry points for deletion, each enforcing a different tier contract:
+
+    - ``delete_log(log_id)`` - MUTABLE only; raises for higher tiers.
+    - ``delete_protected_logs(log_ids, ...)`` - PROTECTED only; requires break-glass.
+    - There is no ``delete_immutable_log``. The method does not exist.
+
+    ``dump()`` writes IMMUTABLE entries to a separate file (``*_immutable.*``)
+    that the KHive backend opens in append-only mode. MUTABLE and PROTECTED
+    entries go to the standard file.
+    """
+
+    def __init__(
+        self,
+        *,
+        logs: Any = None,
+        _config: DataLoggerConfig = None,
+        **kwargs,
+    ):
+        if _config is None:
+            _config = DataLoggerConfig(**kwargs)
+
+        if isinstance(logs, dict):
+            self.logs = Pile.from_dict(logs)
+        else:
+            self.logs = Pile(collections=logs, item_type=Log, strict_type=True)
+        self._config = _config
+
+        if self._config.auto_save_on_exit:
+            atexit.register(self.save_at_exit)
+
+    def log(self, log_: Any, *, tier: LogTier = LogTier.MUTABLE) -> None:
+        """Add a log synchronously, preserving DataLogger as the integration point."""
+        log_ = Log.create(log_, tier=tier) if not isinstance(log_, Log) else log_
+        if self._config.capacity and len(self.logs) >= self._config.capacity:
+            self.dump(clear=self._config.clear_after_dump)
+        self.logs.include(log_)
+
+    async def alog(self, log_: Any, *, tier: LogTier = LogTier.MUTABLE) -> None:
+        """Add a log asynchronously."""
+        async with self.logs:
+            self.log(log_, tier=tier)
+
+    def delete_log(self, log_id: str | UUID) -> None:
+        """Delete a MUTABLE log entry by ID.
+
+        Raises:
+            PermissionError: If the entry is PROTECTED or IMMUTABLE.
+            KeyError:        If no entry with ``log_id`` exists.
+        """
+        entry: Log = self.logs[log_id]  # raises KeyError if absent
+        if entry.tier == LogTier.PROTECTED:
+            raise PermissionError(
+                f"Log {log_id} has tier=PROTECTED. "
+                "Use delete_protected_logs() with a valid break-glass token (ADR-0045)."
+            )
+        if entry.tier == LogTier.IMMUTABLE:
+            raise PermissionError(
+                f"Log {log_id} has tier=IMMUTABLE. "
+                "Deletion is not permitted. No API exists for IMMUTABLE deletion."
+            )
+        self.logs.pop(entry.id)
+
+    def delete_protected_logs(
+        self,
+        log_ids: str | UUID | list[str | UUID],
+        break_glass_token: str,
+        reason: str,
+    ) -> None:
+        """Delete PROTECTED log entries under break-glass authorization.
+
+        The act of deletion itself creates an IMMUTABLE evidence node
+        ("audit of auditing"). An attacker that deletes a PROTECTED log
+        cannot hide that the deletion occurred.
+
+        Args:
+            log_ids:           ID or IDs of the PROTECTED logs to delete.
+            break_glass_token: Valid token issued by ADR-0045 protocol.
+            reason:            Human-readable justification, recorded
+                               in the IMMUTABLE evidence node.
+
+        Raises:
+            PermissionError: If entry is MUTABLE (use delete_log) or
+                             IMMUTABLE (no deletion permitted), or if
+                             break_glass_token fails validation.
+            KeyError:        If no entry with ``log_id`` exists.
+        """
+        from lionagi.protocols.governance.break_glass import validate_break_glass_token
+
+        # Validate break-glass token — raises if invalid (ADR-0045)
+        attestation = validate_break_glass_token(break_glass_token)
+        ids = log_ids if isinstance(log_ids, list) else [log_ids]
+
+        for log_id in ids:
+            entry: Log = self.logs[log_id]
+            if entry.tier == LogTier.MUTABLE:
+                raise PermissionError(
+                    f"Log {log_id} has tier=MUTABLE. Use delete_log() instead."
+                )
+            if entry.tier == LogTier.IMMUTABLE:
+                raise PermissionError(
+                    f"Log {log_id} has tier=IMMUTABLE. Deletion is not permitted."
+                )
+
+            # Create IMMUTABLE evidence BEFORE deleting. If this emission fails,
+            # deletion aborts (fail-closed, principle #1).
+            deletion_record = ProtectedLogDeletion(
+                deleted_log_id=str(entry.id),
+                deleted_log_tier=entry.tier,
+                break_glass_token_id=attestation.token_id,
+                actor=attestation.actor,
+                reason=reason,
+                deleted_content_hash=_hash_content(entry.content),
+            )
+            deletion_evidence = Log.create(
+                content=deletion_record,
+                tier=LogTier.IMMUTABLE,
+            )
+            self.logs.include(deletion_evidence)
+
+            self.logs.pop(entry.id)
+            _log.warning(
+                "PROTECTED log %s deleted by %s under break-glass %s. "
+                "Evidence node %s created.",
+                entry.id,
+                attestation.actor,
+                attestation.token_id,
+                deletion_evidence.id,
+            )
+
+    def delete_protected_log(
+        self,
+        log_id: str | UUID,
+        break_glass_token: str,
+        reason: str,
+    ) -> None:
+        """Backward-compatible singular wrapper for one protected log."""
+        self.delete_protected_logs(
+            log_id,
+            break_glass_token=break_glass_token,
+            reason=reason,
+        )
+
+    def dump(
+        self,
+        clear: bool | None = None,
+        persist_path: str | Path | None = None,
+    ) -> None:
+        """Dump logs to file(s), routing IMMUTABLE entries to a separate file.
+
+        MUTABLE and PROTECTED entries go to the standard path.
+        IMMUTABLE entries go to ``<stem>_immutable<ext>`` in append mode.
+        The KHive backend opens that file append-only via DB triggers.
+
+        IMMUTABLE entries are never cleared after dump.
+        """
+        if not self.logs:
+            _log.debug("No logs to dump.")
+            return
+
+        fp = Path(persist_path) if persist_path else self._create_path()
+        suffix = fp.suffix.lower()
+        if suffix not in {".csv", ".json", ".jsonl"}:
+            raise ValueError(f"Unsupported file extension: {suffix}")
+
+        obj_key = "csv" if suffix == ".csv" else "json"
+        immutable_fp = fp.with_stem(fp.stem + "_immutable")
+
+        mutable_entries: Pile[Log] = Pile(
+            collections=[e for e in self.logs if e.tier == LogTier.MUTABLE],
+            item_type=Log,
+            strict_type=True,
+        )
+        mutable_protected: Pile[Log] = Pile(
+            collections=[e for e in self.logs if e.tier != LogTier.IMMUTABLE],
+            item_type=Log,
+            strict_type=True,
+        )
+        immutable_entries: Pile[Log] = Pile(
+            collections=[e for e in self.logs if e.tier == LogTier.IMMUTABLE],
+            item_type=Log,
+            strict_type=True,
+        )
+
+        # Implementation delegates to existing Pile.dump() per-subset.
+        # IMMUTABLE entries are always appended to the immutable partition.
+        if mutable_protected:
+            mutable_protected.dump(fp, obj_key)
+        if immutable_entries:
+            immutable_entries.dump(immutable_fp, obj_key, mode="a")
+
+        do_clear = self._config.clear_after_dump if clear is None else clear
+        if do_clear:
+            # dump(clear=True) may rotate MUTABLE logs only. PROTECTED deletion
+            # must pass through delete_protected_logs(); IMMUTABLE has no path.
+            self.logs.exclude([entry.id for entry in mutable_entries])
+
+
+def _hash_content(content: dict[str, Any]) -> str:
+    payload = json.dumps(
+        content,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode()
+    return sha256(payload).hexdigest()
+```
+
+### 3. Tier assignment policy
+
+The following table is the authoritative policy. Code emitting events in these categories
+**must** set the corresponding tier. The `tier=` argument on `Log.create()` is the enforcement
+point; there is no automatic classification.
+
+| Event category | Tier | Examples |
+|---|---|---|
+| `log.debug.*`, raw stdin/stdout traces, perf timing | MUTABLE | `log.debug("token count=42")`, request latency |
+| `branch.add_message()` calls | PROTECTED | Every message added to a Branch |
+| Tool invocations (ActionRequest + ActionResponse) | PROTECTED | All `tool_call` events |
+| Status transitions, errors | PROTECTED | `status=failed`, exception captures |
+| Evidence emissions (ADR-0041) | IMMUTABLE | `EvidenceNode` creation events |
+| Task certificate state changes (ADR-0042) | IMMUTABLE | `TaskCertificate` issue / revoke |
+| Gate decisions (ADR-0044) | IMMUTABLE | HARD/SOFT gate ALLOW or DENY |
+| Break-glass attestations (ADR-0045) | IMMUTABLE | Token issuance and consumption |
+| Permit issuance/consumption (ADR-0046) | IMMUTABLE | JIT grant created or expired |
+| Charter activations (ADR-0047) | IMMUTABLE | Charter bound to agent at init |
+| Operation context captures (ADR-0050) | IMMUTABLE | Active-assertion snapshots |
+
+### 4. The "audit of auditing" invariant
+
+The core tamper-resistance property is:
+
+> An agent that deletes a PROTECTED log cannot hide the act of deletion.
+
+This is enforced structurally: `delete_protected_log()` creates the IMMUTABLE evidence node
+*before* removing the entry. If the evidence emission raises (e.g., the backend is unavailable),
+the deletion is aborted. This is the fail-closed default (cross-cutting principle #1): an error in
+the audit trail blocks the operation that would create a gap in it.
+
+IMMUTABLE entries have no deletion path — not even with break-glass. There is no
+`delete_immutable_log()` method. Absence of API is the strongest enforcement: no administrative
+shortcut, no emergency override, no code path to misuse.
+
+### 5. Backend integration (KHive v1)
+
+At the application layer (lionagi), `DataLogger` enforces tier semantics in Python. In the KHive
+backend, the persistence layer adds complementary DB-level triggers following prior research:
+
+- A `BEFORE DELETE` trigger on the IMMUTABLE log table raises an exception unconditionally.
+- The `*_immutable.*` files written by `DataLogger.dump()` are opened in append-only mode by the
+  KHive ingestion worker.
+- PROTECTED log deletion events are written to the immutable table by the ingestion worker,
+  providing a second enforcement layer independent of application code.
+
+These backend constraints are KHive territory and are out of scope for this ADR. The application-
+layer enforcement described in sections 2–4 is fully self-contained for lionagi v1.
+
+## Consequences
+
+**Positive**
+
+- Tamper resistance at the application layer: a compromised agent or tool cannot erase gate
+  decisions, evidence nodes, or charter activations via normal `DataLogger` operations.
+- Audit-grade tier separation: operators can identify exactly which log entries constitute the
+  governance record without scanning all entries.
+- "Audit of auditing" closes the disable-logging attack vector: any PROTECTED log deletion
+  produces its own permanent record.
+- The three-tier model maps cleanly onto the existing `Log` + `DataLogger` design; no new
+  architectural surface is required.
+
+**Negative**
+
+- IMMUTABLE entries accumulate indefinitely in the Pile and in the `*_immutable.*` files.
+  Long-running sessions must tolerate unbounded growth in the immutable partition. Archival to
+  cold storage is a KHive concern; lionagi has no automatic eviction.
+- Every `Log.create()` call that should emit at PROTECTED or IMMUTABLE tier requires an explicit
+  `tier=` argument. Callers that omit it silently default to MUTABLE — a regression risk during
+  migration.
+- `delete_protected_log()` depends on `lionagi.protocols.governance.break_glass` (ADR-0045),
+  which is a sibling ADR not yet shipped. Until ADR-0045 is implemented, PROTECTED deletion raises
+  an `ImportError` at runtime.
+- Slight CPU cost: `__setattr__` on IMMUTABLE entries checks tier on every attribute write. In
+  practice this is negligible; it only fires during Pydantic model initialization.
+
+## Non-Goals
+
+Explicitly out of scope:
+
+- **Cryptographic signing of log entries.** Hash-chain integrity for evidence nodes is covered by
+  ADR-0041. Log-level signing is a separate concern.
+- **Log encryption at rest.** Encryption is a deployment and KHive backend concern, not a
+  per-entry feature of `DataLogger`.
+- **Distributed log replication.** Replication, WAL-based propagation, and multi-replica
+  consistency are KHive infrastructure concerns.
+- **Automatic tier classification.** Tier is always set explicitly at the call site. No heuristic,
+  ML-based, or pattern-matching classifier determines tier post-hoc.
+- **Multi-tenant log isolation.** Per-tenant log namespacing, row-level security, and tenant-scoped
+  deletion policies are KHive territory. lionagi is a single-tenant library.
+- **Retention schedules and archival.** ADR-0049 defines deletion semantics, not retention periods.
+  Archival policy (e.g., 7-year PROTECTED retention per SOC2 CC6.2) is a deployment concern.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|---|---|
+| Single mutable log (current state) | Any agent with DataLogger access can erase its own activity record. No tamper resistance. |
+| Append-only flag on DataLogger | Too coarse: prevents all deletion including legitimate MUTABLE rotation. Breaks long-running session memory management. |
+| Separate file per tier only | Files can still be deleted by OS-level access. Doesn't prevent `DataLogger.clear()` from discarding in-memory IMMUTABLE entries before flush. |
+| Application-flag immutability only (no API removal) | A `delete_immutable_log()` that raises on call is weaker than a method that does not exist. Callers can work around documented exceptions; they cannot call nonexistent methods. |
+| Three-tier with automatic classification | Classification at emission time is correct; post-hoc classification has a window where entries are unclassified. Human + decorator assignment eliminates ambiguity. |
+
+## References
+
+- [ADR-0041](ADR-0041-immutable-evidence-nodes.md) — IMMUTABLE tier is the application-layer
+  representation of evidence nodes; hash-chain integrity is defined there
+- [ADR-0042](ADR-0042-task-certificate.md) — Task certificate state changes are IMMUTABLE tier
+  events
+- [ADR-0044](ADR-0044-tool-gates.md) — Gate decisions (HARD/SOFT/ADVISORY) are IMMUTABLE tier
+  events
+- [ADR-0045](ADR-0045-break-glass-protocol.md) — Required dependency for PROTECTED log deletion;
+  provides `validate_break_glass_token()`
+- [ADR-0046](ADR-0046-jit-tool-grant.md) — Permit issuance and consumption are IMMUTABLE tier
+  events
+- [ADR-0047](ADR-0047-agent-charter.md) — Charter activations are IMMUTABLE tier events
+- [ADR-0050](ADR-0050-operation-context.md) — Operation context captures (active assertions) are
+  IMMUTABLE tier events
+- [ADR-0033](ADR-0033-unified-entity-state-model.md) — `EvidenceRef` kinds map to IMMUTABLE log
+  event categories
+- prior governance research `01_design/034-audit-logging-governance/ADR-034-audit-logging-governance.md` — source
+  pattern; three-tier hierarchy, DB trigger approach, audit-of-auditing invariant

--- a/docs/adrs/ADR-0050-operation-context.md
+++ b/docs/adrs/ADR-0050-operation-context.md
@@ -1,0 +1,724 @@
+# ADR-0050: Operation Context — Active Assertion in Evidence
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Depends on**: [ADR-0041](ADR-0041-immutable-evidence-nodes.md), [ADR-0043](ADR-0043-governed-tool-declaration.md), [ADR-0044](ADR-0044-tool-gates.md), [ADR-0047](ADR-0047-agent-charter.md)
+**Related**: [ADR-0042](ADR-0042-task-certificate.md), [ADR-0045](ADR-0045-break-glass-protocol.md), [ADR-0046](ADR-0046-jit-tool-grant.md), [ADR-0049](ADR-0049-log-tier-governance.md), [ADR-0051](ADR-0051-tool-registry-allowlists.md), [ADR-0052](ADR-0052-policy-resolution.md), [ADR-0033](ADR-0033-unified-entity-state-model.md), [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md)
+
+---
+
+## Context
+
+lionagi's `Branch` today holds session-level state across its four managers: `MessageManager`
+(message history), `ActionManager` (registered tools), `iModelManager` (provider references),
+and `DataLogger` (log entries). When `branch.operate()` dispatches a tool call, the tool
+receives its arguments and returns a result. The `DataLogger` may record a `Log` entry. Nothing
+else is captured about the operation as a unit.
+
+The structural gap is that two evidence nodes emitted by different operations — or even by the
+same operation running twice — are indistinguishable from each other without external context.
+There is no record of which policy version was active, which gates passed or failed, which agent
+charter was in force, or what caused this operation to run. An audit question such as "what
+constraints were active when the agent wrote to this file at 14:32?" cannot be answered by
+inspecting the evidence node itself. The evidence node is a fact about what happened; without
+operation context it is not self-describing proof of how it was authorized to happen.
+
+This violates cross-cutting principle #2: **evidence is first-class, not logs**. A log entry
+records what happened operationally. Evidence carries the policy version, gate results, and
+authorization context active *at execution time* — this is what makes evidence admissible as
+proof. Without operation context embedded in every evidence node, the evidence carries no more
+authority than an application log.
+
+There is also a correctness hazard specific to async code. lionagi uses asyncio throughout. If
+operation-level state (gate results, causation chain, consumed permit tokens) were accumulated
+in a shared mutable session-level structure, concurrent coroutines within the same session would
+see each other's partially-accumulated state. The result would be either incorrect evidence
+(gate results from operation A appear in evidence for operation B) or a race condition requiring
+explicit locking.
+
+### The applicable prior governance research insight
+
+prior research establishes a two-tier context system: a `ServiceContext` initialized once at
+service startup holding long-lived references (charter, gate registry, policy version, tenant
+binding), and a `RequestContext` created per-request and propagated explicitly through every
+governed function as a named parameter. The key design insight is the "active assertion" pattern:
+the `RequestContext.to_evidence_data()` method serializes the *full policy state in force at
+execution time* into every evidence payload. Evidence becomes self-describing: an auditor
+inspecting a node years later can determine exactly what policy version governed the execution,
+which gates ran and what they returned, and which actor initiated the call — without needing to
+consult current system state. The context IS the proof.
+
+Translated to lionagi: `ServiceContext` is initialized at `Branch` creation time; it holds
+the gate registry, charter, resolved policy bundle, and knowledge store references. An
+`OperationContext` is created fresh for each `branch.operate()` call or governed tool execution.
+It is immutable. Gate results, permit tokens, and evidence node IDs are accumulated via
+transform methods that return new instances. Every evidence node emitted during the operation
+(per ADR-0041) receives a snapshot of the `OperationContext` at the moment of emission.
+
+### Why lionagi needs this
+
+Consider a KHive agent that calls `branch.operate()` three times in quick succession: one call
+reads configuration, one writes a checkpoint, one invokes a sub-agent. All three run
+concurrently on the asyncio event loop. The write operation passes a `guard_paths` HARD gate
+and a `confirm_path_outside_workspace` SOFT gate with a provided justification. The read
+operation passes `guard_paths` but has no SOFT gate. Without `OperationContext`, the evidence
+node for the write has no record of the SOFT gate result or the justification that authorized
+it. If the justification is later disputed, the evidence is silent. With `OperationContext`, the
+write's evidence node contains `gate_results: (GateResult(id="confirm_path...", passed=True,
+justification="checkpoint required before migration"),)` and `policy_version_active:
+"2026-05-1.3"` at the moment of emission — independently of what the other two concurrent
+operations did or what the policy version is today.
+
+---
+
+## Decision
+
+Introduce a two-tier context system: `ServiceContext` (per-session, initialized at `Branch`
+creation) and `OperationContext` (per-operation, immutable, transforms create new instances).
+Both are propagated explicitly as function arguments. Neither uses thread-locals or global state.
+Every evidence node emitted during a governed operation embeds the `OperationContext` active at
+the moment of emission as its active assertion.
+
+---
+
+### 1. `ServiceContext` — Per-Session Long-Lived References
+
+`ServiceContext` is created once when a `Branch` is initialized in governed mode. It holds
+references that do not change over the session lifetime: the gate registry (ADR-0044), the agent
+charter and its version (ADR-0047), the resolved policy bundle version (ADR-0052), and the
+knowledge store (ADR-0039).
+
+```python
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+from pydantic import ConfigDict, Field
+
+from lionagi.protocols.action.manager import ActionManager
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.log import DataLogger
+from lionagi.protocols.messages.manager import MessageManager
+from lionagi.service.manager import iModelManager
+
+if TYPE_CHECKING:
+    from lionagi.session.branch import Branch
+    from lionagi.protocols.governance.gates import GateRegistry
+    from lionagi.protocols.governance.charter import AgentCharter
+    from lionagi.protocols.knowledge.store import KnowledgeStore
+
+
+class ServiceContext(Element):
+    """Initialized once at Branch creation in governed mode.
+
+    Holds long-lived references (gate registry, charter, policy version,
+    knowledge store) plus references to the existing Branch managers. Every
+    OperationContext created during the session carries this object so
+    per-operation creation does not create parallel context stores.
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+    )
+
+    branch_id: str
+    session_id: str
+    agent_id: str
+    gate_registry: "GateRegistry" = Field(exclude=True)
+    charter: "AgentCharter" = Field(exclude=True)
+    policy_release_version: str
+    knowledge_store: "KnowledgeStore" = Field(exclude=True)
+    message_manager: MessageManager = Field(exclude=True)
+    action_manager: ActionManager = Field(exclude=True)
+    imodel_manager: iModelManager = Field(exclude=True)
+    data_logger: DataLogger = Field(exclude=True)
+    started_at: float = Field(default_factory=time.time)
+
+    @classmethod
+    def from_branch(
+        cls,
+        branch: "Branch",
+        *,
+        gate_registry: "GateRegistry",
+        charter: "AgentCharter",
+        policy_release_version: str,
+        knowledge_store: "KnowledgeStore",
+        session_id: str | None = None,
+        agent_id: str | None = None,
+    ) -> "ServiceContext":
+        """Bind governance context to Branch's existing manager surfaces."""
+        return cls(
+            branch_id=str(branch.id),
+            session_id=session_id or str(branch.id),
+            agent_id=agent_id or str(branch.user or branch.id),
+            gate_registry=gate_registry,
+            charter=charter,
+            policy_release_version=policy_release_version,
+            knowledge_store=knowledge_store,
+            message_manager=branch.msgs,
+            action_manager=branch.acts,
+            imodel_manager=branch.mdls,
+            data_logger=branch._log_manager,
+        )
+```
+
+`ServiceContext` is frozen: no field can be changed after initialization. A new session always
+produces a new `ServiceContext`. There is no path to mutate the gate registry or charter
+mid-session; changes require starting a new session.
+
+---
+
+### 2. `GateResult` — Atomic Gate Outcome
+
+`GateResult` is the unit stored in `OperationContext.gate_results`. It is a frozen record of one
+gate's evaluation outcome, captured at evaluation time and never modified.
+
+```python
+from __future__ import annotations
+
+import time
+from typing import Literal
+
+from pydantic import ConfigDict, Field
+
+from lionagi.protocols.generic.element import Element
+
+
+class GateResult(Element):
+    """Immutable record of a single gate evaluation (ADR-0044).
+
+    Accumulated into ``OperationContext.gate_results`` via
+    ``with_gate_result()``; serialized into every evidence node.
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+    )
+
+    gate_id: str
+    gate_tier: Literal["HARD", "SOFT", "ADVISORY"]
+    passed: bool
+    reason: str
+    justification: str | None = None
+    evaluated_at: float = Field(default_factory=time.time)
+```
+
+---
+
+### 3. `OperationContext` — Per-Operation Immutable Active Assertion
+
+`OperationContext` is created fresh at the start of each governed operation. Its fields are
+immutable. Gate results, permit tokens, and evidence node IDs are accumulated via transform
+methods that return new instances; the original is never modified.
+
+```python
+from __future__ import annotations
+
+import time
+from typing import Any, Literal
+
+from pydantic import ConfigDict, Field
+
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+
+
+class PermitTokenUse(Element):
+    """JIT permit token consumed during this operation (ADR-0046)."""
+
+    model_config = ConfigDict(
+        frozen=True,
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+    )
+
+    token_id: str
+    consumed_at: float = Field(default_factory=time.time)
+
+
+class EvidenceEmission(Element):
+    """Evidence node emitted during this operation (ADR-0041)."""
+
+    model_config = ConfigDict(
+        frozen=True,
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+    )
+
+    evidence_id: str
+    emitted_at: float = Field(default_factory=time.time)
+
+
+class OperationContext(Element):
+    """Per-operation context. Immutable. Active assertion of state at execution time.
+
+    Created once per governed operation.  Gate results, permit tokens, and
+    evidence IDs are accumulated via transform methods (``with_*``) that
+    return new instances — the original is never mutated.  The final snapshot
+    is serialized into every evidence node via ``to_evidence_data()``.
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+    )
+
+    # Identity
+    service_context: ServiceContext = Field(exclude=True)
+    actor_id: str
+    parent_operation_id: str | None = None  # causation chain; None = top-level
+    initiated_at: float = Field(default_factory=time.time)
+    actor_type: Literal["agent", "user", "system"] = "agent"
+
+    # Accumulated during operation (Pile copies grown via transforms):
+    gate_results: Pile[GateResult] = Field(
+        default_factory=lambda: Pile(item_type=GateResult, strict_type=True)
+    )
+    permit_tokens_consumed: Pile[PermitTokenUse] = Field(
+        default_factory=lambda: Pile(item_type=PermitTokenUse, strict_type=True)
+    )
+    evidence_emitted: Pile[EvidenceEmission] = Field(
+        default_factory=lambda: Pile(item_type=EvidenceEmission, strict_type=True)
+    )
+
+    # Active assertion — captured at creation, not updated later:
+    policy_version_active: str = ""
+    charter_version_active: int | str = 0
+
+    operation_name: str = ""               # optional audit label
+
+    @property
+    def operation_id(self) -> str:
+        """Element id is the operation id used in evidence and causation."""
+        return str(self.id)
+
+    # ------------------------------------------------------------------
+    # Immutable transforms
+    # ------------------------------------------------------------------
+
+    def with_gate_result(self, result: GateResult) -> "OperationContext":
+        """Return a new context with ``result`` appended to ``gate_results``."""
+        return self.model_copy(
+            update={
+                "gate_results": Pile(
+                    collections=[*self.gate_results, result],
+                    item_type=GateResult,
+                    strict_type=True,
+                )
+            }
+        )
+
+    def with_causation(self, parent_id: str) -> "OperationContext":
+        """Return a new context with ``parent_operation_id`` set."""
+        return self.model_copy(update={"parent_operation_id": parent_id})
+
+    def with_evidence(self, evidence_id: str) -> "OperationContext":
+        """Return a new context with ``evidence_id`` appended to ``evidence_emitted``."""
+        emission = EvidenceEmission(evidence_id=evidence_id)
+        return self.model_copy(
+            update={
+                "evidence_emitted": Pile(
+                    collections=[*self.evidence_emitted, emission],
+                    item_type=EvidenceEmission,
+                    strict_type=True,
+                )
+            }
+        )
+
+    def with_permit_token(self, token_id: str) -> "OperationContext":
+        """Return a new context with ``token_id`` appended to ``permit_tokens_consumed``."""
+        token_use = PermitTokenUse(token_id=token_id)
+        return self.model_copy(
+            update={
+                "permit_tokens_consumed": Pile(
+                    collections=[*self.permit_tokens_consumed, token_use],
+                    item_type=PermitTokenUse,
+                    strict_type=True,
+                )
+            }
+        )
+
+    # ------------------------------------------------------------------
+    # Active assertion serialization
+    # ------------------------------------------------------------------
+
+    def to_evidence_data(self) -> dict[str, Any]:
+        """Serialize the context as an active assertion payload.
+
+        Embedded verbatim into every evidence node emitted during this
+        operation.  An auditor reading the evidence node in isolation
+        can determine the full authorization context — policy version,
+        gate outcomes, actor, causation chain — without querying the
+        live system.  Returns a JSON-safe dict.
+        """
+        return {
+            "operation_id": self.operation_id,
+            "parent_operation_id": self.parent_operation_id,
+            "branch_id": self.service_context.branch_id,
+            "session_id": self.service_context.session_id,
+            "agent_id": self.service_context.agent_id,
+            "actor_id": self.actor_id,
+            "actor_type": self.actor_type,
+            "initiated_at": self.initiated_at,
+            "policy_version_active": self.policy_version_active,
+            "charter_version_active": self.charter_version_active,
+            "operation_name": self.operation_name,
+            "message_ids": [
+                str(message_id)
+                for message_id in self.service_context.message_manager.progression
+            ],
+            "registered_tools": sorted(self.service_context.action_manager.registry),
+            "chat_model": getattr(self.service_context.imodel_manager.chat, "model", None),
+            "parse_model": getattr(self.service_context.imodel_manager.parse, "model", None),
+            "gate_results": [gr.to_dict(mode="json") for gr in self.gate_results],
+            "permit_tokens_consumed": [
+                token.to_dict(mode="json") for token in self.permit_tokens_consumed
+            ],
+            "evidence_emitted": [
+                evidence.to_dict(mode="json") for evidence in self.evidence_emitted
+            ],
+        }
+```
+
+---
+
+### 4. `OperationContext` Factory
+
+Context creation is centralized in a single factory function to ensure consistent population of
+`policy_version_active` and `charter_version_active` from the `ServiceContext` at creation time.
+
+```python
+from lionagi.session.branch import Branch
+
+
+class MissingServiceContextError(RuntimeError):
+    """Raised when governed operation context is requested on an ungoverned Branch."""
+
+
+def create_operation_context(
+    branch: Branch,
+    *,
+    actor_id: str | None = None,
+    actor_type: str = "agent",
+    parent_operation_id: str | None = None,
+    operation_name: str = "",
+) -> OperationContext:
+    """Create a fresh OperationContext for a new governed operation.
+
+    Captures ``policy_version_active`` and ``charter_version_active``
+    from Branch's attached ``ServiceContext`` at this instant. Evidence
+    from this operation will always carry the version that was active at
+    start, regardless of later session hot-reloads.
+    """
+    service_context = branch.metadata.get("governance_service_context")
+    if not isinstance(service_context, ServiceContext):
+        raise MissingServiceContextError(
+            "Governed operation requires ServiceContext on Branch.metadata"
+        )
+
+    ctx = OperationContext(
+        service_context=service_context,
+        parent_operation_id=parent_operation_id,
+        actor_id=actor_id or str(branch.user or branch.id),
+        actor_type=actor_type,
+        operation_name=operation_name,
+        policy_version_active=service_context.policy_release_version,
+        charter_version_active=getattr(service_context.charter, "version", 0),
+    )
+    branch._log_manager.log(
+        {"event": "operation_context_created", "context": ctx.to_evidence_data()}
+    )
+    return ctx
+```
+
+---
+
+### 5. Explicit Propagation — Not Thread-Local, Not Global
+
+Context is passed as a named argument to every governed function. There is no global registry,
+no thread-local, and no `contextvars.ContextVar` for the `OperationContext` itself.
+
+```python
+# CORRECT: explicit parameter, async-safe
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from lionagi.agent.config import AgentConfig
+from lionagi.agent.hooks import guard_destructive, guard_paths
+from lionagi.session.branch import Branch
+
+PreHook = Callable[
+    [str, str, dict[str, Any]],
+    Awaitable[dict[str, Any] | None],
+]
+
+
+async def _run_gate(
+    branch: Branch,
+    hook: PreHook,
+    tool_name: str,
+    action: str,
+    kwargs: dict[str, Any],
+    ctx: OperationContext,
+) -> tuple[GateResult, OperationContext, dict[str, Any]]:
+    """Evaluate an existing lionagi pre-hook and return result, ctx, args."""
+    hook_args = {**kwargs, "operation_context": ctx.to_evidence_data()}
+    try:
+        updated_args = await hook(tool_name, action, hook_args)
+    except Exception as exc:
+        gate_result = GateResult(
+            gate_id=getattr(hook, "__name__", hook.__class__.__name__),
+            gate_tier="HARD",
+            passed=False,
+            reason=str(exc),
+            evaluated_at=time.time(),
+        )
+        ctx = ctx.with_gate_result(gate_result)
+        branch._log_manager.log(gate_result)
+        raise
+
+    gate_result = GateResult(
+        gate_id=getattr(hook, "__name__", hook.__class__.__name__),
+        gate_tier="HARD",
+        passed=True,
+        reason="hook passed",
+        evaluated_at=time.time(),
+    )
+    ctx = ctx.with_gate_result(gate_result)
+    branch._log_manager.log(gate_result)
+    return gate_result, ctx, updated_args if updated_args is not None else hook_args
+
+
+# Built-in hooks from lionagi.agent.hooks are registered through AgentConfig
+# and wired into Tool.preprocessor by create_agent()/CodingToolkit.
+config = AgentConfig.coding()
+config.pre("bash", guard_destructive)
+config.pre("editor", guard_paths(allowed_paths=["/workspace"]))
+
+
+# WRONG: global or thread-local lookup
+async def _run_gate_wrong(gate_id: str, tool_name: str, kwargs: dict) -> GateResult:
+    ctx = _get_current_context()   # Anti-pattern: breaks under concurrent coroutines
+    ...
+```
+
+The rationale: asyncio does not guarantee that a `ContextVar` set in coroutine A is invisible
+to coroutine B if B was created with `asyncio.create_task()` before A set the variable. Two
+concurrent `branch.operate()` calls would each create their own asyncio task; `ContextVar`
+inheritance means a child task sees the parent's context at the moment of creation, not live
+updates. This makes `ContextVar` safe for the bypass-prevention flag (ADR-0043, which is
+set-once before calling the handler), but unsafe for the accumulating `OperationContext` where
+each gate evaluation produces a new instance. Explicit propagation has one disadvantage —
+function signatures grow a `ctx: OperationContext` parameter — and one decisive advantage:
+correctness under all concurrency patterns without special reasoning.
+
+---
+
+### 6. Pipeline Integration — How `OperationContext` Flows Through ADR-0043
+
+The eight-phase enforcement pipeline in `ActionManager.execute_governed()` (ADR-0043) creates,
+accumulates, and finalizes the `OperationContext`:
+
+| Phase | Pipeline action | OperationContext interaction |
+|-------|-----------------|------------------------------|
+| Phase 1 | Normalize inputs via `options_schema` | `ctx` not yet created |
+| **Phase 2** | **Validate context exists** | `ctx = create_operation_context(service_ctx, actor_id=...)` — creation |
+| Phase 3 | Resolve applicable gates from registry | `ctx` passed to `_resolve_gates(meta, fn_name, ctx)` |
+| Phase 4 | Execute HARD gates | Each gate: `gate_result, ctx = await _run_gate(gate_id, ..., ctx)` |
+| Phase 5 | Execute SOFT gates | Same pattern; on bypass: `ctx = ctx.with_permit_token(token_id)` if JIT |
+| Phase 6 | Execute ADVISORY gates | Same pattern |
+| Phase 7 | Execute handler inside pipeline context | `ctx` snapshot passed to handler via `_enter_pipeline(op_ctx_id=ctx.operation_id)` |
+| **Phase 8** | **Emit evidence node** | `evidence_id = await _emit_success_evidence(..., ctx=ctx)`; then `ctx = ctx.with_evidence(evidence_id)` |
+
+After Phase 8, `ctx` is the final snapshot: it contains all gate results from Phases 4–6, all
+permit tokens consumed in Phase 5, and the evidence node ID from Phase 8. The Phase 8 evidence
+node embeds `ctx.to_evidence_data()` as its active assertion payload.
+
+On a HARD gate failure in Phase 4, the pipeline emits a failure evidence node carrying the
+partial `ctx` (with gate results up to the failure point), then raises `GateBlockedError`.
+The partial context is not discarded — the failure evidence is as important as the success
+evidence for the audit trail.
+
+---
+
+### 7. Evidence Embedding — The Active Assertion
+
+Every `ImmutableEvidenceNode` (ADR-0041) emitted during a governed operation includes the
+serialized `OperationContext` as a top-level field in its domain data. This is the active
+assertion: the evidence node is self-describing proof of what was in force when it was sealed.
+
+```python
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from pydantic import ConfigDict, Field
+
+from lionagi.protocols.governance.evidence import ImmutableEvidenceNode
+
+
+class ToolExecutionEvidence(ImmutableEvidenceNode):
+    """Evidence node for a governed tool execution.
+
+    ``operation_context_data`` carries ``ctx.to_evidence_data()`` and IS
+    included in the content hash — the policy state that authorized the
+    execution is part of the evidence.  ``raw_inputs`` is excluded via
+    ``_sensitive_fields``: tool arguments may contain secrets.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+    )
+
+    tool_name: str = ""
+    evidence_type: str = ""
+    outcome: str = ""          # "success" | "gate_blocked" | "execution_error"
+    justification: str | None = None
+
+    # The active assertion: full context serialized at emission time
+    operation_context_data: dict[str, Any] = Field(default_factory=dict)
+
+    # Excluded from hashes and audit exports:
+    raw_inputs: dict[str, Any] | None = Field(default=None, exclude=True)
+
+    _sensitive_fields: ClassVar[set[str]] = {"raw_inputs"}
+```
+
+An auditor reading this node in isolation — without access to the live system — sees the
+complete authorization context: policy version, all gate outcomes, actor identity, and
+causation chain. The evidence is self-describing by construction.
+
+---
+
+### 8. Causation Chain
+
+When a governed operation triggers a child operation (for example, a tool call that internally
+invokes another governed tool via a sub-branch, or a `FlowOp` node calling a downstream tool),
+the child's `OperationContext` is created with `parent_operation_id` pointing to the parent's
+`operation_id`. This forms a tree:
+
+```text
+branch.operate() → OperationContext(id="op-A", parent=None)
+  └─ write_file tool → OperationContext(id="op-B", parent="op-A")
+       └─ validate_path tool → OperationContext(id="op-C", parent="op-B")
+```
+
+Every evidence node in the tree carries its own `operation_id` and `parent_operation_id`.
+An audit query reconstructs the full causation tree by following `parent_operation_id` links
+from any leaf to the root — no separate tracing infrastructure required. The field is frozen
+at creation; there is no mechanism to set `parent_operation_id` after the fact.
+
+---
+
+## Consequences
+
+**Positive**
+
+- **Every evidence node is independently interpretable**: the active assertion payload makes
+  each node self-describing. An auditor does not need to query the live system to understand
+  what policy was in force when a given tool call ran. This directly satisfies cross-cutting
+  principle #2.
+- **Async-safe accumulation**: immutable transforms mean concurrent coroutines accumulate their
+  gate results in separate object chains. No locks required; no cross-contamination between
+  concurrent operations.
+- **Causation tree from evidence alone**: `parent_operation_id` links stored in evidence nodes
+  allow full causation reconstruction without a separate tracing infrastructure.
+- **Policy version captured at creation**: `policy_version_active` and `charter_version_active`
+  are snapshotted at `create_operation_context()` time. A hot-reload or charter revision
+  mid-session does not retroactively alter evidence from operations that started before it.
+- **Fail-closed for missing context**: `ActionManager.execute_governed()` Phase 2 raises
+  `MissingOperationContextError` if `ctx` is absent and the tool is not `skip_evidence=True`.
+  The pipeline cannot silently proceed without a context; ambiguity closes the gate.
+- **Testability**: test code creates a `ServiceContext` with mock gate registry and charter,
+  then constructs `OperationContext` instances directly. No global state to set up or tear down.
+
+**Negative**
+
+- **Function signature pollution**: every governed function in the pipeline gains a
+  `ctx: OperationContext` parameter. For simple library-mode callers not using governed tools,
+  this parameter never appears. For governed-mode code, it is present at every gate evaluation
+  site. The verbosity is intentional; it makes dependencies explicit.
+- **Shallow copy per transform**: each `with_gate_result()`, `with_evidence()`, or
+  `with_permit_token()` call produces a new frozen `Element` model. For an operation with ten gates,
+  this is ten allocations of the `OperationContext` Pydantic model. The overhead is measurable in
+  micro-benchmarks but irrelevant at the scale of gate evaluation (each gate is an async call).
+- **`ServiceContext` must be initialized**: ungoverned library-mode branches do not create a
+  `ServiceContext`. Adding governance to an existing branch requires providing a gate registry
+  and charter, which are new dependencies. Migration is explicit, not zero-config.
+
+---
+
+## Non-Goals
+
+Explicitly out of scope:
+
+- **Implicit context via thread-locals or `contextvars`**: deliberately rejected (see §5). The
+  accumulating `OperationContext` is unsafe for implicit propagation under asyncio concurrency.
+  `contextvars` is used only for the bypass-prevention flag (ADR-0043), which is set-once, not
+  accumulated.
+- **Context for ungoverned tools**: tools not decorated with `@governed_tool` (ADR-0043) and
+  invoked via `execute_raw()` do not receive an `OperationContext`. Library-mode callers
+  using plain registered callables are unaffected.
+- **Cross-process context propagation**: distributing `OperationContext` across process
+  boundaries (e.g., serializing `operation_id` into an HTTP header for a remote tool call and
+  reconstructing the causation chain at the receiver) is a KHive concern. Within a single
+  lionagi session, context propagation is entirely in-process.
+- **Multi-tenant context isolation**: ensuring that `ServiceContext` and `OperationContext`
+  instances from different tenants cannot be interchanged requires storage-layer row security
+  and tenant-scoped session initialization. This is KHive v1 territory.
+- **Real-time context streaming**: broadcasting the accumulated `OperationContext` to an
+  external observer as gates are evaluated (for live dashboards) is out of scope. The final
+  snapshot is embedded in evidence; intermediate states are not surfaced.
+- **Context outside the governed pipeline**: operations that run outside `execute_governed()`
+  (break-glass paths in ADR-0045, ungoverned tools, direct `Branch` state manipulation) do not
+  produce an `OperationContext`. Break-glass paths produce their own evidence records defined
+  in ADR-0045.
+
+---
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|---|---|
+| **Thread-local storage** (`threading.local()`) | Incompatible with asyncio: asyncio runs coroutines on a single thread, so a thread-local shared by all concurrent coroutines would conflate their gate results. Rejected unconditionally for async code. |
+| **`contextvars.ContextVar` for the accumulating context** | `ContextVar` is inherited by child tasks at creation time; subsequent updates are not visible to siblings. If coroutine A creates a child task and then appends a gate result via a `ContextVar`, the child does not see the update. Accumulating mutable state via `ContextVar` requires a `ContextVar[list]` with `.get()` and `.append()` — which reintroduces the race condition. `ContextVar` is suitable for set-once flags (ADR-0043's pipeline guard), not for accumulation. |
+| **Global registry keyed by `operation_id`** | A `dict[str, OperationContext]` singleton avoids parameter passing. It introduces a global write point that requires locking under concurrent operations, a cleanup protocol (when does an entry expire?), and an implicit dependency invisible in function signatures. Rejected per explicit-propagation principle from prior research. |
+| **Mutable `OperationContext` with per-field locks** | Locking individual fields (`gate_results_lock: asyncio.Lock`) would allow concurrent accumulation without a global mutex. It adds complexity disproportionate to the problem: the immutable-transform approach achieves the same result with simpler reasoning and no lock hierarchy. Rejected per prior research. |
+| **No `OperationContext`; embed policy version in each `EvidenceRef` directly** | `EvidenceRef` (ADR-0033) could carry individual `policy_version` and `actor_id` fields. This duplicates the same data into every node without establishing the link between nodes that belong to the same operation. The causation chain, the gate accumulation, and the permit token record all require a shared anchor — which IS the `OperationContext`. Individual fields are insufficient. |
+| **Collapse to single-tier (no `ServiceContext`)** | A flat `OperationContext` carrying both session-level and operation-level fields is simpler. It forces re-resolving the gate registry, charter, and knowledge store on every operation, which is expensive. It also conflates what is stable (policy version, charter) with what accumulates (gate results, evidence IDs), making the schema harder to read. Two tiers match the two lifetimes; the separation is structural, not cosmetic. |
+
+---
+
+## References
+
+- [ADR-0041](ADR-0041-immutable-evidence-nodes.md) — `ImmutableEvidenceNode` and `EvidenceChain`; every evidence node emitted during a governed operation is sealed with `ctx.to_evidence_data()` as its active assertion payload
+- [ADR-0043](ADR-0043-governed-tool-declaration.md) — `ActionManager.execute_governed()` pipeline; Phase 2 creates the `OperationContext`, Phases 4–6 accumulate gate results, Phase 8 embeds the final context snapshot into the evidence node
+- [ADR-0044](ADR-0044-tool-gates.md) — Gate registry and `GateResult` semantics; gates evaluated in Phases 4–6 produce the `GateResult` records accumulated in `OperationContext.gate_results`
+- [ADR-0047](ADR-0047-agent-charter.md) — Agent Charter; `charter.version` is captured as `charter_version_active` at `OperationContext` creation time
+- [ADR-0052](ADR-0052-policy-resolution.md) — Policy resolution bundle; `policy_release_version` is captured as `policy_version_active` at `OperationContext` creation time
+- [ADR-0042](ADR-0042-task-certificate.md) — Task Certificate signs over evidence nodes; the active assertion in each node makes the certificate independently verifiable
+- [ADR-0046](ADR-0046-jit-tool-grant.md) — JIT permit tokens consumed during SOFT gate bypass are appended to `OperationContext.permit_tokens_consumed` via `with_permit_token()`
+- [ADR-0045](ADR-0045-break-glass-protocol.md) — Break-glass paths run outside `execute_governed()`; they produce their own evidence records, not `OperationContext`-linked ones
+- [ADR-0033](ADR-0033-unified-entity-state-model.md) — `EvidenceRef` kinds (`tool_result`, `model_inference`, etc.) used by `ToolExecutionEvidence`
+- [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) — `KnowledgeStore` protocol held in `ServiceContext.knowledge_store`
+- prior governance research `01_design/013-service-context/ADR-013-service-context.md` — source pattern: two-tier context, active assertion via `to_evidence_data()`, explicit propagation, immutable transforms

--- a/docs/adrs/ADR-0051-tool-registry-allowlists.md
+++ b/docs/adrs/ADR-0051-tool-registry-allowlists.md
@@ -1,0 +1,822 @@
+# ADR-0051: Tool Registry Allowlists
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Depends on**: [ADR-0041](ADR-0041-immutable-evidence-nodes.md), [ADR-0043](ADR-0043-governed-tool-declaration.md), [ADR-0044](ADR-0044-tool-gates.md), [ADR-0047](ADR-0047-agent-charter.md)
+**Related**: [ADR-0046](ADR-0046-jit-tool-grant.md), [ADR-0049](ADR-0049-log-tier-governance.md), [ADR-0050](ADR-0050-operation-context.md), [ADR-0033](ADR-0033-unified-entity-state-model.md)
+
+---
+
+## Context
+
+lionagi's `PermissionPolicy` (`lionagi/agent/permissions.py`) controls per-tool access via
+allowlist, denylist, and escalate rules keyed by tool name and glob pattern. That mechanism works
+for its intended purpose — session-local access control — but it has a structural gap: the
+allowlist is an in-memory list on `AgentConfig`, assembled at agent creation time, with no
+record of who authorized which tool, when, or why. There is no way to answer "who approved
+`write_file` for agent X?" without reading the code or configuration that instantiated the agent.
+There is no expiry. There is no audit entry when the list changes. Multiple call sites — `AgentConfig.coding()`,
+`AgentConfig.research()`, and direct `PermissionPolicy(allow={...})` construction — each define
+their own allowlists with no shared registry to enforce consistency.
+
+The concrete failure mode is the N-paths problem: a tool that should require explicit approval
+(e.g., a database-write tool in a governed context) can be made available by updating any one of
+several independent allowlist paths. Each path has different bypass characteristics. An agent that
+reaches a tool through an unlisted path is indistinguishable from one that reached it through an
+explicitly governed path. Cross-cutting principle #3 — **every constraint must be enforced, not
+just documented** — is violated when the approval record lives only in configuration prose.
+
+Cross-cutting principle #1 (fail-closed) also has no expression at the allowlist level today.
+`PermissionPolicy` in `mode="allow_all"` (the default for orchestrators) permits any registered
+tool unconditionally. If the allowlist is absent or empty, the policy grants rather than denies.
+A centralized registry with a hard gate that checks membership before execution inverts this
+default: absence of a registry entry is a deny.
+
+### The applicable prior governance research insight
+
+prior research establishes a centralized `Registry` base class for all "is X in the approved
+list?" checks. The key principle is that allowlists are not code — they are configuration entries
+with attribution. A registry entry is not "a value in a Python list": it is a record with an
+actor, a timestamp, a justification, and a scope. When an entry is no longer valid, it is
+superseded (not deleted), so the full approval history is always recoverable. The gate operation
+(`verify_in_allowlist`) is the single enforcement point: every governed tool call goes through it,
+and it fails closed by default.
+
+Translated to lionagi: `ToolRegistryPolicy` holds `RegistryEntry` objects in a `Pile`;
+`verify_in_registry` is installed as a security pre-hook on the existing `Tool.preprocessor`
+path used by `ActionManager` ([ADR-0043](ADR-0043-governed-tool-declaration.md)); and
+`PermissionPolicy.allow` in library mode is re-expressed as an in-memory policy element so that
+the same code path is exercised whether the caller is a library user or a KHive tenant.
+
+### Why lionagi needs this
+
+An agent chartered for read-only research access ([ADR-0047](ADR-0047-agent-charter.md)) must
+not be able to call a `write_file` tool even if that tool is registered in the branch. Today,
+preventing this requires the session constructor to remember to configure `PermissionPolicy` with
+a denylist. If the constructor omits this, nothing in the tool execution path raises an error —
+the tool runs, the file is written, and the operation record is indistinguishable from an
+explicitly approved write. A registry that is consulted unconditionally by the governed tool
+pipeline, and that fails closed on a missing entry, makes this omission structurally impossible.
+
+---
+
+## Decision
+
+Introduce `ToolRegistryPolicy` (append-only, scoped, audited) and `RegistryEntry` (frozen
+`Element` with full attribution) as the canonical allowlist mechanism for governed tool access.
+The `verify_in_registry` HARD gate ([ADR-0044](ADR-0044-tool-gates.md)) consults the policy before
+every governed tool call. In library mode, `PermissionPolicy` constructs an in-memory policy
+element; in KHive, the same Element records are backend-persisted.
+
+### 1. Scope enum
+
+```python
+from __future__ import annotations
+
+from enum import Enum
+
+
+class RegistryScope(Enum):
+    """Determines which agents and sessions an entry applies to.
+
+    Resolution order (most-specific wins): SESSION > AGENT > PROJECT > GLOBAL.
+    Any active entry at any scope level grants access; no entry at any level
+    denies access.
+    """
+
+    GLOBAL = "global"    # all agents and sessions; system-wide approval
+    PROJECT = "project"  # one project (KHive project_id or Studio workspace)
+    AGENT = "agent"      # one agent_id within a project
+    SESSION = "session"  # one session_id; highest specificity, lowest lifetime
+```
+
+### 2. RegistryEntry — frozen, attributed, expirable
+
+```python
+import hashlib
+import json
+from typing import ClassVar
+from uuid import UUID
+
+from pydantic import ConfigDict, Field
+
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+
+
+class RegistryEvidence(Element):
+    """Evidence record for one registry policy decision or mutation."""
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    event: str
+    entry_id: str | None = None
+    tool_name: str | None = None
+    actor: str
+    reason: str
+    payload_hash: str | None = None
+    details: dict = Field(default_factory=dict)
+
+
+class ToolGrant(Element):
+    """Runtime grant produced when an active allowlist entry authorizes a call."""
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    tool_name: str
+    entry_id: str
+    scope: RegistryScope
+    scope_id: str
+    granted_for_action: str = ""
+    expires_at: float | None = None
+    evidence: Pile[RegistryEvidence] = Field(
+        default_factory=lambda: Pile(
+            item_type=RegistryEvidence,
+            strict_type=True,
+        )
+    )
+
+
+class RegistryEntry(Element):
+    """A single approved entry in a Registry.
+
+    Immutable after creation. Supersession (not deletion) is the only way
+    to revoke an entry; the original remains in the append-only pile for audit.
+    All mutations emit IMMUTABLE evidence per ADR-0041.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    category: str
+    """What kind of resource is being allowlisted.
+
+    Canonical categories: "tool" | "model" | "mcp_endpoint" | "url" | "path_prefix".
+    New categories may be added; no category is removed once introduced.
+    """
+
+    value: str
+    """The resource being approved.
+
+    Exact match only (v1). Examples:
+    - category="tool":         "write_file"
+    - category="model":        "openai/gpt-4o"
+    - category="mcp_endpoint": "mcp://khive-memory/v1"
+    - category="url":          "api.github.com"
+    - category="path_prefix":  "/workspace/project/"
+    """
+
+    scope: RegistryScope
+    """Breadth of this approval."""
+
+    scope_id: str
+    """Identifier for the scope target.
+
+    For GLOBAL: use "*".
+    For PROJECT: the project_id string.
+    For AGENT: the agent_id string.
+    For SESSION: the session_id string.
+    """
+
+    registered_by: str
+    """Actor who created this entry (human user, orchestrator agent_id, or system)."""
+
+    registered_at: float
+    """Unix timestamp (UTC) of registration."""
+
+    reason: str
+    """Required justification. Must be non-empty."""
+
+    expires_at: float | None = None
+    """Optional Unix timestamp after which this entry is treated as superseded.
+
+    Expired entries are preserved (not deleted) for audit of historical state.
+    The is_active() method accounts for expiry.
+    """
+
+    evidence: Pile[RegistryEvidence] = Field(
+        default_factory=lambda: Pile(
+            item_type=RegistryEvidence,
+            strict_type=True,
+        )
+    )
+    """Evidence records (ADR-0041) that support this approval decision."""
+
+    superseded_by: str | None = None
+    """entry_id of the replacement entry, if this entry has been superseded."""
+
+    _sensitive_fields: ClassVar[set[str]] = set()
+
+    @property
+    def entry_id(self) -> str:
+        """Compatibility alias for the Element id."""
+        return str(self.id)
+
+    def is_active(self) -> bool:
+        """Return True if this entry is currently effective."""
+        from datetime import datetime, timezone
+        if self.superseded_by is not None:
+            return False
+        if self.expires_at is not None:
+            now = datetime.now(timezone.utc).timestamp()
+            if now > self.expires_at:
+                return False
+        return True
+
+    def payload_hash(self) -> str:
+        """SHA-256 of the canonical JSON representation of this entry.
+
+        Used by the evidence emission path (ADR-0041) to produce a content-
+        addressed reference to this approval record.
+        """
+        payload = self.to_dict(mode="db", exclude={"metadata", "evidence"})
+        payload.pop("node_metadata", None)
+        canonical = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+    def with_supersession(self, superseded_by: UUID | str) -> "RegistryEntry":
+        """Return an immutable replacement with supersession recorded."""
+        return self.model_copy(update={"superseded_by": str(superseded_by)})
+```
+
+### 3. Registry — append-only, scoped resolution
+
+```python
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import ConfigDict, Field, PrivateAttr
+
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.log import DataLogger, Log
+from lionagi.protocols.generic.pile import Pile
+
+
+class ToolRegistryPolicy(Element):
+    """Append-only, audited allowlist policy mounted on ActionManager/PermissionPolicy.
+
+    All writes produce an IMMUTABLE evidence record (ADR-0041). Reads are O(n) in v1
+    (n = active entries per category). Pile supplies managed identity lookup and
+    synchronized mutation for library-mode policy state; KHive can persist the same
+    Element records behind the same API.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+    )
+
+    entries: Pile[RegistryEntry] = Field(
+        default_factory=lambda: Pile(
+            item_type=RegistryEntry,
+            strict_type=True,
+        )
+    )
+    grants: Pile[ToolGrant] = Field(
+        default_factory=lambda: Pile(
+            item_type=ToolGrant,
+            strict_type=True,
+        )
+    )
+    evidence: Pile[RegistryEvidence] = Field(
+        default_factory=lambda: Pile(
+            item_type=RegistryEvidence,
+            strict_type=True,
+        )
+    )
+
+    _data_logger: DataLogger | None = PrivateAttr(default=None)
+
+    def bind_logger(self, data_logger: DataLogger | None) -> "ToolRegistryPolicy":
+        """Bind the Branch DataLogger used to persist registry evidence."""
+        self._data_logger = data_logger
+        return self
+
+    # ------------------------------------------------------------------ reads
+
+    def _scope_candidates(
+        self,
+        *,
+        project_id: str | None = None,
+        agent_id: str | None = None,
+        session_id: str | None = None,
+    ) -> tuple[tuple[RegistryScope, str], ...]:
+        """Most-specific to least-specific resolution order."""
+        candidates = []
+        if session_id:
+            candidates.append((RegistryScope.SESSION, session_id))
+        if agent_id:
+            candidates.append((RegistryScope.AGENT, agent_id))
+        if project_id:
+            candidates.append((RegistryScope.PROJECT, project_id))
+        candidates.append((RegistryScope.GLOBAL, "*"))
+        return tuple(candidates)
+
+    def active_entry(
+        self,
+        category: str,
+        value: str,
+        *,
+        project_id: str | None = None,
+        agent_id: str | None = None,
+        session_id: str | None = None,
+    ) -> RegistryEntry | None:
+        """Return the active entry that grants access, or None."""
+        for check_scope, check_id in self._scope_candidates(
+            project_id=project_id,
+            agent_id=agent_id,
+            session_id=session_id,
+        ):
+            for entry in self.entries:
+                if (
+                    entry.category == category
+                    and entry.value == value
+                    and RegistryScope(entry.scope) == check_scope
+                    and entry.scope_id in {check_id, "*"}
+                    and entry.is_active()
+                ):
+                    return entry
+        return None
+
+    def is_allowed(
+        self,
+        category: str,
+        value: str,
+        *,
+        project_id: str | None = None,
+        agent_id: str | None = None,
+        session_id: str | None = None,
+    ) -> bool:
+        """Return True if an active entry exists for this (category, value) pair.
+
+        Scope resolution: walks from most-specific (SESSION) to least (GLOBAL).
+        Any active entry at any scope level → allowed. No active entry at any
+        level → denied (fail-closed, cross-cutting principle #1).
+        """
+        return self.active_entry(
+            category,
+            value,
+            project_id=project_id,
+            agent_id=agent_id,
+            session_id=session_id,
+        ) is not None
+
+    def get_entry(self, entry_id: str) -> RegistryEntry | None:
+        """Fetch a specific entry by ID (active or historical)."""
+        for entry in self.entries:
+            if entry.entry_id == entry_id:
+                return entry
+        return None
+
+    def history(
+        self,
+        category: str | None = None,
+        value: str | None = None,
+    ) -> Pile[RegistryEntry]:
+        """Return all entries (active and superseded) matching the filters."""
+        result = Pile(item_type=RegistryEntry, strict_type=True)
+        for entry in self.entries:
+            if category is not None and entry.category != category:
+                continue
+            if value is not None and entry.value != value:
+                continue
+            result.include(entry)
+        return result
+
+    # ----------------------------------------------------------------- writes
+
+    def add(
+        self,
+        *,
+        category: str,
+        value: str,
+        scope: RegistryScope,
+        scope_id: str,
+        registered_by: str,
+        reason: str,
+        expires_at: float | None = None,
+        evidence: Pile[RegistryEvidence] | None = None,
+    ) -> RegistryEntry:
+        """Append a new entry.
+
+        Raises ValueError if reason is empty; all approvals require justification.
+        Emits an IMMUTABLE evidence node (ADR-0041) recording the registration
+        event, the actor, and the payload_hash of the new entry.
+        """
+        if not reason.strip():
+            raise ValueError(
+                "RegistryEntry.reason must be non-empty; all approvals require justification."
+            )
+        entry = RegistryEntry(
+            category=category,
+            value=value,
+            scope=scope,
+            scope_id=scope_id,
+            registered_by=registered_by,
+            registered_at=datetime.now(timezone.utc).timestamp(),
+            reason=reason,
+            expires_at=expires_at,
+            evidence=evidence or Pile(item_type=RegistryEvidence, strict_type=True),
+        )
+        self.entries.include(entry)
+        self._record_evidence(
+            event="entry_added",
+            entry=entry,
+            actor=registered_by,
+            reason=reason,
+        )
+        return entry
+
+    def supersede(
+        self,
+        old_entry_id: str,
+        *,
+        reason: str,
+        superseded_by_actor: str,
+        replacement: RegistryEntry | None = None,
+    ) -> None:
+        """Mark an entry as superseded. The original is preserved for audit.
+
+        If replacement is provided, it must already be present in this registry
+        (call add() first, then supersede()). Emits IMMUTABLE evidence for the
+        supersession event.
+
+        Does not raise if old_entry_id is already superseded — idempotent.
+        """
+        for entry in self.entries:
+            if entry.entry_id == old_entry_id:
+                replacement_id = (
+                    replacement.entry_id if replacement is not None else "revoked"
+                )
+                updated = entry.with_supersession(replacement_id)
+                self.entries.update(updated)
+                self._record_evidence(
+                    event="entry_superseded",
+                    entry=updated,
+                    actor=superseded_by_actor,
+                    reason=reason,
+                    details={
+                        "superseded_by_actor": superseded_by_actor,
+                        "supersession_reason": reason,
+                        "replacement_entry_id": replacement_id,
+                    },
+                )
+                return
+
+    def record_grant(
+        self,
+        *,
+        tool_name: str,
+        entry: RegistryEntry,
+        action: str = "",
+    ) -> ToolGrant:
+        """Record the effective grant used by one governed tool call."""
+        grant = ToolGrant(
+            tool_name=tool_name,
+            entry_id=entry.entry_id,
+            scope=entry.scope,
+            scope_id=entry.scope_id,
+            granted_for_action=action,
+            expires_at=entry.expires_at,
+        )
+        self.grants.include(grant)
+        evidence = self._record_evidence(
+            event="grant_issued",
+            entry=entry,
+            actor="policy",
+            reason=f"{tool_name} authorized by registry entry {entry.entry_id}",
+            details={"grant_id": str(grant.id), "action": action},
+        )
+        grant.evidence.include(evidence)
+        return grant
+
+    # --------------------------------------------------------- evidence bridge
+
+    def _record_evidence(
+        self,
+        event: str,
+        entry: RegistryEntry,
+        *,
+        actor: str,
+        reason: str,
+        details: dict[str, Any] | None = None,
+    ) -> RegistryEvidence:
+        """Record IMMUTABLE evidence for a registry mutation or grant.
+
+        In library mode, the record is retained in a Pile and also written to the
+        bound Branch DataLogger when one is available. In KHive, the backend can
+        persist the same Element payload to the immutable evidence store
+        (ADR-0041, ADR-0049 IMMUTABLE tier).
+        """
+        evidence = RegistryEvidence(
+            event=event,
+            entry_id=entry.entry_id,
+            tool_name=entry.value if entry.category == "tool" else None,
+            actor=actor,
+            reason=reason,
+            payload_hash=entry.payload_hash(),
+            details=details or {},
+        )
+        self.evidence.include(evidence)
+        entry.evidence.include(evidence)
+        try:
+            if self._data_logger is not None:
+                self._data_logger.log(Log.create(evidence))
+        except Exception:  # noqa: BLE001
+            # The in-memory evidence Pile remains the source of truth in library mode.
+            pass
+        return evidence
+```
+
+### 4. The `verify_in_registry` gate
+
+`verify_in_registry` is a HARD gate in the sense of [ADR-0044](ADR-0044-tool-gates.md): it raises
+`PermissionError` and fails closed if the policy has no active entry. It is registered through the
+existing hook path (`AgentConfig.pre(...)` before agent creation, or `Tool.preprocessor` on
+`ActionManager`-managed tools after registration).
+
+```python
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable, Sequence
+
+from lionagi.agent.config import AgentConfig
+from lionagi.agent.factory import create_agent
+from lionagi.agent.hooks import guard_destructive, guard_paths, log_tool_use
+from lionagi.protocols.action.manager import ActionManager
+from lionagi.protocols.action.tool import Tool
+
+from lionagi.agent.governance.registry import RegistryScope, ToolRegistryPolicy
+
+
+def make_verify_in_registry_gate(
+    policy: ToolRegistryPolicy,
+    *,
+    project_id: str | None = None,
+    agent_id: str | None = None,
+    session_id: str | None = None,
+):
+    """Factory returning an existing lionagi pre-hook.
+
+    Hook signature matches lionagi.agent.hooks:
+        async def hook(tool_name: str, action: str, args: dict) -> dict | None
+
+    The hook raises PermissionError to block and returns None to pass through.
+    Any registry read failure is treated as deny (fail-closed).
+    """
+
+    async def verify_in_registry(
+        tool_name: str,
+        action: str,
+        args: dict,
+    ) -> dict | None:
+        try:
+            entry = policy.active_entry(
+                "tool",
+                tool_name,
+                project_id=project_id,
+                agent_id=agent_id,
+                session_id=session_id,
+            )
+            if entry is None:
+                raise PermissionError(f"{tool_name} has no active registry entry")
+            policy.record_grant(tool_name=tool_name, entry=entry, action=action)
+            return None
+        except PermissionError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            raise PermissionError(
+                f"Registry check failed closed for {tool_name}: {exc}"
+            ) from exc
+
+    verify_in_registry.__name__ = "verify_in_registry[tool]"
+    return verify_in_registry
+
+
+Hook = Callable[[str, str, dict], Awaitable[dict | None]]
+
+
+def _chain_tool_preprocessor(
+    tool: Tool,
+    *,
+    security_hooks: Sequence[Hook],
+) -> None:
+    """Install registry hooks through Tool.preprocessor without replacing Tool."""
+    previous = tool.preprocessor
+
+    async def chained(args: dict, **kwargs) -> dict:
+        current = args
+        for hook in security_hooks:
+            result = await hook(tool.function, current.get("action", ""), current)
+            if isinstance(result, dict):
+                current = result
+        if previous is not None:
+            result = previous(current, **kwargs)
+            result = await result if inspect.isawaitable(result) else result
+            if isinstance(result, dict):
+                current = result
+        return current
+
+    tool.preprocessor = chained
+
+
+def install_registry_policy(
+    action_manager: ActionManager,
+    policy: ToolRegistryPolicy,
+    *,
+    project_id: str | None = None,
+    agent_id: str | None = None,
+    session_id: str | None = None,
+) -> None:
+    """Mount the allowlist check on existing ActionManager-managed Tool objects.
+
+    ActionManager.registry remains the source of registered tools; the policy only
+    supplies the allowlist hook that each Tool runs before func_callable.
+    """
+    hook = make_verify_in_registry_gate(
+        policy,
+        project_id=project_id,
+        agent_id=agent_id,
+        session_id=session_id,
+    )
+    for tool in action_manager.registry.values():
+        _chain_tool_preprocessor(tool, security_hooks=[hook])
+
+
+# Library-mode setup composes registry policy with existing hooks.py handlers.
+config = AgentConfig.coding()
+policy = ToolRegistryPolicy()
+policy.add(
+    category="tool",
+    value="write_file",
+    scope=RegistryScope.PROJECT,
+    scope_id="my-project",
+    registered_by="ocean",
+    reason="Approved for sandbox write operations.",
+)
+
+# Before create_agent(): AgentConfig wires hooks through Tool.preprocessor.
+config.pre("*", make_verify_in_registry_gate(policy, project_id="my-project"))
+config.pre("bash", guard_destructive)
+config.pre("editor", guard_paths(allowed_paths=["/workspace/project/"]))
+config.post("*", log_tool_use)
+branch = await create_agent(config)
+policy.bind_logger(branch._log_manager)
+
+# For tools registered after create_agent(), install directly on ActionManager.
+install_registry_policy(branch.acts, policy, project_id="my-project")
+```
+
+### 5. Canonical categories
+
+| Category | `value` field semantics | Example |
+|---|---|---|
+| `tool` | tool_id as registered in `ActionManager` | `"write_file"` |
+| `model` | `"{provider}/{model_name}"` | `"openai/gpt-4o"` |
+| `mcp_endpoint` | MCP server URI (scheme + host) | `"mcp://khive-memory/v1"` |
+| `url` | External HTTP host (no path) | `"api.github.com"` |
+| `path_prefix` | Filesystem prefix; trailing `/` required | `"/workspace/project/"` |
+
+Categories are extensible. New categories are introduced by adding to this table; no category is
+removed once any active entry references it.
+
+### 6. Scope resolution semantics
+
+When `is_allowed()` is called with a `(scope, scope_id)` pair identifying the caller's current
+context, resolution walks from SESSION → AGENT → PROJECT → GLOBAL. The first active matching
+entry at any scope level grants access. If no active entry exists at any scope level, the call
+returns `False` (fail-closed).
+
+This means a GLOBAL entry grants access to all agents and sessions. A PROJECT-scoped entry grants
+access to all agents within that project but not globally. A SESSION-scoped entry grants access
+only within that session's lifetime — typically used for JIT grants ([ADR-0046](ADR-0046-jit-tool-grant.md)).
+
+### 7. Integration with AgentCharter
+
+[ADR-0047](ADR-0047-agent-charter.md) defines an `AgentCharter` with an `allowed_tools` field.
+That field is a **snapshot** derived from the active registry entries at charter ratification time
+— it is not a live view. Once a charter is ratified, registry changes do not propagate into it
+automatically. To revoke a tool from a running agent, the charter must be superseded (which
+terminates the current agent session and initiates a new one with the updated charter). This is
+intentional: a charter represents a point-in-time, signed commitment; runtime mutability would
+undermine the guarantees [ADR-0042](ADR-0042-task-certificate.md) (Task Certificate) depends on.
+
+### 8. Library mode vs. KHive mode
+
+The `ToolRegistryPolicy` element is usable with zero configuration in library mode. An in-memory
+policy is created per `AgentConfig` and backs the allow dimension that previously lived only in
+`PermissionPolicy.allow`. No persistence is implied; the policy lifetime is the process lifetime.
+
+In KHive, the registry is backend-persisted. `Registry._emit_registry_evidence` writes to the
+IMMUTABLE evidence tier ([ADR-0049](ADR-0049-log-tier-governance.md)). Multi-actor approval
+workflows (e.g., two-of-three human approvers before a tool is added to a production registry)
+are implemented at the KHive layer by gating the `Registry.add()` call behind an approval flow
+— the `Registry` class itself is unaware of this orchestration.
+
+`PermissionPolicy` is not removed. It continues to express deny rules and escalation paths that
+have no registry equivalent. The registry governs the allowlist dimension; `PermissionPolicy`
+governs the deny and escalate dimensions. Both are consulted on every governed tool call.
+
+---
+
+## Consequences
+
+**Positive**
+
+- Allowlist approvals are auditable: every `add()` call emits an evidence node that records who
+  approved what, when, and why. "Who approved `write_file` for agent X?" is always answerable.
+- Centralized enforcement eliminates the N-paths problem. There is exactly one code path that
+  gates tool execution on registry membership.
+- Fail-closed default: a tool with no registry entry in any scope is denied, not permitted. An
+  absent allowlist no longer implies permission.
+- Expiry is first-class: JIT grants (ADR-0046) expire at session end without requiring explicit
+  revocation; the audit record of the expired grant is preserved.
+- Library and KHive users share the same `Registry` API; behavioral differences are in the
+  persistence and evidence-emission backends, not in the allowlist logic.
+
+**Negative**
+
+- Increased API surface: agents that previously relied on `PermissionPolicy(mode="allow_all")`
+  must now populate a registry. Migration requires explicit approval records for every previously
+  implicit permission.
+- Append-only growth: registries accumulate superseded and expired entries indefinitely. In KHive,
+  storage tiering of historical entries is a backend concern; in library mode, old entries are
+  garbage-collected with the process.
+- Expiry management is a new operational concern: SESSION-scoped entries expire silently. Long-lived
+  agents that acquire SESSION-scoped grants must renew them or escalate to AGENT/PROJECT scope.
+
+---
+
+## Non-Goals
+
+Explicitly out of scope for v1:
+
+- **Multi-tenant registry isolation**: KHive's tenant-scoped registry (where Tenant A cannot see
+  Tenant B's entries) is a KHive v1 concern. The `Registry` class has no tenant_id; the KHive
+  backend adds this as a partitioning key.
+- **Wildcard or regex matching**: `value` is exact-match only. `"write_*"` is not a valid value;
+  each tool must have an explicit entry. Pattern matching introduces ambiguity in scope resolution
+  and is deliberately deferred.
+- **Multi-actor approval workflows**: requiring two-of-three human approvers before `Registry.add()`
+  completes is a KHive workflow concern, not a library concern. The `Registry` class does not model
+  approval state machines.
+- **Automatic allowlist propagation across tenants**: a GLOBAL entry in one KHive tenant does not
+  propagate to another. Propagation is an explicit KHive federation concern.
+- **Dynamic registry mutation by agents**: agents may request that a tool be added to a registry
+  (via the JIT grant flow, ADR-0046), but agents do not call `Registry.add()` directly. That
+  decision is reserved for humans or orchestrators with explicit approval authority.
+- **Performance caching layer**: in-memory caching to reduce O(n) lookup cost is deferred to the
+  KHive backend. Library-mode registries are small enough that O(n) is acceptable at v1.
+
+---
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|---|---|
+| Per-feature allowlists (current) | N-paths problem: each feature implements its own allowlist with different bypass and audit characteristics. No shared invariant that "approved = has registry entry". |
+| `PermissionPolicy.allow` dict only | No attribution: the dict holds tool names, not the actor who approved them or when. No expiry. No evidence emission. Answers "is X allowed now" but not "who allowed X". |
+| Free-form policy text in `AgentConfig` | Not machine-enforceable. A human-readable description of allowed tools has no gate equivalent. Cross-cutting principle #3 requires enforcement, not documentation. |
+| OPA policy engine | Correct for complex policy logic; over-engineered for exact-match membership checks. OPA evaluation overhead on every tool call is unjustified when the check is `value in set`. |
+| Separate list per category (tool_allowlist, model_allowlist, ...) | Schema proliferation. A unified `Registry` with a `category` discriminator is simpler, shares the same audit and expiry semantics, and avoids inconsistency between implementations. |
+
+---
+
+## References
+
+- [ADR-0041](ADR-0041-immutable-evidence-nodes.md) — IMMUTABLE evidence emission on every registry mutation
+- [ADR-0042](ADR-0042-task-certificate.md) — Task Certificate depends on immutable evidence produced by registry mutations
+- [ADR-0043](ADR-0043-governed-tool-declaration.md) — existing `Tool` pipeline where `verify_in_registry` is a HARD gate
+- [ADR-0044](ADR-0044-tool-gates.md) — `gate_in_registry` as a HARD gate in the three-tier enforcement model
+- [ADR-0046](ADR-0046-jit-tool-grant.md) — JIT grants are SESSION-scoped registry entries with `expires_at`
+- [ADR-0047](ADR-0047-agent-charter.md) — `allowed_tools` is a snapshot from the registry at charter ratification time
+- [ADR-0049](ADR-0049-log-tier-governance.md) — registry mutation events are IMMUTABLE tier log records
+- [ADR-0033](ADR-0033-unified-entity-state-model.md) — evidence shape reflected by `RegistryEvidence` records in `RegistryEntry.evidence`
+- prior governance research `01_design/031-registry-allowlists/ADR-031-registry-allowlists.md` — source pattern (tenant → scope, role/destination/tool registries → unified category discriminator)

--- a/docs/adrs/ADR-0052-policy-resolution.md
+++ b/docs/adrs/ADR-0052-policy-resolution.md
@@ -1,0 +1,930 @@
+# ADR-0052: Policy Resolution and Staged Release
+
+**Status**: Proposed
+**Date**: 2026-05-26
+**Depends on**: [ADR-0044](ADR-0044-tool-gates.md) (policies select which gates run), [ADR-0047](ADR-0047-agent-charter.md) (charter pins policy_release_version), [ADR-0050](ADR-0050-operation-context.md) (active policy version captured in operation evidence), [ADR-0051](ADR-0051-tool-registry-allowlists.md) (registry entries are policy-scoped)
+**Related**: [ADR-0041](ADR-0041-immutable-evidence-nodes.md) (bundle hash follows the same SHA-256 pattern), [ADR-0042](ADR-0042-task-certificate.md) (certificate records active policy version), [ADR-0045](ADR-0045-break-glass-protocol.md) (break-glass resolves against a named policy), [ADR-0046](ADR-0046-jit-tool-grant.md) (JIT grants are policy-scoped)
+
+## Context
+
+lionagi's agent governance today is captured in `AgentConfig` (`lionagi/agent/config.py`). An
+`AgentConfig` carries a `PermissionPolicy` with allowlist, denylist, or confirm mode; a set of
+`hook_handlers`; and a list of tool names. This is per-agent and flat: there is exactly one
+permission policy per agent, it has no version, and there is no mechanism for resolving what
+happens when multiple policies could apply to a single operation.
+
+That flat model is adequate for single-agent, single-operator use. It breaks down as soon as scope
+widens. A tool call in a governed session has at least three relevant policy dimensions: what the
+tenant (or organization) requires by default, what the role of the calling agent requires, and what
+the specific resource (the tool being called) requires. These three can conflict. lionagi today
+has no mechanism to resolve that conflict, no representation of policy scope, and no way to version
+the policy so that an audit can reconstruct what rules were in force at execution time.
+
+Cross-cutting principle #1 — **fail-closed is the universal default** — means that the absence of
+a resolution mechanism is not neutral. Unresolved conflicts must deny, not silently proceed. And
+cross-cutting principle #3 — **every constraint must be enforced, not just documented** — means
+the resolution algorithm must be code-backed, not a documentation convention. The gap is structural:
+without `PolicyBundle`, `PolicyScope`, `ScopedPolicy`, and `PolicyResolver`, the framework cannot
+enforce precedence, cannot version policy state, and cannot record which policy version was active
+in evidence.
+
+### The applicable prior governance research insight
+
+prior research establishes *lex specialis* as the resolution rule: the most specific applicable
+policy wins. Specificity is scored by scope level — resource-level policies score higher than
+role-level, role-level higher than tenant-level, tenant-level higher than global. When the
+highest-scoring candidates are tied (two resource-level policies both matching the same tool call),
+the action is blocked. prior research extends this with a staged release model: policies are
+immutable once published, released through `CANARY → ROLLING → ACTIVE` stages, and protected by a
+Two-Key Model requiring separate Legal (what is required) and Engineering (how it is enforced)
+authorship. Translated to lionagi: tenant becomes agent scope, action handler becomes tool call,
+charter becomes the session-binding vehicle.
+
+### Why lionagi needs this
+
+Consider an agent in a governed deployment with role `reviewer`, operating for tenant `acme`, that
+calls a `write_pr` tool. The deployment has four active policies:
+
+- A global default policy that restricts agents to read-only operations.
+- A tenant policy for `acme` that allows reviewers to comment but not merge.
+- A role policy for `reviewer` that blocks direct merges and requires comment evidence.
+- A resource policy for the `write_pr` tool that requires a JIT grant (ADR-0046) before execution.
+
+Without a resolution algorithm, the framework cannot determine which of these four policies governs
+this specific call. It must either apply all of them (combinatorial and potentially contradictory),
+apply the first match (order-dependent and non-deterministic), or deny by default. Only the
+most-specific-wins rule with DENY-on-tie gives the auditable, order-independent answer: the
+resource-level policy `write_pr_requires_jit` governs, because `resource` scope has the highest
+specificity score. The other three policies remain in force for calls they are most-specific for.
+
+## Decision
+
+We introduce `PolicyBundle`, `PolicyScope`, `ScopedPolicy`, `PolicyRelease`, and `PolicyResolver`
+as the policy resolution and lifecycle layer for lionagi. When multiple policies apply to an
+operation, resolution follows most-specific-wins: resource (score 3) > role (score 2) > tenant
+(score 1) > global (score 0). Ties at the top score → DENY (fail-closed). Policy bundles are
+versioned, immutable once published, and released in stages. Sessions pin to a release version at
+start; mid-session policy changes do not apply until the next session.
+
+### 1. `PolicyBundle` — the versioned policy unit
+
+A `PolicyBundle` is the atomic policy artifact. It specifies which gates must run, which models
+and evidence kinds are permitted, scope of tool registry, and session limits. It carries two
+authorship fields implementing the Two-Key Model: `authored_by` (who wrote the policy — the
+"Legal" role) and `implemented_by` (who wrote the enforcement code — the "Engineering" role).
+These must be different actors. A SHA-256 hash over all governance fields enables tamper detection.
+
+```python
+# lionagi/protocols/governance/policy.py
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import ClassVar, Literal
+
+from pydantic import ConfigDict, Field, model_validator
+
+from lionagi.agent.permissions import PermissionPolicy
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+
+
+PolicyDecision = Literal["allow", "deny", "escalate"]
+
+
+class PolicyRuleRef(Element):
+    """Reference to a gate/rule that participates in policy enforcement."""
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    gate_id: str
+    enforcement: Literal["required", "disabled"]
+    justification: str | None = None
+
+
+class PolicyEvidenceRef(Element):
+    """Evidence emitted while resolving or enforcing a policy bundle."""
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    evidence_id: str
+    evidence_kind: str
+    policy_version_active: str
+    metadata_digest: str | None = None
+
+
+class PolicyBundle(Element):
+    """Versioned, immutable unit of policy backed by PermissionPolicy.
+
+    A PolicyBundle specifies the enforcement contract for an operation: which
+    gates must run (ADR-0044), which tool registry scope applies (ADR-0051),
+    which models and evidence kinds are permitted, the PermissionPolicy rules
+    to apply, and optional session limits.
+
+    Two-Key Model:
+        authored_by  — the actor who declared WHAT the policy requires (policy
+                       author / Legal role). Does not write enforcement code.
+        implemented_by — the actor who delivered HOW it is enforced (gate
+                        implementer / Engineering role). Does not decide policy.
+    Neither can produce a valid, active bundle alone.
+
+    hash — SHA-256 of all fields except hash itself. A bundle whose hash does
+    not match its content is rejected before use.
+
+    Attributes:
+        bundle_id:              Unique identifier for this policy bundle.
+        version:                Monotonically increasing integer per bundle_id.
+        permission_policy:      Existing lionagi PermissionPolicy used for the
+                                final allow/deny/escalate decision.
+        rules:                  Pile of PolicyRuleRef gate/rule records. Rules
+                                whose enforcement is "required" replace the old
+                                gates_required list; "disabled" replaces the
+                                old gates_disabled list.
+        registry_scope:         Which tool registry scope applies (ADR-0051).
+        allowed_models:         iModel identifiers permitted under this policy.
+        allowed_evidence_kinds: Subset of the 8 EvidenceRef kinds (ADR-0033)
+                                permitted in evidence emitted under this bundle.
+        max_session_duration_sec: Optional hard cap on session wall time.
+        authored_by:            Identity of the policy author (Two-Key Key 1).
+        implemented_by:         Identity of the gate implementer (Two-Key Key 2).
+        hash:                   SHA-256 over all fields except hash itself.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    bundle_id: str
+    version: int = Field(ge=1)
+    permission_policy: PermissionPolicy = Field(
+        default_factory=PermissionPolicy.deny_all
+    )
+    rules: Pile[PolicyRuleRef] = Field(
+        default_factory=lambda: Pile(item_type=PolicyRuleRef, strict_type=True)
+    )
+    evidence_refs: Pile[PolicyEvidenceRef] = Field(
+        default_factory=lambda: Pile(item_type=PolicyEvidenceRef, strict_type=True)
+    )
+    registry_scope: str           # RegistryScope string; see ADR-0051
+    allowed_models: tuple[str, ...] = ()
+    allowed_evidence_kinds: tuple[str, ...] = ()
+    max_session_duration_sec: int | None = Field(default=None, ge=0)
+    authored_by: str
+    implemented_by: str
+    hash: str = ""
+
+    @model_validator(mode="after")
+    def _validate_two_key_model(self) -> "PolicyBundle":
+        if self.authored_by == self.implemented_by:
+            raise ValueError(
+                f"PolicyBundle '{self.bundle_id}': authored_by and implemented_by "
+                "must be different actors. The Two-Key Model requires separation "
+                "between the policy author (what is required) and the gate "
+                "implementer (how it is enforced). Same actor in both roles "
+                "defeats the control."
+            )
+        return self
+
+    @property
+    def gates_required(self) -> tuple[str, ...]:
+        return tuple(r.gate_id for r in self.rules if r.enforcement == "required")
+
+    @property
+    def gates_disabled(self) -> tuple[str, ...]:
+        return tuple(r.gate_id for r in self.rules if r.enforcement == "disabled")
+
+    def verify_hash(self) -> bool:
+        """Return True if self.hash matches recomputed hash of content fields."""
+        return self.hash == _compute_bundle_hash(self)
+
+
+def _compute_bundle_hash(bundle: PolicyBundle) -> str:
+    """Compute SHA-256 over all ratification-relevant fields.
+
+    Excludes: hash (the field being computed).
+    """
+    content = bundle.to_dict(mode="db", exclude={"hash", "permission_policy"})
+    content["permission_policy"] = {
+        "mode": bundle.permission_policy.mode,
+        "allow": bundle.permission_policy.allow,
+        "deny": bundle.permission_policy.deny,
+        "escalate": bundle.permission_policy.escalate,
+    }
+    serialized = json.dumps(content, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(serialized.encode()).hexdigest()
+```
+
+### 2. `PolicyScope` — specificity scoring
+
+`PolicyScope` encodes where a policy applies and scores its specificity. The scoring follows
+lex specialis: a policy scoped to a specific resource (tool_id) is more specific than one scoped
+to a role, which is more specific than one scoped to a tenant, which is more specific than a
+global default.
+
+```python
+class PolicyScope(Element):
+    """Describes the scope at which a policy applies and its specificity score.
+
+    Specificity scoring (most to least specific):
+        resource  → 3  (applies to a specific tool_id)
+        role      → 2  (applies to agents with a named role)
+        tenant    → 1  (applies to all agents in a tenant)
+        global    → 0  (applies everywhere; baseline default)
+
+    scope_value is the matched identifier:
+        resource:  the tool_id
+        role:      the role name (e.g. "reviewer")
+        tenant:    the tenant_id (e.g. "acme")
+        global:    "*"
+
+    Higher specificity always wins. Ties at the highest specificity → DENY.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    _SPECIFICITY_MAP: ClassVar[dict[str, int]] = {
+        "resource": 3,
+        "role": 2,
+        "tenant": 1,
+        "global": 0,
+    }
+
+    scope_type: Literal["resource", "role", "tenant", "global"]
+    scope_value: str
+    specificity: int = Field(ge=0, le=3)   # resource=3, role=2, tenant=1, global=0
+
+    @model_validator(mode="after")
+    def _validate_specificity(self) -> "PolicyScope":
+        expected = self._SPECIFICITY_MAP[self.scope_type]
+        if self.specificity != expected:
+            raise ValueError(
+                f"PolicyScope scope_type '{self.scope_type}' requires "
+                f"specificity={expected}, got {self.specificity}"
+            )
+        return self
+```
+
+### 3. `ScopedPolicy` — a bundle bound to a scope with a validity window
+
+```python
+class ScopedPolicy(Element):
+    """A PolicyBundle bound to a PolicyScope with a validity window.
+
+    valid_from and valid_until are Unix timestamps. A ScopedPolicy is applicable
+    only when: valid_from <= at < valid_until (or valid_until is None).
+
+    policy_id uniquely identifies this scoped binding. Multiple ScopedPolicies
+    may reference the same PolicyBundle (same bundle_id) with different scopes.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    policy_id: str
+    bundle: PolicyBundle
+    scope: PolicyScope
+    valid_from: float
+    valid_until: float | None = None
+
+    def is_valid_at(self, at: float) -> bool:
+        """Return True if this policy is temporally active at timestamp `at`."""
+        if at < self.valid_from:
+            return False
+        if self.valid_until is not None and at >= self.valid_until:
+            return False
+        return True
+```
+
+### 4. `PolicyResolutionError` — the fail-closed signal
+
+```python
+class PolicyConflict(Element):
+    """Ambiguity record emitted when equally specific policies match."""
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    reason: Literal["no_applicable_policy", "specificity_tie", "hash_mismatch"]
+    conflicting_policies: Pile[ScopedPolicy] = Field(
+        default_factory=lambda: Pile(item_type=ScopedPolicy, strict_type=True)
+    )
+    detail: str
+
+
+class PolicyResolutionResult(Element):
+    """Evidence-grade result of policy resolution for one operation."""
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    operation_ref: str
+    tool_id: str
+    role: str
+    tenant_id: str
+    at: float
+    decision: PolicyDecision
+    selected_policy: ScopedPolicy | None = None
+    bundle: PolicyBundle | None = None
+    candidates: Pile[ScopedPolicy] = Field(
+        default_factory=lambda: Pile(item_type=ScopedPolicy, strict_type=True)
+    )
+    conflicts: Pile[PolicyConflict] = Field(
+        default_factory=lambda: Pile(item_type=PolicyConflict, strict_type=True)
+    )
+    evidence_refs: Pile[PolicyEvidenceRef] = Field(
+        default_factory=lambda: Pile(item_type=PolicyEvidenceRef, strict_type=True)
+    )
+
+    @property
+    def policy_version_active(self) -> str | None:
+        if self.bundle is None:
+            return None
+        return f"{self.bundle.bundle_id}@v{self.bundle.version}"
+
+
+class PolicyResolutionError(PermissionError):
+    """Raised when policy resolution cannot produce an unambiguous result.
+
+    Resolution fails for exactly three reasons:
+        1. No applicable policy exists — no matching scoped policy covers
+           the (tool_id, role, tenant_id, at) tuple.
+        2. The top-scoring candidates are tied — two or more ScopedPolicies
+           at the same (highest) specificity both match.
+        3. Bundle hash verification fails — the selected bundle has been
+           tampered with.
+
+    All three cases result in DENY (fail-closed). Callers MUST NOT proceed
+    with the operation when this exception is raised.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        result: PolicyResolutionResult | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.result = result
+```
+
+### 5. `PolicyResolver` — the resolution algorithm
+
+```python
+class PolicyResolver:
+    """Resolves scoped policies while preserving PermissionPolicy as authority.
+
+    Resolution algorithm (most-specific-wins):
+        1. Collect all ScopedPolicies whose scope matches the operation:
+               - resource match: scope.scope_type == "resource" and
+                 scope.scope_value == tool_id
+               - role match:     scope.scope_type == "role" and
+                 scope.scope_value == role
+               - tenant match:   scope.scope_type == "tenant" and
+                 scope.scope_value == tenant_id
+               - global match:   scope.scope_type == "global"
+           AND is_valid_at(at) == True.
+        2. If no candidates: raise PolicyResolutionError (no policy → deny).
+        3. Sort candidates by scope.specificity descending.
+        4. Identify the maximum specificity score among candidates.
+        5. Collect all candidates at that maximum specificity.
+        6. If more than one: raise PolicyResolutionError (tie → deny).
+        7. Verify winner.bundle.verify_hash(). If False: raise PolicyResolutionError
+           (tampered bundle → deny).
+        8. Delegate the final allow/deny/escalate decision to the selected
+           bundle.permission_policy.check().
+        9. Return a PolicyResolutionResult Element suitable for DataLogger.
+
+    Cross-cutting principle #1: ambiguity at any step → deny.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_policy: PermissionPolicy,
+        policies: Pile[ScopedPolicy] | None = None,
+        release_version: str | None = None,
+    ) -> None:
+        self.base_policy = base_policy
+        self.policies = policies or Pile(item_type=ScopedPolicy, strict_type=True)
+        self.release_version = release_version
+
+    def resolve(
+        self,
+        *,
+        tool_id: str,
+        action: str,
+        args: dict,
+        role: str,
+        tenant_id: str,
+        at: float,
+        operation_ref: str = "",
+    ) -> PolicyResolutionResult:
+        """Return the most-specific applicable result for this operation.
+
+        Args:
+            tool_id:   The identifier of the tool being called.
+            action:    The action string passed to PermissionPolicy.check().
+            args:      Tool arguments passed to PermissionPolicy.check().
+            role:      The calling agent's role.
+            tenant_id: The tenant the agent belongs to.
+            at:        Unix timestamp of the operation (use time.time()).
+
+        Returns:
+            PolicyResolutionResult containing the selected bundle and decision.
+
+        Raises:
+            PolicyResolutionError: If no policy applies, if the top candidates
+                are tied, or if the winning bundle's hash fails verification.
+        """
+        candidates = self._find_applicable(tool_id, role, tenant_id, at)
+
+        if not candidates:
+            result = PolicyResolutionResult(
+                operation_ref=operation_ref,
+                tool_id=tool_id,
+                role=role,
+                tenant_id=tenant_id,
+                at=at,
+                decision="deny",
+            )
+            raise PolicyResolutionError(
+                f"No applicable policy for tool='{tool_id}' role='{role}' "
+                f"tenant='{tenant_id}' at={at:.3f} — fail closed. "
+                "Register at least a global fallback policy.",
+                result=result,
+            )
+
+        ordered = sorted(candidates, key=lambda c: c.scope.specificity, reverse=True)
+        top_score = ordered[0].scope.specificity
+        winners = [c for c in ordered if c.scope.specificity == top_score]
+
+        if len(winners) > 1:
+            ids = ", ".join(w.policy_id for w in winners)
+            conflict = PolicyConflict(
+                reason="specificity_tie",
+                conflicting_policies=Pile(
+                    collections=winners,
+                    item_type=ScopedPolicy,
+                    strict_type=True,
+                ),
+                detail=(
+                    f"{len(winners)} policies tied at specificity={top_score}: {ids}"
+                ),
+            )
+            result = PolicyResolutionResult(
+                operation_ref=operation_ref,
+                tool_id=tool_id,
+                role=role,
+                tenant_id=tenant_id,
+                at=at,
+                decision="deny",
+                candidates=candidates,
+                conflicts=Pile(
+                    collections=[conflict],
+                    item_type=PolicyConflict,
+                    strict_type=True,
+                ),
+            )
+            raise PolicyResolutionError(
+                f"{len(winners)} policies tied at specificity={top_score} "
+                f"for tool='{tool_id}' role='{role}' tenant='{tenant_id}': "
+                f"[{ids}] — fail closed. Disambiguate by adjusting scope or "
+                "superseding one with a more-specific bundle.",
+                result=result,
+            )
+
+        winner = winners[0]
+        if not winner.bundle.verify_hash():
+            conflict = PolicyConflict(
+                reason="hash_mismatch",
+                conflicting_policies=Pile(
+                    collections=[winner],
+                    item_type=ScopedPolicy,
+                    strict_type=True,
+                ),
+                detail=(
+                    f"PolicyBundle '{winner.bundle.bundle_id}' "
+                    f"v{winner.bundle.version} hash verification failed"
+                ),
+            )
+            result = PolicyResolutionResult(
+                operation_ref=operation_ref,
+                tool_id=tool_id,
+                role=role,
+                tenant_id=tenant_id,
+                at=at,
+                decision="deny",
+                selected_policy=winner,
+                bundle=winner.bundle,
+                candidates=candidates,
+                conflicts=Pile(
+                    collections=[conflict],
+                    item_type=PolicyConflict,
+                    strict_type=True,
+                ),
+            )
+            raise PolicyResolutionError(
+                f"PolicyBundle '{winner.bundle.bundle_id}' v{winner.bundle.version} "
+                "hash verification failed — bundle may have been tampered with. "
+                "Reject and investigate before proceeding.",
+                result=result,
+            )
+
+        decision = winner.bundle.permission_policy.check(tool_id, action, args)
+        return PolicyResolutionResult(
+            operation_ref=operation_ref,
+            tool_id=tool_id,
+            role=role,
+            tenant_id=tenant_id,
+            at=at,
+            decision=decision.behavior,
+            selected_policy=winner,
+            bundle=winner.bundle,
+            candidates=candidates,
+        )
+
+    def _find_applicable(
+        self,
+        tool_id: str,
+        role: str,
+        tenant_id: str,
+        at: float,
+    ) -> Pile[ScopedPolicy]:
+        """Return all ScopedPolicies that match the operation context."""
+        matches = []
+        for sp in self.policies:
+            if not sp.is_valid_at(at):
+                continue
+            st = sp.scope.scope_type
+            sv = sp.scope.scope_value
+            if (
+                (st == "resource" and sv == tool_id)
+                or (st == "role" and sv == role)
+                or (st == "tenant" and sv == tenant_id)
+                or st == "global"
+            ):
+                matches.append(sp)
+        return Pile(collections=matches, item_type=ScopedPolicy, strict_type=True)
+
+    def to_pre_hook(self, *, branch=None):
+        """Install through AgentConfig.security_pre or Tool.preprocessor chains."""
+
+        async def policy_resolution_hook(
+            tool_name: str, action: str, args: dict
+        ) -> dict | None:
+            import time
+
+            branch_ref = branch or args.get("branch")
+            role = args.get("role", "default")
+            tenant_id = args.get("tenant_id", "global")
+            result = self.resolve(
+                tool_id=tool_name,
+                action=action,
+                args=args,
+                role=role,
+                tenant_id=tenant_id,
+                at=time.time(),
+                operation_ref=args.get("operation_ref", ""),
+            )
+
+            if branch_ref is not None:
+                # Branch managers are the integration point:
+                # ActionManager supplies the tool registry, iModelManager supplies
+                # active model identity, and DataLogger records the Element result.
+                _ = branch_ref.acts.registry.get(tool_name)
+                model_name = getattr(branch_ref.chat_model, "model", None)
+                if result.bundle and result.bundle.allowed_models:
+                    if model_name not in result.bundle.allowed_models:
+                        raise PermissionError(
+                            f"Model '{model_name}' is not allowed by "
+                            f"{result.policy_version_active}"
+                        )
+                branch_ref.metadata["policy_version_active"] = (
+                    result.policy_version_active
+                )
+                branch_ref._log_manager.log(result)
+
+            if result.decision == "allow":
+                return None
+            if result.decision == "escalate":
+                raise PermissionError(
+                    f"Permission escalation required under "
+                    f"{result.policy_version_active}"
+                )
+            raise PermissionError(
+                f"Permission denied under {result.policy_version_active}"
+            )
+
+        return policy_resolution_hook
+```
+
+### 6. `PolicyRelease` — staged rollout lifecycle
+
+A `PolicyRelease` bundles one or more `ScopedPolicy` records with a version and a status. The
+status lifecycle gates deployment: a release does not affect production sessions until it reaches
+`ACTIVE`. Sessions pin their release version at start; a release transitioning from `ROLLING` to
+`ACTIVE` mid-session does not apply to already-running sessions.
+
+```python
+ReleaseStatus = Literal["DRAFT", "CANARY", "ROLLING", "ACTIVE", "SUPERSEDED"]
+
+
+class PolicyRelease(Element):
+    """A versioned, staged release of a set of ScopedPolicies.
+
+    Status lifecycle:
+        DRAFT     → authored, not yet deployed to any sessions
+        CANARY    → active for <5% of new sessions (opt-in or random sample)
+        ROLLING   → active for a named tenant group (explicit list)
+        ACTIVE    → global default; applies to all new sessions
+        SUPERSEDED → replaced by a newer release; no new sessions pin to this
+
+    Pinning rule: a session records release_version at start. The PolicyResolver
+    for that session is constructed from the bundles in that specific release.
+    Transitions after session start (CANARY → ROLLING, ROLLING → ACTIVE) do not
+    affect already-running sessions.
+
+    Attributes:
+        release_id:       Unique identifier for this release.
+        release_version:  Human-readable version string (e.g. "2026.05.1").
+        status:           Current lifecycle stage.
+        policies:         The ScopedPolicies included in this release.
+        canary_tenant_ids: Tenants opted into CANARY stage (empty = random 5%).
+        rolling_tenant_ids: Tenants in the ROLLING cohort.
+        released_at:      Unix timestamp of transition to CANARY or later.
+        superseded_by:    release_id of the successor, once SUPERSEDED.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    release_id: str
+    release_version: str
+    status: ReleaseStatus
+    policies: Pile[ScopedPolicy] = Field(
+        default_factory=lambda: Pile(item_type=ScopedPolicy, strict_type=True)
+    )
+    canary_tenant_ids: tuple[str, ...]
+    rolling_tenant_ids: tuple[str, ...]
+    released_at: float | None
+    superseded_by: str | None = None
+
+    def resolver_for(
+        self,
+        tenant_id: str,
+        *,
+        base_policy: PermissionPolicy,
+    ) -> PolicyResolver | None:
+        """Return a PolicyResolver if this release applies to tenant_id.
+
+        Returns None if the release is DRAFT or SUPERSEDED, or if the tenant
+        is not yet in scope for the current status (e.g. not in canary cohort
+        when status is CANARY).
+        """
+        if self.status in ("DRAFT", "SUPERSEDED"):
+            return None
+        if self.status == "CANARY":
+            if self.canary_tenant_ids and tenant_id not in self.canary_tenant_ids:
+                return None
+        elif self.status == "ROLLING":
+            if tenant_id not in self.rolling_tenant_ids:
+                return None
+        return PolicyResolver(
+            base_policy=base_policy,
+            policies=self.policies,
+            release_version=self.release_version,
+        )
+```
+
+### 7. Operation Context capture
+
+When `PolicyResolver.resolve()` succeeds, the resolved `bundle_id` and `bundle.version` are
+written into `OperationContext.policy_version_active` (ADR-0050). Every evidence node (ADR-0041)
+emitted during the operation carries this value in its metadata. Auditors can reconstruct the
+exact policy that governed any historical operation by looking up that bundle version in the
+policy store.
+
+```python
+# lionagi/agent/governance/policy.py
+
+from lionagi.agent.config import AgentConfig
+from lionagi.agent.permissions import PermissionPolicy
+from lionagi.session.branch import Branch
+
+
+def attach_policy_release(
+    *,
+    config: AgentConfig,
+    branch: Branch,
+    release: PolicyRelease,
+    tenant_id: str,
+    base_policy: PermissionPolicy,
+) -> PolicyResolver | None:
+    """Attach policy resolution through the existing hook and manager surfaces."""
+    resolver = release.resolver_for(tenant_id, base_policy=base_policy)
+    if resolver is None:
+        return None
+
+    hook = resolver.to_pre_hook(branch=branch)
+    config.hook_handlers.setdefault("security_pre:*", []).insert(0, hook)
+
+    # Existing Branch managers remain authoritative:
+    # - MessageManager carries policy metadata on operation messages.
+    # - ActionManager provides the registered tool set the hook guards.
+    # - iModelManager provides the active model identity checked by the hook.
+    # - DataLogger receives PolicyResolutionResult Element records.
+    branch.metadata["policy_release_version"] = release.release_version
+    branch.metadata["policy_version_active"] = None
+    branch.on_message_added.append(
+        lambda message: message.metadata.setdefault(
+            "policy_release_version", release.release_version
+        )
+    )
+    return resolver
+```
+
+### 8. Resolution algorithm — summary table
+
+| Step | Action | On failure |
+|------|--------|------------|
+| 1 | Collect all ScopedPolicies matching (tool_id, role, tenant_id) with is_valid_at(at) | → step 2 |
+| 2 | If no candidates | → DENY (PolicyResolutionError: "no applicable policy") |
+| 3 | Sort by scope.specificity descending | — |
+| 4 | Identify max specificity score | — |
+| 5 | Collect all candidates at max score | → step 6 |
+| 6 | If more than one winner | → DENY (PolicyResolutionError: "ambiguous tie") |
+| 7 | Verify winner.bundle.verify_hash() | → DENY (PolicyResolutionError: "tampered bundle") |
+| 8 | Return winner.bundle | — |
+
+### 9. Library mode vs. KHive mode
+
+In library mode (open-source lionagi, single-agent, no multi-tenant deployment), policy
+resolution is trivial: the `AgentConfig.permissions` in use constitutes the single applicable
+policy. There is no `PolicyResolver`; the `PermissionPolicy` allowlist/denylist/confirm logic
+continues to apply directly. `OperationContext.policy_version_active` is `None` or a
+config-derived string.
+
+The full `PolicyResolver`, `PolicyRelease`, and staged rollout machinery is KHive territory:
+it becomes necessary when multiple tenants share a deployment and policies must be versioned,
+staged, and audited across organizational boundaries. The protocol (schemas and resolution
+algorithm above) is the same in both modes; the resolver is more sophisticated in KHive.
+
+### 10. Worked example
+
+An agent in `tenant=acme`, `role=reviewer`, calls `tool=write_pr` at Unix timestamp `t`.
+The active `PolicyRelease` contains four `ScopedPolicy` records:
+
+| policy_id | scope_type | scope_value | specificity | bundle_id |
+|-----------|------------|-------------|-------------|-----------|
+| `global-read-only` | global | `*` | 0 | `read_only` |
+| `acme-reviewers-comment` | tenant | `acme` | 1 | `reviewers_can_comment` |
+| `role-reviewer-no-merge` | role | `reviewer` | 2 | `reviewers_can_comment_no_merge` |
+| `tool-write-pr-jit` | resource | `write_pr` | 3 | `write_pr_requires_jit` |
+
+All four match the operation context. Sorted by specificity descending:
+`tool-write-pr-jit` (3), `role-reviewer-no-merge` (2), `acme-reviewers-comment` (1),
+`global-read-only` (0).
+
+Maximum specificity = 3. Only one candidate at that score: `tool-write-pr-jit`. Hash verified.
+
+Resolution result: `write_pr_requires_jit` applies. The gates declared in that bundle run
+(including the JIT grant gate from ADR-0046). `OperationContext.policy_version_active` is set
+to `"write_pr_requires_jit@v3"`. The other three bundles remain authoritative for operations
+they are most-specific for.
+
+### 11. Two-Key Model — enforcement
+
+The structural separation in `PolicyBundle.__post_init__` (`authored_by != implemented_by`) is
+a construction-time check. The policy authorship record is stored in the bundle and covered by
+`bundle.hash`. Any post-creation modification that changes either authorship field or any gate
+list is detectable via `verify_hash()` before the bundle is used.
+
+Operationally, Two-Key means:
+
+- A policy author can declare `gates_required: ["gate_write_pr_approval"]` in a bundle. They
+  cannot ship that gate or modify its logic.
+- A gate implementer can register `gate_write_pr_approval` in the gate registry (ADR-0044).
+  They cannot include or exclude it from a bundle's `gates_required`.
+- A bundle that lists a gate not present in the gate registry is rejected at the same point
+  as a Charter with an unresolvable `gate_id` (ADR-0047, section 4).
+
+## Consequences
+
+**Positive**
+
+- Deterministic resolution: any (tool_id, role, tenant_id, at) tuple resolves to exactly one
+  bundle or raises. Order of policy registration has no effect on the outcome.
+- Fail-closed by construction: every resolution failure path raises `PolicyResolutionError`,
+  which callers must handle. There is no "default permit" fallback.
+- Audit-grade traceability: `OperationContext.policy_version_active` and evidence node metadata
+  record the exact policy bundle in force. Reconstructing governance history requires only the
+  policy store and the operation context.
+- Staged rollback: a bad release transitions from `ACTIVE` to `SUPERSEDED` and a prior release
+  is re-activated. Sessions that pinned to the bad release complete under it (or abort); new
+  sessions pin to the restored release.
+- Two-Key separation: no single actor can produce a valid, deployed bundle that both declares
+  a constraint and ships its enforcement. The hash makes that separation tamper-evident.
+
+**Negative**
+
+- Resolution complexity: operators must reason about scope levels and avoid accidental ties.
+  Two resource-level policies for the same tool_id will always produce a DENY-on-tie until one
+  is superseded or scoped differently.
+- Ambiguity burden is on policy authors: the DENY-on-tie rule is conservative. Legitimate
+  scenarios that happen to tie require explicit disambiguation, which may require a release cycle.
+- Multiple active versions: during CANARY and ROLLING stages, different tenants run against
+  different policy versions. The policy store and audit tooling must support querying by
+  bundle version, not just by current state.
+- Two-Key coordination overhead: policy authors and gate implementers must coordinate each
+  release. A bundle referencing a gate not yet registered blocks the release from advancing
+  past DRAFT.
+
+## Non-Goals
+
+Explicitly out of scope:
+
+- **Full conflict resolution with weights or priorities**: only specificity rank determines the
+  winner. Weighted scoring, confidence-adjusted merging, or partial policy application are not
+  supported. If weights are needed, supersede the lower-specificity policy with a new bundle
+  at a higher specificity scope.
+- **Automatic policy generation from regulations**: tooling that reads GDPR or HIPAA text and
+  produces `PolicyBundle` records is a product concern, not a framework concern.
+- **Cross-tenant policy inheritance**: a policy defined at the global level that automatically
+  specializes for each tenant. This is a KHive concern addressed in the multi-tenant resolver
+  layer. The open-source framework has no tenant hierarchy.
+- **Runtime policy mutation**: a running session cannot modify its own policy. All changes must
+  go through the release lifecycle (DRAFT → CANARY → ROLLING → ACTIVE) and apply only to
+  sessions starting after the release reaches the applicable stage.
+- **Policy composition or merging**: combining two bundles' `gates_required` lists into a
+  synthetic bundle is not supported. Each bundle is the atomic governance unit; composition
+  would re-introduce the conflict resolution problem this ADR solves.
+- **Automatic release promotion**: advancing a release from CANARY to ROLLING to ACTIVE requires
+  explicit human action (or an external approval gate). Automated promotion based on error rates
+  is a deployment platform concern, not a framework concern.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| First-match wins | Resolution depends on registration order. Two deployments with identically scoped policies but different registration sequences produce different results. Non-deterministic; not audit-defensible. |
+| Confidence-weighted merging | Assigns weights to each applicable policy and blends the result. Introduces a scoring function that is itself a policy decision, is difficult to audit, and violates the fail-closed principle — partial application of a policy that would deny is effectively a permit. |
+| Single global policy (current state) | `AgentConfig.permissions` is a single flat policy per agent with no versioning and no scope hierarchy. Adequate for library mode; rejected for multi-agent, multi-tenant deployments where role and resource overrides are required. |
+| Most-specific-wins with permit-on-tie | The alternative to DENY-on-tie. Rejected because a tie indicates two equally-authoritative policies disagree. Picking one arbitrarily is non-deterministic. Denying forces policy authors to resolve the ambiguity explicitly, which is the correct outcome. |
+
+## References
+
+- [ADR-0041](ADR-0041-immutable-evidence-nodes.md) — SHA-256 hash-chain pattern; `PolicyBundle.hash` follows the same construction
+- [ADR-0042](ADR-0042-task-certificate.md) — Task Certificate records the active policy version as part of the proof artifact
+- [ADR-0044](ADR-0044-tool-gates.md) — `PolicyBundle.gates_required` references gate_ids from this registry; a bundle listing an absent gate is rejected
+- [ADR-0045](ADR-0045-break-glass-protocol.md) — break-glass sessions resolve against a named policy bundle for DEGRADED defensibility
+- [ADR-0046](ADR-0046-jit-tool-grant.md) — JIT grant gates appear in `PolicyBundle.gates_required`; the worked example shows `write_pr_requires_jit`
+- [ADR-0047](ADR-0047-agent-charter.md) — `AgentCharter.policy_release_version` pins the charter to a specific release; the charter is the session-binding vehicle
+- [ADR-0050](ADR-0050-operation-context.md) — `OperationContext.policy_version_active` records the resolved bundle; evidence nodes carry this field
+- [ADR-0051](ADR-0051-tool-registry-allowlists.md) — `PolicyBundle.registry_scope` selects which tool registry scope governs tool access
+- [ADR-0033](ADR-0033-unified-entity-state-model.md) — EvidenceRef 8 kinds; `PolicyBundle.allowed_evidence_kinds` is a subset of these
+- `lionagi/agent/config.py` — `AgentConfig` and `PermissionPolicy`; library-mode policy remains here
+- prior governance research `01_design/011-policy-resolution/ADR-011-policy-resolution.md` — lex specialis, deny-by-default, resource > role > tenant hierarchy
+- prior governance research `01_design/017-policy-release/ADR-017-policy-release.md` — staged rollout (CANARY → TENANT_GROUP → GLOBAL), Two-Key Model, immutable releases

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,13 +1,16 @@
 # Architecture Decision Records
 
 ADRs capture significant decisions that affect lionagi's public API, dependencies, architecture
-layout, distribution model, or process patterns that future contributors should follow.
+layout, or distribution model, or process patterns that future contributors should follow.
+
+New readers should start with [reader's-guide.md](reader's-guide.md) for a navigated entry point
+into the ADR set.
 
 ## Naming and Location
 
 Files live in `docs/adrs/` and follow the pattern:
 
-```
+```text
 ADR-NNNN-kebab-case-slug.md
 ```
 
@@ -15,7 +18,7 @@ ADR-NNNN-kebab-case-slug.md
 
 ## Lifecycle
 
-```
+```text
 Proposed → Accepted → Superseded (→ Deprecated, optional)
 ```
 
@@ -50,25 +53,60 @@ Example: `_Supersedes [ADR-0001](ADR-0001-lion-studio-internal-app.md)._`
 
 ## Index
 
+### Foundation (0001–0010): Studio architecture, tech stack, data layer
+
 | ADR | Title | Status |
 |-----|-------|--------|
-| [ADR-0001](ADR-0001-lion-studio-internal-app.md) | Lion Studio as internal monorepo app | Accepted |
-| [ADR-0002](ADR-0002-studio-tech-stack.md) | Lion Studio tech stack | Accepted |
-| [ADR-0003](ADR-0003-claude-code-marketplace.md) | Claude Code marketplace | Amended (v2 catalog) |
-| [ADR-0004](ADR-0004-filesystem-data-layer.md) | Data layer — filesystem + SQLite hybrid | Accepted |
-| [ADR-0005](ADR-0005-workers-playbooks-rename.md) | Playbooks naming convention | Accepted |
-| [ADR-0006](ADR-0006-sse-live-streaming.md) | Live update transport — SSE + interval refresh | Accepted |
-| [ADR-0007](ADR-0007-plugin-auto-discovery.md) | Plugin manifest auto-discovery convention | Accepted |
-| [ADR-0008](ADR-0008-studio-v1-scope.md) | Studio scope — CLI-primary, definition-editable, localhost | Accepted |
-| [ADR-0009](ADR-0009-sqlite-state-layer.md) | SQLite state layer for core data model | Accepted |
-| [ADR-0010](ADR-0010-plugin-aware-studio.md) | Plugin-aware Studio UI | Accepted |
-| [ADR-0011](ADR-0011-shows-data-model.md) | Shows data model — hybrid SQLite + filesystem | Accepted |
-| [ADR-0012](ADR-0012-studio-execution-lineage.md) | Studio execution lineage and UX redesign | Accepted |
-| [ADR-0013](ADR-0013-zero-dependency-ui.md) | Zero component-library UI | Accepted |
-| [ADR-0014](ADR-0014-cli-primary-studio-secondary.md) | CLI-primary, Studio-secondary | Accepted |
-| [ADR-0015](ADR-0015-runs-list-design.md) | Runs list design — identity, filters, pagination | Accepted |
-| [ADR-0016](ADR-0016-definitions-write-path.md) | Definition write path and versioning | Accepted |
-| [ADR-0017](ADR-0017-session-lifecycle-status.md) | Session lifecycle and status derivation | Accepted |
-| [ADR-0018](ADR-0018-studio-distribution.md) | Studio distribution and local access | Accepted |
+| [ADR-0001](ADR-0001-lion-studio-internal-app.md) | Lion Studio as an internal monorepo app, not a separate repo | Accepted |
+| [ADR-0002](ADR-0002-studio-tech-stack.md) | Lion Studio tech stack (Next.js, FastAPI, SQLite) | Accepted |
+| [ADR-0003](ADR-0003-claude-code-marketplace.md) | Claude Code marketplace integration and v2 catalog design | Amended (v2 catalog) |
+| [ADR-0004](ADR-0004-filesystem-data-layer.md) | Filesystem + SQLite hybrid as the primary data layer | Accepted |
+| [ADR-0005](ADR-0005-workers-playbooks-rename.md) | Rename "workers/playbooks" to the canonical "skills" vocabulary | Accepted |
+| [ADR-0006](ADR-0006-sse-live-streaming.md) | SSE + interval refresh as the live-update transport | Accepted |
+| [ADR-0007](ADR-0007-plugin-auto-discovery.md) | Plugin manifest auto-discovery convention and resolution rules | Accepted |
+| [ADR-0008](ADR-0008-studio-v1-scope.md) | Studio v1 scope: CLI-primary, definition-editable, localhost-only | Accepted |
+| [ADR-0009](ADR-0009-sqlite-state-layer.md) | SQLite as the authoritative state layer for core runtime data | Accepted |
+| [ADR-0010](ADR-0010-plugin-aware-studio.md) | Plugin-aware Studio UI with per-plugin route registration | Accepted |
+
+### Operational primitives (0011–0023): shows, teams, hooks, lineage
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [ADR-0011](ADR-0011-shows-data-model.md) | Shows data model: hybrid SQLite metadata + filesystem artifacts | Accepted |
+| [ADR-0012](ADR-0012-studio-execution-lineage.md) | Studio execution lineage tree and UX redesign | Accepted |
+| [ADR-0013](ADR-0013-zero-dependency-ui.md) | Zero component-library UI (hand-rolled Tailwind only) | Superseded by [ADR-0035](ADR-0035-design-system-and-component-library.md) |
+| [ADR-0014](ADR-0014-cli-primary-studio-secondary.md) | CLI is the primary interface; Studio is a secondary observer | Accepted |
+| [ADR-0015](ADR-0015-runs-list-design.md) | Runs list design: identity columns, filters, and pagination | Accepted |
+| [ADR-0016](ADR-0016-definitions-write-path.md) | Definition write path, versioning, and rollback semantics | Accepted |
+| [ADR-0017](ADR-0017-session-lifecycle-status.md) | Session lifecycle and status derivation rules | Partially superseded by [ADR-0033](ADR-0033-unified-entity-state-model.md) |
+| [ADR-0018](ADR-0018-studio-distribution.md) | Studio distribution model and local-access packaging | Accepted |
+| [ADR-0019](ADR-0019-teams-db-and-run-lifecycle.md) | Teams DB schema and per-run lifecycle state machine | Accepted |
+| [ADR-0020](ADR-0020-skill-invocations.md) | Skill invocation contract: request/response envelope and routing | Accepted |
+| [ADR-0021](ADR-0021-skill-artifacts-and-reactive-chaining.md) | Skill artifact model and reactive chaining between skills | Accepted |
+| [ADR-0022](ADR-0022-run-step-provenance.md) | Run-step provenance: linking output artifacts back to source steps | Accepted |
+| [ADR-0023](ADR-0023-unified-hook-system.md) | Unified hook system for pre/post tool-call interception | Accepted |
+
+### State refinement (0024–0032): health, vocab, reasons, attention, navigation
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [ADR-0024](ADR-0024-session-health-and-admin-surface.md) | Session health signals and admin surface for operator visibility | Extended by [ADR-0033](ADR-0033-unified-entity-state-model.md) |
+| [ADR-0025](ADR-0025-session-status-vocabulary.md) | Session status vocabulary (running, completed, failed, …) | Superseded by [ADR-0033](ADR-0033-unified-entity-state-model.md) |
+| [ADR-0026](ADR-0026-project-detection.md) | Project detection cascade for CLI session context | Accepted |
+| [ADR-0027](ADR-0027-scheduled-runs.md) | Scheduled runs: cron/interval triggers and missed-fire policy | Accepted |
+| [ADR-0028](ADR-0028-status-reason-model.md) | Status reason model: attaching structured reasons to state transitions | Extended by [ADR-0033](ADR-0033-unified-entity-state-model.md) |
+| [ADR-0029](ADR-0029-artifact-contract.md) | Artifact contract: storage, MIME types, and lifecycle guarantees | Extended by [ADR-0033](ADR-0033-unified-entity-state-model.md) |
+| [ADR-0030](ADR-0030-attention-queue.md) | Attention queue: surfacing entities that need operator action | Extended by [ADR-0033](ADR-0033-unified-entity-state-model.md) / [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) |
+| [ADR-0031](ADR-0031-entity-header-pattern.md) | Entity header pattern: canonical top-of-page summary block | Accepted |
+| [ADR-0032](ADR-0032-navigation-reorganization.md) | Navigation reorganization: sidebar hierarchy and route ownership | Accepted |
+
+### KHive product evolution (0033–0035, 0039): unified state, frontend, components, knowledge
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [ADR-0033](ADR-0033-unified-entity-state-model.md) | Unified Entity State Model: single authoritative state semantic across all entity types | Accepted |
+| [ADR-0034](ADR-0034-frontend-data-and-state-architecture.md) | Frontend data and state architecture: TanStack Query, SSE, and URL-as-state | Accepted |
+| [ADR-0035](ADR-0035-design-system-and-component-library.md) | Design system and component library: shadcn/ui + Radix primitives | Accepted |
+| [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) | Knowledge substrate minimal interface: claims with evidence | Accepted |
 
 See also [Decision Log](DECISION_LOG.md) for lightweight decisions that don't warrant a full ADR.

--- a/docs/adrs/glossary.md
+++ b/docs/adrs/glossary.md
@@ -1,0 +1,233 @@
+# ADR Glossary
+
+Alphabetized reference for key terms used across the ADR set. Each entry gives a concise
+definition and a pointer to the ADR that introduced or canonically defines the term.
+
+---
+
+**aborted** — A terminal lifecycle state indicating the run or session was stopped by the system
+rather than by user request, typically due to an unrecoverable internal error. Distinct from
+`cancelled` (user-initiated). Canonical: [ADR-0033](ADR-0033-unified-entity-state-model.md).
+
+**Artifact** — A stored output produced during a run or skill invocation: a file, a structured
+JSON blob, a log chunk, or any other addressable payload. Artifacts have MIME types, lifecycle
+states, and optionally serve as evidence for state reasons. Canonical:
+[ADR-0029](ADR-0029-artifact-contract.md).
+
+**Attention Queue** — The ordered list of entities that require operator action, derived from
+unresolved state reasons, stale evidence, or explicit escalation signals. Extended by knowledge
+claims in ADR-0039. Canonical: [ADR-0030](ADR-0030-attention-queue.md).
+
+**blocked** — A lifecycle state indicating the entity is waiting for an external dependency before
+it can continue. The blocking reason must be recorded as a `StateReason`. Canonical:
+[ADR-0033](ADR-0033-unified-entity-state-model.md).
+
+**Branch** — A single conversation thread managed by `MessageManager`, `ActionManager`,
+`iModelManager`, and `DataLogger`. Branches are the primary unit of LLM interaction and are
+owned by a Session. Canonical: [ADR-0017](ADR-0017-session-lifecycle-status.md) / CLAUDE.md.
+
+**cancelled** — A terminal lifecycle state indicating a run or session was stopped by deliberate
+user or operator action before completing normally. Canonical:
+[ADR-0033](ADR-0033-unified-entity-state-model.md).
+
+**Claim** — The fundamental unit of the knowledge substrate: a statement with an associated
+`claim_status`, a `confidence` score, a `scope_type`, and one or more evidence references.
+Claims are the currency of [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md). Canonical:
+[ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md).
+
+**claim_status** — The lifecycle state of a claim: `proposed`, `supported`, `contested`,
+`withdrawn`, or `superseded`. Tracks how confidence has evolved based on evidence. Canonical:
+[ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md).
+
+**Claim Card** — The frontend component that renders a single claim with its evidence chain,
+confidence meter, and action affordances (support, contest, withdraw). Canonical:
+[ADR-0035](ADR-0035-design-system-and-component-library.md).
+
+**completed** — A terminal lifecycle state indicating a run, session, or step finished successfully
+with all expected outputs produced. Canonical: [ADR-0033](ADR-0033-unified-entity-state-model.md).
+
+**compat layer** — The thin adapter in the frontend that translates legacy `status` string fields
+from older API responses into the `NormalizedState` shape expected by current components, enabling
+incremental backend migration. Canonical:
+[ADR-0034](ADR-0034-frontend-data-and-state-architecture.md).
+
+**confidence** — A numeric score in [0, 1] attached to a Claim, reflecting the system's or
+operator's current belief in the claim given available evidence. Not a probability in the strict
+sense; it is a convenience signal for prioritisation. Canonical:
+[ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md).
+
+**critical** — The highest severity value in the severity enum. A `critical` state reason requires
+immediate operator attention and typically blocks downstream progress. Canonical:
+[ADR-0033](ADR-0033-unified-entity-state-model.md).
+
+**danger** — The frontend tone value corresponding to an error or critical condition. Maps to red
+styling in the design system. Distinct from the backend `severity` axis. Canonical:
+[ADR-0035](ADR-0035-design-system-and-component-library.md).
+
+**delivery** — One of the three state axes in the Unified Entity State Model, alongside `lifecycle`
+and `health`. Delivery tracks whether the entity's output has reached its intended consumer
+(e.g., `pending`, `delivered`, `acknowledged`). Canonical:
+[ADR-0033](ADR-0033-unified-entity-state-model.md).
+
+**Domain Component** — A React component in the design system that composes primitives to
+represent a specific product domain object (Run card, Session header, Claim card). Domain
+components own the mapping from `NormalizedState` to visual representation. Canonical:
+[ADR-0035](ADR-0035-design-system-and-component-library.md).
+
+**due** — A health state indicating a scheduled entity has reached its trigger time and is
+awaiting dispatch. Distinct from `misfired` (trigger time passed without dispatch). Canonical:
+[ADR-0027](ADR-0027-scheduled-runs.md) / [ADR-0033](ADR-0033-unified-entity-state-model.md).
+
+**EvidenceRef** — A typed pointer to an artifact, external URL, or inline payload that substantiates
+a `StateReason` or a `Claim`. Evidence references carry a `kind` field (e.g., `log`, `metric`,
+`human_assertion`, `automated_check`). Canonical:
+[ADR-0033](ADR-0033-unified-entity-state-model.md) / [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md).
+
+**failed** — A terminal lifecycle state indicating a run, step, or operation ended in error before
+producing expected outputs. The failure reason must be recorded as a `StateReason`. Canonical:
+[ADR-0033](ADR-0033-unified-entity-state-model.md).
+
+**freshness budget** — The maximum age (in seconds or polling intervals) a frontend cache entry
+is considered valid before TanStack Query should re-fetch from the server. Defined per entity type
+in the data architecture. Canonical: [ADR-0034](ADR-0034-frontend-data-and-state-architecture.md).
+
+**health** — One of the three state axes in the Unified Entity State Model. Health reflects the
+operational condition of a live entity — whether it is responding normally, stalled, or dead —
+independent of its lifecycle position. Canonical:
+[ADR-0033](ADR-0033-unified-entity-state-model.md).
+
+**idle** — A health state indicating the entity is alive but has produced no activity within the
+expected window. Does not imply failure; may precede stalling. Canonical:
+[ADR-0033](ADR-0033-unified-entity-state-model.md).
+
+**info** — A severity value indicating an informational state reason that requires no immediate
+action. Also a tone value in the frontend design system (maps to blue). Canonical:
+[ADR-0033](ADR-0033-unified-entity-state-model.md) / [ADR-0035](ADR-0035-design-system-and-component-library.md).
+
+**Invocation** — A single execution of a skill or tool, with a bounded input/output envelope. An
+invocation is a first-class entity with its own lifecycle, provenance linkage, and artifact
+outputs. Canonical: [ADR-0020](ADR-0020-skill-invocations.md).
+
+**KnowledgeStore** — The backend component that persists Claims, EvidenceRefs, and their
+relationships. Implements the minimal interface defined by ADR-0039 without prescribing a specific
+storage backend. Canonical: [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md).
+
+**Knowledge Lens** — A frontend view mode that renders an entity through the lens of its
+associated claims and evidence, rather than the standard operational timeline. Defined in the
+design system as a composable panel. Canonical:
+[ADR-0035](ADR-0035-design-system-and-component-library.md).
+
+**lifecycle** — One of the three state axes in the Unified Entity State Model. Lifecycle tracks
+the position of an entity within its state machine (e.g., `running`, `completed`, `failed`).
+Canonical: [ADR-0033](ADR-0033-unified-entity-state-model.md).
+
+**merged** — A terminal lifecycle state used for branches and worktrees: the entity's changes
+have been incorporated into the target and the entity itself is no longer active. Canonical:
+[ADR-0033](ADR-0033-unified-entity-state-model.md).
+
+**misfired** — A health state for scheduled entities indicating the trigger time passed but the
+run was not dispatched (e.g., due to a system outage). Requires operator triage. Canonical:
+[ADR-0027](ADR-0027-scheduled-runs.md).
+
+**neutral** — A severity or tone value indicating no signal in either direction. Used for informational
+display that should not draw the eye. Canonical:
+[ADR-0033](ADR-0033-unified-entity-state-model.md) / [ADR-0035](ADR-0035-design-system-and-component-library.md).
+
+**NormalizedState** — The canonical frontend shape that all entity-fetching hooks must return,
+containing `lifecycle`, `health`, `delivery`, `severity`, `tone`, and `reasons` fields. Components
+only consume `NormalizedState`; they never read raw `status` strings. Canonical:
+[ADR-0034](ADR-0034-frontend-data-and-state-architecture.md).
+
+**ok** — The baseline health state: the entity is alive and behaving within expected parameters.
+Canonical: [ADR-0033](ADR-0033-unified-entity-state-model.md).
+
+**orphaned** — A health state indicating the entity's parent context (session, team, or project)
+no longer exists, leaving the entity without a valid owner. Canonical:
+[ADR-0033](ADR-0033-unified-entity-state-model.md).
+
+**outcome** — One of the three state axes in some earlier ADRs; consolidated into `delivery` and
+`lifecycle` in the unified model. Retained as a legacy field in some API responses via the compat
+layer. Canonical: [ADR-0033](ADR-0033-unified-entity-state-model.md).
+
+**Play** — A single execution episode within a Show: one scheduled or triggered invocation of a
+playbook, with its own run lineage. Canonical: [ADR-0011](ADR-0011-shows-data-model.md).
+
+**Primitive** — A low-level, stateless UI component in the design system (Button, Badge, Icon,
+Skeleton) that encodes only structural and typographic concerns, not domain semantics. Canonical:
+[ADR-0035](ADR-0035-design-system-and-component-library.md).
+
+**process_dead** — A health state indicating the underlying process (OS process, container, or
+async task) has exited unexpectedly while the entity's lifecycle state still shows `running`.
+Canonical: [ADR-0033](ADR-0033-unified-entity-state-model.md).
+
+**Project** — The context container resolved by the CLI project detection cascade: a name and
+source (git root, explicit config, environment variable, or default fallback) that scopes sessions
+and runs. Canonical: [ADR-0026](ADR-0026-project-detection.md).
+
+**Run** — A discrete execution unit: one invocation of `li agent` or a flow pipeline that produces
+a timestamped directory under `~/.lionagi/runs/`. Runs have their own lifecycle, step provenance,
+and artifact outputs. Canonical: [ADR-0015](ADR-0015-runs-list-design.md) /
+[ADR-0022](ADR-0022-run-step-provenance.md).
+
+**running** — The active, non-terminal lifecycle state. An entity in this state is currently
+executing and has not reached a terminal outcome. Canonical:
+[ADR-0033](ADR-0033-unified-entity-state-model.md).
+
+**Schedule** — A trigger definition (cron expression or interval) that creates Runs automatically.
+Schedules have their own health states (`due`, `misfired`) separate from the Runs they produce.
+Canonical: [ADR-0027](ADR-0027-scheduled-runs.md).
+
+**scope_type** — The domain boundary within which a Claim is asserted to hold: e.g., `global`,
+`project`, `session`, or `run`. Claims with narrower scopes do not conflict with broader-scope
+claims on the same subject. Canonical:
+[ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md).
+
+**Session** — The persistent container for a multi-turn agent conversation: owns one or more
+Branches, a DataLogger, and a project association. Sessions survive process restarts and are
+stored in SQLite. Canonical: [ADR-0017](ADR-0017-session-lifecycle-status.md).
+
+**severity** — The urgency axis on a `StateReason`: `critical`, `warning`, `info`, or `neutral`.
+Controls prioritisation in the attention queue and inbox. Canonical:
+[ADR-0033](ADR-0033-unified-entity-state-model.md).
+
+**Show** — A named, persistent display surface that aggregates multiple Plays over time. Shows
+are defined as playbook schedules with their own configuration and artifact history. Canonical:
+[ADR-0011](ADR-0011-shows-data-model.md).
+
+**stalled** — A health state more severe than `idle`: the entity has exceeded the expected activity
+window by a significant margin and likely requires intervention. Canonical:
+[ADR-0033](ADR-0033-unified-entity-state-model.md).
+
+**StateReason** — A structured annotation on a state transition: a machine-readable `code`, a
+human-readable `message`, a `severity`, and an optional list of `EvidenceRef`s. StateReasons make
+transitions auditable. Canonical: [ADR-0028](ADR-0028-status-reason-model.md) /
+[ADR-0033](ADR-0033-unified-entity-state-model.md).
+
+**success** — A tone value in the frontend design system indicating a positive outcome. Maps to
+green styling. Not a lifecycle state; use `completed` for lifecycle. Canonical:
+[ADR-0035](ADR-0035-design-system-and-component-library.md).
+
+**sync contract** — The agreement between the backend SSE stream and the TanStack Query cache: what
+events invalidate which cache keys, and at what granularity the frontend re-fetches. Defined in
+the frontend data architecture. Canonical:
+[ADR-0034](ADR-0034-frontend-data-and-state-architecture.md).
+
+**Team** — A named group of concurrent agent workers that share an inbox and coordinate via
+`fcntl.flock`-protected JSON state. Teams are the unit of parallel fan-out for `li team`.
+Canonical: [ADR-0019](ADR-0019-teams-db-and-run-lifecycle.md).
+
+**timed_out** — A terminal lifecycle state indicating the entity exceeded its allowed execution
+window and was forcibly terminated by the scheduler or watchdog. Canonical:
+[ADR-0033](ADR-0033-unified-entity-state-model.md).
+
+**tone** — The visual signal axis: `danger`, `warning`, `info`, `success`, or `neutral`. Tone is
+a frontend concern derived from `severity` and `lifecycle`; it is the input to the design system's
+color and icon tokens. Canonical: [ADR-0035](ADR-0035-design-system-and-component-library.md).
+
+**URL-as-state** — The convention that navigation state (selected entity, active filter, open
+panels) is encoded in the URL rather than component-local React state, enabling deep-linking and
+back-button correctness. Canonical: [ADR-0034](ADR-0034-frontend-data-and-state-architecture.md).
+
+**warning** — A severity value indicating a condition that may require attention but does not yet
+block progress. Also a tone value in the frontend (maps to amber). Canonical:
+[ADR-0033](ADR-0033-unified-entity-state-model.md) / [ADR-0035](ADR-0035-design-system-and-component-library.md).

--- a/docs/adrs/reader's-guide.md
+++ b/docs/adrs/reader's-guide.md
@@ -1,0 +1,124 @@
+# ADR Reader's Guide
+
+> A map for navigating the ADR set. Read this first.
+
+## What is this directory?
+
+Each file here is an Architecture Decision Record — a short document that captures a significant
+design choice, the context that forced it, the alternatives considered, and the consequences
+accepted. ADRs are the authoritative record of why the system looks the way it does. They are
+not design proposals or tutorials; they are binding decisions that have already been made and are
+in effect unless marked Superseded.
+
+## Where to start: by your role
+
+### If you're new to Lion Studio / KHive
+
+Read in this order to build a mental model of the system from the ground up:
+
+1. [ADR-0001](ADR-0001-lion-studio-internal-app.md) — why Studio lives inside the monorepo
+2. [ADR-0002](ADR-0002-studio-tech-stack.md) — the technology choices (Next.js, FastAPI, SQLite)
+3. [ADR-0009](ADR-0009-sqlite-state-layer.md) — why SQLite is the authoritative runtime store
+4. [ADR-0014](ADR-0014-cli-primary-studio-secondary.md) — the CLI/Studio relationship; Studio observes, CLI drives
+5. [ADR-0033](ADR-0033-unified-entity-state-model.md) — the current unified state model that governs all entity types
+
+### If you're working on backend state semantics
+
+Start with the foundation, then follow the refinement chain:
+
+1. [ADR-0033](ADR-0033-unified-entity-state-model.md) — the unified state model (read this first; it consolidates and supersedes several predecessors)
+2. [ADR-0028](ADR-0028-status-reason-model.md) — how reasons attach to state transitions
+3. [ADR-0029](ADR-0029-artifact-contract.md) — the artifact lifecycle and its tie-in to state
+4. [ADR-0024](ADR-0024-session-health-and-admin-surface.md) — health signals that derive from entity state
+5. [ADR-0017](ADR-0017-session-lifecycle-status.md) — the original session lifecycle (partially superseded; read for history)
+
+### If you're working on frontend
+
+1. [ADR-0034](ADR-0034-frontend-data-and-state-architecture.md) — TanStack Query, SSE subscription, and URL-as-state contract
+2. [ADR-0035](ADR-0035-design-system-and-component-library.md) — the component library decision (shadcn/Radix; supersedes ADR-0013)
+3. [ADR-0033](ADR-0033-unified-entity-state-model.md) — the NormalizedState shape that all frontend components consume
+4. [ADR-0031](ADR-0031-entity-header-pattern.md) — the entity header block used on every detail page
+5. [ADR-0032](ADR-0032-navigation-reorganization.md) — sidebar hierarchy and route ownership
+
+### If you're working on knowledge / evidence
+
+1. [ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) — the minimal claims-with-evidence interface
+2. [ADR-0033](ADR-0033-unified-entity-state-model.md) — how knowledge entities participate in the unified state model
+3. [ADR-0029](ADR-0029-artifact-contract.md) — artifact storage, which is how evidence payloads are stored
+4. [ADR-0030](ADR-0030-attention-queue.md) — how claims surface in the attention queue when they need review
+
+### If you're working on the data layer
+
+1. [ADR-0009](ADR-0009-sqlite-state-layer.md) — SQLite as the canonical state store
+2. [ADR-0033](ADR-0033-unified-entity-state-model.md) — the schema contract all tables must conform to
+3. [ADR-0011](ADR-0011-shows-data-model.md) — the shows model (SQLite metadata + filesystem artifacts hybrid)
+4. [ADR-0019](ADR-0019-teams-db-and-run-lifecycle.md) — teams DB schema and per-run lifecycle
+5. [ADR-0004](ADR-0004-filesystem-data-layer.md) — the original filesystem + SQLite layering decision
+
+## How to read an ADR
+
+Each ADR follows the same canonical structure. Here is what to look for in each section:
+
+- **Context**: The situation that forced a decision. Read this to understand what constraints
+  existed at the time — some may no longer apply, but they explain why the decision took the shape
+  it did.
+- **Decision**: The choice made. This is the binding commitment. If you are implementing something
+  in this area, the Decision section is what you must honour.
+- **Consequences**: What the decision enables, what it forecloses, and what technical debt it
+  accepts. The negative consequences are as important as the positive ones.
+- **Alternatives considered**: The options that were evaluated and rejected, with the reasons. Read
+  this before proposing a change — the rejected alternatives have usually been tried or thought
+  through already.
+
+## Cross-reference legend
+
+ADR files use a small set of relationship headers to connect decisions:
+
+- **Supersedes**: The referenced ADR is no longer in effect for the domain covered here. The old
+  ADR is retained for history but should not be followed as current policy.
+- **Extends**: The referenced ADR remains in effect; this ADR adds new rules on top of it without
+  replacing any of the original decisions.
+- **Related**: The referenced ADR covers overlapping ground without a strict supersession or
+  extension relationship. Read both to understand the full picture.
+- **Depends on**: This ADR's decision only makes sense given the referenced ADR's decision. If the
+  dependency is ever reconsidered, this ADR must be revisited.
+
+The [README.md](README.md) index notes these relationships inline next to each entry.
+
+## The evidence chain (the unifying principle)
+
+Starting with [ADR-0028](ADR-0028-status-reason-model.md) and consolidated in
+[ADR-0033](ADR-0033-unified-entity-state-model.md), a single principle runs through the newer
+ADRs: every state transition must carry a structured reason, and every reason that is non-trivial
+must carry evidence.
+
+This chain looks like: an entity moves to a new lifecycle state → the transition records a
+`StateReason` (machine-readable code + human-readable message) → where the reason is based on an
+observation, it links to an `EvidenceRef` (a stored artifact or an external claim) →
+[ADR-0039](ADR-0039-knowledge-substrate-minimal-interface.md) generalises this pattern into the
+knowledge substrate, where claims carry confidence scores and evidence kinds independently of
+whether they are attached to a state transition.
+
+The attention queue ([ADR-0030](ADR-0030-attention-queue.md)) is the operational surface of this
+chain: entities whose reasons are unresolved or whose evidence is stale surface as items requiring
+operator action.
+
+Understanding this chain is the fastest route to understanding why the newer ADRs look the way
+they do. It is not just an audit trail — it is the mechanism by which the system makes its own
+state legible to both humans and downstream agents.
+
+## When to write a new ADR
+
+Write a new ADR when:
+
+- You are changing a public API surface, CLI flag, or schema contract that other code or humans
+  depend on.
+- You are introducing a new architectural boundary — a new top-level module, a new persistence
+  layer, a new transport — that future implementers will need to understand.
+- You are rejecting an apparently obvious approach in favour of a less obvious one; the reasoning
+  needs to survive the next contributor's first instinct.
+- You are making a decision that, if made differently later, would require significant migration
+  work — record the cost of reversal explicitly.
+
+Do not write an ADR for internal implementation choices that have no observable effect on
+public contracts, or for dependency version bumps unless they change a major boundary.

--- a/lionagi/cli/cleanup.py
+++ b/lionagi/cli/cleanup.py
@@ -1,0 +1,455 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""`li state cleanup` — remove stale lionagi state files.
+
+Cleans up expired run directories, orphaned team JSON files, and old log
+files.  All operations are non-destructive by default: pass ``--dry-run``
+to preview what would be removed.
+
+Subcommand registered by :func:`add_cleanup_subcommand`.  Invoked via
+:func:`run_cleanup`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import time
+from pathlib import Path
+
+from ._logging import hint, log_error, progress, warn
+
+# ── constants ──────────────────────────────────────────────────────────────────
+
+_SECS_PER_DAY = 86_400
+
+
+def _default_older_than() -> int:
+    return 30
+
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+
+def _dir_size(path: Path) -> int:
+    """Return total byte size of a directory tree (best-effort)."""
+    total = 0
+    try:
+        for p in path.rglob("*"):
+            if p.is_file():
+                try:
+                    total += p.stat().st_size
+                except OSError:
+                    pass
+    except OSError:
+        pass
+    return total
+
+
+def _file_size(path: Path) -> int:
+    """Return file size in bytes (best-effort)."""
+    try:
+        return path.stat().st_size
+    except OSError:
+        return 0
+
+
+def _format_bytes(n: int) -> str:
+    """Human-readable byte count."""
+    for unit in ("B", "KiB", "MiB", "GiB"):
+        if n < 1024:
+            return f"{n:.1f} {unit}"
+        n //= 1024
+    return f"{n:.1f} TiB"
+
+
+def _mtime(path: Path) -> float:
+    """Return mtime as a float; fall back to now so nothing is accidentally old."""
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return time.time()
+
+
+def _ask_confirm(prompt: str) -> bool:
+    """Prompt the user for y/N confirmation; returns True on 'y'/'yes'."""
+    try:
+        answer = input(f"{prompt} [y/N] ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        return False
+    return answer in ("y", "yes")
+
+
+# ── cleanup functions ──────────────────────────────────────────────────────────
+
+
+def cleanup_runs(
+    runs_root: Path,
+    *,
+    older_than_days: int,
+    dry_run: bool,
+) -> dict[str, int]:
+    """Remove run directories older than *older_than_days*.
+
+    A run directory qualifies for removal when its mtime (last write) is
+    older than the cutoff.  Directories without a ``run.json`` are treated
+    as orphans and are also eligible.
+
+    Returns ``{"removed": N, "bytes_freed": B, "errors": E}``.
+    """
+    counts: dict[str, int] = {"removed": 0, "bytes_freed": 0, "errors": 0}
+
+    if not runs_root.exists():
+        progress(f"runs directory not found: {runs_root} — nothing to clean")
+        return counts
+
+    cutoff = time.time() - older_than_days * _SECS_PER_DAY
+
+    for entry in sorted(runs_root.iterdir()):
+        if not entry.is_dir():
+            continue
+        if _mtime(entry) >= cutoff:
+            continue
+
+        size = _dir_size(entry)
+        if dry_run:
+            print(f"  [dry-run] would remove run: {entry.name}  ({_format_bytes(size)})")
+            counts["removed"] += 1
+            counts["bytes_freed"] += size
+        else:
+            try:
+                shutil.rmtree(entry)
+                counts["removed"] += 1
+                counts["bytes_freed"] += size
+            except OSError as exc:
+                warn(f"could not remove {entry}: {exc}")
+                counts["errors"] += 1
+
+    return counts
+
+
+def cleanup_teams(
+    teams_root: Path,
+    *,
+    dry_run: bool,
+) -> dict[str, int]:
+    """Remove orphaned team JSON files.
+
+    A team file is considered orphaned when it cannot be parsed as valid
+    JSON or when it has no ``id`` field.  Well-formed files are kept — the
+    caller must decide whether to purge active teams via ``li state prune``.
+
+    Returns ``{"removed": N, "bytes_freed": B, "errors": E}``.
+    """
+    import json
+
+    counts: dict[str, int] = {"removed": 0, "bytes_freed": 0, "errors": 0}
+
+    if not teams_root.exists():
+        progress(f"teams directory not found: {teams_root} — nothing to clean")
+        return counts
+
+    for entry in sorted(teams_root.glob("*.json")):
+        if not entry.is_file():
+            continue
+
+        orphaned = False
+        try:
+            data = json.loads(entry.read_text(encoding="utf-8"))
+            if not data.get("id"):
+                orphaned = True
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            orphaned = True
+
+        if not orphaned:
+            continue
+
+        size = _file_size(entry)
+        if dry_run:
+            print(
+                f"  [dry-run] would remove orphaned team file: {entry.name}  ({_format_bytes(size)})"
+            )
+            counts["removed"] += 1
+            counts["bytes_freed"] += size
+        else:
+            try:
+                entry.unlink()
+                counts["removed"] += 1
+                counts["bytes_freed"] += size
+            except OSError as exc:
+                warn(f"could not remove {entry}: {exc}")
+                counts["errors"] += 1
+
+    return counts
+
+
+def cleanup_logs(
+    logs_root: Path,
+    *,
+    older_than_days: int,
+    dry_run: bool,
+) -> dict[str, int]:
+    """Remove log files older than *older_than_days*.
+
+    Scans *logs_root* recursively for ``*.log`` and ``*.jsonl`` files and
+    removes those whose mtime predates the cutoff.
+
+    Returns ``{"removed": N, "bytes_freed": B, "errors": E}``.
+    """
+    counts: dict[str, int] = {"removed": 0, "bytes_freed": 0, "errors": 0}
+
+    if not logs_root.exists():
+        progress(f"logs directory not found: {logs_root} — nothing to clean")
+        return counts
+
+    cutoff = time.time() - older_than_days * _SECS_PER_DAY
+    patterns = ("*.log", "*.jsonl")
+
+    candidates: list[Path] = []
+    for pattern in patterns:
+        candidates.extend(logs_root.rglob(pattern))
+    candidates.sort()
+
+    for entry in candidates:
+        if not entry.is_file():
+            continue
+        if _mtime(entry) >= cutoff:
+            continue
+
+        size = _file_size(entry)
+        if dry_run:
+            print(f"  [dry-run] would remove log: {entry}  ({_format_bytes(size)})")
+            counts["removed"] += 1
+            counts["bytes_freed"] += size
+        else:
+            try:
+                entry.unlink()
+                counts["removed"] += 1
+                counts["bytes_freed"] += size
+            except OSError as exc:
+                warn(f"could not remove {entry}: {exc}")
+                counts["errors"] += 1
+
+    return counts
+
+
+def cleanup_db(
+    db_path: Path,
+    *,
+    older_than_days: int,
+    dry_run: bool,
+) -> dict[str, int]:
+    """Vacuum the SQLite state.db and optionally delete old session records.
+
+    The DB file is NEVER deleted.  Only VACUUM is run (when not dry-run)
+    plus an optional soft-delete of sessions whose ``updated_at`` is older
+    than *older_than_days*.
+
+    Returns ``{"sessions_deleted": N, "vacuum": 1|0}``.
+    """
+    from lionagi.ln.concurrency import run_async
+
+    counts: dict[str, int] = {"sessions_deleted": 0, "vacuum": 0}
+
+    if not db_path.exists():
+        progress(f"state.db not found at {db_path} — skipping DB cleanup")
+        return counts
+
+    async def _do_cleanup() -> dict[str, int]:
+        import time as _time
+
+        from lionagi.state.db import StateDB
+
+        inner: dict[str, int] = {"sessions_deleted": 0, "vacuum": 0}
+        cutoff = _time.time() - older_than_days * _SECS_PER_DAY
+
+        async with StateDB() as db:
+            cur = await db.db.execute(
+                "SELECT COUNT(*) AS n FROM sessions WHERE updated_at < ? OR updated_at IS NULL",
+                (cutoff,),
+            )
+            row = await cur.fetchone()
+            eligible = row["n"] if row else 0
+
+            if dry_run:
+                print(
+                    f"  [dry-run] would delete {eligible} session record(s) "
+                    f"older than {older_than_days} day(s) from state.db"
+                )
+                print("  [dry-run] would run VACUUM on state.db")
+                inner["sessions_deleted"] = eligible
+            else:
+                if eligible:
+                    await db.db.execute(
+                        "DELETE FROM sessions WHERE updated_at < ? OR updated_at IS NULL",
+                        (cutoff,),
+                    )
+                    # Sweep orphaned messages (not referenced by any progression).
+                    await db.db.execute(
+                        """DELETE FROM messages
+                           WHERE id NOT IN (
+                             SELECT value
+                             FROM progressions, json_each(progressions.collection)
+                           )"""
+                    )
+                    await db.db.commit()
+                    inner["sessions_deleted"] = eligible
+
+                await db.db.execute("VACUUM")
+                await db.db.commit()
+                inner["vacuum"] = 1
+
+        return inner
+
+    try:
+        result = run_async(_do_cleanup())
+        counts.update(result)
+    except Exception as exc:  # noqa: BLE001
+        log_error(f"DB cleanup failed: {exc}")
+
+    return counts
+
+
+# ── CLI wiring ────────────────────────────────────────────────────────────────
+
+
+def add_cleanup_subcommand(state_sub: argparse._SubParsersAction) -> None:
+    """Register ``li state cleanup`` under the existing ``state`` subparsers."""
+    cleanup = state_sub.add_parser(
+        "cleanup",
+        help="Remove stale run directories, orphaned team files, and old logs.",
+        description=(
+            "Operational hygiene command: delete old run directories, orphaned "
+            "team JSON files, and stale log files. Pass --dry-run to preview "
+            "what would be deleted without touching anything."
+        ),
+    )
+
+    cleanup.add_argument(
+        "--older-than",
+        metavar="DAYS",
+        type=int,
+        default=_default_older_than(),
+        dest="older_than",
+        help="Only remove items older than N days (default: 30).",
+    )
+    cleanup.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be removed, but do not delete anything.",
+    )
+    cleanup.add_argument(
+        "--runs",
+        action="store_true",
+        default=False,
+        help="Clean old run directories (~/.lionagi/runs/).",
+    )
+    cleanup.add_argument(
+        "--teams",
+        action="store_true",
+        default=False,
+        help="Clean orphaned team files (~/.lionagi/teams/).",
+    )
+    cleanup.add_argument(
+        "--logs",
+        action="store_true",
+        default=False,
+        help="Clean old log files (~/.lionagi/logs/).",
+    )
+    cleanup.add_argument(
+        "--all",
+        action="store_true",
+        default=False,
+        dest="clean_all",
+        help="Clean everything (runs + teams + logs + DB vacuum). Default when no scope flag given.",
+    )
+    cleanup.add_argument(
+        "--force",
+        action="store_true",
+        help="Skip confirmation prompt before deleting.",
+    )
+
+
+def run_cleanup(args: argparse.Namespace) -> int:
+    """Execute ``li state cleanup``."""
+    from lionagi._paths import LIONAGI_HOME
+
+    older_than: int = args.older_than
+    dry_run: bool = args.dry_run
+    force: bool = args.force
+
+    # Determine scope: if no specific flag is set, default to --all.
+    do_runs: bool = args.runs
+    do_teams: bool = args.teams
+    do_logs: bool = args.logs
+    do_all: bool = args.clean_all
+
+    if not (do_runs or do_teams or do_logs or do_all):
+        do_all = True
+
+    if do_all:
+        do_runs = do_teams = do_logs = True
+
+    runs_root = LIONAGI_HOME / "runs"
+    teams_root = LIONAGI_HOME / "teams"
+    logs_root = LIONAGI_HOME / "logs"
+    db_path = LIONAGI_HOME / "state.db"
+
+    # Confirmation gate (skip in dry-run — nothing actually happens).
+    if not dry_run and not force:
+        parts: list[str] = []
+        if do_runs:
+            parts.append(f"run directories older than {older_than}d")
+        if do_teams:
+            parts.append("orphaned team files")
+        if do_logs:
+            parts.append(f"log files older than {older_than}d")
+        if do_all:
+            parts.append("DB vacuum")
+        scope = ", ".join(parts)
+        if not _ask_confirm(f"This will delete: {scope}.  Continue?"):
+            print("aborted.")
+            return 0
+
+    total_removed = 0
+    total_bytes = 0
+    total_errors = 0
+
+    if do_runs:
+        progress(f"cleaning run directories older than {older_than} day(s)...")
+        r = cleanup_runs(runs_root, older_than_days=older_than, dry_run=dry_run)
+        total_removed += r["removed"]
+        total_bytes += r["bytes_freed"]
+        total_errors += r["errors"]
+
+    if do_teams:
+        progress("cleaning orphaned team files...")
+        r = cleanup_teams(teams_root, dry_run=dry_run)
+        total_removed += r["removed"]
+        total_bytes += r["bytes_freed"]
+        total_errors += r["errors"]
+
+    if do_logs:
+        progress(f"cleaning log files older than {older_than} day(s)...")
+        r = cleanup_logs(logs_root, older_than_days=older_than, dry_run=dry_run)
+        total_removed += r["removed"]
+        total_bytes += r["bytes_freed"]
+        total_errors += r["errors"]
+
+    if do_all:
+        progress("vacuuming state.db...")
+        r = cleanup_db(db_path, older_than_days=older_than, dry_run=dry_run)
+        total_removed += r["sessions_deleted"]
+
+    # Summary line.
+    prefix = "(dry-run) would remove" if dry_run else "removed"
+    print(
+        f"{prefix} {total_removed} item(s),  "
+        f"space freed: {_format_bytes(total_bytes)}"
+        + (f"  [errors: {total_errors}]" if total_errors else "")
+    )
+
+    if total_errors:
+        hint("some items could not be removed — check warnings above")
+
+    return 0 if total_errors == 0 else 1

--- a/lionagi/cli/config.py
+++ b/lionagi/cli/config.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""`li config` utilities.
+
+Commands:
+  li config agents-md [--project PATH] [--output PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+from pathlib import Path
+
+from lionagi.config_resolution import ResourceKind, list_resource_names, resolve_config
+
+from ._logging import hint, log_error
+
+
+def add_config_subparser(subparsers: argparse._SubParsersAction) -> None:
+    """Register the `li config` top-level command."""
+    config = subparsers.add_parser(
+        "config",
+        help="Configuration helpers and discoverability outputs.",
+        description="Configuration helpers for .lionagi resources.",
+    )
+    cfg = config.add_subparsers(dest="config_command", required=True)
+
+    agents_md = cfg.add_parser(
+        "agents-md",
+        help=(
+            "Generate `.lionagi/agents.md` from discovered agent configs."
+            " Used for discoverability and quick reference."
+        ),
+    )
+    agents_md.add_argument(
+        "--project",
+        metavar="PATH",
+        default=None,
+        help="Project root to use for resource discovery (defaults to current cwd path search).",
+    )
+    agents_md.add_argument(
+        "--output",
+        metavar="PATH",
+        default=None,
+        help="Output file path (default: <project>/.lionagi/agents.md or .lionagi/agents.md).",
+    )
+
+
+def _default_agents_md_path(project: str | None) -> Path:
+    if project:
+        return Path(project).expanduser() / ".lionagi" / "agents.md"
+    return Path(".lionagi/agents.md").expanduser()
+
+
+def _format_provenance_block(provenance: dict) -> list[str]:
+    lines: list[str] = []
+
+    sources = provenance.get("sources")
+    if isinstance(sources, dict):
+        lines.append("### Resolution sources")
+        for tier in ("default", "user", "project", "env", "cli"):
+            value = sources.get(tier)
+            if value:
+                lines.append(f"- {tier}: `{value}`")
+
+    keys = provenance.get("keys")
+    if isinstance(keys, dict):
+        lines.append("")
+        lines.append("### Key provenance")
+        for k in sorted(keys):
+            lines.append(f"- `{k}` ← {keys[k]}")
+
+    return lines
+
+
+def _build_agents_md(project: str | None = None) -> str:
+    names = list_resource_names(ResourceKind.AGENT, project=project)
+    generated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+    lines = [
+        "# Agents",
+        "",
+        f"Generated: {generated_at}",
+        f"Discovered: {len(names)}",
+        "",
+    ]
+
+    if not names:
+        lines.append("No agent configs discovered.")
+        return "\n".join(lines)
+
+    for name in names:
+        cfg = resolve_config(ResourceKind.AGENT, name, project=project)
+        provenance = cfg.pop("_provenance", {})
+
+        lines.append(f"## {name}")
+        body_keys = sorted(cfg.keys())
+        if not body_keys:
+            lines.append("No agent settings defined.")
+        else:
+            lines.append("")
+            for key in body_keys:
+                lines.append(f"- **{key}**")
+
+        if provenance:
+            lines.extend(_format_provenance_block(provenance))
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def run_config(args: argparse.Namespace) -> int:
+    """Dispatch ``li config`` subcommands."""
+    if args.config_command != "agents-md":
+        log_error(f"unknown config command: {args.config_command}")
+        return 1
+
+    output = Path(args.output or _default_agents_md_path(args.project))
+    content = _build_agents_md(project=args.project)
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(content)
+    hint(f"generated {output}")
+    return 0

--- a/lionagi/cli/main.py
+++ b/lionagi/cli/main.py
@@ -20,14 +20,22 @@ import sys
 
 from ._logging import configure_cli_logging, log_error
 from .agent import add_agent_subparser, run_agent
+from .config import add_config_subparser, run_config
 from .invoke import add_invoke_subparser, run_invoke
 from .kill import add_kill_subparser, run_kill
+
+try:
+    from .mcp import add_mcp_subparser, run_mcp
+except ImportError:
+    add_mcp_subparser = None  # type: ignore[assignment]
+    run_mcp = None  # type: ignore[assignment]
 from .monitor import add_monitor_subparser, run_monitor
 from .orchestrate import (
     add_orchestrate_subparser,
     inject_playbook_schema_into_parser,
     run_orchestrate,
 )
+from .schedule import add_schedule_subcommand, run_schedule
 from .skill import run_skill
 from .state import add_state_subparser, run_state
 from .studio import add_studio_subparser, run_studio
@@ -254,11 +262,15 @@ def main(argv: list[str] | None = None) -> int:
     orch_parsers = add_orchestrate_subparser(sub)
     add_agent_subparser(sub)
     add_team_subparser(sub)
+    if add_mcp_subparser is not None:
+        add_mcp_subparser(sub)
     add_studio_subparser(sub)
     add_state_subparser(sub)
+    add_config_subparser(sub)
     add_invoke_subparser(sub)
     add_kill_subparser(sub)
     add_monitor_subparser(sub)
+    add_schedule_subcommand(sub)
 
     # If the user is invoking `li o flow -p NAME`, inject the playbook's
     # declared args as flags on the flow sub-parser BEFORE argparse runs,
@@ -269,6 +281,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command in ("orchestrate", "o"):
         return run_orchestrate(args)
+
+    if args.command == "config":
+        return run_config(args)
 
     if args.command == "agent":
         return run_agent(args)
@@ -285,11 +300,17 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "invoke":
         return run_invoke(args)
 
+    if args.command == "mcp" and run_mcp is not None:
+        return run_mcp(args)
+
     if args.command == "kill":
         return run_kill(args)
 
     if args.command in ("monitor", "mon"):
         return run_monitor(args)
+
+    if args.command == "schedule":
+        return run_schedule(args)
 
     parser.print_help()
     return 1

--- a/lionagi/cli/orchestrate/charter.py
+++ b/lionagi/cli/orchestrate/charter.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""`li orchestrate charter` — Charter DSL compile, validate, and schema commands."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def add_charter_subparser(
+    orch_sub: argparse._SubParsersAction,
+) -> argparse.ArgumentParser:
+    """Register `li orchestrate charter` with its sub-commands.
+
+    Returns the charter ArgumentParser so callers can extend it if needed.
+    """
+    ch = orch_sub.add_parser(
+        "charter",
+        help="Charter DSL: compile, validate, and schema export.",
+        description=(
+            "Compile a Charter DSL YAML file into runtime targets, "
+            "validate without compiling, or export the JSON Schema."
+        ),
+    )
+    ch_sub = ch.add_subparsers(dest="charter_command", required=True)
+
+    # ── compile ──────────────────────────────────────────────────────────
+    cp = ch_sub.add_parser(
+        "compile",
+        help="Compile a charter file and report runtime targets.",
+        description=(
+            "Parse and compile a Charter DSL YAML file through all six "
+            "phases.  Prints target counts and the first 16 chars of the "
+            "activation hash.  Exits 1 on CharterActivationError."
+        ),
+    )
+    cp.add_argument(
+        "file",
+        type=str,
+        metavar="FILE",
+        help="Path to the Charter DSL YAML file.",
+    )
+
+    # ── validate ─────────────────────────────────────────────────────────
+    va = ch_sub.add_parser(
+        "validate",
+        help="Parse and validate a charter file without full compilation.",
+        description=(
+            "Parse the charter through the P13 parser and run the "
+            "compiler validation phase.  Does not emit runtime targets "
+            "or verify the ratification hash."
+        ),
+    )
+    va.add_argument(
+        "file",
+        type=str,
+        metavar="FILE",
+        help="Path to the Charter DSL YAML file.",
+    )
+
+    # ── schema ───────────────────────────────────────────────────────────
+    ch_sub.add_parser(
+        "schema",
+        help="Print the CharterDocument JSON Schema.",
+        description="Export the Pydantic JSON Schema for Charter DSL v0.",
+    )
+
+    return ch
+
+
+def run_charter(args: argparse.Namespace) -> int:
+    """Dispatch `li orchestrate charter` sub-commands."""
+    from lionagi.protocols.governance.charter import (
+        parse_charter,
+    )
+    from lionagi.protocols.governance.compiler import (
+        CharterActivationError,
+        CharterCompiler,
+    )
+    from lionagi.protocols.governance.dsl import CharterDocument
+
+    cmd = args.charter_command
+
+    if cmd == "compile":
+        path = Path(args.file)
+        try:
+            yaml_text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            print(f"Error reading file: {exc}", file=sys.stderr)
+            return 1
+
+        try:
+            doc = parse_charter(yaml_text)
+        except Exception as exc:
+            print(f"Parse error: {exc}", file=sys.stderr)
+            return 1
+
+        try:
+            result = CharterCompiler().compile(doc)
+        except CharterActivationError as exc:
+            print(f"Activation error: {exc}", file=sys.stderr)
+            return 1
+
+        pin = result.policy_pin
+        print("Compiled successfully")
+        print(f"  gates              : {len(result.gates)}")
+        print(f"  registry entries   : {len(result.registry)}")
+        print(f"  sod rules          : {len(result.sod_rules)}")
+        print(f"  evidence reqs      : {len(result.evidence_reqs)}")
+        print(f"  trace expectations : {len(result.trace_expectations)}")
+        print(f"  permissions        : {len(result.permissions)}")
+        print(f"  activation hash    : {pin.charter_hash[:16]}...")
+        if result.warnings:
+            print(f"  warnings           : {len(result.warnings)}")
+            for w in result.warnings:
+                print(f"    - {w}")
+        return 0
+
+    if cmd == "validate":
+        path = Path(args.file)
+        try:
+            yaml_text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            print(f"Error reading file: {exc}", file=sys.stderr)
+            return 1
+
+        try:
+            doc = parse_charter(yaml_text)
+        except Exception as exc:
+            print(f"Parse error: {exc}", file=sys.stderr)
+            return 1
+
+        warnings = CharterCompiler()._validate(doc)
+        if warnings:
+            print(f"Validation warnings ({len(warnings)}):")
+            for w in warnings:
+                print(f"  - {w}")
+        else:
+            print("Validation OK")
+        return 0
+
+    if cmd == "schema":
+        schema = CharterDocument.model_json_schema()
+        print(json.dumps(schema, indent=2))
+        return 0
+
+    print(f"Unknown charter command: {cmd}", file=sys.stderr)
+    return 1

--- a/lionagi/cli/schedule.py
+++ b/lionagi/cli/schedule.py
@@ -1,0 +1,446 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""`li schedule` — manage scheduled flow definitions.
+
+The schedule command provides sub-commands to add, list, remove, pause, and
+resume scheduled items backed by the in-process :class:`SchedulerEngine`.
+
+Examples
+--------
+::
+
+    # Add a cron schedule — every night at 02:00
+    li schedule add nightly-review --cron "0 2 * * *" --flow-type play --playbook nightly-review
+
+    # Add an interval schedule — every 30 minutes
+    li schedule add heartbeat --interval 1800 --flow-type agent --prompt "check health"
+
+    # One-shot item (fires once immediately, max-runs defaults to 1)
+    li schedule add deploy-once --flow-type shell --argv "uv,run,li,state,prune" --max-runs 1
+
+    # List all schedules
+    li schedule list
+
+    # List only active schedules
+    li schedule list --status active
+
+    # Pause a schedule
+    li schedule pause <item-id>
+
+    # Resume a paused schedule
+    li schedule resume <item-id>
+
+    # Remove a schedule
+    li schedule remove <item-id>
+
+Notes
+-----
+The ``li schedule`` command operates on the *current process's*
+:class:`SchedulerEngine` instance.  For durable, cross-process scheduling
+(including Studio integration) the engine should be backed by a
+:class:`~lionagi.state.store.StateStore` and embedded in the Studio lifespan
+or a long-running daemon.  The CLI surface here is intentionally thin — it
+validates inputs and delegates all state mutations to the engine.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from typing import Any
+
+from ._logging import log_error
+
+# ---------------------------------------------------------------------------
+# Module-level default engine (used by the CLI)
+# ---------------------------------------------------------------------------
+
+# A single shared SchedulerEngine instance for the CLI process.
+# Tests and external callers may replace this reference or instantiate their
+# own engine independently.
+_DEFAULT_ENGINE: Any = None
+
+
+def _get_engine() -> Any:
+    """Return the default :class:`SchedulerEngine`, creating it on first use."""
+    global _DEFAULT_ENGINE  # noqa: PLW0603
+    if _DEFAULT_ENGINE is None:
+        from lionagi.runtime.scheduler import SchedulerEngine
+
+        _DEFAULT_ENGINE = SchedulerEngine()
+    return _DEFAULT_ENGINE
+
+
+def set_engine(engine: Any) -> None:
+    """Replace the default engine (e.g. in tests or daemon setup)."""
+    global _DEFAULT_ENGINE  # noqa: PLW0603
+    _DEFAULT_ENGINE = engine
+
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+
+_STATUS_MARKER = {
+    "active": "[active]",
+    "running": "[running]",
+    "paused": "[paused]",
+    "completed": "[done]",
+    "failed": "[FAILED]",
+    "cancelled": "[cancelled]",
+    "pending": "[pending]",
+}
+
+
+def _fmt_ts(ts: float | None) -> str:
+    if ts is None:
+        return "-"
+    return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(ts))
+
+
+def _print_item(item: Any) -> None:
+    """Print a single :class:`ScheduleItem` in human-readable form."""
+    marker = _STATUS_MARKER.get(item.status, f"[{item.status}]")
+    trigger = (
+        f"cron:{item.cron_expr}"
+        if item.cron_expr
+        else f"interval:{item.interval_seconds}s"
+        if item.interval_seconds
+        else "one-shot"
+    )
+    runs = f"{item.run_count}/{item.max_runs}" if item.max_runs is not None else str(item.run_count)
+    print(
+        f"{marker:<12} {item.item_id[:16]}  {item.name:<24}  "
+        f"{trigger:<30}  runs:{runs:<6}  "
+        f"next:{_fmt_ts(item.next_run_at)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sub-command implementations
+# ---------------------------------------------------------------------------
+
+
+def _cmd_add(args: argparse.Namespace) -> int:
+    """Add a new scheduled item."""
+    from lionagi.runtime.scheduler import parse_cron
+
+    engine = _get_engine()
+
+    if args.cron and args.interval:
+        log_error("specify at most one of --cron and --interval")
+        return 1
+
+    if args.cron:
+        # Validate before handing to engine
+        try:
+            parse_cron(args.cron)
+        except ValueError as exc:
+            log_error(f"invalid cron expression: {exc}")
+            return 1
+
+    interval: float | None = None
+    if args.interval is not None:
+        if args.interval <= 0:
+            log_error("--interval must be a positive number of seconds")
+            return 1
+        interval = float(args.interval)
+
+    # Build flow_spec from remaining flags
+    flow_spec: dict[str, Any] = {}
+    if args.flow_type:
+        flow_spec["flow_type"] = args.flow_type
+    if args.playbook:
+        flow_spec["playbook"] = args.playbook
+    if args.prompt:
+        flow_spec["prompt"] = args.prompt
+    if args.argv:
+        # Accept comma-separated argv or repeated --argv flags
+        flow_spec["argv"] = args.argv
+
+    # Allow raw JSON spec override
+    if args.spec:
+        try:
+            extra = json.loads(args.spec)
+        except json.JSONDecodeError as exc:
+            log_error(f"--spec is not valid JSON: {exc}")
+            return 1
+        if not isinstance(extra, dict):
+            log_error("--spec must be a JSON object (dict)")
+            return 1
+        flow_spec.update(extra)
+
+    max_runs: int | None = args.max_runs
+    if max_runs is not None and max_runs < 1:
+        log_error("--max-runs must be >= 1")
+        return 1
+
+    try:
+        item = engine.add(
+            name=args.name,
+            flow_spec=flow_spec,
+            cron_expr=args.cron or None,
+            interval_seconds=interval,
+            max_runs=max_runs,
+        )
+    except ValueError as exc:
+        log_error(str(exc))
+        return 1
+
+    print(f"scheduled: {item.item_id}")
+    _print_item(item)
+    return 0
+
+
+def _cmd_list(args: argparse.Namespace) -> int:
+    """List scheduled items, optionally filtered by status."""
+    engine = _get_engine()
+    status_filter: str | None = args.status
+    items = engine.list_items(status=status_filter)
+
+    if not items:
+        msg = "(no scheduled items)"
+        if status_filter:
+            msg = f"(no scheduled items with status={status_filter!r})"
+        print(msg)
+        return 0
+
+    for item in sorted(items, key=lambda it: it.next_run_at):
+        _print_item(item)
+    return 0
+
+
+def _cmd_remove(args: argparse.Namespace) -> int:
+    """Remove a scheduled item by id (prefix allowed)."""
+    engine = _get_engine()
+    item_id = _resolve_id(engine, args.item_id)
+    if item_id is None:
+        log_error(f"no scheduled item found for id: {args.item_id!r}")
+        return 1
+
+    removed = engine.remove(item_id)
+    if removed:
+        print(f"removed: {item_id[:16]}")
+        return 0
+    log_error(f"item {item_id[:16]!r} not found")
+    return 1
+
+
+def _cmd_pause(args: argparse.Namespace) -> int:
+    """Pause an active scheduled item."""
+    engine = _get_engine()
+    item_id = _resolve_id(engine, args.item_id)
+    if item_id is None:
+        log_error(f"no scheduled item found for id: {args.item_id!r}")
+        return 1
+
+    ok = engine.pause(item_id)
+    if ok:
+        print(f"paused: {item_id[:16]}")
+        return 0
+    # Give a more specific error if possible
+    item = engine.get_item(item_id)
+    if item is None:
+        log_error(f"item {item_id[:16]!r} not found")
+    else:
+        log_error(
+            f"cannot pause item {item_id[:16]!r} with status={item.status!r} "
+            "(only active items can be paused)"
+        )
+    return 1
+
+
+def _cmd_resume(args: argparse.Namespace) -> int:
+    """Resume a paused scheduled item."""
+    engine = _get_engine()
+    item_id = _resolve_id(engine, args.item_id)
+    if item_id is None:
+        log_error(f"no scheduled item found for id: {args.item_id!r}")
+        return 1
+
+    ok = engine.resume(item_id)
+    if ok:
+        print(f"resumed: {item_id[:16]}")
+        return 0
+    item = engine.get_item(item_id)
+    if item is None:
+        log_error(f"item {item_id[:16]!r} not found")
+    else:
+        log_error(
+            f"cannot resume item {item_id[:16]!r} with status={item.status!r} "
+            "(only paused items can be resumed)"
+        )
+    return 1
+
+
+# ---------------------------------------------------------------------------
+# ID resolution helper (support short id prefixes)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_id(engine: Any, id_or_prefix: str) -> str | None:
+    """Resolve a full UUID or a unique prefix to a canonical item_id.
+
+    Uses the public :meth:`~lionagi.work.engine.WorkEngine.get_item` and
+    :meth:`~lionagi.work.engine.WorkEngine.find_by_prefix` methods instead
+    of accessing private engine internals.
+    """
+    # Exact match first via the public get_item accessor.
+    if engine.get_item(id_or_prefix) is not None:
+        return id_or_prefix
+
+    # Prefix match (at least 4 characters for safety) via find_by_prefix.
+    if len(id_or_prefix) >= 4:
+        matches = engine.find_by_prefix(id_or_prefix)
+        if len(matches) == 1:
+            return matches[0]
+        if len(matches) > 1:
+            log_error(
+                f"ambiguous prefix {id_or_prefix!r} matches {len(matches)} items; "
+                "use a longer prefix or the full id"
+            )
+            return None
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# argparse registration
+# ---------------------------------------------------------------------------
+
+
+def add_schedule_subcommand(subparsers: argparse._SubParsersAction) -> None:
+    """Register ``li schedule`` and its sub-commands with argparse."""
+    sched = subparsers.add_parser(
+        "schedule",
+        help="Manage scheduled flow definitions.",
+        description=(
+            "Add, list, pause, resume, and remove scheduled flows.\n\n"
+            "Examples:\n"
+            "  li schedule add nightly --cron '0 2 * * *' --flow-type play "
+            "--playbook nightly-review\n"
+            "  li schedule add pulse --interval 1800 --flow-type agent "
+            "--prompt 'health check'\n"
+            "  li schedule list\n"
+            "  li schedule list --status active\n"
+            "  li schedule pause <id>\n"
+            "  li schedule resume <id>\n"
+            "  li schedule remove <id>\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    sched_sub = sched.add_subparsers(dest="schedule_cmd", required=True)
+
+    # -- add ----------------------------------------------------------------
+    add_p = sched_sub.add_parser(
+        "add",
+        help="Add a new scheduled item.",
+        description="Create and register a new scheduled flow.",
+    )
+    add_p.add_argument("name", help="Human-readable name for this schedule.")
+    add_p.add_argument(
+        "--cron",
+        default=None,
+        metavar="EXPR",
+        help=(
+            "Five-field cron expression (e.g. '0 2 * * *' for 02:00 daily). "
+            "Mutually exclusive with --interval."
+        ),
+    )
+    add_p.add_argument(
+        "--interval",
+        type=float,
+        default=None,
+        metavar="SECONDS",
+        help=(
+            "Repeat interval in seconds (e.g. 1800 for every 30 minutes). "
+            "Mutually exclusive with --cron."
+        ),
+    )
+    add_p.add_argument(
+        "--flow-type",
+        default=None,
+        dest="flow_type",
+        choices=["agent", "fanout", "flow", "play", "team", "shell", "webhook", "chain"],
+        help="Type of flow to execute.",
+    )
+    add_p.add_argument(
+        "--playbook",
+        default=None,
+        help="Playbook name (for --flow-type play).",
+    )
+    add_p.add_argument(
+        "--prompt",
+        default=None,
+        help="Prompt text (for --flow-type agent).",
+    )
+    add_p.add_argument(
+        "--argv",
+        nargs="+",
+        default=None,
+        metavar="ARG",
+        help="Command argv list (for --flow-type shell or custom execution).",
+    )
+    add_p.add_argument(
+        "--spec",
+        default=None,
+        metavar="JSON",
+        help="Raw JSON object merged into flow_spec (overrides individual flags).",
+    )
+    add_p.add_argument(
+        "--max-runs",
+        type=int,
+        default=None,
+        dest="max_runs",
+        metavar="N",
+        help="Auto-complete after N successful runs. Omit for unlimited.",
+    )
+
+    # -- list ---------------------------------------------------------------
+    list_p = sched_sub.add_parser("list", help="List scheduled items.")
+    list_p.add_argument(
+        "--status",
+        default=None,
+        choices=["pending", "active", "running", "paused", "completed", "failed", "cancelled"],
+        help="Filter by status (default: all).",
+    )
+
+    # -- remove -------------------------------------------------------------
+    rm_p = sched_sub.add_parser("remove", help="Remove a scheduled item.")
+    rm_p.add_argument("item_id", help="Item id or unique prefix.")
+
+    # -- pause --------------------------------------------------------------
+    pause_p = sched_sub.add_parser("pause", help="Pause an active scheduled item.")
+    pause_p.add_argument("item_id", help="Item id or unique prefix.")
+
+    # -- resume -------------------------------------------------------------
+    resume_p = sched_sub.add_parser("resume", help="Resume a paused scheduled item.")
+    resume_p.add_argument("item_id", help="Item id or unique prefix.")
+
+
+def run_schedule(args: argparse.Namespace) -> int:
+    """Dispatch ``li schedule`` sub-command."""
+    cmd = args.schedule_cmd
+    if cmd == "add":
+        return _cmd_add(args)
+    if cmd == "list":
+        return _cmd_list(args)
+    if cmd == "remove":
+        return _cmd_remove(args)
+    if cmd == "pause":
+        return _cmd_pause(args)
+    if cmd == "resume":
+        return _cmd_resume(args)
+
+    log_error(f"unknown schedule sub-command: {cmd!r}")
+    return 1
+
+
+__all__ = [
+    "add_schedule_subcommand",
+    "run_schedule",
+    "set_engine",
+]

--- a/lionagi/runtime/scheduler.py
+++ b/lionagi/runtime/scheduler.py
@@ -622,15 +622,15 @@ class SchedulerEngine:
             if item.max_runs is not None and item.run_count >= item.max_runs:
                 item.status = STATUS_COMPLETED
             else:
-                item.status = STATUS_ACTIVE
                 next_run = self._compute_next_run(item)
-                if next_run is not None:
+                if next_run is None:
+                    # One-shot item (no cron_expr and no interval_seconds):
+                    # there is no future fire time, so complete it now rather
+                    # than leaving it active and letting it re-fire immediately.
+                    item.status = STATUS_COMPLETED
+                else:
                     item.next_run_at = next_run
-                # If no next_run (one-shot item), leave next_run_at unchanged;
-                # the item will not be returned by get_due_items again because
-                # status is not active… actually it IS active.  One-shot items
-                # without max_runs will re-fire immediately.  Callers should
-                # set max_runs=1 for true one-shot behaviour.
+                    item.status = STATUS_ACTIVE
         return True
 
     def mark_failed(self, item_id: str, error: str = "") -> bool:

--- a/lionagi/runtime/scheduler.py
+++ b/lionagi/runtime/scheduler.py
@@ -1,0 +1,749 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Universal scheduler engine for lionagi.
+
+Provides :class:`ScheduleItem`, :class:`SchedulerEngine`, :func:`parse_cron`,
+and :func:`next_cron_fire` for scheduling recurring and one-shot flows.
+
+Design
+------
+* In-memory store (``dict[str, ScheduleItem]``) used by default; an optional
+  :class:`~lionagi.state.store.StateStore` can be supplied for persistence.
+* Thread-safe via :class:`threading.Lock`.
+* No external cron libraries — a minimal subset of cron syntax is implemented
+  directly (``*/N``, ``*``, specific integers).
+
+State machine for :class:`ScheduleItem`
+---------------------------------------
+
+::
+
+    pending → active     (on add, item is set active immediately)
+    active  → running    (mark_started)
+    running → active     (mark_completed — reschedules if cron/interval)
+    running → failed     (mark_failed)
+    active  → paused     (pause)
+    paused  → active     (resume)
+    active  → completed  (max_runs reached after mark_completed)
+    *       → cancelled  (remove)
+
+Transition table
+----------------
+
++----------+-----------+-----------+-------------------------------------+
+| From     | Verb      | To        | Guard                               |
++==========+===========+===========+=====================================+
+| pending  | add       | active    | always (add() sets active)          |
++----------+-----------+-----------+-------------------------------------+
+| active   | start     | running   | item is due (next_run_at <= now)    |
++----------+-----------+-----------+-------------------------------------+
+| running  | complete  | active    | run_count < max_runs (or unlimited) |
++----------+-----------+-----------+-------------------------------------+
+| running  | complete  | completed | run_count >= max_runs               |
++----------+-----------+-----------+-------------------------------------+
+| running  | fail      | failed    | terminal — no reschedule            |
++----------+-----------+-----------+-------------------------------------+
+| active   | pause     | paused    | must not be running                 |
++----------+-----------+-----------+-------------------------------------+
+| paused   | resume    | active    | next_run_at is recomputed           |
++----------+-----------+-----------+-------------------------------------+
+| any      | remove    | cancelled | always                              |
++----------+-----------+-----------+-------------------------------------+
+
+Cron expression reference
+-------------------------
+
+Supported subset (five fields: minute hour day month weekday)::
+
+    *         any value
+    */N       every N units  (e.g. */5 = every 5 minutes)
+    V         specific value (e.g. 0, 15, 30)
+
+Examples::
+
+    "*/5 * * * *"    — every 5 minutes
+    "0 * * * *"      — top of every hour
+    "0 */2 * * *"    — every 2 hours on the hour
+    "0 0 * * *"      — midnight every day
+    "0 0 * * 1"      — midnight every Monday (weekday 1)
+    "30 9 * * 1-5"   — 09:30 Monday–Friday  (range NOT supported; use specific
+                        values or */N for that)
+    "0 0 1 * *"      — first of every month at midnight
+    "0 0 1 1 *"      — 1 January at midnight
+
+Unsupported: ranges (1-5), lists (1,3,5), L/W/# modifiers.  These raise
+:exc:`ValueError` at parse time.
+
+Persistence model
+-----------------
+
+When a :class:`~lionagi.state.store.StateStore` is provided the engine writes
+one row per :class:`ScheduleItem` to the ``scheduled_items`` table (see
+``StateStore.execute_insert``).  Column layout::
+
+    item_id TEXT PRIMARY KEY
+    name TEXT NOT NULL
+    cron_expr TEXT
+    interval_seconds REAL
+    next_run_at REAL NOT NULL
+    last_run_at REAL
+    status TEXT NOT NULL
+    max_runs INTEGER
+    run_count INTEGER NOT NULL DEFAULT 0
+    flow_spec JSON NOT NULL DEFAULT '{}'
+    created_at REAL NOT NULL
+    updated_at REAL NOT NULL
+
+Error handling strategy
+-----------------------
+
+* :func:`parse_cron` raises :exc:`ValueError` on any unsupported syntax.
+* :func:`next_cron_fire` raises :exc:`ValueError` when it cannot find a next
+  fire time within a 4-year search window (handles impossible expressions
+  gracefully).
+* Engine mutating methods return ``False`` (or raise) on precondition failure
+  rather than silently succeeding — callers must check return values.
+* The internal :class:`threading.Lock` is always acquired for the minimum
+  necessary scope; callers must NOT hold the lock when calling engine methods.
+
+Integration with PlayRunner
+---------------------------
+
+:meth:`SchedulerEngine.get_due_items` returns items whose ``next_run_at`` is
+at or before ``time.time()``.  The external driver (e.g. Studio lifespan task,
+``li schedule daemon``) should poll or sleep until the next due time, then:
+
+1. Call ``engine.get_due_items()`` to collect all due :class:`ScheduleItem`s.
+2. For each item call ``engine.mark_started(item.item_id)`` to record the run.
+3. Build an argv list from ``item.flow_spec`` (e.g. ``["uv", "run", "li", ...]``).
+4. Hand the argv to :class:`~lionagi.runtime.runner.LocalRunner` (or a
+   :class:`~lionagi.runtime.runner.PlayRunner` implementation) and await the
+   process exit code.
+5. On exit code 0 call ``engine.mark_completed(item.item_id)``.
+6. On non-zero exit call ``engine.mark_failed(item.item_id, error=...)``.
+
+The engine itself does not spawn processes — that keeps it testable and
+backend-agnostic.
+"""
+
+from __future__ import annotations
+
+import math
+import threading
+import time
+import uuid
+from calendar import monthrange
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# Public status constants
+# ---------------------------------------------------------------------------
+
+STATUS_PENDING = "pending"
+STATUS_ACTIVE = "active"
+STATUS_RUNNING = "running"
+STATUS_PAUSED = "paused"
+STATUS_COMPLETED = "completed"
+STATUS_FAILED = "failed"
+STATUS_CANCELLED = "cancelled"
+
+_TERMINAL_STATUSES = {STATUS_COMPLETED, STATUS_FAILED, STATUS_CANCELLED}
+
+
+# ---------------------------------------------------------------------------
+# ScheduleItem
+# ---------------------------------------------------------------------------
+
+
+class ScheduleItem(BaseModel):
+    """A single scheduled flow definition with lifecycle tracking.
+
+    Parameters
+    ----------
+    item_id:
+        UUID string.  Generated automatically by the engine.
+    name:
+        Human-readable label for the schedule.
+    cron_expr:
+        A five-field cron expression string or ``None`` when
+        ``interval_seconds`` is used instead.
+    interval_seconds:
+        Repeat interval in fractional seconds, or ``None`` when
+        ``cron_expr`` is used.  Exactly one of the two must be set.
+    next_run_at:
+        Unix epoch float of the next scheduled execution.  Set by the
+        engine using :func:`next_cron_fire` or the current time plus
+        ``interval_seconds``.
+    last_run_at:
+        Unix epoch float of the most recent execution start, or ``None``
+        if the item has never run.
+    status:
+        One of ``"pending"``, ``"active"``, ``"running"``, ``"paused"``,
+        ``"completed"``, ``"failed"``, ``"cancelled"``.
+    max_runs:
+        Maximum number of executions before auto-completing.  ``None``
+        means unlimited.
+    run_count:
+        How many times this item has been executed so far.
+    flow_spec:
+        Arbitrary dict describing the flow to run (e.g. ``{"flow_type":
+        "play", "playbook": "nightly-review"}``).  Interpreted by the
+        calling driver, not the engine.
+    created_at:
+        Unix epoch float of creation time.
+    updated_at:
+        Unix epoch float of the most recent state change.
+    """
+
+    item_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    name: str
+    cron_expr: str | None = None
+    interval_seconds: float | None = None
+    next_run_at: float
+    last_run_at: float | None = None
+    status: str = STATUS_ACTIVE
+    max_runs: int | None = None
+    run_count: int = 0
+    flow_spec: dict[str, Any] = Field(default_factory=dict)
+    created_at: float = Field(default_factory=time.time)
+    updated_at: float = Field(default_factory=time.time)
+
+
+# ---------------------------------------------------------------------------
+# Cron parser
+# ---------------------------------------------------------------------------
+
+_CRON_FIELDS = ("minute", "hour", "day", "month", "weekday")
+_CRON_RANGES = {
+    "minute": (0, 59),
+    "hour": (0, 23),
+    "day": (1, 31),
+    "month": (1, 12),
+    "weekday": (0, 6),  # 0=Sunday, 6=Saturday
+}
+
+
+def parse_cron(expr: str) -> dict[str, Any]:
+    """Parse a five-field cron expression into a structured dict.
+
+    Parameters
+    ----------
+    expr:
+        A whitespace-separated five-field cron string.
+
+    Returns
+    -------
+    dict
+        Keys are ``"minute"``, ``"hour"``, ``"day"``, ``"month"``,
+        ``"weekday"``.  Each value is one of:
+
+        * ``"*"`` — any value
+        * ``{"step": N}`` — every N units (``*/N``)
+        * ``int`` — a specific value
+
+    Raises
+    ------
+    ValueError
+        If the expression has fewer or more than five fields, if a field
+        contains an unsupported modifier (ranges, lists), or if a specific
+        integer is out of the allowed range for its field.
+
+    Examples
+    --------
+    >>> parse_cron("*/5 * * * *")
+    {'minute': {'step': 5}, 'hour': '*', 'day': '*', 'month': '*', 'weekday': '*'}
+    >>> parse_cron("0 */2 * * *")
+    {'minute': 0, 'hour': {'step': 2}, 'day': '*', 'month': '*', 'weekday': '*'}
+    >>> parse_cron("0 0 * * 1")
+    {'minute': 0, 'hour': 0, 'day': '*', 'month': '*', 'weekday': 1}
+    """
+    parts = expr.strip().split()
+    if len(parts) != 5:
+        raise ValueError(f"cron expression must have exactly 5 fields, got {len(parts)}: {expr!r}")
+
+    result: dict[str, Any] = {}
+    for field_name, raw in zip(_CRON_FIELDS, parts, strict=False):
+        lo, hi = _CRON_RANGES[field_name]
+
+        if raw == "*":
+            result[field_name] = "*"
+            continue
+
+        if raw.startswith("*/"):
+            # Every-N step
+            step_str = raw[2:]
+            if not step_str.isdigit():
+                raise ValueError(f"invalid step in cron field {field_name!r}: {raw!r}")
+            step = int(step_str)
+            if step <= 0:
+                raise ValueError(f"cron step must be >= 1 in field {field_name!r}: {raw!r}")
+            if step > (hi - lo + 1):
+                raise ValueError(
+                    f"cron step {step} exceeds range for field {field_name!r} ({lo}-{hi})"
+                )
+            result[field_name] = {"step": step}
+            continue
+
+        # Reject unsupported modifiers early
+        if "-" in raw or "," in raw or "L" in raw or "W" in raw or "#" in raw:
+            raise ValueError(
+                f"unsupported cron syntax in field {field_name!r}: {raw!r} "
+                "(ranges, lists, and L/W/# modifiers are not supported)"
+            )
+
+        # Specific integer value
+        if not raw.lstrip("-").isdigit():
+            raise ValueError(f"invalid cron field {field_name!r} value: {raw!r}")
+        val = int(raw)
+        if not (lo <= val <= hi):
+            raise ValueError(f"cron field {field_name!r} value {val} out of range {lo}-{hi}")
+        result[field_name] = val
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# next_cron_fire
+# ---------------------------------------------------------------------------
+
+
+def next_cron_fire(parsed: dict[str, Any], after: float) -> float:
+    """Compute the next fire time for a parsed cron expression.
+
+    Iterates forward in one-minute increments from ``after + 60`` seconds
+    (i.e. the fire will be *strictly after* ``after``) until a match is
+    found.  Searches up to four years ahead before raising.
+
+    Parameters
+    ----------
+    parsed:
+        The dict returned by :func:`parse_cron`.
+    after:
+        Unix epoch float.  The next fire time will be strictly after this.
+
+    Returns
+    -------
+    float
+        Unix epoch float of the next matching time (seconds at 0).
+
+    Raises
+    ------
+    ValueError
+        If no match is found within a four-year (2,102,400-minute) window.
+    """
+
+    def _matches_field(value: Any, field_name: str, t: int) -> bool:
+        if value == "*":
+            return True
+        if isinstance(value, dict):  # {"step": N}
+            step = value["step"]
+            lo = _CRON_RANGES[field_name][0]
+            return (t - lo) % step == 0
+        # specific integer
+        return t == value
+
+    # Start from the next whole minute after ``after``
+    start_ts = math.ceil(after / 60 + 1) * 60
+    # Four years in minutes
+    max_minutes = 4 * 365 * 24 * 60 + 1  # includes leap years
+
+    for offset in range(max_minutes):
+        candidate_ts = start_ts + offset * 60
+        dt = datetime.fromtimestamp(candidate_ts, tz=timezone.utc)
+        minute = dt.minute
+        hour = dt.hour
+        day = dt.day
+        month = dt.month
+        # Python weekday: Monday=0..Sunday=6 → convert to cron 0=Sun..6=Sat
+        py_weekday = dt.weekday()  # 0=Mon
+        weekday = (py_weekday + 1) % 7  # 0=Sun, 1=Mon … 6=Sat
+
+        if not _matches_field(parsed["minute"], "minute", minute):
+            continue
+        if not _matches_field(parsed["hour"], "hour", hour):
+            continue
+        if not _matches_field(parsed["month"], "month", month):
+            continue
+        # Validate day against month length (cron skips over invalid days)
+        _, max_day = monthrange(dt.year, month)
+        if not _matches_field(parsed["day"], "day", day):
+            continue
+        if day > max_day:
+            continue
+        if not _matches_field(parsed["weekday"], "weekday", weekday):
+            continue
+
+        return float(candidate_ts)
+
+    raise ValueError(f"no cron fire time found within 4 years for expression: {parsed!r}")
+
+
+# ---------------------------------------------------------------------------
+# SchedulerEngine
+# ---------------------------------------------------------------------------
+
+
+class SchedulerEngine:
+    """In-memory scheduler engine with optional persistence via StateStore.
+
+    Thread-safe — all public methods acquire ``_lock`` internally.
+
+    Parameters
+    ----------
+    store:
+        An optional :class:`~lionagi.state.store.StateStore` implementation.
+        When provided the engine writes updated items back to the store after
+        each state mutation.  The store is NOT used for initial population of
+        the in-memory dict — callers must hydrate the engine on startup.
+    """
+
+    def __init__(self, store: Any | None = None) -> None:
+        self._items: dict[str, ScheduleItem] = {}
+        self._store = store
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _compute_next_run(self, item: ScheduleItem) -> float | None:
+        """Return the next run epoch float based on cron or interval.
+
+        Returns ``None`` when the item has no scheduling expression (one-shot
+        items that ran already have no next time).
+
+        For cron items the next fire is computed relative to ``time.time()``.
+        For interval items it is ``last_run_at + interval_seconds`` (or
+        ``time.time() + interval_seconds`` when the item has never run).
+        """
+        now = time.time()
+        if item.cron_expr is not None:
+            try:
+                parsed = parse_cron(item.cron_expr)
+                return next_cron_fire(parsed, after=now)
+            except ValueError:
+                return None
+
+        if item.interval_seconds is not None:
+            base = item.last_run_at if item.last_run_at is not None else now
+            return base + item.interval_seconds
+
+        return None
+
+    def _touch(self, item: ScheduleItem) -> None:
+        """Update ``updated_at`` in place (lock must already be held)."""
+        item.updated_at = time.time()
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
+
+    def add(
+        self,
+        name: str,
+        flow_spec: dict[str, Any],
+        *,
+        cron_expr: str | None = None,
+        interval_seconds: float | None = None,
+        max_runs: int | None = None,
+    ) -> ScheduleItem:
+        """Create and register a new :class:`ScheduleItem`.
+
+        Exactly one of *cron_expr* or *interval_seconds* should be provided.
+        When neither is provided the item is treated as a one-shot scheduled
+        for immediate execution (``next_run_at = now``).
+
+        Parameters
+        ----------
+        name:
+            Human-readable label.
+        flow_spec:
+            Arbitrary dict passed through to the driver for execution.
+        cron_expr:
+            Five-field cron string.  Parsed immediately; raises
+            :exc:`ValueError` on invalid syntax.
+        interval_seconds:
+            Positive float interval in seconds.
+        max_runs:
+            Auto-complete after this many successful runs.  ``None`` = unlimited.
+
+        Returns
+        -------
+        ScheduleItem
+            The newly created item (``status="active"``).
+
+        Raises
+        ------
+        ValueError
+            If *cron_expr* is provided and fails to parse.
+        ValueError
+            If both *cron_expr* and *interval_seconds* are provided.
+        """
+        if cron_expr is not None and interval_seconds is not None:
+            raise ValueError("specify at most one of cron_expr or interval_seconds, not both")
+        if cron_expr is not None:
+            # Validate eagerly so we fail at add time, not at run time.
+            parse_cron(cron_expr)
+
+        now = time.time()
+        # Compute first fire time
+        if cron_expr is not None:
+            parsed = parse_cron(cron_expr)
+            next_run = next_cron_fire(parsed, after=now)
+        elif interval_seconds is not None:
+            if interval_seconds <= 0:
+                raise ValueError("interval_seconds must be positive")
+            next_run = now + interval_seconds
+        else:
+            # One-shot: fire as soon as possible
+            next_run = now
+
+        item = ScheduleItem(
+            name=name,
+            cron_expr=cron_expr,
+            interval_seconds=interval_seconds,
+            next_run_at=next_run,
+            status=STATUS_ACTIVE,
+            max_runs=max_runs,
+            flow_spec=dict(flow_spec),
+            created_at=now,
+            updated_at=now,
+        )
+
+        with self._lock:
+            self._items[item.item_id] = item
+
+        return item
+
+    def remove(self, item_id: str) -> bool:
+        """Remove an item from the engine regardless of current status.
+
+        Returns ``True`` if the item existed and was removed, ``False``
+        if no item with *item_id* was found.
+        """
+        with self._lock:
+            if item_id not in self._items:
+                return False
+            del self._items[item_id]
+        return True
+
+    # ------------------------------------------------------------------
+    # State transitions
+    # ------------------------------------------------------------------
+
+    def pause(self, item_id: str) -> bool:
+        """Transition an active item to ``"paused"``.
+
+        Returns ``True`` on success.  Returns ``False`` if the item is not
+        found or is not in ``"active"`` status (e.g. already running,
+        paused, or terminal).
+        """
+        with self._lock:
+            item = self._items.get(item_id)
+            if item is None:
+                return False
+            if item.status != STATUS_ACTIVE:
+                return False
+            item.status = STATUS_PAUSED
+            self._touch(item)
+        return True
+
+    def resume(self, item_id: str) -> bool:
+        """Transition a paused item back to ``"active"``.
+
+        Recomputes ``next_run_at`` relative to the current time so that a
+        recently resumed interval item does not fire immediately unless it
+        was already due before pausing.
+
+        Returns ``True`` on success, ``False`` if the item is not found or
+        is not ``"paused"``.
+        """
+        with self._lock:
+            item = self._items.get(item_id)
+            if item is None:
+                return False
+            if item.status != STATUS_PAUSED:
+                return False
+            item.status = STATUS_ACTIVE
+            # Recompute next_run_at so the item is not immediately due
+            next_run = self._compute_next_run(item)
+            if next_run is not None:
+                item.next_run_at = next_run
+            self._touch(item)
+        return True
+
+    def mark_started(self, item_id: str) -> bool:
+        """Record that execution of an active item has begun.
+
+        Transitions ``active`` → ``running`` and sets ``last_run_at`` to now.
+
+        Returns ``True`` on success.  Returns ``False`` when the item is not
+        found or is not in ``"active"`` status.
+        """
+        with self._lock:
+            item = self._items.get(item_id)
+            if item is None:
+                return False
+            if item.status != STATUS_ACTIVE:
+                return False
+            now = time.time()
+            item.status = STATUS_RUNNING
+            item.last_run_at = now
+            item.updated_at = now
+        return True
+
+    def mark_completed(self, item_id: str) -> bool:
+        """Record successful completion of a running item.
+
+        Increments ``run_count`` and either:
+
+        * Transitions to ``"completed"`` when ``max_runs`` has been reached.
+        * Transitions back to ``"active"`` and schedules the next run when
+          there are remaining runs (or runs are unlimited).
+
+        Returns ``True`` on success.  Returns ``False`` when the item is not
+        found or is not in ``"running"`` status.
+        """
+        with self._lock:
+            item = self._items.get(item_id)
+            if item is None:
+                return False
+            if item.status != STATUS_RUNNING:
+                return False
+
+            item.run_count += 1
+            now = time.time()
+            item.updated_at = now
+
+            if item.max_runs is not None and item.run_count >= item.max_runs:
+                item.status = STATUS_COMPLETED
+            else:
+                item.status = STATUS_ACTIVE
+                next_run = self._compute_next_run(item)
+                if next_run is not None:
+                    item.next_run_at = next_run
+                # If no next_run (one-shot item), leave next_run_at unchanged;
+                # the item will not be returned by get_due_items again because
+                # status is not active… actually it IS active.  One-shot items
+                # without max_runs will re-fire immediately.  Callers should
+                # set max_runs=1 for true one-shot behaviour.
+        return True
+
+    def mark_failed(self, item_id: str, error: str = "") -> bool:
+        """Record a failed run.
+
+        Transitions ``running`` → ``"failed"`` (terminal).
+
+        Parameters
+        ----------
+        item_id:
+            Item identifier.
+        error:
+            Optional error description stored in ``flow_spec["_last_error"]``
+            for diagnostic inspection.
+
+        Returns ``True`` on success.  Returns ``False`` when the item is not
+        found or is not in ``"running"`` status.
+        """
+        with self._lock:
+            item = self._items.get(item_id)
+            if item is None:
+                return False
+            if item.status != STATUS_RUNNING:
+                return False
+            item.status = STATUS_FAILED
+            item.run_count += 1
+            if error:
+                item.flow_spec["_last_error"] = error
+            self._touch(item)
+        return True
+
+    # ------------------------------------------------------------------
+    # Query
+    # ------------------------------------------------------------------
+
+    def list_items(self, status: str | None = None) -> list[ScheduleItem]:
+        """Return all items, optionally filtered by *status*.
+
+        The returned list is a snapshot; mutations to returned items do not
+        affect the engine's internal state.
+
+        Parameters
+        ----------
+        status:
+            When ``None`` all items are returned.  Otherwise only items whose
+            ``status`` field equals *status* are included.
+
+        Returns
+        -------
+        list[ScheduleItem]
+            Copies of the matching items.
+        """
+        with self._lock:
+            items = list(self._items.values())
+
+        if status is not None:
+            items = [it for it in items if it.status == status]
+
+        return [it.model_copy() for it in items]
+
+    def get_due_items(self) -> list[ScheduleItem]:
+        """Return active items whose ``next_run_at`` is at or before now.
+
+        Only items with ``status == "active"`` are considered.
+
+        Returns
+        -------
+        list[ScheduleItem]
+            Copies of all due items, sorted by ``next_run_at`` ascending.
+        """
+        now = time.time()
+        with self._lock:
+            due = [
+                it.model_copy()
+                for it in self._items.values()
+                if it.status == STATUS_ACTIVE and it.next_run_at <= now
+            ]
+        due.sort(key=lambda it: it.next_run_at)
+        return due
+
+    def get_item(self, item_id: str) -> ScheduleItem | None:
+        """Return a copy of the item with *item_id*, or ``None``."""
+        with self._lock:
+            item = self._items.get(item_id)
+            return item.model_copy() if item is not None else None
+
+    def find_by_prefix(self, prefix: str) -> list[str]:
+        """Return item IDs that start with *prefix*.
+
+        Parameters
+        ----------
+        prefix:
+            ID prefix to match (at least 4 characters recommended).
+
+        Returns
+        -------
+        list[str]
+            List of matching item IDs (may be empty, one, or many).
+        """
+        with self._lock:
+            return [iid for iid in self._items if iid.startswith(prefix)]
+
+
+__all__ = [
+    "ScheduleItem",
+    "SchedulerEngine",
+    "STATUS_ACTIVE",
+    "STATUS_CANCELLED",
+    "STATUS_COMPLETED",
+    "STATUS_FAILED",
+    "STATUS_PAUSED",
+    "STATUS_PENDING",
+    "STATUS_RUNNING",
+    "next_cron_fire",
+    "parse_cron",
+]

--- a/lionagi/work/__init__.py
+++ b/lionagi/work/__init__.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""lionagi.work — structured forms, validation rules, worker definitions, and engine.
+
+Public surface:
+
+    Forms & field specs
+    -------------------
+    FieldSpec       — typed field declaration (name, type, required, default)
+    WorkForm        — structured input/output container with lifecycle status
+    fill_form()     — populate a form with values (auto-validates)
+    validate_form() — validate form values against FieldSpec declarations
+
+    Validation rules
+    ----------------
+    Rule            — single declarative validation rule (required/type/range/pattern/custom)
+    RuleSet         — ordered collection of rules applied to a WorkForm
+
+    Worker definitions
+    ------------------
+    WorkerDefinition — static descriptor for a worker type
+    load_definition() — load from a YAML/JSON path or plain dict
+
+    Engine
+    ------
+    WorkEngine   — orchestrator: register workers, submit forms, query results
+    WorkTask     — runtime record for a single submitted task
+    WorkResult   — outcome of a completed or failed task
+"""
+
+from __future__ import annotations
+
+from .definition import HANDLER_ALLOWED_MODULES, WorkerDefinition, load_definition
+from .engine import WorkEngine, WorkResult, WorkTask
+from .form import VALID_TRANSITIONS, FieldSpec, WorkForm, fill_form, validate_form
+from .rules import REGEX_MATCH_TIMEOUT, REGEX_MAX_INPUT_LENGTH, Rule, RuleSet
+
+__all__ = (
+    # Forms
+    "FieldSpec",
+    "VALID_TRANSITIONS",
+    "WorkForm",
+    "fill_form",
+    "validate_form",
+    # Rules
+    "Rule",
+    "RuleSet",
+    "REGEX_MATCH_TIMEOUT",
+    "REGEX_MAX_INPUT_LENGTH",
+    # Worker definitions
+    "HANDLER_ALLOWED_MODULES",
+    "WorkerDefinition",
+    "load_definition",
+    # Engine
+    "WorkEngine",
+    "WorkResult",
+    "WorkTask",
+)

--- a/lionagi/work/definition.py
+++ b/lionagi/work/definition.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""WorkerDefinition: static descriptor for a worker type.
+
+A WorkerDefinition describes *what a worker can do* — its name, the form
+templates it accepts as input and emits as output, the callable that
+processes a form, and operational constraints (concurrency, timeout).
+
+Definitions are loaded from YAML/JSON files or constructed in Python.
+They are immutable once loaded and can be shared across WorkEngine instances.
+
+Usage::
+
+    # From a dict (e.g., parsed YAML)
+    defn = load_definition({
+        "definition_id": "summarise",
+        "name": "Summarise Worker",
+        "description": "Summarises text fields.",
+        "input_form": "text_input",
+        "output_form": "summary_output",
+        "handler": "mypackage.workers.summarise_handler",
+        "max_concurrent": 4,
+        "timeout_seconds": 60,
+    })
+
+    # From a YAML file path
+    defn = load_definition("/path/to/worker.yaml")
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field, model_validator
+
+__all__ = (
+    "HANDLER_ALLOWED_MODULES",
+    "WorkerDefinition",
+    "load_definition",
+)
+
+# Allowlist of top-level package prefixes that ``resolve_handler`` may import
+# from.  Handlers whose module does not start with one of these prefixes are
+# rejected to prevent arbitrary code execution from YAML/JSON config.
+#
+# Extend at application startup::
+#
+#     from lionagi.work.definition import HANDLER_ALLOWED_MODULES
+#     HANDLER_ALLOWED_MODULES.add("myapp.workers")
+#
+HANDLER_ALLOWED_MODULES: set[str] = {"lionagi.work"}
+
+
+class WorkerDefinition(BaseModel):
+    """Static descriptor for a worker type.
+
+    Attributes:
+        definition_id: Unique identifier for this worker type (e.g., ``"summarise"``).
+        name: Human-readable display name.
+        description: Purpose of this worker.
+        input_form: Form template ID that this worker accepts as input.
+        output_form: Form template ID that this worker produces as output.
+        handler: Dotted Python path to the callable that processes a WorkForm.
+            Must be importable at runtime.  Signature:
+            ``handler(form: WorkForm) -> Any``.
+        max_concurrent: Maximum number of simultaneous in-flight tasks for
+            this worker type.  ``0`` means unlimited.
+        timeout_seconds: How long (seconds) an individual task may run before
+            the engine cancels it.  ``0`` means no timeout.
+        tags: Optional list of string tags for categorisation and filtering.
+        extra: Additional metadata preserved as-is (for tooling, documentation).
+    """
+
+    definition_id: str = Field(..., description="Unique worker type identifier.")
+    name: str = Field(..., description="Display name.")
+    description: str = Field("", description="Purpose of this worker.")
+    input_form: str = Field(..., description="ID of the input form template.")
+    output_form: str = Field(..., description="ID of the output form template.")
+    handler: str = Field(
+        ...,
+        description="Dotted path to the handler callable, e.g. 'pkg.module.fn'.",
+    )
+    max_concurrent: int = Field(
+        1,
+        ge=0,
+        description="Max simultaneous tasks (0 = unlimited).",
+    )
+    timeout_seconds: int = Field(
+        0,
+        ge=0,
+        description="Per-task timeout in seconds (0 = no timeout).",
+    )
+    tags: list[str] = Field(default_factory=list, description="Optional tags.")
+    extra: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Arbitrary extra metadata.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_handler_format(self) -> WorkerDefinition:
+        parts = self.handler.split(".")
+        if len(parts) < 2:
+            raise ValueError(
+                f"handler must be a dotted path with at least one module component, "
+                f"e.g. 'mymodule.fn'.  Got {self.handler!r}."
+            )
+        return self
+
+    def resolve_handler(self) -> Callable[..., Any]:
+        """Import and return the callable identified by :attr:`handler`.
+
+        The module path must start with one of the prefixes listed in
+        :data:`HANDLER_ALLOWED_MODULES`.  This prevents arbitrary code
+        execution when handler paths are sourced from untrusted YAML/JSON
+        config (e.g., ``os.system`` or ``subprocess.call`` would otherwise
+        resolve successfully).
+
+        To allow additional packages, extend ``HANDLER_ALLOWED_MODULES``
+        before calling this method::
+
+            from lionagi.work.definition import HANDLER_ALLOWED_MODULES
+            HANDLER_ALLOWED_MODULES.add("myapp.workers")
+
+        Raises:
+            ValueError: If the handler's module prefix is not in the allowlist.
+            ImportError: If the module cannot be imported.
+            AttributeError: If the callable cannot be found in the module.
+            TypeError: If the resolved attribute is not callable.
+        """
+        module_path, attr = self.handler.rsplit(".", 1)
+
+        # Security: enforce allowlist before any import.
+        if not any(
+            module_path == prefix or module_path.startswith(prefix + ".")
+            for prefix in HANDLER_ALLOWED_MODULES
+        ):
+            raise ValueError(
+                f"Handler module {module_path!r} is not in the allowed module list "
+                f"({sorted(HANDLER_ALLOWED_MODULES)}).  "
+                f"Add the package prefix to HANDLER_ALLOWED_MODULES to permit it."
+            )
+
+        mod = importlib.import_module(module_path)
+        fn = getattr(mod, attr)
+        if not callable(fn):
+            raise TypeError(f"handler {self.handler!r} resolved to {fn!r}, which is not callable.")
+        return fn
+
+
+def load_definition(source: str | dict[str, Any]) -> WorkerDefinition:
+    """Load a :class:`WorkerDefinition` from a file path or a dict.
+
+    Supported file formats: JSON (``.json``), YAML (``.yaml`` / ``.yml``).
+    When *source* is a ``dict``, it is passed directly to
+    ``WorkerDefinition.model_validate``.
+
+    Args:
+        source: Path string (to a YAML or JSON file) or a plain dict.
+
+    Returns:
+        A validated :class:`WorkerDefinition` instance.
+
+    Raises:
+        FileNotFoundError: If *source* is a path that doesn't exist.
+        ValueError: If the file extension is unsupported.
+        pydantic.ValidationError: If required fields are missing or invalid.
+    """
+    if isinstance(source, dict):
+        return WorkerDefinition.model_validate(source)
+
+    path = Path(source)
+    if not path.exists():
+        raise FileNotFoundError(f"WorkerDefinition file not found: {path}")
+
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        data: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+    elif suffix in {".yaml", ".yml"}:
+        try:
+            import yaml  # optional dep — only needed when loading YAML files
+        except ImportError as exc:
+            raise ImportError(
+                "PyYAML is required to load YAML worker definitions.  "
+                "Install it with: pip install pyyaml"
+            ) from exc
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    else:
+        raise ValueError(
+            f"Unsupported definition file format {suffix!r}.  Use .json, .yaml, or .yml."
+        )
+
+    return WorkerDefinition.model_validate(data)

--- a/lionagi/work/engine.py
+++ b/lionagi/work/engine.py
@@ -240,9 +240,21 @@ class WorkEngine:
         work).
 
         Returns the task_id.
+
+        Raises:
+            ValueError: No workers registered, *worker_id* not found, or *form*
+                is in a status that cannot be submitted.
+            RuntimeError: Worker is at its concurrency limit.
         """
         import asyncio
         import inspect
+
+        _submittable = {"draft", "filled", "validated"}
+        if form.status not in _submittable:
+            raise ValueError(
+                f"Cannot submit a form in {form.status!r} status.  "
+                f"Only {sorted(_submittable)} forms are accepted."
+            )
 
         with self._lock:
             slot = self._resolve_slot(worker_id)

--- a/lionagi/work/engine.py
+++ b/lionagi/work/engine.py
@@ -1,0 +1,407 @@
+# Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""WorkEngine: orchestration layer that dispatches WorkForms to workers.
+
+The engine is the runtime coordinator:
+
+- Workers register themselves (by definition_id) along with their handler
+  callables.
+- Callers submit a WorkForm; the engine picks a worker, creates a WorkTask,
+  executes the handler, and stores the result.
+- All state mutations are protected by a ``threading.Lock`` so the engine is
+  safe to use from multiple threads.
+
+Execution model
+---------------
+Handlers are called *synchronously* in the current thread by default.  For
+async handlers, use :meth:`WorkEngine.submit_async` which awaits the handler
+in the current event loop.  Timeout enforcement for async handlers is done via
+``asyncio.wait_for``.
+
+Concurrency (max_concurrent) is enforced as a simple gate: if a worker is
+already at its concurrency limit, ``submit`` raises ``RuntimeError`` rather
+than queuing (queueing is the caller's responsibility).
+
+Usage::
+
+    engine = WorkEngine()
+    engine.register_worker(
+        definition=defn,
+        handler=my_callable,  # (form: WorkForm) -> Any
+    )
+    task_id = engine.submit(form, worker_id="summarise")
+    result  = engine.get_result(task_id)
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import threading
+import time
+import uuid
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from .definition import WorkerDefinition
+from .form import WorkForm
+
+__all__ = (
+    "WorkEngine",
+    "WorkResult",
+    "WorkTask",
+)
+
+TaskStatus = Literal["queued", "running", "completed", "failed"]
+
+
+class WorkResult(BaseModel):
+    """Outcome of a completed (or failed) work task.
+
+    Attributes:
+        task_id: Links back to the originating :class:`WorkTask`.
+        value: Return value from the handler, or ``None`` on failure.
+        error: Error message string on failure, ``None`` on success.
+    """
+
+    task_id: str = Field(..., description="ID of the task that produced this result.")
+    value: Any = Field(None, description="Handler return value on success.")
+    error: str | None = Field(None, description="Error message on failure.")
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    @property
+    def success(self) -> bool:
+        """Return True when no error is recorded."""
+        return self.error is None
+
+
+class WorkTask(BaseModel):
+    """Runtime record for a single submitted work item.
+
+    Attributes:
+        task_id: Unique identifier for this task.
+        form_id: ID of the WorkForm that was submitted.
+        worker_id: definition_id of the worker assigned to this task.
+        status: Current lifecycle phase.
+        result: Populated after the task completes or fails.
+        error: Short error message (also stored in result.error).
+        submitted_at: Unix timestamp when the task was created.
+        completed_at: Unix timestamp when the task finished (or None).
+    """
+
+    task_id: str = Field(
+        default_factory=lambda: str(uuid.uuid4()),
+        description="Unique task identifier.",
+    )
+    form_id: str = Field(..., description="ID of the submitted WorkForm.")
+    worker_id: str = Field(..., description="definition_id of the assigned worker.")
+    status: TaskStatus = Field("queued", description="Current task status.")
+    result: Any = Field(None, description="Handler return value after completion.")
+    error: str | None = Field(None, description="Error message if the task failed.")
+    submitted_at: float = Field(
+        default_factory=time.time,
+        description="Unix timestamp of submission.",
+    )
+    completed_at: float | None = Field(
+        None,
+        description="Unix timestamp of completion (None while in-flight).",
+    )
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    @property
+    def is_terminal(self) -> bool:
+        """Return True when the task has reached a final state."""
+        return self.status in {"completed", "failed"}
+
+    @property
+    def duration(self) -> float | None:
+        """Elapsed seconds from submission to completion, or None."""
+        if self.completed_at is None:
+            return None
+        return self.completed_at - self.submitted_at
+
+
+class _WorkerSlot:
+    """Internal: tracks a registered worker and its in-flight count."""
+
+    def __init__(self, definition: WorkerDefinition, handler: Any) -> None:
+        self.definition = definition
+        self.handler = handler
+        self.in_flight: int = 0
+
+    @property
+    def at_capacity(self) -> bool:
+        limit = self.definition.max_concurrent
+        return limit > 0 and self.in_flight >= limit
+
+
+class WorkEngine:
+    """Synchronous orchestration engine for dispatching WorkForms.
+
+    Thread-safe via an internal ``threading.Lock``.
+
+    Attributes:
+        name: Optional display name for this engine instance.
+    """
+
+    def __init__(self, name: str = "default") -> None:
+        self.name = name
+        self._lock = threading.Lock()
+        self._workers: dict[str, _WorkerSlot] = {}
+        self._tasks: dict[str, WorkTask] = {}
+
+    # ------------------------------------------------------------------
+    # Worker registration
+    # ------------------------------------------------------------------
+
+    def register_worker(
+        self,
+        definition: WorkerDefinition,
+        handler: Any | None = None,
+    ) -> None:
+        """Register a worker with the engine.
+
+        Args:
+            definition: Static descriptor for this worker type.
+            handler: The callable that processes a WorkForm.  If None, the
+                engine will try ``definition.resolve_handler()`` at submit time.
+        """
+        if handler is None:
+            handler = definition.resolve_handler()
+        with self._lock:
+            self._workers[definition.definition_id] = _WorkerSlot(definition, handler)
+
+    def unregister_worker(self, worker_id: str) -> bool:
+        """Remove a worker registration.  Returns True if it existed."""
+        with self._lock:
+            if worker_id in self._workers:
+                del self._workers[worker_id]
+                return True
+            return False
+
+    def worker_ids(self) -> list[str]:
+        """Return a list of all registered worker IDs."""
+        with self._lock:
+            return list(self._workers.keys())
+
+    # ------------------------------------------------------------------
+    # Task submission
+    # ------------------------------------------------------------------
+
+    def submit(self, form: WorkForm, worker_id: str | None = None) -> str:
+        """Submit *form* for processing and return its task_id.
+
+        Args:
+            form: The WorkForm to process.  Must be in ``draft``, ``validated``,
+                or ``filled`` status.  Forms in ``submitted``, ``completed``, or
+                ``error`` status are rejected to enforce the lifecycle.
+            worker_id: Which worker to use.  If None, the first registered
+                worker is used (useful when there is only one).
+
+        Returns:
+            The ``task_id`` string that can be passed to :meth:`get_result`.
+
+        Raises:
+            ValueError: No workers registered, *worker_id* not found, or *form*
+                is in a status that cannot be submitted.
+            RuntimeError: Worker is at its concurrency limit.
+        """
+        _submittable = {"draft", "filled", "validated"}
+        if form.status not in _submittable:
+            raise ValueError(
+                f"Cannot submit a form in {form.status!r} status.  "
+                f"Only {sorted(_submittable)} forms are accepted."
+            )
+        with self._lock:
+            slot = self._resolve_slot(worker_id)
+            if slot.at_capacity:
+                raise RuntimeError(
+                    f"Worker {slot.definition.definition_id!r} is at its concurrency "
+                    f"limit ({slot.definition.max_concurrent})."
+                )
+
+            task = WorkTask(form_id=form.form_id, worker_id=slot.definition.definition_id)
+            self._tasks[task.task_id] = task
+            slot.in_flight += 1
+
+        # Execute outside the lock so other threads aren't blocked.
+        self._run_task(task, slot, form)
+        return task.task_id
+
+    async def submit_async(self, form: WorkForm, worker_id: str | None = None) -> str:
+        """Async variant of :meth:`submit` for coroutine handlers.
+
+        If the handler is a coroutine function, it is awaited with the
+        configured timeout (if any).  If the handler is a plain callable,
+        it is called directly in the event loop (use an executor for blocking
+        work).
+
+        Returns the task_id.
+        """
+        import asyncio
+        import inspect
+
+        with self._lock:
+            slot = self._resolve_slot(worker_id)
+            if slot.at_capacity:
+                raise RuntimeError(
+                    f"Worker {slot.definition.definition_id!r} is at its concurrency "
+                    f"limit ({slot.definition.max_concurrent})."
+                )
+            task = WorkTask(form_id=form.form_id, worker_id=slot.definition.definition_id)
+            self._tasks[task.task_id] = task
+            slot.in_flight += 1
+
+        try:
+            with self._lock:
+                task.status = "running"  # type: ignore[assignment]
+
+            timeout = slot.definition.timeout_seconds or None
+            if inspect.iscoroutinefunction(slot.handler):
+                coro = slot.handler(form)
+                value = await (asyncio.wait_for(coro, timeout=timeout) if timeout else coro)
+            else:
+                value = slot.handler(form)
+
+            with self._lock:
+                task.status = "completed"  # type: ignore[assignment]
+                task.result = value
+                task.completed_at = time.time()
+        except Exception as exc:  # noqa: BLE001
+            with self._lock:
+                task.status = "failed"  # type: ignore[assignment]
+                task.error = f"{type(exc).__name__}: {exc}"
+                task.completed_at = time.time()
+        finally:
+            with self._lock:
+                slot.in_flight = max(0, slot.in_flight - 1)
+
+        return task.task_id
+
+    # ------------------------------------------------------------------
+    # Task queries
+    # ------------------------------------------------------------------
+
+    def get_result(self, task_id: str) -> WorkResult | None:
+        """Return a :class:`WorkResult` for a completed/failed task.
+
+        Returns ``None`` if the task is still in-flight or does not exist.
+        """
+        with self._lock:
+            task = self._tasks.get(task_id)
+            if task is None or not task.is_terminal:
+                return None
+            return WorkResult(task_id=task_id, value=task.result, error=task.error)
+
+    def get_task(self, task_id: str) -> WorkTask | None:
+        """Return the raw WorkTask for *task_id*, or None."""
+        with self._lock:
+            return self._tasks.get(task_id)
+
+    def list_tasks(self, status: TaskStatus | None = None) -> list[WorkTask]:
+        """Return all tasks, optionally filtered by *status*.
+
+        Args:
+            status: When provided, only tasks matching this status are returned.
+
+        Returns:
+            List of :class:`WorkTask` instances, ordered by submission time.
+        """
+        with self._lock:
+            tasks = list(self._tasks.values())
+        if status is not None:
+            tasks = [t for t in tasks if t.status == status]
+        return sorted(tasks, key=lambda t: t.submitted_at)
+
+    def clear_completed(self) -> int:
+        """Remove all completed and failed tasks from memory.  Returns count removed."""
+        with self._lock:
+            to_remove = [tid for tid, t in self._tasks.items() if t.is_terminal]
+            for tid in to_remove:
+                del self._tasks[tid]
+            return len(to_remove)
+
+    # ------------------------------------------------------------------
+    # Public ID-resolution helpers (used by CLI schedule.py)
+    # ------------------------------------------------------------------
+
+    def get_item(self, item_id: str) -> WorkTask | None:
+        """Return the WorkTask for *item_id*, or None.
+
+        Alias for :meth:`get_task` that presents a stable public surface
+        for callers that don't want to assume the internal storage name.
+        """
+        return self.get_task(item_id)
+
+    def find_by_prefix(self, prefix: str) -> list[str]:
+        """Return task IDs that start with *prefix*.
+
+        Args:
+            prefix: ID prefix to match (at least 4 characters recommended).
+
+        Returns:
+            List of matching task IDs (may be empty, one, or many).
+        """
+        with self._lock:
+            return [tid for tid in self._tasks if tid.startswith(prefix)]
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _resolve_slot(self, worker_id: str | None) -> _WorkerSlot:
+        """Return the slot for *worker_id* (or the sole registered worker)."""
+        if not self._workers:
+            raise ValueError("No workers registered with this engine.")
+        if worker_id is None:
+            if len(self._workers) != 1:
+                raise ValueError("worker_id is required when more than one worker is registered.")
+            return next(iter(self._workers.values()))
+        if worker_id not in self._workers:
+            raise ValueError(
+                f"No worker registered with id {worker_id!r}.  Available: {list(self._workers)}."
+            )
+        return self._workers[worker_id]
+
+    def _run_task(self, task: WorkTask, slot: _WorkerSlot, form: WorkForm) -> None:
+        """Execute handler synchronously, updating task state.
+
+        Timeout enforcement uses ``concurrent.futures.ThreadPoolExecutor`` so
+        it is safe to call from any thread (unlike ``signal.SIGALRM``, which
+        crashes with ``ValueError`` when called outside the main thread and is
+        process-global, meaning concurrent timeouts clobber each other).
+        """
+        timeout = slot.definition.timeout_seconds or None
+
+        with self._lock:
+            task.status = "running"  # type: ignore[assignment]
+
+        try:
+            if timeout:
+                with concurrent.futures.ThreadPoolExecutor(max_workers=1) as _executor:
+                    future = _executor.submit(slot.handler, form)
+                    try:
+                        value = future.result(timeout=timeout)
+                    except concurrent.futures.TimeoutError as exc:
+                        future.cancel()
+                        raise TimeoutError(
+                            f"Task {task.task_id} timed out after {timeout}s."
+                        ) from exc
+            else:
+                value = slot.handler(form)
+
+            with self._lock:
+                task.status = "completed"  # type: ignore[assignment]
+                task.result = value
+                task.completed_at = time.time()
+        except Exception as exc:  # noqa: BLE001
+            with self._lock:
+                task.status = "failed"  # type: ignore[assignment]
+                task.error = f"{type(exc).__name__}: {exc}"
+                task.completed_at = time.time()
+        finally:
+            with self._lock:
+                slot.in_flight = max(0, slot.in_flight - 1)

--- a/lionagi/work/form.py
+++ b/lionagi/work/form.py
@@ -1,0 +1,256 @@
+# Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""WorkForm: structured input/output container for worker tasks.
+
+A WorkForm captures a typed specification (FieldSpec) for every input
+and output slot a worker needs, tracks live values, and records the
+validation status of those values.  The lifecycle is:
+
+    draft → filled → validated  (happy path)
+    draft → filled → error      (validation failed)
+    validated → submitted       (engine accepted it)
+    submitted → completed       (worker finished)
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+__all__ = (
+    "FieldSpec",
+    "VALID_TRANSITIONS",
+    "WorkForm",
+    "fill_form",
+    "validate_form",
+)
+
+# Allowed value-type labels.  "list" and "dict" are JSON containers.
+FieldType = Literal["str", "int", "float", "bool", "list", "dict"]
+
+_PYTHON_TYPE_MAP: dict[FieldType, type] = {
+    "str": str,
+    "int": int,
+    "float": float,
+    "bool": bool,
+    "list": list,
+    "dict": dict,
+}
+
+FormStatus = Literal["draft", "filled", "validated", "error", "submitted", "completed"]
+
+# Allowed lifecycle transitions.  Any move not listed here is invalid.
+VALID_TRANSITIONS: dict[str, frozenset[str]] = {
+    "draft": frozenset({"filled"}),
+    "filled": frozenset({"validated", "error"}),
+    "validated": frozenset({"submitted", "error"}),
+    "error": frozenset({"draft"}),  # allow re-opening for correction
+    "submitted": frozenset({"completed", "error"}),
+    "completed": frozenset(),  # terminal — no outgoing transitions
+}
+
+
+class FieldSpec(BaseModel):
+    """Declaration of a single field inside a WorkForm.
+
+    Attributes:
+        name: Machine-readable field name (alphanumeric + underscores).
+        type: Expected Python type expressed as a string literal.
+        required: When True, the form cannot be validated with this field absent or None.
+        default: Value used when the field is absent and not required.
+        description: Human-readable explanation of this field's purpose.
+    """
+
+    name: str = Field(..., description="Field identifier (alphanumeric + underscores).")
+    type: FieldType = Field("str", description="Expected value type.")
+    required: bool = Field(True, description="Whether this field must be supplied.")
+    default: Any = Field(None, description="Default value when field is absent.")
+    description: str = Field("", description="Human-readable description.")
+
+    @model_validator(mode="after")
+    def _validate_name(self) -> FieldSpec:
+        if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", self.name):
+            raise ValueError(
+                f"Field name {self.name!r} must start with a letter or underscore "
+                "and contain only alphanumeric characters and underscores."
+            )
+        return self
+
+    def coerce(self, value: Any) -> Any:
+        """Attempt to coerce *value* to this field's declared type.
+
+        Returns the coerced value on success, raises ``TypeError`` on failure.
+        """
+        if value is None:
+            return None
+        target = _PYTHON_TYPE_MAP[self.type]
+        if isinstance(value, target):
+            return value
+        # Numeric widening: int → float is allowed.
+        if self.type == "float" and isinstance(value, int):
+            return float(value)
+        # str → bool special case.
+        if self.type == "bool" and isinstance(value, str):
+            if value.lower() in {"true", "1", "yes"}:
+                return True
+            if value.lower() in {"false", "0", "no"}:
+                return False
+        # str → int / float.
+        if self.type in {"int", "float"} and isinstance(value, str):
+            try:
+                return target(value)
+            except ValueError:
+                pass
+        raise TypeError(
+            f"Field {self.name!r} expects type {self.type!r}, "
+            f"got {type(value).__name__!r} with value {value!r}."
+        )
+
+
+class WorkForm(BaseModel):
+    """A structured data container for a single worker invocation.
+
+    Attributes:
+        form_id: Unique string identifier (template name + optional suffix).
+        title: Human-readable label shown in UI and logs.
+        fields: Ordered mapping from field name to its FieldSpec.
+        values: Mutable mapping from field name to its current value.
+        status: Lifecycle status of this form instance.
+        validation_errors: List of human-readable error messages from the last
+            call to :func:`validate_form`.
+    """
+
+    form_id: str = Field(..., description="Unique form identifier.")
+    title: str = Field("", description="Human-readable form title.")
+    fields: dict[str, FieldSpec] = Field(
+        default_factory=dict,
+        description="Field name → FieldSpec mapping.",
+    )
+    values: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Current field values.",
+    )
+    status: FormStatus = Field("draft", description="Form lifecycle status.")
+    validation_errors: list[str] = Field(
+        default_factory=list,
+        description="Errors from the most recent validation pass.",
+    )
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    def get(self, name: str, default: Any = None) -> Any:
+        """Return the value for *name*, falling back to *default*."""
+        return self.values.get(name, default)
+
+    def field_names(self) -> list[str]:
+        """Return the list of declared field names."""
+        return list(self.fields.keys())
+
+    def is_complete(self) -> bool:
+        """Return True when status is ``validated`` or ``completed``."""
+        return self.status in {"validated", "completed"}
+
+    def transition_to(self, new_status: FormStatus) -> WorkForm:
+        """Return a *new* WorkForm after validating the status transition.
+
+        Args:
+            new_status: The desired next lifecycle status.
+
+        Returns:
+            A new WorkForm with ``status`` set to *new_status*.
+
+        Raises:
+            ValueError: If the transition from the current status to
+                *new_status* is not permitted by :data:`VALID_TRANSITIONS`.
+        """
+        allowed = VALID_TRANSITIONS.get(self.status, frozenset())
+        if new_status not in allowed:
+            raise ValueError(
+                f"Invalid transition {self.status!r} → {new_status!r}.  "
+                f"Allowed from {self.status!r}: {sorted(allowed) or '(none — terminal state)'}."
+            )
+        return self.model_copy(update={"status": new_status})
+
+
+# ---------------------------------------------------------------------------
+# Functional API
+# ---------------------------------------------------------------------------
+
+
+def fill_form(form: WorkForm, values: dict[str, Any]) -> WorkForm:
+    """Return a *new* WorkForm with *values* merged into it and status updated.
+
+    Missing fields default to their FieldSpec.default.  After filling,
+    ``validate_form`` is called automatically — the returned form will have
+    status ``validated`` or ``error``.
+
+    Args:
+        form: Source form (not mutated).
+        values: Key/value pairs to set on the form.
+
+    Returns:
+        A new WorkForm instance with the merged values and updated status.
+    """
+    merged: dict[str, Any] = {}
+    for name, spec in form.fields.items():
+        if name in values:
+            merged[name] = values[name]
+        elif spec.default is not None:
+            merged[name] = spec.default
+        # If neither values nor default: leave absent so validate_form can flag
+        # it as missing when required.
+
+    # Also propagate any extra keys that are not in spec (kept as-is).
+    for k, v in values.items():
+        if k not in merged:
+            merged[k] = v
+
+    filled = form.model_copy(update={"values": merged, "status": "filled", "validation_errors": []})
+    return validate_form(filled)
+
+
+def validate_form(form: WorkForm) -> WorkForm:
+    """Validate *form* values against its FieldSpec declarations.
+
+    Returns a *new* WorkForm with status ``validated`` when all checks pass,
+    or ``error`` with ``validation_errors`` populated when any check fails.
+
+    Checks performed per field:
+    1. Required fields must be present and not ``None``.
+    2. Present values must be coercible to the declared type.
+
+    Args:
+        form: Form to validate (not mutated).
+
+    Returns:
+        New WorkForm with updated ``status`` and ``validation_errors``.
+    """
+    errors: list[str] = []
+    coerced_values: dict[str, Any] = dict(form.values)
+
+    for name, spec in form.fields.items():
+        value = form.values.get(name)
+
+        # Required check.
+        if spec.required and value is None:
+            errors.append(f"Field {name!r} is required but missing or None.")
+            continue
+
+        # Type check / coercion (only when a value is present).
+        if value is not None:
+            try:
+                coerced_values[name] = spec.coerce(value)
+            except TypeError as exc:
+                errors.append(str(exc))
+
+    new_status: FormStatus = "error" if errors else "validated"
+    return form.model_copy(
+        update={
+            "values": coerced_values,
+            "status": new_status,
+            "validation_errors": errors,
+        }
+    )

--- a/lionagi/work/rules.py
+++ b/lionagi/work/rules.py
@@ -184,22 +184,18 @@ class Rule(BaseModel):
         pattern = self.params.get("pattern", "")
         flags = int(self.params.get("flags", 0))
         try:
-            compiled = re.compile(pattern, flags)
+            re.compile(pattern, flags)
         except re.error as exc:
             return f"Rule {self.rule_id!r}: invalid regex pattern — {exc}."
 
-        def _do_match() -> bool:
-            return bool(compiled.search(value))
-
-        _ex = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        _ex = concurrent.futures.ProcessPoolExecutor(max_workers=1)
         try:
-            future = _ex.submit(_do_match)
+            future = _ex.submit(re.search, pattern, value, flags)
             try:
-                matched = future.result(timeout=REGEX_MATCH_TIMEOUT)
+                result = future.result(timeout=REGEX_MATCH_TIMEOUT)
+                matched = bool(result)
             except concurrent.futures.TimeoutError:
                 future.cancel()
-                # wait=False so we don't block on catastrophic backtracking;
-                # cancel_futures=True signals the executor to drop the work item.
                 _ex.shutdown(wait=False, cancel_futures=True)
                 return (
                     f"Rule {self.rule_id!r}: pattern match timed out after "
@@ -211,7 +207,10 @@ class Rule(BaseModel):
             else:
                 _ex.shutdown(wait=False)
         except Exception as exc:  # noqa: BLE001
-            _ex.shutdown(wait=False)
+            try:
+                _ex.shutdown(wait=False)
+            except Exception:  # noqa: BLE001, S110
+                pass
             return f"Rule {self.rule_id!r}: pattern match raised {type(exc).__name__}: {exc}."
 
         if not matched:

--- a/lionagi/work/rules.py
+++ b/lionagi/work/rules.py
@@ -1,0 +1,278 @@
+# Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+r"""Declarative validation rules for WorkForm fields.
+
+Rules complement FieldSpec by expressing *cross-field* or *value-level*
+constraints that cannot be expressed in a plain type declaration:
+
+- **required**: field must be present (alias for FieldSpec.required, useful
+  when you want rules separate from schema).
+- **type**: re-checks the declared type (useful in rule-only pipelines).
+- **range**: numeric value must fall within [min, max].
+- **pattern**: string value must match a regex pattern.
+- **custom**: arbitrary Python callable.
+
+Usage::
+
+    from lionagi.work.rules import Rule, RuleSet
+    from lionagi.work.form import WorkForm, FieldSpec
+
+    rs = RuleSet()
+    rs.add(Rule(rule_id="r1", field="age", check="range", params={"min": 0, "max": 150}))
+    rs.add(Rule(rule_id="r2", field="email", check="pattern", params={"pattern": r".+@.+\..+"}))
+
+    errors = rs.apply_all(form)
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import re
+from collections.abc import Callable
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from .form import WorkForm
+
+__all__ = (
+    "Rule",
+    "RuleSet",
+    "REGEX_MATCH_TIMEOUT",
+    "REGEX_MAX_INPUT_LENGTH",
+)
+
+# Maximum input length for pattern checks.  Inputs longer than this are
+# rejected before regex evaluation to bound worst-case backtracking time.
+REGEX_MAX_INPUT_LENGTH: int = 10_000
+
+# Timeout (seconds) for a single regex match call.  Protects against
+# catastrophic backtracking in patterns with nested quantifiers.
+REGEX_MATCH_TIMEOUT: float = 1.0
+
+CheckKind = Literal["required", "type", "range", "pattern", "custom"]
+
+
+class Rule(BaseModel):
+    """A single declarative validation rule.
+
+    Attributes:
+        rule_id: Unique identifier within a RuleSet.
+        field: Name of the WorkForm field this rule targets.
+        check: Kind of check to perform.
+        params: Check-specific parameters (see class-level docs).
+        message: Optional override for the generated error message.
+        enabled: When False, this rule is skipped silently.
+    """
+
+    rule_id: str = Field(..., description="Unique rule identifier.")
+    field: str = Field(..., description="WorkForm field name this rule applies to.")
+    check: CheckKind = Field(..., description="Kind of validation check.")
+    params: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Check-specific params.  "
+            "range: {min, max} (either or both optional).  "
+            "pattern: {pattern: str, flags: int (optional)}.  "
+            "type: {type: str} (FieldType literal).  "
+            "custom: {callable: Callable[[Any], bool], error: str}."
+        ),
+    )
+    message: str | None = Field(
+        None,
+        description="Custom error message template (overrides auto-generated text).",
+    )
+    enabled: bool = Field(True, description="Skip rule when False.")
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    def apply(self, form: WorkForm) -> str | None:
+        """Apply this rule to *form*.
+
+        Returns an error string on failure, ``None`` on pass.
+        """
+        if not self.enabled:
+            return None
+
+        value = form.values.get(self.field)
+
+        if self.check == "required":
+            return self._check_required(value)
+        if self.check == "type":
+            return self._check_type(value)
+        if self.check == "range":
+            return self._check_range(value)
+        if self.check == "pattern":
+            return self._check_pattern(value)
+        if self.check == "custom":
+            return self._check_custom(value)
+
+        return f"Rule {self.rule_id!r}: unknown check kind {self.check!r}."
+
+    # ------------------------------------------------------------------
+    # Internal checkers
+    # ------------------------------------------------------------------
+
+    def _check_required(self, value: Any) -> str | None:
+        if value is None:
+            return self.message or f"Field {self.field!r} is required but missing or None."
+        return None
+
+    def _check_type(self, value: Any) -> str | None:
+        if value is None:
+            return None  # type check doesn't apply to absent values
+        expected = self.params.get("type", "str")
+        type_map = {
+            "str": str,
+            "int": int,
+            "float": float,
+            "bool": bool,
+            "list": list,
+            "dict": dict,
+        }
+        target = type_map.get(expected)
+        if target is None:
+            return f"Rule {self.rule_id!r}: unknown type {expected!r}."
+        # Allow int where float is expected.
+        if expected == "float" and isinstance(value, int):
+            return None
+        if not isinstance(value, target):
+            return self.message or (
+                f"Field {self.field!r} must be type {expected!r}, got {type(value).__name__!r}."
+            )
+        return None
+
+    def _check_range(self, value: Any) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, int | float):
+            return (
+                self.message
+                or f"Field {self.field!r}: range check requires numeric type, "
+                f"got {type(value).__name__!r}."
+            )
+        lo = self.params.get("min")
+        hi = self.params.get("max")
+        if lo is not None and value < lo:
+            return self.message or f"Field {self.field!r} = {value} is below minimum {lo}."
+        if hi is not None and value > hi:
+            return self.message or f"Field {self.field!r} = {value} exceeds maximum {hi}."
+        return None
+
+    def _check_pattern(self, value: Any) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            return (
+                self.message
+                or f"Field {self.field!r}: pattern check requires str, "
+                f"got {type(value).__name__!r}."
+            )
+
+        # Guard against catastrophic backtracking (ReDoS):
+        # 1. Reject inputs that exceed the configurable length limit.
+        # 2. Run the match inside a thread with a timeout so patterns with
+        #    nested quantifiers (e.g. ``(a+)+b``) cannot spin forever.
+        if len(value) > REGEX_MAX_INPUT_LENGTH:
+            return (
+                self.message
+                or f"Field {self.field!r}: input length {len(value)} exceeds "
+                f"the maximum allowed for pattern matching ({REGEX_MAX_INPUT_LENGTH})."
+            )
+
+        pattern = self.params.get("pattern", "")
+        flags = int(self.params.get("flags", 0))
+        try:
+            compiled = re.compile(pattern, flags)
+        except re.error as exc:
+            return f"Rule {self.rule_id!r}: invalid regex pattern — {exc}."
+
+        def _do_match() -> bool:
+            return bool(compiled.search(value))
+
+        try:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as _ex:
+                future = _ex.submit(_do_match)
+                try:
+                    matched = future.result(timeout=REGEX_MATCH_TIMEOUT)
+                except concurrent.futures.TimeoutError:
+                    future.cancel()
+                    return (
+                        f"Rule {self.rule_id!r}: pattern match timed out after "
+                        f"{REGEX_MATCH_TIMEOUT}s — pattern may cause catastrophic backtracking."
+                    )
+        except Exception as exc:  # noqa: BLE001
+            return f"Rule {self.rule_id!r}: pattern match raised {type(exc).__name__}: {exc}."
+
+        if not matched:
+            return self.message or (
+                f"Field {self.field!r} value {value!r} does not match pattern {pattern!r}."
+            )
+        return None
+
+    def _check_custom(self, value: Any) -> str | None:
+        fn: Callable[[Any], bool] | None = self.params.get("callable")
+        if fn is None:
+            return f"Rule {self.rule_id!r}: 'custom' check requires params['callable']."
+        try:
+            passed = fn(value)
+        except Exception as exc:  # noqa: BLE001
+            return f"Rule {self.rule_id!r}: custom check raised {type(exc).__name__}: {exc}."
+        if not passed:
+            return self.message or (
+                self.params.get("error")
+                or f"Field {self.field!r} failed custom check {self.rule_id!r}."
+            )
+        return None
+
+
+class RuleSet:
+    """An ordered collection of :class:`Rule` objects.
+
+    Rules are applied in insertion order.  All rules are evaluated (no
+    short-circuit), so the caller gets a complete list of errors.
+
+    Usage::
+
+        rs = RuleSet()
+        rs.add(Rule(...))
+        errors = rs.apply_all(form)
+    """
+
+    def __init__(self) -> None:
+        self._rules: list[Rule] = []
+
+    def add(self, rule: Rule) -> RuleSet:
+        """Append *rule* and return ``self`` for chaining."""
+        self._rules.append(rule)
+        return self
+
+    def remove(self, rule_id: str) -> bool:
+        """Remove the rule with *rule_id*.  Returns True if found."""
+        before = len(self._rules)
+        self._rules = [r for r in self._rules if r.rule_id != rule_id]
+        return len(self._rules) < before
+
+    def get(self, rule_id: str) -> Rule | None:
+        """Return the rule with *rule_id*, or None."""
+        for r in self._rules:
+            if r.rule_id == rule_id:
+                return r
+        return None
+
+    def rules(self) -> list[Rule]:
+        """Return a shallow copy of the rule list."""
+        return list(self._rules)
+
+    def apply_all(self, form: WorkForm) -> list[str]:
+        """Apply every enabled rule to *form*.
+
+        Returns a list of error messages.  An empty list means all rules passed.
+        """
+        errors: list[str] = []
+        for rule in self._rules:
+            err = rule.apply(form)
+            if err is not None:
+                errors.append(err)
+        return errors

--- a/lionagi/work/rules.py
+++ b/lionagi/work/rules.py
@@ -27,7 +27,7 @@ Usage::
 
 from __future__ import annotations
 
-import concurrent.futures
+import multiprocessing
 import re
 from collections.abc import Callable
 from typing import Any, Literal
@@ -188,30 +188,31 @@ class Rule(BaseModel):
         except re.error as exc:
             return f"Rule {self.rule_id!r}: invalid regex pattern — {exc}."
 
-        _ex = concurrent.futures.ProcessPoolExecutor(max_workers=1)
+        def _do_match(p: str, v: str, f: int, q: multiprocessing.Queue) -> None:  # type: ignore[type-arg]
+            q.put(bool(re.search(p, v, f)))
+
+        result_q: multiprocessing.Queue = multiprocessing.Queue()  # type: ignore[type-arg]
+        proc = multiprocessing.Process(target=_do_match, args=(pattern, value, flags, result_q))
+        proc.start()
+        proc.join(timeout=REGEX_MATCH_TIMEOUT)
+        if proc.is_alive():
+            proc.terminate()
+            proc.join(timeout=1)
+            if proc.is_alive():
+                proc.kill()
+                proc.join(timeout=1)
+            return (
+                f"Rule {self.rule_id!r}: pattern match timed out after "
+                f"{REGEX_MATCH_TIMEOUT}s — pattern may cause catastrophic backtracking."
+            )
+        if proc.exitcode != 0:
+            return (
+                f"Rule {self.rule_id!r}: pattern match subprocess exited with code {proc.exitcode}."
+            )
         try:
-            future = _ex.submit(re.search, pattern, value, flags)
-            try:
-                result = future.result(timeout=REGEX_MATCH_TIMEOUT)
-                matched = bool(result)
-            except concurrent.futures.TimeoutError:
-                future.cancel()
-                _ex.shutdown(wait=False, cancel_futures=True)
-                return (
-                    f"Rule {self.rule_id!r}: pattern match timed out after "
-                    f"{REGEX_MATCH_TIMEOUT}s — pattern may cause catastrophic backtracking."
-                )
-            except Exception as exc:  # noqa: BLE001
-                _ex.shutdown(wait=False)
-                return f"Rule {self.rule_id!r}: pattern match raised {type(exc).__name__}: {exc}."
-            else:
-                _ex.shutdown(wait=False)
-        except Exception as exc:  # noqa: BLE001
-            try:
-                _ex.shutdown(wait=False)
-            except Exception:  # noqa: BLE001, S110
-                pass
-            return f"Rule {self.rule_id!r}: pattern match raised {type(exc).__name__}: {exc}."
+            matched = result_q.get_nowait()
+        except Exception:  # noqa: BLE001
+            return f"Rule {self.rule_id!r}: pattern match produced no result."
 
         if not matched:
             return self.message or (

--- a/lionagi/work/rules.py
+++ b/lionagi/work/rules.py
@@ -191,18 +191,27 @@ class Rule(BaseModel):
         def _do_match() -> bool:
             return bool(compiled.search(value))
 
+        _ex = concurrent.futures.ThreadPoolExecutor(max_workers=1)
         try:
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as _ex:
-                future = _ex.submit(_do_match)
-                try:
-                    matched = future.result(timeout=REGEX_MATCH_TIMEOUT)
-                except concurrent.futures.TimeoutError:
-                    future.cancel()
-                    return (
-                        f"Rule {self.rule_id!r}: pattern match timed out after "
-                        f"{REGEX_MATCH_TIMEOUT}s — pattern may cause catastrophic backtracking."
-                    )
+            future = _ex.submit(_do_match)
+            try:
+                matched = future.result(timeout=REGEX_MATCH_TIMEOUT)
+            except concurrent.futures.TimeoutError:
+                future.cancel()
+                # wait=False so we don't block on catastrophic backtracking;
+                # cancel_futures=True signals the executor to drop the work item.
+                _ex.shutdown(wait=False, cancel_futures=True)
+                return (
+                    f"Rule {self.rule_id!r}: pattern match timed out after "
+                    f"{REGEX_MATCH_TIMEOUT}s — pattern may cause catastrophic backtracking."
+                )
+            except Exception as exc:  # noqa: BLE001
+                _ex.shutdown(wait=False)
+                return f"Rule {self.rule_id!r}: pattern match raised {type(exc).__name__}: {exc}."
+            else:
+                _ex.shutdown(wait=False)
         except Exception as exc:  # noqa: BLE001
+            _ex.shutdown(wait=False)
             return f"Rule {self.rule_id!r}: pattern match raised {type(exc).__name__}: {exc}."
 
         if not matched:

--- a/lionagi/work/worker.py
+++ b/lionagi/work/worker.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class Worker(BaseModel):
+    name: str
+    func: Callable
+    retries: int = 0
+    timeout: float | None = None
+
+
+_WORKER_REGISTRY: dict[str, Worker] = {}
+
+
+def worker(
+    func: Callable | None = None,
+    *,
+    name: str | None = None,
+    retries: int = 0,
+    timeout: float | None = None,
+) -> Callable | Worker:
+    if retries < 0:
+        raise ValueError("retries must be >= 0")
+    if timeout is not None and timeout <= 0:
+        raise ValueError("timeout must be positive")
+
+    def decorator(func_to_register: Callable) -> Callable:
+        worker_name = name or func_to_register.__name__
+        registered = Worker(
+            name=worker_name,
+            func=func_to_register,
+            retries=retries,
+            timeout=timeout,
+        )
+        _WORKER_REGISTRY[worker_name] = registered
+        return func_to_register
+
+    if func is None:
+        return decorator
+    return decorator(func)
+
+
+def get_worker(name: str) -> Worker | None:
+    return _WORKER_REGISTRY.get(name)
+
+
+async def invoke_worker(func: Callable, args: dict[str, Any], branch: Any) -> Any:
+    sig = inspect.signature(func)
+    params = sig.parameters
+    call_kwargs = dict(args)
+    if "branch" in params and "branch" not in call_kwargs:
+        call_kwargs["branch"] = branch
+
+    if inspect.iscoroutinefunction(func):
+        return await func(**call_kwargs)
+    return func(**call_kwargs)
+
+
+def clear_worker_registry() -> None:
+    _WORKER_REGISTRY.clear()

--- a/tests/cli/test_cleanup.py
+++ b/tests/cli/test_cleanup.py
@@ -1,0 +1,412 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``li state cleanup`` (lionagi/cli/cleanup.py).
+
+All tests use tmp_path so nothing in the real ~/.lionagi tree is touched.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from lionagi.cli.cleanup import (
+    _format_bytes,
+    cleanup_logs,
+    cleanup_runs,
+    cleanup_teams,
+)
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+_DAY = 86_400
+
+
+def _age(path: Path, days: float) -> None:
+    """Back-date a path's mtime by `days` days from now."""
+    ts = time.time() - days * _DAY
+    os.utime(path, (ts, ts))
+
+
+def _make_run_dir(root: Path, name: str, age_days: float = 0.0) -> Path:
+    """Create a minimal run directory and back-date it."""
+    d = root / name
+    d.mkdir(parents=True)
+    manifest = d / "run.json"
+    manifest.write_text(json.dumps({"run_id": name}), encoding="utf-8")
+    if age_days:
+        _age(d, age_days)
+        _age(manifest, age_days)
+    return d
+
+
+def _make_team_file(root: Path, name: str, *, valid: bool = True) -> Path:
+    """Create a team JSON file; if not valid, write invalid content."""
+    root.mkdir(parents=True, exist_ok=True)
+    p = root / f"{name}.json"
+    if valid:
+        p.write_text(json.dumps({"id": name, "members": []}), encoding="utf-8")
+    else:
+        p.write_text("not json", encoding="utf-8")
+    return p
+
+
+def _make_team_file_no_id(root: Path, name: str) -> Path:
+    """Create a team JSON file that has no ``id`` field."""
+    root.mkdir(parents=True, exist_ok=True)
+    p = root / f"{name}.json"
+    p.write_text(json.dumps({"name": name}), encoding="utf-8")
+    return p
+
+
+def _make_log_file(root: Path, rel: str, age_days: float = 0.0) -> Path:
+    """Create a log file under root and optionally back-date it."""
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("log line\n", encoding="utf-8")
+    if age_days:
+        _age(p, age_days)
+    return p
+
+
+# ── _format_bytes ─────────────────────────────────────────────────────────────
+
+
+def test_format_bytes_b() -> None:
+    assert _format_bytes(512) == "512.0 B"
+
+
+def test_format_bytes_kib() -> None:
+    result = _format_bytes(1024)
+    assert "KiB" in result
+
+
+def test_format_bytes_mib() -> None:
+    result = _format_bytes(1024 * 1024)
+    assert "MiB" in result
+
+
+# ── cleanup_runs ──────────────────────────────────────────────────────────────
+
+
+def test_cleanup_runs_dry_run_does_not_delete(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """Dry-run must not remove any directory."""
+    runs = tmp_path / "runs"
+    _make_run_dir(runs, "old-run", age_days=60)
+
+    result = cleanup_runs(runs, older_than_days=30, dry_run=True)
+
+    assert result["removed"] == 1
+    assert (runs / "old-run").exists(), "dry-run must not remove the directory"
+    out = capsys.readouterr().out
+    assert "dry-run" in out
+    assert "old-run" in out
+
+
+def test_cleanup_runs_removes_old_dirs(tmp_path: Path) -> None:
+    """Old run directories are removed; recent ones are kept."""
+    runs = tmp_path / "runs"
+    _make_run_dir(runs, "old-run-1", age_days=45)
+    _make_run_dir(runs, "old-run-2", age_days=60)
+    _make_run_dir(runs, "recent-run", age_days=5)
+
+    result = cleanup_runs(runs, older_than_days=30, dry_run=False)
+
+    assert result["removed"] == 2
+    assert result["errors"] == 0
+    assert not (runs / "old-run-1").exists()
+    assert not (runs / "old-run-2").exists()
+    assert (runs / "recent-run").exists(), "recent run must be kept"
+
+
+def test_cleanup_runs_keeps_recent(tmp_path: Path) -> None:
+    """Runs newer than the threshold must survive."""
+    runs = tmp_path / "runs"
+    _make_run_dir(runs, "run-1d", age_days=1)
+    _make_run_dir(runs, "run-10d", age_days=10)
+
+    result = cleanup_runs(runs, older_than_days=30, dry_run=False)
+
+    assert result["removed"] == 0
+    assert (runs / "run-1d").exists()
+    assert (runs / "run-10d").exists()
+
+
+def test_cleanup_runs_missing_root_is_noop(tmp_path: Path) -> None:
+    """Non-existent runs root must not raise; returns zeros."""
+    result = cleanup_runs(tmp_path / "no-such-dir", older_than_days=30, dry_run=False)
+    assert result["removed"] == 0
+    assert result["errors"] == 0
+
+
+def test_cleanup_runs_counts_bytes(tmp_path: Path) -> None:
+    """bytes_freed should be positive when directories contain files."""
+    runs = tmp_path / "runs"
+    d = _make_run_dir(runs, "old", age_days=60)
+    # Write a file with known content so there is something to measure.
+    (d / "data.txt").write_bytes(b"x" * 1024)
+    _age(d, 60)
+
+    result = cleanup_runs(runs, older_than_days=30, dry_run=False)
+
+    assert result["removed"] == 1
+    assert result["bytes_freed"] > 0
+
+
+def test_cleanup_runs_older_than_filtering(tmp_path: Path) -> None:
+    """--older-than boundary: exactly-at-threshold is kept, one-day-over is removed."""
+    runs = tmp_path / "runs"
+    # 29 days old — should be kept when threshold is 30
+    _make_run_dir(runs, "barely-recent", age_days=29)
+    # 31 days old — should be removed
+    _make_run_dir(runs, "just-over", age_days=31)
+
+    result = cleanup_runs(runs, older_than_days=30, dry_run=False)
+
+    assert result["removed"] == 1
+    assert (runs / "barely-recent").exists()
+    assert not (runs / "just-over").exists()
+
+
+# ── cleanup_teams ─────────────────────────────────────────────────────────────
+
+
+def test_cleanup_teams_dry_run_does_not_delete(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """Dry-run must not remove any file."""
+    teams = tmp_path / "teams"
+    p = _make_team_file(teams, "orphan", valid=False)
+
+    result = cleanup_teams(teams, dry_run=True)
+
+    assert result["removed"] == 1
+    assert p.exists(), "dry-run must not remove the file"
+    out = capsys.readouterr().out
+    assert "dry-run" in out
+
+
+def test_cleanup_teams_removes_invalid_json(tmp_path: Path) -> None:
+    """Team files with unparseable JSON are treated as orphaned and removed."""
+    teams = tmp_path / "teams"
+    bad = _make_team_file(teams, "bad", valid=False)
+    good = _make_team_file(teams, "good", valid=True)
+
+    result = cleanup_teams(teams, dry_run=False)
+
+    assert result["removed"] == 1
+    assert not bad.exists()
+    assert good.exists()
+
+
+def test_cleanup_teams_removes_no_id(tmp_path: Path) -> None:
+    """Team files without an ``id`` field are orphaned."""
+    teams = tmp_path / "teams"
+    p = _make_team_file_no_id(teams, "noid")
+
+    result = cleanup_teams(teams, dry_run=False)
+
+    assert result["removed"] == 1
+    assert not p.exists()
+
+
+def test_cleanup_teams_keeps_valid_files(tmp_path: Path) -> None:
+    """Valid team files with an ``id`` are NOT removed."""
+    teams = tmp_path / "teams"
+    _make_team_file(teams, "alpha", valid=True)
+    _make_team_file(teams, "beta", valid=True)
+
+    result = cleanup_teams(teams, dry_run=False)
+
+    assert result["removed"] == 0
+    assert (teams / "alpha.json").exists()
+    assert (teams / "beta.json").exists()
+
+
+def test_cleanup_teams_missing_root_is_noop(tmp_path: Path) -> None:
+    result = cleanup_teams(tmp_path / "no-teams", dry_run=False)
+    assert result["removed"] == 0
+
+
+# ── cleanup_logs ──────────────────────────────────────────────────────────────
+
+
+def test_cleanup_logs_dry_run_does_not_delete(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    logs = tmp_path / "logs"
+    p = _make_log_file(logs, "old.log", age_days=60)
+
+    result = cleanup_logs(logs, older_than_days=30, dry_run=True)
+
+    assert result["removed"] == 1
+    assert p.exists()
+    out = capsys.readouterr().out
+    assert "dry-run" in out
+
+
+def test_cleanup_logs_removes_old_files(tmp_path: Path) -> None:
+    logs = tmp_path / "logs"
+    old_log = _make_log_file(logs, "session.log", age_days=60)
+    old_jsonl = _make_log_file(logs, "sub/events.jsonl", age_days=45)
+    recent = _make_log_file(logs, "recent.log", age_days=5)
+
+    result = cleanup_logs(logs, older_than_days=30, dry_run=False)
+
+    assert result["removed"] == 2
+    assert not old_log.exists()
+    assert not old_jsonl.exists()
+    assert recent.exists()
+
+
+def test_cleanup_logs_older_than_filtering(tmp_path: Path) -> None:
+    logs = tmp_path / "logs"
+    _make_log_file(logs, "a.log", age_days=29)
+    _make_log_file(logs, "b.log", age_days=31)
+
+    result = cleanup_logs(logs, older_than_days=30, dry_run=False)
+
+    assert result["removed"] == 1
+    assert (logs / "a.log").exists()
+    assert not (logs / "b.log").exists()
+
+
+def test_cleanup_logs_missing_root_is_noop(tmp_path: Path) -> None:
+    result = cleanup_logs(tmp_path / "no-logs", older_than_days=30, dry_run=False)
+    assert result["removed"] == 0
+
+
+# ── run_cleanup integration ───────────────────────────────────────────────────
+
+
+def test_run_cleanup_force_skips_confirmation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """--force must bypass the interactive confirmation prompt."""
+    import argparse
+
+    from lionagi.cli.cleanup import run_cleanup
+
+    monkeypatch.setattr("lionagi._paths.LIONAGI_HOME", tmp_path)
+
+    runs = tmp_path / "runs"
+    _make_run_dir(runs, "old", age_days=60)
+
+    args = argparse.Namespace(
+        older_than=30,
+        dry_run=False,
+        runs=True,
+        teams=False,
+        logs=False,
+        clean_all=False,
+        force=True,
+    )
+    rc = run_cleanup(args)
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    assert "removed" in out
+
+
+def test_run_cleanup_dry_run_all(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """--dry-run with --all prints summary and deletes nothing."""
+    import argparse
+
+    from lionagi.cli.cleanup import run_cleanup
+
+    monkeypatch.setattr("lionagi._paths.LIONAGI_HOME", tmp_path)
+
+    # Populate some state.
+    runs = tmp_path / "runs"
+    _make_run_dir(runs, "old-x", age_days=60)
+    teams = tmp_path / "teams"
+    _make_team_file(teams, "orphan", valid=False)
+    logs = tmp_path / "logs"
+    _make_log_file(logs, "old.log", age_days=60)
+
+    args = argparse.Namespace(
+        older_than=30,
+        dry_run=True,
+        runs=False,
+        teams=False,
+        logs=False,
+        clean_all=True,
+        force=True,
+    )
+    rc = run_cleanup(args)
+    assert rc == 0
+
+    # Nothing must have been deleted.
+    assert (runs / "old-x").exists()
+    assert (teams / "orphan.json").exists()
+    assert (logs / "old.log").exists()
+
+    out = capsys.readouterr().out
+    assert "dry-run" in out
+
+
+def test_run_cleanup_default_scope_is_all(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """When no scope flag is given, the command defaults to cleaning everything."""
+    import argparse
+
+    from lionagi.cli.cleanup import run_cleanup
+
+    monkeypatch.setattr("lionagi._paths.LIONAGI_HOME", tmp_path)
+
+    runs = tmp_path / "runs"
+    _make_run_dir(runs, "old", age_days=60)
+
+    args = argparse.Namespace(
+        older_than=30,
+        dry_run=True,  # safe — nothing will actually be deleted
+        runs=False,
+        teams=False,
+        logs=False,
+        clean_all=False,  # intentionally unset — should default to all
+        force=True,
+    )
+    rc = run_cleanup(args)
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    # With dry_run, we should see the "would remove" summary line.
+    assert "would remove" in out
+
+
+def test_run_cleanup_summary_format(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """Output summary line must contain count and space metrics."""
+    import argparse
+
+    from lionagi.cli.cleanup import run_cleanup
+
+    monkeypatch.setattr("lionagi._paths.LIONAGI_HOME", tmp_path)
+
+    runs = tmp_path / "runs"
+    _make_run_dir(runs, "old", age_days=60)
+
+    args = argparse.Namespace(
+        older_than=30,
+        dry_run=True,
+        runs=True,
+        teams=False,
+        logs=False,
+        clean_all=False,
+        force=True,
+    )
+    run_cleanup(args)
+    out = capsys.readouterr().out
+    # Summary line should mention count and a byte unit.
+    assert "item" in out
+    assert any(unit in out for unit in ("B", "KiB", "MiB", "GiB"))

--- a/tests/test_work/test_worker.py
+++ b/tests/test_work/test_worker.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from lionagi.work.worker import clear_worker_registry, get_worker, worker
+
+
+def test_worker_decorator_registers_and_name_inference():
+    clear_worker_registry()
+
+    @worker()
+    def sample_worker(*, prompt: str):
+        return {"instruction": prompt}
+
+    registered = get_worker("sample_worker")
+    assert registered is not None
+    assert registered.name == "sample_worker"
+    assert registered.func is sample_worker
+
+
+def test_worker_decorator_custom_name():
+    clear_worker_registry()
+
+    @worker(name="custom_name")
+    def base(*, prompt: str):
+        return {"instruction": prompt}
+
+    assert get_worker("custom_name") is not None
+    assert get_worker("base") is None
+
+
+def test_worker_with_explicit_retries_timeout():
+    clear_worker_registry()
+
+    @worker(retries=2, timeout=5.0)
+    def fast(*, prompt: str):
+        return {"instruction": prompt}
+
+    registered = get_worker("fast")
+    assert registered.retries == 2
+    assert registered.timeout == 5.0

--- a/tests/work/test_work_system.py
+++ b/tests/work/test_work_system.py
@@ -1,0 +1,615 @@
+# Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for lionagi.work: forms, rules, definitions, and engine."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import time
+from typing import Any
+
+import pytest
+
+from lionagi.work import (
+    HANDLER_ALLOWED_MODULES,
+    FieldSpec,
+    Rule,
+    RuleSet,
+    WorkEngine,
+    WorkerDefinition,
+    WorkForm,
+    WorkResult,
+    WorkTask,
+    fill_form,
+    load_definition,
+    validate_form,
+)
+
+# Allow the test module's own handlers to be resolved by WorkerDefinition.
+# In production, callers extend HANDLER_ALLOWED_MODULES with their own packages.
+HANDLER_ALLOWED_MODULES.add("tests")
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_form(fields: dict | None = None, values: dict | None = None) -> WorkForm:
+    """Build a simple WorkForm for testing."""
+    specs = {
+        name: FieldSpec(name=name, **spec_kwargs) for name, spec_kwargs in (fields or {}).items()
+    }
+    return WorkForm(form_id="test_form", title="Test Form", fields=specs, values=values or {})
+
+
+def _echo_handler(form: WorkForm) -> dict[str, Any]:
+    """Simple handler that echoes back form values."""
+    return {"echoed": form.values}
+
+
+def _failing_handler(form: WorkForm) -> None:
+    raise ValueError("handler failed on purpose")
+
+
+def _make_defn(handler_path: str = "tests.work.test_work_system._echo_handler") -> WorkerDefinition:
+    return WorkerDefinition(
+        definition_id="echo",
+        name="Echo Worker",
+        input_form="test_form",
+        output_form="test_form",
+        handler=handler_path,
+    )
+
+
+# ---------------------------------------------------------------------------
+# FieldSpec tests
+# ---------------------------------------------------------------------------
+
+
+class TestFieldSpec:
+    def test_defaults(self):
+        spec = FieldSpec(name="x")
+        assert spec.type == "str"
+        assert spec.required is True
+        assert spec.default is None
+        assert spec.description == ""
+
+    def test_name_validation_valid(self):
+        # alphanumeric + underscore starting with letter
+        FieldSpec(name="my_field_1")
+
+    def test_name_validation_invalid_starts_with_digit(self):
+        with pytest.raises(Exception):
+            FieldSpec(name="1bad")
+
+    def test_name_validation_invalid_spaces(self):
+        with pytest.raises(Exception):
+            FieldSpec(name="bad field")
+
+    def test_coerce_str_to_int(self):
+        spec = FieldSpec(name="n", type="int")
+        assert spec.coerce("42") == 42
+
+    def test_coerce_int_to_float(self):
+        spec = FieldSpec(name="n", type="float")
+        assert spec.coerce(3) == 3.0
+        assert isinstance(spec.coerce(3), float)
+
+    def test_coerce_str_to_bool_true(self):
+        spec = FieldSpec(name="flag", type="bool")
+        assert spec.coerce("yes") is True
+        assert spec.coerce("TRUE") is True
+        assert spec.coerce("1") is True
+
+    def test_coerce_str_to_bool_false(self):
+        spec = FieldSpec(name="flag", type="bool")
+        assert spec.coerce("no") is False
+        assert spec.coerce("FALSE") is False
+        assert spec.coerce("0") is False
+
+    def test_coerce_type_mismatch_raises(self):
+        spec = FieldSpec(name="n", type="int")
+        with pytest.raises(TypeError):
+            spec.coerce([1, 2, 3])
+
+    def test_coerce_none_returns_none(self):
+        spec = FieldSpec(name="x", type="str")
+        assert spec.coerce(None) is None
+
+
+# ---------------------------------------------------------------------------
+# WorkForm tests
+# ---------------------------------------------------------------------------
+
+
+class TestWorkForm:
+    def test_creation_defaults(self):
+        form = WorkForm(form_id="f1", title="My Form")
+        assert form.form_id == "f1"
+        assert form.title == "My Form"
+        assert form.fields == {}
+        assert form.values == {}
+        assert form.status == "draft"
+        assert form.validation_errors == []
+
+    def test_field_names(self):
+        form = _make_form({"a": {"type": "str"}, "b": {"type": "int"}})
+        assert set(form.field_names()) == {"a", "b"}
+
+    def test_get_value(self):
+        form = _make_form(values={"x": "hello"})
+        assert form.get("x") == "hello"
+        assert form.get("missing", "default") == "default"
+
+    def test_is_complete_false_on_draft(self):
+        form = _make_form()
+        assert form.is_complete() is False
+
+    def test_is_complete_true_on_validated(self):
+        form = WorkForm(form_id="f", status="validated")
+        assert form.is_complete() is True
+
+    def test_is_complete_true_on_completed(self):
+        form = WorkForm(form_id="f", status="completed")
+        assert form.is_complete() is True
+
+
+# ---------------------------------------------------------------------------
+# validate_form tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidateForm:
+    def test_validates_required_field_present(self):
+        form = _make_form(
+            fields={"name": {"type": "str", "required": True}},
+            values={"name": "Alice"},
+        )
+        result = validate_form(form)
+        assert result.status == "validated"
+        assert result.validation_errors == []
+
+    def test_error_on_missing_required(self):
+        form = _make_form(fields={"name": {"type": "str", "required": True}})
+        result = validate_form(form)
+        assert result.status == "error"
+        assert any("name" in e for e in result.validation_errors)
+
+    def test_optional_field_absent_is_ok(self):
+        form = _make_form(
+            fields={"opt": {"type": "str", "required": False}},
+        )
+        result = validate_form(form)
+        assert result.status == "validated"
+
+    def test_type_mismatch_yields_error(self):
+        form = _make_form(
+            fields={"count": {"type": "int"}},
+            values={"count": [1, 2]},
+        )
+        result = validate_form(form)
+        assert result.status == "error"
+        assert any("count" in e for e in result.validation_errors)
+
+    def test_coerces_string_int(self):
+        form = _make_form(
+            fields={"n": {"type": "int"}},
+            values={"n": "7"},
+        )
+        result = validate_form(form)
+        assert result.status == "validated"
+        assert result.values["n"] == 7
+
+    def test_does_not_mutate_original(self):
+        form = _make_form(
+            fields={"x": {"type": "str"}},
+            values={"x": "hello"},
+        )
+        result = validate_form(form)
+        assert form is not result
+
+
+# ---------------------------------------------------------------------------
+# fill_form tests
+# ---------------------------------------------------------------------------
+
+
+class TestFillForm:
+    def test_fill_and_auto_validate(self):
+        form = _make_form(fields={"msg": {"type": "str"}})
+        result = fill_form(form, {"msg": "hello"})
+        assert result.status == "validated"
+        assert result.values["msg"] == "hello"
+
+    def test_fill_uses_default_when_absent(self):
+        form = _make_form(fields={"level": {"type": "int", "required": False, "default": 1}})
+        result = fill_form(form, {})
+        assert result.values.get("level") == 1
+
+    def test_fill_required_missing_yields_error(self):
+        form = _make_form(fields={"required_field": {"type": "str", "required": True}})
+        result = fill_form(form, {})
+        assert result.status == "error"
+
+    def test_fill_extra_keys_preserved(self):
+        form = _make_form(fields={"a": {"type": "str"}})
+        result = fill_form(form, {"a": "x", "extra": 99})
+        assert result.values.get("extra") == 99
+
+
+# ---------------------------------------------------------------------------
+# Rule tests
+# ---------------------------------------------------------------------------
+
+
+class TestRule:
+    def test_required_passes(self):
+        rule = Rule(rule_id="r1", field="name", check="required")
+        form = WorkForm(form_id="f", values={"name": "Alice"})
+        assert rule.apply(form) is None
+
+    def test_required_fails(self):
+        rule = Rule(rule_id="r1", field="name", check="required")
+        form = WorkForm(form_id="f", values={})
+        assert rule.apply(form) is not None
+
+    def test_range_passes(self):
+        rule = Rule(rule_id="r2", field="age", check="range", params={"min": 0, "max": 120})
+        form = WorkForm(form_id="f", values={"age": 30})
+        assert rule.apply(form) is None
+
+    def test_range_below_min(self):
+        rule = Rule(rule_id="r2", field="age", check="range", params={"min": 18})
+        form = WorkForm(form_id="f", values={"age": 5})
+        err = rule.apply(form)
+        assert err is not None
+        assert "minimum" in err
+
+    def test_range_above_max(self):
+        rule = Rule(rule_id="r2", field="score", check="range", params={"max": 100})
+        form = WorkForm(form_id="f", values={"score": 150})
+        err = rule.apply(form)
+        assert err is not None
+        assert "maximum" in err
+
+    def test_pattern_passes(self):
+        rule = Rule(rule_id="r3", field="email", check="pattern", params={"pattern": r".+@.+"})
+        form = WorkForm(form_id="f", values={"email": "a@b.com"})
+        assert rule.apply(form) is None
+
+    def test_pattern_fails(self):
+        rule = Rule(rule_id="r3", field="email", check="pattern", params={"pattern": r".+@.+"})
+        form = WorkForm(form_id="f", values={"email": "notanemail"})
+        assert rule.apply(form) is not None
+
+    def test_custom_passes(self):
+        rule = Rule(
+            rule_id="r4",
+            field="val",
+            check="custom",
+            params={"callable": lambda v: v is not None and v > 0},
+        )
+        form = WorkForm(form_id="f", values={"val": 5})
+        assert rule.apply(form) is None
+
+    def test_custom_fails(self):
+        rule = Rule(
+            rule_id="r4",
+            field="val",
+            check="custom",
+            params={"callable": lambda v: v is not None and v > 0, "error": "Must be positive"},
+        )
+        form = WorkForm(form_id="f", values={"val": -1})
+        err = rule.apply(form)
+        assert err is not None
+
+    def test_disabled_rule_skipped(self):
+        rule = Rule(rule_id="r5", field="name", check="required", enabled=False)
+        form = WorkForm(form_id="f", values={})
+        assert rule.apply(form) is None
+
+    def test_custom_message_used(self):
+        rule = Rule(rule_id="r6", field="x", check="required", message="x is absolutely required")
+        form = WorkForm(form_id="f", values={})
+        err = rule.apply(form)
+        assert err == "x is absolutely required"
+
+
+# ---------------------------------------------------------------------------
+# RuleSet tests
+# ---------------------------------------------------------------------------
+
+
+class TestRuleSet:
+    def test_add_and_apply_all_no_errors(self):
+        rs = RuleSet()
+        rs.add(Rule(rule_id="r1", field="name", check="required"))
+        form = WorkForm(form_id="f", values={"name": "Bob"})
+        assert rs.apply_all(form) == []
+
+    def test_apply_all_collects_all_errors(self):
+        rs = RuleSet()
+        rs.add(Rule(rule_id="r1", field="a", check="required"))
+        rs.add(Rule(rule_id="r2", field="b", check="required"))
+        form = WorkForm(form_id="f", values={})
+        errors = rs.apply_all(form)
+        assert len(errors) == 2
+
+    def test_remove_rule(self):
+        rs = RuleSet()
+        rs.add(Rule(rule_id="r1", field="x", check="required"))
+        removed = rs.remove("r1")
+        assert removed is True
+        assert rs.get("r1") is None
+
+    def test_remove_nonexistent_returns_false(self):
+        rs = RuleSet()
+        assert rs.remove("nope") is False
+
+    def test_get_rule(self):
+        rs = RuleSet()
+        rule = Rule(rule_id="r1", field="x", check="required")
+        rs.add(rule)
+        assert rs.get("r1") is rule
+
+    def test_chaining(self):
+        rs = RuleSet()
+        result = rs.add(Rule(rule_id="r1", field="x", check="required"))
+        assert result is rs
+
+
+# ---------------------------------------------------------------------------
+# WorkerDefinition tests
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerDefinition:
+    def test_creation(self):
+        defn = WorkerDefinition(
+            definition_id="w1",
+            name="Worker One",
+            input_form="input_f",
+            output_form="output_f",
+            handler="tests.work.test_work_system._echo_handler",
+        )
+        assert defn.definition_id == "w1"
+        assert defn.max_concurrent == 1
+        assert defn.timeout_seconds == 0
+        assert defn.tags == []
+
+    def test_handler_must_have_module(self):
+        with pytest.raises(Exception):
+            WorkerDefinition(
+                definition_id="w",
+                name="W",
+                input_form="f",
+                output_form="f",
+                handler="no_module",  # no dot — invalid
+            )
+
+    def test_resolve_handler(self):
+        defn = _make_defn()
+        fn = defn.resolve_handler()
+        assert callable(fn)
+
+    def test_load_definition_from_dict(self):
+        data = {
+            "definition_id": "d1",
+            "name": "D1 Worker",
+            "input_form": "in",
+            "output_form": "out",
+            "handler": "tests.work.test_work_system._echo_handler",
+            "max_concurrent": 2,
+            "timeout_seconds": 30,
+        }
+        defn = load_definition(data)
+        assert defn.definition_id == "d1"
+        assert defn.max_concurrent == 2
+        assert defn.timeout_seconds == 30
+
+    def test_load_definition_from_json_file(self, tmp_path):
+        data = {
+            "definition_id": "json_worker",
+            "name": "JSON Worker",
+            "input_form": "f",
+            "output_form": "f",
+            "handler": "tests.work.test_work_system._echo_handler",
+        }
+        path = tmp_path / "worker.json"
+        path.write_text(json.dumps(data))
+        defn = load_definition(str(path))
+        assert defn.definition_id == "json_worker"
+
+    def test_load_definition_file_not_found(self):
+        with pytest.raises(FileNotFoundError):
+            load_definition("/nonexistent/path/worker.json")
+
+    def test_load_definition_unsupported_extension(self, tmp_path):
+        path = tmp_path / "worker.txt"
+        path.write_text("{}")
+        with pytest.raises(ValueError, match="Unsupported"):
+            load_definition(str(path))
+
+
+# ---------------------------------------------------------------------------
+# WorkEngine tests
+# ---------------------------------------------------------------------------
+
+
+class TestWorkEngine:
+    def test_register_and_submit(self):
+        engine = WorkEngine()
+        defn = _make_defn()
+        engine.register_worker(defn, _echo_handler)
+        form = fill_form(_make_form({"msg": {"type": "str"}}), {"msg": "hello"})
+        task_id = engine.submit(form, worker_id="echo")
+        assert isinstance(task_id, str)
+
+    def test_get_result_after_submit(self):
+        engine = WorkEngine()
+        engine.register_worker(_make_defn(), _echo_handler)
+        form = fill_form(_make_form({"msg": {"type": "str"}}), {"msg": "world"})
+        task_id = engine.submit(form)
+        result = engine.get_result(task_id)
+        assert result is not None
+        assert result.success is True
+        assert result.value == {"echoed": {"msg": "world"}}
+
+    def test_failed_task_stores_error(self):
+        engine = WorkEngine()
+        engine.register_worker(_make_defn(), _failing_handler)
+        form = fill_form(_make_form({"msg": {"type": "str"}}), {"msg": "x"})
+        task_id = engine.submit(form)
+        result = engine.get_result(task_id)
+        assert result is not None
+        assert result.success is False
+        assert "ValueError" in result.error
+
+    def test_list_tasks_empty(self):
+        engine = WorkEngine()
+        engine.register_worker(_make_defn(), _echo_handler)
+        assert engine.list_tasks() == []
+
+    def test_list_tasks_after_submit(self):
+        engine = WorkEngine()
+        engine.register_worker(_make_defn(), _echo_handler)
+        form = fill_form(_make_form({"x": {"type": "str"}}), {"x": "a"})
+        engine.submit(form)
+        tasks = engine.list_tasks()
+        assert len(tasks) == 1
+        assert tasks[0].status == "completed"
+
+    def test_list_tasks_filtered(self):
+        engine = WorkEngine()
+        engine.register_worker(_make_defn(), _echo_handler)
+        form = fill_form(_make_form({"x": {"type": "str"}}), {"x": "a"})
+        engine.submit(form)
+        completed = engine.list_tasks(status="completed")
+        queued = engine.list_tasks(status="queued")
+        assert len(completed) == 1
+        assert len(queued) == 0
+
+    def test_no_workers_raises(self):
+        engine = WorkEngine()
+        form = fill_form(_make_form({"x": {"type": "str"}}), {"x": "a"})
+        with pytest.raises(ValueError, match="No workers"):
+            engine.submit(form)
+
+    def test_unknown_worker_id_raises(self):
+        engine = WorkEngine()
+        engine.register_worker(_make_defn(), _echo_handler)
+        form = fill_form(_make_form({"x": {"type": "str"}}), {"x": "a"})
+        with pytest.raises(ValueError, match="No worker registered"):
+            engine.submit(form, worker_id="nonexistent")
+
+    def test_worker_ids(self):
+        engine = WorkEngine()
+        engine.register_worker(_make_defn(), _echo_handler)
+        assert "echo" in engine.worker_ids()
+
+    def test_unregister_worker(self):
+        engine = WorkEngine()
+        engine.register_worker(_make_defn(), _echo_handler)
+        removed = engine.unregister_worker("echo")
+        assert removed is True
+        assert "echo" not in engine.worker_ids()
+
+    def test_clear_completed(self):
+        engine = WorkEngine()
+        engine.register_worker(_make_defn(), _echo_handler)
+        form = fill_form(_make_form({"x": {"type": "str"}}), {"x": "a"})
+        engine.submit(form)
+        cleared = engine.clear_completed()
+        assert cleared == 1
+        assert engine.list_tasks() == []
+
+    def test_work_result_success_property(self):
+        r = WorkResult(task_id="t1", value=42, error=None)
+        assert r.success is True
+
+    def test_work_result_failure_property(self):
+        r = WorkResult(task_id="t1", value=None, error="something failed")
+        assert r.success is False
+
+    def test_work_task_is_terminal(self):
+        t = WorkTask(form_id="f", worker_id="w", status="completed")
+        assert t.is_terminal is True
+        t2 = WorkTask(form_id="f", worker_id="w", status="running")
+        assert t2.is_terminal is False
+
+    def test_work_task_duration(self):
+        t = WorkTask(form_id="f", worker_id="w")
+        t.submitted_at = 1000.0
+        t.completed_at = 1005.0
+        assert t.duration == pytest.approx(5.0)
+
+    def test_concurrent_submissions_thread_safe(self):
+        """Multiple threads can submit tasks concurrently without data corruption."""
+        engine = WorkEngine(name="thread-test")
+
+        defn = WorkerDefinition(
+            definition_id="fast",
+            name="Fast",
+            input_form="f",
+            output_form="f",
+            handler="tests.work.test_work_system._echo_handler",
+            max_concurrent=0,  # unlimited
+        )
+        engine.register_worker(defn, _echo_handler)
+
+        task_ids: list[str] = []
+        lock = threading.Lock()
+        errors: list[Exception] = []
+
+        def submit_one() -> None:
+            try:
+                form = fill_form(_make_form({"n": {"type": "int"}}), {"n": 1})
+                tid = engine.submit(form, worker_id="fast")
+                with lock:
+                    task_ids.append(tid)
+            except Exception as exc:  # noqa: BLE001
+                with lock:
+                    errors.append(exc)
+
+        threads = [threading.Thread(target=submit_one) for _ in range(10)]
+        for th in threads:
+            th.start()
+        for th in threads:
+            th.join()
+
+        assert errors == [], f"Thread errors: {errors}"
+        assert len(task_ids) == 10
+        assert len(set(task_ids)) == 10  # all unique
+
+
+# ---------------------------------------------------------------------------
+# Async engine test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_submit_async_coroutine_handler():
+    """submit_async awaits coroutine handlers correctly."""
+
+    async def async_handler(form: WorkForm) -> str:
+        await asyncio.sleep(0)
+        return "async_result"
+
+    engine = WorkEngine()
+    defn = WorkerDefinition(
+        definition_id="async_worker",
+        name="Async Worker",
+        input_form="f",
+        output_form="f",
+        handler="tests.work.test_work_system._echo_handler",
+    )
+    engine.register_worker(defn, async_handler)
+    form = fill_form(_make_form({"x": {"type": "str"}}), {"x": "test"})
+    task_id = await engine.submit_async(form, worker_id="async_worker")
+    result = engine.get_result(task_id)
+    assert result is not None
+    assert result.success is True
+    assert result.value == "async_result"


### PR DESCRIPTION
## Summary

- `lionagi/work/`: WorkForm (6-state lifecycle), Rule/RuleSet, WorkerDefinition, WorkEngine
- `lionagi/cli/schedule.py`: `li schedule add/list/remove/pause/resume`
- `lionagi/cli/cleanup.py`: `li state cleanup` for operational hygiene
- `lionagi/cli/config.py`: Config resolution cascade with provenance
- `lionagi/cli/orchestrate/charter.py`: Charter CLI integration
- Studio: WorkerCanvas component update

## Test plan

- [ ] `uv run pytest tests/work/ tests/test_work/ tests/cli/test_cleanup.py -x -q`
- [ ] 100+ work system tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)