### PR TITLE
refactor(agent): rename log_tool_use to log_tool_call with deprecation alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- `log_tool_call` in `lionagi.agent.hooks` and `lionagi.hooks.builtins` — canonical name for the tool-call observability post-hook, replacing `log_tool_use`. Also name-addressable via `lionagi.hooks.loader` registry as `"log_tool_call"`.
+
+### Deprecated
+
+- `log_tool_use` in `lionagi.agent.hooks` and `lionagi.hooks.builtins` — use `log_tool_call` instead. Will be removed in a future minor release.
+
 ### Removed
 
 - `request_fields` phantom param dropped from `MessageManager.create_instruction`, `create_message`, and `add_message` (was accepted but silently ignored); `parse_lndl_fuzzy` removed from `lndl.__all__` (Phase-2 feature, not yet shipped).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ Modules: chat, parse, operate, ReAct, select, interpret, communicate, run, act. 
 - **`spec.py`** — `AgentSpec` dataclass (Profile + runtime concerns) with constructors `.compose(role, ...)` and preset `.coding()` (CodingToolkit + guard hooks + workspace path policy). Also `HooksMixin` and `_wire_secure_guards`.
 - **`factory.py`** — `create_agent(config: AgentSpec, ...)` async factory: wires a `Branch`, registers tools from the spec, attaches hooks, returns ready-to-use branch.
 - **`permissions.py`** — `PermissionPolicy` with `allow_all` / `deny_all` / `rules` modes. Applied per tool call before execution.
-- **`hooks.py`** — Built-in hooks: `guard_destructive` (blocks rm/drop/truncate), `guard_paths(allowed_paths=...)` (restricts file access to allowed roots), `log_tool_use` (structured tool-call logging).
+- **`hooks.py`** — Built-in hooks: `guard_destructive` (blocks rm/drop/truncate), `guard_paths(allowed_paths=...)` (restricts file access to allowed roots), `log_tool_call` (structured tool-call logging; `log_tool_use` is a deprecated alias).
 - **`settings.py`** — Loads `.lionagi/settings.yaml`; merges global (`~/.lionagi/settings.yaml`) with project-level (`.lionagi/settings.yaml`), project wins on conflict.
 
 ### Sandbox (`lionagi/tools/sandbox.py`)

--- a/docs/reference/agent-hooks.md
+++ b/docs/reference/agent-hooks.md
@@ -58,7 +58,8 @@ keep their defaults.
 | `persist_branch_provenance` | `BRANCH_CREATE` |
 | `persist_message` | `MESSAGE_ADD` |
 | `log_api_metrics` | (name-addressable; not in DEFAULT_HOOKS) |
-| `log_tool_use` | (name-addressable; not in DEFAULT_HOOKS) |
+| `log_tool_call` | (name-addressable; not in DEFAULT_HOOKS) |
+| `log_tool_use` | (name-addressable; not in DEFAULT_HOOKS; deprecated — use `log_tool_call`) |
 
 All handlers are name-addressable via the loader registry and can be referenced
 as strings in agent YAML profiles.

--- a/lionagi/agent/hooks.py
+++ b/lionagi/agent/hooks.py
@@ -7,12 +7,14 @@ from __future__ import annotations
 
 import logging
 import re
+import warnings
 from pathlib import Path
 
 __all__ = (
     "auto_format_python",
     "guard_destructive",
     "guard_paths",
+    "log_tool_call",
     "log_tool_use",
 )
 
@@ -95,11 +97,22 @@ def guard_paths(
     return _guard
 
 
-async def log_tool_use(tool_name: str, action: str, args: dict, result: dict) -> dict | None:
-    """Post-hook: log tool usage for observability."""
+async def log_tool_call(tool_name: str, action: str, args: dict, result: dict) -> dict | None:
+    """Post-hook: log tool call for observability."""
     success = result.get("success", result.get("return_code") == 0)
     logger.info("tool=%s action=%s success=%s", tool_name, action, success)
     return None
+
+
+async def log_tool_use(tool_name: str, action: str, args: dict, result: dict) -> dict | None:
+    """Deprecated: use log_tool_call instead."""
+    warnings.warn(
+        "log_tool_use is deprecated and will be removed in a future minor release. "
+        "Use log_tool_call instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return await log_tool_call(tool_name, action, args, result)
 
 
 async def auto_format_python(tool_name: str, action: str, args: dict, result: dict) -> dict | None:

--- a/lionagi/hooks/builtins.py
+++ b/lionagi/hooks/builtins.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import logging
 import time
+import warnings
 from typing import Any
 
 logger = logging.getLogger("lionagi.hooks.builtins")
@@ -16,6 +17,7 @@ __all__ = (
     "persist_branch_provenance",
     "persist_message",
     "log_api_metrics",
+    "log_tool_call",
     "log_tool_use",
 )
 
@@ -147,7 +149,7 @@ async def log_api_metrics(
         )
 
 
-async def log_tool_use(
+async def log_tool_call(
     *,
     tool_name: str,
     action: str | None = None,
@@ -161,3 +163,20 @@ async def log_tool_use(
         action,
         list(args.keys()) if args else [],
     )
+
+
+async def log_tool_use(
+    *,
+    tool_name: str,
+    action: str | None = None,
+    args: dict[str, Any] | None = None,
+    **_unused: Any,
+) -> None:
+    """Deprecated: use log_tool_call instead."""
+    warnings.warn(
+        "log_tool_use is deprecated and will be removed in a future minor release. "
+        "Use log_tool_call instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    await log_tool_call(tool_name=tool_name, action=action, args=args)

--- a/lionagi/hooks/loader.py
+++ b/lionagi/hooks/loader.py
@@ -36,6 +36,7 @@ _REGISTRY: dict[str, HookHandler] = {
     "persist_branch_provenance": _builtins.persist_branch_provenance,
     "persist_message": _builtins.persist_message,
     "log_api_metrics": _builtins.log_api_metrics,
+    "log_tool_call": _builtins.log_tool_call,
     "log_tool_use": _builtins.log_tool_use,
 }
 

--- a/tests/docs/test_agent_sandbox_api.py
+++ b/tests/docs/test_agent_sandbox_api.py
@@ -170,6 +170,19 @@ class TestHookSignatures:
         assert "allowed_paths" in param_names
         assert "allowed" not in param_names
 
+    def test_log_tool_call_is_async(self):
+        from lionagi.agent.hooks import log_tool_call
+
+        assert inspect.iscoroutinefunction(log_tool_call)
+
+    def test_log_tool_call_no_sink_param(self):
+        """log_tool_call is a plain function, not a factory with a sink param."""
+        from lionagi.agent.hooks import log_tool_call
+
+        sig = inspect.signature(log_tool_call)
+        param_names = set(sig.parameters.keys())
+        assert "sink" not in param_names
+
     def test_log_tool_use_is_async(self):
         from lionagi.agent.hooks import log_tool_use
 

--- a/tests/hooks/test_loader.py
+++ b/tests/hooks/test_loader.py
@@ -28,6 +28,7 @@ def test_builtins_resolvable_by_name():
         "persist_branch_provenance",
         "persist_message",
         "log_api_metrics",
+        "log_tool_call",
         "log_tool_use",
     ):
         assert callable(resolve_handler(name)), f"{name!r} not registered"
@@ -116,7 +117,7 @@ def test_build_session_bus_empty_list_disables_default():
 
 def test_build_session_bus_adds_handlers_for_non_default_points():
     """Profile may register handlers on points that have no default."""
-    bus = build_session_bus({"api.post_call": ["log_api_metrics"], "tool.pre": ["log_tool_use"]})
+    bus = build_session_bus({"api.post_call": ["log_api_metrics"], "tool.pre": ["log_tool_call"]})
     assert len(bus.handlers_for(HookPoint.API_POST_CALL)) == 1
     assert len(bus.handlers_for(HookPoint.TOOL_PRE)) == 1
 
@@ -138,3 +139,40 @@ def test_build_session_bus_returns_fresh_instance_each_call():
     assert a is not b
     assert isinstance(a, HookBus)
     assert isinstance(b, HookBus)
+
+
+# ── Deprecation alias ─────────────────────────────────────────────────────────
+
+
+import asyncio
+import warnings
+
+
+def test_log_tool_use_emits_deprecation_warning():
+    """log_tool_use must emit DeprecationWarning and delegate to log_tool_call."""
+    from lionagi.hooks.builtins import log_tool_use
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        asyncio.get_event_loop().run_until_complete(
+            log_tool_use(tool_name="bash", action="run", args={"command": "ls"})
+        )
+
+    dep_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert len(dep_warnings) == 1
+    assert "log_tool_call" in str(dep_warnings[0].message)
+
+
+def test_agent_log_tool_use_emits_deprecation_warning():
+    """lionagi.agent.hooks.log_tool_use must emit DeprecationWarning."""
+    from lionagi.agent.hooks import log_tool_use
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        asyncio.get_event_loop().run_until_complete(
+            log_tool_use("bash", "run", {}, {"success": True})
+        )
+
+    dep_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert len(dep_warnings) == 1
+    assert "log_tool_call" in str(dep_warnings[0].message)

--- a/tests/hooks/test_loader.py
+++ b/tests/hooks/test_loader.py
@@ -154,9 +154,7 @@ def test_log_tool_use_emits_deprecation_warning():
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        asyncio.get_event_loop().run_until_complete(
-            log_tool_use(tool_name="bash", action="run", args={"command": "ls"})
-        )
+        asyncio.run(log_tool_use(tool_name="bash", action="run", args={"command": "ls"}))
 
     dep_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
     assert len(dep_warnings) == 1
@@ -169,9 +167,7 @@ def test_agent_log_tool_use_emits_deprecation_warning():
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        asyncio.get_event_loop().run_until_complete(
-            log_tool_use("bash", "run", {}, {"success": True})
-        )
+        asyncio.run(log_tool_use("bash", "run", {}, {"success": True}))
 
     dep_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
     assert len(dep_warnings) == 1


### PR DESCRIPTION
Closes #1479

## Summary

- `log_tool_call` is now the canonical function in both `lionagi/agent/hooks.py` and `lionagi/hooks/builtins.py`; `log_tool_use` is kept as a thin backward-compatible wrapper that emits `DeprecationWarning` (stacklevel=2) before delegating.
- `log_tool_call` added to the `lionagi/hooks/loader.py` name registry so agent YAML profiles can address it as `"log_tool_call"`; `"log_tool_use"` entry retained for existing configs.
- Both names in `__all__` on both modules. CHANGELOG, `docs/reference/agent-hooks.md`, and `CLAUDE.md` updated. Deprecation tests added for both module paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)