### PR TITLE
test: make lean_coding no-preamble test actually pin the guarantee

### DIFF
--- a/tests/agent/test_spec.py
+++ b/tests/agent/test_spec.py
@@ -110,13 +110,17 @@ class TestAgentSpecLeanCoding:
         spec = AgentSpec.lean_coding(task_class="edit")
         assert spec.lion_system is False
 
-    def test_system_message_no_lion_preamble(self):
+    async def test_lean_coding_no_lion_preamble_at_runtime(self):
+        # build_system_message() never includes the LION preamble regardless
+        # of lion_system; the preamble is prepended by create_agent(). Drive
+        # the real factory path so a regression there is actually caught.
         from lionagi.session.prompts import LION_SYSTEM_MESSAGE
 
         spec = AgentSpec.lean_coding(task_class="edit")
-        msg = spec.build_system_message()
-        lion_marker = "LION_SYSTEM_MESSAGE"
-        assert lion_marker not in msg
+        branch = await create_agent(spec, load_settings=False)
+        sys_msg = branch.msgs.system
+        assert sys_msg is not None
+        assert LION_SYSTEM_MESSAGE.strip() not in sys_msg.rendered
 
     def test_edit_tools(self):
         spec = AgentSpec.lean_coding(task_class="edit")


### PR DESCRIPTION
## Summary

`test_system_message_no_lion_preamble` (added on this branch, PR #1545) was vacuously true: it compared the variable name `"LION_SYSTEM_MESSAGE"` (a string literal) against `build_system_message()` output, and `build_system_message()` never includes the LION preamble regardless of `lion_system` anyway — the preamble is only prepended inside `create_agent()` (`lionagi/agent/factory.py`). The test would pass unconditionally, whether or not the factory-level guard actually worked.

- Replaced it with `test_lean_coding_no_lion_preamble_at_runtime`, which drives a `lean_coding` spec through `create_agent(spec, load_settings=False)` (same pattern already used by `test_create_agent_system_prompt_without_lion_system` in `tests/agent/test_factory.py`) and asserts the rendered system message excludes `LION_SYSTEM_MESSAGE`.
- No source changes — the guarantee itself (`create_agent` checking `spec.lion_system` before prepending) was already correct; only the test was broken.

Base is `feat/agent-lean-coding-profile` (PR #1545, draft) since that's where `AgentSpec.lean_coding()` and this test currently live — `lean_coding` is not yet on `main`.

Closes #1554

## Test plan

- [x] `pytest tests/agent/test_spec.py` — 62 passed
- [x] `pytest tests/agent/` (full directory) — 197 passed
- [x] `ruff check` — clean
- [x] Red-green: temporarily forced the preamble branch in `factory.py` locally (`if spec.lion_system:` → `if True:`) — new test failed as expected; reverted, confirmed green again. Change never committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)