### PR TITLE
fix(cli): resolve li agent status by the printed resume branch_id

### DIFF
--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -202,8 +202,13 @@ async def _run_agent(
     project: str | None = None,
     bypass: bool = False,
     preset: str | None = None,
-) -> tuple[str, str, str, str]:
-    """Execute one agent turn; returns (result, provider, branch_id, terminal_status)."""
+) -> tuple[str, str, str, str, str | None]:
+    """Execute one agent turn; returns (result, provider, branch_id, terminal_status, session_id).
+
+    session_id is None whenever live persistence never started (e.g. the
+    mangled resume-model-override guard fires before setup_agent_persist is
+    called, or setup itself failed and disabled persistence for this run).
+    """
     effort = normalize_effort(effort)
     if resume and continue_last:
         raise ConfigurationError("--resume / -r and --continue-last / -c are mutually exclusive.")
@@ -264,7 +269,7 @@ async def _run_agent(
                 "[MODEL] PROMPT — this looks like a mangled command, e.g. "
                 "a --resume id accidentally split across two arguments."
             )
-            return "", "", str(branch.id), "failed"
+            return "", "", str(branch.id), "failed", None
         if "/" in ms.model:
             provider, model = ms.model.split("/", 1)
         else:
@@ -480,7 +485,8 @@ async def _run_agent(
 
     save_last_branch_pointer(run.run_id, branch_id)
 
-    return res or "", provider, branch_id, _terminal_status
+    session_id = live.get("session_id") if live else None
+    return res or "", provider, branch_id, _terminal_status, session_id
 
 
 def add_agent_subparser(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
@@ -656,7 +662,7 @@ def run_agent(args: argparse.Namespace) -> int:
         return 1
 
     try:
-        result, provider, branch_id, terminal_status = run_async(
+        result, provider, branch_id, terminal_status, session_id = run_async(
             _run_agent(
                 model,
                 prompt,
@@ -687,4 +693,6 @@ def run_agent(args: argparse.Namespace) -> int:
         print(f"\n{result}" if result is not None else "", flush=True)
 
     hint(f'\n[to resume] li agent -r {branch_id} "..."')
+    if session_id:
+        hint(f"[status]    li agent status {session_id}")
     return EXIT_CODE_BY_STATUS.get(terminal_status, 1)

--- a/lionagi/cli/status.py
+++ b/lionagi/cli/status.py
@@ -111,11 +111,27 @@ async def _latest_session(
     return db._row_to_dict(row) if row is not None else None
 
 
+async def _resolve_session_by_branch_id(db: Any, entity_id: str) -> dict[str, Any] | None:
+    """Fallback: treat *entity_id* as a branch_id (the resume token printed in
+    `li agent -r <branch_id> "..."` hints and echoed as `branch_id` in the status
+    view) and resolve it to its owning session.
+
+    There is no `branch_id` column on `sessions` — `branches` is a separate
+    table, and `branches.session_id` is a NOT NULL FK, so a matched branch row
+    always names exactly one owning session.
+    """
+    branch = await _fetch_by_id(db, "branches", entity_id)
+    if branch is None:
+        return None
+    return await db.get_session(branch["session_id"])
+
+
 async def _resolve_agent_target(
     db: Any, entity_id: str | None, project: str | None
 ) -> tuple[str, dict[str, Any]] | None:
-    """`li agent status` resolution: session (any kind) or ADR-0020 invocation by id;
-    default-latest is scoped to agent-kind sessions for *project*.
+    """`li agent status` resolution: session (any kind), ADR-0020 invocation, or
+    a branch_id (resolved to its owning session), by id; default-latest is
+    scoped to agent-kind sessions for *project*.
 
     Kind scoping only gates the no-id default: an explicit id is honoured
     regardless of invocation_kind, since the id is already unambiguous.
@@ -127,6 +143,9 @@ async def _resolve_agent_target(
         row = await _fetch_by_id(db, "invocations", entity_id)
         if row is not None:
             return "invocation", row
+        row = await _resolve_session_by_branch_id(db, entity_id)
+        if row is not None:
+            return "session", row
         return None
     row = await _latest_session(db, invocation_kinds=("agent",), project=project)
     return ("session", row) if row is not None else None
@@ -154,7 +173,11 @@ async def _resolve_play_target(
 
 
 async def _resolve_any_target(db: Any, entity_id: str) -> tuple[str, dict[str, Any]] | None:
-    """`li o ctl status <id>` resolution: no kind scoping, id required (no latest)."""
+    """`li o ctl status <id>` resolution: no kind scoping, id required (no latest).
+
+    Falls back to branch_id (resolved to its owning session) last, after
+    sessions/invocations/plays all miss — see _resolve_session_by_branch_id.
+    """
     row = await _fetch_by_id(db, "sessions", entity_id)
     if row is not None:
         return "session", row
@@ -164,6 +187,9 @@ async def _resolve_any_target(db: Any, entity_id: str) -> tuple[str, dict[str, A
     row = await _fetch_by_id(db, "plays", entity_id)
     if row is not None:
         return "play", row
+    row = await _resolve_session_by_branch_id(db, entity_id)
+    if row is not None:
+        return "session", row
     return None
 
 

--- a/tests/cli/test_agent_arg_ux.py
+++ b/tests/cli/test_agent_arg_ux.py
@@ -23,9 +23,9 @@ async def _fake_run_agent(
     model_str: str | None,
     prompt: str,
     **kwargs: Any,
-) -> tuple[str, str, str, str]:
+) -> tuple[str, str, str, str, str | None]:
     _CAPTURED["agent"] = {"model_str": model_str, "prompt": prompt, **kwargs}
-    return "output", "provider", "branch-id", "completed"
+    return "output", "provider", "branch-id", "completed", "sess-001"
 
 
 def _run(argv: list[str]) -> int:

--- a/tests/cli/test_agent_codex_robustness.py
+++ b/tests/cli/test_agent_codex_robustness.py
@@ -299,7 +299,7 @@ async def test_run_agent_timeout_preserves_partial_output(monkeypatch, tmp_path)
 
     from lionagi.cli.agent import _run_agent
 
-    result, _provider, _branch_id, terminal_status = await _run_agent(
+    result, _provider, _branch_id, terminal_status, _sid = await _run_agent(
         "codex/gpt-5.3-codex-spark",
         "review all files",
         timeout=30,
@@ -367,7 +367,7 @@ async def test_run_agent_timeout_empty_partial_returns_empty_string(monkeypatch,
 
     from lionagi.cli.agent import _run_agent
 
-    result, _provider, _branch_id, terminal_status = await _run_agent(
+    result, _provider, _branch_id, terminal_status, _sid = await _run_agent(
         "codex/gpt-5.3-codex-spark",
         "review all files",
         timeout=30,

--- a/tests/cli/test_agent_preset_form.py
+++ b/tests/cli/test_agent_preset_form.py
@@ -239,7 +239,7 @@ class TestFormValidationGate:
 
         async def fake_run(*a, **kw):
             llm_called.append(1)
-            return ("done", "claude", "br-001", "completed")
+            return ("done", "claude", "br-001", "completed", "sess-001")
 
         monkeypatch.setattr(agent_mod, "_run_agent", fake_run)
 
@@ -263,7 +263,7 @@ class TestFormValidationGate:
 
         async def fake_run(*a, **kw):
             llm_called.append(1)
-            return ("done", "claude", "br-001", "completed")
+            return ("done", "claude", "br-001", "completed", "sess-001")
 
         monkeypatch.setattr(agent_mod, "_run_agent", fake_run)
 
@@ -289,7 +289,7 @@ class TestFormValidationGate:
 
         async def fake_run(*a, **kw):
             llm_called.append(1)
-            return ("done", "claude", "br-001", "completed")
+            return ("done", "claude", "br-001", "completed", "sess-001")
 
         monkeypatch.setattr(agent_mod, "_run_agent", fake_run)
 
@@ -322,7 +322,7 @@ class TestFormValidationGate:
 
         async def fake_run_agent(model_str, prompt, **kw):
             captured_prompts.append(prompt)
-            return ("done", "claude", "br-001", "completed")
+            return ("done", "claude", "br-001", "completed", "sess-001")
 
         monkeypatch.setattr(agent_mod, "_run_agent", fake_run_agent)
 
@@ -347,7 +347,7 @@ class TestFormValidationGate:
 
         async def fake_run_agent(model_str, prompt, **kw):
             captured_prompts.append(prompt)
-            return ("done", "claude", "br-001", "completed")
+            return ("done", "claude", "br-001", "completed", "sess-001")
 
         monkeypatch.setattr(agent_mod, "_run_agent", fake_run_agent)
 
@@ -376,7 +376,7 @@ class TestPresetCodingBehaviour:
 
         async def spy_run_agent(model_str, prompt, **kw):
             captured_kwargs.append(kw)
-            return ("done", "claude", "br-001", "completed")
+            return ("done", "claude", "br-001", "completed", "sess-001")
 
         monkeypatch.setattr(agent_mod, "_run_agent", spy_run_agent)
 
@@ -397,7 +397,7 @@ class TestPresetCodingBehaviour:
 
         async def spy_run_agent(model_str, prompt, **kw):
             captured_kwargs.append(kw)
-            return ("done", "claude", "br-001", "completed")
+            return ("done", "claude", "br-001", "completed", "sess-001")
 
         monkeypatch.setattr(agent_mod, "_run_agent", spy_run_agent)
 
@@ -417,7 +417,7 @@ class TestPresetCodingBehaviour:
 
         async def spy_run_agent(model_str, prompt, **kw):
             captured_kwargs.append(kw)
-            return ("done", "claude", "br-001", "completed")
+            return ("done", "claude", "br-001", "completed", "sess-001")
 
         monkeypatch.setattr(agent_mod, "_run_agent", spy_run_agent)
 
@@ -497,7 +497,7 @@ async def test_run_agent_preset_coding_creates_preset_config(monkeypatch, tmp_pa
 
     from lionagi.cli.agent import _run_agent
 
-    result, provider, branch_id, status = await _run_agent(
+    result, provider, branch_id, status, session_id = await _run_agent(
         "claude/sonnet", "build a feature", preset="coding"
     )
 
@@ -821,7 +821,7 @@ class TestFormSpecClosedSchema:
 
         async def fake_run(*a, **kw):
             llm_called.append(1)
-            return ("done", "claude", "br-001", "completed")
+            return ("done", "claude", "br-001", "completed", "sess-001")
 
         monkeypatch.setattr(agent_mod, "_run_agent", fake_run)
 
@@ -849,7 +849,7 @@ class TestFormSpecClosedSchema:
 
         async def fake_run(*a, **kw):
             llm_called.append(1)
-            return ("done", "claude", "br-001", "completed")
+            return ("done", "claude", "br-001", "completed", "sess-001")
 
         monkeypatch.setattr(agent_mod, "_run_agent", fake_run)
 
@@ -883,7 +883,7 @@ class TestFormDirectoryPath:
 
         async def fake_run(*a, **kw):
             llm_called.append(1)
-            return ("done", "claude", "br-001", "completed")
+            return ("done", "claude", "br-001", "completed", "sess-001")
 
         monkeypatch.setattr(agent_mod, "_run_agent", fake_run)
 
@@ -946,7 +946,7 @@ class TestFormNonMappingTypes:
 
         async def fake_run(*a, **kw):
             llm_called.append(1)
-            return ("done", "claude", "br-001", "completed")
+            return ("done", "claude", "br-001", "completed", "sess-001")
 
         monkeypatch.setattr(agent_mod, "_run_agent", fake_run)
         errors: list[str] = []

--- a/tests/cli/test_agent_resume_empty_stream.py
+++ b/tests/cli/test_agent_resume_empty_stream.py
@@ -95,7 +95,7 @@ async def test_resume_empty_stream_returns_failed_status(monkeypatch, tmp_path):
 
     from lionagi.cli.agent import _run_agent
 
-    _result, _provider, _bid, terminal_status = await _run_agent(
+    _result, _provider, _bid, terminal_status, _sid = await _run_agent(
         "codex/model",
         "follow up",
         resume=branch_id,
@@ -214,7 +214,7 @@ async def test_resume_nonempty_stream_returns_completed_status(monkeypatch, tmp_
 
     from lionagi.cli.agent import _run_agent
 
-    result, _provider, _bid, terminal_status = await _run_agent(
+    result, _provider, _bid, terminal_status, _sid = await _run_agent(
         "codex/model",
         "follow up",
         resume=branch_id,
@@ -235,7 +235,7 @@ async def test_fresh_run_empty_result_still_exits_zero(monkeypatch, tmp_path):
 
     from lionagi.cli.agent import _run_agent
 
-    _result, _provider, _bid, terminal_status = await _run_agent(
+    _result, _provider, _bid, terminal_status, _sid = await _run_agent(
         "codex/model",
         "say hi",
         resume=None,

--- a/tests/cli/test_agent_resume_gemini_effort.py
+++ b/tests/cli/test_agent_resume_gemini_effort.py
@@ -83,7 +83,7 @@ async def test_resume_explicit_effort_reapplies_onto_persisted_agy_model(
 
     from lionagi.cli.agent import _run_agent
 
-    _result, _provider, _bid, terminal_status = await _run_agent(
+    _result, _provider, _bid, terminal_status, _sid = await _run_agent(
         None,
         "continue",
         resume=branch_id,
@@ -112,7 +112,7 @@ async def test_resume_without_effort_keeps_persisted_agy_model(monkeypatch, tmp_
 
     from lionagi.cli.agent import _run_agent
 
-    _result, _provider, _bid, terminal_status = await _run_agent(
+    _result, _provider, _bid, terminal_status, _sid = await _run_agent(
         None,
         "continue",
         resume=branch_id,
@@ -140,7 +140,7 @@ async def test_resume_new_model_pin_still_wins_over_effort(monkeypatch, tmp_path
 
     from lionagi.cli.agent import _run_agent
 
-    _result, _provider, _bid, terminal_status = await _run_agent(
+    _result, _provider, _bid, terminal_status, _sid = await _run_agent(
         "gemini-code/Gemini 3.1 Pro (Low)",
         "continue",
         resume=branch_id,
@@ -202,7 +202,7 @@ async def test_fresh_run_unaffected_by_reapply_effort(monkeypatch, tmp_path):
 
     from lionagi.cli.agent import _run_agent
 
-    _result, provider, _bid, terminal_status = await _run_agent(
+    _result, provider, _bid, terminal_status, _sid = await _run_agent(
         "gemini-code/gemini-3.5-flash",
         "hello",
         effort="high",
@@ -229,7 +229,7 @@ async def test_resume_mixed_case_effort_reapplies_correct_agy_tier(monkeypatch, 
 
     from lionagi.cli.agent import _run_agent
 
-    _result, _provider, _bid, terminal_status = await _run_agent(
+    _result, _provider, _bid, terminal_status, _sid = await _run_agent(
         None,
         "continue",
         resume=branch_id,
@@ -273,7 +273,7 @@ async def test_resume_mixed_case_profile_effort_reapplies_correct_agy_tier(monke
 
     from lionagi.cli.agent import _run_agent
 
-    _result, _provider, _bid, terminal_status = await _run_agent(
+    _result, _provider, _bid, terminal_status, _sid = await _run_agent(
         None,
         "continue",
         resume=branch_id,

--- a/tests/cli/test_agent_resume_model_override.py
+++ b/tests/cli/test_agent_resume_model_override.py
@@ -113,7 +113,7 @@ async def test_garbage_model_token_on_resume_is_rejected(monkeypatch, tmp_path, 
     from lionagi.cli.agent import _run_agent
 
     with caplog.at_level(logging.ERROR, logger="lionagi.cli.error"):
-        result, _provider, _bid, terminal_status = await _run_agent(
+        result, _provider, _bid, terminal_status, _sid = await _run_agent(
             "c95-32617270327a",
             "actual prompt",
             resume=branch_id,
@@ -193,7 +193,7 @@ async def test_legitimate_model_override_on_resume_proceeds_and_warns(
     from lionagi.cli.agent import _run_agent
 
     with caplog.at_level(logging.WARNING, logger="lionagi.cli.warn"):
-        result, provider, _bid, terminal_status = await _run_agent(
+        result, provider, _bid, terminal_status, _sid = await _run_agent(
             "claude_code/opus",
             "follow up",
             resume=branch_id,
@@ -224,7 +224,7 @@ async def test_matching_model_override_on_resume_does_not_warn(monkeypatch, tmp_
     with caplog.at_level(logging.WARNING, logger="lionagi.cli.warn"):
         # The fixture branch's default chat_model is openai/gpt-4.1-mini
         # (see _make_branch_json → Branch()) — re-supply the same model.
-        _result, _provider, _bid, terminal_status = await _run_agent(
+        _result, _provider, _bid, terminal_status, _sid = await _run_agent(
             "openai/gpt-4.1-mini",
             "follow up",
             resume=branch_id,
@@ -261,7 +261,7 @@ async def test_prefix_matched_resume_id_emits_hint(monkeypatch, tmp_path, caplog
     from lionagi.cli.agent import _run_agent
 
     with caplog.at_level(logging.INFO, logger="lionagi.cli.hint"):
-        _result, _provider, _bid, terminal_status = await _run_agent(
+        _result, _provider, _bid, terminal_status, _sid = await _run_agent(
             "codex/gpt-5.3-codex-spark",
             "follow up",
             resume=given_token,
@@ -289,7 +289,7 @@ async def test_exact_resume_id_does_not_emit_prefix_hint(monkeypatch, tmp_path, 
     from lionagi.cli.agent import _run_agent
 
     with caplog.at_level(logging.INFO, logger="lionagi.cli.hint"):
-        _result, _provider, _bid, terminal_status = await _run_agent(
+        _result, _provider, _bid, terminal_status, _sid = await _run_agent(
             "codex/gpt-5.3-codex-spark",
             "follow up",
             resume=branch_id,

--- a/tests/cli/test_agent_status_hint.py
+++ b/tests/cli/test_agent_status_hint.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the post-run hint surfacing session_id alongside the resume line.
+
+`li agent`'s post-run hint prints the branch_id as a `-r <branch_id>` resume
+command, but that id alone isn't a `li agent status` lookup key an operator
+already has memorized — they'd have to know the session_id separately. These
+tests pin: the hint also prints `li agent status <session_id>` whenever live
+persistence produced a session, and omits that line cleanly when persistence
+never started (setup failure, or the mangled resume-model-override guard
+firing before persistence is even set up).
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+def _reset_channel(name: str) -> logging.Logger:
+    """Clear handlers + force propagate=True so caplog captures this channel.
+
+    Other tests in the suite call configure_cli_logging(), which sets
+    propagate=False and attaches a stderr handler on these channels.
+    """
+    logger = logging.getLogger(name)
+    logger.handlers.clear()
+    logger.propagate = True
+    return logger
+
+
+def _wire_agent_stubs(monkeypatch, tmp_path, *, session_id: str | None):
+    """Monkeypatch all external I/O in _run_agent so tests run without real
+    I/O. setup_agent_persist returns a ctx carrying *session_id*, or None
+    (simulating persistence never starting) when *session_id* is None.
+    """
+    import lionagi.cli.agent as agent_mod
+    from lionagi import Branch
+    from lionagi.service.manager import iModelManager
+
+    async def fake_operate(self, instruction=None, **kw):
+        return "done"
+
+    monkeypatch.setattr(Branch, "operate", fake_operate)
+    monkeypatch.setattr(iModelManager, "shutdown", AsyncMock())
+
+    monkeypatch.setattr(agent_mod, "resolve_persisted_effort", lambda *a, **kw: None)
+
+    async def fake_setup(*a, **kw):
+        return {"session_id": session_id} if session_id else None
+
+    async def fake_teardown(ctx, *, status="completed", exception=None):
+        return status
+
+    monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)
+    monkeypatch.setattr(agent_mod, "teardown_agent_persist", fake_teardown)
+    monkeypatch.setattr(agent_mod, "save_last_branch_pointer", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "_provenance",
+        SimpleNamespace(
+            resolve_model_spec=lambda p, m: f"{p}/{m}",
+            agent_definition_hash=lambda n: "abc",
+        ),
+    )
+    monkeypatch.setattr(agent_mod, "resolve_artifact_contract", lambda **_: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "allocate_run",
+        lambda: SimpleNamespace(
+            run_id="r",
+            artifact_root=tmp_path / "artifacts",
+            stream_dir=tmp_path / "stream",
+            branches_dir=tmp_path / "branches",
+        ),
+    )
+
+
+def _agent_args(**overrides) -> SimpleNamespace:
+    defaults = dict(
+        query=["claude", "hello"],
+        prompt_flag=None,
+        prompt_file=None,
+        yolo=False,
+        verbose=False,
+        theme=None,
+        resume=None,
+        continue_last=False,
+        effort=None,
+        agent=None,
+        cwd=None,
+        timeout=None,
+        fast=False,
+        invocation=None,
+        project=None,
+        bypass=False,
+        preset=None,
+        form=None,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# _run_agent: session_id is the 5th return value
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_agent_returns_session_id_when_persisted(monkeypatch, tmp_path):
+    """_run_agent's 5th return value is the live-persist session_id."""
+    _wire_agent_stubs(monkeypatch, tmp_path, session_id="sess-abc123")
+
+    from lionagi.cli.agent import _run_agent
+
+    _result, _provider, _branch_id, _status, session_id = await _run_agent("claude", "hello")
+
+    assert session_id == "sess-abc123"
+
+
+@pytest.mark.asyncio
+async def test_run_agent_session_id_none_when_persist_disabled(monkeypatch, tmp_path):
+    """setup_agent_persist failure (returns None) -> session_id is None, not a crash."""
+    _wire_agent_stubs(monkeypatch, tmp_path, session_id=None)
+
+    from lionagi.cli.agent import _run_agent
+
+    _result, _provider, _branch_id, _status, session_id = await _run_agent("claude", "hello")
+
+    assert session_id is None
+
+
+# ---------------------------------------------------------------------------
+# run_agent(): post-run hint includes the status line
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_run_hint_includes_status_line_with_session_id(monkeypatch, tmp_path, caplog):
+    """The post-run hint must surface `li agent status <session_id>` alongside
+    the existing resume line, so an operator has both ids up front."""
+    _wire_agent_stubs(monkeypatch, tmp_path, session_id="sess-xyz789")
+
+    import lionagi.cli.agent as agent_mod
+    from lionagi.ln.concurrency import run_async as _real_run_async
+
+    monkeypatch.setattr(agent_mod, "run_async", _real_run_async)
+
+    _reset_channel("lionagi.cli.hint")
+
+    from lionagi.cli.agent import run_agent
+
+    with caplog.at_level(logging.INFO, logger="lionagi.cli.hint"):
+        rc = run_agent(_agent_args())
+
+    assert rc == 0
+    hint_text = "\n".join(rec.message for rec in caplog.records)
+    assert "[to resume]" in hint_text
+    assert "li agent -r " in hint_text
+    assert "li agent status sess-xyz789" in hint_text
+
+
+@pytest.mark.asyncio
+async def test_post_run_hint_omits_status_line_when_no_session(monkeypatch, tmp_path, caplog):
+    """No live session (persistence disabled/failed) -> the resume line still
+    prints, but no status line — there's nothing to point it at."""
+    _wire_agent_stubs(monkeypatch, tmp_path, session_id=None)
+
+    import lionagi.cli.agent as agent_mod
+    from lionagi.ln.concurrency import run_async as _real_run_async
+
+    monkeypatch.setattr(agent_mod, "run_async", _real_run_async)
+
+    _reset_channel("lionagi.cli.hint")
+
+    from lionagi.cli.agent import run_agent
+
+    with caplog.at_level(logging.INFO, logger="lionagi.cli.hint"):
+        rc = run_agent(_agent_args())
+
+    assert rc == 0
+    hint_text = "\n".join(rec.message for rec in caplog.records)
+    assert "[to resume]" in hint_text
+    assert "li agent status" not in hint_text

--- a/tests/cli/test_argv_injection.py
+++ b/tests/cli/test_argv_injection.py
@@ -921,7 +921,7 @@ class TestMainVerboseScanSentinelAware:
         async def _fake_run_agent(model_str, prompt, *, verbose=False, **kwargs):
             captured["prompt"] = prompt
             captured["verbose"] = verbose
-            return "out", "provider", "branch", "completed"
+            return "out", "provider", "branch", "completed", "sess-001"
 
         sched = {
             "id": "t",

--- a/tests/cli/test_argv_parser_regression.py
+++ b/tests/cli/test_argv_parser_regression.py
@@ -39,7 +39,7 @@ async def _fake_run_agent(
     fast: bool = False,
     verbose: bool = False,
     **kwargs: Any,
-) -> tuple[str, str, str, str]:
+) -> tuple[str, str, str, str, str | None]:
     _CAPTURED["agent"] = {
         "model_str": model_str,
         "prompt": prompt,
@@ -48,7 +48,7 @@ async def _fake_run_agent(
         "fast": fast,
         "verbose": verbose,
     }
-    return "output", "provider", "branch-id", "completed"
+    return "output", "provider", "branch-id", "completed", "sess-001"
 
 
 async def _fake_run_flow(

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -144,6 +144,23 @@ async def _make_play(
     return play_id
 
 
+async def _make_branch(db: StateDB, session_id: str, *, branch_id: str | None = None) -> str:
+    """Create a branch row tied to *session_id* — the resume token surfaced
+    as `branch_id` in the status view and printed in `li agent -r` hints."""
+    bid = branch_id or str(uuid.uuid4())
+    pid = uuid.uuid4().hex
+    await db.create_progression(pid)
+    await db.create_branch(
+        {
+            "id": bid,
+            "session_id": session_id,
+            "progression_id": pid,
+            "model": "claude-3-5-sonnet",
+        }
+    )
+    return bid
+
+
 async def _set_fields(db: StateDB, table: str, id_: str, **fields) -> None:
     """Raw column UPDATE for fields create_session()/create_play() don't
     expose directly (current_phase, num_turns) — mirrors the pattern
@@ -330,6 +347,53 @@ async def test_resolve_any_target_no_kind_scoping(temp_db_path: Path):
 async def test_resolve_unknown_id_returns_none(temp_db_path: Path):
     async with StateDB() as db:
         result = await _resolve_agent_target(db, "0" * 40, None)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_agent_target_falls_back_to_branch_id(temp_db_path: Path):
+    """The id `li agent`'s post-run hint prints (`-r <branch_id>`) is a
+    branches.id, not a sessions.id — `li agent status <branch_id>` must
+    still resolve, to the branch's owning session."""
+    async with StateDB() as db:
+        sid = await _make_session(db)
+        branch_id = await _make_branch(db, sid)
+        result = await _resolve_agent_target(db, branch_id, None)
+    assert result is not None
+    entity_type, row = result
+    assert entity_type == "session"
+    assert row["id"] == sid
+
+
+@pytest.mark.asyncio
+async def test_resolve_agent_target_branch_id_prefix_match(temp_db_path: Path):
+    async with StateDB() as db:
+        sid = await _make_session(db)
+        branch_id = await _make_branch(db, sid)
+        result = await _resolve_agent_target(db, branch_id[:8], None)
+    assert result is not None
+    assert result[1]["id"] == sid
+
+
+@pytest.mark.asyncio
+async def test_resolve_any_target_falls_back_to_branch_id(temp_db_path: Path):
+    async with StateDB() as db:
+        sid = await _make_session(db)
+        branch_id = await _make_branch(db, sid)
+        result = await _resolve_any_target(db, branch_id)
+    assert result is not None
+    assert result[0] == "session"
+    assert result[1]["id"] == sid
+
+
+@pytest.mark.asyncio
+async def test_resolve_agent_target_unknown_branch_shaped_id_returns_none(temp_db_path: Path):
+    """A well-formed-but-unknown id must still miss cleanly through the new
+    branch_id fallback, not raise or false-positive match."""
+    async with StateDB() as db:
+        sid = await _make_session(db)
+        await _make_branch(db, sid)
+        result = await _resolve_agent_target(db, str(uuid.uuid4()), None)
     assert result is None
 
 
@@ -536,6 +600,22 @@ async def test_branch_id_surfaced_as_resume_handle(temp_db_path: Path):
     human, _ = await _run_status(command="agent", entity_id=sid, as_json=False)
     assert branch_id in human
     assert f"-r {branch_id}" in human
+
+
+@pytest.mark.asyncio
+async def test_cli_agent_status_resolves_printed_resume_id(temp_db_path: Path):
+    """End-to-end: `li agent status <branch_id>` with the exact id shape the
+    post-run hint prints (a dashed, 36-char branch uuid) must resolve to the
+    owning session, not report 'no id found'."""
+    async with StateDB() as db:
+        sid = await _make_session(db, status="completed")
+        branch_id = await _make_branch(db, sid)
+    output, exit_code = await _run_status(command="agent", entity_id=branch_id, as_json=True)
+    view = json.loads(output)
+    assert exit_code == 0
+    assert view["entity_type"] == "session"
+    assert view["id"] == sid
+    assert view["branch_id"] == branch_id
 
 
 # ── Integration: degraded marker wired through _build_view ─────────────────


### PR DESCRIPTION
## Summary

`li agent`'s post-run hint prints `[to resume] li agent -r <branch_id> "..."`, but `li agent status <branch_id>` couldn't resolve that exact id — it only matched against `sessions` and `invocations`. The printed resume token was not a valid status lookup key on its own.

**Root cause**: the `sessions` table has no `branch_id` column at all. `branches` is a separate table, and `branches.session_id` is a `NOT NULL` foreign key, so a matched branch row always names exactly one owning session (the reverse — session → "the" branch — is the lossy direction, and is already handled elsewhere in `_build_view` by picking the most recently created branch).

## Changes

**`lionagi/cli/status.py`** (Part A)
- Added `_resolve_session_by_branch_id(db, entity_id)`: looks up `entity_id` against the `branches` table (reusing the existing `_fetch_by_id` helper's exact/prefix convention unmodified, since it's already generic over table name), then resolves to the owning session via `branches.session_id`.
- Wired this fallback into `_resolve_agent_target` (`li agent status`) and `_resolve_any_target` (`li o ctl status`), after their existing sessions/invocations(/plays) lookups. `_resolve_play_target` (`li play status`) is intentionally left untouched — it isn't part of this issue and plays don't surface a branch_id resume token.

**`lionagi/cli/agent.py`** (Part B)
- `_run_agent` now also returns the live-persist `session_id` (a 5th tuple element), sourced from the in-memory `setup_agent_persist` context rather than a new DB read — by the time the post-run hint runs, the DB connection has already been closed by `teardown_agent_persist`, so re-querying it there isn't an option.
- The post-run hint in `run_agent()` now also prints `li agent status <session_id>` alongside the existing `-r <branch_id>` resume line, when a live session exists.
- Every existing `_run_agent` call site and test fake across the suite was mechanically updated for the new 5-tuple return shape.

This PR does not touch the exception-handling blocks in `_run_agent`/`run_agent()` or `lionagi/cli/_util.py` — those are in flight for a separate, unrelated fix (#1690).

## Test plan

- [x] New tests in `tests/cli/test_status.py`: `_resolve_agent_target`/`_resolve_any_target` resolve a branch_id (exact and prefix), an unrelated unknown branch-shaped id still misses cleanly, and an end-to-end `li agent status <branch_id>` test using the exact 36-char dashed id shape the hint actually prints.
- [x] New file `tests/cli/test_agent_status_hint.py`: `_run_agent`'s session_id return value, and the post-run hint including/omitting the `li agent status <session_id>` line.
- [x] `uv run ruff format` / `uv run ruff check --fix` clean on all changed files.
- [x] Full `tests/cli/` suite: `1126 passed, 1 skipped in 46.16s`.
- [x] Full project suite (`uv run pytest`): `10421 passed, 9 skipped` on the base commit plus these changes (the two flaky-under-full-parallel-load tests outside this diff's scope were independently verified to fail even on the pre-change codebase and to pass reliably in isolation — not a regression from this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)