### PR TITLE
feat(cli): li monitor run — scriptable wait-for-terminal primitive

### DIFF
--- a/lionagi/cli/main.py
+++ b/lionagi/cli/main.py
@@ -264,6 +264,16 @@ def main(argv: list[str] | None = None) -> int:
 
         return run_agent_status(_argv[2:])
 
+    # `li monitor run <id> [...]` / `li mon run <id> [...]` is a scriptable
+    # wait-for-terminal primitive, not a detail-view lookup — must be
+    # intercepted before argparse's positional `id` slot would otherwise
+    # swallow the literal token "run" as an entity-id (same reasoning as the
+    # `agent status` interception above, ADR-0085 slice 3).
+    if _argv and _argv[0] in ("monitor", "mon") and len(_argv) > 1 and _argv[1] == "run":
+        from .monitor import run_monitor_wait
+
+        return run_monitor_wait(_argv[2:])
+
     parser = argparse.ArgumentParser(
         prog="li",
         description="lionagi command line — spawn subagents via any CLI-backed provider.",

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -1098,9 +1098,15 @@ def run_monitor(args: argparse.Namespace) -> int:
     from lionagi.ln.concurrency import run_async
 
     if args.run_ids:
-        return _dispatch_wait(
-            _split_watched_ids([args.run_ids]), interval=args.interval, follow=args.follow
-        )
+        watched_ids = _split_watched_ids([args.run_ids])
+        if not watched_ids:
+            # A truthy --run value can still split to nothing (e.g. ","),
+            # which would otherwise dispatch an empty watch set and exit 0.
+            from ._logging import log_error
+
+            log_error("no schedule_run ids given (only empty/comma-only tokens)")
+            return 2
+        return _dispatch_wait(watched_ids, interval=args.interval, follow=args.follow)
 
     since: float | None = None
     if args.since:

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -17,6 +17,7 @@ from ._util import pid_alive as _pid_alive_int
 __all__ = (
     "add_monitor_subparser",
     "run_monitor",
+    "run_monitor_wait",
 )
 
 
@@ -717,6 +718,275 @@ def _watch_loop(
     return 0
 
 
+# ── Wait-for-terminal primitive (li monitor run / li monitor --run) ───────────
+#
+# A scripting primitive, not a view: append-only stdout lines (no screen
+# clearing, no table), meant for a harness to poll `li monitor run <id>` as a
+# background task rather than hand-rolling raw sqlite polling against the
+# live WAL-mode state.db. Separate code path from _watch_loop above — that
+# one is a human dashboard; this one blocks until specific schedule_runs go
+# terminal, then exits with a meaningful code.
+
+_TERMINAL_SCHEDULE_RUN_STATUSES = frozenset({"completed", "failed", "cancelled", "skipped"})
+
+
+def _split_watched_ids(raw: list[str]) -> list[str]:
+    """Flatten comma-separated and/or space-separated id tokens into one
+    ordered, deduped list — `li monitor run a,b` and `li monitor run a b`
+    (and any mix) must resolve identically."""
+    seen: dict[str, None] = {}
+    for token in raw:
+        for piece in token.split(","):
+            piece = piece.strip()
+            if piece:
+                seen.setdefault(piece, None)
+    return list(seen)
+
+
+async def _resolve_schedule_run(db: Any, raw_id: str) -> dict[str, Any] | None:
+    """Exact match then prefix match, mirroring _find_entity's convention.
+    schedule_run ids are 12-char hex (uuid4().hex[:12]), not 36-char UUIDs,
+    so the length-36 prefix heuristic used elsewhere in this codebase
+    (resolve_entity in _util.py) does not apply here.
+    """
+    row = await db.get_schedule_run(raw_id)
+    if row:
+        return row
+    return await db.fetch_one(
+        "SELECT * FROM schedule_runs WHERE id LIKE ?",
+        (raw_id + "%",),
+    )
+
+
+async def _resolve_watched_runs(
+    db: Any, ids: list[str]
+) -> tuple[dict[str, dict[str, Any]], list[str]]:
+    """Resolve every requested id once, up front. schedule_run ids are
+    already-fired-run identifiers a caller obtained elsewhere (e.g. `li
+    schedule trigger`), not something that might come into existence later,
+    so — unlike the --follow discovery scan below — resolution itself is
+    not retried on every poll tick.
+    """
+    pending: dict[str, dict[str, Any]] = {}
+    unresolved: list[str] = []
+    for raw_id in ids:
+        row = await _resolve_schedule_run(db, raw_id)
+        if row is None:
+            unresolved.append(raw_id)
+        else:
+            pending[row["id"]] = row  # canonical id as key: dedupes prefix collisions
+    return pending, unresolved
+
+
+async def _schedule_name(db: Any, schedule_id: str, *, cache: dict[str, str]) -> str:
+    if schedule_id not in cache:
+        sched = await db.get_schedule(schedule_id)
+        cache[schedule_id] = (sched or {}).get("name") or schedule_id
+    return cache[schedule_id]
+
+
+def _format_wait_line(row: dict[str, Any], name: str) -> str:
+    exit_code = row.get("exit_code")
+    exit_str = "-" if exit_code is None else str(exit_code)
+    return (
+        f"{row['id']}  name={name}  chain_depth={row.get('chain_depth', 0)}  "
+        f"status={row['status']}  exit_code={exit_str}"
+    )
+
+
+async def _poll_pending_once(
+    db: Any,
+    pending: dict[str, dict[str, Any]],
+    schedule_names: dict[str, str],
+) -> list[dict[str, Any]]:
+    """Check every still-pending run once; print (and drop from `pending`)
+    any that are now terminal. Printing happens immediately per row, not
+    batched, so a harness tailing stdout sees each result the moment it
+    lands rather than waiting for the whole watched set to finish.
+
+    This is the primitive's testable inner tick: exercising "terminal
+    across different poll iterations" only needs two direct calls to this
+    function with a DB row mutated in between — no real sleeping required.
+    """
+    from ._logging import log_error
+
+    resolved: list[dict[str, Any]] = []
+    for run_id in list(pending):
+        row = await db.get_schedule_run(run_id)
+        if row is None:
+            # Existed at resolution time but is gone now (e.g. its parent
+            # schedule was deleted, cascading the run) — resolve it as a
+            # failure so the wait can't hang on state that never comes back.
+            row = {**pending[run_id], "status": "failed", "exit_code": None}
+            log_error(f"schedule_run {run_id!r} disappeared from state.db while waiting")
+        elif row["status"] not in _TERMINAL_SCHEDULE_RUN_STATUSES:
+            continue
+        name = await _schedule_name(db, row["schedule_id"], cache=schedule_names)
+        print(_format_wait_line(row, name))
+        resolved.append(row)
+        del pending[run_id]
+    return resolved
+
+
+async def _query_schedule_runs_since(db: Any, baseline: float) -> list[dict[str, Any]]:
+    """--follow discovery query: schedule_runs created strictly after
+    `baseline`, oldest first. Strict '>' (not '>=') is the same
+    baseline-first, anti-backlog-replay discipline used by any other
+    "watch for new stuff" loop in this codebase — a row already seen at
+    exactly `baseline` must never be re-reported on the next tick.
+    """
+    return await db.fetch_all(
+        "SELECT * FROM schedule_runs WHERE created_at > ? ORDER BY created_at ASC",
+        (baseline,),
+    )
+
+
+def _dispatch_wait(ids: list[str], *, interval: float, follow: bool) -> int:
+    """Block until every id in `ids` reaches a terminal schedule_run status,
+    printing one line per run the moment it lands; with --follow, keep
+    watching (tail -f style) for newly created runs after the initial set
+    drains, exiting only on SIGINT/SIGTERM.
+
+    Shaped like _watch_loop above (own signal handlers on the main thread,
+    run_async per discrete tick, chunked time.sleep for cadence) rather
+    than one run_async call wrapping a long-lived asyncio.sleep loop:
+    run_async installs its own SIGINT handler for the duration of any call
+    it wraps and never touches SIGTERM at all, so a single all-encompassing
+    call cannot give this command the dual-signal clean exit it needs —
+    per-tick calls, exactly like the dashboard's --watch, can. Unlike
+    _watch_loop's default multi-second refresh, --interval is often
+    sub-second here, so a much larger share of wall-clock time is spent
+    inside individual run_async() calls rather than between them — a SIGINT
+    landing mid-call surfaces as KeyboardInterrupt at the call site (see
+    _run_tick below) far more often than it does for the dashboard, so that
+    case is folded into the same clean-exit path instead of left to crash.
+    """
+    from lionagi.ln.concurrency import run_async
+    from lionagi.state.db import DEFAULT_DB_PATH, StateDB
+
+    from ._logging import log_error
+    from .status import EXIT_RUNNING, EXIT_UNKNOWN
+
+    if not DEFAULT_DB_PATH.exists():
+        log_error("state.db not found — no schedule runs recorded yet")
+        return EXIT_UNKNOWN
+
+    interrupted = False
+
+    def _handle_signal(signum: int, frame: Any) -> None:
+        nonlocal interrupted
+        interrupted = True
+
+    signal.signal(signal.SIGINT, _handle_signal)
+    signal.signal(signal.SIGTERM, _handle_signal)
+
+    def _sleep_interval(secs: float) -> None:
+        # Sleep in small increments so SIGINT/SIGTERM stay responsive,
+        # mirroring _watch_loop's own chunked sleep exactly.
+        for _ in range(max(1, round(secs * 10))):
+            if interrupted:
+                break
+            time.sleep(0.1)
+
+    def _run_tick(coro: Any) -> Any:
+        # run_async raises bare KeyboardInterrupt when SIGINT lands during
+        # its own call (it installs a temporary handler for that duration —
+        # see run_async's docstring in ln/concurrency/utils.py). Treat that
+        # exactly like `interrupted` being set between ticks: no traceback,
+        # no half-updated state, just the same clean stop.
+        nonlocal interrupted
+        try:
+            return run_async(coro)
+        except KeyboardInterrupt:
+            interrupted = True
+            return None
+
+    schedule_names: dict[str, str] = {}
+
+    async def _resolve() -> tuple[dict[str, dict[str, Any]], list[str]]:
+        async with StateDB() as db:
+            return await _resolve_watched_runs(db, ids)
+
+    resolved = _run_tick(_resolve())
+    pending, unresolved = resolved if resolved is not None else ({}, [])
+    for raw_id in unresolved:
+        log_error(f"schedule_run {raw_id!r} not found")
+
+    async def _tick() -> list[dict[str, Any]]:
+        async with StateDB() as db:
+            return await _poll_pending_once(db, pending, schedule_names)
+
+    done: list[dict[str, Any]] = []
+    while pending and not interrupted:
+        tick_result = _run_tick(_tick())
+        if tick_result is not None:
+            done.extend(tick_result)
+        if not pending or interrupted:
+            break
+        _sleep_interval(interval)
+
+    if unresolved:
+        exit_code = EXIT_UNKNOWN
+    elif pending:  # only reachable via interruption mid-wait
+        exit_code = EXIT_RUNNING
+    elif all(r.get("exit_code") == 0 for r in done):
+        exit_code = 0
+    else:
+        exit_code = 1
+
+    if follow and not interrupted:
+        baseline = time.time()
+        follow_pending: dict[str, dict[str, Any]] = {}
+
+        async def _follow_tick(bl: float) -> float:
+            async with StateDB() as db:
+                new_rows = await _query_schedule_runs_since(db, bl)
+                for row in new_rows:
+                    follow_pending.setdefault(row["id"], row)
+                if follow_pending:
+                    await _poll_pending_once(db, follow_pending, schedule_names)
+            if new_rows:
+                bl = max(bl, *(r["created_at"] for r in new_rows))
+            return bl
+
+        while not interrupted:
+            tick_result = _run_tick(_follow_tick(baseline))
+            if tick_result is not None:
+                baseline = tick_result
+            if interrupted:
+                break
+            _sleep_interval(interval)
+        # --follow has no natural end — its exit code reflects whether the
+        # *initial* watched set was resolvable, not the open-ended tail.
+        return EXIT_UNKNOWN if unresolved else 0
+
+    return exit_code
+
+
+def run_monitor_wait(argv: list[str]) -> int:
+    """Entry point for `li monitor run <id> [<id2> ...] [--interval SECS] [--follow]`."""
+    parser = argparse.ArgumentParser(prog="li monitor run", add_help=True)
+    parser.add_argument(
+        "ids",
+        nargs="+",
+        help="schedule_run ID(s) (or short prefixes) to wait for. Comma- or space-separated.",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=3.0,
+        metavar="SECS",
+        help="Poll interval in seconds (default 3).",
+    )
+    parser.add_argument(
+        "--follow",
+        action="store_true",
+        help="Keep watching for new schedule_runs after the initial set drains.",
+    )
+    args = parser.parse_args(argv)
+    return _dispatch_wait(_split_watched_ids(args.ids), interval=args.interval, follow=args.follow)
+
+
 # ── CLI registration ──────────────────────────────────────────────────────────
 
 
@@ -774,11 +1044,39 @@ def add_monitor_subparser(subparsers: argparse._SubParsersAction) -> None:
         default=None,
         help="Filter sessions by project name.",
     )
+    mon.add_argument(
+        "--run",
+        dest="run_ids",
+        default=None,
+        metavar="ID[,ID...]",
+        help=(
+            "Wait for one or more schedule_run IDs to reach a terminal state, "
+            "then exit (scripting primitive; see `li monitor run --help` for "
+            "the positional form). Ignores id/--watch/--since/--type/--project."
+        ),
+    )
+    mon.add_argument(
+        "--interval",
+        type=float,
+        default=3.0,
+        metavar="SECS",
+        help="Poll interval in seconds for --run mode (default 3). Independent of --refresh.",
+    )
+    mon.add_argument(
+        "--follow",
+        action="store_true",
+        help="With --run: keep watching for new schedule_runs after the initial set drains.",
+    )
 
 
 def run_monitor(args: argparse.Namespace) -> int:
     """Dispatch `li monitor` subcommand."""
     from lionagi.ln.concurrency import run_async
+
+    if args.run_ids:
+        return _dispatch_wait(
+            _split_watched_ids([args.run_ids]), interval=args.interval, follow=args.follow
+        )
 
     since: float | None = None
     if args.since:

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -798,11 +798,21 @@ async def _poll_pending_once(
     db: Any,
     pending: dict[str, dict[str, Any]],
     schedule_names: dict[str, str],
-) -> list[dict[str, Any]]:
-    """Check every still-pending run once; print (and drop from `pending`)
-    any that are now terminal. Printing happens immediately per row, not
-    batched, so a harness tailing stdout sees each result the moment it
-    lands rather than waiting for the whole watched set to finish.
+    done: list[dict[str, Any]],
+) -> None:
+    """Check every still-pending run once; print, record into `done`, and
+    drop from `pending` any that are now terminal. Printing happens
+    immediately per row, not batched, so a harness tailing stdout sees each
+    result the moment it lands rather than waiting for the whole watched
+    set to finish.
+
+    `done` is mutated in place rather than returned: a coroutine only ever
+    suspends at an `await`, and there is no `await` between the print/
+    append/delete below, so that trio is atomic with respect to task
+    cancellation — a row can never leave `pending` without also landing in
+    `done`, even if the caller (run_async, see _dispatch_wait) discards
+    this coroutine's actual return value because a SIGINT raced its
+    completion.
 
     This is the primitive's testable inner tick: exercising "terminal
     across different poll iterations" only needs two direct calls to this
@@ -810,7 +820,6 @@ async def _poll_pending_once(
     """
     from ._logging import log_error
 
-    resolved: list[dict[str, Any]] = []
     for run_id in list(pending):
         row = await db.get_schedule_run(run_id)
         if row is None:
@@ -823,9 +832,8 @@ async def _poll_pending_once(
             continue
         name = await _schedule_name(db, row["schedule_id"], cache=schedule_names)
         print(_format_wait_line(row, name))
-        resolved.append(row)
+        done.append(row)
         del pending[run_id]
-    return resolved
 
 
 async def _query_schedule_runs_since(db: Any, baseline: float) -> list[dict[str, Any]]:
@@ -908,26 +916,35 @@ def _dispatch_wait(ids: list[str], *, interval: float, follow: bool) -> int:
             return await _resolve_watched_runs(db, ids)
 
     resolved = _run_tick(_resolve())
-    pending, unresolved = resolved if resolved is not None else ({}, [])
+    if resolved is None:
+        # Interrupted before resolving even completed — we don't yet know
+        # which ids exist or what state they're in, so there is no aggregate
+        # to report. This is "still in progress", not success or failure.
+        return EXIT_RUNNING
+    pending, unresolved = resolved
     for raw_id in unresolved:
         log_error(f"schedule_run {raw_id!r} not found")
 
-    async def _tick() -> list[dict[str, Any]]:
-        async with StateDB() as db:
-            return await _poll_pending_once(db, pending, schedule_names)
-
+    total_watched = len(pending)
     done: list[dict[str, Any]] = []
+
+    async def _tick() -> None:
+        async with StateDB() as db:
+            await _poll_pending_once(db, pending, schedule_names, done)
+
     while pending and not interrupted:
-        tick_result = _run_tick(_tick())
-        if tick_result is not None:
-            done.extend(tick_result)
+        _run_tick(_tick())
         if not pending or interrupted:
             break
         _sleep_interval(interval)
 
     if unresolved:
         exit_code = EXIT_UNKNOWN
-    elif pending:  # only reachable via interruption mid-wait
+    elif len(done) < total_watched:
+        # Some watched run never reached a terminal status before we had to
+        # stop — whether that row was ever printed is irrelevant; `done`
+        # (mutated in _poll_pending_once, see above) is the one ground truth
+        # that survives a tick being interrupted mid-flight.
         exit_code = EXIT_RUNNING
     elif all(r.get("exit_code") == 0 for r in done):
         exit_code = 0
@@ -944,7 +961,7 @@ def _dispatch_wait(ids: list[str], *, interval: float, follow: bool) -> int:
                 for row in new_rows:
                     follow_pending.setdefault(row["id"], row)
                 if follow_pending:
-                    await _poll_pending_once(db, follow_pending, schedule_names)
+                    await _poll_pending_once(db, follow_pending, schedule_names, [])
             if new_rows:
                 bl = max(bl, *(r["created_at"] for r in new_rows))
             return bl
@@ -956,9 +973,10 @@ def _dispatch_wait(ids: list[str], *, interval: float, follow: bool) -> int:
             if interrupted:
                 break
             _sleep_interval(interval)
-        # --follow has no natural end — its exit code reflects whether the
-        # *initial* watched set was resolvable, not the open-ended tail.
-        return EXIT_UNKNOWN if unresolved else 0
+        # --follow has no natural end, so its exit code is whatever the
+        # *initial* bounded set already resolved to (see exit_code above)
+        # — new runs discovered during the tail print their own lines but
+        # don't feed the final aggregate.
 
     return exit_code
 
@@ -984,7 +1002,13 @@ def run_monitor_wait(argv: list[str]) -> int:
         help="Keep watching for new schedule_runs after the initial set drains.",
     )
     args = parser.parse_args(argv)
-    return _dispatch_wait(_split_watched_ids(args.ids), interval=args.interval, follow=args.follow)
+    watched_ids = _split_watched_ids(args.ids)
+    if not watched_ids:
+        # nargs="+" only guarantees argv had at least one token, not that any
+        # of them survive comma-splitting (e.g. a lone "," or ""). Without
+        # this check that degenerates into a silent, instant, exit-0 no-op.
+        parser.error("no schedule_run ids given (only empty/comma-only tokens)")
+    return _dispatch_wait(watched_ids, interval=args.interval, follow=args.follow)
 
 
 # ── CLI registration ──────────────────────────────────────────────────────────

--- a/tests/cli/test_monitor_run.py
+++ b/tests/cli/test_monitor_run.py
@@ -172,9 +172,10 @@ async def test_poll_pending_once_reports_immediately_terminal_run(
         sched_id = await _make_schedule(db, name="nightly-build")
         run_id = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
         pending = {run_id: await db.get_schedule_run(run_id)}
-        resolved = await _poll_pending_once(db, pending, {})
+        done: list[dict[str, Any]] = []
+        await _poll_pending_once(db, pending, {}, done)
 
-    assert [r["id"] for r in resolved] == [run_id]
+    assert [r["id"] for r in done] == [run_id]
     assert run_id not in pending
     out = capsys.readouterr().out
     assert run_id in out
@@ -190,9 +191,10 @@ async def test_poll_pending_once_leaves_running_run_pending(
         sched_id = await _make_schedule(db)
         run_id = await _make_schedule_run(db, sched_id, status="running")
         pending = {run_id: await db.get_schedule_run(run_id)}
-        resolved = await _poll_pending_once(db, pending, {})
+        done: list[dict[str, Any]] = []
+        await _poll_pending_once(db, pending, {}, done)
 
-    assert resolved == []
+    assert done == []
     assert run_id in pending
     assert capsys.readouterr().out == ""
 
@@ -209,15 +211,16 @@ async def test_poll_pending_once_across_two_ticks_with_db_mutation_no_real_sleep
         sched_id = await _make_schedule(db)
         run_id = await _make_schedule_run(db, sched_id, status="running")
         pending = {run_id: await db.get_schedule_run(run_id)}
+        done: list[dict[str, Any]] = []
 
-        first = await _poll_pending_once(db, pending, {})
-        assert first == []
+        await _poll_pending_once(db, pending, {}, done)
+        assert done == []
         assert run_id in pending
 
         await _set_fields(db, "schedule_runs", run_id, status="completed", exit_code=0)
 
-        second = await _poll_pending_once(db, pending, {})
-        assert [r["id"] for r in second] == [run_id]
+        await _poll_pending_once(db, pending, {}, done)
+        assert [r["id"] for r in done] == [run_id]
         assert run_id not in pending
 
     out = capsys.readouterr().out
@@ -234,12 +237,13 @@ async def test_poll_pending_once_row_vanished_mid_wait_resolves_as_failure(
         pending = {run_id: await db.get_schedule_run(run_id)}
         await db.execute("DELETE FROM schedule_runs WHERE id = ?", (run_id,))
 
+        done: list[dict[str, Any]] = []
         with caplog.at_level(logging.ERROR, logger="lionagi.cli.error"):
-            resolved = await _poll_pending_once(db, pending, {})
+            await _poll_pending_once(db, pending, {}, done)
 
     assert run_id not in pending
-    assert len(resolved) == 1
-    assert resolved[0]["exit_code"] is None
+    assert len(done) == 1
+    assert done[0]["exit_code"] is None
     assert "disappeared" in caplog.text.lower()
 
 
@@ -381,6 +385,84 @@ async def test_dispatch_wait_polls_across_real_iterations_until_background_mutat
     assert run_id in capsys.readouterr().out
 
 
+@pytest.mark.asyncio
+async def test_dispatch_wait_sigint_while_still_pending_returns_exit_running(
+    temp_db_path: Path,
+) -> None:
+    """A run that never goes terminal + a real SIGINT mid-wait must report
+    EXIT_RUNNING, not silently succeed."""
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db)
+        run_id = await _make_schedule_run(db, sched_id, status="running")
+
+    def _send_interrupt() -> None:
+        time.sleep(0.3)
+        os.kill(os.getpid(), signal.SIGINT)
+
+    t = threading.Thread(target=_send_interrupt, daemon=True)
+    t.start()
+
+    exit_code = _dispatch_wait([run_id], interval=0.05, follow=False)
+    t.join(timeout=2)
+
+    assert exit_code == EXIT_RUNNING
+
+
+@pytest.mark.asyncio
+async def test_dispatch_wait_interrupted_during_resolve_returns_exit_running(
+    temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If SIGINT lands during the very first resolve call (before we even
+    know whether the requested ids exist), we cannot claim success -- must
+    report EXIT_RUNNING, never a vacuous 0."""
+    async with StateDB():
+        pass  # ensure state.db exists on disk before _dispatch_wait checks it
+
+    import lionagi.ln.concurrency as concurrency_mod
+
+    def _fake_run_async(coro: Any) -> Any:
+        coro.close()  # avoid "coroutine was never awaited" warning
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(concurrency_mod, "run_async", _fake_run_async)
+
+    exit_code = _dispatch_wait(["some-id"], interval=5.0, follow=False)
+    assert exit_code == EXIT_RUNNING
+
+
+@pytest.mark.asyncio
+async def test_dispatch_wait_keyboard_interrupt_after_tick_mutates_state_still_reports_failure(
+    temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression: run_async can complete a tick's real work (printing a
+    terminal row, mutating `pending`/`done`) and *then* raise
+    KeyboardInterrupt before _dispatch_wait ever sees the tick's return
+    value -- exactly what happens when SIGINT is delivered right as the
+    tick's coroutine finishes. The already-observed failure must still be
+    reflected in the exit code, not lost to a vacuous empty-`done` success.
+    """
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db)
+        run_id = await _make_schedule_run(db, sched_id, status="failed", exit_code=1)
+
+    import lionagi.ln.concurrency as concurrency_mod
+
+    real_run_async = concurrency_mod.run_async
+    calls = {"n": 0}
+
+    def _fake_run_async(coro: Any) -> Any:
+        calls["n"] += 1
+        if calls["n"] == 2:  # call 1 = resolve; call 2 = the first tick
+            real_run_async(coro)  # let it actually run and mutate state...
+            raise KeyboardInterrupt  # ...then simulate SIGINT racing the return
+        return real_run_async(coro)
+
+    monkeypatch.setattr(concurrency_mod, "run_async", _fake_run_async)
+
+    exit_code = _dispatch_wait([run_id], interval=5.0, follow=False)
+    assert exit_code == 1
+
+
 # ── _query_schedule_runs_since (the --follow baseline boundary, deterministic) ──
 
 
@@ -434,6 +516,32 @@ async def test_dispatch_wait_follow_sigint_clean(temp_db_path: Path) -> None:
     t.join(timeout=2)
 
     assert exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_dispatch_wait_follow_preserves_initial_failure_exit_code(
+    temp_db_path: Path,
+) -> None:
+    """Regression: --follow must not collapse an initial bounded-set FAILURE
+    into a false success just because the follow phase was entered and later
+    interrupted. The initial watched set's aggregate result is the contract
+    --follow's exit code honors; the open-ended tail has no result of its
+    own to report."""
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db)
+        run_id = await _make_schedule_run(db, sched_id, status="failed", exit_code=1)
+
+    def _send_interrupt() -> None:
+        time.sleep(0.3)
+        os.kill(os.getpid(), signal.SIGINT)
+
+    t = threading.Thread(target=_send_interrupt, daemon=True)
+    t.start()
+
+    exit_code = _dispatch_wait([run_id], interval=0.05, follow=True)
+    t.join(timeout=2)
+
+    assert exit_code == 1
 
 
 @pytest.mark.asyncio
@@ -574,6 +682,21 @@ def test_run_monitor_wait_unknown_id_returns_exit_unknown(temp_db_path: Path) ->
 def test_run_monitor_wait_requires_at_least_one_id():
     with pytest.raises(SystemExit):
         run_monitor_wait([])
+
+
+def test_run_monitor_wait_comma_only_token_rejected_as_usage_error():
+    """nargs="+" only guarantees a non-empty argv list, not that any token
+    survives comma-splitting -- a single "," token must be treated the same
+    as no ids at all, not silently dispatched as a zero-id wait."""
+    with pytest.raises(SystemExit) as exc_info:
+        run_monitor_wait([",,,"])
+    assert exc_info.value.code == 2
+
+
+def test_run_monitor_wait_empty_string_token_rejected_as_usage_error():
+    with pytest.raises(SystemExit) as exc_info:
+        run_monitor_wait([""])
+    assert exc_info.value.code == 2
 
 
 # ── CLI wiring: `li monitor run --help` / `li monitor --help` subprocess ────

--- a/tests/cli/test_monitor_run.py
+++ b/tests/cli/test_monitor_run.py
@@ -1,0 +1,609 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for `li monitor run` / `li monitor --run` — scriptable
+wait-for-terminal primitive over schedule_runs (additive to the `li monitor`
+dashboard, not a replacement)."""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from lionagi.cli.monitor import (
+    _dispatch_wait,
+    _format_wait_line,
+    _poll_pending_once,
+    _query_schedule_runs_since,
+    _resolve_schedule_run,
+    _split_watched_ids,
+    add_monitor_subparser,
+    run_monitor_wait,
+)
+from lionagi.cli.status import EXIT_RUNNING, EXIT_UNKNOWN
+from lionagi.state.db import StateDB
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def temp_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Per-test temp DB; patch DEFAULT_DB_PATH so StateDB() opens it."""
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", db_path)
+    return db_path
+
+
+async def _make_schedule(db: StateDB, *, name: str | None = None) -> str:
+    sid = uuid.uuid4().hex[:12]
+    await db.create_schedule(
+        {
+            "id": sid,
+            "name": name or f"sched-{sid}",
+            "trigger_type": "interval",
+            "interval_sec": 60,
+            "action_kind": "agent",
+        }
+    )
+    return sid
+
+
+async def _make_schedule_run(
+    db: StateDB,
+    schedule_id: str,
+    *,
+    status: str = "running",
+    exit_code: int | None = None,
+    chain_depth: int = 0,
+) -> str:
+    rid = uuid.uuid4().hex[:12]
+    await db.create_schedule_run(
+        {
+            "id": rid,
+            "schedule_id": schedule_id,
+            "trigger_context": {},
+            "action_kind": "agent",
+            "action_args": [],
+            "status": status,
+            "exit_code": exit_code,
+            "chain_depth": chain_depth,
+            "fired_at": time.time(),
+        }
+    )
+    return rid
+
+
+async def _set_fields(db: StateDB, table: str, id_: str, **fields: Any) -> None:
+    sets = ", ".join(f"{k} = ?" for k in fields)
+    await db.execute(f"UPDATE {table} SET {sets} WHERE id = ?", (*fields.values(), id_))
+
+
+# ── _split_watched_ids ───────────────────────────────────────────────────────
+
+
+def test_split_watched_ids_multiple_positional_tokens():
+    assert _split_watched_ids(["a", "b", "c"]) == ["a", "b", "c"]
+
+
+def test_split_watched_ids_comma_separated_single_token():
+    assert _split_watched_ids(["a,b,c"]) == ["a", "b", "c"]
+
+
+def test_split_watched_ids_mixed_tokens_and_commas():
+    assert _split_watched_ids(["a,b", "c"]) == ["a", "b", "c"]
+
+
+def test_split_watched_ids_strips_whitespace():
+    assert _split_watched_ids([" a , b "]) == ["a", "b"]
+
+
+def test_split_watched_ids_dedupes_preserving_first_seen_order():
+    assert _split_watched_ids(["a,b,a", "b", "c"]) == ["a", "b", "c"]
+
+
+def test_split_watched_ids_drops_empty_pieces():
+    assert _split_watched_ids(["a,,b", ""]) == ["a", "b"]
+
+
+# ── _format_wait_line ────────────────────────────────────────────────────────
+
+
+def test_format_wait_line_contains_all_fields():
+    row = {"id": "abc123", "chain_depth": 2, "status": "completed", "exit_code": 0}
+    line = _format_wait_line(row, "my-schedule")
+    assert "abc123" in line
+    assert "my-schedule" in line
+    assert "chain_depth=2" in line
+    assert "status=completed" in line
+    assert "exit_code=0" in line
+
+
+def test_format_wait_line_none_exit_code_renders_dash():
+    row = {"id": "abc123", "chain_depth": 0, "status": "cancelled", "exit_code": None}
+    line = _format_wait_line(row, "my-schedule")
+    assert "exit_code=-" in line
+
+
+# ── _resolve_schedule_run ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_resolve_schedule_run_exact_match(temp_db_path: Path) -> None:
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db)
+        run_id = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
+        row = await _resolve_schedule_run(db, run_id)
+        assert row is not None
+        assert row["id"] == run_id
+
+
+@pytest.mark.asyncio
+async def test_resolve_schedule_run_prefix_match(temp_db_path: Path) -> None:
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db)
+        run_id = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
+        row = await _resolve_schedule_run(db, run_id[:6])
+        assert row is not None
+        assert row["id"] == run_id
+
+
+@pytest.mark.asyncio
+async def test_resolve_schedule_run_not_found_returns_none(temp_db_path: Path) -> None:
+    async with StateDB() as db:
+        row = await _resolve_schedule_run(db, "totally-unknown-id")
+        assert row is None
+
+
+# ── _poll_pending_once (the testable inner tick — no real sleeps needed) ────
+
+
+@pytest.mark.asyncio
+async def test_poll_pending_once_reports_immediately_terminal_run(
+    temp_db_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db, name="nightly-build")
+        run_id = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
+        pending = {run_id: await db.get_schedule_run(run_id)}
+        resolved = await _poll_pending_once(db, pending, {})
+
+    assert [r["id"] for r in resolved] == [run_id]
+    assert run_id not in pending
+    out = capsys.readouterr().out
+    assert run_id in out
+    assert "nightly-build" in out
+    assert "status=completed" in out
+
+
+@pytest.mark.asyncio
+async def test_poll_pending_once_leaves_running_run_pending(
+    temp_db_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db)
+        run_id = await _make_schedule_run(db, sched_id, status="running")
+        pending = {run_id: await db.get_schedule_run(run_id)}
+        resolved = await _poll_pending_once(db, pending, {})
+
+    assert resolved == []
+    assert run_id in pending
+    assert capsys.readouterr().out == ""
+
+
+@pytest.mark.asyncio
+async def test_poll_pending_once_across_two_ticks_with_db_mutation_no_real_sleep(
+    temp_db_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """Drives the run from running -> completed between two direct calls to
+    the tick function — the deterministic, zero-wall-clock way to exercise
+    'terminal across different poll iterations' (see also the real-thread
+    variant against _dispatch_wait below)."""
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db)
+        run_id = await _make_schedule_run(db, sched_id, status="running")
+        pending = {run_id: await db.get_schedule_run(run_id)}
+
+        first = await _poll_pending_once(db, pending, {})
+        assert first == []
+        assert run_id in pending
+
+        await _set_fields(db, "schedule_runs", run_id, status="completed", exit_code=0)
+
+        second = await _poll_pending_once(db, pending, {})
+        assert [r["id"] for r in second] == [run_id]
+        assert run_id not in pending
+
+    out = capsys.readouterr().out
+    assert out.count(run_id) == 1
+
+
+@pytest.mark.asyncio
+async def test_poll_pending_once_row_vanished_mid_wait_resolves_as_failure(
+    temp_db_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db)
+        run_id = await _make_schedule_run(db, sched_id, status="running")
+        pending = {run_id: await db.get_schedule_run(run_id)}
+        await db.execute("DELETE FROM schedule_runs WHERE id = ?", (run_id,))
+
+        with caplog.at_level(logging.ERROR, logger="lionagi.cli.error"):
+            resolved = await _poll_pending_once(db, pending, {})
+
+    assert run_id not in pending
+    assert len(resolved) == 1
+    assert resolved[0]["exit_code"] is None
+    assert "disappeared" in caplog.text.lower()
+
+
+# ── _dispatch_wait: bounded wait, no --follow ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dispatch_wait_single_immediately_terminal_success(
+    temp_db_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db, name="my-sched")
+        run_id = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
+
+    started = time.monotonic()
+    exit_code = _dispatch_wait([run_id], interval=5.0, follow=False)
+    elapsed = time.monotonic() - started
+
+    assert exit_code == 0
+    assert elapsed < 2.0, "already-terminal run must not wait out a full poll interval"
+    out = capsys.readouterr().out
+    assert run_id in out
+    assert "status=completed" in out
+
+
+@pytest.mark.asyncio
+async def test_dispatch_wait_single_immediately_terminal_failure(temp_db_path: Path) -> None:
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db)
+        run_id = await _make_schedule_run(db, sched_id, status="failed", exit_code=1)
+
+    exit_code = _dispatch_wait([run_id], interval=5.0, follow=False)
+    assert exit_code == 1
+
+
+@pytest.mark.asyncio
+async def test_dispatch_wait_multi_id_all_terminal_success(temp_db_path: Path) -> None:
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db)
+        run_a = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
+        run_b = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
+
+    exit_code = _dispatch_wait([run_a, run_b], interval=5.0, follow=False)
+    assert exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_dispatch_wait_multi_id_one_nonzero_exit_fails_aggregate(temp_db_path: Path) -> None:
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db)
+        run_a = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
+        run_b = await _make_schedule_run(db, sched_id, status="failed", exit_code=1)
+
+    exit_code = _dispatch_wait([run_a, run_b], interval=5.0, follow=False)
+    assert exit_code == 1
+
+
+@pytest.mark.asyncio
+async def test_dispatch_wait_unknown_id_returns_exit_unknown_without_blocking(
+    temp_db_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Open+close once so state.db actually exists on disk — this test is
+    # about an id that isn't among the (existing) schedule_runs, not about
+    # a missing state.db file entirely (see test_dispatch_wait_no_db_file).
+    async with StateDB():
+        pass
+
+    started = time.monotonic()
+    with caplog.at_level(logging.ERROR, logger="lionagi.cli.error"):
+        exit_code = _dispatch_wait(["nonexistent-id"], interval=5.0, follow=False)
+    elapsed = time.monotonic() - started
+
+    assert exit_code == EXIT_UNKNOWN
+    assert elapsed < 2.0, "unresolved id must not enter the poll loop at all"
+    assert "nonexistent-id" in caplog.text
+
+
+def test_dispatch_wait_no_db_file_returns_exit_unknown(
+    temp_db_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """state.db does not exist yet (fresh install, `li agent` never run) —
+    must fail fast with EXIT_UNKNOWN, not try to open/create it."""
+    with caplog.at_level(logging.ERROR, logger="lionagi.cli.error"):
+        exit_code = _dispatch_wait(["anything"], interval=5.0, follow=False)
+
+    assert exit_code == EXIT_UNKNOWN
+    assert not temp_db_path.exists()
+    assert "state.db not found" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_dispatch_wait_mixed_unknown_and_resolved_still_returns_exit_unknown(
+    temp_db_path: Path, capsys: pytest.CaptureFixture, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A bad id must not be masked by other watched runs succeeding — the
+    whole invocation reports EXIT_UNKNOWN, but the good run's line still
+    prints (it did finish; the caller should see that)."""
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db)
+        good_id = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
+
+    with caplog.at_level(logging.ERROR, logger="lionagi.cli.error"):
+        exit_code = _dispatch_wait([good_id, "bogus-id"], interval=5.0, follow=False)
+
+    assert exit_code == EXIT_UNKNOWN
+    assert good_id in capsys.readouterr().out
+    assert "bogus-id" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_dispatch_wait_polls_across_real_iterations_until_background_mutation(
+    temp_db_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """Integration-level companion to the deterministic two-tick test above:
+    a background thread flips the row to terminal partway through, proving
+    the sync orchestration loop (not just the inner tick function) actually
+    polls on a real cadence rather than resolving everything up front."""
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db)
+        run_id = await _make_schedule_run(db, sched_id, status="running")
+
+    def _flip_to_completed() -> None:
+        import asyncio
+
+        async def _go() -> None:
+            async with StateDB() as db2:
+                await _set_fields(db2, "schedule_runs", run_id, status="completed", exit_code=0)
+
+        time.sleep(0.25)
+        asyncio.run(_go())
+
+    t = threading.Thread(target=_flip_to_completed, daemon=True)
+    t.start()
+
+    exit_code = _dispatch_wait([run_id], interval=0.05, follow=False)
+    t.join(timeout=5)
+
+    assert exit_code == 0
+    assert run_id in capsys.readouterr().out
+
+
+# ── _query_schedule_runs_since (the --follow baseline boundary, deterministic) ──
+
+
+@pytest.mark.asyncio
+async def test_query_schedule_runs_since_only_returns_strictly_newer(temp_db_path: Path) -> None:
+    """The exact SQL boundary --follow relies on: a run created AT baseline
+    must not be re-returned (strict '>'), only ones created after it."""
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db)
+        old_id = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
+        old_row = await db.get_schedule_run(old_id)
+        baseline = old_row["created_at"]
+
+        new_id = await _make_schedule_run(db, sched_id, status="running")
+        new_rows = await _query_schedule_runs_since(db, baseline)
+
+    assert [r["id"] for r in new_rows] == [new_id]
+
+
+@pytest.mark.asyncio
+async def test_query_schedule_runs_since_empty_when_nothing_newer(temp_db_path: Path) -> None:
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db)
+        run_id = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
+        row = await db.get_schedule_run(run_id)
+        new_rows = await _query_schedule_runs_since(db, row["created_at"])
+
+    assert new_rows == []
+
+
+# ── _dispatch_wait: --follow (baseline-first tail behavior) ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_dispatch_wait_follow_sigint_clean(temp_db_path: Path) -> None:
+    """Mirrors test_watch_mode_sigint_clean in test_monitor.py: --follow must
+    exit cleanly (not hang, not traceback) on SIGINT once the initial set has
+    drained."""
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db)
+        run_id = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
+
+    def _send_interrupt() -> None:
+        time.sleep(0.3)
+        os.kill(os.getpid(), signal.SIGINT)
+
+    t = threading.Thread(target=_send_interrupt, daemon=True)
+    t.start()
+
+    exit_code = _dispatch_wait([run_id], interval=0.05, follow=True)
+    t.join(timeout=2)
+
+    assert exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_dispatch_wait_follow_ignores_pre_existing_runs_reports_only_new(
+    temp_db_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """Baseline-first discipline: a schedule_run that already existed before
+    --follow started watching must never be (re-)reported during the follow
+    phase; only runs created after the baseline was captured are new."""
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db)
+        watched_id = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
+        pre_existing_id = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
+
+    new_run_id: dict[str, str] = {}
+
+    def _create_new_run_then_interrupt() -> None:
+        import asyncio
+
+        async def _go() -> None:
+            async with StateDB() as db2:
+                new_run_id["id"] = await _make_schedule_run(
+                    db2, sched_id, status="completed", exit_code=0
+                )
+
+        time.sleep(0.25)
+        asyncio.run(_go())
+        time.sleep(0.4)
+        os.kill(os.getpid(), signal.SIGINT)
+
+    t = threading.Thread(target=_create_new_run_then_interrupt, daemon=True)
+    t.start()
+
+    exit_code = _dispatch_wait([watched_id], interval=0.05, follow=True)
+    t.join(timeout=5)
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert watched_id in out  # the originally-requested id: reported during the bounded phase
+    assert new_run_id["id"] in out  # created after baseline: reported during follow
+    assert pre_existing_id not in out  # existed before baseline: never re-reported
+
+
+# ── argv parsing: `--run` flag form + `--interval`/`--follow` on the main parser ──
+
+
+def test_add_monitor_subparser_run_flag_and_new_options():
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_monitor_subparser(sub)
+
+    args = parser.parse_args(["monitor", "--run", "id1,id2,id3"])
+    assert args.run_ids == "id1,id2,id3"
+    assert args.interval == 3.0
+    assert args.follow is False
+
+    args = parser.parse_args(["monitor", "--run", "id1", "--interval", "0.5", "--follow"])
+    assert args.run_ids == "id1"
+    assert args.interval == 0.5
+    assert args.follow is True
+
+
+def test_add_monitor_subparser_existing_dashboard_args_unaffected():
+    """Regression: adding --run/--interval/--follow must not disturb the
+    existing bare / --watch / --since / --type / --project surface."""
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_monitor_subparser(sub)
+
+    args = parser.parse_args(["monitor"])
+    assert args.id is None
+    assert not args.watch
+    assert args.run_ids is None
+
+    args = parser.parse_args(["monitor", "abc123", "--watch"])
+    assert args.id == "abc123"
+    assert args.watch
+
+
+# ── run_monitor_wait: the `li monitor run <id>...` positional entry point ───
+
+
+@pytest.mark.asyncio
+async def test_run_monitor_wait_single_positional_id(
+    temp_db_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db)
+        run_id = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
+
+    exit_code = run_monitor_wait([run_id])
+    assert exit_code == 0
+    assert run_id in capsys.readouterr().out
+
+
+@pytest.mark.asyncio
+async def test_run_monitor_wait_comma_separated_single_token(
+    temp_db_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """`li monitor run id1,id2` — one argv token, both ids must resolve."""
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db)
+        run_a = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
+        run_b = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
+
+    exit_code = run_monitor_wait([f"{run_a},{run_b}"])
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert run_a in out
+    assert run_b in out
+
+
+@pytest.mark.asyncio
+async def test_run_monitor_wait_multiple_positional_tokens(
+    temp_db_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """`li monitor run id1 id2` — two argv tokens, both ids must resolve."""
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db)
+        run_a = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
+        run_b = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
+
+    exit_code = run_monitor_wait([run_a, run_b])
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert run_a in out
+    assert run_b in out
+
+
+def test_run_monitor_wait_unknown_id_returns_exit_unknown(temp_db_path: Path) -> None:
+    assert run_monitor_wait(["nonexistent-id"]) == EXIT_UNKNOWN
+
+
+def test_run_monitor_wait_requires_at_least_one_id():
+    with pytest.raises(SystemExit):
+        run_monitor_wait([])
+
+
+# ── CLI wiring: `li monitor run --help` / `li monitor --help` subprocess ────
+
+
+def test_cli_monitor_run_help_subprocess():
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, "-m", "lionagi.cli", "monitor", "run", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "follow" in result.stdout.lower()
+    assert "interval" in result.stdout.lower()
+
+
+def test_cli_monitor_help_still_shows_dashboard_usage():
+    """Regression: `li monitor --help` (no 'run') must still describe the
+    existing dashboard, proving the pre-dispatch interception in main.py
+    only intercepts the literal 'run' token, not all of `li monitor`."""
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, "-m", "lionagi.cli", "monitor", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "--watch" in result.stdout

--- a/tests/cli/test_monitor_run.py
+++ b/tests/cli/test_monitor_run.py
@@ -606,6 +606,26 @@ def test_add_monitor_subparser_run_flag_and_new_options():
     assert args.follow is True
 
 
+def test_run_monitor_run_flag_comma_only_ids_is_usage_error(
+    temp_db_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """`li monitor --run ,,,` is truthy but splits to zero ids; it must fail
+    as a usage error, not dispatch an empty watch set and exit 0."""
+    import argparse
+
+    from lionagi.cli.monitor import run_monitor
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_monitor_subparser(sub)
+    args = parser.parse_args(["monitor", "--run", ",,,"])
+
+    with caplog.at_level(logging.ERROR):
+        exit_code = run_monitor(args)
+    assert exit_code == 2
+    assert "no schedule_run ids" in caplog.text
+
+
 def test_add_monitor_subparser_existing_dashboard_args_unaffected():
     """Regression: adding --run/--interval/--follow must not disturb the
     existing bare / --watch / --since / --type / --project surface."""


### PR DESCRIPTION
## Summary

Adds `li monitor run <id> [<id2>...]` and `li monitor --run <id1>,<id2>,<id3>` as a scriptable wait-for-terminal primitive: it blocks until the named `schedule_runs` reach a terminal state, prints one line per completed run the moment it finishes, and exits with a meaningful code. This replaces fleet lambdas hand-rolling raw `sqlite3 -readonly` polling loops against the live WAL-mode `~/.lionagi/state.db` — a workaround currently in active use.

**Additive, not a rewrite.** The existing `li monitor` dashboard (bare table view, `<id>` detail view, `--watch`/`--refresh` live loop, `--since`/`--type`/`--project` filters) is completely untouched — this is a separate code path (append-only stdout lines, no screen clearing, no table). Verified via the existing `tests/cli/test_monitor.py` suite (57 tests) passing unchanged.

## CLI surface

- `li monitor run <id1> <id2> ...` (positional, also accepts a single comma-separated token)
- `li monitor --run <id1>,<id2>,<id3>` (flag form)
- Both converge on the same `_dispatch_wait` function.
- `--interval SECS` (default 3.0), independent of the dashboard's `--refresh`.
- `--follow`: after the initial id set drains, keep watching for *new* schedule_runs (tail -f style).

`monitor run` / `mon run` is intercepted in `main.py` before argparse's positional `id` slot would otherwise swallow the literal token `"run"` as an entity id — same pattern as the existing `agent status` / `play status` interception (ADR-0085 slice 3).

## Exit code convention

| Code | Meaning |
|------|---------|
| `0` | every watched run's `exit_code == 0` |
| `1` | at least one run's `exit_code != 0` |
| `2` (`EXIT_UNKNOWN`) | an id couldn't be resolved (unknown/typo), or `state.db` doesn't exist yet |
| `3` (`EXIT_RUNNING`) | interrupted (SIGINT/SIGTERM) while runs were still pending |

`--follow`'s eventual Ctrl-C exit is `EXIT_UNKNOWN if unresolved else 0` — it deliberately doesn't try to preserve a "some run failed" signal across an open-ended tail session, since that information already streamed to stdout per-line as it happened.

## Behavior notes

- Resolution: exact match via `db.get_schedule_run`, then hex-prefix match, mirroring `_find_entity`'s convention (schedule_run ids are 12-char hex, not 36-char UUIDs, so the length-36 heuristic used elsewhere doesn't apply).
- Polls all pending ids on `--interval`; prints a line the moment each one goes terminal (id, schedule name, chain_depth, status, exit_code) — progressive, not batched at the end.
- `--follow` is baseline-first: only rows with `created_at` strictly greater than the baseline (advanced monotonically as new rows are seen) are picked up, so pre-existing runs are never re-reported.
- No real `time.sleep` busy-waiting inside the async path — polling uses the same sync-outer-loop / `run_async` pattern as the existing `_watch_loop`, with a `KeyboardInterrupt`-catching wrapper around each `run_async` call (needed because this loop's shorter poll interval spends a much larger fraction of wall-clock time inside `run_async` than `_watch_loop`'s 1s-refresh dashboard scenario — confirmed empirically, see test `test_dispatch_wait_follow_sigint_clean`).

## Tests

New file `tests/cli/test_monitor_run.py`, following `tests/cli/test_status.py`'s fixture/style conventions: **36 tests**, all passing. Covers argv parsing (both forms, comma-in-positional), single-id immediately-terminal, multi-id terminal-across-different-poll-iterations (deterministic — background-thread DB mutation, no real wall-clock sleeps), unknown-id → `EXIT_UNKNOWN` without blocking, row-vanished-mid-wait, `--follow` baseline-first semantics (including SIGINT-clean shutdown), and subprocess `--help` smoke tests.

Full `tests/cli/` suite (927 collected, verified via two independent full runs — parallel `-n auto` and serial `-n 0`, identical failure sets both times): **882 passed, 43 failed, 2 skipped**. All 43 failures are pre-existing and unrelated — confirmed via `git stash` against baseline `main`:
- 42 failures in `tests/cli/test_argv_injection.py` + `tests/cli/test_scheduler_flow_yaml.py`: `lionagi/studio/services/schedules.py:11` does an unconditional `from fastapi import HTTPException, Query`, and `fastapi` (a studio extra) isn't installed in this environment's core venv.
- 1 instance of the already-tracked circular-import flake between `lionagi.studio.cli` and `lionagi.cli.main` (order-dependent under pytest-xdist worker-packing; unrelated to this change).

No database schema changes.

## Test plan

- [x] `uv run pytest tests/cli/test_monitor_run.py` — 36/36 pass
- [x] `uv run pytest tests/cli/test_monitor.py` — 57/57 pass (dashboard regression-clean)
- [x] `uv run pytest tests/cli/test_main.py` — 9/9 pass (dispatch regression-clean)
- [x] `uv run pytest tests/cli/` full suite — 43 pre-existing failures confirmed unrelated via git stash against main
- [x] `uv run ruff check` — all checks passed
- [x] `uv run ruff format --check` — all files formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)