### PR TITLE
feat(agent-spec): Layer 3 — Profile + universal AgentSpec (ADR-0073)

### DIFF
--- a/lionagi/agent/__init__.py
+++ b/lionagi/agent/__init__.py
@@ -5,9 +5,11 @@ from .config import AgentConfig
 from .factory import create_agent
 from .permissions import PermissionPolicy
 from .settings import apply_hooks_from_settings, load_settings
+from .spec import AgentSpec
 
 __all__ = (
     "AgentConfig",
+    "AgentSpec",
     "PermissionPolicy",
     "create_agent",
     "load_settings",

--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -11,11 +11,11 @@ from lionagi.session.branch import Branch
 from .config import AgentConfig
 
 if TYPE_CHECKING:
-    pass
+    from .spec import AgentSpec
 
 
 async def create_agent(
-    config: AgentConfig,
+    config: AgentConfig | AgentSpec,
     *,
     load_settings: bool = True,
     project_dir: str | None = None,
@@ -45,6 +45,14 @@ async def create_agent(
     Returns:
         A Branch ready to use with tools registered and hooks applied.
     """
+    from .spec import AgentSpec
+
+    if isinstance(config, AgentSpec):
+        return await _create_agent_from_spec(
+            config,
+            trust_project_settings=trust_project_settings,
+        )
+
     if load_settings:
         from .settings import apply_hooks_from_settings
         from .settings import load_settings as _load
@@ -107,6 +115,68 @@ async def create_agent(
     _apply_permissions(config)
     _register_tools(branch, config)
     await _load_mcp(branch, config, trust_project_settings=trust_project_settings)
+
+    return branch
+
+
+async def _create_agent_from_spec(
+    spec: AgentSpec,
+    *,
+    trust_project_settings: bool = False,
+) -> Branch:
+    """Create a Branch from an AgentSpec (orchestration-facing path)."""
+    from lionagi.service.imodel import iModel
+
+    branch_kwargs = {}
+
+    if spec.model:
+        from lionagi.cli._providers import (
+            PROVIDER_EFFORT_KWARG,
+            parse_model_spec,
+        )
+
+        ms = parse_model_spec(spec.model)
+        if "/" in ms.model:
+            provider, model_name = ms.model.split("/", 1)
+        else:
+            provider = model_name = ms.model
+
+        extra = {}
+        effort = spec.effort or ms.effort
+        if effort:
+            kwarg = PROVIDER_EFFORT_KWARG.get(provider)
+            if kwarg:
+                extra[kwarg] = effort
+
+        branch_kwargs["chat_model"] = iModel(
+            provider=provider,
+            model=model_name,
+            api_key="dummy",
+            **extra,
+        )
+
+    branch = Branch(**branch_kwargs)
+
+    system_message = spec.build_system_message()
+    if system_message:
+        if spec.lion_system:
+            from lionagi.session.prompts import LION_SYSTEM_MESSAGE
+
+            full_prompt = LION_SYSTEM_MESSAGE.strip() + "\n\n" + system_message
+        else:
+            full_prompt = system_message
+        branch.msgs.set_system(branch.msgs.create_system(system=full_prompt))
+
+    # Use a minimal AgentConfig bridge for tool registration and permissions
+    # so we don't duplicate _register_tools/_apply_permissions logic.
+    bridge = AgentConfig(tools=list(spec.tools))
+    if spec.permissions is not None:
+        bridge.permissions = spec.permissions
+    _apply_permissions(bridge)
+    _register_tools(branch, bridge)
+
+    if op := spec.capability_operable():
+        branch.grant_capabilities(op)
 
     return branch
 

--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -50,7 +50,10 @@ async def create_agent(
     if isinstance(config, AgentSpec):
         return await _create_agent_from_spec(
             config,
+            load_settings=load_settings,
+            project_dir=project_dir,
             trust_project_settings=trust_project_settings,
+            trusted_hook_modules=trusted_hook_modules,
         )
 
     if load_settings:
@@ -122,9 +125,19 @@ async def create_agent(
 async def _create_agent_from_spec(
     spec: AgentSpec,
     *,
+    load_settings: bool = True,
+    project_dir: str | None = None,
     trust_project_settings: bool = False,
+    trusted_hook_modules: set[str] | frozenset[str] | None = None,
 ) -> Branch:
-    """Create a Branch from an AgentSpec (orchestration-facing path)."""
+    """Create a Branch from an AgentSpec (orchestration-facing path).
+
+    MAJ-1: load_settings / trust_project_settings / trusted_hook_modules are
+    now live — settings hooks and MCP are applied on the spec path exactly as
+    on the AgentConfig path.
+    MAJ-2: spec.hook_handlers / spec.cwd / spec.yolo are threaded into the
+    bridge AgentConfig so guard hooks and workspace survive the round-trip.
+    """
     from lionagi.service.imodel import iModel
 
     branch_kwargs = {}
@@ -147,6 +160,11 @@ async def _create_agent_from_spec(
             kwarg = PROVIDER_EFFORT_KWARG.get(provider)
             if kwarg:
                 extra[kwarg] = effort
+        # MIN-2: MAJ-2 — apply yolo kwargs on the spec path (mirrors config path)
+        if spec.yolo:
+            from lionagi.cli._providers import PROVIDER_YOLO_KWARGS
+
+            extra.update(PROVIDER_YOLO_KWARGS.get(provider, {}))
 
         branch_kwargs["chat_model"] = iModel(
             provider=provider,
@@ -167,13 +185,35 @@ async def _create_agent_from_spec(
             full_prompt = system_message
         branch.msgs.set_system(branch.msgs.create_system(system=full_prompt))
 
-    # Use a minimal AgentConfig bridge for tool registration and permissions
-    # so we don't duplicate _register_tools/_apply_permissions logic.
-    bridge = AgentConfig(tools=list(spec.tools))
+    # Build a bridge AgentConfig carrying hook_handlers and cwd so that
+    # _register_tools/_apply_permissions/_load_mcp all receive the full spec.
+    # MAJ-2: copy hook_handlers (shallow — lists are mutable, caller owns them)
+    # and cwd so guard hooks and workspace root survive the round-trip.
+    bridge = AgentConfig(
+        tools=list(spec.tools),
+        hook_handlers={k: list(v) for k, v in spec.hook_handlers.items()},
+        cwd=spec.cwd,
+    )
     if spec.permissions is not None:
         bridge.permissions = spec.permissions
+
+    # MAJ-1: apply settings hooks onto the bridge when load_settings is True.
+    if load_settings:
+        from .settings import apply_hooks_from_settings
+        from .settings import load_settings as _load
+
+        settings = _load(project_dir, include_project=trust_project_settings)
+        apply_hooks_from_settings(
+            bridge,
+            settings,
+            trusted_hook_modules=trusted_hook_modules,
+        )
+
     _apply_permissions(bridge)
     _register_tools(branch, bridge)
+
+    # MAJ-1: load MCP tools on the spec path, mirroring the AgentConfig path.
+    await _load_mcp(branch, bridge, trust_project_settings=trust_project_settings)
 
     if op := spec.capability_operable():
         branch.grant_capabilities(op)

--- a/lionagi/agent/hooks.py
+++ b/lionagi/agent/hooks.py
@@ -59,9 +59,7 @@ def guard_paths(
         config.pre("editor", guard_paths(denied_paths=[".env", "credentials"]))
     """
 
-    allowed_roots = [
-        Path(p).expanduser().resolve(strict=False) for p in (allowed_paths or [])
-    ]
+    allowed_roots = [Path(p).expanduser().resolve(strict=False) for p in (allowed_paths or [])]
 
     async def _guard(tool_name: str, action: str, args: dict) -> dict | None:
         raw_path = args.get("path") or args.get("file_path") or ""
@@ -71,19 +69,14 @@ def guard_paths(
         resolved = Path(raw_path).expanduser().resolve(strict=False)
 
         if allowed_roots:
-            if not any(
-                resolved == root or root in resolved.parents for root in allowed_roots
-            ):
+            if not any(resolved == root or root in resolved.parents for root in allowed_roots):
                 raise PermissionError(f"Path not in allowed list: {raw_path}")
         if denied_paths:
             for denied in denied_paths:
                 denied_path = Path(denied).expanduser()
                 if denied_path.is_absolute():
                     denied_resolved = denied_path.resolve(strict=False)
-                    if (
-                        resolved == denied_resolved
-                        or denied_resolved in resolved.parents
-                    ):
+                    if resolved == denied_resolved or denied_resolved in resolved.parents:
                         raise PermissionError(f"Path matches deny rule: {raw_path}")
                 elif denied in raw_path or denied in resolved.name:
                     raise PermissionError(f"Path matches deny rule: {raw_path}")
@@ -92,18 +85,14 @@ def guard_paths(
     return _guard
 
 
-async def log_tool_use(
-    tool_name: str, action: str, args: dict, result: dict
-) -> dict | None:
+async def log_tool_use(tool_name: str, action: str, args: dict, result: dict) -> dict | None:
     """Post-hook: log tool usage for observability."""
     success = result.get("success", result.get("return_code") == 0)
     logger.info("tool=%s action=%s success=%s", tool_name, action, success)
     return None
 
 
-async def auto_format_python(
-    tool_name: str, action: str, args: dict, result: dict
-) -> dict | None:
+async def auto_format_python(tool_name: str, action: str, args: dict, result: dict) -> dict | None:
     """Post-hook: run ruff format on edited Python files."""
     if not result.get("success"):
         return None

--- a/lionagi/agent/permissions.py
+++ b/lionagi/agent/permissions.py
@@ -46,7 +46,6 @@ from __future__ import annotations
 import fnmatch
 import logging
 import re
-import shlex
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
@@ -182,17 +181,13 @@ class PermissionPolicy:
                 )
 
         # Finding 10: default deny instead of default allow in rules mode
-        return PermissionDecision(
-            "deny", tool_name, action, "no matching rule, default deny"
-        )
+        return PermissionDecision("deny", tool_name, action, "no matching rule, default deny")
 
     def to_pre_hook(self) -> Callable:
         """Convert this policy into a Tool preprocessor hook."""
         policy = self
 
-        async def permission_check(
-            tool_name: str, action: str, args: dict
-        ) -> dict | None:
+        async def permission_check(tool_name: str, action: str, args: dict) -> dict | None:
             decision = policy.check(tool_name, action, args)
 
             if decision.behavior == "allow":
@@ -210,9 +205,7 @@ class PermissionPolicy:
                     f"{decision.reason}. No escalation handler configured."
                 )
 
-            raise PermissionError(
-                f"Permission denied for {tool_name}.{action}: {decision.reason}"
-            )
+            raise PermissionError(f"Permission denied for {tool_name}.{action}: {decision.reason}")
 
         return permission_check
 
@@ -222,9 +215,7 @@ def _build_match_string(tool_name: str, action: str, args: dict) -> str:
         command = str(args.get("command", ""))
         # Finding 2: reject shell control operators before fnmatch
         if _SHELL_CONTROL.search(command):
-            raise PermissionError(
-                f"Shell control operator requires explicit approval: {command!r}"
-            )
+            raise PermissionError(f"Shell control operator requires explicit approval: {command!r}")
         return command
     if tool_name == "editor":
         return args.get("file_path", "")
@@ -238,6 +229,4 @@ def _build_match_string(tool_name: str, action: str, args: dict) -> str:
 def _matches(text: str, pattern: str) -> bool:
     if pattern == "*":
         return True
-    return fnmatch.fnmatch(text, pattern) or fnmatch.fnmatch(
-        text.lower(), pattern.lower()
-    )
+    return fnmatch.fnmatch(text, pattern) or fnmatch.fnmatch(text.lower(), pattern.lower())

--- a/lionagi/agent/spec.py
+++ b/lionagi/agent/spec.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from lionagi.casts.pack import Pack
+from lionagi.casts.profile import Profile
+
+if TYPE_CHECKING:
+    from lionagi.ln.types import Operable
+
+    from .config import AgentConfig
+    from .permissions import PermissionPolicy
+
+__all__ = ("AgentSpec",)
+
+
+@dataclass
+class AgentSpec:
+    """Universal runtime agent spec: Profile (identity) + runtime concerns.
+
+    This is the orchestration-facing composition surface. Every entry point
+    (cli, programmatic create_agent, flow wiring) composes to AgentSpec and
+    builds a Branch from it.
+    """
+
+    profile: Profile
+    model: str | None = None
+    effort: str | None = None
+    tools: tuple[str, ...] = ()
+    permissions: PermissionPolicy | None = None
+    grant_capabilities: bool = True
+    pack: str | Pack | None = "default"
+    lion_system: bool = True
+    # Bridge field: captures AgentConfig.system_prompt that has no AgentSpec
+    # equivalent. Appended after role+modes in build_system_message().
+    extra_prompt: str | None = None
+
+    @classmethod
+    def compose(
+        cls,
+        role: Any,
+        *,
+        modes: list[Any] | None = None,
+        model: str | None = None,
+        effort: str | None = None,
+        tools: tuple[str, ...] | list[str] = (),
+        permissions: Any = None,
+        pack: str | Pack | None = "default",
+        grant_capabilities: bool = True,
+    ) -> AgentSpec:
+        """Build an AgentSpec from a role name/object + optional overrides."""
+        prof = Profile.compose(role, modes=modes)
+        perm = _resolve_permissions(permissions)
+        return cls(
+            profile=prof,
+            model=model,
+            effort=effort,
+            tools=tuple(tools),
+            permissions=perm,
+            pack=pack,
+            grant_capabilities=grant_capabilities,
+        )
+
+    def build_system_message(self) -> str:
+        """Compose role + modes + RolePolicy block (authority / boundaries /
+        escalations) + any extra literal prompt."""
+        body = self.profile.build_system_message()
+        policy_block = self._render_policy_block()
+        parts = [p for p in (body, policy_block, self.extra_prompt) if p]
+        return "\n\n".join(parts)
+
+    def capability_operable(self) -> Operable | None:
+        """Return the role's Operable for capability granting, or None when
+        grant_capabilities is False."""
+        if not self.grant_capabilities:
+            return None
+        from lionagi.casts.capabilities import capability_operable
+
+        return capability_operable(self.profile.role.name)
+
+    def _render_policy_block(self) -> str:
+        """Render the RolePolicy as operational guidance in the system message."""
+        if self.pack is None:
+            return ""
+        pack = _load_pack(self.pack)
+        if pack is None:
+            return ""
+        policy = pack.policy(self.profile.role.name)
+        if policy is None:
+            return ""
+
+        lines: list[str] = []
+        if policy.authority:
+            lines.append("## Authority")
+            lines.extend(f"- {a}" for a in policy.authority)
+        if policy.boundaries:
+            if lines:
+                lines.append("")
+            lines.append("## Operational Boundaries")
+            lines.extend(f"- {b}" for b in policy.boundaries)
+        if policy.escalations:
+            if lines:
+                lines.append("")
+            lines.append("## Escalation Conditions")
+            lines.append(
+                "When any of these conditions occur, STOP and emit an"
+                " `escalation_request` capability with the reason:"
+            )
+            lines.extend(f"- {e}" for e in policy.escalations)
+        return "\n".join(lines)
+
+    @classmethod
+    def from_config(cls, config: AgentConfig) -> AgentSpec:
+        """Bridge an AgentConfig into an AgentSpec.
+
+        Contract conflict resolution: AgentConfig.system_prompt has no direct
+        AgentSpec equivalent. It is preserved in extra_prompt and appended to
+        the composed system message by build_system_message().
+        """
+        from .permissions import PermissionPolicy
+
+        perm: PermissionPolicy | None = None
+        if config.permissions:
+            if isinstance(config.permissions, PermissionPolicy):
+                perm = config.permissions
+            elif isinstance(config.permissions, dict):
+                perm = PermissionPolicy.from_dict(config.permissions)
+
+        role = config.role or "implementer"
+        prof = Profile.compose(role=role, modes=config.modes or [])
+
+        return cls(
+            profile=prof,
+            model=config.model,
+            effort=config.effort,
+            tools=tuple(config.tools or []),
+            permissions=perm,
+            grant_capabilities=True,
+            pack="default",
+            lion_system=config.lion_system,
+            extra_prompt=config.system_prompt or None,
+        )
+
+
+def _resolve_permissions(
+    permissions: Any,
+) -> PermissionPolicy | None:
+    """Normalise a permissions argument to a PermissionPolicy or None."""
+    from .permissions import PermissionPolicy
+
+    if permissions is None:
+        return None
+    if isinstance(permissions, PermissionPolicy):
+        return permissions
+    if isinstance(permissions, dict):
+        return PermissionPolicy.from_dict(permissions)
+    if isinstance(permissions, str):
+        preset = permissions.lower()
+        presets = {
+            "safe": PermissionPolicy.safe,
+            "read_only": PermissionPolicy.read_only,
+            "allow_all": PermissionPolicy.allow_all,
+            "deny_all": PermissionPolicy.deny_all,
+        }
+        factory = presets.get(preset)
+        if factory is None:
+            raise ValueError(
+                f"Unknown permissions preset {permissions!r}. Valid: {sorted(presets)}"
+            )
+        return factory()
+    raise TypeError(f"Cannot resolve permissions from {type(permissions)!r}")
+
+
+def _load_pack(pack: str | Pack) -> Pack | None:
+    """Load a Pack by name or return it directly if already a Pack."""
+    if isinstance(pack, Pack):
+        return pack
+    if pack == "default":
+        from importlib.resources import as_file, files
+
+        packaged = files("lionagi.casts").joinpath("packs", "default.yaml")
+        with as_file(packaged) as p:
+            return Pack.from_file(p)
+    return None

--- a/lionagi/agent/spec.py
+++ b/lionagi/agent/spec.py
@@ -3,7 +3,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections.abc import Callable
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from lionagi.casts.pack import Pack
@@ -38,6 +39,10 @@ class AgentSpec:
     # Bridge field: captures AgentConfig.system_prompt that has no AgentSpec
     # equivalent. Appended after role+modes in build_system_message().
     extra_prompt: str | None = None
+    # MAJ-2: preserve hook_handlers / cwd / yolo from AgentConfig round-trips.
+    hook_handlers: dict[str, list[Callable]] = field(default_factory=dict)
+    cwd: str | None = None
+    yolo: bool = False
 
     @classmethod
     def compose(
@@ -120,6 +125,11 @@ class AgentSpec:
         Contract conflict resolution: AgentConfig.system_prompt has no direct
         AgentSpec equivalent. It is preserved in extra_prompt and appended to
         the composed system message by build_system_message().
+
+        MAJ-2: hook_handlers, cwd, and yolo are now preserved so guard hooks
+        and workspace directory survive the AgentConfig → AgentSpec round-trip.
+        mcp_servers / mcp_config_path are not carried (MCP is loaded by
+        _create_agent_from_spec via the trust_project_settings path).
         """
         from .permissions import PermissionPolicy
 
@@ -143,6 +153,12 @@ class AgentSpec:
             pack="default",
             lion_system=config.lion_system,
             extra_prompt=config.system_prompt or None,
+            # MAJ-2: carry hook_handlers, cwd, yolo through the bridge.
+            # Deep-copy the lists so the spec's hook_handlers is independent of
+            # the source config (callers may mutate either side post-bridge).
+            hook_handlers={k: list(v) for k, v in config.hook_handlers.items()},
+            cwd=config.cwd,
+            yolo=config.yolo,
         )
 
 
@@ -176,7 +192,12 @@ def _resolve_permissions(
 
 
 def _load_pack(pack: str | Pack) -> Pack | None:
-    """Load a Pack by name or return it directly if already a Pack."""
+    """Load a Pack by name or return it directly if already a Pack.
+
+    MIN-3 (deferred): re-reads default.yaml from disk on every
+    build_system_message() call. Functionally correct; memoization deferred
+    until profiled as a real bottleneck.
+    """
     if isinstance(pack, Pack):
         return pack
     if pack == "default":

--- a/lionagi/casts/pattern.py
+++ b/lionagi/casts/pattern.py
@@ -159,6 +159,7 @@ def list_modes() -> list[str]:
     """Return sorted names of all available modes (packaged + user-local).
 
     Uses file stems so names round-trip through Mode.load(name).
+    Excludes TEMPLATE; symmetric with list_roles().
     """
     from importlib.resources import files
 
@@ -166,7 +167,7 @@ def list_modes() -> list[str]:
     names: set[str] = set()
     for item in pkg.iterdir():
         n = item.name
-        if n.endswith(".md"):
+        if n.endswith(".md") and n != "TEMPLATE.md":
             names.add(n[:-3])
     user_dir = Path.home() / ".lionagi" / "modes"
     if user_dir.is_dir():

--- a/lionagi/casts/pattern.py
+++ b/lionagi/casts/pattern.py
@@ -15,6 +15,8 @@ __all__ = (
     "PatternKind",
     "Mode",
     "Role",
+    "list_roles",
+    "list_modes",
 )
 
 _FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
@@ -129,3 +131,45 @@ class Role(Pattern):
     def load(cls, name: str, /) -> Role:
         """Load a built-in role by name from the packaged roles/."""
         return cls.from_md(_read_pattern_md(f"{name}.md"))
+
+
+def list_roles() -> list[str]:
+    """Return sorted names of all available roles (packaged + user-local).
+
+    Uses file stems so names round-trip through Role.load(name).
+    Excludes TEMPLATE; the modes/ subdirectory is skipped automatically
+    because it has no .md extension.
+    """
+    from importlib.resources import files
+
+    pkg = files("lionagi.casts").joinpath("roles")
+    names: set[str] = set()
+    for item in pkg.iterdir():
+        n = item.name
+        if n.endswith(".md") and n != "TEMPLATE.md":
+            names.add(n[:-3])
+    user_dir = Path.home() / ".lionagi" / "roles"
+    if user_dir.is_dir():
+        for p in user_dir.glob("*.md"):
+            names.add(p.stem)
+    return sorted(names)
+
+
+def list_modes() -> list[str]:
+    """Return sorted names of all available modes (packaged + user-local).
+
+    Uses file stems so names round-trip through Mode.load(name).
+    """
+    from importlib.resources import files
+
+    pkg = files("lionagi.casts").joinpath("roles", "modes")
+    names: set[str] = set()
+    for item in pkg.iterdir():
+        n = item.name
+        if n.endswith(".md"):
+            names.add(n[:-3])
+    user_dir = Path.home() / ".lionagi" / "modes"
+    if user_dir.is_dir():
+        for p in user_dir.glob("*.md"):
+            names.add(p.stem)
+    return sorted(names)

--- a/lionagi/casts/profile.py
+++ b/lionagi/casts/profile.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from lionagi.casts.pattern import Mode, Role
+
+__all__ = ("Profile",)
+
+
+@dataclass(frozen=True, slots=True)
+class Profile:
+    """Named identity composition: one Role + ordered cognitive Modes.
+
+    Pure configuration — no tools, model, or permissions. Validates mode
+    conflicts at construction time (both directions of conflicts_with).
+    """
+
+    name: str
+    role: Role
+    modes: tuple[Mode, ...] = ()
+
+    def __post_init__(self) -> None:
+        seen: dict[str, Mode] = {}
+        for m in self.modes:
+            for other in seen.values():
+                if m.name in other.conflicts_with or other.name in m.conflicts_with:
+                    raise ValueError(f"Mode conflict: {m.name!r} vs {other.name!r}")
+            seen[m.name] = m
+
+    @property
+    def capabilities(self) -> tuple[type, ...]:
+        from lionagi.casts.capabilities import capability_models
+
+        return capability_models(self.role.name)
+
+    def build_system_message(self) -> str:
+        """Compose role body + each mode's behaviors, joined by blank lines."""
+        parts = [self.role.body] if self.role.body else []
+        parts += [m.behaviors for m in self.modes if m.behaviors]
+        return "\n\n".join(parts)
+
+    @classmethod
+    def compose(
+        cls,
+        role: str | Role,
+        *,
+        modes: list[str | Mode] | None = None,
+        name: str | None = None,
+    ) -> Profile:
+        """Build a Profile from role/mode names or objects."""
+        r = role if not isinstance(role, str) else Role.load(role)
+        ms = tuple(m if not isinstance(m, str) else Mode.load(m) for m in (modes or []))
+        return cls(name=name or r.name, role=r, modes=ms)
+
+    @classmethod
+    def from_yaml(cls, path: str | Path) -> Profile:
+        """Load a Profile from a YAML file with {name, role, modes: [...]}."""
+        import yaml
+
+        data = yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+        return cls.compose(
+            role=data["role"],
+            modes=data.get("modes") or [],
+            name=data.get("name"),
+        )

--- a/lionagi/casts/profile.py
+++ b/lionagi/casts/profile.py
@@ -24,6 +24,11 @@ class Profile:
     modes: tuple[Mode, ...] = ()
 
     def __post_init__(self) -> None:
+        # MIN-4 (deferred): duplicate mode names (same name, different Mode objects)
+        # silently overwrite the earlier entry. No error is raised; mutual
+        # conflict-checking is skipped for the duplicate pair. Deferred — the
+        # caller (compose) round-trips through Mode.load which produces a single
+        # canonical instance, so duplicates are unlikely in practice.
         seen: dict[str, Mode] = {}
         for m in self.modes:
             for other in seen.values():

--- a/tests/agent/test_factory.py
+++ b/tests/agent/test_factory.py
@@ -73,9 +73,7 @@ async def test_create_agent_coding_all_tools_async():
     config = AgentConfig.coding()
     branch = await _make(config)
     for name, tool in branch.acts.registry.items():
-        assert asyncio.iscoroutinefunction(
-            tool.func_callable
-        ), f"Tool '{name}' is not async"
+        assert asyncio.iscoroutinefunction(tool.func_callable), f"Tool '{name}' is not async"
 
 
 # ---------------------------------------------------------------------------
@@ -170,18 +168,14 @@ async def test_create_agent_load_settings_false_no_side_effects(monkeypatch):
         called.append(True)
         return {}
 
-    monkeypatch.setattr(
-        "lionagi.agent.settings.load_settings", fake_load, raising=False
-    )
+    monkeypatch.setattr("lionagi.agent.settings.load_settings", fake_load, raising=False)
 
     config = AgentConfig()
     await create_agent(config, load_settings=False)
     assert called == [], "load_settings was called despite load_settings=False"
 
 
-async def test_create_agent_does_not_autoload_project_mcp_without_trust(
-    tmp_path, monkeypatch
-):
+async def test_create_agent_does_not_autoload_project_mcp_without_trust(tmp_path, monkeypatch):
     from lionagi.protocols.action.manager import ActionManager
 
     project = tmp_path / "project"
@@ -282,9 +276,7 @@ async def test_create_agent_parses_model_provider_effort_and_yolo_kwargs(monkeyp
     import lionagi.cli._providers as providers_mod
     import lionagi.service.imodel as imodel_mod
 
-    monkeypatch.setitem(
-        providers_mod.PROVIDER_EFFORT_KWARG, "openai", "reasoning_effort"
-    )
+    monkeypatch.setitem(providers_mod.PROVIDER_EFFORT_KWARG, "openai", "reasoning_effort")
     monkeypatch.setitem(providers_mod.PROVIDER_YOLO_KWARGS, "openai", {"stream": True})
 
     real_init = imodel_mod.iModel.__init__
@@ -311,9 +303,7 @@ async def test_create_agent_parses_model_provider_effort_and_yolo_kwargs(monkeyp
 # ---------------------------------------------------------------------------
 
 
-async def test_create_agent_does_not_load_project_settings_without_trust(
-    tmp_path, monkeypatch
-):
+async def test_create_agent_does_not_load_project_settings_without_trust(tmp_path, monkeypatch):
     import lionagi.agent.settings as settings_mod
 
     (tmp_path / ".lionagi").mkdir(parents=True)
@@ -386,9 +376,7 @@ async def test_create_agent_model_without_slash_uses_model_as_provider(monkeypat
 
 
 async def test_create_agent_system_prompt_without_lion_system():
-    config = AgentConfig(
-        system_prompt="You are a helpful assistant.", lion_system=False
-    )
+    config = AgentConfig(system_prompt="You are a helpful assistant.", lion_system=False)
     branch = await create_agent(config, load_settings=False)
     sys_msg = branch.msgs.system
     assert sys_msg is not None
@@ -495,7 +483,6 @@ async def test_attach_hooks_adds_postprocessor_for_standalone_tool():
 
 
 async def test_register_coding_tools_skips_malformed_keys():
-
     config = AgentConfig.coding()
     config.hook_handlers["malformed_no_colon"] = [lambda *a: None]
     branch = await _make(config)
@@ -570,3 +557,54 @@ async def test_load_mcp_breaks_at_lionagi_dir(tmp_path, monkeypatch):
     )
 
     assert calls and calls[0] == str(mcp_file)
+
+
+# ---------------------------------------------------------------------------
+# AgentSpec path: create_agent accepts AgentSpec (back-compat with AgentConfig)
+# ---------------------------------------------------------------------------
+
+
+async def test_create_agent_agentspec_returns_branch():
+    from lionagi.agent.spec import AgentSpec
+
+    spec = AgentSpec.compose("analyst")
+    branch = await create_agent(spec, load_settings=False)
+    assert isinstance(branch, Branch)
+
+
+async def test_create_agent_agentspec_system_message_contains_role_body():
+    from lionagi.agent.spec import AgentSpec
+
+    spec = AgentSpec.compose("analyst")
+    branch = await create_agent(spec, load_settings=False)
+    assert spec.profile.role.body in branch.msgs.system.rendered
+
+
+async def test_create_agent_agentspec_with_tools_registers_tool():
+    from lionagi.agent.spec import AgentSpec
+
+    spec = AgentSpec.compose("analyst", tools=["reader"])
+    branch = await create_agent(spec, load_settings=False)
+    assert "reader_tool" in branch.acts.registry
+
+
+async def test_create_agent_agentspec_with_permissions_wires_preprocessor():
+    from lionagi.agent.spec import AgentSpec
+
+    spec = AgentSpec.compose("analyst", tools=["reader"], permissions="deny_all")
+    branch = await create_agent(spec, load_settings=False)
+    reader_tool = branch.acts.registry.get("reader_tool")
+    assert reader_tool is not None
+    assert reader_tool.preprocessor is not None
+
+
+async def test_create_agent_agentspec_deny_all_preprocessor_raises():
+    from lionagi.agent.spec import AgentSpec
+
+    spec = AgentSpec.compose("analyst", tools=["reader"], permissions="deny_all")
+    branch = await create_agent(spec, load_settings=False)
+    reader_tool = branch.acts.registry["reader_tool"]
+    import pytest
+
+    with pytest.raises(PermissionError):
+        await reader_tool.preprocessor({"action": "read", "path": "/tmp/x.py"})

--- a/tests/agent/test_spec.py
+++ b/tests/agent/test_spec.py
@@ -1,0 +1,274 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for AgentSpec (lionagi/agent/spec.py) and factory AgentSpec path."""
+
+import pytest
+
+from lionagi.agent.config import AgentConfig
+from lionagi.agent.factory import create_agent
+from lionagi.agent.permissions import PermissionPolicy
+from lionagi.agent.spec import AgentSpec, _resolve_permissions
+from lionagi.casts.profile import Profile
+from lionagi.session.branch import Branch
+
+# ---------------------------------------------------------------------------
+# _resolve_permissions
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_permissions_none():
+    assert _resolve_permissions(None) is None
+
+
+def test_resolve_permissions_policy_passthrough():
+    p = PermissionPolicy.safe()
+    assert _resolve_permissions(p) is p
+
+
+def test_resolve_permissions_dict():
+    result = _resolve_permissions({"mode": "deny_all"})
+    assert isinstance(result, PermissionPolicy)
+    assert result.mode == "deny_all"
+
+
+@pytest.mark.parametrize(
+    "preset,expected_mode",
+    [
+        ("safe", "rules"),
+        ("read_only", "rules"),
+        ("allow_all", "allow_all"),
+        ("deny_all", "deny_all"),
+    ],
+)
+def test_resolve_permissions_preset_string(preset, expected_mode):
+    result = _resolve_permissions(preset)
+    assert isinstance(result, PermissionPolicy)
+    assert result.mode == expected_mode
+
+
+def test_resolve_permissions_invalid_preset():
+    with pytest.raises(ValueError, match="Unknown permissions preset"):
+        _resolve_permissions("super_safe")
+
+
+def test_resolve_permissions_invalid_type():
+    with pytest.raises(TypeError):
+        _resolve_permissions(42)
+
+
+# ---------------------------------------------------------------------------
+# AgentSpec.compose
+# ---------------------------------------------------------------------------
+
+
+def test_agentspec_compose_basic():
+    spec = AgentSpec.compose("analyst")
+    assert isinstance(spec.profile, Profile)
+    assert spec.profile.role.name == "analyst"
+    assert spec.permissions is None
+
+
+def test_agentspec_compose_with_modes():
+    spec = AgentSpec.compose("critic", modes=["adversarial"])
+    assert len(spec.profile.modes) == 1
+    assert spec.profile.modes[0].name == "adversarial"
+
+
+def test_agentspec_compose_resolves_permission_preset():
+    spec = AgentSpec.compose("analyst", permissions="safe")
+    assert isinstance(spec.permissions, PermissionPolicy)
+    assert spec.permissions.mode == "rules"
+
+
+def test_agentspec_compose_tools_tuple():
+    spec = AgentSpec.compose("implementer", tools=["coding", "reader"])
+    assert spec.tools == ("coding", "reader")
+
+
+def test_agentspec_compose_model_effort():
+    spec = AgentSpec.compose("analyst", model="openai/gpt-4.1", effort="high")
+    assert spec.model == "openai/gpt-4.1"
+    assert spec.effort == "high"
+
+
+# ---------------------------------------------------------------------------
+# AgentSpec.build_system_message
+# ---------------------------------------------------------------------------
+
+
+def test_agentspec_build_system_message_contains_role_body():
+    spec = AgentSpec.compose("analyst")
+    msg = spec.build_system_message()
+    assert spec.profile.role.body in msg
+
+
+def test_agentspec_build_system_message_contains_mode_behaviors():
+    spec = AgentSpec.compose("critic", modes=["adversarial"])
+    msg = spec.build_system_message()
+    from lionagi.casts.pattern import Mode
+
+    adv = Mode.load("adversarial")
+    assert adv.behaviors in msg
+
+
+def test_agentspec_build_system_message_contains_policy_block():
+    spec = AgentSpec.compose("analyst")
+    msg = spec.build_system_message()
+    # analyst has authority + boundaries + escalations in default pack
+    assert "## Authority" in msg
+    assert "## Escalation Conditions" in msg
+
+
+def test_agentspec_build_system_message_policy_escalation_exact_wording():
+    """Escalation block must use the exact STOP + escalation_request wording from ADR."""
+    spec = AgentSpec.compose("analyst")
+    msg = spec.build_system_message()
+    assert "STOP and emit an `escalation_request` capability" in msg
+
+
+def test_agentspec_build_system_message_no_pack():
+    spec = AgentSpec.compose("analyst")
+    spec2 = AgentSpec(profile=spec.profile, pack=None)
+    msg = spec2.build_system_message()
+    # No pack means no policy block; role body still present
+    assert spec2.profile.role.body in msg
+    assert "escalation_request" not in msg
+
+
+def test_agentspec_build_system_message_extra_prompt():
+    spec = AgentSpec(
+        profile=Profile.compose("analyst"),
+        extra_prompt="Be concise.",
+    )
+    msg = spec.build_system_message()
+    assert "Be concise." in msg
+
+
+# ---------------------------------------------------------------------------
+# AgentSpec.capability_operable
+# ---------------------------------------------------------------------------
+
+
+def test_agentspec_capability_operable_delegates():
+    from lionagi.casts.capabilities import capability_operable
+
+    spec = AgentSpec.compose("critic", grant_capabilities=True)
+    result = spec.capability_operable()
+    expected = capability_operable("critic")
+    assert result == expected
+
+
+def test_agentspec_capability_operable_false_returns_none():
+    spec = AgentSpec.compose("critic", grant_capabilities=False)
+    assert spec.capability_operable() is None
+
+
+# ---------------------------------------------------------------------------
+# AgentSpec.from_config
+# ---------------------------------------------------------------------------
+
+
+def test_from_config_maps_role_and_model():
+    config = AgentConfig(
+        name="my-agent",
+        model="anthropic/claude-sonnet-4-6",
+        role="analyst",
+        effort="high",
+    )
+    spec = AgentSpec.from_config(config)
+    assert spec.profile.role.name == "analyst"
+    assert spec.model == "anthropic/claude-sonnet-4-6"
+    assert spec.effort == "high"
+
+
+def test_from_config_preserves_system_prompt():
+    config = AgentConfig(role="analyst", system_prompt="Custom instructions.")
+    spec = AgentSpec.from_config(config)
+    assert spec.extra_prompt == "Custom instructions."
+    msg = spec.build_system_message()
+    assert "Custom instructions." in msg
+
+
+def test_from_config_empty_system_prompt_gives_none():
+    config = AgentConfig(role="analyst", system_prompt="")
+    spec = AgentSpec.from_config(config)
+    assert spec.extra_prompt is None
+
+
+def test_from_config_tools():
+    config = AgentConfig(role="analyst", tools=["coding"])
+    spec = AgentSpec.from_config(config)
+    assert spec.tools == ("coding",)
+
+
+def test_from_config_permissions_dict():
+    config = AgentConfig(role="analyst", permissions={"mode": "deny_all"})
+    spec = AgentSpec.from_config(config)
+    assert isinstance(spec.permissions, PermissionPolicy)
+    assert spec.permissions.mode == "deny_all"
+
+
+def test_from_config_modes():
+    config = AgentConfig(role="analyst", modes=["adversarial"])
+    spec = AgentSpec.from_config(config)
+    assert len(spec.profile.modes) == 1
+    assert spec.profile.modes[0].name == "adversarial"
+
+
+def test_from_config_no_role_defaults_to_implementer():
+    config = AgentConfig()
+    spec = AgentSpec.from_config(config)
+    assert spec.profile.role.name == "implementer"
+
+
+def test_from_config_lion_system_preserved():
+    config = AgentConfig(role="analyst", lion_system=False)
+    spec = AgentSpec.from_config(config)
+    assert spec.lion_system is False
+
+
+# ---------------------------------------------------------------------------
+# factory: create_agent with AgentSpec
+# ---------------------------------------------------------------------------
+
+
+async def test_create_agent_agentspec_returns_branch():
+    spec = AgentSpec.compose("analyst")
+    branch = await create_agent(spec, load_settings=False)
+    assert isinstance(branch, Branch)
+
+
+async def test_create_agent_agentspec_sets_system_message():
+    spec = AgentSpec.compose("analyst")
+    branch = await create_agent(spec, load_settings=False)
+    system_text = branch.msgs.system.rendered
+    assert spec.profile.role.body in system_text
+
+
+async def test_create_agent_agentspec_no_model():
+    spec = AgentSpec.compose("analyst")
+    branch = await create_agent(spec, load_settings=False)
+    assert isinstance(branch, Branch)
+
+
+async def test_create_agent_agentspec_capability_grant_smoke():
+    spec = AgentSpec.compose("critic", grant_capabilities=True)
+    op = spec.capability_operable()
+    if op is not None:
+        branch = await create_agent(spec, load_settings=False)
+        assert isinstance(branch, Branch)
+    else:
+        pytest.skip("No Operable for critic")
+
+
+async def test_create_agent_agentspec_grant_capabilities_false():
+    spec = AgentSpec.compose("critic", grant_capabilities=False)
+    branch = await create_agent(spec, load_settings=False)
+    assert isinstance(branch, Branch)
+
+
+async def test_create_agent_agentconfig_still_works():
+    config = AgentConfig()
+    branch = await create_agent(config, load_settings=False)
+    assert isinstance(branch, Branch)

--- a/tests/agent/test_spec.py
+++ b/tests/agent/test_spec.py
@@ -272,3 +272,186 @@ async def test_create_agent_agentconfig_still_works():
     config = AgentConfig()
     branch = await create_agent(config, load_settings=False)
     assert isinstance(branch, Branch)
+
+
+# ---------------------------------------------------------------------------
+# MAJ-2: AgentSpec new fields (hook_handlers, cwd, yolo) + from_config round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_agentspec_default_new_fields():
+    """New fields default to safe values: empty dict, None, False."""
+    spec = AgentSpec.compose("analyst")
+    assert spec.hook_handlers == {}
+    assert spec.cwd is None
+    assert spec.yolo is False
+
+
+def test_from_config_preserves_hook_handlers():
+    """from_config must copy hook_handlers so guards survive the round-trip."""
+    config = AgentConfig(role="analyst")
+    calls = []
+
+    async def my_guard(tool_name, action, args):
+        calls.append(tool_name)
+
+    config.pre("bash", my_guard)
+    spec = AgentSpec.from_config(config)
+    assert "pre:bash" in spec.hook_handlers
+    assert spec.hook_handlers["pre:bash"] == [my_guard]
+
+
+def test_from_config_preserves_cwd():
+    """from_config must copy cwd so workspace root survives the round-trip."""
+    config = AgentConfig(role="analyst", cwd="/tmp/workspace")
+    spec = AgentSpec.from_config(config)
+    assert spec.cwd == "/tmp/workspace"
+
+
+def test_from_config_preserves_yolo():
+    """from_config must copy yolo flag."""
+    config = AgentConfig(role="analyst", yolo=True)
+    spec = AgentSpec.from_config(config)
+    assert spec.yolo is True
+
+
+def test_from_config_hook_handlers_is_a_copy():
+    """from_config must copy hook_handlers (shallow), not share the reference."""
+    config = AgentConfig(role="analyst")
+
+    async def hook(tool_name, action, args):
+        pass
+
+    config.pre("bash", hook)
+    spec = AgentSpec.from_config(config)
+    # Mutating the copy must not affect the original and vice-versa
+    spec.hook_handlers["pre:bash"].clear()
+    assert len(config.hook_handlers["pre:bash"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# MAJ-2: _create_agent_from_spec threads cwd into bridge → CodingToolkit
+# ---------------------------------------------------------------------------
+
+
+async def test_create_agent_agentspec_cwd_threads_to_bridge(tmp_path, monkeypatch):
+    """cwd on AgentSpec must reach CodingToolkit's workspace_root."""
+    from pathlib import Path
+
+    import lionagi.tools.coding as coding_mod
+
+    captured_roots: list[Path] = []
+    real_init = coding_mod.CodingToolkit.__init__
+
+    def spy_init(self, workspace_root=None, **kw):
+        captured_roots.append(workspace_root)
+        real_init(self, workspace_root=workspace_root, **kw)
+
+    monkeypatch.setattr(coding_mod.CodingToolkit, "__init__", spy_init)
+
+    spec = AgentSpec.compose("implementer", tools=["coding"])
+    import dataclasses
+
+    spec = dataclasses.replace(spec, cwd=str(tmp_path))
+    branch = await create_agent(spec, load_settings=False)
+    assert isinstance(branch, Branch)
+    assert captured_roots and captured_roots[0] == tmp_path
+
+
+# ---------------------------------------------------------------------------
+# MAJ-1: spec path honours load_settings / trust_project_settings
+# ---------------------------------------------------------------------------
+
+
+async def test_create_agent_agentspec_load_settings_false_no_call(monkeypatch):
+    """load_settings=False on AgentSpec path must not call apply_hooks_from_settings."""
+    import lionagi.agent.settings as settings_mod
+
+    calls = []
+    real = settings_mod.load_settings
+
+    def spy(project_dir=None, *, include_project=True):
+        calls.append(include_project)
+        return real(project_dir, include_project=include_project)
+
+    monkeypatch.setattr(settings_mod, "load_settings", spy)
+
+    spec = AgentSpec.compose("analyst")
+    await create_agent(spec, load_settings=False)
+    assert calls == []
+
+
+async def test_create_agent_agentspec_load_settings_true_passes_trust(monkeypatch):
+    """load_settings=True on AgentSpec path must forward trust_project_settings."""
+    import lionagi.agent.settings as settings_mod
+
+    calls = []
+    real = settings_mod.load_settings
+
+    def spy(project_dir=None, *, include_project=True):
+        calls.append(include_project)
+        return real(project_dir, include_project=include_project)
+
+    monkeypatch.setattr(settings_mod, "load_settings", spy)
+
+    spec = AgentSpec.compose("analyst")
+    await create_agent(spec, load_settings=True, trust_project_settings=False)
+    assert calls == [False]
+
+
+async def test_create_agent_agentspec_mcp_loaded_when_trusted(tmp_path, monkeypatch):
+    """MAJ-1: _load_mcp is now reached on the spec path when trusted."""
+    from lionagi.protocols.action.manager import ActionManager
+
+    project = tmp_path / "project"
+    project.mkdir()
+    mcp_file = project / ".mcp.json"
+    mcp_file.write_text('{"mcpServers": {"demo": {"command": "true"}}}')
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    calls = []
+
+    async def fake_load_mcp(self, config_path, server_names=None, update=False):
+        calls.append(config_path)
+        return {}
+
+    monkeypatch.setattr(ActionManager, "load_mcp_config", fake_load_mcp)
+
+    import dataclasses
+
+    spec = AgentSpec.compose("analyst")
+    spec = dataclasses.replace(spec, cwd=str(project))
+    await create_agent(spec, load_settings=False, trust_project_settings=True)
+
+    assert calls == [str(mcp_file)]
+
+
+# ---------------------------------------------------------------------------
+# MIN-2: yolo kwarg flows through spec path
+# ---------------------------------------------------------------------------
+
+
+async def test_create_agent_agentspec_yolo_kwargs_applied(monkeypatch):
+    """MIN-2: yolo=True on AgentSpec must pass PROVIDER_YOLO_KWARGS to iModel."""
+    import lionagi.cli._providers as providers_mod
+    import lionagi.service.imodel as imodel_mod
+
+    monkeypatch.setitem(providers_mod.PROVIDER_EFFORT_KWARG, "openai", "reasoning_effort")
+    monkeypatch.setitem(providers_mod.PROVIDER_YOLO_KWARGS, "openai", {"stream": True})
+
+    captured: dict = {}
+    real_init = imodel_mod.iModel.__init__
+
+    def spy_init(self, *args, **kwargs):
+        captured.update(kwargs)
+        real_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(imodel_mod.iModel, "__init__", spy_init)
+
+    spec = AgentSpec.compose("analyst", model="openai/gpt-4.1-mini")
+    import dataclasses
+
+    spec = dataclasses.replace(spec, yolo=True)
+    branch = await create_agent(spec, load_settings=False)
+    assert isinstance(branch, Branch)
+    assert captured.get("stream") is True

--- a/tests/casts/test_profile.py
+++ b/tests/casts/test_profile.py
@@ -1,0 +1,229 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Profile (lionagi/casts/profile.py) and list_roles/list_modes."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from lionagi.casts.pattern import Mode, Role, list_modes, list_roles
+from lionagi.casts.profile import Profile
+
+ROLES_DIR = Path(__file__).parent.parent.parent / "lionagi" / "casts" / "roles"
+MODES_DIR = ROLES_DIR / "modes"
+
+
+# ---------------------------------------------------------------------------
+# list_roles
+# ---------------------------------------------------------------------------
+
+
+def test_list_roles_excludes_template():
+    roles = list_roles()
+    assert "TEMPLATE" not in roles
+
+
+def test_list_roles_excludes_modes_dir():
+    roles = list_roles()
+    assert "modes" not in roles
+
+
+def test_list_roles_includes_known_roles():
+    roles = list_roles()
+    for expected in ("analyst", "critic", "implementer", "researcher", "reviewer"):
+        assert expected in roles, f"{expected!r} not in list_roles()"
+
+
+def test_list_roles_is_sorted():
+    roles = list_roles()
+    assert roles == sorted(roles)
+
+
+def test_list_roles_matches_disk_stems():
+    disk = sorted(p.stem for p in ROLES_DIR.glob("*.md") if p.stem != "TEMPLATE")
+    assert list_roles() == disk
+
+
+def test_list_roles_user_dir_merge(tmp_path, monkeypatch):
+    user_roles = tmp_path / ".lionagi" / "roles"
+    user_roles.mkdir(parents=True)
+    (user_roles / "my_custom_role.md").write_text("custom")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    roles = list_roles()
+    assert "my_custom_role" in roles
+
+
+# ---------------------------------------------------------------------------
+# list_modes
+# ---------------------------------------------------------------------------
+
+
+def test_list_modes_includes_known_modes():
+    modes = list_modes()
+    for expected in ("adversarial", "fast", "slow", "systematic", "evidential"):
+        assert expected in modes, f"{expected!r} not in list_modes()"
+
+
+def test_list_modes_is_sorted():
+    modes = list_modes()
+    assert modes == sorted(modes)
+
+
+def test_list_modes_matches_disk_stems():
+    disk = sorted(p.stem for p in MODES_DIR.glob("*.md"))
+    assert list_modes() == disk
+
+
+def test_list_modes_user_dir_merge(tmp_path, monkeypatch):
+    user_modes = tmp_path / ".lionagi" / "modes"
+    user_modes.mkdir(parents=True)
+    (user_modes / "my_mode.md").write_text("mode")
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    modes = list_modes()
+    assert "my_mode" in modes
+
+
+# ---------------------------------------------------------------------------
+# Profile.compose
+# ---------------------------------------------------------------------------
+
+
+def test_profile_compose_by_name():
+    p = Profile.compose("analyst")
+    assert p.name == "analyst"
+    assert isinstance(p.role, Role)
+    assert p.modes == ()
+
+
+def test_profile_compose_by_role_object():
+    role = Role.load("critic")
+    p = Profile.compose(role)
+    assert p.role is role
+    assert p.name == "critic"
+
+
+def test_profile_compose_modes_by_name():
+    p = Profile.compose("researcher", modes=["evidential", "systematic"])
+    assert len(p.modes) == 2
+    assert p.modes[0].name == "evidential"
+    assert p.modes[1].name == "systematic"
+
+
+def test_profile_compose_modes_by_object():
+    m = Mode.load("adversarial")
+    p = Profile.compose("critic", modes=[m])
+    assert p.modes[0] is m
+
+
+def test_profile_compose_custom_name():
+    p = Profile.compose("analyst", name="my-analyst")
+    assert p.name == "my-analyst"
+
+
+# ---------------------------------------------------------------------------
+# Profile conflict rejection
+# ---------------------------------------------------------------------------
+
+
+def test_profile_conflict_fast_slow_raises():
+    with pytest.raises(ValueError, match="conflict"):
+        Profile.compose("researcher", modes=["fast", "slow"])
+
+
+def test_profile_conflict_fast_systematic_raises():
+    with pytest.raises(ValueError, match="conflict"):
+        Profile.compose("researcher", modes=["fast", "systematic"])
+
+
+def test_profile_no_conflict_evidential_adversarial():
+    p = Profile.compose("critic", modes=["evidential", "adversarial"])
+    assert len(p.modes) == 2
+
+
+# ---------------------------------------------------------------------------
+# Profile.capabilities
+# ---------------------------------------------------------------------------
+
+
+def test_profile_capabilities_delegates():
+    from lionagi.casts.capabilities import capability_models
+
+    p = Profile.compose("critic")
+    assert p.capabilities == capability_models("critic")
+
+
+def test_profile_capabilities_unknown_role_returns_tuple():
+    p = Profile.compose("analyst")
+    caps = p.capabilities
+    assert isinstance(caps, tuple)
+    assert len(caps) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Profile.build_system_message
+# ---------------------------------------------------------------------------
+
+
+def test_profile_build_system_message_includes_role_body():
+    p = Profile.compose("analyst")
+    msg = p.build_system_message()
+    assert p.role.body in msg
+
+
+def test_profile_build_system_message_includes_mode_behaviors():
+    p = Profile.compose("analyst", modes=["adversarial"])
+    msg = p.build_system_message()
+    adv = Mode.load("adversarial")
+    assert adv.behaviors in msg
+
+
+def test_profile_build_system_message_blank_line_separator():
+    p = Profile.compose("analyst", modes=["adversarial"])
+    msg = p.build_system_message()
+    assert "\n\n" in msg
+
+
+def test_profile_build_system_message_no_modes():
+    p = Profile.compose("analyst")
+    msg = p.build_system_message()
+    assert msg == p.role.body
+
+
+# ---------------------------------------------------------------------------
+# Profile.from_yaml
+# ---------------------------------------------------------------------------
+
+
+def test_profile_from_yaml_round_trip(tmp_path):
+    data = {"name": "test-profile", "role": "analyst", "modes": ["evidential"]}
+    yaml_file = tmp_path / "profile.yaml"
+    yaml_file.write_text(yaml.dump(data))
+
+    p = Profile.from_yaml(yaml_file)
+    assert p.name == "test-profile"
+    assert p.role.name == "analyst"
+    assert len(p.modes) == 1
+    assert p.modes[0].name == "evidential"
+
+
+def test_profile_from_yaml_no_modes(tmp_path):
+    data = {"name": "bare", "role": "critic"}
+    yaml_file = tmp_path / "bare.yaml"
+    yaml_file.write_text(yaml.dump(data))
+
+    p = Profile.from_yaml(yaml_file)
+    assert p.modes == ()
+
+
+# ---------------------------------------------------------------------------
+# Profile is frozen
+# ---------------------------------------------------------------------------
+
+
+def test_profile_is_frozen():
+    p = Profile.compose("analyst")
+    with pytest.raises(AttributeError):
+        p.name = "other"  # type: ignore[misc]

--- a/tests/casts/test_profile.py
+++ b/tests/casts/test_profile.py
@@ -73,8 +73,57 @@ def test_list_modes_is_sorted():
 
 
 def test_list_modes_matches_disk_stems():
-    disk = sorted(p.stem for p in MODES_DIR.glob("*.md"))
+    disk = sorted(p.stem for p in MODES_DIR.glob("*.md") if p.stem != "TEMPLATE")
     assert list_modes() == disk
+
+
+def test_list_modes_excludes_template(monkeypatch):
+    """MIN-1: list_modes must exclude TEMPLATE.md, symmetric with list_roles.
+
+    We inject a fake TEMPLATE.md item into the iterable at the pattern module
+    level to avoid recursion in importlib.resources mocking.
+    """
+    from importlib.resources import files
+
+    import lionagi.casts.pattern as pattern_mod
+
+    real_pkg = files("lionagi.casts").joinpath("roles", "modes")
+
+    class _FakeItem:
+        def __init__(self, name: str):
+            self.name = name
+
+    class _FakePkgWithTemplate:
+        def iterdir(self):
+            real_items = list(real_pkg.iterdir())
+            return iter(real_items + [_FakeItem("TEMPLATE.md")])
+
+    fake_pkg = _FakePkgWithTemplate()
+
+    _real_files = pattern_mod.__builtins__  # keep for reference only
+
+    # Patch files() inside list_modes via monkeypatching the importlib call
+    # indirectly by replacing the joinpath result:
+    import importlib.resources as _ir
+
+    real_files_fn = _ir.files
+
+    def patched_files(package):
+        result = real_files_fn(package)
+
+        class _PatchedResult:
+            def joinpath(self, *parts):
+                inner = result.joinpath(*parts)
+                if parts == ("roles", "modes"):
+                    return fake_pkg
+                return inner
+
+        return _PatchedResult()
+
+    monkeypatch.setattr(_ir, "files", patched_files)
+
+    modes = list_modes()
+    assert "TEMPLATE" not in modes
 
 
 def test_list_modes_user_dir_merge(tmp_path, monkeypatch):


### PR DESCRIPTION
**PR 2 of 3** — stacked on #capabilities. Merge **after** PR 1.

## What
Layer 3 — the composition layer. `Profile` (pure identity = Role + Modes) and the universal `AgentSpec` (Profile + runtime concerns) every surface composes to.

- `lionagi/casts/profile.py` — frozen `Profile(name, role, modes)` with mode-conflict validation, `capabilities` property (delegates to Layer 1), `build_system_message`, `compose`, `from_yaml`.
- `lionagi/agent/spec.py` — `AgentSpec`: `compose`, `build_system_message` (+ RolePolicy escalation block), `capability_operable`, `from_config` (AgentConfig bridge).
- `lionagi/casts/pattern.py` — `list_roles()`, `list_modes()` (wheel-safe roster discovery).
- `lionagi/agent/factory.py` — `create_agent()` accepts AgentSpec **or** AgentConfig; existing AgentConfig path unchanged.

## Backward compat
AgentConfig path preserved. `create_agent(AgentSpec)` dispatches to a new internal builder.

## Verification
`tests/casts/test_profile.py`, `tests/agent/test_spec.py`, `tests/agent/test_factory.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)