### PR TITLE
fix(protocols/messages): image-URL SSRF guard + message hardening

### DIFF
--- a/lionagi/protocols/contracts.py
+++ b/lionagi/protocols/contracts.py
@@ -11,6 +11,10 @@ from __future__ import annotations
 
 from typing import Protocol, runtime_checkable
 
+# Keep legacy nominal ABC for places that need issubclass checks (e.g., Pile)
+# Do NOT remove – Pile and others rely on issubclass(..., Observable) nominal checks.
+from ._concepts import Observable as LegacyObservable
+
 __all__ = (
     "ObservableProto",
     "Observable",
@@ -39,7 +43,3 @@ class ObservableProto(Protocol):
 
 # Convenience alias for V1 consumers (keeps import names short)
 Observable = ObservableProto
-
-# Keep legacy nominal ABC for places that need issubclass checks (e.g., Pile)
-# Do NOT remove – Pile and others rely on issubclass(..., Observable) nominal checks.
-from ._concepts import Observable as LegacyObservable

--- a/lionagi/protocols/generic/element.py
+++ b/lionagi/protocols/generic/element.py
@@ -119,7 +119,7 @@ class Element(BaseModel, Observable):
             raise ValueError(f"Invalid created_at: {val}") from None
 
     @field_validator("id", mode="before")
-    def _ensure_UUID(cls, val: UUID | str) -> UUID:
+    def _ensure_uuid(cls, val: UUID | str) -> UUID:
         """Ensures `id` is validated as an UUID."""
         if isinstance(val, UUID):
             return val
@@ -285,7 +285,7 @@ def validate_order(order: Any) -> list[UUID]:
             out.append(cur)
         elif isinstance(cur, str):
             out.append(UUID(cur))
-        elif isinstance(cur, (list, tuple, set)):
+        elif isinstance(cur, list | tuple | set):
             stack.extend(reversed(cur))
         else:
             raise ValueError("Invalid item in order.")

--- a/lionagi/protocols/generic/flow.py
+++ b/lionagi/protocols/generic/flow.py
@@ -167,16 +167,12 @@ class Flow(Element, Generic[E, P]):
         """
         with self._lock:
             if progression.name and progression.name in self._progression_names:
-                raise ItemExistsError(
-                    f"Progression with name '{progression.name}' already exists."
-                )
+                raise ItemExistsError(f"Progression with name '{progression.name}' already exists.")
 
             item_ids = set(self.items.keys())
             missing = set(progression) - item_ids
             if missing:
-                raise ItemNotFoundError(
-                    f"Progression references missing items: {missing}"
-                )
+                raise ItemNotFoundError(f"Progression references missing items: {missing}")
 
             self.progressions.include(progression)
             if progression.name:
@@ -225,9 +221,7 @@ class Flow(Element, Generic[E, P]):
                     uid = ID.get_id(key)
                     return self.progressions[uid]
                 except Exception as exc:
-                    raise ItemNotFoundError(
-                        f"Progression '{key}' not found in flow"
-                    ) from exc
+                    raise ItemNotFoundError(f"Progression '{key}' not found in flow") from exc
 
             uid = key.id if isinstance(key, Progression) else key
             return self.progressions[uid]
@@ -252,7 +246,7 @@ class Flow(Element, Generic[E, P]):
         with self._lock:
             resolved: list[P] = []
             if progressions is not None:
-                if isinstance(progressions, (str, UUID, Progression)):
+                if isinstance(progressions, str | UUID | Progression):
                     progs_list = [progressions]
                 else:
                     progs_list = list(progressions)

--- a/lionagi/protocols/messages/instruction.py
+++ b/lionagi/protocols/messages/instruction.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import re
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, Literal
 
@@ -6,6 +9,13 @@ from pydantic import BaseModel, field_validator
 from lionagi.ln.types import ModelConfig
 
 from .message import Message, MessageContent, MessageRole
+from .validators import validate_image_url
+
+# Pattern for a well-formed inline image data URI.  Only a bitmap MIME
+# allowlist is accepted and the payload must be non-empty base64.  This is
+# intentionally restrictive — active-content types (HTML, JS, and SVG, which
+# can carry scripts) are rejected, as are other data: schemes.
+_DATA_IMAGE_RE = re.compile(r"^data:image/(?:png|jpe?g|gif|webp);base64,[A-Za-z0-9+/]+=*$")
 
 _INSTRUCTION_SERIALIZE_EXCLUDE: frozenset[str] = frozenset(
     {"response_format", "structure", "_structure_instance"}
@@ -75,7 +85,7 @@ class InstructionContent(MessageContent):
 
         return DataClass.to_dict(self, exclude=frozenset(base_exclude))
 
-    def with_updates(self, **kwargs: Any) -> "InstructionContent":
+    def with_updates(self, **kwargs: Any) -> InstructionContent:
         # to_dict excludes response_format/structure for type/BaseModel refs
         # (they can't survive a JSON round-trip), so the generic with_updates —
         # which goes through to_dict → constructor — silently drops the response
@@ -104,7 +114,7 @@ class InstructionContent(MessageContent):
         return self._format_image_content(text, self.images, self.image_detail)
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "InstructionContent":
+    def from_dict(cls, data: dict[str, Any]) -> InstructionContent:
         inst = cls()
 
         for k in ("instruction", "guidance", "plain_content", "image_detail"):
@@ -187,8 +197,39 @@ class InstructionContent(MessageContent):
 
     @staticmethod
     def _format_image_item(idx: str, detail: str) -> dict[str, Any]:
-        url = idx
-        if not (idx.startswith("http://") or idx.startswith("https://") or idx.startswith("data:")):
+        """Format a single image entry for a provider payload.
+
+        Validation (fail-closed):
+        - http:// and https:// URLs are passed through ``validate_image_url``,
+          which rejects null bytes, non-rooted URLs, and disallowed schemes.
+        - data: URIs are accepted only when they match the ``data:image/*``
+          base64 pattern — other data: payloads (HTML, SVG, JS) are rejected
+          to limit DoS and XSS vectors.
+        - Anything else is treated as raw base64 and wrapped into a
+          ``data:image/jpeg;base64,`` URI (pre-existing behaviour).
+
+        Raises:
+            ValueError: If the URL fails validation.
+        """
+        if idx.startswith("http://") or idx.startswith("https://"):
+            # Delegates null-byte, scheme, and missing-netloc checks.
+            validate_image_url(idx)
+            url = idx
+        elif idx.startswith("data:"):
+            # Accept only well-formed inline image data URIs.
+            if not _DATA_IMAGE_RE.match(idx):
+                raise ValueError(
+                    f"Rejected data: URI — only data:image/*;base64,… is allowed. Got: {idx[:80]!r}"
+                )
+            url = idx
+        elif "://" in idx or (idx.split(":")[0].isalpha() and ":" in idx):
+            # Looks like a URL with a non-http/https/data scheme (e.g. file://,
+            # javascript:, ftp://).  Delegate to validate_image_url which will
+            # reject all disallowed schemes with a clear error.
+            validate_image_url(idx)
+            url = idx  # unreachable if validate_image_url raises
+        else:
+            # Raw base64 payload — wrap as an inline JPEG data URI.
             url = f"data:image/jpeg;base64,{idx}"
         return {
             "type": "image_url",

--- a/lionagi/protocols/messages/system.py
+++ b/lionagi/protocols/messages/system.py
@@ -1,11 +1,14 @@
 # Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from dataclasses import dataclass
-from datetime import datetime
 from typing import Any, ClassVar
 
 from pydantic import Field, field_validator
+
+from lionagi.ln._utils import now_utc
 
 from .base import SenderRecipient
 from .message import Message, MessageContent, MessageRole
@@ -37,7 +40,7 @@ class SystemContent(MessageContent):
         return self.rendered
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "SystemContent":
+    def from_dict(cls, data: dict[str, Any]) -> SystemContent:
         """Construct SystemContent from dictionary."""
         system_message = data.get(
             "system_message",
@@ -47,7 +50,7 @@ class SystemContent(MessageContent):
 
         # Handle datetime generation
         if system_datetime is True:
-            system_datetime = datetime.now().isoformat(timespec="minutes")
+            system_datetime = now_utc().isoformat(timespec="minutes")
         elif system_datetime is False or system_datetime is None:
             system_datetime = None
 

--- a/lionagi/protocols/messages/validators.py
+++ b/lionagi/protocols/messages/validators.py
@@ -5,6 +5,8 @@
 
 from urllib.parse import urlparse
 
+from lionagi.ln._ssrf import is_ssrf_safe
+
 __all__ = ("validate_image_url",)
 
 
@@ -18,9 +20,12 @@ def validate_image_url(url: str) -> None:
         - Reject data:// URLs (DoS via large embedded images)
         - Only allow http:// and https:// schemes
         - Validate URL format
+        - Reject hosts that resolve to private/link-local/loopback ranges
+          (SSRF — e.g. cloud metadata 169.254.169.254, 127.0.0.1, 192.168.x)
 
     Raises:
-        ValueError: If URL is invalid or uses disallowed scheme.
+        ValueError: If URL is invalid, uses a disallowed scheme, or its host
+            resolves to a non-public (SSRF-prone) address.
     """
     if not url or not isinstance(url, str):
         raise ValueError(f"Image URL must be non-empty string, got: {type(url).__name__}")
@@ -47,3 +52,13 @@ def validate_image_url(url: str) -> None:
 
     if not parsed.netloc:
         raise ValueError(f"Image URL missing domain: {url}")
+
+    # SSRF guard: reject hosts that resolve to private, loopback, or link-local
+    # ranges (e.g. the cloud metadata endpoint 169.254.169.254). Fail-closed:
+    # unresolvable hosts are also rejected. is_ssrf_safe expects a bare host.
+    if not is_ssrf_safe(parsed.hostname or ""):
+        raise ValueError(
+            f"Image URL host {parsed.hostname!r} is not allowed: it resolves to a "
+            f"private, loopback, or link-local address (SSRF risk), or could not be "
+            f"resolved.\nRejected URL: {url}"
+        )

--- a/tests/protocols/generic/test_log.py
+++ b/tests/protocols/generic/test_log.py
@@ -118,9 +118,7 @@ class TestLogManager:
         assert len(manager.logs) == 0
 
     def test_custom_initialization(self):
-        manager = LogManager(
-            persist_dir="/custom/path", capacity=100, extension=".json"
-        )
+        manager = LogManager(persist_dir="/custom/path", capacity=100, extension=".json")
         assert manager._config.persist_dir == "/custom/path"
         assert manager._config.capacity == 100
         assert manager._config.extension == ".json"

--- a/tests/protocols/graph/test_graph_advanced.py
+++ b/tests/protocols/graph/test_graph_advanced.py
@@ -268,10 +268,7 @@ class TestGraphAdvancedOperations:
         assert len(graph.internal_nodes) == 1
         assert len(graph.internal_edges) == 1
         assert len(graph.internal_nodes[node.id].content["large_property"]) == 1000000
-        assert (
-            len(graph.internal_edges[edge.id].properties.get("large_property"))
-            == 1000000
-        )
+        assert len(graph.internal_edges[edge.id].properties.get("large_property")) == 1000000
 
     def test_graph_stress(self):
         """Test graph under stress conditions"""

--- a/tests/protocols/graph/test_graph_basic.py
+++ b/tests/protocols/graph/test_graph_basic.py
@@ -159,10 +159,7 @@ class TestGraphContainment:
         """Test edge containment check"""
         graph, _, _, edge = simple_graph
         assert edge in graph
-        assert (
-            Edge(head=create_test_node("Node1"), tail=create_test_node("Node2"))
-            not in graph
-        )
+        assert Edge(head=create_test_node("Node1"), tail=create_test_node("Node2")) not in graph
 
     def test_empty_graph_contains(self, empty_graph):
         """Test containment checks on empty graph"""

--- a/tests/protocols/graph/test_graph_edge.py
+++ b/tests/protocols/graph/test_graph_edge.py
@@ -281,17 +281,13 @@ class TestEdgeLabelInitCoverage:
     def test_invalid_label_raises(self):
         """Line 101: label=[1, 2] → ValueError."""
         h, t = _make_nodes()
-        with pytest.raises(
-            ValueError, match="Label must be a string or a list of strings"
-        ):
+        with pytest.raises(ValueError, match="Label must be a string or a list of strings"):
             Edge(h, t, label=[1, 2])
 
     def test_invalid_label_dict_raises(self):
         """Line 101: label=dict → ValueError."""
         h, t = _make_nodes()
-        with pytest.raises(
-            ValueError, match="Label must be a string or a list of strings"
-        ):
+        with pytest.raises(ValueError, match="Label must be a string or a list of strings"):
             Edge(h, t, label={"a": 1})
 
 
@@ -344,18 +340,14 @@ class TestEdgeLabelSetterCoverage:
         """Line 141: non-string list → ValueError."""
         h, t = _make_nodes()
         e = Edge(h, t)
-        with pytest.raises(
-            ValueError, match="Label must be a string or a list of strings"
-        ):
+        with pytest.raises(ValueError, match="Label must be a string or a list of strings"):
             e.label = [1, 2]
 
     def test_set_mixed_type_list_raises(self):
         """Line 141: mixed-type list → ValueError."""
         h, t = _make_nodes()
         e = Edge(h, t)
-        with pytest.raises(
-            ValueError, match="Label must be a string or a list of strings"
-        ):
+        with pytest.raises(ValueError, match="Label must be a string or a list of strings"):
             e.label = ["valid", 42]
 
 

--- a/tests/protocols/graph/test_graph_primitives.py
+++ b/tests/protocols/graph/test_graph_primitives.py
@@ -127,9 +127,7 @@ def test_splice_after_preserves_custom_edge_properties():
     g.splice_after(a, new)
 
     # The new-to-successor edge should carry extra properties forward.
-    successor_edges = [
-        g.internal_edges[eid] for eid in g.node_edge_mapping[new.id]["out"]
-    ]
+    successor_edges = [g.internal_edges[eid] for eid in g.node_edge_mapping[new.id]["out"]]
     assert len(successor_edges) == 1
     e = successor_edges[0]
     assert e.label == ["hot"]

--- a/tests/protocols/messages/test_action_response.py
+++ b/tests/protocols/messages/test_action_response.py
@@ -292,19 +292,13 @@ def test_action_response_content_validator_with_nested_dict():
 
 def test_action_response_content_validator_invalid_type():
     """Test ActionResponse content validator rejects invalid types."""
-    with pytest.raises(
-        TypeError, match="content must be dict or ActionResponseContent"
-    ):
+    with pytest.raises(TypeError, match="content must be dict or ActionResponseContent"):
         ActionResponse(content="invalid_string")
 
-    with pytest.raises(
-        TypeError, match="content must be dict or ActionResponseContent"
-    ):
+    with pytest.raises(TypeError, match="content must be dict or ActionResponseContent"):
         ActionResponse(content=12345)
 
-    with pytest.raises(
-        TypeError, match="content must be dict or ActionResponseContent"
-    ):
+    with pytest.raises(TypeError, match="content must be dict or ActionResponseContent"):
         ActionResponse(content=["list", "of", "items"])
 
 
@@ -474,13 +468,9 @@ def test_action_response_dataclass_equality():
 
 def test_action_response_multiple_instances_independence():
     """Test that multiple ActionResponse instances are independent."""
-    response1 = ActionResponse(
-        content={"function": "func1", "arguments": {"x": 1}, "output": 1}
-    )
+    response1 = ActionResponse(content={"function": "func1", "arguments": {"x": 1}, "output": 1})
 
-    response2 = ActionResponse(
-        content={"function": "func2", "arguments": {"x": 2}, "output": 2}
-    )
+    response2 = ActionResponse(content={"function": "func2", "arguments": {"x": 2}, "output": 2})
 
     # Modify one instance
     response1.content.arguments["x"] = 999

--- a/tests/protocols/messages/test_assistant_response.py
+++ b/tests/protocols/messages/test_assistant_response.py
@@ -225,9 +225,7 @@ def test_parse_assistant_response_list_of_strings():
 
 def test_parse_assistant_response_empty_content():
     """Test parsing response with empty/null content"""
-    response = OpenAIChatResponse(
-        choices=[OpenAIChoice(message=OpenAIMessage(content=None))]
-    )
+    response = OpenAIChatResponse(choices=[OpenAIChoice(message=OpenAIMessage(content=None))])
 
     text, model_response = parse_assistant_response(response)
 
@@ -326,9 +324,7 @@ def test_assistant_response_initialization_with_none_content():
 
 def test_assistant_response_content_validation_invalid_type():
     """Test content validation raises TypeError for invalid types"""
-    with pytest.raises(
-        TypeError, match="content must be dict or AssistantResponseContent"
-    ):
+    with pytest.raises(TypeError, match="content must be dict or AssistantResponseContent"):
         AssistantResponse(content="invalid string")
 
 
@@ -433,9 +429,7 @@ def test_from_response_preserves_all_formats():
                 output=[
                     OpenAIOutputMessage(
                         type="message",
-                        content=[
-                            OpenAIOutputText(type="output_text", text="Responses API")
-                        ],
+                        content=[OpenAIOutputText(type="output_text", text="Responses API")],
                     )
                 ]
             ),
@@ -466,9 +460,7 @@ def test_model_response_property_access():
 
 def test_model_response_property_empty():
     """Test model_response property returns empty dict if not set"""
-    response = AssistantResponse(
-        content=AssistantResponseContent(assistant_response="Test")
-    )
+    response = AssistantResponse(content=AssistantResponseContent(assistant_response="Test"))
 
     assert response.model_response == {}
 
@@ -504,9 +496,7 @@ def test_assistant_response_complete_workflow():
     )
 
     # Create AssistantResponse
-    response = AssistantResponse.from_response(
-        api_response, sender="assistant", recipient="user"
-    )
+    response = AssistantResponse.from_response(api_response, sender="assistant", recipient="user")
 
     # Verify all properties
     assert response.role == MessageRole.ASSISTANT
@@ -549,9 +539,7 @@ def test_assistant_response_content_rendering():
 
 def test_assistant_response_role_immutable():
     """Test that role is always ASSISTANT"""
-    response = AssistantResponse(
-        content=AssistantResponseContent(assistant_response="Test")
-    )
+    response = AssistantResponse(content=AssistantResponseContent(assistant_response="Test"))
 
     assert response.role == MessageRole.ASSISTANT
     # Role should be set at class level

--- a/tests/protocols/messages/test_instruction.py
+++ b/tests/protocols/messages/test_instruction.py
@@ -5,6 +5,16 @@ from lionagi.protocols.messages.instruction import Instruction, InstructionConte
 from lionagi.protocols.messages.message import MessageRole
 
 
+@pytest.fixture(autouse=True)
+def _allow_public_image_hosts(monkeypatch):
+    """These tests exercise rendering/structure, not live SSRF resolution.
+
+    Stub is_ssrf_safe -> True so example.com image URLs validate without a real
+    DNS lookup. Actual SSRF rejection is covered by test_instruction_url_security.
+    """
+    monkeypatch.setattr("lionagi.protocols.messages.validators.is_ssrf_safe", lambda host: True)
+
+
 class SampleRequestModel(BaseModel):
     """Model for testing Pydantic schema handling"""
 

--- a/tests/protocols/messages/test_instruction_url_security.py
+++ b/tests/protocols/messages/test_instruction_url_security.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Attack regression tests for InstructionContent image URL validation.
+
+Audit finding: LIONAGI-AUDIT-006 — image URL validation was not enforced on
+the public instruction path. The existing validate_image_url helper in
+messages/validators.py was never called from _format_image_item, so
+file://, javascript:, data:text/html and other dangerous URLs could reach
+provider payload construction without the repository's own guard.
+
+Fix: _format_image_item now calls validate_image_url for http/https URLs
+and restricts data: URIs to well-formed data:image/*;base64,… only.
+This test asserts the guard fires BEFORE the provider payload is built.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.protocols.messages.instruction import InstructionContent
+
+
+def _render(url: str) -> None:
+    """Drive the full public path: construct InstructionContent, then render."""
+    content = InstructionContent(instruction="test", images=[url], image_detail="auto")
+    # .rendered triggers _format_image_content → _format_image_item for each URL.
+    _ = content.rendered
+
+
+class TestImageUrlAttackRejection:
+    """Dangerous image URLs must be rejected before provider payload assembly."""
+
+    def test_file_scheme_rejected(self):
+        """file:// URLs enable local file read — must be rejected."""
+        with pytest.raises(ValueError, match="http|https|scheme"):
+            _render("file:///etc/passwd")
+
+    def test_javascript_scheme_rejected(self):
+        """javascript: URLs enable XSS — must be rejected."""
+        with pytest.raises(ValueError, match="http|https|scheme"):
+            _render("javascript:alert(1)")
+
+    def test_null_byte_in_url_rejected(self):
+        """Null bytes enable path-truncation attacks — must be rejected."""
+        with pytest.raises(ValueError, match="null byte"):
+            _render("https://example.com/image\x00.png")
+
+    def test_percent_encoded_null_byte_rejected(self):
+        """Percent-encoded null byte — path truncation variant — must be rejected."""
+        with pytest.raises(ValueError, match="null byte|%00"):
+            _render("https://example.com/image%00.png")
+
+    def test_missing_domain_rejected(self):
+        """http:// without a domain (SSRF / redirect abuse) — must be rejected."""
+        with pytest.raises(ValueError, match="domain|netloc"):
+            _render("http:///image.png")
+
+    def test_data_html_rejected(self):
+        """data:text/html is NOT an image — must be rejected."""
+        with pytest.raises(ValueError, match="data:image"):
+            _render("data:text/html,<script>alert(1)</script>")
+
+    def test_data_svg_rejected(self):
+        """data:image/svg+xml without base64 is not the allowed form."""
+        with pytest.raises(ValueError, match="data:image"):
+            _render("data:image/svg+xml,<svg><script>alert(1)</script></svg>")
+
+    def test_data_svg_base64_rejected(self):
+        """base64 SVG must also be rejected — SVG can carry active content, so
+        only a bitmap MIME allowlist (png/jpeg/gif/webp) is accepted."""
+        import base64
+
+        payload = base64.b64encode(b"<svg><script>alert(1)</script></svg>").decode()
+        with pytest.raises(ValueError, match="data:image"):
+            _render(f"data:image/svg+xml;base64,{payload}")
+
+    def test_cloud_metadata_endpoint_rejected(self):
+        """The cloud metadata endpoint (169.254.169.254) must be blocked (SSRF)."""
+        with pytest.raises(ValueError, match="SSRF|not allowed|private"):
+            _render("http://169.254.169.254/latest/meta-data/")
+
+    def test_loopback_rejected(self):
+        """Loopback hosts must be blocked (SSRF)."""
+        with pytest.raises(ValueError, match="SSRF|not allowed|private"):
+            _render("http://127.0.0.1:8080/image.png")
+
+    def test_private_range_rejected(self):
+        """Private-range IPs must be blocked (SSRF)."""
+        with pytest.raises(ValueError, match="SSRF|not allowed|private"):
+            _render("http://192.168.1.1/image.png")
+
+
+class TestImageUrlSafeInputs:
+    """Well-formed image URLs must pass through unchanged."""
+
+    def test_https_url_accepted(self, monkeypatch):
+        """Standard HTTPS image URL with a public host must be accepted.
+
+        is_ssrf_safe is stubbed True so the test asserts the accept-path without
+        a real DNS lookup (the SSRF resolver is unit-tested separately).
+        """
+        monkeypatch.setattr("lionagi.protocols.messages.validators.is_ssrf_safe", lambda host: True)
+        content = InstructionContent(
+            instruction="test",
+            images=["https://example.com/photo.jpg"],
+            image_detail="auto",
+        )
+        rendered = content.rendered
+        assert isinstance(rendered, list)
+        item = rendered[1]
+        assert item["image_url"]["url"] == "https://example.com/photo.jpg"
+
+    def test_http_url_accepted(self, monkeypatch):
+        """Standard HTTP image URL with a public host must be accepted."""
+        monkeypatch.setattr("lionagi.protocols.messages.validators.is_ssrf_safe", lambda host: True)
+        content = InstructionContent(
+            instruction="test",
+            images=["http://example.com/photo.png"],
+            image_detail="low",
+        )
+        rendered = content.rendered
+        assert rendered[1]["image_url"]["url"] == "http://example.com/photo.png"
+
+    def test_valid_data_image_uri_accepted(self):
+        """Proper data:image/*;base64,… URI must be accepted."""
+        b64 = "iVBORw0KGgo="  # minimal fake PNG base64
+        uri = f"data:image/png;base64,{b64}"
+        content = InstructionContent(
+            instruction="test",
+            images=[uri],
+            image_detail="high",
+        )
+        rendered = content.rendered
+        assert rendered[1]["image_url"]["url"] == uri
+
+    def test_raw_base64_wrapped_as_data_uri(self):
+        """Raw base64 (no scheme) is wrapped as data:image/jpeg;base64,…"""
+        raw_b64 = "iVBORw0KGgo="
+        content = InstructionContent(
+            instruction="test",
+            images=[raw_b64],
+            image_detail="auto",
+        )
+        rendered = content.rendered
+        url = rendered[1]["image_url"]["url"]
+        assert url.startswith("data:image/jpeg;base64,")
+        assert raw_b64 in url

--- a/tests/protocols/messages/test_manager_actions.py
+++ b/tests/protocols/messages/test_manager_actions.py
@@ -26,12 +26,8 @@ def message_manager():
 
 def test_clear_messages_no_system(message_manager):
     """Test clearing messages when no system message exists"""
-    message_manager.add_message(
-        instruction="Test", sender="user", recipient="assistant"
-    )
-    message_manager.add_message(
-        assistant_response="Response", sender="assistant", recipient="user"
-    )
+    message_manager.add_message(instruction="Test", sender="user", recipient="assistant")
+    message_manager.add_message(assistant_response="Response", sender="assistant", recipient="user")
 
     assert len(message_manager.messages) == 2
     message_manager.clear_messages()
@@ -41,12 +37,8 @@ def test_clear_messages_no_system(message_manager):
 def test_clear_messages_preserves_system(message_manager):
     """Test clearing messages preserves system message"""
     system = message_manager.add_message(system="Test system")
-    message_manager.add_message(
-        instruction="Test", sender="user", recipient="assistant"
-    )
-    message_manager.add_message(
-        assistant_response="Response", sender="assistant", recipient="user"
-    )
+    message_manager.add_message(instruction="Test", sender="user", recipient="assistant")
+    message_manager.add_message(assistant_response="Response", sender="assistant", recipient="user")
 
     assert len(message_manager.messages) == 3
     message_manager.clear_messages()
@@ -65,9 +57,7 @@ async def test_async_add_message(message_manager):
 
 async def test_async_clear_messages(message_manager):
     """Test async clear messages"""
-    message_manager.add_message(
-        instruction="Test", sender="user", recipient="assistant"
-    )
+    message_manager.add_message(instruction="Test", sender="user", recipient="assistant")
     assert len(message_manager.messages) == 1
 
     await message_manager.aclear_messages()
@@ -80,9 +70,7 @@ def test_last_response(message_manager):
     assert message_manager.last_response is None
 
     # Add an instruction
-    message_manager.add_message(
-        instruction="Test", sender="user", recipient="assistant"
-    )
+    message_manager.add_message(instruction="Test", sender="user", recipient="assistant")
     assert message_manager.last_response is None
 
     # Add first response
@@ -110,9 +98,7 @@ def test_last_instruction(message_manager):
     assert message_manager.last_instruction == instruction1
 
     # Add a response
-    message_manager.add_message(
-        assistant_response="Response", sender="assistant", recipient="user"
-    )
+    message_manager.add_message(assistant_response="Response", sender="assistant", recipient="user")
     assert message_manager.last_instruction == instruction1
 
     # Add second instruction
@@ -127,9 +113,7 @@ def test_assistant_responses_property(message_manager):
     assert len(message_manager.assistant_responses) == 0
 
     # Add instruction (not included)
-    message_manager.add_message(
-        instruction="Test", sender="user", recipient="assistant"
-    )
+    message_manager.add_message(instruction="Test", sender="user", recipient="assistant")
     assert len(message_manager.assistant_responses) == 0
 
     # Add responses
@@ -160,9 +144,7 @@ def test_instructions_property(message_manager):
     )
 
     # Add response (not included)
-    message_manager.add_message(
-        assistant_response="Response", sender="assistant", recipient="user"
-    )
+    message_manager.add_message(assistant_response="Response", sender="assistant", recipient="user")
 
     instructions = message_manager.instructions
     assert isinstance(instructions, Pile)

--- a/tests/protocols/messages/test_message.py
+++ b/tests/protocols/messages/test_message.py
@@ -229,9 +229,7 @@ def test_roled_message_role_classvar():
 
 def test_roled_message_role_ignored_in_constructor():
     """Test that passing role= to constructor is silently ignored."""
-    message = _MockMessage(
-        role="user", content=_MockContent(text="test"), sender="user"
-    )
+    message = _MockMessage(role="user", content=_MockContent(text="test"), sender="user")
     assert message.role == MessageRole.UNSET
 
 
@@ -441,9 +439,7 @@ def test_roled_message_to_dict():
 
 def test_roled_message_serialization_to_dict():
     """Test serialization of RoledMessage to dict."""
-    message = _MockMessage(
-        role=MessageRole.USER, content=_MockContent(text="test"), sender="user"
-    )
+    message = _MockMessage(role=MessageRole.USER, content=_MockContent(text="test"), sender="user")
 
     serialized = message.to_dict()
     assert "role" in serialized

--- a/tests/protocols/messages/test_rendering.py
+++ b/tests/protocols/messages/test_rendering.py
@@ -32,6 +32,17 @@ from lionagi.protocols.messages import (
 from lionagi.protocols.messages.rendering import CustomParser, CustomRenderer, StructureFormat
 from lionagi.protocols.messages.validators import validate_image_url
 
+
+@pytest.fixture(autouse=True)
+def _allow_public_image_hosts(monkeypatch):
+    """Stub is_ssrf_safe -> True so example.com URLs validate without live DNS.
+
+    SSRF rejection is covered deterministically (IP literals) in
+    test_instruction_url_security; here we only test scheme/format/structure.
+    """
+    monkeypatch.setattr("lionagi.protocols.messages.validators.is_ssrf_safe", lambda host: True)
+
+
 # ---------------------------------------------------------------------------
 # StructureFormat
 # ---------------------------------------------------------------------------

--- a/tests/protocols/messages/test_system.py
+++ b/tests/protocols/messages/test_system.py
@@ -14,10 +14,7 @@ def test_systemcontent_initialization():
     """Test basic initialization of SystemContent dataclass"""
     # Default initialization
     content = SystemContent()
-    assert (
-        content.system_message
-        == "You are a helpful AI assistant. Let's think step by step."
-    )
+    assert content.system_message == "You are a helpful AI assistant. Let's think step by step."
     assert content.system_datetime is None
 
     # Custom message
@@ -26,9 +23,7 @@ def test_systemcontent_initialization():
     assert content.system_datetime is None
 
     # With datetime
-    content = SystemContent(
-        system_message="Test message", system_datetime="2024-01-01T12:00"
-    )
+    content = SystemContent(system_message="Test message", system_datetime="2024-01-01T12:00")
     assert content.system_message == "Test message"
     assert content.system_datetime == "2024-01-01T12:00"
 
@@ -56,9 +51,7 @@ def test_systemcontent_rendered_without_datetime():
 
 def test_systemcontent_rendered_with_datetime():
     """Test rendered property with datetime"""
-    content = SystemContent(
-        system_message="Test message", system_datetime="2024-01-01T12:00"
-    )
+    content = SystemContent(system_message="Test message", system_datetime="2024-01-01T12:00")
 
     rendered = content.rendered
     assert "System Time: 2024-01-01T12:00" in rendered
@@ -122,10 +115,7 @@ def test_systemcontent_from_dict_empty():
     data = {}
     content = SystemContent.from_dict(data)
 
-    assert (
-        content.system_message
-        == "You are a helpful AI assistant. Let's think step by step."
-    )
+    assert content.system_message == "You are a helpful AI assistant. Let's think step by step."
     assert content.system_datetime is None
 
 
@@ -135,10 +125,7 @@ def test_systemcontent_from_dict_partial():
     content = SystemContent.from_dict(data)
 
     # Should use default system_message
-    assert (
-        content.system_message
-        == "You are a helpful AI assistant. Let's think step by step."
-    )
+    assert content.system_message == "You are a helpful AI assistant. Let's think step by step."
     assert content.system_datetime == "2024-01-01T12:00"
 
 
@@ -192,9 +179,7 @@ def test_system_with_datetime_none():
 def test_system_with_custom_datetime():
     """Test System with custom datetime string"""
     custom_datetime = "2024-01-01T12:00:00"
-    system = System(
-        content={"system_message": "Test", "system_datetime": custom_datetime}
-    )
+    system = System(content={"system_message": "Test", "system_datetime": custom_datetime})
 
     assert system.content.system_datetime == custom_datetime
     assert custom_datetime in system.rendered
@@ -306,8 +291,7 @@ def test_system_content_validator_with_none():
 
     assert isinstance(system.content, SystemContent)
     assert (
-        system.content.system_message
-        == "You are a helpful AI assistant. Let's think step by step."
+        system.content.system_message == "You are a helpful AI assistant. Let's think step by step."
     )
 
 
@@ -326,9 +310,7 @@ def test_system_content_validator_with_dict():
 
 def test_system_content_validator_with_systemcontent():
     """Test System content validator handles SystemContent instance"""
-    content = SystemContent(
-        system_message="Custom message", system_datetime="2024-01-01T12:00"
-    )
+    content = SystemContent(system_message="Custom message", system_datetime="2024-01-01T12:00")
     system = System(content=content)
 
     assert system.content is content
@@ -376,9 +358,7 @@ def test_system_complete_workflow():
 
     # Verify serialization
     serialized = system.model_dump()
-    assert (
-        serialized["content"]["system_message"] == "You are an expert Python developer."
-    )
+    assert serialized["content"]["system_message"] == "You are an expert Python developer."
     assert serialized["content"]["system_datetime"] is not None
 
 

--- a/tests/protocols/test_observable_protocol.py
+++ b/tests/protocols/test_observable_protocol.py
@@ -60,15 +60,11 @@ class TestObservableProtocolCompliance:
         ]
 
         for instance in instances:
-            assert isinstance(
-                instance, Observable
-            ), f"{type(instance).__name__} should satisfy Observable Protocol"
-            assert hasattr(
-                instance, "id"
-            ), f"{type(instance).__name__} should have id attribute"
-            assert (
-                instance.id is not None
-            ), f"{type(instance).__name__}.id should not be None"
+            assert isinstance(instance, Observable), (
+                f"{type(instance).__name__} should satisfy Observable Protocol"
+            )
+            assert hasattr(instance, "id"), f"{type(instance).__name__} should have id attribute"
+            assert instance.id is not None, f"{type(instance).__name__}.id should not be None"
 
     def test_protocol_duck_typing(self):
         """Test that objects with id property satisfy protocol without inheritance."""


### PR DESCRIPTION
**Image-URL SSRF guard** on message content + message-construction hardening (instruction/message/system/validators).
---
Part of the sliced **audit-remediation** series (replaces the monolithic #1276). Each slice is file-disjoint and cut from `main`. Full integration branch: `chore/audit-remediation` (7670 tests green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
