### PR TITLE
fix(studio): PATCH exclude_unset semantics + reject enable-dead-cron

### DIFF
--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -140,6 +140,13 @@ class SchedulerEngine:
                     s.get("id"),
                 )
                 continue
+            if s.get("trigger_type") == "interval" and not s.get("interval_sec"):
+                _log.warning(
+                    "Schedule %s is enabled with trigger_type='interval' but has "
+                    "no interval_sec; it will never fire until re-configured",
+                    s.get("id"),
+                )
+                continue
             next_fire_at = s.get("next_fire_at")
             if next_fire_at is not None and next_fire_at <= now:
                 continue

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -133,6 +133,13 @@ class SchedulerEngine:
             return
         now = time.time()
         for s in schedules:
+            if s.get("trigger_type") == "cron" and not s.get("cron_expr"):
+                _log.warning(
+                    "Schedule %s is enabled with trigger_type='cron' but has no "
+                    "cron_expr; it will never fire until re-configured",
+                    s.get("id"),
+                )
+                continue
             next_fire_at = s.get("next_fire_at")
             if next_fire_at is not None and next_fire_at <= now:
                 continue

--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -21,6 +21,13 @@ _log = logging.getLogger(__name__)
 
 _PRESERVE_DASHED: frozenset[str] = frozenset({"argument-hint"})
 
+# schedules columns declared NOT NULL — a PATCH that explicitly sets one of
+# these to null must be rejected (400) rather than passed through to a DB
+# constraint violation (or, worse, silently dropped).
+_NON_NULLABLE_SCHEDULE_FIELDS: frozenset[str] = frozenset(
+    {"name", "trigger_type", "action_kind", "missed_fire_policy", "overlap_policy"}
+)
+
 
 def _svc_validate_action_model(model: str | None) -> None:
     """Service-boundary check: reject action_model values that inject CLI flags.
@@ -340,12 +347,20 @@ async def create_schedule(data: dict[str, Any]) -> dict[str, Any]:
 
 
 async def update_schedule(schedule_id: str, fields: dict[str, Any]) -> bool:
-    if not fields:
-        return False
     async with StateDB() as db:
         schedule = await db.get_schedule(schedule_id)
         if not schedule:
             return False
+        if not fields:
+            # Nothing was explicitly set on the PATCH body — a genuine no-op
+            # on a schedule that exists, not a 404.
+            return True
+
+        cleared = {
+            key for key in _NON_NULLABLE_SCHEDULE_FIELDS if key in fields and fields[key] is None
+        }
+        if cleared:
+            raise ValueError(f"Field(s) {sorted(cleared)} cannot be cleared to null")
 
         if "action_model" in fields:
             _svc_validate_action_model(fields["action_model"])
@@ -404,6 +419,8 @@ async def enable_schedule(schedule_id: str) -> bool:
         schedule = await db.get_schedule(schedule_id)
         if not schedule:
             return False
+        if schedule.get("trigger_type") == "cron":
+            _svc_validate_cron_expr(schedule.get("cron_expr"), required=True)
         await db.update_schedule(schedule_id, enabled=1)
 
     # A schedule can sit disabled for a long time; its stored next_fire_at
@@ -556,7 +573,12 @@ async def create_schedule_route(body: CreateScheduleRequest) -> dict[str, Any]:
     name="update_schedule",
 )
 async def update_schedule_route(schedule_id: str, body: UpdateScheduleRequest) -> dict[str, Any]:
-    fields = body.model_dump(exclude_none=True)
+    # exclude_unset (not exclude_none): a field the client never mentioned is
+    # left untouched, while a field explicitly sent as null is passed through
+    # so update_schedule can clear it (where the column allows) or reject it
+    # (where it doesn't). exclude_none would silently drop explicit nulls,
+    # making an all-null PATCH indistinguishable from an empty one.
+    fields = body.model_dump(exclude_unset=True)
     try:
         ok = await update_schedule(schedule_id, fields)
     except ValueError as exc:
@@ -586,7 +608,10 @@ async def delete_schedule_route(schedule_id: str) -> dict[str, Any]:
     name="enable_schedule",
 )
 async def enable_schedule_route(schedule_id: str) -> dict[str, Any]:
-    ok = await enable_schedule(schedule_id)
+    try:
+        ok = await enable_schedule(schedule_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     if not ok:
         raise HTTPException(status_code=404, detail=f"Schedule '{schedule_id}' not found")
     return {"ok": True, "enabled": True}

--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -87,6 +87,23 @@ def _svc_validate_cron_expr(expr: str | None, *, required: bool = False) -> None
         raise ValueError(f"Invalid cron expression: {expr!r}")
 
 
+def _svc_validate_interval_sec(interval: Any, *, required: bool = False) -> None:
+    """Service-boundary check: reject a missing or non-positive interval.
+
+    `required=True` rejects a missing/null value — callers pass this when
+    trigger_type == "interval", since an interval-triggered schedule without
+    interval_sec commits fine but never fires (next-fire computation returns
+    None forever), the same enabled-but-dead shape as a cron schedule with
+    no expression.
+    """
+    if interval is None:
+        if required:
+            raise ValueError("interval_sec is required when trigger_type is 'interval'")
+        return
+    if isinstance(interval, bool) or not isinstance(interval, int) or interval <= 0:
+        raise ValueError(f"interval_sec must be a positive integer, got {interval!r}")
+
+
 async def _svc_recompute_next_fire_guarded(effective: dict[str, Any], context: str) -> None:
     """Recompute next_fire_at after a committed write, without raising.
 
@@ -322,6 +339,8 @@ async def create_schedule(data: dict[str, Any]) -> dict[str, Any]:
     _svc_validate_github_repo(data.get("github_repo"))
     if data.get("trigger_type") == "cron":
         _svc_validate_cron_expr(data.get("cron_expr"), required=True)
+    if data.get("trigger_type") == "interval":
+        _svc_validate_interval_sec(data.get("interval_sec"), required=True)
 
     if data.get("action_kind") == "flow_yaml":
         yaml_text = data.get("action_flow_yaml") or ""
@@ -393,6 +412,9 @@ async def update_schedule(schedule_id: str, fields: dict[str, Any]) -> bool:
         touches_trigger = "cron_expr" in fields or "trigger_type" in fields
         if touches_trigger and effective.get("trigger_type") == "cron":
             _svc_validate_cron_expr(effective.get("cron_expr"), required=True)
+        touches_interval = "interval_sec" in fields or "trigger_type" in fields
+        if touches_interval and effective.get("trigger_type") == "interval":
+            _svc_validate_interval_sec(effective.get("interval_sec"), required=True)
 
         await db.update_schedule(schedule_id, **fields)
 
@@ -421,6 +443,8 @@ async def enable_schedule(schedule_id: str) -> bool:
             return False
         if schedule.get("trigger_type") == "cron":
             _svc_validate_cron_expr(schedule.get("cron_expr"), required=True)
+        if schedule.get("trigger_type") == "interval":
+            _svc_validate_interval_sec(schedule.get("interval_sec"), required=True)
         await db.update_schedule(schedule_id, enabled=1)
 
     # A schedule can sit disabled for a long time; its stored next_fire_at

--- a/tests/studio/test_schedule_tz_recompute.py
+++ b/tests/studio/test_schedule_tz_recompute.py
@@ -452,3 +452,295 @@ async def test_create_non_cron_empty_expr_still_accepted(temp_db_path):
         }
     )
     assert created["name"] == "create-interval-empty-cron-test"
+
+
+# ---------------------------------------------------------------------------
+# PATCH exclude_unset semantics + enable/startup dead-cron guards
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_route_all_null_body_no_longer_404s(temp_db_path):
+    """An UpdateScheduleRequest built from a body whose only field is
+    explicitly null must reach update_schedule with that field present (not
+    stripped to {}), so an existing schedule is never misreported as 404."""
+    from lionagi.studio.services.schedules import (
+        UpdateScheduleRequest,
+        create_schedule,
+        update_schedule_route,
+    )
+
+    created = await create_schedule(
+        {
+            "name": "patch-all-null-route-test",
+            "trigger_type": "cron",
+            "cron_expr": "0 18 * * *",
+            "action_kind": "agent",
+            "action_prompt": "ping",
+            "description": "will be cleared",
+        }
+    )
+    sid = created["id"]
+
+    body = UpdateScheduleRequest(description=None)
+    result = await update_schedule_route(sid, body)
+    assert result == {"ok": True}
+
+    from lionagi.studio.services.schedules import get_schedule
+
+    row = await get_schedule(sid)
+    assert row["description"] is None
+
+
+@pytest.mark.asyncio
+async def test_patch_explicit_null_clears_nullable_field(temp_db_path):
+    """Explicitly setting a nullable optional field to null via the service
+    layer clears it in the DB."""
+    from lionagi.studio.services.schedules import create_schedule, get_schedule, update_schedule
+
+    created = await create_schedule(
+        {
+            "name": "patch-clear-nullable-test",
+            "trigger_type": "cron",
+            "cron_expr": "0 18 * * *",
+            "action_kind": "agent",
+            "action_prompt": "ping",
+            "action_model": "sonnet",
+        }
+    )
+    sid = created["id"]
+
+    ok = await update_schedule(sid, {"action_model": None})
+    assert ok is True
+
+    row = await get_schedule(sid)
+    assert row["action_model"] is None
+
+
+@pytest.mark.asyncio
+async def test_patch_absent_field_untouched(temp_db_path):
+    """A field never mentioned in the PATCH body (not present in `fields`)
+    is left at its prior value — exercised at the pydantic layer via
+    model_dump(exclude_unset=True)."""
+    from lionagi.studio.services.schedules import (
+        UpdateScheduleRequest,
+        create_schedule,
+        get_schedule,
+    )
+
+    created = await create_schedule(
+        {
+            "name": "patch-absent-field-test",
+            "trigger_type": "cron",
+            "cron_expr": "0 18 * * *",
+            "action_kind": "agent",
+            "action_prompt": "ping",
+            "action_model": "sonnet",
+        }
+    )
+    sid = created["id"]
+
+    # description never mentioned -> must not appear in the dumped fields.
+    body = UpdateScheduleRequest(action_model="gpt-4")
+    fields = body.model_dump(exclude_unset=True)
+    assert "description" not in fields
+    assert fields == {"action_model": "gpt-4"}
+
+    from lionagi.studio.services.schedules import update_schedule
+
+    ok = await update_schedule(sid, fields)
+    assert ok is True
+    row = await get_schedule(sid)
+    assert row["action_model"] == "gpt-4"
+
+
+@pytest.mark.asyncio
+async def test_patch_reject_clearing_non_nullable_field(temp_db_path):
+    """Explicitly nulling a NOT NULL column (name, trigger_type, action_kind,
+    missed_fire_policy, overlap_policy) is rejected with a clear ValueError
+    rather than reaching the DB constraint."""
+    from lionagi.studio.services.schedules import create_schedule, get_schedule, update_schedule
+
+    created = await create_schedule(
+        {
+            "name": "patch-reject-null-name-test",
+            "trigger_type": "cron",
+            "cron_expr": "0 18 * * *",
+            "action_kind": "agent",
+            "action_prompt": "ping",
+        }
+    )
+    sid = created["id"]
+
+    with pytest.raises(ValueError, match="cannot be cleared to null"):
+        await update_schedule(sid, {"name": None})
+
+    row = await get_schedule(sid)
+    assert row["name"] == "patch-reject-null-name-test"  # untouched
+
+
+@pytest.mark.asyncio
+async def test_patch_empty_body_on_existing_schedule_is_noop_not_404(temp_db_path):
+    """A PATCH body with zero fields set (`{}`) on a schedule that exists is
+    a genuine no-op — it must not be misreported as 404."""
+    from lionagi.studio.services.schedules import create_schedule, update_schedule
+
+    created = await create_schedule(
+        {
+            "name": "patch-empty-body-test",
+            "trigger_type": "cron",
+            "cron_expr": "0 18 * * *",
+            "action_kind": "agent",
+            "action_prompt": "ping",
+        }
+    )
+    sid = created["id"]
+
+    ok = await update_schedule(sid, {})
+    assert ok is True
+
+
+@pytest.mark.asyncio
+async def test_patch_unknown_schedule_still_404(temp_db_path):
+    """A PATCH (empty or otherwise) against a schedule id that does not
+    exist is still a genuine 404 — the no-op fix must not mask that."""
+    from lionagi.studio.services.schedules import update_schedule
+
+    ok = await update_schedule("no-such-schedule-id", {})
+    assert ok is False
+
+    ok = await update_schedule("no-such-schedule-id", {"description": "x"})
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_enable_dead_cron_schedule_rejected(temp_db_path):
+    """Enabling a cron schedule whose cron_expr has been blanked (a legacy
+    dead row) is rejected with a 400-worthy ValueError instead of flipping
+    enabled=1 on a schedule that can never fire."""
+    from lionagi.state.db import StateDB
+    from lionagi.studio.services.schedules import (
+        create_schedule,
+        disable_schedule,
+        enable_schedule,
+        get_schedule,
+    )
+
+    created = await create_schedule(
+        {
+            "name": "enable-dead-cron-test",
+            "trigger_type": "cron",
+            "cron_expr": "0 18 * * *",
+            "action_kind": "agent",
+            "action_prompt": "ping",
+        }
+    )
+    sid = created["id"]
+    assert await disable_schedule(sid) is True
+
+    # Simulate a legacy row whose cron_expr was blanked out from under it
+    # (write-time validation now prevents this for new rows, but existing
+    # rows predating that fix can still be in this state).
+    async with StateDB() as db:
+        await db.update_schedule(sid, cron_expr="")
+
+    with pytest.raises(ValueError, match="cron_expr is required"):
+        await enable_schedule(sid)
+
+    row = await get_schedule(sid)
+    assert row["enabled"] == 0  # rejected before the flip committed
+
+
+@pytest.mark.asyncio
+async def test_enable_route_dead_cron_schedule_returns_400(temp_db_path):
+    """The route wrapper turns the enable-dead-cron ValueError into a 400,
+    mirroring create/update's ValueError -> 400 mapping."""
+    from fastapi import HTTPException
+
+    from lionagi.state.db import StateDB
+    from lionagi.studio.services.schedules import (
+        create_schedule,
+        disable_schedule,
+        enable_schedule_route,
+    )
+
+    created = await create_schedule(
+        {
+            "name": "enable-route-dead-cron-test",
+            "trigger_type": "cron",
+            "cron_expr": "0 18 * * *",
+            "action_kind": "agent",
+            "action_prompt": "ping",
+        }
+    )
+    sid = created["id"]
+    assert await disable_schedule(sid) is True
+    async with StateDB() as db:
+        await db.update_schedule(sid, cron_expr="")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await enable_schedule_route(sid)
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_enable_healthy_cron_schedule_still_works(temp_db_path):
+    """Regression guard: enabling a cron schedule with a valid cron_expr is
+    unaffected by the dead-cron guard."""
+    from lionagi.studio.services.schedules import (
+        create_schedule,
+        disable_schedule,
+        enable_schedule,
+        get_schedule,
+    )
+
+    created = await create_schedule(
+        {
+            "name": "enable-healthy-cron-test",
+            "trigger_type": "cron",
+            "cron_expr": "0 18 * * *",
+            "action_kind": "agent",
+            "action_prompt": "ping",
+        }
+    )
+    sid = created["id"]
+    assert await disable_schedule(sid) is True
+
+    ok = await enable_schedule(sid)
+    assert ok is True
+
+    row = await get_schedule(sid)
+    assert row["enabled"] == 1
+
+
+@pytest.mark.asyncio
+async def test_startup_recompute_warns_on_dead_cron_row(temp_db_path, caplog):
+    """_recompute_armed_cron_schedules must log a warning naming the
+    schedule id for an enabled cron row with an empty cron_expr, instead of
+    silently skipping it via recompute_next_fire's falsy early-return."""
+    from lionagi.state.db import StateDB
+    from lionagi.studio.scheduler.engine import scheduler
+    from lionagi.studio.services.schedules import create_schedule
+
+    created = await create_schedule(
+        {
+            "name": "startup-dead-cron-test",
+            "trigger_type": "cron",
+            "cron_expr": "0 18 * * *",
+            "action_kind": "agent",
+            "action_prompt": "ping",
+        }
+    )
+    sid = created["id"]
+    async with StateDB() as db:
+        await db.update_schedule(sid, cron_expr="")
+
+    with caplog.at_level(logging.WARNING):
+        await scheduler._recompute_armed_cron_schedules()
+
+    matches = [
+        r
+        for r in caplog.records
+        if "no cron_expr" in r.getMessage().lower() and sid in r.getMessage()
+    ]
+    assert matches, [r.getMessage() for r in caplog.records]

--- a/tests/studio/test_schedule_tz_recompute.py
+++ b/tests/studio/test_schedule_tz_recompute.py
@@ -744,3 +744,122 @@ async def test_startup_recompute_warns_on_dead_cron_row(temp_db_path, caplog):
         if "no cron_expr" in r.getMessage().lower() and sid in r.getMessage()
     ]
     assert matches, [r.getMessage() for r in caplog.records]
+
+
+@pytest.mark.asyncio
+async def test_patch_null_interval_sec_on_interval_schedule_rejected(temp_db_path):
+    """Explicitly nulling interval_sec on an interval-triggered schedule is
+    rejected — it would strand the schedule enabled-but-dead (next-fire
+    computation returns None without an interval), the same shape the cron
+    guard closes for empty expressions."""
+    from lionagi.studio.services.schedules import create_schedule, get_schedule, update_schedule
+
+    created = await create_schedule(
+        {
+            "name": "patch-null-interval-test",
+            "trigger_type": "interval",
+            "interval_sec": 60,
+            "action_kind": "agent",
+            "action_prompt": "ping",
+        }
+    )
+    sid = created["id"]
+
+    with pytest.raises(ValueError, match="interval_sec is required"):
+        await update_schedule(sid, {"interval_sec": None})
+
+    row = await get_schedule(sid)
+    assert row["interval_sec"] == 60  # untouched
+
+
+@pytest.mark.asyncio
+async def test_patch_nonpositive_interval_sec_rejected(temp_db_path):
+    """Zero or negative interval_sec is rejected on update."""
+    from lionagi.studio.services.schedules import create_schedule, update_schedule
+
+    created = await create_schedule(
+        {
+            "name": "patch-nonpositive-interval-test",
+            "trigger_type": "interval",
+            "interval_sec": 60,
+            "action_kind": "agent",
+            "action_prompt": "ping",
+        }
+    )
+    sid = created["id"]
+
+    with pytest.raises(ValueError, match="positive integer"):
+        await update_schedule(sid, {"interval_sec": 0})
+
+
+@pytest.mark.asyncio
+async def test_create_interval_without_interval_sec_rejected(temp_db_path):
+    """Creating an interval-triggered schedule without interval_sec is
+    rejected instead of committing a schedule that can never fire."""
+    from lionagi.studio.services.schedules import create_schedule
+
+    with pytest.raises(ValueError, match="interval_sec is required"):
+        await create_schedule(
+            {
+                "name": "create-dead-interval-test",
+                "trigger_type": "interval",
+                "action_kind": "agent",
+                "action_prompt": "ping",
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_patch_trigger_flip_away_from_interval_allows_clearing_interval(temp_db_path):
+    """Flipping trigger_type to cron in the same PATCH that clears
+    interval_sec is legal — the interval requirement only binds while the
+    effective trigger_type is 'interval'."""
+    from lionagi.studio.services.schedules import create_schedule, get_schedule, update_schedule
+
+    created = await create_schedule(
+        {
+            "name": "patch-flip-clear-interval-test",
+            "trigger_type": "interval",
+            "interval_sec": 60,
+            "action_kind": "agent",
+            "action_prompt": "ping",
+        }
+    )
+    sid = created["id"]
+
+    ok = await update_schedule(
+        sid, {"trigger_type": "cron", "cron_expr": "0 18 * * *", "interval_sec": None}
+    )
+    assert ok is True
+
+    row = await get_schedule(sid)
+    assert row["trigger_type"] == "cron"
+    assert row["interval_sec"] is None
+
+
+@pytest.mark.asyncio
+async def test_enable_dead_interval_schedule_rejected(temp_db_path):
+    """Enabling an interval schedule whose interval_sec was lost (legacy row)
+    is rejected the same way as enabling a dead cron schedule."""
+    from lionagi.state.db import StateDB
+    from lionagi.studio.services.schedules import create_schedule, disable_schedule, enable_schedule
+
+    created = await create_schedule(
+        {
+            "name": "enable-dead-interval-test",
+            "trigger_type": "interval",
+            "interval_sec": 60,
+            "action_kind": "agent",
+            "action_prompt": "ping",
+        }
+    )
+    sid = created["id"]
+    await disable_schedule(sid)
+
+    # Simulate a legacy dead row: null the interval directly in the DB,
+    # below the service-layer validation.
+    async with StateDB() as db:
+        await db.update_schedule(sid, interval_sec=None)
+
+    with pytest.raises(ValueError, match="interval_sec is required"):
+        await enable_schedule(sid)


### PR DESCRIPTION
## Summary

Three pre-existing gaps in the schedules service/router PATCH + enable lifecycle (`lionagi/studio/services/schedules.py`, `lionagi/studio/scheduler/engine.py`):

1. **PATCH serialization** — `update_schedule_route` built `fields = body.model_dump(exclude_none=True)`, which stripped an all-null PATCH (e.g. `{"description": null}`) to `{}`, causing `update_schedule` to return `False` and the route to return a misleading `404` for a schedule that exists — and made it impossible to ever clear an optional field back to `null`. Switched to `exclude_unset=True` so "absent" and "explicitly null" are distinguished:
   - A field never mentioned in the PATCH body is left untouched.
   - A field explicitly sent as `null` clears it, **where the column is nullable**.
   - Columns declared `NOT NULL` (`name`, `trigger_type`, `action_kind`, `missed_fire_policy`, `overlap_policy`) reject an explicit null with a clear `ValueError` → `400`, instead of reaching a DB constraint violation.
   - **Contract decision**: a genuinely empty PATCH body (`{}`, zero fields set) on a schedule that *exists* is now treated as a no-op success (`{"ok": true}`), not a `404` — the `404` is reserved for an unknown `schedule_id`. This seemed like the more correct REST semantic than inventing a `400` for an empty-but-otherwise-valid PATCH, and it keeps `update_schedule`'s return contract (`bool` = found/not-found) intact.

2. **Enable endpoint on dead legacy cron rows** — `enable_schedule` now validates `cron_expr` (via the same `_svc_validate_cron_expr(required=True)` used by create/update) *before* flipping `enabled=1` for a `trigger_type == "cron"` schedule. Enabling a legacy row with an empty `cron_expr` is now rejected with `400` instead of returning `200` with the schedule enabled-but-dead (`next_fire_at` stuck at `None`).

3. **Startup observability** — `_recompute_armed_cron_schedules` now logs `log.warning(...)` naming the schedule id when it skips an enabled cron row with no `cron_expr`, instead of silently doing nothing (`recompute_next_fire`'s falsy early-return was invisible to operators before this).

None of these three change write-time validation (already covered by the prior empty-cron-expr fix) — they close the corresponding read/update/lifecycle gaps for rows that predate that fix, plus the PATCH serialization bug which is independent of cron entirely.

## Test plan

- [x] `tests/studio/test_schedule_tz_recompute.py` — added:
  - `test_patch_route_all_null_body_no_longer_404s` (router-level, exercises the actual `UpdateScheduleRequest` → `update_schedule_route` path)
  - `test_patch_explicit_null_clears_nullable_field`
  - `test_patch_absent_field_untouched`
  - `test_patch_reject_clearing_non_nullable_field`
  - `test_patch_empty_body_on_existing_schedule_is_noop_not_404`
  - `test_patch_unknown_schedule_still_404`
  - `test_enable_dead_cron_schedule_rejected` / `test_enable_route_dead_cron_schedule_returns_400`
  - `test_enable_healthy_cron_schedule_still_works` (regression guard)
  - `test_startup_recompute_warns_on_dead_cron_row`
- [x] Full file: `PYTHONPATH=$PWD .venv/bin/python -m pytest tests/studio/test_schedule_tz_recompute.py -p no:cacheprovider` — 24 passed
- [x] `tests/cli/test_argv_injection.py` (existing PATCH validation classes) — all pass, no regressions
- [x] Full sweep: `tests/studio/`, `tests/cli/test_schedule_cli.py`, `tests/cli/test_schedule_cli_route_drift.py`, `tests/cli/test_scheduler_flow_yaml.py`, `tests/apps_studio_server/` — all pass
- [x] `ruff format` + `ruff check` on touched files — clean

Closes #1651

🤖 Generated with [Claude Code](https://claude.com/claude-code)