### PR TITLE
chore(deps): drop empty [testing] extra; pyyaml is core

### DIFF
--- a/lionagi/testing/_script.py
+++ b/lionagi/testing/_script.py
@@ -106,15 +106,9 @@ class ScriptModel(BaseModel):
 
     @classmethod
     def from_yaml(cls, path: str | Path) -> ScriptModel:
-        """Load a YAML script. Requires the ``[testing]`` extra (pyyaml)."""
+        """Load a YAML script."""
+        import yaml
 
-        try:
-            import yaml
-        except ImportError as e:
-            raise ImportError(
-                "loading YAML scripts requires pyyaml — install lionagi[testing] "
-                "or use ScriptModel.from_json / from_responses"
-            ) from e
         with open(path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
         return cls.model_validate(data or {})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,8 +140,6 @@ sandbox = [
     "uvicorn>=0.34.0",
 ]
 
-testing = []
-
 studio = [
     "fastapi>=0.115",
     "uvicorn>=0.34",

--- a/uv.lock
+++ b/uv.lock
@@ -3285,7 +3285,7 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'studio'", specifier = ">=0.34" },
     { name = "xmltodict", marker = "extra == 'xml'", specifier = ">=0.12.0" },
 ]
-provides-extras = ["reader", "ollama", "mcp", "rich", "schema", "pandas", "postgres", "sqlite", "graph", "xml", "ag2", "sandbox", "testing", "studio", "all"]
+provides-extras = ["reader", "ollama", "mcp", "rich", "schema", "pandas", "postgres", "sqlite", "graph", "xml", "ag2", "sandbox", "studio", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## What

- Remove the `[testing]` optional-dependency extra. It was an empty list (`testing = []`) that installed nothing.
- `ScriptModel.from_yaml` had a dead `try/except ImportError` telling callers to `pip install lionagi[testing]` for pyyaml support, but **pyyaml has been a core dependency** since it was added to `[project.dependencies]`. Simplified to a plain lazy `import yaml`.
- Regenerate `uv.lock` (drops `testing` from `provides-extras`).

## Why

Follow-up to the optional-dependency audit: `[testing]` was the one extra with no real consumers. Removing it and the stale install hint eliminates a misleading breadcrumb.

## Verification

- `uv lock` diff: single line (drops `testing` extra).
- `uv run pytest tests/testing/ tests/casts/test_profile.py tests/agent/test_spec.py` → **135 passed**.
- `uv run ruff check` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)