### PR TITLE
test(cli): fix main-red — cron fixtures need cron_expr after #1647 validation

### DIFF
--- a/tests/apps_studio_server/test_audit_remediation.py
+++ b/tests/apps_studio_server/test_audit_remediation.py
@@ -1012,6 +1012,7 @@ class TestGithubRepoRealServiceValidation:
             json={
                 "name": "gh-patch-base",
                 "trigger_type": "cron",
+                "cron_expr": "0 * * * *",
                 "action_kind": "agent",
                 "action_model": "sonnet",
             },
@@ -1037,6 +1038,7 @@ class TestGithubRepoRealServiceValidation:
             json={
                 "name": "gh-patch-base2",
                 "trigger_type": "cron",
+                "cron_expr": "0 * * * *",
                 "action_kind": "agent",
                 "action_model": "sonnet",
             },
@@ -1075,6 +1077,7 @@ class TestGithubRepoRealServiceValidation:
             json={
                 "name": "gh-patch-dot-base",
                 "trigger_type": "cron",
+                "cron_expr": "0 * * * *",
                 "action_kind": "agent",
                 "action_model": "sonnet",
             },
@@ -1128,6 +1131,7 @@ class TestGithubRepoRealServiceValidation:
             json={
                 "name": "gh-patch-long-owner-base",
                 "trigger_type": "cron",
+                "cron_expr": "0 * * * *",
                 "action_kind": "agent",
                 "action_model": "sonnet",
             },
@@ -1149,6 +1153,7 @@ class TestGithubRepoRealServiceValidation:
             json={
                 "name": "gh-patch-long-repo-base",
                 "trigger_type": "cron",
+                "cron_expr": "0 * * * *",
                 "action_kind": "agent",
                 "action_model": "sonnet",
             },
@@ -1195,6 +1200,7 @@ class TestGithubRepoRealServiceValidation:
             json={
                 "name": "schema-seed",
                 "trigger_type": "cron",
+                "cron_expr": "0 * * * *",
                 "action_kind": "agent",
                 "action_model": "sonnet",
             },

--- a/tests/cli/test_argv_injection.py
+++ b/tests/cli/test_argv_injection.py
@@ -591,6 +591,7 @@ class TestCreateScheduleInjectionRejection:
             data = {
                 "name": "good-sched",
                 "trigger_type": "cron",
+                "cron_expr": "0 * * * *",
                 "action_kind": "agent",
                 "action_model": "claude-sonnet-4-6",
                 "action_extra_args": ["my-task"],

--- a/tests/cli/test_scheduler_flow_yaml.py
+++ b/tests/cli/test_scheduler_flow_yaml.py
@@ -158,6 +158,7 @@ def test_create_schedule_rejects_empty_flow_yaml():
     data = {
         "name": "bad-sched",
         "trigger_type": "cron",
+        "cron_expr": "0 * * * *",
         "action_kind": "flow_yaml",
         # action_flow_yaml intentionally absent
     }
@@ -181,6 +182,7 @@ def test_create_schedule_rejects_malformed_flow_yaml():
     data = {
         "name": "bad-yaml-sched",
         "trigger_type": "cron",
+        "cron_expr": "0 * * * *",
         "action_kind": "flow_yaml",
         "action_flow_yaml": "key: [unclosed",
     }


### PR DESCRIPTION
Main CI is red on d73eb36cb: #1647's required-cron_expr validation fires before the assertions in three tests whose fixtures used `trigger_type="cron"` without an expression (2 in test_scheduler_flow_yaml.py asserting flow_yaml validation, 1 in test_argv_injection.py asserting the happy path). Adds `cron_expr: "0 * * * *"` to each fixture so they exercise their intended validation again.

Verified: `tests/cli/test_scheduler_flow_yaml.py` + `tests/cli/test_argv_injection.py` → 122 passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)