### PR TITLE
chore(lint): ruff format + mechanical lint cleanup (no behavior change)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-json
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.0
+    rev: v0.15.11
     hooks:
       - id: ruff-format
         exclude: '\.ipynb$'

--- a/apps/studio/frontend/README.md
+++ b/apps/studio/frontend/README.md
@@ -18,7 +18,7 @@ Talks to the Lion Studio backend at `process.env.NEXT_PUBLIC_STUDIO_API_BASE`
 | `/agents/[name]`         | Agent profile detail with frontmatter, body, and edit link.                                                    |
 | `/agents/[name]/edit`    | Edit an existing agent profile.                                                                                |
 | `/agents/new`            | Author a new agent profile.                                                                                    |
-| `/runs`                  | Runs table sourced from SQLite `sessions` (enriched as run summaries), with cost/duration/status filters.       |
+| `/runs`                  | Runs table sourced from SQLite `sessions` (enriched as run summaries), with cost/duration/status filters.      |
 | `/runs/[id]`             | Run detail with branch timelines, messages, API calls, DAG visualization, and live SSE stream for active runs. |
 
 ## Foundation

--- a/apps/studio/frontend/components/DeclarativePlaybookForm.tsx
+++ b/apps/studio/frontend/components/DeclarativePlaybookForm.tsx
@@ -75,7 +75,9 @@ export default function DeclarativePlaybookForm({
         </div>
 
         <div className="flex flex-col gap-1">
-          <label htmlFor="pb-description" className={FIELD_LABEL}>Description</label>
+          <label htmlFor="pb-description" className={FIELD_LABEL}>
+            Description
+          </label>
           <input
             id="pb-description"
             type="text"
@@ -87,7 +89,9 @@ export default function DeclarativePlaybookForm({
         </div>
 
         <div className="flex flex-col gap-1">
-          <label htmlFor="pb-arg-hint" className={FIELD_LABEL}>Argument hint</label>
+          <label htmlFor="pb-arg-hint" className={FIELD_LABEL}>
+            Argument hint
+          </label>
           <input
             id="pb-arg-hint"
             type="text"
@@ -111,7 +115,9 @@ export default function DeclarativePlaybookForm({
 
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
           <div className="flex flex-col gap-1">
-            <label htmlFor="pb-agent" className={FIELD_LABEL}>Agent</label>
+            <label htmlFor="pb-agent" className={FIELD_LABEL}>
+              Agent
+            </label>
             <input
               id="pb-agent"
               type="text"
@@ -123,7 +129,9 @@ export default function DeclarativePlaybookForm({
           </div>
 
           <div className="flex flex-col gap-1">
-            <label htmlFor="pb-effort" className={FIELD_LABEL}>Effort</label>
+            <label htmlFor="pb-effort" className={FIELD_LABEL}>
+              Effort
+            </label>
             <select
               id="pb-effort"
               value={form.effort}
@@ -139,7 +147,9 @@ export default function DeclarativePlaybookForm({
           </div>
 
           <div className="flex flex-col gap-1">
-            <label htmlFor="pb-max-ops" className={FIELD_LABEL}>Max ops</label>
+            <label htmlFor="pb-max-ops" className={FIELD_LABEL}>
+              Max ops
+            </label>
             <input
               id="pb-max-ops"
               type="number"

--- a/apps/studio/frontend/components/LinkEditor.tsx
+++ b/apps/studio/frontend/components/LinkEditor.tsx
@@ -165,7 +165,9 @@ function LinkCard({ link, index, stepNames, onUpdate, onDelete }: LinkCardProps)
       <div className="flex flex-wrap items-center gap-3">
         {/* From */}
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-          <label htmlFor={`link-${index}-from`} className="text-xs uppercase text-neutral-500">from</label>
+          <label htmlFor={`link-${index}-from`} className="text-xs uppercase text-neutral-500">
+            from
+          </label>
           <select
             id={`link-${index}-from`}
             value={link.from}
@@ -188,7 +190,9 @@ function LinkCard({ link, index, stepNames, onUpdate, onDelete }: LinkCardProps)
 
         {/* To */}
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-          <label htmlFor={`link-${index}-to`} className="text-xs uppercase text-neutral-500">to</label>
+          <label htmlFor={`link-${index}-to`} className="text-xs uppercase text-neutral-500">
+            to
+          </label>
           <select
             id={`link-${index}-to`}
             value={link.to}
@@ -245,7 +249,10 @@ function LinkCard({ link, index, stepNames, onUpdate, onDelete }: LinkCardProps)
         <div className="flex flex-col gap-3">
           {/* Condition */}
           <div className="flex flex-col gap-1">
-            <label htmlFor={`link-${index}-condition`} className="text-xs uppercase text-neutral-500">
+            <label
+              htmlFor={`link-${index}-condition`}
+              className="text-xs uppercase text-neutral-500"
+            >
               condition
               <span className="ml-1 normal-case text-neutral-600">(optional)</span>
             </label>
@@ -270,7 +277,9 @@ function LinkCard({ link, index, stepNames, onUpdate, onDelete }: LinkCardProps)
       {/* Code mode body */}
       {mode === "code" ? (
         <div className="flex flex-col gap-1">
-          <label htmlFor={`link-${index}-handler`} className="text-xs uppercase text-neutral-500">handler</label>
+          <label htmlFor={`link-${index}-handler`} className="text-xs uppercase text-neutral-500">
+            handler
+          </label>
           <textarea
             id={`link-${index}-handler`}
             value={link.handler ?? ""}

--- a/apps/studio/frontend/components/StepEditor.tsx
+++ b/apps/studio/frontend/components/StepEditor.tsx
@@ -128,7 +128,9 @@ function StepCard({
         <div className="mt-4 flex flex-col gap-3">
           {/* Role */}
           <div className="flex flex-col gap-1">
-            <label htmlFor={`${stepKey}-role`} className={LABEL_CLS}>Role</label>
+            <label htmlFor={`${stepKey}-role`} className={LABEL_CLS}>
+              Role
+            </label>
             {roles.length > 0 ? (
               <select
                 id={`${stepKey}-role`}
@@ -191,7 +193,9 @@ function StepCard({
 
           {/* Assignment */}
           <div className="flex flex-col gap-1">
-            <label htmlFor={`${stepKey}-assignment`} className={LABEL_CLS}>Assignment</label>
+            <label htmlFor={`${stepKey}-assignment`} className={LABEL_CLS}>
+              Assignment
+            </label>
             <input
               id={`${stepKey}-assignment`}
               type="text"
@@ -204,7 +208,9 @@ function StepCard({
 
           {/* Prompt template */}
           <div className="flex flex-col gap-1">
-            <label htmlFor={`${stepKey}-prompt`} className={LABEL_CLS}>Prompt Template</label>
+            <label htmlFor={`${stepKey}-prompt`} className={LABEL_CLS}>
+              Prompt Template
+            </label>
             <textarea
               id={`${stepKey}-prompt`}
               value={data.prompt}
@@ -220,7 +226,9 @@ function StepCard({
           {/* Capacity + Timeout row */}
           <div className="flex gap-3">
             <div className="flex flex-1 flex-col gap-1">
-              <label htmlFor={`${stepKey}-capacity`} className={LABEL_CLS}>Capacity</label>
+              <label htmlFor={`${stepKey}-capacity`} className={LABEL_CLS}>
+                Capacity
+              </label>
               <input
                 id={`${stepKey}-capacity`}
                 type="number"
@@ -235,7 +243,9 @@ function StepCard({
             </div>
 
             <div className="flex flex-1 flex-col gap-1">
-              <label htmlFor={`${stepKey}-timeout`} className={LABEL_CLS}>Timeout (s)</label>
+              <label htmlFor={`${stepKey}-timeout`} className={LABEL_CLS}>
+                Timeout (s)
+              </label>
               <input
                 id={`${stepKey}-timeout`}
                 type="number"

--- a/apps/studio/frontend/components/canvas/SidePanel.tsx
+++ b/apps/studio/frontend/components/canvas/SidePanel.tsx
@@ -1,7 +1,7 @@
 // TODO(#1020 follow-up): SidePanel form labels need htmlFor/id wiring.
 // Tracked as a Track 1 a11y follow-up — substantial refactor of label+input
 // pairs across this file.
-/* eslint-disable jsx-a11y/label-has-associated-control */
+
 "use client";
 
 import { useCallback } from "react";

--- a/apps/studio/frontend/components/outcomes/CIResultCard.tsx
+++ b/apps/studio/frontend/components/outcomes/CIResultCard.tsx
@@ -48,15 +48,8 @@ function CheckRow({
     <div className="flex items-center justify-between gap-3 py-1 text-body">
       <span className="text-content-primary">{label}</span>
       <span className="flex items-center gap-2">
-        {detail ? (
-          <span className="tabular-nums text-content-secondary">{detail}</span>
-        ) : null}
-        <span
-          className={
-            "tabular-nums " +
-            (passed ? "text-status-success" : "text-status-error")
-          }
-        >
+        {detail ? <span className="tabular-nums text-content-secondary">{detail}</span> : null}
+        <span className={"tabular-nums " + (passed ? "text-status-success" : "text-status-error")}>
           {passed ? "passed" : "failed"}
         </span>
       </span>
@@ -86,9 +79,7 @@ export default function CIResultCard({ name, content }: CIResultCardProps) {
       </header>
 
       {c.summary ? (
-        <div className="px-3 py-2 text-body text-content-secondary">
-          {c.summary}
-        </div>
+        <div className="px-3 py-2 text-body text-content-secondary">{c.summary}</div>
       ) : null}
 
       <section className="border-t border-edge px-3 py-2">
@@ -127,18 +118,12 @@ export default function CIResultCard({ name, content }: CIResultCardProps) {
           <ul className="space-y-1 text-body">
             {c.commands.map((cmd, i) => (
               <li key={i} className="flex items-center justify-between gap-3">
-                <span className="font-mono text-content-primary truncate">
-                  {cmd.command}
-                </span>
+                <span className="font-mono text-content-primary truncate">{cmd.command}</span>
                 <span className="flex items-center gap-2 shrink-0">
                   <span className="tabular-nums text-content-secondary">
                     {formatDuration(cmd.duration_seconds)}
                   </span>
-                  <span
-                    className={
-                      cmd.passed ? "text-status-success" : "text-status-error"
-                    }
-                  >
+                  <span className={cmd.passed ? "text-status-success" : "text-status-error"}>
                     {cmd.passed ? "✓" : "✕"}
                   </span>
                 </span>

--- a/apps/studio/frontend/components/outcomes/GateVerdictCard.tsx
+++ b/apps/studio/frontend/components/outcomes/GateVerdictCard.tsx
@@ -17,14 +17,10 @@ interface GateVerdictCardProps {
   content: Record<string, unknown>;
 }
 
-export default function GateVerdictCard({
-  name,
-  content,
-}: GateVerdictCardProps) {
+export default function GateVerdictCard({ name, content }: GateVerdictCardProps) {
   const c = content as unknown as GateVerdictContent;
   const passed = c.gate_passed ?? c.passed ?? null;
-  const verdictLabel =
-    passed === true ? "ACCEPT" : passed === false ? "REJECT" : "PENDING";
+  const verdictLabel = passed === true ? "ACCEPT" : passed === false ? "REJECT" : "PENDING";
 
   return (
     <div className="rounded border border-edge bg-surface-raised">
@@ -40,9 +36,7 @@ export default function GateVerdictCard({
       </header>
 
       {c.summary ? (
-        <div className="px-3 py-2 text-body text-content-secondary">
-          {c.summary}
-        </div>
+        <div className="px-3 py-2 text-body text-content-secondary">{c.summary}</div>
       ) : null}
 
       {c.feedback ? (
@@ -50,20 +44,14 @@ export default function GateVerdictCard({
           <div className="mb-1 text-meta uppercase tracking-[0.06em] text-content-muted">
             Feedback
           </div>
-          <div className="text-body text-content-primary whitespace-pre-wrap">
-            {c.feedback}
-          </div>
+          <div className="text-body text-content-primary whitespace-pre-wrap">{c.feedback}</div>
         </section>
       ) : null}
 
       {c.notes ? (
         <section className="border-t border-edge px-3 py-2">
-          <div className="mb-1 text-meta uppercase tracking-[0.06em] text-content-muted">
-            Notes
-          </div>
-          <div className="text-body text-content-secondary whitespace-pre-wrap">
-            {c.notes}
-          </div>
+          <div className="mb-1 text-meta uppercase tracking-[0.06em] text-content-muted">Notes</div>
+          <div className="text-body text-content-secondary whitespace-pre-wrap">{c.notes}</div>
         </section>
       ) : null}
     </div>

--- a/apps/studio/frontend/components/outcomes/OutcomeRenderer.tsx
+++ b/apps/studio/frontend/components/outcomes/OutcomeRenderer.tsx
@@ -16,25 +16,12 @@ export default function OutcomeRenderer({ artifact }: OutcomeRendererProps) {
   switch (artifact.kind) {
     case "review_verdict":
       return (
-        <ReviewVerdictCard
-          name={artifact.name}
-          content={content as Record<string, unknown>}
-        />
+        <ReviewVerdictCard name={artifact.name} content={content as Record<string, unknown>} />
       );
     case "gate_verdict":
-      return (
-        <GateVerdictCard
-          name={artifact.name}
-          content={content as Record<string, unknown>}
-        />
-      );
+      return <GateVerdictCard name={artifact.name} content={content as Record<string, unknown>} />;
     case "ci_result":
-      return (
-        <CIResultCard
-          name={artifact.name}
-          content={content as Record<string, unknown>}
-        />
-      );
+      return <CIResultCard name={artifact.name} content={content as Record<string, unknown>} />;
     default:
       return (
         <div className="rounded border border-edge bg-surface-raised p-3">
@@ -42,9 +29,7 @@ export default function OutcomeRenderer({ artifact }: OutcomeRendererProps) {
             <span>{artifact.kind}</span>
             <span className="font-mono">{artifact.id.slice(0, 8)}</span>
           </div>
-          <div className="mb-1 text-body text-content-primary">
-            {artifact.name}
-          </div>
+          <div className="mb-1 text-body text-content-primary">{artifact.name}</div>
           <pre className="overflow-x-auto rounded bg-surface-base p-2 text-meta font-mono text-content-secondary">
             {JSON.stringify(content, null, 2)}
           </pre>

--- a/apps/studio/frontend/components/outcomes/ReviewVerdictCard.tsx
+++ b/apps/studio/frontend/components/outcomes/ReviewVerdictCard.tsx
@@ -26,13 +26,7 @@ interface ReviewVerdictCardProps {
   content: Record<string, unknown>;
 }
 
-const SEVERITY_ORDER: Finding["severity"][] = [
-  "critical",
-  "high",
-  "medium",
-  "low",
-  "info",
-];
+const SEVERITY_ORDER: Finding["severity"][] = ["critical", "high", "medium", "low", "info"];
 const BLOCKING_SEVERITIES = new Set<Finding["severity"]>(["critical", "high"]);
 
 const SEVERITY_LABEL: Record<Finding["severity"], string> = {
@@ -43,10 +37,7 @@ const SEVERITY_LABEL: Record<Finding["severity"], string> = {
   info: "Info",
 };
 
-export default function ReviewVerdictCard({
-  name,
-  content,
-}: ReviewVerdictCardProps) {
+export default function ReviewVerdictCard({ name, content }: ReviewVerdictCardProps) {
   const c = content as unknown as ReviewVerdictContent;
   const verdict = c.verdict ?? "UNKNOWN";
   const findings = c.findings ?? [];
@@ -75,17 +66,13 @@ export default function ReviewVerdictCard({
           <StatusPill value={verdict} taxonomy="verdict" />
           <span className="text-body text-content-primary">{name}</span>
           {c.round != null ? (
-            <span className="text-meta text-content-muted">
-              round {c.round}
-            </span>
+            <span className="text-meta text-content-muted">round {c.round}</span>
           ) : null}
         </div>
       </header>
 
       {c.summary ? (
-        <div className="px-3 py-2 text-body text-content-secondary">
-          {c.summary}
-        </div>
+        <div className="px-3 py-2 text-body text-content-secondary">{c.summary}</div>
       ) : null}
 
       <div className="grid grid-cols-2 gap-3 border-t border-edge px-3 py-2">
@@ -97,17 +84,13 @@ export default function ReviewVerdictCard({
             {SEVERITY_ORDER.map((s) =>
               counts[s] > 0 ? (
                 <span key={s} className="tabular-nums">
-                  <span className="text-content-primary">
-                    {SEVERITY_LABEL[s]}
-                  </span>{" "}
+                  <span className="text-content-primary">{SEVERITY_LABEL[s]}</span>{" "}
                   <span className="text-content-secondary">{counts[s]}</span>
                 </span>
               ) : null,
             )}
             {findings.length === 0 ? (
-              <span className="text-meta text-content-muted">
-                no findings
-              </span>
+              <span className="text-meta text-content-muted">no findings</span>
             ) : null}
           </div>
         </div>
@@ -136,14 +119,15 @@ export default function ReviewVerdictCard({
           </div>
           <ul className="space-y-2">
             {blocking.map((f, i) => (
-              <li key={i} className="rounded border border-status-error/30 bg-status-error-bg/40 p-2">
+              <li
+                key={i}
+                className="rounded border border-status-error/30 bg-status-error-bg/40 p-2"
+              >
                 <div className="flex items-center gap-2">
                   <span className="rounded bg-status-error/10 px-1.5 py-0.5 text-meta uppercase tracking-wide text-status-error">
                     {SEVERITY_LABEL[f.severity]}
                   </span>
-                  <span className="text-body text-content-primary">
-                    {f.description}
-                  </span>
+                  <span className="text-body text-content-primary">{f.description}</span>
                 </div>
                 {f.file ? (
                   <div className="mt-1 font-mono text-meta text-content-muted">

--- a/benchmarks/ci_compare.py
+++ b/benchmarks/ci_compare.py
@@ -21,9 +21,7 @@ def compare(
     """
     lines = []
     norm_note = f" (normalized by {normalize_by})" if normalize_by else ""
-    lines.append(
-        f"Threshold: {threshold:.0%} (negative = faster, positive = slower){norm_note}"
-    )
+    lines.append(f"Threshold: {threshold:.0%} (negative = faster, positive = slower){norm_note}")
     ok = True
 
     cur_results = current.get("results", {})

--- a/benchmarks/comparisons/benchmark_professional.py
+++ b/benchmarks/comparisons/benchmark_professional.py
@@ -868,9 +868,7 @@ def feature_parity_matrix():
     )
     print("-" * 120)
     for r in rows:
-        print(
-            f"{r[0]:<16} {r[1]:<38} {r[2]:<10} {r[3]:<10} {r[4]:<8} {r[5]:<10} {r[6]}"
-        )
+        print(f"{r[0]:<16} {r[1]:<38} {r[2]:<10} {r[3]:<10} {r[4]:<8} {r[5]:<10} {r[6]}")
 
 
 def main():
@@ -1054,9 +1052,7 @@ def main():
 
             # Run the report generator with our files
             old_argv = sys.argv
-            sys.argv = [
-                "generate_benchmark_report.py"
-            ]  # Mock argv to avoid argparse conflicts
+            sys.argv = ["generate_benchmark_report.py"]  # Mock argv to avoid argparse conflicts
 
             report_args = ReportArgs(
                 summary=summary_csv,
@@ -1069,8 +1065,8 @@ def main():
             import argparse as ap_module
 
             old_parse_args = ap_module.ArgumentParser.parse_args
-            ap_module.ArgumentParser.parse_args = (
-                lambda self, args=None, namespace=None: report_args
+            ap_module.ArgumentParser.parse_args = lambda self, args=None, namespace=None: (
+                report_args
             )
 
             try:
@@ -1082,9 +1078,7 @@ def main():
 
         except ImportError:
             print("  ⚠️  Could not import generate_benchmark_report.py")
-            print(
-                "  ℹ️  Make sure generate_benchmark_report.py is in the same directory"
-            )
+            print("  ℹ️  Make sure generate_benchmark_report.py is in the same directory")
         except Exception as e:
             print(f"  ❌ Report generation failed: {e}")
 

--- a/benchmarks/comparisons/generate_benchmark_report.py
+++ b/benchmarks/comparisons/generate_benchmark_report.py
@@ -119,9 +119,7 @@ def md_table(headers, rows):
 
 def rank_block(rows, metric_key, lion_name):
     # Sort ascending (lower is better)
-    rows_sorted = sorted(
-        rows, key=lambda r: (r.get(metric_key, float("inf")), r["framework"])
-    )
+    rows_sorted = sorted(rows, key=lambda r: (r.get(metric_key, float("inf")), r["framework"]))
     if not rows_sorted:
         return rows_sorted, None, None
     best_val = rows_sorted[0].get(metric_key, float("inf"))
@@ -235,11 +233,7 @@ def build_composite(by_cat_mode, categories, modes):
     # Collect all frameworks present in the selected sections
     frameworks = set()
     for (cat, mode), sect in by_cat_mode.items():
-        if (
-            cat in categories
-            and mode in modes
-            and (cat, mode) not in EXCLUDE_FROM_COMPOSITE
-        ):
+        if cat in categories and mode in modes and (cat, mode) not in EXCLUDE_FROM_COMPOSITE:
             for r in sect:
                 frameworks.add(r["framework"])
 
@@ -263,12 +257,8 @@ def build_composite(by_cat_mode, categories, modes):
                 {
                     "framework": fw,
                     "gmean_ms": geomean(medians),
-                    "avg_rss_mb": (
-                        (sum(rss_vals) / len(rss_vals)) if rss_vals else float("nan")
-                    ),
-                    "avg_uss_mb": (
-                        (sum(uss_vals) / len(uss_vals)) if uss_vals else float("nan")
-                    ),
+                    "avg_rss_mb": ((sum(rss_vals) / len(rss_vals)) if rss_vals else float("nan")),
+                    "avg_uss_mb": ((sum(uss_vals) / len(uss_vals)) if uss_vals else float("nan")),
                     "n": n,
                 }
             )
@@ -317,9 +307,7 @@ def composite_section(out, by_cat_mode, title, categories, modes, lion_name):
 
 
 def main():
-    ap = argparse.ArgumentParser(
-        description="Generate benchmark report from CSV/JSON outputs"
-    )
+    ap = argparse.ArgumentParser(description="Generate benchmark report from CSV/JSON outputs")
     ap.add_argument(
         "--summary",
         required=False,
@@ -400,13 +388,9 @@ def main():
         if lion_pair and not math.isinf(best_val):
             lion_val, second_val = lion_pair
             if lion_val is not None and second_val is not None:
-                adv = percent_delta(
-                    second_val, lion_val
-                )  # how much slower #2 is vs lion
+                adv = percent_delta(second_val, lion_val)  # how much slower #2 is vs lion
                 if adv > -1e-9:  # #2 >= lion
-                    out.append(
-                        f"> **LionAGI advantage:** median {adv:+.1f}% vs #2 in this table."
-                    )
+                    out.append(f"> **LionAGI advantage:** median {adv:+.1f}% vs #2 in this table.")
                     out.append("")
 
         # Flag tiny-baseline sections (e.g., imports ~0.1 ms)
@@ -483,17 +467,13 @@ def main():
     # Feature parity (fixed)
     out.append("## Feature Parity Matrix")
     out.append("")
-    out.append(
-        "This matrix demonstrates the equivalence of test cases across frameworks:"
-    )
+    out.append("This matrix demonstrates the equivalence of test cases across frameworks:")
     out.append("")
     out.append(feature_parity_section())
     out.append("")
     out.append("### Documentation Sources")
     out.append("")
-    out.append(
-        "The benchmark design follows official documentation from each framework:"
-    )
+    out.append("The benchmark design follows official documentation from each framework:")
     out.append("")
     out.append(
         "- **LangGraph**: [Graph API & compile()](https://langchain-ai.github.io/langgraph/reference/graphs/)"
@@ -514,16 +494,10 @@ def main():
     out.append("## Methodology")
     out.append("")
     out.append("### Measurement Approach")
-    out.append(
-        "- **Cold Mode**: Full import + object construction (serverless scenario)"
-    )
-    out.append(
-        "- **Construct Mode**: Object construction only (post-import, per-request cost)"
-    )
+    out.append("- **Cold Mode**: Full import + object construction (serverless scenario)")
+    out.append("- **Construct Mode**: Object construction only (post-import, per-request cost)")
     out.append("- **Memory**: RSS (Resident Set Size) and USS (Unique Set Size) deltas")
-    out.append(
-        "- **Statistics**: Median, P95, MAD, trimmed mean for robustness against outliers"
-    )
+    out.append("- **Statistics**: Median, P95, MAD, trimmed mean for robustness against outliers")
     out.append("")
     out.append("### Environmental Controls")
     out.append("- CPU pinning for reduced scheduler noise")

--- a/benchmarks/concurrency_bench.py
+++ b/benchmarks/concurrency_bench.py
@@ -50,9 +50,7 @@ async def _bench_once(fn: Callable[[], Coroutine[Any, Any, Any]]) -> float:
     return time.perf_counter() - t0
 
 
-async def _bench_repeat(
-    name: str, repeat: int, fn: Callable[[], Coroutine[Any, Any, Any]]
-) -> Stat:
+async def _bench_repeat(name: str, repeat: int, fn: Callable[[], Coroutine[Any, Any, Any]]) -> Stat:
     runs = []
     for _ in range(repeat):
         runs.append(await _bench_once(fn))
@@ -84,9 +82,7 @@ def scenario_bounded_map_2000_limit_100() -> Callable[[], Coroutine[Any, Any, An
     return _run
 
 
-def scenario_completion_stream_1000_limit_100() -> (
-    Callable[[], Coroutine[Any, Any, Any]]
-):
+def scenario_completion_stream_1000_limit_100() -> Callable[[], Coroutine[Any, Any, Any]]:
     async def _run():
         async def work(i: int):
             await anyio.sleep(0)
@@ -202,9 +198,7 @@ def compare_results(current: dict[str, Any], baseline: dict[str, Any]) -> str:
             delta = float("inf")
         else:
             delta = (cur_med - base_med) / base_med
-        lines.append(
-            f"- {name}: median {cur_med:.6f}s vs {base_med:.6f}s -> {delta:+.1%}"
-        )
+        lines.append(f"- {name}: median {cur_med:.6f}s vs {base_med:.6f}s -> {delta:+.1%}")
     return "\n".join(lines)
 
 

--- a/benchmarks/fuzzy_bench.py
+++ b/benchmarks/fuzzy_bench.py
@@ -239,9 +239,7 @@ def compare_results(current: dict[str, Any], baseline: dict[str, Any]) -> str:
             delta = float("inf")
         else:
             delta = (cur_med - base_med) / base_med
-        lines.append(
-            f"- {name}: median {cur_med:.6f}s vs {base_med:.6f}s -> {delta:+.1%}"
-        )
+        lines.append(f"- {name}: median {cur_med:.6f}s vs {base_med:.6f}s -> {delta:+.1%}")
     return "\n".join(lines)
 
 

--- a/benchmarks/ln_bench.py
+++ b/benchmarks/ln_bench.py
@@ -46,9 +46,7 @@ async def _bench_once(fn: Callable[[], Coroutine[Any, Any, Any]]) -> float:
     return time.perf_counter() - t0
 
 
-async def _bench_repeat(
-    name: str, repeat: int, fn: Callable[[], Coroutine[Any, Any, Any]]
-) -> Stat:
+async def _bench_repeat(name: str, repeat: int, fn: Callable[[], Coroutine[Any, Any, Any]]) -> Stat:
     runs = []
     for _ in range(repeat):
         runs.append(await _bench_once(fn))
@@ -58,9 +56,7 @@ async def _bench_repeat(
 # --- Scenario implementations ---
 
 
-def scenario_alcall_async_noop_1000_conc_100() -> (
-    Callable[[], Coroutine[Any, Any, Any]]
-):
+def scenario_alcall_async_noop_1000_conc_100() -> Callable[[], Coroutine[Any, Any, Any]]:
     async def _run():
         async def noop(x):
             await anyio.sleep(0)
@@ -107,16 +103,10 @@ def scenario_to_list_flatten_nested_10000() -> Callable[[], Coroutine[Any, Any, 
     return _run
 
 
-def scenario_to_list_flatten_unique_2000_mixed() -> (
-    Callable[[], Coroutine[Any, Any, Any]]
-):
+def scenario_to_list_flatten_unique_2000_mixed() -> Callable[[], Coroutine[Any, Any, Any]]:
     async def _run():
         mixed = [
-            (
-                {"a": i, "b": i % 5}
-                if i % 3 == 0
-                else (i, i % 7) if i % 3 == 1 else [i, i]
-            )
+            ({"a": i, "b": i % 5} if i % 3 == 0 else (i, i % 7) if i % 3 == 1 else [i, i])
             for i in range(2000)
         ]
         to_list(
@@ -135,9 +125,7 @@ def scenario_hash_dict_complex_1000() -> Callable[[], Coroutine[Any, Any, Any]]:
         obj = {
             "ints": list(range(50)),
             "floats": [i / 10 for i in range(50)],
-            "nested": {
-                f"k{i}": {"v": i, "arr": list(range(i % 10))} for i in range(50)
-            },
+            "nested": {f"k{i}": {"v": i, "arr": list(range(i % 10))} for i in range(50)},
             "mix": [{"i": i, "t": (i, str(i))} for i in range(50)],
         }
         for _ in range(1000):
@@ -151,8 +139,7 @@ def scenario_json_dumps_medium_1000() -> Callable[[], Coroutine[Any, Any, Any]]:
         obj = {
             "name": "benchmark",
             "items": [
-                {"id": i, "text": f"item-{i}", "values": list(range(10))}
-                for i in range(200)
+                {"id": i, "text": f"item-{i}", "values": list(range(10))} for i in range(200)
             ],
             "flags": {"a": True, "b": False, "n": None},
         }
@@ -223,9 +210,7 @@ def compare_results(current: dict[str, Any], baseline: dict[str, Any]) -> str:
             delta = float("inf")
         else:
             delta = (cur_med - base_med) / base_med
-        lines.append(
-            f"- {name}: median {cur_med:.6f}s vs {base_med:.6f}s -> {delta:+.1%}"
-        )
+        lines.append(f"- {name}: median {cur_med:.6f}s vs {base_med:.6f}s -> {delta:+.1%}")
     return "\n".join(lines)
 
 

--- a/cookbooks/007_fan_out_in.py
+++ b/cookbooks/007_fan_out_in.py
@@ -72,9 +72,7 @@ async def main():
 
         result = await session.flow(builder.get_graph())
 
-        instruct_model: list[Instruct] = result["operation_results"][
-            root
-        ].instruct_model
+        instruct_model: list[Instruct] = result["operation_results"][root].instruct_model
         research_nodes = []
 
         for i in instruct_model:
@@ -118,9 +116,7 @@ async def main():
         result3 = await session.flow(builder.get_graph())
         result_synthesis = result3["operation_results"][synthesis]
 
-        builder.visualize(
-            "LionAGI codebase investigation: fan-out fan-in pattern with Claude Code"
-        )
+        builder.visualize("LionAGI codebase investigation: fan-out fan-in pattern with Claude Code")
 
         print(f"Flow total cost: ${costs:.4f}")
 

--- a/examples/coding_agent.py
+++ b/examples/coding_agent.py
@@ -50,8 +50,7 @@ async def basic_coding_agent() -> None:
 
     budget = branch.token_budget
     print(
-        f"Token budget — used: {budget.used}, limit: {budget.limit}, "
-        f"usage: {budget.usage_pct:.1%}"
+        f"Token budget — used: {budget.used}, limit: {budget.limit}, usage: {budget.usage_pct:.1%}"
     )
 
     # With a model configured, the branch is ready for:
@@ -170,9 +169,7 @@ async def context_management() -> None:
 
     # Evict all but the last 3 ActionResponse messages.
     keep = 3
-    ar_uids = [
-        uid for uid in cp if uid in pile and isinstance(pile[uid], ActionResponse)
-    ]
+    ar_uids = [uid for uid in cp if uid in pile and isinstance(pile[uid], ActionResponse)]
     to_evict = ar_uids[:-keep] if keep > 0 else ar_uids
     cp.exclude(to_evict)
 
@@ -428,10 +425,7 @@ async def token_budget_awareness() -> None:
     print("=== Initial state ===")
     b = branch.token_budget
     print(f"  used={b.used}  limit={b.limit}  remaining={b.remaining}")
-    print(
-        f"  usage_pct={b.usage_pct:.1%}  "
-        f"is_warning={b.is_warning}  is_critical={b.is_critical}"
-    )
+    print(f"  usage_pct={b.usage_pct:.1%}  is_warning={b.is_warning}  is_critical={b.is_critical}")
 
     # Simulate filling context with bulky search results.
     pile = branch.msgs.messages

--- a/lionagi/cli/_logging.py
+++ b/lionagi/cli/_logging.py
@@ -88,9 +88,7 @@ class _LazyStderrHandler(logging.StreamHandler):
         super().emit(record)
 
 
-def _setup_channel(
-    name: str, level: int, formatter: logging.Formatter
-) -> logging.Logger:
+def _setup_channel(name: str, level: int, formatter: logging.Formatter) -> logging.Logger:
     logger = logging.getLogger(name)
     logger.setLevel(level)
     logger.propagate = False

--- a/lionagi/cli/invoke.py
+++ b/lionagi/cli/invoke.py
@@ -57,9 +57,7 @@ async def _start_invocation(
     return inv_id
 
 
-async def _end_invocation(
-    invocation_id: str, *, status: str, metadata: dict | None
-) -> dict | None:
+async def _end_invocation(invocation_id: str, *, status: str, metadata: dict | None) -> dict | None:
     from lionagi.state.db import StateDB
 
     async with StateDB() as db:
@@ -81,9 +79,7 @@ async def _end_invocation(
         return await db.get_invocation(invocation_id)
 
 
-async def _list_invocations(
-    *, skill: str | None, status: str | None, limit: int
-) -> list[dict]:
+async def _list_invocations(*, skill: str | None, status: str | None, limit: int) -> list[dict]:
     from lionagi.state.db import StateDB
 
     async with StateDB() as db:
@@ -105,9 +101,7 @@ def add_invoke_subparser(subparsers: argparse._SubParsersAction) -> None:
     )
     inv_sub = invoke.add_subparsers(dest="invoke_command", required=True)
 
-    start = inv_sub.add_parser(
-        "start", help="Open a new invocation. Prints the id to stdout."
-    )
+    start = inv_sub.add_parser("start", help="Open a new invocation. Prints the id to stdout.")
     start.add_argument(
         "--skill",
         required=True,
@@ -138,7 +132,11 @@ def add_invoke_subparser(subparsers: argparse._SubParsersAction) -> None:
         "--status",
         default="completed",
         choices=[
-            "completed", "failed", "timed_out", "aborted", "cancelled",
+            "completed",
+            "failed",
+            "timed_out",
+            "aborted",
+            "cancelled",
         ],
         help="Terminal status (ADR-0025 vocabulary).",
     )
@@ -150,12 +148,8 @@ def add_invoke_subparser(subparsers: argparse._SubParsersAction) -> None:
 
     ls = inv_sub.add_parser("list", help="List recent invocations.")
     ls.add_argument("--skill", default=None, help="Filter by skill name.")
-    ls.add_argument(
-        "--status", default=None, help="Filter by status (one of the 6 values)."
-    )
-    ls.add_argument(
-        "--limit", type=int, default=20, help="Max rows to print (default 20)."
-    )
+    ls.add_argument("--status", default=None, help="Filter by status (one of the 6 values).")
+    ls.add_argument("--limit", type=int, default=20, help="Max rows to print (default 20).")
 
 
 def _parse_metadata(raw: str | None) -> dict | None:
@@ -199,33 +193,23 @@ def run_invoke(args: argparse.Namespace) -> int:
             log_error(str(exc))
             return 1
         result = run_async(
-            _end_invocation(
-                args.invocation_id, status=args.status, metadata=metadata
-            )
+            _end_invocation(args.invocation_id, status=args.status, metadata=metadata)
         )
         if result is None:
             log_error(f"invocation not found: {args.invocation_id}")
             return 1
-        print(
-            f"{args.invocation_id}: {result['status']} "
-            f"({result['session_count']} session(s))"
-        )
+        print(f"{args.invocation_id}: {result['status']} ({result['session_count']} session(s))")
         return 0
 
     if args.invoke_command == "list":
-        rows = run_async(
-            _list_invocations(
-                skill=args.skill, status=args.status, limit=args.limit
-            )
-        )
+        rows = run_async(_list_invocations(skill=args.skill, status=args.status, limit=args.limit))
         if not rows:
             print("(no invocations)", file=sys.stderr)
             return 0
         for r in rows:
             prompt = (r.get("prompt") or "").replace("\n", " ")[:60]
             print(
-                f"{r['id']}  {r['skill']:<20}  {r['status']:<10}  "
-                f"{r['session_count']:>3}  {prompt}"
+                f"{r['id']}  {r['skill']:<20}  {r['status']:<10}  {r['session_count']:>3}  {prompt}"
             )
         return 0
 

--- a/lionagi/cli/skill.py
+++ b/lionagi/cli/skill.py
@@ -60,7 +60,7 @@ def resolve_skill_path(name: str) -> tuple[Path | None, str | None]:
     except (OSError, ValueError):
         return (
             None,
-            f"skill {name!r} resolves outside skills root " "(symlink escape blocked)",
+            f"skill {name!r} resolves outside skills root (symlink escape blocked)",
         )
     return candidate, None
 

--- a/lionagi/cli/state.py
+++ b/lionagi/cli/state.py
@@ -275,9 +275,7 @@ async def _import_one_run(
             continue
 
         branch_id = branch_data.get("id") or branch_file.stem
-        branch_created_at = branch_data.get("created_at") or _mtime_as_float(
-            branch_file
-        )
+        branch_created_at = branch_data.get("created_at") or _mtime_as_float(branch_file)
 
         # Extract messages and ordering from Pile format.
         messages_pile = branch_data.get("messages", {})
@@ -356,9 +354,7 @@ async def _import_one_run(
             last_msg_id=session_msg_ids[-1],
         )
 
-    print(
-        f"  imported {run_id}: {total_branches} branch(es), {total_messages} message(s)"
-    )
+    print(f"  imported {run_id}: {total_branches} branch(es), {total_messages} message(s)")
     return 1, total_branches, total_messages
 
 
@@ -396,9 +392,7 @@ async def _import_teams() -> dict[str, int]:
                 continue
 
             # Idempotency: check before inserting.
-            cur = await db.db.execute(
-                "SELECT 1 FROM teams WHERE id = ? LIMIT 1", (team_id,)
-            )
+            cur = await db.db.execute("SELECT 1 FROM teams WHERE id = ? LIMIT 1", (team_id,))
             if await cur.fetchone() is not None:
                 counts["skipped_teams"] += 1
                 continue
@@ -512,9 +506,7 @@ async def _list_sessions(*, limit: int = 50, status: str | None = None) -> None:
             sstat = (row["status"] or "")[:10]
             updated = row["updated_at"]
             updated_str = (
-                time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(updated))
-                if updated
-                else ""
+                time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(updated)) if updated else ""
             )
 
             branch_cur = await db.db.execute(
@@ -531,10 +523,7 @@ async def _list_sessions(*, limit: int = 50, status: str | None = None) -> None:
                 prog_data = await db.get_progression(prog_row["progression_id"])
                 msg_count = len(prog_data)
 
-            print(
-                f"{sid:<36}  {name:<16}  {sstat:<10}  "
-                f"{bc:>8}  {msg_count:>8}  {updated_str:<20}"
-            )
+            print(f"{sid:<36}  {name:<16}  {sstat:<10}  {bc:>8}  {msg_count:>8}  {updated_str:<20}")
 
 
 # ── Maintenance commands: stats / checkpoint / vacuum / prune ───────────────
@@ -738,9 +727,7 @@ async def _doctor(
     cutoff = _time.time() - (stale_hours * 3600)
 
     async with StateDB() as db:
-        cur = await db.db.execute(
-            "SELECT id, started_at FROM sessions WHERE status = 'running'"
-        )
+        cur = await db.db.execute("SELECT id, started_at FROM sessions WHERE status = 'running'")
         rows = await cur.fetchall()
         total = len(rows)
         victims: list[str] = []

--- a/lionagi/cli/team.py
+++ b/lionagi/cli/team.py
@@ -137,9 +137,7 @@ def cmd_create(args: argparse.Namespace) -> int:
 
 def cmd_list(args: argparse.Namespace) -> int:
     teams_dir = _teams_dir()
-    files = sorted(
-        teams_dir.glob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True
-    )
+    files = sorted(teams_dir.glob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True)
     if not files:
         print("No teams.")
         return 0

--- a/lionagi/libs/file/chunk.py
+++ b/lionagi/libs/file/chunk.py
@@ -37,16 +37,12 @@ def chunk_by_chars(
         elif n_chunks == 2:
             return _chunk_two_parts(text, chunk_size, overlap_size, threshold)
         else:
-            return _chunk_multiple_parts(
-                text, chunk_size, overlap_size, n_chunks, threshold
-            )
+            return _chunk_multiple_parts(text, chunk_size, overlap_size, n_chunks, threshold)
     except Exception as e:
         raise ValueError(f"An error occurred while chunking the text: {e}") from e
 
 
-def _chunk_two_parts(
-    text: str, chunk_size: int, overlap_size: int, threshold: int
-) -> list[str]:
+def _chunk_two_parts(text: str, chunk_size: int, overlap_size: int, threshold: int) -> list[str]:
     """Handle chunking for two parts."""
     first_chunk = text[: chunk_size + overlap_size]
     if len(text) - chunk_size > threshold:
@@ -136,9 +132,7 @@ def chunk_by_tokens(
         raise ValueError(f"An error occurred while chunking the tokens: {e}") from e
 
 
-def _process_single_chunk(
-    tokens: list[str], return_tokens: bool
-) -> list[str | list[str]]:
+def _process_single_chunk(tokens: list[str], return_tokens: bool) -> list[str | list[str]]:
     """Handle processing for a single chunk."""
     return [tokens] if return_tokens else [" ".join(tokens).strip()]
 
@@ -187,9 +181,7 @@ def _chunk_token_multiple_parts(
     return _format_chunks(chunks, return_tokens)
 
 
-def _format_chunks(
-    chunks: list[list[str]], return_tokens: bool
-) -> list[str | list[str]]:
+def _format_chunks(chunks: list[list[str]], return_tokens: bool) -> list[str | list[str]]:
     """Format chunks based on the return_tokens flag."""
     return chunks if return_tokens else [" ".join(chunk).strip() for chunk in chunks]
 

--- a/lionagi/libs/schema/as_readable.py
+++ b/lionagi/libs/schema/as_readable.py
@@ -12,12 +12,9 @@ try:
     from rich.align import Align
     from rich.box import MINIMAL, ROUNDED
     from rich.console import Console
-    from rich.markdown import Markdown
     from rich.padding import Padding
     from rich.panel import Panel
-    from rich.style import Style
     from rich.syntax import Syntax
-    from rich.text import Text
     from rich.theme import Theme
 
     DARK_THEME = Theme(

--- a/lionagi/libs/schema/breakdown_pydantic_annotation.py
+++ b/lionagi/libs/schema/breakdown_pydantic_annotation.py
@@ -23,9 +23,7 @@ def breakdown_pydantic_annotation(
         elif origin is list:
             args = get_args(v)
             if args and _is_pydantic_model(args[0]):
-                out[k] = [
-                    breakdown_pydantic_annotation(args[0], max_depth, current_depth + 1)
-                ]
+                out[k] = [breakdown_pydantic_annotation(args[0], max_depth, current_depth + 1)]
             else:
                 out[k] = [args[0] if args else Any]
         else:

--- a/lionagi/libs/schema/extract_docstring.py
+++ b/lionagi/libs/schema/extract_docstring.py
@@ -46,9 +46,7 @@ def extract_docstring(
     elif style == "rest":
         func_description, params_description = _extract_docstring_details_rest(func)
     else:
-        raise ValueError(
-            f'{style} is not supported. Please choose either "google" or "reST".'
-        )
+        raise ValueError(f'{style} is not supported. Please choose either "google" or "reST".')
     return func_description, params_description
 
 

--- a/lionagi/libs/schema/function_to_schema.py
+++ b/lionagi/libs/schema/function_to_schema.py
@@ -134,9 +134,7 @@ def function_to_schema(
             # Default type to string and update if type hint is available
             param_type = "string"
             if param.annotation is not inspect.Parameter.empty:
-                param_type = py_json_msp.get(
-                    param.annotation.__name__, param.annotation.__name__
-                )
+                param_type = py_json_msp.get(param.annotation.__name__, param.annotation.__name__)
             # Extract parameter description from docstring, if available
             param_description = parametert_description.get(name)
 

--- a/lionagi/libs/validate/common_field_validators.py
+++ b/lionagi/libs/validate/common_field_validators.py
@@ -60,9 +60,7 @@ def validate_same_dtype_flat_list(
     return value
 
 
-def validate_nullable_string_field(
-    cls, value, field_name: str = None, strict=True
-) -> str | None:
+def validate_nullable_string_field(cls, value, field_name: str = None, strict=True) -> str | None:
     """Validate nullable string field.
 
     Args:
@@ -107,9 +105,7 @@ def validate_dict_kwargs_params(cls, value) -> dict:
     return value
 
 
-def validate_callable(
-    cls, value, undefind_able: bool = True, check_name: bool = False
-) -> callable:
+def validate_callable(cls, value, undefind_able: bool = True, check_name: bool = False) -> callable:
     """Validate strict callable function.
 
     Args:

--- a/lionagi/ln/_list_call.py
+++ b/lionagi/ln/_list_call.py
@@ -42,15 +42,11 @@ def lcall(
                 raise ValueError("func must contain exactly one callable function.")
             func = func_list[0]
         except TypeError as e:
-            raise ValueError(
-                "func must be callable or iterable with one callable."
-            ) from e
+            raise ValueError("func must be callable or iterable with one callable.") from e
 
     # Validate output processing options
     if output_unique and not (output_flatten or output_dropna):
-        raise ValueError(
-            "unique_output requires flatten or dropna for post-processing."
-        )
+        raise ValueError("unique_output requires flatten or dropna for post-processing.")
 
     # Process input based on sanitization flag
     if input_flatten or input_dropna:

--- a/lionagi/ln/_to_list.py
+++ b/lionagi/ln/_to_list.py
@@ -133,11 +133,7 @@ def to_list(
             return list(input_) if use_values else [input_]
 
         if isinstance(input_, Mapping):
-            return (
-                list(input_.values())
-                if use_values and hasattr(input_, "values")
-                else [input_]
-            )
+            return list(input_.values()) if use_values and hasattr(input_, "values") else [input_]
 
         if isinstance(input_, _MODEL_LIKE):
             return [input_]
@@ -152,9 +148,7 @@ def to_list(
 
     initial_list = _to_list_type(input_, use_values=use_values)
     skip_types: tuple[type, ...] = _SKIP_TYPE if flatten_tuple_set else _SKIP_TUPLE_SET
-    processed = _process_list(
-        initial_list, flatten=flatten, dropna=dropna, skip_types=skip_types
-    )
+    processed = _process_list(initial_list, flatten=flatten, dropna=dropna, skip_types=skip_types)
 
     if unique:
         seen = set()

--- a/lionagi/ln/concurrency/resource_tracker.py
+++ b/lionagi/ln/concurrency/resource_tracker.py
@@ -31,9 +31,7 @@ class LeakTracker:
         self._lock = threading.Lock()
 
     def track(self, obj: object, *, name: str | None, kind: str | None) -> None:
-        info = LeakInfo(
-            name=name or f"obj-{id(obj)}", kind=kind, created_at=time.time()
-        )
+        info = LeakInfo(name=name or f"obj-{id(obj)}", kind=kind, created_at=time.time())
         key = id(obj)
 
         def _finalizer(_key: int = key) -> None:
@@ -60,9 +58,7 @@ class LeakTracker:
 _TRACKER = LeakTracker()
 
 
-def track_resource(
-    obj: object, name: str | None = None, kind: str | None = None
-) -> None:
+def track_resource(obj: object, name: str | None = None, kind: str | None = None) -> None:
     _TRACKER.track(obj, name=name, kind=kind)
 
 

--- a/lionagi/ln/fuzzy/_fuzzy_validate.py
+++ b/lionagi/ln/fuzzy/_fuzzy_validate.py
@@ -27,26 +27,18 @@ def fuzzy_validate_pydantic(
     try:
         model_data = extract_json(text, fuzzy_parse=fuzzy_parse)
     except Exception as e:
-        raise ValidationError(
-            f"Failed to extract valid JSON from model response: {e}"
-        ) from e
+        raise ValidationError(f"Failed to extract valid JSON from model response: {e}") from e
 
     d = model_data
     if fuzzy_match:
         if fuzzy_match_params is None:
-            model_data = fuzzy_match_keys(
-                d, model_type.model_fields, handle_unmatched="remove"
-            )
+            model_data = fuzzy_match_keys(d, model_type.model_fields, handle_unmatched="remove")
         elif isinstance(fuzzy_match_params, dict):
-            model_data = fuzzy_match_keys(
-                d, model_type.model_fields, **fuzzy_match_params
-            )
+            model_data = fuzzy_match_keys(d, model_type.model_fields, **fuzzy_match_params)
         elif isinstance(fuzzy_match_params, FuzzyMatchKeysParams):
             model_data = fuzzy_match_params(d, model_type.model_fields)
         else:
-            raise TypeError(
-                "fuzzy_keys_params must be a dict or FuzzyMatchKeysParams instance"
-            )
+            raise TypeError("fuzzy_keys_params must be a dict or FuzzyMatchKeysParams instance")
 
     try:
         return model_type.model_validate(model_data)
@@ -107,28 +99,18 @@ def fuzzy_validate_mapping(
     try:
         if isinstance(d, str):
             try:
-                json_result = extract_json(
-                    d, fuzzy_parse=True, return_one_if_single=True
-                )
-                dict_input = (
-                    json_result[0] if isinstance(json_result, list) else json_result
-                )
+                json_result = extract_json(d, fuzzy_parse=True, return_one_if_single=True)
+                dict_input = json_result[0] if isinstance(json_result, list) else json_result
             except Exception:
-                dict_input = to_dict(
-                    d, str_type="json", fuzzy_parse=True, suppress=True
-                )
+                dict_input = to_dict(d, str_type="json", fuzzy_parse=True, suppress=True)
         else:
-            dict_input = to_dict(
-                d, use_model_dump=True, fuzzy_parse=True, suppress=True
-            )
+            dict_input = to_dict(d, use_model_dump=True, fuzzy_parse=True, suppress=True)
 
         if not isinstance(dict_input, dict):
             if suppress_conversion_errors:
                 dict_input = {}
             else:
-                raise ValueError(
-                    f"Failed to convert input to dictionary: {type(dict_input)}"
-                )
+                raise ValueError(f"Failed to convert input to dictionary: {type(dict_input)}")
 
     except Exception as e:
         if suppress_conversion_errors:

--- a/lionagi/ln/fuzzy/_string_similarity.py
+++ b/lionagi/ln/fuzzy/_string_similarity.py
@@ -117,9 +117,7 @@ def jaro_distance(s: str, t: str) -> float:
 
     transpositions //= 2
 
-    return (
-        matches / s_len + matches / t_len + (matches - transpositions) / matches
-    ) / 3.0
+    return (matches / s_len + matches / t_len + (matches - transpositions) / matches) / 3.0
 
 
 def jaro_winkler_similarity(s: str, t: str, scaling: float = 0.1) -> float:
@@ -313,15 +311,11 @@ def string_similarity(
     elif callable(algorithm):
         score_func = algorithm
     else:
-        raise ValueError(
-            "algorithm must be a string specifying a built-in algorithm or a callable"
-        )
+        raise ValueError("algorithm must be a string specifying a built-in algorithm or a callable")
 
     # Calculate similarities
     results = []
-    for idx, (orig_word, comp_word) in enumerate(
-        zip(original_words, compare_words, strict=False)
-    ):
+    for idx, (orig_word, comp_word) in enumerate(zip(original_words, compare_words, strict=False)):
         # Skip different length strings for hamming similarity
         if algorithm == "hamming" and len(comp_word) != len(compare_word):
             continue

--- a/lionagi/ln/types/base.py
+++ b/lionagi/ln/types/base.py
@@ -117,9 +117,7 @@ class Params:
         """Return the keys of the parameters."""
         if "_allowed_keys" in cls.__dict__ and cls.__dict__["_allowed_keys"]:
             return cls._allowed_keys
-        cls._allowed_keys = {
-            i for i in cls.__dataclass_fields__.keys() if not i.startswith("_")
-        }
+        cls._allowed_keys = {i for i in cls.__dataclass_fields__.keys() if not i.startswith("_")}
         return cls._allowed_keys
 
     @override
@@ -200,9 +198,7 @@ class DataClass:
         """Return the keys of the parameters."""
         if "_allowed_keys" in cls.__dict__ and cls.__dict__["_allowed_keys"]:
             return cls._allowed_keys
-        cls._allowed_keys = {
-            i for i in cls.__dataclass_fields__.keys() if not i.startswith("_")
-        }
+        cls._allowed_keys = {i for i in cls.__dataclass_fields__.keys() if not i.startswith("_")}
         return cls._allowed_keys
 
     @override

--- a/lionagi/models/field_model.py
+++ b/lionagi/models/field_model.py
@@ -78,9 +78,7 @@ class FieldModel(Params):
     """
 
     # Class configuration - let Params handle Unset population
-    _config: ClassVar[ModelConfig] = ModelConfig(
-        prefill_unset=True, none_as_sentinel=True
-    )
+    _config: ClassVar[ModelConfig] = ModelConfig(prefill_unset=True, none_as_sentinel=True)
 
     # Public fields (all start as Unset when not provided)
     base_type: type[Any]
@@ -134,8 +132,7 @@ class FieldModel(Params):
                 or isinstance(
                     self.base_type, types.UnionType
                 )  # Python 3.10+ union types (str | None)
-                or str(type(self.base_type))
-                == "<class 'types.UnionType'>"  # Fallback check
+                or str(type(self.base_type)) == "<class 'types.UnionType'>"  # Fallback check
             )
             if not is_valid_type:
                 raise ValueError(
@@ -236,9 +233,7 @@ class FieldModel(Params):
             return "field"
 
         # If not found, raise AttributeError as usual
-        raise AttributeError(
-            f"'{self.__class__.__name__}' object has no attribute '{name}'"
-        )
+        raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{name}'")
 
     # ---- factory helpers -------------------------------------------------- #
 
@@ -456,9 +451,7 @@ class FieldModel(Params):
         updated = {**existing, **kwargs}
 
         current_metadata = () if self._is_sentinel(self.metadata) else self.metadata
-        filtered_metadata = tuple(
-            m for m in current_metadata if m.key != "json_schema_extra"
-        )
+        filtered_metadata = tuple(m for m in current_metadata if m.key != "json_schema_extra")
         new_metadata = (
             *filtered_metadata,
             Meta("json_schema_extra", updated),
@@ -652,9 +645,7 @@ class FieldModel(Params):
                         result = validator(value)
                         # If validator returns False (simple boolean validator), raise error
                         if result is False:
-                            validator_name = getattr(
-                                validator, "__name__", f"validator_{i}"
-                            )
+                            validator_name = getattr(validator, "__name__", f"validator_{i}")
                             raise ValidationError(
                                 f"Validation failed for {validator_name}",
                                 details={
@@ -693,9 +684,7 @@ class FieldModel(Params):
             attrs.append("validated")
 
         attr_str = f" [{', '.join(attrs)}]" if attrs else ""
-        base_type_name = (
-            "Any" if self._is_sentinel(self.base_type) else self.base_type.__name__
-        )
+        base_type_name = "Any" if self._is_sentinel(self.base_type) else self.base_type.__name__
         return f"FieldModel({base_type_name}{attr_str})"
 
     @property

--- a/lionagi/models/model_params.py
+++ b/lionagi/models/model_params.py
@@ -83,9 +83,7 @@ class ModelParams(Params):
     """
 
     # Class configuration - let Params handle Unset population
-    _config: ClassVar[ModelConfig] = ModelConfig(
-        prefill_unset=True, none_as_sentinel=True
-    )
+    _config: ClassVar[ModelConfig] = ModelConfig(prefill_unset=True, none_as_sentinel=True)
 
     # Public fields (all start as Unset when not provided)
     name: str | None
@@ -117,13 +115,8 @@ class ModelParams(Params):
 
         # Minimal domain validation - only check what matters
         if not self._is_sentinel(self.base_type):
-            if not (
-                inspect.isclass(self.base_type)
-                and issubclass(self.base_type, BaseModel)
-            ):
-                raise ValueError(
-                    f"base_type must be BaseModel subclass, got {self.base_type}"
-                )
+            if not (inspect.isclass(self.base_type) and issubclass(self.base_type, BaseModel)):
+                raise ValueError(f"base_type must be BaseModel subclass, got {self.base_type}")
 
         # Process and merge all field sources
         self._process_fields()
@@ -159,9 +152,7 @@ class ModelParams(Params):
         if not self._is_sentinel(self.base_type):
             base_fields = copy(self.base_type.model_fields)
             if not self._is_sentinel(self.exclude_fields):
-                base_fields = {
-                    k: v for k, v in base_fields.items() if k not in self.exclude_fields
-                }
+                base_fields = {k: v for k, v in base_fields.items() if k not in self.exclude_fields}
             fields.update(base_fields)
 
         # Process field_models
@@ -298,9 +289,7 @@ class ModelParams(Params):
         model = create_model(
             model_name,
             __base__=base_type,
-            __config__=(
-                self.config_dict if not self._is_sentinel(self.config_dict) else None
-            ),
+            __config__=(self.config_dict if not self._is_sentinel(self.config_dict) else None),
             __doc__=self.doc if not self._is_sentinel(self.doc) else None,
             __validators__=self._validators if self._validators else None,
             **self.use_fields,

--- a/lionagi/operations/builder.py
+++ b/lionagi/operations/builder.py
@@ -306,9 +306,7 @@ class OperationGraphBuilder:
         Returns:
             List of unexecuted operations
         """
-        return [
-            op for op_id, op in self._operations.items() if op_id not in self._executed
-        ]
+        return [op for op_id, op in self._operations.items() if op_id not in self._executed]
 
     def add_conditional_branch(
         self,
@@ -356,16 +354,12 @@ class OperationGraphBuilder:
 
         # Add false branch if specified
         if false_op:
-            false_node = create_operation(
-                operation=false_op, parameters={"branch": "false"}
-            )
+            false_node = create_operation(operation=false_op, parameters={"branch": "false"})
             self.graph.add_node(false_node)
             self._operations[false_node.id] = false_node
             result["false"] = false_node.id
 
-            false_edge = Edge(
-                head=check_node.id, tail=false_node.id, label=["if_false"]
-            )
+            false_edge = Edge(head=check_node.id, tail=false_node.id, label=["if_false"])
             self.graph.add_edge(false_edge)
 
             self._current_heads = [true_node.id, false_node.id]

--- a/lionagi/operations/fields.py
+++ b/lionagi/operations/fields.py
@@ -243,9 +243,7 @@ class ActionRequestModel(HashableModel):
                 if not json_blocks:
                     pattern2 = r"```python\s*(.*?)\s*```"
                     _d = re.findall(pattern2, content, re.DOTALL)
-                    json_blocks = [
-                        extract_json(match, fuzzy_parse=True) for match in _d
-                    ]
+                    json_blocks = [extract_json(match, fuzzy_parse=True) for match in _d]
                     json_blocks = to_list(json_blocks, dropna=True)
 
                 logger.debug("Parsed action request JSON blocks: %s", json_blocks)
@@ -265,11 +263,7 @@ class ActionRequestModel(HashableModel):
                         if "name" in i["function"]:
                             i["function"] = i["function"]["name"]
                     for k, v in i.items():
-                        k = (
-                            k.replace("action_", "")
-                            .replace("recipient_", "")
-                            .replace("s", "")
-                        )
+                        k = k.replace("action_", "").replace("recipient_", "").replace("s", "")
                         if k in ["name", "function", "recipient"]:
                             j["function"] = v
                         elif k in ["parameter", "argument", "arg", "param"]:
@@ -279,11 +273,7 @@ class ActionRequestModel(HashableModel):
                                 fuzzy_parse=True,
                                 suppress=True,
                             )
-                    if (
-                        j
-                        and all(key in j for key in ["function", "arguments"])
-                        and j["arguments"]
-                    ):
+                    if j and all(key in j for key in ["function", "arguments"]) and j["arguments"]:
                         out.append(j)
 
             return out
@@ -404,9 +394,7 @@ def _get_default_fields(
         fm = fm.with_default(default)
 
     if fm.is_listable:
-        fm = fm.with_validator(
-            lambda cls, x: to_list(x, dropna=True, flatten=True, unique=True)
-        )
+        fm = fm.with_validator(lambda cls, x: to_list(x, dropna=True, flatten=True, unique=True))
 
     return fm
 

--- a/lionagi/operations/operate/operative.py
+++ b/lionagi/operations/operate/operative.py
@@ -159,9 +159,7 @@ class Operative:
 
             return None
 
-    def update_response_model(
-        self, text: str | None = None, data: dict | None = None
-    ) -> Any:
+    def update_response_model(self, text: str | None = None, data: dict | None = None) -> Any:
         """Update response model from text or dict.
 
         Args:

--- a/lionagi/operations/operate/step.py
+++ b/lionagi/operations/operate/step.py
@@ -136,15 +136,9 @@ class Step:
             fields_dict["reason"] = reason_spec
 
         if actions:
-            fields_dict["action_required"] = get_default_field(
-                "action_required"
-            ).to_spec()
-            fields_dict["action_requests"] = get_default_field(
-                "action_requests"
-            ).to_spec()
-            fields_dict["action_responses"] = get_default_field(
-                "action_responses"
-            ).to_spec()
+            fields_dict["action_required"] = get_default_field("action_required").to_spec()
+            fields_dict["action_requests"] = get_default_field("action_requests").to_spec()
+            fields_dict["action_responses"] = get_default_field("action_responses").to_spec()
 
         # Add custom fields (will override defaults if same name)
         if fields:

--- a/lionagi/operations/select/select.py
+++ b/lionagi/operations/select/select.py
@@ -90,9 +90,7 @@ async def select_v1(
     """
     # Parse choices into keys and representations
     selections, contents = parse_to_representation(choices)
-    prompt = SelectionModel.PROMPT.format(
-        max_num_selections=max_num_selections, choices=selections
-    )
+    prompt = SelectionModel.PROMPT.format(max_num_selections=max_num_selections, choices=selections)
 
     # Build instruction dictionary
     if isinstance(instruct, Instruct):
@@ -102,9 +100,7 @@ async def select_v1(
 
     # Append selection prompt to instruction
     if instruct_dict.get("instruction", None) is not None:
-        instruct_dict["instruction"] = (
-            f"{instruct_dict['instruction']}\n\n{prompt} \n\n "
-        )
+        instruct_dict["instruction"] = f"{instruct_dict['instruction']}\n\n{prompt} \n\n "
     else:
         instruct_dict["instruction"] = prompt
 

--- a/lionagi/protocols/action/function_calling.py
+++ b/lionagi/protocols/action/function_calling.py
@@ -46,9 +46,7 @@ class FunctionCalling(Event):
                 raise ValueError("arguments must match the function schema")
 
         else:
-            if not self.func_tool.minimum_acceptable_fields.issubset(
-                set(self.arguments.keys())
-            ):
+            if not self.func_tool.minimum_acceptable_fields.issubset(set(self.arguments.keys())):
                 raise ValueError("arguments must match the function schema")
         return self
 
@@ -70,18 +68,14 @@ class FunctionCalling(Event):
                 return await self.func_tool.preprocessor(
                     kwargs, **self.func_tool.preprocessor_kwargs
                 )
-            return self.func_tool.preprocessor(
-                kwargs, **self.func_tool.preprocessor_kwargs
-            )
+            return self.func_tool.preprocessor(kwargs, **self.func_tool.preprocessor_kwargs)
 
         async def _post_process(arg: Any):
             if is_coro_func(self.func_tool.postprocessor):
                 return await self.func_tool.postprocessor(
                     arg, **self.func_tool.postprocessor_kwargs
                 )
-            return self.func_tool.postprocessor(
-                arg, **self.func_tool.postprocessor_kwargs
-            )
+            return self.func_tool.postprocessor(arg, **self.func_tool.postprocessor_kwargs)
 
         if self.func_tool.preprocessor:
             self.arguments = await _preprocess(self.arguments)

--- a/lionagi/protocols/action/tool.py
+++ b/lionagi/protocols/action/tool.py
@@ -147,9 +147,7 @@ class Tool(Element):
         """This is not implemented, as Tools are not typically created from arbitrary dicts."""
         raise NotImplementedError("`Tool.from_dict` is not supported.")
 
-    def to_dict(
-        self, mode: Literal["python", "json", "db"] = "python", **kw
-    ) -> dict[str, Any]:
+    def to_dict(self, mode: Literal["python", "json", "db"] = "python", **kw) -> dict[str, Any]:
         """
         Serialize the Tool to a dict, including the `function` name.
 

--- a/lionagi/protocols/generic/log.py
+++ b/lionagi/protocols/generic/log.py
@@ -31,9 +31,7 @@ class DataLoggerConfig(BaseModel):
     persist_dir: str | Path = "./data/logs"
     subfolder: str | None = None
     file_prefix: str | None = None
-    capacity: int | None = (
-        None  # None means unbounded; set a value for long-running sessions
-    )
+    capacity: int | None = None  # None means unbounded; set a value for long-running sessions
     extension: str = ".json"
     use_timestamp: bool = True
     hash_digits: int | None = Field(5, ge=0, le=10)

--- a/lionagi/protocols/graph/graph.py
+++ b/lionagi/protocols/graph/graph.py
@@ -98,9 +98,7 @@ class Graph(Element, Relational, Generic[T]):
     def add_node(self, node: Relational) -> None:
         """Add a node to the graph."""
         if not isinstance(node, Relational):
-            raise RelationError(
-                "Failed to add node: Invalid node type: not a <Relational> entity."
-            )
+            raise RelationError("Failed to add node: Invalid node type: not a <Relational> entity.")
         _id = ID.get_id(node)
         try:
             self.internal_nodes.insert(len(self.internal_nodes), node)
@@ -530,9 +528,7 @@ class Graph(Element, Relational, Generic[T]):
         for edge_id, tail_id in out_edges:
             old_edge = self.internal_edges[edge_id]
             extra_properties = {
-                k: v
-                for k, v in old_edge.properties.items()
-                if k not in {"condition", "label"}
+                k: v for k, v in old_edge.properties.items() if k not in {"condition", "label"}
             }
 
             replacement = Edge(

--- a/lionagi/protocols/messages/message.py
+++ b/lionagi/protocols/messages/message.py
@@ -75,16 +75,12 @@ class Message(Node, Sendable):
 
     def to_dict(self, mode="python", **kw):
         d = super().to_dict(mode=mode, **kw)
-        d["role"] = (
-            self.role.value if isinstance(self.role, MessageRole) else str(self.role)
-        )
+        d["role"] = self.role.value if isinstance(self.role, MessageRole) else str(self.role)
         return d
 
     def model_dump(self, **kw):
         d = super().model_dump(**kw)
-        d["role"] = (
-            self.role.value if isinstance(self.role, MessageRole) else str(self.role)
-        )
+        d["role"] = self.role.value if isinstance(self.role, MessageRole) else str(self.role)
         return d
 
     @property
@@ -101,11 +97,7 @@ class Message(Node, Sendable):
     def chat_msg(self) -> dict[str, Any] | None:
         """A dictionary representation typically used in chat-based contexts."""
         try:
-            role_str = (
-                self.role.value
-                if isinstance(self.role, MessageRole)
-                else str(self.role)
-            )
+            role_str = self.role.value if isinstance(self.role, MessageRole) else str(self.role)
             return {"role": role_str, "content": self.rendered}
         except Exception:
             return None

--- a/lionagi/protocols/types.py
+++ b/lionagi/protocols/types.py
@@ -1,9 +1,17 @@
 # Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-from ._concepts import Collective, Communicatable, Condition, Manager
+from ._concepts import (
+    Collective,
+    Communicatable,
+    Condition,
+    Manager,
+    Observer,
+    Ordering,
+    Relational,
+    Sendable,
+)
 from ._concepts import Observable as LegacyObservable
-from ._concepts import Observer, Ordering, Relational, Sendable
 from .contracts import Observable, ObservableProto
 from .generic.element import ID, Element, validate_order
 from .generic.event import Event, EventStatus, Execution

--- a/lionagi/providers/ag2/_config.py
+++ b/lionagi/providers/ag2/_config.py
@@ -8,7 +8,6 @@ from lionagi.service.connections.registry import EndpointType
 
 
 class AG2Configs(ProviderConfig, Enum):
-
     GROUP_CHAT = (
         "group_chat",
         ["groupchat", "chat"],

--- a/lionagi/providers/ag2/agent/endpoint.py
+++ b/lionagi/providers/ag2/agent/endpoint.py
@@ -56,9 +56,7 @@ class AG2BetaEndpoint(AgenticEndpoint):
         self._tool_registry: dict[str, Any] = kwargs.get("tool_registry", {})
 
     async def _call(self, payload, headers, **kwargs):
-        raise NotImplementedError(
-            "AG2 beta Agent is stream-only. Use stream() to iterate events."
-        )
+        raise NotImplementedError("AG2 beta Agent is stream-only. Use stream() to iterate events.")
 
     def create_payload(self, request: dict | BaseModel, **kwargs):
         from .models import AG2AgentRequest
@@ -77,9 +75,7 @@ class AG2BetaEndpoint(AgenticEndpoint):
             )
         }, {}
 
-    async def stream(
-        self, request: dict | BaseModel, **kwargs
-    ) -> AsyncIterator[StreamChunk]:
+    async def stream(self, request: dict | BaseModel, **kwargs) -> AsyncIterator[StreamChunk]:
         from .models import AgentConfig, run_beta_agent
 
         if isinstance(request, dict) and "request" in request:
@@ -92,9 +88,7 @@ class AG2BetaEndpoint(AgenticEndpoint):
             request_obj.messages[-1]["content"] if request_obj.messages else ""
         )
         if not prompt:
-            raise ValueError(
-                "AG2BetaEndpoint requires a non-empty prompt or at least one message."
-            )
+            raise ValueError("AG2BetaEndpoint requires a non-empty prompt or at least one message.")
 
         # Resolve the pre-built agent (if any) and the agent_config.
         # Pre-built agent takes precedence; agent_config is the fallback.
@@ -103,9 +97,7 @@ class AG2BetaEndpoint(AgenticEndpoint):
         if prebuilt_agent is None:
             agent_config = request_obj.agent_config
             if agent_config is None:
-                agent_config = AgentConfig(
-                    **kwargs.get("agent_config", self._agent_config)
-                )
+                agent_config = AgentConfig(**kwargs.get("agent_config", self._agent_config))
         else:
             # Pre-built agent path: agent_config may be None; that's fine.
             agent_config = request_obj.agent_config  # kept for metadata only
@@ -116,9 +108,7 @@ class AG2BetaEndpoint(AgenticEndpoint):
         if llm_config is None and prebuilt_agent is None:
             raise ValueError("AG2BetaEndpoint requires llm_config")
 
-        model_config = (
-            _resolve_model_config(llm_config) if llm_config is not None else None
-        )
+        model_config = _resolve_model_config(llm_config) if llm_config is not None else None
 
         # Build system chunk metadata. When a pre-built agent is used the
         # config fields are not authoritative; surface what we know.

--- a/lionagi/providers/ag2/agent/models.py
+++ b/lionagi/providers/ag2/agent/models.py
@@ -147,9 +147,7 @@ async def run_beta_agent(
 
     if agent is not None:
         if config is not None:
-            logger.info(
-                "run_beta_agent: pre-built agent provided; agent_config is ignored."
-            )
+            logger.info("run_beta_agent: pre-built agent provided; agent_config is ignored.")
         # Use the caller-supplied agent as-is.
         # AG2 stream imports still needed for the subscription machinery below.
     else:
@@ -164,9 +162,7 @@ async def run_beta_agent(
 
         agent_kwargs: dict[str, Any] = {
             "name": config.name,
-            "prompt": (
-                config.prompt if isinstance(config.prompt, list) else [config.prompt]
-            ),
+            "prompt": (config.prompt if isinstance(config.prompt, list) else [config.prompt]),
             "config": llm_config,
         }
 
@@ -226,9 +222,7 @@ async def run_beta_agent(
     async def _on_tool_result(event: ToolResultEvent) -> None:
         content = ""
         if event.result and event.result.parts:
-            content = " ".join(
-                getattr(p, "content", str(p)) for p in event.result.parts
-            )
+            content = " ".join(getattr(p, "content", str(p)) for p in event.result.parts)
         await event_queue.put(
             {
                 "type": "tool_result",
@@ -240,12 +234,8 @@ async def run_beta_agent(
 
     from autogen.beta.events.conditions import TypeCondition
 
-    sub_tools = stream.subscribe(
-        _on_tool_calls, condition=TypeCondition(ToolCallsEvent)
-    )
-    sub_results = stream.subscribe(
-        _on_tool_result, condition=TypeCondition(ToolResultEvent)
-    )
+    sub_tools = stream.subscribe(_on_tool_calls, condition=TypeCondition(ToolCallsEvent))
+    sub_results = stream.subscribe(_on_tool_result, condition=TypeCondition(ToolResultEvent))
 
     async def _run_agent():
         return await agent.ask(message, stream=stream)
@@ -275,9 +265,7 @@ async def run_beta_agent(
 
         content = ""
         if reply.response and reply.response.message:
-            content = getattr(
-                reply.response.message, "content", str(reply.response.message)
-            )
+            content = getattr(reply.response.message, "content", str(reply.response.message))
 
         yield {
             "type": "response",
@@ -300,8 +288,5 @@ async def run_beta_agent(
             # that the consumer no longer wants to see.
             try:
                 await task
-            except (
-                asyncio.CancelledError,
-                Exception,
-            ):  # noqa: S110, BLE001 — intentional teardown reap
+            except (asyncio.CancelledError, Exception):  # noqa: S110, BLE001 — intentional teardown reap
                 pass

--- a/lionagi/providers/ag2/groupchat/endpoint.py
+++ b/lionagi/providers/ag2/groupchat/endpoint.py
@@ -42,9 +42,7 @@ class AG2GroupChatEndpoint(AgenticEndpoint):
         self._tool_registry: dict[str, Any] = kwargs.get("tool_registry", {})
 
     async def _call(self, payload, headers, **kwargs):
-        raise NotImplementedError(
-            "AG2 GroupChat is stream-only. Use stream() to iterate events."
-        )
+        raise NotImplementedError("AG2 GroupChat is stream-only. Use stream() to iterate events.")
 
     def create_payload(self, request: dict | BaseModel, **kwargs):
         from .models import AG2GroupChatRequest
@@ -63,9 +61,7 @@ class AG2GroupChatEndpoint(AgenticEndpoint):
             )
         }, {}
 
-    async def stream(
-        self, request: dict | BaseModel, **kwargs
-    ) -> AsyncIterator[StreamChunk]:
+    async def stream(self, request: dict | BaseModel, **kwargs) -> AsyncIterator[StreamChunk]:
         from .models import GroupChatSpec, build_group_chat, stream_group_chat
 
         if isinstance(request, dict) and "request" in request:
@@ -160,9 +156,7 @@ def _event_to_chunk(event) -> StreamChunk | None:
     inner = getattr(event, "content", None)
 
     if isinstance(event, TextEvent):
-        text = (
-            getattr(inner, "content", str(event)) if inner is not None else str(event)
-        )
+        text = getattr(inner, "content", str(event)) if inner is not None else str(event)
         sender = getattr(inner, "sender", "unknown") if inner is not None else "unknown"
         return StreamChunk(
             type="text",
@@ -170,9 +164,7 @@ def _event_to_chunk(event) -> StreamChunk | None:
             metadata={"agent": sender},
         )
     if isinstance(event, GroupChatRunChatEvent):
-        speaker = (
-            getattr(inner, "speaker", "unknown") if inner is not None else "unknown"
-        )
+        speaker = getattr(inner, "speaker", "unknown") if inner is not None else "unknown"
         return StreamChunk(
             type="system",
             content=f"Speaker: {speaker}",
@@ -192,14 +184,8 @@ def _event_to_chunk(event) -> StreamChunk | None:
     if isinstance(event, ToolCallEvent):
         tool_calls = getattr(inner, "tool_calls", []) if inner is not None else []
         first = tool_calls[0] if tool_calls else None
-        tool_name = (
-            getattr(getattr(first, "function", None), "name", None) if first else None
-        )
-        tool_args = (
-            getattr(getattr(first, "function", None), "arguments", None)
-            if first
-            else None
-        )
+        tool_name = getattr(getattr(first, "function", None), "name", None) if first else None
+        tool_args = getattr(getattr(first, "function", None), "arguments", None) if first else None
         sender = getattr(inner, "sender", "unknown") if inner is not None else "unknown"
         return StreamChunk(
             type="tool_use",
@@ -209,9 +195,7 @@ def _event_to_chunk(event) -> StreamChunk | None:
             metadata={"agent": sender},
         )
     if isinstance(event, ToolResponseEvent):
-        tool_responses = (
-            getattr(inner, "tool_responses", []) if inner is not None else []
-        )
+        tool_responses = getattr(inner, "tool_responses", []) if inner is not None else []
         first = tool_responses[0] if tool_responses else None
         tool_output = getattr(first, "content", None) if first else None
         tool_id = getattr(first, "tool_call_id", None) if first else None

--- a/lionagi/providers/ag2/groupchat/models.py
+++ b/lionagi/providers/ag2/groupchat/models.py
@@ -57,9 +57,7 @@ class AgentSpec(BaseModel):
 
     name: str = Field(description="Agent name (e.g. 'Researcher', 'Analyst')")
     role: str = Field(description="One-line role description")
-    system_message: str = Field(
-        default="", description="Full system prompt for the agent"
-    )
+    system_message: str = Field(default="", description="Full system prompt for the agent")
     tools: list[str] = Field(
         default_factory=list,
         description="Tool names from the registry this agent can invoke",
@@ -200,8 +198,7 @@ def build_group_chat(
                 )
                 agent = ConversableAgent(
                     name=agent_spec.name,
-                    system_message=agent_spec.system_message
-                    or f"You are {agent_spec.name}.",
+                    system_message=agent_spec.system_message or f"You are {agent_spec.name}.",
                     llm_config=llm_config,
                     human_input_mode="NEVER",
                 )
@@ -325,57 +322,29 @@ async def stream_group_chat(
 
             if isinstance(event, TextEvent) and on_text:
                 text = getattr(inner, "content", "") if inner is not None else ""
-                sender = (
-                    getattr(inner, "sender", "unknown")
-                    if inner is not None
-                    else "unknown"
-                )
+                sender = getattr(inner, "sender", "unknown") if inner is not None else "unknown"
                 await _maybe_await(on_text, text, sender)
             elif isinstance(event, ToolCallEvent) and on_tool_use:
-                tool_calls = (
-                    getattr(inner, "tool_calls", []) if inner is not None else []
-                )
+                tool_calls = getattr(inner, "tool_calls", []) if inner is not None else []
                 first = tool_calls[0] if tool_calls else None
-                tool_name = (
-                    getattr(getattr(first, "function", None), "name", "")
-                    if first
-                    else ""
-                )
+                tool_name = getattr(getattr(first, "function", None), "name", "") if first else ""
                 tool_args = (
-                    getattr(getattr(first, "function", None), "arguments", None)
-                    if first
-                    else None
+                    getattr(getattr(first, "function", None), "arguments", None) if first else None
                 )
-                sender = (
-                    getattr(inner, "sender", "unknown")
-                    if inner is not None
-                    else "unknown"
-                )
+                sender = getattr(inner, "sender", "unknown") if inner is not None else "unknown"
                 await _maybe_await(on_tool_use, tool_name, sender, tool_args)
             elif isinstance(event, ToolResponseEvent) and on_tool_result:
-                tool_responses = (
-                    getattr(inner, "tool_responses", []) if inner is not None else []
-                )
+                tool_responses = getattr(inner, "tool_responses", []) if inner is not None else []
                 first = tool_responses[0] if tool_responses else None
                 tool_output = getattr(first, "content", None) if first else None
-                sender = (
-                    getattr(inner, "sender", "unknown")
-                    if inner is not None
-                    else "unknown"
-                )
+                sender = getattr(inner, "sender", "unknown") if inner is not None else "unknown"
                 await _maybe_await(on_tool_result, sender, tool_output)
             elif isinstance(event, GroupChatRunChatEvent) and on_speaker:
-                speaker = (
-                    getattr(inner, "speaker", "unknown")
-                    if inner is not None
-                    else "unknown"
-                )
+                speaker = getattr(inner, "speaker", "unknown") if inner is not None else "unknown"
                 await _maybe_await(on_speaker, speaker)
             elif isinstance(event, SelectSpeakerEvent) and on_speaker:
                 agents = getattr(inner, "agents", []) if inner is not None else []
-                first_name = (
-                    getattr(agents[0], "name", str(agents[0])) if agents else "unknown"
-                )
+                first_name = getattr(agents[0], "name", str(agents[0])) if agents else "unknown"
                 await _maybe_await(on_speaker, first_name)
             yield event
     except Exception:

--- a/lionagi/providers/ag2/nlip/endpoint.py
+++ b/lionagi/providers/ag2/nlip/endpoint.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import logging
 from collections.abc import AsyncIterator
-from typing import Any
 
 from pydantic import BaseModel
 
@@ -57,10 +56,8 @@ class AG2NlipEndpoint(AgenticEndpoint):
         prompt = req_dict.pop("prompt", "")
         return {"request": AG2NlipRequest(messages=messages, prompt=prompt)}, {}
 
-    async def stream(
-        self, request: dict | BaseModel, **kwargs
-    ) -> AsyncIterator[StreamChunk]:
-        from .models import AG2NlipRequest, call_nlip_remote
+    async def stream(self, request: dict | BaseModel, **kwargs) -> AsyncIterator[StreamChunk]:
+        from .models import call_nlip_remote
 
         if isinstance(request, dict) and "request" in request:
             request_obj = request["request"]
@@ -72,9 +69,7 @@ class AG2NlipEndpoint(AgenticEndpoint):
             request_obj.messages[-1]["content"] if request_obj.messages else ""
         )
         if not prompt:
-            raise ValueError(
-                "AG2NlipEndpoint requires a non-empty prompt or at least one message."
-            )
+            raise ValueError("AG2NlipEndpoint requires a non-empty prompt or at least one message.")
 
         url = kwargs.get("url", self._url)
         if not url:

--- a/lionagi/providers/ag2/nlip/models.py
+++ b/lionagi/providers/ag2/nlip/models.py
@@ -42,8 +42,7 @@ def _assert_nlip_url_safe(url: str) -> None:
     _parsed = urlparse(url)
     if _parsed.scheme not in ("http", "https"):
         raise ValueError(
-            f"NLIP URL has unsupported scheme {_parsed.scheme!r}. "
-            "Only http and https are allowed."
+            f"NLIP URL has unsupported scheme {_parsed.scheme!r}. Only http and https are allowed."
         )
     if not is_ssrf_safe(_parsed.hostname or ""):
         raise PermissionError(

--- a/lionagi/providers/anthropic/_config.py
+++ b/lionagi/providers/anthropic/_config.py
@@ -8,7 +8,6 @@ from lionagi.service.connections.registry import EndpointType
 
 
 class AnthropicConfigs(ProviderConfig, Enum):
-
     MESSAGES = (
         "messages",
         ["chat"],
@@ -24,7 +23,6 @@ AnthropicConfigs._PROVIDER_ALIASES = []
 
 
 class ClaudeCodeConfigs(ProviderConfig, Enum):
-
     CLI = (
         "query_cli",
         ["cli", "code"],

--- a/lionagi/providers/anthropic/messages/endpoint.py
+++ b/lionagi/providers/anthropic/messages/endpoint.py
@@ -30,9 +30,7 @@ class AnthropicMessagesEndpoint(Endpoint):
         if config is None:
             from lionagi.config import settings
 
-            kwargs.setdefault(
-                "api_key", settings.ANTHROPIC_API_KEY or "dummy-key-for-testing"
-            )
+            kwargs.setdefault("api_key", settings.ANTHROPIC_API_KEY or "dummy-key-for-testing")
             kwargs.setdefault("default_headers", {"anthropic-version": "2023-06-01"})
         super().__init__(config, **kwargs)
 
@@ -54,9 +52,7 @@ class AnthropicMessagesEndpoint(Endpoint):
                 request_dict["messages"] = request_dict["messages"][1:]
                 request = request_dict
 
-        payload, headers = super().create_payload(
-            request, extra_headers=extra_headers, **kwargs
-        )
+        payload, headers = super().create_payload(request, extra_headers=extra_headers, **kwargs)
 
         # Remove api_key from payload if present
         payload.pop("api_key", None)
@@ -72,14 +68,10 @@ class AnthropicMessagesEndpoint(Endpoint):
                         "text": last_message,
                         "cache_control": cache_control,
                     }
-                elif isinstance(last_message, list) and isinstance(
-                    last_message[-1], dict
-                ):
+                elif isinstance(last_message, list) and isinstance(last_message[-1], dict):
                     last_message[-1]["cache_control"] = cache_control
                 payload["messages"][-1]["content"] = (
-                    [last_message]
-                    if not isinstance(last_message, list)
-                    else last_message
+                    [last_message] if not isinstance(last_message, list) else last_message
                 )
 
         # If we extracted a system message earlier, add it to payload

--- a/lionagi/providers/anthropic/messages/models.py
+++ b/lionagi/providers/anthropic/messages/models.py
@@ -105,9 +105,7 @@ class CreateMessageResponse(BaseModel):
     role: Literal["assistant"] = "assistant"
     content: list[ContentBlockResponse]
     model: str
-    stop_reason: None | (
-        Literal["end_turn", "max_tokens", "stop_sequence", "tool_use"]
-    ) = None
+    stop_reason: None | (Literal["end_turn", "max_tokens", "stop_sequence", "tool_use"]) = None
     stop_sequence: str | None = None
     usage: Usage
 

--- a/lionagi/providers/deepseek/_config.py
+++ b/lionagi/providers/deepseek/_config.py
@@ -8,14 +8,11 @@ from lionagi.service.connections.registry import EndpointType
 
 
 class DeepSeekConfigs(ProviderConfig, Enum):
-
     CHAT = (
         "chat/completions",
         ["chat"],
         EndpointType.API,
-        LazyType(
-            "lionagi.providers.deepseek.chat.models:DeepseekChatCompletionsRequest"
-        ),
+        LazyType("lionagi.providers.deepseek.chat.models:DeepseekChatCompletionsRequest"),
         "https://api.deepseek.com/v1",
         "bearer",
     )

--- a/lionagi/providers/deepseek/chat/endpoint.py
+++ b/lionagi/providers/deepseek/chat/endpoint.py
@@ -4,7 +4,6 @@
 from pydantic import BaseModel
 
 from lionagi.service.connections.endpoint import Endpoint
-from lionagi.service.connections.endpoint_config import EndpointConfig
 
 from .._config import DeepSeekConfigs
 from .models import DeepseekChatCompletionsRequest, normalize_deepseek_usage
@@ -27,9 +26,7 @@ class DeepseekChatEndpoint(Endpoint):
         if config is None:
             from lionagi.config import settings
 
-            kwargs.setdefault(
-                "api_key", settings.DEEPSEEK_API_KEY or "dummy-key-for-testing"
-            )
+            kwargs.setdefault("api_key", settings.DEEPSEEK_API_KEY or "dummy-key-for-testing")
             kwargs.setdefault("kwargs", {"model": "deepseek-chat"})
             kwargs.setdefault("requires_tokens", True)
         super().__init__(config, **kwargs)

--- a/lionagi/providers/exa/_config.py
+++ b/lionagi/providers/exa/_config.py
@@ -8,7 +8,6 @@ from lionagi.service.connections.registry import EndpointType
 
 
 class ExaConfigs(ProviderConfig, Enum):
-
     SEARCH = (
         "search",
         [],

--- a/lionagi/providers/exa/contents/endpoint.py
+++ b/lionagi/providers/exa/contents/endpoint.py
@@ -36,9 +36,7 @@ class ExaContentsEndpoint(Endpoint):
         if config is None:
             from lionagi.config import settings
 
-            kwargs.setdefault(
-                "api_key", settings.EXA_API_KEY or "dummy-key-for-testing"
-            )
+            kwargs.setdefault("api_key", settings.EXA_API_KEY or "dummy-key-for-testing")
             kwargs.setdefault("timeout", 120)
             kwargs.setdefault("max_retries", 3)
         super().__init__(config=config, **kwargs)
@@ -51,11 +49,7 @@ class ExaContentsEndpoint(Endpoint):
     ):
         if self.config.request_options is not None:
             model_cls = self.config.request_options
-            raw = (
-                request
-                if isinstance(request, dict)
-                else request.model_dump(exclude_none=True)
-            )
+            raw = request if isinstance(request, dict) else request.model_dump(exclude_none=True)
             merged = {**self.config.kwargs, **raw, **kwargs}
             obj = model_cls.model_validate(merged)
             payload = obj.model_dump(by_alias=True, exclude_none=True)

--- a/lionagi/providers/exa/find_similar/endpoint.py
+++ b/lionagi/providers/exa/find_similar/endpoint.py
@@ -36,9 +36,7 @@ class ExaFindSimilarEndpoint(Endpoint):
         if config is None:
             from lionagi.config import settings
 
-            kwargs.setdefault(
-                "api_key", settings.EXA_API_KEY or "dummy-key-for-testing"
-            )
+            kwargs.setdefault("api_key", settings.EXA_API_KEY or "dummy-key-for-testing")
             kwargs.setdefault("timeout", 120)
             kwargs.setdefault("max_retries", 3)
         super().__init__(config=config, **kwargs)
@@ -51,11 +49,7 @@ class ExaFindSimilarEndpoint(Endpoint):
     ):
         if self.config.request_options is not None:
             model_cls = self.config.request_options
-            raw = (
-                request
-                if isinstance(request, dict)
-                else request.model_dump(exclude_none=True)
-            )
+            raw = request if isinstance(request, dict) else request.model_dump(exclude_none=True)
             merged = {**self.config.kwargs, **raw, **kwargs}
             obj = model_cls.model_validate(merged)
             payload = obj.model_dump(by_alias=True, exclude_none=True)

--- a/lionagi/providers/exa/search/endpoint.py
+++ b/lionagi/providers/exa/search/endpoint.py
@@ -19,9 +19,7 @@ class ExaSearchEndpoint(Endpoint):
         if config is None:
             from lionagi.config import settings
 
-            kwargs.setdefault(
-                "api_key", settings.EXA_API_KEY or "dummy-key-for-testing"
-            )
+            kwargs.setdefault("api_key", settings.EXA_API_KEY or "dummy-key-for-testing")
             kwargs.setdefault("timeout", 120)
             kwargs.setdefault("max_retries", 3)
         super().__init__(config=config, **kwargs)
@@ -34,11 +32,7 @@ class ExaSearchEndpoint(Endpoint):
     ):
         if self.config.request_options is not None:
             model_cls = self.config.request_options
-            raw = (
-                request
-                if isinstance(request, dict)
-                else request.model_dump(exclude_none=True)
-            )
+            raw = request if isinstance(request, dict) else request.model_dump(exclude_none=True)
             merged = {**self.config.kwargs, **raw, **kwargs}
             obj = model_cls.model_validate(merged)
             payload = obj.model_dump(by_alias=True, exclude_none=True)

--- a/lionagi/providers/firecrawl/_config.py
+++ b/lionagi/providers/firecrawl/_config.py
@@ -8,7 +8,6 @@ from lionagi.service.connections.registry import EndpointType
 
 
 class FirecrawlConfigs(ProviderConfig, Enum):
-
     SCRAPE = (
         "v1/scrape",
         ["scrape"],

--- a/lionagi/providers/firecrawl/crawl/endpoint.py
+++ b/lionagi/providers/firecrawl/crawl/endpoint.py
@@ -38,9 +38,7 @@ class FirecrawlCrawlEndpoint(Endpoint):
         if config is None:
             from lionagi.config import settings
 
-            kwargs.setdefault(
-                "api_key", settings.FIRECRAWL_API_KEY or "dummy-key-for-testing"
-            )
+            kwargs.setdefault("api_key", settings.FIRECRAWL_API_KEY or "dummy-key-for-testing")
             kwargs.setdefault("timeout", 120)
             kwargs.setdefault("max_retries", 3)
         super().__init__(config=config, **kwargs)
@@ -53,11 +51,7 @@ class FirecrawlCrawlEndpoint(Endpoint):
     ):
         if self.config.request_options is not None:
             model_cls = self.config.request_options
-            raw = (
-                request
-                if isinstance(request, dict)
-                else request.model_dump(exclude_none=True)
-            )
+            raw = request if isinstance(request, dict) else request.model_dump(exclude_none=True)
             merged = {**self.config.kwargs, **raw, **kwargs}
             obj = model_cls.model_validate(merged)
             payload = obj.model_dump(by_alias=True, exclude_none=True)

--- a/lionagi/providers/firecrawl/map/endpoint.py
+++ b/lionagi/providers/firecrawl/map/endpoint.py
@@ -14,9 +14,7 @@ class FirecrawlMapEndpoint(Endpoint):
         if config is None:
             from lionagi.config import settings
 
-            kwargs.setdefault(
-                "api_key", settings.FIRECRAWL_API_KEY or "dummy-key-for-testing"
-            )
+            kwargs.setdefault("api_key", settings.FIRECRAWL_API_KEY or "dummy-key-for-testing")
             kwargs.setdefault("timeout", 120)
             kwargs.setdefault("max_retries", 3)
         super().__init__(config=config, **kwargs)
@@ -29,11 +27,7 @@ class FirecrawlMapEndpoint(Endpoint):
     ):
         if self.config.request_options is not None:
             model_cls = self.config.request_options
-            raw = (
-                request
-                if isinstance(request, dict)
-                else request.model_dump(exclude_none=True)
-            )
+            raw = request if isinstance(request, dict) else request.model_dump(exclude_none=True)
             merged = {**self.config.kwargs, **raw, **kwargs}
             obj = model_cls.model_validate(merged)
             payload = obj.model_dump(by_alias=True, exclude_none=True)

--- a/lionagi/providers/firecrawl/scrape/endpoint.py
+++ b/lionagi/providers/firecrawl/scrape/endpoint.py
@@ -14,9 +14,7 @@ class FirecrawlScrapeEndpoint(Endpoint):
         if config is None:
             from lionagi.config import settings
 
-            kwargs.setdefault(
-                "api_key", settings.FIRECRAWL_API_KEY or "dummy-key-for-testing"
-            )
+            kwargs.setdefault("api_key", settings.FIRECRAWL_API_KEY or "dummy-key-for-testing")
             kwargs.setdefault("timeout", 120)
             kwargs.setdefault("max_retries", 3)
         super().__init__(config=config, **kwargs)
@@ -29,11 +27,7 @@ class FirecrawlScrapeEndpoint(Endpoint):
     ):
         if self.config.request_options is not None:
             model_cls = self.config.request_options
-            raw = (
-                request
-                if isinstance(request, dict)
-                else request.model_dump(exclude_none=True)
-            )
+            raw = request if isinstance(request, dict) else request.model_dump(exclude_none=True)
             merged = {**self.config.kwargs, **raw, **kwargs}
             obj = model_cls.model_validate(merged)
             payload = obj.model_dump(by_alias=True, exclude_none=True)

--- a/lionagi/providers/google/chat/endpoint.py
+++ b/lionagi/providers/google/chat/endpoint.py
@@ -15,9 +15,7 @@ class GeminiChatEndpoint(Endpoint):
         if config is None:
             from lionagi.config import settings
 
-            kwargs.setdefault(
-                "api_key", settings.GEMINI_API_KEY or "dummy-key-for-testing"
-            )
+            kwargs.setdefault("api_key", settings.GEMINI_API_KEY or "dummy-key-for-testing")
             kwargs.setdefault("kwargs", {"model": "gemini-2.5-flash"})
             kwargs.setdefault("requires_tokens", True)
         super().__init__(config, **kwargs)

--- a/lionagi/providers/google/gemini_code/endpoint.py
+++ b/lionagi/providers/google/gemini_code/endpoint.py
@@ -12,9 +12,9 @@ from lionagi.providers.google.gemini_code.models import (
     GeminiChunk,
     GeminiCodeRequest,
     GeminiSession,
+    stream_gemini_cli,
 )
 from lionagi.providers.google.gemini_code.models import log as gemini_log
-from lionagi.providers.google.gemini_code.models import stream_gemini_cli
 from lionagi.service.connections.agentic_endpoint import AgenticEndpoint
 from lionagi.service.connections.endpoint_config import EndpointConfig
 from lionagi.service.types.stream_chunk import StreamChunk
@@ -84,9 +84,7 @@ class GeminiCLIEndpoint(AgenticEndpoint):
 
     def _runtime_handlers(self, kwargs: dict) -> dict:
         handlers = self.gemini_handlers.copy()
-        call_handlers = {
-            k: kwargs.pop(k) for k in list(kwargs) if k in _GEMINI_HANDLER_PARAMS
-        }
+        call_handlers = {k: kwargs.pop(k) for k in list(kwargs) if k in _GEMINI_HANDLER_PARAMS}
         if call_handlers:
             _validate_handlers(call_handlers)
             handlers.update(call_handlers)
@@ -98,18 +96,14 @@ class GeminiCLIEndpoint(AgenticEndpoint):
         req_obj = GeminiCodeRequest(messages=messages, **req_dict)
         return {"request": req_obj}, {}
 
-    async def stream(
-        self, request: dict | BaseModel, **kwargs
-    ) -> AsyncIterator[StreamChunk]:
+    async def stream(self, request: dict | BaseModel, **kwargs) -> AsyncIterator[StreamChunk]:
         handlers = self._runtime_handlers(kwargs)
         if isinstance(request, dict) and "request" in request:
             request_obj = request["request"]
         else:
             payload, _ = self.create_payload(request, **kwargs)
             request_obj = payload["request"]
-        async with contextlib.aclosing(
-            stream_gemini_cli(request_obj, **handlers)
-        ) as gen:
+        async with contextlib.aclosing(stream_gemini_cli(request_obj, **handlers)) as gen:
             async for item in gen:
                 if isinstance(item, GeminiSession):
                     continue
@@ -168,18 +162,14 @@ class GeminiCLIEndpoint(AgenticEndpoint):
         session: GeminiSession = GeminiSession()
         handlers = self._runtime_handlers(kwargs)
 
-        async with contextlib.aclosing(
-            stream_gemini_cli(request, session, **handlers)
-        ) as gen:
+        async with contextlib.aclosing(stream_gemini_cli(request, session, **handlers)) as gen:
             async for chunk in gen:
                 if isinstance(chunk, dict):
                     if chunk.get("type") == "done":
                         break
                 responses.append(chunk)
 
-        gemini_log.info(
-            f"Session {session.session_id} finished with {len(responses)} chunks"
-        )
+        gemini_log.info(f"Session {session.session_id} finished with {len(responses)} chunks")
 
         # Accumulate text from chunks, concatenating delta fragments
         parts = []

--- a/lionagi/providers/groq/_config.py
+++ b/lionagi/providers/groq/_config.py
@@ -5,7 +5,6 @@ from lionagi.service.connections.registry import EndpointType
 
 
 class GroqConfigs(ProviderConfig, Enum):
-
     CHAT = (
         "chat/completions",
         ["chat"],

--- a/lionagi/providers/groq/audio_transcription/endpoint.py
+++ b/lionagi/providers/groq/audio_transcription/endpoint.py
@@ -29,9 +29,7 @@ class GroqAudioTranscriptionEndpoint(Endpoint):
         if config is None:
             from lionagi.config import settings
 
-            kwargs.setdefault(
-                "api_key", settings.GROQ_API_KEY or "dummy-key-for-testing"
-            )
+            kwargs.setdefault("api_key", settings.GROQ_API_KEY or "dummy-key-for-testing")
             kwargs.setdefault("timeout", 120)
             kwargs.setdefault("max_retries", 3)
         super().__init__(config, **kwargs)
@@ -53,18 +51,12 @@ class GroqAudioTranscriptionEndpoint(Endpoint):
         if file_data is not None:
             form.add_field(
                 "file",
-                (
-                    io.BytesIO(file_data)
-                    if isinstance(file_data, (bytes, bytearray))
-                    else file_data
-                ),
+                (io.BytesIO(file_data) if isinstance(file_data, (bytes, bytearray)) else file_data),
                 filename=filename,
                 content_type="application/octet-stream",
             )
 
-        multipart_headers = {
-            k: v for k, v in headers.items() if k.lower() != "content-type"
-        }
+        multipart_headers = {k: v for k, v in headers.items() if k.lower() != "content-type"}
 
         async with self._create_http_session() as session:
             async with session.post(

--- a/lionagi/providers/groq/chat/endpoint.py
+++ b/lionagi/providers/groq/chat/endpoint.py
@@ -16,9 +16,7 @@ class GroqChatEndpoint(Endpoint):
         if config is None:
             from lionagi.config import settings
 
-            kwargs.setdefault(
-                "api_key", settings.GROQ_API_KEY or "dummy-key-for-testing"
-            )
+            kwargs.setdefault("api_key", settings.GROQ_API_KEY or "dummy-key-for-testing")
             kwargs.setdefault("kwargs", {"model": "llama-3.3-70b-versatile"})
             kwargs.setdefault("requires_tokens", True)
         super().__init__(config, **kwargs)

--- a/lionagi/providers/nvidia_nim/_config.py
+++ b/lionagi/providers/nvidia_nim/_config.py
@@ -8,7 +8,6 @@ from lionagi.service.connections.registry import EndpointType
 
 
 class NvidiaNimConfigs(ProviderConfig, Enum):
-
     CHAT = (
         "chat/completions",
         ["chat"],

--- a/lionagi/providers/nvidia_nim/chat/endpoint.py
+++ b/lionagi/providers/nvidia_nim/chat/endpoint.py
@@ -23,9 +23,7 @@ class NvidiaNimChatEndpoint(Endpoint):
         if config is None:
             from lionagi.config import settings
 
-            kwargs.setdefault(
-                "api_key", settings.NVIDIA_NIM_API_KEY or "dummy-key-for-testing"
-            )
+            kwargs.setdefault("api_key", settings.NVIDIA_NIM_API_KEY or "dummy-key-for-testing")
             kwargs.setdefault("kwargs", {"model": "meta/llama3-8b-instruct"})
             kwargs.setdefault("requires_tokens", True)
         super().__init__(config, **kwargs)

--- a/lionagi/providers/nvidia_nim/embed/endpoint.py
+++ b/lionagi/providers/nvidia_nim/embed/endpoint.py
@@ -14,8 +14,6 @@ class NvidiaNimEmbedEndpoint(Endpoint):
         if config is None:
             from lionagi.config import settings
 
-            kwargs.setdefault(
-                "api_key", settings.NVIDIA_NIM_API_KEY or "dummy-key-for-testing"
-            )
+            kwargs.setdefault("api_key", settings.NVIDIA_NIM_API_KEY or "dummy-key-for-testing")
             kwargs.setdefault("kwargs", {"model": "nvidia/nv-embed-v1"})
         super().__init__(config, **kwargs)

--- a/lionagi/providers/ollama/_config.py
+++ b/lionagi/providers/ollama/_config.py
@@ -8,7 +8,6 @@ from lionagi.service.connections.registry import EndpointType
 
 
 class OllamaConfigs(ProviderConfig, Enum):
-
     CHAT = (
         "chat/completions",
         ["chat"],

--- a/lionagi/providers/ollama/embed/endpoint.py
+++ b/lionagi/providers/ollama/embed/endpoint.py
@@ -14,7 +14,6 @@ from lionagi.service.connections.endpoint_config import EndpointConfig
 from lionagi.utils import is_import_installed
 
 from .._config import OllamaConfigs
-from .models import OllamaEmbedRequest
 
 __all__ = ("OllamaEmbedEndpoint",)
 

--- a/lionagi/providers/ollama/generate/endpoint.py
+++ b/lionagi/providers/ollama/generate/endpoint.py
@@ -18,7 +18,6 @@ from lionagi.service.connections.endpoint_config import EndpointConfig
 from lionagi.utils import is_import_installed
 
 from .._config import OllamaConfigs
-from .models import OllamaGenerateRequest
 
 __all__ = ("OllamaGenerateEndpoint",)
 

--- a/lionagi/providers/openai/_config.py
+++ b/lionagi/providers/openai/_config.py
@@ -8,7 +8,6 @@ from lionagi.service.connections.registry import EndpointType
 
 
 class OpenAIConfigs(ProviderConfig, Enum):
-
     CHAT = (
         "chat/completions",
         ["chat"],
@@ -72,7 +71,6 @@ OpenAIConfigs._PROVIDER_ALIASES = []
 
 
 class CodexConfigs(ProviderConfig, Enum):
-
     CLI = (
         "query_cli",
         ["cli", "code"],

--- a/lionagi/providers/openai/audio/endpoint.py
+++ b/lionagi/providers/openai/audio/endpoint.py
@@ -35,9 +35,7 @@ class OpenaiAudioSpeechEndpoint(Endpoint):
         if config is None:
             from lionagi.config import settings
 
-            kwargs.setdefault(
-                "api_key", settings.OPENAI_API_KEY or "dummy-key-for-testing"
-            )
+            kwargs.setdefault("api_key", settings.OPENAI_API_KEY or "dummy-key-for-testing")
             kwargs.setdefault("timeout", 120)
             kwargs.setdefault("max_retries", 3)
         super().__init__(config=config, **kwargs)
@@ -102,9 +100,7 @@ class OpenaiAudioTranscriptionEndpoint(Endpoint):
         if config is None:
             from lionagi.config import settings
 
-            kwargs.setdefault(
-                "api_key", settings.OPENAI_API_KEY or "dummy-key-for-testing"
-            )
+            kwargs.setdefault("api_key", settings.OPENAI_API_KEY or "dummy-key-for-testing")
             kwargs.setdefault("timeout", 120)
             kwargs.setdefault("max_retries", 3)
         super().__init__(config=config, **kwargs)
@@ -147,9 +143,7 @@ class OpenaiAudioTranscriptionEndpoint(Endpoint):
             )
 
         # Remove Content-Type from headers — aiohttp sets it automatically with boundary
-        multipart_headers = {
-            k: v for k, v in headers.items() if k.lower() != "content-type"
-        }
+        multipart_headers = {k: v for k, v in headers.items() if k.lower() != "content-type"}
 
         async with self._create_http_session() as session:
             async with session.post(

--- a/lionagi/providers/openai/chat/endpoint.py
+++ b/lionagi/providers/openai/chat/endpoint.py
@@ -14,9 +14,7 @@ class OpenaiChatEndpoint(Endpoint):
         if config is None:
             from lionagi.config import settings
 
-            kwargs.setdefault(
-                "api_key", settings.OPENAI_API_KEY or "dummy-key-for-testing"
-            )
+            kwargs.setdefault("api_key", settings.OPENAI_API_KEY or "dummy-key-for-testing")
             kwargs.setdefault("kwargs", {"model": settings.OPENAI_DEFAULT_MODEL})
             kwargs.setdefault("requires_tokens", True)
         super().__init__(config, **kwargs)

--- a/lionagi/providers/openai/chat/models.py
+++ b/lionagi/providers/openai/chat/models.py
@@ -223,9 +223,7 @@ class ResponseFormatJSONObject(BaseModel):
 
 class JSONSchemaFormat(BaseModel):
     name: str
-    schema_: dict[str, Any] = Field(
-        alias="schema", description="JSON Schema definition"
-    )
+    schema_: dict[str, Any] = Field(alias="schema", description="JSON Schema definition")
     strict: bool | None = Field(
         default=None,
         description="If true, disallow unspecified properties (strict schema).",
@@ -282,9 +280,7 @@ class ToolMessage(BaseModel):
     tool_call_id: str  # must reference the assistant's tool_calls[i].id
 
 
-ChatMessage = (
-    SystemMessage | DeveloperMessage | UserMessage | AssistantMessage | ToolMessage
-)
+ChatMessage = SystemMessage | DeveloperMessage | UserMessage | AssistantMessage | ToolMessage
 
 # ---------- Stream options ----------
 
@@ -316,9 +312,7 @@ class OpenAIChatCompletionsRequest(BaseModel):
     temperature: float | None = Field(
         default=None, ge=0.0, le=2.0, description="Higher is more random."
     )
-    top_p: float | None = Field(
-        default=None, ge=0.0, le=1.0, description="Nucleus sampling."
-    )
+    top_p: float | None = Field(default=None, ge=0.0, le=1.0, description="Nucleus sampling.")
     presence_penalty: float | None = Field(
         default=None,
         ge=-2.0,
@@ -383,11 +377,9 @@ class OpenAIChatCompletionsRequest(BaseModel):
     stream_options: StreamOptions | None = None
 
     # Routing / tiering
-    service_tier: Literal["auto", "default", "flex", "scale", "priority"] | None = (
-        Field(
-            default=None,
-            description="Processing tier; requires account eligibility.",
-        )
+    service_tier: Literal["auto", "default", "flex", "scale", "priority"] | None = Field(
+        default=None,
+        description="Processing tier; requires account eligibility.",
     )
 
     # Misc

--- a/lionagi/providers/openai/embed/endpoint.py
+++ b/lionagi/providers/openai/embed/endpoint.py
@@ -9,9 +9,7 @@ class OpenaiEmbedEndpoint(Endpoint):
         if config is None:
             from lionagi.config import settings
 
-            kwargs.setdefault(
-                "api_key", settings.OPENAI_API_KEY or "dummy-key-for-testing"
-            )
+            kwargs.setdefault("api_key", settings.OPENAI_API_KEY or "dummy-key-for-testing")
             kwargs.setdefault("kwargs", {"model": "text-embedding-3-small"})
             kwargs.setdefault("requires_tokens", True)
         super().__init__(config, **kwargs)

--- a/lionagi/providers/openai/images/endpoint.py
+++ b/lionagi/providers/openai/images/endpoint.py
@@ -34,9 +34,7 @@ class OpenaiImageGenerationEndpoint(Endpoint):
         if config is None:
             from lionagi.config import settings
 
-            kwargs.setdefault(
-                "api_key", settings.OPENAI_API_KEY or "dummy-key-for-testing"
-            )
+            kwargs.setdefault("api_key", settings.OPENAI_API_KEY or "dummy-key-for-testing")
             kwargs.setdefault("timeout", 120)
             kwargs.setdefault("max_retries", 3)
         super().__init__(config=config, **kwargs)
@@ -66,9 +64,7 @@ class OpenaiImageEditEndpoint(Endpoint):
         if config is None:
             from lionagi.config import settings
 
-            kwargs.setdefault(
-                "api_key", settings.OPENAI_API_KEY or "dummy-key-for-testing"
-            )
+            kwargs.setdefault("api_key", settings.OPENAI_API_KEY or "dummy-key-for-testing")
             kwargs.setdefault("timeout", 120)
             kwargs.setdefault("max_retries", 3)
         super().__init__(config=config, **kwargs)
@@ -104,18 +100,12 @@ class OpenaiImageEditEndpoint(Endpoint):
         if mask_data is not None:
             form.add_field(
                 "mask",
-                (
-                    io.BytesIO(mask_data)
-                    if isinstance(mask_data, (bytes, bytearray))
-                    else mask_data
-                ),
+                (io.BytesIO(mask_data) if isinstance(mask_data, (bytes, bytearray)) else mask_data),
                 filename=mask_filename,
                 content_type="image/png",
             )
 
-        multipart_headers = {
-            k: v for k, v in headers.items() if k.lower() != "content-type"
-        }
+        multipart_headers = {k: v for k, v in headers.items() if k.lower() != "content-type"}
 
         async with self._create_http_session() as session:
             async with session.post(

--- a/lionagi/providers/openai/response/endpoint.py
+++ b/lionagi/providers/openai/response/endpoint.py
@@ -9,8 +9,6 @@ class OpenaiResponseEndpoint(Endpoint):
         if config is None:
             from lionagi.config import settings
 
-            kwargs.setdefault(
-                "api_key", settings.OPENAI_API_KEY or "dummy-key-for-testing"
-            )
+            kwargs.setdefault("api_key", settings.OPENAI_API_KEY or "dummy-key-for-testing")
             kwargs.setdefault("requires_tokens", True)
         super().__init__(config, **kwargs)

--- a/lionagi/providers/openrouter/_config.py
+++ b/lionagi/providers/openrouter/_config.py
@@ -8,7 +8,6 @@ from lionagi.service.connections.registry import EndpointType
 
 
 class OpenRouterConfigs(ProviderConfig, Enum):
-
     CHAT = (
         "chat/completions",
         ["chat", "chat/completions"],

--- a/lionagi/providers/openrouter/chat/endpoint.py
+++ b/lionagi/providers/openrouter/chat/endpoint.py
@@ -7,7 +7,6 @@ from lionagi.service.connections.endpoint import Endpoint
 from lionagi.service.connections.endpoint_config import EndpointConfig
 
 from .._config import OpenRouterConfigs
-from .models import OpenRouterRequest, ReasoningConfig
 
 __all__ = ("OpenRouterEndpoint",)
 
@@ -41,9 +40,7 @@ class OpenRouterEndpoint(Endpoint):
         if config is None:
             from lionagi.config import settings
 
-            kwargs.setdefault(
-                "api_key", settings.OPENROUTER_API_KEY or "dummy-key-for-testing"
-            )
+            kwargs.setdefault("api_key", settings.OPENROUTER_API_KEY or "dummy-key-for-testing")
             kwargs.setdefault("kwargs", {"model": "google/gemini-2.5-flash"})
             kwargs.setdefault("requires_tokens", True)
         super().__init__(config=config, **kwargs)

--- a/lionagi/providers/perplexity/_config.py
+++ b/lionagi/providers/perplexity/_config.py
@@ -8,7 +8,6 @@ from lionagi.service.connections.registry import EndpointType
 
 
 class PerplexityConfigs(ProviderConfig, Enum):
-
     CHAT = (
         "chat/completions",
         ["chat"],

--- a/lionagi/providers/perplexity/chat/endpoint.py
+++ b/lionagi/providers/perplexity/chat/endpoint.py
@@ -9,7 +9,6 @@ This module configures endpoints for different Sonar model tiers.
 """
 
 from lionagi.service.connections.endpoint import Endpoint
-from lionagi.service.connections.endpoint_config import EndpointConfig
 
 from .._config import PerplexityConfigs
 
@@ -27,9 +26,7 @@ class PerplexityChatEndpoint(Endpoint):
         if config is None:
             from lionagi.config import settings
 
-            kwargs.setdefault(
-                "api_key", settings.PERPLEXITY_API_KEY or "dummy-key-for-testing"
-            )
+            kwargs.setdefault("api_key", settings.PERPLEXITY_API_KEY or "dummy-key-for-testing")
             kwargs.setdefault("kwargs", {"model": "sonar"})
             kwargs.setdefault("requires_tokens", True)
         super().__init__(config, **kwargs)

--- a/lionagi/providers/pi/_config.py
+++ b/lionagi/providers/pi/_config.py
@@ -8,7 +8,6 @@ from lionagi.service.connections.registry import EndpointType
 
 
 class PiConfigs(ProviderConfig, Enum):
-
     CLI = (
         "query_cli",
         ["cli", "code"],

--- a/lionagi/providers/pi/cli/endpoint.py
+++ b/lionagi/providers/pi/cli/endpoint.py
@@ -14,9 +14,8 @@ from lionagi.service.types.stream_chunk import StreamChunk
 from lionagi.utils import to_dict
 
 from .._config import PiConfigs
-from .models import PiChunk, PiCodeRequest, PiSession
+from .models import PiChunk, PiCodeRequest, PiSession, stream_pi_cli
 from .models import log as pi_log
-from .models import stream_pi_cli
 
 CONTEXT_WINDOWS: dict[str, int] = {
     "pi": 128_000,
@@ -77,9 +76,7 @@ class PiCLIEndpoint(AgenticEndpoint):
 
     def _runtime_handlers(self, kwargs: dict) -> dict:
         handlers = self.pi_handlers.copy()
-        call_handlers = {
-            k: kwargs.pop(k) for k in list(kwargs) if k in _PI_HANDLER_PARAMS
-        }
+        call_handlers = {k: kwargs.pop(k) for k in list(kwargs) if k in _PI_HANDLER_PARAMS}
         if call_handlers:
             _validate_handlers(call_handlers)
             handlers.update(call_handlers)
@@ -88,15 +85,11 @@ class PiCLIEndpoint(AgenticEndpoint):
     def create_payload(self, request: dict | BaseModel, **kwargs):
         req_dict = {**self.config.kwargs, **to_dict(request), **kwargs}
         messages = req_dict.pop("messages", [])
-        req_dict = {
-            k: v for k, v in req_dict.items() if k in PiCodeRequest.model_fields
-        }
+        req_dict = {k: v for k, v in req_dict.items() if k in PiCodeRequest.model_fields}
         req_obj = PiCodeRequest(messages=messages, **req_dict)
         return {"request": req_obj}, {}
 
-    async def stream(
-        self, request: dict | BaseModel, **kwargs
-    ) -> AsyncIterator[StreamChunk]:
+    async def stream(self, request: dict | BaseModel, **kwargs) -> AsyncIterator[StreamChunk]:
         handlers = self._runtime_handlers(kwargs)
         if isinstance(request, dict) and "request" in request:
             request_obj = request["request"]
@@ -104,9 +97,7 @@ class PiCLIEndpoint(AgenticEndpoint):
             payload, _ = self.create_payload(request, **kwargs)
             request_obj = payload["request"]
         session = PiSession()
-        async with contextlib.aclosing(
-            stream_pi_cli(request_obj, session, **handlers)
-        ) as gen:
+        async with contextlib.aclosing(stream_pi_cli(request_obj, session, **handlers)) as gen:
             async for item in gen:
                 if isinstance(item, PiSession):
                     yield StreamChunk(
@@ -150,9 +141,7 @@ class PiCLIEndpoint(AgenticEndpoint):
         session: PiSession = PiSession()
         handlers = self._runtime_handlers(kwargs)
 
-        async with contextlib.aclosing(
-            stream_pi_cli(request, session, **handlers)
-        ) as gen:
+        async with contextlib.aclosing(stream_pi_cli(request, session, **handlers)) as gen:
             async for chunk in gen:
                 if isinstance(chunk, dict):
                     if chunk.get("type") == "done":

--- a/lionagi/providers/tavily/_config.py
+++ b/lionagi/providers/tavily/_config.py
@@ -8,7 +8,6 @@ from lionagi.service.connections.registry import EndpointType
 
 
 class TavilyConfigs(ProviderConfig, Enum):
-
     SEARCH = (
         "search",
         [],

--- a/lionagi/providers/tavily/search/endpoint.py
+++ b/lionagi/providers/tavily/search/endpoint.py
@@ -17,9 +17,7 @@ class TavilySearchEndpoint(Endpoint):
         if config is None:
             from lionagi.config import settings
 
-            kwargs.setdefault(
-                "api_key", settings.TAVILY_API_KEY or "dummy-key-for-testing"
-            )
+            kwargs.setdefault("api_key", settings.TAVILY_API_KEY or "dummy-key-for-testing")
             kwargs.setdefault("timeout", 120)
             kwargs.setdefault("max_retries", 3)
         super().__init__(config=config, **kwargs)
@@ -31,9 +29,7 @@ class TavilyExtractEndpoint(Endpoint):
         if config is None:
             from lionagi.config import settings
 
-            kwargs.setdefault(
-                "api_key", settings.TAVILY_API_KEY or "dummy-key-for-testing"
-            )
+            kwargs.setdefault("api_key", settings.TAVILY_API_KEY or "dummy-key-for-testing")
             kwargs.setdefault("timeout", 120)
             kwargs.setdefault("max_retries", 3)
         super().__init__(config=config, **kwargs)

--- a/lionagi/service/connections/api_calling.py
+++ b/lionagi/service/connections/api_calling.py
@@ -63,9 +63,7 @@ class APICalling(HookedEvent):
         # Add token usage information to the last message if requested
         if self.include_token_usage_to_model and self.endpoint.config.requires_tokens:
             # Handle both messages format (chat completions) and input format (responses API)
-            if "messages" in self.payload and isinstance(
-                self.payload["messages"][-1], dict
-            ):
+            if "messages" in self.payload and isinstance(self.payload["messages"][-1], dict):
                 required_tokens = self.required_tokens
                 content = self.payload["messages"][-1]["content"]
                 # Model token limit mapping

--- a/lionagi/service/connections/cli_endpoint.py
+++ b/lionagi/service/connections/cli_endpoint.py
@@ -3,6 +3,5 @@
 
 # Re-export from agentic_endpoint for backward compatibility.
 from .agentic_endpoint import AgenticEndpoint as CLIEndpoint
-from .endpoint_config import EndpointConfig
 
 __all__ = ("CLIEndpoint",)

--- a/lionagi/service/connections/endpoint_config.py
+++ b/lionagi/service/connections/endpoint_config.py
@@ -109,9 +109,7 @@ class EndpointConfig(BaseModel):
                 return load_pydantic_model_from_schema(v)
         except Exception as e:
             raise ValueError("Invalid request options") from e
-        raise ValueError(
-            "Invalid request options: must be a Pydantic model or a schema dict"
-        )
+        raise ValueError("Invalid request options: must be a Pydantic model or a schema dict")
 
     @field_serializer("request_options")
     def _serialize_request_options(self, v: B | None):

--- a/lionagi/service/connections/header_factory.py
+++ b/lionagi/service/connections/header_factory.py
@@ -43,11 +43,7 @@ class HeaderFactory:
         elif not api_key:
             raise ValueError("API key is required for authentication")
         else:
-            api_key = (
-                api_key.get_secret_value()
-                if isinstance(api_key, SecretStr)
-                else api_key
-            )
+            api_key = api_key.get_secret_value() if isinstance(api_key, SecretStr) else api_key
             if auth_type == "bearer":
                 dict_.update(HeaderFactory.get_bearer_auth_header(api_key))
             elif auth_type == "x-api-key":

--- a/lionagi/service/imodel.py
+++ b/lionagi/service/imodel.py
@@ -140,9 +140,7 @@ class iModel:  # noqa: N801
         # 3. Configure executor ---------------------------------------------
         # Resolve defaults based on endpoint type
         if queue_capacity is None:
-            queue_capacity = (
-                self.endpoint.DEFAULT_QUEUE_CAPACITY if self.endpoint.is_cli else 100
-            )
+            queue_capacity = self.endpoint.DEFAULT_QUEUE_CAPACITY if self.endpoint.is_cli else 100
         if concurrency_limit is None and self.endpoint.is_cli:
             concurrency_limit = self.endpoint.DEFAULT_CONCURRENCY_LIMIT
 
@@ -184,11 +182,7 @@ class iModel:  # noqa: N801
                 registry=self.hook_registry,
                 event_like=create_event_type,
                 params=create_event_hook_params or {},
-                exit=(
-                    self.exit_hook
-                    if create_event_exit_hook is None
-                    else create_event_exit_hook
-                ),
+                exit=(self.exit_hook if create_event_exit_hook is None else create_event_exit_hook),
                 timeout=create_event_hook_timeout,
             )
             await h_ev.invoke()
@@ -262,9 +256,7 @@ class iModel:  # noqa: N801
             kwargs["resume"] = self.endpoint.session_id
 
         transport_arg_keys = getattr(self.endpoint, "transport_arg_keys", ())
-        call_kwargs = {
-            k: kwargs.pop(k) for k in list(kwargs) if k in transport_arg_keys
-        }
+        call_kwargs = {k: kwargs.pop(k) for k in list(kwargs) if k in transport_arg_keys}
 
         # The new Endpoint.create_payload returns (payload, headers)
         payload, headers = self.endpoint.create_payload(request=kwargs)
@@ -302,10 +294,8 @@ class iModel:  # noqa: N801
         # Hook registry takes priority over streaming_process_func.
         # If the registry handles the chunk type, streaming_process_func is not called.
         if chunk_key is not None:
-            hook_result, should_exit, _status = (
-                await self.hook_registry.handle_streaming_chunk(
-                    chunk_key, chunk, exit=self.exit_hook
-                )
+            hook_result, should_exit, _status = await self.hook_registry.handle_streaming_chunk(
+                chunk_key, chunk, exit=self.exit_hook
             )
             if should_exit:
                 if (

--- a/lionagi/service/token_budget.py
+++ b/lionagi/service/token_budget.py
@@ -174,9 +174,7 @@ def get_token_budget(branch: Branch) -> TokenBudget:
             msg = pile[uid]
             c = msg.content if hasattr(msg, "content") else ""
             if c:
-                used += TokenCalculator.tokenize(
-                    str(c) if not isinstance(c, str) else c
-                )
+                used += TokenCalculator.tokenize(str(c) if not isinstance(c, str) else c)
 
     model_name = None
     try:

--- a/lionagi/service/token_calculator.py
+++ b/lionagi/service/token_calculator.py
@@ -41,8 +41,7 @@ class TokenCalculator:
             ).encode
 
             return sum(
-                TokenCalculator._calculate_embed_item(i, tokenizer=tokenizer)
-                for i in inputs
+                TokenCalculator._calculate_embed_item(i, tokenizer=tokenizer) for i in inputs
             )
         except Exception:
             return 0
@@ -83,9 +82,7 @@ class TokenCalculator:
     def _calculate_chatitem(i_, tokenizer: Callable, model_name: str) -> int:
         try:
             if isinstance(i_, str):
-                return TokenCalculator.tokenize(
-                    i_, encoding_name=model_name, tokenizer=tokenizer
-                )
+                return TokenCalculator.tokenize(i_, encoding_name=model_name, tokenizer=tokenizer)
 
             if isinstance(i_, dict):
                 if "text" in i_:
@@ -97,8 +94,7 @@ class TokenCalculator:
 
             if isinstance(i_, list):
                 return sum(
-                    TokenCalculator._calculate_chatitem(x, tokenizer, model_name)
-                    for x in i_
+                    TokenCalculator._calculate_chatitem(x, tokenizer, model_name) for x in i_
                 )
         except Exception:
             return 0
@@ -110,8 +106,6 @@ class TokenCalculator:
                 return TokenCalculator.tokenize(s_, tokenizer=tokenizer)
 
             if isinstance(s_, list):
-                return sum(
-                    TokenCalculator._calculate_embed_item(x, tokenizer) for x in s_
-                )
+                return sum(TokenCalculator._calculate_embed_item(x, tokenizer) for x in s_)
         except Exception:
             return 0

--- a/lionagi/session/exchange.py
+++ b/lionagi/session/exchange.py
@@ -39,9 +39,7 @@ def _add_progression_to_flow(flow: Flow, progression: Progression) -> None:
     mirroring what Flow.add_progression() does after include() succeeds.
     """
     if progression.name and progression.name in flow._progression_names:
-        raise ItemExistsError(
-            f"Progression with name '{progression.name}' already exists."
-        )
+        raise ItemExistsError(f"Progression with name '{progression.name}' already exists.")
     flow.progressions.collections[progression.id] = progression
     flow.progressions.progression.append(progression.id)
     if progression.name:
@@ -149,17 +147,11 @@ class Exchange(Element):
                             except Exception:
                                 message_copy = message.model_copy()
                             deliveries.append((other_id, message_copy))
-                elif (
-                    message.recipient is not None
-                    and message.recipient in self._owner_index
-                ):
+                elif message.recipient is not None and message.recipient in self._owner_index:
                     deliveries.append((message.recipient, message))
         if deliveries:
             await gather(
-                *[
-                    self._deliver_to(recipient_id, message)
-                    for recipient_id, message in deliveries
-                ],
+                *[self._deliver_to(recipient_id, message) for recipient_id, message in deliveries],
                 return_exceptions=True,
             )
 
@@ -217,9 +209,7 @@ class Exchange(Element):
         if flow is None:
             raise ValueError(f"Sender {sender} not registered")
 
-        message = Message(
-            sender=sender, recipient=recipient, content=content, channel=channel
-        )
+        message = Message(sender=sender, recipient=recipient, content=content, channel=channel)
         flow.add_item(message, progressions=OUTBOX)
         return message
 

--- a/lionagi/state/health.py
+++ b/lionagi/state/health.py
@@ -99,10 +99,7 @@ def classify_session_health(
         # produced a single message AND no artifacts on disk. This is
         # a session that crashed before doing anything; transitioning
         # it to failed is harmless, deleting it is also safe.
-        if (
-            not has_artifacts
-            and (session.get("message_count") or 0) == 0
-        ):
+        if not has_artifacts and (session.get("message_count") or 0) == 0:
             return SessionHealth.ORPHANED
         return SessionHealth.STALE
 

--- a/lionagi/state/persist.py
+++ b/lionagi/state/persist.py
@@ -67,9 +67,7 @@ async def persist_session(db: StateDB, session: Session) -> None:
         await _persist_branch(db, session_id, branch, all_message_ids)
 
     # Add only NEW messages to session progression
-    new_session_msgs = [
-        mid for mid in all_message_ids if mid not in existing_session_msgs
-    ]
+    new_session_msgs = [mid for mid in all_message_ids if mid not in existing_session_msgs]
     for mid in new_session_msgs:
         await db.append_to_progression(session_prog_id, mid)
 
@@ -136,10 +134,7 @@ async def _persist_branch(
         sys_dict = branch.system.to_dict(mode="db")
         system_msg_id = sys_dict["id"]
         await db.insert_message(sys_dict)
-        if (
-            system_msg_id not in existing_msg_ids
-            and system_msg_id not in all_message_ids
-        ):
+        if system_msg_id not in existing_msg_ids and system_msg_id not in all_message_ids:
             all_message_ids.append(system_msg_id)
 
     # On resume the branch row already exists (INSERT OR IGNORE would be a no-op).

--- a/lionagi/state/provenance.py
+++ b/lionagi/state/provenance.py
@@ -48,9 +48,7 @@ def _hash_file(path: Path) -> str:
     return hashlib.sha256(data).hexdigest()[:_AGENT_HASH_LEN]
 
 
-def resolve_model_spec(
-    provider: str | None, model: str | None
-) -> str | None:
+def resolve_model_spec(provider: str | None, model: str | None) -> str | None:
     """Produce the canonical ``"provider/model"`` string for storage.
 
     ADR-0022 requires the stored value to be the resolved spec, not the

--- a/lionagi/state/staleness.py
+++ b/lionagi/state/staleness.py
@@ -21,18 +21,16 @@ from typing import Any
 # Per-invocation_kind activity thresholds (seconds). Single-shot runs
 # are tight; multi-agent flows get headroom.
 STALE_THRESHOLDS: dict[str, int] = {
-    "agent": 6 * 3600,        # 6h — single agent
-    "play": 6 * 3600,         # 6h — single-play run
-    "flow": 12 * 3600,        # 12h — multi-agent DAG
-    "fanout": 12 * 3600,      # 12h — parallel fanout
-    "show-play": 12 * 3600,   # 12h — show-managed plays
+    "agent": 6 * 3600,  # 6h — single agent
+    "play": 6 * 3600,  # 6h — single-play run
+    "flow": 12 * 3600,  # 12h — multi-agent DAG
+    "fanout": 12 * 3600,  # 12h — parallel fanout
+    "show-play": 12 * 3600,  # 12h — show-managed plays
 }
 DEFAULT_STALE_THRESHOLD: int = 6 * 3600
 
 
-def staleness_check(
-    session: dict[str, Any], *, now: float | None = None
-) -> str | None:
+def staleness_check(session: dict[str, Any], *, now: float | None = None) -> str | None:
     """Return ``"stale"`` if ``session`` is running past its activity threshold.
 
     Returns ``None`` for terminal sessions — ADR-0024's
@@ -48,14 +46,8 @@ def staleness_check(
     """
     if session.get("status") != "running":
         return None
-    threshold = STALE_THRESHOLDS.get(
-        session.get("invocation_kind"), DEFAULT_STALE_THRESHOLD
-    )
-    last_activity = (
-        session.get("last_message_at")
-        or session.get("updated_at")
-        or 0
-    )
+    threshold = STALE_THRESHOLDS.get(session.get("invocation_kind"), DEFAULT_STALE_THRESHOLD)
+    last_activity = session.get("last_message_at") or session.get("updated_at") or 0
     ts = now if now is not None else time.time()
     if ts - last_activity > threshold:
         return "stale"

--- a/lionagi/tools/coding.py
+++ b/lionagi/tools/coding.py
@@ -28,17 +28,12 @@ if TYPE_CHECKING:
     from lionagi.session.branch import Branch
 
 
-# ---------------------------------------------------------------------------
-# Workspace path validation (Finding 14)
-# ---------------------------------------------------------------------------
-
 _DENIED_NAMES: frozenset[str] = frozenset(
     {".env", ".netrc", "id_rsa", "id_ed25519", "id_ecdsa", ".htpasswd"}
 )
 
 
 def _resolve_workspace_path(path: str, workspace_root: Path) -> Path:
-    """Finding 14: resolve path under workspace_root; raise PermissionError if it escapes."""
     raw = Path(path).expanduser()
     candidate = raw if raw.is_absolute() else workspace_root / raw
     # GAP B: check symlink on candidate BEFORE resolve() follows it
@@ -291,7 +286,6 @@ _IMAGE_MEDIA_TYPES = {
 
 
 def _read_image_sync(path: str, workspace_root: Path) -> dict:
-    # Finding 14: validate path before reading image bytes
     try:
         p = _resolve_workspace_path(path, workspace_root)
     except PermissionError as e:
@@ -313,7 +307,6 @@ def _read_image_sync(path: str, workspace_root: Path) -> dict:
 
 
 def _read_file_sync(path: str, offset: int, max_lines: int, workspace_root: Path) -> dict:
-    # Finding 14: validate path under workspace root
     try:
         p = _resolve_workspace_path(path, workspace_root)
     except PermissionError as e:
@@ -360,7 +353,6 @@ def _read_file_sync(path: str, offset: int, max_lines: int, workspace_root: Path
 def _list_dir_sync(
     path: str, recursive: bool, file_types: list[str] | None, workspace_root: Path
 ) -> dict:
-    # Finding 14: validate directory path
     try:
         base = _resolve_workspace_path(path, workspace_root)
     except PermissionError as e:
@@ -376,7 +368,6 @@ def _list_dir_sync(
 
 
 def _write_file_sync(file_path: str, content: str, workspace_root: Path) -> dict:
-    # Finding 14: validate path before writing
     try:
         p = _resolve_workspace_path(file_path, workspace_root)
     except PermissionError as e:
@@ -408,7 +399,6 @@ def _edit_file_sync(
     replace_all: bool,
     workspace_root: Path,
 ) -> dict:
-    # Finding 14: validate path before reading or writing
     try:
         p = _resolve_workspace_path(file_path, workspace_root)
     except PermissionError as e:
@@ -472,10 +462,7 @@ _MAX_OUTPUT_BYTES = 100_000
 
 
 def _drain_stream(stream, buf: bytearray) -> bool:
-    """Finding 5: read stream into buf up to _MAX_OUTPUT_BYTES; return True if truncated.
-
-    Continues reading even after cap to prevent pipe-buffer deadlock.
-    """
+    """Continues reading even after cap to prevent pipe-buffer deadlock."""
     truncated = False
     while True:
         try:
@@ -493,7 +480,6 @@ def _drain_stream(stream, buf: bytearray) -> bool:
 
 
 def _subprocess_sync(cmd, shell: bool, timeout_s: float, cwd: str | None) -> dict:
-    # Finding 5: use Popen + threads for bounded memory capture and child-group kill
     try:
         proc = subprocess.Popen(  # noqa: S603
             cmd,
@@ -626,7 +612,6 @@ class CodingToolkit(LionTool):
     system_tool_name = "coding_toolkit"
 
     def security_pre(self, tool_name: str, handler: Callable) -> CodingToolkit:
-        """Finding 13: register a security hook that runs before user pre-hooks."""
         self._security_pre_hooks.setdefault(tool_name, []).append(handler)
         return self
 
@@ -643,12 +628,8 @@ class CodingToolkit(LionTool):
         return self
 
     def _build_preprocessor(self, tool_name: str) -> Callable | None:
-        """Build a chained preprocessor from registered hooks for this tool.
-
-        Finding 13: security_pre hooks run before user pre hooks.
-        """
+        """Build a chained preprocessor from registered hooks for this tool."""
         security_hooks = [
-            # Finding 13: security hooks first, then user hooks
             *self._security_pre_hooks.get("*", []),
             *self._security_pre_hooks.get(tool_name, []),
         ]
@@ -700,14 +681,13 @@ class CodingToolkit(LionTool):
         workspace_root: str | Path | None = None,
         tools: Sequence[str] | None = None,
     ):
-        self._security_pre_hooks: dict[str, list[Callable]] = {}  # Finding 13
+        self._security_pre_hooks: dict[str, list[Callable]] = {}
         self._pre_hooks: dict[str, list[Callable]] = {}
         self._post_hooks: dict[str, list[Callable]] = {}
         self._error_hooks: dict[str, list[Callable]] = {}
         self.notify = notify
         self.notify_threshold = notify_threshold
         self.notify_max_tokens = notify_max_tokens
-        # Finding 14: workspace root for path containment checks
         self.workspace_root = Path(workspace_root or Path.cwd()).expanduser().resolve()
         # Which tools to register. None -> the lean default core; pass an explicit
         # list to opt into context/sandbox/subagent.
@@ -724,7 +704,6 @@ class CodingToolkit(LionTool):
         call_count = [0]
         msgs = branch.msgs
         notify = self.notify
-        # Finding 14: capture workspace root for use in all sync file helpers
         workspace_root = self.workspace_root
 
         def _system_status() -> str | None:
@@ -805,7 +784,6 @@ class CodingToolkit(LionTool):
             if action == "read":
                 start = max(0, offset or 0)
                 max_lines = limit if (limit and limit > 0) else 2000
-                # Finding 14: pass workspace_root to enforce path containment
                 result = await run_sync(_read_file_sync, path, start, max_lines, workspace_root)
                 _track(result)
                 return result
@@ -843,7 +821,6 @@ class CodingToolkit(LionTool):
                     guard = _check_read_guard(file_path)
                     if guard:
                         return {"success": False, "error": guard}
-                # Finding 14: pass workspace_root to enforce path containment
                 result = await run_sync(_write_file_sync, file_path, content, workspace_root)
                 _track(result)
                 return result
@@ -855,7 +832,6 @@ class CodingToolkit(LionTool):
                 guard = _check_read_guard(file_path)
                 if guard:
                     return {"success": False, "error": guard}
-                # Finding 14: pass workspace_root to enforce path containment
                 result = await run_sync(
                     _edit_file_sync,
                     file_path,

--- a/lionagi/tools/communication/messenger.py
+++ b/lionagi/tools/communication/messenger.py
@@ -110,9 +110,7 @@ class LionMessenger(LionTool):
             if msg not in branch.msgs.messages:
                 branch.msgs.messages.include(msg)
 
-        def messenger(
-            action: str, to: str | list[str] = None, content: str = None
-        ) -> str:
+        def messenger(action: str, to: str | list[str] = None, content: str = None) -> str:
             """Send messages to teammates, signal done/finished, or wake a teammate.
 
             Args:
@@ -143,9 +141,7 @@ class LionMessenger(LionTool):
                 return "; ".join(results)
 
             elif action == "done":
-                fire(
-                    "done", name=_sender_name, sender_id=sender_id, reason=content or ""
-                )
+                fire("done", name=_sender_name, sender_id=sender_id, reason=content or "")
                 return f"{_sender_name} is now done: {content or 'no reason'}"
 
             elif action == "finished":
@@ -155,9 +151,7 @@ class LionMessenger(LionTool):
                     sender_id=sender_id,
                     reason=content or "",
                 )
-                return (
-                    f"{_sender_name} is permanently finished: {content or 'no reason'}"
-                )
+                return f"{_sender_name} is permanently finished: {content or 'no reason'}"
 
             elif action == "wakeup":
                 if not to or not content:

--- a/lionagi/tools/file/editor.py
+++ b/lionagi/tools/file/editor.py
@@ -14,14 +14,12 @@ from lionagi.protocols.action.tool import Tool
 
 from ..base import LionTool
 
-# Finding 6/7: deny access to common secret/credential filenames
 _DENIED_NAMES: frozenset[str] = frozenset(
     {".env", ".netrc", "id_rsa", "id_ed25519", "id_ecdsa", ".htpasswd"}
 )
 
 
 def _resolve_workspace_path(path: str, workspace_root: Path) -> Path:
-    """Finding 6: resolve path under workspace_root; raise PermissionError if it escapes."""
     raw = Path(path).expanduser()
     candidate = raw if raw.is_absolute() else workspace_root / raw
     # GAP B: check symlink on candidate BEFORE resolve() follows it
@@ -38,7 +36,6 @@ def _resolve_workspace_path(path: str, workspace_root: Path) -> Path:
 
 
 def _resolve_existing_workspace_file(path: str, workspace_root: Path) -> Path:
-    """Finding 7: resolve an existing file; reject symlinks."""
     p = _resolve_workspace_path(path, workspace_root)
     if p.is_symlink():
         raise PermissionError(f"Refusing to edit symlink: {path!r}")
@@ -48,7 +45,6 @@ def _resolve_existing_workspace_file(path: str, workspace_root: Path) -> Path:
 
 
 def _write_text_no_follow(path: Path, content: str) -> None:
-    """Finding 7: write to an existing file without following symlinks (O_NOFOLLOW)."""
     flags = os.O_WRONLY | os.O_TRUNC
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
@@ -79,9 +75,7 @@ class EditorRequest(BaseModel):
     )
     content: str | None = Field(
         None,
-        description=(
-            "Full content to write to the file. Required when action='write'."
-        ),
+        description=("Full content to write to the file. Required when action='write'."),
     )
     old_string: str | None = Field(
         None,
@@ -125,7 +119,6 @@ class EditorResponse(BaseModel):
 
 
 def _write_sync(file_path: str, content: str, workspace_root: Path) -> EditorResponse:
-    # Finding 6: validate path is within workspace root before writing
     try:
         p = _resolve_workspace_path(file_path, workspace_root)
     except PermissionError as e:
@@ -145,7 +138,6 @@ def _edit_sync(
     replace_all: bool,
     workspace_root: Path,
 ) -> EditorResponse:
-    # Finding 6/7: validate path and reject symlinks before reading or writing
     try:
         p = _resolve_existing_workspace_file(file_path, workspace_root)
     except PermissionError as e:
@@ -176,7 +168,6 @@ def _edit_sync(
     updated = original.replace(old_string, new_string, -1 if replace_all else 1)
 
     try:
-        # Finding 7: write without following symlinks
         _write_text_no_follow(p, updated)
     except OSError as e:
         return EditorResponse(success=False, error=f"Write error: {e}")
@@ -201,7 +192,6 @@ class EditorTool(LionTool):
 
     def __init__(self, workspace_root: str | Path | None = None):
         self._tool = None
-        # Finding 6: default to CWD when no workspace root is specified
         self.workspace_root = Path(workspace_root or Path.cwd()).expanduser().resolve()
 
     async def handle_request(self, request: EditorRequest) -> EditorResponse:

--- a/lionagi/tools/file/reader.py
+++ b/lionagi/tools/file/reader.py
@@ -16,25 +16,19 @@ from lionagi.protocols.action.tool import Tool
 
 from ..base import LionTool
 
-# Finding 8/9: deny access to sensitive filenames
 _DENIED_NAMES: frozenset[str] = frozenset(
     {".env", ".netrc", "id_rsa", "id_ed25519", "id_ecdsa", ".htpasswd"}
 )
-# Finding 9: allowed document extensions for the 'open' action
 _DOC_EXTENSIONS: frozenset[str] = frozenset({".pdf", ".pptx", ".docx", ".html", ".htm"})
-# Finding 9: max document size for 'open' (50 MB)
 _MAX_DOC_BYTES = 50 * 1024 * 1024
-# Finding 8: max files returned by list_dir
 _MAX_LIST_FILES = 1_000
 
 _CACHE_TTL_SECONDS = 300  # 5 minutes
 
 
 def _resolve_workspace_path(path: str, workspace_root: Path) -> Path:
-    """Finding 8: resolve path under workspace_root; raise PermissionError if it escapes."""
     raw = Path(path).expanduser()
     candidate = raw if raw.is_absolute() else workspace_root / raw
-    # GAP B: check symlink on candidate BEFORE resolve() follows it
     if candidate.is_symlink():
         raise PermissionError(f"Refusing to access symlink: {path!r}")
     resolved = candidate.resolve(strict=False)
@@ -119,7 +113,6 @@ def _read_sync(
     limit: int | None,
     workspace_root: Path,
 ) -> ReaderResponse:
-    # Finding 8: validate path before opening
     try:
         p = _resolve_workspace_path(path, workspace_root)
     except PermissionError as e:
@@ -160,7 +153,6 @@ def _list_dir_sync(
     file_types: list[str] | None,
     workspace_root: Path,
 ) -> ReaderResponse:
-    # Finding 8: validate directory path before listing
     try:
         base = _resolve_workspace_path(path, workspace_root)
     except PermissionError as e:
@@ -172,7 +164,6 @@ def _list_dir_sync(
     from lionagi.libs.file.process import dir_to_files
 
     try:
-        # Finding 8: cap listing to prevent unbounded output
         files = dir_to_files(
             str(base),
             recursive=bool(recursive),
@@ -191,8 +182,6 @@ def _open_sync(
     workspace_root: Path,
     allowed_url_hosts: frozenset[str],
 ) -> ReaderResponse:
-    """Finding 9: validate path/URL before passing to docling."""
-    # Finding 9: split URL vs local file handling
     # NOTE: docling import is intentionally deferred until AFTER all URL/SSRF
     # validation so that the security checks remain testable without the
     # optional docling dependency installed.
@@ -290,9 +279,7 @@ class ReaderTool(LionTool):
         self._tool = None
         self._cache: dict[str, tuple[str, float]] = {}
         self._cache_ttl = cache_ttl
-        # Finding 8: default to CWD when no workspace root is specified
         self.workspace_root = Path(workspace_root or Path.cwd()).expanduser().resolve()
-        # Finding 9: no URL hosts allowed by default
         self._allowed_url_hosts: frozenset[str] = frozenset(allowed_url_hosts or ())
 
     async def handle_request(self, request: ReaderRequest) -> ReaderResponse:

--- a/marketplace/scripts/validate_manifests.py
+++ b/marketplace/scripts/validate_manifests.py
@@ -63,7 +63,9 @@ def main() -> int:
         source = plugin.get("source", "")
         if source:
             if source in seen_sources:
-                print(f"FAIL [{name}]: duplicate source '{source}' (also used by index {seen_sources[source]})")
+                print(
+                    f"FAIL [{name}]: duplicate source '{source}' (also used by index {seen_sources[source]})"
+                )
                 plugin_ok = False
                 failures += 1
             else:
@@ -93,7 +95,9 @@ def main() -> int:
                 # Per-plugin plugin.json validation
                 per_plugin_json = source_dir / ".claude-plugin" / "plugin.json"
                 if not per_plugin_json.exists():
-                    print(f"FAIL [{name}]: Listed source '{plugin['source']}' has no .claude-plugin/plugin.json")
+                    print(
+                        f"FAIL [{name}]: Listed source '{plugin['source']}' has no .claude-plugin/plugin.json"
+                    )
                     plugin_ok = False
                     failures += 1
                 else:
@@ -107,23 +111,31 @@ def main() -> int:
                     for field in PER_PLUGIN_STRING_FIELDS:
                         val = per_plugin.get(field)
                         if val is not None and not isinstance(val, str):
-                            print(f"FAIL [{name}]: plugin.json '{field}' must be a string, got {type(val).__name__}")
+                            print(
+                                f"FAIL [{name}]: plugin.json '{field}' must be a string, got {type(val).__name__}"
+                            )
                             plugin_ok = False
                             failures += 1
                     for field in PER_PLUGIN_OPTIONAL_STRINGS:
                         val = per_plugin.get(field)
                         if val is not None and not isinstance(val, str):
-                            print(f"FAIL [{name}]: plugin.json '{field}' must be a string, got {type(val).__name__}")
+                            print(
+                                f"FAIL [{name}]: plugin.json '{field}' must be a string, got {type(val).__name__}"
+                            )
                             plugin_ok = False
                             failures += 1
                     author = per_plugin.get("author")
                     if author is not None and not isinstance(author, dict):
-                        print(f"FAIL [{name}]: plugin.json 'author' must be an object, got {type(author).__name__}")
+                        print(
+                            f"FAIL [{name}]: plugin.json 'author' must be an object, got {type(author).__name__}"
+                        )
                         plugin_ok = False
                         failures += 1
                     mcp = per_plugin.get("mcpServers")
                     if mcp is not None and not isinstance(mcp, dict):
-                        print(f"FAIL [{name}]: plugin.json 'mcpServers' must be an object, got {type(mcp).__name__}")
+                        print(
+                            f"FAIL [{name}]: plugin.json 'mcpServers' must be an object, got {type(mcp).__name__}"
+                        )
                         plugin_ok = False
                         failures += 1
                     # Reject stub mcpServers entries
@@ -154,7 +166,9 @@ def main() -> int:
                     ok = False
             for server_cfg in pdata.get("mcpServers", {}).values():
                 if server_cfg.get("type") == "stub":
-                    print(f"FAIL [standalone:{plugin_dir}]: plugin.json contains stub mcpServers entry")
+                    print(
+                        f"FAIL [standalone:{plugin_dir}]: plugin.json contains stub mcpServers entry"
+                    )
                     failures += 1
                     ok = False
             if ok:

--- a/notebooks/lndl/lexer.py
+++ b/notebooks/lndl/lexer.py
@@ -127,9 +127,7 @@ class Lexer:
     def read_identifier(self) -> str:
         """Read identifier or keyword"""
         result = ""
-        while self.current_char() and (
-            self.current_char().isalnum() or self.current_char() in "_"
-        ):
+        while self.current_char() and (self.current_char().isalnum() or self.current_char() in "_"):
             result += self.current_char()
             self.advance()
         return result
@@ -137,9 +135,7 @@ class Lexer:
     def read_number(self) -> str:
         """Read number (int or float)"""
         result = ""
-        while self.current_char() and (
-            self.current_char().isdigit() or self.current_char() == "."
-        ):
+        while self.current_char() and (self.current_char().isdigit() or self.current_char() == "."):
             result += self.current_char()
             self.advance()
         return result
@@ -204,9 +200,7 @@ class Lexer:
 
             # Newlines
             if self.current_char() == "\n":
-                self.tokens.append(
-                    Token(TokenType.NEWLINE, "\n", self.line, self.column)
-                )
+                self.tokens.append(Token(TokenType.NEWLINE, "\n", self.line, self.column))
                 self.advance()
                 continue
 
@@ -273,9 +267,7 @@ class Lexer:
                 else:
                     token_type = TokenType.ID
 
-                self.tokens.append(
-                    Token(token_type, identifier, start_line, start_column)
-                )
+                self.tokens.append(Token(token_type, identifier, start_line, start_column))
                 continue
 
             # Numbers
@@ -284,9 +276,7 @@ class Lexer:
                 start_line = self.line
                 start_column = self.column
                 number = self.read_number()
-                self.tokens.append(
-                    Token(TokenType.NUM, number, start_line, start_column)
-                )
+                self.tokens.append(Token(TokenType.NUM, number, start_line, start_column))
                 continue
 
             # Strings
@@ -295,9 +285,7 @@ class Lexer:
                 start_line = self.line
                 start_column = self.column
                 string_val = self.read_string()
-                self.tokens.append(
-                    Token(TokenType.STR, string_val, start_line, start_column)
-                )
+                self.tokens.append(Token(TokenType.STR, string_val, start_line, start_column))
                 continue
 
             # Single character tokens
@@ -307,45 +295,29 @@ class Lexer:
             elif char == ",":
                 self.tokens.append(Token(TokenType.COMMA, char, self.line, self.column))
             elif char == "(":
-                self.tokens.append(
-                    Token(TokenType.LPAREN, char, self.line, self.column)
-                )
+                self.tokens.append(Token(TokenType.LPAREN, char, self.line, self.column))
             elif char == ")":
-                self.tokens.append(
-                    Token(TokenType.RPAREN, char, self.line, self.column)
-                )
+                self.tokens.append(Token(TokenType.RPAREN, char, self.line, self.column))
             elif char == "*":
                 self.tokens.append(Token(TokenType.STAR, char, self.line, self.column))
             elif char == "=":
                 if self.peek_char() == "=":
-                    self.tokens.append(
-                        Token(TokenType.EQ, "==", self.line, self.column)
-                    )
+                    self.tokens.append(Token(TokenType.EQ, "==", self.line, self.column))
                     self.advance()  # Skip second =
                 else:
-                    self.tokens.append(
-                        Token(TokenType.ASSIGN, char, self.line, self.column)
-                    )
+                    self.tokens.append(Token(TokenType.ASSIGN, char, self.line, self.column))
             elif char == ">":
                 if self.peek_char() == "=":
-                    self.tokens.append(
-                        Token(TokenType.GTE, ">=", self.line, self.column)
-                    )
+                    self.tokens.append(Token(TokenType.GTE, ">=", self.line, self.column))
                     self.advance()
                 else:
-                    self.tokens.append(
-                        Token(TokenType.GT, char, self.line, self.column)
-                    )
+                    self.tokens.append(Token(TokenType.GT, char, self.line, self.column))
             elif char == "<":
                 if self.peek_char() == "=":
-                    self.tokens.append(
-                        Token(TokenType.LTE, "<=", self.line, self.column)
-                    )
+                    self.tokens.append(Token(TokenType.LTE, "<=", self.line, self.column))
                     self.advance()
                 else:
-                    self.tokens.append(
-                        Token(TokenType.LT, char, self.line, self.column)
-                    )
+                    self.tokens.append(Token(TokenType.LT, char, self.line, self.column))
             elif char == "+":
                 self.tokens.append(Token(TokenType.PLUS, char, self.line, self.column))
             elif char == "-":
@@ -354,9 +326,7 @@ class Lexer:
                 self.tokens.append(Token(TokenType.COLON, char, self.line, self.column))
             else:
                 # Unknown character
-                self.tokens.append(
-                    Token(TokenType.UNKNOWN, char, self.line, self.column)
-                )
+                self.tokens.append(Token(TokenType.UNKNOWN, char, self.line, self.column))
 
             self.advance()
 

--- a/notebooks/lndl/parser.py
+++ b/notebooks/lndl/parser.py
@@ -12,9 +12,7 @@ class ParseError(Exception):
     def __init__(self, message: str, token: Token):
         self.message = message
         self.token = token
-        super().__init__(
-            f"Parse error at line {token.line}, column {token.column}: {message}"
-        )
+        super().__init__(f"Parse error at line {token.line}, column {token.column}: {message}")
 
 
 class Parser:

--- a/notebooks/using_claude_code/claude_proxy/claude_code_proxy.py
+++ b/notebooks/using_claude_code/claude_proxy/claude_code_proxy.py
@@ -14,12 +14,11 @@ from contextlib import asynccontextmanager
 
 import uvicorn
 from fastapi import FastAPI, HTTPException, Request, Response
-from loguru import logger
-
 from lionagi.service.connections.providers.claude_code_cli import (
     ClaudeCodeCLIEndpoint,
     ClaudeCodeRequest,
 )
+from loguru import logger
 
 # Configure logging
 logger.remove()
@@ -49,9 +48,7 @@ def check_claude_code():
     try:
         from lionagi.service.third_party.claude_code import CLAUDE_CLI
 
-        result = subprocess.run(
-            [CLAUDE_CLI, "--version"], capture_output=True, text=True
-        )
+        result = subprocess.run([CLAUDE_CLI, "--version"], capture_output=True, text=True)
         if result.returncode != 0:
             raise RuntimeError("Claude Code not found, please install it first:\n")
         logger.info(f"Claude Code found: {result.stdout.strip()}")

--- a/notebooks/using_codex/codex_proxy.py
+++ b/notebooks/using_codex/codex_proxy.py
@@ -21,14 +21,13 @@ from contextlib import asynccontextmanager
 
 import uvicorn
 from fastapi import FastAPI, HTTPException, Request, Response
-from loguru import logger
-
 from lionagi.service.connections.providers.codex_cli import CodexCLIEndpoint
 from lionagi.service.third_party.codex_models import (
     CODEX_CLI,
     HAS_CODEX_CLI,
     CodexCodeRequest,
 )
+from loguru import logger
 
 logger.remove()
 logger.add(sys.stderr, level="INFO")

--- a/notebooks/using_mcp/react_mcp_with_schema.py
+++ b/notebooks/using_mcp/react_mcp_with_schema.py
@@ -5,12 +5,12 @@ Test ReAct reasoning with MCP search tools and proper Pydantic schemas
 
 import asyncio
 
+from lionagi.service.third_party.exa_models import ExaSearchRequest
+from lionagi.service.third_party.pplx_models import PerplexityChatRequest
 from pydantic import BaseModel
 
 from lionagi import Branch, iModel
 from lionagi.protocols.action.manager import load_mcp_tools
-from lionagi.service.third_party.exa_models import ExaSearchRequest
-from lionagi.service.third_party.pplx_models import PerplexityChatRequest
 
 
 class ExaRequest(BaseModel):
@@ -39,9 +39,7 @@ async def test_react_with_mcp():
     )
     print(f"   ✅ Loaded {len(tools)} search tools with schemas:")
     for tool in tools:
-        print(
-            f"      - {tool.function} (has request_options: {tool.request_options is not None})"
-        )
+        print(f"      - {tool.function} (has request_options: {tool.request_options is not None})")
 
     # 2. Create a Branch with the tools
     print("\n2. Creating Branch with gpt-4.1-mini...")
@@ -54,9 +52,7 @@ async def test_react_with_mcp():
 
     # 3. Run ReAct reasoning
     print("\n3. Running ReAct reasoning (max 3 extensions)...")
-    print(
-        "   Question: What are the latest developments in Model Context Protocol (MCP)?"
-    )
+    print("   Question: What are the latest developments in Model Context Protocol (MCP)?")
     print("\n   Executing ReAct...")
 
     try:

--- a/notebooks/using_mcp/search_group.py
+++ b/notebooks/using_mcp/search_group.py
@@ -3,11 +3,11 @@ from typing import Literal
 
 from dotenv import load_dotenv
 from khivemcp import ServiceGroup, operation
+from lionagi.service.third_party.exa_models import ExaSearchRequest
+from lionagi.service.third_party.pplx_models import PerplexityChatRequest
 
 from lionagi import iModel
 from lionagi.service.connections.api_calling import APICalling
-from lionagi.service.third_party.exa_models import ExaSearchRequest
-from lionagi.service.third_party.pplx_models import PerplexityChatRequest
 
 logger = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,6 +198,8 @@ ignore = [
 ]
 "cookbooks/**" = ["S101", "B904", "N"]
 "scripts/**" = ["S", "E731"]
+# LOG_CONFIG property mirrors the legacy Settings.Config.LOG attribute name.
+"lionagi/config.py" = ["N802"]
 "apps/studio/**" = [
     "S108",   # /tmp in dev server
     "B007",   # unused loop vars

--- a/scripts/update_openai_models.py
+++ b/scripts/update_openai_models.py
@@ -20,9 +20,7 @@ def run_command(cmd, description=""):
     """Run a command and handle errors."""
     print(f"🔄 {description}")
     try:
-        result = subprocess.run(
-            cmd, shell=True, check=True, capture_output=True, text=True
-        )
+        result = subprocess.run(cmd, shell=True, check=True, capture_output=True, text=True)
         if result.stdout.strip():
             print(f"   {result.stdout.strip()}")
         return True
@@ -166,9 +164,7 @@ def add_post_processing():
     with open(models_file, "w") as f:
         f.write("\n".join(new_lines))
 
-    print(
-        "   ✓ Added imports, warnings suppression, type aliases, and discriminator fixes"
-    )
+    print("   ✓ Added imports, warnings suppression, type aliases, and discriminator fixes")
     return True
 
 
@@ -258,9 +254,7 @@ def main():
     get_file_info()
 
     print("\n✅ OpenAI models update completed!")
-    print(
-        f"✅ Verification: {'PASSED' if verification_passed else 'FAILED (see warnings above)'}"
-    )
+    print(f"✅ Verification: {'PASSED' if verification_passed else 'FAILED (see warnings above)'}")
     print("\n📝 Notes:")
     print("   - File is configured to be ignored by git")
     print("   - Will be regenerated during CI/CD build processes")

--- a/tests/adapters/test_pydantic_spec_adapter.py
+++ b/tests/adapters/test_pydantic_spec_adapter.py
@@ -203,9 +203,7 @@ class TestEndToEnd:
         operable = Operable(specs, name="Player")
 
         # Use Operable's create_model method
-        PlayerModel = operable.create_model(
-            adapter="pydantic", model_name="PlayerModel"
-        )
+        PlayerModel = operable.create_model(adapter="pydantic", model_name="PlayerModel")
 
         assert issubclass(PlayerModel, BaseModel)
         player = PlayerModel(username="player1")

--- a/tests/apps_studio_server/test_admin_transition.py
+++ b/tests/apps_studio_server/test_admin_transition.py
@@ -85,7 +85,7 @@ def test_transition_refused_when_heartbeat_changes_health(tmp_path, monkeypatch)
        SessionHealth.STALE.  The sync constraint is load-bearing: transition_sessions()
        calls classify_session_health() synchronously (line 338 admin.py); an async
        fake would return an un-awaited coroutine — the bump would never fire and the
-       health guard would be skipped entirely (MAJOR-1 codex finding).
+       health guard would be skipped entirely.
     3. Asserting the session ends up in skipped with reason='changed_since_snapshot'
        (not transitioned), because last_message_at changed between snapshot and UPDATE.
     """

--- a/tests/apps_studio_server/test_agents_roundtrip.py
+++ b/tests/apps_studio_server/test_agents_roundtrip.py
@@ -67,7 +67,7 @@ def test_get_agent_surfaces_yolo_and_fast_mode(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Test 1b: lion_system surfaces in get_agent() response (MEDIUM-2 codex finding)
+# Test 1b: lion_system surfaces in get_agent() response
 # ---------------------------------------------------------------------------
 
 
@@ -106,7 +106,7 @@ def test_get_agent_surfaces_lion_system(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Tests 1c/1d/1e: absent bool fields emit CLI defaults (round-2 MEDIUM finding)
+# Tests 1c/1d/1e: absent bool fields emit CLI defaults
 # ---------------------------------------------------------------------------
 
 
@@ -231,7 +231,7 @@ def test_update_agent_writes_yolo_field(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Test 2b: update_agent() writes lion_system field to disk (MEDIUM-2 codex finding)
+# Test 2b: update_agent() writes lion_system field to disk
 # ---------------------------------------------------------------------------
 
 

--- a/tests/hooks/test_loader.py
+++ b/tests/hooks/test_loader.py
@@ -116,9 +116,7 @@ def test_build_session_bus_empty_list_disables_default():
 
 def test_build_session_bus_adds_handlers_for_non_default_points():
     """Profile may register handlers on points that have no default."""
-    bus = build_session_bus(
-        {"api.post_call": ["log_api_metrics"], "tool.pre": ["log_tool_use"]}
-    )
+    bus = build_session_bus({"api.post_call": ["log_api_metrics"], "tool.pre": ["log_tool_use"]})
     assert len(bus.handlers_for(HookPoint.API_POST_CALL)) == 1
     assert len(bus.handlers_for(HookPoint.TOOL_PRE)) == 1
 

--- a/tests/operations/test_flow_id_containment.py
+++ b/tests/operations/test_flow_id_containment.py
@@ -1,17 +1,6 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Security regression tests for artifact-dir path containment.
-
-PR review 2026-04-24 flagged a HIGH finding: agent ids become filesystem path
-segments via ``RunDir.agent_artifact_dir``. After the orchestrate clean break,
-agent ids are CLI-generated from roster-validated role names (``{assignee}-{i}``)
-rather than free-form model output — but ``RunDir.agent_artifact_dir`` remains
-the authoritative, defense-in-depth guard and is what these tests pin: it
-rejects components containing path separators, leading dots, or resolved paths
-outside the artifact root.
-"""
-
 from __future__ import annotations
 
 from pathlib import Path
@@ -19,8 +8,6 @@ from pathlib import Path
 import pytest
 
 from lionagi.cli._runs import RunDir
-
-# ── RunDir.agent_artifact_dir containment ───────────────────────────
 
 
 class TestAgentArtifactDirContainment:

--- a/tests/providers/ag2/agent/test_endpoint.py
+++ b/tests/providers/ag2/agent/test_endpoint.py
@@ -87,9 +87,7 @@ class TestRunBetaAgentRouting:
         from lionagi.providers.ag2.agent.models import run_beta_agent
 
         with pytest.raises(ValueError, match="requires either a pre-built"):
-            async for _ in run_beta_agent(
-                config=None, message="hi", llm_config=None, agent=None
-            ):
+            async for _ in run_beta_agent(config=None, message="hi", llm_config=None, agent=None):
                 pass
 
     @pytest.mark.asyncio
@@ -141,9 +139,7 @@ class TestRunBetaAgentRouting:
             te_mod.ToolCallsEvent = MagicMock
             te_mod.ToolResultEvent = MagicMock
 
-            with caplog.at_level(
-                logging.INFO, logger="lionagi.providers.ag2.agent.models"
-            ):
+            with caplog.at_level(logging.INFO, logger="lionagi.providers.ag2.agent.models"):
                 results = []
                 async for ev in agent_models.run_beta_agent(
                     config=cfg,
@@ -153,9 +149,9 @@ class TestRunBetaAgentRouting:
                 ):
                     results.append(ev)
 
-        assert any(
-            "agent_config is ignored" in r.message for r in caplog.records
-        ), "Expected log message about agent_config being ignored"
+        assert any("agent_config is ignored" in r.message for r in caplog.records), (
+            "Expected log message about agent_config being ignored"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -203,20 +199,14 @@ class TestAG2BetaEndpointStream:
                 "typed_result": None,
             }
 
-        with patch(
-            "lionagi.providers.ag2.agent.models.run_beta_agent", side_effect=mock_run
-        ):
+        with patch("lionagi.providers.ag2.agent.models.run_beta_agent", side_effect=mock_run):
             endpoint = self._make_endpoint()
             chunks = []
-            async for chunk in endpoint.stream(
-                {"prompt": "hello", "agent": fake_agent}
-            ):
+            async for chunk in endpoint.stream({"prompt": "hello", "agent": fake_agent}):
                 chunks.append(chunk)
 
         assert len(captured_agents) == 1
-        assert (
-            captured_agents[0] is fake_agent
-        ), "Pre-built agent must be passed through as-is"
+        assert captured_agents[0] is fake_agent, "Pre-built agent must be passed through as-is"
 
     @pytest.mark.asyncio
     async def test_same_agent_instance_reused_across_two_calls(self):
@@ -234,9 +224,7 @@ class TestAG2BetaEndpointStream:
                 "typed_result": None,
             }
 
-        with patch(
-            "lionagi.providers.ag2.agent.models.run_beta_agent", side_effect=mock_run
-        ):
+        with patch("lionagi.providers.ag2.agent.models.run_beta_agent", side_effect=mock_run):
             endpoint = self._make_endpoint()
 
             # First call
@@ -247,12 +235,10 @@ class TestAG2BetaEndpointStream:
             async for _ in endpoint.stream({"prompt": "second", "agent": fake_agent}):
                 pass
 
-        assert (
-            len(captured_ids) == 2
-        ), "run_beta_agent should be called once per stream() call"
-        assert (
-            captured_ids[0] == captured_ids[1]
-        ), f"Agent id must be identical across calls: {captured_ids[0]} != {captured_ids[1]}"
+        assert len(captured_ids) == 2, "run_beta_agent should be called once per stream() call"
+        assert captured_ids[0] == captured_ids[1], (
+            f"Agent id must be identical across calls: {captured_ids[0]} != {captured_ids[1]}"
+        )
 
     @pytest.mark.asyncio
     async def test_agent_wins_over_agent_config(self):
@@ -271,9 +257,7 @@ class TestAG2BetaEndpointStream:
                 "typed_result": None,
             }
 
-        with patch(
-            "lionagi.providers.ag2.agent.models.run_beta_agent", side_effect=mock_run
-        ):
+        with patch("lionagi.providers.ag2.agent.models.run_beta_agent", side_effect=mock_run):
             endpoint = self._make_endpoint()
             async for _ in endpoint.stream(
                 {"prompt": "test", "agent": fake_agent, "agent_config": cfg}
@@ -281,9 +265,7 @@ class TestAG2BetaEndpointStream:
                 pass
 
         assert len(captured) == 1
-        assert (
-            captured[0]["agent"] is fake_agent
-        ), "Pre-built agent must win over agent_config"
+        assert captured[0]["agent"] is fake_agent, "Pre-built agent must win over agent_config"
 
     @pytest.mark.asyncio
     async def test_no_agent_no_config_raises(self):
@@ -291,9 +273,7 @@ class TestAG2BetaEndpointStream:
 
         async def mock_run(config, message, llm_config, tool_registry=None, agent=None):
             if agent is None and config is None:
-                raise ValueError(
-                    "requires either a pre-built 'agent' or a non-None 'config'."
-                )
+                raise ValueError("requires either a pre-built 'agent' or a non-None 'config'.")
             yield {
                 "type": "response",
                 "text": "ok",
@@ -301,9 +281,7 @@ class TestAG2BetaEndpointStream:
                 "typed_result": None,
             }
 
-        with patch(
-            "lionagi.providers.ag2.agent.models.run_beta_agent", side_effect=mock_run
-        ):
+        with patch("lionagi.providers.ag2.agent.models.run_beta_agent", side_effect=mock_run):
             endpoint = self._make_endpoint()
             # Override _agent_config so create_payload yields no config either
             endpoint._agent_config = {}
@@ -345,9 +323,7 @@ class TestAG2BetaEndpointStream:
                 chunks.append(chunk)
 
         assert len(captured) == 1
-        assert (
-            captured[0]["agent"] is None
-        ), "Config path must not pass a pre-built agent"
+        assert captured[0]["agent"] is None, "Config path must not pass a pre-built agent"
         assert captured[0]["config"] is not None, "Config path must have a config"
 
     @pytest.mark.asyncio
@@ -364,9 +340,7 @@ class TestAG2BetaEndpointStream:
                 "typed_result": None,
             }
 
-        with patch(
-            "lionagi.providers.ag2.agent.models.run_beta_agent", side_effect=mock_run
-        ):
+        with patch("lionagi.providers.ag2.agent.models.run_beta_agent", side_effect=mock_run):
             endpoint = self._make_endpoint()
             chunks = []
             async for chunk in endpoint.stream({"prompt": "hi", "agent": fake_agent}):

--- a/tests/session/test_branch.py
+++ b/tests/session/test_branch.py
@@ -221,9 +221,7 @@ async def test_invoke_action_no_tools(branch_with_mock_imodel: Branch):
     If we pass an ActionRequest referencing an unregistered tool,
     we expect an error ActionResponseModel + a Log error about 'not registered'.
     """
-    req = ActionRequest(
-        content={"function": "unregistered_tool", "arguments": {"x": 1}}
-    )
+    req = ActionRequest(content={"function": "unregistered_tool", "arguments": {"x": 1}})
     resp = await branch_with_mock_imodel.act(req)
 
     # Now returns error response instead of empty list
@@ -250,9 +248,7 @@ async def test_invoke_action_ok(branch_with_mock_imodel: Branch):
     # register the tool
     branch_with_mock_imodel.acts.register_tool(echo_tool)
 
-    req = ActionRequest(
-        content={"function": "echo_tool", "arguments": {"text": "hello"}}
-    )
+    req = ActionRequest(content={"function": "echo_tool", "arguments": {"text": "hello"}})
     resp = await branch_with_mock_imodel.act(req)
     # Should get ActionResponseModel with output = "ECHO: hello"
     assert resp is not None
@@ -275,9 +271,7 @@ async def test_invoke_action_suppress_errors(branch_with_mock_imodel: Branch):
     req = ActionRequest(content={"function": "fail_tool", "arguments": {}})
 
     result = await branch_with_mock_imodel.act(req, suppress_errors=True)
-    assert result == [
-        ActionResponseModel(function="fail_tool", arguments={}, output=None)
-    ]
+    assert result == [ActionResponseModel(function="fail_tool", arguments={}, output=None)]
     logs = branch_with_mock_imodel.logs
     assert len(logs) == 1
     assert logs[-1].content["execution"]["response"] is None
@@ -504,9 +498,7 @@ async def test_react_stream_verbose_true_yields_analysis(monkeypatch):
 
     monkeypatch.setattr("lionagi.operations.ReAct.ReAct.ReActStream", fake_react_stream)
     # as_readable needs to exist; stub it out
-    monkeypatch.setattr(
-        "lionagi.libs.schema.as_readable.as_readable", lambda *a, **kw: None
-    )
+    monkeypatch.setattr("lionagi.libs.schema.as_readable.as_readable", lambda *a, **kw: None)
 
     results = await _drain(branch.ReActStream({"instruction": "q"}, verbose=True))
     assert results == [analysis_obj]
@@ -629,16 +621,12 @@ def test_branch_round_trips_without_duplicate_system_message():
     )
 
     original_msg_count = len(original.msgs.messages)
-    original_system_count = sum(
-        1 for m in original.msgs.messages if isinstance(m, System)
-    )
+    original_system_count = sum(1 for m in original.msgs.messages if isinstance(m, System))
 
     data = original.to_dict()
     restored = Branch.from_dict(data)
 
-    restored_system_count = sum(
-        1 for m in restored.msgs.messages if isinstance(m, System)
-    )
+    restored_system_count = sum(1 for m in restored.msgs.messages if isinstance(m, System))
 
     assert len(restored.msgs.messages) == original_msg_count
     assert restored_system_count == original_system_count

--- a/tests/session/test_branch_actionmanager_coverage.py
+++ b/tests/session/test_branch_actionmanager_coverage.py
@@ -359,23 +359,17 @@ class TestActionManagerMatchTool:
     """match_tool() converts ActionRequest/dict to FunctionCalling."""
 
     def test_match_tool_with_dict(self, populated_manager):
-        fc = populated_manager.match_tool(
-            {"function": "add", "arguments": {"a": 1, "b": 2}}
-        )
+        fc = populated_manager.match_tool({"function": "add", "arguments": {"a": 1, "b": 2}})
         assert fc is not None
 
     def test_match_tool_returns_function_calling(self, populated_manager):
         from lionagi.protocols.action.function_calling import FunctionCalling
 
-        fc = populated_manager.match_tool(
-            {"function": "add", "arguments": {"a": 1, "b": 2}}
-        )
+        fc = populated_manager.match_tool({"function": "add", "arguments": {"a": 1, "b": 2}})
         assert isinstance(fc, FunctionCalling)
 
     def test_match_tool_function_name(self, populated_manager):
-        fc = populated_manager.match_tool(
-            {"function": "add", "arguments": {"a": 1, "b": 2}}
-        )
+        fc = populated_manager.match_tool({"function": "add", "arguments": {"a": 1, "b": 2}})
         assert fc.function == "add"
 
     def test_match_unknown_raises(self, populated_manager):
@@ -451,17 +445,13 @@ class TestActionManagerInvoke:
 
     @pytest.mark.asyncio
     async def test_invoke_with_dict(self, populated_manager):
-        fc = await populated_manager.invoke(
-            {"function": "add", "arguments": {"a": 2, "b": 3}}
-        )
+        fc = await populated_manager.invoke({"function": "add", "arguments": {"a": 2, "b": 3}})
         assert fc.execution is not None
         assert fc.execution.response == 5
 
     @pytest.mark.asyncio
     async def test_invoke_add_result(self, populated_manager):
-        fc = await populated_manager.invoke(
-            {"function": "add", "arguments": {"a": 10, "b": 20}}
-        )
+        fc = await populated_manager.invoke({"function": "add", "arguments": {"a": 10, "b": 20}})
         assert fc.execution.response == 30
 
     @pytest.mark.asyncio
@@ -482,9 +472,7 @@ class TestActionManagerInvoke:
     async def test_invoke_returns_function_calling(self, populated_manager):
         from lionagi.protocols.action.function_calling import FunctionCalling
 
-        fc = await populated_manager.invoke(
-            {"function": "add", "arguments": {"a": 1, "b": 1}}
-        )
+        fc = await populated_manager.invoke({"function": "add", "arguments": {"a": 1, "b": 1}})
         assert isinstance(fc, FunctionCalling)
 
     @pytest.mark.asyncio

--- a/tests/session/test_exchange.py
+++ b/tests/session/test_exchange.py
@@ -165,9 +165,7 @@ class TestMessageRouting:
 
         exchange.register(sender_id)
 
-        msg = exchange.send(
-            sender_id, None, content={"text": "test"}, channel="updates"
-        )
+        msg = exchange.send(sender_id, None, content={"text": "test"}, channel="updates")
 
         assert msg.channel == "updates"
 

--- a/tests/session/test_session_flow_execution.py
+++ b/tests/session/test_session_flow_execution.py
@@ -79,9 +79,7 @@ def make_mock_branch(name: str = "TestBranch") -> Branch:
         return fake_call
 
     mock_invoke = AsyncMock(side_effect=_fake_invoke)
-    mock_chat_model = iModel(
-        provider="openai", model="gpt-4.1-mini", api_key="test_key"
-    )
+    mock_chat_model = iModel(provider="openai", model="gpt-4.1-mini", api_key="test_key")
     mock_chat_model.invoke = mock_invoke
 
     branch.chat_model = mock_chat_model
@@ -176,8 +174,7 @@ class TestEdgeCasesAndErrors:
 
         # Create multiple independent operations
         ops = [
-            Operation(operation="chat", parameters={"instruction": f"Task {i}"})
-            for i in range(5)
+            Operation(operation="chat", parameters={"instruction": f"Task {i}"}) for i in range(5)
         ]
 
         graph = Graph()
@@ -185,9 +182,7 @@ class TestEdgeCasesAndErrors:
             graph.add_node(op)
 
         # Execute with max_concurrent=2
-        result = await session.flow(
-            graph, parallel=True, max_concurrent=2, verbose=False
-        )
+        result = await session.flow(graph, parallel=True, max_concurrent=2, verbose=False)
 
         # All operations should complete
         assert len(result["completed_operations"]) == 5
@@ -211,9 +206,7 @@ class TestEdgeCasesAndErrors:
         graph.add_node(op2)
         graph.add_edge(Edge(head=op1.id, tail=op2.id))
 
-        result = await session.flow(
-            graph, context={"initial": "context"}, parallel=False
-        )
+        result = await session.flow(graph, context={"initial": "context"}, parallel=False)
 
         # op2 should have inherited context from op1
         assert op2.parameters.get("context") is not None
@@ -589,9 +582,7 @@ class TestSessionFlowAsyncEdgeCases:
 
         # Apply timeout to flow execution - should raise TimeoutError
         with pytest.raises(asyncio.TimeoutError):
-            await asyncio.wait_for(
-                session.flow(graph, parallel=False, verbose=False), timeout=0.5
-            )
+            await asyncio.wait_for(session.flow(graph, parallel=False, verbose=False), timeout=0.5)
 
     @pytest.mark.asyncio
     async def test_error_propagation_across_parallel_branches(self):
@@ -718,9 +709,7 @@ class TestSessionFlowAsyncEdgeCases:
         for op in [op_fast, op_medium, op_slow]:
             graph.add_node(op)
 
-        result = await session.flow(
-            graph, parallel=True, max_concurrent=3, verbose=False
-        )
+        result = await session.flow(graph, parallel=True, max_concurrent=3, verbose=False)
 
         # All operations should complete despite potential timing differences
         assert len(result["completed_operations"]) == 3

--- a/tests/session/test_session_lifecycle.py
+++ b/tests/session/test_session_lifecycle.py
@@ -76,9 +76,7 @@ def make_mock_branch(name: str = "TestBranch") -> Branch:
         return fake_call
 
     mock_invoke = AsyncMock(side_effect=_fake_invoke)
-    mock_chat_model = iModel(
-        provider="openai", model="gpt-4.1-mini", api_key="test_key"
-    )
+    mock_chat_model = iModel(provider="openai", model="gpt-4.1-mini", api_key="test_key")
     mock_chat_model.invoke = mock_invoke
 
     branch.chat_model = mock_chat_model
@@ -161,9 +159,7 @@ class TestBasicFlowExecution:
         # Create parallel graph
         graph, ops = make_parallel_graph()
 
-        result = await session.flow(
-            graph, parallel=True, max_concurrent=3, verbose=False
-        )
+        result = await session.flow(graph, parallel=True, max_concurrent=3, verbose=False)
 
         # Verify all operations completed
         assert len(result["completed_operations"]) == 4

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -266,7 +266,6 @@ class TestAllConsistency:
         # importorskip.  importorskip inside parametrize args is evaluated at
         # collection time and silently skips the whole module on any import
         # error — exactly the failure mode this file is meant to catch.
-        # See codex P1 finding on PR #1143.
         list(_lionagi.__all__),
     )
     def test_all_symbol_importable_via_getattr(self, symbol: str) -> None:

--- a/tests/utils/performance.py
+++ b/tests/utils/performance.py
@@ -160,9 +160,7 @@ class TestPerformanceMonitor:
             if metrics.get("duration", 0) > threshold
         }
 
-    def get_memory_heavy_tests(
-        self, threshold: float = 50.0
-    ) -> dict[str, dict[str, Any]]:
+    def get_memory_heavy_tests(self, threshold: float = 50.0) -> dict[str, dict[str, Any]]:
         """
         Get tests that exceed memory usage threshold.
 
@@ -401,9 +399,7 @@ class PerformanceRegression:
             baseline_value = baseline_metrics.get(metric_name, 0)
 
             if baseline_value > 0:
-                percentage_change = (
-                    (current_value - baseline_value) / baseline_value
-                ) * 100
+                percentage_change = ((current_value - baseline_value) / baseline_value) * 100
                 regressions[metric_name] = percentage_change > tolerance_percent
 
         return regressions

--- a/tests/v1_evolution/test_contracts.py
+++ b/tests/v1_evolution/test_contracts.py
@@ -22,9 +22,7 @@ class TestObservableProtocolDefinition:
         try:
             from lionagi.protocols.contracts import Observable
         except ImportError:
-            pytest.fail(
-                "V1 Observable Protocol could not be imported from contracts.py"
-            )
+            pytest.fail("V1 Observable Protocol could not be imported from contracts.py")
 
         # Verify it is a Protocol
         assert issubclass(Observable, Protocol), "Observable must be a Protocol"
@@ -52,11 +50,9 @@ class TestObservableProtocolDefinition:
         # Note: Using 'object' for V0 compatibility as per reviewer recommendation
         expected_type = annotations.get("return")
         # Handle both direct type object and string 'object' (forward references)
-        assert (
-            expected_type is object
-            or expected_type == object
-            or expected_type == "object"
-        ), f"Return type of id should be 'object' for V0 compatibility, got {expected_type}"
+        assert expected_type is object or expected_type == object or expected_type == "object", (
+            f"Return type of id should be 'object' for V0 compatibility, got {expected_type}"
+        )
 
     def test_observable_structural_typing(self):
         """Test structural typing works with the Observable Protocol."""
@@ -81,9 +77,7 @@ class TestObservableProtocolDefinition:
         from lionagi.protocols.contracts import Observable, ObservableProto
 
         # They should be the same object
-        assert (
-            Observable is ObservableProto
-        ), "Observable should be an alias for ObservableProto"
+        assert Observable is ObservableProto, "Observable should be an alias for ObservableProto"
 
     def test_legacy_observable_import(self):
         """Test that LegacyObservable can be imported from contracts."""
@@ -95,6 +89,6 @@ class TestObservableProtocolDefinition:
         # Should be the original ABC from _concepts
         from lionagi.protocols._concepts import Observable as OriginalABC
 
-        assert (
-            LegacyObservable is OriginalABC
-        ), "LegacyObservable should reference the original V0 ABC"
+        assert LegacyObservable is OriginalABC, (
+            "LegacyObservable should reference the original V0 ABC"
+        )

--- a/tests/v1_evolution/test_import_bridge.py
+++ b/tests/v1_evolution/test_import_bridge.py
@@ -22,9 +22,7 @@ class TestImportBridge:
         try:
             from lionagi.protocols.types import LegacyObservable, Observable
         except ImportError:
-            pytest.fail(
-                "Could not import Observable and LegacyObservable from types.py"
-            )
+            pytest.fail("Could not import Observable and LegacyObservable from types.py")
 
         # Import the sources of truth
         from lionagi.protocols._concepts import Observable as V0Source
@@ -35,18 +33,14 @@ class TestImportBridge:
         assert issubclass(Observable, Protocol)
 
         # Verify LegacyObservable (the V0 ABC)
-        assert (
-            LegacyObservable is V0Source
-        ), "types.LegacyObservable should be the V0 ABC"
+        assert LegacyObservable is V0Source, "types.LegacyObservable should be the V0 ABC"
         # Check if it's an ABCMeta (standard check for Abstract Base Classes)
-        assert isinstance(
-            LegacyObservable, ABCMeta
-        ), "LegacyObservable should be an ABC"
+        assert isinstance(LegacyObservable, ABCMeta), "LegacyObservable should be an ABC"
 
         # Ensure they are distinct
-        assert (
-            Observable is not LegacyObservable
-        ), "V1 Observable and LegacyObservable should be distinct objects"
+        assert Observable is not LegacyObservable, (
+            "V1 Observable and LegacyObservable should be distinct objects"
+        )
 
     def test_bridge_utilities_exported(self):
         """Verify bridge utilities are exported from types.py."""
@@ -76,9 +70,7 @@ class TestImportBridge:
         from lionagi.protocols.types import Observable
 
         # Should be the same object
-        assert (
-            ObservableProto is Observable
-        ), "ObservableProto should be the same as Observable"
+        assert ObservableProto is Observable, "ObservableProto should be the same as Observable"
 
     def test_all_exports_in_module_all(self):
         """Verify all new exports are listed in __all__."""
@@ -97,9 +89,7 @@ class TestImportBridge:
 
         # Verify they can actually be imported
         for export in required_exports:
-            assert hasattr(
-                types, export
-            ), f"'{export}' should be available in types module"
+            assert hasattr(types, export), f"'{export}' should be available in types module"
 
     def test_backward_compatibility_import_paths(self):
         """Verify existing import paths still work."""


### PR DESCRIPTION
**Pure-mechanical lint layer** — `ruff format` + autofixes across 134 files. **No behavior change.**

- ruff format reflow (line-length, blank lines) + safe autofixes
- targeted manual mechanical fixes (E402 import reorders, lambda→def, dead-import removal, identifier casing)
- pre-commit ruff pin v0.12.0→v0.15.11 + pyproject per-file-ignores

---
Part of the sliced **audit-remediation** series (replaces the monolithic #1276). Each slice is file-disjoint and cut from `main`. Full integration branch: `chore/audit-remediation` (7670 tests green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
