### PR TITLE
fix(session): enforce branch ownership on include/remove (#1695)

### DIFF
--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -449,6 +449,19 @@ async def teardown_persist(
             except Exception as _exc:  # noqa: BLE001
                 _log.debug("signal persist unbind failed: %s", _exc)
 
+        # Release session ownership of every branch this ephemeral persist
+        # session wired, so a later setup (e.g. in-process resume) can wrap
+        # the same long-lived branch in a fresh session.
+        if session_obj is not None:
+            release = [ctx.get("branch"), *(b for b, _h in ctx.get("hooks", []))]
+            for _b in release:
+                if _b is None:
+                    continue
+                try:
+                    session_obj.remove_branch(_b)
+                except Exception as _exc:  # noqa: BLE001
+                    _log.debug("branch ownership release failed: %s", _exc)
+
         return final_status
     except Exception as exc:
         _log.warning("live persist teardown failed: %s", exc, exc_info=True)

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -449,24 +449,25 @@ async def teardown_persist(
             except Exception as _exc:  # noqa: BLE001
                 _log.debug("signal persist unbind failed: %s", _exc)
 
-        # Release session ownership of every branch this ephemeral persist
-        # session wired, so a later setup (e.g. in-process resume) can wrap
-        # the same long-lived branch in a fresh session.
-        if session_obj is not None:
-            release = [ctx.get("branch"), *(b for b, _h in ctx.get("hooks", []))]
-            for _b in release:
-                if _b is None:
-                    continue
-                try:
-                    session_obj.remove_branch(_b)
-                except Exception as _exc:  # noqa: BLE001
-                    _log.debug("branch ownership release failed: %s", _exc)
-
         return final_status
     except Exception as exc:
         _log.warning("live persist teardown failed: %s", exc, exc_info=True)
         return status
     finally:
+        # Release session ownership of every branch this ephemeral persist
+        # session wired, so a later setup (e.g. in-process resume) can wrap
+        # the same long-lived branch in a fresh session. This must run even
+        # when the bookkeeping above failed: a stranded owner marker would
+        # make the long-lived branch unresumable.
+        _session_obj = ctx.get("session")
+        if _session_obj is not None:
+            for _b in [ctx.get("branch"), *(b for b, _h in ctx.get("hooks", []))]:
+                if _b is None:
+                    continue
+                try:
+                    _session_obj.remove_branch(_b)
+                except Exception as _exc:  # noqa: BLE001
+                    _log.debug("branch ownership release failed: %s", _exc)
         try:
             await db.close()
         except Exception as exc:
@@ -571,11 +572,15 @@ async def setup_agent_persist(
 
     db = None
     try:
-        db = await _open_shared_db()
-
+        # Claim the branch BEFORE touching the shared DB registry: a branch
+        # still owned by a live persist session must be rejected here without
+        # side effects (registering a shared DB closes the previous handle,
+        # which would break the owning context's teardown).
         session = Session(name="agent", default_branch=branch)
         session_id = str(session.id)
         branch_id = str(branch.id)
+
+        db = await _open_shared_db()
 
         existing_branch = await db.get_branch(branch_id)
         if existing_branch:

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -571,6 +571,7 @@ async def setup_agent_persist(
     from lionagi.state import provenance as _provenance
 
     db = None
+    session = None
     try:
         # Claim the branch BEFORE touching the shared DB registry: a branch
         # still owned by a live persist session must be rejected here without
@@ -728,6 +729,13 @@ async def setup_agent_persist(
             exc,
             exc_info=True,
         )
+        # If the wrapper session already claimed the branch, release it so a
+        # later setup (or retry) can wrap the same branch again.
+        if session is not None:
+            try:
+                session.remove_branch(branch)
+            except Exception as release_exc:  # noqa: BLE001
+                _log.debug("branch ownership release failed: %s", release_exc)
         if db is not None:
             try:
                 await db.close()

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -221,8 +221,10 @@ class DependencyAwareExecutor:
                         if isinstance(branch_id, str | UUID) or (
                             hasattr(branch_id, "__str__") and not hasattr(branch_id, "_mock_name")
                         ):
-                            self.session.branches.collections[branch_id] = branch_clone
-                            self.session.branches.progression.append(branch_id)
+                            # Full session wiring (owner marker, observer,
+                            # exchange), not a bare Pile insert that would
+                            # leave the clone claimable by another session.
+                            self.session.include_branches(branch_clone)
                 except Exception:
                     logger.debug("Skipping branch clone registration (likely mock in test).")
 

--- a/lionagi/session/branch.py
+++ b/lionagi/session/branch.py
@@ -103,6 +103,7 @@ class Branch(Element, Relational):
     _observer: Any = PrivateAttr(None)
     _hooks: Any = PrivateAttr(None)
     _memory: MemoryStore | None = PrivateAttr(None)
+    _owning_session_id: Any = PrivateAttr(None)
     _capabilities: Any = PrivateAttr(None)
     _loop_control: "LoopControl | None" = PrivateAttr(None)
     _signal_tasks: list = PrivateAttr(default_factory=list)

--- a/lionagi/session/session.py
+++ b/lionagi/session/session.py
@@ -82,14 +82,18 @@ class Session(Node, Relational):
             self.include_branches(branches)
 
     def include_branches(self, branches: ID[Branch].ItemSeq):
-        def _take_in_branch(branch: Branch):
-            if branch._owning_session_id is not None and branch._owning_session_id != self.id:
+        # Preflight the whole batch before mutating anything, so a rejected
+        # branch never leaves earlier batch members claimed by this session.
+        candidates = [branches] if isinstance(branches, Branch) else list(branches)
+        for b in candidates:
+            if b._owning_session_id is not None and b._owning_session_id != self.id:
                 raise ValueError(
-                    f"Branch {branch.id} is already owned by session "
-                    f"{branch._owning_session_id}; call remove_branch() on the "
+                    f"Branch {b.id} is already owned by session "
+                    f"{b._owning_session_id}; call remove_branch() on the "
                     "owning session first to reparent it."
                 )
 
+        def _take_in_branch(branch: Branch):
             if branch not in self.branches:
                 self.branches.include(branch)
 
@@ -110,9 +114,7 @@ class Session(Node, Relational):
             if self.default_branch is None:
                 self.default_branch = branch
 
-        branches = [branches] if isinstance(branches, Branch) else branches
-
-        for i in branches:
+        for i in candidates:
             _take_in_branch(i)
 
     def register_operation(self, operation: str, func: Callable, *, update: bool = False):

--- a/lionagi/session/session.py
+++ b/lionagi/session/session.py
@@ -83,9 +83,17 @@ class Session(Node, Relational):
 
     def include_branches(self, branches: ID[Branch].ItemSeq):
         def _take_in_branch(branch: Branch):
+            if branch._owning_session_id is not None and branch._owning_session_id != self.id:
+                raise ValueError(
+                    f"Branch {branch.id} is already owned by session "
+                    f"{branch._owning_session_id}; call remove_branch() on the "
+                    "owning session first to reparent it."
+                )
+
             if branch not in self.branches:
                 self.branches.include(branch)
 
+            branch._owning_session_id = self.id
             branch.user = self.id
             branch._operation_manager = self._operation_manager
             branch._observer = self.observer
@@ -249,6 +257,16 @@ class Session(Node, Relational):
 
         self.branches.exclude(branch)
         self.exchange.unregister(branch.id)
+
+        # Routing infrastructure is session-owned: tear it down so a removed
+        # branch reverts to a clean standalone state and can be reparented.
+        # Branch data (messages, memory, logs) stays with the branch.
+        branch._owning_session_id = None
+        branch._observer = None
+        branch._hooks = None
+        branch._operation_manager = OperationManager()
+        if branch.user == self.id:
+            branch.user = None
 
         if self.default_branch.id == branch.id:
             if not self.branches:

--- a/tests/cli/test_agent_live_persist.py
+++ b/tests/cli/test_agent_live_persist.py
@@ -526,6 +526,35 @@ async def test_teardown_closes_db_even_if_bookmark_update_fails(
     # Worker count should be back to (or below) baseline.
     assert _aiosqlite_thread_count() <= before
 
+    # Ownership release also ran despite the failure: the long-lived branch
+    # is back to a clean standalone state and can be re-wrapped on resume.
+    assert branch._owning_session_id is None
+    assert branch._observer is None
+    assert branch._hooks is None
+    assert branch.user is None
+
+
+async def test_rejected_second_setup_leaves_first_context_intact(
+    temp_db_path: Path,
+):
+    """A second setup on a still-owned branch must fail WITHOUT closing the
+    first context's shared DB handle or blocking its teardown release."""
+    branch = Branch(name="b1")
+    ctx1 = await _setup_live_persist(branch)
+
+    ctx2 = await _setup_live_persist(branch)
+    assert ctx2 is None  # rejected: branch still owned by ctx1's session
+
+    # ctx1's DB handle survived the rejected setup...
+    assert ctx1["db"]._engine is not None
+    # ...and teardown still releases ownership cleanly.
+    await _teardown_live_persist(ctx1, status="completed")
+    assert branch._owning_session_id is None
+
+    ctx3 = await _setup_live_persist(branch)
+    assert ctx3 is not None
+    await _teardown_live_persist(ctx3, status="completed")
+
 
 async def test_teardown_with_none_context_is_noop(temp_db_path: Path):
     """If setup returned None (failed), teardown(None) must be safe."""

--- a/tests/cli/test_agent_live_persist.py
+++ b/tests/cli/test_agent_live_persist.py
@@ -556,6 +556,30 @@ async def test_rejected_second_setup_leaves_first_context_intact(
     await _teardown_live_persist(ctx3, status="completed")
 
 
+async def test_failed_setup_releases_branch_claim(
+    temp_db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Setup failing AFTER the wrapper session claims the branch must release
+    the claim, so a retry (or a later run) can wrap the branch again."""
+    import lionagi.cli._runs as _runs_mod
+
+    async def boom():
+        raise RuntimeError("simulated db-open failure")
+
+    monkeypatch.setattr(_runs_mod, "_open_shared_db", boom)
+
+    branch = Branch(name="b1")
+    ctx = await _setup_live_persist(branch)
+    assert ctx is None
+    assert branch._owning_session_id is None
+
+    monkeypatch.undo()
+    ctx2 = await _setup_live_persist(branch)
+    assert ctx2 is not None
+    await _teardown_live_persist(ctx2, status="completed")
+
+
 async def test_teardown_with_none_context_is_noop(temp_db_path: Path):
     """If setup returned None (failed), teardown(None) must be safe."""
     await _teardown_live_persist(None, status="completed")  # MUST NOT raise

--- a/tests/session/test_memory_access_surface.py
+++ b/tests/session/test_memory_access_surface.py
@@ -124,7 +124,7 @@ class TestSessionMemorySurface:
         assert branch.memory is own_store
         assert branch.memory is not session.memory
 
-    def test_branch_already_sharing_another_sessions_store_is_not_stolen(self):
+    def test_adopted_store_survives_reparenting(self):
         session_a = Session()
         session_b = Session()
         shared = Branch(name="shared")
@@ -132,6 +132,7 @@ class TestSessionMemorySurface:
         session_a.include_branches(shared)
         store_from_a = shared.memory
 
+        session_a.remove_branch(shared)
         session_b.include_branches(shared)
 
         assert shared.memory is store_from_a

--- a/tests/session/test_session_branch_ownership.py
+++ b/tests/session/test_session_branch_ownership.py
@@ -34,6 +34,25 @@ class TestCrossSessionInclude:
         assert shared._owning_session_id == session_a.id
         assert shared not in session_b.branches
 
+    def test_rejected_batch_mutates_no_branch(self):
+        """A rejected member anywhere in the batch leaves EVERY member
+        untouched: no partial claim of earlier batch members."""
+        session_a = Session()
+        session_b = Session()
+        owned = Branch(name="owned")
+        session_a.include_branches(owned)
+        fresh1 = Branch(name="fresh1")
+        fresh2 = Branch(name="fresh2")
+
+        with pytest.raises(ValueError, match="already owned by session"):
+            session_b.include_branches([fresh1, owned, fresh2])
+
+        for b in (fresh1, fresh2):
+            assert b._owning_session_id is None
+            assert b.user is None
+            assert b not in session_b.branches
+        assert owned._owning_session_id == session_a.id
+
     def test_session_constructor_rejects_owned_branch(self):
         from lionagi.protocols.types import Pile
 
@@ -41,9 +60,14 @@ class TestCrossSessionInclude:
         shared = Branch(name="shared")
         session_a.include_branches(shared)
 
-        pile = Pile(collections=[shared], item_type={Branch}, strict_type=False)
+        fresh = Branch(name="fresh")
+        pile = Pile(collections=[fresh, shared], item_type={Branch}, strict_type=False)
         with pytest.raises(ValueError, match="already owned by session"):
             Session(branches=pile)
+
+        # the fresh sibling stays claimable after the failed construction
+        assert fresh._owning_session_id is None
+        Session().include_branches(fresh)
 
     def test_same_session_reinclude_is_idempotent(self):
         session = Session()

--- a/tests/session/test_session_branch_ownership.py
+++ b/tests/session/test_session_branch_ownership.py
@@ -1,0 +1,121 @@
+"""Session/Branch ownership semantics: include claims, remove tears down."""
+
+import pytest
+
+from lionagi.session.branch import Branch
+from lionagi.session.session import Session
+
+
+class TestCrossSessionInclude:
+    def test_second_session_include_raises(self):
+        session_a = Session()
+        session_b = Session()
+        shared = Branch(name="shared")
+        session_a.include_branches(shared)
+
+        with pytest.raises(ValueError, match="already owned by session"):
+            session_b.include_branches(shared)
+
+    def test_first_sessions_wiring_survives_rejected_steal(self):
+        session_a = Session()
+        session_b = Session()
+        _ = session_a.hooks
+        shared = Branch(name="shared")
+        session_a.include_branches(shared)
+        observer_a = shared._observer
+        hooks_a = shared._hooks
+
+        with pytest.raises(ValueError):
+            session_b.include_branches(shared)
+
+        assert shared._observer is observer_a
+        assert shared._hooks is hooks_a
+        assert shared._operation_manager is session_a._operation_manager
+        assert shared._owning_session_id == session_a.id
+        assert shared not in session_b.branches
+
+    def test_session_constructor_rejects_owned_branch(self):
+        from lionagi.protocols.types import Pile
+
+        session_a = Session()
+        shared = Branch(name="shared")
+        session_a.include_branches(shared)
+
+        pile = Pile(collections=[shared], item_type={Branch}, strict_type=False)
+        with pytest.raises(ValueError, match="already owned by session"):
+            Session(branches=pile)
+
+    def test_same_session_reinclude_is_idempotent(self):
+        session = Session()
+        branch = Branch(name="b")
+        session.include_branches(branch)
+        observer = branch._observer
+        manager = branch._operation_manager
+
+        session.include_branches(branch)
+
+        assert branch._observer is observer
+        assert branch._operation_manager is manager
+        assert branch._owning_session_id == session.id
+        assert len(session.branches) == 2  # default branch + b
+
+
+class TestRemoveBranchTeardown:
+    def test_remove_clears_routing_keeps_data(self):
+        session = Session()
+        _ = session.hooks
+        branch = Branch(name="b")
+        session.include_branches(branch)
+        store = branch.memory
+
+        session.remove_branch(branch)
+
+        assert branch._owning_session_id is None
+        assert branch._observer is None
+        assert branch._hooks is None
+        assert branch.user is None
+        # fresh standalone manager, not the session's
+        assert branch._operation_manager is not None
+        assert branch._operation_manager is not session._operation_manager
+        # data survives removal
+        assert branch._memory is store
+
+    def test_remove_then_include_reparents_cleanly(self):
+        session_a = Session()
+        session_b = Session()
+        _ = session_a.hooks
+        _ = session_b.hooks
+        branch = Branch(name="b")
+        session_a.include_branches(branch)
+
+        session_a.remove_branch(branch)
+        session_b.include_branches(branch)
+
+        assert branch._owning_session_id == session_b.id
+        assert branch._observer is session_b.observer
+        assert branch._hooks is session_b._hooks
+        assert branch._operation_manager is session_b._operation_manager
+        assert branch.user == session_b.id
+        assert branch not in session_a.branches
+
+    def test_remove_preserves_foreign_user(self):
+        session = Session()
+        branch = Branch(name="b")
+        session.include_branches(branch)
+        branch.user = "someone-else"
+
+        session.remove_branch(branch)
+
+        assert branch.user == "someone-else"
+
+
+class TestSplitUnaffected:
+    def test_split_clone_is_owned_by_same_session(self):
+        session = Session()
+        branch = Branch(name="b")
+        session.include_branches(branch)
+
+        clone = session.split(branch)
+
+        assert clone._owning_session_id == session.id
+        assert clone in session.branches


### PR DESCRIPTION
## Summary

Implements the #1695 agreed design note verbatim.

The principle: a branch carries two kinds of state and the fix treats them differently.
- **Routing infrastructure** (`_observer`, `_hooks`, `_operation_manager`, `user`) is session-owned: installed on include, torn down on remove.
- **Branch data** (`messages`, `_memory`, logs) is branch-owned: never touched by include/remove. The ADR-0090 first-claim `_memory` guard is unchanged.

Changes:
1. `Branch._owning_session_id` private ownership marker (set on include, cleared on remove).
2. `Session.include_branches()` **raises** when the branch is already owned by a *different* session (recommendation over warn-and-steal: with teardown in place, remove-then-include is the clean deliberate reparent path). Same-session re-include stays idempotent.
3. `Session.remove_branch()` tears down routing: clears observer/hooks/owner marker, installs a fresh `OperationManager()` (never `None`, preserving the eager-init invariant), resets `user` only if it still points at this session.

Verified all production `include_branches` call sites (flow.py, _orchestration.py, engine.py, patterns.py) include fresh clones or newly constructed branches only — none cross-session, so no behavior change outside the bug path.

One pre-existing test updated: `test_branch_already_sharing_another_sessions_store_is_not_stolen` pinned the old silent-steal shape; renamed to `test_adopted_store_survives_reparenting` and rewritten to the new remove-then-include contract (the store-survives assertion it protected is preserved and strengthened).

## Test plan

- [x] New `tests/session/test_session_branch_ownership.py` (8 tests): cross-session raise, wiring survives rejected steal, constructor-path rejection, same-session idempotence, remove teardown (routing cleared, data kept), clean reparent, foreign-user preserved, split() unaffected.
- [x] `tests/session/` + `tests/integration/test_orchestration_integration.py` + `tests/cli/orchestrate/` all green.
- [x] ruff format + check clean.

Open items flagged in the design note for review: raise-vs-warn (implemented: raise) and user-reset-without-restore (implemented: reset).

Closes #1695.

🤖 Generated with [Claude Code](https://claude.com/claude-code)