### PR TITLE
feat(agent): AgentConfig composes role + modes into the system prompt

### DIFF
--- a/lionagi/agent/config.py
+++ b/lionagi/agent/config.py
@@ -43,6 +43,8 @@ class AgentConfig:
     model: str | None = None
     effort: str | None = None
     system_prompt: str = ""
+    role: str | None = None
+    modes: list[str] = field(default_factory=list)
     tools: list[str] = field(default_factory=list)
     hook_handlers: dict[str, list[Callable]] = field(default_factory=dict)
     permissions: dict[str, Any] = field(default_factory=dict)
@@ -65,6 +67,30 @@ class AgentConfig:
     def on_error(self, tool_name: str, handler: Callable) -> AgentConfig:
         self.hook_handlers.setdefault(f"error:{tool_name}", []).append(handler)
         return self
+
+    def build_system_message(self) -> str:
+        """Compose the system prompt from role + modes + literal system_prompt.
+
+        ``role`` (a built-in role name or Role) contributes its behavioral body;
+        each entry in ``modes`` (a built-in mode name or Mode) contributes its
+        behaviors; ``system_prompt`` is appended as extra preamble. With no role
+        or modes set, this returns ``system_prompt`` unchanged (backward
+        compatible).
+        """
+        from lionagi.casts.pattern import Mode, Role
+
+        parts: list[str] = []
+        if self.role:
+            role = self.role if not isinstance(self.role, str) else Role.load(self.role)
+            if role.body:
+                parts.append(role.body)
+        for m in self.modes:
+            mode = m if not isinstance(m, str) else Mode.load(m)
+            if mode.behaviors:
+                parts.append(mode.behaviors)
+        if self.system_prompt:
+            parts.append(self.system_prompt)
+        return "\n\n".join(parts)
 
     @classmethod
     def coding(

--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -63,7 +63,6 @@ async def create_agent(
 
     if config.model:
         from lionagi.cli._providers import (
-            _CLAUDE_PROVIDER_NAMES,
             PROVIDER_EFFORT_KWARG,
             parse_model_spec,
         )
@@ -95,13 +94,14 @@ async def create_agent(
 
     branch = Branch(**branch_kwargs)
 
-    if config.system_prompt:
+    system_message = config.build_system_message()
+    if system_message:
         if config.lion_system:
             from lionagi.session.prompts import LION_SYSTEM_MESSAGE
 
-            full_prompt = LION_SYSTEM_MESSAGE.strip() + "\n\n" + config.system_prompt
+            full_prompt = LION_SYSTEM_MESSAGE.strip() + "\n\n" + system_message
         else:
-            full_prompt = config.system_prompt
+            full_prompt = system_message
         branch.msgs.set_system(branch.msgs.create_system(system=full_prompt))
 
     _apply_permissions(config)
@@ -130,9 +130,7 @@ def _apply_permissions(config: AgentConfig) -> None:
         return
 
     # Finding 13: insert permission hook into security_pre phase, not pre phase
-    config.hook_handlers.setdefault("security_pre:*", []).insert(
-        0, policy.to_pre_hook()
-    )
+    config.hook_handlers.setdefault("security_pre:*", []).insert(0, policy.to_pre_hook())
 
 
 def _tool_hooks(config: AgentConfig, phase: str, tool_name: str) -> list[Callable]:

--- a/lionagi/casts/pattern.py
+++ b/lionagi/casts/pattern.py
@@ -59,6 +59,13 @@ def _parse_frontmatter(text: str) -> tuple[dict, str]:
     return meta, body
 
 
+def _read_pattern_md(*parts: str) -> str:
+    """Read a packaged pattern markdown file under casts/roles/ (wheel-safe)."""
+    from importlib.resources import files
+
+    return files("lionagi.casts").joinpath("roles", *parts).read_text(encoding="utf-8")
+
+
 @dataclass(init=False, frozen=True, slots=True)
 class Mode(Pattern):
     """Cognitive overlay — shapes *how* an agent reasons."""
@@ -83,6 +90,11 @@ class Mode(Pattern):
     @classmethod
     def from_file(cls, path: Path, /) -> Mode:
         return cls.from_md(path.read_text(encoding="utf-8"))
+
+    @classmethod
+    def load(cls, name: str, /) -> Mode:
+        """Load a built-in mode by name from the packaged roles/modes/."""
+        return cls.from_md(_read_pattern_md("modes", f"{name}.md"))
 
 
 @dataclass(init=False, frozen=True, slots=True)
@@ -112,3 +124,8 @@ class Role(Pattern):
     @classmethod
     def from_file(cls, path: str | Path, /) -> Role:
         return cls.from_md(Path(path).read_text(encoding="utf-8"))
+
+    @classmethod
+    def load(cls, name: str, /) -> Role:
+        """Load a built-in role by name from the packaged roles/."""
+        return cls.from_md(_read_pattern_md(f"{name}.md"))

--- a/tests/agent/test_config_casts.py
+++ b/tests/agent/test_config_casts.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""AgentConfig composing role + modes into the system message."""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.agent.config import AgentConfig
+from lionagi.casts.pattern import Mode, Role
+
+
+def test_build_system_message_passthrough():
+    # No role/modes → system_prompt unchanged (backward compatible)
+    cfg = AgentConfig(system_prompt="hello")
+    assert cfg.build_system_message() == "hello"
+
+
+def test_build_system_message_empty():
+    assert AgentConfig().build_system_message() == ""
+
+
+def test_build_system_message_role_by_name():
+    cfg = AgentConfig(role="implementer")
+    msg = cfg.build_system_message()
+    role = Role.load("implementer")
+    assert role.body in msg
+    assert msg == role.body  # only the role, no modes/preamble
+
+
+def test_build_system_message_role_and_modes():
+    cfg = AgentConfig(
+        role="implementer",
+        modes=["systematic", "evidential"],
+        system_prompt="Extra house rule.",
+    )
+    msg = cfg.build_system_message()
+    assert Role.load("implementer").body in msg
+    assert Mode.load("systematic").behaviors in msg
+    assert Mode.load("evidential").behaviors in msg
+    assert "Extra house rule." in msg
+    # order: role, then modes, then preamble
+    assert msg.index(Role.load("implementer").body) < msg.index(Mode.load("systematic").behaviors)
+    assert msg.rindex("Extra house rule.") == len(msg) - len("Extra house rule.")
+
+
+def test_build_system_message_accepts_objects():
+    cfg = AgentConfig(role=Role.load("critic"), modes=[Mode.load("slow")])
+    msg = cfg.build_system_message()
+    assert Role.load("critic").body in msg
+    assert Mode.load("slow").behaviors in msg
+
+
+def test_unknown_role_raises():
+    cfg = AgentConfig(role="no-such-role")
+    with pytest.raises(FileNotFoundError):
+        cfg.build_system_message()
+
+
+async def test_create_agent_uses_composed_prompt():
+    from lionagi.agent.factory import create_agent
+
+    cfg = AgentConfig(role="researcher", modes=["evidential"])
+    branch = await create_agent(cfg, load_settings=False)
+    system_text = branch.msgs.system.rendered
+    assert Role.load("researcher").body in system_text
+    assert Mode.load("evidential").behaviors in system_text


### PR DESCRIPTION
## What

The casts behavioral layer (`Role`/`Mode`, shipped in #1200/#1202) plugs into the real agent layer. This is the first runtime consumer of the packaged role/mode markdown.

- **`AgentConfig` gains `role` + `modes`.** `build_system_message()` composes `role.body` + each mode's `behaviors` + the literal `system_prompt`; `create_agent` wires that composed message into the `Branch`.
- **Backward compatible**: with no `role`/`modes`, `build_system_message()` returns `system_prompt` unchanged.
- **`Role.load(name)` / `Mode.load(name)`** resolve a built-in role/mode from packaged `casts/roles/` data via `importlib.resources` (wheel-safe).

## Usage

```python
config = AgentConfig(
    role="implementer",                 # → casts/roles/implementer.md body
    modes=["systematic", "evidential"], # → each mode's behaviors
    model="openai/gpt-4.1",
    tools=["coding"],
)
branch = await create_agent(config)     # system prompt = role + modes + preamble
```

`role`/`modes` accept names (loaded from packaged data) or `Role`/`Mode` objects.

## Tests

`tests/agent/test_config_casts.py` — 7 cases: passthrough, empty, role-by-name, role+modes+preamble ordering, object inputs, unknown-role raises, and `create_agent` end-to-end confirming the composed prompt lands in the branch system message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)