### PR TITLE
chore(testing): remove two zero-caller dead test helpers

### DIFF
--- a/lionagi/testing/__init__.py
+++ b/lionagi/testing/__init__.py
@@ -42,7 +42,6 @@ from .helpers import (
     MockElement,
     TestDataHelpers,
     ValidationHelpers,
-    make_mock_element_class,
 )
 from .loaders import (
     TestDataLoader,
@@ -89,7 +88,6 @@ __all__ = (
     "TestDataHelpers",
     "TestDataLoader",
     "ValidationHelpers",
-    "make_mock_element_class",
     "get_api_response",
     "get_conversation",
     "get_error_scenario",

--- a/lionagi/testing/helpers.py
+++ b/lionagi/testing/helpers.py
@@ -249,11 +249,6 @@ class MockElement(Element):
     value: Any = _Field(None)
 
 
-def make_mock_element_class() -> type[MockElement]:
-    """Back-compat shim — returns the module-level ``MockElement``."""
-    return MockElement
-
-
 class MockClaudeCode:
     """Mock agentic model returning task/research/default dict shapes based on the last user message."""
 
@@ -289,5 +284,4 @@ __all__ = (
     "MockElement",
     "TestDataHelpers",
     "ValidationHelpers",
-    "make_mock_element_class",
 )

--- a/lionagi/testing/pytest_plugin.py
+++ b/lionagi/testing/pytest_plugin.py
@@ -73,14 +73,6 @@ def mocked_branch(mock_factory):
 
 
 @pytest.fixture
-def mocked_branch_with_custom_response(mock_factory) -> Callable[..., Any]:
-    def _create_branch(response: Any = "custom test response", **kwargs: Any):
-        return mock_factory.create_mocked_branch(response=response, **kwargs)
-
-    return _create_branch
-
-
-@pytest.fixture
 def make_mocked_branch(mock_factory) -> Callable[..., Any]:
     """Canonical factory fixture: replaces every per-file ``make_mocked_branch_for_*``.
 


### PR DESCRIPTION
## Summary
Removes two test helpers with zero callers anywhere in the tree:
- `make_mock_element_class` — a back-compat shim in `lionagi.testing`.
- `mocked_branch_with_custom_response` — an unused fixture.

## Note for reviewers
`make_mock_element_class` was a public `lionagi.testing` symbol. Removing it is a minor breaking change for any external caller of that testing util (none internally; the underlying `MockElement` stays).

3 files changed, −16.

## Verification
Self-verified zero callers (`git grep`); full suite green in the integration build (9692 passed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
