### PR TITLE
feat(session,hooks): reactive event bus + observer-as-hook-transport (ADR-0076)

### DIFF
--- a/docs/adrs/ADR-0076-observer-as-hook-transport.md
+++ b/docs/adrs/ADR-0076-observer-as-hook-transport.md
@@ -1,0 +1,177 @@
+# ADR-0076: Observer as the Canonical Hook Transport
+
+**Status**: Accepted
+**Date**: 2026-06-01
+**Amends**: ADR-0023 (unified hook system) · **Builds on**: ADR-0072 (reactive capability bus)
+
+## Context
+
+Three event-dispatch mechanisms now coexist, and two of them are
+unwired buses that solve the same problem without knowing about each
+other:
+
+| Mechanism | Status | Scope | Dispatch | Wired? |
+|-----------|--------|-------|----------|--------|
+| `service/hooks/` `HookEvent`/`HookedEvent`/`HookRegistry` | shipped | per-**iModel** | template method, hand-orchestrated pre→core→post | **yes** — `APICalling(HookedEvent)` |
+| `lionagi/hooks/` `HookBus` (ADR-0023) | built | per-**session** | sequential, ordered, `StopHook` short-circuit, `blocking_emit` | **no** — zero non-test usages |
+| `session/observer.py` `SessionObserver` (ADR-0072) | built | per-**session** | concurrent fan-out (`gather`), typed-payload filters, `gate()` | partial — engines/casts; `gate()` unused |
+
+ADR-0023 set out to consolidate the legacy systems into `HookBus`.
+Before that wiring landed, the reactive arc (ADR-0072) built a *second*
+per-session bus — the observer — for typed capability events. The result
+is the duplication ADR-0023 was meant to remove, reintroduced one layer
+over.
+
+A tempting shortcut — "fold `service/hooks` into `observer.gate()` (pre)
+and `observe(EventStatus.*)` (post)" — does not survive contact with the
+code:
+
+1. **`gate()` runs post-invoke.** `observer.gate()` executes inside
+   `observer.emit()`, and the only emit seam for events
+   (`branch.emit_and_log`) fires at the **log point, after** the call
+   completes. The gate gates *observer dispatch*, not the operation —
+   it cannot block an API call. "pre-hook = gate()" is false as built.
+2. **Scope mismatch.** `service/hooks` is per-iModel; the observer is
+   per-session. A standalone `imodel.invoke()` with no session would
+   silently lose its hooks.
+3. **Dispatch disciplines differ, by design.** `HookBus` dispatches
+   handlers **sequentially, in registration order, with `StopHook`
+   short-circuit and `blocking_emit`**. The observer dispatches async
+   handlers **concurrently via `gather`, with no ordering and no
+   short-circuit**. This is not an accident to paper over: a guard hook
+   must run *before* the thing it guards, and ordered persistence
+   handlers must not race. Forcing hooks onto concurrent fan-out would
+   be a correctness regression.
+
+So the two buses are not redundant implementations of one thing — they
+are a **transport** and a **dispatch discipline** that got fused into two
+separate stacks.
+
+## Decision
+
+**The observer (`SessionObserver`, ADR-0072) is the single canonical
+event transport. The ADR-0023 surface — the `HookPoint` vocabulary, the
+agent-YAML loader, and the ordered/blocking dispatch discipline — is
+re-based to sit on top of that transport rather than owning a parallel
+one.**
+
+Concretely:
+
+### 1. One transport, two dispatch disciplines
+
+The observer's `Flow` is the single in-memory event record. Over it sit
+two dispatch disciplines, chosen per use:
+
+- **Reactive fan-out** (`observe`): concurrent, unordered, no
+  short-circuit. For capability events and lifecycle signals where
+  handlers are independent.
+- **Ordered hook chain** (`HookBus`): sequential, registration-ordered,
+  `StopHook` short-circuit, `blocking_emit`. For guards (must precede the
+  guarded op) and ordered persistence.
+
+Both record onto the same transport, so everything is uniformly
+queryable (`session.observe(...)`, `observer.by_type(...)`) and audit-
+visible in one place. The disciplines are not interchangeable; the bus
+exposes the one the call site needs.
+
+### 2. HookPoint → typed Signal
+
+Each `HookPoint` emission is carried as a typed `HookSignal` (a `Signal`
+envelope holding `point` + the loose `kwargs`). `HookBus`, when bound to
+a session's observer, emits a `HookSignal` onto the observer for every
+`emit`/`blocking_emit` — so hook activity is recorded on the one bus and
+reactive observers may subscribe with `observe(HookSignal)`. The ordered
+handler chain registered via `bus.on(point, handler)` is dispatched by
+`HookBus` itself (preserving order / `StopHook` / blocking), **then** the
+signal is recorded. A standalone `HookBus` (no observer) behaves exactly
+as today.
+
+### 3. Pre/post fall out of `EventStatus`
+
+For events that ride the total-`invoke` contract (ADR-0072: a business
+failure is captured as `FAILED`, not raised), the post-hook is just
+`observe(EventType, EventStatus.COMPLETED | FAILED)` — no parallel
+post-invoke vocabulary required. The genuine **pre**-hook (the one that
+must *block*) is the keystone the shortcut got wrong; see Follow-ups.
+
+### 4. `service/hooks` migration is staged, not ripped out
+
+`APICalling(HookedEvent)` is the hot path behind every provider call and
+stays exactly as-is until its replacement is wired and proven. ADR-0023's
+"keep via compat, remove in 0.28.0" schedule stands; this ADR only
+changes the *target* of that migration from a standalone `HookBus` to the
+observer-backed `HookBus`.
+
+## Scope of the landing change
+
+This ADR lands the **foundation** only:
+
+- `HookSignal` typed envelope (`lionagi/hooks/bus.py`).
+- `HookBus` gains an optional `observer` binding; `emit`/`blocking_emit`
+  record a `HookSignal` onto the bound observer while preserving the
+  ordered/blocking dispatch contract unchanged. Unbound behaviour is
+  identical to before. (`HookBus` has zero non-test wiring today, so this
+  is additive and zero-blast-radius.)
+- Tests proving: emissions land on the observer's flow; reactive
+  `observe(HookSignal)` sees them; ordered dispatch + `StopHook` +
+  `blocking_emit` semantics are intact; unbound `HookBus` still works.
+
+It deliberately does **not** touch the wired hot path. See Follow-ups.
+
+## Follow-ups (sanctioned, not in this change)
+
+1. **Real pre-invoke gate.** Give an operation a way to consult the
+   session's gate(s) *before* invoking (the fix for "gate runs
+   post-invoke"). This is what makes `TOOL_PRE`/`API_PRE_CALL` blocking
+   real on the observer. Wire `blocking_emit` through it.
+2. **Wire `HookBus` into the session** (ADR-0023b): `Session.hooks`,
+   `build_session_bus` from the agent profile, emit at the lifecycle
+   seams (`SESSION_START/END`, `BRANCH_CREATE`, `MESSAGE_ADD`).
+3. **Migrate `service/hooks`** onto the observer-backed bus: `APICalling`
+   pre/post become a pre-invoke gate consult + `observe(EventStatus.*)`;
+   collapse `HookedEvent`'s `_core_invoke`/`_should_exit`/`_exit_cause`
+   once nothing depends on them. Keep the compat shim through 0.28.0.
+4. **CLI/agent `_on_message` and tool hooks** (ADR-0023c) onto the bus.
+
+## Consequences
+
+**Positive**
+
+- One transport, one event record — hooks, capability events, and
+  lifecycle signals are all queryable and audit-visible in the observer's
+  `Flow`. The duplication ADR-0023 targeted is actually removed instead
+  of forked.
+- ADR-0023's product surface (named points, declarative agent-YAML
+  config, `blocking_emit`) is kept, not discarded — it rides the typed
+  bus rather than a parallel dict.
+- The ordered/blocking discipline that guards and persistence *need* is
+  preserved explicitly, rather than being silently broken by concurrent
+  fan-out.
+- Post-hooks collapse into `observe(EventStatus.*)` for total-invoke
+  events — less bespoke vocabulary to maintain.
+
+**Negative**
+
+- Two dispatch disciplines over one transport is a concept a reader must
+  hold; mitigated by making the bus method names carry the discipline
+  (`observe` = fan-out, `HookBus.emit` = ordered chain).
+- The hot-path migration (Follow-up 3) remains the hard, high-blast-
+  radius part and is still ahead of us; this ADR only makes it safe to
+  approach incrementally.
+
+## Alternatives Considered
+
+| Alternative | Why rejected |
+|-------------|--------------|
+| Finish ADR-0023's `HookBus` as-is; keep observer for engines only | Leaves two per-session buses permanently; the duplication persists. |
+| Observer only; delete `HookBus`'s named-point/YAML layer | Loses declarative agent-hook config (a real, intended feature of ADR-0023). |
+| Map `bus.on` → `observe` literally | Breaks guard ordering and `StopHook`/blocking — concurrent fan-out is the wrong discipline for guards and ordered persistence. |
+| Rip out `HookedEvent._invoke` now | High blast radius on every provider call; rests on the false "gate blocks invoke" premise. Staged instead. |
+
+## References
+
+- [ADR-0023](ADR-0023-unified-hook-system.md) — unified hook system (amended here)
+- [ADR-0072](ADR-0072-reactive-capability-bus.md) — reactive capability bus / observer
+- `lionagi/hooks/bus.py` — `HookBus`, `HookPoint`, `StopHook`
+- `lionagi/session/observer.py` — `SessionObserver`, `observe`, `gate`
+- `lionagi/service/hooks/` — legacy iModel hook system (migration target)

--- a/lionagi/hooks/__init__.py
+++ b/lionagi/hooks/__init__.py
@@ -14,12 +14,17 @@ Public surface:
 
 * :class:`HookPoint` — the enumerated event vocabulary.
 * :class:`HookBus` — per-session pub/sub registry.
+* :class:`HookSignal` — typed envelope recording an emission onto the observer.
 * :func:`hook` — decorator for registering custom handlers.
 * :class:`StopHook` — handler may raise to abort siblings on the same point.
 * :func:`load_hooks_for_agent` — build a HookBus from an agent profile.
+
+Per ADR-0076 the bus is re-based onto the session observer: it is the
+ordered/blocking dispatch *discipline* over the observer's single event
+*transport*, not a parallel bus.
 """
 
-from .bus import HookBus, HookPoint, StopHook, hook
+from .bus import HookBus, HookPoint, HookSignal, StopHook, hook
 from .loader import (
     DEFAULT_HOOKS,
     build_session_bus,
@@ -31,6 +36,7 @@ from .loader import (
 __all__ = [
     "HookBus",
     "HookPoint",
+    "HookSignal",
     "StopHook",
     "hook",
     "DEFAULT_HOOKS",

--- a/lionagi/hooks/bus.py
+++ b/lionagi/hooks/bus.py
@@ -27,7 +27,14 @@ import inspect
 import logging
 from collections.abc import Awaitable, Callable
 from enum import Enum
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+from pydantic import Field
+
+from lionagi.session.signal import Signal
+
+if TYPE_CHECKING:
+    from lionagi.session.observer import SessionObserver
 
 logger = logging.getLogger("lionagi.hooks")
 
@@ -72,6 +79,22 @@ class StopHook(Exception):  # noqa: N818 — control-flow signal, not an error
     """
 
 
+class HookSignal(Signal):
+    """A HookBus emission recorded on the observer transport (ADR-0076).
+
+    Carries the named :class:`HookPoint` and the loose ``kwargs`` the
+    handlers receive. When a :class:`HookBus` is bound to a session's
+    observer, every ``emit`` / ``blocking_emit`` records one of these onto
+    the observer's ``Flow`` — so hook activity lives on the single event
+    bus and reactive observers may subscribe with ``observe(HookSignal)``.
+    The ordered, short-circuiting handler chain is still dispatched by the
+    bus itself; this envelope is the *record*, not the dispatcher.
+    """
+
+    point: HookPoint | None = None
+    kwargs: dict[str, Any] = Field(default_factory=dict)
+
+
 def _normalize_point(point: HookPoint | str) -> HookPoint:
     """Coerce ``point`` to a :class:`HookPoint`, raising ``ValueError`` for unknowns."""
     if isinstance(point, HookPoint):
@@ -93,8 +116,35 @@ class HookBus:
     ``PermissionError``) actually blocks the tool call.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, observer: SessionObserver | None = None) -> None:
         self._handlers: dict[HookPoint, list[HookHandler]] = {}
+        # The shared event transport (ADR-0076). When set, every emit records
+        # a HookSignal here so hook activity lives on the one bus. Optional:
+        # an unbound HookBus dispatches exactly as before, recording nothing.
+        self._observer = observer
+
+    def bind(self, observer: SessionObserver | None) -> HookBus:
+        """Bind (or unbind, with ``None``) this bus to a session's observer.
+
+        Returns ``self`` for chaining. The observer is the shared transport
+        onto which emissions are recorded; binding does not change dispatch.
+        """
+        self._observer = observer
+        return self
+
+    async def _record(self, point: HookPoint, kwargs: dict[str, Any]) -> None:
+        """Record this emission onto the bound observer transport, if any.
+
+        Best-effort and isolated: a transport failure must never turn a
+        successful hook dispatch into a failure. Runs *after* the ordered
+        chain so dispatch / blocking semantics are unchanged.
+        """
+        if self._observer is None:
+            return
+        try:
+            await self._observer.emit(HookSignal(point=point, kwargs=dict(kwargs)))
+        except Exception:  # noqa: BLE001 — transport recording is best-effort
+            logger.exception("HookSignal record failed: %s", point.value)
 
     def on(self, point: HookPoint | str, handler: HookHandler) -> None:
         """Register ``handler`` to fire on ``point``. Order preserved.
@@ -141,8 +191,11 @@ class HookBus:
                 if inspect.isawaitable(result):
                     await result
             except StopHook:
-                return
-            # All other exceptions propagate — no except clause here.
+                break  # stop remaining handlers, but still record below
+            # All other exceptions propagate — no except clause here. A
+            # propagated (blocking) exception skips the record; deny-audit
+            # arrives with the real pre-invoke gate (ADR-0076 Follow-up 1).
+        await self._record(point, kwargs)
 
     async def emit(self, point: HookPoint | str, /, **kwargs: Any) -> None:
         """Fire all handlers for ``point`` sequentially with ``kwargs``.
@@ -155,7 +208,7 @@ class HookBus:
         """
         point = _normalize_point(point)
         if point is HookPoint.TOOL_PRE:
-            await self.blocking_emit(point, **kwargs)
+            await self.blocking_emit(point, **kwargs)  # records inside
             return
         # Snapshot handlers before dispatch so a handler registered during
         # this emit cycle does not fire in the current cycle.
@@ -167,9 +220,10 @@ class HookBus:
                 if inspect.isawaitable(result):
                     await result
             except StopHook:
-                return
+                break  # stop remaining handlers, but still record below
             except Exception:  # noqa: BLE001 — hook isolation invariant
                 logger.exception("Hook failed: %s", point.value)
+        await self._record(point, kwargs)
 
 
 # ── Decorator for user-defined handlers ───────────────────────────────────────

--- a/lionagi/hooks/loader.py
+++ b/lionagi/hooks/loader.py
@@ -52,9 +52,7 @@ _REGISTRY: dict[str, HookHandler] = {
 }
 
 
-def register_handler(
-    name: str, handler: Callable[..., Awaitable[Any]]
-) -> None:
+def register_handler(name: str, handler: Callable[..., Awaitable[Any]]) -> None:
     """Register a callable under ``name`` for agent-YAML lookup.
 
     Re-registration overrides — last writer wins. User-defined handlers
@@ -75,10 +73,7 @@ def resolve_handler(name: str) -> HookHandler:
     try:
         return _REGISTRY[name]
     except KeyError as exc:
-        raise KeyError(
-            f"Unknown hook handler {name!r}. "
-            f"Registered: {sorted(_REGISTRY)}"
-        ) from exc
+        raise KeyError(f"Unknown hook handler {name!r}. Registered: {sorted(_REGISTRY)}") from exc
 
 
 def registered_handlers() -> list[str]:
@@ -104,8 +99,7 @@ def load_hooks_for_agent(
             point = HookPoint(point_str)
         except ValueError as exc:
             raise ValueError(
-                f"Unknown hook point {point_str!r}; "
-                f"valid: {sorted(p.value for p in HookPoint)}"
+                f"Unknown hook point {point_str!r}; valid: {sorted(p.value for p in HookPoint)}"
             ) from exc
         if not isinstance(handler_names, list):
             raise ValueError(
@@ -118,6 +112,8 @@ def load_hooks_for_agent(
 
 def build_session_bus(
     agent_hooks: dict[str, list[str]] | None = None,
+    *,
+    observer: Any = None,
 ) -> HookBus:
     """Construct a per-session bus with defaults + profile overrides.
 
@@ -127,9 +123,11 @@ def build_session_bus(
     profile doesn't mention keep the default.
 
     ADR-0023 §"Bus lifecycle" — one bus per session, created at session
-    init, passed to all branches.
+    init, passed to all branches. Per ADR-0076, ``observer`` binds the bus
+    to the session's :class:`SessionObserver` (the shared event transport)
+    so emissions are recorded there; pass ``session.observer`` at wiring.
     """
-    bus = HookBus()
+    bus = HookBus(observer=observer)
     overrides = load_hooks_for_agent(agent_hooks)
 
     for point, handlers in DEFAULT_HOOKS.items():

--- a/lionagi/operations/_observe.py
+++ b/lionagi/operations/_observe.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Transport-neutral observer concerns: emission, capability extraction, control.
+
+These used to live inside ``operations/run/run.py`` — the CLI-streaming Middle —
+which meant only CLI agents emitted signals onto the session bus or honored
+observer control directives. API agents (operate/ReAct/communicate over an HTTP
+chat model) reached none of it. That asymmetry is the bug: observer-powered
+orchestration (capability-routed flow, reactive SpawnRequest, governance
+control) must be transport-agnostic.
+
+So the logic lives here and is applied at transport-neutral seams:
+  - ``emit_message`` runs as a ``MessageManager.on_message_added`` hook → every
+    message any path adds emits its signal uniformly (CLI stream, API turn, act).
+  - ``check_control`` is polled at turn boundaries (operate / ReAct loop) AND
+    between stream chunks (run), at whatever granularity each transport allows
+    (API calls are atomic → turn-granular; CLI streams → chunk-granular).
+
+Nothing here assumes a transport. ``emit_message`` / ``check_control`` are no-ops
+when the branch has no observer / no pending control, so they are safe to call
+unconditionally from every path.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from lionagi.session.control import LoopBreak, LoopDirective
+
+if TYPE_CHECKING:
+    from lionagi.ln.types import Operable
+    from lionagi.protocols.messages.message import RoledMessage
+    from lionagi.session.branch import Branch
+
+logger = logging.getLogger(__name__)
+
+
+class StopStream(Exception):  # noqa: N818
+    """Internal sentinel for observer-requested clean cancellation.
+
+    Raised when an observer sets a CANCEL directive. Distinct from ``LoopBreak``
+    (a hard stop surfaced as ``RunFailed``): ``StopStream`` unwinds the current
+    stream/loop quietly so the operation returns what it has.
+    """
+
+    def __init__(self, reason: str | None = None) -> None:
+        super().__init__(reason or "stream cancelled by observer")
+        self.reason = reason
+
+
+def attempt_extract(text: str, capabilities: Operable) -> tuple[list[Any], list[Any]]:
+    """Parse capability emissions out of an assistant message.
+
+    A capability is a named typed field (a ``Spec``); ``capabilities`` is the
+    ``Operable`` of names the agent is allowed to produce. We pull every fenced
+    ````json`` block out of ``text`` (fuzzy-tolerant; the injected prompt asks
+    the model to fence its emissions) — a single message may carry several
+    blocks; un-fenced JSON embedded in prose is *not* extracted — and per block,
+    per Ocean's rule, require ``set(keys) ⊆ capabilities.allowed()``:
+
+    - no capability keys → ordinary prose/JSON, skipped;
+    - keys ⊆ grant → validated via ``create_model`` into a bundle (a dynamic
+      model with one field per present capability);
+    - any key outside the grant → an *illegal* emission (the agent reaching
+      past its capabilities): not honored, recorded as a ``CapabilityViolation``.
+
+    Returns ``(bundles, violations)`` — both lists, since one response may
+    carry several blocks.
+    """
+    if not text or not isinstance(text, str):
+        return [], []
+    from lionagi.ln.fuzzy._extract_json import extract_json
+    from lionagi.session.capabilities import CapabilityViolation
+
+    try:
+        data = extract_json(text, fuzzy_parse=True, return_one_if_single=False)
+    except Exception:
+        return [], []
+    blocks = data if isinstance(data, list) else [data]
+
+    allowed = capabilities.allowed()
+    bundles: list[Any] = []
+    violations: list[Any] = []
+    for block in blocks:
+        if not isinstance(block, dict) or not block:
+            continue
+        keys = set(block.keys())
+        if keys.isdisjoint(allowed):
+            continue  # not a capability emission
+        if not keys <= allowed:
+            logger.warning(
+                "Illegal capability emission: keys %s outside grant %s",
+                keys - allowed,
+                allowed,
+            )
+            violations.append(
+                CapabilityViolation(
+                    offending=sorted(keys - allowed),
+                    allowed=sorted(allowed),
+                    block=block,
+                )
+            )
+            continue
+        model = capabilities.create_model(include=keys)
+        try:
+            bundles.append(model.model_validate(block))
+        except Exception as e:
+            logger.debug("Capability block failed validation, skipped: %s", e)
+            continue
+    return bundles, violations
+
+
+async def emit_message(branch: Branch, msg: RoledMessage) -> None:
+    """Raise a branch message onto the session bus as a typed Signal.
+
+    AssistantResponse → extract the capability bundle (when a grant is set) and
+    emit it as one StructuredOutput; filters fan out by named field, so one
+    response can satisfy several observers. ActionRequest/ActionResponse →
+    tool-use / tool-result signals. No-op when the branch has no observer or the
+    message is not an emittable type — so it is safe as a universal
+    ``on_message_added`` hook.
+    """
+    if getattr(branch, "_observer", None) is None:
+        return
+    from lionagi.protocols.messages import (
+        ActionRequest,
+        ActionResponse,
+        AssistantResponse,
+    )
+    from lionagi.session.signal import (
+        ActionRequestSignal,
+        ActionResponseSignal,
+        Signal,
+        StructuredOutput,
+    )
+
+    if isinstance(msg, AssistantResponse):
+        capabilities = getattr(branch, "_capabilities", None)
+        if capabilities is not None:
+            bundles, violations = attempt_extract(msg.response, capabilities)
+            role_name: str | None = getattr(capabilities, "name", None)
+            if bundles:
+                # Emit all bundles concurrently — a slow handler on one bundle
+                # must not serialize the others.
+                from lionagi.ln.concurrency import gather as _gather
+
+                await _gather(
+                    *(
+                        branch.emit(StructuredOutput(data=b, emitter_role=role_name))
+                        for b in bundles
+                    )
+                )
+            # Over-grant attempts become observable governance events, not
+            # silent drops — session.observe(CapabilityViolation) can react.
+            for violation in violations:
+                await branch.emit(Signal(data=violation))
+    elif isinstance(msg, ActionRequest):
+        await branch.emit(ActionRequestSignal(data=msg))
+    elif isinstance(msg, ActionResponse):
+        await branch.emit(ActionResponseSignal(data=msg))
+
+
+def check_control(branch: Branch) -> None:
+    """Honor a pending observer control directive at a loop/stream boundary.
+
+    No-op on CONTINUE / no directive. BREAK → ``LoopBreak`` (hard stop surfaced
+    as RunFailed). CANCEL → ``StopStream`` (quiet unwind). Call this at turn
+    boundaries in operate/ReAct and between chunks in run.
+    """
+    ctrl = branch.poll_control()
+    if ctrl is None or ctrl.directive is LoopDirective.CONTINUE:
+        return
+    if ctrl.directive is LoopDirective.BREAK:
+        raise LoopBreak(ctrl.reason)
+    if ctrl.directive is LoopDirective.CANCEL:
+        raise StopStream(ctrl.reason)

--- a/lionagi/operations/act/act.py
+++ b/lionagi/operations/act/act.py
@@ -39,9 +39,7 @@ async def _act(
             "function": action_request.function,
             "arguments": action_request.arguments,
         }
-    if not isinstance(_request, dict) or not {"function", "arguments"} <= set(
-        _request.keys()
-    ):
+    if not isinstance(_request, dict) or not {"function", "arguments"} <= set(_request.keys()):
         raise ValueError(
             "action_request must be an ActionRequest, BaseModel with 'function'"
             " and 'arguments', or dict with 'function' and 'arguments'."
@@ -55,9 +53,7 @@ async def _act(
 
         func_call = await branch._action_manager.invoke(_request)
         if verbose_action:
-            logger.debug(
-                "Action %s invoked, status: %s.", _request["function"], func_call.status
-            )
+            logger.debug("Action %s invoked, status: %s.", _request["function"], func_call.status)
 
     except Exception as e:
         content = {
@@ -101,7 +97,7 @@ async def _act(
             )
         raise e
 
-    branch._log_manager.log(func_call)
+    await branch.emit_and_log(func_call)
 
     if not isinstance(action_request, ActionRequest):
         action_request = ActionRequest(
@@ -188,9 +184,7 @@ async def _concurrent_act(
         return await _act(branch, req, suppress_errors, verbose_action)
 
     # AlcallParams expects a list as first argument
-    action_request_list = (
-        action_request if isinstance(action_request, list) else [action_request]
-    )
+    action_request_list = action_request if isinstance(action_request, list) else [action_request]
 
     return await call_params(action_request_list, _wrapper)
 
@@ -202,9 +196,7 @@ async def _sequential_act(
     verbose_action: bool = False,
 ) -> list:
     """Execute actions sequentially."""
-    action_request = (
-        action_request if isinstance(action_request, list) else [action_request]
-    )
+    action_request = action_request if isinstance(action_request, list) else [action_request]
     results = []
     for req in action_request:
         result = await _act(branch, req, suppress_errors, verbose_action)

--- a/lionagi/operations/chat/chat.py
+++ b/lionagi/operations/chat/chat.py
@@ -28,7 +28,7 @@ async def chat(
         kw["include_token_usage_to_model"] = chat_param.include_token_usage_to_model
     api_call = await imodel.invoke(**kw)
 
-    branch._log_manager.log(api_call)
+    await branch.emit_and_log(api_call)
 
     # Surface API errors before trying to parse a null response
     if api_call.status == EventStatus.FAILED:

--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from collections.abc import AsyncGenerator
 from dataclasses import fields
@@ -25,141 +24,17 @@ from ..chat._prepare import _prepare_run_kwargs
 from ..types import ChatParam, ParseParam, RunParam
 
 if TYPE_CHECKING:
-    from lionagi.ln.types import Operable
     from lionagi.protocols.messages.message import RoledMessage
     from lionagi.session.branch import Branch
 
-from lionagi.session.control import LoopBreak, LoopDirective
+from lionagi.operations._observe import (
+    StopStream as _StopStream,
+)
+from lionagi.operations._observe import (
+    check_control as _check_control,
+)
 
 logger = logging.getLogger(__name__)
-
-
-def _attempt_extract(text: str, capabilities: Operable) -> tuple[list[Any], list[Any]]:
-    """Parse capability emissions out of an assistant message.
-
-    A capability is a named typed field (a ``Spec``); ``capabilities`` is the
-    ``Operable`` of names the agent is allowed to produce. We pull every fenced
-    ````json`` block out of ``text`` (fuzzy-tolerant; the injected prompt asks
-    the model to fence its emissions) — a single message may carry several
-    blocks; un-fenced JSON embedded in prose is *not* extracted — and per block,
-    per Ocean's rule, require ``set(keys) ⊆ capabilities.allowed()``:
-
-    - no capability keys → ordinary prose/JSON, skipped;
-    - keys ⊆ grant → validated via ``create_model`` into a bundle (a dynamic
-      model with one field per present capability);
-    - any key outside the grant → an *illegal* emission (the agent reaching
-      past its capabilities): not honored, recorded as a ``CapabilityViolation``.
-
-    Returns ``(bundles, violations)`` — both lists, since one response may
-    carry several blocks.
-    """
-    if not text or not isinstance(text, str):
-        return [], []
-    from lionagi.ln.fuzzy._extract_json import extract_json
-    from lionagi.session.capabilities import CapabilityViolation
-
-    try:
-        data = extract_json(text, fuzzy_parse=True, return_one_if_single=False)
-    except Exception:
-        return [], []
-    blocks = data if isinstance(data, list) else [data]
-
-    allowed = capabilities.allowed()
-    bundles: list[Any] = []
-    violations: list[Any] = []
-    for block in blocks:
-        if not isinstance(block, dict) or not block:
-            continue
-        keys = set(block.keys())
-        if keys.isdisjoint(allowed):
-            continue  # not a capability emission
-        if not keys <= allowed:
-            logger.warning(
-                "Illegal capability emission: keys %s outside grant %s",
-                keys - allowed,
-                allowed,
-            )
-            violations.append(
-                CapabilityViolation(
-                    offending=sorted(keys - allowed),
-                    allowed=sorted(allowed),
-                    block=block,
-                )
-            )
-            continue
-        model = capabilities.create_model(include=keys)
-        try:
-            bundles.append(model.model_validate(block))
-        except Exception as e:
-            logger.debug("Capability block failed validation, skipped: %s", e)
-            continue
-    return bundles, violations
-
-
-async def _emit_message_signal(branch: Branch, msg: RoledMessage) -> None:
-    """Raise the stream message onto the session bus as a typed Signal.
-
-    AssistantResponse → extract the capability bundle (when a grant is set) and
-    emit it as one StructuredOutput; filters fan out by named field, so one
-    response can satisfy several observers. ActionRequest/ActionResponse →
-    tool-use / tool-result signals. No-op when the branch has no observer.
-    """
-    if getattr(branch, "_observer", None) is None:
-        return
-    from lionagi.protocols.messages import (
-        ActionRequest,
-        ActionResponse,
-        AssistantResponse,
-    )
-    from lionagi.session.signal import (
-        ActionRequestSignal,
-        ActionResponseSignal,
-        Signal,
-        StructuredOutput,
-    )
-
-    if isinstance(msg, AssistantResponse):
-        capabilities = getattr(branch, "_capabilities", None)
-        if capabilities is not None:
-            bundles, violations = _attempt_extract(msg.response, capabilities)
-            role_name: str | None = getattr(capabilities, "name", None)
-            if bundles:
-                # Emit all bundles concurrently — a slow handler on one bundle
-                # must not serialize the others.
-                from lionagi.ln.concurrency import gather as _gather
-
-                await _gather(
-                    *(
-                        branch.emit(StructuredOutput(data=b, emitter_role=role_name))
-                        for b in bundles
-                    )
-                )
-            # Over-grant attempts become observable governance events, not
-            # silent drops — session.observe(CapabilityViolation) can react.
-            for violation in violations:
-                await branch.emit(Signal(data=violation))
-    elif isinstance(msg, ActionRequest):
-        await branch.emit(ActionRequestSignal(data=msg))
-    elif isinstance(msg, ActionResponse):
-        await branch.emit(ActionResponseSignal(data=msg))
-
-
-class _StopStream(Exception):  # noqa: N818
-    """Internal sentinel used for observer-requested clean cancellation."""
-
-    def __init__(self, reason: str | None = None) -> None:
-        super().__init__(reason or "stream cancelled by observer")
-        self.reason = reason
-
-
-def _check_control(branch: Branch) -> None:
-    ctrl = branch.poll_control()
-    if ctrl is None or ctrl.directive is LoopDirective.CONTINUE:
-        return
-    if ctrl.directive is LoopDirective.BREAK:
-        raise LoopBreak(ctrl.reason)
-    if ctrl.directive is LoopDirective.CANCEL:
-        raise _StopStream(ctrl.reason)
 
 
 async def run(
@@ -222,17 +97,21 @@ async def run(
 
         model.streaming_process_func = _persist_chunk
 
-    # Background signal tasks — scheduled non-blocking, awaited in finally.
-    # Keeps the stream loop from stalling on slow observer handlers.
-    _signal_tasks: list[asyncio.Task] = []
-
-    def _schedule_signal(msg: Any) -> None:
-        if getattr(branch, "_observer", None) is not None:
-            _signal_tasks.append(asyncio.ensure_future(_emit_message_signal(branch, msg)))
+    # Signal emission is now universal: every a_add_message below fires the
+    # branch's on_message_added hook, which schedules the bus emission in the
+    # background (branch._signal_tasks) and is drained in `finally`. The stream
+    # loop only polls control between chunks (_check_control).
 
     # Accumulation buffers
     thinking_parts: list[str] = []
     text_parts: list[str] = []
+    # Provider-reported usage/cost from the terminal ``result`` chunk
+    # (codex: input/output tokens; claude_code: usage, total_cost_usd,
+    # num_turns, duration_ms). Captured once at stream end and stamped onto
+    # the final AssistantResponse so callers (Studio cost tracking, the
+    # orchestration benchmark) can read real CLI usage — re-tokenizing the
+    # message history undercounts the agent's internal tool turns.
+    result_meta: dict = {}
 
     async def _flush_response() -> AssistantResponse | None:
         if not text_parts:
@@ -241,6 +120,8 @@ async def run(
         metadata: dict = {}
         if thinking_parts:
             metadata["thinking"] = "\n".join(thinking_parts)
+        if result_meta:
+            metadata["model_response"] = dict(result_meta)
         res = AssistantResponse(
             content=AssistantResponseContent(assistant_response=text),
             sender=branch.id,
@@ -293,7 +174,6 @@ async def run(
 
                         case "tool_use":
                             if res := await _flush_response():
-                                _schedule_signal(res)
                                 _check_control(branch)
                                 yield res
 
@@ -306,7 +186,6 @@ async def run(
                             if chunk.tool_id:
                                 pending_requests[chunk.tool_id] = act_req
                             await branch.msgs.a_add_message(action_request=act_req)
-                            _schedule_signal(act_req)
                             _check_control(branch)
                             yield act_req
 
@@ -332,12 +211,12 @@ async def run(
                                 sender=branch.user or "user",
                                 recipient=branch.id,
                             )
-                            _schedule_signal(act_res)
                             _check_control(branch)
                             yield act_res
 
                         case "result":
-                            pass
+                            if chunk.metadata:
+                                result_meta.update(chunk.metadata)
 
                         case "error":
                             raise RuntimeError(chunk.content or "Stream error from CLI endpoint")
@@ -347,18 +226,14 @@ async def run(
                         call_meta = Note.from_dict(api_call.to_dict())
                         call_meta.pop(["execution", "response"], None)
                         res.metadata["api_call_meta"] = call_meta.to_dict()
-                    _schedule_signal(res)
                     _check_control(branch)
                     yield res
         except _StopStream:
             pass
     finally:
-        # Drain all background signal tasks before returning so handler
+        # Drain background signal emissions before returning so handler
         # results and exceptions are not silently lost.
-        if _signal_tasks:
-            from lionagi.ln.concurrency import gather as _gather
-
-            await _gather(*_signal_tasks, return_exceptions=True)
+        await branch.drain_signals()
 
         # Restore original streaming func
         model.streaming_process_func = prev_stream_func

--- a/lionagi/session/branch.py
+++ b/lionagi/session/branch.py
@@ -368,6 +368,19 @@ class Branch(Element, Relational):
             return []
         return await self._observer.emit(event)
 
+    async def emit_and_log(self, event: Any) -> list[Any]:
+        """Log an event to the DataLogger AND emit it onto the reactive bus.
+
+        The log is the durable record (persisted, outlives the session); the
+        emission is the in-memory reactive trace handlers can react to. Called
+        where an ``Event`` (an ``APICalling``, a tool call) completes, so
+        ``session.observe(APICalling, EventStatus.FAILED)`` reacts to a failed
+        call instead of only finding it after the fact in the logs. Emission is a
+        no-op for a standalone branch (no session); logging always happens.
+        """
+        self._log_manager.log(event)
+        return await self.emit(event)
+
     def control(self, directive: "LoopDirective", *, reason: str | None = None) -> None:
         """Queue a loop-control directive.
 
@@ -592,7 +605,7 @@ class Branch(Element, Relational):
         async def _connect(**kwargs):
             """connect to an api endpoint"""
             api_call = await imodel.invoke(**kwargs)
-            self._log_manager.log(api_call)
+            await self.emit_and_log(api_call)
             return api_call.response
 
         _connect.__name__ = name or imodel.endpoint.name

--- a/lionagi/session/branch.py
+++ b/lionagi/session/branch.py
@@ -122,6 +122,7 @@ class Branch(Element, Relational):
     _observer: Any = PrivateAttr(None)
     _capabilities: Any = PrivateAttr(None)
     _loop_control: "LoopControl | None" = PrivateAttr(None)
+    _signal_tasks: list = PrivateAttr(default_factory=list)
 
     def __init__(
         self,
@@ -189,6 +190,11 @@ class Branch(Element, Relational):
         from lionagi.protocols.messages.manager import MessageManager
 
         self._message_manager = MessageManager(messages=messages)
+        # Universal signal emission: every message any path adds (CLI stream,
+        # API turn, tool act) raises its bus signal through this one hook, so
+        # observer-powered orchestration is transport-agnostic. Scheduled in the
+        # background (see _schedule_emit) and drained at operation boundaries.
+        self._message_manager._on_message_added.append(self._schedule_emit)
 
         if any(
             bool(x)
@@ -367,6 +373,73 @@ class Branch(Element, Relational):
         if self._observer is None:
             return []
         return await self._observer.emit(event)
+
+    def _schedule_emit(self, msg: Any) -> None:
+        """``on_message_added`` hook: schedule this message's bus emission.
+
+        Fire-and-forget (tracked in ``_signal_tasks``, drained by
+        ``drain_signals``) so a slow observer handler never stalls the message
+        pipeline — the same non-blocking contract the CLI stream loop relied on,
+        now applied to EVERY transport. No-op without an observer.
+        """
+        if self._observer is None:
+            return
+        import asyncio
+
+        from lionagi.operations._observe import emit_message
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # Sync add outside an event loop — emission is async-only; skip.
+            # (Not a real orchestration path; observers run under async ops.)
+            return
+        self._signal_tasks.append(loop.create_task(emit_message(self, msg)))
+
+    async def drain_signals(self) -> None:
+        """Await all pending background emissions and clear the queue.
+
+        Called at operation boundaries (run finally, operate/ReAct turn) so a
+        signal emitted on turn N — e.g. a ``SpawnRequest`` — is observed before
+        the orchestration decides quiescence. Handler exceptions are collected,
+        not raised, mirroring the prior CLI-stream drain semantics.
+        """
+        if not self._signal_tasks:
+            return
+        from lionagi.ln.concurrency import gather as _gather
+
+        tasks, self._signal_tasks = self._signal_tasks, []
+        await _gather(*tasks, return_exceptions=True)
+
+    async def _observed_run(self, coro: Any) -> Any:
+        """Wrap a public branch operation with bus lifecycle + signal drain.
+
+        One boundary for every transport/loop (operate, ReAct, communicate):
+        emit RunStart → run → drain this run's emissions (so a SpawnRequest the
+        turn produced is observed before the orchestration settles) → emit
+        RunEnd / RunFailed. ``coro`` is the already-constructed operation
+        coroutine. No-op lifecycle when standalone; the drain is always safe.
+        """
+        has_observer = self._observer is not None
+        if has_observer:
+            from .signal import RunStart
+
+            await self.emit(RunStart())
+        try:
+            result = await coro
+        except Exception as exc:
+            await self.drain_signals()
+            if has_observer:
+                from .signal import RunFailed
+
+                await self.emit(RunFailed(data=exc))
+            raise
+        await self.drain_signals()
+        if has_observer:
+            from .signal import RunEnd
+
+            await self.emit(RunEnd(data=result))
+        return result
 
     async def emit_and_log(self, event: Any) -> list[Any]:
         """Log an event to the DataLogger AND emit it onto the reactive bus.
@@ -1015,30 +1088,13 @@ class Branch(Element, Relational):
             _pms.update(kwargs)
         from lionagi.operations.operate.operate import operate, prepare_operate_kw
 
-        # Run lifecycle on the bus: RunStart → RunEnd(result) | RunFailed(exc).
-        # This is orthogonal to capabilities (no grant required) — it reports
-        # the run, not an exercised capability. ``RunEnd.data`` unwraps so
-        # ``session.observe(ResultType)`` still fires on the final result; the
-        # per-message capability bundles (run loop) are distinct payloads, so
-        # there is no double-emit. No-op when the branch is standalone.
-        has_observer = self._observer is not None
-        if has_observer:
-            from .signal import RunStart
-
-            await self.emit(RunStart())
-        try:
-            result = await operate(self, **prepare_operate_kw(self, **_pms))
-        except Exception as exc:
-            if has_observer:
-                from .signal import RunFailed
-
-                await self.emit(RunFailed(data=exc))
-            raise
-        if has_observer:
-            from .signal import RunEnd
-
-            await self.emit(RunEnd(data=result))
-        return result
+        # Run lifecycle (RunStart → RunEnd|RunFailed) + signal drain via the
+        # shared boundary. Orthogonal to capabilities (no grant required) — it
+        # reports the run, not an exercised capability. ``RunEnd.data`` unwraps
+        # so ``session.observe(ResultType)`` still fires on the final result;
+        # the per-message capability bundles are distinct payloads (no
+        # double-emit). No-op when the branch is standalone.
+        return await self._observed_run(operate(self, **prepare_operate_kw(self, **_pms)))
 
     async def communicate(
         self,
@@ -1125,7 +1181,7 @@ class Branch(Element, Relational):
             prepare_communicate_kw,
         )
 
-        return await communicate(self, **prepare_communicate_kw(self, **_pms))
+        return await self._observed_run(communicate(self, **prepare_communicate_kw(self, **_pms)))
 
     async def act(
         self,
@@ -1307,32 +1363,34 @@ class Branch(Element, Relational):
             k: v for k, v in kwargs.items() if k not in {"verbose_analysis", "verbose_action"}
         }
 
-        return await ReAct(
-            self,
-            instruct,
-            interpret=interpret,
-            interpret_domain=interpret_domain,
-            interpret_style=interpret_style,
-            interpret_sample=interpret_sample,
-            interpret_kwargs=interpret_kwargs,
-            tools=tools,
-            tool_schemas=tool_schemas,
-            response_format=response_format,
-            extension_allowed=extension_allowed,
-            max_extensions=max_extensions,
-            response_kwargs=response_kwargs,
-            return_analysis=return_analysis,
-            analysis_model=analysis_model,
-            verbose_action=verbose,
-            verbose_analysis=verbose,
-            verbose_length=verbose_length,
-            interpret_model=interpret_model,
-            intermediate_response_options=intermediate_response_options,
-            intermediate_listable=intermediate_listable,
-            reasoning_effort=reasoning_effort,
-            display_as=display_as,
-            include_token_usage_to_model=include_token_usage_to_model,
-            **kwargs_filtered,
+        return await self._observed_run(
+            ReAct(
+                self,
+                instruct,
+                interpret=interpret,
+                interpret_domain=interpret_domain,
+                interpret_style=interpret_style,
+                interpret_sample=interpret_sample,
+                interpret_kwargs=interpret_kwargs,
+                tools=tools,
+                tool_schemas=tool_schemas,
+                response_format=response_format,
+                extension_allowed=extension_allowed,
+                max_extensions=max_extensions,
+                response_kwargs=response_kwargs,
+                return_analysis=return_analysis,
+                analysis_model=analysis_model,
+                verbose_action=verbose,
+                verbose_analysis=verbose,
+                verbose_length=verbose_length,
+                interpret_model=interpret_model,
+                intermediate_response_options=intermediate_response_options,
+                intermediate_listable=intermediate_listable,
+                reasoning_effort=reasoning_effort,
+                display_as=display_as,
+                include_token_usage_to_model=include_token_usage_to_model,
+                **kwargs_filtered,
+            )
         )
 
     async def ReActStream(  # noqa: N802

--- a/lionagi/session/observer.py
+++ b/lionagi/session/observer.py
@@ -40,7 +40,7 @@ import inspect
 from collections.abc import Callable
 from typing import Any
 
-from lionagi.ln.types import Filter, RoleFilter, TypeFilter, as_filter
+from lionagi.ln.types import Filter, RoleFilter, TypeFilter, all_of
 from lionagi.protocols._concepts import Observable, Observer
 
 from ..protocols.generic.flow import Flow
@@ -83,6 +83,18 @@ def _payload(obj: Any) -> Any:
     return obj.data if isinstance(obj, Signal) else obj
 
 
+def _is_condition(x: Any) -> bool:
+    """A value usable as a filter condition: a type, a Filter, or an
+    ``__as_filter__`` provider (e.g. an ``EventStatus`` member)."""
+    return isinstance(x, type | Filter) or hasattr(x, "__as_filter__")
+
+
+def _looks_like_handler(x: Any) -> bool:
+    """A plain callable handler — callable but not itself a condition. Used to
+    tell ``observe(key, handler)`` from ``observe(cond1, cond2)``."""
+    return callable(x) and not _is_condition(x)
+
+
 class SessionObserver(Observer):
     """Typed, reactive event dispatch over a session-scoped Flow."""
 
@@ -98,28 +110,37 @@ class SessionObserver(Observer):
 
     def observe(
         self,
-        key: type | Filter | Predicate | None = None,
+        *keys: type | Filter | Predicate | Any,
         handler: Handler | None = None,
-        *,
         role: str | None = None,
     ) -> Any:
-        """Subscribe a handler. Usable as a decorator.
+        """Subscribe a handler to one or more AND-composed conditions. Usable as a decorator.
 
-        ``key`` is a type (→ ``TypeFilter``), a ``Filter`` (e.g.
-        ``spec.q == value``), or a plain predicate. Handlers receive
-        ``(matched, ctx)`` — for a type, the matched instance (the payload or a
-        matching field); for a value/predicate filter, the payload.
+        Each positional *key* is a condition coerced via :func:`as_filter`: a type
+        (``TypeFilter``), a ``Filter`` (``spec.q == value``, ``APICalling.q.duration > 3``),
+        or an ``__as_filter__`` provider (``EventStatus.FAILED``). Multiple keys are
+        AND-composed — ``observe(APICalling, EventStatus.FAILED)`` fires only when every
+        condition matches the same payload. Handlers receive ``(matched, ctx)``.
 
-        ``role`` subscribes by the emitting agent's role name (a ``RoleFilter``).
-        When both ``key`` and ``role`` are provided the filter is their conjunction.
+        A handler may be passed positionally as the last argument (the back-compat
+        ``observe(key, handler)`` form, detected because a handler is callable but not
+        itself a condition), via ``handler=``, or by decoration.
+
+        ``role`` subscribes by the emitting agent's role name (a ``RoleFilter``),
+        conjoined with the key conditions when both are given.
         """
+        keys_list = list(keys)
+        if handler is None and len(keys_list) >= 2 and _looks_like_handler(keys_list[-1]):
+            handler = keys_list.pop()
+
+        key_flt: Filter | None = all_of(*keys_list) if keys_list else None
         if role is not None:
             role_flt = RoleFilter(role)
-            flt: Filter = role_flt if key is None else _KeyAndRoleFilter(as_filter(key), role_flt)
-        elif key is not None:
-            flt = as_filter(key)
+            flt: Filter = role_flt if key_flt is None else _KeyAndRoleFilter(key_flt, role_flt)
+        elif key_flt is not None:
+            flt = key_flt
         else:
-            raise TypeError("observe() requires at least one of 'key' or 'role'")
+            raise TypeError("observe() requires at least one condition or 'role'")
 
         def _register(fn: Handler) -> Handler:
             self._subs.append((flt, fn))
@@ -144,13 +165,19 @@ class SessionObserver(Observer):
 
     # -- Emission / dispatch --------------------------------------------------
 
-    async def emit(self, event: Observable) -> list[Any]:
+    async def emit(self, event: Any) -> list[Any]:
         """Run the chain: gate → store → route → dispatch. Returns handler results.
 
-        ``event`` is any Observable — a :class:`Signal` (whose ``data`` is the
-        payload) or a bare element. Gate, route-conditions, and handlers all
-        operate on the *payload*; the full envelope is stored in the Flow.
+        ``event`` is any payload. An :class:`Observable` (a :class:`Signal`,
+        whose ``data`` is the payload, or a bare element) is stored as-is; a
+        plain payload — e.g. a casts emission ``BaseModel`` — is enveloped in a
+        ``Signal`` so the Flow's Pile, which holds only Observables, accepts it.
+        The store is therefore uniformly ``Pile[Signal(data=…)]`` for plain
+        payloads. Gate, route-conditions, and handlers all operate on the
+        *payload*; the full envelope is stored in the Flow.
         """
+        if not isinstance(event, Observable):
+            event = Signal(data=event)
         payload = _payload(event)
 
         # The gate may deny by returning falsy OR by raising — both deny while

--- a/lionagi/session/session.py
+++ b/lionagi/session/session.py
@@ -140,20 +140,22 @@ class Session(Node, Relational):
 
     def observe(
         self,
-        event_type: type | None = None,
+        *keys: type | Callable | Any,
         handler: Callable | None = None,
-        *,
         role: str | None = None,
     ) -> Any:
-        """Subscribe a handler to an event type or emitter role. Usable as a decorator.
+        """Subscribe a handler to one or more AND-composed conditions. Usable as a decorator.
 
-        Handlers receive ``(event, session)`` and fire when a matching event
-        is emitted. Mirrors ``@session.operation()``.
+        Handlers receive ``(matched, session)`` and fire when every condition
+        matches an emitted payload. Each *key* is a type, a Filter, or an
+        ``__as_filter__`` provider (``EventStatus.FAILED``) —
+        ``session.observe(APICalling, EventStatus.FAILED)`` reacts to failed API
+        calls. Mirrors ``@session.operation()``.
 
         ``role`` subscribes by the emitting agent's role name — fires on anything
         emitted by an agent with that role regardless of capability type.
         """
-        return self.observer.observe(event_type, handler, role=role)
+        return self.observer.observe(*keys, handler=handler, role=role)
 
     def route(self, condition: Callable, *, into: str) -> "SessionObserver":
         """Auto-append emitted events matching ``condition`` to a named stream."""

--- a/lionagi/session/signal.py
+++ b/lionagi/session/signal.py
@@ -32,6 +32,9 @@ __all__ = (
     "RunStart",
     "RunEnd",
     "RunFailed",
+    "NodeStarted",
+    "NodeCompleted",
+    "NodeFailed",
 )
 
 
@@ -84,3 +87,37 @@ class RunEnd(Signal):
 
 class RunFailed(Signal):
     """A run raised. ``data`` is the exception that aborted it."""
+
+
+# -- Node lifecycle (DAG execution) -------------------------------------------
+# Emitted by ``EngineRun.run_dag`` as each operation node of a DAG starts and
+# finishes. They turn the executor's ``on_progress(op_id, name, status, elapsed)``
+# callback into bus events, so persistence, Studio segments, and progress
+# display subscribe with ``session.observe(NodeCompleted)`` instead of threading
+# a bespoke callback. Observed by their own envelope type. ``op_id`` is the
+# operation node id; ``name`` is the executing branch's name; ``elapsed`` is
+# wall-seconds at the event (0 at start).
+
+
+class NodeStarted(Signal):
+    """A DAG operation node began executing."""
+
+    op_id: str = ""
+    name: str = ""
+    elapsed: float = 0.0
+
+
+class NodeCompleted(Signal):
+    """A DAG operation node finished successfully."""
+
+    op_id: str = ""
+    name: str = ""
+    elapsed: float = 0.0
+
+
+class NodeFailed(Signal):
+    """A DAG operation node raised during execution."""
+
+    op_id: str = ""
+    name: str = ""
+    elapsed: float = 0.0

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -155,8 +155,9 @@ async def test_start_create_session_failure_closes_db(
     await start_live_persist(env)
 
     assert env._live_persist is None
-    # The orchestrator branch should not have a hook registered.
-    assert env.orc_branch.on_message_added == []
+    # No PERSISTENCE hook should be registered after the DB failure — only the
+    # branch's baseline signal-emission hook (_schedule_emit) is present.
+    assert env.orc_branch.on_message_added == [env.orc_branch._schedule_emit]
 
     for _ in range(20):
         if _aiosqlite_thread_count() <= before:

--- a/tests/cli/test_agent_live_persist.py
+++ b/tests/cli/test_agent_live_persist.py
@@ -143,8 +143,9 @@ async def test_setup_db_open_failure_disables_persist_no_thread_leak(
     ctx = await _setup_live_persist(branch)
 
     assert ctx is None
-    # The hook was NEVER registered when setup failed.
-    assert branch.on_message_added == []
+    # The PERSISTENCE hook was NEVER registered when setup failed — only the
+    # branch's baseline signal-emission hook (_schedule_emit) remains.
+    assert branch.on_message_added == [branch._schedule_emit]
     # No leaked aiosqlite worker — the count is stable.
     assert _aiosqlite_thread_count() == before
 
@@ -176,7 +177,8 @@ async def test_setup_create_session_failure_closes_db(
     ctx = await _setup_live_persist(branch)
 
     assert ctx is None
-    assert branch.on_message_added == []
+    # Only the baseline signal-emission hook remains; no persistence hook.
+    assert branch.on_message_added == [branch._schedule_emit]
     # Give aiosqlite a moment to join its thread after close().
     for _ in range(20):
         if _aiosqlite_thread_count() == before:

--- a/tests/hooks/test_bus_observer.py
+++ b/tests/hooks/test_bus_observer.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""ADR-0076 — HookBus re-based onto the observer transport.
+
+The observer is the single event *record*; HookBus is the ordered /
+blocking dispatch *discipline* over it. These tests prove a bound bus
+records a HookSignal per emit, reactive observers can subscribe, and the
+ordered / StopHook / blocking semantics are unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.hooks import (
+    HookBus,
+    HookPoint,
+    HookSignal,
+    StopHook,
+    build_session_bus,
+)
+from lionagi.session.observer import SessionObserver
+
+# ── Transport recording ──────────────────────────────────────────────────────
+
+
+async def test_bound_emit_records_hooksignal_on_observer():
+    obs = SessionObserver()
+    bus = HookBus(observer=obs)
+    await bus.emit(HookPoint.MESSAGE_ADD, message={}, session_id="s")
+
+    recs = obs.by_type(HookSignal)
+    assert len(recs) == 1
+    # HookPoint is a str-enum stored by value on the Signal — compare by ==.
+    assert recs[0].point == HookPoint.MESSAGE_ADD
+    assert recs[0].kwargs == {"message": {}, "session_id": "s"}
+
+
+async def test_unbound_bus_records_nothing():
+    bus = HookBus()  # no observer
+    # Dispatches fine, simply records nowhere — no crash, no transport.
+    await bus.emit(HookPoint.SESSION_START, session_id="s")
+    assert bus._observer is None
+
+
+async def test_reactive_observe_sees_emission_point_and_kwargs():
+    obs = SessionObserver()
+    seen: list[tuple] = []
+    obs.observe(HookSignal, handler=lambda s, _c: seen.append((s.point, s.kwargs)))
+
+    bus = HookBus(observer=obs)
+    await bus.emit(HookPoint.API_POST_CALL, model="claude", tokens={"total": 9})
+
+    assert seen == [(HookPoint.API_POST_CALL, {"model": "claude", "tokens": {"total": 9}})]
+
+
+async def test_bind_and_unbind():
+    obs = SessionObserver()
+    bus = HookBus().bind(obs)
+    await bus.emit(HookPoint.API_POST_CALL, model="x")
+    assert len(obs.by_type(HookSignal)) == 1
+
+    bus.bind(None)  # unbind — subsequent emits record nowhere
+    await bus.emit(HookPoint.API_POST_CALL, model="y")
+    assert len(obs.by_type(HookSignal)) == 1
+
+
+# ── Dispatch discipline is preserved when bound ──────────────────────────────
+
+
+async def test_ordered_dispatch_unchanged_when_bound():
+    obs = SessionObserver()
+    bus = HookBus(observer=obs)
+    calls: list[str] = []
+
+    async def h1(**kw):
+        calls.append("h1")
+
+    async def h2(**kw):
+        calls.append("h2")
+
+    bus.on(HookPoint.SESSION_START, h1)
+    bus.on(HookPoint.SESSION_START, h2)
+    await bus.emit(HookPoint.SESSION_START, session_id="s")
+
+    assert calls == ["h1", "h2"]  # registration order
+    assert len(obs.by_type(HookSignal)) == 1
+
+
+async def test_stop_hook_short_circuits_yet_still_records():
+    obs = SessionObserver()
+    bus = HookBus(observer=obs)
+    calls: list[str] = []
+
+    async def stopper(**kw):
+        calls.append("stopper")
+        raise StopHook
+
+    async def never(**kw):  # pragma: no cover
+        calls.append("never")
+
+    bus.on(HookPoint.MESSAGE_ADD, stopper)
+    bus.on(HookPoint.MESSAGE_ADD, never)
+    await bus.emit(HookPoint.MESSAGE_ADD, message={}, session_id="s")
+
+    assert calls == ["stopper"]  # short-circuit intact
+    assert len(obs.by_type(HookSignal)) == 1  # a short-circuited emit is still recorded
+
+
+async def test_blocking_guard_pass_records_but_raise_does_not():
+    obs = SessionObserver()
+    bus = HookBus(observer=obs)
+
+    async def guard_ok(**kw):
+        return None
+
+    bus.on(HookPoint.TOOL_PRE, guard_ok)
+    await bus.emit(HookPoint.TOOL_PRE, tool_name="ls")
+    assert len(obs.by_type(HookSignal)) == 1  # passed guard → recorded
+
+    bus.off(HookPoint.TOOL_PRE, guard_ok)
+
+    async def guard_block(**kw):
+        raise PermissionError("denied")
+
+    bus.on(HookPoint.TOOL_PRE, guard_block)
+    with pytest.raises(PermissionError, match="denied"):
+        await bus.emit(HookPoint.TOOL_PRE, tool_name="rm")
+    # Blocking raise propagates and is NOT recorded — deny-audit arrives with
+    # the real pre-invoke gate (ADR-0076 Follow-up 1).
+    assert len(obs.by_type(HookSignal)) == 1
+
+
+# ── Transport isolation ──────────────────────────────────────────────────────
+
+
+async def test_transport_failure_never_breaks_dispatch():
+    class BrokenObserver:
+        async def emit(self, *_a, **_k):
+            raise RuntimeError("transport down")
+
+    bus = HookBus(observer=BrokenObserver())
+    calls: list[int] = []
+
+    async def h(**kw):
+        calls.append(1)
+
+    bus.on(HookPoint.SESSION_START, h)
+    # The broken transport must not turn a successful dispatch into a failure.
+    await bus.emit(HookPoint.SESSION_START, session_id="s")
+    assert calls == [1]
+
+
+# ── build_session_bus binds the observer ─────────────────────────────────────
+
+
+async def test_build_session_bus_binds_observer():
+    obs = SessionObserver()
+    bus = build_session_bus(observer=obs)
+    # API_POST_CALL has no default handler, so this records without firing any
+    # StateDB-touching builtin.
+    await bus.emit(HookPoint.API_POST_CALL, model="x")
+    assert any(r.point == HookPoint.API_POST_CALL for r in obs.by_type(HookSignal))

--- a/tests/operations/run/test_run_signals.py
+++ b/tests/operations/run/test_run_signals.py
@@ -16,7 +16,8 @@ from __future__ import annotations
 from pydantic import BaseModel
 
 from lionagi.ln.types import Operable, Spec
-from lionagi.operations.run.run import _attempt_extract, _emit_message_signal
+from lionagi.operations._observe import attempt_extract as _attempt_extract
+from lionagi.operations._observe import emit_message as _emit_message_signal
 from lionagi.protocols.messages import (
     ActionRequest,
     ActionResponse,

--- a/tests/session/test_capabilities.py
+++ b/tests/session/test_capabilities.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from pydantic import BaseModel
 
 from lionagi.ln.types import Operable, Spec
-from lionagi.operations.run.run import _emit_message_signal
+from lionagi.operations._observe import emit_message as _emit_message_signal
 from lionagi.protocols.messages import AssistantResponse
 from lionagi.protocols.messages.assistant_response import AssistantResponseContent
 from lionagi.session.capabilities import CAP_BEGIN, CAP_END, render_capabilities_prompt

--- a/tests/session/test_control.py
+++ b/tests/session/test_control.py
@@ -8,7 +8,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from lionagi.operations.run.run import _check_control, _StopStream
+from lionagi.operations._observe import StopStream as _StopStream
+from lionagi.operations._observe import check_control as _check_control
 from lionagi.protocols.messages import AssistantResponse
 from lionagi.service.imodel import iModel
 from lionagi.service.types.stream_chunk import StreamChunk

--- a/tests/session/test_event_reactive_bus.py
+++ b/tests/session/test_event_reactive_bus.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Internal events on the reactive bus: ``branch.emit_and_log`` puts an Event
+(an ``APICalling``, a tool call) onto the session observer, and the compositional
+filter DSL reacts to it by type + status + field — the complement to logging.
+
+The production instance is ``observe(APICalling, EventStatus.FAILED)``; these use
+a bare ``Event`` subclass so the mechanism is exercised without a network call —
+the bus and filters key off ``Event``, not the concrete subclass.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.protocols.generic.event import Event, EventStatus
+from lionagi.session.branch import Branch
+from lionagi.session.session import Session
+
+
+class Call(Event):
+    """A stand-in event (no network) to exercise the bus + filter DSL."""
+
+
+def _at(status: EventStatus, *, duration: float | None = None) -> Call:
+    ev = Call()
+    ev.execution.status = status
+    if duration is not None:
+        ev.execution.duration = duration
+    return ev
+
+
+@pytest.mark.asyncio
+async def test_emit_and_log_reacts_to_failed_status():
+    """observe(EventType, EventStatus.FAILED) fires on a failed event, and the
+    event is also logged (durable record)."""
+    s = Session()
+    branch = s.default_branch
+    failed: list[Call] = []
+    s.observe(Call, EventStatus.FAILED, handler=lambda e, _: failed.append(e))
+
+    ok = _at(EventStatus.COMPLETED)
+    bad = _at(EventStatus.FAILED)
+    await branch.emit_and_log(ok)
+    await branch.emit_and_log(bad)
+
+    assert failed == [bad]  # only the FAILED one reacted
+    # both were logged regardless of reactivity
+    assert len(branch._log_manager.logs) == 2
+
+
+@pytest.mark.asyncio
+async def test_status_enum_alone_is_a_filter():
+    """A bare EventStatus member is a filter over any event's status."""
+    s = Session()
+    completed: list[Call] = []
+    s.observe(EventStatus.COMPLETED, handler=lambda e, _: completed.append(e))
+
+    ok = _at(EventStatus.COMPLETED)
+    bad = _at(EventStatus.FAILED)
+    await s.default_branch.emit_and_log(ok)
+    await s.default_branch.emit_and_log(bad)
+
+    assert completed == [ok]
+
+
+@pytest.mark.asyncio
+async def test_compositional_type_status_field():
+    """observe(Type, EventStatus.COMPLETED, Type.q.duration > N) — Ocean's
+    three-way composition: only a completed AND slow event reacts."""
+    s = Session()
+    slow_ok: list[Call] = []
+    s.observe(
+        Call,
+        EventStatus.COMPLETED,
+        Call.q.duration > 1.0,
+        handler=lambda e, _: slow_ok.append(e),
+    )
+
+    fast = _at(EventStatus.COMPLETED, duration=0.1)
+    slow = _at(EventStatus.COMPLETED, duration=5.0)
+    slow_but_failed = _at(EventStatus.FAILED, duration=9.0)
+    for ev in (fast, slow, slow_but_failed):
+        await s.default_branch.emit_and_log(ev)
+
+    assert slow_ok == [slow]  # completed AND duration>1.0
+
+
+@pytest.mark.asyncio
+async def test_field_handle_on_execution_duration():
+    """Event.q.duration resolves the nested execution.duration field."""
+    s = Session()
+    seen: list[Call] = []
+    s.observe(Call.q.duration > 3600, handler=lambda e, _: seen.append(e))
+
+    await s.default_branch.emit_and_log(_at(EventStatus.COMPLETED, duration=10.0))
+    await s.default_branch.emit_and_log(_at(EventStatus.COMPLETED, duration=7200.0))
+
+    assert [e.execution.duration for e in seen] == [7200.0]
+
+
+@pytest.mark.asyncio
+async def test_emit_and_log_standalone_branch_only_logs():
+    """A standalone branch (no session/observer) logs but does not emit — no error."""
+    b = Branch()
+    assert b._observer is None
+    res = await b.emit_and_log(_at(EventStatus.FAILED))
+    assert res == []  # no observer → no handlers
+    assert len(b._log_manager.logs) == 1  # still logged


### PR DESCRIPTION
**PR 2 of 7** (replaces #1239, auto-closed when PR1's branch was deleted). Now targets main; PR1 (#1238) is merged.

Reactive event bus (variadic observe, signals, emit_and_log) + transport-agnostic observer (operations/_observe.py) + ADR-0076 observer-as-hook-transport. 55 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)