### PR TITLE
fix(studio/scheduler): reject flag injection in action_model/action_extra_args (closes #1404)

### DIFF
--- a/lionagi/cli/main.py
+++ b/lionagi/cli/main.py
@@ -240,7 +240,16 @@ def main(argv: list[str] | None = None) -> int:
     # Resolve verbose once before any CLI code emits. argparse happens
     # below but we need the flag now to configure log levels.
     _argv = argv if argv is not None else sys.argv[1:]
-    verbose = "-v" in _argv or "--verbose" in _argv
+    # Only scan for -v/--verbose BEFORE the '--' end-of-options sentinel so that
+    # a scheduled action_prompt containing '--verbose' does not flip verbose mode.
+    # Human CLI invocations (e.g. `li agent -v sonnet "hi"`) place -v before '--',
+    # so their behaviour is unchanged.
+    try:
+        _sentinel_idx = _argv.index("--")
+        _pre_sentinel = _argv[:_sentinel_idx]
+    except ValueError:
+        _pre_sentinel = _argv
+    verbose = "-v" in _pre_sentinel or "--verbose" in _pre_sentinel
     configure_cli_logging(verbose)
 
     # `li skill NAME` prints a CC-compatible skill body to stdout.

--- a/lionagi/studio/scheduler/subprocess.py
+++ b/lionagi/studio/scheduler/subprocess.py
@@ -21,6 +21,56 @@ _TEMPLATE_RE = re.compile(r"\{\{(\w+)\}\}")
 _VALID_ACTION_KINDS = frozenset({"agent", "flow", "fanout", "play", "flow_yaml"})
 _ALIAS_ACTION_KINDS: dict[str, str] = {"playbook": "play"}
 
+# action_model must be a safe model-spec token: alphanumerics, dots, slashes,
+# colons, hyphens and underscores only.  Values starting with '-' are rejected
+# unconditionally to block flag injection into the spawned li process (CWE-88).
+_MODEL_RE = re.compile(r"^[a-zA-Z0-9_./:@-]+$")
+
+
+def _validate_action_model(model: str) -> None:
+    """Raise ValueError if *model* could inject CLI flags into the subprocess.
+
+    A model value starting with '-' would be interpreted as a flag by the spawned
+    ``li`` process.  Values containing characters outside the safe set are also
+    rejected because they have no legitimate use in a model spec.
+
+    Policy: reject loudly rather than silently filtering so callers discover bad
+    data at write time rather than at fire time.
+    """
+    if not model:
+        return
+    if model.startswith("-"):
+        raise ValueError(
+            f"action_model {model!r} starts with '-' and would inject a CLI flag "
+            "into the spawned li process. Provide a valid model identifier."
+        )
+    if not _MODEL_RE.match(model):
+        raise ValueError(
+            f"action_model {model!r} contains characters not allowed in a model "
+            "identifier. Allowed: letters, digits, '_', '.', '/', ':', '@', '-'."
+        )
+
+
+def _validate_extra_args(extra: list) -> None:
+    """Raise ValueError if any element of *extra* starts with '-'.
+
+    Elements starting with '-' are CLI flags and would be injected verbatim into
+    the argv of the spawned li process (CWE-88).  Positional tokens that do not
+    start with '-' are accepted.
+
+    Policy: reject loudly with the offending element named so callers can fix the
+    schedule spec rather than silently receiving a process that behaves differently
+    from what was intended.
+    """
+    for item in extra:
+        token = str(item)
+        if token.startswith("-"):
+            raise ValueError(
+                f"action_extra_args element {token!r} starts with '-' and would "
+                "inject a CLI flag into the spawned li process. Only positional "
+                "(non-flag) tokens are permitted in action_extra_args."
+            )
+
 
 def _render_template(template: str, context: dict) -> str:
     """Replace {{var}} placeholders with values from trigger context."""
@@ -58,6 +108,14 @@ def build_argv(schedule: dict, trigger_context: dict) -> tuple[list[str], str | 
     project = schedule.get("action_project")
     extra = schedule.get("action_extra_args") or []
 
+    # Defensive validation: reject flag-injection vectors before touching argv.
+    # These checks mirror the service-layer boundary in services/schedules.py;
+    # having them here ensures the subprocess is never spawned with injected flags
+    # regardless of how the schedule dict was created.
+    _validate_action_model(model)
+    if isinstance(extra, list):
+        _validate_extra_args(extra)
+
     # Render template variables from trigger context
     if prompt:
         prompt = _render_template(prompt, trigger_context)
@@ -94,6 +152,7 @@ def build_argv(schedule: dict, trigger_context: dict) -> tuple[list[str], str | 
     if project:
         argv += ["--project", project]
 
+    # extra has already been validated above; extend argv with safe positional tokens.
     if isinstance(extra, list):
         argv.extend(str(a) for a in extra)
 

--- a/lionagi/studio/scheduler/subprocess.py
+++ b/lionagi/studio/scheduler/subprocess.py
@@ -91,6 +91,12 @@ def _validate_extra_args(extra: list) -> None:
     Policy: reject loudly with the offending element named so callers can fix the
     schedule spec rather than silently receiving a process that behaves differently
     from what was intended.
+
+    Note: extra tokens are appended after the subcommand's own positionals.
+    Parsers for agent/flow/fanout do not accept extra positionals, so non-empty
+    action_extra_args will cause those subcommands to exit rc 2 at fire time.
+    action_extra_args is only meaningful for future subcommand extensions or the
+    play kind; restrict its use accordingly.
     """
     for item in extra:
         token = str(item)
@@ -100,6 +106,30 @@ def _validate_extra_args(extra: list) -> None:
                 "inject a CLI flag into the spawned li process. Only positional "
                 "(non-flag) tokens are permitted in action_extra_args."
             )
+
+
+def _validate_prompt(prompt: str) -> None:
+    """Raise ValueError if *prompt* is the literal end-of-options sentinel '--'.
+
+    The '--' sentinel is special to argparse: when placed as the first positional
+    after our own '--' sentinel, argparse consumes it as the separator token and
+    the actual prompt value reaches the runner as an empty string (or causes a
+    'required' error), rather than arriving as the prompt text.
+
+    Freeform prompts are otherwise unrestricted — any other content including
+    leading '-' characters (e.g. '--bypass', '--verbose') is safe because the
+    structural fix in build_argv places a '--' before all positionals.  The sole
+    forbidden value is the exact two-character token '--'.
+
+    Prompt values like '-- --', '-- text', or '--' embedded in longer strings
+    are all permitted; only the exact singleton '--' is rejected.
+    """
+    if prompt == "--":
+        raise ValueError(
+            "action_prompt value '--' is not allowed: the literal end-of-options "
+            "token would be silently consumed by argparse rather than reaching the "
+            "runner as prompt text. Use any other prompt content."
+        )
 
 
 def _render_template(template: str, context: dict) -> str:
@@ -143,6 +173,8 @@ def build_argv(schedule: dict, trigger_context: dict) -> tuple[list[str], str | 
     # having them here ensures the subprocess is never spawned with injected flags
     # regardless of how the schedule dict was created.
     _validate_action_model(model)
+    if prompt:
+        _validate_prompt(prompt)
     if agent:
         _validate_identifier(agent, "action_agent")
     if project:

--- a/lionagi/studio/scheduler/subprocess.py
+++ b/lionagi/studio/scheduler/subprocess.py
@@ -26,6 +26,11 @@ _ALIAS_ACTION_KINDS: dict[str, str] = {"playbook": "play"}
 # unconditionally to block flag injection into the spawned li process (CWE-88).
 _MODEL_RE = re.compile(r"^[a-zA-Z0-9_./:@-]+$")
 
+# Identifier fields (action_agent, action_project, action_playbook) share the
+# same character set as model specs: they name agents, projects, and playbooks
+# and have no legitimate use for leading '-'.
+_IDENT_RE = _MODEL_RE
+
 
 def _validate_action_model(model: str) -> None:
     """Raise ValueError if *model* could inject CLI flags into the subprocess.
@@ -48,6 +53,31 @@ def _validate_action_model(model: str) -> None:
         raise ValueError(
             f"action_model {model!r} contains characters not allowed in a model "
             "identifier. Allowed: letters, digits, '_', '.', '/', ':', '@', '-'."
+        )
+
+
+def _validate_identifier(value: str, field_name: str) -> None:
+    """Raise ValueError if *value* (an identifier field) starts with '-'.
+
+    Covers action_agent, action_project, and action_playbook.  These fields are
+    identifier-shaped (name a profile, project, or playbook) and must not start
+    with '-'.  A leading '-' would cause argparse to misinterpret the value as a
+    flag, producing an unexpected usage error rather than a flag toggle — still
+    fragile behaviour that callers should never be able to trigger.
+
+    Policy: loud rejection at write time (same as action_model).
+    """
+    if not value:
+        return
+    if value.startswith("-"):
+        raise ValueError(
+            f"{field_name} {value!r} starts with '-' and is not a valid identifier. "
+            "Identifier fields must not begin with '-'."
+        )
+    if not _IDENT_RE.match(value):
+        raise ValueError(
+            f"{field_name} {value!r} contains characters not allowed in an identifier. "
+            "Allowed: letters, digits, '_', '.', '/', ':', '@', '-'."
         )
 
 
@@ -113,6 +143,12 @@ def build_argv(schedule: dict, trigger_context: dict) -> tuple[list[str], str | 
     # having them here ensures the subprocess is never spawned with injected flags
     # regardless of how the schedule dict was created.
     _validate_action_model(model)
+    if agent:
+        _validate_identifier(agent, "action_agent")
+    if project:
+        _validate_identifier(project, "action_project")
+    if playbook:
+        _validate_identifier(playbook, "action_playbook")
     if isinstance(extra, list):
         _validate_extra_args(extra)
 
@@ -123,18 +159,51 @@ def build_argv(schedule: dict, trigger_context: dict) -> tuple[list[str], str | 
     argv = ["uv", "run", "li"]
     tmp_path: str | None = None
 
+    # argv structure (CWE-88 hardening):
+    #
+    #   Named flags (--agent, --project, -f …) FIRST, then the '--' end-of-options
+    #   sentinel, then positional arguments (model, prompt).
+    #
+    # The '--' sentinel tells argparse to stop treating subsequent tokens as
+    # option strings, so a prompt like '--bypass' is parsed as the prompt VALUE
+    # rather than toggling the bypass flag — making action_prompt injection-proof
+    # without restricting freeform prompt text at all.
+    #
+    # flow_yaml is a special case: the YAML file supplies the prompt, so the
+    # prompt positional is OMITTED entirely.  Empirically verified: the CLI
+    # parser reads the prompt from the -f spec file (prompt: key) and overwrites
+    # args.prompt, so a positional prompt is redundant and would only open a
+    # second injection surface.  Shape: li o flow -f <tmp> -- <model>
+
     if kind == "agent":
-        argv += ["agent", model, prompt]
+        # Named flags first (--agent must come before --)
+        flags: list[str] = []
         if agent:
-            argv += ["--agent", agent]
+            flags += ["--agent", agent]
+        if project:
+            flags += ["--project", project]
+        argv += ["agent", *flags, "--", model, prompt]
+
     elif kind == "flow":
-        argv += ["o", "flow", model, prompt]
+        flags = []
+        if project:
+            flags += ["--project", project]
+        argv += ["o", "flow", *flags, "--", model, prompt]
+
     elif kind == "fanout":
-        argv += ["o", "fanout", model, prompt]
+        flags = []
+        if project:
+            flags += ["--project", project]
+        argv += ["o", "fanout", *flags, "--", model, prompt]
+
     elif kind == "play":
+        # `li play NAME` is a positional-only subcommand; '--' is not needed
+        # because playbook names are validated as identifiers above and there
+        # is no freeform prompt positional.
         argv += ["play"]
         if playbook:
             argv.append(playbook)
+
     elif kind == "flow_yaml":
         # Write the inline YAML spec to a temp file so `li o flow -f <path>`
         # can read it.  The caller is responsible for deleting tmp_path after
@@ -147,12 +216,16 @@ def build_argv(schedule: dict, trigger_context: dict) -> tuple[list[str], str | 
         except Exception:
             os.unlink(tmp_path)
             raise
-        argv += ["o", "flow", model, prompt, "-f", tmp_path]
-
-    if project:
-        argv += ["--project", project]
+        # Named flags first (-f must come before --), then -- sentinel, then
+        # model positional only (no prompt positional — YAML supplies it).
+        flags = ["-f", tmp_path]
+        if project:
+            flags += ["--project", project]
+        argv += ["o", "flow", *flags, "--", model]
 
     # extra has already been validated above; extend argv with safe positional tokens.
+    # These are appended AFTER the subcommand's positionals, after '--', so they
+    # are treated as positional values by the subcommand's parser.
     if isinstance(extra, list):
         argv.extend(str(a) for a in extra)
 

--- a/lionagi/studio/scheduler/subprocess.py
+++ b/lionagi/studio/scheduler/subprocess.py
@@ -172,9 +172,19 @@ def build_argv(schedule: dict, trigger_context: dict) -> tuple[list[str], str | 
     # These checks mirror the service-layer boundary in services/schedules.py;
     # having them here ensures the subprocess is never spawned with injected flags
     # regardless of how the schedule dict was created.
+    #
+    # IMPORTANT — order of operations for action_prompt:
+    # action_prompt may contain {{var}} template placeholders that are expanded
+    # from trigger_context at fire time.  A stored prompt like '{{payload}}' passes
+    # pre-render validation but could render into the forbidden '--' sentinel when
+    # a trigger context supplies {"payload": "--"}.  To close this window we
+    # validate action_prompt AFTER rendering, not before.
+    #
+    # action_model, action_extra_args, action_agent, action_project, and
+    # action_playbook are NOT passed through _render_template — they are used
+    # verbatim from the schedule dict, so their validation before the render
+    # step is correct and sufficient.
     _validate_action_model(model)
-    if prompt:
-        _validate_prompt(prompt)
     if agent:
         _validate_identifier(agent, "action_agent")
     if project:
@@ -184,9 +194,13 @@ def build_argv(schedule: dict, trigger_context: dict) -> tuple[list[str], str | 
     if isinstance(extra, list):
         _validate_extra_args(extra)
 
-    # Render template variables from trigger context
+    # Render template variables from trigger context FIRST, then validate the
+    # rendered prompt so that template-injected values (e.g. '{{payload}}' →
+    # '--') are caught before argv construction.
     if prompt:
         prompt = _render_template(prompt, trigger_context)
+    if prompt:
+        _validate_prompt(prompt)
 
     argv = ["uv", "run", "li"]
     tmp_path: str | None = None

--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -15,6 +15,36 @@ _VALID_EFFORT_LEVELS: frozenset[str] = frozenset(
 )
 _PRESERVE_DASHED: frozenset[str] = frozenset({"argument-hint"})
 
+# Re-use the same validation helpers as subprocess.py so the service boundary
+# and the spawn boundary enforce identical rules.  Imported lazily inside the
+# validation helpers to avoid circular imports at module load time.
+
+
+def _svc_validate_action_model(model: str | None) -> None:
+    """Service-boundary check: reject action_model values that inject CLI flags.
+
+    Delegates to subprocess._validate_action_model so the allowed-character
+    rule is defined in exactly one place.
+    """
+    if not model:
+        return
+    from lionagi.studio.scheduler.subprocess import _validate_action_model
+
+    _validate_action_model(model)
+
+
+def _svc_validate_extra_args(extra: list | None) -> None:
+    """Service-boundary check: reject action_extra_args elements that inject CLI flags.
+
+    Delegates to subprocess._validate_extra_args so the flag-rejection rule is
+    defined in exactly one place.
+    """
+    if not extra:
+        return
+    from lionagi.studio.scheduler.subprocess import _validate_extra_args
+
+    _validate_extra_args(extra)
+
 
 def _validate_flow_yaml_spec(yaml_text: str) -> str | None:
     """Parse and validate an inline YAML flow spec.
@@ -181,6 +211,10 @@ async def create_schedule(data: dict[str, Any]) -> dict[str, Any]:
     if not data.get("action_kind"):
         raise ValueError("action_kind is required")
 
+    # Reject flag-injection vectors at write time so bad specs never reach storage.
+    _svc_validate_action_model(data.get("action_model"))
+    _svc_validate_extra_args(data.get("action_extra_args"))
+
     if data.get("action_kind") == "flow_yaml":
         yaml_text = data.get("action_flow_yaml") or ""
         if not yaml_text.strip():
@@ -211,6 +245,12 @@ async def update_schedule(schedule_id: str, fields: dict[str, Any]) -> bool:
         schedule = await db.get_schedule(schedule_id)
         if not schedule:
             return False
+
+        # Reject flag-injection vectors in the patched fields before writing.
+        if "action_model" in fields:
+            _svc_validate_action_model(fields["action_model"])
+        if "action_extra_args" in fields:
+            _svc_validate_extra_args(fields["action_extra_args"])
 
         # Merge proposed fields over the existing schedule and re-validate
         # flow_yaml constraints so a PATCH cannot create invalid state that

--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -61,6 +61,22 @@ def _svc_validate_extra_args(extra: list | None) -> None:
     _validate_extra_args(extra)
 
 
+def _svc_validate_prompt(prompt: str | None) -> None:
+    """Service-boundary check: reject action_prompt == '--'.
+
+    The literal end-of-options token '--' is silently consumed by argparse and
+    would not reach the runner as prompt text.  All other prompt content —
+    including values starting with '-' — is unrestricted because the structural
+    argv fix places a '--' sentinel before all positionals.  Delegates to
+    subprocess._validate_prompt so the rule is defined in one place.
+    """
+    if not prompt:
+        return
+    from lionagi.studio.scheduler.subprocess import _validate_prompt
+
+    _validate_prompt(prompt)
+
+
 def _validate_flow_yaml_spec(yaml_text: str) -> str | None:
     """Parse and validate an inline YAML flow spec.
 
@@ -228,6 +244,7 @@ async def create_schedule(data: dict[str, Any]) -> dict[str, Any]:
 
     # Reject flag-injection vectors at write time so bad specs never reach storage.
     _svc_validate_action_model(data.get("action_model"))
+    _svc_validate_prompt(data.get("action_prompt"))
     _svc_validate_identifier(data.get("action_agent"), "action_agent")
     _svc_validate_identifier(data.get("action_project"), "action_project")
     _svc_validate_identifier(data.get("action_playbook"), "action_playbook")
@@ -267,6 +284,8 @@ async def update_schedule(schedule_id: str, fields: dict[str, Any]) -> bool:
         # Reject flag-injection vectors in the patched fields before writing.
         if "action_model" in fields:
             _svc_validate_action_model(fields["action_model"])
+        if "action_prompt" in fields:
+            _svc_validate_prompt(fields["action_prompt"])
         if "action_agent" in fields:
             _svc_validate_identifier(fields["action_agent"], "action_agent")
         if "action_project" in fields:

--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -33,6 +33,21 @@ def _svc_validate_action_model(model: str | None) -> None:
     _validate_action_model(model)
 
 
+def _svc_validate_identifier(value: str | None, field_name: str) -> None:
+    """Service-boundary check: reject identifier fields (agent/project/playbook) starting with '-'.
+
+    Identifier fields are not freeform text — they name profiles, projects, or
+    playbooks and must not start with '-'.  A leading '-' causes argparse to
+    treat the value as a flag, producing either a flag toggle or a usage error
+    depending on the subcommand.  Reject both outcomes at write time.
+    """
+    if not value:
+        return
+    from lionagi.studio.scheduler.subprocess import _validate_identifier
+
+    _validate_identifier(value, field_name)
+
+
 def _svc_validate_extra_args(extra: list | None) -> None:
     """Service-boundary check: reject action_extra_args elements that inject CLI flags.
 
@@ -213,6 +228,9 @@ async def create_schedule(data: dict[str, Any]) -> dict[str, Any]:
 
     # Reject flag-injection vectors at write time so bad specs never reach storage.
     _svc_validate_action_model(data.get("action_model"))
+    _svc_validate_identifier(data.get("action_agent"), "action_agent")
+    _svc_validate_identifier(data.get("action_project"), "action_project")
+    _svc_validate_identifier(data.get("action_playbook"), "action_playbook")
     _svc_validate_extra_args(data.get("action_extra_args"))
 
     if data.get("action_kind") == "flow_yaml":
@@ -249,6 +267,12 @@ async def update_schedule(schedule_id: str, fields: dict[str, Any]) -> bool:
         # Reject flag-injection vectors in the patched fields before writing.
         if "action_model" in fields:
             _svc_validate_action_model(fields["action_model"])
+        if "action_agent" in fields:
+            _svc_validate_identifier(fields["action_agent"], "action_agent")
+        if "action_project" in fields:
+            _svc_validate_identifier(fields["action_project"], "action_project")
+        if "action_playbook" in fields:
+            _svc_validate_identifier(fields["action_playbook"], "action_playbook")
         if "action_extra_args" in fields:
             _svc_validate_extra_args(fields["action_extra_args"])
 

--- a/tests/apps_studio_server/test_audit_remediation.py
+++ b/tests/apps_studio_server/test_audit_remediation.py
@@ -613,3 +613,148 @@ class TestSchedulePatchRouterValidation:
         client = self._client_for_svc_mock(monkeypatch, _not_found)
         r = client.patch("/api/schedules/no-such-id", json={"name": "new-name"})
         assert r.status_code == 404, f"expected 404, got {r.status_code}: {r.text}"
+
+
+# ---------------------------------------------------------------------------
+# CWE-88 argument injection — router-level 400 responses (closes #1404)
+# ---------------------------------------------------------------------------
+
+
+class TestScheduleArgvInjectionRouterValidation:
+    """Router POST and PATCH /api/schedules must translate flag-injection
+    ValueError → HTTP 400 for action_model and action_extra_args rejections.
+
+    Mirrors TestSchedulePatchRouterValidation: the route handler already maps
+    ValueError→400; these tests confirm that the new service-layer checks for
+    action_model/action_extra_args surface as 400 responses through the router.
+    """
+
+    @staticmethod
+    def _client_patch(monkeypatch, mock_fn):
+        """Patch sched_svc.update_schedule and return a TestClient."""
+        from fastapi.testclient import TestClient
+
+        import lionagi.studio.services.schedules as sched_svc
+        from lionagi.studio.app import app
+
+        monkeypatch.setattr(sched_svc, "update_schedule", mock_fn)
+        return TestClient(app, raise_server_exceptions=False)
+
+    @staticmethod
+    def _client_post(monkeypatch, mock_fn):
+        """Patch sched_svc.create_schedule and return a TestClient."""
+        from fastapi.testclient import TestClient
+
+        import lionagi.studio.services.schedules as sched_svc
+        from lionagi.studio.app import app
+
+        monkeypatch.setattr(sched_svc, "create_schedule", mock_fn)
+        return TestClient(app, raise_server_exceptions=False)
+
+    # -- PATCH action_model injection --
+
+    def test_patch_action_model_flag_returns_400(self, monkeypatch):
+        """PATCH action_model='--bypass' → HTTP 400 with detail naming the field."""
+
+        async def _reject(_schedule_id, _fields):
+            raise ValueError("action_model '--bypass' starts with '-' and would inject a CLI flag")
+
+        client = self._client_patch(monkeypatch, _reject)
+        r = client.patch(
+            "/api/schedules/sched-abc",
+            json={"action_model": "--bypass"},
+        )
+        assert r.status_code == 400, f"expected 400, got {r.status_code}: {r.text}"
+        assert "--bypass" in r.json().get("detail", "") or "action_model" in r.json().get(
+            "detail", ""
+        )
+
+    def test_patch_action_model_yolo_returns_400(self, monkeypatch):
+        """PATCH action_model='--yolo' → HTTP 400."""
+
+        async def _reject(_schedule_id, _fields):
+            raise ValueError("action_model '--yolo' starts with '-' and would inject a CLI flag")
+
+        client = self._client_patch(monkeypatch, _reject)
+        r = client.patch(
+            "/api/schedules/sched-abc",
+            json={"action_model": "--yolo"},
+        )
+        assert r.status_code == 400, f"expected 400, got {r.status_code}: {r.text}"
+
+    # -- PATCH action_extra_args injection --
+
+    def test_patch_extra_args_flag_returns_400(self, monkeypatch):
+        """PATCH action_extra_args=['--bypass'] → HTTP 400."""
+
+        async def _reject(_schedule_id, _fields):
+            raise ValueError(
+                "action_extra_args element '--bypass' starts with '-' and would inject a CLI flag"
+            )
+
+        client = self._client_patch(monkeypatch, _reject)
+        r = client.patch(
+            "/api/schedules/sched-abc",
+            json={"action_extra_args": ["--bypass"]},
+        )
+        assert r.status_code == 400, f"expected 400, got {r.status_code}: {r.text}"
+        assert "--bypass" in r.json().get("detail", "") or "action_extra_args" in r.json().get(
+            "detail", ""
+        )
+
+    def test_patch_extra_args_yolo_returns_400(self, monkeypatch):
+        """PATCH action_extra_args=['--yolo'] → HTTP 400."""
+
+        async def _reject(_schedule_id, _fields):
+            raise ValueError(
+                "action_extra_args element '--yolo' starts with '-' and would inject a CLI flag"
+            )
+
+        client = self._client_patch(monkeypatch, _reject)
+        r = client.patch(
+            "/api/schedules/sched-abc",
+            json={"action_extra_args": ["--yolo"]},
+        )
+        assert r.status_code == 400, f"expected 400, got {r.status_code}: {r.text}"
+
+    # -- POST (create) action_model injection --
+
+    def test_create_action_model_flag_returns_400(self, monkeypatch):
+        """POST action_model='--bypass' → HTTP 400."""
+
+        async def _reject(_data):
+            raise ValueError("action_model '--bypass' starts with '-' and would inject a CLI flag")
+
+        client = self._client_post(monkeypatch, _reject)
+        r = client.post(
+            "/api/schedules/",
+            json={
+                "name": "bad-model-sched",
+                "trigger_type": "cron",
+                "action_kind": "agent",
+                "action_model": "--bypass",
+                "action_prompt": "hello",
+            },
+        )
+        assert r.status_code == 400, f"expected 400, got {r.status_code}: {r.text}"
+
+    def test_create_extra_args_flag_returns_400(self, monkeypatch):
+        """POST action_extra_args=['--bypass'] → HTTP 400."""
+
+        async def _reject(_data):
+            raise ValueError(
+                "action_extra_args element '--bypass' starts with '-' and would inject a CLI flag"
+            )
+
+        client = self._client_post(monkeypatch, _reject)
+        r = client.post(
+            "/api/schedules/",
+            json={
+                "name": "bad-extra-sched",
+                "trigger_type": "cron",
+                "action_kind": "agent",
+                "action_model": "sonnet",
+                "action_extra_args": ["--bypass"],
+            },
+        )
+        assert r.status_code == 400, f"expected 400, got {r.status_code}: {r.text}"

--- a/tests/apps_studio_server/test_audit_remediation.py
+++ b/tests/apps_studio_server/test_audit_remediation.py
@@ -758,3 +758,141 @@ class TestScheduleArgvInjectionRouterValidation:
             },
         )
         assert r.status_code == 400, f"expected 400, got {r.status_code}: {r.text}"
+
+
+# ---------------------------------------------------------------------------
+# CWE-88 argument injection — real-service router tests (closes #1404, round 2)
+#
+# These tests use the REAL service layer (no mock) with a temp SQLite DB.
+# They validate that flag-injection rejections in create_schedule propagate
+# through the router as HTTP 400 responses.  Codex concern: the mocked router
+# tests verify HTTP translation only, not the actual validation logic.
+# ---------------------------------------------------------------------------
+
+
+def _real_svc_client(monkeypatch, tmp_path: Path) -> TestClient:
+    """Return a TestClient backed by the real service layer + temp DB.
+
+    We monkeypatch DEFAULT_DB_PATH in both the state.db module and the
+    schedules service module so StateDB() uses an isolated temp file.
+    No mock is applied to create_schedule.
+    """
+    from fastapi.testclient import TestClient
+
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.schedules as sched_svc_mod
+    from lionagi.studio.app import app
+
+    db_file = tmp_path / "test_state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_file)
+    monkeypatch.setattr(sched_svc_mod, "DEFAULT_DB_PATH", db_file)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestScheduleArgvInjectionRealService:
+    """Router → REAL service → temp DB: each flag-injection field must return 400.
+
+    Codex's concern: the mocked router tests (TestScheduleArgvInjectionRouterValidation)
+    verify HTTP translation but not the actual validation logic.  These tests go through
+    the full stack (router → real create_schedule → real validators → DB write) with
+    only the DB path replaced by a temp file.
+    """
+
+    def test_create_action_model_flag_real_svc_returns_400(self, monkeypatch, tmp_path) -> None:
+        """POST action_model='--bypass' through real service → 400."""
+        client = _real_svc_client(monkeypatch, tmp_path)
+        r = client.post(
+            "/api/schedules/",
+            json={
+                "name": "bad-model-real",
+                "trigger_type": "cron",
+                "action_kind": "agent",
+                "action_model": "--bypass",
+                "action_prompt": "hello",
+            },
+        )
+        assert r.status_code == 400, f"expected 400, got {r.status_code}: {r.text}"
+        detail = r.json().get("detail", "")
+        assert "--bypass" in detail or "action_model" in detail, (
+            f"Expected error mentioning --bypass or action_model, got: {detail!r}"
+        )
+
+    def test_create_extra_args_flag_real_svc_returns_400(self, monkeypatch, tmp_path) -> None:
+        """POST action_extra_args=['--bypass'] through real service → 400."""
+        client = _real_svc_client(monkeypatch, tmp_path)
+        r = client.post(
+            "/api/schedules/",
+            json={
+                "name": "bad-extra-real",
+                "trigger_type": "cron",
+                "action_kind": "agent",
+                "action_model": "sonnet",
+                "action_prompt": "hello",
+                "action_extra_args": ["--bypass"],
+            },
+        )
+        assert r.status_code == 400, f"expected 400, got {r.status_code}: {r.text}"
+        detail = r.json().get("detail", "")
+        assert "--bypass" in detail or "action_extra_args" in detail, (
+            f"Expected error mentioning --bypass or action_extra_args, got: {detail!r}"
+        )
+
+    def test_create_action_agent_flag_real_svc_returns_400(self, monkeypatch, tmp_path) -> None:
+        """POST action_agent='--bypass' through real service → 400."""
+        client = _real_svc_client(monkeypatch, tmp_path)
+        r = client.post(
+            "/api/schedules/",
+            json={
+                "name": "bad-agent-real",
+                "trigger_type": "cron",
+                "action_kind": "agent",
+                "action_model": "sonnet",
+                "action_prompt": "hello",
+                "action_agent": "--bypass",
+            },
+        )
+        assert r.status_code == 400, f"expected 400, got {r.status_code}: {r.text}"
+        detail = r.json().get("detail", "")
+        assert "--bypass" in detail or "action_agent" in detail, (
+            f"Expected error mentioning --bypass or action_agent, got: {detail!r}"
+        )
+
+    def test_create_action_project_flag_real_svc_returns_400(self, monkeypatch, tmp_path) -> None:
+        """POST action_project='--bypass' through real service → 400."""
+        client = _real_svc_client(monkeypatch, tmp_path)
+        r = client.post(
+            "/api/schedules/",
+            json={
+                "name": "bad-project-real",
+                "trigger_type": "cron",
+                "action_kind": "agent",
+                "action_model": "sonnet",
+                "action_prompt": "hello",
+                "action_project": "--bypass",
+            },
+        )
+        assert r.status_code == 400, f"expected 400, got {r.status_code}: {r.text}"
+        detail = r.json().get("detail", "")
+        assert "--bypass" in detail or "action_project" in detail, (
+            f"Expected error mentioning --bypass or action_project, got: {detail!r}"
+        )
+
+    def test_create_action_playbook_flag_real_svc_returns_400(self, monkeypatch, tmp_path) -> None:
+        """POST action_playbook='--bypass' through real service → 400."""
+        client = _real_svc_client(monkeypatch, tmp_path)
+        r = client.post(
+            "/api/schedules/",
+            json={
+                "name": "bad-playbook-real",
+                "trigger_type": "cron",
+                "action_kind": "play",
+                "action_model": "sonnet",
+                "action_prompt": "hello",
+                "action_playbook": "--bypass",
+            },
+        )
+        assert r.status_code == 400, f"expected 400, got {r.status_code}: {r.text}"
+        detail = r.json().get("detail", "")
+        assert "--bypass" in detail or "action_playbook" in detail, (
+            f"Expected error mentioning --bypass or action_playbook, got: {detail!r}"
+        )

--- a/tests/apps_studio_server/test_audit_remediation.py
+++ b/tests/apps_studio_server/test_audit_remediation.py
@@ -896,3 +896,28 @@ class TestScheduleArgvInjectionRealService:
         assert "--bypass" in detail or "action_playbook" in detail, (
             f"Expected error mentioning --bypass or action_playbook, got: {detail!r}"
         )
+
+    def test_create_action_prompt_sentinel_real_svc_returns_400(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """POST action_prompt='--' through real service → 400 (codex round 2).
+
+        The literal end-of-options token '--' is silently consumed by argparse;
+        the service must reject it with a descriptive error.
+        """
+        client = _real_svc_client(monkeypatch, tmp_path)
+        r = client.post(
+            "/api/schedules/",
+            json={
+                "name": "bad-prompt-sentinel",
+                "trigger_type": "cron",
+                "action_kind": "agent",
+                "action_model": "sonnet",
+                "action_prompt": "--",
+            },
+        )
+        assert r.status_code == 400, f"expected 400, got {r.status_code}: {r.text}"
+        detail = r.json().get("detail", "")
+        assert "'--'" in detail or "action_prompt" in detail or "end-of-options" in detail, (
+            f"Expected error mentioning '--' or action_prompt, got: {detail!r}"
+        )

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,0 +1,35 @@
+"""Shared fixtures for CLI tests."""
+
+import logging
+
+import pytest
+
+# Loggers mutated by lionagi.cli._logging.configure_cli_logging(). Tests that
+# drive main() end-to-end trigger that call, which sets propagate=False and
+# attaches stderr handlers — breaking caplog for any test that runs later in
+# the same worker (e.g. tests/cli/orchestrate/test_flow_spec_file.py).
+_CLI_LOGGERS = (
+    "lionagi.cli.progress",
+    "lionagi.cli.hint",
+    "lionagi.cli.warn",
+    "lionagi.cli.error",
+    "claude-cli",
+    "codex-cli",
+    "gemini-cli",
+    "lionagi",
+)
+
+
+@pytest.fixture(autouse=True)
+def _restore_cli_logging():
+    """Snapshot and restore CLI logger state around every test."""
+    saved = {}
+    for name in _CLI_LOGGERS:
+        logger = logging.getLogger(name)
+        saved[name] = (logger.level, logger.propagate, list(logger.handlers))
+    yield
+    for name, (level, propagate, handlers) in saved.items():
+        logger = logging.getLogger(name)
+        logger.setLevel(level)
+        logger.propagate = propagate
+        logger.handlers[:] = handlers

--- a/tests/cli/test_argv_injection.py
+++ b/tests/cli/test_argv_injection.py
@@ -597,3 +597,229 @@ class TestUpdateScheduleInjectionRejection:
             asyncio.run(_go())
 
         assert not write_called["value"], "DB write must not be called when validation rejects"
+
+
+# ---------------------------------------------------------------------------
+# action_prompt == '--' sentinel rejection (codex round 2)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildArgvPromptSentinelRejection:
+    """build_argv must reject action_prompt exactly equal to '--'.
+
+    The literal end-of-options token '--' is consumed by argparse as a separator
+    rather than reaching the runner as prompt text.  Any other prompt content —
+    including '--bypass', '--verbose', '-- --', '-- trailing' — is permitted.
+    """
+
+    def test_prompt_double_dash_raises(self):
+        """action_prompt='--' must raise ValueError (silently eaten by argparse)."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        with pytest.raises(ValueError, match="'--'"):
+            build_argv(_schedule(action_prompt="--"), {})
+
+    def test_prompt_double_dash_in_flow_kind_raises(self):
+        """flow kind also rejects prompt == '--'."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        with pytest.raises(ValueError, match="'--'"):
+            build_argv(_schedule(action_kind="flow", action_prompt="--"), {})
+
+    def test_prompt_double_dash_in_fanout_kind_raises(self):
+        """fanout kind also rejects prompt == '--'."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        with pytest.raises(ValueError, match="'--'"):
+            build_argv(_schedule(action_kind="fanout", action_prompt="--"), {})
+
+    def test_prompt_double_dash_prefix_allowed(self):
+        """'-- --' (starts with -- but not exactly --) must be accepted."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        argv, tmp = build_argv(_schedule(action_prompt="-- --"), {})
+        assert tmp is None
+        # Value appears after sentinel in argv
+        assert "-- --" in argv
+
+    def test_prompt_double_dash_with_trailing_text_allowed(self):
+        """'-- some trailing text' must be accepted and appear in argv."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        argv, tmp = build_argv(_schedule(action_prompt="-- some trailing"), {})
+        assert tmp is None
+        assert "-- some trailing" in argv
+
+    def test_prompt_bypass_still_allowed(self):
+        """'--bypass' as prompt must still pass (structural -- fix handles it)."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        argv, tmp = build_argv(_schedule(action_prompt="--bypass"), {})
+        assert tmp is None
+        sentinel_idx = argv.index("--")
+        assert "--bypass" in argv[sentinel_idx + 1 :]
+
+    def test_service_create_prompt_double_dash_raises(self):
+        """create_schedule rejects action_prompt == '--'."""
+        from lionagi.studio.services.schedules import create_schedule
+
+        data = {
+            "name": "bad-prompt-sentinel",
+            "trigger_type": "cron",
+            "action_kind": "agent",
+            "action_model": "sonnet",
+            "action_prompt": "--",
+        }
+        with pytest.raises(ValueError, match="'--'"):
+            asyncio.run(create_schedule(data))
+
+    def test_service_update_prompt_double_dash_raises(self):
+        """update_schedule rejects action_prompt == '--' in PATCH."""
+        from unittest.mock import AsyncMock, patch
+
+        from lionagi.studio.services.schedules import update_schedule
+
+        existing = {
+            "id": "sid-p",
+            "name": "p",
+            "trigger_type": "cron",
+            "action_kind": "agent",
+            "action_model": "sonnet",
+            "action_extra_args": [],
+        }
+
+        class _MockDB:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            async def get_schedule(self, sid):
+                return existing
+
+            async def update_schedule(self, sid, **kw):
+                pass
+
+        async def _go():
+            with patch(
+                "lionagi.studio.services.schedules.StateDB",
+                return_value=_MockDB(),
+            ):
+                await update_schedule("sid-p", {"action_prompt": "--"})
+
+        with pytest.raises(ValueError, match="'--'"):
+            asyncio.run(_go())
+
+
+# ---------------------------------------------------------------------------
+# cli/main.py — pre-parse verbose scan must be sentinel-aware (codex round 2)
+# ---------------------------------------------------------------------------
+
+
+class TestMainVerboseScanSentinelAware:
+    """The pre-argparse --verbose scan in main() must only inspect tokens
+    before the '--' sentinel.  A scheduled action_prompt='--verbose' must
+    not flip verbose mode.
+
+    These tests check the fix directly: the pre-sentinel slice of argv must
+    NOT contain '--verbose' when it appears after the '--' sentinel, and MUST
+    contain it when it appears before the sentinel (normal human usage).
+
+    Note: -v/--verbose is a subcommand flag (added by add_common_cli_args),
+    not a global li flag.  Human invocation is `li agent --verbose sonnet hi`,
+    NOT `li -v agent sonnet hi` (the latter is unrecognised by the top-level
+    parser).  The pre-parse scan sees all of argv (before the fix); the fix
+    restricts it to the pre-sentinel slice.
+    """
+
+    def test_pre_sentinel_slice_excludes_verbose_after_sentinel(self):
+        """Built argv for agent kind with action_prompt='--verbose':
+        the tokens BEFORE '--' must not include '--verbose'."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        sched = {
+            "id": "t",
+            "action_kind": "agent",
+            "action_model": "sonnet",
+            "action_prompt": "--verbose",
+            "action_agent": None,
+            "action_project": None,
+            "action_extra_args": [],
+        }
+        full_argv, _ = build_argv(sched, {})
+        cli_argv = full_argv[3:]  # strip 'uv run li'
+
+        # Reproduce the sentinel-aware scan from main()
+        try:
+            sep_idx = cli_argv.index("--")
+            pre_sentinel = cli_argv[:sep_idx]
+        except ValueError:
+            pre_sentinel = cli_argv
+
+        verbose = "-v" in pre_sentinel or "--verbose" in pre_sentinel
+        assert not verbose, (
+            f"pre-sentinel scan incorrectly set verbose=True. "
+            f"pre_sentinel={pre_sentinel!r}, full argv={cli_argv!r}"
+        )
+        # '--verbose' must be AFTER the sentinel (in the positionals section)
+        assert "--verbose" in cli_argv[cli_argv.index("--") + 1 :], (
+            f"'--verbose' should appear as prompt value after '--'. argv={cli_argv!r}"
+        )
+
+    def test_pre_sentinel_slice_includes_verbose_before_sentinel(self):
+        """Human `li agent --verbose sonnet hello` (no '--' sentinel):
+        the pre-sentinel slice IS all of argv, so verbose=True is correct."""
+        # Without a '--' sentinel in the argv, the full argv is pre_sentinel.
+        cli_argv = ["agent", "--verbose", "sonnet", "hello"]
+
+        try:
+            sep_idx = cli_argv.index("--")
+            pre_sentinel = cli_argv[:sep_idx]
+        except ValueError:
+            pre_sentinel = cli_argv
+
+        verbose = "-v" in pre_sentinel or "--verbose" in pre_sentinel
+        assert verbose, (
+            f"Expected verbose=True for 'agent --verbose sonnet hello'. "
+            f"pre_sentinel={pre_sentinel!r}"
+        )
+
+    def test_scheduled_verbose_prompt_reaches_runner_as_value(self):
+        """End-to-end: action_prompt='--verbose' reaches _run_agent as the prompt
+        value with verbose=False (the argparse-parsed verbose, not the pre-scan)."""
+        from unittest.mock import patch as _patch
+
+        import lionagi.cli.agent as agent_mod
+        from lionagi.cli.main import main
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        captured = {}
+
+        async def _fake_run_agent(model_str, prompt, *, verbose=False, **kwargs):
+            captured["prompt"] = prompt
+            captured["verbose"] = verbose
+            return "out", "provider", "branch", "completed"
+
+        sched = {
+            "id": "t",
+            "action_kind": "agent",
+            "action_model": "sonnet",
+            "action_prompt": "--verbose",
+            "action_agent": None,
+            "action_project": None,
+            "action_extra_args": [],
+        }
+        full_argv, _ = build_argv(sched, {})
+        cli_argv = full_argv[3:]
+
+        with _patch.object(agent_mod, "_run_agent", _fake_run_agent):
+            rc = main(cli_argv)
+
+        assert rc == 0, f"Expected rc=0, got {rc}"
+        assert captured.get("prompt") == "--verbose", (
+            f"Expected '--verbose' as prompt value, got {captured.get('prompt')!r}"
+        )
+        assert captured.get("verbose") is False, (
+            f"Expected verbose=False (argparse-parsed), got {captured.get('verbose')!r}"
+        )

--- a/tests/cli/test_argv_injection.py
+++ b/tests/cli/test_argv_injection.py
@@ -1,0 +1,390 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for argument injection hardening in build_argv (CWE-88).
+
+Covers action_model and action_extra_args flag-injection rejection at:
+  1. The subprocess layer (build_argv defensive validation).
+  2. The service layer (create_schedule / update_schedule boundary).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _schedule(**kwargs) -> dict:
+    base = {
+        "id": "sched-inj",
+        "name": "injection-test",
+        "trigger_type": "cron",
+        "action_kind": "agent",
+        "action_model": "sonnet",
+        "action_prompt": "hello",
+        "action_agent": None,
+        "action_playbook": None,
+        "action_project": None,
+        "action_extra_args": [],
+    }
+    base.update(kwargs)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# subprocess.build_argv — action_model validation
+# ---------------------------------------------------------------------------
+
+
+class TestBuildArgvActionModelInjection:
+    """build_argv must reject action_model values that inject CLI flags."""
+
+    def test_model_starting_with_dash_raises(self):
+        """action_model starting with '-' must raise ValueError."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        with pytest.raises(ValueError, match="starts with '-'"):
+            build_argv(_schedule(action_model="--bypass"), {})
+
+    def test_model_bypass_flag_raises(self):
+        """Literal --bypass must be rejected."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        with pytest.raises(ValueError, match="starts with '-'"):
+            build_argv(_schedule(action_model="--bypass"), {})
+
+    def test_model_yolo_flag_raises(self):
+        """Literal --yolo must be rejected."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        with pytest.raises(ValueError, match="starts with '-'"):
+            build_argv(_schedule(action_model="--yolo"), {})
+
+    def test_model_project_flag_raises(self):
+        """Literal --project must be rejected."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        with pytest.raises(ValueError, match="starts with '-'"):
+            build_argv(_schedule(action_model="--project"), {})
+
+    def test_model_short_flag_raises(self):
+        """Single-dash flag (-m) must be rejected."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        with pytest.raises(ValueError, match="starts with '-'"):
+            build_argv(_schedule(action_model="-m"), {})
+
+    def test_model_invalid_chars_raises(self):
+        """Semicolons and spaces in action_model must be rejected."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        with pytest.raises(ValueError, match="characters not allowed"):
+            build_argv(_schedule(action_model="gpt-4; rm -rf /"), {})
+
+    def test_model_empty_string_accepted(self):
+        """Empty action_model is allowed (means 'no model specified')."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        argv, tmp = build_argv(_schedule(action_model=""), {})
+        assert tmp is None
+        assert "uv" in argv
+
+    def test_model_none_accepted(self):
+        """None action_model is allowed."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        argv, tmp = build_argv(_schedule(action_model=None), {})
+        assert tmp is None
+
+    def test_model_valid_identifiers_accepted(self):
+        """Legitimate model identifiers must pass without error."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        valid_models = [
+            "gpt-4",
+            "claude-sonnet-4-6",
+            "claude_code/sonnet",
+            "openai/gpt-4.1-mini",
+            "anthropic:claude-3-5-sonnet-20241022",
+            "us.anthropic.claude-3-5-sonnet",
+            "provider/model:version",
+        ]
+        for model in valid_models:
+            argv, tmp = build_argv(_schedule(action_model=model), {})
+            assert model in argv, f"model {model!r} should appear in argv"
+            if tmp:
+                import os
+
+                os.unlink(tmp)
+
+
+# ---------------------------------------------------------------------------
+# subprocess.build_argv — action_extra_args validation
+# ---------------------------------------------------------------------------
+
+
+class TestBuildArgvExtraArgsInjection:
+    """build_argv must reject action_extra_args elements that inject CLI flags."""
+
+    def test_extra_bypass_flag_raises(self):
+        """'--bypass' in action_extra_args must raise ValueError."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        with pytest.raises(ValueError, match="starts with '-'"):
+            build_argv(_schedule(action_extra_args=["--bypass"]), {})
+
+    def test_extra_yolo_flag_raises(self):
+        """'--yolo' in action_extra_args must raise ValueError."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        with pytest.raises(ValueError, match="starts with '-'"):
+            build_argv(_schedule(action_extra_args=["--yolo"]), {})
+
+    def test_extra_short_flag_raises(self):
+        """'-v' in action_extra_args must raise ValueError."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        with pytest.raises(ValueError, match="starts with '-'"):
+            build_argv(_schedule(action_extra_args=["-v"]), {})
+
+    def test_extra_flag_in_mixed_list_raises(self):
+        """A flag mixed with legitimate tokens must be caught."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        with pytest.raises(ValueError, match="starts with '-'"):
+            build_argv(_schedule(action_extra_args=["my-task", "--bypass", "arg2"]), {})
+
+    def test_extra_names_the_offending_element(self):
+        """The error message must include the offending token."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        with pytest.raises(ValueError, match="--yolo"):
+            build_argv(_schedule(action_extra_args=["ok-token", "--yolo"]), {})
+
+    def test_extra_empty_list_accepted(self):
+        """Empty action_extra_args is valid."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        argv, tmp = build_argv(_schedule(action_extra_args=[]), {})
+        assert "uv" in argv
+        assert tmp is None
+
+    def test_extra_none_accepted(self):
+        """None action_extra_args is valid."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        argv, tmp = build_argv(_schedule(action_extra_args=None), {})
+        assert "uv" in argv
+        assert tmp is None
+
+    def test_extra_positional_tokens_accepted(self):
+        """Non-flag positional tokens must pass and appear in argv."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        tokens = ["my-playbook", "some_task", "123"]
+        argv, tmp = build_argv(_schedule(action_extra_args=tokens), {})
+        for tok in tokens:
+            assert tok in argv, f"token {tok!r} should be in argv"
+        assert tmp is None
+
+
+# ---------------------------------------------------------------------------
+# service layer — create_schedule validation
+# ---------------------------------------------------------------------------
+
+
+class TestCreateScheduleInjectionRejection:
+    """create_schedule must reject flag-injection in action_model and action_extra_args."""
+
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    def test_create_with_model_flag_raises_value_error(self):
+        """create_schedule raises ValueError when action_model starts with '-'."""
+        from lionagi.studio.services.schedules import create_schedule
+
+        data = {
+            "name": "bad-model",
+            "trigger_type": "cron",
+            "action_kind": "agent",
+            "action_model": "--bypass",
+            "action_prompt": "hello",
+        }
+
+        with pytest.raises(ValueError, match="starts with '-'"):
+            self._run(create_schedule(data))
+
+    def test_create_with_yolo_model_raises(self):
+        """create_schedule rejects --yolo in action_model."""
+        from lionagi.studio.services.schedules import create_schedule
+
+        data = {
+            "name": "bad-yolo",
+            "trigger_type": "cron",
+            "action_kind": "agent",
+            "action_model": "--yolo",
+        }
+
+        with pytest.raises(ValueError, match="starts with '-'"):
+            self._run(create_schedule(data))
+
+    def test_create_with_extra_args_flag_raises_value_error(self):
+        """create_schedule raises ValueError when action_extra_args contains a flag."""
+        from lionagi.studio.services.schedules import create_schedule
+
+        data = {
+            "name": "bad-extra",
+            "trigger_type": "cron",
+            "action_kind": "agent",
+            "action_model": "sonnet",
+            "action_extra_args": ["--bypass"],
+        }
+
+        with pytest.raises(ValueError, match="starts with '-'"):
+            self._run(create_schedule(data))
+
+    def test_create_valid_model_and_extra_does_not_raise(self, monkeypatch):
+        """create_schedule with safe values proceeds past validation."""
+        from lionagi.studio.services.schedules import create_schedule
+
+        async def _fake_create(schedule):
+            pass
+
+        with patch("lionagi.studio.services.schedules.StateDB") as MockDB:
+            mock_db = AsyncMock()
+            mock_db.create_schedule = AsyncMock()
+            MockDB.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+            MockDB.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            data = {
+                "name": "good-sched",
+                "trigger_type": "cron",
+                "action_kind": "agent",
+                "action_model": "claude-sonnet-4-6",
+                "action_extra_args": ["my-task"],
+            }
+            result = self._run(create_schedule(data))
+        assert "id" in result
+
+
+# ---------------------------------------------------------------------------
+# service layer — update_schedule (PATCH) validation
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateScheduleInjectionRejection:
+    """update_schedule must reject flag-injection in patched action_model and action_extra_args."""
+
+    def _mock_db(self, existing: dict):
+        """Return a context-manager mock that returns *existing* from get_schedule."""
+
+        class _MockDB:
+            async def __aenter__(self_inner):
+                return self_inner
+
+            async def __aexit__(self_inner, *a):
+                return False
+
+            async def get_schedule(self_inner, sid):
+                return existing
+
+            async def update_schedule(self_inner, sid, **kw):
+                pass
+
+        return _MockDB()
+
+    def _run_update(self, existing: dict, fields: dict):
+        from lionagi.studio.services.schedules import update_schedule
+
+        async def _go():
+            with patch(
+                "lionagi.studio.services.schedules.StateDB",
+                return_value=self._mock_db(existing),
+            ):
+                return await update_schedule(existing["id"], fields)
+
+        return asyncio.run(_go())
+
+    def _existing(self, **over) -> dict:
+        base = {
+            "id": "sid-patch",
+            "name": "patch-test",
+            "trigger_type": "cron",
+            "action_kind": "agent",
+            "action_model": "sonnet",
+            "action_extra_args": [],
+        }
+        base.update(over)
+        return base
+
+    def test_patch_model_flag_raises(self):
+        """PATCH action_model='--bypass' raises ValueError."""
+        with pytest.raises(ValueError, match="starts with '-'"):
+            self._run_update(self._existing(), {"action_model": "--bypass"})
+
+    def test_patch_model_yolo_raises(self):
+        """PATCH action_model='--yolo' raises ValueError."""
+        with pytest.raises(ValueError, match="starts with '-'"):
+            self._run_update(self._existing(), {"action_model": "--yolo"})
+
+    def test_patch_extra_args_flag_raises(self):
+        """PATCH action_extra_args=['--bypass'] raises ValueError."""
+        with pytest.raises(ValueError, match="starts with '-'"):
+            self._run_update(self._existing(), {"action_extra_args": ["--bypass"]})
+
+    def test_patch_extra_args_yolo_raises(self):
+        """PATCH action_extra_args=['--yolo'] raises ValueError."""
+        with pytest.raises(ValueError, match="starts with '-'"):
+            self._run_update(self._existing(), {"action_extra_args": ["--yolo"]})
+
+    def test_patch_valid_fields_does_not_raise(self):
+        """PATCH with safe values proceeds past validation."""
+        result = self._run_update(
+            self._existing(),
+            {"action_model": "gpt-4", "action_extra_args": ["my-task"]},
+        )
+        assert result is True
+
+    def test_patch_db_write_not_called_on_rejection(self):
+        """When validation fails the DB write must not be reached."""
+        from lionagi.studio.services.schedules import update_schedule
+
+        write_called = {"value": False}
+
+        class _MockDB:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            async def get_schedule(self, sid):
+                return {
+                    "id": "sid-x",
+                    "name": "x",
+                    "trigger_type": "cron",
+                    "action_kind": "agent",
+                    "action_model": "sonnet",
+                    "action_extra_args": [],
+                }
+
+            async def update_schedule(self, sid, **kw):
+                write_called["value"] = True
+
+        async def _go():
+            with patch(
+                "lionagi.studio.services.schedules.StateDB",
+                return_value=_MockDB(),
+            ):
+                await update_schedule("sid-x", {"action_model": "--bypass"})
+
+        with pytest.raises(ValueError):
+            asyncio.run(_go())
+
+        assert not write_called["value"], "DB write must not be called when validation rejects"

--- a/tests/cli/test_argv_injection.py
+++ b/tests/cli/test_argv_injection.py
@@ -823,3 +823,83 @@ class TestMainVerboseScanSentinelAware:
         assert captured.get("verbose") is False, (
             f"Expected verbose=False (argparse-parsed), got {captured.get('verbose')!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# build_argv — template injection: rendered prompt must be validated post-render
+# (codex round 3 — order-of-operations bypass)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildArgvTemplateInjection:
+    """build_argv must validate action_prompt AFTER _render_template, not before.
+
+    A stored prompt like '{{payload}}' passes pre-render validation.  If
+    trigger_context supplies {"payload": "--"}, the rendered value is the
+    forbidden sentinel.  The fix: _validate_prompt runs on the rendered value,
+    so such template reconstruction is caught at spawn time.
+    """
+
+    def test_template_renders_sentinel_raises_agent(self):
+        """agent kind: '{{payload}}' + context {"payload": "--"} must raise ValueError."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        with pytest.raises(ValueError, match="'--'"):
+            build_argv(
+                _schedule(action_kind="agent", action_prompt="{{payload}}"),
+                {"payload": "--"},
+            )
+
+    def test_template_renders_sentinel_raises_flow(self):
+        """flow kind: '{{payload}}' + context {"payload": "--"} must raise ValueError."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        with pytest.raises(ValueError, match="'--'"):
+            build_argv(
+                _schedule(action_kind="flow", action_prompt="{{payload}}"),
+                {"payload": "--"},
+            )
+
+    def test_template_renders_sentinel_raises_fanout(self):
+        """fanout kind: '{{payload}}' + context {"payload": "--"} must raise ValueError."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        with pytest.raises(ValueError, match="'--'"):
+            build_argv(
+                _schedule(action_kind="fanout", action_prompt="{{payload}}"),
+                {"payload": "--"},
+            )
+
+    def test_template_renders_safe_value_passes(self):
+        """'{{payload}}' + context {"payload": "hello"} must build argv normally."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        argv, tmp = build_argv(
+            _schedule(action_kind="agent", action_prompt="{{payload}}"),
+            {"payload": "hello"},
+        )
+        assert tmp is None
+        sentinel_idx = argv.index("--")
+        assert "hello" in argv[sentinel_idx + 1 :]
+
+    def test_template_renders_bypass_flag_safe(self):
+        """'{{payload}}' + context {"payload": "--bypass"} reaches argv as value,
+        not as a flag.  (The structural -- fix handles leading-dash prompts;
+        only the exact '--' singleton is forbidden.)"""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        argv, tmp = build_argv(
+            _schedule(action_kind="agent", action_prompt="{{payload}}"),
+            {"payload": "--bypass"},
+        )
+        assert tmp is None
+        sentinel_idx = argv.index("--")
+        assert "--bypass" in argv[sentinel_idx + 1 :]
+
+    def test_template_literal_sentinel_in_stored_prompt_raises(self):
+        """A stored prompt that IS literally '--' (no template) is still rejected —
+        pre-render path unchanged."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        with pytest.raises(ValueError, match="'--'"):
+            build_argv(_schedule(action_prompt="--"), {})

--- a/tests/cli/test_argv_injection.py
+++ b/tests/cli/test_argv_injection.py
@@ -6,6 +6,8 @@
 Covers action_model and action_extra_args flag-injection rejection at:
   1. The subprocess layer (build_argv defensive validation).
   2. The service layer (create_schedule / update_schedule boundary).
+  3. action_agent / action_project / action_playbook identifier validation.
+  4. Structural: -- sentinel and flow_yaml prompt-drop assertions.
 """
 
 from __future__ import annotations
@@ -27,7 +29,7 @@ def _schedule(**kwargs) -> dict:
         "trigger_type": "cron",
         "action_kind": "agent",
         "action_model": "sonnet",
-        "action_prompt": "hello",
+        "action_prompt": "hello world",
         "action_agent": None,
         "action_playbook": None,
         "action_project": None,
@@ -195,6 +197,174 @@ class TestBuildArgvExtraArgsInjection:
 
 
 # ---------------------------------------------------------------------------
+# subprocess.build_argv — identifier fields (action_agent/project/playbook)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildArgvIdentifierInjection:
+    """build_argv must reject leading-dash values in identifier fields."""
+
+    def test_action_agent_dash_prefix_raises(self):
+        """action_agent starting with '-' must raise ValueError."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        with pytest.raises(ValueError, match="action_agent"):
+            build_argv(_schedule(action_agent="--bypass"), {})
+
+    def test_action_project_dash_prefix_raises(self):
+        """action_project starting with '-' must raise ValueError."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        with pytest.raises(ValueError, match="action_project"):
+            build_argv(_schedule(action_project="--yolo"), {})
+
+    def test_action_playbook_dash_prefix_raises(self):
+        """action_playbook starting with '-' must raise ValueError in play kind."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        with pytest.raises(ValueError, match="action_playbook"):
+            build_argv(
+                _schedule(action_kind="play", action_playbook="--bypass"),
+                {},
+            )
+
+    def test_action_agent_valid_accepted(self):
+        """A valid agent name must pass."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        argv, tmp = build_argv(_schedule(action_agent="my-agent"), {})
+        assert "my-agent" in argv
+        assert tmp is None
+
+    def test_action_project_valid_accepted(self):
+        """A valid project name must pass."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        argv, tmp = build_argv(_schedule(action_project="my-project"), {})
+        assert "--project" in argv
+        assert "my-project" in argv
+        assert tmp is None
+
+
+# ---------------------------------------------------------------------------
+# build_argv structural: -- sentinel and positional ordering
+# ---------------------------------------------------------------------------
+
+
+class TestBuildArgvSentinelStructure:
+    """build_argv must emit a '--' sentinel before positionals so freeform
+    prompt text cannot be parsed as CLI flags by argparse."""
+
+    def test_agent_argv_has_sentinel_before_prompt(self):
+        """agent kind: '--' appears before the model and prompt positionals."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        argv, tmp = build_argv(_schedule(action_kind="agent", action_prompt="--bypass"), {})
+        assert tmp is None
+        assert "--" in argv
+        sentinel_idx = argv.index("--")
+        # model and prompt must come AFTER the sentinel
+        assert "sonnet" in argv[sentinel_idx + 1 :]
+        assert "--bypass" in argv[sentinel_idx + 1 :]
+        # --bypass must NOT appear before the sentinel (no flag injection)
+        assert "--bypass" not in argv[:sentinel_idx]
+
+    def test_flow_argv_has_sentinel_before_prompt(self):
+        """flow kind: '--' appears before model and prompt positionals."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        argv, tmp = build_argv(_schedule(action_kind="flow", action_prompt="--yolo"), {})
+        assert tmp is None
+        assert "--" in argv
+        sentinel_idx = argv.index("--")
+        assert "--yolo" in argv[sentinel_idx + 1 :]
+        assert "--yolo" not in argv[:sentinel_idx]
+
+    def test_fanout_argv_has_sentinel_before_prompt(self):
+        """fanout kind: '--' appears before model and prompt positionals."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        argv, tmp = build_argv(_schedule(action_kind="fanout", action_prompt="--fast"), {})
+        assert tmp is None
+        assert "--" in argv
+        sentinel_idx = argv.index("--")
+        assert "--fast" in argv[sentinel_idx + 1 :]
+        assert "--fast" not in argv[:sentinel_idx]
+
+    def test_flow_yaml_has_no_prompt_positional(self):
+        """flow_yaml kind must NOT include the prompt as a positional in argv.
+
+        The YAML file supplies the prompt.  Including the prompt positional
+        would open a second injection surface for action_prompt.
+        """
+        import os
+
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        sched = {
+            "id": "sy",
+            "action_kind": "flow_yaml",
+            "action_model": "sonnet",
+            "action_prompt": "--bypass",  # hostile prompt — must NOT appear as flag
+            "action_project": None,
+            "action_extra_args": [],
+            "action_flow_yaml": "prompt: yaml-supplied\n",
+        }
+        argv, tmp_path = build_argv(sched, {})
+        try:
+            # The hostile prompt must not appear at all in the argv — it is
+            # ignored because the YAML file supplies the prompt for flow_yaml.
+            assert "--bypass" not in argv, (
+                "action_prompt must not be included in flow_yaml argv "
+                f"(prompt injection still reachable): {argv}"
+            )
+            # -f must appear (pointing to the yaml temp file)
+            assert "-f" in argv
+            # '--' sentinel must be present
+            assert "--" in argv
+        finally:
+            if tmp_path and os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+
+    def test_flow_yaml_named_flags_before_sentinel(self):
+        """flow_yaml: -f <path> must appear BEFORE the '--' sentinel."""
+        import os
+
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        sched = {
+            "id": "sy",
+            "action_kind": "flow_yaml",
+            "action_model": "sonnet",
+            "action_prompt": "hello",
+            "action_project": None,
+            "action_extra_args": [],
+            "action_flow_yaml": "prompt: yaml\n",
+        }
+        argv, tmp_path = build_argv(sched, {})
+        try:
+            sentinel_idx = argv.index("--")
+            f_idx = argv.index("-f")
+            assert f_idx < sentinel_idx, f"-f must appear before '--' sentinel: argv={argv}"
+        finally:
+            if tmp_path and os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+
+    def test_project_flag_placed_before_sentinel(self):
+        """--project <name> must appear before the '--' sentinel in agent kind."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        argv, tmp = build_argv(_schedule(action_kind="agent", action_project="my-proj"), {})
+        assert tmp is None
+        assert "--" in argv
+        sentinel_idx = argv.index("--")
+        proj_idx = argv.index("--project")
+        assert proj_idx < sentinel_idx, (
+            "--project must be before '--' sentinel so it is not misinterpreted"
+        )
+
+
+# ---------------------------------------------------------------------------
 # service layer — create_schedule validation
 # ---------------------------------------------------------------------------
 
@@ -249,13 +419,38 @@ class TestCreateScheduleInjectionRejection:
         with pytest.raises(ValueError, match="starts with '-'"):
             self._run(create_schedule(data))
 
-    def test_create_valid_model_and_extra_does_not_raise(self, monkeypatch):
-        """create_schedule with safe values proceeds past validation."""
+    def test_create_with_agent_flag_raises(self):
+        """create_schedule rejects action_agent starting with '-'."""
         from lionagi.studio.services.schedules import create_schedule
 
-        async def _fake_create(schedule):
-            pass
+        data = {
+            "name": "bad-agent",
+            "trigger_type": "cron",
+            "action_kind": "agent",
+            "action_model": "sonnet",
+            "action_agent": "--bypass",
+        }
 
+        with pytest.raises(ValueError, match="action_agent"):
+            self._run(create_schedule(data))
+
+    def test_create_with_project_flag_raises(self):
+        """create_schedule rejects action_project starting with '-'."""
+        from lionagi.studio.services.schedules import create_schedule
+
+        data = {
+            "name": "bad-proj",
+            "trigger_type": "cron",
+            "action_kind": "agent",
+            "action_model": "sonnet",
+            "action_project": "--yolo",
+        }
+
+        with pytest.raises(ValueError, match="action_project"):
+            self._run(create_schedule(data))
+
+    def test_create_valid_model_and_extra_does_not_raise(self):
+        """create_schedule with safe values proceeds past validation."""
         with patch("lionagi.studio.services.schedules.StateDB") as MockDB:
             mock_db = AsyncMock()
             mock_db.create_schedule = AsyncMock()
@@ -269,7 +464,11 @@ class TestCreateScheduleInjectionRejection:
                 "action_model": "claude-sonnet-4-6",
                 "action_extra_args": ["my-task"],
             }
-            result = self._run(create_schedule(data))
+            result = self._run(
+                __import__(
+                    "lionagi.studio.services.schedules", fromlist=["create_schedule"]
+                ).create_schedule(data)
+            )
         assert "id" in result
 
 
@@ -342,6 +541,16 @@ class TestUpdateScheduleInjectionRejection:
         """PATCH action_extra_args=['--yolo'] raises ValueError."""
         with pytest.raises(ValueError, match="starts with '-'"):
             self._run_update(self._existing(), {"action_extra_args": ["--yolo"]})
+
+    def test_patch_agent_flag_raises(self):
+        """PATCH action_agent='--bypass' raises ValueError."""
+        with pytest.raises(ValueError, match="action_agent"):
+            self._run_update(self._existing(), {"action_agent": "--bypass"})
+
+    def test_patch_project_flag_raises(self):
+        """PATCH action_project='--yolo' raises ValueError."""
+        with pytest.raises(ValueError, match="action_project"):
+            self._run_update(self._existing(), {"action_project": "--yolo"})
 
     def test_patch_valid_fields_does_not_raise(self):
         """PATCH with safe values proceeds past validation."""

--- a/tests/cli/test_argv_parser_regression.py
+++ b/tests/cli/test_argv_parser_regression.py
@@ -554,3 +554,103 @@ class TestDoubleDashSentinelEdgeCases:
                 },
                 {},
             )
+
+
+# ---------------------------------------------------------------------------
+# Parser-level: template-rendered sentinel rejection (codex round 3)
+# ---------------------------------------------------------------------------
+
+
+class TestTemplateRenderedSentinelRejection:
+    """build_argv must validate action_prompt AFTER _render_template.
+
+    Codex round 3 finding: a stored '{{payload}}' passes pre-render validation,
+    but trigger_context {"payload": "--"} renders it into the forbidden sentinel
+    before argv construction.  The fix moves _validate_prompt to post-render.
+    These tests run through real build_argv (not the parser) to confirm that
+    the rendered reconstruction is caught at spawn time, not silently passed.
+    """
+
+    def test_template_payload_renders_sentinel_agent_raises(self) -> None:
+        """agent: '{{payload}}' + {"payload": "--"} → ValueError before argv built."""
+        import pytest as _pytest
+
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        with _pytest.raises(ValueError, match="'--'"):
+            build_argv(
+                {
+                    "id": "t",
+                    "action_kind": "agent",
+                    "action_model": "sonnet",
+                    "action_prompt": "{{payload}}",
+                    "action_agent": None,
+                    "action_project": None,
+                    "action_extra_args": [],
+                },
+                {"payload": "--"},
+            )
+
+    def test_template_payload_renders_sentinel_flow_raises(self) -> None:
+        """flow: '{{payload}}' + {"payload": "--"} → ValueError before argv built."""
+        import pytest as _pytest
+
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        with _pytest.raises(ValueError, match="'--'"):
+            build_argv(
+                {
+                    "id": "t",
+                    "action_kind": "flow",
+                    "action_model": "sonnet",
+                    "action_prompt": "{{payload}}",
+                    "action_agent": None,
+                    "action_project": None,
+                    "action_extra_args": [],
+                },
+                {"payload": "--"},
+            )
+
+    def test_template_payload_renders_sentinel_fanout_raises(self) -> None:
+        """fanout: '{{payload}}' + {"payload": "--"} → ValueError before argv built."""
+        import pytest as _pytest
+
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        with _pytest.raises(ValueError, match="'--'"):
+            build_argv(
+                {
+                    "id": "t",
+                    "action_kind": "fanout",
+                    "action_model": "sonnet",
+                    "action_prompt": "{{payload}}",
+                    "action_agent": None,
+                    "action_project": None,
+                    "action_extra_args": [],
+                },
+                {"payload": "--"},
+            )
+
+    def test_template_payload_safe_reaches_parser_correctly(self) -> None:
+        """'{{payload}}' + {"payload": "hello"} renders to 'hello' and builds valid argv."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        full_argv, _ = build_argv(
+            {
+                "id": "t",
+                "action_kind": "agent",
+                "action_model": "sonnet",
+                "action_prompt": "{{payload}}",
+                "action_agent": None,
+                "action_project": None,
+                "action_extra_args": [],
+            },
+            {"payload": "hello world"},
+        )
+        # The rendered prompt must appear after the '--' sentinel
+        cli_argv = full_argv[3:]  # strip 'uv run li'
+        sep_idx = cli_argv.index("--")
+        positionals = cli_argv[sep_idx + 1 :]
+        assert "hello world" in positionals, (
+            f"Expected rendered prompt 'hello world' in positionals {positionals!r}"
+        )

--- a/tests/cli/test_argv_parser_regression.py
+++ b/tests/cli/test_argv_parser_regression.py
@@ -1,0 +1,470 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Parser-level regression tests for CWE-88 fix (closes #1404, codex round 2).
+
+These tests take the BUILT argv from build_argv() for each action_kind and run
+it through the real lionagi.cli.main.main() parser with terminal run functions
+patched.  They assert that hostile action_prompt values (--bypass, --yolo,
+--fast, --verbose) arrive as the prompt VALUE rather than toggling the
+corresponding boolean flags.
+
+The structural fix: build_argv places a '--' end-of-options sentinel before
+positionals for agent/flow/fanout, and drops the prompt positional entirely
+for flow_yaml (the YAML file supplies the prompt via spec.get("prompt")).
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Shared capture store — reset before each parametrized test invocation
+# ---------------------------------------------------------------------------
+
+_CAPTURED: dict[str, Any] = {}
+
+
+def _reset() -> None:
+    _CAPTURED.clear()
+
+
+# ---------------------------------------------------------------------------
+# Fake run functions
+# Each captures the positional and keyword arguments it receives so tests can
+# assert on flag values without executing any network/agent logic.
+# ---------------------------------------------------------------------------
+
+
+async def _fake_run_agent(
+    model_str: str | None,
+    prompt: str,
+    *,
+    bypass: bool = False,
+    yolo: bool = False,
+    fast: bool = False,
+    verbose: bool = False,
+    **kwargs: Any,
+) -> tuple[str, str, str, str]:
+    _CAPTURED["agent"] = {
+        "model_str": model_str,
+        "prompt": prompt,
+        "bypass": bypass,
+        "yolo": yolo,
+        "fast": fast,
+        "verbose": verbose,
+    }
+    return "output", "provider", "branch-id", "completed"
+
+
+async def _fake_run_flow(
+    model_spec: str,
+    prompt: str,
+    *,
+    bypass: bool = False,
+    yolo: bool = False,
+    fast: bool = False,
+    verbose: bool = False,
+    **kwargs: Any,
+) -> tuple[str, str]:
+    _CAPTURED["flow"] = {
+        "model_spec": model_spec,
+        "prompt": prompt,
+        "bypass": bypass,
+        "yolo": yolo,
+        "fast": fast,
+        "verbose": verbose,
+    }
+    return "output", "completed"
+
+
+async def _fake_run_fanout(
+    model_spec: str,
+    prompt: str,
+    *,
+    bypass: bool = False,
+    yolo: bool = False,
+    fast: bool = False,
+    verbose: bool = False,
+    **kwargs: Any,
+) -> str:
+    _CAPTURED["fanout"] = {
+        "model_spec": model_spec,
+        "prompt": prompt,
+        "bypass": bypass,
+        "yolo": yolo,
+        "fast": fast,
+        "verbose": verbose,
+    }
+    return "output"
+
+
+# ---------------------------------------------------------------------------
+# Helper: run main() with argv (strips 'uv run li' wrapper from build_argv output)
+# ---------------------------------------------------------------------------
+
+
+def _run_main_with_argv(argv: list[str]) -> int:
+    """Call lionagi.cli.main.main(argv) with run functions patched."""
+    import lionagi.cli.agent as agent_mod
+    import lionagi.cli.orchestrate as orch_mod
+    import lionagi.cli.orchestrate.fanout as fanout_mod
+    import lionagi.cli.orchestrate.flow as flow_mod
+    from lionagi.cli.main import main
+
+    with (
+        patch.object(agent_mod, "_run_agent", _fake_run_agent),
+        patch.object(flow_mod, "_run_flow", _fake_run_flow),
+        patch.object(orch_mod, "_run_flow", _fake_run_flow),
+        patch.object(fanout_mod, "_run_fanout", _fake_run_fanout),
+        patch.object(orch_mod, "_run_fanout", _fake_run_fanout),
+    ):
+        return main(argv)
+
+
+def _argv_without_wrapper(argv: list[str]) -> list[str]:
+    """Strip the leading 'uv', 'run', 'li' from build_argv output."""
+    return argv[3:]
+
+
+# ---------------------------------------------------------------------------
+# agent kind
+# ---------------------------------------------------------------------------
+
+HOSTILE_PROMPTS = ["--bypass", "--yolo", "--fast", "--verbose"]
+
+
+class TestAgentParserPromptInjection:
+    """li agent: hostile action_prompt must arrive as VALUE, not toggle a flag."""
+
+    def _build(self, prompt: str) -> list[str]:
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        sched = {
+            "id": "test",
+            "action_kind": "agent",
+            "action_model": "sonnet",
+            "action_prompt": prompt,
+            "action_agent": None,
+            "action_project": None,
+            "action_extra_args": [],
+        }
+        argv, _ = build_argv(sched, {})
+        return _argv_without_wrapper(argv)
+
+    @pytest.mark.parametrize("hostile", HOSTILE_PROMPTS)
+    def test_hostile_prompt_is_value_not_flag(self, hostile: str) -> None:
+        _reset()
+        argv = self._build(hostile)
+        # Sentinel must be present so positionals are protected
+        assert "--" in argv, f"'--' sentinel missing from agent argv: {argv}"
+        rc = _run_main_with_argv(argv)
+        assert rc == 0, f"Expected rc=0 for argv={argv}, got {rc}"
+        c = _CAPTURED.get("agent")
+        assert c is not None, "run_agent was never called"
+        assert c["prompt"] == hostile, (
+            f"Hostile prompt {hostile!r} not received as prompt value; "
+            f"got prompt={c['prompt']!r}. Likely parsed as a flag."
+        )
+        assert c["bypass"] is False, f"bypass=True after hostile prompt {hostile!r}"
+        assert c["yolo"] is False, f"yolo=True after hostile prompt {hostile!r}"
+        assert c["fast"] is False, f"fast=True after hostile prompt {hostile!r}"
+        assert c["verbose"] is False, f"verbose=True after hostile prompt {hostile!r}"
+
+
+# ---------------------------------------------------------------------------
+# flow kind
+# ---------------------------------------------------------------------------
+
+
+class TestFlowParserPromptInjection:
+    """li o flow: hostile action_prompt must arrive as VALUE, not toggle a flag."""
+
+    def _build(self, prompt: str) -> list[str]:
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        sched = {
+            "id": "test",
+            "action_kind": "flow",
+            "action_model": "sonnet",
+            "action_prompt": prompt,
+            "action_project": None,
+            "action_extra_args": [],
+        }
+        argv, _ = build_argv(sched, {})
+        return _argv_without_wrapper(argv)
+
+    @pytest.mark.parametrize("hostile", HOSTILE_PROMPTS)
+    def test_hostile_prompt_is_value_not_flag(self, hostile: str) -> None:
+        _reset()
+        argv = self._build(hostile)
+        assert "--" in argv, f"'--' sentinel missing from flow argv: {argv}"
+        rc = _run_main_with_argv(argv)
+        assert rc == 0, f"Expected rc=0 for argv={argv}, got {rc}"
+        c = _CAPTURED.get("flow")
+        assert c is not None, "run_flow was never called"
+        assert c["prompt"] == hostile, (
+            f"Hostile prompt {hostile!r} not received as prompt value; got prompt={c['prompt']!r}."
+        )
+        assert c["bypass"] is False, f"bypass=True after hostile prompt {hostile!r}"
+        assert c["yolo"] is False, f"yolo=True after hostile prompt {hostile!r}"
+        assert c["fast"] is False, f"fast=True after hostile prompt {hostile!r}"
+        assert c["verbose"] is False, f"verbose=True after hostile prompt {hostile!r}"
+
+
+# ---------------------------------------------------------------------------
+# fanout kind
+# ---------------------------------------------------------------------------
+
+
+class TestFanoutParserPromptInjection:
+    """li o fanout: hostile action_prompt must arrive as VALUE, not toggle a flag."""
+
+    def _build(self, prompt: str) -> list[str]:
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        sched = {
+            "id": "test",
+            "action_kind": "fanout",
+            "action_model": "sonnet",
+            "action_prompt": prompt,
+            "action_project": None,
+            "action_extra_args": [],
+        }
+        argv, _ = build_argv(sched, {})
+        return _argv_without_wrapper(argv)
+
+    @pytest.mark.parametrize("hostile", HOSTILE_PROMPTS)
+    def test_hostile_prompt_is_value_not_flag(self, hostile: str) -> None:
+        _reset()
+        argv = self._build(hostile)
+        assert "--" in argv, f"'--' sentinel missing from fanout argv: {argv}"
+        rc = _run_main_with_argv(argv)
+        assert rc == 0, f"Expected rc=0 for argv={argv}, got {rc}"
+        c = _CAPTURED.get("fanout")
+        assert c is not None, "run_fanout was never called"
+        assert c["prompt"] == hostile, (
+            f"Hostile prompt {hostile!r} not received as prompt value; got prompt={c['prompt']!r}."
+        )
+        assert c["bypass"] is False, f"bypass=True after hostile prompt {hostile!r}"
+        assert c["yolo"] is False, f"yolo=True after hostile prompt {hostile!r}"
+        assert c["fast"] is False, f"fast=True after hostile prompt {hostile!r}"
+        assert c["verbose"] is False, f"verbose=True after hostile prompt {hostile!r}"
+
+
+# ---------------------------------------------------------------------------
+# flow_yaml kind — prompt EXCLUDED from argv
+# ---------------------------------------------------------------------------
+
+
+class TestFlowYamlParserPromptExclusion:
+    """flow_yaml: hostile action_prompt must not appear in argv at all.
+
+    The YAML spec file supplies the prompt (spec.get('prompt') overwrites
+    args.prompt at orchestrate/__init__.py ~line 431).  The built argv must
+    not contain the hostile string, and bypass/yolo/fast must all be False
+    when run through the real parser.
+    """
+
+    @pytest.mark.parametrize("hostile", HOSTILE_PROMPTS)
+    def test_hostile_prompt_absent_from_argv(self, hostile: str) -> None:
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        sched = {
+            "id": "test",
+            "action_kind": "flow_yaml",
+            "action_model": "sonnet",
+            "action_prompt": hostile,
+            "action_project": None,
+            "action_extra_args": [],
+            "action_flow_yaml": "prompt: yaml-supplied\n",
+        }
+        argv, tmp_path = build_argv(sched, {})
+        try:
+            assert hostile not in argv, (
+                f"Hostile action_prompt {hostile!r} must not appear in flow_yaml "
+                f"argv at all. Got: {argv}"
+            )
+        finally:
+            if tmp_path and os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+
+    @pytest.mark.parametrize("hostile", HOSTILE_PROMPTS)
+    def test_yaml_prompt_delivered_bypass_remains_false(self, hostile: str) -> None:
+        """run_flow receives YAML prompt; bypass/yolo/fast all stay False."""
+        import lionagi.cli.orchestrate as orch_mod
+        import lionagi.cli.orchestrate.flow as flow_mod
+        from lionagi.cli.main import main
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        _reset()
+
+        # Write a controlled YAML file so the content is predictable.
+        fd, tmp_yaml = tempfile.mkstemp(suffix=".yaml", prefix="lionagi-test-")
+        try:
+            with os.fdopen(fd, "w") as fh:
+                fh.write("prompt: yaml-supplied-prompt\n")
+
+            sched = {
+                "id": "test",
+                "action_kind": "flow_yaml",
+                "action_model": "sonnet",
+                "action_prompt": hostile,
+                "action_project": None,
+                "action_extra_args": [],
+                "action_flow_yaml": "prompt: yaml-supplied-prompt\n",
+            }
+            full_argv, gen_tmp = build_argv(sched, {})
+            # Discard the generated temp file; substitute our controlled one.
+            if gen_tmp and os.path.exists(gen_tmp):
+                os.unlink(gen_tmp)
+
+            # Swap -f <generated> → -f <our yaml>
+            f_idx = full_argv.index("-f")
+            full_argv[f_idx + 1] = tmp_yaml
+
+            cli_argv = _argv_without_wrapper(full_argv)
+
+            with (
+                patch.object(flow_mod, "_run_flow", _fake_run_flow),
+                patch.object(orch_mod, "_run_flow", _fake_run_flow),
+            ):
+                rc = main(cli_argv)
+
+            assert rc == 0, f"Expected rc=0 for argv={cli_argv}, got {rc}"
+            c = _CAPTURED.get("flow")
+            assert c is not None, "run_flow was never called"
+            assert c["prompt"] == "yaml-supplied-prompt", (
+                f"Expected YAML prompt, got {c['prompt']!r}"
+            )
+            assert c["bypass"] is False, (
+                f"bypass toggled for flow_yaml with hostile action_prompt {hostile!r}"
+            )
+            assert c["yolo"] is False, (
+                f"yolo toggled for flow_yaml with hostile action_prompt {hostile!r}"
+            )
+            assert c["fast"] is False, (
+                f"fast toggled for flow_yaml with hostile action_prompt {hostile!r}"
+            )
+        finally:
+            if os.path.exists(tmp_yaml):
+                os.unlink(tmp_yaml)
+
+
+# ---------------------------------------------------------------------------
+# Sentinel placement sanity: verify '--' is before positionals in argv shape
+# ---------------------------------------------------------------------------
+
+
+class TestSentinelPlacement:
+    """Verify '--' appears before positionals in each action kind's argv."""
+
+    def test_agent_sentinel_before_prompt(self) -> None:
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        sched = {
+            "id": "t",
+            "action_kind": "agent",
+            "action_model": "sonnet",
+            "action_prompt": "hello",
+            "action_agent": None,
+            "action_project": None,
+            "action_extra_args": [],
+        }
+        argv, _ = build_argv(sched, {})
+        sep_idx = argv.index("--")
+        assert argv[sep_idx + 1] == "sonnet", (
+            f"Expected model 'sonnet' after '--', got {argv[sep_idx + 1]!r}. Full argv: {argv}"
+        )
+        assert argv[sep_idx + 2] == "hello", (
+            f"Expected prompt 'hello' after '--', got {argv[sep_idx + 2]!r}. Full argv: {argv}"
+        )
+
+    def test_flow_sentinel_before_prompt(self) -> None:
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        sched = {
+            "id": "t",
+            "action_kind": "flow",
+            "action_model": "sonnet",
+            "action_prompt": "hello",
+            "action_project": None,
+            "action_extra_args": [],
+        }
+        argv, _ = build_argv(sched, {})
+        sep_idx = argv.index("--")
+        assert argv[sep_idx + 1] == "sonnet"
+        assert argv[sep_idx + 2] == "hello"
+
+    def test_fanout_sentinel_before_prompt(self) -> None:
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        sched = {
+            "id": "t",
+            "action_kind": "fanout",
+            "action_model": "sonnet",
+            "action_prompt": "hello",
+            "action_project": None,
+            "action_extra_args": [],
+        }
+        argv, _ = build_argv(sched, {})
+        sep_idx = argv.index("--")
+        assert argv[sep_idx + 1] == "sonnet"
+        assert argv[sep_idx + 2] == "hello"
+
+    def test_flow_yaml_no_prompt_positional(self) -> None:
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        sched = {
+            "id": "t",
+            "action_kind": "flow_yaml",
+            "action_model": "sonnet",
+            "action_prompt": "--bypass",  # hostile
+            "action_project": None,
+            "action_extra_args": [],
+            "action_flow_yaml": "prompt: p\n",
+        }
+        argv, tmp_path = build_argv(sched, {})
+        try:
+            assert "--bypass" not in argv, (
+                f"Hostile prompt must not appear in flow_yaml argv: {argv}"
+            )
+            # Only model after sentinel — no prompt positional
+            sep_idx = argv.index("--")
+            after = argv[sep_idx + 1 :]
+            assert after == ["sonnet"], (
+                f"Expected only ['sonnet'] after '--' in flow_yaml, got {after}"
+            )
+        finally:
+            if tmp_path and os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+
+    def test_flow_yaml_file_flag_before_sentinel(self) -> None:
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        sched = {
+            "id": "t",
+            "action_kind": "flow_yaml",
+            "action_model": "sonnet",
+            "action_prompt": "irrelevant",
+            "action_project": None,
+            "action_extra_args": [],
+            "action_flow_yaml": "prompt: p\n",
+        }
+        argv, tmp_path = build_argv(sched, {})
+        try:
+            f_idx = argv.index("-f")
+            sep_idx = argv.index("--")
+            assert f_idx < sep_idx, (
+                f"-f ({f_idx}) must come before '--' ({sep_idx}). "
+                f"Otherwise argparse may reject -f as an unrecognised positional. "
+                f"argv={argv}"
+            )
+        finally:
+            if tmp_path and os.path.exists(tmp_path):
+                os.unlink(tmp_path)

--- a/tests/cli/test_argv_parser_regression.py
+++ b/tests/cli/test_argv_parser_regression.py
@@ -468,3 +468,89 @@ class TestSentinelPlacement:
         finally:
             if tmp_path and os.path.exists(tmp_path):
                 os.unlink(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Regression pin: '-- --' and '-- trailing' pass through (codex round 2)
+# ---------------------------------------------------------------------------
+
+
+class TestDoubleDashSentinelEdgeCases:
+    """Pin that '-- --' and '-- trailing' reach the runner as prompt values.
+
+    Codex verified '-- --' works today; these tests pin that behaviour so a
+    future change does not silently regress it.  The exact token '--' is
+    rejected by validation (tested in test_argv_injection.py); these tests
+    cover the multi-token or longer forms that must remain permitted.
+    """
+
+    def test_double_dash_space_double_dash_passes_through(self) -> None:
+        """action_prompt='-- --' must reach _run_agent as the prompt VALUE."""
+        _reset()
+        argv = _argv_without_wrapper(
+            __import__("lionagi.studio.scheduler.subprocess", fromlist=["build_argv"]).build_argv(
+                {
+                    "id": "t",
+                    "action_kind": "agent",
+                    "action_model": "sonnet",
+                    "action_prompt": "-- --",
+                    "action_agent": None,
+                    "action_project": None,
+                    "action_extra_args": [],
+                },
+                {},
+            )[0]
+        )
+        rc = _run_main_with_argv(argv)
+        assert rc == 0, f"Expected rc=0, got {rc}. argv={argv}"
+        c = _CAPTURED.get("agent")
+        assert c is not None, "run_agent was not called"
+        assert c["prompt"] == "-- --", f"Expected prompt='-- --', got {c['prompt']!r}"
+        assert c["bypass"] is False
+
+    def test_double_dash_trailing_text_passes_through(self) -> None:
+        """action_prompt='-- some text' must reach _run_agent as the prompt VALUE."""
+        _reset()
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        full_argv, _ = build_argv(
+            {
+                "id": "t",
+                "action_kind": "agent",
+                "action_model": "sonnet",
+                "action_prompt": "-- some trailing",
+                "action_agent": None,
+                "action_project": None,
+                "action_extra_args": [],
+            },
+            {},
+        )
+        argv = _argv_without_wrapper(full_argv)
+        rc = _run_main_with_argv(argv)
+        assert rc == 0, f"Expected rc=0, got {rc}. argv={argv}"
+        c = _CAPTURED.get("agent")
+        assert c is not None, "run_agent was not called"
+        assert c["prompt"] == "-- some trailing", (
+            f"Expected prompt='-- some trailing', got {c['prompt']!r}"
+        )
+        assert c["bypass"] is False
+
+    def test_exact_double_dash_rejected_at_build_time(self) -> None:
+        """action_prompt='--' must be rejected by build_argv before reaching argparse."""
+        import pytest as _pytest
+
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        with _pytest.raises(ValueError, match="'--'"):
+            build_argv(
+                {
+                    "id": "t",
+                    "action_kind": "agent",
+                    "action_model": "sonnet",
+                    "action_prompt": "--",
+                    "action_agent": None,
+                    "action_project": None,
+                    "action_extra_args": [],
+                },
+                {},
+            )


### PR DESCRIPTION
## Summary

Closes #1404 (CWE-88 argument injection in `build_argv()`).

Security testing found three follow-up fixes:

### Validation — action_model / action_extra_args
- `_validate_action_model()`: rejects values starting with `-` and values containing shell-unsafe characters
- `_validate_extra_args()`: rejects any element starting with `-`
- `_validate_identifier()`: applied to `action_agent`, `action_project`, `action_playbook`
- Service boundary: `create_schedule` and `update_schedule` validate all fields before storage

### Structural fix — `--` end-of-options sentinel (Critical bypass)
Testing proved that placing `action_prompt='--bypass'` reached `_run_flow` with `bypass=True`.

- `build_argv()` now inserts `--` before all positionals for agent/flow/fanout
- `flow_yaml` action kind drops the prompt positional entirely (YAML file supplies it via `spec.get("prompt")`)
- `flow_yaml` drops the model positional and uses `--model MODEL` instead
- Parser-level regression tests in `test_argv_parser_regression.py` verify hostile prompts (`--bypass`, `--yolo`, `--fast`, `--verbose`) arrive as prompt VALUES with all flags `False`

### Follow-up validation — two minor findings
**Finding 1 — prompt `'--'` silently eaten:**
The exact token `--` as `action_prompt` is consumed by argparse as a second end-of-options sentinel and does not reach the runner.

- `_validate_prompt()` added to `subprocess.py` — raises `ValueError` for the exact string `'--'`
- `_svc_validate_prompt()` added to `services/schedules.py` — called in both `create_schedule` and `update_schedule`
- `build_argv()` calls `_validate_prompt()` defensively
- All other prompt content (including `'-- --'`, `'-- trailing text'`, `'--bypass'`, `'--verbose'`) remains unrestricted

**Finding — pre-parse verbose scan not sentinel-aware:**
`cli/main.py` scanned raw argv for `-v`/`--verbose` before argparse, so `action_prompt='--verbose'` flipped `configure_cli_logging(True)` even though it no longer reached runner flags.

- Scan restricted to `argv[:argv.index('--')]` when `--` is present
- Falls back to full argv when no `--` is present (normal human CLI use unchanged)

## Test coverage

| File | Tests | What it covers |
|------|-------|----------------|
| `tests/cli/test_argv_injection.py` | 79 | model/extra_args/identifier validation at subprocess + service layer; prompt sentinel rejection; verbose scan sentinel-aware |
| `tests/cli/test_argv_parser_regression.py` | 24 | Real argparse round-trip: hostile prompts arrive as values, flags stay `False`; `'-- --'`/`'-- trailing'` pass-through pinned |
| `tests/apps_studio_server/test_audit_remediation.py` | 18 | FastAPI router integration: all injection payloads → HTTP 400; `action_prompt='--'` → HTTP 400 |
| `tests/cli/test_scheduler_flow_yaml.py` | 12 | flow_yaml action kind: prompt dropped from argv, YAML file path present |

**Total: 133 passed, 0 skipped, 0 failed**

## Security model

Two-layer defense:
1. **Service boundary** (`services/schedules.py`): validates on create/update — malicious values never reach the database
2. **Spawn boundary** (`scheduler/subprocess.py`): validates in `build_argv()` — structural `--` sentinel ensures even bypassed-storage values cannot inject flags into the subprocess

The sole forbidden prompt value is the exact literal `'--'` (meaningless as an LLM prompt; argparse would silently discard it). All other prompt content is unrestricted, including values starting with `-`.