### PR TITLE
fix(tests): stop subprocess-timeout mocks from leaking busy-spin drain threads

### DIFF
--- a/tests/tools/test_bash.py
+++ b/tests/tools/test_bash.py
@@ -318,6 +318,10 @@ async def test_bash_tool_timeout_mock_pid_calls_kill_not_killpg(monkeypatch):
     # Set pid to a MagicMock object — isinstance(pid, int) returns False,
     # so the guard routes to proc.kill() instead of os.killpg().
     mock_proc.pid = MagicMock()
+    # EOF on read() so _subprocess_sync's drain threads exit instead of
+    # busy-spinning forever on a bare-mock stream (saturates CPU on CI).
+    mock_proc.stdout.read.return_value = b""
+    mock_proc.stderr.read.return_value = b""
     mock_proc.wait.side_effect = [subprocess.TimeoutExpired("cmd", 0.01), None]
     mock_proc.kill = MagicMock()
 
@@ -353,6 +357,10 @@ async def test_bash_tool_timeout_invalid_pid_calls_kill_not_killpg(monkeypatch, 
 
     mock_proc = MagicMock()
     mock_proc.pid = invalid_pid
+    # EOF on read() so _subprocess_sync's drain threads exit instead of
+    # busy-spinning forever on a bare-mock stream (saturates CPU on CI).
+    mock_proc.stdout.read.return_value = b""
+    mock_proc.stderr.read.return_value = b""
     mock_proc.wait.side_effect = [subprocess.TimeoutExpired("cmd", 0.01), None]
     mock_proc.kill = MagicMock()
 

--- a/tests/tools/test_coding_coverage.py
+++ b/tests/tools/test_coding_coverage.py
@@ -295,6 +295,10 @@ def test_subprocess_sync_timeout_mock_pid_calls_kill_not_killpg(monkeypatch):
     # Set pid to a MagicMock object — isinstance(pid, int) returns False,
     # so the guard routes to proc.kill() instead of os.killpg().
     mock_proc.pid = MagicMock()
+    # EOF on read() so _subprocess_sync's drain threads exit instead of
+    # busy-spinning forever on a bare-mock stream (saturates CPU on CI).
+    mock_proc.stdout.read.return_value = b""
+    mock_proc.stderr.read.return_value = b""
     # First wait() raises TimeoutExpired; second wait() (after kill) returns normally
     mock_proc.wait.side_effect = [subprocess.TimeoutExpired("cmd", 0.01), None]
     mock_proc.kill = MagicMock()
@@ -318,6 +322,10 @@ def test_subprocess_sync_timeout_invalid_pid_calls_kill_not_killpg(invalid_pid):
 
     mock_proc = MagicMock()
     mock_proc.pid = invalid_pid
+    # EOF on read() so _subprocess_sync's drain threads exit instead of
+    # busy-spinning forever on a bare-mock stream (saturates CPU on CI).
+    mock_proc.stdout.read.return_value = b""
+    mock_proc.stderr.read.return_value = b""
     mock_proc.wait.side_effect = [subprocess.TimeoutExpired("cmd", 0.01), None]
     mock_proc.kill = MagicMock()
 


### PR DESCRIPTION
## Problem

The 3.14 CI leg has been failing (and `main` intermittently) with `The runner has received a shutdown signal` partway through the test run — no test name, no traceback. It reads like a spot-instance reclaim, but it's deterministic on 3.14 and a real bug.

## Root cause (pre-existing, from #1059)

The `os.killpg` guard tests added in #1059 mock `subprocess.Popen` but leave `proc.stdout`/`proc.stderr` as bare `MagicMock`s:

```python
mock_proc = MagicMock()
mock_proc.pid = invalid_pid
mock_proc.wait.side_effect = [TimeoutExpired(...), None]
```

`_subprocess_sync` spawns daemon **drain threads** on those streams. `_drain` busy-spins forever on a mock stream:

- `stream.read(8192)` returns a truthy `MagicMock` (never `b""`), so `if not chunk: break` never fires;
- `buf.extend(chunk[:remaining])` iterates the mock as **empty**, so the buffer never grows and the loop never terminates.

Each affected test leaks **two daemon threads pinning a core**, plus blocks ~2s on `join(timeout=1)` twice (these tests showed up at 2–6s each).

- **macOS (many cores):** absorbed — suite passes, leaked spinners go unnoticed.
- **Linux CI (few cores):** the accumulating spinners saturate every core. The suite crawls to a near-stall around two-thirds through, then the runner watchdog reclaims the VM → "shutdown signal". Deterministic on 3.14, intermittent on `main`.

## Fix

Give the mock streams a realistic EOF (`read()` → `b""`) so the drain threads exit immediately. No production change — real pipes already return `b""` at EOF; only the unrealistic mocks were affected.

## Verification

- Affected subprocess-timeout tests drop from 2–6s each to ~0s; thread leak gone.
- **Full suite green on Linux 3.14 in a `bookworm` container** (`ghcr.io/astral-sh/uv:python3.14-bookworm`). Before the fix, a worker crashed mid-run on `test_subprocess_sync_timeout_invalid_pid_calls_kill_not_killpg[True]`; after, 9468 passed (only container-environment failures: Node.js/git absent in the slim image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)