### PR TITLE
refactor(studio): use shared StateDB methods for engine_runs (preserve fresh-DB empty-list)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
+- Studio engine-runs service (`lionagi.studio.services.engine_runs`) now delegates to `StateDB.list_engine_runs` / `StateDB.get_engine_run` instead of duplicating raw SQL; fresh-DB empty-list behaviour is preserved by an upfront path-existence guard.
 - The CLI, studio, and operations boundaries now raise typed `LionError` subclasses (`ConfigurationError`, `OperationError`, `ExecutionError`) instead of bare `ValueError`/`RuntimeError`. These subclasses also inherit from the corresponding builtin, so existing `except ValueError` / `except RuntimeError` handlers keep working.
 
 ### Deprecated

--- a/lionagi/studio/services/engine_runs.py
+++ b/lionagi/studio/services/engine_runs.py
@@ -10,10 +10,9 @@ from typing import Any
 
 from fastapi import HTTPException, Query
 
-from lionagi.state.db import DEFAULT_DB_PATH
+from lionagi.state.db import DEFAULT_DB_PATH, StateDB
 
 from ..registry import studio_route
-from ._db import open_db as _open_db
 
 _DB = str(DEFAULT_DB_PATH)
 
@@ -39,51 +38,18 @@ async def list_engine_runs(
     if not DEFAULT_DB_PATH.exists():
         return []
 
-    async with _open_db(_DB) as db:
-        cur = await db.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name='engine_runs'"
+    async with StateDB(_DB) as db:
+        rows = await db.list_engine_runs(
+            kind=kind,
+            status=status,
+            session_id=session_id,
+            limit=limit,
+            offset=offset,
         )
-        if not await cur.fetchone():
-            return []
 
-        conditions: list[str] = []
-        params: list[Any] = []
-        if kind is not None:
-            conditions.append("kind = ?")
-            params.append(kind)
-        if status is not None:
-            conditions.append("status = ?")
-            params.append(status)
-        if session_id is not None:
-            conditions.append("session_id = ?")
-            params.append(session_id)
-        where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
-        params.extend([limit, offset])
-
-        sql = (
-            f"SELECT id, kind, spec_json, status, started_at, ended_at, "  # noqa: S608
-            f"session_id, export_dir, error "
-            f"FROM engine_runs {where} "
-            f"ORDER BY started_at DESC "
-            f"LIMIT ? OFFSET ?"
-        )
-        cur = await db.execute(sql, params)
-        rows = await cur.fetchall()
-
-    return [
-        {
-            "id": r["id"],
-            "kind": r["kind"],
-            "spec_json": _parse_spec_json(r["spec_json"]),
-            "status": r["status"],
-            "started_at": r["started_at"],
-            "ended_at": r["ended_at"],
-            "session_id": r["session_id"],
-            "export_dir": r["export_dir"],
-            "error": r["error"],
-        }
-        for r in rows
-    ]
+    for row in rows:
+        row["spec_json"] = _parse_spec_json(row.get("spec_json"))
+    return rows
 
 
 async def get_engine_run(run_id: str) -> dict[str, Any] | None:
@@ -91,34 +57,13 @@ async def get_engine_run(run_id: str) -> dict[str, Any] | None:
     if not DEFAULT_DB_PATH.exists():
         return None
 
-    async with _open_db(_DB) as db:
-        cur = await db.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name='engine_runs'"
-        )
-        if not await cur.fetchone():
-            return None
+    async with StateDB(_DB) as db:
+        row = await db.get_engine_run(run_id)
 
-        cur = await db.execute(
-            "SELECT id, kind, spec_json, status, started_at, ended_at, "
-            "session_id, export_dir, error "
-            "FROM engine_runs WHERE id = ?",
-            (run_id,),
-        )
-        row = await cur.fetchone()
-        if row is None:
-            return None
-
-    return {
-        "id": row["id"],
-        "kind": row["kind"],
-        "spec_json": _parse_spec_json(row["spec_json"]),
-        "status": row["status"],
-        "started_at": row["started_at"],
-        "ended_at": row["ended_at"],
-        "session_id": row["session_id"],
-        "export_dir": row["export_dir"],
-        "error": row["error"],
-    }
+    if row is None:
+        return None
+    row["spec_json"] = _parse_spec_json(row.get("spec_json"))
+    return row
 
 
 @studio_route("/engine-runs/", method="GET", area="engine-runs", name="list_engine_runs")

--- a/tests/apps_studio_server/test_engine_runs_api.py
+++ b/tests/apps_studio_server/test_engine_runs_api.py
@@ -75,6 +75,23 @@ async def test_service_get_returns_none_when_db_absent(patched_engine_runs_svc):
     assert result is None
 
 
+async def test_service_list_returns_empty_on_fresh_db(patched_engine_runs_svc):
+    """Fresh DB file with no rows → service returns [] without raising."""
+    svc, db_path = patched_engine_runs_svc
+    # Touch the file so the exists() guard passes; StateDB creates schema on open.
+    db_path.touch()
+    result = await svc.list_engine_runs()
+    assert result == []
+
+
+async def test_service_get_returns_none_on_fresh_db(patched_engine_runs_svc):
+    """Fresh DB file with no rows → get returns None without raising."""
+    svc, db_path = patched_engine_runs_svc
+    db_path.touch()
+    result = await svc.get_engine_run("any-id")
+    assert result is None
+
+
 async def test_service_list_returns_seeded_rows(patched_engine_runs_svc):
     svc, db_path = patched_engine_runs_svc
     rid1 = await _seed_engine_run(db_path, kind="research", started_at=1000.0)


### PR DESCRIPTION
Closes #1488

## What changed

`lionagi/studio/services/engine_runs.py` was duplicating the SQL that
`StateDB.list_engine_runs` / `StateDB.get_engine_run` already implement.
This PR replaces the raw SQL with calls to the shared StateDB methods.

## Return-shape parity

| Field | Studio (old) | StateDB method |
|-------|-------------|----------------|
| `id` | `r["id"]` | `dict(row)["id"]` |
| `kind` | `r["kind"]` | `dict(row)["kind"]` |
| `spec_json` | `_parse_spec_json(r["spec_json"])` | `json.loads(...)` + studio re-applies `_parse_spec_json` |
| `status` | `r["status"]` | `dict(row)["status"]` |
| `started_at` | `r["started_at"]` | `dict(row)["started_at"]` |
| `ended_at` | `r["ended_at"]` | `dict(row)["ended_at"]` |
| `session_id` | `r["session_id"]` | `dict(row)["session_id"]` |
| `export_dir` | `r["export_dir"]` | `dict(row)["export_dir"]` |
| `error` | `r["error"]` | `dict(row)["error"]` |

StateDB returns the same nine fields in the same types. The only
difference was the JSON-parse-failure fallback (`{}` vs. leave-as-string).
The studio service retains its `_parse_spec_json` post-processing step on
the rows returned by StateDB so the HTTP surface is byte-identical.

## Fresh-DB / no-table path

**Finding:** `StateDB.open()` calls `_apply_schema()` which runs
`CREATE TABLE IF NOT EXISTS engine_runs ...` — so the table always exists
after opening. There is no "file exists but table missing" edge case to
guard against separately.

**How it is preserved:** The `DEFAULT_DB_PATH.exists()` guard is kept
before opening StateDB. When the DB file does not exist, the service
returns `[]` / `None` immediately — identical to the old behaviour —
without creating the file.

When the file exists but is empty (fresh-created), `StateDB.open()`
creates the schema and `list_engine_runs` returns `[]`. Two new tests
cover this path explicitly.

## Test commands and counts

```
uv run --extra studio pytest tests/apps_studio_server/test_engine_runs_api.py -v
# 20 passed

uv run --extra studio pytest tests/state/test_engine_runs_db.py -v
# 14 passed

uv run --extra studio pytest tests/ -k "engine_run or studio"
# 686 passed, 0 failed
```