### PR TITLE
feat(providers): gemini antigravity effort via model-name suffix

### DIFF
--- a/lionagi/cli/_providers.py
+++ b/lionagi/cli/_providers.py
@@ -24,6 +24,7 @@ from lionagi.service.providers import (
     PROVIDER_FAST_KWARGS,
     PROVIDER_TO_ALIAS,
     PROVIDER_YOLO_KWARGS,
+    PROVIDERS_EFFORT_VIA_MODEL_NAME,
     PROVIDERS_NO_EFFORT,
     ModelSpec,
     _clamp_claude_effort,
@@ -40,6 +41,7 @@ __all__ = (
     "PROVIDER_FAST_KWARGS",
     "PROVIDER_TO_ALIAS",
     "PROVIDER_YOLO_KWARGS",
+    "PROVIDERS_EFFORT_VIA_MODEL_NAME",
     "PROVIDERS_NO_EFFORT",
     "add_common_cli_args",
     "build_chat_model",
@@ -77,6 +79,7 @@ def build_imodel_from_spec(
 
     # Resolve provider for yolo/effort kwarg lookup
     provider_raw = ms.model.split("/")[0] if "/" in ms.model else ms.model
+    resolved_model = ms.model
 
     if bypass:
         extra.update(PROVIDER_BYPASS_KWARGS.get(provider_raw, {}))
@@ -96,9 +99,16 @@ def build_imodel_from_spec(
             elif provider_raw in _CLAUDE_PROVIDER_NAMES:
                 effort = _clamp_claude_effort(effort, ms.model)
             extra[kwarg] = effort
+        elif provider_raw in PROVIDERS_EFFORT_VIA_MODEL_NAME:
+            # agy (Antigravity CLI) has no effort kwarg — fold effort into the
+            # resolved --model name instead (see resolve_agy_model).
+            from lionagi.providers.google.gemini_code import resolve_agy_model
+
+            bare_model = ms.model.split("/", 1)[1] if "/" in ms.model else ms.model
+            resolved_model = f"{provider_raw}/{resolve_agy_model(bare_model, effort=effort)}"
 
     return iModel(
-        model=ms.model,
+        model=resolved_model,
         endpoint="query_cli",
         api_key="dummy",
         **extra,
@@ -135,6 +145,12 @@ def build_chat_model(
             elif provider in _CLAUDE_PROVIDER_NAMES:
                 effort = _clamp_claude_effort(effort, model)
             extra[kwarg] = effort
+        elif provider in PROVIDERS_EFFORT_VIA_MODEL_NAME:
+            # agy (Antigravity CLI) has no effort kwarg — fold effort into the
+            # resolved --model name instead (see resolve_agy_model).
+            from lionagi.providers.google.gemini_code import resolve_agy_model
+
+            model = resolve_agy_model(model, effort=effort)
 
     if extra:
         return iModel(
@@ -201,7 +217,9 @@ def add_common_cli_args(parser: argparse.ArgumentParser) -> None:
         help=(
             "Override effort (overrides spec suffix). "
             "claude: low|medium|high|xhigh|max. "
-            "codex: none|minimal|low|medium|high|xhigh."
+            "codex: none|minimal|low|medium|high|xhigh. "
+            "gemini-code/gemini-cli: folded into --model as Low|Medium|High "
+            "(Gemini 3.1 Pro has no Medium)."
         ),
     )
     parser.add_argument(

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -27,6 +27,7 @@ from ._providers import (
     PROVIDER_EFFORT_KWARG,
     PROVIDER_FAST_KWARGS,
     PROVIDER_YOLO_KWARGS,
+    PROVIDERS_EFFORT_VIA_MODEL_NAME,
     add_common_cli_args,
     build_chat_model,
     build_deadline_preamble,
@@ -322,6 +323,12 @@ async def _run_agent(
             kwarg = PROVIDER_EFFORT_KWARG.get(provider)
             if kwarg:
                 cfg[kwarg] = effort
+            elif provider in PROVIDERS_EFFORT_VIA_MODEL_NAME:
+                # agy (Antigravity CLI) has no effort kwarg — fold effort into
+                # the resolved --model name instead (see resolve_agy_model).
+                from lionagi.providers.google.gemini_code import resolve_agy_model
+
+                cfg["model"] = resolve_agy_model(cfg.get("model"), effort=effort)
         if bypass:
             cfg.update(PROVIDER_BYPASS_KWARGS.get(provider, {}))
         elif yolo:

--- a/lionagi/providers/google/gemini_code.py
+++ b/lionagi/providers/google/gemini_code.py
@@ -39,6 +39,7 @@ from lionagi.providers._cli_subprocess import (
 )
 from lionagi.service.connections.agentic_endpoint import AgenticEndpoint
 from lionagi.service.connections.endpoint_config import EndpointConfig
+from lionagi.service.providers import _clamp_gemini_effort
 from lionagi.service.types.cli_session import CLISession
 from lionagi.service.types.stream_chunk import StreamChunk
 from lionagi.utils import to_dict
@@ -131,29 +132,52 @@ _MODEL_ALIASES: dict[str, str] = {
 }
 
 
-def resolve_agy_model(model: str | None) -> str:
-    """Map a lionagi model spec onto an exact `agy --model` name."""
+def resolve_agy_model(model: str | None, effort: str | None = None) -> str:
+    """Map a lionagi model spec onto an exact `agy --model` name.
+
+    agy has no effort flag/kwarg — effort is expressed only as the
+    Low/Medium/High suffix on the model name. `effort` is lionagi's 5-level
+    scale (none|minimal|low|medium|high|xhigh|max); when given, it selects
+    that suffix for the Gemini flash/pro families instead of the family
+    default below (`_clamp_gemini_effort` collapses onto Gemini 3.1 Pro's
+    Low/High-only range). An exact `(...)`-qualified `model` — already a
+    concrete agy display name — always wins over `effort`.
+    """
     if not model:
-        return "Gemini 3.5 Flash (Medium)"
+        model = "gemini-3.5-flash"
     if model in _AGY_MODELS:
         return model
     key = model.strip().lower()
     if key in _MODEL_ALIASES:
-        return _MODEL_ALIASES[key]
+        target = _MODEL_ALIASES[key]
+        if effort is None:
+            return target
+        if target.startswith("Gemini 3.5 Flash"):
+            return f"Gemini 3.5 Flash ({_clamp_gemini_effort(effort, False)})"
+        if target.startswith("Gemini 3.1 Pro"):
+            return f"Gemini 3.1 Pro ({_clamp_gemini_effort(effort, True)})"
+        return target  # cross-family alias (Claude/GPT-OSS via agy) — no effort tiers
+
+    # effort given but the string isn't a known alias: still resolve a
+    # gemini family from it (e.g. "gemini-3-pro-experimental") so --effort
+    # keeps working on forward-compatible model names.
+    is_pro = "pro" in key
+    if effort is not None and (is_pro or "flash" in key or "gemini" in key):
+        family = "Gemini 3.1 Pro" if is_pro else "Gemini 3.5 Flash"
+        return f"{family} ({_clamp_gemini_effort(effort, is_pro)})"
 
     # Heuristic fallback: derive (family, effort) from a free-form string so
     # e.g. "gemini-3-pro-low" or "flash high" still resolve.
-    is_pro = "pro" in key
     if "low" in key:
-        effort = "Low"
+        heuristic = "Low"
     elif "high" in key or "xhigh" in key or "max" in key:
-        effort = "High"
+        heuristic = "High"
     else:
-        effort = "Low" if is_pro else "Medium"
+        heuristic = "Low" if is_pro else "Medium"
     if is_pro:
-        return f"Gemini 3.1 Pro ({'High' if effort == 'Medium' else effort})"
+        return f"Gemini 3.1 Pro ({'High' if heuristic == 'Medium' else heuristic})"
     if "flash" in key or "gemini" in key:
-        return f"Gemini 3.5 Flash ({effort})"
+        return f"Gemini 3.5 Flash ({heuristic})"
 
     # Not recognizable — pass through; agy rejects an invalid name clearly.
     return model

--- a/lionagi/service/providers.py
+++ b/lionagi/service/providers.py
@@ -17,6 +17,7 @@ __all__ = (
     "PROVIDER_FAST_KWARGS",
     "PROVIDER_TO_ALIAS",
     "PROVIDER_YOLO_KWARGS",
+    "PROVIDERS_EFFORT_VIA_MODEL_NAME",
     "PROVIDERS_NO_EFFORT",
     "parse_model_spec",
 )
@@ -53,6 +54,29 @@ def _clamp_claude_effort(effort: str, model: str) -> str:
     return "high"
 
 
+# agy (Antigravity CLI) has no effort flag or kwarg — effort is expressed only
+# as a Low/Medium/High suffix baked into the --model name, and Gemini 3.1 Pro
+# has no Medium tier. lionagi's 5-level none|minimal|low|medium|high|xhigh|max
+# collapses onto this 3-tier scale.
+_GEMINI_EFFORT_CLAMP: dict[str, str] = {
+    "none": "Low",
+    "minimal": "Low",
+    "low": "Low",
+    "medium": "Medium",
+    "high": "High",
+    "xhigh": "High",
+    "max": "High",
+}
+
+
+def _clamp_gemini_effort(effort: str, is_pro: bool) -> str:
+    """Map lionagi's 5-level effort onto agy's Low/Medium/High tiers; Pro has no Medium."""
+    tier = _GEMINI_EFFORT_CLAMP.get(effort, "Medium")
+    if is_pro and tier == "Medium":
+        return "High"
+    return tier
+
+
 # CLI providers use subprocess auth; api_key is a placeholder. Passing a placeholder to API providers OVERRIDES key resolution.
 CLI_PROVIDERS: frozenset[str] = frozenset(
     {
@@ -77,22 +101,37 @@ PROVIDER_EFFORT_KWARG: dict[str, str] = {
     "pi": "thinking",
 }
 
-PROVIDERS_NO_EFFORT: frozenset[str] = frozenset(
+# agy-backed aliases (see lionagi/providers/google/gemini_code.py) fold effort
+# into the resolved --model name via resolve_agy_model instead of a kwarg —
+# classified separately from PROVIDER_EFFORT_KWARG below.
+PROVIDERS_EFFORT_VIA_MODEL_NAME: frozenset[str] = frozenset(
     {
         "gemini_code",
         "gemini-code",
         "gemini_cli",
         "gemini-cli",
+    }
+)
+
+# Bare "gemini" is the direct Google API provider (see
+# providers/google/_config.py:GeminiChatConfigs) — distinct from the agy CLI
+# above — and has no effort concept at all.
+PROVIDERS_NO_EFFORT: frozenset[str] = frozenset(
+    {
         "gemini",
     }
 )
 
-# Invariant: provider cannot be in both PROVIDERS_NO_EFFORT and PROVIDER_EFFORT_KWARG; RuntimeError (not assert) survives -O.
-_overlap = PROVIDERS_NO_EFFORT & set(PROVIDER_EFFORT_KWARG)
+# Invariant: the three provider-effort classifications above are mutually exclusive; RuntimeError (not assert) survives -O.
+_overlap = (
+    (PROVIDERS_NO_EFFORT & set(PROVIDER_EFFORT_KWARG))
+    | (PROVIDERS_NO_EFFORT & PROVIDERS_EFFORT_VIA_MODEL_NAME)
+    | (set(PROVIDER_EFFORT_KWARG) & PROVIDERS_EFFORT_VIA_MODEL_NAME)
+)
 if _overlap:
     raise RuntimeError(
-        f"Provider classification conflict: {_overlap!r} appear in both "
-        "PROVIDERS_NO_EFFORT and PROVIDER_EFFORT_KWARG"
+        f"Provider classification conflict: {_overlap!r} appear in more than one "
+        "of PROVIDERS_NO_EFFORT, PROVIDER_EFFORT_KWARG, PROVIDERS_EFFORT_VIA_MODEL_NAME"
     )
 del _overlap
 

--- a/tests/cli/test_providers.py
+++ b/tests/cli/test_providers.py
@@ -9,10 +9,20 @@ import pytest
 from lionagi.cli._providers import build_imodel_from_spec, parse_model_spec
 
 
-def test_parse_model_spec_rejects_effort_for_gemini_provider():
-    """Gemini providers do not support effort levels — ValueError is raised."""
+def test_parse_model_spec_folds_effort_suffix_for_gemini_code():
+    """gemini-code now supports effort levels — folded into the agy model-name
+    suffix downstream via resolve_agy_model — so an embedded '-high' suffix
+    parses instead of raising."""
+    ms = parse_model_spec("gemini-code/gemini-3.1-pro-high")
+    assert ms.model == "gemini-code/gemini-3.1-pro"
+    assert ms.effort == "high"
+
+
+def test_parse_model_spec_rejects_effort_for_bare_gemini_provider():
+    """The bare 'gemini' provider (direct Google API, not the agy CLI) still
+    does not support effort levels — ValueError is raised."""
     with pytest.raises(ValueError, match="does not support effort"):
-        parse_model_spec("gemini-code/gemini-3.1-pro-high")
+        parse_model_spec("gemini/gemini-3.1-pro-high")
 
 
 def test_build_imodel_from_spec_maps_effort_and_yolo_without_network(monkeypatch):
@@ -133,3 +143,113 @@ def test_module_invariant_sets_are_disjoint():
         f"Provider(s) {overlap!r} appear in both PROVIDERS_NO_EFFORT and "
         f"PROVIDER_EFFORT_KWARG — this is a classification conflict"
     )
+
+
+def test_module_invariant_three_way_disjoint_including_effort_via_model_name():
+    """PROVIDERS_NO_EFFORT, PROVIDER_EFFORT_KWARG, and PROVIDERS_EFFORT_VIA_MODEL_NAME
+    must be pairwise disjoint (providers.py raises RuntimeError at import time if
+    not; this re-checks for a readable failure message at the test layer)."""
+    from lionagi.cli._providers import (
+        PROVIDER_EFFORT_KWARG,
+        PROVIDERS_EFFORT_VIA_MODEL_NAME,
+        PROVIDERS_NO_EFFORT,
+    )
+
+    assert not (PROVIDERS_NO_EFFORT & PROVIDER_EFFORT_KWARG.keys())
+    assert not (PROVIDERS_NO_EFFORT & PROVIDERS_EFFORT_VIA_MODEL_NAME)
+    assert not (PROVIDER_EFFORT_KWARG.keys() & PROVIDERS_EFFORT_VIA_MODEL_NAME)
+
+
+# ── gemini-code / agy effort folding ───────────────────────────────────────
+# agy (Antigravity CLI) has no effort flag/kwarg — --effort must fold into
+# the resolved --model name suffix instead (see resolve_agy_model). These
+# cover the CLI-integration layer (build_chat_model / resolve_persisted_effort);
+# tests/providers/google/gemini_code/test_ndjson_mapping.py covers
+# resolve_agy_model itself directly.
+
+
+def test_gemini_code_no_longer_in_no_effort_but_bare_gemini_still_is():
+    """The four agy-backed aliases moved out of PROVIDERS_NO_EFFORT into
+    PROVIDERS_EFFORT_VIA_MODEL_NAME; bare 'gemini' (the API provider) stays."""
+    from lionagi.cli._providers import PROVIDERS_EFFORT_VIA_MODEL_NAME, PROVIDERS_NO_EFFORT
+
+    for alias in ("gemini_code", "gemini-code", "gemini_cli", "gemini-cli"):
+        assert alias not in PROVIDERS_NO_EFFORT
+        assert alias in PROVIDERS_EFFORT_VIA_MODEL_NAME
+    assert "gemini" in PROVIDERS_NO_EFFORT
+    assert "gemini" not in PROVIDERS_EFFORT_VIA_MODEL_NAME
+
+
+def test_build_chat_model_folds_effort_into_gemini_code_model_name():
+    """--effort high for gemini-code folds into the agy model-name suffix
+    (agy has no effort kwarg) instead of being silently dropped."""
+    from lionagi.cli._providers import build_chat_model
+
+    chat_model = build_chat_model(
+        "gemini-code", "gemini-3.5-flash", False, False, None, "high", False
+    )
+    assert isinstance(chat_model, str), f"expected bare spec string, got {type(chat_model)}"
+    assert chat_model == "gemini-code/Gemini 3.5 Flash (High)"
+
+
+def test_build_chat_model_folds_max_effort_to_high_for_gemini_code():
+    """--effort max clamps to agy's High tier (agy has no 'max')."""
+    from lionagi.cli._providers import build_chat_model
+
+    chat_model = build_chat_model(
+        "gemini-code", "gemini-3.5-flash", False, False, None, "max", False
+    )
+    assert chat_model == "gemini-code/Gemini 3.5 Flash (High)"
+
+
+def test_build_chat_model_folds_medium_effort_to_high_for_gemini_pro():
+    """Gemini 3.1 Pro has no Medium tier — medium clamps to High."""
+    from lionagi.cli._providers import build_chat_model
+
+    chat_model = build_chat_model(
+        "gemini-code", "gemini-3.1-pro", False, False, None, "medium", False
+    )
+    assert chat_model == "gemini-code/Gemini 3.1 Pro (High)"
+
+
+def test_build_chat_model_explicit_qualified_model_wins_over_effort():
+    """An explicit (...)-qualified model name is already a concrete agy
+    display name — it wins over --effort rather than being reinterpreted."""
+    from lionagi.cli._providers import build_chat_model
+
+    chat_model = build_chat_model(
+        "gemini-code", "Gemini 3.5 Flash (Low)", False, False, None, "high", False
+    )
+    assert chat_model == "gemini-code/Gemini 3.5 Flash (Low)"
+
+
+def test_build_chat_model_no_effort_leaves_gemini_model_unresolved():
+    """No --effort given: build_chat_model does not eagerly resolve through
+    resolve_agy_model (unchanged from pre-effort-folding behavior) — the bare
+    spec passes through and is resolved lazily in GeminiCodeRequest.as_cmd_args()."""
+    from lionagi.cli._providers import build_chat_model
+
+    chat_model = build_chat_model(
+        "gemini-code", "gemini-3.5-flash", False, False, None, None, False
+    )
+    assert chat_model == "gemini-code/gemini-3.5-flash"
+
+
+def test_resolve_persisted_effort_gemini_code_keeps_requested_effort():
+    """Unlike bare 'gemini', gemini-code now persists the requested effort
+    instead of forcing None — it consumes effort via model-name resolution,
+    not a PROVIDER_EFFORT_KWARG entry (there still isn't one for gemini-code)."""
+    from lionagi.cli._providers import (
+        PROVIDER_EFFORT_KWARG,
+        build_chat_model,
+        resolve_persisted_effort,
+    )
+
+    provider = "gemini-code"
+    assert provider not in PROVIDER_EFFORT_KWARG
+
+    chat_model = build_chat_model(provider, "gemini-3.5-flash", False, False, None, "high", False)
+    assert isinstance(chat_model, str)
+
+    result = resolve_persisted_effort(provider, chat_model, "high")
+    assert result == "high", f"expected requested effort to persist for gemini-code, got {result!r}"

--- a/tests/providers/google/gemini_code/test_ndjson_mapping.py
+++ b/tests/providers/google/gemini_code/test_ndjson_mapping.py
@@ -286,3 +286,47 @@ async def test_on_text_and_on_final_fire():
 )
 def test_resolve_agy_model(spec, expected):
     assert resolve_agy_model(spec) == expected
+
+
+# ---------------------------------------------------------------------------
+# Model resolution — effort folding (agy has no effort flag/kwarg; effort is
+# expressed only as the Low/Medium/High suffix on --model)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "spec,effort,expected",
+    [
+        # lionagi effort clamps onto agy's Low/Medium/High tier for flash.
+        ("gemini-3.5-flash", "low", "Gemini 3.5 Flash (Low)"),
+        ("gemini-3.5-flash", "medium", "Gemini 3.5 Flash (Medium)"),
+        ("gemini-3.5-flash", "high", "Gemini 3.5 Flash (High)"),
+        # xhigh/max both clamp to High — agy has no tier above High.
+        ("gemini-3.5-flash", "xhigh", "Gemini 3.5 Flash (High)"),
+        ("gemini-3.5-flash", "max", "Gemini 3.5 Flash (High)"),
+        # none/minimal both clamp to Low.
+        ("gemini-3.5-flash", "none", "Gemini 3.5 Flash (Low)"),
+        ("gemini-3.5-flash", "minimal", "Gemini 3.5 Flash (Low)"),
+        # Gemini 3.1 Pro has no Medium tier — medium (and anything clamping to
+        # Medium) bumps to High; Low and High pass through unchanged.
+        ("gemini-3.1-pro", "low", "Gemini 3.1 Pro (Low)"),
+        ("gemini-3.1-pro", "medium", "Gemini 3.1 Pro (High)"),
+        ("gemini-3.1-pro", "high", "Gemini 3.1 Pro (High)"),
+        ("gemini-3.1-pro", "max", "Gemini 3.1 Pro (High)"),
+        # An exact (...)-qualified model is already a concrete agy display
+        # name — it wins over effort rather than being reinterpreted.
+        ("Gemini 3.5 Flash (Low)", "high", "Gemini 3.5 Flash (Low)"),
+        ("Gemini 3.1 Pro (Low)", "high", "Gemini 3.1 Pro (Low)"),
+        # No effort given: family default from _MODEL_ALIASES, unaffected.
+        ("gemini-3.5-flash", None, "Gemini 3.5 Flash (Medium)"),
+        ("gemini-3.1-pro", None, "Gemini 3.1 Pro (High)"),
+    ],
+)
+def test_resolve_agy_model_effort_folding(spec, effort, expected):
+    assert resolve_agy_model(spec, effort=effort) == expected
+
+
+def test_resolve_agy_model_effort_ignored_for_cross_family_alias():
+    """Claude/GPT-OSS routed through agy have no Low/Medium/High tiers —
+    effort is accepted but has no suffix to fold into."""
+    assert resolve_agy_model("opus", effort="high") == "Claude Opus 4.6 (Thinking)"


### PR DESCRIPTION
## What

Makes `--effort` work for the Antigravity (`agy`) Gemini provider, the same way it already works for claude and codex. The design goal is the same user-facing effort control, but the mechanism differs.

## Why the mechanism differs

`agy` has **no effort flag or kwarg**. Effort is expressed only as a `Low`/`Medium`/`High` suffix baked into the `--model` name, and Gemini 3.1 Pro has no `Medium` tier. So instead of injecting an effort kwarg (claude/codex path), effort is folded into the resolved model name.

## How

- `_clamp_gemini_effort` (new, in `service/providers.py`) collapses lionagi's 5-level scale (`none|minimal|low|medium|high|xhigh|max`) onto agy's 3 tiers; `is_pro=True` bumps `Medium → High`.
- `resolve_agy_model(model, effort=None)` folds the clamped suffix into the Flash/Pro family name. An exact `(...)`-qualified model name (already a concrete agy display name) **always wins** over `--effort`.
- `gemini_code`/`gemini-code`/`gemini_cli`/`gemini-cli` move to a new `PROVIDERS_EFFORT_VIA_MODEL_NAME` class, distinct from `PROVIDER_EFFORT_KWARG` (kwarg path) and `PROVIDERS_NO_EFFORT` (bare `gemini`, the direct Google API provider, which has no effort concept). The mutual-exclusion invariant is extended to three-way (RuntimeError, survives `-O`).
- Threaded at the three CLI call sites (`build_chat_model`, `build_imodel_from_spec`, resumed-branch `cfg[model]`) via lazy import, keeping the heavier gemini module out of the light CLI arg path.

## Verified

- `uv run pytest tests/cli/test_providers.py tests/providers/google/gemini_code/` → **53 passed**.
- Live smoke: `flash+high → Gemini 3.5 Flash (High)`, `pro+medium → Gemini 3.1 Pro (High)` (no Medium tier), `flash+low → Gemini 3.5 Flash (Low)`, explicit `Gemini 3.1 Pro (High)` + `--effort low → Gemini 3.1 Pro (High)` (explicit wins).
- ruff clean.

## Follow-up (out of scope)

`agent/factory.py::create_agent` has an independent copy of the `PROVIDER_EFFORT_KWARG.get(provider)` no-op pattern on the `AgentSpec.model`-direct path. That path is dead for the CLI `--effort` flow (`li agent` pre-builds `chat_model` before `create_agent`), but a direct `create_agent(AgentSpec(model='gemini-code/...', effort=...))` call would still drop effort. Flagging for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)