### PR TITLE
feat(agent-spec): Layer 1+2 — capability ontology + loop control (ADR-0073)

### DIFF
--- a/docs/adrs/ADR-0073-universal-agent-spec.md
+++ b/docs/adrs/ADR-0073-universal-agent-spec.md
@@ -186,9 +186,13 @@ def capability_models(role: str) -> tuple[type[BaseModel], ...]:
 def capability_operable(role: str) -> Operable | None:
     """Build the Operable grant for a role. None when the role has no
     capabilities mapped (then the caller skips grant_capabilities)."""
-    models = capability_models(role)
-    if not models:
+    # Errata (PR #1211): the earlier pseudocode used `if not models: return None`,
+    # which can never be True because capability_models() always returns at least
+    # (EscalationRequest,).  The correct guard is `if role not in ROLE_CAPABILITIES`,
+    # which matches the implementation in lionagi/casts/capabilities.py:203.
+    if role not in ROLE_CAPABILITIES:
         return None
+    models = capability_models(role)
     specs = tuple(Spec(m, name=_field_name(m)) for m in models)
     return Operable(specs, name=f"{role}_capabilities")
 ```

--- a/docs/adrs/ADR-0073-universal-agent-spec.md
+++ b/docs/adrs/ADR-0073-universal-agent-spec.md
@@ -1,0 +1,507 @@
+# ADR-0073: Universal Agent Spec — Profile Composition, Capability Ontology, Loop Control
+
+**Status**: accepted (design contract for the `agent-spec-wiring` show)
+**Date**: 2026-05-30
+**Builds on**: ADR-0071 (Cognitive Mode Model), ADR-0072 (Reactive Capability Bus)
+
+## Context
+
+lionagi has, as of v0.26.12, three powerful but **disconnected** primitives:
+
+1. **Casts** (ADR-0071): 41 `Role`s + 14 `Mode`s as composable frozen patterns,
+   plus a `Pack`/`RolePolicy` carrying per-role authority / boundaries /
+   escalation conditions. `AgentConfig.build_system_message()` composes
+   `role + modes + system_prompt`.
+2. **Reactive capability bus** (ADR-0072): a `Signal`/`StructuredOutput`
+   envelope, a `SessionObserver` that dispatches by payload *type* or *field
+   value*, `branch.grant_capabilities(operable)`, and run-lifecycle signals
+   (`RunStart`/`RunEnd`/`RunFailed`).
+3. **Permission system**: `PermissionPolicy` (allow/deny/escalate, fnmatch
+   rules) wired as a `security_pre` hook through `create_agent()`.
+
+These never meet. The CLI orchestration path (`li o flow` / `li o fanout`)
+runs entirely through the thin `AgentProfile` (`cli/_agents.py`): a worker's
+`role` is a *profile-file name*, not a casts `Role`. CLI workers get no modes,
+no permission policy, no capability grant, and the bus — though live — is never
+fed because nobody calls `grant_capabilities()` on a worker branch. The
+`RolePolicy` escalation conditions are dead data.
+
+Three structural gaps follow:
+
+- **No universal agent spec.** Identity composition (`AgentConfig`) and CLI
+  orchestration (`AgentProfile`) are parallel models that don't share a type.
+- **No capability ontology.** Each role's *Artifacts* section already
+  describes what it produces (a critic yields a verdict; a researcher yields
+  findings) — but nothing turns that into typed signals the session observes.
+- **The bus can observe but cannot steer.** `emit` runs handlers, but a
+  handler cannot stop, cancel, or break the in-flight run loop. We built the
+  afferent nerve (sensing) without the efferent nerve (acting).
+
+## Decision
+
+Introduce a **universal `AgentSpec`**, a **capability ontology** derived from
+the roles themselves, and **loop control** that lets observers steer a run.
+Four layers, each a play in the show; this ADR is the contract they build to.
+
+---
+
+### Layer 1 — Capability ontology (`lionagi/casts/capabilities.py`)
+
+A capability is what a role *produces*, expressed as a typed payload model.
+The role's *Artifacts* section is the source of truth — we formalize it.
+
+**Capability payload models** (Pydantic `BaseModel`s, one per produced thing).
+Field types are the contract; keep them small and observable:
+
+```python
+class Finding(BaseModel):
+    description: str
+    confidence: float = Field(ge=0.0, le=1.0, default=0.5)
+    severity: str | None = None          # CRITICAL | MAJOR | MINOR | None
+    evidence: str | None = None
+    source: str | None = None            # file:line, URL, doc ref
+
+class Verdict(BaseModel):
+    verdict: str                          # APPROVE | APPROVE_WITH_FIXES | REQUEST_CHANGES | REJECT
+    rationale: str
+    evidence: str | None = None
+    reversible_by: str | None = None      # what evidence would reverse a REJECT
+
+class ComplianceVerdict(BaseModel):
+    verdict: str                          # BLOCK | PASS
+    control: str                          # the control citation
+    evidence_refs: list[str] = Field(default_factory=list)
+
+class RiskAssessment(BaseModel):
+    failure_mode: str
+    likelihood: float = Field(ge=0.0, le=1.0)
+    impact: float = Field(ge=0.0, le=1.0)
+    mitigation: str | None = None
+
+class AnalysisResult(BaseModel):
+    metric: str
+    value: float
+    ci_95: tuple[float, float] | None = None
+    p_value: float | None = None
+
+class Conflict(BaseModel):              # researcher's conflict register
+    sources: list[str]
+    nature: str
+
+class Gap(BaseModel):                   # coverage / unknowns
+    area: str
+    what_is_unknown: str
+
+class ExecutionPlan(BaseModel):         # orchestrator / strategist / planner
+    steps: list[str]
+    dependencies: list[str] = Field(default_factory=list)
+    exit_criteria: str | None = None
+
+class ComplexityScore(BaseModel):       # strategist's C(τ)
+    score: float = Field(ge=0.0, le=1.0)
+    rationale: str
+
+class ArtifactProduced(BaseModel):      # implementer / writer / migrator / ...
+    path: str
+    kind: str                            # code | doc | test | schema | script | ...
+    description: str | None = None
+    verified: bool = False
+
+class VerificationResult(BaseModel):    # tester / implementer
+    suite: str
+    passed: bool
+    coverage: float | None = None
+    gaps: list[str] = Field(default_factory=list)
+
+class EscalationRequest(BaseModel):     # UNIVERSAL — every role can escalate
+    reason: str
+    context: dict = Field(default_factory=dict)
+    blocking: bool = True
+    from_role: str | None = None
+```
+
+**Role → capability map.** Drawn from each role's *Artifacts* + *escalation*
+language. `EscalationRequest` is appended to **every** role automatically.
+
+```python
+ROLE_CAPABILITIES: dict[str, tuple[type[BaseModel], ...]] = {
+    # Verdict-zone
+    "critic":     (Verdict, Finding),
+    "reviewer":   (Verdict, Finding),
+    "auditor":    (ComplianceVerdict, Finding),
+    "arbitrator": (Verdict,),
+    "evaluator":  (Verdict, Finding),
+    "tester":     (VerificationResult, Finding),
+    # Discovery-zone
+    "researcher":     (Finding, Conflict, Gap),
+    "analyst":        (AnalysisResult, Finding),
+    "explorer":       (Finding, Gap),
+    "investigator":   (Finding, Gap),
+    "troubleshooter": (Finding,),
+    "assessor":       (RiskAssessment, Finding),
+    "contrarian":     (Finding,),
+    "commentator":    (Finding,),
+    "synthesizer":    (Finding, Conflict),
+    # Plan-zone
+    "orchestrator": (ExecutionPlan,),
+    "strategist":   (ComplexityScore, ExecutionPlan),
+    "planner":      (ExecutionPlan,),
+    "coordinator":  (ExecutionPlan,),
+    "architect":    (ExecutionPlan, ArtifactProduced),
+    "modeler":      (ArtifactProduced,),
+    "innovator":    (Finding,),
+    "suggester":    (Finding,),
+    # Build-zone
+    "implementer": (ArtifactProduced, VerificationResult),
+    "prototyper":  (ArtifactProduced, VerificationResult),
+    "refactorer":  (ArtifactProduced, VerificationResult),
+    "migrator":    (ArtifactProduced, VerificationResult),
+    "deployer":    (ArtifactProduced,),
+    "operator":    (ArtifactProduced,),
+    "writer":      (ArtifactProduced,),
+    "translator":  (ArtifactProduced,),
+    "scribe":      (ArtifactProduced,),
+    "curator":     (ArtifactProduced,),
+    # Process-zone
+    "facilitator":    (Finding,),
+    "negotiator":     (Finding,),
+    "mentor":         (Finding,),
+    "persona":        (Finding,),
+    "responder":      (Finding,),
+    "postmortem_lead":(Finding,),
+    "entrepreneur":   (Finding,),
+}
+```
+
+**Builder.** Turns a role name into the `Operable` `grant_capabilities`
+consumes. Field name = snake_case of the model class name (`Finding` →
+`finding`, `ComplianceVerdict` → `compliance_verdict`).
+
+```python
+def capability_models(role: str) -> tuple[type[BaseModel], ...]:
+    """Capability payload types for a role, including EscalationRequest."""
+    base = ROLE_CAPABILITIES.get(role, ())
+    return (*base, EscalationRequest) if EscalationRequest not in base else base
+
+def capability_operable(role: str) -> Operable | None:
+    """Build the Operable grant for a role. None when the role has no
+    capabilities mapped (then the caller skips grant_capabilities)."""
+    models = capability_models(role)
+    if not models:
+        return None
+    specs = tuple(Spec(m, name=_field_name(m)) for m in models)
+    return Operable(specs, name=f"{role}_capabilities")
+```
+
+`_field_name(model)` converts `ComplianceVerdict` → `compliance_verdict` via a
+simple CamelCase→snake_case helper. Keep the map of model→field deterministic
+and round-trippable (observers reference the *type*, not the field name, so the
+exact string only matters for the emitted JSON key the model sees).
+
+**Why this is the right cut.** The observer registry IS the capability registry
+(ADR-0072): a capability is live iff something observes its type. We are not
+introducing a central enum of "what may be emitted" — `ROLE_CAPABILITIES` is a
+*default suggestion* per role, fully overridable on the spec. A user can grant a
+researcher the `Verdict` capability if they want; nothing forbids it.
+
+---
+
+### Layer 2 — Loop control (`lionagi/session/control.py`)
+
+The bus senses; loop control acts. v1 scope is deliberately small and *honest*
+— only directives the CLI stream loop can honor cleanly at a chunk boundary.
+
+```python
+class LoopDirective(Enum):
+    CONTINUE = "continue"   # default / no-op
+    CANCEL   = "cancel"     # stop consuming the stream, flush partial, clean exit
+    BREAK    = "break"      # stop and raise LoopBreak (surfaces as RunFailed)
+
+@dataclass(frozen=True, slots=True)
+class LoopControl:
+    directive: LoopDirective
+    reason: str | None = None
+
+class LoopBreak(Exception):
+    """Raised inside the run loop when an observer issues BREAK."""
+    def __init__(self, reason: str | None = None):
+        super().__init__(reason or "loop broken by observer")
+        self.reason = reason
+```
+
+**PAUSE and INJECT are explicitly OUT of v1.** Pausing/resuming or injecting an
+instruction into a live CLI subprocess stream is a turn-boundary concern, not a
+chunk-boundary one; doing it half-way produces a stub. Document them in the ADR
+as future work; do **not** add them to the enum (no-stubs rule).
+
+**Branch wiring** (`session/branch.py`):
+
+```python
+_loop_control: LoopControl | None = PrivateAttr(None)
+
+def control(self, directive: LoopDirective, *, reason: str | None = None) -> None:
+    """Queue a loop-control directive. Called from an observer handler to
+    steer the in-flight run. The run loop polls this at chunk boundaries."""
+    self._loop_control = LoopControl(directive, reason)
+
+def poll_control(self) -> LoopControl | None:
+    """Return and CLEAR any queued directive (one-shot)."""
+    ctrl, self._loop_control = self._loop_control, None
+    return ctrl
+```
+
+**Run-loop wiring** (`operations/run/run.py`, inside the `async for chunk`
+loop). The seam is *immediately after each* `await _emit_message_signal(...)`
+— at that point all observer handlers for the just-emitted signal have run and
+may have called `branch.control(...)`. Add a single helper and call it after
+each of the three `_emit_message_signal` sites and the final flush:
+
+```python
+def _check_control(branch) -> None:
+    ctrl = branch.poll_control()
+    if ctrl is None or ctrl.directive is LoopDirective.CONTINUE:
+        return
+    if ctrl.directive is LoopDirective.BREAK:
+        raise LoopBreak(ctrl.reason)
+    if ctrl.directive is LoopDirective.CANCEL:
+        raise _StopStream(ctrl.reason)   # internal sentinel caught below
+```
+
+CANCEL must unwind to a *clean* exit: catch the internal `_StopStream` sentinel
+just outside the `async for`, fall through to the existing `finally` (which
+flushes accumulated text + persists the branch snapshot), and return normally
+with the partial result. BREAK propagates `LoopBreak` out of `run()`; `operate`
+already wraps the body and will emit `RunFailed(data=exc)` — that is the
+intended surfacing.
+
+**Closing the subprocess.** Breaking out of `async for chunk in model.stream(...)`
+closes the async generator; verify the CLI provider terminates its subprocess
+on generator close (it should, via the generator's `aclose`/`finally`). If a
+provider leaks, that is a provider bug to file separately — the run-loop
+contract is "stop consuming + clean up via finally".
+
+---
+
+### Layer 3 — Profile + AgentSpec composition
+
+**`Profile` (`lionagi/casts/profile.py`)** — pure identity composition. A named
+`Role` + ordered `Mode`s. Nothing runtime (no tools, model, permissions). This
+is the `Pattern → Profile → Actor → Branch` progression's Profile node.
+
+```python
+@dataclass(frozen=True, slots=True)
+class Profile:
+    name: str
+    role: Role
+    modes: tuple[Mode, ...] = ()
+
+    def __post_init__(self):
+        # Validate mode conflicts (ADR-0071 conflicts_with) at composition time.
+        seen: dict[str, Mode] = {}
+        for m in self.modes:
+            for other in seen.values():
+                if m.name in other.conflicts_with or other.name in m.conflicts_with:
+                    raise ValueError(f"Mode conflict: {m.name} vs {other.name}")
+            seen[m.name] = m
+
+    @property
+    def capabilities(self) -> tuple[type, ...]:
+        from lionagi.casts.capabilities import capability_models
+        return capability_models(self.role.name)
+
+    def build_system_message(self) -> str:
+        parts = [self.role.body] if self.role.body else []
+        parts += [m.behaviors for m in self.modes if m.behaviors]
+        return "\n\n".join(parts)
+
+    @classmethod
+    def compose(cls, role: str | Role, *, modes: list[str | Mode] | None = None,
+                name: str | None = None) -> Profile:
+        r = role if not isinstance(role, str) else Role.load(role)
+        ms = tuple(m if not isinstance(m, str) else Mode.load(m) for m in (modes or []))
+        return cls(name=name or r.name, role=r, modes=ms)
+
+    @classmethod
+    def from_yaml(cls, path) -> Profile:  # ~/.lionagi/profiles/<name>.yaml
+        # {name, role, modes: [...]}
+        ...
+```
+
+**Roster discovery** (`lionagi/casts/pattern.py`): add `list_roles()` and
+`list_modes()` that enumerate the packaged `casts/roles/*.md` (excluding
+`TEMPLATE`, excluding the `modes/` dir) and `casts/roles/modes/*.md`
+respectively, merged with any user `~/.lionagi/roles/` and `~/.lionagi/modes/`.
+These feed the orchestrator's planning roster.
+
+**`AgentSpec` (`lionagi/agent/spec.py`)** — the universal runtime spec. Profile
+(identity) + runtime concerns (model, effort, tools, permissions, capability
+grant). This is what every surface composes to and what builds a Branch.
+
+```python
+@dataclass
+class AgentSpec:
+    profile: Profile
+    model: str | None = None
+    effort: str | None = None
+    tools: tuple[str, ...] = ()                      # tool suites: "coding", "reader", ...
+    permissions: PermissionPolicy | None = None
+    grant_capabilities: bool = True                  # auto-grant the profile's capabilities
+    pack: str | Pack | None = "default"              # RolePolicy source for escalation prose
+    lion_system: bool = True
+
+    @classmethod
+    def compose(cls, role, *, modes=None, model=None, effort=None,
+                tools=(), permissions=None, pack="default",
+                grant_capabilities=True) -> AgentSpec:
+        prof = Profile.compose(role, modes=modes)
+        perm = _resolve_permissions(permissions)     # str preset | dict | PermissionPolicy | None
+        return cls(profile=prof, model=model, effort=effort, tools=tuple(tools),
+                   permissions=perm, pack=pack, grant_capabilities=grant_capabilities)
+
+    def build_system_message(self) -> str:
+        """role + modes + RolePolicy operational block (authority/boundaries/
+        escalations rendered as explicit STOP-and-escalate instructions)."""
+        body = self.profile.build_system_message()
+        policy_block = self._render_policy_block()   # from Pack.policy(role)
+        return "\n\n".join(p for p in (body, policy_block) if p)
+
+    def capability_operable(self) -> Operable | None:
+        from lionagi.casts.capabilities import capability_operable
+        return capability_operable(self.profile.role.name) if self.grant_capabilities else None
+```
+
+`_resolve_permissions`: `"safe"|"read_only"|"allow_all"|"deny_all"` → the
+matching `PermissionPolicy` classmethod; a dict → `PermissionPolicy.from_dict`;
+a `PermissionPolicy` → itself; `None` → `None`.
+
+`_render_policy_block`: load `Pack` (default ships in `casts/packs/default.yaml`),
+get `policy(role)`; render `authority`/`boundaries` as context and
+`escalations` as: *"When any of these conditions occur, STOP and emit an
+`escalation` capability with the reason: …"* — tying the dead `RolePolicy`
+escalation prose to the live `EscalationRequest` capability.
+
+**Bridge for back-compat.** `AgentConfig` stays; add
+`AgentSpec.from_config(config)` and have `create_agent()` accept either. The
+existing `AgentConfig.build_system_message()` already does role+modes — keep it
+working; `AgentSpec` is the richer, orchestration-facing path.
+
+---
+
+### Layer 4 — CLI orchestration wiring
+
+**`FlowAgent` (`cli/orchestrate/flow.py`)** gains optional composition fields:
+
+```python
+class FlowAgent(HashableModel):
+    id: str
+    role: str                                  # now a casts Role name (validated against list_roles())
+    modes: list[str] = Field(default_factory=list, description="cognitive overlays; e.g. ['adversarial','systematic']")
+    permissions: str | None = Field(default=None, description="preset: safe|read_only|allow_all|deny_all")
+    model: str | None = None
+    guidance: str | None = None
+```
+
+(`capabilities` is **not** a FlowAgent field — it is derived from `role`
+automatically. Keep the planner's surface small; the ontology does the work.)
+
+**Orchestrator planning prompt** (`_run_flow_inner`): replace the
+`list_agents()` roster with the casts roster — each role's frontmatter
+`description` + the available modes (name + one-line description) + the
+permission presets. The orchestrator picks `role + modes + permissions` per
+agent. Validation rejects unknown roles/modes and mode conflicts before
+execution (fail-closed, like the existing dep-cycle check).
+
+**`build_worker_branch` (`cli/orchestrate/_orchestration.py`)** is the single
+seam. When a worker has a casts `role` (not a `~/.lionagi/agents/` profile):
+
+1. `spec = AgentSpec.compose(role=agent.role, modes=agent.modes, model=…, permissions=agent.permissions)`
+2. system prompt = `LION_SYSTEM_MESSAGE + spec.build_system_message()` (+ team
+   section as today)
+3. register `spec.tools` (default `("coding",)` for write-capable roles,
+   none/read-only suites for discovery roles — derive a sensible default by
+   zone, overridable)
+4. apply `spec.permissions` (see adapter note)
+5. after `session.include_branches(wb)`, if `op := spec.capability_operable()`:
+   `wb.grant_capabilities(op)` — this lights up the bus for that worker.
+
+Preserve the existing `~/.lionagi/agents/` profile path for backward compat:
+if `resolve_worker_spec(role)` finds a profile, use it (today's behavior); only
+fall to the casts `AgentSpec` path when no profile file matches. This keeps
+every existing flow working unchanged.
+
+**Permission adapter (`lionagi/agent/adapters/`)** — the hard part. CLI workers
+run on provider backends (claude_code, codex) whose tools lionagi's
+`security_pre` hook does **not** intercept; the provider enforces its own
+permissions. v1 ships **one** adapter, `claude_code.py`:
+
+```python
+def translate_permissions(policy: PermissionPolicy) -> dict:
+    """PermissionPolicy → claude_code endpoint kwargs (permission_mode + allow/deny lists)."""
+    # allow_all  → {"permission_mode": "bypassPermissions"} (or yolo kwargs already used)
+    # read_only  → deny editor/bash, allow reader/search
+    # deny_all   → deny everything
+    # rules      → map allow/deny fnmatch patterns to claude_code's permission format
+```
+
+For lionagi-native tools (when a worker uses `register_tools`/`CodingToolkit`
+rather than provider-native), the existing `security_pre` hook path applies
+unchanged. Document clearly which path a given worker takes. Other providers
+(codex, openai) are follow-up adapters — out of scope for this show, noted as
+future work (do not stub them).
+
+**Observer wiring** (`_run_flow_inner`, before `session.flow(...)`): the
+orchestrator may register reactions over the worker capabilities, e.g.
+
+```python
+session.observe(Verdict, lambda v, ctx: ...)          # route REJECT to re-plan
+session.observe(EscalationRequest, lambda e, ctx: ...) # surface / re-assign
+session.observe(Finding, Finding.q ...)                # high-confidence routing
+```
+
+v1 wires a minimal, useful default: observe `EscalationRequest` (log + record
+into the flow's control stream) and `Verdict` (record). The full reactive
+re-planning loop is a documented extension point, not required for this show.
+
+---
+
+## Consequences
+
+**Positive**
+
+- One universal `AgentSpec` across `li o flow`, `li o fanout`, `li agent`, and
+  programmatic `create_agent`.
+- The 41 roles / 14 modes / default pack become *live* in CLI orchestration.
+- Capabilities are derived from roles automatically — a researcher emits
+  findings, a critic yields verdicts, every role can escalate — and the session
+  observes them in real time.
+- The bus becomes bidirectional: observers can CANCEL/BREAK a run.
+- `RolePolicy` escalation prose is wired to the `EscalationRequest` capability.
+
+**Negative / risks**
+
+- Permission parity across providers is partial (claude_code only in v1).
+- Loop control v1 is CANCEL/BREAK only; PAUSE/INJECT deferred.
+- Two role-name namespaces remain during transition (`~/.lionagi/agents/`
+  profiles vs casts roles); resolved by precedence (profile file wins), to be
+  unified later.
+
+**Rejected alternatives**
+
+- *Capabilities as a FlowAgent field*: rejected — bloats the planner surface;
+  the ontology already knows what each role emits.
+- *Profile carrying tools/permissions*: rejected — Profile is identity
+  (frozen, composable, named); runtime concerns live on `AgentSpec`.
+- *A central capability enum*: rejected per ADR-0072 — the observer registry IS
+  the registry; `ROLE_CAPABILITIES` is an overridable default, not a gate.
+
+## Implementation order (show plays)
+
+1. **capabilities** — Layer 1 + Layer 2 (ontology + loop control). No CLI deps.
+2. **composition** — Layer 3 (Profile, AgentSpec, roster discovery). Depends on 1.
+3. **wiring** — Layer 4 (FlowAgent, build_worker_branch, planner prompt,
+   claude_code permission adapter, minimal observer wiring). Depends on 2.
+4. **review** — multi-perspective gate over the integration branch.
+5. **pr-slice** — re-slice the integration branch into layered PRs with a
+   strict merge sequence, codex-review each.
+
+Each layer ships green + tested before the next builds on it.

--- a/lionagi/casts/capabilities.py
+++ b/lionagi/casts/capabilities.py
@@ -1,0 +1,207 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import re
+
+from pydantic import BaseModel, Field
+
+from lionagi.ln.types import Operable, Spec
+
+__all__ = (
+    "Finding",
+    "Verdict",
+    "ComplianceVerdict",
+    "RiskAssessment",
+    "AnalysisResult",
+    "Conflict",
+    "Gap",
+    "ExecutionPlan",
+    "ComplexityScore",
+    "ArtifactProduced",
+    "VerificationResult",
+    "EscalationRequest",
+    "ROLE_CAPABILITIES",
+    "capability_models",
+    "capability_operable",
+)
+
+
+# ---------------------------------------------------------------------------
+# Capability payload models
+# ---------------------------------------------------------------------------
+
+
+class Finding(BaseModel):
+    description: str
+    confidence: float = Field(ge=0.0, le=1.0, default=0.5)
+    severity: str | None = None
+    evidence: str | None = None
+    source: str | None = None
+
+
+class Verdict(BaseModel):
+    verdict: str
+    rationale: str
+    evidence: str | None = None
+    reversible_by: str | None = None
+
+
+class ComplianceVerdict(BaseModel):
+    verdict: str
+    control: str
+    evidence_refs: list[str] = Field(default_factory=list)
+
+
+class RiskAssessment(BaseModel):
+    failure_mode: str
+    likelihood: float = Field(ge=0.0, le=1.0)
+    impact: float = Field(ge=0.0, le=1.0)
+    mitigation: str | None = None
+
+
+class AnalysisResult(BaseModel):
+    metric: str
+    value: float
+    ci_95: tuple[float, float] | None = None
+    p_value: float | None = None
+
+
+class Conflict(BaseModel):
+    sources: list[str]
+    nature: str
+
+
+class Gap(BaseModel):
+    area: str
+    what_is_unknown: str
+
+
+class ExecutionPlan(BaseModel):
+    steps: list[str]
+    dependencies: list[str] = Field(default_factory=list)
+    exit_criteria: str | None = None
+
+
+class ComplexityScore(BaseModel):
+    score: float = Field(ge=0.0, le=1.0)
+    rationale: str
+
+
+class ArtifactProduced(BaseModel):
+    path: str
+    kind: str
+    description: str | None = None
+    verified: bool = False
+
+
+class VerificationResult(BaseModel):
+    suite: str
+    passed: bool
+    coverage: float | None = None
+    gaps: list[str] = Field(default_factory=list)
+
+
+class EscalationRequest(BaseModel):
+    reason: str
+    context: dict = Field(default_factory=dict)
+    blocking: bool = True
+    from_role: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Role → capability model mapping
+# ---------------------------------------------------------------------------
+
+ROLE_CAPABILITIES: dict[str, tuple[type[BaseModel], ...]] = {
+    # Evaluation / quality
+    "critic": (Verdict, Finding),
+    "reviewer": (Verdict, Finding),
+    "auditor": (ComplianceVerdict, Finding),
+    "arbitrator": (Verdict,),
+    "evaluator": (Verdict, Finding),
+    "tester": (VerificationResult, Finding),
+    # Research / discovery
+    "researcher": (Finding, Conflict, Gap),
+    "analyst": (AnalysisResult, Finding),
+    "explorer": (Finding, Gap),
+    "investigator": (Finding, Gap),
+    "troubleshooter": (Finding,),
+    "assessor": (RiskAssessment, Finding),
+    "contrarian": (Finding,),
+    "commentator": (Finding,),
+    "synthesizer": (Finding, Conflict),
+    # Planning / coordination
+    "orchestrator": (ExecutionPlan,),
+    "strategist": (ComplexityScore, ExecutionPlan),
+    "planner": (ExecutionPlan,),
+    "coordinator": (ExecutionPlan,),
+    "architect": (ExecutionPlan, ArtifactProduced),
+    "modeler": (ArtifactProduced,),
+    "innovator": (Finding,),
+    "suggester": (Finding,),
+    # Implementation / production
+    "implementer": (ArtifactProduced, VerificationResult),
+    "prototyper": (ArtifactProduced, VerificationResult),
+    "refactorer": (ArtifactProduced, VerificationResult),
+    "migrator": (ArtifactProduced, VerificationResult),
+    "deployer": (ArtifactProduced,),
+    "operator": (ArtifactProduced,),
+    # Content
+    "writer": (ArtifactProduced,),
+    "translator": (ArtifactProduced,),
+    "scribe": (ArtifactProduced,),
+    "curator": (ArtifactProduced,),
+    # Communication / facilitation
+    "facilitator": (Finding,),
+    "negotiator": (Finding,),
+    "mentor": (Finding,),
+    "persona": (Finding,),
+    "responder": (Finding,),
+    "postmortem_lead": (Finding,),
+    "entrepreneur": (Finding,),
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_CAMEL_RE = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+
+
+def _field_name(model: type[BaseModel]) -> str:
+    """Convert a CamelCase model class name to snake_case for use as a Spec name."""
+    return _CAMEL_RE.sub("_", model.__name__).lower()
+
+
+# ---------------------------------------------------------------------------
+# Public builder API
+# ---------------------------------------------------------------------------
+
+
+def capability_models(role: str) -> tuple[type[BaseModel], ...]:
+    """Return the full capability model tuple for *role*, always including EscalationRequest.
+
+    For roles not present in ROLE_CAPABILITIES the base is empty, so the
+    return value is ``(EscalationRequest,)``.
+    """
+    base = ROLE_CAPABILITIES.get(role, ())
+    if EscalationRequest not in base:
+        return (*base, EscalationRequest)
+    return base
+
+
+def capability_operable(role: str) -> Operable | None:
+    """Build an :class:`~lionagi.ln.types.Operable` for *role*.
+
+    Returns ``None`` when the role has no capabilities mapped (i.e. is absent
+    from :data:`ROLE_CAPABILITIES`).  For known roles the returned Operable
+    always includes an ``escalation_request`` spec in addition to the
+    role-specific models.
+    """
+    if role not in ROLE_CAPABILITIES:
+        return None
+    models = capability_models(role)
+    specs = tuple(Spec(m, name=_field_name(m)) for m in models)
+    return Operable(specs, name=f"{role}_capabilities")

--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -28,6 +28,8 @@ if TYPE_CHECKING:
     from lionagi.protocols.messages.message import RoledMessage
     from lionagi.session.branch import Branch
 
+from lionagi.session.control import LoopBreak, LoopDirective
+
 logger = logging.getLogger(__name__)
 
 
@@ -129,6 +131,24 @@ async def _emit_message_signal(branch: Branch, msg: RoledMessage) -> None:
         await branch.emit(ActionRequestSignal(data=msg))
     elif isinstance(msg, ActionResponse):
         await branch.emit(ActionResponseSignal(data=msg))
+
+
+class _StopStream(Exception):  # noqa: N818
+    """Internal sentinel used for observer-requested clean cancellation."""
+
+    def __init__(self, reason: str | None = None) -> None:
+        super().__init__(reason or "stream cancelled by observer")
+        self.reason = reason
+
+
+def _check_control(branch: Branch) -> None:
+    ctrl = branch.poll_control()
+    if ctrl is None or ctrl.directive is LoopDirective.CONTINUE:
+        return
+    if ctrl.directive is LoopDirective.BREAK:
+        raise LoopBreak(ctrl.reason)
+    if ctrl.directive is LoopDirective.CANCEL:
+        raise _StopStream(ctrl.reason)
 
 
 async def run(
@@ -233,84 +253,91 @@ async def run(
     await model.executor.append(api_call)
 
     try:
-        # ``anyio.fail_after(None)`` is a no-op context, so we can wrap
-        # unconditionally and let the no-timeout case pay the (small)
-        # context-manager cost rather than branching the stream loop.
-        with anyio.fail_after(_stream_timeout):
-            async for chunk in model.stream(api_call=api_call):
-                match chunk.type:
-                    case "system":
-                        if sid := chunk.metadata.get("session_id"):
-                            endpoint.session_id = sid
+        try:
+            # ``anyio.fail_after(None)`` is a no-op context, so we can wrap
+            # unconditionally and let the no-timeout case pay the (small)
+            # context-manager cost rather than branching the stream loop.
+            with anyio.fail_after(_stream_timeout):
+                async for chunk in model.stream(api_call=api_call):
+                    match chunk.type:
+                        case "system":
+                            if sid := chunk.metadata.get("session_id"):
+                                endpoint.session_id = sid
 
-                    case "thinking":
-                        if chunk.content:
-                            thinking_parts.append(chunk.content)
+                        case "thinking":
+                            if chunk.content:
+                                thinking_parts.append(chunk.content)
 
-                    case "text":
-                        if chunk.content:
-                            text_parts.append(chunk.content)
+                        case "text":
+                            if chunk.content:
+                                text_parts.append(chunk.content)
 
-                    case "tool_use":
-                        if res := await _flush_response():
-                            await _emit_message_signal(branch, res)
-                            yield res
+                        case "tool_use":
+                            if res := await _flush_response():
+                                await _emit_message_signal(branch, res)
+                                _check_control(branch)
+                                yield res
 
-                        act_req = branch.msgs.create_action_request(
-                            function=chunk.tool_name or "",
-                            arguments=chunk.tool_input or {},
-                            sender=branch.id,
-                            recipient=branch.user or "user",
-                        )
-                        if chunk.tool_id:
-                            pending_requests[chunk.tool_id] = act_req
-                        await branch.msgs.a_add_message(action_request=act_req)
-                        await _emit_message_signal(branch, act_req)
-                        yield act_req
+                            act_req = branch.msgs.create_action_request(
+                                function=chunk.tool_name or "",
+                                arguments=chunk.tool_input or {},
+                                sender=branch.id,
+                                recipient=branch.user or "user",
+                            )
+                            if chunk.tool_id:
+                                pending_requests[chunk.tool_id] = act_req
+                            await branch.msgs.a_add_message(action_request=act_req)
+                            await _emit_message_signal(branch, act_req)
+                            _check_control(branch)
+                            yield act_req
 
-                    case "tool_result":
-                        orig_req = (
-                            pending_requests.pop(chunk.tool_id, None) if chunk.tool_id else None
-                        )
-                        if orig_req is None:
-                            continue
+                        case "tool_result":
+                            orig_req = (
+                                pending_requests.pop(chunk.tool_id, None) if chunk.tool_id else None
+                            )
+                            if orig_req is None:
+                                continue
 
-                        # Build the ActionResponse and attach is_error BEFORE
-                        # a_add_message so the live-persist hook (and any other
-                        # on_message_added callback) observes the final state.
-                        # Doing it after the await would let the hook serialize
-                        # an incomplete row that omits the error marker.
-                        act_res = branch.msgs.create_action_response(
-                            action_request=orig_req,
-                            action_output=chunk.tool_output,
-                            sender=branch.user or "user",
-                            recipient=branch.id,
-                        )
-                        if chunk.is_error:
-                            act_res.metadata["is_error"] = True
-                        await branch.msgs.a_add_message(
-                            action_request=orig_req,
-                            action_output=chunk.tool_output,
-                            action_response=act_res,
-                            sender=branch.user or "user",
-                            recipient=branch.id,
-                        )
-                        await _emit_message_signal(branch, act_res)
-                        yield act_res
+                            # Build the ActionResponse and attach is_error BEFORE
+                            # a_add_message so the live-persist hook (and any other
+                            # on_message_added callback) observes the final state.
+                            # Doing it after the await would let the hook serialize
+                            # an incomplete row that omits the error marker.
+                            act_res = branch.msgs.create_action_response(
+                                action_request=orig_req,
+                                action_output=chunk.tool_output,
+                                sender=branch.user or "user",
+                                recipient=branch.id,
+                            )
+                            if chunk.is_error:
+                                act_res.metadata["is_error"] = True
+                            await branch.msgs.a_add_message(
+                                action_request=orig_req,
+                                action_output=chunk.tool_output,
+                                action_response=act_res,
+                                sender=branch.user or "user",
+                                recipient=branch.id,
+                            )
+                            await _emit_message_signal(branch, act_res)
+                            _check_control(branch)
+                            yield act_res
 
-                    case "result":
-                        pass
+                        case "result":
+                            pass
 
-                    case "error":
-                        raise RuntimeError(chunk.content or "Stream error from CLI endpoint")
+                        case "error":
+                            raise RuntimeError(chunk.content or "Stream error from CLI endpoint")
 
-            if res := await _flush_response():
-                if hasattr(api_call, "to_dict"):
-                    call_meta = Note.from_dict(api_call.to_dict())
-                    call_meta.pop(["execution", "response"], None)
-                    res.metadata["api_call_meta"] = call_meta.to_dict()
-                await _emit_message_signal(branch, res)
-                yield res
+                if res := await _flush_response():
+                    if hasattr(api_call, "to_dict"):
+                        call_meta = Note.from_dict(api_call.to_dict())
+                        call_meta.pop(["execution", "response"], None)
+                        res.metadata["api_call_meta"] = call_meta.to_dict()
+                    await _emit_message_signal(branch, res)
+                    _check_control(branch)
+                    yield res
+        except _StopStream:
+            pass
     finally:
         # Restore original streaming func
         model.streaming_process_func = prev_stream_func

--- a/lionagi/session/branch.py
+++ b/lionagi/session/branch.py
@@ -44,6 +44,7 @@ from .prompts import LION_SYSTEM_MESSAGE
 if TYPE_CHECKING:
     from lionagi.operations.operate.operative import Operative
     from lionagi.operations.types import Middle
+    from lionagi.session.control import LoopControl, LoopDirective
 
 
 __all__ = ("Branch",)
@@ -120,7 +121,7 @@ class Branch(Element, Relational):
     _operation_manager: OperationManager | None = PrivateAttr(None)
     _observer: Any = PrivateAttr(None)
     _capabilities: Any = PrivateAttr(None)
-    _loop_control: Any = PrivateAttr(None)
+    _loop_control: "LoopControl | None" = PrivateAttr(None)
 
     def __init__(
         self,
@@ -367,7 +368,7 @@ class Branch(Element, Relational):
             return []
         return await self._observer.emit(event)
 
-    def control(self, directive: Any, *, reason: str | None = None) -> None:
+    def control(self, directive: "LoopDirective", *, reason: str | None = None) -> None:
         """Queue a loop-control directive.
 
         Called from an observer handler to steer the in-flight run.
@@ -377,7 +378,7 @@ class Branch(Element, Relational):
 
         self._loop_control = LoopControl(directive, reason)
 
-    def poll_control(self) -> Any:
+    def poll_control(self) -> "LoopControl | None":
         """Return and CLEAR any queued directive (one-shot).
 
         Returns ``None`` when no directive is pending.

--- a/lionagi/session/branch.py
+++ b/lionagi/session/branch.py
@@ -120,6 +120,7 @@ class Branch(Element, Relational):
     _operation_manager: OperationManager | None = PrivateAttr(None)
     _observer: Any = PrivateAttr(None)
     _capabilities: Any = PrivateAttr(None)
+    _loop_control: Any = PrivateAttr(None)
 
     def __init__(
         self,
@@ -365,6 +366,24 @@ class Branch(Element, Relational):
         if self._observer is None:
             return []
         return await self._observer.emit(event)
+
+    def control(self, directive: Any, *, reason: str | None = None) -> None:
+        """Queue a loop-control directive.
+
+        Called from an observer handler to steer the in-flight run.
+        The run loop polls this after each message signal.
+        """
+        from lionagi.session.control import LoopControl
+
+        self._loop_control = LoopControl(directive, reason)
+
+    def poll_control(self) -> Any:
+        """Return and CLEAR any queued directive (one-shot).
+
+        Returns ``None`` when no directive is pending.
+        """
+        ctrl, self._loop_control = self._loop_control, None
+        return ctrl
 
     @property
     def capabilities(self) -> Any:

--- a/lionagi/session/control.py
+++ b/lionagi/session/control.py
@@ -9,7 +9,7 @@ from enum import Enum
 __all__ = ("LoopDirective", "LoopControl", "LoopBreak")
 
 
-class LoopDirective(str, Enum):
+class LoopDirective(Enum):
     CONTINUE = "continue"
     CANCEL = "cancel"
     BREAK = "break"

--- a/lionagi/session/control.py
+++ b/lionagi/session/control.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+__all__ = ("LoopDirective", "LoopControl", "LoopBreak")
+
+
+class LoopDirective(str, Enum):
+    CONTINUE = "continue"
+    CANCEL = "cancel"
+    BREAK = "break"
+
+
+@dataclass(frozen=True, slots=True)
+class LoopControl:
+    directive: LoopDirective
+    reason: str | None = None
+
+
+class LoopBreak(Exception):  # noqa: N818
+    """Raised inside the run loop when an observer requests a hard stop.
+
+    The exception propagates out of ``run()`` so that ``Branch.operate``
+    can surface it as a ``RunFailed`` event.
+    """
+
+    def __init__(self, reason: str | None = None) -> None:
+        super().__init__(reason or "loop broken by observer")
+        self.reason = reason

--- a/tests/casts/test_capabilities.py
+++ b/tests/casts/test_capabilities.py
@@ -1,0 +1,294 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import BaseModel
+
+from lionagi.casts.capabilities import (
+    ROLE_CAPABILITIES,
+    AnalysisResult,
+    ArtifactProduced,
+    ComplexityScore,
+    ComplianceVerdict,
+    Conflict,
+    EscalationRequest,
+    ExecutionPlan,
+    Finding,
+    Gap,
+    RiskAssessment,
+    Verdict,
+    VerificationResult,
+    _field_name,
+    capability_models,
+    capability_operable,
+)
+from lionagi.ln.types import Operable
+from lionagi.session.session import Session
+from lionagi.session.signal import StructuredOutput
+
+
+def _roles_on_disk() -> set[str]:
+    """Role names from lionagi/casts/roles/*.md, excluding TEMPLATE and modes/."""
+    roles_dir = Path(__file__).parent.parent.parent / "lionagi" / "casts" / "roles"
+    return {p.stem for p in roles_dir.glob("*.md") if p.stem != "TEMPLATE"}
+
+
+# ---------------------------------------------------------------------------
+# Every capability model instantiates with required fields
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilityModels:
+    def test_finding_instantiates(self):
+        f = Finding(description="A finding", confidence=0.8)
+        assert f.description == "A finding"
+        assert f.confidence == 0.8
+
+    def test_finding_confidence_clamps_high(self):
+        with pytest.raises(Exception):
+            Finding(description="bad", confidence=1.5)
+
+    def test_finding_confidence_clamps_low(self):
+        with pytest.raises(Exception):
+            Finding(description="bad", confidence=-0.1)
+
+    def test_finding_optional_fields_default_none(self):
+        f = Finding(description="x")
+        assert f.severity is None
+        assert f.evidence is None
+        assert f.source is None
+
+    def test_verdict_instantiates(self):
+        v = Verdict(verdict="approve", rationale="looks good")
+        assert v.verdict == "approve"
+        assert v.evidence is None
+
+    def test_compliance_verdict_instantiates(self):
+        cv = ComplianceVerdict(verdict="pass", control="ISO-27001-A.8.2")
+        assert cv.evidence_refs == []
+
+    def test_risk_assessment_instantiates(self):
+        ra = RiskAssessment(failure_mode="OOM", likelihood=0.3, impact=0.9)
+        assert ra.likelihood == 0.3
+
+    def test_risk_assessment_likelihood_clamps(self):
+        with pytest.raises(Exception):
+            RiskAssessment(failure_mode="x", likelihood=1.5, impact=0.5)
+
+    def test_analysis_result_instantiates(self):
+        ar = AnalysisResult(metric="latency_p99", value=42.0)
+        assert ar.ci_95 is None
+        assert ar.p_value is None
+
+    def test_conflict_instantiates(self):
+        c = Conflict(sources=["a", "b"], nature="contradiction")
+        assert len(c.sources) == 2
+
+    def test_gap_instantiates(self):
+        g = Gap(area="auth", what_is_unknown="session expiry semantics")
+        assert g.area == "auth"
+
+    def test_execution_plan_instantiates(self):
+        ep = ExecutionPlan(steps=["step1", "step2"])
+        assert ep.dependencies == []
+        assert ep.exit_criteria is None
+
+    def test_complexity_score_bounds(self):
+        with pytest.raises(Exception):
+            ComplexityScore(score=1.1, rationale="too high")
+
+    def test_complexity_score_valid(self):
+        cs = ComplexityScore(score=0.7, rationale="complex DB schema")
+        assert cs.score == 0.7
+
+    def test_artifact_produced_defaults(self):
+        ap = ArtifactProduced(path="/out/file.py", kind="module")
+        assert not ap.verified
+        assert ap.description is None
+
+    def test_verification_result_instantiates(self):
+        vr = VerificationResult(suite="unit", passed=True, coverage=0.92)
+        assert vr.gaps == []
+
+    def test_escalation_request_defaults(self):
+        er = EscalationRequest(reason="blocked on infra")
+        assert er.blocking is True
+        assert er.context == {}
+        assert er.from_role is None
+
+    def test_all_models_are_pydantic_base_model(self):
+        models = [
+            Finding,
+            Verdict,
+            ComplianceVerdict,
+            RiskAssessment,
+            AnalysisResult,
+            Conflict,
+            Gap,
+            ExecutionPlan,
+            ComplexityScore,
+            ArtifactProduced,
+            VerificationResult,
+            EscalationRequest,
+        ]
+        for m in models:
+            assert issubclass(m, BaseModel), f"{m.__name__} is not a BaseModel subclass"
+
+
+# ---------------------------------------------------------------------------
+# ROLE_CAPABILITIES covers all roles on disk
+# ---------------------------------------------------------------------------
+
+
+class TestRoleCapabilitiesCoverage:
+    def test_all_disk_roles_in_role_capabilities(self):
+        disk_roles = _roles_on_disk()
+        missing = disk_roles - set(ROLE_CAPABILITIES)
+        assert not missing, f"Roles on disk missing from ROLE_CAPABILITIES: {missing}"
+
+    def test_no_extra_roles_beyond_disk(self):
+        disk_roles = _roles_on_disk()
+        extra = set(ROLE_CAPABILITIES) - disk_roles
+        assert not extra, f"ROLE_CAPABILITIES has keys not on disk: {extra}"
+
+    def test_no_empty_tuples_in_role_capabilities(self):
+        for role, models in ROLE_CAPABILITIES.items():
+            assert len(models) >= 1, f"{role!r} maps to an empty tuple"
+
+    def test_all_values_are_pydantic_base_model_subclasses(self):
+        for role, models in ROLE_CAPABILITIES.items():
+            for m in models:
+                assert issubclass(m, BaseModel), f"{role}: {m} is not a BaseModel subclass"
+
+
+# ---------------------------------------------------------------------------
+# capability_models() always includes EscalationRequest
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilityModelsFunction:
+    def test_researcher_always_includes_escalation(self):
+        models = capability_models("researcher")
+        assert EscalationRequest in models
+
+    def test_unknown_role_returns_just_escalation(self):
+        models = capability_models("no_such_role_xyz")
+        assert models == (EscalationRequest,)
+
+    def test_known_role_preserves_role_models(self):
+        # critic maps to (Verdict, Finding); escalation appended
+        models = capability_models("critic")
+        assert EscalationRequest in models
+        assert Verdict in models
+        assert Finding in models
+
+    @pytest.mark.parametrize("role", list(ROLE_CAPABILITIES))
+    def test_every_role_includes_escalation(self, role):
+        assert EscalationRequest in capability_models(role)
+
+    def test_escalation_not_duplicated_when_already_present(self):
+        # EscalationRequest should not appear twice even if role mapping included it
+        models = capability_models("researcher")
+        assert models.count(EscalationRequest) == 1
+
+
+# ---------------------------------------------------------------------------
+# capability_operable('researcher') builds and validates
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilityOperable:
+    def test_researcher_operable_not_none(self):
+        op = capability_operable("researcher")
+        assert op is not None
+        assert isinstance(op, Operable)
+
+    def test_researcher_operable_has_finding_spec(self):
+        op = capability_operable("researcher")
+        assert "finding" in op.allowed()
+
+    def test_researcher_operable_has_escalation_spec(self):
+        op = capability_operable("researcher")
+        assert "escalation_request" in op.allowed()
+
+    def test_researcher_operable_name(self):
+        op = capability_operable("researcher")
+        assert op.name == "researcher_capabilities"
+
+    def test_unknown_role_returns_none(self):
+        assert capability_operable("unknown_role_xyz") is None
+
+    def test_field_name_helper_cases(self):
+        assert _field_name(Finding) == "finding"
+        assert _field_name(EscalationRequest) == "escalation_request"
+        assert _field_name(VerificationResult) == "verification_result"
+        assert _field_name(ComplianceVerdict) == "compliance_verdict"
+        assert _field_name(AnalysisResult) == "analysis_result"
+        assert _field_name(ExecutionPlan) == "execution_plan"
+        assert _field_name(ComplexityScore) == "complexity_score"
+        assert _field_name(ArtifactProduced) == "artifact_produced"
+        assert _field_name(RiskAssessment) == "risk_assessment"
+
+    def test_critic_operable_contains_verdict(self):
+        op = capability_operable("critic")
+        assert op is not None
+        assert "verdict" in op.allowed()
+
+
+# ---------------------------------------------------------------------------
+# Session.observe(Finding) fires when StructuredOutput(data=Finding) emitted
+# ---------------------------------------------------------------------------
+
+
+class TestSessionObserveFinding:
+    async def test_observe_finding_fires(self):
+        s = Session()
+        seen: list[Finding] = []
+        s.observe(Finding, lambda f, _: seen.append(f))
+
+        await s.default_branch.emit(
+            StructuredOutput(data=Finding(description="SQL injection in query", confidence=0.95))
+        )
+        assert len(seen) == 1
+        assert seen[0].description == "SQL injection in query"
+        assert seen[0].confidence == 0.95
+
+    async def test_observe_finding_does_not_fire_for_other_payload(self):
+        s = Session()
+        finding_seen: list = []
+        verdict_seen: list = []
+        s.observe(Finding, lambda f, _: finding_seen.append(f))
+        s.observe(Verdict, lambda v, _: verdict_seen.append(v))
+
+        await s.default_branch.emit(
+            StructuredOutput(data=Verdict(verdict="approved", rationale="all good"))
+        )
+        assert finding_seen == []
+        assert len(verdict_seen) == 1
+
+    async def test_observe_finding_and_escalation_route_separately(self):
+        s = Session()
+        findings: list = []
+        escalations: list = []
+        s.observe(Finding, lambda f, _: findings.append(f))
+        s.observe(EscalationRequest, lambda e, _: escalations.append(e))
+
+        await s.default_branch.emit(StructuredOutput(data=Finding(description="gap found")))
+        await s.default_branch.emit(StructuredOutput(data=EscalationRequest(reason="need infra")))
+
+        assert len(findings) == 1
+        assert len(escalations) == 1
+
+    async def test_multiple_findings_all_dispatched(self):
+        s = Session()
+        seen: list = []
+        s.observe(Finding, lambda f, _: seen.append(f.description))
+
+        for desc in ["bug A", "bug B", "bug C"]:
+            await s.default_branch.emit(StructuredOutput(data=Finding(description=desc)))
+
+        assert seen == ["bug A", "bug B", "bug C"]

--- a/tests/session/test_control.py
+++ b/tests/session/test_control.py
@@ -3,10 +3,16 @@
 
 from __future__ import annotations
 
+import types
+from unittest.mock import AsyncMock
+
 import pytest
 
 from lionagi.casts.capabilities import EscalationRequest, Finding
 from lionagi.operations.run.run import _check_control, _StopStream
+from lionagi.protocols.messages import AssistantResponse
+from lionagi.service.imodel import iModel
+from lionagi.service.types.stream_chunk import StreamChunk
 from lionagi.session.branch import Branch
 from lionagi.session.control import LoopBreak, LoopControl, LoopDirective
 from lionagi.session.session import Session
@@ -238,3 +244,139 @@ class TestCancelFinallyBehavior:
         assert ctrl is not None
         assert ctrl.directive is LoopDirective.CANCEL
         assert b.poll_control() is None  # one-shot
+
+
+# ---------------------------------------------------------------------------
+# MIN-4: end-to-end integration — real run() loop with loop control
+# ---------------------------------------------------------------------------
+#
+# These tests drive the actual run() async generator against a fake CLI model
+# to verify the real seam placement, the generator's finally (stream-func
+# restore), and CANCEL vs BREAK propagation paths.
+#
+# Helper shared by both tests.
+
+
+def _make_fake_cli_model_for_control(chunks: list[StreamChunk]):
+    """Return an iModel patched to behave as a CLI endpoint yielding *chunks*."""
+    m = iModel(provider="openai", model="gpt-4.1-mini", api_key="test_key")
+    endpoint_ns = types.SimpleNamespace(
+        is_cli=True,
+        session_id=None,
+        to_dict=lambda: {"type": "fake_cli", "session_id": None},
+    )
+    m.endpoint = endpoint_ns
+    m.streaming_process_func = None
+
+    async def create_event(**kw):
+        return object()
+
+    m.create_event = create_event
+    m.executor = types.SimpleNamespace(append=AsyncMock(), config={})
+
+    async def stream(api_call=None):
+        for chunk in chunks:
+            yield chunk
+
+    m.stream = stream
+    return m
+
+
+class TestRunLoopControlIntegration:
+    """Integration tests that drive the real run() generator with loop control.
+
+    MIN-4: verifies the actual _check_control seam, finally (stream-func
+    restore), and the CANCEL vs BREAK propagation paths are exercised by
+    automated tests rather than manual tracing alone.
+    """
+
+    async def test_cancel_stops_loop_cleanly_finally_runs_partial_state_preserved(self):
+        """CANCEL path: observer calls branch.control(CANCEL) after the first
+        text chunk is emitted.  Assertions:
+          - run() returns normally (no exception escapes the generator),
+          - the outer finally ran (streaming_process_func restored to original),
+          - the partial AssistantResponse text is persisted in branch.messages.
+        """
+        from lionagi.operations.run.run import RunParam, run
+
+        sentinel = object()  # original streaming_process_func
+        chunks = [
+            StreamChunk(type="text", content="first"),
+            StreamChunk(type="text", content="second"),
+        ]
+        model = _make_fake_cli_model_for_control(chunks)
+        model.streaming_process_func = sentinel
+
+        branch = Branch()
+        branch.chat_model = model
+
+        collected: list = []
+        cancel_issued = False
+
+        # Drive run() manually; issue CANCEL after the first AssistantResponse
+        # is yielded.  The final flush happens at the end of the stream (after
+        # all text chunks are accumulated into one AssistantResponse), so we
+        # issue CANCEL during the loop — before the final flush yields anything.
+        # We use a flag to issue CANCEL on the first iteration past Instruction.
+        async for msg in run(branch, "go", RunParam()):
+            collected.append(msg)
+            if isinstance(msg, AssistantResponse) and not cancel_issued:
+                cancel_issued = True
+                branch.control(LoopDirective.CANCEL, reason="observer halt")
+
+        # run() must return normally — no exception escapes.
+        # The directive is consumed inside _check_control after the next emit.
+
+        # finally ran → streaming_process_func restored to sentinel
+        assert model.streaming_process_func is sentinel, (
+            "finally block did not restore streaming_process_func"
+        )
+
+        # Partial state preserved in branch messages: the flushed
+        # AssistantResponse was added to branch.msgs via a_add_message
+        # even when CANCEL fires before the yield.
+        assistant_msgs = [m for m in branch.messages if isinstance(m, AssistantResponse)]
+        assert len(assistant_msgs) >= 1, (
+            "partial AssistantResponse not preserved in branch.messages after CANCEL"
+        )
+
+    async def test_break_propagates_out_of_run_and_finally_still_runs(self):
+        """BREAK path: observer calls branch.control(BREAK).  Assertions:
+        - LoopBreak propagates out of the run() async generator,
+        - the outer finally still ran (streaming_process_func restored),
+        - any partial state accumulated before the break is in branch.messages.
+        """
+        from lionagi.operations.run.run import RunParam, run
+
+        sentinel = object()
+        chunks = [
+            StreamChunk(type="text", content="chunk-a"),
+            StreamChunk(type="text", content="chunk-b"),
+        ]
+        model = _make_fake_cli_model_for_control(chunks)
+        model.streaming_process_func = sentinel
+
+        branch = Branch()
+        branch.chat_model = model
+
+        # Issue BREAK before we even start consuming so it fires on the first
+        # _check_control call after the final flush.  The chunks accumulate as
+        # text_parts and are flushed at end-of-stream, triggering _check_control.
+        branch.control(LoopDirective.BREAK, reason="hard stop")
+
+        loop_break_raised = False
+        loop_break_reason = None
+        try:
+            async for _ in run(branch, "go", RunParam()):
+                pass
+        except LoopBreak as exc:
+            loop_break_raised = True
+            loop_break_reason = exc.reason
+
+        assert loop_break_raised, "LoopBreak did not propagate out of run()"
+        assert loop_break_reason == "hard stop"
+
+        # finally ran → streaming_process_func restored
+        assert model.streaming_process_func is sentinel, (
+            "finally block did not run after LoopBreak propagation"
+        )

--- a/tests/session/test_control.py
+++ b/tests/session/test_control.py
@@ -19,13 +19,12 @@ from lionagi.session.signal import StructuredOutput
 
 class TestControlTypes:
     def test_loop_directive_values(self):
-        assert LoopDirective.CONTINUE == "continue"
-        assert LoopDirective.CANCEL == "cancel"
-        assert LoopDirective.BREAK == "break"
+        assert LoopDirective.CONTINUE.value == "continue"
+        assert LoopDirective.CANCEL.value == "cancel"
+        assert LoopDirective.BREAK.value == "break"
 
-    def test_loop_directive_is_str(self):
-        # str subclass so it can be used as a plain string
-        assert isinstance(LoopDirective.BREAK, str)
+    def test_loop_directive_members(self):
+        assert set(LoopDirective.__members__) == {"CONTINUE", "CANCEL", "BREAK"}
 
     def test_loop_control_frozen(self):
         lc = LoopControl(directive=LoopDirective.CANCEL)

--- a/tests/session/test_control.py
+++ b/tests/session/test_control.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.casts.capabilities import EscalationRequest, Finding
+from lionagi.operations.run.run import _check_control, _StopStream
+from lionagi.session.branch import Branch
+from lionagi.session.control import LoopBreak, LoopControl, LoopDirective
+from lionagi.session.session import Session
+from lionagi.session.signal import StructuredOutput
+
+# ---------------------------------------------------------------------------
+# LoopDirective / LoopControl / LoopBreak construction
+# ---------------------------------------------------------------------------
+
+
+class TestControlTypes:
+    def test_loop_directive_values(self):
+        assert LoopDirective.CONTINUE == "continue"
+        assert LoopDirective.CANCEL == "cancel"
+        assert LoopDirective.BREAK == "break"
+
+    def test_loop_directive_is_str(self):
+        # str subclass so it can be used as a plain string
+        assert isinstance(LoopDirective.BREAK, str)
+
+    def test_loop_control_frozen(self):
+        lc = LoopControl(directive=LoopDirective.CANCEL)
+        with pytest.raises((AttributeError, TypeError)):
+            lc.directive = LoopDirective.BREAK  # frozen dataclass
+
+    def test_loop_control_reason_defaults_none(self):
+        lc = LoopControl(LoopDirective.CONTINUE)
+        assert lc.reason is None
+
+    def test_loop_control_with_reason(self):
+        lc = LoopControl(LoopDirective.CANCEL, reason="timeout")
+        assert lc.reason == "timeout"
+
+    def test_loop_break_carries_reason(self):
+        exc = LoopBreak(reason="test stop")
+        assert exc.reason == "test stop"
+        assert "test stop" in str(exc)
+
+    def test_loop_break_no_reason(self):
+        exc = LoopBreak()
+        assert exc.reason is None
+
+    def test_loop_break_is_exception(self):
+        assert issubclass(LoopBreak, Exception)
+
+
+# ---------------------------------------------------------------------------
+# Branch.control() / poll_control() — one-shot semantics
+# ---------------------------------------------------------------------------
+
+
+class TestBranchControlOneShot:
+    def test_poll_before_any_control_returns_none(self):
+        b = Branch()
+        assert b.poll_control() is None
+
+    def test_control_sets_directive(self):
+        b = Branch()
+        b.control(LoopDirective.CANCEL, reason="stop now")
+        ctrl = b.poll_control()
+        assert ctrl is not None
+        assert ctrl.directive is LoopDirective.CANCEL
+        assert ctrl.reason == "stop now"
+
+    def test_one_shot_second_poll_returns_none(self):
+        b = Branch()
+        b.control(LoopDirective.BREAK)
+        b.poll_control()  # consumes
+        assert b.poll_control() is None  # cleared
+
+    def test_overwrite_before_poll_last_write_wins(self):
+        b = Branch()
+        b.control(LoopDirective.CONTINUE)
+        b.control(LoopDirective.BREAK)
+        ctrl = b.poll_control()
+        assert ctrl.directive is LoopDirective.BREAK
+
+    def test_poll_clears_so_can_set_again(self):
+        b = Branch()
+        b.control(LoopDirective.CANCEL)
+        b.poll_control()
+        b.control(LoopDirective.CONTINUE)
+        ctrl = b.poll_control()
+        assert ctrl.directive is LoopDirective.CONTINUE
+
+    def test_returns_loop_control_instance(self):
+        b = Branch()
+        b.control(LoopDirective.BREAK)
+        ctrl = b.poll_control()
+        assert isinstance(ctrl, LoopControl)
+
+    def test_control_without_reason(self):
+        b = Branch()
+        b.control(LoopDirective.BREAK)
+        ctrl = b.poll_control()
+        assert ctrl.reason is None
+
+
+# ---------------------------------------------------------------------------
+# _check_control behavior
+# ---------------------------------------------------------------------------
+
+
+class TestCheckControl:
+    def test_no_directive_is_noop(self):
+        b = Branch()
+        _check_control(b)  # no exception
+
+    def test_continue_directive_is_noop(self):
+        b = Branch()
+        b.control(LoopDirective.CONTINUE)
+        _check_control(b)  # no exception
+
+    def test_break_directive_raises_loop_break(self):
+        b = Branch()
+        b.control(LoopDirective.BREAK, reason="halt immediately")
+        with pytest.raises(LoopBreak) as exc_info:
+            _check_control(b)
+        assert exc_info.value.reason == "halt immediately"
+
+    def test_cancel_directive_raises_stop_stream(self):
+        b = Branch()
+        b.control(LoopDirective.CANCEL, reason="clean stop")
+        with pytest.raises(_StopStream) as exc_info:
+            _check_control(b)
+        assert exc_info.value.reason == "clean stop"
+
+    def test_check_control_consumes_directive_on_break(self):
+        """_check_control calls poll_control, consuming the directive."""
+        b = Branch()
+        b.control(LoopDirective.BREAK)
+        with pytest.raises(LoopBreak):
+            _check_control(b)
+        assert b.poll_control() is None  # consumed
+
+    def test_check_control_consumes_directive_on_cancel(self):
+        b = Branch()
+        b.control(LoopDirective.CANCEL)
+        with pytest.raises(_StopStream):
+            _check_control(b)
+        assert b.poll_control() is None  # consumed
+
+
+# ---------------------------------------------------------------------------
+# CANCEL stops the stream and finally still runs
+# ---------------------------------------------------------------------------
+
+
+class TestCancelFinallyBehavior:
+    async def test_cancel_stops_stream_finally_runs(self):
+        """
+        Mirrors run()'s inner try/except _StopStream: pass with outer finally.
+        CANCEL must not skip the finally block.
+        """
+        b = Branch()
+        b.control(LoopDirective.CANCEL, reason="observer halt")
+
+        finally_ran = False
+        stop_caught = False
+
+        try:
+            try:
+                _check_control(b)
+                pytest.fail("_check_control should have raised _StopStream")
+            except _StopStream:
+                stop_caught = True
+                # mirrors `except _StopStream: pass` in run()
+        finally:
+            finally_ran = True
+
+        assert stop_caught
+        assert finally_ran
+
+    async def test_break_propagates_through_inner_except(self):
+        """
+        BREAK raises LoopBreak, which is NOT caught by `except _StopStream`.
+        It propagates out — but the finally still runs.
+        """
+        b = Branch()
+        b.control(LoopDirective.BREAK, reason="hard stop")
+
+        finally_ran = False
+
+        with pytest.raises(LoopBreak) as exc_info:
+            try:
+                try:
+                    _check_control(b)
+                except _StopStream:
+                    pytest.fail("BREAK must not be caught as _StopStream")
+            finally:
+                finally_ran = True
+
+        assert exc_info.value.reason == "hard stop"
+        assert finally_ran
+
+    async def test_observer_queues_cancel_on_finding(self):
+        """
+        Observer firing on a Finding payload calls branch.control(CANCEL).
+        The directive is then available to the run loop via poll_control.
+        """
+        s = Session()
+        b = s.default_branch
+        signals_seen: list = []
+
+        @s.observe(Finding)
+        def on_finding(payload, session):
+            signals_seen.append(payload)
+            b.control(LoopDirective.CANCEL, reason="finding received, stopping")
+
+        await b.emit(StructuredOutput(data=Finding(description="critical bug found")))
+
+        assert len(signals_seen) == 1
+        ctrl = b.poll_control()
+        assert ctrl is not None
+        assert ctrl.directive is LoopDirective.CANCEL
+        assert ctrl.reason == "finding received, stopping"
+
+    async def test_cancel_after_finding_then_poll_is_one_shot(self):
+        """poll_control() after observer sets CANCEL returns it once, then None."""
+        s = Session()
+        b = s.default_branch
+
+        @s.observe(EscalationRequest)
+        def on_escalation(payload, session):
+            b.control(LoopDirective.CANCEL)
+
+        await b.emit(StructuredOutput(data=EscalationRequest(reason="blocker")))
+
+        ctrl = b.poll_control()
+        assert ctrl is not None
+        assert ctrl.directive is LoopDirective.CANCEL
+        assert b.poll_control() is None  # one-shot


### PR DESCRIPTION
**PR 1 of 3** — universal AgentSpec stack (ADR-0073). Merge order: **capabilities → composition → wiring**.

## What
Layer 1 (capability ontology) + Layer 2 (loop control) — the afferent (sensing) and efferent (steering) nerves of the reactive capability bus.

- `lionagi/casts/capabilities.py` — 12 payload models (Finding, Verdict, ComplianceVerdict, RiskAssessment, AnalysisResult, Conflict, Gap, ExecutionPlan, ComplexityScore, ArtifactProduced, VerificationResult, EscalationRequest); `ROLE_CAPABILITIES` map over 40 roles; `capability_models(role)` (appends EscalationRequest); `capability_operable(role) -> Operable|None`.
- `lionagi/session/control.py` — `LoopDirective` (CONTINUE/CANCEL/BREAK), `LoopControl` (frozen), `LoopBreak`.
- `lionagi/session/branch.py` — `control()` / `poll_control()`.
- `lionagi/operations/run/run.py` — `_check_control(branch)` after each message signal; `_StopStream` sentinel wraps the stream block.
- `docs/adrs/ADR-0073-universal-agent-spec.md` — design contract for the whole stack.

## Scope
v1 loop control = CANCEL/BREAK only. PAUSE/INJECT deferred (turn-boundary, no stubs).

## Verification
`tests/casts/test_capabilities.py`, `tests/session/test_control.py` pass; full `tests/casts tests/agent tests/cli tests/session` green on the integrated branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)