### PR TITLE
feat(studio): #1225 — i18n pipeline (next-intl) with en/zh catalogs + locale switcher

### DIFF
--- a/apps/studio/frontend/app/layout.tsx
+++ b/apps/studio/frontend/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { NextIntlClientProvider } from "next-intl";
+import { getLocale, getMessages, getTranslations } from "next-intl/server";
 import Shell from "@/components/Shell";
 import { ToastProvider } from "@/components/Toast";
 import "./globals.css";
@@ -9,13 +11,17 @@ export const metadata: Metadata = {
   description: "Lion Studio orchestration observability",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: ReactNode;
 }>) {
+  const locale = await getLocale();
+  const messages = await getMessages();
+  const t = await getTranslations({ locale, namespace: "common" });
+
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang={locale} suppressHydrationWarning>
       <head>
         {/* Prevent FOUC: read localStorage before paint, default to light */}
         <script
@@ -29,11 +35,13 @@ export default function RootLayout({
           href="#main-content"
           className="sr-only focus:not-sr-only focus:absolute focus:z-[100] focus:m-2 focus:rounded focus:border focus:border-edge focus:bg-surface-nav focus:px-4 focus:py-2 focus:text-content-primary"
         >
-          Skip to main content
+          {t("skipToMain")}
         </a>
-        <ToastProvider>
-          <Shell>{children}</Shell>
-        </ToastProvider>
+        <NextIntlClientProvider messages={messages}>
+          <ToastProvider>
+            <Shell>{children}</Shell>
+          </ToastProvider>
+        </NextIntlClientProvider>
       </body>
     </html>
   );

--- a/apps/studio/frontend/app/runs/page.tsx
+++ b/apps/studio/frontend/app/runs/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { Fragment, Suspense, useEffect, useMemo, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useTranslations } from "next-intl";
 import Button from "@/components/Button";
 import Duration from "@/components/Duration";
 import PageHeader from "@/components/PageHeader";
@@ -11,7 +12,6 @@ import Timestamp from "@/components/Timestamp";
 import { listRuns } from "@/lib/api";
 import type { RunListResponse } from "@/lib/api";
 import type { RunSummary } from "@/lib/types";
-import { empty, errors } from "@/lib/copy";
 
 // ADR-0025: six-value session vocabulary (running/completed/failed/
 // timed_out/aborted/cancelled). "done" stays as an alias for completed
@@ -25,6 +25,17 @@ const STATUS_FILTERS = [
   "aborted",
   "cancelled",
 ] as const;
+
+// Maps raw status code to the catalog key under runs.filters.status.*
+const STATUS_KEY_MAP: Record<string, string> = {
+  pending: "filters.status.pending",
+  running: "filters.status.running",
+  done: "filters.status.done",
+  failed: "filters.status.failed",
+  timed_out: "filters.status.timedOut",
+  aborted: "filters.status.aborted",
+  cancelled: "filters.status.cancelled",
+};
 
 type ViewMode = "sessions" | "invocations";
 
@@ -112,16 +123,18 @@ function provenanceLabel(run: RunSummary): "fs" | "db" {
 
 function StatusFilterChip({
   value,
+  label,
   active,
   onClick,
 }: {
   value: string;
+  label: string;
   active: boolean;
   onClick: () => void;
 }) {
   return (
     <Button variant="toggle" size="sm" active={active} onClick={onClick}>
-      {value}
+      {label}
     </Button>
   );
 }
@@ -150,6 +163,7 @@ function SessionRow({
   now: number;
   indent?: boolean;
 }) {
+  const t = useTranslations("runs");
   const prov = provenanceLabel(run);
   const durSec = durationSeconds(run, now);
   return (
@@ -166,7 +180,10 @@ function SessionRow({
           {run.project && (
             <span
               className="rounded px-1 py-0.5 font-mono text-[10px] border border-edge text-content-muted"
-              title={`Project: ${run.project} (${run.project_source ?? "unknown"})`}
+              title={t("row.projectTitle", {
+                project: run.project,
+                source: run.project_source ?? "unknown",
+              })}
             >
               {run.project}
             </span>
@@ -191,7 +208,7 @@ function SessionRow({
           <Duration value={durSec} />
           <span
             className="rounded px-1 py-0.5 font-mono text-[10px] border border-edge text-content-muted"
-            title={`Source: ${run.source_kind ?? "live"}`}
+            title={t("row.sourceTitle", { source: run.source_kind ?? "live" })}
           >
             {prov}
           </span>
@@ -205,6 +222,7 @@ function SessionRow({
 }
 
 function RunsPageInner() {
+  const t = useTranslations("runs");
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -280,7 +298,7 @@ function RunsPageInner() {
           }
         }
       } catch {
-        if (active) setError(errors.loadRuns);
+        if (active) setError(t("errors.load"));
       } finally {
         if (active) setLoading(false);
       }
@@ -330,13 +348,13 @@ function RunsPageInner() {
   return (
     <main className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-6 animate-page-enter">
       <PageHeader
-        title="Runs"
-        subtitle="Live and completed agent sessions"
+        title={t("title")}
+        subtitle={t("subtitle")}
         density="tight"
         badges={
           !loading ? (
             <span className="text-meta text-content-muted tabular-nums">
-              {total} run{total !== 1 ? "s" : ""}
+              {t("count", { total })}
             </span>
           ) : null
         }
@@ -352,7 +370,7 @@ function RunsPageInner() {
               active={viewMode === "sessions"}
               onClick={() => setViewMode("sessions")}
             >
-              Sessions
+              {t("view.sessions")}
             </Button>
             <Button
               size="sm"
@@ -360,7 +378,7 @@ function RunsPageInner() {
               active={viewMode === "invocations"}
               onClick={() => setViewMode("invocations")}
             >
-              Invocations
+              {t("view.invocations")}
             </Button>
           </div>
           {/* ADR-0026: project filter chips */}
@@ -372,7 +390,7 @@ function RunsPageInner() {
                 active={!project}
                 onClick={() => setQuery({ project: "", page: 1 })}
               >
-                All
+                {t("filters.project.all")}
               </Button>
               {knownProjects.map((p) => (
                 <Button
@@ -392,14 +410,14 @@ function RunsPageInner() {
           <div className="flex items-center gap-1.5">
             <input
               type="text"
-              placeholder="Filter by playbook..."
+              placeholder={t("filters.playbook.placeholder")}
               value={playbookInput}
               onChange={(e) => setPlaybookInput(e.target.value)}
               onKeyDown={(e) => e.key === "Enter" && applyPlaybookFilter()}
               className="h-7 rounded border border-edge bg-surface-raised px-2.5 text-meta text-content-primary placeholder:text-content-muted focus:border-interactive-primary focus:outline-none"
             />
             <Button size="sm" variant="secondary" onClick={applyPlaybookFilter}>
-              Search
+              {t("filters.playbook.search")}
             </Button>
             {playbook && (
               <Button
@@ -410,7 +428,7 @@ function RunsPageInner() {
                   setQuery({ playbook: "", page: 1 });
                 }}
               >
-                Clear
+                {t("filters.playbook.clear")}
               </Button>
             )}
           </div>
@@ -419,6 +437,7 @@ function RunsPageInner() {
               <StatusFilterChip
                 key={s}
                 value={s}
+                label={t(STATUS_KEY_MAP[s] as Parameters<typeof t>[0])}
                 active={statuses.includes(s)}
                 onClick={() => toggleStatus(s)}
               />
@@ -438,13 +457,13 @@ function RunsPageInner() {
           <thead>
             <tr className="border-b border-edge bg-surface-overlay text-meta uppercase tracking-[0.06em] text-content-muted">
               <th className="px-3 py-2.5 font-medium">
-                {viewMode === "invocations" ? "Invocation" : "Run"}
+                {viewMode === "invocations" ? t("table.invocation") : t("table.run")}
               </th>
-              <th className="px-3 py-2.5 font-medium">Status</th>
+              <th className="px-3 py-2.5 font-medium">{t("table.status")}</th>
               <th className="px-3 py-2.5 font-medium">
-                {viewMode === "invocations" ? "Sessions" : "Activity"}
+                {viewMode === "invocations" ? t("table.sessions") : t("table.activity")}
               </th>
-              <th className="px-3 py-2.5 font-medium">Updated</th>
+              <th className="px-3 py-2.5 font-medium">{t("table.updated")}</th>
             </tr>
           </thead>
           <tbody>
@@ -458,9 +477,9 @@ function RunsPageInner() {
               invocationGroups.length === 0 && ungroupedRuns.length === 0 ? (
                 <tr>
                   <td colSpan={6} className="px-3 py-14 text-center text-body text-content-muted">
-                    <span className="block mb-1 text-[11px]">{empty.runs}</span>
+                    <span className="block mb-1 text-[11px]">{t("empty.none")}</span>
                     {(statuses.length > 0 || playbook) && (
-                      <span className="text-meta">Try adjusting your filters.</span>
+                      <span className="text-meta">{t("empty.adjustFilters")}</span>
                     )}
                   </td>
                 </tr>
@@ -481,7 +500,10 @@ function RunsPageInner() {
                           role="button"
                           tabIndex={0}
                           aria-expanded={isExpanded}
-                          aria-label={`Invocation ${group.invocation_id.slice(-8)}, ${group.sessions.length} session${group.sessions.length !== 1 ? "s" : ""}`}
+                          aria-label={t("invocation.ariaLabel", {
+                            id: group.invocation_id.slice(-8),
+                            count: group.sessions.length,
+                          })}
                           className="border-b border-edge-subtle bg-surface-overlay/50 text-content-primary cursor-pointer transition-colors duration-100 hover:bg-surface-overlay"
                           onClick={() => toggleExpand(group.invocation_id)}
                           onKeyDown={(e) => {
@@ -500,7 +522,7 @@ function RunsPageInner() {
                                 {isExpanded ? "▼" : "▶"}
                               </span>
                               <span className="font-medium">
-                                Invocation{" "}
+                                {t("invocation.label")}{" "}
                                 <span className="font-mono text-meta text-content-muted">
                                   {group.invocation_id.slice(-8)}
                                 </span>
@@ -519,8 +541,7 @@ function RunsPageInner() {
                             )}
                           </td>
                           <td className="px-3 py-2 text-content-secondary">
-                            {group.sessions.length} session
-                            {group.sessions.length !== 1 ? "s" : ""}
+                            {t("invocation.sessionCount", { count: group.sessions.length })}
                           </td>
                           <td className="px-3 py-2 text-meta text-content-muted">
                             <Timestamp value={latestUpdated} />
@@ -541,9 +562,9 @@ function RunsPageInner() {
             ) : runs.length === 0 ? (
               <tr>
                 <td colSpan={4} className="px-3 py-14 text-center text-body text-content-muted">
-                  <span className="block mb-1 text-[11px]">{empty.runs}</span>
+                  <span className="block mb-1 text-[11px]">{t("empty.none")}</span>
                   {(statuses.length > 0 || playbook) && (
-                    <span className="text-meta">Try adjusting your filters.</span>
+                    <span className="text-meta">{t("empty.adjustFilters")}</span>
                   )}
                 </td>
               </tr>
@@ -557,10 +578,7 @@ function RunsPageInner() {
       {/* Pagination — hidden in invocations mode (full dataset loaded client-side) */}
       {viewMode === "sessions" && (
         <div className="flex items-center justify-between text-meta text-content-muted">
-          <span>
-            Page {page} of {totalPages || 1} &mdash; {total} run
-            {total !== 1 ? "s" : ""}
-          </span>
+          <span>{t("pagination.summary", { page, totalPages: totalPages || 1, total })}</span>
           <div className="flex gap-2">
             <Button
               size="sm"
@@ -568,7 +586,7 @@ function RunsPageInner() {
               disabled={!data?.has_prev}
               onClick={() => setQuery({ page: page - 1 })}
             >
-              Previous
+              {t("pagination.previous")}
             </Button>
             <Button
               size="sm"
@@ -576,7 +594,7 @@ function RunsPageInner() {
               disabled={!data?.has_next}
               onClick={() => setQuery({ page: page + 1 })}
             >
-              Next
+              {t("pagination.next")}
             </Button>
           </div>
         </div>

--- a/apps/studio/frontend/app/shows/[topic]/page.tsx
+++ b/apps/studio/frontend/app/shows/[topic]/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import dynamic from "next/dynamic";
 import React, { use, useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
 import Button from "@/components/Button";
 import Duration from "@/components/Duration";
 import PageHeader from "@/components/PageHeader";
@@ -10,7 +11,6 @@ import StatusPill from "@/components/StatusPill";
 import Timestamp from "@/components/Timestamp";
 import { getShow, streamShow } from "@/lib/api";
 import type { PlayMeta, ShowDetail, ShowEvent } from "@/lib/types";
-import { empty } from "@/lib/copy";
 
 const Markdown = dynamic(() => import("@/components/Markdown"), { ssr: false });
 const PlayDag = dynamic(() => import("./components/PlayDag"), { ssr: false });
@@ -59,6 +59,7 @@ function extractSummary(showMd: string | null): Record<string, string> {
 }
 
 export default function ShowDetailPage({ params }: { params: Promise<{ topic: string }> }) {
+  const t = useTranslations("showDetail");
   const { topic: rawTopic } = use(params);
   const topic = decodeURIComponent(rawTopic);
   const [show, setShow] = useState<ShowDetail | null>(null);
@@ -77,9 +78,9 @@ export default function ShowDetailPage({ params }: { params: Promise<{ topic: st
       setError(null);
       setLastRefreshed(Date.now());
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load show");
+      setError(err instanceof Error ? err.message : t("errors.load"));
     }
-  }, [topic]);
+  }, [topic, t]);
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- load is async; setState only fires after await, never synchronously
@@ -135,7 +136,7 @@ export default function ShowDetailPage({ params }: { params: Promise<{ topic: st
         density="tight"
         breadcrumb={[
           <Link key="shows" href="/shows" className="hover:text-content-primary">
-            shows
+            {t("breadcrumb.shows")}
           </Link>,
           <span key="topic" className="text-content-secondary truncate">
             {topic}
@@ -148,7 +149,7 @@ export default function ShowDetailPage({ params }: { params: Promise<{ topic: st
             <span className="text-meta text-content-muted tabular-nums">
               {lastRefreshed ? (
                 <>
-                  refreshed <Timestamp value={lastRefreshed} />
+                  {t("refreshed")} <Timestamp value={lastRefreshed} />
                 </>
               ) : null}
             </span>
@@ -159,7 +160,7 @@ export default function ShowDetailPage({ params }: { params: Promise<{ topic: st
               leading={live ? "●" : "○"}
               onClick={() => setLive((v) => !v)}
             >
-              {live ? "Live on" : "Live off"}
+              {live ? t("live.on") : t("live.off")}
             </Button>
           </div>
         }
@@ -172,7 +173,7 @@ export default function ShowDetailPage({ params }: { params: Promise<{ topic: st
       )}
 
       {!show && !error && (
-        <div className="py-10 text-center text-body text-content-muted">Loading...</div>
+        <div className="py-10 text-center text-body text-content-muted">{t("loading")}</div>
       )}
 
       {show && (
@@ -189,7 +190,7 @@ export default function ShowDetailPage({ params }: { params: Promise<{ topic: st
                 onClick={() => setShowPlan((v) => !v)}
                 className="flex items-center justify-between text-left text-label font-semibold text-content-primary hover:text-content-secondary transition-colors"
               >
-                <span>Plan &amp; decisions</span>
+                <span>{t("plan.toggle")}</span>
                 <span className="text-content-muted text-body ml-2">{showPlan ? "▴" : "▾"}</span>
               </button>
               {showPlan ? (
@@ -197,15 +198,12 @@ export default function ShowDetailPage({ params }: { params: Promise<{ topic: st
                   {show.show_md ? (
                     <Markdown>{show.show_md}</Markdown>
                   ) : (
-                    <p className="text-body text-content-muted">No _show.md found.</p>
+                    <p className="text-body text-content-muted">{t("plan.missing")}</p>
                   )}
                 </div>
               ) : (
                 <div className="rounded border border-edge bg-surface-overlay px-3 py-3 text-body text-content-secondary">
-                  <p>
-                    Operational summary above. Expand <em>Plan &amp; decisions</em> for the full
-                    markdown plan.
-                  </p>
+                  <p>{t("plan.collapsedHint")}</p>
                 </div>
               )}
             </section>
@@ -213,24 +211,28 @@ export default function ShowDetailPage({ params }: { params: Promise<{ topic: st
             {/* Right: plays table — sticky on large screens */}
             <section className="flex min-w-0 flex-col gap-2 lg:sticky lg:top-16 lg:self-start lg:max-h-[calc(100vh-7rem)]">
               <h2 className="text-label font-semibold text-content-primary">
-                Plays <span className="tabular-nums text-content-muted">({show.plays.length})</span>
+                {t("plays.heading", { count: show.plays.length })}
               </h2>
               {show.plays.length === 0 ? (
                 <div className="rounded border border-edge bg-surface-raised px-3 py-10 text-center text-body text-content-muted">
-                  No plays recorded
+                  {t("plays.noneRecorded")}
                 </div>
               ) : (
                 <div className="overflow-auto rounded border border-edge bg-surface-raised lg:max-h-[calc(100vh-9rem)]">
                   <table className="w-full text-left text-body">
                     <thead className="sticky top-0 z-10 border-b border-edge bg-surface-overlay text-meta uppercase tracking-[0.06em] text-content-muted">
                       <tr>
-                        <th className="px-3 py-2 font-medium">Play</th>
-                        <th className="px-3 py-2 font-medium">Status</th>
-                        <th className="px-3 py-2 font-medium">Branch</th>
-                        <th className="px-3 py-2 font-medium tabular-nums">Exit</th>
-                        <th className="px-3 py-2 font-medium">Verdict</th>
-                        <th className="px-3 py-2 font-medium tabular-nums text-right">Dur</th>
-                        <th className="px-3 py-2 font-medium">Updated</th>
+                        <th className="px-3 py-2 font-medium">{t("plays.table.play")}</th>
+                        <th className="px-3 py-2 font-medium">{t("plays.table.status")}</th>
+                        <th className="px-3 py-2 font-medium">{t("plays.table.branch")}</th>
+                        <th className="px-3 py-2 font-medium tabular-nums">
+                          {t("plays.table.exit")}
+                        </th>
+                        <th className="px-3 py-2 font-medium">{t("plays.table.verdict")}</th>
+                        <th className="px-3 py-2 font-medium tabular-nums text-right">
+                          {t("plays.table.durationShort")}
+                        </th>
+                        <th className="px-3 py-2 font-medium">{t("plays.table.updated")}</th>
                         <th className="w-8 px-3 py-2"></th>
                       </tr>
                     </thead>
@@ -262,14 +264,14 @@ export default function ShowDetailPage({ params }: { params: Promise<{ topic: st
                                   <span className="text-body">{play.meta.exit_code ?? "—"}</span>
                                   {flag === "exit_mismatch" && (
                                     <StatusPill
-                                      value="exit mismatch"
+                                      value={t("plays.flags.exitMismatch")}
                                       tone="failed"
                                       kind="verdict"
                                     />
                                   )}
                                   {flag === "missing_exit" && (
                                     <StatusPill
-                                      value="missing exit"
+                                      value={t("plays.flags.missingExit")}
                                       tone="pending"
                                       kind="verdict"
                                     />
@@ -280,7 +282,11 @@ export default function ShowDetailPage({ params }: { params: Promise<{ topic: st
                                 {play.verdict ? (
                                   <StatusPill
                                     kind="verdict"
-                                    value={play.verdict.gate_passed ? "passed" : "rejected"}
+                                    value={
+                                      play.verdict.gate_passed
+                                        ? t("verdict.passed")
+                                        : t("verdict.rejected")
+                                    }
                                   />
                                 ) : (
                                   <span className="text-meta text-content-muted">—</span>
@@ -302,7 +308,7 @@ export default function ShowDetailPage({ params }: { params: Promise<{ topic: st
                               <td className="px-3 py-2">
                                 <span
                                   className="text-body text-content-muted"
-                                  aria-label={isExpanded ? "Collapse" : "Expand"}
+                                  aria-label={isExpanded ? t("plays.collapse") : t("plays.expand")}
                                 >
                                   {isExpanded ? "▴" : "▾"}
                                 </span>
@@ -317,7 +323,7 @@ export default function ShowDetailPage({ params }: { params: Promise<{ topic: st
                                     {play.intent && (
                                       <div>
                                         <div className="text-meta uppercase tracking-[0.06em] text-content-muted">
-                                          Intent
+                                          {t("plays.intent")}
                                         </div>
                                         <div className="mt-1">
                                           <Markdown className="text-body">{play.intent}</Markdown>
@@ -329,7 +335,7 @@ export default function ShowDetailPage({ params }: { params: Promise<{ topic: st
                                     {play.session_id && (
                                       <div>
                                         <div className="text-meta uppercase tracking-[0.06em] text-content-muted">
-                                          Session
+                                          {t("plays.session")}
                                         </div>
                                         <div className="mt-1">
                                           <Link
@@ -347,13 +353,13 @@ export default function ShowDetailPage({ params }: { params: Promise<{ topic: st
                                     <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-body text-content-secondary">
                                       <span>
                                         <span className="text-meta uppercase tracking-[0.06em] text-content-muted mr-1">
-                                          Duration
+                                          {t("plays.duration")}
                                         </span>
                                         <Duration value={dur} />
                                       </span>
                                       <span>
                                         <span className="text-meta uppercase tracking-[0.06em] text-content-muted mr-1">
-                                          Exit
+                                          {t("plays.exit")}
                                         </span>
                                         <span className="tabular-nums">
                                           {play.meta.exit_code ?? "—"}
@@ -361,7 +367,7 @@ export default function ShowDetailPage({ params }: { params: Promise<{ topic: st
                                       </span>
                                       <span>
                                         <span className="text-meta uppercase tracking-[0.06em] text-content-muted mr-1">
-                                          Attempt
+                                          {t("plays.attempt")}
                                         </span>
                                         <span className="tabular-nums">{play.meta.attempt}</span>
                                       </span>
@@ -372,17 +378,21 @@ export default function ShowDetailPage({ params }: { params: Promise<{ topic: st
                                       <div className="flex flex-col gap-1.5">
                                         <div className="flex items-center gap-2">
                                           <span className="text-meta uppercase tracking-[0.06em] text-content-muted">
-                                            Gate
+                                            {t("verdict.gate")}
                                           </span>
                                           <StatusPill
                                             kind="verdict"
-                                            value={play.verdict.gate_passed ? "passed" : "rejected"}
+                                            value={
+                                              play.verdict.gate_passed
+                                                ? t("verdict.passed")
+                                                : t("verdict.rejected")
+                                            }
                                           />
                                         </div>
                                         {play.verdict.feedback && (
                                           <div>
                                             <div className="text-meta uppercase tracking-[0.06em] text-content-muted">
-                                              Feedback
+                                              {t("verdict.feedback")}
                                             </div>
                                             <div className="mt-1">
                                               <Markdown className="text-body">
@@ -394,7 +404,7 @@ export default function ShowDetailPage({ params }: { params: Promise<{ topic: st
                                         {play.verdict.notes && (
                                           <div>
                                             <div className="text-meta uppercase tracking-[0.06em] text-content-muted">
-                                              Notes
+                                              {t("verdict.notes")}
                                             </div>
                                             <div className="mt-1">
                                               <Markdown className="text-body">
@@ -420,13 +430,13 @@ export default function ShowDetailPage({ params }: { params: Promise<{ topic: st
                                         className="flex items-center gap-1 text-meta uppercase tracking-[0.06em] text-content-muted hover:text-content-primary transition-colors"
                                       >
                                         <span>{rawExpanded[play.name] ? "▾" : "▸"}</span>
-                                        <span>Raw data</span>
+                                        <span>{t("raw.toggle")}</span>
                                       </button>
                                       {rawExpanded[play.name] && (
                                         <div className="mt-2 flex flex-col gap-2">
                                           <div>
                                             <div className="flex items-center justify-between text-meta uppercase tracking-[0.06em] text-content-muted">
-                                              <span>Meta</span>
+                                              <span>{t("raw.meta")}</span>
                                               <CopyButton
                                                 text={JSON.stringify(play.meta, null, 2)}
                                               />
@@ -438,7 +448,7 @@ export default function ShowDetailPage({ params }: { params: Promise<{ topic: st
                                           {play.verdict && (
                                             <div>
                                               <div className="flex items-center justify-between text-meta uppercase tracking-[0.06em] text-content-muted">
-                                                <span>Verdict</span>
+                                                <span>{t("raw.verdict")}</span>
                                                 <CopyButton
                                                   text={JSON.stringify(play.verdict, null, 2)}
                                                 />
@@ -467,7 +477,9 @@ export default function ShowDetailPage({ params }: { params: Promise<{ topic: st
 
           {show.plays.length > 0 && (
             <section className="flex flex-col gap-2">
-              <h2 className="text-label font-semibold text-content-primary">Play graph</h2>
+              <h2 className="text-label font-semibold text-content-primary">
+                {t("graph.heading")}
+              </h2>
               <PlayDag plays={show.plays} showMd={show.show_md} />
             </section>
           )}
@@ -484,6 +496,7 @@ function ShowSummaryPanel({
   summary: Record<string, string>;
   rollup: { total: number; failed: Play[]; running: Play[]; merged: Play[] } | null;
 }) {
+  const t = useTranslations("showDetail");
   const hasGoal = Boolean(summary.goal);
   const hasStatus = Boolean(summary.status);
   const hasBlockers = Boolean(summary.blocker);
@@ -496,15 +509,17 @@ function ShowSummaryPanel({
     <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
       {/* Roll-up — always rendered */}
       <section className="rounded border border-edge bg-surface-raised p-3 shadow-card">
-        <h3 className="text-meta uppercase tracking-[0.06em] text-content-muted">Roll-up</h3>
+        <h3 className="text-meta uppercase tracking-[0.06em] text-content-muted">
+          {t("summary.rollup")}
+        </h3>
         {rollup ? (
           <dl className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 text-body">
             <SummaryRow
-              label="Plays"
+              label={t("summary.plays")}
               value={<span className="tabular-nums">{rollup.total}</span>}
             />
             <SummaryRow
-              label="Running"
+              label={t("summary.running")}
               value={
                 <span
                   className={
@@ -518,7 +533,7 @@ function ShowSummaryPanel({
               }
             />
             <SummaryRow
-              label="Failed"
+              label={t("summary.failed")}
               value={
                 <span
                   className={
@@ -532,48 +547,46 @@ function ShowSummaryPanel({
               }
             />
             <SummaryRow
-              label="Merged"
+              label={t("summary.merged")}
               value={
                 <span className="tabular-nums text-content-secondary">{rollup.merged.length}</span>
               }
             />
           </dl>
         ) : (
-          <p className="mt-2 text-body text-content-muted">{empty.plays}</p>
+          <p className="mt-2 text-body text-content-muted">{t("summary.noPlays")}</p>
         )}
       </section>
 
       {/* Goal / Status */}
       <section className="rounded border border-edge bg-surface-raised p-3 shadow-card">
-        <h3 className="text-meta uppercase tracking-[0.06em] text-content-muted">Plan</h3>
+        <h3 className="text-meta uppercase tracking-[0.06em] text-content-muted">
+          {t("summary.plan")}
+        </h3>
         {showSummary ? (
           <dl className="mt-2 flex flex-col gap-1.5 text-body">
-            {hasGoal && <SummaryBlock label="Goal" value={summary.goal} />}
-            {hasStatus && <SummaryBlock label="Status" value={summary.status} />}
+            {hasGoal && <SummaryBlock label={t("summary.goal")} value={summary.goal} />}
+            {hasStatus && <SummaryBlock label={t("summary.status")} value={summary.status} />}
           </dl>
         ) : (
-          <p className="mt-2 text-body text-content-muted">
-            Add{" "}
-            <code className="rounded bg-surface-overlay px-1 text-content-secondary">Goal:</code> /{" "}
-            <code className="rounded bg-surface-overlay px-1 text-content-secondary">Status:</code>{" "}
-            lines near the top of <code className="text-content-secondary">_show.md</code> to
-            surface them here.
-          </p>
+          <p className="mt-2 text-body text-content-muted">{t("summary.addGoalStatusHint")}</p>
         )}
       </section>
 
       {/* Blockers / Next action */}
       <section className="rounded border border-edge bg-surface-raised p-3 shadow-card">
-        <h3 className="text-meta uppercase tracking-[0.06em] text-content-muted">Action</h3>
+        <h3 className="text-meta uppercase tracking-[0.06em] text-content-muted">
+          {t("summary.action")}
+        </h3>
         {hasBlockers || hasNext ? (
           <dl className="mt-2 flex flex-col gap-1.5 text-body">
-            {hasBlockers && <SummaryBlock label="Blockers" value={summary.blocker} tone="failed" />}
-            {hasNext && nextValue && <SummaryBlock label="Next" value={nextValue} />}
+            {hasBlockers && (
+              <SummaryBlock label={t("summary.blockers")} value={summary.blocker} tone="failed" />
+            )}
+            {hasNext && nextValue && <SummaryBlock label={t("summary.next")} value={nextValue} />}
           </dl>
         ) : (
-          <p className="mt-2 text-body text-content-muted">
-            No blockers or next action declared in plan.
-          </p>
+          <p className="mt-2 text-body text-content-muted">{t("summary.noAction")}</p>
         )}
       </section>
     </div>
@@ -603,6 +616,7 @@ function SummaryBlock({ label, value, tone }: { label: string; value: string; to
 }
 
 function CopyButton({ text }: { text: string }) {
+  const t = useTranslations("common");
   const [copied, setCopied] = useState(false);
 
   const handleCopy = useCallback(() => {
@@ -622,7 +636,7 @@ function CopyButton({ text }: { text: string }) {
       onClick={handleCopy}
       className="rounded border border-edge bg-surface-raised px-2 py-0.5 font-mono text-meta text-content-muted hover:border-edge-strong hover:text-content-primary"
     >
-      {copied ? "copied" : "copy"}
+      {copied ? t("copy.copied") : t("copy.copy")}
     </button>
   );
 }

--- a/apps/studio/frontend/components/Shell.tsx
+++ b/apps/studio/frontend/components/Shell.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useLocale, useTranslations } from "next-intl";
 import { Suspense, useEffect, useState, type ReactNode } from "react";
 import Breadcrumb from "@/components/nav/Breadcrumb";
 import NavGroup from "@/components/nav/NavGroup";
@@ -13,6 +14,7 @@ export interface ShellProps {
 }
 
 function ThemeToggle() {
+  const t = useTranslations("nav");
   const [dark, setDark] = useState(false);
 
   useEffect(() => {
@@ -36,7 +38,7 @@ function ThemeToggle() {
     <button
       type="button"
       onClick={toggle}
-      aria-label="Toggle theme"
+      aria-label={t("theme.toggle")}
       aria-pressed={dark}
       className="ml-1 flex h-6 w-6 shrink-0 items-center justify-center rounded text-content-muted hover:bg-interactive-secondary hover:text-content-primary transition-colors"
     >
@@ -83,7 +85,35 @@ function ThemeToggle() {
   );
 }
 
+function LocaleSwitcher() {
+  const t = useTranslations("nav");
+  const locale = useLocale();
+
+  function switchLocale(newLocale: string) {
+    document.cookie = `NEXT_LOCALE=${newLocale};path=/;max-age=31536000;SameSite=Lax`;
+    window.location.reload();
+  }
+
+  const nextLocale = locale === "en" ? "zh" : "en";
+  const buttonLabel = locale === "en" ? t("localeSwitcher.labelZh") : t("localeSwitcher.labelEn");
+  const ariaLabel =
+    locale === "en" ? t("localeSwitcher.switchToZh") : t("localeSwitcher.switchToEn");
+
+  return (
+    <button
+      type="button"
+      onClick={() => switchLocale(nextLocale)}
+      aria-label={ariaLabel}
+      className="ml-1 flex h-6 items-center justify-center rounded border border-edge px-1.5 text-[11px] text-content-secondary hover:border-edge-strong hover:text-content-primary transition-colors cursor-pointer"
+    >
+      {buttonLabel}
+    </button>
+  );
+}
+
 export default function Shell({ children }: ShellProps) {
+  const t = useTranslations("nav");
+  const tc = useTranslations("common");
   const pathname = usePathname() ?? "/";
   const [mobileOpen, setMobileOpen] = useState(false);
 
@@ -94,7 +124,7 @@ export default function Shell({ children }: ShellProps) {
         href="#main-content"
         className="sr-only focus:not-sr-only focus:fixed focus:left-2 focus:top-2 focus:z-[9999] focus:rounded focus:bg-surface-raised focus:px-3 focus:py-1.5 focus:text-body focus:text-content-primary focus:shadow-card-hover focus:outline-none focus:ring-2 focus:ring-interactive-primary"
       >
-        Skip to main content
+        {tc("skipToMain")}
       </a>
       <header
         className="sticky top-0 z-40 border-b border-edge bg-surface-nav"
@@ -104,7 +134,7 @@ export default function Shell({ children }: ShellProps) {
           {/* Brand: monogram + wordmark */}
           <Link
             href="/"
-            title="Dashboard"
+            title={t("dashboard.title")}
             className="group flex shrink-0 items-center gap-2 self-center"
           >
             <span
@@ -116,16 +146,16 @@ export default function Shell({ children }: ShellProps) {
             </span>
             <span className="flex flex-col leading-tight">
               <span className="text-[13px] font-semibold tracking-tight text-content-primary">
-                Lion Studio
+                {t("brand.name")}
               </span>
               <span className="hidden text-[9px] font-medium uppercase tracking-[0.12em] text-content-muted sm:inline">
-                Orchestration
+                {t("brand.subtitle")}
               </span>
             </span>
           </Link>
 
           {/* Desktop: 4-group primary nav */}
-          <nav aria-label="Primary" className="hidden items-stretch gap-0.5 md:flex">
+          <nav aria-label={t("primary.ariaLabel")} className="hidden items-stretch gap-0.5 md:flex">
             {NAV_GROUPS.map((group) => (
               <NavGroup key={group.label} group={group} pathname={pathname} />
             ))}
@@ -139,11 +169,12 @@ export default function Shell({ children }: ShellProps) {
             <Suspense fallback={null}>
               <ProjectChip />
             </Suspense>
+            <LocaleSwitcher />
             <ThemeToggle />
             {/* Hamburger: visible below 768px */}
             <button
               type="button"
-              aria-label="Open navigation menu"
+              aria-label={t("mobile.open")}
               aria-expanded={mobileOpen}
               onClick={() => setMobileOpen((v) => !v)}
               className="flex h-8 w-8 items-center justify-center rounded text-content-muted transition-colors hover:bg-interactive-secondary hover:text-content-primary md:hidden"

--- a/apps/studio/frontend/components/nav/Breadcrumb.tsx
+++ b/apps/studio/frontend/components/nav/Breadcrumb.tsx
@@ -2,19 +2,54 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { NAV_GROUPS, isRouteActive } from "./types";
 
+const GROUP_KEY: Record<string, string> = {
+  Dashboard: "groups.dashboard",
+  Work: "groups.work",
+  Library: "groups.library",
+  Admin: "groups.admin",
+};
+
+const ITEM_KEY: Record<string, string> = {
+  Dashboard: "items.dashboard",
+  Shows: "items.shows",
+  Runs: "items.runs",
+  Projects: "items.projects",
+  Teams: "items.teams",
+  Invocations: "items.invocations",
+  Schedules: "items.schedules",
+  Playbooks: "items.playbooks",
+  Agents: "items.agents",
+  Plugins: "items.plugins",
+  Skills: "items.skills",
+  Health: "items.health",
+  Maintenance: "items.maintenance",
+};
+
 export default function Breadcrumb() {
+  const t = useTranslations("nav");
   const pathname = usePathname() ?? "/";
+
+  const tGroup = (label: string) => {
+    const key = GROUP_KEY[label];
+    return key ? t(key as Parameters<typeof t>[0]) : label;
+  };
+
+  const tItem = (label: string) => {
+    const key = ITEM_KEY[label];
+    return key ? t(key as Parameters<typeof t>[0]) : label;
+  };
 
   // Dashboard root
   if (pathname === "/") {
     return (
       <nav
-        aria-label="Breadcrumb"
+        aria-label={t("breadcrumb.ariaLabel")}
         className="flex h-6 items-center gap-1 border-b border-edge bg-surface-base px-4 text-meta text-content-muted"
       >
-        <span>Dashboard</span>
+        <span>{t("items.dashboard")}</span>
       </nav>
     );
   }
@@ -40,7 +75,7 @@ export default function Breadcrumb() {
     const firstSegment = pathname.split("/").filter(Boolean)[0] ?? "";
     return (
       <nav
-        aria-label="Breadcrumb"
+        aria-label={t("breadcrumb.ariaLabel")}
         className="flex h-6 items-center gap-1 border-b border-edge bg-surface-base px-4 text-meta text-content-muted"
       >
         {firstSegment && <span>{decodeURIComponent(firstSegment)}</span>}
@@ -61,13 +96,13 @@ export default function Breadcrumb() {
 
   return (
     <nav
-      aria-label="Breadcrumb"
+      aria-label={t("breadcrumb.ariaLabel")}
       className="flex h-6 items-center gap-1 border-b border-edge bg-surface-base px-4 text-meta text-content-muted"
     >
-      <span>{groupLabel}</span>
+      <span>{tGroup(groupLabel)}</span>
       <span aria-hidden="true">›</span>
       <Link href={itemHref} className="transition-colors duration-150 hover:text-content-secondary">
-        {itemLabel}
+        {tItem(itemLabel)}
       </Link>
       {detailSegment && (
         <>

--- a/apps/studio/frontend/components/nav/NavGroup.tsx
+++ b/apps/studio/frontend/components/nav/NavGroup.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useId, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 import { type NavGroupDef, isRouteActive } from "./types";
 
 interface NavGroupProps {
@@ -11,7 +12,31 @@ interface NavGroupProps {
   onNavigate?: () => void;
 }
 
+const GROUP_KEY: Record<string, string> = {
+  Dashboard: "groups.dashboard",
+  Work: "groups.work",
+  Library: "groups.library",
+  Admin: "groups.admin",
+};
+
+const ITEM_KEY: Record<string, string> = {
+  Dashboard: "items.dashboard",
+  Shows: "items.shows",
+  Runs: "items.runs",
+  Projects: "items.projects",
+  Teams: "items.teams",
+  Invocations: "items.invocations",
+  Schedules: "items.schedules",
+  Playbooks: "items.playbooks",
+  Agents: "items.agents",
+  Plugins: "items.plugins",
+  Skills: "items.skills",
+  Health: "items.health",
+  Maintenance: "items.maintenance",
+};
+
 export default function NavGroup({ group, pathname, mobile = false, onNavigate }: NavGroupProps) {
+  const t = useTranslations("nav");
   const [open, setOpen] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // closeTimerRef must be declared unconditionally at the top (React
@@ -20,6 +45,16 @@ export default function NavGroup({ group, pathname, mobile = false, onNavigate }
   const menuRef = useRef<HTMLDivElement | null>(null);
   const menuId = useId();
   const groupActive = group.items.some((item) => isRouteActive(item, pathname));
+
+  const tGroup = (label: string) => {
+    const key = GROUP_KEY[label];
+    return key ? t(key as Parameters<typeof t>[0]) : label;
+  };
+
+  const tItem = (label: string) => {
+    const key = ITEM_KEY[label];
+    return key ? t(key as Parameters<typeof t>[0]) : label;
+  };
 
   // Dashboard single direct link — no submenu
   if (group.items.length === 1 && group.items[0].href === "/") {
@@ -36,7 +71,7 @@ export default function NavGroup({ group, pathname, mobile = false, onNavigate }
               active ? "font-semibold text-content-primary" : "text-content-secondary",
             ].join(" ")}
           >
-            {group.label}
+            {tGroup(group.label)}
           </Link>
         </div>
       );
@@ -51,7 +86,7 @@ export default function NavGroup({ group, pathname, mobile = false, onNavigate }
             active ? "text-content-primary" : "text-content-muted hover:text-content-secondary",
           ].join(" ")}
         >
-          {group.label}
+          {tGroup(group.label)}
           {active && (
             <span className="absolute inset-x-2.5 bottom-0 h-[2px] rounded-t bg-interactive-primary" />
           )}
@@ -75,7 +110,7 @@ export default function NavGroup({ group, pathname, mobile = false, onNavigate }
               groupActive ? "font-semibold text-content-primary" : "text-content-secondary"
             }
           >
-            {group.label}
+            {tGroup(group.label)}
           </span>
           <span
             className={["transition-transform duration-150", open ? "rotate-180" : ""].join(" ")}
@@ -99,7 +134,7 @@ export default function NavGroup({ group, pathname, mobile = false, onNavigate }
                       : "text-content-secondary hover:text-content-primary",
                   ].join(" ")}
                 >
-                  {item.label}
+                  {tItem(item.label)}
                 </Link>
               );
             })}
@@ -193,7 +228,7 @@ export default function NavGroup({ group, pathname, mobile = false, onNavigate }
             : "text-content-muted hover:text-content-secondary",
         ].join(" ")}
       >
-        {group.label} ▾
+        {tGroup(group.label)} ▾
         {(groupActive || open) && (
           <span className="absolute inset-x-2.5 bottom-0 h-[2px] rounded-t bg-interactive-primary" />
         )}
@@ -205,7 +240,7 @@ export default function NavGroup({ group, pathname, mobile = false, onNavigate }
           ref={menuRef}
           id={menuId}
           role="menu"
-          aria-label={group.label}
+          aria-label={tGroup(group.label)}
           onKeyDown={handleMenuKeyDown}
           className="absolute left-0 top-full z-50 min-w-44 rounded border border-edge bg-surface-nav py-1 shadow-card"
         >
@@ -222,7 +257,7 @@ export default function NavGroup({ group, pathname, mobile = false, onNavigate }
                   active ? "font-semibold text-content-primary" : "text-content-secondary",
                 ].join(" ")}
               >
-                {item.label}
+                {tItem(item.label)}
               </Link>
             );
           })}

--- a/apps/studio/frontend/components/nav/ProjectChip.tsx
+++ b/apps/studio/frontend/components/nav/ProjectChip.tsx
@@ -2,11 +2,13 @@
 
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { useEffect, useId, useRef, useState } from "react";
 import { listProjects } from "@/lib/api";
 import type { ProjectSummary } from "@/lib/types";
 
 export default function ProjectChip() {
+  const t = useTranslations("nav");
   const router = useRouter();
   const pathname = usePathname() ?? "/";
   const searchParams = useSearchParams();
@@ -98,7 +100,9 @@ export default function ProjectChip() {
     }
   }
 
-  const chipLabel = currentProject ? `[project: ${currentProject} ▾]` : "[All projects ▾]";
+  const chipLabel = currentProject
+    ? t("projectChip.selected", { name: currentProject })
+    : t("projectChip.allShort");
 
   return (
     <div ref={containerRef} className="relative">
@@ -106,7 +110,7 @@ export default function ProjectChip() {
         type="button"
         onClick={() => setOpen((v) => !v)}
         onKeyDown={handleTriggerKeyDown}
-        aria-label="Filter by project"
+        aria-label={t("projectChip.ariaLabel")}
         aria-haspopup="menu"
         aria-expanded={open}
         aria-controls={menuId}
@@ -121,7 +125,7 @@ export default function ProjectChip() {
           ref={menuRef}
           id={menuId}
           role="menu"
-          aria-label="Filter by project"
+          aria-label={t("projectChip.ariaLabel")}
           onKeyDown={handleMenuKeyDown}
           className="absolute right-0 top-full z-50 mt-1 w-64 rounded border border-edge bg-surface-nav py-1 shadow-card"
         >
@@ -137,7 +141,7 @@ export default function ProjectChip() {
                 : "text-content-secondary",
             ].join(" ")}
           >
-            All projects
+            {t("projectChip.all")}
           </button>
 
           {projects.map((p) => (
@@ -168,7 +172,7 @@ export default function ProjectChip() {
               onClick={() => setOpen(false)}
               className="block px-3 py-2 text-body text-content-secondary transition-colors duration-150 hover:bg-surface-overlay hover:text-content-primary focus:bg-surface-overlay focus:outline-none"
             >
-              View all projects
+              {t("projectChip.viewAll")}
             </Link>
           </div>
         </div>

--- a/apps/studio/frontend/i18n/request.ts
+++ b/apps/studio/frontend/i18n/request.ts
@@ -1,0 +1,18 @@
+import { getRequestConfig } from "next-intl/server";
+import { cookies } from "next/headers";
+
+const VALID_LOCALES = ["en", "zh"] as const;
+type Locale = (typeof VALID_LOCALES)[number];
+
+export default getRequestConfig(async () => {
+  const cookieStore = await cookies();
+  const raw = cookieStore.get("NEXT_LOCALE")?.value ?? "en";
+  const locale: Locale = (VALID_LOCALES as readonly string[]).includes(raw)
+    ? (raw as Locale)
+    : "en";
+
+  return {
+    locale,
+    messages: (await import(`../messages/${locale}.json`)).default,
+  };
+});

--- a/apps/studio/frontend/messages/en.json
+++ b/apps/studio/frontend/messages/en.json
@@ -1,0 +1,208 @@
+{
+  "nav": {
+    "theme": {
+      "toggle": "Toggle theme"
+    },
+    "brand": {
+      "name": "Lion Studio",
+      "subtitle": "Orchestration"
+    },
+    "dashboard": {
+      "title": "Dashboard"
+    },
+    "primary": {
+      "ariaLabel": "Primary"
+    },
+    "mobile": {
+      "open": "Open navigation menu"
+    },
+    "breadcrumb": {
+      "ariaLabel": "Breadcrumb"
+    },
+    "groups": {
+      "dashboard": "Dashboard",
+      "work": "Work",
+      "library": "Library",
+      "admin": "Admin"
+    },
+    "items": {
+      "dashboard": "Dashboard",
+      "shows": "Shows",
+      "runs": "Runs",
+      "projects": "Projects",
+      "teams": "Teams",
+      "invocations": "Invocations",
+      "schedules": "Schedules",
+      "playbooks": "Playbooks",
+      "agents": "Agents",
+      "plugins": "Plugins",
+      "skills": "Skills",
+      "health": "Health",
+      "maintenance": "Maintenance"
+    },
+    "projectChip": {
+      "selected": "[project: {name} ▾]",
+      "allShort": "[All projects ▾]",
+      "ariaLabel": "Filter by project",
+      "all": "All projects",
+      "viewAll": "View all projects"
+    },
+    "localeSwitcher": {
+      "switchToZh": "切換到中文",
+      "switchToEn": "Switch to English",
+      "labelZh": "中文",
+      "labelEn": "EN"
+    }
+  },
+  "common": {
+    "skipToMain": "Skip to main content",
+    "copy": {
+      "copy": "copy",
+      "copied": "copied"
+    },
+    "time": {
+      "ago": "ago",
+      "fromNow": "from now",
+      "justNow": "just now"
+    },
+    "duration": {
+      "unavailable": "duration unavailable",
+      "invalidOrder": "timestamp missing or out of order"
+    }
+  },
+  "metadata": {
+    "title": "Lion Studio",
+    "description": "Lion Studio orchestration observability"
+  },
+  "runs": {
+    "title": "Runs",
+    "subtitle": "Live and completed agent sessions",
+    "count": "{total} run(s)",
+    "view": {
+      "sessions": "Sessions",
+      "invocations": "Invocations"
+    },
+    "filters": {
+      "status": {
+        "pending": "pending",
+        "running": "running",
+        "done": "done",
+        "failed": "failed",
+        "timedOut": "timed_out",
+        "aborted": "aborted",
+        "cancelled": "cancelled"
+      },
+      "project": {
+        "all": "All"
+      },
+      "playbook": {
+        "placeholder": "Filter by playbook...",
+        "search": "Search",
+        "clear": "Clear"
+      }
+    },
+    "row": {
+      "projectTitle": "Project: {project} ({source})",
+      "sourceTitle": "Source: {source}"
+    },
+    "table": {
+      "invocation": "Invocation",
+      "run": "Run",
+      "status": "Status",
+      "sessions": "Sessions",
+      "activity": "Activity",
+      "updated": "Updated"
+    },
+    "empty": {
+      "none": "No runs found.",
+      "adjustFilters": "Try adjusting your filters."
+    },
+    "invocation": {
+      "ariaLabel": "Invocation {id}, {count} session(s)",
+      "label": "Invocation",
+      "sessionCount": "{count} session(s)"
+    },
+    "pagination": {
+      "summary": "Page {page} of {totalPages} - {total} run(s)",
+      "previous": "Previous",
+      "next": "Next"
+    },
+    "errors": {
+      "load": "Failed to load runs."
+    }
+  },
+  "showDetail": {
+    "errors": {
+      "load": "Failed to load show"
+    },
+    "breadcrumb": {
+      "shows": "shows"
+    },
+    "refreshed": "refreshed",
+    "live": {
+      "on": "Live on",
+      "off": "Live off"
+    },
+    "loading": "Loading...",
+    "plan": {
+      "toggle": "Plan & decisions",
+      "missing": "No _show.md found.",
+      "collapsedHint": "Operational summary above. Expand Plan & decisions for the full markdown plan."
+    },
+    "plays": {
+      "heading": "Plays ({count})",
+      "noneRecorded": "No plays recorded",
+      "table": {
+        "play": "Play",
+        "status": "Status",
+        "branch": "Branch",
+        "exit": "Exit",
+        "verdict": "Verdict",
+        "durationShort": "Dur",
+        "updated": "Updated"
+      },
+      "flags": {
+        "exitMismatch": "exit mismatch",
+        "missingExit": "missing exit"
+      },
+      "collapse": "Collapse",
+      "expand": "Expand",
+      "intent": "Intent",
+      "session": "Session",
+      "duration": "Duration",
+      "exit": "Exit",
+      "attempt": "Attempt"
+    },
+    "verdict": {
+      "passed": "passed",
+      "rejected": "rejected",
+      "gate": "Gate",
+      "feedback": "Feedback",
+      "notes": "Notes"
+    },
+    "raw": {
+      "toggle": "Raw data",
+      "meta": "Meta",
+      "verdict": "Verdict"
+    },
+    "graph": {
+      "heading": "Play graph"
+    },
+    "summary": {
+      "rollup": "Roll-up",
+      "plays": "Plays",
+      "running": "Running",
+      "failed": "Failed",
+      "merged": "Merged",
+      "noPlays": "No plays yet.",
+      "plan": "Plan",
+      "goal": "Goal",
+      "status": "Status",
+      "addGoalStatusHint": "Add Goal: / Status: lines near the top of _show.md to surface them here.",
+      "action": "Action",
+      "blockers": "Blockers",
+      "next": "Next",
+      "noAction": "No blockers or next action declared in plan."
+    }
+  }
+}

--- a/apps/studio/frontend/messages/zh.json
+++ b/apps/studio/frontend/messages/zh.json
@@ -1,0 +1,208 @@
+{
+  "nav": {
+    "theme": {
+      "toggle": "切换主题"
+    },
+    "brand": {
+      "name": "Lion Studio",
+      "subtitle": "协调引擎"
+    },
+    "dashboard": {
+      "title": "控制台"
+    },
+    "primary": {
+      "ariaLabel": "主导航"
+    },
+    "mobile": {
+      "open": "打开导航菜单"
+    },
+    "breadcrumb": {
+      "ariaLabel": "导航路径"
+    },
+    "groups": {
+      "dashboard": "控制台",
+      "work": "工作",
+      "library": "资源库",
+      "admin": "管理"
+    },
+    "items": {
+      "dashboard": "控制台",
+      "shows": "展示",
+      "runs": "运行",
+      "projects": "项目",
+      "teams": "团队",
+      "invocations": "调用",
+      "schedules": "调度",
+      "playbooks": "剧本",
+      "agents": "智能体",
+      "plugins": "插件",
+      "skills": "技能",
+      "health": "健康状态",
+      "maintenance": "维护"
+    },
+    "projectChip": {
+      "selected": "[项目：{name} ▾]",
+      "allShort": "[所有项目 ▾]",
+      "ariaLabel": "按项目筛选",
+      "all": "所有项目",
+      "viewAll": "查看所有项目"
+    },
+    "localeSwitcher": {
+      "switchToZh": "切换到中文",
+      "switchToEn": "切换到英文",
+      "labelZh": "中文",
+      "labelEn": "EN"
+    }
+  },
+  "common": {
+    "skipToMain": "跳转到主要内容",
+    "copy": {
+      "copy": "复制",
+      "copied": "已复制"
+    },
+    "time": {
+      "ago": "前",
+      "fromNow": "后",
+      "justNow": "刚刚"
+    },
+    "duration": {
+      "unavailable": "持续时间不可用",
+      "invalidOrder": "时间戳缺失或顺序错误"
+    }
+  },
+  "metadata": {
+    "title": "Lion Studio",
+    "description": "Lion Studio 协调可观测性平台"
+  },
+  "runs": {
+    "title": "运行",
+    "subtitle": "实时和已完成的智能体会话",
+    "count": "{total} 条运行",
+    "view": {
+      "sessions": "会话",
+      "invocations": "调用"
+    },
+    "filters": {
+      "status": {
+        "pending": "等待中",
+        "running": "运行中",
+        "done": "已完成",
+        "failed": "已失败",
+        "timedOut": "已超时",
+        "aborted": "已中止",
+        "cancelled": "已取消"
+      },
+      "project": {
+        "all": "全部"
+      },
+      "playbook": {
+        "placeholder": "按剧本筛选...",
+        "search": "搜索",
+        "clear": "清除"
+      }
+    },
+    "row": {
+      "projectTitle": "项目：{project}（{source}）",
+      "sourceTitle": "来源：{source}"
+    },
+    "table": {
+      "invocation": "调用",
+      "run": "运行",
+      "status": "状态",
+      "sessions": "会话",
+      "activity": "活动",
+      "updated": "更新时间"
+    },
+    "empty": {
+      "none": "未找到运行记录。",
+      "adjustFilters": "请尝试调整筛选条件。"
+    },
+    "invocation": {
+      "ariaLabel": "调用 {id}，{count} 个会话",
+      "label": "调用",
+      "sessionCount": "{count} 个会话"
+    },
+    "pagination": {
+      "summary": "第 {page} 页，共 {totalPages} 页 — 共 {total} 条运行",
+      "previous": "上一页",
+      "next": "下一页"
+    },
+    "errors": {
+      "load": "加载运行记录失败。"
+    }
+  },
+  "showDetail": {
+    "errors": {
+      "load": "加载展示失败"
+    },
+    "breadcrumb": {
+      "shows": "展示"
+    },
+    "refreshed": "已刷新",
+    "live": {
+      "on": "实时已开启",
+      "off": "实时已关闭"
+    },
+    "loading": "加载中…",
+    "plan": {
+      "toggle": "计划与决策",
+      "missing": "未找到 _show.md 文件。",
+      "collapsedHint": "上方为运营摘要，展开「计划与决策」查看完整 Markdown 计划。"
+    },
+    "plays": {
+      "heading": "剧本（{count}）",
+      "noneRecorded": "暂无剧本记录",
+      "table": {
+        "play": "剧本",
+        "status": "状态",
+        "branch": "分支",
+        "exit": "退出",
+        "verdict": "评审",
+        "durationShort": "时长",
+        "updated": "更新时间"
+      },
+      "flags": {
+        "exitMismatch": "退出状态不匹配",
+        "missingExit": "缺少退出状态"
+      },
+      "collapse": "折叠",
+      "expand": "展开",
+      "intent": "意图",
+      "session": "会话",
+      "duration": "持续时间",
+      "exit": "退出",
+      "attempt": "尝试次数"
+    },
+    "verdict": {
+      "passed": "通过",
+      "rejected": "拒绝",
+      "gate": "门控",
+      "feedback": "反馈",
+      "notes": "备注"
+    },
+    "raw": {
+      "toggle": "原始数据",
+      "meta": "元数据",
+      "verdict": "评审"
+    },
+    "graph": {
+      "heading": "剧本图"
+    },
+    "summary": {
+      "rollup": "汇总",
+      "plays": "剧本",
+      "running": "运行中",
+      "failed": "已失败",
+      "merged": "已合并",
+      "noPlays": "暂无剧本。",
+      "plan": "计划",
+      "goal": "目标",
+      "status": "状态",
+      "addGoalStatusHint": "在 _show.md 顶部附近添加 Goal: / Status: 行以在此处显示。",
+      "action": "行动",
+      "blockers": "阻塞项",
+      "next": "下一步",
+      "noAction": "计划中未声明阻塞项或下一步行动。"
+    }
+  }
+}

--- a/apps/studio/frontend/next.config.mjs
+++ b/apps/studio/frontend/next.config.mjs
@@ -1,5 +1,16 @@
+import createNextIntlPlugin from "next-intl/plugin";
+
+const withNextIntl = createNextIntlPlugin("./i18n/request.ts");
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Next.js 16 moved turbopack config out of experimental; manually wire the
+  // next-intl/config alias since next-intl's plugin still writes experimental.turbo.
+  turbopack: {
+    resolveAlias: {
+      "next-intl/config": "./i18n/request.ts",
+    },
+  },
   async redirects() {
     return [
       // ADR-0032: remove this one-release compatibility redirect in the next release.
@@ -8,4 +19,4 @@ const nextConfig = {
   },
 };
 
-export default nextConfig;
+export default withNextIntl(nextConfig);

--- a/apps/studio/frontend/package-lock.json
+++ b/apps/studio/frontend/package-lock.json
@@ -8,6 +8,7 @@
         "@types/dagre": "^0.7.54",
         "dagre": "^0.8.5",
         "next": "^16.2.6",
+        "next-intl": "^3.26.0",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "react-markdown": "^10.1.0",
@@ -542,6 +543,66 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+      "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.2",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract/node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+      "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+      "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/icu-skeleton-parser": "1.8.16",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+      "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.10.tgz",
+      "integrity": "sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2"
       }
     },
     "node_modules/@humanfs/core": {
@@ -3316,6 +3377,12 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
@@ -4848,6 +4915,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.18",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+      "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.4",
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/is-alphabetical": {
@@ -6559,6 +6638,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/next": {
       "version": "16.2.6",
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
@@ -6610,6 +6698,27 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-intl": {
+      "version": "3.26.5",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-3.26.5.tgz",
+      "integrity": "sha512-EQlCIfY0jOhRldiFxwSXG+ImwkQtDEfQeSOEQp6ieAGSLWGlgjdb/Ck/O7wMfC430ZHGeUKVKax8KGusTPKCgg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "^0.5.4",
+        "negotiator": "^1.0.0",
+        "use-intl": "^3.26.5"
+      },
+      "peerDependencies": {
+        "next": "^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
       }
     },
     "node_modules/next/node_modules/postcss": {
@@ -8583,6 +8692,19 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-intl": {
+      "version": "3.26.5",
+      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-3.26.5.tgz",
+      "integrity": "sha512-OdsJnC/znPvHCHLQH/duvQNXnP1w0hPfS+tkSi3mAbfjYBGh4JnyfdwkQBfIVf7t8gs9eSX/CntxUMvtKdG2MQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "^2.2.0",
+        "intl-messageformat": "^10.5.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
       }
     },
     "node_modules/use-sync-external-store": {

--- a/apps/studio/frontend/package.json
+++ b/apps/studio/frontend/package.json
@@ -16,6 +16,7 @@
     "@types/dagre": "^0.7.54",
     "dagre": "^0.8.5",
     "next": "^16.2.6",
+    "next-intl": "^3.26.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-markdown": "^10.1.0",

--- a/apps/studio/frontend/pnpm-lock.yaml
+++ b/apps/studio/frontend/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       next:
         specifier: ^16.2.6
         version: 16.2.6(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next-intl:
+        specifier: ^3.26.0
+        version: 3.26.5(next@16.2.6(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -204,6 +207,24 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@formatjs/ecma402-abstract@2.3.6':
+    resolution: {integrity: sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==}
+
+  '@formatjs/fast-memoize@2.2.7':
+    resolution: {integrity: sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==}
+
+  '@formatjs/icu-messageformat-parser@2.11.4':
+    resolution: {integrity: sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==}
+
+  '@formatjs/icu-skeleton-parser@1.8.16':
+    resolution: {integrity: sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==}
+
+  '@formatjs/intl-localematcher@0.5.10':
+    resolution: {integrity: sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==}
+
+  '@formatjs/intl-localematcher@0.6.2':
+    resolution: {integrity: sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==}
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -1095,6 +1116,9 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
@@ -1501,6 +1525,9 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
+  intl-messageformat@10.7.18:
+    resolution: {integrity: sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==}
+
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
 
@@ -1885,6 +1912,16 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
+  next-intl@3.26.5:
+    resolution: {integrity: sha512-EQlCIfY0jOhRldiFxwSXG+ImwkQtDEfQeSOEQp6ieAGSLWGlgjdb/Ck/O7wMfC430ZHGeUKVKax8KGusTPKCgg==}
+    peerDependencies:
+      next: ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
 
   next@16.2.6:
     resolution: {integrity: sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==}
@@ -2414,6 +2451,11 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  use-intl@3.26.5:
+    resolution: {integrity: sha512-OdsJnC/znPvHCHLQH/duvQNXnP1w0hPfS+tkSi3mAbfjYBGh4JnyfdwkQBfIVf7t8gs9eSX/CntxUMvtKdG2MQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
+
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
@@ -2656,6 +2698,36 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@formatjs/ecma402-abstract@2.3.6':
+    dependencies:
+      '@formatjs/fast-memoize': 2.2.7
+      '@formatjs/intl-localematcher': 0.6.2
+      decimal.js: 10.6.0
+      tslib: 2.8.1
+
+  '@formatjs/fast-memoize@2.2.7':
+    dependencies:
+      tslib: 2.8.1
+
+  '@formatjs/icu-messageformat-parser@2.11.4':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.6
+      '@formatjs/icu-skeleton-parser': 1.8.16
+      tslib: 2.8.1
+
+  '@formatjs/icu-skeleton-parser@1.8.16':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.6
+      tslib: 2.8.1
+
+  '@formatjs/intl-localematcher@0.5.10':
+    dependencies:
+      tslib: 2.8.1
+
+  '@formatjs/intl-localematcher@0.6.2':
+    dependencies:
+      tslib: 2.8.1
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -3549,6 +3621,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.6.0: {}
+
   decode-named-character-reference@1.3.0:
     dependencies:
       character-entities: 2.0.2
@@ -4113,6 +4187,13 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.3
       side-channel: 1.1.0
+
+  intl-messageformat@10.7.18:
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.6
+      '@formatjs/fast-memoize': 2.2.7
+      '@formatjs/icu-messageformat-parser': 2.11.4
+      tslib: 2.8.1
 
   is-alphabetical@2.0.1: {}
 
@@ -4700,6 +4781,16 @@ snapshots:
   napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
+
+  negotiator@1.0.0: {}
+
+  next-intl@3.26.5(next@16.2.6(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
+    dependencies:
+      '@formatjs/intl-localematcher': 0.5.10
+      negotiator: 1.0.0
+      next: 16.2.6(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
+      use-intl: 3.26.5(react@19.2.6)
 
   next@16.2.6(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
@@ -5429,6 +5520,12 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-intl@3.26.5(react@19.2.6):
+    dependencies:
+      '@formatjs/fast-memoize': 2.2.7
+      intl-messageformat: 10.7.18
+      react: 19.2.6
 
   use-sync-external-store@1.6.0(react@19.2.6):
     dependencies:


### PR DESCRIPTION
i18n pipeline for #1225. Traced the full `LocaleSwitcher` cookie → `i18n/request.ts` → `NextIntlClientProvider` → `useTranslations` chain and ran lint/typecheck/build green (18/18 pages). pnpm-lock.yaml updated (frozen-install safe).

## Pipeline (validated end-to-end)
- **next-intl ^3.26** wired: `i18n/request.ts` `getRequestConfig` + `NextIntlClientProvider` in the root layout; cookie-based locale (`NEXT_LOCALE`, no URL prefix/middleware), `en` fallback; `next.config.mjs` turbopack resolveAlias for Next 16 compat.
- **Locale switcher** in the header with year-long cookie persistence.
- **en/zh catalogs** — 126/126 keys match exactly; real Chinese translations (运行, 资源库, 阻塞项, 已超时, 协调引擎, 控制台).
- **Converted**: global nav/header (Shell, Breadcrumb, NavGroup, ProjectChip), runs list, show detail.

## Deferred (documented, non-blocking MIN)
Remaining unconverted pages + shared components + metadata listed for follow-up — the ask was to validate the pipeline end-to-end + one locale, which this does.

Closes #1225

🤖 Generated with [Claude Code](https://claude.com/claude-code)