### PR TITLE
fix(cli): li schedule _base_url respects LIONAGI_STUDIO_PORT

### DIFF
--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -468,11 +468,13 @@ def _launch_vite_dev(
 
 # --- `li schedule` — manage lionagi Studio schedules from the CLI ---
 
-_DEFAULT_BASE = "http://127.0.0.1:8765"
-
 
 def _base_url() -> str:
-    return os.environ.get("LIONAGI_STUDIO_URL", _DEFAULT_BASE).rstrip("/")
+    if url := os.environ.get("LIONAGI_STUDIO_URL"):
+        return url.rstrip("/")
+    host = os.environ.get("LIONAGI_STUDIO_HOST", "127.0.0.1")
+    port = os.environ.get("LIONAGI_STUDIO_PORT", "8765")
+    return f"http://{host}:{port}"
 
 
 def _api(path: str, method: str = "GET", body: dict | None = None) -> Any:

--- a/tests/cli/test_schedule_cli.py
+++ b/tests/cli/test_schedule_cli.py
@@ -103,3 +103,46 @@ def test_schedule_list_api_error_returns_1(monkeypatch):
     args = parser.parse_args(["schedule", "list"])
     result = run_schedule(args)
     assert result == 1
+
+
+def test_base_url_default(monkeypatch):
+    """_base_url returns the default when no env vars are set."""
+    monkeypatch.delenv("LIONAGI_STUDIO_URL", raising=False)
+    monkeypatch.delenv("LIONAGI_STUDIO_HOST", raising=False)
+    monkeypatch.delenv("LIONAGI_STUDIO_PORT", raising=False)
+
+    from lionagi.studio.cli import _base_url
+
+    assert _base_url() == "http://127.0.0.1:8765"
+
+
+def test_base_url_respects_studio_port(monkeypatch):
+    """_base_url reflects LIONAGI_STUDIO_PORT when set."""
+    monkeypatch.delenv("LIONAGI_STUDIO_URL", raising=False)
+    monkeypatch.delenv("LIONAGI_STUDIO_HOST", raising=False)
+    monkeypatch.setenv("LIONAGI_STUDIO_PORT", "9000")
+
+    from lionagi.studio.cli import _base_url
+
+    assert _base_url() == "http://127.0.0.1:9000"
+
+
+def test_base_url_respects_studio_host(monkeypatch):
+    """_base_url reflects LIONAGI_STUDIO_HOST when set."""
+    monkeypatch.delenv("LIONAGI_STUDIO_URL", raising=False)
+    monkeypatch.setenv("LIONAGI_STUDIO_HOST", "0.0.0.0")
+    monkeypatch.setenv("LIONAGI_STUDIO_PORT", "8765")
+
+    from lionagi.studio.cli import _base_url
+
+    assert _base_url() == "http://0.0.0.0:8765"
+
+
+def test_base_url_studio_url_takes_precedence(monkeypatch):
+    """LIONAGI_STUDIO_URL wins over host/port env vars."""
+    monkeypatch.setenv("LIONAGI_STUDIO_URL", "https://studio.example.com/")
+    monkeypatch.setenv("LIONAGI_STUDIO_PORT", "9999")
+
+    from lionagi.studio.cli import _base_url
+
+    assert _base_url() == "https://studio.example.com"


### PR DESCRIPTION
Closes #1468

## Summary
- _base_url() in lionagi/studio/cli.py now reads LIONAGI_STUDIO_HOST and LIONAGI_STUDIO_PORT from the environment instead of returning the hardcoded string http://127.0.0.1:8765.
- When neither env var is set, the default (http://127.0.0.1:8765) is unchanged. LIONAGI_STUDIO_URL still takes full precedence when set.

## Test plan
- [ ] test_base_url_default: unset env vars yields http://127.0.0.1:8765
- [ ] test_base_url_respects_studio_port: LIONAGI_STUDIO_PORT=9000 yields http://127.0.0.1:9000
- [ ] test_base_url_respects_studio_host: custom host is reflected in URL
- [ ] test_base_url_studio_url_takes_precedence: LIONAGI_STUDIO_URL wins over port/host vars
- [ ] All 11 tests in tests/cli/test_schedule_cli.py pass

Generated with Claude Code