### PR TITLE
fix(studio/frontend): restore Tailwind content paths (app rendered unstyled)

### DIFF
--- a/apps/studio/frontend/src/components/Duration.tsx
+++ b/apps/studio/frontend/src/components/Duration.tsx
@@ -11,8 +11,10 @@ export interface DurationProps {
 function formatDuration(seconds: number): string {
   if (seconds < 1) return `${Math.round(seconds * 1000)}ms`;
   if (seconds < 60) return `${seconds.toFixed(seconds < 10 ? 1 : 0)}s`;
-  const m = Math.floor(seconds / 60);
-  const s = Math.round(seconds - m * 60);
+  // Round to whole seconds before splitting so 1139.7s renders 19m 0s, not 18m 60s.
+  const total = Math.round(seconds);
+  const m = Math.floor(total / 60);
+  const s = total % 60;
   if (m < 60) return s > 0 ? `${m}m ${s}s` : `${m}m`;
   const h = Math.floor(m / 60);
   const mm = m - h * 60;

--- a/apps/studio/frontend/tailwind.config.ts
+++ b/apps/studio/frontend/tailwind.config.ts
@@ -2,7 +2,7 @@ import type { Config } from "tailwindcss";
 
 const config: Config = {
   darkMode: "class",
-  content: ["./app/**/*.{js,ts,jsx,tsx,mdx}", "./components/**/*.{js,ts,jsx,tsx,mdx}"],
+  content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Summary

The Vite migration (#1430) left `tailwind.config.ts` content globs pointing at the
Next.js-era `./app/**` and `./components/**` directories, which no longer exist.
Tailwind scanned zero files and emitted only its 8KB preflight — **the entire SPA
rendered as unstyled raw HTML**. None of the automated gates caught it: the build
succeeds (Tailwind doesn't error on an empty scan), tsc and vitest don't check CSS.
Caught on the first visual pass through the running app.

- `content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"]` — CSS output goes
  8.4 KB → 47 KB and every surface (dashboard, runs, run detail, shows) renders
  correctly in both light and dark themes (verified in Chrome against live data).
- Also fixes `Duration` showing `18m 60s` for remainders ≥59.5s (round to whole
  seconds before the minute/second split) — spotted on the runs table during the
  same pass.

## Verification

- Visual: dashboard, runs list, run detail, shows — light + dark + in-place theme
  toggle, against the live 1.9k-run state DB.
- `npx tsc --noEmit` clean, vitest 13/13, `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)