### PR TITLE
fix(orchestration): fail-closed guard for unknown assignees in role_node_builder

### DIFF
--- a/lionagi/orchestration/patterns.py
+++ b/lionagi/orchestration/patterns.py
@@ -95,8 +95,13 @@ def role_node_builder(roles: dict[str, Branch]):
             op,
             parameters={"instruction": req.instruction},
         )
-        target = roles.get(req.assignee) if req.assignee else None
-        if target is not None:
+        if req.assignee:
+            target = roles.get(req.assignee)
+            if target is None:
+                raise ValueError(
+                    f"SpawnRequest assignee {req.assignee!r} is not a "
+                    f"recognized role (known: {sorted(roles)})"
+                )
             node.branch_id = target.id
         return node
 

--- a/tests/orchestration/test_patterns.py
+++ b/tests/orchestration/test_patterns.py
@@ -50,6 +50,12 @@ class TestRoleNodeBuilder:
         node = nb(SpawnRequest(instruction="x"), None)
         assert node.branch_id is None
 
+    def test_unknown_assignee_raises(self):
+        session, roles = _roles("researcher")
+        nb = role_node_builder(roles)
+        with pytest.raises(ValueError, match="not a recognized role"):
+            nb(SpawnRequest(instruction="x", assignee="ghost"), None)
+
     def test_custom_operation_preserved(self):
         session, roles = _roles("researcher")
         nb = role_node_builder(roles)


### PR DESCRIPTION
## Summary
- `role_node_builder` now raises `ValueError` when a `SpawnRequest` carries a truthy assignee not in the known roles dict
- Previously silently fell through to execute on a fallback branch with no branch_id

Closes #1305

## Test plan
- [x] `uv run pytest tests/orchestration/test_patterns.py -v` — 22 passed
- [x] `uv run ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)