### PR TITLE
fix(studio): tolerate /api-suffixed LIONAGI_STUDIO_URL in schedule CLI

### DIFF
--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -480,7 +480,10 @@ def _launch_vite_dev(
 
 def _base_url() -> str:
     if url := os.environ.get("LIONAGI_STUDIO_URL"):
-        return url.rstrip("/")
+        # Endpoint paths below add /api themselves; tolerate a base URL that
+        # already carries it (an older documented workaround) so requests
+        # don't hit /api/api/... and 404.
+        return url.rstrip("/").removesuffix("/api")
     host = os.environ.get("LIONAGI_STUDIO_HOST", "127.0.0.1")
     port = os.environ.get("LIONAGI_STUDIO_PORT", "8765")
     return f"http://{host}:{port}"

--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -478,12 +478,29 @@ def _launch_vite_dev(
 # --- `li schedule` — manage lionagi Studio schedules from the CLI ---
 
 
+_warned_api_suffix = False
+
+
 def _base_url() -> str:
     if url := os.environ.get("LIONAGI_STUDIO_URL"):
+        url = url.rstrip("/")
         # Endpoint paths below add /api themselves; tolerate a base URL that
         # already carries it (an older documented workaround) so requests
-        # don't hit /api/api/... and 404.
-        return url.rstrip("/").removesuffix("/api")
+        # don't hit /api/api/... and 404. Warn (once) rather than strip
+        # silently: a reverse proxy whose public prefix genuinely ends in
+        # /api needs to see why its path was rewritten.
+        if url.endswith("/api"):
+            url = url.removesuffix("/api")
+            global _warned_api_suffix
+            if not _warned_api_suffix:
+                _warned_api_suffix = True
+                warn(
+                    f"LIONAGI_STUDIO_URL ends with /api; using {url} as the Studio "
+                    "root because endpoint paths add /api themselves. If your proxy "
+                    "prefix intentionally ends in /api, point LIONAGI_STUDIO_URL at "
+                    "the Studio root instead."
+                )
+        return url
     host = os.environ.get("LIONAGI_STUDIO_HOST", "127.0.0.1")
     port = os.environ.get("LIONAGI_STUDIO_PORT", "8765")
     return f"http://{host}:{port}"

--- a/tests/cli/test_schedule_cli.py
+++ b/tests/cli/test_schedule_cli.py
@@ -159,15 +159,41 @@ def test_base_url_studio_url_takes_precedence(monkeypatch):
     ],
     ids=["api", "api-slash", "https-api"],
 )
-def test_base_url_strips_trailing_api_suffix(monkeypatch, env_url):
+def test_base_url_strips_trailing_api_suffix(monkeypatch, caplog, env_url):
     """A base URL already carrying /api must not double-prefix requests:
-    endpoint paths add /api themselves, so _base_url strips a trailing one."""
+    endpoint paths add /api themselves, so _base_url strips a trailing one
+    and warns (once) so intentional reverse-proxy layouts can diagnose it."""
+    import logging
+
+    import lionagi.studio.cli as sched_mod
+
     monkeypatch.setenv("LIONAGI_STUDIO_URL", env_url)
+    monkeypatch.setattr(sched_mod, "_warned_api_suffix", False)
 
-    from lionagi.studio.cli import _base_url
+    with caplog.at_level(logging.WARNING):
+        first = sched_mod._base_url()
+        second = sched_mod._base_url()
 
-    assert not _base_url().endswith("/api")
-    assert _base_url() == env_url.rstrip("/").removesuffix("/api")
+    assert not first.endswith("/api")
+    assert first == env_url.rstrip("/").removesuffix("/api")
+    assert second == first
+    warnings = [r for r in caplog.records if "LIONAGI_STUDIO_URL ends with /api" in r.message]
+    assert len(warnings) == 1, "strip must warn exactly once per process"
+
+
+def test_base_url_no_warning_without_api_suffix(monkeypatch, caplog):
+    """A clean root URL is returned untouched with no warning."""
+    import logging
+
+    import lionagi.studio.cli as sched_mod
+
+    monkeypatch.setenv("LIONAGI_STUDIO_URL", "https://studio.example.com")
+    monkeypatch.setattr(sched_mod, "_warned_api_suffix", False)
+
+    with caplog.at_level(logging.WARNING):
+        assert sched_mod._base_url() == "https://studio.example.com"
+
+    assert not [r for r in caplog.records if "LIONAGI_STUDIO_URL" in r.message]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_schedule_cli.py
+++ b/tests/cli/test_schedule_cli.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 import argparse
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 
 def test_schedule_subparser_registered():
     """li schedule is wired into the main parser."""
@@ -146,6 +148,26 @@ def test_base_url_studio_url_takes_precedence(monkeypatch):
     from lionagi.studio.cli import _base_url
 
     assert _base_url() == "https://studio.example.com"
+
+
+@pytest.mark.parametrize(
+    "env_url",
+    [
+        "http://127.0.0.1:8765/api",
+        "http://127.0.0.1:8765/api/",
+        "https://studio.example.com/api",
+    ],
+    ids=["api", "api-slash", "https-api"],
+)
+def test_base_url_strips_trailing_api_suffix(monkeypatch, env_url):
+    """A base URL already carrying /api must not double-prefix requests:
+    endpoint paths add /api themselves, so _base_url strips a trailing one."""
+    monkeypatch.setenv("LIONAGI_STUDIO_URL", env_url)
+
+    from lionagi.studio.cli import _base_url
+
+    assert not _base_url().endswith("/api")
+    assert _base_url() == env_url.rstrip("/").removesuffix("/api")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
The `li schedule` client now appends `/api` to every endpoint path (#1596), so a base URL that already carries the `/api` prefix — the previously documented workaround for the missing-prefix bug — produces `/api/api/...` requests and 404s against a running Studio daemon. `_base_url` now strips a trailing `/api`, so both forms of `LIONAGI_STUDIO_URL` work.

## Changes
- `lionagi/studio/cli.py`: `_base_url()` strips a trailing `/api` after the existing trailing-slash strip.
- `tests/cli/test_schedule_cli.py`: parametrized regression test (`/api`, `/api/`, https host) — red on the unmodified code.

## Testing
- tests/cli + tests/studio: 1063 passed, 1 skipped (pre-existing).
- ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)