### PR TITLE
feat(engines): worker tool enrichment + mechanical-repair efficiency (#1425 #1438)

### DIFF
--- a/lionagi/engines/coding.py
+++ b/lionagi/engines/coding.py
@@ -33,6 +33,7 @@ __all__ = (
     "TestsRan",
     "VerifyResult",
     "CodeResultRecorded",
+    "AutoRepairApplied",
     "WorkAborted",
     "WorkerHeartbeat",
     "WorkerActivity",
@@ -180,6 +181,24 @@ class WorkerActivity(EngineEvent):
 
     path: str = Field(description="Workspace-relative path that changed.")
     elapsed_s: float = Field(description="Seconds since the run started.")
+
+
+class AutoRepairApplied(EngineEvent):
+    """Emitted when the harness auto-applies a repair command before a test gate.
+
+    Distinct from a worker fix round: the worker produced the change; the harness
+    normalized it mechanically (e.g. ``cargo fmt --all``).  The dataset records
+    both so analysis can separate worker-produced vs harness-normalized diffs.
+    """
+
+    cmd: str = Field(description="The auto-repair command that was run.")
+    files: list[str] = Field(
+        default_factory=list,
+        description="Workspace-relative paths whose mtime changed after the command.",
+    )
+    round: int = Field(
+        default=0, description="Fix-loop round this repair belongs to (0 = first pass)."
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -462,6 +481,13 @@ class CodingEngine(Engine):
         strict_spec: bool = False,
         heartbeat_interval_s: float | None = 30.0,
         stage_timeout_s: float | None = None,
+        # per-stage tool grants (worker only; judge/plan/verify excluded)
+        worker_extra_tools: tuple[str, ...] = (),
+        worker_mcp_servers: list[str] | None = None,
+        worker_extra_prompt: str | None = None,
+        # mechanical-repair efficiency
+        auto_repair_cmds: list[str] | None = None,
+        fast_test_cmd: str | list[str] | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -477,6 +503,11 @@ class CodingEngine(Engine):
         self.strict_spec = strict_spec
         self.heartbeat_interval_s = heartbeat_interval_s
         self.stage_timeout_s = stage_timeout_s
+        self.worker_extra_tools = tuple(worker_extra_tools)
+        self.worker_mcp_servers = list(worker_mcp_servers) if worker_mcp_servers else None
+        self.worker_extra_prompt = worker_extra_prompt
+        self.auto_repair_cmds = list(auto_repair_cmds) if auto_repair_cmds else []
+        self.fast_test_cmd = fast_test_cmd
 
     # -- lifecycle ------------------------------------------------------------
 
@@ -616,15 +647,18 @@ class CodingEngine(Engine):
     async def _implement(self, run: CodingRun, plan: WorkPlanned) -> ChangeProposed | None:
         emits = (ChangeProposed,)
         before = len(run.events_of(ChangeProposed))
+        all_worker_tools = self.coding_tools + self.worker_extra_tools
         async with run._sem:
             agent = await run.make_agent(
                 self.implement_role,
                 name="implement",
                 model=self.model_for("implement"),
-                tools=self.coding_tools,
-                permissions=self.implement_permissions if self.coding_tools else None,
+                tools=all_worker_tools,
+                permissions=self.implement_permissions if all_worker_tools else None,
                 cwd=run.workspace,
                 emits=emits,
+                mcp_servers=self.worker_mcp_servers,
+                extra_prompt=self.worker_extra_prompt,
             )
             wrapped = self._wrap_turn_timeout(agent, run)
             heartbeat_task = self._start_heartbeat(run, stage="implement")
@@ -645,8 +679,55 @@ class CodingEngine(Engine):
         run._implementer = wrapped  # reused by the fix loop — same branch, more turns
         return run.last(ChangeProposed)
 
+    async def _apply_auto_repairs(
+        self, run: CodingRun, *, round_no: int
+    ) -> list[AutoRepairApplied]:
+        """Run each auto_repair_cmd in sequence; emit AutoRepairApplied per command.
+
+        Returns the list of events emitted.  Errors are notified but never raise
+        — a failed auto-repair command is surfaced as a notification, not a crash.
+        """
+        if not self.auto_repair_cmds:
+            return []
+        applied: list[AutoRepairApplied] = []
+        ws = Path(run.workspace)
+        for raw_cmd in self.auto_repair_cmds:
+            # Snapshot mtimes before running so we can report changed files.
+            before_mtimes: dict[str, float] = {}
+            try:
+                for p in ws.rglob("*"):
+                    if p.is_file():
+                        before_mtimes[str(p)] = p.stat().st_mtime
+            except Exception:  # noqa: BLE001
+                logger.debug("auto_repair mtime snapshot failed", exc_info=True)
+            cmd, shell = _resolve_cmd(raw_cmd)
+            result = await run_sync(_subprocess_sync, cmd, shell, 120.0, run.workspace)
+            if int(result.get("returncode", -1)) != 0:
+                run.notify(
+                    "auto_repair_failed",
+                    cmd=raw_cmd,
+                    returncode=result.get("returncode"),
+                    round=round_no,
+                )
+                continue
+            changed: list[str] = []
+            try:
+                for p in ws.rglob("*"):
+                    if p.is_file():
+                        key = str(p)
+                        if before_mtimes.get(key) != p.stat().st_mtime:
+                            rel = str(p.relative_to(ws)) if p.is_relative_to(ws) else key
+                            changed.append(rel)
+            except Exception:  # noqa: BLE001
+                logger.debug("auto_repair changed-file scan failed", exc_info=True)
+            ev = AutoRepairApplied(cmd=raw_cmd, files=sorted(changed), round=round_no)
+            await run.emit(ev)
+            applied.append(ev)
+        return applied
+
     async def _test(self, run: CodingRun, change: ChangeProposed, *, round_no: int) -> TestsRan:
         """Run the declared test command as a subprocess; passed is the process exit code, never a model claim."""
+        await self._apply_auto_repairs(run, round_no=round_no)
         cmd, shell = _resolve_cmd(run.test_cmd)
         cmd_str = run.test_cmd if isinstance(run.test_cmd, str) else " ".join(run.test_cmd)
         run.notify("testing", change=change.eid, round=round_no, cmd=cmd_str)
@@ -669,35 +750,103 @@ class CodingEngine(Engine):
         await run.emit(tests)
         return run.last(TestsRan)
 
+    async def _fast_test(
+        self, run: CodingRun, change: ChangeProposed, *, round_no: int
+    ) -> TestsRan | None:
+        """Run fast_test_cmd as an incremental gate for intermediate fix rounds.
+
+        Returns None when fast_test_cmd is not configured.  Auto-repair is NOT
+        run here — it fires in _test() which is always the authoritative leg.
+        """
+        if self.fast_test_cmd is None:
+            return None
+        cmd, shell = _resolve_cmd(self.fast_test_cmd)
+        cmd_str = (
+            self.fast_test_cmd
+            if isinstance(self.fast_test_cmd, str)
+            else " ".join(self.fast_test_cmd)
+        )
+        run.notify("fast_testing", change=change.eid, round=round_no, cmd=cmd_str)
+        result = await run_sync(_subprocess_sync, cmd, shell, self.test_timeout_s, run.workspace)
+        combined = (result.get("stdout", "") + result.get("stderr", "")).rstrip()
+        returncode = int(result.get("returncode", -1))
+        timed_out = bool(result.get("timed_out", False))
+        passed = returncode == 0 and not timed_out
+        output_file = self._write_output(run, combined)
+        tests = TestsRan(
+            change_ref=change.eid,
+            cmd=cmd_str,
+            passed=passed,
+            returncode=returncode,
+            timed_out=timed_out,
+            round=round_no,
+            output_tail=_tail(combined),
+            output_file=output_file,
+        )
+        await run.emit(tests)
+        return run.last(TestsRan)
+
     async def _fix_loop(
         self, run: CodingRun, plan: WorkPlanned, change: ChangeProposed, tests: TestsRan
     ) -> tuple[ChangeProposed, TestsRan]:
-        """Re-prompt the implementer on failure and re-test, bounded by max_fix_rounds; judge gate fires before each round."""
+        """Re-prompt the implementer on failure and re-test, bounded by max_fix_rounds.
+
+        Mechanical rounds (failure attributable solely to fmt/lint output, satisfied
+        after auto-repair) skip the judge gate.  Substantive rounds pass through the
+        judge as before.  When fast_test_cmd is configured, intermediate rounds gate
+        on it first; the full test_cmd is always the final ground-truth leg.
+        """
         agent = getattr(run, "_implementer", None)
         round_no = 0
         while not tests.passed and round_no < self.max_fix_rounds and agent is not None:
             round_no += 1
-            subject = f"fix round {round_no}: test `{tests.cmd}` failed (exit {tests.returncode})"
-            if not await self.judge(run, f"fix-{round_no}", subject):
-                run.notify("fix_gated", round=round_no)
-                break
-            before = len(run.events_of(ChangeProposed))
-            async with run._sem:
-                stage_coro = run.operate_with_repair(
-                    agent,
-                    _fix_instruction(tests, plan, round_no, self.max_fix_rounds),
-                    arrived=lambda n=before: len(run.events_of(ChangeProposed)) > n,
-                    emits=(ChangeProposed,),
-                    retries=self.repair_retries,
+            # Classify: mechanical if auto-repair commands are configured and the
+            # previous failure looks like a pure fmt/lint failure.
+            is_mechanical = bool(self.auto_repair_cmds) and _looks_mechanical(tests)
+            if is_mechanical:
+                run.notify("fix_mechanical", round=round_no)
+            else:
+                subject = (
+                    f"fix round {round_no}: test `{tests.cmd}` failed (exit {tests.returncode})"
                 )
-                await self._run_stage_with_watchdog(run, stage_coro, f"fix-{round_no}")
-            if run._aborted:
-                break
-            new_change = run.last(ChangeProposed)
-            if new_change is change:
-                run.notify("fix_no_change", round=round_no)
-                break
-            change = new_change
+                if not await self.judge(run, f"fix-{round_no}", subject):
+                    run.notify("fix_gated", round=round_no)
+                    break
+            before = len(run.events_of(ChangeProposed))
+            if is_mechanical:
+                # Mechanical rounds skip re-prompting the worker: auto_repair_cmds
+                # already corrected the workspace.  Re-test directly.
+                pass
+            else:
+                async with run._sem:
+                    stage_coro = run.operate_with_repair(
+                        agent,
+                        _fix_instruction(tests, plan, round_no, self.max_fix_rounds),
+                        arrived=lambda n=before: len(run.events_of(ChangeProposed)) > n,
+                        emits=(ChangeProposed,),
+                        retries=self.repair_retries,
+                    )
+                    await self._run_stage_with_watchdog(run, stage_coro, f"fix-{round_no}")
+                if run._aborted:
+                    break
+                new_change = run.last(ChangeProposed)
+                if new_change is change:
+                    run.notify("fix_no_change", round=round_no)
+                    break
+                change = new_change
+            # Incremental gate: fast_test_cmd for intermediate substantive rounds;
+            # always run the full test_cmd as the final ground-truth leg.
+            if (
+                not is_mechanical
+                and self.fast_test_cmd is not None
+                and round_no < self.max_fix_rounds
+            ):
+                fast = await self._fast_test(run, change, round_no=round_no)
+                if fast is not None and not fast.passed:
+                    # Fast gate failed — update tests for the fix instruction but
+                    # do not count this as the authoritative result yet.
+                    tests = fast
+                    continue
             tests = await self._test(run, change, round_no=round_no)
         if not tests.passed:
             run.notify("fix_exhausted", rounds=round_no, passed=False)
@@ -758,6 +907,16 @@ class CodingEngine(Engine):
         }
         if run._spec_lint_warnings:
             measurements["spec_lint_warnings"] = run._spec_lint_warnings
+        # Record active tool grants so dataset consumers can correlate grant
+        # configuration with outcome — worker grants only, judge context excluded.
+        if self.worker_extra_tools or self.worker_mcp_servers:
+            measurements["worker_grants"] = {
+                "extra_tools": list(self.worker_extra_tools),
+                "mcp_servers": self.worker_mcp_servers or [],
+            }
+        auto_repairs = run.by_type(AutoRepairApplied)
+        if auto_repairs:
+            measurements["auto_repair_rounds"] = len(auto_repairs)
         result = CodeResultRecorded(
             passed=passed,
             measurements=measurements,
@@ -974,6 +1133,33 @@ class CodingEngine(Engine):
         path = run.export_dir / f"test_output_{run._test_runs}.txt"
         path.write_text(output, encoding="utf-8")
         return str(path)
+
+
+# Patterns that suggest a test failure is purely mechanical (fmt/lint).
+_RE_MECHANICAL = re.compile(
+    r"(?:rustfmt|cargo fmt|black|ruff format|clang-format|gofmt|prettier|"
+    r"isort|yapf|autopep8|scalafmt|ktlint)\b.*(?:would reformat|check|error|diff)",
+    re.IGNORECASE,
+)
+
+
+def _looks_mechanical(tests: TestsRan) -> bool:
+    """Return True when the test failure output looks like a pure fmt/lint failure.
+
+    Heuristic only — used to skip the judge gate for mechanical rounds; the
+    authoritative result is always the full test_cmd exit code.
+    """
+    if tests.passed:
+        return False
+    tail = tests.output_tail
+    if not tail:
+        return False
+    lines = tail.splitlines()
+    # If every non-empty line matches a formatter/linter pattern, call it mechanical.
+    non_empty = [ln for ln in lines if ln.strip()]
+    if not non_empty:
+        return False
+    return all(_RE_MECHANICAL.search(ln) for ln in non_empty)
 
 
 def _parse_porcelain(output: str) -> dict[str, str]:

--- a/lionagi/engines/engine.py
+++ b/lionagi/engines/engine.py
@@ -248,6 +248,8 @@ class EngineRun:
         cwd: str | None = None,
         secure: bool = True,
         exempt: bool = False,
+        mcp_servers: list[str] | None = None,
+        extra_prompt: str | None = None,
     ) -> Branch:
         # ``exempt`` is for terminal stages (synthesis/verdict) that must run
         # even when the expansion budget is gone — degrade, don't lose the run.
@@ -265,7 +267,10 @@ class EngineRun:
             permissions=permissions,
             emits=tuple(emits) if emits else None,
             cwd=cwd,
+            system_prompt=extra_prompt,
         )
+        if mcp_servers is not None:
+            spec.mcp_servers = mcp_servers
         if secure and tools:
             from lionagi.agent.spec import _wire_secure_guards
 

--- a/tests/engines/test_tool_enrichment_repair.py
+++ b/tests/engines/test_tool_enrichment_repair.py
@@ -1,0 +1,711 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for worker tool enrichment (worker_extra_tools / worker_mcp_servers /
+worker_extra_prompt) and mechanical-repair efficiency (auto_repair_cmds /
+fast_test_cmd / _looks_mechanical / AutoRepairApplied)."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from lionagi.engines.coding import (
+    AutoRepairApplied,
+    ChangeProposed,
+    CodingEngine,
+    VerifyResult,
+    WorkPlanned,
+    _looks_mechanical,
+)
+from lionagi.engines.engine import Engine, EngineRun
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+class _StubEngine(Engine):
+    async def _run(self, run: EngineRun, *a: Any, **kw: Any) -> Any:  # pragma: no cover
+        return ""
+
+
+def _async(value):
+    async def _coro():
+        return value
+
+    return _coro()
+
+
+class _ScriptedBranch:
+    def __init__(self, run, events: list, *, name: str = "agent"):
+        self._run = run
+        self._events = list(events)
+        self.name = name
+        self.calls: list[str] = []
+        self.chat_model = None
+
+    async def operate(self, *, instruction, **kw):
+        self.calls.append(instruction)
+        if self._events:
+            await self._run.emit(self._events.pop(0))
+        return "ok"
+
+
+# ---------------------------------------------------------------------------
+# _looks_mechanical unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_looks_mechanical_returns_false_for_passing_tests():
+    from lionagi.engines.coding import TestsRan
+
+    t = TestsRan(cmd="cargo test", passed=True, returncode=0)
+    assert not _looks_mechanical(t)
+
+
+def test_looks_mechanical_returns_false_for_empty_output():
+    from lionagi.engines.coding import TestsRan
+
+    t = TestsRan(cmd="cargo test", passed=False, returncode=1, output_tail="")
+    assert not _looks_mechanical(t)
+
+
+def test_looks_mechanical_returns_true_for_rustfmt_output():
+    from lionagi.engines.coding import TestsRan
+
+    tail = "rustfmt would reformat src/lib.rs\nrustfmt would reformat src/main.rs\n"
+    t = TestsRan(cmd="cargo fmt --check", passed=False, returncode=1, output_tail=tail)
+    assert _looks_mechanical(t)
+
+
+def test_looks_mechanical_returns_false_for_mixed_output():
+    from lionagi.engines.coding import TestsRan
+
+    tail = "rustfmt would reformat src/lib.rs\nerror[E0308]: mismatched types\n"
+    t = TestsRan(cmd="cargo test", passed=False, returncode=1, output_tail=tail)
+    assert not _looks_mechanical(t)
+
+
+def test_looks_mechanical_ruff_format_output():
+    from lionagi.engines.coding import TestsRan
+
+    tail = "ruff format check would reformat 3 files\n"
+    t = TestsRan(cmd="ruff format --check", passed=False, returncode=1, output_tail=tail)
+    assert _looks_mechanical(t)
+
+
+# ---------------------------------------------------------------------------
+# worker_extra_tools: merged into make_agent call
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_worker_extra_tools_merged_with_coding_tools(tmp_path, monkeypatch):
+    """worker_extra_tools must be combined with coding_tools when calling make_agent."""
+    eng = CodingEngine(
+        coding_tools=("coding",),
+        worker_extra_tools=("search",),
+        repair_retries=0,
+        max_fix_rounds=0,
+    )
+    run = eng.new_run()
+
+    plan_ev = WorkPlanned(approach="do it")
+    change_ev = ChangeProposed(summary="done", plan_ref="W-1")
+    verdict_ev = VerifyResult(verdict="APPROVE", rationale="ok", meets_acceptance=True)
+
+    captured_make_calls: list[dict] = []
+    orig_make = run.make_agent
+
+    async def spy_make(role, *, name=None, **kw):
+        captured_make_calls.append({"role": role, "name": name, **kw})
+        return _ScriptedBranch(
+            run,
+            {"plan": [plan_ev], "implement": [change_ev], "verify": [verdict_ev]}.get(name, []),
+            name=name,
+        )
+
+    monkeypatch.setattr(run, "make_agent", spy_make)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async(""))
+
+    await eng._run(
+        run,
+        "Acceptance criteria: passes.",
+        test_cmd=[sys.executable, "-c", "exit(0)"],
+        workspace=str(tmp_path),
+    )
+
+    implement_call = next((c for c in captured_make_calls if c.get("name") == "implement"), None)
+    assert implement_call is not None
+    assert "coding" in implement_call["tools"]
+    assert "search" in implement_call["tools"]
+
+
+@pytest.mark.asyncio
+async def test_plan_and_verify_do_not_get_worker_tools(tmp_path, monkeypatch):
+    """plan/verify agents must not receive worker_extra_tools."""
+    eng = CodingEngine(
+        coding_tools=("coding",),
+        worker_extra_tools=("search",),
+        repair_retries=0,
+        max_fix_rounds=0,
+    )
+    run = eng.new_run()
+
+    plan_ev = WorkPlanned(approach="do it")
+    change_ev = ChangeProposed(summary="done", plan_ref="W-1")
+    verdict_ev = VerifyResult(verdict="APPROVE", rationale="ok", meets_acceptance=True)
+
+    captured_make_calls: list[dict] = []
+
+    async def spy_make(role, *, name=None, **kw):
+        captured_make_calls.append({"role": role, "name": name, **kw})
+        return _ScriptedBranch(
+            run,
+            {"plan": [plan_ev], "implement": [change_ev], "verify": [verdict_ev]}.get(name, []),
+            name=name,
+        )
+
+    monkeypatch.setattr(run, "make_agent", spy_make)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async(""))
+
+    await eng._run(
+        run,
+        "Acceptance criteria: passes.",
+        test_cmd=[sys.executable, "-c", "exit(0)"],
+        workspace=str(tmp_path),
+    )
+
+    for call in captured_make_calls:
+        if call.get("name") in ("plan", "verify"):
+            # plan and verify must not receive the worker extra tools
+            assert "search" not in call.get("tools", ()), (
+                f"{call['name']} agent must not receive worker_extra_tools"
+            )
+
+
+# ---------------------------------------------------------------------------
+# worker_mcp_servers: passed to implement agent only
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_worker_mcp_servers_passed_to_implement_not_verify(tmp_path, monkeypatch):
+    """worker_mcp_servers must be set on the implement agent; plan/verify must have None."""
+    eng = CodingEngine(
+        coding_tools=("coding",),
+        worker_mcp_servers=["khive"],
+        repair_retries=0,
+        max_fix_rounds=0,
+    )
+    run = eng.new_run()
+
+    plan_ev = WorkPlanned(approach="do it")
+    change_ev = ChangeProposed(summary="done", plan_ref="W-1")
+    verdict_ev = VerifyResult(verdict="APPROVE", rationale="ok", meets_acceptance=True)
+
+    captured_make_calls: list[dict] = []
+
+    async def spy_make(role, *, name=None, **kw):
+        captured_make_calls.append({"role": role, "name": name, **kw})
+        return _ScriptedBranch(
+            run,
+            {"plan": [plan_ev], "implement": [change_ev], "verify": [verdict_ev]}.get(name, []),
+            name=name,
+        )
+
+    monkeypatch.setattr(run, "make_agent", spy_make)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async(""))
+
+    await eng._run(
+        run,
+        "Acceptance criteria: passes.",
+        test_cmd=[sys.executable, "-c", "exit(0)"],
+        workspace=str(tmp_path),
+    )
+
+    implement_call = next((c for c in captured_make_calls if c.get("name") == "implement"), None)
+    assert implement_call is not None
+    assert implement_call.get("mcp_servers") == ["khive"]
+
+    for call in captured_make_calls:
+        if call.get("name") in ("plan", "verify"):
+            assert call.get("mcp_servers") is None, f"{call['name']} must not receive mcp_servers"
+
+
+# ---------------------------------------------------------------------------
+# worker_extra_prompt: forwarded to implement agent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_worker_extra_prompt_forwarded(tmp_path, monkeypatch):
+    """worker_extra_prompt must be forwarded as extra_prompt to the implement agent."""
+    eng = CodingEngine(
+        repair_retries=0,
+        max_fix_rounds=0,
+        worker_extra_prompt="Always prefer idiomatic Rust.",
+    )
+    run = eng.new_run()
+
+    plan_ev = WorkPlanned(approach="do it")
+    change_ev = ChangeProposed(summary="done", plan_ref="W-1")
+    verdict_ev = VerifyResult(verdict="APPROVE", rationale="ok", meets_acceptance=True)
+
+    captured_make_calls: list[dict] = []
+
+    async def spy_make(role, *, name=None, **kw):
+        captured_make_calls.append({"role": role, "name": name, **kw})
+        return _ScriptedBranch(
+            run,
+            {"plan": [plan_ev], "implement": [change_ev], "verify": [verdict_ev]}.get(name, []),
+            name=name,
+        )
+
+    monkeypatch.setattr(run, "make_agent", spy_make)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async(""))
+
+    await eng._run(
+        run,
+        "Acceptance criteria: passes.",
+        test_cmd=[sys.executable, "-c", "exit(0)"],
+        workspace=str(tmp_path),
+    )
+
+    implement_call = next((c for c in captured_make_calls if c.get("name") == "implement"), None)
+    assert implement_call is not None
+    assert implement_call.get("extra_prompt") == "Always prefer idiomatic Rust."
+
+
+# ---------------------------------------------------------------------------
+# make_agent: mcp_servers + extra_prompt propagate through AgentSpec
+# ---------------------------------------------------------------------------
+
+
+def test_make_agent_mcp_servers_set_on_spec_directly():
+    """AgentSpec.compose result must have mcp_servers set after make_agent wires it."""
+    from lionagi.agent.spec import AgentSpec
+
+    spec = AgentSpec.compose("implementer", tools=(), cwd=None)
+    assert spec.mcp_servers is None
+    # Simulate what make_agent does
+    spec.mcp_servers = ["khive"]
+    assert spec.mcp_servers == ["khive"]
+
+
+def test_make_agent_extra_prompt_set_via_compose():
+    """AgentSpec.compose must thread system_prompt into extra_prompt."""
+    from lionagi.agent.spec import AgentSpec
+
+    spec = AgentSpec.compose("implementer", system_prompt="prefer idiomatic Rust")
+    assert spec.extra_prompt == "prefer idiomatic Rust"
+
+
+# ---------------------------------------------------------------------------
+# auto_repair_cmds: AutoRepairApplied events emitted before test gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auto_repair_cmds_fires_on_first_test_pass(tmp_path, monkeypatch):
+    """auto_repair_cmds must run before the test gate and emit AutoRepairApplied."""
+    # Use a real auto-repair command that always succeeds (echo/true).
+    eng = CodingEngine(
+        repair_retries=0,
+        max_fix_rounds=0,
+        auto_repair_cmds=["true"],  # no-op that always exits 0
+    )
+    run = eng.new_run()
+
+    plan_ev = WorkPlanned(approach="do it")
+    change_ev = ChangeProposed(summary="done", plan_ref="W-1")
+    verdict_ev = VerifyResult(verdict="APPROVE", rationale="ok", meets_acceptance=True)
+
+    branches = {
+        "plan": _ScriptedBranch(run, [plan_ev], name="plan"),
+        "implement": _ScriptedBranch(run, [change_ev], name="implement"),
+        "verify": _ScriptedBranch(run, [verdict_ev], name="verify"),
+    }
+
+    async def fake_make(role, *, name=None, **kw):
+        return branches.get(name, _ScriptedBranch(run, [], name=name))
+
+    monkeypatch.setattr(run, "make_agent", fake_make)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async(""))
+
+    events: list[dict] = []
+    run.on_event = events.append
+
+    result = await eng._run(
+        run,
+        "Acceptance criteria: passes.",
+        test_cmd=[sys.executable, "-c", "exit(0)"],
+        workspace=str(tmp_path),
+    )
+
+    assert result.passed is True
+    auto_repair_events = [e for e in events if e["type"] == "AutoRepairApplied"]
+    assert auto_repair_events, (
+        "AutoRepairApplied event must be emitted when auto_repair_cmds is set"
+    )
+    assert auto_repair_events[0]["cmd"] == "true"
+
+
+@pytest.mark.asyncio
+async def test_auto_repair_failed_notifies_but_does_not_crash(tmp_path, monkeypatch):
+    """A failing auto_repair_cmd must emit auto_repair_failed and continue."""
+    eng = CodingEngine(
+        repair_retries=0,
+        max_fix_rounds=0,
+        auto_repair_cmds=["false"],  # always exits 1
+    )
+    run = eng.new_run()
+
+    plan_ev = WorkPlanned(approach="do it")
+    change_ev = ChangeProposed(summary="done", plan_ref="W-1")
+    verdict_ev = VerifyResult(verdict="APPROVE", rationale="ok", meets_acceptance=True)
+
+    branches = {
+        "plan": _ScriptedBranch(run, [plan_ev], name="plan"),
+        "implement": _ScriptedBranch(run, [change_ev], name="implement"),
+        "verify": _ScriptedBranch(run, [verdict_ev], name="verify"),
+    }
+
+    async def fake_make(role, *, name=None, **kw):
+        return branches.get(name, _ScriptedBranch(run, [], name=name))
+
+    monkeypatch.setattr(run, "make_agent", fake_make)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async(""))
+
+    events: list[dict] = []
+    run.on_event = events.append
+
+    result = await eng._run(
+        run,
+        "Acceptance criteria: passes.",
+        test_cmd=[sys.executable, "-c", "exit(0)"],
+        workspace=str(tmp_path),
+    )
+
+    # Must not crash; test gate still determines the result
+    assert result.passed is True
+    failed_notifs = [e for e in events if e["type"] == "auto_repair_failed"]
+    assert failed_notifs, (
+        "auto_repair_failed must be emitted when the repair command exits non-zero"
+    )
+
+
+@pytest.mark.asyncio
+async def test_auto_repair_recorded_in_measurements(tmp_path, monkeypatch):
+    """auto_repair_rounds must appear in measurements when repairs are applied."""
+    eng = CodingEngine(
+        repair_retries=0,
+        max_fix_rounds=0,
+        auto_repair_cmds=["true"],
+    )
+    run = eng.new_run()
+
+    plan_ev = WorkPlanned(approach="do it")
+    change_ev = ChangeProposed(summary="done", plan_ref="W-1")
+    verdict_ev = VerifyResult(verdict="APPROVE", rationale="ok", meets_acceptance=True)
+
+    branches = {
+        "plan": _ScriptedBranch(run, [plan_ev], name="plan"),
+        "implement": _ScriptedBranch(run, [change_ev], name="implement"),
+        "verify": _ScriptedBranch(run, [verdict_ev], name="verify"),
+    }
+
+    async def fake_make(role, *, name=None, **kw):
+        return branches.get(name, _ScriptedBranch(run, [], name=name))
+
+    monkeypatch.setattr(run, "make_agent", fake_make)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async(""))
+
+    result = await eng._run(
+        run,
+        "Acceptance criteria: passes.",
+        test_cmd=[sys.executable, "-c", "exit(0)"],
+        workspace=str(tmp_path),
+    )
+
+    assert "auto_repair_rounds" in result.measurements
+
+
+# ---------------------------------------------------------------------------
+# mechanical round: skips judge, skips worker re-prompt
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mechanical_fix_round_skips_judge(tmp_path, monkeypatch):
+    """A mechanical fix round must skip the judge gate entirely."""
+    eng = CodingEngine(
+        repair_retries=0,
+        max_fix_rounds=1,
+        auto_repair_cmds=["true"],  # enables mechanical classification
+    )
+    run = eng.new_run()
+
+    plan_ev = WorkPlanned(approach="do it")
+    change_ev = ChangeProposed(summary="done", plan_ref="W-1")
+    verdict_ev = VerifyResult(verdict="APPROVE", rationale="ok", meets_acceptance=True)
+
+    branches = {
+        "plan": _ScriptedBranch(run, [plan_ev], name="plan"),
+        "implement": _ScriptedBranch(run, [change_ev], name="implement"),
+        "verify": _ScriptedBranch(run, [verdict_ev], name="verify"),
+    }
+
+    async def fake_make(role, *, name=None, **kw):
+        return branches.get(name, _ScriptedBranch(run, [], name=name))
+
+    judge_calls: list[str] = []
+
+    async def spy_judge(r, eid, subject):
+        judge_calls.append(eid)
+        return True
+
+    monkeypatch.setattr(run, "make_agent", fake_make)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async(""))
+    monkeypatch.setattr(eng, "judge", spy_judge)
+
+    # First test fails with rustfmt-looking output; second passes.
+    call_count = 0
+
+    async def fake_test(r, change, *, round_no):
+        nonlocal call_count
+        call_count += 1
+        from lionagi.engines.coding import TestsRan
+
+        if call_count == 1:
+            t = TestsRan(
+                change_ref=change.eid,
+                cmd="cargo fmt --check",
+                passed=False,
+                returncode=1,
+                round=round_no,
+                output_tail="rustfmt would reformat src/lib.rs\n",
+            )
+        else:
+            t = TestsRan(
+                change_ref=change.eid,
+                cmd="cargo test",
+                passed=True,
+                returncode=0,
+                round=round_no,
+            )
+        await run.emit(t)
+        return run.last(TestsRan)
+
+    monkeypatch.setattr(eng, "_test", fake_test)
+
+    events: list[dict] = []
+    run.on_event = events.append
+
+    result = await eng._run(
+        run,
+        "Acceptance criteria: passes.",
+        test_cmd="cargo test",
+        workspace=str(tmp_path),
+    )
+
+    assert result.passed is True
+    # Judge must not have been called for the mechanical round
+    assert not any("fix-" in eid for eid in judge_calls), (
+        f"judge must not be called for mechanical rounds; calls={judge_calls}"
+    )
+    assert any(e["type"] == "fix_mechanical" for e in events)
+
+
+# ---------------------------------------------------------------------------
+# fast_test_cmd: used for intermediate rounds, full test_cmd as final gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fast_test_cmd_used_for_intermediate_rounds(tmp_path, monkeypatch):
+    """fast_test_cmd must be invoked for intermediate fix rounds; full test_cmd is the final gate."""
+    eng = CodingEngine(
+        repair_retries=0,
+        max_fix_rounds=2,
+        fast_test_cmd="echo fast",
+    )
+    run = eng.new_run()
+
+    plan_ev = WorkPlanned(approach="do it")
+    # Two changes: first fails full gate, second passes
+    change_1 = ChangeProposed(summary="attempt 1", plan_ref="W-1")
+    change_2 = ChangeProposed(summary="attempt 2", plan_ref="W-1")
+    verdict_ev = VerifyResult(verdict="APPROVE", rationale="ok", meets_acceptance=True)
+
+    class _TwoBranchImpl:
+        name = "implement"
+        call_count = 0
+
+        async def operate(self, *, instruction, **kw):
+            self.call_count += 1
+            if self.call_count == 1:
+                await run.emit(change_1)
+            else:
+                await run.emit(change_2)
+            return "ok"
+
+    impl = _TwoBranchImpl()
+    branches = {
+        "plan": _ScriptedBranch(run, [plan_ev], name="plan"),
+        "implement": impl,
+        "verify": _ScriptedBranch(run, [verdict_ev], name="verify"),
+    }
+
+    async def fake_make(role, *, name=None, **kw):
+        return branches.get(name, _ScriptedBranch(run, [], name=name))
+
+    monkeypatch.setattr(run, "make_agent", fake_make)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async(""))
+
+    fast_calls: list[int] = []
+    full_calls: list[int] = []
+    real_fast = eng._fast_test
+    real_full = eng._test
+
+    async def spy_fast(r, change, *, round_no):
+        fast_calls.append(round_no)
+        return await real_fast(r, change, round_no=round_no)
+
+    test_round = 0
+
+    async def spy_test(r, change, *, round_no):
+        full_calls.append(round_no)
+        return await real_full(r, change, round_no=round_no)
+
+    monkeypatch.setattr(eng, "_fast_test", spy_fast)
+    monkeypatch.setattr(eng, "_test", spy_test)
+
+    # First full test fails; fast test passes; second full test passes.
+    from lionagi.engines.coding import TestsRan
+
+    full_test_call = 0
+
+    async def controlled_test(r, change, *, round_no):
+        nonlocal full_test_call
+        full_test_call += 1
+        full_calls.append(round_no)
+        passed = full_test_call > 1
+        t = TestsRan(
+            change_ref=change.eid,
+            cmd="real_test",
+            passed=passed,
+            returncode=0 if passed else 1,
+            round=round_no,
+        )
+        await run.emit(t)
+        return run.last(TestsRan)
+
+    monkeypatch.setattr(eng, "_test", controlled_test)
+
+    result = await eng._run(
+        run,
+        "Acceptance criteria: passes.",
+        test_cmd="real_test",
+        workspace=str(tmp_path),
+    )
+
+    assert result.passed is True
+    # fast_test must have been called for the intermediate round (round_no=1, max=2)
+    assert fast_calls, f"_fast_test must be called for intermediate rounds; got calls={fast_calls}"
+
+
+# ---------------------------------------------------------------------------
+# worker_grants recorded in measurements
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_worker_grants_recorded_in_measurements_when_configured(tmp_path, monkeypatch):
+    """worker_grants must appear in measurements when worker_extra_tools or mcp_servers set."""
+    eng = CodingEngine(
+        repair_retries=0,
+        max_fix_rounds=0,
+        worker_extra_tools=("search",),
+        worker_mcp_servers=["khive"],
+    )
+    run = eng.new_run()
+
+    plan_ev = WorkPlanned(approach="do it")
+    change_ev = ChangeProposed(summary="done", plan_ref="W-1")
+    verdict_ev = VerifyResult(verdict="APPROVE", rationale="ok", meets_acceptance=True)
+
+    async def fake_make(role, *, name=None, **kw):
+        return _ScriptedBranch(
+            run,
+            {"plan": [plan_ev], "implement": [change_ev], "verify": [verdict_ev]}.get(name, []),
+            name=name,
+        )
+
+    monkeypatch.setattr(run, "make_agent", fake_make)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async(""))
+
+    result = await eng._run(
+        run,
+        "Acceptance criteria: passes.",
+        test_cmd=[sys.executable, "-c", "exit(0)"],
+        workspace=str(tmp_path),
+    )
+
+    assert "worker_grants" in result.measurements
+    grants = result.measurements["worker_grants"]
+    assert "search" in grants["extra_tools"]
+    assert "khive" in grants["mcp_servers"]
+
+
+@pytest.mark.asyncio
+async def test_worker_grants_absent_when_not_configured(tmp_path, monkeypatch):
+    """worker_grants must not appear in measurements when no worker grants are set."""
+    eng = CodingEngine(repair_retries=0, max_fix_rounds=0)
+    run = eng.new_run()
+
+    plan_ev = WorkPlanned(approach="do it")
+    change_ev = ChangeProposed(summary="done", plan_ref="W-1")
+    verdict_ev = VerifyResult(verdict="APPROVE", rationale="ok", meets_acceptance=True)
+
+    async def fake_make(role, *, name=None, **kw):
+        return _ScriptedBranch(
+            run,
+            {"plan": [plan_ev], "implement": [change_ev], "verify": [verdict_ev]}.get(name, []),
+            name=name,
+        )
+
+    monkeypatch.setattr(run, "make_agent", fake_make)
+    monkeypatch.setattr(eng, "_capture_diff", lambda r: _async(""))
+
+    result = await eng._run(
+        run,
+        "Acceptance criteria: passes.",
+        test_cmd=[sys.executable, "-c", "exit(0)"],
+        workspace=str(tmp_path),
+    )
+
+    assert "worker_grants" not in result.measurements
+
+
+# ---------------------------------------------------------------------------
+# AutoRepairApplied event shape
+# ---------------------------------------------------------------------------
+
+
+def test_auto_repair_applied_event_shape():
+    ev = AutoRepairApplied(cmd="cargo fmt --all", files=["src/lib.rs"], round=1)
+    assert ev.cmd == "cargo fmt --all"
+    assert ev.files == ["src/lib.rs"]
+    assert ev.round == 1
+
+
+def test_auto_repair_applied_default_files():
+    ev = AutoRepairApplied(cmd="cargo fmt --all")
+    assert ev.files == []
+    assert ev.round == 0


### PR DESCRIPTION
## Summary

Stacked on #1546 (`feat/engines-worker-safety`). Implements two issues against `coding.py`:

**Worker tool enrichment** (closes #1425):
- `CodingEngine` gains `worker_extra_tools`, `worker_mcp_servers`, and `worker_extra_prompt` — granted to the implement/fix agent only; plan, verify, and judge agents receive none of these.
- API-model workers can receive provider-native tools via `worker_extra_tools`; CLI workers (claude_code, codex) receive `worker_mcp_servers` so they can call `memory.recall`, `knowledge.search`, etc. without write verbs.
- `worker_grants` key recorded in `measurements` when active, so dataset consumers can correlate grant configuration with outcome.
- `EngineRun.make_agent` gains `mcp_servers` and `extra_prompt` kwargs, making the grant mechanism available to any engine subclass.

**Mechanical-repair efficiency** (closes #1438):
- `auto_repair_cmds: list[str]` — the harness runs these before each test gate (e.g. `cargo fmt --all`); emits `AutoRepairApplied` per command so the dataset preserves worker-produced vs harness-normalized diffs as distinct records.
- `_looks_mechanical()` heuristic classifies fix rounds whose failure output is entirely fmt/lint patterns (rustfmt, ruff format, clang-format, gofmt, etc.) as mechanical.
- Mechanical fix rounds skip the judge gate entirely and skip worker re-prompting — auto-repair already normalized the workspace; a `fix_mechanical` notification replaces the normal subject/judge path.
- `fast_test_cmd: str | list[str]` — optional incremental gate for intermediate substantive fix rounds; the full `test_cmd` is always the authoritative final leg, so ground truth is never weakened.
- `auto_repair_rounds` count recorded in `measurements` when any repairs fired.

## Test plan

- [ ] `tests/engines/test_tool_enrichment_repair.py` — 20 new tests covering:
  - `_looks_mechanical` unit tests (passing, empty, rustfmt, ruff, mixed output)
  - `worker_extra_tools` merged into implement agent, absent from plan/verify
  - `worker_mcp_servers` forwarded to implement, None on plan/verify
  - `worker_extra_prompt` forwarded via `extra_prompt`
  - `AgentSpec.compose` system_prompt → extra_prompt threading
  - `AutoRepairApplied` event shape
  - Auto-repair fires on first test pass; failed repair notifies but does not crash
  - `auto_repair_rounds` in measurements
  - Mechanical fix round skips judge; `fix_mechanical` event emitted
  - `fast_test_cmd` invoked for intermediate rounds
  - `worker_grants` in/absent from measurements based on config
- [ ] Full engines suite: **198/198 passed** (`timeout 300 uv run pytest tests/engines -p no:cov`)
- [ ] `ruff check` + `ruff format --check` pass on all changed files

Closes #1425
Closes #1438

🤖 Generated with [Claude Code](https://claude.com/claude-code)