### PR TITLE
fix(vscode): make Claude Code sessions stream live into the Den runs panel

### DIFF
--- a/apps/vscode/src/runs/runsExplorer.ts
+++ b/apps/vscode/src/runs/runsExplorer.ts
@@ -43,6 +43,13 @@ class RunsProvider implements vscode.TreeDataProvider<RunNode> {
   private readonly _onDidChangeTreeData =
     new vscode.EventEmitter<RunNode | undefined | null | void>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+  // Fires AFTER a root load completes and _activeRuns is fresh. Distinct from
+  // onDidChangeTreeData, which fires when a refresh is *requested* — i.e. before
+  // getChildren() has actually loaded the data. Polling bootstrap must key off
+  // this, or hasActiveRuns() reads the stale-empty set that exists in the gap
+  // between refresh() and the load, and live polling never starts.
+  private readonly _onDidLoad = new vscode.EventEmitter<void>();
+  readonly onDidLoad = this._onDidLoad.event;
 
   constructor(private readonly deps: StudioDeps) {}
 
@@ -102,6 +109,9 @@ class RunsProvider implements vscode.TreeDataProvider<RunNode> {
       this._groupItems.set(item.key, item);
       nodes.push(item);
     });
+    // _activeRuns is now fresh: signal so the bootstrap can (re)evaluate polling
+    // against real data rather than the empty set seen at refresh() time.
+    this._onDidLoad.fire();
     return nodes;
   }
 
@@ -278,6 +288,23 @@ export function registerRunsExplorer(
     }
   });
 
+  // The reliable bootstrap: re-evaluate polling once a load has actually
+  // populated _activeRuns. Opening the view while the backend is already
+  // running — or any first load slower than the 500ms onRefresh window — used to
+  // leave a frozen snapshot because every other trigger checks hasActiveRuns()
+  // before the data arrives. This fires after, so live polling starts.
+  const loadListener = provider.onDidLoad(() => {
+    if (
+      treeView.visible &&
+      deps.backend.isRunning() &&
+      provider.hasActiveRuns()
+    ) {
+      startPolling();
+    } else if (!provider.hasActiveRuns()) {
+      stopPolling();
+    }
+  });
+
   const refreshCmd = vscode.commands.registerCommand(
     "den.refreshRuns",
     () => {
@@ -327,6 +354,7 @@ export function registerRunsExplorer(
     stateListener,
     visibilityListener,
     dataChangeListener,
+    loadListener,
     { dispose: stopPolling }
   );
 }

--- a/apps/vscode/test/runsExplorerPolling.test.ts
+++ b/apps/vscode/test/runsExplorerPolling.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import * as vscode from "vscode";
+import { __resetVscodeMock } from "./mocks/vscode.js";
+import { registerRunsExplorer } from "../src/runs/runsExplorer.js";
+
+// Regression guard for the live-update bootstrap. The runs tree refreshes the
+// count/status by polling /api/runs every 4s — but only while there are active
+// runs. Polling used to be (re)evaluated synchronously right after refresh(),
+// which merely *schedules* the async load, so hasActiveRuns() read the stale
+// empty set and polling never started when the view was already visible and the
+// backend already running (the common case). The fix fires onDidLoad AFTER the
+// load populates _activeRuns and keys polling off that. These tests pin both
+// directions: it starts when a load reveals an active run, and it does not when
+// there are none.
+
+const POLL_INTERVAL_MS = 4_000;
+
+interface Captured {
+  provider: vscode.TreeDataProvider<unknown> & {
+    getChildren(e?: unknown): Promise<unknown[]>;
+  };
+  refreshCount: number;
+}
+
+function makeRun(over: Record<string, unknown> = {}) {
+  return {
+    id: "sess-1",
+    run_id: "sess-1",
+    name: "live session",
+    status: "running",
+    project: "acme/widget",
+    message_count: 3,
+    branch_count: 1,
+    started_at: 1_782_000_000,
+    created_at: 1_782_000_000,
+    ...over,
+  };
+}
+
+/**
+ * Wire registerRunsExplorer against a visible tree view + a backend that is
+ * already running (no state transition fires — that's the path the bug lived
+ * on). Returns the captured provider and a live refresh counter (each poll tick
+ * fires onDidChangeTreeData).
+ */
+function setup(opts: {
+  runningRuns: unknown[];
+  projects: unknown[];
+}): Captured {
+  const stateEmitter = new vscode.EventEmitter<string>();
+  const visibilityEmitter = new vscode.EventEmitter<{ visible: boolean }>();
+  const backend = {
+    isRunning: () => true,
+    onDidChangeState: stateEmitter.event,
+  };
+  const client = {
+    listRuns: vi.fn(async () => ({
+      runs: opts.runningRuns,
+      has_next: false,
+      page: 1,
+      per_page: 100,
+      total: opts.runningRuns.length,
+    })),
+    listProjectGroups: vi.fn(async () => ({
+      projects: opts.projects,
+      total: opts.projects.length,
+    })),
+  };
+  const deps = { backend, client } as never;
+
+  const captured = {} as Captured;
+  (vscode.window.createTreeView as ReturnType<typeof vi.fn>).mockImplementation(
+    (_id: string, viewOpts: { treeDataProvider: unknown }) => {
+      captured.provider = viewOpts.treeDataProvider as Captured["provider"];
+      return {
+        visible: true,
+        onDidChangeVisibility: visibilityEmitter.event,
+        dispose() {},
+      };
+    }
+  );
+
+  const context = { subscriptions: [] } as never;
+  registerRunsExplorer(context, deps);
+
+  captured.refreshCount = 0;
+  captured.provider.onDidChangeTreeData?.(() => {
+    captured.refreshCount += 1;
+  });
+  return captured;
+}
+
+describe("runs explorer live-update polling bootstrap", () => {
+  beforeEach(() => {
+    __resetVscodeMock();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts polling once a load reveals an active run (view already visible, backend already running)", async () => {
+    const c = setup({
+      runningRuns: [makeRun()],
+      projects: [{ project: "acme/widget", count: 1, last_activity: 1_782_000_000 }],
+    });
+
+    // The initial render: VS Code calls getChildren on the root. This populates
+    // _activeRuns and — with the fix — fires onDidLoad → starts the poll timer.
+    await c.provider.getChildren();
+    expect(c.refreshCount).toBe(0); // the load itself does not fire a refresh
+
+    // Three poll intervals must produce three refreshes. Before the fix this
+    // stayed 0: polling never bootstrapped from a load, only a frozen snapshot.
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 3);
+    expect(c.refreshCount).toBeGreaterThanOrEqual(3);
+  });
+
+  it("does not keep polling when no runs are active", async () => {
+    const c = setup({
+      runningRuns: [],
+      projects: [{ project: "acme/widget", count: 2, last_activity: 1_782_000_000 }],
+    });
+
+    await c.provider.getChildren();
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 3);
+    expect(c.refreshCount).toBe(0); // nothing active → no live polling churn
+  });
+});

--- a/lionagi/cli/mirror.py
+++ b/lionagi/cli/mirror.py
@@ -489,21 +489,35 @@ async def mirror_forever(
     offsets = {key: st.offset for key, st in states.items()}  # _one_pass new-file seed
     lineage = _Lineage()
     _seed_lineage(lineage, states)
-    async with StateDB() as db:
-        while not stop.is_set():
-            try:
-                await _one_pass(
-                    db,
-                    root,
-                    states,
-                    offsets,
-                    since=since_secs,
-                    live_window=live_window,
-                    lineage=lineage,
-                )
-                _save_states(states)
-            except Exception:  # a single bad pass must never kill the tail
-                _log.exception("claude mirror pass failed")
+    # The connection lives inside the supervise loop so a failure to OPEN it —
+    # e.g. a locked or half-migrated state.db during first-run startup, when the
+    # studio is creating the schema and checkpointing on another connection — is
+    # retried, not fatal. Opening it once outside the loop meant a single
+    # transient open error silently ended the in-process mirror for the whole
+    # life of the studio process.
+    while not stop.is_set():
+        try:
+            async with StateDB() as db:
+                while not stop.is_set():
+                    try:
+                        await _one_pass(
+                            db,
+                            root,
+                            states,
+                            offsets,
+                            since=since_secs,
+                            live_window=live_window,
+                            lineage=lineage,
+                        )
+                        _save_states(states)
+                    except Exception:  # a single bad pass must never kill the tail
+                        _log.exception("claude mirror pass failed")
+                    try:
+                        await asyncio.wait_for(stop.wait(), timeout=interval)
+                    except (asyncio.TimeoutError, TimeoutError):
+                        pass
+        except Exception:  # connection open/teardown failed — retry, never die
+            _log.exception("claude mirror connection failed; retrying")
             try:
                 await asyncio.wait_for(stop.wait(), timeout=interval)
             except (asyncio.TimeoutError, TimeoutError):

--- a/lionagi/studio/app.py
+++ b/lionagi/studio/app.py
@@ -91,6 +91,19 @@ def _start_claude_mirror() -> tuple[asyncio.Event, asyncio.Task] | tuple[None, N
         mirror_forever(stop, since=MIRROR_CLAUDE_SINCE, interval=MIRROR_CLAUDE_INTERVAL),
         name="claude-mirror-tail",
     )
+
+    def _log_unexpected_exit(t: asyncio.Task) -> None:
+        # The task handle is retained (returned, awaited only at shutdown), so a
+        # task that raises never triggers asyncio's "exception was never
+        # retrieved" warning — its failure is otherwise completely silent and the
+        # studio runs on with no live mirroring. Surface it loudly here instead.
+        if t.cancelled():
+            return
+        exc = t.exception()
+        if exc is not None:
+            _log.error("Claude mirror tail exited unexpectedly", exc_info=exc)
+
+    task.add_done_callback(_log_unexpected_exit)
     _log.info("Claude Code mirror tail started (since=%s)", MIRROR_CLAUDE_SINCE)
     return stop, task
 

--- a/tests/cli/test_mirror.py
+++ b/tests/cli/test_mirror.py
@@ -449,6 +449,55 @@ async def test_one_pass_reprocesses_batch_when_write_fails(
     assert len(msgs) == 2  # both events survived the earlier failure
 
 
+@pytest.mark.asyncio
+async def test_mirror_forever_retries_after_connection_open_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A transient failure to OPEN the StateDB connection — e.g. a locked or
+    # half-migrated state.db during first-run startup, when the studio creates the
+    # schema and checkpoints on another connection — must be retried, not silently
+    # end the in-process tail for the whole life of the studio process. Regression
+    # guard: the connection used to be opened once outside the loop, so the first
+    # transient open error killed the tail permanently and invisibly.
+    import asyncio
+
+    import lionagi.cli.mirror as mirror_mod
+    import lionagi.state.db as dbmod
+
+    monkeypatch.setattr(dbmod, "DEFAULT_DB_PATH", tmp_path / "state.db")
+    monkeypatch.setattr(mirror_mod, "_OFFSETS_PATH", tmp_path / "mirror" / "offsets.json")
+
+    attempts = {"open": 0}
+    real_open = dbmod.StateDB.open
+
+    async def _flaky_open(self) -> None:
+        attempts["open"] += 1
+        if attempts["open"] == 1:
+            raise OSError("database is locked (simulated first-run race)")
+        await real_open(self)
+
+    monkeypatch.setattr(dbmod.StateDB, "open", _flaky_open)
+
+    stop = asyncio.Event()
+    # root is an empty dir: passes find no transcripts, so this isolates the
+    # connection-lifecycle behaviour from any mirroring work.
+    task = asyncio.create_task(
+        mirror_mod.mirror_forever(stop, root=tmp_path, since="24h", interval=0.05)
+    )
+    try:
+        for _ in range(100):  # let it fail the first open, back off, and reconnect
+            if attempts["open"] >= 2:
+                break
+            await asyncio.sleep(0.02)
+        alive = not task.done()
+    finally:
+        stop.set()
+        await asyncio.wait_for(task, timeout=5)
+
+    assert attempts["open"] >= 2, "open was not retried after the first failure"
+    assert alive, "tail died on a transient open failure instead of retrying"
+
+
 # ── watcher helpers: tailing + parsing ───────────────────────────────────────
 
 


### PR DESCRIPTION
## Problem

Claude Code sessions weren't appearing or updating live in the Den (VS Code) runs panel. Two independent bugs, both invisible, each fatal to live updates on its own.

### 1. The in-process Claude mirror died silently at startup
The studio tails `~/.claude/projects/*.jsonl` into StateDB via an in-process task (`mirror_forever`). It opened its StateDB connection **once, outside** the poll loop's `try/except`, and the task handle was retained-but-unawaited. So a single transient open failure — a locked / half-migrated `state.db` during first-run startup, while the schema is created and checkpointed on another connection — raised straight out of the task and **permanently** ended mirroring for the life of the studio process. The exception was never retrieved (no GC), so it logged **nothing**: the studio ran on with the mirror dead, and no data reached StateDB, `/api/runs`, or SSE.

Confirmed in the wild: 0 DB file descriptors in the studio process, a frozen `offsets.json`, an unmirrored transcript, and a `Den` output log that showed normal startup followed by no mirror activity ever.

### 2. The runs panel never bootstrapped its live poll
The tree polls `/api/runs` every 4s, but only while there are active runs. Polling was evaluated **synchronously right after** `provider.refresh()` — which only *schedules* the async load — so `hasActiveRuns()` read the stale-empty set and polling never started when the view was already visible and the backend already running (the common case), or when the first load was slower than the 500ms `onRefresh` window. Result: one frozen snapshot — counts never climbed, status never flipped back to live.

## Fix

- **`lionagi/cli/mirror.py`** — move the StateDB connection inside a supervise loop so an open/teardown failure retries with backoff instead of being fatal.
- **`lionagi/studio/app.py`** — done-callback on the mirror task that logs loudly if it ever exits, so a death is never silent again.
- **`apps/vscode/src/runs/runsExplorer.ts`** — fire a new `onDidLoad` event *after* the load populates `_activeRuns`, and key polling start/stop off that, so the bootstrap reads real data regardless of load timing.

## Tests

- `tests/cli/test_mirror.py` — the tail must survive a simulated first-open lock failure and reconnect.
- `apps/vscode/test/runsExplorerPolling.test.ts` — polling starts once a load reveals an active run, stays quiet when none; verified to fail without the fix.

Backend mirror suite + full extension vitest suite green.

## Verification

Restarted the backend with the fix: `offsets.json` self-advances every ~5s, the live session climbs in `/api/runs` (status `running`, fresh `last_message_at`), and after reloading the extension the runs panel updates live — count climbs, spinner shows, SSE detail streams. Confirmed end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)