### PR TITLE
fix(lndl): lex and parse scientific-notation number literals

### DIFF
--- a/lionagi/lndl/lexer.py
+++ b/lionagi/lndl/lexer.py
@@ -82,6 +82,21 @@ class Lexer:
         while (char := self.current_char()) and (char.isdigit() or char == "."):
             result += char
             self.advance()
+        # Scientific-notation exponent: e/E, optional sign, then at least one
+        # digit. The e/E is only consumed when a valid exponent follows, so a
+        # trailing 'e' with no digits stays a separate token.
+        if (char := self.current_char()) and char in "eE":
+            sign = self.peek_char()
+            exp_digit = self.peek_char(2) if sign in ("+", "-") else sign
+            if exp_digit and exp_digit.isdigit():
+                result += char
+                self.advance()
+                if (sign_char := self.current_char()) and sign_char in "+-":
+                    result += sign_char
+                    self.advance()
+                while (digit := self.current_char()) and digit.isdigit():
+                    result += digit
+                    self.advance()
         return result
 
     def read_string(self) -> str:

--- a/lionagi/lndl/parser.py
+++ b/lionagi/lndl/parser.py
@@ -468,7 +468,8 @@ class Parser:
                 num_str = num_token.value
                 self.advance()
                 try:
-                    fields[field_name] = float(num_str) if "." in num_str else int(num_str)
+                    is_float = any(c in num_str for c in ".eE")
+                    fields[field_name] = float(num_str) if is_float else int(num_str)
                 except ValueError as e:
                     raise ParseError(f"Invalid number literal '{num_str}'", num_token) from e
 

--- a/lionagi/lndl/parser.py
+++ b/lionagi/lndl/parser.py
@@ -4,6 +4,7 @@
 """LNDL Parser — recursive descent parser for structured output tags."""
 
 import ast
+import math
 import re
 import warnings
 from typing import Any
@@ -469,7 +470,14 @@ class Parser:
                 self.advance()
                 try:
                     is_float = any(c in num_str for c in ".eE")
-                    fields[field_name] = float(num_str) if is_float else int(num_str)
+                    if is_float:
+                        parsed = float(num_str)
+                        # Overflow-to-inf (e.g. 1e400) serializes to invalid JSON downstream.
+                        if not math.isfinite(parsed):
+                            raise ValueError("non-finite number literal")
+                        fields[field_name] = parsed
+                    else:
+                        fields[field_name] = int(num_str)
                 except ValueError as e:
                     raise ParseError(f"Invalid number literal '{num_str}'", num_token) from e
 

--- a/tests/lndl/test_lexer.py
+++ b/tests/lndl/test_lexer.py
@@ -56,6 +56,39 @@ class TestLexerLiterals:
         assert tokens[0].type is TokenType.NUM
         assert tokens[0].value == "3.14"
 
+    def test_scientific_notation_lowercase_e(self):
+        tokens = Lexer("1e10").tokenize()
+        assert tokens[0].type is TokenType.NUM
+        assert tokens[0].value == "1e10"
+
+    def test_scientific_notation_uppercase_e(self):
+        tokens = Lexer("2E5").tokenize()
+        assert tokens[0].type is TokenType.NUM
+        assert tokens[0].value == "2E5"
+
+    def test_scientific_notation_negative_exponent(self):
+        tokens = Lexer("1.5e-3").tokenize()
+        assert tokens[0].type is TokenType.NUM
+        assert tokens[0].value == "1.5e-3"
+
+    def test_scientific_notation_positive_exponent(self):
+        tokens = Lexer("2E+5").tokenize()
+        assert tokens[0].type is TokenType.NUM
+        assert tokens[0].value == "2E+5"
+
+    def test_trailing_e_without_exponent_not_consumed(self):
+        """A bare 'e' with no following digit stays its own token, not part of the number."""
+        tokens = Lexer("1e").tokenize()
+        assert tokens[0].type is TokenType.NUM
+        assert tokens[0].value == "1"
+        assert tokens[1].type is TokenType.ID
+        assert tokens[1].value == "e"
+
+    def test_negative_scientific_notation_in_out_block(self):
+        tokens = Lexer("OUT{k: -1.5e-3}").tokenize()
+        types_values = [(t.type, t.value) for t in tokens]
+        assert (TokenType.NUM, "-1.5e-3") in types_values
+
     def test_negative_number_in_out_block(self):
         tokens = Lexer("OUT{score: -1}").tokenize()
         types_values = [(t.type, t.value) for t in tokens]

--- a/tests/lndl/test_lexer.py
+++ b/tests/lndl/test_lexer.py
@@ -84,6 +84,15 @@ class TestLexerLiterals:
         assert tokens[1].type is TokenType.ID
         assert tokens[1].value == "e"
 
+    def test_trailing_e_with_sign_but_no_digit_not_consumed(self):
+        """'e' followed by a sign but no digit is not folded into the number."""
+        for src in ("1e+", "1e-"):
+            tokens = Lexer(src).tokenize()
+            assert tokens[0].type is TokenType.NUM
+            assert tokens[0].value == "1"
+            assert tokens[1].type is TokenType.ID
+            assert tokens[1].value == "e"
+
     def test_negative_scientific_notation_in_out_block(self):
         tokens = Lexer("OUT{k: -1.5e-3}").tokenize()
         types_values = [(t.type, t.value) for t in tokens]

--- a/tests/lndl/test_parser.py
+++ b/tests/lndl/test_parser.py
@@ -136,6 +136,11 @@ class TestScientificNotationLiterals:
         assert prog.out_block.fields["x"] == 42
         assert isinstance(prog.out_block.fields["x"], int)
 
+    def test_exponent_overflow_raises_parse_error(self):
+        """An exponent that overflows to inf is rejected, not silently accepted."""
+        with pytest.raises(ParseError, match="Invalid number literal"):
+            _parse("OUT{x: 1e400}")
+
 
 class TestDottedLact:
     def test_dotted_lact_parses_model_field_alias(self):

--- a/tests/lndl/test_parser.py
+++ b/tests/lndl/test_parser.py
@@ -117,6 +117,26 @@ class TestParseErrors:
         assert nested == ["x"]
 
 
+class TestScientificNotationLiterals:
+    def test_exponent_no_dot_parses_as_float(self):
+        prog = _parse("OUT{x: 1e10}")
+        assert prog.out_block.fields["x"] == 1e10
+        assert isinstance(prog.out_block.fields["x"], float)
+
+    def test_fractional_negative_exponent_parses_as_float(self):
+        prog = _parse("OUT{x: 1.5e-3}")
+        assert prog.out_block.fields["x"] == pytest.approx(0.0015)
+
+    def test_uppercase_positive_exponent_parses_as_float(self):
+        prog = _parse("OUT{x: 2E+5}")
+        assert prog.out_block.fields["x"] == 200000.0
+
+    def test_plain_integer_still_parses_as_int(self):
+        prog = _parse("OUT{x: 42}")
+        assert prog.out_block.fields["x"] == 42
+        assert isinstance(prog.out_block.fields["x"], int)
+
+
 class TestDottedLact:
     def test_dotted_lact_parses_model_field_alias(self):
         prog = _parse("<lact model.field alias>fn(x=1)</lact>\nOUT{alias}")


### PR DESCRIPTION
## What

LNDL's lexer `read_number` only consumed digits and `.`, so a scientific-notation literal like `1e10`, `1.5e-3`, or `2E+5` tokenized as a `NUM` (the mantissa) followed by a stray identifier — a silent parse corruption for any exponent-form number in an `OUT{}` block.

Two coupled fixes:

- **`lionagi/lndl/lexer.py`** — `read_number` now consumes an `e`/`E` exponent with an optional sign and at least one digit. The `e`/`E` is only taken when a valid exponent actually follows, so malformed input like a trailing bare `e` stays its own token.
- **`lionagi/lndl/parser.py`** — the `OUT{}` block's direct-`NUM` dispatch used `float(s) if "." in s else int(s)`, so a no-dot exponent (`1e10`) routed to `int("1e10")` and raised. It now treats any `e`/`E`-bearing literal as a float. `parse_value` already handled exponents via `ast.literal_eval` and is unchanged.

## Tests

- `tests/lndl/test_lexer.py` — exponent tokenization (lower/upper `e`, signed exponents, negative-in-`OUT`, trailing-`e`-not-consumed guard).
- `tests/lndl/test_parser.py` — parsed-value assertions incl. the no-dot `1e10`→`float` regression and plain-int preservation.

Full `tests/lndl/` suite green (289 passed); ruff check + format clean.

First step of the ADR-0087 LNDL seam implementation sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)