### PR TITLE
chore(studio): remove stale phase-0 comments

### DIFF
--- a/lionagi/studio/app.py
+++ b/lionagi/studio/app.py
@@ -125,11 +125,9 @@ async def require_studio_bearer_token(request: Request, call_next):
     return await call_next(request)
 
 
-# Mount routes registered via the @studio_route decorator. In phase 0 the
-# registry is empty (_STUDIO_ROUTE_MODULES = ()), so this loop adds nothing
-# and observable behavior is unchanged. Future phases append area modules to
-# _STUDIO_ROUTE_MODULES so their routes are registered here instead of via
-# include_router.
+# Mount routes registered via the @studio_route decorator. Area modules listed
+# in _STUDIO_ROUTE_MODULES are imported here so their @studio_route decorators
+# fire and populate _ROUTES before the loop below adds each route to the app.
 load_studio_route_modules()
 for _route in iter_studio_routes():
     app.add_api_route(

--- a/lionagi/studio/registry.py
+++ b/lionagi/studio/registry.py
@@ -39,10 +39,7 @@ class StudioRoute:
 _ROUTES: list[StudioRoute] = []
 _DEDUP_KEYS: set[tuple[str, str, str, str]] = set()
 
-# Area modules are appended here as each area migrates in later phases, in this
-# contractual order: casts, runs, engine_runs, sessions, definitions, agents,
-# playbooks, shows, skills, plugins, admin, teams, invocations, launches,
-# projects, schedules, engine_defs, stats.
+# Area modules imported at startup; order controls route registration sequence.
 _STUDIO_ROUTE_MODULES: tuple[str, ...] = (
     "lionagi.studio.services.casts",
     "lionagi.studio.services.runs",


### PR DESCRIPTION
Closes #1469

Route migration to `@studio_route` is complete. Two comments described a transitional state that no longer exists:
- `app.py`: claimed the registry was empty and the load loop added nothing
- `registry.py`: said modules would be appended "in later phases" with a migration ordering note

Both are replaced with accurate descriptions of what the code does today.

## Note on `EngineRun.run_team`

The issue brief describes `run_team` as a dead duplicate of `_drive_node` with zero production callers. This is partially accurate: there are no callers in production code. However, two **live tests** in `tests/engines/test_engine.py` directly exercise `EngineRun.run_team` (`test_run_team_sequences_and_carries_output`, `test_run_team_survives_agent_failure`). Per the scope instructions ("if a live test exercises it, STOP and report"), the method removal is not included here. The method is also functionally distinct from `ResearchEngine._drive_node` (no repair logic, no novelty checks, no emit tracking). The dead-method removal should be a separate decision with the tests handled explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)