### PR TITLE
fix(format): apply ruff format to 7 files failing the lionagi/ gate (#1289)

### DIFF
--- a/lionagi/cli/kill.py
+++ b/lionagi/cli/kill.py
@@ -595,8 +595,7 @@ async def _do_kill(
                     blocked.append(r)
                 else:
                     print(
-                        f"  killed child {child_type} {child_row['id'][:12]} "
-                        f"(signal={r['signal']})"
+                        f"  killed child {child_type} {child_row['id'][:12]} (signal={r['signal']})"
                     )
 
         r = await _kill_one(

--- a/lionagi/providers/anthropic/claude_code/models.py
+++ b/lionagi/providers/anthropic/claude_code/models.py
@@ -579,9 +579,7 @@ async def _ndjson_from_cli(request: ClaudeCodeRequest):
     # path is skipped and cleanup falls through to proc.terminate()/kill()
     # instead of raising AttributeError from the finally block.
     _claude_pgid: int | None = (
-        proc.pid
-        if hasattr(os, "killpg") and isinstance(proc.pid, int) and proc.pid > 1
-        else None
+        proc.pid if hasattr(os, "killpg") and isinstance(proc.pid, int) and proc.pid > 1 else None
     )
 
     decoder = codecs.getincrementaldecoder("utf-8")()

--- a/lionagi/providers/google/gemini_code/models.py
+++ b/lionagi/providers/google/gemini_code/models.py
@@ -320,9 +320,7 @@ async def _ndjson_from_cli(request: GeminiCodeRequest):
     # through to proc.terminate()/proc.kill() instead of raising AttributeError
     # from the finally block (which only suppresses ProcessLookupError).
     _pgid: int | None = (
-        proc.pid
-        if hasattr(os, "killpg") and isinstance(proc.pid, int) and proc.pid > 1
-        else None
+        proc.pid if hasattr(os, "killpg") and isinstance(proc.pid, int) and proc.pid > 1 else None
     )
 
     decoder = codecs.getincrementaldecoder("utf-8")()

--- a/lionagi/providers/openai/codex/models.py
+++ b/lionagi/providers/openai/codex/models.py
@@ -500,9 +500,7 @@ async def _ndjson_from_cli(request: CodexCodeRequest):
     # path is skipped and cleanup falls through to proc.terminate()/kill()
     # instead of raising AttributeError from the finally block.
     _codex_pgid: int | None = (
-        proc.pid
-        if hasattr(os, "killpg") and isinstance(proc.pid, int) and proc.pid > 1
-        else None
+        proc.pid if hasattr(os, "killpg") and isinstance(proc.pid, int) and proc.pid > 1 else None
     )
 
     decoder = codecs.getincrementaldecoder("utf-8")()

--- a/lionagi/providers/pi/cli/models.py
+++ b/lionagi/providers/pi/cli/models.py
@@ -505,9 +505,7 @@ async def _ndjson_from_cli(request: PiCodeRequest):
     # through to proc.terminate()/proc.kill() instead of raising AttributeError
     # from the finally block (which only suppresses ProcessLookupError).
     _pgid: int | None = (
-        proc.pid
-        if hasattr(os, "killpg") and isinstance(proc.pid, int) and proc.pid > 1
-        else None
+        proc.pid if hasattr(os, "killpg") and isinstance(proc.pid, int) and proc.pid > 1 else None
     )
 
     decoder = codecs.getincrementaldecoder("utf-8")()

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -69,9 +69,7 @@ async def _resolve_invocation_terminal(
             }
             if RunReasons.CANCELLED_SIGINT in aborted_reasons:
                 reason_code = RunReasons.CANCELLED_SIGINT
-                reason_summary = (
-                    "Invocation was interrupted (SIGINT) because a child session was."
-                )
+                reason_summary = "Invocation was interrupted (SIGINT) because a child session was."
             else:
                 reason_code = RunReasons.ABORTED_USER
                 reason_summary = (
@@ -429,9 +427,7 @@ class SchedulerEngine:
         try:
             argv = build_argv(schedule, trigger_context)
         except Exception as exc:
-            _log.exception(
-                "Invalid schedule action for %s (run %s)", schedule.get("name"), run_id
-            )
+            _log.exception("Invalid schedule action for %s (run %s)", schedule.get("name"), run_id)
             _end_time = time.time()
             next_at = self._compute_next_fire(schedule, now)
             async with StateDB() as db:
@@ -462,10 +458,8 @@ class SchedulerEngine:
                     actor=run_id,
                     metadata={"exception_class": type(exc).__name__},
                 )
-                inv_status, inv_rc, inv_rs, inv_ev, inv_meta = (
-                    await _resolve_invocation_terminal(
-                        db, inv_id, fallback_status="failed", exception=exc
-                    )
+                inv_status, inv_rc, inv_rs, inv_ev, inv_meta = await _resolve_invocation_terminal(
+                    db, inv_id, fallback_status="failed", exception=exc
                 )
                 await db.update_invocation(inv_id, ended_at=_end_time)
                 await db.update_status(
@@ -633,11 +627,13 @@ class SchedulerEngine:
                         evidence_refs=[{"kind": "schedule", "id": sid}],
                         reason_actor=run_id,
                     )
-                    inv_status, inv_rc, inv_rs, inv_ev, inv_meta = (
-                        await _resolve_invocation_terminal(
-                            db, inv_id, fallback_status="cancelled"
-                        )
-                    )
+                    (
+                        inv_status,
+                        inv_rc,
+                        inv_rs,
+                        inv_ev,
+                        inv_meta,
+                    ) = await _resolve_invocation_terminal(db, inv_id, fallback_status="cancelled")
                     await db.update_invocation(inv_id, ended_at=_end_time)
                     await db.update_status(
                         "invocation",
@@ -651,9 +647,7 @@ class SchedulerEngine:
                         metadata=inv_meta,
                     )
             except Exception:
-                _log.exception(
-                    "Failed to record cancellation for run %s during shutdown", run_id
-                )
+                _log.exception("Failed to record cancellation for run %s during shutdown", run_id)
             raise
         except Exception as exc:
             _log.exception("Error in schedule fire %s (run %s)", schedule.get("name"), run_id)

--- a/lionagi/studio/scheduler/subprocess.py
+++ b/lionagi/studio/scheduler/subprocess.py
@@ -104,9 +104,7 @@ async def spawn_and_wait(argv: list[str], invocation_id: str) -> tuple[int, str]
     # path is skipped and cleanup falls through to proc.terminate()/kill()
     # instead of raising AttributeError.
     _pgid: int | None = (
-        proc.pid
-        if hasattr(os, "killpg") and isinstance(proc.pid, int) and proc.pid > 1
-        else None
+        proc.pid if hasattr(os, "killpg") and isinstance(proc.pid, int) and proc.pid > 1 else None
     )
 
     try:


### PR DESCRIPTION
Closes #1289

## Summary

- 7 files failed the ruff format gate enabled by commit 8c56843cd (pinned ruff v0.15.11)
- Pure formatter pass — zero behavior change, zero logic touched
- All 7 files now pass \`ruff format --check\` and \`ruff check\`

## Files changed

| File | Change |
|---|---|
| \`lionagi/cli/kill.py\` | 2 f-string lines merged (fit <100 chars) |
| \`lionagi/providers/anthropic/claude_code/models.py\` | 3-line ternary collapsed |
| \`lionagi/providers/openai/codex/models.py\` | 3-line ternary collapsed |
| \`lionagi/providers/google/gemini_code/models.py\` | 3-line ternary collapsed |
| \`lionagi/providers/pi/cli/models.py\` | 3-line ternary collapsed |
| \`lionagi/studio/scheduler/engine.py\` | 5 formatting adjustments |
| \`lionagi/studio/scheduler/subprocess.py\` | 3-line ternary collapsed |

Note: the issue spec listed 5 files (CLI-001, providers-ruff, scheduler-ruff). A full \`ruff format --check lionagi/\` scan found 2 additional failing files (gemini, pi) with the same pattern. All 7 fixed to make the gate fully clean.

## Verification

```
$ uv run ruff format --check lionagi/
491 files already formatted

$ uv run ruff check <7 files>
All checks passed!

$ uv run pytest tests/cli/test_kill.py tests/engines/test_engine.py \
    tests/service/connections/providers/test_pi_cli.py \
    tests/service/connections/providers/test_claude_code_cli.py -v
110 passed in 4.68s
```

No new tests added — formatter-only fix per the issue spec.