### PR TITLE
fix(cli): normalize --effort case at the parse boundary

### DIFF
--- a/lionagi/cli/_providers.py
+++ b/lionagi/cli/_providers.py
@@ -28,6 +28,7 @@ from lionagi.service.providers import (
     PROVIDERS_NO_EFFORT,
     ModelSpec,
     _clamp_claude_effort,
+    normalize_effort,
     parse_model_spec,
 )
 
@@ -43,6 +44,7 @@ __all__ = (
     "PROVIDER_YOLO_KWARGS",
     "PROVIDERS_EFFORT_VIA_MODEL_NAME",
     "PROVIDERS_NO_EFFORT",
+    "normalize_effort",
     "add_common_cli_args",
     "build_chat_model",
     "build_imodel_from_spec",
@@ -73,7 +75,7 @@ def build_imodel_from_spec(
 ) -> iModel:
     """Parse spec, build iModel. Effort in spec unless overridden."""
     ms = parse_model_spec(spec)
-    effort = effort_override if effort_override is not None else ms.effort
+    effort = normalize_effort(effort_override) if effort_override is not None else ms.effort
 
     extra: dict = {}
 
@@ -126,6 +128,7 @@ def build_chat_model(
     bypass: bool = False,
 ) -> iModel | str:
     """Legacy: for agent.py compat. Returns bare spec string when no flags."""
+    effort = normalize_effort(effort)
     extra: dict = {}
     if bypass:
         extra.update(PROVIDER_BYPASS_KWARGS.get(provider, {}))

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -229,7 +229,7 @@ async def _run_agent(
         if profile.model and model_str is None:
             model_str = profile.model
         if profile.effort and effort is None:
-            effort = profile.effort
+            effort = normalize_effort(profile.effort)
         if profile.yolo and not yolo:
             yolo = True
         if profile.fast_mode and not fast:

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -33,6 +33,7 @@ from ._providers import (
     build_chat_model,
     build_deadline_preamble,
     load_agent_profile,
+    normalize_effort,
     parse_model_spec,
     resolve_persisted_effort,
 )
@@ -203,6 +204,7 @@ async def _run_agent(
     preset: str | None = None,
 ) -> tuple[str, str, str, str]:
     """Execute one agent turn; returns (result, provider, branch_id, terminal_status)."""
+    effort = normalize_effort(effort)
     if resume and continue_last:
         raise ConfigurationError("--resume / -r and --continue-last / -c are mutually exclusive.")
     if preset and (resume or continue_last):

--- a/lionagi/service/providers.py
+++ b/lionagi/service/providers.py
@@ -19,6 +19,7 @@ __all__ = (
     "PROVIDER_YOLO_KWARGS",
     "PROVIDERS_EFFORT_VIA_MODEL_NAME",
     "PROVIDERS_NO_EFFORT",
+    "normalize_effort",
     "parse_model_spec",
 )
 
@@ -35,6 +36,21 @@ EFFORT_LEVELS = frozenset(
         "max",
     }
 )
+
+
+def normalize_effort(effort: str | None) -> str | None:
+    """Case-fold a raw effort string to lionagi's lowercase vocabulary.
+
+    Every clamp table below (_CODEX_EFFORT_CLAMP, _clamp_claude_effort,
+    _GEMINI_EFFORT_CLAMP) is keyed on lowercase levels and falls back to a
+    default on a lookup miss, so an un-normalized value like "High" silently
+    misclamps rather than raising. Call this once at each boundary where a
+    raw effort string enters lionagi from outside (CLI flag, profile
+    frontmatter, orchestration spec) — accepted vocabulary is unchanged,
+    only case is folded.
+    """
+    return effort.lower() if isinstance(effort, str) else effort
+
 
 # Codex accepts none|minimal|low|medium|high|xhigh — NOT "max".
 # Profiles/orchestrators may emit "max"; clamp to "xhigh" for codex.

--- a/tests/cli/test_agent_resume_gemini_effort.py
+++ b/tests/cli/test_agent_resume_gemini_effort.py
@@ -240,3 +240,48 @@ async def test_resume_mixed_case_effort_reapplies_correct_agy_tier(monkeypatch, 
     assert captured == ["Gemini 3.5 Flash (High)"], (
         f"mixed-case --effort on resume must not misclamp, got {captured}"
     )
+
+
+@pytest.mark.asyncio
+async def test_resume_mixed_case_profile_effort_reapplies_correct_agy_tier(monkeypatch, tmp_path):
+    """A profile with `effort: High` (mixed case) merged in when no --effort
+    is given must also resolve to 'High' on resume — the profile merge
+    happens after the CLI arg is folded, so it needs its own normalization."""
+    from types import SimpleNamespace
+
+    branch_id, branch_path = _make_gemini_branch_json(
+        tmp_path, "gemini-code", "Gemini 3.5 Flash (Low)"
+    )
+
+    import lionagi.cli.agent as agent_mod
+
+    monkeypatch.setattr(agent_mod, "find_branch", lambda bid: ("run-x", branch_path))
+    monkeypatch.setattr(
+        agent_mod,
+        "load_agent_profile",
+        lambda name: SimpleNamespace(
+            model=None,
+            effort="High",
+            yolo=False,
+            fast_mode=False,
+            system_prompt=None,
+            artifact_defaults=None,
+        ),
+    )
+    _wire_agent_stubs(monkeypatch, tmp_path, operate_return="ok")
+    captured = _capture_resolved_model(monkeypatch)
+
+    from lionagi.cli.agent import _run_agent
+
+    _result, _provider, _bid, terminal_status = await _run_agent(
+        None,
+        "continue",
+        resume=branch_id,
+        effort=None,
+        agent_name="mixed-case-profile",
+    )
+
+    assert terminal_status == "completed"
+    assert captured == ["Gemini 3.5 Flash (High)"], (
+        f"mixed-case profile effort on resume must not misclamp, got {captured}"
+    )

--- a/tests/cli/test_agent_resume_gemini_effort.py
+++ b/tests/cli/test_agent_resume_gemini_effort.py
@@ -216,7 +216,7 @@ async def test_fresh_run_unaffected_by_reapply_effort(monkeypatch, tmp_path):
 async def test_resume_mixed_case_effort_reapplies_correct_agy_tier(monkeypatch, tmp_path):
     """`li agent -r <id> --effort High` (mixed case, no new model) must
     replace the persisted 'Low' suffix with 'High', not silently misclamp
-    to 'Medium' via a lowercase-keyed dict miss (issue #1652)."""
+    to 'Medium' via a lowercase-keyed dict miss."""
     branch_id, branch_path = _make_gemini_branch_json(
         tmp_path, "gemini-code", "Gemini 3.5 Flash (Low)"
     )

--- a/tests/cli/test_agent_resume_gemini_effort.py
+++ b/tests/cli/test_agent_resume_gemini_effort.py
@@ -210,3 +210,33 @@ async def test_fresh_run_unaffected_by_reapply_effort(monkeypatch, tmp_path):
 
     assert terminal_status == "completed"
     assert provider == "gemini-code"
+
+
+@pytest.mark.asyncio
+async def test_resume_mixed_case_effort_reapplies_correct_agy_tier(monkeypatch, tmp_path):
+    """`li agent -r <id> --effort High` (mixed case, no new model) must
+    replace the persisted 'Low' suffix with 'High', not silently misclamp
+    to 'Medium' via a lowercase-keyed dict miss (issue #1652)."""
+    branch_id, branch_path = _make_gemini_branch_json(
+        tmp_path, "gemini-code", "Gemini 3.5 Flash (Low)"
+    )
+
+    import lionagi.cli.agent as agent_mod
+
+    monkeypatch.setattr(agent_mod, "find_branch", lambda bid: ("run-x", branch_path))
+    _wire_agent_stubs(monkeypatch, tmp_path, operate_return="ok")
+    captured = _capture_resolved_model(monkeypatch)
+
+    from lionagi.cli.agent import _run_agent
+
+    _result, _provider, _bid, terminal_status = await _run_agent(
+        None,
+        "continue",
+        resume=branch_id,
+        effort="High",
+    )
+
+    assert terminal_status == "completed"
+    assert captured == ["Gemini 3.5 Flash (High)"], (
+        f"mixed-case --effort on resume must not misclamp, got {captured}"
+    )

--- a/tests/cli/test_providers.py
+++ b/tests/cli/test_providers.py
@@ -255,7 +255,7 @@ def test_resolve_persisted_effort_gemini_code_keeps_requested_effort():
     assert result == "high", f"expected requested effort to persist for gemini-code, got {result!r}"
 
 
-# ── issue #1652 — --effort is case-sensitive on effort-via-model-name paths ─
+# ── mixed-case --effort on effort-via-model-name paths ─
 # All clamp tables (_CODEX_EFFORT_CLAMP, _clamp_claude_effort,
 # _GEMINI_EFFORT_CLAMP) are lowercase-keyed. A mixed-case --effort silently
 # misclamps instead of raising (worst on gemini: "High" -> "Medium" fallback).

--- a/tests/cli/test_providers.py
+++ b/tests/cli/test_providers.py
@@ -253,3 +253,67 @@ def test_resolve_persisted_effort_gemini_code_keeps_requested_effort():
 
     result = resolve_persisted_effort(provider, chat_model, "high")
     assert result == "high", f"expected requested effort to persist for gemini-code, got {result!r}"
+
+
+# ── issue #1652 — --effort is case-sensitive on effort-via-model-name paths ─
+# All clamp tables (_CODEX_EFFORT_CLAMP, _clamp_claude_effort,
+# _GEMINI_EFFORT_CLAMP) are lowercase-keyed. A mixed-case --effort silently
+# misclamps instead of raising (worst on gemini: "High" -> "Medium" fallback).
+
+
+def test_normalize_effort_lowercases_and_passes_through_none():
+    from lionagi.service.providers import normalize_effort
+
+    assert normalize_effort("High") == "high"
+    assert normalize_effort("XHIGH") == "xhigh"
+    assert normalize_effort("low") == "low"
+    assert normalize_effort(None) is None
+
+
+def test_build_chat_model_mixed_case_effort_folds_correct_gemini_tier():
+    """--effort High (capitalized) must fold to the High agy tier, not
+    silently misclamp to Medium via a lowercase-keyed dict miss."""
+    from lionagi.cli._providers import build_chat_model
+
+    chat_model = build_chat_model(
+        "gemini-code", "gemini-3.5-flash", False, False, None, "High", False
+    )
+    assert chat_model == "gemini-code/Gemini 3.5 Flash (High)", (
+        f"mixed-case --effort must not misclamp, got {chat_model!r}"
+    )
+
+
+def test_build_chat_model_mixed_case_effort_matches_lowercase_equivalent():
+    from lionagi.cli._providers import build_chat_model
+
+    mixed = build_chat_model("gemini-code", "gemini-3.5-flash", False, False, None, "HIGH", False)
+    lower = build_chat_model("gemini-code", "gemini-3.5-flash", False, False, None, "high", False)
+    assert mixed == lower
+
+
+def test_build_imodel_from_spec_mixed_case_max_clamps_codex_to_xhigh(monkeypatch):
+    """--effort Max (mixed case) must still clamp to xhigh for codex, not
+    pass through raw as "Max"."""
+    import lionagi.cli._providers as pmod
+    from lionagi.testing import IModelKwargCaptor
+
+    captor = IModelKwargCaptor.fresh()
+    monkeypatch.setattr(pmod, "iModel", captor)
+
+    build_imodel_from_spec("codex/gpt-5.4", effort_override="Max")
+
+    assert captor.captures[0].get("reasoning_effort") == "xhigh"
+
+
+def test_build_imodel_from_spec_mixed_case_xhigh_clamps_claude_to_high(monkeypatch):
+    """--effort XHigh on a non-opus-4-7 Claude model must clamp to 'high',
+    matching the lowercase 'xhigh' behavior (case must not bypass the clamp)."""
+    import lionagi.cli._providers as pmod
+    from lionagi.testing import IModelKwargCaptor
+
+    captor = IModelKwargCaptor.fresh()
+    monkeypatch.setattr(pmod, "iModel", captor)
+
+    build_imodel_from_spec("claude/sonnet", effort_override="XHigh")
+
+    assert captor.captures[0].get("effort") == "high"


### PR DESCRIPTION
## Summary
- `--effort` was case-sensitive on every effort-via-model-name path: the gemini clamp table (`_GEMINI_EFFORT_CLAMP`) is lowercase-keyed and falls back to `Medium` on a lookup miss, so `--effort High` silently misclamped to Medium instead of High. The codex (`max`→`xhigh`) and claude (`xhigh`→`high` for non-opus-4-7) clamps had the same gap.
- Added `normalize_effort()` in `lionagi/service/providers.py` as the single lowercasing boundary, called at each place a raw effort string enters lionagi from outside: `build_chat_model` and `build_imodel_from_spec` in `lionagi/cli/_providers.py`, and `_run_agent`'s `effort` parameter in `lionagi/cli/agent.py` (covers both the fresh-branch build path and the resume path, which folds effort directly into a persisted agy model name).
- Accepted effort vocabulary is unchanged — only case is normalized, not scattered `.lower()` calls at each clamp site.

## Test plan
- [x] New regression tests pinned failing before the fix, passing after: mixed-case gemini folding (`build_chat_model`), mixed-case codex `Max`→`xhigh` and claude `XHigh`→`high` clamping (`build_imodel_from_spec`), and a resume-path test (`--effort High` on an existing gemini-code branch).
- [x] `PYTHONPATH=$PWD .venv/bin/python -m pytest tests/cli/ tests/providers/google/gemini_code/ -p no:cacheprovider` — all pass (1 pre-existing unrelated skip).
- [x] `ruff format` + `ruff check` on touched files — clean.

Closes #1652

🤖 Generated with [Claude Code](https://claude.com/claude-code)