### PR TITLE
ci: drop feat/vscode-integration from CI triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,11 @@ name: Continuous Integration
 
 on:
   push:
-    branches: [ main, develop, feat/vscode-integration ]
+    branches: [ main, develop ]
     paths-ignore:
       - '**/*.ipynb'
   pull_request:
-    branches: [ main, develop, feat/vscode-integration ]
+    branches: [ main, develop ]
     paths-ignore:
       - '**/*.ipynb'
 


### PR DESCRIPTION
## What

Remove `feat/vscode-integration` from the `push` and `pull_request` trigger branch lists in `.github/workflows/ci.yml`, restoring them to `[ main, develop ]`.

## Why

The `feat/vscode-integration` entry was a temporary workaround so CI would run on the VS Code (Den) integration slice branch while its sub-PRs were stacked. That integration branch was merged to `main` in #1570, so the slice trigger is now dead config.

## Scope

One-line change to two trigger lists. No workflow logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)