### PR TITLE
fix(state,cli,studio,engines,outcomes,hooks): status history, artifact auth, input validation

### DIFF
--- a/lionagi/cli/_agents.py
+++ b/lionagi/cli/_agents.py
@@ -34,9 +34,32 @@ Frontmatter fields (all optional, CLI flags override):
 
 from __future__ import annotations
 
+import re as _re
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
+
+# Bare-name pattern: one or more ASCII letters, digits, underscores, or hyphens.
+# Rejects empty, path separators, '.', '..', leading dots, and other traversal.
+_BARE_NAME_RE = _re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def _validate_bare_name(name: str) -> None:
+    """Reject agent profile names that are not safe bare identifiers.
+
+    A valid name contains only ASCII letters, digits, underscores, or hyphens.
+    Path separators, '.', '..', leading dots, and control characters are all
+    rejected to prevent path traversal in profile resolution.
+
+    Raises:
+        ValueError: The name contains unsafe characters or components.
+    """
+    if not name or not _BARE_NAME_RE.match(name):
+        raise ValueError(
+            f"Invalid agent profile name {name!r}: must be a bare identifier "
+            "(ASCII letters, digits, underscores, hyphens only — no path "
+            "separators, '.', '..', or leading dots)."
+        )
 
 
 def build_deadline_preamble(timeout_seconds: int) -> str:
@@ -172,7 +195,9 @@ def load_agent_profile(name: str) -> AgentProfile:
     Searches project-local .lionagi/agents/ first, then ~/.lionagi/agents/.
     Resolves directory layout (<name>/<name>.md) before flat (<name>.md).
     Raises FileNotFoundError if not found in any location.
+    Raises ValueError if name contains path separators or traversal components.
     """
+    _validate_bare_name(name)
     dirs = _find_lionagi_dirs()
     if not dirs:
         raise FileNotFoundError(

--- a/lionagi/cli/_project.py
+++ b/lionagi/cli/_project.py
@@ -59,15 +59,25 @@ def _from_config_toml(cwd: Path) -> tuple[str | None, str | None]:
 
 
 def _read_project_from_toml(path: Path) -> str | None:
-    """Parse [project].name from a TOML file without tomllib on < 3.11."""
-    try:
-        import tomllib
-    except ModuleNotFoundError:
-        import tomli as tomllib  # type: ignore[no-redef]
+    """Parse [project].name from a TOML file.
 
+    Uses stdlib ``tomllib`` on Python 3.11+; falls back to the declared
+    ``toml`` runtime dependency on Python 3.10.  ``tomli`` is NOT a
+    declared dependency and must not be imported here.
+    """
     try:
-        with open(path, "rb") as f:
-            data = tomllib.load(f)
+        try:
+            import tomllib
+
+            with open(path, "rb") as f:
+                data = tomllib.load(f)
+        except ModuleNotFoundError:
+            # Python 3.10: use the declared `toml` dependency (pyproject.toml
+            # declares toml>=0.10.2).  `toml.load` accepts a text-mode file.
+            import toml  # type: ignore[import-untyped]
+
+            with open(path) as f:
+                data = toml.load(f)
         project = data.get("project", {})
         if isinstance(project, dict):
             name = project.get("name")
@@ -77,9 +87,7 @@ def _read_project_from_toml(path: Path) -> str | None:
     return None
 
 
-def _from_global_overrides(
-    cwd: Path, remote_slug: str | None
-) -> tuple[str | None, str | None]:
+def _from_global_overrides(cwd: Path, remote_slug: str | None) -> tuple[str | None, str | None]:
     """Check ~/.lionagi/settings.yaml project_overrides."""
     global_path = Path.home() / ".lionagi" / "settings.yaml"
     if not global_path.is_file():

--- a/lionagi/cli/kill.py
+++ b/lionagi/cli/kill.py
@@ -306,7 +306,7 @@ async def _persist_cancel(
         reason_code=reason_code,
         reason_summary=reason_summary,
         evidence_refs=[evidence],
-        source="cli",
+        source="admin",  # CLI kill is an operator/admin action (ADR-0028 source vocabulary)
         actor="user",
     )
 

--- a/lionagi/cli/studio.py
+++ b/lionagi/cli/studio.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 import argparse

--- a/lionagi/engines/engine.py
+++ b/lionagi/engines/engine.py
@@ -182,9 +182,31 @@ class EngineRun:
             task.add_done_callback(self._active.discard)
 
     async def wait_quiescence(self) -> None:
-        """Block until no spawned task remains (the termination condition)."""
+        """Block until no spawned task remains and surface any task failures.
+
+        Non-cancellation exceptions from spawned tasks are collected and
+        re-raised as a single ``ExceptionGroup`` (Python 3.11+) or the first
+        exception on 3.10, so callers are never silently missing failed nodes.
+        CancelledError from individual tasks is silently discarded — the whole
+        run is not cancelled when a single exploration branch is cancelled.
+        """
         while self._active:
-            await asyncio.gather(*list(self._active), return_exceptions=True)
+            results = await asyncio.gather(*list(self._active), return_exceptions=True)
+            task_errors = [
+                r
+                for r in results
+                if isinstance(r, BaseException) and not isinstance(r, asyncio.CancelledError)
+            ]
+            if task_errors:
+                for exc in task_errors:
+                    logger.error("engine spawned task failed: %s", exc)
+                # Re-raise: ExceptionGroup on 3.11+, first exception on 3.10.
+                import sys
+
+                if sys.version_info >= (3, 11):
+                    raise ExceptionGroup("engine spawned task(s) failed", task_errors)  # type: ignore[name-defined]  # noqa: F821
+                else:
+                    raise task_errors[0] from None
 
     # -- team loop ------------------------------------------------------------
 

--- a/lionagi/engines/engine.py
+++ b/lionagi/engines/engine.py
@@ -182,31 +182,36 @@ class EngineRun:
             task.add_done_callback(self._active.discard)
 
     async def wait_quiescence(self) -> None:
-        """Block until no spawned task remains and surface any task failures.
+        """Block until no spawned task remains, then surface any task failures.
 
-        Non-cancellation exceptions from spawned tasks are collected and
-        re-raised as a single ``ExceptionGroup`` (Python 3.11+) or the first
-        exception on 3.10, so callers are never silently missing failed nodes.
+        Drains the *entire* in-flight set before returning or raising — including
+        tasks that a spawned task itself spawns while we wait (a parent may fail
+        after scheduling a child). Errors are accumulated across every drain pass
+        and only re-raised once ``_active`` is empty, so a failed task can never
+        short-circuit the wait and leave its children running in the background.
+        Non-cancellation exceptions are re-raised together as an
+        ``ExceptionGroup`` (Python 3.11+) or the first exception on 3.10.
         CancelledError from individual tasks is silently discarded — the whole
         run is not cancelled when a single exploration branch is cancelled.
         """
+        task_errors: list[BaseException] = []
         while self._active:
             results = await asyncio.gather(*list(self._active), return_exceptions=True)
-            task_errors = [
+            task_errors.extend(
                 r
                 for r in results
                 if isinstance(r, BaseException) and not isinstance(r, asyncio.CancelledError)
-            ]
-            if task_errors:
-                for exc in task_errors:
-                    logger.error("engine spawned task failed: %s", exc)
-                # Re-raise: ExceptionGroup on 3.11+, first exception on 3.10.
-                import sys
+            )
+        if task_errors:
+            for exc in task_errors:
+                logger.error("engine spawned task failed: %s", exc)
+            # Re-raise: ExceptionGroup on 3.11+, first exception on 3.10.
+            import sys
 
-                if sys.version_info >= (3, 11):
-                    raise ExceptionGroup("engine spawned task(s) failed", task_errors)  # type: ignore[name-defined]  # noqa: F821
-                else:
-                    raise task_errors[0] from None
+            if sys.version_info >= (3, 11):
+                raise ExceptionGroup("engine spawned task(s) failed", task_errors)  # type: ignore[name-defined]  # noqa: F821
+            else:
+                raise task_errors[0] from None
 
     # -- team loop ------------------------------------------------------------
 

--- a/lionagi/hooks/__init__.py
+++ b/lionagi/hooks/__init__.py
@@ -24,6 +24,8 @@ ordered/blocking dispatch *discipline* over the observer's single event
 *transport*, not a parallel bus.
 """
 
+from __future__ import annotations
+
 from .bus import HookBus, HookPoint, HookSignal, StopHook, hook
 from .loader import (
     DEFAULT_HOOKS,

--- a/lionagi/hooks/builtins.py
+++ b/lionagi/hooks/builtins.py
@@ -22,6 +22,15 @@ from typing import Any
 
 logger = logging.getLogger("lionagi.hooks.builtins")
 
+__all__ = (
+    "persist_session_start",
+    "persist_session_end",
+    "persist_branch_provenance",
+    "persist_message",
+    "log_api_metrics",
+    "log_tool_use",
+)
+
 
 async def persist_session_start(
     *,

--- a/lionagi/hooks/builtins.py
+++ b/lionagi/hooks/builtins.py
@@ -45,10 +45,17 @@ async def persist_session_start(
 ) -> None:
     """Write the ADR-0022 provenance set + open the lifecycle window."""
     from lionagi.state.db import StateDB
+    from lionagi.state.reasons import RunReasons
 
     async with StateDB() as db:
         await db.update_session(
             session_id,
+            # status="running" routes through update_status(), which requires
+            # a reason_code — pass it explicitly so the transition records a
+            # canonical "started" cause instead of tripping the deprecation
+            # shim (which would raise on the running status and be swallowed by
+            # the bus, silently dropping all the provenance fields above).
+            reason_code=RunReasons.STARTED_OK,
             model=model,
             provider=provider,
             effort=effort,

--- a/lionagi/hooks/bus.py
+++ b/lionagi/hooks/bus.py
@@ -38,6 +38,15 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("lionagi.hooks")
 
+__all__ = (
+    "HookPoint",
+    "HookBus",
+    "HookSignal",
+    "HookHandler",
+    "StopHook",
+    "hook",
+)
+
 
 class HookPoint(str, Enum):
     """ADR-0023 §"Event payloads" — closed vocabulary of hook points."""
@@ -66,7 +75,12 @@ class HookPoint(str, Enum):
     ARTIFACT_CREATED = "artifact.created"
 
 
-HookHandler = Callable[..., Awaitable[Any]]
+# HookHandler accepts both sync and async callables.  The bus calls the
+# handler and awaits the result only if inspect.isawaitable() returns True
+# (see HookBus.emit).  The type reflects the actual contract; narrowing to
+# Awaitable[Any] only would produce false type errors for sync handlers that
+# are tested and supported.
+HookHandler = Callable[..., Awaitable[Any] | Any]
 
 
 class StopHook(Exception):  # noqa: N818 — control-flow signal, not an error

--- a/lionagi/hooks/loader.py
+++ b/lionagi/hooks/loader.py
@@ -33,6 +33,14 @@ from .bus import HookBus, HookHandler, HookPoint
 
 logger = logging.getLogger("lionagi.hooks.loader")
 
+__all__ = (
+    "DEFAULT_HOOKS",
+    "register_handler",
+    "resolve_handler",
+    "load_hooks_for_agent",
+    "build_session_bus",
+)
+
 # Default wiring per ADR-0023 §"Default hooks (no configuration needed)".
 DEFAULT_HOOKS: dict[HookPoint, list[HookHandler]] = {
     HookPoint.SESSION_START: [_builtins.persist_session_start],

--- a/lionagi/hooks/persist.py
+++ b/lionagi/hooks/persist.py
@@ -21,6 +21,11 @@ from typing import Any
 
 from .bus import HookHandler, HookPoint
 
+__all__ = (
+    "route_message_persistence",
+    "unroute_message_persistence",
+)
+
 
 def route_message_persistence(
     session: Any,

--- a/lionagi/outcomes/__init__.py
+++ b/lionagi/outcomes/__init__.py
@@ -13,14 +13,16 @@ separation is deliberate so a future Studio-only consumer can import
 outcomes without pulling in framework machinery.
 """
 
+from __future__ import annotations
+
 from ._base import SkillOutcome
 from .ci import CIResult
 from .verdict import Finding, GateVerdict, ReviewVerdict
 
-__all__ = [
+__all__ = (
     "SkillOutcome",
     "ReviewVerdict",
     "GateVerdict",
     "Finding",
     "CIResult",
-]
+)

--- a/lionagi/outcomes/verdict.py
+++ b/lionagi/outcomes/verdict.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import Field, field_validator
+from pydantic import Field, field_validator, model_validator
 
 from lionagi.models import HashableModel
 
@@ -37,6 +37,7 @@ class Finding(HashableModel):
     )
     line: int | None = Field(
         default=None,
+        ge=1,
         description="1-indexed line number when known.",
     )
     description: str = Field(
@@ -45,10 +46,29 @@ class Finding(HashableModel):
     suggestion: str | None = Field(
         default=None,
         description=(
-            "Concrete fix the reviewer recommends. None when the finding "
-            "is informational only."
+            "Concrete fix the reviewer recommends. None when the finding is informational only."
         ),
     )
+
+    @field_validator("file", mode="before")
+    @classmethod
+    def _validate_file(cls, v: object) -> object:
+        """Reject absolute paths and parent-traversal components."""
+        if v is None:
+            return v
+        if not isinstance(v, str):
+            return v
+        # Reject absolute paths (Unix and Windows).
+        if v.startswith("/") or (len(v) >= 2 and v[1] == ":"):
+            raise ValueError(f"Finding.file must be a repo-relative path, not absolute: {v!r}")
+        # Reject any component that is '..' (traversal).
+        parts = v.replace("\\", "/").split("/")
+        if any(p == ".." for p in parts):
+            raise ValueError(f"Finding.file must not contain parent-traversal components: {v!r}")
+        # Reject NUL bytes (path injection).
+        if "\x00" in v:
+            raise ValueError("Finding.file must not contain NUL bytes.")
+        return v
 
 
 VerdictDecision = Literal[
@@ -78,6 +98,7 @@ class ReviewVerdict(SkillOutcome):
         if isinstance(v, str):
             return v.replace("-", "_").replace(" ", "_")
         return v
+
     findings: list[Finding] = Field(
         default_factory=list,
         description="Findings list — blocking-first ordering is the writer's responsibility.",
@@ -107,3 +128,19 @@ class GateVerdict(SkillOutcome):
         default=None,
         description="Operator notes (free text). Often empty; rendered when present.",
     )
+
+    @model_validator(mode="after")
+    def _sync_passed(self) -> GateVerdict:
+        """Keep SkillOutcome.passed consistent with gate_passed.
+
+        - When ``passed`` is omitted (None), default it to ``gate_passed``.
+        - When both are supplied, they must agree (no contradictory state).
+        """
+        if self.passed is None:
+            self.passed = self.gate_passed
+        elif self.passed != self.gate_passed:
+            raise ValueError(
+                f"GateVerdict.gate_passed ({self.gate_passed}) and "
+                f".passed ({self.passed}) must be the same value."
+            )
+        return self

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -89,6 +89,9 @@ def _default_reason_code_for_status(status: str) -> str:
 _SCHEMA_PATH = Path(__file__).parent / "schema.sql"
 DEFAULT_DB_PATH = LIONAGI_HOME / "state.db"
 
+# ADR-0028: closed vocabulary for transition-history ``source`` column.
+_VALID_STATUS_SOURCES: frozenset[str] = frozenset({"executor", "agent", "admin", "system"})
+
 _SESSION_COLUMNS = frozenset(
     {
         "name",
@@ -775,7 +778,7 @@ class StateDB:
             adr="ADR-0012",
         )
         now = time.time()
-        await self.db.execute(
+        cur = await self.db.execute(
             """INSERT OR IGNORE INTO sessions (id, created_at, node_metadata, name, user,
                progression_id, first_msg_id, last_msg_id, updated_at,
                playbook_name, agent_name, invocation_kind, show_topic,
@@ -831,8 +834,11 @@ class StateDB:
             ),
         )
         # ADR-0020: keep invocations.session_count in sync so list queries
-        # don't need a JOIN.
-        if session.get("invocation_id"):
+        # don't need a JOIN.  Only increment when the INSERT actually created
+        # a row (rowcount == 0 means INSERT OR IGNORE was a no-op — duplicate
+        # id).  This prevents retries or idempotent replays from inflating the
+        # count beyond the actual number of distinct sessions.
+        if session.get("invocation_id") and cur.rowcount:
             await self.db.execute(
                 "UPDATE invocations SET session_count = session_count + 1, "
                 "updated_at = ? WHERE id = ?",
@@ -871,10 +877,33 @@ class StateDB:
         )
         await self.db.commit()
 
-    async def update_session(self, session_id: str, **fields: Any) -> None:
+    async def update_session(
+        self,
+        session_id: str,
+        *,
+        reason_code: str | None = None,
+        reason_summary: str = "",
+        evidence_refs: list[dict[str, Any]] | None = None,
+        reason_source: str = "executor",
+        reason_actor: str | None = None,
+        **fields: Any,
+    ) -> None:
+        """Update session fields; route status changes through update_status().
+
+        ADR-0028: when ``status`` is among the updated fields, the transition
+        goes through :meth:`update_status` so the denormalized reason columns
+        and ``status_transitions`` history row are written atomically.
+
+        Pass ``reason_code`` (required when status is in fields) plus optional
+        ``reason_summary`` / ``evidence_refs`` / ``reason_source`` /
+        ``reason_actor`` to control the transition record.  Non-status fields
+        are written by the legacy UPDATE path below (separate transaction).
+
+        Backwards compatibility: callers that pass ``status`` without a
+        ``reason_code`` get a deprecation warning + a default code derived
+        from the status.  Remove the fallback in a future release.
+        """
         _validate_columns(fields, _SESSION_COLUMNS)
-        if "status" in fields:
-            _validate_session_status(fields["status"])
         if "invocation_kind" in fields:
             _validate_enum(
                 "invocation_kind",
@@ -889,15 +918,53 @@ class StateDB:
                 _SOURCE_KINDS,
                 adr="ADR-0012",
             )
-        fields["updated_at"] = time.time()
-        sets = ", ".join(f"{k} = ?" for k in fields)
-        vals = list(fields.values()) + [session_id]
-        # noqa: S608 — column names allowlisted via _validate_columns
-        await self.db.execute(
-            f"UPDATE sessions SET {sets} WHERE id = ?",  # noqa: S608
-            vals,
-        )
-        await self.db.commit()
+
+        status_value = fields.pop("status", None)
+        if status_value is not None:
+            _validate_session_status(status_value)
+            if reason_code is None:
+                from warnings import warn
+
+                resolved = _default_reason_code_for_entity_status("session", status_value)
+                if resolved is None:
+                    raise ValueError(
+                        f"update_session() called with status={status_value!r} but "
+                        f"no canonical default reason_code exists for "
+                        f"(session, {status_value!r}). Pass reason_code "
+                        f"explicitly from lionagi/state/reasons.py."
+                    )
+                reason_code = resolved
+                warn(
+                    f"update_session({session_id!r}, status={status_value!r}) "
+                    "called without reason_code; defaulting to "
+                    f"{reason_code!r}. Pass reason_code explicitly "
+                    "(ADR-0028 Phase 2 deprecation).",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+            await self.update_status(
+                "session",
+                session_id,
+                new_status=status_value,
+                reason_code=reason_code,
+                reason_summary=reason_summary,
+                evidence_refs=evidence_refs,
+                source=reason_source,
+                actor=reason_actor,
+            )
+
+        # Remaining (non-status) fields go through the legacy update path
+        # in a separate write — update_status() already touched updated_at.
+        if fields:
+            fields["updated_at"] = time.time()
+            sets = ", ".join(f"{k} = ?" for k in fields)
+            vals = list(fields.values()) + [session_id]
+            # noqa: S608 — column names allowlisted via _validate_columns
+            await self.db.execute(
+                f"UPDATE sessions SET {sets} WHERE id = ?",  # noqa: S608
+                vals,
+            )
+            await self.db.commit()
 
     async def update_artifact_verification(
         self,
@@ -963,10 +1030,15 @@ class StateDB:
 
         Raises:
             ValueError: ``reason_code`` not in
-                :data:`VALID_REASON_CODES`, or ``entity_type`` not
-                recognized.
+                :data:`VALID_REASON_CODES`, ``entity_type`` not recognized,
+                or ``source`` not in the closed vocabulary.
             LookupError: Entity row not found.
         """
+        if source not in _VALID_STATUS_SOURCES:
+            raise ValueError(
+                f"update_status() called with source={source!r}; "
+                f"must be one of {sorted(_VALID_STATUS_SOURCES)}."
+            )
         canonical_type = _validate_entity_type_for_reason(entity_type)
         _validate_reason_code(reason_code)
         table = _reason_entity_table(canonical_type)

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -40,6 +40,7 @@ from lionagi.state.reasons import (
 # for (entity, status) pairs without a canonical default, forcing the
 # caller to surface a clear error instead of synthesizing nonsense.
 _RUN_DEFAULTS: dict[str, str] = {
+    "running": _RunReasons.STARTED_OK,
     "completed": _RunReasons.COMPLETED_OK,
     "failed": _RunReasons.FAILED_EXCEPTION,
     "timed_out": _RunReasons.TIMED_OUT_DEADLINE,

--- a/lionagi/state/reasons.py
+++ b/lionagi/state/reasons.py
@@ -66,6 +66,7 @@ LEGACY_IMPORTED: Final[str] = "legacy.imported"
 class RunReasons:
     """Outcomes of session execution (the CLI teardown's view)."""
 
+    STARTED_OK = "run.started.ok"
     COMPLETED_OK = "run.completed.ok"
     FAILED_EXIT_NONZERO = "run.failed.exit_nonzero"
     FAILED_EXCEPTION = "run.failed.exception"

--- a/lionagi/studio/app.py
+++ b/lionagi/studio/app.py
@@ -29,6 +29,12 @@ from .services import stats as stats_svc
 
 _MUTATING_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 
+# API route prefixes whose GET responses contain agent-produced content that
+# must be protected when a bearer token is configured.  The /api/admin/* and
+# /api/artifacts/* surfaces are the two concrete cases identified in
+# LIONAGI-AUDIT-001 (studio-standards 2026-06-06).
+_PROTECTED_GET_PREFIXES = ("/api/admin/", "/api/artifacts")
+
 
 @asynccontextmanager
 async def lifespan(app_instance):
@@ -54,8 +60,8 @@ async def require_studio_bearer_token(request: Request, call_next):
     token = os.getenv("LIONAGI_STUDIO_AUTH_TOKEN")
     path = request.url.path
     if token and request.headers.get("authorization") != f"Bearer {token}":
-        # Gate ALL methods on /api/admin/* — GET endpoints must not bypass auth.
-        if path.startswith("/api/admin/"):
+        # Gate all methods on protected GET prefixes (admin, artifacts).
+        if any(path.startswith(pfx) for pfx in _PROTECTED_GET_PREFIXES):
             return JSONResponse({"detail": "Unauthorized"}, status_code=401)
         # Gate mutating methods on all other /api/* routes.
         if path.startswith("/api") and request.method in _MUTATING_METHODS:

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -402,8 +402,72 @@ class SchedulerEngine:
                 }
             )
 
-        # Build argv
-        argv = build_argv(schedule, trigger_context)
+        # Build argv. A build failure (e.g. an invalid action_kind that slipped
+        # past the Studio API, which only checks presence) must be recorded
+        # deterministically: the invocation already exists as `running` and no
+        # schedule_run row exists yet, so the generic handler below would call
+        # update_status() on a missing row (LookupError) and leave the
+        # invocation stuck `running`. Record a failed run + fail the invocation
+        # here, advance next_fire so it doesn't re-fire the bad schedule every
+        # tick, and return.
+        try:
+            argv = build_argv(schedule, trigger_context)
+        except Exception as exc:
+            _log.exception(
+                "Invalid schedule action for %s (run %s)", schedule.get("name"), run_id
+            )
+            _end_time = time.time()
+            next_at = self._compute_next_fire(schedule, now)
+            async with StateDB() as db:
+                await db.create_schedule_run(
+                    {
+                        "id": run_id,
+                        "schedule_id": sid,
+                        "invocation_id": inv_id,
+                        "trigger_context": trigger_context,
+                        "action_kind": schedule.get("action_kind"),
+                        "action_args": [],
+                        "status": "failed",
+                        "chain_parent_id": chain_parent_id,
+                        "chain_depth": chain_depth,
+                        "fired_at": now,
+                        "ended_at": _end_time,
+                        "error_detail": str(exc),
+                    }
+                )
+                await db.update_status(
+                    "schedule_run",
+                    run_id,
+                    new_status="failed",
+                    reason_code=RunReasons.FAILED_EXCEPTION,
+                    reason_summary=f"{type(exc).__name__}: {exc}",
+                    evidence_refs=[{"kind": "schedule", "id": sid}],
+                    source="executor",
+                    actor=run_id,
+                    metadata={"exception_class": type(exc).__name__},
+                )
+                inv_status, inv_rc, inv_rs, inv_ev, inv_meta = (
+                    await _resolve_invocation_terminal(
+                        db, inv_id, fallback_status="failed", exception=exc
+                    )
+                )
+                await db.update_invocation(inv_id, ended_at=_end_time)
+                await db.update_status(
+                    "invocation",
+                    inv_id,
+                    new_status=inv_status,
+                    reason_code=inv_rc,
+                    reason_summary=inv_rs,
+                    evidence_refs=inv_ev,
+                    source="executor",
+                    actor=inv_id,
+                    metadata=inv_meta,
+                )
+                update_fields: dict[str, Any] = {"last_fired_at": now}
+                if next_at:
+                    update_fields["next_fire_at"] = next_at
+                await db.update_schedule(sid, **update_fields)
+            return
 
         # Create schedule_run
         async with StateDB() as db:
@@ -534,6 +598,47 @@ class SchedulerEngine:
                         chain_depth=chain_depth + 1,
                     )
 
+        except asyncio.CancelledError:
+            # Scheduler shutdown (stop() cancels outstanding fire tasks).
+            # spawn_and_wait has already terminated the child; record the run
+            # and invocation as cancelled so they don't linger as `running`,
+            # then re-raise to honour cooperative cancellation.
+            _log.info("Schedule fire cancelled %s (run %s)", schedule.get("name"), run_id)
+            _end_time = time.time()
+            try:
+                async with StateDB() as db:
+                    await db.update_schedule_run(
+                        run_id,
+                        ended_at=_end_time,
+                        error_detail="Scheduler shutdown",
+                        reason_code=RunReasons.CANCELLED_SYSTEM,
+                        status="cancelled",
+                        reason_summary="Schedule run cancelled by scheduler shutdown.",
+                        evidence_refs=[{"kind": "schedule", "id": sid}],
+                        reason_actor=run_id,
+                    )
+                    inv_status, inv_rc, inv_rs, inv_ev, inv_meta = (
+                        await _resolve_invocation_terminal(
+                            db, inv_id, fallback_status="cancelled"
+                        )
+                    )
+                    await db.update_invocation(inv_id, ended_at=_end_time)
+                    await db.update_status(
+                        "invocation",
+                        inv_id,
+                        new_status=inv_status,
+                        reason_code=inv_rc,
+                        reason_summary=inv_rs,
+                        evidence_refs=inv_ev,
+                        source="executor",
+                        actor=inv_id,
+                        metadata=inv_meta,
+                    )
+            except Exception:
+                _log.exception(
+                    "Failed to record cancellation for run %s during shutdown", run_id
+                )
+            raise
         except Exception as exc:
             _log.exception("Error in schedule fire %s (run %s)", schedule.get("name"), run_id)
             _end_time = time.time()

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -147,6 +147,9 @@ class SchedulerEngine:
         self._task: asyncio.Task | None = None
         self._running: dict[str, str] = {}  # schedule_id -> run_id
         self._stopping = False
+        # Tracks outstanding _fire tasks so stop() can cancel and await them,
+        # preventing fire-and-forget orphans after shutdown (LIONAGI-AUDIT-002).
+        self._fire_tasks: set[asyncio.Task] = set()
 
     async def start(self) -> None:
         _log.info("Scheduler engine starting")
@@ -163,6 +166,24 @@ class SchedulerEngine:
             except asyncio.CancelledError:
                 pass
             self._task = None
+        # Cancel and await all outstanding fire tasks so subprocess spawns
+        # do not outlive the scheduler (LIONAGI-AUDIT-002 fix).
+        if self._fire_tasks:
+            for ft in list(self._fire_tasks):
+                ft.cancel()
+            await asyncio.gather(*self._fire_tasks, return_exceptions=True)
+            self._fire_tasks.clear()
+
+    def _tracked_fire(self, *args: Any, **kwargs: Any) -> asyncio.Task:
+        """Create a _fire task and keep a reference until it completes.
+
+        Prevents fire-and-forget orphan tasks from surviving scheduler shutdown.
+        The done callback removes the handle from the tracking set automatically.
+        """
+        task = asyncio.create_task(self._fire(*args, **kwargs))
+        self._fire_tasks.add(task)
+        task.add_done_callback(self._fire_tasks.discard)
+        return task
 
     async def fire_now(self, schedule_id: str) -> str | None:
         """Manual trigger — fire a schedule immediately. Returns run_id."""
@@ -171,8 +192,8 @@ class SchedulerEngine:
         if not schedule:
             return None
         run_id = uuid.uuid4().hex[:12]
-        asyncio.create_task(
-            self._fire(schedule, run_id, trigger_context={"manual": True, "fired_at": time.time()})
+        self._tracked_fire(
+            schedule, run_id, trigger_context={"manual": True, "fired_at": time.time()}
         )
         return run_id
 
@@ -205,12 +226,10 @@ class SchedulerEngine:
                         s["name"],
                         s["id"],
                     )
-                    asyncio.create_task(
-                        self._fire(
-                            s,
-                            run_id,
-                            trigger_context={"missed_recovery": True, "fired_at": now},
-                        )
+                    self._tracked_fire(
+                        s,
+                        run_id,
+                        trigger_context={"missed_recovery": True, "fired_at": now},
                     )
                 else:
                     # policy in {"skip", default}: drop the missed fire,
@@ -353,7 +372,7 @@ class SchedulerEngine:
 
         run_id = uuid.uuid4().hex[:12]
         ctx = {"scheduled": True, "fired_at": now, "next_fire_at": schedule.get("next_fire_at")}
-        asyncio.create_task(self._fire(schedule, run_id, trigger_context=ctx))
+        self._tracked_fire(schedule, run_id, trigger_context=ctx)
 
     async def _fire(
         self,

--- a/lionagi/studio/scheduler/subprocess.py
+++ b/lionagi/studio/scheduler/subprocess.py
@@ -9,6 +9,7 @@ import contextlib
 import logging
 import os
 import re
+import signal
 
 _log = logging.getLogger(__name__)
 
@@ -89,20 +90,39 @@ async def spawn_and_wait(argv: list[str], invocation_id: str) -> tuple[int, str]
         stdout=asyncio.subprocess.DEVNULL,
         stderr=asyncio.subprocess.PIPE,
         env=env,
+        # `uv run li` forks the real worker (and that worker may fork
+        # further). Put the whole tree in its own session/process group so a
+        # cancel can signal the GROUP, not just the direct child — otherwise
+        # grandchildren survive scheduler shutdown as orphans.
+        start_new_session=True,
+    )
+    # Capture the pgid NOW — once the child exits and is reaped,
+    # os.getpgid(proc.pid) raises ProcessLookupError and we'd skip the group
+    # kill. start_new_session=True makes pgid == proc.pid. Guard mocked pids
+    # in tests: a MagicMock.pid coerces to 1, and killpg(1, …) hits init.
+    _pgid: int | None = (
+        proc.pid if isinstance(proc.pid, int) and proc.pid > 1 else None
     )
 
     try:
         _, stderr = await proc.communicate()
     except asyncio.CancelledError:
         # Cancellation (e.g. scheduler shutdown) must not leave the spawned
-        # `uv run li` child detached. Terminate it, give it a moment to exit,
-        # then kill, before re-raising so the caller can record the cancel.
+        # `uv run li` tree detached. SIGTERM the whole group, give it a moment
+        # to exit, then SIGKILL the group, before re-raising so the caller can
+        # record the cancel.
         _log.warning("spawn_and_wait cancelled; terminating child for %s", invocation_id)
+        if _pgid is not None:
+            with contextlib.suppress(ProcessLookupError, PermissionError):
+                os.killpg(_pgid, signal.SIGTERM)
         with contextlib.suppress(ProcessLookupError):
             proc.terminate()
         try:
             await asyncio.wait_for(proc.wait(), timeout=5)
         except (TimeoutError, asyncio.TimeoutError):
+            if _pgid is not None:
+                with contextlib.suppress(ProcessLookupError, PermissionError):
+                    os.killpg(_pgid, signal.SIGKILL)
             with contextlib.suppress(ProcessLookupError):
                 proc.kill()
             with contextlib.suppress(Exception):

--- a/lionagi/studio/scheduler/subprocess.py
+++ b/lionagi/studio/scheduler/subprocess.py
@@ -13,6 +13,11 @@ _log = logging.getLogger(__name__)
 
 _TEMPLATE_RE = re.compile(r"\{\{(\w+)\}\}")
 
+# ADR-0027 defines the closed set of action kinds.  The CLI parser accepts
+# "playbook" as an alias for "play" for backward compatibility.
+_VALID_ACTION_KINDS = frozenset({"agent", "flow", "fanout", "play"})
+_ALIAS_ACTION_KINDS: dict[str, str] = {"playbook": "play"}
+
 
 def _render_template(template: str, context: dict) -> str:
     """Replace {{var}} placeholders with values from trigger context."""
@@ -32,6 +37,12 @@ def _render_template(template: str, context: dict) -> str:
 
 def build_argv(schedule: dict, trigger_context: dict) -> list[str]:
     kind = schedule["action_kind"]
+    # Normalize legacy alias and validate against the closed set (LIONAGI-AUDIT-003).
+    kind = _ALIAS_ACTION_KINDS.get(kind, kind)
+    if kind not in _VALID_ACTION_KINDS:
+        raise ValueError(
+            f"Unknown action_kind {kind!r}. Valid kinds: {sorted(_VALID_ACTION_KINDS)}"
+        )
     model = schedule.get("action_model") or ""
     prompt = schedule.get("action_prompt") or ""
     agent = schedule.get("action_agent")

--- a/lionagi/studio/scheduler/subprocess.py
+++ b/lionagi/studio/scheduler/subprocess.py
@@ -100,8 +100,13 @@ async def spawn_and_wait(argv: list[str], invocation_id: str) -> tuple[int, str]
     # os.getpgid(proc.pid) raises ProcessLookupError and we'd skip the group
     # kill. start_new_session=True makes pgid == proc.pid. Guard mocked pids
     # in tests: a MagicMock.pid coerces to 1, and killpg(1, …) hits init.
+    # os.killpg is POSIX-only: on Windows leave _pgid None so the group-kill
+    # path is skipped and cleanup falls through to proc.terminate()/kill()
+    # instead of raising AttributeError.
     _pgid: int | None = (
-        proc.pid if isinstance(proc.pid, int) and proc.pid > 1 else None
+        proc.pid
+        if hasattr(os, "killpg") and isinstance(proc.pid, int) and proc.pid > 1
+        else None
     )
 
     try:

--- a/lionagi/studio/scheduler/subprocess.py
+++ b/lionagi/studio/scheduler/subprocess.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import os
 import re
@@ -90,7 +91,24 @@ async def spawn_and_wait(argv: list[str], invocation_id: str) -> tuple[int, str]
         env=env,
     )
 
-    _, stderr = await proc.communicate()
+    try:
+        _, stderr = await proc.communicate()
+    except asyncio.CancelledError:
+        # Cancellation (e.g. scheduler shutdown) must not leave the spawned
+        # `uv run li` child detached. Terminate it, give it a moment to exit,
+        # then kill, before re-raising so the caller can record the cancel.
+        _log.warning("spawn_and_wait cancelled; terminating child for %s", invocation_id)
+        with contextlib.suppress(ProcessLookupError):
+            proc.terminate()
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=5)
+        except (TimeoutError, asyncio.TimeoutError):
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
+            with contextlib.suppress(Exception):
+                await proc.wait()
+        raise
+
     exit_code = proc.returncode or 0
     stderr_tail = (stderr[-2048:] if stderr else b"").decode(errors="replace")
 

--- a/tests/apps_studio_server/test_audit_remediation.py
+++ b/tests/apps_studio_server/test_audit_remediation.py
@@ -379,6 +379,47 @@ class TestSpawnAndWaitCancellation:
         assert killpg_calls, "the process GROUP must be signalled, not just the child"
         assert killpg_calls[0] == (proc.pid, sp.signal.SIGTERM)
 
+    async def test_cancel_no_killpg_platform(self, monkeypatch):
+        """os.killpg is POSIX-only: on Windows cancellation must still terminate
+        the direct child, not raise AttributeError from the cancel handler
+        (which only suppresses ProcessLookupError/PermissionError)."""
+        from lionagi.studio.scheduler import subprocess as sp
+
+        class _FakeProc:
+            def __init__(self):
+                self.pid = 424243
+                self.terminated = False
+
+            async def communicate(self):
+                await asyncio.Event().wait()
+
+            def terminate(self):
+                self.terminated = True
+
+            def kill(self):
+                pass
+
+            async def wait(self):
+                return -15
+
+        proc = _FakeProc()
+
+        async def fake_exec(*a, **k):
+            return proc
+
+        monkeypatch.setattr(sp.asyncio, "create_subprocess_exec", fake_exec)
+        # Simulate Windows: os.killpg does not exist.
+        monkeypatch.delattr(sp.os, "killpg", raising=False)
+
+        task = asyncio.create_task(sp.spawn_and_wait(["sleep", "30"], "inv-2"))
+        for _ in range(5):
+            await asyncio.sleep(0)
+        task.cancel()
+        # Must surface CancelledError, NOT AttributeError.
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert proc.terminated is True, "child must be terminated even without killpg"
+
 
 class TestFireCancellationRecorded:
     """Codex #1283 P1: when stop() cancels an in-flight _fire, the run and

--- a/tests/apps_studio_server/test_audit_remediation.py
+++ b/tests/apps_studio_server/test_audit_remediation.py
@@ -267,3 +267,135 @@ class TestBuildArgvValidation:
 
         with pytest.raises(ValueError, match="Unknown action_kind"):
             build_argv({"action_kind": ""}, {})
+
+
+# ---------------------------------------------------------------------------
+# Codex #1283 — orphaned subprocess on cancel + invalid-kind run recording
+# ---------------------------------------------------------------------------
+
+
+def _interval_schedule(**over):
+    s = {
+        "id": "sched-x",
+        "name": "test-sched",
+        "trigger_type": "interval",
+        "interval_sec": 60,
+        "action_kind": "agent",
+        "action_model": "gpt-4",
+        "action_prompt": "hi",
+        "overlap_policy": "allow",
+    }
+    s.update(over)
+    return s
+
+
+class TestFireBuildFailureRecorded:
+    """Codex #1283 P2: an invalid action_kind raised inside _fire (build_argv)
+    before the schedule_run row existed, so the generic handler called
+    update_status() on a missing row (LookupError) and left the invocation
+    stuck `running`. The failure must be recorded deterministically instead."""
+
+    async def test_invalid_kind_records_failed_run_and_invocation(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", tmp_path / "state.db")
+        from lionagi.state.db import StateDB
+        from lionagi.studio.scheduler.engine import SchedulerEngine
+
+        engine = SchedulerEngine()
+        run_id = "run-bad"
+        # Seed a valid schedule row (schedules.action_kind has a CHECK, so the
+        # bad kind can only reach _fire via a chain action override carrying the
+        # existing schedule_id). schedule_runs.schedule_id FK -> schedules.
+        async with StateDB() as db:
+            await db.create_schedule(_interval_schedule())
+        schedule = _interval_schedule(action_kind="totally-bogus")  # same id
+
+        # Must NOT raise (no LookupError leaking out) and must return cleanly.
+        await engine._fire(schedule, run_id, trigger_context={})
+
+        async with StateDB() as db:
+            run = await db.get_schedule_run(run_id)
+            assert run is not None, "schedule_run row must exist for the bad fire"
+            assert run["status"] == "failed"
+            inv = await db.get_invocation(run["invocation_id"])
+            assert inv is not None
+            assert inv["status"] == "failed", "invocation must not be left running"
+        # Not tracked as running after returning.
+        assert schedule["id"] not in engine._running
+
+
+class TestSpawnAndWaitCancellation:
+    """Codex #1283 P1: cancelling spawn_and_wait must terminate the spawned
+    child, not leave it detached."""
+
+    async def test_cancel_terminates_child(self, monkeypatch):
+        from lionagi.studio.scheduler import subprocess as sp
+
+        class _FakeProc:
+            def __init__(self):
+                self.terminated = False
+                self.killed = False
+                self.returncode = -15
+
+            async def communicate(self):
+                await asyncio.Event().wait()  # block until cancelled
+
+            def terminate(self):
+                self.terminated = True
+
+            def kill(self):
+                self.killed = True
+
+            async def wait(self):
+                return self.returncode
+
+        proc = _FakeProc()
+
+        async def fake_exec(*a, **k):
+            return proc
+
+        monkeypatch.setattr(sp.asyncio, "create_subprocess_exec", fake_exec)
+
+        task = asyncio.create_task(sp.spawn_and_wait(["sleep", "30"], "inv-1"))
+        # Let it reach communicate() and block.
+        for _ in range(5):
+            await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert proc.terminated is True, "child must be terminated on cancellation"
+
+
+class TestFireCancellationRecorded:
+    """Codex #1283 P1: when stop() cancels an in-flight _fire, the run and
+    invocation must be recorded as cancelled, not left `running`."""
+
+    async def test_cancel_during_spawn_records_cancelled(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", tmp_path / "state.db")
+        from lionagi.state.db import StateDB
+        from lionagi.studio.scheduler import subprocess as sp
+        from lionagi.studio.scheduler.engine import SchedulerEngine
+
+        started = asyncio.Event()
+
+        async def blocking_spawn(argv, inv_id):
+            started.set()
+            await asyncio.Event().wait()  # block until the _fire task is cancelled
+
+        # _fire imports spawn_and_wait from .subprocess at call time.
+        monkeypatch.setattr(sp, "spawn_and_wait", blocking_spawn)
+
+        async with StateDB() as db:
+            await db.create_schedule(_interval_schedule())  # satisfy schedule_run FK
+
+        engine = SchedulerEngine()
+        run_id = "run-cancel"
+        engine._tracked_fire(_interval_schedule(), run_id, trigger_context={})
+
+        await started.wait()  # row created, now inside spawn
+        await engine.stop()  # cancels + awaits the fire task
+
+        async with StateDB() as db:
+            run = await db.get_schedule_run(run_id)
+            assert run is not None and run["status"] == "cancelled"
+            inv = await db.get_invocation(run["invocation_id"])
+            assert inv is not None and inv["status"] == "cancelled"

--- a/tests/apps_studio_server/test_audit_remediation.py
+++ b/tests/apps_studio_server/test_audit_remediation.py
@@ -1,0 +1,269 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+from importlib import reload
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
+from fastapi.testclient import TestClient  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_client(monkeypatch, fake_db: Path | None = None) -> TestClient:
+    """Reload app to pick up monkeypatched env vars."""
+    import lionagi.studio.app as app_mod
+    import lionagi.studio.services.stats as stats_mod
+
+    if fake_db is not None:
+        monkeypatch.setattr(stats_mod, "DEFAULT_DB_PATH", fake_db)
+        monkeypatch.setattr(stats_mod, "_DB", str(fake_db))
+
+    reload(app_mod)
+    return TestClient(app_mod.app, raise_server_exceptions=False)
+
+
+# ---------------------------------------------------------------------------
+# LIONAGI-AUDIT-001 — Artifact GET routes bypass bearer auth
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestArtifactAuthBypass:
+    """Regression: artifact GET routes must require bearer token when configured.
+
+    Before the fix, GET /api/artifacts/{id} and GET /api/artifacts/by-session/{sid}
+    returned non-401 responses (404 or 200) even without an Authorization header,
+    proving auth was bypassed.
+
+    Attack scenario: attacker obtains studio URL, guesses or enumerates an artifact
+    ID, and reads agent-produced content (model output, file excerpts, credentials)
+    without any credential.
+    """
+
+    def test_get_artifact_no_token_returns_401(self, monkeypatch, tmp_path):
+        """GET /api/artifacts/{id} without Authorization header → 401 when token set."""
+        monkeypatch.setenv("LIONAGI_STUDIO_AUTH_TOKEN", "test-artifact-secret")
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        # Any artifact id — we want to verify auth fires before reaching the service
+        resp = client.get("/api/artifacts/some-artifact-id")
+        assert resp.status_code == 401, (
+            f"Expected 401 (auth rejected), got {resp.status_code}. "
+            "Artifact GET route is bypassing bearer auth."
+        )
+
+    def test_get_artifact_wrong_token_returns_401(self, monkeypatch, tmp_path):
+        """GET /api/artifacts/{id} with wrong token → 401."""
+        monkeypatch.setenv("LIONAGI_STUDIO_AUTH_TOKEN", "correct-secret")
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.get(
+            "/api/artifacts/some-artifact-id",
+            headers={"Authorization": "Bearer wrong-secret"},
+        )
+        assert resp.status_code == 401
+
+    def test_get_artifact_correct_token_passes_auth(self, monkeypatch, tmp_path):
+        """GET /api/artifacts/{id} with correct token must not return 401."""
+        monkeypatch.setenv("LIONAGI_STUDIO_AUTH_TOKEN", "correct-secret")
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.get(
+            "/api/artifacts/nonexistent",
+            headers={"Authorization": "Bearer correct-secret"},
+        )
+        # Auth passed — 404 is the correct service response for unknown artifact
+        assert resp.status_code != 401
+
+    def test_get_artifacts_by_session_no_token_returns_401(self, monkeypatch, tmp_path):
+        """GET /api/artifacts/by-session/{sid} without Authorization → 401."""
+        monkeypatch.setenv("LIONAGI_STUDIO_AUTH_TOKEN", "test-secret")
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.get("/api/artifacts/by-session/some-session-id")
+        assert resp.status_code == 401
+
+    def test_health_still_open(self, monkeypatch, tmp_path):
+        """/health remains accessible even with artifact auth enabled."""
+        monkeypatch.setenv("LIONAGI_STUDIO_AUTH_TOKEN", "test-secret")
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.get("/health")
+        assert resp.status_code == 200
+
+    def test_stats_still_open(self, monkeypatch, tmp_path):
+        """/api/stats remains accessible (existing behaviour must not regress)."""
+        monkeypatch.setenv("LIONAGI_STUDIO_AUTH_TOKEN", "test-secret")
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.get("/api/stats")
+        assert resp.status_code == 200
+
+    def test_artifact_auth_disabled_when_no_token(self, monkeypatch, tmp_path):
+        """Without LIONAGI_STUDIO_AUTH_TOKEN all routes are open."""
+        monkeypatch.delenv("LIONAGI_STUDIO_AUTH_TOKEN", raising=False)
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        # Should reach service layer, not return 401
+        resp = client.get("/api/artifacts/some-id")
+        assert resp.status_code != 401
+
+
+# ---------------------------------------------------------------------------
+# LIONAGI-AUDIT-002 — Fire tasks must be tracked and cancelled on shutdown
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestSchedulerFireTaskLifecycle:
+    """Regression: _fire tasks must be tracked so stop() can cancel them.
+
+    Before the fix, asyncio.create_task(self._fire(...)) was fire-and-forget.
+    After shutdown self._task was cancelled but outstanding _fire tasks continued
+    running, allowing orphaned subprocess waits after the scheduler stopped.
+    """
+
+    async def test_fire_tasks_tracked_and_removed_on_completion(self):
+        """_tracked_fire stores tasks in _fire_tasks and removes them on completion.
+
+        Regression for LIONAGI-AUDIT-002: fire-and-forget asyncio.create_task() calls
+        produced no tracking set — this test verifies the set grows and shrinks correctly.
+        """
+        from lionagi.studio.scheduler.engine import SchedulerEngine
+
+        engine = SchedulerEngine()
+
+        fired = asyncio.Event()
+        done = asyncio.Event()
+
+        async def fake_fire(*args, **kwargs):
+            fired.set()
+            await done.wait()
+
+        # Inject a tracked task directly via _tracked_fire
+        with patch.object(engine, "_fire", side_effect=fake_fire):
+            task = engine._tracked_fire({}, "run_id", trigger_context={})
+
+        # Task is still running — should be in the set
+        await fired.wait()
+        assert len(engine._fire_tasks) == 1, "Task must be tracked while running"
+
+        # Let it complete
+        done.set()
+        await asyncio.gather(task, return_exceptions=True)
+        # Yield so the done callback fires
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+        assert len(engine._fire_tasks) == 0, "Task handle must be removed on completion"
+
+    async def test_stop_cancels_outstanding_fire_tasks(self):
+        """stop() must cancel and await all outstanding _fire tasks.
+
+        Regression for LIONAGI-AUDIT-002 (studio-standards 2026-06-06).
+        """
+        from lionagi.studio.scheduler.engine import SchedulerEngine
+
+        engine = SchedulerEngine()
+
+        blocking = asyncio.Event()
+        cancelled_flag = {"value": False}
+
+        async def long_fire(*args, **kwargs):
+            try:
+                await blocking.wait()
+            except asyncio.CancelledError:
+                cancelled_flag["value"] = True
+                raise
+
+        # Inject a long-running fire task directly
+        task = asyncio.create_task(long_fire())
+        engine._fire_tasks.add(task)
+        task.add_done_callback(engine._fire_tasks.discard)
+
+        # Also set up the tick-loop task (so stop() can cancel it)
+        async def noop_loop():
+            await asyncio.sleep(9999)
+
+        engine._task = asyncio.create_task(noop_loop())
+
+        # stop() must cancel and await the fire task
+        await engine.stop()
+
+        assert cancelled_flag["value"] is True, "stop() did not cancel the outstanding _fire task"
+        assert len(engine._fire_tasks) == 0, "Outstanding fire tasks remain after stop()"
+
+
+# ---------------------------------------------------------------------------
+# LIONAGI-AUDIT-003 — Schedule action kind validation
+# ---------------------------------------------------------------------------
+
+
+class TestBuildArgvValidation:
+    """Regression: unknown/aliased action_kind must be validated fail-closed."""
+
+    def test_unknown_kind_raises(self):
+        """build_argv with an unknown action_kind must raise ValueError."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        with pytest.raises(ValueError, match="Unknown action_kind"):
+            build_argv({"action_kind": "nonexistent"}, {})
+
+    def test_playbook_alias_normalized_to_play(self):
+        """action_kind='playbook' (legacy CLI alias) normalizes to 'play'.
+
+        Regression for LIONAGI-AUDIT-003: 'playbook' was not recognized by
+        build_argv(), causing it to produce ['uv', 'run', 'li'] — an
+        underspecified command — instead of ['uv', 'run', 'li', 'play', ...].
+        """
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        argv = build_argv(
+            {
+                "action_kind": "playbook",
+                "action_playbook": "audit",
+                "action_model": None,
+                "action_prompt": None,
+                "action_agent": None,
+                "action_project": None,
+                "action_extra_args": [],
+            },
+            {},
+        )
+        assert "play" in argv, f"'play' not in argv: {argv}"
+        assert "audit" in argv, f"playbook name not in argv: {argv}"
+
+    def test_valid_kinds_do_not_raise(self):
+        """All four ADR-0027 action kinds must be accepted."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        for kind in ("agent", "flow", "fanout", "play"):
+            argv = build_argv(
+                {
+                    "action_kind": kind,
+                    "action_model": "gpt-4",
+                    "action_prompt": "do stuff",
+                    "action_agent": None,
+                    "action_playbook": None,
+                    "action_project": None,
+                    "action_extra_args": [],
+                },
+                {},
+            )
+            assert "uv" in argv
+
+    def test_empty_string_kind_raises(self):
+        """Empty string action_kind must be rejected."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        with pytest.raises(ValueError, match="Unknown action_kind"):
+            build_argv({"action_kind": ""}, {})

--- a/tests/apps_studio_server/test_audit_remediation.py
+++ b/tests/apps_studio_server/test_audit_remediation.py
@@ -325,13 +325,15 @@ class TestFireBuildFailureRecorded:
 
 class TestSpawnAndWaitCancellation:
     """Codex #1283 P1: cancelling spawn_and_wait must terminate the spawned
-    child, not leave it detached."""
+    PROCESS GROUP, not just the direct child — `uv run li` forks the real
+    worker, so signalling only the direct child orphans grandchildren."""
 
-    async def test_cancel_terminates_child(self, monkeypatch):
+    async def test_cancel_terminates_child_and_group(self, monkeypatch):
         from lionagi.studio.scheduler import subprocess as sp
 
         class _FakeProc:
             def __init__(self):
+                self.pid = 424242  # > 1 so the group-kill path engages
                 self.terminated = False
                 self.killed = False
                 self.returncode = -15
@@ -351,9 +353,19 @@ class TestSpawnAndWaitCancellation:
         proc = _FakeProc()
 
         async def fake_exec(*a, **k):
+            # The fix must request its own session/process group.
+            assert k.get("start_new_session") is True, (
+                "subprocess must start_new_session so the group is killable"
+            )
             return proc
 
+        killpg_calls: list[tuple[int, int]] = []
+
+        def fake_killpg(pgid, sig):
+            killpg_calls.append((pgid, sig))
+
         monkeypatch.setattr(sp.asyncio, "create_subprocess_exec", fake_exec)
+        monkeypatch.setattr(sp.os, "killpg", fake_killpg)
 
         task = asyncio.create_task(sp.spawn_and_wait(["sleep", "30"], "inv-1"))
         # Let it reach communicate() and block.
@@ -362,7 +374,10 @@ class TestSpawnAndWaitCancellation:
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await task
-        assert proc.terminated is True, "child must be terminated on cancellation"
+
+        assert proc.terminated is True, "direct child must be terminated"
+        assert killpg_calls, "the process GROUP must be signalled, not just the child"
+        assert killpg_calls[0] == (proc.pid, sp.signal.SIGTERM)
 
 
 class TestFireCancellationRecorded:

--- a/tests/cli/test_agent_profile_validation.py
+++ b/tests/cli/test_agent_profile_validation.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for agent profile name validation (LIONAGI-AUDIT-002).
+
+Verify that _validate_bare_name rejects path traversal and separators
+so that load_agent_profile() fails closed on malicious names.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.cli._agents import _validate_bare_name, load_agent_profile
+
+
+class TestValidateBareName:
+    """_validate_bare_name must reject anything that is not a safe identifier."""
+
+    def test_accepts_plain_name(self):
+        _validate_bare_name("orchestrator")
+
+    def test_accepts_hyphenated_name(self):
+        _validate_bare_name("my-agent")
+
+    def test_accepts_underscore_name(self):
+        _validate_bare_name("my_agent_v2")
+
+    def test_accepts_alphanumeric(self):
+        _validate_bare_name("Agent42")
+
+    def test_rejects_path_separator_slash(self):
+        with pytest.raises(ValueError, match="bare identifier"):
+            _validate_bare_name("a/b")
+
+    def test_rejects_parent_traversal(self):
+        with pytest.raises(ValueError, match="bare identifier"):
+            _validate_bare_name("../agents/orchestrator")
+
+    def test_rejects_leading_dot(self):
+        with pytest.raises(ValueError, match="bare identifier"):
+            _validate_bare_name(".hidden")
+
+    def test_rejects_dot_alone(self):
+        with pytest.raises(ValueError, match="bare identifier"):
+            _validate_bare_name(".")
+
+    def test_rejects_double_dot(self):
+        with pytest.raises(ValueError, match="bare identifier"):
+            _validate_bare_name("..")
+
+    def test_rejects_empty_string(self):
+        with pytest.raises(ValueError, match="bare identifier"):
+            _validate_bare_name("")
+
+    def test_rejects_backslash(self):
+        with pytest.raises(ValueError, match="bare identifier"):
+            _validate_bare_name("foo\\bar")
+
+    def test_rejects_null_byte(self):
+        with pytest.raises(ValueError, match="bare identifier"):
+            _validate_bare_name("foo\x00bar")
+
+
+class TestLoadAgentProfileValidation:
+    """load_agent_profile must fail closed before touching the filesystem."""
+
+    def test_rejects_path_traversal_name(self):
+        """Traversal name raises ValueError before any filesystem probe."""
+        with pytest.raises(ValueError, match="bare identifier"):
+            load_agent_profile("../agents/orchestrator")
+
+    def test_rejects_separator_name(self):
+        with pytest.raises(ValueError, match="bare identifier"):
+            load_agent_profile("a/b")
+
+    def test_rejects_hidden_name(self):
+        with pytest.raises(ValueError, match="bare identifier"):
+            load_agent_profile(".hidden")
+
+    def test_valid_name_proceeds_to_file_lookup(self):
+        """A valid name passes validation and raises FileNotFoundError (no
+        .lionagi dir in the test environment), NOT ValueError."""
+        with pytest.raises((FileNotFoundError, Exception)) as exc_info:
+            load_agent_profile("valid-name")
+        # Must NOT be the validation error.
+        assert not isinstance(exc_info.value, ValueError)

--- a/tests/cli/test_kill.py
+++ b/tests/cli/test_kill.py
@@ -283,7 +283,7 @@ async def test_persist_cancel_inserts_status_transition(temp_db_path: Path):
         row = await cur.fetchone()
         assert row is not None
         assert row["reason_code"] == RunReasons.CANCELLED_MANUAL_KILL
-        assert row["source"] == "cli"
+        assert row["source"] == "admin"  # CLI kill is an admin action (ADR-0028)
         assert row["actor"] == "user"
         assert row["previous_status"] == "running"
         assert row["status"] == "cancelled"

--- a/tests/cli/test_project.py
+++ b/tests/cli/test_project.py
@@ -18,7 +18,9 @@ from lionagi.cli._project import (
 
 class TestParseRemoteUrl:
     def test_https_github(self):
-        assert _parse_remote_url("https://github.com/ohdearquant/lionagi.git") == "ohdearquant/lionagi"
+        assert (
+            _parse_remote_url("https://github.com/ohdearquant/lionagi.git") == "ohdearquant/lionagi"
+        )
 
     def test_https_no_dot_git(self):
         assert _parse_remote_url("https://github.com/ohdearquant/lionagi") == "ohdearquant/lionagi"
@@ -27,13 +29,18 @@ class TestParseRemoteUrl:
         assert _parse_remote_url("git@github.com:ohdearquant/lionagi.git") == "ohdearquant/lionagi"
 
     def test_ssh_url_style(self):
-        assert _parse_remote_url("ssh://git@github.com/ohdearquant/lionagi.git") == "ohdearquant/lionagi"
+        assert (
+            _parse_remote_url("ssh://git@github.com/ohdearquant/lionagi.git")
+            == "ohdearquant/lionagi"
+        )
 
     def test_trailing_slash(self):
         assert _parse_remote_url("https://github.com/ohdearquant/lionagi/") == "ohdearquant/lionagi"
 
     def test_single_segment(self):
-        assert _parse_remote_url("https://example.com/repo.git") is None or _parse_remote_url("https://example.com/repo.git")
+        assert _parse_remote_url("https://example.com/repo.git") is None or _parse_remote_url(
+            "https://example.com/repo.git"
+        )
 
 
 class TestReadProjectFromToml:
@@ -115,3 +122,52 @@ class TestDetectProjectGlobalOverrides:
         name, source = detect_project(work_dir)
         assert name == "work-proj"
         assert source == "global_override"
+
+
+class TestReadProjectFromTomlFallback:
+    """LIONAGI-AUDIT-003: the 3.10 TOML fallback must use `toml`, not `tomli`."""
+
+    def test_falls_back_to_toml_when_tomllib_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Simulate Python 3.10: tomllib raises ModuleNotFoundError.
+        _read_project_from_toml must still work via the `toml` package
+        (declared dependency) and must NOT import tomli (undeclared).
+        """
+        import sys
+        import types
+
+        # Build a minimal fake tomllib that always raises ModuleNotFoundError.
+        fake_tomllib = types.ModuleType("tomllib")
+        original = sys.modules.get("tomllib")
+
+        def fail_load(f):
+            raise Exception("should not be called")
+
+        # Patch out tomllib so the except branch is taken.
+        # We do this by making the import inside the function raise.
+        original_tomllib = sys.modules.pop("tomllib", None)
+        try:
+            toml_file = tmp_path / "config.toml"
+            toml_file.write_text('[project]\nname = "compat-project"\n')
+            result = _read_project_from_toml(toml_file)
+            # Either tomllib was available (3.11+) or toml was used (3.10).
+            # Either way, the result should be correct and no ModuleNotFoundError raised.
+            assert result == "compat-project"
+        finally:
+            if original_tomllib is not None:
+                sys.modules["tomllib"] = original_tomllib
+
+    def test_tomli_is_never_imported(self, tmp_path: Path):
+        """tomli must not appear in sys.modules after _read_project_from_toml."""
+        import sys
+
+        # Remove tomli from sys.modules if somehow present, so we can detect
+        # any fresh import.
+        sys.modules.pop("tomli", None)
+        toml_file = tmp_path / "config.toml"
+        toml_file.write_text('[project]\nname = "check-project"\n')
+        _read_project_from_toml(toml_file)
+        assert "tomli" not in sys.modules, (
+            "_read_project_from_toml imported tomli, which is not a declared dependency"
+        )

--- a/tests/cli/test_state_commands.py
+++ b/tests/cli/test_state_commands.py
@@ -162,9 +162,7 @@ async def test_ls_lists_seeded_sessions(
     capsys: pytest.CaptureFixture,
 ):
     async with StateDB() as db:
-        sid = await _seed_session(
-            db, name="foo", status="running", updated_at=time.time()
-        )
+        sid = await _seed_session(db, name="foo", status="running", updated_at=time.time())
 
     await _list_sessions(limit=50, status=None)
     out = capsys.readouterr().out
@@ -179,9 +177,7 @@ async def test_ls_limit_caps_results(
 ):
     async with StateDB() as db:
         for i in range(5):
-            await _seed_session(
-                db, name=f"s{i}", status="completed", updated_at=time.time() - i
-            )
+            await _seed_session(db, name=f"s{i}", status="completed", updated_at=time.time() - i)
 
     await _list_sessions(limit=2, status=None)
     out = capsys.readouterr().out
@@ -195,9 +191,7 @@ async def test_ls_status_filter(
     capsys: pytest.CaptureFixture,
 ):
     async with StateDB() as db:
-        await _seed_session(
-            db, name="finished", status="completed", updated_at=time.time()
-        )
+        await _seed_session(db, name="finished", status="completed", updated_at=time.time())
         await _seed_session(db, name="open", status="running", updated_at=time.time())
 
     await _list_sessions(limit=50, status="completed")
@@ -382,15 +376,9 @@ async def test_prune_keeps_n_most_recent_even_when_old(temp_db_path: Path):
     old_ts = now - (60 * 86400)
     async with StateDB() as db:
         # All three sessions are OLD.
-        s1 = await _seed_session(
-            db, name="oldest", status="completed", updated_at=old_ts - 100
-        )
-        s2 = await _seed_session(
-            db, name="middle", status="completed", updated_at=old_ts - 50
-        )
-        s3 = await _seed_session(
-            db, name="newest_old", status="completed", updated_at=old_ts
-        )
+        s1 = await _seed_session(db, name="oldest", status="completed", updated_at=old_ts - 100)
+        s2 = await _seed_session(db, name="middle", status="completed", updated_at=old_ts - 50)
+        s3 = await _seed_session(db, name="newest_old", status="completed", updated_at=old_ts)
 
     # keep_n=2: must preserve the 2 most recent (s2, s3).
     result = await _prune(keep_days=30, keep_n=2, dry_run=False)
@@ -429,12 +417,14 @@ async def test_doctor_dry_run_does_not_modify_status(temp_db_path: Path):
     async with StateDB() as db:
         stale = await _seed_session(db, status="running")
         await db.db.execute(
-            "UPDATE sessions SET started_at = ? WHERE id = ?", (old, stale),
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (old, stale),
         )
         await db.db.commit()
         recent = await _seed_session(db, status="running")
         await db.db.execute(
-            "UPDATE sessions SET started_at = ? WHERE id = ?", (now, recent),
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (now, recent),
         )
         await db.db.commit()
 
@@ -462,12 +452,14 @@ async def test_doctor_sweeps_stale_running_sessions_to_aborted(
     async with StateDB() as db:
         stale = await _seed_session(db, status="running")
         await db.db.execute(
-            "UPDATE sessions SET started_at = ? WHERE id = ?", (old, stale),
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (old, stale),
         )
         await db.db.commit()
         recent = await _seed_session(db, status="running")
         await db.db.execute(
-            "UPDATE sessions SET started_at = ? WHERE id = ?", (now, recent),
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (now, recent),
         )
         await db.db.commit()
 
@@ -490,7 +482,8 @@ async def test_doctor_handles_null_started_at_as_stale(temp_db_path: Path):
     async with StateDB() as db:
         sid = await _seed_session(db, status="running")
         await db.db.execute(
-            "UPDATE sessions SET started_at = NULL WHERE id = ?", (sid,),
+            "UPDATE sessions SET started_at = NULL WHERE id = ?",
+            (sid,),
         )
         await db.db.commit()
 
@@ -536,7 +529,8 @@ async def test_doctor_does_not_overwrite_session_that_completed_post_select(
     async with StateDB() as db:
         racy = await _seed_session(db, status="running")
         await db.db.execute(
-            "UPDATE sessions SET started_at = ? WHERE id = ?", (old, racy),
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (old, racy),
         )
         truly_stale = await _seed_session(db, status="running")
         await db.db.execute(
@@ -561,8 +555,7 @@ async def test_doctor_does_not_overwrite_session_that_completed_post_select(
             ):
                 self._fired = True
                 await self._real.execute(
-                    "UPDATE sessions SET status = 'completed', ended_at = ? "
-                    "WHERE id = ?",
+                    "UPDATE sessions SET status = 'completed', ended_at = ? WHERE id = ?",
                     (now, racy),
                 )
                 await self._real.commit()
@@ -604,7 +597,8 @@ async def test_doctor_with_failed_new_status(temp_db_path: Path):
     async with StateDB() as db:
         sid = await _seed_session(db, status="running")
         await db.db.execute(
-            "UPDATE sessions SET started_at = ? WHERE id = ?", (old, sid),
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (old, sid),
         )
         await db.db.commit()
 

--- a/tests/engines/test_engine.py
+++ b/tests/engines/test_engine.py
@@ -251,6 +251,39 @@ async def test_spawned_task_cancellation_is_not_surfaced():
 
 
 @pytest.mark.asyncio
+async def test_failed_parent_still_drains_spawned_child():
+    """A parent that spawns a child and then fails must NOT short-circuit the
+    wait. wait_quiescence must drain the child to completion (genuine
+    quiescence — no background work left running) before surfacing the failure.
+    """
+    run = _run()
+    child_ran = asyncio.Event()
+
+    async def child():
+        await asyncio.sleep(0.02)
+        child_ran.set()
+
+    async def parent():
+        run.spawn(child())  # schedule child, then fail
+        await asyncio.sleep(0)
+        raise RuntimeError("parent failed after spawning child")
+
+    run.spawn(parent())
+
+    raised: BaseException | None = None
+    try:
+        await run.wait_quiescence()
+    except BaseException as exc:
+        raised = exc
+
+    assert raised is not None, "parent failure must be surfaced"
+    assert "parent failed after spawning child" in str(raised)
+    # The contract: the run is genuinely quiescent — child finished, none left.
+    assert child_ran.is_set(), "child spawned by failed parent must still run"
+    assert not run._active, "wait_quiescence must leave no background tasks running"
+
+
+@pytest.mark.asyncio
 async def test_successful_tasks_do_not_raise():
     """Successful spawned tasks must complete without raising."""
     run = _run()

--- a/tests/engines/test_engine.py
+++ b/tests/engines/test_engine.py
@@ -198,3 +198,69 @@ async def test_run_dag_emits_node_lifecycle_signals():
     assert len(result["completed_operations"]) == 1
     assert started == ["root"]  # NodeStarted reached the observer with the branch name
     assert len(completed) == 1  # NodeCompleted carried the op id
+
+
+# ── LIONAGI-AUDIT-001: spawned task failures surface to caller ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_spawned_task_failure_is_reported():
+    """Regression: wait_quiescence() must not silently swallow task exceptions.
+
+    A spawned coroutine that raises RuntimeError must cause wait_quiescence
+    to propagate that exception rather than returning successfully.
+    """
+    run = _run()
+
+    async def boom():
+        await asyncio.sleep(0)
+        raise RuntimeError("engine node failed")
+
+    run.spawn(boom())
+    # On Python 3.11+ an ExceptionGroup is raised; on 3.10 the first exception
+    # is re-raised directly.  Either way, the call must NOT return normally.
+    raised: BaseException | None = None
+    try:
+        await run.wait_quiescence()
+    except BaseException as exc:
+        raised = exc
+    assert raised is not None, "wait_quiescence must raise when a spawned task fails"
+    # The original error message must be visible somewhere in the exception chain.
+    assert "engine node failed" in str(raised)
+
+
+@pytest.mark.asyncio
+async def test_spawned_task_cancellation_is_not_surfaced():
+    """CancelledError from a spawned task must be silently discarded —
+    the whole run is not cancelled when a single branch is cancelled."""
+    run = _run()
+    done: list[int] = []
+
+    async def cancel_me():
+        raise asyncio.CancelledError
+
+    async def succeed():
+        await asyncio.sleep(0)
+        done.append(1)
+
+    run.spawn(cancel_me())
+    run.spawn(succeed())
+    # Must not raise; the CancelledError is discarded.
+    await run.wait_quiescence()
+    assert done == [1]
+
+
+@pytest.mark.asyncio
+async def test_successful_tasks_do_not_raise():
+    """Successful spawned tasks must complete without raising."""
+    run = _run()
+    results: list[str] = []
+
+    async def work(val: str) -> None:
+        await asyncio.sleep(0)
+        results.append(val)
+
+    run.spawn(work("a"))
+    run.spawn(work("b"))
+    await run.wait_quiescence()
+    assert sorted(results) == ["a", "b"]

--- a/tests/hooks/test_builtins.py
+++ b/tests/hooks/test_builtins.py
@@ -116,3 +116,56 @@ async def test_persist_message_legacy_progression_id_still_works():
         )
 
     mock_db.append_to_progression.assert_any_await("legacy_prog", "msg_legacy")
+
+
+# ── persist_session_start: running status must carry a reason_code ─────────────
+
+
+class TestPersistSessionStartReasonCode:
+    """Codex finding: persist_session_start writes status='running', which
+    routes through update_status() and REQUIRES a reason_code. There is no
+    canonical default for (session, running), so without an explicit code the
+    deprecation shim raises ValueError — and HookBus.emit() swallows it,
+    silently dropping every provenance field. Regression: the hook must run
+    against a real StateDB without raising and persist provenance + a reason.
+    """
+
+    async def test_persist_session_start_persists_provenance_with_reason(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", tmp_path / "state.db")
+        from lionagi.hooks.builtins import persist_session_start
+        from lionagi.state.db import StateDB
+        from lionagi.state.reasons import RunReasons
+
+        sid = "sess-start-1"
+        async with StateDB() as db:
+            await db.create_progression("prog-start-1")
+            await db.create_session(
+                {
+                    "id": sid,
+                    "progression_id": "prog-start-1",
+                    "status": "running",
+                }
+            )
+
+        # Must NOT raise (the bug raised ValueError, swallowed by the bus).
+        await persist_session_start(
+            session_id=sid,
+            model="gpt-5.4-mini",
+            provider="openai",
+            effort="high",
+            agent_name="reviewer",
+        )
+
+        async with StateDB() as db:
+            row = await db.get_session(sid)
+
+        assert row is not None
+        assert row["status"] == "running"
+        # Provenance survived (it would have been dropped if the status write
+        # raised before the legacy field UPDATE).
+        assert row["model"] == "gpt-5.4-mini"
+        assert row["provider"] == "openai"
+        # A canonical "started" reason was recorded, not the deprecation default.
+        assert row["status_reason_code"] == RunReasons.STARTED_OK

--- a/tests/outcomes/test_outcome_models.py
+++ b/tests/outcomes/test_outcome_models.py
@@ -39,9 +39,6 @@ def test_skill_outcome_dump_round_trips():
     assert again == o
 
 
-# ── ReviewVerdict ─────────────────────────────────────────────────────────────
-
-
 def test_review_verdict_default_outcome_kind_pinned():
     """ADR-0021 promises kind='review_verdict' — frontend dispatch depends on it."""
     v = ReviewVerdict(
@@ -184,3 +181,93 @@ def test_outcome_kinds_are_distinct():
         CIResult(summary="x").outcome_kind,
     }
     assert len(kinds) == 3
+
+
+def test_finding_rejects_absolute_unix_path():
+    with pytest.raises(ValidationError, match="repo-relative"):
+        Finding(severity="high", category="security", description="x", file="/etc/passwd")
+
+
+def test_finding_rejects_absolute_windows_path():
+    with pytest.raises(ValidationError, match="repo-relative"):
+        Finding(severity="high", category="security", description="x", file="C:\\secret.py")
+
+
+def test_finding_rejects_parent_traversal():
+    with pytest.raises(ValidationError, match="traversal"):
+        Finding(severity="high", category="security", description="x", file="../secret.py")
+
+
+def test_finding_rejects_deep_traversal():
+    with pytest.raises(ValidationError, match="traversal"):
+        Finding(
+            severity="medium",
+            category="correctness",
+            description="x",
+            file="foo/../../etc/passwd",
+        )
+
+
+def test_finding_rejects_nul_byte():
+    with pytest.raises(ValidationError, match="NUL"):
+        Finding(severity="low", category="style", description="x", file="foo\x00bar.py")
+
+
+def test_finding_rejects_line_zero():
+    """Line numbers must be 1-indexed (ge=1); 0 is invalid."""
+    with pytest.raises(ValidationError):
+        Finding(severity="low", category="style", description="x", line=0)
+
+
+def test_finding_rejects_negative_line():
+    with pytest.raises(ValidationError):
+        Finding(severity="low", category="style", description="x", line=-3)
+
+
+def test_finding_accepts_valid_relative_path():
+    f = Finding(severity="low", category="style", description="x", file="src/main.py")
+    assert f.file == "src/main.py"
+
+
+def test_finding_accepts_none_file():
+    f = Finding(severity="low", category="style", description="x", file=None)
+    assert f.file is None
+
+
+def test_finding_accepts_positive_line():
+    f = Finding(severity="info", category="docs", description="x", line=42)
+    assert f.line == 42
+
+
+def test_gate_verdict_defaults_passed_to_gate_passed_true():
+    """When passed is omitted, it defaults to gate_passed (LIONAGI-AUDIT-003)."""
+    g = GateVerdict(gate_passed=True, summary="ok")
+    assert g.passed is True
+
+
+def test_gate_verdict_defaults_passed_to_gate_passed_false():
+    g = GateVerdict(gate_passed=False, summary="nope")
+    assert g.passed is False
+
+
+def test_gate_verdict_rejects_contradictory_passed():
+    """gate_passed=True and passed=False is a contradictory state and must fail."""
+    with pytest.raises(ValidationError, match="gate_passed"):
+        GateVerdict(gate_passed=True, passed=False, summary="contradicts")
+
+
+def test_gate_verdict_rejects_contradictory_passed_reversed():
+    with pytest.raises(ValidationError, match="gate_passed"):
+        GateVerdict(gate_passed=False, passed=True, summary="contradicts")
+
+
+def test_gate_verdict_consistent_both_true():
+    g = GateVerdict(gate_passed=True, passed=True, summary="consistent")
+    assert g.gate_passed is True
+    assert g.passed is True
+
+
+def test_gate_verdict_consistent_both_false():
+    g = GateVerdict(gate_passed=False, passed=False, summary="consistent")
+    assert g.gate_passed is False
+    assert g.passed is False

--- a/tests/state/test_artifacts.py
+++ b/tests/state/test_artifacts.py
@@ -67,9 +67,7 @@ async def test_insert_artifact_with_invocation_link(db: StateDB):
 
 async def test_insert_artifact_with_session_link(db: StateDB):
     s = await _make_session(db, status="completed")
-    gate = GateVerdict(
-        summary="ok", gate_passed=True, feedback="all green", passed=True
-    )
+    gate = GateVerdict(summary="ok", gate_passed=True, feedback="all green", passed=True)
     await db.insert_artifact(
         session_id=s["id"],
         kind=gate.outcome_kind,
@@ -196,7 +194,7 @@ async def test_list_artifacts_ordered_by_created_at(db: StateDB):
             await db.insert_artifact(
                 invocation_id=inv["id"],
                 kind="review_verdict",
-                name=f"round-{i+1}",
+                name=f"round-{i + 1}",
                 content={"verdict": "APPROVE", "round": i + 1},
             )
         )

--- a/tests/state/test_health.py
+++ b/tests/state/test_health.py
@@ -262,10 +262,7 @@ def test_worst_health_empty_is_healthy():
 
 def test_worst_health_zombie_beats_orphaned():
     """Zombie sits at the top of the severity scale."""
-    assert (
-        worst_health([SessionHealth.ORPHANED, SessionHealth.ZOMBIE])
-        == SessionHealth.ZOMBIE
-    )
+    assert worst_health([SessionHealth.ORPHANED, SessionHealth.ZOMBIE]) == SessionHealth.ZOMBIE
 
 
 def test_severity_table_covers_all_health_levels():

--- a/tests/state/test_invocations.py
+++ b/tests/state/test_invocations.py
@@ -45,9 +45,7 @@ async def _make_invocation(db: StateDB, **fields) -> dict:
     return inv
 
 
-async def _make_session(
-    db: StateDB, *, invocation_id: str | None = None, **fields
-) -> dict:
+async def _make_session(db: StateDB, *, invocation_id: str | None = None, **fields) -> dict:
     prog_id = _uid()
     await db.create_progression(prog_id)
     session = {
@@ -125,13 +123,35 @@ async def test_create_session_with_invocation_bumps_count(db: StateDB):
     assert fetched["session_count"] == 2
 
 
+async def test_duplicate_create_session_does_not_inflate_session_count(db: StateDB):
+    """LIONAGI-AUDIT-003 regression: a duplicate create_session call (same id)
+    must not increment session_count a second time (INSERT OR IGNORE no-op)."""
+    inv = await _make_invocation(db)
+    session = await _make_session(db, invocation_id=inv["id"], status="running")
+
+    # Replay the exact same session dict — simulates an idempotent retry.
+    await db.create_session(session)
+
+    fetched = await db.get_invocation(inv["id"])
+    assert fetched["session_count"] == 1, (
+        "session_count must be 1 after one distinct session, even if create_session "
+        "was called twice with the same id"
+    )
+    rows = await db.list_sessions_for_invocation(inv["id"])
+    assert len(rows) == 1
+
+
 async def test_list_sessions_for_invocation_orders_by_created(db: StateDB):
     inv = await _make_invocation(db)
     s1 = await _make_session(
-        db, invocation_id=inv["id"], status="running",
+        db,
+        invocation_id=inv["id"],
+        status="running",
     )
     s2 = await _make_session(
-        db, invocation_id=inv["id"], status="completed",
+        db,
+        invocation_id=inv["id"],
+        status="completed",
     )
     rows = await db.list_sessions_for_invocation(inv["id"])
     assert [r["id"] for r in rows] == [s1["id"], s2["id"]]

--- a/tests/state/test_projects.py
+++ b/tests/state/test_projects.py
@@ -25,7 +25,13 @@ def uid() -> str:
     return str(uuid.uuid4())
 
 
-async def _make_session(db: StateDB, *, project: str | None = None, project_source: str | None = None, status: str | None = None) -> dict:
+async def _make_session(
+    db: StateDB,
+    *,
+    project: str | None = None,
+    project_source: str | None = None,
+    status: str | None = None,
+) -> dict:
     prog_id = uid()
     await db.create_progression(prog_id)
     session = {
@@ -109,6 +115,7 @@ async def test_create_project_all_fields(db: StateDB):
 
 async def test_create_project_duplicate_raises(db: StateDB):
     import aiosqlite
+
     await db.create_project("dup-proj")
     with pytest.raises(aiosqlite.IntegrityError):
         await db.create_project("dup-proj")
@@ -210,12 +217,14 @@ async def test_delete_project_non_studio_returns_false(db: StateDB):
 async def test_create_session_auto_registers_project(db: StateDB):
     prog_id = uid()
     await db.create_progression(prog_id)
-    await db.create_session({
-        "id": uid(),
-        "progression_id": prog_id,
-        "project": "auto/project",
-        "project_source": "git_remote",
-    })
+    await db.create_session(
+        {
+            "id": uid(),
+            "progression_id": prog_id,
+            "project": "auto/project",
+            "project_source": "git_remote",
+        }
+    )
     project = await db.get_project("auto/project")
     assert project is not None
     assert project["source"] == "git_remote"
@@ -224,10 +233,12 @@ async def test_create_session_auto_registers_project(db: StateDB):
 async def test_create_session_no_project_skips_registration(db: StateDB):
     prog_id = uid()
     await db.create_progression(prog_id)
-    await db.create_session({
-        "id": uid(),
-        "progression_id": prog_id,
-    })
+    await db.create_session(
+        {
+            "id": uid(),
+            "progression_id": prog_id,
+        }
+    )
     result = await db.list_projects()
     assert result == []
 
@@ -235,12 +246,14 @@ async def test_create_session_no_project_skips_registration(db: StateDB):
 async def test_create_session_missing_project_source_defaults_to_git_remote(db: StateDB):
     prog_id = uid()
     await db.create_progression(prog_id)
-    await db.create_session({
-        "id": uid(),
-        "progression_id": prog_id,
-        "project": "my/proj",
-        # no project_source
-    })
+    await db.create_session(
+        {
+            "id": uid(),
+            "progression_id": prog_id,
+            "project": "my/proj",
+            # no project_source
+        }
+    )
     project = await db.get_project("my/proj")
     assert project is not None
     assert project["source"] == "git_remote"

--- a/tests/state/test_provenance.py
+++ b/tests/state/test_provenance.py
@@ -43,10 +43,7 @@ def test_resolve_combines_provider_and_model():
 
 
 def test_resolve_passes_already_qualified_model_through():
-    assert (
-        resolve_model_spec("claude", "claude/claude-sonnet-4-6")
-        == "claude/claude-sonnet-4-6"
-    )
+    assert resolve_model_spec("claude", "claude/claude-sonnet-4-6") == "claude/claude-sonnet-4-6"
 
 
 def test_resolve_returns_only_arg_when_one_missing():
@@ -169,9 +166,7 @@ async def test_create_session_provenance_nullable(db: StateDB):
     prog_id = _uid()
     sid = _uid()
     await db.create_progression(prog_id)
-    await db.create_session(
-        {"id": sid, "progression_id": prog_id, "status": "running"}
-    )
+    await db.create_session({"id": sid, "progression_id": prog_id, "status": "running"})
     row = await db.get_session(sid)
     assert row["model"] is None
     assert row["provider"] is None
@@ -186,9 +181,7 @@ async def test_create_branch_persists_per_branch_provenance(db: StateDB):
     bid = _uid()
     await db.create_progression(prog_id)
     await db.create_progression(bprog)
-    await db.create_session(
-        {"id": sid, "progression_id": prog_id, "status": "running"}
-    )
+    await db.create_session({"id": sid, "progression_id": prog_id, "status": "running"})
     await db.create_branch(
         {
             "id": bid,
@@ -210,12 +203,8 @@ async def test_update_session_allows_provenance_columns(db: StateDB):
     prog_id = _uid()
     sid = _uid()
     await db.create_progression(prog_id)
-    await db.create_session(
-        {"id": sid, "progression_id": prog_id, "status": "running"}
-    )
-    await db.update_session(
-        sid, model="openai/gpt-4.1", provider="openai", effort="medium"
-    )
+    await db.create_session({"id": sid, "progression_id": prog_id, "status": "running"})
+    await db.update_session(sid, model="openai/gpt-4.1", provider="openai", effort="medium")
     row = await db.get_session(sid)
     assert row["model"] == "openai/gpt-4.1"
     assert row["provider"] == "openai"

--- a/tests/state/test_status_reasons.py
+++ b/tests/state/test_status_reasons.py
@@ -524,3 +524,132 @@ class TestInvocationTransition:
             (inv_id,),
         )
         assert (await cur.fetchone())["n"] == 0
+
+
+# ── LIONAGI-AUDIT-002: update_session routes status through update_status ──
+
+
+class TestUpdateSessionRoutesStatusThroughHistory:
+    """Regression: update_session(status=...) must write a status_transitions row."""
+
+    async def test_status_update_writes_transition_row(self, db: StateDB):
+        sid = await _create_session(db)
+        await db.update_session(
+            sid,
+            status="failed",
+            reason_code=RunReasons.FAILED_EXCEPTION,
+            reason_summary="Crashed during execution.",
+        )
+        cur = await db.db.execute(
+            "SELECT status, status_reason_code, status_reason_summary FROM sessions WHERE id = ?",
+            (sid,),
+        )
+        row = dict(await cur.fetchone())
+        assert row["status"] == "failed"
+        assert row["status_reason_code"] == RunReasons.FAILED_EXCEPTION
+        assert "Crashed" in row["status_reason_summary"]
+
+        cur = await db.db.execute(
+            "SELECT entity_type, previous_status, status, reason_code "
+            "FROM status_transitions WHERE entity_id = ?",
+            (sid,),
+        )
+        rows = [dict(r) for r in await cur.fetchall()]
+        assert len(rows) == 1, "must write exactly one status_transitions row"
+        assert rows[0]["entity_type"] == "session"
+        assert rows[0]["previous_status"] == "running"
+        assert rows[0]["status"] == "failed"
+        assert rows[0]["reason_code"] == RunReasons.FAILED_EXCEPTION
+
+    async def test_status_without_reason_code_emits_deprecation_warning(self, db: StateDB):
+        import warnings
+
+        sid = await _create_session(db)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            await db.update_session(sid, status="completed")
+            deprecations = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert len(deprecations) == 1
+        assert "reason_code" in str(deprecations[0].message)
+
+        # Transition row still recorded.
+        cur = await db.db.execute(
+            "SELECT COUNT(*) AS n FROM status_transitions WHERE entity_id = ?",
+            (sid,),
+        )
+        assert (await cur.fetchone())["n"] == 1
+
+    async def test_non_status_fields_still_written(self, db: StateDB):
+        """Non-status fields (e.g. name) still update via the legacy path."""
+        sid = await _create_session(db)
+        await db.update_session(sid, name="new-name")
+        cur = await db.db.execute("SELECT name FROM sessions WHERE id = ?", (sid,))
+        row = dict(await cur.fetchone())
+        assert row["name"] == "new-name"
+
+        # No transition row for a non-status update.
+        cur = await db.db.execute(
+            "SELECT COUNT(*) AS n FROM status_transitions WHERE entity_id = ?",
+            (sid,),
+        )
+        assert (await cur.fetchone())["n"] == 0
+
+
+# ── LIONAGI-AUDIT-004: update_status rejects invalid source values ──────────
+
+
+class TestUpdateStatusSourceValidation:
+    """Regression: update_status() must reject source values outside the
+    closed vocabulary ('executor', 'agent', 'admin', 'system')."""
+
+    async def test_invalid_source_raises_valueerror(self, db: StateDB):
+        sid = await _create_session(db)
+        with pytest.raises(ValueError, match="source"):
+            await db.update_status(
+                "session",
+                sid,
+                new_status="failed",
+                reason_code=RunReasons.FAILED_EXCEPTION,
+                source="not-a-source",
+            )
+
+    async def test_invalid_source_does_not_write_row(self, db: StateDB):
+        """No entity or transition row must change when source is invalid."""
+        sid = await _create_session(db)
+        try:
+            await db.update_status(
+                "session",
+                sid,
+                new_status="failed",
+                reason_code=RunReasons.FAILED_EXCEPTION,
+                source="badactor",
+            )
+        except ValueError:
+            pass
+
+        cur = await db.db.execute(
+            "SELECT status, status_reason_code FROM sessions WHERE id = ?", (sid,)
+        )
+        row = dict(await cur.fetchone())
+        assert row["status"] == "running", "entity row must be unchanged on invalid source"
+        assert row["status_reason_code"] is None
+
+        cur = await db.db.execute(
+            "SELECT COUNT(*) AS n FROM status_transitions WHERE entity_id = ?", (sid,)
+        )
+        assert (await cur.fetchone())["n"] == 0
+
+    @pytest.mark.parametrize("source", ["executor", "agent", "admin", "system"])
+    async def test_valid_sources_accepted(self, db: StateDB, source: str):
+        sid = await _create_session(db)
+        await db.update_status(
+            "session",
+            sid,
+            new_status="completed",
+            reason_code=RunReasons.COMPLETED_OK,
+            source=source,
+        )
+        cur = await db.db.execute(
+            "SELECT source FROM status_transitions WHERE entity_id = ?", (sid,)
+        )
+        assert (await cur.fetchone())["source"] == source

--- a/tests/state/test_teams_schema.py
+++ b/tests/state/test_teams_schema.py
@@ -34,13 +34,11 @@ async def db():
 async def test_teams_table_exists_with_status_check(db: StateDB):
     """Schema CHECK accepts 'active' / 'archived' and rejects others."""
     await db.db.execute(
-        "INSERT INTO teams (id, name, created_at, updated_at, status) "
-        "VALUES (?, ?, ?, ?, ?)",
+        "INSERT INTO teams (id, name, created_at, updated_at, status) VALUES (?, ?, ?, ?, ?)",
         ("t1", "team-one", 1.0, 1.0, "active"),
     )
     await db.db.execute(
-        "INSERT INTO teams (id, name, created_at, updated_at, status) "
-        "VALUES (?, ?, ?, ?, ?)",
+        "INSERT INTO teams (id, name, created_at, updated_at, status) VALUES (?, ?, ?, ?, ?)",
         ("t2", "team-two", 1.0, 1.0, "archived"),
     )
 
@@ -48,16 +46,14 @@ async def test_teams_table_exists_with_status_check(db: StateDB):
 
     with pytest.raises(sqlite3.IntegrityError):
         await db.db.execute(
-            "INSERT INTO teams (id, name, created_at, updated_at, status) "
-            "VALUES (?, ?, ?, ?, ?)",
+            "INSERT INTO teams (id, name, created_at, updated_at, status) VALUES (?, ?, ?, ?, ?)",
             ("t3", "team-three", 1.0, 1.0, "frozen"),
         )
 
 
 async def test_team_messages_cascade_on_team_delete(db: StateDB):
     await db.db.execute(
-        "INSERT INTO teams (id, name, created_at, updated_at) "
-        "VALUES (?, ?, ?, ?)",
+        "INSERT INTO teams (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)",
         ("t1", "team-one", 1.0, 1.0),
     )
     await db.db.execute(
@@ -84,13 +80,10 @@ async def test_team_messages_session_id_fk_to_sessions(db: StateDB):
     prog_id = str(uuid.uuid4())
     sess_id = str(uuid.uuid4())
     await db.create_progression(prog_id)
-    await db.create_session(
-        {"id": sess_id, "progression_id": prog_id, "status": "running"}
-    )
+    await db.create_session({"id": sess_id, "progression_id": prog_id, "status": "running"})
 
     await db.db.execute(
-        "INSERT INTO teams (id, name, created_at, updated_at) "
-        "VALUES (?, ?, ?, ?)",
+        "INSERT INTO teams (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)",
         ("t1", "team-one", 1.0, 1.0),
     )
     await db.db.execute(
@@ -100,9 +93,7 @@ async def test_team_messages_session_id_fk_to_sessions(db: StateDB):
     )
     await db.db.commit()
 
-    cur = await db.db.execute(
-        "SELECT session_id FROM team_messages WHERE id = ?", ("m1",)
-    )
+    cur = await db.db.execute("SELECT session_id FROM team_messages WHERE id = ?", ("m1",))
     row = await cur.fetchone()
     assert row["session_id"] == sess_id
 
@@ -163,9 +154,7 @@ async def test_import_teams_loads_json_into_db(tmp_path: Path, monkeypatch):
 
     # Verify rows landed correctly.
     async with StateDB(state_db) as db:
-        cur = await db.db.execute(
-            "SELECT id, name, member_count, members, status FROM teams"
-        )
+        cur = await db.db.execute("SELECT id, name, member_count, members, status FROM teams")
         team_row = await cur.fetchone()
         assert team_row["id"] == "abc123"
         assert team_row["name"] == "review-team"
@@ -174,8 +163,7 @@ async def test_import_teams_loads_json_into_db(tmp_path: Path, monkeypatch):
         assert team_row["status"] == "active"
 
         cur = await db.db.execute(
-            "SELECT id, sender, recipient, content FROM team_messages "
-            "ORDER BY created_at"
+            "SELECT id, sender, recipient, content FROM team_messages ORDER BY created_at"
         )
         msgs = await cur.fetchall()
         assert len(msgs) == 2
@@ -193,9 +181,7 @@ async def test_import_teams_is_idempotent(tmp_path: Path, monkeypatch):
     state_db = tmp_path / "state.db"
 
     (teams_dir / "abc.json").write_text(
-        json.dumps(
-            {"id": "abc", "name": "t", "members": [], "messages": []}
-        )
+        json.dumps({"id": "abc", "name": "t", "members": [], "messages": []})
     )
 
     from lionagi.cli import state as state_mod


### PR DESCRIPTION
State/studio/runtime hardening:

- session **status-reason history**
- studio **artifact-endpoint auth** gating + scheduler fire-task lifecycle + build_argv validation
- engine/outcomes error surfacing
- **visible hook errors** (no silent swallow)
---
Part of the sliced **audit-remediation** series (replaces the monolithic #1276). Each slice is file-disjoint and cut from `main`. Full integration branch: `chore/audit-remediation` (7670 tests green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
