### PR TITLE
refactor(session): drop dead progress/tool_manager params from new_branch()

### DIFF
--- a/lionagi/session/session.py
+++ b/lionagi/session/session.py
@@ -31,7 +31,7 @@ from .._errors import ItemNotFoundError
 from ..ln import lcall
 from ..protocols.generic import Flow
 from ..protocols.messages import Message
-from .branch import ActionManager, Branch, OperationManager, Tool
+from .branch import Branch, OperationManager, Tool
 from .exchange import Exchange
 
 
@@ -182,8 +182,6 @@ class Session(Node, Relational):
         user: SenderRecipient = None,
         name: str | None = None,
         messages: Pile[RoledMessage] = None,
-        progress: Progression = None,
-        tool_manager: ActionManager = None,
         tools: Tool | Callable | list = None,
         as_default_branch: bool = False,
         **kwargs,


### PR DESCRIPTION
Closes #1461

`Session.new_branch()` declared `progress: Progression` and `tool_manager: ActionManager` parameters that were never forwarded to `Branch` — `Branch.__init__` does not accept them, and the `locals()`-based param collection skips `None` values so they were silently dropped even if passed.

Grep confirms no caller in `lionagi/` or `tests/` passes either kwarg. Removing them cleans the public API without breaking anything.

## Changes
- Remove `progress` and `tool_manager` params from `new_branch()` signature
- Remove now-unused `ActionManager` import in `session.py`

## Test results
`uv run pytest tests/ -k "new_branch or session"` — **610 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)