### PR TITLE
chore(hooks): annotate dead HookPoint enum entries

### DIFF
--- a/lionagi/hooks/bus.py
+++ b/lionagi/hooks/bus.py
@@ -32,18 +32,19 @@ __all__ = (
 class HookPoint(str, Enum):
     """Closed vocabulary of session lifecycle hook points (see docs/reference/agent-hooks.md)."""
 
+    # not-yet-wired: no emit() call in the codebase; handlers registered but never invoked
     SESSION_START = "session.start"
     SESSION_END = "session.end"
-
     BRANCH_CREATE = "branch.create"
+    # not-yet-wired: no emit() call in the codebase
     API_PRE_CALL = "api.pre_call"
     API_POST_CALL = "api.post_call"
     API_STREAM_CHUNK = "api.stream_chunk"
-    TOOL_PRE = "tool.pre"
-    TOOL_POST = "tool.post"
-    TOOL_ERROR = "tool.error"
-    MESSAGE_ADD = "message.add"
-    ARTIFACT_CREATED = "artifact.created"
+    TOOL_PRE = "tool.pre"  # not-yet-wired: blocking_emit routing exists but no call site
+    TOOL_POST = "tool.post"  # not-yet-wired
+    TOOL_ERROR = "tool.error"  # not-yet-wired
+    MESSAGE_ADD = "message.add"  # live: emitted in session/branch.py
+    ARTIFACT_CREATED = "artifact.created"  # not-yet-wired
 
 
 HookHandler = Callable[..., Awaitable[Any] | Any]


### PR DESCRIPTION
Closes #1467

## Summary
- `MESSAGE_ADD` is the only `HookPoint` with an active `emit()` call site (`session/branch.py`).
- All other entries (`SESSION_START`, `SESSION_END`, `BRANCH_CREATE`, `API_PRE_CALL`, `API_POST_CALL`, `API_STREAM_CHUNK`, `TOOL_PRE`, `TOOL_POST`, `TOOL_ERROR`, `ARTIFACT_CREATED`) have no callers anywhere in the codebase.

Adds terse inline comments at each non-emitting entry so the gap is immediately visible at the definition. Annotation-only — no behavior change, no entries removed.

## Test plan
- [ ] `uv run pytest tests/hooks/test_bus.py tests/hooks/test_loader.py tests/hooks/test_bus_observer.py` — 43 passed
- [ ] `from lionagi.hooks.bus import HookPoint` imports cleanly with all 11 enum values intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)