### PR TITLE
fix(ci): force matrix interpreter + fix 3.14 Annotated incompat (#1443)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,10 @@ jobs:
       matrix:
         # PRs: oldest + newest only (60% faster). Full matrix on main/develop pushes.
         python-version: ${{ fromJSON(github.event_name == 'pull_request' && '["3.10","3.14"]' || '["3.10","3.11","3.12","3.13","3.14"]') }}
+    # Force every `uv` call (venv, sync, run) onto the matrix interpreter; the
+    # repo's .python-version (3.10) otherwise pins all legs to 3.10.
+    env:
+      UV_PYTHON: ${{ matrix.python-version }}
     steps:
     - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}

--- a/lionagi/ln/types/spec.py
+++ b/lionagi/ln/types/spec.py
@@ -247,7 +247,9 @@ class Spec:
 
             if current_metadata:
                 args = [actual_type] + list(current_metadata)
-                result = Annotated.__class_getitem__(tuple(args))  # type: ignore
+                # Subscription (not the __class_getitem__ attribute, which 3.14
+                # removed from special forms). Annotated[(a, b)] == Annotated[a, b].
+                result = Annotated[tuple(args)]  # type: ignore
             else:
                 result = actual_type  # type: ignore[misc]
 

--- a/lionagi/models/field_model.py
+++ b/lionagi/models/field_model.py
@@ -289,7 +289,9 @@ class FieldModel(Params):
 
         if current_metadata:
             args = [actual_type] + list(current_metadata)
-            result = Annotated.__class_getitem__(tuple(args))  # type: ignore
+            # Subscription (not the __class_getitem__ attribute, which 3.14
+            # removed from special forms). Annotated[(a, b, c)] == Annotated[a, b, c].
+            result = Annotated[tuple(args)]  # type: ignore
         else:
             result = actual_type  # type: ignore[misc]
 


### PR DESCRIPTION
## Summary

Two coupled changes — the CI fix and the source bug it exposes:

1. **CI matrix actually tests every Python version (#1443).** `uv venv`/`uv sync`/`uv run` honor the repo's committed `.python-version` (3.10) over setup-python's PATH interpreter, so all matrix legs were silently running on 3.10 for ~7 weeks. Added `UV_PYTHON: ${{ matrix.python-version }}` to the `test` job env so every `uv` call targets the matrix interpreter.

2. **Fix the 3.14 incompatibility this surfaces.** With 3.14 now genuinely running, `FieldModel.annotated()` and `Spec` failed with `AttributeError: __class_getitem__`. Python 3.14 reimplemented `typing` special forms and removed the directly-accessible `Annotated.__class_getitem__` attribute. Switched both sites to canonical subscription `Annotated[tuple(args)]` — identical semantics (`X[(a, b)]` == `X[a, b]`), portable across 3.10–3.14.

## Verification

Full suite on local **Python 3.14.3**, maxfail lifted:
- Before fix: `4 failed` (3× `test_field_model_edge_cases`, 1× `test_spec`), all `AttributeError: __class_getitem__`
- After fix: **9446 passed, 0 failed**

## Why coupled in one PR

Merging the matrix fix alone would turn main's 3.14 leg red (the bug is real and pre-existing). Coupling the fix keeps main green at merge.

Closes #1443