### PR TITLE
feat(session): reactive capability bus — Signals, Filter DSL, per-message emission

### DIFF
--- a/docs/adrs/ADR-0072-reactive-capability-bus.md
+++ b/docs/adrs/ADR-0072-reactive-capability-bus.md
@@ -87,8 +87,12 @@ those Specs, held on `branch.capabilities` (the runtime carrier). The streaming
 `run` loop — the single chokepoint for both `branch.run` and operate-CLI — parses
 every assistant message:
 
-- Pull every JSON object out of the text (raw or ```json-fenced,
-  fuzzy-tolerant). A single response may carry several blocks.
+- Pull every fenced ```json block out of the text (fuzzy-tolerant; the
+  injected prompt instructs the model to fence its emissions). A single
+  response may carry several blocks. A response that is *itself* one JSON
+  object is also parsed, but un-fenced JSON **embedded in surrounding prose**
+  is not extracted — fencing is the contract, which avoids false positives on
+  incidental JSON.
 - Per block, apply the legality rule **`set(keys) ⊆ grant`**:
   - **disjoint** (no granted keys) → ordinary prose/JSON, ignored;
   - **subset** → validate via `operable.create_model(include=keys)
@@ -109,8 +113,25 @@ the extractor validates against, plus the prose mirror of the `keys ⊆ grant`
 rule — so the prose can never drift from what is actually extractable.
 
 `response_format` (the final-output strict parse) and `capabilities`
-(per-message emission) are **independent, orthogonal knobs**. With no grant,
-behavior is exactly as before.
+(per-message emission) are **independent, orthogonal knobs**.
+
+### Run lifecycle signals
+
+`branch.operate` emits a lifecycle triple onto the bus: `RunStart` →
+`RunEnd(data=result)` on success, or `RunFailed(data=exc)` on error. These are
+orthogonal to capabilities — they report the *run*, not an exercised
+capability, so they require **no grant**. Observe them by their own envelope
+type (`session.observe(RunEnd)`); because `RunEnd.data` unwraps, a plain
+`session.observe(ResultType)` also fires on the final result. The per-message
+capability bundles are distinct dynamic-model payloads, so there is no
+double-emit between the two channels.
+
+Lifecycle emission is gated only on *having a session observer attached* — a
+**standalone branch (no observer) emits nothing, so its behavior is exactly as
+before.** Within a session, the final result is intentionally surfaced on the
+bus (it is the most important event of the run); this replaces the earlier,
+ambiguous "emit any `BaseModel` result as `StructuredOutput`" path, which
+conflated lifecycle with capability emission and could double-fire on CLI.
 
 ### Governing principle: the observer registry *is* the capability registry
 

--- a/docs/adrs/ADR-0072-reactive-capability-bus.md
+++ b/docs/adrs/ADR-0072-reactive-capability-bus.md
@@ -1,0 +1,192 @@
+# ADR-0072: Reactive Capability Bus
+
+**Status**: accepted
+**Date**: 2026-05-29
+
+## Context
+
+An agent's turn used to be opaque and terminal. You called
+`response = await branch.operate(response_format=Finding)`, waited for the whole
+run to finish, and got one `Finding` back. While the model worked — reading
+files, reasoning, calling tools — the orchestrator sat idle. The only way to get
+structured signals *during* a run was to hand the model a dedicated tool to
+call, which is heavyweight and bends the model toward tool-calling instead of
+its natural response.
+
+We want the opposite: **an agent's cognition as an observable, typed event
+stream that can be reacted to and steered in real time.** As the model works it
+should be able to emit typed signals — `Finding`, `Question`, `Hypothesis`,
+`Correction`, `Citation` — inline in its ordinary text, and an orchestrator
+should be able to react the instant each one appears, without interrupting the
+agentic loop.
+
+This crystallized a standing thesis: **"a capability = a structured-output
+event."** A capability is a named, typed field an agent may produce; exercising
+it is emitting a value of that type; an observer reacting to that type is the
+capability being *honored*. The whole thing should be built on lionagi's own
+primitives (`Element`, `Pile`, `Progression`, `Flow`, `Observer`), not an
+external event engine.
+
+A prior prototype (lionag2, on AG2/autogen.beta) validated the shape — `Flow` as
+a shared pile plus named condition-streams, `@agent.observer(EventType)`
+reactions, `ctx.send(TypedEvent)` emission — by hacking an `id` onto AG2 events
+so they could live in a `Pile`. The lesson kept: we do **not** need a heavy
+event model, only an identifiable envelope.
+
+## Decision
+
+Build a reactive capability bus on the `Session`, in three layers.
+
+### 1. Signals — the envelope
+
+`Signal(Element)` is a lightweight Observable envelope carrying an arbitrary
+`data` payload; its `id` comes for free from `Element`, so it lives in a
+`Pile`/`Flow` like anything else. `StructuredOutput(Signal)` is the typed case
+(`data` is a structured model). `ActionRequestSignal` / `ActionResponseSignal`
+wrap tool-use / tool-result messages.
+
+Observers key off the **payload**, not the envelope: an emitted `Signal` is
+unwrapped (`_payload`) before filtering, so `session.observe(MyModel)` fires for
+`emit(StructuredOutput(data=MyModel(...)))`. Bare Observables dispatch by their
+own type. The full envelope is always stored in the `Flow` for audit, even when
+a gate denies dispatch.
+
+### 2. The observer and the Filter DSL
+
+`SessionObserver` runs one chain on `emit`: **gate → store → route → dispatch.**
+The gate is the single governance seam (a callable, sync or async; falsy
+suppresses dispatch but not storage). Routes append matching events to named
+condition-streams (lazy `Progression`s over the one shared `Flow`). Dispatch
+fires subscribed handlers.
+
+Subscriptions are **Filters** (`lionagi/ln/types/filters.py`):
+
+- `TypeFilter(T)` — matches when the payload *is* a `T`, or carries a field
+  whose value is a `T` (it scans `model_fields`). A type subscription is just a
+  filter.
+- `SpecFilter` — a predicate, built by `FieldRef`, matching a *named field by
+  value*: `flower.q == "rose"`.
+- Filters compose with `& | ~`; `observe(type | Filter | predicate)` coerces via
+  `as_filter`. The handler receives the matched value (the instance for a type,
+  the payload for a value/predicate filter).
+
+Two naming/structure choices, both forced by existing code:
+
+- **Filter, not Condition.** `Condition` is already a protocols concept
+  (`await condition.apply`).
+- **Operators on `FieldRef` (via `Spec.q`), not `Spec`.** `Spec` is a frozen
+  dataclass used in sets, dedup, and the annotation cache — `Spec.__eq__` is
+  load-bearing. Overloading it to return a predicate would silently break the
+  Operable system, so `spec.q` hands out a fresh `FieldRef` whose operators
+  build `SpecFilter`s.
+
+### 3. Capabilities — grant, emission, prompt
+
+A capability is a named typed `Spec`; an agent's **grant** is an `Operable` of
+those Specs, held on `branch.capabilities` (the runtime carrier). The streaming
+`run` loop — the single chokepoint for both `branch.run` and operate-CLI — parses
+every assistant message:
+
+- Pull every JSON object out of the text (raw or ```json-fenced,
+  fuzzy-tolerant). A single response may carry several blocks.
+- Per block, apply the legality rule **`set(keys) ⊆ grant`**:
+  - **disjoint** (no granted keys) → ordinary prose/JSON, ignored;
+  - **subset** → validate via `operable.create_model(include=keys)
+    .model_validate(block)` into a *bundle* (a dynamic model, one field per
+    present capability) and emit one `StructuredOutput(data=bundle)`;
+  - **mixed** (a granted key plus an ungranted one) → an illegal over-grant:
+    the block is not honored and a `CapabilityViolation` is raised onto the bus.
+
+Tool-use and tool-result messages always emit `ActionRequestSignal` /
+`ActionResponseSignal`, making per-tool stats and reactive manipulation trivial.
+
+**Opt-in is the presence of a grant.** `branch.grant_capabilities(operable)`
+sets the runtime grant *and* injects an idempotent instruction block into the
+system message (markered so a re-grant replaces rather than stacks;
+`revoke_capabilities()` removes it). The prompt is rendered *from* the Operable —
+instructions plus the exact JSON schema (`create_model().model_json_schema()`)
+the extractor validates against, plus the prose mirror of the `keys ⊆ grant`
+rule — so the prose can never drift from what is actually extractable.
+
+`response_format` (the final-output strict parse) and `capabilities`
+(per-message emission) are **independent, orthogonal knobs**. With no grant,
+behavior is exactly as before.
+
+### Governing principle: the observer registry *is* the capability registry
+
+There is no central capability enum or taxonomy. A capability is *live* iff
+something observes it; `session.observe(Finding)` is what makes `Finding` real
+for that session. Extraction only ever materializes what the grant allows, and
+an un-observed value is just recorded data that costs nothing. This is the
+"field earns its place" discipline applied to capabilities — absence beats
+enforcement.
+
+## Consequences
+
+**Positive**
+
+- Real-time steering: react the instant a typed signal streams in, mid-run,
+  without a dedicated emit tool and without interrupting the agentic loop. A
+  `claude_code/sonnet` agent reading the codebase emitted five `Finding`s inline
+  and the observer fired on each as they arrived (`examples/capability_bus_demo.py`).
+- Observability and audit: every signal (and every denied one) lands in the
+  session `Flow`; tool-use stats fall out of `ActionRequestSignal`s.
+- Governance seam: the `gate` mediates dispatch; `CapabilityViolation` turns an
+  over-grant into an observable event rather than a silent drop. (Charter/ocap
+  enforcement plugs in at the gate — see the governance projection.)
+- Backward compatible: bare-type observe and `response_format` are untouched.
+
+**Negative / limits**
+
+- Dispatch is O(subscriptions) per emit (filters are evaluated linearly). Fine
+  at expected handler counts; revisit if a session registers very many.
+- The session `Flow` accumulates every signal (the audit trail). Long runs grow
+  it unbounded; a sliding-window/eviction policy is a future concern.
+- Extraction is best-effort and depends on model compliance — the model must
+  emit valid JSON for the granted keys. The injected prompt elicits this but
+  does not guarantee it.
+- A *pure* ungranted JSON block is ignored, not flagged, to avoid false
+  violations on incidental JSON; only *mixed* over-reach is caught. A model
+  emitting only an ungranted "capability" is indistinguishable from ordinary
+  data and passes silently.
+
+## Alternatives considered
+
+- **Dedicated emit tool (lionag2's `ctx.send`).** Reliable and natively typed,
+  but heavyweight and steers the model toward tool-calling. Rejected as the
+  default; tools stay tools. Field-in-structured-output is the chosen channel.
+- **Parse only the final output.** The original strict mode — kept for
+  `response_format`, but it cannot express a *stream* of mid-run emissions.
+- **Predicate operators on `Spec`.** Ergonomic (`spec == "rose"`) but breaks
+  `Spec`'s hash/eq contract and the Operable system. Resolved via `Spec.q`.
+- **Per-field emission** (one `StructuredOutput` per capability value). Simpler
+  dispatch, but throws away the field *name*, so scalar named capabilities
+  (`Spec(str, name="flower_name")`) and `SpecFilter` value-matching become
+  impossible. Resolved by emitting the named **bundle**.
+- **A heavy `Event` model for emissions.** Unnecessary; a `Signal` envelope with
+  an `id` is enough, exactly as the lionag2 prototype showed.
+
+## Implementation
+
+- `lionagi/ln/types/filters.py` — `Filter`, `TypeFilter`, `SpecFilter`,
+  `FieldRef`, `as_filter`; `Spec.q` in `spec.py`.
+- `lionagi/session/signal.py` — `Signal`, `StructuredOutput`,
+  `ActionRequestSignal`, `ActionResponseSignal`.
+- `lionagi/session/observer.py` — `SessionObserver` (gate → store → route →
+  dispatch; Filter-based).
+- `lionagi/session/capabilities.py` — `render_capabilities_prompt`,
+  `CapabilityViolation`.
+- `lionagi/session/branch.py` — `branch.capabilities`, `grant_capabilities`,
+  `revoke_capabilities`, `emit`.
+- `lionagi/operations/run/run.py` — `_attempt_extract`, `_emit_message_signal`,
+  wired into the streaming yield points.
+- `examples/capability_bus_demo.py` — live demo.
+
+## Deferred
+
+- Wiring capabilities into `AgentConfig`/`Role` (the "agent = role + modes +
+  tools + models + governance + capabilities" home) — held until the casts
+  rework settles.
+- A real reaction in the demo's `dig_deeper` (spawn a sub-branch / enqueue a
+  follow-up on high-confidence findings).
+- `Flow` eviction policy for long-running sessions.

--- a/docs/adrs/ADR-0072-reactive-capability-bus.md
+++ b/docs/adrs/ADR-0072-reactive-capability-bus.md
@@ -192,7 +192,8 @@ enforcement.
 - `lionagi/ln/types/filters.py` — `Filter`, `TypeFilter`, `SpecFilter`,
   `FieldRef`, `as_filter`; `Spec.q` in `spec.py`.
 - `lionagi/session/signal.py` — `Signal`, `StructuredOutput`,
-  `ActionRequestSignal`, `ActionResponseSignal`.
+  `ActionRequestSignal`, `ActionResponseSignal`, and the run-lifecycle
+  `RunStart` / `RunEnd` / `RunFailed`.
 - `lionagi/session/observer.py` — `SessionObserver` (gate → store → route →
   dispatch; Filter-based).
 - `lionagi/session/capabilities.py` — `render_capabilities_prompt`,

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -122,5 +122,7 @@ Numbers 0036–0038 and 0040 were reserved for future use and have no correspond
 | [ADR-0068](ADR-0068-governed-adapter-protocol.md) | Zero-rewrite governed adapter protocol | Accepted |
 | [ADR-0069](ADR-0069-tenant-scope-boundary.md) | Tenant scope boundary | Accepted |
 | [ADR-0070](ADR-0070-governance-tracing.md) | Governance tracing and observability | Accepted |
+| [ADR-0071](ADR-0071-cognitive-mode-model.md) | Cognitive mode model | Accepted |
+| [ADR-0072](ADR-0072-reactive-capability-bus.md) | Reactive capability bus | Accepted |
 
 See also [Decision Log](DECISION_LOG.md) for lightweight decisions that don't warrant a full ADR.

--- a/examples/capability_bus_demo.py
+++ b/examples/capability_bus_demo.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reactive capability bus — live demo.
+
+A claude_code/sonnet agent reads part of the codebase and, *as it goes*, emits
+``Finding`` capabilities inline in its normal text (```json blocks). We don't
+wait for the run to finish: a session observer fires on every Finding the
+instant it streams in, so we can react in real time — log it, score it, or
+spawn a deeper investigation.
+
+Contrast with before: either we sat idle while the model ran, or we had to give
+it a dedicated tool to call. Now any text response can carry typed signals and
+the agentic loop keeps going uninterrupted.
+
+Run::
+
+    uv run python examples/capability_bus_demo.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from pydantic import BaseModel, Field
+
+import lionagi as li
+from lionagi.ln.types import Operable, Spec
+from lionagi.session import Session
+
+
+class Finding(BaseModel):
+    claim: str = Field(description="One specific thing you learned about the code.")
+    file: str = Field(default="", description="Where you saw it.")
+    confidence: float = Field(default=0.5, ge=0.0, le=1.0)
+
+
+async def main() -> None:
+    session = Session()
+    branch = session.default_branch
+    branch.chat_model = li.iModel(provider="claude_code", model="sonnet", verbose_output=True)
+
+    # 1) Grant the capability — sets the runtime grant AND injects the
+    #    instruction block so the model knows it may emit Finding inline.
+    branch.grant_capabilities(Operable((Spec(Finding, name="finding"),), name="Caps"))
+
+    findings: list[Finding] = []
+
+    # 2) React the instant a Finding streams in — real-time, mid-run.
+    @session.observe(Finding)
+    async def dig_deeper(finding: Finding, _session: Session) -> None:
+        findings.append(finding)
+        print(f"\n  ⚡ FINDING #{len(findings)} (conf={finding.confidence}): {finding.claim}")
+        if finding.file:
+            print(f"     ↳ {finding.file}")
+        # Real-time manipulation hook: e.g. on a high-confidence finding you
+        # could spawn a sub-branch to investigate, enqueue a follow-up question,
+        # or steer the run. Kept as a log here to stay cheap and bounded.
+        if finding.confidence >= 0.8:
+            print("     → high confidence; this is where dig_deeper() would branch off")
+
+    # 3) Drive the agentic process. The run loop parses every assistant message
+    #    for capability emissions and raises them onto the bus.
+    prompt = (
+        "Read lionagi/session/signal.py and lionagi/session/observer.py. "
+        "As you go, whenever you understand something concrete about how the "
+        "reactive bus works, immediately emit a Finding inline as a ```json "
+        'block, e.g. {"finding": {"claim": "...", "file": "...", '
+        '"confidence": 0.8}} — then keep reading. Emit 3-5 findings total, '
+        "then give a one-line summary."
+    )
+
+    print("=== streaming claude_code/sonnet (findings fire live) ===")
+    async for _msg in branch.run(prompt):
+        pass  # messages also print via verbose_output; we only care about signals
+
+    print("\n=== done ===")
+    print(f"observer collected {len(findings)} findings")
+    print(f"bus recorded {len(session.observer.by_type(Finding))} Finding-bearing signals")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/lionagi/ln/types/__init__.py
+++ b/lionagi/ln/types/__init__.py
@@ -12,6 +12,7 @@ from ._sentinel import (
     not_sentinel,
 )
 from .base import DataClass, Enum, KeysDict, KeysLike, Meta, ModelConfig, Params
+from .filters import FieldRef, Filter, SpecFilter, TypeFilter, as_filter
 from .operable import Operable
 from .spec import CommonMeta, Spec
 
@@ -40,4 +41,10 @@ __all__ = (
     "Spec",
     "CommonMeta",
     "Operable",
+    # Filter DSL
+    "Filter",
+    "TypeFilter",
+    "SpecFilter",
+    "FieldRef",
+    "as_filter",
 )

--- a/lionagi/ln/types/filters.py
+++ b/lionagi/ln/types/filters.py
@@ -1,0 +1,167 @@
+"""Filters — composable predicates that match an emitted payload.
+
+A capability emission is a dynamic model whose fields are named ``Spec``s. A
+``Filter`` decides whether a payload is interesting and yields the matched
+value(s) to hand to a handler. Two kinds, unified under one abstraction:
+
+- ``TypeFilter(T)`` — matches when the payload *is* a ``T``, or carries a field
+  whose value is a ``T``. Hands back the matched instance(s). (A type
+  subscription is just a filter that scans ``model_fields`` for ``isinstance``.)
+- ``SpecFilter`` — matches a named field by value, built via ``Spec.q``::
+
+      flower = Spec(str, name="flower_name")
+      session.observe(flower.q == "rose")   # flower.q → FieldRef("flower_name")
+
+  ``flower.q == "rose"`` is not a bool — it is a ``SpecFilter``, a predicate
+  asking "does the payload carry a ``flower_name`` field equal to ``rose``?".
+
+Filters compose with ``&`` / ``|`` / ``~``. ``observe``/``route``/``gate`` all
+speak Filter — a plain callable predicate is wrapped via :func:`as_filter`.
+
+Named *Filter*, not *Condition*: ``Condition`` is already a protocols concept
+(``await condition.apply``). And the operators live on ``FieldRef`` (handed out
+by ``Spec.q``), not on ``Spec`` itself — ``Spec.__eq__`` is load-bearing for
+the Operable system (sets, dedup, caches).
+"""
+
+from __future__ import annotations
+
+import operator
+from collections.abc import Callable
+from typing import Any
+
+__all__ = ("Filter", "TypeFilter", "SpecFilter", "FieldRef", "as_filter")
+
+
+def field_values(payload: Any) -> dict[str, Any]:
+    """Field name → value for a payload (Pydantic model or dict); else empty."""
+    model_fields = getattr(type(payload), "model_fields", None)
+    if model_fields:
+        return {name: getattr(payload, name, None) for name in model_fields}
+    if isinstance(payload, dict):
+        return payload
+    return {}
+
+
+class Filter:
+    """A composable predicate over a payload, yielding matched values."""
+
+    def matches(self, payload: Any) -> list[Any]:
+        """The matched value(s) to hand to a handler; empty when no match."""
+        raise NotImplementedError
+
+    def __call__(self, payload: Any) -> bool:
+        return bool(self.matches(payload))
+
+    def __and__(self, other: Filter | Callable) -> SpecFilter:
+        o = as_filter(other)
+        return SpecFilter(lambda p: self(p) and o(p), f"({self!r} & {o!r})")
+
+    def __or__(self, other: Filter | Callable) -> SpecFilter:
+        o = as_filter(other)
+        return SpecFilter(lambda p: self(p) or o(p), f"({self!r} | {o!r})")
+
+    def __invert__(self) -> SpecFilter:
+        return SpecFilter(lambda p: not self(p), f"~{self!r}")
+
+
+class TypeFilter(Filter):
+    """Matches a payload that *is* ``type_``, or carries a field of that type."""
+
+    __slots__ = ("type_",)
+
+    def __init__(self, type_: type) -> None:
+        self.type_ = type_
+
+    def matches(self, payload: Any) -> list[Any]:
+        if isinstance(payload, self.type_):
+            return [payload]
+        return [v for v in field_values(payload).values() if isinstance(v, self.type_)]
+
+    def __repr__(self) -> str:
+        return f"TypeFilter({self.type_.__name__})"
+
+
+class SpecFilter(Filter):
+    """A predicate filter — matches the whole payload when its check passes.
+
+    Built by ``FieldRef`` comparisons (``spec.q == value``), by composition,
+    and by wrapping a plain callable. Hands back the payload on a match.
+    """
+
+    __slots__ = ("_fn", "_repr")
+
+    def __init__(self, fn: Callable[[Any], bool], repr_: str = "SpecFilter") -> None:
+        self._fn = fn
+        self._repr = repr_
+
+    def matches(self, payload: Any) -> list[Any]:
+        try:
+            return [payload] if self._fn(payload) else []
+        except Exception:
+            return []
+
+    def __repr__(self) -> str:
+        return self._repr
+
+
+def as_filter(x: Filter | type | Callable) -> Filter:
+    """Coerce a type, callable, or Filter into a Filter."""
+    if isinstance(x, Filter):
+        return x
+    if isinstance(x, type):
+        return TypeFilter(x)
+    if callable(x):
+        return SpecFilter(x, getattr(x, "__name__", "predicate"))
+    raise TypeError(f"Cannot use {x!r} as a Filter")
+
+
+class FieldRef:
+    """A handle to a named field that builds :class:`SpecFilter`s via comparison.
+
+    Obtained from ``Spec.q``. The operators return Filters, not bools, so a
+    FieldRef must not be used as a dict key or set member.
+    """
+
+    __slots__ = ("name",)
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def _cmp(self, op: Callable, other: Any, sym: str) -> SpecFilter:
+        name = self.name
+
+        def check(payload: Any) -> bool:
+            values = field_values(payload)
+            if name not in values:
+                return False
+            return op(values[name], other)
+
+        return SpecFilter(check, f"{name}{sym}{other!r}")
+
+    def __eq__(self, other: Any) -> SpecFilter:  # type: ignore[override]
+        return self._cmp(operator.eq, other, "==")
+
+    def __ne__(self, other: Any) -> SpecFilter:  # type: ignore[override]
+        return self._cmp(operator.ne, other, "!=")
+
+    def __gt__(self, other: Any) -> SpecFilter:
+        return self._cmp(operator.gt, other, ">")
+
+    def __ge__(self, other: Any) -> SpecFilter:
+        return self._cmp(operator.ge, other, ">=")
+
+    def __lt__(self, other: Any) -> SpecFilter:
+        return self._cmp(operator.lt, other, "<")
+
+    def __le__(self, other: Any) -> SpecFilter:
+        return self._cmp(operator.le, other, "<=")
+
+    def is_in(self, choices: Any) -> SpecFilter:
+        return self._cmp(lambda v, c: v in c, choices, " in ")
+
+    def present(self) -> SpecFilter:
+        name = self.name
+        return SpecFilter(lambda p: field_values(p).get(name) is not None, f"{name}?")
+
+    __hash__ = None  # type: ignore[assignment]  # __eq__ returns a Filter, not a bool

--- a/lionagi/ln/types/filters.py
+++ b/lionagi/ln/types/filters.py
@@ -26,11 +26,14 @@ the Operable system (sets, dedup, caches).
 
 from __future__ import annotations
 
+import logging
 import operator
 from collections.abc import Callable
 from typing import Any
 
 __all__ = ("Filter", "TypeFilter", "SpecFilter", "FieldRef", "as_filter")
+
+logger = logging.getLogger(__name__)
 
 
 def field_values(payload: Any) -> dict[str, Any]:
@@ -87,18 +90,29 @@ class SpecFilter(Filter):
 
     Built by ``FieldRef`` comparisons (``spec.q == value``), by composition,
     and by wrapping a plain callable. Hands back the payload on a match.
+
+    ``safe`` (set by ``FieldRef``) swallows exceptions — a missing or
+    type-incompatible field is just a non-match, by design. Arbitrary user
+    predicates wrapped via :func:`as_filter` are **not** safe: their exceptions
+    are logged with the predicate repr (so a buggy subscription is visible) and
+    then treated as a non-match rather than silently disappearing.
     """
 
-    __slots__ = ("_fn", "_repr")
+    __slots__ = ("_fn", "_repr", "safe")
 
-    def __init__(self, fn: Callable[[Any], bool], repr_: str = "SpecFilter") -> None:
+    def __init__(
+        self, fn: Callable[[Any], bool], repr_: str = "SpecFilter", *, safe: bool = False
+    ) -> None:
         self._fn = fn
         self._repr = repr_
+        self.safe = safe
 
     def matches(self, payload: Any) -> list[Any]:
         try:
             return [payload] if self._fn(payload) else []
         except Exception:
+            if not self.safe:
+                logger.warning("Filter predicate %s raised on payload", self._repr, exc_info=True)
             return []
 
     def __repr__(self) -> str:
@@ -137,7 +151,7 @@ class FieldRef:
                 return False
             return op(values[name], other)
 
-        return SpecFilter(check, f"{name}{sym}{other!r}")
+        return SpecFilter(check, f"{name}{sym}{other!r}", safe=True)
 
     def __eq__(self, other: Any) -> SpecFilter:  # type: ignore[override]
         return self._cmp(operator.eq, other, "==")
@@ -162,6 +176,6 @@ class FieldRef:
 
     def present(self) -> SpecFilter:
         name = self.name
-        return SpecFilter(lambda p: field_values(p).get(name) is not None, f"{name}?")
+        return SpecFilter(lambda p: field_values(p).get(name) is not None, f"{name}?", safe=True)
 
     __hash__ = None  # type: ignore[assignment]  # __eq__ returns a Filter, not a bool

--- a/lionagi/ln/types/spec.py
+++ b/lionagi/ln/types/spec.py
@@ -58,9 +58,7 @@ class CommonMeta(Enum):
                 raise ValueError("Validators must be a list of functions or a function")
 
     @classmethod
-    def prepare(
-        cls, *args: Meta, metadata: tuple[Meta, ...] = None, **kw: Any
-    ) -> tuple[Meta, ...]:
+    def prepare(cls, *args: Meta, metadata: tuple[Meta, ...] = None, **kw: Any) -> tuple[Meta, ...]:
         """Prepare metadata tuple from various inputs, checking for duplicates.
 
         Args:
@@ -161,9 +159,7 @@ class Spec:
                 or str(type(base_type)) == "<class 'types.UnionType'>"
             )
             if not is_valid_type:
-                raise ValueError(
-                    f"base_type must be a type or type annotation, got {base_type}"
-                )
+                raise ValueError(f"base_type must be a type or type annotation, got {base_type}")
 
         # Check for async default factory and warn
         if kw.get("default_factory") and is_coro_func(kw["default_factory"]):
@@ -214,6 +210,19 @@ class Spec:
     def name(self) -> MaybeUndefined[str]:
         """Get the field name from metadata."""
         return self.get(CommonMeta.NAME.value)
+
+    @property
+    def q(self):
+        """A :class:`FieldRef` for this spec's name — the entry point to the
+        filter DSL (``spec.q == value``, ``spec.q > value``, ...).
+
+        Lives here rather than on ``Spec`` directly because ``Spec.__eq__`` is
+        load-bearing (sets, dedup, caches); ``q`` hands out a fresh FieldRef
+        whose operators build :class:`SpecFilter`s instead.
+        """
+        from .filters import FieldRef
+
+        return FieldRef(self.name)
 
     @property
     def is_nullable(self) -> bool:
@@ -310,9 +319,7 @@ class Spec:
             return self.with_updates(default_factory=default)
         return self.with_updates(default=default)
 
-    def with_validator(
-        self, validator: Callable[..., Any] | list[Callable[..., Any]]
-    ) -> Spec:
+    def with_validator(self, validator: Callable[..., Any] | list[Callable[..., Any]]) -> Spec:
         """Create spec with validator(s).
 
         Args:
@@ -360,14 +367,10 @@ class Spec:
 
             # Handle nullable case - wrap in Optional-like union
             actual_type = (
-                Any
-                if is_sentinel(self.base_type, none_as_sentinel=True)
-                else self.base_type
+                Any if is_sentinel(self.base_type, none_as_sentinel=True) else self.base_type
             )
             current_metadata = (
-                ()
-                if is_sentinel(self.metadata, none_as_sentinel=True)
-                else self.metadata
+                () if is_sentinel(self.metadata, none_as_sentinel=True) else self.metadata
             )
 
             if any(m.key == "nullable" and m.value for m in current_metadata):
@@ -409,9 +412,7 @@ class Spec:
             exclude = set()
         if exclude_common:
             exclude = exclude | CommonMeta.allowed()
-        return {
-            meta.key: meta.value for meta in self.metadata if meta.key not in exclude
-        }
+        return {meta.key: meta.value for meta in self.metadata if meta.key not in exclude}
 
 
 def _is_factory(obj: Any) -> tuple[bool, bool]:

--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -35,10 +35,11 @@ def _attempt_extract(text: str, capabilities: Operable) -> tuple[list[Any], list
     """Parse capability emissions out of an assistant message.
 
     A capability is a named typed field (a ``Spec``); ``capabilities`` is the
-    ``Operable`` of names the agent is allowed to produce. We pull every JSON
-    object out of ``text`` (raw or ```json-fenced, fuzzy-tolerant) — a single
-    message may carry several blocks — and per block, per Ocean's rule, require
-    ``set(keys) ⊆ capabilities.allowed()``:
+    ``Operable`` of names the agent is allowed to produce. We pull every fenced
+    ````json`` block out of ``text`` (fuzzy-tolerant; the injected prompt asks
+    the model to fence its emissions) — a single message may carry several
+    blocks; un-fenced JSON embedded in prose is *not* extracted — and per block,
+    per Ocean's rule, require ``set(keys) ⊆ capabilities.allowed()``:
 
     - no capability keys → ordinary prose/JSON, skipped;
     - keys ⊆ grant → validated via ``create_model`` into a bundle (a dynamic

--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -31,51 +31,56 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _attempt_extract(text: str, capabilities: Operable) -> Any | None:
-    """Parse a capability emission out of an assistant message into one bundle.
+def _attempt_extract(text: str, capabilities: Operable) -> list[Any]:
+    """Parse capability emissions out of an assistant message into bundles.
 
     A capability is a named typed field (a ``Spec``); ``capabilities`` is the
-    ``Operable`` of names the agent is allowed to produce. We pull JSON (raw or
-    ```json-fenced, fuzzy-tolerant) from ``text`` and, per Ocean's rule,
-    require ``set(keys) ⊆ capabilities.allowed()``:
+    ``Operable`` of names the agent is allowed to produce. We pull every JSON
+    object out of ``text`` (raw or ```json-fenced, fuzzy-tolerant) — a single
+    message may carry several blocks — and per block, per Ocean's rule, require
+    ``set(keys) ⊆ capabilities.allowed()``:
 
-    - no capability keys at all → ordinary prose/JSON, returns ``None``;
-    - keys ⊆ grant → validate via ``create_model`` and return the bundle: a
-      dynamic model with one field per present capability (a single response
-      can carry several — observers/filters then key off the named fields);
+    - no capability keys → ordinary prose/JSON, skipped;
+    - keys ⊆ grant → validated via ``create_model`` into a bundle (a dynamic
+      model with one field per present capability);
     - any key outside the grant → an *illegal* emission (the agent reaching
-      past its capabilities): dropped with a warning, returns ``None``.
+      past its capabilities): dropped with a warning.
+
+    Returns one bundle per valid block (often one, but the model may emit many
+    in a single response).
     """
     if not text or not isinstance(text, str):
-        return None
+        return []
     from lionagi.ln.fuzzy._extract_json import extract_json
 
     try:
-        data = extract_json(text, fuzzy_parse=True)
+        data = extract_json(text, fuzzy_parse=True, return_one_if_single=False)
     except Exception:
-        return None
-    if isinstance(data, list):
-        data = data[0] if data else None
-    if not isinstance(data, dict) or not data:
-        return None
+        return []
+    blocks = data if isinstance(data, list) else [data]
 
     allowed = capabilities.allowed()
-    keys = set(data.keys())
-    if keys.isdisjoint(allowed):
-        return None  # not a capability emission
-    if not keys <= allowed:
-        logger.warning(
-            "Illegal capability emission: keys %s outside grant %s",
-            keys - allowed,
-            allowed,
-        )
-        return None
-
-    model = capabilities.create_model(include=keys)
-    try:
-        return model.model_validate(data)
-    except Exception:
-        return None
+    bundles: list[Any] = []
+    for block in blocks:
+        if not isinstance(block, dict) or not block:
+            continue
+        keys = set(block.keys())
+        if keys.isdisjoint(allowed):
+            continue  # not a capability emission
+        if not keys <= allowed:
+            logger.warning(
+                "Illegal capability emission: keys %s outside grant %s",
+                keys - allowed,
+                allowed,
+            )
+            continue
+        model = capabilities.create_model(include=keys)
+        try:
+            bundles.append(model.model_validate(block))
+        except Exception as e:
+            logger.debug("Capability block failed validation, skipped: %s", e)
+            continue
+    return bundles
 
 
 async def _emit_message_signal(branch: Branch, msg: RoledMessage) -> None:
@@ -102,8 +107,7 @@ async def _emit_message_signal(branch: Branch, msg: RoledMessage) -> None:
     if isinstance(msg, AssistantResponse):
         capabilities = getattr(branch, "_capabilities", None)
         if capabilities is not None:
-            bundle = _attempt_extract(msg.response, capabilities)
-            if bundle is not None:
+            for bundle in _attempt_extract(msg.response, capabilities):
                 await branch.emit(StructuredOutput(data=bundle))
     elif isinstance(msg, ActionRequest):
         await branch.emit(ActionRequestSignal(data=msg))

--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import AsyncGenerator
 from dataclasses import fields
 from typing import TYPE_CHECKING, Any
@@ -23,8 +24,91 @@ from ..chat._prepare import _prepare_run_kwargs
 from ..types import ChatParam, ParseParam, RunParam
 
 if TYPE_CHECKING:
+    from lionagi.ln.types import Operable
     from lionagi.protocols.messages.message import RoledMessage
     from lionagi.session.branch import Branch
+
+logger = logging.getLogger(__name__)
+
+
+def _attempt_extract(text: str, capabilities: Operable) -> Any | None:
+    """Parse a capability emission out of an assistant message into one bundle.
+
+    A capability is a named typed field (a ``Spec``); ``capabilities`` is the
+    ``Operable`` of names the agent is allowed to produce. We pull JSON (raw or
+    ```json-fenced, fuzzy-tolerant) from ``text`` and, per Ocean's rule,
+    require ``set(keys) ⊆ capabilities.allowed()``:
+
+    - no capability keys at all → ordinary prose/JSON, returns ``None``;
+    - keys ⊆ grant → validate via ``create_model`` and return the bundle: a
+      dynamic model with one field per present capability (a single response
+      can carry several — observers/filters then key off the named fields);
+    - any key outside the grant → an *illegal* emission (the agent reaching
+      past its capabilities): dropped with a warning, returns ``None``.
+    """
+    if not text or not isinstance(text, str):
+        return None
+    from lionagi.ln.fuzzy._extract_json import extract_json
+
+    try:
+        data = extract_json(text, fuzzy_parse=True)
+    except Exception:
+        return None
+    if isinstance(data, list):
+        data = data[0] if data else None
+    if not isinstance(data, dict) or not data:
+        return None
+
+    allowed = capabilities.allowed()
+    keys = set(data.keys())
+    if keys.isdisjoint(allowed):
+        return None  # not a capability emission
+    if not keys <= allowed:
+        logger.warning(
+            "Illegal capability emission: keys %s outside grant %s",
+            keys - allowed,
+            allowed,
+        )
+        return None
+
+    model = capabilities.create_model(include=keys)
+    try:
+        return model.model_validate(data)
+    except Exception:
+        return None
+
+
+async def _emit_message_signal(branch: Branch, msg: RoledMessage) -> None:
+    """Raise the stream message onto the session bus as a typed Signal.
+
+    AssistantResponse → extract the capability bundle (when a grant is set) and
+    emit it as one StructuredOutput; filters fan out by named field, so one
+    response can satisfy several observers. ActionRequest/ActionResponse →
+    tool-use / tool-result signals. No-op when the branch has no observer.
+    """
+    if getattr(branch, "_observer", None) is None:
+        return
+    from lionagi.protocols.messages import (
+        ActionRequest,
+        ActionResponse,
+        AssistantResponse,
+    )
+    from lionagi.session.signal import (
+        ActionRequestSignal,
+        ActionResponseSignal,
+        StructuredOutput,
+    )
+
+    if isinstance(msg, AssistantResponse):
+        capabilities = getattr(branch, "_capabilities", None)
+        if capabilities is not None:
+            bundle = _attempt_extract(msg.response, capabilities)
+            if bundle is not None:
+                await branch.emit(StructuredOutput(data=bundle))
+    elif isinstance(msg, ActionRequest):
+        await branch.emit(ActionRequestSignal(data=msg))
+    elif isinstance(msg, ActionResponse):
+        await branch.emit(ActionResponseSignal(data=msg))
 
 
 async def run(
@@ -149,6 +233,7 @@ async def run(
 
                     case "tool_use":
                         if res := await _flush_response():
+                            await _emit_message_signal(branch, res)
                             yield res
 
                         act_req = branch.msgs.create_action_request(
@@ -160,6 +245,7 @@ async def run(
                         if chunk.tool_id:
                             pending_requests[chunk.tool_id] = act_req
                         await branch.msgs.a_add_message(action_request=act_req)
+                        await _emit_message_signal(branch, act_req)
                         yield act_req
 
                     case "tool_result":
@@ -189,6 +275,7 @@ async def run(
                             sender=branch.user or "user",
                             recipient=branch.id,
                         )
+                        await _emit_message_signal(branch, act_res)
                         yield act_res
 
                     case "result":
@@ -202,6 +289,7 @@ async def run(
                     call_meta = Note.from_dict(api_call.to_dict())
                     call_meta.pop(["execution", "response"], None)
                     res.metadata["api_call_meta"] = call_meta.to_dict()
+                await _emit_message_signal(branch, res)
                 yield res
     finally:
         # Restore original streaming func

--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -31,8 +31,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _attempt_extract(text: str, capabilities: Operable) -> list[Any]:
-    """Parse capability emissions out of an assistant message into bundles.
+def _attempt_extract(text: str, capabilities: Operable) -> tuple[list[Any], list[Any]]:
+    """Parse capability emissions out of an assistant message.
 
     A capability is a named typed field (a ``Spec``); ``capabilities`` is the
     ``Operable`` of names the agent is allowed to produce. We pull every JSON
@@ -44,23 +44,25 @@ def _attempt_extract(text: str, capabilities: Operable) -> list[Any]:
     - keys ⊆ grant → validated via ``create_model`` into a bundle (a dynamic
       model with one field per present capability);
     - any key outside the grant → an *illegal* emission (the agent reaching
-      past its capabilities): dropped with a warning.
+      past its capabilities): not honored, recorded as a ``CapabilityViolation``.
 
-    Returns one bundle per valid block (often one, but the model may emit many
-    in a single response).
+    Returns ``(bundles, violations)`` — both lists, since one response may
+    carry several blocks.
     """
     if not text or not isinstance(text, str):
-        return []
+        return [], []
     from lionagi.ln.fuzzy._extract_json import extract_json
+    from lionagi.session.capabilities import CapabilityViolation
 
     try:
         data = extract_json(text, fuzzy_parse=True, return_one_if_single=False)
     except Exception:
-        return []
+        return [], []
     blocks = data if isinstance(data, list) else [data]
 
     allowed = capabilities.allowed()
     bundles: list[Any] = []
+    violations: list[Any] = []
     for block in blocks:
         if not isinstance(block, dict) or not block:
             continue
@@ -73,6 +75,13 @@ def _attempt_extract(text: str, capabilities: Operable) -> list[Any]:
                 keys - allowed,
                 allowed,
             )
+            violations.append(
+                CapabilityViolation(
+                    offending=sorted(keys - allowed),
+                    allowed=sorted(allowed),
+                    block=block,
+                )
+            )
             continue
         model = capabilities.create_model(include=keys)
         try:
@@ -80,7 +89,7 @@ def _attempt_extract(text: str, capabilities: Operable) -> list[Any]:
         except Exception as e:
             logger.debug("Capability block failed validation, skipped: %s", e)
             continue
-    return bundles
+    return bundles, violations
 
 
 async def _emit_message_signal(branch: Branch, msg: RoledMessage) -> None:
@@ -101,14 +110,20 @@ async def _emit_message_signal(branch: Branch, msg: RoledMessage) -> None:
     from lionagi.session.signal import (
         ActionRequestSignal,
         ActionResponseSignal,
+        Signal,
         StructuredOutput,
     )
 
     if isinstance(msg, AssistantResponse):
         capabilities = getattr(branch, "_capabilities", None)
         if capabilities is not None:
-            for bundle in _attempt_extract(msg.response, capabilities):
+            bundles, violations = _attempt_extract(msg.response, capabilities)
+            for bundle in bundles:
                 await branch.emit(StructuredOutput(data=bundle))
+            # Over-grant attempts become observable governance events, not
+            # silent drops — session.observe(CapabilityViolation) can react.
+            for violation in violations:
+                await branch.emit(Signal(data=violation))
     elif isinstance(msg, ActionRequest):
         await branch.emit(ActionRequestSignal(data=msg))
     elif isinstance(msg, ActionResponse):

--- a/lionagi/session/__init__.py
+++ b/lionagi/session/__init__.py
@@ -4,6 +4,7 @@
 from lionagi.protocols.messages import Message  # noqa: E402
 
 from .branch import Branch
+from .capabilities import CapabilityViolation, render_capabilities_prompt
 from .exchange import Exchange
 from .observer import SessionObserver
 from .session import Session
@@ -18,10 +19,12 @@ __all__ = [
     "ActionRequestSignal",
     "ActionResponseSignal",
     "Branch",
+    "CapabilityViolation",
     "Exchange",
     "Message",
     "Session",
     "SessionObserver",
     "Signal",
     "StructuredOutput",
+    "render_capabilities_prompt",
 ]

--- a/lionagi/session/__init__.py
+++ b/lionagi/session/__init__.py
@@ -7,5 +7,14 @@ from .branch import Branch
 from .exchange import Exchange
 from .observer import SessionObserver
 from .session import Session
+from .signal import Signal, StructuredOutput
 
-__all__ = ["Branch", "Exchange", "Message", "Session", "SessionObserver"]
+__all__ = [
+    "Branch",
+    "Exchange",
+    "Message",
+    "Session",
+    "SessionObserver",
+    "Signal",
+    "StructuredOutput",
+]

--- a/lionagi/session/__init__.py
+++ b/lionagi/session/__init__.py
@@ -7,9 +7,16 @@ from .branch import Branch
 from .exchange import Exchange
 from .observer import SessionObserver
 from .session import Session
-from .signal import Signal, StructuredOutput
+from .signal import (
+    ActionRequestSignal,
+    ActionResponseSignal,
+    Signal,
+    StructuredOutput,
+)
 
 __all__ = [
+    "ActionRequestSignal",
+    "ActionResponseSignal",
     "Branch",
     "Exchange",
     "Message",

--- a/lionagi/session/branch.py
+++ b/lionagi/session/branch.py
@@ -52,6 +52,21 @@ __all__ = ("Branch",)
 _DEFAULT_ALCALL_PARAMS = None
 
 
+def _strip_capability_block(text: str) -> str:
+    """Remove a previously-injected capability block (between its markers)."""
+    if not text:
+        return ""
+    from .capabilities import CAP_BEGIN, CAP_END
+
+    start = text.find(CAP_BEGIN)
+    if start == -1:
+        return text
+    end = text.find(CAP_END, start)
+    if end == -1:
+        return text[:start]
+    return (text[:start] + text[end + len(CAP_END) :]).strip()
+
+
 class Branch(Element, Relational):
     """
     Manages a conversation 'branch' with messages, tools, and iModels.
@@ -353,15 +368,50 @@ class Branch(Element, Relational):
         ``Spec``s the agent is allowed to emit. The streaming run loop parses
         each assistant message against it: keys must be a subset of
         ``capabilities.allowed()`` (else the emission is illegal and dropped),
-        and each present capability is raised as a ``StructuredOutput`` onto the
-        session bus. ``None`` (default) disables per-message extraction;
-        tool-use signals still fire.
+        and present capabilities are raised as a ``StructuredOutput`` bundle
+        onto the session bus. ``None`` (default) disables per-message
+        extraction; tool-use signals still fire.
+
+        Set the runtime grant directly (pure data, no prompt change), or use
+        :meth:`grant_capabilities` to also tell the model what it may emit.
         """
         return self._capabilities
 
     @capabilities.setter
     def capabilities(self, operable: Any) -> None:
         self._capabilities = operable
+
+    def grant_capabilities(self, operable: Any, *, prompt: bool = True) -> None:
+        """Opt this branch into per-message capability emission.
+
+        Sets the runtime grant and (when ``prompt``) injects an idempotent
+        capability-instruction block into the system message so the model knows
+        which structured fields it may emit. Re-granting replaces the block;
+        :meth:`revoke_capabilities` removes it. Old strict behavior
+        (``operate(response_format=...)``) is untouched — that's the
+        final-output parse; this is per-message emission.
+        """
+        self._capabilities = operable
+        if prompt:
+            from .capabilities import CAP_BEGIN, CAP_END, render_capabilities_prompt
+
+            block = f"{CAP_BEGIN}\n{render_capabilities_prompt(operable)}\n{CAP_END}"
+            base = _strip_capability_block(self._system_text())
+            combined = f"{base.rstrip()}\n\n{block}" if base.strip() else block
+            self.msgs.set_system(self.msgs.create_system(system=combined))
+
+    def revoke_capabilities(self) -> None:
+        """Clear the capability grant and remove its system-prompt block."""
+        self._capabilities = None
+        base = _strip_capability_block(self._system_text())
+        if self.msgs.system is not None:
+            self.msgs.set_system(self.msgs.create_system(system=base or None))
+
+    def _system_text(self) -> str:
+        sys_msg = self.msgs.system
+        if sys_msg is None:
+            return ""
+        return sys_msg.content.system_message or ""
 
     # -------------------------------------------------------------------------
     # Cloning

--- a/lionagi/session/branch.py
+++ b/lionagi/session/branch.py
@@ -100,6 +100,7 @@ class Branch(Element, Relational):
     _log_manager: DataLogger | None = PrivateAttr(None)
     _operation_manager: OperationManager | None = PrivateAttr(None)
     _observer: Any = PrivateAttr(None)
+    _capabilities: Any = PrivateAttr(None)
 
     def __init__(
         self,
@@ -345,6 +346,22 @@ class Branch(Element, Relational):
         if self._observer is None:
             return []
         return await self._observer.emit(event)
+
+    @property
+    def capabilities(self) -> Any:
+        """The agent's capability grant — an ``Operable`` of named typed
+        ``Spec``s the agent is allowed to emit. The streaming run loop parses
+        each assistant message against it: keys must be a subset of
+        ``capabilities.allowed()`` (else the emission is illegal and dropped),
+        and each present capability is raised as a ``StructuredOutput`` onto the
+        session bus. ``None`` (default) disables per-message extraction;
+        tool-use signals still fire.
+        """
+        return self._capabilities
+
+    @capabilities.setter
+    def capabilities(self, operable: Any) -> None:
+        self._capabilities = operable
 
     # -------------------------------------------------------------------------
     # Cloning

--- a/lionagi/session/branch.py
+++ b/lionagi/session/branch.py
@@ -63,7 +63,11 @@ def _strip_capability_block(text: str) -> str:
         return text
     end = text.find(CAP_END, start)
     if end == -1:
-        return text[:start]
+        # Unbalanced markers (truncated block, or the begin marker appears in
+        # the user's own prompt): leave the text intact rather than discard
+        # everything after the marker — silent prompt corruption is worse than
+        # a stale block, which a re-grant overwrites cleanly.
+        return text
     return (text[:start] + text[end + len(CAP_END) :]).strip()
 
 
@@ -978,14 +982,29 @@ class Branch(Element, Relational):
             _pms.update(kwargs)
         from lionagi.operations.operate.operate import operate, prepare_operate_kw
 
-        result = await operate(self, **prepare_operate_kw(self, **_pms))
-        # A structured output is a capability emission: raise it onto the
-        # session's reactive bus so type-subscribed observers fire. No-op
-        # when the branch is standalone (no observer attached).
-        if self._observer is not None and isinstance(result, BaseModel):
-            from .signal import StructuredOutput
+        # Run lifecycle on the bus: RunStart → RunEnd(result) | RunFailed(exc).
+        # This is orthogonal to capabilities (no grant required) — it reports
+        # the run, not an exercised capability. ``RunEnd.data`` unwraps so
+        # ``session.observe(ResultType)`` still fires on the final result; the
+        # per-message capability bundles (run loop) are distinct payloads, so
+        # there is no double-emit. No-op when the branch is standalone.
+        has_observer = self._observer is not None
+        if has_observer:
+            from .signal import RunStart
 
-            await self.emit(StructuredOutput(data=result))
+            await self.emit(RunStart())
+        try:
+            result = await operate(self, **prepare_operate_kw(self, **_pms))
+        except Exception as exc:
+            if has_observer:
+                from .signal import RunFailed
+
+                await self.emit(RunFailed(data=exc))
+            raise
+        if has_observer:
+            from .signal import RunEnd
+
+            await self.emit(RunEnd(data=result))
         return result
 
     async def communicate(

--- a/lionagi/session/branch.py
+++ b/lionagi/session/branch.py
@@ -911,7 +911,15 @@ class Branch(Element, Relational):
             _pms.update(kwargs)
         from lionagi.operations.operate.operate import operate, prepare_operate_kw
 
-        return await operate(self, **prepare_operate_kw(self, **_pms))
+        result = await operate(self, **prepare_operate_kw(self, **_pms))
+        # A structured output is a capability emission: raise it onto the
+        # session's reactive bus so type-subscribed observers fire. No-op
+        # when the branch is standalone (no observer attached).
+        if self._observer is not None and isinstance(result, BaseModel):
+            from .signal import StructuredOutput
+
+            await self.emit(StructuredOutput(data=result))
+        return result
 
     async def communicate(
         self,

--- a/lionagi/session/capabilities.py
+++ b/lionagi/session/capabilities.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Render an agent's capability grant into a system-prompt instruction block.
+
+The instruction is rendered *from* the ``Operable`` grant, so the prose the
+model sees can never drift from what the run loop will actually extract and
+validate (``operable.create_model(...).model_validate(...)``, keys ⊆ grant).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lionagi.ln.types import Operable
+
+__all__ = ("render_capabilities_prompt", "CAP_BEGIN", "CAP_END")
+
+# Idempotency markers so a re-grant replaces (rather than stacks) the block.
+CAP_BEGIN = "<!-- lionagi:capabilities -->"
+CAP_END = "<!-- /lionagi:capabilities -->"
+
+
+def render_capabilities_prompt(operable: Operable) -> str:
+    """Render the capability grant into a system-prompt section.
+
+    Includes the exact JSON schema the extractor validates against, plus the
+    rule mirroring ``keys ⊆ grant``: only the listed keys are honored.
+    """
+    model = operable.create_model(model_name=operable.name or "Capabilities")
+    schema = model.model_json_schema()
+    contract: dict = {"properties": schema.get("properties", {})}
+    if "$defs" in schema:
+        contract["$defs"] = schema["$defs"]
+    block = json.dumps(contract, indent=2, default=str)
+    names = ", ".join(sorted(operable.allowed()))
+
+    return (
+        "## Structured capabilities\n\n"
+        "As you work, you may emit structured signals by including a fenced "
+        "```json code block in your reply. Each top-level key is a capability; "
+        "include only those relevant to the current step — you may emit several "
+        "at once, or none. Keep your normal narration as usual; the JSON block "
+        "is in addition to it, not a replacement.\n\n"
+        f"Allowed capability keys (emitting any other key is rejected): {names}.\n\n"
+        "Each key's value must conform to this schema:\n\n"
+        f"```json\n{block}\n```"
+    )

--- a/lionagi/session/capabilities.py
+++ b/lionagi/session/capabilities.py
@@ -13,10 +13,31 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
+from pydantic import BaseModel, Field
+
 if TYPE_CHECKING:
     from lionagi.ln.types import Operable
 
-__all__ = ("render_capabilities_prompt", "CAP_BEGIN", "CAP_END")
+__all__ = (
+    "render_capabilities_prompt",
+    "CapabilityViolation",
+    "CAP_BEGIN",
+    "CAP_END",
+)
+
+
+class CapabilityViolation(BaseModel):
+    """An agent tried to emit a capability outside its grant.
+
+    Raised onto the bus (not silently dropped) so governance can react —
+    ``session.observe(CapabilityViolation)`` to warn/steer/halt, or inspect via
+    the bus audit trail. The offending block is not validated or honored.
+    """
+
+    offending: list[str] = Field(description="Emitted keys outside the grant.")
+    allowed: list[str] = Field(description="The granted capability names.")
+    block: dict | None = Field(default=None, description="The raw rejected block.")
+
 
 # Idempotency markers so a re-grant replaces (rather than stacks) the block.
 CAP_BEGIN = "<!-- lionagi:capabilities -->"

--- a/lionagi/session/observer.py
+++ b/lionagi/session/observer.py
@@ -112,12 +112,17 @@ class SessionObserver(Observer):
         """
         payload = _payload(event)
 
+        # The gate may deny by returning falsy OR by raising — both deny while
+        # the event is still recorded below (documented audit contract).
         allowed = True
         if self._gate is not None:
-            verdict = self._gate(payload)
-            if inspect.isawaitable(verdict):
-                verdict = await verdict
-            allowed = bool(verdict)
+            try:
+                verdict = self._gate(payload)
+                if inspect.isawaitable(verdict):
+                    verdict = await verdict
+                allowed = bool(verdict)
+            except Exception:
+                allowed = False
 
         self.flow.add_item(event)  # always recorded (audit trail)
         if not allowed:
@@ -132,12 +137,27 @@ class SessionObserver(Observer):
         ctx = self.session if self.session is not None else self
         results: list[Any] = []
         for flt, handler in self._subs:
-            for matched in flt.matches(payload):
+            for matched in self._match(flt, event, payload):
                 out = handler(matched, ctx)
                 if inspect.isawaitable(out):
                     out = await out
                 results.append(out)
         return results
+
+    @staticmethod
+    def _match(flt: Filter, event: Any, payload: Any) -> list[Any]:
+        """Matched values for a filter against an emitted event.
+
+        Filters run on the *payload* (a Signal's ``data``). Additionally, an
+        envelope-type subscription — ``observe(RunEnd)`` / ``observe(Signal)`` —
+        matches the Signal itself by exact ``isinstance``, so lifecycle signals
+        (whose payload is unset or a different type) are observable by their own
+        type without field-scanning the envelope.
+        """
+        matched = list(flt.matches(payload))
+        if event is not payload and isinstance(flt, TypeFilter) and isinstance(event, flt.type_):
+            matched.append(event)
+        return matched
 
     # -- Reads ----------------------------------------------------------------
 
@@ -150,9 +170,13 @@ class SessionObserver(Observer):
         return [self.flow.items[uid] for uid in prog]
 
     def by_type(self, event_type: type) -> list[Any]:
-        """Stored items whose payload is — or carries a field of — ``event_type``."""
+        """Stored items whose payload is — or carries a field of — ``event_type``.
+
+        Also matches the envelope by exact type, so lifecycle signals
+        (``by_type(RunEnd)``) are retrievable like dispatch-time subscriptions.
+        """
         flt = TypeFilter(event_type)
-        return [e for e in self.flow.items if flt.matches(_payload(e))]
+        return [e for e in self.flow.items if self._match(flt, e, _payload(e))]
 
     def _ensure_stream(self, name: str) -> Progression:
         try:

--- a/lionagi/session/observer.py
+++ b/lionagi/session/observer.py
@@ -24,6 +24,12 @@ Usage::
 ``emit`` runs the chain: gate (govern) → store in Flow → route to streams →
 dispatch to type-subscribed observers. The gate is where charter/gate
 mediation plugs in; an observer firing is the honored capability.
+
+Dispatch keys off the *payload* type. When the emitted object is a
+:class:`Signal`, the key is ``type(signal.data)`` and handlers/conditions
+receive ``signal.data``; the full envelope is still stored in the Flow for
+audit. Anything else is dispatched by its own type. So
+``session.observe(MyModel)`` fires for ``branch.emit(StructuredOutput(data=MyModel(...)))``.
 """
 
 from __future__ import annotations
@@ -32,17 +38,22 @@ import inspect
 from collections.abc import Callable
 from typing import Any
 
-from lionagi.protocols._concepts import Observer
+from lionagi.protocols._concepts import Observable, Observer
 
-from ..protocols.generic.event import Event
 from ..protocols.generic.flow import Flow
 from ..protocols.generic.progression import Progression
+from .signal import Signal
 
 __all__ = ("SessionObserver",)
 
-Handler = Callable[[Event, "SessionObserver"], Any]
-Condition = Callable[[Event], bool]
-Gate = Callable[[Event], Any]
+Handler = Callable[[Any, "SessionObserver"], Any]
+Condition = Callable[[Any], bool]
+Gate = Callable[[Any], Any]
+
+
+def _payload(obj: Any) -> Any:
+    """The value handlers/conditions see: a Signal's data, else the object."""
+    return obj.data if isinstance(obj, Signal) else obj
 
 
 class SessionObserver(Observer):
@@ -51,14 +62,19 @@ class SessionObserver(Observer):
     def __init__(self, session: Any = None) -> None:
         self.session = session
         self.flow: Flow = Flow(name="session-events")
-        self._handlers: dict[type[Event], list[Handler]] = {}
+        self._handlers: dict[type, list[Handler]] = {}
         self._routes: list[tuple[Condition, str]] = []
         self._gate: Gate | None = None
 
     # -- Registration ---------------------------------------------------------
 
-    def observe(self, event_type: type[Event], handler: Handler | None = None) -> Any:
-        """Subscribe a handler to an event type. Usable as a decorator."""
+    def observe(self, event_type: type, handler: Handler | None = None) -> Any:
+        """Subscribe a handler to a payload type. Usable as a decorator.
+
+        ``event_type`` is the *payload* type — the type carried by an emitted
+        ``Signal.data``, or the type of a directly-emitted object. Handlers
+        receive ``(payload, ctx)``.
+        """
 
         def _register(fn: Handler) -> Handler:
             self._handlers.setdefault(event_type, []).append(fn)
@@ -83,11 +99,19 @@ class SessionObserver(Observer):
 
     # -- Emission / dispatch --------------------------------------------------
 
-    async def emit(self, event: Event) -> list[Any]:
-        """Run the chain: gate → store → route → dispatch. Returns handler results."""
+    async def emit(self, event: Observable) -> list[Any]:
+        """Run the chain: gate → store → route → dispatch. Returns handler results.
+
+        ``event`` is any Observable — a :class:`Signal` (whose ``data`` is the
+        payload) or a bare element. Gate, route-conditions, and handlers all
+        operate on the *payload*; the full envelope is stored in the Flow.
+        """
+        payload = _payload(event)
+        key = type(payload)
+
         allowed = True
         if self._gate is not None:
-            verdict = self._gate(event)
+            verdict = self._gate(payload)
             if inspect.isawaitable(verdict):
                 verdict = await verdict
             allowed = bool(verdict)
@@ -97,15 +121,15 @@ class SessionObserver(Observer):
             return []
 
         for condition, name in self._routes:
-            if condition(event):
+            if condition(payload):
                 self._ensure_stream(name).append(event)
 
-        # Handlers receive (event, ctx) where ctx is the bound Session when
+        # Handlers receive (payload, ctx) where ctx is the bound Session when
         # one is attached, else the observer itself.
         ctx = self.session if self.session is not None else self
         results: list[Any] = []
-        for handler in self._handlers.get(type(event), []):
-            out = handler(event, ctx)
+        for handler in self._handlers.get(key, []):
+            out = handler(payload, ctx)
             if inspect.isawaitable(out):
                 out = await out
             results.append(out)
@@ -113,7 +137,7 @@ class SessionObserver(Observer):
 
     # -- Reads ----------------------------------------------------------------
 
-    def stream(self, name: str) -> list[Event]:
+    def stream(self, name: str) -> list[Any]:
         """Events in a named condition-stream, in arrival order."""
         try:
             prog = self.flow.get_progression(name)
@@ -121,8 +145,9 @@ class SessionObserver(Observer):
             return []
         return [self.flow.items[uid] for uid in prog]
 
-    def by_type(self, event_type: type[Event]) -> list[Event]:
-        return [e for e in self.flow.items if isinstance(e, event_type)]
+    def by_type(self, event_type: type) -> list[Any]:
+        """Stored items whose payload is an instance of ``event_type``."""
+        return [e for e in self.flow.items if isinstance(_payload(e), event_type)]
 
     def _ensure_stream(self, name: str) -> Progression:
         try:

--- a/lionagi/session/observer.py
+++ b/lionagi/session/observer.py
@@ -22,14 +22,15 @@ Usage::
     await obs.emit(DepthRequested(question="..."))   # a tool/branch emits
 
 ``emit`` runs the chain: gate (govern) → store in Flow → route to streams →
-dispatch to type-subscribed observers. The gate is where charter/gate
+dispatch to Filter-subscribed observers. The gate is where charter/gate
 mediation plugs in; an observer firing is the honored capability.
 
-Dispatch keys off the *payload* type. When the emitted object is a
-:class:`Signal`, the key is ``type(signal.data)`` and handlers/conditions
-receive ``signal.data``; the full envelope is still stored in the Flow for
-audit. Anything else is dispatched by its own type. So
-``session.observe(MyModel)`` fires for ``branch.emit(StructuredOutput(data=MyModel(...)))``.
+Subscriptions are :class:`Filter`s. ``observe(MyModel)`` is sugar for a
+``TypeFilter`` — it fires when the payload *is* a ``MyModel`` or carries a
+``MyModel``-typed field, handing the matched instance to the handler.
+``observe(spec.q == "rose")`` is a ``SpecFilter`` — it fires on a named field's
+value, handing the payload. When the emitted object is a :class:`Signal`, the
+filter is applied to ``signal.data``; the full envelope is stored in the Flow.
 """
 
 from __future__ import annotations
@@ -38,6 +39,7 @@ import inspect
 from collections.abc import Callable
 from typing import Any
 
+from lionagi.ln.types import Filter, TypeFilter, as_filter
 from lionagi.protocols._concepts import Observable, Observer
 
 from ..protocols.generic.flow import Flow
@@ -47,12 +49,12 @@ from .signal import Signal
 __all__ = ("SessionObserver",)
 
 Handler = Callable[[Any, "SessionObserver"], Any]
-Condition = Callable[[Any], bool]
+Predicate = Callable[[Any], bool]
 Gate = Callable[[Any], Any]
 
 
 def _payload(obj: Any) -> Any:
-    """The value handlers/conditions see: a Signal's data, else the object."""
+    """The value handlers/filters see: a Signal's data, else the object."""
     return obj.data if isinstance(obj, Signal) else obj
 
 
@@ -62,27 +64,29 @@ class SessionObserver(Observer):
     def __init__(self, session: Any = None) -> None:
         self.session = session
         self.flow: Flow = Flow(name="session-events")
-        self._handlers: dict[type, list[Handler]] = {}
-        self._routes: list[tuple[Condition, str]] = []
+        self._subs: list[tuple[Filter, Handler]] = []
+        self._routes: list[tuple[Predicate, str]] = []
         self._gate: Gate | None = None
 
     # -- Registration ---------------------------------------------------------
 
-    def observe(self, event_type: type, handler: Handler | None = None) -> Any:
-        """Subscribe a handler to a payload type. Usable as a decorator.
+    def observe(self, key: type | Filter | Predicate, handler: Handler | None = None) -> Any:
+        """Subscribe a handler. Usable as a decorator.
 
-        ``event_type`` is the *payload* type — the type carried by an emitted
-        ``Signal.data``, or the type of a directly-emitted object. Handlers
-        receive ``(payload, ctx)``.
+        ``key`` is a type (→ ``TypeFilter``), a ``Filter`` (e.g.
+        ``spec.q == value``), or a plain predicate. Handlers receive
+        ``(matched, ctx)`` — for a type, the matched instance (the payload or a
+        matching field); for a value/predicate filter, the payload.
         """
+        flt = as_filter(key)
 
         def _register(fn: Handler) -> Handler:
-            self._handlers.setdefault(event_type, []).append(fn)
+            self._subs.append((flt, fn))
             return fn
 
         return _register if handler is None else _register(handler)
 
-    def route(self, condition: Condition, *, into: str) -> SessionObserver:
+    def route(self, condition: Predicate, *, into: str) -> SessionObserver:
         """Auto-append events matching ``condition`` to a named stream."""
         self._routes.append((condition, into))
         return self
@@ -107,7 +111,6 @@ class SessionObserver(Observer):
         operate on the *payload*; the full envelope is stored in the Flow.
         """
         payload = _payload(event)
-        key = type(payload)
 
         allowed = True
         if self._gate is not None:
@@ -124,15 +127,16 @@ class SessionObserver(Observer):
             if condition(payload):
                 self._ensure_stream(name).append(event)
 
-        # Handlers receive (payload, ctx) where ctx is the bound Session when
-        # one is attached, else the observer itself.
+        # Each subscription is a Filter; it yields the matched value(s) handed
+        # to the handler. ctx is the bound Session when attached, else self.
         ctx = self.session if self.session is not None else self
         results: list[Any] = []
-        for handler in self._handlers.get(key, []):
-            out = handler(payload, ctx)
-            if inspect.isawaitable(out):
-                out = await out
-            results.append(out)
+        for flt, handler in self._subs:
+            for matched in flt.matches(payload):
+                out = handler(matched, ctx)
+                if inspect.isawaitable(out):
+                    out = await out
+                results.append(out)
         return results
 
     # -- Reads ----------------------------------------------------------------
@@ -146,8 +150,9 @@ class SessionObserver(Observer):
         return [self.flow.items[uid] for uid in prog]
 
     def by_type(self, event_type: type) -> list[Any]:
-        """Stored items whose payload is an instance of ``event_type``."""
-        return [e for e in self.flow.items if isinstance(_payload(e), event_type)]
+        """Stored items whose payload is — or carries a field of — ``event_type``."""
+        flt = TypeFilter(event_type)
+        return [e for e in self.flow.items if flt.matches(_payload(e))]
 
     def _ensure_stream(self, name: str) -> Progression:
         try:
@@ -158,5 +163,4 @@ class SessionObserver(Observer):
             return prog
 
     def __repr__(self) -> str:
-        subs = {t.__name__: len(h) for t, h in self._handlers.items()}
-        return f"SessionObserver(events={len(self.flow.items)}, handlers={subs})"
+        return f"SessionObserver(events={len(self.flow.items)}, subscriptions={len(self._subs)})"

--- a/lionagi/session/signal.py
+++ b/lionagi/session/signal.py
@@ -29,6 +29,9 @@ __all__ = (
     "StructuredOutput",
     "ActionRequestSignal",
     "ActionResponseSignal",
+    "RunStart",
+    "RunEnd",
+    "RunFailed",
 )
 
 
@@ -58,3 +61,24 @@ class ActionResponseSignal(Signal):
     """A tool-result emission. ``data`` is the resolved ``ActionResponse``."""
 
     data: ActionResponse
+
+
+# -- Run lifecycle ------------------------------------------------------------
+# Lifecycle signals report the *fact* that a run began / ended / failed — a
+# concern orthogonal to capability emission (which requires a grant). They fire
+# whenever a session observer is attached, regardless of grant; a standalone
+# branch (no observer) emits nothing, so its behavior is unchanged. Observed by
+# their own envelope type (``session.observe(RunEnd)``); ``RunEnd.data`` also
+# unwraps so ``session.observe(MyModel)`` fires on the final result.
+
+
+class RunStart(Signal):
+    """A run is beginning. ``data`` is unset (a lifecycle marker)."""
+
+
+class RunEnd(Signal):
+    """A run completed. ``data`` is the final result (model, dict, or text)."""
+
+
+class RunFailed(Signal):
+    """A run raised. ``data`` is the exception that aborted it."""

--- a/lionagi/session/signal.py
+++ b/lionagi/session/signal.py
@@ -22,8 +22,14 @@ from typing import Any
 from pydantic import BaseModel
 
 from ..protocols.generic.element import Element
+from ..protocols.messages import ActionRequest, ActionResponse
 
-__all__ = ("Signal", "StructuredOutput")
+__all__ = (
+    "Signal",
+    "StructuredOutput",
+    "ActionRequestSignal",
+    "ActionResponseSignal",
+)
 
 
 class Signal(Element):
@@ -36,3 +42,19 @@ class StructuredOutput(Signal):
     """A Signal whose payload is a structured (typed) model."""
 
     data: BaseModel
+
+
+class ActionRequestSignal(Signal):
+    """A tool-use emission. ``data`` is the originating ``ActionRequest``.
+
+    Lets observers react to tool calls and track per-tool usage:
+    ``session.observe(ActionRequest)`` fires for every tool invocation.
+    """
+
+    data: ActionRequest
+
+
+class ActionResponseSignal(Signal):
+    """A tool-result emission. ``data`` is the resolved ``ActionResponse``."""
+
+    data: ActionResponse

--- a/lionagi/session/signal.py
+++ b/lionagi/session/signal.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Signal — a lightweight Observable envelope for the reactive bus.
+
+A ``Signal`` carries an arbitrary payload (``data``) into the session
+observer. Observers key off the *payload* type, not the Signal subclass:
+``session.observe(MyModel)`` fires for any Signal whose ``data`` is a
+``MyModel`` instance. The id comes for free from :class:`Element`, so the
+envelope lives in a Pile/Flow like any other element.
+
+``StructuredOutput`` is the typed case: its payload is a structured model.
+It is the realization of "capabilities = structured output event" — an agent
+exercises a capability by emitting a typed value; an observer reacting to
+that type is the capability being honored.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+from ..protocols.generic.element import Element
+
+__all__ = ("Signal", "StructuredOutput")
+
+
+class Signal(Element):
+    """An Observable envelope carrying a payload into the reactive bus."""
+
+    data: Any = None
+
+
+class StructuredOutput(Signal):
+    """A Signal whose payload is a structured (typed) model."""
+
+    data: BaseModel

--- a/tests/libs/test_filters.py
+++ b/tests/libs/test_filters.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Filter DSL: TypeFilter scans payload fields by type; SpecFilter (built via
+Spec.q) matches a named field by value; both compose with & | ~.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from lionagi.ln.types import Filter, Spec, SpecFilter, TypeFilter, as_filter
+
+
+class Finding(BaseModel):
+    claim: str
+
+
+class Bundle(BaseModel):
+    finding: Finding | None = None
+    flower_name: str | None = None
+    novelty: float = 0.0
+
+
+# -- TypeFilter -------------------------------------------------------------
+
+
+def test_type_filter_direct_instance():
+    f = TypeFilter(Finding)
+    fnd = Finding(claim="x")
+    assert f.matches(fnd) == [fnd]
+    assert f(fnd) is True
+
+
+def test_type_filter_scans_fields():
+    f = TypeFilter(Finding)
+    b = Bundle(finding=Finding(claim="x"))
+    matched = f.matches(b)
+    assert len(matched) == 1 and matched[0].claim == "x"
+
+
+def test_type_filter_no_match():
+    assert TypeFilter(Finding).matches(Bundle(flower_name="rose")) == []
+
+
+# -- SpecFilter via Spec.q --------------------------------------------------
+
+
+def test_spec_q_returns_field_ref():
+    flower = Spec(str, name="flower_name")
+    cond = flower.q == "rose"
+    assert isinstance(cond, SpecFilter)
+
+
+def test_spec_filter_value_match():
+    flower = Spec(str, name="flower_name")
+    cond = flower.q == "rose"
+    assert cond(Bundle(flower_name="rose")) is True
+    assert cond(Bundle(flower_name="tulip")) is False
+    # missing field → no match, never raises
+    assert cond(Finding(claim="x")) is False
+
+
+def test_spec_filter_comparison_ops():
+    novelty = Spec(float, name="novelty")
+    assert (novelty.q > 0.5)(Bundle(novelty=0.9)) is True
+    assert (novelty.q > 0.5)(Bundle(novelty=0.1)) is False
+    assert (novelty.q >= 0.9)(Bundle(novelty=0.9)) is True
+
+
+def test_spec_filter_is_in_and_present():
+    flower = Spec(str, name="flower_name")
+    assert flower.q.is_in({"rose", "tulip"})(Bundle(flower_name="rose")) is True
+    assert flower.q.present()(Bundle(flower_name="rose")) is True
+    assert flower.q.present()(Bundle()) is False
+
+
+# -- composition ------------------------------------------------------------
+
+
+def test_filter_composition():
+    flower = Spec(str, name="flower_name")
+    novelty = Spec(float, name="novelty")
+    both = (flower.q == "rose") & (novelty.q > 0.5)
+    assert both(Bundle(flower_name="rose", novelty=0.9)) is True
+    assert both(Bundle(flower_name="rose", novelty=0.1)) is False
+
+    either = (flower.q == "rose") | (flower.q == "tulip")
+    assert either(Bundle(flower_name="tulip")) is True
+    assert (~(flower.q == "rose"))(Bundle(flower_name="tulip")) is True
+
+
+def test_as_filter_coercion():
+    assert isinstance(as_filter(Finding), TypeFilter)
+    assert isinstance(as_filter(lambda p: True), Filter)
+    flower = Spec(str, name="flower_name")
+    assert isinstance(as_filter(flower.q == "rose"), SpecFilter)
+
+
+def test_field_ref_not_hashable():
+    flower = Spec(str, name="flower_name")
+    # __eq__ returns a Filter, so FieldRef must not be hashable
+    import pytest
+
+    with pytest.raises(TypeError):
+        {flower.q}  # noqa: B018

--- a/tests/libs/test_filters.py
+++ b/tests/libs/test_filters.py
@@ -104,3 +104,29 @@ def test_field_ref_not_hashable():
 
     with pytest.raises(TypeError):
         {flower.q}  # noqa: B018
+
+
+# -- exception handling: FieldRef-safe vs user-predicate visible ------------
+
+
+def test_field_ref_filter_safe_on_missing_field():
+    # A FieldRef comparison on a payload lacking the field is a quiet non-match.
+    flower = Spec(str, name="flower_name")
+    flt = flower.q == "rose"
+    assert flt.safe is True
+    assert flt.matches(Bundle(flower_name="rose")) == [Bundle(flower_name="rose")]
+    # a model without the field — safe, returns no match, raises nothing
+    assert flt.matches(Finding(claim="x")) == []
+
+
+def test_user_predicate_exception_is_logged_not_silent(caplog):
+    import logging
+
+    def boom(_payload):
+        raise RuntimeError("predicate bug")
+
+    flt = as_filter(boom)
+    assert flt.safe is False
+    with caplog.at_level(logging.WARNING, logger="lionagi.ln.types.filters"):
+        assert flt.matches(Finding(claim="x")) == []  # no crash, no match
+    assert any("raised on payload" in r.message for r in caplog.records)

--- a/tests/operations/run/test_run_signals.py
+++ b/tests/operations/run/test_run_signals.py
@@ -59,31 +59,47 @@ def _assistant(text: str) -> AssistantResponse:
 
 
 def test_extract_single_capability():
-    bundle = _attempt_extract('{"finding": {"claim": "x", "confidence": 0.9}}', _grant())
-    assert isinstance(bundle.finding, Finding)
-    assert bundle.finding.claim == "x" and bundle.finding.confidence == 0.9
+    bundles = _attempt_extract('{"finding": {"claim": "x", "confidence": 0.9}}', _grant())
+    assert len(bundles) == 1
+    assert isinstance(bundles[0].finding, Finding)
+    assert bundles[0].finding.claim == "x" and bundles[0].finding.confidence == 0.9
 
 
-def test_extract_multiple_capabilities():
+def test_extract_multiple_keys_one_block():
     text = '```json\n{"finding": {"claim": "y"}, "question": {"text": "why?"}}\n```'
-    bundle = _attempt_extract(text, _grant())
-    assert bundle.finding.claim == "y"
-    assert bundle.question.text == "why?"
+    bundles = _attempt_extract(text, _grant())
+    assert len(bundles) == 1
+    assert bundles[0].finding.claim == "y"
+    assert bundles[0].question.text == "why?"
 
 
-def test_extract_prose_returns_none():
-    assert _attempt_extract("just thinking out loud", _grant()) is None
+def test_extract_multiple_blocks_one_message():
+    # the case the live demo exposed: several ```json blocks in one response
+    text = (
+        "Reading along...\n"
+        '```json\n{"finding": {"claim": "first"}}\n```\n'
+        "and more...\n"
+        '```json\n{"finding": {"claim": "second", "confidence": 0.9}}\n```\n'
+        "done."
+    )
+    bundles = _attempt_extract(text, _grant())
+    assert len(bundles) == 2
+    assert [b.finding.claim for b in bundles] == ["first", "second"]
+
+
+def test_extract_prose_returns_empty():
+    assert _attempt_extract("just thinking out loud", _grant()) == []
 
 
 def test_extract_non_capability_json_ignored():
     # valid JSON, keys disjoint from the grant → ordinary output, not a capability
-    assert _attempt_extract('{"unrelated": 1}', _grant()) is None
+    assert _attempt_extract('{"unrelated": 1}', _grant()) == []
 
 
 def test_extract_illegal_emission_dropped(caplog):
-    # 'secret' is outside the grant → illegal; the whole emission is dropped
+    # 'secret' is outside the grant → illegal; that block is dropped
     out = _attempt_extract('{"finding": {"claim": "z"}, "secret": {"x": 1}}', _grant())
-    assert out is None
+    assert out == []
     assert any("Illegal capability emission" in r.message for r in caplog.records)
 
 

--- a/tests/operations/run/test_run_signals.py
+++ b/tests/operations/run/test_run_signals.py
@@ -59,15 +59,17 @@ def _assistant(text: str) -> AssistantResponse:
 
 
 def test_extract_single_capability():
-    bundles = _attempt_extract('{"finding": {"claim": "x", "confidence": 0.9}}', _grant())
-    assert len(bundles) == 1
+    bundles, violations = _attempt_extract(
+        '{"finding": {"claim": "x", "confidence": 0.9}}', _grant()
+    )
+    assert len(bundles) == 1 and not violations
     assert isinstance(bundles[0].finding, Finding)
     assert bundles[0].finding.claim == "x" and bundles[0].finding.confidence == 0.9
 
 
 def test_extract_multiple_keys_one_block():
     text = '```json\n{"finding": {"claim": "y"}, "question": {"text": "why?"}}\n```'
-    bundles = _attempt_extract(text, _grant())
+    bundles, _ = _attempt_extract(text, _grant())
     assert len(bundles) == 1
     assert bundles[0].finding.claim == "y"
     assert bundles[0].question.text == "why?"
@@ -82,25 +84,51 @@ def test_extract_multiple_blocks_one_message():
         '```json\n{"finding": {"claim": "second", "confidence": 0.9}}\n```\n'
         "done."
     )
-    bundles = _attempt_extract(text, _grant())
+    bundles, _ = _attempt_extract(text, _grant())
     assert len(bundles) == 2
     assert [b.finding.claim for b in bundles] == ["first", "second"]
 
 
 def test_extract_prose_returns_empty():
-    assert _attempt_extract("just thinking out loud", _grant()) == []
+    assert _attempt_extract("just thinking out loud", _grant()) == ([], [])
 
 
 def test_extract_non_capability_json_ignored():
     # valid JSON, keys disjoint from the grant → ordinary output, not a capability
-    assert _attempt_extract('{"unrelated": 1}', _grant()) == []
+    assert _attempt_extract('{"unrelated": 1}', _grant()) == ([], [])
 
 
-def test_extract_illegal_emission_dropped(caplog):
-    # 'secret' is outside the grant → illegal; that block is dropped
-    out = _attempt_extract('{"finding": {"claim": "z"}, "secret": {"x": 1}}', _grant())
-    assert out == []
+def test_extract_illegal_emission_becomes_violation(caplog):
+    from lionagi.session.capabilities import CapabilityViolation
+
+    # 'secret' is outside the grant → not honored, recorded as a violation
+    bundles, violations = _attempt_extract(
+        '{"finding": {"claim": "z"}, "secret": {"x": 1}}', _grant()
+    )
+    assert bundles == []  # the mixed block is not honored
+    assert len(violations) == 1
+    v = violations[0]
+    assert isinstance(v, CapabilityViolation)
+    assert v.offending == ["secret"]
+    assert "finding" in v.allowed and "question" in v.allowed
     assert any("Illegal capability emission" in r.message for r in caplog.records)
+
+
+async def test_violation_emitted_as_bus_signal():
+    from lionagi.session.capabilities import CapabilityViolation
+
+    s = Session()
+    caught = []
+    s.observe(CapabilityViolation, lambda v, _: caught.append(v.offending))
+
+    branch = s.default_branch
+    branch.capabilities = _grant()
+    # a mixed block reaches past the grant (finding granted, secret not)
+    await _emit_message_signal(
+        branch, _assistant('{"finding": {"claim": "z"}, "secret": {"x": 1}}')
+    )
+
+    assert caught == [["secret"]]  # governance observer fired on the over-grant
 
 
 # -- assistant capability bundle → bus, observed by TYPE --------------------

--- a/tests/operations/run/test_run_signals.py
+++ b/tests/operations/run/test_run_signals.py
@@ -1,0 +1,208 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-message stream emission: the run loop raises each streamed message onto
+the session bus as a typed Signal — tool-use/tool-result signals always, and a
+StructuredOutput bundle when an assistant message carries capability emissions.
+
+A capability is a named typed ``Spec``; the agent's grant is an ``Operable``.
+The bundle preserves field names, so observers can react by type (``Finding``)
+or by named field+value (``flower.q == "rose"``). A response may carry two or
+more capabilities → one bundle satisfying several observers.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from lionagi.ln.types import Operable, Spec
+from lionagi.operations.run.run import _attempt_extract, _emit_message_signal
+from lionagi.protocols.messages import (
+    ActionRequest,
+    ActionResponse,
+    AssistantResponse,
+)
+from lionagi.protocols.messages.assistant_response import AssistantResponseContent
+from lionagi.session.session import Session
+from lionagi.session.signal import (
+    ActionRequestSignal,
+    ActionResponseSignal,
+    StructuredOutput,
+)
+
+
+class Finding(BaseModel):
+    claim: str
+    confidence: float = 0.5
+
+
+class Question(BaseModel):
+    text: str
+
+
+def _grant() -> Operable:
+    return Operable(
+        (Spec(Finding, name="finding"), Spec(Question, name="question")),
+        name="AgentCapabilities",
+    )
+
+
+def _assistant(text: str) -> AssistantResponse:
+    return AssistantResponse(
+        content=AssistantResponseContent(assistant_response=text),
+        sender=None,
+        recipient="user",
+    )
+
+
+# -- _attempt_extract → bundle ----------------------------------------------
+
+
+def test_extract_single_capability():
+    bundle = _attempt_extract('{"finding": {"claim": "x", "confidence": 0.9}}', _grant())
+    assert isinstance(bundle.finding, Finding)
+    assert bundle.finding.claim == "x" and bundle.finding.confidence == 0.9
+
+
+def test_extract_multiple_capabilities():
+    text = '```json\n{"finding": {"claim": "y"}, "question": {"text": "why?"}}\n```'
+    bundle = _attempt_extract(text, _grant())
+    assert bundle.finding.claim == "y"
+    assert bundle.question.text == "why?"
+
+
+def test_extract_prose_returns_none():
+    assert _attempt_extract("just thinking out loud", _grant()) is None
+
+
+def test_extract_non_capability_json_ignored():
+    # valid JSON, keys disjoint from the grant → ordinary output, not a capability
+    assert _attempt_extract('{"unrelated": 1}', _grant()) is None
+
+
+def test_extract_illegal_emission_dropped(caplog):
+    # 'secret' is outside the grant → illegal; the whole emission is dropped
+    out = _attempt_extract('{"finding": {"claim": "z"}, "secret": {"x": 1}}', _grant())
+    assert out is None
+    assert any("Illegal capability emission" in r.message for r in caplog.records)
+
+
+# -- assistant capability bundle → bus, observed by TYPE --------------------
+
+
+async def test_bundle_observed_by_type():
+    s = Session()
+    findings, questions = [], []
+    s.observe(Finding, lambda f, _: findings.append(f.claim))
+    s.observe(Question, lambda q, _: questions.append(q.text))
+
+    branch = s.default_branch
+    branch.capabilities = _grant()
+
+    await _emit_message_signal(
+        branch,
+        _assistant('{"finding": {"claim": "found"}, "question": {"text": "q?"}}'),
+    )
+    # one bundle emit, two observers fire — each handed its typed field
+    assert findings == ["found"]
+    assert questions == ["q?"]
+    # exactly one signal recorded, matched by both type filters
+    assert len(s.observer.by_type(Finding)) == 1
+    assert len(s.observer.by_type(Question)) == 1
+
+
+async def test_assistant_no_grant_no_extraction():
+    s = Session()
+    seen = []
+    s.observe(Finding, lambda f, _: seen.append(f.claim))
+    # capabilities unset (default None) → extraction dormant
+    await _emit_message_signal(s.default_branch, _assistant('{"finding": {"claim": "x"}}'))
+    assert seen == []
+
+
+# -- observed by named FIELD + VALUE (SpecFilter) ---------------------------
+
+
+async def test_bundle_observed_by_spec_filter():
+    flower = Spec(str, name="flower_name")
+    grant = Operable((flower,), name="FlowerCaps")
+
+    s = Session()
+    roses, others = [], []
+    # react only when the agent names a rose
+    s.observe(flower.q == "rose", lambda bundle, _: roses.append(bundle.flower_name))
+    s.observe(flower.q != "rose", lambda bundle, _: others.append(bundle.flower_name))
+
+    branch = s.default_branch
+    branch.capabilities = grant
+
+    await _emit_message_signal(branch, _assistant('{"flower_name": "rose"}'))
+    await _emit_message_signal(branch, _assistant('{"flower_name": "tulip"}'))
+
+    assert roses == ["rose"]
+    assert others == ["tulip"]
+
+
+# -- tool-use / tool-result signals -----------------------------------------
+
+
+async def test_action_request_signal():
+    s = Session()
+    calls = []
+    s.observe(ActionRequest, lambda req, _: calls.append(req.function))
+
+    req = s.default_branch.msgs.create_action_request(
+        function="search", arguments={"q": "lion"}, sender=None, recipient="user"
+    )
+    await _emit_message_signal(s.default_branch, req)
+
+    assert calls == ["search"]
+    sigs = [e for e in s.observer.flow.items if isinstance(e, ActionRequestSignal)]
+    assert len(sigs) == 1 and sigs[0].data.arguments == {"q": "lion"}
+
+
+async def test_action_response_signal():
+    s = Session()
+    outputs = []
+    s.observe(ActionResponse, lambda res, _: outputs.append(res.output))
+
+    branch = s.default_branch
+    req = branch.msgs.create_action_request(
+        function="search", arguments={"q": "x"}, sender=None, recipient="user"
+    )
+    res = branch.msgs.create_action_response(
+        action_request=req, action_output={"hits": 3}, sender="user", recipient=None
+    )
+    await _emit_message_signal(branch, res)
+
+    assert outputs == [{"hits": 3}]
+    sigs = [e for e in s.observer.flow.items if isinstance(e, ActionResponseSignal)]
+    assert len(sigs) == 1
+
+
+async def test_tool_stats_aggregation():
+    # the motivating use case: count tool calls by function from the bus
+    s = Session()
+    branch = s.default_branch
+    for fn in ("search", "search", "read"):
+        req = branch.msgs.create_action_request(
+            function=fn, arguments={}, sender=None, recipient="user"
+        )
+        await _emit_message_signal(branch, req)
+
+    sigs = [e for e in s.observer.flow.items if isinstance(e, ActionRequestSignal)]
+    counts: dict[str, int] = {}
+    for sig in sigs:
+        counts[sig.data.function] = counts.get(sig.data.function, 0) + 1
+    assert counts == {"search": 2, "read": 1}
+
+
+async def test_standalone_branch_emit_noop():
+    from lionagi.session.branch import Branch
+
+    b = Branch()
+    b.capabilities = _grant()
+    await _emit_message_signal(b, _assistant('{"finding": {"claim": "x"}}'))
+    req = b.msgs.create_action_request(function="f", arguments={}, sender=None, recipient="user")
+    await _emit_message_signal(b, req)
+    assert b._observer is None  # no observer was lazily created

--- a/tests/session/test_capabilities.py
+++ b/tests/session/test_capabilities.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Capability opt-in: grant_capabilities sets the runtime grant AND injects an
+idempotent instruction block telling the model what it may emit. Strict
+response_format behavior is orthogonal and untouched.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from lionagi.ln.types import Operable, Spec
+from lionagi.operations.run.run import _emit_message_signal
+from lionagi.protocols.messages import AssistantResponse
+from lionagi.protocols.messages.assistant_response import AssistantResponseContent
+from lionagi.session.capabilities import CAP_BEGIN, CAP_END, render_capabilities_prompt
+from lionagi.session.session import Session
+
+
+class Finding(BaseModel):
+    claim: str
+    confidence: float = 0.5
+
+
+class Question(BaseModel):
+    text: str
+
+
+def _grant() -> Operable:
+    return Operable(
+        (Spec(Finding, name="finding"), Spec(Question, name="question")),
+        name="AgentCapabilities",
+    )
+
+
+def _assistant(text: str) -> AssistantResponse:
+    return AssistantResponse(
+        content=AssistantResponseContent(assistant_response=text),
+        sender=None,
+        recipient="user",
+    )
+
+
+# -- renderer ---------------------------------------------------------------
+
+
+def test_render_lists_names_and_schema():
+    prompt = render_capabilities_prompt(_grant())
+    assert "finding" in prompt and "question" in prompt
+    assert "rejected" in prompt  # the keys ⊆ grant rule, in prose
+    assert "claim" in prompt  # nested schema is shown
+
+
+# -- grant / revoke ---------------------------------------------------------
+
+
+def test_grant_sets_runtime_and_prompt():
+    s = Session()
+    branch = s.default_branch
+    branch.grant_capabilities(_grant())
+
+    assert branch.capabilities is not None
+    sys_text = branch.msgs.system.content.system_message
+    assert CAP_BEGIN in sys_text and CAP_END in sys_text
+    assert "finding" in sys_text
+
+
+def test_grant_prompt_false_sets_runtime_only():
+    s = Session()
+    branch = s.default_branch
+    before = branch.msgs.system.content.system_message if branch.msgs.system else None
+    branch.grant_capabilities(_grant(), prompt=False)
+
+    assert branch.capabilities is not None
+    after = branch.msgs.system.content.system_message if branch.msgs.system else None
+    assert after == before  # no prompt mutation
+
+
+def test_regrant_replaces_block_no_duplicate():
+    s = Session()
+    branch = s.default_branch
+    branch.grant_capabilities(_grant())
+    branch.grant_capabilities(_grant())  # again
+
+    sys_text = branch.msgs.system.content.system_message
+    assert sys_text.count(CAP_BEGIN) == 1  # not stacked
+
+
+def test_grant_preserves_base_system():
+    s = Session()
+    branch = s.default_branch
+    branch.msgs.set_system(branch.msgs.create_system(system="You are a researcher."))
+    branch.grant_capabilities(_grant())
+
+    sys_text = branch.msgs.system.content.system_message
+    assert "You are a researcher." in sys_text
+    assert CAP_BEGIN in sys_text
+
+
+def test_revoke_clears_and_strips():
+    s = Session()
+    branch = s.default_branch
+    branch.msgs.set_system(branch.msgs.create_system(system="Base prompt."))
+    branch.grant_capabilities(_grant())
+    branch.revoke_capabilities()
+
+    assert branch.capabilities is None
+    sys_text = branch.msgs.system.content.system_message
+    assert CAP_BEGIN not in sys_text
+    assert "Base prompt." in sys_text
+
+
+# -- end-to-end: grant → emit → observe -------------------------------------
+
+
+async def test_grant_then_emit_observed():
+    s = Session()
+    seen = []
+    s.observe(Finding, lambda f, _: seen.append(f.claim))
+
+    branch = s.default_branch
+    branch.grant_capabilities(_grant())
+
+    await _emit_message_signal(branch, _assistant('{"finding": {"claim": "wired"}}'))
+    assert seen == ["wired"]

--- a/tests/session/test_capabilities.py
+++ b/tests/session/test_capabilities.py
@@ -111,6 +111,34 @@ def test_revoke_clears_and_strips():
     assert "Base prompt." in sys_text
 
 
+def test_strip_leaves_unbalanced_markers_intact():
+    # If the begin marker is present without a matching end marker (truncated
+    # block, or the user's own prompt contains the marker text), stripping must
+    # NOT discard everything after it — that would corrupt the user's prompt.
+    from lionagi.session.branch import _strip_capability_block
+
+    text = f"Important user instructions.\n{CAP_BEGIN}\nhalf a block, no end"
+    assert _strip_capability_block(text) == text  # unchanged
+
+    # A balanced block is still removed cleanly.
+    balanced = f"Keep me.\n{CAP_BEGIN}\nblock body\n{CAP_END}\nKeep me too."
+    stripped = _strip_capability_block(balanced)
+    assert CAP_BEGIN not in stripped and CAP_END not in stripped
+    assert "Keep me." in stripped and "Keep me too." in stripped
+
+
+def test_grant_then_revoke_preserves_user_marker_text():
+    # A user system prompt that happens to contain the begin marker is not
+    # corrupted by a grant/revoke cycle when its block is balanced.
+    s = Session()
+    branch = s.default_branch
+    branch.msgs.set_system(branch.msgs.create_system(system="Base prompt."))
+    branch.grant_capabilities(_grant())
+    branch.revoke_capabilities()
+    sys_text = branch.msgs.system.content.system_message
+    assert "Base prompt." in sys_text
+
+
 # -- end-to-end: grant → emit → observe -------------------------------------
 
 

--- a/tests/session/test_session_observer.py
+++ b/tests/session/test_session_observer.py
@@ -72,6 +72,27 @@ async def test_gate_denies_dispatch_but_records():
     assert len(s.observer.by_type(DepthRequested)) == 2
 
 
+async def test_gate_raise_denies_but_still_records():
+    # A gate that raises denies dispatch — but the event is still recorded,
+    # and the exception does not propagate out of emit (audit contract).
+    s = Session()
+    fired = []
+
+    @s.observe(DepthRequested)
+    def on_depth(event, session):
+        fired.append(event.question)
+
+    def raising_gate(_event):
+        raise RuntimeError("gate exploded")
+
+    s.gate(raising_gate)
+
+    results = await s.emit(DepthRequested(question="x", novelty=0.9))
+    assert results == []  # no dispatch
+    assert fired == []
+    assert len(s.observer.by_type(DepthRequested)) == 1  # recorded despite raise
+
+
 async def test_route_condition_stream():
     s = Session()
     s.route(lambda e: getattr(e, "novelty", 0) > 0.7, into="high_novelty")

--- a/tests/session/test_signal_emit.py
+++ b/tests/session/test_signal_emit.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""StructuredOutput signals: the observer keys off the *payload* type, and
+``branch.operate`` raises its structured result onto the bus automatically.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+import lionagi.operations.operate.operate as op_mod
+from lionagi.session.session import Session
+from lionagi.session.signal import Signal, StructuredOutput
+
+
+class Plan(BaseModel):
+    steps: int
+
+
+class Finding(BaseModel):
+    claim: str
+
+
+async def test_observe_keys_off_payload_type():
+    s = Session()
+    seen = []
+
+    @s.observe(Plan)
+    def on_plan(payload, session):
+        # handler receives the unwrapped payload, not the Signal envelope
+        assert isinstance(payload, Plan)
+        assert session is s
+        seen.append(payload.steps)
+
+    results = await s.default_branch.emit(StructuredOutput(data=Plan(steps=3)))
+    assert seen == [3]
+    assert results == [None]
+
+
+async def test_payload_type_discriminates_handlers():
+    s = Session()
+    plans, findings = [], []
+
+    s.observe(Plan, lambda p, _: plans.append(p.steps))
+    s.observe(Finding, lambda f, _: findings.append(f.claim))
+
+    await s.default_branch.emit(StructuredOutput(data=Plan(steps=1)))
+    await s.default_branch.emit(StructuredOutput(data=Finding(claim="x")))
+
+    assert plans == [1]
+    assert findings == ["x"]
+
+
+async def test_by_type_matches_payload():
+    s = Session()
+    await s.default_branch.emit(StructuredOutput(data=Plan(steps=9)))
+    matched = s.observer.by_type(Plan)
+    assert len(matched) == 1
+    assert isinstance(matched[0], StructuredOutput)
+    assert matched[0].data.steps == 9
+
+
+async def test_route_condition_sees_payload():
+    s = Session()
+    s.route(lambda p: isinstance(p, Plan) and p.steps > 5, into="big")
+    await s.default_branch.emit(StructuredOutput(data=Plan(steps=10)))
+    await s.default_branch.emit(StructuredOutput(data=Plan(steps=2)))
+    big = s.observer.stream("big")
+    assert len(big) == 1
+    assert big[0].data.steps == 10
+
+
+async def test_gate_sees_payload():
+    s = Session()
+    fired = []
+    s.observe(Plan, lambda p, _: fired.append(p.steps))
+    s.gate(lambda p: getattr(p, "steps", 0) > 0)
+
+    await s.default_branch.emit(StructuredOutput(data=Plan(steps=4)))
+    await s.default_branch.emit(StructuredOutput(data=Plan(steps=0)))
+
+    assert fired == [4]  # only the allowed one dispatched
+    assert len(s.observer.by_type(Plan)) == 2  # both recorded
+
+
+async def test_operate_emits_structured_output(monkeypatch):
+    s = Session()
+    seen = []
+    s.observe(Plan, lambda p, _: seen.append(p.steps))
+
+    async def fake_operate(branch, **kw):
+        return Plan(steps=7)
+
+    monkeypatch.setattr(op_mod, "operate", fake_operate)
+    monkeypatch.setattr(op_mod, "prepare_operate_kw", lambda branch, **kw: {})
+
+    result = await s.default_branch.operate(instruction="plan it")
+    assert isinstance(result, Plan)
+    assert seen == [7]  # the structured result was emitted onto the bus
+
+
+async def test_operate_non_model_result_not_emitted(monkeypatch):
+    s = Session()
+    seen = []
+    s.observe(str, lambda p, _: seen.append(p))
+
+    async def fake_operate(branch, **kw):
+        return "just text"
+
+    monkeypatch.setattr(op_mod, "operate", fake_operate)
+    monkeypatch.setattr(op_mod, "prepare_operate_kw", lambda branch, **kw: {})
+
+    result = await s.default_branch.operate(instruction="x")
+    assert result == "just text"
+    assert seen == []  # plain text is not a structured-output emission
+
+
+async def test_standalone_branch_operate_no_emit(monkeypatch):
+    # A branch with no session/observer must not raise when operate returns a model.
+    from lionagi.session.branch import Branch
+
+    b = Branch()
+
+    async def fake_operate(branch, **kw):
+        return Plan(steps=1)
+
+    monkeypatch.setattr(op_mod, "operate", fake_operate)
+    monkeypatch.setattr(op_mod, "prepare_operate_kw", lambda branch, **kw: {})
+
+    assert b._observer is None
+    result = await b.operate(instruction="x")
+    assert isinstance(result, Plan)  # no observer → emit skipped, no error
+
+
+def test_signal_is_observable():
+    sig = Signal(data={"k": 1})
+    assert sig.id is not None
+    assert sig.data == {"k": 1}

--- a/tests/session/test_signal_emit.py
+++ b/tests/session/test_signal_emit.py
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """StructuredOutput signals: the observer keys off the *payload* type, and
-``branch.operate`` raises its structured result onto the bus automatically.
+``branch.operate`` emits run-lifecycle signals (RunStart/RunEnd/RunFailed)
+onto the bus automatically.
 """
 
 from __future__ import annotations
@@ -11,7 +12,13 @@ from pydantic import BaseModel
 
 import lionagi.operations.operate.operate as op_mod
 from lionagi.session.session import Session
-from lionagi.session.signal import Signal, StructuredOutput
+from lionagi.session.signal import (
+    RunEnd,
+    RunFailed,
+    RunStart,
+    Signal,
+    StructuredOutput,
+)
 
 
 class Plan(BaseModel):
@@ -84,7 +91,9 @@ async def test_gate_sees_payload():
     assert len(s.observer.by_type(Plan)) == 2  # both recorded
 
 
-async def test_operate_emits_structured_output(monkeypatch):
+async def test_operate_emits_result_via_run_end(monkeypatch):
+    # The final result rides on RunEnd; observe(ResultType) still fires because
+    # RunEnd.data unwraps to the payload.
     s = Session()
     seen = []
     s.observe(Plan, lambda p, _: seen.append(p.steps))
@@ -97,10 +106,17 @@ async def test_operate_emits_structured_output(monkeypatch):
 
     result = await s.default_branch.operate(instruction="plan it")
     assert isinstance(result, Plan)
-    assert seen == [7]  # the structured result was emitted onto the bus
+    assert seen == [7]  # the final result was surfaced on the bus via RunEnd
+    # exactly one RunEnd carrying the result; no duplicate StructuredOutput
+    ends = s.observer.by_type(RunEnd)
+    assert len(ends) == 1
+    assert ends[0].data is result
+    assert len(s.observer.by_type(RunStart)) == 1
 
 
-async def test_operate_non_model_result_not_emitted(monkeypatch):
+async def test_operate_lifecycle_fires_for_text_result(monkeypatch):
+    # A non-model result is still the run's output → emitted via RunEnd, and
+    # observe(str) fires on it (the response is emitted, model or not).
     s = Session()
     seen = []
     s.observe(str, lambda p, _: seen.append(p))
@@ -113,11 +129,33 @@ async def test_operate_non_model_result_not_emitted(monkeypatch):
 
     result = await s.default_branch.operate(instruction="x")
     assert result == "just text"
-    assert seen == []  # plain text is not a structured-output emission
+    assert seen == ["just text"]
+    assert len(s.observer.by_type(RunEnd)) == 1
+
+
+async def test_operate_run_failed_on_exception(monkeypatch):
+    s = Session()
+    failures = []
+    s.observe(RunFailed, lambda sig, _: failures.append(sig.data))
+
+    async def fake_operate(branch, **kw):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(op_mod, "operate", fake_operate)
+    monkeypatch.setattr(op_mod, "prepare_operate_kw", lambda branch, **kw: {})
+
+    import pytest
+
+    with pytest.raises(ValueError, match="boom"):
+        await s.default_branch.operate(instruction="x")
+    assert len(failures) == 1
+    assert isinstance(failures[0], ValueError)
+    assert len(s.observer.by_type(RunStart)) == 1  # started before it failed
+    assert len(s.observer.by_type(RunEnd)) == 0  # never completed
 
 
 async def test_standalone_branch_operate_no_emit(monkeypatch):
-    # A branch with no session/observer must not raise when operate returns a model.
+    # A branch with no session/observer must not raise and must not emit.
     from lionagi.session.branch import Branch
 
     b = Branch()
@@ -131,6 +169,16 @@ async def test_standalone_branch_operate_no_emit(monkeypatch):
     assert b._observer is None
     result = await b.operate(instruction="x")
     assert isinstance(result, Plan)  # no observer → emit skipped, no error
+
+
+async def test_observe_lifecycle_by_envelope_type():
+    # Lifecycle signals are observed by their own type; RunStart has no payload.
+    s = Session()
+    starts = []
+    s.observe(RunStart, lambda sig, _: starts.append(sig))
+    await s.default_branch.emit(RunStart())
+    assert len(starts) == 1
+    assert isinstance(starts[0], RunStart)
 
 
 def test_signal_is_observable():


### PR DESCRIPTION
Realizes **\"capabilities = structured output event\"** on lionagi's own primitives: an agent exercises a capability by emitting a typed value; an observer reacting to it is the capability being honored. Built in three layers.

## L0 — Signals + operate emit
- `Signal(Element)` — lightweight Observable envelope; `StructuredOutput(Signal)` — typed payload.
- `Branch.operate` raises its structured result onto the session bus automatically (no-op standalone / non-model).

## L1 — per-message emission + Filter DSL
- **Filter DSL** (`ln/types/filters.py`): `Filter` base; `TypeFilter` (payload *is* `T`, or carries a `T`-typed field — scans `model_fields`); `SpecFilter` (predicate, built by `FieldRef`); compose with `& | ~`. `FieldRef` via `Spec.q`: `spec.q == / != / > / >= / < / <= / is_in / present`. Operators live on `FieldRef`, **not** `Spec` (its `__eq__` is load-bearing for the Operable system).
- **`SessionObserver`**: `observe(type | Filter | predicate)`, dispatch via `Filter.matches`, handler gets the matched value. A type subscription is just a `TypeFilter`. Bare-type / raw-event behavior preserved.
- **run loop** (single chokepoint for `branch.run` + operate-CLI): `AssistantResponse` → validate present capabilities into one bundle via `operable.create_model(include=keys).model_validate(data)`, enforcing **`keys ⊆ grant`** (disjoint → ignore; over-grant → illegal, dropped + warned). Emitted as one `StructuredOutput(data=bundle)`; filters fan out by named field. `ActionRequest`/`ActionResponse` → `ActionRequestSignal`/`ActionResponseSignal` (tool-use stats + reactive manipulation). `branch.capabilities` (Operable) is the runtime grant; `None` → dormant.

## L2 — opt-in grant + prompt injection
- `Branch.grant_capabilities(operable, prompt=True)`: sets the grant AND injects an idempotent capability-instruction block into the system message (re-grant replaces, not stacks). `revoke_capabilities()` clears + strips.
- `render_capabilities_prompt(operable)`: instructions + the exact JSON schema the extractor validates against + the prose mirror of `keys ⊆ grant`. Prompt can't drift from what's extractable — both derive from the same Operable.
- **Opt-in = presence of the grant.** `response_format` (final-output parse) and `capabilities` (per-message emission) are independent knobs; today's strict behavior is untouched.

## Design notes
- **The observer registry is the capability registry** — a capability is live iff something observes it; no central enum.
- **Filter**, not Condition — `Condition` is already a protocols concept (`await condition.apply`).

## Not in this PR
- AgentConfig/Role wiring of capabilities (the "agent = role + … + capabilities" home) — deferred until the casts rework settles.
- Illegal-emission policy is currently drop + `logger.warning`; raise / emit-a-violation-signal is a follow-up if governance wants it.

## Tests
`tests/libs/test_filters.py`, `tests/operations/run/test_run_signals.py`, `tests/session/test_signal_emit.py`, `tests/session/test_capabilities.py` + existing observer/emit suites — full `tests/session/`, `tests/operations/run/`, filter/spec/operable suites green; ruff clean.