### PR TITLE
security(studio): constrain Docker symlink mounts to an allowlist

### DIFF
--- a/lionagi/cli/studio.py
+++ b/lionagi/cli/studio.py
@@ -9,6 +9,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from lionagi.cli._logging import warn
+
 _STUDIO_IMAGE = "ghcr.io/ohdearquant/lion-studio:latest"
 
 
@@ -254,8 +256,8 @@ def _start_docker(host: str, api_port: int, frontend_port: int) -> int:
     # Security constraint: symlink targets are resolved to their real path
     # (no symlink chain games) and then checked against an allowlist of safe
     # roots before they are added to the docker run argv. Any target that
-    # resolves outside the allowlist is silently dropped so the docker run
-    # argv is never contaminated by an escape path.
+    # resolves outside the allowlist is dropped (with a warning) so the docker
+    # run argv is never contaminated by an escape path.
     allowed_roots = _mount_allowed_roots()
     symlink_mounts: set[Path] = set()
     for subdir_name in ("agents", "skills", "playbooks", "teams"):
@@ -274,10 +276,9 @@ def _start_docker(host: str, api_port: int, frontend_port: int) -> int:
             # targets, mount the target itself.
             mount_src = target if target.is_dir() else target.parent
             if not _is_mount_allowed(mount_src, allowed_roots):
-                print(
-                    f"Warning: symlink target {mount_src} is outside the allowed mount "
-                    "roots and will not be mounted.",
-                    file=sys.stderr,
+                warn(
+                    f"symlink target {mount_src} is outside the allowed mount "
+                    "roots and will not be mounted."
                 )
                 continue
             symlink_mounts.add(mount_src)

--- a/lionagi/cli/studio.py
+++ b/lionagi/cli/studio.py
@@ -12,6 +12,44 @@ from pathlib import Path
 _STUDIO_IMAGE = "ghcr.io/ohdearquant/lion-studio:latest"
 
 
+def _mount_allowed_roots() -> list[Path]:
+    """Return the ordered list of host path prefixes that may be bind-mounted.
+
+    Only resolved (real) paths whose first component is one of these roots are
+    permitted. Anything outside — including /etc, /proc, /var, or paths that
+    escape via double-symlink chains — is rejected before it reaches the docker
+    run argv.
+
+    The set is intentionally conservative: the user's home directory and the
+    XDG config home (which defaults to ~/.config). Projects that need additional
+    roots should symlink from inside an allowed root rather than pointing
+    directly at a system path.
+    """
+    roots: list[Path] = [Path.home().resolve()]
+    xdg_config = os.environ.get("XDG_CONFIG_HOME")
+    if xdg_config:
+        xdg_path = Path(xdg_config).resolve()
+        if xdg_path not in roots:
+            roots.append(xdg_path)
+    return roots
+
+
+def _is_mount_allowed(resolved_path: Path, allowed_roots: list[Path]) -> bool:
+    """Return True when *resolved_path* is strictly under an allowed root.
+
+    Both *resolved_path* and every entry in *allowed_roots* must already be
+    fully resolved (no symlinks). The check uses Path.is_relative_to so that
+    a root of ``/home/user`` does not match ``/home/username``.
+    """
+    for root in allowed_roots:
+        try:
+            if resolved_path.is_relative_to(root):
+                return True
+        except (TypeError, ValueError):
+            continue
+    return False
+
+
 def _add_studio_flags(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--port",
@@ -212,6 +250,13 @@ def _start_docker(host: str, api_port: int, frontend_port: int) -> int:
     # symlinks inside the container. Many power-user setups symlink content
     # from external project dirs (e.g. ~/projects/firm/agents/*) into
     # ~/.lionagi/agents/ — without these extra mounts the symlinks dangle.
+    #
+    # Security constraint: symlink targets are resolved to their real path
+    # (no symlink chain games) and then checked against an allowlist of safe
+    # roots before they are added to the docker run argv. Any target that
+    # resolves outside the allowlist is silently dropped so the docker run
+    # argv is never contaminated by an escape path.
+    allowed_roots = _mount_allowed_roots()
     symlink_mounts: set[Path] = set()
     for subdir_name in ("agents", "skills", "playbooks", "teams"):
         subdir = lionagi_home / subdir_name
@@ -228,6 +273,13 @@ def _start_docker(host: str, api_port: int, frontend_port: int) -> int:
             # symlink resolves identically inside the container. For directory
             # targets, mount the target itself.
             mount_src = target if target.is_dir() else target.parent
+            if not _is_mount_allowed(mount_src, allowed_roots):
+                print(
+                    f"Warning: symlink target {mount_src} is outside the allowed mount "
+                    "roots and will not be mounted.",
+                    file=sys.stderr,
+                )
+                continue
             symlink_mounts.add(mount_src)
 
     for mount_src in sorted(symlink_mounts):

--- a/tests/cli/test_studio_mounts.py
+++ b/tests/cli/test_studio_mounts.py
@@ -12,8 +12,8 @@ boundary check, so a symlink pointing at an arbitrary host path (e.g. /etc or
 
 The guard resolves every symlink to its real path and rejects any target that
 falls outside the declared allowlist of safe roots BEFORE the docker run argv
-is constructed.  Rejection is fail-closed: the mount is silently skipped and a
-warning is emitted to stderr.
+is constructed.  Rejection is fail-closed: the mount is dropped (with a warning)
+so the docker run argv is never contaminated by an escape path.
 """
 
 from __future__ import annotations
@@ -107,6 +107,10 @@ class TestSymlinkEscapeIsRejected:
 
         Returns the list passed to subprocess.run (the first positional arg).
         """
+        from lionagi.cli._logging import configure_cli_logging
+
+        configure_cli_logging(verbose=False)
+
         import lionagi.cli.studio as studio_mod
 
         lionagi_home = tmp_path / ".lionagi"

--- a/tests/cli/test_studio_mounts.py
+++ b/tests/cli/test_studio_mounts.py
@@ -1,0 +1,236 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Attack-driven regression tests for the Studio Docker symlink mount guard.
+
+Background: the Studio Docker launcher auto-mounts symlink targets found inside
+~/.lionagi/{agents,skills,playbooks,teams} so that symlinked content from
+project directories is accessible inside the container.  Before this fix, the
+resolved (real) target path was added to the docker run argv without any
+boundary check, so a symlink pointing at an arbitrary host path (e.g. /etc or
+/proc) would cause that path to be mounted into the container.
+
+The guard resolves every symlink to its real path and rejects any target that
+falls outside the declared allowlist of safe roots BEFORE the docker run argv
+is constructed.  Rejection is fail-closed: the mount is silently skipped and a
+warning is emitted to stderr.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Unit tests for the pure helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestIsMountAllowed:
+    """Direct tests for _is_mount_allowed."""
+
+    def test_path_inside_allowed_root_is_permitted(self, tmp_path):
+        from lionagi.cli.studio import _is_mount_allowed
+
+        root = tmp_path / "safe"
+        root.mkdir()
+        target = root / "subdir" / "file.yaml"
+        assert _is_mount_allowed(target, [root]) is True
+
+    def test_path_at_allowed_root_itself_is_permitted(self, tmp_path):
+        from lionagi.cli.studio import _is_mount_allowed
+
+        root = tmp_path / "safe"
+        root.mkdir()
+        assert _is_mount_allowed(root, [root]) is True
+
+    def test_path_outside_allowed_root_is_rejected(self, tmp_path):
+        from lionagi.cli.studio import _is_mount_allowed
+
+        allowed = tmp_path / "allowed"
+        allowed.mkdir()
+        outside = tmp_path / "other" / "secret"
+        assert _is_mount_allowed(outside, [allowed]) is False
+
+    def test_root_prefix_does_not_match_sibling_dir(self, tmp_path):
+        """Allowlist /home/user must not match /home/username."""
+        from lionagi.cli.studio import _is_mount_allowed
+
+        user_root = tmp_path / "user"
+        user_root.mkdir()
+        username_root = tmp_path / "username"
+        username_root.mkdir()
+        target = username_root / "secrets"
+        # /tmp/.../user should not grant access to /tmp/.../username/secrets
+        assert _is_mount_allowed(target, [user_root]) is False
+
+    def test_empty_allowed_roots_rejects_everything(self, tmp_path):
+        from lionagi.cli.studio import _is_mount_allowed
+
+        assert _is_mount_allowed(tmp_path / "anything", []) is False
+
+    def test_second_allowed_root_permits_path(self, tmp_path):
+        """A path may be permitted by any root in the list."""
+        from lionagi.cli.studio import _is_mount_allowed
+
+        root_a = tmp_path / "a"
+        root_a.mkdir()
+        root_b = tmp_path / "b"
+        root_b.mkdir()
+        target = root_b / "data"
+        assert _is_mount_allowed(target, [root_a, root_b]) is True
+
+    def test_system_path_outside_home_is_rejected(self):
+        """/etc/passwd resolves outside a user home — must be rejected."""
+        from lionagi.cli.studio import _is_mount_allowed
+
+        home = Path.home().resolve()
+        assert _is_mount_allowed(Path("/etc/passwd"), [home]) is False
+
+    def test_proc_path_is_rejected(self):
+        """/proc is outside the user home — must be rejected."""
+        from lionagi.cli.studio import _is_mount_allowed
+
+        home = Path.home().resolve()
+        assert _is_mount_allowed(Path("/proc/1/mem"), [home]) is False
+
+
+# ---------------------------------------------------------------------------
+# Attack scenario: symlink escape is rejected before docker argv is built
+# ---------------------------------------------------------------------------
+
+
+class TestSymlinkEscapeIsRejected:
+    """Symlink pointing outside the allowed roots must never appear in docker argv."""
+
+    def _build_docker_cmd(self, tmp_path, monkeypatch, symlink_target: Path) -> list[str]:
+        """Set up a fake ~/.lionagi with a single symlink and capture docker argv.
+
+        Returns the list passed to subprocess.run (the first positional arg).
+        """
+        import lionagi.cli.studio as studio_mod
+
+        lionagi_home = tmp_path / ".lionagi"
+        agents_dir = lionagi_home / "agents"
+        agents_dir.mkdir(parents=True)
+
+        # Create a symlink named "evil" pointing at the supplied target.
+        link = agents_dir / "evil"
+        link.symlink_to(symlink_target)
+
+        captured: list[list[str]] = []
+
+        def fake_subprocess_run(cmd, **kwargs):
+            captured.append(list(cmd))
+
+            class R:
+                returncode = 0
+                stderr = b""
+
+            return R()
+
+        monkeypatch.setattr(studio_mod.subprocess, "run", fake_subprocess_run)
+
+        # Patch Path.home() so lionagi_home resolves inside tmp_path.
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+        # Invoke _start_docker directly; it will call our fake subprocess.run.
+        studio_mod._start_docker(host="127.0.0.1", api_port=8765, frontend_port=3000)
+
+        # We expect two subprocess.run calls: pull + run. Return the run argv.
+        assert len(captured) == 2, f"Expected 2 subprocess.run calls, got {len(captured)}"
+        return captured[1]  # docker run argv
+
+    def test_symlink_to_etc_is_not_mounted(self, tmp_path, monkeypatch, capsys):
+        """Attack: symlink → /etc must be excluded from docker run argv."""
+        etc = Path("/etc")
+        if not etc.exists():
+            import pytest
+
+            pytest.skip("/etc does not exist on this platform")
+
+        argv = self._build_docker_cmd(tmp_path, monkeypatch, etc)
+        argv_str = " ".join(str(a) for a in argv)
+        assert "/etc" not in argv_str, (
+            "Escape succeeded: /etc appeared in docker run argv: " + argv_str
+        )
+        # The warning must have been printed.
+        captured = capsys.readouterr()
+        assert "outside the allowed mount roots" in captured.err
+
+    def test_symlink_to_tmp_subdir_outside_home_is_not_mounted(self, tmp_path, monkeypatch, capsys):
+        """Attack: symlink → a real directory outside allowed roots is blocked."""
+        import tempfile
+
+        # Create a real directory completely outside tmp_path (different mkdtemp).
+        with tempfile.TemporaryDirectory() as outside_dir:
+            outside = Path(outside_dir)
+            argv = self._build_docker_cmd(tmp_path, monkeypatch, outside)
+            argv_str = " ".join(str(a) for a in argv)
+            assert str(outside) not in argv_str, (
+                "Escape succeeded: outside path appeared in docker run argv: " + argv_str
+            )
+        captured = capsys.readouterr()
+        assert "outside the allowed mount roots" in captured.err
+
+    def test_symlink_inside_home_is_mounted(self, tmp_path, monkeypatch):
+        """Normal case: symlink → a directory inside ~/.lionagi is permitted."""
+        # Target lives inside tmp_path (which is the mocked home).
+        safe_dir = tmp_path / "projects" / "firm" / "agents"
+        safe_dir.mkdir(parents=True)
+
+        argv = self._build_docker_cmd(tmp_path, monkeypatch, safe_dir)
+        argv_str = " ".join(str(a) for a in argv)
+        # The safe directory should appear as a -v mount.
+        assert str(safe_dir) in argv_str, (
+            "In-root symlink was incorrectly blocked. argv: " + argv_str
+        )
+
+    def test_broken_symlink_is_silently_skipped(self, tmp_path, monkeypatch):
+        """A symlink pointing at a non-existent path is skipped without error."""
+        nonexistent = tmp_path / "does_not_exist" / "file.yaml"
+        # nonexistent was never created — resolve(strict=True) will raise OSError.
+        argv = self._build_docker_cmd(tmp_path, monkeypatch, nonexistent)
+        argv_str = " ".join(str(a) for a in argv)
+        assert "does_not_exist" not in argv_str
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _mount_allowed_roots
+# ---------------------------------------------------------------------------
+
+
+class TestMountAllowedRoots:
+    """_mount_allowed_roots returns expected safe roots."""
+
+    def test_home_is_always_in_roots(self):
+        from lionagi.cli.studio import _mount_allowed_roots
+
+        roots = _mount_allowed_roots()
+        home = Path.home().resolve()
+        assert home in roots
+
+    def test_xdg_config_home_is_included_when_set(self, tmp_path, monkeypatch):
+        from lionagi.cli.studio import _mount_allowed_roots
+
+        xdg = tmp_path / "xdg-config"
+        xdg.mkdir()
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+        roots = _mount_allowed_roots()
+        assert xdg.resolve() in roots
+
+    def test_xdg_config_home_not_duplicated_if_equals_home(self, monkeypatch):
+        """When XDG_CONFIG_HOME == home, it must not appear twice."""
+        from lionagi.cli.studio import _mount_allowed_roots
+
+        home = Path.home().resolve()
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(home))
+        roots = _mount_allowed_roots()
+        assert roots.count(home) == 1
+
+    def test_no_xdg_env_gives_only_home(self, monkeypatch):
+        from lionagi.cli.studio import _mount_allowed_roots
+
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+        roots = _mount_allowed_roots()
+        assert len(roots) == 1
+        assert Path.home().resolve() in roots


### PR DESCRIPTION
## What

The Studio Docker launcher discovers symlinks under `~/.lionagi/{agents,skills,playbooks,teams}` and mounts their resolved real targets into the container. Before this fix, the resolved path was added to the `docker run` argv without any boundary check. A symlink pointing at `/etc`, `/proc`, or any arbitrary host path would cause that path to be mounted into the container.

## Fix

- **`_mount_allowed_roots()`** — returns the user's home directory plus `XDG_CONFIG_HOME` as the safe mount boundary.
- **`_is_mount_allowed(resolved_path, allowed_roots)`** — pure predicate using `Path.is_relative_to`, which avoids the prefix-aliasing bug (`/home/user` does not match `/home/username`).
- **`_start_docker`** — calls `_is_mount_allowed` after resolving the symlink (already using `resolve(strict=True)`). Any escape path is dropped and a warning is written to stderr. The docker run argv is never built with a path outside the allowlist.

## Tests (`tests/cli/test_studio_mounts.py`)

Attack-driven regression tests:
- `TestIsMountAllowed` — 8 unit tests covering the pure predicate (permitted, rejected, sibling-dir aliasing, `/etc`, `/proc`, empty allowlist, multi-root).
- `TestSymlinkEscapeIsRejected` — integration tests that wire a fake `~/.lionagi` with a symlink and capture the docker argv:
  - symlink → `/etc` is excluded from argv, warning emitted.
  - symlink → real tmpdir outside home is excluded from argv, warning emitted.
  - symlink → directory inside home is correctly mounted (normal case preserved).
  - broken symlink is silently skipped (existing behavior preserved).
- `TestMountAllowedRoots` — 4 tests for root list composition.

All 16 tests pass. `ruff check` and `ruff format` are clean.

Closes #1293