### PR TITLE
fix(orchestration): correct build_dag_graph return annotation to include None

### DIFF
--- a/lionagi/orchestration/patterns.py
+++ b/lionagi/orchestration/patterns.py
@@ -266,7 +266,7 @@ def build_dag_graph(
     session: Session,
     assignments: list[TaskAssignment],
     roles: dict[str, Branch],
-) -> tuple[Graph, list[str]]:
+) -> tuple[Graph, list[str | None]]:
     """Wire assignments into a dependency DAG (honours ``depends_on``).
 
     Like :func:`build_fanout_graph`, each assignment runs on a *clone* of its

--- a/tests/orchestration/test_patterns.py
+++ b/tests/orchestration/test_patterns.py
@@ -178,6 +178,38 @@ class TestBuildDagGraph:
         assert node.branch_id != roles["researcher"].id
         assert node.branch_id in session.branches
 
+    def test_return_annotation_allows_none_in_node_ids(self):
+        """Return annotation must be list[str | None] to match runtime."""
+        import types
+        import typing
+
+        import lionagi.orchestration.patterns as _mod
+
+        # Session/Branch are TYPE_CHECKING-only; inject them so
+        # get_type_hints can resolve the full signature.
+        ns = dict(vars(_mod))
+        ns.setdefault("Session", Session)
+        ns.setdefault("Branch", Branch)
+        hints = typing.get_type_hints(build_dag_graph, globalns=ns, include_extras=True)
+        ret = hints["return"]
+        # tuple[Graph, list[str | None]]
+        assert typing.get_origin(ret) is tuple
+        _, list_type = typing.get_args(ret)
+        assert typing.get_origin(list_type) is list
+        (elem_type,) = typing.get_args(list_type)
+        assert typing.get_origin(elem_type) is types.UnionType
+        assert set(typing.get_args(elem_type)) == {str, type(None)}
+
+        # Verify runtime: a dropped assignee produces None in the list
+        session, roles = _roles("researcher")
+        assignments = [
+            TaskAssignment(task="ok", assignee="researcher"),
+            TaskAssignment(task="ghost", assignee="nobody"),
+        ]
+        _, ids = build_dag_graph(session, assignments, roles)
+        assert ids[0] is not None
+        assert ids[1] is None
+
 
 class _FakeOrc:
     """Stand-in orchestrator branch: returns scripted assignments from operate()."""


### PR DESCRIPTION
## Summary
- `build_dag_graph` return annotation corrected from `list[str]` to `list[str | None]`
- The function inserts `None` for dropped unknown-assignee steps; annotation now matches runtime

Closes #1306

## Test plan
- [x] `uv run pytest tests/orchestration/test_patterns.py -v` — 22 passed
- [x] `uv run ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)