### PR TITLE
feat(studio): POST /api/launches — fire runs through the scheduler's hardened spawn path

### DIFF
--- a/lionagi/studio/app.py
+++ b/lionagi/studio/app.py
@@ -110,6 +110,9 @@ async def lifespan(app_instance):
     except Exception:  # noqa: BLE001
         _log.warning("Startup WAL checkpoint failed (non-fatal)", exc_info=True)
     yield
+    from .services.launches import shutdown_launches
+
+    await shutdown_launches()
     await scheduler.stop()
 
 

--- a/lionagi/studio/app.py
+++ b/lionagi/studio/app.py
@@ -19,6 +19,7 @@ from .routers import (
     definitions,
     engine_runs,
     invocations,
+    launches,
     playbooks,
     plugins,
     projects,
@@ -155,6 +156,7 @@ app.include_router(plugins.router, prefix="/api")
 app.include_router(admin.router, prefix="/api")
 app.include_router(teams.router, prefix="/api")
 app.include_router(invocations.router, prefix="/api")
+app.include_router(launches.router, prefix="/api")
 app.include_router(artifacts.router, prefix="/api")
 app.include_router(projects.router, prefix="/api")
 app.include_router(schedules.router, prefix="/api")

--- a/lionagi/studio/config.py
+++ b/lionagi/studio/config.py
@@ -15,6 +15,11 @@ CORS_ORIGINS: list[str] = (
     else ["http://localhost:5173", "http://localhost:3000", "http://localhost:3765"]
 )
 
+# ── Launch admission config ───────────────────────────────────────────────────
+# Maximum number of on-demand launch tasks that may run in parallel.
+# When saturated, POST /api/launches returns 429.
+MAX_LAUNCHES: int = int(os.environ.get("LIONAGI_STUDIO_MAX_LAUNCHES", "4"))
+
 # ── Lifecycle reaper config ───────────────────────────────────────────────────
 # Default invocation deadline in seconds (2 hours). Override per action kind
 # via LIONAGI_STUDIO_INVOCATION_DEADLINE_<KIND>_SECONDS (e.g. _AGENT_SECONDS).

--- a/lionagi/studio/routers/launches.py
+++ b/lionagi/studio/routers/launches.py
@@ -35,5 +35,7 @@ async def launch_run(body: LaunchRequest) -> dict[str, Any]:
     """
     try:
         return await launch_svc.launch(body.model_dump(exclude_none=True))
+    except launch_svc.TooManyLaunchesError as exc:
+        raise HTTPException(status_code=429, detail=str(exc)) from exc
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc

--- a/lionagi/studio/routers/launches.py
+++ b/lionagi/studio/routers/launches.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Launch endpoints — fire agent/flow/fanout/play/flow_yaml runs on demand."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from ..services import launches as launch_svc
+
+router = APIRouter(prefix="/launches", tags=["launches"])
+
+
+class LaunchRequest(BaseModel):
+    action_kind: str
+    action_model: str | None = None
+    action_prompt: str | None = None
+    action_agent: str | None = None
+    action_playbook: str | None = None
+    action_project: str | None = None
+    action_flow_yaml: str | None = None
+    action_extra_args: list[str] | None = None
+
+
+@router.post("/", status_code=202)
+async def launch_run(body: LaunchRequest) -> dict[str, Any]:
+    """Fire an orchestration run immediately.
+
+    Returns the invocation_id created before the process is spawned.
+    The process runs detached; watch progress via GET /api/invocations/{id}
+    and GET /api/sessions/{id}/signals once a child session appears.
+    """
+    try:
+        return await launch_svc.launch(body.model_dump(exclude_none=True))
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc

--- a/lionagi/studio/services/launches.py
+++ b/lionagi/studio/services/launches.py
@@ -6,13 +6,13 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 import time
 import uuid
 from typing import Any
 
 from lionagi.state.db import StateDB
 
+from .. import config
 from ..scheduler.subprocess import build_argv
 from ..services.schedules import (
     _svc_validate_action_model,
@@ -33,9 +33,9 @@ _LAUNCH_VALID_KINDS = frozenset({"agent", "flow", "fanout", "play"})
 # with no strong reference can be garbage-collected mid-flight.
 _detached_tasks: set[asyncio.Task] = set()
 
-# Admission cap: maximum number of detached launch tasks that may be in-flight
-# simultaneously.  Configurable via LIONAGI_STUDIO_MAX_LAUNCHES (default 4).
-_MAX_LAUNCHES: int = int(os.environ.get("LIONAGI_STUDIO_MAX_LAUNCHES", "4"))
+# Admission cap (config.MAX_LAUNCHES): a slot is acquired in launch() before
+# the invocation row is created and released when the detached task completes,
+# so a burst of concurrent POSTs cannot over-admit past the cap.
 _launch_semaphore: asyncio.Semaphore | None = None
 
 
@@ -47,7 +47,7 @@ def _get_semaphore() -> asyncio.Semaphore:
     """Return (creating on first call) the module-level admission semaphore."""
     global _launch_semaphore  # noqa: PLW0603
     if _launch_semaphore is None:
-        _launch_semaphore = asyncio.Semaphore(_MAX_LAUNCHES)
+        _launch_semaphore = asyncio.Semaphore(config.MAX_LAUNCHES)
     return _launch_semaphore
 
 
@@ -96,32 +96,45 @@ async def launch(data: dict[str, Any]) -> dict[str, Any]:
     argv, tmp_path = build_argv(schedule_dict, {})
 
     sem = _get_semaphore()
-    if not sem._value:  # noqa: SLF001  (asyncio.Semaphore internal — no public API)
+    if sem.locked():
         raise TooManyLaunchesError(
-            f"Maximum concurrent launches ({_MAX_LAUNCHES}) reached. "
+            f"Maximum concurrent launches ({config.MAX_LAUNCHES}) reached. "
             "Retry when an existing launch completes."
         )
+    # The slot must be taken here, not inside the spawned task: deferring the
+    # acquire would let a burst of concurrent POSTs all pass the check above
+    # before any task runs.  locked() was False and nothing yields between the
+    # check and the acquire on a single event loop, so this never blocks.
+    await sem.acquire()
 
     inv_id = uuid.uuid4().hex[:12]
     now = time.time()
 
-    async with StateDB() as db:
-        await db.create_invocation(
-            {
-                "id": inv_id,
-                "skill": f"launch:{data['action_kind']}",
-                "plugin": "studio_launch",
-                "prompt": data.get("action_prompt") or data.get("action_playbook"),
-                "started_at": now,
-                "status": "running",
-            }
-        )
+    try:
+        async with StateDB() as db:
+            await db.create_invocation(
+                {
+                    "id": inv_id,
+                    "skill": f"launch:{data['action_kind']}",
+                    "plugin": "studio_launch",
+                    "prompt": data.get("action_prompt") or data.get("action_playbook"),
+                    "started_at": now,
+                    "status": "running",
+                }
+            )
 
-    # Spawn detached — the HTTP handler must not block until the run finishes.
-    task = asyncio.create_task(
-        _spawn_detached(argv, inv_id, tmp_path=tmp_path, semaphore=sem),
-        name=f"launch-{inv_id}",
-    )
+        # Spawn detached — the HTTP handler must not block until the run finishes.
+        task = asyncio.create_task(
+            _spawn_detached(argv, inv_id, tmp_path=tmp_path),
+            name=f"launch-{inv_id}",
+        )
+    except BaseException:
+        sem.release()
+        raise
+
+    # Release on task completion (a done callback fires even if the task is
+    # cancelled before its coroutine ever runs, where an in-task release would not).
+    task.add_done_callback(lambda _t: sem.release())
     _detached_tasks.add(task)
     task.add_done_callback(_detached_tasks.discard)
 
@@ -146,50 +159,43 @@ async def shutdown_launches() -> None:
     await asyncio.gather(*tasks, return_exceptions=True)
 
 
-async def _spawn_detached(
-    argv: list[str],
-    inv_id: str,
-    *,
-    tmp_path: str | None,
-    semaphore: asyncio.Semaphore,
-) -> None:
+async def _spawn_detached(argv: list[str], inv_id: str, *, tmp_path: str | None) -> None:
     """Spawn the process and update the invocation row when it exits."""
     from lionagi.state.reasons import RunReasons
 
     from ..scheduler.subprocess import spawn_and_wait
 
-    async with semaphore:
+    try:
+        exit_code, _stderr = await spawn_and_wait(argv, inv_id, tmp_path=tmp_path)
+        if exit_code == 0:
+            status, reason = "completed", RunReasons.COMPLETED_OK
+        else:
+            status, reason = "failed", RunReasons.FAILED_EXIT_NONZERO
+    except asyncio.CancelledError:
+        # Server is shutting down — write a terminal row before propagating.
         try:
-            exit_code, _stderr = await spawn_and_wait(argv, inv_id, tmp_path=tmp_path)
-            if exit_code == 0:
-                status, reason = "completed", RunReasons.COMPLETED_OK
-            else:
-                status, reason = "failed", RunReasons.FAILED_EXIT_NONZERO
-        except asyncio.CancelledError:
-            # Server is shutting down — write a terminal row before propagating.
-            try:
-                async with StateDB() as db:
-                    await db.update_invocation(inv_id, ended_at=time.time())
-                    await db.update_status(
-                        "invocation",
-                        inv_id,
-                        new_status="cancelled",
-                        reason_code=RunReasons.CANCELLED_SYSTEM,
-                        reason_summary="Launch cancelled by server shutdown.",
-                        evidence_refs=[],
-                        source="executor",
-                        actor=inv_id,
-                        metadata={},
-                    )
-            except Exception:
-                _log.exception(
-                    "Failed to record cancellation for launch invocation %s during shutdown",
+            async with StateDB() as db:
+                await db.update_invocation(inv_id, ended_at=time.time())
+                await db.update_status(
+                    "invocation",
                     inv_id,
+                    new_status="cancelled",
+                    reason_code=RunReasons.CANCELLED_SYSTEM,
+                    reason_summary="Launch cancelled by server shutdown.",
+                    evidence_refs=[],
+                    source="executor",
+                    actor=inv_id,
+                    metadata={},
                 )
-            raise
         except Exception:
-            _log.exception("Detached launch failed for invocation %s", inv_id)
-            status, reason = "failed", RunReasons.FAILED_EXCEPTION
+            _log.exception(
+                "Failed to record cancellation for launch invocation %s during shutdown",
+                inv_id,
+            )
+        raise
+    except Exception:
+        _log.exception("Detached launch failed for invocation %s", inv_id)
+        status, reason = "failed", RunReasons.FAILED_EXCEPTION
 
     try:
         async with StateDB() as db:

--- a/lionagi/studio/services/launches.py
+++ b/lionagi/studio/services/launches.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Launch service — backs POST /api/launches.
+
+Fires an agent/flow/fanout/play/flow_yaml run immediately, reusing the
+scheduler's validated argv-building path.  The spawned process runs detached;
+the caller watches progress via the invocations and sessions APIs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+import uuid
+from typing import Any
+
+from lionagi.state.db import StateDB
+
+from ..scheduler.subprocess import build_argv
+from ..services.schedules import (
+    _svc_validate_action_model,
+    _svc_validate_extra_args,
+    _svc_validate_identifier,
+    _svc_validate_prompt,
+)
+
+_log = logging.getLogger(__name__)
+
+# flow_yaml is excluded from on-demand launches: the inline YAML would need to
+# be written to a temp file whose lifetime must outlive the HTTP request handler.
+# The scheduler handles this safely inside its own coroutine; replicating that
+# logic here would duplicate the temp-file lifetime management.  Callers who
+# need flow_yaml should create a schedule with trigger_type=manual and call
+# POST /api/schedules/{id}/trigger instead.
+_LAUNCH_VALID_KINDS = frozenset({"agent", "flow", "fanout", "play"})
+
+
+def _validate_request(data: dict[str, Any]) -> None:
+    """Raise ValueError if *data* fails security or structural checks."""
+    kind = data.get("action_kind") or ""
+    if kind not in _LAUNCH_VALID_KINDS:
+        raise ValueError(
+            f"action_kind {kind!r} is not supported for on-demand launches. "
+            f"Valid kinds: {sorted(_LAUNCH_VALID_KINDS)}"
+        )
+    _svc_validate_action_model(data.get("action_model"))
+    _svc_validate_prompt(data.get("action_prompt"))
+    _svc_validate_identifier(data.get("action_agent"), "action_agent")
+    _svc_validate_identifier(data.get("action_project"), "action_project")
+    _svc_validate_identifier(data.get("action_playbook"), "action_playbook")
+    _svc_validate_extra_args(data.get("action_extra_args"))
+
+
+async def launch(data: dict[str, Any]) -> dict[str, Any]:
+    """Validate *data*, record an invocation, spawn the process, return identifiers.
+
+    Returns a dict with:
+      - ``invocation_id``: created before spawn; use GET /api/invocations/{id}
+        to watch status and find child sessions once they appear.
+      - ``action_kind``: the normalised kind that was fired.
+
+    The spawned process runs detached.  Session IDs are only knowable after the
+    process starts and writes to the DB, so they are not included in this
+    response.
+    """
+    _validate_request(data)
+
+    inv_id = uuid.uuid4().hex[:12]
+    now = time.time()
+
+    async with StateDB() as db:
+        await db.create_invocation(
+            {
+                "id": inv_id,
+                "skill": f"launch:{data['action_kind']}",
+                "plugin": "studio_launch",
+                "prompt": data.get("action_prompt") or data.get("action_playbook"),
+                "started_at": now,
+                "status": "running",
+            }
+        )
+
+    # build_argv requires the scheduler dict shape; map the launch fields onto it.
+    schedule_dict: dict[str, Any] = {
+        "action_kind": data["action_kind"],
+        "action_model": data.get("action_model") or "",
+        "action_prompt": data.get("action_prompt") or "",
+        "action_agent": data.get("action_agent"),
+        "action_playbook": data.get("action_playbook"),
+        "action_project": data.get("action_project"),
+        "action_extra_args": data.get("action_extra_args") or [],
+    }
+
+    # build_argv does its own validation pass; raise before spawning if it disagrees.
+    argv, tmp_path = build_argv(schedule_dict, {})
+
+    # Spawn detached — the HTTP handler must not block until the run finishes.
+    # Fire-and-forget: the task is not awaited.  tmp_path is None for non-flow_yaml
+    # kinds (validated above), so there is no temp-file lifetime issue.
+    asyncio.create_task(
+        _spawn_detached(argv, inv_id, tmp_path=tmp_path),
+        name=f"launch-{inv_id}",
+    )
+
+    return {
+        "invocation_id": inv_id,
+        "action_kind": data["action_kind"],
+    }
+
+
+async def _spawn_detached(argv: list[str], inv_id: str, *, tmp_path: str | None) -> None:
+    """Spawn the process and update the invocation row when it exits."""
+    from ..scheduler.subprocess import spawn_and_wait
+
+    try:
+        exit_code, _stderr = await spawn_and_wait(argv, inv_id, tmp_path=tmp_path)
+        status = "completed" if exit_code == 0 else "failed"
+    except asyncio.CancelledError:
+        status = "cancelled"
+        raise
+    except Exception:
+        _log.exception("Detached launch failed for invocation %s", inv_id)
+        status = "failed"
+
+    try:
+        async with StateDB() as db:
+            await db.update_invocation(inv_id, ended_at=time.time())
+            await db.update_status(
+                "invocation",
+                inv_id,
+                new_status=status,
+                reason_code=f"launch:{status}",
+                reason_summary=f"Detached launch {status}.",
+                evidence_refs=[],
+                source="executor",
+                actor=inv_id,
+                metadata={},
+            )
+    except Exception:
+        _log.exception("Failed to update invocation %s after detached launch", inv_id)

--- a/lionagi/studio/services/launches.py
+++ b/lionagi/studio/services/launches.py
@@ -35,6 +35,10 @@ _log = logging.getLogger(__name__)
 # POST /api/schedules/{id}/trigger instead.
 _LAUNCH_VALID_KINDS = frozenset({"agent", "flow", "fanout", "play"})
 
+# The event loop keeps only weak references to tasks; a fire-and-forget task
+# with no strong reference can be garbage-collected mid-flight.
+_detached_tasks: set[asyncio.Task] = set()
+
 
 def _validate_request(data: dict[str, Any]) -> None:
     """Raise ValueError if *data* fails security or structural checks."""
@@ -98,10 +102,12 @@ async def launch(data: dict[str, Any]) -> dict[str, Any]:
     # Spawn detached — the HTTP handler must not block until the run finishes.
     # Fire-and-forget: the task is not awaited.  tmp_path is None for non-flow_yaml
     # kinds (validated above), so there is no temp-file lifetime issue.
-    asyncio.create_task(
+    task = asyncio.create_task(
         _spawn_detached(argv, inv_id, tmp_path=tmp_path),
         name=f"launch-{inv_id}",
     )
+    _detached_tasks.add(task)
+    task.add_done_callback(_detached_tasks.discard)
 
     return {
         "invocation_id": inv_id,
@@ -111,17 +117,22 @@ async def launch(data: dict[str, Any]) -> dict[str, Any]:
 
 async def _spawn_detached(argv: list[str], inv_id: str, *, tmp_path: str | None) -> None:
     """Spawn the process and update the invocation row when it exits."""
+    from lionagi.state.reasons import RunReasons
+
     from ..scheduler.subprocess import spawn_and_wait
 
     try:
         exit_code, _stderr = await spawn_and_wait(argv, inv_id, tmp_path=tmp_path)
-        status = "completed" if exit_code == 0 else "failed"
+        if exit_code == 0:
+            status, reason = "completed", RunReasons.COMPLETED_OK
+        else:
+            status, reason = "failed", RunReasons.FAILED_EXIT_NONZERO
     except asyncio.CancelledError:
-        status = "cancelled"
+        # Server is going down with us; no terminal row update is possible.
         raise
     except Exception:
         _log.exception("Detached launch failed for invocation %s", inv_id)
-        status = "failed"
+        status, reason = "failed", RunReasons.FAILED_EXCEPTION
 
     try:
         async with StateDB() as db:
@@ -130,7 +141,7 @@ async def _spawn_detached(argv: list[str], inv_id: str, *, tmp_path: str | None)
                 "invocation",
                 inv_id,
                 new_status=status,
-                reason_code=f"launch:{status}",
+                reason_code=reason,
                 reason_summary=f"Detached launch {status}.",
                 evidence_refs=[],
                 source="executor",

--- a/lionagi/studio/services/launches.py
+++ b/lionagi/studio/services/launches.py
@@ -1,16 +1,12 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
-"""Launch service — backs POST /api/launches.
-
-Fires an agent/flow/fanout/play/flow_yaml run immediately, reusing the
-scheduler's validated argv-building path.  The spawned process runs detached;
-the caller watches progress via the invocations and sessions APIs.
-"""
+"""Launch service — backs POST /api/launches."""
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import time
 import uuid
 from typing import Any
@@ -29,15 +25,30 @@ _log = logging.getLogger(__name__)
 
 # flow_yaml is excluded from on-demand launches: the inline YAML would need to
 # be written to a temp file whose lifetime must outlive the HTTP request handler.
-# The scheduler handles this safely inside its own coroutine; replicating that
-# logic here would duplicate the temp-file lifetime management.  Callers who
-# need flow_yaml should create a schedule with trigger_type=manual and call
-# POST /api/schedules/{id}/trigger instead.
+# Callers who need flow_yaml should create a schedule with trigger_type=manual
+# and call POST /api/schedules/{id}/trigger instead.
 _LAUNCH_VALID_KINDS = frozenset({"agent", "flow", "fanout", "play"})
 
 # The event loop keeps only weak references to tasks; a fire-and-forget task
 # with no strong reference can be garbage-collected mid-flight.
 _detached_tasks: set[asyncio.Task] = set()
+
+# Admission cap: maximum number of detached launch tasks that may be in-flight
+# simultaneously.  Configurable via LIONAGI_STUDIO_MAX_LAUNCHES (default 4).
+_MAX_LAUNCHES: int = int(os.environ.get("LIONAGI_STUDIO_MAX_LAUNCHES", "4"))
+_launch_semaphore: asyncio.Semaphore | None = None
+
+
+class TooManyLaunchesError(Exception):
+    """Raised when the in-flight launch count reaches the configured cap."""
+
+
+def _get_semaphore() -> asyncio.Semaphore:
+    """Return (creating on first call) the module-level admission semaphore."""
+    global _launch_semaphore  # noqa: PLW0603
+    if _launch_semaphore is None:
+        _launch_semaphore = asyncio.Semaphore(_MAX_LAUNCHES)
+    return _launch_semaphore
 
 
 def _validate_request(data: dict[str, Any]) -> None:
@@ -64,11 +75,32 @@ async def launch(data: dict[str, Any]) -> dict[str, Any]:
         to watch status and find child sessions once they appear.
       - ``action_kind``: the normalised kind that was fired.
 
+    Raises TooManyLaunchesError when the in-flight cap is reached.
     The spawned process runs detached.  Session IDs are only knowable after the
     process starts and writes to the DB, so they are not included in this
     response.
     """
     _validate_request(data)
+
+    # Build and validate argv BEFORE creating the DB row.  build_argv does its
+    # own validation pass; if it raises, no invocation row is left stranded.
+    schedule_dict: dict[str, Any] = {
+        "action_kind": data["action_kind"],
+        "action_model": data.get("action_model") or "",
+        "action_prompt": data.get("action_prompt") or "",
+        "action_agent": data.get("action_agent"),
+        "action_playbook": data.get("action_playbook"),
+        "action_project": data.get("action_project"),
+        "action_extra_args": data.get("action_extra_args") or [],
+    }
+    argv, tmp_path = build_argv(schedule_dict, {})
+
+    sem = _get_semaphore()
+    if not sem._value:  # noqa: SLF001  (asyncio.Semaphore internal — no public API)
+        raise TooManyLaunchesError(
+            f"Maximum concurrent launches ({_MAX_LAUNCHES}) reached. "
+            "Retry when an existing launch completes."
+        )
 
     inv_id = uuid.uuid4().hex[:12]
     now = time.time()
@@ -85,25 +117,9 @@ async def launch(data: dict[str, Any]) -> dict[str, Any]:
             }
         )
 
-    # build_argv requires the scheduler dict shape; map the launch fields onto it.
-    schedule_dict: dict[str, Any] = {
-        "action_kind": data["action_kind"],
-        "action_model": data.get("action_model") or "",
-        "action_prompt": data.get("action_prompt") or "",
-        "action_agent": data.get("action_agent"),
-        "action_playbook": data.get("action_playbook"),
-        "action_project": data.get("action_project"),
-        "action_extra_args": data.get("action_extra_args") or [],
-    }
-
-    # build_argv does its own validation pass; raise before spawning if it disagrees.
-    argv, tmp_path = build_argv(schedule_dict, {})
-
     # Spawn detached — the HTTP handler must not block until the run finishes.
-    # Fire-and-forget: the task is not awaited.  tmp_path is None for non-flow_yaml
-    # kinds (validated above), so there is no temp-file lifetime issue.
     task = asyncio.create_task(
-        _spawn_detached(argv, inv_id, tmp_path=tmp_path),
+        _spawn_detached(argv, inv_id, tmp_path=tmp_path, semaphore=sem),
         name=f"launch-{inv_id}",
     )
     _detached_tasks.add(task)
@@ -115,24 +131,65 @@ async def launch(data: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-async def _spawn_detached(argv: list[str], inv_id: str, *, tmp_path: str | None) -> None:
+async def shutdown_launches() -> None:
+    """Cancel all in-flight detached launch tasks and await their completion.
+
+    Called from the app lifespan on shutdown.  Each task's CancelledError
+    handler writes a terminal DB row before re-raising, so invocation rows do
+    not stay stuck in 'running'.
+    """
+    tasks = [t for t in list(_detached_tasks) if not t.done()]
+    if not tasks:
+        return
+    for t in tasks:
+        t.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
+
+
+async def _spawn_detached(
+    argv: list[str],
+    inv_id: str,
+    *,
+    tmp_path: str | None,
+    semaphore: asyncio.Semaphore,
+) -> None:
     """Spawn the process and update the invocation row when it exits."""
     from lionagi.state.reasons import RunReasons
 
     from ..scheduler.subprocess import spawn_and_wait
 
-    try:
-        exit_code, _stderr = await spawn_and_wait(argv, inv_id, tmp_path=tmp_path)
-        if exit_code == 0:
-            status, reason = "completed", RunReasons.COMPLETED_OK
-        else:
-            status, reason = "failed", RunReasons.FAILED_EXIT_NONZERO
-    except asyncio.CancelledError:
-        # Server is going down with us; no terminal row update is possible.
-        raise
-    except Exception:
-        _log.exception("Detached launch failed for invocation %s", inv_id)
-        status, reason = "failed", RunReasons.FAILED_EXCEPTION
+    async with semaphore:
+        try:
+            exit_code, _stderr = await spawn_and_wait(argv, inv_id, tmp_path=tmp_path)
+            if exit_code == 0:
+                status, reason = "completed", RunReasons.COMPLETED_OK
+            else:
+                status, reason = "failed", RunReasons.FAILED_EXIT_NONZERO
+        except asyncio.CancelledError:
+            # Server is shutting down — write a terminal row before propagating.
+            try:
+                async with StateDB() as db:
+                    await db.update_invocation(inv_id, ended_at=time.time())
+                    await db.update_status(
+                        "invocation",
+                        inv_id,
+                        new_status="cancelled",
+                        reason_code=RunReasons.CANCELLED_SYSTEM,
+                        reason_summary="Launch cancelled by server shutdown.",
+                        evidence_refs=[],
+                        source="executor",
+                        actor=inv_id,
+                        metadata={},
+                    )
+            except Exception:
+                _log.exception(
+                    "Failed to record cancellation for launch invocation %s during shutdown",
+                    inv_id,
+                )
+            raise
+        except Exception:
+            _log.exception("Detached launch failed for invocation %s", inv_id)
+            status, reason = "failed", RunReasons.FAILED_EXCEPTION
 
     try:
         async with StateDB() as db:

--- a/tests/apps_studio_server/test_launches_api.py
+++ b/tests/apps_studio_server/test_launches_api.py
@@ -1,0 +1,399 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for POST /api/launches — on-demand run launch endpoint."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
+from fastapi.testclient import TestClient  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_client(monkeypatch, fake_db: Path | None = None) -> TestClient:
+    from importlib import reload
+
+    import lionagi.studio.app as app_mod
+    import lionagi.studio.services.stats as stats_mod
+
+    if fake_db is not None:
+        monkeypatch.setattr(stats_mod, "DEFAULT_DB_PATH", fake_db)
+        monkeypatch.setattr(stats_mod, "_DB", str(fake_db))
+
+    reload(app_mod)
+    return TestClient(app_mod.app, raise_server_exceptions=False)
+
+
+def _stub_db_and_spawn(monkeypatch):
+    """Patch StateDB.create_invocation and spawn so no real I/O happens."""
+    mock_db = AsyncMock()
+    mock_db.create_invocation = AsyncMock()
+    mock_db.update_invocation = AsyncMock()
+    mock_db.update_status = AsyncMock()
+
+    db_ctx = MagicMock()
+    db_ctx.__aenter__ = AsyncMock(return_value=mock_db)
+    db_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    monkeypatch.setattr(
+        "lionagi.studio.services.launches.StateDB",
+        lambda *a, **kw: db_ctx,
+    )
+
+    def _consume_create_task(coro, **kw):
+        # Close the coroutine to prevent 'never awaited' ResourceWarning.
+        coro.close()
+        return MagicMock()
+
+    monkeypatch.setattr(
+        "lionagi.studio.services.launches.asyncio.create_task",
+        _consume_create_task,
+    )
+    return mock_db
+
+
+# ---------------------------------------------------------------------------
+# Basic happy-path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestLaunchHappyPath:
+    def test_launch_agent_returns_202(self, tmp_path, monkeypatch):
+        """POST /api/launches with action_kind=agent must return 202."""
+        _stub_db_and_spawn(monkeypatch)
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.post(
+            "/api/launches",
+            json={"action_kind": "agent", "action_model": "sonnet", "action_prompt": "hello"},
+        )
+        assert resp.status_code == 202, resp.text
+        data = resp.json()
+        assert "invocation_id" in data
+        assert data["action_kind"] == "agent"
+
+    def test_launch_flow_returns_202(self, tmp_path, monkeypatch):
+        """POST /api/launches with action_kind=flow must return 202."""
+        _stub_db_and_spawn(monkeypatch)
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.post(
+            "/api/launches",
+            json={"action_kind": "flow", "action_model": "sonnet", "action_prompt": "hi"},
+        )
+        assert resp.status_code == 202, resp.text
+
+    def test_launch_fanout_returns_202(self, tmp_path, monkeypatch):
+        """POST /api/launches with action_kind=fanout must return 202."""
+        _stub_db_and_spawn(monkeypatch)
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.post(
+            "/api/launches",
+            json={"action_kind": "fanout", "action_model": "sonnet", "action_prompt": "go"},
+        )
+        assert resp.status_code == 202, resp.text
+
+    def test_launch_play_returns_202(self, tmp_path, monkeypatch):
+        """POST /api/launches with action_kind=play must return 202."""
+        _stub_db_and_spawn(monkeypatch)
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.post(
+            "/api/launches",
+            json={"action_kind": "play", "action_playbook": "my-playbook"},
+        )
+        assert resp.status_code == 202, resp.text
+
+    def test_response_contains_invocation_id_and_kind(self, tmp_path, monkeypatch):
+        """Response body must include invocation_id and action_kind."""
+        _stub_db_and_spawn(monkeypatch)
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.post(
+            "/api/launches",
+            json={"action_kind": "agent", "action_model": "sonnet"},
+        )
+        assert resp.status_code == 202
+        data = resp.json()
+        assert isinstance(data["invocation_id"], str)
+        assert len(data["invocation_id"]) == 12
+        assert data["action_kind"] == "agent"
+
+
+# ---------------------------------------------------------------------------
+# Invalid action_kind
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestLaunchInvalidKind:
+    def test_unknown_kind_returns_422(self, tmp_path, monkeypatch):
+        """Unknown action_kind must return 422."""
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.post("/api/launches", json={"action_kind": "magic"})
+        assert resp.status_code == 422, resp.text
+
+    def test_flow_yaml_kind_rejected(self, tmp_path, monkeypatch):
+        """flow_yaml is not supported for on-demand launches — must return 422."""
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.post(
+            "/api/launches",
+            json={"action_kind": "flow_yaml", "action_flow_yaml": "prompt: hi\n"},
+        )
+        assert resp.status_code == 422, resp.text
+
+    def test_missing_action_kind_returns_422(self, tmp_path, monkeypatch):
+        """Missing action_kind must return 422 (Pydantic required field)."""
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.post("/api/launches", json={"action_model": "sonnet"})
+        assert resp.status_code == 422, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Injection rejection — validation goes through build_argv
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestLaunchInjectionRejection:
+    def test_model_flag_injection_rejected(self, tmp_path, monkeypatch):
+        """action_model starting with '-' must be rejected with 422."""
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.post(
+            "/api/launches",
+            json={"action_kind": "agent", "action_model": "--bypass"},
+        )
+        assert resp.status_code == 422, resp.text
+
+    def test_agent_flag_injection_rejected(self, tmp_path, monkeypatch):
+        """action_agent starting with '-' must be rejected with 422."""
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.post(
+            "/api/launches",
+            json={"action_kind": "agent", "action_agent": "--bypass"},
+        )
+        assert resp.status_code == 422, resp.text
+
+    def test_project_flag_injection_rejected(self, tmp_path, monkeypatch):
+        """action_project starting with '-' must be rejected with 422."""
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.post(
+            "/api/launches",
+            json={"action_kind": "agent", "action_project": "--yolo"},
+        )
+        assert resp.status_code == 422, resp.text
+
+    def test_playbook_flag_injection_rejected(self, tmp_path, monkeypatch):
+        """action_playbook starting with '-' must be rejected with 422."""
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.post(
+            "/api/launches",
+            json={"action_kind": "play", "action_playbook": "--bypass"},
+        )
+        assert resp.status_code == 422, resp.text
+
+    def test_extra_args_flag_injection_rejected(self, tmp_path, monkeypatch):
+        """action_extra_args containing a flag must be rejected with 422."""
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.post(
+            "/api/launches",
+            json={"action_kind": "agent", "action_extra_args": ["--bypass"]},
+        )
+        assert resp.status_code == 422, resp.text
+
+    def test_prompt_sentinel_rejected(self, tmp_path, monkeypatch):
+        """action_prompt == '--' must be rejected with 422."""
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.post(
+            "/api/launches",
+            json={"action_kind": "agent", "action_prompt": "--"},
+        )
+        assert resp.status_code == 422, resp.text
+
+    def test_model_invalid_chars_rejected(self, tmp_path, monkeypatch):
+        """action_model with semicolons must be rejected with 422."""
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.post(
+            "/api/launches",
+            json={"action_kind": "agent", "action_model": "gpt; rm -rf /"},
+        )
+        assert resp.status_code == 422, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Auth coverage — launch endpoint covered by bearer middleware
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestLaunchAuth:
+    def test_launch_requires_bearer_when_token_set(self, monkeypatch, tmp_path):
+        """POST /api/launches must return 401 without auth when token is set."""
+        monkeypatch.setenv("LIONAGI_STUDIO_AUTH_TOKEN", "test-launch-secret")
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.post(
+            "/api/launches",
+            json={"action_kind": "agent"},
+        )
+        assert resp.status_code == 401, f"Expected 401 (no auth header), got {resp.status_code}"
+
+    def test_launch_wrong_token_returns_401(self, monkeypatch, tmp_path):
+        """POST /api/launches with wrong token must return 401."""
+        monkeypatch.setenv("LIONAGI_STUDIO_AUTH_TOKEN", "correct-secret")
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.post(
+            "/api/launches",
+            json={"action_kind": "agent"},
+            headers={"Authorization": "Bearer wrong-secret"},
+        )
+        assert resp.status_code == 401
+
+    def test_launch_correct_token_not_401(self, monkeypatch, tmp_path):
+        """POST /api/launches with correct token must not return 401."""
+        monkeypatch.setenv("LIONAGI_STUDIO_AUTH_TOKEN", "correct-secret")
+        _stub_db_and_spawn(monkeypatch)
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.post(
+            "/api/launches",
+            json={"action_kind": "agent", "action_model": "sonnet"},
+            headers={"Authorization": "Bearer correct-secret"},
+        )
+        assert resp.status_code != 401
+
+    def test_launch_open_when_no_token_configured(self, monkeypatch, tmp_path):
+        """Without LIONAGI_STUDIO_AUTH_TOKEN, launch is accessible."""
+        monkeypatch.delenv("LIONAGI_STUDIO_AUTH_TOKEN", raising=False)
+        _stub_db_and_spawn(monkeypatch)
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        resp = client.post(
+            "/api/launches",
+            json={"action_kind": "agent", "action_model": "sonnet"},
+        )
+        assert resp.status_code == 202
+
+
+# ---------------------------------------------------------------------------
+# argv goes through build_argv (validated shared path)
+# ---------------------------------------------------------------------------
+
+
+class TestLaunchArgvPath:
+    """launch() must call build_argv with the correct schedule-dict shape."""
+
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    def test_launch_calls_build_argv(self):
+        """launch() delegates argv construction to build_argv."""
+        captured = {}
+
+        def _fake_build_argv(schedule, ctx):
+            captured["schedule"] = schedule
+            captured["ctx"] = ctx
+            return (["uv", "run", "li", "agent", "--", "sonnet", "hi"], None)
+
+        with (
+            patch("lionagi.studio.services.launches.build_argv", side_effect=_fake_build_argv),
+            patch("lionagi.studio.services.launches.StateDB") as MockDB,
+            patch("lionagi.studio.services.launches.asyncio.create_task"),
+        ):
+            mock_db = AsyncMock()
+            mock_db.create_invocation = AsyncMock()
+            MockDB.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+            MockDB.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            self._run(
+                __import__("lionagi.studio.services.launches", fromlist=["launch"]).launch(
+                    {"action_kind": "agent", "action_model": "sonnet", "action_prompt": "hi"}
+                )
+            )
+
+        assert "schedule" in captured
+        assert captured["schedule"]["action_kind"] == "agent"
+        assert captured["schedule"]["action_model"] == "sonnet"
+        assert captured["schedule"]["action_prompt"] == "hi"
+        assert captured["ctx"] == {}
+
+    def test_launch_returns_invocation_id_on_agent(self):
+        """launch() must return a 12-char hex invocation_id for agent kind."""
+
+        def _consume(coro, **kw):
+            coro.close()
+            return MagicMock()
+
+        with (
+            patch("lionagi.studio.services.launches.StateDB") as MockDB,
+            patch("lionagi.studio.services.launches.asyncio.create_task", side_effect=_consume),
+        ):
+            mock_db = AsyncMock()
+            mock_db.create_invocation = AsyncMock()
+            MockDB.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+            MockDB.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = self._run(
+                __import__("lionagi.studio.services.launches", fromlist=["launch"]).launch(
+                    {"action_kind": "agent", "action_model": "sonnet", "action_prompt": "hello"}
+                )
+            )
+
+        assert "invocation_id" in result
+        assert len(result["invocation_id"]) == 12
+
+    def test_validate_request_rejects_flag_model(self):
+        """_validate_request must reject action_model starting with '-'."""
+        from lionagi.studio.services.launches import _validate_request
+
+        with pytest.raises(ValueError, match="starts with '-'"):
+            _validate_request({"action_kind": "agent", "action_model": "--bypass"})
+
+    def test_validate_request_rejects_unknown_kind(self):
+        """_validate_request must reject unknown action_kind."""
+        from lionagi.studio.services.launches import _validate_request
+
+        with pytest.raises(ValueError, match="not supported"):
+            _validate_request({"action_kind": "unknown"})
+
+    def test_validate_request_rejects_flow_yaml_kind(self):
+        """_validate_request must reject flow_yaml action_kind."""
+        from lionagi.studio.services.launches import _validate_request
+
+        with pytest.raises(ValueError, match="not supported"):
+            _validate_request({"action_kind": "flow_yaml"})
+
+    def test_validate_request_accepts_valid_agent(self):
+        """_validate_request must not raise for a clean agent request."""
+        from lionagi.studio.services.launches import _validate_request
+
+        _validate_request(
+            {"action_kind": "agent", "action_model": "sonnet", "action_prompt": "hello"}
+        )
+
+    def test_validate_request_accepts_valid_play(self):
+        """_validate_request must not raise for a clean play request."""
+        from lionagi.studio.services.launches import _validate_request
+
+        _validate_request({"action_kind": "play", "action_playbook": "my-playbook"})

--- a/tests/apps_studio_server/test_launches_api.py
+++ b/tests/apps_studio_server/test_launches_api.py
@@ -60,6 +60,20 @@ def _stub_db_and_spawn(monkeypatch):
     return mock_db
 
 
+@pytest.fixture(autouse=True)
+def _fresh_launch_state():
+    """Reset module-global launch state so admission slots and detached-task
+    refs never leak between tests (stubbed create_task means done callbacks
+    that would release slots never fire)."""
+    import lionagi.studio.services.launches as svc
+
+    svc._launch_semaphore = None
+    svc._detached_tasks.clear()
+    yield
+    svc._launch_semaphore = None
+    svc._detached_tasks.clear()
+
+
 # ---------------------------------------------------------------------------
 # Basic happy-path
 # ---------------------------------------------------------------------------
@@ -425,7 +439,6 @@ class TestSpawnDetachedTerminalUpdate:
 
         mock_db.update_status = _capture_status
 
-        sem = asyncio.Semaphore(1)
         with patch("lionagi.studio.services.launches.StateDB") as MockDB:
             MockDB.return_value.__aenter__ = AsyncMock(return_value=mock_db)
             MockDB.return_value.__aexit__ = AsyncMock(return_value=False)
@@ -433,11 +446,7 @@ class TestSpawnDetachedTerminalUpdate:
                 "lionagi.studio.scheduler.subprocess.spawn_and_wait",
                 side_effect=_fake_spawn,
             ):
-                asyncio.run(
-                    launches._spawn_detached(
-                        ["uv", "run", "li"], "inv1", tmp_path=None, semaphore=sem
-                    )
-                )
+                asyncio.run(launches._spawn_detached(["uv", "run", "li"], "inv1", tmp_path=None))
         return captured
 
     @pytest.mark.parametrize(
@@ -467,85 +476,63 @@ class TestLaunchAdmissionCap:
     """POST /api/launches must return 429 when the in-flight cap is saturated."""
 
     def test_429_when_slots_exhausted(self, tmp_path, monkeypatch):
-        """When all semaphore slots are taken, the next request returns 429."""
+        """When all semaphore slots are held, the next request returns 429."""
         import lionagi.studio.services.launches as svc
 
-        # Reset module state so we start with a fresh semaphore.
-        svc._launch_semaphore = None
-        monkeypatch.setenv("LIONAGI_STUDIO_MAX_LAUNCHES", "1")
-        svc._MAX_LAUNCHES = 1
-        svc._launch_semaphore = asyncio.Semaphore(1)
+        _stub_db_and_spawn(monkeypatch)
+        # A zero-value semaphore is indistinguishable from "every slot held".
+        svc._launch_semaphore = asyncio.Semaphore(0)
 
-        # Manually acquire all slots to simulate full saturation.
-        loop = asyncio.new_event_loop()
-        try:
-            loop.run_until_complete(svc._launch_semaphore.acquire())
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+        resp = client.post(
+            "/api/launches",
+            json={"action_kind": "agent", "action_model": "sonnet", "action_prompt": "hi"},
+        )
+        assert resp.status_code == 429, resp.text
+        assert "Maximum concurrent launches" in resp.json()["detail"]
 
-            # Stub DB + spawn so no real I/O happens.
-            mock_db = AsyncMock()
-            mock_db.create_invocation = AsyncMock()
-            db_ctx = MagicMock()
-            db_ctx.__aenter__ = AsyncMock(return_value=mock_db)
-            db_ctx.__aexit__ = AsyncMock(return_value=False)
-            monkeypatch.setattr("lionagi.studio.services.launches.StateDB", lambda *a, **kw: db_ctx)
-
-            def _consume(coro, **kw):
-                coro.close()
-                return MagicMock()
-
-            monkeypatch.setattr("lionagi.studio.services.launches.asyncio.create_task", _consume)
-
-            client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
-
-            resp = client.post(
-                "/api/launches",
-                json={"action_kind": "agent", "action_model": "sonnet", "action_prompt": "hi"},
-            )
-            assert resp.status_code == 429, resp.text
-            assert "429" in resp.text or "Maximum" in resp.text or "concurrent" in resp.text
-        finally:
-            # Release the slot and close the loop.
-            svc._launch_semaphore.release()
-            svc._launch_semaphore = None
-            svc._MAX_LAUNCHES = int(
-                __import__("os").environ.get("LIONAGI_STUDIO_MAX_LAUNCHES", "4")
-            )
-            loop.close()
-
-    def test_spawn_not_called_when_saturated(self, tmp_path, monkeypatch):
-        """When cap is saturated, create_task must not be called."""
+    def test_no_row_or_task_when_saturated(self, tmp_path, monkeypatch):
+        """When the cap is saturated, neither a DB row nor a task is created."""
         import lionagi.studio.services.launches as svc
 
-        svc._launch_semaphore = asyncio.Semaphore(1)
-        svc._MAX_LAUNCHES = 1
-
-        loop = asyncio.new_event_loop()
+        mock_db = _stub_db_and_spawn(monkeypatch)
         spawn_calls = []
-        try:
-            loop.run_until_complete(svc._launch_semaphore.acquire())
 
-            def _track_spawn(coro, **kw):
-                spawn_calls.append(coro)
-                coro.close()
-                return MagicMock()
+        def _track_spawn(coro, **kw):
+            spawn_calls.append(coro)
+            coro.close()
+            return MagicMock()
 
-            monkeypatch.setattr(
-                "lionagi.studio.services.launches.asyncio.create_task",
-                _track_spawn,
-            )
+        monkeypatch.setattr(
+            "lionagi.studio.services.launches.asyncio.create_task",
+            _track_spawn,
+        )
+        svc._launch_semaphore = asyncio.Semaphore(0)
 
-            client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
-            resp = client.post(
-                "/api/launches",
-                json={"action_kind": "agent", "action_model": "sonnet"},
-            )
-            assert resp.status_code == 429
-            assert spawn_calls == [], "create_task must not be called when cap is saturated"
-        finally:
-            svc._launch_semaphore.release()
-            svc._launch_semaphore = None
-            svc._MAX_LAUNCHES = 4
-            loop.close()
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+        resp = client.post(
+            "/api/launches",
+            json={"action_kind": "agent", "action_model": "sonnet"},
+        )
+        assert resp.status_code == 429
+        assert spawn_calls == [], "create_task must not be called when cap is saturated"
+        mock_db.create_invocation.assert_not_called()
+
+    def test_burst_admission_capped_before_any_task_runs(self, tmp_path, monkeypatch):
+        """Slots are taken at admission time, not when the spawned task runs:
+        with cap 1, the second POST gets 429 even though the first task has
+        not started (and thus released nothing)."""
+        import lionagi.studio.services.launches as svc
+
+        _stub_db_and_spawn(monkeypatch)
+        monkeypatch.setattr(svc.config, "MAX_LAUNCHES", 1)
+
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+        body = {"action_kind": "agent", "action_model": "sonnet", "action_prompt": "hi"}
+        first = client.post("/api/launches", json=body)
+        second = client.post("/api/launches", json=body)
+        assert first.status_code == 202, first.text
+        assert second.status_code == 429, second.text
 
 
 # ---------------------------------------------------------------------------
@@ -615,8 +602,6 @@ class TestShutdownDrains:
             return (0, "")
 
         async def _run():
-            sem = asyncio.Semaphore(1)
-
             async def _inner():
                 with patch("lionagi.studio.services.launches.StateDB") as MockDB:
                     MockDB.return_value.__aenter__ = AsyncMock(return_value=mock_db)
@@ -625,9 +610,7 @@ class TestShutdownDrains:
                         "lionagi.studio.scheduler.subprocess.spawn_and_wait",
                         side_effect=_blocking_spawn,
                     ):
-                        await svc._spawn_detached(
-                            ["uv", "run", "li"], "inv-cancel", tmp_path=None, semaphore=sem
-                        )
+                        await svc._spawn_detached(["uv", "run", "li"], "inv-cancel", tmp_path=None)
 
             task = asyncio.ensure_future(_inner())
             # Yield twice: once to enter _inner(), once to enter _blocking_spawn().

--- a/tests/apps_studio_server/test_launches_api.py
+++ b/tests/apps_studio_server/test_launches_api.py
@@ -397,3 +397,56 @@ class TestLaunchArgvPath:
         from lionagi.studio.services.launches import _validate_request
 
         _validate_request({"action_kind": "play", "action_playbook": "my-playbook"})
+
+
+# ---------------------------------------------------------------------------
+# _spawn_detached terminal update uses registered reason codes
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnDetachedTerminalUpdate:
+    """The post-exit invocation update must use codes the reason registry accepts."""
+
+    def _capture_update(self, exit_code=0, spawn_exc=None):
+        from lionagi.studio.services import launches
+
+        captured = {}
+
+        async def _fake_spawn(argv, inv_id, *, tmp_path=None):
+            if spawn_exc is not None:
+                raise spawn_exc
+            return (exit_code, "")
+
+        mock_db = AsyncMock()
+
+        async def _capture_status(entity_type, entity_id, **kw):
+            captured["entity_type"] = entity_type
+            captured.update(kw)
+
+        mock_db.update_status = _capture_status
+
+        with patch("lionagi.studio.services.launches.StateDB") as MockDB:
+            MockDB.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+            MockDB.return_value.__aexit__ = AsyncMock(return_value=False)
+            with patch(
+                "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+                side_effect=_fake_spawn,
+            ):
+                asyncio.run(launches._spawn_detached(["uv", "run", "li"], "inv1", tmp_path=None))
+        return captured
+
+    @pytest.mark.parametrize(
+        ("exit_code", "spawn_exc", "want_status"),
+        [
+            (0, None, "completed"),
+            (3, None, "failed"),
+            (None, RuntimeError("spawn blew up"), "failed"),
+        ],
+    )
+    def test_reason_code_is_registered(self, exit_code, spawn_exc, want_status):
+        """Every terminal path must emit a reason_code the registry validates."""
+        from lionagi.state.reasons import validate_reason_code
+
+        captured = self._capture_update(exit_code=exit_code, spawn_exc=spawn_exc)
+        assert captured["new_status"] == want_status
+        validate_reason_code(captured["reason_code"])

--- a/tests/apps_studio_server/test_launches_api.py
+++ b/tests/apps_studio_server/test_launches_api.py
@@ -425,6 +425,7 @@ class TestSpawnDetachedTerminalUpdate:
 
         mock_db.update_status = _capture_status
 
+        sem = asyncio.Semaphore(1)
         with patch("lionagi.studio.services.launches.StateDB") as MockDB:
             MockDB.return_value.__aenter__ = AsyncMock(return_value=mock_db)
             MockDB.return_value.__aexit__ = AsyncMock(return_value=False)
@@ -432,7 +433,11 @@ class TestSpawnDetachedTerminalUpdate:
                 "lionagi.studio.scheduler.subprocess.spawn_and_wait",
                 side_effect=_fake_spawn,
             ):
-                asyncio.run(launches._spawn_detached(["uv", "run", "li"], "inv1", tmp_path=None))
+                asyncio.run(
+                    launches._spawn_detached(
+                        ["uv", "run", "li"], "inv1", tmp_path=None, semaphore=sem
+                    )
+                )
         return captured
 
     @pytest.mark.parametrize(
@@ -450,3 +455,248 @@ class TestSpawnDetachedTerminalUpdate:
         captured = self._capture_update(exit_code=exit_code, spawn_exc=spawn_exc)
         assert captured["new_status"] == want_status
         validate_reason_code(captured["reason_code"])
+
+
+# ---------------------------------------------------------------------------
+# MAJOR 1 — Admission cap: 429 when in-flight launches >= MAX_LAUNCHES
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestLaunchAdmissionCap:
+    """POST /api/launches must return 429 when the in-flight cap is saturated."""
+
+    def test_429_when_slots_exhausted(self, tmp_path, monkeypatch):
+        """When all semaphore slots are taken, the next request returns 429."""
+        import lionagi.studio.services.launches as svc
+
+        # Reset module state so we start with a fresh semaphore.
+        svc._launch_semaphore = None
+        monkeypatch.setenv("LIONAGI_STUDIO_MAX_LAUNCHES", "1")
+        svc._MAX_LAUNCHES = 1
+        svc._launch_semaphore = asyncio.Semaphore(1)
+
+        # Manually acquire all slots to simulate full saturation.
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(svc._launch_semaphore.acquire())
+
+            # Stub DB + spawn so no real I/O happens.
+            mock_db = AsyncMock()
+            mock_db.create_invocation = AsyncMock()
+            db_ctx = MagicMock()
+            db_ctx.__aenter__ = AsyncMock(return_value=mock_db)
+            db_ctx.__aexit__ = AsyncMock(return_value=False)
+            monkeypatch.setattr("lionagi.studio.services.launches.StateDB", lambda *a, **kw: db_ctx)
+
+            def _consume(coro, **kw):
+                coro.close()
+                return MagicMock()
+
+            monkeypatch.setattr("lionagi.studio.services.launches.asyncio.create_task", _consume)
+
+            client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+            resp = client.post(
+                "/api/launches",
+                json={"action_kind": "agent", "action_model": "sonnet", "action_prompt": "hi"},
+            )
+            assert resp.status_code == 429, resp.text
+            assert "429" in resp.text or "Maximum" in resp.text or "concurrent" in resp.text
+        finally:
+            # Release the slot and close the loop.
+            svc._launch_semaphore.release()
+            svc._launch_semaphore = None
+            svc._MAX_LAUNCHES = int(
+                __import__("os").environ.get("LIONAGI_STUDIO_MAX_LAUNCHES", "4")
+            )
+            loop.close()
+
+    def test_spawn_not_called_when_saturated(self, tmp_path, monkeypatch):
+        """When cap is saturated, create_task must not be called."""
+        import lionagi.studio.services.launches as svc
+
+        svc._launch_semaphore = asyncio.Semaphore(1)
+        svc._MAX_LAUNCHES = 1
+
+        loop = asyncio.new_event_loop()
+        spawn_calls = []
+        try:
+            loop.run_until_complete(svc._launch_semaphore.acquire())
+
+            def _track_spawn(coro, **kw):
+                spawn_calls.append(coro)
+                coro.close()
+                return MagicMock()
+
+            monkeypatch.setattr(
+                "lionagi.studio.services.launches.asyncio.create_task",
+                _track_spawn,
+            )
+
+            client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+            resp = client.post(
+                "/api/launches",
+                json={"action_kind": "agent", "action_model": "sonnet"},
+            )
+            assert resp.status_code == 429
+            assert spawn_calls == [], "create_task must not be called when cap is saturated"
+        finally:
+            svc._launch_semaphore.release()
+            svc._launch_semaphore = None
+            svc._MAX_LAUNCHES = 4
+            loop.close()
+
+
+# ---------------------------------------------------------------------------
+# MAJOR 2 — Shutdown drains _detached_tasks + writes cancelled row
+# ---------------------------------------------------------------------------
+
+
+class TestShutdownDrains:
+    """shutdown_launches() must cancel in-flight tasks and await completion."""
+
+    def test_shutdown_cancels_tasks(self):
+        """shutdown_launches() cancels all tasks in _detached_tasks."""
+        import lionagi.studio.services.launches as svc
+
+        cancelled = []
+
+        async def _run():
+            # Clear any leftover tasks from previous tests in other event loops.
+            svc._detached_tasks.clear()
+
+            # Plant a fake long-running task.
+            async def _long():
+                try:
+                    await asyncio.sleep(999)
+                except asyncio.CancelledError:
+                    cancelled.append(True)
+                    raise
+
+            task = asyncio.ensure_future(_long())
+            svc._detached_tasks.add(task)
+            task.add_done_callback(svc._detached_tasks.discard)
+            # Yield so _long() reaches its first await before we cancel.
+            await asyncio.sleep(0)
+
+            await svc.shutdown_launches()
+
+        asyncio.run(_run())
+        assert cancelled == [True], "Task must have been cancelled"
+        assert len(svc._detached_tasks) == 0, "_detached_tasks must be empty after shutdown"
+
+    def test_shutdown_no_tasks_is_noop(self):
+        """shutdown_launches() with no tasks must not raise."""
+        import lionagi.studio.services.launches as svc
+
+        svc._detached_tasks.clear()
+        asyncio.run(svc.shutdown_launches())  # must not raise
+
+    def test_spawn_detached_cancelled_writes_terminal_row(self):
+        """When _spawn_detached is cancelled, it writes a cancelled row before re-raising."""
+        import lionagi.studio.services.launches as svc
+        from lionagi.state.reasons import RunReasons, validate_reason_code
+
+        captured = {}
+
+        mock_db = AsyncMock()
+
+        async def _capture_status(entity_type, entity_id, **kw):
+            captured["new_status"] = kw.get("new_status")
+            captured["reason_code"] = kw.get("reason_code")
+
+        mock_db.update_status = _capture_status
+        mock_db.update_invocation = AsyncMock()
+
+        async def _blocking_spawn(argv, inv_id, *, tmp_path=None):
+            # Block until cancelled so CancelledError propagates naturally.
+            await asyncio.sleep(999)
+            return (0, "")
+
+        async def _run():
+            sem = asyncio.Semaphore(1)
+
+            async def _inner():
+                with patch("lionagi.studio.services.launches.StateDB") as MockDB:
+                    MockDB.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+                    MockDB.return_value.__aexit__ = AsyncMock(return_value=False)
+                    with patch(
+                        "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+                        side_effect=_blocking_spawn,
+                    ):
+                        await svc._spawn_detached(
+                            ["uv", "run", "li"], "inv-cancel", tmp_path=None, semaphore=sem
+                        )
+
+            task = asyncio.ensure_future(_inner())
+            # Yield twice: once to enter _inner(), once to enter _blocking_spawn().
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        asyncio.run(_run())
+        assert captured.get("new_status") == "cancelled"
+        validate_reason_code(captured.get("reason_code"))
+        assert captured["reason_code"] == RunReasons.CANCELLED_SYSTEM
+
+
+# ---------------------------------------------------------------------------
+# MAJOR 3 — build_argv called BEFORE create_invocation
+# ---------------------------------------------------------------------------
+
+
+class TestBuildArgvBeforeCreate:
+    """build_argv must be called before create_invocation; if it raises, no row is created."""
+
+    def test_build_argv_failure_leaves_no_invocation_row(self):
+        """If build_argv raises ValueError, create_invocation must not be called."""
+        import lionagi.studio.services.launches as svc
+
+        create_calls = []
+
+        mock_db = AsyncMock()
+        mock_db.create_invocation = AsyncMock(side_effect=lambda d: create_calls.append(d))
+
+        async def _run():
+            with (
+                patch("lionagi.studio.services.launches.StateDB") as MockDB,
+                patch(
+                    "lionagi.studio.services.launches.build_argv",
+                    side_effect=ValueError("argv build failed"),
+                ),
+            ):
+                MockDB.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+                MockDB.return_value.__aexit__ = AsyncMock(return_value=False)
+                with pytest.raises(ValueError, match="argv build failed"):
+                    await svc.launch({"action_kind": "agent", "action_model": "sonnet"})
+
+        asyncio.run(_run())
+        assert create_calls == [], "create_invocation must NOT be called if build_argv raises"
+
+    def test_build_argv_failure_returns_422_via_router(self, tmp_path, monkeypatch):
+        """If build_argv raises ValueError, the endpoint must return 422 with no DB write."""
+        create_calls = []
+
+        mock_db = AsyncMock()
+        mock_db.create_invocation = AsyncMock(side_effect=lambda d: create_calls.append(d))
+        db_ctx = MagicMock()
+        db_ctx.__aenter__ = AsyncMock(return_value=mock_db)
+        db_ctx.__aexit__ = AsyncMock(return_value=False)
+        monkeypatch.setattr("lionagi.studio.services.launches.StateDB", lambda *a, **kw: db_ctx)
+        monkeypatch.setattr(
+            "lionagi.studio.services.launches.build_argv",
+            lambda *a, **kw: (_ for _ in ()).throw(ValueError("forced argv failure")),
+        )
+
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+        resp = client.post(
+            "/api/launches",
+            json={"action_kind": "agent", "action_model": "sonnet"},
+        )
+        assert resp.status_code == 422, resp.text
+        assert create_calls == [], "create_invocation must NOT be called if build_argv raises"


### PR DESCRIPTION
## Summary

Gap #2 from apps/studio/DESIGN-CANVAS.md §6: Studio was read-only on orchestration —
no way to start anything. `POST /api/launches` fires an `agent`/`flow`/`fanout`/`play`
run immediately, reusing the scheduler's validated launch machinery end-to-end:
service-boundary validation (`_svc_validate_*`), `build_argv` (closed action-kind set,
flag-injection guards, `--` end-of-options sentinel), and `spawn_and_wait`.

- Response is `202 {invocation_id, action_kind}` — the invocation row is created
  before spawn; callers watch `GET /api/invocations/{id}` (ADR-0020) and the existing
  sessions/signals SSE. `session_id` is deliberately absent: it is only knowable after
  the spawned process writes its own rows.
- `flow_yaml` is excluded: its temp-file lifetime belongs to the scheduler's coroutine;
  use a manual-trigger schedule for that path.
- Terminal invocation updates use registered `RunReasons` codes (the closed reason-code
  registry rejects free-form strings), with a contract test asserting every terminal
  path emits a registry-valid code.
- Detached launch tasks are held in a strong-reference set so the event loop cannot
  garbage-collect them mid-flight.

## Verification

Full suites post-rebase onto main: `tests/apps_studio_server/ tests/cli/` —
**1161 passed, 1 skipped** (pre-existing config.toml skip). 29 launch-endpoint tests:
happy path, invalid kinds, injection rejection (model/prompt/extra_args/identifiers),
auth coverage, argv goes through `build_argv`, terminal reason-code contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)