### PR TITLE
feat(studio): i18n page conversions — kanban/playfield/dashboard + nav keys [PR-B]

### DIFF
--- a/apps/studio/frontend/app/kanban/page.tsx
+++ b/apps/studio/frontend/app/kanban/page.tsx
@@ -124,6 +124,7 @@ function durationSeconds(run: RunSummary, nowSec: number): number | null {
 // ── Card ──────────────────────────────────────────────────────────────────────
 
 function KanbanCard({ run, now }: { run: RunSummary; now: number }) {
+  const t = useTranslations("kanban");
   const durSec = durationSeconds(run, now);
   const name = displayName(run);
   return (
@@ -150,7 +151,7 @@ function KanbanCard({ run, now }: { run: RunSummary; now: number }) {
         <StatusPill value={run.status} kind="lifecycle" />
         {run.branch_count != null && run.branch_count > 0 && (
           <span className="text-meta text-content-muted tabular-nums">
-            {run.branch_count} agent{run.branch_count !== 1 ? "s" : ""}
+            {t("agentCount", { count: run.branch_count })}
           </span>
         )}
       </div>
@@ -290,8 +291,8 @@ export default function KanbanPage() {
         badges={
           !loading ? (
             <span className="text-meta text-content-muted tabular-nums">
-              {total} run{total !== 1 ? "s" : ""}
-              {runningCount > 0 && <> &mdash; {runningCount} running</>}
+              {t("runCount", { count: total })}
+              {runningCount > 0 && <> &mdash; {t("runningCount", { count: runningCount })}</>}
             </span>
           ) : null
         }

--- a/apps/studio/frontend/app/kanban/page.tsx
+++ b/apps/studio/frontend/app/kanban/page.tsx
@@ -4,6 +4,7 @@
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import Duration from "@/components/Duration";
 import PageHeader from "@/components/PageHeader";
 import StatusPill from "@/components/StatusPill";
@@ -53,19 +54,19 @@ interface Lane {
 const LANES: Lane[] = [
   {
     key: "queued",
-    label: "Queued",
+    label: "queued",
     statuses: ["pending", "prepared"],
     headerBg: "bg-status-warning-bg",
   },
   {
     key: "running",
-    label: "In Progress",
+    label: "running",
     statuses: ["running"],
     headerBg: "bg-status-running-bg",
   },
   {
     key: "review",
-    label: "Review / Waiting",
+    label: "review",
     // No canonical session statuses map here; populated once lifecycle-signal
     // enrichment surfaces awaiting/gated states through the runs API.
     statuses: [],
@@ -73,19 +74,19 @@ const LANES: Lane[] = [
   },
   {
     key: "done",
-    label: "Done",
+    label: "done",
     statuses: ["completed", "done", "success", "finished"],
     headerBg: "bg-status-success-bg",
   },
   {
     key: "failed",
-    label: "Failed",
+    label: "failed",
     statuses: ["failed", "timed_out", "timeout"],
     headerBg: "bg-status-error-bg",
   },
   {
     key: "cancelled",
-    label: "Cancelled",
+    label: "cancelled",
     statuses: ["cancelled", "canceled", "aborted"],
     headerBg: "bg-surface-overlay",
   },
@@ -165,11 +166,14 @@ function KanbanCard({ run, now }: { run: RunSummary; now: number }) {
 // ── Lane column ───────────────────────────────────────────────────────────────
 
 function LaneColumn({ lane, runs, now }: { lane: Lane; runs: RunSummary[]; now: number }) {
+  const t = useTranslations("kanban");
   return (
     <div className="flex min-w-[210px] max-w-[260px] flex-1 flex-col rounded border border-edge">
       {/* Lane header */}
       <div className={`flex items-center justify-between rounded-t px-3 py-2 ${lane.headerBg}`}>
-        <h2 className="text-label font-medium text-content-primary">{lane.label}</h2>
+        <h2 className="text-label font-medium text-content-primary">
+          {t(`lanes.${lane.key}` as Parameters<typeof t>[0])}
+        </h2>
         <span className="ml-2 rounded-full border border-edge bg-surface-raised px-1.5 py-0.5 font-mono text-meta text-content-muted tabular-nums">
           {runs.length}
         </span>
@@ -182,7 +186,7 @@ function LaneColumn({ lane, runs, now }: { lane: Lane; runs: RunSummary[]; now: 
       >
         {runs.length === 0 ? (
           <div className="py-6 text-center text-meta text-content-muted/60">
-            {lane.statuses.length === 0 ? "Awaiting lifecycle-signal enrichment." : "No runs."}
+            {lane.statuses.length === 0 ? t("empty.awaitingEnrichment") : t("empty.noRuns")}
           </div>
         ) : (
           runs.map((run) => <KanbanCard key={run.run_id} run={run} now={now} />)
@@ -195,10 +199,13 @@ function LaneColumn({ lane, runs, now }: { lane: Lane; runs: RunSummary[]; now: 
 // ── Skeleton lane for loading state ──────────────────────────────────────────
 
 function SkeletonLane({ lane }: { lane: Lane }) {
+  const t = useTranslations("kanban");
   return (
     <div className="flex min-w-[210px] max-w-[260px] flex-1 flex-col rounded border border-edge">
       <div className={`flex items-center justify-between rounded-t px-3 py-2 ${lane.headerBg}`}>
-        <h2 className="text-label font-medium text-content-primary">{lane.label}</h2>
+        <h2 className="text-label font-medium text-content-primary">
+          {t(`lanes.${lane.key}` as Parameters<typeof t>[0])}
+        </h2>
         <span className="ml-2 rounded-full border border-edge bg-surface-raised px-1.5 py-0.5 font-mono text-meta text-content-muted">
           …
         </span>
@@ -218,6 +225,7 @@ function SkeletonLane({ lane }: { lane: Lane }) {
 // ── Page ──────────────────────────────────────────────────────────────────────
 
 export default function KanbanPage() {
+  const t = useTranslations("kanban");
   const [runs, setRuns] = useState<RunSummary[]>([]);
   const [total, setTotal] = useState<number>(0);
   const [loading, setLoading] = useState(true);
@@ -276,8 +284,8 @@ export default function KanbanPage() {
   return (
     <main className="mx-auto flex w-full max-w-[1600px] flex-col gap-5 px-4 py-6 animate-page-enter">
       <PageHeader
-        title="Kanban"
-        subtitle="Read-only lifecycle view over run status. Drag-to-transition deferred (no transition endpoint on /api/runs/)."
+        title={t("title")}
+        subtitle={t("subtitle")}
         density="tight"
         badges={
           !loading ? (

--- a/apps/studio/frontend/app/page.tsx
+++ b/apps/studio/frontend/app/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
 import MetricCard from "@/components/MetricCard";
 import PageHeader from "@/components/PageHeader";
 import StatusPill from "@/components/StatusPill";
@@ -52,6 +53,7 @@ function isInRange(run: RunSummary, windowSec: number | null, nowSec: number): b
 }
 
 export default function DashboardPage() {
+  const t = useTranslations("dashboard");
   const [stats, setStats] = useState<StudioStats | null>(null);
   const [allRuns, setAllRuns] = useState<RunSummary[]>([]);
   const [shows, setShows] = useState<ShowSummary[]>([]);
@@ -102,7 +104,7 @@ export default function DashboardPage() {
           }
         }
       } catch {
-        if (active) setFetchError("API unreachable — data may be stale");
+        if (active) setFetchError(t("fetchError"));
       }
     }
 
@@ -114,7 +116,7 @@ export default function DashboardPage() {
       clearInterval(interval);
       clearInterval(tick);
     };
-  }, []);
+  }, [t]);
 
   const windowSec = rangeToSeconds(range);
 
@@ -175,8 +177,8 @@ export default function DashboardPage() {
   return (
     <main className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-6 animate-page-enter">
       <PageHeader
-        title="Dashboard"
-        subtitle="Operational overview"
+        title={t("title")}
+        subtitle={t("subtitle")}
         actions={<TimeRangeChips value={range} onChange={setRange} />}
         density="tight"
       />
@@ -190,41 +192,47 @@ export default function DashboardPage() {
       {/* Operational stat cards */}
       <div className="grid grid-cols-2 gap-3 md:grid-cols-5">
         <MetricCard
-          label="Running now"
+          label={t("metrics.runningNow")}
           value={buckets.running.length}
           hint={
             buckets.stuck.length > 0
-              ? `${buckets.stuck.length} stuck >${STUCK_RUN_SECONDS / 60}m`
-              : `${rangeLabel}`
+              ? t("metrics.stuck", { count: buckets.stuck.length, minutes: STUCK_RUN_SECONDS / 60 })
+              : rangeLabel
           }
           tone={buckets.running.length > 0 ? "running" : "neutral"}
           icon={buckets.running.length > 0 ? "◐" : "○"}
         />
         <MetricCard
-          label="Stale"
+          label={t("metrics.stale")}
           value={buckets.stale.length}
-          hint={buckets.stale.length > 0 ? "no activity past threshold" : "no stale activity"}
+          hint={
+            buckets.stale.length > 0
+              ? t("metrics.noActivityPastThreshold")
+              : t("metrics.noStaleActivity")
+          }
           tone={buckets.stale.length > 0 ? "pending" : "neutral"}
           icon={buckets.stale.length > 0 ? "◴" : "·"}
         />
         <MetricCard
-          label={`Failed (${rangeLabel})`}
+          label={t("metrics.failed", { range: rangeLabel })}
           value={buckets.failed.length}
-          hint={buckets.failed.length === 0 ? "all clean" : "needs investigation"}
+          hint={
+            buckets.failed.length === 0 ? t("metrics.allClean") : t("metrics.needsInvestigation")
+          }
           tone={buckets.failed.length > 0 ? "failed" : "ok"}
           icon={buckets.failed.length > 0 ? "✕" : "✓"}
         />
         <MetricCard
-          label={`Slow runs (${rangeLabel})`}
+          label={t("metrics.slowRuns", { range: rangeLabel })}
           value={buckets.slow.length}
-          hint={`completed > ${SLOW_RUN_SECONDS / 60}m`}
+          hint={t("metrics.completedOver", { minutes: SLOW_RUN_SECONDS / 60 })}
           tone={buckets.slow.length > 0 ? "pending" : "neutral"}
           icon={buckets.slow.length > 0 ? "⏱" : "·"}
         />
         <MetricCard
-          label="Needs review"
+          label={t("metrics.needsReview")}
           value={buckets.needsReview.length}
-          hint={`${rangeLabel}`}
+          hint={rangeLabel}
           tone={buckets.needsReview.length > 0 ? "pending" : "neutral"}
           icon={buckets.needsReview.length > 0 ? "⊘" : "·"}
         />
@@ -233,7 +241,7 @@ export default function DashboardPage() {
       {/* Secondary inventory strip */}
       {stats ? (
         <div className="flex flex-wrap items-center gap-x-5 gap-y-1 rounded border border-edge bg-surface-overlay px-4 py-2.5 text-meta text-content-muted">
-          <span className="uppercase tracking-[0.08em] text-content-muted">Inventory</span>
+          <span className="uppercase tracking-[0.08em] text-content-muted">{t("inventory")}</span>
           <Link
             href="/playbooks"
             className="transition-colors duration-100 hover:text-content-primary"
@@ -260,13 +268,15 @@ export default function DashboardPage() {
       {/* Two-column: Needs attention | Recent activity */}
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
         <section>
-          <SectionHeader title="Needs attention" count={buckets.attention.length} href="/runs" />
+          <SectionHeader
+            title={t("sections.needsAttention")}
+            count={buckets.attention.length}
+            href="/runs"
+          />
           {buckets.attention.length === 0 ? (
             <div className="rounded border border-status-success/25 bg-status-success-bg px-4 py-4 text-body text-status-success shadow-card">
-              <span className="font-semibold">All clean.</span>{" "}
-              <span className="text-content-secondary">
-                No failed, stuck, or blocked runs in window.
-              </span>
+              <span className="font-semibold">{t("allClean")}</span>{" "}
+              <span className="text-content-secondary">{t("allCleanDetail")}</span>
             </div>
           ) : (
             <RunsTable runs={buckets.attention} emptyText="" now={now} />
@@ -274,29 +284,33 @@ export default function DashboardPage() {
         </section>
 
         <section>
-          <SectionHeader title="Recent activity" count={buckets.recent.length} href="/runs" />
+          <SectionHeader
+            title={t("sections.recentActivity")}
+            count={buckets.recent.length}
+            href="/runs"
+          />
           <RunsTable runs={buckets.recent} emptyText="No runs in window." now={now} />
         </section>
       </div>
 
       {/* Shows table */}
       <section>
-        <SectionHeader title="Shows" count={shows.length} href="/shows" />
+        <SectionHeader title={t("sections.shows")} count={shows.length} href="/shows" />
         <div className="overflow-hidden rounded border border-edge bg-surface-raised shadow-card">
           <table className="w-full text-left text-body">
             <thead>
               <tr className="border-b border-edge bg-surface-overlay text-meta uppercase tracking-[0.06em] text-content-muted">
-                <th className="px-3 py-2.5 font-medium">Topic</th>
-                <th className="px-3 py-2.5 font-medium tabular-nums">Plays</th>
-                <th className="px-3 py-2.5 font-medium">Status</th>
-                <th className="px-3 py-2.5 font-medium">Last update</th>
+                <th className="px-3 py-2.5 font-medium">{t("table.topic")}</th>
+                <th className="px-3 py-2.5 font-medium tabular-nums">{t("table.plays")}</th>
+                <th className="px-3 py-2.5 font-medium">{t("table.status")}</th>
+                <th className="px-3 py-2.5 font-medium">{t("table.lastUpdate")}</th>
               </tr>
             </thead>
             <tbody>
               {shows.length === 0 ? (
                 <tr>
                   <td colSpan={4} className="px-3 py-8 text-center text-meta text-content-muted">
-                    No shows
+                    {t("table.noShows")}
                   </td>
                 </tr>
               ) : (
@@ -332,6 +346,7 @@ export default function DashboardPage() {
 }
 
 function SectionHeader({ title, count, href }: { title: string; count: number; href: string }) {
+  const t = useTranslations("dashboard");
   return (
     <div className="mb-2.5 flex items-center justify-between">
       <div className="flex items-center gap-2">
@@ -344,7 +359,7 @@ function SectionHeader({ title, count, href }: { title: string; count: number; h
         href={href}
         className="text-meta text-content-muted transition-colors duration-100 hover:text-content-primary"
       >
-        View all →
+        {t("viewAll")}
       </Link>
     </div>
   );
@@ -359,16 +374,19 @@ function RunsTable({
   emptyText: string;
   now: number;
 }) {
+  const t = useTranslations("dashboard");
   return (
     <div className="overflow-hidden rounded border border-edge bg-surface-raised shadow-card">
       <table className="w-full text-left text-body">
         <thead>
           <tr className="border-b border-edge bg-surface-overlay text-meta uppercase tracking-[0.06em] text-content-muted">
-            <th className="px-3 py-2.5 font-medium">Run</th>
-            <th className="px-3 py-2.5 font-medium">Kind</th>
-            <th className="px-3 py-2.5 font-medium">Status</th>
-            <th className="px-3 py-2.5 font-medium tabular-nums text-right">Duration</th>
-            <th className="px-3 py-2.5 font-medium">Started</th>
+            <th className="px-3 py-2.5 font-medium">{t("table.run")}</th>
+            <th className="px-3 py-2.5 font-medium">{t("table.kind")}</th>
+            <th className="px-3 py-2.5 font-medium">{t("table.status")}</th>
+            <th className="px-3 py-2.5 font-medium tabular-nums text-right">
+              {t("table.duration")}
+            </th>
+            <th className="px-3 py-2.5 font-medium">{t("table.started")}</th>
           </tr>
         </thead>
         <tbody>
@@ -422,30 +440,35 @@ function formatBytes(value: number | null | undefined): string {
 }
 
 function SystemHealthCard({ db }: { db: DbStats | undefined }) {
+  const t = useTranslations("dashboard");
   if (!db) return null;
   return (
     <div className="rounded border border-edge bg-surface-raised p-4 shadow-card">
       <div className="mb-3 flex items-center justify-between">
-        <span className="text-label font-semibold text-content-primary">System Health</span>
+        <span className="text-label font-semibold text-content-primary">{t("health.title")}</span>
         <span className="font-mono text-meta text-content-muted">{db.path}</span>
       </div>
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 text-meta">
         <div>
-          <div className="text-content-muted">State DB</div>
+          <div className="text-content-muted">{t("health.stateDb")}</div>
           <div className="tabular-nums text-content-secondary">{formatBytes(db.size_bytes)}</div>
         </div>
         <div>
-          <div className="text-content-muted">WAL</div>
+          <div className="text-content-muted">{t("health.wal")}</div>
           <div className="tabular-nums text-content-secondary">{formatBytes(db.wal_bytes)}</div>
         </div>
         <div>
-          <div className="text-content-muted">Connections</div>
+          <div className="text-content-muted">{t("health.connections")}</div>
           <div className="tabular-nums text-content-secondary">{db.connections_active}</div>
         </div>
         <div>
-          <div className="text-content-muted">Last checkpoint</div>
+          <div className="text-content-muted">{t("health.lastCheckpoint")}</div>
           <div className="text-content-secondary">
-            {db.last_checkpoint_at ? <Timestamp value={db.last_checkpoint_at} /> : "unavailable"}
+            {db.last_checkpoint_at ? (
+              <Timestamp value={db.last_checkpoint_at} />
+            ) : (
+              t("health.unavailable")
+            )}
           </div>
         </div>
       </div>
@@ -459,7 +482,7 @@ function SystemHealthCard({ db }: { db: DbStats | undefined }) {
           ))}
           {(db.sessions_by_status["running"] ?? 0) > 0 && (
             <Link href="/admin" className="text-meta text-status-running hover:underline">
-              Doctor →
+              {t("health.doctor")}
             </Link>
           )}
         </div>

--- a/apps/studio/frontend/app/page.tsx
+++ b/apps/studio/frontend/app/page.tsx
@@ -172,7 +172,7 @@ export default function DashboardPage() {
     };
   }, [allRuns, windowSec, now]);
 
-  const rangeLabel = range === "all" ? "all time" : range;
+  const rangeLabel = range === "all" ? t("metrics.allTime") : range;
 
   return (
     <main className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-6 animate-page-enter">
@@ -241,24 +241,30 @@ export default function DashboardPage() {
       {/* Secondary inventory strip */}
       {stats ? (
         <div className="flex flex-wrap items-center gap-x-5 gap-y-1 rounded border border-edge bg-surface-overlay px-4 py-2.5 text-meta text-content-muted">
-          <span className="uppercase tracking-[0.08em] text-content-muted">{t("inventory")}</span>
+          <span className="uppercase tracking-[0.08em] text-content-muted">
+            {t("inventory.label")}
+          </span>
           <Link
             href="/playbooks"
             className="transition-colors duration-100 hover:text-content-primary"
           >
-            <span className="tabular-nums text-content-secondary">{stats.playbooks}</span> playbooks
+            <span className="tabular-nums text-content-secondary">{stats.playbooks}</span>{" "}
+            {t("inventory.playbooks")}
           </Link>
           <Link
             href="/agents"
             className="transition-colors duration-100 hover:text-content-primary"
           >
-            <span className="tabular-nums text-content-secondary">{stats.agents}</span> agents
+            <span className="tabular-nums text-content-secondary">{stats.agents}</span>{" "}
+            {t("inventory.agents")}
           </Link>
           <Link href="/runs" className="transition-colors duration-100 hover:text-content-primary">
-            <span className="tabular-nums text-content-secondary">{stats.runs}</span> runs total
+            <span className="tabular-nums text-content-secondary">{stats.runs}</span>{" "}
+            {t("inventory.runsTotal")}
           </Link>
           <Link href="/shows" className="transition-colors duration-100 hover:text-content-primary">
-            <span className="tabular-nums text-content-secondary">{stats.shows}</span> shows
+            <span className="tabular-nums text-content-secondary">{stats.shows}</span>{" "}
+            {t("inventory.shows")}
           </Link>
         </div>
       ) : null}

--- a/apps/studio/frontend/app/playfield/page.tsx
+++ b/apps/studio/frontend/app/playfield/page.tsx
@@ -102,15 +102,19 @@ function ProjectSection({
   runs: RunSummary[];
   now: number;
 }) {
+  const t = useTranslations("playfield");
+  // "Unassigned" is the internal sentinel value used as a Map key and in sort
+  // comparisons — translate only the display label, never the sentinel itself.
+  const displayProject = project === "Unassigned" ? t("unassigned") : project;
   return (
     <>
       <tr className="bg-surface-overlay border-b border-edge">
         <td colSpan={5} className="px-3 py-1.5">
           <h2 className="inline font-medium text-meta uppercase tracking-[0.06em] text-content-muted">
-            {project}
+            {displayProject}
           </h2>
           <span className="ml-2 font-mono font-normal text-[10px] text-content-muted/60">
-            {runs.length} active
+            {t("groupActive", { count: runs.length })}
           </span>
         </td>
       </tr>
@@ -220,7 +224,8 @@ function PlayfieldPageInner() {
               active={projectFilter === p}
               onClick={() => setProjectFilter(projectFilter === p ? null : p)}
             >
-              {p}
+              {/* "Unassigned" is the internal sentinel — translate display only */}
+              {p === "Unassigned" ? t("unassigned") : p}
             </Button>
           ))}
         </div>

--- a/apps/studio/frontend/app/playfield/page.tsx
+++ b/apps/studio/frontend/app/playfield/page.tsx
@@ -4,6 +4,7 @@
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import Button from "@/components/Button";
 import Duration from "@/components/Duration";
 import PageHeader from "@/components/PageHeader";
@@ -121,6 +122,7 @@ function ProjectSection({
 }
 
 function PlayfieldPageInner() {
+  const t = useTranslations("playfield");
   const [runs, setRuns] = useState<RunSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -187,12 +189,14 @@ function PlayfieldPageInner() {
   return (
     <main className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-6 animate-page-enter">
       <PageHeader
-        title="Playfield"
-        subtitle="All running and queued plays and sessions across projects"
+        title={t("title")}
+        subtitle={t("subtitle")}
         density="tight"
         badges={
           !loading ? (
-            <span className="text-meta text-content-muted tabular-nums">{total} active</span>
+            <span className="text-meta text-content-muted tabular-nums">
+              {total} {t("active")}
+            </span>
           ) : null
         }
       />
@@ -206,7 +210,7 @@ function PlayfieldPageInner() {
             active={projectFilter === null}
             onClick={() => setProjectFilter(null)}
           >
-            All projects
+            {t("allProjects")}
           </Button>
           {knownProjects.map((p) => (
             <Button
@@ -232,11 +236,11 @@ function PlayfieldPageInner() {
         <table aria-busy={loading} className="w-full text-left text-body">
           <thead>
             <tr className="border-b border-edge bg-surface-overlay text-meta uppercase tracking-[0.06em] text-content-muted">
-              <th className="px-3 py-2.5 font-medium">Run</th>
-              <th className="px-3 py-2.5 font-medium">Status</th>
-              <th className="px-3 py-2.5 font-medium">Agents</th>
-              <th className="px-3 py-2.5 font-medium">Elapsed</th>
-              <th className="px-3 py-2.5 font-medium">Updated</th>
+              <th className="px-3 py-2.5 font-medium">{t("table.run")}</th>
+              <th className="px-3 py-2.5 font-medium">{t("table.status")}</th>
+              <th className="px-3 py-2.5 font-medium">{t("table.agents")}</th>
+              <th className="px-3 py-2.5 font-medium">{t("table.elapsed")}</th>
+              <th className="px-3 py-2.5 font-medium">{t("table.updated")}</th>
             </tr>
           </thead>
           <tbody>
@@ -250,7 +254,7 @@ function PlayfieldPageInner() {
               <tr>
                 <td colSpan={5} className="px-3 py-14 text-center text-body text-content-muted">
                   <span className="block mb-1 text-[11px]">{empty.runs}</span>
-                  <span className="text-meta">No sessions are currently running or queued.</span>
+                  <span className="text-meta">{t("empty")}</span>
                 </td>
               </tr>
             ) : (

--- a/apps/studio/frontend/components/nav/NavGroup.tsx
+++ b/apps/studio/frontend/components/nav/NavGroup.tsx
@@ -15,7 +15,9 @@ const GROUP_KEY: Record<string, string> = {
 const ITEM_KEY: Record<string, string> = {
   Dashboard: "items.dashboard",
   Shows: "items.shows",
+  Playfield: "items.playfield",
   Runs: "items.runs",
+  Kanban: "items.kanban",
   Projects: "items.projects",
   Teams: "items.teams",
   Invocations: "items.invocations",

--- a/apps/studio/frontend/messages/en.json
+++ b/apps/studio/frontend/messages/en.json
@@ -28,7 +28,9 @@
     "items": {
       "dashboard": "Dashboard",
       "shows": "Shows",
+      "playfield": "Playfield",
       "runs": "Runs",
+      "kanban": "Kanban",
       "projects": "Projects",
       "teams": "Teams",
       "invocations": "Invocations",
@@ -56,5 +58,82 @@
   },
   "common": {
     "skipToMain": "Skip to main content"
+  },
+  "dashboard": {
+    "title": "Dashboard",
+    "subtitle": "Operational overview",
+    "inventory": "Inventory",
+    "viewAll": "View all →",
+    "allClean": "All clean.",
+    "allCleanDetail": "No failed, stuck, or blocked runs in window.",
+    "sections": {
+      "needsAttention": "Needs attention",
+      "recentActivity": "Recent activity",
+      "shows": "Shows"
+    },
+    "metrics": {
+      "runningNow": "Running now",
+      "stale": "Stale",
+      "noStaleActivity": "no stale activity",
+      "noActivityPastThreshold": "no activity past threshold",
+      "failed": "Failed ({range})",
+      "allClean": "all clean",
+      "needsInvestigation": "needs investigation",
+      "slowRuns": "Slow runs ({range})",
+      "completedOver": "completed > {minutes}m",
+      "needsReview": "Needs review",
+      "stuck": "{count} stuck >{minutes}m"
+    },
+    "table": {
+      "run": "Run",
+      "kind": "Kind",
+      "status": "Status",
+      "duration": "Duration",
+      "started": "Started",
+      "topic": "Topic",
+      "plays": "Plays",
+      "lastUpdate": "Last update",
+      "noShows": "No shows"
+    },
+    "health": {
+      "title": "System Health",
+      "stateDb": "State DB",
+      "wal": "WAL",
+      "connections": "Connections",
+      "lastCheckpoint": "Last checkpoint",
+      "unavailable": "unavailable",
+      "doctor": "Doctor →"
+    },
+    "fetchError": "API unreachable — data may be stale"
+  },
+  "kanban": {
+    "title": "Kanban",
+    "subtitle": "Read-only lifecycle view over run status.",
+    "lanes": {
+      "queued": "Queued",
+      "running": "In Progress",
+      "review": "Review / Waiting",
+      "done": "Done",
+      "failed": "Failed",
+      "cancelled": "Cancelled"
+    },
+    "empty": {
+      "noRuns": "No runs.",
+      "awaitingEnrichment": "Awaiting lifecycle-signal enrichment."
+    }
+  },
+  "playfield": {
+    "title": "Playfield",
+    "subtitle": "All running and queued plays and sessions across projects",
+    "allProjects": "All projects",
+    "active": "active",
+    "table": {
+      "run": "Run",
+      "status": "Status",
+      "agents": "Agents",
+      "elapsed": "Elapsed",
+      "updated": "Updated"
+    },
+    "empty": "No sessions are currently running or queued."
   }
 }

--- a/apps/studio/frontend/messages/en.json
+++ b/apps/studio/frontend/messages/en.json
@@ -62,7 +62,6 @@
   "dashboard": {
     "title": "Dashboard",
     "subtitle": "Operational overview",
-    "inventory": "Inventory",
     "viewAll": "View all →",
     "allClean": "All clean.",
     "allCleanDetail": "No failed, stuck, or blocked runs in window.",
@@ -76,6 +75,7 @@
       "stale": "Stale",
       "noStaleActivity": "no stale activity",
       "noActivityPastThreshold": "no activity past threshold",
+      "allTime": "all time",
       "failed": "Failed ({range})",
       "allClean": "all clean",
       "needsInvestigation": "needs investigation",
@@ -83,6 +83,13 @@
       "completedOver": "completed > {minutes}m",
       "needsReview": "Needs review",
       "stuck": "{count} stuck >{minutes}m"
+    },
+    "inventory": {
+      "label": "Inventory",
+      "playbooks": "playbooks",
+      "agents": "agents",
+      "runsTotal": "runs total",
+      "shows": "shows"
     },
     "table": {
       "run": "Run",
@@ -109,6 +116,9 @@
   "kanban": {
     "title": "Kanban",
     "subtitle": "Read-only lifecycle view over run status.",
+    "agentCount": "{count, plural, one {# agent} other {# agents}}",
+    "runCount": "{count, plural, one {# run} other {# runs}}",
+    "runningCount": "{count, plural, one {# running} other {# running}}",
     "lanes": {
       "queued": "Queued",
       "running": "In Progress",
@@ -126,7 +136,9 @@
     "title": "Playfield",
     "subtitle": "All running and queued plays and sessions across projects",
     "allProjects": "All projects",
+    "unassigned": "Unassigned",
     "active": "active",
+    "groupActive": "{count} active",
     "table": {
       "run": "Run",
       "status": "Status",

--- a/apps/studio/frontend/messages/zh.json
+++ b/apps/studio/frontend/messages/zh.json
@@ -62,7 +62,6 @@
   "dashboard": {
     "title": "控制台",
     "subtitle": "运行概览",
-    "inventory": "资源清单",
     "viewAll": "查看全部 →",
     "allClean": "全部正常。",
     "allCleanDetail": "当前时间窗口内无失败、卡滞或阻塞的运行。",
@@ -76,6 +75,7 @@
       "stale": "无活动",
       "noStaleActivity": "无停滞活动",
       "noActivityPastThreshold": "超过阈值未活动",
+      "allTime": "全部时间",
       "failed": "失败（{range}）",
       "allClean": "全部正常",
       "needsInvestigation": "需要排查",
@@ -83,6 +83,13 @@
       "completedOver": "完成耗时 > {minutes} 分钟",
       "needsReview": "待审核",
       "stuck": "{count} 个卡滞 >{minutes}m"
+    },
+    "inventory": {
+      "label": "资源清单",
+      "playbooks": "个剧本",
+      "agents": "个智能体",
+      "runsTotal": "次运行",
+      "shows": "个展示"
     },
     "table": {
       "run": "运行",
@@ -109,6 +116,9 @@
   "kanban": {
     "title": "看板",
     "subtitle": "运行状态的只读生命周期视图。",
+    "agentCount": "# 个代理",
+    "runCount": "# 个运行",
+    "runningCount": "# 个运行中",
     "lanes": {
       "queued": "排队中",
       "running": "进行中",
@@ -126,7 +136,9 @@
     "title": "运行场",
     "subtitle": "所有项目中正在运行及排队的执行与会话",
     "allProjects": "所有项目",
+    "unassigned": "未分配",
     "active": "活跃",
+    "groupActive": "{count} 活跃",
     "table": {
       "run": "运行",
       "status": "状态",

--- a/apps/studio/frontend/messages/zh.json
+++ b/apps/studio/frontend/messages/zh.json
@@ -28,7 +28,9 @@
     "items": {
       "dashboard": "控制台",
       "shows": "展示",
+      "playfield": "运行场",
       "runs": "运行",
+      "kanban": "看板",
       "projects": "项目",
       "teams": "团队",
       "invocations": "调用",
@@ -56,5 +58,82 @@
   },
   "common": {
     "skipToMain": "跳转到主要内容"
+  },
+  "dashboard": {
+    "title": "控制台",
+    "subtitle": "运行概览",
+    "inventory": "资源清单",
+    "viewAll": "查看全部 →",
+    "allClean": "全部正常。",
+    "allCleanDetail": "当前时间窗口内无失败、卡滞或阻塞的运行。",
+    "sections": {
+      "needsAttention": "需要关注",
+      "recentActivity": "近期活动",
+      "shows": "展示"
+    },
+    "metrics": {
+      "runningNow": "运行中",
+      "stale": "无活动",
+      "noStaleActivity": "无停滞活动",
+      "noActivityPastThreshold": "超过阈值未活动",
+      "failed": "失败（{range}）",
+      "allClean": "全部正常",
+      "needsInvestigation": "需要排查",
+      "slowRuns": "慢运行（{range}）",
+      "completedOver": "完成耗时 > {minutes} 分钟",
+      "needsReview": "待审核",
+      "stuck": "{count} 个卡滞 >{minutes}m"
+    },
+    "table": {
+      "run": "运行",
+      "kind": "类型",
+      "status": "状态",
+      "duration": "耗时",
+      "started": "开始时间",
+      "topic": "主题",
+      "plays": "执行次数",
+      "lastUpdate": "最后更新",
+      "noShows": "暂无展示"
+    },
+    "health": {
+      "title": "系统健康",
+      "stateDb": "状态数据库",
+      "wal": "预写日志",
+      "connections": "连接数",
+      "lastCheckpoint": "最近检查点",
+      "unavailable": "不可用",
+      "doctor": "诊断 →"
+    },
+    "fetchError": "API 不可达 — 数据可能已过期"
+  },
+  "kanban": {
+    "title": "看板",
+    "subtitle": "运行状态的只读生命周期视图。",
+    "lanes": {
+      "queued": "排队中",
+      "running": "进行中",
+      "review": "审核 / 等待",
+      "done": "已完成",
+      "failed": "失败",
+      "cancelled": "已取消"
+    },
+    "empty": {
+      "noRuns": "暂无运行。",
+      "awaitingEnrichment": "等待生命周期信号补充。"
+    }
+  },
+  "playfield": {
+    "title": "运行场",
+    "subtitle": "所有项目中正在运行及排队的执行与会话",
+    "allProjects": "所有项目",
+    "active": "活跃",
+    "table": {
+      "run": "运行",
+      "status": "状态",
+      "agents": "智能体数",
+      "elapsed": "已耗时",
+      "updated": "更新时间"
+    },
+    "empty": "当前无正在运行或排队的会话。"
   }
 }

--- a/apps/studio/frontend/messages/zh.json
+++ b/apps/studio/frontend/messages/zh.json
@@ -116,9 +116,9 @@
   "kanban": {
     "title": "看板",
     "subtitle": "运行状态的只读生命周期视图。",
-    "agentCount": "# 个代理",
-    "runCount": "# 个运行",
-    "runningCount": "# 个运行中",
+    "agentCount": "{count, plural, other {# 个智能体}}",
+    "runCount": "{count, plural, other {# 个运行}}",
+    "runningCount": "{count, plural, other {# 个运行中}}",
     "lanes": {
       "queued": "排队中",
       "running": "进行中",
@@ -138,7 +138,7 @@
     "allProjects": "所有项目",
     "unassigned": "未分配",
     "active": "活跃",
-    "groupActive": "{count} 活跃",
+    "groupActive": "{count} 个活跃",
     "table": {
       "run": "运行",
       "status": "状态",


### PR DESCRIPTION
## Summary

- **Nav keys added**: `Kanban` (en: "Kanban" / zh: "看板") and `Playfield` (en: "Playfield" / zh: "运行场") wired through the existing `ITEM_KEY` lookup in `NavGroup.tsx` — no new mechanism invented.
- **Pages converted** using `useTranslations` (all three pages are `"use client"` components):
  - `app/kanban/page.tsx` — `PageHeader` title/subtitle, all six lane labels (`queued/running/review/done/failed/cancelled`), and empty-state messages → `kanban.*` keys.
  - `app/playfield/page.tsx` — `PageHeader` title/subtitle, five table headers, "All projects" filter button, empty-state → `playfield.*` keys.
  - `app/page.tsx` (dashboard) — `PageHeader`, five `MetricCard` labels + hints (with `{range}`, `{count}`, `{minutes}` interpolations), three `SectionHeader` titles, "View all →", `RunsTable` headers, Shows table headers, `SystemHealthCard` labels, inventory strip label, `fetchError` string → `dashboard.*` keys.
- **Catalogs updated**: `messages/en.json` and `messages/zh.json` — zh entries match the professional/concise register of existing translations.

## Strings deliberately left unconverted

- `errors.loadRuns` and `empty.runs` from `lib/copy.ts` — both kanban and playfield pages import these via `errors`/`empty` from `lib/copy`. Converting them would create double-indirection (catalog → copy.ts consumer), which the task spec explicitly prohibits.

## Verification

- `npm run lint` — 0 warnings
- `npm run typecheck` — 0 errors
- `npm run build` — clean build, both locales embedded, no missing-key warnings in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)