### PR TITLE
fix(cli): apply --effort override on li agent resume for CLI endpoints

### DIFF
--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -351,9 +351,18 @@ async def _run_agent(
             elif provider in PROVIDERS_EFFORT_VIA_MODEL_NAME:
                 # agy (Antigravity CLI) has no effort kwarg — fold effort into
                 # the resolved --model name instead (see resolve_agy_model).
+                # cfg["model"] here is the *persisted* prior resolution
+                # (already a concrete agy display name) unless the caller
+                # also passed a new model_str this turn — reapply_effort
+                # lets a fresh --effort replace that persisted suffix,
+                # while an explicit model_str given on this call still wins.
                 from lionagi.providers.google.gemini_code import resolve_agy_model
 
-                cfg["model"] = resolve_agy_model(cfg.get("model"), effort=effort)
+                cfg["model"] = resolve_agy_model(
+                    cfg.get("model"),
+                    effort=effort,
+                    reapply_effort=model_str is None,
+                )
         if bypass:
             cfg.update(PROVIDER_BYPASS_KWARGS.get(provider, {}))
         elif yolo:

--- a/lionagi/providers/google/gemini_code.py
+++ b/lionagi/providers/google/gemini_code.py
@@ -132,7 +132,12 @@ _MODEL_ALIASES: dict[str, str] = {
 }
 
 
-def resolve_agy_model(model: str | None, effort: str | None = None) -> str:
+def resolve_agy_model(
+    model: str | None,
+    effort: str | None = None,
+    *,
+    reapply_effort: bool = False,
+) -> str:
     """Map a lionagi model spec onto an exact `agy --model` name.
 
     agy has no effort flag/kwarg — effort is expressed only as the
@@ -141,11 +146,24 @@ def resolve_agy_model(model: str | None, effort: str | None = None) -> str:
     that suffix for the Gemini flash/pro families instead of the family
     default below (`_clamp_gemini_effort` collapses onto Gemini 3.1 Pro's
     Low/High-only range). An exact `(...)`-qualified `model` — already a
-    concrete agy display name — always wins over `effort`.
+    concrete agy display name — always wins over `effort` by default.
+
+    `reapply_effort=True` bypasses that short-circuit for the Gemini
+    flash/pro families so a new `effort` can replace the suffix already
+    baked into `model`. Callers set this only when `model` is a *persisted*
+    prior resolution rather than something the caller typed on this
+    invocation (e.g. `li agent -r ... --effort ...` re-applying effort to
+    a resumed branch's already-resolved model, with no new `--model` given)
+    — a model the caller explicitly pinned this turn must still win.
     """
     if not model:
         model = "gemini-3.5-flash"
     if model in _AGY_MODELS:
+        if reapply_effort and effort is not None:
+            if model.startswith("Gemini 3.5 Flash"):
+                return f"Gemini 3.5 Flash ({_clamp_gemini_effort(effort, False)})"
+            if model.startswith("Gemini 3.1 Pro"):
+                return f"Gemini 3.1 Pro ({_clamp_gemini_effort(effort, True)})"
         return model
     key = model.strip().lower()
     if key in _MODEL_ALIASES:

--- a/tests/cli/test_agent_resume_gemini_effort.py
+++ b/tests/cli/test_agent_resume_gemini_effort.py
@@ -1,0 +1,212 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for `li agent -r --effort` re-applying effort to gemini-code /
+gemini-cli (agy) branches — issue #1595.
+
+agy has no effort flag/kwarg; effort is folded into the `--model` display
+name (e.g. "Gemini 3.5 Flash (High)"). On resume, `cfg["model"]` already
+holds that resolved display name from the first turn. `resolve_agy_model`'s
+exact-match short-circuit (correct for a caller-typed pin) was firing on
+this *persisted* value too, silently dropping a new `--effort` passed on
+resume with no new `--model`. These tests pin:
+
+  * resume + explicit --effort (no new model) re-applies effort onto the
+    persisted agy model name,
+  * resume without --effort leaves the persisted model/effort untouched,
+  * resume with a new --model AND --effort still lets the explicit model
+    pin win over --effort (unchanged pre-existing semantics),
+  * the same shared cfg["model"] resume path is exercised for both
+    gemini-code and gemini-cli aliases.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.cli.test_agent_resume_model_override import _wire_agent_stubs
+
+
+def _capture_resolved_model(monkeypatch) -> list[str | None]:
+    """Patch Branch.operate to record chat_model's kwargs["model"] at call
+    time — _wire_agent_stubs' teardown stub never re-persists the branch to
+    disk, so the on-disk fixture file can't be re-read post-resume."""
+    from lionagi import Branch
+
+    captured: list[str | None] = []
+
+    async def fake_operate(self, instruction=None, **kw):
+        captured.append(self.chat_model.endpoint.config.kwargs.get("model"))
+        return "ok"
+
+    monkeypatch.setattr(Branch, "operate", fake_operate)
+    return captured
+
+
+def _make_gemini_branch_json(tmp_path: Path, provider: str, model: str) -> tuple[str, Path]:
+    """Persist a serialised Branch whose chat_model is an agy provider with
+    an already-resolved (...)-qualified model name, as if a prior turn had
+    folded --effort into it."""
+    from lionagi import Branch, iModel
+
+    b = Branch(
+        chat_model=iModel(
+            provider=provider,
+            endpoint="query_cli",
+            model=model,
+            api_key="dummy",
+        )
+    )
+    branch_id = str(b.id)
+    p = tmp_path / f"{branch_id}.json"
+    p.write_text(json.dumps(b.to_dict()))
+    return branch_id, p
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["gemini-code", "gemini-cli"])
+async def test_resume_explicit_effort_reapplies_onto_persisted_agy_model(
+    monkeypatch, tmp_path, provider
+):
+    """`li agent -r <id> --effort high` (no new model) must replace the
+    persisted 'Low' suffix with 'High' rather than no-op."""
+    branch_id, branch_path = _make_gemini_branch_json(tmp_path, provider, "Gemini 3.5 Flash (Low)")
+
+    import lionagi.cli.agent as agent_mod
+
+    monkeypatch.setattr(agent_mod, "find_branch", lambda bid: ("run-x", branch_path))
+    _wire_agent_stubs(monkeypatch, tmp_path, operate_return="ok")
+    captured = _capture_resolved_model(monkeypatch)
+
+    from lionagi.cli.agent import _run_agent
+
+    _result, _provider, _bid, terminal_status = await _run_agent(
+        None,
+        "continue",
+        resume=branch_id,
+        effort="high",
+    )
+
+    assert terminal_status == "completed"
+    assert captured == ["Gemini 3.5 Flash (High)"], (
+        f"new --effort on resume must replace the persisted agy model suffix, got {captured}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_resume_without_effort_keeps_persisted_agy_model(monkeypatch, tmp_path):
+    """`li agent -r <id>` with no --effort must leave the persisted agy
+    model name (and its baked-in effort suffix) untouched."""
+    branch_id, branch_path = _make_gemini_branch_json(
+        tmp_path, "gemini-code", "Gemini 3.5 Flash (Low)"
+    )
+
+    import lionagi.cli.agent as agent_mod
+
+    monkeypatch.setattr(agent_mod, "find_branch", lambda bid: ("run-x", branch_path))
+    _wire_agent_stubs(monkeypatch, tmp_path, operate_return="ok")
+    captured = _capture_resolved_model(monkeypatch)
+
+    from lionagi.cli.agent import _run_agent
+
+    _result, _provider, _bid, terminal_status = await _run_agent(
+        None,
+        "continue",
+        resume=branch_id,
+        effort=None,
+    )
+
+    assert terminal_status == "completed"
+    assert captured == ["Gemini 3.5 Flash (Low)"]
+
+
+@pytest.mark.asyncio
+async def test_resume_new_model_pin_still_wins_over_effort(monkeypatch, tmp_path):
+    """An explicit --model given on THIS resume call is a caller-typed pin —
+    it must still win over --effort (unchanged pre-existing semantics),
+    unlike the persisted-only case above."""
+    branch_id, branch_path = _make_gemini_branch_json(
+        tmp_path, "gemini-code", "Gemini 3.5 Flash (Low)"
+    )
+
+    import lionagi.cli.agent as agent_mod
+
+    monkeypatch.setattr(agent_mod, "find_branch", lambda bid: ("run-x", branch_path))
+    _wire_agent_stubs(monkeypatch, tmp_path, operate_return="ok")
+    captured = _capture_resolved_model(monkeypatch)
+
+    from lionagi.cli.agent import _run_agent
+
+    _result, _provider, _bid, terminal_status = await _run_agent(
+        "gemini-code/Gemini 3.1 Pro (Low)",
+        "continue",
+        resume=branch_id,
+        effort="high",
+    )
+
+    assert terminal_status == "completed"
+    assert captured == ["Gemini 3.1 Pro (Low)"]
+
+
+@pytest.mark.asyncio
+async def test_fresh_run_unaffected_by_reapply_effort(monkeypatch, tmp_path):
+    """A fresh (non-resume) gemini-code run is unaffected: --effort folds
+    into the model name exactly as before this fix."""
+    from unittest.mock import AsyncMock
+
+    import lionagi.cli.agent as agent_mod
+    from lionagi import Branch
+    from lionagi.service.manager import iModelManager
+
+    async def fake_operate(self, instruction=None, **kw):
+        return "ok"
+
+    monkeypatch.setattr(Branch, "operate", fake_operate)
+    monkeypatch.setattr(iModelManager, "shutdown", AsyncMock())
+    monkeypatch.setattr(agent_mod, "resolve_persisted_effort", lambda *a, **kw: "high")
+
+    async def fake_setup(*a, **kw):
+        return None
+
+    async def fake_teardown(ctx, *, status="completed", exception=None):
+        return status
+
+    monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)
+    monkeypatch.setattr(agent_mod, "teardown_agent_persist", fake_teardown)
+    monkeypatch.setattr(agent_mod, "save_last_branch_pointer", lambda *a, **kw: None)
+
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(
+        agent_mod,
+        "_provenance",
+        SimpleNamespace(
+            resolve_model_spec=lambda p, m: f"{p}/{m}",
+            agent_definition_hash=lambda n: "abc",
+        ),
+    )
+    monkeypatch.setattr(agent_mod, "resolve_artifact_contract", lambda **_: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "allocate_run",
+        lambda: SimpleNamespace(
+            run_id="r",
+            artifact_root=tmp_path / "artifacts",
+            stream_dir=tmp_path / "stream",
+            branches_dir=tmp_path / "branches",
+        ),
+    )
+
+    from lionagi.cli.agent import _run_agent
+
+    _result, provider, _bid, terminal_status = await _run_agent(
+        "gemini-code/gemini-3.5-flash",
+        "hello",
+        effort="high",
+    )
+
+    assert terminal_status == "completed"
+    assert provider == "gemini-code"

--- a/tests/providers/google/gemini_code/test_ndjson_mapping.py
+++ b/tests/providers/google/gemini_code/test_ndjson_mapping.py
@@ -330,3 +330,47 @@ def test_resolve_agy_model_effort_ignored_for_cross_family_alias():
     """Claude/GPT-OSS routed through agy have no Low/Medium/High tiers —
     effort is accepted but has no suffix to fold into."""
     assert resolve_agy_model("opus", effort="high") == "Claude Opus 4.6 (Thinking)"
+
+
+# ---------------------------------------------------------------------------
+# Model resolution — reapply_effort (li agent -r --effort re-applying effort
+# to an already-resolved persisted model, e.g. issue #1595)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "spec,effort,expected",
+    [
+        ("Gemini 3.5 Flash (Low)", "high", "Gemini 3.5 Flash (High)"),
+        ("Gemini 3.5 Flash (High)", "low", "Gemini 3.5 Flash (Low)"),
+        ("Gemini 3.1 Pro (Low)", "high", "Gemini 3.1 Pro (High)"),
+        # medium clamps to High for the Pro family, same as fresh resolution.
+        ("Gemini 3.1 Pro (Low)", "medium", "Gemini 3.1 Pro (High)"),
+    ],
+)
+def test_resolve_agy_model_reapply_effort_overrides_persisted_suffix(spec, effort, expected):
+    assert resolve_agy_model(spec, effort=effort, reapply_effort=True) == expected
+
+
+def test_resolve_agy_model_reapply_effort_default_false_preserves_pin():
+    """Without reapply_effort, an exact qualified model still wins over effort
+    (unchanged default — this is the semantics for a caller-typed pin)."""
+    assert resolve_agy_model("Gemini 3.5 Flash (Low)", effort="high") == "Gemini 3.5 Flash (Low)"
+
+
+def test_resolve_agy_model_reapply_effort_no_new_effort_keeps_persisted():
+    """reapply_effort=True with no new effort given must not touch the
+    persisted model (nothing to reapply)."""
+    assert (
+        resolve_agy_model("Gemini 3.5 Flash (Low)", effort=None, reapply_effort=True)
+        == "Gemini 3.5 Flash (Low)"
+    )
+
+
+def test_resolve_agy_model_reapply_effort_ignored_for_cross_family_alias():
+    """Cross-family agy models (Claude/GPT-OSS) have no effort tier to
+    reapply — reapply_effort has nothing to do and the model passes through."""
+    assert (
+        resolve_agy_model("Claude Opus 4.6 (Thinking)", effort="high", reapply_effort=True)
+        == "Claude Opus 4.6 (Thinking)"
+    )


### PR DESCRIPTION
## What

`li agent -r <branch_id> --effort <level>` (or `-c`/`--continue-last`) was silently no-op'ing the new `--effort` value for `gemini-code`/`gemini-cli` (Antigravity `agy`) branches when no new `--model` was also given.

## Root cause

`agy` has no effort flag/kwarg — effort is folded into the `--model` display name (e.g. `"Gemini 3.5 Flash (High)"`) via `resolve_agy_model()`. That function short-circuits and returns the model unchanged whenever it's already an exact `(...)`-qualified agy display name — correct when a *caller* explicitly pins that exact name, but wrong when the model is merely the *persisted* resolution from a prior turn. On resume, `cfg["model"]` is already such a concrete display name, so the exact-match short-circuit fired and the new `--effort` was dropped with no error or warning (traced through `lionagi/cli/agent.py`'s resume path, which re-resolves the persisted model against the new effort).

## Fix

- `resolve_agy_model()` gains a `reapply_effort: bool = False` kwarg (`lionagi/providers/google/gemini_code.py`). Default `False` preserves existing pin-wins semantics for `build_chat_model`/`build_imodel_from_spec` (fresh construction — unchanged, no call-site changes needed there).
- The resume call site in `lionagi/cli/agent.py` passes `reapply_effort=(model_str is None)`: when the caller didn't also supply a new `--model` this turn, the persisted display name is decomposed back into its family and the new effort tier is re-applied; an explicit `--model` given on the resume call itself still wins over `--effort` (unchanged pre-existing semantics, matching the claude/codex resume behavior this was meant to parity with).
- This shares the fix across both `gemini-code` and `gemini-cli` aliases (both route through the same `PROVIDERS_EFFORT_VIA_MODEL_NAME` classification and the same `resolve_agy_model` call).

## Tests

- `tests/providers/google/gemini_code/test_ndjson_mapping.py` — unit coverage for `resolve_agy_model(..., reapply_effort=...)`: overrides a persisted suffix, no-ops with no new effort, default `False` still preserves the pin, and cross-family aliases (no effort tier) pass through untouched.
- `tests/cli/test_agent_resume_gemini_effort.py` (new) — integration coverage on the actual `_run_agent` resume path: effort-only resume re-applies onto the persisted model (both `gemini-code` and `gemini-cli`), resume without `--effort` leaves the persisted model untouched, an explicit new `--model` + `--effort` on resume still lets the model pin win, and a fresh (non-resume) run is unaffected.

Closes #1595

## Test plan

- [x] `PYTHONPATH=$PWD pytest tests/cli/ tests/providers/google/gemini_code/` — 1100 passed, 1 skipped (pre-existing unrelated `.lionagi/config.toml`-gated skip)
- [x] One pre-existing unrelated flake deselected (`test_ctl_task_and_hb_task_are_cancelled_cleanly_at_run_end`, an asyncio-cancellation timing flake in the orchestrate control-poller tests, reproduced on the unmodified tree with no changes touching that module)
- [x] `ruff check` on touched files — clean
- [x] `ruff format` (pre-commit) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)