### PR TITLE
perf(hooks): reuse a shared StateDB connection across hook firings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ### Changed
 
 - The CLI, studio, and operations boundaries now raise typed `LionError` subclasses (`ConfigurationError`, `OperationError`, `ExecutionError`) instead of bare `ValueError`/`RuntimeError`. These subclasses also inherit from the corresponding builtin, so existing `except ValueError` / `except RuntimeError` handlers keep working.
+- `lionagi.hooks.builtins` persistence handlers now share a single open `StateDB` connection per DB path (via `get_shared_db()`) instead of opening a fresh connection on every hook firing, eliminating the per-firing connect + pragma + schema-check cost.
 
 ### Deprecated
 

--- a/lionagi/hooks/builtins.py
+++ b/lionagi/hooks/builtins.py
@@ -11,6 +11,13 @@ from typing import Any
 
 logger = logging.getLogger("lionagi.hooks.builtins")
 
+
+async def _db():
+    from lionagi.state.db import get_shared_db
+
+    return await get_shared_db()
+
+
 __all__ = (
     "persist_session_start",
     "persist_session_end",
@@ -34,27 +41,26 @@ async def persist_session_start(
     **_unused: Any,
 ) -> None:
     """Write the ADR-0022 provenance set + open the lifecycle window."""
-    from lionagi.state.db import StateDB
     from lionagi.state.reasons import RunReasons
 
-    async with StateDB() as db:
-        await db.update_session(
-            session_id,
-            # status="running" routes through update_status(), which requires
-            # a reason_code — pass it explicitly so the transition records a
-            # canonical "started" cause instead of tripping the deprecation
-            # shim (which would raise on the running status and be swallowed by
-            # the bus, silently dropping all the provenance fields above).
-            reason_code=RunReasons.STARTED_OK,
-            model=model,
-            provider=provider,
-            effort=effort,
-            agent_name=agent_name,
-            agent_hash=agent_hash,
-            invocation_id=invocation_id,
-            status="running",
-            started_at=time.time(),
-        )
+    db = await _db()
+    await db.update_session(
+        session_id,
+        # status="running" routes through update_status(), which requires
+        # a reason_code — pass it explicitly so the transition records a
+        # canonical "started" cause instead of tripping the deprecation
+        # shim (which would raise on the running status and be swallowed by
+        # the bus, silently dropping all the provenance fields above).
+        reason_code=RunReasons.STARTED_OK,
+        model=model,
+        provider=provider,
+        effort=effort,
+        agent_name=agent_name,
+        agent_hash=agent_hash,
+        invocation_id=invocation_id,
+        status="running",
+        started_at=time.time(),
+    )
 
 
 async def persist_session_end(
@@ -65,15 +71,13 @@ async def persist_session_end(
     **_unused: Any,
 ) -> None:
     """Stamp the terminal status + ended_at on the session row."""
-    from lionagi.state.db import StateDB
-
     fields: dict[str, Any] = {"status": status, "ended_at": time.time()}
     if error is not None:
         # node_metadata is JSON — overwriting is destructive, so keep the
         # error in a dedicated field and let the caller merge if needed.
         fields["node_metadata"] = {"error": error}
-    async with StateDB() as db:
-        await db.update_session(session_id, **fields)
+    db = await _db()
+    await db.update_session(session_id, **fields)
 
 
 async def persist_branch_provenance(
@@ -85,15 +89,13 @@ async def persist_branch_provenance(
     **_unused: Any,
 ) -> None:
     """ADR-0022 per-branch model / provider / agent_name."""
-    from lionagi.state.db import StateDB
-
-    async with StateDB() as db:
-        await db.update_branch(
-            branch_id,
-            model=model,
-            provider=provider,
-            agent_name=agent_name,
-        )
+    db = await _db()
+    await db.update_branch(
+        branch_id,
+        model=model,
+        provider=provider,
+        agent_name=agent_name,
+    )
 
 
 async def persist_message(
@@ -108,19 +110,17 @@ async def persist_message(
     **_unused: Any,
 ) -> None:
     """ADR-0019 + ADR-0009 message persistence; ``progression_id`` is a legacy alias."""
-    from lionagi.state.db import StateDB
-
     effective_branch_prog = branch_progression_id or progression_id
 
-    async with StateDB() as db:
-        await db.insert_message(message)
-        if effective_branch_prog is not None:
-            await db.append_to_progression(effective_branch_prog, message["id"])
-        if session_progression_id is not None:
-            await db.append_to_progression(session_progression_id, message["id"])
-        if message.get("role") == "system" and branch_id is not None:
-            await db.update_branch(branch_id, system_msg_id=message["id"])
-        await db.touch_session_activity(session_id)
+    db = await _db()
+    await db.insert_message(message)
+    if effective_branch_prog is not None:
+        await db.append_to_progression(effective_branch_prog, message["id"])
+    if session_progression_id is not None:
+        await db.append_to_progression(session_progression_id, message["id"])
+    if message.get("role") == "system" and branch_id is not None:
+        await db.update_branch(branch_id, system_msg_id=message["id"])
+    await db.touch_session_activity(session_id)
 
 
 async def log_api_metrics(

--- a/lionagi/state/__init__.py
+++ b/lionagi/state/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-from .db import StateDB, get_shared_db
+from .db import StateDB
 
-__all__ = ("StateDB", "get_shared_db")
+__all__ = ("StateDB",)

--- a/lionagi/state/__init__.py
+++ b/lionagi/state/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-from .db import StateDB
+from .db import StateDB, get_shared_db
 
-__all__ = ("StateDB",)
+__all__ = ("StateDB", "get_shared_db")

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -2305,3 +2305,44 @@ class StateDB:
                 except (json.JSONDecodeError, TypeError):
                     pass
         return d
+
+
+# ── Shared singleton accessor ─────────────────────────────────────────────────
+# One open StateDB connection is reused across all hook firings for a given
+# DB path.  This avoids the per-firing connect + pragma + schema-check cost
+# and is the prerequisite for session-lifecycle hook wiring.
+#
+# Async-safety argument:
+#   aiosqlite routes every command through a single background thread, so
+#   SQLite serialises all operations at the C layer.  Concurrent coroutines
+#   sharing the same StateDB instance are further serialised by the instance's
+#   own _write_lock (anyio.Lock) for every mutating path that uses BEGIN
+#   IMMEDIATE or needs atomic execute+commit.  A shared instance therefore
+#   cannot produce "cannot start a transaction within a transaction" races —
+#   that was already the guarantee provided by _write_lock for the CLI paths
+#   that pass an open StateDB to bind_db_persistence().
+#
+# Key by resolved Path so tests that redirect DEFAULT_DB_PATH to a tmp_path
+# get their own isolated instance.
+
+_SHARED: dict[Path, StateDB] = {}
+# Guards the lazy-open window; created on first async call (anyio.Lock
+# must be instantiated inside an active backend task context).
+_SHARED_OPEN_LOCK: Lock | None = None
+
+
+async def get_shared_db(path: str | Path | None = None) -> StateDB:
+    """Return the process-wide open StateDB for *path* (default: DEFAULT_DB_PATH)."""
+    global _SHARED_OPEN_LOCK  # noqa: PLW0603
+    resolved = Path(path) if path else DEFAULT_DB_PATH
+    if resolved in _SHARED:
+        return _SHARED[resolved]
+    if _SHARED_OPEN_LOCK is None:
+        _SHARED_OPEN_LOCK = Lock()
+    async with _SHARED_OPEN_LOCK:
+        # Double-checked: another coroutine may have opened it while we waited.
+        if resolved not in _SHARED:
+            db = StateDB(resolved)
+            await db.open()
+            _SHARED[resolved] = db
+    return _SHARED[resolved]

--- a/tests/hooks/test_builtins.py
+++ b/tests/hooks/test_builtins.py
@@ -5,23 +5,20 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+import asyncio
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from lionagi.hooks.builtins import persist_message
 
-# StateDB is imported lazily inside persist_message, so we patch the module
-# it lives in — not lionagi.hooks.builtins.
-_STATEDB_PATH = "lionagi.state.db.StateDB"
+# get_shared_db is the singleton accessor used by every hook in builtins;
+# patching it controls which db instance the hooks operate on.
+_GET_SHARED_DB = "lionagi.state.db.get_shared_db"
 
 
-def _make_mock_db_ctx():
-    mock_db = AsyncMock()
-    mock_ctx = MagicMock()
-    mock_ctx.__aenter__ = AsyncMock(return_value=mock_db)
-    mock_ctx.__aexit__ = AsyncMock(return_value=None)
-    return mock_db, mock_ctx
+def _make_mock_db():
+    return AsyncMock()
 
 
 # ── persist_message: dual progressions ───────────────────────────────────────
@@ -29,9 +26,9 @@ def _make_mock_db_ctx():
 
 async def test_persist_message_appends_to_branch_progression():
     msg = {"id": "msg1", "role": "user", "content": "hi"}
-    mock_db, mock_ctx = _make_mock_db_ctx()
+    mock_db = _make_mock_db()
 
-    with patch(_STATEDB_PATH, return_value=mock_ctx):
+    with patch(_GET_SHARED_DB, return_value=mock_db):
         await persist_message(
             message=msg,
             session_id="sess1",
@@ -45,9 +42,9 @@ async def test_persist_message_appends_to_branch_progression():
 
 async def test_persist_message_appends_to_session_progression():
     msg = {"id": "msg2", "role": "user", "content": "hi"}
-    mock_db, mock_ctx = _make_mock_db_ctx()
+    mock_db = _make_mock_db()
 
-    with patch(_STATEDB_PATH, return_value=mock_ctx):
+    with patch(_GET_SHARED_DB, return_value=mock_db):
         await persist_message(
             message=msg,
             session_id="sess1",
@@ -59,9 +56,9 @@ async def test_persist_message_appends_to_session_progression():
 
 async def test_persist_message_appends_to_both_progressions():
     msg = {"id": "msg3", "role": "assistant", "content": "reply"}
-    mock_db, mock_ctx = _make_mock_db_ctx()
+    mock_db = _make_mock_db()
 
-    with patch(_STATEDB_PATH, return_value=mock_ctx):
+    with patch(_GET_SHARED_DB, return_value=mock_db):
         await persist_message(
             message=msg,
             session_id="sess1",
@@ -77,9 +74,9 @@ async def test_persist_message_appends_to_both_progressions():
 
 async def test_persist_message_updates_system_msg_id_for_system_role():
     msg = {"id": "sys1", "role": "system", "content": "You are helpful."}
-    mock_db, mock_ctx = _make_mock_db_ctx()
+    mock_db = _make_mock_db()
 
-    with patch(_STATEDB_PATH, return_value=mock_ctx):
+    with patch(_GET_SHARED_DB, return_value=mock_db):
         await persist_message(
             message=msg,
             session_id="sess1",
@@ -91,9 +88,9 @@ async def test_persist_message_updates_system_msg_id_for_system_role():
 
 async def test_persist_message_no_system_msg_update_for_non_system_role():
     msg = {"id": "usr1", "role": "user", "content": "hello"}
-    mock_db, mock_ctx = _make_mock_db_ctx()
+    mock_db = _make_mock_db()
 
-    with patch(_STATEDB_PATH, return_value=mock_ctx):
+    with patch(_GET_SHARED_DB, return_value=mock_db):
         await persist_message(
             message=msg,
             session_id="sess1",
@@ -106,9 +103,9 @@ async def test_persist_message_no_system_msg_update_for_non_system_role():
 async def test_persist_message_legacy_progression_id_still_works():
     """Backward compat: progression_id acts as branch_progression_id."""
     msg = {"id": "msg_legacy", "role": "user", "content": "hi"}
-    mock_db, mock_ctx = _make_mock_db_ctx()
+    mock_db = _make_mock_db()
 
-    with patch(_STATEDB_PATH, return_value=mock_ctx):
+    with patch(_GET_SHARED_DB, return_value=mock_db):
         await persist_message(
             message=msg,
             session_id="sess1",
@@ -127,13 +124,19 @@ class TestPersistSessionStartReasonCode:
     async def test_persist_session_start_persists_provenance_with_reason(
         self, monkeypatch, tmp_path
     ):
-        monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", tmp_path / "state.db")
+        import lionagi.state.db as _db_module
+
+        monkeypatch.setattr(_db_module, "DEFAULT_DB_PATH", tmp_path / "state.db")
+        # Reset the singleton cache so this test gets its own isolated DB.
+        monkeypatch.setitem(_db_module._SHARED, tmp_path / "state.db", None)
+        _db_module._SHARED.pop(tmp_path / "state.db", None)
+
         from lionagi.hooks.builtins import persist_session_start
         from lionagi.state.db import StateDB
         from lionagi.state.reasons import RunReasons
 
         sid = "sess-start-1"
-        async with StateDB() as db:
+        async with StateDB(tmp_path / "state.db") as db:
             await db.create_progression("prog-start-1")
             await db.create_session(
                 {
@@ -152,8 +155,12 @@ class TestPersistSessionStartReasonCode:
             agent_name="reviewer",
         )
 
-        async with StateDB() as db:
-            row = await db.get_session(sid)
+        shared = _db_module._SHARED.get(tmp_path / "state.db")
+        if shared is not None:
+            row = await shared.get_session(sid)
+        else:
+            async with StateDB(tmp_path / "state.db") as db:
+                row = await db.get_session(sid)
 
         assert row is not None
         assert row["status"] == "running"
@@ -163,3 +170,77 @@ class TestPersistSessionStartReasonCode:
         assert row["provider"] == "openai"
         # A canonical "started" reason was recorded, not the deprecation default.
         assert row["status_reason_code"] == RunReasons.STARTED_OK
+
+
+# ── Singleton reuse: same instance returned across multiple firings ───────────
+
+
+async def test_shared_db_returns_same_instance(tmp_path, monkeypatch):
+    """get_shared_db() for the same path must return the identical StateDB instance."""
+    import lionagi.state.db as _db_module
+
+    monkeypatch.setattr(_db_module, "DEFAULT_DB_PATH", tmp_path / "state.db")
+    _db_module._SHARED.pop(tmp_path / "state.db", None)
+    _db_module._SHARED_OPEN_LOCK = None
+
+    from lionagi.state.db import get_shared_db
+
+    db1 = await get_shared_db()
+    db2 = await get_shared_db()
+    assert db1 is db2, "get_shared_db() must return the same instance on repeated calls"
+
+    # Cleanup
+    await db1.close()
+    _db_module._SHARED.pop(tmp_path / "state.db", None)
+
+
+async def test_shared_db_connection_open_once(tmp_path, monkeypatch):
+    """StateDB.open() is called exactly once even when get_shared_db() is called N times."""
+    import lionagi.state.db as _db_module
+
+    monkeypatch.setattr(_db_module, "DEFAULT_DB_PATH", tmp_path / "state.db")
+    _db_module._SHARED.pop(tmp_path / "state.db", None)
+    _db_module._SHARED_OPEN_LOCK = None
+
+    open_count = 0
+    original_open = _db_module.StateDB.open
+
+    async def counting_open(self):
+        nonlocal open_count
+        open_count += 1
+        return await original_open(self)
+
+    monkeypatch.setattr(_db_module.StateDB, "open", counting_open)
+
+    from lionagi.state.db import get_shared_db
+
+    # Call 5 times; open() must be called exactly once.
+    for _ in range(5):
+        await get_shared_db()
+
+    assert open_count == 1, f"StateDB.open() called {open_count} times; expected 1"
+
+    # Cleanup
+    db = _db_module._SHARED.pop(tmp_path / "state.db", None)
+    if db is not None:
+        await db.close()
+
+
+async def test_concurrent_hook_firings_use_same_instance(tmp_path, monkeypatch):
+    """Concurrent get_shared_db() calls must all resolve to the same instance without error."""
+    import lionagi.state.db as _db_module
+
+    monkeypatch.setattr(_db_module, "DEFAULT_DB_PATH", tmp_path / "state.db")
+    _db_module._SHARED.pop(tmp_path / "state.db", None)
+    _db_module._SHARED_OPEN_LOCK = None
+
+    from lionagi.state.db import get_shared_db
+
+    # Fire 20 concurrent calls.
+    results = await asyncio.gather(*[get_shared_db() for _ in range(20)])
+    first = results[0]
+    assert all(r is first for r in results), "All concurrent calls must return the same instance"
+
+    # Cleanup
+    await first.close()
+    _db_module._SHARED.pop(tmp_path / "state.db", None)


### PR DESCRIPTION
Closes #1487

## Summary

- Introduces `get_shared_db(path=None)` in `lionagi/state/db.py`: a module-level `_SHARED` dict keyed by resolved `Path` holds one open `StateDB` per DB path. The first caller for a given path runs `StateDB.open()`; subsequent callers receive the same instance without re-opening.
- `lionagi/hooks/builtins.py` replaces every `async with StateDB() as db:` block with `db = await _db()` (which calls `get_shared_db()`), eliminating the per-firing connect + `PRAGMA` + schema-migration round-trip.
- `lionagi/state/__init__.py` exports `get_shared_db` as part of the public surface.

## Sites changed

| File | Change |
|------|--------|
| `lionagi/state/db.py` | Added `_SHARED`, `_SHARED_OPEN_LOCK`, `get_shared_db()` after `StateDB` class |
| `lionagi/hooks/builtins.py` | Added `_db()` helper; replaced 4x `async with StateDB() as db:` with `db = await _db()` |
| `lionagi/state/__init__.py` | Added `get_shared_db` to exports |
| `tests/hooks/test_builtins.py` | Updated mock target to `get_shared_db`; added 3 singleton/concurrency tests |
| `CHANGELOG.md` | `### Changed` bullet under `[Unreleased]` |

## Async-safety argument

`aiosqlite` routes all commands through a **single background thread**, so SQLite serialises every operation at the C layer. Concurrent coroutines sharing the same `StateDB` instance are further serialised by the instance's own `_write_lock` (an `anyio.Lock`) that guards every `BEGIN IMMEDIATE` / execute+commit window — this is documented in `StateDB.__init__` and covers `insert_session_signal`, `update_status`, `insert_message`, `append_to_progression`, `touch_session_activity`, `update_session`, `update_branch`, and `update_artifact_verification`.

The shared-instance pattern is therefore identical to the guarantee already provided by the CLI paths that pass an open `StateDB` to `SessionObserver.bind_db_persistence()` — the only change is that builtins now participate in the same safe-sharing model.

The `_SHARED_OPEN_LOCK` (lazily created `anyio.Lock`) ensures the lazy-open window is race-free: if two coroutines concurrently call `get_shared_db()` for the same never-before-opened path, only one will call `StateDB.open()`; the second sees the populated cache after acquiring the lock.

## Test commands and results

```
uv run pytest tests/hooks/test_builtins.py -v
# 10 passed

uv run pytest tests/hooks/ -v
# 55 passed
```

New tests added:
- `test_shared_db_returns_same_instance` — identical object identity on repeated calls
- `test_shared_db_connection_open_once` — `StateDB.open()` called exactly once across 5 calls
- `test_concurrent_hook_firings_use_same_instance` — 20 concurrent `asyncio.gather` calls all return the same instance