### PR TITLE
fix(providers,tools): guard os.killpg on non-Unix platforms (Windows AttributeError)

### DIFF
--- a/lionagi/providers/anthropic/claude_code/models.py
+++ b/lionagi/providers/anthropic/claude_code/models.py
@@ -9,7 +9,9 @@ import contextlib
 import inspect
 import json
 import logging
+import os
 import shutil
+import signal
 from collections.abc import AsyncIterator, Callable
 from datetime import datetime, timezone
 from functools import partial
@@ -573,7 +575,14 @@ async def _ndjson_from_cli(request: ClaudeCodeRequest):
     # Guard against mocked subprocesses in tests where proc.pid may not
     # be a real int: a MagicMock.pid coerces to 1 via __int__, and
     # os.killpg(1, SIGTERM) signals init/the CI runner.
-    _claude_pgid: int | None = proc.pid if isinstance(proc.pid, int) and proc.pid > 1 else None
+    # os.killpg is POSIX-only: on Windows leave _pgid None so the group-kill
+    # path is skipped and cleanup falls through to proc.terminate()/kill()
+    # instead of raising AttributeError from the finally block.
+    _claude_pgid: int | None = (
+        proc.pid
+        if hasattr(os, "killpg") and isinstance(proc.pid, int) and proc.pid > 1
+        else None
+    )
 
     decoder = codecs.getincrementaldecoder("utf-8")()
     json_decoder = json.JSONDecoder()
@@ -659,9 +668,6 @@ async def _ndjson_from_cli(request: ClaudeCodeRequest):
         # Terminate the whole process group (start_new_session=True
         # above made pgid == proc.pid). Captured up-front so a reap
         # before teardown doesn't make us skip the group kill.
-        import os
-        import signal
-
         pgid = _claude_pgid
         if pgid is not None:
             with contextlib.suppress(ProcessLookupError, PermissionError):

--- a/lionagi/providers/openai/codex/models.py
+++ b/lionagi/providers/openai/codex/models.py
@@ -9,7 +9,9 @@ import contextlib
 import inspect
 import json
 import logging
+import os
 import shutil
+import signal
 import warnings
 from collections.abc import AsyncIterator, Callable
 from functools import partial
@@ -494,7 +496,14 @@ async def _ndjson_from_cli(request: CodexCodeRequest):
     # Guard against mocked subprocesses in tests where proc.pid may not
     # be a real int: a MagicMock.pid coerces to 1 via __int__, and
     # os.killpg(1, SIGTERM) signals init/the CI runner.
-    _codex_pgid: int | None = proc.pid if isinstance(proc.pid, int) and proc.pid > 1 else None
+    # os.killpg is POSIX-only: on Windows leave _pgid None so the group-kill
+    # path is skipped and cleanup falls through to proc.terminate()/kill()
+    # instead of raising AttributeError from the finally block.
+    _codex_pgid: int | None = (
+        proc.pid
+        if hasattr(os, "killpg") and isinstance(proc.pid, int) and proc.pid > 1
+        else None
+    )
 
     decoder = codecs.getincrementaldecoder("utf-8")()
     json_decoder = json.JSONDecoder()
@@ -581,9 +590,6 @@ async def _ndjson_from_cli(request: CodexCodeRequest):
         # Terminate the whole process group (start_new_session=True
         # above made pgid == proc.pid). Captured up-front so a reap
         # before teardown doesn't make us skip the group kill.
-        import os
-        import signal
-
         pgid = _codex_pgid
         if pgid is not None:
             with contextlib.suppress(ProcessLookupError, PermissionError):

--- a/lionagi/tools/code/bash.py
+++ b/lionagi/tools/code/bash.py
@@ -150,7 +150,8 @@ def _subprocess_sync(
     try:
         proc.wait(timeout=timeout_sec)
     except subprocess.TimeoutExpired:
-        if isinstance(proc.pid, int) and proc.pid > 1:
+        # os.killpg is POSIX-only; on Windows fall through to proc.kill().
+        if hasattr(os, "killpg") and isinstance(proc.pid, int) and proc.pid > 1:
             with contextlib.suppress(ProcessLookupError, OSError):
                 os.killpg(proc.pid, signal.SIGKILL)
         else:

--- a/lionagi/tools/coding.py
+++ b/lionagi/tools/coding.py
@@ -514,7 +514,8 @@ def _subprocess_sync(cmd, shell: bool, timeout_s: float, cwd: str | None) -> dic
     try:
         proc.wait(timeout=timeout_s)
     except subprocess.TimeoutExpired:
-        if isinstance(proc.pid, int) and proc.pid > 1:
+        # os.killpg is POSIX-only; on Windows fall through to proc.kill().
+        if hasattr(os, "killpg") and isinstance(proc.pid, int) and proc.pid > 1:
             with contextlib.suppress(ProcessLookupError, OSError):
                 os.killpg(proc.pid, signal.SIGKILL)
         else:

--- a/tests/service/connections/providers/test_cli_cancellation.py
+++ b/tests/service/connections/providers/test_cli_cancellation.py
@@ -465,3 +465,63 @@ class TestEmptyResponsesGuard:
             # Must not raise IndexError on responses[-1]
             result = await endpoint._call({"request": mock_request}, {})
             assert isinstance(result, dict)
+
+
+# ---------------------------------------------------------------------------
+# 7. Non-Unix cleanup: os.killpg unavailable must not break cleanup
+# ---------------------------------------------------------------------------
+
+
+def _make_cleanup_mock_proc(pid=12345):
+    mock_proc = MagicMock()
+    mock_proc.pid = pid
+    mock_proc.stdout = MagicMock()
+    mock_proc.stdout.read = AsyncMock(return_value=b"")
+    mock_proc.stderr = MagicMock()
+    mock_proc.stderr.read = AsyncMock(return_value=b"")
+    mock_proc.wait = AsyncMock(return_value=0)
+    mock_proc.terminate = MagicMock()
+    mock_proc.kill = MagicMock()
+    return mock_proc
+
+
+class TestKillpgUnavailablePlatform:
+    """os.killpg is POSIX-only. On Windows a real pid still set _pgid, so the
+    finally-block killpg call raised AttributeError (only ProcessLookupError /
+    PermissionError suppressed), failing even a successful run. Cleanup must
+    fall through to proc.terminate() instead."""
+
+    @pytest.mark.asyncio
+    async def test_claude_cleanup_no_killpg_platform(self, monkeypatch):
+        from lionagi.providers.anthropic.claude_code import models
+
+        request = models.ClaudeCodeRequest(prompt="test")
+        mock_proc = _make_cleanup_mock_proc(pid=9201)
+        monkeypatch.delattr(models.os, "killpg", raising=False)
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_exec.return_value = mock_proc
+            async with contextlib.aclosing(models._ndjson_from_cli(request)) as stream:
+                async for _ in stream:
+                    pass
+
+        mock_proc.terminate.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_codex_cleanup_no_killpg_platform(self, monkeypatch):
+        from lionagi.providers.openai.codex import models
+
+        request = models.CodexCodeRequest(prompt="test")
+        mock_proc = _make_cleanup_mock_proc(pid=9202)
+        monkeypatch.delattr(models.os, "killpg", raising=False)
+
+        with (
+            patch("lionagi.providers.openai.codex.models.CODEX_CLI", "codex"),
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
+        ):
+            mock_exec.return_value = mock_proc
+            async with contextlib.aclosing(models._ndjson_from_cli(request)) as stream:
+                async for _ in stream:
+                    pass
+
+        mock_proc.terminate.assert_called()


### PR DESCRIPTION
## Problem

Follow-up to the fix in #1278 (Gemini/Pi). The **same** `os.killpg` bug is live on main in four other subprocess-cleanup sites. `os.killpg` is POSIX-only; on Windows a real subprocess pid still drives the process-group kill path:

- **Streaming providers** (`claude_code`, `codex`): the `finally` block suppresses only `ProcessLookupError`/`PermissionError`, so `os.killpg` raising `AttributeError` propagates — failing even a **successful** CLI run at teardown and skipping the `proc.terminate()` fallback.
- **Sync tools** (`tools/coding.py`, `tools/code/bash.py`): the timeout handler suppresses `(ProcessLookupError, OSError)`; `AttributeError` escapes and the existing `else: proc.kill()` fallback is skipped.

## Fix

- `claude_code` / `codex`: gate the `_pgid` capture on `hasattr(os, "killpg")` → on Windows `_pgid` stays `None`, the group-kill path is skipped, and cleanup falls through to `proc.terminate()`/`proc.kill()`. Also **hoisted `os`/`signal` to module-level imports**: the providers had a local `import os` inside the `finally` block, which makes `os` a function-local name for the whole function — the new top-of-function `hasattr(os, ...)` would otherwise raise `UnboundLocalError`.
- `tools/coding`, `tools/code/bash`: add `hasattr(os, "killpg")` to the `if`-condition so Windows takes the existing `else: proc.kill()` branch.

## Tests
- `TestKillpgUnavailablePlatform` — `monkeypatch.delattr(os, "killpg")` for claude & codex → stream completes cleanly (no `AttributeError`), `proc.terminate()` still called.
- 15 cancellation tests + 96 provider/tool tests pass, ruff clean.

## Relationship to #1278
#1278 fixes the same class of bug for Gemini/Pi (where the group-kill was newly introduced). This PR covers the four sibling sites that predate it and are already on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)