### PR TITLE
fix(cli): li kill recognizes shebang-launched runs

### DIFF
--- a/lionagi/cli/kill.py
+++ b/lionagi/cli/kill.py
@@ -60,6 +60,11 @@ def _cmdline_is_lionagi(cmdline: list[str], expected_cmd: str) -> bool:
     exe = os.path.basename(cmdline[0])
     if exe in ("li", expected_cmd):
         return True
+    # Shebang-launched console scripts: argv[0] is the Python interpreter and
+    # argv[1] is the script path (e.g. .venv/bin/li).
+    if exe.startswith("python") and len(cmdline) >= 2:
+        if os.path.basename(cmdline[1]) == "li":
+            return True
     for flag, mod in zip(cmdline, cmdline[1:], strict=False):
         if flag == "-m" and (mod == expected_cmd or mod.startswith(expected_cmd + ".")):
             return True

--- a/tests/cli/test_kill.py
+++ b/tests/cli/test_kill.py
@@ -286,6 +286,24 @@ def test_identity_accepts_li_entrypoint(monkeypatch: pytest.MonkeyPatch):
     assert _check_pid_identity(42, "lionagi") is True
 
 
+def test_identity_accepts_shebang_launched_li(monkeypatch: pytest.MonkeyPatch):
+    """Shebang-launched li: argv[0]=python3, argv[1]=.../bin/li — must be accepted."""
+    _mock_psutil(
+        monkeypatch,
+        cmdline=["/opt/.venv/bin/python3", "/opt/.venv/bin/li", "play", "abc123"],
+    )
+    assert _check_pid_identity(42, "lionagi") is True
+
+
+def test_identity_rejects_foreign_script_with_li_in_path(monkeypatch: pytest.MonkeyPatch):
+    """A non-lionagi script whose path contains 'li' must not be accepted."""
+    _mock_psutil(
+        monkeypatch,
+        cmdline=["/usr/bin/python3", "/usr/local/bin/olia-tool", "run"],
+    )
+    assert _check_pid_identity(42, "lionagi") is False
+
+
 def test_identity_session_marker_match(monkeypatch: pytest.MonkeyPatch):
     """A matching LIONAGI_SESSION_ID env marker is a definitive match."""
     _mock_psutil(


### PR DESCRIPTION
## Root cause

\`_cmdline_is_lionagi()\` in \`lionagi/cli/kill.py\` only inspected \`cmdline[0]\` basename. When \`li\` is launched via its console-script shebang (the normal installed-package case), the OS cmdline is:

\`\`\`
['/path/to/.venv/bin/python3', '/path/to/.venv/bin/li', 'play', ...]
\`\`\`

So \`cmdline[0]\` basename is \`python3\`, not \`li\`. The guard concluded "not a lionagi process" and returned \`identity_mismatch\`, causing \`li kill\` to skip the signal and print:

> pid N did not match expected lionagi process — kill skipped

## Fix

When \`cmdline[0]\` basename starts with \`python\`, also check that \`cmdline[1]\` basename is exactly \`li\`. This covers the shebang-launched case while preserving the safety guarantee:

- Still an exact basename match — no substring match against arbitrary paths
- Only triggers when argv[0] is a Python interpreter, so an unrelated process with \`li\` anywhere in a path arg is not accepted
- The existing \`-m lionagi\` path check is unchanged

## Tests

Two new tests in \`tests/cli/test_kill.py\`:

- \`test_identity_accepts_shebang_launched_li\`: \`['/opt/.venv/bin/python3', '/opt/.venv/bin/li', 'play', 'abc123']\` → \`True\` — **failed before fix, passes after**
- \`test_identity_rejects_foreign_script_with_li_in_path\`: \`['/usr/bin/python3', '/usr/local/bin/olia-tool', 'run']\` → \`False\` — guard preserved

Full kill suite: 63/63 passed.

Closes #1459