### PR TITLE
docs: fix agent/sandbox API drift in AGENT.md, CLAUDE.md, README.md

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -96,23 +96,12 @@ from lionagi.agent.config import AgentConfig
 from lionagi.agent.factory import create_agent
 
 async def main():
-    config = AgentConfig.coding()          # file tools + guard hooks + strict path policy
+    config = AgentConfig.coding()          # CodingToolkit + guard hooks + workspace path policy
     agent = await create_agent(config)     # returns a wired Branch
     reply = await agent.communicate("Refactor auth.py to use async/await throughout.")
     print(reply)
 
 asyncio.run(main())
-```
-
-**Create a research agent**
-
-```python
-config = AgentConfig.research()            # web + reader tools + log-only policy
-agent = await create_agent(config)
-result = await agent.operate(
-    instruction="Summarize the latest papers on diffusion models.",
-    response_format=Summary,
-)
 ```
 
 **Register custom hooks**
@@ -122,23 +111,24 @@ from lionagi.agent.hooks import guard_paths, log_tool_use
 from lionagi.agent.config import AgentConfig
 
 config = AgentConfig.coding()
-config.hooks.append(guard_paths(allowed=["/tmp/sandbox", "./src"]))
-config.hooks.append(log_tool_use(sink="tool_calls.jsonl"))
+config.pre("reader", guard_paths(allowed_paths=["/tmp/sandbox", "./src"]))
+config.post("*", log_tool_use)
 agent = await create_agent(config)
 ```
 
 **Use Sandbox for isolated edits**
 
 ```python
-from lionagi.tools.sandbox import SandboxSession
+from lionagi.tools.sandbox import create_sandbox, sandbox_diff, sandbox_commit, sandbox_merge
 
-async with await SandboxSession.create(base_branch="main") as session:
-    # agent edits happen inside the worktree
-    agent = await create_agent(AgentConfig.coding(), cwd=session.path)
-    await agent.communicate("Add type hints to all public functions in auth.py.")
-    print(await session.diff())            # inspect changes before committing
-    await session.commit("feat: add type hints to auth module")
-    await session.merge()                  # fast-forward into main; or session.discard()
+session = await create_sandbox(repo_root="/path/to/repo", base_branch="main")
+# agent edits happen inside the worktree at session.worktree_path
+config = AgentConfig.coding(cwd=session.worktree_path)
+agent = await create_agent(config)
+await agent.communicate("Add type hints to all public functions in auth.py.")
+print(await sandbox_diff(session))         # inspect changes before committing
+await sandbox_commit(session, "feat: add type hints to auth module")
+await sandbox_merge(session)               # merge into base; or sandbox_discard(session)
 ```
 
 **Permission policies**
@@ -146,14 +136,22 @@ async with await SandboxSession.create(base_branch="main") as session:
 ```python
 from lionagi.agent.permissions import PermissionPolicy
 
-# Allowlist mode: only listed tools may run
-policy = PermissionPolicy(mode="allowlist", tools=["read_file", "list_dir"])
+# Allow-all mode: everything permitted (default for orchestrators)
+policy = PermissionPolicy(mode="allow_all")
 
-# Confirm mode: prompt before each tool execution
-policy = PermissionPolicy(mode="confirm")
+# Deny-all mode: nothing permitted (safe mode)
+policy = PermissionPolicy(mode="deny_all")
+
+# Rules mode: per-tool allow/deny/escalate patterns
+policy = PermissionPolicy(
+    mode="rules",
+    allow={"reader": ["*"], "search": ["*"]},
+    deny={"bash": ["rm *"]},
+    escalate={"bash": ["*"]},
+)
 
 config = AgentConfig.coding()
-config.permission_policy = policy
+config.permissions = {"mode": "rules", "allow": {"reader": ["*"]}, "deny": {"bash": ["rm *"]}}
 ```
 
 **Settings** — place `.lionagi/settings.yaml` in the project root to override defaults. Global settings live at `~/.lionagi/settings.yaml`; project settings win on conflict.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,15 +64,15 @@ Modules: chat, parse, operate, ReAct, select, interpret, communicate, run, act. 
 
 ### Agent Infrastructure (`lionagi/agent/`)
 
-- **`config.py`** — `AgentConfig` dataclass with presets: `.coding()` (file tools + guard hooks + strict path policy) and `.research()` (web + reader tools + log-only policy).
+- **`config.py`** — `AgentConfig` dataclass with preset: `.coding()` (CodingToolkit + guard hooks + workspace path policy).
 - **`factory.py`** — `create_agent()` async factory: wires a `Branch`, registers tools from config, attaches hooks, returns ready-to-use branch.
-- **`permissions.py`** — `PermissionPolicy` with `allowlist` / `denylist` / `confirm` modes. Applied per tool call before execution.
-- **`hooks.py`** — Built-in hooks: `guard_destructive` (blocks rm/drop/truncate), `guard_paths` (restricts file access to allowed roots), `log_tool_use` (structured tool-call logging).
+- **`permissions.py`** — `PermissionPolicy` with `allow_all` / `deny_all` / `rules` modes. Applied per tool call before execution.
+- **`hooks.py`** — Built-in hooks: `guard_destructive` (blocks rm/drop/truncate), `guard_paths(allowed_paths=...)` (restricts file access to allowed roots), `log_tool_use` (structured tool-call logging).
 - **`settings.py`** — Loads `.lionagi/settings.yaml`; merges global (`~/.lionagi/settings.yaml`) with project-level (`.lionagi/settings.yaml`), project wins on conflict.
 
 ### Sandbox (`lionagi/tools/sandbox.py`)
 
-`SandboxSession` wraps git worktrees for isolated editing. Lifecycle: `SandboxSession.create(base_branch)` → edit files freely → `session.diff()` (returns unified diff) → `session.commit(msg)` → `session.merge()` (fast-forward into base) or `session.discard()` (deletes worktree, no trace). Safe for speculative or destructive edits — the base branch is never touched until an explicit `merge()`.
+`SandboxSession` is a dataclass holding worktree state. Module-level async functions drive the lifecycle: `create_sandbox(repo_root, base_branch)` → edit files freely → `sandbox_diff(session)` (returns diff dict) → `sandbox_commit(session, msg)` → `sandbox_merge(session)` (merges into base) or `sandbox_discard(session)` (deletes worktree, no trace). Safe for speculative or destructive edits — the base branch is never touched until an explicit `sandbox_merge()`.
 
 ### CLI Architecture (`lionagi/cli/`)
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ li studio --dev                 # starts backend + frontend with hot reload
 - **Lion Studio** — web UI for orchestrating agent workflows: projects, scheduled runs, execution DAGs, branch inspection, and multi-agent monitoring.
 - **Project management (ADR-0026)** — per-repo `.lionagi/config.toml` for project identity. Sessions auto-group by project. `--project NAME` flag on all CLI commands.
 - **Scheduled runs (ADR-0027)** — cron, interval, and GitHub-poll triggers with DAG-based conditional chains (`on_fail`/`on_success`). Studio becomes an active operator, not just a monitor.
-- **Agent infrastructure** — `AgentConfig` presets (`.coding()`, `.research()`) with built-in permission policies, hooks, and tool registration via `create_agent()`.
-- **Sandbox tool** — `SandboxSession` uses git worktrees for isolated editing: `create()` → edit → `diff()` → `commit()` → `merge()` or `discard()`.
+- **Agent infrastructure** — `AgentConfig` preset (`.coding()`) with built-in permission policies, hooks, and tool registration via `create_agent()`.
+- **Sandbox tool** — `SandboxSession` dataclass with module-level async functions for git worktree isolation: `create_sandbox()` → edit → `sandbox_diff()` → `sandbox_commit()` → `sandbox_merge()` or `sandbox_discard()`.
 
 ## Install
 
@@ -88,8 +88,8 @@ For multi-agent orchestration without Python, see [CLI Quick Start](docs/getting
 | **team** | Persistent inbox messaging between agents via `li team send/receive`. |
 | **operate** | `branch.operate(instruction=…)` — tool use + structured output + optional streaming. |
 | **persist** | Every run saved to `~/.lionagi/runs/{run_id}/`. Resume with `li agent -r <branch-id>`. |
-| **AgentConfig** | Preset agent configurations (coding, research) with permission policies, hooks, and tool registration. |
-| **Sandbox** | Git worktree isolation for safe experimentation — `SandboxSession.create()` → edit → diff → merge or discard. |
+| **AgentConfig** | Preset agent configuration (`.coding()`) with permission policies, hooks, and tool registration. |
+| **Sandbox** | Git worktree isolation for safe experimentation — `create_sandbox()` → edit → `sandbox_diff()` → `sandbox_merge()` or `sandbox_discard()`. |
 
 ## CLI — `li`
 

--- a/tests/docs/test_agent_sandbox_api.py
+++ b/tests/docs/test_agent_sandbox_api.py
@@ -1,0 +1,300 @@
+# Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests verifying documented agent and sandbox API matches source code.
+
+Guards against docs-drift for:
+- AgentConfig presets and fields
+- PermissionPolicy modes and constructor
+- Hook function signatures (guard_destructive, guard_paths, log_tool_use)
+- SandboxSession dataclass and module-level async functions
+"""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import fields
+
+# =============================================================================
+# AgentConfig
+# =============================================================================
+
+
+class TestAgentConfigPresets:
+    """Verify AgentConfig has exactly the documented presets."""
+
+    def test_coding_preset_exists(self):
+        """AgentConfig.coding() is a classmethod that returns AgentConfig."""
+        from lionagi.agent.config import AgentConfig
+
+        assert hasattr(AgentConfig, "coding")
+        config = AgentConfig.coding()
+        assert isinstance(config, AgentConfig)
+
+    def test_research_preset_does_not_exist(self):
+        """AgentConfig.research() must NOT exist (removed; docs updated)."""
+        from lionagi.agent.config import AgentConfig
+
+        assert not hasattr(AgentConfig, "research")
+
+    def test_coding_tools_value(self):
+        """AgentConfig.coding() sets tools to ['coding'] (CodingToolkit)."""
+        from lionagi.agent.config import AgentConfig
+
+        config = AgentConfig.coding()
+        assert config.tools == ["coding"]
+
+    def test_coding_secure_default_hooks(self):
+        """Secure mode (default) wires guard_destructive and guard_paths."""
+        from lionagi.agent.config import AgentConfig
+
+        config = AgentConfig.coding()
+        # pre:bash should have guard_destructive
+        assert "pre:bash" in config.hook_handlers
+        assert len(config.hook_handlers["pre:bash"]) >= 1
+        # pre:reader and pre:editor should have guard_paths
+        assert "pre:reader" in config.hook_handlers
+        assert "pre:editor" in config.hook_handlers
+
+    def test_coding_insecure_no_hooks(self):
+        """AgentConfig.coding(secure=False) does not add guard hooks."""
+        from lionagi.agent.config import AgentConfig
+
+        config = AgentConfig.coding(secure=False)
+        assert len(config.hook_handlers) == 0
+
+
+# =============================================================================
+# PermissionPolicy
+# =============================================================================
+
+
+class TestPermissionPolicyModes:
+    """Verify PermissionPolicy modes match source (allow_all, deny_all, rules)."""
+
+    def test_default_mode_is_allow_all(self):
+        from lionagi.agent.permissions import PermissionPolicy
+
+        policy = PermissionPolicy()
+        assert policy.mode == "allow_all"
+
+    def test_allow_all_classmethod(self):
+        from lionagi.agent.permissions import PermissionPolicy
+
+        policy = PermissionPolicy.allow_all()
+        assert policy.mode == "allow_all"
+
+    def test_deny_all_classmethod(self):
+        from lionagi.agent.permissions import PermissionPolicy
+
+        policy = PermissionPolicy.deny_all()
+        assert policy.mode == "deny_all"
+
+    def test_rules_mode_with_allow_deny(self):
+        from lionagi.agent.permissions import PermissionPolicy
+
+        policy = PermissionPolicy(
+            mode="rules",
+            allow={"reader": ["*"]},
+            deny={"bash": ["rm *"]},
+        )
+        assert policy.mode == "rules"
+        assert "reader" in policy.allow
+        assert "bash" in policy.deny
+
+    def test_no_allowlist_mode(self):
+        """Mode 'allowlist' is NOT a valid mode (old docs were wrong)."""
+        from lionagi.agent.permissions import PermissionPolicy
+
+        policy = PermissionPolicy(mode="allowlist")
+        decision = policy.check("bash", "run", {"command": "ls"})
+        # 'allowlist' is not recognized; falls through to default deny
+        assert decision.behavior == "deny"
+
+    def test_no_confirm_mode(self):
+        """Mode 'confirm' is NOT a valid mode (old docs were wrong)."""
+        from lionagi.agent.permissions import PermissionPolicy
+
+        policy = PermissionPolicy(mode="confirm")
+        decision = policy.check("bash", "run", {"command": "ls"})
+        assert decision.behavior == "deny"
+
+    def test_constructor_uses_allow_deny_escalate_dicts(self):
+        """PermissionPolicy takes allow/deny/escalate as dict params, not 'tools'."""
+        from lionagi.agent.permissions import PermissionPolicy
+
+        sig = inspect.signature(PermissionPolicy)
+        param_names = set(sig.parameters.keys())
+        assert "allow" in param_names
+        assert "deny" in param_names
+        assert "escalate" in param_names
+        assert "tools" not in param_names
+
+    def test_check_returns_permission_decision(self):
+        from lionagi.agent.permissions import PermissionDecision, PermissionPolicy
+
+        policy = PermissionPolicy(mode="allow_all")
+        decision = policy.check("bash", "run", {"command": "ls"})
+        assert isinstance(decision, PermissionDecision)
+        assert decision.behavior == "allow"
+
+
+# =============================================================================
+# Hooks
+# =============================================================================
+
+
+class TestHookSignatures:
+    """Verify hook function signatures match documented API."""
+
+    def test_guard_destructive_is_async(self):
+        from lionagi.agent.hooks import guard_destructive
+
+        assert inspect.iscoroutinefunction(guard_destructive)
+
+    def test_guard_destructive_signature(self):
+        """guard_destructive(tool_name, action, args) — no factory."""
+        from lionagi.agent.hooks import guard_destructive
+
+        sig = inspect.signature(guard_destructive)
+        params = list(sig.parameters.keys())
+        assert params == ["tool_name", "action", "args"]
+
+    def test_guard_paths_is_factory(self):
+        """guard_paths is a factory returning a hook function."""
+        from lionagi.agent.hooks import guard_paths
+
+        assert not inspect.iscoroutinefunction(guard_paths)
+        hook = guard_paths(allowed_paths=["/tmp"])
+        assert inspect.iscoroutinefunction(hook)
+
+    def test_guard_paths_kwarg_is_allowed_paths(self):
+        """guard_paths takes allowed_paths=, not allowed=."""
+        from lionagi.agent.hooks import guard_paths
+
+        sig = inspect.signature(guard_paths)
+        param_names = set(sig.parameters.keys())
+        assert "allowed_paths" in param_names
+        assert "allowed" not in param_names
+
+    def test_log_tool_use_is_async(self):
+        from lionagi.agent.hooks import log_tool_use
+
+        assert inspect.iscoroutinefunction(log_tool_use)
+
+    def test_log_tool_use_no_sink_param(self):
+        """log_tool_use is a plain function, not a factory with a sink param."""
+        from lionagi.agent.hooks import log_tool_use
+
+        sig = inspect.signature(log_tool_use)
+        param_names = set(sig.parameters.keys())
+        assert "sink" not in param_names
+
+
+# =============================================================================
+# SandboxSession
+# =============================================================================
+
+
+class TestSandboxSessionAPI:
+    """Verify SandboxSession is a dataclass with module-level async helpers."""
+
+    def test_sandbox_session_is_dataclass(self):
+        from lionagi.tools.sandbox import SandboxSession
+
+        assert hasattr(SandboxSession, "__dataclass_fields__")
+
+    def test_sandbox_session_fields(self):
+        from lionagi.tools.sandbox import SandboxSession
+
+        field_names = {f.name for f in fields(SandboxSession)}
+        assert "worktree_path" in field_names
+        assert "branch_name" in field_names
+        assert "base_branch" in field_names
+        assert "repo_root" in field_names
+        assert "is_active" in field_names
+
+    def test_no_create_classmethod(self):
+        """SandboxSession does NOT have a .create() classmethod."""
+        from lionagi.tools.sandbox import SandboxSession
+
+        assert not hasattr(SandboxSession, "create")
+
+    def test_no_diff_method(self):
+        """SandboxSession does NOT have a .diff() instance method."""
+        from lionagi.tools.sandbox import SandboxSession
+
+        assert not hasattr(SandboxSession, "diff")
+
+    def test_no_commit_method(self):
+        """SandboxSession does NOT have a .commit() instance method."""
+        from lionagi.tools.sandbox import SandboxSession
+
+        assert not hasattr(SandboxSession, "commit")
+
+    def test_no_merge_method(self):
+        """SandboxSession does NOT have a .merge() instance method."""
+        from lionagi.tools.sandbox import SandboxSession
+
+        assert not hasattr(SandboxSession, "merge")
+
+    def test_no_discard_method(self):
+        """SandboxSession does NOT have a .discard() instance method."""
+        from lionagi.tools.sandbox import SandboxSession
+
+        assert not hasattr(SandboxSession, "discard")
+
+    def test_module_level_create_sandbox_exists(self):
+        from lionagi.tools.sandbox import create_sandbox
+
+        assert inspect.iscoroutinefunction(create_sandbox)
+
+    def test_module_level_sandbox_diff_exists(self):
+        from lionagi.tools.sandbox import sandbox_diff
+
+        assert inspect.iscoroutinefunction(sandbox_diff)
+
+    def test_module_level_sandbox_commit_exists(self):
+        from lionagi.tools.sandbox import sandbox_commit
+
+        assert inspect.iscoroutinefunction(sandbox_commit)
+
+    def test_module_level_sandbox_merge_exists(self):
+        from lionagi.tools.sandbox import sandbox_merge
+
+        assert inspect.iscoroutinefunction(sandbox_merge)
+
+    def test_module_level_sandbox_discard_exists(self):
+        from lionagi.tools.sandbox import sandbox_discard
+
+        assert inspect.iscoroutinefunction(sandbox_discard)
+
+    def test_create_sandbox_signature(self):
+        """create_sandbox takes repo_root, base_branch, name."""
+        from lionagi.tools.sandbox import create_sandbox
+
+        sig = inspect.signature(create_sandbox)
+        param_names = list(sig.parameters.keys())
+        assert "repo_root" in param_names
+        assert "base_branch" in param_names
+
+
+# =============================================================================
+# create_agent factory
+# =============================================================================
+
+
+class TestCreateAgentFactory:
+    """Verify create_agent exists and accepts AgentConfig."""
+
+    def test_create_agent_is_async(self):
+        from lionagi.agent.factory import create_agent
+
+        assert inspect.iscoroutinefunction(create_agent)
+
+    def test_create_agent_accepts_config_param(self):
+        from lionagi.agent.factory import create_agent
+
+        sig = inspect.signature(create_agent)
+        param_names = list(sig.parameters.keys())
+        assert "config" in param_names


### PR DESCRIPTION
## Summary
- Removed nonexistent `AgentConfig.research()` preset from docs
- Fixed `PermissionPolicy` modes: `allow_all`/`deny_all`/`rules` (not allowlist/confirm)
- Fixed `guard_paths` kwarg: `allowed_paths=` (not `allowed=`)
- Fixed `SandboxSession` API: module-level async functions, not classmethods
- 34 tests verifying all documented symbols match actual source

Closes #1312

## Test plan
- [x] `uv run pytest tests/docs/test_agent_sandbox_api.py -v` — 34 passed
- [x] `uv run ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)