### PR TITLE
fix(release): install all extras in release gate; add studio to [all]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install dependencies
       run: |
         uv venv
-        uv sync --extra all
+        uv sync --all-extras
     
     - name: Run tests
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,7 +160,8 @@ all = [
     "lionagi[graph]",
     "lionagi[sqlite]",
     "lionagi[xml]",
-    "lionagi[ag2]"
+    "lionagi[ag2]",
+    "lionagi[studio]"
 ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -3131,9 +3131,12 @@ all = [
     { name = "ag2", extra = ["openai"] },
     { name = "aiosqlite" },
     { name = "asyncpg" },
+    { name = "croniter" },
     { name = "datamodel-code-generator" },
     { name = "docling" },
+    { name = "fastapi" },
     { name = "fastmcp" },
+    { name = "httpx" },
     { name = "matplotlib" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -3141,6 +3144,7 @@ all = [
     { name = "pydapter", extra = ["postgres"] },
     { name = "rich" },
     { name = "starlette" },
+    { name = "uvicorn" },
     { name = "xmltodict" },
 ]
 graph = [
@@ -3257,6 +3261,7 @@ requires-dist = [
     { name = "lionagi", extras = ["rich"], marker = "extra == 'all'" },
     { name = "lionagi", extras = ["schema"], marker = "extra == 'all'" },
     { name = "lionagi", extras = ["sqlite"], marker = "extra == 'all'" },
+    { name = "lionagi", extras = ["studio"], marker = "extra == 'all'" },
     { name = "lionagi", extras = ["xml"], marker = "extra == 'all'" },
     { name = "matplotlib", marker = "extra == 'graph'", specifier = ">=3.7.0" },
     { name = "msgspec", specifier = ">=0.20.0" },


### PR DESCRIPTION
## Problem

The release workflow's test gate ran `uv sync --extra all` — the hand-maintained `all` **extra** — while CI (`ci.yml`) uses `uv sync --all-extras` (the uv **flag** = every extra). The `all` extra had drifted: it omits `studio`, so `fastapi` was absent in the release test env and studio-importing tests failed **only at the release gate** (green on every PR in CI, red only when publishing v0.27.2).

## Fix

- `.github/workflows/release.yml`: `uv sync --extra all` → `uv sync --all-extras` (release gate now matches CI; robust against future extra drift).
- `pyproject.toml`: add `lionagi[studio]` to the `all` extra so `pip install lionagi[all]` ships the studio surface for users (it currently does not).
- `uv.lock`: refreshed for the `all`-extra change.

Verified: fastapi/sqlalchemy/greenlet present under the dev (`--all-extras`) install, and the test that failed at the gate (`test_argv_injection.py::...test_create_with_model_flag_raises_value_error`) passes with fastapi present. CI already runs the full studio suite green under `--all-extras`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)