### PR TITLE
refactor(service): collapse backoff dual-retry into the native retry path

### DIFF
--- a/lionagi/service/connections/endpoint.py
+++ b/lionagi/service/connections/endpoint.py
@@ -16,6 +16,19 @@ from lionagi.service.types.stream_chunk import StreamChunk
 from .endpoint_config import EndpointConfig
 from .header_factory import HeaderFactory
 
+
+class _NonRetryableClientError(Exception):
+    """Sentinel: 4xx (non-429) client error that must not be retried.
+
+    Wraps the original aiohttp.ClientResponseError so callers can inspect it
+    via the __cause__ chain while the retry engine sees an excluded type.
+    """
+
+    def __init__(self, original: Exception):
+        super().__init__(str(original))
+        self.original = original
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -219,9 +232,8 @@ class Endpoint:
         self._assert_ssrf_safe_url()
 
         import aiohttp
-        import backoff
 
-        async def _make_request_with_backoff():
+        async def _make_request():
             async with self._create_http_session() as session:
                 response = None
                 try:
@@ -234,7 +246,7 @@ class Endpoint:
                     )
 
                     if response.status == 429 or response.status >= 500:
-                        response.raise_for_status()  # This will be caught by backoff
+                        response.raise_for_status()
                     elif response.status != 200:
                         try:
                             error_body = await response.json()
@@ -244,13 +256,16 @@ class Endpoint:
                         except Exception:
                             error_message = f"Request failed with status {response.status}"
 
-                        raise aiohttp.ClientResponseError(
+                        original = aiohttp.ClientResponseError(
                             request_info=response.request_info,
                             history=response.history,
                             status=response.status,
                             message=error_message,
                             headers=response.headers,
                         )
+                        # 4xx (non-429): wrap in sentinel so the native retry layer
+                        # gives up immediately, preserving the original error on __cause__.
+                        raise _NonRetryableClientError(original) from original
 
                     return await response.json()
                 finally:
@@ -259,26 +274,28 @@ class Endpoint:
                     if response is not None and not response.closed:
                         response.release()
 
-        # When retry_config is set, the outer call() already wraps this method in
-        # retry_with_backoff. Skip the internal backoff layer to prevent double-retry.
+        # When retry_config is set, the outer call() already wraps _call in retry_with_backoff.
+        # _call delegates here, so just run the raw request — no extra retry layer.
         if self.retry_config:
-            return await _make_request_with_backoff()
+            return await _make_request()
 
-        def giveup_on_client_error(e):
-            # Don't retry on 4xx except 429 (rate limit)
-            if isinstance(e, aiohttp.ClientResponseError):
-                return 400 <= e.status < 500 and e.status != 429
-            return False
-
-        backoff_handler = backoff.on_exception(
-            backoff.expo,
-            (aiohttp.ClientError, asyncio.TimeoutError),
-            max_tries=self.config.max_retries,
-            giveup=giveup_on_client_error,
-            jitter=backoff.full_jitter,
-        )
-
-        return await backoff_handler(_make_request_with_backoff)()
+        # No RetryConfig: use the native retry path with aiohttp transport errors.
+        # _NonRetryableClientError is in exclude_exceptions so 4xx non-429 gives up immediately.
+        # Re-raise the wrapped original so callers see aiohttp.ClientResponseError.
+        try:
+            return await retry_with_backoff(
+                _make_request,
+                retry_exceptions=(aiohttp.ClientError, asyncio.TimeoutError),
+                exclude_exceptions=(_NonRetryableClientError,),
+                max_retries=self.config.max_retries,
+                base_delay=1.0,
+                max_delay=60.0,
+                backoff_factor=2.0,
+                jitter=True,
+                jitter_factor=0.5,
+            )
+        except _NonRetryableClientError as exc:
+            raise exc.original from exc.__cause__
 
     async def stream(
         self,

--- a/lionagi/service/connections/endpoint.py
+++ b/lionagi/service/connections/endpoint.py
@@ -282,12 +282,14 @@ class Endpoint:
         # No RetryConfig: use the native retry path with aiohttp transport errors.
         # _NonRetryableClientError is in exclude_exceptions so 4xx non-429 gives up immediately.
         # Re-raise the wrapped original so callers see aiohttp.ClientResponseError.
+        # config.max_retries is a total-attempt cap (it was backoff's max_tries); retry_with_backoff
+        # runs max_retries+1 attempts, so subtract one to preserve the same total attempt count.
         try:
             return await retry_with_backoff(
                 _make_request,
                 retry_exceptions=(aiohttp.ClientError, asyncio.TimeoutError),
                 exclude_exceptions=(_NonRetryableClientError,),
-                max_retries=self.config.max_retries,
+                max_retries=max(0, self.config.max_retries - 1),
                 base_delay=1.0,
                 max_delay=60.0,
                 backoff_factor=2.0,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "aiocache>=0.12.0",
     "aiohttp>=3.14.1",
     "anyio>=4.10.0",
-    "backoff>=2.1.0",
     "json-repair>=0.58.0",
     "msgspec>=0.20.0",
     "pydantic>=2.8.0",

--- a/tests/service/connections/test_endpoint.py
+++ b/tests/service/connections/test_endpoint.py
@@ -905,3 +905,206 @@ class TestCLIEndpointDeprecation:
         from lionagi.service.connections import AgenticEndpoint, CLIEndpoint
 
         assert CLIEndpoint is AgenticEndpoint
+
+
+# ---------------------------------------------------------------------------
+# Single-retry-path parity tests (collapse of backoff dual-retry layer)
+# ---------------------------------------------------------------------------
+
+
+class TestSingleRetryPathParity:
+    """Verify the native-only retry path preserves the giveup-except-429 rule."""
+
+    def _make_endpoint(self, max_retries: int = 3) -> Endpoint:
+        config = EndpointConfig(
+            name="test",
+            provider="test",
+            endpoint="v1/chat",
+            base_url="https://api.test.com",
+            auth_type="bearer",
+            api_key="test-key",
+            max_retries=max_retries,
+        )
+        return Endpoint(config=config)
+
+    def _make_mock_session(self, responses):
+        """Build a mock session that returns responses in sequence."""
+        mock_session = AsyncMock(spec=aiohttp.ClientSession)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        calls = iter(responses)
+
+        async def _request(*args, **kwargs):
+            return next(calls)
+
+        mock_session.request = _request
+        return mock_session
+
+    def _make_ok_response(self, body: dict | None = None):
+        r = AsyncMock(spec=aiohttp.ClientResponse)
+        r.status = 200
+        r.closed = False
+        r.release = MagicMock()
+        r.json = AsyncMock(return_value=body or {"ok": True})
+        return r
+
+    def _make_error_response(self, status: int):
+        r = AsyncMock(spec=aiohttp.ClientResponse)
+        r.status = status
+        r.closed = False
+        r.release = MagicMock()
+        r.request_info = MagicMock()
+        r.history = []
+        r.headers = {}
+        r.json = AsyncMock(return_value={"error": f"status {status}"})
+
+        def _raise_for_status():
+            raise aiohttp.ClientResponseError(
+                request_info=r.request_info,
+                history=r.history,
+                status=status,
+                message=f"status {status}",
+                headers=r.headers,
+            )
+
+        r.raise_for_status = _raise_for_status
+        return r
+
+    @pytest.mark.asyncio
+    async def test_200_ok_no_retry(self):
+        endpoint = self._make_endpoint()
+        ok = self._make_ok_response({"choices": []})
+        session = self._make_mock_session([ok])
+        with patch("lionagi.ln._ssrf.is_ssrf_safe", return_value=True):
+            with patch.object(endpoint, "_create_http_session", return_value=session):
+                result = await endpoint._call_aiohttp({}, {})
+        assert result == {"choices": []}
+        assert ok.release.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_429_is_retried(self):
+        """429 must be retried; succeeds on second attempt."""
+        endpoint = self._make_endpoint(max_retries=3)
+        r429 = self._make_error_response(429)
+        ok = self._make_ok_response({"retried": True})
+
+        attempt = 0
+
+        def _make_new_session(*args, **kwargs):
+            nonlocal attempt
+            attempt += 1
+            if attempt == 1:
+                return self._make_mock_session([r429])
+            return self._make_mock_session([ok])
+
+        with patch("lionagi.ln._ssrf.is_ssrf_safe", return_value=True):
+            with patch.object(endpoint, "_create_http_session", side_effect=_make_new_session):
+                with patch("lionagi.ln.concurrency.patterns.anyio.sleep", AsyncMock()):
+                    result = await endpoint._call_aiohttp({}, {})
+        assert result == {"retried": True}
+        assert attempt == 2
+
+    @pytest.mark.asyncio
+    async def test_400_gives_up_immediately(self):
+        """400 client error must not be retried; raises aiohttp.ClientResponseError."""
+        endpoint = self._make_endpoint(max_retries=3)
+        r400 = self._make_error_response(400)
+
+        call_count = 0
+
+        def _make_new_session(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return self._make_mock_session([r400])
+
+        with patch("lionagi.ln._ssrf.is_ssrf_safe", return_value=True):
+            with patch.object(endpoint, "_create_http_session", side_effect=_make_new_session):
+                with pytest.raises(aiohttp.ClientResponseError) as exc_info:
+                    await endpoint._call_aiohttp({}, {})
+        assert exc_info.value.status == 400
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_401_gives_up_immediately(self):
+        """401 must not be retried."""
+        endpoint = self._make_endpoint(max_retries=3)
+        r401 = self._make_error_response(401)
+        call_count = 0
+
+        def _make_new_session(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return self._make_mock_session([r401])
+
+        with patch("lionagi.ln._ssrf.is_ssrf_safe", return_value=True):
+            with patch.object(endpoint, "_create_http_session", side_effect=_make_new_session):
+                with pytest.raises(aiohttp.ClientResponseError) as exc_info:
+                    await endpoint._call_aiohttp({}, {})
+        assert exc_info.value.status == 401
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_403_gives_up_immediately(self):
+        """403 must not be retried."""
+        endpoint = self._make_endpoint(max_retries=3)
+        r403 = self._make_error_response(403)
+        call_count = 0
+
+        def _make_new_session(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return self._make_mock_session([r403])
+
+        with patch("lionagi.ln._ssrf.is_ssrf_safe", return_value=True):
+            with patch.object(endpoint, "_create_http_session", side_effect=_make_new_session):
+                with pytest.raises(aiohttp.ClientResponseError) as exc_info:
+                    await endpoint._call_aiohttp({}, {})
+        assert exc_info.value.status == 403
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_500_is_retried_up_to_max(self):
+        """500 server error must be retried up to max_retries attempts."""
+        endpoint = self._make_endpoint(max_retries=2)
+
+        call_count = 0
+
+        def _make_new_session(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return self._make_mock_session([self._make_error_response(500)])
+
+        with patch("lionagi.ln._ssrf.is_ssrf_safe", return_value=True):
+            with patch.object(endpoint, "_create_http_session", side_effect=_make_new_session):
+                with patch("lionagi.ln.concurrency.patterns.anyio.sleep", AsyncMock()):
+                    with pytest.raises(aiohttp.ClientResponseError) as exc_info:
+                        await endpoint._call_aiohttp({}, {})
+        assert exc_info.value.status == 500
+        # max_retries=2 means 3 total attempts (initial + 2 retries)
+        assert call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_network_timeout_is_retried(self):
+        """asyncio.TimeoutError must be retried."""
+        endpoint = self._make_endpoint(max_retries=2)
+
+        call_count = 0
+
+        async def _raise_timeout(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise asyncio.TimeoutError()
+
+        mock_session = AsyncMock(spec=aiohttp.ClientSession)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session.request = _raise_timeout
+
+        with patch("lionagi.ln._ssrf.is_ssrf_safe", return_value=True):
+            with patch.object(endpoint, "_create_http_session", return_value=mock_session):
+                with patch("lionagi.ln.concurrency.patterns.anyio.sleep", AsyncMock()):
+                    with pytest.raises(asyncio.TimeoutError):
+                        await endpoint._call_aiohttp({}, {})
+        # max_retries=2 → 3 total attempts
+        assert call_count == 3

--- a/tests/service/connections/test_endpoint.py
+++ b/tests/service/connections/test_endpoint.py
@@ -1081,8 +1081,8 @@ class TestSingleRetryPathParity:
                     with pytest.raises(aiohttp.ClientResponseError) as exc_info:
                         await endpoint._call_aiohttp({}, {})
         assert exc_info.value.status == 500
-        # max_retries=2 means 3 total attempts (initial + 2 retries)
-        assert call_count == 3
+        # max_retries is a total-attempt cap (was backoff's max_tries): 2 → 2 attempts
+        assert call_count == 2
 
     @pytest.mark.asyncio
     async def test_network_timeout_is_retried(self):
@@ -1106,5 +1106,5 @@ class TestSingleRetryPathParity:
                 with patch("lionagi.ln.concurrency.patterns.anyio.sleep", AsyncMock()):
                     with pytest.raises(asyncio.TimeoutError):
                         await endpoint._call_aiohttp({}, {})
-        # max_retries=2 → 3 total attempts
-        assert call_count == 3
+        # max_retries is a total-attempt cap (was backoff's max_tries): 2 → 2 attempts
+        assert call_count == 2

--- a/uv.lock
+++ b/uv.lock
@@ -478,15 +478,6 @@ wheels = [
 ]
 
 [[package]]
-name = "backoff"
-version = "2.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
-]
-
-[[package]]
 name = "backports-asyncio-runner"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3105,7 +3096,6 @@ dependencies = [
     { name = "aiohttp" },
     { name = "aiosqlite" },
     { name = "anyio" },
-    { name = "backoff" },
     { name = "json-repair" },
     { name = "msgspec" },
     { name = "orjson" },
@@ -3235,7 +3225,6 @@ requires-dist = [
     { name = "aiosqlite", marker = "extra == 'sqlite'", specifier = ">=0.21.0" },
     { name = "anyio", specifier = ">=4.10.0" },
     { name = "asyncpg", marker = "extra == 'postgres'", specifier = ">=0.27.0" },
-    { name = "backoff", specifier = ">=2.1.0" },
     { name = "croniter", marker = "extra == 'studio'", specifier = ">=1.4" },
     { name = "datamodel-code-generator", marker = "extra == 'schema'", specifier = ">=0.31.2" },
     { name = "daytona", marker = "extra == 'sandbox'", specifier = ">=0.171.0" },


### PR DESCRIPTION
Closes #1490

## Summary

- Removes the `backoff` PyPI library from `_call_aiohttp`. There were two retry layers: `backoff.on_exception` inside the transport method and `retry_with_backoff` wrapping it via `RetryConfig`. An existing guard already short-circuited the inner layer when `retry_config` was set — this removes the inner layer entirely so all paths use the native lionagi retry engine.
- The giveup-except-429 predicate is preserved exactly via `_NonRetryableClientError`: 4xx non-429 responses are wrapped in an excluded sentinel type and never retried; 429 and 5xx raise `aiohttp.ClientResponseError` (a `ClientError`) which the native retry catches and retries.
- Removes `backoff>=2.1.0` from `dependencies` in `pyproject.toml`; `uv lock` regenerated.
- Adds 7 contract tests in `TestSingleRetryPathParity`.

## Before/After Parity Table

| Scenario | Before (backoff layer, no RetryConfig) | After (native retry_with_backoff) | Match? |
|---|---|---|---|
| 200 OK | 1 attempt, return JSON | 1 attempt, return JSON | yes |
| 429 Rate Limit | retried up to max_retries with expo+full_jitter | retried up to max_retries with expo+jitter (base_delay=1s, factor=2.0) | yes |
| 500 Server Error | retried up to max_retries with expo+full_jitter | retried up to max_retries with expo+jitter | yes |
| 400 Client Error | giveup immediately (1 attempt), raises ClientResponseError | giveup immediately (1 attempt), raises ClientResponseError | yes |
| 401/403 Client Error | giveup immediately, raises ClientResponseError | giveup immediately, raises ClientResponseError | yes |
| Network Timeout | retried up to max_retries | retried up to max_retries | yes |
| RetryConfig set | native retry_with_backoff wraps _call; inner backoff skipped | native retry_with_backoff wraps _call; _call_aiohttp runs raw | yes |

**Give-up-except-429 rule**: the old `giveup_on_client_error` predicate (`400 <= status < 500 and status != 429`) is now enforced by `_NonRetryableClientError` in `exclude_exceptions`. The `except _NonRetryableClientError` clause re-raises the original `aiohttp.ClientResponseError` so callers see no type change.

**Timing delta**: `backoff.expo` with `backoff.full_jitter` used random uniform jitter across the full delay. The native path uses `jitter_factor=0.5`. Behavior is equivalent in character; both produce exponential backoff with randomisation.

## Test plan

- [x] `tests/service/connections/test_endpoint.py` — 51/51 passed
- [x] `tests/service/test_resilience.py` + `tests/service/connections/` — 314/314 passed
- [x] `uv run pytest tests/ -k "retry or backoff or invoke or imodel or rate"` — 638 passed, 1 pre-existing ollama-missing-dep failure, 26 skipped
- [x] `ruff format` + `ruff check` — all checks passed
- [x] `backoff` removed from `uv.lock` confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Update — exact attempt-count parity

Review caught an off-by-one: `backoff.on_exception(max_tries=N)` runs **N** total attempts, but `retry_with_backoff(max_retries=N)` runs **N+1**. `config.max_retries` is a total-attempt cap (it fed backoff's `max_tries`), so the call now passes `max(0, config.max_retries - 1)` to keep the exact same attempt count — no silent extra retry on 5xx/timeout. Count assertions in `test_500_is_retried_up_to_max` / `test_network_timeout_is_retried` corrected accordingly (max_retries=2 → 2 attempts).