### PR TITLE
chore(hooks): bump pyupgrade to v3.21.2 for Python 3.14 compat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
         exclude: '\.ipynb$'
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.2
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         args: [--py310-plus]


### PR DESCRIPTION
pyupgrade v3.15.2 crashes under a Python 3.14 pre-commit hook environment (`TypeError: cannot use a bytes pattern on a string-like object` in `tokenize.cookie_re.match`), blocking every local commit that touches a `.py` file. v3.21.2 verified clean on 3.14 against existing sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)