### PR TITLE
fix(flow): render operator steers at invoke time so mid-run steers land in the next op

### DIFF
--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -325,6 +325,7 @@ class DependencyAwareExecutor:
                     logger.debug("Executing operation: %s", ref_id)
 
                 operation._branch = branch
+                self._render_pending_operator_steers(operation)
                 await operation.invoke()
 
                 elapsed = _time.monotonic() - self._op_start_times.get(
@@ -478,6 +479,28 @@ class DependencyAwareExecutor:
 
         branch = self._resolve_branch_for_operation(operation)
         self.operation_branches[operation.id] = branch
+
+    def _render_pending_operator_steers(self, operation: Operation) -> None:
+        """Last-chance render, called immediately before the provider call.
+
+        A steer can land in ``self.context.content["operator_messages"]``
+        after this operation's own ``_prepare_operation`` already ran (e.g.
+        a control-plane poller appending mid-run). Re-reading the canonical
+        queue here, right before ``invoke()``, catches that window instead
+        of silently dropping the steer for the rest of the flow.
+        """
+        messages = self.context.content.get("operator_messages")
+        if not messages:
+            return
+        if not any(isinstance(m, dict) and not m.get("rendered_into_op") for m in messages):
+            return
+
+        context = operation.parameters.get("context")
+        if not isinstance(context, dict):
+            context = {}
+            operation.parameters["context"] = context
+        context["operator_messages"] = messages
+        _render_operator_messages(operation, context)
 
     def _resolve_branch_for_operation(self, operation: Operation) -> "Branch":
         """Resolve which branch an operation should use - all branches are pre-allocated."""

--- a/tests/operations/test_flow_operator_steer.py
+++ b/tests/operations/test_flow_operator_steer.py
@@ -226,5 +226,124 @@ async def test_operator_steer_consume_once_across_real_flow_ops():
     assert "[OPERATOR STEER]" not in (calls[1].last_user_message or "")
 
 
+# ---------------------------------------------------------------------------
+# Regression (issue 1681): a steer landing after prepare, before invoke
+# ---------------------------------------------------------------------------
+
+
+def test_steer_appended_after_prepare_is_caught_by_invoke_time_recheck():
+    """Reproduces the race: op2's prepare runs while the queue is still
+    empty (nothing to render), then a steer lands in the shared context
+    (simulating a control-plane poller landing mid-run). Without an
+    invoke-time recheck this steer would be silently dropped for the rest
+    of the flow; the recheck must catch it right before the provider call."""
+    session = Session()
+    graph = Graph()
+    op1 = Operation(operation="operate", parameters={"instruction": "op1 task"})
+    op2 = Operation(operation="operate", parameters={"instruction": "op2 task"})
+    graph.add_node(op1)
+    graph.add_node(op2)
+    graph.add_edge(Edge(head=op1.id, tail=op2.id))
+
+    executor = DependencyAwareExecutor(session=session, graph=graph)
+
+    executor._prepare_operation(op1)
+    assert "rendered_into_op" not in op1.metadata
+
+    # op2 is prepared while the queue is still empty — the current design's
+    # single prepare-time render sees nothing.
+    executor._prepare_operation(op2)
+    assert op2.parameters["instruction"] == "op2 task"
+    assert "rendered_into_op" not in op2.metadata
+
+    # A steer lands after op2's prepare already ran, mirroring the control
+    # poller appending mid-run (ADR-0085 part 1) after op2's slot passed.
+    executor.context.content["operator_messages"] = [{"ts": 1.0, "text": "late steer"}]
+
+    # The invoke-time recheck (called by _execute_operation immediately
+    # before `await operation.invoke()`) must still catch it.
+    executor._render_pending_operator_steers(op2)
+
+    assert "[OPERATOR STEER]" in op2.parameters["instruction"]
+    assert "late steer" in op2.parameters["instruction"]
+    assert op2.metadata["rendered_into_op"] == str(op2.id)
+
+    # Consume-once: a third op prepared afterwards must not re-render it.
+    op3 = Operation(operation="operate", parameters={"instruction": "op3 task"})
+    graph.add_node(op3)
+    graph.add_edge(Edge(head=op2.id, tail=op3.id))
+    executor._prepare_operation(op3)
+    executor._render_pending_operator_steers(op3)
+    assert op3.parameters["instruction"] == "op3 task"
+    assert "rendered_into_op" not in op3.metadata
+
+
+def test_no_pending_steer_leaves_recheck_a_noop():
+    session = Session()
+    graph = Graph()
+    op = Operation(operation="operate", parameters={"instruction": "do the task"})
+    graph.add_node(op)
+
+    executor = DependencyAwareExecutor(session=session, graph=graph)
+    executor._prepare_operation(op)
+    executor._render_pending_operator_steers(op)
+
+    assert op.parameters["instruction"] == "do the task"
+    assert "rendered_into_op" not in op.metadata
+
+
+@pytest.mark.asyncio
+async def test_operator_steer_injected_at_own_started_callback_still_renders():
+    """Acceptance: inject the steer from op2's own ``on_progress("started")``
+    callback — which fires right after op2's prepare and right before its
+    invoke — deterministically simulating the window a control-plane poller
+    can land in. The rendered block must still reach the provider payload."""
+    branch = TestBranch.from_text(["op1 done", "op2 done"], name="worker")
+    session = Session()
+    session.include_branches(branch)
+    session.default_branch = branch
+
+    graph = Graph()
+    op1 = create_operation("operate", parameters={"instruction": "op1 task"})
+    op2 = create_operation("operate", parameters={"instruction": "op2 task"})
+    op1.branch_id = branch.id
+    op2.branch_id = branch.id
+    graph.add_node(op1)
+    graph.add_node(op2)
+    graph.add_edge(Edge(head=op1.id, tail=op2.id))
+
+    executor_ref: dict = {}
+    injected = False
+
+    def on_progress(op_id, name, status, elapsed):
+        nonlocal injected
+        if injected or status != "started" or op_id != str(op2.id):
+            return
+        executor = executor_ref.get("executor")
+        if executor is not None:
+            existing = executor.context.content.get("operator_messages", [])
+            executor.context.content["operator_messages"] = [
+                *existing,
+                {"ts": 1.0, "text": "steer during op2 start"},
+            ]
+            injected = True
+
+    await session.flow(
+        graph,
+        on_progress=on_progress,
+        executor_ref=executor_ref,
+        parallel=False,
+    )
+
+    assert injected
+    assert op2.metadata.get("rendered_into_op") == str(op2.id)
+
+    calls = TestBranch.calls(branch)
+    assert len(calls) == 2
+    payload_text = json.dumps(calls[1].payload)
+    assert "[OPERATOR STEER]" in payload_text
+    assert "steer during op2 start" in payload_text
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Fixes #1681: the consume-once operator-steer render (`operator_messages` -> `[OPERATOR STEER]` block) only ran once, inside `_prepare_operation`, well before the provider call. Under real concurrent/subprocess load a steer appended to `executor.context.content` (e.g. by the `li o ctl msg` control-plane poller, which only checks "at least one op is still PENDING" before writing) between an operation's own prepare and its own invoke was silently dropped for the rest of the flow — nothing ever re-checked the queue afterward.
- Adds `DependencyAwareExecutor._render_pending_operator_steers(operation)`, called immediately before `await operation.invoke()` in `_execute_operation` — the last synchronous point before the provider call. It re-reads `self.context.content["operator_messages"]` fresh (not the possibly-stale copy already merged into `operation.parameters["context"]`) and renders/stamps any still-unconsumed entries.
- The existing prepare-time render in `_prepare_operation` is left in place: it's idempotent with the new recheck (`_render_operator_messages` mutates entries in place, so a second pass sees nothing pending), and the 8 existing unit tests call `_prepare_operation` directly and depend on it. Both call sites reference the bare module-level `_render_operator_messages` name, so `benchmarks/orchestration/suites/steering/arms.py`'s `suppress_operator_render()` monkeypatch (arm 1) still suppresses both.

## Root cause detail

I could not reproduce a logical race in the simple on_progress-synchronous-append path described in the runner's own comment (op1's `completed` callback fires strictly before its `completion_event.set()`, so op2's dependency wait is correctly gated) — 600+ synthetic trials with varied delays and concurrency via `TestBranch` produced 0 misses. The real gap is on the production control-poller path (`lionagi/cli/orchestrate/flow.py:_apply_session_control`, ~2s cycle): it gates on any node having `execution.status == PENDING`, not on whether the *specific* downstream op has already been prepared. `Operation.execution.status` only flips `PENDING -> PROCESSING` inside `Event.invoke()` (`protocols/generic/event.py:281`), synchronously adjacent to `_prepare_operation` with no intervening await in the common case — so a message landing in that narrow window was dropped. The invoke-time recheck closes this regardless of the exact scheduling mechanism that opens the window.

## Test plan

- [x] New regression tests in `tests/operations/test_flow_operator_steer.py`:
  - `test_steer_appended_after_prepare_is_caught_by_invoke_time_recheck` — deterministic unit-level repro of the exact gap (prepare runs with empty queue, steer lands after, recheck must still catch it) + consume-once against a third op.
  - `test_no_pending_steer_leaves_recheck_a_noop` — zero behavior change when nothing is queued.
  - `test_operator_steer_injected_at_own_started_callback_still_renders` — async acceptance test via `session.flow()` + `TestBranch`, injecting the steer from the target op's own `on_progress("started")` callback (fires right after prepare, right before invoke) and asserting the rendered block reaches the actual provider-bound payload.
- [x] `tests/operations/` + `benchmarks/orchestration/suites/steering/`: 577 passed.
- [x] Full suite: `PYTHONPATH=$PWD .venv/bin/python -m pytest tests/ benchmarks/ -q -p no:cacheprovider` -> **10418 passed, 9 skipped** (skips are environment-only: Postgres container unavailable, `ast-grep` binary not on PATH, `.lionagi/config.toml` not present in this checkout), 0 failed.
- [x] `ruff check` + `ruff format --check` clean on both changed files.

Not merging / not arming auto-merge per current review-gate process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)