### PR TITLE
refactor(studio/scheduler): service abstraction for StateDB access + unit-isolate _fire() (#1409)

### DIFF
--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -12,150 +12,30 @@ import time
 import uuid
 from typing import Any
 
-from lionagi.state.db import StateDB
 from lionagi.state.reasons import RunReasons, ScheduleReasons
+from lionagi.studio.scheduler.subprocess import build_argv, spawn_and_wait
+from lionagi.studio.services.scheduler_state import (
+    SchedulerStateService,
+    create_skipped_run,
+    default_scheduler_state,
+    resolve_invocation_terminal,
+)
 
 _log = logging.getLogger(__name__)
-
-
-async def _resolve_invocation_terminal(
-    db: StateDB,
-    invocation_id: str,
-    *,
-    fallback_status: str,
-    exit_code: int | None = None,
-    exception: BaseException | None = None,
-) -> tuple[str, str, str, list[dict], dict]:
-    sessions = await db.list_sessions_for_invocation(invocation_id)
-    child_statuses = [str(s.get("status") or "") for s in sessions]
-    evidence_refs = [{"kind": "session", "id": s["id"]} for s in sessions if s.get("id")]
-    metadata: dict = {"child_statuses": child_statuses}
-    if exit_code is not None:
-        metadata["exit_code"] = exit_code
-    if exception is not None:
-        metadata["exception_class"] = type(exception).__name__
-
-    # Precedence: timed_out > failed > aborted > cancelled > completed.
-    if child_statuses:
-        if any(s == "timed_out" for s in child_statuses):
-            return (
-                "timed_out",
-                RunReasons.TIMED_OUT_DEADLINE,
-                "Invocation timed out because at least one child session timed out.",
-                evidence_refs,
-                metadata,
-            )
-        if any(s == "failed" for s in child_statuses):
-            return (
-                "failed",
-                RunReasons.FAILED_EXCEPTION,
-                "Invocation failed because at least one child session failed.",
-                evidence_refs,
-                metadata,
-            )
-        if any(s == "aborted" for s in child_statuses):
-            aborted_reasons = {
-                str(sess.get("status_reason_code") or "")
-                for sess in sessions
-                if sess.get("status") == "aborted"
-            }
-            if RunReasons.CANCELLED_SIGINT in aborted_reasons:
-                reason_code = RunReasons.CANCELLED_SIGINT
-                reason_summary = "Invocation was interrupted (SIGINT) because a child session was."
-            else:
-                reason_code = RunReasons.ABORTED_USER
-                reason_summary = (
-                    "Invocation was aborted because at least one child session was aborted."
-                )
-            return ("aborted", reason_code, reason_summary, evidence_refs, metadata)
-        if any(s == "cancelled" for s in child_statuses):
-            return (
-                "cancelled",
-                RunReasons.CANCELLED_SYSTEM,
-                "Invocation was cancelled because at least one child session was cancelled.",
-                evidence_refs,
-                metadata,
-            )
-        if all(s == "completed" for s in child_statuses):
-            return (
-                "completed",
-                RunReasons.COMPLETED_OK,
-                "All child sessions completed successfully.",
-                evidence_refs,
-                metadata,
-            )
-
-    if fallback_status == "completed":
-        return (
-            "completed",
-            RunReasons.COMPLETED_OK,
-            "Invocation process completed successfully.",
-            evidence_refs,
-            metadata,
-        )
-    if fallback_status == "timed_out":
-        return (
-            "timed_out",
-            RunReasons.TIMED_OUT_DEADLINE,
-            "Invocation process exceeded its deadline.",
-            evidence_refs,
-            metadata,
-        )
-    if fallback_status == "aborted":
-        # Process-level abort with no child reason to inspect — keep the neutral
-        # user/admin abort reason rather than assume SIGINT.
-        return (
-            "aborted",
-            RunReasons.ABORTED_USER,
-            "Invocation process was aborted.",
-            evidence_refs,
-            metadata,
-        )
-    if fallback_status == "cancelled":
-        return (
-            "cancelled",
-            RunReasons.CANCELLED_SYSTEM,
-            "Invocation process was cancelled by the runtime.",
-            evidence_refs,
-            metadata,
-        )
-    if exception is not None:
-        return (
-            "failed",
-            RunReasons.FAILED_EXCEPTION,
-            f"{type(exception).__name__}: {exception}",
-            evidence_refs,
-            metadata,
-        )
-    if exit_code is not None and exit_code != 0:
-        return (
-            "failed",
-            RunReasons.FAILED_EXIT_NONZERO,
-            f"Invocation process failed with exit code {exit_code}.",
-            evidence_refs,
-            metadata,
-        )
-    return (
-        "failed",
-        RunReasons.FAILED_EXCEPTION,
-        "Invocation process failed.",
-        evidence_refs,
-        metadata,
-    )
-
 
 _MAX_CHAIN_DEPTH = 10
 _TICK_INTERVAL = 30  # seconds
 
 
 class SchedulerEngine:
-    def __init__(self) -> None:
+    def __init__(self, svc: SchedulerStateService | None = None) -> None:
+        self._svc = svc if svc is not None else default_scheduler_state
         self._task: asyncio.Task | None = None
         self._running: dict[str, str] = {}  # schedule_id -> run_id
         self._stopping = False
         self._fire_tasks: set[asyncio.Task] = set()
-        self._last_reaper_run: float = 0.0  # epoch; 0 means never
-        self._last_checkpoint_run: float = 0.0  # epoch; 0 means never
+        self._last_reaper_run: float = 0.0
+        self._last_checkpoint_run: float = 0.0
 
     async def start(self) -> None:
         _log.info("Scheduler engine starting")
@@ -186,8 +66,7 @@ class SchedulerEngine:
         return task
 
     async def fire_now(self, schedule_id: str) -> str | None:
-        async with StateDB() as db:
-            schedule = await db.get_schedule(schedule_id)
+        schedule = await self._svc.get_schedule(schedule_id)
         if not schedule:
             return None
         run_id = uuid.uuid4().hex[:12]
@@ -207,8 +86,7 @@ class SchedulerEngine:
 
     async def _check_missed_fires(self) -> None:
         try:
-            async with StateDB() as db:
-                schedules = await db.list_schedules(enabled=True)
+            schedules = await self._svc.list_schedules(enabled=True)
             now = time.time()
             for s in schedules:
                 next_fire_at = s.get("next_fire_at")
@@ -236,43 +114,30 @@ class SchedulerEngine:
         """Record missed-fire skip and advance next_fire_at."""
         skipped_run_id = uuid.uuid4().hex[:12]
         try:
-            async with StateDB() as db:
-                await db.create_schedule_run(
-                    {
-                        "id": skipped_run_id,
-                        "schedule_id": schedule["id"],
-                        "trigger_context": {
-                            "skipped_missed_fire": True,
-                            "missed_fire_at": schedule.get("next_fire_at"),
-                            "checked_at": now,
-                        },
-                        "action_kind": schedule["action_kind"],
-                        "action_args": [],
-                        "status": "skipped",
-                        "fired_at": now,
-                    }
-                )
-                await db.update_status(
-                    "schedule_run",
-                    skipped_run_id,
-                    new_status="skipped",
-                    reason_code=ScheduleReasons.SKIPPED_MISSED_FIRE,
-                    reason_summary=(
-                        "Schedule fire skipped because the scheduled time "
-                        "passed while the server was down or the tick was "
-                        "delayed (missed_fire_policy=skip)."
-                    ),
-                    evidence_refs=[{"kind": "schedule", "id": schedule["id"]}],
-                    source="system",
-                    actor=schedule["id"],
-                    metadata={
-                        "missed_fire_policy": schedule.get("missed_fire_policy"),
-                        "missed_fire_at": schedule.get("next_fire_at"),
-                    },
-                )
-                next_at = self._compute_next_fire(schedule, now)
-                if next_at:
-                    await db.update_schedule(schedule["id"], next_fire_at=next_at)
+            await create_skipped_run(
+                self._svc,
+                run_id=skipped_run_id,
+                schedule=schedule,
+                trigger_context={
+                    "skipped_missed_fire": True,
+                    "missed_fire_at": schedule.get("next_fire_at"),
+                    "checked_at": now,
+                },
+                now=now,
+                reason_code=ScheduleReasons.SKIPPED_MISSED_FIRE,
+                reason_summary=(
+                    "Schedule fire skipped because the scheduled time "
+                    "passed while the server was down or the tick was "
+                    "delayed (missed_fire_policy=skip)."
+                ),
+                metadata={
+                    "missed_fire_policy": schedule.get("missed_fire_policy"),
+                    "missed_fire_at": schedule.get("next_fire_at"),
+                },
+            )
+            next_at = self._compute_next_fire(schedule, now)
+            if next_at:
+                await self._svc.update_schedule(schedule["id"], next_fire_at=next_at)
         except Exception:
             _log.exception(
                 "Failed to record missed-fire skip for schedule %s",
@@ -302,8 +167,7 @@ class SchedulerEngine:
                 _log.exception("Periodic checkpoint error")
             self._last_checkpoint_run = now
 
-        async with StateDB() as db:
-            schedules = await db.list_schedules(enabled=True)
+        schedules = await self._svc.list_schedules(enabled=True)
 
         for s in schedules:
             try:
@@ -316,8 +180,7 @@ class SchedulerEngine:
                     elif nfa is None:
                         next_at = self._compute_next_fire(s, now)
                         if next_at:
-                            async with StateDB() as db:
-                                await db.update_schedule(s["id"], next_fire_at=next_at)
+                            await self._svc.update_schedule(s["id"], next_fire_at=next_at)
             except Exception:
                 _log.exception("Error evaluating schedule %s", s.get("name"))
 
@@ -342,33 +205,19 @@ class SchedulerEngine:
         if schedule.get("overlap_policy") == "skip" and schedule["id"] in self._running:
             _log.debug("Skipping overlapping fire for %s", schedule["name"])
             skipped_run_id = uuid.uuid4().hex[:12]
-            async with StateDB() as db:
-                await db.create_schedule_run(
-                    {
-                        "id": skipped_run_id,
-                        "schedule_id": schedule["id"],
-                        "trigger_context": {"skipped_overlap": True, "fired_at": now},
-                        "action_kind": schedule["action_kind"],
-                        "action_args": [],
-                        "status": "skipped",
-                        "fired_at": now,
-                    }
-                )
-                await db.update_status(
-                    "schedule_run",
-                    skipped_run_id,
-                    new_status="skipped",
-                    reason_code=ScheduleReasons.SKIPPED_OVERLAP,
-                    reason_summary="Schedule fire skipped because overlap_policy=skip and a prior run is still active.",
-                    evidence_refs=[{"kind": "schedule", "id": schedule["id"]}],
-                    source="system",
-                    actor=schedule["id"],
-                    metadata={"overlap_policy": schedule.get("overlap_policy")},
-                )
+            await create_skipped_run(
+                self._svc,
+                run_id=skipped_run_id,
+                schedule=schedule,
+                trigger_context={"skipped_overlap": True, "fired_at": now},
+                now=now,
+                reason_code=ScheduleReasons.SKIPPED_OVERLAP,
+                reason_summary="Schedule fire skipped because overlap_policy=skip and a prior run is still active.",
+                metadata={"overlap_policy": schedule.get("overlap_policy")},
+            )
             next_at = self._compute_next_fire(schedule, now)
             if next_at:
-                async with StateDB() as db:
-                    await db.update_schedule(schedule["id"], next_fire_at=next_at)
+                await self._svc.update_schedule(schedule["id"], next_fire_at=next_at)
             return
 
         run_id = uuid.uuid4().hex[:12]
@@ -384,23 +233,20 @@ class SchedulerEngine:
         chain_parent_id: str | None = None,
         chain_depth: int = 0,
     ) -> None:
-        from .subprocess import build_argv, spawn_and_wait
-
         sid = schedule["id"]
         now = time.time()
 
         inv_id = uuid.uuid4().hex[:12]
-        async with StateDB() as db:
-            await db.create_invocation(
-                {
-                    "id": inv_id,
-                    "skill": f"scheduled:{schedule['name']}",
-                    "plugin": schedule["trigger_type"],
-                    "prompt": schedule.get("action_prompt") or schedule.get("action_playbook"),
-                    "started_at": now,
-                    "status": "running",
-                }
-            )
+        await self._svc.create_invocation(
+            {
+                "id": inv_id,
+                "skill": f"scheduled:{schedule['name']}",
+                "plugin": schedule["trigger_type"],
+                "prompt": schedule.get("action_prompt") or schedule.get("action_playbook"),
+                "started_at": now,
+                "status": "running",
+            }
+        )
 
         try:
             argv, _tmp_path = build_argv(schedule, trigger_context)
@@ -408,95 +254,92 @@ class SchedulerEngine:
             _log.exception("Invalid schedule action for %s (run %s)", schedule.get("name"), run_id)
             _end_time = time.time()
             next_at = self._compute_next_fire(schedule, now)
-            async with StateDB() as db:
-                await db.create_schedule_run(
-                    {
-                        "id": run_id,
-                        "schedule_id": sid,
-                        "invocation_id": inv_id,
-                        "trigger_context": trigger_context,
-                        "action_kind": schedule.get("action_kind"),
-                        "action_args": [],
-                        "status": "failed",
-                        "chain_parent_id": chain_parent_id,
-                        "chain_depth": chain_depth,
-                        "fired_at": now,
-                        "ended_at": _end_time,
-                        "error_detail": str(exc),
-                    }
-                )
-                await db.update_status(
-                    "schedule_run",
-                    run_id,
-                    new_status="failed",
-                    reason_code=RunReasons.FAILED_EXCEPTION,
-                    reason_summary=f"{type(exc).__name__}: {exc}",
-                    evidence_refs=[{"kind": "schedule", "id": sid}],
-                    source="executor",
-                    actor=run_id,
-                    metadata={"exception_class": type(exc).__name__},
-                )
-                inv_status, inv_rc, inv_rs, inv_ev, inv_meta = await _resolve_invocation_terminal(
-                    db, inv_id, fallback_status="failed", exception=exc
-                )
-                await db.update_invocation(inv_id, ended_at=_end_time)
-                await db.update_status(
-                    "invocation",
-                    inv_id,
-                    new_status=inv_status,
-                    reason_code=inv_rc,
-                    reason_summary=inv_rs,
-                    evidence_refs=inv_ev,
-                    source="executor",
-                    actor=inv_id,
-                    metadata=inv_meta,
-                )
-                update_fields: dict[str, Any] = {"last_fired_at": now}
-                if next_at:
-                    update_fields["next_fire_at"] = next_at
-                await db.update_schedule(sid, **update_fields)
+            await self._svc.create_schedule_run(
+                {
+                    "id": run_id,
+                    "schedule_id": sid,
+                    "invocation_id": inv_id,
+                    "trigger_context": trigger_context,
+                    "action_kind": schedule.get("action_kind"),
+                    "action_args": [],
+                    "status": "failed",
+                    "chain_parent_id": chain_parent_id,
+                    "chain_depth": chain_depth,
+                    "fired_at": now,
+                    "ended_at": _end_time,
+                    "error_detail": str(exc),
+                }
+            )
+            await self._svc.update_status(
+                "schedule_run",
+                run_id,
+                new_status="failed",
+                reason_code=RunReasons.FAILED_EXCEPTION,
+                reason_summary=f"{type(exc).__name__}: {exc}",
+                evidence_refs=[{"kind": "schedule", "id": sid}],
+                source="executor",
+                actor=run_id,
+                metadata={"exception_class": type(exc).__name__},
+            )
+            inv_status, inv_rc, inv_rs, inv_ev, inv_meta = await resolve_invocation_terminal(
+                self._svc, inv_id, fallback_status="failed", exception=exc
+            )
+            await self._svc.update_invocation(inv_id, ended_at=_end_time)
+            await self._svc.update_status(
+                "invocation",
+                inv_id,
+                new_status=inv_status,
+                reason_code=inv_rc,
+                reason_summary=inv_rs,
+                evidence_refs=inv_ev,
+                source="executor",
+                actor=inv_id,
+                metadata=inv_meta,
+            )
+            update_fields: dict[str, Any] = {"last_fired_at": now}
+            if next_at:
+                update_fields["next_fire_at"] = next_at
+            await self._svc.update_schedule(sid, **update_fields)
             return
 
         # Ensure the flow_yaml tmp file is removed on any exception or
         # cancellation in the DB ops below, before spawn_and_wait() runs.
         # suppress(OSError) makes double-unlink (spawn_and_wait already cleaned up) safe.
         try:
-            async with StateDB() as db:
-                await db.create_schedule_run(
-                    {
-                        "id": run_id,
-                        "schedule_id": sid,
-                        "invocation_id": inv_id,
-                        "trigger_context": trigger_context,
-                        "action_kind": schedule["action_kind"],
-                        "action_args": argv,
-                        "status": "running",
-                        "chain_parent_id": chain_parent_id,
-                        "chain_depth": chain_depth,
-                        "fired_at": now,
-                    }
-                )
-                await db.update_status(
-                    "schedule_run",
-                    run_id,
-                    new_status="running",
-                    reason_code=ScheduleReasons.FIRED_DUE,
-                    reason_summary="Schedule run fired because the trigger was due.",
-                    evidence_refs=[{"kind": "schedule", "id": sid}],
-                    source="system",
-                    actor=sid,
-                    metadata={"trigger_context": trigger_context, "chain_depth": chain_depth},
-                )
+            await self._svc.create_schedule_run(
+                {
+                    "id": run_id,
+                    "schedule_id": sid,
+                    "invocation_id": inv_id,
+                    "trigger_context": trigger_context,
+                    "action_kind": schedule["action_kind"],
+                    "action_args": argv,
+                    "status": "running",
+                    "chain_parent_id": chain_parent_id,
+                    "chain_depth": chain_depth,
+                    "fired_at": now,
+                }
+            )
+            await self._svc.update_status(
+                "schedule_run",
+                run_id,
+                new_status="running",
+                reason_code=ScheduleReasons.FIRED_DUE,
+                reason_summary="Schedule run fired because the trigger was due.",
+                evidence_refs=[{"kind": "schedule", "id": sid}],
+                source="system",
+                actor=sid,
+                metadata={"trigger_context": trigger_context, "chain_depth": chain_depth},
+            )
 
             if chain_depth == 0:
                 self._running[sid] = run_id
 
             next_at = self._compute_next_fire(schedule, now)
-            update_fields: dict[str, Any] = {"last_fired_at": now}
+            update_fields = {"last_fired_at": now}
             if next_at:
                 update_fields["next_fire_at"] = next_at
-            async with StateDB() as db:
-                await db.update_schedule(sid, **update_fields)
+            await self._svc.update_schedule(sid, **update_fields)
 
             _log.info(
                 "Firing schedule %s (run %s, chain_depth=%d)", schedule["name"], run_id, chain_depth
@@ -514,39 +357,38 @@ class SchedulerEngine:
                 else f"Scheduled process exited non-zero: {exit_code}."
             )
 
-            async with StateDB() as db:
-                await db.update_schedule_run(
-                    run_id,
-                    exit_code=exit_code,
-                    ended_at=end_time,
-                    error_detail=stderr_tail if exit_code != 0 else None,
-                )
-                await db.update_status(
-                    "schedule_run",
-                    run_id,
-                    new_status=status,
-                    reason_code=reason_code,
-                    reason_summary=reason_summary,
-                    evidence_refs=[{"kind": "invocation", "id": inv_id}],
-                    source="executor",
-                    actor=run_id,
-                    metadata={"exit_code": exit_code},
-                )
-                inv_status, inv_rc, inv_rs, inv_ev, inv_meta = await _resolve_invocation_terminal(
-                    db, inv_id, fallback_status=status, exit_code=exit_code
-                )
-                await db.update_invocation(inv_id, ended_at=end_time)
-                await db.update_status(
-                    "invocation",
-                    inv_id,
-                    new_status=inv_status,
-                    reason_code=inv_rc,
-                    reason_summary=inv_rs,
-                    evidence_refs=inv_ev,
-                    source="executor",
-                    actor=inv_id,
-                    metadata=inv_meta,
-                )
+            await self._svc.update_schedule_run(
+                run_id,
+                exit_code=exit_code,
+                ended_at=end_time,
+                error_detail=stderr_tail if exit_code != 0 else None,
+            )
+            await self._svc.update_status(
+                "schedule_run",
+                run_id,
+                new_status=status,
+                reason_code=reason_code,
+                reason_summary=reason_summary,
+                evidence_refs=[{"kind": "invocation", "id": inv_id}],
+                source="executor",
+                actor=run_id,
+                metadata={"exit_code": exit_code},
+            )
+            inv_status, inv_rc, inv_rs, inv_ev, inv_meta = await resolve_invocation_terminal(
+                self._svc, inv_id, fallback_status=status, exit_code=exit_code
+            )
+            await self._svc.update_invocation(inv_id, ended_at=end_time)
+            await self._svc.update_status(
+                "invocation",
+                inv_id,
+                new_status=inv_status,
+                reason_code=inv_rc,
+                reason_summary=inv_rs,
+                evidence_refs=inv_ev,
+                source="executor",
+                actor=inv_id,
+                metadata=inv_meta,
+            )
 
             if chain_depth < _MAX_CHAIN_DEPTH:
                 chain_action = None
@@ -588,64 +430,21 @@ class SchedulerEngine:
             _log.info("Schedule fire cancelled %s (run %s)", schedule.get("name"), run_id)
             _end_time = time.time()
             try:
-                async with StateDB() as db:
-                    await db.update_schedule_run(
-                        run_id,
-                        ended_at=_end_time,
-                        error_detail="Scheduler shutdown",
-                        reason_code=RunReasons.CANCELLED_SYSTEM,
-                        status="cancelled",
-                        reason_summary="Schedule run cancelled by scheduler shutdown.",
-                        evidence_refs=[{"kind": "schedule", "id": sid}],
-                        reason_actor=run_id,
-                    )
-                    (
-                        inv_status,
-                        inv_rc,
-                        inv_rs,
-                        inv_ev,
-                        inv_meta,
-                    ) = await _resolve_invocation_terminal(db, inv_id, fallback_status="cancelled")
-                    await db.update_invocation(inv_id, ended_at=_end_time)
-                    await db.update_status(
-                        "invocation",
-                        inv_id,
-                        new_status=inv_status,
-                        reason_code=inv_rc,
-                        reason_summary=inv_rs,
-                        evidence_refs=inv_ev,
-                        source="executor",
-                        actor=inv_id,
-                        metadata=inv_meta,
-                    )
-            except Exception:
-                _log.exception("Failed to record cancellation for run %s during shutdown", run_id)
-            raise
-        except Exception as exc:
-            _log.exception("Error in schedule fire %s (run %s)", schedule.get("name"), run_id)
-            _end_time = time.time()
-            async with StateDB() as db:
-                await db.update_schedule_run(
+                await self._svc.update_schedule_run(
                     run_id,
                     ended_at=_end_time,
-                    error_detail="Internal scheduler error",
-                )
-                await db.update_status(
-                    "schedule_run",
-                    run_id,
-                    new_status="failed",
-                    reason_code=RunReasons.FAILED_EXCEPTION,
-                    reason_summary=f"{type(exc).__name__}: {exc}",
+                    error_detail="Scheduler shutdown",
+                    reason_code=RunReasons.CANCELLED_SYSTEM,
+                    status="cancelled",
+                    reason_summary="Schedule run cancelled by scheduler shutdown.",
                     evidence_refs=[{"kind": "schedule", "id": sid}],
-                    source="executor",
-                    actor=run_id,
-                    metadata={"exception_class": type(exc).__name__},
+                    reason_actor=run_id,
                 )
-                inv_status, inv_rc, inv_rs, inv_ev, inv_meta = await _resolve_invocation_terminal(
-                    db, inv_id, fallback_status="failed", exception=exc
+                inv_status, inv_rc, inv_rs, inv_ev, inv_meta = await resolve_invocation_terminal(
+                    self._svc, inv_id, fallback_status="cancelled"
                 )
-                await db.update_invocation(inv_id, ended_at=_end_time)
-                await db.update_status(
+                await self._svc.update_invocation(inv_id, ended_at=_end_time)
+                await self._svc.update_status(
                     "invocation",
                     inv_id,
                     new_status=inv_status,
@@ -656,11 +455,46 @@ class SchedulerEngine:
                     actor=inv_id,
                     metadata=inv_meta,
                 )
+            except Exception:
+                _log.exception("Failed to record cancellation for run %s during shutdown", run_id)
+            raise
+        except Exception as exc:
+            _log.exception("Error in schedule fire %s (run %s)", schedule.get("name"), run_id)
+            _end_time = time.time()
+            await self._svc.update_schedule_run(
+                run_id,
+                ended_at=_end_time,
+                error_detail="Internal scheduler error",
+            )
+            await self._svc.update_status(
+                "schedule_run",
+                run_id,
+                new_status="failed",
+                reason_code=RunReasons.FAILED_EXCEPTION,
+                reason_summary=f"{type(exc).__name__}: {exc}",
+                evidence_refs=[{"kind": "schedule", "id": sid}],
+                source="executor",
+                actor=run_id,
+                metadata={"exception_class": type(exc).__name__},
+            )
+            inv_status, inv_rc, inv_rs, inv_ev, inv_meta = await resolve_invocation_terminal(
+                self._svc, inv_id, fallback_status="failed", exception=exc
+            )
+            await self._svc.update_invocation(inv_id, ended_at=_end_time)
+            await self._svc.update_status(
+                "invocation",
+                inv_id,
+                new_status=inv_status,
+                reason_code=inv_rc,
+                reason_summary=inv_rs,
+                evidence_refs=inv_ev,
+                source="executor",
+                actor=inv_id,
+                metadata=inv_meta,
+            )
         finally:
             if chain_depth == 0:
                 self._running.pop(sid, None)
-            # Clean up flow_yaml tmp file if spawn_and_wait never ran;
-            # suppress OSError so double-unlink is harmless.
             if _tmp_path is not None:
                 with contextlib.suppress(OSError):
                     os.unlink(_tmp_path)

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -13,7 +13,7 @@ import uuid
 from typing import Any
 
 from lionagi.state.reasons import RunReasons, ScheduleReasons
-from lionagi.studio.scheduler.subprocess import build_argv, spawn_and_wait
+from lionagi.studio.scheduler import subprocess as _subprocess
 from lionagi.studio.services.scheduler_state import (
     SchedulerStateService,
     create_skipped_run,
@@ -249,7 +249,7 @@ class SchedulerEngine:
         )
 
         try:
-            argv, _tmp_path = build_argv(schedule, trigger_context)
+            argv, _tmp_path = _subprocess.build_argv(schedule, trigger_context)
         except Exception as exc:
             _log.exception("Invalid schedule action for %s (run %s)", schedule.get("name"), run_id)
             _end_time = time.time()
@@ -345,7 +345,9 @@ class SchedulerEngine:
                 "Firing schedule %s (run %s, chain_depth=%d)", schedule["name"], run_id, chain_depth
             )
 
-            exit_code, stderr_tail = await spawn_and_wait(argv, inv_id, tmp_path=_tmp_path)
+            exit_code, stderr_tail = await _subprocess.spawn_and_wait(
+                argv, inv_id, tmp_path=_tmp_path
+            )
             end_time = time.time()
             status = "completed" if exit_code == 0 else "failed"
             reason_code = (

--- a/lionagi/studio/services/scheduler_state.py
+++ b/lionagi/studio/services/scheduler_state.py
@@ -1,0 +1,284 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Service layer for SchedulerEngine StateDB access.
+
+All direct StateDB I/O from the scheduler engine is routed here so _fire()
+and friends can be unit-tested by injecting a mock implementation of
+SchedulerStateService.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Protocol
+
+from lionagi.state.db import StateDB
+from lionagi.state.reasons import RunReasons
+
+_log = logging.getLogger(__name__)
+
+
+class SchedulerStateService(Protocol):
+    """Protocol satisfied by both the real DB-backed service and test mocks."""
+
+    async def get_schedule(self, schedule_id: str) -> dict[str, Any] | None: ...
+
+    async def list_schedules(self, *, enabled: bool | None = None) -> list[dict[str, Any]]: ...
+
+    async def update_schedule(self, schedule_id: str, **fields: Any) -> None: ...
+
+    async def create_schedule_run(self, run: dict[str, Any]) -> None: ...
+
+    async def update_schedule_run(self, run_id: str, **fields: Any) -> None: ...
+
+    async def create_invocation(self, invocation: dict[str, Any]) -> None: ...
+
+    async def update_invocation(self, inv_id: str, **fields: Any) -> None: ...
+
+    async def update_status(
+        self,
+        entity_type: str,
+        entity_id: str,
+        *,
+        new_status: str,
+        reason_code: str,
+        reason_summary: str,
+        evidence_refs: list[dict],
+        source: str,
+        actor: str,
+        metadata: dict | None = None,
+    ) -> None: ...
+
+    async def list_sessions_for_invocation(self, invocation_id: str) -> list[dict[str, Any]]: ...
+
+
+class _DBSchedulerStateService:
+    """Real implementation — each method opens a fresh StateDB context."""
+
+    async def get_schedule(self, schedule_id: str) -> dict[str, Any] | None:
+        async with StateDB() as db:
+            return await db.get_schedule(schedule_id)
+
+    async def list_schedules(self, *, enabled: bool | None = None) -> list[dict[str, Any]]:
+        async with StateDB() as db:
+            return await db.list_schedules(enabled=enabled)
+
+    async def update_schedule(self, schedule_id: str, **fields: Any) -> None:
+        async with StateDB() as db:
+            await db.update_schedule(schedule_id, **fields)
+
+    async def create_schedule_run(self, run: dict[str, Any]) -> None:
+        async with StateDB() as db:
+            await db.create_schedule_run(run)
+
+    async def update_schedule_run(self, run_id: str, **fields: Any) -> None:
+        async with StateDB() as db:
+            await db.update_schedule_run(run_id, **fields)
+
+    async def create_invocation(self, invocation: dict[str, Any]) -> None:
+        async with StateDB() as db:
+            await db.create_invocation(invocation)
+
+    async def update_invocation(self, inv_id: str, **fields: Any) -> None:
+        async with StateDB() as db:
+            await db.update_invocation(inv_id, **fields)
+
+    async def update_status(
+        self,
+        entity_type: str,
+        entity_id: str,
+        *,
+        new_status: str,
+        reason_code: str,
+        reason_summary: str,
+        evidence_refs: list[dict],
+        source: str,
+        actor: str,
+        metadata: dict | None = None,
+    ) -> None:
+        async with StateDB() as db:
+            await db.update_status(
+                entity_type,
+                entity_id,
+                new_status=new_status,
+                reason_code=reason_code,
+                reason_summary=reason_summary,
+                evidence_refs=evidence_refs,
+                source=source,
+                actor=actor,
+                metadata=metadata,
+            )
+
+    async def list_sessions_for_invocation(self, invocation_id: str) -> list[dict[str, Any]]:
+        async with StateDB() as db:
+            return await db.list_sessions_for_invocation(invocation_id)
+
+
+# ---------------------------------------------------------------------------
+# Batched write helpers — group related DB ops that must be atomic per caller
+# ---------------------------------------------------------------------------
+
+
+async def create_skipped_run(
+    svc: SchedulerStateService,
+    *,
+    run_id: str,
+    schedule: dict[str, Any],
+    trigger_context: dict[str, Any],
+    now: float,
+    reason_code: str,
+    reason_summary: str,
+    metadata: dict[str, Any],
+) -> None:
+    """Create a skipped schedule_run record and its status event."""
+    sid = schedule["id"]
+    await svc.create_schedule_run(
+        {
+            "id": run_id,
+            "schedule_id": sid,
+            "trigger_context": trigger_context,
+            "action_kind": schedule["action_kind"],
+            "action_args": [],
+            "status": "skipped",
+            "fired_at": now,
+        }
+    )
+    await svc.update_status(
+        "schedule_run",
+        run_id,
+        new_status="skipped",
+        reason_code=reason_code,
+        reason_summary=reason_summary,
+        evidence_refs=[{"kind": "schedule", "id": sid}],
+        source="system",
+        actor=sid,
+        metadata=metadata,
+    )
+
+
+async def resolve_invocation_terminal(
+    svc: SchedulerStateService,
+    invocation_id: str,
+    *,
+    fallback_status: str,
+    exit_code: int | None = None,
+    exception: BaseException | None = None,
+) -> tuple[str, str, str, list[dict], dict]:
+    """Resolve terminal invocation status from child sessions."""
+    sessions = await svc.list_sessions_for_invocation(invocation_id)
+    child_statuses = [str(s.get("status") or "") for s in sessions]
+    evidence_refs = [{"kind": "session", "id": s["id"]} for s in sessions if s.get("id")]
+    metadata: dict = {"child_statuses": child_statuses}
+    if exit_code is not None:
+        metadata["exit_code"] = exit_code
+    if exception is not None:
+        metadata["exception_class"] = type(exception).__name__
+
+    if child_statuses:
+        if any(s == "timed_out" for s in child_statuses):
+            return (
+                "timed_out",
+                RunReasons.TIMED_OUT_DEADLINE,
+                "Invocation timed out because at least one child session timed out.",
+                evidence_refs,
+                metadata,
+            )
+        if any(s == "failed" for s in child_statuses):
+            return (
+                "failed",
+                RunReasons.FAILED_EXCEPTION,
+                "Invocation failed because at least one child session failed.",
+                evidence_refs,
+                metadata,
+            )
+        if any(s == "aborted" for s in child_statuses):
+            aborted_reasons = {
+                str(sess.get("status_reason_code") or "")
+                for sess in sessions
+                if sess.get("status") == "aborted"
+            }
+            if RunReasons.CANCELLED_SIGINT in aborted_reasons:
+                reason_code = RunReasons.CANCELLED_SIGINT
+                reason_summary = "Invocation was interrupted (SIGINT) because a child session was."
+            else:
+                reason_code = RunReasons.ABORTED_USER
+                reason_summary = (
+                    "Invocation was aborted because at least one child session was aborted."
+                )
+            return ("aborted", reason_code, reason_summary, evidence_refs, metadata)
+        if any(s == "cancelled" for s in child_statuses):
+            return (
+                "cancelled",
+                RunReasons.CANCELLED_SYSTEM,
+                "Invocation was cancelled because at least one child session was cancelled.",
+                evidence_refs,
+                metadata,
+            )
+        if all(s == "completed" for s in child_statuses):
+            return (
+                "completed",
+                RunReasons.COMPLETED_OK,
+                "All child sessions completed successfully.",
+                evidence_refs,
+                metadata,
+            )
+
+    if fallback_status == "completed":
+        return (
+            "completed",
+            RunReasons.COMPLETED_OK,
+            "Invocation process completed successfully.",
+            evidence_refs,
+            metadata,
+        )
+    if fallback_status == "timed_out":
+        return (
+            "timed_out",
+            RunReasons.TIMED_OUT_DEADLINE,
+            "Invocation process exceeded its deadline.",
+            evidence_refs,
+            metadata,
+        )
+    if fallback_status == "aborted":
+        return (
+            "aborted",
+            RunReasons.ABORTED_USER,
+            "Invocation process was aborted.",
+            evidence_refs,
+            metadata,
+        )
+    if fallback_status == "cancelled":
+        return (
+            "cancelled",
+            RunReasons.CANCELLED_SYSTEM,
+            "Invocation process was cancelled by the runtime.",
+            evidence_refs,
+            metadata,
+        )
+    if exception is not None:
+        return (
+            "failed",
+            RunReasons.FAILED_EXCEPTION,
+            f"{type(exception).__name__}: {exception}",
+            evidence_refs,
+            metadata,
+        )
+    if exit_code is not None and exit_code != 0:
+        return (
+            "failed",
+            RunReasons.FAILED_EXIT_NONZERO,
+            f"Invocation process failed with exit code {exit_code}.",
+            evidence_refs,
+            metadata,
+        )
+    return (
+        "failed",
+        RunReasons.FAILED_EXCEPTION,
+        "Invocation process failed.",
+        evidence_refs,
+        metadata,
+    )
+
+
+# Singleton for production use
+default_scheduler_state: SchedulerStateService = _DBSchedulerStateService()

--- a/tests/apps_studio_server/test_audit_remediation.py
+++ b/tests/apps_studio_server/test_audit_remediation.py
@@ -473,7 +473,9 @@ class TestInvocationReasonAggregation:
         monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", tmp_path / "state.db")
         from lionagi.state.db import StateDB
         from lionagi.state.reasons import RunReasons
-        from lionagi.studio.scheduler.engine import _resolve_invocation_terminal
+        from lionagi.studio.services.scheduler_state import (
+            resolve_invocation_terminal as _resolve_invocation_terminal,
+        )
 
         async with StateDB() as db:
             await self._seed_aborted_child(
@@ -491,7 +493,9 @@ class TestInvocationReasonAggregation:
         monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", tmp_path / "state.db")
         from lionagi.state.db import StateDB
         from lionagi.state.reasons import RunReasons
-        from lionagi.studio.scheduler.engine import _resolve_invocation_terminal
+        from lionagi.studio.services.scheduler_state import (
+            resolve_invocation_terminal as _resolve_invocation_terminal,
+        )
 
         async with StateDB() as db:
             await self._seed_aborted_child(
@@ -510,7 +514,9 @@ class TestInvocationReasonAggregation:
         monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", tmp_path / "state.db")
         from lionagi.state.db import StateDB
         from lionagi.state.reasons import RunReasons
-        from lionagi.studio.scheduler.engine import _resolve_invocation_terminal
+        from lionagi.studio.services.scheduler_state import (
+            resolve_invocation_terminal as _resolve_invocation_terminal,
+        )
 
         async with StateDB() as db:
             await db.create_invocation(

--- a/tests/studio/test_scheduler_engine.py
+++ b/tests/studio/test_scheduler_engine.py
@@ -160,11 +160,11 @@ async def test_fire_happy_path_records_invocation_and_run():
 
     with (
         patch(
-            "lionagi.studio.scheduler.engine.build_argv",
+            "lionagi.studio.scheduler.subprocess.build_argv",
             return_value=(["uv", "run", "li", "agent", "ping"], None),
         ),
         patch(
-            "lionagi.studio.scheduler.engine.spawn_and_wait",
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
@@ -190,11 +190,11 @@ async def test_fire_nonzero_exit_records_failed_status():
 
     with (
         patch(
-            "lionagi.studio.scheduler.engine.build_argv",
+            "lionagi.studio.scheduler.subprocess.build_argv",
             return_value=(["uv", "run", "li", "agent", "ping"], None),
         ),
         patch(
-            "lionagi.studio.scheduler.engine.spawn_and_wait",
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
             new=AsyncMock(return_value=(1, "error text")),
         ),
     ):
@@ -220,11 +220,11 @@ async def test_fire_build_argv_exception_records_failed_run():
 
     with (
         patch(
-            "lionagi.studio.scheduler.engine.build_argv",
+            "lionagi.studio.scheduler.subprocess.build_argv",
             side_effect=ValueError("bad action_kind"),
         ),
         patch(
-            "lionagi.studio.scheduler.engine.spawn_and_wait",
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
             new=AsyncMock(),
         ) as mock_spawn,
     ):
@@ -249,11 +249,11 @@ async def test_fire_cancellation_records_cancelled_run():
 
     with (
         patch(
-            "lionagi.studio.scheduler.engine.build_argv",
+            "lionagi.studio.scheduler.subprocess.build_argv",
             return_value=(["uv", "run", "li", "agent", "ping"], None),
         ),
         patch(
-            "lionagi.studio.scheduler.engine.spawn_and_wait",
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
             new=AsyncMock(side_effect=asyncio.CancelledError()),
         ),
     ):
@@ -278,11 +278,11 @@ async def test_fire_inner_exception_records_failed_and_does_not_reraise():
 
     with (
         patch(
-            "lionagi.studio.scheduler.engine.build_argv",
+            "lionagi.studio.scheduler.subprocess.build_argv",
             return_value=(["uv", "run", "li", "agent", "ping"], None),
         ),
         patch(
-            "lionagi.studio.scheduler.engine.spawn_and_wait",
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
             new=AsyncMock(side_effect=RuntimeError("unexpected")),
         ),
     ):
@@ -307,11 +307,11 @@ async def test_fire_chain_depth_0_tracks_running():
 
     with (
         patch(
-            "lionagi.studio.scheduler.engine.build_argv",
+            "lionagi.studio.scheduler.subprocess.build_argv",
             return_value=(["uv", "run", "li", "agent", "ping"], None),
         ),
         patch(
-            "lionagi.studio.scheduler.engine.spawn_and_wait",
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
@@ -331,11 +331,11 @@ async def test_fire_chain_depth_nonzero_does_not_track_running():
 
     with (
         patch(
-            "lionagi.studio.scheduler.engine.build_argv",
+            "lionagi.studio.scheduler.subprocess.build_argv",
             return_value=(["uv", "run", "li", "agent", "ping"], None),
         ),
         patch(
-            "lionagi.studio.scheduler.engine.spawn_and_wait",
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
@@ -376,11 +376,11 @@ async def test_fire_on_success_chain_fires():
 
     with (
         patch(
-            "lionagi.studio.scheduler.engine.build_argv",
+            "lionagi.studio.scheduler.subprocess.build_argv",
             return_value=(["uv", "run", "li", "agent", "ping"], None),
         ),
         patch(
-            "lionagi.studio.scheduler.engine.spawn_and_wait",
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
             new=AsyncMock(return_value=(0, "")),
         ),
     ):

--- a/tests/studio/test_scheduler_engine.py
+++ b/tests/studio/test_scheduler_engine.py
@@ -1,0 +1,513 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for SchedulerEngine._fire() and helpers via a mocked service."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _minimal_schedule(**overrides) -> dict:
+    base = {
+        "id": "sched-001",
+        "name": "test-sched",
+        "trigger_type": "cron",
+        "cron_expr": "0 * * * *",
+        "action_kind": "agent",
+        "action_model": "gpt-4.1-mini",
+        "action_prompt": "ping",
+        "action_agent": None,
+        "action_playbook": None,
+        "action_project": None,
+        "action_extra_args": [],
+        "action_flow_yaml": None,
+        "on_success": None,
+        "on_fail": None,
+        "overlap_policy": "skip",
+        "missed_fire_policy": "skip",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_svc() -> AsyncMock:
+    """Return an AsyncMock that satisfies SchedulerStateService."""
+    svc = AsyncMock()
+    svc.get_schedule = AsyncMock(return_value=None)
+    svc.list_schedules = AsyncMock(return_value=[])
+    svc.update_schedule = AsyncMock()
+    svc.create_schedule_run = AsyncMock()
+    svc.update_schedule_run = AsyncMock()
+    svc.create_invocation = AsyncMock()
+    svc.update_invocation = AsyncMock()
+    svc.update_status = AsyncMock()
+    svc.list_sessions_for_invocation = AsyncMock(return_value=[])
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# resolve_invocation_terminal tests (pure-logic, no DB)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_terminal_completed_ok():
+    from lionagi.studio.services.scheduler_state import resolve_invocation_terminal
+
+    svc = _make_svc()
+    svc.list_sessions_for_invocation.return_value = [
+        {"id": "s1", "status": "completed"},
+        {"id": "s2", "status": "completed"},
+    ]
+    status, rc, rs, refs, meta = await resolve_invocation_terminal(
+        svc, "inv-1", fallback_status="completed"
+    )
+    assert status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_resolve_terminal_failed_child():
+    from lionagi.studio.services.scheduler_state import resolve_invocation_terminal
+
+    svc = _make_svc()
+    svc.list_sessions_for_invocation.return_value = [
+        {"id": "s1", "status": "completed"},
+        {"id": "s2", "status": "failed"},
+    ]
+    status, rc, rs, refs, meta = await resolve_invocation_terminal(
+        svc, "inv-1", fallback_status="failed"
+    )
+    assert status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_resolve_terminal_timed_out_child():
+    from lionagi.studio.services.scheduler_state import resolve_invocation_terminal
+
+    svc = _make_svc()
+    svc.list_sessions_for_invocation.return_value = [{"id": "s1", "status": "timed_out"}]
+    status, *_ = await resolve_invocation_terminal(svc, "inv-1", fallback_status="completed")
+    assert status == "timed_out"
+
+
+@pytest.mark.asyncio
+async def test_resolve_terminal_no_sessions_fallback_completed():
+    from lionagi.studio.services.scheduler_state import resolve_invocation_terminal
+
+    svc = _make_svc()
+    svc.list_sessions_for_invocation.return_value = []
+    status, *_ = await resolve_invocation_terminal(svc, "inv-1", fallback_status="completed")
+    assert status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_resolve_terminal_no_sessions_fallback_failed_exception():
+    from lionagi.studio.services.scheduler_state import resolve_invocation_terminal
+
+    svc = _make_svc()
+    svc.list_sessions_for_invocation.return_value = []
+    exc = RuntimeError("boom")
+    status, rc, rs, refs, meta = await resolve_invocation_terminal(
+        svc, "inv-1", fallback_status="failed", exception=exc
+    )
+    assert status == "failed"
+    assert "RuntimeError" in rs
+
+
+@pytest.mark.asyncio
+async def test_resolve_terminal_nonzero_exit():
+    from lionagi.studio.services.scheduler_state import resolve_invocation_terminal
+
+    svc = _make_svc()
+    svc.list_sessions_for_invocation.return_value = []
+    status, rc, rs, refs, meta = await resolve_invocation_terminal(
+        svc, "inv-1", fallback_status="failed", exit_code=1
+    )
+    assert status == "failed"
+    assert "1" in rs
+
+
+@pytest.mark.asyncio
+async def test_resolve_terminal_cancelled():
+    from lionagi.studio.services.scheduler_state import resolve_invocation_terminal
+
+    svc = _make_svc()
+    svc.list_sessions_for_invocation.return_value = []
+    status, *_ = await resolve_invocation_terminal(svc, "inv-1", fallback_status="cancelled")
+    assert status == "cancelled"
+
+
+# ---------------------------------------------------------------------------
+# SchedulerEngine._fire() — happy path (exit_code=0)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fire_happy_path_records_invocation_and_run():
+    """_fire() creates an invocation, schedule_run, updates status and schedule."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.engine.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.engine.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await engine._fire(schedule, "run-001", trigger_context={"scheduled": True})
+
+    svc.create_invocation.assert_awaited_once()
+    svc.create_schedule_run.assert_awaited_once()
+    svc.update_schedule_run.assert_awaited_once()
+    # update_status called for schedule_run AND invocation
+    assert svc.update_status.await_count == 3  # running + completed + invocation
+    svc.update_invocation.assert_awaited_once()
+    svc.update_schedule.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fire_nonzero_exit_records_failed_status():
+    """Non-zero exit code produces a 'failed' schedule_run status."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.engine.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.engine.spawn_and_wait",
+            new=AsyncMock(return_value=(1, "error text")),
+        ),
+    ):
+        await engine._fire(schedule, "run-002", trigger_context={"scheduled": True})
+
+    # Find the update_status call for "schedule_run" with new_status="failed"
+    failed_calls = [
+        c
+        for c in svc.update_status.await_args_list
+        if c.args[0] == "schedule_run" and c.kwargs.get("new_status") == "failed"
+    ]
+    assert failed_calls, "Expected update_status('schedule_run', ..., new_status='failed')"
+
+
+@pytest.mark.asyncio
+async def test_fire_build_argv_exception_records_failed_run():
+    """build_argv raising an exception records a failed run without calling spawn_and_wait."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.engine.build_argv",
+            side_effect=ValueError("bad action_kind"),
+        ),
+        patch(
+            "lionagi.studio.scheduler.engine.spawn_and_wait",
+            new=AsyncMock(),
+        ) as mock_spawn,
+    ):
+        await engine._fire(schedule, "run-003", trigger_context={"scheduled": True})
+
+    mock_spawn.assert_not_awaited()
+    svc.create_schedule_run.assert_awaited_once()
+    failed_calls = [
+        c for c in svc.update_status.await_args_list if c.kwargs.get("new_status") == "failed"
+    ]
+    assert failed_calls
+
+
+@pytest.mark.asyncio
+async def test_fire_cancellation_records_cancelled_run():
+    """CancelledError propagates after recording a 'cancelled' run."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.engine.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.engine.spawn_and_wait",
+            new=AsyncMock(side_effect=asyncio.CancelledError()),
+        ),
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await engine._fire(schedule, "run-004", trigger_context={"scheduled": True})
+
+    svc.update_schedule_run.assert_awaited()
+    cancelled_calls = [
+        c for c in svc.update_schedule_run.await_args_list if c.kwargs.get("status") == "cancelled"
+    ]
+    assert cancelled_calls
+
+
+@pytest.mark.asyncio
+async def test_fire_inner_exception_records_failed_and_does_not_reraise():
+    """Unexpected exception inside the main try block is caught, recorded, and swallowed."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.engine.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.engine.spawn_and_wait",
+            new=AsyncMock(side_effect=RuntimeError("unexpected")),
+        ),
+    ):
+        # Should not raise
+        await engine._fire(schedule, "run-005", trigger_context={"scheduled": True})
+
+    failed_calls = [
+        c for c in svc.update_status.await_args_list if c.kwargs.get("new_status") == "failed"
+    ]
+    assert failed_calls
+
+
+@pytest.mark.asyncio
+async def test_fire_chain_depth_0_tracks_running():
+    """chain_depth=0 adds the schedule to _running and removes it on completion."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+    sid = schedule["id"]
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.engine.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.engine.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await engine._fire(schedule, "run-006", trigger_context={}, chain_depth=0)
+
+    assert sid not in engine._running
+
+
+@pytest.mark.asyncio
+async def test_fire_chain_depth_nonzero_does_not_track_running():
+    """chain_depth>0 does not modify _running."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.engine.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.engine.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await engine._fire(
+            schedule, "run-007", trigger_context={}, chain_depth=1, chain_parent_id="run-006"
+        )
+
+    assert schedule["id"] not in engine._running
+
+
+@pytest.mark.asyncio
+async def test_fire_on_success_chain_fires():
+    """on_success chain action causes a recursive _fire() call."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(
+        on_success={"kind": "agent", "prompt": "chained prompt", "model": "gpt-4.1-mini"}
+    )
+
+    fire_calls: list[tuple] = []
+    original_fire = engine._fire
+
+    async def _patched_fire(sched, run_id, *, trigger_context, chain_parent_id=None, chain_depth=0):
+        fire_calls.append((sched["id"], chain_depth))
+        if chain_depth > 0:
+            return
+        return await original_fire(
+            sched,
+            run_id,
+            trigger_context=trigger_context,
+            chain_parent_id=chain_parent_id,
+            chain_depth=chain_depth,
+        )
+
+    engine._fire = _patched_fire  # type: ignore[method-assign]
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.engine.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.engine.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await original_fire(schedule, "run-chain", trigger_context={}, chain_depth=0)
+
+    # The chain should have been triggered
+    chained = [c for c in fire_calls if c[1] == 1]
+    assert chained, "Expected a chained _fire() call at depth=1"
+
+
+# ---------------------------------------------------------------------------
+# SchedulerEngine.fire_now() — delegates through service
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fire_now_returns_run_id_when_schedule_found():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.get_schedule.return_value = _minimal_schedule()
+    engine = SchedulerEngine(svc=svc)
+
+    with patch.object(engine, "_tracked_fire", return_value=MagicMock()):
+        run_id = await engine.fire_now("sched-001")
+
+    assert run_id is not None
+    assert len(run_id) == 12
+
+
+@pytest.mark.asyncio
+async def test_fire_now_returns_none_when_schedule_missing():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.get_schedule.return_value = None
+    engine = SchedulerEngine(svc=svc)
+
+    run_id = await engine.fire_now("nonexistent")
+    assert run_id is None
+
+
+# ---------------------------------------------------------------------------
+# _maybe_fire() tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_maybe_fire_skips_overlap_and_records_skipped_run():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(overlap_policy="skip")
+    engine._running[schedule["id"]] = "existing-run"
+
+    with patch.object(engine, "_tracked_fire") as mock_tracked:
+        await engine._maybe_fire(schedule, now=1000.0)
+
+    mock_tracked.assert_not_called()
+    svc.create_schedule_run.assert_awaited_once()
+    # update_status called for the skipped run
+    skipped_calls = [
+        c for c in svc.update_status.await_args_list if c.kwargs.get("new_status") == "skipped"
+    ]
+    assert skipped_calls
+
+
+@pytest.mark.asyncio
+async def test_maybe_fire_fires_when_no_overlap():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(overlap_policy="skip")
+    # no entry in _running
+
+    with patch.object(engine, "_tracked_fire") as mock_tracked:
+        await engine._maybe_fire(schedule, now=1000.0)
+
+    mock_tracked.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# create_skipped_run helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_skipped_run_calls_svc_create_and_update_status():
+    from lionagi.state.reasons import ScheduleReasons
+    from lionagi.studio.services.scheduler_state import create_skipped_run
+
+    svc = _make_svc()
+    schedule = _minimal_schedule()
+    await create_skipped_run(
+        svc,
+        run_id="skip-001",
+        schedule=schedule,
+        trigger_context={"skipped_overlap": True},
+        now=999.0,
+        reason_code=ScheduleReasons.SKIPPED_OVERLAP,
+        reason_summary="overlapped",
+        metadata={"overlap_policy": "skip"},
+    )
+    svc.create_schedule_run.assert_awaited_once()
+    svc.update_status.assert_awaited_once()
+    call = svc.update_status.await_args
+    assert call.kwargs["new_status"] == "skipped"
+
+
+# ---------------------------------------------------------------------------
+# SchedulerEngine construction — default vs injected service
+# ---------------------------------------------------------------------------
+
+
+def test_engine_uses_default_svc_when_none_provided():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+    from lionagi.studio.services.scheduler_state import _DBSchedulerStateService
+
+    engine = SchedulerEngine()
+    assert isinstance(engine._svc, _DBSchedulerStateService)
+
+
+def test_engine_uses_injected_svc():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    assert engine._svc is svc


### PR DESCRIPTION
## Summary

- Extracts all 14 inline `async with StateDB()` contexts from `SchedulerEngine` into a `SchedulerStateService` protocol in `lionagi/studio/services/scheduler_state.py`, following the same service-layer pattern as the rest of the studio stack.
- `SchedulerEngine` now accepts an optional `svc` constructor argument (defaults to a DB-backed singleton), making `_fire()`, `_maybe_fire()`, `_record_missed_fire_skip()`, and `fire_now()` fully unit-testable without a live database.
- Moves `_resolve_invocation_terminal` (was a module-level function) and the skipped-run recording logic into typed service-layer helpers (`resolve_invocation_terminal`, `create_skipped_run`) in the new module.
- Adds 22 unit tests in `tests/studio/test_scheduler_engine.py` covering: happy path, non-zero exit, `build_argv` exception (pre-spawn), `CancelledError`, generic exception, chain depth tracking, `on_success` chaining, `fire_now`, `_maybe_fire` overlap skip, `create_skipped_run`, `resolve_invocation_terminal` status precedence, and service injection.

## Files changed

- `lionagi/studio/services/scheduler_state.py` — new service module
- `lionagi/studio/scheduler/engine.py` — refactored, no direct StateDB I/O
- `tests/studio/test_scheduler_engine.py` — 22 new unit tests (all pass, no DB required)

## Test plan

- [x] `uv run pytest tests/studio/test_scheduler_engine.py` — 22/22 pass
- [x] `uv run pytest tests/studio/ tests/cli/test_schedule_cli.py tests/cli/test_argv_parser_regression.py tests/cli/test_engine_cli.py tests/cli/test_engine_emission_diagnostics.py tests/state/` — 163 passed, 1 skipped (pre-existing studio-extra skip)
- [x] `uv run ruff check` — no issues
- [x] `uv run ruff format --check` — all files already formatted
- [x] Pre-commit hooks — all passed

Closes #1409

🤖 Generated with [Claude Code](https://claude.com/claude-code)