### PR TITLE
fix(cli): persist usage/error data for failed sessions in persist_session_end

### DIFF
--- a/lionagi/hooks/builtins.py
+++ b/lionagi/hooks/builtins.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import time
 import warnings
@@ -113,7 +114,9 @@ async def persist_session_end(
     if not already_terminal:
         fields["ended_at"] = time.time()
         if error is not None:
-            fields["node_metadata"] = {"error": error}
+            # update_session() binds this as a raw SQL param (no JSON
+            # bindparam), so pre-serialize to avoid sqlite3.InterfaceError.
+            fields["node_metadata"] = json.dumps({"error": error})
     if input_tokens is not None:
         fields["input_tokens"] = input_tokens
     if output_tokens is not None:

--- a/lionagi/hooks/builtins.py
+++ b/lionagi/hooks/builtins.py
@@ -116,7 +116,13 @@ async def persist_session_end(
         if error is not None:
             # update_session() binds this as a raw SQL param (no JSON
             # bindparam), so pre-serialize to avoid sqlite3.InterfaceError.
-            fields["node_metadata"] = json.dumps({"error": error})
+            # update_session() also does a plain column SET, not a merge, so
+            # start from whatever node_metadata the row already carries
+            # (e.g. identity markers) rather than clobbering it.
+            existing_metadata = row.get("node_metadata")
+            if not isinstance(existing_metadata, dict):
+                existing_metadata = {}
+            fields["node_metadata"] = json.dumps({**existing_metadata, "error": error})
     if input_tokens is not None:
         fields["input_tokens"] = input_tokens
     if output_tokens is not None:

--- a/tests/hooks/test_builtins.py
+++ b/tests/hooks/test_builtins.py
@@ -566,6 +566,55 @@ class TestSessionEndEmission:
             _m._SHARED.pop(db_path, None)
             _m._SHARED.pop(normalize_state_db_url(None), None)
 
+    async def test_non_terminal_error_persists_usage_and_error(self, monkeypatch, tmp_path):
+        """A raw {"error": ...} dict bind must not silently drop usage data.
+
+        Before the fix, the not-already-terminal branch assigned
+        fields["node_metadata"] = {"error": error} as a bare dict.
+        update_session()'s dynamic UPDATE builder binds fields as raw SQL
+        parameters (no JSON bindparam), so sqlite3.InterfaceError aborted the
+        whole statement — taking input_tokens/output_tokens/total_cost_usd/
+        num_turns/status down with it — and HookBus.emit() swallows handler
+        exceptions, so the failure was silent.
+        """
+        from lionagi.hooks.builtins import persist_session_end
+        from lionagi.hooks.bus import HookBus, HookPoint
+
+        db_path = _redirect_shared_db(monkeypatch, tmp_path)
+
+        db = await _shared(db_path)
+        try:
+            sid, prog_id = "se-err-nonterm-1", "prog-se-5"
+            await _seed_session(db, sid, prog_id, status="running")
+
+            bus = HookBus()
+            bus.on(HookPoint.SESSION_END, persist_session_end)
+            await bus.emit(
+                HookPoint.SESSION_END,
+                session_id=sid,
+                status="failed",
+                error="ValueError: boom",
+                input_tokens=42,
+                output_tokens=7,
+                total_cost_usd=0.01,
+                num_turns=3,
+            )
+
+            row = await db.get_session(sid)
+            assert row["status"] == "failed"
+            assert row["input_tokens"] == 42
+            assert row["output_tokens"] == 7
+            assert row["total_cost_usd"] == 0.01
+            assert row["num_turns"] == 3
+            assert row["node_metadata"] == {"error": "ValueError: boom"}
+        finally:
+            await db.close()
+            import lionagi.state.db as _m
+            from lionagi.state.engine import normalize_state_db_url
+
+            _m._SHARED.pop(db_path, None)
+            _m._SHARED.pop(normalize_state_db_url(None), None)
+
 
 class TestBranchCreateEmission:
     """BRANCH_CREATE emit → persist handler fires and is idempotent."""

--- a/tests/hooks/test_builtins.py
+++ b/tests/hooks/test_builtins.py
@@ -567,7 +567,8 @@ class TestSessionEndEmission:
             _m._SHARED.pop(normalize_state_db_url(None), None)
 
     async def test_non_terminal_error_persists_usage_and_error(self, monkeypatch, tmp_path):
-        """A raw {"error": ...} dict bind must not silently drop usage data.
+        """A raw {"error": ...} dict bind must not silently drop usage data,
+        and must not clobber node_metadata the row already carries.
 
         Before the fix, the not-already-terminal branch assigned
         fields["node_metadata"] = {"error": error} as a bare dict.
@@ -576,6 +577,10 @@ class TestSessionEndEmission:
         whole statement — taking input_tokens/output_tokens/total_cost_usd/
         num_turns/status down with it — and HookBus.emit() swallows handler
         exceptions, so the failure was silent.
+
+        Even once pre-serialized, update_session() does a plain column SET,
+        not a merge, so the fix must read the row's existing node_metadata
+        and merge {"error": error} into it rather than overwrite wholesale.
         """
         from lionagi.hooks.builtins import persist_session_end
         from lionagi.hooks.bus import HookBus, HookPoint
@@ -586,6 +591,9 @@ class TestSessionEndEmission:
         try:
             sid, prog_id = "se-err-nonterm-1", "prog-se-5"
             await _seed_session(db, sid, prog_id, status="running")
+            await db.set_session_provenance(
+                sid, node_metadata={"identity": "marker-1", "kind": "cli"}
+            )
 
             bus = HookBus()
             bus.on(HookPoint.SESSION_END, persist_session_end)
@@ -606,7 +614,11 @@ class TestSessionEndEmission:
             assert row["output_tokens"] == 7
             assert row["total_cost_usd"] == 0.01
             assert row["num_turns"] == 3
-            assert row["node_metadata"] == {"error": "ValueError: boom"}
+            assert row["node_metadata"] == {
+                "identity": "marker-1",
+                "kind": "cli",
+                "error": "ValueError: boom",
+            }
         finally:
             await db.close()
             import lionagi.state.db as _m


### PR DESCRIPTION
## Summary

- `persist_session_end()` built `fields["node_metadata"] = {"error": error}` as a bare Python dict in the not-already-terminal branch. `update_session()`'s dynamic UPDATE builder binds every field as a raw SQL parameter (no JSON `bindparam` for `node_metadata`), so aiosqlite raised `sqlite3.InterfaceError` on the dict.
- `HookBus.emit()` logs handler exceptions but does not re-raise, so the whole UPDATE silently failed — taking `input_tokens`, `output_tokens`, `total_cost_usd`, `num_turns`, and the `status`/`reason_code` transition down with it along with the error. This dropped exactly the data a failed session needs most.
- Fix: `json.dumps()` the dict before assigning it to `fields["node_metadata"]`, matching the pre-serialization convention every other `update_session()` caller already follows (`_teardown_common` in `lionagi/cli/_runs.py`, the three call sites in `lionagi/cli/orchestrate/flow.py`).
- Added a regression test (`test_non_terminal_error_persists_usage_and_error`) that seeds a non-terminal session, emits `SESSION_END` with an error plus usage fields, and asserts all of them land on the row.

**Divergence from the issue's literal repro:** the issue's example reproduces by seeding a session already in a terminal status (e.g. `failed`) and then emitting `SESSION_END`. Against current `main` that path no longer reaches the dict-bind: PR #1603 (already merged, `ce4b6b591`) added an `if not already_terminal:` guard so `persist_session_end` never touches `node_metadata` for an already-terminal row (that data is intentionally owned by `_teardown_common()` at that point, and is covered by the existing `test_already_terminal_with_error_preserves_node_metadata` test). The same root cause and failure class is still live in the **non-terminal** branch — i.e. a session that is `running` when `SESSION_END` fires with an error — which is the scenario this PR's test reproduces and fixes.

Fixes #1604

## Test plan

- [x] New regression test fails on pre-fix code with `sqlite3.InterfaceError: Error binding parameter 1 - probably unsupported type`, wiping `status`/`input_tokens`/`output_tokens`/`total_cost_usd`/`num_turns`/`node_metadata` from the row (confirmed via Edit-tool toggle, not git).
- [x] Same test passes post-fix: `1 passed`.
- [x] `PYTHONPATH=$PWD python -m pytest tests/hooks/ tests/state/ tests/cli/orchestrate/test_live_persist.py -p no:cacheprovider` → `483 passed, 3 skipped` (skips are pre-existing Postgres-testcontainer-unavailable skips, unrelated to this change).
- [x] `ruff check lionagi/hooks/builtins.py tests/hooks/test_builtins.py` → All checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
