### PR TITLE
fix(engines): fan collected chain events out to on_event exactly once

### DIFF
--- a/lionagi/engines/coding.py
+++ b/lionagi/engines/coding.py
@@ -48,7 +48,7 @@ from lionagi.casts.emission import Verdict
 from lionagi.ln.concurrency import run_sync
 from lionagi.tools._subprocess import _SHELL_CONTROL, _subprocess_sync
 
-from .engine import Engine, EngineEvent, EngineRun
+from .engine import Engine, EngineEvent, EngineRun, _event_dict, _safe_event_dict
 
 logger = logging.getLogger("lionagi.engines")
 
@@ -317,14 +317,34 @@ class CodingRun(EngineRun):
         self._test_runs: int = 0
 
     def collect(self, event: CodingChainEvent) -> CodingChainEvent:
-        """Stamp the engine-assigned eid and store the event (first observer)."""
+        """Stamp the engine-assigned eid, store the event, and fan it to on_event.
+
+        Every chain event — whether it arrives via run.emit() or directly from
+        an agent on the session bus — is stamped here.  Notifying here (rather
+        than relying on EngineRun.emit's trailing notify) is the only path that
+        reaches all three agent-emitted kinds: WorkPlanned, ChangeProposed, and
+        VerifyResult.  emit() is overridden below to skip its own notify call for
+        CodingChainEvent so there is no double-delivery for the two events that
+        also pass through run.emit() (TestsRan, CodeResultRecorded)."""
         prefix = _EVENT_PREFIX.get(type(event), "N")
         n = self._eid_counts.get(prefix, 0) + 1
         self._eid_counts[prefix] = n
         event.eid = f"{prefix}-{n}"
         self.store.setdefault(type(event), []).append(event)
         self._index[event.eid] = event
+        self.notify(type(event).__name__, **_safe_event_dict(event))
         return event
+
+    async def emit(self, event: Any) -> list[Any]:
+        """Emit onto the session bus; skip the base notify for chain events.
+
+        CodingChainEvent instances are already notified by collect() (triggered
+        by the observer registered in _run).  The base EngineRun.emit() would
+        call notify() a second time — this override suppresses that duplicate."""
+        results = await self.session.emit(event)
+        if not isinstance(event, CodingChainEvent):
+            self.notify(type(event).__name__, **_event_dict(event))
+        return results
 
     def find(self, eid: str) -> CodingChainEvent | None:
         return self._index.get(eid)

--- a/lionagi/engines/engine.py
+++ b/lionagi/engines/engine.py
@@ -56,6 +56,18 @@ def _event_dict(event: Any) -> dict[str, Any]:
     return {}
 
 
+def _safe_event_dict(event: Any) -> dict[str, Any]:
+    """Like _event_dict but renames keys that clash with notify(kind, **data).
+
+    The ``kind`` parameter name is reserved by ``EngineRun.notify``; any event
+    field named ``kind`` (e.g. ``EvidenceCollected.kind``) must be renamed to
+    avoid a TypeError when the dict is splatted into the call."""
+    d = _event_dict(event)
+    if "kind" in d:
+        d["event_kind"] = d.pop("kind")
+    return d
+
+
 def _judge_instruction(eid: str, subject: str, context: str) -> str:
     return (
         "You are the quality gate of an autonomous pipeline. Decide whether this "

--- a/lionagi/engines/hypothesis.py
+++ b/lionagi/engines/hypothesis.py
@@ -31,7 +31,7 @@ from pydantic import BaseModel, Field
 
 from lionagi.casts.emission import Finding, Gap, Verdict
 
-from .engine import Engine, EngineEvent, EngineRun
+from .engine import Engine, EngineEvent, EngineRun, _event_dict, _safe_event_dict
 
 logger = logging.getLogger("lionagi.engines")
 
@@ -438,14 +438,34 @@ class HypothesisRun(EngineRun):
         self._index: dict[str, ChainEvent] = {}
 
     def collect(self, event: ChainEvent) -> ChainEvent:
-        """Stamp the engine-assigned eid and store the event (first observer)."""
+        """Stamp the engine-assigned eid, store the event, and fan it to on_event.
+
+        Every chain event — whether it arrives via run.emit() (seed FindingPosted)
+        or from an agent on the session bus — is stamped here.  Notifying here is
+        the only path that reaches agent-emitted kinds like QuestionRaised,
+        EvidenceCollected, HypothesisFormed, etc.  emit() is overridden below to
+        skip its own notify for ChainEvent so there is no double-delivery for
+        the seed findings that also pass through run.emit()."""
         prefix = _EVENT_PREFIX.get(type(event), "N")
         n = self._eid_counts.get(prefix, 0) + 1
         self._eid_counts[prefix] = n
         event.eid = f"{prefix}-{n}"
         self.store.setdefault(type(event), []).append(event)
         self._index[event.eid] = event
+        self.notify(type(event).__name__, **_safe_event_dict(event))
         return event
+
+    async def emit(self, event: Any) -> list[Any]:
+        """Emit onto the session bus; skip the base notify for chain events.
+
+        ChainEvent instances are already notified by collect() (triggered by the
+        observer registered in _run).  The base EngineRun.emit() would call
+        notify() a second time for seed FindingPosted events — this override
+        suppresses that duplicate."""
+        results = await self.session.emit(event)
+        if not isinstance(event, ChainEvent):
+            self.notify(type(event).__name__, **_event_dict(event))
+        return results
 
     def find(self, eid: str) -> ChainEvent | None:
         return self._index.get(eid)

--- a/tests/engines/test_coding.py
+++ b/tests/engines/test_coding.py
@@ -524,3 +524,142 @@ async def test_judge_can_stop_fix_loop_early(tmp_path, monkeypatch):
     assert result.passed is False
     assert len(run.events_of(TestsRan)) == 1  # judge stopped before any fix round
     assert any(e["type"] == "fix_gated" for e in events)
+
+
+# ---------------------------------------------------------------------------
+# Regression: #1361 — chain events must reach on_event exactly once
+# ---------------------------------------------------------------------------
+
+
+class _BusBranch:
+    """Emits events via the raw session bus only (no run.emit()) — the exact
+    path a real LLM agent uses.  This is the path that was broken before the
+    fix: collect() was triggered by the observer but notify() was never called,
+    so WorkPlanned/ChangeProposed/VerifyResult never reached on_event."""
+
+    def __init__(self, run, events: list, *, name: str = "agent"):
+        self._run = run
+        self._events = list(events)
+        self.name = name
+
+    async def operate(self, *, instruction):
+        if self._events:
+            await self._run.session.emit(self._events.pop(0))
+        return "ok"
+
+
+@pytest.mark.asyncio
+async def test_chain_events_reach_on_event_exactly_once_bus_path(tmp_path, monkeypatch):
+    """Regression for #1361: WorkPlanned, ChangeProposed, and VerifyResult that
+    arrive via the session bus (the real agent path, not run.emit()) must reach
+    on_event exactly once each.  The contract: set of eids delivered to on_event
+    equals set of eids in the run store, and no eid is delivered twice."""
+    eng = CodingEngine(repair_retries=0)
+    run = eng.new_run()
+
+    plan_ev = WorkPlanned(approach="add foo", acceptance_criteria=["foo exists"])
+    change_ev = ChangeProposed(summary="added foo", files_touched=["foo.py"], plan_ref="W-1")
+    verdict_ev = VerifyResult(
+        verdict="APPROVE", rationale="meets criteria", meets_acceptance=True, tests_ref="T-1"
+    )
+
+    # _BusBranch emits via the raw session bus — the bug path
+    branches = {
+        "plan": _BusBranch(run, [plan_ev], name="plan"),
+        "implement": _BusBranch(run, [change_ev], name="implement"),
+        "verify": _BusBranch(run, [verdict_ev], name="verify"),
+    }
+
+    async def fake_make(role, *, name=None, **kw):
+        return branches[name]
+
+    monkeypatch.setattr(run, "make_agent", fake_make)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async(""))
+
+    delivered: list[str] = []
+    run.on_event = lambda e: delivered.append(e["type"])
+
+    result = await eng._run(
+        run,
+        "add a foo function",
+        test_cmd=[sys.executable, "-c", "exit(0)"],
+        workspace=str(tmp_path),
+    )
+
+    assert result.passed is True
+
+    # Every stored chain event kind must be in the delivered stream
+    chain_types = {
+        "WorkPlanned",
+        "ChangeProposed",
+        "TestsRan",
+        "VerifyResult",
+        "CodeResultRecorded",
+    }
+    delivered_set = set(delivered)
+    assert chain_types <= delivered_set, (
+        f"Missing from on_event stream: {chain_types - delivered_set}"
+    )
+
+    # No eid delivered twice (no double-delivery)
+    from collections import Counter
+
+    counts = Counter(delivered)
+    doubled = [k for k, v in counts.items() if k in chain_types and v > 1]
+    assert not doubled, f"Double-delivered chain event types: {doubled}"
+
+
+@pytest.mark.asyncio
+async def test_chain_events_reach_on_event_exactly_once_emit_path(tmp_path, monkeypatch):
+    """Same contract as above but events arrive via run.emit() (the _ScriptedBranch
+    path).  Verifies the emit() override does not suppress delivery for chain events
+    that go through run.emit() (TestsRan, CodeResultRecorded) and that the agent-emit
+    path does not double-deliver WorkPlanned/ChangeProposed/VerifyResult."""
+    eng = CodingEngine(repair_retries=0)
+    run = eng.new_run()
+
+    plan_ev = WorkPlanned(approach="add bar")
+    change_ev = ChangeProposed(summary="added bar", plan_ref="W-1")
+    verdict_ev = VerifyResult(verdict="APPROVE", rationale="ok", meets_acceptance=True)
+
+    branches = {
+        "plan": _ScriptedBranch(run, [plan_ev], name="plan"),
+        "implement": _ScriptedBranch(run, [change_ev], name="implement"),
+        "verify": _ScriptedBranch(run, [verdict_ev], name="verify"),
+    }
+
+    async def fake_make(role, *, name=None, **kw):
+        return branches[name]
+
+    monkeypatch.setattr(run, "make_agent", fake_make)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async(""))
+
+    delivered: list[str] = []
+    run.on_event = lambda e: delivered.append(e["type"])
+
+    result = await eng._run(
+        run,
+        "add a bar function",
+        test_cmd=[sys.executable, "-c", "exit(0)"],
+        workspace=str(tmp_path),
+    )
+
+    assert result.passed is True
+
+    chain_types = {
+        "WorkPlanned",
+        "ChangeProposed",
+        "TestsRan",
+        "VerifyResult",
+        "CodeResultRecorded",
+    }
+    delivered_set = set(delivered)
+    assert chain_types <= delivered_set, (
+        f"Missing from on_event stream: {chain_types - delivered_set}"
+    )
+
+    from collections import Counter
+
+    counts = Counter(delivered)
+    doubled = [k for k, v in counts.items() if k in chain_types and v > 1]
+    assert not doubled, f"Double-delivered chain event types: {doubled}"

--- a/tests/engines/test_hypothesis.py
+++ b/tests/engines/test_hypothesis.py
@@ -264,3 +264,88 @@ async def test_empty_findings_raises():
     eng = HypothesisEngine()
     with pytest.raises(ValueError):
         await eng.run("   ")
+
+
+# ---------------------------------------------------------------------------
+# Regression: #1361 — chain events must reach on_event exactly once
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chain_events_reach_on_event_exactly_once_no_double_delivery():
+    """Regression for #1361: every chain event collected by HypothesisRun must
+    reach on_event exactly once — regardless of whether it arrived via run.emit()
+    (seed FindingPosted) or the session bus (agent-emitted Q/E/H/etc.).
+
+    Contract: set(eids delivered to on_event) == set(eids in run store)
+    and no eid is delivered twice."""
+    eng = HypothesisEngine()
+    run = eng.new_run()
+    # Mute all reactive stages so we control exactly which events land
+    _mute(eng, "extract", "research", "hypothesize", "design", "validate", "conclude", "apply")
+    _wire(eng, run)
+
+    delivered_types: list[str] = []
+    run.on_event = lambda e: delivered_types.append(e["type"])
+
+    # Emit a mix via run.emit() (seed path) and session bus (agent path)
+    await run.emit(FindingPosted(description="seed finding"))  # run.emit path
+    await run.session.emit(QuestionRaised(area="a", what_is_unknown="why X over Y?"))  # bus path
+    await run.session.emit(EvidenceCollected(question_ref="Q-1", description="ev", kind="analysis"))
+    await run.session.emit(
+        HypothesisFormed(question_ref="Q-1", statement="X is faster", metric="ms")
+    )
+    await run.wait_quiescence()
+
+    # Every stored eid must appear in the delivered stream exactly once
+    stored_eids = {e.eid for evs in run.store.values() for e in evs if e.eid}
+    chain_types_seen = {
+        e["type"]
+        for e in [{"type": t} for t in delivered_types]
+        if e["type"]
+        in {
+            "FindingPosted",
+            "QuestionRaised",
+            "EvidenceCollected",
+            "HypothesisFormed",
+            "ExperimentDesigned",
+            "ResultRecorded",
+            "ConclusionDrawn",
+            "ApplicationMapped",
+        }
+    }
+    expected_types = {"FindingPosted", "QuestionRaised", "EvidenceCollected", "HypothesisFormed"}
+    assert expected_types <= chain_types_seen, (
+        f"Missing from on_event stream: {expected_types - chain_types_seen}"
+    )
+
+    # No double delivery: each chain event type should appear exactly once here
+    # (we emitted exactly one of each)
+    from collections import Counter
+
+    counts = Counter(delivered_types)
+    doubled = [k for k, v in counts.items() if k in expected_types and v > 1]
+    assert not doubled, f"Double-delivered chain event types: {doubled}"
+
+    # The stored eids match what was stamped (sanity check)
+    assert len(stored_eids) == 4, f"Expected 4 chain events stored, got {len(stored_eids)}"
+
+
+@pytest.mark.asyncio
+async def test_seed_finding_no_double_delivery_via_run_emit():
+    """Seed FindingPosted goes through run.emit(); the emit() override must not
+    cause a second on_event call for the same event (regression: collect()
+    notifies once, emit() override skips its own call for ChainEvent)."""
+    eng = HypothesisEngine()
+    run = eng.new_run()
+    _mute(eng, "extract")
+    _wire(eng, run)
+
+    delivered: list[dict] = []
+    run.on_event = lambda e: delivered.append(e)
+
+    await run.emit(FindingPosted(description="only seed"))
+    await run.wait_quiescence()
+
+    fp_events = [e for e in delivered if e["type"] == "FindingPosted"]
+    assert len(fp_events) == 1, f"Expected 1 FindingPosted delivery, got {len(fp_events)}"


### PR DESCRIPTION
## Root cause

Chain events in both engines reach the run store via two distinct paths:

1. **`run.emit()` path** (used for seed `FindingPosted` and engine-controlled events like `TestsRan`, `CodeResultRecorded`): calls `collect()` via the session observer, then calls `notify()` explicitly — so `on_event` fires.
2. **Raw session bus path** (the path a real LLM agent uses via `branch.operate()`): fires the observer → `collect()` only. `notify()` is never called.

`WorkPlanned`, `ChangeProposed`, and `VerifyResult` exclusively travel path 2. They are stamped and stored but never reach `on_event`. `HypothesisEngine` has the identical gap: agent-emitted `QuestionRaised`, `EvidenceCollected`, `HypothesisFormed`, etc. were silently dropped from the stream. Only seed `FindingPosted` events (which go through `run.emit()`) were delivered.

## Fix

- Move the `notify()` call into `collect()` — the single stamping point reached by **both** paths.
- Override `emit()` in `CodingRun` and `HypothesisRun` to **skip the base-class `notify()` for chain events**, preventing double-delivery for `TestsRan`/`CodeResultRecorded` (which also travel `run.emit()`).
- Add `_safe_event_dict()` helper in `engine.py` to rename the `kind` field on `EvidenceCollected` (which would otherwise clash with `notify(kind, **data)`).

**Files changed**: `engine.py` (+12 LOC), `coding.py` (+20 LOC), `hypothesis.py` (+20 LOC), plus regression tests in both test modules.

## Contract after the fix

- `set(chain-event types delivered to on_event)` == `set(chain-event types in the run store)` for both engines
- No event type is delivered twice (enforced by regression assertions)
- Existing non-chain notifications (`testing`, `concluded`, `fix_exhausted`, `stage_error`, …) are unchanged

## Test evidence

- `tests/engines/` — **99 passed** (0 failed), including 4 new regression tests:
  - `test_chain_events_reach_on_event_exactly_once_bus_path` — bus path (the actual bug path)
  - `test_chain_events_reach_on_event_exactly_once_emit_path` — emit path (no double-delivery)
  - `test_chain_events_reach_on_event_exactly_once_no_double_delivery` — HypothesisEngine bus + emit mix
  - `test_seed_finding_no_double_delivery_via_run_emit` — seed FindingPosted no double-delivery
- `tests/engines/ tests/casts/ tests/agent/` — **434 passed**

Closes #1361

🤖 Generated with [Claude Code](https://claude.com/claude-code)