### PR TITLE
fix(studio): stop misusing HTTP path-safety wrappers off the request path

### DIFF
--- a/lionagi/studio/services/shows.py
+++ b/lionagi/studio/services/shows.py
@@ -9,6 +9,7 @@ from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import Any
 
+from lionagi.libs.path_safety import safe_join
 from lionagi.state.db import DEFAULT_DB_PATH
 
 from ..config import SHOWS_ROOT
@@ -539,7 +540,11 @@ async def watch_show(topic: str) -> AsyncGenerator[str]:
     terminal (completed or aborted) AND no file has changed for 60 seconds.
     Emits done immediately when the show directory does not exist (Docker deployments).
     """
-    topic_dir = safe_path_join(SHOWS_ROOT, topic)
+    try:
+        topic_dir = safe_join(SHOWS_ROOT, topic)
+    except ValueError:
+        yield f"data: {json.dumps({'type': 'done'})}\n\n"
+        return
     if not topic_dir.is_dir():
         yield f"data: {json.dumps({'type': 'done'})}\n\n"
         return

--- a/lionagi/studio/services/teams.py
+++ b/lionagi/studio/services/teams.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from typing import Any
 
+from lionagi.libs.path_safety import safe_join
 from lionagi.utils import LIONAGI_HOME
 
 from ._io import read_json_file as _read_json
-from ._path_safety import safe_path_join
 
 _TEAMS_ROOT = LIONAGI_HOME / "teams"
 
@@ -43,8 +43,8 @@ def get_team(team_id: str) -> dict[str, Any] | None:
     if ".json" in team_id:
         team_id = team_id.replace(".json", "")
     try:
-        safe_path_join(_TEAMS_ROOT, f"{team_id}.json")
-    except Exception:
+        safe_join(_TEAMS_ROOT, f"{team_id}.json")
+    except ValueError:
         return None
     path = _TEAMS_ROOT / f"{team_id}.json"
     return _read_json(path)

--- a/tests/apps_studio_server/test_shows.py
+++ b/tests/apps_studio_server/test_shows.py
@@ -143,6 +143,24 @@ def test_path_traversal_double_dotdot_shows(patched_app):
     assert r.status_code == 404
 
 
+async def test_watch_show_invalid_topic_yields_done(tmp_path, monkeypatch):
+    """An invalid topic must yield a single `done` event, not raise.
+
+    watch_show() runs inside an SSE stream, so a rejected topic must follow
+    the same yield-done contract as a missing directory rather than raise.
+    """
+    import lionagi.studio.services.shows as shows_mod
+
+    shows_root = tmp_path / "shows"
+    shows_root.mkdir()
+    monkeypatch.setattr(shows_mod, "SHOWS_ROOT", shows_root)
+
+    events = [event async for event in shows_mod.watch_show("../etc")]
+
+    assert len(events) == 1
+    assert json.loads(events[0].removeprefix("data: ").strip()) == {"type": "done"}
+
+
 # ---------------------------------------------------------------------------
 # strict status_source provenance
 # ---------------------------------------------------------------------------

--- a/tests/apps_studio_server/test_teams.py
+++ b/tests/apps_studio_server/test_teams.py
@@ -83,3 +83,24 @@ def test_team_detail_missing_returns_404(tmp_path, monkeypatch):
 
     r = client.get("/api/teams/missing")
     assert r.status_code == 404
+
+
+def test_team_detail_traversal_returns_404(tmp_path, monkeypatch):
+    """A team_id with a path separator is rejected as 404, never 500."""
+    teams_root = tmp_path / "teams"
+    teams_root.mkdir()
+    client = _make_client(monkeypatch, teams_root)
+
+    r = client.get("/api/teams/aaa%2Fbbb")
+    assert r.status_code == 404
+
+
+def test_get_team_invalid_component_returns_none(tmp_path, monkeypatch):
+    """get_team() catches the path-safety ValueError and returns None."""
+    import lionagi.studio.services.teams as teams_mod
+
+    teams_root = tmp_path / "teams"
+    teams_root.mkdir()
+    monkeypatch.setattr(teams_mod, "_TEAMS_ROOT", teams_root)
+
+    assert teams_mod.get_team("../secrets") is None


### PR DESCRIPTION
## Summary

Audit of the consumers of `lionagi/studio/services/_path_safety.py` surfaced two places that call `safe_path_join()` — an `HTTPException`-raising wrapper meant for FastAPI **request paths** — where the HTTP exception can never do its job. Both are fixed to use the underlying `libs.path_safety.safe_join()` primitive and handle `ValueError` locally.

### 1. `teams.get_team()` — HTTPException raised then swallowed
```python
try:
    safe_path_join(_TEAMS_ROOT, f"{team_id}.json")
except Exception:        # catches the HTTPException the wrapper just raised
    return None
```
The wrapper exists solely to turn `ValueError → HTTPException`; here that exception is immediately caught and discarded back to `None`. Now calls `safe_join()` and catches `ValueError`.

### 2. `shows.watch_show()` — HTTP wrapper inside an SSE generator, and redundant
`watch_show()` runs inside an SSE stream. A raised `HTTPException` there cannot become a clean 404 — the `200`/`text/event-stream` response has already started. The call was also **redundant** with the route's preceding `get_show()` guard (`routers/shows.py`), and contradicted `watch_show()`'s own documented contract (*"emits `{"type":"done"}` when the show directory does not exist"*). Now calls `safe_join()` and yields the `done` event on `ValueError`.

## Behavior

External behavior is unchanged:
- teams: invalid/missing `team_id` → `None` → **404** at the route (as before).
- shows: invalid topic on `/api/shows/{topic}/stream` → already **404** via the `get_show()` guard; `watch_show()` now yields `done` instead of raising mid-stream.

The change removes reliance on a broad `except Exception` swallow and a wrong-context `HTTPException` raise.

## Not changed (verified legitimate)
- `plugins`/`playbooks`/`agents`/`skills` `get_*` discard `safe_path_join()`'s return then recompute the path — but they run on the request path with untrusted input, and `safe_join`'s symlink-escape check is a real check `validate_name` lacks, so they were left as-is.
- `definitions.validate_name_component` (×4) — service-boundary validation that also feeds SQL `WHERE`. Correct.
- All `public_path` calls — pure display formatter, not an HTTP wrapper.

## Tests
- `test_get_team_invalid_component_returns_none` + `test_team_detail_traversal_returns_404` — traversal rejected as 404, never 500.
- `test_watch_show_invalid_topic_yields_done` — `watch_show()` yields a single `done` event on an invalid topic instead of raising.
- Full `tests/apps_studio_server/` suite green (167 tests); ruff format + check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)