### PR TITLE
chore: strip excessive docstrings from models/types/ln utilities

### DIFF
--- a/lionagi/libs/validate/to_num.py
+++ b/lionagi/libs/validate/to_num.py
@@ -4,15 +4,12 @@ import re
 from decimal import Decimal
 from typing import Any, Literal, TypeVar
 
-# Type definitions
 NUM_TYPE_LITERAL = Literal["int", "float", "complex"]
 NUM_TYPES = type[int] | type[float] | type[complex] | NUM_TYPE_LITERAL
 NumericType = TypeVar("NumericType", int, float, complex)
 
-# Type mapping
 TYPE_MAP = {"int": int, "float": float, "complex": complex}
 
-# Regex patterns for different numeric formats
 PATTERNS = {
     "scientific": r"[-+]?(?:\d*\.)?\d+[eE][-+]?\d+",
     "complex_sci": r"[-+]?(?:\d*\.)?\d+(?:[eE][-+]?\d+)?[-+](?:\d*\.)?\d+(?:[eE][-+]?\d+)?[jJ]",
@@ -35,32 +32,13 @@ def to_num(
     precision: int | None = None,
     num_count: int = 1,
 ) -> int | float | complex | list[int | float | complex]:
-    """Convert input to numeric type(s) with validation and bounds checking.
-
-    Args:
-        input_value: The input to convert to number(s).
-        upper_bound: Maximum allowed value (inclusive).
-        lower_bound: Minimum allowed value (inclusive).
-        num_type: Target numeric type ('int', 'float', 'complex' or type objects).
-        precision: Number of decimal places for rounding (float only).
-        num_count: Number of numeric values to extract.
-
-    Returns:
-        Converted number(s). Single value if num_count=1, else list.
-
-    Raises:
-        ValueError: For invalid input or out of bounds values.
-        TypeError: For invalid input types or invalid type conversions.
-    """
-    # Validate input
+    """Convert input to numeric type(s) with validation and bounds checking."""
     if isinstance(input_, list | tuple):
         raise TypeError("Input cannot be a sequence")
 
-    # Handle boolean input
     if isinstance(input_, bool):
         return validate_num_type(num_type)(input_)
 
-    # Handle direct numeric input
     if isinstance(input_, int | float | complex | Decimal):
         inferred_type = type(input_)
         if isinstance(input_, Decimal):
@@ -70,14 +48,12 @@ def to_num(
         value = apply_precision(value, precision)
         return convert_type(value, validate_num_type(num_type), inferred_type)
 
-    # Convert input to string and extract numbers
     input_str = str(input_)
     number_matches = extract_numbers(input_str)
 
     if not number_matches:
         raise ValueError(f"No valid numbers found in: {input_str}")
 
-    # Process numbers
     results = []
     target_type = validate_num_type(num_type)
 
@@ -87,19 +63,10 @@ def to_num(
 
     for type_and_value in number_matches:
         try:
-            # Infer appropriate type
             inferred_type = infer_type(type_and_value)
-
-            # Parse to numeric value
             value = parse_number(type_and_value)
-
-            # Apply bounds if not complex
             value = apply_bounds(value, upper_bound, lower_bound)
-
-            # Apply precision
             value = apply_precision(value, precision)
-
-            # Convert to target type if different from inferred
             value = convert_type(value, target_type, inferred_type)
 
             results.append(value)
@@ -115,21 +82,12 @@ def to_num(
 
 
 def extract_numbers(text: str) -> list[tuple[str, str]]:
-    """Extract numeric values from text using ordered regex patterns.
-
-    Args:
-        text: The text to extract numbers from.
-
-    Returns:
-        List of tuples containing (pattern_type, matched_value).
-    """
     combined_pattern = "|".join(PATTERNS.values())
     matches = re.finditer(combined_pattern, text, re.IGNORECASE)
     numbers = []
 
     for match in matches:
         value = match.group()
-        # Check which pattern matched
         for pattern_name, pattern in PATTERNS.items():
             if re.fullmatch(pattern, value, re.IGNORECASE):
                 numbers.append((pattern_name, value))
@@ -139,17 +97,6 @@ def extract_numbers(text: str) -> list[tuple[str, str]]:
 
 
 def validate_num_type(num_type: NUM_TYPES) -> type:
-    """Validate and normalize numeric type specification.
-
-    Args:
-        num_type: The numeric type to validate.
-
-    Returns:
-        The normalized Python type object.
-
-    Raises:
-        ValueError: If the type specification is invalid.
-    """
     if isinstance(num_type, str):
         if num_type not in TYPE_MAP:
             raise ValueError(f"Invalid number type: {num_type}")
@@ -161,14 +108,6 @@ def validate_num_type(num_type: NUM_TYPES) -> type:
 
 
 def infer_type(value: tuple[str, str]) -> type:
-    """Infer appropriate numeric type from value.
-
-    Args:
-        value: Tuple of (pattern_type, matched_value).
-
-    Returns:
-        The inferred Python type.
-    """
     pattern_type, _ = value
     if pattern_type in ("complex", "complex_sci", "pure_imaginary"):
         return complex
@@ -176,14 +115,6 @@ def infer_type(value: tuple[str, str]) -> type:
 
 
 def convert_special(value: str) -> float:
-    """Convert special float values (inf, -inf, nan).
-
-    Args:
-        value: The string value to convert.
-
-    Returns:
-        The converted float value.
-    """
     value = value.lower()
     if "infinity" in value or "inf" in value:
         return float("-inf") if value.startswith("-") else float("inf")
@@ -191,17 +122,6 @@ def convert_special(value: str) -> float:
 
 
 def convert_percentage(value: str) -> float:
-    """Convert percentage string to float.
-
-    Args:
-        value: The percentage string to convert.
-
-    Returns:
-        The converted float value.
-
-    Raises:
-        ValueError: If the percentage value is invalid.
-    """
     try:
         return float(value.rstrip("%")) / 100
     except ValueError as e:
@@ -209,19 +129,7 @@ def convert_percentage(value: str) -> float:
 
 
 def convert_complex(value: str) -> complex:
-    """Convert complex number string to complex.
-
-    Args:
-        value: The complex number string to convert.
-
-    Returns:
-        The converted complex value.
-
-    Raises:
-        ValueError: If the complex number is invalid.
-    """
     try:
-        # Handle pure imaginary numbers
         if value.endswith("j") or value.endswith("J"):
             if value in ("j", "J"):
                 return complex(0, 1)
@@ -230,7 +138,6 @@ def convert_complex(value: str) -> complex:
             if value in ("-j", "-J"):
                 return complex(0, -1)
             if "+" not in value and "-" not in value[1:]:
-                # Pure imaginary number
                 imag = float(value[:-1] or "1")
                 return complex(0, imag)
 
@@ -244,25 +151,10 @@ def convert_type(
     target_type: type,
     inferred_type: type,
 ) -> int | float | complex:
-    """Convert value to target type if specified, otherwise use inferred type.
-
-    Args:
-        value: The value to convert.
-        target_type: The requested target type.
-        inferred_type: The inferred type from the value.
-
-    Returns:
-        The converted value.
-
-    Raises:
-        TypeError: If the conversion is not possible.
-    """
     try:
-        # If no specific type requested, use inferred type
         if target_type is float and inferred_type is complex:
             return value
 
-        # Handle explicit type conversions
         if target_type is int and isinstance(value, complex):
             raise TypeError("Cannot convert complex number to int")
         return target_type(value)
@@ -275,19 +167,6 @@ def apply_bounds(
     upper_bound: float | None = None,
     lower_bound: float | None = None,
 ) -> float | complex:
-    """Apply bounds checking to numeric value.
-
-    Args:
-        value: The value to check.
-        upper_bound: Maximum allowed value (inclusive).
-        lower_bound: Minimum allowed value (inclusive).
-
-    Returns:
-        The validated value.
-
-    Raises:
-        ValueError: If the value is outside bounds.
-    """
     if isinstance(value, complex):
         return value
 
@@ -302,15 +181,6 @@ def apply_precision(
     value: float | complex,
     precision: int | None,
 ) -> float | complex:
-    """Apply precision rounding to numeric value.
-
-    Args:
-        value: The value to round.
-        precision: Number of decimal places.
-
-    Returns:
-        The rounded value.
-    """
     if precision is None or isinstance(value, complex):
         return value
     if isinstance(value, float):
@@ -319,17 +189,6 @@ def apply_precision(
 
 
 def parse_number(type_and_value: tuple[str, str]) -> float | complex:
-    """Parse string to numeric value based on pattern type.
-
-    Args:
-        type_and_value: Tuple of (pattern_type, matched_value).
-
-    Returns:
-        The parsed numeric value.
-
-    Raises:
-        ValueError: If parsing fails.
-    """
     num_type, value = type_and_value
     value = value.strip()
 
@@ -368,5 +227,4 @@ def parse_number(type_and_value: tuple[str, str]) -> float | complex:
 
         raise ValueError(f"Unknown number type: {num_type}")
     except Exception as e:
-        # Preserve the specific error type but wrap with more context
         raise type(e)(f"Failed to parse {value} as {num_type}: {str(e)}") from e

--- a/lionagi/ln/_ssrf.py
+++ b/lionagi/ln/_ssrf.py
@@ -1,48 +1,13 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""SSRF (Server-Side Request Forgery) guard for outbound HTTP requests.
+"""SSRF guard for outbound HTTP requests (CWE-918).
 
-All outbound HTTP requests that accept caller-controlled hostnames MUST
-call :func:`is_ssrf_safe` before issuing the request.
-
-Local-address allowlist
------------------------
-Providers that are documented to run on the local machine (e.g. Ollama at
-``http://localhost:11434``) may set ``allow_local=True`` when calling
-:func:`is_ssrf_safe`.  When ``allow_local=True``:
-
-* The raw hostname (before DNS resolution) MUST exactly match one of the
-  canonical loopback literals: ``localhost``, ``127.0.0.1``, ``::1``.
-  Any other hostname string is rejected immediately, regardless of what it
-  resolves to.  This eliminates DNS-rebinding attacks.
-
-* Alternate numeric encodings of the loopback address (decimal integer
-  ``2130706433``, octal ``017700000001``, hex ``0x7f000001``, short form
-  ``127.1``, zero-padded ``127.000.000.001``) are NOT in the canonical set
-  and are therefore rejected.
-
-* IPv4-mapped/compatible IPv6 loopback forms (``::ffff:127.0.0.1``,
-  ``::127.0.0.1``) are NOT in the canonical set and are rejected.
-
-* After DNS resolution, every resolved address is checked to confirm it is
-  truly a loopback address.  Non-loopback results (including public IPs) are
-  rejected — a local-mode endpoint pointing at a public IP is not a valid
-  local endpoint.
-
-* All other blocked ranges — link-local, metadata endpoints such as
-  ``169.254.169.254`` (AWS/GCP IMDS), private RFC 1918, CGN, IPv6 private
-  — remain blocked regardless of this flag.
-
-DNS re-resolution note
-----------------------
-By gating on the raw hostname string before resolution, this module
-eliminates the DNS-rebinding window that existed when the loopback check
-was performed only on the resolved address.  The canonical allowlist is
-the primary gate; the post-resolution loopback check provides defense in
-depth.
-
-CWE reference: CWE-918.
+All outbound requests with caller-controlled hostnames MUST call
+``is_ssrf_safe()`` first. When ``allow_local=True``, only canonical
+loopback literals (localhost, 127.0.0.1, ::1) are accepted -- alternate
+encodings and DNS-rebinding are blocked by gating on the raw hostname
+string before resolution.
 """
 
 from __future__ import annotations
@@ -50,19 +15,6 @@ from __future__ import annotations
 import ipaddress
 import socket
 
-# Blocked networks — covers:
-#   10/8        private (RFC 1918)
-#   172.16/12   private (RFC 1918)
-#   192.168/16  private (RFC 1918)
-#   169.254/16  link-local / AWS IMDS / GCP metadata
-#   127/8       loopback
-#   0.0.0.0/8   bind-all (IANA reserved; "this network")
-#   100.64/10   Carrier-grade NAT (RFC 6598) — reachable in cloud envs
-#   ::1/128     IPv6 loopback
-#   fc00::/7    IPv6 unique local (fc00:: and fd00:: ranges)
-#   ::ffff:0:0/96  IPv4-mapped IPv6 catch-all (belt-and-suspenders)
-#   fe80::/10   IPv6 link-local (SLAAC; scoped service exposure via %iface)
-#   ff00::/8    IPv6 multicast (defense-in-depth; no legitimate server targets)
 _BLOCKED_NETS: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = [
     ipaddress.ip_network(cidr)
     for cidr in [
@@ -81,51 +33,29 @@ _BLOCKED_NETS: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = [
     ]
 ]
 
-# Networks that are loopback — used for post-resolution defense-in-depth when
-# allow_local=True to ensure a canonical hostname actually resolved to loopback.
 _LOOPBACK_NETS: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = [
     ipaddress.ip_network("127.0.0.0/8"),
     ipaddress.ip_network("::1/128"),
 ]
 
-# Canonical loopback hostname literals accepted by allow_local=True.
-# The loopback exemption is granted on the RAW PARSED HOSTNAME STRING before
-# DNS resolution.  Only these exact strings are accepted:
-#
-#   "localhost"   — the standard loopback name
-#   "127.0.0.1"   — canonical IPv4 loopback decimal literal
-#   "::1"         — canonical IPv6 loopback (urlparse strips brackets, so
-#                   "[::1]" in a URL becomes "::1" at the hostname level)
-#
-# Alternate encodings of 127.0.0.1 (decimal integer 2130706433, octal
-# 017700000001, hex 0x7f000001, short form 127.1, zero-padded
-# 127.000.000.001) are NOT included.  IPv4-mapped / IPv4-compatible IPv6
-# loopback forms (::ffff:127.0.0.1, ::127.0.0.1) are NOT included.  Any
-# hostname that does not appear in this set is rejected immediately when
-# allow_local=True, regardless of what it resolves to.
+# Only these exact hostname strings are accepted for allow_local=True.
+# Alternate encodings (2130706433, 0x7f000001, 127.1, ::ffff:127.0.0.1, etc.)
+# are intentionally excluded to prevent DNS-rebinding bypass.
 _CANONICAL_LOCAL_HOSTS: frozenset[str] = frozenset({"localhost", "127.0.0.1", "::1"})
 
 
 def _unmap_ip(
     ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
 ) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
-    """Unmap IPv4-mapped and IPv4-compatible IPv6 to their IPv4 form.
-
-    IPv4-mapped (::ffff:a.b.c.d) and IPv4-compatible (::a.b.c.d) IPv6
-    addresses are converted to their IPv4 equivalents so they correctly
-    match IPv4 blocked networks.  Pure IPv6 addresses are returned unchanged.
-    """
+    """Unmap IPv4-mapped/compatible IPv6 to IPv4 for blocked-net matching."""
     if not isinstance(ip, ipaddress.IPv6Address):
         return ip
 
-    # IPv4-mapped: ::ffff:a.b.c.d — Python exposes this directly.
     if ip.ipv4_mapped is not None:
         return ip.ipv4_mapped
 
-    # IPv4-compatible: ::a.b.c.d — deprecated form where the IPv4 address is
-    # embedded directly without the 0xffff marker.  Python's ipv4_mapped
-    # returns None for this form.  RFC 4291 §2.5.5.1: packed representation
-    # is 10 zero bytes + 2 zero bytes + 4 IPv4 bytes.
+    # IPv4-compatible (::a.b.c.d, RFC 4291 section 2.5.5.1): 12 zero bytes + 4 IPv4 bytes.
+    # Python's ipv4_mapped returns None for this form.
     b = ip.packed
     if b[:12] == b"\x00" * 12:
         return ipaddress.IPv4Address(b[12:])
@@ -134,73 +64,20 @@ def _unmap_ip(
 
 
 def is_ssrf_safe(hostname: str, *, allow_local: bool = False) -> bool:
-    """Return True if *hostname* is safe for an outbound HTTP request.
+    """Return True if *hostname* is safe for outbound HTTP.
 
-    When ``allow_local=False`` (the default): resolves the hostname via
-    ``socket.getaddrinfo`` and rejects any result that maps to a
-    private/reserved IP range.  Unresolvable hostnames are rejected
-    (fail-closed).
-
-    When ``allow_local=True``: the hostname MUST exactly match one of the
-    canonical loopback literals (``localhost``, ``127.0.0.1``, ``::1``).
-    Any other hostname — including alternate numeric encodings or external
-    hostnames that happen to resolve to loopback — is rejected immediately.
-    After DNS resolution, every address is verified to be a true loopback
-    address; non-loopback results (including public IPs) are rejected.
-
-    Both IPv4-mapped (``::ffff:a.b.c.d``) and IPv4-compatible (``::a.b.c.d``)
-    IPv6 addresses are unmapped to their IPv4 form before checking.
-
-    Args:
-        hostname: Hostname to validate.  Do NOT pass a full URL; extract the
-            host with ``urllib.parse.urlparse(url).hostname`` first.
-        allow_local: When True, permit the endpoint to use canonical loopback
-            addresses only.  Use this only for providers documented to run
-            locally (e.g. Ollama).  All other blocked ranges — including
-            link-local and metadata endpoints such as ``169.254.169.254`` —
-            remain blocked regardless of this flag.
-
-    Returns:
-        True  — hostname is in the canonical loopback set (if allow_local)
-                and all resolved IPs are in permitted ranges.
-        False — hostname fails the canonical check, at least one resolved IP
-                is in a blocked range, or resolution failed.
-
-    Examples::
-
-        >>> is_ssrf_safe("api.openai.com")
-        True
-        >>> is_ssrf_safe("169.254.169.254")
-        False
-        >>> is_ssrf_safe("localhost")
-        False
-        >>> is_ssrf_safe("localhost", allow_local=True)
-        True
-        >>> is_ssrf_safe("127.0.0.1", allow_local=True)
-        True
-        >>> is_ssrf_safe("::1", allow_local=True)
-        True
-        >>> is_ssrf_safe("169.254.169.254", allow_local=True)
-        False
-        >>> is_ssrf_safe("::ffff:169.254.169.254")
-        False
-        >>> is_ssrf_safe("::169.254.169.254")
-        False
+    Pass the hostname only (not a full URL). Resolves via getaddrinfo and
+    rejects private/reserved ranges. With allow_local=True, only canonical
+    loopback literals are accepted.
     """
     if not hostname:
         return False
 
     if allow_local:
-        # Gate on the raw hostname string BEFORE DNS resolution.
-        # Only the exact canonical loopback literals are accepted.
-        # This eliminates DNS rebinding (an external hostname resolving to
-        # 127.0.0.1 does NOT pass) and alternate encodings (2130706433,
-        # 0x7f000001, 017700000001, 127.1, ::ffff:127.0.0.1, etc.).
+        # Gate on raw hostname BEFORE DNS resolution to block rebinding
         if hostname not in _CANONICAL_LOCAL_HOSTS:
             return False
 
-        # Canonical hostname accepted — resolve and verify every address is
-        # loopback (defense in depth).
         try:
             results = socket.getaddrinfo(hostname, None, family=0, type=socket.SOCK_STREAM)
         except OSError:
@@ -216,14 +93,10 @@ def is_ssrf_safe(hostname: str, *, allow_local: bool = False) -> bool:
             except ValueError:
                 return False
 
-            # Retain the original address for the loopback check (::1 unmaps
-            # to 0.0.0.1 via the IPv4-compat path, which would not match
-            # ::1/128; we must test the original against ::1/128).
+            # Keep original for ::1 which unmaps to 0.0.0.1 via IPv4-compat
             original_ip = ip
             ip = _unmap_ip(ip)
 
-            # Every resolved address must be loopback.  A canonical loopback
-            # name resolving to a public IP is not a valid local endpoint.
             if not (
                 any(ip in lb for lb in _LOOPBACK_NETS)
                 or any(original_ip in lb for lb in _LOOPBACK_NETS)
@@ -232,11 +105,9 @@ def is_ssrf_safe(hostname: str, *, allow_local: bool = False) -> bool:
 
         return True
 
-    # allow_local=False path: standard SSRF check — any blocked range fails.
     try:
         results = socket.getaddrinfo(hostname, None, family=0, type=socket.SOCK_STREAM)
     except OSError:
-        # DNS failure, invalid hostname, etc. → fail closed
         return False
 
     if not results:
@@ -247,17 +118,8 @@ def is_ssrf_safe(hostname: str, *, allow_local: bool = False) -> bool:
         try:
             ip = ipaddress.ip_address(raw_ip)
         except ValueError:
-            # Unrecognised format — fail closed
             return False
 
-        # Unmap IPv4-mapped and IPv4-compatible IPv6 addresses to their IPv4
-        # equivalents so they correctly match IPv4 blocked networks.
-        # We check the unmapped form for all networks.  The ::ffff:0:0/96
-        # network in _BLOCKED_NETS acts as belt-and-suspenders for any
-        # IPv6-mapped address that survives unmapping (e.g. if future variants
-        # are not covered by _unmap_ip), but for a cleanly unmapped IPv4
-        # address we only check the unmapped form to avoid false positives
-        # (e.g. ::ffff:8.8.8.8 unmaps to 8.8.8.8 which is public and safe).
         ip = _unmap_ip(ip)
 
         if any(ip in net for net in _BLOCKED_NETS):

--- a/lionagi/ln/_utils.py
+++ b/lionagi/ln/_utils.py
@@ -47,44 +47,18 @@ async def acreate_path(
     random_hash_digits: int = 0,
     timeout: float | None = None,
 ) -> AsyncPath:
-    """Generate file path asynchronously with optional timeout.
-
-    Args:
-        directory: Base directory path.
-        filename: Target filename (may contain subdirectory with /).
-        extension: File extension (if filename doesn't have one).
-        timestamp: Add timestamp to filename.
-        dir_exist_ok: Allow existing directories.
-        file_exist_ok: Allow existing files.
-        time_prefix: Put timestamp before filename instead of after.
-        timestamp_format: Custom strftime format for timestamp.
-        random_hash_digits: Add random hash suffix (0 = disabled).
-        timeout: Maximum time in seconds for async I/O operations
-            (None = no timeout).
-
-    Returns:
-        AsyncPath to the created/validated file path.
-
-    Raises:
-        ValueError: If filename contains backslash.
-        FileExistsError: If file exists and file_exist_ok is False.
-        TimeoutError: If timeout is exceeded.
-    """
     from .concurrency import move_on_after
 
     async def _impl() -> AsyncPath:
         nonlocal directory, filename
 
-        # Capture the ORIGINAL base root (symlinks resolved) BEFORE `filename`
-        # can redirect `directory` into a subdirectory. All containment checks
-        # validate against this fixed root, so a symlinked subdirectory pointing
-        # outside the base cannot be used to escape.
+        # Resolve BEFORE filename can redirect directory into a subdirectory;
+        # all containment checks validate against this fixed root.
         base_root = StdPath(str(directory)).resolve()
 
         if "/" in filename:
             parts = filename.split("/")
-            # Fail-closed: reject any path component that is '.' or '..' to
-            # prevent directory traversal before any filesystem side effect.
+            # Reject '.' or '..' to prevent directory traversal
             for component in parts:
                 if component in (".", ".."):
                     raise ValueError(
@@ -103,12 +77,7 @@ async def acreate_path(
         if filename in (".", ".."):
             raise ValueError(f"Filename must not be '.' or '..'; got {filename!r}.")
 
-        # Verify the (possibly redirected) directory AND the final candidate
-        # both resolve to a location within the original base root. Both are
-        # fully resolve()-d so symlinks are followed — a symlinked subdir OR a
-        # symlinked final component (e.g. base/link.txt -> /outside) escaping
-        # the root is rejected before any filesystem side effect. resolve() on a
-        # not-yet-existing final component simply normalizes it under the dir.
+        # Both dir and candidate must resolve within base_root (symlink-safe)
         dir_resolved = StdPath(str(directory)).resolve()
         candidate_resolved = (dir_resolved / filename).resolve()
         for escapee in (dir_resolved, candidate_resolved):
@@ -156,15 +125,7 @@ async def acreate_path(
 
 
 def get_bins(input_: list[str], upper: int) -> list[list[int]]:
-    """Organizes indices of strings into bins based on a cumulative upper limit.
-
-    Args:
-        input_ (List[str]): The list of strings to be binned.
-        upper (int): The cumulative length upper limit for each bin.
-
-    Returns:
-        List[List[int]]: A list of bins, each bin is a list of indices from the input list.
-    """
+    """Bin string indices by cumulative length limit."""
     current = 0
     bins = []
     current_bin = []
@@ -186,18 +147,6 @@ def import_module(
     module_name: str = None,
     import_name: str | list = None,
 ) -> Any:
-    """
-    Import a module by its path.
-
-    Args:
-        module_path: The path of the module to import.
-
-    Returns:
-        The imported module.
-
-    Raises:
-        ImportError: If the module cannot be imported.
-    """
     try:
         full_import_path = f"{package_name}.{module_name}" if module_name else package_name
 
@@ -218,15 +167,6 @@ def import_module(
 
 
 def is_import_installed(package_name: str) -> bool:
-    """
-    Check if a package is installed.
-
-    Args:
-        package_name: The name of the package to check.
-
-    Returns:
-        bool: True if the package is installed, False otherwise.
-    """
     return importlib.util.find_spec(package_name) is not None
 
 
@@ -241,36 +181,14 @@ _ALLOWED_MODULE_PREFIXES: set[str] = set(_DEFAULT_ALLOWED_PREFIXES)
 
 
 def register_type_prefix(prefix: str) -> None:
-    """Register module prefix for dynamic type loading allowlist.
-
-    Security: Only register prefixes for modules you control.
-
-    Args:
-        prefix: Module prefix to allow (e.g., "myapp.models.").
-            Must end with "." to prevent prefix attacks.
-
-    Raises:
-        ValueError: If prefix doesn't end with ".".
-    """
+    """Register module prefix for dynamic type loading allowlist."""
     if not prefix.endswith("."):
         raise ValueError(f"Prefix must end with '.': {prefix}")
     _ALLOWED_MODULE_PREFIXES.add(prefix)
 
 
 def load_type_from_string(type_str: str) -> type:
-    """Load type from fully qualified path (e.g., 'lionagi.core.Node').
-
-    Security: Only allowlisted module prefixes can be loaded.
-
-    Args:
-        type_str: Fully qualified type path.
-
-    Returns:
-        The loaded type class.
-
-    Raises:
-        ValueError: If path invalid, not allowlisted, or type not found.
-    """
+    """Load type from fully qualified path; only allowlisted prefixes."""
     if type_str in _TYPE_CACHE:
         return _TYPE_CACHE[type_str]
 
@@ -308,17 +226,7 @@ def load_type_from_string(type_str: str) -> type:
 
 
 def extract_types(item_type: Any) -> set[type]:
-    """Extract concrete types from type annotations.
-
-    Handles Union, list, set, and single types recursively.
-
-    Args:
-        item_type: Type annotation (Union[X, Y], list[type],
-            set[type], or type).
-
-    Returns:
-        Set of concrete types extracted from the annotation.
-    """
+    """Extract concrete types from type annotations (Union, list, set)."""
 
     def is_union(t: Any) -> bool:
         origin = get_origin(t)
@@ -354,17 +262,6 @@ def extract_types(item_type: Any) -> set[type]:
 
 
 def to_uuid(value: Any) -> UUID:
-    """Convert value to UUID instance.
-
-    Args:
-        value: UUID, UUID string, or object with ``.id`` attribute.
-
-    Returns:
-        UUID instance.
-
-    Raises:
-        ValueError: If value cannot be converted to UUID.
-    """
     if isinstance(value, UUID):
         return value
     if isinstance(value, str):
@@ -379,19 +276,7 @@ def to_uuid(value: Any) -> UUID:
 
 
 def coerce_created_at(v: Any) -> datetime:
-    """Coerce value to UTC-aware datetime.
-
-    Supports datetime, Unix timestamp (int/float), or ISO string.
-
-    Args:
-        v: datetime, Unix timestamp (int/float), or ISO string.
-
-    Returns:
-        UTC-aware datetime instance.
-
-    Raises:
-        ValueError: If value cannot be parsed as datetime.
-    """
+    """Coerce value to UTC-aware datetime (datetime, timestamp, or ISO string)."""
     if isinstance(v, datetime):
         return v.replace(tzinfo=timezone.utc) if v.tzinfo is None else v
 
@@ -414,11 +299,7 @@ def coerce_created_at(v: Any) -> datetime:
 
 
 def synchronized(func: Callable[P, R]) -> Callable[P, R]:
-    """Decorator for thread-safe method execution.
-
-    Requires decorated method's instance to have ``self._lock``
-    (``threading.Lock``).
-    """
+    """Thread-safe method decorator; requires ``self._lock``."""
 
     @wraps(func)
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
@@ -432,11 +313,7 @@ def synchronized(func: Callable[P, R]) -> Callable[P, R]:
 def async_synchronized(
     func: Callable[P, Awaitable[R]],
 ) -> Callable[P, Awaitable[R]]:
-    """Decorator for async-safe method execution.
-
-    Requires decorated method's instance to have ``self._async_lock``
-    (``anyio.Lock``).
-    """
+    """Async-safe method decorator; requires ``self._async_lock``."""
 
     @wraps(func)
     async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:

--- a/lionagi/ln/concurrency/primitives.py
+++ b/lionagi/ln/concurrency/primitives.py
@@ -25,11 +25,7 @@ __all__ = (
 
 
 class Lock:
-    """Async mutex lock (anyio.Lock wrapper).
-
-    Provides mutual exclusion for async code. Use with async context manager
-    for automatic acquisition/release.
-    """
+    """Async mutex lock (anyio.Lock wrapper)."""
 
     __slots__ = ("_lock",)
 
@@ -37,11 +33,9 @@ class Lock:
         self._lock = anyio.Lock()
 
     async def acquire(self) -> None:
-        """Acquire the lock, blocking if necessary."""
         await self._lock.acquire()
 
     def release(self) -> None:
-        """Release the lock."""
         self._lock.release()
 
     async def __aenter__(self) -> Lock:
@@ -53,11 +47,7 @@ class Lock:
 
 
 class Semaphore:
-    """Async semaphore (anyio.Semaphore wrapper).
-
-    Limits concurrent access to a resource. Initialized with a count,
-    decremented on acquire, incremented on release.
-    """
+    """Async semaphore (anyio.Semaphore wrapper)."""
 
     __slots__ = ("_sem",)
 
@@ -67,11 +57,9 @@ class Semaphore:
         self._sem = anyio.Semaphore(initial_value)
 
     async def acquire(self) -> None:
-        """Acquire a semaphore slot, blocking if none available."""
         await self._sem.acquire()
 
     def release(self) -> None:
-        """Release a semaphore slot."""
         self._sem.release()
 
     async def __aenter__(self) -> Semaphore:
@@ -83,87 +71,49 @@ class Semaphore:
 
 
 class CapacityLimiter:
-    """Capacity limiter for controlling resource usage (anyio.CapacityLimiter wrapper).
-
-    Controls concurrent access to limited resources like threads or connections.
-    Key advantages over Semaphore:
-    - Supports fractional tokens for fine-grained control
-    - Allows dynamic capacity adjustment at runtime
-    - Provides delegation methods for resource pooling
-    """
+    """Async capacity limiter (anyio.CapacityLimiter wrapper)."""
 
     __slots__ = ("_lim",)
 
     def __init__(self, total_tokens: float) -> None:
-        """Initialize with given capacity.
-
-        Args:
-            total_tokens: Maximum capacity (must be > 0).
-                         Can be fractional for fine-grained control.
-        """
         if total_tokens <= 0:
             raise ValueError("total_tokens must be > 0")
         self._lim = anyio.CapacityLimiter(total_tokens)
 
     async def acquire(self) -> None:
-        """Acquire capacity, blocking if none available."""
         await self._lim.acquire()
 
     def release(self) -> None:
-        """Release capacity."""
         self._lim.release()
 
     @property
     def remaining_tokens(self) -> float:
-        """Current available capacity (deprecated, use available_tokens)."""
         return self._lim.available_tokens
 
     @property
     def total_tokens(self) -> float:
-        """Get the current capacity limit."""
         return self._lim.total_tokens
 
     @total_tokens.setter
     def total_tokens(self, value: float) -> None:
-        """Dynamically adjust the capacity limit.
-
-        Args:
-            value: New capacity (must be > 0).
-                  Can be adjusted at runtime to adapt to load.
-        """
         if value <= 0:
             raise ValueError("total_tokens must be > 0")
         self._lim.total_tokens = value
 
     @property
     def borrowed_tokens(self) -> float:
-        """Get the number of currently borrowed tokens."""
         return self._lim.borrowed_tokens
 
     @property
     def available_tokens(self) -> float:
-        """Get the number of currently available tokens."""
         return self._lim.available_tokens
 
     async def acquire_on_behalf_of(self, borrower: object) -> None:
-        """Asynchronously acquire capacity on behalf of another object.
-
-        For resource pooling where the acquirer differs from the releaser.
-
-        Args:
-            borrower: Object that will be responsible for releasing.
-        """
         await self._lim.acquire_on_behalf_of(borrower)
 
     def release_on_behalf_of(self, borrower: object) -> None:
-        """Release capacity that was acquired on behalf of an object.
-
-        Args:
-            borrower: Object that previously acquired the capacity.
-        """
         self._lim.release_on_behalf_of(borrower)
 
-    # Support idiomatic AnyIO usage: `async with limiter: ...`
     async def __aenter__(self) -> CapacityLimiter:
         await self.acquire()
         return self
@@ -174,59 +124,29 @@ class CapacityLimiter:
 
 @dataclass(slots=True)
 class Queue(Generic[T]):
-    """Async queue using anyio memory object streams.
-
-    Provides FIFO queue semantics with optional maxsize for backpressure.
-    Must call close() or use async context manager for proper cleanup.
-
-    Usage:
-        queue = Queue.with_maxsize(100)
-        await queue.put(item)
-        item = await queue.get()
-        await queue.close()
-    """
+    """Async FIFO queue backed by anyio memory object streams."""
 
     _send: anyio.abc.ObjectSendStream[T]
     _recv: anyio.abc.ObjectReceiveStream[T]
 
     @classmethod
     def with_maxsize(cls, maxsize: int) -> Queue[T]:
-        """Create queue with maximum buffer size."""
         send, recv = anyio.create_memory_object_stream(maxsize)
         return cls(send, recv)
 
     async def put(self, item: T) -> None:
-        """Put item into queue. May block if queue is full."""
         await self._send.send(item)
 
     def put_nowait(self, item: T) -> None:
-        """Put item into queue without blocking.
-
-        Args:
-            item: Item to put in the queue.
-
-        Raises:
-            anyio.WouldBlock: If the queue is full.
-        """
         self._send.send_nowait(item)
 
     async def get(self) -> T:
-        """Get item from queue. Blocks until item available."""
         return await self._recv.receive()
 
     def get_nowait(self) -> T:
-        """Get item from queue without blocking.
-
-        Returns:
-            Next item from the queue.
-
-        Raises:
-            anyio.WouldBlock: If the queue is empty.
-        """
         return self._recv.receive_nowait()
 
     async def close(self) -> None:
-        """Close both send and receive streams. Call this for cleanup."""
         await self._send.aclose()
         await self._recv.aclose()
 
@@ -238,22 +158,15 @@ class Queue(Generic[T]):
 
     @property
     def sender(self) -> anyio.abc.ObjectSendStream[T]:
-        """Direct access to send stream for advanced usage."""
         return self._send
 
     @property
     def receiver(self) -> anyio.abc.ObjectReceiveStream[T]:
-        """Direct access to receive stream for advanced usage."""
         return self._recv
 
 
 class Event:
-    """Async event for signaling between tasks (anyio.Event wrapper).
-
-    An event object manages an internal flag that can be set to true
-    with set() and reset to false with clear(). The wait() method blocks
-    until the flag is true.
-    """
+    """Async event for signaling between tasks (anyio.Event wrapper)."""
 
     __slots__ = ("_event",)
 
@@ -261,46 +174,31 @@ class Event:
         self._event = anyio.Event()
 
     def set(self) -> None:
-        """Set the internal flag to true, waking up all waiting tasks."""
         self._event.set()
 
     def is_set(self) -> bool:
-        """Return True if the internal flag is set."""
         return self._event.is_set()
 
     async def wait(self) -> None:
-        """Block until the internal flag becomes true."""
         await self._event.wait()
 
     def statistics(self) -> anyio.EventStatistics:
-        """Return statistics about waiting tasks."""
         return self._event.statistics()
 
 
 class Condition:
-    """Async condition variable (anyio.Condition wrapper).
-
-    A condition variable allows one or more coroutines to wait until
-    they are notified by another coroutine. Must be used with a Lock.
-    """
+    """Async condition variable (anyio.Condition wrapper)."""
 
     __slots__ = ("_condition",)
 
     def __init__(self, lock: Lock | None = None) -> None:
-        """Initialize with an optional lock.
-
-        Args:
-            lock: Lock to use. If None, creates a new Lock.
-        """
         _lock = lock._lock if lock else None
         self._condition = anyio.Condition(_lock)
 
     async def acquire(self) -> None:
-        """Acquire the underlying lock."""
         await self._condition.acquire()
 
     def release(self) -> None:
-        """Release the underlying lock."""
         self._condition.release()
 
     async def __aenter__(self) -> Condition:
@@ -311,24 +209,13 @@ class Condition:
         self.release()
 
     async def wait(self) -> None:
-        """Wait until notified.
-
-        Releases the lock, blocks until notified, then re-acquires the lock.
-        """
         await self._condition.wait()
 
     def notify(self, n: int = 1) -> None:
-        """Wake up at most n tasks waiting on this condition.
-
-        Args:
-            n: Maximum number of tasks to wake (default: 1)
-        """
         self._condition.notify(n)
 
     def notify_all(self) -> None:
-        """Wake up all tasks waiting on this condition."""
         self._condition.notify_all()
 
     def statistics(self) -> anyio.ConditionStatistics:
-        """Return statistics about waiting tasks."""
         return self._condition.statistics()

--- a/lionagi/ln/concurrency/utils.py
+++ b/lionagi/ln/concurrency/utils.py
@@ -28,110 +28,34 @@ __all__ = (
 
 @cache
 def _is_coro_func_cached(func: Callable[..., Any]) -> bool:
-    """Cached coroutine check. Internal: expects already-unwrapped func."""
     return inspect.iscoroutinefunction(func)
 
 
 def is_coro_func(func: Callable[..., Any]) -> bool:
-    """Check if a function is a coroutine function, with caching for performance."""
     while isinstance(func, partial):
         func = func.func
     return _is_coro_func_cached(func)
 
 
 async def run_sync(func: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
-    """Run synchronous function in thread pool without blocking event loop.
-
-    Args:
-        func: Synchronous callable.
-        *args: Positional arguments for func.
-        **kwargs: Keyword arguments for func.
-
-    Returns:
-        Result of func(*args, **kwargs).
-    """
+    """Run synchronous function in a thread pool."""
     if kwargs:
         func_with_kwargs = partial(func, **kwargs)
         return await anyio.to_thread.run_sync(func_with_kwargs, *args)
     return await anyio.to_thread.run_sync(func, *args)
 
 
-# ── SIGINT-aware run_async ────────────────────────────────────────────────────
-# SIGINT (Ctrl-C) is delivered to the MAIN thread by the OS.  The default
-# CPython handler raises KeyboardInterrupt in whatever bytecode the main
-# thread is currently executing — including threading.Thread.join().  When
-# that happens the join() call aborts immediately, the child thread is
-# orphaned with a live event loop, and the session row is never transitioned
-# away from "running" (the phantom-session bug, issue #1055).
-#
-# Fix: install a SIGINT handler in the parent thread *before* spawning the
-# child.  The handler shares the child's asyncio task reference (via a
-# Future) and calls task.cancel() through call_soon_threadsafe(), which
-# schedules the cancellation inside the running event loop.  The child's
-# coroutine then unwinds through its ``finally`` / ``with CancelScope(shield=True)``
-# teardown, closes the DB, transitions the session, and exits cleanly.
-# The parent blocks on thread.join() the whole time (join() is only
-# interrupted if KeyboardInterrupt arrives *outside* our handler, which
-# cannot happen while our handler is installed).
-#
-# Platform notes:
-# - signal.signal() requires the main thread; we guard with a
-#   threading.current_thread() check so nested/worker-thread callers are
-#   completely unaffected.
-# - This is tested on macOS (darwin).  On Linux the behaviour is identical
-#   because both use POSIX signals with the same CPython handler semantics.
-#   Windows does not have SIGINT in the POSIX sense; signal.SIGINT maps to
-#   a Ctrl-C event that Python also routes to the main thread, so the guard
-#   is compatible but untested on Windows.
-# - signal.getsignal() is safe from any thread; only signal.signal() is
-#   main-thread-only.
+# SIGINT-aware run_async: installs a temporary SIGINT handler from the main
+# thread that cancels the inner asyncio task via call_soon_threadsafe instead
+# of raising KeyboardInterrupt in join(), which would orphan the child thread
+# and leave session rows stuck in "running" state.
 
 
 def run_async(coro: Awaitable[T]) -> T:
-    """Execute an async coroutine from a synchronous context.
-
-    Creates an isolated thread with its own event loop to run the coroutine,
-    avoiding conflicts with any existing event loop in the current thread.
-    Thread-safe and blocks until completion.
-
-    When called from the main thread, installs a temporary SIGINT handler so
-    that Ctrl-C cancels the inner coroutine through its structured teardown
-    path (``finally`` / ``anyio.CancelScope(shield=True)``) instead of
-    orphaning the child thread.  The previous SIGINT handler is always
-    restored before this function returns.
-
-    Args:
-        coro: Awaitable to execute (coroutine, Task, or Future).
-
-    Returns:
-        The result of the awaited coroutine.
-
-    Raises:
-        KeyboardInterrupt: If SIGINT was received while the coroutine was
-            running.  By the time this is raised the inner coroutine's
-            teardown has already completed and the child thread has exited.
-        BaseException: Any other exception raised by the coroutine is
-            re-raised.
-        RuntimeError: If the coroutine completes without producing a result.
-
-    Example:
-        >>> async def fetch_data():
-        ...     return {"status": "ok"}
-        >>> result = run_async(fetch_data())
-        >>> result
-        {'status': 'ok'}
-
-    Note:
-        Use sparingly. Prefer native async patterns when possible.
-        Each call creates a new thread and event loop.
-    """
+    """Run an awaitable from sync context in an isolated thread+event loop."""
     result_container: list[Any] = []
     exception_container: list[BaseException] = []
 
-    # Shared state between parent and child threads.
-    # _loop_and_task_future: child resolves with (loop, task) so the parent's
-    #   SIGINT handler can cancel the task via call_soon_threadsafe.
-    # _cancel_requested: set by the SIGINT handler so run_async knows to raise KBI.
     _loop_and_task_future: _ThreadFuture[tuple[Any, Any]] = _ThreadFuture()
     _cancel_requested = threading.Event()
 
@@ -141,11 +65,6 @@ def run_async(coro: Awaitable[T]) -> T:
         try:
 
             async def _runner() -> T:
-                # Capture (loop, task) from INSIDE the coroutine — this is the
-                # actual event loop that anyio.run() created, not any loop we
-                # might create manually before calling anyio.run().  We expose
-                # both to the parent's SIGINT handler BEFORE awaiting ``coro``
-                # so the handler can cancel the task while we're running.
                 _loop_and_task_future.set_result((asyncio.get_event_loop(), asyncio.current_task()))
                 return await coro
 
@@ -154,32 +73,22 @@ def run_async(coro: Awaitable[T]) -> T:
         except BaseException as e:
             exception_container.append(e)
         finally:
-            # If _runner never ran (e.g. anyio setup failed before it was
-            # scheduled), the future would block the parent's SIGINT handler.
-            # Cancel the future with a sentinel so the handler gets a quick
-            # "no task available" signal and falls back gracefully.
             if not _loop_and_task_future.done():
                 _loop_and_task_future.cancel()
 
     thread = threading.Thread(target=run_in_thread, daemon=False)
 
-    # Only install the SIGINT handler when we are in the main thread.
-    # signal.signal() raises ValueError from non-main threads.
+    # signal.signal() raises ValueError from non-main threads
     in_main_thread = threading.current_thread() is threading.main_thread()
 
     if in_main_thread:
         old_sigint_handler = signal.getsignal(signal.SIGINT)
 
         def _sigint_handler(signum: int, frame: Any) -> None:  # noqa: ARG001
-            """Cancel the inner task instead of raising KBI in the parent thread."""
             _cancel_requested.set()
-            # Try to get the (loop, task) pair.  Use a short timeout: if the
-            # child hasn't set it yet (startup race), fall back to the previous
-            # handler so the process can still be interrupted.
             try:
                 child_loop, task = _loop_and_task_future.result(timeout=0.5)
             except Exception:  # noqa: BLE001
-                # Pair unavailable (startup race or already done) — fall back.
                 if callable(old_sigint_handler):
                     old_sigint_handler(signum, frame)
                 return
@@ -190,20 +99,12 @@ def run_async(coro: Awaitable[T]) -> T:
 
     thread.start()
     try:
-        # This join() will now NOT be interrupted by KeyboardInterrupt because
-        # our handler above intercepts SIGINT and schedules task cancellation
-        # instead.  The child thread runs teardown and exits normally, then
-        # join() returns here.
         thread.join()
     finally:
         if in_main_thread:
-            # Always restore the previous handler before we raise anything.
             signal.signal(signal.SIGINT, old_sigint_handler)
 
     if _cancel_requested.is_set():
-        # The inner coroutine's teardown has already completed (thread.join()
-        # returned).  Now raise KeyboardInterrupt so callers (e.g. run_agent)
-        # see the expected signal-interrupted exit path.
         raise KeyboardInterrupt
 
     if exception_container:
@@ -214,18 +115,8 @@ def run_async(coro: Awaitable[T]) -> T:
 
 
 async def sleep(seconds: float) -> None:
-    """Async sleep without blocking the event loop.
-
-    Args:
-        seconds: Duration to sleep.
-    """
     await anyio.sleep(seconds)
 
 
 def current_time() -> float:
-    """Get current monotonic time in seconds.
-
-    Returns:
-        Monotonic clock value from anyio.
-    """
     return anyio.current_time()

--- a/lionagi/ln/fuzzy/_string_similarity.py
+++ b/lionagi/ln/fuzzy/_string_similarity.py
@@ -21,15 +21,6 @@ __all__ = ("string_similarity",)
 
 
 def cosine_similarity(s1: str, s2: str) -> float:
-    """Calculate the cosine similarity between two strings.
-
-    Args:
-        s1: First input string
-        s2: Second input string
-
-    Returns:
-        float: Cosine similarity score between 0 and 1
-    """
     if not s1 or not s2:
         return 0.0
 
@@ -43,18 +34,6 @@ def cosine_similarity(s1: str, s2: str) -> float:
 
 
 def hamming_similarity(s1: str, s2: str) -> float:
-    """Calculate the Hamming similarity between two strings.
-
-    The strings must be of equal length. Returns the proportion of positions
-    at which corresponding symbols are the same.
-
-    Args:
-        s1: First input string
-        s2: Second input string
-
-    Returns:
-        float: Hamming similarity score between 0 and 1
-    """
     if not s1 or not s2 or len(s1) != len(s2):
         return 0.0
 
@@ -63,15 +42,6 @@ def hamming_similarity(s1: str, s2: str) -> float:
 
 
 def jaro_distance(s: str, t: str) -> float:
-    """Calculate the Jaro distance between two strings.
-
-    Args:
-        s: First input string
-        t: Second input string
-
-    Returns:
-        float: Jaro distance score between 0 and 1
-    """
     s_len = len(s)
     t_len = len(t)
 
@@ -81,7 +51,7 @@ def jaro_distance(s: str, t: str) -> float:
         return 0.0
 
     match_distance = (max(s_len, t_len) // 2) - 1
-    match_distance = max(0, match_distance)  # Ensure non-negative
+    match_distance = max(0, match_distance)
 
     s_matches = [False] * s_len
     t_matches = [False] * t_len
@@ -89,7 +59,6 @@ def jaro_distance(s: str, t: str) -> float:
     matches = 0
     transpositions = 0
 
-    # Identify matches
     for i in range(s_len):
         start = max(0, i - match_distance)
         end = min(i + match_distance + 1, t_len)
@@ -104,7 +73,6 @@ def jaro_distance(s: str, t: str) -> float:
     if matches == 0:
         return 0.0
 
-    # Count transpositions
     k = 0
     for i in range(s_len):
         if not s_matches[i]:
@@ -121,19 +89,6 @@ def jaro_distance(s: str, t: str) -> float:
 
 
 def jaro_winkler_similarity(s: str, t: str, scaling: float = 0.1) -> float:
-    """Calculate the Jaro-Winkler similarity between two strings.
-
-    Args:
-        s: First input string
-        t: Second input string
-        scaling: Scaling factor for common prefix adjustment
-
-    Returns:
-        float: Jaro-Winkler similarity score between 0 and 1
-
-    Raises:
-        ValueError: If scaling factor is not between 0 and 0.25
-    """
     if not 0 <= scaling <= 0.25:
         raise ValueError("Scaling factor must be between 0 and 0.25")
 
@@ -141,8 +96,6 @@ def jaro_winkler_similarity(s: str, t: str, scaling: float = 0.1) -> float:
         return _rf_distance.JaroWinkler.similarity(s, t, prefix_weight=scaling)
 
     jaro_sim = jaro_distance(s, t)
-
-    # Find length of common prefix (up to 4 chars)
     prefix_len = 0
     for s_char, t_char in zip(s, t, strict=False):
         if s_char != t_char:
@@ -155,16 +108,6 @@ def jaro_winkler_similarity(s: str, t: str, scaling: float = 0.1) -> float:
 
 
 def levenshtein_distance(a: str, b: str) -> int:
-    """Calculate the Levenshtein (edit) distance between two strings.
-
-    Args:
-        a: First input string
-        b: Second input string
-
-    Returns:
-        int: Minimum number of single-character edits needed to change one
-             string into the other
-    """
     from itertools import product
 
     if not a:
@@ -183,26 +126,15 @@ def levenshtein_distance(a: str, b: str) -> int:
     for i, j in product(range(1, m + 1), range(1, n + 1)):
         cost = 0 if a[i - 1] == b[j - 1] else 1
         d[i][j] = min(
-            d[i - 1][j] + 1,  # deletion
-            d[i][j - 1] + 1,  # insertion
-            d[i - 1][j - 1] + cost,  # substitution
+            d[i - 1][j] + 1,
+            d[i][j - 1] + 1,
+            d[i - 1][j - 1] + cost,
         )
 
     return d[m][n]
 
 
 def levenshtein_similarity(s1: str, s2: str) -> float:
-    """Calculate the Levenshtein similarity between two strings.
-
-    Converts Levenshtein distance to a similarity score between 0 and 1.
-
-    Args:
-        s1: First input string
-        s2: Second input string
-
-    Returns:
-        float: Levenshtein similarity score between 0 and 1
-    """
     if _HAS_RAPIDFUZZ:
         return _rf_distance.Levenshtein.normalized_similarity(s1, s2)
 
@@ -217,21 +149,11 @@ def levenshtein_similarity(s1: str, s2: str) -> float:
 
 
 def sequence_matcher_similarity(s1: str, s2: str) -> float:
-    """Calculate similarity using Python's SequenceMatcher.
-
-    Args:
-        s1: First input string
-        s2: Second input string
-
-    Returns:
-        float: Similarity score between 0 and 1
-    """
     from difflib import SequenceMatcher
 
     return SequenceMatcher(None, s1, s2).ratio()
 
 
-# Map of available similarity algorithms
 SIMILARITY_ALGO_MAP = {
     "jaro_winkler": jaro_winkler_similarity,
     "levenshtein": levenshtein_similarity,
@@ -249,14 +171,11 @@ SIMILARITY_TYPE = Literal[
     "cosine",
 ]
 
-# Type alias for similarity functions
 SimilarityFunc = Callable[[str, str], float]
 
 
 @dataclass(frozen=True)
 class MatchResult:
-    """Represents a string matching result."""
-
     word: str
     score: float
     index: int
@@ -270,40 +189,21 @@ def string_similarity(
     case_sensitive: bool = False,
     return_most_similar: bool = False,
 ) -> str | list[str] | None:
-    """Find similar strings using specified similarity algorithm.
-
-    Args:
-        word: The input string to find matches for
-        correct_words: List of strings to compare against
-        algorithm: Similarity algorithm to use
-        threshold: Minimum similarity score (0.0 to 1.0)
-        case_sensitive: Whether to consider case when matching
-        return_most_similar: Return only the most similar match
-
-    Returns:
-        Matching string(s) or None if no matches found
-
-    Raises:
-        ValueError: If correct_words is empty or threshold is invalid
-    """
     if not correct_words:
         raise ValueError("correct_words must not be empty")
 
     if not 0.0 <= threshold <= 1.0:
         raise ValueError("threshold must be between 0.0 and 1.0")
 
-    # Convert inputs to strings
     compare_word = str(word)
     original_words = [str(w) for w in correct_words]
 
-    # Handle case sensitivity
     if not case_sensitive:
         compare_word = compare_word.lower()
         compare_words = [w.lower() for w in original_words]
     else:
         compare_words = original_words.copy()
 
-    # Get scoring function
     if isinstance(algorithm, str):
         score_func = SIMILARITY_ALGO_MAP.get(algorithm)
         if score_func is None:
@@ -313,10 +213,8 @@ def string_similarity(
     else:
         raise ValueError("algorithm must be a string specifying a built-in algorithm or a callable")
 
-    # Calculate similarities
     results = []
     for idx, (orig_word, comp_word) in enumerate(zip(original_words, compare_words, strict=False)):
-        # Skip different length strings for hamming similarity
         if algorithm == "hamming" and len(comp_word) != len(compare_word):
             continue
 
@@ -324,19 +222,15 @@ def string_similarity(
         if score >= threshold:
             results.append(MatchResult(orig_word, score, idx))
 
-    # Return None if no matches
     if not results:
         return None
 
-    # Sort by score (descending) and index (ascending) for stable ordering
     results.sort(key=lambda x: (-x.score, x.index))
 
-    # Filter exact matches for case sensitive comparisons
     if case_sensitive:
         max_score = results[0].score
         results = [r for r in results if r.score == max_score]
 
-    # Return results
     if return_most_similar:
         return results[0].word
 

--- a/lionagi/ln/fuzzy/_to_dict.py
+++ b/lionagi/ln/fuzzy/_to_dict.py
@@ -11,7 +11,6 @@ from ._fuzzy_json import fuzzy_json
 
 
 def _is_na(obj: Any) -> bool:
-    """None / Pydantic undefined sentinels -> treat as NA."""
     if obj is None:
         return True
     # Avoid importing pydantic types; match by typename to stay lightweight
@@ -39,20 +38,15 @@ def _parse_str(
     parser: Callable[[str], Any] | None,
     **kwargs: Any,
 ) -> Any:
-    """Parse str -> Python object. Keep imports local to avoid cold start overhead."""
     if parser is not None:
         return parser(s, **kwargs)
 
     if str_type == "xml":
-        # xmltodict is optional; import only if needed
         import xmltodict
 
         return xmltodict.parse(s, **kwargs)
 
-    # JSON path
     if fuzzy_parse:
-        # If the caller supplied a fuzzy parser in scope, use it; otherwise fallback.
-        # We intentionally do not import anything heavy here.
         with contextlib.suppress(NameError):
             return fuzzy_json(s, **kwargs)  # type: ignore[name-defined]
     return json.loads(s, **kwargs)
@@ -64,45 +58,25 @@ def _object_to_mapping_like(
     prioritize_model_dump: bool = True,
     **kwargs: Any,
 ) -> Mapping | dict | Any:
-    """
-    Convert 'custom' objects to mapping-like, if possible.
-    Order:
-      1) Pydantic v2 'model_dump' (duck-typed)
-      2) Common methods: to_dict, dict, to_json/json (parsed if string)
-      3) Dataclass
-      4) __dict__
-      5) dict(obj)
-    """
-    # 1) Pydantic v2
     if prioritize_model_dump and hasattr(obj, "model_dump"):
         return obj.model_dump(**kwargs)
 
-    # 2) Common methods
     for name in ("to_dict", "dict", "to_json", "json", "model_dump"):
         if hasattr(obj, name):
             res = getattr(obj, name)(**kwargs)
             return json.loads(res) if isinstance(res, str) else res
 
-    # 3) Dataclass
     if dataclasses.is_dataclass(obj):
-        # asdict is already recursive; keep it (fast enough & simple)
         return dataclasses.asdict(obj)
 
-    # 4) __dict__
     if hasattr(obj, "__dict__"):
         return obj.__dict__
 
-    # 5) Try dict() fallback
-    return dict(obj)  # may raise -> handled by caller
+    return dict(obj)
 
 
 def _enumerate_iterable(it: Iterable) -> dict[int, Any]:
     return {i: v for i, v in enumerate(it)}
-
-
-# ---------------------------------------
-# Recursive pre-processing (single pass)
-# ---------------------------------------
 
 
 def _preprocess_recursive(
@@ -114,20 +88,11 @@ def _preprocess_recursive(
     str_parse_opts: dict[str, Any],
     prioritize_model_dump: bool,
 ) -> Any:
-    """
-    Recursively process nested structures:
-      - Parse strings (JSON/XML/custom parser)
-      - Recurse into dict/list/tuple/set/etc.
-      - If recursive_custom_types=True, convert custom objects to mapping-like then continue
-    Containers retain their original types (dict stays dict, list stays list, set stays set, etc.)
-    """
     if depth >= max_depth:
         return obj
 
-    # Fast paths by exact type where possible
     t = type(obj)
 
-    # Strings: try to parse; on failure, keep as-is
     if t is str:
         try:
             parsed = _parse_str(obj, **str_parse_opts)
@@ -142,9 +107,7 @@ def _preprocess_recursive(
             prioritize_model_dump=prioritize_model_dump,
         )
 
-    # Dict-like
     if isinstance(obj, Mapping):
-        # Recurse only into values (keys kept as-is)
         return {
             k: _preprocess_recursive(
                 v,
@@ -157,7 +120,6 @@ def _preprocess_recursive(
             for k, v in obj.items()
         }
 
-    # Sequence/Set-like (but not str)
     if isinstance(obj, list | tuple | set | frozenset):
         items = [
             _preprocess_recursive(
@@ -179,7 +141,6 @@ def _preprocess_recursive(
         if t is frozenset:
             return frozenset(items)
 
-    # Enum *class* (rare in values, but preserve your original attempt)
     if isinstance(obj, type) and issubclass(obj, _Enum):
         try:
             enum_map = _enum_class_to_dict(
@@ -197,7 +158,6 @@ def _preprocess_recursive(
         except Exception:
             return obj
 
-    # Custom objects
     if recursive_custom_types:
         with contextlib.suppress(Exception):
             mapped = _object_to_mapping_like(obj, prioritize_model_dump=prioritize_model_dump)
@@ -213,11 +173,6 @@ def _preprocess_recursive(
     return obj
 
 
-# ---------------------------------------
-# Top-level conversion (non-recursive)
-# ---------------------------------------
-
-
 def _convert_top_level_to_dict(
     obj: Any,
     *,
@@ -228,27 +183,18 @@ def _convert_top_level_to_dict(
     use_enum_values: bool,
     **kwargs: Any,
 ) -> dict[str, Any]:
-    """
-    Convert a *single* object to dict using the 'brute force' rules.
-    Mirrors your original order, with fixes & optimizations.
-    """
-    # Set -> {v: v}
     if isinstance(obj, set):
         return {v: v for v in obj}
 
-    # Enum class -> members mapping
     if isinstance(obj, type) and issubclass(obj, _Enum):
         return _enum_class_to_dict(obj, use_enum_values)
 
-    # Mapping -> copy to plain dict (preserve your copy semantics)
     if isinstance(obj, Mapping):
         return dict(obj)
 
-    # None / pydantic undefined -> {}
     if _is_na(obj):
         return {}
 
-    # str -> parse (and return *as parsed*, which may be list, dict, etc.)
     if isinstance(obj, str):
         return _parse_str(
             obj,
@@ -258,16 +204,11 @@ def _convert_top_level_to_dict(
             **kwargs,
         )
 
-    # Try "custom" object conversions
-    # (Covers BaseModel via model_dump, dataclasses, __dict__, json-strings, etc.)
     try:
-        # If it's *not* a Sequence (e.g., numbers, objects) we try object conversion first,
-        # faithfully following your previous "non-Sequence -> model path" behavior.
         if not isinstance(obj, Sequence):
             converted = _object_to_mapping_like(
                 obj, prioritize_model_dump=prioritize_model_dump, **kwargs
             )
-            # If conversion returned a string, try to parse JSON to mapping; else pass-through
             if isinstance(converted, str):
                 return _parse_str(
                     converted,
@@ -277,34 +218,23 @@ def _convert_top_level_to_dict(
                 )
             if isinstance(converted, Mapping):
                 return dict(converted)
-            # If it's a list/tuple/etc., enumerate (your original did that after the fact)
             if isinstance(converted, Iterable) and not isinstance(
                 converted, str | bytes | bytearray
             ):
                 return _enumerate_iterable(converted)
-            # Best effort final cast
             return dict(converted)
 
-    except Exception:  # noqa: S110  # intentional parser fallback: exhausts every conversion strategy before giving up
-        # Fall through to other strategies
+    except Exception:  # noqa: S110  # intentional: exhausts every conversion strategy before giving up
         pass
 
-    # Iterable (list/tuple/namedtuple/frozenset/…): enumerate
     if isinstance(obj, Iterable) and not isinstance(obj, str | bytes | bytearray):
         return _enumerate_iterable(obj)
 
-    # Dataclass fallback (reachable only if it wasn't caught above)
     with contextlib.suppress(Exception):
         if dataclasses.is_dataclass(obj):
             return dataclasses.asdict(obj)
 
-    # Last-ditch attempt
-    return dict(obj)  # may raise, handled by top-level try/except
-
-
-# ---------------
-# Public function
-# ---------------
+    return dict(obj)
 
 
 def to_dict(
@@ -323,15 +253,11 @@ def to_dict(
     use_model_dump: bool | None = None,  # deprecated
     **kwargs: Any,
 ) -> dict[str, Any]:
-    """
-    Convert various input types to a dictionary, with optional recursive processing.
-    Semantics preserved from original implementation.
-    """
+    """Convert various input types to a dictionary."""
     if use_model_dump is not None:
         prioritize_model_dump = use_model_dump
 
     try:
-        # Clamp recursion depth (match your constraints)
         if not isinstance(max_recursive_depth, int):
             max_depth = 5
         else:

--- a/lionagi/ln/types/spec.py
+++ b/lionagi/ln/types/spec.py
@@ -1,8 +1,4 @@
-"""Spec - Universal type specification for framework-agnostic field definitions.
-
-This module provides the Spec class for defining field specifications that can be
-adapted to any framework (Pydantic, attrs, dataclasses, etc.) via adapters.
-"""
+"""Framework-agnostic field specification."""
 
 from __future__ import annotations
 
@@ -30,7 +26,7 @@ __all__ = ("Spec", "CommonMeta")
 
 
 class CommonMeta(Enum):
-    """Common metadata keys used across field specifications."""
+    """Standard metadata keys for field specifications."""
 
     NAME = "name"
     NULLABLE = "nullable"
@@ -41,16 +37,11 @@ class CommonMeta(Enum):
 
     @classmethod
     def allowed(cls) -> set[str]:
-        """Return all allowed common metadata keys."""
         return {i.value for i in cls}
 
     @classmethod
     def _validate_common_metas(cls, **kw):
-        """Validate common metadata constraints.
-
-        Uses key-presence checks rather than truthiness so that falsy-but-valid
-        values (e.g. ``default=0``, ``default=False``) are handled correctly.
-        """
+        # Key-presence checks (not truthiness) so default=0/False works
         if "default" in kw and "default_factory" in kw:
             raise ValueError("Cannot provide both 'default' and 'default_factory'")
         if "default_factory" in kw:
@@ -64,26 +55,11 @@ class CommonMeta(Enum):
 
     @classmethod
     def prepare(cls, *args: Meta, metadata: tuple[Meta, ...] = None, **kw: Any) -> tuple[Meta, ...]:
-        """Prepare metadata tuple from various inputs, checking for duplicates.
-
-        Args:
-            *args: Individual Meta objects
-            metadata: Existing metadata tuple
-            **kw: Keyword arguments to convert to Meta objects
-
-        Returns:
-            Tuple of Meta objects
-
-        Raises:
-            ValueError: If duplicate keys are found
-        """
-        # Lazy import to avoid circular dependency
         from .._to_list import to_list
 
         seen_keys = set()
         metas = []
 
-        # Process existing metadata
         if metadata:
             for meta in metadata:
                 if meta.key in seen_keys:
@@ -91,7 +67,6 @@ class CommonMeta(Enum):
                 seen_keys.add(meta.key)
                 metas.append(meta)
 
-        # Process args
         if args:
             _args = to_list(args, flatten=True, flatten_tuple_set=True, dropna=True)
             for meta in _args:
@@ -100,14 +75,12 @@ class CommonMeta(Enum):
                 seen_keys.add(meta.key)
                 metas.append(meta)
 
-        # Process kwargs
         for k, v in kw.items():
             if k in seen_keys:
                 raise ValueError(f"Duplicate metadata key: {k}")
             seen_keys.add(k)
             metas.append(Meta(k, v))
 
-        # Validate common metadata constraints
         meta_dict = {m.key: m.value for m in metas}
         cls._validate_common_metas(**meta_dict)
 
@@ -116,23 +89,7 @@ class CommonMeta(Enum):
 
 @dataclass(frozen=True, slots=True, init=False)
 class Spec:
-    """Framework-agnostic field specification.
-
-    A Spec defines the type and metadata for a field without coupling to any
-    specific framework. Use adapters to convert Spec to framework-specific
-    field definitions (e.g., Pydantic Field, attrs attribute).
-
-    Attributes:
-        base_type: The base Python type for this field
-        metadata: Tuple of metadata objects attached to this spec
-
-    Example:
-        >>> spec = Spec(str, name="username", nullable=False)
-        >>> spec.name
-        'username'
-        >>> spec.annotation
-        str
-    """
+    """Framework-agnostic field type + metadata specification."""
 
     base_type: type
     metadata: tuple[Meta, ...]
@@ -144,14 +101,6 @@ class Spec:
         metadata: tuple[Meta, ...] = None,
         **kw,
     ) -> None:
-        """Initialize Spec with type and metadata.
-
-        Args:
-            base_type: Base Python type
-            *args: Additional Meta objects
-            metadata: Existing metadata tuple
-            **kw: Keyword arguments converted to Meta objects
-        """
         metas = CommonMeta.prepare(*args, metadata=metadata, **kw)
 
         if not_sentinel(base_type, True):
@@ -166,7 +115,6 @@ class Spec:
             if not is_valid_type:
                 raise ValueError(f"base_type must be a type or type annotation, got {base_type}")
 
-        # Check for async default factory and warn
         if kw.get("default_factory") and is_coro_func(kw["default_factory"]):
             import warnings
 
@@ -181,49 +129,25 @@ class Spec:
         object.__setattr__(self, "metadata", metas)
 
     def __getitem__(self, key: str) -> Any:
-        """Get metadata value by key.
-
-        Args:
-            key: Metadata key
-
-        Returns:
-            Metadata value
-
-        Raises:
-            KeyError: If key not found
-        """
         for meta in self.metadata:
             if meta.key == key:
                 return meta.value
         raise KeyError(f"Metadata key '{key}' undefined in Spec.")
 
     def get(self, key: str, default: Any = Undefined) -> Any:
-        """Get metadata value by key with default.
-
-        Args:
-            key: Metadata key
-            default: Default value if key not found
-
-        Returns:
-            Metadata value or default
-        """
         with contextlib.suppress(KeyError):
             return self[key]
         return default
 
     @property
     def name(self) -> MaybeUndefined[str]:
-        """Get the field name from metadata."""
         return self.get(CommonMeta.NAME.value)
 
     @property
     def q(self):
-        """A :class:`FieldRef` for this spec's name — the entry point to the
-        filter DSL (``spec.q == value``, ``spec.q > value``, ...).
+        """Entry point to the filter DSL via FieldRef.
 
-        Lives here rather than on ``Spec`` directly because ``Spec.__eq__`` is
-        load-bearing (sets, dedup, caches); ``q`` hands out a fresh FieldRef
-        whose operators build :class:`SpecFilter`s instead.
+        Separate from Spec because Spec.__eq__ is load-bearing (sets/dedup/caches).
         """
         from .filters import FieldRef
 
@@ -231,17 +155,14 @@ class Spec:
 
     @property
     def is_nullable(self) -> bool:
-        """Check if field is nullable."""
         return self.get(CommonMeta.NULLABLE.value) is True
 
     @property
     def is_listable(self) -> bool:
-        """Check if field is listable."""
         return self.get(CommonMeta.LISTABLE.value) is True
 
     @property
     def default(self) -> MaybeUndefined[Any]:
-        """Get default value or factory."""
         return self.get(
             CommonMeta.DEFAULT.value,
             self.get(CommonMeta.DEFAULT_FACTORY.value),
@@ -249,23 +170,13 @@ class Spec:
 
     @property
     def has_default_factory(self) -> bool:
-        """Check if this spec has a default factory."""
         return _is_factory(self.get(CommonMeta.DEFAULT_FACTORY.value))[0]
 
     @property
     def has_async_default_factory(self) -> bool:
-        """Check if this spec has an async default factory."""
         return _is_factory(self.get(CommonMeta.DEFAULT_FACTORY.value))[1]
 
     def create_default_value(self) -> Any:
-        """Create default value synchronously.
-
-        Returns:
-            Default value
-
-        Raises:
-            ValueError: If no default or factory defined, or if factory is async
-        """
         if self.default is Undefined:
             raise ValueError("No default value or factory defined in Spec.")
         if self.has_async_default_factory:
@@ -278,24 +189,11 @@ class Spec:
         return self.default
 
     async def acreate_default_value(self) -> Any:
-        """Create default value asynchronously.
-
-        Returns:
-            Default value
-        """
         if self.has_async_default_factory:
             return await self.default()
         return self.create_default_value()
 
     def with_updates(self, **kw):
-        """Create new Spec with updated metadata.
-
-        Args:
-            **kw: Metadata updates
-
-        Returns:
-            New Spec instance with updates
-        """
         _filtered = [meta for meta in self.metadata if meta.key not in kw]
         for k, v in kw.items():
             if not_sentinel(v):
@@ -304,44 +202,21 @@ class Spec:
         return type(self)(self.base_type, metadata=_metas)
 
     def as_nullable(self) -> Spec:
-        """Create nullable version of this spec."""
         return self.with_updates(nullable=True)
 
     def as_listable(self) -> Spec:
-        """Create listable version of this spec."""
         return self.with_updates(listable=True)
 
     def with_default(self, default: Any) -> Spec:
-        """Create spec with default value or factory.
-
-        Args:
-            default: Default value or factory function
-
-        Returns:
-            New Spec with default
-        """
         if callable(default):
             return self.with_updates(default_factory=default)
         return self.with_updates(default=default)
 
     def with_validator(self, validator: Callable[..., Any] | list[Callable[..., Any]]) -> Spec:
-        """Create spec with validator(s).
-
-        Args:
-            validator: Single validator or list of validators
-
-        Returns:
-            New Spec with validator(s)
-        """
         return self.with_updates(validator=validator)
 
     @property
     def annotation(self) -> type[Any]:
-        """Plain type annotation representing base type, nullable, and listable.
-
-        Returns:
-            Type annotation
-        """
         if is_sentinel(self.base_type, none_as_sentinel=True):
             return Any
         t_ = self.base_type
@@ -352,25 +227,14 @@ class Spec:
         return t_
 
     def annotated(self) -> type[Any]:
-        """Materialize this spec into an Annotated type.
-
-        This method is cached to ensure repeated calls return the same
-        type object for performance and identity checks. The cache is bounded
-        using LRU eviction to prevent unbounded memory growth.
-
-        Returns:
-            Annotated type with all metadata attached
-        """
-        # Check cache first with thread safety
+        """Materialize into an Annotated type (LRU-cached, thread-safe)."""
         cache_key = (self.base_type, self.metadata)
 
         with _cache_lock:
             if cache_key in _annotated_cache:
-                # Move to end to mark as recently used
                 _annotated_cache.move_to_end(cache_key)
                 return _annotated_cache[cache_key]
 
-            # Handle nullable case - wrap in Optional-like union
             actual_type = (
                 Any if is_sentinel(self.base_type, none_as_sentinel=True) else self.base_type
             )
@@ -379,7 +243,6 @@ class Spec:
             )
 
             if any(m.key == "nullable" and m.value for m in current_metadata):
-                # Use union syntax for nullable
                 actual_type = actual_type | None  # type: ignore
 
             if current_metadata:
@@ -388,15 +251,12 @@ class Spec:
             else:
                 result = actual_type  # type: ignore[misc]
 
-            # Cache the result with LRU eviction
             _annotated_cache[cache_key] = result  # type: ignore[assignment]
 
-            # Evict oldest if cache is too large (guard against empty cache)
             while len(_annotated_cache) > _MAX_CACHE_SIZE:
                 try:
-                    _annotated_cache.popitem(last=False)  # Remove oldest
+                    _annotated_cache.popitem(last=False)
                 except KeyError:
-                    # Cache became empty during race, safe to continue
                     break
 
         return result  # type: ignore[return-value]
@@ -404,15 +264,6 @@ class Spec:
     def metadict(
         self, exclude: set[str] | None = None, exclude_common: bool = False
     ) -> dict[str, Any]:
-        """Get metadata as dictionary.
-
-        Args:
-            exclude: Keys to exclude
-            exclude_common: Exclude all common metadata keys
-
-        Returns:
-            Dictionary of metadata
-        """
         if exclude is None:
             exclude = set()
         if exclude_common:
@@ -421,14 +272,7 @@ class Spec:
 
 
 def _is_factory(obj: Any) -> tuple[bool, bool]:
-    """Check if object is a factory function.
-
-    Args:
-        obj: Object to check
-
-    Returns:
-        Tuple of (is_factory, is_async)
-    """
+    """Return (is_factory, is_async)."""
     if not callable(obj):
         return (False, False)
     if is_coro_func(obj):

--- a/lionagi/models/field_model.py
+++ b/lionagi/models/field_model.py
@@ -1,8 +1,4 @@
-"""Field model implementation for compositional field definitions.
-
-This module provides FieldModel, a Params-based class that enables
-compositional field definitions with lazy materialization and aggressive caching.
-"""
+"""Compositional field definitions with lazy materialization."""
 
 from __future__ import annotations
 
@@ -35,7 +31,6 @@ def _init_pydantic_field_params() -> None:
 
 
 def _get_pydantic_field_params() -> set[str]:
-    """Get valid Pydantic Field parameters (cached, thread-safe)."""
     _lazy_field_params.ensure(_init_pydantic_field_params)
     return _PYDANTIC_FIELD_PARAMS
 
@@ -51,79 +46,29 @@ METADATA_LIMIT = int(os.environ.get("LIONAGI_FIELD_META_LIMIT", "10"))
 
 @dataclass(slots=True, frozen=True, init=False)
 class FieldModel(Params):
-    """Field model for compositional field definitions.
+    """Compositional field definition with lazy Annotated-type materialization."""
 
-    This class provides a way to define field models that can be composed
-    and materialized lazily with aggressive caching for performance.
-
-    Key features:
-    - All unspecified fields are explicitly Unset (not None or empty)
-    - No silent type conversions - fails fast on incorrect types
-    - Aggressive caching of materialized types with LRU eviction
-    - Thread-safe field creation and caching
-    - Not directly instantiable - requires keyword arguments
-
-    Attributes:
-        base_type: The base Python type for this field
-        metadata: Tuple of metadata to attach via Annotated
-
-    Environment Variables:
-        LIONAGI_FIELD_CACHE_SIZE: Maximum number of cached annotated types (default: 10000)
-        LIONAGI_FIELD_META_LIMIT: Maximum metadata items per template (default: 10)
-
-    Example:
-        >>> field = FieldModel(base_type=str, name="username")
-        >>> nullable_field = field.as_nullable()
-        >>> annotated_type = nullable_field.annotated()
-    """
-
-    # Class configuration - let Params handle Unset population
     _config: ClassVar[ModelConfig] = ModelConfig(prefill_unset=True, none_as_sentinel=True)
 
-    # Public fields (all start as Unset when not provided)
     base_type: type[Any]
     metadata: tuple[Meta, ...]
 
     def __init__(self, base_type: type[Any] = None, **kwargs: Any) -> None:
-        """Initialize FieldModel with legacy compatibility.
-
-        Handles backward compatibility by converting old-style kwargs to the new
-        Params-based format.
-
-        Args:
-            **kwargs: Arbitrary keyword arguments, including legacy ones
-        """
-        # Convert legacy kwargs to proper format
         if base_type is not None:
             kwargs["base_type"] = base_type
         converted = self._convert_kwargs_to_params(**kwargs)
-
-        # Set fields directly and validate
         for k, v in converted.items():
             if k in self.allowed():
                 object.__setattr__(self, k, v)
             else:
                 raise ValueError(f"Invalid parameter: {k}")
 
-        # Validate after setting all attributes
         self._validate()
 
     def _validate(self) -> None:
-        """Validate field configuration and process metadata.
-
-        This method performs minimal domain-specific validation, then processes
-        and validates the metadata configuration.
-
-        Raises:
-            ValueError: If base_type is invalid or metadata is malformed
-        """
-        # Let parent handle basic Unset population
         Params._validate(self)
 
-        # Minimal domain validation - only check what matters
         if not self._is_sentinel(self.base_type):
-            # Allow types, GenericAlias (like list[str]), and union types (like str | None)
-            # Check for type, generic types, or union types
             import types
 
             is_valid_type = (
@@ -132,14 +77,13 @@ class FieldModel(Params):
                 or isinstance(
                     self.base_type, types.UnionType
                 )  # Python 3.10+ union types (str | None)
-                or str(type(self.base_type)) == "<class 'types.UnionType'>"  # Fallback check
+                or str(type(self.base_type)) == "<class 'types.UnionType'>"
             )
             if not is_valid_type:
                 raise ValueError(
                     f"base_type must be a type or type annotation, got {self.base_type}"
                 )
 
-        # Validate metadata limit
         if not self._is_sentinel(self.metadata):
             if len(self.metadata) > METADATA_LIMIT:
                 import warnings
@@ -153,27 +97,16 @@ class FieldModel(Params):
 
     @classmethod
     def _convert_kwargs_to_params(cls, **kwargs: Any) -> dict[str, Any]:
-        """Convert legacy kwargs to Params-compatible format.
-
-        This handles backward compatibility with the old FieldModel API.
-
-        Args:
-            **kwargs: Legacy keyword arguments
-
-        Returns:
-            Dictionary of converted parameters
-        """
+        """Convert legacy kwargs to Params-compatible format."""
         params = {}
 
-        # Handle annotation alias for base_type
+        # "annotation" is a legacy alias for "base_type"
         if "annotation" in kwargs and "base_type" not in kwargs:
             kwargs["base_type"] = kwargs.pop("annotation")
 
-        # "field" is a legacy alias for "name"
         if "field" in kwargs and "name" not in kwargs:
             kwargs["name"] = kwargs.pop("field")
 
-        # Take structural fields into params directly (not metadata)
         if "base_type" in kwargs:
             params["base_type"] = kwargs.pop("base_type")
         if "metadata" in kwargs:
@@ -181,23 +114,19 @@ class FieldModel(Params):
 
         metadata = list(params.get("metadata", ()))
 
-        # Handle name in metadata
         if "name" in kwargs:
             name = kwargs.pop("name")
             if name != "field":  # Only add if non-default
                 metadata.append(Meta("name", name))
 
-        # Handle special flags
         if kwargs.pop("nullable", False):
             metadata.append(Meta("nullable", True))
         if kwargs.pop("listable", False):
             metadata.append(Meta("listable", True))
 
-        # Validate conflicting defaults
         if "default" in kwargs and "default_factory" in kwargs:
             raise ValueError("Cannot have both default and default_factory")
 
-        # Validate validators if provided
         if "validator" in kwargs:
             validator = kwargs["validator"]
             if not callable(validator) and not (
@@ -205,7 +134,6 @@ class FieldModel(Params):
             ):
                 raise ValueError("Validators must be a list of functions or a function")
 
-        # Remaining kwargs become metadata entries (permissive legacy API).
         for key, value in kwargs.items():
             metadata.append(Meta(key, value))
 
@@ -215,9 +143,7 @@ class FieldModel(Params):
         return params
 
     def __getattr__(self, name: str) -> Any:
-        """Handle access to custom attributes stored in metadata."""
-        # Use object.__getattribute__ to avoid recursion when the
-        # metadata slot itself is not yet assigned (during __init__).
+        # Avoid recursion when metadata slot is not yet assigned (during __init__)
         try:
             metadata = object.__getattribute__(self, "metadata")
         except AttributeError:
@@ -228,25 +154,16 @@ class FieldModel(Params):
                 if meta.key == name:
                     return meta.value
 
-        # Special handling for common attributes with defaults
         if name == "name":
             return "field"
 
-        # If not found, raise AttributeError as usual
         raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{name}'")
 
     # ---- factory helpers -------------------------------------------------- #
 
     def as_nullable(self) -> Self:
-        """Create a new field model that allows None values.
-
-        Returns:
-            New FieldModel with nullable metadata added
-        """
-        # Add nullable marker to metadata
         current_metadata = () if self._is_sentinel(self.metadata) else self.metadata
         new_metadata = (*current_metadata, Meta("nullable", True))
-        # Create new instance directly without going through __init__
         new_instance = object.__new__(type(self))
         object.__setattr__(new_instance, "base_type", self.base_type)
         object.__setattr__(new_instance, "metadata", new_metadata)
@@ -254,22 +171,10 @@ class FieldModel(Params):
         return new_instance
 
     def as_listable(self) -> Self:
-        """Create a new field model that wraps the type in a list.
-
-        Note: This produces list[T] which is a types.GenericAlias in Python 3.11+,
-        not typing.List. This is intentional for better performance and native support.
-
-        Returns:
-            New FieldModel with list wrapper
-        """
-        # Get current base type
         current_base = Any if self._is_sentinel(self.base_type) else self.base_type
-        # Change base type to list of current type
         new_base = list[current_base]  # type: ignore
-        # Add listable marker to metadata
         current_metadata = () if self._is_sentinel(self.metadata) else self.metadata
         new_metadata = (*current_metadata, Meta("listable", True))
-        # Create new instance directly without going through __init__
         new_instance = object.__new__(type(self))
         object.__setattr__(new_instance, "base_type", new_base)
         object.__setattr__(new_instance, "metadata", new_metadata)
@@ -277,18 +182,8 @@ class FieldModel(Params):
         return new_instance
 
     def with_validator(self, f: Callable[[Any], bool]) -> Self:
-        """Add a validator function to this field model.
-
-        Args:
-            f: Validator function that takes a value and returns bool
-
-        Returns:
-            New FieldModel with validator added
-        """
-        # Add validator to metadata
         current_metadata = () if self._is_sentinel(self.metadata) else self.metadata
         new_metadata = (*current_metadata, Meta("validator", f))
-        # Create new instance directly without going through __init__
         new_instance = object.__new__(type(self))
         object.__setattr__(new_instance, "base_type", self.base_type)
         object.__setattr__(new_instance, "metadata", new_metadata)
@@ -296,23 +191,12 @@ class FieldModel(Params):
         return new_instance
 
     def with_description(self, description: str) -> Self:
-        """Add a description to this field model.
-
-        Args:
-            description: Human-readable description of the field
-
-        Returns:
-            New FieldModel with description added
-        """
-        # Remove any existing description
         current_metadata = () if self._is_sentinel(self.metadata) else self.metadata
         filtered_metadata = tuple(m for m in current_metadata if m.key != "description")
         new_metadata = (
             *filtered_metadata,
             Meta("description", description),
         )
-
-        # Create new instance directly without going through __init__
         new_instance = object.__new__(type(self))
         object.__setattr__(new_instance, "base_type", self.base_type)
         object.__setattr__(new_instance, "metadata", new_metadata)
@@ -320,19 +204,9 @@ class FieldModel(Params):
         return new_instance
 
     def with_default(self, default: Any) -> Self:
-        """Add a default value to this field model.
-
-        Args:
-            default: Default value for the field
-
-        Returns:
-            New FieldModel with default added
-        """
-        # Remove any existing default metadata to avoid conflicts
         current_metadata = () if self._is_sentinel(self.metadata) else self.metadata
         filtered_metadata = tuple(m for m in current_metadata if m.key != "default")
         new_metadata = (*filtered_metadata, Meta("default", default))
-        # Create new instance directly without going through __init__
         new_instance = object.__new__(type(self))
         object.__setattr__(new_instance, "base_type", self.base_type)
         object.__setattr__(new_instance, "metadata", new_metadata)
@@ -340,19 +214,9 @@ class FieldModel(Params):
         return new_instance
 
     def with_frozen(self, frozen: bool = True) -> Self:
-        """Mark this field as frozen (immutable after creation).
-
-        Args:
-            frozen: Whether the field should be frozen
-
-        Returns:
-            New FieldModel with frozen setting
-        """
-        # Remove any existing frozen metadata
         current_metadata = () if self._is_sentinel(self.metadata) else self.metadata
         filtered_metadata = tuple(m for m in current_metadata if m.key != "frozen")
         new_metadata = (*filtered_metadata, Meta("frozen", frozen))
-        # Create new instance directly without going through __init__
         new_instance = object.__new__(type(self))
         object.__setattr__(new_instance, "base_type", self.base_type)
         object.__setattr__(new_instance, "metadata", new_metadata)
@@ -360,18 +224,9 @@ class FieldModel(Params):
         return new_instance
 
     def with_alias(self, alias: str) -> Self:
-        """Add an alias to this field.
-
-        Args:
-            alias: Alternative name for the field
-
-        Returns:
-            New FieldModel with alias
-        """
         current_metadata = () if self._is_sentinel(self.metadata) else self.metadata
         filtered_metadata = tuple(m for m in current_metadata if m.key != "alias")
         new_metadata = (*filtered_metadata, Meta("alias", alias))
-        # Create new instance directly without going through __init__
         new_instance = object.__new__(type(self))
         object.__setattr__(new_instance, "base_type", self.base_type)
         object.__setattr__(new_instance, "metadata", new_metadata)
@@ -379,18 +234,9 @@ class FieldModel(Params):
         return new_instance
 
     def with_title(self, title: str) -> Self:
-        """Add a title to this field.
-
-        Args:
-            title: Human-readable title for the field
-
-        Returns:
-            New FieldModel with title
-        """
         current_metadata = () if self._is_sentinel(self.metadata) else self.metadata
         filtered_metadata = tuple(m for m in current_metadata if m.key != "title")
         new_metadata = (*filtered_metadata, Meta("title", title))
-        # Create new instance directly without going through __init__
         new_instance = object.__new__(type(self))
         object.__setattr__(new_instance, "base_type", self.base_type)
         object.__setattr__(new_instance, "metadata", new_metadata)
@@ -398,18 +244,9 @@ class FieldModel(Params):
         return new_instance
 
     def with_exclude(self, exclude: bool = True) -> Self:
-        """Mark this field to be excluded from serialization.
-
-        Args:
-            exclude: Whether to exclude the field
-
-        Returns:
-            New FieldModel with exclude setting
-        """
         current_metadata = () if self._is_sentinel(self.metadata) else self.metadata
         filtered_metadata = tuple(m for m in current_metadata if m.key != "exclude")
         new_metadata = (*filtered_metadata, Meta("exclude", exclude))
-        # Create new instance directly without going through __init__
         new_instance = object.__new__(type(self))
         object.__setattr__(new_instance, "base_type", self.base_type)
         object.__setattr__(new_instance, "metadata", new_metadata)
@@ -417,20 +254,9 @@ class FieldModel(Params):
         return new_instance
 
     def with_metadata(self, key: str, value: Any) -> Self:
-        """Add custom metadata to this field.
-
-        Args:
-            key: Metadata key
-            value: Metadata value
-
-        Returns:
-            New FieldModel with custom metadata
-        """
-        # Replace existing metadata with same key
         current_metadata = () if self._is_sentinel(self.metadata) else self.metadata
         filtered_metadata = tuple(m for m in current_metadata if m.key != key)
         new_metadata = (*filtered_metadata, Meta(key, value))
-        # Create new instance directly without going through __init__
         new_instance = object.__new__(type(self))
         object.__setattr__(new_instance, "base_type", self.base_type)
         object.__setattr__(new_instance, "metadata", new_metadata)
@@ -438,15 +264,6 @@ class FieldModel(Params):
         return new_instance
 
     def with_json_schema_extra(self, **kwargs: Any) -> Self:
-        """Add JSON schema extra information.
-
-        Args:
-            **kwargs: Key-value pairs for json_schema_extra
-
-        Returns:
-            New FieldModel with json_schema_extra
-        """
-        # Get existing json_schema_extra or create new dict
         existing = self.extract_metadata("json_schema_extra") or {}
         updated = {**existing, **kwargs}
 
@@ -456,7 +273,6 @@ class FieldModel(Params):
             *filtered_metadata,
             Meta("json_schema_extra", updated),
         )
-        # Create new instance directly without going through __init__
         new_instance = object.__new__(type(self))
         object.__setattr__(new_instance, "base_type", self.base_type)
         object.__setattr__(new_instance, "metadata", new_metadata)
@@ -464,51 +280,33 @@ class FieldModel(Params):
         return new_instance
 
     def create_field(self) -> Any:
-        """Create a Pydantic FieldInfo object from this template.
-
-        Returns:
-            A Pydantic FieldInfo object with all metadata applied
-        """
+        """Create a Pydantic FieldInfo from this template."""
         from pydantic import Field as PydanticField
 
-        # Get valid Pydantic Field parameters (cached)
         pydantic_field_params = _get_pydantic_field_params()
-
-        # Extract metadata for FieldInfo
         field_kwargs = {}
 
         if not self._is_sentinel(self.metadata):
             for meta in self.metadata:
                 if meta.key == "default":
-                    # Handle callable defaults as default_factory
                     if callable(meta.value):
                         field_kwargs["default_factory"] = meta.value
                     else:
                         field_kwargs["default"] = meta.value
                 elif meta.key == "validator":
-                    # Validators are handled separately in create_model
                     continue
                 elif meta.key in pydantic_field_params:
-                    # Pass through standard Pydantic field attributes
                     field_kwargs[meta.key] = meta.value
                 elif meta.key in {"nullable", "listable"}:
-                    # These are FieldTemplate markers, don't pass to FieldInfo
                     pass
                 else:
-                    # Filter out unserializable objects from json_schema_extra
-                    # to avoid Pydantic serialization errors when generating JSON schema
-
-                    # Skip model classes and other unserializable types
+                    # Skip type objects -- unserializable in JSON schema
                     if isinstance(meta.value, type):
-                        # Skip type objects (including model classes) - they can't be serialized
                         continue
-
-                    # Any other metadata goes in json_schema_extra
                     if "json_schema_extra" not in field_kwargs:
                         field_kwargs["json_schema_extra"] = {}
                     field_kwargs["json_schema_extra"][meta.key] = meta.value
 
-        # Handle nullable case - ensure default is set if not already
         if (
             self.is_nullable
             and "default" not in field_kwargs
@@ -517,8 +315,6 @@ class FieldModel(Params):
             field_kwargs["default"] = None
 
         field_info = PydanticField(**field_kwargs)
-
-        # Set the annotation from base_type for backward compatibility
         field_info.annotation = self.annotation
 
         return field_info
@@ -526,62 +322,37 @@ class FieldModel(Params):
     # ---- materialization -------------------------------------------------- #
 
     def annotated(self) -> type[Any]:
-        """Materialize this template into an Annotated type.
-
-        This method is cached to ensure repeated calls return the same
-        type object for performance and identity checks. The cache is bounded
-        using LRU eviction to prevent unbounded memory growth.
-
-        Returns:
-            Annotated type with all metadata attached
-        """
-        # Check cache first with thread safety
+        """Materialize into an Annotated type (LRU-cached, thread-safe)."""
         cache_key = (self.base_type, self.metadata)
 
         with _cache_lock:
             if cache_key in _annotated_cache:
-                # Move to end to mark as recently used
                 _annotated_cache.move_to_end(cache_key)
                 return _annotated_cache[cache_key]
 
-            # Handle nullable case - wrap in Optional-like union
             actual_type = Any if self._is_sentinel(self.base_type) else self.base_type
             current_metadata = () if self._is_sentinel(self.metadata) else self.metadata
 
             if any(m.key == "nullable" and m.value for m in current_metadata):
-                # Use union syntax for nullable
                 actual_type = actual_type | None  # type: ignore
 
             if current_metadata:
-                # Python 3.10 doesn't support unpacking in Annotated, so we need to build it differently
-                # We'll use Annotated.__class_getitem__ to build the type dynamically
                 args = [actual_type] + list(current_metadata)
                 result = Annotated.__class_getitem__(tuple(args))  # type: ignore
             else:
                 result = actual_type  # type: ignore[misc]
 
-            # Cache the result with LRU eviction
             _annotated_cache[cache_key] = result  # type: ignore[assignment]
 
-            # Evict oldest if cache is too large (guard against empty cache)
             while len(_annotated_cache) > _MAX_CACHE_SIZE:
                 try:
-                    _annotated_cache.popitem(last=False)  # Remove oldest
+                    _annotated_cache.popitem(last=False)
                 except KeyError:
-                    # Cache became empty during race, safe to continue
                     break
 
         return result  # type: ignore[return-value]
 
     def extract_metadata(self, key: str) -> Any:
-        """Extract metadata value by key.
-
-        Args:
-            key: Metadata key to look for
-
-        Returns:
-            Metadata value if found, None otherwise
-        """
         if not self._is_sentinel(self.metadata):
             for m in self.metadata:
                 if m.key == key:
@@ -589,24 +360,11 @@ class FieldModel(Params):
         return None
 
     def has_validator(self) -> bool:
-        """Check if this template has a validator.
-
-        Returns:
-            True if validator exists in metadata
-        """
         if self._is_sentinel(self.metadata):
             return False
         return any(m.key == "validator" for m in self.metadata)
 
     def is_valid(self, value: Any) -> bool:
-        """Check if a value is valid against all validators in this template.
-
-        Args:
-            value: Value to validate
-
-        Returns:
-            True if all validators pass, False otherwise
-        """
         if self._is_sentinel(self.metadata):
             return True
         for m in self.metadata:
@@ -617,16 +375,6 @@ class FieldModel(Params):
         return True
 
     def validate(self, value: Any, field_name: str | None = None) -> None:
-        """Validate a value against all validators, raising ValidationError on failure.
-
-        Args:
-            value: Value to validate
-            field_name: Optional field name for error context
-
-        Raises:
-            ValidationError: If any validator fails
-        """
-        # Early exit if no validators
         if not self.has_validator():
             return
 
@@ -634,16 +382,12 @@ class FieldModel(Params):
             for i, m in enumerate(self.metadata):
                 if m.key == "validator":
                     validator = m.value
-                    # Try to call validator with correct signature
                     try:
-                        # Try Pydantic-style validator (cls, value) - pass None for cls
+                        # Try Pydantic-style validator (cls, value)
                         result = validator(None, value)
-                        # For Pydantic validators that return the value or raise exceptions,
-                        # if we get here without exception, validation passed
                     except TypeError:
-                        # Try simple validator that just takes value and returns boolean
+                        # Fall back to simple validator(value) -> bool
                         result = validator(value)
-                        # If validator returns False (simple boolean validator), raise error
                         if result is False:
                             validator_name = getattr(validator, "__name__", f"validator_{i}")
                             raise ValidationError(
@@ -655,7 +399,6 @@ class FieldModel(Params):
                                 },
                             ) from None
                     except Exception:
-                        # If validator raises any other exception, let it propagate
                         raise
 
     @property
@@ -674,7 +417,6 @@ class FieldModel(Params):
 
     @override
     def __repr__(self) -> str:
-        """String representation of the field model."""
         import types
 
         attrs = []
@@ -696,21 +438,12 @@ class FieldModel(Params):
 
     @property
     def field_validator(self) -> dict[str, Any] | None:
-        """Create field validator configuration for backward compatibility.
-
-        Returns:
-            Dictionary mapping validator name to validator function if defined,
-            None otherwise.
-        """
         if not self.has_validator():
             return None
 
-        # Extract validators and create field_validator config
         from pydantic import field_validator
 
         validators = {}
-
-        # Get field name from metadata or use default
         field_name = self.extract_metadata("name") or "field"
 
         if not self._is_sentinel(self.metadata):
@@ -736,26 +469,16 @@ class FieldModel(Params):
         return t_
 
     def to_spec(self) -> Spec:
-        """Convert FieldModel to Spec.
-
-        Returns:
-            Spec object with equivalent configuration
-        """
         from ..ln.types import Spec
 
-        # Build kwargs for Spec constructor
         kwargs = {}
-
-        # Extract name from metadata
         name = self.extract_metadata("name")
         if name:
             kwargs["name"] = name
 
-        # Add nullable/listable flags using properties
         kwargs["nullable"] = self.is_nullable
         kwargs["listable"] = self.is_listable
 
-        # Extract default/default_factory
         default = self.extract_metadata("default")
         if default is not None:
             kwargs["default"] = default
@@ -764,23 +487,19 @@ class FieldModel(Params):
         if default_factory is not None:
             kwargs["default_factory"] = default_factory
 
-        # Extract validator
         validator = self.extract_metadata("validator")
         if validator is not None:
             kwargs["validator"] = validator
 
-        # Extract description
         description = self.extract_metadata("description")
         if description:
             kwargs["description"] = description
 
-        # Extract other common metadata
         for key in ["title", "alias", "frozen", "exclude"]:
             val = self.extract_metadata(key)
             if val is not None:
                 kwargs[key] = val
 
-        # Extract json_schema_extra
         json_schema_extra = self.extract_metadata("json_schema_extra")
         if json_schema_extra:
             for k, v in json_schema_extra.items():
@@ -789,18 +508,8 @@ class FieldModel(Params):
         return Spec(self.base_type, **kwargs)
 
     def metadata_dict(self, exclude: list[str] | None = None) -> dict[str, Any]:
-        """Convert all metadata to dictionary with optional exclusions.
-
-        Args:
-            exclude: List of metadata keys to exclude from the result
-
-        Returns:
-            Dictionary mapping metadata keys to their values
-        """
         result = {}
         exclude_set = set(exclude or [])
-
-        # Convert metadata to dictionary
         if not self._is_sentinel(self.metadata):
             for meta in self.metadata:
                 if meta.key not in exclude_set:

--- a/lionagi/models/operable_model.py
+++ b/lionagi/models/operable_model.py
@@ -24,30 +24,7 @@ __all__ = ("OperableModel",)
 
 
 class OperableModel(HashableModel):
-    """Base model supporting dynamic field management and operations.
-
-    A Pydantic model extension that enables runtime field modifications while
-    maintaining type safety and validation. Supports dynamic field addition,
-    updates, and removal, with full serialization capabilities.
-
-    Args:
-        **kwargs: Key-value pairs for initial field values.
-
-    Attributes:
-        extra_fields: Dictionary mapping field names to their FieldInfo
-            definitions for dynamically added fields.
-        extra_field_models: Dictionary mapping field names to their FieldModel
-            instances for fields with additional configuration.
-
-    Examples:
-        >>> class UserModel(OperableModel):
-        ...     name: str = "default"
-        ...
-        >>> user = UserModel()
-        >>> user.add_field("age", value=25, annotation=int)
-        >>> user.age
-        25
-    """
+    """Pydantic model with runtime field addition, update, and removal."""
 
     model_config = ConfigDict(
         extra="forbid",
@@ -59,13 +36,11 @@ class OperableModel(HashableModel):
 
     extra_fields: dict[str, FieldInfo] | Any = Field(
         default_factory=dict,
-        description="Dictionary of dynamically added field definitions",
         exclude=True,
     )
 
     extra_field_models: dict[str, FieldModel] = Field(
         default_factory=dict,
-        description="Dictionary of field models for dynamic fields",
         exclude=True,
     )
 
@@ -73,14 +48,6 @@ class OperableModel(HashableModel):
         self,
         value: dict[str, FieldInfo],
     ) -> dict[str, Any]:
-        """Serialize extra fields to dictionary format.
-
-        Args:
-            value: Dictionary mapping field names to their FieldInfo objects.
-
-        Returns:
-            dict[str, Any]: Serialized field values.
-        """
         output_dict = {}
         for k in value.keys():
             k_value = self.__dict__.get(k)
@@ -96,17 +63,6 @@ class OperableModel(HashableModel):
         cls,
         value: list[FieldModel] | dict[str, FieldModel | FieldInfo],
     ) -> dict[str, FieldInfo]:
-        """Validate and normalize extra field definitions.
-
-        Args:
-            value: Field definitions as list or dictionary.
-
-        Returns:
-            dict[str, FieldInfo]: Normalized field definitions.
-
-        Raises:
-            ValueError: If value format is invalid.
-        """
         out = {}
         if isinstance(value, dict):
             for k, v in value.items():
@@ -123,15 +79,9 @@ class OperableModel(HashableModel):
 
     @model_validator(mode="after")
     def _validate_extra_field_models(self) -> Self:
-        """Validate and normalize extra field models after initial validation.
-
-        Returns:
-            Self: Validated instance with normalized extra fields.
-        """
         extra_fields = {}
         extra_field_models = {}
 
-        # Handle dict[str, FieldInfo | FieldModel]
         if isinstance(self.extra_fields, dict):
             for k, v in self.extra_fields.items():
                 if isinstance(v, FieldModel):
@@ -140,15 +90,12 @@ class OperableModel(HashableModel):
                 elif isinstance(v, FieldInfo):
                     extra_fields[k] = v
 
-        # Handle list input
         elif isinstance(self.extra_fields, list):
             for v in self.extra_fields:
-                # list[FieldModel]
                 if isinstance(v, FieldModel):
                     extra_fields[v.name] = v.create_field()
                     extra_field_models[v.name] = v
 
-                # Handle list[tuple[str, FieldInfo | FieldModel]]
                 if isinstance(v, tuple) and len(v) == 2:
                     if isinstance(v[0], str):
                         if isinstance(v[1], FieldInfo):
@@ -163,36 +110,12 @@ class OperableModel(HashableModel):
 
     @override
     def __getattr__(self, field_name: str) -> Any:
-        """Get attribute value with metadata tracking.
-
-        Args:
-            field_name: Name of the field to get
-
-        Returns:
-            Field value
-
-        Raises:
-            AttributeError: If field not found
-        """
         if field_name == "extra_field" or field_name in self.all_fields:
             return self.__dict__.get(field_name, UNDEFINED)
         raise AttributeError(f"Field {field_name} not found in object fields.")
 
     @override
     def __setattr__(self, field_name: str, value: Any) -> None:
-        """Set attribute value with metadata tracking.
-
-        This method prevents direct assignment to metadata and extra_fields,
-        and tracks the last update time of modified fields.
-
-        Args:
-            field_name: Name of the field to set
-            value: Value to set
-
-        Raises:
-            AttributeError: If attempting to directly assign to metadata or
-                extra_fields
-        """
         if not callable(value) and field_name.startswith("__"):
             raise AttributeError("Cannot directly assign to dunder fields")
 
@@ -200,7 +123,6 @@ class OperableModel(HashableModel):
             field_name in self.extra_field_models
             and self.extra_field_models[field_name].has_validator()
         ):
-            # Use the validate method to check value - let validation errors propagate
             self.extra_field_models[field_name].validate(value, field_name)
         if field_name in self.extra_fields:
             object.__setattr__(self, field_name, value)
@@ -208,15 +130,6 @@ class OperableModel(HashableModel):
             super().__setattr__(field_name, value)
 
     def __delattr__(self, field_name):
-        """Delete an attribute from the model.
-
-        For extra fields, attempts to reset to default value if one exists,
-        otherwise removes the field completely. For regular fields, delegates
-        to parent class deletion behavior.
-
-        Args:
-            field_name: Name of the field to delete.
-        """
         if field_name in self.extra_fields:
             if self.extra_fields[field_name].default not in [
                 UNDEFINED,
@@ -236,14 +149,6 @@ class OperableModel(HashableModel):
 
     @override
     def to_dict(self) -> dict:
-        """Convert model to dictionary including extra fields.
-
-        Args:
-            clean: If True, exclude UNDEFINED values
-
-        Returns:
-            Dictionary containing all fields and their values
-        """
         dict_ = self.model_dump()
         dict_.update(self._serialize_extra_fields(self.extra_fields))
         logger.debug("OperableModel.to_dict(): %s", dict_)
@@ -251,15 +156,9 @@ class OperableModel(HashableModel):
 
     @property
     def all_fields(self) -> dict[str, FieldInfo]:
-        """Get all fields including model fields and extra fields.
-
-        Returns:
-            Dictionary mapping field names to FieldInfo objects,
-            excluding the extra_fields field itself
-        """
         a = {**type(self).model_fields, **self.extra_fields}
         a.pop("extra_fields", None)
-        a.pop("extra_field_models", None)  # Exclude internal field tracking
+        a.pop("extra_field_models", None)
         return a
 
     def add_field(
@@ -272,19 +171,6 @@ class OperableModel(HashableModel):
         field_model: FieldModel = UNDEFINED,
         **kwargs,
     ) -> None:
-        """Add a new field to the model's extra fields.
-
-        Args:
-            field_name: Name of the field to add
-            value: Field value
-            annotation: Type annotation
-            field_obj: Pre-configured FieldInfo object
-            field_model: Pre-configured FieldModel object
-            **kwargs: Additional field configuration
-
-        Raises:
-            ValueError: If field already exists or invalid configuration
-        """
         if field_name in self.all_fields:
             raise ValueError(f"Field '{field_name}' already exists")
 
@@ -307,19 +193,6 @@ class OperableModel(HashableModel):
         field_model: FieldModel = UNDEFINED,
         **kwargs,
     ) -> None:
-        """Update existing field or create new one.
-
-        Args:
-            field_name: Name of field to update
-            value: New field value
-            annotation: Type annotation
-            field_obj: Pre-configured FieldInfo object
-            field_model: Pre-configured FieldModel object
-            **kwargs: Additional field configuration
-
-        Raises:
-            ValueError: If invalid configuration provided
-        """
         if "default" in kwargs and "default_factory" in kwargs:
             raise ValueError(
                 "Cannot provide both 'default' and 'default_factory'",
@@ -330,7 +203,6 @@ class OperableModel(HashableModel):
                 "Cannot provide both 'field_obj' and 'field_model'",
             )
 
-        # Handle field_obj
         if field_obj:
             if not isinstance(field_obj, FieldInfo):
                 raise ValueError("Invalid field_obj, should be a pydantic FieldInfo object")
@@ -342,9 +214,8 @@ class OperableModel(HashableModel):
             self.extra_fields[field_name] = field_model.create_field()
             self.extra_field_models[field_name] = field_model
 
-        # Handle kwargs
         if kwargs:
-            if field_name in self.all_fields:  # existing field
+            if field_name in self.all_fields:
                 for k, v in kwargs.items():
                     self.field_setattr(field_name, k, v)
             else:
@@ -355,20 +226,17 @@ class OperableModel(HashableModel):
                 }
                 self.extra_fields[field_name] = Field(**_kwargs)
 
-        # Handle no explicit defined field
         if not field_obj and not kwargs:
             if field_name not in self.all_fields:
                 self.extra_fields[field_name] = Field()
 
         field_obj = self.extra_fields[field_name]
 
-        # Handle annotation
         if annotation is not None:
             field_obj.annotation = annotation
         if not field_obj.annotation:
             field_obj.annotation = Any
 
-        # Handle value
         if value is UNDEFINED:
             if field_name in self.all_fields:
                 if self.__dict__.get(field_name, UNDEFINED) is not UNDEFINED:
@@ -395,16 +263,6 @@ class OperableModel(HashableModel):
         value: Any,
         /,
     ) -> None:
-        """Set attribute value for a field.
-
-        Args:
-            field_name: Name of field to modify
-            attr: Name of attribute to set
-            value: Value to set
-
-        Raises:
-            KeyError: If field not found
-        """
         all_fields = self.all_fields
         if field_name not in all_fields:
             raise KeyError(f"Field {field_name} not found in object fields.")
@@ -422,18 +280,6 @@ class OperableModel(HashableModel):
         attr: str,
         /,
     ) -> bool:
-        """Check if field has specific attribute.
-
-        Args:
-            field_name: Name of field to check
-            attr: Name of attribute to check
-
-        Returns:
-            True if attribute exists, False otherwise
-
-        Raises:
-            KeyError: If field not found
-        """
         all_fields = self.all_fields
         if field_name not in all_fields:
             raise KeyError(f"Field {field_name} not found in object fields.")
@@ -441,8 +287,6 @@ class OperableModel(HashableModel):
         if hasattr(field_obj, attr):
             return True
         elif isinstance(field_obj.json_schema_extra, dict):
-            # json_schema_extra stores custom attributes set via field_setattr;
-            # check for the requested *attr* name, not the field name.
             if attr in field_obj.json_schema_extra:
                 return True
         return False
@@ -454,20 +298,6 @@ class OperableModel(HashableModel):
         default: Any = UNDEFINED,
         /,
     ) -> Any:
-        """Get attribute value for a field.
-
-        Args:
-            field_name: Name of field to access
-            attr: Name of attribute to get
-            default: Default value if attribute not found
-
-        Returns:
-            Attribute value
-
-        Raises:
-            KeyError: If field not found
-            AttributeError: If attribute not found and no default
-        """
         all_fields = self.all_fields
 
         if field_name not in all_fields:
@@ -478,7 +308,6 @@ class OperableModel(HashableModel):
 
         field_obj = all_fields[field_name]
 
-        # Check fieldinfo attr
         value = getattr(field_obj, attr, UNDEFINED)
         if value is not UNDEFINED:
             return value
@@ -488,7 +317,6 @@ class OperableModel(HashableModel):
                 if value is not UNDEFINED:
                     return value
 
-        # Handle undefined attr
         if default is not UNDEFINED:
             return default
         else:
@@ -499,8 +327,8 @@ class OperableModel(HashableModel):
     def new_model(
         self,
         name: str | None = None,
-        use_fields: set[str] | None = None,  # default is all_fields
-        base_type: type[BaseModel] | None = None,  # default is BaseModel
+        use_fields: set[str] | None = None,
+        base_type: type[BaseModel] | None = None,
         exclude_fields: list = None,
         inherit_base: bool = True,
         config_dict: ConfigDict | dict | None = None,
@@ -508,47 +336,7 @@ class OperableModel(HashableModel):
         frozen: bool = False,
         update_forward_refs: bool = True,
     ) -> type[BaseModel]:
-        """Create a new Pydantic model type from the current model's fields.
-
-        Generates a new model class using the specified fields and configuration.
-        The new model can inherit from a base type and include a subset of fields
-        from the current model.
-
-        Args:
-            name: Name for the new model class. If None, a default name will be
-                generated.
-            use_fields: Set of field names to include in the new model. If None,
-                includes all fields.
-            base_type: Base model class to inherit from. Defaults to BaseModel
-                if None.
-            exclude_fields: List of field names to exclude from the new model.
-            inherit_base: Whether to inherit fields from the base_type.
-                Defaults to True.
-            config_dict: Pydantic model configuration for the new model.
-            doc: Docstring for the new model class.
-            frozen: If True, creates an immutable model where fields cannot be
-                modified after creation. Defaults to False.
-            update_forward_refs: Whether to attempt updating forward references
-                in the new model. Defaults to True.
-
-        Returns:
-            A new Pydantic model class with the specified configuration.
-
-        Raises:
-            ValueError: If use_fields contains invalid field names.
-
-        Examples:
-            >>> model = OperableModel()
-            >>> model.add_field("name", value="test", annotation=str)
-            >>> model.add_field("age", value=25, annotation=int)
-            >>> NewModel = model.new_model(
-            ...     name="UserModel",
-            ...     use_fields={"name", "age"},
-            ...     frozen=True
-            ... )
-            >>> user = NewModel(name="Alice", age=30)
-        """
-
+        """Create a new Pydantic model type from this model's fields."""
         use_fields = set(use_fields) if use_fields else set(self.all_fields.keys())
         if not use_fields.issubset(self.all_fields.keys()):
             raise ValueError("Invalid field names in use_fields")
@@ -575,10 +363,8 @@ class OperableModel(HashableModel):
         )
         model_cls = model_params.create_new_model()
 
-        # Update forward references if requested. model_rebuild() can raise
-        # PydanticUserError when referenced types are not yet defined (e.g.
-        # mutually-recursive models built incrementally). Log and continue so
-        # that the partially-built model is still returned to the caller.
+        # model_rebuild() can raise PydanticUserError when referenced types
+        # are not yet defined; log and continue so the model is still returned.
         if update_forward_refs:
             try:
                 model_cls.model_rebuild()


### PR DESCRIPTION
## Summary
- Trimmed ~1,546 lines from 10 files: FieldModel, OperableModel, Spec, SSRF, concurrency, fuzzy, validate
- SSRF security essay condensed to 5 lines preserving WHY constraints
- SIGINT handler rationale condensed from 30 lines to 3

## Test plan
- [x] `uv run ruff check` — clean
- [x] `uv run pytest --co` — all tests collect

🤖 Generated with [Claude Code](https://claude.com/claude-code)