### PR TITLE
refactor(studio): make engine_runs + sessions + invocations thin adapters (LionError→HTTP at route edge)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 - Studio engine-runs service (`lionagi.studio.services.engine_runs`) now delegates to `StateDB.list_engine_runs` / `StateDB.get_engine_run` instead of duplicating raw SQL; fresh-DB empty-list behaviour is preserved by an upfront path-existence guard.
 - The CLI, studio, and operations boundaries now raise typed `LionError` subclasses (`ConfigurationError`, `OperationError`, `ExecutionError`) instead of bare `ValueError`/`RuntimeError`. These subclasses also inherit from the corresponding builtin, so existing `except ValueError` / `except RuntimeError` handlers keep working.
+- Studio services `engine_runs`, `sessions`, and `invocations` no longer import `fastapi.HTTPException` in their logic functions; not-found conditions raise `NotFoundError` (status 404) instead, and the `app`-level `LionError` exception handler translates domain errors to HTTP responses at the route edge.
 
 ### Deprecated
 

--- a/lionagi/studio/app.py
+++ b/lionagi/studio/app.py
@@ -11,6 +11,8 @@ from starlette.middleware.cors import CORSMiddleware
 from starlette.responses import FileResponse, JSONResponse
 from starlette.staticfiles import StaticFiles
 
+from lionagi._errors import LionError
+
 from .config import CORS_ORIGINS, HOST
 from .registry import iter_studio_routes, load_studio_route_modules
 
@@ -96,6 +98,15 @@ async def lifespan(app_instance):
 
 
 app = FastAPI(title="Lion Studio Server", lifespan=lifespan)
+
+
+@app.exception_handler(LionError)
+async def _lion_error_handler(request: Request, exc: LionError) -> JSONResponse:
+    """Translate domain errors raised by service logic into HTTP responses."""
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"detail": exc.message},
+    )
 
 
 @app.middleware("http")

--- a/lionagi/studio/services/engine_runs.py
+++ b/lionagi/studio/services/engine_runs.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from fastapi import HTTPException, Query
+from fastapi import Query
 
+from lionagi._errors import NotFoundError
 from lionagi.state.db import DEFAULT_DB_PATH, StateDB
 
 from ..registry import studio_route
@@ -89,5 +90,5 @@ async def get_engine_run_route(run_id: str) -> dict[str, Any]:
     """Return a single engine run row by id."""
     row = await get_engine_run(run_id)
     if row is None:
-        raise HTTPException(status_code=404, detail=f"Engine run '{run_id}' not found")
+        raise NotFoundError(f"Engine run '{run_id}' not found")
     return row

--- a/lionagi/studio/services/invocations.py
+++ b/lionagi/studio/services/invocations.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from fastapi import HTTPException, Query
+from fastapi import Query
 
+from lionagi._errors import NotFoundError
 from lionagi.state.db import DEFAULT_DB_PATH, StateDB
 
 from ..registry import studio_route
@@ -169,7 +170,7 @@ async def list_invocations_route(
 async def get_invocation_route(invocation_id: str) -> dict[str, Any]:
     data = await get_invocation(invocation_id)
     if data is None:
-        raise HTTPException(status_code=404, detail=f"Invocation '{invocation_id}' not found")
+        raise NotFoundError(f"Invocation '{invocation_id}' not found")
     return data
 
 
@@ -183,7 +184,7 @@ async def get_invocation_route(invocation_id: str) -> dict[str, Any]:
 async def get_artifact_route(artifact_id: str) -> dict[str, Any]:
     data = await get_artifact(artifact_id)
     if data is None:
-        raise HTTPException(status_code=404, detail=f"Artifact '{artifact_id}' not found")
+        raise NotFoundError(f"Artifact '{artifact_id}' not found")
     return data
 
 

--- a/lionagi/studio/services/sessions.py
+++ b/lionagi/studio/services/sessions.py
@@ -6,8 +6,8 @@ import time
 from typing import Any
 
 import aiosqlite
-from fastapi import HTTPException  # used for 404 guards
 
+from lionagi._errors import NotFoundError
 from lionagi.state.db import DEFAULT_DB_PATH, SESSION_TERMINAL_STATUSES
 
 from ..registry import studio_route
@@ -424,7 +424,7 @@ async def list_sessions_route() -> dict[str, Any]:
 async def get_session_route(session_id: str) -> dict[str, Any]:
     session = await get_session(session_id)
     if session is None:
-        raise HTTPException(status_code=404, detail=f"Session '{session_id}' not found")
+        raise NotFoundError(f"Session '{session_id}' not found")
     return session
 
 
@@ -441,7 +441,7 @@ async def stream_session_route(session_id: str):
     # then waits 60s before emitting done — client hangs with no indication.
     # The shows router already does this at shows.py:34-35; we mirror that pattern.
     if not await session_exists(session_id):
-        raise HTTPException(status_code=404, detail=f"Session '{session_id}' not found")
+        raise NotFoundError(f"Session '{session_id}' not found")
 
     async def generate():
         after_ts: float = 0.0
@@ -489,7 +489,7 @@ async def stream_signals(session_id: str) -> Any:
     # Pre-flight 404 guard before opening the stream — mirrors the pattern
     # at sessions.py:35-36 (ADR-0006).
     if not await session_exists(session_id):
-        raise HTTPException(status_code=404, detail=f"Session '{session_id}' not found")
+        raise NotFoundError(f"Session '{session_id}' not found")
 
     from . import signals as signals_svc
 


### PR DESCRIPTION
Closes #1494

## Summary

- `engine_runs`, `sessions`, and `invocations` service modules no longer import `fastapi.HTTPException` in their logic functions
- Not-found guards in those modules now raise `NotFoundError` (from `lionagi._errors`) instead of `HTTPException`
- A single `@app.exception_handler(LionError)` in `app.py` is the sole translation point: domain errors become HTTP responses there — the `{"detail": exc.message}` body and `exc.status_code` are preserved exactly

## Modules chosen

| Module | Role |
|--------|------|
| `lionagi/studio/services/engine_runs.py` | reads engine-run rows from StateDB |
| `lionagi/studio/services/sessions.py` | reads session rows + drives SSE streams |
| `lionagi/studio/services/invocations.py` | reads invocation + artifact rows from StateDB |

## Route-edge seam

`lionagi/studio/app.py` — `@app.exception_handler(LionError)` registered on the FastAPI application object, after route modules are loaded. Catches `LionError` and all subclasses (including `NotFoundError`).

## Condition → status-code table (before vs after — identical)

| Module | Condition | Before (HTTPException) | After (NotFoundError) | HTTP status |
|--------|-----------|----------------------|-----------------------|-------------|
| engine_runs | run_id not in DB | `HTTPException(404, ...)` | `NotFoundError(...)` | **404** |
| sessions | session_id not in DB (GET detail) | `HTTPException(404, ...)` | `NotFoundError(...)` | **404** |
| sessions | session_id not in DB (stream pre-flight) | `HTTPException(404, ...)` | `NotFoundError(...)` | **404** |
| sessions | session_id not in DB (signals pre-flight) | `HTTPException(404, ...)` | `NotFoundError(...)` | **404** |
| invocations | invocation_id not in DB | `HTTPException(404, ...)` | `NotFoundError(...)` | **404** |
| invocations | artifact_id not in DB | `HTTPException(404, ...)` | `NotFoundError(...)` | **404** |

No status code changed. `NotFoundError.default_status_code = 404` (defined in `_errors.py`).

## Test commands and real counts

```
uv run --extra studio pytest tests/apps_studio_server/test_engine_runs_api.py -v
# 20 passed

uv run --extra studio pytest tests/apps_studio_server/test_sessions_detail.py -v
# 24 passed

uv run --extra studio pytest tests/apps_studio_server/test_signals_sse.py tests/apps_studio_server/test_audit_remediation.py -v
# 79 passed

uv run --extra studio pytest tests/apps_studio_server/ tests/studio/
# 621 passed, 13 warnings
```

All 621 tests pass. No status codes changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)