### PR TITLE
feat(vscode): pre-flight studio import check + self-heal before first-run spawn

### DIFF
--- a/apps/vscode/src/backend/lifecycle.ts
+++ b/apps/vscode/src/backend/lifecycle.ts
@@ -12,6 +12,19 @@ interface SpawnSpec {
   cwd?: string;
   /** One-time dependency install to run (with progress) before spawning. */
   provision?: { command: string; args: string[]; cwd: string };
+  /**
+   * Verify the studio server imports before spawning. Set for interpreters
+   * whose provisioning Den does not control (an explicit den.pythonPath, an
+   * already-present .venv, or system python3); not set when `provision` already
+   * guarantees the deps.
+   */
+  preflight?: boolean;
+  /**
+   * Repair step to run if the preflight import check fails and Den can fix this
+   * interpreter in place (a uv-managed workspace .venv that is missing the
+   * studio extra). Same sync the source-checkout path uses.
+   */
+  repair?: { command: string; args: string[]; cwd: string };
 }
 
 function workspaceRoot(): string | undefined {
@@ -46,12 +59,34 @@ function resolveSpawnSpec(explicitPython: string): SpawnSpec {
 
   // 1. Explicitly configured path.
   if (explicitPython.trim() !== "") {
-    return { command: explicitPython, args: ["-m", "lionagi.studio"] };
+    return {
+      command: explicitPython,
+      args: ["-m", "lionagi.studio"],
+      preflight: true,
+    };
   }
 
-  // 2. Existing workspace venv (already provisioned).
+  // 2. Existing workspace venv (assumed provisioned). Pre-flight it: a .venv the
+  //    user created without the studio extra would otherwise spawn-and-fail. If
+  //    this is a uv-managed project, offer an in-place repair (same sync as the
+  //    source-checkout path) so a studio-less .venv self-heals.
   if (venvPython && fs.existsSync(venvPython)) {
-    return { command: venvPython, args: ["-m", "lionagi.studio"] };
+    const spec: SpawnSpec = {
+      command: venvPython,
+      args: ["-m", "lionagi.studio"],
+      preflight: true,
+    };
+    if (ws && fs.existsSync(path.join(ws, "pyproject.toml"))) {
+      const uv = resolveUv();
+      if (uv) {
+        spec.repair = {
+          command: uv,
+          args: ["sync", "--extra", "studio", "--no-dev"],
+          cwd: ws,
+        };
+      }
+    }
+    return spec;
   }
 
   // 3. uv-managed source checkout (e.g. Codespaces): sync the studio extra
@@ -77,7 +112,7 @@ function resolveSpawnSpec(explicitPython: string): SpawnSpec {
   }
 
   // 4. System python3 fallback (expects `pip install "lionagi[studio]"`).
-  return { command: "python3", args: ["-m", "lionagi.studio"] };
+  return { command: "python3", args: ["-m", "lionagi.studio"], preflight: true };
 }
 
 function delay(ms: number): Promise<void> {
@@ -268,6 +303,43 @@ export class BackendManager implements vscode.Disposable {
       }
     }
 
+    // Pre-flight: for an interpreter whose provisioning Den does not control,
+    // verify the studio server is importable before spawning. A doomed spawn
+    // otherwise costs a process exit plus a multi-second orphan probe before it
+    // can error; this fails fast with an actionable message — and self-heals a
+    // studio-less workspace .venv in place when uv can repair it.
+    if (spec.preflight) {
+      let importable = await this._canImportStudio(spec.command);
+      if (this._superseded(epoch)) {
+        return;
+      }
+      if (!importable && spec.repair) {
+        this._output.appendLine(
+          `[lifecycle] studio server not importable — repairing via ` +
+            `${spec.repair.command} ${spec.repair.args.join(" ")}`
+        );
+        const repaired = await this._provision(spec.repair);
+        if (this._superseded(epoch)) {
+          return;
+        }
+        if (repaired) {
+          importable = await this._canImportStudio(spec.command);
+          if (this._superseded(epoch)) {
+            return;
+          }
+        }
+      }
+      if (!importable) {
+        this.setState("error");
+        void vscode.window.showErrorMessage(
+          `Den: the studio server is not installed for ${spec.command}. ` +
+            `Install it with 'pip install "lionagi[studio]"', set den.pythonPath ` +
+            `to a Python that has it, or set den.url to attach to a running backend.`
+        );
+        return;
+      }
+    }
+
     this._output.appendLine(
       `[lifecycle] spawning via ${spec.command} ${spec.args.join(" ")}`
     );
@@ -444,6 +516,40 @@ export class BackendManager implements vscode.Disposable {
         })
     );
     return ok;
+  }
+
+  /**
+   * Whether `python` can import the studio server. Uses importlib.util.find_spec
+   * (resolves the module spec without executing it) so the happy path does not
+   * pay the full studio import cost twice — once here and again in the spawned
+   * `-m lionagi.studio`. Resolves false on a missing dep, a non-runnable
+   * interpreter (spawn error), or a probe that overruns 5s.
+   */
+  private _canImportStudio(python: string): Promise<boolean> {
+    const code =
+      "import importlib.util as u, sys; " +
+      "sys.exit(0 if u.find_spec('lionagi') and u.find_spec('fastapi') " +
+      "and u.find_spec('uvicorn') else 1)";
+    return new Promise<boolean>((resolve) => {
+      let done = false;
+      const finish = (ok: boolean) => {
+        if (done) {
+          return;
+        }
+        done = true;
+        clearTimeout(timer);
+        resolve(ok);
+      };
+      const probe = child_process.spawn(python, ["-c", code], {
+        stdio: "ignore",
+      });
+      const timer = setTimeout(() => {
+        probe.kill();
+        finish(false);
+      }, 5_000);
+      probe.on("error", () => finish(false));
+      probe.on("exit", (exitCode) => finish(exitCode === 0));
+    });
   }
 
   stop(): void {

--- a/apps/vscode/test/backendLifecycle.test.ts
+++ b/apps/vscode/test/backendLifecycle.test.ts
@@ -1,6 +1,30 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter as NodeEventEmitter } from "events";
+import * as fs from "fs";
+import * as path from "path";
 import { BackendManager } from "../src/backend/lifecycle.js";
-import { __resetVscodeMock } from "./mocks/vscode.js";
+import {
+  __resetVscodeMock,
+  window as mockWindow,
+  workspace as mockWorkspace,
+} from "./mocks/vscode.js";
+
+// child_process.spawn and fs.existsSync are module-namespace exports, which
+// vi.spyOn cannot redefine ("Cannot redefine property"). Mock the modules
+// instead; vi.hoisted lifts these fns above the hoisted vi.mock factories so the
+// factories can reference them. existsSync defaults to false (nothing on disk).
+const { spawnMock, existsSyncMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+  existsSyncMock: vi.fn(() => false),
+}));
+vi.mock("child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("child_process")>()),
+  spawn: spawnMock,
+}));
+vi.mock("fs", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("fs")>()),
+  existsSync: existsSyncMock,
+}));
 
 // Drives probeHealth / _pollHealth: when `healthy` is true, GET /health
 // resolves to {status:"ok"}; otherwise the fetch rejects (backend unreachable).
@@ -99,5 +123,175 @@ describe("BackendManager resilience", () => {
     bm.stop(); // bumps epoch, sets "stopped", before the probe resolves
     await starting;
     expect(bm.state).toBe("stopped");
+  });
+});
+
+// A spawned child, faked: one-shot processes (the `-c` import probe, the `uv
+// sync` repair) emit `exit` on a microtask; the long-lived server stays alive so
+// _pollHealth attaches via the health fetch. kill() emits exit so _killChild's
+// SIGKILL timer clears and teardown is clean.
+class FakeProc extends NodeEventEmitter {
+  stdout = new NodeEventEmitter();
+  stderr = new NodeEventEmitter();
+  exitCode: number | null = null;
+  signalCode: string | null = null;
+  constructor(opts: { exit?: number | null; longLived?: boolean }) {
+    super();
+    if (!opts.longLived) {
+      queueMicrotask(() => {
+        this.exitCode = opts.exit ?? 0;
+        this.emit("exit", this.exitCode);
+      });
+    }
+  }
+  kill(_signal?: string): boolean {
+    if (this.exitCode === null) {
+      queueMicrotask(() => this.emit("exit", null));
+    }
+    return true;
+  }
+}
+
+describe("BackendManager spawn pre-flight", () => {
+  let bm: BackendManager | undefined;
+  // Drives the discovery + health-poll fetch: false until a server is spawned.
+  let healthy = false;
+
+  // Spawn router: dispatch by argv so the test controls each spawned process
+  // independently. Returns a call counter for assertions.
+  function installRouter(opts: {
+    probeExits: number[]; // exit code per `-c` import probe, in order
+    syncExit?: number; // exit code for the `uv sync` repair
+    serverHealthy?: boolean; // flip the backend healthy when the server spawns
+  }): { probes: number; sync: number; server: number } {
+    const calls = { probes: 0, sync: 0, server: 0 };
+    spawnMock.mockImplementation((_cmd: string, args?: readonly string[]) => {
+      const argv = args ?? [];
+      if (argv[0] === "-c") {
+        calls.probes++;
+        return new FakeProc({ exit: opts.probeExits.shift() ?? 1 });
+      }
+      if (argv[0] === "sync") {
+        calls.sync++;
+        return new FakeProc({ exit: opts.syncExit ?? 0 });
+      }
+      if (argv[0] === "-m") {
+        calls.server++;
+        if (opts.serverHealthy) {
+          healthy = true;
+        }
+        return new FakeProc({ longLived: true });
+      }
+      return new FakeProc({ exit: 0 });
+    });
+    return calls;
+  }
+
+  // Empty configuredUrl puts start() on the spawn path (not attach-only).
+  function makeSpawnManager(pythonPath = ""): BackendManager {
+    return new BackendManager(
+      () => pythonPath,
+      () => "", // no den.url → spawn path
+      () => 8765,
+      () => "127.0.0.1",
+      () => ""
+    );
+  }
+
+  // Make resolveSpawnSpec land on the existing-.venv case (2) with a uv repair:
+  // a workspace folder, a present .venv python + pyproject.toml, and a uv binary.
+  function stubUvWorkspaceVenv(): void {
+    const ws = "/ws";
+    (mockWorkspace as { workspaceFolders?: unknown }).workspaceFolders = [
+      { uri: { fsPath: ws } },
+    ];
+    const venvPython = path.join(ws, ".venv", "bin", "python");
+    existsSyncMock.mockImplementation((p: fs.PathLike) => {
+      const s = String(p);
+      return (
+        s === venvPython ||
+        s === path.join(ws, "pyproject.toml") ||
+        s.endsWith(`${path.sep}uv`)
+      );
+    });
+  }
+
+  beforeEach(() => {
+    __resetVscodeMock();
+    healthy = false;
+    spawnMock.mockReset();
+    existsSyncMock.mockReset();
+    existsSyncMock.mockReturnValue(false);
+    vi.stubGlobal("fetch", async () => {
+      if (!healthy) {
+        throw new Error("ECONNREFUSED");
+      }
+      return {
+        ok: true,
+        json: async () => ({ status: "ok" }),
+      } as unknown as Response;
+    });
+  });
+
+  afterEach(() => {
+    bm?.dispose();
+    bm = undefined;
+    vi.unstubAllGlobals();
+    delete (mockWorkspace as { workspaceFolders?: unknown }).workspaceFolders;
+  });
+
+  it("a pre-flight failure errors with guidance and never spawns the server", async () => {
+    // System python3 (no workspace, no .venv) that cannot import the studio
+    // server: the import probe exits non-zero, there is no repair, so Den must
+    // error fast without paying for a doomed `-m lionagi.studio` spawn.
+    const calls = installRouter({ probeExits: [1] });
+    bm = makeSpawnManager("");
+    await bm.start();
+    expect(bm.state).toBe("error");
+    expect(calls.server).toBe(0);
+    expect(mockWindow.showErrorMessage).toHaveBeenCalled();
+  });
+
+  it("a pre-flight pass proceeds to spawn and reaches running", async () => {
+    const calls = installRouter({ probeExits: [0], serverHealthy: true });
+    bm = makeSpawnManager("");
+    await bm.start();
+    expect(bm.state).toBe("running");
+    expect(calls.server).toBe(1);
+  });
+
+  it("repairs a studio-less workspace .venv in place, then runs", async () => {
+    stubUvWorkspaceVenv();
+    mockWindow.withProgress.mockImplementation(
+      (_opts: unknown, task: (p: unknown, t: unknown) => Promise<unknown>) =>
+        task(undefined, undefined)
+    );
+    // First import probe fails (studio missing) → uv sync repairs → second probe
+    // passes → server spawns.
+    const calls = installRouter({
+      probeExits: [1, 0],
+      syncExit: 0,
+      serverHealthy: true,
+    });
+    bm = makeSpawnManager("");
+    await bm.start();
+    expect(bm.state).toBe("running");
+    expect(calls.sync).toBe(1);
+    expect(calls.server).toBe(1);
+  });
+
+  it("a failed repair still errors without spawning the server", async () => {
+    stubUvWorkspaceVenv();
+    mockWindow.withProgress.mockImplementation(
+      (_opts: unknown, task: (p: unknown, t: unknown) => Promise<unknown>) =>
+        task(undefined, undefined)
+    );
+    const calls = installRouter({ probeExits: [1], syncExit: 1 });
+    bm = makeSpawnManager("");
+    await bm.start();
+    expect(bm.state).toBe("error");
+    expect(calls.sync).toBe(1);
+    expect(calls.server).toBe(0);
+    expect(mockWindow.showErrorMessage).toHaveBeenCalled();
   });
 });

--- a/apps/vscode/test/backendLifecycle.test.ts
+++ b/apps/vscode/test/backendLifecycle.test.ts
@@ -163,9 +163,9 @@ describe("BackendManager spawn pre-flight", () => {
     probeExits: number[]; // exit code per `-c` import probe, in order
     syncExit?: number; // exit code for the `uv sync` repair
     serverHealthy?: boolean; // flip the backend healthy when the server spawns
-  }): { probes: number; sync: number; server: number } {
-    const calls = { probes: 0, sync: 0, server: 0 };
-    spawnMock.mockImplementation((_cmd: string, args?: readonly string[]) => {
+  }): { probes: number; sync: number; server: number; serverCmd: string } {
+    const calls = { probes: 0, sync: 0, server: 0, serverCmd: "" };
+    spawnMock.mockImplementation((cmd: string, args?: readonly string[]) => {
       const argv = args ?? [];
       if (argv[0] === "-c") {
         calls.probes++;
@@ -177,6 +177,7 @@ describe("BackendManager spawn pre-flight", () => {
       }
       if (argv[0] === "-m") {
         calls.server++;
+        calls.serverCmd = cmd;
         if (opts.serverHealthy) {
           healthy = true;
         }
@@ -200,20 +201,28 @@ describe("BackendManager spawn pre-flight", () => {
 
   // Make resolveSpawnSpec land on the existing-.venv case (2) with a uv repair:
   // a workspace folder, a present .venv python + pyproject.toml, and a uv binary.
-  function stubUvWorkspaceVenv(): void {
+  // Mirror production's platform-specific interpreter and uv names exactly so this
+  // still selects case 2 on Windows (Scripts/python.exe + uv.exe), not the case-3
+  // source-checkout fallback. Returns the resolved venv interpreter for assertions.
+  function stubUvWorkspaceVenv(): string {
     const ws = "/ws";
     (mockWorkspace as { workspaceFolders?: unknown }).workspaceFolders = [
       { uri: { fsPath: ws } },
     ];
-    const venvPython = path.join(ws, ".venv", "bin", "python");
+    const venvPython =
+      process.platform === "win32"
+        ? path.join(ws, ".venv", "Scripts", "python.exe")
+        : path.join(ws, ".venv", "bin", "python");
+    const uvLeaf = process.platform === "win32" ? "uv.exe" : "uv";
     existsSyncMock.mockImplementation((p: fs.PathLike) => {
       const s = String(p);
       return (
         s === venvPython ||
         s === path.join(ws, "pyproject.toml") ||
-        s.endsWith(`${path.sep}uv`)
+        s.endsWith(`${path.sep}${uvLeaf}`)
       );
     });
+    return venvPython;
   }
 
   beforeEach(() => {
@@ -248,6 +257,7 @@ describe("BackendManager spawn pre-flight", () => {
     bm = makeSpawnManager("");
     await bm.start();
     expect(bm.state).toBe("error");
+    expect(calls.probes).toBe(1); // one preflight probe, no repair to re-probe
     expect(calls.server).toBe(0);
     expect(mockWindow.showErrorMessage).toHaveBeenCalled();
   });
@@ -257,17 +267,20 @@ describe("BackendManager spawn pre-flight", () => {
     bm = makeSpawnManager("");
     await bm.start();
     expect(bm.state).toBe("running");
+    expect(calls.probes).toBe(1); // single preflight probe passes, no repair
     expect(calls.server).toBe(1);
   });
 
   it("repairs a studio-less workspace .venv in place, then runs", async () => {
-    stubUvWorkspaceVenv();
+    const venvPython = stubUvWorkspaceVenv();
     mockWindow.withProgress.mockImplementation(
       (_opts: unknown, task: (p: unknown, t: unknown) => Promise<unknown>) =>
         task(undefined, undefined)
     );
     // First import probe fails (studio missing) → uv sync repairs → second probe
-    // passes → server spawns.
+    // passes → server spawns. probes===2 proves the re-probe after repair ran:
+    // this is case 2 (preflight + repair), not a case-3 fall-through that would
+    // skip preflight entirely (0 probes). serverCmd pins the venv interpreter.
     const calls = installRouter({
       probeExits: [1, 0],
       syncExit: 0,
@@ -276,8 +289,10 @@ describe("BackendManager spawn pre-flight", () => {
     bm = makeSpawnManager("");
     await bm.start();
     expect(bm.state).toBe("running");
+    expect(calls.probes).toBe(2);
     expect(calls.sync).toBe(1);
     expect(calls.server).toBe(1);
+    expect(calls.serverCmd).toBe(venvPython);
   });
 
   it("a failed repair still errors without spawning the server", async () => {
@@ -290,6 +305,7 @@ describe("BackendManager spawn pre-flight", () => {
     bm = makeSpawnManager("");
     await bm.start();
     expect(bm.state).toBe("error");
+    expect(calls.probes).toBe(1); // failed repair is not re-probed
     expect(calls.sync).toBe(1);
     expect(calls.server).toBe(0);
     expect(mockWindow.showErrorMessage).toHaveBeenCalled();


### PR DESCRIPTION
## Stream 1 of 3 — Den first-run robustness (adoption series)

Make Den's first run fail fast with guidance (or self-heal) instead of a silent multi-second orphan-probe failure when the resolved interpreter can't import the studio server.

### What
- `resolveSpawnSpec` flags the interpreter cases Den does **not** provision (explicit `den.pythonPath`, a pre-existing workspace `.venv`, system `python3`) with `preflight`. The uv-source-checkout case is unchanged — its existing `provision` step already guarantees deps.
- `start()` runs `_canImportStudio` before spawning: `importlib.util.find_spec` for `lionagi`/`fastapi`/`uvicorn` (resolve-only, so the happy path does **not** pay the studio import twice; 5s-bounded, idempotent resolve).
- For a uv-managed workspace `.venv` missing the extra, it first attempts an in-place `uv sync --extra studio --no-dev` repair (the same sync the source-checkout path uses), then re-checks.
- On unfixable failure: an actionable error (install the extra / set `den.pythonPath` / set `den.url`) and **no** doomed `-m lionagi.studio` spawn.
- Epoch/supersession invariant preserved: every new pre-flight await is followed by a `_superseded(epoch)` guard, so a concurrent Stop/restart still wins.

### Tests
Introduces the first `child_process` mock in the apps/vscode suite (`FakeProc` + an argv-routed spawn router): pre-flight-fail-no-spawn, pre-flight-pass-runs, repair-then-runs, failed-repair-errors. Full suite 56/56; typecheck + compile green.

Independent of #1567 (disjoint files). Part of the `feat/vscode-integration` adoption series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)