### PR TITLE
fix(lndl): correct bool coercion — 'false'/'0'/'no' → False via validate_boolean

### DIFF
--- a/lionagi/lndl/types.py
+++ b/lionagi/lndl/types.py
@@ -11,6 +11,7 @@ from typing import Any, Union, get_args, get_origin
 
 from pydantic import BaseModel
 
+from lionagi.libs.validate.validate_boolean import validate_boolean
 from lionagi.ln import json_dumps
 
 Scalar = float | int | str | bool
@@ -173,6 +174,11 @@ def _coerce_result(result: Any, target_type: Any) -> Any:
     if isinstance(result, dict):
         return json_dumps(result)
     if not isinstance(result, scalar):
+        # bool(str) uses Python truthiness: bool('false') == True.
+        # Use validate_boolean so that 'false'/'0'/'no' → False and
+        # 'true'/'1'/'yes' → True, matching common tool return conventions.
+        if scalar is bool:
+            return validate_boolean(result)
         return scalar(result)
     return result
 

--- a/tests/lndl/test_coerce_result.py
+++ b/tests/lndl/test_coerce_result.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2025 - 2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for _coerce_result bool-handling correctness.
+
+Python's bool() constructor uses truthiness: bool('false') is True because every
+non-empty string is truthy.  When a tool returns the string 'false', 'False', '0',
+or 'no' for a field typed as bool or bool|None, the result must be the Python bool
+False — not True.  These tests verify that coercion for bool targets goes through
+validate_boolean semantics rather than raw bool().
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+from lionagi.lndl.types import (
+    ActionCall,
+    _coerce_result,
+    revalidate_with_action_results,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_action_call(name: str = "act") -> ActionCall:
+    return ActionCall(name=name, function="fn", arguments={}, raw_call="fn()")
+
+
+# ---------------------------------------------------------------------------
+# Attack-driven tests: the exploit must be rejected
+# ---------------------------------------------------------------------------
+
+
+class TestBoolCoercionAttackCases:
+    """Stringy falsy values must never be coerced to True for a bool field.
+
+    The attack: a tool returns the string 'false' (or '0', 'no', 'False').
+    Before the fix, bool('false') == True would silently corrupt the field.
+    After the fix, validate_boolean semantics apply: 'false' → False.
+    """
+
+    @pytest.mark.parametrize("raw", ["false", "False", "FALSE", "0", "no", "No", "NO"])
+    def test_falsy_string_yields_false_for_bool(self, raw: str) -> None:
+        """Stringy false representations must coerce to Python False for bool targets."""
+        assert _coerce_result(raw, bool) is False
+
+    @pytest.mark.parametrize("raw", ["true", "True", "TRUE", "1", "yes", "Yes", "YES"])
+    def test_truthy_string_yields_true_for_bool(self, raw: str) -> None:
+        """Stringy true representations must coerce to Python True for bool targets."""
+        assert _coerce_result(raw, bool) is True
+
+    @pytest.mark.parametrize("raw", ["false", "False", "0", "no"])
+    def test_falsy_string_yields_false_for_optional_bool(self, raw: str) -> None:
+        """Same attack surface for Optional[bool] (bool | None) fields."""
+        assert _coerce_result(raw, bool | None) is False
+
+    @pytest.mark.parametrize("raw", ["true", "True", "1", "yes"])
+    def test_truthy_string_yields_true_for_optional_bool(self, raw: str) -> None:
+        """Truthy strings for bool | None targets must coerce to True."""
+        assert _coerce_result(raw, bool | None) is True
+
+
+# ---------------------------------------------------------------------------
+# None-preservation for Optional[bool]
+# ---------------------------------------------------------------------------
+
+
+class TestBoolCoercionNonePreservation:
+    def test_none_result_optional_bool_preserved(self) -> None:
+        """None result for bool | None must stay None, not raise."""
+        assert _coerce_result(None, bool | None) is None
+
+    def test_none_result_required_bool_passes_through(self) -> None:
+        """None for required bool passes through so model_validate raises clearly."""
+        assert _coerce_result(None, bool) is None
+
+
+# ---------------------------------------------------------------------------
+# Actual bool input must pass through unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestBoolCoercionNativePassthrough:
+    def test_native_false_passthrough_bool(self) -> None:
+        assert _coerce_result(False, bool) is False
+
+    def test_native_true_passthrough_bool(self) -> None:
+        assert _coerce_result(True, bool) is True
+
+    def test_native_false_passthrough_optional_bool(self) -> None:
+        assert _coerce_result(False, bool | None) is False
+
+    def test_native_true_passthrough_optional_bool(self) -> None:
+        assert _coerce_result(True, bool | None) is True
+
+
+# ---------------------------------------------------------------------------
+# Non-bool scalar coercions remain unaffected
+# ---------------------------------------------------------------------------
+
+
+class TestNonBoolScalarCoercionUnchanged:
+    def test_str_int_still_coerces(self) -> None:
+        assert _coerce_result("42", int) == 42
+
+    def test_str_float_still_coerces(self) -> None:
+        assert abs(_coerce_result("3.14", float) - 3.14) < 1e-6
+
+    def test_int_str_still_coerces(self) -> None:
+        assert _coerce_result(7, str) == "7"
+
+    def test_dict_to_str_still_json_serialises(self) -> None:
+        import json
+
+        result = _coerce_result({"k": "v"}, str)
+        assert isinstance(result, str)
+        assert json.loads(result) == {"k": "v"}
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: revalidate_with_action_results on a bool field
+# ---------------------------------------------------------------------------
+
+
+class FlagModel(BaseModel):
+    enabled: bool
+    active: bool | None = None
+
+
+class TestRevalidateBoolField:
+    """Verify the fix integrates correctly with full revalidation."""
+
+    def test_stringy_false_revalidated_to_false(self) -> None:
+        ac = make_action_call("en")
+        m = FlagModel.model_construct(enabled=ac)
+        result = revalidate_with_action_results(m, {"en": "false"})
+        assert result.enabled is False
+
+    def test_stringy_zero_revalidated_to_false(self) -> None:
+        ac = make_action_call("en")
+        m = FlagModel.model_construct(enabled=ac)
+        result = revalidate_with_action_results(m, {"en": "0"})
+        assert result.enabled is False
+
+    def test_stringy_no_revalidated_to_false(self) -> None:
+        ac = make_action_call("en")
+        m = FlagModel.model_construct(enabled=ac)
+        result = revalidate_with_action_results(m, {"en": "no"})
+        assert result.enabled is False
+
+    def test_stringy_true_revalidated_to_true(self) -> None:
+        ac = make_action_call("en")
+        m = FlagModel.model_construct(enabled=ac)
+        result = revalidate_with_action_results(m, {"en": "true"})
+        assert result.enabled is True
+
+    def test_optional_bool_stringy_false(self) -> None:
+        ac = make_action_call("ac")
+        m = FlagModel.model_construct(enabled=True, active=ac)
+        result = revalidate_with_action_results(m, {"ac": "false"})
+        assert result.active is False
+
+    def test_optional_bool_none_preserved(self) -> None:
+        ac = make_action_call("ac")
+        m = FlagModel.model_construct(enabled=True, active=ac)
+        result = revalidate_with_action_results(m, {"ac": None})
+        assert result.active is None


### PR DESCRIPTION
## What

`_coerce_result` in `lionagi/lndl/types.py` used Python's `bool()` constructor for
bool-typed LNDL fields.  `bool(str)` applies truthiness: every non-empty string is
`True`, so `bool('false') == True`.  When a tool returns the string `'false'`, `'0'`,
or `'no'` for a `bool` or `bool | None` field, the value was silently corrupted to
`True`.

## Fix

Import and use `validate_boolean` from `lionagi.libs.validate.validate_boolean` (the
existing helper) for the bool-target branch in `_coerce_result`.  This gives proper
semantics: `'false'/'0'/'no'/'off'` → `False`, `'true'/'1'/'yes'/'on'` → `True`.

All other scalar types (`str`, `int`, `float`) continue to use `scalar(result)` as
before.  The `None`-preservation path for `Optional` fields is unaffected.

## Tests

New file `tests/lndl/test_coerce_result.py` adds:

- **Attack-driven cases**: parametrized tests confirming `'false'`, `'False'`, `'0'`,
  `'no'` yield `False` for both `bool` and `bool | None` targets (the exploit is
  rejected).
- `None` preservation for `bool | None`.
- Native `bool` passthrough.
- Non-bool scalar regression tests.
- End-to-end tests through `revalidate_with_action_results` with a `FlagModel`.

123 tests pass across the full `tests/lndl/` suite.

Closes #1300