### PR TITLE
feat(orchestrate): session controls + poller + li o ctl (ADR-0085 slice 2)

### DIFF
--- a/lionagi/cli/orchestrate/__init__.py
+++ b/lionagi/cli/orchestrate/__init__.py
@@ -634,13 +634,15 @@ def add_orchestrate_subparser(
     add_common_cli_args(fl)
 
     # `li o ctl status <id>` — generic alias into the same status renderer as
-    # `li agent status` / `li play status` (ADR-0085 section 6). Only
-    # `status` is implemented today; pause/resume/msg/stop land with the
-    # session_controls transport (ADR-0085 part 1).
+    # `li agent status` / `li play status` (ADR-0085 section 6). `pause` /
+    # `resume` / `msg` queue session_controls rows consumed by the control
+    # poller running alongside a live flow's heartbeat loop (ADR-0085 part 1).
+    # `stop` is out of scope for this slice — it depends on the checkpoint
+    # writer, which lands separately.
     ctl = orch_sub.add_parser(
         "ctl",
-        help="Control-plane surfaces for a run (status; more verbs land later).",
-        description="Read-only and (later) control operations addressed by run id.",
+        help="Control-plane surfaces for a run (status, pause, resume, msg).",
+        description="Read-only and control operations addressed by run id.",
     )
     ctl_sub = ctl.add_subparsers(dest="ctl_command", required=True)
     ctl_status = ctl_sub.add_parser(
@@ -656,6 +658,35 @@ def add_orchestrate_subparser(
     ctl_status.add_argument(
         "--json", action="store_true", dest="as_json", help="Emit a stable JSON object."
     )
+
+    ctl_pause = ctl_sub.add_parser(
+        "pause",
+        help="Queue a pause for a running flow.",
+        description=(
+            "Queues a pause control row; the target flow's control poller applies "
+            "it at the next op boundary (idempotent — safe to queue more than once)."
+        ),
+    )
+    ctl_pause.add_argument("id", help="Session, invocation, or play ID (or short prefix).")
+
+    ctl_resume = ctl_sub.add_parser(
+        "resume",
+        help="Queue a resume for a paused flow.",
+        description="Queues a resume control row, releasing a pending pause gate.",
+    )
+    ctl_resume.add_argument("id", help="Session, invocation, or play ID (or short prefix).")
+
+    ctl_msg = ctl_sub.add_parser(
+        "msg",
+        help="Queue an operator message for a running flow (context mode only).",
+        description=(
+            "Queues a message control row; the control poller deep-merges it into "
+            "the flow's workspace context, visible to any op not yet started. "
+            "Op-mode injection (--as-op) is not supported by this command yet."
+        ),
+    )
+    ctl_msg.add_argument("id", help="Session, invocation, or play ID (or short prefix).")
+    ctl_msg.add_argument("text", help="Message text to inject into the flow context.")
 
     return {"fanout": fo, "flow": fl, "ctl": ctl}
 
@@ -934,6 +965,18 @@ def run_orchestrate(args: argparse.Namespace) -> int:
             from lionagi.cli.status import run_ctl_status
 
             return run_ctl_status(args)
+        if args.ctl_command == "pause":
+            from ._control import run_ctl_pause
+
+            return run_ctl_pause(args)
+        if args.ctl_command == "resume":
+            from ._control import run_ctl_resume
+
+            return run_ctl_resume(args)
+        if args.ctl_command == "msg":
+            from ._control import run_ctl_msg
+
+            return run_ctl_msg(args)
         log_error(f"Unknown ctl command: {args.ctl_command}")
         return 1
 

--- a/lionagi/cli/orchestrate/_control.py
+++ b/lionagi/cli/orchestrate/_control.py
@@ -39,15 +39,36 @@ __all__ = (
 _DB_BUSY_TIMEOUT_S = 10.0
 
 
-async def _resolve_session_id(db: Any, entity_id: str) -> str | None:
-    """Resolve a session/invocation/play id (or unambiguous prefix) to a
-    backing session id, mirroring `li o ctl status`'s generic resolution."""
+# Only these session kinds ever run the control poller (`li o flow` sets
+# "flow", playbook runs set "play"); anything else has no consumer, so a
+# queued control would sit pending forever.
+_POLLER_KINDS = frozenset({"flow", "play"})
+
+
+async def _prefix_is_ambiguous(db: Any, entity_id: str) -> bool:
+    """True when a short prefix matches 2+ rows in the first table that
+    matches at all (same sessions→invocations→plays order the resolver
+    sweeps, so cross-table shadowing stays intentional)."""
+    if len(entity_id) >= 36:
+        return False
+    for table in ("sessions", "invocations", "plays"):
+        rows = await db.fetch_all(
+            f"SELECT id FROM {table} WHERE id LIKE ? LIMIT 2",  # noqa: S608
+            (entity_id + "%",),
+        )
+        if rows:
+            return len(rows) > 1
+    return False
+
+
+async def _resolve_session(db: Any, entity_id: str) -> dict[str, Any] | None:
+    """Resolve a session/invocation/play id (or unambiguous prefix) to the
+    backing session row, mirroring `li o ctl status`'s generic resolution."""
     target = await _resolve_any_target(db, entity_id)
     if target is None:
         return None
     entity_type, row = target
-    primary = await _resolve_primary_session(db, entity_type, row)
-    return primary["id"] if primary else None
+    return await _resolve_primary_session(db, entity_type, row)
 
 
 async def _enqueue_control_inner(
@@ -59,16 +80,40 @@ async def _enqueue_control_inner(
         return "state.db not found — no runs recorded yet", EXIT_UNKNOWN
 
     async with StateDB() as db:
-        session_id = await _resolve_session_id(db, entity_id)
-        if session_id is None:
+        entity_id = entity_id.strip()
+        if await _prefix_is_ambiguous(db, entity_id):
+            return (
+                f"ambiguous id prefix {entity_id!r} — matches more than one "
+                "record; use a longer prefix or the full id",
+                EXIT_UNKNOWN,
+            )
+        session = await _resolve_session(db, entity_id)
+        if session is None:
             return f"no session/invocation/play found for id {entity_id!r}", EXIT_UNKNOWN
+        session_id = session["id"]
+        status = session.get("status")
+        if status != "running":
+            return (
+                f"session {session_id[:8]} is {status or 'unknown'} — controls "
+                "apply only while the target flow is running",
+                EXIT_UNKNOWN,
+            )
+        kind = session.get("invocation_kind")
+        if kind not in _POLLER_KINDS:
+            return (
+                f"session {session_id[:8]} is {kind or 'unknown'}-kind — "
+                "`li o ctl` targets `li o flow` / playbook runs (no control "
+                "poller runs for other session kinds)",
+                EXIT_UNKNOWN,
+            )
         control_id = await db.insert_session_control(
             session_id=session_id, verb=verb, payload=payload
         )
 
     return (
         f"queued {verb} (control {control_id[:8]}) for session {session_id[:8]} — "
-        f"applies within {2:.0f}s; check `li o ctl status {session_id[:8]}`",
+        f"applies within ~{2:.0f}s while the flow is live; "
+        f"check `li o ctl status {session_id[:8]}`",
         0,
     )
 

--- a/lionagi/cli/orchestrate/_control.py
+++ b/lionagi/cli/orchestrate/_control.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""`li o ctl pause|resume|msg` — enqueue session_controls rows for a running flow.
+
+These commands are pure writers: they resolve the target session (accepting
+a session id, an invocation id, or a play id — same id shapes `li o ctl
+status` accepts, see lionagi/cli/status.py) and insert one row into
+session_controls. They do not wait for the control to apply — a control
+poller task running alongside the target flow's own heartbeat loop
+(cli/orchestrate/flow.py `_execute_dag`) is the only consumer, and applies
+each row against the live executor on its own poll cycle. Use `li o ctl
+status <id>` to see whether a queued control has applied yet.
+
+Only context-mode `msg` ships in this slice (ADR-0085 §3): the poller
+deep-merges the message into the executor's flow workspace, visible to ops
+that have not yet started. Op-mode (`--as-op`, injecting the message as a
+first-class reactive DAG node) lands with a later slice.
+
+See docs/adrs/ADR-0085-flow-control-plane.md sections 1-3.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from typing import Any
+
+from .._logging import log_error
+from ..status import EXIT_UNKNOWN, _resolve_any_target, _resolve_primary_session
+
+__all__ = (
+    "run_ctl_pause",
+    "run_ctl_resume",
+    "run_ctl_msg",
+)
+
+# Mirrors status.py's _DB_BUSY_TIMEOUT_S — bounds a single enqueue's total DB
+# time so a stuck write fails fast instead of hanging indefinitely.
+_DB_BUSY_TIMEOUT_S = 10.0
+
+
+async def _resolve_session_id(db: Any, entity_id: str) -> str | None:
+    """Resolve a session/invocation/play id (or unambiguous prefix) to a
+    backing session id, mirroring `li o ctl status`'s generic resolution."""
+    target = await _resolve_any_target(db, entity_id)
+    if target is None:
+        return None
+    entity_type, row = target
+    primary = await _resolve_primary_session(db, entity_type, row)
+    return primary["id"] if primary else None
+
+
+async def _enqueue_control_inner(
+    *, entity_id: str, verb: str, payload: dict[str, Any] | None
+) -> tuple[str, int]:
+    from lionagi.state.db import DEFAULT_DB_PATH, StateDB
+
+    if not DEFAULT_DB_PATH.exists():
+        return "state.db not found — no runs recorded yet", EXIT_UNKNOWN
+
+    async with StateDB() as db:
+        session_id = await _resolve_session_id(db, entity_id)
+        if session_id is None:
+            return f"no session/invocation/play found for id {entity_id!r}", EXIT_UNKNOWN
+        control_id = await db.insert_session_control(
+            session_id=session_id, verb=verb, payload=payload
+        )
+
+    return (
+        f"queued {verb} (control {control_id[:8]}) for session {session_id[:8]} — "
+        f"applies within {2:.0f}s; check `li o ctl status {session_id[:8]}`",
+        0,
+    )
+
+
+async def _enqueue_control(
+    *, entity_id: str, verb: str, payload: dict[str, Any] | None
+) -> tuple[str, int]:
+    try:
+        return await asyncio.wait_for(
+            _enqueue_control_inner(entity_id=entity_id, verb=verb, payload=payload),
+            timeout=_DB_BUSY_TIMEOUT_S,
+        )
+    except (TimeoutError, asyncio.TimeoutError):  # 3.10 support: not aliased until 3.11
+        return (
+            f"state.db busy (no write within {_DB_BUSY_TIMEOUT_S:.0f}s) — "
+            "another writer may be holding a long transaction; try again",
+            EXIT_UNKNOWN,
+        )
+
+
+def _dispatch_control(*, entity_id: str, verb: str, payload: dict[str, Any] | None) -> int:
+    from lionagi.ln.concurrency import run_async
+
+    output, exit_code = run_async(_enqueue_control(entity_id=entity_id, verb=verb, payload=payload))
+    if exit_code == EXIT_UNKNOWN:
+        log_error(output)
+    else:
+        print(output)
+    return exit_code
+
+
+# ── CLI entry points ─────────────────────────────────────────────────────────
+
+
+def run_ctl_pause(args: argparse.Namespace) -> int:
+    """`li o ctl pause <id>` — queue a pause; applied at the running flow's next op boundary."""
+    return _dispatch_control(entity_id=args.id, verb="pause", payload=None)
+
+
+def run_ctl_resume(args: argparse.Namespace) -> int:
+    """`li o ctl resume <id>` — queue a resume; releases a pending pause gate."""
+    return _dispatch_control(entity_id=args.id, verb="resume", payload=None)
+
+
+def run_ctl_msg(args: argparse.Namespace) -> int:
+    """`li o ctl msg <id> "text"` — queue a context-mode operator message (ADR-0085 §3)."""
+    return _dispatch_control(entity_id=args.id, verb="message", payload={"text": args.text})

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -94,21 +94,21 @@ async def _apply_session_control(db, executor, row: dict) -> str | None:
     and apply leaves a visible 'applying' row (surfaced by `li o ctl status`)
     rather than risking a double injection on the next poll (at-most-once).
 
-    Never raises: any exception is caught and recorded as a rejected result so
-    a bad control row can never crash the run it rides alongside.
+    Never raises: apply failures are recorded as a rejected result so a bad
+    control row can never crash the run it rides alongside. Finalize failures
+    after a successful apply never mislabel the row as rejected — the 'applied'
+    stamp is retried, then the row is left for the next tick.
     """
     control_id = row["id"]
     verb = row["verb"]
     try:
         if verb == "pause":
             executor.pause()
-            await db.finalize_session_control(control_id, result="applied")
-            return "applied"
+            return await _finalize_applied(db, control_id)
 
         if verb == "resume":
             executor.resume()
-            await db.finalize_session_control(control_id, result="applied")
-            return "applied"
+            return await _finalize_applied(db, control_id)
 
         if verb == "message":
             if row.get("result") == "applying":
@@ -136,8 +136,7 @@ async def _apply_session_control(db, executor, row: dict) -> str | None:
             existing = executor.context.content.get("operator_messages", [])
             entry = {"ts": time.time(), "text": payload.get("text", "")}
             deep_update(executor.context.content, {"operator_messages": [*existing, entry]})
-            await db.finalize_session_control(control_id, result="applied")
-            return "applied"
+            return await _finalize_applied(db, control_id)
 
         # 'stop' is schema-reserved for a later slice (the checkpoint writer);
         # any other verb is unrecognised. Reject loudly instead of leaving a
@@ -157,6 +156,23 @@ async def _apply_session_control(db, executor, row: dict) -> str | None:
             # end the tick so ordering is preserved on the retry.
             return _CONTROL_UNSTAMPED
         return result
+
+
+async def _finalize_applied(db, control_id: str) -> str:
+    """Stamp 'applied' after a successful apply; never mislabel it rejected.
+
+    A finalize failure here means the effect landed but the stamp did not:
+    retry once, then hand the row back to the poller via the unstamped
+    sentinel — pause/resume re-apply idempotently next tick, and a message
+    row stays 'applying' so it is skipped rather than double-injected.
+    """
+    for _ in range(2):
+        try:
+            await db.finalize_session_control(control_id, result="applied")
+            return "applied"
+        except Exception as exc:  # noqa: BLE001 — the poller must never crash the run
+            logger.warning("control %s applied but finalize failed: %s", control_id, exc)
+    return _CONTROL_UNSTAMPED
 
 
 _BUDGET_PREAMBLE_TEMPLATE = """\

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -67,6 +67,87 @@ async def _persist_session_phase(env, phase: str) -> None:
             await ctx["db"].update_session(ctx["session_id"], current_phase=phase)
 
 
+# ── Control poller (ADR-0085 part 1: session_controls transport) ─────────────
+# `li o ctl pause|resume|msg` enqueues a session_controls row from a separate
+# process; this poller — running alongside the heartbeat loop in _execute_dag,
+# same lifecycle — is the only consumer, and applies each row against the live
+# executor. See docs/adrs/ADR-0085-flow-control-plane.md section 1 for the
+# verb-classed apply/stamp ordering this implements.
+
+_CONTROL_POLL_INTERVAL = 2.0
+
+
+async def _apply_session_control(db, executor, row: dict) -> str | None:
+    """Apply one session_controls row against *executor*; returns the finalize
+    result string, or None if the row was left untouched (message already
+    mid-apply from a prior poller crash).
+
+    pause/resume are idempotent: apply, then stamp 'applied' — a poller crash
+    between the two is harmless, since re-applying on the next poll is a no-op.
+    message is not idempotent: stamp 'applying' first, then attempt the
+    (checked, not assumed) injection, then finalize — a crash between stamp
+    and apply leaves a visible 'applying' row (surfaced by `li o ctl status`)
+    rather than risking a double injection on the next poll (at-most-once).
+
+    Never raises: any exception is caught and recorded as a rejected result so
+    a bad control row can never crash the run it rides alongside.
+    """
+    control_id = row["id"]
+    verb = row["verb"]
+    try:
+        if verb == "pause":
+            executor.pause()
+            await db.finalize_session_control(control_id, result="applied")
+            return "applied"
+
+        if verb == "resume":
+            executor.resume()
+            await db.finalize_session_control(control_id, result="applied")
+            return "applied"
+
+        if verb == "message":
+            if row.get("result") == "applying":
+                # A prior poller crashed between stamp and apply. At-most-once:
+                # leave it untouched — re-attempting could double-inject the
+                # message if the earlier apply actually landed before the crash.
+                return None
+            await db.mark_session_control_applying(control_id)
+
+            from lionagi.operations.node import Operation as _Operation  # noqa: PLC0415
+            from lionagi.protocols.types import EventStatus as _EventStatus  # noqa: PLC0415
+
+            has_pending_op = any(
+                isinstance(node, _Operation) and node.execution.status == _EventStatus.PENDING
+                for node in executor.graph.internal_nodes.values()
+            )
+            if not has_pending_op:
+                result = "rejected:no-pending-ops"
+                await db.finalize_session_control(control_id, result=result)
+                return result
+
+            from lionagi.libs.nested import deep_update  # noqa: PLC0415
+
+            payload = row.get("payload") or {}
+            existing = executor.context.content.get("operator_messages", [])
+            entry = {"ts": time.time(), "text": payload.get("text", "")}
+            deep_update(executor.context.content, {"operator_messages": [*existing, entry]})
+            await db.finalize_session_control(control_id, result="applied")
+            return "applied"
+
+        # 'stop' is schema-reserved for a later slice (the checkpoint writer);
+        # any other verb is unrecognised. Reject loudly instead of leaving a
+        # row that would be polled forever.
+        result = f"rejected:unsupported-verb:{verb}"
+        await db.finalize_session_control(control_id, result=result)
+        return result
+    except Exception as exc:  # noqa: BLE001 — the poller must never crash the run
+        result = f"rejected:error:{exc}"[:500]
+        with contextlib.suppress(Exception):
+            await db.finalize_session_control(control_id, result=result)
+        logger.warning("control %s (%s) failed to apply: %s", control_id, verb, exc)
+        return result
+
+
 _BUDGET_PREAMBLE_TEMPLATE = """\
 [BUDGET]
 You are op {op_index} of {num_ops} in this flow. Your share of the total \
@@ -572,6 +653,58 @@ async def _execute_dag(
                         "with no completion — possible hung child process"
                     )
 
+    # ADR-0085 part 1: control poller — the only consumer of session_controls
+    # rows queued by `li o ctl pause|resume|msg`. _executor_ref is populated
+    # synchronously by DependencyAwareExecutor.__init__ the moment run_dag()
+    # constructs it, so the "executor not yet available" window below is at
+    # most one event-loop tick, well inside poll_interval.
+    _executor_ref: dict[str, object] = {}
+    _control_log: list[dict] = []
+
+    def _persist_control_log() -> None:
+        ctx = getattr(env, "_live_persist", None)
+        if not ctx or not ctx.get("db"):
+            return
+        extras = getattr(env, "_finalize_extras", {}) or {}
+        extras["controls"] = _control_log
+        env._finalize_extras = extras
+
+        async def _do():
+            with contextlib.suppress(Exception):
+                _markers = ctx.get("identity_markers") or {}
+                await ctx["db"].update_session(
+                    ctx["session_id"], node_metadata=json.dumps({**extras, **_markers})
+                )
+
+        _asyncio.ensure_future(_do())
+
+    async def _control_poll_loop() -> None:
+        while True:
+            await _asyncio.sleep(_CONTROL_POLL_INTERVAL)
+            ctx = getattr(env, "_live_persist", None)
+            if not ctx or not ctx.get("db"):
+                continue
+            executor = _executor_ref.get("executor")
+            if executor is None:
+                continue
+            try:
+                pending = await ctx["db"].list_pending_session_controls(ctx["session_id"])
+            except Exception as exc:  # noqa: BLE001 — transient DB hiccup, retry next tick
+                logger.debug("control poll: transient error listing pending controls: %s", exc)
+                continue
+            for row in pending:
+                applied_result = await _apply_session_control(ctx["db"], executor, row)
+                if applied_result is not None:
+                    _control_log.append(
+                        {
+                            "id": row["id"],
+                            "verb": row["verb"],
+                            "result": applied_result,
+                            "ts": time.time(),
+                        }
+                    )
+                    _persist_control_log()
+
     from lionagi.engines import PlanningEngine
     from lionagi.session.signal import NodeCompleted, NodeFailed, NodeStarted
 
@@ -582,6 +715,7 @@ async def _execute_dag(
 
     t_exec = time.monotonic()
     _hb_task = _asyncio.ensure_future(_heartbeat_loop())
+    _ctl_task = _asyncio.ensure_future(_control_poll_loop())
     try:
         dag_result = await eng_run.run_dag(
             env.builder.get_graph(),
@@ -591,11 +725,15 @@ async def _execute_dag(
             max_spawn=max_spawn,
             max_concurrent=conc,
             verbose=env.verbose,
+            executor_ref=_executor_ref,
         )
     finally:
         _hb_task.cancel()
+        _ctl_task.cancel()
         with contextlib.suppress(_asyncio.CancelledError):
             await _hb_task
+        with contextlib.suppress(_asyncio.CancelledError):
+            await _ctl_task
     t_exec_elapsed = time.monotonic() - t_exec
 
     op_results = dag_result.get("operation_results", {})

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -76,6 +76,11 @@ async def _persist_session_phase(env, phase: str) -> None:
 
 _CONTROL_POLL_INTERVAL = 2.0
 
+# Sentinel: the row's apply ran but no finalize write landed, so it is still
+# pending in the DB. The poller must stop the tick rather than let later
+# controls overtake it — the whole batch re-reads in order next tick.
+_CONTROL_UNSTAMPED = "unstamped"
+
 
 async def _apply_session_control(db, executor, row: dict) -> str | None:
     """Apply one session_controls row against *executor*; returns the finalize
@@ -142,9 +147,15 @@ async def _apply_session_control(db, executor, row: dict) -> str | None:
         return result
     except Exception as exc:  # noqa: BLE001 — the poller must never crash the run
         result = f"rejected:error:{exc}"[:500]
-        with contextlib.suppress(Exception):
-            await db.finalize_session_control(control_id, result=result)
         logger.warning("control %s (%s) failed to apply: %s", control_id, verb, exc)
+        try:
+            await db.finalize_session_control(control_id, result=result)
+        except Exception:  # noqa: BLE001
+            # The row is still pending: a later control applied this tick
+            # would be overtaken by this one re-applying next tick (e.g. a
+            # stuck pause re-pausing after its resume). Signal the poller to
+            # end the tick so ordering is preserved on the retry.
+            return _CONTROL_UNSTAMPED
         return result
 
 
@@ -694,6 +705,8 @@ async def _execute_dag(
                 continue
             for row in pending:
                 applied_result = await _apply_session_control(ctx["db"], executor, row)
+                if applied_result == _CONTROL_UNSTAMPED:
+                    break
                 if applied_result is not None:
                     _control_log.append(
                         {

--- a/lionagi/cli/status.py
+++ b/lionagi/cli/status.py
@@ -15,15 +15,19 @@ here since other lambdas/tools parse it):
   current_phase, progress_completed, progress_total, model, provider,
   project, last_activity_at, session_id, branch_id, invocation_id, label,
   degraded, degraded_reason,
-  status_reason_code, status_reason_summary, status_evidence_refs
+  status_reason_code, status_reason_summary, status_evidence_refs,
+  pending_controls
 
 Exit codes: 0 terminal-success, 1 terminal-failure, 3 still running/active,
 2 lookup failed (unknown id, or state.db unreachable) — argparse itself
 owns exit code 2 for usage errors, so this reuses that convention for any
 other "could not produce a status" outcome.
 
-`session_controls` (ADR-0085 part 1) does not exist yet, so no pending-
-controls column is rendered here — that lands with a later slice.
+`pending_controls` lists unapplied session_controls rows (id, verb,
+created_at) for the resolved backing session, oldest first — queued via
+`li o ctl pause|resume|msg` and consumed by the control poller running
+alongside a live flow's heartbeat loop (ADR-0085 part 1). Always `[]` when
+there is no backing session or nothing queued.
 """
 
 from __future__ import annotations
@@ -297,10 +301,15 @@ async def _build_view(
             progress_completed, progress_total = prog
 
     branch_id: str | None = None
+    pending_controls: list[dict[str, Any]] = []
     if primary_session is not None:
         branches = await db.list_branches(primary_session["id"])
         if branches:
             branch_id = max(branches, key=lambda b: b.get("created_at") or 0).get("id")
+        pending_controls = [
+            {"id": c["id"], "verb": c["verb"], "created_at": c["created_at"]}
+            for c in await db.list_pending_session_controls(primary_session["id"])
+        ]
 
     status = row.get("status") or ""
     terminal, exit_class, exit_code = _classify(entity_type, status)
@@ -354,6 +363,7 @@ async def _build_view(
         "status_reason_code": row.get("status_reason_code"),
         "status_reason_summary": row.get("status_reason_summary"),
         "status_evidence_refs": row.get("status_evidence_refs"),
+        "pending_controls": pending_controls,
     }
 
 
@@ -390,6 +400,12 @@ def _render_human(view: dict[str, Any]) -> str:
         lines.append(_dim(f'  resume:      li agent -r {view["branch_id"]} "..."'))
     if view["invocation_id"] and view["invocation_id"] != view["id"]:
         lines.append(f"  invocation:  {view['invocation_id']}")
+
+    if view["pending_controls"]:
+        lines.append("")
+        lines.append(_dim("  -- pending controls --"))
+        for ctl in view["pending_controls"]:
+            lines.append(f"    {ctl['verb']:<8} {ctl['id']}  queued {_fmt_ts(ctl['created_at'])}")
 
     if view["degraded"]:
         lines.append("")

--- a/lionagi/engines/engine.py
+++ b/lionagi/engines/engine.py
@@ -458,6 +458,7 @@ class EngineRun:
         max_spawn: int = 50,
         max_concurrent: int = 5,
         verbose: bool = False,
+        executor_ref: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Execute a prebuilt operation DAG on the run's session and return operation results."""
         from lionagi.operations.node import Operation  # noqa: PLC0415
@@ -539,6 +540,7 @@ class EngineRun:
                 max_concurrent=max_concurrent,
                 verbose=verbose,
                 on_progress=_on_progress,
+                executor_ref=executor_ref,
             )
         finally:
             self.session.observer.unobserve(_on_spawned)

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -71,6 +71,7 @@ class DependencyAwareExecutor:
         verbose: bool = False,
         default_branch: "Branch" = None,
         alcall_params: AlcallParams | None = None,
+        executor_ref: dict[str, Any] | None = None,
     ):
         self.session = session
         self.graph = graph
@@ -86,6 +87,13 @@ class DependencyAwareExecutor:
         self.skipped_operations = set()
         self._op_start_times = {}
         self._pause_event: ConcurrencyEvent | None = None
+        # ADR-0085 part 1: an out-of-band handle the caller can pass so a
+        # control poller running alongside this flow (cli/orchestrate/flow.py)
+        # can reach pause()/resume()/context/graph on the live executor. Set
+        # synchronously here (before any awaiting) so it is available the
+        # instant execute() starts.
+        if executor_ref is not None:
+            executor_ref["executor"] = self
         for node in graph.internal_nodes.values():
             if isinstance(node, Operation):
                 self.completion_events[node.id] = ConcurrencyEvent()
@@ -908,6 +916,7 @@ async def flow(
     spawn_type: type | None = None,
     node_builder: Any = None,
     max_spawn: int = 50,
+    executor_ref: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Execute a graph with dependency management and optional reactive self-expansion."""
 
@@ -926,6 +935,7 @@ async def flow(
             spawn_type=spawn_type,
             node_builder=node_builder,
             max_spawn=max_spawn,
+            executor_ref=executor_ref,
         )
     else:
         executor = DependencyAwareExecutor(
@@ -936,6 +946,7 @@ async def flow(
             verbose=verbose,
             default_branch=branch,
             alcall_params=alcall_params,
+            executor_ref=executor_ref,
         )
     if on_progress is not None:
         executor.on_progress = on_progress

--- a/lionagi/session/session.py
+++ b/lionagi/session/session.py
@@ -312,6 +312,7 @@ class Session(Node, Relational):
         spawn_type: type | None = None,
         node_builder: Any = None,
         max_spawn: int = 50,
+        executor_ref: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Execute a graph-based DAG workflow, optionally reactive (self-expanding)."""
         from lionagi.operations.flow import flow
@@ -334,6 +335,7 @@ class Session(Node, Relational):
             spawn_type=spawn_type,
             node_builder=node_builder,
             max_spawn=max_spawn,
+            executor_ref=executor_ref,
         )
 
     async def flow_stream(

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -3057,6 +3057,127 @@ class StateDB:
             )
         return result.rowcount > 0
 
+    # ── Session controls (ADR-0085 part 1: run control plane transport) ────
+    # session_controls rows are written by `li o ctl pause|resume|msg` and
+    # consumed by the control poller task in cli/orchestrate/flow.py's
+    # _execute_dag (same lifecycle as the heartbeat loop). Apply/stamp
+    # ordering is verb-classed by the poller, not by these methods: pause/
+    # resume call insert_session_control() then, once applied against the
+    # executor, finalize_session_control() directly (idempotent — safe to
+    # re-apply on a poller crash). message calls mark_session_control_applying()
+    # before attempting the (non-idempotent) apply, then finalize_session_control()
+    # (a crash between the two leaves a visible 'applying' row instead of a
+    # silent double-injection risk).
+
+    async def insert_session_control(
+        self,
+        *,
+        session_id: str,
+        verb: str,
+        payload: dict[str, Any] | None = None,
+        created_at: float | None = None,
+    ) -> str:
+        """Queue a control verb for *session_id*; returns the new control id.
+
+        Serialised through _tx() like the other append-only session logs.
+        """
+        control_id = uuid.uuid4().hex
+        async with self._tx() as conn:
+            await conn.execute(
+                text(
+                    "INSERT INTO session_controls "
+                    "(id, session_id, verb, payload, created_at, applied_at, result) "
+                    "VALUES (:id, :sid, :verb, :payload, :created_at, NULL, NULL)"
+                ).bindparams(bindparam("payload", type_=JSON)),
+                {
+                    "id": control_id,
+                    "sid": session_id,
+                    "verb": verb,
+                    "payload": payload,
+                    "created_at": created_at if created_at is not None else time.time(),
+                },
+            )
+        return control_id
+
+    async def list_pending_session_controls(self, session_id: str) -> list[dict[str, Any]]:
+        """Unapplied controls (applied_at IS NULL) for *session_id*, oldest first.
+
+        Includes rows mid-apply (result='applying') — the poller/status surface
+        distinguish "never touched" (result IS NULL) from "a prior poller crashed
+        mid-apply" (result='applying') by inspecting that field.
+        """
+        async with self._read() as conn:
+            rows = (
+                (
+                    await conn.execute(
+                        text(
+                            "SELECT id, session_id, verb, payload, created_at, applied_at, result "
+                            "FROM session_controls "
+                            "WHERE session_id = :sid AND applied_at IS NULL "
+                            "ORDER BY created_at"
+                        ),
+                        {"sid": session_id},
+                    )
+                )
+                .mappings()
+                .all()
+            )
+        result = []
+        for r in rows:
+            d = dict(r)
+            if isinstance(d.get("payload"), str):
+                try:
+                    d["payload"] = json.loads(d["payload"])
+                except (json.JSONDecodeError, TypeError):
+                    pass
+            result.append(d)
+        return result
+
+    async def mark_session_control_applying(self, control_id: str) -> None:
+        """Stamp a non-idempotent (message) control as mid-apply, before attempting it.
+
+        applied_at stays NULL — the row remains "pending" until finalize_session_control()
+        runs, so a poller crash right after this stamp is visible, not silently lost.
+        """
+        async with self._tx() as conn:
+            await conn.execute(
+                text("UPDATE session_controls SET result = 'applying' WHERE id = :id"),
+                {"id": control_id},
+            )
+
+    async def finalize_session_control(self, control_id: str, *, result: str) -> None:
+        """Stamp applied_at + a terminal *result* ('applied' or 'rejected:<reason>')."""
+        async with self._tx() as conn:
+            await conn.execute(
+                text(
+                    "UPDATE session_controls SET applied_at = :applied_at, result = :result "
+                    "WHERE id = :id"
+                ),
+                {"applied_at": time.time(), "result": result, "id": control_id},
+            )
+
+    async def get_session_control(self, control_id: str) -> dict[str, Any] | None:
+        async with self._read() as conn:
+            row = (
+                (
+                    await conn.execute(
+                        text("SELECT * FROM session_controls WHERE id = :id"),
+                        {"id": control_id},
+                    )
+                )
+                .mappings()
+                .first()
+            )
+        if row is None:
+            return None
+        d = dict(row)
+        if isinstance(d.get("payload"), str):
+            try:
+                d["payload"] = json.loads(d["payload"])
+            except (json.JSONDecodeError, TypeError):
+                pass
+        return d
+
     # ── Helpers ────────────────────────────────────────────────────────
 
     @staticmethod
@@ -3075,6 +3196,7 @@ class StateDB:
             "artifact_contract_json",
             "artifact_verification_json",
             "status_evidence_refs",
+            "payload",
         ):
             if key in d and isinstance(d[key], str):
                 try:

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -3114,7 +3114,9 @@ class StateDB:
                             "SELECT id, session_id, verb, payload, created_at, applied_at, result "
                             "FROM session_controls "
                             "WHERE session_id = :sid AND applied_at IS NULL "
-                            "ORDER BY created_at"
+                            # id tiebreak: identical created_at floats (rapid
+                            # enqueues) must not flip apply order between ticks
+                            "ORDER BY created_at, id"
                         ),
                         {"sid": session_id},
                     )

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -648,3 +648,26 @@ CREATE INDEX IF NOT EXISTS idx_engine_defs_kind
   ON engine_defs(kind);
 CREATE INDEX IF NOT EXISTS idx_engine_defs_updated
   ON engine_defs(updated_at DESC);
+
+-- ── Session controls (ADR-0085 part 1: run control plane transport) ───────────
+-- One row per operator control verb queued against a live session.  A poller
+-- task in cli/orchestrate/flow.py's _execute_dag (same lifecycle as the
+-- heartbeat loop) reads unapplied rows (applied_at IS NULL) and applies them
+-- against the running executor.  Apply/stamp ordering is verb-classed:
+-- pause/resume/stop are idempotent (apply, then stamp), message is not
+-- (stamp 'applying', then apply, then finalize).  'stop' is schema-reserved
+-- for a later slice (the checkpoint writer); no CLI verb emits it yet.
+
+CREATE TABLE IF NOT EXISTS session_controls (
+  id          TEXT    PRIMARY KEY,         -- uuid4 hex
+  session_id  TEXT    NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  verb        TEXT    NOT NULL
+              CHECK(verb IN ('pause', 'resume', 'message', 'stop')),
+  payload     JSON,                        -- verb-specific; NULL for pause/resume
+  created_at  REAL    NOT NULL,
+  applied_at  REAL,                        -- NULL until the poller consumes it
+  result      TEXT                         -- 'applying' | 'applied' | 'rejected:<reason>'
+);
+
+CREATE INDEX IF NOT EXISTS idx_session_controls_pending
+  ON session_controls(session_id, applied_at) WHERE applied_at IS NULL;

--- a/lionagi/state/schema_meta.py
+++ b/lionagi/state/schema_meta.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""SQLAlchemy MetaData for all 21 StateDB tables — single source of truth for schema DDL."""
+"""SQLAlchemy MetaData for all 22 StateDB tables — single source of truth for schema DDL."""
 
 from __future__ import annotations
 
@@ -797,3 +797,49 @@ engine_defs = Table(
 Index("idx_engine_defs_name", engine_defs.c.name)
 Index("idx_engine_defs_kind", engine_defs.c.kind)
 Index("idx_engine_defs_updated", engine_defs.c.updated_at)
+
+# ── session_controls (ADR-0085 part 1: run control plane transport) ────────────
+# One row per operator control verb queued against a live session. A poller task
+# in `cli/orchestrate/flow.py`'s `_execute_dag` (the same lifecycle as the
+# heartbeat loop) reads unapplied rows and applies them against the running
+# executor. Apply/stamp ordering is verb-classed: pause/resume/stop are
+# idempotent (apply, then stamp — safe to re-apply on a poller crash); message
+# is not (stamp 'applying', then apply, then finalize — a crash surfaces as an
+# unapplied 'applying' row rather than risking a double injection). 'stop' is
+# schema-reserved for a later slice (the checkpoint writer); no CLI verb emits
+# it yet.
+
+session_controls = Table(
+    "session_controls",
+    metadata,
+    Column("id", Text, primary_key=True),
+    Column(
+        "session_id",
+        Text,
+        ForeignKey("sessions.id", ondelete="CASCADE"),
+        nullable=False,
+    ),
+    Column(
+        "verb",
+        Text,
+        CheckConstraint(
+            "verb IN ('pause','resume','message','stop')",
+            name="ck_session_controls_verb",
+        ),
+        nullable=False,
+    ),
+    Column("payload", JSON),
+    Column("created_at", Float, nullable=False),
+    # NULL until the poller consumes the row.
+    Column("applied_at", Float),
+    # 'applying' (message verb, mid-apply) | 'applied' | 'rejected:<reason>'.
+    Column("result", Text),
+)
+
+Index(
+    "idx_session_controls_pending",
+    session_controls.c.session_id,
+    session_controls.c.applied_at,
+    sqlite_where=text("applied_at IS NULL"),
+    postgresql_where=text("applied_at IS NULL"),
+)

--- a/tests/cli/orchestrate/test_control_cli.py
+++ b/tests/cli/orchestrate/test_control_cli.py
@@ -1,0 +1,183 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for `li o ctl pause|resume|msg` (ADR-0085 part 1: session_controls transport).
+
+Covers enqueue row shapes (verb, payload) and id resolution (session,
+invocation, play, short prefix, unknown id) through the same generic
+resolver `li o ctl status` uses.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+from lionagi.cli.orchestrate._control import (
+    run_ctl_msg,
+    run_ctl_pause,
+    run_ctl_resume,
+)
+from lionagi.cli.status import EXIT_UNKNOWN
+from lionagi.state.db import StateDB
+
+
+@pytest.fixture
+def temp_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", db_path)
+    return db_path
+
+
+async def _make_session(db: StateDB, *, invocation_kind: str = "flow") -> str:
+    sid = uuid.uuid4().hex[:12]
+    pid = uuid.uuid4().hex
+    await db.create_progression(pid)
+    await db.create_session(
+        {
+            "id": sid,
+            "progression_id": pid,
+            "status": "running",
+            "invocation_kind": invocation_kind,
+            "started_at": time.time(),
+        }
+    )
+    return sid
+
+
+async def _make_invocation(db: StateDB, *, status: str = "running") -> str:
+    inv_id = uuid.uuid4().hex[:12]
+    await db.create_invocation(
+        {"id": inv_id, "skill": "flow", "started_at": time.time(), "status": status}
+    )
+    return inv_id
+
+
+# ── pause ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_pause_enqueues_row_for_session_id(temp_db_path: Path):
+    async with StateDB() as db:
+        sid = await _make_session(db)
+
+    rc = run_ctl_pause(argparse.Namespace(id=sid))
+    assert rc == 0
+
+    async with StateDB() as db:
+        pending = await db.list_pending_session_controls(sid)
+    assert len(pending) == 1
+    assert pending[0]["verb"] == "pause"
+    assert pending[0]["payload"] is None
+
+
+@pytest.mark.asyncio
+async def test_pause_resolves_short_prefix(temp_db_path: Path):
+    async with StateDB() as db:
+        sid = await _make_session(db)
+
+    rc = run_ctl_pause(argparse.Namespace(id=sid[:6]))
+    assert rc == 0
+
+    async with StateDB() as db:
+        pending = await db.list_pending_session_controls(sid)
+    assert len(pending) == 1
+
+
+@pytest.mark.asyncio
+async def test_pause_resolves_via_invocation_id(temp_db_path: Path):
+    async with StateDB() as db:
+        inv_id = await _make_invocation(db)
+        sid = uuid.uuid4().hex[:12]
+        pid = uuid.uuid4().hex
+        await db.create_progression(pid)
+        await db.create_session(
+            {
+                "id": sid,
+                "progression_id": pid,
+                "status": "running",
+                "invocation_kind": "flow",
+                "invocation_id": inv_id,
+                "started_at": time.time(),
+            }
+        )
+
+    rc = run_ctl_pause(argparse.Namespace(id=inv_id))
+    assert rc == 0
+
+    async with StateDB() as db:
+        pending = await db.list_pending_session_controls(sid)
+    assert len(pending) == 1
+    assert pending[0]["verb"] == "pause"
+
+
+def test_pause_unknown_id_returns_exit_unknown(temp_db_path: Path):
+    rc = run_ctl_pause(argparse.Namespace(id="x" * 36))
+    assert rc == EXIT_UNKNOWN
+
+
+def test_pause_no_state_db_returns_exit_unknown(temp_db_path: Path):
+    # temp_db_path is a fresh, never-created path — no state.db on disk yet.
+    rc = run_ctl_pause(argparse.Namespace(id="anything"))
+    assert rc == EXIT_UNKNOWN
+
+
+# ── resume ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_resume_enqueues_row(temp_db_path: Path):
+    async with StateDB() as db:
+        sid = await _make_session(db)
+
+    rc = run_ctl_resume(argparse.Namespace(id=sid))
+    assert rc == 0
+
+    async with StateDB() as db:
+        pending = await db.list_pending_session_controls(sid)
+    assert len(pending) == 1
+    assert pending[0]["verb"] == "resume"
+    assert pending[0]["payload"] is None
+
+
+# ── msg ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_msg_enqueues_row_with_text_payload(temp_db_path: Path):
+    async with StateDB() as db:
+        sid = await _make_session(db)
+
+    rc = run_ctl_msg(argparse.Namespace(id=sid, text="please pause after this op"))
+    assert rc == 0
+
+    async with StateDB() as db:
+        pending = await db.list_pending_session_controls(sid)
+    assert len(pending) == 1
+    assert pending[0]["verb"] == "message"
+    assert pending[0]["payload"] == {"text": "please pause after this op"}
+
+
+def test_msg_unknown_id_returns_exit_unknown(temp_db_path: Path):
+    rc = run_ctl_msg(argparse.Namespace(id="x" * 36, text="hi"))
+    assert rc == EXIT_UNKNOWN
+
+
+# ── multiple controls queue independently ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_multiple_controls_queue_in_order(temp_db_path: Path):
+    async with StateDB() as db:
+        sid = await _make_session(db)
+
+    assert run_ctl_pause(argparse.Namespace(id=sid)) == 0
+    assert run_ctl_msg(argparse.Namespace(id=sid, text="hold on")) == 0
+    assert run_ctl_resume(argparse.Namespace(id=sid)) == 0
+
+    async with StateDB() as db:
+        pending = await db.list_pending_session_controls(sid)
+    assert [p["verb"] for p in pending] == ["pause", "message", "resume"]

--- a/tests/cli/orchestrate/test_control_cli.py
+++ b/tests/cli/orchestrate/test_control_cli.py
@@ -32,15 +32,21 @@ def temp_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return db_path
 
 
-async def _make_session(db: StateDB, *, invocation_kind: str = "flow") -> str:
-    sid = uuid.uuid4().hex[:12]
+async def _make_session(
+    db: StateDB,
+    *,
+    invocation_kind: str = "flow",
+    status: str = "running",
+    session_id: str | None = None,
+) -> str:
+    sid = session_id or uuid.uuid4().hex[:12]
     pid = uuid.uuid4().hex
     await db.create_progression(pid)
     await db.create_session(
         {
             "id": sid,
             "progression_id": pid,
-            "status": "running",
+            "status": status,
             "invocation_kind": invocation_kind,
             "started_at": time.time(),
         }
@@ -164,6 +170,72 @@ async def test_msg_enqueues_row_with_text_payload(temp_db_path: Path):
 def test_msg_unknown_id_returns_exit_unknown(temp_db_path: Path):
     rc = run_ctl_msg(argparse.Namespace(id="x" * 36, text="hi"))
     assert rc == EXIT_UNKNOWN
+
+
+# ── write-path guards: ambiguity, terminal sessions, non-flow kinds ─────────
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_prefix_rejected_no_row_written(temp_db_path: Path):
+    async with StateDB() as db:
+        sid_a = await _make_session(db, session_id="deadbeef1111")
+        sid_b = await _make_session(db, session_id="deadbeef2222")
+
+    rc = run_ctl_pause(argparse.Namespace(id="deadbeef"))
+    assert rc == EXIT_UNKNOWN
+
+    async with StateDB() as db:
+        for sid in (sid_a, sid_b):
+            assert await db.list_pending_session_controls(sid) == []
+
+
+@pytest.mark.asyncio
+async def test_unambiguous_prefix_still_resolves(temp_db_path: Path):
+    async with StateDB() as db:
+        sid = await _make_session(db, session_id="deadbeef1111")
+        await _make_session(db, session_id="feedface2222")
+
+    rc = run_ctl_pause(argparse.Namespace(id="deadbeef"))
+    assert rc == 0
+
+    async with StateDB() as db:
+        assert len(await db.list_pending_session_controls(sid)) == 1
+
+
+@pytest.mark.asyncio
+async def test_terminal_session_rejected_no_row_written(temp_db_path: Path):
+    async with StateDB() as db:
+        sid = await _make_session(db, status="completed")
+
+    rc = run_ctl_pause(argparse.Namespace(id=sid))
+    assert rc == EXIT_UNKNOWN
+
+    async with StateDB() as db:
+        assert await db.list_pending_session_controls(sid) == []
+
+
+@pytest.mark.asyncio
+async def test_non_poller_kind_rejected_no_row_written(temp_db_path: Path):
+    async with StateDB() as db:
+        sid = await _make_session(db, invocation_kind="agent")
+
+    rc = run_ctl_msg(argparse.Namespace(id=sid, text="hello"))
+    assert rc == EXIT_UNKNOWN
+
+    async with StateDB() as db:
+        assert await db.list_pending_session_controls(sid) == []
+
+
+@pytest.mark.asyncio
+async def test_play_kind_session_accepted(temp_db_path: Path):
+    async with StateDB() as db:
+        sid = await _make_session(db, invocation_kind="play")
+
+    rc = run_ctl_resume(argparse.Namespace(id=sid))
+    assert rc == 0
+
+    async with StateDB() as db:
+        assert len(await db.list_pending_session_controls(sid)) == 1
 
 
 # ── multiple controls queue independently ──────────────────────────────────

--- a/tests/cli/orchestrate/test_control_poller.py
+++ b/tests/cli/orchestrate/test_control_poller.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import pytest
 
-from lionagi.cli.orchestrate.flow import _apply_session_control
+from lionagi.cli.orchestrate.flow import _CONTROL_UNSTAMPED, _apply_session_control
 from lionagi.models.note import Note
 from lionagi.operations.node import Operation
 from lionagi.protocols.generic.pile import Pile
@@ -68,6 +68,19 @@ def _pending_operation() -> Operation:
     return Operation(operation="chat")
 
 
+class _FinalizeFailsDB:
+    """Delegates to a real StateDB but every finalize write raises."""
+
+    def __init__(self, db: StateDB):
+        self._db = db
+
+    def __getattr__(self, name):
+        return getattr(self._db, name)
+
+    async def finalize_session_control(self, *args, **kwargs):
+        raise RuntimeError("database is locked")
+
+
 # ── pause / resume: idempotent apply-then-stamp ─────────────────────────────
 
 
@@ -84,6 +97,24 @@ async def test_pause_applies_and_stamps(tmp_path: Path) -> None:
         finalized = await db.get_session_control(row["id"])
         assert finalized["applied_at"] is not None
         assert finalized["result"] == "applied"
+
+
+async def test_unstamped_row_returns_sentinel_and_stays_pending(tmp_path: Path) -> None:
+    """When no finalize write lands (transient DB failure), the sentinel tells
+    the poller to end the tick — otherwise a later control applied this tick
+    is overtaken by this row re-applying next tick (a resume undone by its
+    own stuck pause)."""
+    async with StateDB(tmp_path / "state.db") as db:
+        sid = await _make_session(db)
+        row = await _queue_control(db, sid, "pause")
+        executor = _FakeExecutor()
+
+        result = await _apply_session_control(_FinalizeFailsDB(db), executor, row)
+
+        assert result == _CONTROL_UNSTAMPED
+        assert executor.paused == 1, "the idempotent apply itself still runs"
+        pending = await db.list_pending_session_controls(sid)
+        assert [p["id"] for p in pending] == [row["id"]], "row must remain pending"
 
 
 async def test_resume_applies_and_stamps(tmp_path: Path) -> None:
@@ -279,7 +310,8 @@ async def test_exception_during_apply_is_caught_and_recorded(tmp_path: Path) -> 
 
 async def test_exception_during_finalize_does_not_raise(tmp_path: Path) -> None:
     """If even the finalize-on-error write fails, _apply_session_control must
-    still return a result string rather than propagating."""
+    return the unstamped sentinel (never propagate) so the poller ends the
+    tick with the row still pending."""
 
     class _BrokenDB:
         def __init__(self, real_db: StateDB):
@@ -298,5 +330,4 @@ async def test_exception_during_finalize_does_not_raise(tmp_path: Path) -> None:
 
         result = await _apply_session_control(_BrokenDB(db), executor, row)
 
-        assert result is not None
-        assert result.startswith("rejected:error:")
+        assert result == _CONTROL_UNSTAMPED

--- a/tests/cli/orchestrate/test_control_poller.py
+++ b/tests/cli/orchestrate/test_control_poller.py
@@ -1,0 +1,302 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for `_apply_session_control` (ADR-0085 part 1 control poller).
+
+Drives apply/stamp ordering per verb class against a real StateDB (for the
+finalize/mark-applying side effects) and a minimal fake executor (pause/
+resume calls recorded, a real Note context, a real Pile of Operation nodes
+for the message-injection "pending op" check).
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+from lionagi.cli.orchestrate.flow import _apply_session_control
+from lionagi.models.note import Note
+from lionagi.operations.node import Operation
+from lionagi.protocols.generic.pile import Pile
+from lionagi.protocols.types import EventStatus
+from lionagi.state.db import StateDB
+
+
+class _FakeGraph:
+    def __init__(self, nodes: Pile[Operation]):
+        self.internal_nodes = nodes
+
+
+class _FakeExecutor:
+    def __init__(self, *, nodes: Pile[Operation] | None = None, context: dict | None = None):
+        self.paused = 0
+        self.resumed = 0
+        self.context = Note(**(context or {}))
+        self.graph = _FakeGraph(nodes if nodes is not None else Pile(item_type={Operation}))
+
+    def pause(self) -> None:
+        self.paused += 1
+
+    def resume(self) -> None:
+        self.resumed += 1
+
+
+async def _make_session(db: StateDB) -> str:
+    sid = uuid.uuid4().hex[:12]
+    pid = uuid.uuid4().hex
+    await db.create_progression(pid)
+    await db.create_session(
+        {
+            "id": sid,
+            "progression_id": pid,
+            "status": "running",
+            "invocation_kind": "flow",
+            "started_at": time.time(),
+        }
+    )
+    return sid
+
+
+async def _queue_control(db: StateDB, session_id: str, verb: str, payload=None) -> dict:
+    control_id = await db.insert_session_control(session_id=session_id, verb=verb, payload=payload)
+    return await db.get_session_control(control_id)
+
+
+def _pending_operation() -> Operation:
+    return Operation(operation="chat")
+
+
+# ── pause / resume: idempotent apply-then-stamp ─────────────────────────────
+
+
+async def test_pause_applies_and_stamps(tmp_path: Path) -> None:
+    async with StateDB(tmp_path / "state.db") as db:
+        sid = await _make_session(db)
+        row = await _queue_control(db, sid, "pause")
+        executor = _FakeExecutor()
+
+        result = await _apply_session_control(db, executor, row)
+
+        assert result == "applied"
+        assert executor.paused == 1
+        finalized = await db.get_session_control(row["id"])
+        assert finalized["applied_at"] is not None
+        assert finalized["result"] == "applied"
+
+
+async def test_resume_applies_and_stamps(tmp_path: Path) -> None:
+    async with StateDB(tmp_path / "state.db") as db:
+        sid = await _make_session(db)
+        row = await _queue_control(db, sid, "resume")
+        executor = _FakeExecutor()
+
+        result = await _apply_session_control(db, executor, row)
+
+        assert result == "applied"
+        assert executor.resumed == 1
+        finalized = await db.get_session_control(row["id"])
+        assert finalized["result"] == "applied"
+
+
+async def test_pause_already_applied_not_stamped_is_safe_to_reapply(tmp_path: Path) -> None:
+    """Crash-window: apply succeeded but finalize() never landed (row still
+    pending). The poller's next pass re-applies — safe, since pause() is
+    idempotent on the executor and finalize() this time actually stamps it."""
+    async with StateDB(tmp_path / "state.db") as db:
+        sid = await _make_session(db)
+        row = await _queue_control(db, sid, "pause")
+        executor = _FakeExecutor()
+        executor.pause()  # simulate: apply already landed before the crash
+        assert executor.paused == 1
+
+        # Row is still pending (applied_at IS NULL) — poller re-applies it.
+        result = await _apply_session_control(db, executor, row)
+
+        assert result == "applied"
+        assert executor.paused == 2  # re-applying pause is harmless (idempotent gate)
+        finalized = await db.get_session_control(row["id"])
+        assert finalized["applied_at"] is not None
+
+
+async def test_pause_and_resume_are_excluded_from_pending_after_finalize(tmp_path: Path) -> None:
+    async with StateDB(tmp_path / "state.db") as db:
+        sid = await _make_session(db)
+        row = await _queue_control(db, sid, "pause")
+        executor = _FakeExecutor()
+
+        pending_before = await db.list_pending_session_controls(sid)
+        assert len(pending_before) == 1
+
+        await _apply_session_control(db, executor, row)
+
+        pending_after = await db.list_pending_session_controls(sid)
+        assert pending_after == []
+
+
+# ── message: non-idempotent stamp-then-apply ────────────────────────────────
+
+
+async def test_message_deep_merges_into_context_when_pending_op_exists(tmp_path: Path) -> None:
+    async with StateDB(tmp_path / "state.db") as db:
+        sid = await _make_session(db)
+        row = await _queue_control(db, sid, "message", payload={"text": "please slow down"})
+        nodes = Pile(item_type={Operation})
+        nodes.include(_pending_operation())
+        executor = _FakeExecutor(nodes=nodes)
+
+        result = await _apply_session_control(db, executor, row)
+
+        assert result == "applied"
+        messages = executor.context.content.get("operator_messages")
+        assert messages is not None
+        assert len(messages) == 1
+        assert messages[0]["text"] == "please slow down"
+        finalized = await db.get_session_control(row["id"])
+        assert finalized["result"] == "applied"
+        assert finalized["applied_at"] is not None
+
+
+async def test_message_appends_to_existing_operator_messages(tmp_path: Path) -> None:
+    async with StateDB(tmp_path / "state.db") as db:
+        sid = await _make_session(db)
+        row = await _queue_control(db, sid, "message", payload={"text": "second message"})
+        nodes = Pile(item_type={Operation})
+        nodes.include(_pending_operation())
+        executor = _FakeExecutor(
+            nodes=nodes, context={"operator_messages": [{"ts": 1.0, "text": "first message"}]}
+        )
+
+        await _apply_session_control(db, executor, row)
+
+        messages = executor.context.content["operator_messages"]
+        assert [m["text"] for m in messages] == ["first message", "second message"]
+
+
+async def test_message_rejected_when_no_pending_ops(tmp_path: Path) -> None:
+    """Checked, not assumed: an executor with no PENDING op must reject the
+    message rather than silently drop it into a context nothing will read."""
+    async with StateDB(tmp_path / "state.db") as db:
+        sid = await _make_session(db)
+        row = await _queue_control(db, sid, "message", payload={"text": "too late"})
+        completed_op = _pending_operation()
+        completed_op.execution.status = EventStatus.COMPLETED
+        nodes = Pile(item_type={Operation})
+        nodes.include(completed_op)
+        executor = _FakeExecutor(nodes=nodes)
+
+        result = await _apply_session_control(db, executor, row)
+
+        assert result == "rejected:no-pending-ops"
+        assert executor.context.content.get("operator_messages") is None
+        finalized = await db.get_session_control(row["id"])
+        assert finalized["applied_at"] is not None
+        assert finalized["result"] == "rejected:no-pending-ops"
+
+
+async def test_message_rejected_when_graph_empty(tmp_path: Path) -> None:
+    async with StateDB(tmp_path / "state.db") as db:
+        sid = await _make_session(db)
+        row = await _queue_control(db, sid, "message", payload={"text": "anyone there?"})
+        executor = _FakeExecutor()  # empty graph
+
+        result = await _apply_session_control(db, executor, row)
+
+        assert result == "rejected:no-pending-ops"
+
+
+async def test_message_stamped_applying_but_unapplied_is_not_reapplied(tmp_path: Path) -> None:
+    """Crash-window: mark_session_control_applying() landed but the poller
+    crashed before finalize_session_control(). At-most-once: the row must
+    stay result='applying' — a re-poll must skip it, not risk a double
+    injection if the earlier apply actually landed before the crash."""
+    async with StateDB(tmp_path / "state.db") as db:
+        sid = await _make_session(db)
+        control_id = await db.insert_session_control(
+            session_id=sid, verb="message", payload={"text": "in flight"}
+        )
+        await db.mark_session_control_applying(control_id)
+        row = await db.get_session_control(control_id)
+        assert row["result"] == "applying"
+        nodes = Pile(item_type={Operation})
+        nodes.include(_pending_operation())
+        executor = _FakeExecutor(nodes=nodes)
+
+        result = await _apply_session_control(db, executor, row)
+
+        assert result is None  # left untouched
+        assert executor.context.content.get("operator_messages") is None
+        still_row = await db.get_session_control(control_id)
+        assert still_row["applied_at"] is None
+        assert still_row["result"] == "applying"
+
+
+# ── unsupported verb / stop (schema-reserved, no CLI verb emits it) ────────
+
+
+async def test_stop_verb_is_rejected_as_unsupported(tmp_path: Path) -> None:
+    """'stop' is schema-reserved for a later slice (the checkpoint writer);
+    the poller must reject it loudly rather than silently no-op forever."""
+    async with StateDB(tmp_path / "state.db") as db:
+        sid = await _make_session(db)
+        row = await _queue_control(db, sid, "stop")
+        executor = _FakeExecutor()
+
+        result = await _apply_session_control(db, executor, row)
+
+        assert result == "rejected:unsupported-verb:stop"
+        finalized = await db.get_session_control(row["id"])
+        assert finalized["applied_at"] is not None
+
+
+# ── crash safety: apply must never raise into the caller ──────────────────
+
+
+async def test_exception_during_apply_is_caught_and_recorded(tmp_path: Path) -> None:
+    """The poller must never crash the run it rides alongside: an exploding
+    executor.pause() is caught, recorded as a rejected result, and does not
+    propagate."""
+
+    class _ExplodingExecutor(_FakeExecutor):
+        def pause(self) -> None:
+            raise RuntimeError("boom")
+
+    async with StateDB(tmp_path / "state.db") as db:
+        sid = await _make_session(db)
+        row = await _queue_control(db, sid, "pause")
+        executor = _ExplodingExecutor()
+
+        result = await _apply_session_control(db, executor, row)
+
+        assert result is not None
+        assert result.startswith("rejected:error:")
+        assert "boom" in result
+        finalized = await db.get_session_control(row["id"])
+        assert finalized["applied_at"] is not None
+        assert finalized["result"] == result
+
+
+async def test_exception_during_finalize_does_not_raise(tmp_path: Path) -> None:
+    """If even the finalize-on-error write fails, _apply_session_control must
+    still return a result string rather than propagating."""
+
+    class _BrokenDB:
+        def __init__(self, real_db: StateDB):
+            self._real = real_db
+
+        async def finalize_session_control(self, *_a, **_kw):
+            raise RuntimeError("db unreachable")
+
+        async def mark_session_control_applying(self, *a, **kw):
+            return await self._real.mark_session_control_applying(*a, **kw)
+
+    async with StateDB(tmp_path / "state.db") as db:
+        sid = await _make_session(db)
+        row = await _queue_control(db, sid, "pause")
+        executor = _FakeExecutor()
+
+        result = await _apply_session_control(_BrokenDB(db), executor, row)
+
+        assert result is not None
+        assert result.startswith("rejected:error:")

--- a/tests/cli/orchestrate/test_control_poller.py
+++ b/tests/cli/orchestrate/test_control_poller.py
@@ -331,3 +331,61 @@ async def test_exception_during_finalize_does_not_raise(tmp_path: Path) -> None:
         result = await _apply_session_control(_BrokenDB(db), executor, row)
 
         assert result == _CONTROL_UNSTAMPED
+
+
+async def test_finalize_retry_recovers_transient_failure(tmp_path: Path) -> None:
+    """A single transient finalize failure after a successful apply must end
+    with a truthful 'applied' stamp, never a rejected label."""
+
+    class _FlakyOnceDB:
+        def __init__(self, real_db: StateDB):
+            self._real = real_db
+            self._failed = False
+
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+        async def finalize_session_control(self, *a, **kw):
+            if not self._failed:
+                self._failed = True
+                raise RuntimeError("database is locked")
+            return await self._real.finalize_session_control(*a, **kw)
+
+    async with StateDB(tmp_path / "state.db") as db:
+        sid = await _make_session(db)
+        row = await _queue_control(db, sid, "pause")
+        executor = _FakeExecutor()
+
+        result = await _apply_session_control(_FlakyOnceDB(db), executor, row)
+
+        assert result == "applied"
+        assert executor.paused == 1
+        finalized = await db.get_session_control(row["id"])
+        assert finalized["result"] == "applied"
+
+
+async def test_message_finalize_failure_never_mislabels_or_reinjects(tmp_path: Path) -> None:
+    """An injected message whose finalize writes all fail stays 'applying'
+    (never 'rejected:...'), and the next poll skips it without a second
+    injection — the at-most-once guarantee survives the stamp failure."""
+    async with StateDB(tmp_path / "state.db") as db:
+        sid = await _make_session(db)
+        row = await _queue_control(db, sid, "message", payload={"text": "steer left"})
+        nodes = Pile(item_type={Operation})
+        nodes.include(_pending_operation())
+        executor = _FakeExecutor(nodes=nodes)
+        flaky = _FinalizeFailsDB(db)
+
+        result = await _apply_session_control(flaky, executor, row)
+
+        assert result == _CONTROL_UNSTAMPED
+        messages = executor.context.content.get("operator_messages")
+        assert messages is not None and len(messages) == 1
+        stored = await db.get_session_control(row["id"])
+        assert stored["result"] == "applying"
+
+        reread = await db.get_session_control(row["id"])
+        second = await _apply_session_control(flaky, executor, reread)
+
+        assert second is None, "an 'applying' row is skipped, not re-applied"
+        assert len(executor.context.content.get("operator_messages")) == 1

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -421,6 +421,7 @@ async def test_json_stable_shape(temp_db_path: Path):
         "status_reason_code",
         "status_reason_summary",
         "status_evidence_refs",
+        "pending_controls",
     }
     assert set(view.keys()) == expected_keys
 
@@ -693,3 +694,106 @@ def test_cli_play_status_help_subprocess():
     )
     assert result.returncode == 0
     assert "audit-degraded" in result.stdout.lower()
+
+
+# ── pending_controls (ADR-0085 part 1: session_controls transport) ────────
+
+
+@pytest.mark.asyncio
+async def test_view_pending_controls_empty_by_default(temp_db_path: Path):
+    async with StateDB() as db:
+        sid = await _make_session(db)
+        row = await db.get_session(sid)
+        view = await _build_view(db, command="ctl", entity_type="session", row=row)
+    assert view["pending_controls"] == []
+
+
+@pytest.mark.asyncio
+async def test_view_pending_controls_lists_queued_rows(temp_db_path: Path):
+    async with StateDB() as db:
+        sid = await _make_session(db)
+        c1 = await db.insert_session_control(session_id=sid, verb="pause", created_at=1.0)
+        c2 = await db.insert_session_control(session_id=sid, verb="resume", created_at=2.0)
+        row = await db.get_session(sid)
+        view = await _build_view(db, command="ctl", entity_type="session", row=row)
+
+    assert [c["id"] for c in view["pending_controls"]] == [c1, c2]
+    assert [c["verb"] for c in view["pending_controls"]] == ["pause", "resume"]
+
+
+@pytest.mark.asyncio
+async def test_view_pending_controls_excludes_applied(temp_db_path: Path):
+    async with StateDB() as db:
+        sid = await _make_session(db)
+        c1 = await db.insert_session_control(session_id=sid, verb="pause")
+        await db.finalize_session_control(c1, result="applied")
+        row = await db.get_session(sid)
+        view = await _build_view(db, command="ctl", entity_type="session", row=row)
+
+    assert view["pending_controls"] == []
+
+
+@pytest.mark.asyncio
+async def test_view_pending_controls_empty_when_no_backing_session(
+    temp_db_path: Path, no_project: None
+):
+    """entity_type='play' with no session_id → primary_session None → []
+    rather than an error (no backing session to query controls against)."""
+    async with StateDB() as db:
+        show_id = await _make_show(db)
+        play_id = await _make_play(db, show_id, session_id=None)
+        row = await db.get_play(play_id)
+        view = await _build_view(db, command="ctl", entity_type="play", row=row)
+    assert view["pending_controls"] == []
+
+
+@pytest.mark.asyncio
+async def test_ctl_status_json_includes_pending_controls(temp_db_path: Path):
+    async with StateDB() as db:
+        sid = await _make_session(db)
+        await db.insert_session_control(session_id=sid, verb="pause")
+
+    output, exit_code = await _run_status(command="ctl", entity_id=sid, as_json=True)
+    view = json.loads(output)
+    assert len(view["pending_controls"]) == 1
+    assert view["pending_controls"][0]["verb"] == "pause"
+
+
+@pytest.mark.asyncio
+async def test_ctl_status_human_renders_pending_controls(temp_db_path: Path):
+    async with StateDB() as db:
+        sid = await _make_session(db)
+        await db.insert_session_control(session_id=sid, verb="pause")
+
+    output, exit_code = await _run_status(command="ctl", entity_id=sid, as_json=False)
+    assert "pending controls" in output
+    assert "pause" in output
+
+
+def test_cli_ctl_pause_help_subprocess():
+    result = subprocess.run(
+        [sys.executable, "-m", "lionagi.cli", "o", "ctl", "pause", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "id" in result.stdout.lower()
+
+
+def test_cli_ctl_resume_help_subprocess():
+    result = subprocess.run(
+        [sys.executable, "-m", "lionagi.cli", "o", "ctl", "resume", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+
+
+def test_cli_ctl_msg_help_subprocess():
+    result = subprocess.run(
+        [sys.executable, "-m", "lionagi.cli", "o", "ctl", "msg", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "text" in result.stdout.lower()

--- a/tests/state/test_engine_schema.py
+++ b/tests/state/test_engine_schema.py
@@ -159,6 +159,7 @@ ALL_TABLES = {
     "session_signals",
     "engine_runs",
     "engine_defs",
+    "session_controls",
 }
 
 
@@ -173,7 +174,7 @@ async def sqlite_meta_engine(tmp_path):
     await engine.dispose()
 
 
-async def test_metadata_creates_all_21_tables(sqlite_meta_engine):
+async def test_metadata_creates_all_22_tables(sqlite_meta_engine):
     """metadata.create_all() builds every expected table in SQLite."""
     async with sqlite_meta_engine.connect() as conn:
         tables = await conn.run_sync(lambda sync_conn: set(sa.inspect(sync_conn).get_table_names()))
@@ -264,7 +265,7 @@ async def test_metadata_check_constraint_parity_vs_schema_sql(tmp_path, sqlite_m
         meta_checks = _checks(await conn.run_sync(_meta_rows))
 
     # Guard against the regex silently extracting nothing (would make equality trivial).
-    assert len(raw_checks) == 14, f"expected 14 enum CHECK columns, got {len(raw_checks)}"
+    assert len(raw_checks) == 15, f"expected 15 enum CHECK columns, got {len(raw_checks)}"
     drift = {
         k: {
             "schema_sql": sorted(raw_checks.get(k) or []),

--- a/tests/state/test_session_controls_db.py
+++ b/tests/state/test_session_controls_db.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for StateDB session_controls CRUD (ADR-0085 part 1: run control plane transport)."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+aiosqlite = pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
+
+from lionagi.state.db import StateDB  # noqa: E402
+
+
+async def _make_session(db: StateDB) -> str:
+    sid = uuid.uuid4().hex[:12]
+    pid = uuid.uuid4().hex
+    await db.create_progression(pid)
+    await db.create_session(
+        {
+            "id": sid,
+            "progression_id": pid,
+            "status": "running",
+            "invocation_kind": "flow",
+            "started_at": time.time(),
+        }
+    )
+    return sid
+
+
+async def test_insert_and_get_session_control(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    async with StateDB(db_path) as db:
+        sid = await _make_session(db)
+        control_id = await db.insert_session_control(session_id=sid, verb="pause")
+        row = await db.get_session_control(control_id)
+
+    assert row is not None
+    assert row["id"] == control_id
+    assert row["session_id"] == sid
+    assert row["verb"] == "pause"
+    assert row["payload"] is None
+    assert row["applied_at"] is None
+    assert row["result"] is None
+    assert row["created_at"] > 0
+
+
+async def test_get_session_control_returns_none_for_missing(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    async with StateDB(db_path) as db:
+        result = await db.get_session_control("nonexistent-control-id")
+    assert result is None
+
+
+async def test_insert_session_control_with_payload_round_trips(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    async with StateDB(db_path) as db:
+        sid = await _make_session(db)
+        control_id = await db.insert_session_control(
+            session_id=sid, verb="message", payload={"text": "hello there"}
+        )
+        row = await db.get_session_control(control_id)
+
+    assert row is not None
+    assert row["payload"] == {"text": "hello there"}
+
+
+async def test_insert_session_control_uses_explicit_created_at(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    async with StateDB(db_path) as db:
+        sid = await _make_session(db)
+        control_id = await db.insert_session_control(
+            session_id=sid, verb="resume", created_at=12345.5
+        )
+        row = await db.get_session_control(control_id)
+
+    assert row["created_at"] == 12345.5
+
+
+async def test_list_pending_session_controls_only_unapplied(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    async with StateDB(db_path) as db:
+        sid = await _make_session(db)
+        c1 = await db.insert_session_control(session_id=sid, verb="pause", created_at=1.0)
+        c2 = await db.insert_session_control(session_id=sid, verb="resume", created_at=2.0)
+        await db.finalize_session_control(c1, result="applied")
+
+        pending = await db.list_pending_session_controls(sid)
+
+    ids = [p["id"] for p in pending]
+    assert c2 in ids
+    assert c1 not in ids
+
+
+async def test_list_pending_session_controls_ordered_oldest_first(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    async with StateDB(db_path) as db:
+        sid = await _make_session(db)
+        c_new = await db.insert_session_control(session_id=sid, verb="pause", created_at=100.0)
+        c_old = await db.insert_session_control(session_id=sid, verb="resume", created_at=1.0)
+
+        pending = await db.list_pending_session_controls(sid)
+
+    assert [p["id"] for p in pending] == [c_old, c_new]
+
+
+async def test_list_pending_session_controls_scoped_to_session(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    async with StateDB(db_path) as db:
+        sid_a = await _make_session(db)
+        sid_b = await _make_session(db)
+        await db.insert_session_control(session_id=sid_a, verb="pause")
+        c_b = await db.insert_session_control(session_id=sid_b, verb="resume")
+
+        pending_b = await db.list_pending_session_controls(sid_b)
+
+    assert [p["id"] for p in pending_b] == [c_b]
+
+
+async def test_list_pending_session_controls_empty(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    async with StateDB(db_path) as db:
+        sid = await _make_session(db)
+        pending = await db.list_pending_session_controls(sid)
+    assert pending == []
+
+
+async def test_mark_session_control_applying_leaves_applied_at_null(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    async with StateDB(db_path) as db:
+        sid = await _make_session(db)
+        control_id = await db.insert_session_control(session_id=sid, verb="message")
+        await db.mark_session_control_applying(control_id)
+        row = await db.get_session_control(control_id)
+
+    assert row["result"] == "applying"
+    assert row["applied_at"] is None
+
+
+async def test_mark_session_control_applying_still_listed_pending(tmp_path: Path) -> None:
+    """result='applying' rows are still 'pending' (applied_at IS NULL) — the
+    poller/status surface distinguish never-touched from mid-apply-crashed
+    by inspecting the result field, not by excluding them from the list."""
+    db_path = tmp_path / "state.db"
+    async with StateDB(db_path) as db:
+        sid = await _make_session(db)
+        control_id = await db.insert_session_control(session_id=sid, verb="message")
+        await db.mark_session_control_applying(control_id)
+        pending = await db.list_pending_session_controls(sid)
+
+    assert len(pending) == 1
+    assert pending[0]["id"] == control_id
+    assert pending[0]["result"] == "applying"
+
+
+async def test_finalize_session_control_stamps_applied_at_and_result(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    async with StateDB(db_path) as db:
+        sid = await _make_session(db)
+        control_id = await db.insert_session_control(session_id=sid, verb="pause")
+        await db.finalize_session_control(control_id, result="applied")
+        row = await db.get_session_control(control_id)
+
+    assert row["applied_at"] is not None
+    assert row["result"] == "applied"
+
+
+async def test_finalize_session_control_with_rejected_reason(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    async with StateDB(db_path) as db:
+        sid = await _make_session(db)
+        control_id = await db.insert_session_control(session_id=sid, verb="message")
+        await db.finalize_session_control(control_id, result="rejected:no-pending-ops")
+        row = await db.get_session_control(control_id)
+
+    assert row["result"] == "rejected:no-pending-ops"
+    assert row["applied_at"] is not None
+
+
+async def test_session_controls_column_present(tmp_path: Path) -> None:
+    """Confirm the table + partial index exist via raw PRAGMA (schema_meta.py parity)."""
+    import aiosqlite
+
+    db_path = tmp_path / "state.db"
+    async with StateDB(db_path):
+        pass  # schema-create only
+
+    async with aiosqlite.connect(str(db_path)) as conn:
+        async with conn.execute("PRAGMA table_info(session_controls)") as cur:
+            cols = {r[1] async for r in cur}
+    assert cols == {"id", "session_id", "verb", "payload", "created_at", "applied_at", "result"}
+
+    async with aiosqlite.connect(str(db_path)) as conn:
+        async with conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='session_controls'"
+        ) as cur:
+            index_names = {r[0] async for r in cur}
+    assert "idx_session_controls_pending" in index_names
+
+
+async def test_session_controls_verb_check_constraint_rejects_invalid(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    async with StateDB(db_path) as db:
+        sid = await _make_session(db)
+        with pytest.raises(Exception):  # noqa: B017, PT011 — sqlite raises IntegrityError via SQLAlchemy
+            await db.insert_session_control(session_id=sid, verb="not-a-real-verb")
+
+
+async def test_session_controls_cascades_on_session_delete(tmp_path: Path) -> None:
+    from sqlalchemy import text
+
+    db_path = tmp_path / "state.db"
+    async with StateDB(db_path) as db:
+        sid = await _make_session(db)
+        control_id = await db.insert_session_control(session_id=sid, verb="pause")
+
+        async with db._tx() as conn:
+            await conn.execute(text("DELETE FROM sessions WHERE id = :id"), {"id": sid})
+
+        row = await db.get_session_control(control_id)
+
+    assert row is None
+
+
+async def test_concurrent_session_control_inserts_no_rows_dropped(tmp_path: Path) -> None:
+    import asyncio
+
+    db_path = tmp_path / "state.db"
+    n = 25
+    async with StateDB(db_path) as db:
+        sid = await _make_session(db)
+        await asyncio.gather(
+            *[db.insert_session_control(session_id=sid, verb="pause") for _ in range(n)]
+        )
+        pending = await db.list_pending_session_controls(sid)
+
+    assert len(pending) == n

--- a/tests/state/test_session_controls_db.py
+++ b/tests/state/test_session_controls_db.py
@@ -239,3 +239,26 @@ async def test_concurrent_session_control_inserts_no_rows_dropped(tmp_path: Path
         pending = await db.list_pending_session_controls(sid)
 
     assert len(pending) == n
+
+
+async def test_identical_created_at_apply_order_is_deterministic(tmp_path: Path) -> None:
+    """Two controls sharing one created_at float (rapid enqueues) must come
+    back in the same order on every read — an unstable tie would let a pause
+    and resume swap apply order between poll ticks."""
+    from sqlalchemy import text
+
+    db_path = tmp_path / "state.db"
+    async with StateDB(db_path) as db:
+        sid = await _make_session(db)
+        id_a = await db.insert_session_control(session_id=sid, verb="pause")
+        id_b = await db.insert_session_control(session_id=sid, verb="resume")
+        async with db._tx() as conn:
+            await conn.execute(
+                text("UPDATE session_controls SET created_at = :ts WHERE id IN (:a, :b)"),
+                {"ts": 1000.0, "a": id_a, "b": id_b},
+            )
+
+        first = [r["id"] for r in await db.list_pending_session_controls(sid)]
+        second = [r["id"] for r in await db.list_pending_session_controls(sid)]
+
+    assert first == second == sorted([id_a, id_b])


### PR DESCRIPTION
## Summary

Implements ADR-0085 part-1 control-plane transport (slice 2): a `session_controls` table, an in-process poller wired into `li o flow`'s DAG execution, and the `li o ctl pause|resume|msg` CLI surface.

- **Schema** (`state/schema_meta.py` + `state/schema.sql`, parity-checked): `session_controls` table (`id`, `session_id` FK `ON DELETE CASCADE`, `verb` CHECK IN `pause/resume/message/stop`, `payload` JSON, `created_at`, `applied_at`, `result`) plus a partial index on `(session_id, applied_at) WHERE applied_at IS NULL`. `stop` is schema-reserved for a later slice (the checkpoint writer) and is deliberately rejected by the poller rather than stubbed.
- **StateDB** (`state/db.py`): `insert_session_control`, `list_pending_session_controls`, `mark_session_control_applying`, `finalize_session_control`, `get_session_control`.
- **Poller** (`cli/orchestrate/flow.py`): 2s poll loop alongside the existing heartbeat task, reaching the live `DependencyAwareExecutor` via a new `executor_ref` threaded through `Session.flow()` → `flow()` → `Engine.run_dag()`. Apply/stamp ordering is verb-classed:
  - `pause`/`resume` (idempotent): apply against the executor, then stamp — safe to re-apply if the poller crashes between apply and stamp (at-least-once).
  - `message` (not idempotent): stamp `'applying'` first, attempt the deep-merge into the executor's context (rejecting when no `PENDING` operation exists to receive it), then finalize — a crash mid-apply leaves the row stuck at `'applying'`, which a later poll pass skips rather than risking a double injection (at-most-once).
  - Any exception during apply is caught, recorded on the row, and logged — the poller never crashes the run it rides alongside.
- **CLI** (`cli/orchestrate/_control.py`, `cli/orchestrate/__init__.py`, `cli/status.py`): `li o ctl pause <id>` / `resume <id>` / `msg <id> "text"` enqueue rows, reusing `status.py`'s generic session/invocation/play id resolver (short prefixes included). `stop` is intentionally absent — it depends on the checkpoint writer, a later slice. `li o ctl status` gains a `pending_controls` list (`id`, `verb`, `created_at`, oldest first) in both `--json` and human output.
- Zero pending controls is behavior-preserving: the poller sleeps, finds nothing, returns — no measurable overhead on a run with no controls queued.

## Known gap (out of scope for this slice, flagged for a future hardening pass)

Slice 1's pause gate (`operations/flow.py::DependencyAwareExecutor`) checks `self._pause_event` before `async with limiter:` but does not re-check it after limiter acquire — an operation already queued at the limiter when `pause()` fires will still start once a slot frees, since it already passed the gate. This does not affect this slice's transport/poller/CLI work and was not touched here to avoid scope creep beyond the session_controls/poller/CLI brief.

## Test plan

- [x] `tests/state/test_session_controls_db.py` — StateDB CRUD, schema/index presence, CHECK-constraint rejection, cascade-delete, concurrent-insert safety (16 tests)
- [x] `tests/cli/orchestrate/test_control_poller.py` — verb-classed apply/stamp ordering, crash-window re-apply/skip semantics, no-pending-op rejection, exception safety (12 tests)
- [x] `tests/cli/orchestrate/test_control_cli.py` — enqueue row shape, id resolution (session/invocation/short-prefix/unknown), multi-control ordering (11 tests)
- [x] `tests/cli/test_status.py` — `pending_controls` JSON/human rendering, empty-by-default, excludes-applied (8 new tests + 1 existing key-set test updated)
- [x] `tests/state/test_engine_schema.py` — updated for the 22nd table + 15th CHECK constraint
- [x] Full gate: `tests/cli/ tests/studio/ tests/state/` with `-p no:cacheprovider` — 1500 passed, 1 skipped (pre-existing, unrelated to `.lionagi/config.toml` absence), 1 pre-existing environmental failure excluded (see below)
- [x] `ruff check` + `ruff format --check` clean on all touched files

### Pre-existing environmental failure (not caused by this change)

`tests/cli/test_monitor.py::test_background_hint_includes_session_id` fails in this shared-venv worktree setup because `/Users/lion/projects/lionagi/.venv`'s editable-install pointer (`_editable_impl_lionagi.pth`) references a stale, already-deleted sibling worktree (`agent-a67d17793a332fe95...`, confirmed absent from disk — not this worktree and not either of the two other currently-active sibling worktrees). Any subprocess invocation of `python -m lionagi.cli` from outside a worktree that currently holds the editable pointer fails with `ModuleNotFoundError: No module named 'lionagi'`, independent of any source change (reproduced directly via `cd /tmp && python -c "import lionagi"` against the shared venv). Not remediated here since repointing the shared venv while two other agents are actively running in sibling worktrees risks disrupting their sessions — flagged for `λ:leo` as the shared-venv/env-wide-install owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)