### PR TITLE
fix(schedule): pin scheduler spawn cwd; resolve from action_project/env

### DIFF
--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import os
 import shutil
@@ -553,6 +554,19 @@ def _cmd_create(args: argparse.Namespace) -> int:
         body["action_flow_yaml"] = p.read_text()
     if args.project:
         body["action_project"] = args.project
+    else:
+        # Best-effort: auto-capture the project from cwd (ADR-0026 detection
+        # cascade) so a schedule created inside a registered project resolves
+        # its spawn cwd at trigger time (see scheduler.engine._resolve_action_cwd).
+        # Any failure here must never block schedule creation.
+        with contextlib.suppress(Exception):
+            from lionagi.cli._project import detect_project
+            from lionagi.studio.scheduler.subprocess import _validate_identifier
+
+            detected, _source = detect_project(Path.cwd())
+            if detected:
+                _validate_identifier(detected, "action_project")
+                body["action_project"] = detected
     if args.description:
         body["description"] = args.description
     result = _api("/", method="POST", body=body)

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -10,6 +10,7 @@ import logging
 import os
 import time
 import uuid
+from pathlib import Path
 from typing import Any
 
 from lionagi.state.reasons import RunReasons, ScheduleReasons
@@ -25,6 +26,48 @@ _log = logging.getLogger(__name__)
 
 _MAX_CHAIN_DEPTH = 10
 _TICK_INTERVAL = 30  # seconds
+
+
+async def _resolve_action_cwd(schedule: dict) -> str | None:
+    """Resolve the working directory for a scheduled subprocess spawn.
+
+    Layered resolution (first hit wins):
+      1. ``action_project`` — the registered project's stored path, if it
+         exists on disk.
+      2. ``LIONAGI_SCHEDULER_CWD`` — an operator-set fallback directory.
+      3. ``None`` — inherit the daemon's own launch cwd (pre-existing
+         behavior); a warning is logged since `uv run li` will fail to spawn
+         if that directory has no project (e.g. the daemon was started at
+         ``/``).
+
+    Imports ``lionagi.studio.services.projects`` lazily so this module (and
+    ``lionagi.studio.scheduler.subprocess``) stay importable without the
+    ``studio`` extra (fastapi) — the scheduler engine only actually reaches
+    this branch when ``action_project`` is set, i.e. inside a running studio
+    daemon where fastapi is already a hard dependency.
+    """
+    action_project = schedule.get("action_project")
+    if action_project:
+        from lionagi.studio.services.projects import get_project
+
+        project = await get_project(action_project)
+        if project:
+            path = project.get("path")
+            if path and Path(path).is_dir():
+                return path
+
+    env_cwd = os.environ.get("LIONAGI_SCHEDULER_CWD")
+    if env_cwd and Path(env_cwd).is_dir():
+        return env_cwd
+
+    _log.warning(
+        "No resolvable cwd for schedule %s (action_project=%r); the scheduled "
+        "action will inherit the daemon's own working directory and may fail "
+        "to spawn (`uv run li` finds no project) if that directory has none.",
+        schedule.get("id"),
+        action_project,
+    )
+    return None
 
 
 class SchedulerEngine:
@@ -345,8 +388,9 @@ class SchedulerEngine:
                 "Firing schedule %s (run %s, chain_depth=%d)", schedule["name"], run_id, chain_depth
             )
 
+            action_cwd = await _resolve_action_cwd(schedule)
             exit_code, stderr_tail = await _subprocess.spawn_and_wait(
-                argv, inv_id, tmp_path=_tmp_path
+                argv, inv_id, tmp_path=_tmp_path, cwd=action_cwd
             )
             end_time = time.time()
             status = "completed" if exit_code == 0 else "failed"

--- a/lionagi/studio/scheduler/subprocess.py
+++ b/lionagi/studio/scheduler/subprocess.py
@@ -314,11 +314,18 @@ async def spawn_and_wait(
     invocation_id: str,
     *,
     tmp_path: str | None = None,
+    cwd: str | None = None,
 ) -> tuple[int, str]:
     """Spawn subprocess and wait for completion. Returns (exit_code, stderr_tail).
 
     If *tmp_path* is given it is deleted after the subprocess exits — used by
     the ``flow_yaml`` action kind which writes a temp spec file before spawning.
+
+    *cwd* pins the subprocess working directory. ``None`` inherits the
+    caller's own cwd (the daemon's launch directory) — callers should resolve
+    a concrete path (e.g. from ``action_project``) before spawning so `uv run
+    li` doesn't fail with "No such file or directory" when the daemon was
+    started somewhere with no project (see SchedulerEngine._resolve_action_cwd).
     """
     env = {**os.environ, "LIONAGI_INVOCATION_ID": invocation_id}
 
@@ -328,6 +335,7 @@ async def spawn_and_wait(
         stdout=asyncio.subprocess.DEVNULL,
         stderr=asyncio.subprocess.PIPE,
         env=env,
+        cwd=cwd,
         # `uv run li` forks the real worker (and that worker may fork
         # further). Put the whole tree in its own session/process group so a
         # cancel can signal the GROUP, not just the direct child — otherwise

--- a/tests/apps_studio_server/test_audit_remediation.py
+++ b/tests/apps_studio_server/test_audit_remediation.py
@@ -412,7 +412,7 @@ class TestFireCancellationRecorded:
 
         started = asyncio.Event()
 
-        async def blocking_spawn(argv, inv_id, *, tmp_path=None):
+        async def blocking_spawn(argv, inv_id, *, tmp_path=None, cwd=None):
             started.set()
             await asyncio.Event().wait()  # block until the _fire task is cancelled
 

--- a/tests/cli/test_schedule_cli.py
+++ b/tests/cli/test_schedule_cli.py
@@ -146,3 +146,96 @@ def test_base_url_studio_url_takes_precedence(monkeypatch):
     from lionagi.studio.cli import _base_url
 
     assert _base_url() == "https://studio.example.com"
+
+
+# ---------------------------------------------------------------------------
+# _cmd_create: --project auto-detect from cwd (scheduler spawn-cwd fix)
+# ---------------------------------------------------------------------------
+
+
+def _run_create(monkeypatch, extra_args: list[str], api_response: dict | None = None) -> dict:
+    """Run `li schedule create ...`, capturing the JSON body posted to _api."""
+    import lionagi.studio.cli as sched_mod
+
+    captured_body: dict = {}
+
+    def _fake_api(path, method="GET", body=None):
+        captured_body.update(body or {})
+        return api_response if api_response is not None else {"id": "sched-1", "name": "n"}
+
+    monkeypatch.setattr(sched_mod, "_api", _fake_api)
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(["schedule", "create", "my-sched", "--cron", "0 * * * *", *extra_args])
+    result = run_schedule(args)
+    return {"result": result, "body": captured_body}
+
+
+def test_schedule_create_explicit_project_skips_auto_detect(monkeypatch):
+    """--project given: used as-is, detect_project is never consulted."""
+    detect_calls = []
+    monkeypatch.setattr(
+        "lionagi.cli._project.detect_project",
+        lambda cwd=None: detect_calls.append(cwd) or ("should-not-be-used", "git_remote"),
+    )
+
+    outcome = _run_create(monkeypatch, ["--project", "explicit-proj"])
+
+    assert outcome["result"] == 0
+    assert outcome["body"]["action_project"] == "explicit-proj"
+    assert detect_calls == []
+
+
+def test_schedule_create_without_project_auto_detects_valid(monkeypatch):
+    """No --project: a valid detect_project() result populates action_project."""
+    monkeypatch.setattr(
+        "lionagi.cli._project.detect_project",
+        lambda cwd=None: ("lionagi/lionagi", "git_remote"),
+    )
+
+    outcome = _run_create(monkeypatch, [])
+
+    assert outcome["result"] == 0
+    assert outcome["body"]["action_project"] == "lionagi/lionagi"
+
+
+def test_schedule_create_without_project_no_detection_omits_field(monkeypatch):
+    """No --project and detect_project finds nothing: action_project is simply absent."""
+    monkeypatch.setattr("lionagi.cli._project.detect_project", lambda cwd=None: (None, None))
+
+    outcome = _run_create(monkeypatch, [])
+
+    assert outcome["result"] == 0
+    assert "action_project" not in outcome["body"]
+
+
+def test_schedule_create_auto_detect_invalid_identifier_silently_skipped(monkeypatch):
+    """A detected name that fails identifier validation (leading '-') must never
+    break `create` — it is silently dropped, not surfaced as an error."""
+    monkeypatch.setattr(
+        "lionagi.cli._project.detect_project",
+        lambda cwd=None: ("-not-a-valid-flag-name", "git_remote"),
+    )
+
+    outcome = _run_create(monkeypatch, [])
+
+    assert outcome["result"] == 0
+    assert "action_project" not in outcome["body"]
+
+
+def test_schedule_create_auto_detect_exception_silently_skipped(monkeypatch):
+    """detect_project() raising must never break `create`."""
+
+    def _boom(cwd=None):
+        raise RuntimeError("cwd detection blew up")
+
+    monkeypatch.setattr("lionagi.cli._project.detect_project", _boom)
+
+    outcome = _run_create(monkeypatch, [])
+
+    assert outcome["result"] == 0
+    assert "action_project" not in outcome["body"]

--- a/tests/studio/test_scheduler_cwd.py
+++ b/tests/studio/test_scheduler_cwd.py
@@ -1,0 +1,257 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests: scheduled subprocess spawns must not inherit the daemon's
+own launch cwd. Covers spawn_and_wait's cwd passthrough and the
+_resolve_action_cwd layered resolution (action_project -> LIONAGI_SCHEDULER_CWD
+-> None+warning)."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# _resolve_action_cwd's action_project branch imports lionagi.studio.services.projects,
+# which requires fastapi (the `studio` extra); skip gracefully in a bare-core install.
+pytest.importorskip("fastapi", reason="studio extra not installed")
+
+# ---------------------------------------------------------------------------
+# spawn_and_wait: cwd passthrough to create_subprocess_exec
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_spawn_and_wait_passes_cwd_through(tmp_path):
+    """cwd kwarg reaches asyncio.create_subprocess_exec unchanged."""
+    from lionagi.studio.scheduler.subprocess import spawn_and_wait
+
+    target_cwd = str(tmp_path)
+    captured: dict = {}
+
+    with patch("lionagi.studio.scheduler.subprocess.asyncio.create_subprocess_exec") as mock_exec:
+        mock_proc = MagicMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+        mock_proc.returncode = 0
+
+        async def _fake_exec(*args, **kwargs):
+            captured.update(kwargs)
+            return mock_proc
+
+        mock_exec.side_effect = _fake_exec
+
+        exit_code, _ = await spawn_and_wait(
+            ["uv", "run", "li", "agent"], "inv-cwd-001", cwd=target_cwd
+        )
+
+    assert exit_code == 0
+    assert captured.get("cwd") == target_cwd
+
+
+@pytest.mark.asyncio
+async def test_spawn_and_wait_default_cwd_is_none():
+    """Omitting cwd preserves the pre-existing inherit-cwd behavior."""
+    from lionagi.studio.scheduler.subprocess import spawn_and_wait
+
+    captured: dict = {}
+
+    with patch("lionagi.studio.scheduler.subprocess.asyncio.create_subprocess_exec") as mock_exec:
+        mock_proc = MagicMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+        mock_proc.returncode = 0
+
+        async def _fake_exec(*args, **kwargs):
+            captured.update(kwargs)
+            return mock_proc
+
+        mock_exec.side_effect = _fake_exec
+
+        await spawn_and_wait(["uv", "run", "li", "agent"], "inv-cwd-002")
+
+    assert captured.get("cwd") is None
+
+
+# ---------------------------------------------------------------------------
+# _resolve_action_cwd
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_action_cwd_uses_registered_project_path(tmp_path, monkeypatch):
+    """action_project resolves to that project's stored path, even when
+    os.getcwd() is a completely different directory (the daemon-started-
+    elsewhere case this bug is about)."""
+    from lionagi.studio.scheduler.engine import _resolve_action_cwd
+
+    project_dir = tmp_path / "registered-project"
+    project_dir.mkdir()
+
+    fake_get_project = AsyncMock(
+        return_value={"name": "myproj", "path": str(project_dir), "source": "studio"}
+    )
+    monkeypatch.setattr(
+        "lionagi.studio.services.projects.get_project", fake_get_project, raising=False
+    )
+
+    other_cwd = tmp_path / "somewhere-else-entirely"
+    other_cwd.mkdir()
+    monkeypatch.chdir(other_cwd)
+
+    schedule = {"id": "sched-1", "action_project": "myproj"}
+    result = await _resolve_action_cwd(schedule)
+
+    assert result == str(project_dir)
+    fake_get_project.assert_awaited_once_with("myproj")
+
+
+@pytest.mark.asyncio
+async def test_resolve_action_cwd_falls_back_to_env_when_project_unresolved(tmp_path, monkeypatch):
+    """No project match (or none set) but LIONAGI_SCHEDULER_CWD points at a
+    real directory -> that directory is used."""
+    from lionagi.studio.scheduler.engine import _resolve_action_cwd
+
+    fake_get_project = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        "lionagi.studio.services.projects.get_project", fake_get_project, raising=False
+    )
+
+    env_dir = tmp_path / "env-fallback"
+    env_dir.mkdir()
+    monkeypatch.setenv("LIONAGI_SCHEDULER_CWD", str(env_dir))
+
+    schedule = {"id": "sched-2", "action_project": "unknown-project"}
+    result = await _resolve_action_cwd(schedule)
+
+    assert result == str(env_dir)
+
+
+@pytest.mark.asyncio
+async def test_resolve_action_cwd_env_fallback_when_no_project_set(monkeypatch, tmp_path):
+    """action_project unset entirely -> env fallback still applies, and
+    get_project is never called."""
+    from lionagi.studio.scheduler.engine import _resolve_action_cwd
+
+    fake_get_project = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        "lionagi.studio.services.projects.get_project", fake_get_project, raising=False
+    )
+
+    env_dir = tmp_path / "env-only"
+    env_dir.mkdir()
+    monkeypatch.setenv("LIONAGI_SCHEDULER_CWD", str(env_dir))
+
+    schedule = {"id": "sched-3", "action_project": None}
+    result = await _resolve_action_cwd(schedule)
+
+    assert result == str(env_dir)
+    fake_get_project.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resolve_action_cwd_returns_none_and_warns_when_unresolved(monkeypatch, caplog):
+    """Neither action_project nor LIONAGI_SCHEDULER_CWD resolve -> None,
+    with a warning naming the schedule id and action_project."""
+    from lionagi.studio.scheduler.engine import _resolve_action_cwd
+
+    monkeypatch.delenv("LIONAGI_SCHEDULER_CWD", raising=False)
+
+    schedule = {"id": "sched-4", "action_project": None}
+    with caplog.at_level(logging.WARNING, logger="lionagi.studio.scheduler.engine"):
+        result = await _resolve_action_cwd(schedule)
+
+    assert result is None
+    assert any("sched-4" in rec.getMessage() for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_resolve_action_cwd_ignores_project_with_nonexistent_path(monkeypatch, tmp_path):
+    """A registered project whose stored path no longer exists on disk must
+    not be trusted; falls through to env/None."""
+    from lionagi.studio.scheduler.engine import _resolve_action_cwd
+
+    fake_get_project = AsyncMock(
+        return_value={"name": "stale", "path": "/no/such/directory/at/all", "source": "studio"}
+    )
+    monkeypatch.setattr(
+        "lionagi.studio.services.projects.get_project", fake_get_project, raising=False
+    )
+    monkeypatch.delenv("LIONAGI_SCHEDULER_CWD", raising=False)
+
+    schedule = {"id": "sched-5", "action_project": "stale"}
+    result = await _resolve_action_cwd(schedule)
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _fire() threads the resolved cwd into spawn_and_wait
+# ---------------------------------------------------------------------------
+
+
+def _minimal_schedule(**overrides) -> dict:
+    base = {
+        "id": "sched-fire-cwd",
+        "name": "test-sched-cwd",
+        "trigger_type": "cron",
+        "cron_expr": "0 * * * *",
+        "action_kind": "agent",
+        "action_model": "gpt-4.1-mini",
+        "action_prompt": "ping",
+        "action_agent": None,
+        "action_playbook": None,
+        "action_project": None,
+        "action_extra_args": [],
+        "action_flow_yaml": None,
+        "on_success": None,
+        "on_fail": None,
+        "overlap_policy": "skip",
+        "missed_fire_policy": "skip",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_svc() -> AsyncMock:
+    svc = AsyncMock()
+    svc.get_schedule = AsyncMock(return_value=None)
+    svc.list_schedules = AsyncMock(return_value=[])
+    svc.update_schedule = AsyncMock()
+    svc.create_schedule_run = AsyncMock()
+    svc.update_schedule_run = AsyncMock()
+    svc.create_invocation = AsyncMock()
+    svc.update_invocation = AsyncMock()
+    svc.update_status = AsyncMock()
+    svc.list_sessions_for_invocation = AsyncMock(return_value=[])
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_fire_threads_resolved_cwd_into_spawn_and_wait(tmp_path, monkeypatch):
+    """SchedulerEngine._fire resolves action_project to a real path and passes
+    it as cwd= to spawn_and_wait, regardless of the process's own os.getcwd()."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    fake_get_project = AsyncMock(return_value={"name": "p1", "path": str(project_dir)})
+    monkeypatch.setattr(
+        "lionagi.studio.services.projects.get_project", fake_get_project, raising=False
+    )
+
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(action_project="p1")
+
+    spawn_mock = AsyncMock(return_value=(0, ""))
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch("lionagi.studio.scheduler.subprocess.spawn_and_wait", new=spawn_mock),
+    ):
+        await engine._fire(schedule, "run-cwd-001", trigger_context={"scheduled": True})
+
+    spawn_mock.assert_awaited_once()
+    _args, kwargs = spawn_mock.await_args
+    assert kwargs.get("cwd") == str(project_dir)


### PR DESCRIPTION
## Bug

`lionagi/studio/scheduler/subprocess.py`'s `spawn_and_wait()` calls
`asyncio.create_subprocess_exec(*argv, ...)` with no `cwd=` argument, so every
scheduled `uv run li ...` subprocess inherits the scheduler **daemon's own
launch cwd**. If the daemon was started from a directory with no project (e.g.
`/`, or a systemd/launchd unit with an unrelated `WorkingDirectory`), `uv run`
fails immediately:

```
error: Failed to spawn: `li` — No such file or directory
```

(exit 2) — every scheduled run fails at spawn, before the agent/flow/play
action ever gets a chance to execute.

## Design

No schema migration, no new DB column (this codebase deliberately avoids
that — see `lionagi/studio/services/shows.py:109`). Three edits:

1. **`subprocess.py`** — `spawn_and_wait()` gains a keyword-only `cwd: str |
   None = None` param, passed straight through to `create_subprocess_exec`.
   Default preserves the pre-existing inherit-cwd behavior, so every existing
   direct caller/test is unaffected unless it opts in.

2. **`engine.py`** — new `_resolve_action_cwd(schedule) -> str | None` with
   layered resolution (first hit wins):
   1. `action_project` → `services.projects.get_project(name)`; use its
      stored `path` if it still exists on disk.
   2. `LIONAGI_SCHEDULER_CWD` env var, if it points at a real directory.
   3. `None` (falls back to the old inherit-daemon-cwd behavior), with a
      `WARNING` naming the schedule id and `action_project` so a bad daemon
      launch location is diagnosable instead of a silent, confusing spawn
      failure.

   `_fire()` threads the result into the existing `spawn_and_wait(...)` call
   as `cwd=action_cwd`. `get_project` is imported **lazily inside the
   function** — `fastapi` (the `studio` extra) is not a core dependency, and
   `engine.py`/`subprocess.py` must stay importable without it. This mirrors
   the existing lazy-import precedent in `services/schedules.py:540`.

3. **`cli.py`**'s `_cmd_create` — when `--project` isn't passed, best-effort
   auto-capture the project via `detect_project(cwd)` (ADR-0026 detection
   cascade: config.toml → global overrides → git remote → None), validated
   through the same identifier guard the rest of the scheduler CLI/services
   use, wrapped in `contextlib.suppress(Exception)` so detection can **never**
   break `create`. This means a schedule created inside a registered project
   picks up `action_project` automatically, so its spawn cwd resolves
   correctly at trigger time without the operator having to pass `--project`
   by hand.

### One evidence-based interpretation, not a deviation

The spec's own text flags the fallback-import concern explicitly ("verify no
circular import between `engine.py` and `services.projects`; if there is one,
lazy-import"). Empirically: `fastapi` is declared only under the `studio`
extra in `pyproject.toml`, not core — `uv run python -c "import fastapi"`
fails in a bare core install. `tests/studio/test_scheduler_engine.py` (the
existing `_fire()` test suite) has no `importorskip` guard, so a module-level
import of `services.projects` in `engine.py` would make that whole file
require the `studio` extra to even collect. The lazy import inside
`_resolve_action_cwd` (used only where `action_project` is actually set —
i.e., inside a running studio daemon, where fastapi is already a hard
dependency) keeps `engine.py` importable without the extra, matching this
codebase's existing lazy-import idiom.

## Out of scope (untouched)

One-shot/run-count trigger types, cron-timezone docs, the `/api` path
(already merged), any schema migration/new column.

## Tests

- `tests/studio/test_scheduler_cwd.py` (new) — `spawn_and_wait`'s `cwd`
  passthrough (both set and default-None), all three `_resolve_action_cwd`
  branches (project-path hit, env fallback, project-set-but-unresolved,
  nonexistent stale project path, warn-and-return-None), and the core
  regression guarantee end-to-end through `SchedulerEngine._fire()`: a
  schedule with `action_project=X` resolves to X's registered path **even
  when `os.getcwd()` is a different directory** (the daemon-started-elsewhere
  case this bug is about).
- `tests/cli/test_schedule_cli.py` — `li schedule create` auto-detect
  coverage: explicit `--project` skips detection entirely; a valid detected
  name populates `action_project`; no detection simply omits the field;
  both an invalid identifier and a `detect_project()` exception are silently
  swallowed and never break `create`.
- `tests/apps_studio_server/test_audit_remediation.py` — one-line fix: the
  hand-written `blocking_spawn` fake in
  `TestFireCancellationRecorded::test_cancel_during_spawn_records_cancelled`
  is updated to accept the new `cwd` kwarg. `_fire()` now always passes
  `cwd=` positionally-as-keyword; the fake's previous fixed signature (no
  `cwd`, no `**kwargs`) raised `TypeError` at the call boundary *before* the
  fake's body could run `started.set()`, which hung the test on its own
  `await started.wait()` until pytest-timeout's 300s ceiling. This was
  diagnosed empirically (verbose, non-xdist run pinpointed the exact stalled
  test; CPU time flat while wall time climbed = blocked, not slow) — not
  guessed.

## Verification

```
$ uv run pytest tests/studio/ tests/apps_studio_server/test_audit_remediation.py \
    tests/apps_studio_server/test_launches_api.py tests/cli/test_scheduler_flow_yaml.py \
    tests/cli/test_schedule_cli.py -p no:xdist -o addopts="" --tb=short
...
======================= 256 passed, 2 warnings in 10.74s =======================
```

Both warnings are pre-existing/unrelated: a `starlette`/`httpx2` deprecation
notice, and an unawaited-coroutine `RuntimeWarning` from
`lionagi/studio/services/launches.py`'s `_spawn_detached` (a different
function in a file this PR does not touch).

```
$ uv run pytest tests/cli/ -p no:xdist -o addopts="" --tb=line
======================= 840 passed, 1 skipped in 43.00s ========================
```

Confirms `tests/cli/test_scheduler_flow_yaml.py::test_cli_flow_yaml_choice_accepted`'s
circular-import failure (`cannot import name 'add_schedule_subparser' from
partially initialized module 'lionagi.studio.cli'`, between
`lionagi.studio.cli` and `lionagi.cli.main`) only reproduces when that test
runs in isolation/narrow subsets — it passes cleanly as part of the full
`tests/cli/` directory (as it does in real CI). Re-confirmed via `git stash`
against baseline `main` (commit `735a251a`): identical failure, same test,
same isolation-only trigger, with none of this PR's changes present. Not a
regression; not touched by this PR.

```
$ uv run ruff check lionagi/studio/scheduler/subprocess.py lionagi/studio/scheduler/engine.py \
    lionagi/studio/cli.py tests/studio/test_scheduler_cwd.py tests/cli/test_schedule_cli.py \
    tests/apps_studio_server/test_audit_remediation.py
All checks passed!

$ uv run ruff format --check <same files>
6 files already formatted
```

## Files changed

```
 lionagi/studio/cli.py                              | 14 ++++
 lionagi/studio/scheduler/engine.py                 | 46 ++++++++++-
 lionagi/studio/scheduler/subprocess.py             |  8 ++
 tests/apps_studio_server/test_audit_remediation.py |  2 +-
 tests/cli/test_schedule_cli.py                     | 93 ++++++++++++++++++++++
 tests/studio/test_scheduler_cwd.py (new)           | 258 ++++++++++++++++++++
```

Not merging — opening for review per instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>