### PR TITLE
fix(sandbox): set is_active=False after merge/discard

### DIFF
--- a/lionagi/tools/sandbox.py
+++ b/lionagi/tools/sandbox.py
@@ -110,6 +110,7 @@ def _cleanup_worktree_sync(session: SandboxSession) -> dict:
         ["branch", "-D", session.branch_name],
         cwd=session.repo_root,
     )
+    session.is_active = False
     return {
         "worktree_removed": rc1 == 0,
         "branch_deleted": rc2 == 0,

--- a/tests/tools/test_sandbox.py
+++ b/tests/tools/test_sandbox.py
@@ -196,9 +196,23 @@ async def test_sandbox_merge_cleans_up_worktree(git_repo):
     assert not os.path.exists(worktree_path)
 
 
+async def test_sandbox_merge_sets_is_active_false(git_repo):
+    session = await create_sandbox(str(git_repo))
+    assert session.is_active is True
+    await sandbox_merge(session)
+    assert session.is_active is False
+
+
 # ---------------------------------------------------------------------------
 # sandbox_discard
 # ---------------------------------------------------------------------------
+
+
+async def test_sandbox_discard_sets_is_active_false(git_repo):
+    session = await create_sandbox(str(git_repo))
+    assert session.is_active is True
+    await sandbox_discard(session)
+    assert session.is_active is False
 
 
 async def test_sandbox_discard_removes_worktree(git_repo):


### PR DESCRIPTION
## Summary
- `SandboxSession.is_active` now set to `False` in `_cleanup_worktree_sync` (shared path for merge and discard)
- Previously stayed `True` after session ended, making the lifecycle flag inaccurate

Closes #1311

## Test plan
- [x] `uv run pytest tests/tools/test_sandbox.py -v` — 20 passed
- [x] `uv run ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)