### PR TITLE
feat(cli/agent): Layer 4 — CLI orchestration wiring (ADR-0073)

### DIFF
--- a/lionagi/agent/adapters/__init__.py
+++ b/lionagi/agent/adapters/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Provider-specific permission adapters.
+
+Translates a PermissionPolicy into endpoint kwargs understood by a CLI provider.
+v1 ships one adapter: claude_code.  Other providers (codex, openai) are future work.
+"""
+
+from __future__ import annotations
+
+from .claude_code import translate_permissions
+
+__all__ = ("translate_permissions",)

--- a/lionagi/agent/adapters/claude_code.py
+++ b/lionagi/agent/adapters/claude_code.py
@@ -3,6 +3,12 @@
 """Permission adapter for the claude_code provider.
 
 Other providers (codex, openai) are follow-up adapters — out of scope for v1.
+
+NOTE (MIN-1 — advisory): The ``safe`` preset carries ``escalate={"bash": ["*"]}``
+semantics, meaning bash *could* be approved interactively.  This adapter has no
+escalation channel so bash → deny in practice.  The RolePolicy block injected into
+the system message mentions escalation; enforcement cannot honour it.  This is
+documented as a known partial-parity limitation (ADR-0073 §5.2) and is advisory only.
 """
 
 from __future__ import annotations
@@ -14,14 +20,28 @@ if TYPE_CHECKING:
 
 __all__ = ("translate_permissions",)
 
-# Tool name → claude_code permission tool type string
-_TOOL_MAP: dict[str, str] = {
-    "editor": "edit",
-    "bash": "bash",
-    "reader": "read",
-    "search": "search",
-    "context": "mcp",
+# Lionagi zone → real claude CLI tool names (PascalCase, verified against
+# providers/anthropic/claude_code/models.py and
+# tests/service/connections/providers/test_cli_cancellation.py).
+# Each zone maps to ONE OR MORE real tool names — the adapter emits lists.
+#
+# Canonical claude tool vocabulary: Bash, Read, Edit, Write, Glob, Grep,
+# WebSearch, WebFetch, Task, NotebookEdit; MCP tools are mcp__<server>__<tool>.
+#
+# NOTE (MIN-2 — known/follow-up): For the API/native-tool path, lionagi
+# registers tools via ActionManager (register_tools) using zone names.  The
+# _TOOL_MAP below is only relevant to the claude_code CLI adapter; it has no
+# observable effect on the native-tool path.
+_TOOL_MAP: dict[str, list[str]] = {
+    "editor": ["Edit", "Write", "NotebookEdit"],
+    "bash": ["Bash"],
+    "reader": ["Read"],
+    "search": ["Grep", "Glob", "WebSearch", "WebFetch"],
+    "context": ["mcp__*"],
 }
+
+# Flat list of ALL real tool names covered by the map (used by deny_all).
+_ALL_CC_TOOLS: list[str] = [t for tools in _TOOL_MAP.values() for t in tools]
 
 
 def translate_permissions(policy: PermissionPolicy) -> dict:
@@ -29,34 +49,40 @@ def translate_permissions(policy: PermissionPolicy) -> dict:
 
     Maps:
       allow_all  → {"permission_mode": "bypassPermissions"}
-      read_only  → deny-list covering editor + bash tools
-      deny_all   → {"permission_mode": "default", "disallowed_tools": [all tools]}
-      rules      → maps allow/deny fnmatch patterns to claude_code allow/deny lists
+      read_only  → deny editor + bash; allow reader + search + context
+      safe       → deny bash; allow editor + reader + search + context
+      deny_all   → deny ALL real claude tool names (fail-closed)
+      rules      → maps allow/deny zone patterns to claude_code allow/deny lists
+
+    Tool names emitted here are the PascalCase names the claude CLI recognises
+    (e.g. "Bash", "Edit", "Write", "Read", "Glob", "Grep", "WebSearch",
+    "WebFetch", "NotebookEdit", "mcp__*").  Using lowercase or invented names
+    causes the CLI to silently ignore the restriction (fail-open).
     """
     if policy.mode == "allow_all":
         return {"permission_mode": "bypassPermissions"}
 
     if policy.mode == "deny_all":
-        # Deny every known tool class
+        # Deny every real claude tool — fail-closed.
         return {
             "permission_mode": "default",
-            "disallowed_tools": list(_TOOL_MAP.values()),
+            "disallowed_tools": list(_ALL_CC_TOOLS),
         }
 
     # rules mode — used by read_only and safe presets as well as custom policies
     allowed_tools: list[str] = []
     denied_tools: list[str] = []
 
-    # Build allow list: tool names that have explicit allow rules with a wildcard
-    for lion_name, cc_name in _TOOL_MAP.items():
+    # Build allow list: zones that have explicit allow rules with a wildcard
+    for lion_name, cc_names in _TOOL_MAP.items():
         patterns = policy.allow.get(lion_name, [])
         if "*" in patterns or any(p.strip() == "*" for p in patterns):
-            allowed_tools.append(cc_name)
+            allowed_tools.extend(cc_names)
 
-    # Build deny list: tool names that have explicit deny rules
-    for lion_name, cc_name in _TOOL_MAP.items():
+    # Build deny list: zones that have explicit deny rules
+    for lion_name, cc_names in _TOOL_MAP.items():
         if lion_name in policy.deny:
-            denied_tools.append(cc_name)
+            denied_tools.extend(cc_names)
 
     result: dict = {"permission_mode": "default"}
     if allowed_tools:

--- a/lionagi/agent/adapters/claude_code.py
+++ b/lionagi/agent/adapters/claude_code.py
@@ -25,22 +25,38 @@ __all__ = ("translate_permissions",)
 # tests/service/connections/providers/test_cli_cancellation.py).
 # Each zone maps to ONE OR MORE real tool names — the adapter emits lists.
 #
-# Canonical claude tool vocabulary: Bash, Read, Edit, Write, Glob, Grep,
-# WebSearch, WebFetch, Task, NotebookEdit; MCP tools are mcp__<server>__<tool>.
+# Parse-site evidence (models.py:619-657):
+#   editor zone: Edit, MultiEdit (multi-file edit — privilege-escalation risk)
+#   spawn  zone: Task            (spawns sub-agents — privilege-escalation risk)
+#   bash   zone: Bash
+#   reader zone: Read
+#   search zone: Grep, Glob, WebSearch, WebFetch
+#   context zone: mcp__* (MCP server tools)
+#   write  zone: Write, NotebookEdit
 #
 # NOTE (MIN-2 — known/follow-up): For the API/native-tool path, lionagi
 # registers tools via ActionManager (register_tools) using zone names.  The
 # _TOOL_MAP below is only relevant to the claude_code CLI adapter; it has no
 # observable effect on the native-tool path.
 _TOOL_MAP: dict[str, list[str]] = {
-    "editor": ["Edit", "Write", "NotebookEdit"],
+    "editor": ["Edit", "MultiEdit", "Write", "NotebookEdit"],
     "bash": ["Bash"],
     "reader": ["Read"],
     "search": ["Grep", "Glob", "WebSearch", "WebFetch"],
+    # spawn: sub-agent spawning — intentionally separate so it can be denied
+    # independently of other tool zones (e.g. safe preset denies bash+spawn).
+    "spawn": ["Task"],
     "context": ["mcp__*"],
 }
 
-# Flat list of ALL real tool names covered by the map (used by deny_all).
+# Flat list of ALL real tool names covered by the map — used as the
+# deny_all denylist.  deny_all is fail-closed BY ENUMERATION: it names every
+# tool this adapter knows about.  The guarantee is "all tools listed here are
+# blocked"; it cannot guarantee tools added to the claude CLI after this code
+# was written are also blocked (that would require an empty allowlist, but
+# the arg-builder in models.py:511 drops empty lists as falsy, so an empty
+# allowed_tools is silently omitted and would provide no additional coverage).
+# Conclusion: keep _TOOL_MAP current as new claude tool names are discovered.
 _ALL_CC_TOOLS: list[str] = [t for tools in _TOOL_MAP.values() for t in tools]
 
 
@@ -51,7 +67,7 @@ def translate_permissions(policy: PermissionPolicy) -> dict:
       allow_all  → {"permission_mode": "bypassPermissions"}
       read_only  → deny editor + bash; allow reader + search + context
       safe       → deny bash; allow editor + reader + search + context
-      deny_all   → deny ALL real claude tool names (fail-closed)
+      deny_all   → deny all tools enumerated in _TOOL_MAP (fail-closed for known vocabulary)
       rules      → maps allow/deny zone patterns to claude_code allow/deny lists
 
     Tool names emitted here are the PascalCase names the claude CLI recognises
@@ -63,7 +79,13 @@ def translate_permissions(policy: PermissionPolicy) -> dict:
         return {"permission_mode": "bypassPermissions"}
 
     if policy.mode == "deny_all":
-        # Deny every real claude tool — fail-closed.
+        # Deny every tool known to this adapter (see _ALL_CC_TOOLS / _TOOL_MAP).
+        # This is fail-closed for the enumerated vocabulary.  Note: an empty
+        # allowed_tools list cannot be used as an additional safety net because
+        # _build_declarative_args (models.py:511) drops empty lists as falsy —
+        # it would emit no --allowedTools flag at all, giving zero extra coverage.
+        # The correct response to a newly discovered claude tool not yet in
+        # _TOOL_MAP is to add it here; do not rely on a "deny-by-default" catch-all.
         return {
             "permission_mode": "default",
             "disallowed_tools": list(_ALL_CC_TOOLS),

--- a/lionagi/agent/adapters/claude_code.py
+++ b/lionagi/agent/adapters/claude_code.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Permission adapter for the claude_code provider.
+
+Other providers (codex, openai) are follow-up adapters — out of scope for v1.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lionagi.agent.permissions import PermissionPolicy
+
+__all__ = ("translate_permissions",)
+
+# Tool name → claude_code permission tool type string
+_TOOL_MAP: dict[str, str] = {
+    "editor": "edit",
+    "bash": "bash",
+    "reader": "read",
+    "search": "search",
+    "context": "mcp",
+}
+
+
+def translate_permissions(policy: PermissionPolicy) -> dict:
+    """Translate a PermissionPolicy to claude_code endpoint kwargs.
+
+    Maps:
+      allow_all  → {"permission_mode": "bypassPermissions"}
+      read_only  → deny-list covering editor + bash tools
+      deny_all   → {"permission_mode": "default", "disallowed_tools": [all tools]}
+      rules      → maps allow/deny fnmatch patterns to claude_code allow/deny lists
+    """
+    if policy.mode == "allow_all":
+        return {"permission_mode": "bypassPermissions"}
+
+    if policy.mode == "deny_all":
+        # Deny every known tool class
+        return {
+            "permission_mode": "default",
+            "disallowed_tools": list(_TOOL_MAP.values()),
+        }
+
+    # rules mode — used by read_only and safe presets as well as custom policies
+    allowed_tools: list[str] = []
+    denied_tools: list[str] = []
+
+    # Build allow list: tool names that have explicit allow rules with a wildcard
+    for lion_name, cc_name in _TOOL_MAP.items():
+        patterns = policy.allow.get(lion_name, [])
+        if "*" in patterns or any(p.strip() == "*" for p in patterns):
+            allowed_tools.append(cc_name)
+
+    # Build deny list: tool names that have explicit deny rules
+    for lion_name, cc_name in _TOOL_MAP.items():
+        if lion_name in policy.deny:
+            denied_tools.append(cc_name)
+
+    result: dict = {"permission_mode": "default"}
+    if allowed_tools:
+        result["allowed_tools"] = allowed_tools
+    if denied_tools:
+        result["disallowed_tools"] = denied_tools
+    return result

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -43,7 +43,7 @@ from lionagi.state.artifact_verifier import (
 )
 
 from .._agents import AgentProfile, load_agent_profile
-from .._logging import hint
+from .._logging import hint, warn
 from .._providers import build_imodel_from_spec, resolve_persisted_effort
 from .._runs import RunDir, allocate_run, save_last_branch_pointer
 
@@ -508,6 +508,16 @@ def build_worker_branch(
 
             _perm_kwargs = _tp(w_spec.permissions)
             w_imodel.endpoint.config.kwargs.update(_perm_kwargs)
+        else:
+            # MAJ-2: No permission adapter exists for this provider.  The policy
+            # was validated but cannot be enforced — the worker will have full
+            # tool access regardless of the preset.  Fail-open by design until a
+            # provider-specific adapter is implemented.
+            warn(
+                f"Worker {explicit_name or role!r} has permissions="
+                f"{w_spec.permissions.mode!r} but provider {_provider!r} has no "
+                "permission adapter — preset is unenforced. Worker runs unrestricted."
+            )
 
     # Team mode APPENDS the coord section — does not replace the base.
     team_section = team_worker_system(env.team_data, wname)

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -332,6 +332,8 @@ def build_worker_branch(
     model_override: str | None = None,
     explicit_name: str | None = None,
     system_prompt_override: str | None = None,
+    agent_modes: list[str] | None = None,
+    agent_permissions: str | None = None,
 ) -> tuple[Branch, str, AgentProfile | None]:
     """Phase C — resolve model/profile/effort/system and build a Branch.
 
@@ -420,13 +422,92 @@ def build_worker_branch(
     else:
         wname = env.assign_name(role)
 
-    # Base system prompt: explicit override > profile > BARE.
+    # ── AgentSpec fallback: casts role with no profile file ─────────
+    # Profile-file path (resolve_worker_spec hit) is the FIRST priority —
+    # preserved for backward compatibility.  Casts AgentSpec is used ONLY
+    # when no profile file matched AND the role is a known casts role.
+    w_spec: Any = None
+    if not env.bare and w_profile is None and system_prompt_override is None:
+        from lionagi.casts.pattern import list_roles as _list_roles
+
+        if role in set(_list_roles()):
+            from lionagi.agent.spec import AgentSpec as _AgentSpec
+
+            # Determine default tool suite by zone.
+            # Write-capable roles get the coding suite; discovery and verdict
+            # roles get read-only tools; others get nothing by default.
+            # Override by passing explicit tools via AgentSpec.compose if needed.
+            _write_roles = frozenset(
+                {
+                    "implementer",
+                    "refactorer",
+                    "migrator",
+                    "prototyper",
+                    "deployer",
+                    "operator",
+                    "writer",
+                    "scribe",
+                    "curator",
+                    "modeler",
+                    "architect",
+                }
+            )
+            _read_roles = frozenset(
+                {
+                    "researcher",
+                    "analyst",
+                    "explorer",
+                    "critic",
+                    "reviewer",
+                    "auditor",
+                    "investigator",
+                    "troubleshooter",
+                    "assessor",
+                    "contrarian",
+                    "commentator",
+                    "synthesizer",
+                }
+            )
+            if role in _write_roles:
+                _default_tools: tuple[str, ...] = ("coding",)
+            elif role in _read_roles:
+                _default_tools = ("reader", "search")
+            else:
+                _default_tools = ()
+
+            w_spec = _AgentSpec.compose(
+                role=role,
+                modes=agent_modes or [],
+                model=w_model,
+                effort=w_effort,
+                tools=_default_tools,
+                permissions=agent_permissions,
+            )
+
+    # Base system prompt: explicit override > profile > casts AgentSpec > BARE.
     if system_prompt_override is not None:
         base_system = system_prompt_override
     elif not env.bare and w_profile and w_profile.system_prompt:
         base_system = w_profile.system_prompt
+    elif w_spec is not None:
+        from lionagi.session.prompts import LION_SYSTEM_MESSAGE as _LION_SYS
+
+        base_system = _LION_SYS.strip() + "\n\n" + w_spec.build_system_message()
     else:
         base_system = BARE_WORKER_SYSTEM
+
+    # Apply permission adapter for claude_code provider when using casts path.
+    # The permission adapter translates the PermissionPolicy to endpoint kwargs
+    # that the claude_code backend enforces natively.  For lionagi-native tools
+    # (registered via ActionManager), the existing security_pre hook path
+    # applies instead.
+    if w_spec is not None and w_spec.permissions is not None:
+        _provider = w_model.split("/")[0] if "/" in w_model else w_model
+        if _provider in ("claude_code", "claude"):
+            from lionagi.agent.adapters.claude_code import translate_permissions as _tp
+
+            _perm_kwargs = _tp(w_spec.permissions)
+            w_imodel.endpoint.config.kwargs.update(_perm_kwargs)
 
     # Team mode APPENDS the coord section — does not replace the base.
     team_section = team_worker_system(env.team_data, wname)
@@ -439,6 +520,12 @@ def build_worker_branch(
         name=wname,
     )
     env.session.include_branches(wb)
+
+    # Grant capabilities for casts-path workers after session attachment.
+    # include_branches sets branch._observer so grant_capabilities can emit.
+    if w_spec is not None:
+        if op := w_spec.capability_operable():
+            wb.grant_capabilities(op)
 
     # Register live persist hook on this new branch
     if env._live_persist:

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -14,11 +14,12 @@ from pydantic import Field, field_validator
 
 from lionagi import Branch, FieldModel
 from lionagi._errors import TimeoutError as LionTimeoutError
+from lionagi.casts.pattern import Mode, Role, list_modes, list_roles
 from lionagi.ln.concurrency import move_on_after
 from lionagi.models import HashableModel
 from lionagi.operations.fields import Instruct
 
-from .._agents import AgentProfile, list_agents, load_agent_profile
+from .._agents import AgentProfile
 from .._logging import progress
 from .._providers import parse_model_spec
 from ._common import _create_fanout_team, _format_result_json, _post_results_to_team
@@ -243,6 +244,22 @@ class FlowAgent(HashableModel):
             "Role name from the available-agents roster (e.g. 'researcher', "
             "'implementer', 'critic'). Determines the agent's profile "
             "(system prompt, default model, effort). Do not invent roles."
+        ),
+    )
+    modes: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Cognitive overlays applied on top of the role, e.g. "
+            "['adversarial', 'systematic'].  Each entry must be a name "
+            "returned by list_modes().  Conflicting mode pairs are rejected "
+            "before execution."
+        ),
+    )
+    permissions: str | None = Field(
+        default=None,
+        description=(
+            "Permission preset for this worker: safe | read_only | "
+            "allow_all | deny_all.  Null inherits the flow default."
         ),
     )
     model: str | None = Field(
@@ -787,28 +804,47 @@ async def _run_flow_inner(
     builder = env.builder
 
     # ── Phase 0: Orchestrator plans the DAG ──────────────────────────
-    # Build role roster for orchestrator guidance
-    available_roles = list_agents()
+    # Build role roster from the casts ontology so the planner has
+    # structured signal: role descriptions, available modes, and the
+    # permission presets.  Profile-file agents still resolve normally in
+    # build_worker_branch; the planner just needs selection metadata.
+    _all_roles = list_roles()
+    _role_lines: list[str] = []
+    for _rname in _all_roles:
+        try:
+            _r = Role.load(_rname)
+            _desc = f" — {_r.description}" if _r.description else ""
+            _role_lines.append(f"  {_rname}{_desc}")
+        except Exception:
+            _role_lines.append(f"  {_rname}")
+    _all_modes = list_modes()
+    _mode_lines: list[str] = []
+    for _mname in _all_modes:
+        try:
+            _m = Mode.load(_mname)
+            _mdesc = f" — {_m.description}" if _m.description else ""
+            _mode_lines.append(f"  {_mname}{_mdesc}")
+        except Exception:
+            _mode_lines.append(f"  {_mname}")
+    _perm_lines = [
+        "  allow_all  — no restrictions (use for write-capable roles needing full tool access)",
+        "  read_only  — reader/search tools only; editor and bash denied",
+        "  safe       — read + edit allowed; dangerous bash patterns denied with escalation",
+        "  deny_all   — all tools denied (analysis-only)",
+    ]
+    roles_guidance = (
+        "AVAILABLE ROLES (set FlowAgent.role to one of these):\n"
+        + "\n".join(_role_lines)
+        + "\n\nAVAILABLE MODES (optional cognitive overlays — set FlowAgent.modes):\n"
+        + "\n".join(_mode_lines)
+        + "\n\nPERMISSION PRESETS (optional — set FlowAgent.permissions):\n"
+        + "\n".join(_perm_lines)
+    )
     if env.bare:
-        roles_guidance = (
-            f"Available roles: {', '.join(available_roles)}. "
-            f"All workers use model {model_spec}. "
-            f"Roles define behavioral focus only — model is fixed."
+        roles_guidance += (
+            f"\n\nAll workers use model {model_spec}. "
+            "Roles define behavioral focus only — model is fixed."
         )
-    else:
-        role_details = []
-        for role in available_roles:
-            try:
-                rp = load_agent_profile(role)
-                rm = rp.model or model_spec
-                detail = f"{role} (model: {rm}"
-                if rp.effort:
-                    detail += f", effort: {rp.effort}"
-                detail += ")"
-                role_details.append(detail)
-            except FileNotFoundError:
-                role_details.append(f"{role} (model: {model_spec})")
-        roles_guidance = f"Available agents: {'; '.join(role_details)}."
 
     budget_note = ""
     if max_ops > 0:
@@ -850,6 +886,19 @@ async def _run_flow_inner(
         reason=True,
     )
 
+    # ── Observer wiring: record escalations and verdicts ────────────
+    # v1: record only.  Reactive re-planning (e.g. observe Verdict REJECT →
+    # re-plan the DAG, or EscalationRequest → reassign the op) would hook in
+    # here by updating `plan` or emitting a control directive on the session.
+    from lionagi.casts.capabilities import EscalationRequest, Verdict
+
+    _escalations: list = []
+    _verdicts: list = []
+
+    if hasattr(session, "observe"):
+        session.observe(EscalationRequest, lambda e, _ctx: _escalations.append(e))
+        session.observe(Verdict, lambda v, _ctx: _verdicts.append(v))
+
     progress("Planning DAG...")
 
     result0 = await session.flow(builder.get_graph())
@@ -887,6 +936,41 @@ async def _run_flow_inner(
                 f"Invalid plan: op {op.id!r} references unknown agent "
                 f"{op.agent_id!r} (known: {sorted(agent_ids)})"
             )
+
+    # Validate FlowAgent.modes and permissions — fail closed before any
+    # agent time is spent, same stance as the dep-cycle check above.
+    known_modes = set(list_modes())
+    known_roles = set(list_roles())
+    for a in plan.agents:
+        # Unknown role check (skip bare-model specs containing '/')
+        if "/" not in a.role and a.role not in known_roles:
+            return (
+                f"Invalid plan: FlowAgent {a.id!r} has unknown role {a.role!r}. "
+                f"Known roles: {sorted(known_roles)}"
+            )
+        # Unknown modes
+        for m in a.modes:
+            if m not in known_modes:
+                return (
+                    f"Invalid plan: FlowAgent {a.id!r} has unknown mode {m!r}. "
+                    f"Known modes: {sorted(known_modes)}"
+                )
+        # Mode conflict check: reuse Profile.__post_init__ logic
+        if a.modes:
+            try:
+                from lionagi.casts.profile import Profile as _Profile
+
+                _Profile.compose(role=a.role if "/" not in a.role else "implementer", modes=a.modes)
+            except ValueError as exc:
+                return f"Invalid plan: FlowAgent {a.id!r} has conflicting modes — {exc}"
+        # Unknown permission preset
+        if a.permissions is not None:
+            _valid_presets = {"safe", "read_only", "allow_all", "deny_all"}
+            if a.permissions not in _valid_presets:
+                return (
+                    f"Invalid plan: FlowAgent {a.id!r} has unknown permissions preset "
+                    f"{a.permissions!r}. Valid: {sorted(_valid_presets)}"
+                )
 
     # Reject plans exceeding the hard op count cap before sorting.
     if len(plan.operations) > 200:
@@ -1019,6 +1103,8 @@ async def _run_flow_inner(
             role=a.role,
             model_override=a.model,
             explicit_name=agent_id_to_name[a.id],
+            agent_modes=a.modes or None,
+            agent_permissions=a.permissions,
         )
 
     # ── Helper: build context + add a node for a single op ──────────

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -941,13 +941,30 @@ async def _run_flow_inner(
     # agent time is spent, same stance as the dep-cycle check above.
     known_modes = set(list_modes())
     known_roles = set(list_roles())
+    # Profile-only agents live in ~/.lionagi/agents/ (a DIFFERENT namespace from
+    # casts roles).  The ADR-0073 guarantee is that existing flows keep working,
+    # so we accept a role that resolves via list_agents() even when it is not a
+    # casts role.  list_agents() is imported lazily to avoid the filesystem scan
+    # for plans that use only casts roles.
+    _known_profile_agents: set[str] | None = None
+
+    def _get_known_agents() -> set[str]:
+        nonlocal _known_profile_agents
+        if _known_profile_agents is None:
+            from lionagi.cli._agents import list_agents as _list_agents
+
+            _known_profile_agents = set(_list_agents())
+        return _known_profile_agents
+
     for a in plan.agents:
-        # Unknown role check (skip bare-model specs containing '/')
+        # Unknown role check (skip bare-model specs containing '/').
+        # Accept: (1) known casts role, OR (2) known profile-only agent name.
         if "/" not in a.role and a.role not in known_roles:
-            return (
-                f"Invalid plan: FlowAgent {a.id!r} has unknown role {a.role!r}. "
-                f"Known roles: {sorted(known_roles)}"
-            )
+            if a.role not in _get_known_agents():
+                return (
+                    f"Invalid plan: FlowAgent {a.id!r} has unknown role {a.role!r}. "
+                    f"Known roles: {sorted(known_roles)}"
+                )
         # Unknown modes
         for m in a.modes:
             if m not in known_modes:
@@ -955,7 +972,13 @@ async def _run_flow_inner(
                     f"Invalid plan: FlowAgent {a.id!r} has unknown mode {m!r}. "
                     f"Known modes: {sorted(known_modes)}"
                 )
-        # Mode conflict check: reuse Profile.__post_init__ logic
+        # Mode conflict check: reuse Profile.__post_init__ logic.
+        # For bare-model specs (containing '/') we substitute "implementer" as the
+        # placeholder role because mode conflicts (e.g. fast vs slow) are
+        # role-independent in the current ontology — no mode is accepted or rejected
+        # based on which specific role is being composed.  The substitution is
+        # therefore sound: it catches real conflicts without masking any role-specific
+        # constraint that does not yet exist.
         if a.modes:
             try:
                 from lionagi.casts.profile import Profile as _Profile

--- a/tests/cli/orchestrate/test_layer4_wiring.py
+++ b/tests/cli/orchestrate/test_layer4_wiring.py
@@ -54,9 +54,10 @@ class _FakeSession:
     def __init__(self, builder, plan):
         self.builder = builder
         self.plan = plan
+        self.observed_types: list = []
 
     def observe(self, event_type, handler):
-        pass  # no-op for testing
+        self.observed_types.append(event_type)
 
     async def flow(self, _graph, **_kwargs):
         plan_root = self.builder.added[0]["id"]
@@ -145,6 +146,11 @@ async def test_plan_accepts_valid_agent_with_modes_and_permissions(tmp_path):
     result = await _run_flow_inner("codex/gpt-5.5", "task", env=env, dry_run=True)
     # Should NOT be an "Invalid plan" error
     assert "Invalid plan" not in result
+    # _run_flow_inner must have registered EscalationRequest and Verdict observers
+    from lionagi.casts.capabilities import EscalationRequest, Verdict
+
+    assert EscalationRequest in env.session.observed_types
+    assert Verdict in env.session.observed_types
 
 
 # ── Planner roster includes roles, modes, permissions ───────────────────────

--- a/tests/cli/orchestrate/test_layer4_wiring.py
+++ b/tests/cli/orchestrate/test_layer4_wiring.py
@@ -197,7 +197,14 @@ def test_translate_permissions_deny_all():
     result = translate_permissions(PermissionPolicy.deny_all())
     assert result["permission_mode"] == "default"
     assert "disallowed_tools" in result
-    assert len(result["disallowed_tools"]) > 0
+    denied = result["disallowed_tools"]
+    assert len(denied) > 0
+    # Must use real PascalCase tool names that the claude CLI recognises.
+    # Lowercase names (bash/edit/read) are silently ignored → fail-open.
+    assert "Bash" in denied
+    assert "Edit" in denied
+    assert "Read" in denied
+    assert "Write" in denied
 
 
 def test_translate_permissions_read_only():
@@ -206,9 +213,12 @@ def test_translate_permissions_read_only():
 
     result = translate_permissions(PermissionPolicy.read_only())
     assert result["permission_mode"] == "default"
-    # editor and bash should be denied
+    # editor and bash should be denied with real PascalCase names
     denied = result.get("disallowed_tools", [])
-    assert "edit" in denied or "bash" in denied
+    assert "Edit" in denied or "Bash" in denied
+    # Confirm no stale lowercase names that the CLI won't honour
+    assert "edit" not in denied
+    assert "bash" not in denied
 
 
 def test_translate_permissions_rules_custom():
@@ -224,8 +234,55 @@ def test_translate_permissions_rules_custom():
     assert result["permission_mode"] == "default"
     allowed = result.get("allowed_tools", [])
     denied = result.get("disallowed_tools", [])
-    assert "read" in allowed
-    assert "bash" in denied
+    # reader zone → "Read" (PascalCase)
+    assert "Read" in allowed
+    assert "read" not in allowed  # no stale lowercase
+    # bash zone → "Bash" (PascalCase)
+    assert "Bash" in denied
+    assert "bash" not in denied  # no stale lowercase
+
+
+def test_translate_permissions_tool_names_are_real_claude_vocabulary():
+    """Emitted tool names must be a subset of the real claude CLI vocabulary.
+
+    This test catches the fail-open bug where invented or lowercase names are
+    passed to --disallowedTools / --allowedTools and silently ignored by the
+    claude binary.  Canonical PascalCase names are from:
+      - providers/anthropic/claude_code/models.py  (ClaudeCodeRequest fields)
+      - tests/service/connections/providers/test_cli_cancellation.py (live usage)
+    """
+    from lionagi.agent.adapters.claude_code import _ALL_CC_TOOLS, translate_permissions
+    from lionagi.agent.permissions import PermissionPolicy
+
+    # Real PascalCase tool names the claude CLI honours.  "mcp__*" is a glob
+    # used for MCP servers; its prefix "mcp__" is the canonical prefix.
+    _KNOWN_CC_TOOLS = {
+        "Bash",
+        "Read",
+        "Edit",
+        "Write",
+        "Glob",
+        "Grep",
+        "WebSearch",
+        "WebFetch",
+        "Task",
+        "NotebookEdit",
+    }
+
+    # Every tool name baked into _ALL_CC_TOOLS must be either a known real name
+    # or the MCP glob pattern.
+    for tool in _ALL_CC_TOOLS:
+        assert tool in _KNOWN_CC_TOOLS or tool.startswith("mcp__"), (
+            f"_ALL_CC_TOOLS contains {tool!r} which is not a real claude CLI tool "
+            "name.  This would cause --disallowedTools to silently ignore it (fail-open)."
+        )
+
+    # Spot-check: deny_all must not emit any invented/lowercase names.
+    deny_result = translate_permissions(PermissionPolicy.deny_all())
+    for tool in deny_result.get("disallowed_tools", []):
+        assert tool in _KNOWN_CC_TOOLS or tool.startswith("mcp__"), (
+            f"deny_all emits {tool!r} — not a real claude CLI tool name (fail-open)"
+        )
 
 
 # ── build_worker_branch: profile path unchanged ──────────────────────────────
@@ -412,3 +469,111 @@ async def test_observer_wiring_records_escalation_request(tmp_path):
 
     assert len(escalations) == 1
     assert escalations[0].reason == "test escalation"
+
+
+# ── MAJ-1: profile-only role survives _run_flow_inner validation ─────────────
+
+
+@pytest.mark.asyncio
+async def test_plan_accepts_profile_only_role(tmp_path):
+    """A role not in casts list_roles() but present in list_agents() must pass
+    validation.  Contradicting this was the MAJ-1 regression — the role gate
+    was hard-rejecting profile-only agents before build_worker_branch ran.
+
+    ADR-0073 guarantees existing flows keep working; profile-only roles were
+    previously accepted via the profile resolution path.
+    """
+    from unittest.mock import patch
+
+    from lionagi.cli.orchestrate.flow import FlowOp
+
+    plan = FlowPlan(
+        agents=[FlowAgent(id="a1", role="my_custom_profile_agent")],
+        operations=[FlowOp(id="o1", agent_id="a1", instruction="do work")],
+    )
+    builder = _FakeBuilder()
+    env = _make_env(builder, plan, tmp_path)
+
+    # "my_custom_profile_agent" is NOT a casts role, but IS a known profile agent.
+    # list_roles is imported at module level in flow.py; list_agents is imported
+    # lazily inside _get_known_agents so we patch it at its definition site.
+    with patch(
+        "lionagi.cli.orchestrate.flow.list_roles", return_value=["implementer", "researcher"]
+    ):
+        with patch(
+            "lionagi.cli.orchestrate.flow.list_modes",
+            return_value=["adversarial", "systematic", "fast", "slow"],
+        ):
+            with patch(
+                "lionagi.cli._agents.list_agents",
+                return_value=["my_custom_profile_agent"],
+            ):
+                result = await _run_flow_inner("codex/gpt-5.5", "task", env=env, dry_run=True)
+
+    # Must NOT produce an "Invalid plan" role-rejection error.
+    assert "unknown role" not in result.lower(), f"Profile-only role was rejected: {result!r}"
+    assert "Invalid plan" not in result or "unknown role" not in result
+
+
+# ── MAJ-2: warn on non-claude provider with permissions set ─────────────────
+
+
+def test_build_worker_branch_warns_unenforced_permissions_non_claude(tmp_path, capsys):
+    """build_worker_branch must emit a warn() when permissions is set on a
+    non-claude provider (no adapter → policy silently dropped → fail-open).
+    """
+    import logging
+    from unittest.mock import patch
+
+    orc_branch = Branch(name="orchestrator")
+    session = Session(default_branch=orc_branch)
+    run_mock = MagicMock()
+    run_mock.agent_artifact_dir.return_value = tmp_path / "artifacts" / "a1"
+    (tmp_path / "artifacts" / "a1").mkdir(parents=True, exist_ok=True)
+
+    env = OrchestrationEnv(
+        run=run_mock,
+        session=session,
+        orc_branch=orc_branch,
+        builder=MagicMock(),
+        orc_profile=None,
+        # codex provider — no permission adapter
+        default_model_spec="codex/gpt-4.1",
+        bare=False,
+        effort=None,
+        theme=None,
+        yolo=False,
+        bypass=False,
+        verbose=False,
+        fast=False,
+        cwd=None,
+    )
+
+    warn_records: list[str] = []
+
+    with patch(
+        "lionagi.cli.orchestrate._orchestration.load_agent_profile",
+        side_effect=FileNotFoundError("no profile"),
+    ):
+        with patch(
+            "lionagi.cli.orchestrate._orchestration.warn",
+            side_effect=lambda msg: warn_records.append(msg),
+        ) as mock_warn:
+            build_worker_branch(
+                env,
+                agent_id="a1",
+                role="researcher",
+                model_override=None,
+                explicit_name="researcher-1",
+                agent_permissions="deny_all",
+            )
+
+    assert mock_warn.called, (
+        "Expected warn() to be called for non-claude provider with permissions set"
+    )
+    combined = " ".join(warn_records).lower()
+    assert (
+        "unenforced" in combined
+        or "no permission adapter" in combined
+        or "unrestricted" in combined
+    )

--- a/tests/cli/orchestrate/test_layer4_wiring.py
+++ b/tests/cli/orchestrate/test_layer4_wiring.py
@@ -203,6 +203,8 @@ def test_translate_permissions_deny_all():
     # Lowercase names (bash/edit/read) are silently ignored → fail-open.
     assert "Bash" in denied
     assert "Edit" in denied
+    assert "MultiEdit" in denied  # multi-file edit: privilege-escalation risk
+    assert "Task" in denied  # sub-agent spawn: privilege-escalation risk
     assert "Read" in denied
     assert "Write" in denied
 
@@ -256,10 +258,12 @@ def test_translate_permissions_tool_names_are_real_claude_vocabulary():
 
     # Real PascalCase tool names the claude CLI honours.  "mcp__*" is a glob
     # used for MCP servers; its prefix "mcp__" is the canonical prefix.
+    # MultiEdit and Task sourced from models.py:629,647 parse-site evidence.
     _KNOWN_CC_TOOLS = {
         "Bash",
         "Read",
         "Edit",
+        "MultiEdit",
         "Write",
         "Glob",
         "Grep",
@@ -283,6 +287,36 @@ def test_translate_permissions_tool_names_are_real_claude_vocabulary():
         assert tool in _KNOWN_CC_TOOLS or tool.startswith("mcp__"), (
             f"deny_all emits {tool!r} — not a real claude CLI tool name (fail-open)"
         )
+
+
+def test_translate_permissions_deny_all_covers_dangerous_tools():
+    """deny_all must block every dangerous tool the parse-site recognises.
+
+    The dangerous tools are those that write files (Edit, MultiEdit, Write,
+    NotebookEdit), execute shell commands (Bash), and spawn sub-agents (Task).
+    This is a COMPLETENESS check: the denylist must be a SUPERSET of these names.
+    A subset check (vocabulary test) is necessary but not sufficient; this test
+    catches omissions like MultiEdit or Task being left off the denylist.
+
+    Source for the dangerous tool list:
+      providers/anthropic/claude_code/models.py:629,634,647
+      (parse-site recognises Edit/MultiEdit, Bash, Task/Agent)
+    """
+    from lionagi.agent.adapters.claude_code import translate_permissions
+    from lionagi.agent.permissions import PermissionPolicy
+
+    # Minimum set that deny_all MUST block — add new dangerous tools here as
+    # the claude CLI adds them.
+    _DANGEROUS_TOOLS = {"Edit", "MultiEdit", "Write", "NotebookEdit", "Bash", "Task"}
+
+    result = translate_permissions(PermissionPolicy.deny_all())
+    denied = set(result.get("disallowed_tools", []))
+
+    missing = _DANGEROUS_TOOLS - denied
+    assert not missing, (
+        f"deny_all is non-exhaustive for dangerous tools — missing: {sorted(missing)}. "
+        "Add them to the appropriate zone in _TOOL_MAP in claude_code.py."
+    )
 
 
 # ── build_worker_branch: profile path unchanged ──────────────────────────────

--- a/tests/cli/orchestrate/test_layer4_wiring.py
+++ b/tests/cli/orchestrate/test_layer4_wiring.py
@@ -1,0 +1,408 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for Layer 4 — CLI orchestration wiring (ADR-0073)."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from lionagi import Branch, Session
+from lionagi.cli.orchestrate._orchestration import (
+    OrchestrationEnv,
+    build_worker_branch,
+    resolve_worker_spec,
+)
+from lionagi.cli.orchestrate.flow import FlowAgent, FlowPlan, _run_flow_inner
+
+# ── FlowAgent field parsing ──────────────────────────────────────────────────
+
+
+def test_flowagent_accepts_modes_and_permissions():
+    a = FlowAgent(id="i1", role="implementer", modes=["adversarial"], permissions="read_only")
+    assert a.modes == ["adversarial"]
+    assert a.permissions == "read_only"
+
+
+def test_flowagent_modes_default_empty():
+    a = FlowAgent(id="r1", role="researcher")
+    assert a.modes == []
+    assert a.permissions is None
+
+
+# ── Plan validation: unknown role ────────────────────────────────────────────
+
+
+class _FakeBuilder:
+    def __init__(self):
+        self.added = []
+
+    def add_operation(self, operation, **kwargs):
+        node_id = f"node-{len(self.added) + 1}"
+        self.added.append({"id": node_id, "operation": operation, "kwargs": kwargs})
+        return node_id
+
+    def get_graph(self):
+        return object()
+
+
+class _FakeSession:
+    def __init__(self, builder, plan):
+        self.builder = builder
+        self.plan = plan
+
+    def observe(self, event_type, handler):
+        pass  # no-op for testing
+
+    async def flow(self, _graph, **_kwargs):
+        plan_root = self.builder.added[0]["id"]
+        return {"operation_results": {plan_root: SimpleNamespace(plan=self.plan)}}
+
+
+def _make_env(builder, plan, tmp_path):
+    return SimpleNamespace(
+        run=SimpleNamespace(
+            artifact_root=tmp_path,
+            dag_image_path=tmp_path / "dag.png",
+        ),
+        session=_FakeSession(builder, plan),
+        orc_branch=SimpleNamespace(id=uuid4()),
+        builder=builder,
+        bare=True,
+        effort=None,
+        verbose=False,
+        team_data=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_plan_rejects_unknown_mode(tmp_path):
+    plan = FlowPlan(
+        agents=[FlowAgent(id="a1", role="researcher", modes=["nonexistent_mode_xyz"])],
+        operations=[],
+    )
+    # Need at least one op for the plan to be non-empty
+    from lionagi.cli.orchestrate.flow import FlowOp
+
+    plan.operations = [FlowOp(id="o1", agent_id="a1", instruction="do it")]
+    builder = _FakeBuilder()
+    env = _make_env(builder, plan, tmp_path)
+    result = await _run_flow_inner("codex/gpt-5.5", "task", env=env, dry_run=True)
+    assert "Invalid plan" in result
+    assert "unknown mode" in result.lower() or "nonexistent_mode_xyz" in result
+
+
+@pytest.mark.asyncio
+async def test_plan_rejects_conflicting_modes(tmp_path):
+    # fast and slow conflict with each other
+    plan = FlowPlan(
+        agents=[FlowAgent(id="a1", role="researcher", modes=["fast", "slow"])],
+        operations=[],
+    )
+    from lionagi.cli.orchestrate.flow import FlowOp
+
+    plan.operations = [FlowOp(id="o1", agent_id="a1", instruction="do it")]
+    builder = _FakeBuilder()
+    env = _make_env(builder, plan, tmp_path)
+    result = await _run_flow_inner("codex/gpt-5.5", "task", env=env, dry_run=True)
+    assert "Invalid plan" in result
+    assert "conflict" in result.lower() or "mode" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_plan_rejects_unknown_permissions_preset(tmp_path):
+    plan = FlowPlan(
+        agents=[FlowAgent(id="a1", role="researcher", permissions="super_yolo")],
+        operations=[],
+    )
+    from lionagi.cli.orchestrate.flow import FlowOp
+
+    plan.operations = [FlowOp(id="o1", agent_id="a1", instruction="do it")]
+    builder = _FakeBuilder()
+    env = _make_env(builder, plan, tmp_path)
+    result = await _run_flow_inner("codex/gpt-5.5", "task", env=env, dry_run=True)
+    assert "Invalid plan" in result
+    assert "permissions" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_plan_accepts_valid_agent_with_modes_and_permissions(tmp_path):
+    plan = FlowPlan(
+        agents=[
+            FlowAgent(id="a1", role="researcher", modes=["systematic"], permissions="read_only")
+        ],
+        operations=[],
+    )
+    from lionagi.cli.orchestrate.flow import FlowOp
+
+    plan.operations = [FlowOp(id="o1", agent_id="a1", instruction="research topic")]
+    builder = _FakeBuilder()
+    env = _make_env(builder, plan, tmp_path)
+    result = await _run_flow_inner("codex/gpt-5.5", "task", env=env, dry_run=True)
+    # Should NOT be an "Invalid plan" error
+    assert "Invalid plan" not in result
+
+
+# ── Planner roster includes roles, modes, permissions ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_planner_roster_contains_roles_modes_permissions(tmp_path):
+    """The plan root guidance should contain casts role/mode names and presets."""
+    plan = FlowPlan(
+        agents=[FlowAgent(id="a1", role="researcher")],
+        operations=[],
+    )
+    from lionagi.cli.orchestrate.flow import FlowOp
+
+    plan.operations = [FlowOp(id="o1", agent_id="a1", instruction="research")]
+    builder = _FakeBuilder()
+    env = _make_env(builder, plan, tmp_path)
+    # Run dry-run — we just need the builder to have been called with guidance
+    await _run_flow_inner("codex/gpt-5.5", "task", env=env, dry_run=True)
+
+    # Inspect the guidance passed to the planner operation
+    assert len(builder.added) >= 1
+    guidance = builder.added[0]["kwargs"].get("instruct", SimpleNamespace(guidance="")).guidance
+    assert "researcher" in guidance
+    assert "adversarial" in guidance  # a known mode
+    assert "allow_all" in guidance  # a known permission preset
+
+
+# ── claude_code adapter ──────────────────────────────────────────────────────
+
+
+def test_translate_permissions_allow_all():
+    from lionagi.agent.adapters.claude_code import translate_permissions
+    from lionagi.agent.permissions import PermissionPolicy
+
+    result = translate_permissions(PermissionPolicy.allow_all())
+    assert result == {"permission_mode": "bypassPermissions"}
+
+
+def test_translate_permissions_deny_all():
+    from lionagi.agent.adapters.claude_code import translate_permissions
+    from lionagi.agent.permissions import PermissionPolicy
+
+    result = translate_permissions(PermissionPolicy.deny_all())
+    assert result["permission_mode"] == "default"
+    assert "disallowed_tools" in result
+    assert len(result["disallowed_tools"]) > 0
+
+
+def test_translate_permissions_read_only():
+    from lionagi.agent.adapters.claude_code import translate_permissions
+    from lionagi.agent.permissions import PermissionPolicy
+
+    result = translate_permissions(PermissionPolicy.read_only())
+    assert result["permission_mode"] == "default"
+    # editor and bash should be denied
+    denied = result.get("disallowed_tools", [])
+    assert "edit" in denied or "bash" in denied
+
+
+def test_translate_permissions_rules_custom():
+    from lionagi.agent.adapters.claude_code import translate_permissions
+    from lionagi.agent.permissions import PermissionPolicy
+
+    policy = PermissionPolicy(
+        mode="rules",
+        allow={"reader": ["*"]},
+        deny={"bash": ["*"]},
+    )
+    result = translate_permissions(policy)
+    assert result["permission_mode"] == "default"
+    allowed = result.get("allowed_tools", [])
+    denied = result.get("disallowed_tools", [])
+    assert "read" in allowed
+    assert "bash" in denied
+
+
+# ── build_worker_branch: profile path unchanged ──────────────────────────────
+
+
+def test_build_worker_branch_profile_path_unchanged(tmp_path):
+    """When resolve_worker_spec finds a profile, the profile path must be used."""
+    from unittest.mock import patch
+
+    from lionagi.cli._agents import AgentProfile
+
+    fake_profile = AgentProfile(
+        name="myagent",
+        system_prompt="Custom system prompt from profile",
+        model="claude_code/opus",
+        effort=None,
+        yolo=False,
+        fast_mode=False,
+        lion_system=False,
+        artifact_defaults=None,
+        extra={},
+    )
+
+    orc_branch = Branch(name="orchestrator")
+    session = Session(default_branch=orc_branch)
+    run_mock = MagicMock()
+    run_mock.agent_artifact_dir.return_value = tmp_path / "artifacts" / "a1"
+    (tmp_path / "artifacts" / "a1").mkdir(parents=True, exist_ok=True)
+
+    env = OrchestrationEnv(
+        run=run_mock,
+        session=session,
+        orc_branch=orc_branch,
+        builder=MagicMock(),
+        orc_profile=None,
+        default_model_spec="claude_code/sonnet",
+        bare=False,
+        effort=None,
+        theme=None,
+        yolo=False,
+        bypass=False,
+        verbose=False,
+        fast=False,
+        cwd=None,
+    )
+
+    with patch(
+        "lionagi.cli.orchestrate._orchestration.load_agent_profile",
+        return_value=fake_profile,
+    ):
+        wb, w_model, w_profile = build_worker_branch(
+            env,
+            agent_id="a1",
+            role="myagent",
+            model_override=None,
+            explicit_name="myagent-1",
+        )
+
+    assert w_profile is fake_profile
+    assert "Custom system prompt from profile" in wb.system.rendered
+
+
+# ── build_worker_branch: casts fallback path ────────────────────────────────
+
+
+def test_build_worker_branch_casts_path_composes_spec(tmp_path):
+    """When no profile file exists but the role is a known casts role,
+    AgentSpec should be composed and capabilities granted."""
+    from unittest.mock import patch
+
+    orc_branch = Branch(name="orchestrator")
+    session = Session(default_branch=orc_branch)
+    run_mock = MagicMock()
+    run_mock.agent_artifact_dir.return_value = tmp_path / "artifacts" / "a1"
+    (tmp_path / "artifacts" / "a1").mkdir(parents=True, exist_ok=True)
+
+    env = OrchestrationEnv(
+        run=run_mock,
+        session=session,
+        orc_branch=orc_branch,
+        builder=MagicMock(),
+        orc_profile=None,
+        default_model_spec="claude_code/sonnet",
+        bare=False,
+        effort=None,
+        theme=None,
+        yolo=False,
+        bypass=False,
+        verbose=False,
+        fast=False,
+        cwd=None,
+    )
+
+    # Force load_agent_profile to raise FileNotFoundError so casts path is taken
+    with patch(
+        "lionagi.cli.orchestrate._orchestration.load_agent_profile",
+        side_effect=FileNotFoundError("no profile"),
+    ):
+        wb, w_model, w_profile = build_worker_branch(
+            env,
+            agent_id="a1",
+            role="critic",
+            model_override=None,
+            explicit_name="critic-1",
+        )
+
+    assert w_profile is None  # no profile file
+    # System message should contain role body (from casts critic role)
+    sys_text = wb.system.rendered
+    assert sys_text  # non-empty, not bare
+    # Capabilities should be granted (critic emits Verdict)
+    assert wb.capabilities is not None
+
+
+def test_build_worker_branch_casts_path_applies_permissions(tmp_path):
+    """Permissions preset should be translated and applied to endpoint kwargs."""
+    from unittest.mock import patch
+
+    orc_branch = Branch(name="orchestrator")
+    session = Session(default_branch=orc_branch)
+    run_mock = MagicMock()
+    run_mock.agent_artifact_dir.return_value = tmp_path / "artifacts" / "a1"
+    (tmp_path / "artifacts" / "a1").mkdir(parents=True, exist_ok=True)
+
+    env = OrchestrationEnv(
+        run=run_mock,
+        session=session,
+        orc_branch=orc_branch,
+        builder=MagicMock(),
+        orc_profile=None,
+        default_model_spec="claude_code/sonnet",
+        bare=False,
+        effort=None,
+        theme=None,
+        yolo=False,
+        bypass=False,
+        verbose=False,
+        fast=False,
+        cwd=None,
+    )
+
+    with patch(
+        "lionagi.cli.orchestrate._orchestration.load_agent_profile",
+        side_effect=FileNotFoundError("no profile"),
+    ):
+        wb, _, _ = build_worker_branch(
+            env,
+            agent_id="a1",
+            role="researcher",
+            model_override=None,
+            explicit_name="researcher-1",
+            agent_permissions="allow_all",
+        )
+
+    # allow_all → permission_mode: bypassPermissions in endpoint kwargs
+    kwargs = wb.chat_model.endpoint.config.kwargs
+    assert kwargs.get("permission_mode") == "bypassPermissions"
+
+
+# ── Observer wiring ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_observer_wiring_records_escalation_request(tmp_path):
+    """EscalationRequest wrapped in a Signal should be recorded by the observer."""
+    from lionagi.casts.capabilities import EscalationRequest
+    from lionagi.session.signal import StructuredOutput
+
+    orc_branch = Branch(name="orchestrator")
+    session = Session(default_branch=orc_branch)
+
+    escalations: list = []
+    session.observe(EscalationRequest, lambda e, _ctx: escalations.append(e))
+
+    # Capability events are emitted as StructuredOutput signals (the observer's
+    # TypeFilter unwraps the payload to match the inner EscalationRequest).
+    req = EscalationRequest(
+        reason="test escalation",
+        context={"detail": "unit test"},
+        blocking=False,
+        from_role="critic",
+    )
+    await session.emit(StructuredOutput(data=req))
+
+    assert len(escalations) == 1
+    assert escalations[0].reason == "test escalation"


### PR DESCRIPTION
**PR 3 of 3** — stacked on #composition. Merge **last**. The payoff layer.

## What
Layer 4 — every `li o flow` / `li o fanout` worker becomes a runtime-composed, permissioned, capability-emitting agent.

- `lionagi/cli/orchestrate/flow.py` — `FlowAgent` gains `modes: list[str]` + `permissions: str|None`; plan validation rejects unknown/conflicting modes and bad presets (fail-closed); planner roster rebuilt from `list_roles()`+`list_modes()`+presets; observer wiring records EscalationRequest + Verdict before `session.flow()`.
- `lionagi/agent/adapters/claude_code.py` — `translate_permissions(PermissionPolicy) -> dict` (allow_all/read_only/deny_all/rules → claude_code endpoint kwargs). One adapter; codex/openai noted as future work.
- `lionagi/cli/orchestrate/_orchestration.py` — `build_worker_branch`: **profile-file path stays first** (backward compat); casts AgentSpec fallback only when `w_profile is None` — composes spec, sets system message, maps tool zone by role, applies permissions via adapter, grants capabilities after `include_branches`.

## Backward compat (non-negotiable)
`~/.lionagi/agents/<name>.md` profile path resolves FIRST; casts is fallback-only. Proven by `test_build_worker_branch_profile_path_unchanged` + all pre-existing orchestrate tests.

## Scope
Observer wiring RECORDS only (v1); reactive re-planning is a documented extension point. No re-planning, no PAUSE/INJECT, no codex/openai adapters.

## Verification
`tests/cli/orchestrate/test_layer4_wiring.py` (15 new) + full cli/agent suite pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)