### PR TITLE
feat(engines): worker safety — heartbeat, spec-lint, watchdog, turn-timeout (#1424 #1426 #1429 #1436)

### DIFF
--- a/lionagi/engines/coding.py
+++ b/lionagi/engines/coding.py
@@ -582,6 +582,8 @@ class CodingEngine(Engine):
 
         tests = await self._test(run, change, round_no=0)
         change, tests = await self._fix_loop(run, plan, change, tests)
+        if run._aborted:
+            return await self._conclude(run, plan, passed=False, caveat="stage aborted by watchdog")
         await self._verify(run, plan, change, tests)
         return await self._conclude(run, plan, passed=tests.passed)
 

--- a/lionagi/engines/coding.py
+++ b/lionagi/engines/coding.py
@@ -33,6 +33,7 @@ __all__ = (
     "TestsRan",
     "VerifyResult",
     "CodeResultRecorded",
+    "WorkAborted",
     "WorkerHeartbeat",
     "WorkerActivity",
     "CodingRun",
@@ -155,8 +156,16 @@ _REF_ATTRS = (
 
 
 # ---------------------------------------------------------------------------
-# Worker observability events (heartbeat + activity)
+# Worker observability events (abort + heartbeat + activity)
 # ---------------------------------------------------------------------------
+
+
+class WorkAborted(EngineEvent):
+    """Emitted when a stage is aborted by the stage watchdog."""
+
+    stage: str = Field(default="")
+    reason: str = Field(default="")
+    elapsed_s: float = Field(default=0.0)
 
 
 class WorkerHeartbeat(EngineEvent):
@@ -339,6 +348,7 @@ class CodingRun(ChainRun):
         # Paths newly changed/added since the baseline (populated by _run).
         self._ws_delta: list[str] = []
         self._spec_lint_warnings: list[str] = []
+        self._aborted: bool = False
 
     # -- typed overrides (narrower signatures than the Any base) ---------------
 
@@ -451,6 +461,7 @@ class CodingEngine(Engine):
         turn_timeout_s: float | None = 600.0,
         strict_spec: bool = False,
         heartbeat_interval_s: float | None = 30.0,
+        stage_timeout_s: float | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -465,6 +476,7 @@ class CodingEngine(Engine):
         self.turn_timeout_s = turn_timeout_s
         self.strict_spec = strict_spec
         self.heartbeat_interval_s = heartbeat_interval_s
+        self.stage_timeout_s = stage_timeout_s
 
     # -- lifecycle ------------------------------------------------------------
 
@@ -532,6 +544,8 @@ class CodingEngine(Engine):
         # implement check computes a delta, not an absolute status read.
         run._ws_baseline = await self._capture_ws_baseline(run)
         change = await self._implement(run, plan)
+        if run._aborted:
+            return await self._conclude(run, plan, passed=False, caveat="stage aborted by watchdog")
         if change is None:
             # Emission is metadata; the workspace delta is ground truth.  Three
             # outcomes after _implement returns None:
@@ -613,13 +627,14 @@ class CodingEngine(Engine):
             wrapped = self._wrap_turn_timeout(agent, run)
             heartbeat_task = self._start_heartbeat(run, stage="implement")
             try:
-                await run.operate_with_repair(
+                stage_coro = run.operate_with_repair(
                     wrapped,
                     _implement_instruction(plan, run.task_text, run.workspace),
                     arrived=lambda: len(run.events_of(ChangeProposed)) > before,
                     emits=emits,
                     retries=self.repair_retries,
                 )
+                await self._run_stage_with_watchdog(run, stage_coro, "implement")
             finally:
                 if heartbeat_task is not None and not heartbeat_task.done():
                     heartbeat_task.cancel()
@@ -666,13 +681,16 @@ class CodingEngine(Engine):
                 break
             before = len(run.events_of(ChangeProposed))
             async with run._sem:
-                await run.operate_with_repair(
+                stage_coro = run.operate_with_repair(
                     agent,
                     _fix_instruction(tests, plan, round_no, self.max_fix_rounds),
                     arrived=lambda n=before: len(run.events_of(ChangeProposed)) > n,
                     emits=(ChangeProposed,),
                     retries=self.repair_retries,
                 )
+                await self._run_stage_with_watchdog(run, stage_coro, f"fix-{round_no}")
+            if run._aborted:
+                break
             new_change = run.last(ChangeProposed)
             if new_change is change:
                 run.notify("fix_no_change", round=round_no)
@@ -821,6 +839,29 @@ class CodingEngine(Engine):
                     logger.debug("heartbeat mtime poll failed", exc_info=True)
 
         return asyncio.ensure_future(_loop())
+
+    async def _run_stage_with_watchdog(
+        self, run: CodingRun, stage_coro: Any, stage_name: str
+    ) -> None:
+        """Run *stage_coro* bounded by stage_timeout_s; on timeout emit WorkAborted and set run._aborted."""
+        if self.stage_timeout_s is None:
+            await stage_coro
+            return
+        t0 = monotonic()
+        try:
+            await asyncio.wait_for(stage_coro, timeout=self.stage_timeout_s)
+        except asyncio.TimeoutError:
+            elapsed = round(monotonic() - t0, 1)
+            reason = f"stage '{stage_name}' exceeded {self.stage_timeout_s}s wall-clock limit"
+            run.notify("WorkAborted", stage=stage_name, reason=reason, elapsed_s=elapsed)
+            run._aborted = True
+
+    async def _partial_export(
+        self, run: CodingRun, *args: Any, **kwargs: Any
+    ) -> CodeResultRecorded:  # type: ignore[override]
+        """Write results.json and report.md even when the run is aborted mid-stage."""
+        plan = run.last(WorkPlanned) or WorkPlanned(approach="(aborted)")
+        return await self._conclude(run, plan, passed=False, caveat="run aborted")
 
     # -- ground-truth helpers -------------------------------------------------
 

--- a/lionagi/engines/coding.py
+++ b/lionagi/engines/coding.py
@@ -6,12 +6,14 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
 import re
 import shlex
 from pathlib import Path
+from time import monotonic
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -31,6 +33,8 @@ __all__ = (
     "TestsRan",
     "VerifyResult",
     "CodeResultRecorded",
+    "WorkerHeartbeat",
+    "WorkerActivity",
     "CodingRun",
     "CodingEngine",
     "_lint_spec",
@@ -148,6 +152,25 @@ _REF_ATTRS = (
     "change_ref",
     "plan_ref",
 )
+
+
+# ---------------------------------------------------------------------------
+# Worker observability events (heartbeat + activity)
+# ---------------------------------------------------------------------------
+
+
+class WorkerHeartbeat(EngineEvent):
+    """Periodic liveness ping emitted while a stage is running."""
+
+    elapsed_s: float = Field(description="Seconds since the run started.")
+    stage: str = Field(default="implement")
+
+
+class WorkerActivity(EngineEvent):
+    """Emitted when a file in the workspace is written during a stage."""
+
+    path: str = Field(description="Workspace-relative path that changed.")
+    elapsed_s: float = Field(description="Seconds since the run started.")
 
 
 # ---------------------------------------------------------------------------
@@ -427,6 +450,7 @@ class CodingEngine(Engine):
         repair_retries: int = 1,
         turn_timeout_s: float | None = 600.0,
         strict_spec: bool = False,
+        heartbeat_interval_s: float | None = 30.0,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -440,6 +464,7 @@ class CodingEngine(Engine):
         self.repair_retries = repair_retries
         self.turn_timeout_s = turn_timeout_s
         self.strict_spec = strict_spec
+        self.heartbeat_interval_s = heartbeat_interval_s
 
     # -- lifecycle ------------------------------------------------------------
 
@@ -586,13 +611,20 @@ class CodingEngine(Engine):
                 emits=emits,
             )
             wrapped = self._wrap_turn_timeout(agent, run)
-            await run.operate_with_repair(
-                wrapped,
-                _implement_instruction(plan, run.task_text, run.workspace),
-                arrived=lambda: len(run.events_of(ChangeProposed)) > before,
-                emits=emits,
-                retries=self.repair_retries,
-            )
+            heartbeat_task = self._start_heartbeat(run, stage="implement")
+            try:
+                await run.operate_with_repair(
+                    wrapped,
+                    _implement_instruction(plan, run.task_text, run.workspace),
+                    arrived=lambda: len(run.events_of(ChangeProposed)) > before,
+                    emits=emits,
+                    retries=self.repair_retries,
+                )
+            finally:
+                if heartbeat_task is not None and not heartbeat_task.done():
+                    heartbeat_task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await heartbeat_task
         run._implementer = wrapped  # reused by the fix loop — same branch, more turns
         return run.last(ChangeProposed)
 
@@ -750,6 +782,45 @@ class CodingEngine(Engine):
                     return None  # operate_with_repair sees arrived()=False → fix path
 
         return _Proxy()
+
+    def _start_heartbeat(self, run: CodingRun, *, stage: str) -> asyncio.Task | None:
+        """Start a background task that emits WorkerHeartbeat at the configured interval.
+
+        Also emits WorkerActivity whenever a file in the workspace changes mtime.
+        Returns None when heartbeat_interval_s is None (disabled).
+        """
+        if self.heartbeat_interval_s is None:
+            return None
+        t0 = run._t0
+        ws = Path(run.workspace)
+        # Snapshot existing files so only NEW writes trigger WorkerActivity.
+        last_mtime: dict[str, float] = {}
+        try:
+            for p in ws.rglob("*"):
+                if p.is_file():
+                    last_mtime[str(p)] = p.stat().st_mtime
+        except Exception:
+            logger.debug("heartbeat baseline snapshot failed", exc_info=True)
+
+        async def _loop() -> None:
+            while True:
+                await asyncio.sleep(self.heartbeat_interval_s)
+                elapsed = round(monotonic() - t0, 1)
+                run.notify("WorkerHeartbeat", elapsed_s=elapsed, stage=stage)
+                try:
+                    for p in ws.rglob("*"):
+                        if p.is_file():
+                            key = str(p)
+                            mt = p.stat().st_mtime
+                            prev = last_mtime.get(key)
+                            if prev != mt:
+                                rel = str(p.relative_to(ws)) if p.is_relative_to(ws) else key
+                                run.notify("WorkerActivity", path=rel, elapsed_s=elapsed)
+                                last_mtime[key] = mt
+                except Exception:
+                    logger.debug("heartbeat mtime poll failed", exc_info=True)
+
+        return asyncio.ensure_future(_loop())
 
     # -- ground-truth helpers -------------------------------------------------
 

--- a/lionagi/engines/coding.py
+++ b/lionagi/engines/coding.py
@@ -9,6 +9,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import shlex
 from pathlib import Path
 from typing import Any
@@ -32,6 +33,7 @@ __all__ = (
     "CodeResultRecorded",
     "CodingRun",
     "CodingEngine",
+    "_lint_spec",
 )
 
 
@@ -146,6 +148,44 @@ _REF_ATTRS = (
     "change_ref",
     "plan_ref",
 )
+
+
+# ---------------------------------------------------------------------------
+# Spec lint
+# ---------------------------------------------------------------------------
+
+_RE_ACCEPTANCE = re.compile(r"acceptance.{0,20}criteria|acceptance:", re.IGNORECASE)
+_RE_TEST_CMD = re.compile(r"test_cmd\s*:", re.IGNORECASE)
+_RE_COUNT_ASSERT = re.compile(r"\d+\s*(test|case|item|assert|pass)", re.IGNORECASE)
+_RE_FILE_PATH = re.compile(r"(?:^|[\s(\"'])(/[\w/.\-]+\.[\w]+)", re.MULTILINE)
+
+
+def _lint_spec(
+    spec: str | dict[str, Any],
+    *,
+    workspace: str | Path | None = None,
+    strict: bool = False,
+) -> list[str]:
+    """Return a list of warning strings for common spec deficiencies.
+
+    Pass *strict=True* to raise ValueError on the first warning instead.
+    """
+    text = spec if isinstance(spec, str) else json.dumps(spec)
+    warnings: list[str] = []
+    if not _RE_ACCEPTANCE.search(text):
+        warnings.append("spec has no acceptance criteria — add an 'acceptance criteria:' section")
+    if _RE_TEST_CMD.search(text) and not _RE_COUNT_ASSERT.search(text):
+        warnings.append(
+            "spec has a test_cmd but no count assertion (e.g. '3 tests pass') — hard to verify"
+        )
+    if workspace is not None:
+        for m in _RE_FILE_PATH.finditer(text):
+            candidate = Path(m.group(1))
+            if candidate.is_absolute() and not candidate.exists():
+                warnings.append(f"referenced path does not exist: {candidate}")
+    if strict and warnings:
+        raise ValueError(warnings[0])
+    return warnings
 
 
 # ---------------------------------------------------------------------------
@@ -275,6 +315,7 @@ class CodingRun(ChainRun):
         self._ws_baseline: dict[str, str] | None = {}
         # Paths newly changed/added since the baseline (populated by _run).
         self._ws_delta: list[str] = []
+        self._spec_lint_warnings: list[str] = []
 
     # -- typed overrides (narrower signatures than the Any base) ---------------
 
@@ -385,6 +426,7 @@ class CodingEngine(Engine):
         test_timeout_s: float = 600.0,
         repair_retries: int = 1,
         turn_timeout_s: float | None = 600.0,
+        strict_spec: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -397,6 +439,7 @@ class CodingEngine(Engine):
         self.test_timeout_s = test_timeout_s
         self.repair_retries = repair_retries
         self.turn_timeout_s = turn_timeout_s
+        self.strict_spec = strict_spec
 
     # -- lifecycle ------------------------------------------------------------
 
@@ -452,6 +495,12 @@ class CodingEngine(Engine):
         # Collector first: stamps eids before anything reads them. The pipeline
         # is sequential (no reactive spawning), so observers only stamp + store.
         run.observe(CodingChainEvent, lambda e, _c: run.collect(e))
+
+        lint_warnings = _lint_spec(task_text, workspace=run.workspace, strict=self.strict_spec)
+        for w in lint_warnings:
+            run.notify("spec_lint_warning", warning=w)
+        if lint_warnings:
+            run._spec_lint_warnings = lint_warnings
 
         plan = await self._plan(run)
         # Snapshot workspace state before the implementer runs so the post-
@@ -655,6 +704,8 @@ class CodingEngine(Engine):
                 {f for c in run.events_of(ChangeProposed) for f in c.files_touched}
             ),
         }
+        if run._spec_lint_warnings:
+            measurements["spec_lint_warnings"] = run._spec_lint_warnings
         result = CodeResultRecorded(
             passed=passed,
             measurements=measurements,

--- a/lionagi/engines/coding.py
+++ b/lionagi/engines/coding.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -383,6 +384,7 @@ class CodingEngine(Engine):
         max_fix_rounds: int = 3,
         test_timeout_s: float = 600.0,
         repair_retries: int = 1,
+        turn_timeout_s: float | None = 600.0,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -394,6 +396,7 @@ class CodingEngine(Engine):
         self.max_fix_rounds = max_fix_rounds
         self.test_timeout_s = test_timeout_s
         self.repair_retries = repair_retries
+        self.turn_timeout_s = turn_timeout_s
 
     # -- lifecycle ------------------------------------------------------------
 
@@ -533,14 +536,15 @@ class CodingEngine(Engine):
                 cwd=run.workspace,
                 emits=emits,
             )
+            wrapped = self._wrap_turn_timeout(agent, run)
             await run.operate_with_repair(
-                agent,
+                wrapped,
                 _implement_instruction(plan, run.task_text, run.workspace),
                 arrived=lambda: len(run.events_of(ChangeProposed)) > before,
                 emits=emits,
                 retries=self.repair_retries,
             )
-        run._implementer = agent  # reused by the fix loop — same branch, more turns
+        run._implementer = wrapped  # reused by the fix loop — same branch, more turns
         return run.last(ChangeProposed)
 
     async def _test(self, run: CodingRun, change: ChangeProposed, *, round_no: int) -> TestsRan:
@@ -666,6 +670,35 @@ class CodingEngine(Engine):
             paths = run.export(run.export_dir, report=report)
             run.notify("exported", **paths)
         return result
+
+    # -- worker helpers -------------------------------------------------------
+
+    def _wrap_turn_timeout(self, agent: Any, run: CodingRun) -> Any:
+        """Return a proxy whose operate() is bounded by turn_timeout_s.
+
+        On TimeoutError the proxy emits a turn_timeout notification and returns
+        None so operate_with_repair sees arrived()=False and enters the fix path.
+        """
+        if self.turn_timeout_s is None:
+            return agent
+        timeout_s = self.turn_timeout_s
+
+        class _Proxy:
+            name = getattr(agent, "name", "")
+            chat_model = getattr(agent, "chat_model", None)
+            capabilities = getattr(agent, "capabilities", None)
+
+            async def operate(self_, *, instruction: str, **kw: Any) -> Any:
+                try:
+                    return await asyncio.wait_for(
+                        agent.operate(instruction=instruction, **kw),
+                        timeout=timeout_s,
+                    )
+                except asyncio.TimeoutError:
+                    run.notify("turn_timeout", stage=self_.name, timeout_s=timeout_s)
+                    return None  # operate_with_repair sees arrived()=False → fix path
+
+        return _Proxy()
 
     # -- ground-truth helpers -------------------------------------------------
 

--- a/tests/engines/test_worker_safety.py
+++ b/tests/engines/test_worker_safety.py
@@ -56,7 +56,7 @@ class _ScriptedBranch:
 
 
 # ---------------------------------------------------------------------------
-# Issue #1380 — bounded cancel_active timeout
+# bounded cancel_active timeout
 # ---------------------------------------------------------------------------
 
 
@@ -105,7 +105,7 @@ async def test_cancel_active_noop_when_empty():
 
 
 # ---------------------------------------------------------------------------
-# Issue #1436 — turn-level timeout into repair loop
+# turn-level timeout into repair loop
 # ---------------------------------------------------------------------------
 
 
@@ -202,7 +202,7 @@ async def test_turn_timeout_all_rounds_concludes_failed(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Issue #1426 — spec lint
+# spec lint
 # ---------------------------------------------------------------------------
 
 
@@ -312,7 +312,7 @@ async def test_spec_lint_strict_raises_before_run(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Issue #1424 — worker heartbeat + activity events
+# worker heartbeat + activity events
 # ---------------------------------------------------------------------------
 
 
@@ -522,7 +522,7 @@ async def test_heartbeat_events_not_in_judge_context(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Issue #1429 — stage watchdog + partial export on abort
+# stage watchdog + partial export on abort
 # ---------------------------------------------------------------------------
 
 
@@ -627,4 +627,68 @@ async def test_no_watchdog_progress_aborts_implement(tmp_path, monkeypatch):
 
     assert result.passed is False
     assert any(e["type"] == "WorkAborted" for e in events)
+    assert (export_dir / "report.md").exists()
+
+
+@pytest.mark.asyncio
+async def test_hanging_fix_round_aborts_with_caveat(tmp_path, monkeypatch):
+    """A fix round hung past the watchdog must abort with a caveat and skip verify, not be reported as a plain exhausted-fix-loop failure."""
+    import sys
+
+    eng = CodingEngine(repair_retries=0, max_fix_rounds=1, stage_timeout_s=0.2)
+    run = eng.new_run()
+    plan_ev = WorkPlanned(approach="implement then stall on fix")
+
+    class _FixHangsBranch:
+        name = "implement"
+
+        def __init__(self):
+            self.calls = 0
+
+        async def operate(self, *, instruction, **kw):
+            self.calls += 1
+            if self.calls == 1:
+                await run.emit(ChangeProposed(summary="initial change"))
+                return "ok"
+            await asyncio.sleep(60)  # fix round hangs -> watchdog aborts
+            return "never"
+
+    branches = {
+        "plan": _ScriptedBranch(run, [plan_ev], name="plan"),
+        "implement": _FixHangsBranch(),
+    }
+
+    async def fake_make(role, *, name=None, **kw):
+        return branches.get(name, _ScriptedBranch(run, [], name=name))
+
+    verify_calls: list[int] = []
+    orig_verify = eng._verify
+
+    async def spy_verify(*a, **kw):
+        verify_calls.append(1)
+        return await orig_verify(*a, **kw)
+
+    monkeypatch.setattr(run, "make_agent", fake_make)
+    monkeypatch.setattr(eng, "_verify", spy_verify)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async(""))
+
+    export_dir = tmp_path / "export"
+    events: list[dict] = []
+    run.on_event = events.append
+
+    result = await eng._run(
+        run,
+        "implement then stall on fix",
+        test_cmd=[sys.executable, "-c", "exit(1)"],  # fails -> enters fix loop
+        workspace=str(tmp_path),
+        export_dir=export_dir,
+    )
+
+    aborted = [e for e in events if e["type"] == "WorkAborted"]
+    assert aborted, f"WorkAborted not found in {[e['type'] for e in events]}"
+    assert aborted[0].get("stage") == "fix-1"
+
+    assert result.passed is False
+    assert "stage aborted by watchdog" in result.caveats
+    assert verify_calls == [], "verify must not run after a watchdog abort"
     assert (export_dir / "report.md").exists()

--- a/tests/engines/test_worker_safety.py
+++ b/tests/engines/test_worker_safety.py
@@ -73,8 +73,9 @@ async def test_cancel_active_returns_within_timeout_when_task_swallows_cancelled
             await asyncio.sleep(60)  # second indefinite wait
 
     run.spawn(stubborn())
+    run.engine.cancel_timeout_s = 0.2
     t0 = time.monotonic()
-    await run.cancel_active(timeout=0.2)
+    await run.cancel_active()
     elapsed = time.monotonic() - t0
     # Must finish within 2s; no hang
     assert elapsed < 2.0, f"cancel_active hung for {elapsed:.2f}s"
@@ -91,8 +92,9 @@ async def test_cancel_active_returns_fast_when_tasks_cooperate():
 
     run.spawn(cooperative())
     run.spawn(cooperative())
+    run.engine.cancel_timeout_s = 5.0
     t0 = time.monotonic()
-    await run.cancel_active(timeout=5.0)
+    await run.cancel_active()
     elapsed = time.monotonic() - t0
     assert elapsed < 1.0
     assert not run._active

--- a/tests/engines/test_worker_safety.py
+++ b/tests/engines/test_worker_safety.py
@@ -1,0 +1,630 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Worker-safety tests: bounded cancel, turn timeout, spec lint, heartbeat/activity, stage watchdog."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from lionagi.engines.coding import (
+    ChangeProposed,
+    CodingEngine,
+    VerifyResult,
+    WorkAborted,
+    WorkerActivity,
+    WorkerHeartbeat,
+    WorkPlanned,
+    _lint_spec,
+)
+from lionagi.engines.engine import Engine, EngineRun
+
+# ---------------------------------------------------------------------------
+# Helpers shared across sections
+# ---------------------------------------------------------------------------
+
+
+class _StubEngine(Engine):
+    async def _run(self, run: EngineRun, *a: Any, **kw: Any) -> Any:  # pragma: no cover
+        return ""
+
+
+def _async(value):
+    async def _coro():
+        return value
+
+    return _coro()
+
+
+class _ScriptedBranch:
+    def __init__(self, run, events: list, *, name: str = "agent"):
+        self._run = run
+        self._events = list(events)
+        self.name = name
+        self.calls: list[str] = []
+
+    async def operate(self, *, instruction, **kw):
+        self.calls.append(instruction)
+        if self._events:
+            await self._run.emit(self._events.pop(0))
+        return "ok"
+
+
+# ---------------------------------------------------------------------------
+# Issue #1380 — bounded cancel_active timeout
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancel_active_returns_within_timeout_when_task_swallows_cancelled_error():
+    """cancel_active must return within ~timeout+buffer even when a task swallows CancelledError."""
+    run = _StubEngine().new_run()
+
+    async def stubborn():
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            # swallow — does NOT re-raise
+            await asyncio.sleep(60)  # second indefinite wait
+
+    run.spawn(stubborn())
+    t0 = time.monotonic()
+    await run.cancel_active(timeout=0.2)
+    elapsed = time.monotonic() - t0
+    # Must finish within 2s; no hang
+    assert elapsed < 2.0, f"cancel_active hung for {elapsed:.2f}s"
+    assert not run._active, "_active must be cleared even after timeout"
+
+
+@pytest.mark.asyncio
+async def test_cancel_active_returns_fast_when_tasks_cooperate():
+    """When tasks cooperate with cancellation, cancel_active returns well before timeout."""
+    run = _StubEngine().new_run()
+
+    async def cooperative():
+        await asyncio.sleep(60)  # waits indefinitely; will cooperate with CancelledError
+
+    run.spawn(cooperative())
+    run.spawn(cooperative())
+    t0 = time.monotonic()
+    await run.cancel_active(timeout=5.0)
+    elapsed = time.monotonic() - t0
+    assert elapsed < 1.0
+    assert not run._active
+
+
+@pytest.mark.asyncio
+async def test_cancel_active_noop_when_empty():
+    run = _StubEngine().new_run()
+    await run.cancel_active()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Issue #1436 — turn-level timeout into repair loop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_turn_timeout_enters_fix_loop(tmp_path, monkeypatch):
+    """When branch.operate raises asyncio.TimeoutError, the engine must enter the fix loop."""
+    eng = CodingEngine(max_fix_rounds=2, repair_retries=0, turn_timeout_s=0.01)
+    run = eng.new_run()
+
+    plan_ev = WorkPlanned(approach="do something", acceptance_criteria=["passes"])
+    timeout_count = 0
+
+    class _TimeoutBranch:
+        name = "implement"
+        calls: list[str] = []
+
+        async def operate(self, *, instruction, **kw):
+            nonlocal timeout_count
+            self.calls.append(instruction)
+            # First call times out; fix-round call emits a change
+            if timeout_count == 0:
+                timeout_count += 1
+                raise asyncio.TimeoutError("turn timed out")
+            await run.emit(ChangeProposed(summary="fixed after timeout", plan_ref="W-1"))
+            return "ok"
+
+    impl = _TimeoutBranch()
+    verdict_ev = VerifyResult(verdict="APPROVE", rationale="ok", meets_acceptance=True)
+    branches = {
+        "plan": _ScriptedBranch(run, [plan_ev], name="plan"),
+        "implement": impl,
+        "verify": _ScriptedBranch(run, [verdict_ev], name="verify"),
+    }
+
+    async def fake_make(role, *, name=None, **kw):
+        return branches[name]
+
+    monkeypatch.setattr(run, "make_agent", fake_make)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async(""))
+
+    events: list[dict] = []
+    run.on_event = events.append
+
+    result = await eng._run(
+        run,
+        "do something",
+        test_cmd=["python", "-c", "exit(0)"],
+        workspace=str(tmp_path),
+    )
+    assert result.passed is True
+    assert any(e["type"] == "turn_timeout" for e in events), (
+        f"turn_timeout event not found in {[e['type'] for e in events]}"
+    )
+    assert timeout_count == 1
+
+
+@pytest.mark.asyncio
+async def test_turn_timeout_all_rounds_concludes_failed(tmp_path, monkeypatch):
+    """If every turn times out and all fix rounds are spent, concludes failed."""
+    import sys
+
+    eng = CodingEngine(max_fix_rounds=1, repair_retries=0, turn_timeout_s=0.01)
+    run = eng.new_run()
+
+    plan_ev = WorkPlanned(approach="impossible")
+
+    class _AlwaysTimeout:
+        name = "implement"
+
+        async def operate(self, *, instruction, **kw):
+            raise asyncio.TimeoutError("always")
+
+    branches = {
+        "plan": _ScriptedBranch(run, [plan_ev], name="plan"),
+        "implement": _AlwaysTimeout(),
+        "verify": _ScriptedBranch(
+            run, [VerifyResult(verdict="REJECT", rationale="x")], name="verify"
+        ),
+    }
+
+    async def fake_make(role, *, name=None, **kw):
+        return branches[name]
+
+    monkeypatch.setattr(run, "make_agent", fake_make)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async(""))
+
+    result = await eng._run(
+        run,
+        "impossible",
+        test_cmd=[sys.executable, "-c", "exit(1)"],
+        workspace=str(tmp_path),
+    )
+    assert result.passed is False
+
+
+# ---------------------------------------------------------------------------
+# Issue #1426 — spec lint
+# ---------------------------------------------------------------------------
+
+
+def test_lint_spec_warns_missing_acceptance_criteria():
+    warnings = _lint_spec("Implement a parser", workspace=None)
+    assert any("acceptance" in w.lower() for w in warnings)
+
+
+def test_lint_spec_no_warnings_for_complete_spec(tmp_path):
+    (tmp_path / "src.py").write_text("# placeholder\n")
+    spec = (
+        "Implement a parser.\n"
+        "Acceptance criteria: all edge cases pass.\n"
+        f"See {tmp_path}/src.py for context."
+    )
+    warnings = _lint_spec(spec, workspace=str(tmp_path))
+    # Must have no acceptance-criteria warning
+    assert not any("acceptance" in w.lower() for w in warnings)
+
+
+def test_lint_spec_strict_raises_on_warnings():
+    from lionagi.engines.coding import _lint_spec
+
+    with pytest.raises(ValueError, match="acceptance"):
+        _lint_spec("no acceptance here", workspace=None, strict=True)
+
+
+def test_lint_spec_test_cmd_without_count_assertion_warns():
+    spec = "Implement foo. Acceptance criteria: bar. test_cmd: pytest tests/"
+    warnings = _lint_spec(spec, workspace=None)
+    assert any("count" in w.lower() or "assertion" in w.lower() for w in warnings)
+
+
+def test_lint_spec_missing_referenced_file_warns(tmp_path):
+    spec = f"See {tmp_path}/nonexistent.py for details. Acceptance: passes."
+    warnings = _lint_spec(spec, workspace=str(tmp_path))
+    assert any("nonexistent.py" in w for w in warnings)
+
+
+@pytest.mark.asyncio
+async def test_spec_lint_events_emitted_before_plan(tmp_path, monkeypatch):
+    """spec_lint_warning events must arrive before WorkPlanned."""
+    eng = CodingEngine(repair_retries=0)
+    run = eng.new_run()
+
+    plan_ev = WorkPlanned(approach="x")
+    branches = {
+        "plan": _ScriptedBranch(run, [plan_ev], name="plan"),
+        "implement": _ScriptedBranch(
+            run, [ChangeProposed(summary="x", plan_ref="W-1")], name="implement"
+        ),
+        "verify": _ScriptedBranch(
+            run,
+            [VerifyResult(verdict="APPROVE", rationale="ok", meets_acceptance=True)],
+            name="verify",
+        ),
+    }
+
+    async def fake_make(role, *, name=None, **kw):
+        return branches[name]
+
+    monkeypatch.setattr(run, "make_agent", fake_make)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async(""))
+
+    events: list[dict] = []
+    run.on_event = events.append
+    import sys
+
+    await eng._run(
+        run,
+        "Build the module from scratch.",
+        test_cmd=[sys.executable, "-c", "exit(0)"],
+        workspace=str(tmp_path),
+    )
+
+    lint_idxs = [i for i, e in enumerate(events) if e["type"] == "spec_lint_warning"]
+    plan_idxs = [i for i, e in enumerate(events) if e["type"] == "WorkPlanned"]
+    assert lint_idxs, "spec_lint_warning events must be emitted"
+    assert plan_idxs, "WorkPlanned event must be emitted"
+    assert min(lint_idxs) < min(plan_idxs), "lint warnings must precede plan"
+
+
+@pytest.mark.asyncio
+async def test_spec_lint_strict_raises_before_run(tmp_path, monkeypatch):
+    """strict_spec=True must raise ValueError before any agent is made."""
+    eng = CodingEngine(repair_retries=0, strict_spec=True)
+    run = eng.new_run()
+
+    made: list[str] = []
+
+    async def fake_make(role, *, name=None, **kw):
+        made.append(name)
+        return _ScriptedBranch(run, [], name=name)
+
+    monkeypatch.setattr(run, "make_agent", fake_make)
+    import sys
+
+    # "Build the module." has no acceptance criteria → strict mode raises
+    with pytest.raises(ValueError):
+        await eng._run(
+            run,
+            "Build the module.",
+            test_cmd=[sys.executable, "-c", "exit(0)"],
+            workspace=str(tmp_path),
+        )
+    assert not made, "no agent must be created when strict spec check fails"
+
+
+# ---------------------------------------------------------------------------
+# Issue #1424 — worker heartbeat + activity events
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_events_arrive_at_cadence(tmp_path, monkeypatch):
+    """WorkerHeartbeat events must be emitted at the configured cadence during the run."""
+    import sys
+
+    eng = CodingEngine(
+        repair_retries=0,
+        heartbeat_interval_s=0.05,
+        max_fix_rounds=0,
+    )
+    run = eng.new_run()
+
+    plan_ev = WorkPlanned(approach="quick")
+    change_ev = ChangeProposed(summary="done", plan_ref="W-1")
+    verdict_ev = VerifyResult(verdict="APPROVE", rationale="ok", meets_acceptance=True)
+
+    # Slow-ish implement branch so heartbeat fires at least twice
+    class _SlowBranch:
+        name = "implement"
+
+        async def operate(self, *, instruction, **kw):
+            await asyncio.sleep(0.15)
+            await run.emit(change_ev)
+            return "ok"
+
+    branches = {
+        "plan": _ScriptedBranch(run, [plan_ev], name="plan"),
+        "implement": _SlowBranch(),
+        "verify": _ScriptedBranch(run, [verdict_ev], name="verify"),
+    }
+
+    async def fake_make(role, *, name=None, **kw):
+        return branches[name]
+
+    monkeypatch.setattr(run, "make_agent", fake_make)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async(""))
+
+    events: list[dict] = []
+    run.on_event = events.append
+
+    await eng._run(
+        run,
+        "do quick work",
+        test_cmd=[sys.executable, "-c", "exit(0)"],
+        workspace=str(tmp_path),
+    )
+
+    hb_events = [e for e in events if e["type"] == "WorkerHeartbeat"]
+    assert len(hb_events) >= 2, f"Expected >=2 heartbeat events, got {len(hb_events)}"
+    # elapsed_s must be present and increasing
+    assert all("elapsed_s" in e for e in hb_events)
+
+
+@pytest.mark.asyncio
+async def test_no_activity_event_when_no_writes(tmp_path, monkeypatch):
+    """WorkerActivity must NOT be emitted when no files change during implement."""
+    import sys
+
+    eng = CodingEngine(
+        repair_retries=0,
+        heartbeat_interval_s=0.05,
+        max_fix_rounds=0,
+    )
+    run = eng.new_run()
+
+    plan_ev = WorkPlanned(approach="noop")
+    change_ev = ChangeProposed(summary="nothing written", plan_ref="W-1")
+    verdict_ev = VerifyResult(verdict="APPROVE", rationale="ok", meets_acceptance=True)
+
+    class _NopBranch:
+        name = "implement"
+
+        async def operate(self, *, instruction, **kw):
+            await asyncio.sleep(0.12)
+            await run.emit(change_ev)
+            return "ok"
+
+    branches = {
+        "plan": _ScriptedBranch(run, [plan_ev], name="plan"),
+        "implement": _NopBranch(),
+        "verify": _ScriptedBranch(run, [verdict_ev], name="verify"),
+    }
+
+    async def fake_make(role, *, name=None, **kw):
+        return branches[name]
+
+    monkeypatch.setattr(run, "make_agent", fake_make)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async(""))
+
+    events: list[dict] = []
+    run.on_event = events.append
+
+    await eng._run(
+        run,
+        "do nothing",
+        test_cmd=[sys.executable, "-c", "exit(0)"],
+        workspace=str(tmp_path),
+    )
+
+    assert not any(e["type"] == "WorkerActivity" for e in events)
+
+
+@pytest.mark.asyncio
+async def test_activity_event_emitted_on_file_write(tmp_path, monkeypatch):
+    """WorkerActivity must be emitted when a file is written during implement."""
+    import sys
+
+    eng = CodingEngine(
+        repair_retries=0,
+        heartbeat_interval_s=0.05,
+        max_fix_rounds=0,
+    )
+    run = eng.new_run()
+
+    plan_ev = WorkPlanned(approach="write file")
+    verdict_ev = VerifyResult(verdict="APPROVE", rationale="ok", meets_acceptance=True)
+
+    target = tmp_path / "out.txt"
+
+    class _WritingBranch:
+        name = "implement"
+
+        async def operate(self, *, instruction, **kw):
+            await asyncio.sleep(0.02)
+            target.write_text("hello\n")
+            await asyncio.sleep(0.08)
+            await run.emit(ChangeProposed(summary="wrote out.txt", plan_ref="W-1"))
+            return "ok"
+
+    branches = {
+        "plan": _ScriptedBranch(run, [plan_ev], name="plan"),
+        "implement": _WritingBranch(),
+        "verify": _ScriptedBranch(run, [verdict_ev], name="verify"),
+    }
+
+    async def fake_make(role, *, name=None, **kw):
+        return branches[name]
+
+    monkeypatch.setattr(run, "make_agent", fake_make)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async(""))
+
+    events: list[dict] = []
+    run.on_event = events.append
+
+    await eng._run(
+        run,
+        "write a file",
+        test_cmd=[sys.executable, "-c", "exit(0)"],
+        workspace=str(tmp_path),
+    )
+
+    assert any(e["type"] == "WorkerActivity" for e in events), (
+        f"WorkerActivity missing from {[e['type'] for e in events]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_events_not_in_judge_context(tmp_path, monkeypatch):
+    """WorkerHeartbeat events must be excluded from the judge context filter."""
+    # Heartbeat events are EngineEvent but not CodingChainEvent — they should
+    # not appear in run.events_of(WorkerHeartbeat) via chain store.
+    import sys
+
+    eng = CodingEngine(
+        repair_retries=0,
+        heartbeat_interval_s=0.05,
+        max_fix_rounds=0,
+    )
+    run = eng.new_run()
+
+    plan_ev = WorkPlanned(approach="quick")
+    change_ev = ChangeProposed(summary="done", plan_ref="W-1")
+    verdict_ev = VerifyResult(verdict="APPROVE", rationale="ok", meets_acceptance=True)
+
+    class _SlowBranch:
+        name = "implement"
+
+        async def operate(self, *, instruction, **kw):
+            await asyncio.sleep(0.12)
+            await run.emit(change_ev)
+            return "ok"
+
+    branches = {
+        "plan": _ScriptedBranch(run, [plan_ev], name="plan"),
+        "implement": _SlowBranch(),
+        "verify": _ScriptedBranch(run, [verdict_ev], name="verify"),
+    }
+
+    async def fake_make(role, *, name=None, **kw):
+        return branches[name]
+
+    monkeypatch.setattr(run, "make_agent", fake_make)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async(""))
+
+    await eng._run(
+        run,
+        "do quick work",
+        test_cmd=[sys.executable, "-c", "exit(0)"],
+        workspace=str(tmp_path),
+    )
+
+    # WorkerHeartbeat is not a CodingChainEvent; chain store must not have it
+    assert not run.events_of(WorkerHeartbeat), "HeartBeat must not pollute the chain store"
+
+
+# ---------------------------------------------------------------------------
+# Issue #1429 — stage watchdog + partial export on abort
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hanging_implement_triggers_work_aborted_and_partial_export(tmp_path, monkeypatch):
+    """A hung _implement stage must be aborted; WorkAborted event must fire; export dir must have report.md."""
+    import sys
+
+    eng = CodingEngine(
+        repair_retries=0,
+        max_fix_rounds=0,
+        stage_timeout_s=0.2,
+    )
+    run = eng.new_run()
+
+    plan_ev = WorkPlanned(approach="hang forever")
+
+    class _HangingBranch:
+        name = "implement"
+
+        async def operate(self, *, instruction, **kw):
+            await asyncio.sleep(60)  # hangs indefinitely
+            return "never"
+
+    branches = {
+        "plan": _ScriptedBranch(run, [plan_ev], name="plan"),
+        "implement": _HangingBranch(),
+    }
+
+    async def fake_make(role, *, name=None, **kw):
+        return branches.get(name, _ScriptedBranch(run, [], name=name))
+
+    monkeypatch.setattr(run, "make_agent", fake_make)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async(""))
+
+    export_dir = tmp_path / "export"
+    events: list[dict] = []
+    run.on_event = events.append
+
+    result = await eng._run(
+        run,
+        "hang forever",
+        test_cmd=[sys.executable, "-c", "exit(0)"],
+        workspace=str(tmp_path),
+        export_dir=export_dir,
+    )
+
+    # Must complete (not hang)
+    work_aborted = [e for e in events if e["type"] == "WorkAborted"]
+    assert work_aborted, f"WorkAborted not found in {[e['type'] for e in events]}"
+    assert work_aborted[0].get("reason")
+
+    # Partial export must have written report.md
+    assert (export_dir / "report.md").exists(), "report.md must be written on abort"
+
+    # Result must indicate failure
+    assert result.passed is False
+
+
+@pytest.mark.asyncio
+async def test_no_watchdog_progress_aborts_implement(tmp_path, monkeypatch):
+    """A stage with no workspace progress within the watchdog window must abort."""
+    import sys
+
+    eng = CodingEngine(
+        repair_retries=0,
+        max_fix_rounds=0,
+        stage_timeout_s=0.3,
+    )
+    run = eng.new_run()
+    plan_ev = WorkPlanned(approach="stall silently")
+
+    class _StalledBranch:
+        name = "implement"
+
+        async def operate(self, *, instruction, **kw):
+            await asyncio.sleep(60)  # no writes, no emission
+            return "never"
+
+    branches = {
+        "plan": _ScriptedBranch(run, [plan_ev], name="plan"),
+        "implement": _StalledBranch(),
+    }
+
+    async def fake_make(role, *, name=None, **kw):
+        return branches.get(name, _ScriptedBranch(run, [], name=name))
+
+    monkeypatch.setattr(run, "make_agent", fake_make)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async(""))
+
+    export_dir = tmp_path / "export"
+    events: list[dict] = []
+    run.on_event = events.append
+
+    result = await eng._run(
+        run,
+        "stall silently",
+        test_cmd=[sys.executable, "-c", "exit(0)"],
+        workspace=str(tmp_path),
+        export_dir=export_dir,
+    )
+
+    assert result.passed is False
+    assert any(e["type"] == "WorkAborted" for e in events)
+    assert (export_dir / "report.md").exists()


### PR DESCRIPTION
**Draft** — harvested from a stale fanout branch (42 commits behind at time of harvest); rebasing onto main hits a conflict in `lionagi/engines/engine.py` that needs manual resolution before this is mergeable. Opening as draft to preserve the work and make it actionable.

Bundles four engine features on `lionagi/engines/coding.py`:
- #1424 worker heartbeat + activity events (`WorkerHeartbeat`, `WorkerActivity`, `heartbeat_interval_s`)
- #1426 spec lint + strict mode (`_lint_spec`, `strict_spec`)
- #1429 stage watchdog + partial export on abort (`stage_timeout_s`, `WorkAborted`) — wall-clock guard only; the no-file-write "no-progress" guard from the issue is NOT yet implemented
- #1436 turn-level timeout into repair loop (`turn_timeout_s`)
- plus #1380 bounded `cancel_active` timeout

Tests: `tests/engines/test_worker_safety.py`.

TODO before un-drafting: resolve `engine.py` rebase conflict, add the #1429 no-progress guard, re-run full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)