### PR TITLE
fix(spec): use key-presence checks in CommonMeta._validate_common_metas

### DIFF
--- a/lionagi/ln/types/spec.py
+++ b/lionagi/ln/types/spec.py
@@ -46,13 +46,18 @@ class CommonMeta(Enum):
 
     @classmethod
     def _validate_common_metas(cls, **kw):
-        """Validate common metadata constraints."""
-        if kw.get("default") and kw.get("default_factory"):
+        """Validate common metadata constraints.
+
+        Uses key-presence checks rather than truthiness so that falsy-but-valid
+        values (e.g. ``default=0``, ``default=False``) are handled correctly.
+        """
+        if "default" in kw and "default_factory" in kw:
             raise ValueError("Cannot provide both 'default' and 'default_factory'")
-        if _df := kw.get("default_factory"):
-            if not callable(_df):
+        if "default_factory" in kw:
+            if not callable(kw["default_factory"]):
                 raise ValueError("'default_factory' must be callable")
-        if _val := kw.get("validator"):
+        if "validator" in kw:
+            _val = kw["validator"]
             _val = [_val] if not isinstance(_val, list) else _val
             if not all(callable(v) for v in _val):
                 raise ValueError("Validators must be a list of functions or a function")

--- a/tests/libs/test_spec.py
+++ b/tests/libs/test_spec.py
@@ -246,6 +246,65 @@ class TestSpec:
             spec.base_type = int
 
 
+class TestCommonMetaFalsyValueHandling:
+    """Attack-driven tests: falsy-but-valid values must not bypass validation."""
+
+    def test_default_zero_and_factory_conflict_raises(self):
+        """default=0 (falsy) alongside default_factory must still be detected as a conflict.
+
+        Previously, truthiness on kw.get('default') treated 0 as absent, silently
+        accepting an invalid combination that would produce undefined behaviour at
+        instantiation time.
+        """
+        with pytest.raises(ValueError, match="both 'default' and 'default_factory'"):
+            CommonMeta._validate_common_metas(default=0, default_factory=list)
+
+    def test_default_false_and_factory_conflict_raises(self):
+        """default=False (falsy) alongside default_factory must be detected as a conflict."""
+        with pytest.raises(ValueError, match="both 'default' and 'default_factory'"):
+            CommonMeta._validate_common_metas(default=False, default_factory=list)
+
+    def test_default_factory_zero_non_callable_raises(self):
+        """default_factory=0 is not callable and must be rejected.
+
+        Previously the walrus assignment ``if _df := kw.get('default_factory')``
+        skipped the callable check for falsy non-callables, silently producing a
+        broken Spec that would fail at runtime when the factory was invoked.
+        """
+        with pytest.raises(ValueError, match="must be callable"):
+            CommonMeta._validate_common_metas(default_factory=0)
+
+    def test_validator_zero_non_callable_raises(self):
+        """validator=0 is not callable and must be rejected.
+
+        Previously the walrus assignment ``if _val := kw.get('validator')`` skipped
+        validator-callability checks when the value was falsy, allowing invalid
+        validators to be stored without error.
+        """
+        with pytest.raises(ValueError, match="must be a list of functions or a function"):
+            CommonMeta._validate_common_metas(validator=0)
+
+    def test_default_zero_alone_is_valid(self):
+        """default=0 without default_factory must succeed; 0 is a legitimate default."""
+        CommonMeta._validate_common_metas(default=0)  # must not raise
+
+    def test_default_false_alone_is_valid(self):
+        """default=False without default_factory must succeed."""
+        CommonMeta._validate_common_metas(default=False)  # must not raise
+
+    def test_spec_default_zero_is_stored(self):
+        """Spec(int, default=0) must store 0 and return it as the default."""
+        spec = Spec(int, name="count", default=0)
+        assert spec.default == 0
+        assert spec.create_default_value() == 0
+
+    def test_spec_default_false_is_stored(self):
+        """Spec(bool, default=False) must store False and return it as the default."""
+        spec = Spec(bool, name="flag", default=False)
+        assert spec.default is False
+        assert spec.create_default_value() is False
+
+
 class TestSpecDefaultValueEdgeCases:
     def test_spec_create_default_value_errors_without_default(self):
         """Spec with no default or factory raises ValueError."""


### PR DESCRIPTION
## What

`CommonMeta._validate_common_metas` used truthiness to detect the presence of
`default`, `default_factory`, and `validator` keys. This caused three silent
failure modes:

1. **`default=0` + `default_factory=...`** — the conflict check evaluates
   `kw.get('default')` as falsy (`0`), so the duplicate-key guard is skipped.
   Both are stored; adapter behaviour is undefined.
2. **`default_factory=0`** — the walrus `if _df := kw.get(...)` evaluates to
   false for `0`, so the callable check is never reached. A non-callable factory
   is stored silently and fails at call time.
3. **`validator=0`** — same walrus pattern, same silent-pass outcome.

## Fix

Replace all three truthiness checks with explicit key-presence tests (`'key' in kw`).
The validation now fires whenever the caller supplies the key, regardless of the value.

## Tests

New test class `TestCommonMetaFalsyValueHandling` in `tests/libs/test_spec.py`:

- `test_default_zero_and_factory_conflict_raises` — exploit: `default=0 + default_factory=list`
- `test_default_false_and_factory_conflict_raises` — exploit: `default=False + default_factory=list`
- `test_default_factory_zero_non_callable_raises` — exploit: `default_factory=0`
- `test_validator_zero_non_callable_raises` — exploit: `validator=0`
- `test_default_zero_alone_is_valid` — regression: `default=0` alone must succeed
- `test_default_false_alone_is_valid` — regression: `default=False` alone must succeed
- `test_spec_default_zero_is_stored` — `Spec(int, default=0).create_default_value() == 0`
- `test_spec_default_false_is_stored` — `Spec(bool, default=False).create_default_value() is False`

All 44 tests in `tests/libs/test_spec.py` pass. `ruff check` and `ruff format` clean.

Closes #1303