### PR TITLE
ci(docs): serialize gh-pages deploys with a concurrency group

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -9,6 +9,12 @@ on:
 permissions:
   contents: write
 
+# gh-deploy force-pushes gh-pages; concurrent runs race on the ref and the
+# loser fails with "cannot lock ref". Only the newest commit's docs matter.
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem
The five squash-merges this afternoon landed within 14 seconds; each push to main fired its own **Deploy Documentation** run. `mkdocs gh-deploy --force` force-pushes `gh-pages`, so two concurrent runs raced on the ref and the later one failed:

```
! [remote rejected] gh-pages -> gh-pages (cannot lock ref 'refs/heads/gh-pages': is at 9831f01... but expected b3c458d...)
```

That left main's checks red on the tip commit even though CI + Benchmarks were green.

## Fix
`concurrency: {group: docs-deploy, cancel-in-progress: true}` — stale deploys cancel, only the newest commit's docs deploy. The failed tip run was also re-run manually and the docs are current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)