### PR TITLE
feat(cli): follow scheduler chains in li monitor run

### DIFF
--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -726,8 +726,23 @@ def _watch_loop(
 # live WAL-mode state.db. Separate code path from _watch_loop above — that
 # one is a human dashboard; this one blocks until specific schedule_runs go
 # terminal, then exits with a meaningful code.
+#
+# Chain-following (default on; opt out with --no-chain): the scheduler can
+# fire a child run from a terminal run's schedule on_success/on_fail (engine
+# records chain_parent_id/chain_depth on the child — see
+# lionagi/studio/scheduler/engine.py's _fire). A watched run going terminal
+# is not necessarily the end of its chain, so once it lands we extend the
+# watch frontier with any already-fired children and keep watching. A
+# schedule that declares a chain action for the outcome but whose child
+# hasn't fired yet gets a bounded grace window (_CHAIN_GRACE_TICKS poll
+# ticks) before the chain is concluded on the parent's own exit code — a
+# schedule with no matching chain action needs no grace wait at all. The
+# aggregate exit code is final-link-wins: each chain's *last* link decides,
+# not every link along the way (an on_fail recovery child that succeeds
+# means the chain as a whole succeeded).
 
 _TERMINAL_SCHEDULE_RUN_STATUSES = frozenset({"completed", "failed", "cancelled", "skipped"})
+_CHAIN_GRACE_TICKS = 2
 
 
 def _split_watched_ids(raw: list[str]) -> list[str]:
@@ -836,6 +851,111 @@ async def _poll_pending_once(
         del pending[run_id]
 
 
+async def _find_chain_children(db: Any, parent_run_id: str) -> list[dict[str, Any]]:
+    """schedule_runs the engine fired as an on_success/on_fail chain child
+    of `parent_run_id` (chain_parent_id wiring — see engine.py's _fire)."""
+    return await db.fetch_all(
+        "SELECT * FROM schedule_runs WHERE chain_parent_id = ?",
+        (parent_run_id,),
+    )
+
+
+async def _schedule_declares_chain_action(
+    db: Any,
+    schedule_id: str,
+    exit_code: int | None,
+    *,
+    cache: dict[str, dict[str, Any] | None],
+) -> bool:
+    """True if `schedule_id` declares an on_success/on_fail action matching
+    the outcome that just landed — i.e. the engine *will* attempt to fire a
+    chain child, so a grace wait for it is warranted. A schedule with no
+    matching action needs no grace wait at all."""
+    if schedule_id not in cache:
+        cache[schedule_id] = await db.get_schedule(schedule_id)
+    sched = cache[schedule_id] or {}
+    return bool(sched.get("on_success")) if exit_code == 0 else bool(sched.get("on_fail"))
+
+
+def _new_chain_state(pending: dict[str, dict[str, Any]], *, chain: bool) -> dict[str, Any]:
+    """Build the bookkeeping dict `_advance_chains` mutates tick over tick —
+    one root per originally-watched id currently in `pending`. Factored out
+    so tests can drive `_advance_chains` directly the same way they drive
+    `_poll_pending_once`, without duplicating its internal shape."""
+    return {
+        "root_of": {rid: rid for rid in pending},
+        "chain_tail_exit": {},
+        "awaiting_grace": {},
+        "resolved_roots": set(),
+        "schedule_cache": {},
+        "chain": chain,
+    }
+
+
+async def _advance_chains(
+    db: Any,
+    pending: dict[str, dict[str, Any]],
+    done: list[dict[str, Any]],
+    *,
+    chain_state: dict[str, Any],
+    processed: int,
+) -> int:
+    """Fold the newly-terminal tail of `done` (index `processed` onward)
+    into chain bookkeeping: extend `pending` with any already-fired
+    children, resolve roots whose schedule has no matching chain action
+    immediately, and start/advance a grace countdown for roots that do
+    declare one but whose child hasn't fired yet. Returns the new
+    `processed` index.
+
+    Mutates `pending` in place exactly like `_poll_pending_once` mutates
+    `done` — so a caller (the real dispatch loop, or a test) can drive this
+    function tick-by-tick with direct DB mutations in between, no real
+    sleeping required, the same way `_poll_pending_once` is tested above.
+
+    `chain_state` keys: root_of (run_id -> originally-watched root id),
+    chain_tail_exit (root id -> most recent terminal exit_code seen for
+    that chain), awaiting_grace (run_id -> {root, ticks_left}),
+    resolved_roots (root ids whose chain has concluded), schedule_cache
+    (memoized `db.get_schedule` lookups), chain (bool — chain-following
+    on/off; when off, every terminal row resolves its root immediately,
+    matching --no-chain's "watch only the literal ids given").
+    """
+    root_of = chain_state["root_of"]
+    chain_tail_exit = chain_state["chain_tail_exit"]
+    awaiting_grace = chain_state["awaiting_grace"]
+    resolved_roots = chain_state["resolved_roots"]
+    schedule_cache = chain_state["schedule_cache"]
+    chain = chain_state["chain"]
+
+    for row in done[processed:]:
+        root = root_of.get(row["id"], row["id"])
+        chain_tail_exit[root] = row.get("exit_code")
+        if chain and await _schedule_declares_chain_action(
+            db, row["schedule_id"], row.get("exit_code"), cache=schedule_cache
+        ):
+            awaiting_grace[row["id"]] = {"root": root, "ticks_left": _CHAIN_GRACE_TICKS}
+        else:
+            resolved_roots.add(root)
+    processed = len(done)
+
+    if chain:
+        for parent_id in list(awaiting_grace):
+            info = awaiting_grace[parent_id]
+            children = await _find_chain_children(db, parent_id)
+            if children:
+                for child in children:
+                    root_of[child["id"]] = info["root"]
+                    pending[child["id"]] = child
+                del awaiting_grace[parent_id]
+                continue
+            info["ticks_left"] -= 1
+            if info["ticks_left"] <= 0:
+                resolved_roots.add(info["root"])
+                del awaiting_grace[parent_id]
+
+    return processed
+
+
 async def _query_schedule_runs_since(db: Any, baseline: float) -> list[dict[str, Any]]:
     """--follow discovery query: schedule_runs created strictly after
     `baseline`, oldest first. Strict '>' (not '>=') is the same
@@ -849,11 +969,19 @@ async def _query_schedule_runs_since(db: Any, baseline: float) -> list[dict[str,
     )
 
 
-def _dispatch_wait(ids: list[str], *, interval: float, follow: bool) -> int:
+def _dispatch_wait(ids: list[str], *, interval: float, follow: bool, chain: bool = True) -> int:
     """Block until every id in `ids` reaches a terminal schedule_run status,
     printing one line per run the moment it lands; with --follow, keep
     watching (tail -f style) for newly created runs after the initial set
     drains, exiting only on SIGINT/SIGTERM.
+
+    Chain-following (default on; `chain=False` for --no-chain): a watched
+    run going terminal extends the watch frontier with any scheduler
+    on_success/on_fail chain children (see module comment above
+    _TERMINAL_SCHEDULE_RUN_STATUSES and _advance_chains). The aggregate exit
+    code is final-link-wins per chain, not every link along the way — with
+    chain-following off, that collapses back to the original one-run-one-
+    link behavior.
 
     Shaped like _watch_loop above (own signal handlers on the main thread,
     run_async per discrete tick, chunked time.sleep for cadence) rather
@@ -927,26 +1055,40 @@ def _dispatch_wait(ids: list[str], *, interval: float, follow: bool) -> int:
 
     total_watched = len(pending)
     done: list[dict[str, Any]] = []
+    chain_state = _new_chain_state(pending, chain=chain)
+    processed = 0
 
     async def _tick() -> None:
+        nonlocal processed
         async with StateDB() as db:
             await _poll_pending_once(db, pending, schedule_names, done)
+            processed = await _advance_chains(
+                db, pending, done, chain_state=chain_state, processed=processed
+            )
 
-    while pending and not interrupted:
+    def _chain_open() -> bool:
+        return bool(pending or chain_state["awaiting_grace"])
+
+    while _chain_open() and not interrupted:
         _run_tick(_tick())
-        if not pending or interrupted:
+        if not _chain_open() or interrupted:
             break
         _sleep_interval(interval)
 
+    resolved_roots = chain_state["resolved_roots"]
+    chain_tail_exit = chain_state["chain_tail_exit"]
     if unresolved:
         exit_code = EXIT_UNKNOWN
-    elif len(done) < total_watched:
-        # Some watched run never reached a terminal status before we had to
-        # stop — whether that row was ever printed is irrelevant; `done`
-        # (mutated in _poll_pending_once, see above) is the one ground truth
-        # that survives a tick being interrupted mid-flight.
+    elif len(resolved_roots) < total_watched:
+        # Some watched chain never concluded before we had to stop — either
+        # still pending outright or still inside its grace window. `done`
+        # (mutated in _poll_pending_once) and `chain_state` (mutated in
+        # _advance_chains, see above) are the ground truth that survives a
+        # tick being interrupted mid-flight.
         exit_code = EXIT_RUNNING
-    elif all(r.get("exit_code") == 0 for r in done):
+    elif all(chain_tail_exit.get(root) == 0 for root in resolved_roots):
+        # Final-link-wins: each resolved chain's most recently seen terminal
+        # exit_code decides, not every link along the way.
         exit_code = 0
     else:
         exit_code = 1
@@ -982,7 +1124,8 @@ def _dispatch_wait(ids: list[str], *, interval: float, follow: bool) -> int:
 
 
 def run_monitor_wait(argv: list[str]) -> int:
-    """Entry point for `li monitor run <id> [<id2> ...] [--interval SECS] [--follow]`."""
+    """Entry point for `li monitor run <id> [<id2> ...] [--interval SECS]
+    [--follow] [--no-chain]`."""
     parser = argparse.ArgumentParser(prog="li monitor run", add_help=True)
     parser.add_argument(
         "ids",
@@ -1001,6 +1144,18 @@ def run_monitor_wait(argv: list[str]) -> int:
         action="store_true",
         help="Keep watching for new schedule_runs after the initial set drains.",
     )
+    parser.add_argument(
+        "--no-chain",
+        dest="chain",
+        action="store_false",
+        default=True,
+        help=(
+            "Watch only the literal id(s) given. By default a watched run "
+            "going terminal follows any scheduler on_success/on_fail chain "
+            "child the engine fires for it, so the wait tracks the chain to "
+            "its final link instead of exiting on the first terminal run."
+        ),
+    )
     args = parser.parse_args(argv)
     watched_ids = _split_watched_ids(args.ids)
     if not watched_ids:
@@ -1008,7 +1163,7 @@ def run_monitor_wait(argv: list[str]) -> int:
         # of them survive comma-splitting (e.g. a lone "," or ""). Without
         # this check that degenerates into a silent, instant, exit-0 no-op.
         parser.error("no schedule_run ids given (only empty/comma-only tokens)")
-    return _dispatch_wait(watched_ids, interval=args.interval, follow=args.follow)
+    return _dispatch_wait(watched_ids, interval=args.interval, follow=args.follow, chain=args.chain)
 
 
 # ── CLI registration ──────────────────────────────────────────────────────────
@@ -1076,7 +1231,9 @@ def add_monitor_subparser(subparsers: argparse._SubParsersAction) -> None:
         help=(
             "Wait for one or more schedule_run IDs to reach a terminal state, "
             "then exit (scripting primitive; see `li monitor run --help` for "
-            "the positional form). Ignores id/--watch/--since/--type/--project."
+            "the positional form). Follows scheduler on_success/on_fail chain "
+            "children by default (see --no-chain). "
+            "Ignores id/--watch/--since/--type/--project."
         ),
     )
     mon.add_argument(
@@ -1090,6 +1247,16 @@ def add_monitor_subparser(subparsers: argparse._SubParsersAction) -> None:
         "--follow",
         action="store_true",
         help="With --run: keep watching for new schedule_runs after the initial set drains.",
+    )
+    mon.add_argument(
+        "--no-chain",
+        dest="chain",
+        action="store_false",
+        default=True,
+        help=(
+            "With --run: watch only the literal id(s) given, instead of "
+            "following scheduler on_success/on_fail chain children by default."
+        ),
     )
 
 
@@ -1106,7 +1273,9 @@ def run_monitor(args: argparse.Namespace) -> int:
 
             log_error("no schedule_run ids given (only empty/comma-only tokens)")
             return 2
-        return _dispatch_wait(watched_ids, interval=args.interval, follow=args.follow)
+        return _dispatch_wait(
+            watched_ids, interval=args.interval, follow=args.follow, chain=args.chain
+        )
 
     since: float | None = None
     if args.since:

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -894,6 +894,15 @@ def _new_chain_state(pending: dict[str, dict[str, Any]], *, chain: bool) -> dict
         # (printed by _poll_pending_once) — lets discovery tell an
         # already-processed child apart from one still in `pending`.
         "done_ids": set(),
+        # run id -> exit_code observed when that run was folded — unlike
+        # chain_tail_exit (keyed by root), this answers "what did run X
+        # itself exit with" for any folded run, watched root or not.
+        "exit_of": {},
+        # parent run id -> the chain child its grace window handed off to.
+        # Lets a later-discovering ancestor follow an already-processed
+        # link forward to wherever the chain currently lives instead of
+        # stopping at that link's own exit.
+        "handoff": {},
     }
 
 
@@ -928,7 +937,10 @@ async def _advance_chains(
     resolves its root immediately, matching --no-chain's "watch only the
     literal ids given"), done_ids (run ids already folded into the above
     once — lets discovery tell an already-processed child apart from one
-    still waiting in `pending`).
+    still waiting in `pending`), exit_of (run id -> its own folded
+    exit_code), handoff (parent run id -> the chain child its grace window
+    handed off to — followed forward when an ancestor discovers an
+    already-processed link, see below).
     """
     root_of = chain_state["root_of"]
     chain_tail_exit = chain_state["chain_tail_exit"]
@@ -937,9 +949,12 @@ async def _advance_chains(
     schedule_cache = chain_state["schedule_cache"]
     chain = chain_state["chain"]
     done_ids = chain_state["done_ids"]
+    exit_of = chain_state["exit_of"]
+    handoff = chain_state["handoff"]
 
     for row in done[processed:]:
         done_ids.add(row["id"])
+        exit_of[row["id"]] = row.get("exit_code")
         roots = root_of.get(row["id"]) or {row["id"]}
         for root in roots:
             chain_tail_exit[root] = row.get("exit_code")
@@ -966,28 +981,47 @@ async def _advance_chains(
                     # of overwriting, so the child's own root still resolves
                     # once the child (now the chain's tail) goes terminal.
                     root_of.setdefault(child_id, set()).update(info["roots"])
+                    handoff[parent_id] = child_id
                     if child_id in done_ids:
                         # The child already went terminal (possibly in the
                         # very same tick as its parent) and was already
                         # printed once by _poll_pending_once. Re-adding it
                         # to `pending` would print it again on the next
                         # tick, so fold the parent's root(s) into whatever
-                        # bookkeeping the child already landed in instead —
-                        # never touch `pending` for it.
-                        child_exit = chain_tail_exit.get(child_id)
-                        for root in info["roots"]:
-                            chain_tail_exit[root] = child_exit
-                        if child_id in awaiting_grace:
-                            # The child's own schedule also declares a
-                            # matching chain action — join its still-open
-                            # grace window rather than spinning up separate
-                            # bookkeeping for the same run.
-                            awaiting_grace[child_id]["roots"].update(info["roots"])
+                        # bookkeeping the chain currently lives in instead —
+                        # never touch `pending` for an already-printed run.
+                        # The child's own grace window may itself have
+                        # already handed off to a deeper link, so follow the
+                        # handoff trail to the chain's current carrier
+                        # first; stopping at this child would resolve the
+                        # parent's root(s) with an intermediate exit code
+                        # instead of the final link's.
+                        carrier = child_id
+                        seen = {carrier}
+                        while carrier in handoff and handoff[carrier] not in seen:
+                            carrier = handoff[carrier]
+                            seen.add(carrier)
+                        if carrier not in done_ids:
+                            # The chain's tail is a still-live descendant in
+                            # `pending` — the parent's root(s) ride on it and
+                            # resolve when it goes terminal, like any other
+                            # handed-off root.
+                            root_of.setdefault(carrier, set()).update(info["roots"])
                         else:
-                            # The child already resolved outright (no
-                            # matching chain action of its own) — the
-                            # parent's root(s) resolve right along with it.
-                            resolved_roots.update(info["roots"])
+                            carrier_exit = exit_of.get(carrier)
+                            for root in info["roots"]:
+                                chain_tail_exit[root] = carrier_exit
+                            if carrier in awaiting_grace:
+                                # The carrier's own schedule also declares a
+                                # matching chain action — join its still-open
+                                # grace window rather than spinning up
+                                # separate bookkeeping for the same run.
+                                awaiting_grace[carrier]["roots"].update(info["roots"])
+                            else:
+                                # The carrier resolved outright (no matching
+                                # chain action of its own) — the parent's
+                                # root(s) resolve right along with it.
+                                resolved_roots.update(info["roots"])
                     else:
                         pending[child_id] = child
                 del awaiting_grace[parent_id]

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -890,6 +890,10 @@ def _new_chain_state(pending: dict[str, dict[str, Any]], *, chain: bool) -> dict
         "resolved_roots": set(),
         "schedule_cache": {},
         "chain": chain,
+        # run ids that have already gone terminal and been folded once below
+        # (printed by _poll_pending_once) — lets discovery tell an
+        # already-processed child apart from one still in `pending`.
+        "done_ids": set(),
     }
 
 
@@ -922,7 +926,9 @@ async def _advance_chains(
     has concluded), schedule_cache (memoized `db.get_schedule` lookups),
     chain (bool — chain-following on/off; when off, every terminal row
     resolves its root immediately, matching --no-chain's "watch only the
-    literal ids given").
+    literal ids given"), done_ids (run ids already folded into the above
+    once — lets discovery tell an already-processed child apart from one
+    still waiting in `pending`).
     """
     root_of = chain_state["root_of"]
     chain_tail_exit = chain_state["chain_tail_exit"]
@@ -930,8 +936,10 @@ async def _advance_chains(
     resolved_roots = chain_state["resolved_roots"]
     schedule_cache = chain_state["schedule_cache"]
     chain = chain_state["chain"]
+    done_ids = chain_state["done_ids"]
 
     for row in done[processed:]:
+        done_ids.add(row["id"])
         roots = root_of.get(row["id"]) or {row["id"]}
         for root in roots:
             chain_tail_exit[root] = row.get("exit_code")
@@ -949,6 +957,7 @@ async def _advance_chains(
             children = await _find_chain_children(db, parent_id)
             if children:
                 for child in children:
+                    child_id = child["id"]
                     # A discovered child can itself already own a root — it
                     # may be a directly-watched id in an overlapping watch
                     # set (e.g. `li monitor run parent child` where child is
@@ -956,8 +965,31 @@ async def _advance_chains(
                     # root(s) into whatever the child already owns instead
                     # of overwriting, so the child's own root still resolves
                     # once the child (now the chain's tail) goes terminal.
-                    root_of.setdefault(child["id"], set()).update(info["roots"])
-                    pending[child["id"]] = child
+                    root_of.setdefault(child_id, set()).update(info["roots"])
+                    if child_id in done_ids:
+                        # The child already went terminal (possibly in the
+                        # very same tick as its parent) and was already
+                        # printed once by _poll_pending_once. Re-adding it
+                        # to `pending` would print it again on the next
+                        # tick, so fold the parent's root(s) into whatever
+                        # bookkeeping the child already landed in instead —
+                        # never touch `pending` for it.
+                        child_exit = chain_tail_exit.get(child_id)
+                        for root in info["roots"]:
+                            chain_tail_exit[root] = child_exit
+                        if child_id in awaiting_grace:
+                            # The child's own schedule also declares a
+                            # matching chain action — join its still-open
+                            # grace window rather than spinning up separate
+                            # bookkeeping for the same run.
+                            awaiting_grace[child_id]["roots"].update(info["roots"])
+                        else:
+                            # The child already resolved outright (no
+                            # matching chain action of its own) — the
+                            # parent's root(s) resolve right along with it.
+                            resolved_roots.update(info["roots"])
+                    else:
+                        pending[child_id] = child
                 del awaiting_grace[parent_id]
                 continue
             info["ticks_left"] -= 1

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -879,11 +879,12 @@ async def _schedule_declares_chain_action(
 
 def _new_chain_state(pending: dict[str, dict[str, Any]], *, chain: bool) -> dict[str, Any]:
     """Build the bookkeeping dict `_advance_chains` mutates tick over tick —
-    one root per originally-watched id currently in `pending`. Factored out
-    so tests can drive `_advance_chains` directly the same way they drive
-    `_poll_pending_once`, without duplicating its internal shape."""
+    each originally-watched id in `pending` starts out owning itself as its
+    own root. Factored out so tests can drive `_advance_chains` directly the
+    same way they drive `_poll_pending_once`, without duplicating its
+    internal shape."""
     return {
-        "root_of": {rid: rid for rid in pending},
+        "root_of": {rid: {rid} for rid in pending},
         "chain_tail_exit": {},
         "awaiting_grace": {},
         "resolved_roots": set(),
@@ -912,13 +913,16 @@ async def _advance_chains(
     function tick-by-tick with direct DB mutations in between, no real
     sleeping required, the same way `_poll_pending_once` is tested above.
 
-    `chain_state` keys: root_of (run_id -> originally-watched root id),
-    chain_tail_exit (root id -> most recent terminal exit_code seen for
-    that chain), awaiting_grace (run_id -> {root, ticks_left}),
-    resolved_roots (root ids whose chain has concluded), schedule_cache
-    (memoized `db.get_schedule` lookups), chain (bool — chain-following
-    on/off; when off, every terminal row resolves its root immediately,
-    matching --no-chain's "watch only the literal ids given").
+    `chain_state` keys: root_of (run_id -> set of originally-watched roots
+    that run currently accounts for — a run can own more than one root when
+    an overlapping watch set passes both a run and one of its own chain
+    descendants as separate roots, see below), chain_tail_exit (root id ->
+    most recent terminal exit_code seen for that chain), awaiting_grace
+    (run_id -> {roots, ticks_left}), resolved_roots (root ids whose chain
+    has concluded), schedule_cache (memoized `db.get_schedule` lookups),
+    chain (bool — chain-following on/off; when off, every terminal row
+    resolves its root immediately, matching --no-chain's "watch only the
+    literal ids given").
     """
     root_of = chain_state["root_of"]
     chain_tail_exit = chain_state["chain_tail_exit"]
@@ -928,14 +932,15 @@ async def _advance_chains(
     chain = chain_state["chain"]
 
     for row in done[processed:]:
-        root = root_of.get(row["id"], row["id"])
-        chain_tail_exit[root] = row.get("exit_code")
+        roots = root_of.get(row["id"]) or {row["id"]}
+        for root in roots:
+            chain_tail_exit[root] = row.get("exit_code")
         if chain and await _schedule_declares_chain_action(
             db, row["schedule_id"], row.get("exit_code"), cache=schedule_cache
         ):
-            awaiting_grace[row["id"]] = {"root": root, "ticks_left": _CHAIN_GRACE_TICKS}
+            awaiting_grace[row["id"]] = {"roots": set(roots), "ticks_left": _CHAIN_GRACE_TICKS}
         else:
-            resolved_roots.add(root)
+            resolved_roots.update(roots)
     processed = len(done)
 
     if chain:
@@ -944,13 +949,20 @@ async def _advance_chains(
             children = await _find_chain_children(db, parent_id)
             if children:
                 for child in children:
-                    root_of[child["id"]] = info["root"]
+                    # A discovered child can itself already own a root — it
+                    # may be a directly-watched id in an overlapping watch
+                    # set (e.g. `li monitor run parent child` where child is
+                    # parent's own chain_parent_id link). Union the parent's
+                    # root(s) into whatever the child already owns instead
+                    # of overwriting, so the child's own root still resolves
+                    # once the child (now the chain's tail) goes terminal.
+                    root_of.setdefault(child["id"], set()).update(info["roots"])
                     pending[child["id"]] = child
                 del awaiting_grace[parent_id]
                 continue
             info["ticks_left"] -= 1
             if info["ticks_left"] <= 0:
-                resolved_roots.add(info["root"])
+                resolved_roots.update(info["roots"])
                 del awaiting_grace[parent_id]
 
     return processed

--- a/tests/cli/test_monitor_run.py
+++ b/tests/cli/test_monitor_run.py
@@ -874,6 +874,49 @@ async def test_dispatch_wait_child_already_terminal_joins_own_grace_prints_once(
     assert out.count(child_id) == 1
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("descendant_first", [False, True])
+async def test_dispatch_wait_deep_chain_follows_handoff_past_terminal_child(
+    temp_db_path: Path, capsys: pytest.CaptureFixture, descendant_first: bool
+) -> None:
+    """Regression: a three-link chain (parent failed -> child failed ->
+    grandchild succeeded), all terminal before the wait starts, watched via
+    both the parent AND the child as overlapping roots. When the child is
+    listed first, its grace window discovers the grandchild and hands its
+    root off BEFORE the parent's grace window discovers the child — so the
+    parent's discovery finds an already-processed child that is no longer
+    in awaiting_grace. It must follow the child's handoff forward to the
+    grandchild (the chain's real tail) instead of resolving the parent's
+    root on the child's intermediate failure: final-link-wins means this
+    recovered chain reports success in both watch orders, each run printed
+    exactly once."""
+    async with StateDB() as db:
+        parent_sched = await _make_schedule(db, name="parent-sched", on_fail={"kind": "agent"})
+        parent_id = await _make_schedule_run(db, parent_sched, status="failed", exit_code=1)
+        child_sched = await _make_schedule(db, name="child-sched", on_fail={"kind": "agent"})
+        child_id = await _make_schedule_run(
+            db, child_sched, status="failed", exit_code=1, chain_depth=1, chain_parent_id=parent_id
+        )
+        grand_sched = await _make_schedule(db, name="grandchild-sched")
+        grandchild_id = await _make_schedule_run(
+            db,
+            grand_sched,
+            status="completed",
+            exit_code=0,
+            chain_depth=2,
+            chain_parent_id=child_id,
+        )
+
+    roots = [child_id, parent_id] if descendant_first else [parent_id, child_id]
+    exit_code = _dispatch_wait(roots, interval=0.02, follow=False)
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert out.count(parent_id) == 1
+    assert out.count(child_id) == 1
+    assert out.count(grandchild_id) == 1
+
+
 # ── _query_schedule_runs_since (the --follow baseline boundary, deterministic) ──
 
 

--- a/tests/cli/test_monitor_run.py
+++ b/tests/cli/test_monitor_run.py
@@ -737,6 +737,85 @@ async def test_dispatch_wait_no_chain_ignores_fired_children(
     assert child_id not in out
 
 
+@pytest.mark.asyncio
+async def test_dispatch_wait_overlapping_roots_child_watched_directly_succeeds(
+    temp_db_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """Regression: a parent AND its already-linked chain child are both
+    passed as initial watch roots (e.g. from comma/list expansion). The
+    parent is terminal from the start, which starts a grace window that
+    discovers the child via chain_parent_id -- but the child is *also* one
+    of the originally-watched roots, and is still running at that moment.
+    The discovery must not clobber the child's own root ownership: once the
+    child later completes on its own, both the parent's root (resolved via
+    the child as its final link) and the child's own root must resolve, not
+    just the parent's."""
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db, name="chained", on_success={"kind": "agent"})
+        parent_id = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
+        child_id = await _make_schedule_run(
+            db, sched_id, status="running", chain_depth=1, chain_parent_id=parent_id
+        )
+
+    def _flip_child_to_completed() -> None:
+        import asyncio
+
+        async def _go() -> None:
+            async with StateDB() as db2:
+                await _set_fields(db2, "schedule_runs", child_id, status="completed", exit_code=0)
+
+        time.sleep(0.2)
+        asyncio.run(_go())
+
+    t = threading.Thread(target=_flip_child_to_completed, daemon=True)
+    t.start()
+
+    exit_code = _dispatch_wait([parent_id, child_id], interval=0.05, follow=False)
+    t.join(timeout=5)
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert out.count(parent_id) == 1
+    assert out.count(child_id) == 1
+
+
+@pytest.mark.asyncio
+async def test_dispatch_wait_overlapping_roots_child_watched_directly_fails(
+    temp_db_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """Failure-side variant of the overlapping-roots regression above: the
+    child (also a directly-watched root) completes with a nonzero exit code
+    -- the aggregate must report failure (1), not fall back to EXIT_RUNNING
+    because the child's own root never resolved."""
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db, name="chained", on_success={"kind": "agent"})
+        parent_id = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
+        child_id = await _make_schedule_run(
+            db, sched_id, status="running", chain_depth=1, chain_parent_id=parent_id
+        )
+
+    def _flip_child_to_failed() -> None:
+        import asyncio
+
+        async def _go() -> None:
+            async with StateDB() as db2:
+                await _set_fields(db2, "schedule_runs", child_id, status="failed", exit_code=1)
+
+        time.sleep(0.2)
+        asyncio.run(_go())
+
+    t = threading.Thread(target=_flip_child_to_failed, daemon=True)
+    t.start()
+
+    exit_code = _dispatch_wait([parent_id, child_id], interval=0.05, follow=False)
+    t.join(timeout=5)
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert out.count(parent_id) == 1
+    assert out.count(child_id) == 1
+
+
 # ── _query_schedule_runs_since (the --follow baseline boundary, deterministic) ──
 
 

--- a/tests/cli/test_monitor_run.py
+++ b/tests/cli/test_monitor_run.py
@@ -18,8 +18,10 @@ from typing import Any
 import pytest
 
 from lionagi.cli.monitor import (
+    _advance_chains,
     _dispatch_wait,
     _format_wait_line,
+    _new_chain_state,
     _poll_pending_once,
     _query_schedule_runs_since,
     _resolve_schedule_run,
@@ -41,7 +43,13 @@ def temp_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return db_path
 
 
-async def _make_schedule(db: StateDB, *, name: str | None = None) -> str:
+async def _make_schedule(
+    db: StateDB,
+    *,
+    name: str | None = None,
+    on_success: dict[str, Any] | None = None,
+    on_fail: dict[str, Any] | None = None,
+) -> str:
     sid = uuid.uuid4().hex[:12]
     await db.create_schedule(
         {
@@ -50,6 +58,8 @@ async def _make_schedule(db: StateDB, *, name: str | None = None) -> str:
             "trigger_type": "interval",
             "interval_sec": 60,
             "action_kind": "agent",
+            "on_success": on_success,
+            "on_fail": on_fail,
         }
     )
     return sid
@@ -62,6 +72,7 @@ async def _make_schedule_run(
     status: str = "running",
     exit_code: int | None = None,
     chain_depth: int = 0,
+    chain_parent_id: str | None = None,
 ) -> str:
     rid = uuid.uuid4().hex[:12]
     await db.create_schedule_run(
@@ -74,6 +85,7 @@ async def _make_schedule_run(
             "status": status,
             "exit_code": exit_code,
             "chain_depth": chain_depth,
+            "chain_parent_id": chain_parent_id,
             "fired_at": time.time(),
         }
     )
@@ -245,6 +257,180 @@ async def test_poll_pending_once_row_vanished_mid_wait_resolves_as_failure(
     assert len(done) == 1
     assert done[0]["exit_code"] is None
     assert "disappeared" in caplog.text.lower()
+
+
+# ── _advance_chains (the testable chain-follow tick — no real sleeps needed) ─
+#
+# Mirrors _poll_pending_once's testing style: direct calls with DB mutations
+# in between, driving the exact same pending/done/chain_state a real
+# `_dispatch_wait` tick would, but deterministically and with zero wall-clock
+# waiting for the grace window itself.
+
+
+async def _chain_tick(
+    db: StateDB,
+    pending: dict[str, Any],
+    done: list[dict[str, Any]],
+    chain_state: dict[str, Any],
+    processed: int,
+) -> int:
+    """One `_dispatch_wait` tick's worth of work: poll pending runs, then
+    fold newly-terminal rows into chain bookkeeping — exactly the order
+    `_dispatch_wait`'s own `_tick()` closure uses."""
+    await _poll_pending_once(db, pending, {}, done)
+    return await _advance_chains(db, pending, done, chain_state=chain_state, processed=processed)
+
+
+@pytest.mark.asyncio
+async def test_advance_chains_extends_frontier_and_child_exit_code_decides(
+    temp_db_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """(a) parent terminal + child fires within the grace window -> the
+    frontier extends to the child, and the chain concludes on the child's
+    own exit code (not the parent's, even though the parent succeeded)."""
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db, name="parent-sched", on_success={"kind": "agent"})
+        parent_id = await _make_schedule_run(db, sched_id, status="running")
+        pending = {parent_id: await db.get_schedule_run(parent_id)}
+        done: list[dict[str, Any]] = []
+        chain_state = _new_chain_state(pending, chain=True)
+        processed = 0
+
+        # tick 1: parent still running -- nothing to do yet
+        processed = await _chain_tick(db, pending, done, chain_state, processed)
+        assert done == []
+        assert chain_state["resolved_roots"] == set()
+
+        # parent goes terminal (success); on_success is declared -> grace starts
+        await _set_fields(db, "schedule_runs", parent_id, status="completed", exit_code=0)
+        processed = await _chain_tick(db, pending, done, chain_state, processed)
+        assert parent_id not in pending
+        assert parent_id in chain_state["awaiting_grace"]
+        assert chain_state["resolved_roots"] == set()
+
+        # child fires (simulating the scheduler engine) before grace expires
+        child_id = await _make_schedule_run(
+            db, sched_id, status="running", chain_depth=1, chain_parent_id=parent_id
+        )
+        processed = await _chain_tick(db, pending, done, chain_state, processed)
+        assert child_id in pending  # frontier extended
+        assert not chain_state["awaiting_grace"]
+        assert chain_state["resolved_roots"] == set()
+
+        # child completes -- but FAILS this time: the schedule only declares
+        # on_success, so a failing child has no further chain action and
+        # the chain concludes immediately on the child's own (nonzero) exit
+        # code, proving the child -- not the successful parent -- decides.
+        await _set_fields(db, "schedule_runs", child_id, status="failed", exit_code=1)
+        processed = await _chain_tick(db, pending, done, chain_state, processed)
+
+    assert chain_state["resolved_roots"] == {parent_id}
+    assert chain_state["chain_tail_exit"][parent_id] == 1
+    out = capsys.readouterr().out
+    assert parent_id in out
+    assert child_id in out
+
+
+@pytest.mark.asyncio
+async def test_advance_chains_no_declared_action_resolves_without_grace(
+    temp_db_path: Path,
+) -> None:
+    """(c) a schedule declaring on_success only, hit by a FAILED run, has no
+    on_fail counterpart -- the root resolves immediately, no grace entry at
+    all."""
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db, name="success-only", on_success={"kind": "agent"})
+        run_id = await _make_schedule_run(db, sched_id, status="failed", exit_code=1)
+        pending = {run_id: await db.get_schedule_run(run_id)}
+        chain_state = _new_chain_state(pending, chain=True)
+
+        await _chain_tick(db, pending, [], chain_state, 0)
+
+    assert chain_state["resolved_roots"] == {run_id}
+    assert chain_state["chain_tail_exit"][run_id] == 1
+    assert not chain_state["awaiting_grace"]
+
+
+@pytest.mark.asyncio
+async def test_advance_chains_grace_expires_without_child_resolves_on_parent_exit_code(
+    temp_db_path: Path,
+) -> None:
+    """(d) a schedule declares on_success, but the child never fires within
+    the grace window -- the chain concludes on the parent's own exit code
+    rather than hanging."""
+    async with StateDB() as db:
+        sched_id = await _make_schedule(
+            db, name="declares-but-never-fires", on_success={"kind": "agent"}
+        )
+        parent_id = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
+        pending = {parent_id: await db.get_schedule_run(parent_id)}
+        done: list[dict[str, Any]] = []
+        chain_state = _new_chain_state(pending, chain=True)
+        processed = 0
+
+        processed = await _chain_tick(db, pending, done, chain_state, processed)
+        assert parent_id in chain_state["awaiting_grace"]
+        assert chain_state["resolved_roots"] == set()
+
+        # second tick, still no child anywhere -- grace expires
+        processed = await _chain_tick(db, pending, done, chain_state, processed)
+
+    assert chain_state["resolved_roots"] == {parent_id}
+    assert chain_state["chain_tail_exit"][parent_id] == 0
+    assert not chain_state["awaiting_grace"]
+
+
+@pytest.mark.asyncio
+async def test_advance_chains_multi_hop_chain_followed_to_final_link(
+    temp_db_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """(f) a retry-on-failure chain (on_fail declared, no on_success):
+    parent fails -> child1 fails -> child2 succeeds. Depth-2 chain; the
+    final link (child2) decides the aggregate, and child2's own schedule
+    has no on_success declared so it resolves immediately once it succeeds
+    (no further grace, no infinite chase)."""
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db, name="retry-on-fail", on_fail={"kind": "agent"})
+        parent_id = await _make_schedule_run(db, sched_id, status="failed", exit_code=1)
+        pending = {parent_id: await db.get_schedule_run(parent_id)}
+        done: list[dict[str, Any]] = []
+        chain_state = _new_chain_state(pending, chain=True)
+        processed = 0
+
+        # parent already terminal (failed); on_fail declared -> grace starts
+        processed = await _chain_tick(db, pending, done, chain_state, processed)
+        assert parent_id in chain_state["awaiting_grace"]
+
+        # hop 1 fires and also fails
+        child1_id = await _make_schedule_run(
+            db, sched_id, status="failed", exit_code=1, chain_depth=1, chain_parent_id=parent_id
+        )
+        processed = await _chain_tick(db, pending, done, chain_state, processed)
+        assert child1_id in pending  # discovered, not yet polled this tick
+        assert not chain_state["awaiting_grace"]
+
+        # next tick resolves child1 (already terminal) -> on_fail declared
+        # again for its own outcome -> grace starts for hop 2
+        processed = await _chain_tick(db, pending, done, chain_state, processed)
+        assert chain_state["chain_tail_exit"][parent_id] == 1
+        assert child1_id in chain_state["awaiting_grace"]
+
+        # hop 2 fires and succeeds -- final link
+        child2_id = await _make_schedule_run(
+            db, sched_id, status="completed", exit_code=0, chain_depth=2, chain_parent_id=child1_id
+        )
+        processed = await _chain_tick(db, pending, done, chain_state, processed)
+        assert child2_id in pending
+
+        processed = await _chain_tick(db, pending, done, chain_state, processed)
+
+    assert chain_state["resolved_roots"] == {parent_id}
+    assert chain_state["chain_tail_exit"][parent_id] == 0
+    assert not chain_state["awaiting_grace"]
+    out = capsys.readouterr().out
+    assert parent_id in out
+    assert child1_id in out
+    assert child2_id in out
 
 
 # ── _dispatch_wait: bounded wait, no --follow ────────────────────────────────
@@ -463,6 +649,94 @@ async def test_dispatch_wait_keyboard_interrupt_after_tick_mutates_state_still_r
     assert exit_code == 1
 
 
+# ── _dispatch_wait: chain-following (li monitor run's default; --no-chain) ──
+
+
+@pytest.mark.asyncio
+async def test_dispatch_wait_chain_follow_on_fail_recovery_final_link_wins(
+    temp_db_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """(b) a failed parent whose schedule declares on_fail, and whose
+    already-fired child succeeded, must report exit 0 -- the chain
+    recovered, and the *final* link decides, not the failed first one. Both
+    links' lines are printed."""
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db, name="flaky", on_fail={"kind": "agent"})
+        parent_id = await _make_schedule_run(db, sched_id, status="failed", exit_code=1)
+        child_id = await _make_schedule_run(
+            db, sched_id, status="completed", exit_code=0, chain_depth=1, chain_parent_id=parent_id
+        )
+
+    exit_code = _dispatch_wait([parent_id], interval=0.05, follow=False)
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert parent_id in out
+    assert child_id in out
+
+
+@pytest.mark.asyncio
+async def test_dispatch_wait_chain_follow_no_declared_action_resolves_immediately(
+    temp_db_path: Path,
+) -> None:
+    """(c) a schedule declaring on_success only, hit by a FAILED run, needs
+    no grace wait at all -- must resolve well before a full poll interval,
+    not just before some generous timeout."""
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db, name="success-only", on_success={"kind": "agent"})
+        run_id = await _make_schedule_run(db, sched_id, status="failed", exit_code=1)
+
+    started = time.monotonic()
+    exit_code = _dispatch_wait([run_id], interval=5.0, follow=False)
+    elapsed = time.monotonic() - started
+
+    assert exit_code == 1
+    assert elapsed < 2.0, "no matching chain action declared -- must not enter a grace wait"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_wait_chain_follow_grace_expiry_does_not_hang(
+    temp_db_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """(d) a schedule declares on_success but the child never fires -- the
+    wait must still conclude (on the parent's own exit code), not hang
+    forever waiting on a chain child that's never coming."""
+    async with StateDB() as db:
+        sched_id = await _make_schedule(
+            db, name="declares-but-never-fires", on_success={"kind": "agent"}
+        )
+        parent_id = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
+
+    started = time.monotonic()
+    exit_code = _dispatch_wait([parent_id], interval=0.02, follow=False)
+    elapsed = time.monotonic() - started
+
+    assert exit_code == 0
+    assert elapsed < 3.0
+    assert parent_id in capsys.readouterr().out
+
+
+@pytest.mark.asyncio
+async def test_dispatch_wait_no_chain_ignores_fired_children(
+    temp_db_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """(e) --no-chain (chain=False) watches only the literal id given, even
+    when a chain child has already fired for it."""
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db, name="chained", on_success={"kind": "agent"})
+        parent_id = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
+        child_id = await _make_schedule_run(
+            db, sched_id, status="failed", exit_code=1, chain_depth=1, chain_parent_id=parent_id
+        )
+
+    exit_code = _dispatch_wait([parent_id], interval=5.0, follow=False, chain=False)
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert parent_id in out
+    assert child_id not in out
+
+
 # ── _query_schedule_runs_since (the --follow baseline boundary, deterministic) ──
 
 
@@ -599,11 +873,45 @@ def test_add_monitor_subparser_run_flag_and_new_options():
     assert args.run_ids == "id1,id2,id3"
     assert args.interval == 3.0
     assert args.follow is False
+    assert args.chain is True  # chain-following is the default
 
-    args = parser.parse_args(["monitor", "--run", "id1", "--interval", "0.5", "--follow"])
+    args = parser.parse_args(
+        ["monitor", "--run", "id1", "--interval", "0.5", "--follow", "--no-chain"]
+    )
     assert args.run_ids == "id1"
     assert args.interval == 0.5
     assert args.follow is True
+    assert args.chain is False
+
+
+@pytest.mark.asyncio
+async def test_run_monitor_run_flag_no_chain_ignores_fired_children(
+    temp_db_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """CLI wiring: `li monitor --run <id> --no-chain` must actually thread
+    chain=False through to _dispatch_wait, not just parse the flag."""
+    import argparse
+
+    from lionagi.cli.monitor import run_monitor
+
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db, name="chained", on_success={"kind": "agent"})
+        parent_id = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
+        child_id = await _make_schedule_run(
+            db, sched_id, status="failed", exit_code=1, chain_depth=1, chain_parent_id=parent_id
+        )
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_monitor_subparser(sub)
+    args = parser.parse_args(["monitor", "--run", parent_id, "--no-chain"])
+
+    exit_code = run_monitor(args)
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert parent_id in out
+    assert child_id not in out
 
 
 def test_run_monitor_run_flag_comma_only_ids_is_usage_error(
@@ -659,6 +967,27 @@ async def test_run_monitor_wait_single_positional_id(
     exit_code = run_monitor_wait([run_id])
     assert exit_code == 0
     assert run_id in capsys.readouterr().out
+
+
+@pytest.mark.asyncio
+async def test_run_monitor_wait_no_chain_flag_ignores_fired_children(
+    temp_db_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """`li monitor run <id> --no-chain` — the positional entry point wires
+    --no-chain through to _dispatch_wait too, not just the --run flag form."""
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db, name="chained", on_success={"kind": "agent"})
+        parent_id = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
+        child_id = await _make_schedule_run(
+            db, sched_id, status="failed", exit_code=1, chain_depth=1, chain_parent_id=parent_id
+        )
+
+    exit_code = run_monitor_wait([parent_id, "--no-chain"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert parent_id in out
+    assert child_id not in out
 
 
 @pytest.mark.asyncio
@@ -734,6 +1063,7 @@ def test_cli_monitor_run_help_subprocess():
     assert result.returncode == 0
     assert "follow" in result.stdout.lower()
     assert "interval" in result.stdout.lower()
+    assert "chain" in result.stdout.lower()
 
 
 def test_cli_monitor_help_still_shows_dashboard_usage():

--- a/tests/cli/test_monitor_run.py
+++ b/tests/cli/test_monitor_run.py
@@ -816,6 +816,64 @@ async def test_dispatch_wait_overlapping_roots_child_watched_directly_fails(
     assert out.count(child_id) == 1
 
 
+@pytest.mark.asyncio
+async def test_dispatch_wait_child_already_terminal_same_tick_prints_once(
+    temp_db_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """Regression: parent AND its chain child are *both* already terminal
+    before `_dispatch_wait` even starts (no background flip needed) -- the
+    very first poll tick prints both directly, then the parent's grace-
+    window discovery finds the child via chain_parent_id. The child's own
+    schedule declares no chain action of its own, so it should already be
+    resolved outright by the time discovery reaches it -- re-adding it to
+    `pending` would make the next tick's `_poll_pending_once` print it a
+    second time."""
+    async with StateDB() as db:
+        parent_sched = await _make_schedule(db, name="parent-sched", on_success={"kind": "agent"})
+        parent_id = await _make_schedule_run(db, parent_sched, status="completed", exit_code=0)
+        child_sched = await _make_schedule(db, name="child-sched")
+        child_id = await _make_schedule_run(
+            db,
+            child_sched,
+            status="completed",
+            exit_code=0,
+            chain_depth=1,
+            chain_parent_id=parent_id,
+        )
+
+    exit_code = _dispatch_wait([parent_id, child_id], interval=0.05, follow=False)
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert out.count(parent_id) == 1
+    assert out.count(child_id) == 1
+
+
+@pytest.mark.asyncio
+async def test_dispatch_wait_child_already_terminal_joins_own_grace_prints_once(
+    temp_db_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """Variant of the above: the already-terminal child's own schedule
+    *also* declares a matching chain action (on_success), so discovery must
+    join the parent's root into the child's own `awaiting_grace` entry
+    instead of resolving it outright -- and once that grace window expires
+    (no grandchild ever fires), both roots resolve together on the child's
+    exit code, each line still printed exactly once."""
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db, name="chained", on_success={"kind": "agent"})
+        parent_id = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
+        child_id = await _make_schedule_run(
+            db, sched_id, status="completed", exit_code=0, chain_depth=1, chain_parent_id=parent_id
+        )
+
+    exit_code = _dispatch_wait([parent_id, child_id], interval=0.02, follow=False)
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert out.count(parent_id) == 1
+    assert out.count(child_id) == 1
+
+
 # ── _query_schedule_runs_since (the --follow baseline boundary, deterministic) ──
 
 


### PR DESCRIPTION
## Summary

`li monitor run <id>` watched a schedule_run reach terminal status and exited — but the scheduler engine can chain a child run from a terminal run's `on_success`/`on_fail` (`chain_parent_id`/`chain_depth` on the child row, see `lionagi/studio/scheduler/engine.py`'s `_fire`). A caller watching a chained schedule previously got exit success while the chain was still running downstream.

Chain-following is now the **default** behavior for the wait primitive; `--no-chain` opts out (watch only the literal id(s) given).

## Semantics

| Situation | Behavior |
|---|---|
| Watched run goes terminal, no matching `on_success`/`on_fail` declared for its outcome | Resolves immediately — no grace wait |
| Watched run goes terminal, schedule declares a matching chain action | Bounded, poll-tick-based grace window (a couple of ticks) waiting for the child to appear |
| Child fires within the grace window | Frontier extends to the child; watching continues on it (and its own children, recursively) |
| Grace window expires with no child | Chain concludes on **the parent's own exit code** — does not hang |
| Aggregate exit code | **Final-link-wins per chain** — each chain's last link decides, not every link along the way (an `on_fail` recovery child that succeeds means the chain as a whole succeeded) |
| `--no-chain` | Watches only the literal id(s) given; no schedule lookups, no grace wait, matches prior behavior exactly |

Every link's line is still printed as it lands (`chain_depth` already renders in `_format_wait_line`), so chain-following is visible in the output even though only the final link decides the exit code.

## Implementation

- `_find_chain_children` / `_schedule_declares_chain_action` — new small DB-query helpers.
- `_new_chain_state` / `_advance_chains` — the chain-follow bookkeeping and tick, built the same way `_poll_pending_once` is: a plain function mutating explicit state, directly callable tick-by-tick from tests with DB mutations in between (no real sleeps needed for the grace window).
- `_dispatch_wait` gained a `chain: bool = True` parameter; its loop condition and aggregate computation now key off resolved *chains* (roots) rather than resolved *runs*.
- `--no-chain` wired through both CLI entry points: `li monitor run <id> --no-chain` (positional) and `li monitor --run <id> --no-chain` (flag form).
- `_poll_pending_once`'s existing no-await print/append/delete atomicity contract is untouched — chain lookups happen in a separate function called after it within the same tick, never interleaved with that trio.

## Test plan

- [x] `uv run pytest tests/cli/test_monitor_run.py tests/cli/test_monitor.py tests/cli/test_main.py` — 119 passed
- [x] `uv run ruff check` / `uv run ruff format --check` on both touched files — clean
- [x] Red-green verified: stashing the `monitor.py` changes makes the new tests fail (ImportError on the new symbols) before re-applying
- [x] Covers: parent terminal + child fires within grace (frontier extends, child's exit code decides); failed parent + `on_fail` child recovers (exit 0, final-link-wins, both lines printed); no declared chain action for the outcome (no grace wait); declared action but child never fires (grace expires, concludes on parent's exit code, does not hang); `--no-chain` ignores already-fired children (both CLI entry points); multi-hop (depth 2) chain followed to its final link

🤖 Generated with [Claude Code](https://claude.com/claude-code)