### PR TITLE
refactor(service): unify duplicated CONTEXT_WINDOWS registries

### DIFF
--- a/lionagi/providers/openai/codex/endpoint.py
+++ b/lionagi/providers/openai/codex/endpoint.py
@@ -21,8 +21,6 @@ CONTEXT_WINDOWS: dict[str, int] = {
     "codex-mini": 200_000,
     "o4-mini": 200_000,
     "o3": 200_000,
-    "gpt-4.1": 1_047_576,
-    "gpt-5.5": 1_047_576,
 }
 
 _CODEX_HANDLER_PARAMS = (

--- a/tests/service/test_token_budget.py
+++ b/tests/service/test_token_budget.py
@@ -288,3 +288,51 @@ class TestGetTokenBudget:
         budget = get_token_budget(branch)
         # model may be None or a string — just check the type
         assert budget.model is None or isinstance(budget.model, str)
+
+
+class TestCanonicalContextWindowRegistry:
+    """Pin representative model→context-length lookups through the canonical registry.
+
+    These values must stay consistent as provider registries evolve.
+    Changing a value here requires a deliberate update with justification.
+    """
+
+    def test_gpt_4_1_canonical_value_is_openai(self):
+        """gpt-4.1 from the openai provider must match openai/_config.py (primary path)."""
+        result = lookup_context_window("gpt-4.1", provider="openai")
+        assert result == 1_000_000
+
+    def test_gpt_5_5_canonical_value_is_openai(self):
+        """gpt-5.5 from the openai provider must match openai/_config.py (primary path)."""
+        result = lookup_context_window("gpt-5.5", provider="openai")
+        assert result == 1_000_000
+
+    def test_codex_mini_resolves_from_codex_provider(self):
+        """codex-mini is codex-provider-only; not in openai/_config.py."""
+        result = lookup_context_window("codex-mini", provider="codex")
+        assert result == 200_000
+
+    def test_gpt_4_1_cross_provider_matches_openai(self):
+        """Without a provider hint, gpt-4.1 resolves to the openai value (openai wins iteration)."""
+        openai_val = lookup_context_window("gpt-4.1", provider="openai")
+        cross_val = lookup_context_window("gpt-4.1")
+        assert openai_val == cross_val
+
+    def test_gpt_5_5_no_conflict_between_providers(self):
+        """gpt-5.5 removed from codex registry; only openai/_config.py returns a value."""
+        openai_val = lookup_context_window("gpt-5.5", provider="openai")
+        codex_val = lookup_context_window("gpt-5.5", provider="codex")
+        # codex no longer has gpt-5.5; falls back to cross-provider search → finds openai
+        assert openai_val == codex_val
+
+    def test_claude_sonnet_4_6_anthropic(self):
+        result = lookup_context_window("claude-sonnet-4-6", provider="anthropic")
+        assert result == 1_000_000
+
+    def test_gemini_2_5_flash_google(self):
+        result = lookup_context_window("gemini-2.5-flash", provider="gemini")
+        assert result == 1_048_576
+
+    def test_deepseek_r1_resolves(self):
+        result = lookup_context_window("deepseek-r1", provider="deepseek")
+        assert result == 64_000


### PR DESCRIPTION
Closes #1492

## Summary

- Removes `gpt-4.1` and `gpt-5.5` from `lionagi/providers/openai/codex/endpoint.py` — these are OpenAI API models whose canonical home is `openai/_config.py`; they had conflicting values that caused `lookup_context_window` to return different numbers depending on which provider won iteration order.
- The codex endpoint registry now contains only codex-native models (`codex-mini`, `o4-mini`, `o3`).
- Adds `TestCanonicalContextWindowRegistry` — 8 pinned model→context-length assertions guarding against future drift.

## Architecture note

`CONTEXT_WINDOWS` is consumed only via `getattr(mod, "CONTEXT_WINDOWS", None)` in `token_budget.py` and is never imported by name elsewhere. Each provider module legitimately owns its own registry for its native models; `token_budget.py` is the existing unification layer. No public surface changed; no deprecation aliases needed.

## Parity table

| model | openai/_config.py | codex/endpoint.py (before) | canonical value chosen | reason |
|-------|-------------------|---------------------------|------------------------|--------|
| `gpt-4.1` | 1,000,000 | 1,047,576 | **1,000,000** (openai/_config.py) | Primary runtime path for `provider="openai"`; openai wins `_all_provider_windows` iteration; codex entry was erroneous |
| `gpt-5.5` | 1,000,000 | 1,047,576 | **1,000,000** (openai/_config.py) | Same reason as gpt-4.1 |
| `o3` | 200,000 | 200,000 | **200,000** (no conflict) | Same value in both; retained in codex registry |
| `o4-mini` | 200,000 | 200,000 | **200,000** (no conflict) | Same value in both; retained in codex registry |

### Models that existed in only one registry (no behavior change for readers)

All other provider registries (`anthropic`, `deepseek`, `gemini`, `gemini_code`, `groq`, `nvidia_nim`, `openrouter`, `perplexity`, `pi`) contain exclusively provider-native models with no cross-registry overlap. Readers of those providers always got the correct value; this PR does not touch them.

`codex-mini` (200,000) exists only in the codex registry — now the sole codex-specific entry alongside `o4-mini` and `o3`. Readers using `provider="codex"` continue to resolve it correctly.

## Test plan

- [x] `uv run pytest tests/service/test_token_budget.py -q` — 42 passed
- [x] `uv run python -c "import lionagi; print('ok')"` — clean import
- [x] All former reader paths (`lookup_context_window("gpt-4.1", provider="openai")`, `lookup_context_window("gpt-4.1")`, `lookup_context_window("codex-mini", provider="codex")`) verified consistent post-change
- [x] `uv run ruff format && uv run ruff check --fix` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)