### PR TITLE
ci: coverage on one version + uv cache + gate perf tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,15 +66,32 @@ jobs:
         curl -LsSf https://astral.sh/uv/install.sh | sh
         echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
+    - name: Cache uv downloads
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/uv
+        key: uv-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('uv.lock') }}
+        restore-keys: |
+          uv-${{ runner.os }}-py${{ matrix.python-version }}-
+
     - name: Install dependencies
       run: |
         uv venv
         uv sync --all-extras
 
+    # Coverage runs on 3.10 only (present in both the PR and the full matrix);
+    # other versions run without coverage instrumentation — 5-10x faster.
+    # Codecov is uploaded only from the coverage run.
     - name: Run tests with coverage
+      if: matrix.python-version == '3.10'
       run: scripts/ci.sh test-python-cov
 
+    - name: Run tests
+      if: matrix.python-version != '3.10'
+      run: scripts/ci.sh test-python
+
     - name: Upload coverage reports to Codecov
+      if: matrix.python-version == '3.10'
       uses: codecov/codecov-action@v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -37,11 +37,15 @@ fmt-python() {
   uv run ruff check --fix "${@:-.}" 2>/dev/null || true
 }
 
+# Wall-clock perf/scaling tests are unreliable under CI load + coverage; they
+# are gated behind the `performance` marker and validated by benchmarks.yml.
+# Override with PYTEST_MARKEXPR=performance (or "") to run them locally.
 test-python() {
   echo "==> pytest"
   uv run pytest \
     --asyncio-mode=auto \
     --maxfail="${MAXFAIL:-3}" \
+    -m "${PYTEST_MARKEXPR:-not performance}" \
     --disable-warnings \
     "${@:-tests/}"
 }
@@ -51,6 +55,7 @@ test-python-cov() {
   uv run pytest \
     --asyncio-mode=auto \
     --maxfail="${MAXFAIL:-1}" \
+    -m "${PYTEST_MARKEXPR:-not performance}" \
     --disable-warnings \
     --cov=lionagi --cov-report=xml --cov-report=term \
     "${@:-tests/}"

--- a/tests/protocols/generic/test_pile.py
+++ b/tests/protocols/generic/test_pile.py
@@ -320,11 +320,13 @@ def test_pile_with_custom_hash_elements():
     assert elements[2] in p
 
 
+@pytest.mark.performance
 @pytest.mark.parametrize("n", [100, 1000, 10000])
 def test_pile_scaling_performance(n):
-    # Coverage instrumentation adds 5-10x overhead, making wall-clock
-    # thresholds unreliable. Skip when coverage is active — perf is
-    # validated by the benchmarks workflow, not the coverage suite.
+    # Wall-clock thresholds are unreliable under CI load and coverage (5-10x
+    # overhead). The `performance` marker excludes this from CI runs; the
+    # in-body guard additionally skips it under coverage if the marker filter
+    # is bypassed. Real perf regression detection lives in benchmarks.yml.
     if sys.gettrace() is not None or "coverage" in sys.modules:
         pytest.skip("perf thresholds unreliable under coverage/tracing")
 


### PR DESCRIPTION
## Why

CI's `test` job is the wall-clock bottleneck: it runs the **full suite under coverage** (the pile scaling test's own comment notes coverage adds **5-10x overhead**) on **every** matrix Python version (2 on PRs, 5 on main), with **no dependency cache** (`uv sync --all-extras` cold every job).

## Changes

1. **Coverage on 3.10 only.** 3.10 is present in both the PR (`3.10, 3.14`) and full (`3.10–3.14`) matrices. Other versions run plain `pytest` (no coverage instrumentation → 5-10x faster). Codecov uploads only from the 3.10 run. → the slow path goes from *5 coverage runs* to *1 coverage + 4 fast runs*.
2. **Cache `~/.cache/uv`** keyed on `uv.lock`, so `uv sync` reuses built wheels instead of rebuilding each job.
3. **Gate the wall-clock pile scaling test** behind the existing `performance` marker + `-m "not performance"` in both `ci.sh` test targets. Coverage's in-body skip guard previously hid this timing test in CI; running plain pytest on 4 versions would un-hide it and it would flake on slow shared runners. Real perf-regression detection lives in `benchmarks.yml`. Override locally with `PYTEST_MARKEXPR=performance`.

## Verification (local)

- Exact coverage path (`test-python-cov`, `--maxfail=1`): **8144 passed, 3 skipped** in 97.6s.
- Exact non-coverage path (`test-python`): **8147 passed** in 39.9s (~2.5x faster locally; larger on CI's slower coverage).
- Marker filter confirmed both directions: `-m "not performance"` deselects the scaling test; `-m performance` selects exactly its 3 params.
- `ci.yml` validated as well-formed YAML.

Lands first; the primitive-wave1 refactor PR rebases onto this for faster CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)