### PR TITLE
feat(engines): li engine run + engine_runs visibility — Phase C Move 2

### DIFF
--- a/apps/studio/frontend/app/runs/page.tsx
+++ b/apps/studio/frontend/app/runs/page.tsx
@@ -8,8 +8,8 @@ import Duration from "@/components/Duration";
 import PageHeader from "@/components/PageHeader";
 import StatusPill from "@/components/StatusPill";
 import Timestamp from "@/components/Timestamp";
-import { listRuns } from "@/lib/api";
-import type { RunListResponse } from "@/lib/api";
+import { listRuns, listEngineRuns } from "@/lib/api";
+import type { RunListResponse, EngineRunSummary } from "@/lib/api";
 import type { RunSummary } from "@/lib/types";
 import { empty, errors } from "@/lib/copy";
 
@@ -26,7 +26,7 @@ const STATUS_FILTERS = [
   "cancelled",
 ] as const;
 
-type ViewMode = "sessions" | "invocations";
+type ViewMode = "sessions" | "invocations" | "engines";
 
 interface InvocationGroup {
   invocation_id: string;
@@ -233,6 +233,9 @@ function RunsPageInner() {
   const [viewMode, setViewMode] = useState<ViewMode>("sessions");
   const [expandedInvocations, setExpandedInvocations] = useState<Set<string>>(new Set());
   const [knownProjects, setKnownProjects] = useState<string[]>([]);
+  const [engineRuns, setEngineRuns] = useState<EngineRunSummary[]>([]);
+  const [engineLoading, setEngineLoading] = useState(false);
+  const [engineError, setEngineError] = useState<string | null>(null);
 
   // eslint-disable-next-line react-hooks/set-state-in-effect -- sync URL→input: no external system involved, single derived state write
   useEffect(() => setPlaybookInput(playbook), [playbook]);
@@ -309,6 +312,34 @@ function RunsPageInner() {
     const tick = setInterval(() => setNow(Math.floor(Date.now() / 1000)), 30000);
     return () => clearInterval(tick);
   }, []);
+
+  // Engine runs fetch — only active when "engines" tab is selected.
+  useEffect(() => {
+    if (viewMode !== "engines") return;
+    let active = true;
+
+    async function loadEngines() {
+      setEngineLoading(true);
+      try {
+        const rows = await listEngineRuns({ limit: 100 });
+        if (active) {
+          setEngineRuns(rows);
+          setEngineError(null);
+        }
+      } catch {
+        if (active) setEngineError(errors.loadEngineRuns);
+      } finally {
+        if (active) setEngineLoading(false);
+      }
+    }
+
+    void loadEngines();
+    const interval = setInterval(loadEngines, 5000);
+    return () => {
+      active = false;
+      clearInterval(interval);
+    };
+  }, [viewMode]);
 
   function toggleStatus(s: string) {
     const next = statuses.includes(s) ? statuses.filter((x) => x !== s) : [...statuses, s];
@@ -390,6 +421,14 @@ function RunsPageInner() {
             >
               Invocations
             </Button>
+            <Button
+              size="sm"
+              variant="toggle"
+              active={viewMode === "engines"}
+              onClick={() => setViewMode("engines")}
+            >
+              Engines
+            </Button>
           </div>
           {/* ADR-0026: project filter chips */}
           {knownProjects.length > 0 && (
@@ -459,13 +498,113 @@ function RunsPageInner() {
         </div>
       </div>
 
-      {error && (
+      {error && viewMode !== "engines" && (
         <div className="rounded border border-status-error/30 bg-status-error-bg px-3 py-2 text-body text-status-error">
           {error}
         </div>
       )}
+      {engineError && viewMode === "engines" && (
+        <div className="rounded border border-status-error/30 bg-status-error-bg px-3 py-2 text-body text-status-error">
+          {engineError}
+        </div>
+      )}
 
-      <div className="overflow-x-auto rounded border border-edge bg-surface-raised shadow-card">
+      {/* Engine runs table — rendered when "engines" tab is active */}
+      {viewMode === "engines" && (
+        <div className="overflow-x-auto rounded border border-edge bg-surface-raised shadow-card">
+          <table aria-busy={engineLoading} className="w-full text-left text-body">
+            <thead>
+              <tr className="border-b border-edge bg-surface-overlay text-meta uppercase tracking-[0.06em] text-content-muted">
+                <th className="px-3 py-2.5 font-medium">Run</th>
+                <th className="px-3 py-2.5 font-medium">Kind</th>
+                <th className="px-3 py-2.5 font-medium">Status</th>
+                <th className="px-3 py-2.5 font-medium">Session</th>
+                <th className="px-3 py-2.5 font-medium">Export dir</th>
+                <th className="px-3 py-2.5 font-medium">Started</th>
+                <th className="px-3 py-2.5 font-medium">Duration</th>
+              </tr>
+            </thead>
+            <tbody>
+              {engineLoading && engineRuns.length === 0 ? (
+                <>
+                  <SkeletonRow />
+                  <SkeletonRow />
+                  <SkeletonRow />
+                </>
+              ) : engineRuns.length === 0 ? (
+                <tr>
+                  <td colSpan={7} className="px-3 py-14 text-center text-body text-content-muted">
+                    {empty.engineRuns}
+                  </td>
+                </tr>
+              ) : (
+                engineRuns.map((er) => {
+                  // For running engine runs (no ended_at), pass null duration
+                  // so Duration shows "—" rather than calling Date.now() in
+                  // render (which violates react-hooks/purity).
+                  const durSec =
+                    er.started_at != null && er.ended_at != null
+                      ? er.ended_at - er.started_at
+                      : null;
+                  return (
+                    <tr
+                      key={er.id}
+                      className="border-b border-edge-subtle text-content-secondary transition-colors duration-100 hover:bg-surface-overlay"
+                    >
+                      <td className="px-3 py-2">
+                        <span className="font-mono text-meta text-content-muted">
+                          {er.id.slice(-8)}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2">
+                        <span className="rounded px-1 py-0.5 font-mono text-[10px] border border-edge text-content-muted">
+                          {er.kind}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2">
+                        <StatusPill value={er.status} kind="lifecycle" />
+                      </td>
+                      <td className="px-3 py-2 font-mono text-meta text-content-muted">
+                        {er.session_id ? (
+                          <Link
+                            href={`/runs/${er.session_id}`}
+                            className="hover:text-status-running transition-colors"
+                          >
+                            {er.session_id.slice(-8)}
+                          </Link>
+                        ) : (
+                          <span className="text-content-muted/40">—</span>
+                        )}
+                      </td>
+                      <td className="px-3 py-2 font-mono text-meta text-content-muted max-w-[200px] truncate">
+                        {er.export_dir ? (
+                          <span title={er.export_dir}>{er.export_dir}</span>
+                        ) : (
+                          <span className="text-content-muted/40">—</span>
+                        )}
+                      </td>
+                      <td className="px-3 py-2 text-meta text-content-muted">
+                        <Timestamp value={er.started_at} />
+                      </td>
+                      <td className="px-3 py-2">
+                        <Duration value={durSec} />
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <div
+        className={
+          viewMode === "engines"
+            ? "hidden"
+            : "overflow-x-auto rounded border border-edge bg-surface-raised shadow-card"
+        }
+      >
         <table aria-busy={loading} className="w-full text-left text-body">
           <thead>
             <tr className="border-b border-edge bg-surface-overlay text-meta uppercase tracking-[0.06em] text-content-muted">

--- a/apps/studio/frontend/lib/api.ts
+++ b/apps/studio/frontend/lib/api.ts
@@ -978,3 +978,40 @@ export async function listScheduleRuns(
   const qs = query.toString();
   return fetchJson(`/api/schedules/${encodeURIComponent(scheduleId)}/runs${qs ? `?${qs}` : ""}`);
 }
+
+// ─── Engine runs (Phase C Move 2) ─────────────────────────────────────────────
+
+export interface EngineRunSummary {
+  id: string;
+  kind: string;
+  spec_json: Record<string, unknown>;
+  status: string;
+  started_at: number;
+  ended_at: number | null;
+  session_id: string | null;
+  export_dir: string | null;
+  error: string | null;
+}
+
+export interface EngineRunListParams {
+  kind?: string;
+  status?: string;
+  session_id?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export async function listEngineRuns(params?: EngineRunListParams): Promise<EngineRunSummary[]> {
+  const query = new URLSearchParams();
+  if (params?.kind) query.set("kind", params.kind);
+  if (params?.status) query.set("status", params.status);
+  if (params?.session_id) query.set("session_id", params.session_id);
+  if (params?.limit != null) query.set("limit", String(params.limit));
+  if (params?.offset != null) query.set("offset", String(params.offset));
+  const qs = query.toString();
+  return fetchJson<EngineRunSummary[]>(`/api/engine-runs${qs ? `?${qs}` : ""}`);
+}
+
+export async function getEngineRun(runId: string): Promise<EngineRunSummary> {
+  return fetchJson<EngineRunSummary>(`/api/engine-runs/${encodeURIComponent(runId)}`);
+}

--- a/apps/studio/frontend/lib/copy.ts
+++ b/apps/studio/frontend/lib/copy.ts
@@ -71,6 +71,7 @@ export const empty = {
   skills: "No skills found.",
   shows: "No shows found.",
   runs: "No runs found.",
+  engineRuns: "No engine runs found.",
   teamsNotFound: "No teams found.",
 
   // Filter results — user typed a filter and nothing matched.
@@ -104,6 +105,7 @@ export const errors = {
   loadSchedules: "Failed to load schedules.",
   loadTeams: "Failed to load teams.",
   loadRuns: "Failed to load runs.",
+  loadEngineRuns: "Failed to load engine runs.",
   teamNotFound: "Team not found.",
 
   // Action failures — operator tried to do something, it failed.

--- a/apps/studio/frontend/messages/en.json
+++ b/apps/studio/frontend/messages/en.json
@@ -147,5 +147,30 @@
       "updated": "Updated"
     },
     "empty": "No sessions are currently running or queued."
+  },
+  "engineRuns": {
+    "tab": "Engines",
+    "title": "Engine Runs",
+    "subtitle": "Domain-specific multi-agent pipeline executions",
+    "runCount": "{count, plural, one {# run} other {# runs}}",
+    "table": {
+      "run": "Run",
+      "kind": "Kind",
+      "status": "Status",
+      "session": "Session",
+      "exportDir": "Export dir",
+      "started": "Started",
+      "duration": "Duration"
+    },
+    "status": {
+      "running": "running",
+      "completed": "completed",
+      "failed": "failed",
+      "cancelled": "cancelled"
+    },
+    "empty": "No engine runs found.",
+    "loadError": "Failed to load engine runs.",
+    "noSession": "—",
+    "noExportDir": "—"
   }
 }

--- a/apps/studio/frontend/messages/zh.json
+++ b/apps/studio/frontend/messages/zh.json
@@ -147,5 +147,30 @@
       "updated": "更新时间"
     },
     "empty": "当前无正在运行或排队的会话。"
+  },
+  "engineRuns": {
+    "tab": "引擎",
+    "title": "引擎运行",
+    "subtitle": "领域专用多智能体流水线执行记录",
+    "runCount": "{count, plural, other {# 次运行}}",
+    "table": {
+      "run": "运行",
+      "kind": "类型",
+      "status": "状态",
+      "session": "会话",
+      "exportDir": "导出目录",
+      "started": "开始时间",
+      "duration": "耗时"
+    },
+    "status": {
+      "running": "运行中",
+      "completed": "已完成",
+      "failed": "失败",
+      "cancelled": "已取消"
+    },
+    "empty": "未找到引擎运行记录。",
+    "loadError": "加载引擎运行失败。",
+    "noSession": "—",
+    "noExportDir": "—"
   }
 }

--- a/lionagi/cli/engine.py
+++ b/lionagi/cli/engine.py
@@ -250,6 +250,8 @@ async def _do_engine_run(args: argparse.Namespace) -> int:
     except Exception as exc:
         log_error(f"failed to import engine class for kind {kind!r}: {exc}")
         await _maybe_update_db(db, run_id, "failed", error=str(exc))
+        if db is not None:
+            await db.close()
         return 1
 
     # Build the on_event callback that translates engine events to stderr lines.
@@ -318,7 +320,8 @@ async def _do_engine_run(args: argparse.Namespace) -> int:
         if hasattr(result, "model_dump"):
             # Pydantic model (e.g. CodingEngine returns CodeResultRecorded).
             result_data = result.model_dump(mode="json")
-            export_dir_for_db = result_data.get("export_dir") or export_dir_from_args
+            _rd_export = result_data.get("export_dir")
+            export_dir_for_db = _rd_export if _rd_export is not None else export_dir_from_args
         elif isinstance(result, str):
             result_data = {"result": result}
         else:

--- a/lionagi/cli/engine.py
+++ b/lionagi/cli/engine.py
@@ -1,0 +1,338 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""`li engine run <kind> <spec>` — shell-reachable engine execution.
+
+Engines are domain-specific multi-agent pipelines exposed here so they can
+be invoked without writing Python.  Each engine kind maps to one required
+positional argument; optional flags mirror the engine constructor kwargs
+that are most commonly overridden from the command line.
+
+Progress events from the engine's ``on_event`` callback are written to
+stderr via :func:`~lionagi.cli._logging.progress`.  The final result is
+serialised as JSON on stdout so callers can pipe it downstream.
+
+Run records are persisted in the StateDB ``engine_runs`` table (Phase C
+Move 2): one INSERT at start, one UPDATE at end with status/error/export_dir.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+import uuid
+from typing import Any
+
+from ._logging import log_error, progress, warn
+
+# ── Engine kind registry ───────────────────────────────────────────────────
+# Maps the CLI kind name to the class import path and the main positional
+# argument name and help text.  Adding a new kind means adding one entry here.
+
+_KIND_META: dict[str, dict[str, Any]] = {
+    "research": {
+        "cls_path": ("lionagi.engines", "ResearchEngine"),
+        "pos_arg": "topic",
+        "pos_help": "Research topic or question.",
+    },
+    "review": {
+        "cls_path": ("lionagi.engines", "ReviewEngine"),
+        "pos_arg": "artifact",
+        "pos_help": "Artifact text or path to review.",
+    },
+    "coding": {
+        "cls_path": ("lionagi.engines", "CodingEngine"),
+        "pos_arg": "spec",
+        "pos_help": "Coding specification (natural-language or JSON string).",
+    },
+    "hypothesis": {
+        "cls_path": ("lionagi.engines", "HypothesisEngine"),
+        "pos_arg": "findings",
+        "pos_help": "Research findings or background text for hypothesis generation.",
+    },
+    "planning": {
+        "cls_path": ("lionagi.engines", "PlanningEngine"),
+        "pos_arg": "prompt",
+        "pos_help": "Goal or task description to plan and execute.",
+    },
+}
+
+
+def _import_engine_class(module: str, name: str) -> type:
+    import importlib
+
+    mod = importlib.import_module(module)
+    return getattr(mod, name)
+
+
+# ── Subparser builder ──────────────────────────────────────────────────────
+
+
+def add_engine_subparser(subparsers: argparse._SubParsersAction) -> None:
+    """Register `li engine` and its `run` sub-subcommand."""
+    engine_parser = subparsers.add_parser(
+        "engine",
+        help="Run domain-specific multi-agent engine pipelines.",
+        description=(
+            "Run a lionagi engine kind from the command line.\n\n"
+            "Each engine kind wraps a multi-agent pipeline specialised for a\n"
+            "domain (research, code review, hypothesis generation, …).  The\n"
+            "engine's progress events stream to stderr; the final result is\n"
+            "emitted as JSON on stdout.\n\n"
+            "Examples:\n"
+            "  li engine run research 'What are the latest advances in GQA?'\n"
+            "  li engine run review 'See artifact.py' --model claude/sonnet\n"
+            "  li engine run coding 'Implement a BFS traversal' --test-cmd 'pytest'\n"
+            "  li engine run hypothesis 'Finding: X causes Y' --export-dir ./out\n"
+            "  li engine run planning 'Build a REST API'\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    engine_sub = engine_parser.add_subparsers(dest="engine_command", required=True)
+
+    kinds_str = ", ".join(sorted(_KIND_META))
+    run_parser = engine_sub.add_parser(
+        "run",
+        help=f"Run an engine. Kinds: {kinds_str}.",
+        description=(
+            f"Run a lionagi engine of a specific kind.\n\n"
+            f"Available kinds: {kinds_str}\n\n"
+            "Progress events are written to stderr as human-readable lines.\n"
+            "The final result is written as JSON to stdout.\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    run_parser.add_argument(
+        "kind",
+        choices=list(_KIND_META),
+        metavar="kind",
+        help=f"Engine kind to run. One of: {kinds_str}.",
+    )
+    run_parser.add_argument(
+        "spec",
+        help=("Main input for the engine (topic / artifact / spec / findings / prompt)."),
+    )
+
+    # ── Coding-specific flags ──────────────────────────────────────────
+    run_parser.add_argument(
+        "--test-cmd",
+        default=None,
+        metavar="CMD",
+        help=(
+            "Test command to validate generated code (required for 'coding' kind). "
+            "May be a shell string or a quoted list."
+        ),
+    )
+    run_parser.add_argument(
+        "--export-dir",
+        default=None,
+        metavar="DIR",
+        help=(
+            "Directory to save engine outputs to (optional; supported by 'coding' "
+            "and 'hypothesis' kinds)."
+        ),
+    )
+
+    # ── Engine constructor overrides ───────────────────────────────────
+    run_parser.add_argument(
+        "--model",
+        default=None,
+        metavar="MODEL",
+        help="Model to use (provider/name, e.g. claude/sonnet). Uses default if omitted.",
+    )
+    run_parser.add_argument(
+        "--max-depth",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Maximum recursion/expansion depth for the engine (kind-specific default).",
+    )
+    run_parser.add_argument(
+        "--max-agents",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Maximum number of sub-agents the engine may spawn.",
+    )
+    run_parser.add_argument(
+        "--session-id",
+        default=None,
+        metavar="SESSION_ID",
+        help=(
+            "Associate this engine run with an existing session in StateDB "
+            "(written to engine_runs.session_id)."
+        ),
+    )
+    run_parser.add_argument(
+        "--no-persist",
+        action="store_true",
+        help="Skip writing the engine run record to StateDB.",
+    )
+
+
+# ── Main dispatch ──────────────────────────────────────────────────────────
+
+
+def run_engine(args: argparse.Namespace) -> int:
+    """Entry point called from main() when args.command == 'engine'."""
+    from lionagi.ln.concurrency import run_async
+
+    if args.engine_command == "run":
+        return run_async(_do_engine_run(args))
+
+    log_error(f"unknown engine subcommand: {args.engine_command!r}")
+    return 1
+
+
+# ── Core async implementation ──────────────────────────────────────────────
+
+
+async def _do_engine_run(args: argparse.Namespace) -> int:
+    """Resolve args, instantiate engine, run it, persist result."""
+    kind = args.kind
+    spec = args.spec
+    meta = _KIND_META[kind]
+
+    # Validate kind-specific required args.
+    if kind == "coding" and not args.test_cmd:
+        log_error("the 'coding' engine requires --test-cmd (e.g. --test-cmd 'pytest tests/')")
+        return 1
+
+    # Build engine kwargs from CLI flags.
+    engine_kwargs: dict[str, Any] = {}
+    if args.model:
+        engine_kwargs["model"] = args.model
+    if args.max_depth is not None:
+        engine_kwargs["max_depth"] = args.max_depth
+    if args.max_agents is not None:
+        engine_kwargs["max_agents"] = args.max_agents
+
+    # Build run kwargs (positional input + kind-specific options).
+    run_kwargs: dict[str, Any] = {}
+    if kind == "coding":
+        run_kwargs["test_cmd"] = args.test_cmd
+        if args.export_dir:
+            run_kwargs["export_dir"] = args.export_dir
+    elif kind == "hypothesis":
+        if args.export_dir:
+            run_kwargs["export_dir"] = args.export_dir
+
+    # Spec JSON stored in DB represents the user-visible call parameters.
+    spec_for_db: dict[str, Any] = {meta["pos_arg"]: spec, **run_kwargs}
+
+    run_id = uuid.uuid4().hex
+    started_at = time.time()
+
+    # Open DB for persistence.
+    db = None
+    if not args.no_persist:
+        try:
+            from lionagi.state.db import StateDB
+
+            db = StateDB()
+            await db.open()
+            await db.insert_engine_run(
+                run_id=run_id,
+                kind=kind,
+                spec_json=spec_for_db,
+                started_at=started_at,
+                session_id=args.session_id,
+            )
+        except Exception as exc:  # noqa: BLE001
+            warn(f"could not open StateDB for persistence: {exc}")
+            db = None
+
+    # Import engine class lazily (no circular import; heavy deps stay unloaded
+    # until actually needed).
+    try:
+        module, cls_name = meta["cls_path"]
+        engine_class = _import_engine_class(module, cls_name)
+    except Exception as exc:
+        log_error(f"failed to import engine class for kind {kind!r}: {exc}")
+        await _maybe_update_db(db, run_id, "failed", error=str(exc))
+        return 1
+
+    # Build the on_event callback that translates engine events to stderr lines.
+    def on_event(event: dict[str, Any]) -> None:
+        event_type = event.get("type", "event")
+        # Format: "engine[research] phase: <msg>" or "engine[research] done"
+        parts = [f"engine[{kind}] {event_type}"]
+        for key, val in event.items():
+            if key == "type":
+                continue
+            if isinstance(val, (dict, list)):
+                val_str = json.dumps(val, ensure_ascii=False)
+            else:
+                val_str = str(val)
+            parts.append(f"{key}={val_str}")
+        progress("  ".join(parts))
+
+    # Instantiate and run the engine.
+    progress(f"engine[{kind}] starting  spec={spec!r}")
+    try:
+        engine = engine_class(**engine_kwargs)
+        # CodingEngine has its own .run() signature (positional spec + keyword
+        # test_cmd/workspace/export_dir); other engines use Engine.run() which
+        # dispatches to _run(run, <main_arg>, **run_kwargs).
+        result = await engine.run(spec, on_event=on_event, **run_kwargs)
+    except Exception as exc:
+        log_error(f"engine[{kind}] failed: {exc}")
+        ended_at = time.time()
+        await _maybe_update_db(db, run_id, "failed", ended_at=ended_at, error=str(exc))
+        if db is not None:
+            await db.close()
+        return 1
+
+    ended_at = time.time()
+    progress(f"engine[{kind}] completed  elapsed={ended_at - started_at:.1f}s")
+
+    # Serialise result to stdout as JSON.
+    export_dir_for_db: str | None = None
+    try:
+        if hasattr(result, "model_dump"):
+            # Pydantic model (e.g. CodingEngine returns CodeResultRecorded).
+            result_data = result.model_dump(mode="json")
+            export_dir_for_db = result_data.get("export_dir")
+        elif isinstance(result, str):
+            result_data = {"result": result}
+        else:
+            result_data = {"result": str(result)}
+        print(json.dumps(result_data, ensure_ascii=False, indent=2))
+    except Exception as exc:
+        warn(f"could not serialise result to JSON: {exc}")
+        print(repr(result))
+
+    await _maybe_update_db(
+        db,
+        run_id,
+        "completed",
+        ended_at=ended_at,
+        export_dir=export_dir_for_db,
+    )
+    if db is not None:
+        await db.close()
+    return 0
+
+
+async def _maybe_update_db(
+    db: Any,
+    run_id: str,
+    status: str,
+    *,
+    ended_at: float | None = None,
+    export_dir: str | None = None,
+    error: str | None = None,
+) -> None:
+    """Update the engine run row if a DB handle is open; swallow errors."""
+    if db is None:
+        return
+    try:
+        await db.update_engine_run(
+            run_id,
+            status=status,
+            ended_at=ended_at or time.time(),
+            export_dir=export_dir,
+            error=error,
+        )
+    except Exception as exc:  # noqa: BLE001
+        warn(f"could not update engine run record in StateDB: {exc}")

--- a/lionagi/cli/engine.py
+++ b/lionagi/cli/engine.py
@@ -269,6 +269,8 @@ async def _do_engine_run(args: argparse.Namespace) -> int:
 
     # Instantiate and run the engine.
     progress(f"engine[{kind}] starting  spec={spec!r}")
+    result = None
+    ended_at: float | None = None
     try:
         engine = engine_class(**engine_kwargs)
         # CodingEngine has its own .run() signature (positional spec + keyword
@@ -282,17 +284,41 @@ async def _do_engine_run(args: argparse.Namespace) -> int:
         if db is not None:
             await db.close()
         return 1
+    except BaseException as exc:
+        # asyncio.CancelledError and KeyboardInterrupt are BaseException paths that
+        # bypass the `except Exception` handler above.  Mark the row cancelled before
+        # re-raising so Studio doesn't show it as permanently 'running'.
+        # run_async() in lionagi/ln/concurrency/utils.py:86 cancels the task on
+        # SIGINT and then raises KeyboardInterrupt at :108; we re-raise here to
+        # preserve that exit-code behaviour (interpreter default for SIGINT).
+        ended_at = time.time()
+        await _maybe_update_db(
+            db,
+            run_id,
+            "cancelled",
+            ended_at=ended_at,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+        if db is not None:
+            await db.close()
+        raise
 
     ended_at = time.time()
     progress(f"engine[{kind}] completed  elapsed={ended_at - started_at:.1f}s")
 
     # Serialise result to stdout as JSON.
-    export_dir_for_db: str | None = None
+    # export_dir: the CLI knows what directory it passed; neither CodeResultRecorded
+    # (lionagi/engines/coding.py:153 — fields: passed, measurements, caveats,
+    # experiment_ref, verdict_ref) nor the hypothesis string echo it back.  Source
+    # export_dir from args directly for kinds that accept the flag, falling back to
+    # result_data for any future engine model that does include it.
+    export_dir_from_args: str | None = args.export_dir if kind in ("coding", "hypothesis") else None
+    export_dir_for_db: str | None = export_dir_from_args
     try:
         if hasattr(result, "model_dump"):
             # Pydantic model (e.g. CodingEngine returns CodeResultRecorded).
             result_data = result.model_dump(mode="json")
-            export_dir_for_db = result_data.get("export_dir")
+            export_dir_for_db = result_data.get("export_dir") or export_dir_from_args
         elif isinstance(result, str):
             result_data = {"result": result}
         else:

--- a/lionagi/cli/main.py
+++ b/lionagi/cli/main.py
@@ -20,6 +20,7 @@ import sys
 
 from ._logging import configure_cli_logging, log_error
 from .agent import add_agent_subparser, run_agent
+from .engine import add_engine_subparser, run_engine
 from .invoke import add_invoke_subparser, run_invoke
 from .kill import add_kill_subparser, run_kill
 from .monitor import add_monitor_subparser, run_monitor
@@ -268,6 +269,7 @@ def main(argv: list[str] | None = None) -> int:
 
     orch_parsers = add_orchestrate_subparser(sub)
     add_agent_subparser(sub)
+    add_engine_subparser(sub)
     add_team_subparser(sub)
     add_studio_subparser(sub)
     add_schedule_subparser(sub)
@@ -288,6 +290,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "agent":
         return run_agent(args)
+
+    if args.command == "engine":
+        return run_engine(args)
 
     if args.command == "team":
         return run_team(args)

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -2056,6 +2056,133 @@ class StateDB:
             )
         return result
 
+    # ── Engine runs (Phase C Move 2) ──────────────────────────────────
+
+    async def insert_engine_run(
+        self,
+        *,
+        run_id: str,
+        kind: str,
+        spec_json: dict[str, Any],
+        started_at: float,
+        session_id: str | None = None,
+    ) -> None:
+        """Insert a new engine run row with status='running'.
+
+        Serialised through ``self._write_lock`` (same pattern as
+        ``insert_session_signal``) to prevent concurrent INSERT conflicts on
+        the shared connection.
+        """
+        async with self._write_lock:
+            await self.db.execute("BEGIN IMMEDIATE")
+            try:
+                await self.db.execute(
+                    "INSERT INTO engine_runs "
+                    "(id, kind, spec_json, status, started_at, session_id) "
+                    "VALUES (?, ?, ?, 'running', ?, ?)",
+                    (
+                        run_id,
+                        kind,
+                        _to_json_column(spec_json),
+                        started_at,
+                        session_id,
+                    ),
+                )
+                await self.db.commit()
+            except BaseException:
+                await self.db.rollback()
+                raise
+
+    async def update_engine_run(
+        self,
+        run_id: str,
+        *,
+        status: str,
+        ended_at: float | None = None,
+        export_dir: str | None = None,
+        error: str | None = None,
+    ) -> None:
+        """Update the mutable fields of an engine run row.
+
+        *status* must be one of ``completed``, ``failed``, or ``cancelled``.
+        Serialised through ``self._write_lock``.
+        """
+        async with self._write_lock:
+            await self.db.execute("BEGIN IMMEDIATE")
+            try:
+                await self.db.execute(
+                    "UPDATE engine_runs "
+                    "SET status = ?, ended_at = ?, export_dir = ?, error = ? "
+                    "WHERE id = ?",
+                    (status, ended_at, export_dir, error, run_id),
+                )
+                await self.db.commit()
+            except BaseException:
+                await self.db.rollback()
+                raise
+
+    async def get_engine_run(self, run_id: str) -> dict[str, Any] | None:
+        """Return a single engine run row as a dict, or None if not found."""
+        cur = await self.db.execute(
+            "SELECT id, kind, spec_json, status, started_at, ended_at, "
+            "session_id, export_dir, error "
+            "FROM engine_runs WHERE id = ?",
+            (run_id,),
+        )
+        row = await cur.fetchone()
+        if row is None:
+            return None
+        d = dict(row)
+        if isinstance(d.get("spec_json"), str):
+            try:
+                d["spec_json"] = json.loads(d["spec_json"])
+            except (json.JSONDecodeError, TypeError):
+                pass
+        return d
+
+    async def list_engine_runs(
+        self,
+        *,
+        kind: str | None = None,
+        status: str | None = None,
+        session_id: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        """Return engine run rows, newest-first, with optional filters."""
+        conditions: list[str] = []
+        params: list[Any] = []
+        if kind is not None:
+            conditions.append("kind = ?")
+            params.append(kind)
+        if status is not None:
+            conditions.append("status = ?")
+            params.append(status)
+        if session_id is not None:
+            conditions.append("session_id = ?")
+            params.append(session_id)
+        where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+        params.extend([limit, offset])
+        sql = (
+            f"SELECT id, kind, spec_json, status, started_at, ended_at, "  # noqa: S608
+            f"session_id, export_dir, error "
+            f"FROM engine_runs {where} "
+            f"ORDER BY started_at DESC "
+            f"LIMIT ? OFFSET ?"
+        )
+        cur = await self.db.execute(sql, params)
+        rows = await cur.fetchall()
+        result = []
+        for r in rows:
+            d = dict(r)
+            if isinstance(d.get("spec_json"), str):
+                try:
+                    d["spec_json"] = json.loads(d["spec_json"])
+                except (json.JSONDecodeError, TypeError):
+                    pass
+            result.append(d)
+        return result
+
     # ── Helpers ────────────────────────────────────────────────────────
 
     @staticmethod

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -589,3 +589,31 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_session_signals_seq
   ON session_signals(session_id, seq);
 CREATE INDEX IF NOT EXISTS idx_session_signals_session_ts
   ON session_signals(session_id, ts);
+
+-- ── Engine runs (Phase C Move 2) ─────────────────────────────────────────────
+-- One row per `li engine run` invocation.  Tracks the kind, spec, lifecycle
+-- status, and optional link to the Session that ran inside the engine.
+-- session_id is a nullable FK: populated after the engine creates its Session
+-- so the row exists from the moment the CLI is invoked.
+
+CREATE TABLE IF NOT EXISTS engine_runs (
+  id          TEXT    PRIMARY KEY,         -- uuid4 hex
+  kind        TEXT    NOT NULL,            -- 'research' | 'review' | 'coding' | 'hypothesis' | 'planning'
+  spec_json   JSON    NOT NULL,            -- serialised CLI spec (prompt / artifact / findings …)
+  status      TEXT    NOT NULL DEFAULT 'running'
+              CHECK(status IN ('running', 'completed', 'failed', 'cancelled')),
+  started_at  REAL    NOT NULL,            -- Unix epoch seconds
+  ended_at    REAL,                        -- NULL while running
+  session_id  TEXT    REFERENCES sessions(id) ON DELETE SET NULL,
+  export_dir  TEXT,                        -- filesystem path when --save used
+  error       TEXT                         -- last exception message on failure
+);
+
+CREATE INDEX IF NOT EXISTS idx_engine_runs_kind
+  ON engine_runs(kind);
+CREATE INDEX IF NOT EXISTS idx_engine_runs_status
+  ON engine_runs(status);
+CREATE INDEX IF NOT EXISTS idx_engine_runs_started
+  ON engine_runs(started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_engine_runs_session
+  ON engine_runs(session_id) WHERE session_id IS NOT NULL;

--- a/lionagi/state/schema_migrations.py
+++ b/lionagi/state/schema_migrations.py
@@ -99,4 +99,18 @@ MIGRATION_COLUMNS: dict[str, list[tuple[str, str]]] = {
         ("status_reason_summary", "TEXT"),
         ("status_evidence_refs", "JSON"),
     ],
+    # Phase C Move 2: engine run persistence.
+    # New table created via schema.sql; these columns allow ALTER TABLE on
+    # existing databases that pre-date this table (rare, but handled uniformly).
+    "engine_runs": [
+        ("id", "TEXT NOT NULL"),
+        ("kind", "TEXT NOT NULL"),
+        ("spec_json", "JSON NOT NULL"),
+        ("status", "TEXT NOT NULL DEFAULT 'running'"),
+        ("started_at", "REAL NOT NULL"),
+        ("ended_at", "REAL"),
+        ("session_id", "TEXT"),
+        ("export_dir", "TEXT"),
+        ("error", "TEXT"),
+    ],
 }

--- a/lionagi/studio/app.py
+++ b/lionagi/studio/app.py
@@ -15,6 +15,7 @@ from .routers import (
     agents,
     artifacts,
     definitions,
+    engine_runs,
     invocations,
     playbooks,
     plugins,
@@ -83,6 +84,7 @@ async def require_studio_bearer_token(request: Request, call_next):
 
 
 app.include_router(runs.router, prefix="/api")
+app.include_router(engine_runs.router, prefix="/api")
 app.include_router(sessions.router, prefix="/api")
 app.include_router(signals.router, prefix="/api")
 app.include_router(definitions.router, prefix="/api")

--- a/lionagi/studio/routers/engine_runs.py
+++ b/lionagi/studio/routers/engine_runs.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""GET /api/engine-runs/ and /api/engine-runs/{id} — engine run read path.
+
+Phase C Move 2: exposes the ``engine_runs`` table written by ``li engine run``
+so Studio can display engine run history alongside session runs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query
+
+from ..services import engine_runs as engine_runs_svc
+
+router = APIRouter(prefix="/engine-runs", tags=["engine-runs"])
+
+
+@router.get("/")
+async def list_engine_runs(
+    kind: str | None = Query(default=None, description="Filter by engine kind."),
+    status: str | None = Query(default=None, description="Filter by status."),
+    session_id: str | None = Query(default=None, description="Filter by associated session id."),
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+) -> list[dict[str, Any]]:
+    """List engine runs, newest-first.  All query params are optional filters."""
+    return await engine_runs_svc.list_engine_runs(
+        kind=kind,
+        status=status,
+        session_id=session_id,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.get("/{run_id}")
+async def get_engine_run(run_id: str) -> dict[str, Any]:
+    """Return a single engine run row by id."""
+    row = await engine_runs_svc.get_engine_run(run_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"Engine run '{run_id}' not found")
+    return row

--- a/lionagi/studio/services/engine_runs.py
+++ b/lionagi/studio/services/engine_runs.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Studio service: read path for the engine_runs table (Phase C Move 2)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from lionagi.state.db import DEFAULT_DB_PATH
+
+from ._db import open_db as _open_db
+
+_DB = str(DEFAULT_DB_PATH)
+
+
+def _parse_spec_json(raw: Any) -> Any:
+    if isinstance(raw, str):
+        try:
+            return json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return {}
+    return raw or {}
+
+
+async def list_engine_runs(
+    *,
+    kind: str | None = None,
+    status: str | None = None,
+    session_id: str | None = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> list[dict[str, Any]]:
+    """Return engine run rows, newest-first, with optional filters."""
+    if not DEFAULT_DB_PATH.exists():
+        return []
+
+    async with _open_db(_DB) as db:
+        cur = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='engine_runs'"
+        )
+        if not await cur.fetchone():
+            return []
+
+        conditions: list[str] = []
+        params: list[Any] = []
+        if kind is not None:
+            conditions.append("kind = ?")
+            params.append(kind)
+        if status is not None:
+            conditions.append("status = ?")
+            params.append(status)
+        if session_id is not None:
+            conditions.append("session_id = ?")
+            params.append(session_id)
+        where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+        params.extend([limit, offset])
+
+        sql = (
+            f"SELECT id, kind, spec_json, status, started_at, ended_at, "  # noqa: S608
+            f"session_id, export_dir, error "
+            f"FROM engine_runs {where} "
+            f"ORDER BY started_at DESC "
+            f"LIMIT ? OFFSET ?"
+        )
+        cur = await db.execute(sql, params)
+        rows = await cur.fetchall()
+
+    return [
+        {
+            "id": r["id"],
+            "kind": r["kind"],
+            "spec_json": _parse_spec_json(r["spec_json"]),
+            "status": r["status"],
+            "started_at": r["started_at"],
+            "ended_at": r["ended_at"],
+            "session_id": r["session_id"],
+            "export_dir": r["export_dir"],
+            "error": r["error"],
+        }
+        for r in rows
+    ]
+
+
+async def get_engine_run(run_id: str) -> dict[str, Any] | None:
+    """Return a single engine run row as a dict, or None if not found."""
+    if not DEFAULT_DB_PATH.exists():
+        return None
+
+    async with _open_db(_DB) as db:
+        cur = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='engine_runs'"
+        )
+        if not await cur.fetchone():
+            return None
+
+        cur = await db.execute(
+            "SELECT id, kind, spec_json, status, started_at, ended_at, "
+            "session_id, export_dir, error "
+            "FROM engine_runs WHERE id = ?",
+            (run_id,),
+        )
+        row = await cur.fetchone()
+        if row is None:
+            return None
+
+    return {
+        "id": row["id"],
+        "kind": row["kind"],
+        "spec_json": _parse_spec_json(row["spec_json"]),
+        "status": row["status"],
+        "started_at": row["started_at"],
+        "ended_at": row["ended_at"],
+        "session_id": row["session_id"],
+        "export_dir": row["export_dir"],
+        "error": row["error"],
+    }

--- a/tests/apps_studio_server/test_engine_runs_api.py
+++ b/tests/apps_studio_server/test_engine_runs_api.py
@@ -1,0 +1,327 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the engine_runs Studio API (Phase C Move 2).
+
+Coverage targets:
+  - GET /api/engine-runs/          (list, filters, empty state)
+  - GET /api/engine-runs/{id}      (single row, 404 on miss)
+  - lionagi.studio.services.engine_runs  (service layer, DB absent)
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+
+aiosqlite = pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
+
+from lionagi.state.db import StateDB  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _rid() -> str:
+    return uuid.uuid4().hex
+
+
+async def _seed_engine_run(
+    db_path: Path,
+    *,
+    run_id: str | None = None,
+    kind: str = "research",
+    spec_json: dict | None = None,
+    started_at: float = 1000.0,
+    status: str = "running",
+    session_id: str | None = None,
+) -> str:
+    rid = run_id or _rid()
+    spec = spec_json or {"topic": "test topic"}
+    async with StateDB(db_path) as db:
+        await db.insert_engine_run(
+            run_id=rid,
+            kind=kind,
+            spec_json=spec,
+            started_at=started_at,
+            session_id=session_id,
+        )
+        if status != "running":
+            await db.update_engine_run(rid, status=status, ended_at=started_at + 100.0)
+    return rid
+
+
+# ---------------------------------------------------------------------------
+# Studio service layer: engine_runs service
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def patched_engine_runs_svc(tmp_path: Path, monkeypatch):
+    import lionagi.studio.services.engine_runs as svc
+
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(svc, "_DB", str(db_path))
+    monkeypatch.setattr(svc, "DEFAULT_DB_PATH", db_path)
+    return svc, db_path
+
+
+async def test_service_list_returns_empty_when_db_absent(patched_engine_runs_svc):
+    svc, db_path = patched_engine_runs_svc
+    result = await svc.list_engine_runs()
+    assert result == []
+
+
+async def test_service_get_returns_none_when_db_absent(patched_engine_runs_svc):
+    svc, db_path = patched_engine_runs_svc
+    result = await svc.get_engine_run("any-id")
+    assert result is None
+
+
+async def test_service_list_returns_seeded_rows(patched_engine_runs_svc):
+    svc, db_path = patched_engine_runs_svc
+    rid1 = await _seed_engine_run(db_path, kind="research", started_at=1000.0)
+    rid2 = await _seed_engine_run(db_path, kind="review", started_at=1001.0)
+
+    rows = await svc.list_engine_runs()
+    ids = [r["id"] for r in rows]
+    assert rid1 in ids
+    assert rid2 in ids
+
+
+async def test_service_list_newest_first(patched_engine_runs_svc):
+    svc, db_path = patched_engine_runs_svc
+    rid_old = await _seed_engine_run(db_path, started_at=500.0)
+    rid_new = await _seed_engine_run(db_path, started_at=1500.0)
+
+    rows = await svc.list_engine_runs()
+    ids = [r["id"] for r in rows]
+    assert ids.index(rid_new) < ids.index(rid_old)
+
+
+async def test_service_list_filter_by_kind(patched_engine_runs_svc):
+    svc, db_path = patched_engine_runs_svc
+    rid_r = await _seed_engine_run(db_path, kind="research")
+    rid_p = await _seed_engine_run(db_path, kind="planning")
+
+    rows = await svc.list_engine_runs(kind="planning")
+    ids = [r["id"] for r in rows]
+    assert rid_p in ids
+    assert rid_r not in ids
+
+
+async def test_service_list_filter_by_status(patched_engine_runs_svc):
+    svc, db_path = patched_engine_runs_svc
+    rid_running = await _seed_engine_run(db_path, status="running")
+    rid_done = await _seed_engine_run(db_path, status="completed")
+
+    rows = await svc.list_engine_runs(status="completed")
+    ids = [r["id"] for r in rows]
+    assert rid_done in ids
+    assert rid_running not in ids
+
+
+async def test_service_get_returns_row(patched_engine_runs_svc):
+    svc, db_path = patched_engine_runs_svc
+    rid = await _seed_engine_run(
+        db_path,
+        kind="hypothesis",
+        spec_json={"findings": "X causes Y"},
+        started_at=900.0,
+    )
+
+    row = await svc.get_engine_run(rid)
+    assert row is not None
+    assert row["id"] == rid
+    assert row["kind"] == "hypothesis"
+    assert row["spec_json"] == {"findings": "X causes Y"}
+
+
+async def test_service_get_returns_none_for_missing(patched_engine_runs_svc):
+    svc, db_path = patched_engine_runs_svc
+    # Ensure DB exists (create at least one row so the table exists)
+    await _seed_engine_run(db_path)
+    result = await svc.get_engine_run("nonexistent-id")
+    assert result is None
+
+
+async def test_service_spec_json_round_trips(patched_engine_runs_svc):
+    """spec_json stored as TEXT is deserialized back to a dict by the service."""
+    svc, db_path = patched_engine_runs_svc
+    spec = {"topic": "GQA", "depth": 3, "tags": ["attn", "fast"]}
+    rid = await _seed_engine_run(db_path, spec_json=spec)
+
+    row = await svc.get_engine_run(rid)
+    assert row is not None
+    assert row["spec_json"] == spec
+
+
+# ---------------------------------------------------------------------------
+# HTTP endpoint layer
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def patched_app(tmp_path: Path, monkeypatch):
+    """Return (app, db_path, httpx.AsyncClient) with engine_runs DB patched.
+
+    Skips when fastapi/httpx extras are not installed.
+    """
+    pytest.importorskip("fastapi", reason="studio extra not installed")
+    httpx = pytest.importorskip("httpx", reason="httpx not installed")
+
+    import lionagi.studio.services.engine_runs as er_svc
+
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(er_svc, "_DB", str(db_path))
+    monkeypatch.setattr(er_svc, "DEFAULT_DB_PATH", db_path)
+
+    from lionagi.studio.app import app
+
+    transport = httpx.ASGITransport(app=app)
+    client = httpx.AsyncClient(transport=transport, base_url="http://test")
+    return app, db_path, client
+
+
+async def test_list_endpoint_returns_empty(patched_app):
+    _, db_path, client = patched_app
+    async with client as ac:
+        resp = await ac.get("/api/engine-runs/")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+async def test_list_endpoint_returns_seeded_rows(patched_app):
+    _, db_path, client = patched_app
+    rid1 = await _seed_engine_run(db_path, kind="research", started_at=1000.0)
+    rid2 = await _seed_engine_run(db_path, kind="review", started_at=1001.0)
+
+    async with client as ac:
+        resp = await ac.get("/api/engine-runs/")
+    assert resp.status_code == 200
+    data = resp.json()
+    ids = [r["id"] for r in data]
+    assert rid1 in ids
+    assert rid2 in ids
+
+
+async def test_list_endpoint_filter_kind(patched_app):
+    _, db_path, client = patched_app
+    rid_r = await _seed_engine_run(db_path, kind="research")
+    rid_p = await _seed_engine_run(db_path, kind="planning")
+
+    async with client as ac:
+        resp = await ac.get("/api/engine-runs/?kind=planning")
+    assert resp.status_code == 200
+    ids = [r["id"] for r in resp.json()]
+    assert rid_p in ids
+    assert rid_r not in ids
+
+
+async def test_list_endpoint_filter_status(patched_app):
+    _, db_path, client = patched_app
+    rid_running = await _seed_engine_run(db_path, status="running")
+    rid_done = await _seed_engine_run(db_path, status="completed")
+
+    async with client as ac:
+        resp = await ac.get("/api/engine-runs/?status=completed")
+    assert resp.status_code == 200
+    ids = [r["id"] for r in resp.json()]
+    assert rid_done in ids
+    assert rid_running not in ids
+
+
+async def test_list_endpoint_newest_first(patched_app):
+    _, db_path, client = patched_app
+    rid_old = await _seed_engine_run(db_path, started_at=500.0)
+    rid_new = await _seed_engine_run(db_path, started_at=1500.0)
+
+    async with client as ac:
+        resp = await ac.get("/api/engine-runs/")
+    assert resp.status_code == 200
+    rows = resp.json()
+    ids = [r["id"] for r in rows]
+    assert ids.index(rid_new) < ids.index(rid_old)
+
+
+async def test_get_endpoint_returns_row(patched_app):
+    _, db_path, client = patched_app
+    rid = await _seed_engine_run(
+        db_path,
+        kind="coding",
+        spec_json={"spec": "BFS impl", "test_cmd": "pytest"},
+        started_at=200.0,
+    )
+
+    async with client as ac:
+        resp = await ac.get(f"/api/engine-runs/{rid}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == rid
+    assert data["kind"] == "coding"
+    assert data["spec_json"] == {"spec": "BFS impl", "test_cmd": "pytest"}
+
+
+async def test_get_endpoint_404_on_missing(patched_app):
+    _, db_path, client = patched_app
+    # Seed one row so the table exists.
+    await _seed_engine_run(db_path)
+
+    async with client as ac:
+        resp = await ac.get("/api/engine-runs/nonexistent-run-id")
+    assert resp.status_code == 404
+
+
+async def test_get_endpoint_session_link_field(patched_app):
+    """session_id on a run is returned in the response payload."""
+    _, db_path, client = patched_app
+
+    # Ensure schema is initialised by seeding a row without FK violation.
+    await _seed_engine_run(db_path)
+
+    # Insert a row with a non-null session_id bypassing the FK (the
+    # production code only sets session_id when the session already exists;
+    # this test is verifying the API field shape, not the FK constraint).
+    rid = uuid.uuid4().hex
+    async with aiosqlite.connect(str(db_path)) as conn:
+        await conn.execute("PRAGMA foreign_keys = OFF")
+        await conn.execute(
+            "INSERT INTO engine_runs (id, kind, spec_json, status, started_at, session_id)"
+            " VALUES (?, 'research', '{}', 'running', 1000.0, 'test-session-001')",
+            (rid,),
+        )
+        await conn.commit()
+
+    async with client as ac:
+        resp = await ac.get(f"/api/engine-runs/{rid}")
+    assert resp.status_code == 200
+    assert resp.json()["session_id"] == "test-session-001"
+
+
+def test_list_endpoint_bearer_auth(tmp_path: Path, monkeypatch):
+    """GET /api/engine-runs/ returns 401 when auth token is set and missing."""
+    pytest.importorskip("fastapi", reason="studio extra not installed")
+    from fastapi.testclient import TestClient
+
+    import lionagi.studio.services.engine_runs as er_svc
+
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(er_svc, "_DB", str(db_path))
+    monkeypatch.setattr(er_svc, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setenv("LIONAGI_STUDIO_AUTH_TOKEN", "secret-engine-token")
+
+    from lionagi.studio.app import app
+
+    client = TestClient(app, raise_server_exceptions=False)
+
+    resp = client.get("/api/engine-runs/")
+    assert resp.status_code == 401
+
+    resp_ok = client.get(
+        "/api/engine-runs/",
+        headers={"Authorization": "Bearer secret-engine-token"},
+    )
+    assert resp_ok.status_code != 401

--- a/tests/cli/test_engine_cli.py
+++ b/tests/cli/test_engine_cli.py
@@ -1,0 +1,414 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for `li engine run` CLI subcommand (Phase C Move 2).
+
+Coverage targets:
+  - add_engine_subparser wires all expected engine kinds
+  - Missing --test-cmd for 'coding' kind returns exit 1
+  - Valid arg parsing for each kind
+  - Engine execution dispatches to the correct class (mocked)
+  - run_engine returns 0 on success and emits JSON result on stdout
+  - run_engine returns 1 on engine failure
+  - StateDB insert/update called on success and failure paths
+  - --no-persist skips DB writes
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib
+import json
+import sys
+from io import StringIO
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _build_args(**kwargs) -> argparse.Namespace:
+    """Build a minimal argparse.Namespace for engine run tests."""
+    defaults = {
+        "command": "engine",
+        "engine_command": "run",
+        "kind": "research",
+        "spec": "What is GQA?",
+        "test_cmd": None,
+        "export_dir": None,
+        "model": None,
+        "max_depth": None,
+        "max_agents": None,
+        "session_id": None,
+        "no_persist": True,  # skip DB by default in unit tests
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Subparser registration
+# ---------------------------------------------------------------------------
+
+
+def test_add_engine_subparser_registers_engine_command():
+    """add_engine_subparser must register 'engine' as a valid subcommand."""
+    from lionagi.cli.engine import add_engine_subparser
+
+    top = argparse.ArgumentParser(prog="li")
+    sub = top.add_subparsers(dest="command")
+    add_engine_subparser(sub)
+
+    # Should parse without error.
+    args = top.parse_args(["engine", "run", "research", "What is GQA?"])
+    assert args.command == "engine"
+    assert args.kind == "research"
+    assert args.spec == "What is GQA?"
+
+
+def test_all_engine_kinds_are_valid():
+    """Every expected kind is accepted by the parser."""
+    from lionagi.cli.engine import _KIND_META, add_engine_subparser
+
+    top = argparse.ArgumentParser(prog="li")
+    sub = top.add_subparsers(dest="command")
+    add_engine_subparser(sub)
+
+    for kind in _KIND_META:
+        args = top.parse_args(["engine", "run", kind, f"input for {kind}"])
+        assert args.kind == kind, f"kind={kind} was not parsed correctly"
+
+
+def test_invalid_kind_raises_parser_error():
+    """An unknown kind must cause argparse to exit (SystemExit)."""
+    from lionagi.cli.engine import add_engine_subparser
+
+    top = argparse.ArgumentParser(prog="li")
+    sub = top.add_subparsers(dest="command")
+    add_engine_subparser(sub)
+
+    with pytest.raises(SystemExit):
+        top.parse_args(["engine", "run", "nonexistent-kind", "some input"])
+
+
+def test_coding_kind_accepts_test_cmd():
+    """--test-cmd is stored correctly on the parsed args."""
+    from lionagi.cli.engine import add_engine_subparser
+
+    top = argparse.ArgumentParser(prog="li")
+    sub = top.add_subparsers(dest="command")
+    add_engine_subparser(sub)
+
+    args = top.parse_args(["engine", "run", "coding", "impl BFS", "--test-cmd", "pytest tests/"])
+    assert args.kind == "coding"
+    assert args.test_cmd == "pytest tests/"
+
+
+def test_engine_run_accepts_model_and_depth_flags():
+    """--model and --max-depth are stored correctly."""
+    from lionagi.cli.engine import add_engine_subparser
+
+    top = argparse.ArgumentParser(prog="li")
+    sub = top.add_subparsers(dest="command")
+    add_engine_subparser(sub)
+
+    args = top.parse_args(
+        [
+            "engine",
+            "run",
+            "planning",
+            "Build a REST API",
+            "--model",
+            "claude/sonnet",
+            "--max-depth",
+            "5",
+        ]
+    )
+    assert args.model == "claude/sonnet"
+    assert args.max_depth == 5
+
+
+# ---------------------------------------------------------------------------
+# Coding kind: missing --test-cmd → exit 1
+# ---------------------------------------------------------------------------
+
+
+async def test_coding_without_test_cmd_returns_1(monkeypatch):
+    """'coding' kind without --test-cmd must return exit code 1."""
+    import lionagi.cli._logging as log_mod
+
+    monkeypatch.setattr(log_mod, "log_error", lambda *a, **kw: None)
+
+    from lionagi.cli.engine import _do_engine_run
+
+    args = _build_args(kind="coding", spec="impl BFS", test_cmd=None, no_persist=True)
+    result = await _do_engine_run(args)
+    assert result == 1
+
+
+# ---------------------------------------------------------------------------
+# Successful engine run (mocked engine)
+# ---------------------------------------------------------------------------
+
+
+async def test_successful_engine_run_returns_0(monkeypatch, capsys):
+    """A mocked engine that returns a string → exit 0 + JSON on stdout."""
+    import lionagi.cli._logging as log_mod
+    import lionagi.cli.engine as engine_mod
+
+    monkeypatch.setattr(log_mod, "progress", lambda *a, **kw: None)
+    monkeypatch.setattr(log_mod, "warn", lambda *a, **kw: None)
+
+    # Patch _import_engine_class to return a mock engine class.
+    async def _mock_run(spec, *, on_event=None, **kwargs):
+        if on_event:
+            on_event({"type": "thinking", "detail": "deep dive"})
+        return "This is the research result."
+
+    mock_engine = MagicMock()
+    mock_engine.run = _mock_run
+    MockEngineClass = MagicMock(return_value=mock_engine)
+    monkeypatch.setattr(engine_mod, "_import_engine_class", lambda m, n: MockEngineClass)
+
+    args = _build_args(kind="research", spec="What is GQA?", no_persist=True)
+    result = await engine_mod._do_engine_run(args)
+
+    assert result == 0
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    assert output["result"] == "This is the research result."
+
+
+async def test_engine_failure_returns_1(monkeypatch):
+    """A mocked engine that raises → exit 1."""
+    import lionagi.cli._logging as log_mod
+    import lionagi.cli.engine as engine_mod
+
+    monkeypatch.setattr(log_mod, "progress", lambda *a, **kw: None)
+    monkeypatch.setattr(log_mod, "warn", lambda *a, **kw: None)
+    monkeypatch.setattr(log_mod, "log_error", lambda *a, **kw: None)
+
+    async def _mock_run_fail(spec, *, on_event=None, **kwargs):
+        raise RuntimeError("LLM unavailable")
+
+    mock_engine = MagicMock()
+    mock_engine.run = _mock_run_fail
+    MockEngineClass = MagicMock(return_value=mock_engine)
+    monkeypatch.setattr(engine_mod, "_import_engine_class", lambda m, n: MockEngineClass)
+
+    args = _build_args(kind="planning", spec="Build something", no_persist=True)
+    result = await engine_mod._do_engine_run(args)
+    assert result == 1
+
+
+# ---------------------------------------------------------------------------
+# Pydantic model result (CodingEngine-like)
+# ---------------------------------------------------------------------------
+
+
+async def test_pydantic_result_serialized_to_json(monkeypatch, capsys):
+    """A result that has .model_dump() is serialised via model_dump, not str()."""
+    import lionagi.cli._logging as log_mod
+    import lionagi.cli.engine as engine_mod
+
+    monkeypatch.setattr(log_mod, "progress", lambda *a, **kw: None)
+    monkeypatch.setattr(log_mod, "warn", lambda *a, **kw: None)
+
+    pydantic_result = MagicMock()
+    pydantic_result.model_dump = MagicMock(
+        return_value={"status": "success", "files": ["main.py"], "export_dir": "/tmp/out"}
+    )
+
+    async def _mock_run(spec, *, on_event=None, **kwargs):
+        return pydantic_result
+
+    mock_engine = MagicMock()
+    mock_engine.run = _mock_run
+    MockEngineClass = MagicMock(return_value=mock_engine)
+    monkeypatch.setattr(engine_mod, "_import_engine_class", lambda m, n: MockEngineClass)
+
+    args = _build_args(
+        kind="coding",
+        spec="impl BFS",
+        test_cmd="pytest",
+        no_persist=True,
+    )
+    result = await engine_mod._do_engine_run(args)
+
+    assert result == 0
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    assert output["status"] == "success"
+    assert output["files"] == ["main.py"]
+
+
+# ---------------------------------------------------------------------------
+# StateDB persistence paths
+# ---------------------------------------------------------------------------
+
+
+async def test_db_insert_called_on_success(monkeypatch, capsys):
+    """With no_persist=False, insert_engine_run and update_engine_run are called."""
+    import lionagi.cli._logging as log_mod
+    import lionagi.cli.engine as engine_mod
+    import lionagi.state.db as db_mod
+
+    monkeypatch.setattr(log_mod, "progress", lambda *a, **kw: None)
+    monkeypatch.setattr(log_mod, "warn", lambda *a, **kw: None)
+
+    async def _mock_run(spec, *, on_event=None, **kwargs):
+        return "done"
+
+    mock_engine = MagicMock()
+    mock_engine.run = _mock_run
+    MockEngineClass = MagicMock(return_value=mock_engine)
+    monkeypatch.setattr(engine_mod, "_import_engine_class", lambda m, n: MockEngineClass)
+
+    insert_calls: list[dict] = []
+    update_calls: list[dict] = []
+
+    class MockStateDB:
+        async def open(self):
+            pass
+
+        async def close(self):
+            pass
+
+        async def insert_engine_run(self, *, run_id, kind, spec_json, started_at, session_id=None):
+            insert_calls.append({"run_id": run_id, "kind": kind})
+
+        async def update_engine_run(
+            self, run_id, *, status, ended_at=None, export_dir=None, error=None
+        ):
+            update_calls.append({"run_id": run_id, "status": status})
+
+    # Patch StateDB in the db module so the `from lionagi.state.db import StateDB`
+    # inside _do_engine_run picks up the mock.
+    monkeypatch.setattr(db_mod, "StateDB", MockStateDB)
+
+    args = _build_args(kind="research", spec="test topic", no_persist=False)
+    rc = await engine_mod._do_engine_run(args)
+
+    assert rc == 0
+    assert len(insert_calls) == 1
+    assert insert_calls[0]["kind"] == "research"
+    assert any(c["status"] == "completed" for c in update_calls)
+
+
+async def test_no_persist_skips_db(monkeypatch, capsys):
+    """--no-persist flag means no DB calls are made."""
+    import lionagi.cli._logging as log_mod
+    import lionagi.cli.engine as engine_mod
+    import lionagi.state.db as db_mod
+
+    monkeypatch.setattr(log_mod, "progress", lambda *a, **kw: None)
+    monkeypatch.setattr(log_mod, "warn", lambda *a, **kw: None)
+
+    async def _mock_run(spec, *, on_event=None, **kwargs):
+        return "no persist result"
+
+    mock_engine = MagicMock()
+    mock_engine.run = _mock_run
+    MockEngineClass = MagicMock(return_value=mock_engine)
+    monkeypatch.setattr(engine_mod, "_import_engine_class", lambda m, n: MockEngineClass)
+
+    db_opened = []
+
+    class FailingStateDB:
+        async def open(self):
+            db_opened.append(True)
+            raise AssertionError("StateDB should not be opened with --no-persist")
+
+    monkeypatch.setattr(db_mod, "StateDB", FailingStateDB)
+
+    args = _build_args(kind="research", spec="test", no_persist=True)
+    rc = await engine_mod._do_engine_run(args)
+
+    assert rc == 0
+    assert not db_opened, "StateDB.open() was called despite --no-persist"
+
+
+# ---------------------------------------------------------------------------
+# run_engine dispatch (synchronous entry point)
+# ---------------------------------------------------------------------------
+
+
+def test_run_engine_dispatches_run_subcommand(monkeypatch):
+    """run_engine with engine_command='run' calls _do_engine_run via run_async."""
+    import lionagi.cli._logging as log_mod
+    import lionagi.cli.engine as engine_mod
+
+    called_with = []
+
+    async def _mock_do_engine_run(args):
+        called_with.append(args)
+        return 0
+
+    monkeypatch.setattr(engine_mod, "_do_engine_run", _mock_do_engine_run)
+    monkeypatch.setattr(log_mod, "log_error", lambda *a, **kw: None)
+
+    # Patch run_async to execute the coroutine synchronously in a fresh event loop.
+    import lionagi.ln.concurrency as conc_mod
+
+    monkeypatch.setattr(conc_mod, "run_async", lambda coro: asyncio.run(coro))
+
+    from lionagi.cli.engine import run_engine
+
+    args = _build_args(kind="research", spec="test", no_persist=True)
+    rc = run_engine(args)
+    assert rc == 0
+    assert len(called_with) == 1
+
+
+def test_run_engine_unknown_subcommand_returns_1(monkeypatch):
+    """Unknown engine subcommand → exit 1."""
+    import lionagi.cli._logging as log_mod
+
+    monkeypatch.setattr(log_mod, "log_error", lambda *a, **kw: None)
+
+    from lionagi.cli.engine import run_engine
+
+    args = _build_args()
+    args.engine_command = "unknown-cmd"
+
+    rc = run_engine(args)
+    assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# Main entrypoint: 'engine' command is routed in main()
+# ---------------------------------------------------------------------------
+
+
+def test_main_routes_engine_command(monkeypatch):
+    """main() routes 'engine run ...' to run_engine (not run_agent or others).
+
+    Because `lionagi.cli` exports a `main` function that shadows the module
+    name, we retrieve the actual main.py module via importlib and patch
+    run_engine on that module object.
+    """
+    import lionagi.cli._logging as log_mod
+
+    monkeypatch.setattr(log_mod, "configure_cli_logging", lambda *a: None)
+
+    # Get the actual main.py module (not the main() function exported via __init__)
+    main_module = importlib.import_module("lionagi.cli.main")
+
+    run_engine_calls = []
+
+    def _mock_run_engine(args):
+        run_engine_calls.append(args)
+        return 0
+
+    monkeypatch.setattr(main_module, "run_engine", _mock_run_engine)
+
+    # 'engine run research <spec>' — must be routed to run_engine.
+    rc = main_module.main(["engine", "run", "research", "test topic"])
+    assert rc == 0
+    assert len(run_engine_calls) == 1
+    assert run_engine_calls[0].command == "engine"

--- a/tests/cli/test_engine_cli.py
+++ b/tests/cli/test_engine_cli.py
@@ -207,22 +207,31 @@ async def test_engine_failure_returns_1(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Pydantic model result (CodingEngine-like)
+# Pydantic model result — CodeResultRecorded real shape
 # ---------------------------------------------------------------------------
 
 
-async def test_pydantic_result_serialized_to_json(monkeypatch, capsys):
-    """A result that has .model_dump() is serialised via model_dump, not str()."""
+async def test_code_result_recorded_shape_serialized(monkeypatch, capsys):
+    """CodingEngine returns CodeResultRecorded (passed/measurements/caveats/
+    experiment_ref/verdict_ref) — NOT a dict with export_dir.  Verify the CLI
+    serialises that real shape and does NOT crash when export_dir is absent."""
     import lionagi.cli._logging as log_mod
     import lionagi.cli.engine as engine_mod
 
     monkeypatch.setattr(log_mod, "progress", lambda *a, **kw: None)
     monkeypatch.setattr(log_mod, "warn", lambda *a, **kw: None)
 
+    # Simulate the real CodeResultRecorded.model_dump() output — no export_dir field.
+    real_coding_dump = {
+        "passed": True,
+        "measurements": {"rounds": 1, "test_runs": 1, "returncode": 0},
+        "caveats": [],
+        "experiment_ref": "",
+        "verdict_ref": "",
+    }
+
     pydantic_result = MagicMock()
-    pydantic_result.model_dump = MagicMock(
-        return_value={"status": "success", "files": ["main.py"], "export_dir": "/tmp/out"}
-    )
+    pydantic_result.model_dump = MagicMock(return_value=real_coding_dump)
 
     async def _mock_run(spec, *, on_event=None, **kwargs):
         return pydantic_result
@@ -243,8 +252,282 @@ async def test_pydantic_result_serialized_to_json(monkeypatch, capsys):
     assert result == 0
     captured = capsys.readouterr()
     output = json.loads(captured.out)
-    assert output["status"] == "success"
-    assert output["files"] == ["main.py"]
+    assert output["passed"] is True
+    assert "measurements" in output
+    # No export_dir in CodeResultRecorded, no args.export_dir → None in DB (verified
+    # in export_dir persistence tests below).
+
+
+# ---------------------------------------------------------------------------
+# export_dir persistence — sourced from args, not result model
+# ---------------------------------------------------------------------------
+
+
+async def test_export_dir_persisted_from_args_coding(monkeypatch, capsys):
+    """--export-dir must be written to the DB for 'coding' even though
+    CodeResultRecorded has no export_dir field (confirmed real shape above)."""
+    import lionagi.cli._logging as log_mod
+    import lionagi.cli.engine as engine_mod
+    import lionagi.state.db as db_mod
+
+    monkeypatch.setattr(log_mod, "progress", lambda *a, **kw: None)
+    monkeypatch.setattr(log_mod, "warn", lambda *a, **kw: None)
+
+    # Real CodeResultRecorded dump — NO export_dir key.
+    real_coding_dump = {
+        "passed": True,
+        "measurements": {"rounds": 1},
+        "caveats": [],
+        "experiment_ref": "",
+        "verdict_ref": "",
+    }
+    pydantic_result = MagicMock()
+    pydantic_result.model_dump = MagicMock(return_value=real_coding_dump)
+
+    async def _mock_run(spec, *, on_event=None, **kwargs):
+        return pydantic_result
+
+    mock_engine = MagicMock()
+    mock_engine.run = _mock_run
+    MockEngineClass = MagicMock(return_value=mock_engine)
+    monkeypatch.setattr(engine_mod, "_import_engine_class", lambda m, n: MockEngineClass)
+
+    update_calls: list[dict] = []
+
+    class MockStateDB:
+        async def open(self):
+            pass
+
+        async def close(self):
+            pass
+
+        async def insert_engine_run(self, *, run_id, kind, spec_json, started_at, session_id=None):
+            pass
+
+        async def update_engine_run(
+            self, run_id, *, status, ended_at=None, export_dir=None, error=None
+        ):
+            update_calls.append({"status": status, "export_dir": export_dir})
+
+    monkeypatch.setattr(db_mod, "StateDB", MockStateDB)
+
+    args = _build_args(
+        kind="coding",
+        spec="impl BFS",
+        test_cmd="pytest tests/",
+        export_dir="/tmp/real-export",
+        no_persist=False,
+    )
+    rc = await engine_mod._do_engine_run(args)
+
+    assert rc == 0
+    completed = [c for c in update_calls if c["status"] == "completed"]
+    assert completed, "no completed update call"
+    assert completed[0]["export_dir"] == "/tmp/real-export", (
+        f"expected /tmp/real-export, got {completed[0]['export_dir']!r}"
+    )
+
+
+async def test_export_dir_persisted_from_args_hypothesis(monkeypatch, capsys):
+    """--export-dir must be written to the DB for 'hypothesis'; the hypothesis
+    engine returns a plain string, not a Pydantic model."""
+    import lionagi.cli._logging as log_mod
+    import lionagi.cli.engine as engine_mod
+    import lionagi.state.db as db_mod
+
+    monkeypatch.setattr(log_mod, "progress", lambda *a, **kw: None)
+    monkeypatch.setattr(log_mod, "warn", lambda *a, **kw: None)
+
+    async def _mock_run(spec, *, on_event=None, **kwargs):
+        # Hypothesis engine returns a plain string report.
+        return "Hypothesis: X causes Y because Z."
+
+    mock_engine = MagicMock()
+    mock_engine.run = _mock_run
+    MockEngineClass = MagicMock(return_value=mock_engine)
+    monkeypatch.setattr(engine_mod, "_import_engine_class", lambda m, n: MockEngineClass)
+
+    update_calls: list[dict] = []
+
+    class MockStateDB:
+        async def open(self):
+            pass
+
+        async def close(self):
+            pass
+
+        async def insert_engine_run(self, *, run_id, kind, spec_json, started_at, session_id=None):
+            pass
+
+        async def update_engine_run(
+            self, run_id, *, status, ended_at=None, export_dir=None, error=None
+        ):
+            update_calls.append({"status": status, "export_dir": export_dir})
+
+    monkeypatch.setattr(db_mod, "StateDB", MockStateDB)
+
+    args = _build_args(
+        kind="hypothesis",
+        spec="Finding: X causes Y",
+        export_dir="/tmp/hypo-export",
+        no_persist=False,
+    )
+    rc = await engine_mod._do_engine_run(args)
+
+    assert rc == 0
+    completed = [c for c in update_calls if c["status"] == "completed"]
+    assert completed, "no completed update call"
+    assert completed[0]["export_dir"] == "/tmp/hypo-export", (
+        f"expected /tmp/hypo-export, got {completed[0]['export_dir']!r}"
+    )
+
+
+async def test_export_dir_none_when_not_passed(monkeypatch, capsys):
+    """No --export-dir → export_dir=None in the DB update (not a stale string)."""
+    import lionagi.cli._logging as log_mod
+    import lionagi.cli.engine as engine_mod
+    import lionagi.state.db as db_mod
+
+    monkeypatch.setattr(log_mod, "progress", lambda *a, **kw: None)
+    monkeypatch.setattr(log_mod, "warn", lambda *a, **kw: None)
+
+    async def _mock_run(spec, *, on_event=None, **kwargs):
+        return "Research findings."
+
+    mock_engine = MagicMock()
+    mock_engine.run = _mock_run
+    MockEngineClass = MagicMock(return_value=mock_engine)
+    monkeypatch.setattr(engine_mod, "_import_engine_class", lambda m, n: MockEngineClass)
+
+    update_calls: list[dict] = []
+
+    class MockStateDB:
+        async def open(self):
+            pass
+
+        async def close(self):
+            pass
+
+        async def insert_engine_run(self, *, run_id, kind, spec_json, started_at, session_id=None):
+            pass
+
+        async def update_engine_run(
+            self, run_id, *, status, ended_at=None, export_dir=None, error=None
+        ):
+            update_calls.append({"status": status, "export_dir": export_dir})
+
+    monkeypatch.setattr(db_mod, "StateDB", MockStateDB)
+
+    args = _build_args(kind="research", spec="GQA", no_persist=False, export_dir=None)
+    rc = await engine_mod._do_engine_run(args)
+
+    assert rc == 0
+    completed = [c for c in update_calls if c["status"] == "completed"]
+    assert completed[0]["export_dir"] is None
+
+
+# ---------------------------------------------------------------------------
+# Cancellation handling — BaseException paths
+# ---------------------------------------------------------------------------
+
+
+async def test_cancelled_error_marks_row_cancelled(monkeypatch):
+    """asyncio.CancelledError → row status='cancelled', db closed, error re-raised."""
+    import lionagi.cli._logging as log_mod
+    import lionagi.cli.engine as engine_mod
+    import lionagi.state.db as db_mod
+
+    monkeypatch.setattr(log_mod, "progress", lambda *a, **kw: None)
+    monkeypatch.setattr(log_mod, "warn", lambda *a, **kw: None)
+    monkeypatch.setattr(log_mod, "log_error", lambda *a, **kw: None)
+
+    async def _mock_run_cancel(spec, *, on_event=None, **kwargs):
+        raise asyncio.CancelledError("test cancel")
+
+    mock_engine = MagicMock()
+    mock_engine.run = _mock_run_cancel
+    MockEngineClass = MagicMock(return_value=mock_engine)
+    monkeypatch.setattr(engine_mod, "_import_engine_class", lambda m, n: MockEngineClass)
+
+    insert_calls: list[dict] = []
+    update_calls: list[dict] = []
+    close_count = [0]
+
+    class MockStateDB:
+        async def open(self):
+            pass
+
+        async def close(self):
+            close_count[0] += 1
+
+        async def insert_engine_run(self, *, run_id, kind, spec_json, started_at, session_id=None):
+            insert_calls.append({"run_id": run_id, "kind": kind})
+
+        async def update_engine_run(
+            self, run_id, *, status, ended_at=None, export_dir=None, error=None
+        ):
+            update_calls.append({"run_id": run_id, "status": status, "error": error})
+
+    monkeypatch.setattr(db_mod, "StateDB", MockStateDB)
+
+    args = _build_args(kind="research", spec="test", no_persist=False)
+    with pytest.raises(asyncio.CancelledError):
+        await engine_mod._do_engine_run(args)
+
+    # Row must be marked 'cancelled', not left as 'running'.
+    assert len(insert_calls) == 1
+    cancelled_updates = [c for c in update_calls if c["status"] == "cancelled"]
+    assert cancelled_updates, f"expected a 'cancelled' update; got {update_calls}"
+    assert cancelled_updates[0]["error"] is not None
+    # DB must be closed.
+    assert close_count[0] == 1
+
+
+async def test_keyboard_interrupt_marks_row_cancelled(monkeypatch):
+    """KeyboardInterrupt → row status='cancelled', db closed, re-raised."""
+    import lionagi.cli._logging as log_mod
+    import lionagi.cli.engine as engine_mod
+    import lionagi.state.db as db_mod
+
+    monkeypatch.setattr(log_mod, "progress", lambda *a, **kw: None)
+    monkeypatch.setattr(log_mod, "warn", lambda *a, **kw: None)
+    monkeypatch.setattr(log_mod, "log_error", lambda *a, **kw: None)
+
+    async def _mock_run_interrupt(spec, *, on_event=None, **kwargs):
+        raise KeyboardInterrupt("SIGINT simulation")
+
+    mock_engine = MagicMock()
+    mock_engine.run = _mock_run_interrupt
+    MockEngineClass = MagicMock(return_value=mock_engine)
+    monkeypatch.setattr(engine_mod, "_import_engine_class", lambda m, n: MockEngineClass)
+
+    update_calls: list[dict] = []
+    close_count = [0]
+
+    class MockStateDB:
+        async def open(self):
+            pass
+
+        async def close(self):
+            close_count[0] += 1
+
+        async def insert_engine_run(self, *, run_id, kind, spec_json, started_at, session_id=None):
+            pass
+
+        async def update_engine_run(
+            self, run_id, *, status, ended_at=None, export_dir=None, error=None
+        ):
+            update_calls.append({"status": status})
+
+    monkeypatch.setattr(db_mod, "StateDB", MockStateDB)
+
+    args = _build_args(kind="planning", spec="test", no_persist=False)
+    with pytest.raises(KeyboardInterrupt):
+        await engine_mod._do_engine_run(args)
+
+    cancelled = [c for c in update_calls if c["status"] == "cancelled"]
+    assert cancelled, f"expected 'cancelled' update; got {update_calls}"
+    assert close_count[0] == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_engine_cli.py
+++ b/tests/cli/test_engine_cli.py
@@ -617,6 +617,54 @@ async def test_no_persist_skips_db(monkeypatch, capsys):
 
 
 # ---------------------------------------------------------------------------
+# Import-failure closes the DB
+# ---------------------------------------------------------------------------
+
+
+async def test_import_failure_closes_db(monkeypatch):
+    """When _import_engine_class raises, the open DB handle must still be closed."""
+    import lionagi.cli._logging as log_mod
+    import lionagi.cli.engine as engine_mod
+    import lionagi.state.db as db_mod
+
+    monkeypatch.setattr(log_mod, "progress", lambda *a, **kw: None)
+    monkeypatch.setattr(log_mod, "warn", lambda *a, **kw: None)
+    monkeypatch.setattr(log_mod, "log_error", lambda *a, **kw: None)
+
+    def _failing_import(module, name):
+        raise ImportError(f"cannot import {name} from {module}")
+
+    monkeypatch.setattr(engine_mod, "_import_engine_class", _failing_import)
+
+    close_count = [0]
+    update_calls: list[dict] = []
+
+    class MockStateDB:
+        async def open(self):
+            pass
+
+        async def close(self):
+            close_count[0] += 1
+
+        async def insert_engine_run(self, *, run_id, kind, spec_json, started_at, session_id=None):
+            pass
+
+        async def update_engine_run(
+            self, run_id, *, status, ended_at=None, export_dir=None, error=None
+        ):
+            update_calls.append({"status": status})
+
+    monkeypatch.setattr(db_mod, "StateDB", MockStateDB)
+
+    args = _build_args(kind="research", spec="test", no_persist=False)
+    rc = await engine_mod._do_engine_run(args)
+
+    assert rc == 1
+    assert close_count[0] == 1, "DB was not closed after import failure"
+    assert any(c["status"] == "failed" for c in update_calls)
+
+
+# ---------------------------------------------------------------------------
 # run_engine dispatch (synchronous entry point)
 # ---------------------------------------------------------------------------
 

--- a/tests/state/test_engine_runs_db.py
+++ b/tests/state/test_engine_runs_db.py
@@ -1,0 +1,410 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the engine_runs StateDB methods (Phase C Move 2).
+
+Coverage targets:
+  - StateDB.insert_engine_run  (round-trip, fields stored correctly)
+  - StateDB.update_engine_run  (status, ended_at, export_dir, error)
+  - StateDB.get_engine_run     (single-row lookup, None on miss)
+  - StateDB.list_engine_runs   (ordering, filters, offset/limit)
+  - _write_lock discipline: concurrent inserts must not drop rows
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+aiosqlite = pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
+
+from lionagi.state.db import StateDB  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_id() -> str:
+    return uuid.uuid4().hex
+
+
+# ---------------------------------------------------------------------------
+# insert_engine_run + get_engine_run
+# ---------------------------------------------------------------------------
+
+
+async def test_insert_and_get_engine_run(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    rid = _run_id()
+
+    async with StateDB(db_path) as db:
+        await db.insert_engine_run(
+            run_id=rid,
+            kind="research",
+            spec_json={"topic": "GQA attention"},
+            started_at=1000.0,
+        )
+        row = await db.get_engine_run(rid)
+
+    assert row is not None
+    assert row["id"] == rid
+    assert row["kind"] == "research"
+    assert row["spec_json"] == {"topic": "GQA attention"}
+    assert row["status"] == "running"
+    assert row["started_at"] == 1000.0
+    assert row["ended_at"] is None
+    assert row["session_id"] is None
+    assert row["export_dir"] is None
+    assert row["error"] is None
+
+
+async def test_get_engine_run_returns_none_for_missing(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    async with StateDB(db_path) as db:
+        result = await db.get_engine_run("nonexistent-run-id")
+    assert result is None
+
+
+async def test_insert_engine_run_session_id_column_present(tmp_path: Path) -> None:
+    """session_id column exists and is stored/retrieved; no FK required here."""
+    import aiosqlite
+
+    db_path = tmp_path / "state.db"
+    rid = _run_id()
+
+    # Seed the schema by opening StateDB once (creates all tables).
+    async with StateDB(db_path) as db:
+        await db.insert_engine_run(
+            run_id=rid,
+            kind="planning",
+            spec_json={"prompt": "Build a REST API"},
+            started_at=2000.0,
+            session_id=None,  # NULL is always valid (no FK violation)
+        )
+        row = await db.get_engine_run(rid)
+
+    assert row is not None
+    assert row["session_id"] is None
+
+    # Confirm the column itself is present in the schema.
+    async with aiosqlite.connect(str(db_path)) as conn:
+        async with conn.execute("PRAGMA table_info(engine_runs)") as cur:
+            cols = {r[1] async for r in cur}
+    assert "session_id" in cols
+
+    # Verify non-null session_id can be stored by bypassing the FK
+    # (the FK is valid in production — sessions exist before engine runs
+    # reference them; this test just confirms the column stores the value).
+    rid2 = _run_id()
+    async with aiosqlite.connect(str(db_path)) as conn:
+        await conn.execute("PRAGMA foreign_keys = OFF")
+        await conn.execute(
+            "INSERT INTO engine_runs (id, kind, spec_json, status, started_at, session_id)"
+            " VALUES (?, 'research', '{}', 'running', 1000.0, 'test-sess-xyz')",
+            (rid2,),
+        )
+        await conn.commit()
+
+    async with StateDB(db_path) as db:
+        row2 = await db.get_engine_run(rid2)
+    assert row2 is not None
+    assert row2["session_id"] == "test-sess-xyz"
+
+
+# ---------------------------------------------------------------------------
+# update_engine_run
+# ---------------------------------------------------------------------------
+
+
+async def test_update_engine_run_completed(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    rid = _run_id()
+
+    async with StateDB(db_path) as db:
+        await db.insert_engine_run(
+            run_id=rid,
+            kind="review",
+            spec_json={"artifact": "some code"},
+            started_at=500.0,
+        )
+        await db.update_engine_run(
+            rid,
+            status="completed",
+            ended_at=600.0,
+        )
+        row = await db.get_engine_run(rid)
+
+    assert row is not None
+    assert row["status"] == "completed"
+    assert row["ended_at"] == 600.0
+    assert row["error"] is None
+    assert row["export_dir"] is None
+
+
+async def test_update_engine_run_failed(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    rid = _run_id()
+
+    async with StateDB(db_path) as db:
+        await db.insert_engine_run(
+            run_id=rid,
+            kind="hypothesis",
+            spec_json={"findings": "X causes Y"},
+            started_at=100.0,
+        )
+        await db.update_engine_run(
+            rid,
+            status="failed",
+            ended_at=150.0,
+            error="LLM call timed out",
+        )
+        row = await db.get_engine_run(rid)
+
+    assert row is not None
+    assert row["status"] == "failed"
+    assert row["error"] == "LLM call timed out"
+
+
+async def test_update_engine_run_with_export_dir(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    rid = _run_id()
+
+    async with StateDB(db_path) as db:
+        await db.insert_engine_run(
+            run_id=rid,
+            kind="coding",
+            spec_json={"spec": "Implement BFS", "test_cmd": "pytest"},
+            started_at=300.0,
+        )
+        await db.update_engine_run(
+            rid,
+            status="completed",
+            ended_at=400.0,
+            export_dir="/tmp/coding-output",
+        )
+        row = await db.get_engine_run(rid)
+
+    assert row is not None
+    assert row["export_dir"] == "/tmp/coding-output"
+    assert row["status"] == "completed"
+
+
+# ---------------------------------------------------------------------------
+# list_engine_runs
+# ---------------------------------------------------------------------------
+
+
+async def test_list_engine_runs_ordering_newest_first(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    ids = [_run_id() for _ in range(3)]
+
+    async with StateDB(db_path) as db:
+        for i, rid in enumerate(ids):
+            await db.insert_engine_run(
+                run_id=rid,
+                kind="research",
+                spec_json={"topic": f"topic-{i}"},
+                started_at=float(1000 + i),
+            )
+        rows = await db.list_engine_runs()
+
+    assert len(rows) >= 3
+    returned_ids = [r["id"] for r in rows]
+    # The newest (started_at=1002) should appear first.
+    assert returned_ids.index(ids[2]) < returned_ids.index(ids[0])
+
+
+async def test_list_engine_runs_filter_by_kind(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    research_id = _run_id()
+    review_id = _run_id()
+
+    async with StateDB(db_path) as db:
+        await db.insert_engine_run(
+            run_id=research_id,
+            kind="research",
+            spec_json={"topic": "test"},
+            started_at=1000.0,
+        )
+        await db.insert_engine_run(
+            run_id=review_id,
+            kind="review",
+            spec_json={"artifact": "code"},
+            started_at=1001.0,
+        )
+        rows = await db.list_engine_runs(kind="research")
+
+    assert all(r["kind"] == "research" for r in rows)
+    ids_in = [r["id"] for r in rows]
+    assert research_id in ids_in
+    assert review_id not in ids_in
+
+
+async def test_list_engine_runs_filter_by_status(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    running_id = _run_id()
+    done_id = _run_id()
+
+    async with StateDB(db_path) as db:
+        await db.insert_engine_run(
+            run_id=running_id,
+            kind="planning",
+            spec_json={"prompt": "plan"},
+            started_at=1000.0,
+        )
+        await db.insert_engine_run(
+            run_id=done_id,
+            kind="planning",
+            spec_json={"prompt": "plan2"},
+            started_at=1001.0,
+        )
+        await db.update_engine_run(done_id, status="completed", ended_at=1100.0)
+        rows = await db.list_engine_runs(status="running")
+
+    ids_in = [r["id"] for r in rows]
+    assert running_id in ids_in
+    assert done_id not in ids_in
+
+
+async def test_list_engine_runs_limit_and_offset(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    ids = [_run_id() for _ in range(5)]
+
+    async with StateDB(db_path) as db:
+        for i, rid in enumerate(ids):
+            await db.insert_engine_run(
+                run_id=rid,
+                kind="research",
+                spec_json={"topic": f"t-{i}"},
+                started_at=float(1000 + i),
+            )
+        page1 = await db.list_engine_runs(limit=3, offset=0)
+        page2 = await db.list_engine_runs(limit=3, offset=3)
+
+    assert len(page1) == 3
+    assert len(page2) == 2
+    # No overlap between pages.
+    p1_ids = {r["id"] for r in page1}
+    p2_ids = {r["id"] for r in page2}
+    assert p1_ids.isdisjoint(p2_ids)
+
+
+async def test_list_engine_runs_empty(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    async with StateDB(db_path) as db:
+        rows = await db.list_engine_runs()
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# spec_json round-trip: JSON string stored in DB must be deserialized back
+# ---------------------------------------------------------------------------
+
+
+async def test_spec_json_round_trips_complex(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    rid = _run_id()
+    spec = {
+        "topic": "attention mechanisms",
+        "max_depth": 5,
+        "tags": ["GQA", "MHA"],
+        "nested": {"key": "val"},
+    }
+
+    async with StateDB(db_path) as db:
+        await db.insert_engine_run(
+            run_id=rid,
+            kind="research",
+            spec_json=spec,
+            started_at=time.time(),
+        )
+        row = await db.get_engine_run(rid)
+
+    assert row is not None
+    assert row["spec_json"] == spec
+
+
+# ---------------------------------------------------------------------------
+# _write_lock discipline: concurrent inserts must not drop rows or raise
+# ---------------------------------------------------------------------------
+
+
+async def test_concurrent_inserts_no_rows_dropped(tmp_path: Path) -> None:
+    """50 concurrent insert_engine_run calls on the same DB must all succeed.
+
+    Before the _write_lock pattern, concurrent coroutines on a shared
+    aiosqlite connection raced on BEGIN IMMEDIATE and silently dropped writes.
+    """
+    db_path = tmp_path / "state.db"
+    n = 50
+    ids = [_run_id() for _ in range(n)]
+
+    async with StateDB(db_path) as db:
+        await asyncio.gather(
+            *[
+                db.insert_engine_run(
+                    run_id=ids[i],
+                    kind="research",
+                    spec_json={"topic": f"topic-{i}"},
+                    started_at=float(1000 + i),
+                )
+                for i in range(n)
+            ]
+        )
+        rows = await db.list_engine_runs(limit=n + 10)
+
+    assert len(rows) == n, (
+        f"Expected {n} rows after concurrent inserts, got {len(rows)} — lock discipline broken"
+    )
+
+
+async def test_concurrent_insert_and_update_no_errors(tmp_path: Path) -> None:
+    """25 concurrent inserts + 25 concurrent updates on same DB → zero errors."""
+    db_path = tmp_path / "state.db"
+    n = 25
+    ids = [_run_id() for _ in range(n)]
+
+    errors: list[Exception] = []
+
+    async with StateDB(db_path) as db:
+        # Pre-seed rows for updates.
+        for i in range(n):
+            await db.insert_engine_run(
+                run_id=ids[i],
+                kind="planning",
+                spec_json={"prompt": f"plan-{i}"},
+                started_at=float(1000 + i),
+            )
+
+        async def _update(i: int) -> None:
+            try:
+                await db.update_engine_run(
+                    ids[i],
+                    status="completed",
+                    ended_at=float(2000 + i),
+                )
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        # New inserts + updates running concurrently on the same connection.
+        new_ids = [_run_id() for _ in range(n)]
+
+        async def _insert(i: int) -> None:
+            try:
+                await db.insert_engine_run(
+                    run_id=new_ids[i],
+                    kind="review",
+                    spec_json={"artifact": f"code-{i}"},
+                    started_at=float(3000 + i),
+                )
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        await asyncio.gather(*[_insert(i) for i in range(n)], *[_update(i) for i in range(n)])
+
+    assert not errors, f"{len(errors)} write errors on concurrent insert+update: {errors[0]}"

--- a/tests/state/test_migrations.py
+++ b/tests/state/test_migrations.py
@@ -123,6 +123,7 @@ async def test_migration_columns_constant_is_importable():
         "artifacts",
         "schedules",
         "schedule_runs",
+        "engine_runs",  # Phase C Move 2 — new table registered for future migrations
     }
     assert set(MIGRATION_COLUMNS.keys()) == expected_tables
 
@@ -150,11 +151,15 @@ async def test_reconcile_adds_all_columns(old_schema_db):
                 await db.execute(f"ALTER TABLE {table} ADD COLUMN {name} {defn}")
     await db.commit()
 
-    # Verify every migration column now exists
+    # Verify every migration column now exists (skip tables not in old_schema_db
+    # — newly added tables like engine_runs are created by schema.sql, not via
+    # ALTER TABLE, so they won't be present in an "old schema" DB fixture).
     for table, columns in MIGRATION_COLUMNS.items():
         if not columns:
             continue
         actual = await _column_names(db, table)
+        if not actual:
+            continue  # table not present in old_schema_db — skip (new table, not migrated)
         for col_name, _ in columns:
             assert col_name in actual, (
                 f"Migration column '{col_name}' missing from table '{table}' after reconcile"
@@ -184,6 +189,8 @@ async def test_reconcile_is_idempotent(old_schema_db):
         if not columns:
             continue
         actual = await _column_names(db, table)
+        if not actual:
+            continue  # new table not in old_schema_db — skip
         for col_name, _ in columns:
             assert col_name in actual
 


### PR DESCRIPTION
## Summary

Phase C Move 2 — makes engines visible, shell-reachable objects.

**Three pieces shipped:**

1. **`li engine run <kind> <spec>` CLI subcommand** (`lionagi/cli/engine.py`)
   - All five kinds exposed: `research`, `review`, `coding`, `hypothesis`, `planning`
   - Progress events from `on_event` callback stream to stderr via `progress()`
   - Final result emitted as JSON on stdout (`str → {"result": ...}`, Pydantic model → `model_dump(mode="json")`)
   - `CodingEngine` special-cased: requires `--test-cmd`; validates upfront with clear error
   - Optional flags: `--model`, `--max-depth`, `--max-agents`, `--session-id`, `--no-persist`, `--export-dir`
   - `lionagi/cli/main.py` wired

2. **`engine_runs` StateDB table** (`lionagi/state/schema.sql`, `schema_migrations.py`, `db.py`)
   - Columns: `id, kind, spec_json, status, started_at, ended_at, session_id (FK→sessions), export_dir, error`
   - Four StateDB methods: `insert_engine_run`, `update_engine_run`, `get_engine_run`, `list_engine_runs`
   - All mutating methods use `async with self._write_lock:` + `BEGIN IMMEDIATE` (same pattern as PR #1403)
   - Migration entry in `MIGRATION_COLUMNS` for forward-compat ALTER TABLE tracking

3. **Studio read path + Engines frontend tab** (`lionagi/studio/services/engine_runs.py`, `routers/engine_runs.py`, `app.py`, `apps/studio/frontend/`)
   - `GET /api/engine-runs/` — list with `kind/status/session_id/limit/offset` filters, newest-first
   - `GET /api/engine-runs/{run_id}` — single row, 404 on miss
   - Service layer returns `[]`/`None` gracefully when DB doesn't exist yet
   - Frontend `/runs` page gains "Engines" view mode toggle
   - Engine-run cards: short id, kind badge, StatusPill, session link (when `session_id` present), export_dir, started timestamp, duration
   - i18n: `engineRuns` section in `en.json` + `zh.json` (ICU plurals, zh register: 智能体/运行)

## Engine kinds and CLI mapping

| Kind | Positional arg | Special requirements |
|------|---------------|----------------------|
| `research` | `topic` | none |
| `review` | `artifact` | none |
| `coding` | `spec` | `--test-cmd` required |
| `hypothesis` | `findings` | `--export-dir` optional |
| `planning` | `prompt` | none |

## Spec ambiguities resolved

- **`CodingEngine` returns `CodeResultRecorded` (Pydantic), not `str`** — detected by reading source; handled via `model_dump(mode="json")` check before str fallback
- **FK enforcement on `session_id`** — `engine_runs.session_id` references `sessions(id)`; tests that need non-null `session_id` bypass FK via `PRAGMA foreign_keys = OFF` (valid in production where sessions pre-exist engine runs)
- **Migration test expected_tables** — updated to include `engine_runs` and skip tables absent from old_schema_db (newly added tables are created by schema.sql, not via ALTER TABLE)

## Test evidence

```
1156 passed, 1 skipped (pre-existing: .lionagi/config.toml not in checkout), 0 failed
```

New tests:
- `tests/state/test_engine_runs_db.py` — 14 tests: insert/update/get/list round-trips + `_write_lock` discipline (50 concurrent inserts, 25+25 concurrent insert+update)
- `tests/apps_studio_server/test_engine_runs_api.py` — 18 tests: service layer (empty DB), HTTP list/get/filter/auth
- `tests/cli/test_engine_cli.py` — 14 tests: argparse registration, kind validation, on_event callback, result serialization, DB persistence, `--no-persist`, dispatch, `main()` routing

Frontend: ESLint clean, `tsc --noEmit` clean, `next build` clean.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)