### PR TITLE
test(studio): guard 4 studio tests with importorskip so core-only release install passes

### DIFF
--- a/tests/apps_studio_server/test_adversarial_reapers.py
+++ b/tests/apps_studio_server/test_adversarial_reapers.py
@@ -10,9 +10,11 @@ from pathlib import Path
 
 import pytest
 
-from lionagi.state.db import StateDB
+pytest.importorskip("fastapi", reason="studio extra not installed")
 
-from ._helpers import run_async
+from lionagi.state.db import StateDB  # noqa: E402
+
+from ._helpers import run_async  # noqa: E402
 
 # ── shared DB helpers ─────────────────────────────────────────────────────────
 

--- a/tests/apps_studio_server/test_cas_race_conditions.py
+++ b/tests/apps_studio_server/test_cas_race_conditions.py
@@ -20,9 +20,11 @@ from pathlib import Path
 import pytest
 from sqlalchemy import text
 
-from lionagi.state.db import StateDB
+pytest.importorskip("fastapi", reason="studio extra not installed")
 
-from ._helpers import run_async
+from lionagi.state.db import StateDB  # noqa: E402
+
+from ._helpers import run_async  # noqa: E402
 
 # ── DB helpers ────────────────────────────────────────────────────────────────
 

--- a/tests/apps_studio_server/test_claude_mirror_tail.py
+++ b/tests/apps_studio_server/test_claude_mirror_tail.py
@@ -10,10 +10,14 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
-from lionagi.state.claude_mirror import session_db_id
-from lionagi.state.db import StateDB
+import pytest
 
-from ._helpers import run_async
+pytest.importorskip("fastapi", reason="studio extra not installed")
+
+from lionagi.state.claude_mirror import session_db_id  # noqa: E402
+from lionagi.state.db import StateDB  # noqa: E402
+
+from ._helpers import run_async  # noqa: E402
 
 
 def _write_transcript(root: Path, uid: str, *, cwd: str, base_ts: float) -> Path:

--- a/tests/apps_studio_server/test_invocations_service.py
+++ b/tests/apps_studio_server/test_invocations_service.py
@@ -8,10 +8,14 @@ from __future__ import annotations
 import time
 import uuid
 
-import lionagi.state.db as state_db_mod
-import lionagi.studio.services.invocations as invocations_mod
-from lionagi.state.db import StateDB
-from lionagi.state.reasons import RunReasons
+import pytest
+
+pytest.importorskip("fastapi", reason="studio extra not installed")
+
+import lionagi.state.db as state_db_mod  # noqa: E402
+import lionagi.studio.services.invocations as invocations_mod  # noqa: E402
+from lionagi.state.db import StateDB  # noqa: E402
+from lionagi.state.reasons import RunReasons  # noqa: E402
 
 
 async def _create_invocation(db: StateDB, *, status: str = "running") -> str:


### PR DESCRIPTION
The release workflow (release.yml) installs lionagi **core-only** (no studio extra) and runs the test suite as a publish gate. Four `apps_studio_server` tests imported studio modules without the `importorskip("fastapi")` guard their siblings use:

- `test_invocations_service.py` — module-top `import lionagi.studio.services.invocations` → **collection error** (`ModuleNotFoundError: fastapi`), which blocked the v0.27.2 publish job.
- `test_adversarial_reapers.py`, `test_cas_race_conditions.py`, `test_claude_mirror_tail.py` — deferred in-function studio imports (e.g. `lionagi.studio.app`) that would error at run-time in the same core-only env.

`ci.yml` uses `uv sync --all-extras`, so studio is always present there and this was masked. Fix: add the module-level `importorskip` guard to all four so they skip cleanly without the studio extra, matching the rest of the suite. Verified: all four execute (30 pass) with studio present, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)