### PR TITLE
fix(registry): make LION_CLASS_FILE_REGISTRY fallback actually load classes (closes #1407)

### DIFF
--- a/lionagi/_class_registry.py
+++ b/lionagi/_class_registry.py
@@ -3,7 +3,6 @@
 
 import ast
 import importlib
-import importlib.util
 import os
 from typing import TypeVar
 
@@ -54,10 +53,17 @@ if not LION_CLASS_FILE_REGISTRY:
 
     LION_CLASS_FILE_REGISTRY = get_class_file_registry(script_dir, pattern_list)
 
+# The `lionagi/` package directory itself.  A valid *file_path* must live
+# under this directory — not merely under the project root — so that a stale
+# or polluted LION_CLASS_FILE_REGISTRY entry cannot import arbitrary top-level
+# modules from the checkout (e.g. test files outside the package).
+_PACKAGE_DIR: str = os.path.dirname(os.path.abspath(__file__))
+
 # The parent directory of the lionagi package (i.e. the project root that
-# contains the `lionagi/` directory).  Stored at module level so it can be
-# used by get_class_objects without re-computing on every call.
-_PACKAGE_PARENT: str = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+# contains the `lionagi/` directory).  Used to derive the dotted module name,
+# which must include the `lionagi.` prefix.  Stored at module level so it can
+# be used by get_class_objects without re-computing on every call.
+_PACKAGE_PARENT: str = os.path.dirname(_PACKAGE_DIR)
 
 
 def get_class_objects(file_path):
@@ -81,14 +87,25 @@ def get_class_objects(file_path):
         ImportError: Propagated if the derived module fails to import.
     """
     abs_path = os.path.abspath(file_path)
-    rel = os.path.relpath(abs_path, _PACKAGE_PARENT)
 
-    # Guard: relpath produces ".." when the file is outside the package tree.
-    if rel.startswith(".."):
+    # Guard: the file must live inside the `lionagi/` package directory itself,
+    # not merely under the project root.  Otherwise any importable top-level
+    # module in the checkout (e.g. a test file) would be treated as a valid
+    # dotted module, broadening the fallback import surface.  os.path.commonpath
+    # raises ValueError for paths on different drives (Windows); treat that the
+    # same as "outside the package".
+    try:
+        within_package = os.path.commonpath([_PACKAGE_DIR, abs_path]) == _PACKAGE_DIR
+    except ValueError:
+        within_package = False
+
+    if not within_package:
         raise ValueError(
             f"Cannot derive a dotted module name for {file_path!r}: "
-            f"it is not located under the package root {_PACKAGE_PARENT!r}."
+            f"it is not located under the package root {_PACKAGE_DIR!r}."
         )
+
+    rel = os.path.relpath(abs_path, _PACKAGE_PARENT)
 
     # Convert filesystem path to dotted module name.
     # Example: "lionagi/protocols/graph/node.py" -> "lionagi.protocols.graph.node"

--- a/lionagi/_class_registry.py
+++ b/lionagi/_class_registry.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import ast
+import importlib
 import importlib.util
 import os
 from typing import TypeVar
@@ -53,17 +54,53 @@ if not LION_CLASS_FILE_REGISTRY:
 
     LION_CLASS_FILE_REGISTRY = get_class_file_registry(script_dir, pattern_list)
 
+# The parent directory of the lionagi package (i.e. the project root that
+# contains the `lionagi/` directory).  Stored at module level so it can be
+# used by get_class_objects without re-computing on every call.
+_PACKAGE_PARENT: str = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
 
 def get_class_objects(file_path):
-    class_objects = {}
-    spec = importlib.util.spec_from_file_location("module.name", file_path)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    """Return a mapping of {class_name: class} for all classes in *file_path*.
 
-    for class_name in dir(module):
-        obj = getattr(module, class_name)
+    Instead of loading the file as an isolated module via
+    ``spec_from_file_location`` (which breaks relative imports), we derive the
+    canonical dotted module name from *file_path* relative to the package root
+    and use ``importlib.import_module``.  This preserves full package context
+    so relative imports (``from .x import Y``) resolve correctly.
+
+    Args:
+        file_path: Absolute path to a ``.py`` file inside the lionagi package.
+
+    Returns:
+        Dict mapping class names to class objects found in the module.
+
+    Raises:
+        ValueError: If *file_path* is not located under the package root (i.e.
+            the dotted name cannot be derived) or the module has no classes.
+        ImportError: Propagated if the derived module fails to import.
+    """
+    abs_path = os.path.abspath(file_path)
+    rel = os.path.relpath(abs_path, _PACKAGE_PARENT)
+
+    # Guard: relpath produces ".." when the file is outside the package tree.
+    if rel.startswith(".."):
+        raise ValueError(
+            f"Cannot derive a dotted module name for {file_path!r}: "
+            f"it is not located under the package root {_PACKAGE_PARENT!r}."
+        )
+
+    # Convert filesystem path to dotted module name.
+    # Example: "lionagi/protocols/graph/node.py" -> "lionagi.protocols.graph.node"
+    dotted_name = rel.replace(os.sep, ".").removesuffix(".py")
+
+    module = importlib.import_module(dotted_name)
+
+    class_objects = {}
+    for attr_name in dir(module):
+        obj = getattr(module, attr_name)
         if isinstance(obj, type):
-            class_objects[class_name] = obj
+            class_objects[attr_name] = obj
 
     return class_objects
 

--- a/tests/test_class_registry.py
+++ b/tests/test_class_registry.py
@@ -8,7 +8,7 @@ Covers:
 - FILE_REGISTRY population at import (filesystem scan)
 - LION_CLASS_REGISTRY population via Node.__pydantic_init_subclass__
 - get_class: hit (registry) + miss (unknown name)
-- get_class file-registry fallback path (pinned as known-broken latent bug)
+- get_class file-registry fallback path (fixed in #1407; package-boundary guard)
 - Duplicate-name handling: real-path collision via actual subclass creation
 - Registry isolation: autouse fixture snapshots/restores both registries
 - Polymorphic round-trip: Node subclass -> to_dict -> Element.from_dict -> type preserved

--- a/tests/test_class_registry.py
+++ b/tests/test_class_registry.py
@@ -23,6 +23,7 @@ would produce un-importable qualified names, causing ImportError in the
 fallback deserialization path.
 """
 
+import os
 import tempfile
 from pathlib import Path
 
@@ -345,21 +346,18 @@ class TestGetClassMiss:
 
 
 # ---------------------------------------------------------------------------
-# 4b. get_class file-registry fallback path — pinned as known-broken
+# 4b. get_class file-registry fallback path — fixed (issue #1407)
 #
-# LATENT BUG: get_class()'s fallback at _class_registry.py:100 calls
-# get_class_objects() which uses importlib.util.spec_from_file_location with
-# a dummy module name ("module.name").  Modules in the scanned directories
-# (lionagi/protocols/generic, protocols/graph, protocols/messages) use
-# relative imports (e.g. "from .element import Element").  When exec'd under a
-# standalone spec with no parent package, those relative imports fail with
-# "ImportError: attempted relative import beyond top-level package".
+# Previously latent bug: get_class()'s fallback called get_class_objects()
+# which used importlib.util.spec_from_file_location with a dummy module name.
+# Modules in the scanned directories use relative imports (e.g. "from .element
+# import Element"); exec'd under a standalone spec with no parent package, those
+# relative imports failed with "ImportError: attempted relative import beyond
+# top-level package", making the fallback unreachable for any real lionagi class.
 #
-# As a result, only in-memory LION_CLASS_REGISTRY lookups work reliably.
-# The file-registry fallback path is unreachable for any real lionagi class.
-#
-# This test pins the current behavior so that any accidental "fix" that changes
-# the error type or suppresses the ValueError is caught immediately.
+# get_class_objects() now derives the canonical dotted module name from the file
+# path relative to the package root and uses importlib.import_module, restoring
+# full package context.  These tests pin the fixed behavior and the path guards.
 # ---------------------------------------------------------------------------
 
 
@@ -436,6 +434,37 @@ class TestGetClassFileRegistryFallback:
 
         with pytest.raises(ValueError, match="not located under the package root"):
             get_class_objects("/tmp/some_random_file_outside_package.py")
+
+    def test_file_registry_fallback_repo_root_outside_package_raises(self):
+        """A file under the project root but OUTSIDE the lionagi package (e.g. a
+        test module) must be rejected.  Otherwise a stale or polluted
+        LION_CLASS_FILE_REGISTRY entry could import arbitrary top-level modules
+        from the checkout instead of failing cleanly (regression for #1422
+        codex review: guard must use the package dir, not its parent)."""
+        from lionagi._class_registry import get_class_objects
+
+        # This very test file lives under the repo root but NOT under lionagi/.
+        outside_pkg_file = os.path.abspath(__file__)
+
+        with pytest.raises(ValueError, match="not located under the package root"):
+            get_class_objects(outside_pkg_file)
+
+    def test_file_registry_fallback_repo_root_via_get_class_raises(self):
+        """End-to-end: a registry entry pointing at a repo-root-but-outside-
+        package file must surface as ValueError through get_class(), not import
+        a top-level module."""
+        from lionagi._class_registry import (
+            LION_CLASS_FILE_REGISTRY,
+            LION_CLASS_REGISTRY,
+            get_class,
+        )
+
+        fake_class_name = "_RegistryPathEscape_xyz"
+        LION_CLASS_FILE_REGISTRY[fake_class_name] = os.path.abspath(__file__)
+        LION_CLASS_REGISTRY.pop(fake_class_name, None)
+
+        with pytest.raises(ValueError, match="Unable to find class"):
+            get_class(fake_class_name)
 
     def test_file_registry_fallback_class_not_in_module_raises_value_error(self):
         """get_class() must raise ValueError when the file-registry entry exists

--- a/tests/test_class_registry.py
+++ b/tests/test_class_registry.py
@@ -364,65 +364,100 @@ class TestGetClassMiss:
 
 
 class TestGetClassFileRegistryFallback:
-    """Pin the broken file-registry fallback in get_class().
+    """Pin the fixed file-registry fallback in get_class().
 
-    The fallback at _class_registry.py:100 always raises ImportError when
-    trying to load modules that use relative imports, and get_class() wraps
-    that in ValueError.  This is a documented latent bug.
+    get_class_objects() now derives the canonical dotted module name from
+    the file path relative to the package root and uses
+    ``importlib.import_module`` instead of ``spec_from_file_location`` with a
+    bare context-less name.  This restores full package context so relative
+    imports resolve correctly.  Fixes issue #1407.
     """
 
-    @pytest.mark.xfail(
-        strict=True,
-        raises=ValueError,
-        reason=(
-            "LATENT BUG: get_class_objects() executes modules via a bare spec "
-            "('module.name') with no parent package context.  Any module that "
-            "uses relative imports (from .x import Y) raises "
-            "'ImportError: attempted relative import beyond top-level package'. "
-            "This makes the file-registry fallback path unreachable for all "
-            "real lionagi classes.  Only in-memory LION_CLASS_REGISTRY hits "
-            "work.  Tracked so a future fix is pinned explicitly."
-        ),
-    )
-    def test_file_registry_fallback_raises_for_relative_import_module(self):
-        """Calling get_class() on a scanned class NOT already in LION_CLASS_REGISTRY
-        triggers the file-registry fallback and raises because relative imports fail."""
+    def test_file_registry_fallback_works_for_relative_import_module(self):
+        """Calling get_class() on a class present only in LION_CLASS_FILE_REGISTRY
+        (not in LION_CLASS_REGISTRY) must succeed via the file-registry fallback.
+
+        Formerly pinned as xfail because the old ``spec_from_file_location``
+        approach broke relative imports.  Now a strict passing test.
+        """
+        from lionagi._class_registry import (
+            LION_CLASS_FILE_REGISTRY,
+            LION_CLASS_REGISTRY,
+            get_class,
+        )
+        from lionagi.protocols.graph.node import Node
+
+        # 'Node' is guaranteed to be in FILE_REGISTRY (scanned at import time).
+        target = "Node"
+        assert target in LION_CLASS_FILE_REGISTRY, (
+            "Prerequisite: Node must be in LION_CLASS_FILE_REGISTRY"
+        )
+
+        # Remove all registry entries whose key contains 'Node' so that
+        # get_class is forced through the file-registry fallback path.
+        # The autouse _registry_snapshot fixture restores these afterwards.
+        keys_to_remove = [k for k in LION_CLASS_REGISTRY if k.endswith(f".{target}") or k == target]
+        for k in keys_to_remove:
+            del LION_CLASS_REGISTRY[k]
+        LION_CLASS_REGISTRY.pop(target, None)
+
+        # The fallback must now succeed — relative imports resolve correctly.
+        result = get_class(target)
+        assert isinstance(result, type)
+        assert issubclass(result, Node)
+
+    def test_file_registry_fallback_returns_correct_class(self):
+        """The class returned via the file-registry fallback is the real class,
+        not a re-imported duplicate with a different identity."""
+        from lionagi._class_registry import (
+            LION_CLASS_FILE_REGISTRY,
+            LION_CLASS_REGISTRY,
+            get_class,
+        )
+        from lionagi.protocols.generic.element import Element
+
+        target = "Element"
+        assert target in LION_CLASS_FILE_REGISTRY
+
+        keys_to_remove = [k for k in LION_CLASS_REGISTRY if k.endswith(f".{target}") or k == target]
+        for k in keys_to_remove:
+            del LION_CLASS_REGISTRY[k]
+        LION_CLASS_REGISTRY.pop(target, None)
+
+        result = get_class(target)
+        # importlib.import_module is idempotent (uses sys.modules cache), so
+        # the returned class object is identical to the already-imported one.
+        assert result is Element
+
+    def test_file_registry_fallback_path_outside_package_raises_clear_error(self):
+        """get_class_objects() must raise ValueError with a clear message when
+        the file path is not under the package root."""
+        from lionagi._class_registry import get_class_objects
+
+        with pytest.raises(ValueError, match="not located under the package root"):
+            get_class_objects("/tmp/some_random_file_outside_package.py")
+
+    def test_file_registry_fallback_class_not_in_module_raises_value_error(self):
+        """get_class() must raise ValueError when the file-registry entry exists
+        but the named class is not actually exported by that module.
+
+        This simulates a stale registry entry pointing to the wrong file.
+        """
         from lionagi._class_registry import (
             LION_CLASS_FILE_REGISTRY,
             LION_CLASS_REGISTRY,
             get_class,
         )
 
-        # Find a class that is in FILE_REGISTRY but not yet in LION_CLASS_REGISTRY
-        # by temporarily removing it from the in-memory registry.
-        # We use 'Node' which is guaranteed to be in FILE_REGISTRY.
-        target = "Node"
-        assert target in LION_CLASS_FILE_REGISTRY, (
-            "Prerequisite: Node must be in LION_CLASS_FILE_REGISTRY"
-        )
+        # Inject a fake entry: 'Element' file path but ask for a class that
+        # definitely isn't in element.py.
+        fake_class_name = "_NonExistentClassInElementPy_xyz"
+        LION_CLASS_FILE_REGISTRY[fake_class_name] = LION_CLASS_FILE_REGISTRY["Element"]
+        # Ensure it's not in the in-memory registry either.
+        LION_CLASS_REGISTRY.pop(fake_class_name, None)
 
-        # Remove from in-memory registry so get_class falls through to file path.
-        # (The autouse _registry_snapshot fixture will restore this automatically.)
-        keys_to_remove = [k for k in LION_CLASS_REGISTRY if k.endswith(f".{target}") or k == target]
-        for k in keys_to_remove:
-            del LION_CLASS_REGISTRY[k]
-
-        # Also remove bare name if present.
-        LION_CLASS_REGISTRY.pop(target, None)
-
-        # This should succeed if the fallback worked.  Because modules use
-        # relative imports, it actually raises ValueError wrapping ImportError.
-        # The xfail marks that as the *expected* failure — it passes when broken,
-        # fails (xpass) if someone fixes the underlying importlib loading logic.
-        # A *different* ValueError would fail the inner message assertion with
-        # AssertionError, which raises=ValueError does not absorb — keeping the
-        # xfail pinned to exactly this latent bug.
-        try:
-            result = get_class(target)
-        except ValueError as exc:
-            assert "attempted relative import" in str(exc)
-            raise
-        assert isinstance(result, type)  # only reached if fallback is fixed
+        with pytest.raises(ValueError, match="Unable to find class"):
+            get_class(fake_class_name)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`get_class_objects()` loaded files via `spec_from_file_location("module.name", file_path)` — a context-less spec name. Executing any real lionagi file (e.g. `protocols/graph/node.py`) then raised `ImportError: attempted relative import beyond top-level package` because its `from ..x import Y` had no parent package. The entire file-registry fallback was dead for every real class.

**Fix**: derive the dotted module name from `file_path` relative to the package root and use `importlib.import_module(dotted_name)` — proper package context, relative imports resolve, idempotent via `sys.modules`, same class identity. (Issue's suggested approach; sound against the code.)

Edge cases: path outside package root → clear `ValueError`; class name absent from the imported module → `ValueError` wrapping the `KeyError`.

## Tests

The formerly-XFAIL `TestGetClassFileRegistryFallback` is replaced with 4 strict passing tests (fallback resolves a relative-import class; identity check; path-outside-package error; class-not-in-module error). `tests/test_class_registry.py`: 61 passed, 0 xfail. Broader registry/serialization run: 513 passed (33 skips are pre-existing optional-extras gates, unchanged by this diff).

Closes #1407.

🤖 Generated with [Claude Code](https://claude.com/claude-code)