### PR TITLE
feat(schedule): expose on_success/on_fail chaining flags in li schedule create

### DIFF
--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -536,8 +536,64 @@ def _cmd_get(args: argparse.Namespace) -> int:
     return 0
 
 
+def _validate_chain_action_node(
+    action: Any,
+    label: str,
+    self_field: str,
+    chain_depth: int,
+    max_chain_depth: int,
+) -> str | None:
+    """Validate one chain_action node, recursing into its own nested
+    on_success/on_fail the same way the engine's chain-fire would reach them.
+
+    `label` is a human-readable path for error messages (e.g. "--on-success"
+    or "--on-success.on_success"). `self_field` is the chain field this node
+    was reached through — used for the re-fire warning: does this node set
+    its own copy of that field, or will it inherit the parent's via the
+    shallow merge? `chain_depth` is the engine chain_depth this node fires at
+    if reached (see scheduler/engine.py); recursion stops once that reaches
+    `max_chain_depth`, matching the engine's own `chain_depth < _MAX_CHAIN_DEPTH`
+    gate — beyond it, a node's own on_success/on_fail is never read.
+    """
+    if not isinstance(action, dict):
+        return f"{label}: must be a JSON object, got {type(action).__name__}"
+
+    unknown = set(action) - _CHAIN_ACTION_ALLOWED_KEYS
+    if unknown:
+        allowed = ", ".join(sorted(_CHAIN_ACTION_ALLOWED_KEYS))
+        return f"{label}: unknown key(s) {sorted(unknown)}; allowed: {allowed}"
+
+    if self_field not in action:
+        warn(
+            f'{label} does not set its own "{self_field}" key — under the '
+            f"engine's shallow merge, the chained run will inherit its "
+            f"parent's {self_field} and may re-fire again at the next chain "
+            f'depth. Add "{self_field}": null to the JSON to stop the chain '
+            "here."
+        )
+
+    if chain_depth >= max_chain_depth:
+        return None
+
+    for nested_field in ("on_success", "on_fail"):
+        if nested_field in action and action[nested_field] is not None:
+            err = _validate_chain_action_node(
+                action[nested_field],
+                f"{label}.{nested_field}",
+                nested_field,
+                chain_depth + 1,
+                max_chain_depth,
+            )
+            if err:
+                return err
+    return None
+
+
 def _parse_chain_action(raw: str, flag: str) -> tuple[dict[str, Any] | None, str | None]:
-    """Parse+validate a --on-success/--on-fail JSON blob.
+    """Parse+validate a --on-success/--on-fail JSON blob, recursively —
+    nested on_success/on_fail chain actions are validated the same way as
+    the top level, since they ride the same shallow merge into the engine's
+    fired child schedules.
 
     Returns (parsed_dict, error_message); error_message is None on success.
     """
@@ -545,12 +601,15 @@ def _parse_chain_action(raw: str, flag: str) -> tuple[dict[str, Any] | None, str
         parsed = json.loads(raw)
     except json.JSONDecodeError as exc:
         return None, f"{flag}: invalid JSON ({exc})"
-    if not isinstance(parsed, dict):
-        return None, f"{flag}: must be a JSON object, got {type(parsed).__name__}"
-    unknown = set(parsed) - _CHAIN_ACTION_ALLOWED_KEYS
-    if unknown:
-        allowed = ", ".join(sorted(_CHAIN_ACTION_ALLOWED_KEYS))
-        return None, f"{flag}: unknown key(s) {sorted(unknown)}; allowed: {allowed}"
+
+    from lionagi.studio.scheduler.engine import _MAX_CHAIN_DEPTH
+
+    field = "on_success" if flag == "--on-success" else "on_fail"
+    err = _validate_chain_action_node(
+        parsed, flag, field, chain_depth=1, max_chain_depth=_MAX_CHAIN_DEPTH
+    )
+    if err:
+        return None, err
     return parsed, None
 
 
@@ -600,26 +659,12 @@ def _cmd_create(args: argparse.Namespace) -> int:
         if err:
             print(f"Error: {err}", file=sys.stderr)
             return 1
-        if "on_success" not in parsed:
-            warn(
-                '--on-success does not set its own "on_success" key — under the '
-                "engine's shallow merge, the chained run will inherit THIS schedule's "
-                "on_success and may re-fire again at the next chain depth. Add "
-                '"on_success": null to the JSON to stop the chain here.'
-            )
         body["on_success"] = parsed
     if args.on_fail:
         parsed, err = _parse_chain_action(args.on_fail, "--on-fail")
         if err:
             print(f"Error: {err}", file=sys.stderr)
             return 1
-        if "on_fail" not in parsed:
-            warn(
-                '--on-fail does not set its own "on_fail" key — under the engine\'s '
-                "shallow merge, the chained run will inherit THIS schedule's on_fail "
-                'and may re-fire again at the next chain depth. Add "on_fail": null '
-                "to the JSON to stop the chain here."
-            )
         body["on_fail"] = parsed
     result = _api("/", method="POST", body=body)
     if result is None:

--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -18,6 +18,14 @@ from lionagi.cli._logging import warn
 
 _STUDIO_IMAGE = "ghcr.io/ohdearquant/lion-studio:latest"
 
+# Keys the scheduler engine's chain-fire merge (`{**schedule, **chain_action}`,
+# see studio/scheduler/engine.py) actually understands. Anything else would
+# still shallow-merge into the fired child schedule row and silently clobber
+# unrelated columns (id, trigger_type, cron_expr, ...) — reject it up front.
+_CHAIN_ACTION_ALLOWED_KEYS = frozenset(
+    {"kind", "action_kind", "model", "prompt", "agent", "playbook", "on_success", "on_fail"}
+)
+
 
 def _mount_allowed_roots() -> list[Path]:
     """Host path prefixes allowed for Docker bind-mounts (home + XDG_CONFIG_HOME)."""
@@ -528,6 +536,24 @@ def _cmd_get(args: argparse.Namespace) -> int:
     return 0
 
 
+def _parse_chain_action(raw: str, flag: str) -> tuple[dict[str, Any] | None, str | None]:
+    """Parse+validate a --on-success/--on-fail JSON blob.
+
+    Returns (parsed_dict, error_message); error_message is None on success.
+    """
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return None, f"{flag}: invalid JSON ({exc})"
+    if not isinstance(parsed, dict):
+        return None, f"{flag}: must be a JSON object, got {type(parsed).__name__}"
+    unknown = set(parsed) - _CHAIN_ACTION_ALLOWED_KEYS
+    if unknown:
+        allowed = ", ".join(sorted(_CHAIN_ACTION_ALLOWED_KEYS))
+        return None, f"{flag}: unknown key(s) {sorted(unknown)}; allowed: {allowed}"
+    return parsed, None
+
+
 def _cmd_create(args: argparse.Namespace) -> int:
     body: dict[str, Any] = {
         "name": args.name,
@@ -569,6 +595,32 @@ def _cmd_create(args: argparse.Namespace) -> int:
                 body["action_project"] = detected
     if args.description:
         body["description"] = args.description
+    if args.on_success:
+        parsed, err = _parse_chain_action(args.on_success, "--on-success")
+        if err:
+            print(f"Error: {err}", file=sys.stderr)
+            return 1
+        if "on_success" not in parsed:
+            warn(
+                '--on-success does not set its own "on_success" key — under the '
+                "engine's shallow merge, the chained run will inherit THIS schedule's "
+                "on_success and may re-fire again at the next chain depth. Add "
+                '"on_success": null to the JSON to stop the chain here.'
+            )
+        body["on_success"] = parsed
+    if args.on_fail:
+        parsed, err = _parse_chain_action(args.on_fail, "--on-fail")
+        if err:
+            print(f"Error: {err}", file=sys.stderr)
+            return 1
+        if "on_fail" not in parsed:
+            warn(
+                '--on-fail does not set its own "on_fail" key — under the engine\'s '
+                "shallow merge, the chained run will inherit THIS schedule's on_fail "
+                'and may re-fire again at the next chain depth. Add "on_fail": null '
+                "to the JSON to stop the chain here."
+            )
+        body["on_fail"] = parsed
     result = _api("/", method="POST", body=body)
     if result is None:
         return 1
@@ -675,6 +727,33 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> None:
     )
     create_p.add_argument("--project", help="Project name.")
     create_p.add_argument("--description", help="Human-readable description.")
+    create_p.add_argument(
+        "--on-success",
+        dest="on_success",
+        metavar="JSON",
+        help=(
+            "Chain action to fire when this run exits 0, as a JSON object "
+            "(allowed keys: kind/action_kind, model, prompt, agent, playbook, "
+            "on_success, on_fail). WARNING — shallow merge: the chain child is "
+            "built as {**this_schedule, **on_success}, so any key you omit is "
+            "INHERITED from this schedule, including on_success/on_fail "
+            "themselves. A 2-level chain must set the inner level's own "
+            '"on_success": null explicitly, or the chain keeps re-firing at '
+            "each depth (capped, but rarely what you want). Example: "
+            '--on-success \'{"prompt": "notify done", "on_success": null}\'.'
+        ),
+    )
+    create_p.add_argument(
+        "--on-fail",
+        dest="on_fail",
+        metavar="JSON",
+        help=(
+            "Chain action to fire when this run exits non-zero, as a JSON "
+            "object (same allowed keys and shallow-merge caveat as "
+            "--on-success — see above). Example: --on-fail "
+            '\'{"prompt": "alert on-call", "on_fail": null}\'.'
+        ),
+    )
 
     # enable / disable / trigger / delete
     for sub_name, sub_help in (

--- a/tests/cli/test_schedule_cli.py
+++ b/tests/cli/test_schedule_cli.py
@@ -239,3 +239,202 @@ def test_schedule_create_auto_detect_exception_silently_skipped(monkeypatch):
 
     assert outcome["result"] == 0
     assert "action_project" not in outcome["body"]
+
+
+# ---------------------------------------------------------------------------
+# _cmd_create: --on-success / --on-fail chain flags
+# ---------------------------------------------------------------------------
+
+
+def test_schedule_create_on_success_round_trips_to_body(monkeypatch):
+    """--on-success JSON parses and lands on the posted body as a dict."""
+    outcome = _run_create(
+        monkeypatch, ["--on-success", '{"prompt": "notify done", "on_success": null}']
+    )
+
+    assert outcome["result"] == 0
+    assert outcome["body"]["on_success"] == {"prompt": "notify done", "on_success": None}
+
+
+def test_schedule_create_on_fail_round_trips_to_body(monkeypatch):
+    """--on-fail JSON parses and lands on the posted body as a dict."""
+    outcome = _run_create(
+        monkeypatch, ["--on-fail", '{"prompt": "alert on-call", "on_fail": null}']
+    )
+
+    assert outcome["result"] == 0
+    assert outcome["body"]["on_fail"] == {"prompt": "alert on-call", "on_fail": None}
+
+
+def test_schedule_create_on_success_and_on_fail_together(monkeypatch):
+    """Both chain flags can be set on the same create call."""
+    outcome = _run_create(
+        monkeypatch,
+        [
+            "--on-success",
+            '{"agent": "notifier", "on_success": null}',
+            "--on-fail",
+            '{"agent": "pager", "on_fail": null}',
+        ],
+    )
+
+    assert outcome["result"] == 0
+    assert outcome["body"]["on_success"] == {"agent": "notifier", "on_success": None}
+    assert outcome["body"]["on_fail"] == {"agent": "pager", "on_fail": None}
+
+
+def test_schedule_create_on_success_malformed_json_errors_cleanly(monkeypatch, capsys):
+    """Malformed --on-success JSON returns 1 with a clear stderr message, no API call."""
+    api_called = []
+    import lionagi.studio.cli as sched_mod
+
+    monkeypatch.setattr(sched_mod, "_api", lambda *a, **kw: api_called.append(1))
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(
+        ["schedule", "create", "my-sched", "--cron", "0 * * * *", "--on-success", "{not json"]
+    )
+    result = run_schedule(args)
+
+    assert result == 1
+    assert api_called == []
+    captured = capsys.readouterr()
+    assert "--on-success" in captured.err
+    assert "invalid JSON" in captured.err
+
+
+def test_schedule_create_on_fail_malformed_json_errors_cleanly(monkeypatch, capsys):
+    """Malformed --on-fail JSON returns 1 with a clear stderr message, no API call."""
+    api_called = []
+    import lionagi.studio.cli as sched_mod
+
+    monkeypatch.setattr(sched_mod, "_api", lambda *a, **kw: api_called.append(1))
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(
+        ["schedule", "create", "my-sched", "--cron", "0 * * * *", "--on-fail", "[1, 2"]
+    )
+    result = run_schedule(args)
+
+    assert result == 1
+    assert api_called == []
+    captured = capsys.readouterr()
+    assert "--on-fail" in captured.err
+    assert "invalid JSON" in captured.err
+
+
+def test_schedule_create_on_success_non_object_json_rejected(monkeypatch, capsys):
+    """--on-success must be a JSON object, not e.g. a bare list or string."""
+    import lionagi.studio.cli as sched_mod
+
+    monkeypatch.setattr(sched_mod, "_api", lambda *a, **kw: (_ for _ in ()).throw(AssertionError))
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(
+        ["schedule", "create", "my-sched", "--cron", "0 * * * *", "--on-success", "[1, 2, 3]"]
+    )
+    result = run_schedule(args)
+
+    assert result == 1
+    captured = capsys.readouterr()
+    assert "must be a JSON object" in captured.err
+
+
+def test_schedule_create_on_success_unknown_key_rejected(monkeypatch, capsys):
+    """A chain_action key the engine's merge doesn't understand is rejected up front,
+    since it would otherwise silently clobber an unrelated schedule column via the
+    shallow merge in scheduler/engine.py."""
+    import lionagi.studio.cli as sched_mod
+
+    monkeypatch.setattr(sched_mod, "_api", lambda *a, **kw: (_ for _ in ()).throw(AssertionError))
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(
+        [
+            "schedule",
+            "create",
+            "my-sched",
+            "--cron",
+            "0 * * * *",
+            "--on-success",
+            '{"trigger_type": "interval"}',
+        ]
+    )
+    result = run_schedule(args)
+
+    assert result == 1
+    captured = capsys.readouterr()
+    assert "unknown key" in captured.err
+    assert "trigger_type" in captured.err
+
+
+def test_schedule_create_on_success_missing_explicit_key_warns(monkeypatch):
+    """A nested chain_action that omits its own on_success key triggers the
+    re-fire warning (shallow-merge inheritance gotcha)."""
+    import lionagi.studio.cli as sched_mod
+
+    warnings: list[str] = []
+    monkeypatch.setattr(sched_mod, "warn", warnings.append)
+
+    outcome = _run_create(monkeypatch, ["--on-success", '{"prompt": "notify done"}'])
+
+    assert outcome["result"] == 0
+    assert len(warnings) == 1
+    assert "on_success" in warnings[0]
+    assert "re-fire" in warnings[0]
+
+
+def test_schedule_create_on_fail_missing_explicit_key_warns(monkeypatch):
+    """A nested chain_action that omits its own on_fail key triggers the
+    re-fire warning (shallow-merge inheritance gotcha)."""
+    import lionagi.studio.cli as sched_mod
+
+    warnings: list[str] = []
+    monkeypatch.setattr(sched_mod, "warn", warnings.append)
+
+    outcome = _run_create(monkeypatch, ["--on-fail", '{"prompt": "alert on-call"}'])
+
+    assert outcome["result"] == 0
+    assert len(warnings) == 1
+    assert "on_fail" in warnings[0]
+    assert "re-fire" in warnings[0]
+
+
+def test_schedule_create_on_success_explicit_null_no_warning(monkeypatch):
+    """Explicitly setting on_success: null in the chain_action suppresses the warning."""
+    import lionagi.studio.cli as sched_mod
+
+    warnings: list[str] = []
+    monkeypatch.setattr(sched_mod, "warn", warnings.append)
+
+    outcome = _run_create(
+        monkeypatch, ["--on-success", '{"prompt": "notify done", "on_success": null}']
+    )
+
+    assert outcome["result"] == 0
+    assert warnings == []
+
+
+def test_schedule_create_without_chain_flags_omits_fields(monkeypatch):
+    """No --on-success/--on-fail: neither key is posted to the API."""
+    outcome = _run_create(monkeypatch, [])
+
+    assert outcome["result"] == 0
+    assert "on_success" not in outcome["body"]
+    assert "on_fail" not in outcome["body"]

--- a/tests/cli/test_schedule_cli.py
+++ b/tests/cli/test_schedule_cli.py
@@ -438,3 +438,125 @@ def test_schedule_create_without_chain_flags_omits_fields(monkeypatch):
     assert outcome["result"] == 0
     assert "on_success" not in outcome["body"]
     assert "on_fail" not in outcome["body"]
+
+
+# ---------------------------------------------------------------------------
+# _cmd_create: nested chain_action validation (recursive)
+#
+# The engine fires a chain_action via a shallow merge (`{**schedule,
+# **chain_action}` in scheduler/engine.py), so a chain_action nested inside
+# on_success/on_fail rides the exact same merge one level deeper when its
+# parent's run completes. Validation must recurse into those nested actions,
+# not just check the top level.
+# ---------------------------------------------------------------------------
+
+
+def test_schedule_create_nested_on_success_unknown_key_rejected(monkeypatch, capsys):
+    """A nested on_success dict with a key outside the allowed set is
+    rejected, even though the top-level chain_action is clean — an unknown
+    key at any depth would otherwise clobber an unrelated schedule column
+    (e.g. trigger_type) via the engine's shallow merge one level down."""
+    import lionagi.studio.cli as sched_mod
+
+    monkeypatch.setattr(sched_mod, "_api", lambda *a, **kw: (_ for _ in ()).throw(AssertionError))
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(
+        [
+            "schedule",
+            "create",
+            "my-sched",
+            "--cron",
+            "0 * * * *",
+            "--on-success",
+            '{"prompt": "step 1", "on_success": {"trigger_type": "interval", "prompt": "step 2"}}',
+        ]
+    )
+    result = run_schedule(args)
+
+    assert result == 1
+    captured = capsys.readouterr()
+    assert "unknown key" in captured.err
+    assert "trigger_type" in captured.err
+    assert "--on-success.on_success" in captured.err
+
+
+def test_schedule_create_nested_on_success_non_dict_rejected(monkeypatch, capsys):
+    """A nested on_success value that isn't a JSON object (e.g. a list) is
+    rejected up front — left unchecked, the engine would treat it as a truthy
+    chain_action on the child's successful run and blow up on
+    `{**schedule, **chain_action}` after that child action already ran."""
+    import lionagi.studio.cli as sched_mod
+
+    monkeypatch.setattr(sched_mod, "_api", lambda *a, **kw: (_ for _ in ()).throw(AssertionError))
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(
+        [
+            "schedule",
+            "create",
+            "my-sched",
+            "--cron",
+            "0 * * * *",
+            "--on-success",
+            '{"prompt": "step 1", "on_success": [1, 2, 3]}',
+        ]
+    )
+    result = run_schedule(args)
+
+    assert result == 1
+    captured = capsys.readouterr()
+    assert "must be a JSON object" in captured.err
+    assert "--on-success.on_success" in captured.err
+
+
+def test_schedule_create_nested_chain_explicit_null_accepted_no_warning(monkeypatch):
+    """A valid 2-level chain where the innermost level explicitly nulls out
+    its own on_success is accepted with no warnings at any depth."""
+    import lionagi.studio.cli as sched_mod
+
+    warnings: list[str] = []
+    monkeypatch.setattr(sched_mod, "warn", warnings.append)
+
+    outcome = _run_create(
+        monkeypatch,
+        [
+            "--on-success",
+            '{"prompt": "step 1", "on_success": {"prompt": "step 2", "on_success": null}}',
+        ],
+    )
+
+    assert outcome["result"] == 0
+    assert warnings == []
+    assert outcome["body"]["on_success"] == {
+        "prompt": "step 1",
+        "on_success": {"prompt": "step 2", "on_success": None},
+    }
+
+
+def test_schedule_create_nested_chain_missing_on_success_warns(monkeypatch):
+    """The top level sets its own on_success (to the nested dict), so it does
+    not warn — but the nested dict itself omits its own on_success key, which
+    does trigger the re-fire warning, scoped to that nested path."""
+    import lionagi.studio.cli as sched_mod
+
+    warnings: list[str] = []
+    monkeypatch.setattr(sched_mod, "warn", warnings.append)
+
+    outcome = _run_create(
+        monkeypatch,
+        ["--on-success", '{"prompt": "step 1", "on_success": {"prompt": "step 2"}}'],
+    )
+
+    assert outcome["result"] == 0
+    assert len(warnings) == 1
+    assert "--on-success.on_success" in warnings[0]
+    assert "re-fire" in warnings[0]


### PR DESCRIPTION
## Summary

- Adds `--on-success JSON` / `--on-fail JSON` flags to `li schedule create`. The scheduler engine (`lionagi/studio/scheduler/engine.py`) has supported chain-fire on success/failure for a while — it's already reachable via the Studio HTTP API (`CreateScheduleRequest.on_success`/`on_fail`, `dict | None`) — but the CLI never exposed it. This closes that gap.
- Validates the chain_action JSON **recursively** against the exact key set the engine's merge understands: `kind`, `action_kind`, `model`, `prompt`, `agent`, `playbook`, `on_success`, `on_fail`. Any other key is **rejected** (exit 1, clear stderr message with the exact nested path, e.g. `--on-success.on_success`) because the engine fires each chain step via a *shallow* merge (`{**schedule, **chain_action}`) — an unrecognized key at any nesting depth would otherwise silently overwrite an unrelated column on the fired schedule row (`id`, `trigger_type`, `cron_expr`, ...) instead of doing nothing. Recursion tracks the engine chain_depth each nested action would actually fire at and stops once it reaches `_MAX_CHAIN_DEPTH` (imported from `scheduler/engine.py`, not hardcoded) — the same point past which the engine itself never reads a schedule's on_success/on_fail.
- Emits a **warning** (not an error) at *every nesting level* where a chain_action doesn't explicitly set its own `on_success`/`on_fail` key. Because the merge is shallow, an omitted key is inherited from the parent rather than cleared — so a chain that doesn't explicitly null out an inner level's own field will keep re-firing at the next chain depth (capped, but rarely what you want). This is a real gotcha hit live during a nested chain run.
- `--help` documents the shallow-merge semantics with a worked example (`--on-success '{"prompt": "notify done", "on_success": null}'`).

## Follow-up fix (nested validation gap)

An earlier revision only validated the *top-level* JSON object; `on_success`/`on_fail` are themselves allowed keys but their nested values passed through unchecked. Testing surfaced two accepted-but-broken inputs:

```bash
--on-success '{"prompt":"step 1","on_success":{"trigger_type":"interval","prompt":"step 2"}}'
--on-success '{"prompt":"step 1","on_success":[1,2,3]}'
```

The first smuggled an unknown key (`trigger_type`) through the nested level, which would clobber the grandchild schedule's own `trigger_type` via the engine's shallow merge. The second left a non-dict `on_success` that would pass a truthy list into `{**schedule, **chain_action}` on the child's successful run, blowing up *after* that child's action already ran. Both are now rejected up front (see test plan). `_parse_chain_action` now delegates to a recursive `_validate_chain_action_node()` that walks nested `on_success`/`on_fail` the same way the engine's own chain-fire would reach them.

## Scope notes

- No scheduler engine changes — this is CLI-surface only.
- No new subcommands. There is no `li schedule update`/`edit` subcommand in the CLI today (checked `add_schedule_subparser` in `lionagi/studio/cli.py`), so per the task scope none was added — the new flags only apply to `create`.

## Test plan

- [x] `uv run pytest tests/cli/test_schedule_cli.py -v` — **31 passed** (16 pre-existing + 15 new: top-level round-trip of `--on-success`/`--on-fail`, both flags together, malformed JSON on each flag, non-object JSON rejection, unknown-key rejection, missing-explicit-key warning on each flag, warning suppression when explicitly `null`, no-flags case, plus the 4 nested-validation cases added for the follow-up fix — nested unknown key rejected, nested non-dict rejected, valid multi-level chain with innermost explicit `null` accepted with no warnings, and a nested level omitting its own `on_success` warning at the correct path).
- [x] `uv run pytest tests/studio/ -q` — 22 passed, 2 skipped (`test_auth.py`, `test_scheduler_cwd.py` skip with "studio extra not installed" — this worktree venv lacks the `fastapi`/studio extra; pre-existing condition, unrelated to this change).
- [x] `uv run pytest tests/studio/test_scheduler_engine.py -k chain` — 3 passed.
- [x] `uv run ruff check` / `uv run ruff format --check` on both changed files — clean.
- [x] Manually exercised the live (non-mocked) path, including the two exact accepted-but-broken inputs — both now rejected with `rc=1` and an error naming the nested path (`--on-success.on_success: unknown key(s) ['trigger_type']; ...` and `--on-success.on_success: must be a JSON object, got list`). Also re-verified the top-level warning/error/help paths still work after the refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
