### PR TITLE
feat(agent): universal AgentSpec — Profile composition + emission wiring

### DIFF
--- a/lionagi/agent/__init__.py
+++ b/lionagi/agent/__init__.py
@@ -5,9 +5,11 @@ from .config import AgentConfig
 from .factory import create_agent
 from .permissions import PermissionPolicy
 from .settings import apply_hooks_from_settings, load_settings
+from .spec import AgentSpec
 
 __all__ = (
     "AgentConfig",
+    "AgentSpec",
     "PermissionPolicy",
     "create_agent",
     "load_settings",

--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
@@ -8,51 +8,51 @@ from typing import TYPE_CHECKING, Any
 
 from lionagi.session.branch import Branch
 
-from .config import AgentConfig
+from .spec import AgentSpec
 
 if TYPE_CHECKING:
-    pass
+    from .config import AgentConfig
+
+__all__ = ("create_agent",)
 
 
 async def create_agent(
-    config: AgentConfig,
+    config: AgentSpec | AgentConfig,
     *,
     load_settings: bool = True,
     project_dir: str | None = None,
     trust_project_settings: bool = False,
     trusted_hook_modules: set[str] | frozenset[str] | None = None,
 ) -> Branch:
-    """Create a fully configured Branch from an AgentConfig.
+    """Create a fully configured Branch from an AgentSpec (or legacy AgentConfig).
 
-    Wires: settings → hooks → system prompt → model → tools.
+    Wires: settings -> hooks -> system prompt -> model -> tools -> emissions.
 
     Args:
-        config: Agent configuration.
-        load_settings: If True, load hooks from .lionagi/settings.yaml
-            (global always; project-local only when trust_project_settings=True).
+        config: Agent specification. AgentConfig is accepted for back-compat
+            and converted internally via AgentSpec.from_legacy().
+        load_settings: If True, load hooks from .lionagi/settings.yaml.
         project_dir: Project root for settings resolution. Auto-detected if None.
-        trust_project_settings: If True, load and apply hooks from project-local
-            .lionagi/settings.yaml. Defaults to False (Finding 1: safe default).
+        trust_project_settings: If True, load project-local settings.
         trusted_hook_modules: Python module paths allowed for import-based hooks.
-            Defaults to {"lionagi.agent.hooks"}.
-
-    Usage::
-
-        config = AgentConfig.coding(model="openai/gpt-4.1")
-        branch = await create_agent(config)
-        response = await branch.chat("Fix the bug in utils.py")
 
     Returns:
         A Branch ready to use with tools registered and hooks applied.
     """
+    from .config import AgentConfig
+
+    if isinstance(config, AgentConfig):
+        spec = AgentSpec.from_legacy(config)
+    else:
+        spec = config
+
     if load_settings:
         from .settings import apply_hooks_from_settings
         from .settings import load_settings as _load
 
-        # Finding 1: only load project-local hooks when explicitly trusted
         settings = _load(project_dir, include_project=trust_project_settings)
         apply_hooks_from_settings(
-            config,
+            spec,
             settings,
             trusted_hook_modules=trusted_hook_modules,
         )
@@ -61,25 +61,25 @@ async def create_agent(
 
     branch_kwargs = {}
 
-    if config.model:
+    if spec.model:
         from lionagi.cli._providers import (
             PROVIDER_EFFORT_KWARG,
             parse_model_spec,
         )
 
-        ms = parse_model_spec(config.model)
+        ms = parse_model_spec(spec.model)
         if "/" in ms.model:
             provider, model_name = ms.model.split("/", 1)
         else:
             provider = model_name = ms.model
 
         extra = {}
-        effort = config.effort or ms.effort
+        effort = spec.effort or ms.effort
         if effort:
             kwarg = PROVIDER_EFFORT_KWARG.get(provider)
             if kwarg:
                 extra[kwarg] = effort
-        if config.yolo:
+        if spec.yolo:
             from lionagi.cli._providers import PROVIDER_YOLO_KWARGS
 
             extra.update(PROVIDER_YOLO_KWARGS.get(provider, {}))
@@ -94,9 +94,9 @@ async def create_agent(
 
     branch = Branch(**branch_kwargs)
 
-    system_message = config.build_system_message()
+    system_message = spec.build_system_message()
     if system_message:
-        if config.lion_system:
+        if spec.lion_system:
             from lionagi.session.prompts import LION_SYSTEM_MESSAGE
 
             full_prompt = LION_SYSTEM_MESSAGE.strip() + "\n\n" + system_message
@@ -104,41 +104,36 @@ async def create_agent(
             full_prompt = system_message
         branch.msgs.set_system(branch.msgs.create_system(system=full_prompt))
 
-    _apply_permissions(config)
-    _register_tools(branch, config)
-    await _load_mcp(branch, config, trust_project_settings=trust_project_settings)
+    _apply_permissions(spec)
+    _register_tools(branch, spec)
+    await _load_mcp(branch, spec, trust_project_settings=trust_project_settings)
+
+    if op := spec.emission_operable():
+        branch.grant_capabilities(op)
 
     return branch
 
 
-def _apply_permissions(config: AgentConfig) -> None:
-    """Convert permission config into a security_pre hook on all tools.
-
-    Finding 13: uses 'security_pre' phase so permission hooks always run
-    before user-defined pre-hooks.
-    """
-    if not config.permissions:
+def _apply_permissions(spec: AgentSpec) -> None:
+    """Convert permission config into a security_pre hook on all tools."""
+    if spec.permissions is None:
         return
 
     from .permissions import PermissionPolicy
 
-    if isinstance(config.permissions, PermissionPolicy):
-        policy = config.permissions
-    elif isinstance(config.permissions, dict):
-        policy = PermissionPolicy.from_dict(config.permissions)
+    if isinstance(spec.permissions, PermissionPolicy):
+        policy = spec.permissions
     else:
         return
 
-    # Finding 13: insert permission hook into security_pre phase, not pre phase
-    config.hook_handlers.setdefault("security_pre:*", []).insert(0, policy.to_pre_hook())
+    spec.hook_handlers.setdefault("security_pre:*", []).insert(0, policy.to_pre_hook())
 
 
-def _tool_hooks(config: AgentConfig, phase: str, tool_name: str) -> list[Callable]:
-    """Finding 15: collect hooks for a tool from all relevant phase:name keys."""
+def _tool_hooks(spec: AgentSpec, phase: str, tool_name: str) -> list[Callable]:
     return [
-        *config.hook_handlers.get(f"{phase}:*", []),
-        *config.hook_handlers.get(f"{phase}:{tool_name}", []),
-        *config.hook_handlers.get(f"{phase}:{tool_name}_tool", []),
+        *spec.hook_handlers.get(f"{phase}:*", []),
+        *spec.hook_handlers.get(f"{phase}:{tool_name}", []),
+        *spec.hook_handlers.get(f"{phase}:{tool_name}_tool", []),
     ]
 
 
@@ -150,7 +145,6 @@ def _chain_pre_hooks(
     user_hooks = user_hooks or []
     hooks = [*security_hooks, *user_hooks]
     if user_hooks:
-        # User pre-hooks may rewrite args; validate the final args too.
         hooks.extend(security_hooks)
     if not hooks:
         return None
@@ -181,11 +175,10 @@ def _chain_post_hooks(tool_name: str, hooks: list[Callable]) -> Callable | None:
     return chained
 
 
-def _attach_hooks(tool: Any, config: AgentConfig, canonical_name: str) -> Any:
-    """Finding 15: attach security_pre + pre + post hooks to a standalone tool."""
-    security_hooks = _tool_hooks(config, "security_pre", canonical_name)
-    user_pre_hooks = _tool_hooks(config, "pre", canonical_name)
-    post_hooks = _tool_hooks(config, "post", canonical_name)
+def _attach_hooks(tool: Any, spec: AgentSpec, canonical_name: str) -> Any:
+    security_hooks = _tool_hooks(spec, "security_pre", canonical_name)
+    user_pre_hooks = _tool_hooks(spec, "pre", canonical_name)
+    post_hooks = _tool_hooks(spec, "post", canonical_name)
     pre = _chain_pre_hooks(canonical_name, security_hooks, user_pre_hooks)
     post = _chain_post_hooks(canonical_name, post_hooks)
     if pre is not None:
@@ -195,54 +188,47 @@ def _attach_hooks(tool: Any, config: AgentConfig, canonical_name: str) -> Any:
     return tool
 
 
-def _register_tools(branch: Branch, config: AgentConfig) -> None:
-    """Register tools based on config.tools list, applying hooks."""
-    for tool_spec in config.tools:
+def _register_tools(branch: Branch, spec: AgentSpec) -> None:
+    for tool_spec in spec.tools:
         if tool_spec == "coding":
-            _register_coding_tools(branch, config)
+            _register_coding_tools(branch, spec)
         elif tool_spec == "reader":
             from lionagi.tools.file.reader import ReaderTool
 
-            # Finding 15: attach config hooks to standalone reader tool
-            tool = _attach_hooks(ReaderTool().to_tool(), config, "reader")
+            tool = _attach_hooks(ReaderTool().to_tool(), spec, "reader")
             branch.register_tools(tool)
         elif tool_spec == "editor":
             from lionagi.tools.file.editor import EditorTool
 
-            # Finding 15: attach config hooks to standalone editor tool
-            tool = _attach_hooks(EditorTool().to_tool(), config, "editor")
+            tool = _attach_hooks(EditorTool().to_tool(), spec, "editor")
             branch.register_tools(tool)
         elif tool_spec == "bash":
             from lionagi.tools.code.bash import BashTool
 
-            # Finding 15: attach config hooks to standalone bash tool
-            tool = _attach_hooks(BashTool().to_tool(), config, "bash")
+            tool = _attach_hooks(BashTool().to_tool(), spec, "bash")
             branch.register_tools(tool)
         elif tool_spec == "search":
             from lionagi.tools.code.search import SearchTool
 
-            # Finding 15: attach config hooks to standalone search tool
-            tool = _attach_hooks(SearchTool().to_tool(), config, "search")
+            tool = _attach_hooks(SearchTool().to_tool(), spec, "search")
             branch.register_tools(tool)
 
 
-def _register_coding_tools(branch: Branch, config: AgentConfig) -> None:
-    """Register CodingToolkit with hooks from config."""
+def _register_coding_tools(branch: Branch, spec: AgentSpec) -> None:
     from pathlib import Path
 
     from lionagi.tools.coding import CodingToolkit
 
-    workspace_root = Path(config.cwd) if config.cwd else Path.cwd()
+    workspace_root = Path(spec.cwd) if spec.cwd else Path.cwd()
     toolkit = CodingToolkit(workspace_root=workspace_root)
 
-    for key, handlers in config.hook_handlers.items():
+    for key, handlers in spec.hook_handlers.items():
         parts = key.split(":", 1)
         if len(parts) != 2:
             continue
         phase, tool_name = parts
         for handler in handlers:
             if phase == "security_pre":
-                # Finding 13: wire security_pre hooks into CodingToolkit's dedicated phase
                 toolkit.security_pre(tool_name, handler)
             elif phase == "pre":
                 toolkit.pre(tool_name, handler)
@@ -257,29 +243,21 @@ def _register_coding_tools(branch: Branch, config: AgentConfig) -> None:
 
 async def _load_mcp(
     branch: Branch,
-    config: AgentConfig,
+    spec: AgentSpec,
     *,
     trust_project_settings: bool = False,
 ) -> None:
-    """Auto-discover and load MCP tools from .mcp.json files.
-
-    Discovery order:
-        1. config.mcp_config_path (explicit)
-        2. .lionagi/.mcp.json (project-local, only when trusted)
-        3. cwd/.mcp.json (current directory, only when trusted)
-        4. ~/.lionagi/.mcp.json (global)
-    """
     from pathlib import Path
 
     mcp_path = None
 
-    if config.mcp_config_path:
-        p = Path(config.mcp_config_path)
+    if spec.mcp_config_path:
+        p = Path(spec.mcp_config_path)
         if p.is_file():
             mcp_path = str(p)
     else:
         candidates = []
-        cwd = Path(config.cwd) if config.cwd else Path.cwd()
+        cwd = Path(spec.cwd) if spec.cwd else Path.cwd()
 
         if trust_project_settings:
             for parent in [cwd, *cwd.parents]:
@@ -300,5 +278,5 @@ async def _load_mcp(
 
     await branch.acts.load_mcp_config(
         mcp_path,
-        server_names=config.mcp_servers,
+        server_names=spec.mcp_servers,
     )

--- a/lionagi/agent/settings.py
+++ b/lionagi/agent/settings.py
@@ -42,6 +42,7 @@ from typing import Any
 import yaml
 
 from .config import AgentConfig
+from .spec import AgentSpec
 
 logger = logging.getLogger(__name__)
 
@@ -92,12 +93,12 @@ def load_settings(
 
 
 def apply_hooks_from_settings(
-    config: AgentConfig,
+    config: AgentSpec | AgentConfig,
     settings: dict[str, Any] | None = None,
     *,
     trusted_hook_modules: set[str] | frozenset[str] | None = None,
-) -> AgentConfig:
-    """Apply hook configuration from settings dict to an AgentConfig.
+) -> AgentSpec | AgentConfig:
+    """Apply hook configuration from settings dict to an AgentSpec (or legacy AgentConfig).
 
     Resolves hook specs (shell commands, Python import paths) into callables
     and registers them on the config.

--- a/lionagi/agent/spec.py
+++ b/lionagi/agent/spec.py
@@ -1,0 +1,261 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from lionagi.casts.pack import Pack
+from lionagi.casts.profile import Profile
+
+if TYPE_CHECKING:
+    from lionagi.ln.types import Operable
+
+    from .permissions import PermissionPolicy
+
+__all__ = ("AgentSpec",)
+
+
+@dataclass
+class AgentSpec:
+    """Universal runtime agent spec: Profile (identity) + runtime concerns.
+
+    This is the orchestration-facing composition surface. Every entry point
+    (CLI, programmatic create_agent, flow wiring) composes to AgentSpec and
+    builds a Branch from it.
+    """
+
+    profile: Profile
+    model: str | None = None
+    effort: str | None = None
+    tools: tuple[str, ...] = ()
+    permissions: PermissionPolicy | None = None
+    grant_emissions: bool = True
+    pack: str | Pack | None = "default"
+    lion_system: bool = True
+    extra_prompt: str | None = None
+    hook_handlers: dict[str, list[Callable]] = field(default_factory=dict)
+    cwd: str | None = None
+    yolo: bool = False
+    mcp_servers: list[str] | None = None
+    mcp_config_path: str | None = None
+
+    def pre(self, tool_name: str, handler: Callable) -> AgentSpec:
+        self.hook_handlers.setdefault(f"pre:{tool_name}", []).append(handler)
+        return self
+
+    def post(self, tool_name: str, handler: Callable) -> AgentSpec:
+        self.hook_handlers.setdefault(f"post:{tool_name}", []).append(handler)
+        return self
+
+    def on_error(self, tool_name: str, handler: Callable) -> AgentSpec:
+        self.hook_handlers.setdefault(f"error:{tool_name}", []).append(handler)
+        return self
+
+    @classmethod
+    def compose(
+        cls,
+        role: Any,
+        *,
+        modes: list[Any] | None = None,
+        model: str | None = None,
+        effort: str | None = None,
+        tools: tuple[str, ...] | list[str] = (),
+        permissions: Any = None,
+        pack: str | Pack | None = "default",
+        grant_emissions: bool = True,
+        system_prompt: str | None = None,
+        cwd: str | None = None,
+        yolo: bool = False,
+    ) -> AgentSpec:
+        """Build an AgentSpec from a role name/object + optional overrides."""
+        prof = Profile.compose(role, modes=modes)
+        perm = _resolve_permissions(permissions)
+        return cls(
+            profile=prof,
+            model=model,
+            effort=effort,
+            tools=tuple(tools),
+            permissions=perm,
+            pack=pack,
+            grant_emissions=grant_emissions,
+            extra_prompt=system_prompt or None,
+            cwd=cwd,
+            yolo=yolo,
+        )
+
+    @classmethod
+    def coding(
+        cls,
+        *,
+        model: str | None = None,
+        effort: str | None = "high",
+        system_prompt: str | None = None,
+        cwd: str | None = None,
+        **kwargs: Any,
+    ) -> AgentSpec:
+        """Preset for a coding agent — implementer role + coding tools."""
+        return cls.compose(
+            "implementer",
+            model=model,
+            effort=effort,
+            tools=["coding"],
+            system_prompt=system_prompt,
+            cwd=cwd,
+            **kwargs,
+        )
+
+    @classmethod
+    def from_yaml(cls, path: str | Path) -> AgentSpec:
+        """Load an agent spec from a YAML file."""
+        import yaml
+
+        p = Path(path)
+        data = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+        return cls.compose(
+            role=data.get("role", "implementer"),
+            modes=data.get("modes"),
+            model=data.get("model"),
+            effort=data.get("effort"),
+            tools=data.get("tools", []),
+            permissions=data.get("permissions"),
+            pack=data.get("pack", "default"),
+            system_prompt=data.get("system_prompt"),
+            cwd=data.get("cwd"),
+            yolo=data.get("yolo", False),
+        )
+
+    def build_system_message(self) -> str:
+        """Compose role + modes + RolePolicy block + any extra literal prompt."""
+        body = self.profile.build_system_message()
+        policy_block = self._render_policy_block()
+        parts = [p for p in (body, policy_block, self.extra_prompt) if p]
+        return "\n\n".join(parts)
+
+    def emission_operable(self) -> Operable | None:
+        """Return the role's Operable for emission granting, or None."""
+        if not self.grant_emissions:
+            return None
+        return self.profile.emission_operable()
+
+    def to_yaml(self, path: str | Path) -> None:
+        """Save spec to YAML (without hook callables — those are code-only)."""
+        data = {
+            "role": self.profile.role.name,
+            "modes": [m.name for m in self.profile.modes],
+            "model": self.model,
+            "effort": self.effort,
+            "tools": list(self.tools),
+            "pack": self.pack if isinstance(self.pack, str) else None,
+            "system_prompt": self.extra_prompt,
+            "yolo": self.yolo,
+            "lion_system": self.lion_system,
+        }
+        if self.cwd:
+            data["cwd"] = self.cwd
+        with open(path, "w") as f:
+            import yaml
+
+            yaml.dump(data, f, default_flow_style=False, allow_unicode=True)
+
+    def _render_policy_block(self) -> str:
+        if self.pack is None:
+            return ""
+        pack = _load_pack(self.pack)
+        if pack is None:
+            return ""
+        policy = pack.policy(self.profile.role.name)
+        if policy is None:
+            return ""
+
+        lines: list[str] = []
+        if policy.authority:
+            lines.append("## Authority")
+            lines.extend(f"- {a}" for a in policy.authority)
+        if policy.boundaries:
+            if lines:
+                lines.append("")
+            lines.append("## Operational Boundaries")
+            lines.extend(f"- {b}" for b in policy.boundaries)
+        if policy.escalations:
+            if lines:
+                lines.append("")
+            lines.append("## Escalation Conditions")
+            lines.append(
+                "When any of these conditions occur, STOP and emit an"
+                " `escalation_request` with the reason:"
+            )
+            lines.extend(f"- {e}" for e in policy.escalations)
+        return "\n".join(lines)
+
+    @classmethod
+    def from_legacy(cls, config: Any) -> AgentSpec:
+        """Bridge a legacy AgentConfig into an AgentSpec."""
+        from .permissions import PermissionPolicy
+
+        perm: PermissionPolicy | None = None
+        if config.permissions:
+            if isinstance(config.permissions, PermissionPolicy):
+                perm = config.permissions
+            elif isinstance(config.permissions, dict):
+                perm = PermissionPolicy.from_dict(config.permissions)
+
+        role = config.role or "implementer"
+        prof = Profile.compose(role=role, modes=config.modes or [])
+
+        return cls(
+            profile=prof,
+            model=config.model,
+            effort=config.effort,
+            tools=tuple(config.tools or []),
+            permissions=perm,
+            grant_emissions=True,
+            pack="default",
+            lion_system=config.lion_system,
+            extra_prompt=config.system_prompt or None,
+            hook_handlers={k: list(v) for k, v in config.hook_handlers.items()},
+            cwd=config.cwd,
+            yolo=config.yolo,
+            mcp_servers=config.mcp_servers,
+            mcp_config_path=config.mcp_config_path,
+        )
+
+
+def _resolve_permissions(permissions: Any) -> PermissionPolicy | None:
+    from .permissions import PermissionPolicy
+
+    if permissions is None:
+        return None
+    if isinstance(permissions, PermissionPolicy):
+        return permissions
+    if isinstance(permissions, dict):
+        return PermissionPolicy.from_dict(permissions)
+    if isinstance(permissions, str):
+        presets = {
+            "safe": PermissionPolicy.safe,
+            "read_only": PermissionPolicy.read_only,
+            "allow_all": PermissionPolicy.allow_all,
+            "deny_all": PermissionPolicy.deny_all,
+        }
+        factory = presets.get(permissions.lower())
+        if factory is None:
+            raise ValueError(
+                f"Unknown permissions preset {permissions!r}. Valid: {sorted(presets)}"
+            )
+        return factory()
+    raise TypeError(f"Cannot resolve permissions from {type(permissions)!r}")
+
+
+def _load_pack(pack: str | Pack) -> Pack | None:
+    if isinstance(pack, Pack):
+        return pack
+    if pack == "default":
+        from importlib.resources import as_file, files
+
+        packaged = files("lionagi.casts").joinpath("packs", "default.yaml")
+        with as_file(packaged) as p:
+            return Pack.from_file(p)
+    return None

--- a/lionagi/casts/profile.py
+++ b/lionagi/casts/profile.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from lionagi.casts.pattern import Mode, Role
+
+if TYPE_CHECKING:
+    from lionagi.ln.types import Operable
+
+__all__ = ("Profile",)
+
+
+@dataclass(frozen=True, slots=True)
+class Profile:
+    """Named identity composition: one Role + ordered cognitive Modes.
+
+    Pure configuration — no tools, model, or permissions. Validates mode
+    conflicts at construction time (both directions of conflicts_with).
+    """
+
+    name: str
+    role: Role
+    modes: tuple[Mode, ...] = ()
+
+    def __post_init__(self) -> None:
+        seen: dict[str, Mode] = {}
+        for m in self.modes:
+            for other in seen.values():
+                if m.name in other.conflicts_with or other.name in m.conflicts_with:
+                    raise ValueError(f"Mode conflict: {m.name!r} vs {other.name!r}")
+            seen[m.name] = m
+
+    def emission_operable(self) -> Operable | None:
+        """Delegate to the role's emission contract."""
+        return self.role.emission_operable()
+
+    def build_system_message(self) -> str:
+        """Compose role body + each mode's behaviors, joined by blank lines."""
+        parts = [self.role.body] if self.role.body else []
+        parts += [m.behaviors for m in self.modes if m.behaviors]
+        return "\n\n".join(parts)
+
+    @classmethod
+    def compose(
+        cls,
+        role: str | Role,
+        *,
+        modes: list[str | Mode] | None = None,
+        name: str | None = None,
+    ) -> Profile:
+        """Build a Profile from role/mode names or objects."""
+        r = role if not isinstance(role, str) else Role.load(role)
+        ms = tuple(m if not isinstance(m, str) else Mode.load(m) for m in (modes or []))
+        return cls(name=name or r.name, role=r, modes=ms)
+
+    @classmethod
+    def from_yaml(cls, path: str | Path) -> Profile:
+        """Load a Profile from a YAML file with {name, role, modes: [...]}."""
+        import yaml
+
+        data = yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+        return cls.compose(
+            role=data["role"],
+            modes=data.get("modes") or [],
+            name=data.get("name"),
+        )

--- a/lionagi/tools/coding.py
+++ b/lionagi/tools/coding.py
@@ -297,9 +297,7 @@ def _read_image_sync(path: str, workspace_root: Path) -> dict:
     }
 
 
-def _read_file_sync(
-    path: str, offset: int, max_lines: int, workspace_root: Path
-) -> dict:
+def _read_file_sync(path: str, offset: int, max_lines: int, workspace_root: Path) -> dict:
     # Finding 14: validate path under workspace root
     try:
         p = _resolve_workspace_path(path, workspace_root)
@@ -470,7 +468,7 @@ def _drain_stream(stream, buf: bytearray) -> bool:
 def _subprocess_sync(cmd, shell: bool, timeout_s: float, cwd: str | None) -> dict:
     # Finding 5: use Popen + threads for bounded memory capture and child-group kill
     try:
-        proc = subprocess.Popen(
+        proc = subprocess.Popen(  # noqa: S603
             cmd,
             shell=shell,
             stdout=subprocess.PIPE,
@@ -672,8 +670,6 @@ class CodingToolkit(LionTool):
         call_count = [0]
         msgs = branch.msgs
         notify = self.notify
-        threshold = self.notify_threshold
-        max_tokens = self.notify_max_tokens
         # Finding 14: capture workspace root for use in all sync file helpers
         workspace_root = self.workspace_root
 
@@ -756,9 +752,7 @@ class CodingToolkit(LionTool):
                 start = max(0, offset or 0)
                 max_lines = limit if (limit and limit > 0) else 2000
                 # Finding 14: pass workspace_root to enforce path containment
-                result = await run_sync(
-                    _read_file_sync, path, start, max_lines, workspace_root
-                )
+                result = await run_sync(_read_file_sync, path, start, max_lines, workspace_root)
                 _track(result)
                 return result
             elif action == "list_dir":
@@ -794,9 +788,7 @@ class CodingToolkit(LionTool):
                     if guard:
                         return {"success": False, "error": guard}
                 # Finding 14: pass workspace_root to enforce path containment
-                result = await run_sync(
-                    _write_file_sync, file_path, content, workspace_root
-                )
+                result = await run_sync(_write_file_sync, file_path, content, workspace_root)
                 _track(result)
                 return result
             elif action == "edit":
@@ -875,9 +867,7 @@ class CodingToolkit(LionTool):
             """
             if action == "grep":
                 try:
-                    search_path = str(
-                        _resolve_workspace_path(path or ".", workspace_root)
-                    )
+                    search_path = str(_resolve_workspace_path(path or ".", workspace_root))
                 except PermissionError as e:
                     return {"success": False, "error": str(e)}
                 limit = max_results or 50
@@ -887,9 +877,7 @@ class CodingToolkit(LionTool):
                 raw = await run_sync(_subprocess_sync, cmd, False, 30.0, None)
                 if raw.get("returncode") == 2:
                     return {"success": False, "error": raw["stderr"].strip()}
-                lines = (
-                    raw["stdout"].strip().split("\n") if raw["stdout"].strip() else []
-                )
+                lines = raw["stdout"].strip().split("\n") if raw["stdout"].strip() else []
                 total = len(lines)
                 return {
                     "success": True,
@@ -899,9 +887,7 @@ class CodingToolkit(LionTool):
                 }
             elif action == "find":
                 try:
-                    search_path = str(
-                        _resolve_workspace_path(path or ".", workspace_root)
-                    )
+                    search_path = str(_resolve_workspace_path(path or ".", workspace_root))
                 except PermissionError as e:
                     return {"success": False, "error": str(e)}
                 limit = max_results or 100
@@ -909,9 +895,7 @@ class CodingToolkit(LionTool):
                 raw = await run_sync(_subprocess_sync, cmd, False, 30.0, None)
                 if raw.get("returncode", 0) != 0 and raw.get("stderr", "").strip():
                     return {"success": False, "error": raw["stderr"].strip()}
-                lines = (
-                    raw["stdout"].strip().split("\n") if raw["stdout"].strip() else []
-                )
+                lines = raw["stdout"].strip().split("\n") if raw["stdout"].strip() else []
                 total = len(lines)
                 return {
                     "success": True,
@@ -1020,9 +1004,7 @@ class CodingToolkit(LionTool):
                 cp = _ensure_current_progression()
                 keep = keep_last if keep_last is not None else 5
                 ar_uids = [
-                    uid
-                    for uid in cp
-                    if uid in pile and isinstance(pile[uid], ActionResponse)
+                    uid for uid in cp if uid in pile and isinstance(pile[uid], ActionResponse)
                 ]
                 if len(ar_uids) <= keep:
                     return {
@@ -1145,18 +1127,10 @@ class CodingToolkit(LionTool):
             - safe: read + write + search, bash restricted (no rm/sudo)
             - allow_all: full access (use for trusted implementation tasks)
             """
-            from lionagi.agent.config import AgentConfig
-            from lionagi.agent.permissions import PermissionPolicy
+            from lionagi.agent.spec import AgentSpec
 
             max_turns = min(max(1, max_turns), 50)
             sub_cwd = cwd or (str(workspace_root) if workspace_root else None)
-
-            perm_map = {
-                "read_only": PermissionPolicy.read_only(),
-                "safe": PermissionPolicy.safe(),
-                "allow_all": PermissionPolicy.allow_all(),
-            }
-            sub_permissions = perm_map.get(permissions, PermissionPolicy.read_only())
 
             try:
                 model_spec = None
@@ -1171,22 +1145,23 @@ class CodingToolkit(LionTool):
                 except AttributeError:
                     pass
 
-                sub_config = AgentConfig(
-                    name="subagent",
+                sub_spec = AgentSpec.compose(
+                    "implementer",
                     model=model_spec,
                     tools=["coding"],
-                    permissions=sub_permissions,
-                    cwd=sub_cwd,
+                    permissions=permissions,
                     system_prompt=(
                         "You are a sub-agent. Complete the assigned task concisely. "
                         "Report your findings and any changes made. Be thorough but brief."
                     ),
-                    lion_system=False,
+                    cwd=sub_cwd,
+                    yolo=False,
                 )
+                sub_spec.lion_system = False
 
                 from lionagi.agent.factory import create_agent as _create
 
-                sub_branch = await _create(sub_config, load_settings=False)
+                sub_branch = await _create(sub_spec, load_settings=False)
 
                 result = await sub_branch.ReAct(
                     instruction=instruction,

--- a/tests/agent/test_spec.py
+++ b/tests/agent/test_spec.py
@@ -1,0 +1,381 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.agent.config import AgentConfig
+from lionagi.agent.factory import create_agent
+from lionagi.agent.permissions import PermissionPolicy
+from lionagi.agent.spec import AgentSpec, _resolve_permissions
+from lionagi.casts.profile import Profile
+from lionagi.session.branch import Branch
+
+# ---------------------------------------------------------------------------
+# _resolve_permissions
+# ---------------------------------------------------------------------------
+
+
+class TestResolvePermissions:
+    def test_none(self):
+        assert _resolve_permissions(None) is None
+
+    def test_policy_passthrough(self):
+        p = PermissionPolicy.safe()
+        assert _resolve_permissions(p) is p
+
+    def test_dict(self):
+        result = _resolve_permissions({"mode": "deny_all"})
+        assert isinstance(result, PermissionPolicy)
+        assert result.mode == "deny_all"
+
+    @pytest.mark.parametrize(
+        "preset,expected_mode",
+        [
+            ("safe", "rules"),
+            ("read_only", "rules"),
+            ("allow_all", "allow_all"),
+            ("deny_all", "deny_all"),
+        ],
+    )
+    def test_preset_string(self, preset, expected_mode):
+        result = _resolve_permissions(preset)
+        assert isinstance(result, PermissionPolicy)
+        assert result.mode == expected_mode
+
+    def test_invalid_preset(self):
+        with pytest.raises(ValueError, match="Unknown permissions preset"):
+            _resolve_permissions("super_safe")
+
+    def test_invalid_type(self):
+        with pytest.raises(TypeError):
+            _resolve_permissions(42)
+
+
+# ---------------------------------------------------------------------------
+# AgentSpec.compose
+# ---------------------------------------------------------------------------
+
+
+class TestAgentSpecCompose:
+    def test_basic(self):
+        spec = AgentSpec.compose("analyst")
+        assert isinstance(spec.profile, Profile)
+        assert spec.profile.role.name == "analyst"
+        assert spec.permissions is None
+
+    def test_with_modes(self):
+        spec = AgentSpec.compose("critic", modes=["adversarial"])
+        assert len(spec.profile.modes) == 1
+        assert spec.profile.modes[0].name == "adversarial"
+
+    def test_resolves_permission_preset(self):
+        spec = AgentSpec.compose("analyst", permissions="safe")
+        assert isinstance(spec.permissions, PermissionPolicy)
+
+    def test_tools_tuple(self):
+        spec = AgentSpec.compose("implementer", tools=["coding", "reader"])
+        assert spec.tools == ("coding", "reader")
+
+    def test_model_effort(self):
+        spec = AgentSpec.compose("analyst", model="openai/gpt-4.1", effort="high")
+        assert spec.model == "openai/gpt-4.1"
+        assert spec.effort == "high"
+
+
+# ---------------------------------------------------------------------------
+# AgentSpec.coding preset
+# ---------------------------------------------------------------------------
+
+
+class TestAgentSpecCoding:
+    def test_coding_preset(self):
+        spec = AgentSpec.coding()
+        assert spec.profile.role.name == "implementer"
+        assert "coding" in spec.tools
+        assert spec.effort == "high"
+
+    def test_coding_custom_model(self):
+        spec = AgentSpec.coding(model="anthropic/claude-sonnet-4-6")
+        assert spec.model == "anthropic/claude-sonnet-4-6"
+
+
+# ---------------------------------------------------------------------------
+# AgentSpec.build_system_message
+# ---------------------------------------------------------------------------
+
+
+class TestAgentSpecSystemMessage:
+    def test_contains_role_body(self):
+        spec = AgentSpec.compose("analyst")
+        msg = spec.build_system_message()
+        assert spec.profile.role.body in msg
+
+    def test_contains_mode_behaviors(self):
+        spec = AgentSpec.compose("critic", modes=["adversarial"])
+        msg = spec.build_system_message()
+        from lionagi.casts.pattern import Mode
+
+        adv = Mode.load("adversarial")
+        assert adv.behaviors in msg
+
+    def test_contains_policy_block(self):
+        spec = AgentSpec.compose("analyst")
+        msg = spec.build_system_message()
+        assert "## Authority" in msg
+        assert "## Escalation Conditions" in msg
+
+    def test_no_pack(self):
+        spec = AgentSpec.compose("analyst")
+        spec2 = AgentSpec(profile=spec.profile, pack=None)
+        msg = spec2.build_system_message()
+        assert spec2.profile.role.body in msg
+        assert "escalation_request" not in msg
+
+    def test_extra_prompt(self):
+        spec = AgentSpec(
+            profile=Profile.compose("analyst"),
+            extra_prompt="Be concise.",
+        )
+        msg = spec.build_system_message()
+        assert "Be concise." in msg
+
+
+# ---------------------------------------------------------------------------
+# AgentSpec.emission_operable
+# ---------------------------------------------------------------------------
+
+
+class TestAgentSpecEmission:
+    def test_delegates_to_role(self):
+        spec = AgentSpec.compose("critic", grant_emissions=True)
+        result = spec.emission_operable()
+        expected = spec.profile.role.emission_operable()
+        assert result == expected
+
+    def test_false_returns_none(self):
+        spec = AgentSpec.compose("critic", grant_emissions=False)
+        assert spec.emission_operable() is None
+
+
+# ---------------------------------------------------------------------------
+# AgentSpec.from_legacy (AgentConfig bridge)
+# ---------------------------------------------------------------------------
+
+
+class TestAgentSpecFromLegacy:
+    def test_maps_role_and_model(self):
+        config = AgentConfig(
+            model="anthropic/claude-sonnet-4-6",
+            role="analyst",
+            effort="high",
+        )
+        spec = AgentSpec.from_legacy(config)
+        assert spec.profile.role.name == "analyst"
+        assert spec.model == "anthropic/claude-sonnet-4-6"
+        assert spec.effort == "high"
+
+    def test_preserves_system_prompt(self):
+        config = AgentConfig(role="analyst", system_prompt="Custom.")
+        spec = AgentSpec.from_legacy(config)
+        assert spec.extra_prompt == "Custom."
+        assert "Custom." in spec.build_system_message()
+
+    def test_empty_system_prompt_gives_none(self):
+        config = AgentConfig(role="analyst", system_prompt="")
+        spec = AgentSpec.from_legacy(config)
+        assert spec.extra_prompt is None
+
+    def test_tools(self):
+        config = AgentConfig(role="analyst", tools=["coding"])
+        spec = AgentSpec.from_legacy(config)
+        assert spec.tools == ("coding",)
+
+    def test_permissions_dict(self):
+        config = AgentConfig(role="analyst", permissions={"mode": "deny_all"})
+        spec = AgentSpec.from_legacy(config)
+        assert isinstance(spec.permissions, PermissionPolicy)
+        assert spec.permissions.mode == "deny_all"
+
+    def test_no_role_defaults_to_implementer(self):
+        config = AgentConfig()
+        spec = AgentSpec.from_legacy(config)
+        assert spec.profile.role.name == "implementer"
+
+    def test_lion_system_preserved(self):
+        config = AgentConfig(role="analyst", lion_system=False)
+        spec = AgentSpec.from_legacy(config)
+        assert spec.lion_system is False
+
+    def test_preserves_hook_handlers(self):
+        config = AgentConfig(role="analyst")
+
+        async def my_guard(tool_name, action, args):
+            pass
+
+        config.pre("bash", my_guard)
+        spec = AgentSpec.from_legacy(config)
+        assert "pre:bash" in spec.hook_handlers
+        assert spec.hook_handlers["pre:bash"] == [my_guard]
+
+    def test_preserves_cwd(self):
+        config = AgentConfig(role="analyst", cwd="/tmp/workspace")
+        spec = AgentSpec.from_legacy(config)
+        assert spec.cwd == "/tmp/workspace"
+
+    def test_preserves_yolo(self):
+        config = AgentConfig(role="analyst", yolo=True)
+        spec = AgentSpec.from_legacy(config)
+        assert spec.yolo is True
+
+    def test_hook_handlers_is_a_copy(self):
+        config = AgentConfig(role="analyst")
+
+        async def hook(tool_name, action, args):
+            pass
+
+        config.pre("bash", hook)
+        spec = AgentSpec.from_legacy(config)
+        spec.hook_handlers["pre:bash"].clear()
+        assert len(config.hook_handlers["pre:bash"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Hook methods
+# ---------------------------------------------------------------------------
+
+
+class TestAgentSpecHooks:
+    def test_pre(self):
+        spec = AgentSpec.compose("analyst")
+
+        async def h(t, a, args):
+            pass
+
+        spec.pre("bash", h)
+        assert spec.hook_handlers["pre:bash"] == [h]
+
+    def test_post(self):
+        spec = AgentSpec.compose("analyst")
+
+        async def h(t, a, args, result):
+            pass
+
+        spec.post("editor", h)
+        assert spec.hook_handlers["post:editor"] == [h]
+
+    def test_on_error(self):
+        spec = AgentSpec.compose("analyst")
+
+        async def h(t, a, args):
+            pass
+
+        spec.on_error("bash", h)
+        assert spec.hook_handlers["error:bash"] == [h]
+
+    def test_chaining(self):
+        spec = AgentSpec.compose("analyst")
+
+        async def h(t, a, args):
+            pass
+
+        result = spec.pre("bash", h)
+        assert result is spec
+
+
+# ---------------------------------------------------------------------------
+# Factory: create_agent with AgentSpec
+# ---------------------------------------------------------------------------
+
+
+class TestCreateAgentWithSpec:
+    async def test_returns_branch(self):
+        spec = AgentSpec.compose("analyst")
+        branch = await create_agent(spec, load_settings=False)
+        assert isinstance(branch, Branch)
+
+    async def test_system_message_contains_role(self):
+        spec = AgentSpec.compose("analyst")
+        branch = await create_agent(spec, load_settings=False)
+        assert spec.profile.role.body in branch.msgs.system.rendered
+
+    async def test_with_tools(self):
+        spec = AgentSpec.compose("analyst", tools=["reader"])
+        branch = await create_agent(spec, load_settings=False)
+        assert "reader_tool" in branch.acts.registry
+
+    async def test_with_permissions_wires_preprocessor(self):
+        spec = AgentSpec.compose("analyst", tools=["reader"], permissions="deny_all")
+        branch = await create_agent(spec, load_settings=False)
+        reader_tool = branch.acts.registry.get("reader_tool")
+        assert reader_tool is not None
+        assert reader_tool.preprocessor is not None
+
+    async def test_deny_all_preprocessor_raises(self):
+        spec = AgentSpec.compose("analyst", tools=["reader"], permissions="deny_all")
+        branch = await create_agent(spec, load_settings=False)
+        reader_tool = branch.acts.registry["reader_tool"]
+        with pytest.raises(PermissionError):
+            await reader_tool.preprocessor({"action": "read", "path": "/tmp/x.py"})
+
+    async def test_agentconfig_still_works(self):
+        config = AgentConfig()
+        branch = await create_agent(config, load_settings=False)
+        assert isinstance(branch, Branch)
+
+    async def test_emission_grant(self):
+        spec = AgentSpec.compose("critic", grant_emissions=True)
+        branch = await create_agent(spec, load_settings=False)
+        assert isinstance(branch, Branch)
+
+    async def test_no_emission_grant(self):
+        spec = AgentSpec.compose("critic", grant_emissions=False)
+        branch = await create_agent(spec, load_settings=False)
+        assert isinstance(branch, Branch)
+
+    async def test_load_settings_false_no_call(self, monkeypatch):
+        import lionagi.agent.settings as settings_mod
+
+        calls = []
+
+        def spy(project_dir=None, *, include_project=True):
+            calls.append(True)
+            return {}
+
+        monkeypatch.setattr(settings_mod, "load_settings", spy)
+        spec = AgentSpec.compose("analyst")
+        await create_agent(spec, load_settings=False)
+        assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# YAML round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestAgentSpecYaml:
+    def test_from_yaml(self, tmp_path):
+        data = {
+            "role": "analyst",
+            "modes": ["adversarial"],
+            "model": "openai/gpt-4.1",
+            "effort": "high",
+            "tools": ["reader"],
+        }
+        import yaml
+
+        p = tmp_path / "spec.yaml"
+        p.write_text(yaml.dump(data))
+        spec = AgentSpec.from_yaml(p)
+        assert spec.profile.role.name == "analyst"
+        assert spec.model == "openai/gpt-4.1"
+        assert spec.tools == ("reader",)
+
+    def test_to_yaml_round_trip(self, tmp_path):
+        spec = AgentSpec.compose("analyst", model="openai/gpt-4.1", tools=["reader"])
+        p = tmp_path / "out.yaml"
+        spec.to_yaml(p)
+        loaded = AgentSpec.from_yaml(p)
+        assert loaded.profile.role.name == "analyst"
+        assert loaded.model == "openai/gpt-4.1"

--- a/tests/casts/test_profile.py
+++ b/tests/casts/test_profile.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from lionagi.casts.pattern import Mode, Role, list_modes, list_roles
+from lionagi.casts.profile import Profile
+
+
+class TestProfileCompose:
+    def test_compose_by_name(self):
+        p = Profile.compose("analyst")
+        assert p.name == "analyst"
+        assert isinstance(p.role, Role)
+        assert p.modes == ()
+
+    def test_compose_by_role_object(self):
+        role = Role.load("critic")
+        p = Profile.compose(role)
+        assert p.role is role
+        assert p.name == "critic"
+
+    def test_compose_modes_by_name(self):
+        p = Profile.compose("researcher", modes=["evidential", "systematic"])
+        assert len(p.modes) == 2
+        assert p.modes[0].name == "evidential"
+        assert p.modes[1].name == "systematic"
+
+    def test_compose_modes_by_object(self):
+        m = Mode.load("adversarial")
+        p = Profile.compose("critic", modes=[m])
+        assert p.modes[0] is m
+
+    def test_compose_custom_name(self):
+        p = Profile.compose("analyst", name="my-analyst")
+        assert p.name == "my-analyst"
+
+
+class TestProfileConflicts:
+    def test_fast_slow_conflict(self):
+        with pytest.raises(ValueError, match="conflict"):
+            Profile.compose("researcher", modes=["fast", "slow"])
+
+    def test_fast_systematic_conflict(self):
+        with pytest.raises(ValueError, match="conflict"):
+            Profile.compose("researcher", modes=["fast", "systematic"])
+
+    def test_no_conflict_evidential_adversarial(self):
+        p = Profile.compose("critic", modes=["evidential", "adversarial"])
+        assert len(p.modes) == 2
+
+
+class TestProfileBuildSystemMessage:
+    def test_includes_role_body(self):
+        p = Profile.compose("analyst")
+        msg = p.build_system_message()
+        assert p.role.body in msg
+
+    def test_includes_mode_behaviors(self):
+        p = Profile.compose("analyst", modes=["adversarial"])
+        msg = p.build_system_message()
+        adv = Mode.load("adversarial")
+        assert adv.behaviors in msg
+
+    def test_no_modes_returns_role_body(self):
+        p = Profile.compose("analyst")
+        msg = p.build_system_message()
+        assert msg == p.role.body
+
+
+class TestProfileEmission:
+    def test_emission_operable_delegates_to_role(self):
+        p = Profile.compose("analyst")
+        op = p.emission_operable()
+        assert op == p.role.emission_operable()
+
+    def test_emission_operable_for_role_with_emits(self):
+        p = Profile.compose("critic")
+        op = p.emission_operable()
+        assert op is not None
+        assert "escalation_request" in op.allowed()
+
+
+class TestProfileFrozen:
+    def test_is_frozen(self):
+        p = Profile.compose("analyst")
+        with pytest.raises(AttributeError):
+            p.name = "other"
+
+
+class TestProfileFromYaml:
+    def test_round_trip(self, tmp_path):
+        data = {"name": "test-profile", "role": "analyst", "modes": ["evidential"]}
+        yaml_file = tmp_path / "profile.yaml"
+        yaml_file.write_text(yaml.dump(data))
+        p = Profile.from_yaml(yaml_file)
+        assert p.name == "test-profile"
+        assert p.role.name == "analyst"
+        assert len(p.modes) == 1
+        assert p.modes[0].name == "evidential"
+
+    def test_no_modes(self, tmp_path):
+        data = {"name": "bare", "role": "critic"}
+        yaml_file = tmp_path / "bare.yaml"
+        yaml_file.write_text(yaml.dump(data))
+        p = Profile.from_yaml(yaml_file)
+        assert p.modes == ()
+
+
+class TestListRolesAndModes:
+    def test_list_roles_includes_known(self):
+        roles = list_roles()
+        for name in ("analyst", "critic", "implementer", "researcher", "reviewer"):
+            assert name in roles
+
+    def test_list_roles_is_sorted(self):
+        roles = list_roles()
+        assert roles == sorted(roles)
+
+    def test_list_modes_includes_known(self):
+        modes = list_modes()
+        for name in ("adversarial", "fast", "slow", "systematic", "evidential"):
+            assert name in modes
+
+    def test_list_modes_is_sorted(self):
+        modes = list_modes()
+        assert modes == sorted(modes)


### PR DESCRIPTION
## Summary
- **AgentSpec** as primary agent creation surface, superseding AgentConfig internally
- **Profile** (frozen `Role + tuple[Mode]`) with mode conflict detection
- Emission auto-granting via `Role.emission_operable()`
- Pack policy block rendered into system prompt (authority/boundaries/escalation)
- **CLI orchestration wiring** (Layer 4 from #1213):
  - FlowAgent gains `modes` and `permissions` fields
  - Planner roster uses casts ontology (role descriptions, mode descriptions, permission presets)
  - Plan validation: unknown roles/modes, mode conflicts, unknown permission presets
  - `build_worker_branch` casts AgentSpec fallback when no profile file matches
  - Permission translation via `translate_permissions()` in `providers/anthropic/claude_code/models.py`
  - Emission operable granted to casts-path workers after session attachment
  - Observer wiring: EscalationRequest + Verdict recorded during flow execution
- `tools/coding.py` sub-agent updated from AgentConfig to AgentSpec
- Fixes pre-existing UP038/S110 lint in claude_code models

Closes #1212, #1213 (both superseded by this PR)

## Test plan
- [x] 69 tests for Profile + AgentSpec (composition, conflicts, emission, factory, YAML, legacy bridge)
- [x] 22 tests for Layer 4 (FlowAgent fields, plan validation, permission adapter, build_worker_branch, observer wiring)
- [x] 251 total agent + casts tests pass (zero regressions)
- [x] Lint clean (ruff + pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)