### PR TITLE
refactor(service): point callers at AgenticEndpoint, retire cli_endpoint shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Deprecated
+
+- `CLIEndpoint` in `lionagi.service.connections` — use `AgenticEndpoint` instead. The alias now emits `DeprecationWarning` at import. Will be removed in a future minor release.
+
 ### Removed
 
 - `request_fields` phantom param dropped from `MessageManager.create_instruction`, `create_message`, and `add_message` (was accepted but silently ignored); `parse_lndl_fuzzy` removed from `lndl.__all__` (Phase-2 feature, not yet shipped).

--- a/lionagi/service/connections/__init__.py
+++ b/lionagi/service/connections/__init__.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
+
 from .agentic_endpoint import AgenticEndpoint
 from .api_calling import APICalling
-from .cli_endpoint import CLIEndpoint
 from .endpoint import Endpoint
 from .endpoint_config import EndpointConfig
 from .header_factory import HeaderFactory
@@ -30,3 +31,19 @@ __all__ = (
     "ProviderConfig",
     "register_endpoint",
 )
+
+
+def __getattr__(name: str):
+    if name == "CLIEndpoint":
+        warnings.warn(
+            "CLIEndpoint is deprecated and will be removed in a future release. "
+            "Use AgenticEndpoint from lionagi.service.connections instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        # Cache to prevent double-fire from importlib _handle_fromlist.
+        import sys
+
+        sys.modules[__name__].__dict__["CLIEndpoint"] = AgenticEndpoint
+        return AgenticEndpoint
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/lionagi/service/connections/cli_endpoint.py
+++ b/lionagi/service/connections/cli_endpoint.py
@@ -1,7 +1,18 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-# Re-export from agentic_endpoint for backward compatibility.
-from .agentic_endpoint import AgenticEndpoint as CLIEndpoint
+import warnings
 
-__all__ = ("CLIEndpoint",)
+from .agentic_endpoint import AgenticEndpoint
+
+
+def __getattr__(name: str):
+    if name == "CLIEndpoint":
+        warnings.warn(
+            "CLIEndpoint is deprecated and will be removed in a future release. "
+            "Use AgenticEndpoint from lionagi.service.connections instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return AgenticEndpoint
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/lionagi/service/imodel.py
+++ b/lionagi/service/imodel.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel
 from lionagi.ln import is_coro_func, now_utc
 from lionagi.protocols.generic import ID, Event, EventStatus, Log
 
-from .connections import APICalling, CLIEndpoint, Endpoint, match_endpoint
+from .connections import AgenticEndpoint, APICalling, Endpoint, match_endpoint
 from .hooks import (
     HookedEvent,
     HookEvent,
@@ -185,7 +185,7 @@ class iModel:  # noqa: N801
         """Construct an APICalling from endpoint-specific payload."""
         # Auto-inject session_id for CLI endpoint resume
         if (
-            isinstance(self.endpoint, CLIEndpoint)
+            isinstance(self.endpoint, AgenticEndpoint)
             and "resume" not in kwargs
             and "session_id" not in kwargs
             and self.endpoint.session_id
@@ -301,7 +301,7 @@ class iModel:  # noqa: N801
 
             completed_call = self.executor.pile.pop(api_call.id)
             if (
-                isinstance(self.endpoint, CLIEndpoint)
+                isinstance(self.endpoint, AgenticEndpoint)
                 and completed_call
                 and completed_call.response
             ):
@@ -345,8 +345,8 @@ class iModel:  # noqa: N801
         self.endpoint.copy_runtime_state_to(new_endpoint)
         if (
             share_session
-            and isinstance(new_endpoint, CLIEndpoint)
-            and isinstance(self.endpoint, CLIEndpoint)
+            and isinstance(new_endpoint, AgenticEndpoint)
+            and isinstance(self.endpoint, AgenticEndpoint)
         ):
             new_endpoint.session_id = self.endpoint.session_id
         return iModel(

--- a/tests/service/connections/test_endpoint.py
+++ b/tests/service/connections/test_endpoint.py
@@ -878,3 +878,30 @@ class TestProviderCallOverrideSSRFGuard:
         with patch("lionagi.ln._ssrf.is_ssrf_safe", return_value=False):
             with pytest.raises(PermissionError, match="SSRF guard"):
                 await endpoint._call(payload={"model": "whisper-large-v3"}, headers={})
+
+
+# ---------------------------------------------------------------------------
+# CLIEndpoint deprecation bridge
+# ---------------------------------------------------------------------------
+
+
+class TestCLIEndpointDeprecation:
+    """CLIEndpoint is a deprecated alias for AgenticEndpoint."""
+
+    def test_cli_endpoint_emits_deprecation_warning(self):
+        import sys
+
+        import lionagi.service.connections as _conn_mod
+
+        # Clear the cached attribute so __getattr__ fires fresh.
+        _conn_mod.__dict__.pop("CLIEndpoint", None)
+        try:
+            with pytest.warns(DeprecationWarning, match="CLIEndpoint is deprecated"):
+                from lionagi.service.connections import CLIEndpoint  # noqa: F401
+        finally:
+            _conn_mod.__dict__.pop("CLIEndpoint", None)
+
+    def test_cli_endpoint_resolves_to_agentic_endpoint(self):
+        from lionagi.service.connections import AgenticEndpoint, CLIEndpoint
+
+        assert CLIEndpoint is AgenticEndpoint


### PR DESCRIPTION
## Summary

- **Public/internal determination**: \`CLIEndpoint\` is **public** — it appears in \`lionagi.service.connections.__all__\`, the migration guide (\`docs/migration/0.23.0-to-0.23.1.md\`), and several test files. Hard-deletion is not allowed per the deprecation policy.
- \`imodel.py\` now imports \`AgenticEndpoint\` directly (internal caller — no deprecation required).
- \`connections/__init__.py\` serves \`CLIEndpoint\` via \`__getattr__\` with a \`DeprecationWarning\`; the attribute is cached after first access to prevent double-fire from \`importlib._handle_fromlist\`.
- \`cli_endpoint.py\` body replaced with a \`__getattr__\` deprecation bridge (no \`__all__\` to avoid ruff F822).
- \`CHANGELOG.md\` updated with a \`Deprecated\` entry under \`[Unreleased]\`.
- Two new tests assert the warning fires and the alias resolves to \`AgenticEndpoint\`.

## Test plan

- [x] \`tests/service/connections/test_endpoint.py\` — 44 passed
- [x] \`tests/service/imodel/\` + imodel hook/default-provider tests — 91 passed, 1 skipped
- [x] \`tests/docs/test_integrations.py::TestCLIEndpointArchitecture\` — 16 passed
- [x] Star-import (\`from lionagi.service.connections import *\`) works; warning fires
- [x] Pre-existing failures (fastmcp/ollama missing modules) unrelated to this change

Closes #1478

🤖 Generated with [Claude Code](https://claude.com/claude-code)