### PR TITLE
chore(deps): move croniter to studio extra, de-duplicate pyyaml and aiosqlite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
     "aiohttp>=3.14.1",
     "anyio>=4.10.0",
     "backoff>=2.1.0",
-    "croniter>=1.4",
     "json-repair>=0.58.0",
     "msgspec>=0.20.0",
     "pydantic>=2.8.0",
@@ -138,22 +137,13 @@ sandbox = [
     "uvicorn>=0.34.0",
 ]
 
-testing = [
-    # Optional YAML support for ScriptModel.from_yaml(); JSON/dict workflows
-    # work without this extra.
-    "pyyaml>=6.0",
-]
+testing = []
 
 studio = [
     "fastapi>=0.115",
     "uvicorn>=0.34",
-    "pyyaml>=6.0",
     "starlette>=1.3.1",
-    # F-A4-9 (ADR-0018 §"li studio extras dependency"): aiosqlite is required
-    # by the studio services that query state.db directly (sessions, shows, runs,
-    # definitions). It is also listed as a core dep but explicit in the extra
-    # keeps the [studio] group self-contained for pip install lionagi[studio].
-    "aiosqlite>=0.21.0",
+    "croniter>=1.4",
 ]
 
 all = [

--- a/uv.lock
+++ b/uv.lock
@@ -3106,7 +3106,6 @@ dependencies = [
     { name = "aiosqlite" },
     { name = "anyio" },
     { name = "backoff" },
-    { name = "croniter" },
     { name = "json-repair" },
     { name = "msgspec" },
     { name = "orjson" },
@@ -3179,14 +3178,10 @@ sqlite = [
     { name = "aiosqlite" },
 ]
 studio = [
-    { name = "aiosqlite" },
+    { name = "croniter" },
     { name = "fastapi" },
-    { name = "pyyaml" },
     { name = "starlette" },
     { name = "uvicorn" },
-]
-testing = [
-    { name = "pyyaml" },
 ]
 xml = [
     { name = "xmltodict" },
@@ -3238,11 +3233,10 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.14.1" },
     { name = "aiosqlite", specifier = ">=0.21.0" },
     { name = "aiosqlite", marker = "extra == 'sqlite'", specifier = ">=0.21.0" },
-    { name = "aiosqlite", marker = "extra == 'studio'", specifier = ">=0.21.0" },
     { name = "anyio", specifier = ">=4.10.0" },
     { name = "asyncpg", marker = "extra == 'postgres'", specifier = ">=0.27.0" },
     { name = "backoff", specifier = ">=2.1.0" },
-    { name = "croniter", specifier = ">=1.4" },
+    { name = "croniter", marker = "extra == 'studio'", specifier = ">=1.4" },
     { name = "datamodel-code-generator", marker = "extra == 'schema'", specifier = ">=0.31.2" },
     { name = "daytona", marker = "extra == 'sandbox'", specifier = ">=0.171.0" },
     { name = "docling", marker = "extra == 'reader'", specifier = ">=2.91.0" },
@@ -3271,8 +3265,6 @@ requires-dist = [
     { name = "pydapter", extras = ["postgres"], marker = "extra == 'postgres'", specifier = ">=1.3.2" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "pyyaml", specifier = ">=6.0" },
-    { name = "pyyaml", marker = "extra == 'studio'", specifier = ">=6.0" },
-    { name = "pyyaml", marker = "extra == 'testing'", specifier = ">=6.0" },
     { name = "rich", marker = "extra == 'rich'", specifier = ">=13.0.0" },
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'postgres'", specifier = ">=2.0.0" },
     { name = "starlette", marker = "extra == 'mcp'", specifier = ">=1.3.1" },


### PR DESCRIPTION
## Summary

- **croniter** moved from core `dependencies` to `[studio]` optional-dependencies — it is only imported (lazily) inside `lionagi/studio/scheduler/engine.py`
- **pyyaml** de-duplicated: core listing kept (used widely in `lionagi/libs/`, `lionagi/agent/`, `lionagi/casts/`, `lionagi/cli/`); redundant copies removed from `[testing]` and `[studio]`
- **aiosqlite** de-duplicated: core listing kept (`lionagi/state/db.py` uses it outside studio); redundant copy removed from `[studio]`; the `[sqlite]` compat-shim extra is unchanged

Closes #1484

## Test plan

- [x] `uv lock` resolves cleanly (349 packages)
- [x] `uv sync --extra studio` installs croniter correctly
- [x] `uv run python -c "import lionagi; import yaml; print('ok')"` passes
- [x] `uv run python -c "import croniter; import aiosqlite; print('ok')"` passes (after `--extra studio` sync)
- [x] `uv run pytest tests/ -k "config or settings or schedule"` — **430 passed, 0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)