### PR TITLE
fix(engines): structured concurrency in ReviewEngine fan-out

### DIFF
--- a/lionagi/engines/engine.py
+++ b/lionagi/engines/engine.py
@@ -181,6 +181,21 @@ class EngineRun:
             self._active.add(task)
             task.add_done_callback(self._active.discard)
 
+    async def cancel_active(self) -> None:
+        """Cancel every in-flight spawned task and wait for it to finish.
+
+        Used when the primary pipeline fails so that no background task (e.g. a
+        verifier spawned just before the failure) outlives the run and keeps
+        mutating shared state.
+        """
+        if not self._active:
+            return
+        for t in list(self._active):
+            t.cancel()
+        await asyncio.gather(*list(self._active), return_exceptions=True)
+        # Callbacks remove tasks from _active as they settle.
+        self._active.clear()
+
     async def wait_quiescence(self) -> None:
         """Block until no spawned task remains, then surface any task failures.
 

--- a/lionagi/engines/review.py
+++ b/lionagi/engines/review.py
@@ -15,12 +15,12 @@ converge), the complement to research's recursive *Tree* shape.
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 from pydantic import Field
 
 from lionagi.casts.emission import Finding, Verdict
+from lionagi.ln import gather as ln_gather
 
 from .engine import Engine, EngineEvent, EngineRun
 
@@ -165,7 +165,15 @@ class ReviewEngine(Engine):
         run.observe(IssueFound, lambda i, _c: self._on_issue(run, i))
 
         # Fan out: one reviewer per dimension, in parallel.
-        await asyncio.gather(*(self._review_dimension(run, artifact, d) for d in dims))
+        # Using ln_gather (structured concurrency) so a dimension failure cancels
+        # siblings and no coroutine outlives this scope.
+        try:
+            await ln_gather(*(self._review_dimension(run, artifact, d) for d in dims))
+        except BaseException:
+            # Cancel any verifier tasks that were spawned before the failure so
+            # no background work keeps mutating shared run state after _run exits.
+            await run.cancel_active()
+            raise
         # Drain any adversarial verifiers spawned by high-severity issues.
         await run.wait_quiescence()
         return await self._verdict(run, artifact, dims)

--- a/tests/engines/test_review_concurrency.py
+++ b/tests/engines/test_review_concurrency.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Concurrency safety tests for ReviewEngine fan-out.
+
+Verifies that when a dimension reviewer raises, any verifier tasks that were
+spawned before the failure are cancelled and do not outlive the run.  No
+orphaned background task should be able to mutate shared EngineRun state
+after _run has exited.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from lionagi.engines.review import ReviewEngine
+from lionagi.ln.concurrency import BaseExceptionGroup  # 3.10 compat shim
+
+
+class _OKAgent:
+    """A reviewer that completes immediately without errors."""
+
+    def __init__(self, name: str):
+        self.name = name
+
+    async def operate(self, *, instruction: str):
+        await asyncio.sleep(0)
+        return None
+
+
+class _BoomAgent:
+    """A reviewer that raises after a short delay."""
+
+    def __init__(self, name: str):
+        self.name = name
+
+    async def operate(self, *, instruction: str):
+        await asyncio.sleep(0.01)
+        raise RuntimeError("reviewer exploded")
+
+
+@pytest.mark.asyncio
+async def test_no_orphaned_tasks_after_dimension_failure():
+    """Attack: a dimension reviewer raises mid-flight.
+
+    Before the fix, verifier tasks spawned just before the failure kept running
+    in the background and mutated shared EngineRun state after _run raised.
+    After the fix, cancel_active() is called and _active must be empty before
+    the exception propagates to the caller.
+    """
+    eng = ReviewEngine(dimensions=("correctness", "security"))
+    run = eng.new_run()
+
+    # Inject a verifier-like task into _active to simulate the condition where
+    # a verifier was spawned by _on_issue just before the reviewer blew up.
+    mutated_after_raise: list[str] = []
+
+    async def lingering_verifier():
+        # This task must NOT complete normally if cancel_active() fires correctly.
+        await asyncio.sleep(10)  # long enough to outlive the run if not cancelled
+        mutated_after_raise.append("orphan mutated state")
+
+    # Set up agents: 'correctness' is fine, 'security' explodes.
+    async def fake_make(role, *, name=None, **kw):
+        if name and "security" in name:
+            return _BoomAgent(name or role)
+        return _OKAgent(name or role)
+
+    run.make_agent = fake_make
+
+    # Manually plant a long-running task into _active before calling _run so
+    # we can verify it gets cancelled.
+    task = asyncio.ensure_future(lingering_verifier())
+    run._active.add(task)
+    task.add_done_callback(run._active.discard)
+
+    with pytest.raises((RuntimeError, BaseExceptionGroup)):
+        await eng._run(run, "ARTIFACT")
+
+    # After _run raises, the orphaned task must have been cancelled — _active
+    # must be empty (no background work outlives the run).
+    assert not run._active, (
+        f"cancel_active() must leave _active empty: found {len(run._active)} task(s) still running"
+    )
+
+    # The lingering verifier never got to append because it was cancelled.
+    # Give the event loop a moment to process cancellation callbacks.
+    await asyncio.sleep(0.05)
+    assert mutated_after_raise == [], (
+        "Orphaned verifier mutated shared state after _run raised. "
+        "Structured concurrency cleanup is broken."
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_orphaned_tasks_when_all_dimensions_succeed():
+    """Baseline: when all reviewers succeed, _active is drained by wait_quiescence."""
+    eng = ReviewEngine(dimensions=("correctness", "security"))
+    run = eng.new_run()
+
+    calls: list[str] = []
+
+    async def fake_make(role, *, name=None, **kw):
+        return _OKAgent(name or role)
+
+    run.make_agent = fake_make
+
+    # Run succeeds (no LLM call, fake agents emit nothing).
+    await eng._run(run, "ARTIFACT")
+
+    # After a successful run there are no pending tasks.
+    assert not run._active, "_active must be empty after a successful run"
+
+
+@pytest.mark.asyncio
+async def test_cancel_active_clears_active_set():
+    """Unit test for EngineRun.cancel_active() directly.
+
+    Verifies that cancel_active() cancels every task and leaves _active empty,
+    regardless of what the tasks are doing.
+    """
+    eng = ReviewEngine()
+    run = eng.new_run()
+
+    ran: list[str] = []
+
+    async def long_task(label: str):
+        await asyncio.sleep(10)
+        ran.append(label)  # must never reach here if cancelled
+
+    for label in ("a", "b", "c"):
+        t = asyncio.ensure_future(long_task(label))
+        run._active.add(t)
+        t.add_done_callback(run._active.discard)
+
+    assert len(run._active) == 3
+
+    await run.cancel_active()
+
+    assert not run._active, "cancel_active must leave _active empty"
+
+    # Give event loop time to process callbacks.
+    await asyncio.sleep(0.01)
+    assert ran == [], "Cancelled tasks must not complete their body"
+
+
+@pytest.mark.asyncio
+async def test_cancel_active_is_idempotent_on_empty():
+    """cancel_active() on an already-empty _active must not raise."""
+    eng = ReviewEngine()
+    run = eng.new_run()
+    assert not run._active
+    await run.cancel_active()  # must not raise
+    assert not run._active


### PR DESCRIPTION
## What and why

`ReviewEngine._run()` used `asyncio.gather` to fan out dimension reviewers. When a reviewer raised, `asyncio.gather` cancelled sibling reviewer coroutines, but any verifier tasks that `_on_issue` had already spawned into `EngineRun._active` kept running in the background. Those orphaned tasks continued mutating shared `EngineRun` state (emission store, dedup set) after `_run` had already propagated an exception to the caller.

## Changes

- **`lionagi/engines/review.py`**: Replace `asyncio.gather` with `lionagi.ln.gather` (anyio `TaskGroup` — cancels sibling coroutines on failure). Wrap the fan-out in a `try/except BaseException` that calls `await run.cancel_active()` before re-raising, so no background verifier task outlives a failed run.

- **`lionagi/engines/engine.py`**: Add `EngineRun.cancel_active()` — cancels every task in `_active`, awaits them, and clears the set. Idempotent on empty.

- **`tests/engines/test_review_concurrency.py`** (new): Attack-driven tests that verify no orphaned tasks remain after a dimension failure:
  - `test_no_orphaned_tasks_after_dimension_failure` — plants a long-running task in `_active`, fires a reviewer that explodes, asserts `_active` is empty and the task never ran its body.
  - `test_no_orphaned_tasks_when_all_dimensions_succeed` — baseline: clean run leaves `_active` empty.
  - `test_cancel_active_clears_active_set` — direct unit test for the new method.
  - `test_cancel_active_is_idempotent_on_empty` — idempotency guard.

## Verification

```
uv run pytest tests/engines/ -v   # 35 passed
uv run ruff check lionagi/engines/review.py lionagi/engines/engine.py tests/engines/test_review_concurrency.py  # All checks passed
```

Closes #1299