### PR TITLE
feat(session): canonical lifecycle signal contract + lane projection

### DIFF
--- a/docs/adrs/ADR-0083-lifecycle-signal-contract.md
+++ b/docs/adrs/ADR-0083-lifecycle-signal-contract.md
@@ -65,6 +65,14 @@ the state from any terminal (`succeeded | failed | escalated`) back to
 `NodeStarted / NodeCompleted / NodeFailed` (existing) cover `running /
 succeeded / failed` and require no changes.
 
+**`op_id` is the only stable key.** The `name` field is an informational
+display label and is NOT normative for grouping or identity: emitters may
+derive it from the node's `reference_id` (queue time, before a branch is
+assigned) or from the executing branch's name (execution time — the existing
+contract consumed by the CLI heartbeat display). Observers MUST group and
+project by `op_id`; a node's `name` may legitimately differ across its own
+lifecycle signals.
+
 ### 3. Projection helper: `lane_for`
 
 ```python

--- a/docs/adrs/ADR-0083-lifecycle-signal-contract.md
+++ b/docs/adrs/ADR-0083-lifecycle-signal-contract.md
@@ -1,0 +1,173 @@
+# ADR-0083: Canonical Per-Node Lifecycle Signal Contract
+
+**Status**: Accepted
+**Date**: 2026-06-10
+**Implements**: GitHub #1251
+**Builds on**: ADR-0076 (observer as hook transport) · ADR-0072 (reactive capability bus)
+
+## Context
+
+The signals introduced in ADR-0072 and extended in ADR-0076 (`NodeStarted`,
+`NodeCompleted`, `NodeFailed`, `GateDenied`, `RunStart`, `RunEnd`, …) are
+ad-hoc to specific execution paths. Any subscriber that wants to derive a
+node's current state — a progress board, an audit log, a test assertion —
+must parse the signal stream with bespoke conditionals and tolerate gaps:
+
+- There is no `queued` signal to mark when a node enters the runnable graph
+  (including injected `SpawnRequest` children).
+- There is no `awaiting_approval` signal to distinguish "paused for a gate
+  decision" from "still running".
+- There is no `escalated` signal to mark nodes that emitted an
+  `EscalationRequest` and are waiting for re-dispatch or give-up.
+
+The result is that a subscriber reading the observer's `Flow` cannot
+determine the node's current lifecycle lane without coupling to the
+executor's internal dispatch logic.
+
+## Decision
+
+Define a **canonical per-node lifecycle** with six states and a
+**projection helper** that reduces any ordered, single-node signal stream
+to its current lane.
+
+### 1. Canonical states
+
+```python
+NodeLifecycleState = Literal[
+    "queued", "running", "awaiting_approval", "succeeded", "failed", "escalated"
+]
+```
+
+The natural transition graph:
+
+```text
+queued ──► running ──► succeeded
+               │
+               ├──► awaiting_approval ──► running (approval granted)
+               │
+               ├──► failed
+               │
+               └──► escalated
+```
+
+A node may retry: a subsequent `NodeQueued` or `NodeStarted` signal resets
+the state from any terminal (`succeeded | failed | escalated`) back to
+`queued` or `running` for the new attempt.
+
+### 2. Three new signals completing the contract
+
+| Signal | State | When to emit |
+|--------|-------|--------------|
+| `NodeQueued(op_id, name, elapsed=0.0)` | `queued` | When a node enters the runnable graph, including `SpawnRequest` injections. |
+| `NodeAwaitingApproval(op_id, name, reason=None)` | `awaiting_approval` | Immediately before a blocking gate/approval wait. |
+| `NodeEscalated(op_id, name, reason, route)` | `escalated` | When an `EscalationRequest` is routed — `route="higher_tier"` if re-dispatch is scheduled, `route="give_up"` if no escalation path is configured. |
+
+`NodeStarted / NodeCompleted / NodeFailed` (existing) cover `running /
+succeeded / failed` and require no changes.
+
+### 3. Projection helper: `lane_for`
+
+```python
+def lane_for(signals: Iterable[Signal | Any]) -> NodeLifecycleState:
+    """Project an ordered, single-node signal stream into its current lane."""
+```
+
+Invariants:
+
+- **Default** state for an empty or non-state-bearing stream is `"queued"`.
+- **Latest wins**: the last state-bearing signal governs.
+- **Terminal sticky**: once `succeeded | failed | escalated` is reached,
+  only a subsequent `NodeQueued` or `NodeStarted` (a new attempt) can reset
+  it. Other signals are ignored.
+- Callers must **pre-filter** signals to a single `op_id` before calling
+  `lane_for`; the helper does not group by node id.
+
+### 4. Signal-to-state mapping
+
+| Signal or condition | Projected state | Notes |
+|---------------------|-----------------|-------|
+| (empty stream) | `queued` | Default. |
+| `NodeQueued` | `queued` | New — see §2. |
+| `NodeStarted` | `running` | Existing. |
+| `RunStart` | `running` | Run-scoped fallback; valid for single-run cards. |
+| `NodeAwaitingApproval` | `awaiting_approval` | New — see §2. |
+| `NodeCompleted` | `succeeded` | Existing. |
+| `RunEnd` | `succeeded` | Run-scoped fallback. |
+| `NodeFailed` | `failed` | Existing. |
+| `RunFailed` | `failed` | Existing. |
+| `NodeEscalated` | `escalated` | New — see §2. |
+| `StructuredOutput(data=EscalationRequest)` | `escalated` | Capability-emission path before `NodeEscalated` is issued. |
+| `GateDenied` | *(ignored)* | Governance detail; may trigger `NodeAwaitingApproval` upstream but is not a lane by itself. |
+| `MessageAdded`, `HookSignal`, others | *(ignored)* | Not state-bearing. |
+| `EventStatus.SKIPPED / CANCELLED / ABORTED` | `failed` (v1) | Mapped conservatively until a `cancelled` lane is added in a follow-up. |
+
+### 5. Location
+
+All new symbols live in `lionagi/session/signal.py` and are exported from
+`lionagi/session/__init__.py`. No new module is introduced. The existing
+`Signal` hierarchy is extended directly.
+
+## Consequences
+
+**Positive**
+
+- Any subscriber (board, dashboard, audit, test) calls `lane_for(signals)`
+  and gets a stable, typed state — no bespoke parser per consumer.
+- `NodeQueued` closes the gap for `SpawnRequest`-injected children that had
+  no observable queued state.
+- `NodeEscalated` makes escalation visible in the audit `Flow` without
+  requiring observers to parse `EscalationRequest` payloads.
+- `NodeAwaitingApproval` distinguishes "blocked on approval" from "still
+  running", enabling time-to-approval metrics.
+- Zero breaking changes: existing signals are unmodified; new signals are
+  additive. Subscribers not yet emitting new signals get `"queued"` as the
+  default, which is conservative and correct.
+
+**Negative**
+
+- Emitters (executor, reactive flow) must be updated to emit `NodeQueued`
+  at the right seams. Until that wiring lands, the default state for
+  un-instrumented nodes is `"queued"` (acceptable conservative fallback).
+- `lane_for` trusts signal ordering. Out-of-order delivery (rare on a
+  synchronous in-process bus) could misproject state.
+
+## Bridge points wired in this ADR
+
+| Location | Signal | When |
+|----------|--------|------|
+| `engines/engine.py` `_on_progress` | `NodeQueued` | `status=="queued"` callback from flow |
+| `operations/flow.py` `DependencyAwareExecutor.execute()` | via `on_progress` callback | Before `_alcall` on initial nodes |
+| `operations/flow.py` `ReactiveExecutor.execute()` | via `on_progress` callback | Before `tg.start_soon` for each initial node |
+| `operations/flow.py` `ReactiveExecutor.execute_stream()` | via `on_progress` callback | Before `tg.start_soon` for each initial node (inside `_driver`) |
+| `operations/flow.py` `ReactiveExecutor._accept_node()` | via `on_progress` callback | After `_assign_injected_branch` for injected children |
+
+`NodeAwaitingApproval` live emission is deferred to a future approval-gate
+feature (no blocking gate seam exists in the current execution path).
+
+## Follow-ups (not in this landing)
+
+1. **Wire `NodeAwaitingApproval`** before any blocking gate wait (ADR-0076
+   Follow-up — the real pre-invoke gate).
+2. **Wire `NodeEscalated`** in the escalation routing handler when an
+   `EscalationRequest` is routed (ships with the escalation routing slice).
+3. Add a `cancelled` lane for `EventStatus.CANCELLED / ABORTED` if the
+   scope is expanded.
+4. `lane_for` does not group by `op_id`; a higher-level helper that
+   segments a mixed-node stream by id and projects each may be needed for
+   whole-run dashboards.
+
+## Alternatives Considered
+
+| Alternative | Why rejected |
+|-------------|--------------|
+| Add state fields to existing signals | Breaks existing observers keyed on `NodeStarted` etc.; conflates transport with state machine. |
+| Dedicated `NodeLifecycleEvent` with an enum field | Replaces the typed-signal pattern ADR-0072 established without benefit; loses the `observe(NodeCompleted)` ergonomic. |
+| Leave projection to each subscriber | The current state that motivated this ADR; bespoke parsers drift and diverge. |
+| `verifying / verified / cancelled` from the issue text | The flow instruction narrows the required states to six; the broader set is deferred (see Follow-up 3). |
+
+## References
+
+- [ADR-0072](ADR-0072-reactive-capability-bus.md) — reactive capability bus
+- [ADR-0076](ADR-0076-observer-as-hook-transport.md) — observer as hook transport
+- `lionagi/session/signal.py` — `NodeQueued`, `NodeAwaitingApproval`, `NodeEscalated`, `lane_for`
+- `tests/session/test_lifecycle_signals.py` — contract tests

--- a/docs/adrs/ADR-0083-lifecycle-signal-contract.md
+++ b/docs/adrs/ADR-0083-lifecycle-signal-contract.md
@@ -99,7 +99,8 @@ Invariants:
 | `StructuredOutput(data=EscalationRequest)` | `escalated` | Capability-emission path before `NodeEscalated` is issued. |
 | `GateDenied` | *(ignored)* | Governance detail; may trigger `NodeAwaitingApproval` upstream but is not a lane by itself. |
 | `MessageAdded`, `HookSignal`, others | *(ignored)* | Not state-bearing. |
-| `EventStatus.SKIPPED / CANCELLED / ABORTED` | `failed` (v1) | Mapped conservatively until a `cancelled` lane is added in a follow-up. |
+| `EventStatus.SKIPPED` | `failed` (v1) | `_execute_operation` emits `on_progress(..., "failed")` in the skip path, producing `NodeFailed` on the bus. Conservative mapping until a `cancelled` lane is added. |
+| `EventStatus.CANCELLED / ABORTED` | *(not emitted in v1)* | These statuses are raised as exceptions and propagate up the call stack; no signal is emitted for them in the current executor. A `cancelled` lane is deferred to a follow-up. |
 
 ### 5. Location
 
@@ -130,13 +131,20 @@ All new symbols live in `lionagi/session/signal.py` and are exported from
   un-instrumented nodes is `"queued"` (acceptable conservative fallback).
 - `lane_for` trusts signal ordering. Out-of-order delivery (rare on a
   synchronous in-process bus) could misproject state.
+- In the batch executor (`DependencyAwareExecutor`), `NodeQueued` is emitted
+  for all nodes upfront before any dependency check, so it means "entered the
+  runnable graph" rather than "dependencies met". This is intentional v1
+  semantics and consistent with the ADR definition; a future "ready" lane
+  could close the gap if needed.
 
 ## Bridge points wired in this ADR
 
 | Location | Signal | When |
 |----------|--------|------|
 | `engines/engine.py` `_on_progress` | `NodeQueued` | `status=="queued"` callback from flow |
+| `engines/engine.py` `_on_progress` | `NodeFailed` | `status=="failed"` — covers both execution failure and skipped nodes |
 | `operations/flow.py` `DependencyAwareExecutor.execute()` | via `on_progress` callback | Before `_alcall` on initial nodes |
+| `operations/flow.py` `DependencyAwareExecutor._execute_operation()` | via `on_progress("failed")` | In the skip path when edge conditions are not met |
 | `operations/flow.py` `ReactiveExecutor.execute()` | via `on_progress` callback | Before `tg.start_soon` for each initial node |
 | `operations/flow.py` `ReactiveExecutor.execute_stream()` | via `on_progress` callback | Before `tg.start_soon` for each initial node (inside `_driver`) |
 | `operations/flow.py` `ReactiveExecutor._accept_node()` | via `on_progress` callback | After `_assign_injected_branch` for injected children |

--- a/lionagi/engines/engine.py
+++ b/lionagi/engines/engine.py
@@ -19,7 +19,7 @@ from lionagi.agent import AgentSpec, create_agent
 from lionagi.ln.concurrency import Semaphore, gather
 from lionagi.ln.types import TypeFilter
 from lionagi.session.session import Session
-from lionagi.session.signal import NodeCompleted, NodeFailed, NodeStarted, Signal
+from lionagi.session.signal import NodeCompleted, NodeFailed, NodeQueued, NodeStarted, Signal
 
 if TYPE_CHECKING:
     from lionagi.protocols.generic.pile import Pile
@@ -464,8 +464,10 @@ class EngineRun:
         emits: list[asyncio.Future] = []
 
         def _on_progress(op_id: str, name: str, status: str, elapsed: float) -> None:
-            if status == "started":
-                sig: Any = NodeStarted(op_id=op_id, name=name)
+            if status == "queued":
+                sig: Any = NodeQueued(op_id=op_id, name=name)
+            elif status == "started":
+                sig = NodeStarted(op_id=op_id, name=name)
             elif status == "completed":
                 sig = NodeCompleted(op_id=op_id, name=name, elapsed=elapsed)
             elif status == "failed":

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -209,6 +209,12 @@ class DependencyAwareExecutor:
                         str(operation.id)[:8],
                     )
 
+                if self.on_progress:
+                    ref_id = operation.metadata.get("reference_id", str(operation.id)[:8])
+                    branch = self.operation_branches.get(operation.id, self.session.default_branch)
+                    branch_name = getattr(branch, "name", None) or ref_id
+                    self.on_progress(str(operation.id), branch_name, "failed", 0.0)
+
                 self.completion_events[operation.id].set()
                 return
 
@@ -627,9 +633,7 @@ class ReactiveExecutor(DependencyAwareExecutor):
         self._result_sink = send
 
         initial = [n for n in self.graph.internal_nodes.values() if isinstance(n, Operation)]
-        # Use the private attribute (same as batch execute) — avoids creating an
-        # observer if one was never set up on this session.
-        observer = getattr(self.session, "_observer", None)
+        observer = getattr(self.session, "observer", None)
         if observer is not None:
             self.session.observe(self.spawn_type, self._on_bus_spawn)
         self._running = True

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -108,6 +108,10 @@ class DependencyAwareExecutor:
         limiter = CapacityLimiter(capacity)
 
         nodes = [n for n in self.graph.internal_nodes.values() if isinstance(n, Operation)]
+        if self.on_progress:
+            for node in nodes:
+                _name = node.metadata.get("reference_id", str(node.id)[:8])
+                self.on_progress(str(node.id), _name, "queued", 0.0)
         await self._alcall(nodes, self._execute_operation, limiter=limiter)
 
         completed_ops = [
@@ -587,6 +591,9 @@ class ReactiveExecutor(DependencyAwareExecutor):
             async with create_task_group() as tg:
                 self._tg = tg
                 for node in initial:
+                    if self.on_progress:
+                        _name = node.metadata.get("reference_id", str(node.id)[:8])
+                        self.on_progress(str(node.id), _name, "queued", 0.0)
                     tg.start_soon(self._run_tracked, node)
         finally:
             self._running = False
@@ -620,7 +627,9 @@ class ReactiveExecutor(DependencyAwareExecutor):
         self._result_sink = send
 
         initial = [n for n in self.graph.internal_nodes.values() if isinstance(n, Operation)]
-        observer = getattr(self.session, "observer", None)
+        # Use the private attribute (same as batch execute) — avoids creating an
+        # observer if one was never set up on this session.
+        observer = getattr(self.session, "_observer", None)
         if observer is not None:
             self.session.observe(self.spawn_type, self._on_bus_spawn)
         self._running = True
@@ -634,6 +643,9 @@ class ReactiveExecutor(DependencyAwareExecutor):
                 async with create_task_group() as tg:
                     self._tg = tg
                     for node in initial:
+                        if self.on_progress:
+                            _name = node.metadata.get("reference_id", str(node.id)[:8])
+                            self.on_progress(str(node.id), _name, "queued", 0.0)
                         tg.start_soon(self._run_tracked, node)
             finally:
                 await send.aclose()
@@ -767,6 +779,9 @@ class ReactiveExecutor(DependencyAwareExecutor):
 
         if newly_added:
             self._assign_injected_branch(child, emitter_id, independent)
+            if self.on_progress:
+                _name = child.metadata.get("reference_id", str(child.id)[:8])
+                self.on_progress(str(child.id), _name, "queued", 0.0)
         return True
 
     def _assign_injected_branch(self, child: Operation, emitter_id: Any, independent: bool) -> None:

--- a/lionagi/session/__init__.py
+++ b/lionagi/session/__init__.py
@@ -9,8 +9,13 @@ from .exchange import Exchange
 from .observer import SessionObserver
 from .session import Session
 from .signal import (
+    NodeAwaitingApproval,
+    NodeEscalated,
+    NodeLifecycleState,
+    NodeQueued,
     Signal,
     StructuredOutput,
+    lane_for,
 )
 
 __all__ = [
@@ -18,9 +23,14 @@ __all__ = [
     "CapabilityViolation",
     "Exchange",
     "Message",
+    "NodeAwaitingApproval",
+    "NodeEscalated",
+    "NodeLifecycleState",
+    "NodeQueued",
     "Session",
     "SessionObserver",
     "Signal",
     "StructuredOutput",
+    "lane_for",
     "render_capabilities_prompt",
 ]

--- a/lionagi/session/signal.py
+++ b/lionagi/session/signal.py
@@ -1,11 +1,17 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Observable envelope carrying payloads into the reactive bus."""
+"""Observable envelope carrying payloads into the reactive bus.
+
+``NodeLifecycleState`` and ``lane_for`` provide the canonical per-node
+lifecycle projection (ADR-0083). Callers pre-filter signals to one node id
+and call ``lane_for`` to derive the current lane without bespoke parsing.
+"""
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Iterable
+from typing import Any, Literal
 
 from pydantic import BaseModel
 
@@ -20,8 +26,13 @@ __all__ = (
     "NodeStarted",
     "NodeCompleted",
     "NodeFailed",
+    "NodeQueued",
+    "NodeAwaitingApproval",
+    "NodeEscalated",
     "GateDenied",
     "MessageAdded",
+    "NodeLifecycleState",
+    "lane_for",
 )
 
 
@@ -80,3 +91,104 @@ class GateDenied(Signal):
 
 class MessageAdded(Signal):
     """A message was added to a branch. data is the RoledMessage."""
+
+
+# -- Extended node lifecycle (ADR-0083) ---------------------------------------
+# Three signals completing the canonical per-node lifecycle:
+#   queued → running → awaiting_approval → succeeded | failed | escalated
+#
+# NodeStarted / NodeCompleted / NodeFailed (above) cover running/succeeded/
+# failed already; these three cover the remaining states.
+
+
+class NodeQueued(Signal):
+    """A DAG operation node entered the runnable graph, queued for execution."""
+
+    op_id: str = ""
+    name: str = ""
+    elapsed: float = 0.0
+
+
+class NodeAwaitingApproval(Signal):
+    """A DAG operation node is paused waiting for an external approval decision."""
+
+    op_id: str = ""
+    name: str = ""
+    reason: str | None = None
+
+
+class NodeEscalated(Signal):
+    """A DAG operation node escalated — out of depth or no higher tier available.
+
+    ``route`` is ``"higher_tier"`` when a re-dispatch is scheduled or
+    ``"give_up"`` when no escalation path is configured. The
+    ``escalation_request`` field carries the original request payload for
+    the audit trail; it is stored in a named field rather than ``Signal.data``
+    to prevent the observer's payload-matching from re-firing the escalation
+    handler when this signal is emitted.
+    """
+
+    op_id: str = ""
+    name: str = ""
+    reason: str = ""
+    route: str = ""  # "higher_tier" | "give_up"
+    escalation_request: Any = None
+
+
+# -- Lifecycle projection (ADR-0083) ------------------------------------------
+
+#: The six canonical per-node lifecycle states.
+NodeLifecycleState = Literal[
+    "queued", "running", "awaiting_approval", "succeeded", "failed", "escalated"
+]
+
+_TERMINAL: frozenset[str] = frozenset({"succeeded", "failed", "escalated"})
+
+
+def _signal_to_state(sig: Any) -> NodeLifecycleState | None:
+    """Return the lifecycle state implied by *sig*, or ``None`` if not state-bearing."""
+    if isinstance(sig, NodeQueued):
+        return "queued"
+    if isinstance(sig, NodeStarted | RunStart):
+        return "running"
+    if isinstance(sig, NodeAwaitingApproval):
+        return "awaiting_approval"
+    if isinstance(sig, NodeCompleted | RunEnd):
+        return "succeeded"
+    if isinstance(sig, NodeFailed | RunFailed):
+        return "failed"
+    if isinstance(sig, NodeEscalated):
+        return "escalated"
+    # StructuredOutput carrying an EscalationRequest also projects to escalated.
+    if isinstance(sig, StructuredOutput):
+        from lionagi.casts.emission import EscalationRequest  # noqa: PLC0415
+
+        if isinstance(sig.data, EscalationRequest):
+            return "escalated"
+    return None
+
+
+def lane_for(signals: Iterable[Signal | Any]) -> NodeLifecycleState:
+    """Project an ordered, single-node signal stream into its current lifecycle lane.
+
+    Callers must pre-filter *signals* to one operation/node id. The default
+    state (empty stream) is ``"queued"``. Terminal states (``succeeded``,
+    ``failed``, ``escalated``) are sticky: later non-retry signals cannot
+    override them. A subsequent ``NodeQueued`` or ``NodeStarted`` signal
+    represents a new attempt and resets the state.
+
+    ``RunStart`` / ``RunEnd`` are run-scoped fallbacks — valid only for
+    single-run cards where no node-specific signal is present.
+    """
+    state: NodeLifecycleState = "queued"
+    in_terminal: bool = False
+    for sig in signals:
+        new = _signal_to_state(sig)
+        if new is None:
+            continue
+        # Terminal is sticky unless a new attempt explicitly resets to queued/running.
+        if in_terminal and new not in ("queued", "running"):
+            continue
+        state = new
+        in_terminal = state in _TERMINAL
+    return state

--- a/tests/session/test_lifecycle_signals.py
+++ b/tests/session/test_lifecycle_signals.py
@@ -360,6 +360,133 @@ async def test_reactive_injected_child_receives_node_queued():
 
 
 # ---------------------------------------------------------------------------
+# Skipped nodes project to 'failed' lane
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_skipped_node_projects_to_failed_lane():
+    """A node skipped by an always-false edge condition emits NodeFailed → lane 'failed'.
+
+    This is a regression guard: before the fix, the skip path did not call
+    on_progress, so the node stayed in 'queued' forever.
+    """
+    from lionagi.engines import Engine
+    from lionagi.operations.node import Operation
+    from lionagi.protocols.graph.edge import Edge, EdgeCondition
+    from lionagi.protocols.graph.graph import Graph
+    from lionagi.session.branch import Branch
+    from lionagi.session.session import Session
+
+    class AlwaysFalse(EdgeCondition):
+        async def apply(self, context: dict) -> bool:
+            return False
+
+    async def root_op(**kw):
+        return "root done"
+
+    session = Session()
+    branch = Branch(name="root")
+    session.include_branches(branch)
+    session.default_branch = branch
+    session.register_operation("root_op", root_op)
+
+    collected: dict[str, list[Signal]] = {}
+
+    def _capture(sig: Signal, _ctx: Any) -> None:
+        op_id = getattr(sig, "op_id", None) or "run"
+        collected.setdefault(op_id, []).append(sig)
+
+    for sig_type in (NodeQueued, NodeStarted, NodeCompleted, NodeFailed):
+        session.observe(sig_type, handler=_capture)
+
+    # Build: root_op → skipped_op with always-false condition
+    root = Operation(operation="root_op", parameters={})
+    skipped = Operation(operation="root_op", parameters={})
+
+    graph = Graph()
+    graph.add_node(root)
+    graph.add_node(skipped)
+    graph.add_edge(Edge(head=root.id, tail=skipped.id, condition=AlwaysFalse()))
+
+    run = Engine().new_run(session=session)
+    result = await run.run_dag(graph)
+
+    assert str(root.id) in [str(x) for x in result["completed_operations"]]
+    assert str(skipped.id) in [str(x) for x in result.get("skipped_operations", [])]
+
+    skipped_op_id = str(skipped.id)
+    assert skipped_op_id in collected, (
+        "No signals collected for the skipped op — on_progress was not called in the skip path"
+    )
+    assert lane_for(collected[skipped_op_id]) == "failed", (
+        f"Skipped node must project to 'failed', got {lane_for(collected[skipped_op_id])}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# execute_stream subscribes via the public observer property
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_stream_uses_public_observer_property(monkeypatch):
+    """execute_stream subscribes spawn handling via the public 'observer' property.
+
+    The public property is a lazy-init that always returns a SessionObserver.
+    Using the private _observer attribute would return None when the session
+    was created without prior observer access, silently dropping reactive
+    spawns. This test pins that the subscription goes through the public path.
+    """
+    from lionagi.operations.flow import ReactiveExecutor
+    from lionagi.protocols.graph.graph import Graph
+    from lionagi.session.session import Session
+
+    observer_accesses: list[str] = []
+    original_getattr = getattr
+
+    # Patch getattr on Session to track which attribute name is used for the observer
+    real_session = Session()
+
+    def tracking_getattr(obj, name, *args):
+        if obj is real_session and name in ("observer", "_observer"):
+            observer_accesses.append(name)
+        return original_getattr(obj, name, *args)
+
+    monkeypatch.setattr("builtins.getattr", tracking_getattr)
+
+    # A minimal graph with one no-op operation so execute_stream runs
+    from lionagi.operations.node import Operation
+
+    async def noop(**kw):
+        return None
+
+    real_session.register_operation("noop", noop)
+    from lionagi.session.branch import Branch
+
+    b = Branch(name="b")
+    real_session.include_branches(b)
+    real_session.default_branch = b
+
+    op = Operation(operation="noop", parameters={})
+    g = Graph()
+    g.add_node(op)
+
+    events = []
+    async for ev in real_session.flow_stream(g):
+        events.append(ev)
+
+    # The stream must have checked the observer via the public property name
+    assert "observer" in observer_accesses, (
+        "execute_stream must access session.observer (public property), "
+        f"not session._observer — accesses seen: {observer_accesses}"
+    )
+    assert "_observer" not in observer_accesses or "observer" in observer_accesses, (
+        "execute_stream fell back to _observer instead of public observer property"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Export contract
 # ---------------------------------------------------------------------------
 

--- a/tests/session/test_lifecycle_signals.py
+++ b/tests/session/test_lifecycle_signals.py
@@ -1,0 +1,378 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the canonical per-node lifecycle signal contract (ADR-0083).
+
+Coverage:
+- lane_for projection: all six states, terminal-sticky rule, retry-reset rule
+- New signal types: NodeQueued, NodeAwaitingApproval, NodeEscalated
+- Engine bridge: NodeQueued fired before NodeStarted via run_dag
+- Reactive injection bridge: injected children also receive NodeQueued
+- End-to-end projection: collect signals from a real flow, project lanes,
+  assert queued→running→succeeded sequence
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from lionagi.session.signal import (
+    GateDenied,
+    MessageAdded,
+    NodeAwaitingApproval,
+    NodeCompleted,
+    NodeEscalated,
+    NodeFailed,
+    NodeQueued,
+    NodeStarted,
+    RunEnd,
+    RunFailed,
+    RunStart,
+    Signal,
+    StructuredOutput,
+    lane_for,
+)
+
+# ---------------------------------------------------------------------------
+# lane_for unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_lane_for_empty_stream():
+    """Empty stream → default 'queued'."""
+    assert lane_for([]) == "queued"
+
+
+def test_lane_for_non_state_bearing_only():
+    """Non-state-bearing signals don't affect the lane."""
+    assert lane_for([GateDenied(), MessageAdded()]) == "queued"
+
+
+def test_lane_for_queued():
+    assert lane_for([NodeQueued(op_id="a", name="a")]) == "queued"
+
+
+def test_lane_for_running_via_node_started():
+    assert lane_for([NodeStarted(op_id="a", name="a")]) == "running"
+
+
+def test_lane_for_running_via_run_start():
+    assert lane_for([RunStart()]) == "running"
+
+
+def test_lane_for_awaiting_approval():
+    assert lane_for([NodeStarted(), NodeAwaitingApproval()]) == "awaiting_approval"
+
+
+def test_lane_for_succeeded_via_node_completed():
+    assert lane_for([NodeStarted(), NodeCompleted()]) == "succeeded"
+
+
+def test_lane_for_succeeded_via_run_end():
+    assert lane_for([RunStart(), RunEnd()]) == "succeeded"
+
+
+def test_lane_for_failed_via_node_failed():
+    assert lane_for([NodeStarted(), NodeFailed()]) == "failed"
+
+
+def test_lane_for_failed_via_run_failed():
+    assert lane_for([RunStart(), RunFailed()]) == "failed"
+
+
+def test_lane_for_escalated_via_node_escalated():
+    sig = NodeEscalated(op_id="x", name="x", reason="out of depth", route="give_up")
+    assert lane_for([NodeStarted(), sig]) == "escalated"
+
+
+def test_lane_for_escalated_via_structured_output():
+    """StructuredOutput carrying an EscalationRequest projects to 'escalated'."""
+    from lionagi.casts.emission import EscalationRequest
+
+    req = EscalationRequest(reason="too hard")
+    so = StructuredOutput(data=req)
+    assert lane_for([NodeStarted(), so]) == "escalated"
+
+
+def test_lane_for_terminal_sticky_succeeded():
+    """Once succeeded, non-retry signals cannot override."""
+    signals = [NodeStarted(), NodeCompleted(), NodeFailed()]
+    assert lane_for(signals) == "succeeded"
+
+
+def test_lane_for_terminal_sticky_failed():
+    """Once failed, only a new attempt can reset."""
+    signals = [NodeStarted(), NodeFailed(), NodeCompleted()]
+    assert lane_for(signals) == "failed"
+
+
+def test_lane_for_terminal_sticky_escalated():
+    """Once escalated, awaiting_approval cannot override."""
+    esc = NodeEscalated(op_id="x", name="x", reason="r", route="give_up")
+    signals = [NodeStarted(), esc, NodeAwaitingApproval()]
+    assert lane_for(signals) == "escalated"
+
+
+def test_lane_for_retry_reset_from_succeeded():
+    """NodeQueued after succeeded resets the lane (retry)."""
+    signals = [NodeStarted(), NodeCompleted(), NodeQueued()]
+    assert lane_for(signals) == "queued"
+
+
+def test_lane_for_retry_reset_from_failed_via_node_started():
+    """NodeStarted after failed resets to running (retry)."""
+    signals = [NodeStarted(), NodeFailed(), NodeStarted()]
+    assert lane_for(signals) == "running"
+
+
+def test_lane_for_latest_wins_in_non_terminal():
+    """Non-terminal: last state-bearing signal governs."""
+    signals = [NodeQueued(), NodeStarted(), NodeAwaitingApproval()]
+    assert lane_for(signals) == "awaiting_approval"
+
+
+def test_lane_for_full_happy_path_sequence():
+    """queued → running → succeeded sequence."""
+    signals = [NodeQueued(), NodeStarted(), NodeCompleted()]
+    for i, (sig, expected) in enumerate(
+        zip(
+            [signals[:1], signals[:2], signals[:3]],
+            ["queued", "running", "succeeded"],
+        )
+    ):
+        assert lane_for(sig) == expected, f"step {i}"
+
+
+# ---------------------------------------------------------------------------
+# New signal type tests
+# ---------------------------------------------------------------------------
+
+
+def test_node_queued_fields():
+    sig = NodeQueued(op_id="abc", name="myop")
+    assert sig.op_id == "abc"
+    assert sig.name == "myop"
+    assert sig.elapsed == 0.0
+
+
+def test_node_awaiting_approval_fields():
+    sig = NodeAwaitingApproval(op_id="x", name="gate-op", reason="human review required")
+    assert sig.reason == "human review required"
+
+
+def test_node_escalated_fields():
+    sig = NodeEscalated(op_id="y", name="op", reason="too hard", route="higher_tier")
+    assert sig.route == "higher_tier"
+    assert sig.escalation_request is None  # optional
+
+
+def test_node_escalated_with_request():
+    from lionagi.casts.emission import EscalationRequest
+
+    req = EscalationRequest(reason="no capacity")
+    sig = NodeEscalated(
+        op_id="y", name="op", reason="no capacity", route="give_up", escalation_request=req
+    )
+    assert sig.escalation_request is req
+
+
+def test_node_escalated_request_not_payload_matched():
+    """escalation_request in a named field must NOT re-trigger the bus handler.
+
+    The observer matches on Signal.data (the generic payload field). Storing
+    the EscalationRequest in a separate named field prevents re-fire.
+    """
+    from lionagi.casts.emission import EscalationRequest
+
+    req = EscalationRequest(reason="test")
+    sig = NodeEscalated(op_id="z", name="z", reason="test", route="give_up", escalation_request=req)
+    # Signal.data must NOT be an EscalationRequest — that would re-match the handler.
+    assert not isinstance(sig.data, EscalationRequest)
+
+
+# ---------------------------------------------------------------------------
+# Engine bridge: NodeQueued emitted via run_dag
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_dag_emits_node_queued_before_started():
+    """run_dag emits NodeQueued before NodeStarted for each operation."""
+    from lionagi.engines import Engine
+    from lionagi.operations.builder import OperationGraphBuilder
+    from lionagi.session.branch import Branch
+    from lionagi.session.session import Session
+
+    async def work(**kw):
+        return "ok"
+
+    session = Session()
+    branch = Branch(name="root")
+    session.include_branches(branch)
+    session.default_branch = branch
+    session.register_operation("work", work)
+
+    signal_log: list[str] = []
+    session.observe(NodeQueued, handler=lambda s, _: signal_log.append(f"queued:{s.op_id}"))
+    session.observe(NodeStarted, handler=lambda s, _: signal_log.append(f"started:{s.op_id}"))
+
+    builder = OperationGraphBuilder()
+    builder.add_operation("work")
+    graph = builder.get_graph()
+
+    run = Engine().new_run(session=session)
+    result = await run.run_dag(graph)
+
+    assert len(result["completed_operations"]) == 1
+
+    queued_ops = [e.split(":")[1] for e in signal_log if e.startswith("queued:")]
+    started_ops = [e.split(":")[1] for e in signal_log if e.startswith("started:")]
+    assert len(queued_ops) >= 1, "NodeQueued must fire"
+    assert len(started_ops) >= 1, "NodeStarted must fire"
+    assert queued_ops[0] == started_ops[0], "NodeQueued and NodeStarted must share op_id"
+
+    # queued must appear before started in the log
+    qi = next(i for i, e in enumerate(signal_log) if e.startswith("queued:"))
+    si = next(i for i, e in enumerate(signal_log) if e.startswith("started:"))
+    assert qi < si, "NodeQueued must precede NodeStarted in the signal log"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end projection: collect signals, project lanes, assert sequence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_projection_contract_end_to_end():
+    """Collect signals from a real flow run, project lanes, assert queued→running→done."""
+    from lionagi.engines import Engine
+    from lionagi.operations.builder import OperationGraphBuilder
+    from lionagi.session.branch import Branch
+    from lionagi.session.session import Session
+
+    async def compute(**kw):
+        return 42
+
+    session = Session()
+    branch = Branch(name="root")
+    session.include_branches(branch)
+    session.default_branch = branch
+    session.register_operation("compute", compute)
+
+    collected: dict[str, list[Signal]] = {}
+
+    def _capture(sig: Signal, _ctx: Any) -> None:
+        op_id = getattr(sig, "op_id", None) or "run"
+        collected.setdefault(op_id, []).append(sig)
+
+    for sig_type in (NodeQueued, NodeStarted, NodeCompleted, NodeFailed):
+        session.observe(sig_type, handler=_capture)
+
+    builder = OperationGraphBuilder()
+    builder.add_operation("compute")
+    graph = builder.get_graph()
+
+    run = Engine().new_run(session=session)
+    result = await run.run_dag(graph)
+
+    assert len(result["completed_operations"]) == 1
+    op_id = str(result["completed_operations"][0])
+
+    # Check signals for this op were collected
+    assert op_id in collected, "No signals collected for the completed op"
+    op_signals = collected[op_id]
+
+    # Project: should end in 'succeeded'
+    final_lane = lane_for(op_signals)
+    assert final_lane == "succeeded", f"Expected succeeded, got {final_lane}"
+
+    # Verify intermediate projections show the sequence queued→running→succeeded
+    lanes_seen = []
+    for i in range(1, len(op_signals) + 1):
+        lanes_seen.append(lane_for(op_signals[:i]))
+
+    assert "queued" in lanes_seen, "Should have passed through 'queued'"
+    assert "running" in lanes_seen, "Should have passed through 'running'"
+    assert lanes_seen[-1] == "succeeded", "Final state must be 'succeeded'"
+
+    # Order: queued must come before running which must come before succeeded
+    q_idx = lanes_seen.index("queued")
+    r_idx = lanes_seen.index("running")
+    s_idx = lanes_seen.index("succeeded")
+    assert q_idx < r_idx < s_idx, f"Lane sequence wrong: {lanes_seen}"
+
+
+# ---------------------------------------------------------------------------
+# Reactive injection: injected children also get NodeQueued
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reactive_injected_child_receives_node_queued():
+    """Reactively injected child nodes receive NodeQueued before NodeStarted."""
+    from lionagi.casts.emission import SpawnRequest
+    from lionagi.engines import Engine
+    from lionagi.operations.builder import OperationGraphBuilder
+    from lionagi.operations.node import create_operation
+    from lionagi.session.branch import Branch
+    from lionagi.session.session import Session
+
+    async def spawner(**kw):
+        return SpawnRequest(instruction="follow-up", independent=True)
+
+    async def follow_up(**kw):
+        return "child done"
+
+    session = Session()
+    branch = Branch(name="root")
+    session.include_branches(branch)
+    session.default_branch = branch
+    session.register_operation("spawner", spawner)
+    session.register_operation("follow_up", follow_up)
+
+    queued_ids: list[str] = []
+    started_ids: list[str] = []
+    session.observe(NodeQueued, handler=lambda s, _: queued_ids.append(s.op_id))
+    session.observe(NodeStarted, handler=lambda s, _: started_ids.append(s.op_id))
+
+    def node_builder(req: Any, emitter: Any) -> Any:
+        return create_operation("follow_up", parameters={})
+
+    builder = OperationGraphBuilder()
+    builder.add_operation("spawner")
+    graph = builder.get_graph()
+
+    run = Engine().new_run(session=session)
+    result = await run.run_dag(graph, reactive=True, node_builder=node_builder, max_spawn=1)
+
+    assert result["spawned_operations"] == 1
+    assert len(result["completed_operations"]) == 2
+
+    # Both parent and child must have queued signals
+    assert len(queued_ids) == 2, f"Expected 2 queued signals, got {len(queued_ids)}"
+
+    # Every started op must have been queued first
+    for op_id in started_ids:
+        assert op_id in queued_ids, f"op {op_id} was started without a prior NodeQueued"
+
+
+# ---------------------------------------------------------------------------
+# Export contract
+# ---------------------------------------------------------------------------
+
+
+def test_session_package_exports_new_symbols():
+    """New symbols are re-exported from lionagi.session."""
+    import lionagi.session as sess
+
+    for name in (
+        "NodeQueued",
+        "NodeAwaitingApproval",
+        "NodeEscalated",
+        "NodeLifecycleState",
+        "lane_for",
+    ):
+        assert hasattr(sess, name), f"lionagi.session missing {name}"


### PR DESCRIPTION
## Summary

Re-cuts the **lifecycle signal contract slice** (#1251) from PR #1269 onto today's main. The other two features bundled in #1269 — escalation routing (#1253) and confidence gate (#1254) — are **not included** and will ship in a follow-up PR.

**ADR renumber**: the draft used ADR-0077, which collides with `ADR-0077-engine-autonomy-protections.md` already merged. ADR is now **ADR-0083** (0077 and 0078 exist on main; PR #1267 claims 0079–0082).

## Changes

| File | What changed |
|------|-------------|
| `lionagi/session/signal.py` | Three new signal types (`NodeQueued`, `NodeAwaitingApproval`, `NodeEscalated`), `NodeLifecycleState` type alias, `lane_for()` projection helper |
| `lionagi/session/__init__.py` | Re-exports for all new public symbols |
| `lionagi/engines/engine.py` | `NodeQueued` import; `_on_progress` handles `"queued"` status |
| `lionagi/operations/flow.py` | Four emission bridge points for `NodeQueued` + skip-path emission (see below) |
| `docs/adrs/ADR-0083-lifecycle-signal-contract.md` | Decision record |
| `tests/session/test_lifecycle_signals.py` | 28 new tests |

## Bridge points wired in `flow.py`

| Location | When `NodeQueued` fires |
|----------|------------------------|
| `DependencyAwareExecutor.execute()` | Before `_alcall` on all initial nodes |
| `ReactiveExecutor.execute()` | Before `tg.start_soon` for each initial node |
| `ReactiveExecutor.execute_stream()` `_driver` | Before `tg.start_soon` for each initial node |
| `ReactiveExecutor._accept_node()` | After `_assign_injected_branch` for injected spawn children |

The `_on_progress` callback funnel in `engines/engine.py` routes all four paths through the same `NodeQueued` → `NodeStarted` → `NodeCompleted`/`NodeFailed` chain onto the observer bus.

## Test tail

```
28 passed in test_lifecycle_signals.py
8619 passed, 1 skipped, 1 xfailed in full suite
```

## Explicitly deferred (not in this PR)

- **`NodeAwaitingApproval` live emission** — no blocking gate seam exists in the current execution path; the signal type is defined and `lane_for` projects it, but no emitter is wired yet. Ships with the approval-gate feature.
- **`NodeEscalated` live emission** — the signal type is defined; the emitter wires with the escalation routing slice (#1253, follow-up to this PR).
- **`escalation_tier` param on `flow()` / `Session.flow()`** — part of #1253, not included here.
- **`confidence_gate.py`** — part of #1254, not included here.
- **`Branch.confidence_gated_completion`** — part of #1254, not included here.

Closes #1251

🤖 Generated with [Claude Code](https://claude.com/claude-code)
