### PR TITLE
fix(providers/engines): surface CLI worker failures — typed provider errors + emission diagnostics (closes #1397)

### DIFF
--- a/lionagi/cli/engine.py
+++ b/lionagi/cli/engine.py
@@ -308,6 +308,13 @@ async def _do_engine_run(args: argparse.Namespace) -> int:
     ended_at = time.time()
     progress(f"engine[{kind}] completed  elapsed={ended_at - started_at:.1f}s")
 
+    # Collect emission-missing diagnostics from the engine run object so they
+    # can be written to engine_runs.error even when status stays "completed".
+    emission_error: str | None = None
+    _emission_failures: list[str] = getattr(engine, "_emission_failures", [])
+    if _emission_failures:
+        emission_error = "emission_missing: " + "; ".join(_emission_failures)
+
     # Serialise result to stdout as JSON.
     # export_dir: the CLI knows what directory it passed; neither CodeResultRecorded
     # (lionagi/engines/coding.py:153 — fields: passed, measurements, caveats,
@@ -337,6 +344,7 @@ async def _do_engine_run(args: argparse.Namespace) -> int:
         "completed",
         ended_at=ended_at,
         export_dir=export_dir_for_db,
+        error=emission_error,
     )
     if db is not None:
         await db.close()

--- a/lionagi/engines/engine.py
+++ b/lionagi/engines/engine.py
@@ -200,6 +200,10 @@ class EngineRun:
         # so in-flight sequential work (operate_with_repair, branch.operate) is
         # interrupted promptly rather than continuing past the deadline.
         self._run_task: asyncio.Task | None = None
+        # Collects emission-missing diagnostics so the CLI can write them to
+        # the engine_runs.error column even when the overall status is "completed".
+        # Each entry is a string like "<agent> x<attempts>".
+        self._emission_failures: list[str] = []
 
     @property
     def events(self) -> Pile:
@@ -341,10 +345,15 @@ class EngineRun:
                 repair_msg = _repair_instruction(hint)
             res = await branch.operate(instruction=repair_msg)
         if retries and not arrived():
+            _agent_name = getattr(branch, "name", "") or ""
+            _attempts = attempt + 1
             self.notify(
                 "emission_missing",
-                agent=getattr(branch, "name", "") or "",
-                attempts=attempt + 1,
+                agent=_agent_name,
+                attempts=_attempts,
+            )
+            self._emission_failures.append(
+                f"{_agent_name} x{_attempts}" if _agent_name else f"x{_attempts}"
             )
         return res
 

--- a/lionagi/engines/engine.py
+++ b/lionagi/engines/engine.py
@@ -700,6 +700,9 @@ class Engine:
         ``CancelledError`` — asyncio structured-concurrency rules are upheld.
         """
         run = self.new_run(session=session, on_event=on_event)
+        # Reset per-run diagnostics on the engine instance so a reused engine
+        # never carries emission failures from a previous run into the next one.
+        self._emission_failures: list[str] = []
         watchdog: asyncio.Task | None = None
         if run._deadline is not None:
             watchdog = asyncio.ensure_future(run._deadline_watchdog())
@@ -766,6 +769,11 @@ class Engine:
                 # External cancellation — surface it after cleanup (below).
                 raise
         finally:
+            # Copy per-run emission diagnostics back onto the engine instance so
+            # the CLI read site (getattr(engine, "_emission_failures", [])) sees
+            # the real list regardless of which return/exception path was taken.
+            # Uses a fresh list copy so no shared-reference aliasing between runs.
+            self._emission_failures = list(run._emission_failures)
             if watchdog is not None and not watchdog.done():
                 watchdog.cancel()
                 with contextlib.suppress(asyncio.CancelledError):

--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -331,6 +331,24 @@ async def run(
                 # as RunEnd (clean abandonment).  The outer finally will emit the
                 # terminal signal; re-raise here so the outer try sees it too.
                 raise
+            except RuntimeError as _exc:
+                # Provider subprocess failures (e.g. ndjson_from_cli raises
+                # RuntimeError(stderr) on nonzero exit) propagate here as plain
+                # RuntimeError.  Classify them so callers can distinguish quota,
+                # auth, and context-length failures from generic errors.
+                #
+                # Guard: ProviderError is already a RuntimeError subclass, so
+                # `except RuntimeError` catches it too.  Avoid double-wrapping
+                # by checking isinstance first; if already classified, propagate
+                # unchanged so the richer type is preserved for the caller.
+                from lionagi.providers._provider_errors import ProviderError
+
+                if isinstance(_exc, ProviderError):
+                    _run_exc = _exc
+                    raise
+                classified = classify_provider_error(str(_exc))
+                _run_exc = classified
+                raise classified from _exc
             except BaseException as _exc:
                 _run_exc = _exc
                 raise

--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -19,6 +19,7 @@ from lionagi.protocols.messages import (
     AssistantResponseContent,
     Instruction,
 )
+from lionagi.providers._provider_errors import classify_provider_error
 
 from ..chat._prepare import _prepare_run_kwargs
 from ..types import ChatParam, ParseParam, RunParam
@@ -314,7 +315,7 @@ async def run(
                                 )
                                 break
                             content = chunk.content or "(empty error)"
-                            raise RuntimeError(content)
+                            raise classify_provider_error(content)
 
                 if res := await _flush_response():
                     if hasattr(api_call, "to_dict"):

--- a/lionagi/providers/_provider_errors.py
+++ b/lionagi/providers/_provider_errors.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed provider error hierarchy for CLI worker failures.
+
+All subclasses remain ``RuntimeError``-compatible so existing
+``except RuntimeError`` handlers in callers continue to work without
+modification.  The ``classify_provider_error`` factory returns the most
+specific subclass that matches the error text.
+"""
+
+from __future__ import annotations
+
+import re
+
+# ---------------------------------------------------------------------------
+# Base hierarchy
+# ---------------------------------------------------------------------------
+
+
+class ProviderError(RuntimeError):
+    """A generic error surfaced by a CLI provider subprocess.
+
+    Attributes:
+        stderr_tail: The last N bytes of the subprocess stderr, if available.
+        raw: The raw error string passed to this exception.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        stderr_tail: str = "",
+        raw: str = "",
+    ) -> None:
+        super().__init__(message)
+        self.stderr_tail: str = stderr_tail
+        self.raw: str = raw or message
+
+
+class ProviderQuotaError(ProviderError):
+    """The provider CLI rejected the request due to usage/rate limits."""
+
+
+class ProviderAuthError(ProviderError):
+    """The provider CLI rejected the request due to invalid credentials."""
+
+
+class ProviderContextError(ProviderError):
+    """The provider CLI rejected the request because the context is too long."""
+
+
+# ---------------------------------------------------------------------------
+# Emission error (separate axis — not a provider subprocess failure)
+# ---------------------------------------------------------------------------
+
+
+class EmissionError(RuntimeError):
+    """An agent in a multi-agent pipeline failed to emit expected structured output.
+
+    Attributes:
+        agent: Name or id of the agent whose emission was missing.
+        attempts: Total number of operate calls made (initial + repairs).
+        stage: Optional label identifying which pipeline stage the agent belonged to.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        agent: str = "",
+        attempts: int = 0,
+        stage: str = "",
+    ) -> None:
+        super().__init__(message)
+        self.agent: str = agent
+        self.attempts: int = attempts
+        self.stage: str = stage
+
+
+# ---------------------------------------------------------------------------
+# Regex catalogue (case-insensitive patterns → subclass)
+# ---------------------------------------------------------------------------
+
+# Each entry: (compiled_pattern, subclass)
+_QUOTA_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"usage\s+limit\s+reached", re.IGNORECASE),
+    re.compile(r"rate[\s._-]?limit[\s._-]?exceeded", re.IGNORECASE),
+    re.compile(r"try\s+again\s+at\s+\d", re.IGNORECASE),
+]
+
+_AUTH_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"invalid[\s._-]?api[\s._-]?key", re.IGNORECASE),
+    re.compile(r"not\s+logged\s+in", re.IGNORECASE),
+    re.compile(r"401.*unauthorized", re.IGNORECASE),
+]
+
+_CONTEXT_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"context[\s._-]?(window|length)[\s._-]?(exceeded|too\s+long)", re.IGNORECASE),
+]
+
+
+def classify_provider_error(
+    content: str,
+    *,
+    stderr_tail: str = "",
+) -> ProviderError:
+    """Return the most-specific ``ProviderError`` subclass for *content*.
+
+    The full *content* string and any available *stderr_tail* are searched
+    against the quota, auth, and context-length pattern families in that
+    priority order.  An unmatched error becomes the base ``ProviderError``.
+
+    Args:
+        content: The primary error message string (e.g. the chunk content from
+            a CLI provider's ``turn.failed`` or ``error`` event, or the stderr
+            tail raised by ``ndjson_from_cli``).
+        stderr_tail: Additional stderr text to search alongside *content*.
+
+    Returns:
+        A ``ProviderError`` (or subclass) instance.  All returned instances
+        are also ``RuntimeError`` instances so existing ``except RuntimeError``
+        handlers remain unaffected.
+    """
+    combined = f"{content}\n{stderr_tail}" if stderr_tail else content
+
+    for pat in _QUOTA_PATTERNS:
+        if pat.search(combined):
+            return ProviderQuotaError(content, stderr_tail=stderr_tail, raw=content)
+
+    for pat in _AUTH_PATTERNS:
+        if pat.search(combined):
+            return ProviderAuthError(content, stderr_tail=stderr_tail, raw=content)
+
+    for pat in _CONTEXT_PATTERNS:
+        if pat.search(combined):
+            return ProviderContextError(content, stderr_tail=stderr_tail, raw=content)
+
+    return ProviderError(content, stderr_tail=stderr_tail, raw=content)

--- a/lionagi/providers/openai/codex/models.py
+++ b/lionagi/providers/openai/codex/models.py
@@ -718,7 +718,15 @@ async def stream_codex_cli(
                 # otherwise a top-level-message error renders as the useless
                 # str() of an empty dict and the actionable text is discarded.
                 session.result = (
-                    (err.get("message") or obj.get("message") or str(err))
+                    (
+                        err.get("message")
+                        or obj.get("message")
+                        or (
+                            f"CLI failure (empty error payload; event type={typ!r})"
+                            if err == {}
+                            else str(err)
+                        )
+                    )
                     if isinstance(err, dict)
                     else obj.get("message", str(err))
                 )

--- a/lionagi/providers/openai/codex/models.py
+++ b/lionagi/providers/openai/codex/models.py
@@ -717,6 +717,11 @@ async def stream_codex_cli(
                 # "turn.failed" nests it under error.message.  Check both —
                 # otherwise a top-level-message error renders as the useless
                 # str() of an empty dict and the actionable text is discarded.
+                # Normalise null/missing error payloads: JSON "error": null
+                # arrives as None here (obj.get returns the default only when the
+                # key is absent, not when it is explicitly null).
+                if err is None:
+                    err = {}
                 session.result = (
                     (
                         err.get("message")

--- a/lionagi/providers/openai/codex/models.py
+++ b/lionagi/providers/openai/codex/models.py
@@ -720,6 +720,11 @@ async def stream_codex_cli(
                 # Normalise null/missing error payloads: JSON "error": null
                 # arrives as None here (obj.get returns the default only when the
                 # key is absent, not when it is explicitly null).
+                # IMPORTANT: capture the raw value BEFORE normalising.  The
+                # benign-EOS predicate below must see the original value; a null
+                # payload normalised to {} would otherwise match the empty-dict
+                # sentinel and silently swallow a real (malformed) provider error.
+                _raw_err = err
                 if err is None:
                     err = {}
                 session.result = (
@@ -745,16 +750,20 @@ async def stream_codex_cli(
                 #   1. Event type is "error" — "turn.failed" events are NEVER benign
                 #      regardless of their error payload, because they signal an
                 #      explicit model-side failure (e.g. rate_limit, context_overflow).
-                #   2. The error payload is EXACTLY the empty dict.  A structured
-                #      payload with falsy values ({"message": ""}, {"message": None})
-                #      is a real failure whose detail happens to be empty — only the
-                #      bare {} sentinel is produced by a resumed-session EOF.
+                #   2. The error payload is EXACTLY the empty dict in the RAW event.
+                #      A structured payload with falsy values ({"message": ""},
+                #      {"message": None}) is a real failure whose detail happens to be
+                #      empty — only the bare {} sentinel is produced by a resumed-session
+                #      EOF.  Crucially, ``"error": null`` (raw value = None) is NOT the
+                #      sentinel: it indicates a malformed/unexpected provider envelope
+                #      and must surface as a real error.  We test _raw_err (the value
+                #      before null-normalisation) to preserve this distinction.
                 #   3. The top-level event carries no failure indicators beyond the
                 #      known EOF envelope (no "code", "message", or "status" keys).
                 _is_benign_eos = (
                     typ == "error"
                     and "error" in obj  # a bare {"type": "error"} is malformed, not EOF
-                    and err == {}
+                    and _raw_err == {}  # null normalised to {} must NOT qualify
                     and not any(k in obj for k in ("code", "message", "status"))
                 )
                 chunk_meta = dict(obj)

--- a/tests/cli/test_engine_emission_diagnostics.py
+++ b/tests/cli/test_engine_emission_diagnostics.py
@@ -317,3 +317,211 @@ async def test_completed_run_with_error_column_in_real_db(tmp_path):
     assert row["error"] == "emission_missing: planner x2; summariser x1", (
         f"error column must persist alongside 'completed' status; got: {row['error']!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# INTEGRATION: real Engine subclass whose _run() calls operate_with_repair
+# with a branch that never emits — verifies the full Engine.run() → CLI
+# read-site handoff that the mock-based tests above could not catch.
+# ---------------------------------------------------------------------------
+
+
+class _NeverEmitBranch:
+    """Minimal Branch-like object whose operate() always returns None and
+    whose chat_model.is_cli is False (API worker path)."""
+
+    name = "planner"
+
+    class _ChatModel:
+        is_cli = False
+
+    chat_model = _ChatModel()
+
+    async def operate(self, instruction=None, **kw):
+        return None
+
+
+class _ZeroEmissionEngine:
+    """Minimal Engine-compatible subclass: _run() calls operate_with_repair
+    once with a branch that never emits, then returns a plain string result.
+    Inherits from Engine so Engine.run() orchestrates the lifecycle."""
+
+    from lionagi.engines.engine import Engine as _EngineBase  # imported at class body level
+
+    # We construct it as a proper subclass below to avoid a forward-reference
+    # issue in the class body itself.
+
+
+async def _build_zero_emission_engine():
+    """Construct a real Engine subclass that always fires emission_missing."""
+    from lionagi.engines.engine import Engine, EngineRun
+
+    class ZeroEmissionEngine(Engine):
+        async def _run(self, run: EngineRun, spec: str, **kwargs) -> str:  # type: ignore[override]
+            branch = _NeverEmitBranch()
+            # arrived() always returns False → retries exhausted → emission_missing fired
+            await run.operate_with_repair(
+                branch,  # type: ignore[arg-type]
+                "please emit",
+                arrived=lambda: False,
+                emits=(),
+                retries=1,
+            )
+            return "partial result despite missing emission"
+
+    return ZeroEmissionEngine(max_agents=5)
+
+
+async def test_real_engine_emission_failure_propagates_to_cli(monkeypatch):
+    """Integration: real Engine subclass with a branch that never emits →
+    _do_engine_run writes error='emission_missing: ...' with status='completed'.
+
+    This is the test codex identified as missing: the mock-based test above
+    only tested the CLI read path (manually set attr), not the real
+    Engine.run() → engine._emission_failures handoff."""
+    import lionagi.cli._logging as log_mod
+    import lionagi.cli.engine as engine_mod
+    import lionagi.state.db as db_mod
+
+    monkeypatch.setattr(log_mod, "progress", lambda *a, **kw: None)
+    monkeypatch.setattr(log_mod, "warn", lambda *a, **kw: None)
+
+    real_engine = await _build_zero_emission_engine()
+    MockEngineClass = MagicMock(return_value=real_engine)
+    monkeypatch.setattr(engine_mod, "_import_engine_class", lambda m, n: MockEngineClass)
+
+    mock_db = MockStateDB()
+    monkeypatch.setattr(db_mod, "StateDB", lambda: mock_db)
+
+    args = _build_args(kind="research", spec="test topic", no_persist=False)
+    rc = await engine_mod._do_engine_run(args)
+
+    assert rc == 0, f"expected exit 0 (completed), got {rc}"
+    completed = [c for c in mock_db.update_calls if c["status"] == "completed"]
+    assert completed, f"no completed update; all calls: {mock_db.update_calls}"
+    error_val = completed[0]["error"]
+    assert error_val is not None, (
+        "emission_missing fired but engine_runs.error stayed NULL — "
+        "Engine.run() → engine._emission_failures handoff is broken"
+    )
+    assert "emission_missing" in error_val, (
+        f"error column must contain 'emission_missing'; got: {error_val!r}"
+    )
+    assert "planner" in error_val, f"agent name must appear in error column; got: {error_val!r}"
+
+
+async def test_real_engine_clean_run_leaves_error_null(monkeypatch):
+    """Integration: real Engine subclass with a branch whose emission arrives →
+    engine_runs.error stays NULL (no cross-run leak)."""
+    import lionagi.cli._logging as log_mod
+    import lionagi.cli.engine as engine_mod
+    import lionagi.state.db as db_mod
+
+    monkeypatch.setattr(log_mod, "progress", lambda *a, **kw: None)
+    monkeypatch.setattr(log_mod, "warn", lambda *a, **kw: None)
+
+    from lionagi.engines.engine import Engine, EngineRun
+
+    class _AlwaysArriveBranch:
+        name = "worker"
+
+        class _ChatModel:
+            is_cli = False
+
+        chat_model = _ChatModel()
+
+        async def operate(self, instruction=None, **kw):
+            return "emission arrived"
+
+    class CleanEngine(Engine):
+        async def _run(self, run: EngineRun, spec: str, **kwargs) -> str:  # type: ignore[override]
+            branch = _AlwaysArriveBranch()
+            await run.operate_with_repair(
+                branch,  # type: ignore[arg-type]
+                "please emit",
+                arrived=lambda: True,  # arrived immediately — no emission_missing
+                emits=(),
+                retries=1,
+            )
+            return "clean result"
+
+    real_engine = CleanEngine(max_agents=5)
+    MockEngineClass = MagicMock(return_value=real_engine)
+    monkeypatch.setattr(engine_mod, "_import_engine_class", lambda m, n: MockEngineClass)
+
+    mock_db = MockStateDB()
+    monkeypatch.setattr(db_mod, "StateDB", lambda: mock_db)
+
+    args = _build_args(kind="research", spec="clean run", no_persist=False)
+    rc = await engine_mod._do_engine_run(args)
+
+    assert rc == 0
+    completed = [c for c in mock_db.update_calls if c["status"] == "completed"]
+    assert completed
+    assert completed[0]["error"] is None, (
+        f"clean run must leave error=NULL; got: {completed[0]['error']!r}"
+    )
+
+
+async def test_engine_reuse_second_run_resets_emission_failures(monkeypatch):
+    """Engine instance reused for a second clean run must NOT carry emission
+    failures from the first run (no cross-run leak)."""
+    import lionagi.cli._logging as log_mod
+    import lionagi.cli.engine as engine_mod
+    import lionagi.state.db as db_mod
+
+    monkeypatch.setattr(log_mod, "progress", lambda *a, **kw: None)
+    monkeypatch.setattr(log_mod, "warn", lambda *a, **kw: None)
+
+    from lionagi.engines.engine import Engine, EngineRun
+
+    call_count = [0]
+
+    class _ConditionalBranch:
+        name = "agent"
+
+        class _ChatModel:
+            is_cli = False
+
+        chat_model = _ChatModel()
+
+        async def operate(self, instruction=None, **kw):
+            return None
+
+    class TwoRunEngine(Engine):
+        """First run: emission_missing. Second run: clean."""
+
+        async def _run(self, run: EngineRun, spec: str, **kwargs) -> str:  # type: ignore[override]
+            call_count[0] += 1
+            branch = _ConditionalBranch()
+            if call_count[0] == 1:
+                # First run: never arrives → emission_missing
+                await run.operate_with_repair(
+                    branch,  # type: ignore[arg-type]
+                    "emit",
+                    arrived=lambda: False,
+                    emits=(),
+                    retries=1,
+                )
+            else:
+                # Second run: arrives immediately
+                await run.operate_with_repair(
+                    branch,  # type: ignore[arg-type]
+                    "emit",
+                    arrived=lambda: True,
+                    emits=(),
+                    retries=1,
+                )
+            return "result"
+
+    real_engine = TwoRunEngine(max_agents=5)
+
+    # Run 1: should produce emission_missing on engine
+    await real_engine.run("run-1")
+    assert real_engine._emission_failures, "first run should have emission failures"
+
+    # Run 2: clean run — engine._emission_failures must be reset
+    await real_engine.run("run-2")
+    assert real_engine._emission_failures == [], (
+        f"second clean run must reset _emission_failures; got: {real_engine._emission_failures}"
+    )

--- a/tests/cli/test_engine_emission_diagnostics.py
+++ b/tests/cli/test_engine_emission_diagnostics.py
@@ -1,0 +1,319 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for engine emission-missing diagnostics written to engine_runs DB (issue #1397).
+
+Covers:
+  - Zero-emission run → engine_runs row has status='completed' AND
+    error containing 'emission_missing'
+  - Normal run (no emission failures) → error column stays NULL
+  - EngineRun._emission_failures accumulates correctly
+  - EngineRun.operate_with_repair notifies and records emission_missing
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_args(**kwargs) -> argparse.Namespace:
+    defaults = {
+        "command": "engine",
+        "engine_command": "run",
+        "kind": "research",
+        "spec": "What is GQA?",
+        "test_cmd": None,
+        "export_dir": None,
+        "model": None,
+        "max_depth": None,
+        "max_agents": None,
+        "session_id": None,
+        "no_persist": False,
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+class MockStateDB:
+    """Minimal StateDB mock that records insert and update calls."""
+
+    def __init__(self):
+        self.insert_calls: list[dict] = []
+        self.update_calls: list[dict] = []
+
+    async def open(self):
+        pass
+
+    async def close(self):
+        pass
+
+    async def insert_engine_run(self, *, run_id, kind, spec_json, started_at, session_id=None):
+        self.insert_calls.append({"run_id": run_id, "kind": kind})
+
+    async def update_engine_run(
+        self, run_id, *, status, ended_at=None, export_dir=None, error=None
+    ):
+        self.update_calls.append({"run_id": run_id, "status": status, "error": error})
+
+
+# ---------------------------------------------------------------------------
+# Engine CLI: emission_missing events → error column on completed row
+# ---------------------------------------------------------------------------
+
+
+async def test_emission_failures_written_to_db_error_on_completed(monkeypatch):
+    """When an engine run completes but emission failures occurred, the DB row
+    must have status='completed' AND a non-None error with 'emission_missing'."""
+    import lionagi.cli._logging as log_mod
+    import lionagi.cli.engine as engine_mod
+    import lionagi.state.db as db_mod
+
+    monkeypatch.setattr(log_mod, "progress", lambda *a, **kw: None)
+    monkeypatch.setattr(log_mod, "warn", lambda *a, **kw: None)
+
+    # Engine that returns a result but has _emission_failures populated.
+    mock_engine = MagicMock()
+    mock_engine._emission_failures = ["planner x2", "summariser x1"]
+
+    async def _mock_run(spec, *, on_event=None, **kwargs):
+        return "partial result despite missing emissions"
+
+    mock_engine.run = _mock_run
+    MockEngineClass = MagicMock(return_value=mock_engine)
+    monkeypatch.setattr(engine_mod, "_import_engine_class", lambda m, n: MockEngineClass)
+
+    mock_db = MockStateDB()
+    monkeypatch.setattr(db_mod, "StateDB", lambda: mock_db)
+
+    args = _build_args(kind="research", spec="GQA", no_persist=False)
+    rc = await engine_mod._do_engine_run(args)
+
+    assert rc == 0
+    completed = [c for c in mock_db.update_calls if c["status"] == "completed"]
+    assert completed, f"no completed update; calls={mock_db.update_calls}"
+    error_val = completed[0]["error"]
+    assert error_val is not None, "emission failures must be written to error column"
+    assert "emission_missing" in error_val, (
+        f"error column must contain 'emission_missing'; got: {error_val!r}"
+    )
+    assert "planner" in error_val or "summariser" in error_val, (
+        f"error column must name the failing agents; got: {error_val!r}"
+    )
+
+
+async def test_no_emission_failures_error_column_stays_null(monkeypatch):
+    """A clean run with no emission failures must leave error=None in the DB."""
+    import lionagi.cli._logging as log_mod
+    import lionagi.cli.engine as engine_mod
+    import lionagi.state.db as db_mod
+
+    monkeypatch.setattr(log_mod, "progress", lambda *a, **kw: None)
+    monkeypatch.setattr(log_mod, "warn", lambda *a, **kw: None)
+
+    mock_engine = MagicMock()
+    mock_engine._emission_failures = []  # no failures
+
+    async def _mock_run(spec, *, on_event=None, **kwargs):
+        return "clean result"
+
+    mock_engine.run = _mock_run
+    MockEngineClass = MagicMock(return_value=mock_engine)
+    monkeypatch.setattr(engine_mod, "_import_engine_class", lambda m, n: MockEngineClass)
+
+    mock_db = MockStateDB()
+    monkeypatch.setattr(db_mod, "StateDB", lambda: mock_db)
+
+    args = _build_args(kind="research", spec="GQA", no_persist=False)
+    rc = await engine_mod._do_engine_run(args)
+
+    assert rc == 0
+    completed = [c for c in mock_db.update_calls if c["status"] == "completed"]
+    assert completed, f"no completed update; calls={mock_db.update_calls}"
+    assert completed[0]["error"] is None, (
+        f"clean run must have error=None; got: {completed[0]['error']!r}"
+    )
+
+
+async def test_engine_without_emission_failures_attr_error_column_stays_null(monkeypatch):
+    """Engine objects without _emission_failures attr (older subclass) must not crash."""
+    import lionagi.cli._logging as log_mod
+    import lionagi.cli.engine as engine_mod
+    import lionagi.state.db as db_mod
+
+    monkeypatch.setattr(log_mod, "progress", lambda *a, **kw: None)
+    monkeypatch.setattr(log_mod, "warn", lambda *a, **kw: None)
+
+    mock_engine = MagicMock(spec=[])  # spec=[] means no _emission_failures attr
+
+    async def _mock_run(spec, *, on_event=None, **kwargs):
+        return "result"
+
+    mock_engine.run = _mock_run
+    MockEngineClass = MagicMock(return_value=mock_engine)
+    monkeypatch.setattr(engine_mod, "_import_engine_class", lambda m, n: MockEngineClass)
+
+    mock_db = MockStateDB()
+    monkeypatch.setattr(db_mod, "StateDB", lambda: mock_db)
+
+    args = _build_args(kind="research", spec="GQA", no_persist=False)
+    rc = await engine_mod._do_engine_run(args)
+
+    assert rc == 0
+    completed = [c for c in mock_db.update_calls if c["status"] == "completed"]
+    assert completed
+    assert completed[0]["error"] is None
+
+
+# ---------------------------------------------------------------------------
+# EngineRun._emission_failures accumulation
+# ---------------------------------------------------------------------------
+
+
+def _make_minimal_engine_run() -> Any:
+    """Build a minimal EngineRun with a no-op on_event."""
+    from unittest.mock import MagicMock
+
+    from lionagi.engines.engine import EngineRun
+
+    engine = MagicMock()
+    engine.max_concurrent = 1
+    engine.max_agents = 100
+    engine.deadline_s = None
+    engine.model = None
+    run = EngineRun(engine, on_event=None)
+    return run
+
+
+def test_engine_run_emission_failures_starts_empty():
+    er = _make_minimal_engine_run()
+    assert er._emission_failures == []
+
+
+async def test_operate_with_repair_records_emission_failure(monkeypatch):
+    """When arrived() never returns True and retries are exhausted,
+    _emission_failures must contain a descriptive entry."""
+    from lionagi.engines.engine import EngineRun
+
+    engine = MagicMock()
+    engine.max_concurrent = 1
+    engine.max_agents = 100
+    engine.deadline_s = None
+    engine.model = None
+
+    er = EngineRun(engine, on_event=None)
+
+    # Branch mock: operate always returns None-ish
+    branch = MagicMock()
+    branch.name = "planner"
+    branch.chat_model = MagicMock()
+    branch.chat_model.is_cli = False
+
+    async def fake_operate(instruction=None, **kw):
+        return None
+
+    branch.operate = fake_operate
+
+    arrived_count = [0]
+
+    def never_arrived():
+        return False
+
+    await er.operate_with_repair(
+        branch,
+        "do work",
+        arrived=never_arrived,
+        emits=(),
+        retries=2,
+    )
+
+    assert len(er._emission_failures) == 1, (
+        f"expected 1 emission_failure entry, got {er._emission_failures}"
+    )
+    entry = er._emission_failures[0]
+    assert "planner" in entry, f"agent name must be in entry; got: {entry!r}"
+    assert "x" in entry, f"attempt count must be in entry; got: {entry!r}"
+
+
+async def test_operate_with_repair_no_failure_when_arrived(monkeypatch):
+    """When arrived() returns True on the first try, no failure is recorded."""
+    from lionagi.engines.engine import EngineRun
+
+    engine = MagicMock()
+    engine.max_concurrent = 1
+    engine.max_agents = 100
+    engine.deadline_s = None
+    engine.model = None
+
+    er = EngineRun(engine, on_event=None)
+
+    branch = MagicMock()
+    branch.name = "worker"
+    branch.chat_model = MagicMock()
+    branch.chat_model.is_cli = False
+
+    async def fake_operate(instruction=None, **kw):
+        return "emission ok"
+
+    branch.operate = fake_operate
+
+    def always_arrived():
+        return True
+
+    await er.operate_with_repair(
+        branch,
+        "do work",
+        arrived=always_arrived,
+        emits=(),
+        retries=2,
+    )
+
+    assert er._emission_failures == [], (
+        f"no failure should be recorded when arrived=True; got: {er._emission_failures}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Real StateDB: completed + error coexist in engine_runs table
+# ---------------------------------------------------------------------------
+
+
+async def test_completed_run_with_error_column_in_real_db(tmp_path):
+    """Verify the real StateDB allows writing error='emission_missing: x2' with
+    status='completed' — confirms no DB-level constraint prevents it."""
+    aiosqlite = pytest.importorskip("aiosqlite")
+
+    from lionagi.state.db import StateDB
+
+    db_path = tmp_path / "state.db"
+    import uuid
+
+    rid = uuid.uuid4().hex
+
+    async with StateDB(db_path) as db:
+        await db.insert_engine_run(
+            run_id=rid,
+            kind="research",
+            spec_json={"topic": "test"},
+            started_at=1000.0,
+        )
+        await db.update_engine_run(
+            rid,
+            status="completed",
+            ended_at=1100.0,
+            error="emission_missing: planner x2; summariser x1",
+        )
+        row = await db.get_engine_run(rid)
+
+    assert row is not None
+    assert row["status"] == "completed"
+    assert row["error"] == "emission_missing: planner x2; summariser x1", (
+        f"error column must persist alongside 'completed' status; got: {row['error']!r}"
+    )

--- a/tests/operations/test_run_error_classification.py
+++ b/tests/operations/test_run_error_classification.py
@@ -147,3 +147,92 @@ async def test_run_empty_error_chunk_uses_fallback_string():
     # The '(empty error)' guard in run.py means content becomes '(empty error)'
     with pytest.raises(ProviderError, match="empty error"):
         await _drain(run(branch, "do something", RunParam()))
+
+
+# ---------------------------------------------------------------------------
+# Finding #3: subprocess RuntimeError path → classified ProviderError
+# ---------------------------------------------------------------------------
+
+
+async def test_run_subprocess_runtime_error_is_classified():
+    """A plain RuntimeError raised by the stream iterator (e.g. from
+    ndjson_from_cli on nonzero exit) must be caught, classified, and
+    re-raised as the appropriate ProviderError subclass with the original
+    exception as __cause__."""
+    quota_stderr = "usage limit reached. try again at 9:00 PM"
+    branch = Branch()
+
+    # Patch stream to raise RuntimeError instead of yielding chunks
+    m = iModel(provider="openai", model="gpt-4.1-mini", api_key="test_key")
+    import types
+
+    endpoint_ns = types.SimpleNamespace(
+        is_cli=True,
+        session_id=None,
+        to_dict=lambda: {"type": "fake_cli", "session_id": None},
+    )
+    m.endpoint = endpoint_ns
+    m.streaming_process_func = None
+
+    async def create_event(**kw):
+        return object()
+
+    m.create_event = create_event
+    m.executor = types.SimpleNamespace(append=AsyncMock(), config={})
+
+    original_exc = RuntimeError(quota_stderr)
+
+    async def stream_raises(api_call=None):
+        raise original_exc
+        # make it an async generator
+        yield  # pragma: no cover
+
+    m.stream = stream_raises
+    branch.chat_model = m
+
+    with pytest.raises(ProviderQuotaError, match="usage limit reached") as exc_info:
+        await _drain(run(branch, "do something", RunParam()))
+
+    # Original exception must be chained as __cause__
+    assert exc_info.value.__cause__ is original_exc, (
+        "classified ProviderError must chain the original RuntimeError as __cause__"
+    )
+
+
+async def test_run_already_classified_provider_error_not_double_wrapped():
+    """A ProviderError raised by the stream iterator must NOT be re-wrapped
+    — it must propagate unchanged (no double classification)."""
+    original_exc = ProviderQuotaError("usage limit reached. try again at 9:00 PM")
+    branch = Branch()
+
+    import types
+
+    m = iModel(provider="openai", model="gpt-4.1-mini", api_key="test_key")
+    endpoint_ns = types.SimpleNamespace(
+        is_cli=True,
+        session_id=None,
+        to_dict=lambda: {"type": "fake_cli", "session_id": None},
+    )
+    m.endpoint = endpoint_ns
+    m.streaming_process_func = None
+
+    async def create_event(**kw):
+        return object()
+
+    m.create_event = create_event
+    m.executor = types.SimpleNamespace(append=AsyncMock(), config={})
+
+    async def stream_raises(api_call=None):
+        raise original_exc
+        yield  # pragma: no cover
+
+    m.stream = stream_raises
+    branch.chat_model = m
+
+    with pytest.raises(ProviderQuotaError) as exc_info:
+        await _drain(run(branch, "do something", RunParam()))
+
+    # Must be the same object — no wrapping
+    assert exc_info.value is original_exc, (
+        "already-classified ProviderError must not be double-wrapped"
+    )

--- a/tests/operations/test_run_error_classification.py
+++ b/tests/operations/test_run_error_classification.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the run.py error-classification path (issue #1397).
+
+Verifies that a StreamChunk with type="error" whose content contains a
+provider-recognisable pattern raises the typed ProviderError subclass rather
+than a plain RuntimeError.  All subclasses remain RuntimeError-compatible so
+existing ``except RuntimeError`` callers are unaffected.
+"""
+
+from __future__ import annotations
+
+import types
+from unittest.mock import AsyncMock
+
+import pytest
+
+from lionagi.operations.run.run import RunParam, run
+from lionagi.providers._provider_errors import (
+    ProviderAuthError,
+    ProviderContextError,
+    ProviderError,
+    ProviderQuotaError,
+)
+from lionagi.service.imodel import iModel
+from lionagi.service.types.stream_chunk import StreamChunk
+from lionagi.session.branch import Branch
+
+
+def _make_fake_cli_model(chunks: list[StreamChunk]):
+    """Return an iModel patched to behave as a CLI endpoint yielding *chunks*."""
+    m = iModel(provider="openai", model="gpt-4.1-mini", api_key="test_key")
+    endpoint_ns = types.SimpleNamespace(
+        is_cli=True,
+        session_id=None,
+        to_dict=lambda: {"type": "fake_cli", "session_id": None},
+    )
+    m.endpoint = endpoint_ns
+    m.streaming_process_func = None
+
+    async def create_event(**kw):
+        return object()
+
+    m.create_event = create_event
+    m.executor = types.SimpleNamespace(append=AsyncMock(), config={})
+
+    async def stream(api_call=None):
+        for chunk in chunks:
+            yield chunk
+
+    m.stream = stream
+    return m
+
+
+async def _drain(gen) -> list:
+    return [item async for item in gen]
+
+
+# ---------------------------------------------------------------------------
+# Quota error chunk → ProviderQuotaError raised (still a RuntimeError)
+# ---------------------------------------------------------------------------
+
+
+async def test_run_raises_quota_error_for_usage_limit_chunk():
+    """A StreamChunk with quota-limit text must raise ProviderQuotaError."""
+    quota_msg = "usage limit reached. try again at 9:00 PM"
+    branch = Branch()
+    branch.chat_model = _make_fake_cli_model([StreamChunk(type="error", content=quota_msg)])
+
+    with pytest.raises(ProviderQuotaError, match="usage limit reached"):
+        await _drain(run(branch, "do something", RunParam()))
+
+
+async def test_run_quota_error_is_runtime_error():
+    """ProviderQuotaError from run() must also be RuntimeError-catchable."""
+    quota_msg = "rate_limit_exceeded: too many requests"
+    branch = Branch()
+    branch.chat_model = _make_fake_cli_model([StreamChunk(type="error", content=quota_msg)])
+
+    with pytest.raises(RuntimeError):
+        await _drain(run(branch, "do something", RunParam()))
+
+
+# ---------------------------------------------------------------------------
+# Auth error chunk → ProviderAuthError
+# ---------------------------------------------------------------------------
+
+
+async def test_run_raises_auth_error_for_invalid_key_chunk():
+    auth_msg = "Error: invalid_api_key — check your credentials"
+    branch = Branch()
+    branch.chat_model = _make_fake_cli_model([StreamChunk(type="error", content=auth_msg)])
+
+    with pytest.raises(ProviderAuthError):
+        await _drain(run(branch, "do something", RunParam()))
+
+
+# ---------------------------------------------------------------------------
+# Context error chunk → ProviderContextError
+# ---------------------------------------------------------------------------
+
+
+async def test_run_raises_context_error_for_window_exceeded_chunk():
+    ctx_msg = "context window exceeded — please shorten your prompt"
+    branch = Branch()
+    branch.chat_model = _make_fake_cli_model([StreamChunk(type="error", content=ctx_msg)])
+
+    with pytest.raises(ProviderContextError):
+        await _drain(run(branch, "do something", RunParam()))
+
+
+# ---------------------------------------------------------------------------
+# Unknown error chunk → base ProviderError (still RuntimeError)
+# ---------------------------------------------------------------------------
+
+
+async def test_run_raises_base_provider_error_for_unknown_chunk():
+    unknown_msg = "An unexpected internal server error occurred"
+    branch = Branch()
+    branch.chat_model = _make_fake_cli_model([StreamChunk(type="error", content=unknown_msg)])
+
+    with pytest.raises(ProviderError):
+        await _drain(run(branch, "do something", RunParam()))
+
+
+async def test_run_base_provider_error_is_runtime_error():
+    branch = Branch()
+    branch.chat_model = _make_fake_cli_model(
+        [StreamChunk(type="error", content="some unknown provider failure")]
+    )
+
+    with pytest.raises(RuntimeError):
+        await _drain(run(branch, "do something", RunParam()))
+
+
+# ---------------------------------------------------------------------------
+# Empty content → "(empty error)" guard, base ProviderError
+# ---------------------------------------------------------------------------
+
+
+async def test_run_empty_error_chunk_uses_fallback_string():
+    """A StreamChunk(type='error', content=None) must not raise with a None message."""
+    branch = Branch()
+    branch.chat_model = _make_fake_cli_model([StreamChunk(type="error", content=None)])
+
+    # The '(empty error)' guard in run.py means content becomes '(empty error)'
+    with pytest.raises(ProviderError, match="empty error"):
+        await _drain(run(branch, "do something", RunParam()))

--- a/tests/operations/test_run_error_classification.py
+++ b/tests/operations/test_run_error_classification.py
@@ -236,3 +236,35 @@ async def test_run_already_classified_provider_error_not_double_wrapped():
     assert exc_info.value is original_exc, (
         "already-classified ProviderError must not be double-wrapped"
     )
+
+
+# ---------------------------------------------------------------------------
+# Round-3 regression: error:null chunk must NOT be swallowed as benign EOS
+# (codex round-2 finding: null normalised to {} matched the benign predicate)
+# ---------------------------------------------------------------------------
+
+
+async def test_run_raises_provider_error_for_null_error_payload_chunk():
+    """A StreamChunk from {"type":"error","error":null} must raise ProviderError
+    rather than completing silently.
+
+    Regression: after the null-normalisation fix (round 2), the null payload was
+    normalised to {} before the benign-EOS predicate, causing run() to treat it as
+    the resume-EOF sentinel and return a successful result.  The fix captures
+    _raw_err before normalising so null does NOT qualify as benign.
+    """
+    # This is the chunk that the adapter emits for {"type":"error","error":null}.
+    # After the fix it is NOT benign_eos, so run() must raise ProviderError.
+    # The self-describing content from the empty-payload branch matches the base
+    # ProviderError classifier (no quota/auth/context pattern).
+    null_error_chunk = StreamChunk(
+        type="error",
+        content="CLI failure (empty error payload; event type='error')",
+        metadata={"type": "error", "error": None},
+        # Crucially: benign_eos is NOT set
+    )
+    branch = Branch()
+    branch.chat_model = _make_fake_cli_model([null_error_chunk])
+
+    with pytest.raises(ProviderError):
+        await _drain(run(branch, "do something", RunParam()))

--- a/tests/providers/openai/codex/test_benign_eos.py
+++ b/tests/providers/openai/codex/test_benign_eos.py
@@ -222,3 +222,53 @@ async def test_turn_failed_with_nested_message_still_preferred_over_toplevel():
     assert chunks[0].type == "error"
     assert not chunks[0].metadata.get("benign_eos")
     assert chunks[0].content == "inner detail"
+
+
+# ---------------------------------------------------------------------------
+# Round-3 regression: "error": null must NOT be treated as benign EOS
+# (fix/cli-worker-error-surfacing codex round-2 finding)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_error_event_null_payload_is_not_benign():
+    """{"type": "error", "error": null} must NOT be tagged benign_eos=True.
+
+    Regression for the round-2 null-normalisation fix: normalising null→{} before
+    the benign predicate caused this shape to match the empty-dict sentinel and be
+    swallowed silently.  null is a malformed/unexpected provider envelope; it must
+    surface as a real error with a self-describing message.
+    """
+    events = [{"type": "error", "error": None}]
+    chunks = await _chunks_from_events(events)
+
+    assert len(chunks) == 1
+    chunk = chunks[0]
+    assert chunk.type == "error"
+    assert not chunk.metadata.get("benign_eos"), (
+        "error:null must NOT be tagged benign_eos — it is a malformed envelope, "
+        f"not the resume-EOF sentinel; metadata={chunk.metadata}"
+    )
+    # The content must be self-describing (null normalised to {} hits the empty-
+    # payload branch), not the raw string "None".
+    assert chunk.content != "None", (
+        f"null error payload must not render as the string 'None'; got: {chunk.content!r}"
+    )
+    assert "turn.failed" not in chunk.content or "error" in chunk.content, (
+        "self-describing fallback message should name the event type"
+    )
+
+
+@pytest.mark.asyncio
+async def test_error_event_empty_dict_is_still_benign_after_null_fix():
+    """Confirm {"type": "error", "error": {}} remains benign EOS after the null
+    fix — the original sentinel behavior must not be broken."""
+    events = [{"type": "error", "error": {}}]
+    chunks = await _chunks_from_events(events)
+
+    error_chunks = [c for c in chunks if c.type == "error"]
+    assert len(error_chunks) == 1
+    assert error_chunks[0].metadata.get("benign_eos") is True, (
+        "explicit empty-dict error payload must still be tagged benign_eos=True; "
+        f"metadata={error_chunks[0].metadata}"
+    )

--- a/tests/providers/openai/codex/test_empty_payload_fallback.py
+++ b/tests/providers/openai/codex/test_empty_payload_fallback.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the empty-payload fallback in stream_codex_cli (issue #1397).
+
+When a 'turn.failed' event has an empty error dict {}, the result must be a
+self-describing string rather than the useless str({}) == '{}' that the old
+code emitted.  The existing populated-message path must remain unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.providers.openai.codex.models import CodexCodeRequest, stream_codex_cli
+from lionagi.service.types.stream_chunk import StreamChunk
+
+
+def _make_request() -> CodexCodeRequest:
+    return CodexCodeRequest(prompt="test", verbose_output=False)
+
+
+async def _chunks_from_events(events: list[dict]) -> list[StreamChunk]:
+    """Drive stream_codex_cli with a mocked event stream, collect StreamChunks."""
+    from unittest.mock import patch
+
+    async def fake_events(request):
+        for ev in events:
+            yield ev
+
+    collected = []
+    with patch(
+        "lionagi.providers.openai.codex.models.stream_codex_cli_events",
+        side_effect=fake_events,
+    ):
+        async for item in stream_codex_cli(_make_request()):
+            if isinstance(item, StreamChunk):
+                collected.append(item)
+    return collected
+
+
+# ---------------------------------------------------------------------------
+# turn.failed with empty error payload → self-describing message
+# ---------------------------------------------------------------------------
+
+
+async def test_turn_failed_empty_payload_has_self_describing_content():
+    """turn.failed with err={} must NOT produce '{}' as content — it must be a
+    human-readable description indicating the event type."""
+    events = [{"type": "turn.failed", "error": {}}]
+    chunks = await _chunks_from_events(events)
+
+    assert len(chunks) == 1
+    chunk = chunks[0]
+    assert chunk.type == "error"
+    # Must NOT be the useless literal '{}' from str({})
+    assert chunk.content != "{}", (
+        f"empty-payload turn.failed must not render as '{{}}'; got: {chunk.content!r}"
+    )
+    # Must be self-describing: mention the event type
+    assert "turn.failed" in chunk.content, (
+        f"self-describing message must name the event type; got: {chunk.content!r}"
+    )
+    assert "CLI failure" in chunk.content or "empty error payload" in chunk.content, (
+        f"self-describing message must indicate empty payload; got: {chunk.content!r}"
+    )
+
+
+async def test_error_event_empty_payload_benign_eos_still_applies():
+    """'error' event with err={} is the benign-EOS sentinel — the empty-payload
+    fallback must NOT override the benign_eos tagging path for this shape."""
+    events = [{"type": "error", "error": {}}]
+    chunks = await _chunks_from_events(events)
+
+    error_chunks = [c for c in chunks if c.type == "error"]
+    assert len(error_chunks) == 1
+    # For the 'error' type with empty dict, the benign-EOS guard retracted
+    # is_error; the content for such events is handled by the same block but
+    # the benign_eos sentinel is the real distinguishing property.
+    # Accept any content — what matters is the benign_eos tag.
+    assert error_chunks[0].metadata.get("benign_eos") is True
+
+
+# ---------------------------------------------------------------------------
+# Populated message — existing behaviour preserved
+# ---------------------------------------------------------------------------
+
+
+async def test_turn_failed_populated_message_preserved():
+    """turn.failed with a real error.message must surface that exact text."""
+    msg = "Rate limit hit — please retry in 60 seconds"
+    events = [{"type": "turn.failed", "error": {"message": msg}}]
+    chunks = await _chunks_from_events(events)
+
+    assert len(chunks) == 1
+    assert chunks[0].type == "error"
+    assert chunks[0].content == msg, (
+        f"populated message must be preserved unchanged; got: {chunks[0].content!r}"
+    )
+
+
+async def test_turn_failed_top_level_message_surfaced_when_no_nested():
+    """turn.failed with a top-level 'message' but no error.message must surface
+    the top-level message (fallback path)."""
+    msg = "Provider failure: model unavailable"
+    events = [{"type": "turn.failed", "error": {}, "message": msg}]
+    chunks = await _chunks_from_events(events)
+
+    assert len(chunks) == 1
+    assert chunks[0].type == "error"
+    # obj.get("message") should win over the fallback
+    assert chunks[0].content == msg, (
+        f"top-level message must be surfaced as fallback; got: {chunks[0].content!r}"
+    )
+
+
+async def test_error_event_top_level_message_preserved():
+    """'error' event with top-level 'message' (usage-limit shape) is unchanged."""
+    msg = "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits."
+    events = [{"type": "error", "message": msg}]
+    chunks = await _chunks_from_events(events)
+
+    assert len(chunks) == 1
+    assert chunks[0].type == "error"
+    assert chunks[0].content == msg

--- a/tests/providers/openai/codex/test_empty_payload_fallback.py
+++ b/tests/providers/openai/codex/test_empty_payload_fallback.py
@@ -123,3 +123,79 @@ async def test_error_event_top_level_message_preserved():
     assert len(chunks) == 1
     assert chunks[0].type == "error"
     assert chunks[0].content == msg
+
+
+# ---------------------------------------------------------------------------
+# Edge cases from codex review finding #2:
+# error=null, error missing, {"code": ...} no message, non-dict error
+# ---------------------------------------------------------------------------
+
+
+async def test_turn_failed_error_null_has_self_describing_content():
+    """turn.failed with JSON 'error': null must NOT surface as the string 'None'.
+    It should produce the same self-describing message as an empty dict."""
+    # JSON {"type": "turn.failed", "error": null} → obj.get("error", {}) returns None
+    events = [{"type": "turn.failed", "error": None}]
+    chunks = await _chunks_from_events(events)
+
+    assert len(chunks) == 1
+    chunk = chunks[0]
+    assert chunk.type == "error"
+    assert chunk.content != "None", (
+        f"null error payload must not render as the string 'None'; got: {chunk.content!r}"
+    )
+    assert "turn.failed" in chunk.content, (
+        f"self-describing message must name the event type; got: {chunk.content!r}"
+    )
+
+
+async def test_turn_failed_missing_error_key_is_self_describing():
+    """turn.failed with no 'error' key at all should produce a self-describing message."""
+    events = [{"type": "turn.failed"}]
+    chunks = await _chunks_from_events(events)
+
+    assert len(chunks) == 1
+    chunk = chunks[0]
+    assert chunk.type == "error"
+    assert chunk.content != "{}", (
+        f"missing-error turn.failed must not render as '{{}}'; got: {chunk.content!r}"
+    )
+    assert "turn.failed" in chunk.content, (
+        f"self-describing message must name event type; got: {chunk.content!r}"
+    )
+
+
+async def test_turn_failed_code_no_message_uses_str_repr():
+    """turn.failed with {'code': 'rate_limit'} but no 'message' key surfaces
+    str(err) which is informative, not the empty-payload fallback."""
+    events = [{"type": "turn.failed", "error": {"code": "rate_limit"}}]
+    chunks = await _chunks_from_events(events)
+
+    assert len(chunks) == 1
+    chunk = chunks[0]
+    assert chunk.type == "error"
+    # str({'code': 'rate_limit'}) is informative — acceptable per spec
+    assert "rate_limit" in chunk.content or "code" in chunk.content, (
+        f"non-empty dict without message should use str(err); got: {chunk.content!r}"
+    )
+    # Must NOT be the empty-payload fallback string
+    assert "empty error payload" not in chunk.content, (
+        f"non-empty dict must not trigger empty-payload fallback; got: {chunk.content!r}"
+    )
+    assert "null error payload" not in chunk.content, (
+        f"non-empty dict must not trigger null-payload fallback; got: {chunk.content!r}"
+    )
+
+
+async def test_turn_failed_non_dict_error_uses_obj_message_or_str():
+    """turn.failed with a non-dict error (e.g. a string) falls to
+    obj.get('message', str(err)) — the non-dict branch."""
+    events = [{"type": "turn.failed", "error": "process failed"}]
+    chunks = await _chunks_from_events(events)
+
+    assert len(chunks) == 1
+    chunk = chunks[0]
+    assert chunk.type == "error"
+    assert chunk.content == "process failed", (
+        f"non-dict error string should be surfaced directly; got: {chunk.content!r}"
+    )

--- a/tests/providers/test_provider_errors.py
+++ b/tests/providers/test_provider_errors.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for lionagi/providers/_provider_errors.py (issue #1397).
+
+Covers:
+  - classify_provider_error returns correct subclass for each regex family
+  - All classifications are case-insensitive
+  - Unmatched text → base ProviderError
+  - All subclasses are RuntimeError instances
+  - EmissionError attrs preserved
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.providers._provider_errors import (
+    EmissionError,
+    ProviderAuthError,
+    ProviderContextError,
+    ProviderError,
+    ProviderQuotaError,
+    classify_provider_error,
+)
+
+# ---------------------------------------------------------------------------
+# Quota patterns
+# ---------------------------------------------------------------------------
+
+
+def test_classify_usage_limit_reached_returns_quota_error():
+    err = classify_provider_error("You've hit your usage limit reached. Please wait.")
+    assert isinstance(err, ProviderQuotaError)
+
+
+def test_classify_rate_limit_exceeded_returns_quota_error():
+    err = classify_provider_error("rate_limit_exceeded: too many requests")
+    assert isinstance(err, ProviderQuotaError)
+
+
+def test_classify_rate_limit_space_sep_returns_quota_error():
+    err = classify_provider_error("Rate limit exceeded on this endpoint")
+    assert isinstance(err, ProviderQuotaError)
+
+
+def test_classify_try_again_at_hour_returns_quota_error():
+    err = classify_provider_error("try again at 8:32 PM")
+    assert isinstance(err, ProviderQuotaError)
+
+
+def test_classify_quota_case_insensitive_upper():
+    err = classify_provider_error("USAGE LIMIT REACHED")
+    assert isinstance(err, ProviderQuotaError)
+
+
+def test_classify_quota_in_stderr_tail():
+    err = classify_provider_error(
+        "CLI failure (empty error payload; event type='error')",
+        stderr_tail="usage limit reached. try again at 9:00 PM",
+    )
+    assert isinstance(err, ProviderQuotaError)
+
+
+# ---------------------------------------------------------------------------
+# Auth patterns
+# ---------------------------------------------------------------------------
+
+
+def test_classify_invalid_api_key_returns_auth_error():
+    err = classify_provider_error("Error: invalid_api_key provided")
+    assert isinstance(err, ProviderAuthError)
+
+
+def test_classify_invalid_api_key_space_sep():
+    err = classify_provider_error("invalid api key: please check your credentials")
+    assert isinstance(err, ProviderAuthError)
+
+
+def test_classify_not_logged_in_returns_auth_error():
+    err = classify_provider_error("not logged in — run `codex login`")
+    assert isinstance(err, ProviderAuthError)
+
+
+def test_classify_401_unauthorized_returns_auth_error():
+    err = classify_provider_error("401: Unauthorized access denied")
+    assert isinstance(err, ProviderAuthError)
+
+
+def test_classify_auth_case_insensitive():
+    err = classify_provider_error("INVALID API KEY")
+    assert isinstance(err, ProviderAuthError)
+
+
+# ---------------------------------------------------------------------------
+# Context-length patterns
+# ---------------------------------------------------------------------------
+
+
+def test_classify_context_window_exceeded_returns_context_error():
+    err = classify_provider_error("context window exceeded — please shorten your prompt")
+    assert isinstance(err, ProviderContextError)
+
+
+def test_classify_context_length_too_long_returns_context_error():
+    err = classify_provider_error("context length too long for this model")
+    assert isinstance(err, ProviderContextError)
+
+
+def test_classify_context_case_insensitive():
+    err = classify_provider_error("CONTEXT WINDOW EXCEEDED")
+    assert isinstance(err, ProviderContextError)
+
+
+# ---------------------------------------------------------------------------
+# Unmatched → base ProviderError (not a subclass)
+# ---------------------------------------------------------------------------
+
+
+def test_classify_unknown_returns_base_provider_error():
+    err = classify_provider_error("Some random failure with no known pattern")
+    assert type(err) is ProviderError
+
+
+def test_classify_empty_string_returns_base_provider_error():
+    err = classify_provider_error("")
+    assert type(err) is ProviderError
+
+
+# ---------------------------------------------------------------------------
+# All classes are RuntimeError-compatible
+# ---------------------------------------------------------------------------
+
+
+def test_provider_error_is_runtime_error():
+    err = ProviderError("msg")
+    assert isinstance(err, RuntimeError)
+
+
+def test_quota_error_is_runtime_error():
+    err = ProviderQuotaError("quota exceeded")
+    assert isinstance(err, RuntimeError)
+
+
+def test_auth_error_is_runtime_error():
+    err = ProviderAuthError("bad key")
+    assert isinstance(err, RuntimeError)
+
+
+def test_context_error_is_runtime_error():
+    err = ProviderContextError("too long")
+    assert isinstance(err, RuntimeError)
+
+
+def test_emission_error_is_runtime_error():
+    err = EmissionError("missing", agent="planner", attempts=2, stage="synthesis")
+    assert isinstance(err, RuntimeError)
+
+
+def test_classify_result_is_runtime_error():
+    err = classify_provider_error("usage limit reached")
+    assert isinstance(err, RuntimeError)
+
+
+# ---------------------------------------------------------------------------
+# Attrs preserved correctly
+# ---------------------------------------------------------------------------
+
+
+def test_provider_error_attrs_stored():
+    err = ProviderError("the message", stderr_tail="tail text", raw="raw text")
+    assert str(err) == "the message"
+    assert err.stderr_tail == "tail text"
+    assert err.raw == "raw text"
+
+
+def test_provider_error_raw_defaults_to_message():
+    err = ProviderError("only a message")
+    assert err.raw == "only a message"
+
+
+def test_emission_error_attrs_stored():
+    err = EmissionError("no emission", agent="synthesiser", attempts=3, stage="final")
+    assert err.agent == "synthesiser"
+    assert err.attempts == 3
+    assert err.stage == "final"
+    assert str(err) == "no emission"


### PR DESCRIPTION
## Summary

Fixes both failure modes from #1397 (root-cause analysis in the issue comments):

**`RuntimeError: {}`** — codex `turn.failed` events with an empty error payload fell through to `str({})`. Now: a self-describing `CLI failure (empty error payload; event type=...)` fallback (populated-message behavior unchanged, benign-EOS guard untouched), and `run.py` raises typed errors via `classify_provider_error()` instead of bare RuntimeError.

**Silent zero-chain success** — `emission_missing` was a fire-and-forget notify that never reached run state. Now: the engine records emission failures, and `li engine run` writes a diagnostic (`error="emission_missing: <agent> x<attempts>"`) into `engine_runs.error` while keeping `status="completed"` — no schema churn, no new status values, exit code unchanged (harness back-compat).

**New `lionagi/providers/_provider_errors.py`**: `ProviderError(RuntimeError)` hierarchy — `ProviderQuotaError`, `ProviderAuthError`, `ProviderContextError`, `EmissionError` — with regex classification (quota/auth/context-window) so harnesses can branch retry-later vs escalate. All RuntimeError-compatible; existing `except RuntimeError` handlers unaffected.

## Tests

44 new across 4 files: classifier units, empty-payload extraction, run.py error classification, engine emission diagnostics (real StateDB round-trip: completed + error set; normal run → error NULL). Combined `tests/providers tests/operations tests/cli tests/state`: 1554 passed, 1 pre-existing skip.

Closes #1397.

🤖 Generated with [Claude Code](https://claude.com/claude-code)