### PR TITLE
feat(vscode): marketplace metadata + getting-started walkthrough

### DIFF
--- a/apps/vscode/media/walkthrough/install.md
+++ b/apps/vscode/media/walkthrough/install.md
@@ -1,0 +1,11 @@
+## Install the studio backend
+
+Den renders a small local backend that runs on `localhost`. Install it once:
+
+```bash
+pip install 'lionagi[studio]'
+```
+
+If your workspace already uses a `.venv` or a `uv` project, Den auto-detects it and installs the backend on first run, so you can skip this step.
+
+Nothing leaves your machine. Den only reads from the local backend over `127.0.0.1`.

--- a/apps/vscode/media/walkthrough/open.md
+++ b/apps/vscode/media/walkthrough/open.md
@@ -1,0 +1,7 @@
+## Open the Den panel
+
+Click the lion in the activity bar to open Den.
+
+The backend auto-starts the first time you open it. The Runs view shows its status while it comes up, then switches to your live run tree.
+
+Prefer to attach to a backend you already run? Set `den.url` in settings and Den connects instead of spawning one.

--- a/apps/vscode/media/walkthrough/open.md
+++ b/apps/vscode/media/walkthrough/open.md
@@ -2,6 +2,6 @@
 
 Click the lion in the activity bar to open Den.
 
-The backend auto-starts the first time you open it. The Runs view shows its status while it comes up, then switches to your live run tree.
+The backend auto-starts in the background. The Runs view shows its status while it comes up, then switches to your live run tree.
 
 Prefer to attach to a backend you already run? Set `den.url` in settings and Den connects instead of spawning one.

--- a/apps/vscode/media/walkthrough/run.md
+++ b/apps/vscode/media/walkthrough/run.md
@@ -1,0 +1,11 @@
+## Start your first run
+
+Start a run the way you already do, from your terminal:
+
+```bash
+li agent claude/sonnet "summarize this repo"
+```
+
+`li agent`, `li o`, and your Claude Code sessions all land in the same tree, grouped by project and streamed live as they happen. Anything running right now is pinned in the Active band at the top.
+
+Den is read-only. You start runs, and Den watches them.

--- a/apps/vscode/media/walkthrough/trace.md
+++ b/apps/vscode/media/walkthrough/trace.md
@@ -1,0 +1,8 @@
+## Trace a run
+
+There are two ways to look at a run:
+
+- **Observe**: click a run to open its detail panel and stream the output live.
+- **Trace**: right-click a run and choose **View Run Tree** to draw its branch and agent graph with typed nodes and per-run cost, refreshed as it progresses.
+
+That is the whole loop. Start runs from your terminal, watch them here.

--- a/apps/vscode/package-lock.json
+++ b/apps/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "den",
-  "version": "0.0.24",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "den",
-      "version": "0.0.24",
+      "version": "0.1.0",
       "devDependencies": {
         "@types/node": "^20.0.0",
         "@types/vscode": "^1.90.0",

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -198,7 +198,7 @@
               "markdown": "media/walkthrough/install.md"
             },
             "completionEvents": [
-              "onCommand:den.startBackend"
+              "onContext:den.backendState == 'running'"
             ]
           },
           {

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -2,18 +2,31 @@
   "name": "den",
   "displayName": "Den",
   "description": "Watch your lionagi agent runs and Claude Code sessions live in VS Code.",
-  "version": "0.0.24",
+  "version": "0.1.0",
   "publisher": "lionagi",
+  "license": "Apache-2.0",
   "icon": "media/icon.png",
+  "galleryBanner": {
+    "color": "#1E1B2E",
+    "theme": "dark"
+  },
+  "pricing": "Free",
+  "qna": "marketplace",
+  "homepage": "https://github.com/ohdearquant/lionagi/tree/main/apps/vscode#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/ohdearquant/lionagi.git",
     "directory": "apps/vscode"
   },
+  "bugs": {
+    "url": "https://github.com/ohdearquant/lionagi/issues"
+  },
   "engines": {
     "vscode": "^1.90.0"
   },
   "categories": [
+    "AI",
+    "Visualization",
     "Other"
   ],
   "keywords": [
@@ -21,7 +34,9 @@
     "agent",
     "orchestration",
     "ai",
-    "llm"
+    "llm",
+    "claude code",
+    "observability"
   ],
   "main": "./out/extension.js",
   "activationEvents": [
@@ -168,7 +183,60 @@
           "description": "Bearer token for LIONAGI_STUDIO_AUTH_TOKEN (optional)."
         }
       }
-    }
+    },
+    "walkthroughs": [
+      {
+        "id": "den.gettingStarted",
+        "title": "Get started with Den",
+        "description": "Watch your lionagi runs and Claude Code sessions live, without leaving VS Code.",
+        "steps": [
+          {
+            "id": "den.install",
+            "title": "Install the studio backend",
+            "description": "Den renders a small local backend. Install it once with `pip install 'lionagi[studio]'`, or let Den auto-detect your workspace `.venv` or `uv` project.\n[Open a terminal](command:workbench.action.terminal.new)",
+            "media": {
+              "markdown": "media/walkthrough/install.md"
+            },
+            "completionEvents": [
+              "onCommand:den.startBackend"
+            ]
+          },
+          {
+            "id": "den.open",
+            "title": "Open the Den panel",
+            "description": "Click the lion in the activity bar. Den auto-starts the backend and shows your live run tree.\n[Open Den](command:den.runs.focus)",
+            "media": {
+              "markdown": "media/walkthrough/open.md"
+            },
+            "completionEvents": [
+              "onView:den.runs"
+            ]
+          },
+          {
+            "id": "den.run",
+            "title": "Start your first run",
+            "description": "Start any run from your terminal and it appears in the tree live. `li agent`, `li o`, and Claude Code sessions all land here.\n[Open a terminal](command:workbench.action.terminal.new)",
+            "media": {
+              "markdown": "media/walkthrough/run.md"
+            },
+            "completionEvents": [
+              "onContext:den.hasRuns"
+            ]
+          },
+          {
+            "id": "den.trace",
+            "title": "Trace a run",
+            "description": "Click a run to stream its output live, or right-click and choose View Run Tree to see its branch and agent graph with per-run cost.",
+            "media": {
+              "markdown": "media/walkthrough/trace.md"
+            },
+            "completionEvents": [
+              "onCommand:den.openRunTree"
+            ]
+          }
+        ]
+      }
+    ]
   },
   "scripts": {
     "compile": "node esbuild.js",


### PR DESCRIPTION
Third of three adoption-focused PRs into \`feat/vscode-integration\`. Makes Den marketplace-installable and gives first-run users a guided path.

## What

**Marketplace metadata** (\`package.json\`)
- Version 0.0.24 → 0.1.0 (first marketplace-candidate cut).
- Adds the fields \`vsce package\` validates for a publishable manifest: \`license\` (Apache-2.0), \`galleryBanner\`, \`pricing: Free\`, \`qna\`, \`homepage\`, \`bugs\`.
- Categories \`["AI", "Visualization", "Other"]\`; keywords gain \`claude code\`, \`observability\`.

**Getting-started walkthrough** (\`contributes.walkthroughs\`)
- One walkthrough (\`den.gettingStarted\`), four steps: install backend → open panel → start first run → trace a run.
- Each step carries on-brand markdown media (\`media/walkthrough/{install,open,run,trace}.md\`) and a real \`completionEvents\` trigger (\`onCommand:\`/\`onView:\`/\`onContext:\`) so steps self-check as the user does them.

## Scope

Strictly \`apps/vscode/\` — 4 new walkthrough docs + \`package.json\`. No source/runtime changes; read-only observability contract unchanged.

## Verification

- \`vsce package\` succeeds (den-0.1.0.vsix builds — the full-manifest marketplace gate).
- \`npm run typecheck\`, \`npm run compile\`, \`vitest run\` (full suite) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)