### PR TITLE
fix(codex): surface top-level error message (usage-limit errors rendered as 'RuntimeError: {}')

### DIFF
--- a/lionagi/providers/openai/codex/models.py
+++ b/lionagi/providers/openai/codex/models.py
@@ -711,8 +711,14 @@ async def stream_codex_cli(
             elif typ in ("turn.failed", "error"):
                 session.is_error = True
                 err = obj.get("error", {})
+                # The CLI puts the human-readable message in different spots
+                # depending on event type: "error" events carry a TOP-LEVEL
+                # "message" with no "error" key (e.g. usage-limit errors), while
+                # "turn.failed" nests it under error.message.  Check both —
+                # otherwise a top-level-message error renders as the useless
+                # str() of an empty dict and the actionable text is discarded.
                 session.result = (
-                    err.get("message", str(err))
+                    (err.get("message") or obj.get("message") or str(err))
                     if isinstance(err, dict)
                     else obj.get("message", str(err))
                 )

--- a/tests/providers/openai/codex/test_benign_eos.py
+++ b/tests/providers/openai/codex/test_benign_eos.py
@@ -177,3 +177,48 @@ async def test_error_event_without_error_key_is_not_benign():
     assert len(chunks) == 1
     assert chunks[0].type == "error"
     assert not chunks[0].metadata.get("benign_eos")
+
+
+@pytest.mark.asyncio
+async def test_error_event_with_toplevel_message_surfaces_the_message():
+    """An "error" event carrying its message at the TOP LEVEL (no "error" key)
+    — the shape the codex CLI emits for usage-limit errors — must surface the
+    actual message as chunk content, not the str() of an empty error dict.
+
+    Real-world shape:
+        {"type": "error", "message": "You've hit your usage limit. ..."}
+    """
+    msg = (
+        "You've hit your usage limit. Visit "
+        "https://chatgpt.com/codex/settings/usage to purchase more credits."
+    )
+    events = [{"type": "error", "message": msg}]
+    chunks = await _chunks_from_events(events)
+
+    assert len(chunks) == 1
+    error_chunk = chunks[0]
+    assert error_chunk.type == "error"
+    assert not error_chunk.metadata.get("benign_eos")
+    assert error_chunk.content == msg, (
+        f"actionable message discarded: content={error_chunk.content!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_turn_failed_with_nested_message_still_preferred_over_toplevel():
+    """turn.failed keeps its nested error.message as the surfaced content even
+    when a top-level "message" is also present — the nested one is the
+    provider's canonical detail for that event type."""
+    events = [
+        {
+            "type": "turn.failed",
+            "message": "outer",
+            "error": {"message": "inner detail"},
+        }
+    ]
+    chunks = await _chunks_from_events(events)
+
+    assert len(chunks) == 1
+    assert chunks[0].type == "error"
+    assert not chunks[0].metadata.get("benign_eos")
+    assert chunks[0].content == "inner detail"


### PR DESCRIPTION
Closes #1387 (codex path — the observed failure mode).

Codex CLI emits usage-limit errors as `{"type": "error", "message": "You've hit your usage limit..."}` — top-level `message`, no `error` key. The adapter read only the (empty) nested error dict, so `session.result` became `str({})` = `"{}"`, and both raise sites in run.py (line ~228 and ~317) threw `RuntimeError: {}` with the actionable text discarded. Four live occurrences on 2026-06-10, confirmed by direct `codex exec` probe.

Fix: prefer `error.message` → top-level `message` → `str(err)`. `turn.failed` keeps nested `error.message` as canonical. The benign-EOS predicate is untouched — it correctly treated the quota failure as real rather than swallowing it as clean EOS.

Meets #1387's acceptance: a quota-exhausted codex run now raises with the words "usage limit" in the message. The issue's fuller sketch (typed QuotaExceeded errors, stderr-tail preservation, claude_code/gemini sweep) is follow-up scope — if wanted I'd keep #1387 open re-titled or file a fresh issue for the typed-error layer.

Two regression tests pin the real-world shapes; FAIL-before verified; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)