### PR TITLE
fix(cli): li monitor filter gaps (project on plays, type-session drop, --run degenerate ids)

### DIFF
--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -192,8 +192,15 @@ async def _query_running_plays(
     db: Any,
     *,
     since: float | None = None,
+    project: str | None = None,
 ) -> list[dict[str, Any]]:
-    """In-flight statuses only by default; with since, all statuses in the window."""
+    """In-flight statuses only by default; with since, all statuses in the window.
+
+    The plays table has no project column, so project-scoping matches
+    against the project of the play's linked session (session_id) — the
+    same source of truth _query_running_sessions filters on. A play with
+    no linked session has no project to match and is excluded.
+    """
     query = (
         "SELECT plays.*, "  # noqa: S608
         "(SELECT COUNT(*) FROM branches WHERE session_id = plays.session_id) AS branch_count "
@@ -208,6 +215,9 @@ async def _query_running_plays(
         placeholders = ",".join("?" * len(running_statuses))
         query += f" AND status IN ({placeholders})"
         params.extend(running_statuses)
+    if project:
+        query += " AND plays.session_id IN (SELECT id FROM sessions WHERE project = ?)"
+        params.append(project)
     query += " ORDER BY updated_at DESC"
     rows = await db.fetch_all(query, params)
     return rows
@@ -621,7 +631,7 @@ async def _gather_table_rows(
 
     plays: list[dict[str, Any]] = []
     if entity_type in (None, "play"):
-        plays = await _query_running_plays(db, since=since)
+        plays = await _query_running_plays(db, since=since, project=project)
         # A play row is the canonical rendering of its backing session, so
         # drop that session only when the play row itself is being shown —
         # dedup against what this view actually fetched, never in SQL, so a
@@ -1329,7 +1339,7 @@ def add_monitor_subparser(subparsers: argparse._SubParsersAction) -> None:
         "--project",
         "-p",
         default=None,
-        help="Filter sessions by project name.",
+        help="Filter sessions and plays by project name.",
     )
     mon.add_argument(
         "--run",

--- a/tests/cli/test_monitor.py
+++ b/tests/cli/test_monitor.py
@@ -100,7 +100,12 @@ async def _make_show(db: StateDB, *, status: str = "active", topic: str = "test-
 
 
 async def _make_play(
-    db: StateDB, show_id: str, *, status: str = "running", name: str = "play-1"
+    db: StateDB,
+    show_id: str,
+    *,
+    status: str = "running",
+    name: str = "play-1",
+    session_id: str | None = None,
 ) -> str:
     play_id = uuid.uuid4().hex[:12]
     await db.create_play(
@@ -109,6 +114,7 @@ async def _make_play(
             "show_id": show_id,
             "name": name,
             "status": status,
+            "session_id": session_id,
             "started_at": time.time(),
         }
     )
@@ -378,6 +384,29 @@ async def test_gather_table_rows_project_filter(temp_db_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_gather_table_rows_project_filter_applies_to_plays(temp_db_path: Path) -> None:
+    """--project must scope plays too, not just sessions — the plays table
+    has no project column, so a play's project is inherited from its
+    linked session."""
+    async with StateDB() as db:
+        show_id = await _make_show(db)
+        sid_a = await _make_session(db, project="proj-a")
+        sid_b = await _make_session(db, project="proj-b")
+        play_a = await _make_play(db, show_id, name="play-a", session_id=sid_a)
+        play_b = await _make_play(db, show_id, name="play-b", session_id=sid_b)
+
+        rows_a = await _gather_table_rows(db, since=None, entity_type="play", project="proj-a")
+        rows_b = await _gather_table_rows(db, since=None, entity_type="play", project="proj-b")
+
+    ids_a = [r["id"] for r in rows_a]
+    ids_b = [r["id"] for r in rows_b]
+    assert play_a[:16] in ids_a
+    assert play_b[:16] not in ids_a
+    assert play_b[:16] in ids_b
+    assert play_a[:16] not in ids_b
+
+
+@pytest.mark.asyncio
 async def test_gather_table_rows_type_filter_session(temp_db_path: Path) -> None:
     async with StateDB() as db:
         sid = await _make_session(db)
@@ -512,6 +541,21 @@ async def test_since_shows_terminal_play(temp_db_path: Path) -> None:
 
     assert play_id[:16] in [r["id"] for r in rows_since]
     assert play_id[:16] not in [r["id"] for r in rows_default]
+
+
+@pytest.mark.asyncio
+async def test_since_shows_terminal_show(temp_db_path: Path) -> None:
+    """--since widens the shows query past the active-only filter to every
+    show status (e.g. 'completed')."""
+    async with StateDB() as db:
+        show_id = await _make_show(db, status="completed")
+        since = time.time() - 3600
+
+        rows_since = await _gather_table_rows(db, since=since, entity_type="show", project=None)
+        rows_default = await _gather_table_rows(db, since=None, entity_type="show", project=None)
+
+    assert show_id[:16] in [r["id"] for r in rows_since]
+    assert show_id[:16] not in [r["id"] for r in rows_default]
 
 
 # ── Integration: _find_entity ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **#1634** — `--project` was not applied to plays rows in the gathering layer. The `plays` table has no `project` column, so `_query_running_plays` now scopes plays by the project of their linked session (`session_id`) — the same source of truth `_query_running_sessions` uses. A play with no linked session has nothing to match and is excluded. Wired through `_gather_table_rows` and the `--project` help text.
- **#1628** — `--type session` silently dropping show-orchestrated play sessions. Investigated and found this was already fixed on `main` prior to this branch (a prior squash-merge moved the dedup logic out of an unconditional SQL `NOT` clause — which silently drops NULL-kind rows under three-valued SQL logic — into the Python gathering layer, scoped to only fire when the play row itself is being rendered). No code change needed; the existing regression test already pins this exact scenario.
- **#1608** — `li monitor --run <id>` with a degenerate/unknown id list silently exiting 0. Also already fixed on `main`: `run_monitor()`'s `--run` path already returns exit code 2 with a logged error when the id list splits to empty, matching `li monitor run`'s failure mode. Existing test asserts this.
- **#1631** — no regression test existed for `--since` widening the shows query past the active-only filter to terminal statuses within the time window. Added `test_since_shows_terminal_show` pinning this behavior.

Only #1634 required an actual code change (`_query_running_plays` project-join); #1631 required a new test. #1628 and #1608 were discovered already resolved on `main` via a prior squash-merge — confirmed via git history rather than re-implemented.

## Test plan

- [x] `tests/cli/test_monitor.py` — 71 passed (includes 2 new tests: `test_gather_table_rows_project_filter_applies_to_plays`, `test_since_shows_terminal_show`)
- [x] `tests/cli/test_monitor_run.py` — 59 passed (confirms #1608's existing fix/test untouched by this diff)
- [x] Full `tests/cli/` suite — 1042 passed, 1 skipped (unrelated environment-gated skip in `test_project.py`)
- [x] `ruff check` on both touched files — clean

Fixes #1634, Fixes #1628, Fixes #1608, Closes #1631

🤖 Generated with [Claude Code](https://claude.com/claude-code)