### PR TITLE
feat(session): reactive event observation + direct run_operation

### DIFF
--- a/lionagi/session/__init__.py
+++ b/lionagi/session/__init__.py
@@ -5,6 +5,7 @@ from lionagi.protocols.messages import Message  # noqa: E402
 
 from .branch import Branch
 from .exchange import Exchange
+from .observer import SessionObserver
 from .session import Session
 
-__all__ = ["Branch", "Exchange", "Message", "Session"]
+__all__ = ["Branch", "Exchange", "Message", "Session", "SessionObserver"]

--- a/lionagi/session/observer.py
+++ b/lionagi/session/observer.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""SessionObserver — reactive, typed event dispatch over a session's Flow.
+
+The complement to ``Exchange``: where Exchange is *addressed pull* messaging
+("send this Message to branch B"), SessionObserver is *typed push* reaction
+("when any DepthRequested appears, run this handler").
+
+Usage::
+
+    obs = SessionObserver(session)
+
+    @obs.observe(DepthRequested)            # register a reaction (setup)
+    async def on_depth(event, obs):
+        branch = obs.session.new_branch()
+        return await branch.operate(instruction=event.question)
+
+    obs.route(lambda e: e.novelty > 0.7, into="high_novelty")   # condition stream
+    obs.gate(my_permission_check)           # governance seam (request_permission)
+
+    await obs.emit(DepthRequested(question="..."))   # a tool/branch emits
+
+``emit`` runs the chain: gate (govern) → store in Flow → route to streams →
+dispatch to type-subscribed observers. The gate is where charter/gate
+mediation plugs in; an observer firing is the honored capability.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+from typing import Any
+
+from lionagi.protocols._concepts import Observer
+
+from ..protocols.generic.event import Event
+from ..protocols.generic.flow import Flow
+from ..protocols.generic.progression import Progression
+
+__all__ = ("SessionObserver",)
+
+Handler = Callable[[Event, "SessionObserver"], Any]
+Condition = Callable[[Event], bool]
+Gate = Callable[[Event], Any]
+
+
+class SessionObserver(Observer):
+    """Typed, reactive event dispatch over a session-scoped Flow."""
+
+    def __init__(self, session: Any = None) -> None:
+        self.session = session
+        self.flow: Flow = Flow(name="session-events")
+        self._handlers: dict[type[Event], list[Handler]] = {}
+        self._routes: list[tuple[Condition, str]] = []
+        self._gate: Gate | None = None
+
+    # -- Registration ---------------------------------------------------------
+
+    def observe(self, event_type: type[Event], handler: Handler | None = None) -> Any:
+        """Subscribe a handler to an event type. Usable as a decorator."""
+
+        def _register(fn: Handler) -> Handler:
+            self._handlers.setdefault(event_type, []).append(fn)
+            return fn
+
+        return _register if handler is None else _register(handler)
+
+    def route(self, condition: Condition, *, into: str) -> SessionObserver:
+        """Auto-append events matching ``condition`` to a named stream."""
+        self._routes.append((condition, into))
+        return self
+
+    def gate(self, check: Gate) -> SessionObserver:
+        """Set the permission gate run before an emitted event is honored.
+
+        This is the governance seam — charter/gate mediation lives here.
+        Return falsy (or raise) to deny; the event is recorded but no
+        observers fire.
+        """
+        self._gate = check
+        return self
+
+    # -- Emission / dispatch --------------------------------------------------
+
+    async def emit(self, event: Event) -> list[Any]:
+        """Run the chain: gate → store → route → dispatch. Returns handler results."""
+        allowed = True
+        if self._gate is not None:
+            verdict = self._gate(event)
+            if inspect.isawaitable(verdict):
+                verdict = await verdict
+            allowed = bool(verdict)
+
+        self.flow.add_item(event)  # always recorded (audit trail)
+        if not allowed:
+            return []
+
+        for condition, name in self._routes:
+            if condition(event):
+                self._ensure_stream(name).append(event)
+
+        # Handlers receive (event, ctx) where ctx is the bound Session when
+        # one is attached, else the observer itself.
+        ctx = self.session if self.session is not None else self
+        results: list[Any] = []
+        for handler in self._handlers.get(type(event), []):
+            out = handler(event, ctx)
+            if inspect.isawaitable(out):
+                out = await out
+            results.append(out)
+        return results
+
+    # -- Reads ----------------------------------------------------------------
+
+    def stream(self, name: str) -> list[Event]:
+        """Events in a named condition-stream, in arrival order."""
+        try:
+            prog = self.flow.get_progression(name)
+        except Exception:
+            return []
+        return [self.flow.items[uid] for uid in prog]
+
+    def by_type(self, event_type: type[Event]) -> list[Event]:
+        return [e for e in self.flow.items if isinstance(e, event_type)]
+
+    def _ensure_stream(self, name: str) -> Progression:
+        try:
+            return self.flow.get_progression(name)
+        except Exception:
+            prog = Progression(name=name)
+            self.flow.add_progression(prog)
+            return prog
+
+    def __repr__(self) -> str:
+        subs = {t.__name__: len(h) for t, h in self._handlers.items()}
+        return f"SessionObserver(events={len(self.flow.items)}, handlers={subs})"

--- a/lionagi/session/session.py
+++ b/lionagi/session/session.py
@@ -3,8 +3,11 @@
 
 import contextlib
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from uuid import UUID
+
+if TYPE_CHECKING:
+    from .observer import SessionObserver
 
 from pydantic import Field, JsonValue, PrivateAttr, field_serializer, model_validator
 from typing_extensions import Self
@@ -24,7 +27,7 @@ from lionagi.protocols.types import (
 
 from .._errors import ItemNotFoundError
 from ..ln import lcall
-from ..protocols.generic import Flow, Progression
+from ..protocols.generic import Flow
 from ..protocols.messages import Message
 from ..service.imodel import iModel
 from .branch import ActionManager, Branch, OperationManager, Tool
@@ -48,6 +51,7 @@ class Session(Node, Relational):
     name: str = Field(default="Session")
     user: SenderRecipient | None = None
     _operation_manager: OperationManager = PrivateAttr(default_factory=OperationManager)
+    _observer: Any = PrivateAttr(default=None)
 
     @field_serializer("user")
     def _serialize_user(self, value: SenderRecipient | None) -> JsonValue:
@@ -76,9 +80,7 @@ class Session(Node, Relational):
         for i in branches:
             _take_in_branch(i)
 
-    def register_operation(
-        self, operation: str, func: Callable, *, update: bool = False
-    ):
+    def register_operation(self, operation: str, func: Callable, *, update: bool = False):
         self._operation_manager.register(operation, func, update=update)
 
     def operation(self, name: str = None, *, update: bool = False):
@@ -106,6 +108,60 @@ class Session(Node, Relational):
 
         return decorator
 
+    async def run_operation(
+        self, operation: str, *, branch: Branch | ID.Ref | None = None, **kwargs: Any
+    ) -> Any:
+        """Directly invoke a registered operation (or built-in branch method).
+
+        Resolves ``operation`` via ``branch.get_operation`` — a registered
+        ``@session.operation()`` function or a built-in verb (chat, operate,
+        ReAct, …) — and calls it with ``**kwargs``. The direct counterpart to
+        graph execution: handy for observer handlers and one-off calls.
+        """
+        b = branch or self.default_branch
+        if isinstance(b, str | UUID):
+            b = self.branches[b]
+        meth = b.get_operation(operation)
+        if meth is None:
+            raise ValueError(f"Unknown operation: {operation!r}")
+        return await meth(**kwargs)
+
+    # ==================== Reactive event observation ====================
+
+    @property
+    def observer(self) -> "SessionObserver":
+        """Lazily-created reactive event dispatcher bound to this session."""
+        if self._observer is None:
+            from .observer import SessionObserver
+
+            self._observer = SessionObserver(session=self)
+        return self._observer
+
+    def observe(self, event_type: type, handler: Callable | None = None) -> Any:
+        """Subscribe a handler to an event type. Usable as a decorator.
+
+        Handlers receive ``(event, session)`` and fire when a matching event
+        is emitted. Mirrors ``@session.operation()``.
+        """
+        return self.observer.observe(event_type, handler)
+
+    def route(self, condition: Callable, *, into: str) -> "SessionObserver":
+        """Auto-append emitted events matching ``condition`` to a named stream."""
+        return self.observer.route(condition, into=into)
+
+    def gate(self, check: Callable) -> "SessionObserver":
+        """Set the permission gate run before an emitted event is honored.
+
+        The governance seam — charter/gate mediation plugs in here. Return
+        falsy (or raise) to deny: the event is still recorded, but no
+        observers fire.
+        """
+        return self.observer.gate(check)
+
+    async def emit(self, event: Any) -> list[Any]:
+        """Emit an event: gate → record → route → dispatch. Returns handler results."""
+        return await self.observer.emit(event)
+
     @model_validator(mode="after")
     def _initialize_branches(self) -> Self:
         if self.default_branch is None:
@@ -126,8 +182,8 @@ class Session(Node, Relational):
         """Get a branch by its ID or name."""
 
         with contextlib.suppress(ItemNotFoundError, ValueError):
-            id = ID.get_id(branch)
-            return self.branches[id]
+            id_ = ID.get_id(branch)
+            return self.branches[id_]
 
         if isinstance(branch, str):
             if b := self._lookup_branch_by_name(branch):
@@ -327,7 +383,7 @@ class Session(Node, Relational):
         from lionagi.operations.flow import flow
 
         branch = default_branch or self.default_branch
-        if isinstance(branch, (str, UUID)):
+        if isinstance(branch, str | UUID):
             branch = self.branches[branch]
 
         return await flow(

--- a/tests/session/test_session_observer.py
+++ b/tests/session/test_session_observer.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Session reactive observation: observe / emit / gate / route + run_operation,
+and the observer→operation composition that makes a Session a useful orchestrator.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.protocols.generic.event import Event
+from lionagi.session.session import Session
+
+
+class DepthRequested(Event):
+    question: str = ""
+    novelty: float = 0.7
+
+
+class Noticed(Event):
+    note: str = ""
+
+
+async def test_run_operation_direct_invoke():
+    s = Session()
+
+    @s.operation()
+    async def deepen(question: str):
+        return f"deepened: {question}"
+
+    assert await s.run_operation("deepen", question="RAFT") == "deepened: RAFT"
+
+
+async def test_run_operation_unknown_raises():
+    s = Session()
+    with pytest.raises(ValueError, match="Unknown operation"):
+        await s.run_operation("nope")
+
+
+async def test_observe_and_emit_passes_session():
+    s = Session()
+    seen = []
+
+    @s.observe(DepthRequested)
+    async def on_depth(event, session):
+        # handler receives the bound Session
+        assert session is s
+        seen.append(event.question)
+        return "ok"
+
+    results = await s.emit(DepthRequested(question="x"))
+    assert seen == ["x"]
+    assert results == ["ok"]
+
+
+async def test_gate_denies_dispatch_but_records():
+    s = Session()
+    fired = []
+
+    @s.observe(DepthRequested)
+    def on_depth(event, session):
+        fired.append(event.question)
+
+    s.gate(lambda e: getattr(e, "novelty", 1) > 0.5)
+
+    await s.emit(DepthRequested(question="high", novelty=0.9))
+    await s.emit(DepthRequested(question="low", novelty=0.1))  # gated out
+
+    assert fired == ["high"]  # only the allowed one dispatched
+    # both recorded (audit trail)
+    assert len(s.observer.by_type(DepthRequested)) == 2
+
+
+async def test_route_condition_stream():
+    s = Session()
+    s.route(lambda e: getattr(e, "novelty", 0) > 0.7, into="high_novelty")
+
+    await s.emit(DepthRequested(question="a", novelty=0.9))
+    await s.emit(DepthRequested(question="b", novelty=0.2))
+
+    streamed = [e.question for e in s.observer.stream("high_novelty")]
+    assert streamed == ["a"]
+
+
+async def test_observer_triggers_operation():
+    """The synthesis: an observed event drives a registered operation."""
+    s = Session()
+
+    @s.operation()
+    async def record(note: str):
+        return f"recorded: {note}"
+
+    @s.observe(Noticed)
+    async def on_notice(event, session):
+        return await session.run_operation("record", note=event.note)
+
+    results = await s.emit(Noticed(note="cross-thread link"))
+    assert results == ["recorded: cross-thread link"]
+
+
+async def test_multiple_handlers_same_event():
+    s = Session()
+    calls = []
+
+    @s.observe(Noticed)
+    def first(event, session):
+        calls.append("first")
+
+    @s.observe(Noticed)
+    def second(event, session):
+        calls.append("second")
+
+    await s.emit(Noticed(note="x"))
+    assert calls == ["first", "second"]


### PR DESCRIPTION
## What

Makes a `Session` a usable **reactive orchestrator**. `@session.operation()` already worked (register → resolve via `branch.get_operation` → invoke), but was only reachable through the Operation-graph path. This adds the reactive layer and a direct call path.

- **`SessionObserver`** (`session/observer.py`) — typed, reactive event dispatch over a session-scoped `Flow`. The *push* complement to `Exchange`'s *addressed-pull* messaging ("react to any `DepthRequested`" vs "send this Message to branch B").
- **Session gains** `observe` / `route` / `gate` / `emit` (mirroring `@session.operation()`), plus **`run_operation`** — directly invoke a registered operation or built-in branch verb without building a graph.

## The chain

`emit` runs: **gate** (governance seam — charter/gate mediation plugs here) → **record** in `Flow` (audit trail) → **route** to condition-streams → **dispatch** to type-subscribed handlers. Handlers receive `(event, session)`.

```python
@session.operation()
async def record(note): return f"recorded: {note}"

@session.observe(Noticed)
async def on_notice(event, session):
    return await session.run_operation("record", note=event.note)

await session.emit(Noticed(note="cross-thread link"))   # → gate → record → dispatch → operation
```

This realizes "capabilities = structured-output event" on lionagi's **own** primitives (`Flow` / `Event` / `Observer`) — no external event engine. Gated events are recorded but not dispatched.

## Tests

`tests/session/test_session_observer.py` — 7 cases: `run_operation` direct + unknown-raises, observe/emit passes session, gate denies-but-records, route condition-stream, observer→operation composition, multiple handlers. Full session suite (222) green.

## Housekeeping

Fixed 3 latent ruff errors in `session.py` (duplicate `Progression` import, `id` builtin shadow, `isinstance` tuple→union) that surfaced now that the file is modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)