### PR TITLE
refactor(operations): dedup validate helper, collapse ReActStream, drop dead flow_with_cleanup

### DIFF
--- a/lionagi/operations/ReAct/ReAct.py
+++ b/lionagi/operations/ReAct/ReAct.py
@@ -164,64 +164,36 @@ async def ReAct_v1(  # noqa: N802  # public name preserves the ReAct acronym
     """Collect all ReActStream outputs; return list of analyses when return_analysis=True, else the final result."""
     outs = []
 
-    if verbose_analysis:
-        async for i in ReActStream(
-            branch=branch,
-            instruction=instruction,
-            chat_param=chat_param,
-            action_param=action_param,
-            parse_param=parse_param,
-            intp_param=intp_param,
-            resp_ctx=resp_ctx,
-            reasoning_effort=reasoning_effort,
-            reason=reason,
-            field_models=field_models,
-            handle_validation=handle_validation,
-            invoke_actions=invoke_actions,
-            clear_messages=clear_messages,
-            intermediate_response_options=intermediate_response_options,
-            intermediate_listable=intermediate_listable,
-            intermediate_nullable=intermediate_nullable,
-            max_extensions=max_extensions,
-            extension_allowed=extension_allowed,
-            verbose_analysis=verbose_analysis,
-            display_as=display_as,
-            verbose_length=verbose_length,
-            continue_after_failed_response=continue_after_failed_response,
-            between_rounds=between_rounds,
-        ):
+    async for i in ReActStream(
+        branch=branch,
+        instruction=instruction,
+        chat_param=chat_param,
+        action_param=action_param,
+        parse_param=parse_param,
+        intp_param=intp_param,
+        resp_ctx=resp_ctx,
+        reasoning_effort=reasoning_effort,
+        reason=reason,
+        field_models=field_models,
+        handle_validation=handle_validation,
+        invoke_actions=invoke_actions,
+        clear_messages=clear_messages,
+        intermediate_response_options=intermediate_response_options,
+        intermediate_listable=intermediate_listable,
+        intermediate_nullable=intermediate_nullable,
+        max_extensions=max_extensions,
+        extension_allowed=extension_allowed,
+        verbose_analysis=verbose_analysis,
+        display_as=display_as,
+        verbose_length=verbose_length,
+        continue_after_failed_response=continue_after_failed_response,
+        between_rounds=between_rounds,
+    ):
+        if verbose_analysis:
             analysis, str_ = i
-            as_readable(
-                str_,
-                md=True,
-                display_str=True,
-            )
+            as_readable(str_, md=True, display_str=True)
             outs.append(analysis)
-    else:
-        async for i in ReActStream(
-            branch=branch,
-            instruction=instruction,
-            chat_param=chat_param,
-            action_param=action_param,
-            parse_param=parse_param,
-            intp_param=intp_param,
-            resp_ctx=resp_ctx,
-            reasoning_effort=reasoning_effort,
-            reason=reason,
-            field_models=field_models,
-            handle_validation=handle_validation,
-            invoke_actions=invoke_actions,
-            clear_messages=clear_messages,
-            intermediate_response_options=intermediate_response_options,
-            intermediate_listable=intermediate_listable,
-            intermediate_nullable=intermediate_nullable,
-            max_extensions=max_extensions,
-            extension_allowed=extension_allowed,
-            display_as=display_as,
-            verbose_length=verbose_length,
-            continue_after_failed_response=continue_after_failed_response,
-            between_rounds=between_rounds,
-        ):
+        else:
             outs.append(i)
 
     if return_analysis:

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -855,33 +855,3 @@ def cleanup_flow_results(result: dict[str, Any], keep_only: list[str] = None) ->
         result["completed_operations"] = []
 
     return result
-
-
-async def flow_with_cleanup(
-    session: "Session",
-    graph: "Graph",
-    context: dict[str, Any] | None = None,
-    parallel: bool = True,
-    max_concurrent: int = 5,
-    verbose: bool = False,
-    branch: "Branch" = None,
-    alcall_params: AlcallParams | None = None,
-    cleanup_results: bool = True,
-    keep_only: list[str] = None,
-) -> dict[str, Any]:
-    """Execute flow with optional post-run cleanup."""
-    result = await flow(
-        session=session,
-        graph=graph,
-        context=context,
-        parallel=parallel,
-        max_concurrent=max_concurrent,
-        verbose=verbose,
-        branch=branch,
-        alcall_params=alcall_params,
-    )
-
-    if cleanup_results:
-        result = cleanup_flow_results(result, keep_only=keep_only)
-
-    return result

--- a/lionagi/operations/schema/json_structure.py
+++ b/lionagi/operations/schema/json_structure.py
@@ -9,7 +9,6 @@ from typing import Any
 import orjson
 from pydantic import BaseModel
 
-from lionagi.ln import extract_json, fuzzy_validate_mapping, to_list
 from lionagi.ln.fuzzy import FuzzyMatchKeysParams
 
 from .structure import Structure
@@ -79,47 +78,12 @@ class JsonStructure(Structure):
             "No triple backticks. Escape all quotes and special characters."
         ).strip()
 
-    # ------------------------------------------------------------------
-    # Canonical parsing — copied from operations/parse
-    # ------------------------------------------------------------------
-
     @staticmethod
     def _validate_dict_or_model(
         text: str,
         response_format: type[BaseModel] | dict | Any,
         fuzzy_match_params: FuzzyMatchKeysParams | dict = None,
     ):
-        try:
-            if isinstance(fuzzy_match_params, dict):
-                fuzzy_match_params = FuzzyMatchKeysParams(**fuzzy_match_params)
+        from lionagi.operations.parse.parse import _validate_dict_or_model
 
-            d_ = extract_json(text, fuzzy_parse=True, return_one_if_single=False)
-            dict_, keys_ = None, None
-            if d_:
-                dict_ = to_list(d_, flatten=True)[0]
-            if isinstance(fuzzy_match_params, FuzzyMatchKeysParams):
-                keys_ = (
-                    response_format.model_fields
-                    if isinstance(response_format, type)
-                    else response_format
-                )
-                dict_ = fuzzy_validate_mapping(dict_, keys_, **fuzzy_match_params.to_dict())
-            elif fuzzy_match_params:
-                keys_ = (
-                    response_format.model_fields
-                    if isinstance(response_format, type)
-                    else response_format
-                )
-                dict_ = fuzzy_validate_mapping(
-                    dict_,
-                    keys_,
-                    handle_unmatched="force",
-                    fill_value=None,
-                    strict=False,
-                )
-            if isinstance(response_format, type) and issubclass(response_format, BaseModel):
-                return response_format.model_validate(dict_)
-            return dict_
-
-        except Exception as e:
-            raise ValueError(f"Failed to parse text: {e}") from e
+        return _validate_dict_or_model(text, response_format, fuzzy_match_params)


### PR DESCRIPTION
Closes #1464
Closes #1465
Closes #1466

## Summary
- **#1464**: `JsonStructure._validate_dict_or_model` now delegates to the canonical `_validate_dict_or_model` in `parse.py`, eliminating 39 lines of duplicated dict-or-model validation logic (the shim-required `logger` name is preserved)
- **#1465**: `ReAct_v1` had two identical `ReActStream` loops diverging only on the `verbose_analysis` branch; collapsed to a single loop with a post-yield display branch
- **#1466**: `flow_with_cleanup` had zero callers outside its own file and was not exported; removed the 28-line dead function; `cleanup_flow_results` (which has dedicated tests) is untouched

All three changes are behavior-preserving. 79/79 targeted tests pass; 6 pre-existing failures confirmed present on main before this branch.