### PR TITLE
chore(state): declare explicit public __all__ for the state package

### DIFF
--- a/tests/state/test_public_surface.py
+++ b/tests/state/test_public_surface.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+import lionagi.state as state_pkg
+from lionagi.state import StateDB
+
+
+def test_all_is_declared():
+    assert hasattr(state_pkg, "__all__")
+
+
+def test_all_contents():
+    assert set(state_pkg.__all__) == {"StateDB"}
+
+
+def test_statedb_importable():
+    assert StateDB is state_pkg.StateDB


### PR DESCRIPTION
Closes #1473

## Summary

- `lionagi/state/__init__.py` already had `__all__ = ("StateDB",)` since the package was first committed; the declared surface is correct and complete.
- Adds `tests/state/test_public_surface.py` to pin the public surface and prevent future drift.

## Test plan

- `uv run pytest tests/state/test_public_surface.py` — 3 passed
- `uv run pytest tests/state/` — 319 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)