### PR TITLE
feat(core): primitives — Pile type/Filter query, ln filter DSL, total Event

### DIFF
--- a/lionagi/ln/types/__init__.py
+++ b/lionagi/ln/types/__init__.py
@@ -12,7 +12,16 @@ from ._sentinel import (
     not_sentinel,
 )
 from .base import DataClass, Enum, KeysDict, KeysLike, Meta, ModelConfig, Params
-from .filters import FieldRef, Filter, RoleFilter, SpecFilter, TypeFilter, as_filter
+from .filters import (
+    FieldRef,
+    Filter,
+    RoleFilter,
+    SpecFilter,
+    TypeFilter,
+    all_of,
+    as_filter,
+    resolve_path,
+)
 from .operable import Operable
 from .spec import CommonMeta, Spec
 
@@ -48,4 +57,6 @@ __all__ = (
     "FieldRef",
     "RoleFilter",
     "as_filter",
+    "all_of",
+    "resolve_path",
 )

--- a/lionagi/ln/types/filters.py
+++ b/lionagi/ln/types/filters.py
@@ -31,7 +31,16 @@ import operator
 from collections.abc import Callable
 from typing import Any
 
-__all__ = ("Filter", "TypeFilter", "SpecFilter", "FieldRef", "RoleFilter", "as_filter")
+__all__ = (
+    "Filter",
+    "TypeFilter",
+    "SpecFilter",
+    "FieldRef",
+    "RoleFilter",
+    "as_filter",
+    "all_of",
+    "resolve_path",
+)
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +53,31 @@ def field_values(payload: Any) -> dict[str, Any]:
     if isinstance(payload, dict):
         return payload
     return {}
+
+
+_MISSING = object()
+
+
+def resolve_path(payload: Any, dotted: str) -> Any:
+    """Resolve a (possibly dotted) field path on a payload; ``_MISSING`` if absent.
+
+    Reads via attribute access (so properties like ``Event.status`` and nested
+    paths like ``execution.duration`` resolve), falling back to item access for
+    dict payloads. Unlike :func:`field_values`, this is not limited to declared
+    model fields — it is what lets the filter DSL reach an event's execution
+    state, not just its Pydantic fields.
+    """
+    cur: Any = payload
+    for part in dotted.split("."):
+        if isinstance(cur, dict):
+            if part not in cur:
+                return _MISSING
+            cur = cur[part]
+        else:
+            cur = getattr(cur, part, _MISSING)
+            if cur is _MISSING:
+                return _MISSING
+    return cur
 
 
 class Filter:
@@ -120,14 +154,45 @@ class SpecFilter(Filter):
 
 
 def as_filter(x: Filter | type | Callable) -> Filter:
-    """Coerce a type, callable, or Filter into a Filter."""
+    """Coerce a type, ``__as_filter__`` provider, callable, or Filter into a Filter.
+
+    An object exposing ``__as_filter__()`` (e.g. an ``EventStatus`` member) builds
+    its own Filter — the hook that lets a value participate in the DSL without the
+    low-level filter module importing it. Checked before ``callable`` so a Filter
+    that happens to be callable is not mistaken for a bare predicate.
+    """
     if isinstance(x, Filter):
         return x
     if isinstance(x, type):
         return TypeFilter(x)
+    conv = getattr(x, "__as_filter__", None)
+    if conv is not None:
+        result = conv()
+        if not isinstance(result, Filter):
+            raise TypeError(
+                f"{type(x).__name__}.__as_filter__() must return a Filter, got {result!r}"
+            )
+        return result
     if callable(x):
         return SpecFilter(x, getattr(x, "__name__", "predicate"))
     raise TypeError(f"Cannot use {x!r} as a Filter")
+
+
+def all_of(*keys: Filter | type | Callable) -> Filter:
+    """AND-compose one or more keys (each coerced via :func:`as_filter`).
+
+    The compositional core of ``observe(APICalling, EventStatus.FAILED, …)`` —
+    every key must match the same payload. A single key returns its own filter
+    unchanged; zero keys is an error (an empty conjunction matches everything,
+    which is never what a subscription wants).
+    """
+    flts = [as_filter(k) for k in keys]
+    if not flts:
+        raise TypeError("all_of() requires at least one filter")
+    if len(flts) == 1:
+        return flts[0]
+    composed = "(" + " & ".join(repr(f) for f in flts) + ")"
+    return SpecFilter(lambda p: all(f(p) for f in flts), composed)
 
 
 class RoleFilter(Filter):
@@ -183,10 +248,10 @@ class FieldRef:
         name = self.name
 
         def check(payload: Any) -> bool:
-            values = field_values(payload)
-            if name not in values:
+            val = resolve_path(payload, name)
+            if val is _MISSING:
                 return False
-            return op(values[name], other)
+            return op(val, other)
 
         return SpecFilter(check, f"{name}{sym}{other!r}", safe=True)
 
@@ -213,6 +278,11 @@ class FieldRef:
 
     def present(self) -> SpecFilter:
         name = self.name
-        return SpecFilter(lambda p: field_values(p).get(name) is not None, f"{name}?", safe=True)
+
+        def check(p: Any) -> bool:
+            val = resolve_path(p, name)
+            return val is not None and val is not _MISSING
+
+        return SpecFilter(check, f"{name}?", safe=True)
 
     __hash__ = None  # type: ignore[assignment]  # __eq__ returns a Filter, not a bool

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -322,7 +322,9 @@ class DependencyAwareExecutor:
             raise
 
         except Exception as e:
-            # Event.invoke() already set FAILED status and re-raised
+            # invoke() is total (failures are captured as FAILED status and
+            # handled above); this is a defensive net for an unexpected
+            # flow-level error around the operation, not the operation itself.
             if operation.id not in self.results:
                 self.results[operation.id] = {"error": str(e)}
 

--- a/lionagi/protocols/action/manager.py
+++ b/lionagi/protocols/action/manager.py
@@ -103,9 +103,7 @@ class ActionManager(Manager):
             )
         self.registry[tool.function] = tool
 
-    def register_tools(
-        self, tools: list[FuncTool] | FuncTool, update: bool = False
-    ) -> None:
+    def register_tools(self, tools: list[FuncTool] | FuncTool, update: bool = False) -> None:
         """
         Register multiple tools at once.
 
@@ -123,9 +121,7 @@ class ActionManager(Manager):
         for t in tools_list:
             self.register_tool(t, update=update)
 
-    def match_tool(
-        self, action_request: ActionRequest | BaseModel | dict
-    ) -> FunctionCalling:
+    def match_tool(self, action_request: ActionRequest | BaseModel | dict) -> FunctionCalling:
         """
         Convert an ActionRequest (or dict with "function"/"arguments")
         into a `FunctionCalling` instance by finding the matching tool.
@@ -173,10 +169,9 @@ class ActionManager(Manager):
             `FunctionCalling` event after it completes execution.
         """
         function_calling = self.match_tool(func_call)
-        try:
-            await function_calling.invoke()
-        except Exception:
-            pass  # Error captured in function_calling.execution
+        # invoke() is total: a tool failure is captured as FAILED status +
+        # execution.error, not raised. Cancellation still propagates.
+        await function_calling.invoke()
         return function_calling
 
     @property
@@ -217,9 +212,7 @@ class ActionManager(Manager):
                 return {"tools": self.schema_list}
             return []
         else:
-            schemas = self._get_tool_schema(
-                tools, auto_register=auto_register, update=update
-            )
+            schemas = self._get_tool_schema(tools, auto_register=auto_register, update=update)
             return {"tools": schemas}
 
     def _get_tool_schema(
@@ -355,18 +348,14 @@ class ActionManager(Manager):
                             "function": {
                                 "name": tool.name,
                                 "description": (
-                                    tool.description
-                                    if hasattr(tool, "description")
-                                    else None
+                                    tool.description if hasattr(tool, "description") else None
                                 ),
                                 "parameters": tool.inputSchema,
                             },
                         }
                 except Exception as schema_error:
                     # If schema extraction fails, let Tool auto-generate from function signature
-                    logging.warning(
-                        f"Could not extract schema for {tool.name}: {schema_error}"
-                    )
+                    logging.warning(f"Could not extract schema for {tool.name}: {schema_error}")
                     tool_schema = None
 
                 try:
@@ -427,13 +416,9 @@ class ActionManager(Manager):
         for server_name in server_names:
             try:
                 # Register using server reference
-                tools = await self.register_mcp_server(
-                    {"server": server_name}, update=update
-                )
+                tools = await self.register_mcp_server({"server": server_name}, update=update)
                 all_tools[server_name] = tools
-                logger.info(
-                    "Registered %d tools from server '%s'", len(tools), server_name
-                )
+                logger.info("Registered %d tools from server '%s'", len(tools), server_name)
             except Exception as e:
                 logger.warning("Failed to register server '%s': %s", server_name, e)
                 all_tools[server_name] = []
@@ -496,9 +481,7 @@ async def load_mcp_tools(
         server_names = list(MCPConnectionPool._configs.keys())
 
     if server_names is None:
-        raise ValueError(
-            "Either provide server_names or config_path to discover servers"
-        )
+        raise ValueError("Either provide server_names or config_path to discover servers")
 
     # Register all servers
     for server_name in server_names:

--- a/lionagi/protocols/generic/event.py
+++ b/lionagi/protocols/generic/event.py
@@ -47,6 +47,19 @@ class EventStatus(str, ln.types.Enum):
     CANCELLED = "cancelled"
     ABORTED = "aborted"
 
+    def __as_filter__(self) -> Any:
+        """Build a Filter matching any event whose ``status`` equals this member.
+
+        The :func:`~lionagi.ln.types.as_filter` hook that lets a status drive a
+        subscription directly — ``session.observe(EventStatus.FAILED)`` reacts to
+        every event that reached FAILED, the reactive-bus complement to logging.
+        Composes with a type and field predicates via
+        ``observe(APICalling, EventStatus.FAILED)``.
+        """
+        from lionagi.ln.types import FieldRef
+
+        return FieldRef("status") == self
+
 
 class Execution:
     """Represents the execution state of an event.
@@ -196,9 +209,7 @@ class Execution:
             exceptions = []
             for exc in eg.exceptions:
                 if isinstance(exc, ExceptionGroup):
-                    exceptions.append(
-                        self._serialize_exception_group(exc, depth + 1, _seen)
-                    )
+                    exceptions.append(self._serialize_exception_group(exc, depth + 1, _seen))
                 else:
                     exceptions.append(
                         {
@@ -253,6 +264,32 @@ class Execution:
             self.error = exc
 
 
+class _EventQuery:
+    """Field handles for an event's queryable state, including nested ``execution.*``.
+
+    Reached via ``Event.q`` (a stateless singleton). ``APICalling.q.duration > 3600``
+    builds a Filter over ``execution.duration``; ``APICalling.q.status`` over the
+    status. Well-known names map to their execution path; anything else is treated
+    as a top-level attribute. The complement to the ``EventStatus`` enum filter for
+    the non-enum (numeric, value) fields.
+    """
+
+    _PATHS: ClassVar[dict[str, str]] = {
+        "status": "execution.status",
+        "duration": "execution.duration",
+        "response": "execution.response",
+        "error": "execution.error",
+        "retryable": "execution.retryable",
+    }
+
+    def __getattr__(self, name: str) -> Any:
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        from lionagi.ln.types import FieldRef
+
+        return FieldRef(self._PATHS.get(name, name))
+
+
 class Event(Element):
     """Extends Element with an execution state.
 
@@ -262,6 +299,10 @@ class Event(Element):
 
     execution: Execution = Field(default_factory=Execution)
     streaming: bool = Field(False, exclude=True)
+
+    # Class-level filter-DSL handle: ``APICalling.q.duration > 3600`` etc. A
+    # stateless singleton; ClassVar keeps Pydantic from treating it as a field.
+    q: ClassVar[_EventQuery] = _EventQuery()
 
     # TODO(#1043 Phase 2): migrate to anyio.Event (needs .clear() audit first)
     # Lazily-created asyncio.Event signalled on terminal status transitions.
@@ -333,9 +374,7 @@ class Event(Element):
             if val in self._TERMINAL_STATUSES and self._completion_event is not None:
                 self._completion_event.set()
         else:
-            raise ValueError(
-                f"Invalid status type: {type(val)}. Expected EventStatus or str."
-            )
+            raise ValueError(f"Invalid status type: {type(val)}. Expected EventStatus or str.")
 
     @property
     def request(self) -> dict:
@@ -343,19 +382,27 @@ class Event(Element):
         return {}
 
     async def invoke(self) -> None:
-        """Execute the event with lifecycle management.
+        """Execute the event, recording the outcome as internal state.
 
-        Idempotent: no-op if status is not PENDING. Handles status
-        transitions, timing, error capture. Override ``_invoke()`` for
-        business logic — do NOT override invoke() in subclasses.
+        Idempotent: no-op if status is not PENDING. Handles status transitions,
+        timing, and error capture. Override ``_invoke()`` for business logic — do
+        NOT override invoke() in subclasses.
 
-        Uses ``self.status`` (the property setter) for terminal
-        transitions so that ``completion_event`` is signalled.
+        Uses ``self.status`` (the property setter) for terminal transitions so
+        that ``completion_event`` is signalled.
 
-        Exception handling:
-            - ``Exception`` subclasses → FAILED status, re-raised.
-            - ``BaseException`` (CancelledError, KeyboardInterrupt) →
-              CANCELLED status, always re-raised.
+        The event IS the outcome channel — a business failure is captured, not
+        propagated:
+
+            - success → COMPLETED, ``response`` set.
+            - ``Exception`` (a failing tool, a bad response, …) → FAILED, the
+              error recorded on ``execution``; **not** re-raised. Callers inspect
+              ``status`` / ``execution.error`` (or call ``assert_completed()`` to
+              opt into fail-fast), and observers react via
+              ``session.observe(EventType, EventStatus.FAILED)``.
+            - ``BaseException`` (CancelledError, KeyboardInterrupt, SystemExit) →
+              CANCELLED, then **re-raised**: cancellation is a control-flow
+              signal that must propagate, never a result to inspect.
         """
         if self.execution.status != EventStatus.PENDING:
             return
@@ -368,11 +415,11 @@ class Event(Element):
             self.execution.response = result
             self.status = EventStatus.COMPLETED
         except Exception as e:
+            # A business failure is internal state, not a propagated exception.
             self.status = EventStatus.FAILED
             self.execution.add_error(e)
-            raise
         except BaseException as e:
-            # CancelledError, KeyboardInterrupt, SystemExit
+            # CancelledError, KeyboardInterrupt, SystemExit — must propagate.
             self.execution.add_error(e)
             self.status = EventStatus.CANCELLED
             raise
@@ -398,10 +445,11 @@ class Event(Element):
         Uses ``self.status`` (the property setter) for terminal transitions
         so that ``completion_event`` is signalled.
 
-        Exception handling:
-            - ``Exception`` subclasses → FAILED status, re-raised.
-            - ``BaseException`` (CancelledError, KeyboardInterrupt) →
-              CANCELLED status, always re-raised.
+        Same outcome contract as :meth:`invoke` (the event IS the outcome):
+            - all chunks yielded → COMPLETED.
+            - ``Exception`` → FAILED, error recorded on ``execution``; **not**
+              re-raised. Chunks emitted before the failure are still yielded.
+            - ``BaseException`` (cancellation) → CANCELLED, then **re-raised**.
         """
         if self.execution.status in self._TERMINAL_STATUSES:
             return
@@ -414,11 +462,11 @@ class Event(Element):
                 yield chunk
             self.status = EventStatus.COMPLETED
         except Exception as e:
+            # A business failure is internal state, not a propagated exception.
             self.status = EventStatus.FAILED
             self.execution.add_error(e)
-            raise
         except BaseException as e:
-            # CancelledError, KeyboardInterrupt, SystemExit
+            # CancelledError, KeyboardInterrupt, SystemExit — must propagate.
             self.execution.add_error(e)
             self.status = EventStatus.CANCELLED
             raise

--- a/lionagi/protocols/generic/pile.py
+++ b/lionagi/protocols/generic/pile.py
@@ -782,6 +782,14 @@ class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
         if key is None:
             raise ValueError("getitem key not provided.")
 
+        # A bare type queries by it: ``pile[FindingEmitted]`` → items that *are*
+        # (or carry a field of) that type, via a TypeFilter. Returns a filtered
+        # Pile, like a slice. A Filter instance is callable and handled below.
+        if isinstance(key, type):
+            from lionagi.ln.types import TypeFilter
+
+            return self._filter_by_function(TypeFilter(key))
+
         if callable(key) and not isinstance(key, (UUID, Element, type)):  # noqa: UP038
             return self._filter_by_function(key)
 

--- a/lionagi/protocols/generic/processor.py
+++ b/lionagi/protocols/generic/processor.py
@@ -188,16 +188,15 @@ class Processor(Observer):
                     next_event = await self.dequeue()
 
                 if await self.request_permission(**next_event.request):
+                    # invoke()/stream() are total: a business failure is captured
+                    # as FAILED status, not raised, so one event's failure never
+                    # aborts the TaskGroup. Cancellation (BaseException) still
+                    # propagates — correctly aborting the group.
                     if next_event.streaming:
-                        # For streaming, we need to consume the async generator.
-                        # Catch exceptions so TaskGroup is not aborted — event
-                        # status is already FAILED/CANCELLED before the raise.
+
                         async def consume_stream(event):
-                            try:
-                                async for _ in event.stream():
-                                    pass
-                            except Exception:
-                                pass  # Status already recorded by Event.stream()
+                            async for _ in event.stream():
+                                pass
 
                         if self._concurrency_sem:
 
@@ -209,24 +208,15 @@ class Processor(Observer):
                         else:
                             tg.start_soon(consume_stream, next_event)
                     else:
-                        # For non-streaming, just invoke.
-                        # Catch exceptions so TaskGroup is not aborted — event
-                        # status is already FAILED/CANCELLED before the raise.
-                        async def _invoke_safe(event):
-                            try:
-                                await event.invoke()
-                            except Exception:
-                                pass  # Status already recorded by Event.invoke()
-
                         if self._concurrency_sem:
 
                             async def invoke_with_sem(event):
                                 async with self._concurrency_sem:
-                                    await _invoke_safe(event)
+                                    await event.invoke()
 
                             tg.start_soon(invoke_with_sem, next_event)
                         else:
-                            tg.start_soon(_invoke_safe, next_event)
+                            tg.start_soon(next_event.invoke)
                     events_processed += 1
 
                 prev_event = next_event
@@ -423,12 +413,8 @@ class Executor(Observer):
             "total_events": len(self.pile),
             "status_counts": self.status_counts(),
             "pending_queue": len(self.pending),
-            "processor_running": (
-                self.processor.execution_mode if self.processor else False
-            ),
-            "processor_stopped": (
-                self.processor.is_stopped() if self.processor else True
-            ),
+            "processor_running": (self.processor.execution_mode if self.processor else False),
+            "processor_stopped": (self.processor.is_stopped() if self.processor else True),
         }
 
     def __contains__(self, ref: ID[Event].Ref) -> bool:

--- a/lionagi/session/observer.py
+++ b/lionagi/session/observer.py
@@ -232,6 +232,11 @@ class SessionObserver(Observer):
 
         Also matches the envelope by exact type, so lifecycle signals
         (``by_type(RunEnd)``) are retrievable like dispatch-time subscriptions.
+
+        Distinct from ``pile[type]`` (which matches at the item level): this
+        UNWRAPS a Signal to its ``data`` payload first, so a capability *bundle*
+        whose ``data`` carries an ``event_type`` field still matches. Pile stays
+        Signal-ignorant by design; this Signal-aware query layers on top.
         """
         flt = TypeFilter(event_type)
         return [e for e in self.flow.items if self._match(flt, e, _payload(e))]

--- a/tests/operations/test_cancelled_status.py
+++ b/tests/operations/test_cancelled_status.py
@@ -103,8 +103,7 @@ async def test_cancelled_vs_failed_status():
 
     op_failed = Operation(operation="chat")
     op_failed._branch = branch
-    with pytest.raises(ValueError, match="This is a failure"):
-        await op_failed.invoke()
+    await op_failed.invoke()  # total: a business failure is captured, not raised
 
     # Failed operation should have FAILED status
     assert op_failed.execution.status == EventStatus.FAILED

--- a/tests/operations/test_operation_node.py
+++ b/tests/operations/test_operation_node.py
@@ -191,9 +191,7 @@ async def test_operation_invoke_with_basemodel_params():
     await op.invoke()
 
     # Verify the method was called with unpacked parameters
-    branch.operate.assert_called_once_with(
-        instruction="Complex task", count=3, enabled=False
-    )
+    branch.operate.assert_called_once_with(instruction="Complex task", count=3, enabled=False)
 
     # Verify response
     assert op.response == {"operation": "operate", "result": "success"}
@@ -244,9 +242,7 @@ async def test_operation_invoke_all_operations():
 
     # Set up all mock methods
     branch.chat = AsyncMock(return_value="chat_response: test")
-    branch.operate = AsyncMock(
-        return_value={"operation": "operate", "result": "success"}
-    )
+    branch.operate = AsyncMock(return_value={"operation": "operate", "result": "success"})
     branch.communicate = AsyncMock(return_value="communicate_response")
     branch.parse = AsyncMock(return_value={"parsed": True})
     branch.ReAct = AsyncMock(return_value={"react": "result"})
@@ -303,10 +299,11 @@ async def test_operation_invoke_invalid_operation():
     # Then change to invalid type (bypassing validation)
     op.operation = "invalid_operation"
 
-    # Invoke should raise ValueError for unsupported operation
+    # invoke() is total: the unsupported-operation error is captured as FAILED state.
     _set_branch(op, branch)
-    with pytest.raises(ValueError, match="Unsupported operation type"):
-        await op.invoke()
+    await op.invoke()
+    assert op.execution.status == EventStatus.FAILED
+    assert "Unsupported operation type" in str(op.execution.error)
 
 
 @pytest.mark.asyncio
@@ -332,10 +329,9 @@ async def test_operation_invoke_exception_handling():
 
     op = Operation(operation="chat", parameters={"instruction": "This will fail"})
     _set_branch(op, branch)
-    with pytest.raises(RuntimeError, match="Test error occurred"):
-        await op.invoke()
+    await op.invoke()  # total: the error is captured as FAILED state, not re-raised
 
-    # Verify error handling — exception is recorded via add_error AND re-raised
+    # Verify error handling — exception is recorded via add_error, not re-raised
     assert op.execution.status == EventStatus.FAILED
     assert isinstance(op.execution.error, RuntimeError)
     assert str(op.execution.error) == "Test error occurred"
@@ -440,10 +436,7 @@ async def test_operation_concurrent_invocations():
     branch.get_operation = MagicMock(side_effect=mock_get_operation)
 
     # Create multiple operations
-    ops = [
-        Operation(operation="chat", parameters={"instruction": f"Task {i}"})
-        for i in range(5)
-    ]
+    ops = [Operation(operation="chat", parameters={"instruction": f"Task {i}"}) for i in range(5)]
 
     # Invoke all operations concurrently
     for op in ops:

--- a/tests/protocols/action/test_function_calling.py
+++ b/tests/protocols/action/test_function_calling.py
@@ -93,9 +93,7 @@ async def test_function_calling_with_async_function(async_tool):
 @pytest.mark.asyncio
 async def test_function_calling_with_parser(tool_with_processors):
     """Test FunctionCalling with result parser."""
-    func_call = FunctionCalling(
-        func_tool=tool_with_processors, arguments={"x": 1, "y": "test"}
-    )
+    func_call = FunctionCalling(func_tool=tool_with_processors, arguments={"x": 1, "y": "test"})
 
     result = await func_call.invoke()
     assert isinstance(func_call.response, str)
@@ -112,8 +110,7 @@ async def test_function_calling_error_handling():
     tool = Tool(func_callable=error_func)
     func_call = FunctionCalling(func_tool=tool, arguments={})
 
-    with pytest.raises(ValueError, match="Test error"):
-        await func_call.invoke()
+    await func_call.invoke()  # total: tool failure captured as FAILED, not raised
     assert func_call.status == EventStatus.FAILED
     assert "Test error" in str(func_call.execution.error)
     assert func_call.execution.duration is not None
@@ -158,8 +155,7 @@ async def test_function_calling_processor_error():
 
     func_call = FunctionCalling(func_tool=tool, arguments={"x": 1})
 
-    with pytest.raises(ValueError, match="Processor error"):
-        await func_call.invoke()
+    await func_call.invoke()  # total: processor failure captured as FAILED, not raised
     assert func_call.response is None
     assert func_call.status == EventStatus.FAILED
     assert "Processor error" in str(func_call.execution.error)

--- a/tests/protocols/generic/test_event.py
+++ b/tests/protocols/generic/test_event.py
@@ -63,8 +63,9 @@ def test_event_serialization():
 @pytest.mark.asyncio
 async def test_event_invoke_not_implemented():
     event = Event()
-    with pytest.raises(NotImplementedError):
-        await event.invoke()
+    await event.invoke()  # total: NotImplementedError captured, not raised
+    assert event.status == EventStatus.FAILED
+    assert isinstance(event.execution.error, NotImplementedError)
 
 
 def test_event_from_dict_not_implemented():

--- a/tests/protocols/generic/test_event_lifecycle.py
+++ b/tests/protocols/generic/test_event_lifecycle.py
@@ -109,26 +109,25 @@ class TestInvokeLifecycle:
         """Status transitions PENDING -> PROCESSING -> FAILED on error."""
         event = FailingEvent()
         assert event.execution.status == EventStatus.PENDING
-        with pytest.raises(ValueError, match="boom"):
-            await event.invoke()
+        await event.invoke()  # total: a business failure is captured, not raised
         assert event.execution.status == EventStatus.FAILED
 
     @pytest.mark.asyncio
     async def test_error_captured_on_failure(self):
         """Error is captured in execution.error via add_error()."""
         event = FailingEvent()
-        with pytest.raises(ValueError):
-            await event.invoke()
+        await event.invoke()
         assert event.execution.error is not None
         assert isinstance(event.execution.error, ValueError)
         assert "boom" in str(event.execution.error)
 
     @pytest.mark.asyncio
-    async def test_error_is_reraised(self):
-        """The original exception is re-raised after being captured."""
+    async def test_error_not_reraised(self):
+        """A business failure is captured as state, NOT re-raised (total invoke)."""
         event = FailingEvent()
-        with pytest.raises(ValueError, match="boom"):
-            await event.invoke()
+        await event.invoke()  # must not raise
+        assert event.execution.status == EventStatus.FAILED
+        assert isinstance(event.execution.error, ValueError)
 
     @pytest.mark.asyncio
     async def test_idempotency_completed(self):
@@ -148,8 +147,7 @@ class TestInvokeLifecycle:
     async def test_idempotency_failed(self):
         """Calling invoke() on a FAILED event is a no-op."""
         event = FailingEvent()
-        with pytest.raises(ValueError):
-            await event.invoke()
+        await event.invoke()
         assert event.execution.status == EventStatus.FAILED
         first_duration = event.execution.duration
 
@@ -171,8 +169,8 @@ class TestInvokeLifecycle:
     async def test_duration_recorded_on_failure(self):
         """Duration is recorded even when _invoke() fails."""
         event = FailingEvent()
-        with pytest.raises(ValueError):
-            await event.invoke()
+        await event.invoke()
+        assert event.execution.status == EventStatus.FAILED
         assert event.execution.duration is not None
         assert event.execution.duration >= 0
 
@@ -187,12 +185,12 @@ class TestInvokeLifecycle:
         assert event.execution.duration is Unset
 
     @pytest.mark.asyncio
-    async def test_base_event_invoke_raises(self):
-        """Calling invoke() on bare Event raises NotImplementedError."""
+    async def test_base_event_invoke_captures(self):
+        """Calling invoke() on bare Event captures NotImplementedError as FAILED."""
         event = Event()
-        with pytest.raises(NotImplementedError):
-            await event.invoke()
+        await event.invoke()
         assert event.execution.status == EventStatus.FAILED
+        assert isinstance(event.execution.error, NotImplementedError)
 
     @pytest.mark.asyncio
     async def test_response_preserved_on_success(self):
@@ -233,9 +231,8 @@ class TestStreamLifecycle:
         """Status transitions to FAILED when _stream() raises."""
         event = StreamFailEvent()
         chunks = []
-        with pytest.raises(RuntimeError, match="stream failed"):
-            async for chunk in event.stream():
-                chunks.append(chunk)
+        async for chunk in event.stream():  # total: failure captured, not raised
+            chunks.append(chunk)
         assert event.execution.status == EventStatus.FAILED
         # First chunk was yielded before the error
         assert chunks == ["first"]
@@ -244,9 +241,8 @@ class TestStreamLifecycle:
     async def test_stream_error_captured(self):
         """Error is captured in execution.error during streaming."""
         event = StreamFailEvent()
-        with pytest.raises(RuntimeError):
-            async for _ in event.stream():
-                pass
+        async for _ in event.stream():
+            pass
         assert event.execution.error is not None
         assert isinstance(event.execution.error, RuntimeError)
 
@@ -263,9 +259,9 @@ class TestStreamLifecycle:
     async def test_stream_duration_recorded_on_failure(self):
         """Duration is recorded even when streaming fails."""
         event = StreamFailEvent()
-        with pytest.raises(RuntimeError):
-            async for _ in event.stream():
-                pass
+        async for _ in event.stream():
+            pass
+        assert event.execution.status == EventStatus.FAILED
         assert event.execution.duration is not None
         assert event.execution.duration >= 0
 
@@ -287,9 +283,8 @@ class TestStreamLifecycle:
     async def test_stream_idempotency_failed(self):
         """Calling stream() on a FAILED event yields nothing."""
         event = StreamFailEvent()
-        with pytest.raises(RuntimeError):
-            async for _ in event.stream():
-                pass
+        async for _ in event.stream():
+            pass
         assert event.execution.status == EventStatus.FAILED
 
         # Stream again -- should yield nothing (no exception)
@@ -310,13 +305,13 @@ class TestStreamLifecycle:
         assert event.execution.response == "direct-stream"
 
     @pytest.mark.asyncio
-    async def test_base_event_stream_raises(self):
-        """Calling stream() on bare Event raises NotImplementedError."""
+    async def test_base_event_stream_captures(self):
+        """Calling stream() on bare Event captures NotImplementedError as FAILED."""
         event = Event()
-        with pytest.raises(NotImplementedError):
-            async for _ in event.stream():
-                pass
+        async for _ in event.stream():
+            pass
         assert event.execution.status == EventStatus.FAILED
+        assert isinstance(event.execution.error, NotImplementedError)
 
     @pytest.mark.asyncio
     async def test_stream_cancelled_status(self):

--- a/tests/protocols/generic/test_pile_filter.py
+++ b/tests/protocols/generic/test_pile_filter.py
@@ -268,3 +268,60 @@ class TestFilterMethod:
         result = p.filter(lambda x: x.value % 2 == 0)
         values = [item.value for item in result]
         assert values == [0, 2, 4]
+
+
+# ---------------------------------------------------------------------------
+# 15. pile[type] / pile[Filter] — getitem query via the Filter primitive
+# ---------------------------------------------------------------------------
+
+
+class TestGetitemFilter:
+    def test_bare_type_filters_by_type(self):
+        items = [Item(value=i) for i in range(3)]
+        others = [OtherItem(name="a"), OtherItem(name="b")]
+        p = Pile(collections=items + others)
+
+        only_items = p[Item]
+        assert isinstance(only_items, Pile)
+        assert len(only_items) == 3
+        assert all(isinstance(x, Item) for x in only_items)
+
+        only_others = p[OtherItem]
+        assert len(only_others) == 2
+        assert all(isinstance(x, OtherItem) for x in only_others)
+
+    def test_bare_type_no_match_returns_empty_pile(self, pile_3):
+        result = pile_3[OtherItem]
+        assert isinstance(result, Pile)
+        assert len(result) == 0
+
+    def test_typefilter_instance(self):
+        from lionagi.ln.types import TypeFilter
+
+        items = [Item(value=i) for i in range(3)]
+        p = Pile(collections=[*items, OtherItem(name="x")])
+        result = p[TypeFilter(Item)]
+        assert len(result) == 3
+
+    def test_specfilter_via_fieldref(self, five_items):
+        from lionagi.ln.types import Spec
+
+        p = Pile(collections=five_items)
+        result = p[Spec(int, name="value").q >= 3]
+        assert isinstance(result, Pile)
+        assert sorted(x.value for x in result) == [3, 4]
+
+    def test_composed_filter(self, five_items):
+        from lionagi.ln.types import Spec, TypeFilter
+
+        p = Pile(collections=[*five_items, OtherItem(name="z")])
+        result = p[TypeFilter(Item) & (Spec(int, name="value").q > 2)]
+        assert sorted(x.value for x in result) == [3, 4]
+
+    def test_preserves_order(self, five_items):
+        from lionagi.ln.types import Spec
+
+        p = Pile(collections=five_items)
+        result = p[Spec(int, name="value").q.is_in([4, 0, 2])]
+        # original progression order, not the choices order
+        assert [x.value for x in result] == [0, 2, 4]

--- a/tests/service/connections/test_api_calling.py
+++ b/tests/service/connections/test_api_calling.py
@@ -42,9 +42,7 @@ class TestAPICalling:
         )
         return Endpoint(config=config)
 
-    def test_api_calling_initialization(
-        self, sample_payload, sample_headers, mock_endpoint
-    ):
+    def test_api_calling_initialization(self, sample_payload, sample_headers, mock_endpoint):
         """Test APICalling initialization."""
         api_call = APICalling(
             payload=sample_payload,
@@ -72,9 +70,7 @@ class TestAPICalling:
 
         assert api_call.response is None
 
-    def test_response_property_after_execution(
-        self, sample_payload, sample_headers, mock_endpoint
-    ):
+    def test_response_property_after_execution(self, sample_payload, sample_headers, mock_endpoint):
         """Test response property returns execution response."""
         api_call = APICalling(
             payload=sample_payload,
@@ -100,9 +96,7 @@ class TestAPICalling:
             endpoint=mock_endpoint,
         )
 
-        with patch.object(
-            mock_endpoint, "call", return_value=mock_response.json.return_value
-        ):
+        with patch.object(mock_endpoint, "call", return_value=mock_response.json.return_value):
             await api_call.invoke()
 
         assert api_call.status == EventStatus.COMPLETED
@@ -110,30 +104,26 @@ class TestAPICalling:
         assert api_call.response is not None
 
     @pytest.mark.asyncio
-    async def test_execution_error_handling(
-        self, sample_payload, sample_headers, mock_endpoint
-    ):
-        """Test error handling during execution — exception is re-raised by Event.invoke()."""
+    async def test_execution_error_handling(self, sample_payload, sample_headers, mock_endpoint):
+        """Test error handling during execution — the error is captured as FAILED state."""
         api_call = APICalling(
             payload=sample_payload,
             headers=sample_headers,
             endpoint=mock_endpoint,
         )
 
-        # Event.invoke() re-raises exceptions after recording FAILED status.
+        # invoke() is total: the error is recorded on execution, not re-raised.
         with patch.object(mock_endpoint, "call", side_effect=Exception("API Error")):
-            with pytest.raises(Exception, match="API Error"):
-                await api_call.invoke()
+            await api_call.invoke()
 
         assert api_call.status == EventStatus.FAILED
         assert api_call.execution is not None
         assert "API Error" in str(api_call.execution.error)
 
     @pytest.mark.asyncio
-    async def test_timeout_handling(
-        self, sample_payload, sample_headers, mock_endpoint
-    ):
-        """Test timeout handling during execution — exception is re-raised by Event.invoke()."""
+    async def test_timeout_handling(self, sample_payload, sample_headers, mock_endpoint):
+        """Test timeout handling during execution — captured as FAILED state (a timeout
+        is a business failure, not cancellation)."""
         api_call = APICalling(
             payload=sample_payload,
             headers=sample_headers,
@@ -145,15 +135,12 @@ class TestAPICalling:
             "call",
             side_effect=asyncio.TimeoutError("Request timed out"),
         ):
-            with pytest.raises(asyncio.TimeoutError):
-                await api_call.invoke()
+            await api_call.invoke()
 
         assert api_call.status == EventStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_streaming_execution(
-        self, sample_payload, sample_headers, mock_endpoint
-    ):
+    async def test_streaming_execution(self, sample_payload, sample_headers, mock_endpoint):
         """Test streaming API call execution."""
         sample_payload["stream"] = True
         api_call = APICalling(
@@ -175,9 +162,7 @@ class TestAPICalling:
         assert len(chunks) >= 2
         assert api_call.status == EventStatus.COMPLETED
 
-    def test_cache_control_handling(
-        self, sample_payload, sample_headers, mock_endpoint
-    ):
+    def test_cache_control_handling(self, sample_payload, sample_headers, mock_endpoint):
         """Test cache control parameter handling."""
         api_call = APICalling(
             payload=sample_payload,
@@ -222,9 +207,7 @@ class TestAPICalling:
             assert api_call.response == responses[i]
 
     @pytest.mark.asyncio
-    async def test_error_propagation(
-        self, sample_payload, sample_headers, mock_endpoint
-    ):
+    async def test_error_propagation(self, sample_payload, sample_headers, mock_endpoint):
         """Test that errors are properly propagated and not swallowed."""
         api_call = APICalling(
             payload=sample_payload,
@@ -234,18 +217,16 @@ class TestAPICalling:
 
         original_error = ValueError("Custom API error")
 
-        # Event.invoke() re-raises after recording FAILED status.
+        # invoke() is total: the error is recorded on execution, not swallowed and
+        # not re-raised. The caller inspects status / execution.error.
         with patch.object(mock_endpoint, "call", side_effect=original_error):
-            with pytest.raises(ValueError, match="Custom API error"):
-                await api_call.invoke()
+            await api_call.invoke()
 
         assert api_call.status == EventStatus.FAILED
         assert api_call.execution.error is not None
         assert "Custom API error" in str(api_call.execution.error)
 
-    def test_include_token_usage_to_model(
-        self, sample_payload, sample_headers, mock_endpoint
-    ):
+    def test_include_token_usage_to_model(self, sample_payload, sample_headers, mock_endpoint):
         """Test include_token_usage_to_model parameter."""
         api_call = APICalling(
             payload=sample_payload,
@@ -273,8 +254,7 @@ class TestAPICalling:
             "call",
             side_effect=ConnectionError("Transient error"),
         ):
-            with pytest.raises(ConnectionError):
-                await api_call1.invoke()
+            await api_call1.invoke()  # total: captured as FAILED, not raised
 
         assert api_call1.status == EventStatus.FAILED
 
@@ -291,9 +271,7 @@ class TestAPICalling:
         assert api_call2.status == EventStatus.COMPLETED
 
     @pytest.mark.asyncio
-    async def test_payload_immutability(
-        self, sample_payload, sample_headers, mock_endpoint
-    ):
+    async def test_payload_immutability(self, sample_payload, sample_headers, mock_endpoint):
         """Test that payload is not mutated during execution."""
         original_payload = sample_payload.copy()
         api_call = APICalling(
@@ -360,9 +338,7 @@ class TestTokenUsageContentInjection:
 
     def test_dict_content_with_text_key_gets_appended(self, token_endpoint):
         """Dict content with 'text' key has token usage appended to that key (line 91-92)."""
-        api_call = self._make_api_call(
-            {"type": "text", "text": "Hello"}, token_endpoint
-        )
+        api_call = self._make_api_call({"type": "text", "text": "Hello"}, token_endpoint)
         result_content = api_call.payload["messages"][-1]["content"]
         assert isinstance(result_content, dict)
         assert "Estimated Current Token Usage" in result_content["text"]
@@ -452,9 +428,7 @@ class TestRequiredTokensProperty:
             payload={"input": "hello world", "model": "gpt-4"},
             endpoint=token_endpoint,
         )
-        with patch.object(
-            TokenCalculator, "calculate_message_tokens", return_value=7
-        ) as mock_calc:
+        with patch.object(TokenCalculator, "calculate_message_tokens", return_value=7) as mock_calc:
             count = api_call.required_tokens
         assert count == 7
         mock_calc.assert_called_once()
@@ -471,9 +445,7 @@ class TestRequiredTokensProperty:
             payload={"input": ["hello", "world"], "model": "gpt-4"},
             endpoint=token_endpoint,
         )
-        with patch.object(
-            TokenCalculator, "calculate_message_tokens", return_value=5
-        ) as mock_calc:
+        with patch.object(TokenCalculator, "calculate_message_tokens", return_value=5) as mock_calc:
             count = api_call.required_tokens
         assert count == 5
         call_args = mock_calc.call_args[0][0]
@@ -488,15 +460,11 @@ class TestRequiredTokensProperty:
             payload={"input": [msg], "model": "gpt-4"},
             endpoint=token_endpoint,
         )
-        with patch.object(
-            TokenCalculator, "calculate_message_tokens", return_value=4
-        ) as mock_calc:
+        with patch.object(TokenCalculator, "calculate_message_tokens", return_value=4) as mock_calc:
             count = api_call.required_tokens
         assert count == 4
 
-    def test_required_tokens_input_non_string_non_list_returns_none(
-        self, token_endpoint
-    ):
+    def test_required_tokens_input_non_string_non_list_returns_none(self, token_endpoint):
         """Input that is neither str nor list results in None (line 133)."""
         api_call = APICalling(
             payload={"input": 12345, "model": "gpt-4"},
@@ -517,9 +485,7 @@ class TestRequiredTokensProperty:
             payload={"texts": ["text1", "text2"], "model": "text-embedding-3-small"},
             endpoint=embed_endpoint,
         )
-        with patch.object(
-            TokenCalculator, "calculate_embed_token", return_value=8
-        ) as mock_calc:
+        with patch.object(TokenCalculator, "calculate_embed_token", return_value=8) as mock_calc:
             count = api_call.required_tokens
         assert count == 8
         mock_calc.assert_called_once()

--- a/tests/service/hooks/integration/test_hooked_event_pre_post_invoke.py
+++ b/tests/service/hooks/integration/test_hooked_event_pre_post_invoke.py
@@ -38,9 +38,7 @@ class TestHookedEventPreHookIntegration:
     """Test pre-invocation hook integration."""
 
     @pytest.mark.anyio
-    async def test_pre_hook_normal_allows_invoke(
-        self, patch_cancellation, patch_logger
-    ):
+    async def test_pre_hook_normal_allows_invoke(self, patch_cancellation, patch_logger):
         """Test that normal pre-hook execution allows _core_invoke() to proceed."""
 
         async def pre_hook(ev, **kw):
@@ -65,7 +63,8 @@ class TestHookedEventPreHookIntegration:
     async def test_pre_hook_exit_aborts_invoke_and_propagates(
         self, patch_cancellation, patch_logger
     ):
-        """Cancellation from pre-hook propagates out of event.invoke() and sets FAILED."""
+        """A pre-hook raising Exception (here MyCancelled) is captured as FAILED; the
+        action is still blocked (core never runs). Raise BaseException to hard-abort."""
 
         async def pre_hook(ev, **kw):
             raise MyCancelled("pre-hook denied")
@@ -74,18 +73,19 @@ class TestHookedEventPreHookIntegration:
         event = MockHookedEvent(invoke_result="SHOULD_NOT_HAPPEN")
         event.create_pre_invoke_hook(hook_registry=registry, exit_hook=True)
 
-        with pytest.raises(MyCancelled, match="pre-hook denied"):
-            await event.invoke()
+        await event.invoke()  # total: hook Exception captured as FAILED, not raised
 
         # Main _core_invoke() should NOT have been called
         assert event.invoke_called is False
         assert event.execution.status == EventStatus.FAILED
+        assert isinstance(event.execution.error, MyCancelled)
 
     @pytest.mark.anyio
     async def test_pre_hook_error_aborts_invoke_regardless_of_exit_flag(
         self, patch_cancellation, patch_logger
     ):
-        """A failing pre-hook (RuntimeError, exit=False) aborts _core_invoke and re-raises."""
+        """A failing pre-hook (RuntimeError, exit=False) aborts _core_invoke; the error is
+        captured as FAILED, not re-raised."""
 
         async def pre_hook(ev, **kw):
             raise RuntimeError("pre-hook error")
@@ -94,18 +94,15 @@ class TestHookedEventPreHookIntegration:
         event = MockHookedEvent(invoke_result="main_result")
         event.create_pre_invoke_hook(hook_registry=registry, exit_hook=False)
 
-        with pytest.raises(RuntimeError):
-            await event.invoke()
+        await event.invoke()  # total: hook error captured as FAILED, not raised
 
-        # _core_invoke is not reached because the hook marked the event CANCELLED
+        # _core_invoke is not reached because the pre-hook failed
         assert event.invoke_called is False
         assert event.execution.status == EventStatus.FAILED
 
     @pytest.mark.anyio
-    async def test_pre_hook_error_with_exit_true_aborts(
-        self, patch_cancellation, patch_logger
-    ):
-        """A failing pre-hook (RuntimeError, exit=True) aborts execution and re-raises."""
+    async def test_pre_hook_error_with_exit_true_aborts(self, patch_cancellation, patch_logger):
+        """A failing pre-hook (RuntimeError, exit=True) aborts execution; captured as FAILED."""
 
         async def pre_hook(ev, **kw):
             raise RuntimeError("pre-hook critical error")
@@ -114,8 +111,7 @@ class TestHookedEventPreHookIntegration:
         event = MockHookedEvent(invoke_result="SHOULD_NOT_HAPPEN")
         event.create_pre_invoke_hook(hook_registry=registry, exit_hook=True)
 
-        with pytest.raises(RuntimeError):
-            await event.invoke()
+        await event.invoke()  # total: hook error captured as FAILED, not raised
 
         assert event.invoke_called is False
         assert event.execution.status == EventStatus.FAILED
@@ -149,7 +145,7 @@ class TestHookedEventPostHookIntegration:
     async def test_post_hook_cancellation_propagates_after_main(
         self, patch_cancellation, patch_logger
     ):
-        """Cancellation from post-hook propagates out of event.invoke() after main ran."""
+        """A post-hook raising Exception (exit=True) after main ran is captured as FAILED."""
 
         async def post_hook(ev, **kw):
             raise MyCancelled("post-hook failed")
@@ -158,10 +154,9 @@ class TestHookedEventPostHookIntegration:
         event = MockHookedEvent(invoke_result="main_result")
         event.create_post_invoke_hook(hook_registry=registry, exit_hook=True)
 
-        with pytest.raises(MyCancelled, match="post-hook failed"):
-            await event.invoke()
+        await event.invoke()  # total: post-hook Exception captured as FAILED, not raised
 
-        # Main invoke DID run, but the cancellation from post-hook propagated
+        # Main invoke DID run; the post-hook failure is recorded as FAILED
         assert event.invoke_called is True
         assert event.execution.status == EventStatus.FAILED
 
@@ -193,9 +188,7 @@ class TestHookedEventBothHooks:
     """Test HookedEvent with both pre and post hooks."""
 
     @pytest.mark.anyio
-    async def test_both_hooks_normal_execution_order(
-        self, patch_cancellation, patch_logger
-    ):
+    async def test_both_hooks_normal_execution_order(self, patch_cancellation, patch_logger):
         """Test that both hooks run in correct order: pre -> _core_invoke -> post."""
         execution_order = []
 
@@ -233,10 +226,8 @@ class TestHookedEventBothHooks:
         assert len(patch_logger) == 2
 
     @pytest.mark.anyio
-    async def test_pre_hook_exit_prevents_post_hook(
-        self, patch_cancellation, patch_logger
-    ):
-        """Pre-hook cancellation propagates immediately; neither core nor post hook runs."""
+    async def test_pre_hook_exit_prevents_post_hook(self, patch_cancellation, patch_logger):
+        """A pre-hook exit (Exception) is captured as FAILED; neither core nor post hook runs."""
         hooks_called = []
 
         async def pre_hook(ev, **kw):
@@ -257,8 +248,7 @@ class TestHookedEventBothHooks:
         event.create_pre_invoke_hook(hook_registry=registry, exit_hook=True)
         event.create_post_invoke_hook(hook_registry=registry, exit_hook=False)
 
-        with pytest.raises(MyCancelled):
-            await event.invoke()
+        await event.invoke()  # total: pre-hook Exception captured as FAILED, not raised
 
         # Only pre-hook ran; post-hook and core never reached
         assert hooks_called == ["pre"]
@@ -266,9 +256,7 @@ class TestHookedEventBothHooks:
         assert event.execution.status == EventStatus.FAILED
 
     @pytest.mark.anyio
-    async def test_main_invoke_error_still_runs_post_hook(
-        self, patch_cancellation, patch_logger
-    ):
+    async def test_main_invoke_error_still_runs_post_hook(self, patch_cancellation, patch_logger):
         """Test that _core_invoke errors still allow post-hook to run."""
         hooks_called = []
 
@@ -290,9 +278,8 @@ class TestHookedEventBothHooks:
         event.create_pre_invoke_hook(hook_registry=registry, exit_hook=False)
         event.create_post_invoke_hook(hook_registry=registry, exit_hook=False)
 
-        # core error propagates after post-hook runs
-        with pytest.raises(RuntimeError, match="main invoke failed"):
-            await event.invoke()
+        # core error is captured as FAILED after the post-hook runs (post runs even on core error)
+        await event.invoke()  # total: core error captured as FAILED, not raised
 
         # Both hooks ran despite the core error
         assert hooks_called == ["pre", "post"]
@@ -307,9 +294,7 @@ class TestHookedEventParameterForwarding:
     """Test parameter forwarding in HookedEvent hook creation."""
 
     @pytest.mark.anyio
-    async def test_hook_params_forwarded_to_hook(
-        self, patch_cancellation, patch_logger
-    ):
+    async def test_hook_params_forwarded_to_hook(self, patch_cancellation, patch_logger):
         """Test that hook_params are forwarded to the hook function."""
         captured_params = {}
 
@@ -336,13 +321,9 @@ class TestHookedEventParameterForwarding:
     @pytest.mark.anyio
     async def test_hook_timeout_configuration(self, patch_cancellation):
         """Test that hook timeout is properly configured."""
-        registry = HookRegistry(
-            hooks={HookEventTypes.PreInvocation: lambda ev, **kw: "ok"}
-        )
+        registry = HookRegistry(hooks={HookEventTypes.PreInvocation: lambda ev, **kw: "ok"})
         event = MockHookedEvent()
-        event.create_pre_invoke_hook(
-            hook_registry=registry, exit_hook=True, hook_timeout=120.0
-        )
+        event.create_pre_invoke_hook(hook_registry=registry, exit_hook=True, hook_timeout=120.0)
 
         # Check that the hook event was configured with correct timeout
         assert event._pre_invoke_hook_event.timeout == 120.0
@@ -351,9 +332,7 @@ class TestHookedEventParameterForwarding:
     @pytest.mark.anyio
     async def test_hook_creation_defaults(self, patch_cancellation):
         """Test default values for hook creation parameters."""
-        registry = HookRegistry(
-            hooks={HookEventTypes.PostInvocation: lambda ev, **kw: "ok"}
-        )
+        registry = HookRegistry(hooks={HookEventTypes.PostInvocation: lambda ev, **kw: "ok"})
         event = MockHookedEvent()
         event.create_post_invoke_hook(hook_registry=registry)
 
@@ -368,18 +347,14 @@ class TestHookedEventCancellationPropagation:
     """Test cancellation propagation in HookedEvent."""
 
     @pytest.mark.anyio
-    async def test_main_invoke_error_propagates(self, patch_cancellation, patch_logger):
-        """Test that exceptions in _core_invoke() propagate and set FAILED status."""
-        registry = HookRegistry(
-            hooks={HookEventTypes.PostInvocation: lambda ev, **kw: "post"}
-        )
-        # MyCancelled extends Exception; Event.invoke() catches it as Exception → FAILED + re-raise
+    async def test_main_invoke_error_captured(self, patch_cancellation, patch_logger):
+        """Exceptions in _core_invoke() are captured as FAILED state, not propagated."""
+        registry = HookRegistry(hooks={HookEventTypes.PostInvocation: lambda ev, **kw: "post"})
+        # MyCancelled extends Exception; Event.invoke() catches it → FAILED (no re-raise)
         event = MockHookedEvent(invoke_error=MyCancelled("main cancelled"))
         event.create_post_invoke_hook(hook_registry=registry, exit_hook=False)
 
-        # Exception propagates out of Event.invoke() (re-raised after recording FAILED)
-        with pytest.raises(MyCancelled, match="main cancelled"):
-            await event.invoke()
+        await event.invoke()  # total: Exception captured as FAILED, not raised
 
         # Event.invoke() catches Exception subclasses → FAILED (not CANCELLED)
         assert event.execution.status == EventStatus.FAILED


### PR DESCRIPTION
**PR 1 of 7** — bottom of the `feat/orchestrate-reactive-casts` stack. Pure foundation, no deps.

### What
- **Pile `__getitem__` by type/Filter** — `pile[SomeType]` / `pile[Filter(...)]` returns matching items.
- **ln compositional filter DSL** — `FieldRef` paths, `all_of`, `__as_filter__`.
- **Total `Event.invoke`/`stream`** — capture FAILED, propagate only `BaseException`; `Event.q` field handles.

### Why
These are the substrate the rest of the stack builds on (reactive bus, engines, casts). Splitting them out keeps each later PR reviewable against a stable base.

### Tests
132 passing across pile/event/filter/function-calling/api-calling.

Part of the 7-PR slice of the reactive-casts branch (core → bus → react-fixes → engines → orchestrate → tools → benchmarks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)