### PR TITLE
feat(session,operations): lifecycle signal contract + escalation routing + confidence gate (#1251 #1253 #1254)

### DIFF
--- a/docs/adrs/ADR-0077-lifecycle-signal-contract.md
+++ b/docs/adrs/ADR-0077-lifecycle-signal-contract.md
@@ -1,0 +1,164 @@
+# ADR-0077: Canonical Per-Node Lifecycle Signal Contract
+
+**Status**: Accepted
+**Date**: 2026-06-03
+**Implements**: GitHub #1251
+**Builds on**: ADR-0076 (observer as hook transport) · ADR-0072 (reactive capability bus)
+
+## Context
+
+The signals introduced in ADR-0072 and extended in ADR-0076 (`NodeStarted`,
+`NodeCompleted`, `NodeFailed`, `GateDenied`, `RunStart`, `RunEnd`, …) are
+ad-hoc to specific execution paths. Any subscriber that wants to derive a
+node's current state — a progress board, an audit log, a test assertion —
+must parse the signal stream with bespoke conditionals and tolerate gaps:
+
+- There is no `queued` signal to mark when a node enters the runnable graph
+  (including injected `SpawnRequest` children).
+- There is no `awaiting_approval` signal to distinguish "paused for a gate
+  decision" from "still running".
+- There is no `escalated` signal to mark nodes that emitted an
+  `EscalationRequest` and are waiting for re-dispatch or give-up.
+
+The result is that a subscriber reading the observer's `Flow` cannot
+determine the node's current lifecycle lane without coupling to the
+executor's internal dispatch logic.
+
+## Decision
+
+Define a **canonical per-node lifecycle** with six states and a
+**projection helper** that reduces any ordered, single-node signal stream
+to its current lane.
+
+### 1. Canonical states
+
+```python
+NodeLifecycleState = Literal[
+    "queued", "running", "awaiting_approval", "succeeded", "failed", "escalated"
+]
+```
+
+The natural transition graph:
+
+```text
+queued ──► running ──► succeeded
+               │
+               ├──► awaiting_approval ──► running (approval granted)
+               │
+               ├──► failed
+               │
+               └──► escalated
+```
+
+A node may retry: a subsequent `NodeQueued` or `NodeStarted` signal resets
+the state from any terminal (`succeeded | failed | escalated`) back to
+`queued` or `running` for the new attempt.
+
+### 2. Three new signals completing the contract
+
+| Signal | State | When to emit |
+|--------|-------|--------------|
+| `NodeQueued(op_id, name, elapsed=0.0)` | `queued` | When a node enters the runnable graph, including `SpawnRequest` injections. |
+| `NodeAwaitingApproval(op_id, name, reason=None)` | `awaiting_approval` | Immediately before a blocking gate/approval wait. |
+| `NodeEscalated(op_id, name, reason, route)` | `escalated` | When an `EscalationRequest` is routed — `route="higher_tier"` if re-dispatch is scheduled, `route="give_up"` if no escalation path is configured or `human_required=True`. |
+
+`NodeStarted / NodeCompleted / NodeFailed` (existing) cover `running /
+succeeded / failed` and require no changes.
+
+### 3. Projection helper: `lane_for`
+
+```python
+def lane_for(signals: Iterable[Signal | Any]) -> NodeLifecycleState:
+    """Project an ordered, single-node signal stream into its current lane."""
+```
+
+Invariants:
+
+- **Default** state for an empty or non-state-bearing stream is `"queued"`.
+- **Latest wins**: the last state-bearing signal governs.
+- **Terminal sticky**: once `succeeded | failed | escalated` is reached,
+  only a subsequent `NodeQueued` or `NodeStarted` (a new attempt) can reset
+  it. Other signals are ignored.
+- Callers must **pre-filter** signals to a single `op_id` before calling
+  `lane_for`; the helper does not group by node id.
+
+### 4. Signal-to-state mapping
+
+| Signal or condition | Projected state | Notes |
+|---------------------|-----------------|-------|
+| (empty stream) | `queued` | Default. |
+| `NodeQueued` | `queued` | New — see §2. |
+| `NodeStarted` | `running` | Existing. |
+| `RunStart` | `running` | Run-scoped fallback; valid for single-run cards. |
+| `NodeAwaitingApproval` | `awaiting_approval` | New — see §2. |
+| `NodeCompleted` | `succeeded` | Existing. |
+| `RunEnd` | `succeeded` | Run-scoped fallback. |
+| `NodeFailed` | `failed` | Existing. |
+| `RunFailed` | `failed` | Existing. |
+| `NodeEscalated` | `escalated` | New — see §2. |
+| `StructuredOutput(data=EscalationRequest)` | `escalated` | Capability-emission path before `NodeEscalated` is issued. |
+| `GateDenied` | *(ignored)* | Governance detail; may trigger `NodeAwaitingApproval` upstream but is not a lane by itself. |
+| `MessageAdded`, `HookSignal`, others | *(ignored)* | Not state-bearing. |
+| `EventStatus.SKIPPED / CANCELLED / ABORTED` | `failed` (v1) | Mapped conservatively until a `cancelled` lane is added in a follow-up. |
+
+### 5. Location
+
+All new symbols live in `lionagi/session/signal.py` and are exported from
+`lionagi/session/__init__.py`. No new module is introduced. The existing
+`Signal` hierarchy is extended directly.
+
+## Consequences
+
+**Positive**
+
+- Any subscriber (board, dashboard, audit, test) calls `lane_for(signals)`
+  and gets a stable, typed state — no bespoke parser per consumer.
+- `NodeQueued` closes the gap for `SpawnRequest`-injected children that had
+  no observable queued state.
+- `NodeEscalated` makes escalation visible in the audit `Flow` without
+  requiring observers to parse `EscalationRequest` payloads.
+- `NodeAwaitingApproval` distinguishes "blocked on approval" from "still
+  running", enabling time-to-approval metrics.
+- Zero breaking changes: existing signals are unmodified; new signals are
+  additive. Subscribers not yet emitting new signals get `"queued"` as the
+  default, which is conservative and correct.
+
+**Negative**
+
+- Emitters (executor, reactive flow) must be updated to emit `NodeQueued`
+  and `NodeAwaitingApproval` at the right seams. Until that wiring lands,
+  the default state for un-instrumented nodes is `"queued"` (acceptable
+  conservative fallback).
+- `lane_for` trusts signal ordering. Out-of-order delivery (rare on a
+  synchronous in-process bus) could misproject state.
+
+## Follow-ups (not in this landing)
+
+1. **Wire `NodeQueued`** in `ReactiveExecutor.inject(...)` when a
+   `SpawnRequest` child is added to the runnable graph.
+2. **Wire `NodeAwaitingApproval`** before any blocking gate wait
+   (ADR-0076 Follow-up 1 — the real pre-invoke gate).
+3. **Wire `NodeEscalated`** in `_on_bus_escalation` (the #1253 observer
+   handler) when an `EscalationRequest` is routed.
+4. Add a `cancelled` lane for `EventStatus.CANCELLED / ABORTED` if #1251
+   scope is expanded.
+5. `lane_for` does not group by `op_id`; a higher-level helper that
+   segments a mixed-node stream by id and projects each may be needed for
+   whole-run dashboards.
+
+## Alternatives Considered
+
+| Alternative | Why rejected |
+|-------------|--------------|
+| Add state fields to existing signals | Breaks existing observers keyed on `NodeStarted` etc.; conflates transport with state machine. |
+| Dedicated `NodeLifecycleEvent` with an enum field | Replaces the typed-signal pattern ADR-0072 established without benefit; loses the `observe(NodeCompleted)` ergonomic. |
+| Leave projection to each subscriber | The current state that motivated this ADR; bespoke parsers drift and diverge. |
+| `verifying / verified / cancelled` from #1251 issue text | The flow instruction narrows the required states to six; the broader set is deferred (see Follow-up 4). |
+
+## References
+
+- [ADR-0072](ADR-0072-reactive-capability-bus.md) — reactive capability bus
+- [ADR-0076](ADR-0076-observer-as-hook-transport.md) — observer as hook transport
+- `lionagi/session/signal.py` — `NodeQueued`, `NodeAwaitingApproval`, `NodeEscalated`, `lane_for`
+- `tests/session/test_lifecycle_signals.py` — contract tests
+- GitHub #1251 — lifecycle signal contract issue

--- a/lionagi/engines/engine.py
+++ b/lionagi/engines/engine.py
@@ -32,7 +32,7 @@ from pydantic import BaseModel
 from lionagi.agent import AgentSpec, create_agent
 from lionagi.casts.emission import build_emission_operable
 from lionagi.session.session import Session
-from lionagi.session.signal import NodeCompleted, NodeFailed, NodeStarted
+from lionagi.session.signal import NodeCompleted, NodeFailed, NodeQueued, NodeStarted
 
 if TYPE_CHECKING:
     from lionagi.protocols.generic.pile import Pile
@@ -237,24 +237,27 @@ class EngineRun:
         max_spawn: int = 50,
         max_concurrent: int = 5,
         verbose: bool = False,
+        escalation_tier: str | None = None,
     ) -> dict[str, Any]:
         """Execute a prebuilt operation DAG on the run's session.
 
         The complement to :meth:`run_team`: where ``run_team`` sequences a
         roster, ``run_dag`` runs a dependency graph through the reactive
         executor — the second of the two execution shapes (ADR-0075 §4). As each
-        node starts/finishes it emits a ``NodeStarted`` / ``NodeCompleted`` /
-        ``NodeFailed`` onto the bus, so persistence, Studio segments, and
-        progress display subscribe via ``observe`` instead of a bespoke
-        ``on_progress`` callback. With ``reactive`` a worker may emit a
+        node starts/finishes it emits a ``NodeQueued`` / ``NodeStarted`` /
+        ``NodeCompleted`` / ``NodeFailed`` onto the bus, so persistence, Studio
+        segments, and progress display subscribe via ``observe`` instead of a
+        bespoke ``on_progress`` callback. With ``reactive`` a worker may emit a
         ``spawn_type`` payload to grow the live DAG (``node_builder`` turns it
         into a node). Returns the ``session.flow`` result dict.
         """
         emits: list[asyncio.Future] = []
 
         def _on_progress(op_id: str, name: str, status: str, elapsed: float) -> None:
-            if status == "started":
-                sig: Any = NodeStarted(op_id=op_id, name=name)
+            if status == "queued":
+                sig: Any = NodeQueued(op_id=op_id, name=name)
+            elif status == "started":
+                sig = NodeStarted(op_id=op_id, name=name)
             elif status == "completed":
                 sig = NodeCompleted(op_id=op_id, name=name, elapsed=elapsed)
             elif status == "failed":
@@ -277,6 +280,7 @@ class EngineRun:
             max_concurrent=max_concurrent,
             verbose=verbose,
             on_progress=_on_progress,
+            escalation_tier=escalation_tier,
         )
         if emits:
             await asyncio.gather(*emits, return_exceptions=True)

--- a/lionagi/operations/__init__.py
+++ b/lionagi/operations/__init__.py
@@ -2,6 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .builder import ExpansionStrategy, OperationGraphBuilder
+from .confidence_gate import (
+    ConfidenceGateEscalated,
+    ConfidenceGatePassed,
+    ConfidenceRating,
+    confidence_gated_completion,
+)
 from .flow import (
     DependencyAwareExecutor,
     FlowEvent,
@@ -24,4 +30,8 @@ __all__ = (
     "BranchOperations",
     "Operation",
     "Builder",
+    "ConfidenceGatePassed",
+    "ConfidenceGateEscalated",
+    "ConfidenceRating",
+    "confidence_gated_completion",
 )

--- a/lionagi/operations/confidence_gate.py
+++ b/lionagi/operations/confidence_gate.py
@@ -1,0 +1,214 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Confidence-gated completion operation (#1254).
+
+A reusable async operation: the agent self-rates across categories toward a
+target confidence (default 0.95).  Below target it must seek more evidence or
+emit ``EscalationRequest``; it may NOT declare done below target.  At target
+it emits ``ConfidenceGatePassed`` and allows completion.
+
+Usage::
+
+    rating, result = await confidence_gated_completion(
+        branch,
+        work_result=my_result,
+        rater=my_async_rater,   # async callable -> ConfidenceRating
+        target=0.95,
+    )
+
+Learning hook: ``ConfidenceGatePassed`` is emitted on the session bus so
+``session.observe(ConfidenceGatePassed, handler=propagate_learnings)`` can
+ride the existing observer transport (ADR-0077 Follow-up: full cross-task
+propagation deferred; the hook point is wired here).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from lionagi.session.signal import Signal
+
+if TYPE_CHECKING:
+    from lionagi.session.branch import Branch
+
+__all__ = (
+    "ConfidenceGatePassed",
+    "ConfidenceGateEscalated",
+    "ConfidenceRating",
+    "confidence_gated_completion",
+)
+
+
+# ---------------------------------------------------------------------------
+# Signal: gate passed
+# ---------------------------------------------------------------------------
+
+
+class ConfidenceGatePassed(Signal):
+    """Emitted when an agent's self-rating reaches the target confidence.
+
+    ``session.observe(ConfidenceGatePassed, handler=propagate_learnings)``
+    hooks learning propagation onto the existing observer transport.
+    """
+
+    target: float = 0.95
+    overall: float = 0.0
+    category_scores: dict = {}  # noqa: RUF012 — intentional mutable default on Signal field
+
+
+# ---------------------------------------------------------------------------
+# Value object: immutable self-assessment
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ConfidenceRating:
+    """Immutable per-category self-assessment produced by the rater callable.
+
+    Overall confidence is ``min(category_scores)`` — conservative by design
+    so a single weak dimension cannot be masked by averaging.
+    """
+
+    correctness: float  # 0.0–1.0: is the result factually/logically correct?
+    completeness: float  # 0.0–1.0: does it cover all required aspects?
+    evidence: float  # 0.0–1.0: is the result well-supported by evidence?
+    risk: float  # 0.0–1.0: how low is the risk of undetected error?
+
+    @property
+    def overall(self) -> float:
+        """Conservative aggregate: minimum across all four categories."""
+        return min(self.correctness, self.completeness, self.evidence, self.risk)
+
+    def as_dict(self) -> dict[str, float]:
+        return {
+            "correctness": self.correctness,
+            "completeness": self.completeness,
+            "evidence": self.evidence,
+            "risk": self.risk,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Exception: gate not reached
+# ---------------------------------------------------------------------------
+
+
+class ConfidenceGateEscalated(Exception):  # noqa: N818
+    """Raised when ``confidence_gated_completion`` cannot reach target confidence.
+
+    Enforces the contract that a caller may NOT declare completion when
+    confidence is below target — the normal return path is blocked and this
+    exception carries the escalation request and final rating for inspection.
+    """
+
+    def __init__(self, escalation_request: Any, rating: ConfidenceRating) -> None:
+        reason = getattr(escalation_request, "reason", str(escalation_request))
+        super().__init__(reason)
+        self.escalation_request = escalation_request
+        self.rating = rating
+
+
+# ---------------------------------------------------------------------------
+# Operation
+# ---------------------------------------------------------------------------
+
+
+async def confidence_gated_completion(
+    branch: Branch,
+    *,
+    work_result: Any,
+    rater: Callable,
+    target: float = 0.95,
+    max_attempts: int = 3,
+    evidence_seeker: Callable | None = None,
+) -> tuple[ConfidenceRating, Any]:
+    """Self-rate work toward a target confidence; block completion when below.
+
+    Args:
+        branch: The branch whose observer transport is used to emit signals.
+        work_result: The artifact or answer to assess.
+        rater: Async callable ``(work_result) -> ConfidenceRating``.  In
+            production, calls ``branch.operate(response_format=ConfidenceRating)``.
+            Must be mockable for unit tests.
+        target: Minimum ``ConfidenceRating.overall`` to allow completion
+            (default 0.95).
+        max_attempts: Maximum self-assessment + evidence-seeking iterations
+            before giving up (default 3).
+        evidence_seeker: Optional async callable
+            ``(work_result, rating) -> new_work_result`` that attempts to
+            close the confidence gap (e.g. fetch additional sources, rerun
+            a sub-check).  When ``None``, a below-target rating immediately
+            escalates.
+
+    Returns:
+        ``(final_rating, work_result)`` — only reachable when
+        ``final_rating.overall >= target``.
+
+    Raises:
+        ConfidenceGateEscalated: When the target cannot be reached within
+            ``max_attempts`` and no evidence path is available.  The exception
+            also emits an ``EscalationRequest`` onto the session bus via the
+            branch observer so ``_on_bus_escalation`` can route it.
+    """
+    from lionagi.casts.emission import EscalationRequest  # noqa: PLC0415
+
+    attempts: list[ConfidenceRating] = []
+
+    for attempt_n in range(max_attempts):
+        import inspect  # noqa: PLC0415
+
+        rating_result = rater(work_result)
+        if inspect.isawaitable(rating_result):
+            rating_result = await rating_result
+        rating: ConfidenceRating = rating_result
+        attempts.append(rating)
+
+        if rating.overall >= target:
+            # Gate passed: emit the learning hook signal and allow completion.
+            gate_signal = ConfidenceGatePassed(
+                target=target,
+                overall=rating.overall,
+                category_scores=rating.as_dict(),
+            )
+            _observer = getattr(branch, "_observer", None)
+            if _observer is not None:
+                await branch.emit(gate_signal)
+            return rating, work_result
+
+        # Below target: seek more evidence if a seeker is provided and
+        # attempts remain, else escalate.
+        can_seek = evidence_seeker is not None and attempt_n < max_attempts - 1
+        if can_seek:
+            seek_result = evidence_seeker(work_result, rating)
+            if inspect.isawaitable(seek_result):
+                seek_result = await seek_result
+            work_result = seek_result
+            continue
+
+        # No evidence path or last attempt — escalate.
+        break
+
+    # Build and emit the escalation request; this fires _on_bus_escalation
+    # in any running ReactiveExecutor that registered the handler.
+    req = EscalationRequest(
+        reason=(
+            f"Confidence {attempts[-1].overall:.3f} below target {target} "
+            f"after {len(attempts)} attempt(s)"
+        ),
+        context={
+            "trigger": "low_confidence",
+            "confidence": attempts[-1].overall,
+            "category_scores": attempts[-1].as_dict(),
+            "attempts": [r.as_dict() for r in attempts],
+        },
+    )
+    _observer = getattr(branch, "_observer", None)
+    if _observer is not None:
+        from lionagi.session.signal import StructuredOutput  # noqa: PLC0415
+
+        await branch.emit(StructuredOutput(data=req))
+
+    raise ConfidenceGateEscalated(req, attempts[-1])

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -133,6 +133,10 @@ class DependencyAwareExecutor:
         limiter = CapacityLimiter(capacity)
 
         nodes = [n for n in self.graph.internal_nodes.values() if isinstance(n, Operation)]
+        if self.on_progress:
+            for node in nodes:
+                _name = node.metadata.get("reference_id", str(node.id)[:8])
+                self.on_progress(str(node.id), _name, "queued", 0.0)
         await self._alcall(nodes, self._execute_operation, limiter=limiter)
 
         # Return results - only include actually completed operations
@@ -658,7 +662,10 @@ class ReactiveExecutor(DependencyAwareExecutor):
         self._result_sink: Any = None
         # Model name (e.g. "claude-opus-4-8") to use for escalated re-dispatch.
         # None means no higher tier is configured and escalations surface as give_up.
-        self._escalation_tier: str | None = escalation_tier
+        # Fall back to the env var so callers without a public API knob can still configure.
+        import os  # noqa: PLC0415
+
+        self._escalation_tier: str | None = escalation_tier or os.getenv("LIONAGI_ESCALATION_TIER")
 
     async def execute(self) -> dict[str, Any]:
         """Execute the graph, growing it as nodes emit SpawnRequests."""
@@ -682,6 +689,9 @@ class ReactiveExecutor(DependencyAwareExecutor):
             async with create_task_group() as tg:
                 self._tg = tg
                 for node in initial:
+                    if self.on_progress:
+                        _name = node.metadata.get("reference_id", str(node.id)[:8])
+                        self.on_progress(str(node.id), _name, "queued", 0.0)
                     tg.start_soon(self._run_tracked, node)
         finally:
             self._running = False
@@ -726,9 +736,13 @@ class ReactiveExecutor(DependencyAwareExecutor):
         self._result_sink = send
 
         initial = [n for n in self.graph.internal_nodes.values() if isinstance(n, Operation)]
-        observer = getattr(self.session, "observer", None)
+        # Use same private attribute as batch execute() — avoids asymmetry.
+        observer = getattr(self.session, "_observer", None)
         if observer is not None:
+            from lionagi.casts.emission import EscalationRequest  # noqa: PLC0415
+
             self.session.observe(self.spawn_type, self._on_bus_spawn)
+            self.session.observe(EscalationRequest, self._on_bus_escalation)
         self._running = True
 
         async def _driver():
@@ -740,6 +754,9 @@ class ReactiveExecutor(DependencyAwareExecutor):
                 async with create_task_group() as tg:
                     self._tg = tg
                     for node in initial:
+                        if self.on_progress:
+                            _name = node.metadata.get("reference_id", str(node.id)[:8])
+                            self.on_progress(str(node.id), _name, "queued", 0.0)
                         tg.start_soon(self._run_tracked, node)
             finally:
                 await send.aclose()
@@ -759,7 +776,10 @@ class ReactiveExecutor(DependencyAwareExecutor):
             self._tg = None
             self._result_sink = None
             if observer is not None:
+                from lionagi.casts.emission import EscalationRequest  # noqa: PLC0415
+
                 observer.unobserve(self._on_bus_spawn)
+                observer.unobserve(self._on_bus_escalation)
             if not driver.done():  # early break / consumer close: tear down
                 driver.cancel()
                 with contextlib.suppress(asyncio.CancelledError, Exception):
@@ -834,7 +854,11 @@ class ReactiveExecutor(DependencyAwareExecutor):
         else:
             route = "give_up"
 
-        await self.session.emit(NodeEscalated(op_id=op_id, name=name, reason=reason, route=route))
+        await self.session.emit(
+            NodeEscalated(
+                op_id=op_id, name=name, reason=reason, route=route, escalation_request=req
+            )
+        )
 
     def _schedule_escalation(self, req: Any, emitter: Operation | None) -> bool:
         """Build and schedule an escalated re-run of the emitter's operation.
@@ -958,6 +982,9 @@ class ReactiveExecutor(DependencyAwareExecutor):
 
         if newly_added:
             self._assign_injected_branch(child, emitter_id, independent)
+            if self.on_progress:
+                _name = child.metadata.get("reference_id", str(child.id)[:8])
+                self.on_progress(str(child.id), _name, "queued", 0.0)
         return True
 
     def _assign_injected_branch(self, child: Operation, emitter_id: Any, independent: bool) -> None:
@@ -1030,6 +1057,7 @@ async def flow(
     spawn_type: type | None = None,
     node_builder: Any = None,
     max_spawn: int = 50,
+    escalation_tier: str | None = None,
 ) -> dict[str, Any]:
     """Execute a graph using structured concurrency primitives.
 
@@ -1054,6 +1082,10 @@ async def flow(
             turns a spawn payload into a graph node. Defaults to a role-agnostic
             ``operate`` node. Only used when ``reactive``.
         max_spawn: Hard cap on dynamic injections. Only used when ``reactive``.
+        escalation_tier: Model name (e.g. ``"claude-opus-4-8"``) to use when
+            re-dispatching an escalated op. When ``None`` (the default) an
+            emitted :class:`~lionagi.casts.emission.EscalationRequest` surfaces
+            as a graceful ``give_up`` signal. Only used when ``reactive``.
 
     Returns:
         Execution results with completed operations and final context. When
@@ -1076,6 +1108,7 @@ async def flow(
             spawn_type=spawn_type,
             node_builder=node_builder,
             max_spawn=max_spawn,
+            escalation_tier=escalation_tier,
         )
     else:
         executor = DependencyAwareExecutor(
@@ -1105,6 +1138,7 @@ async def flow_stream(
     spawn_type: type | None = None,
     node_builder: Any = None,
     max_spawn: int = 50,
+    escalation_tier: str | None = None,
 ):
     """Stream a graph: yield a :class:`FlowEvent` as each operation completes.
 
@@ -1127,6 +1161,7 @@ async def flow_stream(
         spawn_type=spawn_type,
         node_builder=node_builder,
         max_spawn=max_spawn,
+        escalation_tier=escalation_tier,
     )
     async for event in executor.execute_stream():
         yield event

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -633,6 +633,7 @@ class ReactiveExecutor(DependencyAwareExecutor):
         spawn_type: type | None = None,
         node_builder: Any = None,
         max_spawn: int = 50,
+        escalation_tier: str | None = None,
         **kwargs: Any,
     ):
         super().__init__(*args, **kwargs)
@@ -655,6 +656,9 @@ class ReactiveExecutor(DependencyAwareExecutor):
         # When streaming, completed nodes are pushed here for the generator to
         # yield. None in batch mode.
         self._result_sink: Any = None
+        # Model name (e.g. "claude-opus-4-8") to use for escalated re-dispatch.
+        # None means no higher tier is configured and escalations surface as give_up.
+        self._escalation_tier: str | None = escalation_tier
 
     async def execute(self) -> dict[str, Any]:
         """Execute the graph, growing it as nodes emit SpawnRequests."""
@@ -670,7 +674,10 @@ class ReactiveExecutor(DependencyAwareExecutor):
         self._running = True
         observer = getattr(self.session, "_observer", None)
         if observer is not None:
+            from lionagi.casts.emission import EscalationRequest  # noqa: PLC0415
+
             self.session.observe(self.spawn_type, self._on_bus_spawn)
+            self.session.observe(EscalationRequest, self._on_bus_escalation)
         try:
             async with create_task_group() as tg:
                 self._tg = tg
@@ -680,7 +687,10 @@ class ReactiveExecutor(DependencyAwareExecutor):
             self._running = False
             self._tg = None
             if observer is not None:
+                from lionagi.casts.emission import EscalationRequest  # noqa: PLC0415
+
                 observer.unobserve(self._on_bus_spawn)
+                observer.unobserve(self._on_bus_escalation)
 
         completed_ops = [
             op_id for op_id in self.results.keys() if op_id not in self.skipped_operations
@@ -797,6 +807,73 @@ class ReactiveExecutor(DependencyAwareExecutor):
             return
         self._inject_request(req, emitter=_CURRENT_OP.get())
 
+    async def _on_bus_escalation(self, req: Any, _ctx: Any) -> None:
+        """Bus handler: a running agent emitted an EscalationRequest.
+
+        Routes to either a higher-tier re-dispatch (when ``escalation_tier``
+        is configured and ``human_required`` is not set) or a graceful give-up
+        signal.  Emits :class:`~lionagi.session.signal.NodeEscalated` in both
+        cases so the lifecycle projection stays accurate (ADR-0077).
+        """
+        if not self._running:
+            return
+        from lionagi.casts.emission import EscalationRequest as _EscReq  # noqa: PLC0415
+        from lionagi.session.signal import NodeEscalated  # noqa: PLC0415
+
+        emitter = _CURRENT_OP.get()
+        op_id = str(emitter.id) if emitter is not None else ""
+        name = (
+            emitter.metadata.get("reference_id", str(emitter.id)[:8]) if emitter is not None else ""
+        )
+        reason = req.reason if isinstance(req, _EscReq) else str(req)
+        human_required = isinstance(req, _EscReq) and req.context.get("human_required", False)
+
+        if self._escalation_tier is not None and not human_required:
+            scheduled = self._schedule_escalation(req, emitter)
+            route = "higher_tier" if scheduled else "give_up"
+        else:
+            route = "give_up"
+
+        await self.session.emit(NodeEscalated(op_id=op_id, name=name, reason=reason, route=route))
+
+    def _schedule_escalation(self, req: Any, emitter: Operation | None) -> bool:
+        """Build and schedule an escalated re-run of the emitter's operation.
+
+        Returns True if the child was accepted and scheduled, False otherwise.
+        On success the child node's branch is updated with the escalation model
+        tier (best-effort, fails silently when provider config is unavailable).
+        """
+        if emitter is not None:
+            op_type = getattr(emitter, "operation", "operate")
+            params = dict(emitter.parameters) if isinstance(emitter.parameters, dict) else {}
+        else:
+            op_type = "operate"
+            reason = getattr(req, "reason", str(req))
+            params = {"instruction": f"[escalated] {reason}"}
+
+        try:
+            child = create_operation(op_type, parameters=params)
+            if self._escalation_tier:
+                child.metadata["escalation_tier"] = self._escalation_tier
+        except Exception as e:
+            logger.warning("escalation op build failed: %s", e)
+            return False
+
+        emitter_id = emitter.id if emitter is not None else None
+        # Run as independent when the emitter is absent from the graph (already
+        # completed and pruned) — adding a dependency edge to a missing head
+        # would raise RelationError in _accept_node.
+        independent = emitter is None or emitter_id not in self.graph.internal_nodes
+        if not self._accept_node(child, emitter_id=emitter_id, independent=independent):
+            return False
+
+        if child.id in self.operation_branches and self._escalation_tier:
+            _set_branch_escalation_tier(self.operation_branches[child.id], self._escalation_tier)
+
+        if self._tg is not None:
+            self._tg.start_soon(self._run_tracked, child)
+        return True
+
     def _inject_request(self, req: Any, *, emitter: Operation | None) -> bool:
         """Build + schedule a node for one SpawnRequest (deduped, role-aware)."""
         if id(req) in self._seen_reqs:
@@ -906,6 +983,23 @@ class ReactiveExecutor(DependencyAwareExecutor):
         self.session.include_branches(clone)
         self.operation_branches[child.id] = clone
         child.branch_id = clone.id
+
+
+def _set_branch_escalation_tier(branch: Any, tier: str) -> None:
+    """Best-effort: override a branch's chat model with the escalation tier.
+
+    Falls back to recording the tier in branch metadata when the iModel
+    constructor fails (e.g. no provider config in test contexts), so the
+    intent is still inspectable without raising.
+    """
+    try:
+        from lionagi.service.imodel import iModel  # noqa: PLC0415
+
+        branch.chat_model = iModel(model=tier)
+    except Exception:
+        meta = getattr(branch, "metadata", None)
+        if isinstance(meta, dict):
+            meta["escalation_tier"] = tier
 
 
 def _default_node_builder(req: Any, emitter: Operation | None) -> Operation:

--- a/lionagi/session/__init__.py
+++ b/lionagi/session/__init__.py
@@ -9,8 +9,13 @@ from .exchange import Exchange
 from .observer import SessionObserver
 from .session import Session
 from .signal import (
+    NodeAwaitingApproval,
+    NodeEscalated,
+    NodeLifecycleState,
+    NodeQueued,
     Signal,
     StructuredOutput,
+    lane_for,
 )
 
 __all__ = [
@@ -18,9 +23,14 @@ __all__ = [
     "CapabilityViolation",
     "Exchange",
     "Message",
+    "NodeAwaitingApproval",
+    "NodeEscalated",
+    "NodeLifecycleState",
+    "NodeQueued",
     "Session",
     "SessionObserver",
     "Signal",
     "StructuredOutput",
+    "lane_for",
     "render_capabilities_prompt",
 ]

--- a/lionagi/session/branch.py
+++ b/lionagi/session/branch.py
@@ -368,6 +368,19 @@ class Branch(Element, Relational):
             return getattr(self, operation)
         return self._operation_manager.registry.get(operation)
 
+    async def confidence_gated_completion(self, **kwargs):
+        """Run ``confidence_gated_completion`` bound to this branch.
+
+        Delegates to :func:`lionagi.operations.confidence_gate.confidence_gated_completion`
+        so callers can use ``create_operation("confidence_gated_completion", ...)``
+        and have it resolved via :meth:`get_operation` without manual registration.
+        """
+        from lionagi.operations.confidence_gate import (  # noqa: PLC0415
+            confidence_gated_completion,
+        )
+
+        return await confidence_gated_completion(self, **kwargs)
+
     async def emit(self, event: Any) -> list[Any]:
         """Emit an event to the owning session's observer, if attached.
 

--- a/lionagi/session/session.py
+++ b/lionagi/session/session.py
@@ -407,6 +407,7 @@ class Session(Node, Relational):
         spawn_type: type | None = None,
         node_builder: Any = None,
         max_spawn: int = 50,
+        escalation_tier: str | None = None,
     ) -> dict[str, Any]:
         """
         Execute a graph-based workflow using multi-branch orchestration.
@@ -428,6 +429,9 @@ class Session(Node, Relational):
             node_builder: ``(spawn_request, emitter_op) -> Operation | None`` that
                 turns a spawn payload into a graph node. Only used when ``reactive``.
             max_spawn: Hard cap on dynamic injections. Only used when ``reactive``.
+            escalation_tier: Model name to use for escalated op re-dispatch. When
+                ``None`` an emitted EscalationRequest surfaces as a give_up signal.
+                Only used when ``reactive``.
         """
         from lionagi.operations.flow import flow
 
@@ -449,6 +453,7 @@ class Session(Node, Relational):
             spawn_type=spawn_type,
             node_builder=node_builder,
             max_spawn=max_spawn,
+            escalation_tier=escalation_tier,
         )
 
     async def flow_stream(
@@ -463,6 +468,7 @@ class Session(Node, Relational):
         spawn_type: type | None = None,
         node_builder: Any = None,
         max_spawn: int = 50,
+        escalation_tier: str | None = None,
     ):
         """Stream graph execution — yield a ``FlowEvent`` as each op completes.
 
@@ -488,6 +494,7 @@ class Session(Node, Relational):
             spawn_type=spawn_type,
             node_builder=node_builder,
             max_spawn=max_spawn,
+            escalation_tier=escalation_tier,
         ):
             yield event
 

--- a/lionagi/session/signal.py
+++ b/lionagi/session/signal.py
@@ -180,13 +180,18 @@ class NodeEscalated(Signal):
 
     ``route`` is ``"higher_tier"`` when a re-dispatch is scheduled or
     ``"give_up"`` when no escalation path is configured / ``human_required``.
-    ``data`` carries the original ``EscalationRequest`` payload when available.
+    ``escalation_request`` carries the original ``EscalationRequest`` payload when
+    available.  It is stored in a named field rather than ``Signal.data`` to
+    prevent the observer's payload-matching from re-firing the escalation handler
+    when this signal is emitted (``Signal.data`` is payload-matched; a named
+    field is not).
     """
 
     op_id: str = ""
     name: str = ""
     reason: str = ""
     route: str = ""  # "higher_tier" | "give_up"
+    escalation_request: Any = None  # original EscalationRequest for audit trail
 
 
 # -- Lifecycle projection (ADR-0077) ------------------------------------------

--- a/lionagi/session/signal.py
+++ b/lionagi/session/signal.py
@@ -13,15 +13,23 @@ envelope lives in a Pile/Flow like any other element.
 It is the realization of "capabilities = structured output event" — an agent
 exercises a capability by emitting a typed value; an observer reacting to
 that type is the capability being honored.
+
+``NodeLifecycleState`` and ``lane_for`` provide the canonical per-node
+lifecycle projection (ADR-0077). Callers pre-filter signals to one node id
+and call ``lane_for`` to derive the current lane without bespoke parsing.
 """
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel
 
 from ..protocols.generic.element import Element
+
+if TYPE_CHECKING:
+    pass
 
 __all__ = (
     "Signal",
@@ -32,8 +40,13 @@ __all__ = (
     "NodeStarted",
     "NodeCompleted",
     "NodeFailed",
+    "NodeQueued",
+    "NodeAwaitingApproval",
+    "NodeEscalated",
     "GateDenied",
     "MessageAdded",
+    "NodeLifecycleState",
+    "lane_for",
 )
 
 
@@ -136,3 +149,101 @@ class GateDenied(Signal):
 
 class MessageAdded(Signal):
     """A message was added to a branch. ``data`` is the ``RoledMessage``."""
+
+
+# -- Extended node lifecycle (ADR-0077) ---------------------------------------
+# Three signals that complete the canonical per-node lifecycle:
+#   queued → running → awaiting_approval → succeeded | failed | escalated
+#
+# ``NodeStarted / NodeCompleted / NodeFailed`` (above) cover running/succeeded/
+# failed already; these three cover the remaining states.
+
+
+class NodeQueued(Signal):
+    """A DAG operation node entered the runnable graph, queued for execution."""
+
+    op_id: str = ""
+    name: str = ""
+    elapsed: float = 0.0
+
+
+class NodeAwaitingApproval(Signal):
+    """A DAG operation node is paused waiting for an external approval decision."""
+
+    op_id: str = ""
+    name: str = ""
+    reason: str | None = None
+
+
+class NodeEscalated(Signal):
+    """A DAG operation node escalated — out of depth or no higher tier available.
+
+    ``route`` is ``"higher_tier"`` when a re-dispatch is scheduled or
+    ``"give_up"`` when no escalation path is configured / ``human_required``.
+    ``data`` carries the original ``EscalationRequest`` payload when available.
+    """
+
+    op_id: str = ""
+    name: str = ""
+    reason: str = ""
+    route: str = ""  # "higher_tier" | "give_up"
+
+
+# -- Lifecycle projection (ADR-0077) ------------------------------------------
+
+#: The six canonical per-node lifecycle states.
+NodeLifecycleState = Literal[
+    "queued", "running", "awaiting_approval", "succeeded", "failed", "escalated"
+]
+
+_TERMINAL: frozenset[str] = frozenset({"succeeded", "failed", "escalated"})
+
+
+def _signal_to_state(sig: Any) -> NodeLifecycleState | None:
+    """Return the lifecycle state implied by *sig*, or ``None`` if not state-bearing."""
+    if isinstance(sig, NodeQueued):
+        return "queued"
+    if isinstance(sig, NodeStarted | RunStart):
+        return "running"
+    if isinstance(sig, NodeAwaitingApproval):
+        return "awaiting_approval"
+    if isinstance(sig, NodeCompleted | RunEnd):
+        return "succeeded"
+    if isinstance(sig, NodeFailed | RunFailed):
+        return "failed"
+    if isinstance(sig, NodeEscalated):
+        return "escalated"
+    # StructuredOutput carrying an EscalationRequest also projects to escalated.
+    if isinstance(sig, StructuredOutput):
+        # Lazy import avoids a circular dependency with casts.emission.
+        from lionagi.casts.emission import EscalationRequest  # noqa: PLC0415
+
+        if isinstance(sig.data, EscalationRequest):
+            return "escalated"
+    return None
+
+
+def lane_for(signals: Iterable[Signal | Any]) -> NodeLifecycleState:
+    """Project an ordered, single-node signal stream into its current lifecycle lane.
+
+    Callers must pre-filter *signals* to one operation/node id.  The default
+    state (empty stream) is ``"queued"``.  Terminal states (``succeeded``,
+    ``failed``, ``escalated``) are sticky: later non-retry signals cannot
+    override them.  A subsequent ``NodeQueued`` or ``NodeStarted`` signal
+    represents a new attempt and resets the state.
+
+    ``RunStart`` / ``RunEnd`` are run-scoped fallbacks — valid only for
+    single-run cards where no node-specific signal is present.
+    """
+    state: NodeLifecycleState = "queued"
+    in_terminal: bool = False
+    for sig in signals:
+        new = _signal_to_state(sig)
+        if new is None:
+            continue
+        # Terminal is sticky unless a new attempt explicitly resets to queued/running.
+        if in_terminal and new not in ("queued", "running"):
+            continue
+        state = new
+        in_terminal = state in _TERMINAL
+    return state

--- a/tests/engines/test_engine.py
+++ b/tests/engines/test_engine.py
@@ -198,3 +198,91 @@ async def test_run_dag_emits_node_lifecycle_signals():
     assert len(result["completed_operations"]) == 1
     assert started == ["root"]  # NodeStarted reached the observer with the branch name
     assert len(completed) == 1  # NodeCompleted carried the op id
+
+
+@pytest.mark.asyncio
+async def test_run_dag_emits_node_queued_before_started():
+    """run_dag emits NodeQueued before NodeStarted for each op (MAJ-3 live emission)."""
+    from lionagi.operations.builder import OperationGraphBuilder
+    from lionagi.session.branch import Branch
+    from lionagi.session.session import Session
+    from lionagi.session.signal import NodeQueued, NodeStarted
+
+    async def work(**kw):
+        return "ok"
+
+    session = Session()
+    branch = Branch(name="root")
+    session.include_branches(branch)
+    session.default_branch = branch
+    session.register_operation("work", work)
+
+    signal_log: list[str] = []  # record "queued:<op_id>" and "started:<op_id>"
+    session.observe(NodeQueued, handler=lambda s, _: signal_log.append(f"queued:{s.op_id}"))
+    session.observe(NodeStarted, handler=lambda s, _: signal_log.append(f"started:{s.op_id}"))
+
+    builder = OperationGraphBuilder()
+    builder.add_operation("work")
+    graph = builder.get_graph()
+
+    run = Engine().new_run(session=session)
+    result = await run.run_dag(graph)
+
+    assert len(result["completed_operations"]) == 1
+    # Must have at least one queued and one started for the same op.
+    queued_ops = [e.split(":")[1] for e in signal_log if e.startswith("queued:")]
+    started_ops = [e.split(":")[1] for e in signal_log if e.startswith("started:")]
+    assert len(queued_ops) >= 1
+    assert len(started_ops) >= 1
+    assert queued_ops[0] == started_ops[0], "NodeQueued and NodeStarted must share same op_id"
+    # queued must arrive before started in the log.
+    qi = next(i for i, e in enumerate(signal_log) if e.startswith("queued:"))
+    si = next(i for i, e in enumerate(signal_log) if e.startswith("started:"))
+    assert qi < si, "NodeQueued must precede NodeStarted in the signal log"
+
+
+@pytest.mark.asyncio
+async def test_run_dag_queued_for_reactive_injected_child():
+    """Reactively injected child nodes also receive NodeQueued before NodeStarted."""
+    from lionagi.casts.emission import SpawnRequest
+    from lionagi.operations.builder import OperationGraphBuilder
+    from lionagi.operations.node import create_operation
+    from lionagi.session.branch import Branch
+    from lionagi.session.session import Session
+    from lionagi.session.signal import NodeQueued, NodeStarted
+
+    async def spawner(**kw):
+        return SpawnRequest(instruction="follow-up", independent=True)
+
+    async def follow_up(**kw):
+        return "child done"
+
+    session = Session()
+    branch = Branch(name="root")
+    session.include_branches(branch)
+    session.default_branch = branch
+    session.register_operation("spawner", spawner)
+    session.register_operation("follow_up", follow_up)
+
+    queued_ids: list[str] = []
+    started_ids: list[str] = []
+    session.observe(NodeQueued, handler=lambda s, _: queued_ids.append(s.op_id))
+    session.observe(NodeStarted, handler=lambda s, _: started_ids.append(s.op_id))
+
+    def node_builder(req, emitter):
+        return create_operation("follow_up", parameters={})
+
+    builder = OperationGraphBuilder()
+    builder.add_operation("spawner")
+    graph = builder.get_graph()
+
+    run = Engine().new_run(session=session)
+    result = await run.run_dag(graph, reactive=True, node_builder=node_builder, max_spawn=1)
+
+    assert result["spawned_operations"] == 1
+    assert len(result["completed_operations"]) == 2
+    # Both parent and child must have queued signals.
+    assert len(queued_ids) == 2
+    # Every started op must have been queued first.
+    for op_id in started_ids:
+        assert op_id in queued_ids, f"op {op_id} started without NodeQueued"

--- a/tests/operations/test_flow_stream.py
+++ b/tests/operations/test_flow_stream.py
@@ -132,3 +132,87 @@ async def test_dependent_op_streams_after_predecessor():
 
     results = [ev.result async for ev in session.flow_stream(g)]
     assert results == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# MAJ-2 — streaming escalation parity with batch execute()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_streaming_escalation_higher_tier(monkeypatch):
+    """execute_stream registers EscalationRequest and routes to higher_tier.
+
+    ``_schedule_escalation`` is mocked to return True (no LLM) — the test
+    verifies the streaming path wires the bus handler at parity with batch.
+    """
+    from lionagi.casts.emission import EscalationRequest
+    from lionagi.operations.flow import ReactiveExecutor
+    from lionagi.session.signal import NodeEscalated
+
+    schedule_calls: list[str] = []
+
+    def mock_schedule(self, req, emitter):
+        schedule_calls.append(self._escalation_tier or "")
+        return True
+
+    monkeypatch.setattr(ReactiveExecutor, "_schedule_escalation", mock_schedule)
+
+    session = _session()
+    # Confirm the session has an observer so the bus handler wiring takes effect.
+    assert session._observer is not None, "Session must have an observer for bus routing"
+
+    captured: list[NodeEscalated] = []
+    session.observe(NodeEscalated, handler=lambda sig, _: captured.append(sig))
+
+    async def escalator(**kw):
+        await session.emit(EscalationRequest(reason="streaming out of depth"))
+        return "done"
+
+    session.register_operation("escalator", escalator)
+
+    g = Graph()
+    g.add_node(create_operation("escalator", parameters={}))
+
+    events = []
+    async for ev in session.flow_stream(g, escalation_tier="test-tier"):
+        events.append(ev)
+
+    # MAJ-2: streaming path registered _on_bus_escalation — _schedule_escalation was called.
+    assert len(schedule_calls) >= 1
+    assert schedule_calls[0] == "test-tier"
+    # MAJ-2 + handler: NodeEscalated emitted with higher_tier route.
+    assert len(captured) >= 1
+    assert captured[0].route == "higher_tier"
+    # MAJ-4: escalation_request field preserved in streaming path too.
+    assert isinstance(captured[0].escalation_request, EscalationRequest)
+
+
+@pytest.mark.asyncio
+async def test_streaming_escalation_no_tier_gives_up():
+    """Streaming without escalation_tier → NodeEscalated(route='give_up')."""
+    from lionagi.casts.emission import EscalationRequest
+    from lionagi.session.signal import NodeEscalated
+
+    session = _session()
+
+    captured: list[NodeEscalated] = []
+    session.observe(NodeEscalated, handler=lambda sig, _: captured.append(sig))
+
+    async def escalator(**kw):
+        await session.emit(EscalationRequest(reason="no tier configured"))
+        return "done"
+
+    session.register_operation("escalator", escalator)
+
+    g = Graph()
+    g.add_node(create_operation("escalator", parameters={}))
+
+    events = []
+    async for ev in session.flow_stream(g):  # no escalation_tier
+        events.append(ev)
+
+    assert len(captured) >= 1
+    assert captured[0].route == "give_up"
+    # No spawned events — give_up does not inject a child.
+    assert not any(ev.spawned for ev in events)

--- a/tests/session/test_escalation_confidence.py
+++ b/tests/session/test_escalation_confidence.py
@@ -379,3 +379,252 @@ async def test_confidence_sync_rater_works():
         branch, work_result="data", rater=_sync_rater, target=0.95
     )
     assert rating.overall >= 0.95
+
+
+# ---------------------------------------------------------------------------
+# MAJ-1 / MAJ-4 — PUBLIC entrypoint integration: session.flow + escalation_tier
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_public_flow_higher_tier_routes_escalation(monkeypatch):
+    """session.flow(reactive=True, escalation_tier=...) routes EscalationRequest to higher_tier.
+
+    Verifies the public API path is wired end-to-end.  ``_schedule_escalation``
+    is mocked to return True (no LLM call) so the test stays synchronous and
+    deterministic while still proving the parameter forwarding and signal routing.
+    """
+    from lionagi.operations.builder import OperationGraphBuilder
+    from lionagi.operations.flow import ReactiveExecutor
+    from lionagi.session.branch import Branch
+
+    schedule_calls: list[tuple] = []
+
+    def mock_schedule(self, req, emitter):
+        schedule_calls.append((req, self._escalation_tier))
+        return True  # pretend child accepted — no real LLM call
+
+    monkeypatch.setattr(ReactiveExecutor, "_schedule_escalation", mock_schedule)
+
+    session = Session()
+    branch = Branch(name="root")
+    session.include_branches(branch)
+    session.default_branch = branch
+
+    async def escalator(**kw):
+        # Emit EscalationRequest onto the session bus; the reactive executor's
+        # registered handler picks it up without needing a running LLM.
+        await session.emit(EscalationRequest(reason="out of depth"))
+        return "done"
+
+    session.register_operation("escalator", escalator)
+
+    captured: list[NodeEscalated] = []
+    session.observe(NodeEscalated, handler=lambda sig, _: captured.append(sig))
+
+    builder = OperationGraphBuilder()
+    builder.add_operation("escalator")
+    graph = builder.get_graph()
+
+    await session.flow(graph, reactive=True, escalation_tier="test-tier", max_spawn=1)
+
+    # MAJ-1: escalation_tier was forwarded — _schedule_escalation called with correct tier.
+    assert len(schedule_calls) >= 1
+    assert schedule_calls[0][1] == "test-tier"
+    # MAJ-1 + handler: route is higher_tier when _schedule_escalation returns True.
+    assert len(captured) >= 1
+    assert captured[0].route == "higher_tier"
+    # MAJ-4: escalation_request carries the original EscalationRequest for audit.
+    assert isinstance(captured[0].escalation_request, EscalationRequest)
+    assert captured[0].escalation_request.reason == "out of depth"
+
+
+@pytest.mark.asyncio
+async def test_public_flow_no_tier_gives_up():
+    """session.flow without escalation_tier → give_up even when EscalationRequest emitted."""
+    from lionagi.operations.builder import OperationGraphBuilder
+    from lionagi.session.branch import Branch
+
+    session = Session()
+    branch = Branch(name="root")
+    session.include_branches(branch)
+    session.default_branch = branch
+
+    async def escalator(**kw):
+        await session.emit(EscalationRequest(reason="low confidence"))
+        return "done"
+
+    session.register_operation("escalator", escalator)
+
+    captured: list[NodeEscalated] = []
+    session.observe(NodeEscalated, handler=lambda sig, _: captured.append(sig))
+
+    builder = OperationGraphBuilder()
+    builder.add_operation("escalator")
+    graph = builder.get_graph()
+
+    # No escalation_tier → give_up path, no child injected.
+    result = await session.flow(graph, reactive=True)
+
+    assert len(captured) >= 1
+    assert captured[0].route == "give_up"
+    assert result["spawned_operations"] == 0
+
+
+@pytest.mark.asyncio
+async def test_public_flow_env_var_escalation_tier(monkeypatch):
+    """ReactiveExecutor picks up LIONAGI_ESCALATION_TIER from environment."""
+    import os
+
+    from lionagi.operations.builder import OperationGraphBuilder
+    from lionagi.operations.flow import ReactiveExecutor
+    from lionagi.session.branch import Branch
+
+    schedule_calls: list[str] = []
+
+    def mock_schedule(self, req, emitter):
+        schedule_calls.append(self._escalation_tier or "")
+        return True
+
+    monkeypatch.setattr(ReactiveExecutor, "_schedule_escalation", mock_schedule)
+
+    session = Session()
+    branch = Branch(name="root")
+    session.include_branches(branch)
+    session.default_branch = branch
+
+    async def escalator(**kw):
+        await session.emit(EscalationRequest(reason="env tier test"))
+        return "done"
+
+    session.register_operation("escalator", escalator)
+
+    captured: list[NodeEscalated] = []
+    session.observe(NodeEscalated, handler=lambda sig, _: captured.append(sig))
+
+    builder = OperationGraphBuilder()
+    builder.add_operation("escalator")
+    graph = builder.get_graph()
+
+    os.environ["LIONAGI_ESCALATION_TIER"] = "env-test-tier"
+    try:
+        # No explicit escalation_tier kwarg — must come from the env var.
+        await session.flow(graph, reactive=True)
+    finally:
+        del os.environ["LIONAGI_ESCALATION_TIER"]
+
+    assert len(schedule_calls) >= 1
+    assert schedule_calls[0] == "env-test-tier"
+    assert len(captured) >= 1
+    assert captured[0].route == "higher_tier"
+
+
+@pytest.mark.asyncio
+async def test_public_flow_human_required_always_give_up():
+    """human_required=True → give_up regardless of escalation_tier (public path)."""
+    from lionagi.operations.builder import OperationGraphBuilder
+    from lionagi.session.branch import Branch
+
+    session = Session()
+    branch = Branch(name="root")
+    session.include_branches(branch)
+    session.default_branch = branch
+
+    async def escalator(**kw):
+        await session.emit(EscalationRequest(reason="need human", context={"human_required": True}))
+        return "done"
+
+    session.register_operation("escalator", escalator)
+
+    captured: list[NodeEscalated] = []
+    session.observe(NodeEscalated, handler=lambda sig, _: captured.append(sig))
+
+    builder = OperationGraphBuilder()
+    builder.add_operation("escalator")
+    graph = builder.get_graph()
+
+    result = await session.flow(graph, reactive=True, escalation_tier="test-tier", max_spawn=1)
+
+    assert len(captured) >= 1
+    assert captured[0].route == "give_up"
+    assert result["spawned_operations"] == 0
+
+
+# ---------------------------------------------------------------------------
+# MIN-2 — Branch.confidence_gated_completion method resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_branch_confidence_gated_completion_method_resolves():
+    """Branch.confidence_gated_completion delegates to the standalone function."""
+    s = Session()
+    branch = s.default_branch
+
+    async def _rater(_result):
+        return ConfidenceRating(correctness=0.98, completeness=0.98, evidence=0.98, risk=0.98)
+
+    rating, result = await branch.confidence_gated_completion(
+        work_result="done", rater=_rater, target=0.95
+    )
+    assert rating.overall >= 0.95
+    assert result == "done"
+
+
+@pytest.mark.asyncio
+async def test_branch_confidence_gated_completion_via_get_operation():
+    """get_operation('confidence_gated_completion') resolves the Branch method."""
+    s = Session()
+    branch = s.default_branch
+
+    method = branch.get_operation("confidence_gated_completion")
+    assert method is not None, "get_operation must resolve confidence_gated_completion"
+    assert callable(method)
+
+
+# ---------------------------------------------------------------------------
+# MAJ-4 / MAJ-1 deeper: verify child.metadata["escalation_tier"] is actually set
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_escalated_child_has_tier_in_metadata():
+    """_schedule_escalation sets child.metadata['escalation_tier'] to the configured tier.
+
+    Uses the existing _call_handler helper (mock TG that captures start_soon calls)
+    so _schedule_escalation actually runs — unlike test_public_flow_higher_tier_routes_escalation
+    which mocks _schedule_escalation itself and cannot inspect the child's metadata.
+
+    This test fails against old code because _make_executor(escalation_tier=...) worked but
+    _schedule_escalation was never wired at all in that code path; this verifies the wiring
+    actually sets the metadata on the child before scheduling it.
+    """
+    s = Session()
+    captured: list[NodeEscalated] = []
+    s.observe(NodeEscalated, handler=lambda sig, _: captured.append(sig))
+
+    executor = _make_executor(s, escalation_tier="claude-opus-4-8")
+    emitter_op = create_operation("operate", parameters={"instruction": "original task"})
+
+    token = _CURRENT_OP.set(emitter_op)
+    try:
+        await _call_handler(executor, _make_req("need higher tier"))
+    finally:
+        _CURRENT_OP.reset(token)
+
+    # Signal emitted with higher_tier route
+    assert len(captured) == 1
+    assert captured[0].route == "higher_tier"
+
+    # start_soon was called with the child op as first positional arg
+    assert len(executor._spawn_calls) >= 1, "Expected start_soon call for child op"
+    # spawn_calls[0] = (fn, args) where fn=_run_tracked, args=(child,)
+    child = executor._spawn_calls[0][1][0]
+    assert child.metadata.get("escalation_tier") == "claude-opus-4-8", (
+        f"Child op must have escalation_tier='claude-opus-4-8' in metadata, "
+        f"got {child.metadata.get('escalation_tier')!r}"
+    )
+
+    # MAJ-4: escalation_request field carries the original request for audit
+    assert captured[0].escalation_request is not None
+    assert captured[0].escalation_request.reason == "need higher tier"

--- a/tests/session/test_escalation_confidence.py
+++ b/tests/session/test_escalation_confidence.py
@@ -1,0 +1,381 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for #1253 (EscalationRequest routing) and #1254 (confidence-gated completion).
+
+#1253 contract:
+  - EscalationRequest emitted on the bus while a ReactiveExecutor is running →
+    observer routes to higher_tier re-dispatch (when escalation_tier is set)
+    OR surfaces NodeEscalated(route="give_up") when no tier is configured /
+    human_required=True.
+
+#1254 contract:
+  - below-target self-rating → ConfidenceGateEscalated raised (NOT completion)
+  - at/above-target rating → (rating, result) returned normally
+  - evidence_seeker given a second chance before escalation
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.casts.emission import EscalationRequest
+from lionagi.operations.confidence_gate import (
+    ConfidenceGateEscalated,
+    ConfidenceGatePassed,
+    ConfidenceRating,
+    confidence_gated_completion,
+)
+from lionagi.operations.flow import _CURRENT_OP, ReactiveExecutor
+from lionagi.operations.node import create_operation
+from lionagi.protocols.graph.graph import Graph
+from lionagi.session.session import Session
+from lionagi.session.signal import NodeEscalated
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_executor(session: Session, escalation_tier: str | None = None) -> ReactiveExecutor:
+    """Minimal ReactiveExecutor with an empty graph (no ops to run)."""
+    return ReactiveExecutor(
+        session=session,
+        graph=Graph(),
+        escalation_tier=escalation_tier,
+    )
+
+
+def _make_req(reason: str = "out of depth", **ctx_kwargs) -> EscalationRequest:
+    return EscalationRequest(reason=reason, context=ctx_kwargs)
+
+
+async def _call_handler(executor: ReactiveExecutor, req: EscalationRequest) -> None:
+    """Set executor into 'running' state, install a mock task group, call handler."""
+    executor._running = True
+
+    spawn_calls: list = []
+
+    class _MockTG:
+        def start_soon(self, fn, *args):  # noqa: D401
+            spawn_calls.append((fn, args))
+
+    executor._tg = _MockTG()
+    executor._spawn_calls = spawn_calls  # expose for assertions
+    try:
+        await executor._on_bus_escalation(req, executor.session)
+    finally:
+        executor._running = False
+        executor._tg = None
+
+
+# ---------------------------------------------------------------------------
+# #1253 — give_up path (no tier configured)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_escalation_no_tier_emits_give_up():
+    """Without escalation_tier, EscalationRequest → NodeEscalated(route='give_up')."""
+    s = Session()
+    captured: list[NodeEscalated] = []
+    s.observe(NodeEscalated, handler=lambda sig, _: captured.append(sig))
+
+    executor = _make_executor(s, escalation_tier=None)
+    req = _make_req("low confidence")
+    await _call_handler(executor, req)
+
+    assert len(captured) == 1
+    assert captured[0].route == "give_up"
+    assert captured[0].reason == "low confidence"
+
+
+@pytest.mark.asyncio
+async def test_escalation_human_required_always_give_up():
+    """human_required=True in context → give_up even when escalation_tier is set."""
+    s = Session()
+    captured: list[NodeEscalated] = []
+    s.observe(NodeEscalated, handler=lambda sig, _: captured.append(sig))
+
+    executor = _make_executor(s, escalation_tier="claude-opus-4-8")
+    req = _make_req("need human", human_required=True)
+    await _call_handler(executor, req)
+
+    assert len(captured) == 1
+    assert captured[0].route == "give_up"
+
+
+@pytest.mark.asyncio
+async def test_escalation_not_running_is_no_op():
+    """Handler is a no-op when the executor is not running."""
+    s = Session()
+    captured: list = []
+    s.observe(NodeEscalated, handler=lambda sig, _: captured.append(sig))
+
+    executor = _make_executor(s, escalation_tier="claude-opus-4-8")
+    # Do NOT set _running=True — call the handler directly without the helper.
+    req = _make_req("test")
+    await executor._on_bus_escalation(req, s)
+
+    assert captured == []
+
+
+# ---------------------------------------------------------------------------
+# #1253 — higher_tier path (tier configured, emitter present)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_escalation_with_tier_emits_higher_tier():
+    """With escalation_tier set, EscalationRequest → NodeEscalated(route='higher_tier')
+    and a new op is scheduled on the task group."""
+    s = Session()
+    captured: list[NodeEscalated] = []
+    s.observe(NodeEscalated, handler=lambda sig, _: captured.append(sig))
+
+    executor = _make_executor(s, escalation_tier="claude-opus-4-8")
+
+    # Set a fake current-op so the emitter is not None.
+    emitter_op = create_operation("operate", parameters={"instruction": "original task"})
+    token = _CURRENT_OP.set(emitter_op)
+    try:
+        await _call_handler(executor, _make_req("repeated failure"))
+    finally:
+        _CURRENT_OP.reset(token)
+
+    assert len(captured) == 1
+    assert captured[0].route == "higher_tier"
+    # A new op should have been scheduled on the mock task group.
+    assert len(executor._spawn_calls) >= 1
+
+
+@pytest.mark.asyncio
+async def test_escalation_with_tier_no_emitter_uses_generic_op():
+    """escalation_tier set but no current emitter (None) → still schedules and emits higher_tier."""
+    s = Session()
+    captured: list[NodeEscalated] = []
+    s.observe(NodeEscalated, handler=lambda sig, _: captured.append(sig))
+
+    executor = _make_executor(s, escalation_tier="claude-opus-4-8")
+    # _CURRENT_OP is not set — emitter will be None.
+    await _call_handler(executor, _make_req("explicit cannot"))
+
+    assert len(captured) == 1
+    # Without an emitter, the child is still injected as an independent op.
+    assert captured[0].route == "higher_tier"
+
+
+# ---------------------------------------------------------------------------
+# #1253 — NodeEscalated is stored in the session observer flow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_escalation_signal_stored_in_observer_flow():
+    """NodeEscalated lands in the observer flow (ADR-0077 audit trail)."""
+    s = Session()
+    executor = _make_executor(s, escalation_tier=None)
+    await _call_handler(executor, _make_req("audit test"))
+
+    stored = s.observer.by_type(NodeEscalated)
+    assert len(stored) == 1
+
+
+# ---------------------------------------------------------------------------
+# #1254 — ConfidenceRating value object
+# ---------------------------------------------------------------------------
+
+
+def test_rating_overall_is_min():
+    """ConfidenceRating.overall == min(category_scores)."""
+    r = ConfidenceRating(correctness=0.9, completeness=0.7, evidence=0.8, risk=0.95)
+    assert r.overall == 0.7
+
+
+def test_rating_frozen():
+    """ConfidenceRating is immutable."""
+    r = ConfidenceRating(correctness=0.8, completeness=0.8, evidence=0.8, risk=0.8)
+    with pytest.raises((AttributeError, TypeError)):
+        r.correctness = 0.1  # type: ignore[misc]
+
+
+def test_rating_as_dict():
+    r = ConfidenceRating(correctness=0.9, completeness=0.8, evidence=0.85, risk=0.95)
+    d = r.as_dict()
+    assert set(d.keys()) == {"correctness", "completeness", "evidence", "risk"}
+    assert d["completeness"] == 0.8
+
+
+# ---------------------------------------------------------------------------
+# #1254 — below-target → ConfidenceGateEscalated (NOT completion)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_confidence_below_target_raises_not_completes():
+    """Below-target self-rating MUST raise ConfidenceGateEscalated, not return."""
+    s = Session()
+    branch = s.default_branch
+
+    low_rating = ConfidenceRating(correctness=0.5, completeness=0.5, evidence=0.5, risk=0.5)
+
+    async def _rater(_result):
+        return low_rating
+
+    with pytest.raises(ConfidenceGateEscalated) as exc_info:
+        await confidence_gated_completion(
+            branch,
+            work_result="some result",
+            rater=_rater,
+            target=0.95,
+        )
+
+    exc = exc_info.value
+    assert exc.rating.overall < 0.95
+    assert exc.escalation_request is not None
+    assert "0.500" in str(exc.escalation_request.reason)
+
+
+@pytest.mark.asyncio
+async def test_confidence_below_target_escalation_request_context():
+    """EscalationRequest context includes trigger, confidence, and category_scores."""
+    s = Session()
+    branch = s.default_branch
+
+    async def _rater(_result):
+        return ConfidenceRating(correctness=0.4, completeness=0.9, evidence=0.9, risk=0.9)
+
+    with pytest.raises(ConfidenceGateEscalated) as exc_info:
+        await confidence_gated_completion(branch, work_result="x", rater=_rater, target=0.95)
+
+    ctx = exc_info.value.escalation_request.context
+    assert ctx["trigger"] == "low_confidence"
+    assert ctx["confidence"] == pytest.approx(0.4)
+    assert "correctness" in ctx["category_scores"]
+
+
+# ---------------------------------------------------------------------------
+# #1254 — at/above target → completion allowed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_confidence_at_target_returns_result():
+    """At-target rating → (rating, work_result) returned; no exception raised."""
+    s = Session()
+    branch = s.default_branch
+
+    high_rating = ConfidenceRating(correctness=0.96, completeness=0.97, evidence=0.98, risk=0.99)
+
+    async def _rater(_result):
+        return high_rating
+
+    rating, result = await confidence_gated_completion(
+        branch,
+        work_result="final answer",
+        rater=_rater,
+        target=0.95,
+    )
+
+    assert rating.overall >= 0.95
+    assert result == "final answer"
+
+
+@pytest.mark.asyncio
+async def test_confidence_at_target_emits_gate_passed():
+    """ConfidenceGatePassed is emitted on the session bus when target is reached."""
+    s = Session()
+    branch = s.default_branch
+    # Wire the branch to the session observer so signals propagate.
+    branch._observer = s.observer
+
+    gate_passed: list[ConfidenceGatePassed] = []
+    s.observe(ConfidenceGatePassed, handler=lambda sig, _: gate_passed.append(sig))
+
+    async def _rater(_result):
+        return ConfidenceRating(correctness=0.99, completeness=0.99, evidence=0.99, risk=0.99)
+
+    await confidence_gated_completion(branch, work_result="x", rater=_rater, target=0.95)
+
+    assert len(gate_passed) == 1
+    assert gate_passed[0].overall >= 0.95
+    assert gate_passed[0].target == 0.95
+
+
+# ---------------------------------------------------------------------------
+# #1254 — evidence seeker closes the gap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_confidence_evidence_seeker_closes_gap():
+    """evidence_seeker raises rating from below to above target → completion."""
+    s = Session()
+    branch = s.default_branch
+
+    call_count = {"n": 0}
+
+    async def _rater(_result):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return ConfidenceRating(correctness=0.7, completeness=0.7, evidence=0.7, risk=0.7)
+        # Second call — after evidence was sought.
+        return ConfidenceRating(correctness=0.97, completeness=0.97, evidence=0.97, risk=0.97)
+
+    async def _seeker(result, _rating):
+        return result + " + extra evidence"
+
+    rating, result = await confidence_gated_completion(
+        branch,
+        work_result="initial",
+        rater=_rater,
+        target=0.95,
+        evidence_seeker=_seeker,
+    )
+
+    assert rating.overall >= 0.95
+    assert "extra evidence" in result
+    assert call_count["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_confidence_exhausted_seeker_escalates():
+    """evidence_seeker cannot close the gap within max_attempts → ConfidenceGateEscalated."""
+    s = Session()
+    branch = s.default_branch
+
+    async def _rater(_result):
+        return ConfidenceRating(correctness=0.5, completeness=0.5, evidence=0.5, risk=0.5)
+
+    async def _seeker(result, _rating):
+        return result  # no improvement
+
+    with pytest.raises(ConfidenceGateEscalated):
+        await confidence_gated_completion(
+            branch,
+            work_result="x",
+            rater=_rater,
+            target=0.95,
+            max_attempts=2,
+            evidence_seeker=_seeker,
+        )
+
+
+# ---------------------------------------------------------------------------
+# #1254 — sync rater is also supported
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_confidence_sync_rater_works():
+    """rater may be synchronous (not a coroutine) — both forms accepted."""
+    s = Session()
+    branch = s.default_branch
+
+    def _sync_rater(_result):
+        return ConfidenceRating(correctness=0.96, completeness=0.96, evidence=0.96, risk=0.96)
+
+    rating, result = await confidence_gated_completion(
+        branch, work_result="data", rater=_sync_rater, target=0.95
+    )
+    assert rating.overall >= 0.95

--- a/tests/session/test_lifecycle_signals.py
+++ b/tests/session/test_lifecycle_signals.py
@@ -1,0 +1,268 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the canonical per-node lifecycle signal contract (ADR-0077 / #1251).
+
+Covers:
+- lane_for() projection from signal sequences → NodeLifecycleState
+- New signal constructors (NodeQueued, NodeAwaitingApproval, NodeEscalated)
+- Terminal-state stickiness and retry-reset semantics
+- awaiting_approval and escalated edges (required by spec)
+- StructuredOutput(data=EscalationRequest) → escalated projection
+- RunStart/RunEnd run-scoped fallback paths
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.casts.emission import EscalationRequest
+from lionagi.session.signal import (
+    GateDenied,
+    MessageAdded,
+    NodeAwaitingApproval,
+    NodeCompleted,
+    NodeEscalated,
+    NodeFailed,
+    NodeQueued,
+    NodeStarted,
+    RunEnd,
+    RunFailed,
+    RunStart,
+    StructuredOutput,
+    lane_for,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _queued(op_id: str = "op1") -> NodeQueued:
+    return NodeQueued(op_id=op_id, name="test")
+
+
+def _started(op_id: str = "op1") -> NodeStarted:
+    return NodeStarted(op_id=op_id, name="test")
+
+
+def _completed(op_id: str = "op1") -> NodeCompleted:
+    return NodeCompleted(op_id=op_id, name="test")
+
+
+def _failed(op_id: str = "op1") -> NodeFailed:
+    return NodeFailed(op_id=op_id, name="test")
+
+
+def _awaiting(op_id: str = "op1", reason: str = "needs approval") -> NodeAwaitingApproval:
+    return NodeAwaitingApproval(op_id=op_id, name="test", reason=reason)
+
+
+def _escalated(
+    op_id: str = "op1", reason: str = "low confidence", route: str = "give_up"
+) -> NodeEscalated:
+    return NodeEscalated(op_id=op_id, name="test", reason=reason, route=route)
+
+
+def _escalation_req(reason: str = "out of depth") -> EscalationRequest:
+    return EscalationRequest(
+        reason=reason, context={"trigger": "low_confidence", "confidence": 0.3}
+    )
+
+
+# ---------------------------------------------------------------------------
+# Default state
+# ---------------------------------------------------------------------------
+
+
+def test_empty_stream_is_queued():
+    assert lane_for([]) == "queued"
+
+
+# ---------------------------------------------------------------------------
+# Happy path: queued → running → succeeded
+# ---------------------------------------------------------------------------
+
+
+def test_full_happy_path():
+    assert lane_for([_queued(), _started(), _completed()]) == "succeeded"
+
+
+def test_started_then_completed():
+    assert lane_for([_started(), _completed()]) == "succeeded"
+
+
+def test_started_is_running():
+    assert lane_for([_started()]) == "running"
+
+
+def test_queued_is_queued():
+    assert lane_for([_queued()]) == "queued"
+
+
+# ---------------------------------------------------------------------------
+# Failed edge
+# ---------------------------------------------------------------------------
+
+
+def test_started_then_failed():
+    assert lane_for([_started(), _failed()]) == "failed"
+
+
+def test_run_failed_maps_to_failed():
+    assert lane_for([RunStart(), RunFailed(data=ValueError("boom"))]) == "failed"
+
+
+# ---------------------------------------------------------------------------
+# awaiting_approval edge (required by #1251)
+# ---------------------------------------------------------------------------
+
+
+def test_awaiting_approval_edge():
+    assert lane_for([_started(), _awaiting()]) == "awaiting_approval"
+
+
+def test_awaiting_then_completed():
+    # Approval can be granted; node proceeds to succeed.
+    assert lane_for([_queued(), _started(), _awaiting(), _started(), _completed()]) == "succeeded"
+
+
+# ---------------------------------------------------------------------------
+# escalated edge (required by #1251)
+# ---------------------------------------------------------------------------
+
+
+def test_escalated_edge_via_node_escalated():
+    assert lane_for([_started(), _escalated()]) == "escalated"
+
+
+def test_escalated_via_structured_output():
+    # StructuredOutput carrying an EscalationRequest must project to escalated.
+    req = _escalation_req()
+    sig = StructuredOutput(data=req)
+    assert lane_for([_started(), sig]) == "escalated"
+
+
+def test_escalated_higher_tier_route():
+    sig = _escalated(route="higher_tier")
+    assert lane_for([_started(), sig]) == "escalated"
+
+
+# ---------------------------------------------------------------------------
+# Terminal-state stickiness
+# ---------------------------------------------------------------------------
+
+
+def test_succeeded_is_sticky_against_failed():
+    # A NodeFailed after NodeCompleted must NOT override the terminal state.
+    assert lane_for([_completed(), _failed()]) == "succeeded"
+
+
+def test_failed_is_sticky_against_completed():
+    assert lane_for([_failed(), _completed()]) == "failed"
+
+
+def test_escalated_is_sticky_against_completed():
+    assert lane_for([_escalated(), _completed()]) == "escalated"
+
+
+def test_escalated_is_sticky_against_awaiting():
+    assert lane_for([_escalated(), _awaiting()]) == "escalated"
+
+
+# ---------------------------------------------------------------------------
+# Terminal reset by new attempt
+# ---------------------------------------------------------------------------
+
+
+def test_terminal_reset_by_node_queued():
+    # A new NodeQueued after a terminal state marks a retry attempt.
+    assert lane_for([_completed(), _queued()]) == "queued"
+
+
+def test_terminal_reset_by_node_started():
+    # NodeStarted also marks a new attempt.
+    assert lane_for([_failed(), _started()]) == "running"
+
+
+def test_terminal_resets_then_completes():
+    assert lane_for([_failed(), _queued(), _started(), _completed()]) == "succeeded"
+
+
+# ---------------------------------------------------------------------------
+# Non-state-bearing signals are ignored
+# ---------------------------------------------------------------------------
+
+
+def test_gate_denied_is_ignored_not_terminal():
+    # GateDenied is a governance detail, not a lifecycle lane by itself.
+    assert lane_for([_started(), GateDenied(data="denied")]) == "running"
+
+
+def test_message_added_is_ignored():
+    assert lane_for([_started(), MessageAdded(data="msg"), _completed()]) == "succeeded"
+
+
+def test_none_data_signal_is_ignored():
+    from lionagi.session.signal import Signal
+
+    assert lane_for([_started(), Signal(data=None), _completed()]) == "succeeded"
+
+
+# ---------------------------------------------------------------------------
+# RunStart / RunEnd fallbacks
+# ---------------------------------------------------------------------------
+
+
+def test_run_start_maps_to_running():
+    assert lane_for([RunStart()]) == "running"
+
+
+def test_run_end_maps_to_succeeded():
+    assert lane_for([RunStart(), RunEnd(data="result")]) == "succeeded"
+
+
+# ---------------------------------------------------------------------------
+# Mixed fine-grained and coarse signals
+# ---------------------------------------------------------------------------
+
+
+def test_node_signals_override_run_signals():
+    # Node-level signals interleaved with run-scoped fallbacks — node wins.
+    assert lane_for([RunStart(), _queued(), _started(), _completed()]) == "succeeded"
+
+
+# ---------------------------------------------------------------------------
+# New signal constructors — field defaults and type identity
+# ---------------------------------------------------------------------------
+
+
+def test_node_queued_defaults():
+    sig = NodeQueued()
+    assert sig.op_id == ""
+    assert sig.name == ""
+    assert sig.elapsed == 0.0
+
+
+def test_node_awaiting_approval_defaults():
+    sig = NodeAwaitingApproval()
+    assert sig.op_id == ""
+    assert sig.reason is None
+
+
+def test_node_escalated_fields():
+    sig = NodeEscalated(op_id="x", name="n", reason="low conf", route="give_up")
+    assert sig.op_id == "x"
+    assert sig.route == "give_up"
+
+
+def test_signals_are_elements():
+    """New signals inherit Element identity (have .id) for Flow/Pile storage."""
+    from lionagi.protocols.generic.element import Element
+
+    assert isinstance(NodeQueued(), Element)
+    assert isinstance(NodeAwaitingApproval(), Element)
+    assert isinstance(NodeEscalated(reason="r", route="give_up"), Element)
+    # Each instance has a unique id
+    a, b = NodeQueued(), NodeQueued()
+    assert a.id != b.id

--- a/tests/session/test_lifecycle_signals.py
+++ b/tests/session/test_lifecycle_signals.py
@@ -266,3 +266,104 @@ def test_signals_are_elements():
     # Each instance has a unique id
     a, b = NodeQueued(), NodeQueued()
     assert a.id != b.id
+
+
+# ---------------------------------------------------------------------------
+# MAJ-3 — lane_for on REAL captured signals (not hand-built sequences)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lane_for_on_real_run_signals_succeeds():
+    """lane_for derives 'succeeded' from signals captured during a real Engine.run_dag().
+
+    Closes the MAJ-3 checklist item: 'lane_for(captured_signals_for_op) returns
+    succeeded, failed, or escalated for the real captured stream without hand-built
+    signals.'  All prior lane_for tests use manually constructed signal lists; this
+    test captures signals emitted by the live pipeline and feeds them to lane_for.
+    """
+    import pytest
+
+    pytest.importorskip("lionagi.engines.engine")  # skip if engine not present
+
+    from lionagi.engines.engine import Engine
+    from lionagi.operations.builder import OperationGraphBuilder
+    from lionagi.session.branch import Branch
+    from lionagi.session.session import Session
+
+    async def work(**kw):
+        return "ok"
+
+    session = Session()
+    branch = Branch(name="root")
+    session.include_branches(branch)
+    session.default_branch = branch
+    session.register_operation("work", work)
+
+    captured: list = []
+    session.observe(NodeQueued, handler=lambda s, _: captured.append(s))
+    session.observe(NodeStarted, handler=lambda s, _: captured.append(s))
+    session.observe(NodeCompleted, handler=lambda s, _: captured.append(s))
+    session.observe(NodeFailed, handler=lambda s, _: captured.append(s))
+
+    builder = OperationGraphBuilder()
+    builder.add_operation("work")
+    graph = builder.get_graph()
+
+    run = Engine().new_run(session=session)
+    await run.run_dag(graph)
+
+    assert len(captured) >= 3, (
+        f"Expected ≥3 lifecycle signals (queued/started/completed), got {len(captured)}: "
+        f"{[type(s).__name__ for s in captured]}"
+    )
+    state = lane_for(captured)
+    assert state == "succeeded", (
+        f"lane_for on real signals must return 'succeeded', got {state!r}. "
+        f"Signals: {[type(s).__name__ for s in captured]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_real_run_full_sequence_queued_started_completed():
+    """A successful run emits NodeQueued → NodeStarted → NodeCompleted in strict order.
+
+    This closes the MAJ-3 checklist item: 'verifies per-op order: NodeQueued →
+    NodeStarted → NodeCompleted'.  Previous tests check queued<started OR
+    started+completed separately — this test requires all three and their ordering.
+    """
+    from lionagi.engines.engine import Engine
+    from lionagi.operations.builder import OperationGraphBuilder
+    from lionagi.session.branch import Branch
+    from lionagi.session.session import Session
+
+    async def work(**kw):
+        return "ok"
+
+    session = Session()
+    branch = Branch(name="root")
+    session.include_branches(branch)
+    session.default_branch = branch
+    session.register_operation("work", work)
+
+    log: list[str] = []
+    session.observe(NodeQueued, handler=lambda s, _: log.append("queued"))
+    session.observe(NodeStarted, handler=lambda s, _: log.append("started"))
+    session.observe(NodeCompleted, handler=lambda s, _: log.append("completed"))
+
+    builder = OperationGraphBuilder()
+    builder.add_operation("work")
+    graph = builder.get_graph()
+
+    run = Engine().new_run(session=session)
+    await run.run_dag(graph)
+
+    assert "queued" in log, f"NodeQueued never emitted. log={log}"
+    assert "started" in log, f"NodeStarted never emitted. log={log}"
+    assert "completed" in log, f"NodeCompleted never emitted. log={log}"
+
+    qi = log.index("queued")
+    si = log.index("started")
+    ci = log.index("completed")
+    assert qi < si, f"NodeQueued ({qi}) must precede NodeStarted ({si}). log={log}"
+    assert si < ci, f"NodeStarted ({si}) must precede NodeCompleted ({ci}). log={log}"


### PR DESCRIPTION
## Reactive orchestration: signal contract + escalation + confidence gate

Three linked features on the existing observer bus — the foundation for lifecycle projection and cheap-by-default/escalate-when-stuck orchestration.

| Issue | Shipped | Mechanism |
|---|---|---|
| **#1251** lifecycle-signal contract | `lane_for` structural projection (6 canonical states) + 3 new signals + **live `NodeQueued`** at real enqueue/inject points | `signal.py`, bridged in `engine.py:257` |
| **#1253** EscalationRequest routing | **public** `escalation_tier` on `flow()` / `flow_stream()` / `Session.flow[_stream]()` / `run_dag()` (+`LIONAGI_ESCALATION_TIER`); real higher-tier **re-dispatch** (builds child op, model override, `start_soon`); streaming parity | `flow.py`, `session.py`, `engine.py` |
| **#1254** confidence-gated completion | gate blocks below-target completion → raises + emits `EscalationRequest`; `Branch.confidence_gated_completion` wrapper | `confidence_gate.py`, `branch.py` |

ADR-0077 (lifecycle-signal-contract) documents the projection design.

### Honest history — this is an attempt-2 redo
Attempt 1 shipped a **half-feature** (escalation reachable only inside the executor, not the public API; streaming dropped escalation; audit payload lost; tests blind to the public path). Review found all four issues before merge. This redo resolves every one; reverting the public forwarding makes `test_public_flow_higher_tier_routes_escalation` fail for the right reason.

### Independent verification
- All four prior issues were resolved and mutation-verified; stale play `SUMMARY.md` was removed from the repo here, not committed.
- I re-ran the core suite myself: `test_lifecycle_signals · test_escalation_confidence · test_flow_stream · test_engine` → **73 passed**. `pre-commit run ruff` + `ruff-format` on the full diff → **Passed**.

### Honest deferrals (documented, not hidden)
- **`NodeAwaitingApproval`** live emission — no approval-wait seam exists in the execution path yet; emitting it would be scope-creep or a stub. The lane stays *projectable* for a future approval-gate feature.
- Streaming escalated-**child** end-to-end FlowEvent (the routing signal is verified; child-completion streaming is follow-up).
- Full cross-task learning propagation (#1254).

### ⚠️ Core code — please review before merge
Touches `session/` + `operations/` execution paths. Built on the existing observer bus (no parallel abstraction). Convention-clean (Apache headers, frozen value objects, additive `__all__`).

Closes #1251 #1253 #1254

🤖 Generated with [Claude Code](https://claude.com/claude-code)