### PR TITLE
feat(operations): escalation request routing in ReactiveExecutor (#1253)

### DIFF
--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -523,6 +523,7 @@ class ReactiveExecutor(DependencyAwareExecutor):
         self._seen_reqs: set[int] = set()
         self._spawned_ids: set[Any] = set()
         self._result_sink: Any = None
+        self._escalated_ids: set[Any] = set()
 
     async def execute(self) -> dict[str, Any]:
         if not self.graph.is_acyclic():
@@ -536,7 +537,10 @@ class ReactiveExecutor(DependencyAwareExecutor):
         initial = [n for n in self.graph.internal_nodes.values() if isinstance(n, Operation)]
         self._running = True
         observer = self.session.observer
+        from lionagi.casts.emission import EscalationRequest  # noqa: PLC0415
+
         self.session.observe(self.spawn_type, self._on_bus_spawn)
+        self.session.observe(EscalationRequest, self._on_bus_escalation)
         try:
             async with create_task_group() as tg:
                 self._tg = tg
@@ -549,6 +553,7 @@ class ReactiveExecutor(DependencyAwareExecutor):
             self._running = False
             self._tg = None
             observer.unobserve(self._on_bus_spawn)
+            observer.unobserve(self._on_bus_escalation)
 
         completed_ops = [
             op_id for op_id in self.results.keys() if op_id not in self.skipped_operations
@@ -559,6 +564,7 @@ class ReactiveExecutor(DependencyAwareExecutor):
             "final_context": self.context.content,
             "skipped_operations": list(self.skipped_operations),
             "spawned_operations": self._spawn_count,
+            "escalated_operations": list(self._escalated_ids),
         }
         self._validate_execution_results(result)
         return result
@@ -577,7 +583,10 @@ class ReactiveExecutor(DependencyAwareExecutor):
 
         initial = [n for n in self.graph.internal_nodes.values() if isinstance(n, Operation)]
         observer = self.session.observer
+        from lionagi.casts.emission import EscalationRequest  # noqa: PLC0415
+
         self.session.observe(self.spawn_type, self._on_bus_spawn)
+        self.session.observe(EscalationRequest, self._on_bus_escalation)
         self._running = True
 
         async def _driver():
@@ -611,6 +620,7 @@ class ReactiveExecutor(DependencyAwareExecutor):
             self._tg = None
             self._result_sink = None
             observer.unobserve(self._on_bus_spawn)
+            observer.unobserve(self._on_bus_escalation)
             if not driver.done():  # early break / consumer close: tear down
                 driver.cancel()
                 with contextlib.suppress(asyncio.CancelledError, Exception):
@@ -624,8 +634,12 @@ class ReactiveExecutor(DependencyAwareExecutor):
             _CURRENT_OP.reset(token)
         if self._result_sink is not None:
             self._result_sink.send_nowait(self._make_event(node))
+        from lionagi.casts.emission import EscalationRequest  # noqa: PLC0415
+
         for req in _extract_spawn_requests(self.results.get(node.id), self.spawn_type):
             self._inject_request(req, emitter=node)
+        for req in _extract_spawn_requests(self.results.get(node.id), EscalationRequest):
+            self._schedule_escalation(req, emitter=node)
 
     def _make_event(self, node: Operation) -> FlowEvent:
         if node.id in self.skipped_operations:
@@ -646,6 +660,64 @@ class ReactiveExecutor(DependencyAwareExecutor):
         if not self._running:
             return
         self._inject_request(req, emitter=_CURRENT_OP.get())
+
+    async def _on_bus_escalation(self, req: Any, _ctx: Any) -> None:
+        if not self._running:
+            return
+        self._schedule_escalation(req, emitter=_CURRENT_OP.get())
+
+    def _schedule_escalation(self, req: Any, *, emitter: Operation | None) -> None:
+        """Consume an EscalationRequest: higher_tier re-spawns the op; give_up just signals."""
+        if id(req) in self._seen_reqs:
+            return
+        self._seen_reqs.add(id(req))
+
+        context = getattr(req, "context", {}) or {}
+        route = context.get("route", "higher_tier")
+
+        reason = getattr(req, "reason", "")
+        emitter_id = emitter.id if emitter is not None else None
+        op_id = str(emitter_id) if emitter_id is not None else ""
+        name = emitter.metadata.get("reference_id", op_id[:8]) if emitter is not None else ""
+
+        self._emit_node_escalated(op_id, name, reason, route, req)
+
+        if route == "higher_tier" and emitter is not None and self._tg is not None:
+            params = emitter.parameters if isinstance(emitter.parameters, dict) else {}
+            original_instr = params.get("instruction", "")
+            escalation_instr = f"[escalation] {reason}\nOriginal: {original_instr}"
+            child_params = {
+                **{k: v for k, v in params.items() if k != "instruction"},
+                "instruction": escalation_instr,
+            }
+            child = create_operation(emitter.operation, parameters=child_params)
+            child.metadata["escalated_from"] = op_id
+            if self._accept_node(child, emitter_id=emitter_id, independent=True):
+                self._escalated_ids.add(emitter_id)
+        else:
+            if emitter_id is not None:
+                self._escalated_ids.add(emitter_id)
+
+    def _emit_node_escalated(
+        self, op_id: str, name: str, reason: str, route: str, req: Any
+    ) -> None:
+        """Fire-and-forget NodeEscalated onto the session bus."""
+        try:
+            from lionagi.session.signal import NodeEscalated  # noqa: PLC0415
+
+            sig = NodeEscalated(
+                op_id=op_id,
+                name=name,
+                reason=reason,
+                route=route,
+                escalation_request=req,
+            )
+            loop = asyncio.get_running_loop()
+            loop.create_task(self.session.emit(sig))
+        except RuntimeError:
+            pass  # no running loop — tests / sync contexts
+        except Exception:  # noqa: BLE001, S110
+            pass  # best-effort; never break the escalation path
 
     def _inject_request(self, req: Any, *, emitter: Operation | None) -> bool:
         if id(req) in self._seen_reqs:

--- a/tests/operations/test_escalation_routing.py
+++ b/tests/operations/test_escalation_routing.py
@@ -1,0 +1,291 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Escalation routing tests for ReactiveExecutor.
+
+Verifies that an EscalationRequest emitted by a node is consumed by the
+executor, drives the intended routing (higher_tier re-spawn / give_up),
+and emits NodeEscalated on the session bus.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from lionagi.casts.emission import EscalationRequest, SpawnRequest
+from lionagi.operations import Operation, flow
+from lionagi.operations.builder import OperationGraphBuilder
+from lionagi.operations.node import create_operation
+from lionagi.session.branch import Branch
+from lionagi.session.session import Session
+from lionagi.session.signal import NodeEscalated
+
+
+def _session(**ops):
+    session = Session()
+    branch = Branch(name="root")
+    session.include_branches(branch)
+    session.default_branch = branch
+    for name, fn in ops.items():
+        session.register_operation(name, fn)
+    return session
+
+
+# ---------------------------------------------------------------------------
+# higher_tier: re-spawns the op
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_escalation_higher_tier_spawns_child():
+    """An EscalationRequest with route=higher_tier causes a child op to be injected."""
+    executed: list[str] = []
+
+    async def cheap(**kw):
+        executed.append("cheap")
+        return EscalationRequest(reason="too hard", context={"route": "higher_tier"})
+
+    async def cheap_escalated(**kw):
+        executed.append("cheap_escalated")
+        return "done by higher tier"
+
+    session = _session(cheap=cheap)
+
+    # node_builder maps the escalation re-spawn -> cheap_escalated
+    def node_builder(req: Any, emitter: Operation) -> Operation:
+        return create_operation("cheap_escalated", parameters={})
+
+    # Register the op the re-spawned child will use
+    session.register_operation("cheap_escalated", cheap_escalated)
+
+    builder = OperationGraphBuilder()
+    builder.add_operation("cheap")
+    graph = builder.get_graph()
+
+    result = await flow(session, graph, reactive=True, node_builder=node_builder)
+
+    assert "cheap" in executed
+    # escalation re-spawn uses the default node builder path, so we need to
+    # check escalated_operations is populated and spawn_count reflects it.
+    assert len(result["escalated_operations"]) >= 1
+    assert result["spawned_operations"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_escalation_higher_tier_emits_node_escalated_signal():
+    """NodeEscalated is emitted on the session bus when higher_tier routing fires."""
+    escalated_signals: list[NodeEscalated] = []
+
+    async def cheap(**kw):
+        return EscalationRequest(reason="stuck", context={"route": "higher_tier"})
+
+    session = _session(cheap=cheap)
+    session.observe(NodeEscalated, handler=lambda s, _: escalated_signals.append(s))
+
+    builder = OperationGraphBuilder()
+    builder.add_operation("cheap")
+    graph = builder.get_graph()
+
+    await flow(session, graph, reactive=True)
+
+    # Give the event loop a tick to flush fire-and-forget tasks
+    await asyncio.sleep(0)
+
+    assert len(escalated_signals) >= 1
+    sig = escalated_signals[0]
+    assert sig.route == "higher_tier"
+    assert "stuck" in sig.reason
+    assert isinstance(sig.escalation_request, EscalationRequest)
+
+
+# ---------------------------------------------------------------------------
+# give_up: signals without re-spawning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_escalation_give_up_does_not_spawn():
+    """An EscalationRequest with route=give_up signals but does NOT inject a new op."""
+    executed: list[str] = []
+
+    async def overloaded(**kw):
+        executed.append("overloaded")
+        return EscalationRequest(reason="beyond capacity", context={"route": "give_up"})
+
+    session = _session(overloaded=overloaded)
+
+    builder = OperationGraphBuilder()
+    builder.add_operation("overloaded")
+    graph = builder.get_graph()
+
+    result = await flow(session, graph, reactive=True)
+
+    assert "overloaded" in executed
+    # give_up must NOT spawn new ops
+    assert result["spawned_operations"] == 0
+    # but the op should be in escalated_operations
+    assert len(result["escalated_operations"]) >= 1
+
+
+@pytest.mark.asyncio
+async def test_escalation_give_up_emits_node_escalated_signal():
+    """NodeEscalated is emitted on the bus even for give_up route."""
+    escalated_signals: list[NodeEscalated] = []
+
+    async def give_up_op(**kw):
+        return EscalationRequest(reason="cannot proceed", context={"route": "give_up"})
+
+    session = _session(give_up_op=give_up_op)
+    session.observe(NodeEscalated, handler=lambda s, _: escalated_signals.append(s))
+
+    builder = OperationGraphBuilder()
+    builder.add_operation("give_up_op")
+    graph = builder.get_graph()
+
+    await flow(session, graph, reactive=True)
+    await asyncio.sleep(0)
+
+    assert len(escalated_signals) >= 1
+    sig = escalated_signals[0]
+    assert sig.route == "give_up"
+    assert isinstance(sig.escalation_request, EscalationRequest)
+
+
+# ---------------------------------------------------------------------------
+# Default route (no explicit route key) → higher_tier
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_escalation_default_route_is_higher_tier():
+    """EscalationRequest without a route key in context defaults to higher_tier."""
+    escalated_signals: list[NodeEscalated] = []
+
+    async def unsure(**kw):
+        return EscalationRequest(reason="unsure")  # no context.route
+
+    session = _session(unsure=unsure)
+    session.observe(NodeEscalated, handler=lambda s, _: escalated_signals.append(s))
+
+    builder = OperationGraphBuilder()
+    builder.add_operation("unsure")
+    graph = builder.get_graph()
+
+    result = await flow(session, graph, reactive=True)
+    await asyncio.sleep(0)
+
+    assert len(escalated_signals) >= 1
+    assert escalated_signals[0].route == "higher_tier"
+    assert result["spawned_operations"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Deduplication: same EscalationRequest object only processed once
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_escalation_request_deduplicated():
+    """The same EscalationRequest object is not processed twice."""
+    escalated_signals: list[NodeEscalated] = []
+    call_count = {"n": 0}
+
+    req = EscalationRequest(reason="once", context={"route": "give_up"})
+
+    async def emitter(**kw):
+        call_count["n"] += 1
+        return req  # same object reference each time
+
+    session = _session(emitter=emitter)
+    session.observe(NodeEscalated, handler=lambda s, _: escalated_signals.append(s))
+
+    builder = OperationGraphBuilder()
+    builder.add_operation("emitter")
+    graph = builder.get_graph()
+
+    await flow(session, graph, reactive=True)
+    await asyncio.sleep(0)
+
+    # NodeEscalated fires at most once per unique EscalationRequest object
+    assert len(escalated_signals) <= 1
+
+
+# ---------------------------------------------------------------------------
+# NodeEscalated.escalation_request is stored in a named field, not Signal.data
+# ---------------------------------------------------------------------------
+
+
+def test_node_escalated_request_not_in_data_field():
+    """escalation_request lives in a named field, not Signal.data, so it can't re-trigger the bus."""
+    req = EscalationRequest(reason="test")
+    sig = NodeEscalated(op_id="x", name="x", reason="test", route="give_up", escalation_request=req)
+    assert not isinstance(sig.data, EscalationRequest)
+    assert sig.escalation_request is req
+
+
+# ---------------------------------------------------------------------------
+# SpawnRequest and EscalationRequest coexist without interference
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_spawn_and_escalation_coexist():
+    """SpawnRequest and EscalationRequest are both consumed without mutual interference."""
+    spawn_signal_received: list[bool] = []
+    escalation_signal_received: list[NodeEscalated] = []
+
+    async def both_emitter(**kw):
+        # Return a SpawnRequest — EscalationRequest is tested separately below
+        return SpawnRequest(instruction="follow-up", independent=True)
+
+    async def follow_up(**kw):
+        return EscalationRequest(reason="needs help", context={"route": "give_up"})
+
+    session = _session(both_emitter=both_emitter, follow_up=follow_up)
+    session.observe(NodeEscalated, handler=lambda s, _: escalation_signal_received.append(s))
+
+    def node_builder(req: SpawnRequest, emitter: Operation) -> Operation:
+        return create_operation("follow_up", parameters={})
+
+    builder = OperationGraphBuilder()
+    builder.add_operation("both_emitter")
+    graph = builder.get_graph()
+
+    result = await flow(session, graph, reactive=True, node_builder=node_builder)
+    await asyncio.sleep(0)
+
+    # spawner spawned follow_up, which in turn escalated
+    assert result["spawned_operations"] >= 1
+    assert len(escalation_signal_received) >= 1
+    assert len(result["escalated_operations"]) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Bus-based emission path (observe fires _on_bus_escalation)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_escalation_via_result_extraction():
+    """EscalationRequest returned as a direct result is extracted and routed."""
+    escalated_signals: list[NodeEscalated] = []
+
+    async def stuck(**kw):
+        return EscalationRequest(reason="extracted-from-result", context={"route": "give_up"})
+
+    session = _session(stuck=stuck)
+    session.observe(NodeEscalated, handler=lambda s, _: escalated_signals.append(s))
+
+    builder = OperationGraphBuilder()
+    builder.add_operation("stuck")
+    graph = builder.get_graph()
+
+    result = await flow(session, graph, reactive=True)
+    await asyncio.sleep(0)
+
+    assert len(result["escalated_operations"]) >= 1
+    assert len(escalated_signals) >= 1
+    assert escalated_signals[0].route == "give_up"


### PR DESCRIPTION
## Summary

The escalation contract (`EscalationRequest` + `NodeEscalated`) was already on `main`. This PR adds the **routing** — the consumption side that makes the contract do something inside a running reactive flow.

- `_on_bus_escalation` subscribed in `execute()` and `execute_stream()` (mirrors `_on_bus_spawn`)
- `_schedule_escalation` consumes an `EscalationRequest`: reads `context["route"]` (default `"higher_tier"`)
  - `higher_tier`: re-spawns the emitting op as an independent child with the escalation reason prepended to its instruction, via `_accept_node` (reuses the existing spawn injection machinery)
  - `give_up`: emits `NodeEscalated` only, no re-spawn
- `_emit_node_escalated`: fire-and-forget `NodeEscalated` onto the session bus (same pattern as `_emit_node_spawned`)
- `_run_tracked` also extracts `EscalationRequest` objects from operation results (same path as `SpawnRequest` extraction)
- `execute()` result dict gains `"escalated_operations"` key (list of emitter op ids)
- Deduplication via `_seen_reqs` prevents double-processing

## Test plan

- [x] `test_escalation_higher_tier_spawns_child` — `higher_tier` route causes a child op to be injected
- [x] `test_escalation_higher_tier_emits_node_escalated_signal` — `NodeEscalated` fires on the bus
- [x] `test_escalation_give_up_does_not_spawn` — `give_up` route produces zero spawn count
- [x] `test_escalation_give_up_emits_node_escalated_signal` — signal still fires
- [x] `test_escalation_default_route_is_higher_tier` — missing `route` key defaults to `higher_tier`
- [x] `test_escalation_request_deduplicated` — same object reference only triggers one `NodeEscalated`
- [x] `test_node_escalated_request_not_in_data_field` — `Signal.data` is not an `EscalationRequest` (prevents re-triggering the bus handler)
- [x] `test_spawn_and_escalation_coexist` — `SpawnRequest` and `EscalationRequest` handled independently
- [x] `test_escalation_via_result_extraction` — extraction from operation result (not only bus)
- [x] Full `tests/operations/` suite: **491 passed** (pre-existing), **559 passed** combined with session/orchestration
- [x] `ruff check lionagi/ tests/` — clean
- [x] `ruff format --check lionagi/ tests/` — clean
- [x] All pre-commit hooks pass

Closes #1253

🤖 Generated with [Claude Code](https://claude.com/claude-code)