### PR TITLE
fix: preserve delivered content on degraded CLI terminations

### DIFF
--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -260,6 +260,12 @@ async def run(
                                     "ending stream cleanly"
                                 )
                                 break
+                            # Persist text the provider already delivered before
+                            # failing — a late failure (timeout after streaming a
+                            # response) must not destroy content the caller and
+                            # state.db would otherwise have received.
+                            if res := await _flush_response():
+                                yield res
                             content = chunk.content or "(empty error)"
                             raise classify_provider_error(content)
 

--- a/lionagi/providers/google/gemini_code.py
+++ b/lionagi/providers/google/gemini_code.py
@@ -378,7 +378,13 @@ async def stream_gemini_cli(
                 yield sys_sc
 
             if session.is_error:
-                msg = response or f"agy returned status={status or 'UNKNOWN'}"
+                # The error chunk must never impersonate the response: a
+                # degraded termination (e.g. timeout after a complete final
+                # message) would otherwise surface the delivered content AS
+                # the error. Lead with the status; keep a bounded detail so
+                # quota/auth patterns still classify.
+                detail = f": {response[:500]}" if response else ""
+                msg = f"agy returned status={status or 'UNKNOWN'}{detail}"
                 sc = StreamChunk(type="error", content=msg, is_error=True, metadata=obj)
                 session.chunks.append(sc)
                 yield sc

--- a/tests/operations/test_run_error_classification.py
+++ b/tests/operations/test_run_error_classification.py
@@ -233,6 +233,45 @@ async def test_run_already_classified_provider_error_not_double_wrapped():
 
 
 # ---------------------------------------------------------------------------
+# Late error must not destroy already-streamed text
+# ---------------------------------------------------------------------------
+
+
+async def test_run_error_after_text_persists_delivered_content():
+    """Text the provider streamed before failing is flushed into the branch
+    (and yielded) before the classified error is raised — a timeout after a
+    complete final message must not destroy the delivered response."""
+    branch = Branch()
+    branch.chat_model = _make_fake_cli_model(
+        [
+            StreamChunk(type="text", content="the complete final answer"),
+            StreamChunk(type="error", content="agy returned status=TIMEOUT"),
+        ]
+    )
+
+    with pytest.raises(ProviderError, match="status=TIMEOUT"):
+        await _drain(run(branch, "do something", RunParam()))
+
+    responses = [m for m in branch.msgs.messages if type(m).__name__ == "AssistantResponse"]
+    assert len(responses) == 1
+    assert responses[0].response == "the complete final answer"
+
+
+async def test_run_error_without_text_persists_nothing():
+    """The flush-before-raise path is a no-op when no text was streamed."""
+    branch = Branch()
+    branch.chat_model = _make_fake_cli_model(
+        [StreamChunk(type="error", content="hard failure, no content")]
+    )
+
+    with pytest.raises(ProviderError):
+        await _drain(run(branch, "do something", RunParam()))
+
+    responses = [m for m in branch.msgs.messages if type(m).__name__ == "AssistantResponse"]
+    assert responses == []
+
+
+# ---------------------------------------------------------------------------
 # Regression: error:null chunk must NOT be swallowed as benign EOS
 # (null normalised to {} matched the benign predicate before the fix)
 # ---------------------------------------------------------------------------

--- a/tests/providers/google/gemini_code/test_ndjson_mapping.py
+++ b/tests/providers/google/gemini_code/test_ndjson_mapping.py
@@ -216,6 +216,29 @@ async def test_no_system_chunk_when_no_session_id():
     assert "system" not in [c.type for c in chunks]
 
 
+@pytest.mark.asyncio
+async def test_error_chunk_leads_with_status_not_response():
+    """The error chunk must not impersonate the response: a degraded
+    termination can carry a complete final message in ``response``, and
+    surfacing that text bare as the error inverts success into failure."""
+    chunks = await _run_chunks(
+        [_success_obj(status="TIMEOUT", response="the complete final answer")]
+    )
+    error_chunks = [c for c in chunks if c.type == "error"]
+    assert len(error_chunks) == 1
+    assert error_chunks[0].content.startswith("agy returned status=TIMEOUT")
+    # bounded detail retained so quota/auth patterns still classify
+    assert "the complete final answer" in error_chunks[0].content
+
+
+@pytest.mark.asyncio
+async def test_error_chunk_without_response_names_status():
+    chunks = await _run_chunks([_success_obj(status="FAILURE", response="")])
+    error_chunks = [c for c in chunks if c.type == "error"]
+    assert len(error_chunks) == 1
+    assert error_chunks[0].content == "agy returned status=FAILURE"
+
+
 # ---------------------------------------------------------------------------
 # Callbacks
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1589. Targets the 0.27.2 window.

## The failure (live, today)

A ~380s `li agent gemini-code/gemini-3.1-pro` review run completed its work — deliverable written, complete final message with a verdict line — and `li agent` exited 1 with the successful response text AS the ProviderError message. The response was also absent from branch persistence.

## Two halves, both fixed

1. **agy wrapper** (`gemini_code.py`): on a non-SUCCESS terminal status the error chunk carried `content=response` bare, so a degraded termination (timeout after a complete final message) impersonated the response as the error. It now leads with `agy returned status=<STATUS>` plus a bounded 500-char response detail — quota/auth substrings still reach `classify_provider_error`, and the honest prefix makes the failure mode legible.
2. **run.py error path**: raised before `_flush_response()`, destroying text the provider had already streamed. It now flushes accumulated text into an AssistantResponse (persisted + yielded) before raising, so late failures stop deleting delivered content. No-op when nothing was streamed.

## Not in scope (stays on #1589)

Recovering the full response as a *success* on specific degraded statuses needs agy's terminal-status enum semantics verified empirically (binary strings suggest `SUCCESS | FAILURE | TIMEOUT | CANCELLED | ABORTED`; the response field carries error text on real failures, so response-presence alone cannot discriminate). Evidence gathering tracked on the issue.

## Tests

- Wrapper: error chunk leads with status (with + without response detail); all existing mapping tests unchanged.
- run(): late-error-after-text persists the AssistantResponse then raises; error-without-text persists nothing.
- Suites green: operations, session, service, providers/google, codex benign-EOS, agent-resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
