### PR TITLE
fix(providers): unify CLI provider types + fix codex silent failures

### DIFF
--- a/lionagi/providers/anthropic/claude_code/endpoint.py
+++ b/lionagi/providers/anthropic/claude_code/endpoint.py
@@ -8,15 +8,11 @@ from collections.abc import AsyncIterator, Callable
 
 from pydantic import BaseModel
 
-from lionagi.providers.anthropic.claude_code.models import (
-    ClaudeChunk,
-    ClaudeCodeRequest,
-    ClaudeSession,
-)
+from lionagi.providers.anthropic.claude_code.models import ClaudeCodeRequest, stream_claude_code_cli
 from lionagi.providers.anthropic.claude_code.models import log as cc_log
-from lionagi.providers.anthropic.claude_code.models import stream_claude_code_cli
 from lionagi.service.connections.agentic_endpoint import AgenticEndpoint
 from lionagi.service.connections.endpoint_config import EndpointConfig
+from lionagi.service.types.cli_session import CLISession
 from lionagi.service.types.stream_chunk import StreamChunk
 from lionagi.utils import to_dict
 
@@ -90,9 +86,7 @@ class ClaudeCodeCLIEndpoint(AgenticEndpoint):
 
     def _runtime_handlers(self, kwargs: dict) -> dict:
         handlers = self.claude_handlers.copy()
-        call_handlers = {
-            k: kwargs.pop(k) for k in list(kwargs) if k in _CLAUDE_HANDLER_PARAMS
-        }
+        call_handlers = {k: kwargs.pop(k) for k in list(kwargs) if k in _CLAUDE_HANDLER_PARAMS}
         if call_handlers:
             _validate_handlers(call_handlers)
             handlers.update(call_handlers)
@@ -101,86 +95,22 @@ class ClaudeCodeCLIEndpoint(AgenticEndpoint):
     def create_payload(self, request: dict | BaseModel, **kwargs):
         req_dict = {**self.config.kwargs, **to_dict(request), **kwargs}
         messages = req_dict.pop("messages", [])
-        req_dict = {
-            k: v for k, v in req_dict.items() if k in ClaudeCodeRequest.model_fields
-        }
+        req_dict = {k: v for k, v in req_dict.items() if k in ClaudeCodeRequest.model_fields}
         req_obj = ClaudeCodeRequest(messages=messages, **req_dict)
         return {"request": req_obj}, {}
 
-    async def stream(
-        self, request: dict | BaseModel, **kwargs
-    ) -> AsyncIterator[StreamChunk]:
+    async def stream(self, request: dict | BaseModel, **kwargs) -> AsyncIterator[StreamChunk]:
         handlers = self._runtime_handlers(kwargs)
         if isinstance(request, dict) and "request" in request:
             request_obj = request["request"]
         else:
             payload, _ = self.create_payload(request, **kwargs)
             request_obj = payload["request"]
-        async with contextlib.aclosing(
-            stream_claude_code_cli(request_obj, **handlers)
-        ) as gen:
+        async with contextlib.aclosing(stream_claude_code_cli(request_obj, **handlers)) as gen:
             async for item in gen:
-                if isinstance(item, ClaudeSession):
+                if isinstance(item, CLISession):
                     continue
-                if isinstance(item, dict):
-                    typ = item.get("type", "")
-                    if typ == "system":
-                        yield StreamChunk(
-                            type="system",
-                            metadata={
-                                "session_id": item.get("session_id"),
-                                "model": item.get("model"),
-                                "tools": item.get("tools", []),
-                            },
-                        )
-                    elif typ == "result":
-                        yield StreamChunk(
-                            type="result",
-                            content=item.get("result", ""),
-                            metadata={
-                                k: item.get(k)
-                                for k in (
-                                    "usage",
-                                    "total_cost_usd",
-                                    "num_turns",
-                                    "duration_ms",
-                                    "duration_api_ms",
-                                )
-                                if item.get(k) is not None
-                            },
-                            is_error=item.get("is_error", False),
-                        )
-                    continue
-                if isinstance(item, ClaudeChunk):
-                    raw = item.raw
-                    if item.type in ("assistant", "user"):
-                        msg = raw.get("message", {})
-                        for blk in msg.get("content", []):
-                            btype = blk.get("type")
-                            if btype == "thinking":
-                                yield StreamChunk(
-                                    type="thinking",
-                                    content=blk.get("thinking", ""),
-                                )
-                            elif btype == "text":
-                                yield StreamChunk(
-                                    type="text",
-                                    content=blk.get("text", ""),
-                                )
-                            elif btype == "tool_use":
-                                yield StreamChunk(
-                                    type="tool_use",
-                                    tool_name=blk.get("name"),
-                                    tool_id=blk.get("id"),
-                                    tool_input=blk.get("input"),
-                                )
-                            elif btype == "tool_result":
-                                yield StreamChunk(
-                                    type="tool_result",
-                                    tool_id=blk.get("tool_use_id"),
-                                    tool_output=blk.get("content"),
-                                    is_error=blk.get("is_error", False),
-                                )
+                yield item
 
     async def _call(
         self,
@@ -190,24 +120,20 @@ class ClaudeCodeCLIEndpoint(AgenticEndpoint):
     ):
         responses = []
         request: ClaudeCodeRequest = payload["request"]
-        session: ClaudeSession = ClaudeSession()
-        system: dict = None
+        session: CLISession = CLISession()
+        system_meta: dict | None = None
         _cancelled = False
         handlers = self._runtime_handlers(kwargs)
 
-        # 1. stream the Claude Code response
         try:
             async with contextlib.aclosing(
                 stream_claude_code_cli(request, session, **handlers)
             ) as gen:
                 async for chunk in gen:
-                    if isinstance(chunk, dict):
-                        if chunk.get("type") == "done":
-                            break
-                        system = chunk
+                    if isinstance(chunk, StreamChunk) and chunk.type == "system":
+                        system_meta = chunk.metadata
                     responses.append(chunk)
         except BaseException:
-            # CancelledError, KeyboardInterrupt — must not trigger auto_finish
             _cancelled = True
             raise
 
@@ -215,35 +141,29 @@ class ClaudeCodeCLIEndpoint(AgenticEndpoint):
             not _cancelled
             and request.auto_finish
             and responses
-            and not isinstance(responses[-1], ClaudeSession)
+            and not isinstance(responses[-1], CLISession)
         ):
             req2 = request.model_copy(deep=True)
             req2.prompt = "Please provide a the final result message only"
             req2.max_turns = 1
             req2.continue_conversation = True
-            if system:
-                req2.resume = system.get("session_id") if system else None
+            if system_meta:
+                req2.resume = system_meta.get("session_id")
 
-            async with contextlib.aclosing(
-                stream_claude_code_cli(req2, session)
-            ) as gen2:
+            async with contextlib.aclosing(stream_claude_code_cli(req2, session)) as gen2:
                 async for chunk in gen2:
                     responses.append(chunk)
-                    if isinstance(chunk, ClaudeSession):
+                    if isinstance(chunk, CLISession):
                         break
-        cc_log.info(
-            f"Session {session.session_id} finished with {len(responses)} chunks"
-        )
+        cc_log.info(f"Session {session.session_id} finished with {len(responses)} chunks")
         texts = []
-        for i in session.chunks:
-            if i.text is not None:
-                texts.append(i.text)
+        for sc in session.chunks:
+            if sc.type == "text" and sc.content is not None:
+                texts.append(sc.content)
 
         # Guard against IndexError when no text chunks arrived (early cancel,
         # tool-only sessions, empty responses under auto_finish).
-        if session.result and (
-            not texts or session.result.strip() != texts[-1].strip()
-        ):
+        if session.result and (not texts or session.result.strip() != texts[-1].strip()):
             texts.append(session.result)
 
         session.result = "\n".join(texts)

--- a/lionagi/providers/anthropic/claude_code/models.py
+++ b/lionagi/providers/anthropic/claude_code/models.py
@@ -11,8 +11,6 @@ import json
 import logging
 import shutil
 from collections.abc import AsyncIterator, Callable
-from dataclasses import dataclass
-from dataclasses import field as datafield
 from datetime import datetime, timezone
 from functools import partial
 from pathlib import Path
@@ -23,6 +21,8 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 from lionagi import ln
 from lionagi.libs.schema.as_readable import as_readable
+from lionagi.service.types.cli_session import CLISession
+from lionagi.service.types.stream_chunk import StreamChunk
 
 HAS_CLAUDE_CODE_CLI = False
 CLAUDE_CLI = None
@@ -53,8 +53,6 @@ ClaudeInputFormat = Literal["text", "stream-json"]
 
 __all__ = (
     "ClaudeCodeRequest",
-    "ClaudeChunk",
-    "ClaudeSession",
     "stream_claude_code_cli",
 )
 
@@ -318,7 +316,7 @@ class ClaudeCodeRequest(BaseModel):
         if resume or continue_conversation:
             continue_conversation = True
             prompt = msg[-1]["content"]
-            if isinstance(prompt, (dict, list)):
+            if isinstance(prompt, dict | list):
                 prompt = ln.json_dumps(prompt)
 
         # 2. else, use entire messages except system message
@@ -329,9 +327,7 @@ class ClaudeCodeRequest(BaseModel):
                 if message["role"] != "system":
                     content = message["content"]
                     prompts.append(
-                        ln.json_dumps(content)
-                        if isinstance(content, (dict, list))
-                        else content
+                        ln.json_dumps(content) if isinstance(content, dict | list) else content
                     )
 
             prompt = "\n".join(prompts)
@@ -367,10 +363,7 @@ class ClaudeCodeRequest(BaseModel):
             raise ValueError("--fork-session requires --resume or --continue")
 
         # Permission flag mutual exclusivity
-        if (
-            self.allow_dangerously_skip_permissions
-            and self.permission_mode == "bypassPermissions"
-        ):
+        if self.allow_dangerously_skip_permissions and self.permission_mode == "bypassPermissions":
             raise ValueError(
                 "allow_dangerously_skip_permissions and "
                 "permission_mode='bypassPermissions' are mutually exclusive"
@@ -378,9 +371,7 @@ class ClaudeCodeRequest(BaseModel):
 
         # System prompt mutual exclusivity
         if self.system_prompt and self.system_prompt_file:
-            raise ValueError(
-                "--system-prompt and --system-prompt-file are mutually exclusive"
-            )
+            raise ValueError("--system-prompt and --system-prompt-file are mutually exclusive")
 
         # Workspace bounds check for bypassPermissions
         if self.permission_mode == "bypassPermissions":
@@ -406,14 +397,10 @@ class ClaudeCodeRequest(BaseModel):
         ws_path = Path(self.ws)
 
         if ws_path.is_absolute():
-            raise ValueError(
-                f"Workspace path must be relative, got absolute: {self.ws}"
-            )
+            raise ValueError(f"Workspace path must be relative, got absolute: {self.ws}")
 
         if ".." in ws_path.parts:
-            raise ValueError(
-                f"Directory traversal detected in workspace path: {self.ws}"
-            )
+            raise ValueError(f"Directory traversal detected in workspace path: {self.ws}")
 
         repo_resolved = self.repo.resolve()
         result = (self.repo / ws_path).resolve()
@@ -536,9 +523,7 @@ class ClaudeCodeRequest(BaseModel):
                 args.extend(str(v) for v in val)
 
             elif kind == "json_value":
-                serialized = (
-                    json.dumps(val) if isinstance(val, (dict, list)) else str(val)
-                )
+                serialized = json.dumps(val) if isinstance(val, dict | list) else str(val)
                 args.extend([flag, serialized])
 
             elif kind == "repeat":
@@ -554,142 +539,7 @@ class ClaudeCodeRequest(BaseModel):
 # --------------------------------------------------------------------------- chunks & session
 
 
-@dataclass
-class ClaudeChunk:
-    """Low-level wrapper around every NDJSON object coming from the CLI."""
-
-    raw: dict[str, Any]
-    type: str
-    # convenience views
-    thinking: str | None = None
-    text: str | None = None
-    tool_use: dict[str, Any] | None = None
-    tool_result: dict[str, Any] | None = None
-
-
-@dataclass
-class ClaudeSession:
-    """Aggregated view of a whole CLI conversation."""
-
-    session_id: str | None = None
-    model: str | None = None
-
-    # chronological log
-    chunks: list[ClaudeChunk] = datafield(default_factory=list)
-
-    # materialised views
-    thinking_log: list[str] = datafield(default_factory=list)
-    messages: list[dict[str, Any]] = datafield(default_factory=list)
-    tool_uses: list[dict[str, Any]] = datafield(default_factory=list)
-    tool_results: list[dict[str, Any]] = datafield(default_factory=list)
-
-    # final summary
-    result: str = ""
-    usage: dict[str, Any] = datafield(default_factory=dict)
-    total_cost_usd: float | None = None
-    num_turns: int | None = None
-    duration_ms: int | None = None
-    duration_api_ms: int | None = None
-    is_error: bool = False
-    summary: dict | None = None
-
-    def populate_summary(self) -> None:
-        self.summary = _extract_summary(self)
-
-
-def _extract_summary(session: ClaudeSession) -> dict[str, Any]:
-    tool_counts = {}
-    tool_details = []
-    file_operations = {"reads": [], "writes": [], "edits": []}
-    key_actions = []
-
-    # Process tool uses from the clean materialized view
-    for tool_use in session.tool_uses:
-        tool_name = tool_use.get("name", "unknown")
-        tool_input = tool_use.get("input", {})
-        tool_id = tool_use.get("id", "")
-
-        # Count tool usage
-        tool_counts[tool_name] = tool_counts.get(tool_name, 0) + 1
-
-        # Store detailed info
-        tool_details.append({"tool": tool_name, "id": tool_id, "input": tool_input})
-
-        # Categorize file operations and actions
-        if tool_name in ["Read", "read"]:
-            file_path = tool_input.get("file_path", "unknown")
-            file_operations["reads"].append(file_path)
-            key_actions.append(f"Read {file_path}")
-
-        elif tool_name in ["Write", "write"]:
-            file_path = tool_input.get("file_path", "unknown")
-            file_operations["writes"].append(file_path)
-            key_actions.append(f"Wrote {file_path}")
-
-        elif tool_name in ["Edit", "edit", "MultiEdit"]:
-            file_path = tool_input.get("file_path", "unknown")
-            file_operations["edits"].append(file_path)
-            key_actions.append(f"Edited {file_path}")
-
-        elif tool_name in ["Bash", "bash"]:
-            command = tool_input.get("command", "")
-            command_summary = command[:50] + "..." if len(command) > 50 else command
-            key_actions.append(f"Ran: {command_summary}")
-
-        elif tool_name in ["Glob", "glob"]:
-            pattern = tool_input.get("pattern", "")
-            key_actions.append(f"Searched files: {pattern}")
-
-        elif tool_name in ["Grep", "grep"]:
-            pattern = tool_input.get("pattern", "")
-            key_actions.append(f"Searched content: {pattern}")
-
-        elif tool_name in ["Task", "task", "Agent"]:
-            description = tool_input.get("description", "")
-            key_actions.append(f"Spawned agent: {description}")
-
-        elif tool_name.startswith("mcp__"):
-            operation = tool_name.replace("mcp__", "")
-            key_actions.append(f"MCP {operation}")
-
-        elif tool_name == "TodoWrite":
-            todos = tool_input.get("todos", [])
-            key_actions.append(f"Created {len(todos)} todos")
-
-        else:
-            key_actions.append(f"Used {tool_name}")
-
-    # Deduplicate key actions
-    key_actions = (
-        list(dict.fromkeys(key_actions))
-        if key_actions
-        else ["No specific actions detected"]
-    )
-
-    # Deduplicate file paths
-    for op_type in file_operations:
-        file_operations[op_type] = list(dict.fromkeys(file_operations[op_type]))
-
-    # Extract result summary (first 200 chars)
-    result_summary = (
-        (session.result[:200] + "...") if len(session.result) > 200 else session.result
-    )
-
-    return {
-        "tool_counts": tool_counts,
-        "tool_details": tool_details,
-        "file_operations": file_operations,
-        "key_actions": key_actions,
-        "total_tool_calls": sum(tool_counts.values()),
-        "result_summary": result_summary,
-        "usage_stats": {
-            "total_cost_usd": session.total_cost_usd,
-            "num_turns": session.num_turns,
-            "duration_ms": session.duration_ms,
-            "duration_api_ms": session.duration_api_ms,
-            **session.usage,
-        },
-    }
+ClaudeSession = CLISession
 
 
 # --------------------------------------------------------------------------- NDJSON stream
@@ -723,9 +573,7 @@ async def _ndjson_from_cli(request: ClaudeCodeRequest):
     # Guard against mocked subprocesses in tests where proc.pid may not
     # be a real int: a MagicMock.pid coerces to 1 via __int__, and
     # os.killpg(1, SIGTERM) signals init/the CI runner.
-    _claude_pgid: int | None = (
-        proc.pid if isinstance(proc.pid, int) and proc.pid > 1 else None
-    )
+    _claude_pgid: int | None = proc.pid if isinstance(proc.pid, int) and proc.pid > 1 else None
 
     decoder = codecs.getincrementaldecoder("utf-8")()
     json_decoder = json.JSONDecoder()
@@ -836,19 +684,14 @@ async def _ndjson_from_cli(request: ClaudeCodeRequest):
         stderr_task.cancel()
         try:
             await stderr_task
-        except (
-            asyncio.CancelledError,
-            Exception,
-        ):  # noqa: S110, BLE001 — intentional teardown reap
+        except (asyncio.CancelledError, Exception):  # noqa: S110, BLE001
             pass
 
 
 # --------------------------------------------------------------------------- SSE route
 async def stream_cc_cli_events(request: ClaudeCodeRequest):
     if not CLAUDE_CLI:
-        raise RuntimeError(
-            "Claude CLI binary not found (npm i -g @anthropic-ai/claude-code)"
-        )
+        raise RuntimeError("Claude CLI binary not found (npm i -g @anthropic-ai/claude-code)")
     async with contextlib.aclosing(_ndjson_from_cli(request)) as stream:
         async for obj in stream:
             yield obj
@@ -894,17 +737,13 @@ def _pp_tool_use(tu: dict[str, Any], theme) -> None:
 def _pp_tool_result(tr: dict[str, Any], theme) -> None:
     body_preview = shorten(str(tr["content"]).replace("\n", " "), 130)
     status = "ERR" if tr.get("is_error") else "OK"
-    body = (
-        f"- 📄 Tool Result({tr['tool_use_id']}) - {status}\n\n\tcontent: {body_preview}"
-    )
+    body = f"- 📄 Tool Result({tr['tool_use_id']}) - {status}\n\n\tcontent: {body_preview}"
     print_readable(body, border=False, panel=False, theme=theme)
 
 
-def _pp_final(sess: ClaudeSession, theme) -> None:
+def _pp_final(sess: CLISession, theme) -> None:
     usage = sess.usage or {}
-    cost_str = (
-        f"${sess.total_cost_usd:.4f}" if sess.total_cost_usd is not None else "N/A"
-    )
+    cost_str = f"${sess.total_cost_usd:.4f}" if sess.total_cost_usd is not None else "N/A"
     txt = (
         f"### ✅ Session complete - {datetime.now(timezone.utc).isoformat(timespec='seconds')} UTC\n"
         f"**Result:**\n\n{sess.result or ''}\n\n"
@@ -929,41 +768,47 @@ async def _maybe_await(func, *args, **kw):
 # --------------------------------------------------------------------------- main parser
 async def stream_claude_code_cli(  # noqa: C901
     request: ClaudeCodeRequest,
-    session: ClaudeSession | None = None,
+    session: CLISession | None = None,
     *,
     on_system: Callable[[dict[str, Any]], None] | None = None,
     on_thinking: Callable[[str], None] | None = None,
     on_text: Callable[[str], None] | None = None,
     on_tool_use: Callable[[dict[str, Any]], None] | None = None,
     on_tool_result: Callable[[dict[str, Any]], None] | None = None,
-    on_final: Callable[[ClaudeSession], None] | None = None,
-) -> AsyncIterator[ClaudeChunk | dict | ClaudeSession]:
-    """
-    Consume the ND-JSON stream produced by ndjson_from_cli()
-    and return a fully-populated ClaudeSession.
-
-    If callbacks are omitted a default pretty-print is emitted.
-    """
+    on_final: Callable[[CLISession], None] | None = None,
+) -> AsyncIterator[StreamChunk | CLISession]:
+    """Consume ND-JSON from the Claude Code CLI, yield StreamChunks,
+    and populate a CLISession accumulator."""
     if session is None:
-        session = ClaudeSession()
+        session = CLISession()
     theme = request.cli_display_theme or "light"
+    seen_system_ids: set[str] = set()
 
     stream = stream_cc_cli_events(request)
     try:
         async for obj in stream:
             typ = obj.get("type", "unknown")
-            chunk = ClaudeChunk(raw=obj, type=typ)
-            session.chunks.append(chunk)
 
             # ------------------------ SYSTEM -----------------------------------
             if typ == "system":
-                data = obj
-                session.session_id = data.get("session_id", session.session_id)
-                session.model = data.get("model", session.model)
-                await _maybe_await(on_system, data)
+                session.session_id = obj.get("session_id", session.session_id)
+                session.model = obj.get("model", session.model)
+                await _maybe_await(on_system, obj)
                 if request.verbose_output:
-                    _pp_system(data, theme)
-                yield data
+                    sid = str(obj.get("session_id", ""))
+                    if obj.get("model") and sid not in seen_system_ids:
+                        seen_system_ids.add(sid)
+                        _pp_system(obj, theme)
+                sc = StreamChunk(
+                    type="system",
+                    metadata={
+                        "session_id": obj.get("session_id"),
+                        "model": obj.get("model"),
+                        "tools": obj.get("tools", []),
+                    },
+                )
+                session.chunks.append(sc)
+                yield sc
 
             # ------------------------ ASSISTANT --------------------------------
             elif typ == "assistant":
@@ -974,30 +819,38 @@ async def stream_claude_code_cli(  # noqa: C901
                     btype = blk.get("type")
                     if btype == "thinking":
                         thought = blk.get("thinking", "").strip()
-                        chunk.thinking = thought
                         session.thinking_log.append(thought)
                         await _maybe_await(on_thinking, thought)
                         if request.verbose_output:
                             _pp_thinking(thought, theme)
+                        sc = StreamChunk(type="thinking", content=thought, metadata=obj)
+                        session.chunks.append(sc)
+                        yield sc
 
                     elif btype == "text":
                         text = blk.get("text", "")
-                        chunk.text = text
                         await _maybe_await(on_text, text)
                         if request.verbose_output:
                             _pp_assistant_text(text, theme)
+                        sc = StreamChunk(type="text", content=text, metadata=obj)
+                        session.chunks.append(sc)
+                        yield sc
 
                     elif btype == "tool_use":
-                        tu = {
-                            "id": blk["id"],
-                            "name": blk["name"],
-                            "input": blk["input"],
-                        }
-                        chunk.tool_use = tu
+                        tu = {"id": blk["id"], "name": blk["name"], "input": blk["input"]}
                         session.tool_uses.append(tu)
                         await _maybe_await(on_tool_use, tu)
                         if request.verbose_output:
                             _pp_tool_use(tu, theme)
+                        sc = StreamChunk(
+                            type="tool_use",
+                            tool_name=tu["name"],
+                            tool_id=tu["id"],
+                            tool_input=tu["input"],
+                            metadata=obj,
+                        )
+                        session.chunks.append(sc)
+                        yield sc
 
                     elif btype == "tool_result":
                         tr = {
@@ -1005,12 +858,19 @@ async def stream_claude_code_cli(  # noqa: C901
                             "content": blk["content"],
                             "is_error": blk.get("is_error", False),
                         }
-                        chunk.tool_result = tr
                         session.tool_results.append(tr)
                         await _maybe_await(on_tool_result, tr)
                         if request.verbose_output:
                             _pp_tool_result(tr, theme)
-                yield chunk
+                        sc = StreamChunk(
+                            type="tool_result",
+                            tool_id=tr["tool_use_id"],
+                            tool_output=tr["content"],
+                            is_error=tr["is_error"],
+                            metadata=obj,
+                        )
+                        session.chunks.append(sc)
+                        yield sc
 
             # ------------------------ USER (tool_result containers) ------------
             elif typ == "user":
@@ -1023,12 +883,19 @@ async def stream_claude_code_cli(  # noqa: C901
                             "content": blk["content"],
                             "is_error": blk.get("is_error", False),
                         }
-                        chunk.tool_result = tr
                         session.tool_results.append(tr)
                         await _maybe_await(on_tool_result, tr)
                         if request.verbose_output:
                             _pp_tool_result(tr, theme)
-                yield chunk
+                        sc = StreamChunk(
+                            type="tool_result",
+                            tool_id=tr["tool_use_id"],
+                            tool_output=tr["content"],
+                            is_error=tr["is_error"],
+                            metadata=obj,
+                        )
+                        session.chunks.append(sc)
+                        yield sc
 
             # ------------------------ RESULT -----------------------------------
             elif typ == "result":
@@ -1046,7 +913,6 @@ async def stream_claude_code_cli(  # noqa: C901
     finally:
         await stream.aclose()
 
-    # final pretty print
     await _maybe_await(on_final, session)
     if request.verbose_output:
         _pp_final(session, theme)

--- a/lionagi/providers/openai/codex/endpoint.py
+++ b/lionagi/providers/openai/codex/endpoint.py
@@ -8,15 +8,11 @@ from collections.abc import AsyncIterator, Callable
 
 from pydantic import BaseModel
 
-from lionagi.providers.openai.codex.models import (
-    CodexChunk,
-    CodexCodeRequest,
-    CodexSession,
-)
+from lionagi.providers.openai.codex.models import CodexCodeRequest, stream_codex_cli
 from lionagi.providers.openai.codex.models import log as codex_log
-from lionagi.providers.openai.codex.models import stream_codex_cli
 from lionagi.service.connections.agentic_endpoint import AgenticEndpoint
 from lionagi.service.connections.endpoint_config import EndpointConfig
+from lionagi.service.types.cli_session import CLISession
 from lionagi.service.types.stream_chunk import StreamChunk
 from lionagi.utils import to_dict
 
@@ -27,6 +23,7 @@ CONTEXT_WINDOWS: dict[str, int] = {
     "o4-mini": 200_000,
     "o3": 200_000,
     "gpt-4.1": 1_047_576,
+    "gpt-5.5": 1_047_576,
 }
 
 _CODEX_HANDLER_PARAMS = (
@@ -84,9 +81,7 @@ class CodexCLIEndpoint(AgenticEndpoint):
 
     def _runtime_handlers(self, kwargs: dict) -> dict:
         handlers = self.codex_handlers.copy()
-        call_handlers = {
-            k: kwargs.pop(k) for k in list(kwargs) if k in _CODEX_HANDLER_PARAMS
-        }
+        call_handlers = {k: kwargs.pop(k) for k in list(kwargs) if k in _CODEX_HANDLER_PARAMS}
         if call_handlers:
             _validate_handlers(call_handlers)
             handlers.update(call_handlers)
@@ -95,66 +90,27 @@ class CodexCLIEndpoint(AgenticEndpoint):
     def create_payload(self, request: dict | BaseModel, **kwargs):
         req_dict = {**self.config.kwargs, **to_dict(request), **kwargs}
         messages = req_dict.pop("messages", [])
-        req_dict = {
-            k: v for k, v in req_dict.items() if k in CodexCodeRequest.model_fields
-        }
+        req_dict = {k: v for k, v in req_dict.items() if k in CodexCodeRequest.model_fields}
         req_obj = CodexCodeRequest(messages=messages, **req_dict)
         return {"request": req_obj}, {}
 
-    async def stream(
-        self, request: dict | BaseModel, **kwargs
-    ) -> AsyncIterator[StreamChunk]:
+    async def stream(self, request: dict | BaseModel, **kwargs) -> AsyncIterator[StreamChunk]:
         handlers = self._runtime_handlers(kwargs)
         if isinstance(request, dict) and "request" in request:
             request_obj = request["request"]
         else:
             payload, _ = self.create_payload(request, **kwargs)
             request_obj = payload["request"]
-        async with contextlib.aclosing(
-            stream_codex_cli(request_obj, **handlers)
-        ) as gen:
+        async with contextlib.aclosing(stream_codex_cli(request_obj, **handlers)) as gen:
             async for item in gen:
-                if isinstance(item, CodexSession):
-                    continue
-                if isinstance(item, dict):
-                    typ = item.get("type", "")
-                    if typ == "result":
+                if isinstance(item, CLISession):
+                    if item.is_error:
                         yield StreamChunk(
-                            type="result",
-                            content=item.get("result", ""),
-                            metadata=item,
+                            type="error",
+                            content=item.result or "Codex session failed",
                         )
                     continue
-                if isinstance(item, CodexChunk):
-                    if item.text is not None:
-                        yield StreamChunk(type="text", content=item.text)
-                    if item.tool_use is not None:
-                        tu = item.tool_use
-                        yield StreamChunk(
-                            type="tool_use",
-                            tool_name=tu.get("name"),
-                            tool_id=tu.get("id"),
-                            tool_input=tu.get("input"),
-                        )
-                    if item.tool_result is not None:
-                        tr = item.tool_result
-                        yield StreamChunk(
-                            type="tool_result",
-                            tool_id=tr.get("tool_use_id"),
-                            tool_output=tr.get("content"),
-                            is_error=tr.get("is_error", False),
-                        )
-                    if (
-                        item.text is None
-                        and item.tool_use is None
-                        and item.tool_result is None
-                        and item.type == "result"
-                    ):
-                        yield StreamChunk(
-                            type="result",
-                            content=item.raw.get("result", ""),
-                            metadata=item.raw,
-                        )
+                yield item
 
     async def _call(
         self,
@@ -164,23 +120,19 @@ class CodexCLIEndpoint(AgenticEndpoint):
     ):
         responses = []
         request: CodexCodeRequest = payload["request"]
-        session: CodexSession = CodexSession()
+        session: CLISession = CLISession()
         handlers = self._runtime_handlers(kwargs)
 
-        async with contextlib.aclosing(
-            stream_codex_cli(request, session, **handlers)
-        ) as gen:
+        async with contextlib.aclosing(stream_codex_cli(request, session, **handlers)) as gen:
             async for chunk in gen:
                 if isinstance(chunk, dict):
                     if chunk.get("type") == "done":
                         break
                 responses.append(chunk)
 
-        codex_log.info(
-            f"Session {session.session_id} finished with {len(responses)} chunks"
-        )
+        codex_log.info(f"Session {session.session_id} finished with {len(responses)} chunks")
         if not session.result:
-            texts = [c.text for c in session.chunks if c.text is not None]
+            texts = [c.content for c in session.chunks if c.type == "text" and c.content]
             session.result = "\n".join(texts)
         if request.cli_include_summary:
             session.populate_summary()

--- a/lionagi/providers/openai/codex/models.py
+++ b/lionagi/providers/openai/codex/models.py
@@ -12,8 +12,6 @@ import logging
 import shutil
 import warnings
 from collections.abc import AsyncIterator, Callable
-from dataclasses import dataclass
-from dataclasses import field as datafield
 from functools import partial
 from pathlib import Path
 from textwrap import shorten
@@ -23,6 +21,8 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 from lionagi import ln
 from lionagi.libs.schema.as_readable import as_readable
+from lionagi.service.types.cli_session import CLISession
+from lionagi.service.types.stream_chunk import StreamChunk
 
 HAS_CODEX_CLI = False
 CODEX_CLI = None
@@ -60,9 +60,7 @@ CodexReasoningEffort = Literal[
 ]
 
 __all__ = (
-    "CodexChunk",
     "CodexCodeRequest",
-    "CodexSession",
     "stream_codex_cli",
 )
 
@@ -231,13 +229,12 @@ class CodexCodeRequest(BaseModel):
         description="Plan-mode reasoning effort (emitted as -c plan_mode_reasoning_effort=<val>)",
     )
 
-    # ── fast mode (priority service tier) ────────────────────────
+    # ── fast mode (fast service tier) ────────────────────────────
     fast_mode: bool = Field(
         default=False,
         description=(
-            "Route this request through OpenAI's *priority* service tier for "
-            "lower latency. Emitted as ``-c service_tier=flex``. "
-            "Requires an OpenAI account with priority-tier eligibility. "
+            "Route this request through OpenAI's *fast* service tier for "
+            "lower latency. Emitted as ``-c service_tier=fast``. "
             "Does NOT cap or change ``reasoning_effort`` — "
             "``fast_mode=True`` with ``reasoning_effort='xhigh'`` is valid "
             "and gives maximum reasoning depth on the fast lane."
@@ -402,9 +399,9 @@ class CodexCodeRequest(BaseModel):
                 ]
             )
 
-        # Fast mode → -c service_tier=flex (priority renamed to flex in codex CLI)
+        # Fast mode → -c service_tier=fast
         if self.fast_mode:
-            args.extend(["-c", "service_tier=flex"])
+            args.extend(["-c", "service_tier=fast"])
 
         # Images (repeat -i per image)
         for image in self.images:
@@ -460,122 +457,7 @@ class CodexCodeRequest(BaseModel):
         return args
 
 
-# --------------------------------------------------------------------------- chunks & session
-
-
-@dataclass
-class CodexChunk:
-    """Low-level wrapper around every JSON object from the Codex CLI."""
-
-    raw: dict[str, Any]
-    type: str
-    # convenience views
-    text: str | None = None
-    tool_use: dict[str, Any] | None = None
-    tool_result: dict[str, Any] | None = None
-
-
-@dataclass
-class CodexSession:
-    """Aggregated view of a whole Codex CLI conversation."""
-
-    session_id: str | None = None
-    model: str | None = None
-
-    # chronological log
-    chunks: list[CodexChunk] = datafield(default_factory=list)
-
-    # materialized views
-    messages: list[dict[str, Any]] = datafield(default_factory=list)
-    tool_uses: list[dict[str, Any]] = datafield(default_factory=list)
-    tool_results: list[dict[str, Any]] = datafield(default_factory=list)
-
-    # final summary
-    result: str = ""
-    usage: dict[str, Any] = datafield(default_factory=dict)
-    total_cost_usd: float | None = None
-    num_turns: int | None = None
-    duration_ms: int | None = None
-    is_error: bool = False
-    summary: dict | None = None
-
-    def populate_summary(self) -> None:
-        self.summary = _extract_summary(self)
-
-
-def _extract_summary(session: CodexSession) -> dict[str, Any]:
-    """Extract summary from session data."""
-    tool_counts: dict[str, int] = {}
-    tool_details: list[dict[str, Any]] = []
-    file_operations: dict[str, list[str]] = {
-        "reads": [],
-        "writes": [],
-        "edits": [],
-    }
-    key_actions: list[str] = []
-
-    for tool_use in session.tool_uses:
-        tool_name = tool_use.get("name", "unknown")
-        tool_input = tool_use.get("input", {})
-        tool_id = tool_use.get("id", "")
-
-        tool_counts[tool_name] = tool_counts.get(tool_name, 0) + 1
-        tool_details.append({"tool": tool_name, "id": tool_id, "input": tool_input})
-
-        if tool_name in ("read_file", "Read", "read"):
-            file_path = tool_input.get("path", tool_input.get("file_path", "unknown"))
-            file_operations["reads"].append(file_path)
-            key_actions.append(f"Read {file_path}")
-
-        elif tool_name in ("write_file", "create_file", "Write", "write"):
-            file_path = tool_input.get("path", tool_input.get("file_path", "unknown"))
-            file_operations["writes"].append(file_path)
-            key_actions.append(f"Wrote {file_path}")
-
-        elif tool_name in ("edit_file", "patch", "Edit", "edit"):
-            file_path = tool_input.get("path", tool_input.get("file_path", "unknown"))
-            file_operations["edits"].append(file_path)
-            key_actions.append(f"Edited {file_path}")
-
-        elif tool_name in (
-            "shell",
-            "terminal",
-            "run_shell_command",
-            "Bash",
-            "bash",
-        ):
-            command = tool_input.get("command", tool_input.get("cmd", ""))
-            command_summary = command[:50] + "..." if len(command) > 50 else command
-            key_actions.append(f"Ran: {command_summary}")
-
-        elif tool_name.startswith("mcp_") or tool_name.startswith("mcp__"):
-            operation = tool_name.replace("mcp__", "").replace("mcp_", "")
-            key_actions.append(f"MCP {operation}")
-
-        else:
-            key_actions.append(f"Used {tool_name}")
-
-    key_actions = list(dict.fromkeys(key_actions)) if key_actions else ["No specific actions"]
-
-    for op_type in file_operations:
-        file_operations[op_type] = list(dict.fromkeys(file_operations[op_type]))
-
-    result_summary = (session.result[:200] + "...") if len(session.result) > 200 else session.result
-
-    return {
-        "tool_counts": tool_counts,
-        "tool_details": tool_details,
-        "file_operations": file_operations,
-        "key_actions": key_actions,
-        "total_tool_calls": sum(tool_counts.values()),
-        "result_summary": result_summary,
-        "usage_stats": {
-            "total_cost_usd": session.total_cost_usd,
-            "num_turns": session.num_turns,
-            "duration_ms": session.duration_ms,
-            **session.usage,
-        },
-    }
+CodexSession = CLISession
 
 
 # --------------------------------------------------------------------------- NDJSON stream
@@ -777,7 +659,7 @@ def _pp_tool_result(tr: dict[str, Any], theme: str = "light") -> None:
     print_readable(body, border=False, panel=False, theme=theme)
 
 
-def _pp_final(sess: CodexSession, theme: str = "light") -> None:
+def _pp_final(sess: CLISession, theme: str = "light") -> None:
     usage = sess.usage or {}
     cost_str = f"${sess.total_cost_usd:.4f}" if sess.total_cost_usd else "N/A"
     txt = (
@@ -796,22 +678,21 @@ def _pp_final(sess: CodexSession, theme: str = "light") -> None:
 
 async def stream_codex_cli(
     request: CodexCodeRequest,
-    session: CodexSession | None = None,
+    session: CLISession | None = None,
     *,
     on_text: Callable[[str], None] | None = None,
     on_tool_use: Callable[[dict[str, Any]], None] | None = None,
     on_tool_result: Callable[[dict[str, Any]], None] | None = None,
-    on_final: Callable[[CodexSession], None] | None = None,
-) -> AsyncIterator[CodexChunk | dict | CodexSession]:
-    """
-    Consume the JSONL stream from Codex CLI and return a populated
-    CodexSession.
+    on_final: Callable[[CLISession], None] | None = None,
+) -> AsyncIterator[StreamChunk | CLISession]:
+    """Consume the JSONL stream from Codex CLI, yield StreamChunks, and
+    populate a CodexSession accumulator.
 
-    Handles flexible event type names since Codex CLI output format
-    may vary.
+    Yields ``StreamChunk`` for every content-bearing event so the endpoint
+    can pass them straight through without conversion.
     """
     if session is None:
-        session = CodexSession()
+        session = CLISession()
     theme = request.cli_display_theme or "light"
     _start_monotonic = asyncio.get_running_loop().time()
 
@@ -819,8 +700,6 @@ async def stream_codex_cli(
     try:
         async for obj in stream:
             typ = obj.get("type", "unknown")
-            chunk = CodexChunk(raw=obj, type=typ)
-            session.chunks.append(chunk)
 
             # -- thread / session start --
             if typ in ("thread.started", "system", "init", "session.start"):
@@ -829,7 +708,9 @@ async def stream_codex_cli(
                     obj.get("session_id", obj.get("id")),
                 )
                 session.model = obj.get("model")
-                yield obj
+                sc = StreamChunk(type="system", metadata=obj)
+                session.chunks.append(sc)
+                yield sc
 
             # -- item.completed (agent_message, reasoning, tool calls) --
             elif typ == "item.completed":
@@ -838,12 +719,13 @@ async def stream_codex_cli(
 
                 if item_type == "agent_message":
                     text = item.get("text", "")
-                    chunk.text = text
                     session.messages.append(item)
                     await _maybe_await(on_text, text)
                     if request.verbose_output:
                         _pp_text(text, theme)
-                    yield chunk
+                    sc = StreamChunk(type="text", content=text, metadata=obj)
+                    session.chunks.append(sc)
+                    yield sc
 
                 elif item_type in ("function_call", "tool_call"):
                     tu = {
@@ -854,18 +736,21 @@ async def stream_codex_cli(
                             item.get("input", item.get("args", {})),
                         ),
                     }
-                    chunk.tool_use = tu
                     session.tool_uses.append(tu)
                     await _maybe_await(on_tool_use, tu)
                     if request.verbose_output:
                         _pp_tool_use(tu, theme)
-                    yield chunk
+                    sc = StreamChunk(
+                        type="tool_use",
+                        tool_name=tu["name"],
+                        tool_id=tu["id"],
+                        tool_input=tu["input"],
+                        metadata=obj,
+                    )
+                    session.chunks.append(sc)
+                    yield sc
 
                 elif item_type == "command_execution":
-                    # Codex CLI emits command_execution items with command +
-                    # aggregated_output + exit_code. Treat as a paired
-                    # tool_use + tool_result so downstream message routing
-                    # records both the request and the result.
                     item_id = item.get("id", "")
                     command = item.get("command", "")
                     output = item.get("aggregated_output", "")
@@ -874,51 +759,56 @@ async def stream_codex_cli(
                     is_error = status == "failed" or (exit_code is not None and exit_code != 0)
 
                     tu = {"id": item_id, "name": "Bash", "input": {"command": command}}
-                    chunk.tool_use = tu
                     session.tool_uses.append(tu)
                     await _maybe_await(on_tool_use, tu)
                     if request.verbose_output:
                         _pp_tool_use(tu, theme)
-                    yield chunk
+                    sc = StreamChunk(
+                        type="tool_use",
+                        tool_name="Bash",
+                        tool_id=item_id,
+                        tool_input={"command": command},
+                        metadata=obj,
+                    )
+                    session.chunks.append(sc)
+                    yield sc
 
-                    # Emit paired tool_result on a fresh chunk so the caller
-                    # always sees both halves of the exchange.
-                    result_chunk = CodexChunk(raw=obj, type=typ)
-                    tr = {
-                        "tool_use_id": item_id,
-                        "content": output,
-                        "is_error": is_error,
-                    }
-                    result_chunk.tool_result = tr
+                    tr = {"tool_use_id": item_id, "content": output, "is_error": is_error}
                     session.tool_results.append(tr)
-                    session.chunks.append(result_chunk)
                     await _maybe_await(on_tool_result, tr)
                     if request.verbose_output:
                         _pp_tool_result(tr, theme)
-                    yield result_chunk
+                    sc = StreamChunk(
+                        type="tool_result",
+                        tool_id=item_id,
+                        tool_output=output,
+                        is_error=is_error,
+                        metadata=obj,
+                    )
+                    session.chunks.append(sc)
+                    yield sc
 
                 elif item_type == "file_change":
-                    # Codex CLI emits file_change items with a `changes` list.
-                    # Surface each change as a single Edit tool call so the
-                    # branch records what files were touched.
                     item_id = item.get("id", "")
                     changes = item.get("changes", [])
                     status = item.get("status", "")
                     is_error = status == "failed"
 
-                    tu = {
-                        "id": item_id,
-                        "name": "Edit",
-                        "input": {"changes": changes},
-                    }
-                    chunk.tool_use = tu
+                    tu = {"id": item_id, "name": "Edit", "input": {"changes": changes}}
                     session.tool_uses.append(tu)
                     await _maybe_await(on_tool_use, tu)
                     if request.verbose_output:
                         _pp_tool_use(tu, theme)
-                    yield chunk
+                    sc = StreamChunk(
+                        type="tool_use",
+                        tool_name="Edit",
+                        tool_id=item_id,
+                        tool_input={"changes": changes},
+                        metadata=obj,
+                    )
+                    session.chunks.append(sc)
+                    yield sc
 
-                    result_chunk = CodexChunk(raw=obj, type=typ)
                     summary_parts = [
                         f"{c.get('kind', 'change')}: {c.get('path', '?')}"
                         for c in changes
@@ -929,13 +819,19 @@ async def stream_codex_cli(
                         "content": "; ".join(summary_parts) or status,
                         "is_error": is_error,
                     }
-                    result_chunk.tool_result = tr
                     session.tool_results.append(tr)
-                    session.chunks.append(result_chunk)
                     await _maybe_await(on_tool_result, tr)
                     if request.verbose_output:
                         _pp_tool_result(tr, theme)
-                    yield result_chunk
+                    sc = StreamChunk(
+                        type="tool_result",
+                        tool_id=item_id,
+                        tool_output=tr["content"],
+                        is_error=is_error,
+                        metadata=obj,
+                    )
+                    session.chunks.append(sc)
+                    yield sc
 
                 elif item_type == "function_call_output":
                     tr = {
@@ -943,18 +839,24 @@ async def stream_codex_cli(
                         "content": item.get("output", item.get("content", "")),
                         "is_error": item.get("is_error", False),
                     }
-                    chunk.tool_result = tr
                     session.tool_results.append(tr)
                     await _maybe_await(on_tool_result, tr)
                     if request.verbose_output:
                         _pp_tool_result(tr, theme)
-                    yield chunk
+                    sc = StreamChunk(
+                        type="tool_result",
+                        tool_id=tr["tool_use_id"],
+                        tool_output=tr["content"],
+                        is_error=tr["is_error"],
+                        metadata=obj,
+                    )
+                    session.chunks.append(sc)
+                    yield sc
 
                 elif item_type == "reasoning":
-                    yield chunk
-
-                else:
-                    yield chunk
+                    sc = StreamChunk(type="thinking", content=item.get("text"), metadata=obj)
+                    session.chunks.append(sc)
+                    yield sc
 
             # -- turn.completed (usage stats) --
             elif typ == "turn.completed":
@@ -971,6 +873,11 @@ async def stream_codex_cli(
                     if isinstance(err, dict)
                     else obj.get("message", str(err))
                 )
+                if request.verbose_output:
+                    log.error("Codex error: %s", session.result)
+                sc = StreamChunk(type="error", content=session.result, metadata=obj)
+                session.chunks.append(sc)
+                yield sc
 
             # -- legacy event types (older CLI versions) --
             elif typ in ("message", "assistant", "agent"):
@@ -979,41 +886,44 @@ async def stream_codex_cli(
 
                 content = msg.get("content", "")
                 if isinstance(content, str):
-                    chunk.text = content
                     await _maybe_await(on_text, content)
                     if request.verbose_output:
                         _pp_text(content, theme)
+                    sc = StreamChunk(type="text", content=content, metadata=obj)
+                    session.chunks.append(sc)
+                    yield sc
                 elif isinstance(content, list):
                     for blk in content:
-                        if isinstance(blk, dict):
-                            btype = blk.get("type")
-                            if btype == "text":
-                                text = blk.get("text", "")
-                                chunk.text = text
-                                await _maybe_await(on_text, text)
-                                if request.verbose_output:
-                                    _pp_text(text, theme)
-                            elif btype in (
-                                "tool_use",
-                                "function_call",
-                            ):
-                                tu = {
-                                    "id": blk.get("id", ""),
-                                    "name": blk.get(
-                                        "name",
-                                        blk.get("function", {}).get("name", ""),
-                                    ),
-                                    "input": blk.get(
-                                        "input",
-                                        blk.get("arguments", {}),
-                                    ),
-                                }
-                                chunk.tool_use = tu
-                                session.tool_uses.append(tu)
-                                await _maybe_await(on_tool_use, tu)
-                                if request.verbose_output:
-                                    _pp_tool_use(tu, theme)
-                yield chunk
+                        if not isinstance(blk, dict):
+                            continue
+                        btype = blk.get("type")
+                        if btype == "text":
+                            text = blk.get("text", "")
+                            await _maybe_await(on_text, text)
+                            if request.verbose_output:
+                                _pp_text(text, theme)
+                            sc = StreamChunk(type="text", content=text, metadata=obj)
+                            session.chunks.append(sc)
+                            yield sc
+                        elif btype in ("tool_use", "function_call"):
+                            tu = {
+                                "id": blk.get("id", ""),
+                                "name": blk.get("name", blk.get("function", {}).get("name", "")),
+                                "input": blk.get("input", blk.get("arguments", {})),
+                            }
+                            session.tool_uses.append(tu)
+                            await _maybe_await(on_tool_use, tu)
+                            if request.verbose_output:
+                                _pp_tool_use(tu, theme)
+                            sc = StreamChunk(
+                                type="tool_use",
+                                tool_name=tu["name"],
+                                tool_id=tu["id"],
+                                tool_input=tu["input"],
+                                metadata=obj,
+                            )
+                            session.chunks.append(sc)
+                            yield sc
 
             elif typ in ("result", "response", "session.end"):
                 session.result = obj.get(
@@ -1031,11 +941,8 @@ async def stream_codex_cli(
     finally:
         await stream.aclose()
 
-    # Reconstruct session.result from chunk texts when the CLI didn't emit a
-    # dedicated "response"/"result" event. CodexChunk has no delta flag, so all
-    # text chunks are treated as independent parts.
     if not session.result:
-        parts = [c.text for c in session.chunks if c.text is not None]
+        parts = [c.content for c in session.chunks if c.type == "text" and c.content]
         if parts:
             session.result = "\n".join(parts)
     if session.num_turns is None and session.messages:

--- a/lionagi/service/types/__init__.py
+++ b/lionagi/service/types/__init__.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
+from .cli_session import CLISession
 from .stream_chunk import StreamChunk
 
-__all__ = ("StreamChunk",)
+__all__ = ("CLISession", "StreamChunk")

--- a/lionagi/service/types/cli_session.py
+++ b/lionagi/service/types/cli_session.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from textwrap import shorten
+from typing import Any
+
+
+@dataclass
+class CLISession:
+    """Provider-agnostic accumulator for a CLI agent session.
+
+    Shared by claude_code and codex providers. Collects StreamChunks,
+    materialised tool-use/result views, and final summary stats.
+    """
+
+    session_id: str | None = None
+    model: str | None = None
+
+    # chronological log (StreamChunk instances)
+    chunks: list = field(default_factory=list)
+
+    # materialised views
+    thinking_log: list[str] = field(default_factory=list)
+    messages: list[dict[str, Any]] = field(default_factory=list)
+    tool_uses: list[dict[str, Any]] = field(default_factory=list)
+    tool_results: list[dict[str, Any]] = field(default_factory=list)
+
+    # final summary
+    result: str = ""
+    usage: dict[str, Any] = field(default_factory=dict)
+    total_cost_usd: float | None = None
+    num_turns: int | None = None
+    duration_ms: int | None = None
+    duration_api_ms: int | None = None
+    is_error: bool = False
+    summary: dict | None = None
+
+    def populate_summary(self) -> None:
+        self.summary = _extract_summary(self)
+
+
+def _extract_summary(session: CLISession) -> dict[str, Any]:
+    tool_counts: dict[str, int] = {}
+    tool_details: list[dict[str, Any]] = []
+    file_operations: dict[str, list[str]] = {"reads": [], "writes": [], "edits": []}
+    key_actions: list[str] = []
+
+    for tool_use in session.tool_uses:
+        tool_name = tool_use.get("name", "unknown")
+        tool_input = tool_use.get("input", {})
+        tool_id = tool_use.get("id", "")
+
+        tool_counts[tool_name] = tool_counts.get(tool_name, 0) + 1
+        tool_details.append({"tool": tool_name, "id": tool_id, "input": tool_input})
+
+        if tool_name in ("Read", "read", "read_file"):
+            file_path = tool_input.get("file_path", tool_input.get("path", "unknown"))
+            file_operations["reads"].append(file_path)
+            key_actions.append(f"Read {file_path}")
+
+        elif tool_name in ("Write", "write", "write_file", "create_file"):
+            file_path = tool_input.get("file_path", tool_input.get("path", "unknown"))
+            file_operations["writes"].append(file_path)
+            key_actions.append(f"Wrote {file_path}")
+
+        elif tool_name in ("Edit", "edit", "edit_file", "patch", "MultiEdit"):
+            file_path = tool_input.get("file_path", tool_input.get("path", "unknown"))
+            file_operations["edits"].append(file_path)
+            key_actions.append(f"Edited {file_path}")
+
+        elif tool_name in ("Bash", "bash", "shell", "terminal", "run_shell_command"):
+            command = tool_input.get("command", tool_input.get("cmd", ""))
+            key_actions.append(f"Ran: {shorten(command, 53)}")
+
+        elif tool_name in ("Glob", "glob"):
+            key_actions.append(f"Searched files: {tool_input.get('pattern', '')}")
+
+        elif tool_name in ("Grep", "grep"):
+            key_actions.append(f"Searched content: {tool_input.get('pattern', '')}")
+
+        elif tool_name in ("Task", "task", "Agent"):
+            key_actions.append(f"Spawned agent: {tool_input.get('description', '')}")
+
+        elif tool_name == "TodoWrite":
+            key_actions.append(f"Created {len(tool_input.get('todos', []))} todos")
+
+        elif tool_name.startswith("mcp__") or tool_name.startswith("mcp_"):
+            key_actions.append(f"MCP {tool_name.replace('mcp__', '').replace('mcp_', '')}")
+
+        else:
+            key_actions.append(f"Used {tool_name}")
+
+    key_actions = list(dict.fromkeys(key_actions)) if key_actions else ["No specific actions"]
+
+    for op_type in file_operations:
+        file_operations[op_type] = list(dict.fromkeys(file_operations[op_type]))
+
+    result_summary = (session.result[:200] + "...") if len(session.result) > 200 else session.result
+
+    return {
+        "tool_counts": tool_counts,
+        "tool_details": tool_details,
+        "file_operations": file_operations,
+        "key_actions": key_actions,
+        "total_tool_calls": sum(tool_counts.values()),
+        "result_summary": result_summary,
+        "usage_stats": {
+            "total_cost_usd": session.total_cost_usd,
+            "num_turns": session.num_turns,
+            "duration_ms": session.duration_ms,
+            "duration_api_ms": session.duration_api_ms,
+            **session.usage,
+        },
+    }

--- a/tests/providers/openai/codex/test_fast_mode.py
+++ b/tests/providers/openai/codex/test_fast_mode.py
@@ -5,7 +5,7 @@
 
 Tests verify that:
 1. fast_mode=False (default) emits no service_tier arg.
-2. fast_mode=True emits ``-c service_tier=flex`` in the command args.
+2. fast_mode=True emits ``-c service_tier=fast`` in the command args.
 3. fast_mode does NOT cap or remove reasoning_effort.
 4. Profile frontmatter ``fast_mode: true`` is parsed and propagated to
    CodexCodeRequest via build_imodel_from_spec (mocked iModel).
@@ -38,18 +38,17 @@ def test_fast_mode_default_false():
     assert "service_tier" not in " ".join(args)
 
 
-# ── 2. fast_mode=True emits service_tier=flex ────────────────────────────
+# ── 2. fast_mode=True emits service_tier=fast ────────────────────────────
 
 
 def test_fast_mode_true_emits_service_tier():
-    """fast_mode=True inserts -c service_tier=flex into CLI args."""
+    """fast_mode=True inserts -c service_tier=fast into CLI args."""
     req = CodexCodeRequest(prompt="hello", fast_mode=True)
     args = req.as_cmd_args()
-    # Should contain -c service_tier=flex as adjacent pair
     for i, arg in enumerate(args[:-1]):
-        if arg == "-c" and args[i + 1] == "service_tier=flex":
+        if arg == "-c" and args[i + 1] == "service_tier=fast":
             return
-    pytest.fail(f"service_tier=flex not found in args: {args}")
+    pytest.fail(f"service_tier=fast not found in args: {args}")
 
 
 # ── 3. fast_mode does NOT alter reasoning_effort ─────────────────────────
@@ -59,9 +58,9 @@ def test_fast_mode_preserves_reasoning_effort():
     """fast_mode=True does not cap or remove reasoning_effort."""
     req = CodexCodeRequest(prompt="hello", fast_mode=True, reasoning_effort="xhigh")
     args = req.as_cmd_args()
-    # Both service_tier=flex and reasoning_effort=xhigh must appear
+    # Both service_tier=fast and reasoning_effort=xhigh must appear
     flat = " ".join(args)
-    assert "service_tier=flex" in flat
+    assert "service_tier=fast" in flat
     assert "reasoning_effort=xhigh" in flat
 
 

--- a/tests/service/connections/providers/test_claude_code_cli.py
+++ b/tests/service/connections/providers/test_claude_code_cli.py
@@ -239,9 +239,7 @@ class TestPayloadCreation:
             "messages": [{"role": "user", "content": "Hello"}],
         }
 
-        payload, headers = endpoint.create_payload(
-            request, max_turns=5, auto_finish=True
-        )
+        payload, headers = endpoint.create_payload(request, max_turns=5, auto_finish=True)
 
         assert "request" in payload
         # ClaudeCodeRequest should have merged these
@@ -256,28 +254,13 @@ class TestStreamMethod:
         from lionagi.providers.anthropic.claude_code.endpoint import (
             ClaudeCodeCLIEndpoint,
         )
-        from lionagi.providers.anthropic.claude_code.models import ClaudeChunk
         from lionagi.service.types.stream_chunk import StreamChunk
 
         with patch(
             "lionagi.providers.anthropic.claude_code.endpoint.stream_claude_code_cli"
         ) as mock_stream:
-            chunk1 = ClaudeChunk(
-                raw={
-                    "type": "assistant",
-                    "message": {"content": [{"type": "text", "text": "hello"}]},
-                },
-                type="assistant",
-                text="hello",
-            )
-            chunk2 = ClaudeChunk(
-                raw={
-                    "type": "assistant",
-                    "message": {"content": [{"type": "text", "text": "world"}]},
-                },
-                type="assistant",
-                text="world",
-            )
+            chunk1 = StreamChunk(type="text", content="hello")
+            chunk2 = StreamChunk(type="text", content="world")
 
             async def async_gen(*args, **kwargs):
                 yield chunk1

--- a/uv.lock
+++ b/uv.lock
@@ -3046,7 +3046,7 @@ wheels = [
 
 [[package]]
 name = "lionagi"
-version = "0.26.14"
+version = "0.26.15"
 source = { editable = "." }
 dependencies = [
     { name = "aiocache" },


### PR DESCRIPTION
## Summary

- **Remove `ClaudeChunk`/`CodexChunk`**: both `stream_*_cli` functions now yield `StreamChunk` directly; endpoints become simple passthroughs instead of doing redundant type conversion
- **Replace `ClaudeSession`/`CodexSession`** with shared `CLISession` in `service/types/cli_session.py`; provider-level aliases kept for backward compat
- **Merge two duplicate `_extract_summary`** implementations into one unified version covering both providers' tool vocabularies
- **Fix codex silent error swallowing**: `turn.failed`/`error` events now yield `StreamChunk(type="error")` — previously the error was stored on the session but never surfaced to the caller, causing `li agent codex ...` to exit silently with no output
- **Fix codex `fast_mode`**: emit `service_tier=fast` (not `flex`, which the OpenAI API now rejects with 400)
- **Fix pre-existing UP038/S110 lint** in `claude_code/models.py`
- Net **-255 lines**

## Test plan

- [x] 7396 tests pass (0 failures)
- [x] `li agent codex/gpt-5.5-low "ping" -v` returns "pong" with verbose output
- [x] `ClaudeSession`/`CodexSession` aliases resolve to `CLISession`
- [x] `fast_mode=True` emits `service_tier=fast` in CLI args
- [x] Pre-commit hooks pass (ruff, format, markdownlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)