### PR TITLE
feat(state): Claude Code transcript mirror — `li mirror` tail into StateDB

### DIFF
--- a/lionagi/cli/main.py
+++ b/lionagi/cli/main.py
@@ -21,6 +21,7 @@ from .casts import add_casts_subparser, run_casts
 from .engine import add_engine_subparser, run_engine
 from .invoke import add_invoke_subparser, run_invoke
 from .kill import add_kill_subparser, run_kill
+from .mirror import add_mirror_subparser, run_mirror
 from .monitor import add_monitor_subparser, run_monitor
 from .orchestrate import (
     add_orchestrate_subparser,
@@ -272,6 +273,7 @@ def main(argv: list[str] | None = None) -> int:
     add_state_subparser(sub)
     add_invoke_subparser(sub)
     add_kill_subparser(sub)
+    add_mirror_subparser(sub)
     add_monitor_subparser(sub)
 
     # If the user is invoking `li o flow -p NAME`, inject the playbook's
@@ -307,6 +309,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "kill":
         return run_kill(args)
+
+    if args.command == "mirror":
+        return run_mirror(args)
 
     if args.command in ("monitor", "mon"):
         return run_monitor(args)

--- a/lionagi/cli/mirror.py
+++ b/lionagi/cli/mirror.py
@@ -52,6 +52,7 @@ def add_mirror_subparser(subparsers: argparse._SubParsersAction) -> None:
     )
     p.add_argument(
         "--since",
+        type=_since_window,
         default=None,
         metavar="WINDOW",
         help="Only mirror transcripts modified within this window (e.g. 12h, 7d). Default: all.",
@@ -187,6 +188,11 @@ _WINDOW_UNITS = {"m": 60, "h": 3600, "d": 86400}
 
 
 def _parse_window(spec: str) -> float | None:
+    """Seconds for a window like '30m'/'12h'/'7d', or bare seconds; None if empty.
+
+    Raises ValueError on a non-empty but unparseable spec so callers fail loudly
+    instead of silently falling back to an unbounded scan.
+    """
     spec = spec.strip().lower()
     if not spec:
         return None
@@ -195,12 +201,31 @@ def _parse_window(spec: str) -> float | None:
             return float(spec[:-1]) * _WINDOW_UNITS[spec[-1]]
         return float(spec)
     except ValueError:
-        warn(f"unrecognized --since window {spec!r}; ignoring")
-        return None
+        raise ValueError(
+            f"unrecognized --since window {spec!r} (expected e.g. 30m, 12h, 7d, or seconds)"
+        ) from None
 
 
-def _read_new_events(path: Path, state: _FileState) -> list[dict[str, Any]]:
-    """Read complete JSONL lines past the cursor; advance the cursor past them."""
+def _since_window(spec: str) -> float:
+    """argparse type for --since: parse to seconds, or reject with a clean CLI error."""
+    try:
+        secs = _parse_window(spec)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from None
+    if secs is None:
+        raise argparse.ArgumentTypeError("--since must be a non-empty window, e.g. 30m, 12h, 7d")
+    return secs
+
+
+def _read_new_events(path: Path, state: _FileState) -> tuple[list[dict[str, Any]], int]:
+    """Read complete JSONL lines past the cursor; return (events, new_offset).
+
+    The cursor is NOT advanced here — the caller sets ``state.offset`` to the
+    returned offset only after the batch is durably mirrored, so a write failure
+    re-reads the same lines next pass instead of skipping them. Non-object JSON (a
+    bare ``[]`` or a scalar) is dropped as malformed rather than handed on as an
+    event.
+    """
     size = path.stat().st_size
     if state.offset > size:  # file truncated/rotated — re-read from the top.
         state.offset = 0
@@ -208,18 +233,20 @@ def _read_new_events(path: Path, state: _FileState) -> list[dict[str, Any]]:
         fh.seek(state.offset)
         chunk = fh.read()
     if b"\n" not in chunk:
-        return []
+        return [], state.offset
     body, _, _ = chunk.rpartition(b"\n")
-    state.offset += len(body) + 1
+    new_offset = state.offset + len(body) + 1
     events = []
     for raw in body.split(b"\n"):
         if not raw.strip():
             continue
         try:
-            events.append(json.loads(raw))
+            obj = json.loads(raw)
         except json.JSONDecodeError:
             continue
-    return events
+        if isinstance(obj, dict):
+            events.append(obj)
+    return events, new_offset
 
 
 _COMMAND_NOISE = ("<command-", "<local-command-")
@@ -321,8 +348,9 @@ def _first_prompt(events: list[dict[str, Any]]) -> str | None:
 async def _mirror_one(db, path: Path, state: _FileState, lineage: _Lineage) -> int:
     from lionagi.state.claude_mirror import mirror_session
 
-    events = _read_new_events(path, state)
+    events, new_offset = _read_new_events(path, state)
     if not events:
+        state.offset = new_offset  # advance past blank/malformed-only lines
         return 0
 
     if not state.session_uid:
@@ -345,6 +373,10 @@ async def _mirror_one(db, path: Path, state: _FileState, lineage: _Lineage) -> i
         name=state.name,
         status="running",
     )
+    # Advance the cursor only after the batch is durably mirrored: if the write
+    # above raised, state.offset is unchanged and the batch is re-read (idempotently)
+    # next pass rather than silently lost.
+    state.offset = new_offset
     if written and not state.created:
         state.created = True
         progress(f"  mirror: {state.name or state.session_uid[:8]} (+{written} msgs)")
@@ -452,7 +484,7 @@ async def _run(args: argparse.Namespace) -> int:
         warn(f"no Claude projects directory at {root}")
         return 1
 
-    since = _parse_window(args.since) if args.since else None
+    since = args.since  # argparse already parsed --since to seconds (or None)
     offsets = _load_offsets()
     states: dict[str, _FileState] = {}
     lineage = _Lineage()

--- a/lionagi/cli/mirror.py
+++ b/lionagi/cli/mirror.py
@@ -1,0 +1,490 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""`li mirror` — stream Claude Code transcripts into StateDB so they appear live in studio."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from lionagi._paths import LIONAGI_HOME
+
+from ._logging import hint, log_error, progress, warn
+
+CLAUDE_PROJECTS_DIR = Path.home() / ".claude" / "projects"
+_OFFSETS_PATH = LIONAGI_HOME / "mirror" / "offsets.json"
+
+# A session whose newest message is within this window counts as live (running);
+# past it, the next pass flips it to completed.
+_DEFAULT_LIVE_WINDOW = 300.0
+
+_log = logging.getLogger(__name__)
+
+
+def add_mirror_subparser(subparsers: argparse._SubParsersAction) -> None:
+    """Register `li mirror` with argparse."""
+    p = subparsers.add_parser(
+        "mirror",
+        help="Mirror Claude Code sessions into studio (live).",
+        description=(
+            "Tail ~/.claude/projects transcripts and write them to the lionagi "
+            "state DB so every Claude Code session shows up — and streams live — "
+            "in studio and the VS Code extension. Resumable and idempotent."
+        ),
+    )
+    p.add_argument(
+        "--once",
+        action="store_true",
+        help="Do a single catch-up pass and exit (backfill), instead of tailing.",
+    )
+    p.add_argument(
+        "--interval",
+        type=float,
+        default=3.0,
+        metavar="SECS",
+        help="Poll interval while tailing (default 3).",
+    )
+    p.add_argument(
+        "--since",
+        default=None,
+        metavar="WINDOW",
+        help="Only mirror transcripts modified within this window (e.g. 12h, 7d). Default: all.",
+    )
+    p.add_argument(
+        "--root",
+        default=None,
+        metavar="DIR",
+        help=f"Claude projects directory (default {CLAUDE_PROJECTS_DIR}).",
+    )
+    p.add_argument(
+        "--live-window",
+        type=float,
+        default=_DEFAULT_LIVE_WINDOW,
+        metavar="SECS",
+        help="Idle gap since the last message after which a session is marked completed (default 300).",
+    )
+
+
+@dataclass
+class _FileState:
+    """Per-transcript cursor + derived session metadata, kept across poll passes."""
+
+    session_uid: str
+    offset: int = 0
+    tool_names: dict[str, str] = field(default_factory=dict)
+    project: str | None = None
+    project_source: str | None = None
+    model: str | None = None
+    name: str | None = None
+    created: bool = False
+    leaf_uuid: str | None = None  # this file's newest event uuid (lineage index)
+    head_checked: bool = False  # whether the file's root parentUuid was examined
+    attr_peeked: bool = False  # whether idle project attribution was attempted
+
+
+@dataclass
+class _Lineage:
+    """Cross-session conversation-lineage detector, kept across poll passes.
+
+    A continued conversation (after compaction, ``--resume``, or a new window that
+    resumes an earlier thread) opens a fresh transcript whose first message points
+    — via ``parentUuid`` — at the last message of the session it continues. We
+    index each file's current leaf uuid and, when a file's root parent resolves to
+    a *different* session's leaf, record a provenance link. It almost never fires
+    on today's transcripts (continuations are rare), so it is insurance + the
+    substrate for showing conversation provenance, not a hot path.
+    """
+
+    leaf_owner: dict[str, str] = field(default_factory=dict)  # event uuid -> session_uid
+    pending: dict[str, str] = field(default_factory=dict)  # child session_uid -> parent uuid
+    linked: set[str] = field(default_factory=set)  # child session_uids already linked
+
+    def note_leaf(self, state: _FileState, events: list[dict[str, Any]]) -> None:
+        """Index this file's newest event uuid as a candidate continuation point."""
+        last = next((str(e["uuid"]) for e in reversed(events) if e.get("uuid")), None)
+        if not last:
+            return
+        prev = state.leaf_uuid
+        if prev and self.leaf_owner.get(prev) == state.session_uid:
+            self.leaf_owner.pop(prev, None)  # only the current leaf stays indexed
+        self.leaf_owner[last] = state.session_uid
+        state.leaf_uuid = last
+
+    def note_head(self, state: _FileState, events: list[dict[str, Any]]) -> None:
+        """If the file's thread root has a parent, queue it for cross-session resolution."""
+        if state.head_checked or state.session_uid in self.linked:
+            return
+        for e in events:
+            if "parentUuid" not in e:  # summary/file-history events have no parent
+                continue
+            state.head_checked = True
+            parent = e.get("parentUuid")
+            if parent:  # null parent == self-rooted, no lineage
+                self.pending[state.session_uid] = str(parent)
+            return
+
+    def resolve(self) -> list[tuple[str, str, str]]:
+        """Match pending roots against indexed leaves; return new (child, parent, uuid) links."""
+        links: list[tuple[str, str, str]] = []
+        for child, parent_uuid in list(self.pending.items()):
+            owner = self.leaf_owner.get(parent_uuid)
+            if owner is None:
+                continue  # parent not yet indexed (older pass, or outside the window)
+            del self.pending[child]
+            if owner == child:
+                continue  # same session spread across files — not cross-session lineage
+            self.linked.add(child)
+            links.append((child, owner, parent_uuid))
+        return links
+
+
+def _fallback_project(cwd: str) -> tuple[str, str]:
+    """Attribute a cwd that detect_project couldn't place to a project.
+
+    Bucket it by the cwd's own folder name, or "others" when that directory no
+    longer exists (e.g. a transcript mirrored from a machine/path that is gone).
+    """
+    p = Path(cwd)
+    if p.is_dir():
+        return p.name, "cwd_dir"
+    return "others", "cwd_missing"
+
+
+def _resolve_project(cwd: str) -> tuple[str, str]:
+    """Project + source for a cwd: detect_project, else the folder-name fallback."""
+    from ._project import detect_project
+
+    try:
+        project, source = detect_project(Path(cwd))
+    except Exception:  # detection is best-effort; never block the mirror
+        project, source = None, None
+    if not project:
+        return _fallback_project(cwd)
+    return project, source
+
+
+def _load_offsets() -> dict[str, int]:
+    try:
+        return json.loads(_OFFSETS_PATH.read_text())
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+def _save_offsets(offsets: dict[str, int]) -> None:
+    _OFFSETS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = _OFFSETS_PATH.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(offsets))
+    tmp.replace(_OFFSETS_PATH)
+
+
+_WINDOW_UNITS = {"m": 60, "h": 3600, "d": 86400}
+
+
+def _parse_window(spec: str) -> float | None:
+    spec = spec.strip().lower()
+    if not spec:
+        return None
+    try:
+        if spec[-1] in _WINDOW_UNITS:
+            return float(spec[:-1]) * _WINDOW_UNITS[spec[-1]]
+        return float(spec)
+    except ValueError:
+        warn(f"unrecognized --since window {spec!r}; ignoring")
+        return None
+
+
+def _read_new_events(path: Path, state: _FileState) -> list[dict[str, Any]]:
+    """Read complete JSONL lines past the cursor; advance the cursor past them."""
+    size = path.stat().st_size
+    if state.offset > size:  # file truncated/rotated — re-read from the top.
+        state.offset = 0
+    with path.open("rb") as fh:
+        fh.seek(state.offset)
+        chunk = fh.read()
+    if b"\n" not in chunk:
+        return []
+    body, _, _ = chunk.rpartition(b"\n")
+    state.offset += len(body) + 1
+    events = []
+    for raw in body.split(b"\n"):
+        if not raw.strip():
+            continue
+        try:
+            events.append(json.loads(raw))
+        except json.JSONDecodeError:
+            continue
+    return events
+
+
+_COMMAND_NOISE = ("<command-", "<local-command-")
+
+
+def _derive_metadata(state: _FileState, events: list[dict[str, Any]]) -> None:
+    """Fill project/model/name from the transcript the first time we see them."""
+    if state.project is None:
+        cwd = next((e.get("cwd") for e in events if e.get("cwd")), None)
+        if cwd:
+            state.project, state.project_source = _resolve_project(cwd)
+            if state.name is None:
+                state.name = f"Claude · {state.project.split('/')[-1]}"
+    if state.model is None:
+        for e in events:
+            if e.get("type") == "assistant" and isinstance(e.get("message"), dict):
+                model = e["message"].get("model")
+                if model:
+                    state.model = model
+                    break
+    # Prefer the first real user prompt as the session name.
+    if events and (state.name is None or state.name.startswith("Claude · ")):
+        prompt = _first_prompt(events)
+        if prompt:
+            state.name = prompt[:72]
+
+
+def _peek_head(path: Path) -> tuple[str, str | None]:
+    """Recover (sessionId, cwd) from a transcript's head without consuming the tail.
+
+    Needed for idle files after a restart: with no new events to read, the session
+    id is otherwise unknown (the liveness sweep would never flip it completed) and
+    the cwd needed to attribute it to a project is otherwise unavailable.
+    """
+    uid = ""
+    cwd: str | None = None
+    try:
+        with path.open("rb") as fh:
+            for _ in range(20):
+                line = fh.readline()
+                if not line:
+                    break
+                try:
+                    ev = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not uid and ev.get("sessionId"):
+                    uid = str(ev["sessionId"])
+                if cwd is None and ev.get("cwd"):
+                    cwd = str(ev["cwd"])
+                if uid and cwd is not None:
+                    break
+    except OSError:
+        pass
+    return uid or path.stem, cwd
+
+
+async def _attribute_idle(db, state: _FileState, cwd: str) -> None:
+    """Attribute an idle/already-read transcript and backfill its session row.
+
+    The activity path attributes a project from streamed events, but a session
+    fully mirrored before project attribution existed (or before its cwd could be
+    placed) has no new events to trigger that. This derives the project from the
+    head cwd and backfills the existing row — without moving the liveness clock.
+    """
+    from lionagi.state.claude_mirror import session_db_id
+
+    state.project, state.project_source = _resolve_project(cwd)
+    row = await db.get_session(session_db_id(state.session_uid))
+    if row is not None and not row.get("project"):
+        await db.set_session_provenance(
+            session_db_id(state.session_uid),
+            project=state.project,
+            project_source=state.project_source,
+        )
+
+
+def _first_prompt(events: list[dict[str, Any]]) -> str | None:
+    for e in events:
+        if e.get("type") != "user" or e.get("isMeta"):
+            continue
+        msg = e.get("message")
+        content = msg.get("content") if isinstance(msg, dict) else None
+        text = ""
+        if isinstance(content, str):
+            text = content
+        elif isinstance(content, list):
+            text = " ".join(
+                b.get("text", "")
+                for b in content
+                if isinstance(b, dict) and b.get("type") == "text"
+            )
+        text = text.strip()
+        if text and not text.startswith(_COMMAND_NOISE):
+            return " ".join(text.split())
+    return None
+
+
+async def _mirror_one(db, path: Path, state: _FileState, lineage: _Lineage) -> int:
+    from lionagi.state.claude_mirror import mirror_session
+
+    events = _read_new_events(path, state)
+    if not events:
+        return 0
+
+    if not state.session_uid:
+        state.session_uid = next((e["sessionId"] for e in events if e.get("sessionId")), path.stem)
+    _derive_metadata(state, events)
+    lineage.note_head(state, events)
+    lineage.note_leaf(state, events)
+
+    # Always created/kept running; the session-level idle sweep (after the whole
+    # pass) is what flips it to completed, so a fresh transcript anywhere in a
+    # multi-file session keeps the whole session live.
+    written = await mirror_session(
+        db,
+        session_uid=state.session_uid,
+        events=events,
+        tool_names=state.tool_names,
+        project=state.project,
+        project_source=state.project_source,
+        model=state.model,
+        name=state.name,
+        status="running",
+    )
+    if written and not state.created:
+        state.created = True
+        progress(f"  mirror: {state.name or state.session_uid[:8]} (+{written} msgs)")
+    return written
+
+
+async def _one_pass(db, root: Path, states, offsets, *, since, live_window, lineage=None) -> int:
+    now = time.time()
+    total = 0
+    seen: set[str] = set()
+    if lineage is None:
+        lineage = _Lineage()
+    for path in sorted(root.glob("*/*.jsonl")):
+        if "_precompact_" in path.name:
+            continue  # PreCompact-hook backups duplicate the live transcript (same sessionId)
+        try:
+            if since is not None and (now - path.stat().st_mtime) > since:
+                continue
+            key = str(path)
+            state = states.get(key)
+            if state is None:
+                state = _FileState(session_uid="", offset=offsets.get(key, 0))
+                states[key] = state
+            total += await _mirror_one(db, path, state, lineage)
+            offsets[key] = state.offset
+            # Idle/already-read files have no streamed events to derive from: peek
+            # the head once to recover the session id and (one-time) attribute the
+            # project, backfilling a row left as "(no project)" by an earlier pass.
+            if not state.session_uid or (state.project is None and not state.attr_peeked):
+                uid, cwd = _peek_head(path)
+                if not state.session_uid:
+                    state.session_uid = uid
+                if state.project is None and not state.attr_peeked:
+                    state.attr_peeked = True
+                    if cwd:
+                        await _attribute_idle(db, state, cwd)
+            seen.add(state.session_uid)
+        except FileNotFoundError:
+            continue
+        except Exception as exc:  # one bad transcript must not kill the tail
+            log_error(f"mirror failed for {path.name}: {exc}")
+    from lionagi.state.claude_mirror import link_session_lineage, reconcile_session_status
+
+    for uid in seen:
+        await reconcile_session_status(db, uid, now=now, live_window=live_window)
+    for child_uid, parent_uid, parent_event_uuid in lineage.resolve():
+        await link_session_lineage(
+            db, child_uid=child_uid, parent_uid=parent_uid, parent_event_uuid=parent_event_uuid
+        )
+        progress(f"  mirror: {child_uid[:8]} continues {parent_uid[:8]} (lineage)")
+    return total
+
+
+async def mirror_forever(
+    stop: asyncio.Event,
+    *,
+    root: Path | None = None,
+    since: str | None = "24h",
+    interval: float = 5.0,
+    live_window: float = _DEFAULT_LIVE_WINDOW,
+) -> None:
+    """Tail recent Claude transcripts into StateDB until ``stop`` is set.
+
+    ``since`` bounds the scan to the recent window, so it catches up and tails
+    live without ever backfilling full history. Studio's in-process entry point;
+    ``li mirror`` keeps its own loop in ``_run``.
+    """
+    from lionagi.state.db import StateDB
+
+    root = Path(root).expanduser() if root else CLAUDE_PROJECTS_DIR
+    if not root.exists():
+        return
+    since_secs = _parse_window(since) if since else None
+    offsets = _load_offsets()
+    states: dict[str, _FileState] = {}
+    lineage = _Lineage()
+    async with StateDB() as db:
+        while not stop.is_set():
+            try:
+                await _one_pass(
+                    db,
+                    root,
+                    states,
+                    offsets,
+                    since=since_secs,
+                    live_window=live_window,
+                    lineage=lineage,
+                )
+                _save_offsets(offsets)
+            except Exception:  # a single bad pass must never kill the tail
+                _log.exception("claude mirror pass failed")
+            try:
+                await asyncio.wait_for(stop.wait(), timeout=interval)
+            except (asyncio.TimeoutError, TimeoutError):
+                pass
+
+
+async def _run(args: argparse.Namespace) -> int:
+    import anyio
+
+    from lionagi.state.db import StateDB
+
+    root = Path(args.root).expanduser() if args.root else CLAUDE_PROJECTS_DIR
+    if not root.exists():
+        warn(f"no Claude projects directory at {root}")
+        return 1
+
+    since = _parse_window(args.since) if args.since else None
+    offsets = _load_offsets()
+    states: dict[str, _FileState] = {}
+    lineage = _Lineage()
+
+    mode = "catch-up pass" if args.once else f"tailing (every {args.interval:g}s)"
+    hint(f"li mirror: {mode} over {root}")
+
+    async with StateDB() as db:
+        while True:
+            n = await _one_pass(
+                db,
+                root,
+                states,
+                offsets,
+                since=since,
+                live_window=args.live_window,
+                lineage=lineage,
+            )
+            _save_offsets(offsets)
+            if n:
+                progress(f"  mirrored {n} new message(s)")
+            if args.once:
+                break
+            await anyio.sleep(args.interval)
+    return 0
+
+
+def run_mirror(args: argparse.Namespace) -> int:
+    from lionagi.ln.concurrency import run_async
+
+    try:
+        return run_async(_run(args))
+    except KeyboardInterrupt:
+        hint("li mirror: stopped")
+        return 0

--- a/lionagi/cli/mirror.py
+++ b/lionagi/cli/mirror.py
@@ -170,18 +170,51 @@ def _resolve_project(cwd: str) -> tuple[str, str]:
     return project, source
 
 
-def _load_offsets() -> dict[str, int]:
+def _load_states() -> dict[str, _FileState]:
+    # Persist tool_names + leaf_uuid alongside the byte offset so a restart resumes
+    # mid-conversation without dropping a later tool_result's function name or
+    # losing cross-session lineage — both live only in process memory otherwise.
+    # Legacy {path: int} caches (offset only) load as bare cursors, then upgrade.
     try:
-        return json.loads(_OFFSETS_PATH.read_text())
+        raw = json.loads(_OFFSETS_PATH.read_text())
     except (FileNotFoundError, json.JSONDecodeError):
         return {}
+    states: dict[str, _FileState] = {}
+    for key, val in raw.items():
+        if isinstance(val, int):
+            states[key] = _FileState(session_uid="", offset=val)
+        elif isinstance(val, dict):
+            states[key] = _FileState(
+                session_uid=val.get("session_uid") or "",
+                offset=val.get("offset", 0),
+                tool_names=dict(val.get("tool_names") or {}),
+                leaf_uuid=val.get("leaf_uuid"),
+            )
+    return states
 
 
-def _save_offsets(offsets: dict[str, int]) -> None:
+def _save_states(states: dict[str, _FileState]) -> None:
     _OFFSETS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        key: {
+            "offset": st.offset,
+            "session_uid": st.session_uid,
+            "tool_names": st.tool_names,
+            "leaf_uuid": st.leaf_uuid,
+        }
+        for key, st in states.items()
+    }
     tmp = _OFFSETS_PATH.with_suffix(".json.tmp")
-    tmp.write_text(json.dumps(offsets))
+    tmp.write_text(json.dumps(payload))
     tmp.replace(_OFFSETS_PATH)
+
+
+def _seed_lineage(lineage: _Lineage, states: dict[str, _FileState]) -> None:
+    # Re-index persisted leaves so a continuation opened after a restart still
+    # resolves its parent, whose transcript is now at EOF and streams no events.
+    for st in states.values():
+        if st.leaf_uuid and st.session_uid:
+            lineage.leaf_owner[st.leaf_uuid] = st.session_uid
 
 
 _WINDOW_UNITS = {"m": 60, "h": 3600, "d": 86400}
@@ -452,9 +485,10 @@ async def mirror_forever(
     if not root.exists():
         return
     since_secs = _parse_window(since) if since else None
-    offsets = _load_offsets()
-    states: dict[str, _FileState] = {}
+    states = _load_states()
+    offsets = {key: st.offset for key, st in states.items()}  # _one_pass new-file seed
     lineage = _Lineage()
+    _seed_lineage(lineage, states)
     async with StateDB() as db:
         while not stop.is_set():
             try:
@@ -467,7 +501,7 @@ async def mirror_forever(
                     live_window=live_window,
                     lineage=lineage,
                 )
-                _save_offsets(offsets)
+                _save_states(states)
             except Exception:  # a single bad pass must never kill the tail
                 _log.exception("claude mirror pass failed")
             try:
@@ -487,9 +521,10 @@ async def _run(args: argparse.Namespace) -> int:
         return 1
 
     since = args.since  # argparse already parsed --since to seconds (or None)
-    offsets = _load_offsets()
-    states: dict[str, _FileState] = {}
+    states = _load_states()
+    offsets = {key: st.offset for key, st in states.items()}  # _one_pass new-file seed
     lineage = _Lineage()
+    _seed_lineage(lineage, states)
 
     mode = "catch-up pass" if args.once else f"tailing (every {args.interval:g}s)"
     hint(f"li mirror: {mode} over {root}")
@@ -505,7 +540,7 @@ async def _run(args: argparse.Namespace) -> int:
                 live_window=args.live_window,
                 lineage=lineage,
             )
-            _save_offsets(offsets)
+            _save_states(states)
             if n:
                 progress(f"  mirrored {n} new message(s)")
             if args.once:

--- a/lionagi/cli/mirror.py
+++ b/lionagi/cli/mirror.py
@@ -293,6 +293,8 @@ def _peek_head(path: Path) -> tuple[str, str | None]:
                     ev = json.loads(line)
                 except json.JSONDecodeError:
                     continue
+                if not isinstance(ev, dict):  # non-dict JSON (e.g. `[]`) — skip, don't .get()
+                    continue
                 if not uid and ev.get("sessionId"):
                     uid = str(ev["sessionId"])
                 if cwd is None and ev.get("cwd"):

--- a/lionagi/state/claude_mirror.py
+++ b/lionagi/state/claude_mirror.py
@@ -235,18 +235,25 @@ async def mirror_session(
         messages.extend(messages_for_event(ev, session_uid, tool_names))
 
     existing = await db.get_session(sid)
+    if existing is None and not messages:
+        return 0
 
+    first_ts = min((m.created_at for m in messages), default=None)
+    last_ts = max((m.created_at for m in messages), default=None)
+    created_at = (existing.get("created_at") if existing is not None else None) or first_ts
+
+    # Ensure the full scaffold (progressions -> session -> branch) exists on every
+    # call, in dependency order. Each write is INSERT OR IGNORE, so once present
+    # this is a no-op; if an earlier pass died mid-scaffold (e.g. the branch write
+    # raised after the session row committed) the next pass repairs the partial
+    # instead of skipping scaffolding just because the session row now exists.
+    await db.create_progression(sprog)
+    await db.create_progression(bprog)
     if existing is None:
-        if not messages:
-            return 0
-        first_ts = min(m.created_at for m in messages)
-        last_ts = max(m.created_at for m in messages)
-        await db.create_progression(sprog)
-        await db.create_progression(bprog)
         await db.create_session(
             {
                 "id": sid,
-                "created_at": first_ts,
+                "created_at": created_at,
                 "progression_id": sprog,
                 "name": name or "Claude Code session",
                 "status": status,
@@ -260,23 +267,23 @@ async def mirror_session(
                 "updated_at": last_ts,
             }
         )
-        await db.create_branch(
-            {
-                "id": branch_id,
-                "created_at": first_ts,
-                "session_id": sid,
-                "progression_id": bprog,
-                "model": model,
-                "provider": provider,
-                "agent_name": "claude-code",
-            }
-        )
     elif project and not existing.get("project"):
         # Backfill attribution for a session first mirrored before its cwd could
         # be attributed to a project. INSERT OR IGNORE never updates an existing
         # row, so without this an already-seen "(no project)" session stays that
         # way forever; this writes it without disturbing the liveness clock.
         await db.set_session_provenance(sid, project=project, project_source=project_source)
+    await db.create_branch(
+        {
+            "id": branch_id,
+            "created_at": created_at,
+            "session_id": sid,
+            "progression_id": bprog,
+            "model": model,
+            "provider": provider,
+            "agent_name": "claude-code",
+        }
+    )
 
     for m in messages:
         md = m.to_dict(mode="db")
@@ -285,7 +292,7 @@ async def mirror_session(
         await db.append_to_progression(sprog, md["id"])
 
     if messages:
-        await db.touch_session_activity(sid, at=max(m.created_at for m in messages))
+        await db.touch_session_activity(sid, at=last_ts)
 
     return len(messages)
 
@@ -301,17 +308,20 @@ async def reconcile_session_status(
 
     A mirror session's ``completed`` means dormant, not terminal: when the
     transcript resumes, the next reconcile brings it back to ``running``. Liveness
-    is judged by the session's last message time (the same ``updated_at`` the
-    studio SSE reader and the phantom reaper read), so an idle session converges
-    to ``completed`` before the reaper can mark it failed, and an active one shows
-    ``running`` (a live spinner in studio and the VS Code extension).
+    is judged by ``last_message_at`` — the timestamp of the newest mirrored
+    message — so an idle session converges to ``completed`` before the reaper can
+    mark it failed, and an active one shows ``running`` (a live spinner in studio
+    and the VS Code extension). It must NOT read ``updated_at``: the status write
+    below bumps ``updated_at``, so keying liveness off it would let a just-marked
+    ``completed`` session read as fresh again on the next pass and oscillate back
+    to ``running``.
     """
     from lionagi.state.reasons import RunReasons
 
     existing = await db.get_session(session_db_id(session_uid))
     if not existing:
         return
-    live = (now - float(existing.get("updated_at") or 0.0)) <= live_window
+    live = (now - float(existing.get("last_message_at") or 0.0)) <= live_window
     desired = "running" if live else "completed"
     if existing.get("status") == desired:
         return

--- a/lionagi/state/claude_mirror.py
+++ b/lionagi/state/claude_mirror.py
@@ -1,0 +1,353 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Mirror Claude Code session transcripts (~/.claude/projects/*.jsonl) into StateDB.
+
+A Claude Code session is just another writer to ``state.db``: each JSONL event
+maps to one or more lionagi messages, written under a session/branch/progression
+with deterministic ids so re-reading the same transcript never duplicates rows.
+The studio SSE reader polls the same tables, so mirrored sessions stream live in
+the dashboard and the VS Code extension with no studio-side change.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from lionagi.protocols.messages.action_request import ActionRequest
+from lionagi.protocols.messages.action_response import ActionResponse
+from lionagi.protocols.messages.assistant_response import AssistantResponse
+from lionagi.protocols.messages.instruction import Instruction
+
+if TYPE_CHECKING:
+    from lionagi.protocols.messages.message import RoledMessage
+
+    from .db import StateDB
+
+# Fixed namespace so ids derived from a Claude session/event are stable across
+# mirror restarts — the basis for idempotent, resumable writes.
+_NS = uuid.UUID("5f1d6e2a-1c3b-4a5d-8e9f-0a1b2c3d4e5f")
+
+# Only conversation-bearing events become messages; the rest is editor metadata.
+_MESSAGE_TYPES = frozenset({"user", "assistant"})
+
+# Slash-command invocations and local-command output wrap their text in these
+# tags. They are editor machinery, not conversation — a real prompt never opens
+# with one — so they are dropped to keep the mirrored transcript readable.
+_COMMAND_NOISE_PREFIXES = ("<command-", "<local-command-")
+
+
+def _det(*parts: str) -> str:
+    """Deterministic UUID for a logical entity (session/branch/message/link)."""
+    return str(uuid.uuid5(_NS, "|".join(parts)))
+
+
+def session_db_id(session_uid: str) -> str:
+    """StateDB session id for a Claude session uuid (stable across runs)."""
+    return _det(session_uid, "session")
+
+
+def _ts(iso: str | None) -> float | None:
+    if not iso:
+        return None
+    try:
+        return datetime.fromisoformat(iso.replace("Z", "+00:00")).timestamp()
+    except (ValueError, TypeError):
+        return None
+
+
+def _tool_result_text(content: Any) -> str:
+    """Flatten a Claude tool_result payload (str | blocks | dict) to display text."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for c in content:
+            if isinstance(c, dict):
+                if c.get("type") == "text" or "text" in c:
+                    parts.append(str(c.get("text", "")))
+            elif isinstance(c, str):
+                parts.append(c)
+        return "\n".join(p for p in parts if p)
+    if isinstance(content, dict):
+        return content.get("text") or json.dumps(content, default=str)
+    return str(content)
+
+
+def messages_for_event(
+    event: dict[str, Any],
+    session_uid: str,
+    tool_names: dict[str, str],
+) -> list[RoledMessage]:
+    """Map one Claude JSONL event to ordered lionagi messages.
+
+    ``tool_names`` is read/written in place: tool_use blocks record their
+    function name so the matching tool_result can label its ActionResponse.
+    """
+    etype = event.get("type")
+    if etype not in _MESSAGE_TYPES or event.get("isMeta"):
+        return []
+    msg = event.get("message")
+    if not isinstance(msg, dict):
+        return []
+
+    euid = str(event.get("uuid") or "")
+    base = _ts(event.get("timestamp")) or 0.0
+    content = msg.get("content")
+    blocks: list[Any]
+    if isinstance(content, str):
+        blocks = [{"type": "text", "text": content}]
+    elif isinstance(content, list):
+        blocks = content
+    else:
+        blocks = []
+
+    # Each spec is (id, builder(id, created_at) -> message); built in order with
+    # a micro-incremented timestamp so messages of one event stay ordered.
+    specs: list[tuple[str, Any]] = []
+
+    if etype == "user":
+        text_parts: list[str] = []
+        for b in blocks:
+            if not isinstance(b, dict):
+                continue
+            bt = b.get("type")
+            if bt == "text" and b.get("text"):
+                text_parts.append(b["text"])
+            elif bt == "tool_result":
+                tuid = str(b.get("tool_use_id") or "")
+                out = _tool_result_text(b.get("content"))
+                err = "error" if b.get("is_error") else None
+                link = _det(session_uid, "toolreq", tuid) if tuid else None
+                mid = _det(session_uid, "toolresp", tuid or euid)
+                fn = tool_names.get(tuid, "")
+                specs.append(
+                    (
+                        mid,
+                        lambda mid, ts, fn=fn, out=out, link=link, err=err: ActionResponse(
+                            id=mid,
+                            created_at=ts,
+                            content={
+                                "function": fn,
+                                "output": out,
+                                "action_request_id": link,
+                                "error": err,
+                            },
+                        ),
+                    )
+                )
+        text = "".join(text_parts).strip()
+        if text and not text.startswith(_COMMAND_NOISE_PREFIXES):
+            mid = _det(session_uid, euid, "instr")
+            specs.insert(
+                0,
+                (
+                    mid,
+                    lambda mid, ts, text=text: Instruction(
+                        id=mid, created_at=ts, content={"instruction": text}
+                    ),
+                ),
+            )
+
+    elif etype == "assistant":
+        buf: list[str] = []
+        flush_n = 0
+
+        def _flush() -> None:
+            nonlocal flush_n
+            txt = "".join(buf).strip()
+            buf.clear()
+            if not txt:
+                return
+            mid = _det(session_uid, euid, "text", str(flush_n))
+            specs.append(
+                (
+                    mid,
+                    lambda mid, ts, txt=txt: AssistantResponse(
+                        id=mid, created_at=ts, content={"assistant_response": txt}
+                    ),
+                )
+            )
+            flush_n += 1
+
+        for b in blocks:
+            if not isinstance(b, dict):
+                continue
+            bt = b.get("type")
+            if bt == "text" and b.get("text"):
+                buf.append(b["text"])
+            elif bt == "tool_use":
+                _flush()  # preserve text→tool ordering within the turn
+                tuid = str(b.get("id") or "")
+                fn = b.get("name") or ""
+                args = b.get("input")
+                if not isinstance(args, dict):
+                    args = {} if args is None else {"value": args}
+                if tuid:
+                    tool_names[tuid] = fn
+                mid = _det(session_uid, "toolreq", tuid or f"{euid}:{len(specs)}")
+                specs.append(
+                    (
+                        mid,
+                        lambda mid, ts, fn=fn, args=args: ActionRequest(
+                            id=mid, created_at=ts, content={"function": fn, "arguments": args}
+                        ),
+                    )
+                )
+            # thinking blocks carry no display value in the studio reader — skip.
+        _flush()
+
+    return [builder(mid, base + i * 1e-3) for i, (mid, builder) in enumerate(specs)]
+
+
+async def mirror_session(
+    db: StateDB,
+    *,
+    session_uid: str,
+    events: list[dict[str, Any]],
+    tool_names: dict[str, str],
+    project: str | None = None,
+    project_source: str | None = None,
+    model: str | None = None,
+    provider: str | None = "anthropic",
+    name: str | None = None,
+    status: str = "running",
+) -> int:
+    """Idempotently write a batch of Claude events for one session; returns msgs written.
+
+    Re-calling with already-seen events is a no-op: message ids are deterministic
+    (upsert), and progression appends dedupe. Creates the session/branch on first
+    call with a rich row (project, model, agent_name) so it groups correctly in
+    the runs explorer, with ``status`` as the initial status. Live/idle transitions
+    are owned by ``reconcile_session_status``, not this writer.
+    """
+    sid = session_db_id(session_uid)
+    branch_id = _det(session_uid, "branch")
+    bprog = _det(session_uid, "bprog")
+    sprog = _det(session_uid, "sprog")
+
+    messages: list[RoledMessage] = []
+    for ev in events:
+        messages.extend(messages_for_event(ev, session_uid, tool_names))
+
+    existing = await db.get_session(sid)
+
+    if existing is None:
+        if not messages:
+            return 0
+        first_ts = min(m.created_at for m in messages)
+        last_ts = max(m.created_at for m in messages)
+        await db.create_progression(sprog)
+        await db.create_progression(bprog)
+        await db.create_session(
+            {
+                "id": sid,
+                "created_at": first_ts,
+                "progression_id": sprog,
+                "name": name or "Claude Code session",
+                "status": status,
+                "invocation_kind": "agent",
+                "agent_name": "claude-code",
+                "model": model,
+                "provider": provider,
+                "project": project,
+                "project_source": project_source,
+                "started_at": first_ts,
+                "updated_at": last_ts,
+            }
+        )
+        await db.create_branch(
+            {
+                "id": branch_id,
+                "created_at": first_ts,
+                "session_id": sid,
+                "progression_id": bprog,
+                "model": model,
+                "provider": provider,
+                "agent_name": "claude-code",
+            }
+        )
+    elif project and not existing.get("project"):
+        # Backfill attribution for a session first mirrored before its cwd could
+        # be attributed to a project. INSERT OR IGNORE never updates an existing
+        # row, so without this an already-seen "(no project)" session stays that
+        # way forever; this writes it without disturbing the liveness clock.
+        await db.set_session_provenance(sid, project=project, project_source=project_source)
+
+    for m in messages:
+        md = m.to_dict(mode="db")
+        await db.insert_message(md)
+        await db.append_to_progression(bprog, md["id"])
+        await db.append_to_progression(sprog, md["id"])
+
+    if messages:
+        await db.touch_session_activity(sid, at=max(m.created_at for m in messages))
+
+    return len(messages)
+
+
+async def reconcile_session_status(
+    db: StateDB,
+    session_uid: str,
+    *,
+    now: float,
+    live_window: float,
+) -> None:
+    """Align a mirrored session's status with its live/idle state — both directions.
+
+    A mirror session's ``completed`` means dormant, not terminal: when the
+    transcript resumes, the next reconcile brings it back to ``running``. Liveness
+    is judged by the session's last message time (the same ``updated_at`` the
+    studio SSE reader and the phantom reaper read), so an idle session converges
+    to ``completed`` before the reaper can mark it failed, and an active one shows
+    ``running`` (a live spinner in studio and the VS Code extension).
+    """
+    from lionagi.state.reasons import RunReasons
+
+    existing = await db.get_session(session_db_id(session_uid))
+    if not existing:
+        return
+    live = (now - float(existing.get("updated_at") or 0.0)) <= live_window
+    desired = "running" if live else "completed"
+    if existing.get("status") == desired:
+        return
+    await db.update_session(
+        session_db_id(session_uid),
+        status=desired,
+        reason_code=RunReasons.STARTED_OK if desired == "running" else RunReasons.COMPLETED_OK,
+    )
+
+
+async def link_session_lineage(
+    db: StateDB,
+    *,
+    child_uid: str,
+    parent_uid: str,
+    parent_event_uuid: str,
+) -> None:
+    """Record that one Claude session continues another (conversation lineage).
+
+    A continued conversation (after compaction, ``--resume``, or a fresh window
+    that picks up an earlier thread) starts a new transcript whose first message
+    points, via ``parentUuid``, at the last message of the session it continues.
+    When the mirror resolves that pointer to a different session it calls this to
+    store a ``lineage`` link on the child's node_metadata, so studio and the VS
+    Code extension can show the provenance and walk the chain back. Written
+    without moving the liveness clock; idempotent (re-linking rewrites the same
+    value).
+    """
+    child_sid = session_db_id(child_uid)
+    existing = await db.get_session(child_sid)
+    if existing is None:
+        return
+    meta = dict(existing.get("node_metadata") or {})
+    meta["lineage"] = {
+        "parent_session_id": session_db_id(parent_uid),
+        "parent_session_uid": parent_uid,
+        "parent_event_uuid": parent_event_uuid,
+    }
+    await db.set_session_provenance(child_sid, node_metadata=meta)

--- a/tests/cli/test_mirror.py
+++ b/tests/cli/test_mirror.py
@@ -16,9 +16,12 @@ from lionagi.cli.mirror import (
     _FileState,
     _first_prompt,
     _Lineage,
+    _load_states,
     _one_pass,
     _parse_window,
     _read_new_events,
+    _save_states,
+    _seed_lineage,
     _since_window,
 )
 from lionagi.state.claude_mirror import (
@@ -744,3 +747,93 @@ async def test_peek_head_skips_non_dict_head_line(temp_db_path: Path, tmp_path: 
         await _one_pass(db, root, {}, offsets, since=None, live_window=300)
         row = await db.get_session(session_db_id(uid))
     assert row["status"] == "completed"
+
+
+# ── restart durability: derived state persisted with the cursor ──────────────
+
+
+@pytest.mark.asyncio
+async def test_tool_name_survives_restart_between_use_and_result(
+    temp_db_path: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A restart between a tool_use and its tool_result must not drop the response's
+    # function name. tool_names is rebuilt from the persisted per-file state, so the
+    # ActionResponse still labels the call instead of falling back to "".
+    monkeypatch.setattr("lionagi.cli.mirror._OFFSETS_PATH", tmp_path / "offsets.json")
+    root = tmp_path / "projects"
+    path = root / "-w-proj" / f"{SID}.jsonl"
+    _write_lineage_file(
+        path,
+        [
+            _user_text("u1", "run it"),
+            _assistant("a1", [{"type": "tool_use", "id": "tool_1", "name": "Bash", "input": {}}]),
+        ],
+    )
+    async with StateDB() as db:
+        # Pass 1: mirror the tool_use, persist the cursor + tool_names, then drop
+        # all in-memory state — a restart.
+        states1: dict[str, _FileState] = {}
+        await _one_pass(db, root, states1, {}, since=None, live_window=300)
+        _save_states(states1)
+
+        # Restart: state comes back from disk only.
+        states2 = _load_states()
+        offsets2 = {k: s.offset for k, s in states2.items()}
+
+        # The tool_result lands after the restart.
+        with path.open("a") as fh:
+            fh.write(json.dumps(_tool_result("u2", "tool_1", "total 0")) + "\n")
+        await _one_pass(db, root, states2, offsets2, since=None, live_window=300)
+
+        row = await db.get_session(session_db_id(SID))
+        contents = []
+        for mid in await db.get_progression(row["progression_id"]):
+            c = (await db.get_message(mid))["content"]
+            contents.append(json.loads(c) if isinstance(c, str) else c)
+    resp = next(c for c in contents if "action_request_id" in c)
+    assert resp["function"] == "Bash"  # recovered from persisted tool_names, not ""
+
+
+@pytest.mark.asyncio
+async def test_lineage_resolves_after_restart(
+    temp_db_path: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The parent transcript is mirrored, then state is dropped (restart) before the
+    # continuation arrives. Its leaf is re-indexed from persisted state on reload,
+    # so the child still links to it instead of losing the cross-session lineage.
+    monkeypatch.setattr("lionagi.cli.mirror._OFFSETS_PATH", tmp_path / "offsets.json")
+    root = tmp_path / "projects"
+    a = "a1a1a1a1-0000-0000-0000-000000000aaa"
+    b = "b2b2b2b2-0000-0000-0000-000000000bbb"
+    _write_lineage_file(
+        root / "-w-proj" / f"{a}.jsonl",
+        [
+            _lineage_event(a, "a-1", None, "user", "start the work"),
+            _lineage_event(a, "a-leaf", "a-1", "assistant", "done, ending here"),
+        ],
+    )
+    async with StateDB() as db:
+        # Pass 1: mirror only the parent; persist its leaf index, then restart.
+        states1: dict[str, _FileState] = {}
+        await _one_pass(db, root, states1, {}, since=None, live_window=300)
+        _save_states(states1)
+
+        # Restart: rebuild states + re-seed the leaf index from disk only.
+        states2 = _load_states()
+        offsets2 = {k: s.offset for k, s in states2.items()}
+        lineage2 = _Lineage()
+        _seed_lineage(lineage2, states2)
+
+        # The continuation opens after the restart, pointing at the parent's leaf.
+        _write_lineage_file(
+            root / "-w-proj" / f"{b}.jsonl",
+            [
+                _lineage_event(b, "b-1", "a-leaf", "user", "continuing from before"),
+                _lineage_event(b, "b-2", "b-1", "assistant", "picking it up"),
+            ],
+        )
+        await _one_pass(db, root, states2, offsets2, since=None, live_window=300, lineage=lineage2)
+        child = await db.get_session(session_db_id(b))
+    lineage = child["node_metadata"]["lineage"]
+    assert lineage["parent_session_uid"] == a
+    assert lineage["parent_event_uuid"] == "a-leaf"

--- a/tests/cli/test_mirror.py
+++ b/tests/cli/test_mirror.py
@@ -721,3 +721,26 @@ async def test_idle_session_backfilled_with_project(temp_db_path: Path, tmp_path
         row = await db.get_session(session_db_id(uid))
     assert row["project"] == "ghost-proj"
     assert row["project_source"] == "cwd_dir"
+
+
+@pytest.mark.asyncio
+async def test_peek_head_skips_non_dict_head_line(temp_db_path: Path, tmp_path: Path) -> None:
+    # A valid-JSON-but-non-dict head line (e.g. `[]`) must not wedge the idle
+    # reconcile path: _peek_head must skip it like _read_new_events, so an
+    # already-mirrored, now-idle session still reconciles to completed instead of
+    # being left stuck at running by an AttributeError swallowed mid-pass.
+    root = tmp_path / "projects"
+    uid = "abababab-0000-0000-0000-0000000000cd"
+    path = root / "-w-proj" / f"{uid}.jsonl"
+    _write_session_file(path, uid, age_secs=7200)  # idle -> should become completed
+    events = [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+    path.write_text("[]\n" + path.read_text())  # prepend a non-dict JSON head line
+    async with StateDB() as db:
+        await mirror_session(db, session_uid=uid, events=events, tool_names={}, status="running")
+        assert (await db.get_session(session_db_id(uid)))["status"] == "running"
+        # Idle pass: file already fully read (offset at EOF) -> no streamed events,
+        # so _peek_head scans the head and hits the `[]` line.
+        offsets = {str(path): path.stat().st_size}
+        await _one_pass(db, root, {}, offsets, since=None, live_window=300)
+        row = await db.get_session(session_db_id(uid))
+    assert row["status"] == "completed"

--- a/tests/cli/test_mirror.py
+++ b/tests/cli/test_mirror.py
@@ -1,0 +1,602 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for `li mirror` — Claude Code transcript -> StateDB mirror."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from lionagi.cli.mirror import (
+    _derive_metadata,
+    _fallback_project,
+    _FileState,
+    _first_prompt,
+    _Lineage,
+    _one_pass,
+    _parse_window,
+    _read_new_events,
+)
+from lionagi.state.claude_mirror import (
+    messages_for_event,
+    mirror_session,
+    reconcile_session_status,
+    session_db_id,
+)
+from lionagi.state.db import StateDB
+
+SID = "11111111-2222-3333-4444-555555555555"
+
+
+# ── Event builders (verified Claude JSONL shapes) ────────────────────────────
+
+
+def _user_text(uuid: str, text: str, *, ts: str = "2026-06-20T00:00:00.000Z") -> dict:
+    return {
+        "type": "user",
+        "uuid": uuid,
+        "timestamp": ts,
+        "sessionId": SID,
+        "message": {"role": "user", "content": [{"type": "text", "text": text}]},
+    }
+
+
+def _assistant(uuid: str, blocks: list[dict], *, ts: str = "2026-06-20T00:00:01.000Z") -> dict:
+    return {
+        "type": "assistant",
+        "uuid": uuid,
+        "timestamp": ts,
+        "sessionId": SID,
+        "message": {"role": "assistant", "model": "claude-opus-4-8", "content": blocks},
+    }
+
+
+def _tool_result(uuid: str, tool_use_id: str, content, *, is_error: bool = False) -> dict:
+    return {
+        "type": "user",
+        "uuid": uuid,
+        "timestamp": "2026-06-20T00:00:02.000Z",
+        "sessionId": SID,
+        "message": {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": tool_use_id,
+                    "content": content,
+                    "is_error": is_error,
+                }
+            ],
+        },
+    }
+
+
+def _db_content(msg) -> dict:
+    c = msg.to_dict(mode="db")["content"]
+    return json.loads(c) if isinstance(c, str) else c
+
+
+# ── messages_for_event: mapping + ordering + linkage ─────────────────────────
+
+
+def test_user_text_maps_to_single_instruction() -> None:
+    out = messages_for_event(_user_text("u1", "hello there"), SID, {})
+    assert [type(m).__name__ for m in out] == ["Instruction"]
+
+
+def test_bare_string_user_content_supported() -> None:
+    ev = {
+        "type": "user",
+        "uuid": "u1",
+        "timestamp": "2026-06-20T00:00:00Z",
+        "sessionId": SID,
+        "message": {"role": "user", "content": "plain string content"},
+    }
+    out = messages_for_event(ev, SID, {})
+    assert [type(m).__name__ for m in out] == ["Instruction"]
+
+
+def test_command_noise_user_text_is_dropped() -> None:
+    ev = _user_text("u1", "<command-name>/clear</command-name>")
+    assert messages_for_event(ev, SID, {}) == []
+
+
+def test_meta_event_is_dropped() -> None:
+    ev = _user_text("u1", "real text")
+    ev["isMeta"] = True
+    assert messages_for_event(ev, SID, {}) == []
+
+
+def test_assistant_text_then_tool_preserves_order() -> None:
+    ev = _assistant(
+        "a1",
+        [
+            {"type": "text", "text": "let me check"},
+            {"type": "tool_use", "id": "tool_1", "name": "Bash", "input": {"command": "ls"}},
+            {"type": "text", "text": "done"},
+        ],
+    )
+    tool_names: dict[str, str] = {}
+    out = messages_for_event(ev, SID, tool_names)
+    assert [type(m).__name__ for m in out] == [
+        "AssistantResponse",
+        "ActionRequest",
+        "AssistantResponse",
+    ]
+    # tool_use records its function name for the later tool_result to label.
+    assert tool_names["tool_1"] == "Bash"
+    # micro-incremented timestamps keep intra-event order stable.
+    assert out[0].created_at < out[1].created_at < out[2].created_at
+
+
+def test_thinking_block_is_skipped() -> None:
+    ev = _assistant(
+        "a1",
+        [{"type": "thinking", "thinking": "hmm"}, {"type": "text", "text": "answer"}],
+    )
+    out = messages_for_event(ev, SID, {})
+    assert [type(m).__name__ for m in out] == ["AssistantResponse"]
+
+
+def test_action_request_response_linkage() -> None:
+    tool_names: dict[str, str] = {}
+    req = messages_for_event(
+        _assistant("a1", [{"type": "tool_use", "id": "tool_x", "name": "Read", "input": {"p": 1}}]),
+        SID,
+        tool_names,
+    )[0]
+    resp = messages_for_event(_tool_result("u2", "tool_x", "file contents"), SID, tool_names)[0]
+    assert type(req).__name__ == "ActionRequest"
+    assert type(resp).__name__ == "ActionResponse"
+    rc = _db_content(resp)
+    # The response points back at the request id, with the recovered function name.
+    assert rc["action_request_id"] == str(req.id)
+    assert rc["function"] == "Read"
+    assert rc["output"] == "file contents"
+
+
+def test_tool_result_error_flag_recorded() -> None:
+    out = messages_for_event(_tool_result("u2", "t", "boom", is_error=True), SID, {"t": "Bash"})
+    assert _db_content(out[0])["error"] == "error"
+
+
+def test_tool_result_block_list_flattened() -> None:
+    out = messages_for_event(
+        _tool_result("u2", "t", [{"type": "text", "text": "a"}, {"type": "text", "text": "b"}]),
+        SID,
+        {"t": "Grep"},
+    )
+    assert _db_content(out[0])["output"] == "a\nb"
+
+
+def test_deterministic_ids_are_idempotent() -> None:
+    ev = _assistant(
+        "a1",
+        [
+            {"type": "text", "text": "x"},
+            {"type": "tool_use", "id": "tool_1", "name": "Bash", "input": {}},
+        ],
+    )
+    ids1 = [m.id for m in messages_for_event(ev, SID, {})]
+    ids2 = [m.id for m in messages_for_event(ev, SID, {})]
+    assert ids1 == ids2
+
+
+# ── mirror_session: idempotent write + status lifecycle ──────────────────────
+
+
+def _conversation() -> list[dict]:
+    return [
+        _user_text("u1", "do the thing"),
+        _assistant(
+            "a1",
+            [
+                {"type": "text", "text": "okay"},
+                {"type": "tool_use", "id": "tool_1", "name": "Bash", "input": {"command": "ls"}},
+            ],
+        ),
+        _tool_result("u2", "tool_1", "total 0"),
+    ]
+
+
+@pytest.fixture
+def temp_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", db_path)
+    return db_path
+
+
+@pytest.mark.asyncio
+async def test_mirror_session_creates_rich_session_row(temp_db_path: Path) -> None:
+    async with StateDB() as db:
+        n = await mirror_session(
+            db,
+            session_uid=SID,
+            events=_conversation(),
+            tool_names={},
+            project="acme/widget",
+            project_source="cwd",
+            model="claude-opus-4-8",
+            name="do the thing",
+            status="running",
+        )
+        row = await db.get_session(session_db_id(SID))
+    assert n > 0
+    assert row["status"] == "running"
+    assert row["invocation_kind"] == "agent"
+    assert row["agent_name"] == "claude-code"
+    assert row["project"] == "acme/widget"
+    assert row["model"] == "claude-opus-4-8"
+
+
+@pytest.mark.asyncio
+async def test_mirror_session_is_idempotent(temp_db_path: Path) -> None:
+    events = _conversation()
+    async with StateDB() as db:
+        await mirror_session(db, session_uid=SID, events=events, tool_names={}, status="completed")
+        row = await db.get_session(session_db_id(SID))
+        first = await db.get_progression(row["progression_id"])
+        # Re-run from scratch (fresh tool_names, as after a restart).
+        await mirror_session(db, session_uid=SID, events=events, tool_names={}, status="completed")
+        second = await db.get_progression(row["progression_id"])
+    assert len(first) > 0
+    assert first == second  # no duplicate appends
+
+
+@pytest.mark.asyncio
+async def test_reconcile_flips_running_to_completed_when_idle(temp_db_path: Path) -> None:
+    async with StateDB() as db:
+        await mirror_session(
+            db, session_uid=SID, events=_conversation(), tool_names={}, status="running"
+        )
+        before = await db.get_session(session_db_id(SID))
+        # Wall-clock well past the last message -> idle -> completed.
+        await reconcile_session_status(db, SID, now=before["updated_at"] + 10_000, live_window=300)
+        after = await db.get_session(session_db_id(SID))
+    assert before["status"] == "running"
+    assert after["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_reconcile_reactivates_completed_when_fresh(temp_db_path: Path) -> None:
+    # A mirror session's "completed" is dormant, not terminal: when the transcript
+    # resumes, reconcile brings it back to running (green check -> live spinner).
+    async with StateDB() as db:
+        await mirror_session(
+            db, session_uid=SID, events=_conversation(), tool_names={}, status="completed"
+        )
+        before = await db.get_session(session_db_id(SID))
+        # "now" within the live window of the last message -> running.
+        await reconcile_session_status(db, SID, now=before["updated_at"] + 1, live_window=300)
+        after = await db.get_session(session_db_id(SID))
+    assert before["status"] == "completed"
+    assert after["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_mirror_session_empty_no_session(temp_db_path: Path) -> None:
+    async with StateDB() as db:
+        n = await mirror_session(db, session_uid=SID, events=[], tool_names={}, status="running")
+        row = await db.get_session(session_db_id(SID))
+    assert n == 0
+    assert row is None
+
+
+# ── watcher passes: session-level liveness across multiple files ─────────────
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
+def _write_session_file(path: Path, uid: str, *, age_secs: float) -> None:
+    """One transcript file for `uid` whose messages are `age_secs` old."""
+    ts = _iso(datetime.now(timezone.utc) - timedelta(seconds=age_secs))
+    stem = path.stem
+    events = [
+        {
+            "type": "user",
+            "uuid": f"{stem}-u",
+            "timestamp": ts,
+            "sessionId": uid,
+            "message": {"role": "user", "content": [{"type": "text", "text": f"prompt {stem}"}]},
+        },
+        {
+            "type": "assistant",
+            "uuid": f"{stem}-a",
+            "timestamp": ts,
+            "sessionId": uid,
+            "message": {
+                "role": "assistant",
+                "model": "claude-opus-4-8",
+                "content": [{"type": "text", "text": "ok"}],
+            },
+        },
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(e) for e in events) + "\n")
+
+
+@pytest.mark.asyncio
+async def test_multifile_session_stays_running_when_any_file_is_fresh(
+    temp_db_path: Path, tmp_path: Path
+) -> None:
+    # A resumed session spans two transcript files sharing one sessionId: one old,
+    # one with a recent message. The merged session must read as live (running) —
+    # the regression guard against a per-file status decision burying an active one.
+    root = tmp_path / "projects"
+    uid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    _write_session_file(root / "-work-acme" / "old.jsonl", uid, age_secs=7200)
+    _write_session_file(root / "-work-acme" / "fresh.jsonl", uid, age_secs=5)
+    async with StateDB() as db:
+        await _one_pass(db, root, {}, {}, since=None, live_window=300)
+        row = await db.get_session(session_db_id(uid))
+    assert row is not None
+    assert row["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_multifile_session_completes_when_all_files_idle(
+    temp_db_path: Path, tmp_path: Path
+) -> None:
+    root = tmp_path / "projects"
+    uid = "11112222-3333-4444-5555-666677778888"
+    _write_session_file(root / "-work-acme" / "a.jsonl", uid, age_secs=7200)
+    _write_session_file(root / "-work-acme" / "b.jsonl", uid, age_secs=3600)
+    async with StateDB() as db:
+        await _one_pass(db, root, {}, {}, since=None, live_window=300)
+        row = await db.get_session(session_db_id(uid))
+    assert row is not None
+    assert row["status"] == "completed"
+
+
+# ── watcher helpers: tailing + parsing ───────────────────────────────────────
+
+
+def test_read_new_events_buffers_partial_line(tmp_path: Path) -> None:
+    path = tmp_path / "t.jsonl"
+    path.write_text('{"a":1}\n{"a":2}\n{"a":3')  # last line incomplete
+    state = _FileState(session_uid="x")
+    first = _read_new_events(path, state)
+    assert [e["a"] for e in first] == [1, 2]
+    # Complete the dangling line; the next read picks up only the new event.
+    with path.open("a") as fh:
+        fh.write("}\n")
+    second = _read_new_events(path, state)
+    assert [e["a"] for e in second] == [3]
+
+
+def test_read_new_events_resets_on_truncation(tmp_path: Path) -> None:
+    path = tmp_path / "t.jsonl"
+    path.write_text('{"a":1}\n')
+    state = _FileState(session_uid="x", offset=9999)  # offset past EOF
+    out = _read_new_events(path, state)
+    assert [e["a"] for e in out] == [1]
+
+
+def test_read_new_events_skips_corrupt_lines(tmp_path: Path) -> None:
+    path = tmp_path / "t.jsonl"
+    path.write_text('{"a":1}\nnot json\n{"a":2}\n')
+    state = _FileState(session_uid="x")
+    out = _read_new_events(path, state)
+    assert [e["a"] for e in out] == [1, 2]
+
+
+def test_first_prompt_skips_meta_and_command_noise() -> None:
+    events = [
+        {
+            "type": "user",
+            "isMeta": True,
+            "message": {"content": [{"type": "text", "text": "meta"}]},
+        },
+        {
+            "type": "user",
+            "message": {"content": [{"type": "text", "text": "<command-name>/x</command-name>"}]},
+        },
+        {"type": "assistant", "message": {"content": [{"type": "text", "text": "hi"}]}},
+        {"type": "user", "message": {"content": [{"type": "text", "text": "the real question"}]}},
+    ]
+    assert _first_prompt(events) == "the real question"
+
+
+@pytest.mark.parametrize(
+    ("spec", "expected"),
+    [("30m", 1800.0), ("12h", 43200.0), ("7d", 604800.0), ("120", 120.0), ("bad", None)],
+)
+def test_parse_window(spec: str, expected: float | None) -> None:
+    assert _parse_window(spec) == expected
+
+
+# ── project attribution fallback ─────────────────────────────────────────────
+
+
+def test_fallback_project_uses_folder_name_when_dir_exists(tmp_path: Path) -> None:
+    work = tmp_path / "my-workspace"
+    work.mkdir()
+    assert _fallback_project(str(work)) == ("my-workspace", "cwd_dir")
+
+
+def test_fallback_project_uses_others_when_dir_missing() -> None:
+    assert _fallback_project("/no/such/dir/anymore") == ("others", "cwd_missing")
+
+
+def test_derive_metadata_falls_back_to_folder_name(tmp_path: Path) -> None:
+    # A cwd that detect_project can't place (no git remote / config / override)
+    # is bucketed by its own folder name rather than left unattributed.
+    work = tmp_path / "loose-scripts"
+    work.mkdir()
+    state = _FileState(session_uid=SID)
+    _derive_metadata(
+        state, [_user_text("u1", "hi", ts="2026-06-20T00:00:00.000Z") | {"cwd": str(work)}]
+    )
+    assert state.project == "loose-scripts"
+    assert state.project_source == "cwd_dir"
+
+
+def test_derive_metadata_others_when_cwd_gone() -> None:
+    state = _FileState(session_uid=SID)
+    _derive_metadata(state, [_user_text("u1", "hi") | {"cwd": "/gone/missing/path"}])
+    assert state.project == "others"
+    assert state.project_source == "cwd_missing"
+
+
+@pytest.mark.asyncio
+async def test_mirror_session_backfills_missing_project(temp_db_path: Path) -> None:
+    # A session first mirrored with no project must be backfilled on a later pass
+    # once a project is derived — without disturbing updated_at (the liveness clock).
+    events = _conversation()
+    async with StateDB() as db:
+        await mirror_session(db, session_uid=SID, events=events, tool_names={}, project=None)
+        before = await db.get_session(session_db_id(SID))
+        assert before["project"] is None
+
+        await mirror_session(
+            db,
+            session_uid=SID,
+            events=events,
+            tool_names={},
+            project="acme/widget",
+            project_source="cwd_dir",
+        )
+        after = await db.get_session(session_db_id(SID))
+    assert after["project"] == "acme/widget"
+    assert after["project_source"] == "cwd_dir"
+    # Provenance backfill is not activity: the liveness clock must not move.
+    assert after["updated_at"] == before["updated_at"]
+
+
+# ── conversation-lineage detector ────────────────────────────────────────────
+
+
+def _lineage_event(uid: str, euid: str, parent: str | None, role: str, text: str) -> dict:
+    ev = {
+        "type": role,
+        "uuid": euid,
+        "parentUuid": parent,
+        "timestamp": _iso(datetime.now(timezone.utc)),
+        "sessionId": uid,
+        "cwd": "/tmp",
+        "message": {"role": role, "content": [{"type": "text", "text": text}]},
+    }
+    if role == "assistant":
+        ev["message"]["model"] = "claude-opus-4-8"
+    return ev
+
+
+def _write_lineage_file(path: Path, events: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(e) for e in events) + "\n")
+
+
+@pytest.mark.asyncio
+async def test_lineage_links_continued_session(temp_db_path: Path, tmp_path: Path) -> None:
+    # Session B's first message points (parentUuid) at session A's last message:
+    # B continues A. The mirror records that as a lineage link on B.
+    root = tmp_path / "projects"
+    a, b = "aaaaaaaa-0000-0000-0000-000000000001", "bbbbbbbb-0000-0000-0000-000000000002"
+    _write_lineage_file(
+        root / "-w-proj" / f"{a}.jsonl",
+        [
+            _lineage_event(a, "a-1", None, "user", "start the work"),
+            _lineage_event(a, "a-leaf", "a-1", "assistant", "done, ending here"),
+        ],
+    )
+    _write_lineage_file(
+        root / "-w-proj" / f"{b}.jsonl",
+        [
+            _lineage_event(b, "b-1", "a-leaf", "user", "continuing from before"),
+            _lineage_event(b, "b-2", "b-1", "assistant", "picking it up"),
+        ],
+    )
+    async with StateDB() as db:
+        await _one_pass(db, root, {}, {}, since=None, live_window=300)
+        child = await db.get_session(session_db_id(b))
+    lineage = child["node_metadata"]["lineage"]
+    assert lineage["parent_session_id"] == session_db_id(a)
+    assert lineage["parent_session_uid"] == a
+    assert lineage["parent_event_uuid"] == "a-leaf"
+
+
+@pytest.mark.asyncio
+async def test_no_lineage_for_self_rooted_session(temp_db_path: Path, tmp_path: Path) -> None:
+    root = tmp_path / "projects"
+    s = "cccccccc-0000-0000-0000-000000000003"
+    _write_lineage_file(
+        root / "-w-proj" / f"{s}.jsonl",
+        [
+            _lineage_event(s, "c-1", None, "user", "fresh start"),
+            _lineage_event(s, "c-2", "c-1", "assistant", "ok"),
+        ],
+    )
+    async with StateDB() as db:
+        await _one_pass(db, root, {}, {}, since=None, live_window=300)
+        row = await db.get_session(session_db_id(s))
+    assert "lineage" not in (row["node_metadata"] or {})
+
+
+@pytest.mark.asyncio
+async def test_no_lineage_for_same_session_across_files(temp_db_path: Path, tmp_path: Path) -> None:
+    # Two files share one sessionId (a resumed session). File 2's head points at
+    # file 1's leaf — same session, so it is NOT cross-session lineage.
+    root = tmp_path / "projects"
+    s = "dddddddd-0000-0000-0000-000000000004"
+    _write_lineage_file(
+        root / "-w-proj" / f"{s}-1.jsonl",
+        [
+            _lineage_event(s, "d-1", None, "user", "part one"),
+            _lineage_event(s, "d-mid", "d-1", "assistant", "more"),
+        ],
+    )
+    _write_lineage_file(
+        root / "-w-proj" / f"{s}-2.jsonl",
+        [
+            _lineage_event(s, "d-3", "d-mid", "user", "part two same session"),
+            _lineage_event(s, "d-4", "d-3", "assistant", "ok"),
+        ],
+    )
+    async with StateDB() as db:
+        await _one_pass(db, root, {}, {}, since=None, live_window=300)
+        row = await db.get_session(session_db_id(s))
+    assert "lineage" not in (row["node_metadata"] or {})
+
+
+def test_lineage_resolve_skips_unindexed_and_same_session() -> None:
+    lin = _Lineage()
+    lin.leaf_owner = {"leaf-A": "sessA"}
+    lin.pending = {
+        "sessB": "leaf-A",  # resolves to a different session -> link
+        "sessC": "unknown-leaf",  # parent not indexed -> stays pending
+        "sessA": "leaf-A",  # resolves to itself -> not lineage
+    }
+    links = lin.resolve()
+    assert links == [("sessB", "sessA", "leaf-A")]
+    assert lin.pending == {"sessC": "unknown-leaf"}  # unresolved stays for next pass
+    assert "sessB" in lin.linked
+
+
+@pytest.mark.asyncio
+async def test_idle_session_backfilled_with_project(temp_db_path: Path, tmp_path: Path) -> None:
+    # A session fully mirrored before attribution (row has no project) and now
+    # idle (file at EOF, no new events) is still backfilled from its head cwd.
+    work = tmp_path / "ghost-proj"
+    work.mkdir()
+    uid = "eeeeeeee-0000-0000-0000-000000000005"
+    root = tmp_path / "projects"
+    path = root / "-w-proj" / f"{uid}.jsonl"
+    events = [
+        _lineage_event(uid, "e-1", None, "user", "hi") | {"cwd": str(work)},
+        _lineage_event(uid, "e-2", "e-1", "assistant", "ok"),
+    ]
+    _write_lineage_file(path, events)
+    async with StateDB() as db:
+        await mirror_session(db, session_uid=uid, events=events, tool_names={}, project=None)
+        assert (await db.get_session(session_db_id(uid)))["project"] is None
+        # Idle pass: file already fully read (offset at EOF) -> no streamed events.
+        offsets = {str(path): path.stat().st_size}
+        await _one_pass(db, root, {}, offsets, since=None, live_window=300)
+        row = await db.get_session(session_db_id(uid))
+    assert row["project"] == "ghost-proj"
+    assert row["project_source"] == "cwd_dir"

--- a/tests/cli/test_mirror.py
+++ b/tests/cli/test_mirror.py
@@ -19,8 +19,10 @@ from lionagi.cli.mirror import (
     _one_pass,
     _parse_window,
     _read_new_events,
+    _since_window,
 )
 from lionagi.state.claude_mirror import (
+    _det,
     messages_for_event,
     mirror_session,
     reconcile_session_status,
@@ -277,6 +279,58 @@ async def test_reconcile_reactivates_completed_when_fresh(temp_db_path: Path) ->
 
 
 @pytest.mark.asyncio
+async def test_reconcile_idle_session_stays_completed_across_passes(temp_db_path: Path) -> None:
+    # The status write bumps updated_at; liveness must key off last_message_at
+    # instead. Otherwise a just-completed idle session reads as fresh on the next
+    # pass (its own status write moved updated_at) and oscillates back to running.
+    async with StateDB() as db:
+        await mirror_session(
+            db, session_uid=SID, events=_conversation(), tool_names={}, status="running"
+        )
+        row = await db.get_session(session_db_id(SID))
+        lm = row["last_message_at"]
+        await reconcile_session_status(db, SID, now=lm + 10_000, live_window=300)
+        first = await db.get_session(session_db_id(SID))
+        # last_message_at is the liveness clock; the status write must not touch it.
+        assert first["last_message_at"] == lm
+        # Second pass a moment later must NOT resurrect the still-idle session.
+        await reconcile_session_status(db, SID, now=lm + 10_001, live_window=300)
+        second = await db.get_session(session_db_id(SID))
+    assert first["status"] == "completed"
+    assert second["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_mirror_session_repairs_partial_scaffold(
+    temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # If branch creation fails after the session row commits, a later pass must
+    # repair the missing branch — not skip scaffolding just because the session
+    # row now exists. (Idempotent INSERT OR IGNORE scaffold, run every call.)
+    events = _conversation()
+    branch_id = _det(SID, "branch")
+    async with StateDB() as db:
+        real_create_branch = db.create_branch
+
+        async def _boom(*_a, **_k):
+            raise RuntimeError("branch write failed")
+
+        monkeypatch.setattr(db, "create_branch", _boom)
+        with pytest.raises(RuntimeError, match="branch write failed"):
+            await mirror_session(
+                db, session_uid=SID, events=events, tool_names={}, status="running"
+            )
+        # Session row committed but the branch is missing — a partial scaffold.
+        assert await db.get_session(session_db_id(SID)) is not None
+        assert await db.get_branch(branch_id) is None
+
+        # Next pass with the write restored repairs the scaffold.
+        monkeypatch.setattr(db, "create_branch", real_create_branch)
+        await mirror_session(db, session_uid=SID, events=events, tool_names={}, status="running")
+        assert await db.get_branch(branch_id) is not None
+
+
+@pytest.mark.asyncio
 async def test_mirror_session_empty_no_session(temp_db_path: Path) -> None:
     async with StateDB() as db:
         n = await mirror_session(db, session_uid=SID, events=[], tool_names={}, status="running")
@@ -353,6 +407,45 @@ async def test_multifile_session_completes_when_all_files_idle(
     assert row["status"] == "completed"
 
 
+@pytest.mark.asyncio
+async def test_one_pass_reprocesses_batch_when_write_fails(
+    temp_db_path: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A failed mirror write must not advance the persisted cursor past the
+    # unmirrored events: the next pass re-reads and mirrors them (at-least-once +
+    # idempotent), so a transient DB error never silently drops a batch.
+    root = tmp_path / "projects"
+    uid = "ffffffff-0000-0000-0000-00000000000a"
+    _write_session_file(root / "-w-proj" / f"{uid}.jsonl", uid, age_secs=5)
+
+    from lionagi.state import claude_mirror as cm
+
+    real_mirror_session = cm.mirror_session
+    fail = {"on": True}
+
+    async def _maybe_fail(*a, **k):
+        if fail["on"]:
+            raise RuntimeError("db down")
+        return await real_mirror_session(*a, **k)
+
+    monkeypatch.setattr("lionagi.state.claude_mirror.mirror_session", _maybe_fail)
+
+    offsets: dict[str, int] = {}
+    async with StateDB() as db:
+        # Pass 1: the write fails; the cursor must NOT be persisted past the batch.
+        await _one_pass(db, root, {}, offsets, since=None, live_window=300)
+        assert await db.get_session(session_db_id(uid)) is None
+        assert offsets == {}  # cursor never advanced past the unmirrored batch
+
+        # Pass 2: write restored; the same batch is mirrored, not lost.
+        fail["on"] = False
+        await _one_pass(db, root, {}, offsets, since=None, live_window=300)
+        row = await db.get_session(session_db_id(uid))
+        msgs = await db.get_progression(row["progression_id"])
+    assert row is not None
+    assert len(msgs) == 2  # both events survived the earlier failure
+
+
 # ── watcher helpers: tailing + parsing ───────────────────────────────────────
 
 
@@ -360,12 +453,13 @@ def test_read_new_events_buffers_partial_line(tmp_path: Path) -> None:
     path = tmp_path / "t.jsonl"
     path.write_text('{"a":1}\n{"a":2}\n{"a":3')  # last line incomplete
     state = _FileState(session_uid="x")
-    first = _read_new_events(path, state)
+    first, new_offset = _read_new_events(path, state)
     assert [e["a"] for e in first] == [1, 2]
+    state.offset = new_offset  # caller commits the cursor only after a durable mirror
     # Complete the dangling line; the next read picks up only the new event.
     with path.open("a") as fh:
         fh.write("}\n")
-    second = _read_new_events(path, state)
+    second, _ = _read_new_events(path, state)
     assert [e["a"] for e in second] == [3]
 
 
@@ -373,7 +467,7 @@ def test_read_new_events_resets_on_truncation(tmp_path: Path) -> None:
     path = tmp_path / "t.jsonl"
     path.write_text('{"a":1}\n')
     state = _FileState(session_uid="x", offset=9999)  # offset past EOF
-    out = _read_new_events(path, state)
+    out, _ = _read_new_events(path, state)
     assert [e["a"] for e in out] == [1]
 
 
@@ -381,7 +475,18 @@ def test_read_new_events_skips_corrupt_lines(tmp_path: Path) -> None:
     path = tmp_path / "t.jsonl"
     path.write_text('{"a":1}\nnot json\n{"a":2}\n')
     state = _FileState(session_uid="x")
-    out = _read_new_events(path, state)
+    out, _ = _read_new_events(path, state)
+    assert [e["a"] for e in out] == [1, 2]
+
+
+def test_read_new_events_skips_non_dict_json_without_losing_followers(tmp_path: Path) -> None:
+    # Valid JSON of the wrong shape (a bare list / scalar) must be dropped as
+    # malformed, not handed downstream as an event, and must not swallow the
+    # valid events that follow it on later lines.
+    path = tmp_path / "t.jsonl"
+    path.write_text('[]\n{"a":1}\n42\n{"a":2}\n')
+    state = _FileState(session_uid="x")
+    out, _ = _read_new_events(path, state)
     assert [e["a"] for e in out] == [1, 2]
 
 
@@ -404,10 +509,26 @@ def test_first_prompt_skips_meta_and_command_noise() -> None:
 
 @pytest.mark.parametrize(
     ("spec", "expected"),
-    [("30m", 1800.0), ("12h", 43200.0), ("7d", 604800.0), ("120", 120.0), ("bad", None)],
+    [("30m", 1800.0), ("12h", 43200.0), ("7d", 604800.0), ("120", 120.0), ("", None)],
 )
 def test_parse_window(spec: str, expected: float | None) -> None:
     assert _parse_window(spec) == expected
+
+
+def test_parse_window_raises_on_malformed() -> None:
+    # A bad spec must fail loudly, not silently become an unbounded (None) scan.
+    with pytest.raises(ValueError, match="unrecognized --since window"):
+        _parse_window("bad")
+
+
+def test_since_window_argparse_type() -> None:
+    import argparse
+
+    assert _since_window("12h") == 43200.0
+    with pytest.raises(argparse.ArgumentTypeError):
+        _since_window("nonsense")
+    with pytest.raises(argparse.ArgumentTypeError):
+        _since_window("")  # empty is rejected at the CLI boundary (default=None handles "all")
 
 
 # ── project attribution fallback ─────────────────────────────────────────────


### PR DESCRIPTION
## What

Slice 3/6 of the Den VS Code extension work (parent #1555), targeting the `feat/vscode-integration` branch.

Adds **`li mirror`** — a resumable, idempotent tail over `~/.claude/projects` transcripts that ingests Claude Code sessions into the lionagi StateDB. Result: Claude Code sessions surface (and stream live) in studio and the Den extension alongside lionagi runs, giving one cross-project, cross-agent dashboard.

## Files (4)

- `lionagi/state/claude_mirror.py` (new) — transcript parse + idempotent StateDB upsert
- `lionagi/cli/mirror.py` (new) — CLI surface: `--once` (backfill), `--interval`, `--since`, `--root`, `--live-window`
- `lionagi/cli/main.py` — wire the `mirror` subcommand (import + register + dispatch; 3 lines)
- `tests/cli/test_mirror.py` (new) — 36 tests

## Dependency

Builds on the StateDB provenance slice (#1559, merged into integration). Independent of the ext-core (#1560) and runs slices.

## Verification

- `uv run ruff check` — clean
- `uv run pytest tests/cli/test_mirror.py` — 36 passed
- `li mirror --help` — subcommand wired

🤖 Generated with [Claude Code](https://claude.com/claude-code)