### PR TITLE
chore(testing): document lionagi.testing as public, prune dead _legacy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- `lionagi.testing` is now documented as a supported public surface. Register `lionagi.testing.pytest_plugin` in your `pytest_plugins` to get the bundled fixtures.
+
 ### Removed
 
 - `request_fields` phantom param dropped from `MessageManager.create_instruction`, `create_message`, and `add_message` (was accepted but silently ignored); `parse_lndl_fuzzy` removed from `lndl.__all__` (Phase-2 feature, not yet shipped).
+- Internal `_get_oai_config` alias in `lionagi.testing._legacy` removed (was never public; callers within the module now call `oai_chat_endpoint_config` directly).
 
 ## [0.27.1] - 2026-06-16
 

--- a/lionagi/testing/__init__.py
+++ b/lionagi/testing/__init__.py
@@ -1,7 +1,12 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Test infrastructure for the Lion ecosystem: scripted endpoints, mock factories, and pytest fixtures."""
+"""Supported public testing surface for lionagi downstream projects.
+
+Provides scripted endpoints, mock factories, pytest fixtures, async helpers,
+and test-data loaders. Register ``lionagi.testing.pytest_plugin`` in your
+conftest (or ``pytest_plugins``) to get the bundled fixtures automatically.
+"""
 
 from __future__ import annotations
 

--- a/lionagi/testing/_legacy.py
+++ b/lionagi/testing/_legacy.py
@@ -45,10 +45,6 @@ def oai_chat_endpoint_config(
     )
 
 
-# Back-compat alias for code that imported the private helper directly.
-_get_oai_config = oai_chat_endpoint_config
-
-
 class LionAGIMockFactory:
     """Centralized factory for AsyncMock-based test branches and iModels. Prefer ``TestBranch`` for new tests."""
 
@@ -129,7 +125,7 @@ class LionAGIMockFactory:
         endpoint_config: dict[str, Any] | None = None,
     ) -> APICalling:
         if endpoint_config is None:
-            endpoint_config = _get_oai_config(
+            endpoint_config = oai_chat_endpoint_config(
                 name="oai_chat",
                 endpoint="chat/completions",
                 request_options=OpenAIChatCompletionsRequest,


### PR DESCRIPTION
Closes #1480

## Summary

- `lionagi.testing` is declared a **supported public surface** via an expanded module docstring in `__init__.py`. It has `__all__`, a registered pytest plugin loaded by `tests/conftest.py`, and active consumers across 20+ test files.
- Internal `_get_oai_config` alias removed from `lionagi/testing/_legacy.py` — it was `_`-prefixed, never in `__all__`, never imported externally (three `tests/session/*.py` files each define their own local copy with the same name, independent of the one here).
- CHANGELOG updated under `[Unreleased]`: Added entry for public-surface declaration, Removed entry for the dead alias.

## Per-symbol determination

| Symbol | Status | Reason |
|---|---|---|
| `LionAGIMockFactory` | KEPT | In __all__; consumed across tests/docs/, tests/operations/, etc. |
| `oai_chat_endpoint_config` | KEPT | In __all__; consumed by tests/operations/test_cancelled_status.py |
| `_get_oai_config` | DELETED | _-prefix; not in __all__; only used internally within the same file. Policy section 3 (internal-only). |

## Test plan

- `uv run pytest tests/testing/` — 67 passed
- `uv run pytest tests/operations/test_cancelled_status.py tests/fixtures/test_mock_factory.py tests/testing/test_legacy_factory.py` — 19 passed
- `uv run pytest tests/ -k "testing or plugin or helper"` — 99 passed, 25 skipped
- `uv run python -c "import lionagi.testing; print(lionagi.testing.__all__)"` — all 35 public names present
- All pre-commit hooks passed (ruff format, ruff check, pyupgrade, markdownlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)