### PR TITLE
feat(operations): render operator steer messages into next op instruction

### DIFF
--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -43,6 +43,54 @@ UNLIMITED_CONCURRENCY = int(os.environ.get("LIONAGI_MAX_CONCURRENCY", "10000"))
 # Tracks which Operation a reactive task is running (per-task contextvar).
 _CURRENT_OP: contextvars.ContextVar = contextvars.ContextVar("reactive_current_op", default=None)
 
+_OPERATOR_STEER_TEMPLATE = """\
+[OPERATOR STEER]
+A human operator sent these live corrections while this flow is running.
+Attend to them before continuing. Most recent last.
+{lines}
+[/OPERATOR STEER]
+
+"""
+
+
+def _format_operator_ts(ts: Any) -> str:
+    import datetime
+
+    try:
+        dt = datetime.datetime.fromtimestamp(float(ts), tz=datetime.timezone.utc)
+        return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    except (TypeError, ValueError, OSError):
+        return str(ts)
+
+
+def _render_operator_messages(operation: "Operation", context: dict[str, Any]) -> None:
+    """Lift ``operator_messages`` out of context and render unconsumed entries into the instruction.
+
+    Always pops the key so it never rides along as raw JSON in the model's
+    context, whether or not there was anything new to render. Consume-once:
+    an entry already carrying a ``rendered_into_op`` breadcrumb was rendered
+    into an earlier operation and is skipped here.
+    """
+    messages = context.pop("operator_messages", None)
+    if not messages:
+        return
+
+    pending = [m for m in messages if isinstance(m, dict) and not m.get("rendered_into_op")]
+    if not pending:
+        return
+
+    lines = "\n".join(f"- {_format_operator_ts(m.get('ts'))}: {m.get('text', '')}" for m in pending)
+    block = _OPERATOR_STEER_TEMPLATE.format(lines=lines)
+
+    instruction = operation.parameters.get("instruction")
+    instruction = "" if instruction is None else str(instruction)
+    operation.parameters["instruction"] = block + instruction
+
+    op_id = str(operation.id)
+    for m in pending:
+        m["rendered_into_op"] = op_id
+    operation.metadata["rendered_into_op"] = op_id
+
 
 @dataclass(slots=True)
 class FlowEvent:
@@ -423,6 +471,10 @@ class DependencyAwareExecutor:
                         "original_context": existing_context,
                         **self.context.content,
                     }
+
+        context = operation.parameters.get("context")
+        if isinstance(context, dict):
+            _render_operator_messages(operation, context)
 
         branch = self._resolve_branch_for_operation(operation)
         self.operation_branches[operation.id] = branch

--- a/tests/operations/test_flow_operator_steer.py
+++ b/tests/operations/test_flow_operator_steer.py
@@ -1,0 +1,230 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Operator-message render slot tests (ADR-0088 slice 1, Mode A).
+
+Covers: the labeled [OPERATOR STEER] block renders into the next op's
+instruction and is lifted out of the raw context dict; consume-once so a
+steer renders into exactly one downstream op; and an acceptance check that
+the rendered text reaches the provider-bound payload, not just an internal
+field.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from lionagi.operations.flow import DependencyAwareExecutor
+from lionagi.operations.node import Operation, create_operation
+from lionagi.protocols.graph.edge import Edge
+from lionagi.protocols.graph.graph import Graph
+from lionagi.session.session import Session
+from lionagi.testing import TestBranch
+
+# ---------------------------------------------------------------------------
+# Unit: render + lift-out (operates directly on _prepare_operation)
+# ---------------------------------------------------------------------------
+
+
+def test_operator_message_renders_labeled_block_into_instruction():
+    session = Session()
+    graph = Graph()
+    op = Operation(operation="operate", parameters={"instruction": "do the task"})
+    graph.add_node(op)
+
+    executor = DependencyAwareExecutor(
+        session=session,
+        graph=graph,
+        context={
+            "operator_messages": [{"ts": 1720000000.0, "text": "change target language to Rust"}]
+        },
+    )
+    executor._prepare_operation(op)
+
+    instruction = op.parameters["instruction"]
+    assert instruction.startswith("[OPERATOR STEER]")
+    assert "change target language to Rust" in instruction
+    assert instruction.endswith("do the task")
+    assert "[/OPERATOR STEER]" in instruction
+
+
+def test_operator_message_absent_from_raw_context_after_render():
+    session = Session()
+    graph = Graph()
+    op = Operation(operation="operate", parameters={"instruction": "do the task"})
+    graph.add_node(op)
+
+    executor = DependencyAwareExecutor(
+        session=session,
+        graph=graph,
+        context={"operator_messages": [{"ts": 1.0, "text": "steer left"}]},
+    )
+    executor._prepare_operation(op)
+
+    ctx = op.parameters["context"]
+    assert "operator_messages" not in ctx
+
+
+def test_operator_message_records_rendered_into_op_breadcrumb():
+    session = Session()
+    graph = Graph()
+    op = Operation(operation="operate", parameters={"instruction": "do the task"})
+    graph.add_node(op)
+
+    executor = DependencyAwareExecutor(
+        session=session,
+        graph=graph,
+        context={"operator_messages": [{"ts": 1.0, "text": "steer left"}]},
+    )
+    executor._prepare_operation(op)
+
+    assert op.metadata["rendered_into_op"] == str(op.id)
+    entry = executor.context.content["operator_messages"][0]
+    assert entry["rendered_into_op"] == str(op.id)
+
+
+def test_no_operator_messages_leaves_instruction_and_context_untouched():
+    session = Session()
+    graph = Graph()
+    op = Operation(
+        operation="operate", parameters={"instruction": "do the task", "context": {"k": "v"}}
+    )
+    graph.add_node(op)
+
+    executor = DependencyAwareExecutor(session=session, graph=graph)
+    executor._prepare_operation(op)
+
+    assert op.parameters["instruction"] == "do the task"
+    assert op.parameters["context"] == {"k": "v"}
+    assert "rendered_into_op" not in op.metadata
+
+
+# ---------------------------------------------------------------------------
+# Consume-once: a steer renders into exactly one downstream op
+# ---------------------------------------------------------------------------
+
+
+def test_consume_once_second_op_does_not_rerender_first_message():
+    session = Session()
+    graph = Graph()
+    op1 = Operation(operation="operate", parameters={"instruction": "op1 task"})
+    op2 = Operation(operation="operate", parameters={"instruction": "op2 task"})
+    graph.add_node(op1)
+    graph.add_node(op2)
+
+    executor = DependencyAwareExecutor(
+        session=session,
+        graph=graph,
+        context={"operator_messages": [{"ts": 1.0, "text": "first steer"}]},
+    )
+
+    executor._prepare_operation(op1)
+    assert "first steer" in op1.parameters["instruction"]
+
+    executor._prepare_operation(op2)
+    assert "first steer" not in op2.parameters["instruction"]
+    assert op2.parameters["instruction"] == "op2 task"
+    assert "rendered_into_op" not in op2.metadata
+
+
+def test_consume_once_new_message_queued_between_ops_renders_into_next_op_only():
+    session = Session()
+    graph = Graph()
+    op1 = Operation(operation="operate", parameters={"instruction": "op1 task"})
+    op2 = Operation(operation="operate", parameters={"instruction": "op2 task"})
+    graph.add_node(op1)
+    graph.add_node(op2)
+
+    executor = DependencyAwareExecutor(
+        session=session,
+        graph=graph,
+        context={"operator_messages": [{"ts": 1.0, "text": "first steer"}]},
+    )
+
+    executor._prepare_operation(op1)
+    assert "first steer" in op1.parameters["instruction"]
+
+    # Simulate the control poller appending a new message mid-run (ADR-0085
+    # part 1 semantics) between op1's prep and op2's prep.
+    existing = executor.context.content.get("operator_messages", [])
+    executor.context.content["operator_messages"] = [*existing, {"ts": 2.0, "text": "second steer"}]
+
+    executor._prepare_operation(op2)
+    instr2 = op2.parameters["instruction"]
+    assert "second steer" in instr2
+    assert "first steer" not in instr2
+
+
+# ---------------------------------------------------------------------------
+# Acceptance: the rendered block reaches the provider-bound payload
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_operator_steer_reaches_provider_bound_payload():
+    """The scripted endpoint records the actual outbound payload — assert the
+    steer block lands there, not just on an internal Operation field."""
+    branch = TestBranch.from_text("draft acknowledged", name="worker")
+    session = Session()
+    session.include_branches(branch)
+    session.default_branch = branch
+
+    graph = Graph()
+    node = create_operation("operate", parameters={"instruction": "implement feature X in Python"})
+    node.branch_id = branch.id
+    graph.add_node(node)
+
+    await session.flow(
+        graph,
+        context={
+            "operator_messages": [
+                {"ts": 1720000000.0, "text": "change the target language to Rust"}
+            ]
+        },
+        parallel=False,
+    )
+
+    calls = TestBranch.calls(branch)
+    assert len(calls) == 1
+    payload_text = json.dumps(calls[0].payload)
+    assert "[OPERATOR STEER]" in payload_text
+    assert "change the target language to Rust" in payload_text
+    assert "operator_messages" not in payload_text
+
+
+@pytest.mark.asyncio
+async def test_operator_steer_consume_once_across_real_flow_ops():
+    """Two dependent real ops: op1 sees the queued steer rendered; op2 (which
+    depends on op1) must not see it re-rendered in its own payload."""
+    branch = TestBranch.from_text(["op1 done", "op2 done"], name="worker")
+    session = Session()
+    session.include_branches(branch)
+    session.default_branch = branch
+
+    graph = Graph()
+    op1 = create_operation("operate", parameters={"instruction": "op1 task"})
+    op2 = create_operation("operate", parameters={"instruction": "op2 task"})
+    op1.branch_id = branch.id
+    op2.branch_id = branch.id
+    graph.add_node(op1)
+    graph.add_node(op2)
+    graph.add_edge(Edge(head=op1.id, tail=op2.id))
+
+    await session.flow(
+        graph,
+        context={"operator_messages": [{"ts": 1.0, "text": "steer once"}]},
+        parallel=False,
+    )
+
+    calls = TestBranch.calls(branch)
+    assert len(calls) == 2
+    assert "[OPERATOR STEER]" in (calls[0].last_user_message or "")
+    # op2's own (latest) turn must not re-render the steer; it may still
+    # appear earlier in the same branch's conversation history from op1's turn.
+    assert "[OPERATOR STEER]" not in (calls[1].last_user_message or "")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

ADR-0088 slice 1 (Mode A: the operator-message render slot). The control
plane already writes `session_controls` rows and an in-process poller
(`cli/orchestrate/flow.py`) appends the message into
`context.content["operator_messages"]`, but nothing read that key by name —
it only reached the model as an anonymous key buried inside the generic
context dict. This PR adds the reader.

- `operations/flow.py` `_prepare_operation` now lifts `operator_messages`
  out of the merged context (after both the predecessor-context and
  flow-context merge steps) and, if any entries are unconsumed, prepends a
  salient `[OPERATOR STEER]` block to the op's instruction, mirroring the
  existing `_BUDGET_PREAMBLE_TEMPLATE` pattern used by `cli/orchestrate/flow.py`.
- The raw `operator_messages` key is always popped from the per-op context
  dict, so it never rides along as raw JSON in what the model sees —
  whether or not there was anything new to render.
- **Consume-once**: each rendered entry is tagged in place with a
  `rendered_into_op` breadcrumb (the op id), and since the entries are
  shared-by-reference with the executor's flow-wide context, this marks
  them consumed globally — a steer renders into exactly one downstream op.
  A new message queued after that still renders into the *next* op.
- **Provenance**: the receiving `Operation`'s own `metadata["rendered_into_op"]`
  is set to its own id (serialized as `node_metadata` per the existing
  DB/session-row convention — see `models/hashable_model.py`), giving the
  measurement harness and `li o ctl status`/`li monitor` (future slices) a
  join key from "steer delivered" to "op that saw it."

## Fence compliance

- Does **not** touch the pause/resume gate (`_pause_event`, the
  `while (gate := self._pause_event)` loop) or its tests
  (`tests/operations/test_flow_pause.py`, unmodified, still green).
- Does **not** touch the `session_controls` transport, the poller's stamp
  semantics, or the `rejected:*` codes (`tests/cli/orchestrate/test_control_poller.py`,
  unmodified, still green — including `rejected:no-pending-ops`).
- Does **not** build Mode B (`op-mode inject`) — deferred per the ADR's
  measurement gate.
- Does **not** add any provider-specific mid-turn interrupt.
- Purely additive: one call site added at the end of the context-merge
  block in `_prepare_operation`, plus one module-level template and two
  small helper functions.

**FENCE READ: consume-once did not require touching pause/resume state.**
It is achieved entirely within the context dict: consumed entries are
tagged with `rendered_into_op` and filtered out on subsequent
`_prepare_operation` calls, sharing the same list object by reference with
the executor's flow-wide `context.content`.

## Test plan

New file `tests/operations/test_flow_operator_steer.py` (8 tests):

- [x] Unit: a queued operator message renders as the labeled
  `[OPERATOR STEER]` block, prepended to the op's instruction
- [x] Unit: `operator_messages` is absent from the raw context dict after render
- [x] Unit: the `rendered_into_op` breadcrumb lands on both the op's
  `metadata` and the consumed message entry
- [x] Unit: no operator messages present → instruction/context untouched, no breadcrumb
- [x] Consume-once: op N+1 does not re-render a message already rendered into op N
- [x] Consume-once: a new message queued between op N and op N+1 renders into op N+1 only
- [x] **Acceptance**: using `lionagi.testing.TestBranch` (scripted endpoint),
  assert the `[OPERATOR STEER]` block and steer text land in the actual
  provider-bound payload (`RecordedCall.payload`/`last_user_message`), not
  just an internal Operation field — and that `operator_messages` never
  appears as raw JSON in the payload
- [x] Acceptance: consume-once holds through a real two-op dependent flow —
  op1's payload carries the block, op2's own (latest) turn does not
  re-render it (though it naturally remains in the branch's prior-turn
  conversation history)

Regression:
- `tests/operations/test_flow_pause.py` — unmodified, all pass (pause/resume
  boundary semantics unchanged)
- `tests/cli/orchestrate/test_control_poller.py` — unmodified, all pass
  (including `rejected:no-pending-ops` and all message/stamp-ordering cases)

Commands run in the worktree (`PYTHONPATH=$PWD .venv/bin/python -m pytest ...`, never `uv run --active`):
- `tests/cli/orchestrate/ tests/operations/` — all pass
- Full `tests/` suite — ~10,318 test-result markers, 0 failed, 0 errors, 9
  environmental skips (no Docker/Postgres, no `ast-grep` binary, no
  `.lionagi/config.toml` in checkout) — all pre-existing and unrelated to
  this change
- `ruff format` / `ruff check` on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)