### PR TITLE
docs(adr): add NodePaused row to ADR-0083 signal-to-state table

### DIFF
--- a/docs/adrs/ADR-0083-lifecycle-signal-contract.md
+++ b/docs/adrs/ADR-0083-lifecycle-signal-contract.md
@@ -104,6 +104,7 @@ Invariants:
 | `NodeFailed` | `failed` | Existing. |
 | `RunFailed` | `failed` | Existing. |
 | `NodeEscalated` | `escalated` | New — see §2. |
+| `NodePaused` | `paused` | Added by ADR-0085 slice 1 — a node blocked at an operation boundary, awaiting `resume()`. |
 | `StructuredOutput(data=EscalationRequest)` | `escalated` | Capability-emission path before `NodeEscalated` is issued. |
 | `GateDenied` | *(ignored)* | Governance detail; may trigger `NodeAwaitingApproval` upstream but is not a lane by itself. |
 | `MessageAdded`, `HookSignal`, others | *(ignored)* | Not state-bearing. |


### PR DESCRIPTION
## Summary

- Investigated issue #1618, which reported that PR #1617's `NodePaused`/`"paused"` lifecycle lane was not mirrored in the VS Code ("Den") extension (`apps/vscode/src/api/types.ts`, `apps/vscode/src/runs/runTreeModel.ts`).
- On `origin/main`, PR #1617's commit (998f58db6) already includes the full extension mirror: `NodeLifecycleState` union has `"paused"`, `runTreeModel.ts` has `case "NodePaused": newState = "paused";`, the webview (`media/runTree.js`/`media/runTree.css`) styles the `paused` lane consistently with the other lanes (color-coded badge, same pattern as `awaiting_approval`/`escalated`), and `test/runTreeModel.test.ts` already covers the paused lane end-to-end (park on `NodePaused`, resume on `NodeStarted`, terminal-state stickiness against a stale `NodePaused`).
- The one gap that was still open: ADR-0083 §4 ("Signal-to-state mapping") never got a row for `NodePaused`, even though ADR-0085 (§ "Signals") documents `NodePaused`/`"paused"` as an additive extension of that exact table. This PR adds that row.

## Test plan

- [x] `npm ci` in `apps/vscode`
- [x] `npm run typecheck` — clean, no errors
- [x] `npm run compile` — esbuild succeeds
- [x] `npm run test` (vitest) — 9 files / 59 tests pass, including the existing paused-lane coverage in `test/runTreeModel.test.ts`

Closes #1618

🤖 Generated with [Claude Code](https://claude.com/claude-code)