### PR TITLE
fix(testing): defensive copy in ScriptModel to prevent caller dict mutation

### DIFF
--- a/lionagi/testing/_script.py
+++ b/lionagi/testing/_script.py
@@ -118,7 +118,7 @@ class ScriptModel(BaseModel):
         responses).
         """
         if isinstance(source, cls):
-            return source
+            return source.model_copy(deep=True)
         if isinstance(source, str | Path):
             p = Path(source)
             if p.suffix in {".yaml", ".yml"}:

--- a/lionagi/testing/_script.py
+++ b/lionagi/testing/_script.py
@@ -90,15 +90,19 @@ class ScriptModel(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def _coerce_responses(cls, data: Any) -> Any:
-        """Accept raw dicts in ``responses`` and dispatch to subclasses."""
+        """Accept raw dicts in ``responses`` and dispatch to subclasses.
+
+        Works on a shallow copy so the caller-supplied dict is never mutated.
+        """
 
         if isinstance(data, dict):
+            data = dict(data)
             raw = data.get("responses")
             if isinstance(raw, list):
                 coerced: list[Any] = []
                 for entry in raw:
                     if isinstance(entry, dict):
-                        coerced.append(_build_entry(entry))
+                        coerced.append(_build_entry(dict(entry)))
                     else:
                         coerced.append(entry)
                 data["responses"] = coerced

--- a/tests/testing/test_script_dict_mutation.py
+++ b/tests/testing/test_script_dict_mutation.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests that ScriptModel does not mutate caller-supplied dicts."""
+
+from __future__ import annotations
+
+import copy
+
+from lionagi.testing import ScriptModel, ToolCallResponse
+
+
+def _payload(prompt: str = "hi") -> dict:
+    return {
+        "model": "scripted-test",
+        "messages": [{"role": "user", "content": prompt}],
+    }
+
+
+class TestCallerDictUnchanged:
+    """ScriptModel construction must not modify the dict the caller passed in."""
+
+    def test_model_validate_does_not_mutate_input_dict(self):
+        responses_list = [
+            {"type": "text", "content": "hello"},
+            {"type": "tool_call", "name": "fn", "arguments": {"x": 1}},
+        ]
+        caller_dict = {"version": 1, "responses": responses_list}
+        snapshot = copy.deepcopy(caller_dict)
+
+        ScriptModel.model_validate(caller_dict)
+
+        assert caller_dict == snapshot, "model_validate mutated the caller-supplied dict"
+
+    def test_from_responses_does_not_mutate_entry_dicts(self):
+        entry = {"type": "text", "content": "original"}
+        snapshot = dict(entry)
+
+        ScriptModel.from_responses([entry])
+
+        assert entry == snapshot, "from_responses mutated the caller-supplied entry dict"
+
+    def test_coerce_dict_does_not_mutate_input(self):
+        caller = {
+            "version": 1,
+            "responses": [{"type": "text", "content": "coerced"}],
+        }
+        snapshot = copy.deepcopy(caller)
+
+        ScriptModel.coerce(caller)
+
+        assert caller == snapshot, "coerce mutated the caller-supplied dict"
+
+
+class TestNoStateBleeding:
+    """Reusing a ScriptModel must not bleed state between uses."""
+
+    def test_reset_gives_clean_state(self):
+        script = ScriptModel.from_responses(
+            [
+                {"type": "text", "content": "a"},
+                {"type": "text", "content": "b"},
+            ]
+        )
+        # Consume both entries
+        r1, _ = script.next(_payload(), 0)
+        r2, _ = script.next(_payload(), 1)
+        assert r1.content == "a"
+        assert r2.content == "b"
+        assert script.exhausted
+
+        # Reset and replay
+        script.reset()
+        r3, _ = script.next(_payload(), 0)
+        r4, _ = script.next(_payload(), 1)
+        assert r3.content == "a"
+        assert r4.content == "b"
+
+    def test_two_models_from_same_list_are_independent(self):
+        shared_responses = [
+            {"type": "text", "content": "shared"},
+        ]
+        model_a = ScriptModel.from_responses(shared_responses)
+        model_b = ScriptModel.from_responses(shared_responses)
+
+        # Consume model_a
+        model_a.next(_payload(), 0)
+        assert model_a.exhausted
+
+        # model_b must be unaffected
+        assert not model_b.exhausted
+        entry, _ = model_b.next(_payload(), 0)
+        assert entry.content == "shared"
+
+    def test_tool_call_arguments_not_shared_across_models(self):
+        args = {"key": "value"}
+        entry_dict = {"type": "tool_call", "name": "fn", "arguments": args}
+
+        model_a = ScriptModel.from_responses([entry_dict])
+        model_b = ScriptModel.from_responses([entry_dict])
+
+        resp_a, _ = model_a.next(_payload(), 0)
+        resp_b, _ = model_b.next(_payload(), 0)
+
+        assert isinstance(resp_a, ToolCallResponse)
+        assert isinstance(resp_b, ToolCallResponse)
+
+        # Mutating one model's response must not affect the other
+        resp_a.arguments["key"] = "mutated"
+        assert resp_b.arguments["key"] == "value"
+
+    def test_original_entry_dict_unchanged_after_build(self):
+        args = {"original": True}
+        entry_dict = {
+            "type": "tool_call",
+            "name": "fn",
+            "arguments": args,
+        }
+        snapshot_args = dict(args)
+        snapshot_entry = copy.deepcopy(entry_dict)
+
+        ScriptModel.from_responses([entry_dict])
+
+        assert args == snapshot_args, "caller's arguments dict was mutated"
+        assert entry_dict == snapshot_entry, "caller's entry dict was mutated"
+
+    def test_when_matcher_served_list_independent_across_resets(self):
+        script = ScriptModel.from_responses(
+            [
+                {
+                    "type": "text",
+                    "content": "conditional",
+                    "when": {"prompt_contains": "magic"},
+                },
+                {"type": "text", "content": "fallback"},
+            ]
+        )
+
+        # Serve conditional
+        r1, _ = script.next(_payload("magic word"), 0)
+        assert r1.content == "conditional"
+
+        # Reset clears when-served state
+        script.reset()
+        r2, _ = script.next(_payload("magic word"), 0)
+        assert r2.content == "conditional"

--- a/tests/testing/test_script_model.py
+++ b/tests/testing/test_script_model.py
@@ -165,10 +165,32 @@ class TestLoaders:
         entry, _ = script.next(_payload(), 0)
         assert entry.content == "list-coerced"
 
-    def test_coerce_passes_through_scriptmodel(self):
+    def test_coerce_scriptmodel_returns_independent_copy(self):
         original = ScriptModel.from_responses([{"type": "text", "content": "x"}])
-        again = ScriptModel.coerce(original)
-        assert again is original
+        copy = ScriptModel.coerce(original)
+        # Must be a distinct object with independent cursor state.
+        assert copy is not original
+        assert copy.responses[0].content == "x"
+
+    def test_coerce_scriptmodel_cursor_independence(self):
+        script = ScriptModel.from_responses(
+            [
+                {"type": "text", "content": "one"},
+                {"type": "text", "content": "two"},
+            ]
+        )
+        copy_a = ScriptModel.coerce(script)
+        copy_b = ScriptModel.coerce(script)
+
+        # Advance copy_a by one step.
+        entry_a, _ = copy_a.next({"model": "t", "messages": [{"role": "user", "content": "hi"}]}, 0)
+        assert entry_a.content == "one"
+        assert copy_a.cursor == 1
+
+        # copy_b must be unaffected.
+        assert copy_b.cursor == 0
+        entry_b, _ = copy_b.next({"model": "t", "messages": [{"role": "user", "content": "hi"}]}, 0)
+        assert entry_b.content == "one"
 
     def test_invalid_response_type_raises(self):
         with pytest.raises(ValueError, match="unknown response type"):


### PR DESCRIPTION
## Summary
- `ScriptModel._coerce_responses` now shallow-copies input dicts before coercion
- Prevents caller-supplied dicts from being mutated in-place and state bleeding between models

Closes #1307

## Test plan
- [x] `uv run pytest tests/testing/test_script_dict_mutation.py -v` — 8 passed
- [x] `uv run ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)