### PR TITLE
chore(ci): enable lionagi/ ruff gate

### DIFF
--- a/lionagi/testing/helpers.py
+++ b/lionagi/testing/helpers.py
@@ -17,6 +17,7 @@ from typing import Any, TypeVar
 
 from pydantic import Field as _Field
 
+from lionagi.ln import fail_after, gather, move_on_after
 from lionagi.protocols.generic.element import UUID, Element
 from lionagi.protocols.generic.event import EventStatus
 from lionagi.protocols.graph.node import Node
@@ -47,30 +48,41 @@ class AsyncTestHelpers:
         limit: int = 100,
         timeout: float = 10.0,
     ) -> list[T]:
+        """Collect up to *limit* items from an async generator within *timeout* seconds.
+
+        Uses ``lionagi.ln.move_on_after`` for Python 3.10-compatible timeout handling
+        (``asyncio.timeout`` requires Python 3.11+).
+        """
         results: list[T] = []
-        try:
-            async with asyncio.timeout(timeout):
-                async for item in async_gen:
-                    results.append(item)
-                    if len(results) >= limit:
-                        break
-        except asyncio.TimeoutError:
-            pass
+        with move_on_after(timeout):
+            async for item in async_gen:
+                results.append(item)
+                if len(results) >= limit:
+                    break
         return results
 
     @staticmethod
     async def run_with_timeout(
         coro: Callable[..., Any], timeout: float = 5.0, *args: Any, **kwargs: Any
     ) -> Any:
-        async with asyncio.timeout(timeout):
+        """Run *coro* with a hard timeout, raising ``TimeoutError`` on expiry.
+
+        Uses ``lionagi.ln.fail_after`` for Python 3.10-compatible timeout handling.
+        """
+        with fail_after(timeout):
             return await coro(*args, **kwargs)
 
     @staticmethod
     async def wait_for_all(tasks: list[asyncio.Task], timeout: float = 10.0) -> list[Any]:
+        """Await all *tasks* within *timeout* seconds.
+
+        Cancels any incomplete tasks on timeout and re-raises ``TimeoutError``.
+        Uses ``lionagi.ln.fail_after`` for Python 3.10-compatible timeout handling.
+        """
         try:
-            async with asyncio.timeout(timeout):
-                return await asyncio.gather(*tasks)
-        except asyncio.TimeoutError:
+            with fail_after(timeout):
+                return list(await gather(*tasks))
+        except TimeoutError:
             for task in tasks:
                 if not task.done():
                     task.cancel()

--- a/lionagi/testing/loaders.py
+++ b/lionagi/testing/loaders.py
@@ -26,9 +26,34 @@ class TestDataLoader:
         self.data_dir = Path(data_dir) if data_dir is not None else _DATA_DIR
 
     def load_json(self, filename: str) -> dict[str, Any]:
+        """Load a JSON fixture from within ``self.data_dir``.
+
+        *filename* must be a plain name (no path separators, no ``..``).
+        Absolute paths and traversal sequences are rejected fail-closed before
+        any filesystem access (LIONAGI-AUDIT-002 path-boundary fix).
+        """
+        import os
+
+        # Reject absolute paths and names containing any path separator.
+        if os.path.isabs(filename) or os.sep in filename or (os.altsep and os.altsep in filename):
+            raise ValueError(f"Filename must be a plain name, not a path: {filename!r}")
+        # Reject forward slashes explicitly (covers posix and windows altsep gaps).
+        if "/" in filename or "\\" in filename:
+            raise ValueError(f"Filename must be a plain name, not a path: {filename!r}")
+
         if not filename.endswith(".json"):
             filename += ".json"
-        file_path = self.data_dir / filename
+
+        data_dir_resolved = self.data_dir.resolve()
+        file_path = (data_dir_resolved / filename).resolve()
+
+        # Containment check — resolved path must stay inside data_dir.
+        if (
+            not str(file_path).startswith(str(data_dir_resolved) + os.sep)
+            and file_path != data_dir_resolved
+        ):
+            raise PermissionError(f"Fixture path escapes data directory: {filename!r}")
+
         if not file_path.exists():
             raise FileNotFoundError(f"Test data file not found: {file_path}")
         with open(file_path, encoding="utf-8") as f:

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -23,11 +23,8 @@ _require() {
 
 lint-python() {
   echo "==> ruff check"
-  # Scope to non-core paths by default. Core SDK (lionagi/) has pre-existing
-  # violations from the black+isort era; full migration tracked separately.
-  # Pre-commit ruff hook still catches violations in edited core files.
   if [ $# -eq 0 ]; then
-    uv run ruff check apps/ tests/ marketplace/ scripts/
+    uv run ruff check lionagi/ apps/ tests/ marketplace/ scripts/
   else
     uv run ruff check "$@"
   fi

--- a/tests/testing/test_helpers_audit.py
+++ b/tests/testing/test_helpers_audit.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# LIONAGI-AUDIT-001 — AsyncTestHelpers 3.10 compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncTestHelpersPy310:
+    """All three helpers must work on Python 3.10 (no asyncio.timeout)."""
+
+    async def test_collect_async_results_returns_items(self):
+        """collect_async_results works without asyncio.timeout."""
+        from lionagi.testing.helpers import AsyncTestHelpers
+
+        async def _gen():
+            for i in range(3):
+                yield i
+
+        results = await AsyncTestHelpers.collect_async_results(_gen(), timeout=5.0)
+        assert results == [0, 1, 2]
+
+    async def test_collect_async_results_respects_limit(self):
+        """collect_async_results stops at limit."""
+        from lionagi.testing.helpers import AsyncTestHelpers
+
+        async def _gen():
+            for i in range(100):
+                yield i
+
+        results = await AsyncTestHelpers.collect_async_results(_gen(), limit=5, timeout=5.0)
+        assert len(results) == 5
+
+    async def test_collect_async_results_times_out_without_error(self):
+        """collect_async_results returns partial results when generator is slow."""
+        from lionagi.testing.helpers import AsyncTestHelpers
+
+        collected = []
+
+        async def _slow_gen():
+            for i in range(10):
+                collected.append(i)
+                yield i
+                await asyncio.sleep(0.5)  # each item takes 0.5 s
+
+        # timeout is 0.2 s — we expect at most one item before timeout
+        results = await AsyncTestHelpers.collect_async_results(_slow_gen(), timeout=0.2)
+        assert len(results) <= 2, f"Too many items collected before timeout: {results}"
+
+    async def test_run_with_timeout_returns_result(self):
+        """run_with_timeout returns the coroutine result within the timeout."""
+        from lionagi.testing.helpers import AsyncTestHelpers
+
+        async def _fn():
+            return 42
+
+        result = await AsyncTestHelpers.run_with_timeout(_fn, timeout=5.0)
+        assert result == 42
+
+    async def test_run_with_timeout_raises_on_expiry(self):
+        """run_with_timeout raises TimeoutError when the coroutine exceeds the deadline."""
+        from lionagi.testing.helpers import AsyncTestHelpers
+
+        async def _slow():
+            await asyncio.sleep(10)
+
+        with pytest.raises(TimeoutError):
+            await AsyncTestHelpers.run_with_timeout(_slow, timeout=0.05)
+
+    async def test_wait_for_all_returns_results(self):
+        """wait_for_all returns results from all tasks."""
+        from lionagi.testing.helpers import AsyncTestHelpers
+
+        async def _one(n: int) -> int:
+            await asyncio.sleep(0)
+            return n
+
+        tasks = [asyncio.create_task(_one(i)) for i in range(3)]
+        results = await AsyncTestHelpers.wait_for_all(tasks, timeout=5.0)
+        assert sorted(results) == [0, 1, 2]
+
+    async def test_wait_for_all_cancels_tasks_on_timeout(self):
+        """wait_for_all cancels pending tasks and raises TimeoutError on expiry."""
+        from lionagi.testing.helpers import AsyncTestHelpers
+
+        async def _forever() -> int:
+            await asyncio.sleep(9999)
+            return 0
+
+        tasks = [asyncio.create_task(_forever())]
+        with pytest.raises(TimeoutError):
+            await AsyncTestHelpers.wait_for_all(tasks, timeout=0.05)
+
+        # Task must be cancelled
+        await asyncio.sleep(0)
+        assert tasks[0].cancelled() or tasks[0].done()
+
+
+# ---------------------------------------------------------------------------
+# LIONAGI-AUDIT-002 — TestDataLoader path traversal
+# ---------------------------------------------------------------------------
+
+
+class TestDataLoaderPathBoundary:
+    """Regression: TestDataLoader.load_json must not escape data_dir.
+
+    Attack scenario: caller passes '../../../benchmarks/baselines/fuzzy.json'
+    expecting the loader to read bundled fixtures, but the old implementation
+    silently traversed outside the package directory.
+    """
+
+    def test_traversal_with_dotdot_is_rejected(self, tmp_path):
+        """'../../../outside' must be rejected before any filesystem access."""
+        from lionagi.testing.loaders import TestDataLoader
+
+        # Create a data dir inside tmp_path and a file outside it
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        outside = tmp_path / "secret.json"
+        outside.write_text('{"secret": true}')
+
+        loader = TestDataLoader(data_dir=data_dir)
+
+        with pytest.raises((ValueError, PermissionError)):
+            loader.load_json("../secret")
+
+    def test_absolute_path_is_rejected(self, tmp_path):
+        """An absolute path as filename must be rejected."""
+        from lionagi.testing.loaders import TestDataLoader
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+
+        loader = TestDataLoader(data_dir=data_dir)
+
+        with pytest.raises(ValueError, match="plain name"):
+            loader.load_json("/etc/passwd")
+
+    def test_forward_slash_in_name_is_rejected(self, tmp_path):
+        """A filename containing '/' must be rejected."""
+        from lionagi.testing.loaders import TestDataLoader
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        loader = TestDataLoader(data_dir=data_dir)
+
+        with pytest.raises(ValueError, match="plain name"):
+            loader.load_json("subdir/secret")
+
+    def test_valid_filename_is_loaded(self, tmp_path):
+        """A plain filename inside data_dir loads correctly."""
+        from lionagi.testing.loaders import TestDataLoader
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        fixture = data_dir / "fixture.json"
+        fixture.write_text('{"key": "value"}')
+
+        loader = TestDataLoader(data_dir=data_dir)
+        result = loader.load_json("fixture")
+        assert result == {"key": "value"}
+
+    def test_missing_file_raises_file_not_found(self, tmp_path):
+        """A valid plain name that doesn't exist raises FileNotFoundError."""
+        from lionagi.testing.loaders import TestDataLoader
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        loader = TestDataLoader(data_dir=data_dir)
+
+        with pytest.raises(FileNotFoundError):
+            loader.load_json("nonexistent")


### PR DESCRIPTION
This pull request introduces important security and compatibility improvements to the test helpers and data loader utilities, along with expanded test coverage for these changes. The main themes are: (1) ensuring Python 3.10 compatibility for async test helpers by replacing `asyncio.timeout` with custom timeout context managers, (2) preventing path traversal vulnerabilities in `TestDataLoader.load_json`, and (3) adding regression tests for both areas.

**Async test helpers: Python 3.10 compatibility and robustness**
* Replaced all usage of `asyncio.timeout` in `AsyncTestHelpers` with the custom `fail_after` and `move_on_after` context managers from `lionagi.ln`, ensuring timeouts work on Python 3.10 and improving error handling and documentation. [[1]](diffhunk://#diff-aef420952a74d8053dbb55a75b870cb8a71c224a8f91bf37e917b6fd6228647fR20) [[2]](diffhunk://#diff-aef420952a74d8053dbb55a75b870cb8a71c224a8f91bf37e917b6fd6228647fR51-R85)
* Added regression tests in `tests/testing/test_helpers_audit.py` to verify that all async test helpers (`collect_async_results`, `run_with_timeout`, `wait_for_all`) work correctly under Python 3.10 and handle timeouts as expected.

**Test data loader: Path traversal hardening**
* Hardened `TestDataLoader.load_json` to strictly reject any filename that is an absolute path, contains path separators, or attempts path traversal, and added a containment check to ensure the resolved path stays within the intended data directory, closing a path traversal vulnerability (LIONAGI-AUDIT-002).
* Added regression tests to ensure `TestDataLoader.load_json` rejects path traversal attempts and only loads files within the allowed directory.

**Tooling**
* Updated `scripts/ci.sh` to include the `lionagi/` directory in the default scope for `ruff` linting, ensuring core code is checked for style violations.