### PR TITLE
fix(studio): dashboard staleness, show-status sync, HEALTH column, breadcrumb/favicon (#1162 #1161 #1176 #1168)

### DIFF
--- a/apps/studio/frontend/app/icon.svg
+++ b/apps/studio/frontend/app/icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#10b981"/>
+      <stop offset="100%" stop-color="#0d9488"/>
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" rx="6" fill="url(#g)"/>
+  <text x="16" y="23" text-anchor="middle" font-family="monospace,sans-serif" font-size="18" font-weight="bold" fill="white">L</text>
+</svg>

--- a/apps/studio/frontend/app/page.tsx
+++ b/apps/studio/frontend/app/page.tsx
@@ -8,7 +8,7 @@ import StatusPill from "@/components/StatusPill";
 import Timestamp from "@/components/Timestamp";
 import Duration from "@/components/Duration";
 import TimeRangeChips, { type TimeRange, rangeToSeconds } from "@/components/TimeRangeChips";
-import { API_BASE, getStats } from "@/lib/api";
+import { API_BASE, getShow, getStats } from "@/lib/api";
 import type { DbStats, StudioStats } from "@/lib/api";
 import type { RunSummary, ShowSummary } from "@/lib/types";
 
@@ -17,11 +17,7 @@ const RUNNING_STATES = new Set(["running", "executing", "in_progress", "director
 // a deliberate bound (amber, retry); aborted = Ctrl-C, cancelled = system
 // cancellation (both neutral). Keeping them out of FAILED_STATES so the
 // "Failed" dashboard card only counts actual errors.
-const FAILED_STATES = new Set([
-  "failed",
-  "error",
-  "failure",
-]);
+const FAILED_STATES = new Set(["failed", "error", "failure"]);
 const COMPLETED_STATES = new Set([
   "completed",
   "done",
@@ -76,8 +72,35 @@ export default function DashboardPage() {
         if (!active) return;
         setStats(statsRes);
         setAllRuns(runsRes.runs ?? []);
-        setShows(showsRes ?? []);
+        const showsList = showsRes ?? [];
+        setShows(showsList);
         setFetchError(null);
+        // #1161: list endpoint reads latest_status from SQLite (always "active");
+        // detail endpoint reads from _show.md and returns the real status.
+        // Fire concurrent detail fetches to patch the displayed statuses.
+        if (showsList.length > 0) {
+          const settled = await Promise.allSettled(
+            showsList.map((s: ShowSummary) =>
+              getShow(s.topic).then((d) => ({
+                topic: s.topic,
+                status: d.status ?? s.latest_status,
+              })),
+            ),
+          );
+          if (active) {
+            const resolved = new Map<string, string>();
+            for (const r of settled) {
+              if (r.status === "fulfilled") resolved.set(r.value.topic, r.value.status);
+            }
+            if (resolved.size > 0) {
+              setShows((prev) =>
+                prev.map((s) =>
+                  resolved.has(s.topic) ? { ...s, latest_status: resolved.get(s.topic)! } : s,
+                ),
+              );
+            }
+          }
+        }
       } catch {
         if (active) setFetchError("API unreachable — data may be stale");
       }
@@ -124,9 +147,7 @@ export default function DashboardPage() {
       ...failed,
       ...stale.filter((s) => !failed.includes(s)),
       ...stuck.filter((s) => !failed.includes(s) && !stale.includes(s)),
-      ...needsReview.filter(
-        (n) => !failed.includes(n) && !stale.includes(n) && !stuck.includes(n),
-      ),
+      ...needsReview.filter((n) => !failed.includes(n) && !stale.includes(n) && !stuck.includes(n)),
     ]
       .sort((a, b) => (b.started_at ?? 0) - (a.started_at ?? 0))
       .slice(0, 8);
@@ -135,7 +156,18 @@ export default function DashboardPage() {
       .sort((a, b) => (b.started_at ?? 0) - (a.started_at ?? 0))
       .slice(0, 8);
 
-    return { scoped, running, failed, completed, needsReview, slow, stuck, stale, attention, recent };
+    return {
+      scoped,
+      running,
+      failed,
+      completed,
+      needsReview,
+      slow,
+      stuck,
+      stale,
+      attention,
+      recent,
+    };
   }, [allRuns, windowSec, now]);
 
   const rangeLabel = range === "all" ? "all time" : range;
@@ -160,18 +192,18 @@ export default function DashboardPage() {
         <MetricCard
           label="Running now"
           value={buckets.running.length}
-          hint={buckets.stuck.length > 0 ? `${buckets.stuck.length} stuck >${STUCK_RUN_SECONDS / 60}m` : `${rangeLabel}`}
+          hint={
+            buckets.stuck.length > 0
+              ? `${buckets.stuck.length} stuck >${STUCK_RUN_SECONDS / 60}m`
+              : `${rangeLabel}`
+          }
           tone={buckets.running.length > 0 ? "running" : "neutral"}
           icon={buckets.running.length > 0 ? "◐" : "○"}
         />
         <MetricCard
           label="Stale"
           value={buckets.stale.length}
-          hint={
-            buckets.stale.length > 0
-              ? "no activity past threshold"
-              : "all running runs active"
-          }
+          hint={buckets.stale.length > 0 ? "no activity past threshold" : "no stale activity"}
           tone={buckets.stale.length > 0 ? "pending" : "neutral"}
           icon={buckets.stale.length > 0 ? "◴" : "·"}
         />
@@ -228,11 +260,7 @@ export default function DashboardPage() {
       {/* Two-column: Needs attention | Recent activity */}
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
         <section>
-          <SectionHeader
-            title="Needs attention"
-            count={buckets.attention.length}
-            href="/runs"
-          />
+          <SectionHeader title="Needs attention" count={buckets.attention.length} href="/runs" />
           {buckets.attention.length === 0 ? (
             <div className="rounded border border-status-success/25 bg-status-success-bg px-4 py-4 text-body text-status-success shadow-card">
               <span className="font-semibold">All clean.</span>{" "}
@@ -417,11 +445,7 @@ function SystemHealthCard({ db }: { db: DbStats | undefined }) {
         <div>
           <div className="text-content-muted">Last checkpoint</div>
           <div className="text-content-secondary">
-            {db.last_checkpoint_at ? (
-              <Timestamp value={db.last_checkpoint_at} />
-            ) : (
-              "unavailable"
-            )}
+            {db.last_checkpoint_at ? <Timestamp value={db.last_checkpoint_at} /> : "unavailable"}
           </div>
         </div>
       </div>

--- a/apps/studio/frontend/app/runs/page.tsx
+++ b/apps/studio/frontend/app/runs/page.tsx
@@ -435,9 +435,7 @@ function RunsPageInner() {
               <th className="px-3 py-2.5 font-medium">
                 {viewMode === "invocations" ? "Invocation" : "Run"}
               </th>
-              <th className="px-3 py-2.5 font-medium">Model</th>
               <th className="px-3 py-2.5 font-medium">Status</th>
-              <th className="px-3 py-2.5 font-medium">Health</th>
               <th className="px-3 py-2.5 font-medium">
                 {viewMode === "invocations" ? "Sessions" : "Activity"}
               </th>
@@ -534,7 +532,7 @@ function RunsPageInner() {
               )
             ) : runs.length === 0 ? (
               <tr>
-                <td colSpan={6} className="px-3 py-14 text-center text-body text-content-muted">
+                <td colSpan={4} className="px-3 py-14 text-center text-body text-content-muted">
                   <span className="block mb-1 text-[11px]">{empty.runs}</span>
                   {(statuses.length > 0 || playbook) && (
                     <span className="text-meta">Try adjusting your filters.</span>

--- a/apps/studio/frontend/components/nav/types.ts
+++ b/apps/studio/frontend/components/nav/types.ts
@@ -35,6 +35,7 @@ export const NAV_GROUPS: NavGroupDef[] = [
     items: [
       { label: "Shows", href: "/shows" },
       { label: "Runs", href: "/runs" },
+      { label: "Projects", href: "/projects" },
       { label: "Teams", href: "/teams" },
       { label: "Invocations", href: "/invocations" },
       { label: "Schedules", href: "/schedules" },


### PR DESCRIPTION
Closes #1162, closes #1161, closes #1176, closes #1168.

- **#1162**: Stale card hint changed from "all running runs active" → "no stale activity"; the old text contradicted the stuck-run subtitle in Running now (stale and stuck are independent metrics — stale = no message activity; stuck = duration-based)
- **#1161**: Dashboard shows table now fires concurrent `getShow()` detail requests after the list loads, patching each show's status with the filesystem-derived value from `_show.md` (list endpoint reads SQLite where `latest_status` is always "active")
- **#1176**: Removed orphaned Model and Health header columns from the Runs table; the data rows have 4 cells (Run / Status / Activity / Updated) but the header had 6, causing visual misalignment and the confusing "Failed · Healthy" contradiction; also fixed sessions empty-state `colSpan` from 6 → 4
- **#1168**: Added Projects to the Work nav group so breadcrumb renders "Work › Projects" (title case, with parent) instead of bare lowercase "projects"; added `app/icon.svg` (Next.js App Router convention) resolving `/favicon.ico` 404 errors

🤖 Generated with Claude Code