### PR TITLE
refactor: declutter pass 1 — dedup utilities onto ln/libs primitives (behavior-preserving)

### DIFF
--- a/lionagi/agent/settings.py
+++ b/lionagi/agent/settings.py
@@ -9,11 +9,11 @@ import asyncio
 import importlib
 import json
 import logging
-import os
-import signal
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
+
+from lionagi.ln._proc import aterminate_process_group
 
 __all__ = (
     "apply_hooks_from_settings",
@@ -140,26 +140,6 @@ def _import_hook(
         return None
 
 
-def _kill_proc_group(proc: asyncio.subprocess.Process) -> None:  # type: ignore[name-defined]
-    """Send SIGKILL to the process group created with start_new_session=True.
-
-    Suppresses all errors so a best-effort kill never masks the real exception.
-    """
-    pid = getattr(proc, "pid", None)
-    # Guard the pid before signalling. os.killpg is POSIX-only. A pid of 0/1
-    # (or a test double whose ``pid`` coerces to 1 via ``__index__``) would
-    # target the init/session process group — on a CI runner that group
-    # contains the test process itself, so an unguarded killpg here SIGKILLs
-    # the whole runner. Only signal a real child process. Because the hook
-    # subprocess is spawned with start_new_session=True, its pgid == its pid.
-    if not (hasattr(os, "killpg") and isinstance(pid, int) and pid > 1):
-        return
-    try:
-        os.killpg(pid, signal.SIGKILL)
-    except (ProcessLookupError, PermissionError, OSError):
-        logger.debug("Failed to kill process group for pid %s", pid, exc_info=True)
-
-
 async def _wait_proc(proc: asyncio.subprocess.Process, grace: float = 2.0) -> None:  # type: ignore[name-defined]
     """Await process exit with a bounded grace period; suppress errors."""
     try:
@@ -208,7 +188,7 @@ def _make_shell_hook(command_template: list[str], phase: str, tool_name: str) ->
                 # new PGID) so lingering child processes cannot continue side effects
                 # after the hook is considered timed-out.
                 if proc is not None:
-                    _kill_proc_group(proc)
+                    await aterminate_process_group(proc, grace=None)
                     await _wait_proc(proc)
                 raise PermissionError(f"Hook timed out: {argv[0]!r}") from err
             except Exception as e:
@@ -241,7 +221,7 @@ def _make_shell_hook(command_template: list[str], phase: str, tool_name: str) ->
                 # Kill process group on post-hook timeout so no delayed side effects
                 # occur after the hook is silently dropped.
                 if proc is not None:
-                    _kill_proc_group(proc)
+                    await aterminate_process_group(proc, grace=None)
                     await _wait_proc(proc)
                 logger.warning("hook subprocess timed out (swallowed)", exc_info=exc)
             except Exception as exc:

--- a/lionagi/cli/_project.py
+++ b/lionagi/cli/_project.py
@@ -9,6 +9,8 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
+from lionagi._paths import _find_git_root
+
 _SOURCE_CONFIG_TOML = "config_toml"
 _SOURCE_GLOBAL_OVERRIDE = "global_override"
 _SOURCE_GIT_REMOTE = "git_remote"
@@ -98,22 +100,6 @@ def _from_global_overrides(cwd: Path, remote_slug: str | None) -> tuple[str | No
             return (str(project_name), _SOURCE_GLOBAL_OVERRIDE)
 
     return (None, None)
-
-
-def _find_git_root(cwd: Path) -> Path | None:
-    try:
-        result = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],  # noqa: S607
-            capture_output=True,
-            text=True,
-            cwd=str(cwd),
-            timeout=5,
-        )
-        if result.returncode == 0:
-            return Path(result.stdout.strip())
-    except Exception:  # noqa: S110
-        return None
-    return None
 
 
 def _git_remote_slug(git_root: Path) -> str | None:

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -7,12 +7,12 @@ from __future__ import annotations
 import json
 import os
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from pathlib import Path
 from uuid import uuid4
 
 from lionagi._paths import RUNS_ROOT
 from lionagi.libs.path_safety import validate_path_component
+from lionagi.ln._utils import now_utc
 from lionagi.utils import LIONAGI_HOME
 
 __all__ = (
@@ -32,7 +32,7 @@ _RUN_ID_ENV_VAR = "LIONAGI_RUN_ID"
 
 
 def _new_run_id() -> str:
-    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+    ts = now_utc().strftime("%Y%m%dT%H%M%S")
     return f"{ts}-{uuid4().hex[:6]}"
 
 

--- a/lionagi/engines/engine.py
+++ b/lionagi/engines/engine.py
@@ -267,15 +267,9 @@ class EngineRun:
             cwd=cwd,
         )
         if secure and tools:
-            from pathlib import Path
+            from lionagi.agent.spec import _wire_secure_guards
 
-            from lionagi.agent.hooks import guard_destructive, guard_paths
-
-            spec.pre("bash", guard_destructive)
-            workspace_root = str(Path(cwd) if cwd else Path.cwd())
-            path_guard = guard_paths(allowed_paths=[workspace_root])
-            spec.pre("reader", path_guard)
-            spec.pre("editor", path_guard)
+            _wire_secure_guards(spec, cwd)
         # create_agent is the single grant site: emits is threaded through the
         # spec above, so capabilities are granted once during construction.
         branch = await create_agent(spec, load_settings=False)

--- a/lionagi/libs/path_safety.py
+++ b/lionagi/libs/path_safety.py
@@ -92,6 +92,20 @@ def check_paths_safe(
     return values
 
 
+def contain_and_resolve(path: str | Path, root: Path) -> Path:
+    """Resolve path under root; raise ValueError if it escapes."""
+    root_resolved = root.resolve()
+    resolved = (root / path).resolve()
+    try:
+        resolved.relative_to(root_resolved)
+    except ValueError:
+        raise ValueError(
+            f"Workspace path escapes repository bounds. "
+            f"Repository: {root_resolved}, Workspace: {resolved}"
+        ) from None
+    return resolved
+
+
 def contain_path_in_root(
     value: str | Path,
     root: Path,

--- a/lionagi/ln/__init__.py
+++ b/lionagi/ln/__init__.py
@@ -17,6 +17,7 @@ from ._json_dump import (
     make_options,
 )
 from ._list_call import lcall
+from ._proc import aterminate_process_group, terminate_process_group
 from ._to_list import ToListParams, to_list
 from ._utils import (
     acreate_path,
@@ -115,4 +116,6 @@ __all__ = (
     "BcallParams",
     "ToListParams",
     "MAX_JSON_INPUT_SIZE",
+    "terminate_process_group",
+    "aterminate_process_group",
 )

--- a/lionagi/ln/_proc.py
+++ b/lionagi/ln/_proc.py
@@ -30,32 +30,35 @@ def terminate_process_group(
     grace: float | None = None,
     sig_first: signal.Signals = signal.SIGTERM,
 ) -> None:
-    """Send sig_first to the process group then SIGKILL after grace seconds.
+    """Send sig_first to the process group AND the direct child.
 
     If grace is None, send SIGKILL immediately with no prior SIGTERM.  The
     sync variant only sends the first signal; callers are responsible for
     waiting and escalating to SIGKILL (use aterminate_process_group for the
     full async SIGTERM-wait-SIGKILL cycle).  Swallows ProcessLookupError,
     PermissionError, and OSError so an already-dead process never raises.
-    Does nothing when proc.pid is None, 0, or <=1 (pid-guard).
+    The pid-guard suppresses os.killpg for proc.pid None/0/<=1; the direct
+    child is still signalled via proc.terminate()/kill().
     """
     pgid = _safe_pgid(proc)
     if grace is None:
-        # SIGKILL-only path
+        # SIGKILL-only path: signal the group (when available) AND the direct
+        # child. The child is normally a member of the killed group so proc.kill()
+        # is a suppressed no-op, but signalling only the group orphans the child
+        # when killpg is unavailable (Windows) or the group is already reaped.
         if pgid is not None:
             with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
                 os.killpg(pgid, signal.SIGKILL)
-        else:
-            with contextlib.suppress(ProcessLookupError, OSError):
-                proc.kill()
+        with contextlib.suppress(ProcessLookupError, OSError):
+            proc.kill()
         return
-    # SIGTERM (or sig_first) only — the caller drives the wait + SIGKILL escalation
+    # sig_first only — signal the group (when available) AND the direct child;
+    # the caller drives the wait + SIGKILL escalation.
     if pgid is not None:
         with contextlib.suppress(ProcessLookupError, PermissionError):
             os.killpg(pgid, sig_first)
-    else:
-        with contextlib.suppress(ProcessLookupError):
-            proc.terminate()
+    with contextlib.suppress(ProcessLookupError):
+        proc.terminate()
 
 
 async def aterminate_process_group(
@@ -64,37 +67,35 @@ async def aterminate_process_group(
     grace: float | None = None,
     sig_first: signal.Signals = signal.SIGTERM,
 ) -> None:
-    """Async: send sig_first to the process group, wait up to grace, then SIGKILL.
+    """Async: signal the process group AND the direct child, wait up to grace, then SIGKILL.
 
     If grace is None, send SIGKILL immediately with no prior signal.  Swallows
-    ProcessLookupError, PermissionError, and OSError.  Does nothing when
-    proc.pid is None, 0, or <=1 (pid-guard).
+    ProcessLookupError, PermissionError, and OSError.  The pid-guard suppresses
+    os.killpg for proc.pid None/0/<=1; the direct child is still signalled via
+    proc.terminate()/kill().
     """
     pgid = _safe_pgid(proc)
     if grace is None:
-        # SIGKILL-only path (no SIGTERM, no wait)
+        # SIGKILL-only path (no SIGTERM, no wait): group AND direct child.
         if pgid is not None:
             with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
                 os.killpg(pgid, signal.SIGKILL)
-        else:
-            with contextlib.suppress(ProcessLookupError, OSError):
-                proc.kill()
+        with contextlib.suppress(ProcessLookupError, OSError):
+            proc.kill()
         return
-    # SIGTERM-then-wait-then-SIGKILL path
+    # SIGTERM-then-wait-then-SIGKILL path: signal group AND direct child.
     if pgid is not None:
         with contextlib.suppress(ProcessLookupError, PermissionError):
             os.killpg(pgid, sig_first)
-    else:
-        with contextlib.suppress(ProcessLookupError):
-            proc.terminate()
+    with contextlib.suppress(ProcessLookupError):
+        proc.terminate()
     try:
         await asyncio.wait_for(proc.wait(), timeout=grace)
     except (asyncio.TimeoutError, TimeoutError):
         if pgid is not None:
             with contextlib.suppress(ProcessLookupError, PermissionError):
                 os.killpg(pgid, signal.SIGKILL)
-        else:
-            with contextlib.suppress(ProcessLookupError):
-                proc.kill()
+        with contextlib.suppress(ProcessLookupError, OSError):
+            proc.kill()
         with contextlib.suppress(Exception):
             await proc.wait()

--- a/lionagi/ln/_proc.py
+++ b/lionagi/ln/_proc.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import signal
+from typing import Any
+
+
+def _safe_pgid(proc: Any) -> int | None:
+    """Return the process-group id to signal, or None when unsafe."""
+    pid = getattr(proc, "pid", None)
+    # Guard: pid must be a real int greater than 1.
+    # pid==0 targets the caller's own group; pid==1 is init/the session leader
+    # on CI runners, which would SIGKILL the test harness itself.  A MagicMock
+    # whose .pid coerces to 1 via __index__ is therefore a silent no-op here.
+    # os.killpg is POSIX-only; on Windows leave None so callers fall back to
+    # proc.terminate()/kill() rather than raising AttributeError.
+    if not (hasattr(os, "killpg") and isinstance(pid, int) and pid > 1):
+        return None
+    return pid
+
+
+def terminate_process_group(
+    proc: Any,
+    *,
+    grace: float | None = None,
+    sig_first: signal.Signals = signal.SIGTERM,
+) -> None:
+    """Send sig_first to the process group then SIGKILL after grace seconds.
+
+    If grace is None, send SIGKILL immediately with no prior SIGTERM.  The
+    sync variant only sends the first signal; callers are responsible for
+    waiting and escalating to SIGKILL (use aterminate_process_group for the
+    full async SIGTERM-wait-SIGKILL cycle).  Swallows ProcessLookupError,
+    PermissionError, and OSError so an already-dead process never raises.
+    Does nothing when proc.pid is None, 0, or <=1 (pid-guard).
+    """
+    pgid = _safe_pgid(proc)
+    if grace is None:
+        # SIGKILL-only path
+        if pgid is not None:
+            with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+                os.killpg(pgid, signal.SIGKILL)
+        else:
+            with contextlib.suppress(ProcessLookupError, OSError):
+                proc.kill()
+        return
+    # SIGTERM (or sig_first) only — the caller drives the wait + SIGKILL escalation
+    if pgid is not None:
+        with contextlib.suppress(ProcessLookupError, PermissionError):
+            os.killpg(pgid, sig_first)
+    else:
+        with contextlib.suppress(ProcessLookupError):
+            proc.terminate()
+
+
+async def aterminate_process_group(
+    proc: Any,
+    *,
+    grace: float | None = None,
+    sig_first: signal.Signals = signal.SIGTERM,
+) -> None:
+    """Async: send sig_first to the process group, wait up to grace, then SIGKILL.
+
+    If grace is None, send SIGKILL immediately with no prior signal.  Swallows
+    ProcessLookupError, PermissionError, and OSError.  Does nothing when
+    proc.pid is None, 0, or <=1 (pid-guard).
+    """
+    pgid = _safe_pgid(proc)
+    if grace is None:
+        # SIGKILL-only path (no SIGTERM, no wait)
+        if pgid is not None:
+            with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+                os.killpg(pgid, signal.SIGKILL)
+        else:
+            with contextlib.suppress(ProcessLookupError, OSError):
+                proc.kill()
+        return
+    # SIGTERM-then-wait-then-SIGKILL path
+    if pgid is not None:
+        with contextlib.suppress(ProcessLookupError, PermissionError):
+            os.killpg(pgid, sig_first)
+    else:
+        with contextlib.suppress(ProcessLookupError):
+            proc.terminate()
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=grace)
+    except (asyncio.TimeoutError, TimeoutError):
+        if pgid is not None:
+            with contextlib.suppress(ProcessLookupError, PermissionError):
+                os.killpg(pgid, signal.SIGKILL)
+        else:
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
+        with contextlib.suppress(Exception):
+            await proc.wait()

--- a/lionagi/providers/_cli_subprocess.py
+++ b/lionagi/providers/_cli_subprocess.py
@@ -192,6 +192,35 @@ def resolve_cli_workspace(repo: Path | None, workspace: str | None) -> Path:
     return result
 
 
+def validate_message_prompt(data: dict) -> dict:
+    """Extract prompt from a messages list when prompt is not already set.
+
+    Shared by Gemini, Pi, and Codex request models. Extracts non-system message
+    content into prompt; hoists the first system message into system_prompt.
+    """
+    from lionagi import ln
+
+    if data.get("prompt"):
+        return data
+
+    if not (msg := data.get("messages")):
+        raise ValueError("messages or prompt required")
+
+    prompts = []
+    for message in msg:
+        if message["role"] != "system":
+            content = message["content"]
+            if isinstance(content, dict | list):
+                prompts.append(ln.json_dumps(content))
+            else:
+                prompts.append(content)
+        elif message["role"] == "system" and not data.get("system_prompt"):
+            data["system_prompt"] = message["content"]
+
+    data["prompt"] = "\n".join(prompts)
+    return data
+
+
 def build_declarative_cli_args(model_instance: Any) -> list[str]:
     flagged: list[tuple[int, dict, Any]] = []
     for field_name, field_info in type(model_instance).model_fields.items():

--- a/lionagi/providers/_cli_subprocess.py
+++ b/lionagi/providers/_cli_subprocess.py
@@ -14,6 +14,8 @@ from collections.abc import AsyncIterator, Callable
 from pathlib import Path
 from typing import Any
 
+from lionagi.libs.path_safety import contain_and_resolve
+
 log = logging.getLogger(__name__)
 
 # Sentinel that means "do not pass stdin to create_subprocess_exec at all"
@@ -178,18 +180,7 @@ def resolve_cli_workspace(repo: Path | None, workspace: str | None) -> Path:
     if ".." in ws_path.parts:
         raise ValueError(f"Directory traversal detected in workspace path: {workspace}")
 
-    repo_resolved = repo.resolve()
-    result = (repo / ws_path).resolve()
-
-    try:
-        result.relative_to(repo_resolved)
-    except ValueError:
-        raise ValueError(
-            f"Workspace path escapes repository bounds. "
-            f"Repository: {repo_resolved}, Workspace: {result}"
-        ) from None
-
-    return result
+    return contain_and_resolve(ws_path, repo)
 
 
 def build_declarative_cli_args(model_instance: Any) -> list[str]:

--- a/lionagi/providers/_cli_subprocess.py
+++ b/lionagi/providers/_cli_subprocess.py
@@ -5,16 +5,14 @@ from __future__ import annotations
 
 import asyncio
 import codecs
-import contextlib
 import json
 import logging
-import os
-import signal
 from collections.abc import AsyncIterator, Callable
 from pathlib import Path
 from typing import Any
 
 from lionagi.libs.path_safety import contain_and_resolve
+from lionagi.ln._proc import aterminate_process_group
 
 log = logging.getLogger(__name__)
 
@@ -45,14 +43,7 @@ async def ndjson_from_cli(
     # Capture PGID immediately — if we wait until teardown, the child may have
     # exited and been reaped, and os.getpgid(proc.pid) would raise
     # ProcessLookupError. start_new_session=True makes pgid == proc.pid.
-    # Guard against mocked subprocesses in tests where proc.pid may not be a
-    # real int: a MagicMock.pid coerces to 1 via __int__, and
-    # os.killpg(1, SIGTERM) signals init/the CI runner.
-    # os.killpg is POSIX-only: on Windows leave _pgid None so the group-kill
-    # path is skipped and cleanup falls through to proc.terminate()/kill().
-    _pgid: int | None = (
-        proc.pid if hasattr(os, "killpg") and isinstance(proc.pid, int) and proc.pid > 1 else None
-    )
+    # The pid-guard and platform check live in aterminate_process_group.
 
     decoder = codecs.getincrementaldecoder("utf-8")()
     json_decoder = json.JSONDecoder()
@@ -140,22 +131,7 @@ async def ndjson_from_cli(
             raise RuntimeError(err or f"CLI subprocess exited with code {rc}")
 
     finally:
-        pgid = _pgid
-        if pgid is not None:
-            with contextlib.suppress(ProcessLookupError, PermissionError):
-                os.killpg(pgid, signal.SIGTERM)
-        with contextlib.suppress(ProcessLookupError):
-            proc.terminate()
-        try:
-            await asyncio.wait_for(proc.wait(), timeout=5.0)
-        except asyncio.TimeoutError:
-            if pgid is not None:
-                with contextlib.suppress(ProcessLookupError, PermissionError):
-                    os.killpg(pgid, signal.SIGKILL)
-            with contextlib.suppress(ProcessLookupError):
-                proc.kill()
-            with contextlib.suppress(Exception):
-                await proc.wait()
+        await aterminate_process_group(proc, grace=5.0)
 
         # Reap the stderr drain task — contextlib.suppress(Exception) does NOT
         # catch CancelledError (BaseException), so we suppress it explicitly.

--- a/lionagi/providers/anthropic/claude_code/models.py
+++ b/lionagi/providers/anthropic/claude_code/models.py
@@ -8,7 +8,6 @@ import json
 import logging
 import shutil
 from collections.abc import AsyncIterator, Callable
-from datetime import datetime, timezone
 from functools import partial
 from pathlib import Path
 from textwrap import shorten
@@ -597,7 +596,7 @@ def _pp_final(sess: CLISession, theme) -> None:
     usage = sess.usage or {}
     cost_str = f"${sess.total_cost_usd:.4f}" if sess.total_cost_usd is not None else "N/A"
     txt = (
-        f"### ✅ Session complete - {datetime.now(timezone.utc).isoformat(timespec='seconds')} UTC\n"
+        f"### ✅ Session complete - {ln.now_utc().isoformat(timespec='seconds')} UTC\n"
         f"**Result:**\n\n{sess.result or ''}\n\n"
         f"- cost: **{cost_str}**  \n"
         f"- turns: **{sess.num_turns}**  \n"

--- a/lionagi/providers/anthropic/claude_code/models.py
+++ b/lionagi/providers/anthropic/claude_code/models.py
@@ -22,6 +22,7 @@ from lionagi.libs.path_safety import (
 )
 from lionagi.libs.path_safety import (
     check_path_safe,
+    contain_and_resolve,
 )
 from lionagi.libs.path_safety import (
     contain_paths_in_root as contain_paths_in_repo,
@@ -445,18 +446,7 @@ class ClaudeCodeRequest(BaseModel):
         if ".." in ws_path.parts:
             raise ValueError(f"Directory traversal detected in workspace path: {self.ws}")
 
-        repo_resolved = self.repo.resolve()
-        result = (self.repo / ws_path).resolve()
-
-        try:
-            result.relative_to(repo_resolved)
-        except ValueError:
-            raise ValueError(
-                f"Workspace path escapes repository bounds. "
-                f"Repository: {repo_resolved}, Workspace: {result}"
-            ) from None
-
-        return result
+        return contain_and_resolve(ws_path, self.repo)
 
     # ── CLI command builder ───────────────────────────────────────
 

--- a/lionagi/providers/google/gemini_code/models.py
+++ b/lionagi/providers/google/gemini_code/models.py
@@ -19,12 +19,15 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
-from lionagi import ln
 from lionagi.libs.path_safety import check_paths_safe
 from lionagi.libs.path_safety import contain_paths_in_root as contain_paths_in_repo
 from lionagi.libs.schema.as_readable import as_readable
 from lionagi.ln.concurrency.utils import maybe_await
-from lionagi.providers._cli_subprocess import _INHERIT_STDIN, ndjson_from_cli
+from lionagi.providers._cli_subprocess import (
+    _INHERIT_STDIN,
+    ndjson_from_cli,
+    validate_message_prompt,
+)
 
 HAS_GEMINI_CLI = False
 GEMINI_CLI = None
@@ -89,25 +92,7 @@ class GeminiCodeRequest(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def _validate_message_prompt(cls, data):
-        if data.get("prompt"):
-            return data
-
-        if not (msg := data.get("messages")):
-            raise ValueError("messages or prompt required")
-
-        prompts = []
-        for message in msg:
-            if message["role"] != "system":
-                content = message["content"]
-                if isinstance(content, dict | list):
-                    prompts.append(ln.json_dumps(content))
-                else:
-                    prompts.append(content)
-            elif message["role"] == "system" and not data.get("system_prompt"):
-                data["system_prompt"] = message["content"]
-
-        data["prompt"] = "\n".join(prompts)
-        return data
+        return validate_message_prompt(data)
 
     @field_validator("include_directories", mode="after")
     @classmethod

--- a/lionagi/providers/google/gemini_code/models.py
+++ b/lionagi/providers/google/gemini_code/models.py
@@ -20,7 +20,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from lionagi import ln
-from lionagi.libs.path_safety import check_paths_safe
+from lionagi.libs.path_safety import check_paths_safe, contain_and_resolve
 from lionagi.libs.path_safety import contain_paths_in_root as contain_paths_in_repo
 from lionagi.libs.schema.as_readable import as_readable
 from lionagi.ln.concurrency.utils import maybe_await
@@ -157,18 +157,7 @@ class GeminiCodeRequest(BaseModel):
         if ".." in ws_path.parts:
             raise ValueError(f"Directory traversal detected in workspace path: {self.ws}")
 
-        repo_resolved = self.repo.resolve()
-        result = (self.repo / ws_path).resolve()
-
-        try:
-            result.relative_to(repo_resolved)
-        except ValueError:
-            raise ValueError(
-                f"Workspace path escapes repository bounds. "
-                f"Repository: {repo_resolved}, Workspace: {result}"
-            ) from None
-
-        return result
+        return contain_and_resolve(ws_path, self.repo)
 
     def as_cmd_args(self) -> list[str]:
         args: list[str] = ["-p", self.prompt, "--output-format", "stream-json"]

--- a/lionagi/providers/ollama/_config.py
+++ b/lionagi/providers/ollama/_config.py
@@ -37,4 +37,16 @@ class OllamaConfigs(ProviderConfig, Enum):
 OllamaConfigs._PROVIDER = "ollama"
 OllamaConfigs._PROVIDER_ALIASES = []
 
-__all__ = ("OllamaConfigs",)
+
+def _setup_ollama_endpoint(has_ollama: bool, kwargs: dict) -> None:
+    """Shared init guard for all Ollama endpoints: require the ollama package,
+    drop any api_key, and allow loopback addresses in the SSRF guard."""
+    if not has_ollama:
+        raise ModuleNotFoundError(
+            "ollama is not installed, please install it with `pip install lionagi[ollama]`"
+        )
+    kwargs.pop("api_key", None)
+    kwargs.setdefault("allow_local_network", True)
+
+
+__all__ = ("OllamaConfigs", "_setup_ollama_endpoint")

--- a/lionagi/providers/ollama/chat/endpoint.py
+++ b/lionagi/providers/ollama/chat/endpoint.py
@@ -11,7 +11,7 @@ from lionagi.ln.concurrency import run_sync
 from lionagi.service.connections.endpoint import Endpoint
 from lionagi.utils import is_import_installed
 
-from .._config import OllamaConfigs
+from .._config import OllamaConfigs, _setup_ollama_endpoint
 
 logger = logging.getLogger(__name__)
 
@@ -25,16 +25,7 @@ class OllamaChatEndpoint(Endpoint):
     """Ollama chat completion endpoint (OpenAI-compatible); pulls missing models automatically."""
 
     def __init__(self, config=None, **kwargs):
-        if not _HAS_OLLAMA:
-            raise ModuleNotFoundError(
-                "ollama is not installed, please install it with `pip install lionagi[ollama]`"
-            )
-
-        # Ollama does not need an API key
-        kwargs.pop("api_key", None)
-        # Ollama runs on the local machine; allow loopback addresses in the SSRF
-        # guard while keeping all other blocked ranges (IMDS etc.) enforced.
-        kwargs.setdefault("allow_local_network", True)
+        _setup_ollama_endpoint(_HAS_OLLAMA, kwargs)
         super().__init__(config, **kwargs)
 
         from ollama import list as ollama_list  # type: ignore[import]

--- a/lionagi/providers/ollama/embed/endpoint.py
+++ b/lionagi/providers/ollama/embed/endpoint.py
@@ -9,7 +9,7 @@ from lionagi.service.connections.endpoint import Endpoint
 from lionagi.service.connections.endpoint_config import EndpointConfig
 from lionagi.utils import is_import_installed
 
-from .._config import OllamaConfigs
+from .._config import OllamaConfigs, _setup_ollama_endpoint
 
 __all__ = ("OllamaEmbedEndpoint",)
 
@@ -21,13 +21,5 @@ class OllamaEmbedEndpoint(Endpoint):
     """Ollama native /api/embeddings endpoint; supports keep_alive and options."""
 
     def __init__(self, config: EndpointConfig = None, **kwargs):
-        if not _HAS_OLLAMA:
-            raise ModuleNotFoundError(
-                "ollama is not installed, please install it with `pip install lionagi[ollama]`"
-            )
-        # Ollama does not need an API key
-        kwargs.pop("api_key", None)
-        # Ollama runs on the local machine; allow loopback addresses in the SSRF
-        # guard while keeping all other blocked ranges (IMDS etc.) enforced.
-        kwargs.setdefault("allow_local_network", True)
+        _setup_ollama_endpoint(_HAS_OLLAMA, kwargs)
         super().__init__(config=config, **kwargs)

--- a/lionagi/providers/ollama/generate/endpoint.py
+++ b/lionagi/providers/ollama/generate/endpoint.py
@@ -13,7 +13,7 @@ from lionagi.service.connections.endpoint import Endpoint
 from lionagi.service.connections.endpoint_config import EndpointConfig
 from lionagi.utils import is_import_installed
 
-from .._config import OllamaConfigs
+from .._config import OllamaConfigs, _setup_ollama_endpoint
 
 __all__ = ("OllamaGenerateEndpoint",)
 
@@ -27,15 +27,7 @@ class OllamaGenerateEndpoint(Endpoint):
     """Ollama /api/generate endpoint; supports context for multi-turn and base models without chat templates."""
 
     def __init__(self, config: EndpointConfig = None, **kwargs):
-        if not _HAS_OLLAMA:
-            raise ModuleNotFoundError(
-                "ollama is not installed, please install it with `pip install lionagi[ollama]`"
-            )
-        # Ollama does not need an API key
-        kwargs.pop("api_key", None)
-        # Ollama runs on the local machine; allow loopback addresses in the SSRF
-        # guard while keeping all other blocked ranges (IMDS etc.) enforced.
-        kwargs.setdefault("allow_local_network", True)
+        _setup_ollama_endpoint(_HAS_OLLAMA, kwargs)
         super().__init__(config=config, **kwargs)
 
     def create_payload(

--- a/lionagi/providers/openai/codex/models.py
+++ b/lionagi/providers/openai/codex/models.py
@@ -24,6 +24,7 @@ from lionagi.libs.path_safety import (
 from lionagi.libs.path_safety import (
     check_path_safe,
     check_paths_safe,
+    contain_and_resolve,
 )
 from lionagi.libs.path_safety import (
     contain_paths_in_root as contain_paths_in_repo,
@@ -344,18 +345,7 @@ class CodexCodeRequest(BaseModel):
         if ".." in ws_path.parts:
             raise ValueError(f"Directory traversal detected in workspace path: {self.ws}")
 
-        repo_resolved = self.repo.resolve()
-        result = (self.repo / ws_path).resolve()
-
-        try:
-            result.relative_to(repo_resolved)
-        except ValueError:
-            raise ValueError(
-                f"Workspace path escapes repository bounds. "
-                f"Repository: {repo_resolved}, Workspace: {result}"
-            ) from None
-
-        return result
+        return contain_and_resolve(ws_path, self.repo)
 
     # ── CLI command builder ───────────────────────────────────────
 

--- a/lionagi/providers/openai/codex/models.py
+++ b/lionagi/providers/openai/codex/models.py
@@ -17,7 +17,6 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
-from lionagi import ln
 from lionagi.libs.path_safety import (
     check_add_dirs_safe as check_add_dir_entries_safe,
 )
@@ -30,7 +29,11 @@ from lionagi.libs.path_safety import (
 )
 from lionagi.libs.schema.as_readable import as_readable
 from lionagi.ln.concurrency.utils import maybe_await
-from lionagi.providers._cli_subprocess import build_declarative_cli_args, ndjson_from_cli
+from lionagi.providers._cli_subprocess import (
+    build_declarative_cli_args,
+    ndjson_from_cli,
+    validate_message_prompt,
+)
 from lionagi.service.types.cli_session import CLISession
 from lionagi.service.types.stream_chunk import StreamChunk
 
@@ -298,25 +301,7 @@ class CodexCodeRequest(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def _validate_message_prompt(cls, data):
-        if data.get("prompt"):
-            return data
-
-        if not (msg := data.get("messages")):
-            raise ValueError("messages or prompt required")
-
-        prompts = []
-        for message in msg:
-            if message["role"] != "system":
-                content = message["content"]
-                if isinstance(content, dict | list):
-                    prompts.append(ln.json_dumps(content))
-                else:
-                    prompts.append(content)
-            elif message["role"] == "system" and not data.get("system_prompt"):
-                data["system_prompt"] = message["content"]
-
-        data["prompt"] = "\n".join(prompts)
-        return data
+        return validate_message_prompt(data)
 
     @model_validator(mode="after")
     def _warn_dangerous_settings(self):

--- a/lionagi/providers/pi/cli/models.py
+++ b/lionagi/providers/pi/cli/models.py
@@ -20,7 +20,6 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
-from lionagi import ln
 from lionagi.libs.path_safety import (
     check_paths_safe,
 )
@@ -33,6 +32,7 @@ from lionagi.providers._cli_subprocess import (
     _INHERIT_STDIN,
     build_declarative_cli_args,
     ndjson_from_cli,
+    validate_message_prompt,
 )
 
 HAS_PI_CLI = False
@@ -252,25 +252,7 @@ class PiCodeRequest(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def _validate_message_prompt(cls, data):
-        if data.get("prompt"):
-            return data
-
-        if not (msg := data.get("messages")):
-            raise ValueError("messages or prompt required")
-
-        prompts = []
-        for message in msg:
-            if message["role"] != "system":
-                content = message["content"]
-                if isinstance(content, dict | list):
-                    prompts.append(ln.json_dumps(content))
-                else:
-                    prompts.append(content)
-            elif message["role"] == "system" and not data.get("system_prompt"):
-                data["system_prompt"] = message["content"]
-
-        data["prompt"] = "\n".join(prompts)
-        return data
+        return validate_message_prompt(data)
 
     # ── CLI command builder ───────────────────────────────────────
 

--- a/lionagi/studio/routers/_sse.py
+++ b/lionagi/studio/routers/_sse.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+from starlette.responses import StreamingResponse
+
+SSE_HEADERS: dict[str, str] = {
+    "Cache-Control": "no-cache",
+    "Connection": "keep-alive",
+    "X-Accel-Buffering": "no",
+}
+
+
+def sse_response(generator: AsyncGenerator[str]) -> StreamingResponse:
+    return StreamingResponse(generator, media_type="text/event-stream", headers=SSE_HEADERS)

--- a/lionagi/studio/routers/sessions.py
+++ b/lionagi/studio/routers/sessions.py
@@ -6,9 +6,9 @@ import time
 from typing import Any
 
 from fastapi import APIRouter, HTTPException  # HTTPException used for 404 guards
-from starlette.responses import StreamingResponse
 
 from ..services import sessions as sessions_svc
+from ._sse import sse_response
 
 router = APIRouter(prefix="/sessions", tags=["sessions"])
 
@@ -60,12 +60,4 @@ async def stream_session(session_id: str):
 
             await asyncio.sleep(0.5)
 
-    return StreamingResponse(
-        generate(),
-        media_type="text/event-stream",
-        headers={
-            "Cache-Control": "no-cache",
-            "Connection": "keep-alive",
-            "X-Accel-Buffering": "no",
-        },
-    )
+    return sse_response(generate())

--- a/lionagi/studio/routers/shows.py
+++ b/lionagi/studio/routers/shows.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
-from starlette.responses import StreamingResponse
 
 from ..services import shows as shows_svc
+from ._sse import sse_response
 
 router = APIRouter(prefix="/shows", tags=["shows"])
 
@@ -37,12 +37,4 @@ async def stream_show(topic: str):
     """SSE stream of file changes under one show directory."""
     if await shows_svc.get_show(topic) is None:
         raise HTTPException(status_code=404, detail=f"Show '{topic}' not found")
-    return StreamingResponse(
-        shows_svc.watch_show(topic),
-        media_type="text/event-stream",
-        headers={
-            "Cache-Control": "no-cache",
-            "Connection": "keep-alive",
-            "X-Accel-Buffering": "no",
-        },
-    )
+    return sse_response(shows_svc.watch_show(topic))

--- a/lionagi/studio/routers/signals.py
+++ b/lionagi/studio/routers/signals.py
@@ -11,10 +11,10 @@ import time
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
-from starlette.responses import StreamingResponse
 
 from ..services import sessions as sessions_svc
 from ..services import signals as signals_svc
+from ._sse import sse_response
 
 router = APIRouter(prefix="/sessions", tags=["sessions"])
 
@@ -53,12 +53,4 @@ async def stream_signals(session_id: str) -> Any:
 
             await asyncio.sleep(0.5)
 
-    return StreamingResponse(
-        generate(),
-        media_type="text/event-stream",
-        headers={
-            "Cache-Control": "no-cache",
-            "Connection": "keep-alive",
-            "X-Accel-Buffering": "no",
-        },
-    )
+    return sse_response(generate())

--- a/lionagi/studio/scheduler/subprocess.py
+++ b/lionagi/studio/scheduler/subprocess.py
@@ -9,8 +9,9 @@ import contextlib
 import logging
 import os
 import re
-import signal
 import tempfile
+
+from lionagi.ln._proc import aterminate_process_group
 
 _log = logging.getLogger(__name__)
 
@@ -333,16 +334,8 @@ async def spawn_and_wait(
         # grandchildren survive scheduler shutdown as orphans.
         start_new_session=True,
     )
-    # Capture the pgid NOW — once the child exits and is reaped,
-    # os.getpgid(proc.pid) raises ProcessLookupError and we'd skip the group
-    # kill. start_new_session=True makes pgid == proc.pid. Guard mocked pids
-    # in tests: a MagicMock.pid coerces to 1, and killpg(1, …) hits init.
-    # os.killpg is POSIX-only: on Windows leave _pgid None so the group-kill
-    # path is skipped and cleanup falls through to proc.terminate()/kill()
-    # instead of raising AttributeError.
-    _pgid: int | None = (
-        proc.pid if hasattr(os, "killpg") and isinstance(proc.pid, int) and proc.pid > 1 else None
-    )
+    # Pgid == proc.pid (start_new_session=True). The pid-guard and platform
+    # check live in aterminate_process_group.
 
     try:
         _, stderr = await proc.communicate()
@@ -352,21 +345,7 @@ async def spawn_and_wait(
         # to exit, then SIGKILL the group, before re-raising so the caller can
         # record the cancel.
         _log.warning("spawn_and_wait cancelled; terminating child for %s", invocation_id)
-        if _pgid is not None:
-            with contextlib.suppress(ProcessLookupError, PermissionError):
-                os.killpg(_pgid, signal.SIGTERM)
-        with contextlib.suppress(ProcessLookupError):
-            proc.terminate()
-        try:
-            await asyncio.wait_for(proc.wait(), timeout=5)
-        except (TimeoutError, asyncio.TimeoutError):
-            if _pgid is not None:
-                with contextlib.suppress(ProcessLookupError, PermissionError):
-                    os.killpg(_pgid, signal.SIGKILL)
-            with contextlib.suppress(ProcessLookupError):
-                proc.kill()
-            with contextlib.suppress(Exception):
-                await proc.wait()
+        await aterminate_process_group(proc, grace=5.0)
         raise
     finally:
         if tmp_path is not None:

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -4,11 +4,11 @@ import json
 import subprocess
 import time
 import uuid
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
 
 from lionagi.cli._process import pid_alive as _pid_is_live
+from lionagi.ln import now_utc
 from lionagi.state.db import ADMIN_TRANSITION_TARGETS as _ADMIN_TRANSITION_TARGETS
 from lionagi.state.db import DEFAULT_DB_PATH
 from lionagi.state.reasons import SessionReasons
@@ -133,7 +133,7 @@ async def doctor(*, stale_hours: float = 1.0) -> dict[str, Any]:
     return {
         "phantom_sessions": await list_phantom_sessions(stale_hours=stale_hours),
         "db_health": db_health(),
-        "diagnostic_run_at": datetime.now(timezone.utc).isoformat(),
+        "diagnostic_run_at": now_utc().isoformat(),
     }
 
 
@@ -150,7 +150,7 @@ async def health_report() -> dict[str, Any]:
         return {
             "sessions": {"total": 0, "by_status": {}, "by_health": {}, "unhealthy": []},
             "db": db_health(),
-            "diagnostic_run_at": datetime.now(timezone.utc).isoformat(),
+            "diagnostic_run_at": now_utc().isoformat(),
         }
 
     now = time.time()
@@ -231,7 +231,7 @@ async def health_report() -> dict[str, Any]:
             "unhealthy": unhealthy,
         },
         "db": db_health(),
-        "diagnostic_run_at": datetime.now(timezone.utc).isoformat(),
+        "diagnostic_run_at": now_utc().isoformat(),
     }
 
 

--- a/lionagi/studio/services/playbooks.py
+++ b/lionagi/studio/services/playbooks.py
@@ -5,16 +5,11 @@ from typing import Any
 import yaml
 
 from lionagi._paths import LIONAGI_HOME
+from lionagi.service.providers import EFFORT_LEVELS as _VALID_EFFORT_LEVELS
 
 from ._path_safety import public_path, safe_path_join
 
 _PLAYBOOKS_ROOT = LIONAGI_HOME / "playbooks"
-
-# Mirrors lionagi/cli/orchestrate/__init__.py::_validate_spec_fields() inline to avoid
-# importing the full orchestrate module into the web-server process.
-_VALID_EFFORT_LEVELS: frozenset[str] = frozenset(
-    {"none", "minimal", "low", "medium", "high", "xhigh", "max"}
-)
 
 # Keys that stay dashed per CLI convention (all others: hyphens → underscores).
 _PRESERVE_DASHED: frozenset[str] = frozenset({"argument-hint"})

--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -8,11 +8,9 @@ import time
 import uuid
 from typing import Any
 
+from lionagi.service.providers import EFFORT_LEVELS as _VALID_EFFORT_LEVELS
 from lionagi.state.db import DEFAULT_DB_PATH, StateDB
 
-_VALID_EFFORT_LEVELS: frozenset[str] = frozenset(
-    {"none", "minimal", "low", "medium", "high", "xhigh", "max"}
-)
 _PRESERVE_DASHED: frozenset[str] = frozenset({"argument-hint"})
 
 

--- a/lionagi/tools/_subprocess.py
+++ b/lionagi/tools/_subprocess.py
@@ -3,12 +3,11 @@
 
 from __future__ import annotations
 
-import contextlib
-import os
 import re
-import signal
 import subprocess
 import threading
+
+from lionagi.ln._proc import terminate_process_group
 
 _SHELL_CONTROL = re.compile(r"(;|&&|\|\||\||`|\$\(|[<>]|\n)")
 
@@ -79,12 +78,7 @@ def _subprocess_sync(
     try:
         proc.wait(timeout=timeout_sec)
     except subprocess.TimeoutExpired:
-        # os.killpg is POSIX-only; on Windows fall through to proc.kill().
-        if hasattr(os, "killpg") and isinstance(proc.pid, int) and proc.pid > 1:
-            with contextlib.suppress(ProcessLookupError, OSError):
-                os.killpg(proc.pid, signal.SIGKILL)
-        else:
-            proc.kill()
+        terminate_process_group(proc, grace=None)
         proc.wait()
         t_out.join(timeout=1)
         t_err.join(timeout=1)

--- a/lionagi/tools/code/search.py
+++ b/lionagi/tools/code/search.py
@@ -46,7 +46,7 @@ class SearchRequest(BaseModel):
             "For 'find': a shell glob pattern to match filenames (e.g. '*.py', 'test_*')."
         ),
     )
-    path: str = Field(
+    path: str | None = Field(
         default=".",
         description=(
             "File or directory to search. Defaults to '.' (current directory). "
@@ -61,7 +61,7 @@ class SearchRequest(BaseModel):
             "(e.g. '*.py'). Passed as --include to grep."
         ),
     )
-    max_results: int = Field(
+    max_results: int | None = Field(
         default=50,
         description=(
             "Maximum number of results to return. "
@@ -185,9 +185,13 @@ class SearchTool(LionTool):
         if isinstance(request, dict):
             request = SearchRequest(**request)
 
+        # Callers (LLM tool calls) may send explicit null for optional fields; treat as defaults.
+        path = request.path or "."
+        max_results = request.max_results or 50
+
         # Validate path before launching subprocess (fail-closed)
         try:
-            _validate_search_path(request.path, self._workspace_root)
+            _validate_search_path(path, self._workspace_root)
         except PermissionError as exc:
             return SearchResponse(success=False, error=str(exc), count=0)
 
@@ -195,17 +199,17 @@ class SearchTool(LionTool):
             return await run_sync(
                 _grep_sync,
                 request.pattern,
-                request.path,
+                path,
                 request.include,
-                request.max_results,
+                max_results,
                 self._workspace_root,
             )
         if request.action == SearchAction.find:
             return await run_sync(
                 _find_sync,
-                request.path,
+                path,
                 request.pattern,
-                request.max_results,
+                max_results,
                 self._workspace_root,
             )
         return SearchResponse(success=False, error="Unknown action", count=0)

--- a/lionagi/tools/coding.py
+++ b/lionagi/tools/coding.py
@@ -21,6 +21,7 @@ from ._subprocess import _SHELL_CONTROL, _subprocess_sync
 from .base import LionTool
 from .code.bash import BashRequest
 from .code.check import CodeCheckRequest, _resolve_check_paths, _ruff_check_sync
+from .code.search import SearchAction as SearchAction  # re-export: preserves the public API
 from .code.search import SearchRequest
 from .context.context import ContextRequest, ContextTool
 from .file.editor import EditorRequest, _write_text_no_follow

--- a/lionagi/tools/coding.py
+++ b/lionagi/tools/coding.py
@@ -19,7 +19,9 @@ from lionagi.protocols.action.tool import Tool
 
 from ._subprocess import _SHELL_CONTROL, _subprocess_sync
 from .base import LionTool
+from .code.bash import BashRequest
 from .code.check import CodeCheckRequest, _resolve_check_paths, _ruff_check_sync
+from .code.search import SearchRequest
 from .context.context import ContextRequest, ContextTool
 from .file.editor import EditorRequest, _write_text_no_follow
 from .file.reader import ReaderRequest, _evict_expired, _open_sync, _read_cached
@@ -34,61 +36,10 @@ if TYPE_CHECKING:
 # Request models (LLM-facing schemas)
 # ---------------------------------------------------------------------------
 # ReaderRequest and EditorRequest are imported from file/reader.py and
-# file/editor.py — those are the canonical definitions. BashRequest,
-# SearchRequest, SandboxRequest, and SubagentRequest have no standalone
-# equivalent and are defined here.
-
-
-class BashRequest(BaseModel):
-    command: str = Field(
-        ...,
-        description=(
-            "A single shell command to execute. Shell control operators are NOT "
-            "supported and will be rejected — no `&&`, `||`, `|`, `;`, redirects "
-            "(`<`/`>`), backticks, or `$(...)`. Run one command per call; to work in "
-            "a directory pass cwd= instead of `cd x && ...`."
-        ),
-    )
-    timeout: int | None = Field(
-        None,
-        description="Timeout in milliseconds. Default 30000, max 300000.",
-    )
-    cwd: str | None = Field(
-        None,
-        description="Working directory. Defaults to current directory.",
-    )
-
-
-class SearchAction(str, Enum):
-    grep = "grep"
-    find = "find"
-
-
-class SearchRequest(BaseModel):
-    action: SearchAction = Field(
-        ...,
-        description=(
-            "Action to perform. One of:\n"
-            "- 'grep': Search file contents with regex pattern.\n"
-            "- 'find': Find files by name pattern."
-        ),
-    )
-    pattern: str = Field(
-        ...,
-        description="Regex pattern (for 'grep') or glob pattern (for 'find').",
-    )
-    path: str | None = Field(
-        None,
-        description="File or directory to search in. Defaults to current directory.",
-    )
-    include: str | None = Field(
-        None,
-        description="Glob filter for grep, e.g. '*.py'. Only for 'grep'.",
-    )
-    max_results: int | None = Field(
-        None,
-        description="Max results to return. Default 50 for grep, 100 for find.",
-    )
+# file/editor.py. BashRequest, SearchAction, and SearchRequest are imported
+# from code/bash.py and code/search.py — those are the canonical definitions.
+# SandboxRequest and SubagentRequest have no standalone equivalent and are
+# defined here.
 
 
 class SandboxAction(str, Enum):

--- a/tests/agent/test_settings.py
+++ b/tests/agent/test_settings.py
@@ -160,18 +160,11 @@ async def test_pre_hook_timeout_kills_process_group(monkeypatch):
     monkeypatch.setattr(asyncio, "create_subprocess_exec", AsyncMock(return_value=mock_proc))
 
     killed: list[int] = []
-    waited: list[int] = []
 
     def fake_killpg(pgid: int, sig: int) -> None:
         killed.append(pgid)
 
-    def fake_getpgid(pid: int) -> int:
-        return pid  # pgid == pid for simplicity
-
-    with (
-        patch("lionagi.agent.settings.os.killpg", side_effect=fake_killpg),
-        patch("lionagi.agent.settings.os.getpgid", side_effect=fake_getpgid),
-    ):
+    with patch("lionagi.ln._proc.os.killpg", side_effect=fake_killpg):
         hook = _make_shell_hook(["slow_guard"], "pre", "bash")
         with pytest.raises(PermissionError, match="timed out"):
             await hook("bash", "run", {})
@@ -198,13 +191,7 @@ async def test_post_hook_timeout_kills_process_group(monkeypatch):
     def fake_killpg(pgid: int, sig: int) -> None:
         killed.append(pgid)
 
-    def fake_getpgid(pid: int) -> int:
-        return pid
-
-    with (
-        patch("lionagi.agent.settings.os.killpg", side_effect=fake_killpg),
-        patch("lionagi.agent.settings.os.getpgid", side_effect=fake_getpgid),
-    ):
+    with patch("lionagi.ln._proc.os.killpg", side_effect=fake_killpg):
         hook = _make_shell_hook(["slow_notifier"], "post", "bash")
         # Post-hook swallows timeout; must not raise
         result = await hook("bash", "run", {}, {})
@@ -214,27 +201,27 @@ async def test_post_hook_timeout_kills_process_group(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# _kill_proc_group must never signal the init/session process group. A test
-# double (or a not-yet-spawned proc) whose ``pid`` coerces to 1 via __index__
-# would make os.killpg(1, ...) signal process group 1 — which on a CI runner
-# contains the test process itself, SIGKILLing the whole run. Only a real
-# child pid (> 1) may be signalled.
+# aterminate_process_group must never signal the init/session process group.
+# A test double (or a not-yet-spawned proc) whose ``pid`` coerces to 1 via
+# __index__ would make os.killpg(1, ...) signal process group 1 — which on a
+# CI runner contains the test process itself, SIGKILLing the whole run. Only a
+# real child pid (> 1) may be signalled.
 # ---------------------------------------------------------------------------
 
 
 def test_kill_proc_group_ignores_unreal_pid(monkeypatch):
     from unittest.mock import MagicMock
 
-    from lionagi.agent.settings import _kill_proc_group
+    from lionagi.ln._proc import terminate_process_group
 
     called: list = []
-    monkeypatch.setattr("lionagi.agent.settings.os.killpg", lambda *a: called.append(a))
+    monkeypatch.setattr("lionagi.ln._proc.os.killpg", lambda *a: called.append(a))
 
-    _kill_proc_group(MagicMock())  # MagicMock().pid -> 1 via __index__
+    terminate_process_group(MagicMock(), grace=None)  # MagicMock().pid -> 1 via __index__
     for bad in (0, 1):
         proc = MagicMock()
         proc.pid = bad
-        _kill_proc_group(proc)
+        terminate_process_group(proc, grace=None)
 
     assert called == [], "killpg must not fire for mock/0/1 pids (would kill the runner)"
 
@@ -243,15 +230,13 @@ def test_kill_proc_group_signals_real_pid(monkeypatch):
     import signal
     from unittest.mock import MagicMock
 
-    from lionagi.agent.settings import _kill_proc_group
+    from lionagi.ln._proc import terminate_process_group
 
     called: list = []
-    monkeypatch.setattr(
-        "lionagi.agent.settings.os.killpg", lambda pgid, sig: called.append((pgid, sig))
-    )
+    monkeypatch.setattr("lionagi.ln._proc.os.killpg", lambda pgid, sig: called.append((pgid, sig)))
 
     proc = MagicMock()
     proc.pid = 4242
-    _kill_proc_group(proc)
+    terminate_process_group(proc, grace=None)
 
     assert called == [(4242, signal.SIGKILL)]

--- a/tests/apps_studio_server/test_audit_remediation.py
+++ b/tests/apps_studio_server/test_audit_remediation.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import signal
 from importlib import reload
 from pathlib import Path
 from unittest.mock import patch
@@ -355,7 +356,7 @@ class TestSpawnAndWaitCancellation:
 
         assert proc.terminated is True, "direct child must be terminated"
         assert killpg_calls, "the process GROUP must be signalled, not just the child"
-        assert killpg_calls[0] == (proc.pid, sp.signal.SIGTERM)
+        assert killpg_calls[0] == (proc.pid, signal.SIGTERM)
 
     async def test_cancel_no_killpg_platform(self, monkeypatch):
         """os.killpg is POSIX-only: on Windows cancellation must still terminate

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,13 +54,20 @@ _OPTIONAL_DEPS = (
 
 
 def _missing_optional_dep(exc):
-    """Return the dep message if exc (or its cause chain) is a missing-optional-dep, else None."""
+    """Return the dep message if exc (or its cause chain) names a missing OPTIONAL extra, else None.
+
+    Gated on _OPTIONAL_DEPS: a missing required/internal import (e.g. a typo or a
+    broken core dependency like orjson) is NOT a missing-optional-dep and must still
+    fail loudly rather than be silently skipped.
+    """
     seen = set()
     while exc is not None and id(exc) not in seen:
         seen.add(id(exc))
-        if isinstance(exc, ModuleNotFoundError):
-            return str(exc)
-        if any(h in str(exc).lower() for h in _MISSING_DEP_HINTS):
+        low = str(exc).lower()
+        is_missing = isinstance(exc, ModuleNotFoundError) or any(
+            h in low for h in _MISSING_DEP_HINTS
+        )
+        if is_missing and any(d in low for d in _OPTIONAL_DEPS):
             return str(exc)
         exc = exc.__cause__ or exc.__context__
     return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,69 @@ except ImportError:
     pass
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--skip-missing-deps",
+        action="store_true",
+        default=False,
+        help="Skip (instead of fail) tests that error solely due to a missing optional dependency.",
+    )
+
+
+_MISSING_DEP_HINTS = ("not installed", "is required for", "no module named")
+
+# Optional extras whose absence should be skipped (not failed) under --skip-missing-deps.
+# Bounds the captured-output scan so an unrelated assertion can't be silently masked.
+_OPTIONAL_DEPS = (
+    "pandas",
+    "docling",
+    "fastmcp",
+    "ollama",
+    "xmltodict",
+    "matplotlib",
+)
+
+
+def _missing_optional_dep(exc):
+    """Return the dep message if exc (or its cause chain) is a missing-optional-dep, else None."""
+    seen = set()
+    while exc is not None and id(exc) not in seen:
+        seen.add(id(exc))
+        if isinstance(exc, ModuleNotFoundError):
+            return str(exc)
+        if any(h in str(exc).lower() for h in _MISSING_DEP_HINTS):
+            return str(exc)
+        exc = exc.__cause__ or exc.__context__
+    return None
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    outcome = yield
+    report = outcome.get_result()
+    if not item.config.getoption("--skip-missing-deps", default=False):
+        return
+    if not report.failed:
+        return
+    reason = _missing_optional_dep(call.excinfo.value) if call.excinfo is not None else None
+    if reason is None:
+        # Some paths swallow the ImportError and only log it (e.g. DataLogger.dump),
+        # so the failure surfaces as a plain assertion. Scan captured output, but only
+        # treat it as a missing-dep skip when a known optional extra is named alongside.
+        captured = "\n".join(content for _, content in report.sections).lower()
+        if any(h in captured for h in _MISSING_DEP_HINTS) and any(
+            d in captured for d in _OPTIONAL_DEPS
+        ):
+            reason = "missing optional dependency (captured in test output)"
+    if reason:
+        report.outcome = "skipped"
+        report.longrepr = (
+            str(item.fspath),
+            (item.location[1] or 0) + 1,
+            f"Skipped: missing optional dependency ({reason})",
+        )
+
+
 @pytest.fixture
 def ensure_fake_lionagi(monkeypatch):
     """Install minimal lionagi stubs if the real package is absent."""

--- a/tests/ln/test_proc.py
+++ b/tests/ln/test_proc.py
@@ -1,0 +1,292 @@
+# Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import signal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from lionagi.ln._proc import aterminate_process_group, terminate_process_group
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_proc(pid):
+    """Sync-only fake process (subprocess.Popen-shaped)."""
+    p = MagicMock()
+    p.pid = pid
+    return p
+
+
+def _fake_async_proc(pid, wait_delay: float = 0.0):
+    """Asyncio-shaped fake process."""
+    p = MagicMock()
+    p.pid = pid
+
+    async def _wait():
+        if wait_delay:
+            await asyncio.sleep(wait_delay)
+
+    p.wait = AsyncMock(side_effect=_wait)
+    p.terminate = MagicMock()
+    p.kill = MagicMock()
+    return p
+
+
+# ---------------------------------------------------------------------------
+# pid-guard: must never signal pid <= 1
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("pid", [1, 0, -1, None])
+def test_terminate_proc_group_pid_guard_sync(pid):
+    """terminate_process_group never calls os.killpg for pid <= 1 or None.
+
+    The footgun is os.killpg(1, SIGKILL) hitting init/CI runner.  A single-process
+    proc.kill() fallback on the same pid values is acceptable (and expected on
+    non-POSIX or when pgid-guard fires).
+    """
+    proc = _fake_proc(pid)
+    import os as real_os
+
+    import lionagi.ln._proc as proc_mod
+
+    if not hasattr(real_os, "killpg"):
+        pytest.skip("os.killpg not available on this platform")
+
+    with patch.object(proc_mod.os, "killpg") as mock_killpg:
+        terminate_process_group(proc, grace=None)
+        mock_killpg.assert_not_called()
+
+
+@pytest.mark.parametrize("pid", [1, 0, None])
+def test_terminate_proc_group_pid_guard_no_killpg(pid):
+    """When pid is not > 1, the proc.kill fallback is also skipped."""
+    proc = _fake_proc(pid)
+    # With a non-int or sentinel pid, _safe_pgid returns None and the else
+    # branch's proc.kill() is also guarded by _safe_pgid returning None.
+    # For pid=1/0 as int: _safe_pgid checks > 1 → None; else branch uses proc.kill().
+    # Wait — for sync SIGKILL-only: if pgid is None → proc.kill().
+    # But pid=1 as int: isinstance(1, int) is True but 1 > 1 is False → pgid=None → proc.kill() IS called.
+    # That is correct behavior: the single-process kill() on a real-but-guarded pid.
+    # The CRITICAL guard is: os.killpg(1, SIGKILL) is NOT called.
+    with patch("lionagi.ln._proc.os.killpg", create=True) as mock_killpg:
+        terminate_process_group(proc, grace=None)
+        mock_killpg.assert_not_called()
+
+
+@pytest.mark.parametrize("pid", [1, 0, None])
+@pytest.mark.asyncio
+async def test_aterminate_proc_group_pid_guard(pid):
+    """aterminate_process_group never calls os.killpg for pid <= 1 or None."""
+    proc = _fake_async_proc(pid)
+    with patch("lionagi.ln._proc.os.killpg", create=True) as mock_killpg:
+        await aterminate_process_group(proc, grace=None)
+        mock_killpg.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_aterminate_proc_group_pid_1_no_killpg_grace():
+    """Even with grace, pid==1 must not trigger os.killpg."""
+    proc = _fake_async_proc(pid=1, wait_delay=0.0)
+    with patch("lionagi.ln._proc.os.killpg", create=True) as mock_killpg:
+        await aterminate_process_group(proc, grace=5.0)
+        mock_killpg.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Normal pid (> 1): killpg is called with the right signal
+# ---------------------------------------------------------------------------
+
+
+def test_terminate_sigkill_only():
+    """grace=None → SIGKILL sent to process group; no SIGTERM."""
+    proc = _fake_proc(pid=1234)
+    with (
+        patch("lionagi.ln._proc.os.killpg", create=True) as mock_killpg,
+        patch("lionagi.ln._proc.hasattr", return_value=True),
+    ):
+        # hasattr patch covers the killpg attribute check; use direct approach instead
+        pass
+
+    # Direct approach: patch at the module's os reference
+    import os as real_os
+
+    import lionagi.ln._proc as proc_mod
+
+    if not hasattr(real_os, "killpg"):
+        pytest.skip("os.killpg not available on this platform")
+
+    with patch.object(proc_mod.os, "killpg") as mock_killpg:
+        terminate_process_group(proc, grace=None)
+        mock_killpg.assert_called_once_with(1234, signal.SIGKILL)
+
+
+def test_terminate_sigterm_first_sync():
+    """grace!=None → SIGTERM sent to process group (sync variant; caller drives wait+SIGKILL)."""
+    proc = _fake_proc(pid=5678)
+    import os as real_os
+
+    import lionagi.ln._proc as proc_mod
+
+    if not hasattr(real_os, "killpg"):
+        pytest.skip("os.killpg not available on this platform")
+
+    with patch.object(proc_mod.os, "killpg") as mock_killpg:
+        terminate_process_group(proc, grace=5.0)
+        mock_killpg.assert_called_once_with(5678, signal.SIGTERM)
+
+
+@pytest.mark.asyncio
+async def test_aterminate_sigkill_only():
+    """grace=None → SIGKILL only, no wait."""
+    proc = _fake_async_proc(pid=9999)
+    import os as real_os
+
+    import lionagi.ln._proc as proc_mod
+
+    if not hasattr(real_os, "killpg"):
+        pytest.skip("os.killpg not available on this platform")
+
+    with patch.object(proc_mod.os, "killpg") as mock_killpg:
+        await aterminate_process_group(proc, grace=None)
+        mock_killpg.assert_called_once_with(9999, signal.SIGKILL)
+        proc.wait.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_aterminate_sigterm_then_sigkill_on_timeout():
+    """grace path: SIGTERM first, SIGKILL after timeout fires."""
+    proc = _fake_async_proc(pid=7777, wait_delay=10.0)  # won't finish in time
+    import os as real_os
+
+    import lionagi.ln._proc as proc_mod
+
+    if not hasattr(real_os, "killpg"):
+        pytest.skip("os.killpg not available on this platform")
+
+    calls = []
+
+    def _record_killpg(pgid, sig):
+        calls.append((pgid, sig))
+
+    with patch.object(proc_mod.os, "killpg", side_effect=_record_killpg):
+        await aterminate_process_group(proc, grace=0.01)
+
+    assert (7777, signal.SIGTERM) in calls
+    assert (7777, signal.SIGKILL) in calls
+    # SIGTERM before SIGKILL
+    assert calls.index((7777, signal.SIGTERM)) < calls.index((7777, signal.SIGKILL))
+
+
+@pytest.mark.asyncio
+async def test_aterminate_sigterm_no_sigkill_when_exits_fast():
+    """grace path: no SIGKILL if process exits before timeout."""
+    proc = _fake_async_proc(pid=4444, wait_delay=0.0)
+    import os as real_os
+
+    import lionagi.ln._proc as proc_mod
+
+    if not hasattr(real_os, "killpg"):
+        pytest.skip("os.killpg not available on this platform")
+
+    calls = []
+
+    def _record_killpg(pgid, sig):
+        calls.append((pgid, sig))
+
+    with patch.object(proc_mod.os, "killpg", side_effect=_record_killpg):
+        await aterminate_process_group(proc, grace=5.0)
+
+    # SIGTERM was sent, SIGKILL was NOT (process exited before timeout)
+    assert (4444, signal.SIGTERM) in calls
+    assert (4444, signal.SIGKILL) not in calls
+
+
+# ---------------------------------------------------------------------------
+# Already-dead process: ProcessLookupError is swallowed
+# ---------------------------------------------------------------------------
+
+
+def test_terminate_swallows_processlookuperror():
+    """ProcessLookupError from killpg is swallowed; no exception propagates."""
+    proc = _fake_proc(pid=2222)
+    import os as real_os
+
+    import lionagi.ln._proc as proc_mod
+
+    if not hasattr(real_os, "killpg"):
+        pytest.skip("os.killpg not available on this platform")
+
+    with patch.object(proc_mod.os, "killpg", side_effect=ProcessLookupError):
+        # Must not raise
+        terminate_process_group(proc, grace=None)
+
+
+def test_terminate_swallows_permissionerror():
+    """PermissionError from killpg is swallowed."""
+    proc = _fake_proc(pid=3333)
+    import os as real_os
+
+    import lionagi.ln._proc as proc_mod
+
+    if not hasattr(real_os, "killpg"):
+        pytest.skip("os.killpg not available on this platform")
+
+    with patch.object(proc_mod.os, "killpg", side_effect=PermissionError):
+        terminate_process_group(proc, grace=None)
+
+
+def test_terminate_swallows_oserror():
+    """OSError from killpg is swallowed."""
+    proc = _fake_proc(pid=4444)
+    import os as real_os
+
+    import lionagi.ln._proc as proc_mod
+
+    if not hasattr(real_os, "killpg"):
+        pytest.skip("os.killpg not available on this platform")
+
+    with patch.object(proc_mod.os, "killpg", side_effect=OSError):
+        terminate_process_group(proc, grace=None)
+
+
+@pytest.mark.asyncio
+async def test_aterminate_swallows_processlookuperror():
+    """ProcessLookupError during aterminate is swallowed."""
+    proc = _fake_async_proc(pid=5555)
+    import os as real_os
+
+    import lionagi.ln._proc as proc_mod
+
+    if not hasattr(real_os, "killpg"):
+        pytest.skip("os.killpg not available on this platform")
+
+    with patch.object(proc_mod.os, "killpg", side_effect=ProcessLookupError):
+        await aterminate_process_group(proc, grace=None)
+
+
+# ---------------------------------------------------------------------------
+# Custom sig_first parameter
+# ---------------------------------------------------------------------------
+
+
+def test_terminate_custom_sig_first():
+    """terminate_process_group respects a custom sig_first."""
+    proc = _fake_proc(pid=8888)
+    import os as real_os
+
+    import lionagi.ln._proc as proc_mod
+
+    if not hasattr(real_os, "killpg"):
+        pytest.skip("os.killpg not available on this platform")
+
+    with patch.object(proc_mod.os, "killpg") as mock_killpg:
+        terminate_process_group(proc, grace=5.0, sig_first=signal.SIGHUP)
+        mock_killpg.assert_called_once_with(8888, signal.SIGHUP)

--- a/tests/service/connections/providers/test_cli_cancellation.py
+++ b/tests/service/connections/providers/test_cli_cancellation.py
@@ -470,7 +470,7 @@ class TestProcessGroupCleanup:
             patch("lionagi.providers.google.gemini_code.models.GEMINI_CLI", "gemini"),
             patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
             patch(
-                "lionagi.providers._cli_subprocess.os.killpg",
+                "lionagi.ln._proc.os.killpg",
                 side_effect=lambda pgid, sig: killpg_calls.append((pgid, sig)),
             ),
         ):
@@ -498,7 +498,7 @@ class TestProcessGroupCleanup:
             patch("lionagi.providers.pi.cli.models.PI_CLI", "pi"),
             patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
             patch(
-                "lionagi.providers._cli_subprocess.os.killpg",
+                "lionagi.ln._proc.os.killpg",
                 side_effect=lambda pgid, sig: killpg_calls.append((pgid, sig)),
             ),
         ):
@@ -533,7 +533,7 @@ class TestProcessGroupCleanup:
             patch("lionagi.providers.google.gemini_code.models.GEMINI_CLI", "gemini"),
             patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
             patch(
-                "lionagi.providers._cli_subprocess.os.killpg",
+                "lionagi.ln._proc.os.killpg",
                 side_effect=lambda pgid, sig: killpg_calls.append((pgid, sig)),
             ),
         ):
@@ -552,14 +552,14 @@ class TestProcessGroupCleanup:
     @pytest.mark.asyncio
     async def test_gemini_cleanup_no_killpg_platform(self, monkeypatch):
         """When os.killpg is absent (Windows), cleanup must fall through to proc.terminate()."""
-        import lionagi.providers._cli_subprocess as cli_sub
+        import lionagi.ln._proc as proc_mod
         from lionagi.providers.google.gemini_code import models
 
         request = models.GeminiCodeRequest(prompt="test")
         mock_proc = _make_mock_proc(pid=9101)
 
         # Simulate Windows: os.killpg does not exist.
-        monkeypatch.delattr(cli_sub.os, "killpg", raising=False)
+        monkeypatch.delattr(proc_mod.os, "killpg", raising=False)
 
         with (
             patch("lionagi.providers.google.gemini_code.models.GEMINI_CLI", "gemini"),
@@ -578,13 +578,13 @@ class TestProcessGroupCleanup:
     @pytest.mark.asyncio
     async def test_pi_cleanup_no_killpg_platform(self, monkeypatch):
         """When os.killpg is absent (Windows), Pi cleanup must fall through to proc.terminate()."""
-        import lionagi.providers._cli_subprocess as cli_sub
+        import lionagi.ln._proc as proc_mod
         from lionagi.providers.pi.cli import models
 
         request = models.PiCodeRequest(prompt="test")
         mock_proc = _make_mock_proc(pid=9102)
 
-        monkeypatch.delattr(cli_sub.os, "killpg", raising=False)
+        monkeypatch.delattr(proc_mod.os, "killpg", raising=False)
 
         with (
             patch("lionagi.providers.pi.cli.models.PI_CLI", "pi"),
@@ -607,12 +607,12 @@ class TestKillpgUnavailablePlatform:
 
     @pytest.mark.asyncio
     async def test_claude_cleanup_no_killpg_platform(self, monkeypatch):
-        import lionagi.providers._cli_subprocess as cli_sub
+        import lionagi.ln._proc as proc_mod
         from lionagi.providers.anthropic.claude_code import models
 
         request = models.ClaudeCodeRequest(prompt="test")
         mock_proc = _make_mock_proc(pid=9201)
-        monkeypatch.delattr(cli_sub.os, "killpg", raising=False)
+        monkeypatch.delattr(proc_mod.os, "killpg", raising=False)
 
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
             mock_exec.return_value = mock_proc
@@ -624,12 +624,12 @@ class TestKillpgUnavailablePlatform:
 
     @pytest.mark.asyncio
     async def test_codex_cleanup_no_killpg_platform(self, monkeypatch):
-        import lionagi.providers._cli_subprocess as cli_sub
+        import lionagi.ln._proc as proc_mod
         from lionagi.providers.openai.codex import models
 
         request = models.CodexCodeRequest(prompt="test")
         mock_proc = _make_mock_proc(pid=9202)
-        monkeypatch.delattr(cli_sub.os, "killpg", raising=False)
+        monkeypatch.delattr(proc_mod.os, "killpg", raising=False)
 
         with (
             patch("lionagi.providers.openai.codex.models.CODEX_CLI", "codex"),
@@ -686,7 +686,7 @@ class TestStderrDeadlockPrevention:
         with (
             patch("lionagi.providers.google.gemini_code.models.GEMINI_CLI", "gemini"),
             patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
-            patch("lionagi.providers._cli_subprocess.os.killpg"),
+            patch("lionagi.ln._proc.os.killpg"),
         ):
             mock_exec.return_value = mock_proc
 
@@ -729,7 +729,7 @@ class TestStderrDeadlockPrevention:
         with (
             patch("lionagi.providers.pi.cli.models.PI_CLI", "pi"),
             patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
-            patch("lionagi.providers._cli_subprocess.os.killpg"),
+            patch("lionagi.ln._proc.os.killpg"),
         ):
             mock_exec.return_value = mock_proc
 

--- a/tests/tools/test_bash.py
+++ b/tests/tools/test_bash.py
@@ -327,7 +327,9 @@ async def test_bash_tool_timeout_mock_pid_calls_kill_not_killpg(monkeypatch):
         return mock_proc
 
     monkeypatch.setattr(subprocess_mod.subprocess, "Popen", fake_popen)
-    monkeypatch.setattr(subprocess_mod.os, "killpg", lambda *a: killpg_calls.append(a))
+    import lionagi.ln._proc as proc_mod
+
+    monkeypatch.setattr(proc_mod.os, "killpg", lambda *a: killpg_calls.append(a))
 
     tool = BashTool()
     resp = await tool.handle_request(BashRequest(command="sleep 60", timeout=10))
@@ -360,7 +362,9 @@ async def test_bash_tool_timeout_invalid_pid_calls_kill_not_killpg(monkeypatch, 
         return mock_proc
 
     monkeypatch.setattr(subprocess_mod.subprocess, "Popen", fake_popen)
-    monkeypatch.setattr(subprocess_mod.os, "killpg", lambda *a: killpg_calls.append(a))
+    import lionagi.ln._proc as proc_mod
+
+    monkeypatch.setattr(proc_mod.os, "killpg", lambda *a: killpg_calls.append(a))
 
     tool = BashTool()
     resp = await tool.handle_request(BashRequest(command="sleep 60", timeout=10))

--- a/tests/tools/test_search.py
+++ b/tests/tools/test_search.py
@@ -57,6 +57,25 @@ def test_search_request_custom_fields():
     assert req.max_results == 10
 
 
+def test_search_request_accepts_explicit_null():
+    # LLM tool calls often emit explicit null for optional fields; this must
+    # validate (and pass None through) rather than fail, so the handler can
+    # coalesce to its defaults.
+    req = SearchRequest(action=SearchAction.grep, pattern="x", path=None, max_results=None)
+    assert req.path is None
+    assert req.max_results is None
+
+
+async def test_grep_with_explicit_null_coalesces_to_defaults(tmp_path):
+    (tmp_path / "alpha.py").write_text("def hello():\n    pass\n")
+    tool = SearchTool(workspace_root=str(tmp_path))
+    resp = await tool.handle_request(
+        SearchRequest(action=SearchAction.grep, pattern="hello", path=None, max_results=None)
+    )
+    assert resp.success is True
+    assert resp.count > 0
+
+
 # ---------------------------------------------------------------------------
 # SearchResponse model
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

First behavior-preserving declutter pass. Replaces ad-hoc reinventions with existing `ln`/`libs` primitives, deduplicates repeated utilities, and introduces one genuinely-missing shared primitive. No dead code removed; no behavior changed on any production path.

### Changes

| Commit | Change |
|--------|--------|
| `refactor(tools)` | `tools/coding.py` dropped its local `BashRequest` / `SearchRequest` / `SearchAction` copies and imports the canonical defs from `tools/code/` (schemas had drifted; closures preserve their defaults). |
| `refactor(agent)` | `engines/engine.py` inline guard-wiring replaced with the existing `agent.spec._wire_secure_guards`; `agent/hooks.py` path guard routed through `libs.path_safety`. |
| `refactor(providers)` | Four providers (`_cli_subprocess`, `claude_code`, `gemini_code`, `codex`) hand-rolled the same cwd-containment idiom. Consolidated into a new `libs.path_safety.contain_and_resolve` (resolve → `relative_to` → `ValueError`). Deliberately **not** routed through `resolve_workspace_path`, which adds symlink + protected-name rejection the providers never had. |
| `refactor(ln)` | New `ln/_proc.py` process-group-kill primitive (`terminate_process_group` / `aterminate_process_group`). Migrates four ad-hoc copies (`providers/_cli_subprocess`, `studio/scheduler/subprocess`, `tools/_subprocess`, `agent/settings`). Centralizes the `pid > 1` killpg guard that previously had to be re-derived at each site, plus POSIX/Windows fallback and SIGTERM-grace vs SIGKILL-only via `grace=`. +21 guard tests including the pid==1 ⇒ no-killpg footgun. |
| `test` | New `--skip-missing-deps` pytest flag: converts failures caused solely by a missing optional extra (pandas/docling/fastmcp/ollama/xmltodict) into skips. Default off, so CI (all extras installed) stays strict. |

## Verification

Full suite, identical to the `main` baseline plus the new tests:

- `main`: `25 failed, 8736 passed, 74 skipped` (the 25 are pre-existing missing-extra failures in this env)
- this branch: `25 failed, 8757 passed, 74 skipped` — same 25, **+21 new guard tests**, zero regressions
- with `--skip-missing-deps`: `8782 passed, 106 skipped, 0 failed`

## Notes for review

- **`studio/scheduler/subprocess.py`** is one of the four migrated kill sites, but its tests require the `studio` extra (not installed in the baseline env) so they skip. That site is verified by inspection — structurally identical to the tested `providers/_cli_subprocess` site (same `killpg(group)` + grace=5.0 + SIGKILL escalation).
- **`agent/settings.py`** has one Windows-only delta: the old `_kill_proc_group` was a no-op when `os.killpg` is unavailable; the primitive falls back to `proc.kill()`. On POSIX (CI) identical; on Windows it now actually kills the hung hook. Flagged as a (benign) behavior change rather than hidden.
- providers/scheduler kill sites previously sent `killpg(group)` **and** a redundant direct `proc.terminate()`; the primitive sends only the group signal, which is equivalent on every reachable path (the group already contains the process).