### PR TITLE
fix(scheduler): reject empty action_model + action_extra_args for kind=agent

### DIFF
--- a/lionagi/studio/scheduler/subprocess.py
+++ b/lionagi/studio/scheduler/subprocess.py
@@ -231,6 +231,24 @@ def build_argv(schedule: dict, trigger_context: dict) -> tuple[list[str], str | 
         # the --agent profile's own default model. Passing an empty string as
         # the model positional would instead be parsed as an explicit (blank)
         # model spec, overriding the profile default and crashing Branch init.
+        #
+        # But omitting the model positional only holds the "extra positionals
+        # are rejected loudly" invariant when there are no extra args to
+        # append: with model omitted, a single action_extra_args token brings
+        # the positional count back up to 2 (the same arity as [model,
+        # prompt]), so the CLI's resolver would silently reparse the real
+        # prompt as MODEL and the extra-args token as PROMPT instead of
+        # failing. Reject that combination here rather than let it corrupt
+        # argument positions at fire time.
+        if not model and isinstance(extra, list) and extra:
+            raise ValueError(
+                "action_extra_args is not supported together with an empty "
+                "action_model for kind='agent': omitting the model "
+                "positional makes the extra-args token(s) indistinguishable "
+                "from an explicit [model, prompt] pair, which would silently "
+                "misroute action_prompt as the model. Set action_model "
+                "explicitly, or clear action_extra_args."
+            )
         positionals = [model, prompt] if model else [prompt]
         argv += ["agent", *flags, "--", *positionals]
 

--- a/tests/cli/test_argv_injection.py
+++ b/tests/cli/test_argv_injection.py
@@ -121,6 +121,56 @@ class TestBuildArgvActionModelInjection:
         positionals = argv[argv.index("--") + 1 :]
         assert positionals == ["sonnet", "hello world"]
 
+    def test_model_empty_with_extra_args_raises(self):
+        """Regression: when kind='agent' omits the model positional (falsy
+        action_model), a non-empty action_extra_args token collapses the CLI
+        down to exactly 2 positionals -- the same arity as the historical
+        [model, prompt] shape -- so `li agent`'s model/prompt resolver
+        silently reparses the real prompt as MODEL and the extra-args token
+        as PROMPT instead of failing loudly. This combination must raise at
+        build time."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        with pytest.raises(ValueError, match="action_extra_args"):
+            build_argv(
+                _schedule(
+                    action_model="",
+                    action_agent="researcher",
+                    action_extra_args=["strict"],
+                ),
+                {},
+            )
+
+    def test_model_none_with_extra_args_raises(self):
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        with pytest.raises(ValueError, match="action_extra_args"):
+            build_argv(
+                _schedule(
+                    action_model=None,
+                    action_agent="researcher",
+                    action_extra_args=["strict"],
+                ),
+                {},
+            )
+
+    def test_model_set_with_extra_args_still_accepted(self):
+        """Non-empty action_model + action_extra_args is unaffected: the
+        positional count is unambiguous (model, prompt) regardless of the
+        extra tokens appended after them."""
+        from lionagi.studio.scheduler.subprocess import build_argv
+
+        argv, tmp = build_argv(
+            _schedule(
+                action_model="sonnet",
+                action_agent="researcher",
+                action_extra_args=["strict"],
+            ),
+            {},
+        )
+        positionals = argv[argv.index("--") + 1 :]
+        assert positionals == ["sonnet", "hello world", "strict"]
+
     def test_model_valid_identifiers_accepted(self):
         from lionagi.studio.scheduler.subprocess import build_argv
 


### PR DESCRIPTION
## Summary

- PR #1609 fixed `build_argv()`'s `kind == "agent"` branch to omit the model positional when `action_model` is falsy, so `li agent`'s `--agent <profile>` default model applies instead of a blank/overriding model.
- That change left the positional-count safety invariant broken for one combination: when `action_model` is falsy **and** `action_extra_args` is non-empty, the single omitted-model positional plus one extra-args token collapses back to exactly 2 positionals — the same arity as the historical `[model, prompt]` shape. `li agent`'s model/prompt resolver then silently reparses the real prompt as `MODEL` and the extra-args token as `PROMPT`, instead of the loud `rc=1` failure the invariant used to guarantee.
- This PR closes the gap: `build_argv` now raises `ValueError` for `kind == "agent"` when `action_model` is empty/`None` and `action_extra_args` is non-empty, matching the existing `flow_yaml` precedent of failing loudly at build time.

## Test plan

- [x] Added failing-first regression tests (`test_model_empty_with_extra_args_raises`, `test_model_none_with_extra_args_raises`) confirming the old code silently produced the ambiguous 2-positional argv instead of raising.
- [x] Added `test_model_set_with_extra_args_still_accepted` confirming a non-empty `action_model` + extra args combination is unaffected (still unambiguous 3-positional shape).
- [x] `tests/cli/test_argv_injection.py` full file: 105 passed.
- [x] `tests/cli/`, `tests/studio/` full suites: all passed (1 unrelated skip: missing `.lionagi/config.toml` in checkout).
- [x] `ruff check` on touched files: all checks passed.

Fixes #1610

🤖 Generated with [Claude Code](https://claude.com/claude-code)