### PR TITLE
feat(state): session provenance + busy_timeout-first for concurrent writers

### DIFF
--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -314,10 +314,14 @@ class StateDB:
         return self._db
 
     async def _apply_pragmas(self) -> None:
+        # busy_timeout MUST be first: the journal_mode=WAL switch below takes a
+        # momentary exclusive lock, so when a second connection initialises the
+        # same file concurrently (the mirror is "just another writer") it must
+        # wait out the timeout rather than fail instantly with "database is locked".
+        await self.db.execute("PRAGMA busy_timeout = 5000")
         await self.db.execute("PRAGMA journal_mode = WAL")
         await self.db.execute("PRAGMA synchronous = NORMAL")
         await self.db.execute("PRAGMA foreign_keys = ON")
-        await self.db.execute("PRAGMA busy_timeout = 5000")
         await self.db.execute("PRAGMA cache_size = -64000")
         await self.db.execute("PRAGMA wal_autocheckpoint = 1000")
 
@@ -807,6 +811,43 @@ class StateDB:
                 (_to_json_column(verification), time.time(), session_id),
             )
             await self.db.commit()
+
+    async def set_session_provenance(
+        self,
+        session_id: str,
+        *,
+        node_metadata: dict[str, Any] | None = None,
+        project: str | None = None,
+        project_source: str | None = None,
+    ) -> None:
+        """Write attribution/provenance fields without touching updated_at.
+
+        Project bucketing and conversation lineage describe where a session came
+        from, not whether it is live, so they must never move the liveness clock
+        (which reconcile_session_status and the phantom reaper read). Each given
+        field is written; project also upserts the projects registry.
+        """
+        sets: list[str] = []
+        vals: list[Any] = []
+        if node_metadata is not None:
+            sets.append("node_metadata = ?")
+            vals.append(_to_json_column(node_metadata))
+        if project is not None:
+            sets.append("project = ?")
+            vals.append(project)
+            sets.append("project_source = ?")
+            vals.append(project_source)
+        if not sets:
+            return
+        vals.append(session_id)
+        async with self._write_lock:
+            await self.db.execute(
+                f"UPDATE sessions SET {', '.join(sets)} WHERE id = ?",  # noqa: S608
+                vals,
+            )
+            await self.db.commit()
+        if project:
+            await self.register_project(project, project_source or "cwd_dir")
 
     # ── Status reason model ───────────────────────────────────────────
 

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -824,8 +824,10 @@ class StateDB:
 
         Project bucketing and conversation lineage describe where a session came
         from, not whether it is live, so they must never move the liveness clock
-        (which reconcile_session_status and the phantom reaper read). Each given
-        field is written; project also upserts the projects registry.
+        (which reconcile_session_status and the phantom reaper read). project and
+        project_source are written together (the source is meaningless alone).
+        The session update and the projects-registry upsert run as one locked
+        write so neither can commit without the other.
         """
         sets: list[str] = []
         vals: list[Any] = []
@@ -845,9 +847,9 @@ class StateDB:
                 f"UPDATE sessions SET {', '.join(sets)} WHERE id = ?",  # noqa: S608
                 vals,
             )
+            if project:
+                await self._upsert_project_stmt(project, project_source or "cwd_dir")
             await self.db.commit()
-        if project:
-            await self.register_project(project, project_source or "cwd_dir")
 
     # ── Status reason model ───────────────────────────────────────────
 
@@ -1031,7 +1033,7 @@ class StateDB:
 
     # ── Projects ──────────────────────────────────────────────────────
 
-    async def register_project(
+    async def _upsert_project_stmt(
         self,
         name: str,
         source: str,
@@ -1039,7 +1041,7 @@ class StateDB:
         path: str | None = None,
         github: str | None = None,
     ) -> None:
-        """Upsert a project entry; bumps last_seen_at on conflict."""
+        """Projects-registry upsert statement only; caller owns the lock and commit."""
         now = time.time()
         await self.db.execute(
             """INSERT INTO projects
@@ -1057,6 +1059,17 @@ class StateDB:
                    github = COALESCE(excluded.github, projects.github)""",
             (name, source, path, github, now, now, now),
         )
+
+    async def register_project(
+        self,
+        name: str,
+        source: str,
+        *,
+        path: str | None = None,
+        github: str | None = None,
+    ) -> None:
+        """Upsert a project entry; bumps last_seen_at on conflict."""
+        await self._upsert_project_stmt(name, source, path=path, github=github)
         await self.db.commit()
 
     async def create_project(

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -843,13 +843,18 @@ class StateDB:
             return
         vals.append(session_id)
         async with self._write_lock:
-            await self.db.execute(
-                f"UPDATE sessions SET {', '.join(sets)} WHERE id = ?",  # noqa: S608
-                vals,
-            )
-            if project:
-                await self._upsert_project_stmt(project, project_source or "cwd_dir")
-            await self.db.commit()
+            await self.db.execute("BEGIN IMMEDIATE")
+            try:
+                await self.db.execute(
+                    f"UPDATE sessions SET {', '.join(sets)} WHERE id = ?",  # noqa: S608
+                    vals,
+                )
+                if project:
+                    await self._upsert_project_stmt(project, project_source or "cwd_dir")
+                await self.db.commit()
+            except BaseException:
+                await self.db.rollback()
+                raise
 
     # ── Status reason model ───────────────────────────────────────────
 

--- a/tests/state/test_provenance.py
+++ b/tests/state/test_provenance.py
@@ -204,3 +204,23 @@ async def test_update_session_allows_provenance_columns(db: StateDB):
     assert row["model"] == "openai/gpt-4.1"
     assert row["provider"] == "openai"
     assert row["effort"] == "medium"
+
+
+async def test_set_session_provenance_rolls_back_on_upsert_failure(db: StateDB, monkeypatch):
+    """A failing project upsert must not leave the session half of the write committed."""
+    prog_id = _uid()
+    sid = _uid()
+    await db.create_progression(prog_id)
+    await db.create_session({"id": sid, "progression_id": prog_id, "status": "running"})
+
+    async def _boom(*_a, **_k):
+        raise RuntimeError("upsert failed")
+
+    monkeypatch.setattr(db, "_upsert_project_stmt", _boom)
+
+    with pytest.raises(RuntimeError, match="upsert failed"):
+        await db.set_session_provenance(sid, project="acme", project_source="config_toml")
+
+    assert db.db.in_transaction is False
+    row = await db.get_session(sid)
+    assert row["project"] is None


### PR DESCRIPTION
## What
Two self-contained `lionagi/state/db.py` changes that let the Claude Code mirror tail safely share the StateDB with the studio app:

1. **`StateDB.set_session_provenance()`** — writes `project` / `node_metadata` attribution **without** bumping `updated_at`, so provenance never moves the liveness clock that `reconcile_session_status` and the phantom reaper read.
2. **`busy_timeout` first** — `PRAGMA busy_timeout = 5000` moves ahead of the `journal_mode = WAL` switch. The WAL switch takes a momentary exclusive lock; a second connection initialising the same file concurrently waits out the timeout instead of failing instantly with `database is locked`.

No new imports, no new dependencies — the base of the mirror dependency chain.

## Context
Part of the Den PR split (#1555). Targets `feat/vscode-integration`. **Wave 1** (independent). The Claude Code mirror PR builds on `set_session_provenance()` and merges after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)