### PR TITLE
feat(session): loop control — observers can CANCEL/BREAK a running stream

### DIFF
--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -28,6 +28,8 @@ if TYPE_CHECKING:
     from lionagi.protocols.messages.message import RoledMessage
     from lionagi.session.branch import Branch
 
+from lionagi.session.control import LoopBreak, LoopDirective
+
 logger = logging.getLogger(__name__)
 
 
@@ -129,6 +131,24 @@ async def _emit_message_signal(branch: Branch, msg: RoledMessage) -> None:
         await branch.emit(ActionRequestSignal(data=msg))
     elif isinstance(msg, ActionResponse):
         await branch.emit(ActionResponseSignal(data=msg))
+
+
+class _StopStream(Exception):  # noqa: N818
+    """Internal sentinel used for observer-requested clean cancellation."""
+
+    def __init__(self, reason: str | None = None) -> None:
+        super().__init__(reason or "stream cancelled by observer")
+        self.reason = reason
+
+
+def _check_control(branch: Branch) -> None:
+    ctrl = branch.poll_control()
+    if ctrl is None or ctrl.directive is LoopDirective.CONTINUE:
+        return
+    if ctrl.directive is LoopDirective.BREAK:
+        raise LoopBreak(ctrl.reason)
+    if ctrl.directive is LoopDirective.CANCEL:
+        raise _StopStream(ctrl.reason)
 
 
 async def run(
@@ -233,84 +253,91 @@ async def run(
     await model.executor.append(api_call)
 
     try:
-        # ``anyio.fail_after(None)`` is a no-op context, so we can wrap
-        # unconditionally and let the no-timeout case pay the (small)
-        # context-manager cost rather than branching the stream loop.
-        with anyio.fail_after(_stream_timeout):
-            async for chunk in model.stream(api_call=api_call):
-                match chunk.type:
-                    case "system":
-                        if sid := chunk.metadata.get("session_id"):
-                            endpoint.session_id = sid
+        try:
+            # ``anyio.fail_after(None)`` is a no-op context, so we can wrap
+            # unconditionally and let the no-timeout case pay the (small)
+            # context-manager cost rather than branching the stream loop.
+            with anyio.fail_after(_stream_timeout):
+                async for chunk in model.stream(api_call=api_call):
+                    match chunk.type:
+                        case "system":
+                            if sid := chunk.metadata.get("session_id"):
+                                endpoint.session_id = sid
 
-                    case "thinking":
-                        if chunk.content:
-                            thinking_parts.append(chunk.content)
+                        case "thinking":
+                            if chunk.content:
+                                thinking_parts.append(chunk.content)
 
-                    case "text":
-                        if chunk.content:
-                            text_parts.append(chunk.content)
+                        case "text":
+                            if chunk.content:
+                                text_parts.append(chunk.content)
 
-                    case "tool_use":
-                        if res := await _flush_response():
-                            await _emit_message_signal(branch, res)
-                            yield res
+                        case "tool_use":
+                            if res := await _flush_response():
+                                await _emit_message_signal(branch, res)
+                                _check_control(branch)
+                                yield res
 
-                        act_req = branch.msgs.create_action_request(
-                            function=chunk.tool_name or "",
-                            arguments=chunk.tool_input or {},
-                            sender=branch.id,
-                            recipient=branch.user or "user",
-                        )
-                        if chunk.tool_id:
-                            pending_requests[chunk.tool_id] = act_req
-                        await branch.msgs.a_add_message(action_request=act_req)
-                        await _emit_message_signal(branch, act_req)
-                        yield act_req
+                            act_req = branch.msgs.create_action_request(
+                                function=chunk.tool_name or "",
+                                arguments=chunk.tool_input or {},
+                                sender=branch.id,
+                                recipient=branch.user or "user",
+                            )
+                            if chunk.tool_id:
+                                pending_requests[chunk.tool_id] = act_req
+                            await branch.msgs.a_add_message(action_request=act_req)
+                            await _emit_message_signal(branch, act_req)
+                            _check_control(branch)
+                            yield act_req
 
-                    case "tool_result":
-                        orig_req = (
-                            pending_requests.pop(chunk.tool_id, None) if chunk.tool_id else None
-                        )
-                        if orig_req is None:
-                            continue
+                        case "tool_result":
+                            orig_req = (
+                                pending_requests.pop(chunk.tool_id, None) if chunk.tool_id else None
+                            )
+                            if orig_req is None:
+                                continue
 
-                        # Build the ActionResponse and attach is_error BEFORE
-                        # a_add_message so the live-persist hook (and any other
-                        # on_message_added callback) observes the final state.
-                        # Doing it after the await would let the hook serialize
-                        # an incomplete row that omits the error marker.
-                        act_res = branch.msgs.create_action_response(
-                            action_request=orig_req,
-                            action_output=chunk.tool_output,
-                            sender=branch.user or "user",
-                            recipient=branch.id,
-                        )
-                        if chunk.is_error:
-                            act_res.metadata["is_error"] = True
-                        await branch.msgs.a_add_message(
-                            action_request=orig_req,
-                            action_output=chunk.tool_output,
-                            action_response=act_res,
-                            sender=branch.user or "user",
-                            recipient=branch.id,
-                        )
-                        await _emit_message_signal(branch, act_res)
-                        yield act_res
+                            # Build the ActionResponse and attach is_error BEFORE
+                            # a_add_message so the live-persist hook (and any other
+                            # on_message_added callback) observes the final state.
+                            # Doing it after the await would let the hook serialize
+                            # an incomplete row that omits the error marker.
+                            act_res = branch.msgs.create_action_response(
+                                action_request=orig_req,
+                                action_output=chunk.tool_output,
+                                sender=branch.user or "user",
+                                recipient=branch.id,
+                            )
+                            if chunk.is_error:
+                                act_res.metadata["is_error"] = True
+                            await branch.msgs.a_add_message(
+                                action_request=orig_req,
+                                action_output=chunk.tool_output,
+                                action_response=act_res,
+                                sender=branch.user or "user",
+                                recipient=branch.id,
+                            )
+                            await _emit_message_signal(branch, act_res)
+                            _check_control(branch)
+                            yield act_res
 
-                    case "result":
-                        pass
+                        case "result":
+                            pass
 
-                    case "error":
-                        raise RuntimeError(chunk.content or "Stream error from CLI endpoint")
+                        case "error":
+                            raise RuntimeError(chunk.content or "Stream error from CLI endpoint")
 
-            if res := await _flush_response():
-                if hasattr(api_call, "to_dict"):
-                    call_meta = Note.from_dict(api_call.to_dict())
-                    call_meta.pop(["execution", "response"], None)
-                    res.metadata["api_call_meta"] = call_meta.to_dict()
-                await _emit_message_signal(branch, res)
-                yield res
+                if res := await _flush_response():
+                    if hasattr(api_call, "to_dict"):
+                        call_meta = Note.from_dict(api_call.to_dict())
+                        call_meta.pop(["execution", "response"], None)
+                        res.metadata["api_call_meta"] = call_meta.to_dict()
+                    await _emit_message_signal(branch, res)
+                    _check_control(branch)
+                    yield res
+        except _StopStream:
+            pass
     finally:
         # Restore original streaming func
         model.streaming_process_func = prev_stream_func

--- a/lionagi/session/branch.py
+++ b/lionagi/session/branch.py
@@ -44,6 +44,7 @@ from .prompts import LION_SYSTEM_MESSAGE
 if TYPE_CHECKING:
     from lionagi.operations.operate.operative import Operative
     from lionagi.operations.types import Middle
+    from lionagi.session.control import LoopControl, LoopDirective
 
 
 __all__ = ("Branch",)
@@ -120,6 +121,7 @@ class Branch(Element, Relational):
     _operation_manager: OperationManager | None = PrivateAttr(None)
     _observer: Any = PrivateAttr(None)
     _capabilities: Any = PrivateAttr(None)
+    _loop_control: "LoopControl | None" = PrivateAttr(None)
 
     def __init__(
         self,
@@ -365,6 +367,24 @@ class Branch(Element, Relational):
         if self._observer is None:
             return []
         return await self._observer.emit(event)
+
+    def control(self, directive: "LoopDirective", *, reason: str | None = None) -> None:
+        """Queue a loop-control directive.
+
+        Called from an observer handler to steer the in-flight run.
+        The run loop polls this after each message signal.
+        """
+        from lionagi.session.control import LoopControl
+
+        self._loop_control = LoopControl(directive, reason)
+
+    def poll_control(self) -> "LoopControl | None":
+        """Return and CLEAR any queued directive (one-shot).
+
+        Returns ``None`` when no directive is pending.
+        """
+        ctrl, self._loop_control = self._loop_control, None
+        return ctrl
 
     @property
     def capabilities(self) -> Any:

--- a/lionagi/session/control.py
+++ b/lionagi/session/control.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+__all__ = ("LoopDirective", "LoopControl", "LoopBreak")
+
+
+class LoopDirective(Enum):
+    CONTINUE = "continue"
+    CANCEL = "cancel"
+    BREAK = "break"
+
+
+@dataclass(frozen=True, slots=True)
+class LoopControl:
+    directive: LoopDirective
+    reason: str | None = None
+
+
+class LoopBreak(Exception):  # noqa: N818
+    """Raised inside the run loop when an observer requests a hard stop.
+
+    The exception propagates out of ``run()`` so that ``Branch.operate``
+    can surface it as a ``RunFailed`` event.
+    """
+
+    def __init__(self, reason: str | None = None) -> None:
+        super().__init__(reason or "loop broken by observer")
+        self.reason = reason

--- a/tests/session/test_control.py
+++ b/tests/session/test_control.py
@@ -1,0 +1,329 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import types
+from unittest.mock import AsyncMock
+
+import pytest
+
+from lionagi.operations.run.run import _check_control, _StopStream
+from lionagi.protocols.messages import AssistantResponse
+from lionagi.service.imodel import iModel
+from lionagi.service.types.stream_chunk import StreamChunk
+from lionagi.session.branch import Branch
+from lionagi.session.control import LoopBreak, LoopControl, LoopDirective
+from lionagi.session.session import Session
+from lionagi.session.signal import StructuredOutput
+
+# ---------------------------------------------------------------------------
+# LoopDirective / LoopControl / LoopBreak construction
+# ---------------------------------------------------------------------------
+
+
+class TestControlTypes:
+    def test_loop_directive_values(self):
+        assert LoopDirective.CONTINUE.value == "continue"
+        assert LoopDirective.CANCEL.value == "cancel"
+        assert LoopDirective.BREAK.value == "break"
+
+    def test_loop_directive_members(self):
+        assert set(LoopDirective.__members__) == {"CONTINUE", "CANCEL", "BREAK"}
+
+    def test_loop_control_frozen(self):
+        lc = LoopControl(directive=LoopDirective.CANCEL)
+        with pytest.raises((AttributeError, TypeError)):
+            lc.directive = LoopDirective.BREAK  # frozen dataclass
+
+    def test_loop_control_reason_defaults_none(self):
+        lc = LoopControl(LoopDirective.CONTINUE)
+        assert lc.reason is None
+
+    def test_loop_control_with_reason(self):
+        lc = LoopControl(LoopDirective.CANCEL, reason="timeout")
+        assert lc.reason == "timeout"
+
+    def test_loop_break_carries_reason(self):
+        exc = LoopBreak(reason="test stop")
+        assert exc.reason == "test stop"
+        assert "test stop" in str(exc)
+
+    def test_loop_break_no_reason(self):
+        exc = LoopBreak()
+        assert exc.reason is None
+
+    def test_loop_break_is_exception(self):
+        assert issubclass(LoopBreak, Exception)
+
+
+# ---------------------------------------------------------------------------
+# Branch.control() / poll_control() — one-shot semantics
+# ---------------------------------------------------------------------------
+
+
+class TestBranchControlOneShot:
+    def test_poll_before_any_control_returns_none(self):
+        b = Branch()
+        assert b.poll_control() is None
+
+    def test_control_sets_directive(self):
+        b = Branch()
+        b.control(LoopDirective.CANCEL, reason="stop now")
+        ctrl = b.poll_control()
+        assert ctrl is not None
+        assert ctrl.directive is LoopDirective.CANCEL
+        assert ctrl.reason == "stop now"
+
+    def test_one_shot_second_poll_returns_none(self):
+        b = Branch()
+        b.control(LoopDirective.BREAK)
+        b.poll_control()  # consumes
+        assert b.poll_control() is None  # cleared
+
+    def test_overwrite_before_poll_last_write_wins(self):
+        b = Branch()
+        b.control(LoopDirective.CONTINUE)
+        b.control(LoopDirective.BREAK)
+        ctrl = b.poll_control()
+        assert ctrl.directive is LoopDirective.BREAK
+
+    def test_poll_clears_so_can_set_again(self):
+        b = Branch()
+        b.control(LoopDirective.CANCEL)
+        b.poll_control()
+        b.control(LoopDirective.CONTINUE)
+        ctrl = b.poll_control()
+        assert ctrl.directive is LoopDirective.CONTINUE
+
+    def test_returns_loop_control_instance(self):
+        b = Branch()
+        b.control(LoopDirective.BREAK)
+        ctrl = b.poll_control()
+        assert isinstance(ctrl, LoopControl)
+
+    def test_control_without_reason(self):
+        b = Branch()
+        b.control(LoopDirective.BREAK)
+        ctrl = b.poll_control()
+        assert ctrl.reason is None
+
+
+# ---------------------------------------------------------------------------
+# _check_control behavior
+# ---------------------------------------------------------------------------
+
+
+class TestCheckControl:
+    def test_no_directive_is_noop(self):
+        b = Branch()
+        _check_control(b)  # no exception
+
+    def test_continue_directive_is_noop(self):
+        b = Branch()
+        b.control(LoopDirective.CONTINUE)
+        _check_control(b)  # no exception
+
+    def test_break_directive_raises_loop_break(self):
+        b = Branch()
+        b.control(LoopDirective.BREAK, reason="halt immediately")
+        with pytest.raises(LoopBreak) as exc_info:
+            _check_control(b)
+        assert exc_info.value.reason == "halt immediately"
+
+    def test_cancel_directive_raises_stop_stream(self):
+        b = Branch()
+        b.control(LoopDirective.CANCEL, reason="clean stop")
+        with pytest.raises(_StopStream) as exc_info:
+            _check_control(b)
+        assert exc_info.value.reason == "clean stop"
+
+    def test_check_control_consumes_directive_on_break(self):
+        b = Branch()
+        b.control(LoopDirective.BREAK)
+        with pytest.raises(LoopBreak):
+            _check_control(b)
+        assert b.poll_control() is None  # consumed
+
+    def test_check_control_consumes_directive_on_cancel(self):
+        b = Branch()
+        b.control(LoopDirective.CANCEL)
+        with pytest.raises(_StopStream):
+            _check_control(b)
+        assert b.poll_control() is None  # consumed
+
+
+# ---------------------------------------------------------------------------
+# CANCEL stops the stream and finally still runs
+# ---------------------------------------------------------------------------
+
+
+class TestCancelFinallyBehavior:
+    async def test_cancel_stops_stream_finally_runs(self):
+        b = Branch()
+        b.control(LoopDirective.CANCEL, reason="observer halt")
+
+        finally_ran = False
+        stop_caught = False
+
+        try:
+            try:
+                _check_control(b)
+                pytest.fail("_check_control should have raised _StopStream")
+            except _StopStream:
+                stop_caught = True
+        finally:
+            finally_ran = True
+
+        assert stop_caught
+        assert finally_ran
+
+    async def test_break_propagates_through_inner_except(self):
+        b = Branch()
+        b.control(LoopDirective.BREAK, reason="hard stop")
+
+        finally_ran = False
+
+        with pytest.raises(LoopBreak) as exc_info:
+            try:
+                try:
+                    _check_control(b)
+                except _StopStream:
+                    pytest.fail("BREAK must not be caught as _StopStream")
+            finally:
+                finally_ran = True
+
+        assert exc_info.value.reason == "hard stop"
+        assert finally_ran
+
+    async def test_observer_queues_cancel_on_payload(self):
+        from pydantic import BaseModel
+
+        class _TestFinding(BaseModel):
+            description: str
+
+        s = Session()
+        b = s.default_branch
+        signals_seen: list = []
+
+        @s.observe(_TestFinding)
+        def on_finding(payload, session):
+            signals_seen.append(payload)
+            b.control(LoopDirective.CANCEL, reason="finding received, stopping")
+
+        await b.emit(StructuredOutput(data=_TestFinding(description="critical bug found")))
+
+        assert len(signals_seen) == 1
+        ctrl = b.poll_control()
+        assert ctrl is not None
+        assert ctrl.directive is LoopDirective.CANCEL
+        assert ctrl.reason == "finding received, stopping"
+
+    async def test_cancel_after_payload_then_poll_is_one_shot(self):
+        from pydantic import BaseModel
+
+        class _TestEscalation(BaseModel):
+            reason: str
+
+        s = Session()
+        b = s.default_branch
+
+        @s.observe(_TestEscalation)
+        def on_escalation(payload, session):
+            b.control(LoopDirective.CANCEL)
+
+        await b.emit(StructuredOutput(data=_TestEscalation(reason="blocker")))
+
+        ctrl = b.poll_control()
+        assert ctrl is not None
+        assert ctrl.directive is LoopDirective.CANCEL
+        assert b.poll_control() is None  # one-shot
+
+
+# ---------------------------------------------------------------------------
+# End-to-end integration — real run() loop with loop control
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_cli_model_for_control(chunks: list[StreamChunk]):
+    m = iModel(provider="openai", model="gpt-4.1-mini", api_key="test_key")
+    endpoint_ns = types.SimpleNamespace(
+        is_cli=True,
+        session_id=None,
+        to_dict=lambda: {"type": "fake_cli", "session_id": None},
+    )
+    m.endpoint = endpoint_ns
+    m.streaming_process_func = None
+
+    async def create_event(**kw):
+        return object()
+
+    m.create_event = create_event
+    m.executor = types.SimpleNamespace(append=AsyncMock(), config={})
+
+    async def stream(api_call=None):
+        for chunk in chunks:
+            yield chunk
+
+    m.stream = stream
+    return m
+
+
+class TestRunLoopControlIntegration:
+    async def test_cancel_stops_loop_cleanly_finally_runs(self):
+        from lionagi.operations.run.run import RunParam, run
+
+        sentinel = object()
+        chunks = [
+            StreamChunk(type="text", content="first"),
+            StreamChunk(type="text", content="second"),
+        ]
+        model = _make_fake_cli_model_for_control(chunks)
+        model.streaming_process_func = sentinel
+
+        branch = Branch()
+        branch.chat_model = model
+
+        collected: list = []
+        cancel_issued = False
+
+        async for msg in run(branch, "go", RunParam()):
+            collected.append(msg)
+            if isinstance(msg, AssistantResponse) and not cancel_issued:
+                cancel_issued = True
+                branch.control(LoopDirective.CANCEL, reason="observer halt")
+
+        assert model.streaming_process_func is sentinel
+
+        assistant_msgs = [m for m in branch.messages if isinstance(m, AssistantResponse)]
+        assert len(assistant_msgs) >= 1
+
+    async def test_break_propagates_out_of_run_and_finally_still_runs(self):
+        from lionagi.operations.run.run import RunParam, run
+
+        sentinel = object()
+        chunks = [
+            StreamChunk(type="text", content="chunk-a"),
+            StreamChunk(type="text", content="chunk-b"),
+        ]
+        model = _make_fake_cli_model_for_control(chunks)
+        model.streaming_process_func = sentinel
+
+        branch = Branch()
+        branch.chat_model = model
+
+        branch.control(LoopDirective.BREAK, reason="hard stop")
+
+        loop_break_raised = False
+        loop_break_reason = None
+        try:
+            async for _ in run(branch, "go", RunParam()):
+                pass
+        except LoopBreak as exc:
+            loop_break_raised = True
+            loop_break_reason = exc.reason
+
+        assert loop_break_raised
+        assert loop_break_reason == "hard stop"
+
+        assert model.streaming_process_func is sentinel


### PR DESCRIPTION
## Summary
- Extracted loop control (Layer 2) from PR #1211, which is being closed since the capability ontology (Layer 1) was superseded by the emission system in #1224
- Adds `LoopDirective` enum (CONTINUE/CANCEL/BREAK), `Branch.control()`/`poll_control()` one-shot API, and `_check_control` seam inside the `run()` stream loop
- CANCEL stops the stream cleanly (partial state preserved via finally); BREAK raises `LoopBreak` out of `run()` for `operate()` to surface as `RunFailed`
- PAUSE/INJECT explicitly deferred (turn-boundary concerns, not chunk-boundary)

## Test plan
- [x] 27 new tests in `tests/session/test_control.py` — types, one-shot semantics, `_check_control` dispatch, observer→control integration, e2e run() with fake CLI model
- [x] All 274 session tests pass (zero regressions)
- [x] Lint clean (ruff + pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)