### PR TITLE
fix(cli): stop `li agent` hanging on exit (reuse owned StateDB in lifecycle hooks)

### DIFF
--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -415,6 +415,11 @@ async def teardown_persist(
             await db.close()
         except Exception as exc:
             _log.warning("live persist db.close failed: %s", exc, exc_info=True)
+        # Sweep the shared-db registry (our connection plus any stray a hook
+        # opened) so no non-daemon aiosqlite worker thread blocks process exit.
+        from lionagi.state.db import close_shared_db
+
+        await close_shared_db()
 
 
 # Keep old names as aliases so callers don't break.
@@ -442,6 +447,12 @@ async def setup_agent_persist(
     try:
         db = StateDB()
         await db.open()
+        # Lifecycle hooks (SESSION_START/END, BRANCH_CREATE) reach a db via
+        # get_shared_db(); register ours so they reuse this owned connection
+        # rather than opening a second one whose aiosqlite worker thread leaks.
+        from lionagi.state.db import register_shared_db
+
+        register_shared_db(db)
 
         session = Session(name="agent", default_branch=branch)
         session_id = str(session.id)

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -452,7 +452,7 @@ async def setup_agent_persist(
         # rather than opening a second one whose aiosqlite worker thread leaks.
         from lionagi.state.db import register_shared_db
 
-        register_shared_db(db)
+        await register_shared_db(db)
 
         session = Session(name="agent", default_branch=branch)
         session_id = str(session.id)
@@ -618,4 +618,8 @@ async def setup_agent_persist(
                 await db.close()
             except Exception as close_exc:
                 _log.warning("fallback db.close after setup failure also failed: %s", close_exc)
+            # Drop the now-closed handle so get_shared_db() can't hand it out.
+            from lionagi.state.db import unregister_shared_db
+
+            unregister_shared_db(db)
         return None

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -596,12 +596,15 @@ async def setup_orchestration_persist(
     project: str | None = None,
     branches: list[Any] | None = None,
 ) -> dict | None:
-    from lionagi.state.db import StateDB
+    from lionagi.state.db import StateDB, register_shared_db
 
     db = None
     try:
         db = StateDB()
         await db.open()
+        # Lifecycle hooks reuse this owned connection via get_shared_db()
+        # instead of opening a second, never-closed one (see _runs.py).
+        register_shared_db(db)
 
         session_id = str(session.id)
         session_dict = session.to_dict(mode="db")

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -604,7 +604,7 @@ async def setup_orchestration_persist(
         await db.open()
         # Lifecycle hooks reuse this owned connection via get_shared_db()
         # instead of opening a second, never-closed one (see _runs.py).
-        register_shared_db(db)
+        await register_shared_db(db)
 
         session_id = str(session.id)
         session_dict = session.to_dict(mode="db")
@@ -676,6 +676,10 @@ async def setup_orchestration_persist(
                 _log_orch.warning(
                     "fallback db.close after setup failure also failed: %s", close_exc
                 )
+            # Drop the now-closed handle so get_shared_db() can't hand it out.
+            from lionagi.state.db import unregister_shared_db
+
+            unregister_shared_db(db)
         return None
 
 

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -2346,3 +2346,21 @@ async def get_shared_db(path: str | Path | None = None) -> StateDB:
             await db.open()
             _SHARED[resolved] = db
     return _SHARED[resolved]
+
+
+def register_shared_db(db: StateDB) -> None:
+    """Adopt a caller-owned StateDB as the shared instance so hooks reuse it."""
+    _SHARED[db.path] = db
+
+
+async def close_shared_db() -> None:
+    """Close and forget every shared StateDB (frees its aiosqlite worker thread)."""
+    global _SHARED_OPEN_LOCK  # noqa: PLW0603
+    import contextlib
+
+    instances = list(_SHARED.values())
+    _SHARED.clear()
+    _SHARED_OPEN_LOCK = None
+    for db in instances:
+        with contextlib.suppress(Exception):
+            await db.close()

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -2348,9 +2348,25 @@ async def get_shared_db(path: str | Path | None = None) -> StateDB:
     return _SHARED[resolved]
 
 
-def register_shared_db(db: StateDB) -> None:
-    """Adopt a caller-owned StateDB as the shared instance so hooks reuse it."""
-    _SHARED[db.path] = db
+async def register_shared_db(db: StateDB) -> None:
+    """Adopt a caller-owned StateDB as the shared instance, closing any prior one for its path."""
+    global _SHARED_OPEN_LOCK  # noqa: PLW0603
+    import contextlib
+
+    if _SHARED_OPEN_LOCK is None:
+        _SHARED_OPEN_LOCK = Lock()
+    async with _SHARED_OPEN_LOCK:
+        existing = _SHARED.get(db.path)
+        if existing is not None and existing is not db:
+            with contextlib.suppress(Exception):
+                await existing.close()
+        _SHARED[db.path] = db
+
+
+def unregister_shared_db(db: StateDB) -> None:
+    """Drop *db* from the shared registry iff it is the registered instance."""
+    if _SHARED.get(db.path) is db:
+        del _SHARED[db.path]
 
 
 async def close_shared_db() -> None:

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -2329,6 +2329,13 @@ _SHARED: dict[Path, StateDB] = {}
 # Guards the lazy-open window; created on first async call (anyio.Lock
 # must be instantiated inside an active backend task context).
 _SHARED_OPEN_LOCK: Lock | None = None
+# Bumped by every close_shared_db() sweep so a get_shared_db()/register_shared_db()
+# that waited on a now-abandoned lock can detect it raced a teardown.
+_SHARED_CLOSE_GEN: int = 0
+_SHARED_TEARDOWN_RACE = (
+    "shared StateDB was torn down while this call was pending; quiesce "
+    "get_shared_db()/register_shared_db() callers before close_shared_db()"
+)
 
 
 async def get_shared_db(path: str | Path | None = None) -> StateDB:
@@ -2339,7 +2346,13 @@ async def get_shared_db(path: str | Path | None = None) -> StateDB:
         return _SHARED[resolved]
     if _SHARED_OPEN_LOCK is None:
         _SHARED_OPEN_LOCK = Lock()
-    async with _SHARED_OPEN_LOCK:
+    lock = _SHARED_OPEN_LOCK
+    gen = _SHARED_CLOSE_GEN
+    async with lock:
+        # A close_shared_db() swept the registry while we waited on this lock;
+        # refuse to resurrect the singleton rather than leak a fresh worker.
+        if _SHARED_CLOSE_GEN != gen:
+            raise RuntimeError(_SHARED_TEARDOWN_RACE)
         # Double-checked: another coroutine may have opened it while we waited.
         if resolved not in _SHARED:
             db = StateDB(resolved)
@@ -2355,7 +2368,11 @@ async def register_shared_db(db: StateDB) -> None:
 
     if _SHARED_OPEN_LOCK is None:
         _SHARED_OPEN_LOCK = Lock()
-    async with _SHARED_OPEN_LOCK:
+    lock = _SHARED_OPEN_LOCK
+    gen = _SHARED_CLOSE_GEN
+    async with lock:
+        if _SHARED_CLOSE_GEN != gen:
+            raise RuntimeError(_SHARED_TEARDOWN_RACE)
         existing = _SHARED.get(db.path)
         if existing is not None and existing is not db:
             with contextlib.suppress(Exception):
@@ -2370,8 +2387,8 @@ def unregister_shared_db(db: StateDB) -> None:
 
 
 async def close_shared_db() -> None:
-    """Close and forget every shared StateDB (frees its aiosqlite worker thread)."""
-    global _SHARED_OPEN_LOCK  # noqa: PLW0603
+    """Close and forget every shared StateDB; callers must quiesce get_shared_db() first."""
+    global _SHARED_OPEN_LOCK, _SHARED_CLOSE_GEN  # noqa: PLW0603
     import contextlib
 
     lock = _SHARED_OPEN_LOCK
@@ -2379,17 +2396,20 @@ async def close_shared_db() -> None:
         # No open ever happened in this loop (opens create the lock first).
         instances = list(_SHARED.values())
         _SHARED.clear()
+        _SHARED_CLOSE_GEN += 1
         for db in instances:
             with contextlib.suppress(Exception):
                 await db.close()
         return
     # Hold the open lock so an in-flight get_shared_db()/register_shared_db()
-    # cannot repopulate _SHARED after the sweep; null it last so a later event
-    # loop lazily recreates a fresh lock.
+    # cannot repopulate _SHARED after the sweep; bump the generation and null
+    # the lock last so a waiter that raced this close refuses to resurrect it
+    # and a later event loop lazily recreates a fresh lock.
     async with lock:
         instances = list(_SHARED.values())
         _SHARED.clear()
         for db in instances:
             with contextlib.suppress(Exception):
                 await db.close()
+        _SHARED_CLOSE_GEN += 1
         _SHARED_OPEN_LOCK = None

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -2374,9 +2374,22 @@ async def close_shared_db() -> None:
     global _SHARED_OPEN_LOCK  # noqa: PLW0603
     import contextlib
 
-    instances = list(_SHARED.values())
-    _SHARED.clear()
-    _SHARED_OPEN_LOCK = None
-    for db in instances:
-        with contextlib.suppress(Exception):
-            await db.close()
+    lock = _SHARED_OPEN_LOCK
+    if lock is None:
+        # No open ever happened in this loop (opens create the lock first).
+        instances = list(_SHARED.values())
+        _SHARED.clear()
+        for db in instances:
+            with contextlib.suppress(Exception):
+                await db.close()
+        return
+    # Hold the open lock so an in-flight get_shared_db()/register_shared_db()
+    # cannot repopulate _SHARED after the sweep; null it last so a later event
+    # loop lazily recreates a fresh lock.
+    async with lock:
+        instances = list(_SHARED.values())
+        _SHARED.clear()
+        for db in instances:
+            with contextlib.suppress(Exception):
+                await db.close()
+        _SHARED_OPEN_LOCK = None

--- a/tests/cli/test_agent_live_persist.py
+++ b/tests/cli/test_agent_live_persist.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 import threading
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -283,6 +284,44 @@ async def test_close_shared_db_sweeps_inflight_open(
     assert _aiosqlite_thread_count() == before, (
         "in-flight-opened aiosqlite worker leaked past close_shared_db()"
     )
+
+
+async def test_close_shared_db_rejects_stale_waiter(temp_db_path: Path):
+    """A get_shared_db() that waited on a lock a concurrent close swept must refuse to
+    resurrect the singleton (raise), not open a fresh worker that survives teardown."""
+    from lionagi.state.db import _SHARED, close_shared_db, get_shared_db
+
+    before = _aiosqlite_thread_count()
+    await get_shared_db(temp_db_path)  # give the sweep something to slow-close
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    real_close = StateDB.close
+
+    async def slow_close(self):
+        entered.set()  # close now holds the open lock, mid-sweep
+        await release.wait()
+        await real_close(self)
+
+    with mock.patch.object(StateDB, "close", slow_close):
+        closer = asyncio.create_task(close_shared_db())
+        await asyncio.wait_for(entered.wait(), timeout=5)
+
+        getter = asyncio.create_task(get_shared_db(temp_db_path))
+        await asyncio.sleep(0.1)
+        assert not getter.done(), "getter should block on the lock the close holds"
+
+        release.set()
+        await asyncio.wait_for(closer, timeout=5)
+        with pytest.raises(RuntimeError):
+            await asyncio.wait_for(getter, timeout=5)
+
+    assert temp_db_path not in _SHARED
+    for _ in range(20):
+        if _aiosqlite_thread_count() == before:
+            break
+        await asyncio.sleep(0.05)
+    assert _aiosqlite_thread_count() == before, "stale-waiter open leaked an aiosqlite worker"
 
 
 # ── Resume path ───────────────────────────────────────────────────────────────

--- a/tests/cli/test_agent_live_persist.py
+++ b/tests/cli/test_agent_live_persist.py
@@ -244,6 +244,47 @@ async def test_register_shared_db_closes_displaced_instance(temp_db_path: Path):
     assert _aiosqlite_thread_count() == before
 
 
+async def test_close_shared_db_sweeps_inflight_open(
+    temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """close_shared_db() must serialize with an in-flight get_shared_db() open so the
+    just-opened connection is swept, not orphaned past teardown."""
+    from lionagi.state.db import _SHARED, close_shared_db, get_shared_db
+
+    before = _aiosqlite_thread_count()
+    opened = asyncio.Event()
+    release = asyncio.Event()
+    real_open = StateDB.open
+
+    async def slow_open(self):
+        await real_open(self)  # real aiosqlite worker spawned
+        opened.set()  # get_shared_db holds the open lock; db open, not yet stored
+        await release.wait()
+
+    monkeypatch.setattr(StateDB, "open", slow_open)
+
+    opener = asyncio.create_task(get_shared_db(temp_db_path))
+    await asyncio.wait_for(opened.wait(), timeout=5)
+
+    closer = asyncio.create_task(close_shared_db())
+    await asyncio.sleep(0.1)
+    assert not closer.done(), "close_shared_db() did not wait for the in-flight open"
+
+    release.set()
+    opened_db = await asyncio.wait_for(opener, timeout=5)
+    await asyncio.wait_for(closer, timeout=5)
+
+    assert temp_db_path not in _SHARED
+    assert opened_db._db is None, "in-flight-opened StateDB survived close_shared_db()"
+    for _ in range(20):
+        if _aiosqlite_thread_count() == before:
+            break
+        await asyncio.sleep(0.05)
+    assert _aiosqlite_thread_count() == before, (
+        "in-flight-opened aiosqlite worker leaked past close_shared_db()"
+    )
+
+
 # ── Resume path ───────────────────────────────────────────────────────────────
 
 

--- a/tests/cli/test_agent_live_persist.py
+++ b/tests/cli/test_agent_live_persist.py
@@ -164,6 +164,38 @@ async def test_setup_create_session_failure_closes_db(
     monkeypatch.setattr(StateDB, "create_session", original_create)
 
 
+# ── Shared-db reuse + teardown cleanup (lifecycle-hook leak guard) ────────────
+
+
+async def test_lifecycle_hooks_reuse_owned_db_no_shared_leak(temp_db_path: Path):
+    """SESSION_START/BRANCH_CREATE hooks reuse the owned connection, and teardown
+    leaves no shared StateDB whose non-daemon aiosqlite worker would block exit."""
+    from lionagi.state.db import _SHARED, get_shared_db
+
+    before = _aiosqlite_thread_count()
+    branch = Branch(name="b1")
+
+    ctx = await _setup_live_persist(branch, agent_name="reviewer")
+    assert ctx is not None
+
+    # The lifecycle hooks reach the db via get_shared_db(); setup registered the
+    # owned connection, so they reuse it instead of opening a second one.
+    assert await get_shared_db() is ctx["db"]
+    assert _SHARED.get(ctx["db"].path) is ctx["db"]
+
+    await _teardown_live_persist(ctx, status="completed")
+
+    # Registry swept — nothing left to leak its aiosqlite worker thread.
+    assert ctx["db"].path not in _SHARED
+    for _ in range(20):
+        if _aiosqlite_thread_count() == before:
+            break
+        await asyncio.sleep(0.05)
+    assert _aiosqlite_thread_count() == before, (
+        "shared StateDB survived teardown — aiosqlite worker thread leaked"
+    )
+
+
 # ── Resume path ───────────────────────────────────────────────────────────────
 
 

--- a/tests/cli/test_agent_live_persist.py
+++ b/tests/cli/test_agent_live_persist.py
@@ -28,12 +28,19 @@ def temp_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 
 def _aiosqlite_thread_count() -> int:
-    """Number of live threads whose name starts with 'sqlite_'.
+    """Live aiosqlite connection-worker threads — a leaked connection shows up here.
 
-    aiosqlite spawns a worker per connection with names like
-    ``sqlite_/path/to/db``. A leaked connection shows up here.
+    Matched by the worker's run target ``_connection_worker_thread`` (stable across
+    aiosqlite versions; current builds surface it in the auto thread name, and the
+    ``_target`` qualname is the fallback) plus the legacy ``sqlite_<path>`` name prefix.
     """
-    return sum(1 for t in threading.enumerate() if t.name.startswith("sqlite"))
+    return sum(
+        1
+        for t in threading.enumerate()
+        if "_connection_worker_thread" in t.name
+        or t.name.startswith("sqlite")
+        or getattr(getattr(t, "_target", None), "__name__", "") == "_connection_worker_thread"
+    )
 
 
 # ── _setup_live_persist: happy path + invariants ──────────────────────────────
@@ -194,6 +201,47 @@ async def test_lifecycle_hooks_reuse_owned_db_no_shared_leak(temp_db_path: Path)
     assert _aiosqlite_thread_count() == before, (
         "shared StateDB survived teardown — aiosqlite worker thread leaked"
     )
+
+
+async def test_register_shared_db_closes_displaced_instance(temp_db_path: Path):
+    """Re-registering a path must close the prior instance, not orphan its worker thread."""
+    from lionagi.state.db import (
+        _SHARED,
+        close_shared_db,
+        register_shared_db,
+        unregister_shared_db,
+    )
+
+    before = _aiosqlite_thread_count()
+    db1 = StateDB(temp_db_path)
+    await db1.open()
+    await register_shared_db(db1)
+
+    db2 = StateDB(temp_db_path)
+    await db2.open()
+    await register_shared_db(db2)  # displaces db1 → must close it
+
+    assert _SHARED.get(temp_db_path) is db2
+    assert db1._db is None, "displaced StateDB was orphaned instead of closed"
+    for _ in range(20):
+        if _aiosqlite_thread_count() == before + 1:
+            break
+        await asyncio.sleep(0.05)
+    assert _aiosqlite_thread_count() == before + 1, (
+        "displaced connection's aiosqlite worker thread leaked"
+    )
+
+    # unregister is identity-guarded: dropping a stale handle must not evict the live one.
+    unregister_shared_db(db1)
+    assert _SHARED.get(temp_db_path) is db2
+
+    await close_shared_db()
+    await db2.close()
+    for _ in range(20):
+        if _aiosqlite_thread_count() == before:
+            break
+        await asyncio.sleep(0.05)
+    assert _aiosqlite_thread_count() == before
 
 
 # ── Resume path ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`li agent codex/...` (and any `li agent` run) prints its final response — `Codex Session complete` — then **never exits**. `^C` shows the main thread parked in `threading._shutdown()` → `lock.acquire()`, joining a non-daemon thread forever.

Root cause, confirmed via `PYTHONFAULTHANDLER=1` + `kill -ABRT`: the stuck thread is aiosqlite's `_connection_worker_thread`. The lifecycle hooks (`persist_session_start` / `persist_branch_provenance` / `persist_session_end`) reach a DB through `get_shared_db()` — a **process-wide `StateDB` that nothing ever closes**. aiosqlite backs each connection with a non-daemon worker thread, so the open shared connection blocks interpreter shutdown.

Two-PR interaction (matches the "a previous PR broke it" report):
- **#1520** introduced `get_shared_db()` — the never-closed shared connection (latent).
- **#1524** wired the SESSION_START / BRANCH_CREATE emissions that actually *fire* those hooks on the agent path → the connection opens → the hang manifests.

## Fix

`setup_agent_persist` / `setup_orchestration_persist` already open a `StateDB` they own and that `teardown_persist` closes. Register that owned connection as the shared instance (`register_shared_db`) so the lifecycle hooks **reuse it** instead of opening a second, unmanaged connection. Add `close_shared_db()` and call it in `teardown_persist`'s `finally` as a backstop that sweeps any stray shared connection.

Net effect: one connection, owned and closed on the existing teardown path. No second aiosqlite thread to block exit.

## Why not daemon the thread?

aiosqlite exposes no `daemon=` knob and the worker thread can't be re-flagged after `start()`; daemoning would also skip the clean sqlite close on a *persistence* DB. Explicit close is free here because every write is awaited-to-completion, so the worker is idle at teardown.

## Verification

- **Empirical:** `PYTHONFAULTHANDLER=1 li agent codex/gpt-5.3-codex-spark "ping" --bypass -v` now exits `rc=0` in 16s (was: hang → `^C`).
- **Guard test** `test_lifecycle_hooks_reuse_owned_db_no_shared_leak`: drives setup → hook emission → teardown, asserts the hooks reuse the owned connection and no aiosqlite worker survives. Fails on pre-fix code, passes after.
- **Regression:** `tests/cli`, `tests/hooks`, `tests/state`, `tests/apps_studio_server`, `tests/orchestration`, `tests/cli/orchestrate` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)