### PR TITLE
feat(studio/admin): POST /api/admin/maintenance — vacuum/checkpoint/prune + page wiring

### DIFF
--- a/apps/studio/frontend/app/admin/maintenance/page.tsx
+++ b/apps/studio/frontend/app/admin/maintenance/page.tsx
@@ -4,8 +4,13 @@ import { useEffect, useState } from "react";
 import Button from "@/components/Button";
 import PageHeader from "@/components/PageHeader";
 import Timestamp from "@/components/Timestamp";
-import { getAdminDoctor, pruneAdmin } from "@/lib/api";
-import type { AdminDoctorResponse, PhantomReason } from "@/lib/api";
+import { getAdminDoctor, pruneAdmin, runMaintenance } from "@/lib/api";
+import type {
+  AdminDoctorResponse,
+  MaintenanceAction,
+  MaintenanceResult,
+  PhantomReason,
+} from "@/lib/api";
 import { confirmPhantomPrune, empty, errors } from "@/lib/copy";
 
 function formatBytes(value: number): string {
@@ -49,12 +54,28 @@ function DbHealthStrip({ doctor }: { doctor: AdminDoctorResponse }) {
   );
 }
 
+function formatMaintenanceResult(result: MaintenanceResult): string {
+  if (result.action === "vacuum") {
+    return `Vacuum complete (status: ${result.status ?? "ok"}).`;
+  }
+  if (result.action === "checkpoint") {
+    return `Checkpoint complete (busy: ${result.busy ?? 0}, log_pages: ${result.log_pages ?? 0}, checkpointed: ${result.checkpointed ?? 0}).`;
+  }
+  if (result.action === "prune") {
+    return `Prune complete: ${result.sessions_pruned ?? 0} session(s), ${result.runs_pruned ?? 0} run(s) removed.`;
+  }
+  return "Done.";
+}
+
 export default function AdminMaintenancePage() {
   const [doctor, setDoctor] = useState<AdminDoctorResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [pruning, setPruning] = useState(false);
+  const [maintenanceRunning, setMaintenanceRunning] = useState<MaintenanceAction | null>(null);
+  const [maintenanceResult, setMaintenanceResult] = useState<string | null>(null);
+  const [maintenanceError, setMaintenanceError] = useState<string | null>(null);
 
   async function refresh() {
     try {
@@ -111,6 +132,26 @@ export default function AdminMaintenancePage() {
       setError(errors.pruneAll);
     } finally {
       setPruning(false);
+    }
+  }
+
+  async function handleMaintenance(action: MaintenanceAction) {
+    setMaintenanceRunning(action);
+    setMaintenanceResult(null);
+    setMaintenanceError(null);
+    try {
+      const result = await runMaintenance(action);
+      setMaintenanceResult(formatMaintenanceResult(result));
+    } catch {
+      const key =
+        action === "vacuum"
+          ? errors.maintenanceVacuum
+          : action === "checkpoint"
+            ? errors.maintenanceCheckpoint
+            : errors.maintenancePrune;
+      setMaintenanceError(key);
+    } finally {
+      setMaintenanceRunning(null);
     }
   }
 
@@ -211,6 +252,54 @@ export default function AdminMaintenancePage() {
             </table>
           </div>
         )}
+      </section>
+
+      <section>
+        <div className="mb-2.5 flex items-center justify-between">
+          <h2 className="text-label font-semibold text-content-primary">DB maintenance</h2>
+        </div>
+
+        {maintenanceResult && (
+          <div className="mb-3 rounded border border-status-success/30 bg-status-success-bg px-3 py-2 text-body text-content-primary">
+            {maintenanceResult}
+          </div>
+        )}
+        {maintenanceError && (
+          <div className="mb-3 rounded border border-status-error/30 bg-status-error-bg px-3 py-2 text-body text-content-primary">
+            {maintenanceError}
+          </div>
+        )}
+
+        <div className="flex flex-wrap gap-2">
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={maintenanceRunning !== null}
+            onClick={() => void handleMaintenance("checkpoint")}
+          >
+            {maintenanceRunning === "checkpoint" ? "Running..." : "Checkpoint WAL"}
+          </Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={maintenanceRunning !== null}
+            onClick={() => void handleMaintenance("prune")}
+          >
+            {maintenanceRunning === "prune" ? "Running..." : "Prune old data"}
+          </Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={maintenanceRunning !== null}
+            onClick={() => void handleMaintenance("vacuum")}
+          >
+            {maintenanceRunning === "vacuum" ? "Running..." : "Vacuum DB"}
+          </Button>
+        </div>
+        <p className="mt-2 text-meta text-content-muted">
+          Checkpoint flushes the WAL file. Prune removes terminal sessions older than the configured
+          keep_days. Vacuum reclaims freed pages (run after prune).
+        </p>
       </section>
     </main>
   );

--- a/apps/studio/frontend/app/admin/maintenance/page.tsx
+++ b/apps/studio/frontend/app/admin/maintenance/page.tsx
@@ -56,10 +56,15 @@ function DbHealthStrip({ doctor }: { doctor: AdminDoctorResponse }) {
 
 function formatMaintenanceResult(result: MaintenanceResult): string {
   if (result.action === "vacuum") {
+    if (result.status === "skipped") return "Vacuum skipped: no state database exists yet.";
     return `Vacuum complete (status: ${result.status ?? "ok"}).`;
   }
   if (result.action === "checkpoint") {
-    return `Checkpoint complete (busy: ${result.busy ?? 0}, log_pages: ${result.log_pages ?? 0}, checkpointed: ${result.checkpointed ?? 0}).`;
+    // busy/log_pages/checkpointed are null when the DB does not exist yet.
+    if (result.busy == null && result.log_pages == null && result.checkpointed == null) {
+      return "Checkpoint skipped: no state database exists yet.";
+    }
+    return `Checkpoint complete (busy: ${result.busy}, log_pages: ${result.log_pages}, checkpointed: ${result.checkpointed}).`;
   }
   if (result.action === "prune") {
     return `Prune complete: ${result.sessions_pruned ?? 0} session(s), ${result.runs_pruned ?? 0} run(s) removed.`;
@@ -142,14 +147,17 @@ export default function AdminMaintenancePage() {
     try {
       const result = await runMaintenance(action);
       setMaintenanceResult(formatMaintenanceResult(result));
-    } catch {
-      const key =
+    } catch (err) {
+      // Prefer the backend detail string preserved by fetchJson; fall back to
+      // the generic copy string when no structured message is available.
+      const backendMsg = err instanceof Error ? err.message : undefined;
+      const fallback =
         action === "vacuum"
           ? errors.maintenanceVacuum
           : action === "checkpoint"
             ? errors.maintenanceCheckpoint
             : errors.maintenancePrune;
-      setMaintenanceError(key);
+      setMaintenanceError(backendMsg ?? fallback);
     } finally {
       setMaintenanceRunning(null);
     }

--- a/apps/studio/frontend/app/admin/maintenance/page.tsx
+++ b/apps/studio/frontend/app/admin/maintenance/page.tsx
@@ -148,8 +148,9 @@ export default function AdminMaintenancePage() {
       const result = await runMaintenance(action);
       setMaintenanceResult(formatMaintenanceResult(result));
     } catch (err) {
-      // Prefer the backend detail string preserved by fetchJson; fall back to
-      // the generic copy string when no structured message is available.
+      // fetchJson always throws an Error (backend detail when present, else
+      // "Request failed: <status>"), so the copy-string fallback only fires
+      // for non-Error throws (network-layer failures).
       const backendMsg = err instanceof Error ? err.message : undefined;
       const fallback =
         action === "vacuum"

--- a/apps/studio/frontend/lib/api.ts
+++ b/apps/studio/frontend/lib/api.ts
@@ -789,6 +789,32 @@ export async function pruneAdmin(body: AdminPruneRequest): Promise<{ pruned: num
   });
 }
 
+// ─── Admin maintenance (Phase C Move 3) ──────────────────────────────────────
+
+export type MaintenanceAction = "vacuum" | "checkpoint" | "prune";
+
+export interface MaintenanceResult {
+  action: MaintenanceAction;
+  // vacuum
+  status?: string;
+  // checkpoint
+  mode?: string;
+  busy?: number | null;
+  log_pages?: number | null;
+  checkpointed?: number | null;
+  // prune
+  sessions_pruned?: number;
+  runs_pruned?: number;
+}
+
+export async function runMaintenance(action: MaintenanceAction): Promise<MaintenanceResult> {
+  return fetchJson<MaintenanceResult>("/api/admin/maintenance", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ action }),
+  });
+}
+
 // ─── Projects (ADR-0026) ──────────────────────────────────────────────────────
 
 export interface ProjectListResponse {

--- a/apps/studio/frontend/lib/api.ts
+++ b/apps/studio/frontend/lib/api.ts
@@ -48,7 +48,17 @@ async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
   const url = `${API_BASE}${path}`;
   const response = await fetch(url, { redirect: "follow", ...init });
   if (!response.ok) {
-    throw new Error(`Request failed: ${response.status}`);
+    // Preserve the backend `detail` field (FastAPI/Pydantic validation errors,
+    // our structured 409 body, etc.) so callers can surface it to the operator.
+    // Falls back to the status code when the body is not JSON or has no detail.
+    let detail: string | undefined;
+    try {
+      const body = (await response.json()) as { detail?: string };
+      if (typeof body?.detail === "string") detail = body.detail;
+    } catch {
+      // not JSON — ignore
+    }
+    throw new Error(detail ?? `Request failed: ${response.status}`);
   }
   return response.json() as Promise<T>;
 }

--- a/apps/studio/frontend/lib/copy.ts
+++ b/apps/studio/frontend/lib/copy.ts
@@ -111,4 +111,7 @@ export const errors = {
   // Action failures — operator tried to do something, it failed.
   prune: "Failed to prune sessions.",
   pruneAll: "Failed to prune all phantom sessions.",
+  maintenanceVacuum: "Failed to run vacuum.",
+  maintenanceCheckpoint: "Failed to run checkpoint.",
+  maintenancePrune: "Failed to run prune.",
 } as const;

--- a/lionagi/studio/routers/admin.py
+++ b/lionagi/studio/routers/admin.py
@@ -1,19 +1,17 @@
 from __future__ import annotations
 
 import logging
+import sqlite3
 from typing import Any, Literal
 
 from fastapi import APIRouter, HTTPException, Query
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from lionagi.state.reasons import RunReasons, validate_reason_code
 
 from ..services import admin as admin_svc
 
 router = APIRouter(prefix="/admin", tags=["admin"])
-
-# Closed set of DB maintenance actions exposed through the Studio UI.
-_MAINTENANCE_ACTIONS = frozenset({"vacuum", "checkpoint", "prune"})
 
 _log = logging.getLogger(__name__)
 
@@ -28,11 +26,16 @@ _LEGACY_ADMIN_REASON_CODES: dict[str, str] = {
 class MaintenanceBody(BaseModel):
     """Request body for POST /api/admin/maintenance.
 
-    ``action`` must be one of the allowlisted values; any other token is
-    rejected with 422 before any operation runs.
+    The schema is closed (``extra="forbid"``) so any unknown field causes a
+    422 before the action string is even inspected.  ``action`` is typed as a
+    ``Literal`` — Pydantic rejects out-of-vocabulary values at parse time with
+    a validation error that already carries the allowed values, so the manual
+    frozenset check is no longer needed.
     """
 
-    action: str = Field(
+    model_config = ConfigDict(extra="forbid")
+
+    action: Literal["vacuum", "checkpoint", "prune"] = Field(
         ...,
         description="DB maintenance action: 'vacuum', 'checkpoint', or 'prune'.",
     )
@@ -141,34 +144,44 @@ async def prune_old_data(body: PruneOldDataBody) -> dict[str, int]:
 async def run_maintenance(body: MaintenanceBody) -> dict[str, Any]:
     """Run a DB maintenance action (vacuum | checkpoint | prune).
 
-    The ``action`` field is validated against a strict allowlist before
-    any operation runs; unknown values return 422 immediately.
-    """
-    if body.action not in _MAINTENANCE_ACTIONS:
-        raise HTTPException(
-            status_code=422,
-            detail=(
-                f"Unknown action {body.action!r}. Allowed values: {sorted(_MAINTENANCE_ACTIONS)}"
-            ),
-        )
+    ``action`` is validated as a ``Literal`` by Pydantic at parse time; the
+    schema is closed (``extra="forbid"``), so unknown fields and out-of-
+    vocabulary action values return 422 before this handler runs.
 
+    Returns 409 with a structured detail when the state database is held by
+    another writer and the operation cannot acquire the write lock within
+    SQLite's configured busy_timeout (5 s).  The global busy_timeout in
+    db.py is intentionally left unchanged — this 409 is the maintenance-
+    specific policy so the operator sees an actionable message instead of a
+    generic 500.
+    """
     from ..services.db_maintenance import (
         checkpoint_state_db,
         prune_old_data,
         vacuum_state_db,
     )
 
-    if body.action == "vacuum":
-        result = await vacuum_state_db(actor="admin")
-        return {"action": "vacuum", **result}
+    try:
+        if body.action == "vacuum":
+            result = await vacuum_state_db(actor="admin")
+            return {"action": "vacuum", **result}
 
-    if body.action == "checkpoint":
-        result = await checkpoint_state_db(actor="admin")
-        return {"action": "checkpoint", **result}
+        if body.action == "checkpoint":
+            result = await checkpoint_state_db(actor="admin")
+            return {"action": "checkpoint", **result}
 
-    # action == "prune"
-    result = await prune_old_data(actor="admin")
-    return {"action": "prune", **result}
+        # action == "prune"
+        result = await prune_old_data(actor="admin")
+        return {"action": "prune", **result}
+
+    except sqlite3.OperationalError as exc:
+        msg = str(exc).lower()
+        if "locked" in msg or "in progress" in msg or "unable to open" in msg:
+            raise HTTPException(
+                status_code=409,
+                detail="State database is busy — another writer holds the lock. Try again shortly.",
+            ) from exc
+        raise
 
 
 @router.post("/prune")

--- a/lionagi/studio/routers/admin.py
+++ b/lionagi/studio/routers/admin.py
@@ -12,6 +12,9 @@ from ..services import admin as admin_svc
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
+# Closed set of DB maintenance actions exposed through the Studio UI.
+_MAINTENANCE_ACTIONS = frozenset({"vacuum", "checkpoint", "prune"})
+
 _log = logging.getLogger(__name__)
 
 # Fallback mapping for deprecated 'reason' field without reason_code.
@@ -20,6 +23,19 @@ _LEGACY_ADMIN_REASON_CODES: dict[str, str] = {
     "aborted": RunReasons.ABORTED_USER,
     "cancelled": RunReasons.CANCELLED_SYSTEM,
 }
+
+
+class MaintenanceBody(BaseModel):
+    """Request body for POST /api/admin/maintenance.
+
+    ``action`` must be one of the allowlisted values; any other token is
+    rejected with 422 before any operation runs.
+    """
+
+    action: str = Field(
+        ...,
+        description="DB maintenance action: 'vacuum', 'checkpoint', or 'prune'.",
+    )
 
 
 class PruneBody(BaseModel):
@@ -119,6 +135,40 @@ async def prune_old_data(body: PruneOldDataBody) -> dict[str, int]:
     from ..services.db_maintenance import prune_old_data as _prune
 
     return await _prune(keep_days=body.keep_days, actor="admin")
+
+
+@router.post("/maintenance")
+async def run_maintenance(body: MaintenanceBody) -> dict[str, Any]:
+    """Run a DB maintenance action (vacuum | checkpoint | prune).
+
+    The ``action`` field is validated against a strict allowlist before
+    any operation runs; unknown values return 422 immediately.
+    """
+    if body.action not in _MAINTENANCE_ACTIONS:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Unknown action {body.action!r}. Allowed values: {sorted(_MAINTENANCE_ACTIONS)}"
+            ),
+        )
+
+    from ..services.db_maintenance import (
+        checkpoint_state_db,
+        prune_old_data,
+        vacuum_state_db,
+    )
+
+    if body.action == "vacuum":
+        result = await vacuum_state_db(actor="admin")
+        return {"action": "vacuum", **result}
+
+    if body.action == "checkpoint":
+        result = await checkpoint_state_db(actor="admin")
+        return {"action": "checkpoint", **result}
+
+    # action == "prune"
+    result = await prune_old_data(actor="admin")
+    return {"action": "prune", **result}
 
 
 @router.post("/prune")

--- a/lionagi/studio/routers/admin.py
+++ b/lionagi/studio/routers/admin.py
@@ -175,8 +175,11 @@ async def run_maintenance(body: MaintenanceBody) -> dict[str, Any]:
         return {"action": "prune", **result}
 
     except sqlite3.OperationalError as exc:
+        # Only genuine lock/busy contention is retry-able. Open/path failures
+        # ("unable to open database file") are configuration problems and must
+        # not tell the operator to retry shortly — let them surface as 500.
         msg = str(exc).lower()
-        if "locked" in msg or "in progress" in msg or "unable to open" in msg:
+        if "locked" in msg or "in progress" in msg:
             raise HTTPException(
                 status_code=409,
                 detail="State database is busy — another writer holds the lock. Try again shortly.",

--- a/lionagi/studio/services/db_maintenance.py
+++ b/lionagi/studio/services/db_maintenance.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """DB maintenance helpers for Studio.
 
-Three capabilities:
+Four capabilities:
 - ``checkpoint_state_db()``: runs ``PRAGMA wal_checkpoint(TRUNCATE)`` and
   records an ``admin_events`` row so ``/api/stats`` can surface the timestamp.
 - ``get_last_checkpoint_at()``: fetches the most recent checkpoint event.
@@ -10,6 +10,8 @@ Three capabilities:
 - ``prune_old_data()``: transactionally removes terminal sessions/runs older
   than ``keep_days``, respecting FK constraints (nullifies soft FKs before
   deleting parents), and writes an ``admin_events`` audit row.
+- ``vacuum_state_db()``: runs ``VACUUM`` to reclaim freed pages, writes an
+  ``admin_events`` audit row.
 """
 
 from __future__ import annotations
@@ -334,3 +336,26 @@ async def prune_old_data(
         runs_pruned,
     )
     return {"sessions_pruned": sessions_pruned, "runs_pruned": runs_pruned}
+
+
+async def vacuum_state_db(
+    *,
+    actor: str = "studio_db_maintenance",
+) -> dict[str, str]:
+    """Run ``VACUUM`` to reclaim freed pages and write an audit event.
+
+    VACUUM rebuilds the entire DB file under an exclusive lock.  Call this
+    after ``prune_old_data()`` to reclaim space freed by the deletes.
+    Returns ``{"status": "ok"}`` on success, ``{"status": "skipped"}`` when
+    the DB file does not yet exist.
+    """
+    if not DEFAULT_DB_PATH.exists():
+        return {"status": "skipped"}
+
+    async with StateDB() as db:
+        await db.db.execute("VACUUM")
+        await db.db.commit()
+        await db.insert_admin_event(action="vacuum", details={}, actor=actor)
+
+    _log.info("VACUUM complete")
+    return {"status": "ok"}

--- a/tests/apps_studio_server/test_admin_maintenance_api.py
+++ b/tests/apps_studio_server/test_admin_maintenance_api.py
@@ -256,7 +256,7 @@ def test_maintenance_vacuum_live_existing_db(tmp_path, monkeypatch):
     client, db_path = _make_client(tmp_path, monkeypatch)
 
     # Initialize the schema so the DB file exists before the request.
-    asyncio.get_event_loop().run_until_complete(_async_init_db(db_path))
+    asyncio.run(_async_init_db(db_path))
 
     resp = client.post("/api/admin/maintenance", json={"action": "vacuum"})
     assert resp.status_code == 200, resp.text
@@ -265,9 +265,7 @@ def test_maintenance_vacuum_live_existing_db(tmp_path, monkeypatch):
     assert data["status"] == "ok"
 
     # Verify the audit event was written to the same db_path.
-    events = asyncio.get_event_loop().run_until_complete(
-        _async_list_events(db_path, action="vacuum")
-    )
+    events = asyncio.run(_async_list_events(db_path, action="vacuum"))
     assert any(e["action"] == "vacuum" for e in events), (
         f"Expected vacuum audit event in {db_path}, got: {events}"
     )
@@ -332,7 +330,7 @@ def test_maintenance_lock_contention_returns_409(tmp_path, monkeypatch, action):
     client, db_path = _make_client(tmp_path, monkeypatch)
 
     # Initialize the schema so the DB file exists and is in WAL mode.
-    asyncio.get_event_loop().run_until_complete(_async_init_db(db_path))
+    asyncio.run(_async_init_db(db_path))
 
     # Patch _apply_pragmas to use a short busy_timeout so the test is fast.
     original_apply_pragmas = StateDB._apply_pragmas

--- a/tests/apps_studio_server/test_admin_maintenance_api.py
+++ b/tests/apps_studio_server/test_admin_maintenance_api.py
@@ -4,12 +4,19 @@
 """Tests for POST /api/admin/maintenance (Phase C Move 3).
 
 Coverage:
-  - auth required (401 when LIONAGI_STUDIO_AUTH_TOKEN is set and absent)
-  - allowlist enforcement: unknown / shell-injection / flag-shaped actions → 422
-  - success path for each of vacuum, checkpoint, prune (service layer monkeypatched)
+  - auth: missing token, wrong token, correct token
+  - closed schema: extra fields → 422 with no service call (spy)
+  - allowlist enforcement: unknown/shell-injection/flag-shaped actions → 422
+  - success path for each action (service layer monkeypatched)
+  - live vacuum on an existing initialized DB
+  - DB-absent graceful paths
+  - SQLite lock contention → 409 with structured detail (all three actions)
 """
 
 from __future__ import annotations
+
+import asyncio
+import sqlite3
 
 import pytest
 
@@ -17,13 +24,15 @@ fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 from fastapi.testclient import TestClient  # noqa: E402
 
 # ---------------------------------------------------------------------------
-# Shared fixture: a TestClient wired to a tmp DB path
+# Shared fixture helpers
 # ---------------------------------------------------------------------------
 
 
 def _make_client(tmp_path, monkeypatch):
+    """Return (client, db_path) with all relevant service modules pointed at db_path."""
     import lionagi.state.db as state_db_mod
     import lionagi.studio.services.admin as admin_mod
+    import lionagi.studio.services.db_maintenance as maint_mod
     import lionagi.studio.services.sessions as sessions_mod
 
     db_path = tmp_path / "state.db"
@@ -32,6 +41,7 @@ def _make_client(tmp_path, monkeypatch):
     monkeypatch.setattr(admin_mod, "_DB", str(db_path))
     monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
+    monkeypatch.setattr(maint_mod, "DEFAULT_DB_PATH", db_path)
 
     from lionagi.studio.app import app
 
@@ -43,12 +53,25 @@ def _make_client(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_maintenance_requires_auth_when_token_set(tmp_path, monkeypatch):
-    """401 when LIONAGI_STUDIO_AUTH_TOKEN is set and the request omits it."""
+def test_maintenance_requires_auth_when_token_missing(tmp_path, monkeypatch):
+    """401 when LIONAGI_STUDIO_AUTH_TOKEN is set and the request omits Authorization."""
     monkeypatch.setenv("LIONAGI_STUDIO_AUTH_TOKEN", "s3cret-maint")
     client, _ = _make_client(tmp_path, monkeypatch)
 
     resp = client.post("/api/admin/maintenance", json={"action": "checkpoint"})
+    assert resp.status_code == 401
+
+
+def test_maintenance_requires_auth_when_token_wrong(tmp_path, monkeypatch):
+    """401 when LIONAGI_STUDIO_AUTH_TOKEN is set and the request supplies a wrong token."""
+    monkeypatch.setenv("LIONAGI_STUDIO_AUTH_TOKEN", "s3cret-maint")
+    client, _ = _make_client(tmp_path, monkeypatch)
+
+    resp = client.post(
+        "/api/admin/maintenance",
+        json={"action": "checkpoint"},
+        headers={"Authorization": "Bearer wrong-token"},
+    )
     assert resp.status_code == 401
 
 
@@ -57,8 +80,6 @@ def test_maintenance_passes_with_correct_token(tmp_path, monkeypatch):
     monkeypatch.setenv("LIONAGI_STUDIO_AUTH_TOKEN", "s3cret-maint")
 
     import lionagi.studio.services.db_maintenance as maint
-
-    monkeypatch.setattr(maint, "DEFAULT_DB_PATH", tmp_path / "state.db")
 
     async def _fake_checkpoint(**_):
         return {"mode": "TRUNCATE", "busy": 0, "log_pages": 0, "checkpointed": 0}
@@ -72,6 +93,51 @@ def test_maintenance_passes_with_correct_token(tmp_path, monkeypatch):
         headers={"Authorization": "Bearer s3cret-maint"},
     )
     assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Closed schema: extra fields must be rejected and must not reach service
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"action": "vacuum", "extra": "field"},
+        {"action": "checkpoint", "keep_days": 0},
+        {"action": "prune", "dry_run": True},
+        {"action": "vacuum", "actor": "hacker"},
+    ],
+)
+def test_maintenance_rejects_extra_fields_without_calling_service(tmp_path, monkeypatch, payload):
+    """Extra fields must return 422 and must NOT invoke any maintenance function."""
+    import lionagi.studio.services.db_maintenance as maint
+
+    calls = []
+
+    async def _spy_vacuum(**_):
+        calls.append("vacuum")
+        return {"status": "ok"}
+
+    async def _spy_checkpoint(**_):
+        calls.append("checkpoint")
+        return {"mode": "TRUNCATE", "busy": 0, "log_pages": 0, "checkpointed": 0}
+
+    async def _spy_prune(**_):
+        calls.append("prune")
+        return {"sessions_pruned": 0, "runs_pruned": 0}
+
+    monkeypatch.setattr(maint, "vacuum_state_db", _spy_vacuum)
+    monkeypatch.setattr(maint, "checkpoint_state_db", _spy_checkpoint)
+    monkeypatch.setattr(maint, "prune_old_data", _spy_prune)
+
+    client, _ = _make_client(tmp_path, monkeypatch)
+    resp = client.post("/api/admin/maintenance", json=payload)
+
+    assert resp.status_code == 422, (
+        f"Expected 422 for payload={payload!r}, got {resp.status_code}: {resp.text}"
+    )
+    assert calls == [], f"Service functions were called despite 422: {calls}"
 
 
 # ---------------------------------------------------------------------------
@@ -98,7 +164,7 @@ def test_maintenance_passes_with_correct_token(tmp_path, monkeypatch):
     ],
 )
 def test_maintenance_rejects_disallowed_action(tmp_path, monkeypatch, bad_action):
-    """Any action outside the closed allowlist must return 422."""
+    """Any action outside the Literal vocabulary must return 422."""
     client, _ = _make_client(tmp_path, monkeypatch)
 
     resp = client.post("/api/admin/maintenance", json={"action": bad_action})
@@ -123,8 +189,6 @@ def test_maintenance_vacuum_success(tmp_path, monkeypatch):
     """action='vacuum' calls vacuum_state_db and returns action + status."""
     import lionagi.studio.services.db_maintenance as maint
 
-    monkeypatch.setattr(maint, "DEFAULT_DB_PATH", tmp_path / "state.db")
-
     called = []
 
     async def _fake_vacuum(**_):
@@ -146,8 +210,6 @@ def test_maintenance_checkpoint_success(tmp_path, monkeypatch):
     """action='checkpoint' calls checkpoint_state_db and returns action + PRAGMA counts."""
     import lionagi.studio.services.db_maintenance as maint
 
-    monkeypatch.setattr(maint, "DEFAULT_DB_PATH", tmp_path / "state.db")
-
     async def _fake_checkpoint(**_):
         return {"mode": "TRUNCATE", "busy": 0, "log_pages": 5, "checkpointed": 5}
 
@@ -167,8 +229,6 @@ def test_maintenance_prune_success(tmp_path, monkeypatch):
     """action='prune' calls prune_old_data and returns action + pruned counts."""
     import lionagi.studio.services.db_maintenance as maint
 
-    monkeypatch.setattr(maint, "DEFAULT_DB_PATH", tmp_path / "state.db")
-
     async def _fake_prune(**_):
         return {"sessions_pruned": 3, "runs_pruned": 1}
 
@@ -184,21 +244,58 @@ def test_maintenance_prune_success(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Live path (no mock) — DB absent should still return without crashing
+# Live path — existing initialized DB
+# ---------------------------------------------------------------------------
+
+
+def test_maintenance_vacuum_live_existing_db(tmp_path, monkeypatch):
+    """vacuum on an existing initialized DB returns status='ok' and writes an audit event."""
+    from lionagi.state.db import StateDB
+
+    # _make_client patches everything to tmp_path/"state.db"
+    client, db_path = _make_client(tmp_path, monkeypatch)
+
+    # Initialize the schema so the DB file exists before the request.
+    asyncio.get_event_loop().run_until_complete(_async_init_db(db_path))
+
+    resp = client.post("/api/admin/maintenance", json={"action": "vacuum"})
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["action"] == "vacuum"
+    assert data["status"] == "ok"
+
+    # Verify the audit event was written to the same db_path.
+    events = asyncio.get_event_loop().run_until_complete(
+        _async_list_events(db_path, action="vacuum")
+    )
+    assert any(e["action"] == "vacuum" for e in events), (
+        f"Expected vacuum audit event in {db_path}, got: {events}"
+    )
+
+
+async def _async_init_db(db_path):
+    from lionagi.state.db import StateDB
+
+    async with StateDB(db_path):
+        pass
+
+
+async def _async_list_events(db_path, *, action):
+    from lionagi.state.db import StateDB
+
+    async with StateDB(db_path) as db:
+        return await db.list_admin_events(action=action, limit=5)
+
+
+# ---------------------------------------------------------------------------
+# Live path — DB absent should return graceful responses
 # ---------------------------------------------------------------------------
 
 
 def test_maintenance_vacuum_db_absent(tmp_path, monkeypatch):
     """vacuum with no DB yet returns skipped, not 500."""
-    import lionagi.studio.services.db_maintenance as maint
-
-    nonexistent = tmp_path / "noexist.db"
-    monkeypatch.setattr(maint, "DEFAULT_DB_PATH", nonexistent)
-
-    import lionagi.state.db as state_db_mod
-
-    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", nonexistent)
     client, _ = _make_client(tmp_path, monkeypatch)
+    # db_path is tmp_path/"state.db" but it doesn't exist yet.
 
     resp = client.post("/api/admin/maintenance", json={"action": "vacuum"})
     assert resp.status_code == 200, resp.text
@@ -207,14 +304,6 @@ def test_maintenance_vacuum_db_absent(tmp_path, monkeypatch):
 
 def test_maintenance_checkpoint_db_absent(tmp_path, monkeypatch):
     """checkpoint with no DB yet returns None counts, not 500."""
-    import lionagi.studio.services.db_maintenance as maint
-
-    nonexistent = tmp_path / "noexist.db"
-    monkeypatch.setattr(maint, "DEFAULT_DB_PATH", nonexistent)
-
-    import lionagi.state.db as state_db_mod
-
-    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", nonexistent)
     client, _ = _make_client(tmp_path, monkeypatch)
 
     resp = client.post("/api/admin/maintenance", json={"action": "checkpoint"})
@@ -222,3 +311,53 @@ def test_maintenance_checkpoint_db_absent(tmp_path, monkeypatch):
     data = resp.json()
     assert data["action"] == "checkpoint"
     assert data["busy"] is None
+
+
+# ---------------------------------------------------------------------------
+# Lock-contention → 409 with structured detail
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("action", ["vacuum", "checkpoint", "prune"])
+def test_maintenance_lock_contention_returns_409(tmp_path, monkeypatch, action):
+    """When another writer holds the DB lock all three actions must return 409.
+
+    We initialize the DB, hold a raw BEGIN IMMEDIATE on a second connection,
+    then patch StateDB._apply_pragmas to set busy_timeout=100 ms so the test
+    finishes quickly instead of waiting the production 5 s.
+    """
+    from lionagi.state.db import StateDB
+
+    # _make_client patches everything to tmp_path/"state.db".
+    client, db_path = _make_client(tmp_path, monkeypatch)
+
+    # Initialize the schema so the DB file exists and is in WAL mode.
+    asyncio.get_event_loop().run_until_complete(_async_init_db(db_path))
+
+    # Patch _apply_pragmas to use a short busy_timeout so the test is fast.
+    original_apply_pragmas = StateDB._apply_pragmas
+
+    async def _fast_pragmas(self):
+        await original_apply_pragmas(self)
+        await self.db.execute("PRAGMA busy_timeout = 100")
+
+    monkeypatch.setattr(StateDB, "_apply_pragmas", _fast_pragmas)
+
+    # Hold an exclusive write lock with a raw sqlite3 connection.
+    lock_conn = sqlite3.connect(str(db_path), timeout=0)
+    try:
+        lock_conn.execute("BEGIN IMMEDIATE")
+
+        resp = client.post("/api/admin/maintenance", json={"action": action})
+    finally:
+        lock_conn.close()
+
+    assert resp.status_code == 409, (
+        f"Expected 409 for locked DB ({action}), got {resp.status_code}: {resp.text}"
+    )
+    body = resp.json()
+    assert "detail" in body, f"Expected 'detail' in 409 body, got: {body}"
+    detail_lower = body["detail"].lower()
+    assert "busy" in detail_lower or "lock" in detail_lower, (
+        f"Expected 'busy' or 'lock' in detail, got: {body['detail']!r}"
+    )

--- a/tests/apps_studio_server/test_admin_maintenance_api.py
+++ b/tests/apps_studio_server/test_admin_maintenance_api.py
@@ -1,0 +1,224 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for POST /api/admin/maintenance (Phase C Move 3).
+
+Coverage:
+  - auth required (401 when LIONAGI_STUDIO_AUTH_TOKEN is set and absent)
+  - allowlist enforcement: unknown / shell-injection / flag-shaped actions → 422
+  - success path for each of vacuum, checkpoint, prune (service layer monkeypatched)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
+from fastapi.testclient import TestClient  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Shared fixture: a TestClient wired to a tmp DB path
+# ---------------------------------------------------------------------------
+
+
+def _make_client(tmp_path, monkeypatch):
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.admin as admin_mod
+    import lionagi.studio.services.sessions as sessions_mod
+
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(admin_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(admin_mod, "_DB", str(db_path))
+    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
+
+    from lionagi.studio.app import app
+
+    return TestClient(app, raise_server_exceptions=False), db_path
+
+
+# ---------------------------------------------------------------------------
+# Auth tests
+# ---------------------------------------------------------------------------
+
+
+def test_maintenance_requires_auth_when_token_set(tmp_path, monkeypatch):
+    """401 when LIONAGI_STUDIO_AUTH_TOKEN is set and the request omits it."""
+    monkeypatch.setenv("LIONAGI_STUDIO_AUTH_TOKEN", "s3cret-maint")
+    client, _ = _make_client(tmp_path, monkeypatch)
+
+    resp = client.post("/api/admin/maintenance", json={"action": "checkpoint"})
+    assert resp.status_code == 401
+
+
+def test_maintenance_passes_with_correct_token(tmp_path, monkeypatch):
+    """Request succeeds (not 401) when the correct bearer token is supplied."""
+    monkeypatch.setenv("LIONAGI_STUDIO_AUTH_TOKEN", "s3cret-maint")
+
+    import lionagi.studio.services.db_maintenance as maint
+
+    monkeypatch.setattr(maint, "DEFAULT_DB_PATH", tmp_path / "state.db")
+
+    async def _fake_checkpoint(**_):
+        return {"mode": "TRUNCATE", "busy": 0, "log_pages": 0, "checkpointed": 0}
+
+    monkeypatch.setattr(maint, "checkpoint_state_db", _fake_checkpoint)
+    client, _ = _make_client(tmp_path, monkeypatch)
+
+    resp = client.post(
+        "/api/admin/maintenance",
+        json={"action": "checkpoint"},
+        headers={"Authorization": "Bearer s3cret-maint"},
+    )
+    assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Allowlist / injection rejection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_action",
+    [
+        # Shell injection attempt
+        "vacuum; rm -rf /",
+        # Flag-shaped string
+        "--help",
+        # Entirely unknown
+        "reindex",
+        # Empty string
+        "",
+        # SQL injection
+        "vacuum' OR '1'='1",
+        # Looks similar but not in the set
+        "Vacuum",
+        "VACUUM",
+    ],
+)
+def test_maintenance_rejects_disallowed_action(tmp_path, monkeypatch, bad_action):
+    """Any action outside the closed allowlist must return 422."""
+    client, _ = _make_client(tmp_path, monkeypatch)
+
+    resp = client.post("/api/admin/maintenance", json={"action": bad_action})
+    assert resp.status_code == 422, (
+        f"Expected 422 for action={bad_action!r}, got {resp.status_code}"
+    )
+
+
+def test_maintenance_missing_action_field_returns_422(tmp_path, monkeypatch):
+    """Omitting the required 'action' field returns 422 (Pydantic validation)."""
+    client, _ = _make_client(tmp_path, monkeypatch)
+    resp = client.post("/api/admin/maintenance", json={})
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Success paths (service layer monkeypatched)
+# ---------------------------------------------------------------------------
+
+
+def test_maintenance_vacuum_success(tmp_path, monkeypatch):
+    """action='vacuum' calls vacuum_state_db and returns action + status."""
+    import lionagi.studio.services.db_maintenance as maint
+
+    monkeypatch.setattr(maint, "DEFAULT_DB_PATH", tmp_path / "state.db")
+
+    called = []
+
+    async def _fake_vacuum(**_):
+        called.append(True)
+        return {"status": "ok"}
+
+    monkeypatch.setattr(maint, "vacuum_state_db", _fake_vacuum)
+    client, _ = _make_client(tmp_path, monkeypatch)
+
+    resp = client.post("/api/admin/maintenance", json={"action": "vacuum"})
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["action"] == "vacuum"
+    assert data["status"] == "ok"
+    assert called
+
+
+def test_maintenance_checkpoint_success(tmp_path, monkeypatch):
+    """action='checkpoint' calls checkpoint_state_db and returns action + PRAGMA counts."""
+    import lionagi.studio.services.db_maintenance as maint
+
+    monkeypatch.setattr(maint, "DEFAULT_DB_PATH", tmp_path / "state.db")
+
+    async def _fake_checkpoint(**_):
+        return {"mode": "TRUNCATE", "busy": 0, "log_pages": 5, "checkpointed": 5}
+
+    monkeypatch.setattr(maint, "checkpoint_state_db", _fake_checkpoint)
+    client, _ = _make_client(tmp_path, monkeypatch)
+
+    resp = client.post("/api/admin/maintenance", json={"action": "checkpoint"})
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["action"] == "checkpoint"
+    assert data["mode"] == "TRUNCATE"
+    assert "log_pages" in data
+    assert "checkpointed" in data
+
+
+def test_maintenance_prune_success(tmp_path, monkeypatch):
+    """action='prune' calls prune_old_data and returns action + pruned counts."""
+    import lionagi.studio.services.db_maintenance as maint
+
+    monkeypatch.setattr(maint, "DEFAULT_DB_PATH", tmp_path / "state.db")
+
+    async def _fake_prune(**_):
+        return {"sessions_pruned": 3, "runs_pruned": 1}
+
+    monkeypatch.setattr(maint, "prune_old_data", _fake_prune)
+    client, _ = _make_client(tmp_path, monkeypatch)
+
+    resp = client.post("/api/admin/maintenance", json={"action": "prune"})
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["action"] == "prune"
+    assert data["sessions_pruned"] == 3
+    assert data["runs_pruned"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Live path (no mock) — DB absent should still return without crashing
+# ---------------------------------------------------------------------------
+
+
+def test_maintenance_vacuum_db_absent(tmp_path, monkeypatch):
+    """vacuum with no DB yet returns skipped, not 500."""
+    import lionagi.studio.services.db_maintenance as maint
+
+    nonexistent = tmp_path / "noexist.db"
+    monkeypatch.setattr(maint, "DEFAULT_DB_PATH", nonexistent)
+
+    import lionagi.state.db as state_db_mod
+
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", nonexistent)
+    client, _ = _make_client(tmp_path, monkeypatch)
+
+    resp = client.post("/api/admin/maintenance", json={"action": "vacuum"})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "skipped"
+
+
+def test_maintenance_checkpoint_db_absent(tmp_path, monkeypatch):
+    """checkpoint with no DB yet returns None counts, not 500."""
+    import lionagi.studio.services.db_maintenance as maint
+
+    nonexistent = tmp_path / "noexist.db"
+    monkeypatch.setattr(maint, "DEFAULT_DB_PATH", nonexistent)
+
+    import lionagi.state.db as state_db_mod
+
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", nonexistent)
+    client, _ = _make_client(tmp_path, monkeypatch)
+
+    resp = client.post("/api/admin/maintenance", json={"action": "checkpoint"})
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["action"] == "checkpoint"
+    assert data["busy"] is None


### PR DESCRIPTION
## Summary

Phase C Move 3c: closes the "page exists, backend missing" gap on /admin/maintenance.

- `POST /api/admin/maintenance` with strict action allowlist (`vacuum` | `checkpoint` | `prune`); anything else → 422.
- Python-native ops (added `vacuum_state_db()` as the missing peer to existing `checkpoint_state_db()` / `prune_old_data()` in `services/db_maintenance.py`) — same approach as the existing `/api/admin/prune-old-data` route; no subprocess.
- Frontend: "DB maintenance" section on /admin/maintenance with three buttons + result/error states (`runMaintenance()` in lib/api.ts).
- Auth: middleware-level bearer token like all other admin routes (401 covered by test).

## Tests

- `tests/apps_studio_server/test_admin_maintenance_api.py` — 15 tests (auth, allowlist rejection incl. injection-shaped actions, success paths, error paths). 0 skips.
- Full `tests/apps_studio_server/`: 339 passed.
- Frontend: tsc --noEmit clean, eslint clean, prettier clean.

Part of the Phase C control-center plan (Move 3c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)