### PR TITLE
fix(cli): restore callable main re-export on the cli package init

### DIFF
--- a/lionagi/cli/__init__.py
+++ b/lionagi/cli/__init__.py
@@ -1,9 +1,20 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
-"""lionagi command-line interface.
+"""lionagi command-line interface — `li` entry point."""
 
-The `li` entry point is `lionagi.cli.main:main`; import it from there.
-This package init stays empty so that importing any submodule (e.g.
-lionagi.cli._logging from lionagi.studio.cli, which main.py itself imports
-at module level) never re-enters main.py through the package init.
-"""
+__all__ = ("main",)
+
+
+def __getattr__(name: str):
+    # Lazy so that importing any lionagi.cli submodule (e.g. from
+    # lionagi.studio.cli, which main.py itself imports at module level)
+    # never re-enters main.py through the package init.
+    if name == "main":
+        from .main import main
+
+        # Importing .main also binds the submodule as this package's `main`
+        # attribute; pin the function over it so `from lionagi.cli import
+        # main` yields the callable, not the module.
+        globals()["main"] = main
+        return main
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -167,8 +167,8 @@ def test_cli_package_init_is_lazy():
     lionagi.studio.cli) must not pull in lionagi.cli.main — main.py imports
     lionagi.studio.cli at module level, so an eager package init would make
     every studio->cli._logging import re-enter a partially-initialized
-    module. The entry point is lionagi.cli.main:main; the package itself
-    exports nothing."""
+    module. `from lionagi.cli import main` still resolves to the callable
+    via the package's lazy __getattr__ re-export."""
     import subprocess
     import sys
 
@@ -177,7 +177,30 @@ def test_cli_package_init_is_lazy():
         "assert 'lionagi.cli.main' not in sys.modules, 'eager main import'; "
         "import lionagi.studio.cli; "
         "assert 'lionagi.cli.main' not in sys.modules, 'studio pulled main'; "
-        "import lionagi.cli.main; assert callable(lionagi.cli.main.main)"
+        "from lionagi.cli import main; assert callable(main), type(main); "
+        "import types; "
+        "assert not isinstance(main, types.ModuleType), type(main)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, timeout=120
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_cli_package_getattr_raises_for_unknown_attr():
+    """The package's __getattr__ only special-cases `main`; anything
+    else must raise AttributeError like a normal missing attribute."""
+    import subprocess
+    import sys
+
+    code = (
+        "import lionagi.cli as pkg\n"
+        "try:\n"
+        "    pkg.not_a_real_attribute\n"
+        "except AttributeError:\n"
+        "    pass\n"
+        "else:\n"
+        "    raise SystemExit('expected AttributeError for unknown attr')\n"
     )
     result = subprocess.run(
         [sys.executable, "-c", code], capture_output=True, text=True, timeout=120


### PR DESCRIPTION
## Summary

PR #1615 landed `lionagi/cli/__init__.py` as a docstring-only package init in its second commit, silently reverting the `__getattr__` re-export from its own first commit. That leaves `lionagi.cli` with no `main` attribute at all, so `from lionagi.cli import main` falls through to the import system's normal `package.submodule` fallback: it imports `lionagi.cli.main` and binds the **module** as `lionagi.cli.main`, not the `main` **callable**. Calling that "main" then raises `TypeError: 'module' object is not callable` — silently, with no error until something actually tries to call it.

This restores the `__getattr__` pin (the code the reverted PR's own description said was landing):

```python
def __getattr__(name: str):
    if name == "main":
        from .main import main
        globals()["main"] = main  # pin the callable over the submodule binding
        return main
    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
```

Importing `.main` inside `__getattr__` has the same submodule-binding side effect, so the explicit `globals()["main"] = main` overwrite is what makes `from lionagi.cli import main` resolve to the function.

## Verified (and a known limitation)

- `from lionagi.cli import main; assert callable(main)` now resolves the callable when the package attribute is accessed before `lionagi.cli.main` has been imported directly — confirmed with a subprocess probe and in `tests/cli/test_main.py::test_cli_package_init_is_lazy`.
- Unknown attributes still raise `AttributeError` (`tests/cli/test_main.py::test_cli_package_getattr_raises_for_unknown_attr`).
- Caveat, verified empirically: if `lionagi.cli.main` is imported directly *first* in a process (e.g. via the `li` console-script entry point `lionagi.cli.main:main`, or `lionagi/cli/__main__.py`'s `from .main import main`), Python's import machinery binds the submodule onto the package **before** `__getattr__` is ever invoked, and that binding is permanent for the rest of the process — `__getattr__` is a fallback that only fires when normal attribute lookup fails, and once the submodule is bound directly the lookup always succeeds. This matches the original revert commit's stated rationale (`46c166bd`) and I could not find a way to close it without eagerly importing `main.py` in the package init, which reintroduces the circular-import hazard documented in the removed docstring (`main.py` imports `lionagi.studio.cli` at module level, which imports `lionagi.cli._logging`). The `li` entry point itself is unaffected either way, since it never goes through the package-level `main` attribute.

Fixes #1622

🤖 Generated with [Claude Code](https://claude.com/claude-code)