### PR TITLE
fix(flow): ReactiveExecutor.execute subscribes via public observer property

### DIFF
--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -535,9 +535,8 @@ class ReactiveExecutor(DependencyAwareExecutor):
 
         initial = [n for n in self.graph.internal_nodes.values() if isinstance(n, Operation)]
         self._running = True
-        observer = getattr(self.session, "_observer", None)
-        if observer is not None:
-            self.session.observe(self.spawn_type, self._on_bus_spawn)
+        observer = self.session.observer
+        self.session.observe(self.spawn_type, self._on_bus_spawn)
         try:
             async with create_task_group() as tg:
                 self._tg = tg
@@ -549,8 +548,7 @@ class ReactiveExecutor(DependencyAwareExecutor):
         finally:
             self._running = False
             self._tg = None
-            if observer is not None:
-                observer.unobserve(self._on_bus_spawn)
+            observer.unobserve(self._on_bus_spawn)
 
         completed_ops = [
             op_id for op_id in self.results.keys() if op_id not in self.skipped_operations
@@ -578,9 +576,8 @@ class ReactiveExecutor(DependencyAwareExecutor):
         self._result_sink = send
 
         initial = [n for n in self.graph.internal_nodes.values() if isinstance(n, Operation)]
-        observer = getattr(self.session, "observer", None)
-        if observer is not None:
-            self.session.observe(self.spawn_type, self._on_bus_spawn)
+        observer = self.session.observer
+        self.session.observe(self.spawn_type, self._on_bus_spawn)
         self._running = True
 
         async def _driver():
@@ -613,8 +610,7 @@ class ReactiveExecutor(DependencyAwareExecutor):
             self._running = False
             self._tg = None
             self._result_sink = None
-            if observer is not None:
-                observer.unobserve(self._on_bus_spawn)
+            observer.unobserve(self._on_bus_spawn)
             if not driver.done():  # early break / consumer close: tear down
                 driver.cancel()
                 with contextlib.suppress(asyncio.CancelledError, Exception):

--- a/tests/integration/test_orchestration_integration.py
+++ b/tests/integration/test_orchestration_integration.py
@@ -217,34 +217,50 @@ def test_branch_gets_hooks_when_added_after_bus_init():
     assert b2._hooks is bus
 
 
-# ── Test 7: executor uses _observer private attr, not .observer property ──────
+# ── Test 7: both execute() and execute_stream() use the public observer property ──
 
 
-def test_reactive_executor_uses_private_observer_attr():
-    """ReactiveExecutor.execute() must use getattr(session, '_observer', None), not session.observer."""
-    source = inspect.getsource(
+def test_reactive_executor_uses_public_observer_property():
+    """ReactiveExecutor.execute() must use session.observer (public property), not _observer.
+
+    The private _observer PrivateAttr is None until first accessed; relying on
+    it in execute() would silently drop reactive spawns when the observer hasn't
+    been pre-initialised. Both execute() and execute_stream() must use the
+    lazy-init public property instead.
+    """
+    source_execute = inspect.getsource(
         __import__(
             "lionagi.operations.flow", fromlist=["ReactiveExecutor"]
         ).ReactiveExecutor.execute
     )
-
-    # Must use the private attribute access pattern
-    assert '"_observer"' in source or "'_observer'" in source, (
-        "ReactiveExecutor.execute() must access session._observer via getattr "
-        "(the private PrivateAttr), not session.observer (the lazy property)"
+    source_stream = inspect.getsource(
+        __import__(
+            "lionagi.operations.flow", fromlist=["ReactiveExecutor"]
+        ).ReactiveExecutor.execute_stream
     )
 
-    # Must NOT call the property directly (self.session.observer without getattr)
-    # Allow 'self.session.observer' only in comments, not as a bare attribute access
-    non_comment_lines = [
-        (i + 1, line)
-        for i, line in enumerate(source.splitlines())
-        if "session.observer" in line and not line.strip().startswith("#") and "getattr" not in line
-    ]
-    assert not non_comment_lines, (
-        f"ReactiveExecutor.execute() must not call session.observer (lazy property). "
-        f"Found bare access at lines: {non_comment_lines}"
-    )
+    for method_name, source in (("execute", source_execute), ("execute_stream", source_stream)):
+        # Must NOT access the private _observer attribute via getattr
+        private_lines = [
+            (i + 1, line)
+            for i, line in enumerate(source.splitlines())
+            if '"_observer"' in line or "'_observer'" in line
+        ]
+        assert not private_lines, (
+            f"ReactiveExecutor.{method_name}() must not access session._observer "
+            f"(private PrivateAttr). Found at lines: {private_lines}"
+        )
+
+        # Must use the public property (self.session.observer)
+        public_lines = [
+            line
+            for line in source.splitlines()
+            if "session.observer" in line and not line.strip().startswith("#")
+        ]
+        assert public_lines, (
+            f"ReactiveExecutor.{method_name}() must access session.observer "
+            f"(public lazy-init property) to ensure the observer is always initialised"
+        )
 
 
 # ── Test 8: _wait_for_dependencies reads aggregation_sources from metadata ────

--- a/tests/operations/test_reactive_flow.py
+++ b/tests/operations/test_reactive_flow.py
@@ -199,3 +199,88 @@ async def test_no_spawn_behaves_like_normal_flow():
     assert ran == ["plain"]
     assert result["spawned_operations"] == 0
     assert len(result["completed_operations"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Regression: execute() must subscribe via the public observer property
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_subscribes_via_public_observer_not_private():
+    """ReactiveExecutor.execute() must reach the bus via session.observer (public property).
+
+    Strategy: after normal session construction (which initialises _observer via
+    the model_validator), we forcibly clear _observer back to None to simulate
+    the scenario where the private attr is uninitialised.  If execute() still
+    used getattr(session, '_observer', None) it would see None and skip
+    subscribing, causing SpawnRequests to be silently dropped.  With the fix,
+    execute() calls session.observer (the property) which re-creates the
+    observer and the spawn is received.
+    """
+    executed: list[str] = []
+
+    async def spawner(**kw):
+        executed.append("spawner")
+        return SpawnRequest(instruction="follow-up", independent=True)
+
+    async def follow_up(**kw):
+        executed.append("follow_up")
+        return "done"
+
+    session = _session_with_ops(spawner=spawner, follow_up=follow_up)
+
+    # Forcibly clear the private attr to simulate the fragile pre-fix state.
+    # After this, getattr(session, '_observer', None) returns None,
+    # but session.observer (the property) will lazily recreate it.
+    session._observer = None
+
+    def node_builder(req: SpawnRequest, emitter: Operation) -> Operation:
+        return create_operation("follow_up", parameters={})
+
+    builder = OperationGraphBuilder()
+    builder.add_operation("spawner")
+    graph = builder.get_graph()
+
+    result = await flow(session, graph, reactive=True, node_builder=node_builder)
+
+    # Without the fix, follow_up would never be scheduled (spawn silently dropped).
+    assert "follow_up" in executed, (
+        "follow_up did not run — execute() did not subscribe via the public observer property"
+    )
+    assert result["spawned_operations"] == 1
+
+
+@pytest.mark.asyncio
+async def test_execute_stream_subscribes_via_public_observer_not_private():
+    """flow_stream() must also subscribe via session.observer when _observer is None."""
+    from lionagi.operations import flow_stream
+
+    executed: list[str] = []
+
+    async def spawner(**kw):
+        executed.append("spawner")
+        return SpawnRequest(instruction="follow-up", independent=True)
+
+    async def follow_up(**kw):
+        executed.append("follow_up")
+        return "done"
+
+    session = _session_with_ops(spawner=spawner, follow_up=follow_up)
+    session._observer = None  # simulate uninitialised private attr
+
+    def node_builder(req: SpawnRequest, emitter: Operation) -> Operation:
+        return create_operation("follow_up", parameters={})
+
+    builder = OperationGraphBuilder()
+    builder.add_operation("spawner")
+    graph = builder.get_graph()
+
+    events = []
+    async for event in flow_stream(session, graph, node_builder=node_builder):
+        events.append(event)
+
+    assert "follow_up" in executed, (
+        "follow_up did not run — execute_stream() did not subscribe via the public observer property"
+    )
+    assert any(e.spawned for e in events)

--- a/tests/session/test_lifecycle_signals.py
+++ b/tests/session/test_lifecycle_signals.py
@@ -403,57 +403,59 @@ async def test_skipped_node_projects_to_failed_lane():
 
 
 @pytest.mark.asyncio
-async def test_execute_stream_uses_public_observer_property(monkeypatch):
-    """execute_stream subscribes spawn handling via the public 'observer' property.
+async def test_execute_stream_subscribes_spawn_via_public_observer(monkeypatch):
+    """execute_stream receives SpawnRequests even when _observer was None before run.
 
-    The public property is a lazy-init that always returns a SessionObserver.
-    Using the private _observer attribute would return None when the session
-    was created without prior observer access, silently dropping reactive
-    spawns. This test pins that the subscription goes through the public path.
+    The public observer property is a lazy-init that always returns a SessionObserver.
+    If execute_stream used the private _observer attribute it would return None when
+    the session was built without prior observer access, silently dropping reactive
+    spawns. This test verifies the spawn is received via a behavioral check.
     """
-    from lionagi.operations.flow import ReactiveExecutor
-    from lionagi.protocols.graph.graph import Graph
+    from lionagi.casts.emission import SpawnRequest
+    from lionagi.operations import flow_stream
+    from lionagi.operations.builder import OperationGraphBuilder
+    from lionagi.operations.node import Operation, create_operation
+    from lionagi.session.branch import Branch
     from lionagi.session.session import Session
 
-    observer_accesses: list[str] = []
-    original_getattr = getattr
+    executed: list[str] = []
 
-    real_session = Session()
+    async def spawner(**kw):
+        executed.append("spawner")
+        return SpawnRequest(instruction="follow-up", independent=True)
 
-    def tracking_getattr(obj, name, *args):
-        if obj is real_session and name in ("observer", "_observer"):
-            observer_accesses.append(name)
-        return original_getattr(obj, name, *args)
+    async def follow_up(**kw):
+        executed.append("follow_up")
+        return "done"
 
-    monkeypatch.setattr("builtins.getattr", tracking_getattr)
+    session = Session()
+    branch = Branch(name="root")
+    session.include_branches(branch)
+    session.default_branch = branch
+    session.register_operation("spawner", spawner)
+    session.register_operation("follow_up", follow_up)
 
-    from lionagi.operations.node import Operation
+    # Forcibly clear _observer to simulate an uninitialised private attr.
+    # getattr(session, '_observer', None) would return None here; but
+    # session.observer (the property) lazily recreates it — the correct path.
+    session._observer = None
 
-    async def noop(**kw):
-        return None
+    def node_builder(req: SpawnRequest, emitter: Operation) -> Operation:
+        return create_operation("follow_up", parameters={})
 
-    real_session.register_operation("noop", noop)
-    from lionagi.session.branch import Branch
-
-    b = Branch(name="b")
-    real_session.include_branches(b)
-    real_session.default_branch = b
-
-    op = Operation(operation="noop", parameters={})
-    g = Graph()
-    g.add_node(op)
+    builder = OperationGraphBuilder()
+    builder.add_operation("spawner")
+    graph = builder.get_graph()
 
     events = []
-    async for ev in real_session.flow_stream(g):
+    async for ev in flow_stream(session, graph, node_builder=node_builder):
         events.append(ev)
 
-    assert "observer" in observer_accesses, (
-        "execute_stream must access session.observer (public property), "
-        f"not session._observer — accesses seen: {observer_accesses}"
+    assert "follow_up" in executed, (
+        "execute_stream did not receive the SpawnRequest — "
+        "it may have fallen back to _observer (None) instead of the public property"
     )
-    assert "_observer" not in observer_accesses or "observer" in observer_accesses, (
-        "execute_stream fell back to _observer instead of public observer property"
-    )
+    assert any(e.spawned for e in events)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Part 1 (the landmine):** `ReactiveExecutor.execute()` was using `getattr(self.session, "_observer", None)` (the raw PrivateAttr) to decide whether to subscribe to the bus. If `_observer` was None at call time, it silently skipped subscribing — meaning all `SpawnRequest` emissions in the batch path would be dropped with no error. Changed both `execute()` and `execute_stream()` to use `self.session.observer` (the public lazy-init property) directly, which always returns a live `SessionObserver`. The redundant `if observer is not None` guards are removed since the property never returns None.

- **Part 2 (node-signal name flicker):** Deferred. `NodeQueued.name` uses `reference_id` while `NodeStarted/Completed/Failed.name` uses the branch name — these strings are consumed by the CLI heartbeat display and changing the semantics risks breaking downstream consumers. The inconsistency is documented here for a follow-up.

## Why it was accidentally safe before

`Session`'s `model_validator` calls `include_branches()`, which touches `self.observer`, so `_observer` is populated on every `Session()`. The bug was latent — one internal change to `Session.__init__` would have activated it silently.

## Test changes

- `tests/operations/test_reactive_flow.py`: two new regression tests that forcibly set `session._observer = None` after construction, then verify spawns still propagate through both `flow()` (batch) and `flow_stream()`.
- `tests/integration/test_orchestration_integration.py`: replaced `test_reactive_executor_uses_private_observer_attr` (which **asserted the buggy behavior**) with `test_reactive_executor_uses_public_observer_property` (asserts neither method contains `_observer` string access, both contain `session.observer`).
- `tests/session/test_lifecycle_signals.py`: replaced the `builtins.getattr` monkeypatch approach (which stopped working once we switched from `getattr(obj, "observer")` to direct attribute access) with a behavioral test mirroring the new regression tests.

## Test output

```
454 passed, 25 skipped in 10.76s
```

Ruff check: `All checks passed!` · Ruff format: `4 files already formatted`

Closes #1398