### PR TITLE
fix(cli): gate monitor chain grace window on chain depth and cancelled status

### DIFF
--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -1038,15 +1038,20 @@ async def _advance_chains(
         for root in roots:
             chain_tail_exit[root] = row.get("exit_code")
         # The engine only ever fires a chain child when chain_depth is still
-        # under its cap AND the run wasn't cancelled (its CancelledError
-        # branch sets status="cancelled" and skips the chain-fire block
-        # entirely) -- so a run past either gate can never get a child, no
+        # under its cap AND the run actually completed its fire path: its
+        # chain block sits after the subprocess returns a real exit code, so
+        # a cancelled run (the CancelledError branch sets status="cancelled"),
+        # a skipped run (created terminal by create_skipped_run, never fired),
+        # and a run that failed before spawning (argv build error or internal
+        # exception; status="failed" with exit_code=None) all bypass it
+        # entirely. A run past any of these gates can never get a child, no
         # matter what its schedule declares, and opening a grace window for
         # it would just burn the full window before falling back.
         if (
             chain
             and row.get("chain_depth", 0) < _MAX_CHAIN_DEPTH
-            and row.get("status") != "cancelled"
+            and row.get("status") not in ("cancelled", "skipped")
+            and row.get("exit_code") is not None
             and await _schedule_declares_chain_action(
                 db, row["schedule_id"], row.get("exit_code"), cache=schedule_cache
             )

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -818,6 +818,10 @@ def _watch_loop(
 
 _TERMINAL_SCHEDULE_RUN_STATUSES = frozenset({"completed", "failed", "cancelled", "skipped"})
 _CHAIN_GRACE_TICKS = 2
+# Mirrors the scheduler engine's own chain-depth cap (lionagi/studio/scheduler/engine.py
+# _MAX_CHAIN_DEPTH) -- the engine never fires a chain child at or past this depth, so a
+# grace window here would just burn ticks waiting on a child that is never coming.
+_MAX_CHAIN_DEPTH = 10
 
 
 def _split_watched_ids(raw: list[str]) -> list[str]:
@@ -1033,8 +1037,19 @@ async def _advance_chains(
         roots = root_of.get(row["id"]) or {row["id"]}
         for root in roots:
             chain_tail_exit[root] = row.get("exit_code")
-        if chain and await _schedule_declares_chain_action(
-            db, row["schedule_id"], row.get("exit_code"), cache=schedule_cache
+        # The engine only ever fires a chain child when chain_depth is still
+        # under its cap AND the run wasn't cancelled (its CancelledError
+        # branch sets status="cancelled" and skips the chain-fire block
+        # entirely) -- so a run past either gate can never get a child, no
+        # matter what its schedule declares, and opening a grace window for
+        # it would just burn the full window before falling back.
+        if (
+            chain
+            and row.get("chain_depth", 0) < _MAX_CHAIN_DEPTH
+            and row.get("status") != "cancelled"
+            and await _schedule_declares_chain_action(
+                db, row["schedule_id"], row.get("exit_code"), cache=schedule_cache
+            )
         ):
             awaiting_grace[row["id"]] = {"roots": set(roots), "ticks_left": _CHAIN_GRACE_TICKS}
         else:

--- a/tests/cli/test_monitor_run.py
+++ b/tests/cli/test_monitor_run.py
@@ -402,6 +402,51 @@ async def test_advance_chains_cancelled_run_resolves_without_grace(
 
 
 @pytest.mark.asyncio
+async def test_advance_chains_skipped_run_resolves_without_grace(
+    temp_db_path: Path,
+) -> None:
+    """A skipped run (overlap or missed-fire policy) is created terminal by
+    create_skipped_run and never goes through the engine's fire path, so no
+    chain child can ever follow it -- even though its schedule declares a
+    matching on_fail (skipped runs have exit_code=None), no grace window
+    opens; the root resolves on the very next tick."""
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db, name="declares-on-fail-skip", on_fail={"kind": "agent"})
+        run_id = await _make_schedule_run(db, sched_id, status="skipped", exit_code=None)
+        pending = {run_id: await db.get_schedule_run(run_id)}
+        chain_state = _new_chain_state(pending, chain=True)
+
+        await _chain_tick(db, pending, [], chain_state, 0)
+
+    assert chain_state["resolved_roots"] == {run_id}
+    assert not chain_state["awaiting_grace"]
+
+
+@pytest.mark.asyncio
+async def test_advance_chains_failed_run_without_exit_code_resolves_without_grace(
+    temp_db_path: Path,
+) -> None:
+    """A run that failed before its subprocess ever spawned (argv build
+    error or internal exception) lands status="failed" with exit_code=None.
+    The engine's chain block sits after the subprocess returns a real exit
+    code, so such a run can never get a chain child -- even with a matching
+    on_fail declared, no grace window opens; the root resolves on the very
+    next tick."""
+    async with StateDB() as db:
+        sched_id = await _make_schedule(
+            db, name="declares-on-fail-noexit", on_fail={"kind": "agent"}
+        )
+        run_id = await _make_schedule_run(db, sched_id, status="failed", exit_code=None)
+        pending = {run_id: await db.get_schedule_run(run_id)}
+        chain_state = _new_chain_state(pending, chain=True)
+
+        await _chain_tick(db, pending, [], chain_state, 0)
+
+    assert chain_state["resolved_roots"] == {run_id}
+    assert not chain_state["awaiting_grace"]
+
+
+@pytest.mark.asyncio
 async def test_advance_chains_chain_depth_at_cap_resolves_without_grace(
     temp_db_path: Path,
 ) -> None:

--- a/tests/cli/test_monitor_run.py
+++ b/tests/cli/test_monitor_run.py
@@ -381,6 +381,52 @@ async def test_advance_chains_grace_expires_without_child_resolves_on_parent_exi
 
 
 @pytest.mark.asyncio
+async def test_advance_chains_cancelled_run_resolves_without_grace(
+    temp_db_path: Path,
+) -> None:
+    """A watched run that lands status="cancelled" can never get a chain
+    child fired for it -- the engine's CancelledError branch sets
+    status="cancelled" and skips its chain-fire block entirely -- so even
+    though the schedule declares a matching on_fail, no grace window opens;
+    the root resolves on the very next tick."""
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db, name="declares-on-fail", on_fail={"kind": "agent"})
+        run_id = await _make_schedule_run(db, sched_id, status="cancelled", exit_code=None)
+        pending = {run_id: await db.get_schedule_run(run_id)}
+        chain_state = _new_chain_state(pending, chain=True)
+
+        await _chain_tick(db, pending, [], chain_state, 0)
+
+    assert chain_state["resolved_roots"] == {run_id}
+    assert not chain_state["awaiting_grace"]
+
+
+@pytest.mark.asyncio
+async def test_advance_chains_chain_depth_at_cap_resolves_without_grace(
+    temp_db_path: Path,
+) -> None:
+    """A watched run already at the engine's chain-depth cap can never get a
+    chain child fired for it either -- the engine only fires when
+    chain_depth < _MAX_CHAIN_DEPTH (10) -- so a schedule declaring a
+    matching on_success still gets no grace window; the root resolves on
+    the very next tick."""
+    async with StateDB() as db:
+        sched_id = await _make_schedule(
+            db, name="declares-on-success", on_success={"kind": "agent"}
+        )
+        run_id = await _make_schedule_run(
+            db, sched_id, status="completed", exit_code=0, chain_depth=10
+        )
+        pending = {run_id: await db.get_schedule_run(run_id)}
+        chain_state = _new_chain_state(pending, chain=True)
+
+        await _chain_tick(db, pending, [], chain_state, 0)
+
+    assert chain_state["resolved_roots"] == {run_id}
+    assert not chain_state["awaiting_grace"]
+
+
+@pytest.mark.asyncio
 async def test_advance_chains_multi_hop_chain_followed_to_final_link(
     temp_db_path: Path, capsys: pytest.CaptureFixture
 ) -> None:


### PR DESCRIPTION
## Summary

`li monitor run`'s chain grace-wait opens a `_CHAIN_GRACE_TICKS` grace window whenever the watched run's schedule declares a matching `on_success`/`on_fail` for the run's exit code. But the scheduler engine (`lionagi/studio/scheduler/engine.py` `_fire`, ~line 439) only actually fires a chain child when `chain_depth < _MAX_CHAIN_DEPTH` (10) **and** the run wasn't cancelled — its `except asyncio.CancelledError` branch bypasses the chain-fire block entirely, setting `status="cancelled"`.

So a watched run with `status="cancelled"` or `chain_depth >= 10` on a chain-declaring schedule burned the full grace window (~2× `--interval`) before falling back, instead of resolving on the next tick.

- Gate `_advance_chains`'s grace-window open on `row.get("chain_depth", 0) < _MAX_CHAIN_DEPTH` and `row.get("status") != "cancelled"`, mirroring the engine's own gate.
- Add a module-level `_MAX_CHAIN_DEPTH = 10` in `monitor.py` (CLI/studio layering means it doesn't import the engine's constant), with a comment noting it mirrors the scheduler engine's cap.
- Add two tests in `tests/cli/test_monitor_run.py` covering both new gates.

Closes #1623

## Test plan
- [x] `PYTHONPATH=$PWD .venv/bin/python -m pytest tests/cli/test_monitor_run.py tests/cli/test_monitor.py -p no:cacheprovider` — 140 passed
- [x] `ruff check` / `ruff format --check` on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)