### PR TITLE
fix(messages): preserve error field in ActionResponseContent round-trip

### DIFF
--- a/lionagi/protocols/messages/action_response.py
+++ b/lionagi/protocols/messages/action_response.py
@@ -73,10 +73,12 @@ class ActionResponseContent(MessageContent):
             function = resp.get("function", "")
             arguments = resp.get("arguments", {})
             output = resp.get("output")
+            error = resp.get("error")
         else:
             function = data.get("function", "")
             arguments = data.get("arguments", {})
             output = data.get("output")
+            error = data.get("error")
 
         action_request_id = data.get("action_request_id")
         if action_request_id:
@@ -87,6 +89,7 @@ class ActionResponseContent(MessageContent):
             arguments=arguments,
             output=output,
             action_request_id=action_request_id,
+            error=error,
         )
 
 

--- a/tests/protocols/messages/test_action_response.py
+++ b/tests/protocols/messages/test_action_response.py
@@ -464,3 +464,33 @@ def test_action_response_content_rendered_is_always_string():
         rendered = content.rendered
         assert isinstance(rendered, str)
         assert len(rendered) > 0  # Should not be empty string
+
+
+def test_error_field_round_trips_through_to_dict_from_dict():
+    """Error and success must survive a to_dict/from_dict round-trip."""
+    original = ActionResponseContent(
+        function="call_tool",
+        arguments={"x": 1},
+        output=None,
+        action_request_id="req-1",
+        error="timeout after 30s",
+    )
+    assert not original.success
+
+    restored = ActionResponseContent.from_dict(original.to_dict())
+    assert restored.error == original.error
+    assert not restored.success
+
+
+def test_success_true_round_trips_through_to_dict_from_dict():
+    """A successful (error=None) response must remain successful after round-trip."""
+    original = ActionResponseContent(
+        function="call_tool",
+        arguments={},
+        output={"ok": True},
+    )
+    assert original.success
+
+    restored = ActionResponseContent.from_dict(original.to_dict())
+    assert restored.error is None
+    assert restored.success


### PR DESCRIPTION
Closes #1460

## Summary
- `from_dict` was silently dropping the `error` field on reload, causing `.success` to flip `False→True` for persisted tool-error responses.
- Thread `error` through `from_dict` for both the flat format and the legacy nested `action_response` format. `to_dict` already emitted the field correctly.
- Add two round-trip tests: one asserting error and `.success=False` survive serialization, one asserting a clean response stays `.success=True`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)