### PR TITLE
fix(tests): guard fastapi import in studio run-detail tests

### DIFF
--- a/tests/apps_studio_server/test_runs_detail.py
+++ b/tests/apps_studio_server/test_runs_detail.py
@@ -19,6 +19,7 @@ from typing import Any
 import pytest
 
 aiosqlite = pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
+fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 
 from lionagi.state.db import StateDB  # noqa: E402
 


### PR DESCRIPTION
The v0.26.18 release workflow failed at `test (3.11)`/`test (3.13)`: `tests/apps_studio_server/test_runs_detail.py` errors at fixture setup with `ModuleNotFoundError: No module named 'fastapi'` — the release env doesn't install the studio extra, and the `patched_runs_svc` fixture imports `services.runs → _path_safety → fastapi` at module level.

Fix: module-level `pytest.importorskip("fastapi")`, matching sibling `test_runs_list.py:12`.

Verified both ways: with fastapi → 5 passed; with fastapi blocked via PYTHONPATH shim → whole module skips, RC=0.

Unblocks the v0.26.18 release (deploy never ran; PyPI untouched — tag will be moved to the fixed commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)