### PR TITLE
fix(ln): handle non-list Sequence keys and reject bare str in fuzzy_match_keys

### DIFF
--- a/lionagi/ln/fuzzy/_fuzzy_match.py
+++ b/lionagi/ln/fuzzy/_fuzzy_match.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, ClassVar, Literal
 
@@ -63,11 +66,20 @@ def fuzzy_match_keys(
         raise TypeError("First argument must be a dictionary")
     if keys is None:
         raise TypeError("Keys argument cannot be None")
+    # A bare str is a Sequence[str] but iterating it yields single characters,
+    # not key names.  Reject it early with a clear message rather than silently
+    # producing wrong results.
+    if isinstance(keys, str):
+        raise TypeError(
+            "keys must be a Mapping (dict) or a non-string Sequence of key names "
+            "(e.g. list, tuple, frozenset); got a bare str"
+        )
     if not 0.0 <= similarity_threshold <= 1.0:
         raise ValueError("similarity_threshold must be between 0.0 and 1.0")
 
-    # Extract expected keys
-    fields_set = set(keys) if isinstance(keys, list) else set(keys.keys())
+    # Extract expected keys: Mapping types expose their keys via .keys();
+    # all other Sequence types (list, tuple, frozenset, …) are iterable directly.
+    fields_set = set(keys.keys()) if isinstance(keys, Mapping) else set(keys)
     if not fields_set:
         return d_.copy()  # Return copy of original if no expected keys
 

--- a/lionagi/ln/types/base.py
+++ b/lionagi/ln/types/base.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass, field
 from enum import Enum as _Enum
 from typing import Any, ClassVar
@@ -262,7 +261,11 @@ class DataClass:
         return hash(self) == hash(other)
 
 
-KeysLike = Sequence[str] | KeysDict
+# Concrete key-container types accepted by fuzzy_match_keys.
+# Bare ``str`` is intentionally excluded: iterating a str yields individual
+# characters, not key names.  Generic Sequences other than list/tuple are also
+# excluded because the runtime guard rejects them.
+KeysLike = list[str] | tuple[str, ...] | set[str] | frozenset[str] | KeysDict
 
 
 @dataclass(slots=True, frozen=True)

--- a/tests/ln/test_fuzzy_match.py
+++ b/tests/ln/test_fuzzy_match.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for fuzzy_match_keys with non-list Sequence and Mapping key types.
+
+A bare str is a Sequence[str] but iterating it yields single characters, not
+key names.  Callers who accidentally pass a raw string must get a clear
+TypeError rather than a silent wrong result (char-split) or an opaque
+AttributeError.  This module verifies that:
+
+  - tuple and frozenset keys work correctly (the primary regression).
+  - dict keys work correctly (Mapping path).
+  - A bare str is rejected with TypeError before any matching occurs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.ln.fuzzy._fuzzy_match import fuzzy_match_keys
+
+# ---------------------------------------------------------------------------
+# 1. Non-list Sequence types — should work identically to list
+# ---------------------------------------------------------------------------
+
+
+def test_tuple_keys_exact_match():
+    """Tuple of key names must work the same as a list."""
+    d = {"name": "Alice", "age": 30}
+    result = fuzzy_match_keys(d, ("name", "age"))
+    assert result["name"] == "Alice"
+    assert result["age"] == 30
+
+
+def test_tuple_keys_fuzzy_match():
+    """Fuzzy matching must work when keys are supplied as a tuple."""
+    d = {"usr_name": "Bob"}
+    # "usr_name" is close enough to "username" with jaro_winkler at 0.7
+    result = fuzzy_match_keys(d, ("username",), similarity_threshold=0.7)
+    assert "username" in result
+    assert result["username"] == "Bob"
+
+
+def test_frozenset_keys_exact_match():
+    """frozenset of key names must work the same as a list."""
+    d = {"x": 1, "y": 2}
+    result = fuzzy_match_keys(d, frozenset({"x", "y"}))
+    assert result["x"] == 1
+    assert result["y"] == 2
+
+
+def test_frozenset_keys_unmatched_removed():
+    """Unmatched keys with frozenset input and handle_unmatched='remove'."""
+    d = {"x": 1, "extra": 99}
+    result = fuzzy_match_keys(d, frozenset({"x"}), handle_unmatched="remove")
+    assert "x" in result
+    assert "extra" not in result
+
+
+def test_tuple_empty_keys_returns_copy():
+    """An empty tuple for keys must return a copy of the original dict."""
+    d = {"a": 1}
+    result = fuzzy_match_keys(d, ())
+    assert result == d
+    assert result is not d
+
+
+# ---------------------------------------------------------------------------
+# 2. Mapping (dict) path — must use .keys()
+# ---------------------------------------------------------------------------
+
+
+def test_dict_keys_exact_match():
+    """A dict passed as keys should use its .keys() for matching."""
+    d = {"name": "Carol", "age": 25}
+    schema = {"name": str, "age": int}
+    result = fuzzy_match_keys(d, schema)
+    assert result["name"] == "Carol"
+    assert result["age"] == 25
+
+
+# ---------------------------------------------------------------------------
+# 3. Bare str — attack-driven: must be rejected, NOT char-split
+#
+# A str is a Sequence[str] in the type system.  A naive Mapping/Sequence
+# dispatch would silently iterate it into individual characters and attempt
+# to fuzzy-match each char against the dict's keys — a wrong and silent
+# result.  The guard must fire BEFORE any matching logic runs.
+# ---------------------------------------------------------------------------
+
+
+def test_bare_str_raises_type_error():
+    """A bare str must raise TypeError, not produce char-split results.
+
+    The silent-wrong-result path would be: set('name') == {'n','a','m','e'} and
+    the function would try to match those single-char pseudo-keys against the
+    dict.  The correct behaviour is an explicit TypeError before any matching.
+    """
+    d = {"name": "Dave"}
+    with pytest.raises(TypeError, match="bare str"):
+        fuzzy_match_keys(d, "name")
+
+
+def test_bare_str_does_not_char_split():
+    """Verify the str guard fires even for a single-char string."""
+    d = {"a": 1}
+    with pytest.raises(TypeError):
+        fuzzy_match_keys(d, "a")
+
+
+def test_bare_str_longer_key_raises():
+    """A multi-char string that looks like a valid key must still raise."""
+    d = {"username": "Eve", "email": "eve@example.com"}
+    with pytest.raises(TypeError):
+        fuzzy_match_keys(d, "username")


### PR DESCRIPTION
## What

`fuzzy_match_keys` dispatched on `isinstance(keys, list)` and fell through to `keys.keys()` for everything else — any valid non-list `Sequence` (`tuple`, `frozenset`) raised `AttributeError` at runtime.

## Fix

- Split dispatch on `collections.abc.Mapping` (call `.keys()`) vs all other iterables (iterate directly).
- Add an explicit `str` guard **before** the dispatch: a bare `str` is a `Sequence[str]` in the type system but iterating it yields single characters rather than key names — a naive `Mapping/else` branch would silently char-split it, producing wrong results with no error. Callers now get a clear `TypeError` instead.
- Added `from __future__ import annotations` to the source file.

## Tests added (`tests/ln/test_fuzzy_match.py`)

- `test_tuple_keys_exact_match` — tuple input, exact match
- `test_tuple_keys_fuzzy_match` — tuple input, fuzzy match
- `test_frozenset_keys_exact_match` — frozenset input, exact match
- `test_frozenset_keys_unmatched_removed` — frozenset input, handle_unmatched="remove"
- `test_tuple_empty_keys_returns_copy` — empty tuple returns copy
- `test_dict_keys_exact_match` — Mapping (dict) path
- `test_bare_str_raises_type_error` — attack-driven: bare str rejected with TypeError
- `test_bare_str_does_not_char_split` — single-char str also rejected
- `test_bare_str_longer_key_raises` — multi-char str that looks like a key still rejected

All 9 new tests pass. Existing `tests/libs/validate/test_validate_keys.py` (9 tests) also unaffected.

Closes #1302