### PR TITLE
fix(messages): remove dead lionagi.beta import path in prepare.py

### DIFF
--- a/lionagi/protocols/messages/prepare.py
+++ b/lionagi/protocols/messages/prepare.py
@@ -79,24 +79,7 @@ def _build_round_notification(
     """Build system notification block for agent grounding between rounds."""
     ts = int(time.time())
 
-    capabilities: set[str] = set()
-    resources: set[str] = set()
-
-    # Branch is session-layer; import lazily to avoid circular dependency.
-    try:
-        from lionagi.beta.session.session import Branch  # type: ignore[import]
-
-        if isinstance(progression, Branch):
-            capabilities = getattr(progression, "capabilities", set())
-            resources = getattr(progression, "resources", set())
-    except ImportError:
-        pass
-
     parts = [f'<system round="{round_num}" time="{ts}">']
-    if capabilities:
-        parts.append(f"  tools: [{', '.join(sorted(capabilities))}]")
-    if resources:
-        parts.append(f"  resources: [{', '.join(sorted(resources))}]")
     parts.append(f"  context: {msg_count} msgs | round {round_num}")
     if scratchpad:
         scratch_lines = ["  scratchpad:"]


### PR DESCRIPTION
Closes #1481

## Summary

- `_build_round_notification` in `prepare.py` had a `try/except ImportError` block importing `Branch` from `lionagi.beta.session.session`, a package that does not exist.
- The import always failed; the `except ImportError: pass` silently swallowed it, making the `capabilities`/`resources` injection permanently dead code — behavior was **unchanged** at runtime.
- Removed the dead `try/except` block and the two `if capabilities:` / `if resources:` conditional sections that consumed variables it set.

## Test plan

- [x] Circular import check: `python -c "import lionagi; from lionagi.protocols.messages import prepare; print('ok')"` — passes
- [x] `tests/protocols/messages/test_rendering.py` + `tests/operations/test_chat_prepare.py` — 50/50 passed
- [x] Breadth suite `-k "prepare or instruction or message"` — 591 passed, 0 failed
- [x] `ruff format` + `ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)