### PR TITLE
refactor(operate): consolidate Operative construction; document HookPoint dispatch status

### DIFF
--- a/lionagi/hooks/bus.py
+++ b/lionagi/hooks/bus.py
@@ -30,7 +30,32 @@ __all__ = (
 
 
 class HookPoint(str, Enum):
-    """Closed vocabulary of hook points."""
+    """Closed vocabulary of hook points.
+
+    Dispatched (production callsites that call ``bus.emit`` or
+    ``bus.blocking_emit`` with this point):
+
+    * ``MESSAGE_ADD``  — branch.py ``_persist_via_bus`` on every inbound message.
+
+    Registered in ``DEFAULT_HOOKS`` (handlers wired, but the emit callsite is
+    deferred to ADR-0023b; wiring is in-progress):
+
+    * ``SESSION_START``  — ``persist_session_start`` registered, emit pending.
+    * ``SESSION_END``    — ``persist_session_end`` registered, emit pending.
+    * ``BRANCH_CREATE``  — ``persist_branch_provenance`` registered, emit pending.
+
+    Reserved — defined for vocabulary completeness, no handler registered and no
+    emit callsite exists yet (planned future hook surfaces, per ADR-0023):
+
+    * ``API_PRE_CALL``    — before each iModel API call.
+    * ``API_POST_CALL``   — after each iModel API call (tokens / latency).
+    * ``API_STREAM_CHUNK`` — per-chunk during streaming responses.
+    * ``TOOL_PRE``        — before tool invocation; intended to be blocking
+                           (``blocking_emit`` route already wired in bus.py).
+    * ``TOOL_POST``       — after successful tool invocation.
+    * ``TOOL_ERROR``      — on tool invocation failure.
+    * ``ARTIFACT_CREATED`` — when an artifact is persisted to disk.
+    """
 
     SESSION_START = "session.start"
     SESSION_END = "session.end"

--- a/lionagi/operations/operate/operate.py
+++ b/lionagi/operations/operate/operate.py
@@ -311,7 +311,11 @@ async def operate(
     # Handle actions. Middle may return a BaseModel (structured), a dict
     # (fuzzy-parsed), or a raw str (CLI text path with no response_format).
     # Only dicts and BaseModels can carry action_requests — raw text can't.
-    if model_class:
+    # Inspect ANY BaseModel result, not just model_class matches: actions=True
+    # with no caller response_format materializes a generated operative type
+    # while model_class stays None, and gating on model_class silently
+    # skipped tool invocation for that path (codex round-2 regression).
+    if isinstance(result, BaseModel):
         requests = getattr(result, "action_requests", None)
     elif isinstance(result, dict):
         requests = result.get("action_requests")
@@ -333,16 +337,20 @@ async def operate(
     if not action_response_models:
         return result
 
-    if not model_class:
-        # Dict response: merge action_responses in. Raw-text results stay
-        # untouched (text has no structured slot for action_responses).
-        if isinstance(result, dict):
-            result["action_responses"] = action_response_models
-        return result
+    # Structured results merge through the operative (single construction
+    # path above).  Gate on the operative + a BaseModel result rather than
+    # model_class: actions=True with no caller response_format constructs an
+    # operative while model_class stays None, and gating on model_class
+    # returned the result with action_responses unmerged (codex round-2).
+    if operative is not None and isinstance(result, BaseModel):
+        # First set the response_model to the existing result
+        operative.response_model = result
+        # Then update it with action_responses
+        operative.update_response_model(data={"action_responses": action_response_models})
+        return operative.response_model
 
-    # If we have model_class, operative was constructed above (single path).
-    # First set the response_model to the existing result
-    operative.response_model = result
-    # Then update it with action_responses
-    operative.update_response_model(data={"action_responses": action_response_models})
-    return operative.response_model
+    # Dict response: merge action_responses in. Raw-text results stay
+    # untouched (text has no structured slot for action_responses).
+    if isinstance(result, dict):
+        result["action_responses"] = action_response_models
+    return result

--- a/lionagi/operations/operate/operate.py
+++ b/lionagi/operations/operate/operate.py
@@ -105,25 +105,6 @@ def prepare_operate_kw(
         if action_strategy:
             instruct.action_strategy = action_strategy
 
-    fields_dict = _specs_from_fields(field_models)
-
-    # Build Operative if needed
-    operative = None
-    if instruct.reason or instruct.actions or response_format or fields_dict:
-        from .step import Step
-
-        operative = Step.request_operative(
-            base_type=response_format,
-            reason=instruct.reason,
-            actions=instruct.actions or actions,
-            fields=fields_dict,
-        )
-
-        # Create response model
-        operative = Step.respond_operative(operative)
-
-    final_response_format = operative.response_type if operative else response_format
-
     # Choose ChatParam vs RunParam. RunParam is required when the middle
     # streams via run() (CLI endpoints, explicit stream_persist, or when
     # caller passes a middle that needs persist_dir). Defaulting to
@@ -137,7 +118,7 @@ def prepare_operate_kw(
         context=instruct.context,
         sender=sender or branch.user or "user",
         recipient=recipient or branch.id,
-        response_format=final_response_format,
+        response_format=response_format,
         progression=progression,
         tool_schemas=tool_schemas,
         images=images,
@@ -157,11 +138,11 @@ def prepare_operate_kw(
     chat_param = param_cls(**param_kw)
 
     parse_param = None
-    if final_response_format and not skip_validation:
+    if response_format and not skip_validation:
         from ..parse.parse import get_default_call
 
         parse_param = ParseParam(
-            response_format=final_response_format,
+            response_format=response_format,
             fuzzy_match_params=FuzzyMatchKeysParams(),
             handle_validation=handle_validation,
             alcall_params=get_default_call(),
@@ -192,6 +173,8 @@ def prepare_operate_kw(
         "clear_messages": clear_messages,
         "operative": operative,
         "middle": middle,
+        "field_models": field_models,
+        "reason": instruct.reason,
     }
 
 
@@ -262,8 +245,11 @@ async def operate(
 
     fields_dict = _specs_from_fields(field_models)
 
-    # Create operative if needed
-    if not operative and (model_class or action_param or fields_dict):
+    # Create operative if needed. This is the single construction path for all
+    # callers — both Branch.operate (via prepare_operate_kw) and direct callers
+    # such as ReAct. prepare_operate_kw forwards field_models and reason so
+    # that this block has full information regardless of call path.
+    if not operative and (model_class or action_param or fields_dict or reason):
         from .step import Step
 
         operative = Step.request_operative(
@@ -274,7 +260,8 @@ async def operate(
         )
         operative = Step.respond_operative(operative)
 
-        # Update contexts
+        # Update contexts with the derived response type so the API call
+        # and the parse step use the materialized Pydantic model.
         response_fmt = operative.response_type or model_class
         if response_fmt:
             _cctx = _cctx.with_updates(response_format=response_fmt)
@@ -353,7 +340,7 @@ async def operate(
             result["action_responses"] = action_response_models
         return result
 
-    # If we have model_class, we must have operative (created at line 268)
+    # If we have model_class, operative was constructed above (single path).
     # First set the response_model to the existing result
     operative.response_model = result
     # Then update it with action_responses

--- a/lionagi/operations/operate/operate.py
+++ b/lionagi/operations/operate/operate.py
@@ -171,7 +171,13 @@ def prepare_operate_kw(
         "invoke_actions": invoke_actions,
         "skip_validation": skip_validation,
         "clear_messages": clear_messages,
-        "operative": operative,
+        # The public Branch.operate() path has always discarded a caller
+        # supplied operative (main set `operative = None` before building its
+        # own).  Forwarding it would skip the single-construction block below
+        # and merge results through a model that may not match the requested
+        # response/action shape, silently dropping response fields.  Only
+        # direct operate() callers (e.g. ReAct) may supply an operative.
+        "operative": None,
         "middle": middle,
         "field_models": field_models,
         "reason": instruct.reason,

--- a/tests/operations/test_operate.py
+++ b/tests/operations/test_operate.py
@@ -117,10 +117,15 @@ from lionagi.operations.operate.operate import prepare_operate_kw
 
 
 def test_prepare_operate_kw_rejects_invalid_field_model_entry():
-    """field_models list containing a non-FieldModel/Spec raises TypeError."""
+    """field_models containing a non-FieldModel/Spec is passed through to
+    operate() where _specs_from_fields raises TypeError. prepare_operate_kw
+    no longer validates field_models itself (single-construction path is in
+    operate()). Verify the invalid entry is forwarded in the returned dict."""
     branch = Branch()
-    with pytest.raises(TypeError, match="Expected FieldModel or Spec"):
-        prepare_operate_kw(branch, field_models=[object()])
+    result = prepare_operate_kw(branch, field_models=[object()])
+    # field_models is forwarded unchanged; error surfaces later in operate()
+    assert result["field_models"] is not None
+    assert len(result["field_models"]) == 1
 
 
 @pytest.mark.asyncio
@@ -166,28 +171,34 @@ def test_prepare_operate_kw_instruct_as_dict():
 
 
 def test_prepare_operate_kw_reason_flag_sets_instruct_reason():
-    """reason=True sets instruct.reason=True (line 116)."""
+    """reason=True is forwarded to operate() via the return dict (reason key)
+    so the single construction path in operate() can build the Operative.
+    prepare_operate_kw no longer constructs the Operative itself."""
     branch = Branch()
     result = prepare_operate_kw(branch, reason=True)
-    # operative is built because reason=True
-    assert result["operative"] is not None
+    # operative construction is deferred to operate(); reason is forwarded
+    assert result["reason"] is True
+    assert result["operative"] is None
 
 
 def test_prepare_operate_kw_field_models_with_fieldmodel():
-    """FieldModel in field_models is converted to Spec (line 129)."""
+    """FieldModel in field_models is forwarded as-is to operate() where
+    _specs_from_fields converts it to a Spec for Operative construction."""
     branch = Branch()
     fm = FieldModel(name="score", annotation=float)
     result = prepare_operate_kw(branch, field_models=[fm])
-    # operative is built because fields_dict is non-empty
-    assert result["operative"] is not None
+    # field_models forwarded; Operative built lazily in operate()
+    assert result["field_models"] == [fm]
+    assert result["operative"] is None
 
 
 def test_prepare_operate_kw_field_models_with_spec():
-    """Spec in field_models is used directly (line 131)."""
+    """Spec in field_models is forwarded unchanged to operate()."""
     branch = Branch()
     spec = Spec(name="label", annotation=str)
     result = prepare_operate_kw(branch, field_models=[spec])
-    assert result["operative"] is not None
+    assert result["field_models"] == [spec]
+    assert result["operative"] is None
 
 
 def test_prepare_operate_kw_persist_dir_sets_run_param():

--- a/tests/operations/test_operate.py
+++ b/tests/operations/test_operate.py
@@ -151,6 +151,51 @@ async def test_operate_actions_only_invokes_tools_without_response_format():
     assert result.action_responses[0].output == 3
 
 
+async def test_branch_operate_ignores_caller_supplied_operative():
+    """Regression (codex round-3): Branch.operate() discards a caller-supplied
+    operative, matching main's prepare-time `operative = None`.
+
+    Forwarding it would skip single construction and merge through a
+    mismatched model, silently dropping the requested response fields."""
+    from lionagi.operations.operate.step import Step
+
+    class ResponseModel(BaseModel):
+        answer: str
+
+    def add(a: int, b: int) -> int:
+        """Add two numbers."""
+        return a + b
+
+    mismatched = Step.respond_operative(Step.request_operative(reason=True))
+
+    branch = LionAGIMockFactory.create_mocked_branch(
+        name="OperativeIgnoreTest",
+        user="tester",
+        response="""{
+            "answer": "42",
+            "action_required": true,
+            "action_requests": [
+                {"function": "add", "arguments": {"a": 1, "b": 2}}
+            ]
+        }""",
+        model="gpt-4.1-mini",
+        tools=[add],
+    )
+
+    result = await branch.operate(
+        instruction="Calculate something",
+        response_format=ResponseModel,
+        actions=True,
+        invoke_actions=True,
+        operative=mismatched,
+    )
+
+    # The requested response shape wins; the mismatched operative is ignored.
+    assert result.answer == "42"
+    assert len(result.action_responses) == 1
+    assert result.action_responses[0].output == 3
+
+
 # ---------------------------------------------------------------------------
 # Edge cases for prepare_operate_kw (P0)
 # ---------------------------------------------------------------------------

--- a/tests/operations/test_operate.py
+++ b/tests/operations/test_operate.py
@@ -109,6 +109,48 @@ async def test_operate_with_actions_preserves_response_data():
     assert result.action_responses[0].function == "add"
 
 
+async def test_operate_actions_only_invokes_tools_without_response_format():
+    """Regression (codex round-2): actions=True with NO caller response_format
+    must still invoke tools.
+
+    The single-construction refactor extracted model_class only from the
+    original chat_param.response_format; for action-only calls that left
+    model_class None, so action_requests on the generated operative BaseModel
+    were never extracted and act() was silently skipped.
+    """
+
+    def add(a: int, b: int) -> int:
+        """Add two numbers."""
+        return a + b
+
+    branch = LionAGIMockFactory.create_mocked_branch(
+        name="ActionOnlyTest",
+        user="tester",
+        response="""{
+            "action_required": true,
+            "action_requests": [
+                {"function": "add", "arguments": {"a": 1, "b": 2}}
+            ]
+        }""",
+        model="gpt-4.1-mini",
+        tools=[add],
+    )
+
+    result = await branch.operate(
+        instruction="Calculate something",
+        actions=True,
+        invoke_actions=True,
+    )
+
+    assert hasattr(result, "action_responses"), (
+        "action_responses missing — act() was skipped for the "
+        "actions-only (no response_format) path"
+    )
+    assert len(result.action_responses) == 1
+    assert result.action_responses[0].function == "add"
+    assert result.action_responses[0].output == 3
+
+
 # ---------------------------------------------------------------------------
 # Edge cases for prepare_operate_kw (P0)
 # ---------------------------------------------------------------------------

--- a/tests/operations/test_operate.py
+++ b/tests/operations/test_operate.py
@@ -404,3 +404,85 @@ async def test_operate_with_field_models_builds_operative():
         middle=fake_middle,
     )
     assert result == {"label": "test_value"}
+
+
+# ---------------------------------------------------------------------------
+# Finding 3 replacement: TypeError raised at new boundary (_specs_from_fields)
+# before any model call is reached.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_operate_invalid_field_models_raises_before_model_call():
+    """operate() raises TypeError('Expected FieldModel or Spec') for invalid
+    field_models entries at _specs_from_fields() (operate.py:246), i.e. BEFORE
+    the middle/model layer is invoked.  A mock middle is injected that fails
+    loudly if called — ensuring a missed raise would be detected."""
+    branch = Branch()
+
+    async def _should_not_be_called(*args, **kwargs):
+        pytest.fail("middle was called — TypeError was NOT raised before the model call")
+
+    chat_param = ChatParam(imodel=branch.chat_model)
+
+    with pytest.raises(TypeError, match="Expected FieldModel or Spec"):
+        await operate(
+            branch,
+            "test_invalid_field_models",
+            chat_param,
+            field_models=[object()],  # invalid entry — not FieldModel or Spec
+            skip_validation=False,
+            invoke_actions=False,
+            middle=_should_not_be_called,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Lock-in: reason=True alone (no response_format / actions / field_models)
+# takes the Operative-construction branch (operate.py:252).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_operate_reason_only_constructs_operative_with_reason_field():
+    """operate(..., reason=True) with no response_format/actions/field_models
+    must enter the Operative-construction branch (operate.py:252) and produce
+    a response_format that includes a 'reason' field.  The generated response
+    type is injected into _cctx before middle is called, so we capture it."""
+    branch = Branch()
+
+    captured_response_format = {}
+
+    async def capturing_middle(b, ins, cctx, pctx, clear, **kw):
+        # Capture the response_format that operate() materialised for this call.
+        captured_response_format["fmt"] = cctx.response_format
+        # Return a minimal instance of the captured model so downstream code
+        # does not raise on type checks.
+        if cctx.response_format is not None:
+            try:
+                return cctx.response_format()
+            except Exception:
+                pass
+        return {}
+
+    chat_param = ChatParam(imodel=branch.chat_model)
+    await operate(
+        branch,
+        "reason only test",
+        chat_param,
+        reason=True,
+        skip_validation=True,
+        invoke_actions=False,
+        middle=capturing_middle,
+    )
+
+    fmt = captured_response_format.get("fmt")
+    assert fmt is not None, (
+        "reason=True should have triggered Operative construction and set a "
+        "response_format on the chat context"
+    )
+    # The materialised model must have a 'reason' field.
+    assert "reason" in fmt.model_fields, (
+        f"'reason' field missing from generated response_format {fmt}; "
+        "Operative was not constructed or reason spec was dropped"
+    )


### PR DESCRIPTION
## Summary

- **R1-5 item 1 — Operative double-construction eliminated**: `prepare_operate_kw()` previously contained a complete duplicate of the `Step.request_operative / Step.respond_operative` call sequence that also exists in `operate()`. The duplicate block (~16 LOC) is removed; `field_models` and `reason` are now forwarded in the `prepare_operate_kw()` return dict so `operate()` has full information from all call paths (via `Branch.operate` or direct ReAct calls). No behaviour change — same inputs produce the same Operative via the same factory calls.

- **R1-5 item 2 — HookPoint enum documented**: The `HookPoint` enum in `hooks/bus.py` gains a docstring recording the dispatched/reserved split, established by grepping every `_hooks.emit` and `bus.emit` callsite in production code (result: only `MESSAGE_ADD` is dispatched today).

## HookPoint dispatch/reserved split (grep evidence)

Production `_hooks.emit` / `bus.emit` callsites found:

| Point | Status | Evidence |
|-------|--------|---------|
| `MESSAGE_ADD` | **Dispatched** | `branch.py:296` `await self._hooks.emit(HookPoint.MESSAGE_ADD, ...)` |
| `SESSION_START` | Registered, emit pending ADR-0023b | `loader.py:46` default handler registered; no emit callsite |
| `SESSION_END` | Registered, emit pending ADR-0023b | `loader.py:47` default handler registered; no emit callsite |
| `BRANCH_CREATE` | Registered, emit pending ADR-0023b | `loader.py:49` default handler registered; no emit callsite |
| `API_PRE_CALL` | **Reserved** | enum only; no handler, no emit callsite |
| `API_POST_CALL` | **Reserved** | enum only; `log_api_metrics` in registry but not in DEFAULT_HOOKS and never emitted |
| `API_STREAM_CHUNK` | **Reserved** | enum only |
| `TOOL_PRE` | **Reserved** | referenced in `bus.py:118` for routing logic only; no production emit callsite |
| `TOOL_POST` | **Reserved** | enum only |
| `TOOL_ERROR` | **Reserved** | enum only |
| `ARTIFACT_CREATED` | **Reserved** | enum only |

## Conflict avoidance

`run.py` and `session/branch.py` are untouched per the conflict-awareness note regarding PR #1373.

## Test plan

- [x] `uv run pytest tests/operations/ tests/session/ -q` — **755 passed**
- [x] 4 unit tests in `test_operate.py` updated to reflect the new contract: `prepare_operate_kw` forwards `field_models`/`reason` rather than returning a pre-built operative
- [x] No changes to `run.py` or `session/branch.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)