### PR TITLE
fix(protocols/pile): correct items= kwarg and dict_values crash in Pile set ops (#1291)

### DIFF
--- a/lionagi/protocols/generic/pile.py
+++ b/lionagi/protocols/generic/pile.py
@@ -549,7 +549,7 @@ class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
             raise TypeError(f"Invalid type for Pile operation. expected <Pile>, got {type(other)}")
 
         result = self.__class__(
-            items=self.values(),
+            collections=self.values(),
             item_type=self.item_type,
             order=self.progression,
         )
@@ -586,7 +586,7 @@ class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
         ]
 
         result = self.__class__(
-            items=values,
+            collections=values,
             item_type=self.item_type,
         )
         return result
@@ -610,7 +610,7 @@ class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
 
         values = [i for i in self if i in other]
         return self.__class__(
-            items=values,
+            collections=values,
             item_type=self.item_type,
         )
 
@@ -916,7 +916,7 @@ class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
                 self.progression.exclude(pops)
                 result = [self.collections.pop(i) for i in pops]
                 result = (
-                    self.__class__(items=result, item_type=self.item_type)
+                    self.__class__(collections=result, item_type=self.item_type)
                     if len(result) > 1
                     else result[0]
                 )
@@ -987,7 +987,7 @@ class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
 
     def is_homogenous(self) -> bool:
         """Check if all items are same type."""
-        return len(self.collections) < 2 or all(is_same_dtype(self.collections.values()))
+        return len(self.collections) < 2 or is_same_dtype(list(self.collections.values()))
 
     @classmethod
     def list_adapters(cls) -> list[str]:

--- a/lionagi/protocols/generic/pile.py
+++ b/lionagi/protocols/generic/pile.py
@@ -551,7 +551,8 @@ class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
         result = self.__class__(
             collections=self.values(),
             item_type=self.item_type,
-            order=self.progression,
+            strict_type=self.strict_type,
+            order=list(self.progression),
         )
         result.include(list(other))
         return result
@@ -588,6 +589,7 @@ class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
         result = self.__class__(
             collections=values,
             item_type=self.item_type,
+            strict_type=self.strict_type,
         )
         return result
 
@@ -612,6 +614,7 @@ class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
         return self.__class__(
             collections=values,
             item_type=self.item_type,
+            strict_type=self.strict_type,
         )
 
     @override
@@ -916,7 +919,11 @@ class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
                 self.progression.exclude(pops)
                 result = [self.collections.pop(i) for i in pops]
                 result = (
-                    self.__class__(collections=result, item_type=self.item_type)
+                    self.__class__(
+                        collections=result,
+                        item_type=self.item_type,
+                        strict_type=self.strict_type,
+                    )
                     if len(result) > 1
                     else result[0]
                 )

--- a/tests/protocols/generic/test_pile_filter.py
+++ b/tests/protocols/generic/test_pile_filter.py
@@ -66,7 +66,7 @@ class TestIsHomogenous:
     """is_homogenous previously iterated over dict_values directly, causing
     TypeError in is_same_dtype which requires a list or Mapping, not
     dict_values. Fixed by materialising list(self.collections.values())
-    before the call. See issue #1291."""
+    before the call."""
 
     def test_empty_is_homogenous(self):
         p = Pile()

--- a/tests/protocols/generic/test_pile_filter.py
+++ b/tests/protocols/generic/test_pile_filter.py
@@ -63,6 +63,11 @@ pandas_missing = importlib.util.find_spec("pandas") is None
 
 
 class TestIsHomogenous:
+    """is_homogenous previously iterated over dict_values directly, causing
+    TypeError in is_same_dtype which requires a list or Mapping, not
+    dict_values. Fixed by materialising list(self.collections.values())
+    before the call. See issue #1291."""
+
     def test_empty_is_homogenous(self):
         p = Pile()
         assert p.is_homogenous() is True
@@ -71,12 +76,28 @@ class TestIsHomogenous:
         p = Pile(collections=[Item(value=0)])
         assert p.is_homogenous() is True
 
-    def test_single_type_multiple_items_is_homogenous_fast_path(self):
-        # With 2+ items, is_homogenous calls is_same_dtype which expects a list,
-        # but collections.values() is dict_values — this exercises the known bug.
-        # For now assert the fast-path (size < 2) returns True correctly.
-        p = Pile(collections=[Item(value=0)])
+    def test_same_type_two_items_is_homogenous(self):
+        """Two items of the same type must return True (exercises the fixed path)."""
+        p = Pile(collections=[Item(value=0), Item(value=1)])
         assert p.is_homogenous() is True
+
+    def test_same_type_five_items_is_homogenous(self):
+        """Five items of the same type must return True."""
+        items = [Item(value=i) for i in range(5)]
+        p = Pile(collections=items)
+        assert p.is_homogenous() is True
+
+    def test_mixed_types_is_not_homogenous(self):
+        """A pile with two different concrete types is not homogenous."""
+        items = [Item(value=0), OtherItem(name="x")]
+        p = Pile(collections=items)
+        assert p.is_homogenous() is False
+
+    def test_mixed_types_three_items_is_not_homogenous(self):
+        """Mixed-type pile with 3 items is not homogenous."""
+        items = [Item(value=0), Item(value=1), OtherItem(name="x")]
+        p = Pile(collections=items)
+        assert p.is_homogenous() is False
 
     def test_empty_pile_homogenous(self):
         assert Pile().is_homogenous() is True

--- a/tests/protocols/generic/test_pile_mutation.py
+++ b/tests/protocols/generic/test_pile_mutation.py
@@ -110,9 +110,9 @@ pandas_missing = importlib.util.find_spec("pandas") is None
 
 
 class TestInPlaceSetOps:
-    """In-place set ops mutate self — tested here because |= / &= / ^=
-    are uncovered and work correctly (unlike __or__, __and__, __xor__
-    which have an 'items=' kwarg bug)."""
+    """In-place set ops mutate self — |= / &= / ^= operate on self and
+    return self, distinct from the non-in-place __or__/__and__/__xor__
+    which return a fresh Pile."""
 
     def setup_method(self):
         self.a0, self.a1, self.a2 = Item(value=0), Item(value=1), Item(value=2)
@@ -313,6 +313,57 @@ class TestNonInPlaceSetOps:
         _ = p1 & p2
         assert len(p1) == 2
         assert len(p2) == 1
+
+
+class TestSetOpsIntegrity:
+    """The non-in-place set ops must build the result from copies of self's
+    internal state — never alias the left operand's Progression, and never
+    silently relax a strict pile to non-strict."""
+
+    def setup_method(self):
+        self.a0, self.a1, self.a2 = Item(value=0), Item(value=1), Item(value=2)
+
+    def test_or_does_not_alias_left_progression(self):
+        """``p1 | p2`` must not mutate p1's progression through the shared
+        order object — including p2's item only into the result, leaving p1
+        internally consistent (collections and progression stay in sync)."""
+        p1 = Pile(collections=[self.a0])
+        p2 = Pile(collections=[self.a1])
+        before = list(p1.progression)
+        _ = p1 | p2
+        assert list(p1.progression) == before
+        assert self.a1 not in p1
+        assert len(p1.progression) == len(p1.collections) == 1
+        # values() walks progression -> collections; corruption would KeyError.
+        assert [i.value for i in p1.values()] == [self.a0.value]
+
+    def test_or_preserves_strict_type(self):
+        p1 = Pile(collections=[self.a0], item_type={Item}, strict_type=True)
+        p2 = Pile(collections=[self.a1], item_type={Item}, strict_type=True)
+        result = p1 | p2
+        assert result.strict_type is True
+
+    def test_and_preserves_strict_type(self):
+        p1 = Pile(collections=[self.a0, self.a1], item_type={Item}, strict_type=True)
+        p2 = Pile(collections=[self.a1], item_type={Item}, strict_type=True)
+        result = p1 & p2
+        assert result.strict_type is True
+
+    def test_xor_preserves_strict_type(self):
+        p1 = Pile(collections=[self.a0, self.a1], item_type={Item}, strict_type=True)
+        p2 = Pile(collections=[self.a1, self.a2], item_type={Item}, strict_type=True)
+        result = p1 ^ p2
+        assert result.strict_type is True
+
+    def test_multi_pop_preserves_strict_type(self):
+        p = Pile(
+            collections=[self.a0, self.a1, self.a2],
+            item_type={Item},
+            strict_type=True,
+        )
+        popped = p.pop(slice(0, 2))
+        assert isinstance(popped, Pile)
+        assert popped.strict_type is True
 
 
 class TestMultiItemPop:

--- a/tests/protocols/generic/test_pile_mutation.py
+++ b/tests/protocols/generic/test_pile_mutation.py
@@ -186,52 +186,169 @@ class TestInPlaceSetOps:
 
 
 # ---------------------------------------------------------------------------
-# 3. Non-in-place set ops (__or__, __and__, __xor__) — known bug documented
+# 3. Non-in-place set ops (__or__, __and__, __xor__) — fixed (#1291)
 # ---------------------------------------------------------------------------
 
 
 class TestNonInPlaceSetOps:
-    """__or__, __and__, __xor__ currently pass 'items=' instead of
-    'collections=' to Pile.__init__, causing extra_forbidden errors.
-    These tests document and assert the actual behaviour (raise TypeError)
-    so that future fixes are caught by CI."""
+    """__or__, __and__, __xor__ previously passed 'items=' instead of
+    'collections=' to Pile.__init__, causing ValidationError on every call.
+    These tests assert the corrected behaviour: set ops return a new Pile
+    with the expected membership. See GitHub issue #1291."""
 
     def setup_method(self):
-        self.a0, self.a1 = Item(value=0), Item(value=1)
+        self.a0, self.a1, self.a2 = Item(value=0), Item(value=1), Item(value=2)
 
     def test_or_raises_on_non_pile(self):
+        """TypeError is still raised for non-Pile operands."""
         p = Pile(collections=[self.a0])
         with pytest.raises(TypeError):
             _ = p | [self.a1]
 
     def test_and_raises_on_non_pile(self):
+        """TypeError is still raised for non-Pile operands."""
         p = Pile(collections=[self.a0])
         with pytest.raises(TypeError):
             _ = p & [self.a1]
 
     def test_xor_raises_on_non_pile(self):
+        """TypeError is still raised for non-Pile operands."""
         p = Pile(collections=[self.a0])
         with pytest.raises(TypeError):
             _ = p ^ [self.a1]
 
-    def test_or_raises_due_to_items_kwarg_bug(self):
-        """Non-in-place union raises ValueError from _validate_progression length mismatch."""
-        p1 = Pile(collections=[self.a0])
-        p2 = Pile(collections=[self.a1])
-        with pytest.raises(ValueError):  # _validate_progression length mismatch
-            _ = p1 | p2
+    def test_or_union_returns_new_pile(self):
+        """Non-in-place union produces a new Pile containing all unique items."""
+        p1 = Pile(collections=[self.a0, self.a1])
+        p2 = Pile(collections=[self.a1, self.a2])
+        result = p1 | p2
+        assert isinstance(result, Pile)
+        assert len(result) == 3
+        assert self.a0 in result
+        assert self.a1 in result
+        assert self.a2 in result
 
-    def test_and_raises_due_to_items_kwarg_bug(self):
-        p1 = Pile(collections=[self.a0])
+    def test_or_preserves_item_type(self):
+        """Union preserves item_type from the left operand."""
+        p1 = Pile(collections=[self.a0], item_type={Item})
         p2 = Pile(collections=[self.a1])
-        with pytest.raises(ValueError):
-            _ = p1 & p2
+        result = p1 | p2
+        assert result.item_type == {Item}
 
-    def test_xor_raises_due_to_items_kwarg_bug(self):
+    def test_or_disjoint(self):
+        """Union of disjoint piles contains all items."""
         p1 = Pile(collections=[self.a0])
         p2 = Pile(collections=[self.a1])
-        with pytest.raises(ValueError):
-            _ = p1 ^ p2
+        result = p1 | p2
+        assert len(result) == 2
+
+    def test_or_no_duplicate(self):
+        """Union does not duplicate shared items."""
+        p1 = Pile(collections=[self.a0, self.a1])
+        p2 = Pile(collections=[self.a0])
+        result = p1 | p2
+        assert len(result) == 2
+
+    def test_and_intersection_returns_new_pile(self):
+        """Non-in-place intersection produces a new Pile of shared items."""
+        p1 = Pile(collections=[self.a0, self.a1])
+        p2 = Pile(collections=[self.a1, self.a2])
+        result = p1 & p2
+        assert isinstance(result, Pile)
+        assert len(result) == 1
+        assert self.a1 in result
+        assert self.a0 not in result
+        assert self.a2 not in result
+
+    def test_and_empty_result(self):
+        """Intersection of disjoint piles is empty."""
+        p1 = Pile(collections=[self.a0])
+        p2 = Pile(collections=[self.a1])
+        result = p1 & p2
+        assert len(result) == 0
+
+    def test_and_preserves_item_type(self):
+        """Intersection preserves item_type from the left operand."""
+        p1 = Pile(collections=[self.a0, self.a1], item_type={Item})
+        p2 = Pile(collections=[self.a1])
+        result = p1 & p2
+        assert result.item_type == {Item}
+
+    def test_xor_symmetric_difference_returns_new_pile(self):
+        """Non-in-place symmetric difference excludes common items."""
+        p1 = Pile(collections=[self.a0, self.a1])
+        p2 = Pile(collections=[self.a1, self.a2])
+        result = p1 ^ p2
+        assert isinstance(result, Pile)
+        assert len(result) == 2
+        assert self.a0 in result
+        assert self.a2 in result
+        assert self.a1 not in result
+
+    def test_xor_disjoint(self):
+        """Symmetric difference of disjoint piles contains all items."""
+        p1 = Pile(collections=[self.a0])
+        p2 = Pile(collections=[self.a1])
+        result = p1 ^ p2
+        assert len(result) == 2
+
+    def test_xor_identical(self):
+        """Symmetric difference of identical piles is empty."""
+        p1 = Pile(collections=[self.a0, self.a1])
+        p2 = Pile(collections=[self.a0, self.a1])
+        result = p1 ^ p2
+        assert len(result) == 0
+
+    def test_or_does_not_mutate_operands(self):
+        """Non-in-place ops must not mutate either operand."""
+        p1 = Pile(collections=[self.a0])
+        p2 = Pile(collections=[self.a1])
+        _ = p1 | p2
+        assert len(p1) == 1
+        assert len(p2) == 1
+
+    def test_and_does_not_mutate_operands(self):
+        p1 = Pile(collections=[self.a0, self.a1])
+        p2 = Pile(collections=[self.a1])
+        _ = p1 & p2
+        assert len(p1) == 2
+        assert len(p2) == 1
+
+
+class TestMultiItemPop:
+    """_pop with a slice returning >1 item previously used 'items=' kwarg,
+    causing the same ValidationError as the set-op bug. See issue #1291."""
+
+    def setup_method(self):
+        self.items = [Item(value=i) for i in range(5)]
+        self.pile = Pile(collections=self.items)
+
+    def test_pop_slice_multi_returns_pile(self):
+        """Popping a slice of 3 items returns a Pile, not an error."""
+        result = self.pile.pop(slice(0, 3))
+        assert isinstance(result, Pile)
+        assert len(result) == 3
+        assert len(self.pile) == 2
+
+    def test_pop_slice_single_returns_item(self):
+        """Popping a slice of exactly 1 item returns the item directly."""
+        result = self.pile.pop(slice(0, 1))
+        assert isinstance(result, Item)
+        assert len(self.pile) == 4
+
+    def test_pop_slice_all_returns_pile(self):
+        """Popping all items returns a Pile."""
+        result = self.pile.pop(slice(None))
+        assert isinstance(result, Pile)
+        assert len(result) == 5
+        assert len(self.pile) == 0
+
+    def test_pop_slice_preserves_item_type(self):
+        """Multi-item pop preserves the item_type of the parent pile."""
+        p = Pile(collections=[Item(value=i) for i in range(3)], item_type={Item})
+        result = p.pop(slice(0, 2))
+        assert isinstance(result, Pile)
+        assert result.item_type == {Item}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/protocols/generic/test_pile_mutation.py
+++ b/tests/protocols/generic/test_pile_mutation.py
@@ -186,7 +186,7 @@ class TestInPlaceSetOps:
 
 
 # ---------------------------------------------------------------------------
-# 3. Non-in-place set ops (__or__, __and__, __xor__) — fixed (#1291)
+# 3. Non-in-place set ops (__or__, __and__, __xor__)
 # ---------------------------------------------------------------------------
 
 
@@ -194,7 +194,7 @@ class TestNonInPlaceSetOps:
     """__or__, __and__, __xor__ previously passed 'items=' instead of
     'collections=' to Pile.__init__, causing ValidationError on every call.
     These tests assert the corrected behaviour: set ops return a new Pile
-    with the expected membership. See GitHub issue #1291."""
+    with the expected membership."""
 
     def setup_method(self):
         self.a0, self.a1, self.a2 = Item(value=0), Item(value=1), Item(value=2)
@@ -317,7 +317,7 @@ class TestNonInPlaceSetOps:
 
 class TestMultiItemPop:
     """_pop with a slice returning >1 item previously used 'items=' kwarg,
-    causing the same ValidationError as the set-op bug. See issue #1291."""
+    causing the same ValidationError as the set-op bug."""
 
     def setup_method(self):
         self.items = [Item(value=i) for i in range(5)]


### PR DESCRIPTION
## Summary

Closes #1291

Two blocker bugs in `lionagi/protocols/generic/pile.py`:

- **P-001** (`items=` wrong kwarg, 4 sites): `__or__`, `__xor__`, `__and__`, and the multi-item `_pop` slice path all constructed `Pile(items=..., ...)`. The constructor only accepts `collections=`. Every call raised `ValueError` from `_validate_progression` due to a collection/order length mismatch. Fixed at all four sites.

- **P-002** (`dict_values` crash in `is_homogenous`): `is_homogenous()` called `is_same_dtype(self.collections.values())`. `dict_values` is neither subscriptable nor a `Mapping`, so `is_same_dtype` raised `TypeError: 'dict_values' object is not subscriptable` on any pile with 2+ items. Fixed by materialising `list(self.collections.values())`. Also removed the spurious `all()` wrapper (which would itself raise `TypeError: 'bool' object is not iterable`).

## What changed

| File | Change |
|------|--------|
| `lionagi/protocols/generic/pile.py` | `items=` → `collections=` at 4 sites; `is_homogenous` fix |
| `tests/protocols/generic/test_pile_mutation.py` | `TestNonInPlaceSetOps` asserts success; new `TestMultiItemPop` class |
| `tests/protocols/generic/test_pile_filter.py` | `TestIsHomogenous` gains same-type and mixed-type multi-item cases |

## Test plan

- [x] `uv run pytest tests/protocols/generic/test_pile_mutation.py tests/protocols/generic/test_pile_filter.py -v` → 104 passed
- [x] `uv run ruff format` → 3 files left unchanged
- [x] `uv run ruff check` → All checks passed
- [x] All pre-commit hooks passed on commit

## Verification

```
$ uv run pytest tests/protocols/generic/test_pile_mutation.py \
               tests/protocols/generic/test_pile_filter.py -v
104 passed in 3.68s
```

Before the fix: `p1 | p2`, `p1 & p2`, `p1 ^ p2`, `pile.pop(slice(0,3))`, and `pile.is_homogenous()` (2+ items) all raised exceptions. After: all work correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)