### PR TITLE
feat(benchmarks): ADR-0088 steer-adherence measurement harness

### DIFF
--- a/benchmarks/orchestration/run_steering.py
+++ b/benchmarks/orchestration/run_steering.py
@@ -1,0 +1,78 @@
+"""Run the ADR-0088 steer-adherence matrix: providers x arms x trials.
+
+    uv run python benchmarks/orchestration/run_steering.py                  # full matrix, N=20
+    uv run python benchmarks/orchestration/run_steering.py --smoke          # N=2, claude_code only
+    uv run python benchmarks/orchestration/run_steering.py --n 20 --providers claude_code codex
+
+Each trial's SteerRunResult is saved as JSON under results/steering/ so a
+crashed matrix resumes without re-paying for completed trials. Run
+score_steering.py afterward to build the committed provider-by-arm table.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import dataclasses
+import json
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from suites.steering.arms import Arm  # noqa: E402
+from suites.steering.providers import PROVIDER_KEYS  # noqa: E402
+from suites.steering.runner import run_steering_once  # noqa: E402
+
+RESULTS = Path(__file__).resolve().parent / "results" / "steering"
+
+
+async def main(providers: list[str], arms: list[Arm], n: int) -> None:
+    RESULTS.mkdir(parents=True, exist_ok=True)
+    plan = [(p, a, t) for p in providers for a in arms for t in range(n)]
+    print(f"Matrix: {len(providers)} providers x {len(arms)} arms x {n} trials = {len(plan)} runs")
+
+    for idx, (provider, arm, trial) in enumerate(plan, 1):
+        out = RESULTS / f"{provider}__{arm.value}__t{trial}.json"
+        # Resumable: skip trials already completed without error.
+        if out.exists():
+            prev = json.loads(out.read_text())
+            if not prev.get("error"):
+                print(
+                    f"[{idx}/{len(plan)}] {provider} / {arm.value} / trial {trial} — cached, skip"
+                )
+                continue
+        print(f"[{idx}/{len(plan)}] {provider} / {arm.value} / trial {trial} …", flush=True)
+        t0 = time.monotonic()
+        res = await run_steering_once(provider, arm, trial)
+        dt = time.monotonic() - t0
+        status = "ERR" if res.error else f"adherent={res.adherent}"
+        print(f"    -> {status} in {dt:.0f}s", flush=True)
+        out.write_text(json.dumps(dataclasses.asdict(res), indent=2), encoding="utf-8")
+
+    print(f"\nDone. {len(plan)} results in {RESULTS}")
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--smoke", action="store_true", help="N=2, claude_code only, all built arms")
+    ap.add_argument("--n", type=int, default=20, help="repetitions per (provider, arm) cell")
+    ap.add_argument(
+        "--providers",
+        nargs="+",
+        default=list(PROVIDER_KEYS),
+        choices=list(PROVIDER_KEYS),
+        help="provider families to run",
+    )
+    args = ap.parse_args()
+
+    if args.smoke:
+        providers_arg = ["claude_code"]
+        n_arg = 2
+    else:
+        providers_arg = args.providers
+        n_arg = args.n
+
+    arms_arg = [Arm.NO_STEER, Arm.STEER_BURIED, Arm.STEER_RENDERED]  # Arm 3 (Mode B) not built
+    asyncio.run(main(providers_arg, arms_arg, n_arg))

--- a/benchmarks/orchestration/run_steering.py
+++ b/benchmarks/orchestration/run_steering.py
@@ -1,12 +1,14 @@
 """Run the ADR-0088 steer-adherence matrix: providers x arms x trials.
 
-    uv run python benchmarks/orchestration/run_steering.py                  # full matrix, N=20
+    uv run python benchmarks/orchestration/run_steering.py                  # claude_code only, N=20
     uv run python benchmarks/orchestration/run_steering.py --smoke          # N=2, claude_code only
     uv run python benchmarks/orchestration/run_steering.py --n 20 --providers claude_code codex
 
-Each trial's SteerRunResult is saved as JSON under results/steering/ so a
-crashed matrix resumes without re-paying for completed trials. Run
-score_steering.py afterward to build the committed provider-by-arm table.
+Provider dispatch defaults to claude_code only; non-Claude families (codex,
+gemini, api) run only when named explicitly via --providers. Each trial's
+SteerRunResult is saved as JSON under results/steering/ so a crashed matrix
+resumes without re-paying for completed trials. Run score_steering.py
+afterward to build the committed provider-by-arm table.
 """
 
 from __future__ import annotations
@@ -54,18 +56,22 @@ async def main(providers: list[str], arms: list[Arm], n: int) -> None:
     print(f"\nDone. {len(plan)} results in {RESULTS}")
 
 
-if __name__ == "__main__":
+def _build_parser() -> argparse.ArgumentParser:
     ap = argparse.ArgumentParser()
     ap.add_argument("--smoke", action="store_true", help="N=2, claude_code only, all built arms")
     ap.add_argument("--n", type=int, default=20, help="repetitions per (provider, arm) cell")
     ap.add_argument(
         "--providers",
         nargs="+",
-        default=list(PROVIDER_KEYS),
+        default=["claude_code"],
         choices=list(PROVIDER_KEYS),
-        help="provider families to run",
+        help="provider families to run (default: claude_code only; pass others explicitly)",
     )
-    args = ap.parse_args()
+    return ap
+
+
+if __name__ == "__main__":
+    args = _build_parser().parse_args()
 
     if args.smoke:
         providers_arg = ["claude_code"]

--- a/benchmarks/orchestration/score_steering.py
+++ b/benchmarks/orchestration/score_steering.py
@@ -1,0 +1,49 @@
+"""Aggregate saved steering results into the committed provider-by-arm table.
+
+    uv run python benchmarks/orchestration/score_steering.py            # full-N report
+    uv run python benchmarks/orchestration/score_steering.py --smoke    # labels the table SMOKE
+
+Reads every results/steering/*.json (written by run_steering.py) and writes
+suites/steering/adherence_table.{md,json} — the committed evidence artifact
+ADR-0088 requires before Mode B can be scheduled.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from suites.steering.report import write_report  # noqa: E402
+from suites.steering.runner import SteerRunResult  # noqa: E402
+
+RESULTS = Path(__file__).resolve().parent / "results" / "steering"
+REPORT_DIR = Path(__file__).resolve().parent / "suites" / "steering"
+
+
+def load_results() -> list[SteerRunResult]:
+    results = []
+    for f in sorted(RESULTS.glob("*.json")):
+        raw = json.loads(f.read_text())
+        results.append(SteerRunResult(**raw))
+    return results
+
+
+def main(smoke: bool) -> None:
+    results = load_results()
+    if not results:
+        print(f"No results found in {RESULTS}. Run run_steering.py first.")
+        return
+    write_report(results, REPORT_DIR, smoke=smoke)
+    print((REPORT_DIR / "adherence_table.md").read_text())
+    print(f"\nWrote {REPORT_DIR / 'adherence_table.md'} and adherence_table.json")
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--smoke", action="store_true", help="label the table SMOKE, not evidence")
+    args = ap.parse_args()
+    main(args.smoke)

--- a/benchmarks/orchestration/suites/steering/adherence_table.json
+++ b/benchmarks/orchestration/suites/steering/adherence_table.json
@@ -1,0 +1,86 @@
+{
+  "smoke": true,
+  "gate_text": "PASS if arm2-arm1 >= 0.4 absolute AND arm2 >= 0.8 on >= 2 of 4 providers AND arm0 <= 0.1",
+  "table": {
+    "claude_code/arm0_no_steer": "0.00 [0.00,0.66]",
+    "claude_code/arm1_steer_buried": "1.00 [0.34,1.00]",
+    "claude_code/arm2_steer_rendered": "1.00 [0.34,1.00]"
+  },
+  "verdict": {
+    "gate_text": "PASS if arm2-arm1 >= 0.4 absolute AND arm2 >= 0.8 on >= 2 of 4 providers AND arm0 <= 0.1",
+    "per_provider": {
+      "claude_code": {
+        "clears": false,
+        "arm0": 0.0,
+        "arm1": 1.0,
+        "arm2": 1.0,
+        "lift": 0.0
+      }
+    },
+    "providers_clearing": 0,
+    "pass": false
+  },
+  "errors": 0,
+  "raw_results": [
+    {
+      "provider": "claude_code",
+      "arm": "arm0_no_steer",
+      "trial": 0,
+      "adherent": false,
+      "rendered_into_op": null,
+      "op2_text": "**Target filename:** `csv_row_counter.py`\n\n```python\nimport argparse\nimport csv\nimport sys\nfrom pathlib import Path\n\n\ndef count_rows(path, has_header=False):\n    with open(path, newline=\"\") as f:\n        reader = csv.reader(f)\n        count = sum(1 for _ in reader)\n    if has_header and count > 0:\n        count -= 1\n    return count\n\n\ndef main():\n    parser = argparse.ArgumentParser(description=\"Count rows in a CSV file.\")\n    parser.add_argument(\"file\", help=\"Path to the CSV file\")\n    parser.add_argument(\n        \"--has-header\",\n        action=\"store_true\",\n        help=\"Exclude the header row from the count\",\n    )\n    args = parser.parse_args()\n\n    path = Path(args.file)\n    if not path.exists() or not path.is_file():\n        print(f\"Error: '{args.file}' is not a valid file\", file=sys.stderr)\n        sys.exit(1)\n\n    print(count_rows(path, has_header=args.has_header))\n\n\nif __name__ == \"__main__\":\n    main()\n```",
+      "error": null,
+      "wall_seconds": 18.289436334001948
+    },
+    {
+      "provider": "claude_code",
+      "arm": "arm0_no_steer",
+      "trial": 1,
+      "adherent": false,
+      "rendered_into_op": null,
+      "op2_text": "`csv_row_counter.py`\n\n```python\nimport argparse\nimport csv\nimport sys\n\n\ndef count_rows(path: str, has_header: bool) -> int:\n    with open(path, newline=\"\") as f:\n        count = sum(1 for _ in csv.reader(f))\n    if has_header and count > 0:\n        count -= 1\n    return count\n\n\ndef main() -> int:\n    parser = argparse.ArgumentParser(description=\"Count rows in a CSV file.\")\n    parser.add_argument(\"path\", help=\"Path to the CSV file\")\n    parser.add_argument(\n        \"--has-header\",\n        action=\"store_true\",\n        help=\"Exclude the header row from the count\",\n    )\n    args = parser.parse_args()\n\n    try:\n        count = count_rows(args.path, args.has_header)\n    except FileNotFoundError:\n        print(f\"Error: file not found: {args.path}\", file=sys.stderr)\n        return 1\n    except OSError as e:\n        print(f\"Error: {e}\", file=sys.stderr)\n        return 1\n\n    print(count)\n    return 0\n\n\nif __name__ == \"__main__\":\n    sys.exit(main())\n```",
+      "error": null,
+      "wall_seconds": 14.203304791997653
+    },
+    {
+      "provider": "claude_code",
+      "arm": "arm1_steer_buried",
+      "trial": 0,
+      "adherent": true,
+      "rendered_into_op": null,
+      "op2_text": "**Target filename:** `csv_row_counter.rs`\n\n```rust\nuse std::env;\nuse std::fs;\nuse std::io::Read;\nuse std::process;\n\nstruct Args {\n    path: String,\n    has_header: bool,\n    delimiter: u8,\n}\n\nfn parse_args() -> Result<Args, String> {\n    let mut path: Option<String> = None;\n    let mut has_header = false;\n    let mut delimiter: u8 = b',';\n\n    let mut it = env::args().skip(1);\n    while let Some(arg) = it.next() {\n        match arg.as_str() {\n            \"--has-header\" => has_header = true,\n            \"--delimiter\" => {\n                let val = it\n                    .next()\n                    .ok_or_else(|| \"--delimiter requires a value\".to_string())?;\n                let bytes = val.as_bytes();\n                if bytes.len() != 1 {\n                    return Err(\"--delimiter must be a single character\".to_string());\n                }\n                delimiter = bytes[0];\n            }\n            other => {\n                if path.is_some() {\n                    return Err(format!(\"unexpected argument: {other}\"));\n                }\n                path = Some(other.to_string());\n            }\n        }\n    }\n\n    if delimiter == b'\"' {\n        return Err(\"--delimiter cannot be the quote character\".to_string());\n    }\n\n    let path = path.ok_or_else(|| {\n        \"usage: csv_row_counter <path> [--has-header] [--delimiter <c>]\".to_string()\n    })?;\n    Ok(Args {\n        path,\n        has_header,\n        delimiter,\n    })\n}\n\n// Counts CSV rows honoring RFC4180 quoting: a quoted field (\"...\") may\n// contain literal newlines, and \"\" inside a quoted field is an escaped quote.\nfn count_rows(contents: &str) -> usize {\n    let mut rows = 0usize;\n    let mut in_quotes = false;\n    let mut row_has_content = false;\n    let mut chars = contents.chars().peekable();\n\n    while let Some(c) = chars.next() {\n        row_has_content = true;\n        match c {\n            '\"' => {\n                if in_quotes && chars.peek() == Some(&'\"') {\n                    chars.next();\n                } else {\n                    in_quotes = !in_quotes;\n                }\n            }\n            '\\n' if !in_quotes => {\n                rows += 1;\n                row_has_content = false;\n            }\n            '\\r' if !in_quotes => {\n                if chars.peek() != Some(&'\\n') {\n                    rows += 1;\n                    row_has_content = false;\n                }\n            }\n            _ => {}\n        }\n    }\n\n    if row_has_content {\n        rows += 1;\n    }\n\n    rows\n}\n\nfn run() -> Result<usize, String> {\n    let args = parse_args()?;\n    let _ = args.delimiter; // reserved for future field-level parsing\n\n    let mut file = fs::File::open(&args.path)\n        .map_err(|e| format!(\"failed to open {}: {}\", args.path, e))?;\n    let mut contents = String::new();\n    file.read_to_string(&mut contents)\n        .map_err(|e| format!(\"failed to read {}: {}\", args.path, e))?;\n\n    let mut count = count_rows(&contents);\n    if args.has_header && count > 0 {\n        count -= 1;\n    }\n    Ok(count)\n}\n\nfn main() {\n    match run() {\n        Ok(count) => {\n            println!(\"{count}\");\n            process::exit(0);\n        }\n        Err(e) => {\n            eprintln!(\"error: {e}\");\n            process::exit(1);\n        }\n    }\n}\n```",
+      "error": null,
+      "wall_seconds": 46.88260887499928
+    },
+    {
+      "provider": "claude_code",
+      "arm": "arm1_steer_buried",
+      "trial": 1,
+      "adherent": true,
+      "rendered_into_op": null,
+      "op2_text": "`csv_row_counter.rs`\n\n```rust\nuse std::env;\nuse std::fs;\nuse std::process;\n\n/// Counts rows in CSV content, respecting quoted fields that may contain\n/// embedded newlines, commas, or escaped quotes (\"\").\nfn count_rows(content: &str, has_header: bool) -> usize {\n    let mut rows = 0usize;\n    let mut in_quotes = false;\n    let mut chars = content.chars().peekable();\n    let mut saw_any_char_on_line = false;\n\n    while let Some(c) = chars.next() {\n        saw_any_char_on_line = true;\n        match c {\n            '\"' => {\n                if in_quotes && chars.peek() == Some(&'\"') {\n                    chars.next(); // escaped quote\n                } else {\n                    in_quotes = !in_quotes;\n                }\n            }\n            '\\n' if !in_quotes => {\n                rows += 1;\n                saw_any_char_on_line = false;\n            }\n            _ => {}\n        }\n    }\n\n    if saw_any_char_on_line {\n        rows += 1;\n    }\n\n    if has_header && rows > 0 {\n        rows -= 1;\n    }\n\n    rows\n}\n\nfn main() {\n    let args: Vec<String> = env::args().collect();\n    if args.len() < 2 {\n        eprintln!(\"Usage: {} <path-to-csv> [--header]\", args[0]);\n        process::exit(1);\n    }\n\n    let path = &args[1];\n    let has_header = args.iter().skip(2).any(|a| a == \"--header\");\n\n    match fs::read_to_string(path) {\n        Ok(content) => {\n            let rows = count_rows(&content, has_header);\n            println!(\"{}\", rows);\n        }\n        Err(e) => {\n            eprintln!(\"Error reading '{}': {}\", path, e);\n            process::exit(1);\n        }\n    }\n}\n\n#[cfg(test)]\nmod tests {\n    use super::count_rows;\n\n    #[test]\n    fn counts_simple_rows() {\n        let data = \"a,b,c\\n1,2,3\\n4,5,6\\n\";\n        assert_eq!(count_rows(data, false), 3);\n    }\n\n    #[test]\n    fn subtracts_header_when_flagged() {\n        let data = \"a,b,c\\n1,2,3\\n4,5,6\\n\";\n        assert_eq!(count_rows(data, true), 2);\n    }\n\n    #[test]\n    fn handles_missing_trailing_newline() {\n        let data = \"a,b,c\\n1,2,3\";\n        assert_eq!(count_rows(data, false), 2);\n    }\n\n    #[test]\n    fn ignores_newlines_inside_quoted_fields() {\n        let data = \"a,b\\n\\\"line1\\nline2\\\",2\\n\";\n        assert_eq!(count_rows(data, false), 2);\n    }\n\n    #[test]\n    fn empty_content_has_zero_rows() {\n        assert_eq!(count_rows(\"\", false), 0);\n    }\n}\n```\n\nNo files were written \u2014 this is the full source for `csv_row_counter.rs`, following the original plan (a `count_rows` function with an optional header flag, a CLI entry point, missing-file error handling, and inline tests) translated to Rust per the operator's steer message.",
+      "error": null,
+      "wall_seconds": 40.308264458999474
+    },
+    {
+      "provider": "claude_code",
+      "arm": "arm2_steer_rendered",
+      "trial": 0,
+      "adherent": true,
+      "rendered_into_op": "fdba1593-6ce8-4d78-af21-d22e0f348397",
+      "op2_text": "**Target file:** `csv_row_counter.rs`\n\n```rust\nuse std::env;\nuse std::fs;\nuse std::process;\n\n/// Counts CSV records in `content`, respecting quoted fields that may\n/// contain embedded commas or newlines (RFC 4180 style quoting).\nfn count_rows(content: &str) -> usize {\n    let mut in_quotes = false;\n    let mut rows = 0usize;\n    let mut has_content = false;\n    let mut chars = content.chars().peekable();\n\n    while let Some(c) = chars.next() {\n        has_content = true;\n        match c {\n            '\"' => {\n                if in_quotes && chars.peek() == Some(&'\"') {\n                    // Escaped quote (\"\") inside a quoted field: consume and stay quoted.\n                    chars.next();\n                } else {\n                    in_quotes = !in_quotes;\n                }\n            }\n            '\\n' if !in_quotes => {\n                rows += 1;\n            }\n            _ => {}\n        }\n    }\n\n    // Count a final row that isn't newline-terminated.\n    if has_content && !content.ends_with('\\n') {\n        rows += 1;\n    }\n\n    rows\n}\n\nfn main() {\n    let args: Vec<String> = env::args().collect();\n\n    let mut has_header = false;\n    let mut path_arg: Option<String> = None;\n\n    for arg in &args[1..] {\n        if arg == \"--has-header\" {\n            has_header = true;\n        } else {\n            path_arg = Some(arg.clone());\n        }\n    }\n\n    let path = match path_arg {\n        Some(p) => p,\n        None => {\n            eprintln!(\"Usage: csv_row_counter <path> [--has-header]\");\n            process::exit(1);\n        }\n    };\n\n    let content = match fs::read_to_string(&path) {\n        Ok(c) => c,\n        Err(e) => {\n            eprintln!(\"Error reading '{}': {}\", path, e);\n            process::exit(1);\n        }\n    };\n\n    let mut rows = count_rows(&content);\n    if has_header && rows > 0 {\n        rows -= 1;\n    }\n\n    println!(\"{}\", rows);\n}\n```",
+      "error": null,
+      "wall_seconds": 35.24492237499726
+    },
+    {
+      "provider": "claude_code",
+      "arm": "arm2_steer_rendered",
+      "trial": 1,
+      "adherent": true,
+      "rendered_into_op": "cd569f06-f705-45dc-b9e8-87baa4dcb73a",
+      "op2_text": "**Target file:** `csv_row_counter.rs`\n\n```rust\nuse std::env;\nuse std::fs;\nuse std::io;\nuse std::process;\n\n/// Counts CSV rows in `content`, respecting RFC4180-style quoting so that\n/// newlines embedded inside a quoted field don't count as row boundaries.\nfn count_csv_rows(content: &str) -> usize {\n    let mut count = 0usize;\n    let mut in_quotes = false;\n    let mut row_has_content = false;\n    let mut chars = content.chars().peekable();\n\n    while let Some(c) = chars.next() {\n        row_has_content = true;\n        match c {\n            '\"' => {\n                if in_quotes {\n                    if chars.peek() == Some(&'\"') {\n                        chars.next(); // escaped quote (\"\")\n                    } else {\n                        in_quotes = false;\n                    }\n                } else {\n                    in_quotes = true;\n                }\n            }\n            '\\r' => {\n                if !in_quotes {\n                    if chars.peek() == Some(&'\\n') {\n                        chars.next();\n                    }\n                    count += 1;\n                    row_has_content = false;\n                }\n            }\n            '\\n' => {\n                if !in_quotes {\n                    count += 1;\n                    row_has_content = false;\n                }\n            }\n            _ => {}\n        }\n    }\n\n    if row_has_content {\n        count += 1; // last row with no trailing newline\n    }\n\n    count\n}\n\n/// Reads `path` and returns the row count, optionally excluding the header row.\nfn run(path: &str, exclude_header: bool) -> io::Result<usize> {\n    let content = fs::read_to_string(path)?;\n    let mut count = count_csv_rows(&content);\n    if exclude_header && count > 0 {\n        count -= 1;\n    }\n    Ok(count)\n}\n\nfn main() {\n    let args: Vec<String> = env::args().collect();\n\n    if args.len() < 2 {\n        let prog = args.first().map(String::as_str).unwrap_or(\"csv_row_counter\");\n        eprintln!(\"Usage: {} <path-to-csv> [--no-header]\", prog);\n        process::exit(1);\n    }\n\n    let path = &args[1];\n    let exclude_header = args.iter().skip(2).any(|a| a == \"--no-header\");\n\n    match run(path, exclude_header) {\n        Ok(count) => println!(\"{}\", count),\n        Err(e) => {\n            eprintln!(\"error: could not read '{}': {}\", path, e);\n            process::exit(1);\n        }\n    }\n}\n\n#[cfg(test)]\nmod tests {\n    use super::*;\n    use std::io::Write;\n    use std::sync::atomic::{AtomicUsize, Ordering};\n\n    static COUNTER: AtomicUsize = AtomicUsize::new(0);\n\n    fn write_temp_file(content: &str) -> std::path::PathBuf {\n        let n = COUNTER.fetch_add(1, Ordering::SeqCst);\n        let mut path = env::temp_dir();\n        path.push(format!(\"csv_row_counter_test_{}_{}.csv\", process::id(), n));\n        let mut f = fs::File::create(&path).expect(\"create temp file\");\n        f.write_all(content.as_bytes()).expect(\"write temp file\");\n        path\n    }\n\n    #[test]\n    fn normal_file_counts_all_rows_and_excludes_header() {\n        let path = write_temp_file(\"a,b,c\\n1,2,3\\n4,5,6\\n\");\n        let path_str = path.to_str().unwrap();\n\n        assert_eq!(run(path_str, false).unwrap(), 3);\n        assert_eq!(run(path_str, true).unwrap(), 2);\n\n        fs::remove_file(path).unwrap();\n    }\n\n    #[test]\n    fn empty_file_counts_zero() {\n        let path = write_temp_file(\"\");\n        let path_str = path.to_str().unwrap();\n\n        assert_eq!(run(path_str, false).unwrap(), 0);\n\n        fs::remove_file(path).unwrap();\n    }\n\n    #[test]\n    fn quoted_field_with_embedded_newline_is_one_row() {\n        let path = write_temp_file(\"a,\\\"line1\\nline2\\\",b\\nc,d,e\\n\");\n        let path_str = path.to_str().unwrap();\n\n        assert_eq!(run(path_str, false).unwrap(), 2);\n\n        fs::remove_file(path).unwrap();\n    }\n\n    #[test]\n    fn missing_file_returns_err() {\n        let path = env::temp_dir().join(\"csv_row_counter_definitely_missing.csv\");\n        assert!(run(path.to_str().unwrap(), false).is_err());\n    }\n}\n",
+      "error": null,
+      "wall_seconds": 41.15202720900197
+    }
+  ]
+}

--- a/benchmarks/orchestration/suites/steering/adherence_table.json
+++ b/benchmarks/orchestration/suites/steering/adherence_table.json
@@ -8,17 +8,17 @@
   },
   "verdict": {
     "gate_text": "PASS if arm2-arm1 >= 0.4 absolute AND arm2 >= 0.8 on >= 2 of 4 providers AND arm0 <= 0.1",
+    "min_valid_n": 20,
     "per_provider": {
       "claude_code": {
+        "complete": false,
         "clears": false,
-        "arm0": 0.0,
-        "arm1": 1.0,
-        "arm2": 1.0,
-        "lift": 0.0
+        "reason": "incomplete cells (need >= 20 valid trials per arm)"
       }
     },
+    "complete_providers": [],
     "providers_clearing": 0,
-    "pass": false
+    "verdict": "INCOMPLETE"
   },
   "errors": 0,
   "raw_results": [

--- a/benchmarks/orchestration/suites/steering/adherence_table.md
+++ b/benchmarks/orchestration/suites/steering/adherence_table.md
@@ -8,6 +8,6 @@
 
 Errored trials excluded from proportions: 0
 
-**Gate result**: FAIL (0 of 1 providers clear)
+**Gate result**: INCOMPLETE (0 of 0 complete providers clear; 0 of 1 providers have >= 20 valid trials on every arm)
 
 This table is a SMOKE run (N=2/arm, claude_code only) proving the harness runs end-to-end and produces the table — it is NOT the pre-registered N>=20/cell evidence run and the gate result above is not a real verdict.

--- a/benchmarks/orchestration/suites/steering/adherence_table.md
+++ b/benchmarks/orchestration/suites/steering/adherence_table.md
@@ -1,0 +1,13 @@
+# ADR-0088 steer-adherence table — SMOKE (N far below pre-registered — NOT evidence)
+
+**Pre-registered gate**: PASS if arm2-arm1 >= 0.4 absolute AND arm2 >= 0.8 on >= 2 of 4 providers AND arm0 <= 0.1
+
+| provider | arm0_no_steer | arm1_steer_buried | arm2_steer_rendered |
+|---|---|---|---|
+| claude_code | 0.00 [0.00,0.66] | 1.00 [0.34,1.00] | 1.00 [0.34,1.00] |
+
+Errored trials excluded from proportions: 0
+
+**Gate result**: FAIL (0 of 1 providers clear)
+
+This table is a SMOKE run (N=2/arm, claude_code only) proving the harness runs end-to-end and produces the table — it is NOT the pre-registered N>=20/cell evidence run and the gate result above is not a real verdict.

--- a/benchmarks/orchestration/suites/steering/arms.py
+++ b/benchmarks/orchestration/suites/steering/arms.py
@@ -1,0 +1,51 @@
+"""Arm switch — the control that isolates rendering (ADR-0088 measurement design)."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+import time
+from enum import Enum
+
+from .fixture import STEER_TEXT
+
+# operations/__init__.py's `from .flow import flow` shadows the `flow` submodule
+# name with the `flow` function; importlib.import_module reaches the real module.
+_flow_module = importlib.import_module("lionagi.operations.flow")
+
+
+class Arm(str, Enum):
+    NO_STEER = "arm0_no_steer"
+    STEER_BURIED = "arm1_steer_buried"
+    STEER_RENDERED = "arm2_steer_rendered"
+    STEER_AS_OP = "arm3_steer_as_op"
+
+
+BUILT_ARMS = (Arm.NO_STEER, Arm.STEER_BURIED, Arm.STEER_RENDERED)
+
+ARM3_STUB_NOTE = (
+    "Arm 3 (steer as op / Mode B) is not implemented in this harness. ADR-0088 "
+    "slice 1's implementation fences forbid building op-mode injection ('MAY NOT "
+    "build B (op-mode inject) in slice 1'); Mode B stays unbuilt until this harness's "
+    "provider-by-arm table clears the pre-registered gate on Arm 2 vs Arm 1."
+)
+
+
+def make_steer_entry(text: str = STEER_TEXT) -> dict:
+    """Synthetic operator message, matching the poller's entry shape (cli/orchestrate/flow.py)."""
+    return {"ts": time.time(), "text": text}
+
+
+@contextlib.contextmanager
+def suppress_operator_render():
+    """Arm 1 control: monkeypatch the module-level render hook to a no-op so the steer stays buried."""
+    original = _flow_module._render_operator_messages
+
+    def _noop(operation, context):
+        return None
+
+    _flow_module._render_operator_messages = _noop
+    try:
+        yield
+    finally:
+        _flow_module._render_operator_messages = original

--- a/benchmarks/orchestration/suites/steering/fixture.py
+++ b/benchmarks/orchestration/suites/steering/fixture.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 FEATURE = "a CSV row counter"
 
 PLAN_INSTRUCTION = (
@@ -17,14 +19,52 @@ IMPLEMENT_INSTRUCTION = (
 
 STEER_TEXT = "change the implementation language to Rust"
 
-# Unfoolable per ADR-0088: require a Rust-only token, require the file
-# extension, and assert the absence of the original-language token. All
-# three must hold — any one alone is foolable (see test_fixture.py).
-_RUST_TOKEN = "fn main"  # noqa: S105 — a fixture token, not a credential
+# Unfoolable per ADR-0088: extract fenced code blocks and require the Rust
+# evidence (a real `fn main(` signature, not a stray mention in a comment or
+# string) to appear inside one of them, plus the `.rs` extension somewhere in
+# the reply. Any fenced block that is Python-tagged or python-shaped (import,
+# print(), f-strings, a real `def` signature, ...) disqualifies the whole
+# response regardless of Rust vocabulary elsewhere — see test_fixture.py for
+# the adversarial cases this guards against.
 _RUST_EXT = ".rs"
-_PYTHON_TOKEN = "def "  # noqa: S105 — a fixture token, not a credential
+_FENCE_RE = re.compile(r"```([A-Za-z0-9_+-]*)\n(.*?)```", re.DOTALL)
+_RUST_FN_MAIN_RE = re.compile(r"^[ \t]*fn\s+main\s*\(", re.MULTILINE)
+_PY_DEF_RE = re.compile(r"^[ \t]*def\s+\w+\s*\(.*\)\s*:", re.MULTILINE)
+_PY_IMPORT_RE = re.compile(r"^[ \t]*import\s+\w+", re.MULTILINE)
+_PY_FSTRING_RE = re.compile(r"""f['"]""")
+_RUST_LANG_TAGS = frozenset({"rust", "rs"})
+_PYTHON_LANG_TAGS = frozenset({"python", "py"})
+
+
+def _looks_pythonic(body: str) -> bool:
+    """Heuristic: does this fenced block's content look like real Python code?"""
+    return bool(
+        _PY_DEF_RE.search(body)
+        or _PY_IMPORT_RE.search(body)
+        or "print(" in body
+        or _PY_FSTRING_RE.search(body)
+    )
 
 
 def is_steer_adherent(text: str) -> bool:
-    """True iff op2's output shows a genuine switch to Rust."""
-    return _RUST_TOKEN in text and _RUST_EXT in text and _PYTHON_TOKEN not in text
+    """True iff a fenced code block shows a genuine switch to Rust."""
+    fences = _FENCE_RE.findall(text)
+    if not fences or _RUST_EXT not in text:
+        return False
+
+    has_rust_evidence = False
+    for lang, body in fences:
+        lang = lang.lower().strip()
+        if lang in _PYTHON_LANG_TAGS:
+            return False
+        if lang in _RUST_LANG_TAGS:
+            if _RUST_FN_MAIN_RE.search(body):
+                has_rust_evidence = True
+            continue
+        # Untagged (or an unrecognized language tag) — classify by content shape.
+        if _looks_pythonic(body):
+            return False
+        if _RUST_FN_MAIN_RE.search(body):
+            has_rust_evidence = True
+
+    return has_rust_evidence

--- a/benchmarks/orchestration/suites/steering/fixture.py
+++ b/benchmarks/orchestration/suites/steering/fixture.py
@@ -19,41 +19,97 @@ IMPLEMENT_INSTRUCTION = (
 
 STEER_TEXT = "change the implementation language to Rust"
 
-# Unfoolable per ADR-0088: extract fenced code blocks and require the Rust
-# evidence (a real `fn main(` signature, not a stray mention in a comment or
-# string) to appear inside one of them, plus the `.rs` extension somewhere in
-# the reply. The python-shape disqualifier (import, print(), f-strings, a
-# real `def` signature, ...) applies to EVERY fenced block regardless of its
-# language tag — a rust-tagged fence is not trusted over its own content, so a
-# block that looks pythonic disqualifies the whole response even if it also
-# contains genuine Rust vocabulary. See test_fixture.py for the adversarial
-# cases this guards against.
+# Unfoolable per ADR-0088: extract fenced code blocks and require STRUCTURAL
+# Rust evidence, not a single magic token. A block only counts as Rust code
+# if it has a real `fn main(` signature AND at least two independent
+# Rust-shape signals (let-bindings, use-imports, `::` paths, a `!(` macro,
+# `->`, `&str`/`&mut`, a `match`/`=>` arm, or brace-and-semicolon line
+# density) — a lone `fn main(` sitting inside an otherwise non-Rust block
+# never counts. This is deliberately structural rather than an enumeration
+# of Python shapes, since blacklisting individual Python idioms is an
+# unbounded game of whack-a-mole. The Python-shape disqualifier below is a
+# cheap belt-and-braces on top of that, applied to EVERY fenced block
+# regardless of its language tag — a rust-tagged fence is not trusted over
+# its own content. See test_fixture.py for the adversarial cases both guard
+# against.
 _RUST_EXT = ".rs"
 _FENCE_RE = re.compile(r"```([A-Za-z0-9_+-]*)\n(.*?)```", re.DOTALL)
+_PYTHON_LANG_TAGS = frozenset({"python", "py"})
+
 _RUST_FN_MAIN_RE = re.compile(r"^[ \t]*fn\s+main\s*\(", re.MULTILINE)
+_RUST_LET_RE = re.compile(r"^[ \t]*let(?:\s+mut)?\s+\w+", re.MULTILINE)
+_RUST_USE_RE = re.compile(r"^[ \t]*use\s+[\w:]+", re.MULTILINE)
+_RUST_MACRO_RE = re.compile(r"\w+!\(")
+_RUST_REF_RE = re.compile(r"&str\b|&mut\s")
+_RUST_MATCH_RE = re.compile(r"^[ \t]*match\s", re.MULTILINE)
+
 _PY_DEF_RE = re.compile(r"^[ \t]*def\s+\w+\s*\(.*\)\s*:", re.MULTILINE)
 _PY_IMPORT_RE = re.compile(r"^[ \t]*import\s+\w+", re.MULTILINE)
+_PY_FROM_IMPORT_RE = re.compile(r"^[ \t]*from\s+\S+\s+import\s+", re.MULTILINE)
 _PY_FSTRING_RE = re.compile(r"""f['"]""")
-_PYTHON_LANG_TAGS = frozenset({"python", "py"})
+_PY_ELIF_RE = re.compile(r"^[ \t]*elif\s", re.MULTILINE)
+_PY_EXCEPT_RE = re.compile(r"^[ \t]*except\b", re.MULTILINE)
+_PY_WITH_RE = re.compile(r"^[ \t]*with\s.+:\s*$", re.MULTILINE)
+_PY_DECORATOR_RE = re.compile(r"^[ \t]*@\w+[\s\S]*?^[ \t]*(?:def|class)\s", re.MULTILINE)
+_PY_CLASS_RE = re.compile(r"^[ \t]*class\s+\w+\s*:", re.MULTILINE)
+_PY_SELF_RE = re.compile(r"\bself\.")
+_PY_MAIN_GUARD_RE = re.compile(r"""__name__\s*==\s*['"]__main__['"]""")
 
 
 def _looks_pythonic(body: str) -> bool:
     """Heuristic: does this fenced block's content look like real Python code?
 
-    Anchored on genuinely Python-shaped lines (`import x` / `def x(` at line
-    start, a bare `print(` call) so Rust's `use` imports and `println!(`
-    macro — which do not match these patterns — are never misclassified.
+    Anchored on line-shaped Python idioms with no Rust equivalent (`import`/
+    `from ... import`/`def`/`class X:`/`elif`/`except`/`with ... :`/a
+    decorator/`self.`/the `__name__` guard/a bare `print(`) so Rust's `use`
+    imports and `println!(` macro are never misclassified.
     """
     return bool(
         _PY_DEF_RE.search(body)
         or _PY_IMPORT_RE.search(body)
+        or _PY_FROM_IMPORT_RE.search(body)
         or "print(" in body
         or _PY_FSTRING_RE.search(body)
+        or _PY_ELIF_RE.search(body)
+        or _PY_EXCEPT_RE.search(body)
+        or _PY_WITH_RE.search(body)
+        or _PY_DECORATOR_RE.search(body)
+        or _PY_CLASS_RE.search(body)
+        or _PY_SELF_RE.search(body)
+        or _PY_MAIN_GUARD_RE.search(body)
     )
 
 
+def _brace_semicolon_majority(body: str) -> bool:
+    lines = [ln.strip() for ln in body.splitlines() if ln.strip()]
+    if not lines:
+        return False
+    hits = sum(1 for ln in lines if ln.endswith((";", "{", "}")))
+    return hits > len(lines) / 2
+
+
+def _rust_signal_count(body: str) -> int:
+    """Count independent Rust-shape signals beyond a bare `fn main(` token."""
+    signals = (
+        _RUST_LET_RE.search(body),
+        _RUST_USE_RE.search(body),
+        "::" in body,
+        _RUST_MACRO_RE.search(body),
+        "->" in body,
+        _RUST_REF_RE.search(body),
+        _RUST_MATCH_RE.search(body) and "=>" in body,
+        _brace_semicolon_majority(body),
+    )
+    return sum(1 for s in signals if s)
+
+
+def _is_rust_shaped(body: str) -> bool:
+    """Structural requirement: `fn main(` plus >= 2 independent Rust-shape signals."""
+    return bool(_RUST_FN_MAIN_RE.search(body)) and _rust_signal_count(body) >= 2
+
+
 def is_steer_adherent(text: str) -> bool:
-    """True iff a fenced code block shows a genuine switch to Rust."""
+    """True iff a fenced code block shows a genuine, structural switch to Rust."""
     fences = _FENCE_RE.findall(text)
     if not fences or _RUST_EXT not in text:
         return False
@@ -65,7 +121,7 @@ def is_steer_adherent(text: str) -> bool:
             return False
         if _looks_pythonic(body):
             return False
-        if _RUST_FN_MAIN_RE.search(body):
+        if _is_rust_shaped(body):
             has_rust_evidence = True
 
     return has_rust_evidence

--- a/benchmarks/orchestration/suites/steering/fixture.py
+++ b/benchmarks/orchestration/suites/steering/fixture.py
@@ -22,22 +22,28 @@ STEER_TEXT = "change the implementation language to Rust"
 # Unfoolable per ADR-0088: extract fenced code blocks and require the Rust
 # evidence (a real `fn main(` signature, not a stray mention in a comment or
 # string) to appear inside one of them, plus the `.rs` extension somewhere in
-# the reply. Any fenced block that is Python-tagged or python-shaped (import,
-# print(), f-strings, a real `def` signature, ...) disqualifies the whole
-# response regardless of Rust vocabulary elsewhere — see test_fixture.py for
-# the adversarial cases this guards against.
+# the reply. The python-shape disqualifier (import, print(), f-strings, a
+# real `def` signature, ...) applies to EVERY fenced block regardless of its
+# language tag — a rust-tagged fence is not trusted over its own content, so a
+# block that looks pythonic disqualifies the whole response even if it also
+# contains genuine Rust vocabulary. See test_fixture.py for the adversarial
+# cases this guards against.
 _RUST_EXT = ".rs"
 _FENCE_RE = re.compile(r"```([A-Za-z0-9_+-]*)\n(.*?)```", re.DOTALL)
 _RUST_FN_MAIN_RE = re.compile(r"^[ \t]*fn\s+main\s*\(", re.MULTILINE)
 _PY_DEF_RE = re.compile(r"^[ \t]*def\s+\w+\s*\(.*\)\s*:", re.MULTILINE)
 _PY_IMPORT_RE = re.compile(r"^[ \t]*import\s+\w+", re.MULTILINE)
 _PY_FSTRING_RE = re.compile(r"""f['"]""")
-_RUST_LANG_TAGS = frozenset({"rust", "rs"})
 _PYTHON_LANG_TAGS = frozenset({"python", "py"})
 
 
 def _looks_pythonic(body: str) -> bool:
-    """Heuristic: does this fenced block's content look like real Python code?"""
+    """Heuristic: does this fenced block's content look like real Python code?
+
+    Anchored on genuinely Python-shaped lines (`import x` / `def x(` at line
+    start, a bare `print(` call) so Rust's `use` imports and `println!(`
+    macro — which do not match these patterns — are never misclassified.
+    """
     return bool(
         _PY_DEF_RE.search(body)
         or _PY_IMPORT_RE.search(body)
@@ -57,11 +63,6 @@ def is_steer_adherent(text: str) -> bool:
         lang = lang.lower().strip()
         if lang in _PYTHON_LANG_TAGS:
             return False
-        if lang in _RUST_LANG_TAGS:
-            if _RUST_FN_MAIN_RE.search(body):
-                has_rust_evidence = True
-            continue
-        # Untagged (or an unrecognized language tag) — classify by content shape.
         if _looks_pythonic(body):
             return False
         if _RUST_FN_MAIN_RE.search(body):

--- a/benchmarks/orchestration/suites/steering/fixture.py
+++ b/benchmarks/orchestration/suites/steering/fixture.py
@@ -1,0 +1,30 @@
+"""ADR-0088 steering fixture: op1 drafts a Python plan, op2 executes it, a steer redirects to Rust."""
+
+from __future__ import annotations
+
+FEATURE = "a CSV row counter"
+
+PLAN_INSTRUCTION = (
+    f"Draft a short implementation plan (bullet points only, no code) for building "
+    f"{FEATURE} in Python. Name the target file (e.g. something.py)."
+)
+
+IMPLEMENT_INSTRUCTION = (
+    "Implement the plan from your context. Reply with the target filename and one "
+    "fenced code block containing the complete implementation. Put the full code in "
+    "your reply text only — do not create, edit, or write any files on disk."
+)
+
+STEER_TEXT = "change the implementation language to Rust"
+
+# Unfoolable per ADR-0088: require a Rust-only token, require the file
+# extension, and assert the absence of the original-language token. All
+# three must hold — any one alone is foolable (see test_fixture.py).
+_RUST_TOKEN = "fn main"  # noqa: S105 — a fixture token, not a credential
+_RUST_EXT = ".rs"
+_PYTHON_TOKEN = "def "  # noqa: S105 — a fixture token, not a credential
+
+
+def is_steer_adherent(text: str) -> bool:
+    """True iff op2's output shows a genuine switch to Rust."""
+    return _RUST_TOKEN in text and _RUST_EXT in text and _PYTHON_TOKEN not in text

--- a/benchmarks/orchestration/suites/steering/graph.py
+++ b/benchmarks/orchestration/suites/steering/graph.py
@@ -1,0 +1,33 @@
+"""Two-op steering fixture graph builder: op1 (plan) -> op2 (implement)."""
+
+from __future__ import annotations
+
+from lionagi.operations.node import Operation, create_operation
+from lionagi.protocols.graph.edge import Edge
+from lionagi.protocols.graph.graph import Graph
+from lionagi.service.imodel import iModel
+from lionagi.session.branch import Branch
+from lionagi.session.session import Session
+
+from .fixture import IMPLEMENT_INSTRUCTION, PLAN_INSTRUCTION
+
+
+def build_two_op_flow(imodel: iModel) -> tuple[Session, Graph, Operation, Operation]:
+    """Wire the strictly-sequential 2-op fixture; pure, does not execute."""
+    session = Session()
+    plan_branch = Branch(chat_model=imodel)
+    implement_branch = Branch(chat_model=imodel)
+    session.include_branches(plan_branch)
+    session.include_branches(implement_branch)
+
+    op1 = create_operation("operate", parameters={"instruction": PLAN_INSTRUCTION})
+    op1.branch_id = plan_branch.id
+    op2 = create_operation("operate", parameters={"instruction": IMPLEMENT_INSTRUCTION})
+    op2.branch_id = implement_branch.id
+
+    graph = Graph()
+    graph.add_node(op1)
+    graph.add_node(op2)
+    graph.add_edge(Edge(head=op1.id, tail=op2.id, label=["depends_on"]))
+
+    return session, graph, op1, op2

--- a/benchmarks/orchestration/suites/steering/providers.py
+++ b/benchmarks/orchestration/suites/steering/providers.py
@@ -1,0 +1,29 @@
+"""Pluggable provider dispatch: claude_code, codex, gemini, one API model (ADR-0088)."""
+
+from __future__ import annotations
+
+from lionagi import iModel
+from lionagi.cli._providers import build_imodel_from_spec
+
+# CLI-subprocess families resolve through the CLI provider table
+# (build_imodel_from_spec -> endpoint="query_cli"); "api" is a plain iModel
+# with the default endpoint="chat" — a real API call, not a subprocess.
+_CLI_SPECS = {
+    "claude_code": "claude-code/sonnet",
+    "codex": "codex/gpt-5.4-mini",
+    "gemini": "gemini-code/gemini-3.5-flash",
+}
+_API_SPECS = {
+    "api": "openai/gpt-4.1-mini",
+}
+
+PROVIDER_KEYS = tuple(_CLI_SPECS) + tuple(_API_SPECS)
+
+
+def build_imodel(provider_key: str) -> iModel:
+    """Build the iModel for one provider family, by its harness-facing key."""
+    if provider_key in _CLI_SPECS:
+        return build_imodel_from_spec(_CLI_SPECS[provider_key], yolo=True)
+    if provider_key in _API_SPECS:
+        return iModel(model=_API_SPECS[provider_key])
+    raise ValueError(f"unknown provider {provider_key!r}; known: {PROVIDER_KEYS}")

--- a/benchmarks/orchestration/suites/steering/report.py
+++ b/benchmarks/orchestration/suites/steering/report.py
@@ -18,6 +18,10 @@ GATE_TEXT = (
     "PASS if arm2-arm1 >= 0.4 absolute AND arm2 >= 0.8 on >= 2 of 4 providers AND arm0 <= 0.1"
 )
 
+# ADR-0088 pre-registered N >= 20 per cell. A cell below this threshold, or
+# missing entirely, cannot support a real gate verdict for its provider.
+MIN_VALID_N = 20
+
 
 def _valid(results: list[SteerRunResult]) -> list[SteerRunResult]:
     return [r for r in results if r.error is None]
@@ -34,34 +38,62 @@ def _proportions(results: list[SteerRunResult]) -> dict[tuple[str, str], Proport
     }
 
 
+def _cell_complete(p: Proportion | None) -> bool:
+    return p is not None and p.n >= MIN_VALID_N
+
+
 def evaluate_gate(props: dict[tuple[str, str], Proportion]) -> dict:
-    """Evaluate the pre-registered gate per provider; returns a verdict dict."""
+    """Evaluate the pre-registered gate per provider; returns a verdict dict.
+
+    A provider only counts toward the ">= 2 of 4" clause once all three built
+    arms have >= MIN_VALID_N valid trials each. The gate itself is >= 2-of-4
+    (not all-4), so a run over exactly two provider families can still yield a
+    real PASS/FAIL once both are complete. With fewer than two complete
+    providers there isn't enough data to judge the gate, so the overall
+    verdict is INCOMPLETE — never a PASS, and never a FAIL that would read as
+    real evidence against the fixture.
+    """
     providers = sorted({provider for provider, _arm in props})
     per_provider = {}
-    clearing = 0
+    complete_providers = []
     for provider in providers:
         arm0 = props.get((provider, Arm.NO_STEER.value))
         arm1 = props.get((provider, Arm.STEER_BURIED.value))
         arm2 = props.get((provider, Arm.STEER_RENDERED.value))
-        if not (arm0 and arm1 and arm2 and arm0.n and arm1.n and arm2.n):
-            per_provider[provider] = {"clears": False, "reason": "incomplete cells"}
+        if not (_cell_complete(arm0) and _cell_complete(arm1) and _cell_complete(arm2)):
+            per_provider[provider] = {
+                "complete": False,
+                "clears": False,
+                "reason": f"incomplete cells (need >= {MIN_VALID_N} valid trials per arm)",
+            }
             continue
         lift = arm2.p - arm1.p
         clears = lift >= 0.4 and arm2.p >= 0.8 and arm0.p <= 0.1
         per_provider[provider] = {
+            "complete": True,
             "clears": clears,
             "arm0": arm0.p,
             "arm1": arm1.p,
             "arm2": arm2.p,
             "lift": lift,
         }
-        if clears:
-            clearing += 1
+        complete_providers.append(provider)
+
+    clearing = sum(1 for p in complete_providers if per_provider[p]["clears"])
+    if len(complete_providers) < 2:
+        verdict = "INCOMPLETE"
+    elif clearing >= 2:
+        verdict = "PASS"
+    else:
+        verdict = "FAIL"
+
     return {
         "gate_text": GATE_TEXT,
+        "min_valid_n": MIN_VALID_N,
         "per_provider": per_provider,
+        "complete_providers": complete_providers,
         "providers_clearing": clearing,
-        "pass": clearing >= 2,
+        "verdict": verdict,
     }
 
 
@@ -92,9 +124,12 @@ def build_report(results: list[SteerRunResult], *, smoke: bool = False) -> tuple
     lines.append("")
     lines.append(f"Errored trials excluded from proportions: {errors}")
     lines.append("")
+    n_complete = len(verdict["complete_providers"])
     lines.append(
-        f"**Gate result**: {'PASS' if verdict['pass'] else 'FAIL'} "
-        f"({verdict['providers_clearing']} of {len(providers)} providers clear)"
+        f"**Gate result**: {verdict['verdict']} "
+        f"({verdict['providers_clearing']} of {n_complete} complete providers clear; "
+        f"{n_complete} of {len(providers)} providers have >= {verdict['min_valid_n']} "
+        "valid trials on every arm)"
     )
     if smoke:
         lines.append("")

--- a/benchmarks/orchestration/suites/steering/report.py
+++ b/benchmarks/orchestration/suites/steering/report.py
@@ -1,0 +1,133 @@
+"""Provider-by-arm adherence table — the committed evidence artifact (ADR-0088)."""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from dataclasses import asdict
+from pathlib import Path
+
+from harness.stats import Proportion, wilson
+
+from .arms import Arm
+from .runner import SteerRunResult
+
+# Verbatim from ADR-0088 "Success gate (pre-registered, the number that
+# decides B)" and the task's restatement — do not recompute or alter.
+GATE_TEXT = (
+    "PASS if arm2-arm1 >= 0.4 absolute AND arm2 >= 0.8 on >= 2 of 4 providers AND arm0 <= 0.1"
+)
+
+
+def _valid(results: list[SteerRunResult]) -> list[SteerRunResult]:
+    return [r for r in results if r.error is None]
+
+
+def _proportions(results: list[SteerRunResult]) -> dict[tuple[str, str], Proportion]:
+    """(provider, arm) -> Wilson proportion over valid trials."""
+    by_cell: dict[tuple[str, str], list[SteerRunResult]] = defaultdict(list)
+    for r in _valid(results):
+        by_cell[(r.provider, r.arm)].append(r)
+    return {
+        cell: wilson(sum(r.adherent for r in trials), len(trials))
+        for cell, trials in by_cell.items()
+    }
+
+
+def evaluate_gate(props: dict[tuple[str, str], Proportion]) -> dict:
+    """Evaluate the pre-registered gate per provider; returns a verdict dict."""
+    providers = sorted({provider for provider, _arm in props})
+    per_provider = {}
+    clearing = 0
+    for provider in providers:
+        arm0 = props.get((provider, Arm.NO_STEER.value))
+        arm1 = props.get((provider, Arm.STEER_BURIED.value))
+        arm2 = props.get((provider, Arm.STEER_RENDERED.value))
+        if not (arm0 and arm1 and arm2 and arm0.n and arm1.n and arm2.n):
+            per_provider[provider] = {"clears": False, "reason": "incomplete cells"}
+            continue
+        lift = arm2.p - arm1.p
+        clears = lift >= 0.4 and arm2.p >= 0.8 and arm0.p <= 0.1
+        per_provider[provider] = {
+            "clears": clears,
+            "arm0": arm0.p,
+            "arm1": arm1.p,
+            "arm2": arm2.p,
+            "lift": lift,
+        }
+        if clears:
+            clearing += 1
+    return {
+        "gate_text": GATE_TEXT,
+        "per_provider": per_provider,
+        "providers_clearing": clearing,
+        "pass": clearing >= 2,
+    }
+
+
+def build_report(results: list[SteerRunResult], *, smoke: bool = False) -> tuple[str, dict]:
+    """Return (markdown, json-dict) for the provider-by-arm adherence table."""
+    props = _proportions(results)
+    verdict = evaluate_gate(props)
+    providers = sorted({r.provider for r in results})
+    arms = [a.value for a in (Arm.NO_STEER, Arm.STEER_BURIED, Arm.STEER_RENDERED)]
+    errors = sum(1 for r in results if r.error is not None)
+
+    lines = []
+    label = "SMOKE (N far below pre-registered — NOT evidence)" if smoke else "EVIDENCE"
+    lines.append(f"# ADR-0088 steer-adherence table — {label}")
+    lines.append("")
+    lines.append(f"**Pre-registered gate**: {GATE_TEXT}")
+    lines.append("")
+    header = "| provider | " + " | ".join(arms) + " |"
+    sep = "|---|" + "---|" * len(arms)
+    lines.append(header)
+    lines.append(sep)
+    for provider in providers:
+        row = [provider]
+        for arm in arms:
+            p = props.get((provider, arm))
+            row.append(p.fmt() if p else "N/A")
+        lines.append("| " + " | ".join(row) + " |")
+    lines.append("")
+    lines.append(f"Errored trials excluded from proportions: {errors}")
+    lines.append("")
+    lines.append(
+        f"**Gate result**: {'PASS' if verdict['pass'] else 'FAIL'} "
+        f"({verdict['providers_clearing']} of {len(providers)} providers clear)"
+    )
+    if smoke:
+        lines.append("")
+        lines.append(
+            "This table is a SMOKE run (N=2/arm, claude_code only) proving the "
+            "harness runs end-to-end and produces the table — it is NOT the "
+            "pre-registered N>=20/cell evidence run and the gate result above "
+            "is not a real verdict."
+        )
+    markdown = "\n".join(lines) + "\n"
+
+    payload = {
+        "smoke": smoke,
+        "gate_text": GATE_TEXT,
+        "table": {
+            f"{provider}/{arm}": (
+                props[(provider, arm)].fmt() if (provider, arm) in props else None
+            )
+            for provider in providers
+            for arm in arms
+        },
+        "verdict": verdict,
+        "errors": errors,
+        "raw_results": [asdict(r) for r in results],
+    }
+    return markdown, payload
+
+
+def write_report(results: list[SteerRunResult], out_dir: Path, *, smoke: bool = False) -> None:
+    """Write the committed markdown + json artifact pair."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    markdown, payload = build_report(results, smoke=smoke)
+    (out_dir / "adherence_table.md").write_text(markdown, encoding="utf-8")
+    (out_dir / "adherence_table.json").write_text(
+        json.dumps(payload, indent=2, default=str), encoding="utf-8"
+    )

--- a/benchmarks/orchestration/suites/steering/runner.py
+++ b/benchmarks/orchestration/suites/steering/runner.py
@@ -1,0 +1,86 @@
+"""Runner — execute one (provider, arm) cell of the steering fixture once."""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+
+from .arms import Arm, make_steer_entry, suppress_operator_render
+from .fixture import is_steer_adherent
+from .graph import build_two_op_flow
+from .providers import build_imodel
+
+logger = logging.getLogger("orchbench.steering")
+
+
+@dataclass(slots=True)
+class SteerRunResult:
+    """One trial's outcome for one (provider, arm) cell."""
+
+    provider: str
+    arm: str
+    trial: int
+    adherent: bool = False
+    rendered_into_op: str | None = None
+    op2_text: str = ""
+    error: str | None = None
+    wall_seconds: float = 0.0
+
+
+async def run_steering_once(provider_key: str, arm: Arm, trial: int) -> SteerRunResult:
+    """Run one trial. Catches errors into ``SteerRunResult.error`` (never raises)."""
+    t0 = time.monotonic()
+    try:
+        imodel = build_imodel(provider_key)
+        session, graph, op1, op2 = build_two_op_flow(imodel)
+
+        executor_ref: dict = {}
+        injected = False
+
+        def on_progress(op_id, name, status, elapsed):
+            # op1's "completed" callback fires before its completion_event is
+            # set, so this always lands before op2's _prepare_operation runs.
+            nonlocal injected
+            if arm is Arm.NO_STEER or injected:
+                return
+            if status == "completed" and op_id == str(op1.id):
+                executor = executor_ref.get("executor")
+                if executor is not None:
+                    existing = executor.context.content.get("operator_messages", [])
+                    executor.context.content["operator_messages"] = [
+                        *existing,
+                        make_steer_entry(),
+                    ]
+                    injected = True
+
+        if arm is Arm.STEER_BURIED:
+            with suppress_operator_render():
+                result = await session.flow(
+                    graph, on_progress=on_progress, executor_ref=executor_ref, max_concurrent=2
+                )
+        else:
+            result = await session.flow(
+                graph, on_progress=on_progress, executor_ref=executor_ref, max_concurrent=2
+            )
+
+        op_results = result.get("operation_results", {})
+        op2_text = str(op_results.get(op2.id, ""))
+        return SteerRunResult(
+            provider=provider_key,
+            arm=arm.value,
+            trial=trial,
+            adherent=is_steer_adherent(op2_text),
+            rendered_into_op=op2.metadata.get("rendered_into_op"),
+            op2_text=op2_text[:4000],
+            wall_seconds=time.monotonic() - t0,
+        )
+    except Exception as e:  # noqa: BLE001 — a failed run is data, not a crash
+        logger.exception("run_steering_once failed: %s / %s / trial %d", provider_key, arm, trial)
+        return SteerRunResult(
+            provider=provider_key,
+            arm=arm.value,
+            trial=trial,
+            error=f"{type(e).__name__}: {e}",
+            wall_seconds=time.monotonic() - t0,
+        )

--- a/benchmarks/orchestration/suites/steering/test_arms.py
+++ b/benchmarks/orchestration/suites/steering/test_arms.py
@@ -1,0 +1,80 @@
+"""Unit tests for this harness's arm switch against a real DependencyAwareExecutor (ADR-0088)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from suites.steering.arms import make_steer_entry, suppress_operator_render  # noqa: E402
+from suites.steering.fixture import (  # noqa: E402
+    IMPLEMENT_INSTRUCTION,
+    PLAN_INSTRUCTION,
+    STEER_TEXT,
+)
+
+from lionagi.operations.flow import DependencyAwareExecutor  # noqa: E402
+from lionagi.operations.node import create_operation  # noqa: E402
+from lionagi.protocols.graph.edge import Edge  # noqa: E402
+from lionagi.protocols.graph.graph import Graph  # noqa: E402
+from lionagi.session.branch import Branch  # noqa: E402
+from lionagi.session.session import Session  # noqa: E402
+
+
+def _build_executor():
+    op1 = create_operation("operate", parameters={"instruction": PLAN_INSTRUCTION})
+    op2 = create_operation("operate", parameters={"instruction": IMPLEMENT_INSTRUCTION})
+    graph = Graph()
+    graph.add_node(op1)
+    graph.add_node(op2)
+    graph.add_edge(Edge(head=op1.id, tail=op2.id, label=["depends_on"]))
+    executor = DependencyAwareExecutor(session=Session(), graph=graph)
+    # Simulate op1 having already completed, without running a real branch.
+    executor.results[op1.id] = "draft plan: write counter.py using def count_rows(path): ..."
+    executor.operation_branches[op2.id] = Branch()
+    return executor, op1, op2
+
+
+def test_arm0_no_steer_injects_nothing():
+    executor, _op1, op2 = _build_executor()
+    executor._prepare_operation(op2)
+    ctx = op2.parameters.get("context") or {}
+    assert "operator_messages" not in ctx
+    assert op2.parameters["instruction"] == IMPLEMENT_INSTRUCTION
+    assert "rendered_into_op" not in op2.metadata
+
+
+def test_arm1_steer_buried_survives_unrendered():
+    executor, _op1, op2 = _build_executor()
+    executor.context.content["operator_messages"] = [make_steer_entry()]
+    with suppress_operator_render():
+        executor._prepare_operation(op2)
+    ctx = op2.parameters.get("context") or {}
+    assert "operator_messages" in ctx
+    assert ctx["operator_messages"][0]["text"] == STEER_TEXT
+    assert "[OPERATOR STEER]" not in op2.parameters["instruction"]
+    assert op2.parameters["instruction"] == IMPLEMENT_INSTRUCTION
+    assert "rendered_into_op" not in op2.metadata
+
+
+def test_arm2_steer_rendered_lifts_into_instruction():
+    executor, _op1, op2 = _build_executor()
+    executor.context.content["operator_messages"] = [make_steer_entry()]
+    executor._prepare_operation(op2)
+    ctx = op2.parameters.get("context") or {}
+    assert "operator_messages" not in ctx
+    assert "[OPERATOR STEER]" in op2.parameters["instruction"]
+    assert STEER_TEXT in op2.parameters["instruction"]
+    assert op2.metadata["rendered_into_op"] == str(op2.id)
+
+
+def test_suppress_operator_render_restores_original_after_context_exit():
+    import importlib
+
+    flow_module = importlib.import_module("lionagi.operations.flow")
+
+    original = flow_module._render_operator_messages
+    with suppress_operator_render():
+        assert flow_module._render_operator_messages is not original
+    assert flow_module._render_operator_messages is original

--- a/benchmarks/orchestration/suites/steering/test_fixture.py
+++ b/benchmarks/orchestration/suites/steering/test_fixture.py
@@ -57,8 +57,8 @@ def test_fool_python_mentioning_rust_is_rejected():
     assert is_steer_adherent(text) is False
 
 
-def test_fool_rust_mentioning_def_in_comment_is_conservatively_rejected():
-    """Genuine Rust mentioning 'def ' in a comment is an accepted false negative, never a false positive."""
+def test_genuine_rust_mentioning_def_in_comment_is_still_adherent():
+    """A `def` mention inside a Rust comment must not sink an otherwise-genuine Rust answer."""
     text = (
         "Target file: main.rs\n"
         "```rust\n"
@@ -66,6 +66,36 @@ def test_fool_rust_mentioning_def_in_comment_is_conservatively_rejected():
         "fn main() {\n"
         '    println!("done");\n'
         "}\n"
+        "```\n"
+    )
+    assert is_steer_adherent(text) is True
+
+
+def test_genuine_rust_with_def_inside_string_literal_is_still_adherent():
+    """A `def` substring inside a Rust string literal must not sink a genuine Rust answer."""
+    text = (
+        "Target file: main.rs\n"
+        "```rust\n"
+        "fn main() {\n"
+        '    println!("def is not a rust keyword");\n'
+        "}\n"
+        "```\n"
+    )
+    assert is_steer_adherent(text) is True
+
+
+def test_untagged_python_avoiding_def_but_mentioning_rust_vocabulary_is_rejected():
+    """Untagged Python code mentioning .rs/fn main in a comment, with no real `def`, must not fool the check."""
+    text = (
+        "Target file: counter.rs\n"
+        "```\n"
+        "# fn main equivalent below (Rust's entrypoint, for reference)\n"
+        "import csv\n"
+        "\n"
+        'with open("data.csv") as f:\n'
+        "    rows = list(csv.reader(f))\n"
+        "\n"
+        "print(len(rows))\n"
         "```\n"
     )
     assert is_steer_adherent(text) is False

--- a/benchmarks/orchestration/suites/steering/test_fixture.py
+++ b/benchmarks/orchestration/suites/steering/test_fixture.py
@@ -101,6 +101,21 @@ def test_untagged_python_avoiding_def_but_mentioning_rust_vocabulary_is_rejected
     assert is_steer_adherent(text) is False
 
 
+def test_rust_tagged_fence_with_python_shaped_lines_is_rejected():
+    """The fence tag must not be trusted over content: a ```rust fence containing
+    genuinely Python-shaped lines is rejected even alongside a real `fn main(`."""
+    text = (
+        "Target file: counter.rs\n"
+        "```rust\n"
+        "fn main() {\n"
+        "    import csv\n"
+        "    print(len(rows))\n"
+        "}\n"
+        "```\n"
+    )
+    assert is_steer_adherent(text) is False
+
+
 def test_missing_rs_extension_is_rejected():
     text = 'fn main() { println!("hi"); }'
     assert is_steer_adherent(text) is False

--- a/benchmarks/orchestration/suites/steering/test_fixture.py
+++ b/benchmarks/orchestration/suites/steering/test_fixture.py
@@ -116,6 +116,29 @@ def test_rust_tagged_fence_with_python_shaped_lines_is_rejected():
     assert is_steer_adherent(text) is False
 
 
+def test_lone_fn_main_with_from_import_line_is_rejected():
+    """A single `fn main(` token plus a `from X import Y` line is not structural Rust evidence."""
+    text = "Target file: counter.rs\n```rust\nfn main() {\n    from csv import reader\n}\n```\n"
+    assert is_steer_adherent(text) is False
+
+
+def test_lone_fn_main_with_pythonic_expression_style_is_rejected():
+    """A different shape of the same fooling class: `fn main(` with no Rust-only
+    idiom (no let/use/::/macro/arrow/ref/match) beyond a single bare token,
+    wrapped around plain expression-style assignment, is not structural Rust
+    evidence — no single blacklisted Python keyword is even present here."""
+    text = (
+        "Target file: counter.rs\n"
+        "```rust\n"
+        "fn main() {\n"
+        '    rows = list(open("data.csv"))\n'
+        "    total = len(rows)\n"
+        "}\n"
+        "```\n"
+    )
+    assert is_steer_adherent(text) is False
+
+
 def test_missing_rs_extension_is_rejected():
     text = 'fn main() { println!("hi"); }'
     assert is_steer_adherent(text) is False

--- a/benchmarks/orchestration/suites/steering/test_fixture.py
+++ b/benchmarks/orchestration/suites/steering/test_fixture.py
@@ -1,0 +1,85 @@
+"""Unit tests for the steering fixture's unfoolable machine check (ADR-0088)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from suites.steering.fixture import is_steer_adherent  # noqa: E402
+
+_GENUINE_RUST = """\
+Target file: main.rs
+
+```rust
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+
+fn main() {
+    let file = File::open("data.csv").unwrap();
+    let count = BufReader::new(file).lines().count();
+    println!("{}", count);
+}
+```
+"""
+
+_GENUINE_PYTHON = """\
+Target file: counter.py
+
+```python
+def count_rows(path):
+    with open(path) as f:
+        return sum(1 for _ in f)
+```
+"""
+
+
+def test_genuine_rust_is_adherent():
+    assert is_steer_adherent(_GENUINE_RUST) is True
+
+
+def test_genuine_python_is_not_adherent():
+    assert is_steer_adherent(_GENUINE_PYTHON) is False
+
+
+def test_fool_python_mentioning_rust_is_rejected():
+    """Python name-dropping Rust vocabulary must not fool the check — the real 'def ' still trips it."""
+    text = (
+        "Target file: counter.rs (renamed to sound like Rust, save as .rs)\n"
+        "```python\n"
+        "# like Rust's fn main pattern\n"
+        "def count_rows(path):\n"
+        "    with open(path) as f:\n"
+        "        return sum(1 for _ in f)\n"
+        "```\n"
+    )
+    assert is_steer_adherent(text) is False
+
+
+def test_fool_rust_mentioning_def_in_comment_is_conservatively_rejected():
+    """Genuine Rust mentioning 'def ' in a comment is an accepted false negative, never a false positive."""
+    text = (
+        "Target file: main.rs\n"
+        "```rust\n"
+        "// this replaces Python's def keyword entirely\n"
+        "fn main() {\n"
+        '    println!("done");\n'
+        "}\n"
+        "```\n"
+    )
+    assert is_steer_adherent(text) is False
+
+
+def test_missing_rs_extension_is_rejected():
+    text = 'fn main() { println!("hi"); }'
+    assert is_steer_adherent(text) is False
+
+
+def test_missing_rust_token_is_rejected():
+    text = "See main.rs for the full source."
+    assert is_steer_adherent(text) is False
+
+
+def test_empty_text_is_rejected():
+    assert is_steer_adherent("") is False

--- a/benchmarks/orchestration/suites/steering/test_report.py
+++ b/benchmarks/orchestration/suites/steering/test_report.py
@@ -1,0 +1,80 @@
+"""Unit tests for the ADR-0088 gate-evaluation logic (report.py)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from suites.steering.arms import Arm  # noqa: E402
+from suites.steering.report import MIN_VALID_N, _proportions, evaluate_gate  # noqa: E402
+from suites.steering.runner import SteerRunResult  # noqa: E402
+
+
+def _cell(provider: str, arm: Arm, adherent_count: int, n: int) -> list[SteerRunResult]:
+    return [
+        SteerRunResult(provider=provider, arm=arm.value, trial=i, adherent=i < adherent_count)
+        for i in range(n)
+    ]
+
+
+def test_underpowered_two_provider_matrix_is_incomplete_not_pass():
+    """Two-provider, one-trial-per-cell matrix (the proven counterexample) must never PASS."""
+    results = []
+    for provider in ("claude_code", "codex"):
+        results += _cell(provider, Arm.NO_STEER, 0, 1)
+        results += _cell(provider, Arm.STEER_BURIED, 0, 1)
+        results += _cell(provider, Arm.STEER_RENDERED, 1, 1)
+    verdict = evaluate_gate(_proportions(results))
+    assert verdict["verdict"] == "INCOMPLETE"
+    assert verdict["complete_providers"] == []
+
+
+def test_two_complete_providers_clearing_the_gate_is_pass():
+    """Exactly two complete provider families (>= MIN_VALID_N/arm) that clear is a real PASS."""
+    n = MIN_VALID_N
+    results = []
+    for provider in ("claude_code", "codex"):
+        results += _cell(provider, Arm.NO_STEER, 0, n)
+        results += _cell(provider, Arm.STEER_BURIED, 0, n)
+        results += _cell(provider, Arm.STEER_RENDERED, n, n)
+    verdict = evaluate_gate(_proportions(results))
+    assert verdict["verdict"] == "PASS"
+    assert verdict["providers_clearing"] == 2
+    assert set(verdict["complete_providers"]) == {"claude_code", "codex"}
+
+
+def test_two_complete_providers_not_clearing_is_fail():
+    n = MIN_VALID_N
+    results = []
+    for provider in ("claude_code", "codex"):
+        results += _cell(provider, Arm.NO_STEER, 0, n)
+        results += _cell(provider, Arm.STEER_BURIED, n, n)  # arm1 already adherent -> no lift
+        results += _cell(provider, Arm.STEER_RENDERED, n, n)
+    verdict = evaluate_gate(_proportions(results))
+    assert verdict["verdict"] == "FAIL"
+    assert verdict["providers_clearing"] == 0
+
+
+def test_single_complete_provider_is_incomplete():
+    """One complete provider alone cannot judge the >= 2-of-4 clause."""
+    n = MIN_VALID_N
+    results = []
+    results += _cell("claude_code", Arm.NO_STEER, 0, n)
+    results += _cell("claude_code", Arm.STEER_BURIED, 0, n)
+    results += _cell("claude_code", Arm.STEER_RENDERED, n, n)
+    verdict = evaluate_gate(_proportions(results))
+    assert verdict["verdict"] == "INCOMPLETE"
+    assert verdict["complete_providers"] == ["claude_code"]
+
+
+def test_error_trials_do_not_count_toward_n():
+    """Failed/errored trials must not count toward the MIN_VALID_N threshold."""
+    n = MIN_VALID_N
+    valid = _cell("claude_code", Arm.NO_STEER, 0, n - 1)
+    errored = [
+        SteerRunResult(provider="claude_code", arm=Arm.NO_STEER.value, trial=n, error="boom")
+    ]
+    props = _proportions(valid + errored)
+    assert props[("claude_code", Arm.NO_STEER.value)].n == n - 1

--- a/benchmarks/orchestration/test_run_steering.py
+++ b/benchmarks/orchestration/test_run_steering.py
@@ -1,0 +1,27 @@
+"""Unit tests pinning run_steering.py's provider-dispatch defaults (ADR-0088)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import run_steering  # noqa: E402
+
+
+def test_default_providers_is_claude_code_only():
+    """No --providers flag must dispatch claude_code only, never codex/gemini/api."""
+    args = run_steering._build_parser().parse_args([])
+    assert args.providers == ["claude_code"]
+
+
+def test_explicit_providers_flag_overrides_default():
+    args = run_steering._build_parser().parse_args(["--providers", "codex", "gemini"])
+    assert args.providers == ["codex", "gemini"]
+
+
+def test_smoke_flag_still_available_alongside_default_providers():
+    args = run_steering._build_parser().parse_args(["--smoke"])
+    assert args.smoke is True
+    assert args.providers == ["claude_code"]


### PR DESCRIPTION
## Summary

Slice-1 measurement leg for ADR-0088's merged operator-steer render slot
(`operations/flow.py`, #1677). Rides `benchmarks/orchestration/` with a new
steering suite:

- **Fixture** (`suites/steering/fixture.py`): a 2-op flow — op1 drafts a
  short Python plan, op2 implements it. A steer ("change the implementation
  language to Rust") should redirect op2. The machine check requires ALL
  THREE: a Rust-only token (`fn main`), a `.rs` reference, and the absence
  of `def ` — unfoolable per the ADR, not any one alone.
- **Arms** (`suites/steering/arms.py`): Arm 0 (no steer, fixture-validity
  control), Arm 1 (steer buried in raw context — render suppressed via a
  harness-level monkeypatch of `_render_operator_messages`, no production
  flag needed), Arm 2 (steer rendered — the merged default behavior,
  untouched). Arm 3 (Mode B, op-mode injection) is **not built** — a named
  stub only, per the slice-1 fence ("MAY NOT build B in slice 1").
- **Runner** (`suites/steering/graph.py`, `providers.py`, `runner.py`): the
  2-op graph, a pluggable 4-provider dispatcher (claude_code, codex, gemini,
  one true API model), and the per-trial driver. The synthetic steer is
  injected via `on_progress` on op1's "completed" callback, which fires
  synchronously before op1's `completion_event` is set — deterministically
  before op2's dependency wait can unblock and `_prepare_operation` runs.
- **Report** (`suites/steering/report.py`, `run_steering.py`,
  `score_steering.py`): a provider-by-arm adherence table (markdown + json,
  reusing `harness/stats.py`'s Wilson intervals), stating the pre-registered
  gate verbatim: `arm2-arm1 >= 0.4 absolute AND arm2 >= 0.8 on >= 2 of 4
  providers AND arm0 <= 0.1`. Uses the `rendered_into_op` breadcrumb to join
  steer -> consuming op -> artifact.
- 11 unit tests: the machine check's unfoolability (adversarial cases —
  Python code name-dropping Rust vocabulary, Rust code mentioning `def ` in
  a comment) and the arm switch driven against a real
  `DependencyAwareExecutor` (no LLM calls, no network/subprocess spend).

**Smoke run** (the one live-spend run authorized for this PR — N=2/arm,
`claude_code/sonnet` only, committed at
`suites/steering/adherence_table.{md,json}`, explicitly labeled SMOKE, not
evidence): arm0=0.00, arm1=1.00, arm2=1.00. Sonnet noticed the buried
`operator_messages` key and switched to Rust even without salient
rendering, so this provider's real lift is unmeasured at N=2 — the full
N>=20 x 4-provider run is what actually decides the gate.

`operations/flow.py` is untouched. `tests/operations/test_flow_pause.py`,
`test_flow_operator_steer.py`, and `test_flow.py` (35 tests) still pass.

## Test plan

- [x] `PYTHONPATH=$PWD .venv/bin/python -m pytest benchmarks/orchestration/suites/steering/test_fixture.py benchmarks/orchestration/suites/steering/test_arms.py -p no:cacheprovider` — 11 passed
- [x] `pytest tests/operations/test_flow_pause.py tests/operations/test_flow_operator_steer.py tests/operations/test_flow.py` — 35 passed (pause/resume + operator-steer render unchanged)
- [x] `ruff format` + `ruff check` clean on all new files
- [x] Smoke run: `run_steering.py --smoke` then `score_steering.py --smoke` — table generated, committed
- [ ] Full N>=20 x 4-provider evidence run (not part of this PR — out of authorized live-spend scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)