### PR TITLE
fix(providers): async correctness + fail-closed CLI path validation

### DIFF
--- a/lionagi/providers/google/gemini_code/models.py
+++ b/lionagi/providers/google/gemini_code/models.py
@@ -315,7 +315,15 @@ async def _ndjson_from_cli(request: GeminiCodeRequest):
     # Guard against mocked subprocesses in tests where proc.pid may not be a
     # real int: a MagicMock.pid coerces to 1 via __int__, and
     # os.killpg(1, SIGTERM) would signal init/the CI runner.
-    _pgid: int | None = proc.pid if isinstance(proc.pid, int) and proc.pid > 1 else None
+    # ``os.killpg`` is POSIX-only: on Windows it does not exist, so leave
+    # _pgid None there — the group-kill path is skipped and cleanup falls
+    # through to proc.terminate()/proc.kill() instead of raising AttributeError
+    # from the finally block (which only suppresses ProcessLookupError).
+    _pgid: int | None = (
+        proc.pid
+        if hasattr(os, "killpg") and isinstance(proc.pid, int) and proc.pid > 1
+        else None
+    )
 
     decoder = codecs.getincrementaldecoder("utf-8")()
     json_decoder = json.JSONDecoder()

--- a/lionagi/providers/google/gemini_code/models.py
+++ b/lionagi/providers/google/gemini_code/models.py
@@ -9,7 +9,9 @@ import contextlib
 import inspect
 import json
 import logging
+import os
 import shutil
+import signal
 import warnings
 from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass
@@ -92,7 +94,7 @@ class GeminiCodeRequest(BaseModel):
         for message in msg:
             if message["role"] != "system":
                 content = message["content"]
-                if isinstance(content, (dict, list)):
+                if isinstance(content, dict | list):
                     prompts.append(ln.json_dumps(content))
                 else:
                     prompts.append(content)
@@ -135,14 +137,10 @@ class GeminiCodeRequest(BaseModel):
         ws_path = Path(self.ws)
 
         if ws_path.is_absolute():
-            raise ValueError(
-                f"Workspace path must be relative, got absolute: {self.ws}"
-            )
+            raise ValueError(f"Workspace path must be relative, got absolute: {self.ws}")
 
         if ".." in ws_path.parts:
-            raise ValueError(
-                f"Directory traversal detected in workspace path: {self.ws}"
-            )
+            raise ValueError(f"Directory traversal detected in workspace path: {self.ws}")
 
         repo_resolved = self.repo.resolve()
         result = (self.repo / ws_path).resolve()
@@ -269,16 +267,12 @@ def _extract_summary(session: GeminiSession) -> dict[str, Any]:
         else:
             key_actions.append(f"Used {tool_name}")
 
-    key_actions = (
-        list(dict.fromkeys(key_actions)) if key_actions else ["No specific actions"]
-    )
+    key_actions = list(dict.fromkeys(key_actions)) if key_actions else ["No specific actions"]
 
     for op_type in file_operations:
         file_operations[op_type] = list(dict.fromkeys(file_operations[op_type]))
 
-    result_summary = (
-        (session.result[:200] + "...") if len(session.result) > 200 else session.result
-    )
+    result_summary = (session.result[:200] + "...") if len(session.result) > 200 else session.result
 
     return {
         "tool_counts": tool_counts,
@@ -317,6 +311,11 @@ async def _ndjson_from_cli(request: GeminiCodeRequest):
         stderr=asyncio.subprocess.PIPE,
         start_new_session=True,  # isolate from parent's SIGINT
     )
+    # Capture PGID immediately — same pattern as Claude/Codex.
+    # Guard against mocked subprocesses in tests where proc.pid may not be a
+    # real int: a MagicMock.pid coerces to 1 via __int__, and
+    # os.killpg(1, SIGTERM) would signal init/the CI runner.
+    _pgid: int | None = proc.pid if isinstance(proc.pid, int) and proc.pid > 1 else None
 
     decoder = codecs.getincrementaldecoder("utf-8")()
     json_decoder = json.JSONDecoder()
@@ -324,6 +323,31 @@ async def _ndjson_from_cli(request: GeminiCodeRequest):
 
     if proc.stdout is None:
         raise RuntimeError("Failed to capture stdout from Gemini CLI")
+
+    # Bounded stderr drain — without this, a stderr-heavy Gemini session can
+    # deadlock when the OS pipe buffer fills before stdout EOF.
+    stderr_cap = 256 * 1024
+    stderr_chunks: list[bytes] = []
+    stderr_total = 0
+
+    async def _drain_stderr() -> None:
+        nonlocal stderr_total
+        if proc.stderr is None:
+            return
+        try:
+            while True:
+                chunk = await proc.stderr.read(4096)
+                if not chunk:
+                    break
+                remaining = stderr_cap - stderr_total
+                if remaining > 0:
+                    take = chunk[:remaining]
+                    stderr_chunks.append(take)
+                    stderr_total += len(take)
+        except Exception as exc:
+            log.debug("gemini stderr drain ended: %s", exc)
+
+    stderr_task = asyncio.create_task(_drain_stderr())
 
     try:
         while True:
@@ -354,21 +378,46 @@ async def _ndjson_from_cli(request: GeminiCodeRequest):
                 log.error("Skipped unrecoverable JSON tail: %.120s...", buffer)
 
         if await proc.wait() != 0:
-            err = ""
-            if proc.stderr is not None:
-                err = (await proc.stderr.read()).decode().strip()
+            drain_truncated = False
+            try:
+                await asyncio.wait_for(asyncio.shield(stderr_task), timeout=2.0)
+            except asyncio.TimeoutError:
+                drain_truncated = True
+            except asyncio.CancelledError:
+                raise
+            err = b"".join(stderr_chunks).decode(errors="replace").strip()
+            if drain_truncated:
+                err = (err or "") + " [stderr drain timed out]"
             raise RuntimeError(err or "Gemini CLI exited non-zero")
 
     finally:
+        # Terminate the whole process group (start_new_session=True above made
+        # pgid == proc.pid). Kill the group so descendant subprocesses started
+        # by the Gemini CLI are also cleaned up — direct proc.terminate() only
+        # reaches the CLI process itself, leaving children behind.
+        pgid = _pgid
+        if pgid is not None:
+            with contextlib.suppress(ProcessLookupError, PermissionError):
+                os.killpg(pgid, signal.SIGTERM)
         with contextlib.suppress(ProcessLookupError):
             proc.terminate()
         try:
             await asyncio.wait_for(proc.wait(), timeout=5.0)
         except asyncio.TimeoutError:
+            if pgid is not None:
+                with contextlib.suppress(ProcessLookupError, PermissionError):
+                    os.killpg(pgid, signal.SIGKILL)
             with contextlib.suppress(ProcessLookupError):
                 proc.kill()
             with contextlib.suppress(Exception):
                 await proc.wait()
+
+        # Reap the stderr drain task.
+        stderr_task.cancel()
+        try:
+            await stderr_task
+        except (asyncio.CancelledError, Exception):  # noqa: S110, BLE001
+            pass
 
 
 async def stream_gemini_cli_events(request: GeminiCodeRequest):
@@ -562,9 +611,7 @@ async def stream_gemini_cli(
     if session.num_turns is None and session.messages:
         session.num_turns = len(session.messages)
     if session.duration_ms is None:
-        session.duration_ms = int(
-            (asyncio.get_running_loop().time() - _start_monotonic) * 1000
-        )
+        session.duration_ms = int((asyncio.get_running_loop().time() - _start_monotonic) * 1000)
 
     await _maybe_await(on_final, session)
     if request.verbose_output:

--- a/lionagi/providers/ollama/chat/endpoint.py
+++ b/lionagi/providers/ollama/chat/endpoint.py
@@ -12,18 +12,15 @@ import logging
 
 from pydantic import BaseModel
 
+from lionagi.ln.concurrency import run_sync
 from lionagi.service.connections.endpoint import Endpoint
-from lionagi.service.connections.endpoint_config import EndpointConfig
 from lionagi.utils import is_import_installed
 
 from .._config import OllamaConfigs
 
 logger = logging.getLogger(__name__)
 
-__all__ = (
-    "OllamaChatEndpoint",
-    "OLLAMA_CHAT_ENDPOINT_CONFIG",
-)
+__all__ = ("OllamaChatEndpoint",)
 
 _HAS_OLLAMA = is_import_installed("ollama")
 
@@ -64,15 +61,14 @@ class OllamaChatEndpoint(Endpoint):
 
         return (payload, headers)
 
-    async def call(
-        self, request: dict | BaseModel, cache_control: bool = False, **kwargs
-    ):
+    async def call(self, request: dict | BaseModel, cache_control: bool = False, **kwargs):
         payload, headers = self.create_payload(request, **kwargs)
 
-        # Check if model exists and pull if needed
+        # Check if model exists and pull if needed (off the event loop to avoid
+        # blocking: both _list() and _pull() are synchronous Ollama SDK calls).
         model = payload.get("model")
         if model:
-            self._check_model(model)
+            await run_sync(self._check_model, model)
 
         # Pass the already-created payload directly to avoid double create_payload
         return await super().call(

--- a/lionagi/providers/pi/cli/models.py
+++ b/lionagi/providers/pi/cli/models.py
@@ -9,7 +9,9 @@ import codecs
 import contextlib
 import json
 import logging
+import os
 import shutil
+import signal
 from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass
 from dataclasses import field as datafield
@@ -204,6 +206,62 @@ class PiCodeRequest(BaseModel):
             return [v]
         return v
 
+    @field_validator("file_args", mode="before")
+    @classmethod
+    def _validate_file_args(cls, v: list) -> list:
+        """Reject absolute paths and directory-traversal sequences in file_args.
+
+        Pi forwards each entry as ``@<path>`` to the CLI. Without validation an
+        untrusted payload could read arbitrary files (e.g. /etc/passwd or
+        ../../secrets.txt). Validation is fail-closed: any invalid entry raises
+        ValueError before the subprocess is constructed.
+
+        Relative paths that stay inside the repo are permitted; callers that
+        need an absolute path should pre-validate and use an explicit allowlist.
+        """
+        safe: list[str] = []
+        for raw in v:
+            # Strip the leading @ prefix if present — the CLI builder re-adds it.
+            entry = raw.lstrip("@")
+            p = Path(entry)
+            if p.is_absolute():
+                raise ValueError(
+                    f"file_args entry {raw!r} is an absolute path — "
+                    "only relative paths inside the repository are allowed. "
+                    "Absolute paths can grant CLI access to arbitrary files."
+                )
+            if ".." in p.parts:
+                raise ValueError(
+                    f"file_args entry {raw!r} contains directory traversal ('..') — "
+                    "only paths that remain inside the repository are allowed."
+                )
+            safe.append(raw)
+        return safe
+
+    @model_validator(mode="after")
+    def _contain_file_args_in_repo(self) -> PiCodeRequest:
+        """Fail-closed: every file_args entry must resolve inside ``repo``.
+
+        The lexical field validator rejects absolute paths and ``..``, but a
+        repo-local symlink (``repo/link -> /outside``) is lexically clean yet
+        lets Pi read outside the repo. ``resolve()`` follows symlinks, so this
+        rejects any entry whose real location escapes ``repo`` before the
+        subprocess is constructed.
+        """
+        repo_root = self.repo.resolve()
+        for raw in self.file_args:
+            entry = raw.lstrip("@")
+            resolved = (repo_root / entry).resolve()
+            try:
+                resolved.relative_to(repo_root)
+            except ValueError as exc:
+                raise ValueError(
+                    f"file_args entry {raw!r} resolves to {resolved} which is "
+                    f"outside the repository root {repo_root} (symlink escape). "
+                    "Only paths that remain inside the repository are allowed."
+                ) from exc
+        return self
+
     @model_validator(mode="before")
     @classmethod
     def _infer_provider_from_model(cls, data):
@@ -239,7 +297,7 @@ class PiCodeRequest(BaseModel):
         for message in msg:
             if message["role"] != "system":
                 content = message["content"]
-                if isinstance(content, (dict, list)):
+                if isinstance(content, dict | list):
                     prompts.append(ln.json_dumps(content))
                 else:
                     prompts.append(content)
@@ -400,9 +458,7 @@ def _extract_summary(session: PiSession) -> dict[str, Any]:
     for op_type in file_operations:
         file_operations[op_type] = list(dict.fromkeys(file_operations[op_type]))
 
-    result_summary = (
-        (session.result[:200] + "...") if len(session.result) > 200 else session.result
-    )
+    result_summary = (session.result[:200] + "...") if len(session.result) > 200 else session.result
 
     return {
         "tool_counts": tool_counts,
@@ -425,11 +481,7 @@ def _extract_summary(session: PiSession) -> dict[str, Any]:
 async def _ndjson_from_cli(request: PiCodeRequest):
     """Yields each JSON object emitted by Pi CLI (JSONL mode)."""
     if PI_CLI is None:
-        raise RuntimeError(
-            "Pi CLI not found. Install with: npm i -g @mariozechner/pi-coding-agent"
-        )
-
-    import os
+        raise RuntimeError("Pi CLI not found. Install with: npm i -g @mariozechner/pi-coding-agent")
 
     env = None
     if request.env():
@@ -444,6 +496,11 @@ async def _ndjson_from_cli(request: PiCodeRequest):
         env=env,
         start_new_session=True,
     )
+    # Capture PGID immediately — same pattern as Claude/Codex.
+    # Guard against mocked subprocesses in tests where proc.pid may not be a
+    # real int: a MagicMock.pid coerces to 1 via __int__, and
+    # os.killpg(1, SIGTERM) would signal init/the CI runner.
+    _pgid: int | None = proc.pid if isinstance(proc.pid, int) and proc.pid > 1 else None
 
     decoder = codecs.getincrementaldecoder("utf-8")()
     json_decoder = json.JSONDecoder()
@@ -451,6 +508,31 @@ async def _ndjson_from_cli(request: PiCodeRequest):
 
     if proc.stdout is None:
         raise RuntimeError("Failed to capture stdout from Pi CLI")
+
+    # Bounded stderr drain — without this, a stderr-heavy Pi session can
+    # deadlock when the OS pipe buffer fills before stdout EOF.
+    stderr_cap = 256 * 1024
+    stderr_chunks: list[bytes] = []
+    stderr_total = 0
+
+    async def _drain_stderr() -> None:
+        nonlocal stderr_total
+        if proc.stderr is None:
+            return
+        try:
+            while True:
+                chunk = await proc.stderr.read(4096)
+                if not chunk:
+                    break
+                remaining = stderr_cap - stderr_total
+                if remaining > 0:
+                    take = chunk[:remaining]
+                    stderr_chunks.append(take)
+                    stderr_total += len(take)
+        except Exception as exc:
+            log.debug("pi stderr drain ended: %s", exc)
+
+    stderr_task = asyncio.create_task(_drain_stderr())
 
     try:
         while True:
@@ -482,21 +564,46 @@ async def _ndjson_from_cli(request: PiCodeRequest):
 
         rc = await proc.wait()
         if rc != 0:
-            err = ""
-            if proc.stderr is not None:
-                err = (await proc.stderr.read()).decode().strip()
+            drain_truncated = False
+            try:
+                await asyncio.wait_for(asyncio.shield(stderr_task), timeout=2.0)
+            except asyncio.TimeoutError:
+                drain_truncated = True
+            except asyncio.CancelledError:
+                raise
+            err = b"".join(stderr_chunks).decode(errors="replace").strip()
+            if drain_truncated:
+                err = (err or "") + " [stderr drain timed out]"
             raise RuntimeError(err or f"Pi CLI exited with code {rc}")
 
     finally:
+        # Terminate the whole process group (start_new_session=True above made
+        # pgid == proc.pid). Kill the group so descendant subprocesses started
+        # by the Pi CLI are also cleaned up — direct proc.terminate() only
+        # reaches the CLI process itself, leaving children behind.
+        pgid = _pgid
+        if pgid is not None:
+            with contextlib.suppress(ProcessLookupError, PermissionError):
+                os.killpg(pgid, signal.SIGTERM)
         with contextlib.suppress(ProcessLookupError):
             proc.terminate()
         try:
             await asyncio.wait_for(proc.wait(), timeout=5.0)
         except asyncio.TimeoutError:
+            if pgid is not None:
+                with contextlib.suppress(ProcessLookupError, PermissionError):
+                    os.killpg(pgid, signal.SIGKILL)
             with contextlib.suppress(ProcessLookupError):
                 proc.kill()
             with contextlib.suppress(Exception):
                 await proc.wait()
+
+        # Reap the stderr drain task.
+        stderr_task.cancel()
+        try:
+            await stderr_task
+        except (asyncio.CancelledError, Exception):  # noqa: S110, BLE001
+            pass
 
 
 async def stream_pi_cli_events(request: PiCodeRequest):

--- a/lionagi/providers/pi/cli/models.py
+++ b/lionagi/providers/pi/cli/models.py
@@ -500,7 +500,15 @@ async def _ndjson_from_cli(request: PiCodeRequest):
     # Guard against mocked subprocesses in tests where proc.pid may not be a
     # real int: a MagicMock.pid coerces to 1 via __int__, and
     # os.killpg(1, SIGTERM) would signal init/the CI runner.
-    _pgid: int | None = proc.pid if isinstance(proc.pid, int) and proc.pid > 1 else None
+    # ``os.killpg`` is POSIX-only: on Windows it does not exist, so leave
+    # _pgid None there — the group-kill path is skipped and cleanup falls
+    # through to proc.terminate()/proc.kill() instead of raising AttributeError
+    # from the finally block (which only suppresses ProcessLookupError).
+    _pgid: int | None = (
+        proc.pid
+        if hasattr(os, "killpg") and isinstance(proc.pid, int) and proc.pid > 1
+        else None
+    )
 
     decoder = codecs.getincrementaldecoder("utf-8")()
     json_decoder = json.JSONDecoder()

--- a/tests/service/connections/providers/test_cli_cancellation.py
+++ b/tests/service/connections/providers/test_cli_cancellation.py
@@ -36,9 +36,7 @@ class TestSubprocessSessionIsolation:
 
         from lionagi.providers.anthropic.claude_code.models import _ndjson_from_cli
 
-        with patch(
-            "asyncio.create_subprocess_exec", new_callable=AsyncMock
-        ) as mock_exec:
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
             mock_proc = MagicMock()
             mock_proc.stdout = MagicMock()
             mock_proc.stdout.read = AsyncMock(return_value=b"")
@@ -57,9 +55,9 @@ class TestSubprocessSessionIsolation:
             # Verify start_new_session=True was passed
             mock_exec.assert_called_once()
             _, kwargs = mock_exec.call_args
-            assert (
-                kwargs.get("start_new_session") is True
-            ), "CLI subprocess must use start_new_session=True to isolate from SIGINT"
+            assert kwargs.get("start_new_session") is True, (
+                "CLI subprocess must use start_new_session=True to isolate from SIGINT"
+            )
 
     @pytest.mark.asyncio
     async def test_codex_cli_uses_start_new_session(self):
@@ -72,9 +70,7 @@ class TestSubprocessSessionIsolation:
 
         with (
             patch("lionagi.providers.openai.codex.models.CODEX_CLI", "codex"),
-            patch(
-                "asyncio.create_subprocess_exec", new_callable=AsyncMock
-            ) as mock_exec,
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
         ):
             mock_proc = MagicMock()
             mock_proc.stdout = MagicMock()
@@ -105,9 +101,7 @@ class TestSubprocessSessionIsolation:
 
         with (
             patch("lionagi.providers.google.gemini_code.models.GEMINI_CLI", "gemini"),
-            patch(
-                "asyncio.create_subprocess_exec", new_callable=AsyncMock
-            ) as mock_exec,
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
         ):
             mock_proc = MagicMock()
             mock_proc.stdout = MagicMock()
@@ -167,9 +161,9 @@ class TestCancellationSkipsAutoFinish:
 
             # stream_claude_code_cli must only be called ONCE —
             # the second (auto_finish) call must never happen
-            assert (
-                stream_call_count == 1
-            ), f"auto_finish spawned {stream_call_count - 1} extra session(s) after cancellation"
+            assert stream_call_count == 1, (
+                f"auto_finish spawned {stream_call_count - 1} extra session(s) after cancellation"
+            )
 
     @pytest.mark.asyncio
     async def test_keyboard_interrupt_skips_auto_finish(self):
@@ -282,9 +276,7 @@ class TestCancellationSkipsAutoFinish:
             result = await endpoint._call({"request": mock_request}, {})
 
             # auto_finish SHOULD trigger normally
-            assert (
-                stream_call_count == 2
-            ), "auto_finish should fire on normal completion"
+            assert stream_call_count == 2, "auto_finish should fire on normal completion"
 
 
 # ---------------------------------------------------------------------------
@@ -306,9 +298,7 @@ class TestNdjsonCleanupPropagation:
 
         request = ClaudeCodeRequest(prompt="test")
 
-        with patch(
-            "asyncio.create_subprocess_exec", new_callable=AsyncMock
-        ) as mock_exec:
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
             mock_proc = MagicMock()
 
             read_call = 0
@@ -404,9 +394,7 @@ class TestToolAllowlistArgs:
 
         idx = args.index("--mcp-config")
         config_val = args[idx + 1]
-        assert (
-            '"' not in config_val
-        ), f"mcp_config value {config_val!r} has embedded quotes"
+        assert '"' not in config_val, f"mcp_config value {config_val!r} has embedded quotes"
 
 
 # ---------------------------------------------------------------------------
@@ -465,3 +453,233 @@ class TestEmptyResponsesGuard:
             # Must not raise IndexError on responses[-1]
             result = await endpoint._call({"request": mock_request}, {})
             assert isinstance(result, dict)
+
+
+# ---------------------------------------------------------------------------
+# 7. Gemini & Pi process-group kill (AUDIT-005)
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_proc(pid=12345):
+    """Build a minimal mock subprocess suitable for ndjson_from_cli tests."""
+    mock_proc = MagicMock()
+    mock_proc.pid = pid
+    mock_proc.stdout = MagicMock()
+    mock_proc.stdout.read = AsyncMock(return_value=b"")
+    mock_proc.stderr = MagicMock()
+    mock_proc.stderr.read = AsyncMock(return_value=b"")
+    mock_proc.wait = AsyncMock(return_value=0)
+    mock_proc.terminate = MagicMock()
+    mock_proc.kill = MagicMock()
+    return mock_proc
+
+
+class TestProcessGroupCleanup:
+    """AUDIT-005: Gemini and Pi cleanup must use os.killpg on the process group.
+
+    Claude and Codex capture the PGID immediately after spawn and call
+    os.killpg(pgid, SIGTERM/SIGKILL) in cleanup so that descendant processes
+    started by the CLI are also terminated.  Gemini and Pi now mirror this.
+    """
+
+    @pytest.mark.asyncio
+    async def test_gemini_cleanup_calls_killpg(self):
+        """Gemini _ndjson_from_cli cleanup must call os.killpg (AUDIT-005)."""
+        from lionagi.providers.google.gemini_code.models import (
+            GeminiCodeRequest,
+            _ndjson_from_cli,
+        )
+
+        request = GeminiCodeRequest(prompt="test")
+        mock_proc = _make_mock_proc(pid=9001)
+        killpg_calls: list[tuple] = []
+
+        with (
+            patch("lionagi.providers.google.gemini_code.models.GEMINI_CLI", "gemini"),
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
+            patch(
+                "lionagi.providers.google.gemini_code.models.os.killpg",
+                side_effect=lambda pgid, sig: killpg_calls.append((pgid, sig)),
+            ),
+        ):
+            mock_exec.return_value = mock_proc
+
+            async with contextlib.aclosing(_ndjson_from_cli(request)) as stream:
+                async for _ in stream:
+                    pass
+
+        # At least one killpg(9001, ...) call must have been made.
+        assert any(pgid == 9001 for pgid, _ in killpg_calls), (
+            f"Expected os.killpg(9001, ...) in cleanup; got {killpg_calls}. "
+            "Gemini must terminate the whole process group (AUDIT-005)."
+        )
+
+    @pytest.mark.asyncio
+    async def test_pi_cleanup_calls_killpg(self):
+        """Pi _ndjson_from_cli cleanup must call os.killpg (AUDIT-005)."""
+        from lionagi.providers.pi.cli.models import PiCodeRequest, _ndjson_from_cli
+
+        request = PiCodeRequest(prompt="test")
+        mock_proc = _make_mock_proc(pid=9002)
+        killpg_calls: list[tuple] = []
+
+        with (
+            patch("lionagi.providers.pi.cli.models.PI_CLI", "pi"),
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
+            patch(
+                "lionagi.providers.pi.cli.models.os.killpg",
+                side_effect=lambda pgid, sig: killpg_calls.append((pgid, sig)),
+            ),
+        ):
+            mock_exec.return_value = mock_proc
+
+            async with contextlib.aclosing(_ndjson_from_cli(request)) as stream:
+                async for _ in stream:
+                    pass
+
+        assert any(pgid == 9002 for pgid, _ in killpg_calls), (
+            f"Expected os.killpg(9002, ...) in cleanup; got {killpg_calls}. "
+            "Pi must terminate the whole process group (AUDIT-005)."
+        )
+
+    @pytest.mark.asyncio
+    async def test_gemini_mock_pid_guard_skips_killpg(self):
+        """Gemini must NOT call os.killpg when proc.pid is a mock (pid > 1 guard)."""
+        from lionagi.providers.google.gemini_code.models import (
+            GeminiCodeRequest,
+            _ndjson_from_cli,
+        )
+
+        request = GeminiCodeRequest(prompt="test")
+        mock_proc = _make_mock_proc()
+        # Simulate a MagicMock pid (like in test environments where proc.pid is
+        # not a real int but isinstance check still passes if set to 1).
+        mock_proc.pid = 1  # pid=1 should be filtered out by the safety guard
+
+        killpg_calls: list = []
+
+        with (
+            patch("lionagi.providers.google.gemini_code.models.GEMINI_CLI", "gemini"),
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
+            patch(
+                "lionagi.providers.google.gemini_code.models.os.killpg",
+                side_effect=lambda pgid, sig: killpg_calls.append((pgid, sig)),
+            ),
+        ):
+            mock_exec.return_value = mock_proc
+
+            async with contextlib.aclosing(_ndjson_from_cli(request)) as stream:
+                async for _ in stream:
+                    pass
+
+        # pid=1 must be blocked by the isinstance + pid > 1 guard.
+        assert killpg_calls == [], (
+            f"os.killpg was called with pid=1: {killpg_calls}. "
+            "The safety guard must prevent signalling init/CI runner."
+        )
+
+
+# ---------------------------------------------------------------------------
+# 8. Gemini & Pi stderr deadlock prevention (AUDIT-004)
+# ---------------------------------------------------------------------------
+
+
+class TestStderrDeadlockPrevention:
+    """AUDIT-004: stderr-heavy subprocesses must not deadlock.
+
+    Gemini and Pi now drain stderr concurrently via an asyncio task.
+    We feed a large stderr payload and verify:
+    1. The stream completes without hanging.
+    2. The drained bytes appear in the error message on non-zero exit.
+    """
+
+    @pytest.mark.asyncio
+    async def test_gemini_large_stderr_does_not_deadlock(self):
+        """Gemini _ndjson_from_cli must not deadlock with large stderr (AUDIT-004)."""
+        import asyncio
+
+        from lionagi.providers.google.gemini_code.models import (
+            GeminiCodeRequest,
+            _ndjson_from_cli,
+        )
+
+        request = GeminiCodeRequest(prompt="test")
+        large_stderr = b"E: " + b"x" * 65536  # 64 KB — fills a typical pipe buffer
+
+        mock_proc = MagicMock()
+        mock_proc.pid = 9003
+        mock_proc.stdout = MagicMock()
+        # stdout returns empty immediately (no JSON output)
+        mock_proc.stdout.read = AsyncMock(return_value=b"")
+        mock_proc.stderr = MagicMock()
+        stderr_reads = [large_stderr, b""]
+        stderr_idx = 0
+
+        async def fake_stderr_read(n):
+            nonlocal stderr_idx
+            val = stderr_reads[min(stderr_idx, len(stderr_reads) - 1)]
+            stderr_idx += 1
+            return val
+
+        mock_proc.stderr.read = fake_stderr_read
+        mock_proc.wait = AsyncMock(return_value=1)  # non-zero exit to test error path
+        mock_proc.terminate = MagicMock()
+        mock_proc.kill = MagicMock()
+
+        with (
+            patch("lionagi.providers.google.gemini_code.models.GEMINI_CLI", "gemini"),
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
+            patch("lionagi.providers.google.gemini_code.models.os.killpg"),
+        ):
+            mock_exec.return_value = mock_proc
+
+            with pytest.raises(RuntimeError) as exc_info:
+                async with contextlib.aclosing(_ndjson_from_cli(request)) as stream:
+                    async for _ in stream:
+                        pass
+
+        # The error message should include the captured stderr content.
+        assert "x" * 10 in str(exc_info.value), (
+            "Stderr content was not captured in the error — concurrent drain may be broken"
+        )
+
+    @pytest.mark.asyncio
+    async def test_pi_large_stderr_does_not_deadlock(self):
+        """Pi _ndjson_from_cli must not deadlock with large stderr (AUDIT-004)."""
+        from lionagi.providers.pi.cli.models import PiCodeRequest, _ndjson_from_cli
+
+        request = PiCodeRequest(prompt="test")
+        large_stderr = b"E: " + b"y" * 65536
+
+        mock_proc = MagicMock()
+        mock_proc.pid = 9004
+        mock_proc.stdout = MagicMock()
+        mock_proc.stdout.read = AsyncMock(return_value=b"")
+        mock_proc.stderr = MagicMock()
+        stderr_reads = [large_stderr, b""]
+        stderr_idx = 0
+
+        async def fake_stderr_read(n):
+            nonlocal stderr_idx
+            val = stderr_reads[min(stderr_idx, len(stderr_reads) - 1)]
+            stderr_idx += 1
+            return val
+
+        mock_proc.stderr.read = fake_stderr_read
+        mock_proc.wait = AsyncMock(return_value=1)
+        mock_proc.terminate = MagicMock()
+        mock_proc.kill = MagicMock()
+
+        with (
+            patch("lionagi.providers.pi.cli.models.PI_CLI", "pi"),
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
+            patch("lionagi.providers.pi.cli.models.os.killpg"),
+        ):
+            mock_exec.return_value = mock_proc
+
+            with pytest.raises(RuntimeError) as exc_info:
+                async with contextlib.aclosing(_ndjson_from_cli(request)) as stream:
+                    async for _ in stream:
+                        pass
+
+        assert "y" * 10 in str(exc_info.value)

--- a/tests/service/connections/providers/test_cli_cancellation.py
+++ b/tests/service/connections/providers/test_cli_cancellation.py
@@ -578,6 +578,56 @@ class TestProcessGroupCleanup:
             "The safety guard must prevent signalling init/CI runner."
         )
 
+    @pytest.mark.asyncio
+    async def test_gemini_cleanup_no_killpg_platform(self, monkeypatch):
+        """Codex #1278: on a platform without os.killpg (Windows), cleanup must
+        fall through to proc.terminate() instead of raising AttributeError from
+        the finally block (which only suppresses ProcessLookupError)."""
+        from lionagi.providers.google.gemini_code import models
+
+        request = models.GeminiCodeRequest(prompt="test")
+        mock_proc = _make_mock_proc(pid=9101)
+
+        # Simulate Windows: os.killpg does not exist.
+        monkeypatch.delattr(models.os, "killpg", raising=False)
+
+        with (
+            patch("lionagi.providers.google.gemini_code.models.GEMINI_CLI", "gemini"),
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
+        ):
+            mock_exec.return_value = mock_proc
+
+            # Must complete cleanly — no AttributeError leaking from cleanup.
+            async with contextlib.aclosing(models._ndjson_from_cli(request)) as stream:
+                async for _ in stream:
+                    pass
+
+        # Group-kill skipped; direct terminate still ran.
+        mock_proc.terminate.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_pi_cleanup_no_killpg_platform(self, monkeypatch):
+        """Codex #1278: Pi cleanup must not raise AttributeError when os.killpg
+        is unavailable (Windows); it falls back to proc.terminate()."""
+        from lionagi.providers.pi.cli import models
+
+        request = models.PiCodeRequest(prompt="test")
+        mock_proc = _make_mock_proc(pid=9102)
+
+        monkeypatch.delattr(models.os, "killpg", raising=False)
+
+        with (
+            patch("lionagi.providers.pi.cli.models.PI_CLI", "pi"),
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
+        ):
+            mock_exec.return_value = mock_proc
+
+            async with contextlib.aclosing(models._ndjson_from_cli(request)) as stream:
+                async for _ in stream:
+                    pass
+
+        mock_proc.terminate.assert_called()
+
 
 # ---------------------------------------------------------------------------
 # 8. Gemini & Pi stderr deadlock prevention (AUDIT-004)

--- a/tests/service/connections/providers/test_endpoint_contract_consistency.py
+++ b/tests/service/connections/providers/test_endpoint_contract_consistency.py
@@ -76,9 +76,7 @@ def test_openai_embed_and_response_payloads_filter_internal_kwargs():
     assert payload == {"model": "text-embedding-3-small", "input": "hello"}
 
     response = EndpointRegistry.match("openai", "response")
-    payload, _ = response.create_payload(
-        {"model": "gpt-5", "input": "hello", "branch": "drop"}
-    )
+    payload, _ = response.create_payload({"model": "gpt-5", "input": "hello", "branch": "drop"})
     assert payload == {"model": "gpt-5", "input": "hello"}
 
 
@@ -103,9 +101,7 @@ def test_openai_response_payload_keeps_current_api_fields_and_prompt_only():
         "prompt_cache_key": "cache-key",
     }
 
-    prompt_payload, _ = response.create_payload(
-        {"model": "gpt-5", "prompt": {"id": "pmpt_123"}}
-    )
+    prompt_payload, _ = response.create_payload({"model": "gpt-5", "prompt": {"id": "pmpt_123"}})
     assert prompt_payload == {"model": "gpt-5", "prompt": {"id": "pmpt_123"}}
 
 
@@ -160,9 +156,7 @@ def test_base_http_stream_lines_convert_to_stream_chunks():
         )
     )
 
-    text_chunk = endpoint._line_to_stream_chunk(
-        'data: {"choices":[{"delta":{"content":"hi"}}]}'
-    )
+    text_chunk = endpoint._line_to_stream_chunk('data: {"choices":[{"delta":{"content":"hi"}}]}')
     done_chunk = endpoint._line_to_stream_chunk("data: [DONE]")
 
     assert isinstance(text_chunk, StreamChunk)

--- a/tests/service/connections/providers/test_oai.py
+++ b/tests/service/connections/providers/test_oai.py
@@ -171,9 +171,7 @@ class TestOpenAIIntegration:
             for chunk in chunks:
                 yield chunk
 
-        with patch.object(
-            openai_imodel.endpoint, "stream", return_value=mock_openai_stream()
-        ):
+        with patch.object(openai_imodel.endpoint, "stream", return_value=mock_openai_stream()):
             chunks = []
             async for chunk in openai_imodel.stream(
                 messages=[{"role": "user", "content": "Hello"}],
@@ -192,9 +190,7 @@ class TestOpenAIIntegration:
 
     def test_openai_url_construction(self):
         """Test OpenAI URL construction."""
-        endpoint = match_endpoint(
-            provider="openai", endpoint="chat", model="gpt-4.1-mini"
-        )
+        endpoint = match_endpoint(provider="openai", endpoint="chat", model="gpt-4.1-mini")
 
         url = endpoint.config.full_url
         assert "api.openai.com" in url
@@ -230,9 +226,7 @@ class TestOpenAIIntegration:
             response["id"] = f"chatcmpl-{request['messages'][0]['content'][-1]}"
             return response
 
-        with patch.object(
-            openai_imodel.endpoint, "call", side_effect=mock_request_with_delay
-        ):
+        with patch.object(openai_imodel.endpoint, "call", side_effect=mock_request_with_delay):
             tasks = []
             for i in range(3):
                 task = asyncio.create_task(
@@ -340,9 +334,7 @@ class TestOpenAIIntegration:
             "call",
             side_effect=aiohttp.ClientError("Rate limit exceeded"),
         ):
-            result = await openai_imodel.invoke(
-                messages=[{"role": "user", "content": "Hello"}]
-            )
+            result = await openai_imodel.invoke(messages=[{"role": "user", "content": "Hello"}])
 
             # The invoke method returns a failed APICalling object instead of raising
             assert result.status == EventStatus.FAILED
@@ -398,18 +390,13 @@ class TestGeminiIntegration:
     def test_gemini_endpoint_configuration(self, gemini_imodel):
         """Test that Gemini endpoint is configured correctly."""
         assert gemini_imodel.endpoint.config.provider == "gemini"
-        assert (
-            "generativelanguage.googleapis.com"
-            in gemini_imodel.endpoint.config.base_url
-        )
+        assert "generativelanguage.googleapis.com" in gemini_imodel.endpoint.config.base_url
 
     def test_gemini_config_defaults(self):
         """Test _get_gemini_config returns correct defaults."""
         config = _get_gemini_config()
         assert config.provider == "gemini"
-        assert (
-            config.base_url == "https://generativelanguage.googleapis.com/v1beta/openai"
-        )
+        assert config.base_url == "https://generativelanguage.googleapis.com/v1beta/openai"
         assert config.endpoint == "chat/completions"
         assert config.auth_type == "bearer"
         assert config.method == "POST"
@@ -455,17 +442,13 @@ class TestGeminiIntegration:
 
     def test_gemini_match_endpoint_routing(self):
         """Test that match_endpoint routes 'gemini' + 'chat' correctly."""
-        endpoint = match_endpoint(
-            provider="gemini", endpoint="chat", model="gemini-2.5-flash"
-        )
+        endpoint = match_endpoint(provider="gemini", endpoint="chat", model="gemini-2.5-flash")
         assert isinstance(endpoint, GeminiChatEndpoint)
         assert endpoint.config.provider == "gemini"
 
     def test_gemini_url_construction(self):
         """Test Gemini URL construction."""
-        endpoint = match_endpoint(
-            provider="gemini", endpoint="chat", model="gemini-2.5-flash"
-        )
+        endpoint = match_endpoint(provider="gemini", endpoint="chat", model="gemini-2.5-flash")
         url = endpoint.config.full_url
         assert "generativelanguage.googleapis.com" in url
         assert "chat/completions" in url

--- a/tests/service/connections/providers/test_ollama.py
+++ b/tests/service/connections/providers/test_ollama.py
@@ -1,5 +1,6 @@
 """Tests for lionagi.providers.ollama.chat.endpoint module."""
 
+import contextlib
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -385,3 +386,107 @@ class TestOllamaConfig:
 
         assert OLLAMA_CHAT_ENDPOINT_CONFIG is not None
         assert OLLAMA_CHAT_ENDPOINT_CONFIG.provider == "ollama"
+
+
+class TestOllamaPublicSurface:
+    """AUDIT-002 regression: __all__ must not export undefined names (F822).
+
+    The stale ``OLLAMA_CHAT_ENDPOINT_CONFIG`` entry was removed from ``__all__``
+    because no such symbol is defined in the module.  A star-import must succeed
+    and the resulting namespace must only contain names that actually exist.
+    """
+
+    @patch("lionagi.providers.ollama.chat.endpoint._HAS_OLLAMA", True)
+    def test_star_import_succeeds(self):
+        """``from lionagi.providers.ollama.chat.endpoint import *`` must not raise."""
+        import importlib
+
+        mod = importlib.import_module("lionagi.providers.ollama.chat.endpoint")
+        namespace = {}
+        # Simulate star-import by executing each exported name.
+        for name in mod.__all__:
+            assert hasattr(mod, name), (
+                f"__all__ exports {name!r} but module has no such attribute — "
+                "remove the stale name or define the symbol (AUDIT-002 / F822)"
+            )
+            namespace[name] = getattr(mod, name)
+
+    @patch("lionagi.providers.ollama.chat.endpoint._HAS_OLLAMA", True)
+    def test_all_does_not_contain_ollama_chat_endpoint_config(self):
+        """Stale OLLAMA_CHAT_ENDPOINT_CONFIG must be absent from __all__."""
+        import importlib
+
+        mod = importlib.import_module("lionagi.providers.ollama.chat.endpoint")
+        assert "OLLAMA_CHAT_ENDPOINT_CONFIG" not in mod.__all__, (
+            "OLLAMA_CHAT_ENDPOINT_CONFIG is in __all__ but not defined in the module; "
+            "remove it from __all__ to fix AUDIT-002 / F822"
+        )
+
+
+class TestOllamaAsyncCheckModel:
+    """AUDIT-003 regression: _check_model must not block the event loop.
+
+    The fix wraps the synchronous Ollama SDK calls in ``run_sync`` so they run
+    in a thread pool.  We verify that calling ``call()`` does NOT block by
+    confirming a concurrent ticker task keeps ticking while the (mocked) slow
+    model-check executes.
+    """
+
+    @pytest.mark.asyncio
+    @patch("lionagi.providers.ollama.chat.endpoint._HAS_OLLAMA", True)
+    async def test_call_check_model_runs_in_thread_not_blocking(self):
+        """A slow _check_model must not block concurrent async tasks (AUDIT-003).
+
+        We measure how many ticks a short-interval counter task completes while
+        ``call()`` is waiting on a "slow" (sleep-based) _check_model.  If the
+        event loop is blocked, the ticker gets zero ticks; if the fix is correct
+        it gets at least a few.
+        """
+        import asyncio
+
+        from lionagi.providers.ollama.chat.endpoint import OllamaChatEndpoint
+
+        mock_ollama.reset_mock()
+        mock_ollama.list = MagicMock()
+        mock_ollama.pull = MagicMock()
+
+        endpoint = OllamaChatEndpoint()
+
+        tick_count = 0
+
+        async def ticker():
+            nonlocal tick_count
+            while True:
+                await asyncio.sleep(0.01)
+                tick_count += 1
+
+        def slow_check(model: str) -> None:
+            """Simulates a slow sync check — sleeps in the current thread."""
+            import time
+
+            time.sleep(0.1)
+
+        with (
+            patch.object(endpoint, "_check_model", side_effect=slow_check),
+            patch.object(
+                endpoint.__class__.__bases__[0],
+                "call",
+                new_callable=AsyncMock,
+                return_value={"response": "ok"},
+            ),
+        ):
+            ticker_task = asyncio.create_task(ticker())
+            try:
+                await endpoint.call({"model": "llama2", "messages": []})
+            finally:
+                ticker_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await ticker_task
+
+        # If the event loop was blocked, tick_count would be 0.
+        # With run_sync the event loop stays alive, so we get ≥ 2 ticks during
+        # the 100 ms wait (10 ms interval).
+        assert tick_count >= 2, (
+            f"tick_count={tick_count}: event loop appears blocked during _check_model "
+            "— ensure _check_model is wrapped in run_sync (AUDIT-003)"
+        )

--- a/tests/service/connections/providers/test_pi_cli.py
+++ b/tests/service/connections/providers/test_pi_cli.py
@@ -210,3 +210,89 @@ async def test_pi_cli_endpoint_stream_maps_pi_chunks_to_stream_chunks(monkeypatc
     assert chunks[2].tool_input == {"path": "a.py"}
     assert chunks[3].tool_output == {"ok": True}
     assert chunks[4].content == "done"
+
+
+# ---------------------------------------------------------------------------
+# AUDIT-006 regression: Pi file_args path validation (fail-closed)
+# ---------------------------------------------------------------------------
+
+
+class TestPiFileArgsValidation:
+    """AUDIT-006: Pi file_args must reject absolute paths and ``..`` traversal.
+
+    Without validation, PiCodeRequest(file_args=["../../secrets.txt"]) would
+    cause the CLI to emit ``@../../secrets.txt`` and read an arbitrary file.
+    The validator must raise ValueError at model construction time (fail-closed)
+    before any subprocess is launched.
+    """
+
+    def test_absolute_path_is_rejected(self):
+        """Absolute path in file_args must raise ValueError (AUDIT-006)."""
+        with pytest.raises(ValueError, match="absolute path"):
+            PiCodeRequest(prompt="hello", file_args=["/etc/passwd"])
+
+    def test_absolute_path_with_at_prefix_is_rejected(self):
+        """Absolute path with @ prefix in file_args must raise ValueError."""
+        with pytest.raises(ValueError, match="absolute path"):
+            PiCodeRequest(prompt="hello", file_args=["@/etc/passwd"])
+
+    def test_dotdot_traversal_is_rejected(self):
+        """Directory traversal (``..``) in file_args must raise ValueError (AUDIT-006)."""
+        with pytest.raises(ValueError, match="traversal"):
+            PiCodeRequest(prompt="hello", file_args=["../../secrets.txt"])
+
+    def test_dotdot_with_at_prefix_is_rejected(self):
+        """``@../../secrets.txt`` traversal must be caught before CLI launch."""
+        with pytest.raises(ValueError, match="traversal"):
+            PiCodeRequest(prompt="hello", file_args=["@../../secrets.txt"])
+
+    def test_relative_path_is_allowed(self):
+        """Safe relative paths inside the repo must be accepted."""
+        req = PiCodeRequest(prompt="hello", file_args=["README.md", "src/main.py"])
+        assert "@README.md" in req.as_cmd_args()
+        assert "@src/main.py" in req.as_cmd_args()
+
+    def test_at_prefixed_relative_path_is_allowed(self):
+        """``@``-prefixed relative paths must pass validation unchanged."""
+        req = PiCodeRequest(prompt="hello", file_args=["@pyproject.toml"])
+        args = req.as_cmd_args()
+        # The builder should not double-prefix already-@-prefixed entries.
+        assert "@pyproject.toml" in args
+
+    def test_empty_file_args_is_allowed(self):
+        """An empty file_args list must not raise."""
+        req = PiCodeRequest(prompt="hello", file_args=[])
+        assert req.file_args == []
+
+    def test_mixed_valid_and_invalid_raises_on_invalid(self):
+        """If any entry is invalid the whole list must be rejected."""
+        with pytest.raises(ValueError):
+            PiCodeRequest(
+                prompt="hello",
+                file_args=["safe.txt", "/absolute/path.txt"],
+            )
+
+    def test_symlink_escape_rejected(self, tmp_path):
+        """A repo-local symlink to outside the repo must be rejected.
+
+        ``repo/link -> /outside`` with file_args=["link/secret.txt"] is
+        lexically clean (no abs path, no ``..``) but resolves outside the repo.
+        The model-level validator resolves against repo.resolve() and rejects it.
+        """
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "secret.txt").write_text("secret")
+        (repo / "link").symlink_to(outside, target_is_directory=True)
+
+        with pytest.raises(ValueError, match="outside the repository"):
+            PiCodeRequest(prompt="hi", repo=repo, file_args=["link/secret.txt"])
+
+    def test_real_relative_path_inside_repo_allowed(self, tmp_path):
+        """A genuine relative path inside the repo passes the symlink check."""
+        repo = tmp_path / "repo"
+        (repo / "src").mkdir(parents=True)
+        (repo / "src" / "main.py").write_text("x = 1")
+        req = PiCodeRequest(prompt="hi", repo=repo, file_args=["src/main.py"])
+        assert "@src/main.py" in req.as_cmd_args()


### PR DESCRIPTION
Provider endpoint **async correctness** + **fail-closed CLI path validation** (ag2, google gemini_code, pi/cli, ollama, openai).
---
Part of the sliced **audit-remediation** series (replaces the monolithic #1276). Each slice is file-disjoint and cut from `main`. Full integration branch: `chore/audit-remediation` (7670 tests green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
