### PR TITLE
fix(orchestrate): populate DAG-flow artifact contracts at plan time; fail loud on undeclared escalation

### DIFF
--- a/docs/adrs/ADR-0029-artifact-contract.md
+++ b/docs/adrs/ADR-0029-artifact-contract.md
@@ -99,6 +99,23 @@ for outcome-kind contract checks (deferred to v1.1; see Non-Goals).
 written at session creation, never updated. Editing the playbook
 mid-run does not retroactively change what was expected.
 
+> **DAG-flow extension** (`li o flow`, `lionagi/cli/orchestrate/flow.py`):
+> the rule above assumes the full contract is resolvable at
+> `create_session` time, which holds for the single-agent case (§5) where
+> the playbook and agent profile are both known before the session row is
+> written. Multi-leg flows break that assumption — which casts `Role` (or
+> `AgentProfile`) runs which leg is only known once planning finishes,
+> which happens *after* `create_session`. `_build_dag` performs exactly
+> one additional write to `artifact_contract_json`, folding each leg's
+> resolved role `artifact_defaults` into the contract, namespaced under
+> that leg's own artifact subdirectory. This happens once, before
+> `_execute_dag` runs any leg — i.e. before any worker output could exist
+> — so the anti-drift guarantee ("no retroactive change of what was
+> expected") still holds; it is just anchored at "DAG built" rather than
+> "session created" for this call path. No other call site may write this
+> column after that point. See `_SESSION_COLUMNS` in `lionagi/state/db.py`
+> for the allowlist entry and rationale.
+
 ### 2. Playbook contract shape
 
 ```yaml
@@ -496,6 +513,13 @@ lionagi/cli/_agents.py                    # AgentProfile parser exposes
 apps/studio/server/services/sessions.py   # include contract+verification in API
 apps/studio/server/routers/runs.py        # detail endpoint exposes both
 apps/studio/frontend/components/runs/ExpectedArtifacts.tsx  # new UI section
+lionagi/cli/orchestrate/flow.py           # DAG-flow extension: _build_dag folds
+                                          # per-leg role artifact_defaults into
+                                          # the contract once, pre-execution (see
+                                          # "DAG-flow extension" note above)
+lionagi/casts/pattern.py                  # Role.artifact_defaults field
+lionagi/casts/roles/reviewer.py           # ROLE.artifact_defaults declares review.md
+lionagi/casts/roles/critic.py             # ROLE.artifact_defaults declares review.md
 ```
 
 ## Consequences

--- a/lionagi/casts/pattern.py
+++ b/lionagi/casts/pattern.py
@@ -109,6 +109,11 @@ class Role(Pattern):
 
     body: str = ""
     emits: tuple = ()
+    # ADR-0029 shape ({"expected": [{"id", "path", "required", ...}]}) — a gate
+    # role's own declared output contract, merged per-leg into the flow's
+    # artifact_contract at DAG-build time (see flow.py _build_dag). None means
+    # this role makes no artifact claim.
+    artifact_defaults: dict | None = None
 
     @property
     def kind(self) -> PatternKind:

--- a/lionagi/casts/roles/critic.py
+++ b/lionagi/casts/roles/critic.py
@@ -10,6 +10,16 @@ ROLE = Role(
     name="critic",
     description="Final adversarial quality gate — assumes the artifact is broken until evidence proves otherwise, runs last after all other verify-zone roles, and issues the terminal quality verdict (APPROVE / APPROVE-WITH-FIXES / REQUEST-CHANGES / REJECT). High effort. Pick when a release needs a terminal correctness gate, not a checklist pass.",
     emits=(Verdict, Finding),
+    artifact_defaults={
+        "expected": [
+            {
+                "id": "review",
+                "path": "review.md",
+                "required": True,
+                "description": "Adversarial review report with terminal verdict (see Artifacts below).",
+            }
+        ]
+    },
     body="""\
 # Critic
 

--- a/lionagi/casts/roles/reviewer.py
+++ b/lionagi/casts/roles/reviewer.py
@@ -10,6 +10,16 @@ ROLE = Role(
     name="reviewer",
     description="Checklist-driven quality gate — evaluates artifacts against defined standards and issues a verdict (APPROVE / REQUEST-CHANGES / REJECT) grounded in specific rule citations, not intuition. Medium effort. Pick when an artifact needs a structured pass/fail verdict against known criteria; use critic instead when you need a terminal adversarial gate.",
     emits=(Verdict, Finding),
+    artifact_defaults={
+        "expected": [
+            {
+                "id": "review",
+                "path": "review.md",
+                "required": True,
+                "description": "Checklist verdict with rule citations (see Artifacts below).",
+            }
+        ]
+    },
     body="""\
 # Reviewer
 

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -280,6 +280,7 @@ async def _teardown_common(
     artifact_contract: dict | None,
     extras: dict | None = None,
     identity_markers: dict | None = None,
+    escalated_evidence: list[dict] | None = None,
 ) -> str:
     from lionagi.state.artifact_verifier import (
         missing_artifact_evidence,
@@ -333,6 +334,23 @@ async def _teardown_common(
                 str(entry.get("id", "")) for entry in missing
             ]
 
+    # Escalation backstop: a leg that never declared an artifact (so the check
+    # above has nothing to verify) but gave up mid-run via EscalationRequest
+    # still must not read as a clean completion. Only fires when nothing else
+    # already made the run loud — an existing failure reason (including the
+    # artifact check above) is preserved untouched.
+    if escalated_evidence and final_status == "completed":
+        from lionagi.state.reasons import RunReasons
+
+        final_status = "failed"
+        final_reason_code = RunReasons.FAILED_ESCALATED
+        ids = [str(e.get("id", "")) for e in escalated_evidence]
+        final_reason_summary = (
+            f"{len(escalated_evidence)} operation(s) escalated without producing "
+            f"required output: {', '.join(ids)}."
+        )
+        final_evidence_refs = escalated_evidence
+
     await db.update_status(
         "session",
         session_id,
@@ -361,6 +379,7 @@ async def teardown_persist(
     status: str = "completed",
     exception: BaseException | None = None,
     extras: dict | None = None,
+    escalated_evidence: list[dict] | None = None,
 ) -> str:
     if ctx is None:
         return status
@@ -377,6 +396,7 @@ async def teardown_persist(
             artifact_contract=ctx.get("artifact_contract"),
             extras=extras,
             identity_markers=ctx.get("identity_markers"),
+            escalated_evidence=escalated_evidence,
         )
 
         from lionagi.hooks import unroute_message_persistence

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -802,11 +802,13 @@ async def stop_live_persist(
 ) -> str:
     ctx = env._live_persist
     extras = getattr(env, "_finalize_extras", None)
+    escalated_evidence = getattr(env, "_escalated_evidence", None)
     final_status = await teardown_persist(
         ctx,
         status=status,
         exception=exception,
         extras=extras,
+        escalated_evidence=escalated_evidence,
     )
     env._live_persist = None
     return final_status

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -258,6 +258,7 @@ class _ExecResult:
     agent_results: list[dict]
     n_spawned: int
     t_exec_elapsed: float
+    escalated_agent_ids: list[str] = field(default_factory=list)
 
 
 # ── Phase 1: build DAG ────────────────────────────────────────────────────────
@@ -285,6 +286,7 @@ async def _build_dag(
     worker_models: list[str] = []
     node_ids: list[str] = []
     role_base: dict[str, object] = {}
+    role_artifact_entries: list[dict] = []
 
     for i, ta in enumerate(assignments):
         w_branch, w_model, w_profile = await build_worker_branch(
@@ -299,11 +301,43 @@ async def _build_dag(
         worker_models.append(w_model)
         role_base.setdefault(ta.assignee, w_branch)
 
+        # ADR-0029: fold this leg's OWN declared artifact contract (profile
+        # first, else the casts role's artifact_defaults — e.g. reviewer/
+        # critic) into the flow-wide contract, namespaced under this leg's
+        # own artifact subdirectory. A role that declares nothing leaves the
+        # contract untouched — this only fires for a real declaration.
+        role_defaults = w_profile.artifact_defaults if w_profile else None
+        if not role_defaults:
+            from lionagi.casts.pattern import Role as _Role
+
+            with contextlib.suppress(ValueError):
+                role_defaults = _Role.load(ta.assignee).artifact_defaults
+        leg_expected: list[dict] = []
+        if role_defaults:
+            for entry in role_defaults.get("expected", []):
+                eid = entry.get("id", "")
+                epath = entry.get("path", "")
+                leg_expected.append(
+                    {
+                        **entry,
+                        "id": f"{agent_ids[i]}__{eid}",
+                        "path": f"{agent_ids[i]}/{epath}",
+                        "source": "role_default",
+                    }
+                )
+            role_artifact_entries.extend(leg_expected)
+
         ctx: list = [{"original_task": prompt}]
         artifact_note = (
             f"Your artifact directory: {env.run.agent_artifact_dir(agent_ids[i])}/ — "
             "write output files here."
         )
+        if leg_expected:
+            required_paths = ", ".join(e["path"].split("/", 1)[1] for e in leg_expected)
+            artifact_note += (
+                f" REQUIRED: write {required_paths} in that directory — the run "
+                "is marked failed if it is missing at completion."
+            )
         if dep_indices[i]:
             ups = "; ".join(
                 f"step {j + 1} ({agent_ids[j]}): {env.run.agent_artifact_dir(agent_ids[j])}/"
@@ -367,6 +401,33 @@ async def _build_dag(
             await ctx_lp["db"].update_session(
                 ctx_lp["session_id"], node_metadata=json.dumps({**early_graph, **_markers})
             )
+
+    # Persist the per-leg role/profile artifact declarations collected above.
+    # start_live_persist already ran (playbook/whole-flow contract, if any) —
+    # this extends that contract now that per-leg roles are resolved, so
+    # teardown's verify_artifact_contract (reading ctx["artifact_contract"])
+    # sees the full picture. Validated eagerly: a malformed role declaration
+    # should fail loudly here, not be silently dropped.
+    #
+    # ADR-0029 extension (see db.py _SESSION_COLUMNS comment): this is the
+    # one allowed post-creation write to artifact_contract_json, happening
+    # once here at DAG-build time, before _execute_dag runs any leg. It must
+    # reach the session row (not just env._live_persist) — a crash or
+    # orphan exit before teardown should still leave the DB row showing what
+    # was actually expected, matching what Studio/`li state show-session`
+    # read directly from artifact_contract_json.
+    if role_artifact_entries and ctx_lp is not None:
+        from lionagi.state.artifact_verifier import validate_artifact_contract
+
+        existing = ctx_lp.get("artifact_contract") or {"expected": []}
+        merged_contract = {"expected": [*existing.get("expected", []), *role_artifact_entries]}
+        validate_artifact_contract(merged_contract)
+        ctx_lp["artifact_contract"] = merged_contract
+        if ctx_lp.get("db"):
+            with contextlib.suppress(Exception):
+                await ctx_lp["db"].update_session(
+                    ctx_lp["session_id"], artifact_contract_json=json.dumps(merged_contract)
+                )
 
     return _DagState(
         node_ids=node_ids,
@@ -540,6 +601,24 @@ async def _execute_dag(
     op_results = dag_result.get("operation_results", {})
     n_spawned = dag_result.get("spawned_operations", 0)
 
+    # Escalation backstop: a leg the executor tracked as escalated (gave up
+    # instead of producing a result — see NodeEscalated / EscalationRequest,
+    # ADR-0072/0083) reads as a normal completed op_result to the loop below.
+    # Without this, a reviewer/critic that emits EscalationRequest(route=
+    # "give_up") instead of writing its artifact is indistinguishable from a
+    # clean completion once execution finishes — this makes it loud at
+    # teardown even when no artifact_defaults declaration exists to catch it.
+    escalated_op_ids = {str(x) for x in dag_result.get("escalated_operations", [])}
+    escalated_agent_ids = [
+        agent_ids[i] for i in range(len(assignments)) if node_ids[i] in escalated_op_ids
+    ]
+    if escalated_agent_ids:
+        env._escalated_evidence = [
+            {"kind": "escalated_operation", "id": agent_ids[i], "label": assignments[i].assignee}
+            for i in range(len(assignments))
+            if node_ids[i] in escalated_op_ids
+        ]
+
     agent_results: list[dict] = []
 
     def _record_result(result: dict) -> None:
@@ -592,6 +671,7 @@ async def _execute_dag(
         agent_results=agent_results,
         n_spawned=n_spawned,
         t_exec_elapsed=t_exec_elapsed,
+        escalated_agent_ids=escalated_agent_ids,
     )
 
 

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -113,6 +113,20 @@ _SESSION_COLUMNS = frozenset(
         "total_cost_usd",
         "num_turns",
         "duration_ms",
+        # ADR-0029 documents artifact_contract_json as fixed at session
+        # creation for the single-agent case, where the full contract
+        # (playbook + agent profile) is already known at create_session time.
+        # DAG flows break that assumption: which role runs which leg is only
+        # known once planning finishes, which happens after create_session
+        # (see _build_dag in cli/orchestrate/flow.py). This column is
+        # allowlisted here so that ONE extension write is possible — folding
+        # resolved per-leg role artifact_defaults into the flow-wide
+        # contract, done once at DAG-build time, strictly before any leg
+        # starts executing. No writer may touch it after that point; the
+        # anti-drift intent of ADR-0029 (no changes once work is underway)
+        # still holds, it is just anchored at "DAG built" instead of
+        # "session created" for this call path.
+        "artifact_contract_json",
     }
 )
 

--- a/lionagi/state/reasons.py
+++ b/lionagi/state/reasons.py
@@ -64,6 +64,7 @@ class RunReasons:
     FAILED_EXIT_NONZERO = "run.failed.exit_nonzero"
     FAILED_EXCEPTION = "run.failed.exception"
     FAILED_MISSING_ARTIFACT = "run.failed.missing_artifact"  # ADR-0029
+    FAILED_ESCALATED = "run.failed.escalated"  # undeclared-artifact backstop
     TIMED_OUT_DEADLINE = "run.timed_out.deadline"
     ABORTED_USER = "run.aborted.user"
     CANCELLED_SIGINT = "run.cancelled.sigint"  # issue #1055

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -1020,3 +1020,299 @@ async def test_stop_verification_preserves_non_completed_reason(
     v = s["artifact_verification_json"]
     assert isinstance(v, dict)
     assert v["status"] == "failed"
+
+
+# ── ADR-0029 + ADR-0028: session→invocation propagation on missing artifact ──
+#
+# The tests above prove the *session* row flips to failed/FAILED_MISSING_ARTIFACT.
+# A multi-leg `li play`/`li o flow` run is read by callers (Studio, `li status`,
+# `li play check`) at the *invocation* level, not the raw session level, via
+# _resolve_invocation_terminal_flow(). That function had no direct test —
+# these confirm the flip a reviewer/critic gate leg produces actually reaches
+# the record a status-reader queries, and pin down exactly what does and does
+# not survive the trip.
+
+
+async def test_missing_artifact_session_failure_propagates_to_invocation_status(
+    temp_db_path: Path,
+    tmp_path: Path,
+):
+    """A required artifact missing at teardown flips the session to failed, and
+    _resolve_invocation_terminal_flow (flow.py) — the function the real `finally`
+    block in _run_flow uses to finalize the invocation record — reflects that
+    into the invocation's terminal status. This is the propagation hop a
+    status-reader (Studio, `li status`) actually observes.
+    """
+    from lionagi.cli.orchestrate.flow import _resolve_invocation_terminal_flow
+    from lionagi.state.reasons import RunReasons
+
+    invocation_id = "inv-missing-artifact"
+    artifacts_dir = tmp_path / "artifacts" / "reviewer"
+    artifacts_dir.mkdir(parents=True)
+    # review.md deliberately not written — reproduces the incident shape: a
+    # reviewer gate leg that completes without producing its review.
+
+    async with StateDB() as db:
+        await db.create_invocation(
+            {"id": invocation_id, "skill": "codex-pr-review", "started_at": 0.0}
+        )
+
+    env = _minimal_env()
+    contract = {"expected": [{"id": "review", "path": "review.md", "required": True}]}
+    await start_live_persist(
+        env,
+        invocation_kind="flow",
+        artifacts_path=str(artifacts_dir),
+        artifact_contract=contract,
+        invocation_id=invocation_id,
+    )
+    ctx = env._live_persist
+    assert ctx is not None
+
+    await stop_live_persist(env, status="completed")
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "failed"
+    assert s["status_reason_code"] == "run.failed.missing_artifact"
+
+    # The hop this test exists for: does the invocation-level resolver see it?
+    (
+        inv_status,
+        inv_reason_code,
+        inv_summary,
+        inv_evidence,
+        inv_metadata,
+    ) = await _resolve_invocation_terminal_flow(invocation_id, fallback_status="completed")
+    assert inv_status == "failed"
+    # NOTE: the invocation layer generalizes to "a child session failed" — it
+    # does NOT carry the session's specific FAILED_MISSING_ARTIFACT reason code
+    # or the missing-artifact evidence forward verbatim. A status-reader at the
+    # invocation level sees loud failure but must drill into the child session
+    # (evidence below references it) to learn *why* it failed.
+    assert inv_reason_code == RunReasons.FAILED_EXCEPTION
+    assert "child session failed" in inv_summary
+    assert any(e.get("id") == ctx["session_id"] for e in inv_evidence)
+    assert inv_metadata["child_statuses"] == ["failed"]
+
+    # Persist it exactly as _run_flow's finally block does, then read back the
+    # invocation row itself — "the record a status-reader sees."
+    async with StateDB() as db:
+        await db.update_status(
+            "invocation",
+            invocation_id,
+            new_status=inv_status,
+            reason_code=inv_reason_code,
+            reason_summary=inv_summary,
+            evidence_refs=inv_evidence,
+            source="executor",
+            actor=invocation_id,
+            metadata=inv_metadata,
+        )
+        inv_row = await db.get_invocation(invocation_id)
+    assert inv_row is not None
+    assert inv_row["status"] == "failed"
+
+
+async def test_all_legs_completed_resolves_invocation_completed(
+    temp_db_path: Path,
+    tmp_path: Path,
+):
+    """Control case: when every child session completes cleanly (artifact
+    present), the invocation resolves to completed — the failure path above
+    is a real signal, not an always-failed resolver.
+    """
+    from lionagi.cli.orchestrate.flow import _resolve_invocation_terminal_flow
+
+    invocation_id = "inv-all-completed"
+    artifacts_dir = tmp_path / "artifacts" / "reviewer"
+    artifacts_dir.mkdir(parents=True)
+    (artifacts_dir / "review.md").write_text("looks good")
+
+    async with StateDB() as db:
+        await db.create_invocation(
+            {"id": invocation_id, "skill": "codex-pr-review", "started_at": 0.0}
+        )
+
+    env = _minimal_env()
+    contract = {"expected": [{"id": "review", "path": "review.md", "required": True}]}
+    await start_live_persist(
+        env,
+        invocation_kind="flow",
+        artifacts_path=str(artifacts_dir),
+        artifact_contract=contract,
+        invocation_id=invocation_id,
+    )
+    await stop_live_persist(env, status="completed")
+
+    (
+        inv_status,
+        inv_reason_code,
+        _summary,
+        _evidence,
+        _metadata,
+    ) = await _resolve_invocation_terminal_flow(invocation_id, fallback_status="completed")
+    assert inv_status == "completed"
+
+
+# ── bench545 regressions: plan-time per-leg wiring + escalation backstop ──────
+#
+# Both tests below reproduce the actual production gap (play fe9a23ac,
+# artifacts under bench545): the play-level artifact_contract was NULL for
+# the WHOLE run — nothing at plan time ever populated a per-leg contract, so
+# the tests above (which hand-build a `contract` and pass it to
+# start_live_persist directly) do not exercise the gap itself. These two
+# start with NO contract, exactly like bench545, and drive the real
+# _build_dag / _execute_dag phase functions to prove the wiring — not just a
+# role-profile declaration nobody consults — is what closes it.
+
+
+async def test_build_dag_wires_role_artifact_defaults_into_live_contract_and_fails_loud(
+    temp_db_path: Path,
+    tmp_path: Path,
+):
+    """A path: no whole-flow contract is declared (play-level NULL, as in
+    bench545). The only source of a per-leg contract is the resolved
+    worker's own casts Role (no committed AgentProfile file exists in this
+    repo, so w_profile is always None in practice — the role fallback IS the
+    real path). _build_dag must itself populate the live contract from the
+    reviewer role's artifact_defaults, persist it to the session row, and
+    the run must still fail loud at teardown when the declared artifact is
+    never written.
+    """
+    from unittest.mock import patch
+
+    from lionagi.casts.emission import TaskAssignment
+    from lionagi.cli.orchestrate.flow import _build_dag, _PlanResult
+
+    env = _minimal_env()
+    artifacts_dir = tmp_path / "artifacts"
+    await start_live_persist(
+        env,
+        invocation_kind="flow",
+        artifacts_path=str(artifacts_dir),
+    )
+    ctx = env._live_persist
+    assert ctx is not None
+    assert ctx["artifact_contract"] is None  # bench545 starting state
+
+    assignments = [TaskAssignment(task="review the PR", assignee="reviewer")]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["reviewer"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+
+    with patch(
+        "lionagi.cli.orchestrate.flow.build_worker_branch",
+        return_value=(Branch(name="reviewer"), "codex/gpt-5.5", None),
+    ):
+        await _build_dag(env, "review this PR", plan_result, reactive_spec="off")
+
+    # The live in-memory contract was extended during DAG build, before any
+    # worker ran.
+    merged = env._live_persist["artifact_contract"]
+    assert merged is not None
+    entry = next(e for e in merged["expected"] if e["id"] == "reviewer__review")
+    assert entry["path"] == "reviewer/review.md"
+    assert entry["required"] is True
+
+    # ...and the session row itself carries it — the exact field bench545
+    # showed stuck at NULL for the whole play.
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    stored = s["artifact_contract_json"]
+    assert isinstance(stored, dict)
+    assert "reviewer__review" in {e["id"] for e in stored["expected"]}
+
+    # The reviewer leg never wrote reviewer/review.md.
+    await stop_live_persist(env, status="completed")
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "failed"
+    assert s["status_reason_code"] == "run.failed.missing_artifact"
+
+
+async def test_execute_dag_escalation_without_artifact_declaration_fails_loud(
+    temp_db_path: Path,
+    tmp_path: Path,
+):
+    """B path: an ordinary (non-gate) role with no artifact_defaults at all —
+    the undeclared case _build_dag's merge cannot catch by construction — that
+    gives up mid-run via EscalationRequest instead of completing cleanly. The
+    ReactiveExecutor already tracks this (NodeEscalated / _escalated_ids) but
+    before this fix nothing surfaced it past _execute_dag, so a completed run
+    with an escalated leg and no result read as an ordinary clean completion.
+    This is the backstop: it must still fail loud even though no contract was
+    ever declared for the leg.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from lionagi.casts.emission import TaskAssignment
+    from lionagi.cli.orchestrate.flow import _DagState, _execute_dag, _PlanResult
+
+    env = _minimal_env()
+    artifacts_dir = tmp_path / "artifacts"
+    await start_live_persist(env, invocation_kind="flow", artifacts_path=str(artifacts_dir))
+    ctx = env._live_persist
+    assert ctx is not None
+
+    assignments = [TaskAssignment(task="do the risky thing", assignee="worker")]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["worker"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["node-0"],
+        known_nodes={"node-0"},
+        deps_by_node={"node-0": []},
+        reactive=False,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["codex/gpt-5.5"],
+    )
+
+    from lionagi.engines import PlanningEngine
+
+    async def _run_dag_result():
+        return {
+            "operation_results": {},
+            "spawned_operations": 0,
+            "escalated_operations": ["node-0"],
+        }
+
+    fake_engine_run = MagicMock()
+    fake_engine_run.run_dag = MagicMock(return_value=_run_dag_result())
+
+    with patch.object(PlanningEngine, "new_run", return_value=fake_engine_run):
+        exec_result = await _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0)
+
+    assert exec_result.escalated_agent_ids == ["worker"]
+    assert env._escalated_evidence == [
+        {"kind": "escalated_operation", "id": "worker", "label": "worker"}
+    ]
+    # Confirms this really is the undeclared case, not the A-path in disguise.
+    assert env._live_persist["artifact_contract"] is None
+
+    await stop_live_persist(env, status="completed")
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "failed"
+    assert s["status_reason_code"] == "run.failed.escalated"
+
+    import json as _json
+
+    evidence = s["status_evidence_refs"]
+    evidence = _json.loads(evidence) if isinstance(evidence, str) else evidence
+    assert any(e.get("id") == "worker" for e in evidence)


### PR DESCRIPTION
## What

Two related gaps in `li o flow`'s artifact-verification path, both rooted in `artifact_contract_json` staying NULL for DAG-flow sessions (verification short-circuits to skipped when `contract is None`).

**A — plan-time contract population.** `_build_dag` now folds each leg's resolved role `artifact_defaults` into the session's `artifact_contract_json` once, before `_execute_dag` runs any leg. Previously this column was only ever populated by the single-agent path (ADR-0029 §5), so multi-leg flows silently skipped verification entirely. ADR-0029 is extended with a documented **DAG-flow extension** addendum explaining why this one additional write point (strictly pre-execution) preserves the ADR's anti-drift intent — just anchored at "DAG built" instead of "session created" for this call path.

**B — fail loud on undeclared escalation.** A role that escalates mid-run via `EscalationRequest` without ever having declared an artifact now fails loud (`status_reason_code=run.failed.escalated`) instead of silently succeeding with no verification performed.

**Root cause for both**: `artifact_contract_json` was missing from `StateDB._SESSION_COLUMNS`, so `update_session()`'s write raised `ValueError`, silently swallowed by a pre-existing `contextlib.suppress(Exception)`. Fixed by allowlisting the column (single addition, narrowly commented with the ADR rationale) and adding `json.dumps()` before binding (matching the sibling `node_metadata=json.dumps(...)` call already in the same function).

## Orphan-exit investigation (bounded scope, ruled out)

Traced the two fields flagged as anomalous in the original bug report. `current_phase` for a flow session only ever takes two values codebase-wide (`executing`, `synthesizing`) with no later marker any run reaches, successful or not. `num_turns`/`duration_ms` are CLI-subprocess-mirror-only fields, never touched by `operate()`-based DAG legs. Audited all three Studio lifecycle reapers (`lionagi/studio/services/lifecycle.py`) — none resolve an orphaned flow session to `completed`. The NULL-contract gap above fully explains the reported symptom; not splitting a teardown-bypass fast-follow since no evidence of one was found.

## Tests

Two new regression tests in `tests/cli/orchestrate/test_live_persist.py`, both starting from a NULL contract (matching the original repro) and driving `_build_dag`/`_execute_dag` directly:
- `test_build_dag_wires_role_artifact_defaults_into_live_contract_and_fails_loud` (path A)
- `test_execute_dag_escalation_without_artifact_declaration_fails_loud` (path B)

## Verification

- `uv run pytest tests/cli/orchestrate/test_live_persist.py` → **31 passed**.
- `uv run pytest tests/casts/ tests/state/ tests/cli/` (broad sweep, this checkout has fastapi installed) → **1331 passed**, 0 failed.
- `uv run ruff check` / `ruff format --check` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)