### PR TITLE
refactor(service): add serialize_by_alias flag, remove 6 duplicate create_payload overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
+- `EndpointConfig` gains a `serialize_by_alias` flag (default `False`); the Exa and Firecrawl endpoints set it to `True`, removing six identical per-file `create_payload` overrides whose only purpose was alias-serialization.
 - The CLI, studio, and operations boundaries now raise typed `LionError` subclasses (`ConfigurationError`, `OperationError`, `ExecutionError`) instead of bare `ValueError`/`RuntimeError`. These subclasses also inherit from the corresponding builtin, so existing `except ValueError` / `except RuntimeError` handlers keep working.
 
 ### Deprecated

--- a/lionagi/providers/exa/contents/endpoint.py
+++ b/lionagi/providers/exa/contents/endpoint.py
@@ -5,8 +5,6 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel
-
 from lionagi.service.connections.endpoint import Endpoint
 from lionagi.service.connections.endpoint_config import EndpointConfig
 
@@ -24,31 +22,7 @@ class ExaContentsEndpoint(Endpoint):
             from lionagi.config import settings
 
             kwargs.setdefault("api_key", settings.EXA_API_KEY or "dummy-key-for-testing")
+            kwargs.setdefault("serialize_by_alias", True)
             kwargs.setdefault("timeout", 120)
             kwargs.setdefault("max_retries", 3)
         super().__init__(config=config, **kwargs)
-
-    def create_payload(
-        self,
-        request: dict | BaseModel,
-        extra_headers: dict | None = None,
-        **kwargs,
-    ):
-        if self.config.request_options is not None:
-            model_cls = self.config.request_options
-            raw = request if isinstance(request, dict) else request.model_dump(exclude_none=True)
-            merged = {**self.config.kwargs, **raw, **kwargs}
-            obj = model_cls.model_validate(merged)
-            payload = obj.model_dump(by_alias=True, exclude_none=True)
-            from lionagi.service.connections.header_factory import HeaderFactory
-
-            headers = HeaderFactory.get_header(
-                auth_type=self.config.auth_type,
-                content_type=self.config.content_type,
-                api_key=self.config._api_key,
-                default_headers=self.config.default_headers,
-            )
-            if extra_headers:
-                headers.update(extra_headers)
-            return payload, headers
-        return super().create_payload(request, extra_headers, **kwargs)

--- a/lionagi/providers/exa/find_similar/endpoint.py
+++ b/lionagi/providers/exa/find_similar/endpoint.py
@@ -5,8 +5,6 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel
-
 from lionagi.service.connections.endpoint import Endpoint
 from lionagi.service.connections.endpoint_config import EndpointConfig
 
@@ -24,31 +22,7 @@ class ExaFindSimilarEndpoint(Endpoint):
             from lionagi.config import settings
 
             kwargs.setdefault("api_key", settings.EXA_API_KEY or "dummy-key-for-testing")
+            kwargs.setdefault("serialize_by_alias", True)
             kwargs.setdefault("timeout", 120)
             kwargs.setdefault("max_retries", 3)
         super().__init__(config=config, **kwargs)
-
-    def create_payload(
-        self,
-        request: dict | BaseModel,
-        extra_headers: dict | None = None,
-        **kwargs,
-    ):
-        if self.config.request_options is not None:
-            model_cls = self.config.request_options
-            raw = request if isinstance(request, dict) else request.model_dump(exclude_none=True)
-            merged = {**self.config.kwargs, **raw, **kwargs}
-            obj = model_cls.model_validate(merged)
-            payload = obj.model_dump(by_alias=True, exclude_none=True)
-            from lionagi.service.connections.header_factory import HeaderFactory
-
-            headers = HeaderFactory.get_header(
-                auth_type=self.config.auth_type,
-                content_type=self.config.content_type,
-                api_key=self.config._api_key,
-                default_headers=self.config.default_headers,
-            )
-            if extra_headers:
-                headers.update(extra_headers)
-            return payload, headers
-        return super().create_payload(request, extra_headers, **kwargs)

--- a/lionagi/providers/exa/search/endpoint.py
+++ b/lionagi/providers/exa/search/endpoint.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel
-
 from lionagi.service.connections.endpoint import Endpoint
 from lionagi.service.connections.endpoint_config import EndpointConfig
 
@@ -20,31 +18,7 @@ class ExaSearchEndpoint(Endpoint):
             from lionagi.config import settings
 
             kwargs.setdefault("api_key", settings.EXA_API_KEY or "dummy-key-for-testing")
+            kwargs.setdefault("serialize_by_alias", True)
             kwargs.setdefault("timeout", 120)
             kwargs.setdefault("max_retries", 3)
         super().__init__(config=config, **kwargs)
-
-    def create_payload(
-        self,
-        request: dict | BaseModel,
-        extra_headers: dict | None = None,
-        **kwargs,
-    ):
-        if self.config.request_options is not None:
-            model_cls = self.config.request_options
-            raw = request if isinstance(request, dict) else request.model_dump(exclude_none=True)
-            merged = {**self.config.kwargs, **raw, **kwargs}
-            obj = model_cls.model_validate(merged)
-            payload = obj.model_dump(by_alias=True, exclude_none=True)
-            from lionagi.service.connections.header_factory import HeaderFactory
-
-            headers = HeaderFactory.get_header(
-                auth_type=self.config.auth_type,
-                content_type=self.config.content_type,
-                api_key=self.config._api_key,
-                default_headers=self.config.default_headers,
-            )
-            if extra_headers:
-                headers.update(extra_headers)
-            return payload, headers
-        return super().create_payload(request, extra_headers, **kwargs)

--- a/lionagi/providers/firecrawl/crawl/endpoint.py
+++ b/lionagi/providers/firecrawl/crawl/endpoint.py
@@ -5,8 +5,6 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel
-
 from lionagi.service.connections.endpoint import Endpoint
 from lionagi.service.connections.endpoint_config import EndpointConfig
 
@@ -24,31 +22,7 @@ class FirecrawlCrawlEndpoint(Endpoint):
             from lionagi.config import settings
 
             kwargs.setdefault("api_key", settings.FIRECRAWL_API_KEY or "dummy-key-for-testing")
+            kwargs.setdefault("serialize_by_alias", True)
             kwargs.setdefault("timeout", 120)
             kwargs.setdefault("max_retries", 3)
         super().__init__(config=config, **kwargs)
-
-    def create_payload(
-        self,
-        request: dict | BaseModel,
-        extra_headers: dict | None = None,
-        **kwargs,
-    ):
-        if self.config.request_options is not None:
-            model_cls = self.config.request_options
-            raw = request if isinstance(request, dict) else request.model_dump(exclude_none=True)
-            merged = {**self.config.kwargs, **raw, **kwargs}
-            obj = model_cls.model_validate(merged)
-            payload = obj.model_dump(by_alias=True, exclude_none=True)
-            from lionagi.service.connections.header_factory import HeaderFactory
-
-            headers = HeaderFactory.get_header(
-                auth_type=self.config.auth_type,
-                content_type=self.config.content_type,
-                api_key=self.config._api_key,
-                default_headers=self.config.default_headers,
-            )
-            if extra_headers:
-                headers.update(extra_headers)
-            return payload, headers
-        return super().create_payload(request, extra_headers, **kwargs)

--- a/lionagi/providers/firecrawl/map/endpoint.py
+++ b/lionagi/providers/firecrawl/map/endpoint.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from pydantic import BaseModel
-
 from lionagi.service.connections.endpoint import Endpoint
 from lionagi.service.connections.endpoint_config import EndpointConfig
 
@@ -15,31 +13,7 @@ class FirecrawlMapEndpoint(Endpoint):
             from lionagi.config import settings
 
             kwargs.setdefault("api_key", settings.FIRECRAWL_API_KEY or "dummy-key-for-testing")
+            kwargs.setdefault("serialize_by_alias", True)
             kwargs.setdefault("timeout", 120)
             kwargs.setdefault("max_retries", 3)
         super().__init__(config=config, **kwargs)
-
-    def create_payload(
-        self,
-        request: dict | BaseModel,
-        extra_headers: dict | None = None,
-        **kwargs,
-    ):
-        if self.config.request_options is not None:
-            model_cls = self.config.request_options
-            raw = request if isinstance(request, dict) else request.model_dump(exclude_none=True)
-            merged = {**self.config.kwargs, **raw, **kwargs}
-            obj = model_cls.model_validate(merged)
-            payload = obj.model_dump(by_alias=True, exclude_none=True)
-            from lionagi.service.connections.header_factory import HeaderFactory
-
-            headers = HeaderFactory.get_header(
-                auth_type=self.config.auth_type,
-                content_type=self.config.content_type,
-                api_key=self.config._api_key,
-                default_headers=self.config.default_headers,
-            )
-            if extra_headers:
-                headers.update(extra_headers)
-            return payload, headers
-        return super().create_payload(request, extra_headers, **kwargs)

--- a/lionagi/providers/firecrawl/scrape/endpoint.py
+++ b/lionagi/providers/firecrawl/scrape/endpoint.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from pydantic import BaseModel
-
 from lionagi.service.connections.endpoint import Endpoint
 from lionagi.service.connections.endpoint_config import EndpointConfig
 
@@ -15,31 +13,7 @@ class FirecrawlScrapeEndpoint(Endpoint):
             from lionagi.config import settings
 
             kwargs.setdefault("api_key", settings.FIRECRAWL_API_KEY or "dummy-key-for-testing")
+            kwargs.setdefault("serialize_by_alias", True)
             kwargs.setdefault("timeout", 120)
             kwargs.setdefault("max_retries", 3)
         super().__init__(config=config, **kwargs)
-
-    def create_payload(
-        self,
-        request: dict | BaseModel,
-        extra_headers: dict | None = None,
-        **kwargs,
-    ):
-        if self.config.request_options is not None:
-            model_cls = self.config.request_options
-            raw = request if isinstance(request, dict) else request.model_dump(exclude_none=True)
-            merged = {**self.config.kwargs, **raw, **kwargs}
-            obj = model_cls.model_validate(merged)
-            payload = obj.model_dump(by_alias=True, exclude_none=True)
-            from lionagi.service.connections.header_factory import HeaderFactory
-
-            headers = HeaderFactory.get_header(
-                auth_type=self.config.auth_type,
-                content_type=self.config.content_type,
-                api_key=self.config._api_key,
-                default_headers=self.config.default_headers,
-            )
-            if extra_headers:
-                headers.update(extra_headers)
-            return payload, headers
-        return super().create_payload(request, extra_headers, **kwargs)

--- a/lionagi/service/connections/endpoint_config.py
+++ b/lionagi/service/connections/endpoint_config.py
@@ -48,6 +48,7 @@ class EndpointConfig(BaseModel):
     kwargs: dict = Field(default_factory=dict)
     client_kwargs: dict = Field(default_factory=dict)
     allow_local_network: bool = False
+    serialize_by_alias: bool = False
     _api_key: str | None = PrivateAttr(None)
 
     @model_validator(mode="before")
@@ -135,19 +136,14 @@ class EndpointConfig(BaseModel):
                 self.kwargs[key] = value
 
     def validate_payload(self, data: dict[str, Any]) -> dict[str, Any]:
-        """Validate payload data against the request_options model.
-
-        Args:
-            data: The payload data to validate
-
-        Returns:
-            The validated data
-        """
+        """Validate payload data against the request_options model."""
         if not self.request_options:
             return data
 
         try:
-            self.request_options.model_validate(data)
+            obj = self.request_options.model_validate(data)
+            if self.serialize_by_alias:
+                return obj.model_dump(by_alias=True, exclude_none=True)
             return data
         except Exception as e:
             raise ValueError("Invalid payload") from e

--- a/tests/service/connections/test_serialize_by_alias.py
+++ b/tests/service/connections/test_serialize_by_alias.py
@@ -1,0 +1,266 @@
+# Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Payload-parity tests for the serialize_by_alias flag on EndpointConfig.
+
+Each test verifies that the flag-based path in the base Endpoint.create_payload
+produces the same dict as the old per-file override did (model_dump by_alias=True,
+exclude_none=True).
+"""
+
+from __future__ import annotations
+
+from lionagi.service.connections.endpoint import Endpoint
+from lionagi.service.connections.endpoint_config import EndpointConfig
+
+# ---------------------------------------------------------------------------
+# Helper: simulate the old override behaviour for a given model class + inputs
+# ---------------------------------------------------------------------------
+
+
+def _old_override_payload(model_cls, config_kwargs: dict, request: dict, extra_kwargs: dict):
+    """Reproduces the pre-refactor override logic verbatim."""
+    merged = {**config_kwargs, **request, **extra_kwargs}
+    obj = model_cls.model_validate(merged)
+    return obj.model_dump(by_alias=True, exclude_none=True)
+
+
+def _new_flag_payload(endpoint: Endpoint, request: dict):
+    payload, _ = endpoint.create_payload(request)
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Exa Search
+# ---------------------------------------------------------------------------
+
+
+class TestExaSearchPayloadParity:
+    def test_basic_query(self):
+        from lionagi.providers.exa.search.endpoint import ExaSearchEndpoint
+        from lionagi.providers.exa.search.models import ExaSearchRequest
+
+        ep = ExaSearchEndpoint()
+        req = {"query": "lionagi framework", "num_results": 5}
+
+        expected = _old_override_payload(ExaSearchRequest, {}, req, {})
+        got = _new_flag_payload(ep, req)
+
+        assert got == expected
+
+    def test_alias_fields_present(self):
+        from lionagi.providers.exa.search.endpoint import ExaSearchEndpoint
+
+        ep = ExaSearchEndpoint()
+        req = {"query": "test", "num_results": 3}
+        payload, _ = ep.create_payload(req)
+        # alias "numResults" must appear, not the Python name
+        assert "numResults" in payload
+        assert "num_results" not in payload
+
+    def test_none_fields_excluded(self):
+        from lionagi.providers.exa.search.endpoint import ExaSearchEndpoint
+
+        ep = ExaSearchEndpoint()
+        req = {"query": "test"}
+        payload, _ = ep.create_payload(req)
+        assert "includeDomains" not in payload
+        assert "excludeDomains" not in payload
+
+
+# ---------------------------------------------------------------------------
+# Exa Contents
+# ---------------------------------------------------------------------------
+
+
+class TestExaContentsPayloadParity:
+    def test_basic_ids(self):
+        from lionagi.providers.exa.contents.endpoint import ExaContentsEndpoint
+        from lionagi.providers.exa.contents.models import ExaContentsRequest
+
+        ep = ExaContentsEndpoint()
+        req = {"ids": ["https://example.com"]}
+
+        expected = _old_override_payload(ExaContentsRequest, {}, req, {})
+        got = _new_flag_payload(ep, req)
+
+        assert got == expected
+
+    def test_alias_fields_present(self):
+        from lionagi.providers.exa.contents.endpoint import ExaContentsEndpoint
+
+        ep = ExaContentsEndpoint()
+        req = {"ids": ["https://example.com"]}
+        payload, _ = ep.create_payload(req)
+        assert "ids" in payload
+
+
+# ---------------------------------------------------------------------------
+# Exa FindSimilar
+# ---------------------------------------------------------------------------
+
+
+class TestExaFindSimilarPayloadParity:
+    def test_basic_url(self):
+        from lionagi.providers.exa.find_similar.endpoint import ExaFindSimilarEndpoint
+        from lionagi.providers.exa.find_similar.models import ExaFindSimilarRequest
+
+        ep = ExaFindSimilarEndpoint()
+        req = {"url": "https://example.com"}
+
+        expected = _old_override_payload(ExaFindSimilarRequest, {}, req, {})
+        got = _new_flag_payload(ep, req)
+
+        assert got == expected
+
+    def test_alias_fields_present(self):
+        from lionagi.providers.exa.find_similar.endpoint import ExaFindSimilarEndpoint
+
+        ep = ExaFindSimilarEndpoint()
+        req = {"url": "https://example.com", "num_results": 5}
+        payload, _ = ep.create_payload(req)
+        assert "numResults" in payload
+        assert "num_results" not in payload
+
+
+# ---------------------------------------------------------------------------
+# Firecrawl Scrape
+# ---------------------------------------------------------------------------
+
+
+class TestFirecrawlScrapePayloadParity:
+    def test_basic_url(self):
+        from lionagi.providers.firecrawl.scrape.endpoint import FirecrawlScrapeEndpoint
+        from lionagi.providers.firecrawl.scrape.models import FirecrawlScrapeRequest
+
+        ep = FirecrawlScrapeEndpoint()
+        req = {"url": "https://example.com"}
+
+        expected = _old_override_payload(FirecrawlScrapeRequest, {}, req, {})
+        got = _new_flag_payload(ep, req)
+
+        assert got == expected
+
+    def test_alias_fields_present(self):
+        from lionagi.providers.firecrawl.scrape.endpoint import FirecrawlScrapeEndpoint
+
+        ep = FirecrawlScrapeEndpoint()
+        req = {"url": "https://example.com", "only_main_content": True}
+        payload, _ = ep.create_payload(req)
+        assert "onlyMainContent" in payload
+        assert "only_main_content" not in payload
+
+    def test_none_fields_excluded(self):
+        from lionagi.providers.firecrawl.scrape.endpoint import FirecrawlScrapeEndpoint
+
+        ep = FirecrawlScrapeEndpoint()
+        req = {"url": "https://example.com"}
+        payload, _ = ep.create_payload(req)
+        assert "includeTags" not in payload
+        assert "excludeTags" not in payload
+
+
+# ---------------------------------------------------------------------------
+# Firecrawl Map
+# ---------------------------------------------------------------------------
+
+
+class TestFirecrawlMapPayloadParity:
+    def test_basic_url(self):
+        from lionagi.providers.firecrawl.map.endpoint import FirecrawlMapEndpoint
+        from lionagi.providers.firecrawl.map.models import FirecrawlMapRequest
+
+        ep = FirecrawlMapEndpoint()
+        req = {"url": "https://example.com"}
+
+        expected = _old_override_payload(FirecrawlMapRequest, {}, req, {})
+        got = _new_flag_payload(ep, req)
+
+        assert got == expected
+
+
+# ---------------------------------------------------------------------------
+# Firecrawl Crawl
+# ---------------------------------------------------------------------------
+
+
+class TestFirecrawlCrawlPayloadParity:
+    def test_basic_url(self):
+        from lionagi.providers.firecrawl.crawl.endpoint import FirecrawlCrawlEndpoint
+        from lionagi.providers.firecrawl.crawl.models import FirecrawlCrawlRequest
+
+        ep = FirecrawlCrawlEndpoint()
+        req = {"url": "https://example.com"}
+
+        expected = _old_override_payload(FirecrawlCrawlRequest, {}, req, {})
+        got = _new_flag_payload(ep, req)
+
+        assert got == expected
+
+    def test_alias_fields_present(self):
+        from lionagi.providers.firecrawl.crawl.endpoint import FirecrawlCrawlEndpoint
+
+        ep = FirecrawlCrawlEndpoint()
+        req = {"url": "https://example.com", "max_depth": 3}
+        payload, _ = ep.create_payload(req)
+        assert "maxDepth" in payload
+        assert "max_depth" not in payload
+
+
+# ---------------------------------------------------------------------------
+# Default-false guard: serialize_by_alias=False must NOT affect non-Exa/Firecrawl
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeByAliasDefault:
+    def test_default_is_false(self):
+        config = EndpointConfig(
+            name="openai_chat",
+            provider="openai",
+            endpoint="chat/completions",
+            api_key="dummy-key-for-testing",
+        )
+        assert config.serialize_by_alias is False
+
+    def test_openai_payload_unaffected(self):
+        from pydantic import BaseModel, Field
+
+        class ChatRequest(BaseModel):
+            messages: list
+            max_tokens: int | None = Field(None, alias="maxTokens")
+
+        config = EndpointConfig(
+            name="openai_chat",
+            provider="openai",
+            endpoint="chat/completions",
+            api_key="dummy-key-for-testing",
+            request_options=ChatRequest,
+        )
+        ep = Endpoint(config=config)
+        req = {"messages": [{"role": "user", "content": "hi"}]}
+        payload, _ = ep.create_payload(req)
+        # Without serialize_by_alias, validate_payload returns the input dict unchanged
+        assert "messages" in payload
+        # alias field not present because serialize_by_alias=False → raw dict returned
+        assert "maxTokens" not in payload
+
+    def test_flag_endpoint_configs_are_true(self):
+        from lionagi.providers.exa.contents.endpoint import ExaContentsEndpoint
+        from lionagi.providers.exa.find_similar.endpoint import ExaFindSimilarEndpoint
+        from lionagi.providers.exa.search.endpoint import ExaSearchEndpoint
+        from lionagi.providers.firecrawl.crawl.endpoint import FirecrawlCrawlEndpoint
+        from lionagi.providers.firecrawl.map.endpoint import FirecrawlMapEndpoint
+        from lionagi.providers.firecrawl.scrape.endpoint import FirecrawlScrapeEndpoint
+
+        for cls in (
+            ExaSearchEndpoint,
+            ExaContentsEndpoint,
+            ExaFindSimilarEndpoint,
+            FirecrawlScrapeEndpoint,
+            FirecrawlMapEndpoint,
+            FirecrawlCrawlEndpoint,
+        ):
+            ep = cls()
+            assert ep.config.serialize_by_alias is True, (
+                f"{cls.__name__} must have serialize_by_alias=True"
+            )


### PR DESCRIPTION
Closes #1491

## Summary

- Adds `serialize_by_alias: bool = False` to `EndpointConfig`; default preserves all existing provider behaviour unchanged.
- Updates `EndpointConfig.validate_payload` to return `obj.model_dump(by_alias=True, exclude_none=True)` when the flag is `True`, which is exactly what each removed override produced.
- Removes the identical `create_payload` override from all 6 Exa/Firecrawl endpoint files; each `__init__` now sets `serialize_by_alias=True` via `kwargs.setdefault`.

## Override identity audit

All 6 overrides were byte-for-byte identical (diff confirms zero functional difference between any pair):

| File | Override present before | Mechanism | Result |
|---|---|---|---|
| `exa/search/endpoint.py` | yes | `model_dump(by_alias=True, exclude_none=True)` | removed, flag=True |
| `exa/contents/endpoint.py` | yes | identical | removed, flag=True |
| `exa/find_similar/endpoint.py` | yes | identical | removed, flag=True |
| `firecrawl/scrape/endpoint.py` | yes | identical | removed, flag=True |
| `firecrawl/map/endpoint.py` | yes | identical | removed, flag=True |
| `firecrawl/crawl/endpoint.py` | yes | identical | removed, flag=True |

## Default preservation for all other providers

`serialize_by_alias` defaults to `False`. When `False`, `validate_payload` returns the raw filtered dict unchanged — identical to the previous behaviour. No other provider sets this flag.

## Per-provider payload parity table

| Provider | Payload key before (alias) | Payload key after (alias) | Identical |
|---|---|---|---|
| Exa Search `numResults` | present | present | yes |
| Exa Search `useAutoprompt` | present | present | yes |
| Exa Contents `ids` | present | present | yes |
| Exa FindSimilar `numResults` | present | present | yes |
| Firecrawl Scrape `onlyMainContent` | present | present | yes |
| Firecrawl Crawl `maxDepth` | present | present | yes |

## Test plan

```
uv run pytest tests/service/connections/test_serialize_by_alias.py -v
# 16 passed in 1.54s

uv run pytest tests/ -k "exa or firecrawl or payload or endpoint_config or create_payload or serialize_by_alias"
# 157 passed, 25 skipped in 5.46s  (skips = studio extra not installed)

uv run pytest tests/service/ -v
# 935 passed, 1 skipped, 4 failed in 4.22s
# 4 pre-existing failures in tests/service/connections/mcp/test_wrapper.py (confirmed on main before this branch)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)