### PR TITLE
fix(ci): fail fast and name the test when an xdist worker crashes

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -42,9 +42,13 @@ fmt-python() {
 # Override with PYTEST_MARKEXPR=performance (or "") to run them locally.
 test-python() {
   echo "==> pytest"
+  # --max-worker-restart=0: a hard-crashed xdist worker ("node down") otherwise
+  # wedges the session for ~15 minutes before the job dies with no test name;
+  # failing fast prints "crashed while running <nodeid>" instead.
   uv run pytest \
     --asyncio-mode=auto \
     --maxfail="${MAXFAIL:-3}" \
+    --max-worker-restart="${MAX_WORKER_RESTART:-0}" \
     -m "${PYTEST_MARKEXPR:-not performance}" \
     --disable-warnings \
     "${@:-tests/}"
@@ -55,6 +59,7 @@ test-python-cov() {
   uv run pytest \
     --asyncio-mode=auto \
     --maxfail="${MAXFAIL:-1}" \
+    --max-worker-restart="${MAX_WORKER_RESTART:-0}" \
     -m "${PYTEST_MARKEXPR:-not performance}" \
     --disable-warnings \
     --cov=lionagi --cov-report=xml --cov-report=term \


### PR DESCRIPTION
## Problem

Main's CI is intermittently failing with a roaming xdist worker hard-crash:

- main run for 7dd19b6b9: test (3.11) — `[gw1] node down: Not properly terminated` at 17:25:58, session wedged, job canceled at 17:36:40 with no test summary
- main run for bcca9a927: test (3.11) and test (3.14) failed the same way
- PR #1434 hit it twice on test (3.14) (18m1s and 19m38s, both canceled mid-wedge); attempt 3 of the identical commit passed in 3m13s

Signature: a worker dies with no Python traceback at a varying suite position, xdist spawns a replacement but never schedules work onto it (verified locally via faulthandler dump: replacement idle in `pytest_runtestloop` waiting for the controller), the session sits silent ~15 minutes at 99%, then the job dies. The crashed test's identity is lost because the summary never prints. Reproduced locally on macOS under 3.14 (1 of ~8 full-suite runs); 5 follow-up hunt runs did not re-trigger it.

## Change

`--max-worker-restart=0` in both `test-python` and `test-python-cov`: the first worker death aborts the session immediately and pytest-xdist reports `worker gwX crashed while running <nodeid>`. Same red outcome as today, but in ~4 minutes instead of ~18 and with the culprit named — every future CI hit becomes evidence for the actual fix. `MAX_WORKER_RESTART` env override is available if a run should tolerate crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)