### PR TITLE
feat(cli): persist engine-run signals for live Studio streaming

### DIFF
--- a/lionagi/cli/engine.py
+++ b/lionagi/cli/engine.py
@@ -225,12 +225,31 @@ async def _do_engine_run(args: argparse.Namespace) -> int:
 
     # Open DB for persistence.
     db = None
+    # session_id for signal persistence: the engine run creates its own
+    # sessions row (run_id) so Studio can stream signals live.  The
+    # engine_runs.session_id column still carries the user-supplied
+    # --session-id for cross-linking to an existing session.
+    signal_session_id: str | None = None
     if not args.no_persist:
         try:
             from lionagi.state.db import StateDB
 
             db = StateDB()
             await db.open()
+            # Create a sessions row so session_signals FK is satisfied.
+            prog_id = f"{run_id}-prog"
+            await db.create_progression(prog_id)
+            await db.create_session(
+                {
+                    "id": run_id,
+                    "created_at": started_at,
+                    "progression_id": prog_id,
+                    "name": f"engine:{kind}",
+                    "status": "running",
+                    "invocation_kind": None,
+                }
+            )
+            signal_session_id = run_id
             await db.insert_engine_run(
                 run_id=run_id,
                 kind=kind,
@@ -241,6 +260,7 @@ async def _do_engine_run(args: argparse.Namespace) -> int:
         except Exception as exc:  # noqa: BLE001
             warn(f"could not open StateDB for persistence: {exc}")
             db = None
+            signal_session_id = None
 
     # Import engine class lazily (no circular import; heavy deps stay unloaded
     # until actually needed).
@@ -249,7 +269,9 @@ async def _do_engine_run(args: argparse.Namespace) -> int:
         engine_class = _import_engine_class(module, cls_name)
     except Exception as exc:
         log_error(f"failed to import engine class for kind {kind!r}: {exc}")
-        await _maybe_update_db(db, run_id, "failed", error=str(exc))
+        await _maybe_update_db(
+            db, run_id, "failed", error=str(exc), signal_session_id=signal_session_id
+        )
         if db is not None:
             await db.close()
         return 1
@@ -269,6 +291,19 @@ async def _do_engine_run(args: argparse.Namespace) -> int:
             parts.append(f"{key}={val_str}")
         progress("  ".join(parts))
 
+    # Create a Session for signal binding, then bind persistence before running.
+    # This lets Studio poll session_signals live via GET /api/sessions/{run_id}/signals.
+    _session = None
+    if signal_session_id is not None:
+        try:
+            from lionagi.session.session import Session as _Session
+
+            _session = _Session()
+            _session.observer.bind_db_persistence(signal_session_id, db=db)
+        except Exception as exc:  # noqa: BLE001
+            warn(f"could not bind signal persistence for engine run: {exc}")
+            _session = None
+
     # Instantiate and run the engine.
     progress(f"engine[{kind}] starting  spec={spec!r}")
     result = None
@@ -278,11 +313,18 @@ async def _do_engine_run(args: argparse.Namespace) -> int:
         # CodingEngine has its own .run() signature (positional spec + keyword
         # test_cmd/workspace/export_dir); other engines use Engine.run() which
         # dispatches to _run(run, <main_arg>, **run_kwargs).
-        result = await engine.run(spec, on_event=on_event, **run_kwargs)
+        result = await engine.run(spec, on_event=on_event, session=_session, **run_kwargs)
     except Exception as exc:
         log_error(f"engine[{kind}] failed: {exc}")
         ended_at = time.time()
-        await _maybe_update_db(db, run_id, "failed", ended_at=ended_at, error=str(exc))
+        await _maybe_update_db(
+            db,
+            run_id,
+            "failed",
+            ended_at=ended_at,
+            error=str(exc),
+            signal_session_id=signal_session_id,
+        )
         if db is not None:
             await db.close()
         return 1
@@ -300,6 +342,7 @@ async def _do_engine_run(args: argparse.Namespace) -> int:
             "cancelled",
             ended_at=ended_at,
             error=f"{type(exc).__name__}: {exc}",
+            signal_session_id=signal_session_id,
         )
         if db is not None:
             await db.close()
@@ -345,6 +388,7 @@ async def _do_engine_run(args: argparse.Namespace) -> int:
         ended_at=ended_at,
         export_dir=export_dir_for_db,
         error=emission_error,
+        signal_session_id=signal_session_id,
     )
     if db is not None:
         await db.close()
@@ -359,6 +403,7 @@ async def _maybe_update_db(
     ended_at: float | None = None,
     export_dir: str | None = None,
     error: str | None = None,
+    signal_session_id: str | None = None,
 ) -> None:
     """Update the engine run row if a DB handle is open; swallow errors."""
     if db is None:
@@ -373,3 +418,25 @@ async def _maybe_update_db(
         )
     except Exception as exc:  # noqa: BLE001
         warn(f"could not update engine run record in StateDB: {exc}")
+    # Mirror terminal status to the sessions row so Studio's SSE generator
+    # knows the stream is done (same done-detection logic as agent/flow runs).
+    if signal_session_id is not None and status in ("completed", "failed", "cancelled"):
+        _session_status = "completed" if status == "completed" else status
+        try:
+            from lionagi.state.reasons import RunReasons
+
+            _reason = (
+                RunReasons.COMPLETED_OK
+                if status == "completed"
+                else RunReasons.FAILED_EXCEPTION
+                if status == "failed"
+                else RunReasons.CANCELLED_SYSTEM
+            )
+            await db.update_status(
+                "session",
+                signal_session_id,
+                new_status=_session_status,
+                reason_code=_reason,
+            )
+        except Exception as exc:  # noqa: BLE001
+            warn(f"could not update engine session status in StateDB: {exc}")

--- a/lionagi/cli/engine.py
+++ b/lionagi/cli/engine.py
@@ -251,19 +251,27 @@ async def _do_engine_run(args: argparse.Namespace) -> int:
         # separately: a failure here only disables live signal streaming,
         # never the engine_runs record itself.
         try:
-            prog_id = f"{run_id}-prog"
-            await db.create_progression(prog_id)
-            await db.create_session(
-                {
-                    "id": run_id,
-                    "created_at": started_at,
-                    "progression_id": prog_id,
-                    "name": f"engine:{kind}",
-                    "status": "running",
-                    "invocation_kind": None,
-                }
-            )
-            signal_session_id = run_id
+            # create_session is INSERT OR IGNORE: a pre-existing row with this
+            # id would be silently reused, appending our signals to an
+            # unrelated session and mirroring terminal status onto it.  run_id
+            # is a fresh uuid4 so this should never happen — but never bind to
+            # a row this run did not create.
+            if await db.get_session(run_id) is not None:
+                warn(f"sessions row {run_id} already exists; skipping signal binding")
+            else:
+                prog_id = f"{run_id}-prog"
+                await db.create_progression(prog_id)
+                await db.create_session(
+                    {
+                        "id": run_id,
+                        "created_at": started_at,
+                        "progression_id": prog_id,
+                        "name": f"engine:{kind}",
+                        "status": "running",
+                        "invocation_kind": None,
+                    }
+                )
+                signal_session_id = run_id
         except Exception as exc:  # noqa: BLE001
             warn(f"could not create signal session for engine run: {exc}")
             signal_session_id = None

--- a/lionagi/cli/engine.py
+++ b/lionagi/cli/engine.py
@@ -236,7 +236,21 @@ async def _do_engine_run(args: argparse.Namespace) -> int:
 
             db = StateDB()
             await db.open()
-            # Create a sessions row so session_signals FK is satisfied.
+            await db.insert_engine_run(
+                run_id=run_id,
+                kind=kind,
+                spec_json=spec_for_db,
+                started_at=started_at,
+                session_id=args.session_id,
+            )
+        except Exception as exc:  # noqa: BLE001
+            warn(f"could not open StateDB for persistence: {exc}")
+            db = None
+    if db is not None:
+        # Create a sessions row so session_signals FK is satisfied.  Guarded
+        # separately: a failure here only disables live signal streaming,
+        # never the engine_runs record itself.
+        try:
             prog_id = f"{run_id}-prog"
             await db.create_progression(prog_id)
             await db.create_session(
@@ -250,16 +264,8 @@ async def _do_engine_run(args: argparse.Namespace) -> int:
                 }
             )
             signal_session_id = run_id
-            await db.insert_engine_run(
-                run_id=run_id,
-                kind=kind,
-                spec_json=spec_for_db,
-                started_at=started_at,
-                session_id=args.session_id,
-            )
         except Exception as exc:  # noqa: BLE001
-            warn(f"could not open StateDB for persistence: {exc}")
-            db = None
+            warn(f"could not create signal session for engine run: {exc}")
             signal_session_id = None
 
     # Import engine class lazily (no circular import; heavy deps stay unloaded

--- a/tests/cli/test_engine_cli.py
+++ b/tests/cli/test_engine_cli.py
@@ -301,6 +301,15 @@ async def test_export_dir_persisted_from_args_coding(monkeypatch, capsys):
         async def close(self):
             pass
 
+        async def create_progression(self, prog_id, collection=None):
+            pass
+
+        async def create_session(self, session):
+            pass
+
+        async def update_status(self, entity_type, entity_id, *, new_status, reason_code, **kw):
+            pass
+
         async def insert_engine_run(self, *, run_id, kind, spec_json, started_at, session_id=None):
             pass
 
@@ -356,6 +365,15 @@ async def test_export_dir_persisted_from_args_hypothesis(monkeypatch, capsys):
         async def close(self):
             pass
 
+        async def create_progression(self, prog_id, collection=None):
+            pass
+
+        async def create_session(self, session):
+            pass
+
+        async def update_status(self, entity_type, entity_id, *, new_status, reason_code, **kw):
+            pass
+
         async def insert_engine_run(self, *, run_id, kind, spec_json, started_at, session_id=None):
             pass
 
@@ -406,6 +424,15 @@ async def test_export_dir_none_when_not_passed(monkeypatch, capsys):
             pass
 
         async def close(self):
+            pass
+
+        async def create_progression(self, prog_id, collection=None):
+            pass
+
+        async def create_session(self, session):
+            pass
+
+        async def update_status(self, entity_type, entity_id, *, new_status, reason_code, **kw):
             pass
 
         async def insert_engine_run(self, *, run_id, kind, spec_json, started_at, session_id=None):
@@ -460,6 +487,15 @@ async def test_cancelled_error_marks_row_cancelled(monkeypatch):
         async def close(self):
             close_count[0] += 1
 
+        async def create_progression(self, prog_id, collection=None):
+            pass
+
+        async def create_session(self, session):
+            pass
+
+        async def update_status(self, entity_type, entity_id, *, new_status, reason_code, **kw):
+            pass
+
         async def insert_engine_run(self, *, run_id, kind, spec_json, started_at, session_id=None):
             insert_calls.append({"run_id": run_id, "kind": kind})
 
@@ -511,6 +547,15 @@ async def test_keyboard_interrupt_marks_row_cancelled(monkeypatch):
         async def close(self):
             close_count[0] += 1
 
+        async def create_progression(self, prog_id, collection=None):
+            pass
+
+        async def create_session(self, session):
+            pass
+
+        async def update_status(self, entity_type, entity_id, *, new_status, reason_code, **kw):
+            pass
+
         async def insert_engine_run(self, *, run_id, kind, spec_json, started_at, session_id=None):
             pass
 
@@ -560,6 +605,15 @@ async def test_db_insert_called_on_success(monkeypatch, capsys):
             pass
 
         async def close(self):
+            pass
+
+        async def create_progression(self, prog_id, collection=None):
+            pass
+
+        async def create_session(self, session):
+            pass
+
+        async def update_status(self, entity_type, entity_id, *, new_status, reason_code, **kw):
             pass
 
         async def insert_engine_run(self, *, run_id, kind, spec_json, started_at, session_id=None):
@@ -645,6 +699,15 @@ async def test_import_failure_closes_db(monkeypatch):
 
         async def close(self):
             close_count[0] += 1
+
+        async def create_progression(self, prog_id, collection=None):
+            pass
+
+        async def create_session(self, session):
+            pass
+
+        async def update_status(self, entity_type, entity_id, *, new_status, reason_code, **kw):
+            pass
 
         async def insert_engine_run(self, *, run_id, kind, spec_json, started_at, session_id=None):
             pass
@@ -743,3 +806,61 @@ def test_main_routes_engine_command(monkeypatch):
     assert rc == 0
     assert len(run_engine_calls) == 1
     assert run_engine_calls[0].command == "engine"
+
+
+# ---------------------------------------------------------------------------
+# Signal persistence integration: engine run → session_signals table
+# ---------------------------------------------------------------------------
+
+
+async def test_engine_run_signals_land_in_session_signals(tmp_path):
+    """Engine session observer emits signals that land in session_signals.
+
+    Mirrors test_bind_db_persistence_production_path from test_signals_sse.py
+    but exercises the engine-run binding path: create sessions row with
+    run_id, bind persistence, emit signals via the session observer, confirm
+    rows appear in session_signals with correct kinds and monotone seq.
+    """
+    aiosqlite = pytest.importorskip("aiosqlite", reason="aiosqlite not installed")  # noqa: F841
+
+    from lionagi.session.session import Session
+    from lionagi.session.signal import NodeCompleted, NodeStarted, RunStart
+    from lionagi.state.db import StateDB
+
+    db_path = tmp_path / "state.db"
+    run_id = "engine-sig-test-001"
+
+    async with StateDB(db_path) as db:
+        # Replicate the sessions/progressions row creation done by _do_engine_run.
+        prog_id = f"{run_id}-prog"
+        await db.create_progression(prog_id)
+        await db.create_session(
+            {
+                "id": run_id,
+                "created_at": 100.0,
+                "progression_id": prog_id,
+                "name": "engine:research",
+                "status": "running",
+                "invocation_kind": None,
+            }
+        )
+
+        # Bind persistence the same way _do_engine_run does.
+        session = Session()
+        session.observer.bind_db_persistence(run_id, db=db)
+
+        # Emit signals the way the engine's EngineRun.emit() would.
+        await session.observer.emit(RunStart())
+        await session.observer.emit(NodeStarted(op_id="node-1", name="step1"))
+        await session.observer.emit(NodeCompleted(op_id="node-1", name="step1", elapsed=0.3))
+
+        rows = await db.get_session_signals_after(run_id, 0)
+
+    assert len(rows) == 3
+    assert rows[0]["kind"] == "RunStart"
+    assert rows[1]["kind"] == "NodeStarted"
+    assert rows[2]["kind"] == "NodeCompleted"
+    assert rows[1]["op_id"] == "node-1"
+    assert rows[2]["payload"]["elapsed"] == pytest.approx(0.3)
+    # seq must be monotone starting at 1.
+    assert [r["seq"] for r in rows] == [1, 2, 3]

--- a/tests/cli/test_engine_cli.py
+++ b/tests/cli/test_engine_cli.py
@@ -301,6 +301,9 @@ async def test_export_dir_persisted_from_args_coding(monkeypatch, capsys):
         async def close(self):
             pass
 
+        async def get_session(self, session_id):
+            return None
+
         async def create_progression(self, prog_id, collection=None):
             pass
 
@@ -365,6 +368,9 @@ async def test_export_dir_persisted_from_args_hypothesis(monkeypatch, capsys):
         async def close(self):
             pass
 
+        async def get_session(self, session_id):
+            return None
+
         async def create_progression(self, prog_id, collection=None):
             pass
 
@@ -425,6 +431,9 @@ async def test_export_dir_none_when_not_passed(monkeypatch, capsys):
 
         async def close(self):
             pass
+
+        async def get_session(self, session_id):
+            return None
 
         async def create_progression(self, prog_id, collection=None):
             pass
@@ -487,6 +496,9 @@ async def test_cancelled_error_marks_row_cancelled(monkeypatch):
         async def close(self):
             close_count[0] += 1
 
+        async def get_session(self, session_id):
+            return None
+
         async def create_progression(self, prog_id, collection=None):
             pass
 
@@ -547,6 +559,9 @@ async def test_keyboard_interrupt_marks_row_cancelled(monkeypatch):
         async def close(self):
             close_count[0] += 1
 
+        async def get_session(self, session_id):
+            return None
+
         async def create_progression(self, prog_id, collection=None):
             pass
 
@@ -606,6 +621,9 @@ async def test_db_insert_called_on_success(monkeypatch, capsys):
 
         async def close(self):
             pass
+
+        async def get_session(self, session_id):
+            return None
 
         async def create_progression(self, prog_id, collection=None):
             pass
@@ -699,6 +717,9 @@ async def test_import_failure_closes_db(monkeypatch):
 
         async def close(self):
             close_count[0] += 1
+
+        async def get_session(self, session_id):
+            return None
 
         async def create_progression(self, prog_id, collection=None):
             pass
@@ -864,3 +885,84 @@ async def test_engine_run_signals_land_in_session_signals(tmp_path):
     assert rows[2]["payload"]["elapsed"] == pytest.approx(0.3)
     # seq must be monotone starting at 1.
     assert [r["seq"] for r in rows] == [1, 2, 3]
+
+
+async def test_engine_run_skips_signal_binding_on_session_id_collision(
+    monkeypatch, tmp_path, capsys
+):
+    """A pre-existing sessions row with the run's id must not be hijacked.
+
+    create_session is INSERT OR IGNORE, so _do_engine_run checks for an
+    existing row first and disables signal binding instead of appending
+    signals to (and terminal-updating) a session this run did not create.
+    """
+    pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
+
+    import functools
+    import uuid as uuid_mod
+
+    import lionagi.cli._logging as log_mod
+    import lionagi.cli.engine as engine_mod
+    import lionagi.state.db as db_mod
+    from lionagi.state.db import StateDB
+
+    monkeypatch.setattr(log_mod, "progress", lambda *a, **kw: None)
+    # warn is imported into engine.py's namespace; patch it there.
+    warns: list[str] = []
+    monkeypatch.setattr(engine_mod, "warn", warns.append)
+
+    db_path = tmp_path / "state.db"
+    fixed = uuid_mod.uuid4()
+    monkeypatch.setattr(engine_mod.uuid, "uuid4", lambda: fixed)
+    run_id = fixed.hex
+
+    # Pre-seed an unrelated, already-terminal session under the colliding id.
+    async with StateDB(db_path) as db:
+        await db.create_progression("other-prog")
+        await db.create_session(
+            {
+                "id": run_id,
+                "created_at": 50.0,
+                "progression_id": "other-prog",
+                "name": "unrelated-session",
+                "status": "completed",
+                "invocation_kind": None,
+            }
+        )
+
+    monkeypatch.setattr(db_mod, "StateDB", functools.partial(StateDB, db_path))
+
+    captured: dict = {}
+
+    async def _mock_run(spec, *, on_event=None, session=None, **kwargs):
+        captured["session"] = session
+        if session is not None:
+            from lionagi.session.signal import NodeStarted
+
+            await session.observer.emit(NodeStarted(op_id="n1", name="step"))
+        return "done"
+
+    mock_engine = MagicMock()
+    mock_engine.run = _mock_run
+    monkeypatch.setattr(
+        engine_mod, "_import_engine_class", lambda m, n: MagicMock(return_value=mock_engine)
+    )
+
+    args = _build_args(kind="research", spec="GQA", no_persist=False)
+    rc = await engine_mod._do_engine_run(args)
+    assert rc == 0
+
+    # Collision detected → no session passed to the engine, warn emitted.
+    assert captured["session"] is None
+    assert any("already exists" in w for w in warns)
+
+    async with StateDB(db_path) as db:
+        # The unrelated row is untouched (status NOT mirrored).
+        row = await db.get_session(run_id)
+        assert row["name"] == "unrelated-session"
+        assert row["status"] == "completed"
+        # No signals were appended under the hijacked id.
+        assert await db.get_session_signals_after(run_id, 0) == []
+        # The engine_runs record itself still persisted.
+        runs = await db.get_engine_run(run_id)
+        assert runs is not None


### PR DESCRIPTION
## Summary

`li engine run` now creates its own `sessions` row (keyed by the run id) and binds
`bind_db_persistence` on a fresh `Session` before running the engine, so every signal
the engine emits lands in `session_signals` — Studio can stream engine runs live via
the existing `GET /api/sessions/{run_id}/signals` SSE generator (gap #1 from
DESIGN-CANVAS.md §6).

- The sessions row is created in its own guarded step: a failure there only disables
  live signal streaming, never the `engine_runs` record itself.
- Terminal status (`completed`/`failed`/`cancelled`) is mirrored to the sessions row
  with the matching `RunReasons` code so the SSE generator's done-detection fires.
- `engine_runs.session_id` still carries the user-supplied `--session-id` for
  cross-linking; the signal session is always the run id.

## Verification

- Full related suites in worktree: `tests/cli/test_engine_cli.py`,
  `test_engine_emission_diagnostics.py`, `tests/apps_studio_server/test_engine_runs_api.py`,
  `test_signals_sse.py`, `tests/state/test_engine_runs_db.py`, `tests/engines/` —
  **231 passed, 14 skipped**.
- New integration test drives `bind_db_persistence` against a real StateDB and asserts
  `session_signals` rows (kinds, op_id, payload, monotone seq).

🤖 Generated with [Claude Code](https://claude.com/claude-code)