### PR TITLE
chore: strip excessive docstrings from studio/state/misc modules

### DIFF
--- a/lionagi/casts/emission.py
+++ b/lionagi/casts/emission.py
@@ -1,11 +1,7 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Emission contracts — the typed payloads a role PRODUCES (behavior, not authority).
-
-Composed by union, no security semantics. Field descriptions flow into the
-output JSON schema, so write them as agent-facing guidance.
-"""
+"""Emission contracts — typed payloads a role produces."""
 
 from __future__ import annotations
 
@@ -16,9 +12,6 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from lionagi.ln.types import Operable, Spec
 
-# Allowlist of branch operations that a model-emitted SpawnRequest may name.
-# Updating this set requires a deliberate review — do not expand it lightly.
-# See ADR note in orchestration/patterns.py:role_node_builder for context.
 _SPAWN_ALLOWED_OPERATIONS: frozenset[str] = frozenset({"operate", "chat", "communicate", "ReAct"})
 
 __all__ = (
@@ -62,12 +55,7 @@ __all__ = (
 
 
 class _EmissionModel(BaseModel):
-    """Private base for all emission contracts.
-
-    ``extra='forbid'`` rejects unknown keys from model output at validation
-    time, making malformed or over-broad emissions visible to tests and
-    observers rather than silently discarded.
-    """
+    """Private base for all emission contracts; extra='forbid'."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -424,9 +412,7 @@ class EscalationRequest(_EmissionModel):
 
 
 class SpawnRequest(_EmissionModel):
-    """Add a new operation to the RUNNING workflow — emit when work beyond the
-    current plan is discovered. Grows the live DAG without halting it (reactive
-    self-expansion). The emitting node becomes the new op's upstream by default."""
+    """Request to add a new operation to the running workflow."""
 
     instruction: str = Field(
         description="The new unit of work, stated as a concrete, self-contained objective."
@@ -459,19 +445,13 @@ _CAMEL_RE = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
 
 
 def _field_name(model: type[BaseModel]) -> str:
-    """CamelCase model class name -> snake_case Spec name."""
     return _CAMEL_RE.sub("_", model.__name__).lower()
 
 
 def build_emission_operable(
     emits: tuple[type[BaseModel], ...], /, *, name: str = "emissions"
 ) -> Operable | None:
-    """Build an :class:`Operable` from an emission tuple.
-
-    Returns ``None`` when *emits* is empty (the role declares no structured
-    emission contract). For a non-empty contract, ``EscalationRequest`` is
-    always appended — any role that emits anything may also escalate.
-    """
+    """Build an Operable from an emission tuple; returns None if empty."""
     models = tuple(emits)
     if not models:
         return None

--- a/lionagi/config.py
+++ b/lionagi/config.py
@@ -8,8 +8,6 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class CacheConfig(BaseModel):
-    """Configuration for aiocache."""
-
     ttl: int = 300
     key: str | None = None
     namespace: str | None = None
@@ -21,12 +19,7 @@ class CacheConfig(BaseModel):
     noself: Any = lambda _: False
 
     def as_kwargs(self) -> dict[str, Any]:
-        """Convert config to kwargs dict for @cached decorator.
-
-        Removes unserialisable callables that aiocache can't pickle.
-        """
         raw = self.model_dump(exclude_none=True)
-        # Remove all unserialisable callables
         unserialisable_keys = (
             "key_builder",
             "skip_cache_func",
@@ -40,8 +33,6 @@ class CacheConfig(BaseModel):
 
 
 class AppSettings(BaseSettings, frozen=True):
-    """Application settings with environment variable support."""
-
     model_config = SettingsConfigDict(
         env_file=(".env", ".env.local", ".secrets.env"),
         env_file_encoding="utf-8",
@@ -53,7 +44,6 @@ class AppSettings(BaseSettings, frozen=True):
         default_factory=CacheConfig, description="Cache settings for aiocache"
     )
 
-    # secrets
     OPENAI_API_KEY: SecretStr | None = None
     OPENROUTER_API_KEY: SecretStr | None = None
     OLLAMA_API_KEY: SecretStr | None = None
@@ -69,24 +59,20 @@ class AppSettings(BaseSettings, frozen=True):
 
     OPENAI_DEFAULT_MODEL: str = "gpt-4.1-mini"
 
-    # defaults models
     LIONAGI_EMBEDDING_PROVIDER: str = "openai"
     LIONAGI_EMBEDDING_MODEL: str = "text-embedding-3-small"
 
     LIONAGI_CHAT_PROVIDER: str = "openai"
     LIONAGI_CHAT_MODEL: str = "gpt-4.1-mini"
 
-    # default storage
     LIONAGI_AUTO_STORE_EVENT: bool = False
     LIONAGI_STORAGE_PROVIDER: str = "async_qdrant"
 
     LIONAGI_AUTO_EMBED_LOG: bool = False
 
-    # specific storage
     LIONAGI_QDRANT_URL: str = "http://localhost:6333"
     LIONAGI_DEFAULT_QDRANT_COLLECTION: str = "event_logs"
 
-    # Log configuration
     LOG_PERSIST_DIR: str = "./data/logs"
     LOG_SUBFOLDER: str | None = None
     LOG_CAPACITY: int = 50
@@ -97,23 +83,9 @@ class AppSettings(BaseSettings, frozen=True):
     LOG_AUTO_SAVE_ON_EXIT: bool = True
     LOG_CLEAR_AFTER_DUMP: bool = True
 
-    # Class variable to store the singleton instance
     _instance: ClassVar[Any] = None
 
     def get_secret(self, key_name: str) -> str:
-        """
-        Get the secret value for a given key name.
-
-        Args:
-            key_name: The name of the secret key (e.g., "OPENAI_API_KEY")
-
-        Returns:
-            The secret value as a string
-
-        Raises:
-            AttributeError: If the key doesn't exist
-            ValueError: If the key exists but is None
-        """
         if not hasattr(self, key_name):
             if "ollama" in key_name.lower():
                 return "ollama"
@@ -121,7 +93,6 @@ class AppSettings(BaseSettings, frozen=True):
 
         secret = getattr(self, key_name)
         if secret is None:
-            # Special case for Ollama - return "ollama" even if key exists but is None
             if "ollama" in key_name.lower():
                 return "ollama"
             raise ValueError(f"Secret key '{key_name}' is not set")
@@ -133,7 +104,6 @@ class AppSettings(BaseSettings, frozen=True):
 
     @property
     def LOG_CONFIG(self) -> dict[str, Any]:
-        """Get LOG configuration dict compatible with old Settings.Config.LOG format."""
         return {
             "persist_dir": self.LOG_PERSIST_DIR,
             "subfolder": self.LOG_SUBFOLDER,
@@ -147,7 +117,5 @@ class AppSettings(BaseSettings, frozen=True):
         }
 
 
-# Create a singleton instance
 settings = AppSettings()
-# Store the instance in the class variable for singleton pattern
 AppSettings._instance = settings

--- a/lionagi/engines/engine.py
+++ b/lionagi/engines/engine.py
@@ -1,22 +1,7 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Generic event-driven multi-agent engine over a lionagi Session (ADR-0075).
-
-Two objects, cleanly split:
-
-- ``Engine`` — STATELESS config + reaction *logic*. Holds no session and no
-  run-state, so one engine is reusable and runs many tasks (even concurrently).
-- ``EngineRun`` — the per-``run()`` context: the ``Session``, dedup/active-task
-  state, and the *operations* (emit, observe, by_type, make_agent, spawn,
-  run_team, wait_quiescence). The session is the *run's* state, not the engine's.
-
-``run(input, session=None)`` makes a fresh ``EngineRun`` (fresh session by
-default; pass one to continue/share a conversation or memory). Agents emit
-Observable domain events; the engine's observers react — exactly the
-reactive-capability-bus path the DAG flow uses for ``SpawnRequest``, generalized
-to any domain event.
-"""
+"""Event-driven multi-agent engine: stateless Engine + per-run EngineRun."""
 
 from __future__ import annotations
 
@@ -43,15 +28,7 @@ EventCallback = Callable[[dict[str, Any]], Any]
 
 
 class EngineEvent(BaseModel):
-    """Base for engine-only domain events — those with no casts-emission twin.
-
-    A plain payload (e.g. :class:`~lionagi.engines.research.DepthRequested`). It
-    needs no ``id`` of its own: ``session.emit`` envelopes any non-Observable
-    payload in a :class:`~lionagi.session.signal.Signal`, so the emission store
-    is uniformly ``Pile[Signal(data=event)]``. Events that DO have a casts twin
-    subclass the emission directly (``FindingEmitted(Finding)``) and reuse its
-    fields; observers key off the concrete subclass type either way.
-    """
+    """Base for engine-only domain events with no casts-emission twin."""
 
 
 def _event_dict(event: Any) -> dict[str, Any]:
@@ -64,13 +41,7 @@ def _event_dict(event: Any) -> dict[str, Any]:
 
 
 class EngineRun:
-    """One run's context: session + state + operations.
-
-    Created per :meth:`Engine.run`. Owns the session, the dedup set, the
-    in-flight task set, and the concurrency limiter — so concurrent runs of the
-    same engine never collide. All the agent/event/recursion operations live
-    here because they need this per-run state.
-    """
+    """Per-run context: session, dedup set, in-flight tasks, concurrency limiter."""
 
     def __init__(
         self,
@@ -87,21 +58,11 @@ class EngineRun:
         self._pending: deque = deque()
         self._seen: set[str] = set()
 
-    # -- event store (the reactive emission store) ----------------------------
-
     @property
     def events(self) -> Pile:
-        """The Pile of emitted domain events — query it: ``run.events[Finding]``."""
         return self.session.observer.flow.items
 
     def by_type(self, event_type: type) -> list[Any]:
-        """Domain-event payloads of ``event_type`` from the store.
-
-        Domain events ride the bus inside a ``Signal`` — added by ``emit`` for a
-        plain payload, or by ``operate`` for an agent exercising a grant — so
-        this unwraps the envelope to its ``data``. A bare Observable whose own
-        type matches (a lifecycle ``Signal``) is returned as-is.
-        """
         out: list[Any] = []
         for e in self.session.observer.by_type(event_type):
             data = getattr(e, "data", None)
@@ -109,33 +70,23 @@ class EngineRun:
         return out
 
     async def emit(self, event: Any) -> list[Any]:
-        """Emit a domain event onto the bus (observers fire) and stream it."""
         results = await self.session.emit(event)
         self.notify(type(event).__name__, **_event_dict(event))
         return results
 
     def observe(self, *keys: Any, handler: Any = None, role: str | None = None) -> Any:
-        """Register a reaction. Sugar over ``session.observe``; usable as a decorator.
-
-        Accepts one or more AND-composed conditions (type, Filter, or
-        ``EventStatus``), with the handler positional/keyword/decorated."""
         return self.session.observe(*keys, handler=handler, role=role)
 
     def notify(self, kind: str, **data: Any) -> None:
         if self.on_event:
             self.on_event({"type": kind, **data})
 
-    # -- dedup ----------------------------------------------------------------
-
     def seen(self, key: str) -> bool:
-        """Return True if *key* (normalized) was seen before; otherwise mark + False."""
         norm = key.strip().lower()
         if norm in self._seen:
             return True
         self._seen.add(norm)
         return False
-
-    # -- agent construction (casts) -------------------------------------------
 
     async def make_agent(
         self,
@@ -147,7 +98,6 @@ class EngineRun:
         tools: tuple[str, ...] = (),
         emits: tuple[type, ...] = (),
     ) -> Branch:
-        """Build a casts-role agent, join it to the session, grant it emissions."""
         spec = AgentSpec.compose(
             role, modes=modes, model=model or self.engine.model, tools=tuple(tools)
         )
@@ -161,10 +111,7 @@ class EngineRun:
                 branch.grant_capabilities(op)
         return branch
 
-    # -- bounded recursion / quiescence ---------------------------------------
-
     def spawn(self, coro: Any) -> asyncio.Task | None:
-        """Schedule a coroutine as a tracked background task (for recursion)."""
         try:
             task = asyncio.ensure_future(coro)
         except RuntimeError:
@@ -182,12 +129,7 @@ class EngineRun:
             task.add_done_callback(self._active.discard)
 
     async def cancel_active(self) -> None:
-        """Cancel every in-flight spawned task and wait for it to finish.
-
-        Used when the primary pipeline fails so that no background task (e.g. a
-        verifier spawned just before the failure) outlives the run and keeps
-        mutating shared state.
-        """
+        """Cancel all in-flight spawned tasks and await completion."""
         if not self._active:
             return
         for t in list(self._active):
@@ -197,18 +139,7 @@ class EngineRun:
         self._active.clear()
 
     async def wait_quiescence(self) -> None:
-        """Block until no spawned task remains, then surface any task failures.
-
-        Drains the *entire* in-flight set before returning or raising — including
-        tasks that a spawned task itself spawns while we wait (a parent may fail
-        after scheduling a child). Errors are accumulated across every drain pass
-        and only re-raised once ``_active`` is empty, so a failed task can never
-        short-circuit the wait and leave its children running in the background.
-        Non-cancellation exceptions are re-raised together as an
-        ``ExceptionGroup`` (Python 3.11+) or the first exception on 3.10.
-        CancelledError from individual tasks is silently discarded — the whole
-        run is not cancelled when a single exploration branch is cancelled.
-        """
+        """Block until no spawned task remains; re-raise accumulated failures."""
         task_errors: list[BaseException] = []
         while self._active:
             results = await asyncio.gather(*list(self._active), return_exceptions=True)
@@ -220,15 +151,12 @@ class EngineRun:
         if task_errors:
             for exc in task_errors:
                 logger.error("engine spawned task failed: %s", exc)
-            # Re-raise: ExceptionGroup on 3.11+, first exception on 3.10.
             import sys
 
             if sys.version_info >= (3, 11):
                 raise ExceptionGroup("engine spawned task(s) failed", task_errors)  # type: ignore[name-defined]  # noqa: F821
             else:
                 raise task_errors[0] from None
-
-    # -- team loop ------------------------------------------------------------
 
     async def run_team(
         self,
@@ -237,14 +165,7 @@ class EngineRun:
         *,
         carry_instruction: bool = False,
     ) -> str:
-        """Run ``team`` agents in sequence, each building on the prior output.
-
-        The first agent gets ``instruction``; later agents get the prior reply
-        (and, when ``carry_instruction``, the original instruction too — useful
-        when the instruction *is* the artifact under analysis, e.g. review).
-        Each agent's emissions hit the bus mid-turn, so observers may spawn more
-        work while the team runs. Returns the last reply text.
-        """
+        """Run agents in sequence, each building on the prior output."""
         last = ""
         for i, branch in enumerate(team):
             if i == 0:
@@ -267,8 +188,6 @@ class EngineRun:
             self.drain_pending()
         return last
 
-    # -- DAG execution --------------------------------------------------------
-
     async def run_dag(
         self,
         graph: Any,
@@ -280,18 +199,7 @@ class EngineRun:
         max_concurrent: int = 5,
         verbose: bool = False,
     ) -> dict[str, Any]:
-        """Execute a prebuilt operation DAG on the run's session.
-
-        The complement to :meth:`run_team`: where ``run_team`` sequences a
-        roster, ``run_dag`` runs a dependency graph through the reactive
-        executor — the second of the two execution shapes (ADR-0075 §4). As each
-        node starts/finishes it emits a ``NodeStarted`` / ``NodeCompleted`` /
-        ``NodeFailed`` onto the bus, so persistence, Studio segments, and
-        progress display subscribe via ``observe`` instead of a bespoke
-        ``on_progress`` callback. With ``reactive`` a worker may emit a
-        ``spawn_type`` payload to grow the live DAG (``node_builder`` turns it
-        into a node). Returns the ``session.flow`` result dict.
-        """
+        """Execute a prebuilt operation DAG on the run's session."""
         emits: list[asyncio.Future] = []
 
         def _on_progress(op_id: str, name: str, status: str, elapsed: float) -> None:
@@ -326,21 +234,7 @@ class EngineRun:
 
 
 class Engine:
-    """Stateless event-driven engine base — config + reaction logic.
-
-    Holds no session and no run-state; one instance is reusable and may run many
-    tasks concurrently. Subclasses define the domain: which agents, what events,
-    which observers react, and the pipeline in ``_run``.
-
-    Parameters
-    ----------
-    model
-        Default model spec for agents that don't pin their own.
-    max_depth
-        Hard cap on recursive expansion depth (subclasses enforce via ``depth``).
-    max_concurrent
-        Max concurrently-running spawned tasks, per run.
-    """
+    """Stateless event-driven engine base; subclasses implement _run()."""
 
     run_context_cls: type[EngineRun] = EngineRun
 
@@ -361,7 +255,6 @@ class Engine:
         session: Session | None = None,
         on_event: EventCallback | None = None,
     ) -> EngineRun:
-        """Create a fresh per-run context (fresh session unless one is passed)."""
         return self.run_context_cls(self, session=session, on_event=on_event)
 
     async def run(
@@ -371,10 +264,8 @@ class Engine:
         on_event: EventCallback | None = None,
         **kwargs: Any,
     ) -> Any:
-        """Execute the pipeline in a fresh run context. Returns the engine's result."""
         run = self.new_run(session=session, on_event=on_event)
         return await self._run(run, *args, **kwargs)
 
     async def _run(self, run: EngineRun, *args: Any, **kwargs: Any) -> Any:
-        """The pipeline lifecycle, operating on a per-run context. Subclass implements."""
         raise NotImplementedError("Engine subclass must implement _run(run, ...)")

--- a/lionagi/hooks/bus.py
+++ b/lionagi/hooks/bus.py
@@ -1,25 +1,6 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
-"""ADR-0023: HookBus + HookPoint vocabulary.
-
-The bus is intentionally minimal. Handlers register against a
-:class:`HookPoint`, the bus dispatches sequentially, and a handler
-exception is logged but never aborts the user-facing operation. The one
-exception is :class:`StopHook`, which the handler may raise to short-
-circuit subsequent handlers on the same point (but still doesn't fail
-the surrounding operation).
-
-Isolation invariants (enforced by convention, not code):
-
-* Handlers MUST NOT mutate the kwargs they receive — pass-by-reference
-  observers only.
-* DB-writing handlers MUST be tolerant of in-flight failure (the bus
-  keeps going).
-* ``TOOL_PRE`` is the one hook point where a handler may legitimately
-  raise to block the underlying operation (e.g., destructive-command
-  guard). The bus enforces this via :meth:`HookBus.blocking_emit`, which
-  propagates handler exceptions to the caller instead of swallowing them.
-"""
+"""HookBus and HookPoint vocabulary for session lifecycle hooks."""
 
 from __future__ import annotations
 
@@ -49,110 +30,56 @@ __all__ = (
 
 
 class HookPoint(str, Enum):
-    """ADR-0023 §"Event payloads" — closed vocabulary of hook points."""
+    """Closed vocabulary of hook points."""
 
-    # Session lifecycle
     SESSION_START = "session.start"
     SESSION_END = "session.end"
 
-    # Branch lifecycle
     BRANCH_CREATE = "branch.create"
-
-    # iModel (API calls)
     API_PRE_CALL = "api.pre_call"
     API_POST_CALL = "api.post_call"
     API_STREAM_CHUNK = "api.stream_chunk"
-
-    # Tool execution
     TOOL_PRE = "tool.pre"
     TOOL_POST = "tool.post"
     TOOL_ERROR = "tool.error"
-
-    # Message lifecycle
     MESSAGE_ADD = "message.add"
-
-    # Artifact production (ADR-0021)
     ARTIFACT_CREATED = "artifact.created"
 
 
-# HookHandler accepts both sync and async callables.  The bus calls the
-# handler and awaits the result only if inspect.isawaitable() returns True
-# (see HookBus.emit).  The type reflects the actual contract; narrowing to
-# Awaitable[Any] only would produce false type errors for sync handlers that
-# are tested and supported.
 HookHandler = Callable[..., Awaitable[Any] | Any]
 
 
 class StopHook(Exception):  # noqa: N818 — control-flow signal, not an error
-    """Raised by a handler to skip remaining handlers on this point.
-
-    Does NOT abort the underlying operation — only stops the bus from
-    invoking later handlers for the same emit call. Named without the
-    ``Error`` suffix on purpose: this is the StopIteration-style control
-    flow signal of the hook bus, not a failure indication.
-    """
+    """Raised by a handler to skip remaining handlers on this point."""
 
 
 class HookSignal(Signal):
-    """A HookBus emission recorded on the observer transport (ADR-0076).
-
-    Carries the named :class:`HookPoint` and the loose ``kwargs`` the
-    handlers receive. When a :class:`HookBus` is bound to a session's
-    observer, every ``emit`` / ``blocking_emit`` records one of these onto
-    the observer's ``Flow`` — so hook activity lives on the single event
-    bus and reactive observers may subscribe with ``observe(HookSignal)``.
-    The ordered, short-circuiting handler chain is still dispatched by the
-    bus itself; this envelope is the *record*, not the dispatcher.
-    """
+    """A HookBus emission recorded on the observer transport."""
 
     point: HookPoint | None = None
     kwargs: dict[str, Any] = Field(default_factory=dict)
 
 
 def _normalize_point(point: HookPoint | str) -> HookPoint:
-    """Coerce ``point`` to a :class:`HookPoint`, raising ``ValueError`` for unknowns."""
     if isinstance(point, HookPoint):
         return point
     return HookPoint(point)  # raises ValueError for unknown values
 
 
 class HookBus:
-    """Per-session pub/sub bus for the eleven :class:`HookPoint` events.
-
-    Handlers are dispatched sequentially in registration order. A handler
-    raising any exception other than :class:`StopHook` is logged and
-    skipped — the user-facing operation is never blocked. This trades
-    strict error propagation for the operational invariant that
-    persistence side-effects must never break the agent loop.
-
-    ``TOOL_PRE`` is the exception: emit() routes it through
-    :meth:`blocking_emit` so that a guard handler raising (e.g.
-    ``PermissionError``) actually blocks the tool call.
-    """
+    """Per-session pub/sub bus for HookPoint events."""
 
     def __init__(self, observer: SessionObserver | None = None) -> None:
         self._handlers: dict[HookPoint, list[HookHandler]] = {}
-        # The shared event transport (ADR-0076). When set, every emit records
-        # a HookSignal here so hook activity lives on the one bus. Optional:
-        # an unbound HookBus dispatches exactly as before, recording nothing.
         self._observer = observer
 
     def bind(self, observer: SessionObserver | None) -> HookBus:
-        """Bind (or unbind, with ``None``) this bus to a session's observer.
-
-        Returns ``self`` for chaining. The observer is the shared transport
-        onto which emissions are recorded; binding does not change dispatch.
-        """
+        """Bind (or unbind) this bus to a session's observer. Returns self."""
         self._observer = observer
         return self
 
     async def _record(self, point: HookPoint, kwargs: dict[str, Any]) -> None:
-        """Record this emission onto the bound observer transport, if any.
-
-        Best-effort and isolated: a transport failure must never turn a
-        successful hook dispatch into a failure. Runs *after* the ordered
-        chain so dispatch / blocking semantics are unchanged.
-        """
+        """Best-effort record onto the bound observer transport."""
         if self._observer is None:
             return
         try:
@@ -161,42 +88,21 @@ class HookBus:
             logger.exception("HookSignal record failed: %s", point.value)
 
     def on(self, point: HookPoint | str, handler: HookHandler) -> None:
-        """Register ``handler`` to fire on ``point``. Order preserved.
-
-        Accepts a string hook-point value (e.g. ``"session.start"``) and
-        normalises it to a :class:`HookPoint`. Raises ``ValueError`` for
-        unrecognised strings.
-        """
         point = _normalize_point(point)
         self._handlers.setdefault(point, []).append(handler)
 
     def off(self, point: HookPoint | str, handler: HookHandler) -> None:
-        """Unregister ``handler``. No-op if not registered."""
         point = _normalize_point(point)
         handlers = self._handlers.get(point, [])
         if handler in handlers:
             handlers.remove(handler)
 
     def handlers_for(self, point: HookPoint | str) -> list[HookHandler]:
-        """Public read of the registered handlers for ``point``.
-
-        Useful for testing / introspection. Returns a shallow copy so
-        callers can't mutate the bus by mutating the returned list.
-        """
         point = _normalize_point(point)
         return list(self._handlers.get(point, []))
 
     async def blocking_emit(self, point: HookPoint | str, /, **kwargs: Any) -> None:
-        """Fire all handlers for ``point``, propagating exceptions.
-
-        Unlike :meth:`emit`, handler exceptions are NOT swallowed —
-        they propagate to the caller. Intended for ``TOOL_PRE`` where a
-        guard handler raising ``PermissionError`` (or similar) should
-        actually abort the tool call.
-
-        :class:`StopHook` still short-circuits remaining handlers without
-        propagating as an error.
-        """
+        """Fire handlers, propagating exceptions (used for TOOL_PRE guards)."""
         point = _normalize_point(point)
         handlers = list(self._handlers.get(point, []))
         for handler in handlers:
@@ -205,36 +111,23 @@ class HookBus:
                 if inspect.isawaitable(result):
                     await result
             except StopHook:
-                break  # stop remaining handlers, but still record below
-            # All other exceptions propagate — no except clause here. A
-            # propagated (blocking) exception skips the record; deny-audit
-            # arrives with the real pre-invoke gate (ADR-0076 Follow-up 1).
+                break
         await self._record(point, kwargs)
 
     async def emit(self, point: HookPoint | str, /, **kwargs: Any) -> None:
-        """Fire all handlers for ``point`` sequentially with ``kwargs``.
-
-        Handler exceptions are logged + swallowed. ``StopHook`` short-
-        circuits remaining handlers on this point only.
-
-        ``TOOL_PRE`` is routed through :meth:`blocking_emit` so guard
-        handlers can block the operation by raising.
-        """
+        """Fire handlers sequentially; exceptions logged, not propagated."""
         point = _normalize_point(point)
         if point is HookPoint.TOOL_PRE:
-            await self.blocking_emit(point, **kwargs)  # records inside
+            await self.blocking_emit(point, **kwargs)
             return
-        # Snapshot handlers before dispatch so a handler registered during
-        # this emit cycle does not fire in the current cycle.
         handlers = list(self._handlers.get(point, []))
         for handler in handlers:
             try:
                 result = handler(**kwargs)
-                # Allow sync handlers too — await only if needed.
                 if inspect.isawaitable(result):
                     await result
             except StopHook:
-                break  # stop remaining handlers, but still record below
+                break
             except Exception:  # noqa: BLE001 — hook isolation invariant
                 logger.exception("Hook failed: %s", point.value)
         await self._record(point, kwargs)
@@ -244,24 +137,10 @@ class HookBus:
 
 
 def hook(point: HookPoint | str) -> Callable[[HookHandler], HookHandler]:
-    """Tag a callable as a handler for ``point`` (registered at load time).
-
-    The decorator only marks the function — registration into a bus is
-    the loader's job (see :func:`lionagi.hooks.loader.register_handler`).
-    This separation lets a single module define multiple handlers without
-    side effects at import time.
-
-    Usage::
-
-        @hook(HookPoint.API_POST_CALL)
-        async def notify_on_expensive_call(*, tokens, model, **kw):
-            ...
-    """
+    """Tag a callable as a handler for *point* (registered at load time)."""
     point_enum = point if isinstance(point, HookPoint) else HookPoint(point)
 
     def _wrap(fn: HookHandler) -> HookHandler:
-        # Attribute is consulted by the loader to bind by HookPoint without
-        # requiring the user to import the bus.
         fn.__lionagi_hook_point__ = point_enum  # type: ignore[attr-defined]
         return fn
 

--- a/lionagi/libs/schema/load_pydantic_model_from_schema.py
+++ b/lionagi/libs/schema/load_pydantic_model_from_schema.py
@@ -1,15 +1,7 @@
 # Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Build Pydantic models from JSON Schema dicts/strings.
-
-Primary approach uses ``pydantic.create_model()`` which constructs models
-programmatically without code generation -- eliminating the CWE-94 code
-injection vector present in the previous ``exec_module()`` approach.
-
-Falls back to ``datamodel-code-generator`` + ``exec_module()`` only when
-``create_model()`` cannot handle a schema (raises ``_CreateModelUnsupportedError``).
-"""
+"""Build Pydantic models from JSON Schema dicts/strings."""
 
 from __future__ import annotations
 
@@ -68,7 +60,6 @@ class _CreateModelUnsupportedError(Exception):
 
 
 def _sanitize_model_name(raw: str) -> str | None:
-    """Return a valid Python identifier from *raw*, or ``None``."""
     valid_chars = string.ascii_letters + string.digits + "_"
     sanitized = "".join(c for c in raw.replace(" ", "") if c in valid_chars)
     if sanitized and sanitized[0].isalpha():
@@ -77,7 +68,6 @@ def _sanitize_model_name(raw: str) -> str | None:
 
 
 def _resolve_model_name(schema_dict: dict[str, Any], default: str) -> str:
-    """Pick a model name from the schema title or fall back to *default*."""
     title = schema_dict.get("title")
     if title and isinstance(title, str):
         name = _sanitize_model_name(title)
@@ -87,7 +77,6 @@ def _resolve_model_name(schema_dict: dict[str, Any], default: str) -> str:
 
 
 def _make_enum(name: str, values: list[Any]) -> type:
-    """Build a stdlib ``Enum`` for JSON Schema ``enum`` constraints."""
     members: dict[str, Any] = {}
     for v in values:
         member_name = str(v).upper().replace(" ", "_").replace("-", "_")
@@ -102,7 +91,6 @@ def _make_enum(name: str, values: list[Any]) -> type:
 
 
 def _resolve_ref(ref: str, root_schema: dict[str, Any]) -> dict[str, Any]:
-    """Resolve a ``$ref`` pointer (only local ``#/...`` refs supported)."""
     if not ref.startswith("#/"):
         raise _CreateModelUnsupportedError(f"Non-local $ref not supported: {ref}")
 
@@ -127,30 +115,19 @@ def _schema_to_type(
     models_cache: dict[str, type[BaseModel]],
     parent_name: str,
 ) -> type:
-    """Convert a single JSON-Schema property definition to a Python type.
-
-    Handles: primitives, ``$ref``, ``enum``, ``array``, nested ``object``,
-    ``anyOf``/``oneOf``, ``allOf``, and ``const``.
-
-    Raises ``_CreateModelUnsupportedError`` for constructs we cannot map.
-    """
-    # --- $ref ---
     if "$ref" in prop_schema:
         resolved = _resolve_ref(prop_schema["$ref"], root_schema)
         ref_name = prop_schema["$ref"].rsplit("/", 1)[-1]
         return _build_model_from_object(resolved, ref_name, root_schema, models_cache)
 
-    # --- enum ---
     if "enum" in prop_schema:
         enum_name = f"{parent_name}_{prop_name}_enum".replace(" ", "")
         return _make_enum(enum_name, prop_schema["enum"])
 
-    # --- const ---
     if "const" in prop_schema:
         enum_name = f"{parent_name}_{prop_name}_const".replace(" ", "")
         return _make_enum(enum_name, [prop_schema["const"]])
 
-    # --- anyOf / oneOf ---
     for combo_key in ("anyOf", "oneOf"):
         if combo_key in prop_schema:
             variants = prop_schema[combo_key]
@@ -163,7 +140,6 @@ def _schema_to_type(
                 return py_types[0]
             return Union[tuple(py_types)]  # type: ignore[return-value]
 
-    # --- allOf (merge into single object) ---
     if "allOf" in prop_schema:
         merged: dict[str, Any] = {}
         for sub in prop_schema["allOf"]:
@@ -174,16 +150,12 @@ def _schema_to_type(
 
     schema_type = prop_schema.get("type")
 
-    # --- no type specified ---
     if schema_type is None:
-        # If it has properties, treat as object
         if "properties" in prop_schema:
             schema_type = "object"
         else:
-            # Permissive fallback
             return Any  # type: ignore[return-value]
 
-    # --- type as list (e.g. ["string", "null"]) ---
     if isinstance(schema_type, list):
         py_types_list: list[type] = []
         for t in schema_type:
@@ -220,21 +192,17 @@ def _schema_to_type(
             return py_types_list[0]
         return Union[tuple(py_types_list)]  # type: ignore[return-value]
 
-    # --- primitive types ---
     mapped = _JSON_TYPE_MAP.get(schema_type)
     if mapped is not None:
         return mapped
 
-    # --- array ---
     if schema_type == "array":
         return _array_type(prop_schema, prop_name, root_schema, models_cache, parent_name)
 
-    # --- object ---
     if schema_type == "object":
         if "properties" in prop_schema:
             nested_name = prop_schema.get("title") or f"{parent_name}_{prop_name}"
             return _build_model_from_object(prop_schema, nested_name, root_schema, models_cache)
-        # Generic dict if no properties defined
         additional = prop_schema.get("additionalProperties")
         if isinstance(additional, dict):
             val_type = _schema_to_type(
@@ -253,7 +221,6 @@ def _array_type(
     models_cache: dict[str, type[BaseModel]],
     parent_name: str,
 ) -> type:
-    """Return the Python type for a JSON Schema ``array``."""
     items = prop_schema.get("items")
     if items is None:
         return list  # type: ignore[return-value]
@@ -262,7 +229,6 @@ def _array_type(
 
 
 def _deep_merge(base: dict, override: dict) -> dict:
-    """Recursively merge *override* into *base* (shallow copy)."""
     merged = dict(base)
     for k, v in override.items():
         if k in merged and isinstance(merged[k], dict) and isinstance(v, dict):
@@ -278,11 +244,8 @@ def _build_model_from_object(
     root_schema: dict[str, Any],
     models_cache: dict[str, type[BaseModel]],
 ) -> type[BaseModel]:
-    """Recursively build a Pydantic model from an ``object``-typed schema."""
-    # Sanitize name
     safe_name = _sanitize_model_name(model_name) or "DynamicModel"
 
-    # Return cached model if already built (handles circular-ish refs)
     if safe_name in models_cache:
         return models_cache[safe_name]
 
@@ -339,17 +302,10 @@ def _create_model_from_schema(
     schema_dict: dict[str, Any],
     model_name: str,
 ) -> type[BaseModel]:
-    """Build a Pydantic model via ``create_model()`` from *schema_dict*.
-
-    Raises ``_CreateModelUnsupportedError`` if the schema uses constructs that
-    cannot be mapped.
-    """
-    # Resolve $defs / definitions into the root schema so $ref works
     root_schema = dict(schema_dict)
 
     models_cache: dict[str, type[BaseModel]] = {}
 
-    # Pre-build $defs / definitions models
     for defs_key in ("$defs", "definitions"):
         defs = root_schema.get(defs_key, {})
         if isinstance(defs, dict):
@@ -375,10 +331,6 @@ def _load_via_codegen(
     pydantic_version: Any,
     python_version: Any,
 ) -> type[BaseModel]:
-    """Original implementation using datamodel-code-generator.
-
-    Kept as fallback for schemas that ``create_model()`` cannot handle.
-    """
     with tempfile.TemporaryDirectory() as temporary_directory_name:
         temporary_directory = Path(temporary_directory_name)
         output_file = (
@@ -469,39 +421,7 @@ def load_pydantic_model_from_schema(
     python_version: Any = None,
     allow_codegen: bool = False,
 ) -> type[BaseModel]:
-    """Build a Pydantic model class from a JSON schema string or dict.
-
-    Uses ``pydantic.create_model()`` to construct models programmatically --
-    no code generation and no ``exec_module()``.  Falls back to
-    ``datamodel-code-generator`` **only** when *allow_codegen=True* is
-    explicitly passed; that path writes and executes a generated Python module,
-    so it must never be reached from untrusted schema input.
-
-    Args:
-        schema: The JSON schema as a string or a Python dictionary.
-        model_name: The desired base name for the generated Pydantic model.
-            If the schema has a ``title``, that will be preferred.
-        pydantic_version: (Fallback only) The Pydantic model type for
-            ``datamodel-code-generator``.
-        python_version: (Fallback only) The target Python version for
-            ``datamodel-code-generator``.
-        allow_codegen: When ``False`` (the default), the
-            ``datamodel-code-generator`` fallback is disabled and any schema
-            that ``create_model`` cannot handle raises ``RuntimeError`` rather
-            than falling through to code generation and ``exec_module``.  Set
-            to ``True`` only for schemas from fully trusted sources (e.g.
-            hand-written library schemas under your own version control).
-
-    Returns:
-        The dynamically created Pydantic ``BaseModel`` subclass.
-
-    Raises:
-        ValueError: If the schema string is not valid JSON.
-        TypeError: If *schema* is neither ``str`` nor ``dict``.
-        RuntimeError: If ``create_model`` cannot handle the schema and
-            *allow_codegen* is ``False``, or if both paths fail.
-    """
-    # --- 1. Parse / validate schema input ---
+    """Build a Pydantic model class from a JSON schema string or dict."""
     schema_dict: dict[str, Any]
 
     if isinstance(schema, dict):
@@ -516,7 +436,6 @@ def load_pydantic_model_from_schema(
 
     resolved_model_name = _resolve_model_name(schema_dict, model_name)
 
-    # --- 2. Primary path: pydantic.create_model ---
     create_model_error: _CreateModelUnsupportedError | None = None
     try:
         return _create_model_from_schema(schema_dict, resolved_model_name)
@@ -528,10 +447,7 @@ def load_pydantic_model_from_schema(
             allow_codegen,
         )
 
-    # --- 3. Fallback: datamodel-code-generator (opt-in, fail-closed by default) ---
-    # Security: this path executes generated Python via exec_module.  It must
-    # never be reached from untrusted schema input.  Callers must pass
-    # allow_codegen=True explicitly to opt in.
+    # Codegen fallback executes generated Python; opt-in only for trusted input.
     if not allow_codegen:
         raise RuntimeError(
             f"create_model could not handle this schema ({create_model_error}). "

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -34,13 +34,6 @@ from lionagi.state.reasons import (
 )
 from lionagi.state.schema_migrations import MIGRATION_COLUMNS as _MIGRATION_COLUMNS
 
-# Per-entity default-reason maps used by the Phase 2 deprecation shim
-# in update_invocation / update_show / update_play / update_schedule_run.
-# Picking a wrong-domain code (e.g. ``run.completed.ok`` for a successful
-# show) pollutes the reason-grouping primitive ADR-0028 introduces for
-# Phase 3/4 + ADR-0030. The resolver is conservative — it returns None
-# for (entity, status) pairs without a canonical default, forcing the
-# caller to surface a clear error instead of synthesizing nonsense.
 _RUN_DEFAULTS: dict[str, str] = {
     "running": _RunReasons.STARTED_OK,
     "completed": _RunReasons.COMPLETED_OK,
@@ -63,15 +56,7 @@ _PLAY_DEFAULTS: dict[str, str] = {
 
 
 def _default_reason_code_for_entity_status(entity_type: str, status: str) -> str | None:
-    """Map (entity_type, status) → canonical reason_code, or None.
-
-    Returns None for ambiguous (entity, status) pairs — sessions/
-    invocations/schedule_runs share the run.* codes (they're process
-    runs); shows + plays have entity-specific codes for the subset
-    of statuses with canonical defaults. Statuses outside the per-
-    entity map return None and the deprecation shim raises so
-    callers supply reason_code explicitly.
-    """
+    """Map (entity_type, status) to canonical reason_code, or None."""
     if entity_type in ("session", "invocation", "schedule_run"):
         return _RUN_DEFAULTS.get(status)
     if entity_type == "show":
@@ -82,17 +67,13 @@ def _default_reason_code_for_entity_status(entity_type: str, status: str) -> str
 
 
 def _default_reason_code_for_status(status: str) -> str:
-    """Legacy run-only resolver. Kept for one release to avoid
-    breaking external callers that imported the private name.
-    New code MUST use :func:`_default_reason_code_for_entity_status`.
-    """
+    """Legacy run-only resolver; prefer _default_reason_code_for_entity_status."""
     return _RUN_DEFAULTS.get(status, _RunReasons.FAILED_EXCEPTION)
 
 
 _SCHEMA_PATH = Path(__file__).parent / "schema.sql"
 DEFAULT_DB_PATH = LIONAGI_HOME / "state.db"
 
-# ADR-0028: closed vocabulary for transition-history ``source`` column.
 _VALID_STATUS_SOURCES: frozenset[str] = frozenset({"executor", "agent", "admin", "system"})
 
 _SESSION_COLUMNS = frozenset(
@@ -113,32 +94,18 @@ _SESSION_COLUMNS = frozenset(
         "status",
         "started_at",
         "ended_at",
-        # ADR-0019: activity marker for staleness detection. Bumped on
-        # every message INSERT so a session that hasn't produced output
-        # in N hours is detectably stale without scanning ``messages``.
         "last_message_at",
-        # #1235: coarse live flow phase (planning/executing/synthesizing)
-        # for the `li monitor` PHASE column.
         "current_phase",
-        # ADR-0020: optional FK to the skill orchestration that spawned
-        # this session (e.g. a /show invocation grouping its plays).
         "invocation_id",
-        # ADR-0022: provenance disclosure — resolved model spec, provider,
-        # effort, and the agent profile content hash at invocation time.
         "model",
         "provider",
         "effort",
         "agent_hash",
-        # ADR-0026: project detection for session organization.
         "project",
         "project_source",
     }
 )
 
-# ADR-0020: invocation lifecycle vocabulary — narrower than session
-# status (no 'aborted_after_finish') but otherwise shares the ADR-0025
-# terminal set. The schema CHECK is in schema.sql; this set lets the
-# Python helpers validate updates symmetrically.
 _INVOCATION_STATUSES = frozenset(
     {"running", "completed", "failed", "timed_out", "aborted", "cancelled"}
 )
@@ -199,7 +166,6 @@ _BRANCH_COLUMNS = frozenset(
         "user",
         "node_metadata",
         "system_msg_id",
-        # ADR-0022: per-branch provenance for multi-model flows.
         "model",
         "provider",
         "agent_name",
@@ -209,47 +175,26 @@ _BRANCH_COLUMNS = frozenset(
     }
 )
 
-# ADR-0025: expanded closed status vocabulary for sessions. The SQLite
-# CHECK constraint is removed (see schema.sql); Python is the source of
-# truth so we get a clear ``ValueError`` instead of an opaque sqlite
-# IntegrityError, and the vocabulary can evolve without table rebuilds.
-#
-# The six values distinguish operational follow-up actions:
-#   - timed_out: deliberate bound hit ("retry with more time")
-#   - failed:    unexpected error ("investigate")
-#   - aborted:   user pressed Ctrl-C (no follow-up needed)
-#   - cancelled: system/orchestrator cancelled (cascade or admin decision)
 VALID_SESSION_STATUSES = frozenset(
     {"running", "completed", "failed", "timed_out", "aborted", "cancelled"}
 )
 SESSION_TERMINAL_STATUSES = frozenset({"completed", "failed", "timed_out", "aborted", "cancelled"})
-# Admin/operator transitions cannot mark a session "completed" or
-# "timed_out" — those are system-determined outcomes.
+# Admin cannot mark completed/timed_out — those are system-determined.
 ADMIN_TRANSITION_TARGETS = frozenset({"failed", "aborted", "cancelled"})
 
-# Legacy alias retained for any internal call sites that still import the
-# private name. New code should use ``VALID_SESSION_STATUSES``.
 _SESSION_STATUSES = VALID_SESSION_STATUSES
 
 
 def can_transition(current: str | None, target: str) -> bool:
-    """Return True iff a session may move from ``current`` to ``target``.
-
-    Mirrors khive's GTD ``can_transition`` (Lean4-proven FSM properties):
-    transitions only originate from ``running``; terminal states have no
-    outgoing transitions.
-    """
+    """Return True iff a session may move from *current* to *target*."""
     if current != "running":
         return False
     return target in SESSION_TERMINAL_STATUSES
 
 
-# ADR-0012: closed provenance vocabularies. Validated alongside status
-# so dashboards/filters can't be polluted with arbitrary text.
 _INVOCATION_KINDS = frozenset({"agent", "play", "flow", "fanout", "show-play"})
 _SOURCE_KINDS = frozenset({"live", "imported_fs"})
 
-# ADR-0011: shows + plays lifecycle vocabularies.
 _SHOW_STATUSES = frozenset({"active", "completed", "aborted", "imported"})
 _PLAY_STATUSES = frozenset(
     {
@@ -267,8 +212,6 @@ _PLAY_STATUSES = frozenset(
     }
 )
 
-# ADR-0016: only agent + playbook definitions are editable via Studio's
-# write path. Skills and third-party plugin components are read-only.
 _DEFINITION_KINDS = frozenset({"agent", "playbook"})
 
 
@@ -279,18 +222,7 @@ def _validate_columns(fields: dict[str, Any], allowed: frozenset[str]) -> None:
 
 
 def _to_json_column(value: Any) -> Any:
-    """Serialize ``value`` to a JSON-tagged string for round-trippable storage.
-
-    Without this, a string that happens to be valid JSON (e.g. user
-    content ``'{"text": "x"}'``) round-trips to a dict because
-    ``_row_to_dict`` ``json.loads()`` every string column. Always
-    serializing here means ``json.loads`` on the way out is the exact
-    inverse — a string stays a string, a dict stays a dict.
-
-    ``None`` is preserved as ``NULL``. ``bytes`` (used for embeddings)
-    are passed through unchanged so they go into the SQLite BLOB
-    storage class without UTF-8 coercion.
-    """
+    """Serialize value to JSON string for round-trippable storage."""
     if value is None or isinstance(value, bytes | bytearray | memoryview):
         return value
     return _json_dumps(value)
@@ -323,21 +255,12 @@ def _validate_enum(
 
 
 class StateDB:
-    """Async SQLite state layer for lionagi's core data model.
-
-    Mirrors the runtime Session / Branch / Message / Progression objects.
-    Uses WAL mode for concurrent read + single writer.
-    """
+    """Async SQLite state layer for sessions, branches, messages, and progressions."""
 
     def __init__(self, path: str | Path | None = None):
         self.path = Path(path) if path else DEFAULT_DB_PATH
         self._db: aiosqlite.Connection | None = None
-        # Per-(kind, name) serialization for save_definition. Concurrent
-        # writers for the same definition stream would race on
-        # ``SELECT MAX(version) + INSERT`` and most would fail on the
-        # UNIQUE(kind, name, version) index. The lock is keyed by
-        # ``(kind, name)`` so unrelated definitions can still progress
-        # in parallel.
+        # Per-(kind, name) lock to serialize version increment for save_definition.
         self._definition_locks: dict[tuple[str, str], Lock] = {}
 
     # ── Connection lifecycle ───────────────────────────────────────────
@@ -373,36 +296,15 @@ class StateDB:
         await self.db.execute("PRAGMA foreign_keys = ON")
         await self.db.execute("PRAGMA busy_timeout = 5000")
         await self.db.execute("PRAGMA cache_size = -64000")
-        # Explicit policy (matches SQLite default) so the intent is
-        # visible: auto-checkpoint every 1000 frames. Long-lived
-        # readers can still prevent WAL truncation; users should run
-        # ``li state checkpoint --mode TRUNCATE`` to force it.
         await self.db.execute("PRAGMA wal_autocheckpoint = 1000")
 
     async def _apply_schema(self) -> None:
-        # Older state.db files from earlier iterations of the schema lack
-        # the provenance / lifecycle columns added by ADR-0012 / ADR-0017,
-        # and ``CREATE TABLE IF NOT EXISTS`` is a no-op on existing
-        # tables. Reconcile column-by-column FIRST so the index/trigger
-        # statements in schema.sql that reference these columns can
-        # succeed. This is a forward-only migration; all migrated
-        # columns are nullable or have an INSERT-time default.
         await self._reconcile_columns()
-        # ADR-0025: existing DBs created under ADR-0017 carry a 4-value
-        # CHECK on sessions.status. Drop the constraint via table rebuild
-        # before the new vocabulary (timed_out / cancelled) is written.
         await self._drop_legacy_session_status_check()
         schema = _SCHEMA_PATH.read_text()
         lines = [ln for ln in schema.splitlines() if not ln.strip().upper().startswith("PRAGMA")]
         await self.db.executescript("\n".join(lines))
 
-    # Columns that may need to be back-added to an existing sessions
-    # table — keyed by table name. Each entry is (column_name, column_def).
-    # Migration column definitions live in schema_migrations.py.
-    # column_def must be valid in an ``ALTER TABLE ... ADD COLUMN`` clause
-    # (SQLite only allows CHECK constraints inline here if they reference
-    # only the new column; we skip CHECKs in ALTER and rely on the Python
-    # validators in this module to enforce them on old databases).
     _MIGRATION_COLUMNS: dict[str, list[tuple[str, str]]] = _MIGRATION_COLUMNS
 
     async def _reconcile_columns(self) -> None:
@@ -410,64 +312,41 @@ class StateDB:
             cur = await self.db.execute(f"PRAGMA table_info({table})")
             rows = await cur.fetchall()
             if not rows:
-                # Table doesn't exist yet — schema.sql will CREATE it
-                # with the full column list. Nothing to migrate.
                 continue
             existing = {row["name"] for row in rows}
             for name, defn in columns:
                 if name not in existing:
-                    # Identifier safety: name/defn come from the
-                    # _MIGRATION_COLUMNS class constant above, never user
-                    # input. Table name same. F-string is safe here.
                     await self.db.execute(  # noqa: S608
                         f"ALTER TABLE {table} ADD COLUMN {name} {defn}"
                     )
         await self.db.commit()
 
-    # Substring that appears in the ADR-0017 CHECK clause but not in the
-    # ADR-0025 schema (the new schema has no CHECK on sessions.status).
     _LEGACY_SESSION_STATUS_CHECK_MARKER = "'running', 'completed', 'failed', 'aborted'"
 
     async def _drop_legacy_session_status_check(self) -> None:
-        """Rebuild ``sessions`` if it still carries the ADR-0017 CHECK.
-
-        SQLite cannot ``ALTER TABLE ... DROP CONSTRAINT``; the only path
-        is the documented "rename → CREATE new → INSERT SELECT → DROP
-        old" pattern. This runs at most once per database — subsequent
-        opens find no marker and skip the rebuild.
-        """
+        """Rebuild sessions table if it carries the legacy 4-value CHECK constraint."""
         cur = await self.db.execute(
             "SELECT sql FROM sqlite_master WHERE type='table' AND name='sessions'"
         )
         row = await cur.fetchone()
         if row is None or row["sql"] is None:
-            # Table doesn't exist yet — schema.sql will CREATE it without
-            # the legacy CHECK. Nothing to migrate.
             return
         create_sql: str = row["sql"]
         if self._LEGACY_SESSION_STATUS_CHECK_MARKER not in create_sql:
             return
 
-        # Capture indexes so we can recreate them after the swap. SQLite
-        # auto-drops indexes attached to a dropped table.
         idx_cur = await self.db.execute(
             "SELECT sql FROM sqlite_master "
             "WHERE type='index' AND tbl_name='sessions' AND sql IS NOT NULL"
         )
         index_sqls = [r["sql"] for r in await idx_cur.fetchall()]
 
-        # Discover the actual live columns (may include ALTER-added
-        # columns not present in any historical CREATE TABLE statement).
         info_cur = await self.db.execute("PRAGMA table_info(sessions)")
         cols = [r["name"] for r in await info_cur.fetchall()]
         col_list = ", ".join(cols)
 
         await self.db.execute("PRAGMA foreign_keys = OFF")
         try:
-            # Use sessions_new pattern to avoid FK rewrites: SQLite's
-            # ALTER TABLE RENAME rewrites child-table FK references
-            # (branches, plays) to point at the renamed table. Creating
-            # a _new table, copying, then swapping avoids that.
             await self.db.execute(
                 """
                 CREATE TABLE sessions_new (
@@ -498,8 +377,6 @@ class StateDB:
                   started_at      REAL,
                   ended_at        REAL,
                   last_message_at REAL,
-                  -- #1235: live flow phase column; keep parity with
-                  -- schema.sql so the rebuild preserves it.
                   current_phase   TEXT,
                   invocation_id   TEXT,
                   model           TEXT,
@@ -508,19 +385,14 @@ class StateDB:
                   agent_hash      TEXT,
                   project         TEXT,
                   project_source  TEXT,
-                  -- ADR-0028: keep parity with schema.sql so the rebuild
-                  -- preserves these columns when migrating from ADR-0017.
                   status_reason_code     TEXT,
                   status_reason_summary  TEXT,
                   status_evidence_refs   JSON,
-                  -- ADR-0029: artifact contract snapshot and verification.
                   artifact_contract_json      JSON,
                   artifact_verification_json  JSON
                 )
                 """
             )
-            # Build SELECT with COALESCE for updated_at — legacy DBs
-            # may have NULL values from _reconcile_columns additions.
             select_cols = []
             for c in cols:
                 if c == "updated_at":
@@ -552,17 +424,11 @@ class StateDB:
     _UNKNOWN_TYPE_ID = 0
 
     async def insert_message(self, msg: dict[str, Any]) -> None:
-        # ADR-0009 invariants: messages.content + messages.role are
-        # NOT NULL. SQLite enforces that at the column level, but
-        # ``INSERT OR IGNORE`` silently swallows constraint violations
-        # — without these explicit checks the live-persist hook would
-        # log a NULL row as a successful insert, then progression
-        # would reference a missing ID.
         if msg.get("content") is None:
             raise ValueError("messages.content is NOT NULL (ADR-0009)")
         role = msg.get("role")
         if not isinstance(role, str) or not role.strip():
-            raise ValueError(f"messages.role must be a non-empty string (ADR-0009); got {role!r}")
+            raise ValueError(f"messages.role must be a non-empty string; got {role!r}")
 
         lion_class_str = (msg.get("node_metadata") or {}).get("lion_class", "")
         node_metadata = _to_json_column(msg.get("node_metadata"))
@@ -570,11 +436,7 @@ class StateDB:
 
         type_id = await self._resolve_lion_class(lion_class_str)
 
-        # ON CONFLICT(id) DO UPDATE so a re-fire of the hook for a
-        # mutated existing message (e.g. ActionResponse.update via
-        # create_action_response) overwrites the stale row instead of
-        # silently keeping the old content. Immutable identity stays
-        # ``id`` + ``created_at``; mutable content is replaced.
+        # ON CONFLICT(id) DO UPDATE so re-emitted hooks overwrite stale content.
         await self.db.execute(
             """INSERT INTO messages (id, created_at, node_metadata, content,
                embedding, sender, recipient, channel, role, lion_class)
@@ -615,14 +477,7 @@ class StateDB:
         return self._row_to_dict(row) if row else None
 
     async def _resolve_lion_class(self, lion_class_str: str) -> int:
-        """Get or create a ``message_types`` row for ``lion_class_str``.
-
-        Concurrent live-persist writes can see the same novel class.
-        ``INSERT OR IGNORE`` + ``SELECT`` is atomic w.r.t. the SQLite
-        connection lock and avoids the ``UNIQUE constraint failed``
-        race that the previous SELECT-then-INSERT pattern produced
-        when two tasks raced on the same new class.
-        """
+        """Get or create a message_types row; race-safe via INSERT OR IGNORE."""
         if not lion_class_str:
             return self._UNKNOWN_TYPE_ID
         await self.db.execute(
@@ -659,16 +514,7 @@ class StateDB:
         return json.loads(row["collection"])
 
     async def append_to_progression(self, progression_id: str, message_id: str) -> None:
-        """Append ``message_id`` to the progression's ordered collection.
-
-        Idempotent for same-(progression_id, message_id) pairs — a re-fire
-        of an on_message_added hook for an existing message (the
-        ActionResponse-update path mutates an existing object and re-emits
-        the hook) must not duplicate the ID in the progression JSON array.
-        Uses ``json_insert`` only when the ID is not already present;
-        ``EXISTS (json_each)`` lets SQLite do the check in one statement
-        without round-tripping the whole collection to Python.
-        """
+        """Idempotent append of message_id to the progression JSON array."""
         await self.db.execute(
             """UPDATE progressions
                SET collection = json_insert(collection, '$[#]', ?)
@@ -718,8 +564,6 @@ class StateDB:
                 session["progression_id"],
                 session.get("first_msg_id"),
                 session.get("last_msg_id"),
-                # ADR-0009: caller may preserve ``updated_at`` for lossless
-                # import/backfill. Live sessions omit it and get ``now``.
                 session.get("updated_at", now),
                 session.get("playbook_name"),
                 session.get("agent_name"),
@@ -733,31 +577,17 @@ class StateDB:
                 session.get("status"),
                 session.get("started_at"),
                 session.get("ended_at"),
-                # ADR-0019: initialize last_message_at to session start so
-                # a freshly-created session that has produced no messages
-                # yet isn't immediately classified stale.
                 session.get("last_message_at", session.get("started_at", now)),
-                # ADR-0020: optional FK to invocations(id). NULL when the
-                # session was spawned standalone (no `li invoke start`).
                 session.get("invocation_id"),
-                # ADR-0022: resolved provenance — model/provider/effort
-                # are the values the runtime actually used, not the user
-                # input. agent_hash is the SHA-256 of the agent profile
-                # content at invocation time (drift detection).
                 session.get("model"),
                 session.get("provider"),
                 session.get("effort"),
                 session.get("agent_hash"),
-                # ADR-0026: project detection for session organization.
                 session.get("project"),
                 session.get("project_source"),
             ),
         )
-        # ADR-0020: keep invocations.session_count in sync so list queries
-        # don't need a JOIN.  Only increment when the INSERT actually created
-        # a row (rowcount == 0 means INSERT OR IGNORE was a no-op — duplicate
-        # id).  This prevents retries or idempotent replays from inflating the
-        # count beyond the actual number of distinct sessions.
+        # Only increment session_count when INSERT actually created a row.
         if session.get("invocation_id") and cur.rowcount:
             await self.db.execute(
                 "UPDATE invocations SET session_count = session_count + 1, "
@@ -765,8 +595,6 @@ class StateDB:
                 (now, session["invocation_id"]),
             )
         await self.db.commit()
-        # ADR-0026: auto-register the detected project so Studio's project
-        # list is populated without any explicit studio action.
         project_name = session.get("project")
         if project_name:
             await self.register_project(
@@ -780,13 +608,7 @@ class StateDB:
         return self._row_to_dict(row) if row else None
 
     async def touch_session_activity(self, session_id: str, *, at: float | None = None) -> None:
-        """Bump ``last_message_at`` (and ``updated_at``) for staleness signal.
-
-        ADR-0019: stored at write time so the runs list and dashboard can
-        compute staleness with one indexed read instead of scanning
-        messages. ``at`` lets the caller pass the message timestamp for
-        precision; callers without one let it default to ``time.time()``.
-        """
+        """Bump last_message_at and updated_at for staleness detection."""
         ts = at if at is not None else time.time()
         await self.db.execute(
             "UPDATE sessions "
@@ -808,21 +630,7 @@ class StateDB:
         reason_actor: str | None = None,
         **fields: Any,
     ) -> None:
-        """Update session fields; route status changes through update_status().
-
-        ADR-0028: when ``status`` is among the updated fields, the transition
-        goes through :meth:`update_status` so the denormalized reason columns
-        and ``status_transitions`` history row are written atomically.
-
-        Pass ``reason_code`` (required when status is in fields) plus optional
-        ``reason_summary`` / ``evidence_refs`` / ``reason_source`` /
-        ``reason_actor`` to control the transition record.  Non-status fields
-        are written by the legacy UPDATE path below (separate transaction).
-
-        Backwards compatibility: callers that pass ``status`` without a
-        ``reason_code`` get a deprecation warning + a default code derived
-        from the status.  Remove the fallback in a future release.
-        """
+        """Update session fields; route status changes through update_status()."""
         _validate_columns(fields, _SESSION_COLUMNS)
         if "invocation_kind" in fields:
             _validate_enum(
@@ -873,13 +681,10 @@ class StateDB:
                 actor=reason_actor,
             )
 
-        # Remaining (non-status) fields go through the legacy update path
-        # in a separate write — update_status() already touched updated_at.
         if fields:
             fields["updated_at"] = time.time()
             sets = ", ".join(f"{k} = ?" for k in fields)
             vals = list(fields.values()) + [session_id]
-            # noqa: S608 — column names allowlisted via _validate_columns
             await self.db.execute(
                 f"UPDATE sessions SET {sets} WHERE id = ?",  # noqa: S608
                 vals,
@@ -897,17 +702,7 @@ class StateDB:
         )
         await self.db.commit()
 
-    # ── Status reason model (ADR-0028) ───────────────────────────────
-    # update_status() is the single sanctioned mutation point for any
-    # entity's status. It always writes:
-    #   1. the entity row (status + denormalized reason columns)
-    #   2. an append-only status_transitions row (history)
-    # ...in the same SQLite transaction, so denormalized "current
-    # reason" and the transition log never drift.
-    #
-    # The legacy update_session(..., status=...) path remains for
-    # callers that haven't migrated yet; new code MUST use
-    # update_status() so reason tracking is enforced.
+    # ── Status reason model ───────────────────────────────────────────
 
     async def update_status(
         self,
@@ -922,38 +717,7 @@ class StateDB:
         actor: str | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> None:
-        """Atomically transition an entity's status and record the reason.
-
-        Args:
-            entity_type: Canonical singular ('session', 'show', ...) or a
-                registered alias ('run', 'sessions'). Resolved to the
-                canonical form before the table lookup.
-            entity_id: Primary key of the row being transitioned.
-            new_status: The target status string. Per ADR-0025, sessions
-                accept only the six-value vocabulary; other entities have
-                their own vocabularies (still validated by their own
-                table's CHECK).
-            reason_code: Must be in :data:`VALID_REASON_CODES`. The
-                ``legacy.imported`` sentinel is permitted as the one
-                two-segment code.
-            reason_summary: Human-readable message; rendered in the
-                StatusPill tooltip. Free text; not validated.
-            evidence_refs: Optional list of typed references — see
-                ADR-0028 Section 3 for the kind vocabulary.
-            source: Who initiated the write. One of 'executor', 'agent',
-                'admin', 'system'.
-            actor: Optional identifier for the actor (session id, user
-                name, 'doctor_auto', ...). Stored on the transition row
-                for audit.
-            metadata: Optional JSON blob for additional context (timing,
-                exit code, exception class).
-
-        Raises:
-            ValueError: ``reason_code`` not in
-                :data:`VALID_REASON_CODES`, ``entity_type`` not recognized,
-                or ``source`` not in the closed vocabulary.
-            LookupError: Entity row not found.
-        """
+        """Atomically transition an entity's status and record the reason."""
         if source not in _VALID_STATUS_SOURCES:
             raise ValueError(
                 f"update_status() called with source={source!r}; "
@@ -966,11 +730,8 @@ class StateDB:
         metadata_json = _json_dumps(metadata) if metadata is not None else None
         now = time.time()
 
-        # Single transaction: status + denormalized reason + transition row.
         await self.db.execute("BEGIN IMMEDIATE")
         try:
-            # Lookup previous status. NOT FOUND raises before any write.
-            # noqa: S608 — `table` is allowlisted via _reason_entity_table.
             cur = await self.db.execute(
                 f"SELECT status FROM {table} WHERE id = ?",  # noqa: S608
                 (entity_id,),
@@ -980,9 +741,6 @@ class StateDB:
                 raise LookupError(f"{canonical_type} {entity_id!r} not found (table={table})")
             previous_status = row["status"] if "status" in row.keys() else None
 
-            # Update the entity row. updated_at is always touched; every
-            # status-bearing table has the column per ADR-0028 migration.
-            # noqa: S608 — `table` is allowlisted.
             await self.db.execute(
                 f"UPDATE {table} SET "  # noqa: S608
                 "  status = ?, "
@@ -1001,7 +759,6 @@ class StateDB:
                 ),
             )
 
-            # Append to transition history.
             await self.db.execute(
                 "INSERT INTO status_transitions "
                 "(id, entity_type, entity_id, previous_status, status, "
@@ -1057,7 +814,7 @@ class StateDB:
         row = await cur.fetchone()
         return row["n"]
 
-    # ── Projects (ADR-0026) ────────────────────────────────────────────
+    # ── Projects ──────────────────────────────────────────────────────
 
     async def register_project(
         self,
@@ -1067,13 +824,7 @@ class StateDB:
         path: str | None = None,
         github: str | None = None,
     ) -> None:
-        """Register or update a project entry (ADR-0026).
-
-        Called during session creation to auto-register detected projects.
-        Uses INSERT ... ON CONFLICT to bump last_seen_at on subsequent
-        encounters. Prefers config_toml/global_override over git_remote as
-        source; never overwrites existing path/github with NULL.
-        """
+        """Upsert a project entry; bumps last_seen_at on conflict."""
         now = time.time()
         await self.db.execute(
             """INSERT INTO projects
@@ -1101,10 +852,7 @@ class StateDB:
         description: str | None = None,
         path: str | None = None,
     ) -> None:
-        """Insert a Studio-managed project (source='studio').
-
-        Raises ``aiosqlite.IntegrityError`` on duplicate name.
-        """
+        """Insert a Studio-managed project (source='studio')."""
         now = time.time()
         await self.db.execute(
             """INSERT INTO projects
@@ -1116,7 +864,6 @@ class StateDB:
         await self.db.commit()
 
     async def list_projects(self) -> list[dict[str, Any]]:
-        """List all projects ordered by last_seen_at DESC, with session counts."""
         cur = await self.db.execute(
             """SELECT p.*,
                       COUNT(s.id) AS session_count,
@@ -1130,7 +877,6 @@ class StateDB:
         return [dict(r) for r in rows]
 
     async def get_project(self, name: str) -> dict[str, Any] | None:
-        """Return a single project row with session counts, or None."""
         cur = await self.db.execute(
             """SELECT p.*,
                       COUNT(s.id) AS session_count,
@@ -1145,11 +891,6 @@ class StateDB:
         return dict(row) if row else None
 
     async def update_project(self, name: str, **fields: Any) -> bool:
-        """Patch allowed mutable columns on a project row.
-
-        Returns True when a row was updated, False when the project was not
-        found. Raises ``ValueError`` for disallowed column names.
-        """
         allowed = {"description", "github", "path"}
         bad = set(fields) - allowed
         if bad:
@@ -1167,12 +908,7 @@ class StateDB:
         return cur.rowcount > 0
 
     async def delete_project(self, name: str) -> bool:
-        """Delete a Studio-managed project.
-
-        Only projects with source='studio' may be deleted; auto-detected
-        projects are immutable from the Studio API.  Returns True when a
-        row was deleted.
-        """
+        """Delete a Studio-managed project; auto-detected ones are immutable."""
         cur = await self.db.execute(
             "DELETE FROM projects WHERE name = ? AND source = 'studio'",
             (name,),
@@ -1354,12 +1090,7 @@ class StateDB:
         reason_actor: str | None = None,
         **fields: Any,
     ) -> None:
-        """Update schedule_run fields; route status through update_status().
-
-        ADR-0028 Phase 2: status writes go through update_status() so
-        reason columns + status_transitions are atomic. See
-        update_invocation() for the pattern.
-        """
+        """Update schedule_run fields; route status through update_status()."""
         allowed = {"status", "exit_code", "ended_at", "error_detail", "invocation_id"}
         bad = set(fields) - allowed
         if bad:
@@ -1442,12 +1173,6 @@ class StateDB:
     # ── Invocations (ADR-0020) ──────────────────────────────────────────
 
     async def create_invocation(self, invocation: dict[str, Any]) -> None:
-        """Insert an invocation row (skill-level orchestration record).
-
-        Called by ``li invoke start``. Required keys: ``id``, ``skill``,
-        ``started_at``. Optional: ``plugin``, ``prompt``, ``status``,
-        ``node_metadata``.
-        """
         status = invocation.get("status", "running")
         _validate_enum(
             "status",
@@ -1489,24 +1214,7 @@ class StateDB:
         reason_actor: str | None = None,
         **fields: Any,
     ) -> None:
-        """Update invocation fields; route status changes through update_status().
-
-        ADR-0028 Phase 2: when ``status`` is among the updated fields, the
-        transition goes through :meth:`update_status` so the denormalized
-        reason columns and ``status_transitions`` history row are written
-        atomically.
-
-        Pass ``reason_code`` (required when status is in fields) plus
-        optional ``reason_summary`` / ``evidence_refs`` / ``reason_source``
-        / ``reason_actor`` to control the transition record. The
-        non-status fields are written by the legacy UPDATE path below
-        (separate transaction).
-
-        Backwards compatibility: callers that pass ``status`` without a
-        ``reason_code`` get a deprecation warning + a default code
-        derived from the status (matching the executor's resolution
-        logic for sessions). Remove the fallback in a future release.
-        """
+        """Update invocation fields; route status changes through update_status()."""
         _validate_columns(fields, _INVOCATION_COLUMNS)
         if "status" in fields:
             _validate_enum(
@@ -1552,13 +1260,10 @@ class StateDB:
                 actor=reason_actor,
             )
 
-        # Remaining (non-status) fields go through the legacy update path
-        # in a separate write — update_status() already touched updated_at.
         if fields:
             fields["updated_at"] = time.time()
             sets = ", ".join(f"{k} = ?" for k in fields)
             vals = list(fields.values()) + [invocation_id]
-            # columns validated above; SQL is identifier-only interpolation.
             update_sql = f"UPDATE invocations SET {sets} WHERE id = ?"  # noqa: S608
             await self.db.execute(update_sql, vals)
             await self.db.commit()
@@ -1576,10 +1281,6 @@ class StateDB:
         limit: int = 100,
         offset: int = 0,
     ) -> list[dict[str, Any]]:
-        # ADR-0026: surface project/project_source from the most-recently
-        # updated child session so Studio can render project chips on the
-        # invocations list page.  The subquery picks one row per invocation
-        # by latest updated_at; NULL when the invocation has no sessions yet.
         query = (
             "SELECT inv.*, "
             "  sq.project        AS project, "
@@ -1665,18 +1366,7 @@ class StateDB:
         session_id: str | None = None,
         file_path: str | None = None,
     ) -> str:
-        """Upsert one structured skill artifact; return its stable id.
-
-        ``content`` is typically ``SkillOutcome.model_dump()``. Either
-        ``invocation_id`` or ``session_id`` (or both) should be set so
-        the artifact is reachable from a parent; the schema permits NULL
-        on both for unattached blobs (rare; the API doesn't expose this).
-
-        INSERT OR REPLACE must not be used — it deletes then re-inserts,
-        generating a new id and silently breaking external FK references.
-        We SELECT the existing id first and UPDATE in place; a new id is
-        only minted when no matching row exists.
-        """
+        """Upsert one structured artifact; return its stable id."""
         if not kind:
             raise ValueError("artifact kind is required")
         if not name:
@@ -1734,11 +1424,7 @@ class StateDB:
         target_id: str | None = None,
         actor: str = "admin",
     ) -> str:
-        """Append one row to the admin event log (NIST SP 800-92 pattern).
-
-        Insert-only; the cleanup job is the only allowed deleter. Returns
-        the generated event id so callers can correlate follow-up writes.
-        """
+        """Append one row to the admin event log; returns the event id."""
         event_id = uuid.uuid4().hex[:12]
         await self.db.execute(
             "INSERT INTO admin_events (id, created_at, action, target_id, "
@@ -1795,7 +1481,6 @@ class StateDB:
                 branch["session_id"],
                 branch["progression_id"],
                 branch.get("system_msg_id"),
-                # ADR-0022: per-branch resolved provenance.
                 branch.get("model"),
                 branch.get("provider"),
                 branch.get("agent_name"),
@@ -1809,20 +1494,11 @@ class StateDB:
         return self._row_to_dict(row) if row else None
 
     async def update_branch(self, branch_id: str, **fields: Any) -> None:
-        """Update mutable columns on a branch row.
-
-        Restricted to the allowlist in ``_BRANCH_COLUMNS`` — system
-        prompt pointer (``system_msg_id``), display name, user, and
-        ``node_metadata`` are the only fields a long-lived branch
-        should change after creation. The branch identity (id,
-        session_id, progression_id, created_at) is immutable.
-        """
         _validate_columns(fields, _BRANCH_COLUMNS)
         if not fields:
             return
         sets = ", ".join(f"{k} = ?" for k in fields)
         vals = list(fields.values()) + [branch_id]
-        # noqa: S608 — column names allowlisted via _validate_columns
         await self.db.execute(
             f"UPDATE branches SET {sets} WHERE id = ?",  # noqa: S608
             vals,
@@ -1834,32 +1510,7 @@ class StateDB:
         branch_id: str,
         new_progression_id: str,
     ) -> str | None:
-        """Backfill ``branches.progression_id`` for a legacy row that has NULL.
-
-        Pre-PR DBs may have ``branches.progression_id IS NULL``. The live
-        hook then calls ``append_to_progression(None, msg_id)`` which is
-        an ``UPDATE progressions ... WHERE id = NULL`` — a silent no-op
-        that loses branch history. This helper repairs the row by
-        pointing it at a freshly-created progression.
-
-        Returns the EFFECTIVE progression id stored on the row: if we
-        won the race, it's ``new_progression_id``; if another concurrent
-        repair landed first, it's whatever the row now points to. The
-        caller MUST use the returned id rather than its locally-generated
-        one, or it will append to an orphan progression while
-        ``branches.progression_id`` points elsewhere.
-
-        Returns None only if the branch row itself does not exist.
-
-        Bypasses the ``_BRANCH_COLUMNS`` allowlist on purpose: normal
-        runtime must NOT mutate ``progression_id`` (the branch identity
-        includes its progression), but a one-shot migration from NULL
-        is the explicit exception.
-        """
-        # Atomic: the conditional UPDATE either lands our id or no-ops
-        # if a concurrent writer already filled the column. Then read
-        # back the actual stored id so the caller cannot diverge from
-        # the row.
+        """Backfill NULL progression_id; returns the effective id or None."""
         await self.db.execute(
             "UPDATE branches SET progression_id = ? WHERE id = ? AND progression_id IS NULL",
             (new_progression_id, branch_id),
@@ -1879,13 +1530,7 @@ class StateDB:
         session_id: str,
         new_progression_id: str,
     ) -> str | None:
-        """Backfill ``sessions.progression_id`` for a legacy row that has NULL.
-
-        Parallel to ``repair_branch_progression``: returns the effective
-        progression id stored on the row after the conditional UPDATE,
-        or None if the session row does not exist. Caller MUST adopt
-        the returned id.
-        """
+        """Backfill NULL progression_id; returns the effective id or None."""
         await self.db.execute(
             "UPDATE sessions SET progression_id = ? WHERE id = ? AND progression_id IS NULL",
             (new_progression_id, session_id),
@@ -1916,8 +1561,6 @@ class StateDB:
         if not message_ids:
             return []
         placeholders = ",".join("?" for _ in message_ids)
-        # noqa: S608 — `placeholders` is a fixed-shape "?,?,?" string built
-        # from message_ids length; values flow through parameter binding.
         cur = await self.db.execute(
             f"""SELECT m.*, mt.lion_class AS lion_class_str
                 FROM messages m
@@ -1926,7 +1569,6 @@ class StateDB:
             message_ids,
         )
         rows = await cur.fetchall()
-        # Restore progression order (SQL IN doesn't guarantee order)
         by_id = {r["id"]: self._row_to_dict(r) for r in rows}
         return [by_id[mid] for mid in message_ids if mid in by_id]
 
@@ -1994,12 +1636,7 @@ class StateDB:
         reason_actor: str | None = None,
         **fields: Any,
     ) -> None:
-        """Update show fields; route status changes through update_status().
-
-        ADR-0028 Phase 2: status writes go through StateDB.update_status()
-        so reason columns and status_transitions are written atomically.
-        Backwards-compatible deprecation shim mirrors update_invocation().
-        """
+        """Update show fields; route status changes through update_status()."""
         _validate_columns(fields, _SHOW_COLUMNS)
         if "status" in fields:
             _validate_enum(
@@ -2047,7 +1684,6 @@ class StateDB:
             fields["updated_at"] = time.time()
             sets = ", ".join(f"{k} = ?" for k in fields)
             vals = list(fields.values()) + [show_id]
-            # noqa: S608 — column names allowlisted via _validate_columns
             await self.db.execute(
                 f"UPDATE shows SET {sets} WHERE id = ?",  # noqa: S608
                 vals,
@@ -2121,11 +1757,7 @@ class StateDB:
         reason_actor: str | None = None,
         **fields: Any,
     ) -> None:
-        """Update play fields; route status changes through update_status().
-
-        ADR-0028 Phase 2: see update_invocation() / update_show() for
-        the same routing pattern.
-        """
+        """Update play fields; route status changes through update_status()."""
         _validate_columns(fields, _PLAY_COLUMNS)
         if "status" in fields:
             _validate_enum(
@@ -2173,7 +1805,6 @@ class StateDB:
             fields["updated_at"] = time.time()
             sets = ", ".join(f"{k} = ?" for k in fields)
             vals = list(fields.values()) + [play_id]
-            # noqa: S608 — column names allowlisted via _validate_columns
             await self.db.execute(
                 f"UPDATE plays SET {sets} WHERE id = ?",  # noqa: S608
                 vals,
@@ -2191,26 +1822,12 @@ class StateDB:
         content: str,
         message: str | None = None,
     ) -> int:
-        # ADR-0016: Studio's write path is limited to agent + playbook
-        # definitions. Skills and third-party plugin components are
-        # source-controlled, read-only, and must not be versioned through
-        # this API.
         if kind not in _DEFINITION_KINDS:
             raise ValueError(
                 f"Invalid definition kind {kind!r}; "
                 f"ADR-0016 editable set is {sorted(_DEFINITION_KINDS)}"
             )
 
-        # Concurrent saves for the same (kind, name) need a serialization
-        # point: ``SELECT MAX(version)`` + ``INSERT`` is not atomic and
-        # two writers can pick the same next version, with all but one
-        # losing on the ``UNIQUE(kind, name, version)`` index. We
-        # serialize at the Python level with a per-(kind, name)
-        # asyncio.Lock — explicit BEGIN IMMEDIATE would conflict with
-        # aiosqlite's implicit-transaction default. Bounded retry on
-        # IntegrityError catches the residual case where a separate
-        # ``StateDB`` instance (different connection) races us; the
-        # Lock alone handles intra-instance concurrency.
         lock_key = (kind, name)
         lock = self._definition_locks.setdefault(lock_key, Lock())
         async with lock:

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
-"""ADR-0027 scheduler engine — in-process asyncio tick loop."""
+"""Scheduler engine — in-process asyncio tick loop."""
 
 from __future__ import annotations
 
@@ -24,7 +24,6 @@ async def _resolve_invocation_terminal(
     exit_code: int | None = None,
     exception: BaseException | None = None,
 ) -> tuple[str, str, str, list[dict], dict]:
-    """Aggregate child session statuses into an invocation terminal reason."""
     sessions = await db.list_sessions_for_invocation(invocation_id)
     child_statuses = [str(s.get("status") or "") for s in sessions]
     evidence_refs = [{"kind": "session", "id": s["id"]} for s in sessions if s.get("id")]
@@ -35,10 +34,6 @@ async def _resolve_invocation_terminal(
         metadata["exception_class"] = type(exception).__name__
 
     # Precedence: timed_out > failed > aborted > cancelled > completed.
-    # `failed` MUST beat `aborted`/`cancelled` so a real failure isn't
-    # masked by sibling cleanup-cancellation. ADR-0028 §5 cancellation
-    # is system-cascade; preserving the failed signal lets downstream
-    # failure-clustering see the real cause.
     if child_statuses:
         if any(s == "timed_out" for s in child_statuses):
             return (
@@ -57,11 +52,6 @@ async def _resolve_invocation_terminal(
                 metadata,
             )
         if any(s == "aborted" for s in child_statuses):
-            # "aborted" is not exclusively SIGINT: the agent/flow teardown
-            # records CANCELLED_SIGINT, but Studio admin transitions and
-            # `li state doctor` also abort sessions with non-SIGINT reasons.
-            # Surface SIGINT only when an aborted child actually recorded it;
-            # otherwise keep the user/admin abort reason (ABORTED_USER).
             aborted_reasons = {
                 str(sess.get("status_reason_code") or "")
                 for sess in sessions
@@ -161,8 +151,6 @@ class SchedulerEngine:
         self._task: asyncio.Task | None = None
         self._running: dict[str, str] = {}  # schedule_id -> run_id
         self._stopping = False
-        # Tracks outstanding _fire tasks so stop() can cancel and await them,
-        # preventing fire-and-forget orphans after shutdown (LIONAGI-AUDIT-002).
         self._fire_tasks: set[asyncio.Task] = set()
 
     async def start(self) -> None:
@@ -180,8 +168,6 @@ class SchedulerEngine:
             except asyncio.CancelledError:
                 pass
             self._task = None
-        # Cancel and await all outstanding fire tasks so subprocess spawns
-        # do not outlive the scheduler (LIONAGI-AUDIT-002 fix).
         if self._fire_tasks:
             for ft in list(self._fire_tasks):
                 ft.cancel()
@@ -189,18 +175,13 @@ class SchedulerEngine:
             self._fire_tasks.clear()
 
     def _tracked_fire(self, *args: Any, **kwargs: Any) -> asyncio.Task:
-        """Create a _fire task and keep a reference until it completes.
-
-        Prevents fire-and-forget orphan tasks from surviving scheduler shutdown.
-        The done callback removes the handle from the tracking set automatically.
-        """
+        """Create a tracked _fire task; prevents orphans surviving shutdown."""
         task = asyncio.create_task(self._fire(*args, **kwargs))
         self._fire_tasks.add(task)
         task.add_done_callback(self._fire_tasks.discard)
         return task
 
     async def fire_now(self, schedule_id: str) -> str | None:
-        """Manual trigger — fire a schedule immediately. Returns run_id."""
         async with StateDB() as db:
             schedule = await db.get_schedule(schedule_id)
         if not schedule:
@@ -212,7 +193,6 @@ class SchedulerEngine:
         return run_id
 
     async def _tick_loop(self) -> None:
-        # On startup, check for missed fires
         await self._check_missed_fires()
         while not self._stopping:
             try:
@@ -232,8 +212,6 @@ class SchedulerEngine:
                     continue
                 policy = s.get("missed_fire_policy")
                 if policy == "run_once":
-                    # Recover by firing once; the resulting schedule_run
-                    # row gets ScheduleReasons.FIRED_DUE via _fire().
                     run_id = uuid.uuid4().hex[:12]
                     _log.info(
                         "Missed fire recovery for schedule %s (%s)",
@@ -246,23 +224,12 @@ class SchedulerEngine:
                         trigger_context={"missed_recovery": True, "fired_at": now},
                     )
                 else:
-                    # policy in {"skip", default}: drop the missed fire,
-                    # but record the skip so operators can see why.
-                    # ADR-0028 § ScheduleReasons.SKIPPED_MISSED_FIRE is
-                    # the canonical code for this case.
                     await self._record_missed_fire_skip(s, now)
         except Exception:
             _log.exception("Missed fire check error")
 
     async def _record_missed_fire_skip(self, schedule: dict, now: float) -> None:
-        """Create a schedule_runs row recording the missed-fire skip.
-
-        Writes status="skipped" with reason_code=SKIPPED_MISSED_FIRE so
-        downstream attention-queue / failure-grouping (ADR-0028, ADR-0030)
-        can distinguish missed-fire skips from overlap skips and normal
-        due fires. Also advances next_fire_at so the schedule doesn't
-        re-trigger this same skip every tick.
-        """
+        """Record missed-fire skip and advance next_fire_at."""
         skipped_run_id = uuid.uuid4().hex[:12]
         try:
             async with StateDB() as db:
@@ -299,8 +266,6 @@ class SchedulerEngine:
                         "missed_fire_at": schedule.get("next_fire_at"),
                     },
                 )
-                # Advance next_fire_at so this schedule doesn't keep
-                # producing skip rows for the same missed slot.
                 next_at = self._compute_next_fire(schedule, now)
                 if next_at:
                     await db.update_schedule(schedule["id"], next_fire_at=next_at)
@@ -324,7 +289,6 @@ class SchedulerEngine:
                     if nfa is not None and nfa <= now:
                         await self._maybe_fire(s, now)
                     elif nfa is None:
-                        # First run — compute next_fire_at
                         next_at = self._compute_next_fire(s, now)
                         if next_at:
                             async with StateDB() as db:
@@ -350,7 +314,6 @@ class SchedulerEngine:
             await self._fire(schedule, run_id, trigger_context=ctx)
 
     async def _maybe_fire(self, schedule: dict, now: float) -> None:
-        # Overlap check
         if schedule.get("overlap_policy") == "skip" and schedule["id"] in self._running:
             _log.debug("Skipping overlapping fire for %s", schedule["name"])
             skipped_run_id = uuid.uuid4().hex[:12]
@@ -377,7 +340,6 @@ class SchedulerEngine:
                     actor=schedule["id"],
                     metadata={"overlap_policy": schedule.get("overlap_policy")},
                 )
-            # Still advance next_fire_at
             next_at = self._compute_next_fire(schedule, now)
             if next_at:
                 async with StateDB() as db:
@@ -402,7 +364,6 @@ class SchedulerEngine:
         sid = schedule["id"]
         now = time.time()
 
-        # Create invocation
         inv_id = uuid.uuid4().hex[:12]
         async with StateDB() as db:
             await db.create_invocation(
@@ -416,14 +377,6 @@ class SchedulerEngine:
                 }
             )
 
-        # Build argv. A build failure (e.g. an invalid action_kind that slipped
-        # past the Studio API, which only checks presence) must be recorded
-        # deterministically: the invocation already exists as `running` and no
-        # schedule_run row exists yet, so the generic handler below would call
-        # update_status() on a missing row (LookupError) and leave the
-        # invocation stuck `running`. Record a failed run + fail the invocation
-        # here, advance next_fire so it doesn't re-fire the bad schedule every
-        # tick, and return.
         try:
             argv = build_argv(schedule, trigger_context)
         except Exception as exc:
@@ -479,7 +432,6 @@ class SchedulerEngine:
                 await db.update_schedule(sid, **update_fields)
             return
 
-        # Create schedule_run
         async with StateDB() as db:
             await db.create_schedule_run(
                 {
@@ -507,11 +459,9 @@ class SchedulerEngine:
                 metadata={"trigger_context": trigger_context, "chain_depth": chain_depth},
             )
 
-        # Track as running
         if chain_depth == 0:
             self._running[sid] = run_id
 
-        # Update last_fired_at and compute next
         next_at = self._compute_next_fire(schedule, now)
         update_fields: dict[str, Any] = {"last_fired_at": now}
         if next_at:
@@ -523,7 +473,6 @@ class SchedulerEngine:
             "Firing schedule %s (run %s, chain_depth=%d)", schedule["name"], run_id, chain_depth
         )
 
-        # Spawn and wait
         try:
             exit_code, stderr_tail = await spawn_and_wait(argv, inv_id)
             end_time = time.time()
@@ -571,7 +520,6 @@ class SchedulerEngine:
                     metadata=inv_meta,
                 )
 
-            # Evaluate chain
             if chain_depth < _MAX_CHAIN_DEPTH:
                 chain_action = None
                 if exit_code == 0 and schedule.get("on_success"):
@@ -609,10 +557,6 @@ class SchedulerEngine:
                     )
 
         except asyncio.CancelledError:
-            # Scheduler shutdown (stop() cancels outstanding fire tasks).
-            # spawn_and_wait has already terminated the child; record the run
-            # and invocation as cancelled so they don't linger as `running`,
-            # then re-raise to honour cooperative cancellation.
             _log.info("Schedule fire cancelled %s (run %s)", schedule.get("name"), run_id)
             _end_time = time.time()
             try:
@@ -711,5 +655,4 @@ class SchedulerEngine:
         return None
 
 
-# Module-level singleton — imported by app.py lifespan and by the trigger endpoint
 scheduler = SchedulerEngine()

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -148,14 +148,7 @@ async def doctor(*, stale_hours: float = 1.0) -> dict[str, Any]:
 
 
 async def health_report() -> dict[str, Any]:
-    """Composite session health snapshot for the admin console.
-
-    Layers ADR-0024's ``classify_session_health`` over the existing
-    phantom checks: process liveness comes from the same PID/ps scan
-    that ``doctor`` uses; artifacts/locks come from the run directory.
-    Terminal sessions are classified too (so we can spot zombies left
-    behind by past crashes).
-    """
+    """Composite session health snapshot for the admin console."""
     from collections import Counter
 
     from lionagi.state.health import (
@@ -192,7 +185,6 @@ async def health_report() -> dict[str, Any]:
     unhealthy: list[dict[str, Any]] = []
 
     for row in rows:
-        # Convert sqlite3.Row to dict for the pure classifier.
         sess = {k: row[k] for k in row.keys()}
         status = sess.get("status") or "completed"
         by_status[status] += 1
@@ -201,17 +193,12 @@ async def health_report() -> dict[str, Any]:
         has_artifacts = artifacts is not None and artifacts.exists()
         has_stale_locks = False
         if artifacts is not None and artifacts.exists():
-            # Lock check is cheap (one glob) but only matters for
-            # candidate-zombie terminal sessions and stale-process
-            # running ones. Skip for clearly-healthy active ones.
             cutoff = now - 3600
             has_stale_locks = _find_stale_lock(artifacts, cutoff=cutoff) is not None
 
         if status == "running":
             process_alive = _live_process_matches(row["id"], artifacts)
         else:
-            # Terminal session — process_alive is moot; classifier only
-            # uses it on the running branch.
             process_alive = False
 
         health = classify_session_health(
@@ -223,7 +210,6 @@ async def health_report() -> dict[str, Any]:
         )
         by_health[health.value] += 1
 
-        # "Unhealthy" = anything that warrants operator attention.
         if health not in (SessionHealth.HEALTHY, SessionHealth.IDLE):
             last_activity = (
                 sess.get("last_message_at") or sess.get("updated_at") or sess.get("started_at") or 0
@@ -259,12 +245,8 @@ async def health_report() -> dict[str, Any]:
     }
 
 
-# ADR-0025: admin operators cannot mark sessions completed/timed_out —
-# those are system-determined. Mirror the Python guard from db.py here
-# so the API rejects the request before touching the DB.
 _ADMIN_TRANSITION_TARGETS: frozenset[str] = frozenset({"failed", "aborted", "cancelled"})
 
-# ADR-0028 §5: phantom-classifier (PhantomReason) → reason code mapping.
 _PHANTOM_REASON_CODES: dict[str, str] = {
     "process_dead": SessionReasons.HEALTH_PHANTOM_PROCESS_DEAD,
     "missing_artifacts": SessionReasons.HEALTH_PHANTOM_MISSING_ARTIFACTS,
@@ -272,30 +254,14 @@ _PHANTOM_REASON_CODES: dict[str, str] = {
 }
 
 
-# ADR-0028 §5: SessionHealth (read-time) → reason code mapping. The
-# phantom resolver checks this AFTER the PhantomReason map so a
-# concrete phantom cause wins, but a non-phantom unhealthy session
-# (STALE without lock, ORPHANED, IDLE-but-process-dead) still gets a
-# specific reason code instead of falling back to the operator's
-# generic choice.
 def _resolve_session_health_reason_code(
     *,
     phantom_reason: str | None,
     health,  # SessionHealth enum from lionagi.state.health
 ) -> str | None:
-    """Return the most-specific health-derived reason code, or None.
-
-    Returns None when neither classifier yields a specific cause —
-    callers should keep the operator's `reason_code` in that case.
-    """
+    """Return the most-specific health-derived reason code, or None."""
     if phantom_reason is not None:
-        # PhantomReason wins — the phantom classifier names a concrete
-        # filesystem-level cause (dead process, missing artifacts, stale
-        # lock) that's more actionable than a generic health label.
         return _PHANTOM_REASON_CODES.get(phantom_reason)
-    # Non-phantom unhealthy states use SessionReasons.HEALTH_* codes.
-    # Map by enum name so changes to the SessionHealth enum surface
-    # here at import time, not at runtime.
     from lionagi.state.health import SessionHealth
 
     if health == SessionHealth.STALE:
@@ -317,21 +283,7 @@ async def transition_sessions(
     actor: str = "admin",
     legacy_reason: str | None = None,
 ) -> dict[str, Any]:
-    """Mark running sessions terminal with an audit-log entry.
-
-    ADR-0024 §B replaces the blunt "prune" with "transition": the session
-    row + messages + artifacts are preserved for debugging. Guards:
-
-    * ``target_status`` must be in ``ADMIN_TRANSITION_TARGETS``.
-    * Only ``running`` sessions are touched; already-terminal ones are
-      reported in ``skipped`` so the caller can warn the operator.
-    * HEALTHY and IDLE sessions are refused with ValueError (→ 422) to
-      prevent accidental termination of active sessions (ADR-0024 health
-      guard).
-    * The DB update is conditional on ``status='running'`` in the WHERE
-      clause to close the TOCTOU window between the pre-check read and the
-      write.
-    """
+    """Mark running sessions terminal with an audit-log entry."""
     from lionagi.state.reasons import validate_reason_code
 
     if target_status not in _ADMIN_TRANSITION_TARGETS:
@@ -356,9 +308,6 @@ async def transition_sessions(
     now = time.time()
 
     async with StateDB() as db:
-        # Health guard + UPDATE merged into one loop per session.
-        # Re-classify each session immediately before the UPDATE to minimize
-        # the TOCTOU window between the guard read and the destructive write.
         for sid in session_ids:
             current = await db.get_session(sid)
             if current is None:
@@ -369,7 +318,6 @@ async def transition_sessions(
                     {"session_id": sid, "reason": f"not_running:{current.get('status')}"}
                 )
                 continue
-            # Snapshot health-relevant timestamps for the atomic WHERE below.
             _snap_last_msg = current.get("last_message_at")
             _snap_updated = current.get("updated_at")
             artifacts = _artifacts_path(current)
@@ -393,12 +341,6 @@ async def transition_sessions(
                     "Only unhealthy sessions may be force-transitioned."
                 )
 
-            # Health/phantom classification overrides the operator reason
-            # code when a concrete cause is available (ADR-0028 §5).
-            # _resolve_session_health_reason_code() returns the
-            # most-specific code — PhantomReason takes priority over
-            # SessionHealth so a dead process / missing artifacts /
-            # stale lock isn't masked by the broader STALE label.
             phantom_reason = _classify_phantom(current, now=now, stale_seconds=3600)
             classifier_code = _resolve_session_health_reason_code(
                 phantom_reason=phantom_reason,
@@ -409,8 +351,6 @@ async def transition_sessions(
             effective_evidence_refs: list[dict[str, Any]] = list(evidence_refs)
             if classifier_code is not None:
                 effective_reason_code = classifier_code
-                # Preserve the operator's narrative when they bothered
-                # to write one; otherwise synthesize from the classifier.
                 if not reason_summary:
                     cause = phantom_reason or health.value
                     effective_reason_summary = (
@@ -433,18 +373,6 @@ async def transition_sessions(
                         }
                     )
 
-            # ADR-0028: the conditional sessions UPDATE and the
-            # status_transitions INSERT must commit together. The
-            # earlier two-commit layout had a window where a crash
-            # between commits left the session terminal with no
-            # history row — the exact drift ADR-0028 §4 says must
-            # not happen.
-            #
-            # BEGIN IMMEDIATE acquires the write lock up front so the
-            # TOCTOU window is the same length as before (we already
-            # held the SQLite connection; this just makes the lock
-            # explicit instead of letting aiosqlite take it lazily on
-            # the first write).
             await db.db.execute("BEGIN IMMEDIATE")
             try:
                 cur = await db.db.execute(
@@ -468,16 +396,11 @@ async def transition_sessions(
                     ),
                 )
                 if cur.rowcount == 0:
-                    # No row to transition — roll back the empty
-                    # transaction so we don't leave a no-op BEGIN
-                    # blocking the connection.
                     await db.db.rollback()
                     existing = await db.get_session(sid)
                     if existing is None:
                         skipped.append({"session_id": sid, "reason": "not_found"})
                     elif existing.get("status") == "running":
-                        # Status is still running but timestamps changed
-                        # between snapshot and UPDATE — concurrent heartbeat.
                         skipped.append(
                             {
                                 "session_id": sid,
@@ -492,7 +415,6 @@ async def transition_sessions(
                             }
                         )
                     continue
-                # Append the transition row inside the same transaction.
                 await db.db.execute(
                     "INSERT INTO status_transitions "
                     "(id, entity_type, entity_id, previous_status, status, "
@@ -522,8 +444,6 @@ async def transition_sessions(
                 )
                 await db.db.commit()
             except BaseException:
-                # Any failure between BEGIN and COMMIT rolls back both
-                # writes, restoring the running session.
                 await db.db.rollback()
                 raise
             transitioned.append(sid)
@@ -565,7 +485,7 @@ async def list_admin_events(
 
 
 async def prune_sessions(session_ids: list[str]) -> int:
-    """Delete sessions by explicit ID list (intentional admin action; unconditional)."""
+    """Delete sessions by explicit ID list."""
     seen: dict[str, None] = {}
     for sid in session_ids:
         seen[sid] = None
@@ -593,20 +513,7 @@ async def prune_sessions(session_ids: list[str]) -> int:
 
 
 async def prune_phantom_sessions(*, stale_hours: float = 1.0) -> int:
-    """Prune phantom sessions with a TOCTOU-safe guarded DELETE.
-
-    Re-checks the phantom condition atomically in the WHERE clause so sessions
-    that transitioned to a terminal state between classification and deletion are
-    never removed.
-
-    Guard strategy is per-reason:
-    - ``process_dead`` / ``stale_lock``: require ``status = 'running' AND
-      updated_at <= stale_cutoff`` (staleness confirms the process is gone).
-    - ``missing_artifacts``: require ``status = 'running' AND updated_at <=
-      stale_cutoff`` — same guard as stale reasons to prevent deleting a session
-      that recovered (created its artifacts + heartbeated) between classification
-      and deletion.
-    """
+    """Prune phantom sessions with a TOCTOU-safe guarded DELETE."""
     phantoms = await list_phantom_sessions(stale_hours=stale_hours)
     if not phantoms or not DEFAULT_DB_PATH.exists():
         return 0

--- a/lionagi/studio/services/runs.py
+++ b/lionagi/studio/services/runs.py
@@ -13,8 +13,6 @@ from ._path_safety import public_path, safe_path_join
 
 _STATUS_ALIASES: dict[str, set[str]] = {
     "done": {"done", "completed", "success", "finished"},
-    # ADR-0025: cancelled (system/orchestrator) and aborted (Ctrl-C) are
-    # operationally distinct; only collapse the US/UK spelling.
     "cancelled": {"cancelled", "canceled"},
     "canceled": {"cancelled", "canceled"},
     "aborted": {"aborted", "aborted_after_finish"},
@@ -43,7 +41,6 @@ def _normalize_status_filter(status: str | list[str] | None) -> set[str] | None:
 def _adapt_summary(
     manifest: dict[str, Any], run_id: str, state_root: Path, artifact_root: Path
 ) -> dict[str, Any]:
-    """Return a RunSummary-shaped dict from a manifest and run paths."""
     branches_dir = state_root / "branches"
     step_count = 0
     if branches_dir.exists():
@@ -105,7 +102,6 @@ def _adapt_summary(
 
 
 def _build_graph(manifest: dict[str, Any]) -> dict[str, Any]:
-    """Build a graph from manifest data — tries graph, then agents+operations."""
     graph_raw = manifest.get("graph")
     if graph_raw and (graph_raw.get("nodes") or graph_raw.get("edges")):
         return {
@@ -172,11 +168,8 @@ def _build_graph(manifest: dict[str, Any]) -> dict[str, Any]:
 
 
 def _summarize_args(fn: str, args: dict[str, Any]) -> str:
-    """Return a one-line readable summary of tool call arguments."""
     if not isinstance(args, dict):
         return str(args)[:200]
-    # Common argument key precedence — codex uses `cmd`, claude_code uses
-    # `command`, file tools use `file_path`, edit/write also have `content`.
     for key in ("cmd", "command", "file_path", "pattern", "url", "query"):
         val = args.get(key)
         if val:
@@ -184,7 +177,6 @@ def _summarize_args(fn: str, args: dict[str, Any]) -> str:
     if fn in ("apply_patch", "Edit", "Write"):
         path = args.get("path") or args.get("file_path") or ""
         return str(path) if path else "(patch)"
-    # Fallback: show first non-trivial arg.
     for k, v in args.items():
         if isinstance(v, str | int | float) and v:
             return f"{k}={v}"
@@ -192,7 +184,6 @@ def _summarize_args(fn: str, args: dict[str, Any]) -> str:
 
 
 def _detect_status(output: str, function: str) -> tuple[str, int | None]:
-    """Heuristic: extract status (ok|error) and exit code from tool output."""
     if not output:
         return ("ok", None)
     lower = output.lower()
@@ -219,12 +210,6 @@ def _detect_status(output: str, function: str) -> tuple[str, int | None]:
 
 
 def _extract_messages(branch: dict[str, Any]) -> list[dict[str, Any]]:
-    """Extract readable messages from a branch's Pile-serialized messages.
-
-    Pairs ActionRequest + ActionResponse by `action_response_id` /
-    `action_request_id` so each tool invocation becomes a single rich entry
-    with command, output, status, and exit code.
-    """
     msgs_raw = branch.get("messages", {})
     if isinstance(msgs_raw, list):
         collections = msgs_raw
@@ -233,7 +218,6 @@ def _extract_messages(branch: dict[str, Any]) -> list[dict[str, Any]]:
     else:
         return []
 
-    # First pass: build response_id -> ActionResponse map for pairing.
     response_by_id: dict[str, dict[str, Any]] = {}
     for item in collections:
         if not isinstance(item, dict):
@@ -270,7 +254,6 @@ def _extract_messages(branch: dict[str, Any]) -> list[dict[str, Any]]:
             ):
                 continue
 
-        # Render System
         if role == "system":
             text = content.get("system_message", "") if isinstance(content, dict) else str(content)
             if text:
@@ -284,7 +267,6 @@ def _extract_messages(branch: dict[str, Any]) -> list[dict[str, Any]]:
                 )
             continue
 
-        # Render User (Instruction)
         if role == "user":
             if isinstance(content, dict):
                 text = content.get("instruction") or ""
@@ -306,7 +288,6 @@ def _extract_messages(branch: dict[str, Any]) -> list[dict[str, Any]]:
                 )
             continue
 
-        # Render Assistant
         if role == "assistant":
             text = (
                 content.get("assistant_response", "") if isinstance(content, dict) else str(content)
@@ -322,7 +303,6 @@ def _extract_messages(branch: dict[str, Any]) -> list[dict[str, Any]]:
                 )
             continue
 
-        # Render Action (tool call) — pair request with its response
         if role == "action" and cls == "ActionRequest":
             args = content.get("arguments", {}) if isinstance(content, dict) else {}
             fn = content.get("function", "") if isinstance(content, dict) else ""
@@ -355,7 +335,6 @@ def _extract_messages(branch: dict[str, Any]) -> list[dict[str, Any]]:
             )
             continue
 
-        # Orphan action_response (shouldn't normally happen)
         if role == "action":
             args = content.get("arguments", {}) if isinstance(content, dict) else {}
             fn = content.get("function", "") if isinstance(content, dict) else ""
@@ -381,7 +360,6 @@ def _extract_messages(branch: dict[str, Any]) -> list[dict[str, Any]]:
 def _build_steps(
     manifest: dict[str, Any], branches: list[dict[str, Any]]
 ) -> list[dict[str, Any]] | None:
-    """Build step results from operations + branches when steps aren't explicit."""
     operations = manifest.get("operations") or []
     agents = manifest.get("agents") or []
 
@@ -473,7 +451,6 @@ def _adapt_detail(
     manifest: dict[str, Any],
     branches: list[dict[str, Any]],
 ) -> dict[str, Any]:
-    """Return a RunDetail-shaped dict."""
     summary = _adapt_summary(manifest, run_id, state_root, artifact_root)
     graph = _build_graph(manifest)
     steps = manifest.get("steps")
@@ -505,27 +482,10 @@ async def list_runs(
     status: str | list[str] | None = None,
     project: str | None = None,
 ) -> list[dict[str, Any]]:
-    """List runs from SQLite sessions table (F-A1-1, ADR-0004 rewire).
-
-    Each session row is mapped to a RunSummary-shaped dict so routers and
-    app.py see a consistent shape. The ``playbook`` filter is a
-    case-insensitive contains match; ``status`` supports multiple values with
-    alias normalization (e.g. "done" matches "completed").
-
-    Decision (F-A1-3): stream_run_events() was removed entirely because the
-    ``stream/*.buffer.jsonl`` files it read are explicitly forbidden as a
-    Studio query source by ADR-0004 ("Studio query routes MUST NOT read
-    them"), and the ``lineage`` / messages rows in SQLite are the correct
-    alternative via the sessions SSE endpoint already implemented in
-    routers/sessions.py.  The /api/runs/{id}/events route in routers/runs.py
-    is removed in the same commit.
-    """
     from lionagi.state.health import SessionHealth, classify_session_health
 
     sessions = await _sessions_svc.list_sessions()
     status_set = _normalize_status_filter(status)
-    # One shared "now" so two adjacent sessions can't disagree about
-    # whether the same elapsed time crossed the threshold.
     now = time.time()
     out = []
     for s in sessions:
@@ -535,13 +495,6 @@ async def list_runs(
             continue
         if status_set and s.get("status") not in status_set:
             continue
-        # ADR-0024: process liveness + artifact / lock signals would be
-        # checked here for full classification. Studio reads come from
-        # SQLite only — process/FS checks happen in admin endpoints
-        # where they're explicitly opted into. For the runs list we
-        # assume process_alive=True (we'd have heard otherwise via the
-        # CLI teardown), and fall back to the activity-only signal that
-        # gives stale / unresponsive / idle / healthy + zombie.
         health = classify_session_health(
             s,
             now=now,
@@ -549,11 +502,7 @@ async def list_runs(
             has_artifacts=bool(s.get("artifacts_path")),
             has_stale_locks=False,
         )
-        # UNRESPONSIVE and STALE both mean "past activity threshold, needs
-        # operator attention". The runs list assumes process_alive=True so
-        # it never emits STALE naturally; the dashboard frontend counts
-        # effective_health === 'stale'. Map UNRESPONSIVE → 'stale' so the
-        # dashboard counter stays correct without requiring a frontend change.
+        # Map UNRESPONSIVE -> 'stale' for dashboard consistency.
         effective_health = (
             SessionHealth.STALE.value if health == SessionHealth.UNRESPONSIVE else health.value
         )
@@ -568,12 +517,9 @@ async def list_runs(
                 "show_topic": s.get("show_topic"),
                 "show_play_name": s.get("show_play_name"),
                 "source_kind": s.get("source_kind", "live"),
-                # ADR-0029: expected artifact contract and teardown verification.
                 "artifact_contract_json": s.get("artifact_contract_json"),
                 "artifact_verification_json": s.get("artifact_verification_json"),
-                # ADR-0020: parent skill orchestration; null when standalone.
                 "invocation_id": s.get("invocation_id"),
-                # ADR-0022: provenance disclosure.
                 "model": s.get("model"),
                 "provider": s.get("provider"),
                 "effort": s.get("effort"),
@@ -583,12 +529,10 @@ async def list_runs(
                 "ended_at": s.get("ended_at"),
                 "created_at": s.get("created_at"),
                 "updated_at": s.get("updated_at"),
-                # ADR-0019/0024: activity marker + derived health label.
                 "last_message_at": s.get("last_message_at"),
                 "effective_health": effective_health,
                 "branch_count": s.get("branch_count", 0),
                 "message_count": s.get("message_count", 0),
-                # ADR-0026: project detection.
                 "project": s.get("project"),
                 "project_source": s.get("project_source"),
             }
@@ -602,7 +546,6 @@ def paginate_runs(
     page: int,
     per_page: int,
 ) -> dict[str, Any]:
-    """Slice *runs* into a page and return pagination metadata."""
     total = len(runs)
     total_pages = math.ceil(total / per_page) if total else 0
     start = (page - 1) * per_page
@@ -622,8 +565,7 @@ def get_run(run_id: str) -> dict[str, Any] | None:
     if not RUNS_ROOT.exists():
         return None
 
-    # Validate + resolve the run_id path component
-    safe_path_join(RUNS_ROOT, run_id)  # raises 404 if unsafe
+    safe_path_join(RUNS_ROOT, run_id)
 
     state_root = RUNS_ROOT / run_id
     if not state_root.is_dir():
@@ -659,11 +601,3 @@ def get_run(run_id: str) -> dict[str, Any] | None:
                 pass
 
     return _adapt_detail(run_id, state_root, artifact_root, manifest, branches)
-
-
-# stream_run_events() was removed (F-A1-3 / ADR-0004).
-# ADR-0004 §"Run persistence: SQLite only" explicitly forbids Studio from
-# reading stream/*.buffer.jsonl files.  Live monitoring of a run uses the
-# /api/sessions/{id}/stream SSE endpoint (routers/sessions.py) which reads
-# from SQLite messages rows.  The /api/runs/{id}/events route in
-# routers/runs.py has been removed in the same commit.

--- a/lionagi/tools/coding.py
+++ b/lionagi/tools/coding.py
@@ -36,7 +36,6 @@ _DENIED_NAMES: frozenset[str] = frozenset(
 def _resolve_workspace_path(path: str, workspace_root: Path) -> Path:
     raw = Path(path).expanduser()
     candidate = raw if raw.is_absolute() else workspace_root / raw
-    # GAP B: check symlink on candidate BEFORE resolve() follows it
     if candidate.is_symlink():
         raise PermissionError(f"Refusing to access symlink: {path!r}")
     resolved = candidate.resolve(strict=False)
@@ -412,9 +411,6 @@ def _edit_file_sync(
     count = original.count(old_string)
     if count == 0:
         hint = ""
-        # Most common cause on a fresh read: the model copied the reader's
-        # `<number>\t` line-number prefix into old_string. If stripping a
-        # leading "<digits><tab>" from each line WOULD match, say so.
         stripped = re.sub(r"(?m)^\s*\d+\t", "", old_string)
         if stripped != old_string and stripped in original:
             hint = (
@@ -455,14 +451,12 @@ def _edit_file_sync(
     }
 
 
-# GAP A: shell control operators — same pattern as bash.py
 _SHELL_CONTROL = re.compile(r"(;|&&|\|\||\||`|\$\(|[<>]|\n)")
 
 _MAX_OUTPUT_BYTES = 100_000
 
 
 def _drain_stream(stream, buf: bytearray) -> bool:
-    """Continues reading even after cap to prevent pipe-buffer deadlock."""
     truncated = False
     while True:
         try:
@@ -555,7 +549,6 @@ def _subprocess_sync(cmd, shell: bool, timeout_s: float, cwd: str | None) -> dic
 # ---------------------------------------------------------------------------
 
 
-#: Every tool the coding toolkit can build.
 ALL_CODING_TOOLS: tuple[str, ...] = (
     "reader",
     "editor",
@@ -566,48 +559,11 @@ ALL_CODING_TOOLS: tuple[str, ...] = (
     "subagent",
 )
 
-#: Tools registered by default — the proven, in-use core. ``context`` (manual
-#: context eviction), ``sandbox`` (git-worktree sessions), and ``subagent``
-#: (delegation) are opt-in: they add capability surface the agent rarely uses,
-#: and delegation in particular shouldn't be advertised before a single agent is
-#: solid. Enable extras explicitly via ``CodingToolkit(tools=[...])``.
 DEFAULT_CODING_TOOLS: tuple[str, ...] = ("reader", "editor", "bash", "search")
 
 
 class CodingToolkit(LionTool):
-    """Coding tools bound to a Branch with shared file state and hooks.
-
-    Usage::
-
-        toolkit = CodingToolkit()
-
-        # Register hooks before binding
-        async def guard_destructive(tool_name, action, args):
-            cmd = args.get("command", "")
-            if "rm -rf" in cmd:
-                raise PermissionError(f"Blocked: {cmd}")
-
-        async def auto_format(tool_name, action, args, result):
-            if result.get("success") and args.get("file_path", "").endswith(".py"):
-                # run formatter...
-                pass
-            return result
-
-        toolkit.pre("bash", guard_destructive)
-        toolkit.post("editor", auto_format)
-
-        tools = toolkit.bind(branch)
-        branch.register_tools(tools)
-
-    Hook signatures:
-        pre:  async def handler(tool_name: str, action: str, args: dict) -> dict | None
-              - Return modified args dict to override, or None to pass through.
-              - Raise to abort the tool call (exception propagates as error result).
-        post: async def handler(tool_name: str, action: str, args: dict, result: dict) -> dict | None
-              - Return modified result dict to override, or None to pass through.
-        on_error: async def handler(tool_name: str, action: str, args: dict, error: Exception) -> dict | None
-              - Return a result dict to suppress the error, or None to propagate.
-    """
+    """Coding tools (reader, editor, bash, search, etc.) bound to a Branch."""
 
     is_lion_system_tool = True
     system_tool_name = "coding_toolkit"
@@ -629,7 +585,6 @@ class CodingToolkit(LionTool):
         return self
 
     def _build_preprocessor(self, tool_name: str) -> Callable | None:
-        """Build a chained preprocessor from registered hooks for this tool."""
         security_hooks = [
             *self._security_pre_hooks.get("*", []),
             *self._security_pre_hooks.get(tool_name, []),
@@ -655,7 +610,6 @@ class CodingToolkit(LionTool):
         return chained_pre
 
     def _build_postprocessor(self, tool_name: str) -> Callable | None:
-        """Build a chained postprocessor from registered post-hooks for this tool."""
         hooks = [
             *self._post_hooks.get(tool_name, []),
             *self._post_hooks.get("*", []),
@@ -690,8 +644,6 @@ class CodingToolkit(LionTool):
         self.notify_threshold = notify_threshold
         self.notify_max_tokens = notify_max_tokens
         self.workspace_root = Path(workspace_root or Path.cwd()).expanduser().resolve()
-        # Which tools to register. None -> the lean default core; pass an explicit
-        # list to opt into context/sandbox/subagent.
         selected = tuple(tools) if tools is not None else DEFAULT_CODING_TOOLS
         unknown = [t for t in selected if t not in ALL_CODING_TOOLS]
         if unknown:
@@ -767,8 +719,6 @@ class CodingToolkit(LionTool):
             if resolved and mtime is not None:
                 file_state[resolved] = mtime
 
-        # -- Reader ----------------------------------------------------------
-
         async def reader(
             action: str,
             path: str,
@@ -793,8 +743,6 @@ class CodingToolkit(LionTool):
                     _list_dir_sync, path, bool(recursive), file_types, workspace_root
                 )
             return {"success": False, "error": f"Unknown action: {action}"}
-
-        # -- Editor ----------------------------------------------------------
 
         async def editor(
             action: str,
@@ -845,8 +793,6 @@ class CodingToolkit(LionTool):
                 return result
             return {"success": False, "error": f"Unknown action: {action}"}
 
-        # -- Bash ------------------------------------------------------------
-
         async def bash(
             command: str,
             timeout: int = None,
@@ -862,7 +808,6 @@ class CodingToolkit(LionTool):
             timeout_ms = max(1, min(timeout or 30000, 300000))
             timeout_s = timeout_ms / 1000.0
 
-            # GAP A: reject shell control operators (same filter as standalone BashTool)
             if _SHELL_CONTROL.search(command):
                 return {
                     "stdout": "",
@@ -885,8 +830,6 @@ class CodingToolkit(LionTool):
             result.setdefault("timed_out", False)
             result["return_code"] = result.pop("returncode", -1)
             return result
-
-        # -- Search ----------------------------------------------------------
 
         async def search(
             action: str,
@@ -940,10 +883,7 @@ class CodingToolkit(LionTool):
                 }
             return {"success": False, "error": f"Unknown action: {action}"}
 
-        # -- Context ---------------------------------------------------------
-
         def _ensure_current_progression():
-            """Lazily copy full progression into metadata on first evict."""
             if "current_progression" not in branch.metadata:
                 from lionagi.protocols.generic.progression import Progression
 
@@ -1058,8 +998,6 @@ class CodingToolkit(LionTool):
 
             return {"success": False, "error": f"Unknown action: {action}"}
 
-        # -- System notification as built-in post-hook -----------------------
-
         async def _notify_post(
             tool_name: str, action: str, args: dict, result: dict
         ) -> dict | None:
@@ -1071,9 +1009,7 @@ class CodingToolkit(LionTool):
         if notify:
             self.post("*", _notify_post)
 
-        # -- Sandbox ---------------------------------------------------------
-
-        _sandbox_session = [None]  # mutable ref for closure
+        _sandbox_session = [None]
 
         async def sandbox(
             action: str,
@@ -1141,8 +1077,6 @@ class CodingToolkit(LionTool):
                 return {"success": True, **result}
 
             return {"success": False, "error": f"Unknown action: {action}"}
-
-        # -- Subagent --------------------------------------------------------
 
         async def subagent(
             instruction: str,
@@ -1212,8 +1146,6 @@ class CodingToolkit(LionTool):
                 }
             except Exception as e:
                 return {"success": False, "error": str(e)}
-
-        # -- Assemble (hooks wired via Tool's native pre/postprocessor) ------
 
         tool_defs = [
             ("reader", reader, ReaderRequest),


### PR DESCRIPTION
## Summary
- Trimmed ~1,102 lines from 10 files: state/db, studio services, scheduler, hooks, engines, casts, tools, config
- StateDB alone lost ~235 docstring lines; coding toolkit similarly trimmed

## Test plan
- [x] `uv run ruff check` — clean
- [x] `uv run pytest --co` — all tests collect

🤖 Generated with [Claude Code](https://claude.com/claude-code)