### PR TITLE
fix(adapters): redact credentials in all URL schemes and nested dict details

### DIFF
--- a/lionagi/adapters/_base.py
+++ b/lionagi/adapters/_base.py
@@ -156,6 +156,10 @@ def _redact_value(key: str, value: Any) -> Any:
         # Non-sensitive key, but the nested dict may contain sensitive sub-keys
         # or URL values — recurse so they are caught.
         return _redact_details(value)
+    if isinstance(value, list):
+        # Each list element may be a dict with sensitive sub-keys, a URL string,
+        # or another list — recurse with the same key so nested values are caught.
+        return [_redact_value(key, item) for item in value]
     return value
 
 

--- a/lionagi/adapters/_base.py
+++ b/lionagi/adapters/_base.py
@@ -99,7 +99,7 @@ _SENSITIVE_QUERY_PARAMS: frozenset[str] = frozenset(
 def _redact_url(value: str) -> str:
     """Sanitize a URL string for safe inclusion in error messages.
 
-    Redacts:
+    Redacts for ALL URL schemes (not just a known whitelist):
     - The password component of ``user:password@host`` netloc credentials.
     - Any query-string parameter whose name matches ``_SENSITIVE_QUERY_PARAMS``.
     """
@@ -107,8 +107,8 @@ def _redact_url(value: str) -> str:
         parsed = urllib.parse.urlparse(value)
     except Exception:
         return value
-    scheme = parsed.scheme.lower()
-    if scheme not in _CREDENTIAL_SCHEMES:
+    # Require a scheme so plain strings are not mis-parsed as URLs.
+    if not parsed.scheme:
         return value
 
     replacements: dict[str, str] = {}
@@ -145,14 +145,22 @@ def _redact_value(key: str, value: Any) -> Any:
         if isinstance(value, str):
             return _redact_url(value) if "://" in value else "***"
         if isinstance(value, dict):
-            return dict.fromkeys(value, "***")
+            # The entire dict is under a sensitive key — blank all leaf values.
+            return {k: "***" for k in value}
+        if isinstance(value, list):
+            return [_redact_value(key, item) for item in value]
         return "***"
     if isinstance(value, str) and "://" in value:
         return _redact_url(value)
+    if isinstance(value, dict):
+        # Non-sensitive key, but the nested dict may contain sensitive sub-keys
+        # or URL values — recurse so they are caught.
+        return _redact_details(value)
     return value
 
 
 def _redact_details(details: dict[str, Any]) -> dict[str, Any]:
+    """Recursively redact sensitive keys and URL credentials from a details dict."""
     redacted: dict[str, Any] = {}
     for k, v in details.items():
         v = _redact_value(k, v)

--- a/tests/adapters/test_credential_redaction.py
+++ b/tests/adapters/test_credential_redaction.py
@@ -3,13 +3,19 @@
 
 """Attack-driven regression tests for credential redaction in adapter errors.
 
-Issue (High, security): _redact_url only masked the URL netloc password
-(user:pass@host), but left query-string credentials (e.g. ?token=secret&
-api_key=k) in plain text inside AdapterError messages, which may be logged
-or displayed.
+Security boundary: credentials embedded in error detail values must never
+appear in AdapterError string representations, regardless of the URL scheme
+or nesting depth of the details dict.
 
-Fix: _redact_url now also redacts query parameters whose key matches
-_SENSITIVE_QUERY_PARAMS.
+Two attack vectors are covered:
+
+1. Non-whitelisted URL scheme (e.g. ``s3://``, ``ftp://``, ``jdbc://``):
+   previously the scheme guard returned the URL unmodified, leaking any
+   query-parameter credentials.
+
+2. Nested dict in error details: previously ``_redact_details`` walked only
+   the top-level dict, so a value that was itself a dict escaped redaction
+   entirely.
 """
 
 from __future__ import annotations
@@ -62,16 +68,36 @@ class TestRedactUrlQueryCredentials:
         # No sensitive keys → URL unchanged
         assert result == url
 
-    def test_non_credentialed_scheme_unchanged(self):
-        """Schemes not in _CREDENTIAL_SCHEMES must pass through untouched."""
-        url = "ftp://example.com?token=secret"
+    def test_non_http_scheme_query_credentials_redacted(self):
+        """Attack: non-whitelisted scheme (s3://) with ?token= must be redacted.
+
+        Previously the scheme-whitelist guard returned the URL unmodified,
+        leaking query-parameter credentials for any scheme not in
+        _CREDENTIAL_SCHEMES (s3, ftp, jdbc, custom, …).
+        """
+        url = "s3://my-bucket/path?token=supersecret&safe=ok"
         result = _redact_url(url)
-        assert result == url
+        assert "supersecret" not in result, "token value leaked through non-whitelisted scheme"
+        assert "token=***" in result
+        # Non-sensitive param preserved
+        assert "safe=ok" in result
+
+    def test_ftp_scheme_query_credentials_redacted(self):
+        """Attack: ftp:// scheme with ?api_key= must be redacted."""
+        url = "ftp://files.example.com/data?api_key=privatekeyvalue"
+        result = _redact_url(url)
+        assert "privatekeyvalue" not in result, "api_key leaked through ftp:// scheme"
+        assert "api_key=***" in result
 
     def test_empty_query_unchanged(self):
         url = "https://example.com/path"
         result = _redact_url(url)
         assert result == url
+
+    def test_no_scheme_string_unchanged(self):
+        """Bare strings with no scheme must not be mis-parsed as URLs."""
+        value = "just-a-plain-string"
+        assert _redact_url(value) == value
 
 
 class TestAdapterErrorDoesNotLeakCredentials:
@@ -83,7 +109,7 @@ class TestAdapterErrorDoesNotLeakCredentials:
     """
 
     def test_url_with_query_token_not_in_error_str(self):
-        """Regression for the exact scenario from the audit finding."""
+        """Regression: URL detail containing query credentials must be redacted."""
         err = AdapterError(
             "connection failed",
             details={"url": "https://example.com/cb?token=secret&api_key=k"},
@@ -113,3 +139,52 @@ class TestAdapterErrorDoesNotLeakCredentials:
         assert "api.example.com" in err_str
         # The secret must not
         assert "secret123" not in err_str
+
+    def test_non_http_scheme_url_credential_not_in_error_str(self):
+        """Attack: s3:// URL with ?token= in a detail must not appear in error string.
+
+        This reproduces the bypass where a non-whitelisted scheme caused
+        _redact_url to return the URL unmodified, leaking token values into
+        logged error messages.
+        """
+        err = AdapterError(
+            "storage error",
+            details={"url": "s3://my-bucket/key?token=s3secrettoken123&region=us-east-1"},
+        )
+        err_str = str(err)
+        assert "s3secrettoken123" not in err_str, (
+            "token value leaked through s3:// URL in AdapterError string"
+        )
+
+    def test_nested_dict_detail_credentials_redacted(self):
+        """Attack: secret inside a nested dict detail value must be redacted.
+
+        Previously _redact_details only walked the top-level dict.  A value
+        that was itself a dict escaped redaction entirely, leaking any
+        sensitive keys it contained.
+        """
+        err = AdapterError(
+            "config error",
+            details={
+                "connection": {
+                    "url": "postgresql://user:pass@host/db",
+                    "secret": "db-secret-value",
+                    "host": "db.example.com",
+                }
+            },
+        )
+        err_str = str(err)
+        assert "pass" not in err_str, "nested netloc password leaked"
+        assert "db-secret-value" not in err_str, "nested 'secret' key value leaked"
+        # Non-sensitive nested key (host) may or may not appear; we only
+        # require that credentials are absent.
+
+    def test_nested_dict_under_sensitive_key_all_values_redacted(self):
+        """A dict stored under a sensitive top-level key must be fully redacted."""
+        err = AdapterError(
+            "auth error",
+            details={"token": {"access": "tok-abc", "refresh": "tok-xyz"}},
+        )
+        err_str = str(err)
+        assert "tok-abc" not in err_str
+        assert "tok-xyz" not in err_str

--- a/tests/adapters/test_credential_redaction.py
+++ b/tests/adapters/test_credential_redaction.py
@@ -188,3 +188,49 @@ class TestAdapterErrorDoesNotLeakCredentials:
         err_str = str(err)
         assert "tok-abc" not in err_str
         assert "tok-xyz" not in err_str
+
+
+class TestListLeakRegression:
+    """Regression: list values under non-sensitive keys must also be redacted.
+
+    A credential URL inside a list element (e.g. ``errors=[{'input': 'postgresql://u:PW@h/db'}]``)
+    or a bare list of URL strings under any non-sensitive key must not appear in
+    AdapterError string representations.
+    """
+
+    def test_credential_url_inside_list_of_dicts_under_non_sensitive_key(self):
+        """Attack: errors=[{'input': 'postgresql://u:REALPW@h/db'}] must not leak REALPW.
+
+        Previously the non-sensitive-key branch of _redact_value returned a list
+        as-is, so dict elements (and their URL strings) bypassed redaction entirely.
+        """
+        from lionagi.adapters._base import AdapterValidationError
+
+        err = AdapterValidationError(
+            adapter="x",
+            errors=[{"input": "postgresql://u:REALPW@h/db"}],
+        )
+        err_str = str(err)
+        assert "REALPW" not in err_str, (
+            f"netloc password leaked from list[dict] under non-sensitive key: {err_str!r}"
+        )
+
+    def test_bare_credential_url_strings_in_list_under_non_sensitive_key(self):
+        """Attack: a list of bare credential URL strings must have passwords redacted.
+
+        The same non-sensitive-key branch previously skipped list-of-strings,
+        so each URL string was returned unmodified.
+        """
+        err = AdapterError(
+            "connection error",
+            details={
+                "candidates": [
+                    "postgresql://alice:SECRETPW@primary/db",
+                    "postgresql://alice:SECRETPW@replica/db",
+                ]
+            },
+        )
+        err_str = str(err)
+        assert "SECRETPW" not in err_str, (
+            f"netloc password leaked from list of URL strings under non-sensitive key: {err_str!r}"
+        )


### PR DESCRIPTION
## Summary

- `_redact_url` previously returned any URL whose scheme was not in a whitelist (`_CREDENTIAL_SCHEMES`) completely unredacted. Non-whitelisted schemes (`s3://`, `ftp://`, `jdbc://`, `custom://`, ...) with sensitive query-string parameters (`token=`, `api_key=`, etc.) leaked credential values into `AdapterError` string representations, which may be logged or displayed.
- `_redact_details` only walked the top-level details dict. A value that was itself a dict escaped redaction entirely, leaking sensitive sub-keys (e.g. `{"connection": {"secret": "...", "url": "postgres://user:pass@host"}}`).

**Fix 1**: Remove the scheme whitelist from `_redact_url`; require only that a scheme is present. Redaction now applies universally to all URL-shaped values.

**Fix 2**: `_redact_value` now recurses into non-sensitive dict values via `_redact_details`, and blanks all leaf values in dicts stored under a sensitive top-level key (preserving the original all-or-nothing semantics for sensitive containers).

## Test plan

- [x] `test_non_http_scheme_query_credentials_redacted` — s3:// URL with `?token=` is redacted
- [x] `test_ftp_scheme_query_credentials_redacted` — ftp:// URL with `?api_key=` is redacted
- [x] `test_non_http_scheme_url_credential_not_in_error_str` — end-to-end: s3:// URL credential absent from `str(AdapterError(...))`
- [x] `test_nested_dict_detail_credentials_redacted` — `connection.secret` and `connection.url` password redacted when nested under a non-sensitive key
- [x] `test_nested_dict_under_sensitive_key_all_values_redacted` — all values in a dict under a sensitive key (`token`) are blanked
- [x] All 17 tests pass; ruff check and format clean; pre-commit hooks passed

Closes #1295