### PR TITLE
fix(service): fingerprint full inline MCP transport in policy key (trust-leak follow-up to #1279)

### DIFF
--- a/lionagi/service/connections/mcp_wrapper.py
+++ b/lionagi/service/connections/mcp_wrapper.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -237,11 +238,24 @@ class MCPConnectionPool:
 
         Content-based (NOT ``id()``-based) so the key computed at registration
         matches the one computed from the metadata-stripped config at tool
-        invocation time.
+        invocation time. Both call sites pass the same non-underscore key set
+        (registration: the raw ``server_config``; invocation: that same dict
+        minus ``_``-prefixed metadata), so fingerprinting all non-``_`` keys
+        is stable across both.
+
+        For inline configs the key fingerprints the ENTIRE transport
+        definition (command + args + env + url + headers + …), not just the
+        command or URL. Two different inline servers that merely share an
+        executable (e.g. both ``python``) or a host would otherwise collide
+        on one key, letting an UNauthorized config recover a trusted config's
+        policy and bypass the fail-closed default.
         """
         if "server" in server_config:
             return f"server:{server_config['server']}"
-        return f"inline:{server_config.get('command') or server_config.get('url')}"
+        material = {k: v for k, v in server_config.items() if not k.startswith("_")}
+        blob = json.dumps(material, sort_keys=True, default=str)
+        digest = hashlib.sha256(blob.encode("utf-8")).hexdigest()
+        return f"inline:{digest}"
 
     @classmethod
     def remember_security(

--- a/tests/service/test_mcp_security.py
+++ b/tests/service/test_mcp_security.py
@@ -488,10 +488,12 @@ class TestPerServerPolicyPersistence:
         try:
             policy = MCPSecurityConfig(allow_commands=True)
             # Trusted load records the policy (no client created — tool_names path).
-            MCPConnectionPool.remember_security({"command": "echo", "args": []}, policy)
+            MCPConnectionPool.remember_security({"command": "echo", "args": ["a"]}, policy)
             # Stored callable invokes get_client WITHOUT a policy, with a fresh
-            # dict of the same content — the recorded policy must be recovered.
-            await MCPConnectionPool.get_client({"command": "echo", "args": ["x"]})
+            # dict of the SAME content (the real flow strips only `_`-prefixed
+            # metadata, so transport fields are identical) — the recorded policy
+            # must be recovered.
+            await MCPConnectionPool.get_client({"command": "echo", "args": ["a"]})
             assert seen[-1] is policy
         finally:
             self._reset()
@@ -555,5 +557,64 @@ class TestPerServerPolicyPersistence:
             )
             key = MCPConnectionPool._policy_key({"command": "echo", "args": []})
             assert MCPConnectionPool._server_security[key] is policy
+        finally:
+            self._reset()
+
+    async def test_shared_command_different_args_do_not_share_policy(self, monkeypatch):
+        """Codex follow-up: the inline policy key must fingerprint the WHOLE
+        transport, not just the command/url. A trusted
+        ``{command: python, args: [safe.py]}`` must NOT authorize a different
+        ``{command: python, args: [-c, ...]}`` that merely shares the executable.
+        """
+        self._reset()
+        seen = []
+
+        async def fake_create(config, security=None):
+            seen.append(security)
+            return object()
+
+        monkeypatch.setattr(MCPConnectionPool, "_create_client", staticmethod(fake_create))
+        try:
+            policy = MCPSecurityConfig(allow_commands=True)
+            safe = {"command": "python", "args": ["safe_server.py"]}
+            evil = {"command": "python", "args": ["-c", "import os; os.system('x')"]}
+
+            # Distinct fingerprints — the leak would make these collide.
+            assert MCPConnectionPool._policy_key(safe) != MCPConnectionPool._policy_key(evil)
+
+            # Trust only the safe config.
+            MCPConnectionPool.remember_security(safe, policy)
+
+            # The evil config must NOT recover the safe policy → stays fail-closed.
+            await MCPConnectionPool.get_client(evil)
+            assert seen[-1] is None, "different args must not inherit another config's policy"
+
+            # The safe config still recovers its own policy.
+            await MCPConnectionPool.get_client(safe)
+            assert seen[-1] is policy
+        finally:
+            self._reset()
+
+    async def test_shared_url_different_headers_do_not_share_policy(self, monkeypatch):
+        """Same leak for HTTP transports keyed only on URL."""
+        self._reset()
+        seen = []
+
+        async def fake_create(config, security=None):
+            seen.append(security)
+            return object()
+
+        monkeypatch.setattr(MCPConnectionPool, "_create_client", staticmethod(fake_create))
+        try:
+            policy = MCPSecurityConfig(allow_urls=True)
+            trusted = {"url": "https://api.example.com", "headers": {"X-Tenant": "a"}}
+            other = {"url": "https://api.example.com", "headers": {"X-Tenant": "b"}}
+
+            assert MCPConnectionPool._policy_key(trusted) != MCPConnectionPool._policy_key(
+                other
+            )
+            MCPConnectionPool.remember_security(trusted, policy)
+            await MCPConnectionPool.get_client(other)
+            assert seen[-1] is None
         finally:
             self._reset()


### PR DESCRIPTION
## Problem (Codex follow-up on merged #1279)

The per-server MCP policy registry keys **inline** configs on command-or-url only:

```python
return f"inline:{server_config.get('command') or server_config.get('url')}"
```

So two *different* inline servers that merely share an executable or host collide on one key. A trusted load of `{"command": "python", "args": ["safe_server.py"]}` records its allow-policy under `inline:python`; a later, **unauthorized** `get_client({"command": "python", "args": ["-c", "..."]})` recovers that policy and bypasses the fail-closed default (`allow_commands=False`).

## Fix

`_policy_key` now SHA-256 fingerprints the **entire** non-`_` transport definition (command + args + env + url + headers + …) for inline configs. Server-reference configs still key on the server name.

Registration passes the raw `server_config`; invocation passes that same dict minus `_`-prefixed metadata (`create_mcp_tool`/`mcp_callable`). Both therefore share an identical non-`_` key set, so the fingerprint is stable across both sides — recovery for the *same* server still works, while a different transport no longer inherits another's authorization.

## Tests
- `test_shared_command_different_args_do_not_share_policy` — distinct keys; evil config stays fail-closed (`None`); safe config still recovers its own policy.
- `test_shared_url_different_headers_do_not_share_policy` — same for HTTP transports.
- Fixed `test_invocation_without_security_recovers_recorded_policy` to use identical transport content (the prior `[]` vs `["x"]` modeled "same content" but actually changed it — exactly the leak this closes).

38 pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)