### PR TITLE
fix(agent): make PyYAML a core dependency so lionagi.agent imports on base install

### DIFF
--- a/lionagi/agent/settings.py
+++ b/lionagi/agent/settings.py
@@ -46,23 +46,12 @@ __all__ = (
     "load_settings",
 )
 
+import yaml
+
 from .config import AgentConfig
 from .spec import AgentSpec
 
 logger = logging.getLogger(__name__)
-
-
-def _yaml_safe_load(stream: Any) -> Any:
-    """Lazily import yaml and parse *stream*, raising ImportError with install hint on miss."""
-    try:
-        import yaml  # noqa: PLC0415 — intentional lazy import; yaml is optional
-    except ImportError as exc:
-        raise ImportError(
-            "PyYAML is required to load .lionagi/settings.yaml. "
-            "Install it with: pip install pyyaml  (or add pyyaml to your project deps)."
-        ) from exc
-    return yaml.safe_load(stream)
-
 
 _DEFAULT_TRUSTED_HOOK_MODULES: frozenset[str] = frozenset({"lionagi.agent.hooks"})
 
@@ -84,7 +73,7 @@ def load_settings(
     global_path = Path.home() / ".lionagi" / "settings.yaml"
     if global_path.is_file():
         with open(global_path) as f:
-            global_settings = _yaml_safe_load(f) or {}
+            global_settings = yaml.safe_load(f) or {}
         _deep_merge(merged, global_settings)
 
     if not include_project:
@@ -94,7 +83,7 @@ def load_settings(
         local_path = Path(project_dir) / ".lionagi" / "settings.yaml"
         if local_path.is_file():
             with open(local_path) as f:
-                local_settings = _yaml_safe_load(f) or {}
+                local_settings = yaml.safe_load(f) or {}
             _deep_merge(merged, local_settings)
     else:
         cwd = Path.cwd()
@@ -102,7 +91,7 @@ def load_settings(
             candidate = parent / ".lionagi" / "settings.yaml"
             if candidate.is_file():
                 with open(candidate) as f:
-                    local_settings = _yaml_safe_load(f) or {}
+                    local_settings = yaml.safe_load(f) or {}
                 _deep_merge(merged, local_settings)
                 break
 

--- a/lionagi/agent/settings.py
+++ b/lionagi/agent/settings.py
@@ -46,12 +46,23 @@ __all__ = (
     "load_settings",
 )
 
-import yaml
-
 from .config import AgentConfig
 from .spec import AgentSpec
 
 logger = logging.getLogger(__name__)
+
+
+def _yaml_safe_load(stream: Any) -> Any:
+    """Lazily import yaml and parse *stream*, raising ImportError with install hint on miss."""
+    try:
+        import yaml  # noqa: PLC0415 — intentional lazy import; yaml is optional
+    except ImportError as exc:
+        raise ImportError(
+            "PyYAML is required to load .lionagi/settings.yaml. "
+            "Install it with: pip install pyyaml  (or add pyyaml to your project deps)."
+        ) from exc
+    return yaml.safe_load(stream)
+
 
 _DEFAULT_TRUSTED_HOOK_MODULES: frozenset[str] = frozenset({"lionagi.agent.hooks"})
 
@@ -73,7 +84,7 @@ def load_settings(
     global_path = Path.home() / ".lionagi" / "settings.yaml"
     if global_path.is_file():
         with open(global_path) as f:
-            global_settings = yaml.safe_load(f) or {}
+            global_settings = _yaml_safe_load(f) or {}
         _deep_merge(merged, global_settings)
 
     if not include_project:
@@ -83,7 +94,7 @@ def load_settings(
         local_path = Path(project_dir) / ".lionagi" / "settings.yaml"
         if local_path.is_file():
             with open(local_path) as f:
-                local_settings = yaml.safe_load(f) or {}
+                local_settings = _yaml_safe_load(f) or {}
             _deep_merge(merged, local_settings)
     else:
         cwd = Path.cwd()
@@ -91,7 +102,7 @@ def load_settings(
             candidate = parent / ".lionagi" / "settings.yaml"
             if candidate.is_file():
                 with open(candidate) as f:
-                    local_settings = yaml.safe_load(f) or {}
+                    local_settings = _yaml_safe_load(f) or {}
                 _deep_merge(merged, local_settings)
                 break
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "aiosqlite>=0.21.0",
     "orjson>=3.11.8",
     "psutil>=5.9.0",
+    "pyyaml>=6.0",
 ]
 license = {file = "LICENSE"}
 classifiers=[

--- a/tests/agent/test_public_import.py
+++ b/tests/agent/test_public_import.py
@@ -1,45 +1,28 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Regression tests for lazy PyYAML import in lionagi.agent.
+"""Regression tests for the lionagi.agent public import surface.
 
-Issue: importing lionagi.agent transitively triggered a module-level ``import yaml``
-in lionagi/agent/settings.py, which raised ModuleNotFoundError on a base install
-(PyYAML is an optional dependency).
+``import lionagi.agent`` transitively imports lionagi/agent/settings.py, which
+imports PyYAML at module level. On a base install where PyYAML was only an
+optional dependency this raised ModuleNotFoundError.
 
-Fix: the ``yaml`` import is moved inside ``_yaml_safe_load()``, the private helper
-called only when a settings.yaml file is actually read.  The public package surface
-(``lionagi.agent``) must import cleanly even when PyYAML is absent.
+Fix: PyYAML is declared as a core runtime dependency, so the public package
+surface imports cleanly on a base install. These tests guard both halves: the
+import succeeds, and PyYAML stays a core (non-optional) dependency so the
+failure cannot silently return.
 """
 
 from __future__ import annotations
 
 import importlib
-import sys
+from pathlib import Path
 
-import pytest
-
-# ---------------------------------------------------------------------------
-# Trust-boundary regression: import must succeed without PyYAML
-# ---------------------------------------------------------------------------
+import toml
 
 
-def test_lionagi_agent_imports_without_pyyaml(monkeypatch):
-    """``import lionagi.agent`` succeeds even when PyYAML is not installed.
-
-    Regression guard for the module-level ``import yaml`` that was present in
-    lionagi/agent/settings.py.  The import must complete without raising
-    ModuleNotFoundError.
-    """
-    # Simulate PyYAML being absent by blocking it in sys.modules.
-    monkeypatch.setitem(sys.modules, "yaml", None)  # type: ignore[arg-type]
-
-    # Drop any cached import so we exercise the actual import machinery.
-    for key in list(sys.modules.keys()):
-        if key == "lionagi.agent" or key.startswith("lionagi.agent."):
-            monkeypatch.delitem(sys.modules, key)
-
-    # This must not raise — the import is the test.
+def test_lionagi_agent_public_surface_imports():
+    """``import lionagi.agent`` exposes its documented public surface."""
     mod = importlib.import_module("lionagi.agent")
 
     assert hasattr(mod, "AgentConfig"), "AgentConfig must be accessible after import"
@@ -47,26 +30,21 @@ def test_lionagi_agent_imports_without_pyyaml(monkeypatch):
     assert hasattr(mod, "create_agent"), "create_agent must be accessible after import"
 
 
-def test_load_settings_raises_clear_error_when_pyyaml_absent(monkeypatch, tmp_path):
-    """``load_settings()`` raises ImportError with an install hint when PyYAML is absent.
+def test_pyyaml_is_a_core_dependency():
+    """PyYAML must stay in core dependencies, not an optional extra.
 
-    The error must only surface when the yaml-loading function is actually called
-    (i.e., when a settings.yaml file exists and is read), not at import time.
+    Importing lionagi.agent requires PyYAML at module load time; if it regresses
+    to an optional extra, a base install breaks again. This pins the contract.
     """
-    # Create a real settings.yaml so load_settings actually tries to read it.
-    settings_dir = tmp_path / ".lionagi"
-    settings_dir.mkdir()
-    (settings_dir / "settings.yaml").write_text("hooks: {}\n")
+    pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    if not pyproject.is_file():
+        import pytest
 
-    # Block PyYAML so the lazy import inside _yaml_safe_load fails.
-    # We also remove the cached yaml module so the import attempt inside
-    # _yaml_safe_load actually hits the blocked entry.
-    monkeypatch.setitem(sys.modules, "yaml", None)  # type: ignore[arg-type]
+        pytest.skip("pyproject.toml not available (installed package)")
 
-    from lionagi.agent.settings import _yaml_safe_load
+    data = toml.load(pyproject)
+    core_deps = data["project"]["dependencies"]
 
-    with pytest.raises(ImportError, match="PyYAML is required"):
-        # Open the yaml file and pass its stream to the helper — simulates
-        # exactly the path that load_settings takes when reading settings.yaml.
-        with open(settings_dir / "settings.yaml") as f:
-            _yaml_safe_load(f)
+    assert any(dep.lower().replace("_", "-").startswith("pyyaml") for dep in core_deps), (
+        f"pyyaml must be a core dependency, got: {core_deps}"
+    )

--- a/tests/agent/test_public_import.py
+++ b/tests/agent/test_public_import.py
@@ -20,7 +20,7 @@ import sys
 import pytest
 
 # ---------------------------------------------------------------------------
-# Trust-boundary regression: import must succeed without PyYAML (AGENT-001)
+# Trust-boundary regression: import must succeed without PyYAML
 # ---------------------------------------------------------------------------
 
 

--- a/tests/agent/test_public_import.py
+++ b/tests/agent/test_public_import.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for lazy PyYAML import in lionagi.agent.
+
+Issue: importing lionagi.agent transitively triggered a module-level ``import yaml``
+in lionagi/agent/settings.py, which raised ModuleNotFoundError on a base install
+(PyYAML is an optional dependency).
+
+Fix: the ``yaml`` import is moved inside ``_yaml_safe_load()``, the private helper
+called only when a settings.yaml file is actually read.  The public package surface
+(``lionagi.agent``) must import cleanly even when PyYAML is absent.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Trust-boundary regression: import must succeed without PyYAML (AGENT-001)
+# ---------------------------------------------------------------------------
+
+
+def test_lionagi_agent_imports_without_pyyaml(monkeypatch):
+    """``import lionagi.agent`` succeeds even when PyYAML is not installed.
+
+    Regression guard for the module-level ``import yaml`` that was present in
+    lionagi/agent/settings.py.  The import must complete without raising
+    ModuleNotFoundError.
+    """
+    # Simulate PyYAML being absent by blocking it in sys.modules.
+    monkeypatch.setitem(sys.modules, "yaml", None)  # type: ignore[arg-type]
+
+    # Drop any cached import so we exercise the actual import machinery.
+    for key in list(sys.modules.keys()):
+        if key == "lionagi.agent" or key.startswith("lionagi.agent."):
+            monkeypatch.delitem(sys.modules, key)
+
+    # This must not raise — the import is the test.
+    mod = importlib.import_module("lionagi.agent")
+
+    assert hasattr(mod, "AgentConfig"), "AgentConfig must be accessible after import"
+    assert hasattr(mod, "load_settings"), "load_settings must be accessible after import"
+    assert hasattr(mod, "create_agent"), "create_agent must be accessible after import"
+
+
+def test_load_settings_raises_clear_error_when_pyyaml_absent(monkeypatch, tmp_path):
+    """``load_settings()`` raises ImportError with an install hint when PyYAML is absent.
+
+    The error must only surface when the yaml-loading function is actually called
+    (i.e., when a settings.yaml file exists and is read), not at import time.
+    """
+    # Create a real settings.yaml so load_settings actually tries to read it.
+    settings_dir = tmp_path / ".lionagi"
+    settings_dir.mkdir()
+    (settings_dir / "settings.yaml").write_text("hooks: {}\n")
+
+    # Block PyYAML so the lazy import inside _yaml_safe_load fails.
+    # We also remove the cached yaml module so the import attempt inside
+    # _yaml_safe_load actually hits the blocked entry.
+    monkeypatch.setitem(sys.modules, "yaml", None)  # type: ignore[arg-type]
+
+    from lionagi.agent.settings import _yaml_safe_load
+
+    with pytest.raises(ImportError, match="PyYAML is required"):
+        # Open the yaml file and pass its stream to the helper — simulates
+        # exactly the path that load_settings takes when reading settings.yaml.
+        with open(settings_dir / "settings.yaml") as f:
+            _yaml_safe_load(f)

--- a/uv.lock
+++ b/uv.lock
@@ -3117,6 +3117,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
+    { name = "pyyaml" },
     { name = "tiktoken" },
     { name = "toml" },
 ]
@@ -3270,6 +3271,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.8.0" },
     { name = "pydapter", extras = ["postgres"], marker = "extra == 'postgres'", specifier = ">=1.3.2" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "pyyaml", marker = "extra == 'studio'", specifier = ">=6.0" },
     { name = "pyyaml", marker = "extra == 'testing'", specifier = ">=6.0" },
     { name = "rich", marker = "extra == 'rich'", specifier = ">=13.0.0" },


### PR DESCRIPTION
## Problem
`import lionagi.agent` transitively imports `lionagi/agent/settings.py`, which imports PyYAML at module level. On a base install PyYAML was only an optional extra, so the public import raised `ModuleNotFoundError`.

## Fix
Promote `pyyaml>=6.0` to a **core runtime dependency**. It is small and already needed across `agent/`, `casts/`, and `studio/` paths. This replaces the earlier lazy-import shim with the simpler, more honest fix — `settings.py` is restored to its original top-level `import yaml`.

## Tests
- `test_lionagi_agent_public_surface_imports` — the public surface imports cleanly.
- `test_pyyaml_is_a_core_dependency` — pins pyyaml in `[project].dependencies` so it cannot regress back to an optional extra (the original root cause).

Net diff: `pyproject.toml` (+1), regression test, `uv.lock`. `settings.py` matches main.

Closes #1290