### PR TITLE
fix(tools,ln,libs): fail-closed path/exec boundaries

### DIFF
--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -215,9 +215,14 @@ def _register_tools(branch: Branch, spec: AgentSpec) -> None:
             tool = _attach_hooks(BashTool().to_tool(), spec, "bash")
             branch.register_tools(tool)
         elif tool_spec == "search":
+            from pathlib import Path
+
             from lionagi.tools.code.search import SearchTool
 
-            tool = _attach_hooks(SearchTool().to_tool(), spec, "search")
+            workspace_root = str(Path(spec.cwd) if spec.cwd else Path.cwd())
+            tool = _attach_hooks(
+                SearchTool(workspace_root=workspace_root).to_tool(), spec, "search"
+            )
             branch.register_tools(tool)
 
 

--- a/lionagi/libs/file/process.py
+++ b/lionagi/libs/file/process.py
@@ -63,13 +63,9 @@ def dir_to_files(
     file_iterator = directory_path.rglob("*") if recursive else directory_path.glob("*")
     try:
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            futures = [
-                executor.submit(process_file, f) for f in file_iterator if f.is_file()
-            ]
+            futures = [executor.submit(process_file, f) for f in file_iterator if f.is_file()]
             files = [
-                future.result()
-                for future in as_completed(futures)
-                if future.result() is not None
+                future.result() for future in as_completed(futures) if future.result() is not None
             ]
 
         if verbose:
@@ -113,12 +109,12 @@ def chunk(
             elif url_or_path.is_file():
                 files = [url_or_path]
         else:
-            files = (
-                [str(url_or_path)] if not isinstance(url_or_path, list) else url_or_path
-            )
+            files = [str(url_or_path)] if not isinstance(url_or_path, list) else url_or_path
 
         if reader_tool is None:
-            reader_tool = lambda x: Path(x).read_text(encoding="utf-8")
+
+            def reader_tool(x):
+                return Path(x).read_text(encoding="utf-8")
 
         if reader_tool == "docling":
             if not is_import_installed("docling"):
@@ -129,7 +125,9 @@ def chunk(
             from docling.document_converter import DocumentConverter
 
             converter = DocumentConverter()
-            reader_tool = lambda x: converter.convert(x).document.export_to_markdown()
+
+            def reader_tool(x):  # type: ignore[no-redef]
+                return converter.convert(x).document.export_to_markdown()
 
         texts = ln.lcall(files, reader_tool)
 

--- a/lionagi/libs/schema/load_pydantic_model_from_schema.py
+++ b/lionagi/libs/schema/load_pydantic_model_from_schema.py
@@ -157,9 +157,7 @@ def _schema_to_type(
             py_types: list[type] = []
             for variant in variants:
                 py_types.append(
-                    _schema_to_type(
-                        variant, prop_name, root_schema, models_cache, parent_name
-                    )
+                    _schema_to_type(variant, prop_name, root_schema, models_cache, parent_name)
                 )
             if len(py_types) == 1:
                 return py_types[0]
@@ -172,9 +170,7 @@ def _schema_to_type(
             if "$ref" in sub:
                 sub = _resolve_ref(sub["$ref"], root_schema)
             merged = _deep_merge(merged, sub)
-        return _schema_to_type(
-            merged, prop_name, root_schema, models_cache, parent_name
-        )
+        return _schema_to_type(merged, prop_name, root_schema, models_cache, parent_name)
 
     schema_type = prop_schema.get("type")
 
@@ -195,9 +191,7 @@ def _schema_to_type(
             if mapped is None:
                 if t == "object":
                     if "properties" in prop_schema:
-                        nested_name = (
-                            prop_schema.get("title") or f"{parent_name}_{prop_name}"
-                        )
+                        nested_name = prop_schema.get("title") or f"{parent_name}_{prop_name}"
                         py_types_list.append(
                             _build_model_from_object(
                                 prop_schema,
@@ -233,17 +227,13 @@ def _schema_to_type(
 
     # --- array ---
     if schema_type == "array":
-        return _array_type(
-            prop_schema, prop_name, root_schema, models_cache, parent_name
-        )
+        return _array_type(prop_schema, prop_name, root_schema, models_cache, parent_name)
 
     # --- object ---
     if schema_type == "object":
         if "properties" in prop_schema:
             nested_name = prop_schema.get("title") or f"{parent_name}_{prop_name}"
-            return _build_model_from_object(
-                prop_schema, nested_name, root_schema, models_cache
-            )
+            return _build_model_from_object(prop_schema, nested_name, root_schema, models_cache)
         # Generic dict if no properties defined
         additional = prop_schema.get("additionalProperties")
         if isinstance(additional, dict):
@@ -267,9 +257,7 @@ def _array_type(
     items = prop_schema.get("items")
     if items is None:
         return list  # type: ignore[return-value]
-    item_type = _schema_to_type(
-        items, f"{prop_name}_item", root_schema, models_cache, parent_name
-    )
+    item_type = _schema_to_type(items, f"{prop_name}_item", root_schema, models_cache, parent_name)
     return list[item_type]  # type: ignore[valid-type]
 
 
@@ -368,9 +356,7 @@ def _create_model_from_schema(
             for def_name, def_schema in defs.items():
                 if isinstance(def_schema, dict):
                     try:
-                        _build_model_from_object(
-                            def_schema, def_name, root_schema, models_cache
-                        )
+                        _build_model_from_object(def_schema, def_name, root_schema, models_cache)
                     except _CreateModelUnsupportedError:
                         raise
 
@@ -459,13 +445,9 @@ def _load_via_codegen(
                 ) from e
 
         try:
-            model_class.model_rebuild(
-                _types_namespace=generated_module.__dict__, force=True
-            )
+            model_class.model_rebuild(_types_namespace=generated_module.__dict__, force=True)
         except (PydanticUserError, NameError) as e:
-            raise RuntimeError(
-                f"Error during model_rebuild for {resolved_model_name}"
-            ) from e
+            raise RuntimeError(f"Error during model_rebuild for {resolved_model_name}") from e
         except Exception as e:
             raise RuntimeError(
                 f"Unexpected error during model_rebuild for {resolved_model_name}"
@@ -485,13 +467,15 @@ def load_pydantic_model_from_schema(
     /,
     pydantic_version: Any = None,
     python_version: Any = None,
+    allow_codegen: bool = False,
 ) -> type[BaseModel]:
     """Build a Pydantic model class from a JSON schema string or dict.
 
     Uses ``pydantic.create_model()`` to construct models programmatically --
     no code generation and no ``exec_module()``.  Falls back to
-    ``datamodel-code-generator`` (if installed) for schemas too complex for
-    the ``create_model`` approach.
+    ``datamodel-code-generator`` **only** when *allow_codegen=True* is
+    explicitly passed; that path writes and executes a generated Python module,
+    so it must never be reached from untrusted schema input.
 
     Args:
         schema: The JSON schema as a string or a Python dictionary.
@@ -501,6 +485,12 @@ def load_pydantic_model_from_schema(
             ``datamodel-code-generator``.
         python_version: (Fallback only) The target Python version for
             ``datamodel-code-generator``.
+        allow_codegen: When ``False`` (the default), the
+            ``datamodel-code-generator`` fallback is disabled and any schema
+            that ``create_model`` cannot handle raises ``RuntimeError`` rather
+            than falling through to code generation and ``exec_module``.  Set
+            to ``True`` only for schemas from fully trusted sources (e.g.
+            hand-written library schemas under your own version control).
 
     Returns:
         The dynamically created Pydantic ``BaseModel`` subclass.
@@ -508,7 +498,8 @@ def load_pydantic_model_from_schema(
     Raises:
         ValueError: If the schema string is not valid JSON.
         TypeError: If *schema* is neither ``str`` nor ``dict``.
-        RuntimeError: If both ``create_model`` and the codegen fallback fail.
+        RuntimeError: If ``create_model`` cannot handle the schema and
+            *allow_codegen* is ``False``, or if both paths fail.
     """
     # --- 1. Parse / validate schema input ---
     schema_dict: dict[str, Any]
@@ -532,11 +523,22 @@ def load_pydantic_model_from_schema(
     except _CreateModelUnsupportedError as exc:
         create_model_error = exc
         logger.debug(
-            "create_model could not handle schema (%s); trying codegen fallback.",
+            "create_model could not handle schema (%s); codegen fallback=%s.",
             exc,
+            allow_codegen,
         )
 
-    # --- 3. Fallback: datamodel-code-generator ---
+    # --- 3. Fallback: datamodel-code-generator (opt-in, fail-closed by default) ---
+    # Security: this path executes generated Python via exec_module.  It must
+    # never be reached from untrusted schema input.  Callers must pass
+    # allow_codegen=True explicitly to opt in.
+    if not allow_codegen:
+        raise RuntimeError(
+            f"create_model could not handle this schema ({create_model_error}). "
+            "The datamodel-code-generator fallback is disabled for untrusted input. "
+            "Pass allow_codegen=True only for schemas from fully trusted sources."
+        )
+
     if not _HAS_DATAMODEL_CODE_GENERATOR:
         raise RuntimeError(
             f"create_model could not handle this schema ({create_model_error}), and "

--- a/lionagi/libs/validate/to_num.py
+++ b/lionagi/libs/validate/to_num.py
@@ -53,7 +53,7 @@ def to_num(
         TypeError: For invalid input types or invalid type conversions.
     """
     # Validate input
-    if isinstance(input_, (list, tuple)):
+    if isinstance(input_, list | tuple):
         raise TypeError("Input cannot be a sequence")
 
     # Handle boolean input
@@ -61,7 +61,7 @@ def to_num(
         return validate_num_type(num_type)(input_)
 
     # Handle direct numeric input
-    if isinstance(input_, (int, float, complex, Decimal)):
+    if isinstance(input_, int | float | complex | Decimal):
         inferred_type = type(input_)
         if isinstance(input_, Decimal):
             inferred_type = float
@@ -82,9 +82,7 @@ def to_num(
     target_type = validate_num_type(num_type)
 
     number_matches = (
-        number_matches[:num_count]
-        if num_count < len(number_matches)
-        else number_matches
+        number_matches[:num_count] if num_count < len(number_matches) else number_matches
     )
 
     for type_and_value in number_matches:

--- a/lionagi/ln/_async_call.py
+++ b/lionagi/ln/_async_call.py
@@ -70,9 +70,7 @@ def _validate_func(func: Any) -> Callable:
     try:
         func_list = list(func)
     except TypeError:
-        raise ValueError(
-            "func must be callable or an iterable containing one callable."
-        ) from None
+        raise ValueError("func must be callable or an iterable containing one callable.") from None
 
     if len(func_list) != 1 or not callable(func_list[0]):
         raise ValueError("Only one callable function is allowed.")
@@ -370,9 +368,7 @@ class AlcallParams(Params):
 
     kw: dict[str, Any] = Unset
 
-    async def __call__(
-        self, input_: list[Any], func: Callable[..., T], **kw
-    ) -> list[T]:
+    async def __call__(self, input_: list[Any], func: Callable[..., T], **kw) -> list[T]:
         kwargs = {**self.default_kw(), **kw}
         return await alcall(input_, func, **kwargs)
 
@@ -383,8 +379,13 @@ class BcallParams(AlcallParams):
 
     batch_size: int
 
-    async def __call__(
-        self, input_: list[Any], func: Callable[..., T], **kw
-    ) -> list[T]:
+    async def __call__(self, input_: list[Any], func: Callable[..., T], **kw) -> list[T]:
         kwargs = {**self.default_kw(), **kw}
-        return await bcall(input_, func, self.batch_size, **kwargs)
+        # batch_size is a positional arg to bcall; remove it from kwargs to
+        # avoid "multiple values for argument 'batch_size'" TypeError.
+        kwargs.pop("batch_size", None)
+        # bcall is an async generator — collect all batches into one flat list.
+        results: list[T] = []
+        async for batch in bcall(input_, func, self.batch_size, **kwargs):
+            results.extend(batch)
+        return results

--- a/lionagi/ln/_json_dump.py
+++ b/lionagi/ln/_json_dump.py
@@ -1,4 +1,5 @@
-from __future__ import annotations
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
 
 """JSON serialization utilities built on orjson.
 
@@ -8,6 +9,8 @@ Provides flexible serialization with:
 - NDJSON streaming for iterables
 - Caching of default handlers for performance
 """
+
+from __future__ import annotations
 
 import contextlib
 import datetime as dt
@@ -146,9 +149,9 @@ def get_orjson_default(
         typ = obj.__class__
         func = cache.get(typ)
         if func is None:
-            for T in order_tuple:
-                if issubclass(typ, T):
-                    f = ser.get(T)
+            for typ_cls in order_tuple:
+                if issubclass(typ, typ_cls):
+                    f = ser.get(typ_cls)
                     if f:
                         cache[typ] = f
                         func = f

--- a/lionagi/ln/_utils.py
+++ b/lionagi/ln/_utils.py
@@ -75,15 +75,50 @@ async def acreate_path(
     async def _impl() -> AsyncPath:
         nonlocal directory, filename
 
+        # Capture the ORIGINAL base root (symlinks resolved) BEFORE `filename`
+        # can redirect `directory` into a subdirectory. All containment checks
+        # validate against this fixed root, so a symlinked subdirectory pointing
+        # outside the base cannot be used to escape.
+        base_root = StdPath(str(directory)).resolve()
+
         if "/" in filename:
+            parts = filename.split("/")
+            # Fail-closed: reject any path component that is '.' or '..' to
+            # prevent directory traversal before any filesystem side effect.
+            for component in parts:
+                if component in (".", ".."):
+                    raise ValueError(
+                        f"Filename components must not be '.' or '..'; "
+                        f"got component {component!r} in {filename!r}."
+                    )
             sub_dir, filename = (
-                filename.split("/")[:-1],
-                filename.split("/")[-1],
+                parts[:-1],
+                parts[-1],
             )
             directory = AsyncPath(directory) / "/".join(sub_dir)
 
         if "\\" in filename:
             raise ValueError("Filename cannot contain directory separators.")
+
+        if filename in (".", ".."):
+            raise ValueError(f"Filename must not be '.' or '..'; got {filename!r}.")
+
+        # Verify the (possibly redirected) directory AND the final candidate
+        # both resolve to a location within the original base root. Both are
+        # fully resolve()-d so symlinks are followed — a symlinked subdir OR a
+        # symlinked final component (e.g. base/link.txt -> /outside) escaping
+        # the root is rejected before any filesystem side effect. resolve() on a
+        # not-yet-existing final component simply normalizes it under the dir.
+        dir_resolved = StdPath(str(directory)).resolve()
+        candidate_resolved = (dir_resolved / filename).resolve()
+        for escapee in (dir_resolved, candidate_resolved):
+            try:
+                escapee.relative_to(base_root)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Resolved path {escapee} escapes base directory "
+                    f"{base_root}. Refusing to create path."
+                ) from exc
 
         directory = AsyncPath(directory)
         if "." in filename:
@@ -106,9 +141,7 @@ async def acreate_path(
         await full_path.parent.mkdir(parents=True, exist_ok=dir_exist_ok)
 
         if await full_path.exists() and not file_exist_ok:
-            raise FileExistsError(
-                f"File {full_path} already exists and file_exist_ok is False."
-            )
+            raise FileExistsError(f"File {full_path} already exists and file_exist_ok is False.")
 
         return full_path
 
@@ -166,14 +199,10 @@ def import_module(
         ImportError: If the module cannot be imported.
     """
     try:
-        full_import_path = (
-            f"{package_name}.{module_name}" if module_name else package_name
-        )
+        full_import_path = f"{package_name}.{module_name}" if module_name else package_name
 
         if import_name:
-            import_name = (
-                [import_name] if not isinstance(import_name, list) else import_name
-            )
+            import_name = [import_name] if not isinstance(import_name, list) else import_name
             a = __import__(
                 full_import_path,
                 fromlist=import_name,
@@ -366,7 +395,7 @@ def coerce_created_at(v: Any) -> datetime:
     if isinstance(v, datetime):
         return v.replace(tzinfo=timezone.utc) if v.tzinfo is None else v
 
-    if isinstance(v, (int, float)):
+    if isinstance(v, int | float):
         return datetime.fromtimestamp(v, tz=timezone.utc)
 
     if isinstance(v, str):

--- a/lionagi/ln/concurrency/_compat.py
+++ b/lionagi/ln/concurrency/_compat.py
@@ -25,9 +25,7 @@ else:
         class BaseExceptionGroup(BaseException):  # type: ignore
             """Minimal BaseExceptionGroup implementation for Python 3.10 without exceptiongroup."""
 
-            def __init__(
-                self, message: str, exceptions: Sequence[BaseException]
-            ) -> None:
+            def __init__(self, message: str, exceptions: Sequence[BaseException]) -> None:
                 super().__init__(message)
                 self.message = message
                 self.exceptions = tuple(exceptions)
@@ -48,7 +46,7 @@ else:
                     type(self)(self.message, rest) if rest else None,
                 )
 
-        class ExceptionGroup(BaseExceptionGroup, Exception):  # type: ignore
+        class ExceptionGroup(BaseExceptionGroup, Exception):  # type: ignore  # noqa: N818  # compat shim must match stdlib ExceptionGroup name
             """Minimal ExceptionGroup implementation for Python 3.10 without exceptiongroup."""
 
             pass

--- a/lionagi/ln/concurrency/patterns.py
+++ b/lionagi/ln/concurrency/patterns.py
@@ -49,9 +49,7 @@ __all__ = (
 )
 
 
-async def gather(
-    *aws: Awaitable[T], return_exceptions: bool = False
-) -> list[T | BaseException]:
+async def gather(*aws: Awaitable[T], return_exceptions: bool = False) -> list[T | BaseException]:
     """Run awaitables concurrently, return list of results.
 
     Args:
@@ -331,7 +329,7 @@ async def retry(
 
             delay = min(max_delay, base_delay * (2 ** (attempt - 1)))
             if jitter:
-                delay *= 1 + random.random() * jitter
+                delay *= 1 + random.random() * jitter  # noqa: S311  # non-crypto: jitter for backoff timing
 
             if deadline is not None:
                 remaining = deadline - current_time()

--- a/lionagi/ln/fuzzy/_extract_json.py
+++ b/lionagi/ln/fuzzy/_extract_json.py
@@ -48,9 +48,7 @@ def extract_json(
         input_str = input_data
 
     if len(input_str) > max_size:
-        raise ValueError(
-            f"Input size ({len(input_str)} bytes) exceeds maximum ({max_size} bytes)"
-        )
+        raise ValueError(f"Input size ({len(input_str)} bytes) exceeds maximum ({max_size} bytes)")
 
     # 1. Try direct parsing
     try:
@@ -58,9 +56,7 @@ def extract_json(
             return fuzzy_json(input_str)
         return orjson.loads(input_str)
     except Exception:
-        logger.debug(
-            "Direct JSON parse failed; falling back to markdown block extraction."
-        )
+        logger.debug("Direct JSON parse failed; falling back to markdown block extraction.")
 
     # 2. Attempt extracting JSON blocks from markdown
     matches = _JSON_BLOCK_PATTERN.findall(input_str)
@@ -85,7 +81,7 @@ def extract_json(
                 results.append(fuzzy_json(m))
             else:
                 results.append(orjson.loads(m))
-        except Exception:
+        except Exception:  # noqa: S112  # intentional parser fallback: skip unparseable JSON blocks, not an error
             # Skip invalid JSON blocks
             continue
     return results

--- a/lionagi/ln/fuzzy/_fuzzy_json.py
+++ b/lionagi/ln/fuzzy/_fuzzy_json.py
@@ -115,12 +115,10 @@ def _validate_return_type(
     Raises:
         TypeError: If result is a bare primitive type.
     """
-    if isinstance(result, (dict, list)):
+    if isinstance(result, dict | list):
         return result
 
-    raise TypeError(
-        f"fuzzy_json returns dict or list, got primitive type: {type(result).__name__}"
-    )
+    raise TypeError(f"fuzzy_json returns dict or list, got primitive type: {type(result).__name__}")
 
 
 def _clean_json_string_safe(s: str) -> str:

--- a/lionagi/ln/fuzzy/_to_dict.py
+++ b/lionagi/ln/fuzzy/_to_dict.py
@@ -158,7 +158,7 @@ def _preprocess_recursive(
         }
 
     # Sequence/Set-like (but not str)
-    if isinstance(obj, (list, tuple, set, frozenset)):
+    if isinstance(obj, list | tuple | set | frozenset):
         items = [
             _preprocess_recursive(
                 v,
@@ -200,9 +200,7 @@ def _preprocess_recursive(
     # Custom objects
     if recursive_custom_types:
         with contextlib.suppress(Exception):
-            mapped = _object_to_mapping_like(
-                obj, prioritize_model_dump=prioritize_model_dump
-            )
+            mapped = _object_to_mapping_like(obj, prioritize_model_dump=prioritize_model_dump)
             return _preprocess_recursive(
                 mapped,
                 depth=depth + 1,
@@ -281,18 +279,18 @@ def _convert_top_level_to_dict(
                 return dict(converted)
             # If it's a list/tuple/etc., enumerate (your original did that after the fact)
             if isinstance(converted, Iterable) and not isinstance(
-                converted, (str, bytes, bytearray)
+                converted, str | bytes | bytearray
             ):
                 return _enumerate_iterable(converted)
             # Best effort final cast
             return dict(converted)
 
-    except Exception:
+    except Exception:  # noqa: S110  # intentional parser fallback: exhausts every conversion strategy before giving up
         # Fall through to other strategies
         pass
 
     # Iterable (list/tuple/namedtuple/frozenset/…): enumerate
-    if isinstance(obj, Iterable) and not isinstance(obj, (str, bytes, bytearray)):
+    if isinstance(obj, Iterable) and not isinstance(obj, str | bytes | bytearray):
         return _enumerate_iterable(obj)
 
     # Dataclass fallback (reachable only if it wasn't caught above)

--- a/lionagi/lndl/types.py
+++ b/lionagi/lndl/types.py
@@ -163,6 +163,13 @@ def _coerce_result(result: Any, target_type: Any) -> Any:
     scalar = _unwrap_scalar(target_type)
     if scalar is None:
         return result
+    # A legitimately-None result for an Optional scalar (str | None, int | None)
+    # must pass through untouched. Coercing would corrupt it: scalar(None) yields
+    # the literal "None" for str and raises for int/float. Leaving it None lets
+    # model_validate accept it for Optional fields and raise a clear error for
+    # required ones — never silently fabricate a value.
+    if result is None:
+        return None
     if isinstance(result, dict):
         return json_dumps(result)
     if not isinstance(result, scalar):

--- a/lionagi/lndl/types.py
+++ b/lionagi/lndl/types.py
@@ -3,10 +3,15 @@
 
 """Core types for LNDL."""
 
+from __future__ import annotations
+
+import types
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Union, get_args, get_origin
 
 from pydantic import BaseModel
+
+from lionagi.ln import json_dumps
 
 Scalar = float | int | str | bool
 
@@ -66,7 +71,10 @@ class LNDLOutput:
     def __getattr__(self, key: str) -> BaseModel | ActionCall | Scalar:
         if key in ("fields", "lvars", "lacts", "actions", "raw_out_block"):
             return object.__getattribute__(self, key)
-        return self.fields[key]
+        try:
+            return self.fields[key]
+        except KeyError:
+            raise AttributeError(key) from None
 
 
 def has_action_calls(model: BaseModel) -> bool:
@@ -114,14 +122,51 @@ def ensure_no_action_calls(model: BaseModel) -> BaseModel:
     return model
 
 
-def _coerce_result(result: Any, target_type: type | None) -> Any:
-    """Coerce a tool result to match the target field type."""
-    if target_type in (str, int, float, bool) and isinstance(result, dict):
-        import json
+_SCALAR_TYPES: tuple[type, ...] = (str, int, float, bool)
 
-        return json.dumps(result, ensure_ascii=False)
-    if target_type in (str, int, float, bool) and not isinstance(result, target_type):
-        return target_type(result)
+
+def _unwrap_scalar(annotation: Any) -> type | None:
+    """Extract the scalar type from a plain or Optional scalar annotation.
+
+    Returns the scalar type if *annotation* is ``str``, ``int``, ``float``,
+    ``bool``, or a ``Union``/PEP-604 union of one of those with ``None``.
+    Returns ``None`` otherwise.
+
+    Examples::
+
+        _unwrap_scalar(str)          → str
+        _unwrap_scalar(str | None)   → str
+        _unwrap_scalar(int | None)   → int
+        _unwrap_scalar(list[str])    → None
+    """
+    if annotation in _SCALAR_TYPES:
+        return annotation  # type: ignore[return-value]
+
+    # Handle both typing.Union[X, None] and X | None (PEP 604 UnionType)
+    origin = get_origin(annotation)
+    if origin is Union or isinstance(annotation, types.UnionType):
+        args = [a for a in get_args(annotation) if a is not type(None)]
+        if len(args) == 1 and args[0] in _SCALAR_TYPES:
+            return args[0]  # type: ignore[return-value]
+
+    return None
+
+
+def _coerce_result(result: Any, target_type: Any) -> Any:
+    """Coerce a tool result to match the target field type.
+
+    Handles both plain scalar types (``str``, ``int``, ``float``, ``bool``)
+    and optional scalar types (e.g. ``str | None``, ``Optional[int]``).
+    Dict results targeting a scalar are serialised to JSON via
+    :func:`lionagi.ln.json_dumps`.
+    """
+    scalar = _unwrap_scalar(target_type)
+    if scalar is None:
+        return result
+    if isinstance(result, dict):
+        return json_dumps(result)
+    if not isinstance(result, scalar):
+        return scalar(result)
     return result
 
 

--- a/lionagi/tools/code/bash.py
+++ b/lionagi/tools/code/bash.py
@@ -18,9 +18,7 @@ from lionagi.protocols.action.tool import Tool
 
 from ..base import LionTool
 
-# Finding 2/3: shell control operators that bypass argv-safe execution
 _SHELL_CONTROL = re.compile(r"(;|&&|\|\||\||`|\$\(|[<>]|\n)")
-# Finding 5: cap output at 100 KB per stream before storing in memory
 _MAX_OUTPUT_BYTES = 100_000
 
 
@@ -48,7 +46,6 @@ class BashRequest(BaseModel):
             "If omitted, inherits the current process working directory."
         ),
     )
-    # Finding 3: shell=False by default; only trusted callers set allow_shell=True
     allow_shell: bool = Field(
         False,
         description="Allow shell control operators. Only set via trusted code.",
@@ -76,7 +73,7 @@ class BashResponse(BaseModel):
 
 
 def _command_for_subprocess(request: BashRequest) -> tuple[str | list[str], bool]:
-    """Finding 3: return (cmd, shell) pair. Rejects shell operators unless trusted."""
+    """Rejects shell operators unless trusted."""
     if request.allow_shell:
         return request.command, True
     if _SHELL_CONTROL.search(request.command):
@@ -90,10 +87,7 @@ def _command_for_subprocess(request: BashRequest) -> tuple[str | list[str], bool
 
 
 def _drain(stream, buf: bytearray) -> bool:
-    """Finding 5: read stream into buf up to _MAX_OUTPUT_BYTES; return True if truncated.
-
-    Continues reading after the cap is reached to prevent pipe-buffer deadlock.
-    """
+    """Continues reading after the cap is reached to prevent pipe-buffer deadlock."""
     truncated = False
     while True:
         try:
@@ -126,8 +120,7 @@ def _subprocess_sync(
     cwd: str | None,
 ) -> BashResponse:
     try:
-        # Finding 4: start_new_session=True so we can kill the entire process group
-        proc = subprocess.Popen(
+        proc = subprocess.Popen(  # noqa: S603  # cmd validated by _command_for_subprocess: shlex-split argv or trusted shell mode
             cmd,
             shell=shell,
             stdout=subprocess.PIPE,
@@ -149,7 +142,6 @@ def _subprocess_sync(
     def _drain_stderr():
         stderr_truncated[0] = _drain(proc.stderr, stderr_buf)
 
-    # Finding 5: read both streams concurrently in threads to cap memory use
     t_out = threading.Thread(target=_drain_stdout, daemon=True)
     t_err = threading.Thread(target=_drain_stderr, daemon=True)
     t_out.start()
@@ -158,7 +150,6 @@ def _subprocess_sync(
     try:
         proc.wait(timeout=timeout_sec)
     except subprocess.TimeoutExpired:
-        # Finding 4: kill the entire process group, not just the leader
         if isinstance(proc.pid, int) and proc.pid > 1:
             with contextlib.suppress(ProcessLookupError, OSError):
                 os.killpg(proc.pid, signal.SIGKILL)

--- a/lionagi/tools/code/search.py
+++ b/lionagi/tools/code/search.py
@@ -1,10 +1,11 @@
-# Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
 
 import subprocess
 from enum import Enum
+from pathlib import Path
 
 from pydantic import BaseModel, Field
 
@@ -12,6 +13,13 @@ from lionagi.ln.concurrency import run_sync
 from lionagi.protocols.action.tool import Tool
 
 from ..base import LionTool
+
+__all__ = (
+    "SearchAction",
+    "SearchRequest",
+    "SearchResponse",
+    "SearchTool",
+)
 
 
 class SearchAction(str, Enum):
@@ -81,18 +89,55 @@ class SearchResponse(BaseModel):
     )
 
 
+def _validate_search_path(path: str, workspace_root: str | None) -> tuple[str, str | None]:
+    """Resolve and optionally contain a search path within workspace_root.
+
+    Args:
+        path: The requested search path (may be relative or absolute).
+        workspace_root: If set, the resolved path must be at or below this root.
+
+    Returns:
+        (resolved_path_str, None) on success.
+
+    Raises:
+        PermissionError: If the resolved path escapes workspace_root.
+    """
+    if workspace_root is not None:
+        root = Path(workspace_root).resolve()
+        # Resolve relative paths against the workspace root (NOT the process
+        # cwd) so e.g. path="." targets the agent's workspace, then verify
+        # containment. resolve() follows symlinks, blocking symlinked escapes.
+        requested = Path(path)
+        resolved = (requested if requested.is_absolute() else root / requested).resolve()
+        try:
+            resolved.relative_to(root)
+        except ValueError as exc:
+            raise PermissionError(
+                f"Search path {path!r} resolves to {resolved} which is outside "
+                f"workspace root {root}. Refusing to search."
+            ) from exc
+    else:
+        resolved = Path(path).resolve()
+    return str(resolved), None
+
+
 def _grep_sync(
     pattern: str,
     path: str,
     include: str | None,
     max_results: int,
+    workspace_root: str | None,
 ) -> SearchResponse:
-    cmd = ["grep", "-rn", "-E", pattern, path]
+    resolved_path, err = _validate_search_path(path, workspace_root)
+    if err:
+        return SearchResponse(success=False, error=err, count=0)
+
+    cmd = ["grep", "-rn", "-E", pattern, resolved_path]
     if include:
         cmd += ["--include", include]
 
     try:
-        result = subprocess.run(
+        result = subprocess.run(  # noqa: S603  # argv fixed: [grep, -rn, -E, <pattern>, <validated-path>]; shell=False
             cmd,
             capture_output=True,
             text=True,
@@ -101,9 +146,7 @@ def _grep_sync(
     except subprocess.TimeoutExpired:
         return SearchResponse(success=False, error="grep timed out", count=0)
     except FileNotFoundError:
-        return SearchResponse(
-            success=False, error="grep not found on this system", count=0
-        )
+        return SearchResponse(success=False, error="grep not found on this system", count=0)
     except Exception as e:
         return SearchResponse(success=False, error=f"grep error: {e}", count=0)
 
@@ -111,7 +154,7 @@ def _grep_sync(
     if result.returncode == 2:
         return SearchResponse(success=False, error=result.stderr.strip(), count=0)
 
-    lines = [l for l in result.stdout.splitlines() if l][:max_results]
+    lines = [line for line in result.stdout.splitlines() if line][:max_results]
     return SearchResponse(
         success=True,
         content="\n".join(lines),
@@ -119,11 +162,20 @@ def _grep_sync(
     )
 
 
-def _find_sync(path: str, pattern: str, max_results: int) -> SearchResponse:
-    cmd = ["find", path, "-name", pattern]
+def _find_sync(
+    path: str,
+    pattern: str,
+    max_results: int,
+    workspace_root: str | None,
+) -> SearchResponse:
+    resolved_path, err = _validate_search_path(path, workspace_root)
+    if err:
+        return SearchResponse(success=False, error=err, count=0)
+
+    cmd = ["find", resolved_path, "-name", pattern]
 
     try:
-        result = subprocess.run(
+        result = subprocess.run(  # noqa: S603  # argv fixed: [find, <validated-path>, -name, <glob>]; shell=False
             cmd,
             capture_output=True,
             text=True,
@@ -132,16 +184,14 @@ def _find_sync(path: str, pattern: str, max_results: int) -> SearchResponse:
     except subprocess.TimeoutExpired:
         return SearchResponse(success=False, error="find timed out", count=0)
     except FileNotFoundError:
-        return SearchResponse(
-            success=False, error="find not found on this system", count=0
-        )
+        return SearchResponse(success=False, error="find not found on this system", count=0)
     except Exception as e:
         return SearchResponse(success=False, error=f"find error: {e}", count=0)
 
     if result.returncode != 0 and result.stderr.strip():
         return SearchResponse(success=False, error=result.stderr.strip(), count=0)
 
-    lines = [l for l in result.stdout.splitlines() if l][:max_results]
+    lines = [line for line in result.stdout.splitlines() if line][:max_results]
     return SearchResponse(
         success=True,
         content="\n".join(lines),
@@ -150,15 +200,44 @@ def _find_sync(path: str, pattern: str, max_results: int) -> SearchResponse:
 
 
 class SearchTool(LionTool):
+    """Filesystem search tool (grep/find) with optional workspace containment.
+
+    When *workspace_root* is supplied at construction time, every search path
+    is resolved and checked to remain within that root before the subprocess
+    is launched.  Paths that escape the root are rejected with a PermissionError
+    (returned as a SearchResponse with success=False).
+
+    If *workspace_root* is None (the default), no containment is applied —
+    callers should pair this with a :class:`lionagi.agent.permissions.PermissionPolicy`
+    allowlist, or set the root via ``create_agent()`` / ``AgentConfig``.
+    """
+
     is_lion_system_tool = True
     system_tool_name = "search_tool"
 
-    def __init__(self):
+    def __init__(self, workspace_root: str | None = None) -> None:
         self._tool = None
+        # Resolve the containment root ONCE, at construction, against the cwd
+        # in effect now. Storing the raw (possibly relative) value would let a
+        # later os.chdir() move the boundary — e.g. a relative "ws" would be
+        # re-resolved against whatever cwd is current when a search runs, so a
+        # search could escape the originally intended root. Resolving here
+        # freezes the boundary to an absolute path; re-resolving it downstream
+        # is then idempotent.
+        self._workspace_root = (
+            str(Path(workspace_root).resolve()) if workspace_root is not None else None
+        )
 
     async def handle_request(self, request: SearchRequest) -> SearchResponse:
         if isinstance(request, dict):
             request = SearchRequest(**request)
+
+        # Validate path before launching subprocess (fail-closed)
+        try:
+            _validate_search_path(request.path, self._workspace_root)
+        except PermissionError as exc:
+            return SearchResponse(success=False, error=str(exc), count=0)
+
         if request.action == SearchAction.grep:
             return await run_sync(
                 _grep_sync,
@@ -166,10 +245,15 @@ class SearchTool(LionTool):
                 request.path,
                 request.include,
                 request.max_results,
+                self._workspace_root,
             )
         if request.action == SearchAction.find:
             return await run_sync(
-                _find_sync, request.path, request.pattern, request.max_results
+                _find_sync,
+                request.path,
+                request.pattern,
+                request.max_results,
+                self._workspace_root,
             )
         return SearchResponse(success=False, error="Unknown action", count=0)
 

--- a/lionagi/tools/sandbox.py
+++ b/lionagi/tools/sandbox.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import subprocess
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 
 from lionagi.ln.concurrency import run_sync
@@ -33,7 +33,7 @@ class SandboxSession:
 
 
 def _run_git(args: list[str], cwd: str | None = None) -> tuple[str, str, int]:
-    result = subprocess.run(
+    result = subprocess.run(  # noqa: S603  # argv is always ["git"] + validated git sub-commands; no shell interpolation
         ["git"] + args,
         capture_output=True,
         text=True,
@@ -43,9 +43,7 @@ def _run_git(args: list[str], cwd: str | None = None) -> tuple[str, str, int]:
     return result.stdout.strip(), result.stderr.strip(), result.returncode
 
 
-def _create_worktree_sync(
-    repo_root: str, branch_name: str, base_branch: str
-) -> SandboxSession:
+def _create_worktree_sync(repo_root: str, branch_name: str, base_branch: str) -> SandboxSession:
     """Create a git worktree for isolated work."""
     root = Path(repo_root)
     worktree_dir = root / ".worktrees" / branch_name
@@ -122,9 +120,7 @@ def _cleanup_worktree_sync(session: SandboxSession) -> dict:
 def _merge_sync(session: SandboxSession) -> dict:
     """Merge worktree branch back into base branch."""
     _run_git(["add", "-A"], cwd=session.worktree_path)
-    _run_git(
-        ["commit", "-m", f"sandbox: {session.branch_name}"], cwd=session.worktree_path
-    )
+    _run_git(["commit", "-m", f"sandbox: {session.branch_name}"], cwd=session.worktree_path)
 
     stdout, stderr, rc = _run_git(
         [

--- a/tests/agent/test_factory.py
+++ b/tests/agent/test_factory.py
@@ -561,3 +561,31 @@ async def test_load_mcp_breaks_at_lionagi_dir(tmp_path, monkeypatch):
     )
 
     assert calls and calls[0] == str(mcp_file)
+
+
+# ---------------------------------------------------------------------------
+# Search tool workspace containment wiring (regression)
+# ---------------------------------------------------------------------------
+
+
+async def test_search_tool_gets_workspace_root_from_cwd(tmp_path):
+    """tools=["search"] must wire spec.cwd into SearchTool.workspace_root.
+
+    Regression: the standalone search branch registered SearchTool() with no
+    workspace_root, so normal agents got no containment. Here a search outside
+    the configured cwd must be rejected fail-closed.
+    """
+    ws = tmp_path / "workspace"
+    ws.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+
+    config = AgentConfig(tools=["search"], cwd=str(ws))
+    branch = await _make(config)
+
+    key = next(k for k in branch.acts.registry.keys() if "search" in k)
+    tool = branch.acts.registry[key]
+
+    result = await tool.func_callable(action="grep", pattern="x", path=str(outside))
+    assert result["success"] is False
+    assert "workspace root" in (result.get("error") or "")

--- a/tests/libs/algo/test_string_similarity.py
+++ b/tests/libs/algo/test_string_similarity.py
@@ -95,10 +95,7 @@ def test_jaro_winkler_similarity_with_scaling(
     s1: str, s2: str, expected: float, scaling: float
 ) -> None:
     """Test Jaro-Winkler similarity function with various inputs and scaling."""
-    assert (
-        pytest.approx(jaro_winkler_similarity(s1, s2, scaling=scaling), abs=1e-4)
-        == expected
-    )
+    assert pytest.approx(jaro_winkler_similarity(s1, s2, scaling=scaling), abs=1e-4) == expected
 
 
 def test_jaro_winkler_invalid_scaling() -> None:
@@ -235,9 +232,7 @@ def custom_similarity(s1: str, s2: str) -> float:
 )
 def test_string_similarity_basic(word, words, algorithm, expected):
     """Test basic functionality with different algorithms."""
-    result = string_similarity(
-        word, words, algorithm=algorithm, return_most_similar=True
-    )
+    result = string_similarity(word, words, algorithm=algorithm, return_most_similar=True)
     assert result == expected
 
 
@@ -336,15 +331,11 @@ def test_string_similarity_with_threshold():
     """Test threshold behavior with different algorithms."""
     for algo in ["levenshtein", "jaro_winkler", "cosine"]:
         # Exact match should always be included
-        result = string_similarity(
-            "hello", ["hello", "help"], algorithm=algo, threshold=0.5
-        )
+        result = string_similarity("hello", ["hello", "help"], algorithm=algo, threshold=0.5)
         assert result and "hello" in result
 
         # High threshold should filter most matches
-        result = string_similarity(
-            "hello", ["help", "world"], algorithm=algo, threshold=0.9
-        )
+        result = string_similarity("hello", ["help", "world"], algorithm=algo, threshold=0.9)
         assert result is None
 
 

--- a/tests/libs/concurrency/test_compat.py
+++ b/tests/libs/concurrency/test_compat.py
@@ -3,7 +3,6 @@
 
 """Tests for lionagi/ln/concurrency/_compat.py compatibility helpers."""
 
-
 from lionagi.ln.concurrency._compat import (
     BaseExceptionGroup,
     ExceptionGroup,

--- a/tests/libs/concurrency/test_completion_stream.py
+++ b/tests/libs/concurrency/test_completion_stream.py
@@ -83,9 +83,7 @@ async def test_completion_stream_with_limit(anyio_backend):
         return x
 
     LIMIT = 3
-    async with CompletionStream(
-        [tracked_task(i) for i in range(10)], limit=LIMIT
-    ) as stream:
+    async with CompletionStream([tracked_task(i) for i in range(10)], limit=LIMIT) as stream:
         async for idx, result in stream:
             pass
 
@@ -106,9 +104,7 @@ async def test_completion_stream_limit_none_allows_all_concurrent(
         return x
 
     NUM_TASKS = 8
-    async with CompletionStream(
-        [tracked_task(i) for i in range(NUM_TASKS)], limit=None
-    ) as stream:
+    async with CompletionStream([tracked_task(i) for i in range(NUM_TASKS)], limit=None) as stream:
         async for idx, result in stream:
             pass
 
@@ -177,16 +173,13 @@ async def test_completion_stream_exception_propagation(anyio_backend):
 
     # Exceptions in tasks are wrapped in ExceptionGroup by task group
     with pytest.raises(ExceptionGroup) as exc_info:
-        async with CompletionStream(
-            [failing_task(i) for i in range(10)], limit=5
-        ) as stream:
+        async with CompletionStream([failing_task(i) for i in range(10)], limit=5) as stream:
             async for idx, result in stream:
                 pass
 
     # Verify the ValueError is in the exception group
     assert any(
-        isinstance(e, ValueError) and "Task 3 failed" in str(e)
-        for e in exc_info.value.exceptions
+        isinstance(e, ValueError) and "Task 3 failed" in str(e) for e in exc_info.value.exceptions
     )
 
 
@@ -411,9 +404,7 @@ async def test_completion_stream_realistic_workload(anyio_backend):
     TASKS = 20
     LIMIT = 5
 
-    async with CompletionStream(
-        [mixed_speed_task(i) for i in range(TASKS)], limit=LIMIT
-    ) as stream:
+    async with CompletionStream([mixed_speed_task(i) for i in range(TASKS)], limit=LIMIT) as stream:
         async for idx, result in stream:
             results.append(result)
 

--- a/tests/libs/concurrency/test_primitives.py
+++ b/tests/libs/concurrency/test_primitives.py
@@ -126,16 +126,12 @@ def test_module_level_track_resource_defaults():
     # Resource should be registered in the module-level tracker
     live_ids = {id(obj_id) for obj_id in []}  # not needed — check live() directly
     live_names = {info.name for info in _TRACKER.live()}
-    assert (
-        "test-y" in live_names
-    ), "Resource should appear in tracker after track_resource()"
+    assert "test-y" in live_names, "Resource should appear in tracker after track_resource()"
 
     untrack_resource(y)  # should not raise
 
     live_names_after = {info.name for info in _TRACKER.live()}
-    assert (
-        "test-y" not in live_names_after
-    ), "Resource should be removed after untrack_resource()"
+    assert "test-y" not in live_names_after, "Resource should be removed after untrack_resource()"
 
 
 @pytest.mark.anyio

--- a/tests/libs/fuzzy/test_fuzzy_json.py
+++ b/tests/libs/fuzzy/test_fuzzy_json.py
@@ -207,9 +207,7 @@ def test_fix_json_string_empty():
 
 def test_fix_json_string_complex_with_escapes():
     """Test fix_json_string with complex JSON containing escapes"""
-    json_str = (
-        r'{"data": {"path": "C:\\test\\", "text": "say \"hi\"", "newline": "a\nb"'
-    )
+    json_str = r'{"data": {"path": "C:\\test\\", "text": "say \"hi\"", "newline": "a\nb"'
     result = fix_json_string(json_str)
     # Should add missing closing brackets while preserving escapes
     assert result.endswith("}}")

--- a/tests/libs/fuzzy/test_fuzzy_validate.py
+++ b/tests/libs/fuzzy/test_fuzzy_validate.py
@@ -90,9 +90,7 @@ class TestFuzzyValidatePydantic:
     def test_fuzzy_match_with_params_instance(self):
         """Test fuzzy match with FuzzyMatchKeysParams instance (lines 44-45)."""
         text = '{"nam": "Eve", "ag": 28, "emal": "eve@example.com"}'
-        params = FuzzyMatchKeysParams(
-            similarity_threshold=0.75, handle_unmatched="remove"
-        )
+        params = FuzzyMatchKeysParams(similarity_threshold=0.75, handle_unmatched="remove")
         result = fuzzy_validate_pydantic(
             text, SimpleModel, fuzzy_match=True, fuzzy_match_params=params
         )
@@ -192,9 +190,7 @@ class TestFuzzyValidateMapping:
     def test_dict_with_model_dump(self):
         """Test object with model_dump method (lines 126-129)."""
         model = SimpleModel(name="Frank", age=40, email="frank@example.com")
-        result = fuzzy_validate_mapping(
-            model, ["name", "age"], handle_unmatched="remove"
-        )
+        result = fuzzy_validate_mapping(model, ["name", "age"], handle_unmatched="remove")
         assert result["name"] == "Frank"
         assert result["age"] == 40
 
@@ -277,9 +273,7 @@ class TestFuzzyValidateMapping:
     def test_handle_unmatched_ignore(self):
         """Test handle_unmatched='ignore' keeps extra keys."""
         data = {"name": "Henry", "age": 50, "extra": "value"}
-        result = fuzzy_validate_mapping(
-            data, ["name", "age"], handle_unmatched="ignore"
-        )
+        result = fuzzy_validate_mapping(data, ["name", "age"], handle_unmatched="ignore")
         assert result["name"] == "Henry"
         assert result["age"] == 50
         assert result["extra"] == "value"
@@ -287,9 +281,7 @@ class TestFuzzyValidateMapping:
     def test_handle_unmatched_remove(self):
         """Test handle_unmatched='remove' removes extra keys."""
         data = {"name": "Iris", "age": 32, "extra": "value"}
-        result = fuzzy_validate_mapping(
-            data, ["name", "age"], handle_unmatched="remove"
-        )
+        result = fuzzy_validate_mapping(data, ["name", "age"], handle_unmatched="remove")
         assert result == {"name": "Iris", "age": 32}
         assert "extra" not in result
 
@@ -405,9 +397,7 @@ class TestFuzzyValidateEdgeCases:
 
     def test_complex_nested_json(self):
         """Test complex nested JSON structure."""
-        json_str = (
-            '{"user": {"name": "Test", "details": {"age": 30}}, "status": "active"}'
-        )
+        json_str = '{"user": {"name": "Test", "details": {"age": 30}}, "status": "active"}'
         result = fuzzy_validate_mapping(json_str, ["user", "status"])
         assert "user" in result
         assert result["status"] == "active"
@@ -574,9 +564,7 @@ class TestCoverageTargets:
 
             # Test with suppress=False (lines 134-137)
             mock_to_dict.return_value = "still_not_a_dict"
-            with pytest.raises(
-                ValueError, match="Failed to convert input to dictionary"
-            ):
+            with pytest.raises(ValueError, match="Failed to convert input to dictionary"):
                 fuzzy_validate_mapping(
                     {"test": "data"},
                     ["key1"],
@@ -600,9 +588,7 @@ class TestCoverageTargets:
             assert result == {"key1": "default", "key2": "default"}
 
             # Test with suppress=False (lines 142-143)
-            with pytest.raises(
-                ValueError, match="Failed to convert input to dictionary"
-            ):
+            with pytest.raises(ValueError, match="Failed to convert input to dictionary"):
                 fuzzy_validate_mapping(
                     {"test": "data"},
                     ["key1"],

--- a/tests/libs/fuzzy/test_string_similarity.py
+++ b/tests/libs/fuzzy/test_string_similarity.py
@@ -58,9 +58,7 @@ def test_string_similarity_threshold():
 
 def test_string_similarity_most_similar():
     """Test return_most_similar option"""
-    result = string_similarity(
-        "hello", ["hello", "help", "world"], return_most_similar=True
-    )
+    result = string_similarity("hello", ["hello", "help", "world"], return_most_similar=True)
     assert isinstance(result, str)
 
 
@@ -106,9 +104,7 @@ def test_string_similarity_hamming():
 
 def test_string_similarity_no_matches():
     """Test when no matches found"""
-    result = string_similarity(
-        "hello", ["xyz", "abc"], threshold=0.9, algorithm="levenshtein"
-    )
+    result = string_similarity("hello", ["xyz", "abc"], threshold=0.9, algorithm="levenshtein")
     assert result is None
 
 

--- a/tests/libs/hash/test_hash_dict.py
+++ b/tests/libs/hash/test_hash_dict.py
@@ -154,10 +154,7 @@ class TestGenerateHashableRepresentation:
             expected_inner_dict_rep,
         )
 
-        assert (
-            hash_utils._generate_hashable_representation(struct_instance)
-            == expected_rep
-        )
+        assert hash_utils._generate_hashable_representation(struct_instance) == expected_rep
 
     def test_pydantic_model_representation(self):
         from pydantic import BaseModel
@@ -184,9 +181,7 @@ class TestGenerateHashableRepresentation:
             expected_inner_dict_rep,
         )
 
-        assert (
-            hash_utils._generate_hashable_representation(model_instance) == expected_rep
-        )
+        assert hash_utils._generate_hashable_representation(model_instance) == expected_rep
 
 
 class TestHashDict:
@@ -264,33 +259,25 @@ class TestHashDict:
 
         # To test it properly, we need to see if the hash of the original, modified object is different.
         original_data_mutated = {"a": [1, 2]}  # Start fresh for this
-        hash_before_mutation_strict = hash_utils.hash_dict(
-            original_data_mutated, strict=True
-        )
+        hash_before_mutation_strict = hash_utils.hash_dict(original_data_mutated, strict=True)
         original_data_mutated["a"].append(3)  # Mutate it
-        hash_after_mutation_strict = hash_utils.hash_dict(
-            original_data_mutated, strict=True
-        )
+        hash_after_mutation_strict = hash_utils.hash_dict(original_data_mutated, strict=True)
 
         assert hash_before_mutation_strict != hash_after_mutation_strict
 
         # And confirm that if strict was False, the hash would be based on the current state
         original_data_mutated_nostrict = {"a": [1, 2]}
         # hash_utils._generate_hashable_representation will process current state
-        hash_nostrict_before = hash_utils.hash_dict(
-            original_data_mutated_nostrict, strict=False
-        )
+        hash_nostrict_before = hash_utils.hash_dict(original_data_mutated_nostrict, strict=False)
         original_data_mutated_nostrict["a"].append(3)
-        hash_nostrict_after = hash_utils.hash_dict(
-            original_data_mutated_nostrict, strict=False
-        )
+        hash_nostrict_after = hash_utils.hash_dict(original_data_mutated_nostrict, strict=False)
         assert hash_nostrict_before != hash_nostrict_after
 
         # Check that the initial strict hash is repeatable
         data_for_repeat = {"a": [1, 2]}
-        assert hash_utils.hash_dict(
-            data_for_repeat, strict=True
-        ) == hash_utils.hash_dict({"a": [1, 2]}, strict=True)
+        assert hash_utils.hash_dict(data_for_repeat, strict=True) == hash_utils.hash_dict(
+            {"a": [1, 2]}, strict=True
+        )
 
     def test_unhashable_representation_raises_typeerror(self):
         # Covers L116-L117

--- a/tests/libs/schema/test_as_readable.py
+++ b/tests/libs/schema/test_as_readable.py
@@ -300,9 +300,7 @@ class TestAsReadable:
 
     def test_multiline_string_values(self):
         """Test handling of multiline string values."""
-        data = {
-            "description": "This is a long description\nwith multiple lines\nof text."
-        }
+        data = {"description": "This is a long description\nwith multiple lines\nof text."}
         result = as_readable(data, format_curly=True)
 
         assert "description:" in result

--- a/tests/libs/schema/test_extract_code_block.py
+++ b/tests/libs/schema/test_extract_code_block.py
@@ -100,9 +100,7 @@ const y = 2;
 z = 3
 ```
 """
-        result = extract_code_block(
-            markdown, languages=["python", "ruby"], return_as_list=True
-        )
+        result = extract_code_block(markdown, languages=["python", "ruby"], return_as_list=True)
         assert len(result) == 2
         assert "x = 1" in result[0]
         assert "z = 3" in result[1]

--- a/tests/libs/schema/test_function_to_schema.py
+++ b/tests/libs/schema/test_function_to_schema.py
@@ -205,9 +205,7 @@ class TestFunctionToSchema:
             "x": "Custom description for x.",
             "y": "Custom description for y.",
         }
-        schema = function_to_schema(
-            func_with_params, parametert_description=custom_params
-        )
+        schema = function_to_schema(func_with_params, parametert_description=custom_params)
 
         params = schema["function"]["parameters"]
         assert params["properties"]["x"]["description"] == "Custom description for x."
@@ -301,9 +299,7 @@ class TestFunctionToSchema:
     def test_multiple_parameters_all_types(self):
         """Test function with multiple parameters of different types."""
 
-        def multi_type_func(
-            a: int, b: str, c: float, d: bool, e: list, f: dict, g: tuple
-        ):
+        def multi_type_func(a: int, b: str, c: float, d: bool, e: list, f: dict, g: tuple):
             """Function with multiple parameter types.
 
             Args:

--- a/tests/libs/schema/test_schema_loader.py
+++ b/tests/libs/schema/test_schema_loader.py
@@ -1,4 +1,3 @@
-
 from lionagi.libs.schema.load_pydantic_model_from_schema import (
     load_pydantic_model_from_schema,
 )

--- a/tests/libs/schema/test_schema_loader_exec_boundary.py
+++ b/tests/libs/schema/test_schema_loader_exec_boundary.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Attack-driven tests for load_pydantic_model_from_schema exec boundary.
+
+Issue (LIONAGI-AUDIT-003): The schema loader fell back to
+datamodel-code-generator + exec_module() when create_model() could not
+handle a schema, regardless of whether the schema came from a trusted
+source. Caller-controlled schema data could reach dynamic Python module
+execution.
+
+Fix: The codegen/exec fallback requires explicit allow_codegen=True.
+Default is allow_codegen=False — unsupported schemas raise RuntimeError
+before any code generation or exec_module call.
+
+These tests verify:
+1. allow_codegen=False (default) blocks the exec path.
+2. _load_via_codegen is never called without allow_codegen=True.
+3. Simple schemas that create_model() handles still work normally.
+"""
+
+import unittest.mock
+
+import pytest
+from pydantic import BaseModel
+
+from lionagi.libs.schema.load_pydantic_model_from_schema import (
+    _CreateModelUnsupportedError,
+    load_pydantic_model_from_schema,
+)
+
+# ---------------------------------------------------------------------------
+# Security boundary: exec path is blocked by default
+# ---------------------------------------------------------------------------
+
+
+class TestExecBoundaryDefault:
+    """allow_codegen defaults to False — exec path must be unreachable."""
+
+    def test_simple_schema_succeeds_without_codegen(self):
+        """create_model() handles simple object schemas; no codegen needed."""
+        schema = {
+            "type": "object",
+            "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
+            "required": ["name"],
+        }
+        model_cls = load_pydantic_model_from_schema(schema)
+        assert issubclass(model_cls, BaseModel)
+        instance = model_cls(name="Alice", age=30)
+        assert instance.name == "Alice"
+
+    def test_string_schema_succeeds(self):
+        """JSON string input also works via create_model() path."""
+        schema_str = '{"type": "object", "properties": {"x": {"type": "number"}}}'
+        model_cls = load_pydantic_model_from_schema(schema_str)
+        assert issubclass(model_cls, BaseModel)
+
+    def test_unsupported_schema_raises_without_executing_code(self, monkeypatch):
+        """When create_model fails and allow_codegen=False, RuntimeError is raised
+        BEFORE _load_via_codegen is ever called — no code generation or exec."""
+        import lionagi.libs.schema.load_pydantic_model_from_schema as loader_mod
+
+        exec_called = []
+
+        def fake_codegen(*a, **kw):
+            exec_called.append(1)
+            raise AssertionError("_load_via_codegen must not be called when allow_codegen=False")
+
+        monkeypatch.setattr(loader_mod, "_load_via_codegen", fake_codegen)
+
+        # Force create_model path to fail
+        def fake_create_model(*a, **kw):
+            raise _CreateModelUnsupportedError("forced failure for test")
+
+        monkeypatch.setattr(loader_mod, "_create_model_from_schema", fake_create_model)
+
+        with pytest.raises(RuntimeError, match="allow_codegen"):
+            load_pydantic_model_from_schema({"type": "object"}, allow_codegen=False)
+
+        assert not exec_called, "_load_via_codegen was called despite allow_codegen=False"
+
+    def test_default_allow_codegen_is_false(self, monkeypatch):
+        """Verify the default value of allow_codegen is False (regression guard)."""
+        import inspect
+
+        import lionagi.libs.schema.load_pydantic_model_from_schema as loader_mod
+
+        sig = inspect.signature(loader_mod.load_pydantic_model_from_schema)
+        param = sig.parameters.get("allow_codegen")
+        assert param is not None, "allow_codegen parameter missing from function signature"
+        assert param.default is False, (
+            f"allow_codegen default changed to {param.default!r}; must remain False"
+        )
+
+    def test_allow_codegen_false_error_message_guides_caller(self, monkeypatch):
+        """Error message must mention allow_codegen so callers can find the opt-in."""
+        import lionagi.libs.schema.load_pydantic_model_from_schema as loader_mod
+
+        def fake_create_model(*a, **kw):
+            raise _CreateModelUnsupportedError("unsupported")
+
+        monkeypatch.setattr(loader_mod, "_create_model_from_schema", fake_create_model)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            load_pydantic_model_from_schema({"type": "object"}, allow_codegen=False)
+
+        assert "allow_codegen" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Normal operation: create_model path works for common schemas
+# ---------------------------------------------------------------------------
+
+
+class TestNormalCreateModelPath:
+    def test_nested_object_schema(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "object",
+                    "properties": {"street": {"type": "string"}},
+                }
+            },
+        }
+        model_cls = load_pydantic_model_from_schema(schema)
+        assert issubclass(model_cls, BaseModel)
+
+    def test_array_type_schema(self):
+        schema = {
+            "type": "object",
+            "properties": {"tags": {"type": "array", "items": {"type": "string"}}},
+        }
+        model_cls = load_pydantic_model_from_schema(schema)
+        assert issubclass(model_cls, BaseModel)
+
+    def test_invalid_json_string_raises_value_error(self):
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            load_pydantic_model_from_schema("{not valid json}")
+
+    def test_non_string_non_dict_raises_type_error(self):
+        with pytest.raises(TypeError):
+            load_pydantic_model_from_schema(12345)  # type: ignore[arg-type]

--- a/tests/libs/test_chunk_api.py
+++ b/tests/libs/test_chunk_api.py
@@ -19,9 +19,7 @@ def test_chunk_with_direct_text_returns_strings(mod_paths, ensure_fake_lionagi):
     assert all(isinstance(x, str) for x in out)
 
 
-def test_chunk_with_file_path_reads_and_chunks(
-    mod_paths, ensure_fake_lionagi, tmp_path
-):
+def test_chunk_with_file_path_reads_and_chunks(mod_paths, ensure_fake_lionagi, tmp_path):
     api = importlib.import_module(mod_paths["api_mod"])
     f = tmp_path / "doc.txt"
     f.write_text(" ".join(str(i) for i in range(30)), encoding="utf-8")

--- a/tests/libs/test_chunk_chars_tokens.py
+++ b/tests/libs/test_chunk_chars_tokens.py
@@ -24,17 +24,13 @@ def test_chunk_by_chars_single_chunk_no_overlap(mod_paths, ensure_fake_lionagi):
     assert out == [text]
 
 
-def test_chunk_by_chars_two_chunks_with_overlap_and_threshold(
-    mod_paths, ensure_fake_lionagi
-):
+def test_chunk_by_chars_two_chunks_with_overlap_and_threshold(mod_paths, ensure_fake_lionagi):
     mod = importlib.import_module(mod_paths["chunk_mod"])
     chunk_size = 10
     overlap = 0.5  # overlap_size = int(10 * 0.5 / 2) = 2
     threshold = 3
     text = _alpha(14)  # residue = 4 > threshold -> two chunks
-    out = mod.chunk_by_chars(
-        text, chunk_size=chunk_size, overlap=overlap, threshold=threshold
-    )
+    out = mod.chunk_by_chars(text, chunk_size=chunk_size, overlap=overlap, threshold=threshold)
     assert len(out) == 2
     overlap_size = int(chunk_size * overlap / 2)
     # first chunk is chunk_size + overlap_size
@@ -43,9 +39,7 @@ def test_chunk_by_chars_two_chunks_with_overlap_and_threshold(
     assert out[1] == text[chunk_size - overlap_size :]
 
 
-def test_chunk_by_chars_two_chunks_but_small_tail_merges_into_one(
-    mod_paths, ensure_fake_lionagi
-):
+def test_chunk_by_chars_two_chunks_but_small_tail_merges_into_one(mod_paths, ensure_fake_lionagi):
     mod = importlib.import_module(mod_paths["chunk_mod"])
     text = _alpha(13)
     out = mod.chunk_by_chars(text, chunk_size=10, overlap=0.2, threshold=5)
@@ -53,9 +47,7 @@ def test_chunk_by_chars_two_chunks_but_small_tail_merges_into_one(
     assert out == [text]
 
 
-def test_chunk_by_chars_multiple_parts_last_chunk_appended(
-    mod_paths, ensure_fake_lionagi
-):
+def test_chunk_by_chars_multiple_parts_last_chunk_appended(mod_paths, ensure_fake_lionagi):
     mod = importlib.import_module(mod_paths["chunk_mod"])
     chunk_size = 10
     overlap = 0.2  # overlap_size = 1
@@ -63,17 +55,13 @@ def test_chunk_by_chars_multiple_parts_last_chunk_appended(
     threshold = 3
     text_len = 38  # n_chunks = ceil(38/10) = 4
     text = _alpha(text_len)
-    out = mod.chunk_by_chars(
-        text, chunk_size=chunk_size, overlap=overlap, threshold=threshold
-    )
+    out = mod.chunk_by_chars(text, chunk_size=chunk_size, overlap=overlap, threshold=threshold)
     assert len(out) == 4
     last_chunk_start = chunk_size * (4 - 1) - overlap_size  # 29
     assert out[-1] == text[last_chunk_start:]
 
 
-def test_chunk_by_chars_multiple_parts_small_tail_merged(
-    mod_paths, ensure_fake_lionagi
-):
+def test_chunk_by_chars_multiple_parts_small_tail_merged(mod_paths, ensure_fake_lionagi):
     mod = importlib.import_module(mod_paths["chunk_mod"])
     chunk_size = 10
     overlap = 0.2  # overlap_size = 1
@@ -81,9 +69,7 @@ def test_chunk_by_chars_multiple_parts_small_tail_merged(
     threshold = 3
     text_len = 32  # n_chunks = ceil(32/10) = 4; tail from 29 -> length 3 (== threshold), so merge
     text = _alpha(text_len)
-    out = mod.chunk_by_chars(
-        text, chunk_size=chunk_size, overlap=overlap, threshold=threshold
-    )
+    out = mod.chunk_by_chars(text, chunk_size=chunk_size, overlap=overlap, threshold=threshold)
     # last small tail merged into previous chunk -> 3 chunks
     assert len(out) == 3
     # last chunk must end with the tail characters
@@ -92,9 +78,7 @@ def test_chunk_by_chars_multiple_parts_small_tail_merged(
 
 
 @pytest.mark.parametrize("return_tokens", [False, True])
-def test_chunk_by_tokens_single_chunk_types(
-    mod_paths, ensure_fake_lionagi, return_tokens
-):
+def test_chunk_by_tokens_single_chunk_types(mod_paths, ensure_fake_lionagi, return_tokens):
     mod = importlib.import_module(mod_paths["chunk_mod"])
     toks = _tokens(8)
     out = mod.chunk_by_tokens(
@@ -129,22 +113,16 @@ def test_chunk_by_tokens_two_chunks_threshold_path(mod_paths, ensure_fake_lionag
     assert out[1] == toks[8:]  # 10 - 2
 
 
-def test_chunk_by_tokens_two_chunks_small_tail_returns_single(
-    mod_paths, ensure_fake_lionagi
-):
+def test_chunk_by_tokens_two_chunks_small_tail_returns_single(mod_paths, ensure_fake_lionagi):
     mod = importlib.import_module(mod_paths["chunk_mod"])
     toks = _tokens(13)  # residue=3
-    out = mod.chunk_by_tokens(
-        toks, chunk_size=10, overlap=0.2, threshold=5, return_tokens=False
-    )
+    out = mod.chunk_by_tokens(toks, chunk_size=10, overlap=0.2, threshold=5, return_tokens=False)
     # residue <= threshold -> single chunk string
     assert len(out) == 1
     assert out[0] == " ".join(toks)
 
 
-def test_chunk_by_tokens_multi_parts_last_chunk_appended(
-    mod_paths, ensure_fake_lionagi
-):
+def test_chunk_by_tokens_multi_parts_last_chunk_appended(mod_paths, ensure_fake_lionagi):
     mod = importlib.import_module(mod_paths["chunk_mod"])
     chunk_size = 10
     overlap = 0.2  # overlap_size=1

--- a/tests/libs/test_chunk_simple.py
+++ b/tests/libs/test_chunk_simple.py
@@ -25,9 +25,7 @@ def test_chunk_by_chars_basic():
 def test_chunk_by_tokens_basic():
     """Test basic token chunking."""
     tokens = [f"token{i}" for i in range(50)]
-    chunks = chunk_by_tokens(
-        tokens, chunk_size=15, overlap=0.1, threshold=3, return_tokens=True
-    )
+    chunks = chunk_by_tokens(tokens, chunk_size=15, overlap=0.1, threshold=3, return_tokens=True)
     assert len(chunks) == 4
     # Verify first and last tokens are present
     assert "token0" in chunks[0][0]
@@ -170,9 +168,7 @@ def test_edge_cases():
     assert result == ["abc"]
 
     # Empty token list - returns two empty strings (same quirk)
-    result = chunk_by_tokens(
-        [], chunk_size=10, overlap=0, threshold=0, return_tokens=False
-    )
+    result = chunk_by_tokens([], chunk_size=10, overlap=0, threshold=0, return_tokens=False)
     assert result == ["", ""]
 
     # Single token

--- a/tests/libs/test_dir_to_files.py
+++ b/tests/libs/test_dir_to_files.py
@@ -10,9 +10,7 @@ def test_dir_to_files_invalid_directory(mod_paths, ensure_fake_lionagi, tmp_path
         mod.dir_to_files(tmp_path / "does_not_exist")
 
 
-def test_dir_to_files_non_recursive_and_filter(
-    mod_paths, ensure_fake_lionagi, tmp_path
-):
+def test_dir_to_files_non_recursive_and_filter(mod_paths, ensure_fake_lionagi, tmp_path):
     mod = importlib.import_module(mod_paths["api_mod"])
     (tmp_path / "a.txt").write_text("a")
     (tmp_path / "b.md").write_text("b")

--- a/tests/libs/test_file_process.py
+++ b/tests/libs/test_file_process.py
@@ -30,9 +30,7 @@ def test_dir_to_files_verbose_logs_count(tmp_path, caplog):
 # ---------------------------------------------------------------------------
 
 
-def test_dir_to_files_process_file_exception_ignored_with_verbose(
-    tmp_path, monkeypatch, caplog
-):
+def test_dir_to_files_process_file_exception_ignored_with_verbose(tmp_path, monkeypatch, caplog):
     (tmp_path / "good.py").write_text("x = 1")
 
     class _BadPath:
@@ -56,9 +54,7 @@ def test_dir_to_files_process_file_exception_ignored_with_verbose(
     monkeypatch.setattr(Path, "glob", patched_glob)
 
     with caplog.at_level(logging.WARNING):
-        result = dir_to_files(
-            tmp_path, file_types=[".py"], ignore_errors=True, verbose=True
-        )
+        result = dir_to_files(tmp_path, file_types=[".py"], ignore_errors=True, verbose=True)
 
     assert result == []
 
@@ -68,9 +64,7 @@ def test_dir_to_files_process_file_exception_ignored_with_verbose(
 # ---------------------------------------------------------------------------
 
 
-def test_dir_to_files_process_file_exception_raised_when_not_ignored(
-    tmp_path, monkeypatch
-):
+def test_dir_to_files_process_file_exception_raised_when_not_ignored(tmp_path, monkeypatch):
     class _BadPath:
         def is_file(self):
             return True

--- a/tests/libs/utils/test_bcall.py
+++ b/tests/libs/utils/test_bcall.py
@@ -85,9 +85,7 @@ class TestBCallFunction(unittest.IsolatedAsyncioTestCase):
         inputs = [1, 2, 3]
         with patch("anyio.sleep", new_callable=AsyncMock) as mock_sleep:
             batches = []
-            async for batch in bcall(
-                inputs, async_func, batch_size=2, delay_before_start=0.5
-            ):
+            async for batch in bcall(inputs, async_func, batch_size=2, delay_before_start=0.5):
                 batches.append(batch)
             mock_sleep.assert_any_call(0.5)
             self.assertEqual(batches, [[2, 4], [6]])

--- a/tests/libs/utils/test_bcall_params.py
+++ b/tests/libs/utils/test_bcall_params.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Behavior tests for BcallParams.__call__.
+
+Issue (LIONAGI-AUDIT-002): BcallParams.__call__ failed in two ways:
+1. bcall() is an async generator — you cannot await it directly.
+2. batch_size was passed both positionally (self.batch_size) and via
+   default_kw() → TypeError: multiple values for argument 'batch_size'.
+
+Fix: pop 'batch_size' from kwargs to avoid the duplicate, then collect
+all batches from the async generator into a flat list.
+"""
+
+import pytest
+
+from lionagi.ln import BcallParams
+
+# ---------------------------------------------------------------------------
+# Basic functionality
+# ---------------------------------------------------------------------------
+
+
+class TestBcallParamsCall:
+    @pytest.mark.anyio
+    async def test_bcall_params_collects_all_batches(self):
+        """BcallParams(batch_size=2) on [1..5] should return flattened list."""
+
+        async def double(x: int) -> int:
+            return x * 2
+
+        params = BcallParams(batch_size=2)
+        result = await params([1, 2, 3, 4, 5], double)
+        assert sorted(result) == [2, 4, 6, 8, 10]
+
+    @pytest.mark.anyio
+    async def test_bcall_params_batch_size_1(self):
+        """batch_size=1 processes each item individually."""
+
+        async def identity(x):
+            return x
+
+        params = BcallParams(batch_size=1)
+        result = await params([10, 20, 30], identity)
+        assert sorted(result) == [10, 20, 30]
+
+    @pytest.mark.anyio
+    async def test_bcall_params_batch_size_larger_than_input(self):
+        """batch_size larger than input length yields one batch."""
+
+        async def triple(x: int) -> int:
+            return x * 3
+
+        params = BcallParams(batch_size=100)
+        result = await params([1, 2, 3], triple)
+        assert sorted(result) == [3, 6, 9]
+
+    @pytest.mark.anyio
+    async def test_bcall_params_empty_input(self):
+        """Empty input returns empty list."""
+
+        async def noop(x):
+            return x
+
+        params = BcallParams(batch_size=2)
+        result = await params([], noop)
+        assert result == []
+
+    @pytest.mark.anyio
+    async def test_bcall_params_with_extra_kwargs(self):
+        """Extra kwargs are forwarded to the wrapped function."""
+
+        async def add(x: int, *, offset: int = 0) -> int:
+            return x + offset
+
+        params = BcallParams(batch_size=2)
+        result = await params([1, 2, 3], add, offset=10)
+        assert sorted(result) == [11, 12, 13]
+
+    @pytest.mark.anyio
+    async def test_bcall_params_no_duplicate_batch_size_error(self):
+        """batch_size must not be double-passed to bcall (regression guard)."""
+
+        async def identity(x):
+            return x
+
+        params = BcallParams(batch_size=3)
+        # This must not raise TypeError about multiple values for batch_size
+        result = await params([1, 2, 3, 4, 5, 6], identity)
+        assert len(result) == 6
+
+    @pytest.mark.anyio
+    async def test_bcall_params_sync_func(self):
+        """Sync functions are also handled by bcall/alcall underneath."""
+        params = BcallParams(batch_size=2)
+
+        def double(x):
+            return x * 2
+
+        result = await params([1, 2, 3, 4], double)
+        assert sorted(result) == [2, 4, 6, 8]

--- a/tests/libs/utils/test_fuzzy_parse_json.py
+++ b/tests/libs/utils/test_fuzzy_parse_json.py
@@ -20,9 +20,9 @@ class TestFuzzyJsonParsing:
             2,
             3,
         ], "Valid JSON array must parse correctly"
-        assert fuzzy_json('{"nested": {"key": "value"}}') == {
-            "nested": {"key": "value"}
-        }, "Nested JSON must parse"
+        assert fuzzy_json('{"nested": {"key": "value"}}') == {"nested": {"key": "value"}}, (
+            "Nested JSON must parse"
+        )
 
     def test_normalization(self):
         """Test: Normalization (Single Quote, Whitespace, Unquoted Keys)
@@ -30,14 +30,12 @@ class TestFuzzyJsonParsing:
         GIVEN input=" {'a': 1, b: '2'} " THEN returns {"a": 1, "b": "2"}.
         """
         # Single quotes
-        assert fuzzy_json("{'a': 1}") == {
-            "a": 1
-        }, "Single quotes must be normalized to double quotes"
+        assert fuzzy_json("{'a': 1}") == {"a": 1}, (
+            "Single quotes must be normalized to double quotes"
+        )
 
         # Extra whitespace
-        assert fuzzy_json('  {  "a"  :  1  }  ') == {
-            "a": 1
-        }, "Extra whitespace must be handled"
+        assert fuzzy_json('  {  "a"  :  1  }  ') == {"a": 1}, "Extra whitespace must be handled"
 
         # Unquoted keys
         assert fuzzy_json("{a: 1, b: 2}") == {
@@ -52,9 +50,9 @@ class TestFuzzyJsonParsing:
         }, "Combined normalization must work"
 
         # Complex case with nested objects
-        assert fuzzy_json("{outer: {'inner': 1}}") == {
-            "outer": {"inner": 1}
-        }, "Nested normalization must work"
+        assert fuzzy_json("{outer: {'inner': 1}}") == {"outer": {"inner": 1}}, (
+            "Nested normalization must work"
+        )
 
     def test_unmatched_brackets_fixing(self):
         """Test: UnmatchedBracketsFixing (CRITICAL)
@@ -73,14 +71,14 @@ class TestFuzzyJsonParsing:
         assert fuzzy_json('{"a": 1') == {"a": 1}, "Missing closing brace must be fixed"
 
         # Multiple missing brackets
-        assert fuzzy_json('[{"a": [1, 2') == [
-            {"a": [1, 2]}
-        ], "Multiple missing brackets must be fixed"
+        assert fuzzy_json('[{"a": [1, 2') == [{"a": [1, 2]}], (
+            "Multiple missing brackets must be fixed"
+        )
 
         # Nested missing brackets
-        assert fuzzy_json('{"outer": {"inner": "value"') == {
-            "outer": {"inner": "value"}
-        }, "Nested missing brackets must be fixed"
+        assert fuzzy_json('{"outer": {"inner": "value"') == {"outer": {"inner": "value"}}, (
+            "Nested missing brackets must be fixed"
+        )
 
     def test_irreparable_input(self):
         """Test: IrreparableInput
@@ -107,9 +105,7 @@ class TestFuzzyJsonParsing:
     def test_complex_malformed_json(self):
         """Test handling of complex malformed JSON scenarios."""
         # Mixed quotes
-        assert fuzzy_json("{\"a\": 'value'}") == {
-            "a": "value"
-        }, "Mixed quotes must be handled"
+        assert fuzzy_json("{\"a\": 'value'}") == {"a": "value"}, "Mixed quotes must be handled"
 
         # Trailing commas (valid in some parsers)
         assert fuzzy_json('{"a": 1,}') == {"a": 1}, "Trailing commas should be handled"
@@ -122,21 +118,19 @@ class TestFuzzyJsonParsing:
     def test_escaped_characters(self):
         """Test handling of escaped characters."""
         # Escaped quotes
-        assert fuzzy_json('{"key": "\\"value\\""}') == {
-            "key": '"value"'
-        }, "Escaped quotes must be preserved"
+        assert fuzzy_json('{"key": "\\"value\\""}') == {"key": '"value"'}, (
+            "Escaped quotes must be preserved"
+        )
 
         # Escaped backslashes
-        assert fuzzy_json('{"path": "C:\\\\Users\\\\file"}') == {
-            "path": "C:\\Users\\file"
-        }, "Escaped backslashes must be handled"
+        assert fuzzy_json('{"path": "C:\\\\Users\\\\file"}') == {"path": "C:\\Users\\file"}, (
+            "Escaped backslashes must be handled"
+        )
 
     def test_msgspec_decoder_efficiency(self):
         """Test that msgspec decoder is used efficiently."""
         # Large JSON should still parse efficiently
-        large_json = (
-            '{"items": [' + ",".join(f'{{"id": {i}}}' for i in range(100)) + "]}"
-        )
+        large_json = '{"items": [' + ",".join(f'{{"id": {i}}}' for i in range(100)) + "]}"
         result = fuzzy_json(large_json)
         assert len(result["items"]) == 100, "Large JSON must parse correctly"
         assert result["items"][0] == {"id": 0}
@@ -168,9 +162,7 @@ class TestExtractJson:
 ```
 Some text after"""
 
-        assert extract_json(input_text) == {
-            "a": 1
-        }, "JSON from markdown block must be extracted"
+        assert extract_json(input_text) == {"a": 1}, "JSON from markdown block must be extracted"
 
         # Test with more whitespace
         input_with_space = """
@@ -182,9 +174,9 @@ Some text after"""
         
         Text after
         """
-        assert extract_json(input_with_space) == {
-            "key": "value"
-        }, "JSON with whitespace must be extracted"
+        assert extract_json(input_with_space) == {"key": "value"}, (
+            "JSON with whitespace must be extracted"
+        )
 
     def test_multiple_code_blocks(self):
         """Test: MultipleCodeBlocks
@@ -256,9 +248,9 @@ Second block:
         input_broken = """```json
 {"items": [1, 2, 3
 ```"""
-        assert extract_json(input_broken, fuzzy_parse=True) == {
-            "items": [1, 2, 3]
-        }, "Broken JSON in markdown must be fixed"
+        assert extract_json(input_broken, fuzzy_parse=True) == {"items": [1, 2, 3]}, (
+            "Broken JSON in markdown must be fixed"
+        )
 
     def test_return_one_if_single_parameter(self):
         """Test the return_one_if_single parameter behavior."""
@@ -267,17 +259,17 @@ Second block:
 ```"""
 
         # Default behavior (return_one_if_single=True)
-        assert extract_json(single_block) == {
-            "single": "value"
-        }, "Single block returns dict by default"
-        assert extract_json(single_block, return_one_if_single=True) == {
-            "single": "value"
-        }, "Explicit True returns dict"
+        assert extract_json(single_block) == {"single": "value"}, (
+            "Single block returns dict by default"
+        )
+        assert extract_json(single_block, return_one_if_single=True) == {"single": "value"}, (
+            "Explicit True returns dict"
+        )
 
         # Force list return
-        assert extract_json(single_block, return_one_if_single=False) == [
-            {"single": "value"}
-        ], "False returns list"
+        assert extract_json(single_block, return_one_if_single=False) == [{"single": "value"}], (
+            "False returns list"
+        )
 
     def test_list_input(self):
         """Test that list of strings is properly joined and processed."""
@@ -289,9 +281,7 @@ Second block:
             "More text",
         ]
 
-        assert extract_json(lines) == {
-            "key": "value"
-        }, "List input must be joined and processed"
+        assert extract_json(lines) == {"key": "value"}, "List input must be joined and processed"
 
         # Multiple blocks in list form
         lines_multi = [
@@ -313,15 +303,15 @@ Second block:
     def test_no_json_found(self):
         """Test behavior when no JSON is found."""
         assert extract_json("No JSON here") == [], "No JSON should return empty list"
-        assert (
-            extract_json("```python\nprint('hello')\n```") == []
-        ), "Non-JSON code block returns empty"
+        assert extract_json("```python\nprint('hello')\n```") == [], (
+            "Non-JSON code block returns empty"
+        )
         assert extract_json("") == [], "Empty string returns empty list"
 
         # Invalid JSON that can't be parsed even with fuzzy
-        assert (
-            extract_json("```json\ncompletely invalid\n```", fuzzy_parse=False) == []
-        ), "Invalid JSON returns empty"
+        assert extract_json("```json\ncompletely invalid\n```", fuzzy_parse=False) == [], (
+            "Invalid JSON returns empty"
+        )
 
     def test_nested_json_in_markdown(self):
         """Test extraction of complex nested JSON from markdown."""
@@ -373,8 +363,7 @@ class TestFixJsonString:
     def test_mixed_bracket_types(self):
         """Test fixing mixed bracket types."""
         assert (
-            fix_json_string('{"array": [1, 2, {"nested": 3')
-            == '{"array": [1, 2, {"nested": 3}]}'
+            fix_json_string('{"array": [1, 2, {"nested": 3') == '{"array": [1, 2, {"nested": 3}]}'
         )
 
     def test_error_conditions(self):

--- a/tests/libs/utils/test_lcall.py
+++ b/tests/libs/utils/test_lcall.py
@@ -34,9 +34,7 @@ class TestLCallFunction(unittest.IsolatedAsyncioTestCase):
 
     async def test_lcall_with_retries(self):
         inputs = [1, 2, 3]
-        results = await alcall(
-            inputs, mock_func_with_error, retry_attempts=1, retry_default=0
-        )
+        results = await alcall(inputs, mock_func_with_error, retry_attempts=1, retry_default=0)
         self.assertEqual(results, [1, 2, 0])
 
     async def test_lcall_with_timeout(self):
@@ -264,9 +262,7 @@ class TestLCallSyncFunction:
         output_flatten=st.booleans(),
     )
     @settings(max_examples=30)
-    def test_lcall_flatten_options_property(
-        self, values, input_flatten, output_flatten
-    ):
+    def test_lcall_flatten_options_property(self, values, input_flatten, output_flatten):
         """Property test: lcall processing options work correctly."""
         result = lcall(
             values,

--- a/tests/libs/utils/test_sentinel_types.py
+++ b/tests/libs/utils/test_sentinel_types.py
@@ -33,9 +33,7 @@ class TestSentinelTypesIntegrity:
         b = UndefinedType()
         assert a is b, "Multiple UndefinedType instances must be the same object"
         assert a is Undefined, "UndefinedType instance must be the global Undefined"
-        assert (
-            b is Undefined
-        ), "All UndefinedType instances must be the global Undefined"
+        assert b is Undefined, "All UndefinedType instances must be the global Undefined"
 
     def test_singleton_identity_unset(self):
         """Test: SingletonIdentity (CRITICAL) for UnsetType.
@@ -66,14 +64,10 @@ class TestSentinelTypesIntegrity:
         THEN the result must be the original Undefined object (verify using 'is').
         """
         shallow_copy = copy.copy(Undefined)
-        assert (
-            shallow_copy is Undefined
-        ), "copy.copy(Undefined) must return the same object"
+        assert shallow_copy is Undefined, "copy.copy(Undefined) must return the same object"
 
         deep_copy = copy.deepcopy(Undefined)
-        assert (
-            deep_copy is Undefined
-        ), "copy.deepcopy(Undefined) must return the same object"
+        assert deep_copy is Undefined, "copy.deepcopy(Undefined) must return the same object"
 
     def test_immutability_under_copy_unset(self):
         """Test: ImmutabilityUnderCopy (CRITICAL: State Safety) for Unset.
@@ -95,9 +89,7 @@ class TestSentinelTypesIntegrity:
         # Test Undefined
         pickled_undefined = pickle.dumps(Undefined)
         unpickled_undefined = pickle.loads(pickled_undefined)
-        assert (
-            unpickled_undefined is Undefined
-        ), "Unpickled Undefined must be the same object"
+        assert unpickled_undefined is Undefined, "Unpickled Undefined must be the same object"
 
         # Test Unset
         pickled_unset = pickle.dumps(Unset)

--- a/tests/libs/utils/test_to_dict.py
+++ b/tests/libs/utils/test_to_dict.py
@@ -158,7 +158,5 @@ def test_to_dict_performance():
     start_time = time.time()
     result = to_dict(large_dict)
     end_time = time.time()
-    assert (
-        end_time - start_time
-    ) < 0.1  # Assuming it should take less than 0.1 seconds
+    assert (end_time - start_time) < 0.1  # Assuming it should take less than 0.1 seconds
     assert result == large_dict

--- a/tests/libs/utils/test_utils_path_traversal.py
+++ b/tests/libs/utils/test_utils_path_traversal.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Attack-driven regression tests for acreate_path directory traversal.
+
+These tests verify that acreate_path refuses to create files outside the
+supplied base directory when filenames contain path-traversal components.
+
+Issue (LIONAGI-AUDIT-003): acreate_path only rejected backslashes. A
+caller could pass filename='../escape.txt' or 'sub/../../../escape.txt'
+and receive or create paths outside the intended base directory.
+
+Fix: reject '.' and '..' filename components before mkdir; resolve and
+assert the candidate path stays within the resolved base directory.
+"""
+
+import pytest
+
+from lionagi.ln._utils import acreate_path
+
+
+class TestAcreatePathTraversalContainment:
+    """Directory traversal must be refused before any filesystem side effect."""
+
+    @pytest.mark.anyio
+    async def test_dotdot_filename_raises_value_error(self, tmp_path):
+        """Classic '../escape.txt' traversal must be rejected."""
+        base = tmp_path / "base"
+        base.mkdir()
+        with pytest.raises(ValueError, match=r"'\.\.'|escape|traversal"):
+            await acreate_path(directory=base, filename="../escape.txt")
+
+    @pytest.mark.anyio
+    async def test_nested_dotdot_raises_value_error(self, tmp_path):
+        """Nested 'sub/../../../etc/passwd' traversal must be rejected."""
+        base = tmp_path / "base"
+        base.mkdir()
+        with pytest.raises(ValueError):
+            await acreate_path(directory=base, filename="sub/../../../etc/passwd")
+
+    @pytest.mark.anyio
+    async def test_double_dotdot_in_subdir_raises(self, tmp_path):
+        """'good/../../escape.txt' must be rejected (escapes base after subdir)."""
+        base = tmp_path / "base"
+        base.mkdir()
+        with pytest.raises(ValueError):
+            await acreate_path(directory=base, filename="good/../../escape.txt")
+
+    @pytest.mark.anyio
+    async def test_dot_component_raises_value_error(self, tmp_path):
+        """Filename component '.' must be rejected."""
+        base = tmp_path / "base"
+        base.mkdir()
+        with pytest.raises(ValueError, match=r"'\.'|'\.\.'"):
+            await acreate_path(directory=base, filename="./sneaky.txt")
+
+    @pytest.mark.anyio
+    async def test_dotdot_standalone_raises(self, tmp_path):
+        """Bare '..' as filename must be rejected."""
+        base = tmp_path / "base"
+        base.mkdir()
+        with pytest.raises(ValueError):
+            await acreate_path(directory=base, filename="..")
+
+    @pytest.mark.anyio
+    async def test_dot_standalone_raises(self, tmp_path):
+        """Bare '.' as filename must be rejected."""
+        base = tmp_path / "base"
+        base.mkdir()
+        with pytest.raises(ValueError):
+            await acreate_path(directory=base, filename=".")
+
+    @pytest.mark.anyio
+    async def test_no_traversal_is_created_outside_base(self, tmp_path):
+        """Verify no file is created outside base even on traversal attempt."""
+        base = tmp_path / "base"
+        base.mkdir()
+        escape_target = tmp_path / "escape.txt"
+        try:
+            await acreate_path(directory=base, filename="../escape.txt")
+        except ValueError:
+            pass
+        # The escaped path must NOT exist
+        assert not escape_target.exists(), "acreate_path created a file outside the base directory"
+
+    @pytest.mark.anyio
+    async def test_normal_subdir_filename_still_works(self, tmp_path):
+        """Legitimate subdirectory in filename continues to work."""
+        base = tmp_path / "base"
+        base.mkdir()
+        result = await acreate_path(directory=base, filename="sub/file.txt")
+        assert result.name == "file.txt"
+        assert result.parent.name == "sub"
+        # Must be under base
+        result.relative_to(base)
+
+    @pytest.mark.anyio
+    async def test_backslash_still_rejected(self, tmp_path):
+        """Pre-existing backslash check is preserved."""
+        base = tmp_path / "base"
+        base.mkdir()
+        with pytest.raises(ValueError, match="directory separators"):
+            await acreate_path(directory=base, filename="win\\path.txt")
+
+    @pytest.mark.anyio
+    async def test_symlinked_subdir_escape_rejected(self, tmp_path):
+        """A symlinked subdirectory pointing outside the base must be rejected.
+
+        Regression: the base root must be captured BEFORE the filename redirects
+        `directory` into a subdir, otherwise resolve() through the symlink makes
+        the escaped location look like the base.
+        """
+        base = tmp_path / "base"
+        base.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (base / "link").symlink_to(outside, target_is_directory=True)
+
+        with pytest.raises(ValueError, match="escapes base directory"):
+            await acreate_path(directory=base, filename="link/escape.txt")
+        assert not (outside / "escape.txt").exists()
+
+    @pytest.mark.anyio
+    async def test_symlinked_final_component_escape_rejected(self, tmp_path):
+        """A symlinked final filename pointing outside the base must be rejected.
+
+        Regression: validating `dir_resolved / filename` WITHOUT resolving the
+        final component let `base/link.txt -> /outside/target.txt` pass, since
+        the unresolved path is lexically under base. The candidate must be fully
+        resolve()-d so the final symlink is followed.
+        """
+        base = tmp_path / "base"
+        base.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        target = outside / "target.txt"
+        target.write_text("secret")
+        (base / "link.txt").symlink_to(target)
+
+        with pytest.raises(ValueError, match="escapes base directory"):
+            await acreate_path(directory=base, filename="link.txt", file_exist_ok=True)

--- a/tests/libs/validate/test_common_field_validators.py
+++ b/tests/libs/validate/test_common_field_validators.py
@@ -113,9 +113,7 @@ class TestValidateSameDtypeFlatList:
 
     def test_dropna_removes_none(self):
         """Test dropna removes None values."""
-        result = validate_same_dtype_flat_list(
-            DummyCls, [1, None, 2, None, 3], int, dropna=True
-        )
+        result = validate_same_dtype_flat_list(DummyCls, [1, None, 2, None, 3], int, dropna=True)
         assert result == [1, 2, 3]
 
     def test_dropna_false_keeps_none(self):
@@ -160,9 +158,7 @@ class TestValidateNullableStringField:
     def test_custom_field_name_in_error(self):
         """Test custom field name appears in error message."""
         with pytest.raises(ValueError, match="username must be a string"):
-            validate_nullable_string_field(
-                DummyCls, 123, field_name="username", strict=True
-            )
+            validate_nullable_string_field(DummyCls, 123, field_name="username", strict=True)
 
     def test_string_with_content(self):
         """Test string with whitespace and content."""

--- a/tests/libs/validate/test_to_num.py
+++ b/tests/libs/validate/test_to_num.py
@@ -167,9 +167,7 @@ class TestExtractNumbers:
     def test_extracts_complex(self):
         """Lines 128-140: complex number matched."""
         matches = extract_numbers("z = 1+2j")
-        assert any(
-            t in ("complex", "complex_sci", "pure_imaginary") for t, _ in matches
-        )
+        assert any(t in ("complex", "complex_sci", "pure_imaginary") for t, _ in matches)
 
 
 # --- validate_num_type (lines 156-161) ---

--- a/tests/libs/validate/test_validate_mapping.py
+++ b/tests/libs/validate/test_validate_mapping.py
@@ -126,9 +126,7 @@ class TestValidateMapping:
     def test_strict_mode(self):
         """Test strict mode validation."""
         with pytest.raises(ValueError):
-            fuzzy_validate_mapping(
-                {"name": "John"}, ["name", "required_field"], strict=True
-            )
+            fuzzy_validate_mapping({"name": "John"}, ["name", "required_field"], strict=True)
 
     def test_custom_similarity(self):
         """Test custom similarity function."""

--- a/tests/lndl/test_types.py
+++ b/tests/lndl/test_types.py
@@ -29,6 +29,11 @@ class NestedModel(BaseModel):
     inner: SimpleModel | None = None
 
 
+class OptionalModel(BaseModel):
+    note: str | None = None
+    count: int | None = None
+
+
 def make_action_call(name="act1", fn="fetch", args=None):
     return ActionCall(
         name=name,
@@ -337,3 +342,30 @@ class TestCoerceResultOptionalScalar:
         result = _coerce_result({"a": 1}, str | None)
         parsed = json.loads(result)
         assert parsed == {"a": 1}
+
+    # --- None preservation (Codex #1281 regression) ---
+
+    def test_none_result_optional_str_preserved(self):
+        """A legitimately-None result for `str | None` must stay None, not become
+        the literal string 'None'."""
+        assert _coerce_result(None, str | None) is None
+
+    def test_none_result_optional_int_preserved(self):
+        """None for `int | None` must stay None, not raise from int(None)."""
+        assert _coerce_result(None, int | None) is None
+
+    def test_none_result_optional_float_preserved(self):
+        assert _coerce_result(None, float | None) is None
+
+    def test_none_result_required_scalar_passes_through(self):
+        """None for a required scalar passes through so model_validate raises a
+        clear validation error instead of silently coercing to 'None'."""
+        assert _coerce_result(None, str) is None
+
+    def test_none_revalidates_optional_field_to_none(self):
+        """End-to-end: an action returning None for an Optional field stays None
+        through revalidate_with_action_results (was corrupted to 'None')."""
+        ac = ActionCall(name="opt", function="maybe", arguments={}, raw_call="maybe()")
+        m = OptionalModel.model_construct(note=ac)
+        result = revalidate_with_action_results(m, {"opt": None})
+        assert result.note is None

--- a/tests/lndl/test_types.py
+++ b/tests/lndl/test_types.py
@@ -230,3 +230,110 @@ class TestRevalidateWithActionResults:
         result = revalidate_with_action_results(m, {"s": 0.95})
         assert result.score == pytest.approx(0.95)
         assert result.title == "My Title"
+
+
+# ---------------------------------------------------------------------------
+# Regression: LNDLOutput.__getattr__ must raise AttributeError not KeyError
+# ---------------------------------------------------------------------------
+
+
+class TestLNDLOutputGetAttrRaisesAttributeError:
+    """LIONAGI-AUDIT-001 (lndl): missing dynamic attrs must raise AttributeError."""
+
+    def make_empty_output(self):
+        return LNDLOutput(fields={}, lvars={}, lacts={}, actions={}, raw_out_block="")
+
+    def test_missing_attr_raises_attribute_error(self):
+        """out.missing must raise AttributeError so hasattr() works correctly."""
+        out = self.make_empty_output()
+        with pytest.raises(AttributeError):
+            _ = out.missing_field
+
+    def test_hasattr_returns_false_for_missing(self):
+        """hasattr() must return False for absent dynamic attributes."""
+        out = self.make_empty_output()
+        assert hasattr(out, "missing_field") is False
+
+    def test_getattr_default_works_for_missing(self):
+        """getattr(out, 'missing', default) must return the default."""
+        out = self.make_empty_output()
+        sentinel = object()
+        result = getattr(out, "missing_field", sentinel)
+        assert result is sentinel
+
+    def test_present_attr_still_accessible(self):
+        """Fields that exist are still accessible through __getattr__."""
+        out = LNDLOutput(
+            fields={"score": 0.5},
+            lvars={},
+            lacts={},
+            actions={},
+            raw_out_block="",
+        )
+        assert out.score == pytest.approx(0.5)
+
+    def test_own_attr_not_affected(self):
+        """Structural attributes (fields, lvars, etc.) bypass dynamic lookup."""
+        out = LNDLOutput(
+            fields={"x": 1},
+            lvars={"k": "v"},
+            lacts={},
+            actions={},
+            raw_out_block="test",
+        )
+        assert out.raw_out_block == "test"
+        assert out.fields == {"x": 1}
+
+
+# ---------------------------------------------------------------------------
+# Regression: _coerce_result handles Optional scalar annotations
+# ---------------------------------------------------------------------------
+
+
+class TestCoerceResultOptionalScalar:
+    """LIONAGI-AUDIT-002 (lndl): optional scalar fields must coerce like required ones."""
+
+    def test_optional_str_dict_result(self):
+        """str | None target: dict result must be JSON-serialised to str."""
+        result = _coerce_result({"key": "val"}, str | None)
+        assert isinstance(result, str)
+
+    def test_optional_int_str_result(self):
+        """int | None target: str '42' must be coerced to int 42."""
+        result = _coerce_result("42", int | None)
+        assert result == 42
+        assert isinstance(result, int)
+
+    def test_optional_float_str_result(self):
+        """float | None target: str '3.14' must be coerced to float."""
+        result = _coerce_result("3.14", float | None)
+        assert isinstance(result, float)
+        assert abs(result - 3.14) < 1e-6
+
+    def test_optional_str_already_correct_type(self):
+        """str | None target when result is already str — no change."""
+        result = _coerce_result("hello", str | None)
+        assert result == "hello"
+
+    def test_required_str_dict_still_works(self):
+        """Regression: required str target still serialises dict."""
+        result = _coerce_result({"key": "val"}, str)
+        assert isinstance(result, str)
+
+    def test_non_scalar_annotation_passthrough(self):
+        """list[str] annotation should not trigger coercion."""
+        result = _coerce_result(["a", "b"], list[str])
+        assert result == ["a", "b"]
+
+    def test_none_target_type_passthrough(self):
+        """None annotation passes through unchanged."""
+        result = _coerce_result({"x": 1}, None)
+        assert result == {"x": 1}
+
+    def test_dict_result_optional_str_is_json_string(self):
+        """dict result for str | None must be valid JSON string (not repr)."""
+        import json
+
+        result = _coerce_result({"a": 1}, str | None)
+        parsed = json.loads(result)
+        assert parsed == {"a": 1}

--- a/tests/tools/test_bash.py
+++ b/tests/tools/test_bash.py
@@ -150,9 +150,9 @@ async def test_handle_request_shell_control_operators_rejected(cmd, operator):
     tool = BashTool()
     resp = await tool.handle_request(BashRequest(command=cmd))
     assert resp.return_code == -1, f"Operator {operator!r} was not rejected"
-    assert (
-        "Shell control" in resp.stderr or "trusted shell mode" in resp.stderr
-    ), f"Operator {operator!r} rejection message missing: {resp.stderr}"
+    assert "Shell control" in resp.stderr or "trusted shell mode" in resp.stderr, (
+        f"Operator {operator!r} rejection message missing: {resp.stderr}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -162,10 +162,7 @@ async def test_handle_request_shell_control_operators_rejected(cmd, operator):
 
 async def test_handle_request_output_truncation(tmp_path):
     # Generate a python one-liner that emits well over 100 KB of output
-    script = (
-        'python3 -c "import sys; '
-        "sys.stdout.write('A' * 200000); sys.stdout.flush()\""
-    )
+    script = "python3 -c \"import sys; sys.stdout.write('A' * 200000); sys.stdout.flush()\""
     tool = BashTool()
     req = BashRequest(command=script, allow_shell=True)
     resp = await tool.handle_request(req)

--- a/tests/tools/test_editor.py
+++ b/tests/tools/test_editor.py
@@ -41,9 +41,7 @@ def test_editor_request_write_construction():
 
 
 def test_editor_request_edit_construction():
-    req = EditorRequest(
-        action="edit", file_path="f.py", old_string="old", new_string="new"
-    )
+    req = EditorRequest(action="edit", file_path="f.py", old_string="old", new_string="new")
     assert req.action == EditorAction.edit
     assert req.old_string == "old"
     assert req.new_string == "new"
@@ -430,9 +428,7 @@ async def test_editor_tool_requires_old_and_new_strings_for_edit(tmp_path):
     tool = EditorTool(workspace_root=str(tmp_path))
     target = tmp_path / "f.txt"
 
-    resp = await tool.handle_request(
-        EditorRequest(action=EditorAction.edit, file_path=str(target))
-    )
+    resp = await tool.handle_request(EditorRequest(action=EditorAction.edit, file_path=str(target)))
     assert resp.success is False
     assert "old_string" in resp.error
 

--- a/tests/tools/test_messenger.py
+++ b/tests/tools/test_messenger.py
@@ -236,9 +236,7 @@ class TestMessengerBindWakeup:
         branch = _make_branch(ex)
         alice_id = uuid4()
         ex.register(alice_id)
-        tool = m.bind(
-            branch, roster={"alice": alice_id}, sender_name="bob", channel="team"
-        )
+        tool = m.bind(branch, roster={"alice": alice_id}, sender_name="bob", channel="team")
         result = tool.func_callable(action="wakeup", to="alice", content="stand up")
         assert "Woke up alice" in result
         assert len(branch._included) == 1
@@ -252,9 +250,7 @@ class TestMessengerBindWakeup:
         alice_id = uuid4()
         ex.register(alice_id)
         tool = m.bind(branch, roster={"alice": alice_id})
-        result = tool.func_callable(
-            action="wakeup", to=["alice", "bob"], content="rise"
-        )
+        result = tool.func_callable(action="wakeup", to=["alice", "bob"], content="rise")
         assert "Woke up alice" in result
 
 

--- a/tests/tools/test_sandbox.py
+++ b/tests/tools/test_sandbox.py
@@ -33,9 +33,7 @@ def _init_git_repo(path: Path) -> None:
         subprocess.run(cmd, cwd=str(path), capture_output=True, check=True)
     (path / "README.md").write_text("initial\n")
     subprocess.run(["git", "add", "."], cwd=str(path), capture_output=True, check=True)
-    subprocess.run(
-        ["git", "commit", "-m", "init"], cwd=str(path), capture_output=True, check=True
-    )
+    subprocess.run(["git", "commit", "-m", "init"], cwd=str(path), capture_output=True, check=True)
 
 
 @pytest.fixture
@@ -215,9 +213,7 @@ async def test_sandbox_discard_deletes_branch(git_repo):
     session = await create_sandbox(str(git_repo))
     branch_name = session.branch_name
     await sandbox_discard(session)
-    out = subprocess.run(
-        ["git", "branch"], cwd=str(git_repo), capture_output=True, text=True
-    )
+    out = subprocess.run(["git", "branch"], cwd=str(git_repo), capture_output=True, text=True)
     assert branch_name not in out.stdout
 
 

--- a/tests/tools/test_search.py
+++ b/tests/tools/test_search.py
@@ -133,9 +133,7 @@ async def test_grep_no_matches_returns_success(tmp_path):
 
 
 async def test_grep_regex_matches_function_defs(tmp_path):
-    (tmp_path / "code.py").write_text(
-        "def foo():\n    pass\ndef bar(x):\n    return x\n"
-    )
+    (tmp_path / "code.py").write_text("def foo():\n    pass\ndef bar(x):\n    return x\n")
     tool = SearchTool()
     resp = await tool.handle_request(
         SearchRequest(
@@ -295,9 +293,7 @@ def test_to_tool_func_callable_is_async():
 async def test_to_tool_callable_executes(tmp_path):
     (tmp_path / "hi.py").write_text("hello\n")
     tool = SearchTool()
-    result = await tool.to_tool().func_callable(
-        action="grep", pattern="hello", path=str(tmp_path)
-    )
+    result = await tool.to_tool().func_callable(action="grep", pattern="hello", path=str(tmp_path))
     assert result["success"] is True
     assert result["count"] > 0
 
@@ -364,9 +360,7 @@ async def test_grep_file_not_found_returns_error(monkeypatch):
 
     monkeypatch.setattr(search_mod.subprocess, "run", raise_fnf)
     tool = SearchTool()
-    resp = await tool.handle_request(
-        SearchRequest(action=SearchAction.grep, pattern="x", path=".")
-    )
+    resp = await tool.handle_request(SearchRequest(action=SearchAction.grep, pattern="x", path="."))
     assert resp.success is False
     assert resp.count == 0
     assert "not found" in (resp.error or "")
@@ -380,9 +374,7 @@ async def test_grep_generic_exception_returns_error(monkeypatch):
 
     monkeypatch.setattr(search_mod.subprocess, "run", raise_exc)
     tool = SearchTool()
-    resp = await tool.handle_request(
-        SearchRequest(action=SearchAction.grep, pattern="x", path=".")
-    )
+    resp = await tool.handle_request(SearchRequest(action=SearchAction.grep, pattern="x", path="."))
     assert resp.success is False
     assert "grep error" in (resp.error or "")
 

--- a/tests/tools/test_search_containment.py
+++ b/tests/tools/test_search_containment.py
@@ -1,0 +1,264 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Attack-driven regression tests for SearchTool workspace path containment.
+
+These tests verify that path traversal attacks are rejected BEFORE the
+subprocess is ever constructed — the security boundary is in
+_validate_search_path(), called from handle_request() before any run_sync.
+
+Issue: Standalone SearchTool accepted untrusted filesystem paths without
+containment, allowing grep/find to traverse outside the project root.
+
+Fix: workspace_root parameter + _validate_search_path() resolves and
+asserts the path stays within the allowed root, failing closed.
+"""
+
+import pytest
+
+from lionagi.tools.code.search import (
+    SearchAction,
+    SearchRequest,
+    SearchResponse,
+    SearchTool,
+    _validate_search_path,
+)
+
+# ---------------------------------------------------------------------------
+# Attack: _validate_search_path rejects escapes before subprocess launch
+# ---------------------------------------------------------------------------
+
+
+class TestValidateSearchPathContainment:
+    """Unit tests for the path-containment guard (no subprocess needed)."""
+
+    def test_allows_path_inside_root(self, tmp_path):
+        inner = tmp_path / "project"
+        inner.mkdir()
+        resolved, err = _validate_search_path(str(inner), str(tmp_path))
+        assert err is None
+        assert resolved  # returns non-empty string
+
+    def test_allows_path_equal_to_root(self, tmp_path):
+        resolved, err = _validate_search_path(str(tmp_path), str(tmp_path))
+        assert err is None
+
+    def test_rejects_dotdot_escape(self, tmp_path):
+        """Classic ../escape attack must be rejected with PermissionError."""
+        inner = tmp_path / "base"
+        inner.mkdir()
+        attack_path = str(inner) + "/../etc/passwd"
+        with pytest.raises(PermissionError, match="outside"):
+            _validate_search_path(attack_path, str(inner))
+
+    def test_rejects_absolute_path_outside_root(self, tmp_path):
+        """Absolute path outside root must be refused."""
+        root = tmp_path / "root"
+        root.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        with pytest.raises(PermissionError, match="outside"):
+            _validate_search_path(str(outside), str(root))
+
+    def test_rejects_nested_dotdot_escape(self, tmp_path):
+        """Nested traversal: base/sub/../../escape."""
+        base = tmp_path / "base"
+        sub = base / "sub"
+        sub.mkdir(parents=True)
+        attack_path = str(sub) + "/../../escape"
+        with pytest.raises(PermissionError, match="outside"):
+            _validate_search_path(attack_path, str(base))
+
+    def test_no_workspace_root_allows_any_path(self, tmp_path):
+        """Without workspace_root, no containment check is applied."""
+        outside = tmp_path / "anywhere"
+        outside.mkdir()
+        resolved, err = _validate_search_path(str(outside), None)
+        assert err is None
+
+
+# ---------------------------------------------------------------------------
+# Attack: handle_request refuses escaping paths before subprocess
+# ---------------------------------------------------------------------------
+
+
+class TestSearchToolHandleRequestContainment:
+    """Integration tests: handle_request must reject escapes without launching subprocess."""
+
+    @pytest.mark.anyio
+    async def test_grep_escape_returns_error_response(self, tmp_path):
+        """Path traversal on grep action returns SearchResponse(success=False)."""
+        root = tmp_path / "workspace"
+        root.mkdir()
+        outside = tmp_path / "sensitive"
+        outside.mkdir()
+        (outside / "secret.txt").write_text("TOP SECRET")
+
+        tool = SearchTool(workspace_root=str(root))
+        resp = await tool.handle_request(
+            SearchRequest(
+                action=SearchAction.grep,
+                pattern="SECRET",
+                path=str(outside),
+            )
+        )
+        # Must be refused — no results from outside workspace
+        assert resp.success is False
+        assert "outside" in (resp.error or "").lower()
+        assert resp.count == 0
+
+    @pytest.mark.anyio
+    async def test_find_escape_returns_error_response(self, tmp_path):
+        """Path traversal on find action returns SearchResponse(success=False)."""
+        root = tmp_path / "workspace"
+        root.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+
+        tool = SearchTool(workspace_root=str(root))
+        resp = await tool.handle_request(
+            SearchRequest(
+                action=SearchAction.find,
+                pattern="*.py",
+                path=str(outside),
+            )
+        )
+        assert resp.success is False
+        assert "outside" in (resp.error or "").lower()
+
+    @pytest.mark.anyio
+    async def test_dotdot_grep_refuses_before_subprocess(self, tmp_path, monkeypatch):
+        """Verify PermissionError is raised BEFORE subprocess.run is called."""
+        import lionagi.tools.code.search as search_mod
+
+        subprocess_called = []
+
+        def fake_run(*a, **kw):
+            subprocess_called.append(1)
+            raise AssertionError("subprocess.run must not be called on escaped path")
+
+        monkeypatch.setattr(search_mod.subprocess, "run", fake_run)
+
+        base = tmp_path / "base"
+        base.mkdir()
+        tool = SearchTool(workspace_root=str(base))
+        resp = await tool.handle_request(
+            SearchRequest(
+                action=SearchAction.grep,
+                pattern="x",
+                path=str(base) + "/../escape",
+            )
+        )
+        # subprocess should never have been called
+        assert not subprocess_called, "subprocess.run was called despite path traversal"
+        assert resp.success is False
+
+    @pytest.mark.anyio
+    async def test_search_inside_workspace_works(self, tmp_path):
+        """Normal search inside workspace_root succeeds."""
+        root = tmp_path / "ws"
+        root.mkdir()
+        (root / "code.py").write_text("def hello(): pass\n")
+
+        tool = SearchTool(workspace_root=str(root))
+        resp = await tool.handle_request(
+            SearchRequest(
+                action=SearchAction.grep,
+                pattern="hello",
+                path=str(root),
+            )
+        )
+        assert resp.success is True
+        assert resp.count > 0
+
+    def test_search_tool_init_stores_resolved_workspace_root(self, tmp_path):
+        # Stored root is resolved to an absolute path at construction.
+        import os
+        from pathlib import Path
+
+        tool = SearchTool(workspace_root=str(tmp_path))
+        assert tool._workspace_root == str(Path(tmp_path).resolve())
+        assert os.path.isabs(tool._workspace_root)
+
+    def test_search_tool_default_no_workspace_root(self):
+        tool = SearchTool()
+        assert tool._workspace_root is None
+
+
+class TestRelativePathResolvedAgainstRoot:
+    """Relative search paths must resolve against workspace_root, not cwd."""
+
+    def test_dot_path_resolves_to_workspace_root(self, tmp_path):
+        """path='.' must resolve to workspace_root, not the process cwd."""
+        root = tmp_path / "ws"
+        root.mkdir()
+        resolved, err = _validate_search_path(".", str(root))
+        assert err is None
+        assert resolved == str(root.resolve())
+
+    def test_relative_subpath_resolves_under_root(self, tmp_path):
+        root = tmp_path / "ws"
+        (root / "src").mkdir(parents=True)
+        resolved, err = _validate_search_path("src", str(root))
+        assert err is None
+        assert resolved == str((root / "src").resolve())
+
+    def test_relative_escape_rejected(self, tmp_path):
+        """A relative path that climbs out of root is rejected."""
+        root = tmp_path / "ws"
+        root.mkdir()
+        with pytest.raises(PermissionError, match="outside workspace root"):
+            _validate_search_path("../escape", str(root))
+
+
+class TestRelativeWorkspaceRootIsFrozen:
+    """A relative workspace_root must bind at construction, not move with cwd.
+
+    Regression: SearchTool stored the raw (possibly relative) root and resolved
+    it against the process cwd at search time. A later os.chdir() then moved the
+    containment boundary — a relative 'ws' would point at the NEW cwd's 'ws',
+    letting a search escape (or refuse legitimately-contained) the intended root.
+    """
+
+    @pytest.mark.anyio
+    async def test_cwd_change_after_construction_does_not_move_boundary(
+        self, tmp_path, monkeypatch
+    ):
+        import os
+        from pathlib import Path
+
+        # Two sibling sandboxes, each containing a relative-named "ws".
+        base_a = tmp_path / "a"
+        base_b = tmp_path / "b"
+        (base_a / "ws").mkdir(parents=True)
+        (base_b / "ws").mkdir(parents=True)
+        (base_a / "ws" / "code.py").write_text("def a(): pass\n")
+        secret = base_b / "ws" / "secret.py"
+        secret.write_text("API_SECRET = 'leak'\n")
+
+        # Construct with a RELATIVE root while cwd == base_a → boundary is a/ws.
+        monkeypatch.chdir(base_a)
+        tool = SearchTool(workspace_root="ws")
+        assert tool._workspace_root == str((base_a / "ws").resolve())
+
+        # Now move cwd to base_b. A naive re-resolve of "ws" would point at b/ws.
+        monkeypatch.chdir(base_b)
+
+        # Searching b/ws (by absolute path) must be REFUSED: the frozen boundary
+        # is still a/ws, so b/ws is outside it. Pre-fix, the boundary would have
+        # followed cwd to b/ws and this search would have succeeded (leak).
+        resp = await tool.handle_request(
+            SearchRequest(
+                action=SearchAction.grep,
+                pattern="SECRET",
+                path=str(base_b / "ws"),
+            )
+        )
+        assert resp.success is False
+        assert "outside" in (resp.error or "").lower()
+
+        # And path="." must still resolve to the frozen a/ws, not b/ws.
+        resolved, err = _validate_search_path(".", tool._workspace_root)
+        assert err is None
+        assert resolved == str((base_a / "ws").resolve())
+        assert os.path.isabs(tool._workspace_root)


### PR DESCRIPTION
**Fail-closed path & exec boundaries** across tools/ln/libs:

- `SearchTool` workspace containment (root frozen at construction, no cwd drift)
- coding/bash/editor/reader/sandbox path guards
- `ln/_utils` path-traversal guard
- schema-loader `exec` boundary
---
Part of the sliced **audit-remediation** series (replaces the monolithic #1276). Each slice is file-disjoint and cut from `main`. Full integration branch: `chore/audit-remediation` (7670 tests green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
