### PR TITLE
test(vscode): regression-guard run-detail retarget abort-isolation

### DIFF
--- a/apps/vscode/test/mocks/vscode.ts
+++ b/apps/vscode/test/mocks/vscode.ts
@@ -223,4 +223,13 @@ export const workspace = {
   fs: {
     readFile: vi.fn<[uri: unknown], Promise<Uint8Array>>(),
   },
+  // Plain stub (not vi.fn) so __resetVscodeMock never wipes it. `den` config
+  // accessors (config.ts) call .get(key, default); echo the default so tests
+  // that hit the live-stream path (getAuthToken etc.) get clean empty values.
+  getConfiguration: (_section?: string) => ({
+    get: (_key: string, defaultValue?: unknown) => defaultValue,
+    has: () => false,
+    inspect: () => undefined,
+    update: async () => undefined,
+  }),
 };

--- a/apps/vscode/test/runDetailPanelHost.test.ts
+++ b/apps/vscode/test/runDetailPanelHost.test.ts
@@ -3,8 +3,12 @@
  * GET /api/runs/{id} response carries status_reason_* must post a "reason" message
  * even when invocation_id is null, without falling back to GET /api/invocations.
  * Guards the panel wiring the pure runReasonBannerMessage unit test cannot reach.
+ *
+ * Also guards retarget abort-isolation: clicking a second live run while the first
+ * is still streaming must abort the first stream silently, never surfacing the old
+ * run's abort as an error on the newly-targeted run.
  */
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as vscodeMock from "./mocks/vscode.js";
 import { RunDetailPanel } from "../src/runs/runDetailPanel.js";
 import type { Run } from "../src/api/types.js";
@@ -78,6 +82,102 @@ describe("RunDetailPanel run-detail reason banner (host)", () => {
       expect(getRun).toHaveBeenCalledOnce();
       // Run carried its own reason → the invocation fallback must never fire.
       expect(getInvocation).not.toHaveBeenCalled();
+    } finally {
+      panel!.__fireDispose();
+    }
+  });
+});
+
+function liveRun(id: string): Run {
+  return {
+    run_id: id,
+    id,
+    name: `live ${id}`,
+    playbook_name: null,
+    agent_name: null,
+    invocation_kind: "agent",
+    model: null,
+    provider: null,
+    effort: null,
+    status: "running",
+    started_at: null,
+    ended_at: null,
+    created_at: 0,
+    updated_at: null,
+    last_message_at: null,
+    effective_health: null,
+    branch_count: 0,
+    message_count: 0,
+    project: null,
+    project_source: null,
+    invocation_id: null,
+    status_reason_code: null,
+    status_reason_summary: null,
+    status_evidence_refs: null,
+  };
+}
+
+// A fetch that never resolves but rejects with AbortError the moment its signal
+// aborts — models a held-open SSE connection cut by a retarget.
+function abortingFetch(): ReturnType<typeof vi.fn> {
+  return vi.fn((_url: string, init?: { signal?: AbortSignal }) => {
+    const signal = init?.signal;
+    return new Promise<Response>((_resolve, reject) => {
+      const fail = () => reject(new DOMException("The operation was aborted.", "AbortError"));
+      if (signal?.aborted) {
+        fail();
+        return;
+      }
+      signal?.addEventListener("abort", fail, { once: true });
+    });
+  });
+}
+
+describe("RunDetailPanel retarget abort-isolation (host)", () => {
+  let realFetch: typeof globalThis.fetch;
+  let fetchStub: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vscodeMock.__resetVscodeMock();
+    realFetch = globalThis.fetch;
+    fetchStub = abortingFetch();
+    globalThis.fetch = fetchStub as unknown as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it("retargeting mid-stream aborts the old run's stream without posting a spurious error on the new run", async () => {
+    const deps = {
+      client: { getRun: vi.fn(), getInvocation: vi.fn() },
+      backend: { baseUrl: "http://127.0.0.1:0" },
+    } as unknown as OpenArgs[1];
+    const context = { extensionPath: "/ext" } as unknown as OpenArgs[0];
+
+    // Open a live run → streamLive holds an SSE fetch open (pending).
+    RunDetailPanel.open(context, deps, liveRun("r-A"));
+    const panel = vscodeMock.__lastWebviewPanel;
+    expect(panel).toBeTruthy();
+
+    try {
+      await vi.waitFor(() => expect(fetchStub).toHaveBeenCalledTimes(1));
+
+      // Retarget to a different live run: aborts run A's controller, swaps in a
+      // fresh one, and starts run B's stream. Run A's fetch now rejects (abort).
+      RunDetailPanel.open(context, deps, liveRun("r-B"));
+      await vi.waitFor(() => expect(fetchStub).toHaveBeenCalledTimes(2));
+
+      // Drain microtasks so run A's abort-induced catch has executed.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const errors = panel!.webview.postMessage.mock.calls
+        .map((c) => c[0] as { type?: string })
+        .filter((m) => m?.type === "error");
+      // The aborted old stream must be swallowed: streamLive tests the controller
+      // it *started* with (now aborted), not the panel's current (run B's) one.
+      expect(errors).toEqual([]);
     } finally {
       panel!.__fireDispose();
     }


### PR DESCRIPTION
## What

Adds the one regression test missing from the Den runs-panel slice: the
`RunDetailPanel` retarget **abort-isolation** contract.

`streamLive()` captures `const ac = this.ac` at stream start and tests *that*
controller in its `catch`. So when `retarget()` swaps `this.ac` and aborts the
previous controller mid-stream, the old run's abort-induced throw is swallowed
(its captured `ac` is aborted) instead of being posted as a spurious `error`
onto the freshly-targeted run. This was verified by eye during the runs-panel
review but had no test.

## Test

Host-level (`test/runDetailPanelHost.test.ts`): open a live run holding an SSE
fetch open, retarget to a second live run, assert the aborted first stream posts
no `error` message. A `global.fetch` stub rejects with `AbortError` the moment
its signal aborts (no real network/timers — deterministic; 12/12 green locally).

RED-verified: reintroducing the bug (`this.ac` in the catch) fails the test with
exactly `{type:"error","The operation was aborted."}`.

The shared `test/mocks/vscode.ts` gains `workspace.getConfiguration` so the
live-stream path (`getAuthToken`) resolves cleanly — a method the prior
terminal-run host test never exercised.

## Scope

Test-only. No runtime/source changes. `make typecheck test compile` → 50 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)