### PR TITLE
fix(studio): reject empty cron_expr on cron-triggered schedules

### DIFF
--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -63,9 +63,16 @@ def _svc_validate_extra_args(extra: list | None) -> None:
     _validate_extra_args(extra)
 
 
-def _svc_validate_cron_expr(expr: str | None) -> None:
-    """Service-boundary check: reject a syntactically invalid cron expression."""
+def _svc_validate_cron_expr(expr: str | None, *, required: bool = False) -> None:
+    """Service-boundary check: reject a syntactically invalid cron expression.
+
+    `required=True` also rejects a missing/empty expression — callers pass
+    this when trigger_type == "cron", since a cron-triggered schedule with no
+    expression commits fine but never fires (next_fire_at stays None forever).
+    """
     if not expr:
+        if required:
+            raise ValueError("cron_expr is required when trigger_type is 'cron'")
         return
     from croniter import croniter
 
@@ -307,7 +314,7 @@ async def create_schedule(data: dict[str, Any]) -> dict[str, Any]:
     _svc_validate_extra_args(data.get("action_extra_args"))
     _svc_validate_github_repo(data.get("github_repo"))
     if data.get("trigger_type") == "cron":
-        _svc_validate_cron_expr(data.get("cron_expr"))
+        _svc_validate_cron_expr(data.get("cron_expr"), required=True)
 
     if data.get("action_kind") == "flow_yaml":
         yaml_text = data.get("action_flow_yaml") or ""
@@ -370,7 +377,7 @@ async def update_schedule(schedule_id: str, fields: dict[str, Any]) -> bool:
                 raise ValueError(f"Invalid flow_yaml spec: {spec_err}")
         touches_trigger = "cron_expr" in fields or "trigger_type" in fields
         if touches_trigger and effective.get("trigger_type") == "cron":
-            _svc_validate_cron_expr(effective.get("cron_expr"))
+            _svc_validate_cron_expr(effective.get("cron_expr"), required=True)
 
         await db.update_schedule(schedule_id, **fields)
 

--- a/tests/studio/test_schedule_tz_recompute.py
+++ b/tests/studio/test_schedule_tz_recompute.py
@@ -329,7 +329,7 @@ async def test_enable_recompute_failure_does_not_raise(temp_db_path, caplog, mon
 async def test_create_cron_empty_string_expr_rejected(temp_db_path):
     """A cron-triggered create with an empty cron_expr must not commit — the
     falsy early-return in the validator used to let this through, producing a
-    schedule whose next_fire_at is never set (issue #1638)."""
+    schedule whose next_fire_at is never set."""
     from lionagi.studio.services.schedules import create_schedule, get_schedule_by_name
 
     with pytest.raises(ValueError, match="cron_expr is required"):

--- a/tests/studio/test_schedule_tz_recompute.py
+++ b/tests/studio/test_schedule_tz_recompute.py
@@ -323,3 +323,106 @@ async def test_enable_recompute_failure_does_not_raise(temp_db_path, caplog, mon
         row = await db.get_schedule(sid)
     assert row["enabled"] == 1  # the enable flag still committed
     assert any("Failed to recompute next_fire_at" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_create_cron_empty_string_expr_rejected(temp_db_path):
+    """A cron-triggered create with an empty cron_expr must not commit — the
+    falsy early-return in the validator used to let this through, producing a
+    schedule whose next_fire_at is never set (issue #1638)."""
+    from lionagi.studio.services.schedules import create_schedule, get_schedule_by_name
+
+    with pytest.raises(ValueError, match="cron_expr is required"):
+        await create_schedule(
+            {
+                "name": "create-empty-cron-test",
+                "trigger_type": "cron",
+                "cron_expr": "",
+                "action_kind": "agent",
+                "action_prompt": "ping",
+            }
+        )
+
+    assert await get_schedule_by_name("create-empty-cron-test") is None
+
+
+@pytest.mark.asyncio
+async def test_create_cron_none_expr_rejected(temp_db_path):
+    """Same as above but cron_expr omitted entirely (None)."""
+    from lionagi.studio.services.schedules import create_schedule, get_schedule_by_name
+
+    with pytest.raises(ValueError, match="cron_expr is required"):
+        await create_schedule(
+            {
+                "name": "create-none-cron-test",
+                "trigger_type": "cron",
+                "action_kind": "agent",
+                "action_prompt": "ping",
+            }
+        )
+
+    assert await get_schedule_by_name("create-none-cron-test") is None
+
+
+@pytest.mark.asyncio
+async def test_patch_flip_to_cron_without_expr_rejected(temp_db_path):
+    """A PATCH that flips trigger_type to 'cron' while cron_expr is absent (and
+    was never set) on the effective row must also be rejected — the
+    touches_trigger gate fires on trigger_type alone."""
+    from lionagi.state.db import StateDB
+    from lionagi.studio.services.schedules import create_schedule, update_schedule
+
+    created = await create_schedule(
+        {
+            "name": "patch-flip-to-cron-test",
+            "trigger_type": "interval",
+            "interval_sec": 60,
+            "action_kind": "agent",
+            "action_prompt": "ping",
+        }
+    )
+    sid = created["id"]
+
+    with pytest.raises(ValueError, match="cron_expr is required"):
+        await update_schedule(sid, {"trigger_type": "cron"})
+
+    async with StateDB() as db:
+        row = await db.get_schedule(sid)
+    assert row["trigger_type"] == "interval"  # untouched — rejected before commit
+
+
+@pytest.mark.asyncio
+async def test_create_cron_valid_expr_still_accepted(temp_db_path):
+    """A valid cron_expr on a cron-triggered create still passes (regression
+    guard for the required=True change)."""
+    from lionagi.studio.services.schedules import create_schedule
+
+    created = await create_schedule(
+        {
+            "name": "create-valid-cron-test",
+            "trigger_type": "cron",
+            "cron_expr": "0 18 * * *",
+            "action_kind": "agent",
+            "action_prompt": "ping",
+        }
+    )
+    assert created["name"] == "create-valid-cron-test"
+
+
+@pytest.mark.asyncio
+async def test_create_non_cron_empty_expr_still_accepted(temp_db_path):
+    """A non-cron trigger with an empty/absent cron_expr is unaffected — the
+    required check only applies when trigger_type == 'cron'."""
+    from lionagi.studio.services.schedules import create_schedule
+
+    created = await create_schedule(
+        {
+            "name": "create-interval-empty-cron-test",
+            "trigger_type": "interval",
+            "interval_sec": 60,
+            "cron_expr": "",
+            "action_kind": "agent",
+            "action_prompt": "ping",
+        }
+    )
+    assert created["name"] == "create-interval-empty-cron-test"

--- a/tests/studio/test_schedule_tz_recompute.py
+++ b/tests/studio/test_schedule_tz_recompute.py
@@ -392,6 +392,32 @@ async def test_patch_flip_to_cron_without_expr_rejected(temp_db_path):
 
 
 @pytest.mark.asyncio
+async def test_patch_blank_expr_on_cron_schedule_rejected(temp_db_path):
+    """A PATCH that blanks cron_expr on an existing cron schedule is rejected —
+    the touches_trigger gate fires on cron_expr alone."""
+    from lionagi.state.db import StateDB
+    from lionagi.studio.services.schedules import create_schedule, update_schedule
+
+    created = await create_schedule(
+        {
+            "name": "patch-blank-cron-expr-test",
+            "trigger_type": "cron",
+            "cron_expr": "0 18 * * *",
+            "action_kind": "agent",
+            "action_prompt": "ping",
+        }
+    )
+    sid = created["id"]
+
+    with pytest.raises(ValueError, match="cron_expr is required"):
+        await update_schedule(sid, {"cron_expr": ""})
+
+    async with StateDB() as db:
+        row = await db.get_schedule(sid)
+    assert row["cron_expr"] == "0 18 * * *"  # untouched — rejected before commit
+
+
+@pytest.mark.asyncio
 async def test_create_cron_valid_expr_still_accepted(temp_db_path):
     """A valid cron_expr on a cron-triggered create still passes (regression
     guard for the required=True change)."""


### PR DESCRIPTION
## Summary

- `_svc_validate_cron_expr` in `lionagi/studio/services/schedules.py` returned early on a falsy `cron_expr`, so a schedule with `trigger_type=\"cron\"` and an empty or missing `cron_expr` passed validation at both create and PATCH.
- The row committed fine, but `_compute_next_fire` returns `None` on the empty expression, so `next_fire_at` is never set and the tick loop never picks the schedule up — a silently dead schedule that consumes tick cycles with no error surfaced to the caller.
- Added a `required` flag to the validator, set at both cron-gated call sites (`create_schedule`, and the PATCH `touches_trigger` branch in `update_schedule`), so a cron trigger without an expression now raises a clear `ValueError` (→ 400) before anything commits. A PATCH that flips `trigger_type` to `\"cron\"` while `cron_expr` is absent on the effective row is rejected the same way.
- Non-cron triggers are unaffected — the required check only applies when `trigger_type == \"cron\"`.

Closes #1638

## Test plan

- [x] `tests/studio/test_schedule_tz_recompute.py`: create with `cron_expr=\"\"` rejected
- [x] create with `cron_expr=None`/absent rejected
- [x] PATCH flipping `trigger_type` to `cron` with no `cron_expr` on the row rejected
- [x] valid cron expr on create still accepted (regression guard)
- [x] non-cron trigger with empty `cron_expr` still accepted
- [x] `PYTHONPATH=$PWD python -m pytest tests/studio/` — 131 passed
- [x] `ruff check` on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)