### PR TITLE
test(studio): add shared studio_client fixture, dedup test client setup

### DIFF
--- a/tests/apps_studio_server/conftest.py
+++ b/tests/apps_studio_server/conftest.py
@@ -1,0 +1,16 @@
+"""Shared fixtures for the apps_studio_server test suite."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture()
+def studio_client():
+    """Return a TestClient wired to the studio app with no additional patching."""
+    fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
+    from fastapi.testclient import TestClient
+
+    from lionagi.studio.app import app
+
+    return TestClient(app)

--- a/tests/apps_studio_server/test_casts_api.py
+++ b/tests/apps_studio_server/test_casts_api.py
@@ -8,106 +8,85 @@ from __future__ import annotations
 import pytest
 
 fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
-from fastapi.testclient import TestClient  # noqa: E402
-
-
-def _make_client() -> TestClient:
-    from lionagi.studio.app import app
-
-    return TestClient(app)
 
 
 class TestGetCasts:
-    def test_status_ok(self):
-        client = _make_client()
-        r = client.get("/api/casts/")
+    def test_status_ok(self, studio_client):
+        r = studio_client.get("/api/casts/")
         assert r.status_code == 200
 
-    def test_top_level_keys(self):
-        client = _make_client()
-        data = client.get("/api/casts/").json()
+    def test_top_level_keys(self, studio_client):
+        data = studio_client.get("/api/casts/").json()
         assert "roles" in data
         assert "modes" in data
 
-    def test_roles_is_list(self):
-        client = _make_client()
-        assert isinstance(client.get("/api/casts/").json()["roles"], list)
+    def test_roles_is_list(self, studio_client):
+        assert isinstance(studio_client.get("/api/casts/").json()["roles"], list)
 
-    def test_modes_is_list(self):
-        client = _make_client()
-        assert isinstance(client.get("/api/casts/").json()["modes"], list)
+    def test_modes_is_list(self, studio_client):
+        assert isinstance(studio_client.get("/api/casts/").json()["modes"], list)
 
-    def test_role_entry_shape(self):
-        client = _make_client()
-        data = client.get("/api/casts/").json()
+    def test_role_entry_shape(self, studio_client):
+        data = studio_client.get("/api/casts/").json()
         for role in data["roles"]:
             for field in ("name", "description", "emits", "body", "config"):
                 assert field in role, f"role {role.get('name')!r} missing {field!r}"
             assert isinstance(role["emits"], list)
             assert role["config"] is None or isinstance(role["config"], dict)
 
-    def test_emit_entry_shape(self):
-        client = _make_client()
-        data = client.get("/api/casts/").json()
+    def test_emit_entry_shape(self, studio_client):
+        data = studio_client.get("/api/casts/").json()
         for role in data["roles"]:
             for entry in role["emits"]:
                 assert "model" in entry
                 assert "key" in entry
 
-    def test_mode_entry_shape(self):
-        client = _make_client()
-        data = client.get("/api/casts/").json()
+    def test_mode_entry_shape(self, studio_client):
+        data = studio_client.get("/api/casts/").json()
         for mode in data["modes"]:
             for field in ("name", "description", "behaviors", "conflicts_with"):
                 assert field in mode, f"mode {mode.get('name')!r} missing {field!r}"
             assert isinstance(mode["conflicts_with"], list)
 
-    def test_known_roles_present(self):
-        client = _make_client()
-        data = client.get("/api/casts/").json()
+    def test_known_roles_present(self, studio_client):
+        data = studio_client.get("/api/casts/").json()
         names = {r["name"] for r in data["roles"]}
         assert "analyst" in names
         assert "critic" in names
 
-    def test_known_modes_present(self):
-        client = _make_client()
-        data = client.get("/api/casts/").json()
+    def test_known_modes_present(self, studio_client):
+        data = studio_client.get("/api/casts/").json()
         names = {m["name"] for m in data["modes"]}
         assert "adversarial" in names
         assert "evidential" in names
 
-    def test_non_empty(self):
-        client = _make_client()
-        data = client.get("/api/casts/").json()
+    def test_non_empty(self, studio_client):
+        data = studio_client.get("/api/casts/").json()
         assert len(data["roles"]) > 0
         assert len(data["modes"]) > 0
 
-    def test_analyst_emits_contains_escalation_request(self):
+    def test_analyst_emits_contains_escalation_request(self, studio_client):
         """EscalationRequest is implicitly added to every emitting role."""
-        client = _make_client()
-        data = client.get("/api/casts/").json()
+        data = studio_client.get("/api/casts/").json()
         analyst = next(r for r in data["roles"] if r["name"] == "analyst")
         emit_models = {e["model"] for e in analyst["emits"]}
         assert "EscalationRequest" in emit_models
 
-    def test_analyst_emits_contains_analysis_result(self):
-        client = _make_client()
-        data = client.get("/api/casts/").json()
+    def test_analyst_emits_contains_analysis_result(self, studio_client):
+        data = studio_client.get("/api/casts/").json()
         analyst = next(r for r in data["roles"] if r["name"] == "analyst")
         emit_models = {e["model"] for e in analyst["emits"]}
         assert "AnalysisResult" in emit_models
 
-    def test_emit_keys_are_snake_case(self):
+    def test_emit_keys_are_snake_case(self, studio_client):
         """key field is snake_case (from field_name_for)."""
-        client = _make_client()
-        data = client.get("/api/casts/").json()
+        data = studio_client.get("/api/casts/").json()
         analyst = next(r for r in data["roles"] if r["name"] == "analyst")
         esc = next(e for e in analyst["emits"] if e["model"] == "EscalationRequest")
         assert esc["key"] == "escalation_request"
 
-    def test_pack_config_present_for_critic(self):
-        client = _make_client()
-        data = client.get("/api/casts/").json()
+    def test_pack_config_present_for_critic(self, studio_client):
+        data = studio_client.get("/api/casts/").json()
         critic = next(r for r in data["roles"] if r["name"] == "critic")
         assert critic["config"] is not None
         cfg = critic["config"]


### PR DESCRIPTION
Closes #1474

## Summary
- Adds `tests/apps_studio_server/conftest.py` with a `studio_client` pytest fixture providing a bare `TestClient(app)` with no monkeypatching.
- Migrates `test_casts_api.py` — the only file with an identical bare-app client setup — to consume the shared fixture, removing the local `_make_client()` helper and 13 per-test redundant calls.
- All other test files use bespoke setups (different service-module patches per test) and are left unchanged; consolidating them would alter effective client configuration.

## Test plan
- [ ] `uv run pytest tests/apps_studio_server/` passes with identical counts before and after (34 failed, 41 passed, 56 skipped, 50 errors — pre-existing failures unrelated to this change).
- [ ] `test_casts_api.py` skips cleanly when studio extra is not installed (same as before — module-level `importorskip` still guards the file).
- [ ] Lint and pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)