### PR TITLE
fix(pile): don't drop falsy Observable items on include

### DIFF
--- a/lionagi/protocols/generic/pile.py
+++ b/lionagi/protocols/generic/pile.py
@@ -131,7 +131,10 @@ def _validate_progression(value: Any, collections: dict[UUID, T], /) -> Progress
 
 
 def _validate_collections(value: Any, item_type: set | None, strict_type: bool, /) -> dict[str, T]:
-    if not value:
+    # Short-circuit genuinely empty input (None, empty list/dict/str) but NOT a
+    # single Observable that happens to be falsy — e.g. an empty Progression or
+    # Pile is a valid item whose len() is 0, and must not be silently dropped.
+    if not value and not isinstance(value, Observable):
         return {}
 
     value = to_list_type(value)

--- a/tests/protocols/generic/test_pile_mutation.py
+++ b/tests/protocols/generic/test_pile_mutation.py
@@ -32,6 +32,53 @@ class OtherItem(Element):
     name: str = ""
 
 
+# ---------------------------------------------------------------------------
+# Regression: sized Element that is falsy when empty must not be dropped
+# ---------------------------------------------------------------------------
+
+
+class TestIncludeFalsyElement:
+    """An empty Progression/Pile is a valid item whose len() is 0.
+
+    Regression for the `if not value: return {}` short-circuit in
+    _validate_collections that silently dropped any falsy Observable.
+    """
+
+    def test_include_empty_progression(self):
+        from lionagi.protocols.generic.progression import Progression
+
+        pile = Pile()
+        prog = Progression(name="empty")
+        assert not prog  # empty → falsy
+        pile.include(prog)
+        assert len(pile) == 1
+        assert prog.id in pile
+
+    def test_include_empty_pile(self):
+        pile = Pile()
+        inner = Pile()  # empty → falsy
+        pile.include(inner)
+        assert len(pile) == 1
+
+    def test_nonempty_progression_is_single_item(self):
+        from lionagi.protocols.generic.progression import Progression
+
+        a, b = Item(value=1), Item(value=2)
+        prog = Progression(order=[a.id, b.id], name="ord")
+        pile = Pile()
+        pile.include(prog)
+        # the Progression is ONE item, not expanded into its member UUIDs
+        assert len(pile) == 1
+        assert prog.id in pile
+
+    def test_empty_inputs_still_noop(self):
+        pile = Pile()
+        pile.include([])
+        pile.include(None)
+        pile.include("")
+        assert len(pile) == 0
+
+
 @pytest.fixture
 def three_items():
     return [Item(value=i) for i in range(3)]


### PR DESCRIPTION
## What

`Pile.include()` silently dropped any **falsy `Observable`** — an empty `Progression` or `Pile` (`len() == 0`) was discarded instead of stored as a single item.

Root cause: `_validate_collections` short-circuits with `if not value: return {}` before `to_list_type` runs. An empty sized-Element is falsy, so it hit the short-circuit and never made it into the pile.

## Impact

Surfaced via `Flow.add_progression(...)`: the call appeared to succeed, but `get_progression(...)` then raised `ItemNotFoundError` because the progression was never actually added to the backing pile. Any code adding an empty progression/pile as a pile item was affected.

## Fix

Guard the short-circuit with `not isinstance(value, Observable)`:

```python
if not value and not isinstance(value, Observable):
    return {}
```

- Empty sized-Elements (`Progression`, `Pile`) now pass through to `to_list_type`, which already wraps a single `Element` as `[value]` correctly.
- `None` / `[]` / `{}` / `""` / other falsy non-items still no-op (no regression).
- Confirmed: a **non-empty** `Progression` is stored as **one** item, not expanded into its member UUIDs.

## Tests

New `TestIncludeFalsyElement` (4 cases): empty Progression included, empty Pile included, non-empty Progression is a single item, empty inputs still no-op. Full pile/flow/progression suite green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)