### PR TITLE
Engines: hypothesis + coding engines, autonomy protections, module coherence (ADR-0077/0078)

### DIFF
--- a/docs/adrs/ADR-0077-engine-autonomy-protections.md
+++ b/docs/adrs/ADR-0077-engine-autonomy-protections.md
@@ -1,0 +1,162 @@
+# ADR-0077: Engine Autonomy Protections and the Hypothesis Engine
+
+**Status**: Accepted — implemented
+**Date**: 2026-06-09
+
+## Context
+
+ADR-0075 shipped the engine layer: standing reaction machines (research, review,
+planning) where casts agents emit typed events and reaction rules spawn more
+work. Two pressures now change the requirements:
+
+1. **Workers will be small, cheap, or local models — and agent processes.**
+   The economic target is running engines on open-weight models, subscription
+   CLI agents (`claude_code`, `codex`, `pi`), or local ones — not frontier API
+   calls. Weak workers fail differently: they emit malformed JSON, hallucinate
+   fields, forget to emit entirely, and wander off-topic under recursion. The
+   engine layer, not the model, must supply quality, direction, and safety.
+
+2. **Autonomous recursion needs hard resource protection.** The only bounds
+   were semantic (`max_depth`, topic dedup) and a concurrency semaphore.
+   Nothing capped total agent count or wall-clock; a model emitting 50
+   plausible sub-topics per node recurses within `max_depth` yet spends an
+   unbounded budget. Prompt-level caps ("at most 8") are suggestions weak
+   models ignore.
+
+A live-path audit also found a real defect: agent emissions arrive on the bus
+as `StructuredOutput` *bundles* (one dynamic model with a field per
+capability), and `EngineRun.by_type` returned the envelopes rather than the
+typed events — so research/review synthesis crashed in any real run. Unit
+tests emitted raw events and never exercised the bundle path.
+
+## Decision
+
+### 1. Bundle-aware queries
+
+`EngineRun.by_type` unwraps both `Signal` envelopes and capability bundles via
+the observer's `TypeFilter` matching, returning typed event instances. A
+scripted-provider e2e suite (`tests/engines/test_engines_scripted_e2e.py`)
+drives every engine through the real `fenced JSON → attempt_extract → bundle →
+reaction` path so this class of defect cannot reland.
+
+### 2. Hard resource budget (per run)
+
+- `max_agents` (default 50): the primary recursion bound. `EngineRun.spawn`
+  declines new work once exhausted (single `budget_exhausted` notify);
+  `make_agent` raises `EngineBudgetError`.
+- `deadline_s`: optional wall-clock cap checked at the same points.
+- **Graceful degradation**: terminal stages (synthesis, verdict) pass
+  `exempt=True` — a budget-capped run still reports everything it gathered
+  instead of dying empty.
+
+Layering: budget (hard) > judge gate (advisory) > `max_depth`/dedup (semantic)
+> semaphore (concurrency). Prompts are never load-bearing for safety.
+
+### 3. Emission repair loop
+
+In-grant capability blocks that fail schema validation were silently dropped
+(`logger.debug`). They now surface as `EmissionRejected` bus events carrying
+the validation error and the emitting branch's name. On top of that,
+`EngineRun.operate_with_repair(branch, instruction, arrived=..., emits=...)`
+re-prompts up to `retries` times when the stage's expected emission did not
+arrive, naming the expected top-level keys. This is the difference between a
+weak model recovering and its work vanishing — the single highest-leverage
+mechanism for the small-model thesis.
+
+### 4. Hierarchical judge gate
+
+Setting `judge_model` arms `Engine.judge(run, eid, subject)` at expansion
+points (hypothesis question fan-out, research depth spawn): a cheap judge
+agent sees the run's **root objective** plus the candidate item and emits a
+`JudgeVerdict` (`PASS`/`REJECT` text fallback for judges too weak to emit).
+Reject stops that branch. Errors fail open with a `judge_error` notify —
+quality gating is advisory; the budget remains the hard backstop. This is the
+direction-control mechanism: off-topic, duplicative, trivial, or unsafe
+expansions die at the gate instead of spending budget.
+
+### 5. Per-stage model routing; workers are agent processes
+
+`Engine(models={"extract": "ollama/qwen3", "conclude": "claude_code/sonnet"})`
+routes each stage through `model_for(stage)`. Any process lionagi can drive is
+a worker: API chat models, CLI agents (`claude_code/...`, `codex/...`,
+`pi/...`), or the scripted test provider. Volume stages go to cheap workers;
+judgement stages to capable ones.
+
+### 6. Sandboxed tool grants
+
+`make_agent` threads `permissions` and `cwd` into `AgentSpec.compose` and
+auto-applies `guard_destructive` (bash) plus path guards (reader/editor) to
+any tool-bearing agent (`secure=True` default). The hypothesis validator
+defaults to `permissions="safe"` — experiments can measure for real without
+an unguarded shell.
+
+### 7. The hypothesis engine (Chain shape)
+
+A fourth engine encoding hypothesis-driven development: every architectural
+decision should be a hypothesis with evidence, not taste.
+
+```text
+FindingPosted → QuestionRaised → EvidenceCollected → HypothesisFormed
+  → ExperimentDesigned → ResultRecorded → ConclusionDrawn → ApplicationMapped
+```
+
+- Events carry engine-stamped ids (`F-1`, `Q-3`, …) assigned by a
+  first-registered collector observer; agents fill upstream refs from their
+  instructions. The reference graph **is** the audit trail; `trace_chains()`
+  reconstructs root→terminal chains.
+- Conclusions are typed by basis: `empirical | quantitative | theoretical |
+  taste` — taste is legitimate but must be labeled, never disguised.
+- Applications map conclusions onto a caller-supplied decision register as
+  `supports | challenges | qualifies` — the ADR-support link.
+- Back-edges are first-class (results post findings; conclusions raise
+  follow-up questions), bounded by cycle generation (`max_depth`) + dedup.
+- Experiments whose `method` is not in `executable_methods` (default:
+  benchmark) queue on `run.pending` with their full spec — a ready-to-run
+  queue for CI/humans — instead of being faked.
+- `run.export(dir)` writes `chains.json` (typed event graph, for downstream
+  knowledge-graph ingestion) and `report.md` (synthesis + evidence trail).
+
+Shapes now: research = Tree, review = Dimensional, planning = Planned-DAG,
+hypothesis = Chain.
+
+## Consequences
+
+**Positive**
+
+- Engines are safe to run autonomously on weak workers: hard budgets bound
+  spend, the judge bounds direction, repair bounds emission fragility, guards
+  bound tool blast radius.
+- The live path is tested end-to-end without a model (scripted provider), so
+  transport-level regressions surface in CI.
+- Evidence chains give architectural decisions a durable, machine-readable
+  provenance trail — accumulating experiment-backed support for every choice.
+
+**Negative**
+
+- Judge gates add one cheap call per expansion point (~1:3–1:10 of worker
+  calls depending on fan-out).
+- Repair adds up to `retries` extra calls per silent stage; bounded and
+  observable (`emission_repair` / `emission_missing`).
+- The event store still retains everything; the retention/compaction policy
+  flagged in ADR-0075 remains open.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Prompt-level caps only ("at most N") | Weak models ignore them; nothing bounds total spend. |
+| Fail-closed judge | A flaky cheap judge would kill healthy runs; budget already hard-bounds the damage of failing open. |
+| N-vote redundancy instead of a judge | 2–3× worker cost on every stage; weak against correlated errors; no direction control. |
+| Constrained decoding for emissions | Only available on some local backends; repair works transport-universally, including CLI agents. |
+| Sub-question relevance via embedding similarity | Cheaper than a judge but cannot assess "worth the budget" or safety; may complement the judge later. |
+
+## References
+
+- ADR-0072 — Reactive Capability Bus (the substrate).
+- ADR-0075 — Domain-Specific Agent Engines (the layer this hardens).
+- `lionagi/engines/engine.py` — budget, judge, repair, routing, sandbox.
+- `lionagi/engines/hypothesis.py` — the Chain-shape engine.
+- `lionagi/operations/_observe.py`, `lionagi/session/capabilities.py` —
+  `EmissionRejected` surfacing.
+- `tests/engines/test_engine_protection.py`,
+  `tests/engines/test_engines_scripted_e2e.py`.

--- a/docs/adrs/ADR-0078-casts-conceptual-model-and-module-coherence.md
+++ b/docs/adrs/ADR-0078-casts-conceptual-model-and-module-coherence.md
@@ -128,6 +128,3 @@ deferral above.
 - ADR-0072 (reactive capability bus), ADR-0074 (role composition and packs),
   ADR-0075 (engines), ADR-0077 (autonomy protections), ADR-0021 (artifact
   outcomes).
-- Survey + debt inventory + design doc:
-  `khive .khive/workspaces/20260909/lionagi-coherence/` (`survey/A–E`,
-  `DEBT_INVENTORY.md`, `DESIGN.md`).

--- a/docs/adrs/ADR-0078-casts-conceptual-model-and-module-coherence.md
+++ b/docs/adrs/ADR-0078-casts-conceptual-model-and-module-coherence.md
@@ -1,0 +1,133 @@
+# ADR-0078: The Casts Conceptual Model and Module Coherence
+
+**Status**: Accepted — implemented
+**Date**: 2026-06-09
+
+## Context
+
+Nine modules were added to lionagi over a short period — `casts`, `agent`,
+`engines`, `orchestration`, `outcomes`, `hooks`, `state`, `studio`, `cli` —
+without a written statement of how they relate to the established core
+(`protocols`, `ln`, `service`, `session`, `operations`, `libs`) or to each
+other. A five-module survey plus a verified debt inventory (35 items) found
+the recurring failure mode was not bad code but **missing normative
+boundaries**: duplicated construction stacks, two config surfaces for one
+concept, name collisions across planes, and upward imports from lower layers.
+
+Two clarifications resolve most of it.
+
+## Decision 1: the casts conceptual model is normative
+
+The vocabulary, as designed:
+
+- **Pattern** — the composable atom of agent configuration. A frozen value
+  object (`casts.pattern.Pattern`).
+- **Role** and **Mode** — *special patterns* that carry specific material:
+  a Role carries behavioral body and an emission contract (`emits`); a Mode
+  carries cognitive behaviors and conflict declarations. `PatternKind` is the
+  taxonomy discriminator for exactly this specialness — it is declarative
+  vocabulary, not dead code.
+- **Profile** — a named composition of patterns *plus persistence*: one Role,
+  ordered Modes, conflict-validated, YAML round-trip (`from_yaml`/`to_yaml`).
+  Identity lives here and only here.
+- **Agent** — a **runtime concept**, never persisted. `AgentSpec` = Profile +
+  runtime concerns (model, effort, tools, permissions, capability grants,
+  hooks, cwd, MCP). `create_agent(spec)` is the **only** construction site
+  that turns a spec into a live `Branch`, and the only site that grants
+  emission capabilities.
+
+Consequences applied:
+
+- `AgentSpec.emits: tuple | None` — `None` grants the Role's declared
+  contract; a tuple overrides it (engines grant stage-specific events); `()`
+  grants nothing. The engine layer's post-construction re-grant is deleted;
+  one grant source.
+- `AgentConfig` (a persisted "agent" predating the model) is deprecated by
+  delegation: its system-message composition delegates to `Profile`, its
+  secure-guard wiring shares one helper with `AgentSpec`, its YAML round-trip
+  warns `DeprecationWarning`.
+- `casts/__init__.py` exports a curated surface; the previously-leaking
+  private symbols are public (`field_name_for`, `SPAWN_ALLOWED_OPERATIONS`).
+
+## Decision 2: two planes, meeting only at persisted state
+
+```text
+agent-model plane (reactive)            ops plane (persisted)
+ln / protocols / service / session      cli  →  state (StateDB)  ←  studio
+        ↓                                            ↑ hooks
+casts (patterns) → agent (runtime)      SSE, artifacts, run rows
+        ↓
+engines / orchestration / operations
+```
+
+- The planes communicate **only** through `StateDB` and exported artifacts.
+  `studio` imports nothing from `casts`/`agent`/`engines`; `casts`/`agent`
+  import nothing from `state`/`studio`/`hooks`. This separation is deliberate
+  and load-bearing — do not "unify" it.
+- Shared foundations live **below both planes**: provider/model-spec tables
+  moved from `cli/_providers.py` to `service/providers.py`; filesystem layout
+  constants moved from `cli/_runs.py`/`cli/_agents.py` to `lionagi/_paths.py`.
+  `cli` keeps re-export shims. Rule: **lower layers never import from `cli`.**
+- Vocabulary is plane-scoped. `outcomes` (the ops-plane artifact contract,
+  ADR-0021) renamed its classes that collided with the reactive plane's
+  emission vocabulary: `Finding` → `ReviewFinding`, `ReviewVerdict` →
+  `ReviewOutcome`. The casts emission types and their engine subclasses keep
+  the short names — the bus owns them.
+- One construction stack: the CLI orchestrator and casts-role workers compose
+  `AgentSpec` and call `create_agent` rather than building `Branch` directly,
+  so factory wiring (system-message assembly, MCP config, future guards)
+  applies uniformly. `create_agent` gained additive `chat_model=` and
+  `log_config=` passthroughs so the CLI's richer iModel construction injects
+  at the factory rather than around it. Workers keep their exact capability
+  surface via `grant_spawn` (`grant_emissions=False`); CLI runs use
+  `load_settings=False`. Verbatim-prompt workers (explicit `system_prompt`,
+  `--bare`) have no Role to compose and retain direct `Branch` construction
+  by design.
+
+## Decision 3: engines complete the ADR-0077 retrofit
+
+- `operate_with_repair` now covers `research` exploration and `review`
+  dimension/verify stages, not just `hypothesis`. Terminal text-consumed
+  stages (synthesis, verdict) deliberately stay unrepaired.
+- `EngineEvent` is `extra="forbid"`, matching its casts twins — one
+  strictness rule on the whole bus.
+
+## Correction to ADR-0075
+
+ADR-0075 anticipated `pile[filter]` sugar replacing observer-level queries.
+`pile[Type]` landed (`protocols/generic/pile.py`), but engines intentionally
+continue to use `EngineRun.by_type` — agent emissions arrive as `Signal`
+envelopes carrying capability bundles, and unwrapping them is observer-layer
+knowledge `Pile` deliberately does not have (ADR-0077 §1). The "by_type
+collapses to `flow.items[T]`" expectation is withdrawn.
+
+## What was deliberately NOT unified
+
+| Candidate | Verdict |
+|-----------|---------|
+| `orchestration/` into `engines/` | Deferred — thin shared glue with one-directional edges; folding is a rename, not a need. |
+| `cli/orchestrate/flow.py` onto `PlanningEngine` | Deferred — flow re-drives plan/DAG/synthesis itself and only delegates `run_dag`; consolidation is high-blast-radius (`li play` is the daily driver) and needs its own pass with a live smoke. Budget/judge/repair do not cover the CLI path until then. |
+| `hooks/` (1 of 11 points wired) | Forward deployment per ADR-0023b/c — wiring is roadmap, not debt. |
+| `outcomes/` producers | Forward deployment per ADR-0021 — the CLI skill runner lands separately. |
+| `state/` vs `protocols.generic` | Parallel by design: ops-plane SQLite rows vs in-process substrate. Documented, not merged. |
+
+## Consequences
+
+**Positive**: one construction stack, one grant source, one config surface
+per concept, no upward imports into `cli`, plane-distinct vocabulary, repair
+coverage everywhere weak workers run, and a studio run-detail view that
+actually returns data (it read a manifest file nothing ever wrote).
+
+**Negative**: `cli/_providers.py` and `cli/_runs.py` carry re-export shims
+until external callers migrate; `AgentConfig` lingers deprecated; the
+flow-onto-PlanningEngine consolidation remains open debt with a written
+deferral above.
+
+## References
+
+- ADR-0072 (reactive capability bus), ADR-0074 (role composition and packs),
+  ADR-0075 (engines), ADR-0077 (autonomy protections), ADR-0021 (artifact
+  outcomes).
+- Survey + debt inventory + design doc:
+  `khive .khive/workspaces/20260909/lionagi-coherence/` (`survey/A–E`,
+  `DEBT_INVENTORY.md`, `DESIGN.md`).

--- a/lionagi/_paths.py
+++ b/lionagi/_paths.py
@@ -1,8 +1,73 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
-"""Path constants — leaf module, no lionagi deps. Imported by state, cli, etc."""
+"""Path constants and directory helpers — stdlib only, no lionagi deps.
+
+Imported by state, studio, cli, and operations modules. Must remain
+dependency-free so it can be the lowest-level shared location for
+filesystem paths used across the ops plane.
+"""
+
+from __future__ import annotations
 
 import os
+import subprocess
 from pathlib import Path
 
+__all__ = (
+    "LIONAGI_HOME",
+    "RUNS_ROOT",
+    "find_lionagi_dirs",
+)
+
 LIONAGI_HOME: Path = Path(os.environ.get("LIONAGI_HOME", Path.home() / ".lionagi")).expanduser()
+RUNS_ROOT: Path = LIONAGI_HOME / "runs"
+
+
+def _find_git_root(cwd: Path) -> Path | None:
+    """Return the git repository root for *cwd*, or None if not in a repo."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            cwd=str(cwd),
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return Path(result.stdout.strip())
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+def find_lionagi_dirs() -> list[Path]:
+    """Find .lionagi/ directories — project-local first, then global ~/.lionagi/.
+
+    Returns all found directories in priority order (project-local wins).
+    """
+    dirs: list[Path] = []
+
+    # 1. Git root
+    git_root = _find_git_root(Path.cwd())
+    if git_root is not None:
+        candidate = git_root / ".lionagi"
+        if candidate.is_dir():
+            dirs.append(candidate)
+
+    # 2. Walk up from cwd
+    cwd = Path.cwd()
+    for parent in [cwd, *cwd.parents]:
+        candidate = parent / ".lionagi"
+        if candidate.is_dir() and candidate not in dirs:
+            dirs.append(candidate)
+
+    # 3. Global ~/.lionagi/ (always check)
+    home_candidate = Path.home() / ".lionagi"
+    if home_candidate.is_dir() and home_candidate not in dirs:
+        dirs.append(home_candidate)
+
+    return dirs
+
+
+# Private alias for callers that imported the old name.
+_find_lionagi_dirs = find_lionagi_dirs

--- a/lionagi/agent/config.py
+++ b/lionagi/agent/config.py
@@ -1,14 +1,15 @@
-# Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-__all__ = ("AgentConfig", "HooksMixin")
+__all__ = ("AgentConfig", "HooksMixin", "_wire_secure_guards")
 
 
 class HooksMixin:
@@ -29,9 +30,27 @@ class HooksMixin:
         return self
 
 
+def _wire_secure_guards(obj: HooksMixin, cwd: str | None) -> None:
+    """Register the standard destructive-command + path-containment guards.
+
+    Shared by AgentConfig.coding() and AgentSpec.coding() so the guard logic
+    lives in exactly one place.  ``obj`` must support .pre() (HooksMixin).
+    """
+    from lionagi.agent.hooks import guard_destructive, guard_paths
+
+    obj.pre("bash", guard_destructive)
+    workspace_root = str(Path(cwd) if cwd else Path.cwd())
+    path_guard = guard_paths(allowed_paths=[workspace_root])
+    obj.pre("reader", path_guard)
+    obj.pre("editor", path_guard)
+
+
 @dataclass
 class AgentConfig(HooksMixin):
     """Configuration for a lionagi agent.
+
+    Deprecated: compose an AgentSpec instead.  Retained as a bridge —
+    create_agent() converts via AgentSpec.from_legacy().
 
     Combines model settings, tool selection, hook registration, system prompt,
     and permissions into a single config that create_agent() wires into a Branch.
@@ -79,21 +98,27 @@ class AgentConfig(HooksMixin):
 
         ``role`` (a built-in role name or Role) contributes its behavioral body;
         each entry in ``modes`` (a built-in mode name or Mode) contributes its
-        behaviors; ``system_prompt`` is appended as extra preamble. With no role
-        or modes set, this returns ``system_prompt`` unchanged (backward
+        behaviors; ``system_prompt`` is appended as extra preamble.  With no
+        role or modes set this returns ``system_prompt`` unchanged (backward
         compatible).
+
+        Role + mode composition is delegated to ``Profile`` so the logic lives
+        in one place.  When ``role`` is None the mode list is iterated directly
+        (Profile requires a role; that case is handled inline).
         """
-        from lionagi.casts.pattern import Mode, Role
+        from lionagi.casts.pattern import Mode
+        from lionagi.casts.profile import Profile
 
         parts: list[str] = []
         if self.role:
-            role = self.role if not isinstance(self.role, str) else Role.load(self.role)
-            if role.body:
-                parts.append(role.body)
-        for m in self.modes:
-            mode = m if not isinstance(m, str) else Mode.load(m)
-            if mode.behaviors:
-                parts.append(mode.behaviors)
+            body = Profile.compose(self.role, modes=self.modes).build_system_message()
+            if body:
+                parts.append(body)
+        else:
+            for m in self.modes:
+                mode = m if not isinstance(m, str) else Mode.load(m)
+                if mode.behaviors:
+                    parts.append(mode.behaviors)
         if self.system_prompt:
             parts.append(self.system_prompt)
         return "\n\n".join(parts)
@@ -131,18 +156,16 @@ class AgentConfig(HooksMixin):
             **kwargs,
         )
         if secure:
-            from lionagi.agent.hooks import guard_destructive, guard_paths
-
-            config.pre("bash", guard_destructive)
-            workspace_root = str(Path(cwd) if cwd else Path.cwd())
-            path_guard = guard_paths(allowed_paths=[workspace_root])
-            config.pre("reader", path_guard)
-            config.pre("editor", path_guard)
+            _wire_secure_guards(config, cwd)
         return config
 
     @classmethod
     def from_yaml(cls, path: str | Path) -> AgentConfig:
         """Load agent config from a YAML file.
+
+        .. deprecated::
+            Use ``AgentSpec.from_yaml()`` instead.  AgentConfig YAML round-trip
+            is retained for back-compat only.
 
         YAML format::
 
@@ -156,6 +179,11 @@ class AgentConfig(HooksMixin):
               bash.allow: ["git *", "cargo *", "uv *"]
               bash.deny: ["rm -rf *"]
         """
+        warnings.warn(
+            "AgentConfig.from_yaml() is deprecated. Use AgentSpec.from_yaml() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         import yaml
 
         p = Path(path)
@@ -191,7 +219,17 @@ class AgentConfig(HooksMixin):
         )
 
     def to_yaml(self, path: str | Path) -> None:
-        """Save config to YAML (without hook callables — those are code-only)."""
+        """Save config to YAML (without hook callables — those are code-only).
+
+        .. deprecated::
+            Use ``AgentSpec.to_yaml()`` instead.  AgentConfig YAML round-trip
+            is retained for back-compat only.
+        """
+        warnings.warn(
+            "AgentConfig.to_yaml() is deprecated. Use AgentSpec.to_yaml() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         import yaml
 
         data = {

--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -62,9 +62,10 @@ async def create_agent(
     branch_kwargs = {}
 
     if spec.model:
-        from lionagi.cli._providers import (
+        from lionagi.service.providers import (
             CLI_PROVIDERS,
             PROVIDER_EFFORT_KWARG,
+            PROVIDER_YOLO_KWARGS,
             parse_model_spec,
         )
 
@@ -81,8 +82,6 @@ async def create_agent(
             if kwarg:
                 extra[kwarg] = effort
         if spec.yolo:
-            from lionagi.cli._providers import PROVIDER_YOLO_KWARGS
-
             extra.update(PROVIDER_YOLO_KWARGS.get(provider, {}))
 
         # CLI providers (codex/claude_code) auth via subprocess — a placeholder

--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -23,6 +23,8 @@ async def create_agent(
     project_dir: str | None = None,
     trust_project_settings: bool = False,
     trusted_hook_modules: set[str] | frozenset[str] | None = None,
+    chat_model: Any = None,
+    log_config: Any = None,
 ) -> Branch:
     """Create a fully configured Branch from an AgentSpec (or legacy AgentConfig).
 
@@ -35,6 +37,13 @@ async def create_agent(
         project_dir: Project root for settings resolution. Auto-detected if None.
         trust_project_settings: If True, load project-local settings.
         trusted_hook_modules: Python module paths allowed for import-based hooks.
+        chat_model: Prebuilt ``iModel`` to use verbatim. When provided, the
+            ``spec.model`` string-parsing path is skipped — callers that build a
+            richer iModel (CLI flag routing: bypass/yolo/fast/theme/repo) inject
+            it here so the factory stays the single construction site.
+        log_config: Optional ``DataLoggerConfig`` (or dict) forwarded to the
+            Branch. Lets a caller pin log behavior (e.g. ``auto_save_on_exit``)
+            without a second Branch builder.
 
     Returns:
         A Branch ready to use with tools registered and hooks applied.
@@ -61,7 +70,9 @@ async def create_agent(
 
     branch_kwargs = {}
 
-    if spec.model:
+    if chat_model is not None:
+        branch_kwargs["chat_model"] = chat_model
+    elif spec.model:
         from lionagi.service.providers import (
             CLI_PROVIDERS,
             PROVIDER_EFFORT_KWARG,
@@ -97,6 +108,9 @@ async def create_agent(
             **extra,
         )
         branch_kwargs["chat_model"] = chat_model
+
+    if log_config is not None:
+        branch_kwargs["log_config"] = log_config
 
     branch = Branch(**branch_kwargs)
 

--- a/lionagi/agent/spec.py
+++ b/lionagi/agent/spec.py
@@ -35,6 +35,7 @@ class AgentSpec(HooksMixin):
     tools: tuple[str, ...] = ()
     permissions: PermissionPolicy | None = None
     grant_emissions: bool = True
+    emits: tuple | None = None
     pack: str | Pack | None = "default"
     lion_system: bool = True
     extra_prompt: str | None = None
@@ -56,11 +57,17 @@ class AgentSpec(HooksMixin):
         permissions: Any = None,
         pack: str | Pack | None = "default",
         grant_emissions: bool = True,
+        emits: tuple | None = None,
         system_prompt: str | None = None,
         cwd: str | None = None,
         yolo: bool = False,
     ) -> AgentSpec:
-        """Build an AgentSpec from a role name/object + optional overrides."""
+        """Build an AgentSpec from a role name/object + optional overrides.
+
+        ``emits`` overrides *what* capability models are granted: ``None`` uses
+        the role's declared contract; a tuple grants exactly those models (plus
+        EscalationRequest). Engines pass it for stage-specific event types.
+        """
         prof = Profile.compose(role, modes=modes)
         perm = _resolve_permissions(permissions)
         return cls(
@@ -71,6 +78,7 @@ class AgentSpec(HooksMixin):
             permissions=perm,
             pack=pack,
             grant_emissions=grant_emissions,
+            emits=emits,
             extra_prompt=system_prompt or None,
             cwd=cwd,
             yolo=yolo,
@@ -145,9 +153,21 @@ class AgentSpec(HooksMixin):
         return "\n\n".join(parts)
 
     def emission_operable(self) -> Operable | None:
-        """Return the role's Operable for emission granting, or None."""
+        """Return the Operable for emission granting, or None.
+
+        ``grant_emissions=False`` disables granting entirely. Otherwise an
+        explicit ``emits`` tuple overrides *what* is granted (empty tuple ⇒
+        grant nothing, since ``build_emission_operable(())`` is None); ``None``
+        falls back to the role's declared contract.
+        """
         if not self.grant_emissions:
             return None
+        if self.emits is not None:
+            from lionagi.casts import build_emission_operable
+
+            return build_emission_operable(
+                tuple(self.emits), name=f"{self.profile.role.name}_emissions"
+            )
         return self.profile.emission_operable()
 
     def to_yaml(self, path: str | Path) -> None:

--- a/lionagi/agent/spec.py
+++ b/lionagi/agent/spec.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from lionagi.agent.config import HooksMixin
+from lionagi.agent.config import HooksMixin, _wire_secure_guards
 from lionagi.casts.pack import Pack
 from lionagi.casts.profile import Profile
 
@@ -109,13 +109,7 @@ class AgentSpec(HooksMixin):
             **kwargs,
         )
         if secure:
-            from lionagi.agent.hooks import guard_destructive, guard_paths
-
-            spec.pre("bash", guard_destructive)
-            workspace_root = str(Path(cwd) if cwd else Path.cwd())
-            path_guard = guard_paths(allowed_paths=[workspace_root])
-            spec.pre("reader", path_guard)
-            spec.pre("editor", path_guard)
+            _wire_secure_guards(spec, cwd)
         return spec
 
     @classmethod

--- a/lionagi/casts/__init__.py
+++ b/lionagi/casts/__init__.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""casts — composable agent configuration: patterns, profiles, packs, and emission contracts."""
+
+from .emission import (
+    SPAWN_ALLOWED_OPERATIONS,
+    AnalysisResult,
+    ArtifactProduced,
+    ComplexityScore,
+    ComplianceVerdict,
+    Conflict,
+    DesignSpec,
+    Diagnosis,
+    Document,
+    EscalationRequest,
+    ExecutionPlan,
+    Finding,
+    Gap,
+    Objection,
+    OperationOutcome,
+    Postmortem,
+    Proposal,
+    Recommendation,
+    RiskAssessment,
+    SpawnRequest,
+    Synthesis,
+    TaskAssignment,
+    Verdict,
+    VerificationResult,
+    build_emission_operable,
+    field_name_for,
+)
+from .pack import Pack, RoleConfig, RolePolicy
+from .pattern import Mode, Pattern, PatternKind, Role, list_modes, list_roles
+from .profile import Profile
+
+__all__ = (
+    # pattern layer
+    "Pattern",
+    "PatternKind",
+    "Role",
+    "Mode",
+    "list_roles",
+    "list_modes",
+    # profile
+    "Profile",
+    # pack layer
+    "Pack",
+    "RolePolicy",
+    "RoleConfig",
+    # emission builder
+    "build_emission_operable",
+    "field_name_for",
+    "SPAWN_ALLOWED_OPERATIONS",
+    # emission contracts — discovery
+    "Finding",
+    "Conflict",
+    "Gap",
+    "Diagnosis",
+    "Synthesis",
+    # emission contracts — judgement
+    "Verdict",
+    "ComplianceVerdict",
+    "RiskAssessment",
+    "Objection",
+    "Recommendation",
+    # emission contracts — analysis
+    "AnalysisResult",
+    "ComplexityScore",
+    # emission contracts — planning / coordination
+    "ExecutionPlan",
+    "TaskAssignment",
+    "DesignSpec",
+    # emission contracts — production
+    "ArtifactProduced",
+    "VerificationResult",
+    "Document",
+    "OperationOutcome",
+    # emission contracts — generative / retrospective
+    "Proposal",
+    "Postmortem",
+    # emission contracts — universal
+    "EscalationRequest",
+    "SpawnRequest",
+)

--- a/lionagi/casts/emission.py
+++ b/lionagi/casts/emission.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from lionagi.ln.types import Operable, Spec
 
-_SPAWN_ALLOWED_OPERATIONS: frozenset[str] = frozenset({"operate", "chat", "communicate", "ReAct"})
+SPAWN_ALLOWED_OPERATIONS: frozenset[str] = frozenset({"operate", "chat", "communicate", "ReAct"})
 
 __all__ = (
     # discovery
@@ -46,6 +46,8 @@ __all__ = (
     "EscalationRequest",
     "SpawnRequest",
     "build_emission_operable",
+    "field_name_for",
+    "SPAWN_ALLOWED_OPERATIONS",
 )
 
 
@@ -441,10 +443,14 @@ class SpawnRequest(_EmissionModel):
 # Operable builder
 # ---------------------------------------------------------------------------
 
-_CAMEL_RE = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+_CAMEL_RE = re.compile(r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])")
 
 
-def _field_name(model: type[BaseModel]) -> str:
+def field_name_for(model: type[BaseModel]) -> str:
+    """Convert a PascalCase model name to a snake_case field key.
+
+    Handles acronym runs: ``CIResult`` → ``ci_result``.
+    """
     return _CAMEL_RE.sub("_", model.__name__).lower()
 
 
@@ -457,5 +463,5 @@ def build_emission_operable(
         return None
     if EscalationRequest not in models:
         models = (*models, EscalationRequest)
-    specs = tuple(Spec(m, name=_field_name(m)) for m in models)
+    specs = tuple(Spec(m, name=field_name_for(m)) for m in models)
     return Operable(specs, name=name)

--- a/lionagi/casts/profile.py
+++ b/lionagi/casts/profile.py
@@ -69,3 +69,22 @@ class Profile:
             modes=data.get("modes") or [],
             name=data.get("name"),
         )
+
+    def to_yaml(self, path: str | Path) -> None:
+        """Save this Profile to a YAML file, symmetric with :meth:`from_yaml`.
+
+        Writes ``{name, role, modes: [...]}`` using role/mode canonical names —
+        the same schema ``from_yaml`` reads, so the round-trip recomposes an
+        equal Profile.
+        """
+        import yaml
+
+        data = {
+            "name": self.name,
+            "role": self.role.name,
+            "modes": [m.name for m in self.modes],
+        }
+        Path(path).write_text(
+            yaml.dump(data, default_flow_style=False, allow_unicode=True),
+            encoding="utf-8",
+        )

--- a/lionagi/cli/_agents.py
+++ b/lionagi/cli/_agents.py
@@ -37,10 +37,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from lionagi._paths import find_lionagi_dirs as _find_lionagi_dirs
 from lionagi.libs.frontmatter import parse_frontmatter as _parse_frontmatter
 from lionagi.libs.path_safety import validate_bare_name
-
-from ._project import _find_git_root
 
 
 def _validate_bare_name(name: str) -> None:
@@ -92,35 +91,6 @@ class AgentProfile:
     lion_system: bool = True
     artifact_defaults: dict | None = None
     extra: dict = field(default_factory=dict)
-
-
-def _find_lionagi_dirs() -> list[Path]:
-    """Find .lionagi/ directories — project-local first, then global ~/.lionagi/.
-
-    Returns all found directories in priority order (project-local wins).
-    """
-    dirs: list[Path] = []
-
-    # 1. Git root
-    git_root = _find_git_root(Path.cwd())
-    if git_root is not None:
-        candidate = git_root / ".lionagi"
-        if candidate.is_dir():
-            dirs.append(candidate)
-
-    # 2. Walk up from cwd
-    cwd = Path.cwd()
-    for parent in [cwd, *cwd.parents]:
-        candidate = parent / ".lionagi"
-        if candidate.is_dir() and candidate not in dirs:
-            dirs.append(candidate)
-
-    # 3. Global ~/.lionagi/ (always check)
-    home_candidate = Path.home() / ".lionagi"
-    if home_candidate.is_dir() and home_candidate not in dirs:
-        dirs.append(home_candidate)
-
-    return dirs
 
 
 def _find_lionagi_dir() -> Path | None:

--- a/lionagi/cli/_providers.py
+++ b/lionagi/cli/_providers.py
@@ -1,236 +1,48 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
-"""Model spec parsing — strip effort suffix, pass the rest to iModel.
-
-Model spec format: ``provider/model-effort``
-
-    claude/opus-4-7-high   → model="claude/opus-4-7", effort="high"
-    codex/gpt-5.4-xhigh   → model="codex/gpt-5.4", effort="xhigh"
-    claude/sonnet          → model="claude/sonnet", effort=None
-
-iModel handles provider/model splitting internally. We only strip effort.
-"""
+"""CLI-level model construction helpers — re-exports service-layer tables plus iModel builders."""
 
 from __future__ import annotations
 
 import argparse
-import re
-from dataclasses import dataclass
 from typing import Any
 
 from lionagi import iModel
-
-# ── Effort levels (stripped from spec, mapped to provider kwarg) ──────────
-
-EFFORT_LEVELS = frozenset(
-    {
-        "none",
-        "minimal",
-        "low",
-        "medium",
-        "high",
-        "xhigh",
-        "max",
-    }
+from lionagi.service.providers import (
+    _CLAUDE_PROVIDER_NAMES,
+    _CODEX_EFFORT_CLAMP,
+    BACKENDS,
+    CLI_PROVIDERS,
+    EFFORT_LEVELS,
+    PROVIDER_BYPASS_KWARGS,
+    PROVIDER_EFFORT_KWARG,
+    PROVIDER_FAST_KWARGS,
+    PROVIDER_TO_ALIAS,
+    PROVIDER_YOLO_KWARGS,
+    PROVIDERS_NO_EFFORT,
+    ModelSpec,
+    _clamp_claude_effort,
+    parse_model_spec,
 )
 
-# Codex accepts none|minimal|low|medium|high|xhigh — NOT "max".
-# Profiles/orchestrators may emit "max"; clamp to "xhigh" for codex.
-_CODEX_EFFORT_CLAMP: dict[str, str] = {"max": "xhigh"}
-
-# Claude: only opus-4-7 accepts xhigh. All other models clamp to high.
-_CLAUDE_XHIGH_MODELS = frozenset({"opus", "opus-4-7", "claude-opus-4-7"})
-
-
-def _clamp_claude_effort(effort: str, model: str) -> str:
-    """Clamp xhigh to high for non-opus-4-7 Claude models."""
-    if effort != "xhigh":
-        return effort
-    model_part = model.split("/", 1)[-1] if "/" in model else model
-    if model_part in _CLAUDE_XHIGH_MODELS:
-        return effort
-    return "high"
-
-
-# CLI providers authenticate via a local subprocess (ChatGPT/Claude
-# subscription), so their api_key is an irrelevant placeholder. API providers
-# (openai, deepseek, anthropic, …) resolve a real key from settings — passing a
-# placeholder there OVERRIDES that resolution and breaks auth.
-CLI_PROVIDERS: frozenset[str] = frozenset({"claude_code", "claude-code", "claude", "codex"})
-
-
-# provider name → kwarg name for effort
-PROVIDER_EFFORT_KWARG: dict[str, str] = {
-    "claude-code": "effort",
-    "claude_code": "effort",
-    "claude": "effort",
-    "codex": "reasoning_effort",
-    "pi": "thinking",
-}
-
-# providers that do NOT support effort
-PROVIDERS_NO_EFFORT: frozenset[str] = frozenset(
-    {
-        "gemini_code",
-        "gemini-code",
-        "gemini_cli",
-        "gemini-cli",
-        "gemini",
-    }
+__all__ = (
+    "BACKENDS",
+    "CLI_PROVIDERS",
+    "EFFORT_LEVELS",
+    "ModelSpec",
+    "PROVIDER_BYPASS_KWARGS",
+    "PROVIDER_EFFORT_KWARG",
+    "PROVIDER_FAST_KWARGS",
+    "PROVIDER_TO_ALIAS",
+    "PROVIDER_YOLO_KWARGS",
+    "PROVIDERS_NO_EFFORT",
+    "add_common_cli_args",
+    "build_chat_model",
+    "build_imodel_from_spec",
+    "parse_model_spec",
+    "resolve_model_spec",
+    "resolve_persisted_effort",
 )
-
-# Module-level invariant: a provider cannot be in both sets simultaneously.
-# A future maintainer adding a provider to the wrong set gets an ImportError
-# at startup instead of silent effort-kwarg corruption at runtime.
-# Using raise RuntimeError (not assert) so the check survives `python -O`.
-_overlap = PROVIDERS_NO_EFFORT & set(PROVIDER_EFFORT_KWARG)
-if _overlap:
-    raise RuntimeError(
-        f"Provider classification conflict: {_overlap!r} appear in both "
-        "PROVIDERS_NO_EFFORT and PROVIDER_EFFORT_KWARG"
-    )
-del _overlap
-
-# ── Per-provider yolo kwargs ──────────────────────────────────────────────
-
-PROVIDER_YOLO_KWARGS: dict[str, dict] = {
-    "claude_code": {"permission_mode": "bypassPermissions"},
-    "claude": {"permission_mode": "bypassPermissions"},
-    "codex": {"full_auto": True, "skip_git_repo_check": True},
-    "gemini_code": {"yolo": True},
-    "gemini-code": {"yolo": True},
-    "pi": {"no_tools": False},
-}
-
-PROVIDER_BYPASS_KWARGS: dict[str, dict] = {
-    "claude_code": {"permission_mode": "bypassPermissions"},
-    "claude": {"permission_mode": "bypassPermissions"},
-    "codex": {"bypass_approvals": True, "skip_git_repo_check": True},
-    "gemini_code": {"yolo": True},
-    "gemini-code": {"yolo": True},
-    "pi": {"no_tools": False},
-}
-
-# fast_mode: route codex via OpenAI priority tier (lower latency, same effort)
-# No-op for providers that don't support service_tier.
-PROVIDER_FAST_KWARGS: dict[str, dict] = {
-    "codex": {"fast_mode": True},
-}
-
-PROVIDER_TO_ALIAS: dict[str, str] = {
-    "claude_code": "claude",
-    "codex": "codex",
-    "gemini_code": "gemini-code",
-    "pi": "pi",
-}
-
-# ── Aliases (bare name → provider/model) ──────────────────────────────────
-
-BACKENDS: dict[str, str] = {
-    "claude": "claude_code/sonnet",
-    "claude-code": "claude_code/sonnet",
-    "claude_code": "claude_code/sonnet",
-    "codex": "codex/gpt-5.3-codex-spark",
-    "gemini-code": "gemini_code/gemini-3.1-flash-lite-preview",
-    "gemini_code": "gemini_code/gemini-3.1-flash-lite-preview",
-    "gemini-cli": "gemini_code/gemini-3.1-flash-lite-preview",
-    "gemini_cli": "gemini_code/gemini-3.1-flash-lite-preview",
-    "pi": "pi/gemini-2.5-flash",
-    "pi-code": "pi/gemini-2.5-flash",
-    "pi_code": "pi/gemini-2.5-flash",
-}
-
-
-# ── Parsing ───────────────────────────────────────────────────────────────
-
-_EFFORT_SUFFIX_RE = re.compile(
-    r"^(.+?)-(" + "|".join(sorted(EFFORT_LEVELS, key=len, reverse=True)) + r")$"
-)
-
-
-@dataclass(frozen=True)
-class ModelSpec:
-    """Parsed model spec: raw model string (for iModel) + extracted effort."""
-
-    model: str  # "claude/opus-4-7" or "codex/gpt-5.4" — passed to iModel as-is
-    effort: str | None  # extracted effort or None
-
-    def __str__(self) -> str:
-        if self.effort:
-            return f"{self.model}-{self.effort}"
-        return self.model
-
-
-_CLAUDE_MODEL_PREFIXES = ("opus", "sonnet", "haiku")
-
-
-_CLAUDE_PROVIDER_NAMES = frozenset(
-    {
-        "claude",
-        "claude-code",
-        "claude_code",
-    }
-)
-
-
-def _normalize_model(spec_or_model: str, provider_hint: str | None = None) -> str:
-    """Normalize model name for the target provider.
-
-    Claude Code CLI accepts: 'sonnet', 'opus', 'haiku' (aliases)
-    or full names like 'claude-sonnet-4-6', 'claude-opus-4-7'.
-    'opus-4-7' is neither — normalize to 'claude-opus-4-7'.
-
-    Handles both 'provider/model' and bare 'model' inputs.
-    """
-    if "/" in spec_or_model:
-        prov, model = spec_or_model.split("/", 1)
-        normalized = _normalize_model_name(model, prov)
-        return f"{prov}/{normalized}"
-    return _normalize_model_name(spec_or_model, provider_hint)
-
-
-def _normalize_model_name(model: str, provider_hint: str | None = None) -> str:
-    """Normalize bare model name (no provider prefix)."""
-    if provider_hint and provider_hint in _CLAUDE_PROVIDER_NAMES:
-        for prefix in _CLAUDE_MODEL_PREFIXES:
-            if model.startswith(prefix) and model != prefix and not model.startswith("claude-"):
-                return f"claude-{model}"
-    return model
-
-
-def parse_model_spec(spec: str) -> ModelSpec:
-    """Parse effort suffix from spec. Everything else stays intact for iModel.
-
-    Examples::
-        "claude/opus-4-7-high"   → ModelSpec("claude/opus-4-7", "high")
-        "codex/gpt-5.4-xhigh"   → ModelSpec("codex/gpt-5.4", "xhigh")
-        "claude/sonnet"          → ModelSpec("claude/sonnet", None)
-        "claude"                 → ModelSpec("claude_code/sonnet", None)  # alias
-        "gemini-code/gemini-3.1-pro-high" → ERROR (gemini has no effort)
-    """
-    # Alias expansion
-    if spec in BACKENDS:
-        return ModelSpec(model=BACKENDS[spec], effort=None)
-
-    # Split provider for effort validation
-    provider_raw = spec.split("/")[0] if "/" in spec else spec
-
-    # Try to strip effort suffix from the full spec
-    m = _EFFORT_SUFFIX_RE.match(spec)
-    if m:
-        model_clean = m.group(1)
-        effort = m.group(2)
-
-        # Validate: provider supports effort?
-        if provider_raw in PROVIDERS_NO_EFFORT:
-            raise ValueError(
-                f"Provider '{provider_raw}' does not support effort levels. "
-                f"Remove '-{effort}' from '{spec}'."
-            )
-        return ModelSpec(model=_normalize_model(model_clean, provider_raw), effort=effort)
-
-    return ModelSpec(model=_normalize_model(spec, provider_raw), effort=None)
-
 
 # ── iModel construction ───────────────────────────────────────────────────
 

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -37,6 +37,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from uuid import uuid4
 
+from lionagi._paths import RUNS_ROOT
 from lionagi.libs.path_safety import validate_path_component
 from lionagi.utils import LIONAGI_HOME
 
@@ -51,8 +52,6 @@ __all__ = (
     "list_runs",
     "current_run_id",
 )
-
-RUNS_ROOT = LIONAGI_HOME / "runs"
 _LEGACY_AGENTS_ROOT = LIONAGI_HOME / "logs" / "agents"
 _LAST_BRANCH_POINTER = LIONAGI_HOME / "last_branch.json"
 _RUN_ID_ENV_VAR = "LIONAGI_RUN_ID"

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from lionagi import Branch, Session
+from lionagi.agent import AgentSpec, create_agent
 from lionagi.operations.builder import OperationGraphBuilder
 from lionagi.protocols.generic.log import DataLoggerConfig
 from lionagi.state import provenance as _provenance
@@ -145,6 +146,17 @@ def resolve_modes(role: str, override: list[str] | None = None) -> list[str]:
     return out
 
 
+def _is_casts_role(role: str) -> bool:
+    """True if *role* is a loadable built-in casts Role (vs a user profile)."""
+    from lionagi.casts.pattern import Role
+
+    try:
+        Role.load(role)
+    except ValueError:
+        return False
+    return True
+
+
 def casts_role_system(role: str, modes: list[str] | None = None) -> str | None:
     """Composed system message for a casts role, or None if not built-in."""
     from lionagi.casts.pattern import Role
@@ -270,7 +282,7 @@ class OrchestrationEnv:
         return list(self._all_names)
 
 
-def setup_orchestration(
+async def setup_orchestration(
     *,
     pattern_name: str,
     model_spec: str,
@@ -318,13 +330,27 @@ def setup_orchestration(
     run = allocate_run(save_dir=save_dir)
     run.ensure_artifact_root()
 
-    orc_system = orc_profile.system_prompt if orc_profile else casts_role_system("orchestrator")
-    orc_branch = Branch(
-        chat_model=orc_imodel,
-        system=orc_system,
-        log_config=DataLoggerConfig(auto_save_on_exit=False),
-        name="orchestrator",
-    )
+    orc_log_config = DataLoggerConfig(auto_save_on_exit=False)
+    if orc_profile:
+        # User profile supplies a verbatim system prompt (no casts composition).
+        orc_branch = Branch(
+            chat_model=orc_imodel,
+            system=orc_profile.system_prompt,
+            log_config=orc_log_config,
+            name="orchestrator",
+        )
+    else:
+        # Canonical path: the built-in "orchestrator" casts role composed +
+        # built by the factory (LION prepend + policy block), byte-identical to
+        # the old casts_role_system("orchestrator").
+        orc_spec = AgentSpec.compose("orchestrator", grant_emissions=False)
+        orc_branch = await create_agent(
+            orc_spec,
+            load_settings=False,
+            chat_model=orc_imodel,
+            log_config=orc_log_config,
+        )
+        orc_branch.name = "orchestrator"
     _session_id_env = os.environ.get("LIONAGI_SESSION_ID")
     session = (
         Session(id=_session_id_env, default_branch=orc_branch)
@@ -352,7 +378,7 @@ def setup_orchestration(
     )
 
 
-def build_worker_branch(
+async def build_worker_branch(
     env: OrchestrationEnv,
     *,
     agent_id: str,
@@ -363,7 +389,14 @@ def build_worker_branch(
     grant_spawn: bool = False,
     modes: list[str] | None = None,
 ) -> tuple[Branch, str, AgentProfile | None]:
-    """Resolve model/profile/system and build a worker Branch."""
+    """Resolve model/profile/system and build a worker Branch.
+
+    Casts-role workers route through ``AgentSpec.compose`` + ``create_agent``
+    (the canonical construction path — factory wires settings/system/model/
+    emissions consistently). Verbatim-prompt workers (explicit override, a user
+    profile's own ``system_prompt``, or ``--bare``) have no casts Role to
+    compose, so their Branch is built directly with the literal prompt.
+    """
     from ._common import BARE_WORKER_SYSTEM
 
     w_cfg = None if env.bare else role_config(role)
@@ -418,27 +451,50 @@ def build_worker_branch(
     else:
         wname = env.assign_name(role)
 
-    if system_prompt_override is not None:
-        base_system = system_prompt_override
-    elif not env.bare and w_profile and w_profile.system_prompt:
-        base_system = w_profile.system_prompt
-    elif (
-        not env.bare
-        and (role_system := casts_role_system(role, modes=resolve_modes(role, modes))) is not None
-    ):
-        base_system = role_system
-    else:
-        base_system = BARE_WORKER_SYSTEM
-
+    resolved_modes = [] if env.bare else resolve_modes(role, modes)
     team_section = team_worker_system(env.team_data, wname)
-    w_system = f"{base_system}\n\n{team_section}" if team_section else base_system
 
-    wb = Branch(
-        chat_model=w_imodel,
-        system=w_system,
-        log_config=DataLoggerConfig(auto_save_on_exit=False),
-        name=wname,
-    )
+    # A worker's system is either a casts-role composition or a verbatim string
+    # (explicit override / user-profile prompt / bare default). Only the casts
+    # case routes its prompt through the factory; the verbatim cases have no
+    # casts Role to compose from, so their string is set after construction.
+    verbatim_system: str | None = None
+    if system_prompt_override is not None:
+        verbatim_system = system_prompt_override
+    elif not env.bare and w_profile and w_profile.system_prompt:
+        verbatim_system = w_profile.system_prompt
+    elif env.bare or not _is_casts_role(role):
+        verbatim_system = BARE_WORKER_SYSTEM
+
+    log_config = DataLoggerConfig(auto_save_on_exit=False)
+    if verbatim_system is None:
+        # Casts-role worker: AgentSpec.compose + create_agent is the canonical
+        # construction. The factory prepends LION_SYSTEM and renders the role's
+        # policy block, so the result is byte-identical to the old
+        # casts_role_system(role, modes) + team_section path. grant_emissions is
+        # off — spawn rights (if any) are granted below exactly as before.
+        spec = AgentSpec.compose(
+            role,
+            modes=resolved_modes,
+            grant_emissions=False,
+            system_prompt=team_section,
+        )
+        wb = await create_agent(
+            spec,
+            load_settings=False,
+            chat_model=w_imodel,
+            log_config=log_config,
+        )
+        wb.name = wname
+    else:
+        w_system = f"{verbatim_system}\n\n{team_section}" if team_section else verbatim_system
+        wb = Branch(
+            chat_model=w_imodel,
+            system=w_system,
+            log_config=log_config,
+            name=wname,
+        )
+
     env.session.include_branches(wb)
 
     if grant_spawn:

--- a/lionagi/cli/orchestrate/fanout.py
+++ b/lionagi/cli/orchestrate/fanout.py
@@ -64,7 +64,7 @@ async def _run_fanout(
 
     cache_cancelled_exc_class()
 
-    env = setup_orchestration(
+    env = await setup_orchestration(
         pattern_name="Fanout",
         model_spec=model_spec,
         agent_name=agent_name,
@@ -196,7 +196,7 @@ async def _run_fanout_inner(
     for i, ta in enumerate(assignments):
         model_override = pool[i % len(pool)] if pool else None
         wname = worker_names[i]
-        w_branch, w_model, _ = build_worker_branch(
+        w_branch, w_model, _ = await build_worker_branch(
             env,
             agent_id=wname,
             role=ta.assignee,

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -265,7 +265,7 @@ async def _run_flow(
 
     cache_cancelled_exc_class()
 
-    env = setup_orchestration(
+    env = await setup_orchestration(
         pattern_name="Flow",
         model_spec=model_spec,
         agent_name=agent_name,
@@ -556,7 +556,7 @@ async def _run_flow_inner(
     role_base: dict[str, object] = {}
 
     for i, ta in enumerate(assignments):
-        w_branch, w_model, w_profile = build_worker_branch(
+        w_branch, w_model, w_profile = await build_worker_branch(
             env,
             agent_id=agent_ids[i],
             role=ta.assignee,

--- a/lionagi/engines/__init__.py
+++ b/lionagi/engines/__init__.py
@@ -17,6 +17,18 @@ review, …) subclass it.
 
 from __future__ import annotations
 
+from .coding import (
+    ChangeProposed,
+    CodeResultRecorded,
+    CodingChainEvent,
+    CodingEngine,
+    CodingRun,
+    TestsRan,
+    WorkPlanned,
+)
+from .coding import (
+    VerifyResult as CodeVerifyResult,
+)
 from .engine import (
     Engine,
     EngineBudgetError,
@@ -88,4 +100,15 @@ __all__ = (
     "ApplicationMapped",
     "trace_chains",
     "render_evidence",
+    # coding (Gated-Loop shape — plan/implement/test/fix/verify with a
+    # ground-truth subprocess test runner; CodeVerifyResult disambiguates the
+    # review engine's VerifyResult at the package level)
+    "CodingEngine",
+    "CodingRun",
+    "CodingChainEvent",
+    "WorkPlanned",
+    "ChangeProposed",
+    "TestsRan",
+    "CodeVerifyResult",
+    "CodeResultRecorded",
 )

--- a/lionagi/engines/__init__.py
+++ b/lionagi/engines/__init__.py
@@ -18,6 +18,20 @@ review, …) subclass it.
 from __future__ import annotations
 
 from .engine import Engine, EngineEvent, EngineRun
+from .hypothesis import (
+    ApplicationMapped,
+    ChainEvent,
+    ConclusionDrawn,
+    EvidenceCollected,
+    ExperimentDesigned,
+    FindingPosted,
+    HypothesisEngine,
+    HypothesisFormed,
+    HypothesisRun,
+    QuestionRaised,
+    ResultRecorded,
+    trace_chains,
+)
 from .planning import PlanError, PlanningEngine
 from .research import (
     ContradictionFound,
@@ -51,4 +65,17 @@ __all__ = (
     "VerifyResult",
     "ReviewVerdict",
     "DEFAULT_DIMENSIONS",
+    # hypothesis (Chain shape — evidence chains for decisions)
+    "HypothesisEngine",
+    "HypothesisRun",
+    "ChainEvent",
+    "FindingPosted",
+    "QuestionRaised",
+    "EvidenceCollected",
+    "HypothesisFormed",
+    "ExperimentDesigned",
+    "ResultRecorded",
+    "ConclusionDrawn",
+    "ApplicationMapped",
+    "trace_chains",
 )

--- a/lionagi/engines/__init__.py
+++ b/lionagi/engines/__init__.py
@@ -17,7 +17,13 @@ review, …) subclass it.
 
 from __future__ import annotations
 
-from .engine import Engine, EngineEvent, EngineRun
+from .engine import (
+    Engine,
+    EngineBudgetError,
+    EngineEvent,
+    EngineRun,
+    JudgeVerdict,
+)
 from .hypothesis import (
     ApplicationMapped,
     ChainEvent,
@@ -30,6 +36,7 @@ from .hypothesis import (
     HypothesisRun,
     QuestionRaised,
     ResultRecorded,
+    render_evidence,
     trace_chains,
 )
 from .planning import PlanError, PlanningEngine
@@ -51,6 +58,8 @@ __all__ = (
     "Engine",
     "EngineRun",
     "EngineEvent",
+    "EngineBudgetError",
+    "JudgeVerdict",
     # planning (Planned-DAG shape — li o flow as an engine)
     "PlanningEngine",
     "PlanError",
@@ -78,4 +87,5 @@ __all__ = (
     "ConclusionDrawn",
     "ApplicationMapped",
     "trace_chains",
+    "render_evidence",
 )

--- a/lionagi/engines/coding.py
+++ b/lionagi/engines/coding.py
@@ -1,0 +1,746 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Coding engine — the gated implement/test/fix-loop shape.
+
+A coding spec (a task description, or a pending experiment exported by a
+hypothesis run) is driven through a deterministic pipeline whose ground truth
+is a real test command, not a model's claim:
+
+```text
+WorkPlanned -> ChangeProposed -> TestsRan -> [fix loop] -> VerifyResult
+  -> CodeResultRecorded
+```
+
+- ``plan`` (analyst, no tools): the spec becomes a ``WorkPlanned`` — files to
+  touch, approach, test strategy, acceptance criteria.
+- ``implement`` (implementer WITH coding tools, ``permissions="safe"``, path-
+  guarded to the run workspace): executes the plan across its own tool turns
+  and emits a ``ChangeProposed``.
+- ``test`` (the engine itself, NOT an agent): runs the declared ``test_cmd`` in
+  a subprocess with a timeout and captured output, emitting ``TestsRan``. This
+  is ground truth — never an LLM claim.
+- the fix loop: on failure the implementer is re-prompted with the captured
+  output for a new ``ChangeProposed``, then re-tested — the test-failure
+  analogue of emission repair, bounded by ``max_fix_rounds``.
+- ``verify`` (critic, read-only): reviews the captured ``git diff`` against the
+  acceptance criteria and emits a ``VerifyResult`` (the casts ``Verdict``).
+- ``conclude``: the engine emits a ``CodeResultRecorded`` shaped so a hypothesis
+  run can ingest it (:meth:`CodingRun.to_hypothesis_seeds`).
+
+This is the *Gated-Loop* shape, complementing research's Tree, review's
+Dimensional, and hypothesis's Chain. The bus-interop bridge here is by export +
+λ ferry (:meth:`CodingRun.to_hypothesis_seeds`); standing-bus consumption of
+``ExperimentDesigned`` events is a future seam, not this engine.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shlex
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from lionagi.casts.emission import Verdict
+from lionagi.ln.concurrency import run_sync
+from lionagi.tools._subprocess import _SHELL_CONTROL, _subprocess_sync
+
+from .engine import Engine, EngineEvent, EngineRun
+
+logger = logging.getLogger("lionagi.engines")
+
+__all__ = (
+    "CodingChainEvent",
+    "WorkPlanned",
+    "ChangeProposed",
+    "TestsRan",
+    "VerifyResult",
+    "CodeResultRecorded",
+    "CodingRun",
+    "CodingEngine",
+)
+
+
+# ---------------------------------------------------------------------------
+# Events — the pipeline vocabulary. The engine stamps ``eid`` (W/P/T/V/K, no
+# collision with hypothesis's F/Q/E/H/X/R/C/A); refs link a stage to its
+# upstream stage so the export is a walkable chain.
+# ---------------------------------------------------------------------------
+
+
+class CodingChainEvent(BaseModel):
+    """Mixin: engine-assigned chain id for the coding pipeline's audit trail."""
+
+    eid: str = Field(default="", description="Leave empty — the engine assigns this id.")
+
+
+class WorkPlanned(EngineEvent, CodingChainEvent):
+    """The implementation plan for a coding spec — what the implementer executes."""
+
+    approach: str = Field(description="How the change will be made, in concrete steps.")
+    files_to_touch: list[str] = Field(
+        default_factory=list, description="The files expected to be created or modified."
+    )
+    test_strategy: str = Field(
+        default="", description="How the change will be proven (which tests, what they assert)."
+    )
+    acceptance_criteria: list[str] = Field(
+        default_factory=list, description="The conditions that mean the work is done and correct."
+    )
+
+
+class ChangeProposed(EngineEvent, CodingChainEvent):
+    """A code change the implementer made via its tools — the unit the test
+    command then judges. Re-emitted once per fix round."""
+
+    plan_ref: str = Field(default="", description="Id of the WorkPlanned this implements.")
+    summary: str = Field(description="What was changed, stated concretely.")
+    files_touched: list[str] = Field(
+        default_factory=list, description="The files actually created or modified."
+    )
+    test_cmd: str = Field(
+        default="",
+        description="The command the implementer believes proves the change "
+        "(advisory; the engine runs the spec's declared test_cmd as ground truth).",
+    )
+
+
+class TestsRan(EngineEvent, CodingChainEvent):
+    """Ground truth: the outcome of the engine running the declared test command
+    in a subprocess. ``passed`` is the process exit code, never a model claim."""
+
+    # Not a pytest test class — the name starts with "Test" but it is an event.
+    __test__ = False
+
+    change_ref: str = Field(default="", description="Id of the ChangeProposed this tested.")
+    cmd: str = Field(description="The exact command that was run.")
+    passed: bool = Field(description="True iff the process exited 0 (and did not time out).")
+    returncode: int = Field(
+        default=0, description="The process exit code (-1 on timeout/spawn error)."
+    )
+    timed_out: bool = Field(default=False, description="True if the command exceeded the timeout.")
+    round: int = Field(
+        default=0, description="Fix-loop round this run belongs to (0 = first pass)."
+    )
+    output_tail: str = Field(
+        default="",
+        description="Tail of combined stdout+stderr; the full capture is written to the export dir.",
+    )
+    output_file: str = Field(
+        default="", description="Path to the full captured output, when an export dir is set."
+    )
+
+
+class VerifyResult(Verdict, CodingChainEvent):
+    """The critic's call on whether the change meets the acceptance criteria —
+    the casts ``Verdict`` (verdict, rationale, evidence, reversible_by) plus the
+    refs and the unmet-criteria list."""
+
+    change_ref: str = Field(default="", description="Id of the ChangeProposed being verified.")
+    tests_ref: str = Field(default="", description="Id of the TestsRan that produced ground truth.")
+    meets_acceptance: bool = Field(
+        default=False, description="True only if every acceptance criterion is satisfied."
+    )
+    unmet: list[str] = Field(
+        default_factory=list, description="Acceptance criteria not yet satisfied by the change."
+    )
+
+
+class CodeResultRecorded(EngineEvent, CodingChainEvent):
+    """The terminal result of the coding run, shaped for hypothesis ingestion.
+
+    ``measurements`` is a dict so a coding run can carry structured outcomes
+    (rounds, files touched, returncode); :meth:`CodingRun.to_hypothesis_seeds`
+    renders it to the string ``ResultRecorded`` expects. ``experiment_ref``
+    carries the originating ``ExperimentDesigned`` eid when the spec came from a
+    pending experiment, '' otherwise."""
+
+    passed: bool = Field(description="Whether the declared test command ultimately passed.")
+    measurements: dict[str, Any] = Field(
+        default_factory=dict, description="Structured outcome — counts, rounds, the final command."
+    )
+    caveats: list[str] = Field(
+        default_factory=list, description="Conditions that limit what this result shows."
+    )
+    experiment_ref: str = Field(
+        default="", description="Originating experiment eid when seeded from a hypothesis run."
+    )
+    verdict_ref: str = Field(default="", description="Id of the VerifyResult, if one was produced.")
+
+
+_EVENT_PREFIX: dict[type, str] = {
+    WorkPlanned: "W",
+    ChangeProposed: "P",
+    TestsRan: "T",
+    VerifyResult: "V",
+    CodeResultRecorded: "K",
+}
+
+_REF_ATTRS = (
+    "verdict_ref",
+    "tests_ref",
+    "change_ref",
+    "plan_ref",
+)
+
+
+# ---------------------------------------------------------------------------
+# Spec normalization
+# ---------------------------------------------------------------------------
+
+
+def _normalize_spec(spec: str | dict[str, Any]) -> tuple[str, str]:
+    """Return ``(task_text, experiment_ref)`` for a coding spec.
+
+    A string is the task description. A dict is a pending experiment exported by
+    a hypothesis run (``method``/``dataset``/``procedure``/``acceptance``/``eid``)
+    — its fields are rendered into the task text and its ``eid`` becomes the
+    ``experiment_ref`` the result carries back."""
+    if isinstance(spec, str):
+        text = spec.strip()
+        if not text:
+            raise ValueError("coding spec is empty")
+        return text, ""
+    if isinstance(spec, dict):
+        parts = []
+        if procedure := str(spec.get("procedure", "")).strip():
+            parts.append(f"- procedure: {procedure}")
+        if dataset := str(spec.get("dataset", "")).strip():
+            parts.append(f"- dataset / fixtures: {dataset}")
+        if acceptance := str(spec.get("acceptance", "")).strip():
+            parts.append(f"- acceptance: {acceptance}")
+        if method := str(spec.get("method", "")).strip():
+            parts.append(f"- method: {method}")
+        if not parts:
+            raise ValueError("coding spec dict has no procedure/acceptance/dataset/method")
+        text = "Implement and validate this experiment:\n" + "\n".join(parts)
+        return text, str(spec.get("eid", "") or "")
+    raise TypeError(f"coding spec must be str or dict, got {type(spec)!r}")
+
+
+# ---------------------------------------------------------------------------
+# Instructions
+# ---------------------------------------------------------------------------
+
+
+def _plan_instruction(task_text: str, workspace: str) -> str:
+    return (
+        f"You are planning a coding task. Workspace: {workspace}\n\n"
+        f"# Task\n{task_text}\n\n"
+        "Inspect the workspace if needed, then emit a work_planned with: approach "
+        "(the concrete steps to make the change), files_to_touch (the files you "
+        "expect to create or modify), test_strategy (how the change is proven — "
+        "which tests, what they assert), acceptance_criteria (the conditions that "
+        "mean the work is done and correct). Do not write code yet — plan only."
+    )
+
+
+def _implement_instruction(plan: WorkPlanned, task_text: str, workspace: str) -> str:
+    files = ", ".join(plan.files_to_touch) if plan.files_to_touch else "(decide as you go)"
+    accept = "; ".join(plan.acceptance_criteria) if plan.acceptance_criteria else "(meet the task)"
+    return (
+        f"Implement the plan in the workspace ({workspace}). Use your coding tools — "
+        "read files, edit them, run commands — across as many turns as you need.\n\n"
+        f"# Task\n{task_text}\n\n"
+        f"# Plan ({plan.eid})\n"
+        f"- approach: {plan.approach}\n"
+        f"- files to touch: {files}\n"
+        f"- test strategy: {plan.test_strategy or '(use the task)'}\n"
+        f"- acceptance: {accept}\n\n"
+        "When the change is in place, emit a change_proposed with: summary (what you "
+        "changed), files_touched (the files you actually created or modified), "
+        f"test_cmd (the command that proves it), plan_ref='{plan.eid}'. Make the "
+        "change real on disk before emitting — the engine runs the test command "
+        "itself and trusts only its exit code."
+    )
+
+
+def _fix_instruction(t: TestsRan, plan: WorkPlanned, round_no: int, max_rounds: int) -> str:
+    accept = "; ".join(plan.acceptance_criteria) if plan.acceptance_criteria else "(meet the task)"
+    return (
+        f"The test command failed (fix round {round_no}/{max_rounds}). Diagnose the "
+        "failure from the output below, fix the code with your tools, then emit a "
+        f"new change_proposed (summary, files_touched, test_cmd, plan_ref='{plan.eid}').\n\n"
+        f"# Failing command\n{t.cmd}\n\n"
+        f"# Output (exit {t.returncode}{', TIMED OUT' if t.timed_out else ''})\n{t.output_tail}\n\n"
+        f"# Acceptance criteria\n{accept}\n\n"
+        "Read the actual error before changing anything; do not retry the same edit "
+        "blindly. Make the fix real on disk before emitting."
+    )
+
+
+def _verify_instruction(plan: WorkPlanned, change: ChangeProposed, t: TestsRan, diff: str) -> str:
+    accept = (
+        "\n".join(f"- {c}" for c in plan.acceptance_criteria)
+        if plan.acceptance_criteria
+        else "(none stated — judge against the task)"
+    )
+    diff_block = diff.strip() or "(no diff captured — the change may be untracked or empty)"
+    return (
+        "Review the implemented change against its acceptance criteria. Ground truth "
+        f"is the test result, not the diff's appearance.\n\n"
+        f"# Acceptance criteria\n{accept}\n\n"
+        f"# Test outcome\ncommand: {t.cmd}\npassed: {t.passed} (exit {t.returncode})\n\n"
+        f"# Change summary ({change.eid})\n{change.summary}\n\n"
+        f"# Diff\n```diff\n{diff_block}\n```\n\n"
+        "Emit a verify_result with: verdict (APPROVE | APPROVE-WITH-FIXES | "
+        "REQUEST-CHANGES | REJECT), rationale, meets_acceptance (true only if every "
+        "criterion is satisfied), unmet (criteria not yet satisfied), "
+        f"change_ref='{change.eid}', tests_ref='{t.eid}'. A passing test with unmet "
+        "acceptance is still APPROVE-WITH-FIXES at best."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Run context
+# ---------------------------------------------------------------------------
+
+
+class CodingRun(EngineRun):
+    """Per-run state: typed event store, eid counters, the workspace + declared
+    test command, and the captured diff."""
+
+    def __init__(self, engine: Engine, **kwargs: Any) -> None:
+        super().__init__(engine, **kwargs)
+        self.store: dict[type, list[Any]] = {t: [] for t in _EVENT_PREFIX}
+        self.workspace: str = str(Path.cwd())
+        self.test_cmd: str | list[str] = ""
+        self.task_text: str = ""
+        self.experiment_ref: str = ""
+        self.diff: str = ""
+        self.export_dir: Path | None = None
+        self._eid_counts: dict[str, int] = {}
+        self._index: dict[str, CodingChainEvent] = {}
+        self._test_runs: int = 0
+
+    def collect(self, event: CodingChainEvent) -> CodingChainEvent:
+        """Stamp the engine-assigned eid and store the event (first observer)."""
+        prefix = _EVENT_PREFIX.get(type(event), "N")
+        n = self._eid_counts.get(prefix, 0) + 1
+        self._eid_counts[prefix] = n
+        event.eid = f"{prefix}-{n}"
+        self.store.setdefault(type(event), []).append(event)
+        self._index[event.eid] = event
+        return event
+
+    def find(self, eid: str) -> CodingChainEvent | None:
+        return self._index.get(eid)
+
+    def events_of(self, event_type: type) -> list[Any]:
+        return self.store.get(event_type, [])
+
+    def last(self, event_type: type) -> Any | None:
+        evs = self.store.get(event_type, [])
+        return evs[-1] if evs else None
+
+    def to_hypothesis_seeds(self) -> list[dict[str, Any]]:
+        """Render the run's results as ``ResultRecorded`` inputs for a hypothesis
+        run — the bus-interop bridge. Each ``CodeResultRecorded`` becomes a dict
+        with ``experiment_ref`` (the originating experiment, '' if none),
+        ``measurements`` (the structured dict rendered to a string), ``passed``,
+        and ``caveats`` — exactly the fields ``HypothesisRun`` ingests."""
+        seeds: list[dict[str, Any]] = []
+        for k in self.events_of(CodeResultRecorded):
+            seeds.append(
+                {
+                    "experiment_ref": k.experiment_ref,
+                    "measurements": json.dumps(k.measurements, default=str, sort_keys=True),
+                    "passed": k.passed,
+                    "caveats": list(k.caveats),
+                }
+            )
+        return seeds
+
+    def export(self, dir_path: str | Path, *, report: str = "") -> dict[str, str]:
+        """Write the run's record to *dir_path*: ``results.json`` (typed events +
+        refs + hypothesis seeds) and ``report.md`` (the verify rationale +
+        outcome). Full test outputs are written separately as ``test_output_N.txt``
+        during the run."""
+        d = Path(dir_path)
+        d.mkdir(parents=True, exist_ok=True)
+        events = [e for evs in self.store.values() for e in evs]
+        result = self.last(CodeResultRecorded)
+        payload = {
+            "root": self.root,
+            "workspace": self.workspace,
+            "agents_made": self.agents_made,
+            "passed": bool(result.passed) if result else None,
+            "events": [{"type": type(e).__name__, **e.model_dump()} for e in events],
+            "refs": [[e.eid, _first_ref(e)] for e in events if _first_ref(e)],
+            "hypothesis_seeds": self.to_hypothesis_seeds(),
+        }
+        results_path = d / "results.json"
+        results_path.write_text(json.dumps(payload, indent=2, default=str), encoding="utf-8")
+        md = _render_report(self, report)
+        report_path = d / "report.md"
+        report_path.write_text(md, encoding="utf-8")
+        return {"results": str(results_path), "report": str(report_path)}
+
+
+def _first_ref(e: CodingChainEvent) -> str:
+    for attr in _REF_ATTRS:
+        ref = getattr(e, attr, "")
+        if ref:
+            return ref
+    return ""
+
+
+def _render_report(run: CodingRun, report: str) -> str:
+    plan = run.last(WorkPlanned)
+    result = run.last(CodeResultRecorded)
+    verdict = run.last(VerifyResult)
+    parts = [f"# Coding run\n\n- root: {run.root}\n- workspace: {run.workspace}"]
+    if result is not None:
+        parts.append(f"\n- passed: {result.passed}")
+        if result.experiment_ref:
+            parts.append(f"\n- experiment_ref: {result.experiment_ref}")
+    if plan is not None:
+        parts.append(f"\n\n## Plan ({plan.eid})\n{plan.approach}")
+        if plan.acceptance_criteria:
+            parts.append(
+                "\n\n### Acceptance\n" + "\n".join(f"- {c}" for c in plan.acceptance_criteria)
+            )
+    parts.append(f"\n\n## Test runs ({len(run.events_of(TestsRan))})")
+    for t in run.events_of(TestsRan):
+        parts.append(f"\n- round {t.round}: `{t.cmd}` -> passed={t.passed} (exit {t.returncode})")
+    if verdict is not None:
+        parts.append(f"\n\n## Verdict ({verdict.eid})\n{verdict.verdict} — {verdict.rationale}")
+        if verdict.unmet:
+            parts.append("\n\n### Unmet criteria\n" + "\n".join(f"- {u}" for u in verdict.unmet))
+    if report.strip():
+        parts.append(f"\n\n---\n\n{report.strip()}")
+    return "".join(parts) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Engine
+# ---------------------------------------------------------------------------
+
+
+class CodingEngine(Engine):
+    """Gated implement/test/fix-loop engine (stateless config).
+
+    Parameters extend :class:`Engine` with one casts role per agent stage —
+    ``plan_role`` (plans the change, no tools), ``implement_role`` (implements
+    it WITH coding tools, path-guarded), ``verify_role`` (reviews the diff
+    against acceptance) — plus:
+
+    coding_tools
+        Tool names granted to the implementer (default ``("coding",)`` — the
+        full reader/editor/bash/search toolkit). Tool-bearing agents get the
+        destructive-command guard and workspace path guards from
+        :meth:`EngineRun.make_agent` (``secure=True``).
+    implement_permissions
+        Permission preset for the implementer (default ``"safe"``).
+    max_fix_rounds
+        How many times a failed test re-prompts the implementer before the run
+        concludes with ``passed=False`` — the test-failure analogue of emission
+        repair.
+    test_timeout_s
+        Wall-clock cap on each test-command subprocess (default 600s). The
+        process group is killed on timeout; output is captured up to a hard
+        byte cap and the full capture is written to the export dir.
+    repair_retries
+        Re-prompt turns when a stage's expected emission did not arrive — the
+        loop that keeps small/weak workers in the pipeline (ADR-0077 §3).
+
+    Set ``judge_model`` (base class) to gate the fix loop on a quality judge:
+    before each extra round it asks whether another attempt is worth the budget.
+    Per-stage models route through ``models={"plan": ..., "implement": ...,
+    "verify": ...}``.
+    """
+
+    run_context_cls: type[EngineRun] = CodingRun
+
+    def __init__(
+        self,
+        *,
+        plan_role: str = "analyst",
+        implement_role: str = "implementer",
+        verify_role: str = "critic",
+        coding_tools: tuple[str, ...] = ("coding",),
+        implement_permissions: str | None = "safe",
+        max_fix_rounds: int = 3,
+        test_timeout_s: float = 600.0,
+        repair_retries: int = 1,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.plan_role = plan_role
+        self.implement_role = implement_role
+        self.verify_role = verify_role
+        self.coding_tools = tuple(coding_tools)
+        self.implement_permissions = implement_permissions
+        self.max_fix_rounds = max_fix_rounds
+        self.test_timeout_s = test_timeout_s
+        self.repair_retries = repair_retries
+
+    # -- lifecycle ------------------------------------------------------------
+
+    async def _run(
+        self,
+        run: CodingRun,
+        spec: str | dict[str, Any],
+        *,
+        test_cmd: str | list[str],
+        workspace: str | None = None,
+        export_dir: str | Path | None = None,
+    ) -> CodeResultRecorded:
+        """Drive *spec* through plan -> implement -> test -> [fix] -> verify ->
+        conclude. Returns the terminal :class:`CodeResultRecorded`.
+
+        *test_cmd* is the ground-truth command (a list runs ``shell=False``; a
+        string with shell-control characters runs in a shell, otherwise it is
+        split). *workspace* is the implementer's cwd and path-guard root. When
+        *export_dir* is given, ``results.json`` + ``report.md`` (and the full
+        per-round test outputs) are written there."""
+        if not test_cmd:
+            raise ValueError("test_cmd is required — the engine needs ground truth to gate on")
+        task_text, experiment_ref = _normalize_spec(spec)
+        run.task_text = task_text
+        run.experiment_ref = experiment_ref
+        run.test_cmd = test_cmd
+        run.workspace = str(Path(workspace).expanduser()) if workspace else str(Path.cwd())
+        run.root = task_text
+        run.export_dir = Path(export_dir) if export_dir is not None else None
+        if run.export_dir is not None:
+            run.export_dir.mkdir(parents=True, exist_ok=True)
+
+        # Collector first: stamps eids before anything reads them. The pipeline
+        # is sequential (no reactive spawning), so observers only stamp + store.
+        run.observe(CodingChainEvent, lambda e, _c: run.collect(e))
+
+        plan = await self._plan(run)
+        change = await self._implement(run, plan)
+        if change is None:
+            return await self._conclude(
+                run, plan, passed=False, caveat="implementer emitted no change"
+            )
+
+        tests = await self._test(run, change, round_no=0)
+        change, tests = await self._fix_loop(run, plan, change, tests)
+        await self._verify(run, plan, change, tests)
+        return await self._conclude(run, plan, passed=tests.passed)
+
+    # -- stages ---------------------------------------------------------------
+
+    async def _plan(self, run: CodingRun) -> WorkPlanned:
+        emits = (WorkPlanned,)
+        async with run._sem:
+            agent = await run.make_agent(
+                self.plan_role,
+                name="plan",
+                model=self.model_for("plan"),
+                emits=emits,
+            )
+            await run.operate_with_repair(
+                agent,
+                _plan_instruction(run.task_text, run.workspace),
+                arrived=lambda: bool(run.events_of(WorkPlanned)),
+                emits=emits,
+                retries=self.repair_retries,
+            )
+        plan = run.last(WorkPlanned)
+        if plan is None:
+            # Degrade rather than crash: a planless run still implements against
+            # the raw task, so the stage's emission is best-effort.
+            plan = run.collect(WorkPlanned(approach=run.task_text))
+            run.notify("plan_missing", eid=plan.eid)
+        return plan
+
+    async def _implement(self, run: CodingRun, plan: WorkPlanned) -> ChangeProposed | None:
+        emits = (ChangeProposed,)
+        before = len(run.events_of(ChangeProposed))
+        async with run._sem:
+            agent = await run.make_agent(
+                self.implement_role,
+                name="implement",
+                model=self.model_for("implement"),
+                tools=self.coding_tools,
+                permissions=self.implement_permissions if self.coding_tools else None,
+                cwd=run.workspace,
+                emits=emits,
+            )
+            await run.operate_with_repair(
+                agent,
+                _implement_instruction(plan, run.task_text, run.workspace),
+                arrived=lambda: len(run.events_of(ChangeProposed)) > before,
+                emits=emits,
+                retries=self.repair_retries,
+            )
+        run._implementer = agent  # reused by the fix loop — same branch, more turns
+        return run.last(ChangeProposed)
+
+    async def _test(self, run: CodingRun, change: ChangeProposed, *, round_no: int) -> TestsRan:
+        """Run the declared test command as a subprocess — the ground-truth
+        stage. NOT an agent: ``passed`` is the process exit code."""
+        cmd, shell = _resolve_cmd(run.test_cmd)
+        cmd_str = run.test_cmd if isinstance(run.test_cmd, str) else " ".join(run.test_cmd)
+        run.notify("testing", change=change.eid, round=round_no, cmd=cmd_str)
+        result = await run_sync(_subprocess_sync, cmd, shell, self.test_timeout_s, run.workspace)
+        combined = (result.get("stdout", "") + result.get("stderr", "")).rstrip()
+        returncode = int(result.get("returncode", -1))
+        timed_out = bool(result.get("timed_out", False))
+        passed = returncode == 0 and not timed_out
+        output_file = self._write_output(run, combined)
+        tests = TestsRan(
+            change_ref=change.eid,
+            cmd=cmd_str,
+            passed=passed,
+            returncode=returncode,
+            timed_out=timed_out,
+            round=round_no,
+            output_tail=_tail(combined),
+            output_file=output_file,
+        )
+        await run.emit(tests)
+        return run.last(TestsRan)
+
+    async def _fix_loop(
+        self, run: CodingRun, plan: WorkPlanned, change: ChangeProposed, tests: TestsRan
+    ) -> tuple[ChangeProposed, TestsRan]:
+        """Re-prompt the implementer with the captured failure for a new change,
+        then re-test — bounded by ``max_fix_rounds``. The judge gate (if armed)
+        decides whether another round is worth the budget before each attempt."""
+        agent = getattr(run, "_implementer", None)
+        round_no = 0
+        while not tests.passed and round_no < self.max_fix_rounds and agent is not None:
+            round_no += 1
+            subject = f"fix round {round_no}: test `{tests.cmd}` failed (exit {tests.returncode})"
+            if not await self.judge(run, f"fix-{round_no}", subject):
+                run.notify("fix_gated", round=round_no)
+                break
+            before = len(run.events_of(ChangeProposed))
+            async with run._sem:
+                await run.operate_with_repair(
+                    agent,
+                    _fix_instruction(tests, plan, round_no, self.max_fix_rounds),
+                    arrived=lambda n=before: len(run.events_of(ChangeProposed)) > n,
+                    emits=(ChangeProposed,),
+                    retries=self.repair_retries,
+                )
+            new_change = run.last(ChangeProposed)
+            if new_change is change:
+                run.notify("fix_no_change", round=round_no)
+                break
+            change = new_change
+            tests = await self._test(run, change, round_no=round_no)
+        if not tests.passed:
+            run.notify("fix_exhausted", rounds=round_no, passed=False)
+        return change, tests
+
+    async def _verify(
+        self, run: CodingRun, plan: WorkPlanned, change: ChangeProposed, tests: TestsRan
+    ) -> VerifyResult | None:
+        run.diff = await self._capture_diff(run)
+        emits = (VerifyResult,)
+        async with run._sem:
+            # exempt: the verdict must report even when the expansion budget
+            # (fix-round agents) is spent — degrade, don't lose the verdict.
+            agent = await run.make_agent(
+                self.verify_role,
+                name="verify",
+                model=self.model_for("verify"),
+                emits=emits,
+                exempt=True,
+            )
+            await run.operate_with_repair(
+                agent,
+                _verify_instruction(plan, change, tests, run.diff),
+                arrived=lambda: bool(run.events_of(VerifyResult)),
+                emits=emits,
+                retries=self.repair_retries,
+            )
+        return run.last(VerifyResult)
+
+    async def _conclude(
+        self,
+        run: CodingRun,
+        plan: WorkPlanned,
+        *,
+        passed: bool,
+        caveat: str = "",
+    ) -> CodeResultRecorded:
+        """Emit the terminal CodeResultRecorded — shaped for hypothesis ingestion."""
+        tests = run.events_of(TestsRan)
+        last_test = tests[-1] if tests else None
+        verdict = run.last(VerifyResult)
+        caveats: list[str] = []
+        if caveat:
+            caveats.append(caveat)
+        if last_test is not None and last_test.timed_out:
+            caveats.append(f"test command timed out after {self.test_timeout_s}s")
+        if verdict is not None and verdict.unmet:
+            caveats.extend(f"unmet: {u}" for u in verdict.unmet)
+        measurements = {
+            "passed": passed,
+            "fix_rounds": last_test.round if last_test is not None else 0,
+            "test_cmd": last_test.cmd if last_test is not None else "",
+            "returncode": last_test.returncode if last_test is not None else None,
+            "test_runs": len(tests),
+            "files_touched": sorted(
+                {f for c in run.events_of(ChangeProposed) for f in c.files_touched}
+            ),
+        }
+        result = CodeResultRecorded(
+            passed=passed,
+            measurements=measurements,
+            caveats=caveats,
+            experiment_ref=run.experiment_ref,
+            verdict_ref=verdict.eid if verdict is not None else "",
+        )
+        await run.emit(result)
+        result = run.last(CodeResultRecorded)
+        run.notify("concluded", passed=passed, experiment_ref=run.experiment_ref)
+        if run.export_dir is not None:
+            report = verdict.rationale if verdict is not None else ""
+            paths = run.export(run.export_dir, report=report)
+            run.notify("exported", **paths)
+        return result
+
+    # -- ground-truth helpers -------------------------------------------------
+
+    async def _capture_diff(self, run: CodingRun) -> str:
+        """Capture ``git diff`` in the workspace for the verify stage. Best-effort
+        — a non-git workspace simply yields an empty diff."""
+        result = await run_sync(_subprocess_sync, ["git", "diff"], False, 30.0, run.workspace)
+        if int(result.get("returncode", -1)) != 0:
+            return ""
+        return result.get("stdout", "")
+
+    def _write_output(self, run: CodingRun, output: str) -> str:
+        """Write the full captured test output to the export dir, returning the
+        path. Info preservation: the event carries only a tail, the file carries
+        everything the runner captured (which is itself byte-capped + annotated
+        by the subprocess runner, never silently dropped)."""
+        if run.export_dir is None:
+            return ""
+        run._test_runs += 1
+        path = run.export_dir / f"test_output_{run._test_runs}.txt"
+        path.write_text(output, encoding="utf-8")
+        return str(path)
+
+
+def _resolve_cmd(test_cmd: str | list[str]) -> tuple[str | list[str], bool]:
+    """Resolve a test command into ``(cmd, shell)`` for the subprocess runner.
+
+    A list runs ``shell=False`` verbatim. A string with shell-control characters
+    (pipes, redirects, ``&&``, …) runs in a shell because the caller asked for a
+    pipeline; an otherwise-plain string is ``shlex``-split and runs
+    ``shell=False`` — the safe default."""
+    if isinstance(test_cmd, (list, tuple)):
+        return list(test_cmd), False
+    if _SHELL_CONTROL.search(test_cmd):
+        return test_cmd, True
+    return shlex.split(test_cmd), False
+
+
+def _tail(text: str, *, lines: int = 40, max_chars: int = 4000) -> str:
+    """Last *lines* lines of *text*, bounded to *max_chars* — for event display."""
+    tail = "\n".join(text.splitlines()[-lines:])
+    if len(tail) > max_chars:
+        tail = "…" + tail[-max_chars:]
+    return tail

--- a/lionagi/engines/engine.py
+++ b/lionagi/engines/engine.py
@@ -10,15 +10,17 @@ import contextlib
 import logging
 from collections import deque
 from collections.abc import Callable
+from time import monotonic
 from typing import TYPE_CHECKING, Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from lionagi.agent import AgentSpec, create_agent
 from lionagi.casts.emission import build_emission_operable
 from lionagi.ln.concurrency import Semaphore, gather
+from lionagi.ln.types import TypeFilter
 from lionagi.session.session import Session
-from lionagi.session.signal import NodeCompleted, NodeFailed, NodeStarted
+from lionagi.session.signal import NodeCompleted, NodeFailed, NodeStarted, Signal
 
 if TYPE_CHECKING:
     from lionagi.protocols.generic.pile import Pile
@@ -32,6 +34,18 @@ class EngineEvent(BaseModel):
     """Base for engine-only domain events with no casts-emission twin."""
 
 
+class JudgeVerdict(EngineEvent):
+    """The quality gate's call on whether a work item is worth expanding."""
+
+    subject: str = Field(default="", description="The id of the item being judged.")
+    allow: bool = Field(default=True, description="True to expand, false to stop this branch.")
+    reason: str = Field(default="", description="Why — one concrete sentence.")
+
+
+class EngineBudgetError(RuntimeError):
+    """The run's hard agent budget is exhausted; no further agents may be made."""
+
+
 def _event_dict(event: Any) -> dict[str, Any]:
     if hasattr(event, "model_dump"):
         try:
@@ -41,8 +55,40 @@ def _event_dict(event: Any) -> dict[str, Any]:
     return {}
 
 
+def _judge_instruction(eid: str, subject: str, context: str) -> str:
+    return (
+        "You are the quality gate of an autonomous pipeline. Decide whether this "
+        "work item deserves further expansion (it will spawn more agents).\n\n"
+        f"# Root objective\n{context or '(none stated)'}\n\n"
+        f"# Item ({eid})\n{subject}\n\n"
+        "Reject if it is off-topic for the root objective, duplicative, trivial, "
+        "or unsafe. Otherwise pass. Emit a judge_verdict with "
+        f"subject='{eid}', allow (true|false), reason. If you cannot emit, reply "
+        "with exactly PASS or REJECT."
+    )
+
+
+def _repair_instruction(schema_hint: str) -> str:
+    return (
+        "Your previous response produced no valid emission, so the pipeline "
+        "received nothing. Emit now, inside a fenced ```json code block. Common "
+        "failures: JSON not fenced, wrong top-level key, misspelled field names, "
+        "extra fields not in the schema (forbidden), prose instead of JSON. "
+        f"{schema_hint} Emit only the fenced block(s); no other text is needed."
+    )
+
+
+def emission_keys(emits: tuple[type, ...]) -> str:
+    """Render the top-level emission key(s) for a repair hint."""
+    from lionagi.casts.emission import _field_name
+
+    names = ", ".join(f"'{_field_name(m)}'" for m in emits)
+    return f"Expected top-level key(s): {names}." if names else ""
+
+
 class EngineRun:
-    """Per-run context: session, dedup set, in-flight tasks, concurrency limiter."""
+    """Per-run context: session, dedup set, in-flight tasks, concurrency limiter,
+    and the hard resource budget (agent count + wall-clock deadline)."""
 
     def __init__(
         self,
@@ -54,21 +100,49 @@ class EngineRun:
         self.engine = engine
         self.session = session if session is not None else Session()
         self.on_event = on_event
+        self.root: str = ""
+        self.agents_made: int = 0
         self._sem = Semaphore(engine.max_concurrent)
         self._active: set[asyncio.Task] = set()
         self._pending: deque = deque()
         self._seen: set[str] = set()
+        self._t0 = monotonic()
+        self._deadline = None if engine.deadline_s is None else self._t0 + engine.deadline_s
+        self._budget_notified = False
 
     @property
     def events(self) -> Pile:
         return self.session.observer.flow.items
 
     def by_type(self, event_type: type) -> list[Any]:
+        """Stored payloads matching *event_type* — unwraps Signal envelopes AND
+        capability bundles (an agent's emission arrives as a StructuredOutput
+        whose bundle carries the typed event as a field)."""
+        obs = self.session.observer
+        flt = TypeFilter(event_type)
         out: list[Any] = []
-        for e in self.session.observer.by_type(event_type):
-            data = getattr(e, "data", None)
-            out.append(data if isinstance(data, event_type) else e)
+        for e in obs.flow.items:
+            payload = e.data if isinstance(e, Signal) else e
+            out.extend(obs._match(flt, e, payload))
         return out
+
+    # -- resource budget --------------------------------------------------------
+
+    def budget_left(self) -> bool:
+        """True while the run may still make agents (count + deadline)."""
+        if self.agents_made >= self.engine.max_agents:
+            return False
+        return not (self._deadline is not None and monotonic() >= self._deadline)
+
+    def _notify_budget_once(self, reason: str) -> None:
+        if not self._budget_notified:
+            self._budget_notified = True
+            self.notify(
+                "budget_exhausted",
+                reason=reason,
+                agents_made=self.agents_made,
+                elapsed=round(monotonic() - self._t0, 1),
+            )
 
     async def emit(self, event: Any) -> list[Any]:
         results = await self.session.emit(event)
@@ -98,10 +172,37 @@ class EngineRun:
         model: str | None = None,
         tools: tuple[str, ...] = (),
         emits: tuple[type, ...] = (),
+        permissions: Any = None,
+        cwd: str | None = None,
+        secure: bool = True,
+        exempt: bool = False,
     ) -> Branch:
+        # ``exempt`` is for terminal stages (synthesis/verdict) that must run
+        # even when the expansion budget is gone — degrade, don't lose the run.
+        if not exempt and not self.budget_left():
+            self._notify_budget_once("make_agent")
+            raise EngineBudgetError(
+                f"agent budget exhausted ({self.agents_made}/{self.engine.max_agents})"
+            )
+        self.agents_made += 1
         spec = AgentSpec.compose(
-            role, modes=modes, model=model or self.engine.model, tools=tuple(tools)
+            role,
+            modes=modes,
+            model=model or self.engine.model,
+            tools=tuple(tools),
+            permissions=permissions,
+            cwd=cwd,
         )
+        if secure and tools:
+            from pathlib import Path
+
+            from lionagi.agent.hooks import guard_destructive, guard_paths
+
+            spec.pre("bash", guard_destructive)
+            workspace_root = str(Path(cwd) if cwd else Path.cwd())
+            path_guard = guard_paths(allowed_paths=[workspace_root])
+            spec.pre("reader", path_guard)
+            spec.pre("editor", path_guard)
         branch = await create_agent(spec, load_settings=False)
         if name:
             branch.name = name
@@ -112,7 +213,43 @@ class EngineRun:
                 branch.grant_capabilities(op)
         return branch
 
+    async def operate_with_repair(
+        self,
+        branch: Branch,
+        instruction: str,
+        *,
+        arrived: Callable[[], bool],
+        emits: tuple[type, ...] = (),
+        retries: int = 1,
+    ) -> Any:
+        """Operate, then re-prompt up to *retries* times while *arrived*() is
+        false — the repair loop that keeps weak models in the pipeline. The
+        repair turn names the expected emission keys so the model can fix
+        fence/field mistakes instead of being silently dropped."""
+        res = await branch.operate(instruction=instruction)
+        attempt = 0
+        while not arrived() and attempt < retries:
+            attempt += 1
+            self.notify(
+                "emission_repair",
+                agent=getattr(branch, "name", "") or "",
+                attempt=attempt,
+            )
+            res = await branch.operate(instruction=_repair_instruction(emission_keys(emits)))
+        if retries and not arrived():
+            self.notify(
+                "emission_missing",
+                agent=getattr(branch, "name", "") or "",
+                attempts=attempt + 1,
+            )
+        return res
+
     def spawn(self, coro: Any) -> asyncio.Task | None:
+        if not self.budget_left():
+            self._notify_budget_once("spawn")
+            with contextlib.suppress(Exception):
+                coro.close()
+            return None
         try:
             task = asyncio.ensure_future(coro)
         except RuntimeError:
@@ -234,7 +371,36 @@ class EngineRun:
 
 
 class Engine:
-    """Stateless event-driven engine base; subclasses implement _run()."""
+    """Stateless event-driven engine base; subclasses implement _run().
+
+    Resource protection (per run):
+
+    max_agents
+        Hard cap on agents created — the primary recursion bound. When
+        exhausted, reactions stop spawning (graceful: the run still
+        synthesizes what it has) and ``make_agent`` raises
+        :class:`EngineBudgetError`.
+    deadline_s
+        Optional wall-clock cap; expansion stops once passed.
+    max_depth / dedup
+        Semantic bounds — engines also gate on depth/cycle generation and
+        normalized-topic dedup.
+
+    Quality / direction control:
+
+    judge_model + judge_role
+        When ``judge_model`` is set, :meth:`judge` runs a cheap gate agent at
+        expansion points: it sees the run's root objective and the candidate
+        item, and passes or rejects it (off-topic, duplicative, trivial,
+        unsafe). Fail-open with a ``judge_error`` notify — the hard budget
+        remains the backstop.
+    models
+        Per-stage model overrides (``{"extract": "ollama/qwen3", "conclude":
+        "claude_code/sonnet"}``) — route cheap models to volume stages and
+        capable ones to judgement stages. Any agent process lionagi supports
+        is a valid worker: API chat models, CLI agents (``claude_code/...``,
+        ``codex/...``, ``pi/...``), or local ones.
+    """
 
     run_context_cls: type[EngineRun] = EngineRun
 
@@ -242,12 +408,59 @@ class Engine:
         self,
         *,
         model: str | None = None,
+        models: dict[str, str] | None = None,
         max_depth: int = 3,
         max_concurrent: int = 5,
+        max_agents: int = 50,
+        deadline_s: float | None = None,
+        judge_model: str | None = None,
+        judge_role: str = "critic",
     ) -> None:
         self.model = model
+        self.models = dict(models) if models else {}
         self.max_depth = max_depth
         self.max_concurrent = max_concurrent
+        self.max_agents = max_agents
+        self.deadline_s = deadline_s
+        self.judge_model = judge_model
+        self.judge_role = judge_role
+
+    def model_for(self, stage: str) -> str | None:
+        return self.models.get(stage) or self.model
+
+    async def judge(self, run: EngineRun, eid: str, subject: str) -> bool:
+        """Quality gate before an expansion point. True = expand.
+
+        No-op (True) when ``judge_model`` is unset. The judge sees the run's
+        root objective (direction control) and emits a ``JudgeVerdict``; a
+        weak judge that cannot emit may answer PASS/REJECT in text. Errors
+        fail open with a ``judge_error`` notify — budget still bounds.
+        """
+        if not self.judge_model:
+            return True
+        try:
+            async with run._sem:
+                agent = await run.make_agent(
+                    self.judge_role,
+                    name=f"judge-{eid}",
+                    model=self.judge_model,
+                    emits=(JudgeVerdict,),
+                )
+                res = await agent.operate(instruction=_judge_instruction(eid, subject, run.root))
+            for v in run.by_type(JudgeVerdict):
+                if v.subject == eid:
+                    if not v.allow:
+                        run.notify("gated", eid=eid, reason=v.reason)
+                    return v.allow
+            allow = "reject" not in str(res or "").lower()
+            if not allow:
+                run.notify("gated", eid=eid, reason="text-reject")
+            return allow
+        except EngineBudgetError:
+            return False
+        except Exception as exc:
+            run.notify("judge_error", eid=eid, error=str(exc))
+            return True
 
     def new_run(
         self,

--- a/lionagi/engines/engine.py
+++ b/lionagi/engines/engine.py
@@ -80,9 +80,9 @@ def _repair_instruction(schema_hint: str) -> str:
 
 def emission_keys(emits: tuple[type, ...]) -> str:
     """Render the top-level emission key(s) for a repair hint."""
-    from lionagi.casts.emission import _field_name
+    from lionagi.casts.emission import field_name_for
 
-    names = ", ".join(f"'{_field_name(m)}'" for m in emits)
+    names = ", ".join(f"'{field_name_for(m)}'" for m in emits)
     return f"Expected top-level key(s): {names}." if names else ""
 
 

--- a/lionagi/engines/engine.py
+++ b/lionagi/engines/engine.py
@@ -16,7 +16,6 @@ from typing import TYPE_CHECKING, Any
 from pydantic import BaseModel, Field
 
 from lionagi.agent import AgentSpec, create_agent
-from lionagi.casts.emission import build_emission_operable
 from lionagi.ln.concurrency import Semaphore, gather
 from lionagi.ln.types import TypeFilter
 from lionagi.session.session import Session
@@ -191,6 +190,7 @@ class EngineRun:
             model=model or self.engine.model,
             tools=tuple(tools),
             permissions=permissions,
+            emits=tuple(emits) if emits else None,
             cwd=cwd,
         )
         if secure and tools:
@@ -203,14 +203,12 @@ class EngineRun:
             path_guard = guard_paths(allowed_paths=[workspace_root])
             spec.pre("reader", path_guard)
             spec.pre("editor", path_guard)
+        # create_agent is the single grant site: emits is threaded through the
+        # spec above, so capabilities are granted once during construction.
         branch = await create_agent(spec, load_settings=False)
         if name:
             branch.name = name
         self.session.include_branches(branch)
-        if emits:
-            op = build_emission_operable(tuple(emits))
-            if op is not None:
-                branch.grant_capabilities(op)
         return branch
 
     async def operate_with_repair(

--- a/lionagi/engines/engine.py
+++ b/lionagi/engines/engine.py
@@ -13,7 +13,7 @@ from collections.abc import Callable
 from time import monotonic
 from typing import TYPE_CHECKING, Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from lionagi.agent import AgentSpec, create_agent
 from lionagi.ln.concurrency import Semaphore, gather
@@ -31,6 +31,8 @@ EventCallback = Callable[[dict[str, Any]], Any]
 
 class EngineEvent(BaseModel):
     """Base for engine-only domain events with no casts-emission twin."""
+
+    model_config = ConfigDict(extra="forbid")
 
 
 class JudgeVerdict(EngineEvent):

--- a/lionagi/engines/hypothesis.py
+++ b/lionagi/engines/hypothesis.py
@@ -22,7 +22,9 @@ the *Chain* shape, complementing research's Tree and review's Dimensional.
 
 from __future__ import annotations
 
+import json
 import logging
+from pathlib import Path
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -231,8 +233,6 @@ def _label(e: ChainEvent) -> str:
         or getattr(e, "procedure", "")
     )
     text = " ".join(str(text).split())
-    if len(text) > 100:
-        text = text[:97] + "..."
     return f"{e.eid}[{type(e).__name__}] {text}"
 
 
@@ -377,14 +377,16 @@ def _apply_instruction(c: ConclusionDrawn, decisions: str) -> str:
     )
 
 
-def _synthesis_instruction(run: HypothesisRun) -> str:
+def render_evidence(run: HypothesisRun) -> str:
+    """Render the run's evidence trail — chains, conclusions, applications,
+    pending experiments, open questions. Shared by the synthesis instruction
+    and the exported ``report.md`` appendix."""
     events: list[ChainEvent] = [e for evs in run.store.values() for e in evs]
     chains = trace_chains(events)
     concluded = {c.question_ref for c in run.events_of(ConclusionDrawn)}
     open_qs = [q for q in run.events_of(QuestionRaised) if q.eid not in concluded]
 
-    parts = ["Write the evidence report for this hypothesis-pipeline run.\n"]
-    parts.append(f"\n# Evidence chains ({len(chains)})")
+    parts = [f"# Evidence chains ({len(chains)})"]
     for chain in chains:
         parts.append("\n- " + " -> ".join(_label(e) for e in chain))
     parts.append(f"\n\n# Conclusions ({len(run.events_of(ConclusionDrawn))})")
@@ -404,14 +406,19 @@ def _synthesis_instruction(run: HypothesisRun) -> str:
         parts.append(f"\n\n# Open questions — no conclusion yet ({len(open_qs)})")
         for q in open_qs:
             parts.append(f"\n- {q.eid} {q.what_is_unknown}")
-    parts.append(
-        "\n\nOrganize by decision, not by pipeline stage: for each decision touched, "
+    return "".join(parts)
+
+
+def _synthesis_instruction(run: HypothesisRun) -> str:
+    return (
+        "Write the evidence report for this hypothesis-pipeline run.\n\n"
+        f"{render_evidence(run)}\n\n"
+        "Organize by decision, not by pipeline stage: for each decision touched, "
         "state what is now supported, challenged, or qualified, on what basis "
         "(empirical | quantitative | theoretical | taste), and what evidence is "
         "still missing. List pending experiments as a ready-to-run queue. Be "
         "specific; do not pad."
     )
-    return "".join(parts)
 
 
 # ---------------------------------------------------------------------------
@@ -446,6 +453,36 @@ class HypothesisRun(EngineRun):
     def events_of(self, event_type: type) -> list[Any]:
         return self.store.get(event_type, [])
 
+    def export(self, dir_path: str | Path, *, report: str = "") -> dict[str, str]:
+        """Write the run's evidence to *dir_path*: ``chains.json`` (the full
+        typed event graph, machine-readable for downstream KG ingestion) and
+        ``report.md`` (synthesis + evidence-trail appendix)."""
+        d = Path(dir_path)
+        d.mkdir(parents=True, exist_ok=True)
+        events = [e for evs in self.store.values() for e in evs]
+        chains = trace_chains(events)
+        concluded = {c.question_ref for c in self.events_of(ConclusionDrawn)}
+        payload = {
+            "root": self.root,
+            "agents_made": self.agents_made,
+            "events": [{"type": type(e).__name__, **e.model_dump()} for e in events],
+            "chains": [[e.eid for e in ch] for ch in chains],
+            "pending_experiments": [x.model_dump() for x in self.pending],
+            "open_questions": [
+                q.eid for q in self.events_of(QuestionRaised) if q.eid not in concluded
+            ],
+            "decisions_touched": sorted(
+                {a.decision_ref for a in self.events_of(ApplicationMapped) if a.decision_ref}
+            ),
+        }
+        chains_path = d / "chains.json"
+        chains_path.write_text(json.dumps(payload, indent=2, default=str), encoding="utf-8")
+        trail = render_evidence(self)
+        md = f"{report.strip()}\n\n---\n\n{trail}\n" if report.strip() else f"{trail}\n"
+        report_path = d / "report.md"
+        report_path.write_text(md, encoding="utf-8")
+        return {"chains": str(chains_path), "report": str(report_path)}
+
 
 # ---------------------------------------------------------------------------
 # Engine
@@ -466,15 +503,25 @@ class HypothesisEngine(Engine):
     executable_methods
         Experiment methods agents can run inline. Others (``benchmark`` by
         default) queue on ``run.pending`` with their full spec for CI/human
-        execution.
-    validate_tools
-        Tool names granted to the validator so experiments can measure for
-        real instead of reasoning analytically.
+        execution. Add ``"benchmark"`` only when the validator has real tools.
+    validate_tools / validate_cwd / validate_permissions
+        Sandbox for the validator: tool names granted so experiments measure
+        for real, the workspace they are path-guarded to, and the permission
+        preset (default ``"safe"``). Tool-bearing agents also get the
+        destructive-command guard from :meth:`EngineRun.make_agent`.
     max_questions
-        Per-extraction cap threaded into the prompt.
+        Per-extraction cap threaded into the prompt (soft; the judge gate and
+        the run budget are the hard bounds).
+    repair_retries
+        Re-prompt turns when an expected emission did not arrive — the loop
+        that keeps small/weak models productive instead of silently dropped.
 
     ``max_depth`` bounds back-edge *cycles*: follow-up questions and findings
-    raised at ``gen > max_depth`` are recorded but not expanded.
+    raised at ``gen > max_depth`` are recorded but not expanded. Set
+    ``judge_model`` (base class) to gate question expansion on a quality judge.
+    Per-stage models route through ``models={"extract": ..., "research": ...,
+    "hypothesize": ..., "design": ..., "validate": ..., "conclude": ...,
+    "apply": ..., "synthesize": ...}``.
     """
 
     run_context_cls: type[EngineRun] = HypothesisRun
@@ -492,7 +539,10 @@ class HypothesisEngine(Engine):
         synthesis_role: str = "synthesizer",
         executable_methods: tuple[str, ...] = ("analysis", "comparison", "proof"),
         validate_tools: tuple[str, ...] = (),
+        validate_cwd: str | None = None,
+        validate_permissions: str | None = "safe",
         max_questions: int = 8,
+        repair_retries: int = 1,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -506,19 +556,32 @@ class HypothesisEngine(Engine):
         self.synthesis_role = synthesis_role
         self.executable_methods = set(executable_methods)
         self.validate_tools = tuple(validate_tools)
+        self.validate_cwd = validate_cwd
+        self.validate_permissions = validate_permissions
         self.max_questions = max_questions
+        self.repair_retries = repair_retries
 
     # -- lifecycle ------------------------------------------------------------
 
     async def _run(
-        self, run: HypothesisRun, findings: str | list[str], *, decisions: str = ""
+        self,
+        run: HypothesisRun,
+        findings: str | list[str],
+        *,
+        decisions: str = "",
+        export_dir: str | Path | None = None,
     ) -> str:
-        """Push *findings* through the pipeline, then write the evidence report."""
+        """Push *findings* through the pipeline, then write the evidence report.
+
+        When *export_dir* is given, also writes ``chains.json`` + ``report.md``
+        there (the files-now persistence layer for downstream KG ingestion).
+        """
         seeds = [findings] if isinstance(findings, str) else list(findings)
         seeds = [s.strip() for s in seeds if s and s.strip()]
         if not seeds:
             raise ValueError("findings is empty")
         run.decisions = decisions
+        run.root = " | ".join(seeds)
 
         # Collector first: stamps eids before any reaction reads them.
         run.observe(ChainEvent, lambda e, _c: run.collect(e))
@@ -533,7 +596,11 @@ class HypothesisEngine(Engine):
             await run.emit(FindingPosted(description=seed, source="seed", gen=0))
 
         await run.wait_quiescence()
-        return await self._synthesize(run)
+        report = await self._synthesize(run)
+        if export_dir is not None:
+            paths = run.export(export_dir, report=report)
+            run.notify("exported", **paths)
+        return report
 
     # -- reactions ------------------------------------------------------------
 
@@ -543,7 +610,7 @@ class HypothesisEngine(Engine):
             return
         if run.seen(f"f:{f.description}"):
             return
-        run.spawn(self._guard(run, "extract", self._extract(run, f)))
+        run.spawn(self._guard(run, "extract", self._extract, f))
 
     def _on_question(self, run: HypothesisRun, q: QuestionRaised) -> None:
         if q.gen > self.max_depth:
@@ -551,83 +618,145 @@ class HypothesisEngine(Engine):
             return
         if run.seen(f"q:{q.what_is_unknown}"):
             return
-        run.spawn(self._guard(run, "research", self._research(run, q)))
+        run.spawn(self._guard(run, "research", self._research, q))
 
     def _on_hypothesis(self, run: HypothesisRun, h: HypothesisFormed) -> None:
         if run.seen(f"h:{h.statement}"):
             return
-        run.spawn(self._guard(run, "design", self._design(run, h)))
+        run.spawn(self._guard(run, "design", self._design, h))
 
     def _on_experiment(self, run: HypothesisRun, x: ExperimentDesigned) -> None:
         if x.method not in self.executable_methods:
             run.pending.append(x)
             run.notify("experiment_pending", eid=x.eid, method=x.method)
             return
-        run.spawn(self._guard(run, "validate", self._validate(run, x)))
+        run.spawn(self._guard(run, "validate", self._validate, x))
 
     def _on_result(self, run: HypothesisRun, r: ResultRecorded) -> None:
         if run.seen(f"r:{r.experiment_ref}:{r.eid}"):
             return
-        run.spawn(self._guard(run, "conclude", self._conclude(run, r)))
+        run.spawn(self._guard(run, "conclude", self._conclude, r))
 
     def _on_conclusion(self, run: HypothesisRun, c: ConclusionDrawn) -> None:
-        run.spawn(self._guard(run, "apply", self._apply(run, c)))
+        run.spawn(self._guard(run, "apply", self._apply, c))
 
     # -- stages ---------------------------------------------------------------
 
-    async def _guard(self, run: HypothesisRun, stage: str, coro: Any) -> None:
-        """A stage failure must not kill the pipeline."""
+    async def _guard(self, run: HypothesisRun, stage: str, fn: Any, event: Any) -> None:
+        """A stage failure must not kill the pipeline. Takes the stage function
+        (not a coroutine) so a budget-declined spawn closes cleanly without an
+        orphaned never-awaited inner coroutine."""
         try:
-            await coro
+            await fn(run, event)
         except Exception as exc:
             logger.warning("hypothesis stage %s failed: %s", stage, exc)
             run.notify("stage_error", stage=stage, error=str(exc))
 
     async def _extract(self, run: HypothesisRun, f: FindingPosted) -> None:
+        # Seeds are caller-provided; back-edge findings (gen > 0) came from an
+        # agent and pass the judge before spending more budget.
+        if f.gen > 0 and not await self.judge(run, f.eid, _label(f)):
+            return
+        emits = (QuestionRaised,)
         async with run._sem:
             agent = await run.make_agent(
-                self.question_role, name=f"extract-{f.eid}", emits=(QuestionRaised,)
+                self.question_role,
+                name=f"extract-{f.eid}",
+                model=self.model_for("extract"),
+                emits=emits,
             )
-            await agent.operate(
-                instruction=_extract_instruction(f, run.decisions, self.max_questions)
+            await run.operate_with_repair(
+                agent,
+                _extract_instruction(f, run.decisions, self.max_questions),
+                arrived=lambda: any(x.parent_ref == f.eid for x in run.events_of(QuestionRaised)),
+                emits=emits,
+                retries=self.repair_retries,
             )
 
     async def _research(self, run: HypothesisRun, q: QuestionRaised) -> None:
+        subject = f"{_label(q)} | alternatives: {'; '.join(q.alternatives) or '(none)'}"
+        if not await self.judge(run, q.eid, subject):
+            return
+        emits = (EvidenceCollected, QuestionRaised)
         async with run._sem:
             researcher = await run.make_agent(
                 self.research_role,
                 name=f"research-{q.eid}",
-                emits=(EvidenceCollected, QuestionRaised),
+                model=self.model_for("research"),
+                emits=emits,
             )
-            await researcher.operate(instruction=_research_instruction(q))
+            await run.operate_with_repair(
+                researcher,
+                _research_instruction(q),
+                arrived=lambda: any(
+                    e.question_ref == q.eid for e in run.events_of(EvidenceCollected)
+                ),
+                emits=(EvidenceCollected,),
+                retries=self.repair_retries,
+            )
         evidence = [e for e in run.events_of(EvidenceCollected) if e.question_ref == q.eid]
+        h_emits = (HypothesisFormed, ConclusionDrawn)
         async with run._sem:
             hypothesizer = await run.make_agent(
                 self.hypothesis_role,
                 name=f"hypothesize-{q.eid}",
-                emits=(HypothesisFormed, ConclusionDrawn),
+                model=self.model_for("hypothesize"),
+                emits=h_emits,
             )
-            await hypothesizer.operate(instruction=_hypothesize_instruction(q, evidence))
+            await run.operate_with_repair(
+                hypothesizer,
+                _hypothesize_instruction(q, evidence),
+                arrived=lambda: (
+                    any(h.question_ref == q.eid for h in run.events_of(HypothesisFormed))
+                    or any(c.question_ref == q.eid for c in run.events_of(ConclusionDrawn))
+                ),
+                emits=h_emits,
+                retries=self.repair_retries,
+            )
 
     async def _design(self, run: HypothesisRun, h: HypothesisFormed) -> None:
+        emits = (ExperimentDesigned,)
         async with run._sem:
             agent = await run.make_agent(
-                self.design_role, name=f"design-{h.eid}", emits=(ExperimentDesigned,)
+                self.design_role,
+                name=f"design-{h.eid}",
+                model=self.model_for("design"),
+                emits=emits,
             )
-            await agent.operate(instruction=_design_instruction(h))
+            await run.operate_with_repair(
+                agent,
+                _design_instruction(h),
+                arrived=lambda: any(
+                    x.hypothesis_ref == h.eid for x in run.events_of(ExperimentDesigned)
+                ),
+                emits=emits,
+                retries=self.repair_retries,
+            )
 
     async def _validate(self, run: HypothesisRun, x: ExperimentDesigned) -> None:
         h = run.find(x.hypothesis_ref)
         q = run.find(h.question_ref) if isinstance(h, HypothesisFormed) else None
         gen = q.gen if isinstance(q, QuestionRaised) else 0
+        emits = (ResultRecorded, FindingPosted)
         async with run._sem:
             agent = await run.make_agent(
                 self.validate_role,
                 name=f"validate-{x.eid}",
+                model=self.model_for("validate"),
                 tools=self.validate_tools,
-                emits=(ResultRecorded, FindingPosted),
+                permissions=self.validate_permissions if self.validate_tools else None,
+                cwd=self.validate_cwd,
+                emits=emits,
             )
-            await agent.operate(instruction=_validate_instruction(x, gen))
+            await run.operate_with_repair(
+                agent,
+                _validate_instruction(x, gen),
+                arrived=lambda: any(
+                    r.experiment_ref == x.eid for r in run.events_of(ResultRecorded)
+                ),
+                emits=(ResultRecorded,),
+                retries=self.repair_retries,
+            )
 
     async def _conclude(self, run: HypothesisRun, r: ResultRecorded) -> None:
         x = run.find(r.experiment_ref)
@@ -636,21 +765,32 @@ class HypothesisEngine(Engine):
         h = h if isinstance(h, HypothesisFormed) else None
         q = run.find(h.question_ref) if h else None
         q = q if isinstance(q, QuestionRaised) else None
+        emits = (ConclusionDrawn, QuestionRaised)
         async with run._sem:
             agent = await run.make_agent(
                 self.conclude_role,
                 name=f"conclude-{r.eid}",
-                emits=(ConclusionDrawn, QuestionRaised),
+                model=self.model_for("conclude"),
+                emits=emits,
             )
-            await agent.operate(
-                instruction=_conclude_instruction(r, x, h, q.eid if q else "", q.gen if q else 0)
+            await run.operate_with_repair(
+                agent,
+                _conclude_instruction(r, x, h, q.eid if q else "", q.gen if q else 0),
+                arrived=lambda: any(c.result_ref == r.eid for c in run.events_of(ConclusionDrawn)),
+                emits=(ConclusionDrawn,),
+                retries=self.repair_retries,
             )
 
     async def _apply(self, run: HypothesisRun, c: ConclusionDrawn) -> None:
         async with run._sem:
             agent = await run.make_agent(
-                self.apply_role, name=f"apply-{c.eid}", emits=(ApplicationMapped,)
+                self.apply_role,
+                name=f"apply-{c.eid}",
+                model=self.model_for("apply"),
+                emits=(ApplicationMapped,),
             )
+            # No repair: "bears on nothing -> emit nothing" is a legitimate
+            # outcome for this stage.
             await agent.operate(instruction=_apply_instruction(c, run.decisions))
 
     async def _synthesize(self, run: HypothesisRun) -> str:
@@ -660,6 +800,11 @@ class HypothesisEngine(Engine):
             applications=len(run.events_of(ApplicationMapped)),
             pending=len(run.pending),
         )
-        synth = await run.make_agent(self.synthesis_role, name="synthesizer")
+        synth = await run.make_agent(
+            self.synthesis_role,
+            name="synthesizer",
+            model=self.model_for("synthesize"),
+            exempt=True,
+        )
         res = await synth.operate(instruction=_synthesis_instruction(run))
         return str(res) if res is not None else ""

--- a/lionagi/engines/hypothesis.py
+++ b/lionagi/engines/hypothesis.py
@@ -1,0 +1,665 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Hypothesis-driven development engine — the evidence-chain shape.
+
+Every architectural decision should be a hypothesis with evidence, not taste.
+This engine automates the pipeline that produces that evidence: a posted
+``FindingPosted`` is decomposed into ``QuestionRaised`` (the implicit choices);
+each question gathers ``EvidenceCollected`` and forms a ``HypothesisFormed``
+(or concludes directly as taste/theoretical); a hypothesis gets an
+``ExperimentDesigned``; executable experiments produce ``ResultRecorded``;
+results become ``ConclusionDrawn`` (empirical | quantitative | theoretical |
+taste); conclusions are mapped onto the decision register as
+``ApplicationMapped`` (supports | challenges | qualifies).
+
+Events reference each other by engine-assigned ids — the reference graph IS
+the audit trail (:func:`trace_chains` reconstructs it). Back-edges are first
+class: a result may post a new finding, a conclusion may raise a follow-up
+question — bounded by ``max_depth`` cycle generations and topic dedup. This is
+the *Chain* shape, complementing research's Tree and review's Dimensional.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from lionagi.casts.emission import Finding, Gap, Verdict
+
+from .engine import Engine, EngineEvent, EngineRun
+
+logger = logging.getLogger("lionagi.engines")
+
+__all__ = (
+    "ChainEvent",
+    "FindingPosted",
+    "QuestionRaised",
+    "EvidenceCollected",
+    "HypothesisFormed",
+    "ExperimentDesigned",
+    "ResultRecorded",
+    "ConclusionDrawn",
+    "ApplicationMapped",
+    "HypothesisRun",
+    "HypothesisEngine",
+    "trace_chains",
+)
+
+
+# ---------------------------------------------------------------------------
+# Events — the pipeline vocabulary. Each carries refs to upstream events;
+# the engine stamps ``eid``, agents fill refs from their instructions.
+# ---------------------------------------------------------------------------
+
+
+class ChainEvent(BaseModel):
+    """Mixin: engine-assigned chain id for audit-trail reconstruction."""
+
+    eid: str = Field(default="", description="Leave empty — the engine assigns this id.")
+
+
+class FindingPosted(Finding, ChainEvent):
+    """An observation entering the pipeline — the casts ``Finding`` plus the
+    cycle generation and an optional upstream ref (set on back-edge findings
+    surfaced during validation)."""
+
+    gen: int = Field(default=0, description="Cycle generation — copy from your instruction.")
+    parent_ref: str = Field(
+        default="", description="Id of the upstream event that surfaced this, '' for seeds."
+    )
+
+
+class QuestionRaised(Gap, ChainEvent):
+    """An implicit choice extracted from a finding — the casts ``Gap`` (area,
+    what_is_unknown) plus the alternatives that were rejected and the decision
+    it bears on."""
+
+    gen: int = Field(default=0, description="Cycle generation — copy from your instruction.")
+    parent_ref: str = Field(default="", description="Id of the event that raised this question.")
+    alternatives: list[str] = Field(
+        default_factory=list, description="The options rejected by the choice under test."
+    )
+    decision_ref: str = Field(
+        default="",
+        description="Decision id from the register this bears on (e.g. 'D-012'), '' if none.",
+    )
+
+
+class EvidenceCollected(Finding, ChainEvent):
+    """One piece of evidence for a question — the casts ``Finding`` plus the
+    question ref and the evidence kind."""
+
+    question_ref: str = Field(description="Id of the question this evidence addresses.")
+    kind: str = Field(
+        default="analysis",
+        description="citation | precedent | analysis | measurement | knowledge.",
+    )
+
+
+class HypothesisFormed(EngineEvent, ChainEvent):
+    """A falsifiable prediction formed from a question's evidence."""
+
+    question_ref: str = Field(description="Id of the question this hypothesis answers.")
+    statement: str = Field(description="The falsifiable prediction, stated concretely.")
+    metric: str = Field(default="", description="What to measure to test it.")
+    threshold: str = Field(default="", description="The pass/fail boundary on the metric.")
+    falsifier: str = Field(
+        default="", description="The observation that would falsify the hypothesis."
+    )
+
+
+class ExperimentDesigned(EngineEvent, ChainEvent):
+    """The decisive test for a hypothesis — cheapest method that decides."""
+
+    hypothesis_ref: str = Field(description="Id of the hypothesis under test.")
+    method: str = Field(description="benchmark | analysis | proof | comparison.")
+    dataset: str = Field(default="", description="Data or fixtures the experiment needs.")
+    procedure: str = Field(description="Concrete steps to execute.")
+    acceptance: str = Field(default="", description="The criteria that mean the hypothesis holds.")
+
+
+class ResultRecorded(EngineEvent, ChainEvent):
+    """The outcome of executing an experiment — numbers or a worked derivation."""
+
+    experiment_ref: str = Field(description="Id of the experiment that produced this.")
+    measurements: str = Field(description="The concrete numbers, counts, or derivation.")
+    passed: bool | None = Field(
+        default=None, description="Verdict vs acceptance criteria; null if inconclusive."
+    )
+    caveats: list[str] = Field(
+        default_factory=list, description="Conditions that limit what this result shows."
+    )
+
+
+class ConclusionDrawn(Verdict, ChainEvent):
+    """The typed conclusion on a question — the casts ``Verdict`` plus the
+    evidence basis. ``basis='taste'`` is legitimate when no stronger backing
+    exists; it must be acknowledged, not disguised."""
+
+    question_ref: str = Field(description="Id of the question being concluded.")
+    result_ref: str = Field(
+        default="", description="Id of the supporting result; '' for taste/theoretical paths."
+    )
+    basis: str = Field(description="empirical | quantitative | theoretical | taste.")
+    confidence: float = Field(
+        default=0.5, ge=0.0, le=1.0, description="How settled this conclusion is."
+    )
+    limitations: list[str] = Field(
+        default_factory=list, description="Scopes where this conclusion does not apply."
+    )
+
+
+class ApplicationMapped(EngineEvent, ChainEvent):
+    """A conclusion applied to the architecture — the ADR-support link."""
+
+    conclusion_ref: str = Field(description="Id of the conclusion being applied.")
+    decision_ref: str = Field(description="The decision or component this bears on (e.g. 'D-012').")
+    effect: str = Field(description="supports | challenges | qualifies.")
+    note: str = Field(default="", description="How the conclusion bears on the decision.")
+
+
+_EVENT_PREFIX: dict[type, str] = {
+    FindingPosted: "F",
+    QuestionRaised: "Q",
+    EvidenceCollected: "E",
+    HypothesisFormed: "H",
+    ExperimentDesigned: "X",
+    ResultRecorded: "R",
+    ConclusionDrawn: "C",
+    ApplicationMapped: "A",
+}
+
+_REF_ATTRS = (
+    "conclusion_ref",
+    "result_ref",
+    "experiment_ref",
+    "hypothesis_ref",
+    "question_ref",
+    "parent_ref",
+)
+
+
+# ---------------------------------------------------------------------------
+# Audit trail
+# ---------------------------------------------------------------------------
+
+
+def trace_chains(events: list[ChainEvent]) -> list[list[ChainEvent]]:
+    """Reconstruct evidence chains (root → terminal) from event refs.
+
+    Terminals are ``ApplicationMapped`` events plus any ``ConclusionDrawn``
+    no application references. Each chain walks upstream refs to its root.
+    """
+    index = {e.eid: e for e in events if e.eid}
+    applied = {e.conclusion_ref for e in events if isinstance(e, ApplicationMapped)}
+    terminals = [e for e in events if isinstance(e, ApplicationMapped)]
+    terminals += [e for e in events if isinstance(e, ConclusionDrawn) and e.eid not in applied]
+
+    chains: list[list[ChainEvent]] = []
+    for terminal in terminals:
+        chain = [terminal]
+        visited = {terminal.eid}
+        cur: ChainEvent | None = terminal
+        while cur is not None:
+            nxt = None
+            for attr in _REF_ATTRS:
+                ref = getattr(cur, attr, "")
+                if ref and ref in index and ref not in visited:
+                    nxt = index[ref]
+                    break
+            if nxt is None:
+                break
+            chain.append(nxt)
+            visited.add(nxt.eid)
+            cur = nxt
+        chain.reverse()
+        chains.append(chain)
+    return chains
+
+
+def _label(e: ChainEvent) -> str:
+    text = (
+        getattr(e, "what_is_unknown", "")
+        or getattr(e, "statement", "")
+        or getattr(e, "verdict", "")
+        or getattr(e, "description", "")
+        or getattr(e, "measurements", "")
+        or getattr(e, "note", "")
+        or getattr(e, "procedure", "")
+    )
+    text = " ".join(str(text).split())
+    if len(text) > 100:
+        text = text[:97] + "..."
+    return f"{e.eid}[{type(e).__name__}] {text}"
+
+
+# ---------------------------------------------------------------------------
+# Instructions
+# ---------------------------------------------------------------------------
+
+
+def _register_block(decisions: str) -> str:
+    return f"\n\n# Decision register\n{decisions}" if decisions.strip() else ""
+
+
+def _extract_instruction(f: FindingPosted, decisions: str, cap: int) -> str:
+    return (
+        f"A finding was posted (id {f.eid}, cycle {f.gen}):\n"
+        f"- claim: {f.description}\n"
+        f"- evidence: {f.evidence or '(none)'}\n"
+        f"- source: {f.source or '(unknown)'}\n\n"
+        "Extract the architectural questions hidden in it — every implicit choice "
+        "where an alternative was rejected without evidence. For each, emit a "
+        "question_raised with: area, what_is_unknown (the claim under test, phrased "
+        "as 'why X over Y?'), alternatives (the rejected options), decision_ref "
+        "(the decision id from the register it bears on, '' if none), "
+        f"parent_ref='{f.eid}', gen={f.gen}. At most {cap} questions; skip choices "
+        "that are pure style with no reversal cost."
+        f"{_register_block(decisions)}"
+    )
+
+
+def _research_instruction(q: QuestionRaised) -> str:
+    alts = "; ".join(q.alternatives) if q.alternatives else "(none stated)"
+    return (
+        f"Research question {q.eid} (cycle {q.gen}) in area '{q.area}':\n"
+        f"- claim under test: {q.what_is_unknown}\n"
+        f"- rejected alternatives: {alts}\n"
+        f"- bears on decision: {q.decision_ref or '(unmapped)'}\n\n"
+        "Gather concrete evidence from several kinds — citation (literature, docs), "
+        "precedent (what shipped systems do), analysis (complexity, counting), "
+        "measurement (existing numbers), knowledge (domain expertise). For each "
+        "piece emit an evidence_collected with: description (the claim), kind, "
+        "evidence (the concrete proof), source, confidence, "
+        f"question_ref='{q.eid}'. Evidence for the alternatives counts as much as "
+        "evidence for the chosen option. If a genuinely distinct sub-question "
+        "emerges, emit a question_raised with parent_ref='" + q.eid + "' and "
+        f"gen={q.gen + 1}."
+    )
+
+
+def _hypothesize_instruction(q: QuestionRaised, evidence: list[EvidenceCollected]) -> str:
+    parts = [
+        f"Form the testable hypothesis for question {q.eid}: {q.what_is_unknown}\n",
+        f"\n# Evidence ({len(evidence)})",
+    ]
+    for e in evidence:
+        parts.append(
+            f"\n- [{e.eid} {e.kind} conf={e.confidence:.2f}] {e.description}"
+            f" — {e.evidence or e.source or ''}"
+        )
+    parts.append(
+        "\n\nIf the choice is decidable by measurement or formal argument, emit a "
+        "hypothesis_formed with: statement (a falsifiable prediction), metric, "
+        f"threshold, falsifier, question_ref='{q.eid}'. If it is provable from the "
+        "evidence alone or is a pure preference, emit a conclusion_drawn directly "
+        "with: verdict, rationale, basis ('theoretical' if provable, 'taste' if "
+        f"preference), confidence, limitations, question_ref='{q.eid}', "
+        "result_ref=''. Do not disguise taste as evidence — label it."
+    )
+    return "".join(parts)
+
+
+def _design_instruction(h: HypothesisFormed) -> str:
+    return (
+        f"Design the decisive experiment for hypothesis {h.eid}:\n"
+        f"- statement: {h.statement}\n"
+        f"- metric: {h.metric or '(unspecified)'}\n"
+        f"- threshold: {h.threshold or '(unspecified)'}\n"
+        f"- falsifier: {h.falsifier or '(unspecified)'}\n\n"
+        "Emit an experiment_designed with: method (benchmark | analysis | proof | "
+        "comparison — prefer the cheapest that decides), dataset (data or fixtures "
+        "needed), procedure (concrete executable steps), acceptance (what outcome "
+        f"confirms the hypothesis), hypothesis_ref='{h.eid}'."
+    )
+
+
+def _validate_instruction(x: ExperimentDesigned, gen: int) -> str:
+    return (
+        f"Execute experiment {x.eid} ({x.method}):\n"
+        f"- procedure: {x.procedure}\n"
+        f"- dataset: {x.dataset or '(none)'}\n"
+        f"- acceptance: {x.acceptance or '(judge rigorously)'}\n\n"
+        "Carry it out with rigor — counting, complexity analysis, worked "
+        "comparison, or proof steps; use tools if you have them. Emit a "
+        "result_recorded with: measurements (the concrete numbers or derivation), "
+        "passed (true/false vs acceptance, null if inconclusive), caveats, "
+        f"experiment_ref='{x.eid}'. If execution surfaces a genuinely new fact, "
+        f"emit a finding_posted with parent_ref='{x.eid}' and gen={gen + 1}."
+    )
+
+
+def _conclude_instruction(
+    r: ResultRecorded,
+    x: ExperimentDesigned | None,
+    h: HypothesisFormed | None,
+    q_eid: str,
+    gen: int,
+) -> str:
+    caveats = "; ".join(r.caveats) if r.caveats else "(none)"
+    return (
+        f"Draw the conclusion from result {r.eid}:\n"
+        f"- hypothesis: {h.statement if h else '(unavailable)'}\n"
+        f"- method: {x.method if x else '(unavailable)'}\n"
+        f"- measurements: {r.measurements}\n"
+        f"- passed: {r.passed}\n"
+        f"- caveats: {caveats}\n\n"
+        "Emit a conclusion_drawn with: verdict (the decision the evidence supports), "
+        "rationale, basis ('empirical' if measured, 'quantitative' if counted, "
+        "'theoretical' if proven), confidence, limitations (scopes where it does "
+        f"not apply), question_ref='{q_eid}', result_ref='{r.eid}'. If the result "
+        "raises a genuine follow-up, emit a question_raised with "
+        f"parent_ref='{r.eid}' and gen={gen + 1}."
+    )
+
+
+def _apply_instruction(c: ConclusionDrawn, decisions: str) -> str:
+    lim = "; ".join(c.limitations) if c.limitations else "(none)"
+    target = (
+        "For each decision in the register it bears on"
+        if decisions.strip()
+        else "For each architectural component or decision it bears on"
+    )
+    return (
+        f"Apply conclusion {c.eid} to the architecture:\n"
+        f"- verdict: {c.verdict}\n"
+        f"- rationale: {c.rationale}\n"
+        f"- basis: {c.basis} (confidence {c.confidence:.2f})\n"
+        f"- limitations: {lim}\n\n"
+        f"{target}, emit an application_mapped with: decision_ref, effect "
+        "('supports' | 'challenges' | 'qualifies'), note (exactly how it bears), "
+        f"conclusion_ref='{c.eid}'. A conclusion that bears on nothing is a signal "
+        "the question was not architectural — emit nothing in that case."
+        f"{_register_block(decisions)}"
+    )
+
+
+def _synthesis_instruction(run: HypothesisRun) -> str:
+    events: list[ChainEvent] = [e for evs in run.store.values() for e in evs]
+    chains = trace_chains(events)
+    concluded = {c.question_ref for c in run.events_of(ConclusionDrawn)}
+    open_qs = [q for q in run.events_of(QuestionRaised) if q.eid not in concluded]
+
+    parts = ["Write the evidence report for this hypothesis-pipeline run.\n"]
+    parts.append(f"\n# Evidence chains ({len(chains)})")
+    for chain in chains:
+        parts.append("\n- " + " -> ".join(_label(e) for e in chain))
+    parts.append(f"\n\n# Conclusions ({len(run.events_of(ConclusionDrawn))})")
+    for c in run.events_of(ConclusionDrawn):
+        parts.append(f"\n- {c.eid} [{c.basis} conf={c.confidence:.2f}] {c.verdict} — {c.rationale}")
+    parts.append(f"\n\n# Applications ({len(run.events_of(ApplicationMapped))})")
+    for a in run.events_of(ApplicationMapped):
+        parts.append(f"\n- {a.decision_ref} <- {a.effect} <- {a.conclusion_ref}: {a.note}")
+    if run.pending:
+        parts.append(f"\n\n# Pending experiments — need real infrastructure ({len(run.pending)})")
+        for x in run.pending:
+            parts.append(
+                f"\n- {x.eid} [{x.method}] {x.procedure} | dataset: {x.dataset} "
+                f"| acceptance: {x.acceptance}"
+            )
+    if open_qs:
+        parts.append(f"\n\n# Open questions — no conclusion yet ({len(open_qs)})")
+        for q in open_qs:
+            parts.append(f"\n- {q.eid} {q.what_is_unknown}")
+    parts.append(
+        "\n\nOrganize by decision, not by pipeline stage: for each decision touched, "
+        "state what is now supported, challenged, or qualified, on what basis "
+        "(empirical | quantitative | theoretical | taste), and what evidence is "
+        "still missing. List pending experiments as a ready-to-run queue. Be "
+        "specific; do not pad."
+    )
+    return "".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Run context
+# ---------------------------------------------------------------------------
+
+
+class HypothesisRun(EngineRun):
+    """Per-run state: typed event store, eid counters, pending experiments."""
+
+    def __init__(self, engine: Engine, **kwargs: Any) -> None:
+        super().__init__(engine, **kwargs)
+        self.store: dict[type, list[Any]] = {t: [] for t in _EVENT_PREFIX}
+        self.pending: list[ExperimentDesigned] = []
+        self.decisions: str = ""
+        self._eid_counts: dict[str, int] = {}
+        self._index: dict[str, ChainEvent] = {}
+
+    def collect(self, event: ChainEvent) -> ChainEvent:
+        """Stamp the engine-assigned eid and store the event (first observer)."""
+        prefix = _EVENT_PREFIX.get(type(event), "N")
+        n = self._eid_counts.get(prefix, 0) + 1
+        self._eid_counts[prefix] = n
+        event.eid = f"{prefix}-{n}"
+        self.store.setdefault(type(event), []).append(event)
+        self._index[event.eid] = event
+        return event
+
+    def find(self, eid: str) -> ChainEvent | None:
+        return self._index.get(eid)
+
+    def events_of(self, event_type: type) -> list[Any]:
+        return self.store.get(event_type, [])
+
+
+# ---------------------------------------------------------------------------
+# Engine
+# ---------------------------------------------------------------------------
+
+
+class HypothesisEngine(Engine):
+    """Evidence-chain engine for hypothesis-driven development (stateless config).
+
+    Parameters extend :class:`Engine` with one casts role per stage —
+    ``question_role`` (extracts questions from findings), ``research_role``
+    (gathers evidence), ``hypothesis_role`` (forms falsifiable predictions),
+    ``design_role`` (designs the decisive experiment), ``validate_role``
+    (executes it), ``conclude_role`` (draws the typed conclusion),
+    ``apply_role`` (maps conclusions onto the decision register) and
+    ``synthesis_role`` (writes the final evidence report) — plus:
+
+    executable_methods
+        Experiment methods agents can run inline. Others (``benchmark`` by
+        default) queue on ``run.pending`` with their full spec for CI/human
+        execution.
+    validate_tools
+        Tool names granted to the validator so experiments can measure for
+        real instead of reasoning analytically.
+    max_questions
+        Per-extraction cap threaded into the prompt.
+
+    ``max_depth`` bounds back-edge *cycles*: follow-up questions and findings
+    raised at ``gen > max_depth`` are recorded but not expanded.
+    """
+
+    run_context_cls: type[EngineRun] = HypothesisRun
+
+    def __init__(
+        self,
+        *,
+        question_role: str = "analyst",
+        research_role: str = "researcher",
+        hypothesis_role: str = "analyst",
+        design_role: str = "evaluator",
+        validate_role: str = "analyst",
+        conclude_role: str = "critic",
+        apply_role: str = "architect",
+        synthesis_role: str = "synthesizer",
+        executable_methods: tuple[str, ...] = ("analysis", "comparison", "proof"),
+        validate_tools: tuple[str, ...] = (),
+        max_questions: int = 8,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.question_role = question_role
+        self.research_role = research_role
+        self.hypothesis_role = hypothesis_role
+        self.design_role = design_role
+        self.validate_role = validate_role
+        self.conclude_role = conclude_role
+        self.apply_role = apply_role
+        self.synthesis_role = synthesis_role
+        self.executable_methods = set(executable_methods)
+        self.validate_tools = tuple(validate_tools)
+        self.max_questions = max_questions
+
+    # -- lifecycle ------------------------------------------------------------
+
+    async def _run(
+        self, run: HypothesisRun, findings: str | list[str], *, decisions: str = ""
+    ) -> str:
+        """Push *findings* through the pipeline, then write the evidence report."""
+        seeds = [findings] if isinstance(findings, str) else list(findings)
+        seeds = [s.strip() for s in seeds if s and s.strip()]
+        if not seeds:
+            raise ValueError("findings is empty")
+        run.decisions = decisions
+
+        # Collector first: stamps eids before any reaction reads them.
+        run.observe(ChainEvent, lambda e, _c: run.collect(e))
+        run.observe(FindingPosted, lambda f, _c: self._on_finding(run, f))
+        run.observe(QuestionRaised, lambda q, _c: self._on_question(run, q))
+        run.observe(HypothesisFormed, lambda h, _c: self._on_hypothesis(run, h))
+        run.observe(ExperimentDesigned, lambda x, _c: self._on_experiment(run, x))
+        run.observe(ResultRecorded, lambda r, _c: self._on_result(run, r))
+        run.observe(ConclusionDrawn, lambda c, _c: self._on_conclusion(run, c))
+
+        for seed in seeds:
+            await run.emit(FindingPosted(description=seed, source="seed", gen=0))
+
+        await run.wait_quiescence()
+        return await self._synthesize(run)
+
+    # -- reactions ------------------------------------------------------------
+
+    def _on_finding(self, run: HypothesisRun, f: FindingPosted) -> None:
+        if f.gen > self.max_depth:
+            run.notify("cycle_capped", eid=f.eid, gen=f.gen)
+            return
+        if run.seen(f"f:{f.description}"):
+            return
+        run.spawn(self._guard(run, "extract", self._extract(run, f)))
+
+    def _on_question(self, run: HypothesisRun, q: QuestionRaised) -> None:
+        if q.gen > self.max_depth:
+            run.notify("cycle_capped", eid=q.eid, gen=q.gen)
+            return
+        if run.seen(f"q:{q.what_is_unknown}"):
+            return
+        run.spawn(self._guard(run, "research", self._research(run, q)))
+
+    def _on_hypothesis(self, run: HypothesisRun, h: HypothesisFormed) -> None:
+        if run.seen(f"h:{h.statement}"):
+            return
+        run.spawn(self._guard(run, "design", self._design(run, h)))
+
+    def _on_experiment(self, run: HypothesisRun, x: ExperimentDesigned) -> None:
+        if x.method not in self.executable_methods:
+            run.pending.append(x)
+            run.notify("experiment_pending", eid=x.eid, method=x.method)
+            return
+        run.spawn(self._guard(run, "validate", self._validate(run, x)))
+
+    def _on_result(self, run: HypothesisRun, r: ResultRecorded) -> None:
+        if run.seen(f"r:{r.experiment_ref}:{r.eid}"):
+            return
+        run.spawn(self._guard(run, "conclude", self._conclude(run, r)))
+
+    def _on_conclusion(self, run: HypothesisRun, c: ConclusionDrawn) -> None:
+        run.spawn(self._guard(run, "apply", self._apply(run, c)))
+
+    # -- stages ---------------------------------------------------------------
+
+    async def _guard(self, run: HypothesisRun, stage: str, coro: Any) -> None:
+        """A stage failure must not kill the pipeline."""
+        try:
+            await coro
+        except Exception as exc:
+            logger.warning("hypothesis stage %s failed: %s", stage, exc)
+            run.notify("stage_error", stage=stage, error=str(exc))
+
+    async def _extract(self, run: HypothesisRun, f: FindingPosted) -> None:
+        async with run._sem:
+            agent = await run.make_agent(
+                self.question_role, name=f"extract-{f.eid}", emits=(QuestionRaised,)
+            )
+            await agent.operate(
+                instruction=_extract_instruction(f, run.decisions, self.max_questions)
+            )
+
+    async def _research(self, run: HypothesisRun, q: QuestionRaised) -> None:
+        async with run._sem:
+            researcher = await run.make_agent(
+                self.research_role,
+                name=f"research-{q.eid}",
+                emits=(EvidenceCollected, QuestionRaised),
+            )
+            await researcher.operate(instruction=_research_instruction(q))
+        evidence = [e for e in run.events_of(EvidenceCollected) if e.question_ref == q.eid]
+        async with run._sem:
+            hypothesizer = await run.make_agent(
+                self.hypothesis_role,
+                name=f"hypothesize-{q.eid}",
+                emits=(HypothesisFormed, ConclusionDrawn),
+            )
+            await hypothesizer.operate(instruction=_hypothesize_instruction(q, evidence))
+
+    async def _design(self, run: HypothesisRun, h: HypothesisFormed) -> None:
+        async with run._sem:
+            agent = await run.make_agent(
+                self.design_role, name=f"design-{h.eid}", emits=(ExperimentDesigned,)
+            )
+            await agent.operate(instruction=_design_instruction(h))
+
+    async def _validate(self, run: HypothesisRun, x: ExperimentDesigned) -> None:
+        h = run.find(x.hypothesis_ref)
+        q = run.find(h.question_ref) if isinstance(h, HypothesisFormed) else None
+        gen = q.gen if isinstance(q, QuestionRaised) else 0
+        async with run._sem:
+            agent = await run.make_agent(
+                self.validate_role,
+                name=f"validate-{x.eid}",
+                tools=self.validate_tools,
+                emits=(ResultRecorded, FindingPosted),
+            )
+            await agent.operate(instruction=_validate_instruction(x, gen))
+
+    async def _conclude(self, run: HypothesisRun, r: ResultRecorded) -> None:
+        x = run.find(r.experiment_ref)
+        x = x if isinstance(x, ExperimentDesigned) else None
+        h = run.find(x.hypothesis_ref) if x else None
+        h = h if isinstance(h, HypothesisFormed) else None
+        q = run.find(h.question_ref) if h else None
+        q = q if isinstance(q, QuestionRaised) else None
+        async with run._sem:
+            agent = await run.make_agent(
+                self.conclude_role,
+                name=f"conclude-{r.eid}",
+                emits=(ConclusionDrawn, QuestionRaised),
+            )
+            await agent.operate(
+                instruction=_conclude_instruction(r, x, h, q.eid if q else "", q.gen if q else 0)
+            )
+
+    async def _apply(self, run: HypothesisRun, c: ConclusionDrawn) -> None:
+        async with run._sem:
+            agent = await run.make_agent(
+                self.apply_role, name=f"apply-{c.eid}", emits=(ApplicationMapped,)
+            )
+            await agent.operate(instruction=_apply_instruction(c, run.decisions))
+
+    async def _synthesize(self, run: HypothesisRun) -> str:
+        run.notify(
+            "synthesizing",
+            conclusions=len(run.events_of(ConclusionDrawn)),
+            applications=len(run.events_of(ApplicationMapped)),
+            pending=len(run.pending),
+        )
+        synth = await run.make_agent(self.synthesis_role, name="synthesizer")
+        res = await synth.operate(instruction=_synthesis_instruction(run))
+        return str(res) if res is not None else ""

--- a/lionagi/engines/planning.py
+++ b/lionagi/engines/planning.py
@@ -157,6 +157,11 @@ class PlanningEngine(Engine):
             res = op_results.get(nid)
             outputs.append(f"## {ta.assignee}\n{res if res is not None else '(no output)'}")
         run.notify("synthesizing", outputs=len(outputs))
-        synth = await run.make_agent(self.synthesis_role, name="synthesizer")
+        synth = await run.make_agent(
+            self.synthesis_role,
+            name="synthesizer",
+            model=self.model_for("synthesize"),
+            exempt=True,
+        )
         res = await synth.operate(instruction=_synthesis_instruction(prompt, outputs))
         return str(res) if res is not None else ""

--- a/lionagi/engines/research.py
+++ b/lionagi/engines/research.py
@@ -13,6 +13,7 @@ reaction rules, not a per-task DAG plan.
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from pydantic import Field
@@ -150,6 +151,7 @@ class ResearchEngine(Engine):
         topic = topic.strip()
         if not topic:
             raise ValueError("topic is empty")
+        run.root = topic
         run.seen(topic)  # mark the root so a child cannot re-explore it
 
         # Reaction rules — the engine's decomposition logic, bound to this run.
@@ -178,11 +180,19 @@ class ResearchEngine(Engine):
 
     async def _team_for(self, run: EngineRun, depth: int) -> list:
         return [
-            await run.make_agent(role, name=f"{role}-d{depth}", emits=_EMITS) for role in self.roles
+            await run.make_agent(
+                role, name=f"{role}-d{depth}", model=self.model_for(role), emits=_EMITS
+            )
+            for role in self.roles
         ]
 
     async def _explore(self, run: EngineRun, topic: str, depth: int) -> None:
         if depth > self.max_depth or run.seen(topic):
+            return
+        # Depth expansion spends a whole team — gate it on the quality judge
+        # (off-topic / duplicative / trivial sub-questions stop here).
+        jid = f"d{depth}-" + re.sub(r"[^a-zA-Z0-9]+", "-", topic).strip("-")[:32]
+        if not await self.judge(run, jid, f"deeper exploration (depth {depth}): {topic}"):
             return
         run.notify("node_registered", topic=topic, depth=depth)
         async with run._sem:
@@ -193,7 +203,12 @@ class ResearchEngine(Engine):
         findings = run.by_type(FindingEmitted)
         contradictions = run.by_type(ContradictionFound)
         run.notify("synthesizing", findings=len(findings))
-        synth = await run.make_agent(self.synthesis_role, name="synthesizer")
+        synth = await run.make_agent(
+            self.synthesis_role,
+            name="synthesizer",
+            model=self.model_for("synthesize"),
+            exempt=True,
+        )
         res = await synth.operate(
             instruction=_synthesis_instruction(topic, findings, contradictions)
         )

--- a/lionagi/engines/research.py
+++ b/lionagi/engines/research.py
@@ -126,6 +126,10 @@ class ResearchEngine(Engine):
         output). Each is granted the research emissions.
     synthesis_role
         Casts role that writes the final synthesis from the emission store.
+    repair_retries
+        Re-prompt turns when an exploration node's whole team emitted no finding
+        — the loop that keeps small/weak workers in the pipeline instead of a
+        node silently producing nothing (ADR-0077 §3).
 
     All run-state (session, seen topics, in-flight nodes) lives on the
     per-call :class:`EngineRun`, so one engine runs many topics concurrently.
@@ -137,12 +141,14 @@ class ResearchEngine(Engine):
         novelty_threshold: float = 0.7,
         roles: tuple[str, ...] = ("researcher", "analyst", "critic"),
         synthesis_role: str = "synthesizer",
+        repair_retries: int = 1,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.novelty_threshold = novelty_threshold
         self.roles = roles
         self.synthesis_role = synthesis_role
+        self.repair_retries = repair_retries
 
     # -- lifecycle ------------------------------------------------------------
 
@@ -160,7 +166,7 @@ class ResearchEngine(Engine):
 
         run.notify("node_registered", topic=topic, depth=0)
         team = await self._team_for(run, 0)
-        await run.run_team(team, _node_instruction(topic, 0, self.max_depth))
+        await self._drive_node(run, team, _node_instruction(topic, 0, self.max_depth))
 
         # Drain the recursively-spawned depth nodes before synthesizing.
         await run.wait_quiescence()
@@ -197,7 +203,33 @@ class ResearchEngine(Engine):
         run.notify("node_registered", topic=topic, depth=depth)
         async with run._sem:
             team = await self._team_for(run, depth)
-            await run.run_team(team, _node_instruction(topic, depth, self.max_depth))
+            await self._drive_node(run, team, _node_instruction(topic, depth, self.max_depth))
+
+    async def _drive_node(self, run: EngineRun, team: list, instruction: str) -> None:
+        """Run an exploration team, then repair if the whole node emitted nothing.
+
+        The team runs as before (sequential, build-on-prior); repair only fires
+        when no ``FindingEmitted``/``DepthRequested`` arrived from this node — the
+        weak-model case where every member returned prose. It re-prompts the
+        consolidating (last) member; a node with real findings costs no extra
+        call (early return). An empty team has nothing to drive or repair."""
+        before = len(run.by_type(FindingEmitted)) + len(run.by_type(DepthRequested))
+        await run.run_team(team, instruction)
+        if not team:
+            return
+
+        def arrived() -> bool:
+            return len(run.by_type(FindingEmitted)) + len(run.by_type(DepthRequested)) > before
+
+        if arrived():
+            return
+        await run.operate_with_repair(
+            team[-1],
+            instruction,
+            arrived=arrived,
+            emits=(FindingEmitted,),
+            retries=self.repair_retries,
+        )
 
     async def _synthesize(self, run: EngineRun, topic: str) -> str:
         findings = run.by_type(FindingEmitted)

--- a/lionagi/engines/review.py
+++ b/lionagi/engines/review.py
@@ -139,6 +139,10 @@ class ReviewEngine(Engine):
         verdict author.
     verify_severities
         Issue severities that reactively spawn an adversarial verifier.
+    repair_retries
+        Re-prompt turns when a reviewer or verifier emits no valid event — the
+        loop that keeps small/weak workers in the pipeline instead of silently
+        dropping their stage (ADR-0077 §3).
     """
 
     def __init__(
@@ -149,6 +153,7 @@ class ReviewEngine(Engine):
         verifier_role: str = "critic",
         synthesis_role: str = "synthesizer",
         verify_severities: tuple[str, ...] = ("critical", "major"),
+        repair_retries: int = 1,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -157,6 +162,7 @@ class ReviewEngine(Engine):
         self.verifier_role = verifier_role
         self.synthesis_role = synthesis_role
         self.verify_severities = set(verify_severities)
+        self.repair_retries = repair_retries
 
     async def _run(
         self, run: EngineRun, artifact: str, *, dimensions: tuple[str, ...] | None = None
@@ -188,6 +194,7 @@ class ReviewEngine(Engine):
     # -- stages ---------------------------------------------------------------
 
     async def _review_dimension(self, run: EngineRun, artifact: str, dimension: str) -> None:
+        emits = (IssueFound,)
         async with run._sem:
             mode = _DIM_MODE.get(dimension)
             agent = await run.make_agent(
@@ -195,20 +202,38 @@ class ReviewEngine(Engine):
                 name=f"review-{dimension}",
                 modes=[mode] if mode else None,
                 model=self.model_for("review"),
-                emits=(IssueFound,),
+                emits=emits,
             )
-            await agent.operate(instruction=_dimension_instruction(artifact, dimension))
+            # Repair re-prompts a reviewer that emitted prose instead of fenced
+            # issues — it requests an emission, never fabricates one, so a
+            # genuinely clean dimension simply emits nothing again.
+            await run.operate_with_repair(
+                agent,
+                _dimension_instruction(artifact, dimension),
+                arrived=lambda: any(i.dimension == dimension for i in run.by_type(IssueFound)),
+                emits=emits,
+                retries=self.repair_retries,
+            )
 
     async def _verify(self, run: EngineRun, issue: IssueFound) -> None:
+        emits = (VerifyResult,)
         async with run._sem:
             verifier = await run.make_agent(
                 self.verifier_role,
                 name=f"verify-{issue.dimension}",
                 modes=["adversarial"],
                 model=self.model_for("verify"),
-                emits=(VerifyResult,),
+                emits=emits,
             )
-            await verifier.operate(instruction=_verify_instruction(issue))
+            await run.operate_with_repair(
+                verifier,
+                _verify_instruction(issue),
+                arrived=lambda: any(
+                    v.issue == issue.description for v in run.by_type(VerifyResult)
+                ),
+                emits=emits,
+                retries=self.repair_retries,
+            )
 
     async def _verdict(self, run: EngineRun, artifact: str, dimensions: tuple[str, ...]) -> str:
         issues = run.by_type(IssueFound)

--- a/lionagi/engines/review.py
+++ b/lionagi/engines/review.py
@@ -162,6 +162,7 @@ class ReviewEngine(Engine):
         self, run: EngineRun, artifact: str, *, dimensions: tuple[str, ...] | None = None
     ) -> str:
         dims = tuple(dimensions) if dimensions else self.dimensions
+        run.root = artifact
         run.observe(IssueFound, lambda i, _c: self._on_issue(run, i))
 
         # Fan out: one reviewer per dimension, in parallel.
@@ -193,6 +194,7 @@ class ReviewEngine(Engine):
                 self.reviewer_role,
                 name=f"review-{dimension}",
                 modes=[mode] if mode else None,
+                model=self.model_for("review"),
                 emits=(IssueFound,),
             )
             await agent.operate(instruction=_dimension_instruction(artifact, dimension))
@@ -203,6 +205,7 @@ class ReviewEngine(Engine):
                 self.verifier_role,
                 name=f"verify-{issue.dimension}",
                 modes=["adversarial"],
+                model=self.model_for("verify"),
                 emits=(VerifyResult,),
             )
             await verifier.operate(instruction=_verify_instruction(issue))
@@ -211,7 +214,13 @@ class ReviewEngine(Engine):
         issues = run.by_type(IssueFound)
         verifications = run.by_type(VerifyResult)
         run.notify("verdict", issues=len(issues), verifications=len(verifications))
-        synth = await run.make_agent(self.synthesis_role, name="verdict", emits=(ReviewVerdict,))
+        synth = await run.make_agent(
+            self.synthesis_role,
+            name="verdict",
+            model=self.model_for("verdict"),
+            emits=(ReviewVerdict,),
+            exempt=True,
+        )
         res = await synth.operate(
             instruction=_verdict_instruction(artifact, dimensions, issues, verifications)
         )

--- a/lionagi/operations/_observe.py
+++ b/lionagi/operations/_observe.py
@@ -50,7 +50,7 @@ class StopStream(Exception):  # noqa: N818
         self.reason = reason
 
 
-def attempt_extract(text: str, capabilities: Operable) -> tuple[list[Any], list[Any]]:
+def attempt_extract(text: str, capabilities: Operable) -> tuple[list[Any], list[Any], list[Any]]:
     """Parse capability emissions out of an assistant message.
 
     A capability is a named typed field (a ``Spec``); ``capabilities`` is the
@@ -64,25 +64,29 @@ def attempt_extract(text: str, capabilities: Operable) -> tuple[list[Any], list[
     - keys ⊆ grant → validated via ``create_model`` into a bundle (a dynamic
       model with one field per present capability);
     - any key outside the grant → an *illegal* emission (the agent reaching
-      past its capabilities): not honored, recorded as a ``CapabilityViolation``.
+      past its capabilities): not honored, recorded as a ``CapabilityViolation``;
+    - keys ⊆ grant but schema validation fails → recorded as an
+      ``EmissionRejected`` so repair loops can re-prompt instead of the work
+      silently vanishing.
 
-    Returns ``(bundles, violations)`` — both lists, since one response may
-    carry several blocks.
+    Returns ``(bundles, violations, rejects)`` — all lists, since one response
+    may carry several blocks.
     """
     if not text or not isinstance(text, str):
-        return [], []
+        return [], [], []
     from lionagi.ln.fuzzy._extract_json import extract_json
-    from lionagi.session.capabilities import CapabilityViolation
+    from lionagi.session.capabilities import CapabilityViolation, EmissionRejected
 
     try:
         data = extract_json(text, fuzzy_parse=True, return_one_if_single=False)
     except Exception:
-        return [], []
+        return [], [], []
     blocks = data if isinstance(data, list) else [data]
 
     allowed = capabilities.allowed()
     bundles: list[Any] = []
     violations: list[Any] = []
+    rejects: list[Any] = []
     for block in blocks:
         if not isinstance(block, dict) or not block:
             continue
@@ -108,8 +112,9 @@ def attempt_extract(text: str, capabilities: Operable) -> tuple[list[Any], list[
             bundles.append(model.model_validate(block))
         except Exception as e:
             logger.debug("Capability block failed validation, skipped: %s", e)
+            rejects.append(EmissionRejected(error=str(e), block=block))
             continue
-    return bundles, violations
+    return bundles, violations, rejects
 
 
 async def emit_message(branch: Branch, msg: RoledMessage) -> None:
@@ -144,7 +149,7 @@ async def emit_message(branch: Branch, msg: RoledMessage) -> None:
     if isinstance(msg, AssistantResponse):
         capabilities = getattr(branch, "_capabilities", None)
         if capabilities is not None:
-            bundles, violations = attempt_extract(msg.response, capabilities)
+            bundles, violations, rejects = attempt_extract(msg.response, capabilities)
             role_name: str | None = getattr(capabilities, "name", None)
             if bundles:
                 # Emit all bundles concurrently — a slow handler on one bundle
@@ -161,6 +166,11 @@ async def emit_message(branch: Branch, msg: RoledMessage) -> None:
             # silent drops — session.observe(CapabilityViolation) can react.
             for violation in violations:
                 await branch.emit(Signal(data=violation))
+            # In-grant blocks that failed schema validation become observable
+            # repair events — session.observe(EmissionRejected) can re-prompt.
+            for reject in rejects:
+                reject.branch_name = getattr(branch, "name", "") or ""
+                await branch.emit(Signal(data=reject))
 
 
 def check_control(branch: Branch) -> None:

--- a/lionagi/orchestration/patterns.py
+++ b/lionagi/orchestration/patterns.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any
 from lionagi import FieldModel
 from lionagi.agent import AgentSpec, create_agent
 from lionagi.casts.emission import (
-    _SPAWN_ALLOWED_OPERATIONS,
+    SPAWN_ALLOWED_OPERATIONS,
     SpawnRequest,
     TaskAssignment,
     build_emission_operable,
@@ -83,12 +83,12 @@ def role_node_builder(roles: dict[str, Branch]):
         # via model-emitted spawn requests. Fail closed on anything outside the
         # documented allowlist.
         op = req.operation or "operate"
-        if op not in _SPAWN_ALLOWED_OPERATIONS:
+        if op not in SPAWN_ALLOWED_OPERATIONS:
             logger.warning(
                 "SpawnRequest.operation %r is outside the allowed set %r — "
                 "falling back to 'operate'. (Possible prompt injection.)",
                 op,
-                sorted(_SPAWN_ALLOWED_OPERATIONS),
+                sorted(SPAWN_ALLOWED_OPERATIONS),
             )
             op = "operate"
         node = create_operation(

--- a/lionagi/outcomes/__init__.py
+++ b/lionagi/outcomes/__init__.py
@@ -1,13 +1,15 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
-"""ADR-0021: structured outputs that skills produce and Studio renders.
+"""Artifact outcome contracts persisted for Studio (ops plane) — distinct from lionagi.casts.emission (reactive bus).
+
+ADR-0021: structured outputs that skills produce and Studio renders.
 
 The shared contract between CLI skill runners (producers) and Studio
 (consumer). Outcomes are persisted as ``artifacts`` table rows with
 ``kind = outcome_kind`` so the frontend's kind-dispatched renderer can
 pick the right card component.
 
-This package holds *domain* types (review verdicts, CI results, gate
+This package holds *domain* types (review outcomes, CI results, gate
 outcomes). Infrastructure types live in :mod:`lionagi.models`; the
 separation is deliberate so a future Studio-only consumer can import
 outcomes without pulling in framework machinery.
@@ -17,12 +19,12 @@ from __future__ import annotations
 
 from ._base import SkillOutcome
 from .ci import CIResult
-from .verdict import Finding, GateVerdict, ReviewVerdict
+from .verdict import GateVerdict, ReviewFinding, ReviewOutcome
 
 __all__ = (
-    "SkillOutcome",
-    "ReviewVerdict",
-    "GateVerdict",
-    "Finding",
     "CIResult",
+    "GateVerdict",
+    "ReviewFinding",
+    "ReviewOutcome",
+    "SkillOutcome",
 )

--- a/lionagi/outcomes/verdict.py
+++ b/lionagi/outcomes/verdict.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """ADR-0021 §A: review + gate verdicts.
 
-Produced by codex-pr-review (ReviewVerdict), play-gate (GateVerdict),
+Produced by codex-pr-review (ReviewOutcome), play-gate (GateVerdict),
 or any skill that issues a binary or graded judgment.
 """
 
@@ -20,8 +20,12 @@ from ._base import SkillOutcome
 Severity = Literal["critical", "high", "medium", "low", "info"]
 
 
-class Finding(HashableModel):
-    """One reviewer finding with optional file/line + suggestion."""
+class ReviewFinding(HashableModel):
+    """One reviewer finding with optional file/line + suggestion.
+
+    Distinct from ``lionagi.casts.emission.Finding`` (reactive-bus base).
+    This is the ops-plane artifact contract (ADR-0021).
+    """
 
     severity: Severity = Field(
         description="Operator severity bucket (drives sort + render color).",
@@ -56,7 +60,7 @@ class Finding(HashableModel):
     def _validate_file(cls, v: object) -> object:
         if v is None or not isinstance(v, str):
             return v
-        check_path_safe(v, "Finding.file", reject_absolute=True)
+        check_path_safe(v, "ReviewFinding.file", reject_absolute=True)
         return v
 
 
@@ -68,12 +72,15 @@ VerdictDecision = Literal[
 ]
 
 
-class ReviewVerdict(SkillOutcome):
-    """Reviewer judgment + findings list.
+class ReviewOutcome(SkillOutcome):
+    """Reviewer judgment + findings list (ops-plane artifact, ADR-0021 §A).
 
     The frontend renders this as the ``ReviewVerdictCard`` (ADR-0021 §E)
     — severity/category breakdown on top, blocking findings expanded,
     minor suggestions collapsed.
+
+    Distinct from ``lionagi.engines.review.ReviewVerdict`` (reactive-bus
+    emission from the engines layer).
     """
 
     outcome_kind: Literal["review_verdict"] = "review_verdict"
@@ -88,7 +95,7 @@ class ReviewVerdict(SkillOutcome):
             return v.replace("-", "_").replace(" ", "_")
         return v
 
-    findings: list[Finding] = Field(
+    findings: list[ReviewFinding] = Field(
         default_factory=list,
         description="Findings list — blocking-first ordering is the writer's responsibility.",
     )
@@ -97,7 +104,7 @@ class ReviewVerdict(SkillOutcome):
         ge=1,
         description=(
             "1-indexed iteration number for multi-round reviews. The "
-            "codex-pr-review skill writes one ReviewVerdict per round."
+            "codex-pr-review skill writes one ReviewOutcome per round."
         ),
     )
 

--- a/lionagi/service/providers.py
+++ b/lionagi/service/providers.py
@@ -1,0 +1,242 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Provider/model-spec tables and parsing — shared across service and agent layers.
+
+Model spec format: ``provider/model-effort``
+
+    claude/opus-4-7-high   → model="claude/opus-4-7", effort="high"
+    codex/gpt-5.4-xhigh   → model="codex/gpt-5.4", effort="xhigh"
+    claude/sonnet          → model="claude/sonnet", effort=None
+
+iModel handles provider/model splitting internally. We only strip effort.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+__all__ = (
+    "BACKENDS",
+    "CLI_PROVIDERS",
+    "EFFORT_LEVELS",
+    "ModelSpec",
+    "PROVIDER_BYPASS_KWARGS",
+    "PROVIDER_EFFORT_KWARG",
+    "PROVIDER_FAST_KWARGS",
+    "PROVIDER_TO_ALIAS",
+    "PROVIDER_YOLO_KWARGS",
+    "PROVIDERS_NO_EFFORT",
+    "parse_model_spec",
+)
+
+# ── Effort levels (stripped from spec, mapped to provider kwarg) ──────────
+
+EFFORT_LEVELS = frozenset(
+    {
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+    }
+)
+
+# Codex accepts none|minimal|low|medium|high|xhigh — NOT "max".
+# Profiles/orchestrators may emit "max"; clamp to "xhigh" for codex.
+_CODEX_EFFORT_CLAMP: dict[str, str] = {"max": "xhigh"}
+
+# Claude: only opus-4-7 accepts xhigh. All other models clamp to high.
+_CLAUDE_XHIGH_MODELS = frozenset({"opus", "opus-4-7", "claude-opus-4-7"})
+
+
+def _clamp_claude_effort(effort: str, model: str) -> str:
+    """Clamp xhigh to high for non-opus-4-7 Claude models."""
+    if effort != "xhigh":
+        return effort
+    model_part = model.split("/", 1)[-1] if "/" in model else model
+    if model_part in _CLAUDE_XHIGH_MODELS:
+        return effort
+    return "high"
+
+
+# CLI providers authenticate via a local subprocess (ChatGPT/Claude
+# subscription), so their api_key is an irrelevant placeholder. API providers
+# (openai, deepseek, anthropic, …) resolve a real key from settings — passing a
+# placeholder there OVERRIDES that resolution and breaks auth.
+CLI_PROVIDERS: frozenset[str] = frozenset({"claude_code", "claude-code", "claude", "codex"})
+
+
+# provider name → kwarg name for effort
+PROVIDER_EFFORT_KWARG: dict[str, str] = {
+    "claude-code": "effort",
+    "claude_code": "effort",
+    "claude": "effort",
+    "codex": "reasoning_effort",
+    "pi": "thinking",
+}
+
+# providers that do NOT support effort
+PROVIDERS_NO_EFFORT: frozenset[str] = frozenset(
+    {
+        "gemini_code",
+        "gemini-code",
+        "gemini_cli",
+        "gemini-cli",
+        "gemini",
+    }
+)
+
+# Module-level invariant: a provider cannot be in both sets simultaneously.
+# A future maintainer adding a provider to the wrong set gets an ImportError
+# at startup instead of silent effort-kwarg corruption at runtime.
+# Using raise RuntimeError (not assert) so the check survives `python -O`.
+_overlap = PROVIDERS_NO_EFFORT & set(PROVIDER_EFFORT_KWARG)
+if _overlap:
+    raise RuntimeError(
+        f"Provider classification conflict: {_overlap!r} appear in both "
+        "PROVIDERS_NO_EFFORT and PROVIDER_EFFORT_KWARG"
+    )
+del _overlap
+
+# ── Per-provider yolo kwargs ──────────────────────────────────────────────
+
+PROVIDER_YOLO_KWARGS: dict[str, dict] = {
+    "claude_code": {"permission_mode": "bypassPermissions"},
+    "claude": {"permission_mode": "bypassPermissions"},
+    "codex": {"full_auto": True, "skip_git_repo_check": True},
+    "gemini_code": {"yolo": True},
+    "gemini-code": {"yolo": True},
+    "pi": {"no_tools": False},
+}
+
+PROVIDER_BYPASS_KWARGS: dict[str, dict] = {
+    "claude_code": {"permission_mode": "bypassPermissions"},
+    "claude": {"permission_mode": "bypassPermissions"},
+    "codex": {"bypass_approvals": True, "skip_git_repo_check": True},
+    "gemini_code": {"yolo": True},
+    "gemini-code": {"yolo": True},
+    "pi": {"no_tools": False},
+}
+
+# fast_mode: route codex via OpenAI priority tier (lower latency, same effort)
+# No-op for providers that don't support service_tier.
+PROVIDER_FAST_KWARGS: dict[str, dict] = {
+    "codex": {"fast_mode": True},
+}
+
+PROVIDER_TO_ALIAS: dict[str, str] = {
+    "claude_code": "claude",
+    "codex": "codex",
+    "gemini_code": "gemini-code",
+    "pi": "pi",
+}
+
+# ── Aliases (bare name → provider/model) ──────────────────────────────────
+
+BACKENDS: dict[str, str] = {
+    "claude": "claude_code/sonnet",
+    "claude-code": "claude_code/sonnet",
+    "claude_code": "claude_code/sonnet",
+    "codex": "codex/gpt-5.3-codex-spark",
+    "gemini-code": "gemini_code/gemini-3.1-flash-lite-preview",
+    "gemini_code": "gemini_code/gemini-3.1-flash-lite-preview",
+    "gemini-cli": "gemini_code/gemini-3.1-flash-lite-preview",
+    "gemini_cli": "gemini_code/gemini-3.1-flash-lite-preview",
+    "pi": "pi/gemini-2.5-flash",
+    "pi-code": "pi/gemini-2.5-flash",
+    "pi_code": "pi/gemini-2.5-flash",
+}
+
+
+# ── Parsing ───────────────────────────────────────────────────────────────
+
+_EFFORT_SUFFIX_RE = re.compile(
+    r"^(.+?)-(" + "|".join(sorted(EFFORT_LEVELS, key=len, reverse=True)) + r")$"
+)
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    """Parsed model spec: raw model string (for iModel) + extracted effort."""
+
+    model: str  # "claude/opus-4-7" or "codex/gpt-5.4" — passed to iModel as-is
+    effort: str | None  # extracted effort or None
+
+    def __str__(self) -> str:
+        if self.effort:
+            return f"{self.model}-{self.effort}"
+        return self.model
+
+
+_CLAUDE_MODEL_PREFIXES = ("opus", "sonnet", "haiku")
+
+
+_CLAUDE_PROVIDER_NAMES = frozenset(
+    {
+        "claude",
+        "claude-code",
+        "claude_code",
+    }
+)
+
+
+def _normalize_model(spec_or_model: str, provider_hint: str | None = None) -> str:
+    """Normalize model name for the target provider.
+
+    Claude Code CLI accepts: 'sonnet', 'opus', 'haiku' (aliases)
+    or full names like 'claude-sonnet-4-6', 'claude-opus-4-7'.
+    'opus-4-7' is neither — normalize to 'claude-opus-4-7'.
+
+    Handles both 'provider/model' and bare 'model' inputs.
+    """
+    if "/" in spec_or_model:
+        prov, model = spec_or_model.split("/", 1)
+        normalized = _normalize_model_name(model, prov)
+        return f"{prov}/{normalized}"
+    return _normalize_model_name(spec_or_model, provider_hint)
+
+
+def _normalize_model_name(model: str, provider_hint: str | None = None) -> str:
+    """Normalize bare model name (no provider prefix)."""
+    if provider_hint and provider_hint in _CLAUDE_PROVIDER_NAMES:
+        for prefix in _CLAUDE_MODEL_PREFIXES:
+            if model.startswith(prefix) and model != prefix and not model.startswith("claude-"):
+                return f"claude-{model}"
+    return model
+
+
+def parse_model_spec(spec: str) -> ModelSpec:
+    """Parse effort suffix from spec. Everything else stays intact for iModel.
+
+    Examples::
+        "claude/opus-4-7-high"   → ModelSpec("claude/opus-4-7", "high")
+        "codex/gpt-5.4-xhigh"   → ModelSpec("codex/gpt-5.4", "xhigh")
+        "claude/sonnet"          → ModelSpec("claude/sonnet", None)
+        "claude"                 → ModelSpec("claude_code/sonnet", None)  # alias
+        "gemini-code/gemini-3.1-pro-high" → ERROR (gemini has no effort)
+    """
+    # Alias expansion
+    if spec in BACKENDS:
+        return ModelSpec(model=BACKENDS[spec], effort=None)
+
+    # Split provider for effort validation
+    provider_raw = spec.split("/")[0] if "/" in spec else spec
+
+    # Try to strip effort suffix from the full spec
+    m = _EFFORT_SUFFIX_RE.match(spec)
+    if m:
+        model_clean = m.group(1)
+        effort = m.group(2)
+
+        # Validate: provider supports effort?
+        if provider_raw in PROVIDERS_NO_EFFORT:
+            raise ValueError(
+                f"Provider '{provider_raw}' does not support effort levels. "
+                f"Remove '-{effort}' from '{spec}'."
+            )
+        return ModelSpec(model=_normalize_model(model_clean, provider_raw), effort=effort)
+
+    return ModelSpec(model=_normalize_model(spec, provider_raw), effort=None)

--- a/lionagi/session/capabilities.py
+++ b/lionagi/session/capabilities.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 __all__ = (
     "render_capabilities_prompt",
     "CapabilityViolation",
+    "EmissionRejected",
     "CAP_BEGIN",
     "CAP_END",
 )
@@ -35,6 +36,19 @@ class CapabilityViolation(BaseModel):
 
     offending: list[str] = Field(description="Emitted keys outside the grant.")
     allowed: list[str] = Field(description="The granted capability names.")
+    block: dict | None = Field(default=None, description="The raw rejected block.")
+
+
+class EmissionRejected(BaseModel):
+    """An in-grant capability block failed schema validation — not honored.
+
+    Surfaced onto the bus (not silently dropped) so a repair loop can re-prompt
+    the agent with the concrete validation error — the difference between a
+    weak model recovering and its work vanishing.
+    """
+
+    branch_name: str = Field(default="", description="The emitting branch, for attribution.")
+    error: str = Field(description="The validation error, verbatim.")
     block: dict | None = Field(default=None, description="The raw rejected block.")
 
 

--- a/lionagi/state/provenance.py
+++ b/lionagi/state/provenance.py
@@ -29,9 +29,10 @@ def agent_definition_hash(agent_name: str | None) -> str | None:
     """
     if not agent_name:
         return None
-    from lionagi.cli._agents import _find_lionagi_dirs, _resolve_profile_path
+    from lionagi._paths import find_lionagi_dirs
+    from lionagi.cli._agents import _resolve_profile_path
 
-    for d in _find_lionagi_dirs():
+    for d in find_lionagi_dirs():
         path = _resolve_profile_path(d / "agents", agent_name)
         if path is not None:
             return _hash_file(path)

--- a/lionagi/studio/routers/artifacts.py
+++ b/lionagi/studio/routers/artifacts.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """ADR-0021 artifacts API.
 
-Skill-produced structured outcomes (ReviewVerdict, GateVerdict,
+Skill-produced structured outcomes (ReviewOutcome, GateVerdict,
 CIResult, ...). Most consumers fetch via /api/invocations/{id} which
 returns the artifact list inline; these endpoints exist for the cases
 where the caller has only a session id, or wants the artifact alone.

--- a/lionagi/studio/routers/runs.py
+++ b/lionagi/studio/routers/runs.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-from functools import partial
 from typing import Any
 
-import anyio
 from fastapi import APIRouter, HTTPException, Query
 
 from ..services import runs as runs_svc
@@ -29,10 +27,8 @@ async def list_runs(
 
 @router.get("/{run_id}")
 async def get_run(run_id: str) -> dict[str, Any]:
-    # get_run performs synchronous filesystem I/O (directory iteration, JSON
-    # reads, stat calls); offload to a worker thread to avoid blocking the
-    # event loop.
-    run = await anyio.to_thread.run_sync(partial(runs_svc.get_run, run_id))
+    # get_run reads from StateDB (same source as list_runs); no thread offload needed.
+    run = await runs_svc.get_run(run_id)
     if run is None:
         raise HTTPException(status_code=404, detail=f"Run '{run_id}' not found")
     return run

--- a/lionagi/studio/services/agents.py
+++ b/lionagi/studio/services/agents.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import yaml
 
-from lionagi.cli._runs import LIONAGI_HOME
+from lionagi._paths import LIONAGI_HOME
 from lionagi.libs.frontmatter import parse_frontmatter as _parse_frontmatter
 
 from ._path_safety import public_path, safe_path_join

--- a/lionagi/studio/services/definitions.py
+++ b/lionagi/studio/services/definitions.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import anyio
 
-from lionagi.cli._runs import LIONAGI_HOME
+from lionagi._paths import LIONAGI_HOME
 from lionagi.state.db import DEFAULT_DB_PATH
 
 from ._db import open_db as _open_db

--- a/lionagi/studio/services/playbooks.py
+++ b/lionagi/studio/services/playbooks.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import yaml
 
-from lionagi.cli._runs import LIONAGI_HOME
+from lionagi._paths import LIONAGI_HOME
 
 from ._path_safety import public_path, safe_path_join
 

--- a/lionagi/studio/services/plugins.py
+++ b/lionagi/studio/services/plugins.py
@@ -21,7 +21,7 @@ MARKETPLACE_DIR = _REPO_ROOT / "marketplace"
 # Fallback: if the server is running from a pip-install, try LIONAGI_HOME.parent
 if not MARKETPLACE_DIR.exists():
     try:
-        from lionagi.cli._runs import LIONAGI_HOME  # type: ignore[import-untyped]
+        from lionagi._paths import LIONAGI_HOME
 
         _fallback = LIONAGI_HOME.parent / "marketplace"
         if _fallback.exists():

--- a/lionagi/studio/services/runs.py
+++ b/lionagi/studio/services/runs.py
@@ -5,11 +5,8 @@ import time
 from pathlib import Path
 from typing import Any
 
-from lionagi._paths import RUNS_ROOT
-
 from . import sessions as _sessions_svc
-from ._io import read_json_file as _read_json_file
-from ._path_safety import public_path, safe_path_join
+from ._path_safety import public_path
 
 _STATUS_ALIASES: dict[str, set[str]] = {
     "done": {"done", "completed", "success", "finished"},
@@ -561,41 +558,94 @@ def paginate_runs(
     }
 
 
-def get_run(run_id: str) -> dict[str, Any] | None:
-    if not RUNS_ROOT.exists():
+async def get_run(run_id: str) -> dict[str, Any] | None:
+    """Return run detail for *run_id* by reading from StateDB.
+
+    Uses the same data source as list_runs() (StateDB sessions/branches).
+    The flat-file run.json read path was removed because write_manifest()
+    had zero callers — all live runs persist to SQLite via create_session().
+    Keys in the returned dict are kept identical to the old flat-file path so
+    the frontend contract is unchanged.
+
+    Fields with no direct DB equivalent:
+      state_root            — derived from artifacts_path if stored, else None
+      artifact_root         — derived from artifacts_path column, else None
+      task                  — not persisted in DB; returns ""
+      step_count            — count of branches (proxy for steps)
+      error                 — not persisted in DB; returns None
+      cwd                   — not persisted in DB; returns None
+      manifest              — returns {} (no flat-file manifest exists)
+    """
+    session = await _sessions_svc.get_session(run_id)
+    if session is None:
         return None
 
-    safe_path_join(RUNS_ROOT, run_id)
+    artifacts_path = session.get("artifacts_path")
+    artifact_root: Path | None = Path(artifacts_path) if artifacts_path else None
 
-    state_root = RUNS_ROOT / run_id
-    if not state_root.is_dir():
-        matches = [d for d in RUNS_ROOT.iterdir() if d.is_dir() and d.name.startswith(run_id)]
-        if not matches:
-            return None
-        state_root = sorted(matches, key=lambda p: p.stat().st_mtime, reverse=True)[0]
-        run_id = state_root.name
+    branches: list[dict[str, Any]] = session.get("branches") or []
+    step_count = len(branches)
 
-    manifest_path = state_root / "run.json"
-    artifact_root = state_root / "artifacts"
-    manifest: dict[str, Any] = {}
-    if manifest_path.exists():
-        loaded = _read_json_file(manifest_path)
-        if loaded is not None:
-            manifest = loaded
-            art = manifest.get("artifact_root")
-            if art:
-                artifact_root = Path(art)
+    # Derive state_root from artifact_root (artifact_root is inside state_root)
+    state_root: Path | None = artifact_root.parent if artifact_root else None
 
-    branches: list[dict[str, Any]] = []
-    branches_dir = state_root / "branches"
-    if branches_dir.exists():
-        for bf in sorted(
-            branches_dir.glob("*.json"),
-            key=lambda p: p.stat().st_mtime,
-            reverse=True,
-        ):
-            loaded = _read_json_file(bf)
-            if loaded is not None:
-                branches.append(loaded)
+    summary: dict[str, Any] = {
+        "run_id": run_id,
+        "state_root": public_path(state_root) if state_root else None,
+        "artifact_root": public_path(artifact_root) if artifact_root else None,
+        "worker_name": session.get("agent_name") or session.get("playbook_name") or "",
+        "task": "",
+        "status": session.get("status") or "completed",
+        "step_count": step_count,
+        "started_at": session.get("started_at"),
+        "finished_at": session.get("ended_at"),
+        "model": session.get("model") or "",
+    }
 
-    return _adapt_detail(run_id, state_root, artifact_root, manifest, branches)
+    return {
+        **summary,
+        "error": None,
+        "cwd": None,
+        "steps": _build_steps_from_db(branches),
+        "graph": session.get("graph"),
+        "manifest": {},
+        "branches": branches,
+        "artifact_contract_json": session.get("artifact_contract_json"),
+        "artifact_verification_json": session.get("artifact_verification_json"),
+    }
+
+
+def _build_steps_from_db(branches: list[dict[str, Any]]) -> list[dict[str, Any]] | None:
+    """Build a steps list from DB-hydrated branch dicts.
+
+    Each branch dict from get_session() has: id, name, messages (list),
+    model, provider, agent_name, status, started_at, ended_at.
+    """
+    if not branches:
+        return None
+    steps = []
+    for b in branches:
+        if not isinstance(b, dict):
+            continue
+        name = b.get("name") or b.get("agent_name") or "agent"
+        messages = b.get("messages") or []
+        role_counts: dict[str, int] = {}
+        for m in messages:
+            r = m.get("role", "")
+            if r:
+                role_counts[r] = role_counts.get(r, 0) + 1
+        steps.append(
+            {
+                "step": name,
+                "status": "completed" if messages else "pending",
+                "result": {
+                    "agent": name,
+                    "model": b.get("model") or "",
+                    "message_count": len(messages),
+                    "roles": role_counts,
+                },
+                "messages": messages,
+                "timestamp": b.get("started_at"),
+            }
+        )
+    return steps if steps else None

--- a/lionagi/studio/services/runs.py
+++ b/lionagi/studio/services/runs.py
@@ -5,7 +5,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-from lionagi.cli._runs import RUNS_ROOT
+from lionagi._paths import RUNS_ROOT
 
 from . import sessions as _sessions_svc
 from ._io import read_json_file as _read_json_file

--- a/lionagi/studio/services/skills.py
+++ b/lionagi/studio/services/skills.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from lionagi.cli._runs import LIONAGI_HOME
+from lionagi._paths import LIONAGI_HOME
 from lionagi.libs.frontmatter import parse_frontmatter as _parse_frontmatter
 
 from ._path_safety import public_path, safe_path_join

--- a/tests/agent/test_config.py
+++ b/tests/agent/test_config.py
@@ -168,3 +168,38 @@ def test_from_yaml_extra_keys_collected(tmp_path):
 
     loaded = AgentConfig.from_yaml(yaml_path)
     assert loaded.extra.get("custom_key") == "hello"
+
+
+def test_from_yaml_emits_deprecation_warning(tmp_path):
+    """AgentConfig.from_yaml() must emit a DeprecationWarning."""
+    import warnings
+
+    import yaml
+
+    yaml_path = tmp_path / "dep.yaml"
+    with open(yaml_path, "w") as f:
+        yaml.dump({"name": "x"}, f)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        AgentConfig.from_yaml(yaml_path)
+
+    depr = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert depr, "Expected a DeprecationWarning from AgentConfig.from_yaml()"
+    assert "AgentSpec.from_yaml" in str(depr[0].message)
+
+
+def test_to_yaml_emits_deprecation_warning(tmp_path):
+    """AgentConfig.to_yaml() must emit a DeprecationWarning."""
+    import warnings
+
+    yaml_path = tmp_path / "dep.yaml"
+    config = AgentConfig(name="x")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        config.to_yaml(yaml_path)
+
+    depr = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert depr, "Expected a DeprecationWarning from AgentConfig.to_yaml()"
+    assert "AgentSpec.to_yaml" in str(depr[0].message)

--- a/tests/agent/test_spec.py
+++ b/tests/agent/test_spec.py
@@ -158,6 +158,42 @@ class TestAgentSpecEmission:
         spec = AgentSpec.compose("critic", grant_emissions=False)
         assert spec.emission_operable() is None
 
+    def test_emits_none_uses_role_contract(self):
+        # None (default) ⇒ identical to the role's declared emission contract.
+        spec = AgentSpec.compose("analyst")
+        assert spec.emits is None
+        assert spec.emission_operable() == spec.profile.role.emission_operable()
+
+    def test_emits_explicit_tuple_overrides_role(self):
+        from lionagi.casts import Finding, Gap
+
+        spec = AgentSpec.compose("analyst", emits=(Finding, Gap))
+        op = spec.emission_operable()
+        assert op is not None
+        # The override governs the field set, not the role's (AnalysisResult,
+        # Finding) contract; EscalationRequest is always appended.
+        assert op.allowed() == {"finding", "gap", "escalation_request"}
+        assert op.allowed() != spec.profile.role.emission_operable().allowed()
+
+    def test_emits_empty_tuple_grants_nothing(self):
+        # Deliberate: () ⇒ grant nothing (build_emission_operable(()) is None),
+        # distinct from None which falls back to the role contract.
+        spec = AgentSpec.compose("analyst", emits=())
+        assert spec.emits == ()
+        assert spec.emission_operable() is None
+
+    def test_emits_false_grant_short_circuits_override(self):
+        from lionagi.casts import Finding
+
+        spec = AgentSpec.compose("analyst", emits=(Finding,), grant_emissions=False)
+        assert spec.emission_operable() is None
+
+    def test_compose_threads_emits_onto_spec(self):
+        from lionagi.casts import Finding
+
+        spec = AgentSpec.compose("analyst", emits=(Finding,))
+        assert spec.emits == (Finding,)
+
 
 # ---------------------------------------------------------------------------
 # AgentSpec.from_legacy (AgentConfig bridge)

--- a/tests/apps_studio_server/test_async_fs_io.py
+++ b/tests/apps_studio_server/test_async_fs_io.py
@@ -8,7 +8,9 @@ filesystem reads on the main async thread.
 
 from __future__ import annotations
 
+import asyncio
 import json
+import uuid
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -59,7 +61,6 @@ def _make_client(
     monkeypatch.setattr(agents_mod, "_AGENTS_ROOT", agents_root)
     monkeypatch.setattr(playbooks_mod, "_PLAYBOOKS_ROOT", playbooks_root)
     monkeypatch.setattr(skills_mod, "SKILLS_ROOT", skills_root)
-    monkeypatch.setattr(runs_mod, "RUNS_ROOT", runs_root)
     monkeypatch.setattr(cli_runs_mod, "RUNS_ROOT", runs_root)
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
     monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", fake_db)
@@ -121,18 +122,49 @@ def _make_client(
 # ---------------------------------------------------------------------------
 
 
-def test_run_detail_uses_thread_offload(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """GET /api/runs/{id} must complete without blocking the event loop.
+def test_run_detail_reads_from_statedb(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """GET /api/runs/{id} reads from StateDB (not flat-file run.json).
 
-    The route handler wraps the synchronous get_run() in
-    anyio.to_thread.run_sync. We verify the route works correctly and
-    that anyio.to_thread.run_sync is actually called.
+    get_run() is now async and reads the same SQLite source as list_runs().
     """
-    client = _make_client(tmp_path, monkeypatch, with_run=True)
-    r = client.get("/api/runs/20240101T000000-abc123")
+    from lionagi.state.db import StateDB
+
+    run_id = str(uuid.uuid4())
+    db_path = tmp_path / "state.db"
+
+    async def _seed():
+        async with StateDB(db_path) as db:
+            prog_id = f"{run_id}-prog"
+            await db.create_progression(prog_id)
+            await db.create_session(
+                {
+                    "id": run_id,
+                    "progression_id": prog_id,
+                    "name": "async-run",
+                    "status": "completed",
+                    "agent_name": "my-worker",
+                    "model": "gpt-5",
+                    "invocation_kind": "agent",
+                    "source_kind": "live",
+                }
+            )
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(_seed())
+    finally:
+        loop.close()
+
+    import lionagi.studio.services.sessions as sessions_mod
+
+    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
+
+    client = _make_client(tmp_path, monkeypatch)
+    r = client.get(f"/api/runs/{run_id}")
     assert r.status_code == 200
     data = r.json()
-    assert data["run_id"] == "20240101T000000-abc123"
+    assert data["run_id"] == run_id
     assert data["worker_name"] == "my-worker"
 
 
@@ -243,23 +275,16 @@ def test_skill_detail_uses_thread_offload(tmp_path: Path, monkeypatch: pytest.Mo
 # ---------------------------------------------------------------------------
 
 
-def test_run_detail_calls_anyio_to_thread(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Verify that the runs detail route actually invokes anyio.to_thread.run_sync."""
-    import anyio.to_thread
+def test_run_detail_returns_404_for_nonexistent_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GET /api/runs/{id} returns 404 for an ID absent from StateDB.
 
-    original_run_sync = anyio.to_thread.run_sync
-    call_count = 0
-
-    async def tracking_run_sync(*args: Any, **kwargs: Any) -> Any:
-        nonlocal call_count
-        call_count += 1
-        return await original_run_sync(*args, **kwargs)
-
-    client = _make_client(tmp_path, monkeypatch, with_run=True)
-    with patch.object(anyio.to_thread, "run_sync", side_effect=tracking_run_sync):
-        r = client.get("/api/runs/20240101T000000-abc123")
-    assert r.status_code == 200
-    assert call_count >= 1, "anyio.to_thread.run_sync was not called for runs detail"
+    get_run() is now async and reads StateDB directly (no thread offload needed).
+    """
+    client = _make_client(tmp_path, monkeypatch)
+    r = client.get("/api/runs/20240101T000000-abc123")
+    assert r.status_code == 404
 
 
 def test_agents_list_calls_anyio_to_thread(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/apps_studio_server/test_runs_detail.py
+++ b/tests/apps_studio_server/test_runs_detail.py
@@ -1,0 +1,335 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for DEBT-04 fix: get_run() reads from StateDB, not dead flat-file path.
+
+Coverage targets:
+  - lionagi.studio.services.runs.get_run  (DB-backed, async)
+  - 404 path for missing run id
+  - Correct key contract: run_id, status, worker_name, started_at,
+    finished_at, model, graph, branches, steps, artifact_contract_json,
+    artifact_verification_json, error, cwd, manifest, state_root, artifact_root
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+aiosqlite = pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
+
+from lionagi.state.db import StateDB  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Shared seed helpers (mirror test_sessions_detail.py idioms)
+# ---------------------------------------------------------------------------
+
+
+async def seed_session(
+    db_path: Path,
+    *,
+    session_id: str,
+    status: str = "completed",
+    agent_name: str | None = None,
+    model: str | None = None,
+    started_at: float | None = None,
+    ended_at: float | None = None,
+    artifacts_path: str | None = None,
+    artifact_contract_json: dict | None = None,
+    artifact_verification_json: dict | None = None,
+    node_metadata: dict | None = None,
+    invocation_kind: str = "agent",
+) -> None:
+    prog_id = f"{session_id}-prog"
+    async with StateDB(db_path) as db:
+        await db.create_progression(prog_id)
+        await db.create_session(
+            {
+                "id": session_id,
+                "progression_id": prog_id,
+                "name": f"run-{session_id}",
+                "status": status,
+                "agent_name": agent_name,
+                "model": model,
+                "started_at": started_at,
+                "ended_at": ended_at,
+                "artifacts_path": artifacts_path,
+                "artifact_contract_json": artifact_contract_json,
+                "artifact_verification_json": artifact_verification_json,
+                "node_metadata": node_metadata,
+                "invocation_kind": invocation_kind,
+                "source_kind": "live",
+            }
+        )
+
+
+async def seed_branch(
+    db_path: Path,
+    *,
+    branch_id: str,
+    session_id: str,
+    name: str = "worker",
+    model: str = "gpt-5",
+    msg_ids: list[str] | None = None,
+) -> None:
+    prog_id = f"{branch_id}-prog"
+    async with StateDB(db_path) as db:
+        if msg_ids:
+            await db.create_progression(prog_id, msg_ids)
+        else:
+            await db.create_progression(prog_id)
+        await db.create_branch(
+            {
+                "id": branch_id,
+                "created_at": 200.0,
+                "name": name,
+                "session_id": session_id,
+                "progression_id": prog_id,
+                "model": model,
+                "provider": "openai",
+                "agent_name": name,
+            }
+        )
+
+
+@pytest.fixture
+def patched_runs_svc(tmp_path: Path, monkeypatch: Any):
+    """Patch sessions service to point at a tmp DB; return (svc, db_path)."""
+    import lionagi.studio.services.sessions as sessions_mod
+
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
+    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
+
+    import lionagi.studio.services.runs as runs_svc
+
+    return runs_svc, db_path
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — get_run returns None for a missing run id
+# ---------------------------------------------------------------------------
+
+
+async def test_get_run_returns_none_for_missing_id(patched_runs_svc):
+    svc, db_path = patched_runs_svc
+    # Create DB file with no matching session
+    async with StateDB(db_path) as db:
+        await db.create_progression("init")
+
+    result = await svc.get_run("nonexistent-id")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — get_run returns None when DB file does not exist
+# ---------------------------------------------------------------------------
+
+
+async def test_get_run_returns_none_when_db_absent(patched_runs_svc):
+    svc, db_path = patched_runs_svc
+    # Do NOT create the DB file
+
+    result = await svc.get_run("any-id")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — get_run returns all required keys for a DB-seeded run
+# ---------------------------------------------------------------------------
+
+
+_REQUIRED_KEYS = {
+    "run_id",
+    "state_root",
+    "artifact_root",
+    "worker_name",
+    "task",
+    "status",
+    "step_count",
+    "started_at",
+    "finished_at",
+    "model",
+    "error",
+    "cwd",
+    "steps",
+    "graph",
+    "manifest",
+    "branches",
+    "artifact_contract_json",
+    "artifact_verification_json",
+}
+
+
+async def test_get_run_returns_all_required_keys(patched_runs_svc):
+    svc, db_path = patched_runs_svc
+    sid = str(uuid.uuid4())
+    await seed_session(db_path, session_id=sid, status="completed")
+
+    result = await svc.get_run(sid)
+
+    assert result is not None
+    missing = _REQUIRED_KEYS - result.keys()
+    assert not missing, f"Missing keys in get_run response: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — get_run maps session fields to correct response keys
+# ---------------------------------------------------------------------------
+
+
+async def test_get_run_maps_session_fields_correctly(patched_runs_svc):
+    svc, db_path = patched_runs_svc
+    sid = str(uuid.uuid4())
+    await seed_session(
+        db_path,
+        session_id=sid,
+        status="failed",
+        agent_name="researcher",
+        model="openai/gpt-5",
+        started_at=1000.0,
+        ended_at=2000.0,
+    )
+
+    result = await svc.get_run(sid)
+
+    assert result is not None
+    assert result["run_id"] == sid
+    assert result["status"] == "failed"
+    assert result["worker_name"] == "researcher"
+    assert result["model"] == "openai/gpt-5"
+    assert result["started_at"] == 1000.0
+    assert result["finished_at"] == 2000.0
+    # DB-path fields with no direct equivalent
+    assert result["error"] is None
+    assert result["cwd"] is None
+    assert result["manifest"] == {}
+    assert result["task"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — step_count matches branch count; steps list is populated
+# ---------------------------------------------------------------------------
+
+
+async def test_get_run_step_count_and_steps_from_branches(patched_runs_svc):
+    svc, db_path = patched_runs_svc
+    sid = str(uuid.uuid4())
+    await seed_session(db_path, session_id=sid)
+    await seed_branch(db_path, branch_id=f"{sid}-br1", session_id=sid, name="alpha")
+    await seed_branch(db_path, branch_id=f"{sid}-br2", session_id=sid, name="beta")
+
+    result = await svc.get_run(sid)
+
+    assert result is not None
+    assert result["step_count"] == 2
+    assert isinstance(result["steps"], list)
+    assert len(result["steps"]) == 2
+    step_names = {s["step"] for s in result["steps"]}
+    assert step_names == {"alpha", "beta"}
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — artifact_contract_json and artifact_verification_json are passed through
+# ---------------------------------------------------------------------------
+
+
+async def test_get_run_passes_artifact_json_fields(patched_runs_svc):
+    svc, db_path = patched_runs_svc
+    sid = str(uuid.uuid4())
+    contract = {"files": ["report.md"], "required": True}
+    verification = {"passed": True, "score": 1.0}
+    await seed_session(
+        db_path,
+        session_id=sid,
+        artifact_contract_json=contract,
+        artifact_verification_json=verification,
+    )
+
+    result = await svc.get_run(sid)
+
+    assert result is not None
+    assert result["artifact_contract_json"] == contract
+    assert result["artifact_verification_json"] == verification
+
+
+# ---------------------------------------------------------------------------
+# Test 7 — graph is populated from node_metadata when present
+# ---------------------------------------------------------------------------
+
+
+async def test_get_run_graph_from_node_metadata(patched_runs_svc):
+    svc, db_path = patched_runs_svc
+    sid = str(uuid.uuid4())
+    meta = {
+        "agents": [{"id": "a1", "name": "Analyst", "model": "gpt-5"}],
+        "operations": [{"id": "collect", "agent_id": "a1", "depends_on": []}],
+    }
+    await seed_session(db_path, session_id=sid, node_metadata=meta)
+
+    result = await svc.get_run(sid)
+
+    assert result is not None
+    graph = result["graph"]
+    assert graph is not None
+    assert len(graph["nodes"]) == 1
+    assert graph["nodes"][0]["id"] == "collect"
+
+
+# ---------------------------------------------------------------------------
+# Test 8 — graph is None when no node_metadata present
+# ---------------------------------------------------------------------------
+
+
+async def test_get_run_graph_is_none_without_node_metadata(patched_runs_svc):
+    svc, db_path = patched_runs_svc
+    sid = str(uuid.uuid4())
+    await seed_session(db_path, session_id=sid, node_metadata=None)
+
+    result = await svc.get_run(sid)
+
+    assert result is not None
+    assert result["graph"] is None
+
+
+# ---------------------------------------------------------------------------
+# Test 9 — steps is None when no branches exist
+# ---------------------------------------------------------------------------
+
+
+async def test_get_run_steps_is_none_with_no_branches(patched_runs_svc):
+    svc, db_path = patched_runs_svc
+    sid = str(uuid.uuid4())
+    await seed_session(db_path, session_id=sid)
+
+    result = await svc.get_run(sid)
+
+    assert result is not None
+    assert result["steps"] is None
+    assert result["step_count"] == 0
+    assert result["branches"] == []
+
+
+# ---------------------------------------------------------------------------
+# Test 10 — HTTP endpoint returns 404 for missing run
+# ---------------------------------------------------------------------------
+
+
+def test_get_run_endpoint_returns_404_for_missing(tmp_path, monkeypatch):
+    fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
+
+    import lionagi.studio.services.sessions as sessions_mod
+
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
+    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
+
+    from fastapi.testclient import TestClient
+
+    from lionagi.studio.app import app
+
+    client = TestClient(app)
+    r = client.get(f"/api/runs/{uuid.uuid4()}")
+    assert r.status_code == 404

--- a/tests/apps_studio_server/test_smoke.py
+++ b/tests/apps_studio_server/test_smoke.py
@@ -6,7 +6,9 @@ plus path-traversal guard tests for /api/runs and /api/agents.
 
 from __future__ import annotations
 
+import asyncio
 import json
+import uuid
 from pathlib import Path
 
 import pytest
@@ -53,7 +55,6 @@ def _make_client(
     monkeypatch.setattr(shows_mod, "SHOWS_ROOT", shows_root)
     monkeypatch.setattr(agents_mod, "_AGENTS_ROOT", agents_root)
     monkeypatch.setattr(playbooks_mod, "_PLAYBOOKS_ROOT", playbooks_root)
-    monkeypatch.setattr(runs_mod, "RUNS_ROOT", runs_root)
     monkeypatch.setattr(cli_runs_mod, "RUNS_ROOT", runs_root)
     # Redirect state DB so runs/sessions/shows queries don't touch the real DB
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
@@ -223,9 +224,42 @@ def test_runs_list_filter_by_status(tmp_path, monkeypatch):
 
 
 def test_run_detail_contract_fields(tmp_path, monkeypatch):
-    """RunDetail must include graph, error, cwd, manifest, branches."""
-    client = _make_client(tmp_path, monkeypatch, with_run=True)
-    r = client.get("/api/runs/20240101T000000-abc123")
+    """RunDetail must include all required fields; reads from StateDB not flat-file."""
+    from lionagi.state.db import StateDB
+
+    run_id = str(uuid.uuid4())
+    db_path = tmp_path / "state.db"
+
+    async def _seed():
+        async with StateDB(db_path) as db:
+            prog_id = f"{run_id}-prog"
+            await db.create_progression(prog_id)
+            await db.create_session(
+                {
+                    "id": run_id,
+                    "progression_id": prog_id,
+                    "name": "smoke-run",
+                    "status": "completed",
+                    "agent_name": "my-worker",
+                    "model": "gpt-5",
+                    "invocation_kind": "agent",
+                    "source_kind": "live",
+                }
+            )
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(_seed())
+    finally:
+        loop.close()
+
+    import lionagi.studio.services.sessions as sessions_mod
+
+    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
+
+    client = _make_client(tmp_path, monkeypatch)
+    r = client.get(f"/api/runs/{run_id}")
     assert r.status_code == 200
     data = r.json()
     for field in (
@@ -242,9 +276,11 @@ def test_run_detail_contract_fields(tmp_path, monkeypatch):
         "branches",
     ):
         assert field in data, f"missing field: {field}"
-    assert data["graph"] == {"nodes": [], "edges": []}
+    # graph is None when no node_metadata stored (DB-backed path)
+    assert data["graph"] is None
     assert isinstance(data["branches"], list)
     assert isinstance(data["manifest"], dict)
+    assert data["worker_name"] == "my-worker"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/casts/test_emission_security.py
+++ b/tests/casts/test_emission_security.py
@@ -20,7 +20,7 @@ import pytest
 from pydantic import ValidationError
 
 from lionagi.casts.emission import (
-    _SPAWN_ALLOWED_OPERATIONS,
+    SPAWN_ALLOWED_OPERATIONS,
     Finding,
     SpawnRequest,
 )
@@ -35,7 +35,7 @@ class TestSpawnRequestOperationAllowlist:
     role_node_builder or create_operation.
     """
 
-    @pytest.mark.parametrize("op", sorted(_SPAWN_ALLOWED_OPERATIONS))
+    @pytest.mark.parametrize("op", sorted(SPAWN_ALLOWED_OPERATIONS))
     def test_allowed_operations_accepted(self, op: str):
         """All documented operations must be accepted."""
         req = SpawnRequest(instruction="do something", operation=op)

--- a/tests/casts/test_profile.py
+++ b/tests/casts/test_profile.py
@@ -110,6 +110,36 @@ class TestProfileFromYaml:
         assert p.modes == ()
 
 
+class TestProfileToYaml:
+    def test_round_trip_equals_original(self, tmp_path):
+        original = Profile.compose(
+            "researcher", modes=["evidential", "systematic"], name="my-researcher"
+        )
+        yaml_file = tmp_path / "profile.yaml"
+        original.to_yaml(yaml_file)
+        reloaded = Profile.from_yaml(yaml_file)
+        assert reloaded == original
+
+    def test_writes_canonical_schema(self, tmp_path):
+        p = Profile.compose("critic", modes=["adversarial"], name="adv-critic")
+        yaml_file = tmp_path / "profile.yaml"
+        p.to_yaml(yaml_file)
+        data = yaml.safe_load(yaml_file.read_text())
+        assert data == {
+            "name": "adv-critic",
+            "role": "critic",
+            "modes": ["adversarial"],
+        }
+
+    def test_round_trip_no_modes(self, tmp_path):
+        original = Profile.compose("analyst")
+        yaml_file = tmp_path / "bare.yaml"
+        original.to_yaml(yaml_file)
+        reloaded = Profile.from_yaml(yaml_file)
+        assert reloaded == original
+        assert reloaded.modes == ()
+
+
 class TestListRolesAndModes:
     def test_list_roles_includes_known(self):
         roles = list_roles()

--- a/tests/casts/test_public_import.py
+++ b/tests/casts/test_public_import.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for the lionagi.casts public import surface."""
+
+from __future__ import annotations
+
+import importlib
+
+_EXPECTED = (
+    "Pattern",
+    "PatternKind",
+    "Role",
+    "Mode",
+    "list_roles",
+    "list_modes",
+    "Profile",
+    "Pack",
+    "RolePolicy",
+    "RoleConfig",
+    "build_emission_operable",
+    "field_name_for",
+    "SPAWN_ALLOWED_OPERATIONS",
+    "Finding",
+    "Conflict",
+    "Gap",
+    "Diagnosis",
+    "Synthesis",
+    "Verdict",
+    "ComplianceVerdict",
+    "RiskAssessment",
+    "Objection",
+    "Recommendation",
+    "AnalysisResult",
+    "ComplexityScore",
+    "ExecutionPlan",
+    "TaskAssignment",
+    "DesignSpec",
+    "ArtifactProduced",
+    "VerificationResult",
+    "Document",
+    "OperationOutcome",
+    "Proposal",
+    "Postmortem",
+    "EscalationRequest",
+    "SpawnRequest",
+)
+
+
+def test_lionagi_casts_public_surface_imports():
+    """``import lionagi.casts`` exposes its documented public surface."""
+    mod = importlib.import_module("lionagi.casts")
+    for name in _EXPECTED:
+        assert hasattr(mod, name), f"{name!r} must be accessible from lionagi.casts"
+
+
+def test_lionagi_casts_all_matches_expected():
+    """``lionagi.casts.__all__`` contains exactly the declared public names."""
+    mod = importlib.import_module("lionagi.casts")
+    declared = set(mod.__all__)
+    expected = set(_EXPECTED)
+    missing = expected - declared
+    extra = declared - expected
+    assert not missing, f"Names missing from __all__: {sorted(missing)}"
+    assert not extra, f"Undocumented names in __all__: {sorted(extra)}"
+
+
+def test_field_name_for_standard_cases():
+    """field_name_for produces correct snake_case for standard PascalCase names."""
+    from pydantic import BaseModel
+
+    from lionagi.casts import field_name_for
+
+    def fn(name: str) -> str:
+        return field_name_for(type(name, (BaseModel,), {"__name__": name}))
+
+    assert fn("Finding") == "finding"
+    assert fn("RiskAssessment") == "risk_assessment"
+    assert fn("ComplianceVerdict") == "compliance_verdict"
+    assert fn("SpawnRequest") == "spawn_request"
+    assert fn("TaskAssignment") == "task_assignment"
+    assert fn("OperationOutcome") == "operation_outcome"
+
+
+def test_field_name_for_acronym_cases():
+    """field_name_for handles acronym-led names without mangling."""
+    from pydantic import BaseModel
+
+    from lionagi.casts import field_name_for
+
+    def fn(name: str) -> str:
+        return field_name_for(type(name, (BaseModel,), {"__name__": name}))
+
+    assert fn("CIResult") == "ci_result", f"got {fn('CIResult')!r}"
+    assert fn("HTMLParser") == "html_parser", f"got {fn('HTMLParser')!r}"
+    assert fn("URLConfig") == "url_config", f"got {fn('URLConfig')!r}"
+    assert fn("HTTPSRequest") == "https_request", f"got {fn('HTTPSRequest')!r}"

--- a/tests/cli/orchestrate/test_flowop_budget.py
+++ b/tests/cli/orchestrate/test_flowop_budget.py
@@ -18,7 +18,9 @@ from __future__ import annotations
 
 import re
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from lionagi.cli.orchestrate.flow import _format_budget_preamble
 
@@ -112,11 +114,14 @@ def test_orchestration_env_has_total_budget_field():
     assert "total_budget" in field_names
 
 
-def test_setup_orchestration_passes_total_budget():
+@pytest.mark.asyncio
+async def test_setup_orchestration_passes_total_budget():
     """setup_orchestration must forward total_budget to OrchestrationEnv."""
     from lionagi.cli.orchestrate._orchestration import setup_orchestration
 
-    # Patch the heavy internal calls so we don't need a live model.
+    # Patch the heavy internal calls so we don't need a live model. The
+    # no-profile orchestrator now builds its branch via create_agent (the
+    # canonical construction path), so that is what we stub.
     with (
         patch("lionagi.cli.orchestrate._orchestration.build_imodel_from_spec") as mock_imodel,
         patch("lionagi.cli.orchestrate._orchestration.allocate_run") as mock_run,
@@ -125,7 +130,10 @@ def test_setup_orchestration_passes_total_budget():
             side_effect=FileNotFoundError,
         ),
         patch("lionagi.cli.orchestrate._orchestration.resolve_persisted_effort", return_value=None),
-        patch("lionagi.cli.orchestrate._orchestration.Branch") as mock_branch,
+        patch(
+            "lionagi.cli.orchestrate._orchestration.create_agent",
+            new=AsyncMock(return_value=MagicMock(system=None)),
+        ),
         patch("lionagi.cli.orchestrate._orchestration.Session"),
         patch("lionagi.cli.orchestrate._orchestration.OperationGraphBuilder"),
     ):
@@ -135,9 +143,8 @@ def test_setup_orchestration_passes_total_budget():
         mock_ep.config.kwargs = {}
         mock_imodel.return_value.endpoint = mock_ep
         mock_run.return_value.ensure_artifact_root.return_value = None
-        mock_branch.return_value = MagicMock(system=None)
 
-        env = setup_orchestration(
+        env = await setup_orchestration(
             pattern_name="Flow",
             model_spec="openai/gpt-4.1-mini",
             agent_name=None,
@@ -153,7 +160,8 @@ def test_setup_orchestration_passes_total_budget():
     assert env.total_budget == 1800
 
 
-def test_setup_orchestration_total_budget_defaults_none():
+@pytest.mark.asyncio
+async def test_setup_orchestration_total_budget_defaults_none():
     """setup_orchestration default leaves total_budget as None."""
     from lionagi.cli.orchestrate._orchestration import setup_orchestration
 
@@ -165,7 +173,10 @@ def test_setup_orchestration_total_budget_defaults_none():
             side_effect=FileNotFoundError,
         ),
         patch("lionagi.cli.orchestrate._orchestration.resolve_persisted_effort", return_value=None),
-        patch("lionagi.cli.orchestrate._orchestration.Branch") as mock_branch,
+        patch(
+            "lionagi.cli.orchestrate._orchestration.create_agent",
+            new=AsyncMock(return_value=MagicMock(system=None)),
+        ),
         patch("lionagi.cli.orchestrate._orchestration.Session"),
         patch("lionagi.cli.orchestrate._orchestration.OperationGraphBuilder"),
     ):
@@ -174,9 +185,8 @@ def test_setup_orchestration_total_budget_defaults_none():
         mock_ep.config.kwargs = {}
         mock_imodel.return_value.endpoint = mock_ep
         mock_run.return_value.ensure_artifact_root.return_value = None
-        mock_branch.return_value = MagicMock(system=None)
 
-        env = setup_orchestration(
+        env = await setup_orchestration(
             pattern_name="Flow",
             model_spec="openai/gpt-4.1-mini",
             agent_name=None,

--- a/tests/engines/test_coding.py
+++ b/tests/engines/test_coding.py
@@ -1,0 +1,526 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Coding engine unit tests — the gated implement/test/fix loop.
+
+These exercise the engine's own logic with direct event emission and a REAL
+subprocess test runner (the ground-truth stage is the point). The fix loop is
+driven with a ``test_cmd`` that flips from failing to passing via a tmp_path
+flag file — deterministic, no time/random dependence. The scripted-provider
+e2e (the live emission path) lives in test_engines_scripted_e2e.py.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import pytest
+
+from lionagi.engines.coding import (
+    ChangeProposed,
+    CodeResultRecorded,
+    CodingChainEvent,
+    CodingEngine,
+    TestsRan,
+    VerifyResult,
+    WorkPlanned,
+    _normalize_spec,
+    _resolve_cmd,
+    _tail,
+)
+from lionagi.engines.hypothesis import ResultRecorded
+
+
+class _ScriptedBranch:
+    """A fake agent whose ``operate`` emits a queued event each call — stands in
+    for plan/implement/verify agents so the engine's own control flow (and the
+    real test runner) is what's under test."""
+
+    def __init__(self, run, events: list, *, name: str = "agent"):
+        self._run = run
+        self._events = list(events)
+        self.name = name
+        self.calls: list[str] = []
+
+    async def operate(self, *, instruction):
+        self.calls.append(instruction)
+        if self._events:
+            await self._run.emit(self._events.pop(0))
+        return "ok"
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_cmd_list_runs_shell_false():
+    assert _resolve_cmd(["uv", "run", "pytest"]) == (["uv", "run", "pytest"], False)
+
+
+def test_resolve_cmd_plain_string_is_split_shell_false():
+    assert _resolve_cmd("pytest -q tests/") == (["pytest", "-q", "tests/"], False)
+
+
+def test_resolve_cmd_shell_control_runs_shell_true():
+    cmd, shell = _resolve_cmd("pytest && echo ok")
+    assert cmd == "pytest && echo ok" and shell is True
+
+
+def test_normalize_spec_string_is_task_with_no_experiment_ref():
+    assert _normalize_spec("add a parser") == ("add a parser", "")
+
+
+def test_normalize_spec_dict_renders_experiment_and_carries_eid():
+    text, ref = _normalize_spec(
+        {"eid": "X-3", "procedure": "count ops", "acceptance": "CSR < CTE/10", "method": "analysis"}
+    )
+    assert ref == "X-3"
+    assert "count ops" in text and "CSR < CTE/10" in text and "analysis" in text
+
+
+def test_normalize_spec_rejects_empty():
+    with pytest.raises(ValueError):
+        _normalize_spec("   ")
+    with pytest.raises(ValueError):
+        _normalize_spec({})
+    with pytest.raises(TypeError):
+        _normalize_spec(42)
+
+
+def test_tail_bounds_lines_and_chars():
+    text = "\n".join(str(i) for i in range(200))
+    tail = _tail(text, lines=5, max_chars=1000)
+    assert tail.splitlines() == ["195", "196", "197", "198", "199"]
+    big = "x" * 9000
+    assert len(_tail(big, lines=5, max_chars=4000)) <= 4001  # leading ellipsis
+
+
+# ---------------------------------------------------------------------------
+# Ground-truth subprocess runner
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_test_stage_passes_on_zero_exit(tmp_path):
+    """A real ``python -c`` that exits 0 produces passed=True; the full output
+    lands in the export dir, the event carries only a tail."""
+    eng = CodingEngine()
+    run = eng.new_run()
+    run.workspace = str(tmp_path)
+    run.export_dir = tmp_path / "out"
+    run.export_dir.mkdir()
+    run.test_cmd = [sys.executable, "-c", "print('hello-stdout'); exit(0)"]
+    run.observe(CodingChainEvent, lambda e, _c: run.collect(e))
+    change = run.collect(ChangeProposed(summary="noop"))
+
+    tests = await eng._test(run, change, round_no=0)
+    assert tests.passed is True
+    assert tests.returncode == 0
+    assert "hello-stdout" in tests.output_tail
+    assert tests.output_file and (tmp_path / "out" / "test_output_1.txt").exists()
+    assert "hello-stdout" in (tmp_path / "out" / "test_output_1.txt").read_text()
+
+
+@pytest.mark.asyncio
+async def test_test_stage_fails_on_nonzero_exit(tmp_path):
+    eng = CodingEngine()
+    run = eng.new_run()
+    run.workspace = str(tmp_path)
+    run.test_cmd = [sys.executable, "-c", "import sys; sys.stderr.write('boom'); sys.exit(3)"]
+    run.observe(CodingChainEvent, lambda e, _c: run.collect(e))
+    change = run.collect(ChangeProposed(summary="bad"))
+
+    tests = await eng._test(run, change, round_no=0)
+    assert tests.passed is False
+    assert tests.returncode == 3
+    assert "boom" in tests.output_tail
+
+
+@pytest.mark.asyncio
+async def test_test_stage_times_out(tmp_path):
+    """A command exceeding the timeout is killed and reported timed_out — passed
+    is False regardless of what the process would have returned."""
+    eng = CodingEngine(test_timeout_s=0.5)
+    run = eng.new_run()
+    run.workspace = str(tmp_path)
+    run.test_cmd = [sys.executable, "-c", "import time; time.sleep(30)"]
+    run.observe(CodingChainEvent, lambda e, _c: run.collect(e))
+    change = run.collect(ChangeProposed(summary="hang"))
+
+    tests = await eng._test(run, change, round_no=0)
+    assert tests.passed is False
+    assert tests.timed_out is True
+
+
+# ---------------------------------------------------------------------------
+# Full pipeline — plan -> implement -> test (pass path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_full_pass_path(tmp_path, monkeypatch):
+    """plan -> implement -> test(pass) -> verify -> conclude(passed=True) with a
+    trivial passing test command and fake plan/implement/verify agents."""
+    eng = CodingEngine(max_fix_rounds=3)
+    run = eng.new_run()
+
+    plan_ev = WorkPlanned(approach="add foo", acceptance_criteria=["foo exists"])
+    change_ev = ChangeProposed(summary="added foo", files_touched=["foo.py"], plan_ref="W-1")
+    verdict_ev = VerifyResult(
+        verdict="APPROVE", rationale="meets criteria", meets_acceptance=True, tests_ref="T-1"
+    )
+
+    # Each named stage gets its scripted branch; make_agent is the only seam.
+    branches = {
+        "plan": _ScriptedBranch(run, [plan_ev], name="plan"),
+        "implement": _ScriptedBranch(run, [change_ev], name="implement"),
+        "verify": _ScriptedBranch(run, [verdict_ev], name="verify"),
+    }
+
+    async def fake_make(role, *, name=None, **kw):
+        return branches[name]
+
+    monkeypatch.setattr(run, "make_agent", fake_make)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async("diff --git a/foo.py b/foo.py"))
+
+    result = await eng._run(
+        run,
+        "add a foo function",
+        test_cmd=[sys.executable, "-c", "exit(0)"],
+        workspace=str(tmp_path),
+        export_dir=tmp_path / "out",
+    )
+    assert isinstance(result, CodeResultRecorded)
+    assert result.passed is True
+    assert run.last(TestsRan).passed is True
+    assert run.last(VerifyResult).meets_acceptance is True
+    # chain refs wired: change.plan_ref -> plan, tests.change_ref -> change
+    assert run.last(ChangeProposed).plan_ref == "W-1"
+    assert run.last(TestsRan).change_ref == "P-1"
+    # export written
+    data = json.loads((tmp_path / "out" / "results.json").read_text())
+    assert data["passed"] is True
+    assert (tmp_path / "out" / "report.md").exists()
+
+
+def _async(value):
+    async def _coro():
+        return value
+
+    return _coro()
+
+
+# ---------------------------------------------------------------------------
+# Fix loop — fail then pass on a flipping test command
+# ---------------------------------------------------------------------------
+
+
+def _flip_test_cmd(flag_path) -> list[str]:
+    """python -c that exits 1 the first time (creating the flag), 0 thereafter.
+
+    The flip is keyed on the flag file existing BEFORE this invocation —
+    deterministic across re-runs, no Date/random."""
+    code = (
+        "import os,sys;"
+        f"p=r'{flag_path}';"
+        "existed=os.path.exists(p);"
+        "open(p,'a').close();"
+        "sys.exit(0 if existed else 1)"
+    )
+    return [sys.executable, "-c", code]
+
+
+@pytest.mark.asyncio
+async def test_fix_loop_recovers_on_second_test(tmp_path, monkeypatch):
+    """First test run fails; the implementer is re-prompted, emits a new change,
+    the second test run passes — passed=True, exactly one fix round."""
+    eng = CodingEngine(max_fix_rounds=3, repair_retries=0)
+    run = eng.new_run()
+    flag = tmp_path / "flip.flag"
+
+    plan_ev = WorkPlanned(approach="fix it", acceptance_criteria=["passes"])
+    # implementer emits the first change, then a second change on the fix prompt
+    impl = _ScriptedBranch(
+        run,
+        [
+            ChangeProposed(summary="attempt 1", plan_ref="W-1"),
+            ChangeProposed(summary="attempt 2 (fixed)", plan_ref="W-1"),
+        ],
+        name="implement",
+    )
+    branches = {
+        "plan": _ScriptedBranch(run, [plan_ev], name="plan"),
+        "implement": impl,
+        "verify": _ScriptedBranch(
+            run,
+            [VerifyResult(verdict="APPROVE", rationale="green", meets_acceptance=True)],
+            name="verify",
+        ),
+    }
+
+    async def fake_make(role, *, name=None, **kw):
+        return branches[name]
+
+    monkeypatch.setattr(run, "make_agent", fake_make)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async(""))
+
+    result = await eng._run(
+        run,
+        "make the test pass",
+        test_cmd=_flip_test_cmd(flag),
+        workspace=str(tmp_path),
+    )
+    assert result.passed is True
+    test_runs = run.events_of(TestsRan)
+    assert [t.passed for t in test_runs] == [False, True]
+    assert [t.round for t in test_runs] == [0, 1]
+    # implementer was re-prompted once with the failure output
+    assert any("fix round 1" in c for c in impl.calls)
+    assert result.measurements["fix_rounds"] == 1
+
+
+@pytest.mark.asyncio
+async def test_fix_loop_exhausts_and_concludes_failed(tmp_path, monkeypatch):
+    """A test that never passes exhausts max_fix_rounds and concludes with
+    passed=False — graceful, with the failure recorded as a caveat."""
+    eng = CodingEngine(max_fix_rounds=2, repair_retries=0)
+    run = eng.new_run()
+
+    plan_ev = WorkPlanned(approach="impossible", acceptance_criteria=["passes"])
+    # implementer always emits a *new* change (so the loop is bounded by rounds,
+    # not by no-change detection)
+    impl = _ScriptedBranch(
+        run,
+        [ChangeProposed(summary=f"attempt {i}", plan_ref="W-1") for i in range(1, 5)],
+        name="implement",
+    )
+    branches = {
+        "plan": _ScriptedBranch(run, [plan_ev], name="plan"),
+        "implement": impl,
+        "verify": _ScriptedBranch(
+            run,
+            [
+                VerifyResult(
+                    verdict="REQUEST-CHANGES",
+                    rationale="still red",
+                    meets_acceptance=False,
+                    unmet=["passes"],
+                )
+            ],
+            name="verify",
+        ),
+    }
+
+    async def fake_make(role, *, name=None, **kw):
+        return branches[name]
+
+    monkeypatch.setattr(run, "make_agent", fake_make)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async(""))
+
+    events: list[dict] = []
+    run.on_event = events.append
+
+    result = await eng._run(
+        run,
+        "never passes",
+        test_cmd=[sys.executable, "-c", "exit(1)"],
+        workspace=str(tmp_path),
+    )
+    assert result.passed is False
+    # first pass + 2 fix rounds = 3 test runs
+    assert len(run.events_of(TestsRan)) == 3
+    assert result.measurements["fix_rounds"] == 2
+    assert any(e["type"] == "fix_exhausted" for e in events)
+    assert any("unmet" in c for c in result.caveats)
+
+
+@pytest.mark.asyncio
+async def test_fix_loop_stops_when_implementer_repeats_change(tmp_path, monkeypatch):
+    """If a fix round produces no *new* change (same event), the loop stops
+    early rather than spinning to max_fix_rounds."""
+    eng = CodingEngine(max_fix_rounds=5, repair_retries=0)
+    run = eng.new_run()
+    plan_ev = WorkPlanned(approach="stuck", acceptance_criteria=["passes"])
+    # implementer emits ONE change, then emits nothing on the fix prompt
+    impl = _ScriptedBranch(
+        run, [ChangeProposed(summary="only attempt", plan_ref="W-1")], name="implement"
+    )
+    branches = {
+        "plan": _ScriptedBranch(run, [plan_ev], name="plan"),
+        "implement": impl,
+        "verify": _ScriptedBranch(
+            run, [VerifyResult(verdict="REJECT", rationale="x")], name="verify"
+        ),
+    }
+
+    async def fake_make(role, *, name=None, **kw):
+        return branches[name]
+
+    monkeypatch.setattr(run, "make_agent", fake_make)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async(""))
+    events: list[dict] = []
+    run.on_event = events.append
+
+    result = await eng._run(
+        run, "stuck", test_cmd=[sys.executable, "-c", "exit(1)"], workspace=str(tmp_path)
+    )
+    assert result.passed is False
+    # one initial test; the single fix round emitted no new change -> stop
+    assert len(run.events_of(TestsRan)) == 1
+    assert any(e["type"] == "fix_no_change" for e in events)
+
+
+# ---------------------------------------------------------------------------
+# Implementer emits nothing -> graceful conclude
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_change_proposed_concludes_failed(tmp_path, monkeypatch):
+    eng = CodingEngine(repair_retries=0)
+    run = eng.new_run()
+    plan_ev = WorkPlanned(approach="x")
+    branches = {
+        "plan": _ScriptedBranch(run, [plan_ev], name="plan"),
+        "implement": _ScriptedBranch(run, [], name="implement"),  # emits nothing
+    }
+
+    async def fake_make(role, *, name=None, **kw):
+        return branches[name]
+
+    monkeypatch.setattr(run, "make_agent", fake_make)
+
+    result = await eng._run(
+        run, "do nothing", test_cmd=[sys.executable, "-c", "exit(0)"], workspace=str(tmp_path)
+    )
+    assert result.passed is False
+    assert any("emitted no change" in c for c in result.caveats)
+    # no test ran (nothing to test)
+    assert run.events_of(TestsRan) == []
+
+
+# ---------------------------------------------------------------------------
+# Pending-experiment ingestion + hypothesis seed round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pending_experiment_spec_carries_experiment_ref(tmp_path, monkeypatch):
+    """A spec that is a pending experiment dict (from a hypothesis export)
+    threads its eid into the CodeResultRecorded as experiment_ref."""
+    eng = CodingEngine(repair_retries=0)
+    run = eng.new_run()
+    plan_ev = WorkPlanned(approach="bench", acceptance_criteria=["CSR < CTE/10"])
+    branches = {
+        "plan": _ScriptedBranch(run, [plan_ev], name="plan"),
+        "implement": _ScriptedBranch(
+            run, [ChangeProposed(summary="wrote bench", plan_ref="W-1")], name="implement"
+        ),
+        "verify": _ScriptedBranch(
+            run,
+            [VerifyResult(verdict="APPROVE", rationale="ok", meets_acceptance=True)],
+            name="verify",
+        ),
+    }
+
+    async def fake_make(role, *, name=None, **kw):
+        return branches[name]
+
+    monkeypatch.setattr(run, "make_agent", fake_make)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async(""))
+
+    experiment = {
+        "eid": "X-12",
+        "method": "benchmark",
+        "dataset": "synthetic 500K-edge graph",
+        "procedure": "count page reads per traversal",
+        "acceptance": "CSR ops < CTE ops / 10",
+    }
+    result = await eng._run(
+        run, experiment, test_cmd=[sys.executable, "-c", "exit(0)"], workspace=str(tmp_path)
+    )
+    assert result.passed is True
+    assert result.experiment_ref == "X-12"
+
+
+def test_to_hypothesis_seeds_round_trips_into_result_recorded():
+    """The bus-interop bridge: every seed must validate as hypothesis's
+    ResultRecorded (the model a HypothesisRun ingests)."""
+    eng = CodingEngine()
+    run = eng.new_run()
+    run.experiment_ref = "X-5"
+    run.collect(
+        CodeResultRecorded(
+            passed=True,
+            measurements={"returncode": 0, "fix_rounds": 1, "files_touched": ["a.py"]},
+            caveats=["validated on python only"],
+            experiment_ref="X-5",
+        )
+    )
+    seeds = run.to_hypothesis_seeds()
+    assert len(seeds) == 1
+    rr = ResultRecorded.model_validate(seeds[0])
+    assert rr.experiment_ref == "X-5"
+    assert rr.passed is True
+    assert isinstance(rr.measurements, str)  # dict was rendered to a string
+    assert "fix_rounds" in rr.measurements
+    assert rr.caveats == ["validated on python only"]
+
+
+def test_to_hypothesis_seeds_empty_experiment_ref_still_validates():
+    """A task-spec run (no experiment) still yields a valid ResultRecorded seed
+    — experiment_ref is required by the model but '' is a valid string."""
+    eng = CodingEngine()
+    run = eng.new_run()
+    run.collect(CodeResultRecorded(passed=False, measurements={"returncode": 1}))
+    seed = run.to_hypothesis_seeds()[0]
+    assert seed["experiment_ref"] == ""
+    rr = ResultRecorded.model_validate(seed)
+    assert rr.experiment_ref == "" and rr.passed is False
+
+
+# ---------------------------------------------------------------------------
+# Judge gate on the fix-loop boundary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_judge_can_stop_fix_loop_early(tmp_path, monkeypatch):
+    """With judge_model armed, a REJECT before a fix round stops the loop —
+    no further test runs, graceful failed conclude."""
+    eng = CodingEngine(max_fix_rounds=5, judge_model="scripted/judge", repair_retries=0)
+    run = eng.new_run()
+    plan_ev = WorkPlanned(approach="x", acceptance_criteria=["passes"])
+    impl = _ScriptedBranch(
+        run,
+        [ChangeProposed(summary=f"a{i}", plan_ref="W-1") for i in range(1, 5)],
+        name="implement",
+    )
+    branches = {
+        "plan": _ScriptedBranch(run, [plan_ev], name="plan"),
+        "implement": impl,
+        "verify": _ScriptedBranch(
+            run, [VerifyResult(verdict="REJECT", rationale="x")], name="verify"
+        ),
+    }
+
+    async def fake_make(role, *, name=None, **kw):
+        return branches[name]
+
+    async def deny(run_, eid, subject):
+        return False  # never worth another round
+
+    monkeypatch.setattr(run, "make_agent", fake_make)
+    monkeypatch.setattr(eng, "judge", deny)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async(""))
+    events: list[dict] = []
+    run.on_event = events.append
+
+    result = await eng._run(
+        run, "x", test_cmd=[sys.executable, "-c", "exit(1)"], workspace=str(tmp_path)
+    )
+    assert result.passed is False
+    assert len(run.events_of(TestsRan)) == 1  # judge stopped before any fix round
+    assert any(e["type"] == "fix_gated" for e in events)

--- a/tests/engines/test_engine.py
+++ b/tests/engines/test_engine.py
@@ -165,6 +165,44 @@ async def test_make_agent_builds_casts_branch_with_emissions():
 
 
 @pytest.mark.asyncio
+async def test_make_agent_grants_emits_exactly_once(monkeypatch):
+    """Single-grant regression: emits is threaded through AgentSpec, so
+    create_agent grants once — the engine no longer re-grants afterward.
+    The branch's capabilities must match the stage emits exactly (the field
+    set is the override plus the always-appended escalation_request), and
+    grant_capabilities must fire exactly once."""
+    from lionagi.session.branch import Branch
+
+    calls: list[object] = []
+    original = Branch.grant_capabilities
+
+    def spy(self, operable, *, prompt: bool = True):
+        calls.append(operable)
+        return original(self, operable, prompt=prompt)
+
+    monkeypatch.setattr(Branch, "grant_capabilities", spy)
+
+    run = _run()
+    b = await run.make_agent("researcher", name="r1", emits=(Finding,))
+    assert len(calls) == 1  # one grant site, not two
+    assert b.capabilities.allowed() == {"finding", "escalation_request"}
+
+
+@pytest.mark.asyncio
+async def test_make_agent_no_emits_uses_role_contract():
+    """No emits ⇒ the role's declared contract is granted (researcher emits
+    Finding + Gap), still via the single create_agent grant site."""
+    run = _run()
+    b = await run.make_agent("researcher", name="r1")
+    role_op = b.capabilities
+    assert role_op is not None
+    from lionagi.casts import Role
+
+    expected = Role.load("researcher").emission_operable().allowed()
+    assert role_op.allowed() == expected
+
+
+@pytest.mark.asyncio
 async def test_run_dag_emits_node_lifecycle_signals():
     """run_dag executes a prebuilt DAG and tees NodeStarted/NodeCompleted onto
     the bus — the seam persistence/Studio observe instead of an on_progress

--- a/tests/engines/test_engine_protection.py
+++ b/tests/engines/test_engine_protection.py
@@ -1,0 +1,295 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Engine base protections — bundle-aware by_type, hard budgets, judge gate,
+emission repair, export. No LLM."""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.casts.emission import build_emission_operable
+from lionagi.engines.engine import Engine, EngineBudgetError, JudgeVerdict
+from lionagi.engines.hypothesis import (
+    ApplicationMapped,
+    ChainEvent,
+    ConclusionDrawn,
+    ExperimentDesigned,
+    HypothesisEngine,
+    QuestionRaised,
+)
+from lionagi.engines.research import FindingEmitted
+from lionagi.session.signal import StructuredOutput
+
+
+class _StubEngine(Engine):
+    async def _run(self, run, *a, **kw):  # pragma: no cover - not exercised
+        return ""
+
+
+# -- by_type: the production bundle path -------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_by_type_unwraps_capability_bundles():
+    """Agent emissions arrive as StructuredOutput bundles; by_type must return
+    the typed events, not the envelopes (this crashed research/review synthesis
+    in any real run)."""
+    run = _StubEngine().new_run()
+    op = build_emission_operable((FindingEmitted,))
+    bundle_model = op.create_model(include={"finding_emitted"})
+    bundle = bundle_model.model_validate(
+        {"finding_emitted": {"description": "prod finding", "novelty": 0.4}}
+    )
+    await run.session.emit(StructuredOutput(data=bundle))
+    got = run.by_type(FindingEmitted)
+    assert len(got) == 1
+    assert isinstance(got[0], FindingEmitted)
+    assert got[0].novelty == 0.4
+
+
+@pytest.mark.asyncio
+async def test_by_type_still_returns_directly_emitted_events():
+    run = _StubEngine().new_run()
+    await run.emit(FindingEmitted(description="direct", novelty=0.9))
+    got = run.by_type(FindingEmitted)
+    assert len(got) == 1 and got[0].description == "direct"
+
+
+# -- hard budgets -------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_spawn_denied_when_agent_budget_exhausted():
+    run = _StubEngine(max_agents=0).new_run()
+    events: list[dict] = []
+    run.on_event = events.append
+
+    async def work():  # pragma: no cover - must never run
+        raise AssertionError("spawned past budget")
+
+    assert run.spawn(work()) is None
+    await run.wait_quiescence()
+    assert any(e["type"] == "budget_exhausted" for e in events)
+
+
+@pytest.mark.asyncio
+async def test_make_agent_raises_when_exhausted_but_exempt_passes():
+    run = _StubEngine(max_agents=0).new_run()
+    with pytest.raises(EngineBudgetError):
+        await run.make_agent("synthesizer")
+    branch = await run.make_agent("synthesizer", name="synth", exempt=True)
+    assert branch.name == "synth"
+    assert run.agents_made == 1
+
+
+@pytest.mark.asyncio
+async def test_deadline_blocks_spawning():
+    run = _StubEngine(deadline_s=0.0).new_run()
+
+    async def work():  # pragma: no cover - must never run
+        raise AssertionError("spawned past deadline")
+
+    assert not run.budget_left()
+    assert run.spawn(work()) is None
+
+
+# -- judge gate ---------------------------------------------------------------
+
+
+class _FakeJudge:
+    name = "judge"
+
+    def __init__(self, run, verdict: JudgeVerdict | None, text: str = ""):
+        self._run = run
+        self._verdict = verdict
+        self._text = text
+
+    async def operate(self, *, instruction):
+        assert "Root objective" in instruction
+        if self._verdict is not None:
+            await self._run.emit(self._verdict)
+        return self._text
+
+
+@pytest.mark.asyncio
+async def test_judge_disabled_always_passes():
+    eng = _StubEngine()
+    run = eng.new_run()
+    assert await eng.judge(run, "Q-1", "anything") is True
+    assert run.agents_made == 0
+
+
+@pytest.mark.asyncio
+async def test_judge_verdict_gates_expansion():
+    eng = _StubEngine(judge_model="scripted/judge")
+    run = eng.new_run()
+    events: list[dict] = []
+    run.on_event = events.append
+
+    async def fake_make(role, **kw):
+        return _FakeJudge(run, JudgeVerdict(subject="Q-1", allow=False, reason="off-topic"))
+
+    run.make_agent = fake_make
+    assert await eng.judge(run, "Q-1", "tangent question") is False
+    assert any(e["type"] == "gated" and e["eid"] == "Q-1" for e in events)
+
+
+@pytest.mark.asyncio
+async def test_judge_text_fallback_for_weak_judges():
+    eng = _StubEngine(judge_model="scripted/judge")
+    run = eng.new_run()
+
+    async def fake_make(role, **kw):
+        return _FakeJudge(run, None, text="REJECT — duplicative")
+
+    run.make_agent = fake_make
+    assert await eng.judge(run, "Q-2", "dup question") is False
+
+
+@pytest.mark.asyncio
+async def test_judge_fails_open_on_error():
+    eng = _StubEngine(judge_model="scripted/judge")
+    run = eng.new_run()
+    events: list[dict] = []
+    run.on_event = events.append
+
+    async def fake_make(role, **kw):
+        raise RuntimeError("judge backend down")
+
+    run.make_agent = fake_make
+    assert await eng.judge(run, "Q-3", "question") is True
+    assert any(e["type"] == "judge_error" for e in events)
+
+
+@pytest.mark.asyncio
+async def test_judge_denied_when_budget_exhausted():
+    eng = _StubEngine(judge_model="scripted/judge", max_agents=0)
+    run = eng.new_run()
+    assert await eng.judge(run, "Q-4", "question") is False
+
+
+# -- emission repair ----------------------------------------------------------
+
+
+class _ProseBranch:
+    """Emits nothing on the first call; emits on the repair call."""
+
+    name = "weak-agent"
+
+    def __init__(self, run, emit_on_call: int, event):
+        self._run = run
+        self._event = event
+        self._emit_on = emit_on_call
+        self.calls: list[str] = []
+
+    async def operate(self, *, instruction):
+        self.calls.append(instruction)
+        if len(self.calls) == self._emit_on:
+            await self._run.emit(self._event)
+        return "prose"
+
+
+@pytest.mark.asyncio
+async def test_repair_reprompts_until_emission_arrives():
+    eng = _StubEngine()
+    run = eng.new_run()
+    events: list[dict] = []
+    run.on_event = events.append
+    branch = _ProseBranch(run, 2, FindingEmitted(description="late", novelty=0.1))
+
+    await run.operate_with_repair(
+        branch,
+        "find things",
+        arrived=lambda: bool(run.by_type(FindingEmitted)),
+        emits=(FindingEmitted,),
+        retries=2,
+    )
+    assert len(branch.calls) == 2
+    assert "produced no valid emission" in branch.calls[1]
+    assert "finding_emitted" in branch.calls[1]  # repair names the expected key
+    assert any(e["type"] == "emission_repair" for e in events)
+    assert not any(e["type"] == "emission_missing" for e in events)
+
+
+@pytest.mark.asyncio
+async def test_repair_gives_up_and_notifies():
+    eng = _StubEngine()
+    run = eng.new_run()
+    events: list[dict] = []
+    run.on_event = events.append
+    branch = _ProseBranch(run, 99, FindingEmitted(description="never", novelty=0.1))
+
+    await run.operate_with_repair(
+        branch,
+        "find things",
+        arrived=lambda: False,
+        emits=(FindingEmitted,),
+        retries=1,
+    )
+    assert len(branch.calls) == 2
+    assert any(e["type"] == "emission_missing" for e in events)
+
+
+# -- hypothesis judge wiring ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_question_expansion_gated_by_judge():
+    eng = HypothesisEngine(judge_model="scripted/judge")
+    run = eng.new_run()
+    judged: list[str] = []
+    made: list[str] = []
+
+    async def deny(run_, eid, subject):
+        judged.append(eid)
+        return False
+
+    async def fake_make(role, **kw):  # pragma: no cover - must never run
+        made.append(role)
+        raise AssertionError("agent made despite judge denial")
+
+    eng.judge = deny
+    run.make_agent = fake_make
+    run.observe(ChainEvent, lambda e, _c: run.collect(e))
+    run.observe(QuestionRaised, lambda q, _c: eng._on_question(run, q))
+    await run.emit(QuestionRaised(area="x", what_is_unknown="why tangent?"))
+    await run.wait_quiescence()
+    assert judged == ["Q-1"]
+    assert made == []
+
+
+# -- export ---------------------------------------------------------------------
+
+
+def test_export_writes_chains_json_and_report(tmp_path):
+    import json as _json
+
+    eng = HypothesisEngine()
+    run = eng.new_run()
+    run.root = "seed finding"
+    q = run.collect(QuestionRaised(area="a", what_is_unknown="why X over Y?"))
+    c = run.collect(
+        ConclusionDrawn(
+            question_ref=q.eid,
+            verdict="keep X",
+            rationale="cheaper",
+            basis="quantitative",
+        )
+    )
+    run.collect(ApplicationMapped(conclusion_ref=c.eid, decision_ref="D-007", effect="supports"))
+    pend = run.collect(
+        ExperimentDesigned(hypothesis_ref="H-9", method="benchmark", procedure="criterion run")
+    )
+    run.pending.append(pend)
+
+    paths = run.export(tmp_path / "out", report="THE REPORT")
+    data = _json.loads((tmp_path / "out" / "chains.json").read_text())
+    assert data["root"] == "seed finding"
+    assert data["decisions_touched"] == ["D-007"]
+    assert data["chains"] == [["Q-1", "C-1", "A-1"]]
+    assert data["pending_experiments"][0]["procedure"] == "criterion run"
+    report = (tmp_path / "out" / "report.md").read_text()
+    assert report.startswith("THE REPORT")
+    assert "criterion run" in report and "D-007" in report
+    assert paths["report"].endswith("report.md")

--- a/tests/engines/test_engines_scripted_e2e.py
+++ b/tests/engines/test_engines_scripted_e2e.py
@@ -321,6 +321,42 @@ async def test_review_engine_e2e_with_adversarial_verify(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_review_repair_recovers_prose_reviewer_e2e(tmp_path, monkeypatch):
+    """The reviewer's first response is prose (a weak-model failure); the repair
+    turn re-prompts and the second response emits a valid issue through the real
+    fenced-JSON → bundle path. The verdict then reads it from the store."""
+    _write_script(
+        tmp_path,
+        monkeypatch,
+        [
+            _when("for **correctness** only", text="The cursor logic looks suspicious..."),
+            _when(
+                "produced no valid emission",
+                {
+                    "issue_found": {
+                        "dimension": "correctness",
+                        "description": "off-by-one in cursor advance",
+                        "severity": "major",
+                        "location": "store.rs:41",
+                        "confidence": 0.7,
+                    }
+                },
+            ),
+            _when("Issue a single ReviewVerdict", text="REQUEST-CHANGES: fix cursor advance."),
+        ],
+    )
+
+    notified: list[dict] = []
+    eng = ReviewEngine(model=SCRIPTED_MODEL, dimensions=("correctness",), repair_retries=1)
+    out = await eng.run(
+        "fn next(&mut self) { self.pos += 1; ... }",
+        on_event=lambda e: notified.append(e),
+    )
+    assert "REQUEST-CHANGES" in out
+    assert any(e["type"] == "emission_repair" for e in notified)
+
+
+@pytest.mark.asyncio
 async def test_hypothesis_budget_degrades_gracefully_e2e(tmp_path, monkeypatch):
     """With budget for only the extraction agent, expansion stops but the
     exempt synthesizer still writes the report — the run never dies empty."""

--- a/tests/engines/test_engines_scripted_e2e.py
+++ b/tests/engines/test_engines_scripted_e2e.py
@@ -1,0 +1,350 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end engine runs through the scripted provider — the REAL path.
+
+Unlike the reaction unit tests (which emit events directly), these drive
+``branch.operate`` against ``provider="scripted"``: the canned response text
+carries fenced ```json blocks, ``attempt_extract`` validates them against the
+capability grant, ``StructuredOutput`` bundles land on the session bus, and
+the engines' reactions fire off the unwrapped events. This is exactly how a
+live model (API, claude_code/codex CLI, or local) feeds the engines — so it
+catches the failure class unit mocks cannot (e.g. the by_type envelope bug).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import yaml
+
+from lionagi.engines.hypothesis import (
+    ApplicationMapped,
+    ConclusionDrawn,
+    EvidenceCollected,
+    HypothesisEngine,
+    QuestionRaised,
+)
+from lionagi.engines.research import FindingEmitted, ResearchEngine
+from lionagi.engines.review import IssueFound, ReviewEngine, VerifyResult
+from lionagi.testing._endpoint import ENV_SCRIPT_PATH
+
+SCRIPTED_MODEL = "scripted/scripted-test"
+
+
+def _emit(payload: dict) -> str:
+    return f"Done.\n```json\n{json.dumps(payload)}\n```\n"
+
+
+def _write_script(tmp_path, monkeypatch, entries: list[dict]) -> None:
+    """Each engine agent constructs its own ScriptedEndpoint from this file —
+    fresh cursor per agent, ``when:`` matchers route stages by instruction."""
+    path = tmp_path / "script.yaml"
+    path.write_text(yaml.safe_dump({"version": 1, "responses": entries}), encoding="utf-8")
+    monkeypatch.setenv(ENV_SCRIPT_PATH, str(path))
+
+
+def _when(marker: str, payload: dict | None = None, text: str = "") -> dict:
+    return {
+        "type": "text",
+        "content": _emit(payload) if payload is not None else text,
+        "when": {"prompt_contains": marker},
+    }
+
+
+@pytest.mark.asyncio
+async def test_hypothesis_engine_full_chain_e2e(tmp_path, monkeypatch):
+    _write_script(
+        tmp_path,
+        monkeypatch,
+        [
+            _when(
+                "Extract the architectural questions",
+                {
+                    "question_raised": {
+                        "area": "graph storage",
+                        "what_is_unknown": "why CSR over recursive CTE for BFS?",
+                        "alternatives": ["recursive CTE in SQLite"],
+                        "decision_ref": "D-012",
+                        "parent_ref": "F-1",
+                        "gen": 0,
+                    }
+                },
+            ),
+            _when(
+                "Gather concrete evidence",
+                {
+                    "evidence_collected": {
+                        "description": "SurrealDB traverses in-memory, not via SQL CTE",
+                        "kind": "precedent",
+                        "evidence": "surrealdb graph executor source",
+                        "confidence": 0.8,
+                        "question_ref": "Q-1",
+                    }
+                },
+            ),
+            _when(
+                "Form the testable hypothesis",
+                {
+                    "hypothesis_formed": {
+                        "question_ref": "Q-1",
+                        "statement": "CSR BFS depth-2 beats CTE by >10x at 500K edges",
+                        "metric": "ops per traversal",
+                        "threshold": "10x",
+                        "falsifier": "CTE within 2x of CSR",
+                    }
+                },
+            ),
+            _when(
+                "Design the decisive experiment",
+                {
+                    "experiment_designed": {
+                        "hypothesis_ref": "H-1",
+                        "method": "analysis",
+                        "dataset": "synthetic 500K-edge graph",
+                        "procedure": "count page reads and row decodes per traversal",
+                        "acceptance": "CSR ops < CTE ops / 10",
+                    }
+                },
+            ),
+            _when(
+                "Execute experiment",
+                {
+                    "result_recorded": {
+                        "experiment_ref": "X-1",
+                        "measurements": "CSR: 1.2M ops; CTE: 38M ops (31x)",
+                        "passed": True,
+                        "caveats": ["cold-cache behavior untested"],
+                    }
+                },
+            ),
+            _when(
+                "Draw the conclusion",
+                {
+                    "conclusion_drawn": {
+                        "question_ref": "Q-1",
+                        "result_ref": "R-1",
+                        "verdict": "keep CSR for in-memory BFS",
+                        "rationale": "31x fewer ops than recursive CTE",
+                        "basis": "quantitative",
+                        "confidence": 0.85,
+                        "limitations": ["validated at <=500K edges only"],
+                    }
+                },
+            ),
+            _when(
+                "Apply conclusion",
+                {
+                    "application_mapped": {
+                        "conclusion_ref": "C-1",
+                        "decision_ref": "D-012",
+                        "effect": "supports",
+                        "note": "quantitative op-count evidence for the CSR choice",
+                    }
+                },
+            ),
+            _when(
+                "Write the evidence report",
+                text="EVIDENCE REPORT: D-012 supported on quantitative basis (31x).",
+            ),
+        ],
+    )
+
+    eng = HypothesisEngine(model=SCRIPTED_MODEL, max_questions=1, repair_retries=0)
+    run = eng.new_run()
+    report = await eng._run(
+        run,
+        "ChatGPT R3 proposes CSR snapshot for BFS instead of recursive CTE",
+        decisions="D-012: in-memory CSR graph snapshot for traversal",
+        export_dir=tmp_path / "evidence",
+    )
+
+    assert "D-012 supported" in report
+    # The full typed chain formed through the real emission path:
+    chains = json.loads((tmp_path / "evidence" / "chains.json").read_text())["chains"]
+    assert ["F-1", "Q-1", "H-1", "X-1", "R-1", "C-1", "A-1"] in chains
+    assert run.events_of(QuestionRaised)[0].decision_ref == "D-012"
+    assert run.events_of(EvidenceCollected)[0].kind == "precedent"
+    assert run.events_of(ConclusionDrawn)[0].basis == "quantitative"
+    assert run.events_of(ApplicationMapped)[0].effect == "supports"
+    report_md = (tmp_path / "evidence" / "report.md").read_text()
+    assert "EVIDENCE REPORT" in report_md and "Evidence chains" in report_md
+
+
+@pytest.mark.asyncio
+async def test_hypothesis_repair_recovers_weak_model_e2e(tmp_path, monkeypatch):
+    """First extraction response is prose (a classic weak-model failure); the
+    repair turn re-prompts and the second response emits validly."""
+    _write_script(
+        tmp_path,
+        monkeypatch,
+        [
+            _when("Extract the architectural questions", text="Let me think about this..."),
+            _when(
+                "produced no valid emission",
+                {
+                    "question_raised": {
+                        "area": "ql",
+                        "what_is_unknown": "why || over + for concat?",
+                        "parent_ref": "F-1",
+                        "gen": 0,
+                    }
+                },
+            ),
+            _when(
+                "Gather concrete evidence",
+                {
+                    "evidence_collected": {
+                        "description": "SQL standard uses ||",
+                        "kind": "citation",
+                        "question_ref": "Q-1",
+                    }
+                },
+            ),
+            _when(
+                "Form the testable hypothesis",
+                {
+                    "conclusion_drawn": {
+                        "question_ref": "Q-1",
+                        "result_ref": "",
+                        "verdict": "keep ||",
+                        "rationale": "SQL convention; + overload invites coercion bugs",
+                        "basis": "taste",
+                        "confidence": 0.6,
+                    }
+                },
+            ),
+            _when("Apply conclusion", text="Bears on nothing specific."),
+            _when("Write the evidence report", text="REPORT: taste conclusion recorded."),
+        ],
+    )
+
+    notified: list[dict] = []
+    eng = HypothesisEngine(model=SCRIPTED_MODEL, max_questions=1, repair_retries=1)
+    report = await eng.run(
+        "Grammar uses || for concat",
+        on_event=lambda e: notified.append(e),
+    )
+    assert "taste conclusion" in report
+    assert any(e["type"] == "emission_repair" for e in notified)
+
+
+@pytest.mark.asyncio
+async def test_research_engine_e2e_with_depth_spawn(tmp_path, monkeypatch):
+    """A high-novelty finding at depth 0 spawns a depth-1 node; synthesis reads
+    findings from the store through the (fixed) bundle-aware by_type."""
+    _write_script(
+        tmp_path,
+        monkeypatch,
+        [
+            _when(
+                "depth 0/1",
+                {
+                    "finding_emitted": {
+                        "description": "fusion parameter k dominates recall",
+                        "evidence": "ablation table",
+                        "novelty": 0.9,
+                        "confidence": 0.8,
+                        "depth": 0,
+                    }
+                },
+            ),
+            _when(
+                "depth 1/1",
+                {
+                    "finding_emitted": {
+                        "description": "k=60 is a historical default, not tuned",
+                        "evidence": "original RRF paper",
+                        "novelty": 0.2,
+                        "confidence": 0.9,
+                        "depth": 1,
+                    }
+                },
+            ),
+            _when("Synthesize the research", text="SYNTHESIS: k=60 needs a sweep."),
+        ],
+    )
+
+    eng = ResearchEngine(model=SCRIPTED_MODEL, roles=("researcher",), max_depth=1)
+    run = eng.new_run()
+    out = await eng._run(run, "RRF fusion defaults")
+    assert out == "SYNTHESIS: k=60 needs a sweep."
+    findings = run.by_type(FindingEmitted)
+    assert len(findings) == 2  # depth-0 + spawned depth-1, through real bundles
+    assert {f.depth for f in findings} == {0, 1}
+
+
+@pytest.mark.asyncio
+async def test_review_engine_e2e_with_adversarial_verify(tmp_path, monkeypatch):
+    """A critical issue spawns the adversarial verifier; the verdict stage
+    reads both from the store through bundle-aware by_type."""
+    _write_script(
+        tmp_path,
+        monkeypatch,
+        [
+            _when(
+                "for **correctness** only",
+                {
+                    "issue_found": {
+                        "dimension": "correctness",
+                        "description": "off-by-one in cursor advance",
+                        "severity": "critical",
+                        "location": "store.rs:41",
+                        "confidence": 0.7,
+                    }
+                },
+            ),
+            _when(
+                "Adversarially verify",
+                {
+                    "verify_result": {
+                        "issue": "off-by-one in cursor advance",
+                        "holds": True,
+                        "rationale": "boundary test confirms skip of last row",
+                    }
+                },
+            ),
+            _when(
+                "Issue a single ReviewVerdict",
+                text="REQUEST-CHANGES: fix cursor advance.",
+            ),
+        ],
+    )
+
+    eng = ReviewEngine(model=SCRIPTED_MODEL, dimensions=("correctness",))
+    run = eng.new_run()
+    out = await eng._run(run, "fn next(&mut self) { self.pos += 1; ... }")
+    assert "REQUEST-CHANGES" in out
+    assert len(run.by_type(IssueFound)) == 1
+    assert run.by_type(VerifyResult)[0].holds is True
+
+
+@pytest.mark.asyncio
+async def test_hypothesis_budget_degrades_gracefully_e2e(tmp_path, monkeypatch):
+    """With budget for only the extraction agent, expansion stops but the
+    exempt synthesizer still writes the report — the run never dies empty."""
+    _write_script(
+        tmp_path,
+        monkeypatch,
+        [
+            _when(
+                "Extract the architectural questions",
+                {
+                    "question_raised": {
+                        "area": "a",
+                        "what_is_unknown": "why X?",
+                        "parent_ref": "F-1",
+                        "gen": 0,
+                    }
+                },
+            ),
+            _when("Write the evidence report", text="PARTIAL REPORT: 1 open question."),
+        ],
+    )
+
+    notified: list[dict] = []
+    eng = HypothesisEngine(model=SCRIPTED_MODEL, max_agents=1, repair_retries=0)
+    report = await eng.run("seed finding", on_event=lambda e: notified.append(e))
+    assert "PARTIAL REPORT" in report
+    assert any(e["type"] == "budget_exhausted" for e in notified)

--- a/tests/engines/test_engines_scripted_e2e.py
+++ b/tests/engines/test_engines_scripted_e2e.py
@@ -19,12 +19,23 @@ import json
 import pytest
 import yaml
 
+from lionagi.engines.coding import (
+    ChangeProposed,
+    CodeResultRecorded,
+    CodingEngine,
+    TestsRan,
+    WorkPlanned,
+)
+from lionagi.engines.coding import (
+    VerifyResult as CodeVerifyResult,
+)
 from lionagi.engines.hypothesis import (
     ApplicationMapped,
     ConclusionDrawn,
     EvidenceCollected,
     HypothesisEngine,
     QuestionRaised,
+    ResultRecorded,
 )
 from lionagi.engines.research import FindingEmitted, ResearchEngine
 from lionagi.engines.review import IssueFound, ReviewEngine, VerifyResult
@@ -384,3 +395,78 @@ async def test_hypothesis_budget_degrades_gracefully_e2e(tmp_path, monkeypatch):
     report = await eng.run("seed finding", on_event=lambda e: notified.append(e))
     assert "PARTIAL REPORT" in report
     assert any(e["type"] == "budget_exhausted" for e in notified)
+
+
+@pytest.mark.asyncio
+async def test_coding_engine_pass_path_e2e(tmp_path, monkeypatch):
+    """plan + implement emit through the real fenced-JSON -> bundle path; the
+    engine runs a trivial passing test command as ground truth, the critic
+    approves, and the run concludes passed=True. The implementer's coding tools
+    are granted but not exercised (the scripted provider returns canned JSON) —
+    what is under test is the live emission + the real subprocess gate."""
+    _write_script(
+        tmp_path,
+        monkeypatch,
+        [
+            _when(
+                "planning a coding task",
+                {
+                    "work_planned": {
+                        "approach": "add a hello() that returns 'hi'",
+                        "files_to_touch": ["hello.py"],
+                        "test_strategy": "assert hello() == 'hi'",
+                        "acceptance_criteria": ["hello() returns 'hi'"],
+                    }
+                },
+            ),
+            _when(
+                "Implement the plan",
+                {
+                    "change_proposed": {
+                        "summary": "wrote hello() returning 'hi'",
+                        "files_touched": ["hello.py"],
+                        "test_cmd": "pytest -q",
+                        "plan_ref": "W-1",
+                    }
+                },
+            ),
+            _when(
+                "Review the implemented change",
+                {
+                    "verify_result": {
+                        "verdict": "APPROVE",
+                        "rationale": "tests green and hello() returns 'hi'",
+                        "meets_acceptance": True,
+                        "change_ref": "P-1",
+                        "tests_ref": "T-1",
+                    }
+                },
+            ),
+        ],
+    )
+
+    eng = CodingEngine(model=SCRIPTED_MODEL, repair_retries=0)
+    run = eng.new_run()
+    result = await eng._run(
+        run,
+        "add a hello function",
+        # ground truth: a trivial command that exits 0, through the REAL runner
+        test_cmd="true",
+        workspace=str(tmp_path),
+        export_dir=tmp_path / "out",
+    )
+
+    assert isinstance(result, CodeResultRecorded)
+    assert result.passed is True
+    # the full typed chain formed through the real emission path:
+    assert run.events_of(WorkPlanned)[0].acceptance_criteria == ["hello() returns 'hi'"]
+    assert run.events_of(ChangeProposed)[0].plan_ref == "W-1"
+    assert run.events_of(TestsRan)[0].passed is True  # ground truth, not a claim
+    assert run.events_of(CodeVerifyResult)[0].meets_acceptance is True
+
+    # results.json carries hypothesis-ingestible seeds
+    data = json.loads((tmp_path / "out" / "results.json").read_text())
+    assert data["passed"] is True
+    seed = data["hypothesis_seeds"][0]
+    rr = ResultRecorded.model_validate(seed)  # the bus-interop bridge round-trips
+    assert rr.passed is True

--- a/tests/engines/test_hypothesis.py
+++ b/tests/engines/test_hypothesis.py
@@ -1,0 +1,266 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""HypothesisEngine reaction logic — eid stamping, stage spawning, cycle caps,
+pending experiments, chain tracing, synthesis. No LLM."""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.engines.hypothesis import (
+    ApplicationMapped,
+    ChainEvent,
+    ConclusionDrawn,
+    EvidenceCollected,
+    ExperimentDesigned,
+    FindingPosted,
+    HypothesisEngine,
+    HypothesisFormed,
+    QuestionRaised,
+    ResultRecorded,
+    trace_chains,
+)
+
+
+def _wire(eng, run):
+    """Register the engine's collector + reactions on a run, as ``_run`` does."""
+    run.observe(ChainEvent, lambda e, _c: run.collect(e))
+    run.observe(FindingPosted, lambda f, _c: eng._on_finding(run, f))
+    run.observe(QuestionRaised, lambda q, _c: eng._on_question(run, q))
+    run.observe(HypothesisFormed, lambda h, _c: eng._on_hypothesis(run, h))
+    run.observe(ExperimentDesigned, lambda x, _c: eng._on_experiment(run, x))
+    run.observe(ResultRecorded, lambda r, _c: eng._on_result(run, r))
+    run.observe(ConclusionDrawn, lambda c, _c: eng._on_conclusion(run, c))
+
+
+def _mute(eng, *stages):
+    """Replace stage coroutines with recorders; returns the call log."""
+    calls: list[tuple] = []
+
+    def make(stage):
+        async def rec(_run, event, *a):
+            calls.append((stage, event))
+
+        return rec
+
+    for s in stages:
+        setattr(eng, f"_{s}", make(s))
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_collector_stamps_sequential_eids_and_stores():
+    eng = HypothesisEngine()
+    run = eng.new_run()
+    _mute(eng, "extract", "research")
+    _wire(eng, run)
+    await run.emit(FindingPosted(description="finding one"))
+    await run.emit(QuestionRaised(area="x", what_is_unknown="why A over B?"))
+    await run.emit(QuestionRaised(area="x", what_is_unknown="why C over D?"))
+    await run.wait_quiescence()
+    assert [f.eid for f in run.events_of(FindingPosted)] == ["F-1"]
+    assert [q.eid for q in run.events_of(QuestionRaised)] == ["Q-1", "Q-2"]
+    assert run.find("Q-2").what_is_unknown == "why C over D?"
+
+
+@pytest.mark.asyncio
+async def test_finding_spawns_extraction_and_dedups():
+    eng = HypothesisEngine()
+    run = eng.new_run()
+    calls = _mute(eng, "extract")
+    _wire(eng, run)
+    await run.emit(FindingPosted(description="CSR chosen for BFS"))
+    await run.emit(FindingPosted(description="csr chosen for bfs"))  # dup after normalize
+    await run.wait_quiescence()
+    assert [s for s, _ in calls] == ["extract"]
+
+
+@pytest.mark.asyncio
+async def test_cycle_cap_blocks_question_expansion():
+    eng = HypothesisEngine(max_depth=2)
+    run = eng.new_run()
+    calls = _mute(eng, "research")
+    _wire(eng, run)
+    await run.emit(QuestionRaised(area="a", what_is_unknown="in budget?", gen=2))
+    await run.emit(QuestionRaised(area="a", what_is_unknown="over budget?", gen=3))
+    await run.wait_quiescence()
+    assert [e.what_is_unknown for _, e in calls] == ["in budget?"]
+
+
+@pytest.mark.asyncio
+async def test_question_dedup_spawns_once():
+    eng = HypothesisEngine()
+    run = eng.new_run()
+    calls = _mute(eng, "research")
+    _wire(eng, run)
+    await run.emit(QuestionRaised(area="a", what_is_unknown="Why HNSW over Vamana?"))
+    await run.emit(QuestionRaised(area="b", what_is_unknown="why hnsw over vamana?"))
+    await run.wait_quiescence()
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_benchmark_experiment_goes_pending_analysis_runs():
+    eng = HypothesisEngine()
+    run = eng.new_run()
+    calls = _mute(eng, "validate")
+    _wire(eng, run)
+    await run.emit(
+        ExperimentDesigned(hypothesis_ref="H-1", method="benchmark", procedure="run criterion")
+    )
+    await run.emit(
+        ExperimentDesigned(hypothesis_ref="H-2", method="analysis", procedure="count AST nodes")
+    )
+    await run.wait_quiescence()
+    assert [x.method for x in run.pending] == ["benchmark"]
+    assert [e.method for _, e in calls] == ["analysis"]
+
+
+@pytest.mark.asyncio
+async def test_result_spawns_conclude_and_conclusion_spawns_apply():
+    eng = HypothesisEngine()
+    run = eng.new_run()
+    calls = _mute(eng, "conclude", "apply")
+    _wire(eng, run)
+    await run.emit(ResultRecorded(experiment_ref="X-1", measurements="180us vs 4.2ms"))
+    await run.emit(
+        ConclusionDrawn(
+            question_ref="Q-1",
+            verdict="keep CSR",
+            rationale="23x faster",
+            basis="empirical",
+        )
+    )
+    await run.wait_quiescence()
+    assert sorted(s for s, _ in calls) == ["apply", "conclude"]
+
+
+@pytest.mark.asyncio
+async def test_taste_conclusion_without_result_still_applies():
+    eng = HypothesisEngine()
+    run = eng.new_run()
+    calls = _mute(eng, "apply")
+    _wire(eng, run)
+    await run.emit(
+        ConclusionDrawn(
+            question_ref="Q-1",
+            result_ref="",
+            verdict="keep || for concat",
+            rationale="SQL convention",
+            basis="taste",
+        )
+    )
+    await run.wait_quiescence()
+    assert [s for s, _ in calls] == ["apply"]
+    assert run.events_of(ConclusionDrawn)[0].basis == "taste"
+
+
+@pytest.mark.asyncio
+async def test_stage_error_does_not_kill_pipeline():
+    eng = HypothesisEngine()
+    run = eng.new_run()
+    errors: list[dict] = []
+    run.on_event = lambda e: errors.append(e) if e["type"] == "stage_error" else None
+
+    async def boom(_run, _q):
+        raise RuntimeError("research exploded")
+
+    eng._research = boom
+    _wire(eng, run)
+    await run.emit(QuestionRaised(area="a", what_is_unknown="why X?"))
+    await run.wait_quiescence()  # must not raise
+    assert errors and errors[0]["stage"] == "research"
+
+
+def test_trace_chains_reconstructs_full_chain_and_taste_path():
+    f = FindingPosted(eid="F-1", description="CSR chosen")
+    q = QuestionRaised(eid="Q-1", area="graph", what_is_unknown="why CSR?", parent_ref="F-1")
+    h = HypothesisFormed(eid="H-1", question_ref="Q-1", statement="CSR < 500us")
+    x = ExperimentDesigned(eid="X-1", hypothesis_ref="H-1", method="analysis", procedure="bench")
+    r = ResultRecorded(eid="R-1", experiment_ref="X-1", measurements="180us", passed=True)
+    c = ConclusionDrawn(
+        eid="C-1",
+        question_ref="Q-1",
+        result_ref="R-1",
+        verdict="keep",
+        rationale="fast",
+        basis="empirical",
+    )
+    a = ApplicationMapped(eid="A-1", conclusion_ref="C-1", decision_ref="D-012", effect="supports")
+    # taste path: conclusion straight off a question, no application yet
+    q2 = QuestionRaised(eid="Q-2", area="ql", what_is_unknown="why ||?", parent_ref="F-1")
+    c2 = ConclusionDrawn(
+        eid="C-2", question_ref="Q-2", verdict="keep ||", rationale="convention", basis="taste"
+    )
+
+    chains = trace_chains([f, q, h, x, r, c, a, q2, c2])
+    assert len(chains) == 2
+    full = next(ch for ch in chains if ch[-1].eid == "A-1")
+    assert [e.eid for e in full] == ["F-1", "Q-1", "H-1", "X-1", "R-1", "C-1", "A-1"]
+    taste = next(ch for ch in chains if ch[-1].eid == "C-2")
+    assert [e.eid for e in taste] == ["F-1", "Q-2", "C-2"]
+
+
+@pytest.mark.asyncio
+async def test_synthesis_reports_chains_pending_and_open_questions():
+    eng = HypothesisEngine()
+    run = eng.new_run()
+    run.collect(QuestionRaised(area="a", what_is_unknown="why HNSW over Vamana at 100K?"))
+    run.collect(
+        ConclusionDrawn(
+            question_ref="Q-9",  # no matching question -> Q-1 stays open
+            verdict="keep",
+            rationale="r",
+            basis="quantitative",
+        )
+    )
+    pending = run.collect(
+        ExperimentDesigned(hypothesis_ref="H-1", method="benchmark", procedure="criterion 100K")
+    )
+    run.pending.append(pending)
+
+    captured: dict = {}
+
+    class FakeSynth:
+        name = "synthesizer"
+
+        async def operate(self, *, instruction):
+            captured["instruction"] = instruction
+            return "REPORT"
+
+    async def fake_make(role, **kw):
+        return FakeSynth()
+
+    run.make_agent = fake_make
+    out = await eng._synthesize(run)
+    assert out == "REPORT"
+    text = captured["instruction"]
+    assert "why HNSW over Vamana at 100K?" in text  # open question listed
+    assert "criterion 100K" in text  # pending experiment listed
+    assert "quantitative" in text  # conclusion basis listed
+
+
+@pytest.mark.asyncio
+async def test_run_seeds_findings_and_synthesizes(monkeypatch):
+    eng = HypothesisEngine()
+    seen: list[str] = []
+
+    async def fake_extract(run, f):
+        seen.append(f.description)
+
+    async def fake_synth(run):
+        return "DONE"
+
+    eng._extract = fake_extract
+    eng._synthesize = fake_synth
+    out = await eng.run(["alpha choice", "beta choice"], decisions="D-001: something")
+    assert out == "DONE"
+    assert seen == ["alpha choice", "beta choice"]
+
+
+@pytest.mark.asyncio
+async def test_empty_findings_raises():
+    eng = HypothesisEngine()
+    with pytest.raises(ValueError):
+        await eng.run("   ")

--- a/tests/engines/test_research.py
+++ b/tests/engines/test_research.py
@@ -131,3 +131,83 @@ async def test_synthesis_reads_findings_from_store():
     assert "A" in captured["instruction"]
     assert "B" in captured["instruction"]
     assert "the topic" in captured["instruction"]
+
+
+# -- emission repair (ADR-0077 §3) -------------------------------------------
+
+
+class _ProseTeamMember:
+    """A node's team member that returns prose until ``emit_on_call``, then
+    emits — the weak-model failure the repair loop recovers (mirrors the
+    ``_ProseBranch`` in test_engine_protection.py)."""
+
+    name = "researcher-d0"
+
+    def __init__(self, run, emit_on_call: int, event):
+        self._run = run
+        self._event = event
+        self._emit_on = emit_on_call
+        self.calls: list[str] = []
+
+    async def operate(self, *, instruction):
+        self.calls.append(instruction)
+        if len(self.calls) == self._emit_on:
+            await self._run.emit(self._event)
+        return "prose"
+
+
+@pytest.mark.asyncio
+async def test_drive_node_repairs_when_team_emits_nothing():
+    """A node whose whole team returned prose gets re-prompted; the repair turn
+    lands the finding and an ``emission_repair`` notify fires."""
+    eng = ResearchEngine(repair_retries=1)
+    run = eng.new_run()
+    events: list[dict] = []
+    run.on_event = events.append
+    # emit only on the 3rd call: run_team(1) → repair first-operate(2) → repair turn(3).
+    member = _ProseTeamMember(run, 3, FindingEmitted(description="late finding", novelty=0.1))
+
+    await eng._drive_node(run, [member], "Research topic (depth 0/1): X")
+    await run.wait_quiescence()
+
+    assert len(member.calls) == 3
+    assert "produced no valid emission" in member.calls[2]
+    assert "finding_emitted" in member.calls[2]  # repair names the expected key
+    assert any(e["type"] == "emission_repair" for e in events)
+    assert len(run.by_type(FindingEmitted)) == 1
+
+
+@pytest.mark.asyncio
+async def test_drive_node_no_repair_when_team_emits():
+    """A node that emits on the first team pass costs no extra agent call — the
+    arrived() pre-check short-circuits before any repair operate."""
+    eng = ResearchEngine(repair_retries=1)
+    run = eng.new_run()
+    events: list[dict] = []
+    run.on_event = events.append
+    member = _ProseTeamMember(run, 1, FindingEmitted(description="early", novelty=0.1))
+
+    await eng._drive_node(run, [member], "Research topic (depth 0/1): X")
+    await run.wait_quiescence()
+
+    assert len(member.calls) == 1  # run_team only; no repair operate
+    assert not any(e["type"] == "emission_repair" for e in events)
+    assert len(run.by_type(FindingEmitted)) == 1
+
+
+@pytest.mark.asyncio
+async def test_drive_node_empty_team_is_noop():
+    """An empty team (e.g. a budget-declined node) drives run_team once and never
+    attempts repair — preserves the dedup/budget contracts."""
+    eng = ResearchEngine(repair_retries=2)
+    run = eng.new_run()
+    teams_run: list[str] = []
+
+    async def fake_run_team(team, instruction, **kw):
+        teams_run.append(instruction)
+        return ""
+
+    run.run_team = fake_run_team
+    await eng._drive_node(run, [], "Research topic (depth 0/1): X")
+    assert teams_run == ["Research topic (depth 0/1): X"]
+    assert len(run.by_type(FindingEmitted)) == 0

--- a/tests/engines/test_review.py
+++ b/tests/engines/test_review.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import pytest
 
-from lionagi.engines.review import IssueFound, ReviewEngine
+from lionagi.engines.review import IssueFound, ReviewEngine, VerifyResult
 
 
 class _FakeAgent:
@@ -18,6 +18,25 @@ class _FakeAgent:
     async def operate(self, *, instruction: str):
         self._rec.append(instruction)
         return None
+
+
+class _ProseAgent:
+    """Returns prose until ``emit_on_call``, then emits — the weak-model failure
+    the repair loop recovers (mirrors ``_ProseBranch`` in
+    test_engine_protection.py). ``emit_on_call=0`` never emits (clean reviewer)."""
+
+    def __init__(self, run, name: str, emit_on_call: int, event):
+        self.name = name
+        self._run = run
+        self._event = event
+        self._emit_on = emit_on_call
+        self.calls: list[str] = []
+
+    async def operate(self, *, instruction: str):
+        self.calls.append(instruction)
+        if self._emit_on and len(self.calls) == self._emit_on:
+            await self._run.emit(self._event)
+        return "prose"
 
 
 @pytest.mark.asyncio
@@ -95,3 +114,76 @@ async def test_verdict_reads_issues_from_store():
     out = await eng._verdict(run, "ART", ("security",))
     assert out == "REQUEST-CHANGES"
     assert "X-issue" in captured["instruction"]
+
+
+# -- emission repair (ADR-0077 §3) -------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_review_dimension_repairs_prose_reviewer():
+    """A reviewer that returns prose first gets re-prompted; the repair turn
+    lands the issue and an ``emission_repair`` notify fires."""
+    eng = ReviewEngine(repair_retries=1)
+    run = eng.new_run()
+    events: list[dict] = []
+    run.on_event = events.append
+    issue = IssueFound(dimension="security", description="sqli", severity="critical")
+    agent = _ProseAgent(run, "review-security", emit_on_call=2, event=issue)
+
+    async def fake_make(role, **kw):
+        return agent
+
+    run.make_agent = fake_make
+    await eng._review_dimension(run, "ARTIFACT", "security")
+
+    assert len(agent.calls) == 2  # initial operate (prose) + repair turn (emits)
+    assert "produced no valid emission" in agent.calls[1]
+    assert "issue_found" in agent.calls[1]
+    assert any(e["type"] == "emission_repair" for e in events)
+    assert len(run.by_type(IssueFound)) == 1
+
+
+@pytest.mark.asyncio
+async def test_review_dimension_clean_reviewer_fabricates_nothing():
+    """A genuinely clean dimension (prose, no issue) is nudged once but the
+    repair never invents an issue — transport-hardening, not gold-plating."""
+    eng = ReviewEngine(repair_retries=1)
+    run = eng.new_run()
+    events: list[dict] = []
+    run.on_event = events.append
+    agent = _ProseAgent(run, "review-style", emit_on_call=0, event=None)
+
+    async def fake_make(role, **kw):
+        return agent
+
+    run.make_agent = fake_make
+    await eng._review_dimension(run, "ARTIFACT", "style")
+
+    assert len(agent.calls) == 2  # one repair nudge attempted
+    assert any(e["type"] == "emission_missing" for e in events)
+    assert len(run.by_type(IssueFound)) == 0  # nothing fabricated
+
+
+@pytest.mark.asyncio
+async def test_verify_repairs_prose_verifier():
+    """The adversarial verifier always owes a verdict, so a prose first response
+    is repaired into a VerifyResult."""
+    eng = ReviewEngine(repair_retries=1)
+    run = eng.new_run()
+    events: list[dict] = []
+    run.on_event = events.append
+    issue = IssueFound(dimension="security", description="sqli", severity="critical")
+    result = VerifyResult(issue="sqli", holds=True, rationale="boundary test confirms")
+    agent = _ProseAgent(run, "verify-security", emit_on_call=2, event=result)
+
+    async def fake_make(role, **kw):
+        return agent
+
+    run.make_agent = fake_make
+    await eng._verify(run, issue)
+
+    assert len(agent.calls) == 2
+    assert "produced no valid emission" in agent.calls[1]
+    assert "verify_result" in agent.calls[1]
+    assert any(e["type"] == "emission_repair" for e in events)
+    assert run.by_type(VerifyResult)[0].holds is True

--- a/tests/operations/run/test_run_signals.py
+++ b/tests/operations/run/test_run_signals.py
@@ -57,7 +57,7 @@ def _assistant(text: str) -> AssistantResponse:
 
 
 def test_extract_single_capability():
-    bundles, violations = _attempt_extract(
+    bundles, violations, _rejects = _attempt_extract(
         '{"finding": {"claim": "x", "confidence": 0.9}}', _grant()
     )
     assert len(bundles) == 1 and not violations
@@ -67,7 +67,7 @@ def test_extract_single_capability():
 
 def test_extract_multiple_keys_one_block():
     text = '```json\n{"finding": {"claim": "y"}, "question": {"text": "why?"}}\n```'
-    bundles, _ = _attempt_extract(text, _grant())
+    bundles, _, _ = _attempt_extract(text, _grant())
     assert len(bundles) == 1
     assert bundles[0].finding.claim == "y"
     assert bundles[0].question.text == "why?"
@@ -82,25 +82,25 @@ def test_extract_multiple_blocks_one_message():
         '```json\n{"finding": {"claim": "second", "confidence": 0.9}}\n```\n'
         "done."
     )
-    bundles, _ = _attempt_extract(text, _grant())
+    bundles, _, _ = _attempt_extract(text, _grant())
     assert len(bundles) == 2
     assert [b.finding.claim for b in bundles] == ["first", "second"]
 
 
 def test_extract_prose_returns_empty():
-    assert _attempt_extract("just thinking out loud", _grant()) == ([], [])
+    assert _attempt_extract("just thinking out loud", _grant()) == ([], [], [])
 
 
 def test_extract_non_capability_json_ignored():
     # valid JSON, keys disjoint from the grant → ordinary output, not a capability
-    assert _attempt_extract('{"unrelated": 1}', _grant()) == ([], [])
+    assert _attempt_extract('{"unrelated": 1}', _grant()) == ([], [], [])
 
 
 def test_extract_illegal_emission_becomes_violation(caplog):
     from lionagi.session.capabilities import CapabilityViolation
 
     # 'secret' is outside the grant → not honored, recorded as a violation
-    bundles, violations = _attempt_extract(
+    bundles, violations, _rejects = _attempt_extract(
         '{"finding": {"claim": "z"}, "secret": {"x": 1}}', _grant()
     )
     assert bundles == []  # the mixed block is not honored
@@ -127,6 +127,38 @@ async def test_violation_emitted_as_bus_signal():
     )
 
     assert caught == [["secret"]]  # governance observer fired on the over-grant
+
+
+def test_extract_invalid_in_grant_block_becomes_reject():
+    from lionagi.session.capabilities import EmissionRejected
+
+    # 'finding' is granted but the block fails schema validation (bad type)
+    bundles, violations, rejects = _attempt_extract(
+        '{"finding": {"claim": "z", "confidence": "very high"}}', _grant()
+    )
+    assert bundles == [] and violations == []
+    assert len(rejects) == 1
+    r = rejects[0]
+    assert isinstance(r, EmissionRejected)
+    assert "confidence" in r.error
+    assert r.block == {"finding": {"claim": "z", "confidence": "very high"}}
+
+
+async def test_reject_emitted_as_bus_signal_with_branch_name():
+    from lionagi.session.capabilities import EmissionRejected
+
+    s = Session()
+    caught = []
+    s.observe(EmissionRejected, lambda r, _: caught.append(r.branch_name))
+
+    branch = s.default_branch
+    branch.name = "weak-extractor"
+    branch.capabilities = _grant()
+    await _emit_message_signal(
+        branch, _assistant('{"finding": {"claim": "z", "confidence": "very high"}}')
+    )
+
+    assert caught == ["weak-extractor"]  # repair observers can attribute it
 
 
 # -- assistant capability bundle → bus, observed by TYPE --------------------

--- a/tests/orchestration/test_spawn_operation_constraint.py
+++ b/tests/orchestration/test_spawn_operation_constraint.py
@@ -8,7 +8,7 @@ create_operation without validating against the allowlist, enabling model output
 to route spawned work to any registered session operation.
 
 Fix: Defense-in-depth guard in role_node_builder falls back to 'operate' and
-emits a warning when the operation is outside _SPAWN_ALLOWED_OPERATIONS.
+emits a warning when the operation is outside SPAWN_ALLOWED_OPERATIONS.
 The primary guard is SpawnRequest being typed as Literal[...], but this
 routing-level check survives if the Literal enforcement is bypassed (e.g.
 via a constructed SpawnRequest with model_construct).
@@ -21,7 +21,7 @@ import logging
 
 import pytest
 
-from lionagi.casts.emission import _SPAWN_ALLOWED_OPERATIONS, SpawnRequest
+from lionagi.casts.emission import SPAWN_ALLOWED_OPERATIONS, SpawnRequest
 from lionagi.orchestration.patterns import role_node_builder
 from lionagi.session.branch import Branch
 from lionagi.session.session import Session
@@ -40,7 +40,7 @@ def _make_roles(*names: str) -> dict[str, Branch]:
 class TestRoleNodeBuilderOperationConstraint:
     """The routing boundary must not pass untrusted operation names to create_operation."""
 
-    @pytest.mark.parametrize("op", sorted(_SPAWN_ALLOWED_OPERATIONS))
+    @pytest.mark.parametrize("op", sorted(SPAWN_ALLOWED_OPERATIONS))
     def test_allowed_operations_pass_through(self, op: str):
         """Documented operations must work unchanged after the guard."""
         roles = _make_roles("researcher")
@@ -104,7 +104,7 @@ class TestSpawnedNodeParamsBindToTarget:
     ``instruction``), so an allowed ReAct spawn raised ``TypeError`` at run time.
     """
 
-    @pytest.mark.parametrize("op", sorted(_SPAWN_ALLOWED_OPERATIONS))
+    @pytest.mark.parametrize("op", sorted(SPAWN_ALLOWED_OPERATIONS))
     def test_node_params_bind_to_branch_method(self, op: str):
         roles = _make_roles("researcher")
         nb = role_node_builder(roles)

--- a/tests/outcomes/test_outcome_models.py
+++ b/tests/outcomes/test_outcome_models.py
@@ -15,9 +15,9 @@ from pydantic import ValidationError
 
 from lionagi.outcomes import (
     CIResult,
-    Finding,
     GateVerdict,
-    ReviewVerdict,
+    ReviewFinding,
+    ReviewOutcome,
     SkillOutcome,
 )
 from lionagi.outcomes.ci import CIRunCommand
@@ -41,7 +41,7 @@ def test_skill_outcome_dump_round_trips():
 
 def test_review_verdict_default_outcome_kind_pinned():
     """ADR-0021 promises kind='review_verdict' — frontend dispatch depends on it."""
-    v = ReviewVerdict(
+    v = ReviewOutcome(
         verdict="APPROVE",
         summary="LGTM",
     )
@@ -52,43 +52,43 @@ def test_review_verdict_default_outcome_kind_pinned():
 
 def test_review_verdict_accepts_hyphenated_producer_string():
     """Producer strings like APPROVE-WITH-SUGGESTIONS are normalized on ingest."""
-    v = ReviewVerdict.model_validate({"verdict": "APPROVE-WITH-SUGGESTIONS", "summary": "ok"})
+    v = ReviewOutcome.model_validate({"verdict": "APPROVE-WITH-SUGGESTIONS", "summary": "ok"})
     assert v.verdict == "APPROVE_WITH_SUGGESTIONS"
 
 
 def test_review_verdict_accepts_spaced_producer_string():
-    v = ReviewVerdict.model_validate({"verdict": "REQUEST CHANGES", "summary": "ok"})
+    v = ReviewOutcome.model_validate({"verdict": "REQUEST CHANGES", "summary": "ok"})
     assert v.verdict == "REQUEST_CHANGES"
 
 
 def test_review_verdict_rejects_unknown_decision():
     with pytest.raises(ValidationError):
-        ReviewVerdict(verdict="MEH", summary="?")
+        ReviewOutcome(verdict="MEH", summary="?")
 
 
 def test_review_verdict_round_must_be_positive():
     with pytest.raises(ValidationError):
-        ReviewVerdict(verdict="APPROVE", summary="ok", round=0)
+        ReviewOutcome(verdict="APPROVE", summary="ok", round=0)
 
 
 def test_finding_severity_constrained():
-    Finding(
+    ReviewFinding(
         severity="critical",
         category="security",
         description="rm -rf in user input",
     )
     with pytest.raises(ValidationError):
-        Finding(severity="hot", category="x", description="y")
+        ReviewFinding(severity="hot", category="x", description="y")
 
 
 def test_review_verdict_dump_round_trips():
-    v = ReviewVerdict(
+    v = ReviewOutcome(
         verdict="REQUEST_CHANGES",
         summary="3 issues",
         passed=False,
         round=2,
         findings=[
-            Finding(
+            ReviewFinding(
                 severity="high",
                 category="correctness",
                 file="src/main.py",
@@ -100,7 +100,7 @@ def test_review_verdict_dump_round_trips():
     )
     dumped = v.model_dump()
     assert dumped["outcome_kind"] == "review_verdict"
-    again = ReviewVerdict.model_validate(dumped)
+    again = ReviewOutcome.model_validate(dumped)
     assert again == v
 
 
@@ -176,7 +176,7 @@ def test_outcome_kinds_are_distinct():
     """Each concrete outcome must have a unique outcome_kind string —
     the frontend's switch dispatches on this value."""
     kinds = {
-        ReviewVerdict(verdict="APPROVE", summary="x").outcome_kind,
+        ReviewOutcome(verdict="APPROVE", summary="x").outcome_kind,
         GateVerdict(summary="x", gate_passed=True).outcome_kind,
         CIResult(summary="x").outcome_kind,
     }
@@ -185,22 +185,22 @@ def test_outcome_kinds_are_distinct():
 
 def test_finding_rejects_absolute_unix_path():
     with pytest.raises(ValidationError, match="repo-relative"):
-        Finding(severity="high", category="security", description="x", file="/etc/passwd")
+        ReviewFinding(severity="high", category="security", description="x", file="/etc/passwd")
 
 
 def test_finding_rejects_absolute_windows_path():
     with pytest.raises(ValidationError, match="repo-relative"):
-        Finding(severity="high", category="security", description="x", file="C:\\secret.py")
+        ReviewFinding(severity="high", category="security", description="x", file="C:\\secret.py")
 
 
 def test_finding_rejects_parent_traversal():
     with pytest.raises(ValidationError, match="traversal"):
-        Finding(severity="high", category="security", description="x", file="../secret.py")
+        ReviewFinding(severity="high", category="security", description="x", file="../secret.py")
 
 
 def test_finding_rejects_deep_traversal():
     with pytest.raises(ValidationError, match="traversal"):
-        Finding(
+        ReviewFinding(
             severity="medium",
             category="correctness",
             description="x",
@@ -210,32 +210,32 @@ def test_finding_rejects_deep_traversal():
 
 def test_finding_rejects_nul_byte():
     with pytest.raises(ValidationError, match="NUL"):
-        Finding(severity="low", category="style", description="x", file="foo\x00bar.py")
+        ReviewFinding(severity="low", category="style", description="x", file="foo\x00bar.py")
 
 
 def test_finding_rejects_line_zero():
     """Line numbers must be 1-indexed (ge=1); 0 is invalid."""
     with pytest.raises(ValidationError):
-        Finding(severity="low", category="style", description="x", line=0)
+        ReviewFinding(severity="low", category="style", description="x", line=0)
 
 
 def test_finding_rejects_negative_line():
     with pytest.raises(ValidationError):
-        Finding(severity="low", category="style", description="x", line=-3)
+        ReviewFinding(severity="low", category="style", description="x", line=-3)
 
 
 def test_finding_accepts_valid_relative_path():
-    f = Finding(severity="low", category="style", description="x", file="src/main.py")
+    f = ReviewFinding(severity="low", category="style", description="x", file="src/main.py")
     assert f.file == "src/main.py"
 
 
 def test_finding_accepts_none_file():
-    f = Finding(severity="low", category="style", description="x", file=None)
+    f = ReviewFinding(severity="low", category="style", description="x", file=None)
     assert f.file is None
 
 
 def test_finding_accepts_positive_line():
-    f = Finding(severity="info", category="docs", description="x", line=42)
+    f = ReviewFinding(severity="info", category="docs", description="x", line=42)
     assert f.line == 42
 
 

--- a/tests/state/test_artifacts.py
+++ b/tests/state/test_artifacts.py
@@ -10,7 +10,7 @@ import uuid
 
 import pytest
 
-from lionagi.outcomes import GateVerdict, ReviewVerdict
+from lionagi.outcomes import GateVerdict, ReviewOutcome
 from lionagi.state.db import StateDB
 
 
@@ -46,7 +46,7 @@ async def _make_session(db: StateDB, **fields) -> dict:
 
 async def test_insert_artifact_with_invocation_link(db: StateDB):
     inv = await _make_invocation(db)
-    verdict = ReviewVerdict(
+    verdict = ReviewOutcome(
         verdict="APPROVE",
         summary="LGTM",
         round=1,

--- a/tests/state/test_provenance.py
+++ b/tests/state/test_provenance.py
@@ -60,9 +60,9 @@ def test_resolve_none_for_both_none():
 
 def test_hash_none_for_missing_agent(tmp_path: Path, monkeypatch):
     """Unknown agent name → None (caller writes NULL to agent_hash)."""
-    import lionagi.cli._agents as _agents_mod
+    import lionagi._paths as _paths_mod
 
-    monkeypatch.setattr(_agents_mod, "_find_lionagi_dirs", lambda: [tmp_path / "empty"])
+    monkeypatch.setattr(_paths_mod, "find_lionagi_dirs", lambda: [tmp_path / "empty"])
     assert agent_definition_hash("never-existed") is None
 
 
@@ -73,7 +73,7 @@ def test_hash_none_for_empty_name():
 
 def test_hash_finds_nested_md(tmp_path: Path, monkeypatch):
     """ADR-0022 lookup order: ``agents/<name>/<name>.md`` first."""
-    import lionagi.cli._agents as _agents_mod
+    import lionagi._paths as _paths_mod
 
     home = tmp_path / "lionagi-home"
     agents = home / "agents"
@@ -82,14 +82,14 @@ def test_hash_finds_nested_md(tmp_path: Path, monkeypatch):
     body = b"# reviewer\nbe thorough.\n"
     (nested / "reviewer.md").write_bytes(body)
 
-    monkeypatch.setattr(_agents_mod, "_find_lionagi_dirs", lambda: [home])
+    monkeypatch.setattr(_paths_mod, "find_lionagi_dirs", lambda: [home])
     expected = hashlib.sha256(body).hexdigest()[:16]
     assert agent_definition_hash("reviewer") == expected
 
 
 def test_hash_falls_back_to_flat_md(tmp_path: Path, monkeypatch):
     """When no nested dir exists, fall back to ``agents/<name>.md``."""
-    import lionagi.cli._agents as _agents_mod
+    import lionagi._paths as _paths_mod
 
     home = tmp_path / "lionagi-home"
     agents = home / "agents"
@@ -97,14 +97,14 @@ def test_hash_falls_back_to_flat_md(tmp_path: Path, monkeypatch):
     body = b"# analyst\n"
     (agents / "analyst.md").write_bytes(body)
 
-    monkeypatch.setattr(_agents_mod, "_find_lionagi_dirs", lambda: [home])
+    monkeypatch.setattr(_paths_mod, "find_lionagi_dirs", lambda: [home])
     expected = hashlib.sha256(body).hexdigest()[:16]
     assert agent_definition_hash("analyst") == expected
 
 
 def test_hash_finds_project_local_profile(tmp_path: Path, monkeypatch):
     """Project-local .lionagi takes priority over global ~/.lionagi."""
-    import lionagi.cli._agents as _agents_mod
+    import lionagi._paths as _paths_mod
 
     # Project-local profile
     local_home = tmp_path / "project" / ".lionagi"
@@ -121,8 +121,8 @@ def test_hash_finds_project_local_profile(tmp_path: Path, monkeypatch):
 
     # Project-local dir comes first, matching load_agent_profile() semantics
     monkeypatch.setattr(
-        _agents_mod,
-        "_find_lionagi_dirs",
+        _paths_mod,
+        "find_lionagi_dirs",
         lambda: [local_home, global_home],
     )
 


### PR DESCRIPTION
## What this is

Three arcs in 15 commits, each commit independently reviewable and test-green:

### 1. Hypothesis engine + autonomy protections (commits 1–3, ADR-0077)
- **HypothesisEngine** (Chain shape): `FindingPosted → QuestionRaised → EvidenceCollected → HypothesisFormed → ExperimentDesigned → ResultRecorded → ConclusionDrawn(empirical|quantitative|theoretical|taste) → ApplicationMapped(supports|challenges|qualifies)`. Engine-stamped eids, `trace_chains()` audit reconstruction, `export()` → chains.json + report.md. Benchmark experiments queue on `run.pending` — never faked.
- **Engine base hardening**: `by_type` bundle-unwrap fix (production bug — agent emissions arrive as StructuredOutput bundles; synthesis crashed in any live run), hard budgets (`max_agents`/`deadline_s`, exempt terminal stages → graceful degradation), `EmissionRejected` + `operate_with_repair` (weak-model repair loop), judge gate (cheap-model quality gate at expansion points, fail-open), per-stage `models={}` routing, sandboxed tool grants.
- **Validated live**: full run on `claude_code` CLI workers — 57 typed events, 2 evidence chains, repair recovered a silently-failing stage in production, budget degradation delivered partial synthesis.

### 2. Module coherence (commits 4–12, ADR-0078)
Casts conceptual model made normative: Pattern = atom; Role/Mode = special patterns; **Profile = patterns + persistence**; **Agent = runtime concept** — `create_agent` is the single construction site and single capability-grant site.
- `casts/__init__.py` curated surface; private leaks sealed; acronym field-name fix
- `AgentSpec.emits` single grant source — engine double-grant deleted
- CLI orchestrator/workers route through `create_agent` (byte-for-byte prompt verification; additive `chat_model=`/`log_config=` factory passthroughs)
- `AgentConfig` deprecated by delegation; provider tables → `service/providers.py`; path constants → `lionagi/_paths.py` (layering inversions gone)
- outcomes renamed plane-distinct (`ReviewFinding`/`ReviewOutcome`); `EngineEvent` forbids extras
- repair retrofit to research/review stages
- **Studio fix**: run detail read a manifest file nothing ever wrote (writer had zero callers) — now reads StateDB like the list view

### 3. Coding engine (commit 14)
Gated-Loop shape: plan → implement (sandboxed coding tools, path guards verified to block out-of-workspace writes) → **subprocess test stage: `passed` = exit code, never an LLM claim** → judge-gated fix rounds (bounded) → critic verify → `CodeResultRecorded`. `to_hypothesis_seeds()` round-trips into hypothesis `ResultRecorded` — the engine-to-engine evidence bridge.

## Verification
- Full suite: **7756 passed, RC=0** (`pytest tests/ --ignore=tests/cli`)
- Complete `tests/cli` suite: RC=0 (run explicitly since the orchestrator changed)
- ruff format/check clean; per-commit suites green at every slice

## Review pointers
- Commit-by-commit is the intended review path — each slice is scoped and conventional-commit-labeled.
- ADR-0078 documents what was deliberately NOT unified (flow→PlanningEngine deferred with rationale; hooks/outcomes are forward deployment per ADR-0023b/c / ADR-0021).
- One prod-visible alignment to confirm intent: casts CLI workers now load `~/.lionagi/.mcp.json` via the factory (matches the canonical programmatic path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)