### PR TITLE
feat(cli): li schedule one-shot semantics (--once/--max-runs) + help/UX pass

### DIFF
--- a/lionagi/cli/main.py
+++ b/lionagi/cli/main.py
@@ -293,7 +293,7 @@ def main(argv: list[str] | None = None) -> int:
     add_engine_subparser(sub)
     add_team_subparser(sub)
     add_studio_subparser(sub)
-    add_schedule_subparser(sub)
+    schedule_parser = add_schedule_subparser(sub)
     add_state_subparser(sub)
     add_invoke_subparser(sub)
     add_kill_subparser(sub)
@@ -324,6 +324,24 @@ def main(argv: list[str] | None = None) -> int:
             agent_parser.error(f"unrecognized arguments: {' '.join(unknown)}")
         args.query = [*(args.query or []), *extras, *post]
         return run_agent(args)
+
+    # `li schedule ...` parses its own subparser directly (mirroring the
+    # `agent` special-case above) so an unrecognized flag gets a one-line
+    # "did you mean --X?" suggestion instead of argparse's generic usage dump.
+    if _argv and _argv[0] == "schedule":
+        ns, extras = schedule_parser.parse_known_args(_argv[1:])
+        unknown = [e for e in extras if e.startswith("-") and e != "-"]
+        if unknown:
+            from lionagi.studio.cli import suggest_schedule_flag
+
+            for tok in unknown:
+                suggestion = suggest_schedule_flag(tok)
+                if suggestion:
+                    log_error(f"unrecognized argument {tok!r} — did you mean {suggestion!r}?")
+                else:
+                    log_error(f"unrecognized argument: {tok}")
+            return 2
+        return run_schedule(ns)
 
     args = parser.parse_args(_argv)
 

--- a/lionagi/cli/main.py
+++ b/lionagi/cli/main.py
@@ -330,16 +330,20 @@ def main(argv: list[str] | None = None) -> int:
     # "did you mean --X?" suggestion instead of argparse's generic usage dump.
     if _argv and _argv[0] == "schedule":
         ns, extras = schedule_parser.parse_known_args(_argv[1:])
-        unknown = [e for e in extras if e.startswith("-") and e != "-"]
-        if unknown:
+        if extras:
             from lionagi.studio.cli import suggest_schedule_flag
 
-            for tok in unknown:
-                suggestion = suggest_schedule_flag(tok)
-                if suggestion:
-                    log_error(f"unrecognized argument {tok!r} — did you mean {suggestion!r}?")
-                else:
-                    log_error(f"unrecognized argument: {tok}")
+            # Any leftover token — flag-shaped or not — is unrecognized and
+            # must error like plain argparse would (rc=2); did-you-mean
+            # suggestions only make sense for dash-prefixed tokens, since a
+            # bare positional like a surplus id has no "real flag" to guess.
+            for tok in extras:
+                if tok.startswith("-") and tok != "-":
+                    suggestion = suggest_schedule_flag(tok)
+                    if suggestion:
+                        log_error(f"unrecognized argument {tok!r} — did you mean {suggestion!r}?")
+                        continue
+                log_error(f"unrecognized argument: {tok}")
             return 2
         return run_schedule(ns)
 

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -732,6 +732,7 @@ class StateDB:
                                               CHECK(missed_fire_policy IN ('skip', 'run_once')),
                           overlap_policy      TEXT    NOT NULL DEFAULT 'skip'
                                               CHECK(overlap_policy IN ('skip', 'allow')),
+                          max_runs            INTEGER,
                           project             TEXT,
                           created_at          REAL    NOT NULL,
                           updated_at          REAL    NOT NULL
@@ -1528,7 +1529,7 @@ class StateDB:
                         action_kind, action_model, action_prompt, action_agent,
                         action_playbook, action_flow_yaml, action_project, action_extra_args,
                         on_success, on_fail, last_fired_at, next_fire_at,
-                        missed_fire_policy, overlap_policy, project,
+                        missed_fire_policy, overlap_policy, max_runs, project,
                         created_at, updated_at)
                        VALUES (:id, :name, :description, :enabled, :trigger_type,
                                :cron_expr, :interval_sec, :github_repo, :github_filter,
@@ -1536,7 +1537,7 @@ class StateDB:
                                :action_kind, :action_model, :action_prompt, :action_agent,
                                :action_playbook, :action_flow_yaml, :action_project, :action_extra_args,
                                :on_success, :on_fail, :last_fired_at, :next_fire_at,
-                               :missed_fire_policy, :overlap_policy, :project,
+                               :missed_fire_policy, :overlap_policy, :max_runs, :project,
                                :created_at, :updated_at)"""
                 ).bindparams(
                     bindparam("github_filter", type_=JSON),
@@ -1570,6 +1571,7 @@ class StateDB:
                     "next_fire_at": schedule.get("next_fire_at"),
                     "missed_fire_policy": schedule.get("missed_fire_policy", "skip"),
                     "overlap_policy": schedule.get("overlap_policy", "skip"),
+                    "max_runs": schedule.get("max_runs"),
                     "project": schedule.get("project"),
                     "created_at": schedule.get("created_at", now),
                     "updated_at": schedule.get("updated_at", now),
@@ -1660,6 +1662,7 @@ class StateDB:
             "next_fire_at",
             "missed_fire_policy",
             "overlap_policy",
+            "max_runs",
             "project",
         }
         bad = set(fields) - allowed
@@ -1786,6 +1789,28 @@ class StateDB:
         async with self._read() as conn:
             rows = (await conn.execute(text(query), params)).mappings().all()
         return [self._row_to_dict(r) for r in rows]
+
+    async def count_schedule_runs(
+        self,
+        schedule_id: str,
+        *,
+        chain_depth: int = 0,
+        statuses: tuple[str, ...] = ("completed", "failed", "cancelled"),
+    ) -> int:
+        """Count runs that actually fired and reached a terminal status.
+
+        Used for max_runs bookkeeping: chain_depth=0 excludes on_success/
+        on_fail chain children (they don't consume the parent's budget), and
+        the default status set excludes 'skipped' (missed-fire/overlap skips
+        never ran) and 'running' (not yet terminal).
+        """
+        placeholders = ", ".join(f":status{i}" for i in range(len(statuses)))
+        params: dict[str, Any] = {"schedule_id": schedule_id, "chain_depth": chain_depth}
+        params.update({f"status{i}": s for i, s in enumerate(statuses)})
+        query = f"SELECT COUNT(*) AS n FROM schedule_runs WHERE schedule_id = :schedule_id AND chain_depth = :chain_depth AND status IN ({placeholders})"  # noqa: S608
+        async with self._read() as conn:
+            row = (await conn.execute(text(query), params)).mappings().first()
+        return int(row["n"]) if row else 0
 
     async def get_schedule_run(self, run_id: str) -> dict[str, Any] | None:
         async with self._read() as conn:

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -422,6 +422,10 @@ CREATE TABLE IF NOT EXISTS schedules (
                       CHECK(missed_fire_policy IN ('skip', 'run_once')),
   overlap_policy      TEXT    NOT NULL DEFAULT 'skip'
                       CHECK(overlap_policy IN ('skip', 'allow')),
+  -- One-shot / bounded-run semantics: NULL means unlimited. Once the number
+  -- of fired top-level runs (chain children excluded) reaches max_runs, the
+  -- engine auto-disables the schedule via the existing enabled flag.
+  max_runs            INTEGER,
   project             TEXT,
   created_at          REAL    NOT NULL,
   updated_at          REAL    NOT NULL

--- a/lionagi/state/schema_meta.py
+++ b/lionagi/state/schema_meta.py
@@ -505,6 +505,9 @@ schedules = Table(
         nullable=False,
         server_default="skip",
     ),
+    # One-shot / bounded-run semantics: NULL means unlimited (see
+    # schema.sql for the fuller comment on how the engine counts runs).
+    Column("max_runs", Integer),
     Column("project", Text),
     Column("created_at", Float, nullable=False),
     Column("updated_at", Float, nullable=False),

--- a/lionagi/state/schema_migrations.py
+++ b/lionagi/state/schema_migrations.py
@@ -89,6 +89,8 @@ MIGRATION_COLUMNS: dict[str, list[tuple[str, str]]] = {
     "schedules": [
         # YAML flow spec column added by sched-yaml feature.
         ("action_flow_yaml", "TEXT"),
+        # One-shot / bounded-run semantics: NULL means unlimited.
+        ("max_runs", "INTEGER"),
     ],
     "schedule_runs": [
         # ADR-0028: schedule_runs originally had no updated_at.

--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -544,7 +544,10 @@ def _cmd_list(args: argparse.Namespace) -> int:
         return 0
     for s in schedules:
         status = "enabled" if s.get("enabled") else "disabled"
-        print(f"  {s['id']}  {s['name']:<30} [{status}]  {s.get('trigger_type', '?')}")
+        line = f"  {s['id']}  {s['name']:<30} [{status}]  {s.get('trigger_type', '?')}"
+        if s.get("max_runs"):
+            line += f"  (runs left: {s.get('remaining_runs')}/{s['max_runs']})"
+        print(line)
     return 0
 
 
@@ -633,7 +636,47 @@ def _parse_chain_action(raw: str, flag: str) -> tuple[dict[str, Any] | None, str
     return parsed, None
 
 
+def _warn_if_cron_far_out(cron_expr: str) -> None:
+    """Best-effort heads-up when a cron expression's next fire is far out.
+
+    Addresses the date-pinned one-shot footgun: a cron schedule created
+    after its literal moment for this year (but meant to fire "today")
+    silently resolves to the same date *next* year instead. croniter is
+    part of the `studio` extra, not a core dependency, so this degrades to
+    a no-op rather than failing schedule creation when it isn't installed.
+    """
+    try:
+        from croniter import croniter
+    except ImportError:
+        return
+    import time as _time
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc)
+    try:
+        next_fire = croniter(cron_expr, start_time=now).get_next(float)
+    except Exception:
+        return
+    days_out = (next_fire - _time.time()) / 86400
+    if days_out > 360:
+        warn(
+            f"cron {cron_expr!r} next fires in about {days_out:.0f} days. "
+            "If you meant a one-shot for a specific date this year, the "
+            "schedule may have been created after that date's moment has "
+            "already passed (cron resolves in UTC) and silently waits a "
+            "full year. Consider --max-runs / --once plus a nearer date."
+        )
+
+
 def _cmd_create(args: argparse.Namespace) -> int:
+    if args.once and args.max_runs is not None:
+        print("Error: --once and --max-runs are mutually exclusive.", file=sys.stderr)
+        return 1
+    max_runs = 1 if args.once else args.max_runs
+    if max_runs is not None and max_runs < 1:
+        print(f"Error: --max-runs must be a positive integer, got {max_runs}.", file=sys.stderr)
+        return 1
+
     body: dict[str, Any] = {
         "name": args.name,
         "trigger_type": args.trigger_type,
@@ -641,8 +684,11 @@ def _cmd_create(args: argparse.Namespace) -> int:
     }
     if args.cron:
         body["cron_expr"] = args.cron
+        _warn_if_cron_far_out(args.cron)
     if args.interval:
         body["interval_sec"] = args.interval
+    if max_runs is not None:
+        body["max_runs"] = max_runs
     if args.prompt:
         body["action_prompt"] = args.prompt
     if args.model:
@@ -792,6 +838,23 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> None:
     )
     create_p.add_argument("--project", help="Project name.")
     create_p.add_argument("--description", help="Human-readable description.")
+    create_p.add_argument(
+        "--max-runs",
+        dest="max_runs",
+        type=int,
+        metavar="N",
+        help=(
+            "Auto-disable this schedule once N total runs have fired "
+            "(default: unlimited). Chained on_success/on_fail fires do not "
+            "count toward N. Mutually exclusive with --once."
+        ),
+    )
+    create_p.add_argument(
+        "--once",
+        dest="once",
+        action="store_true",
+        help="Sugar for --max-runs 1 — fire once, then auto-disable.",
+    )
     create_p.add_argument(
         "--on-success",
         dest="on_success",

--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -786,8 +786,41 @@ def _cmd_runs(args: argparse.Namespace) -> int:
     return 0
 
 
-def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> None:
-    """Register `li schedule` sub-command."""
+# Common wrong spellings/guesses mapped to the real flag they were probably
+# aiming for — checked before the generic difflib fuzzy match below, since
+# some of these (e.g. --every for --interval) aren't close enough by edit
+# distance for difflib to catch on its own.
+_SCHEDULE_FLAG_SYNONYMS: dict[str, str] = {
+    "--every": "--interval",
+    "--at": "--cron",
+    "--action": "--action-kind",
+    "--on_success": "--on-success",
+    "--on_fail": "--on-fail",
+    "--max_runs": "--max-runs",
+}
+
+# Populated by add_schedule_subparser() with every long option string across
+# all `li schedule` subcommands, for fuzzy did-you-mean matching.
+_ALL_SCHEDULE_FLAGS: set[str] = set()
+
+
+def suggest_schedule_flag(token: str) -> str | None:
+    """Return a suggested correction for an unrecognized `li schedule` flag.
+
+    Checks the explicit synonym map first (catches guesses too far from the
+    real flag for edit-distance matching, e.g. "--every" for "--interval"),
+    then falls back to a fuzzy match against every registered flag.
+    """
+    if token in _SCHEDULE_FLAG_SYNONYMS:
+        return _SCHEDULE_FLAG_SYNONYMS[token]
+    import difflib
+
+    matches = difflib.get_close_matches(token, _ALL_SCHEDULE_FLAGS, n=1, cutoff=0.6)
+    return matches[0] if matches else None
+
+
+def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
+    """Register `li schedule` sub-command. Returns the `schedule` parser."""
     sched = subparsers.add_parser(
         "schedule",
         help="Manage lionagi Studio schedules.",
@@ -801,14 +834,41 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> None:
     sched_sub.required = True
 
     # list
-    sched_sub.add_parser("list", help="List all schedules.")
+    sched_sub.add_parser(
+        "list",
+        help="List all schedules.",
+        epilog="Example: li schedule list",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
 
     # get
-    get_p = sched_sub.add_parser("get", help="Show schedule details.")
+    get_p = sched_sub.add_parser(
+        "get",
+        help="Show schedule details.",
+        epilog="Example: li schedule get sched-abc123",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     get_p.add_argument("id", help="Schedule ID.")
 
     # create
-    create_p = sched_sub.add_parser("create", help="Create a new schedule.")
+    create_p = sched_sub.add_parser(
+        "create",
+        help="Create a new schedule.",
+        epilog=(
+            "Examples:\n"
+            '  li schedule create daily-digest --cron "0 9 * * *" \\\n'
+            '      --prompt "summarize overnight activity"\n'
+            "  li schedule create hourly-poll --interval 3600 --agent researcher\n"
+            '  li schedule create one-shot-backfill --cron "0 18 2 7 *" --once\n'
+            '  li schedule create nightly-chain --cron "0 2 * * *" --prompt build \\\n'
+            '      --on-success \'{"prompt": "notify done", "on_success": null}\'\n'
+            "      # WARNING: --on-success/--on-fail shallow-merge into the chained\n"
+            "      # run — any key you omit is INHERITED from this schedule,\n"
+            '      # including on_success/on_fail themselves; set "on_success": null\n'
+            "      # explicitly at each level to stop the chain there."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     create_p.add_argument("name", help="Schedule name.")
     create_p.add_argument(
         "--trigger-type",
@@ -884,18 +944,38 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> None:
     )
 
     # enable / disable / trigger / delete
-    for sub_name, sub_help in (
-        ("enable", "Enable a schedule."),
-        ("disable", "Disable a schedule."),
-        ("trigger", "Fire a schedule immediately."),
-        ("delete", "Delete a schedule."),
+    for sub_name, sub_help, example in (
+        ("enable", "Enable a schedule.", "li schedule enable sched-abc123"),
+        ("disable", "Disable a schedule.", "li schedule disable sched-abc123"),
+        ("trigger", "Fire a schedule immediately.", "li schedule trigger sched-abc123"),
+        ("delete", "Delete a schedule.", "li schedule delete sched-abc123"),
     ):
-        p = sched_sub.add_parser(sub_name, help=sub_help)
+        p = sched_sub.add_parser(
+            sub_name,
+            help=sub_help,
+            epilog=f"Example: {example}",
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+        )
         p.add_argument("id", help="Schedule ID.")
 
     # runs
-    runs_p = sched_sub.add_parser("runs", help="List runs for a schedule.")
+    runs_p = sched_sub.add_parser(
+        "runs",
+        help="List runs for a schedule.",
+        epilog="Example: li schedule runs sched-abc123",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     runs_p.add_argument("id", help="Schedule ID.")
+
+    _ALL_SCHEDULE_FLAGS.clear()
+    for action_parser in sched_sub.choices.values():
+        _ALL_SCHEDULE_FLAGS.update(
+            opt
+            for opt in action_parser._option_string_actions
+            if opt.startswith("--") and opt != "--help"
+        )
+
+    return sched
 
 
 _ACTION_MAP = {

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -421,6 +421,32 @@ class SchedulerEngine:
         ctx = {"scheduled": True, "fired_at": now, "next_fire_at": schedule.get("next_fire_at")}
         self._tracked_fire(schedule, run_id, trigger_context=ctx)
 
+    async def _check_max_runs(self, schedule: dict, chain_depth: int) -> None:
+        """Auto-disable a schedule once its fired top-level runs hit max_runs.
+
+        Only chain_depth == 0 fires consume the budget — on_success/on_fail
+        chain children are follow-on actions of a single top-level run, not
+        additional scheduled runs, so they never count toward it. Reuses the
+        existing enabled flag (the same mechanism enable/disable already use)
+        rather than introducing a new schedule state.
+        """
+        if chain_depth != 0:
+            return
+        max_runs = schedule.get("max_runs")
+        if not max_runs:
+            return
+        sid = schedule["id"]
+        count = await self._svc.count_schedule_runs(sid, chain_depth=0)
+        if count >= max_runs:
+            _log.info(
+                "Schedule %s (%s) reached max_runs=%d after %d run(s); auto-disabling",
+                schedule.get("name"),
+                sid,
+                max_runs,
+                count,
+            )
+            await self._svc.update_schedule(sid, enabled=0)
+
     async def _fire(
         self,
         schedule: dict,
@@ -497,6 +523,7 @@ class SchedulerEngine:
             if next_at:
                 update_fields["next_fire_at"] = next_at
             await self._svc.update_schedule(sid, **update_fields)
+            await self._check_max_runs(schedule, chain_depth)
             return
 
         # Ensure the flow_yaml tmp file is removed on any exception or
@@ -589,6 +616,7 @@ class SchedulerEngine:
                 actor=inv_id,
                 metadata=inv_meta,
             )
+            await self._check_max_runs(schedule, chain_depth)
 
             if chain_depth < _MAX_CHAIN_DEPTH:
                 chain_action = None
@@ -655,6 +683,7 @@ class SchedulerEngine:
                     actor=inv_id,
                     metadata=inv_meta,
                 )
+                await self._check_max_runs(schedule, chain_depth)
             except Exception:
                 _log.exception("Failed to record cancellation for run %s during shutdown", run_id)
             raise
@@ -692,6 +721,7 @@ class SchedulerEngine:
                 actor=inv_id,
                 metadata=inv_meta,
             )
+            await self._check_max_runs(schedule, chain_depth)
         finally:
             if chain_depth == 0:
                 self._running.pop(sid, None)

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -474,14 +474,33 @@ class SchedulerEngine:
         ``_check_max_runs()`` (e.g. ``create_invocation`` raising) would
         otherwise leak the claim permanently for the life of the process,
         since nothing else would ever release it.
+
+        Snapshot ordering matters here: ``inflight`` is read BEFORE the
+        awaited ``count_schedule_runs()`` call, not after. ``release()`` is
+        deliberately lock-free (a claim must still release from a
+        cancelled/failing ``_fire()``'s ``finally`` without depending on
+        this lock, which would otherwise reintroduce cancellation-unsafe
+        lock-acquire-in-finally hazards), so a concurrent fire's claim can
+        be released by another task while this call is suspended awaiting
+        the DB. If ``inflight`` were read *after* that await (the round-2
+        shape), a fire that both completes its terminal write and releases
+        its claim entirely within this call's await window would vanish
+        from both the persisted count (read too early, before the write)
+        and the in-flight snapshot (read too late, after the release) —
+        the exact gap the round-3 review's forced interleaving exploited.
+        Reading ``inflight`` first captures that other fire's claim before
+        it can disappear: the persisted count may still be stale, but the
+        in-flight snapshot backstops it, so the sum can only ever
+        over-count (spurious refusal, safe and self-correcting on the next
+        tick) — never under-count (an actual overshoot).
         """
         max_runs = schedule.get("max_runs")
         if not max_runs:
             return True, None
         sid = schedule["id"]
         async with self._max_runs_lock:
-            used = await self._svc.count_schedule_runs(sid, chain_depth=0)
             inflight = self._max_runs_inflight.get(sid, 0)
+            used = await self._svc.count_schedule_runs(sid, chain_depth=0)
             if used + inflight >= max_runs:
                 return False, None
             self._max_runs_inflight[sid] = inflight + 1

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -30,6 +30,33 @@ _MAX_CHAIN_DEPTH = 10
 _TICK_INTERVAL = 30  # seconds
 
 
+class _MaxRunsClaim:
+    """One-shot handle for an in-process max_runs reservation.
+
+    Returned by ``_reserve_max_runs_budget()`` when a top-level fire is
+    allowed to proceed. The holder (``_fire()``) must call ``release()``
+    exactly once, from a ``finally`` block that covers every exit path —
+    normal completion, a caught exception, an uncaught exception raised out
+    of bookkeeping code, or cancellation — so the claim never survives past
+    the fire it was reserved for. ``release()`` is itself idempotent (a
+    second call is a no-op) as a defense-in-depth measure, not because any
+    call site is expected to invoke it twice.
+    """
+
+    __slots__ = ("_engine", "_schedule_id", "_released")
+
+    def __init__(self, engine: SchedulerEngine, schedule_id: str) -> None:
+        self._engine = engine
+        self._schedule_id = schedule_id
+        self._released = False
+
+    def release(self) -> None:
+        if self._released:
+            return
+        self._released = True
+        self._engine._release_max_runs_claim(self._schedule_id)
+
+
 def _resolve_scheduler_tzinfo(tz_name: str) -> ZoneInfo:
     """Resolve the configured scheduler timezone name to a ZoneInfo.
 
@@ -225,14 +252,18 @@ class SchedulerEngine:
         schedule = await self._svc.get_schedule(schedule_id)
         if not schedule:
             return None
-        if not await self._reserve_max_runs_budget(schedule):
+        allowed, claim = await self._reserve_max_runs_budget(schedule)
+        if not allowed:
             raise ValueError(
                 f"Schedule {schedule_id!r} has already reached its max_runs="
                 f"{schedule.get('max_runs')} limit; manual trigger refused."
             )
         run_id = uuid.uuid4().hex[:12]
         self._tracked_fire(
-            schedule, run_id, trigger_context={"manual": True, "fired_at": time.time()}
+            schedule,
+            run_id,
+            trigger_context={"manual": True, "fired_at": time.time()},
+            max_runs_claim=claim,
         )
         return run_id
 
@@ -400,7 +431,8 @@ class SchedulerEngine:
 
         new_events = await github_poll(schedule)
         if new_events:
-            if not await self._reserve_max_runs_budget(schedule):
+            allowed, claim = await self._reserve_max_runs_budget(schedule)
+            if not allowed:
                 _log.info(
                     "Schedule %s (%s) has exhausted max_runs; skipping github_poll fire",
                     schedule.get("name"),
@@ -413,35 +445,47 @@ class SchedulerEngine:
                 "fired_at": now,
             }
             run_id = uuid.uuid4().hex[:12]
-            await self._fire(schedule, run_id, trigger_context=ctx)
+            await self._fire(schedule, run_id, trigger_context=ctx, max_runs_claim=claim)
 
-    async def _reserve_max_runs_budget(self, schedule: dict) -> bool:
+    async def _reserve_max_runs_budget(self, schedule: dict) -> tuple[bool, _MaxRunsClaim | None]:
         """Atomically claim one top-level fire against schedule['max_runs'].
 
-        Returns True if the fire may proceed, False if the schedule has
-        already consumed its budget (persisted terminal runs plus runs
-        already claimed-but-not-yet-terminal in this process). Guarded by
-        an engine-wide lock so concurrent callers — the tick loop,
-        fire_now(), github polling — can't both read the same count and
-        both claim it before either claim is visible. This is the
-        single-process analogue of a DB-backed compare-and-set; only one
-        scheduler process runs today, so a DB-backed reservation is not
-        needed. Chain children (chain_depth>0) never call this — only
-        top-level fires consume budget. The claim is released in
-        _check_max_runs() once the fire it was reserved for reaches a
-        terminal status.
+        Returns ``(allowed, claim)``. ``allowed`` is False only when the
+        schedule is bounded (``max_runs`` set) and has already consumed its
+        budget — persisted terminal runs plus runs already
+        claimed-but-not-yet-terminal in this process; callers must refuse to
+        fire in that case. ``claim`` is a ``_MaxRunsClaim`` token when a
+        bounded schedule's budget was actually reserved, or ``None`` when
+        the schedule is unbounded (``max_runs`` unset — always allowed, no
+        claim to release). Guarded by an engine-wide lock so concurrent
+        callers — the tick loop, fire_now(), github polling — can't both
+        read the same count and both claim it before either claim is
+        visible. This is the single-process analogue of a DB-backed
+        compare-and-set; only one scheduler process runs today, so a
+        DB-backed reservation is not needed. Chain children (chain_depth>0)
+        never call this — only top-level fires consume budget.
+
+        Whenever ``allowed`` is True the caller MUST pass ``claim`` through
+        to ``_fire()`` as ``max_runs_claim=`` (even when it is ``None``) so
+        it gets released — exactly once, on every exit path including
+        pre-run failures — from ``_fire()``'s own ``finally`` block. Unlike
+        the round-1 shape, the claim is no longer released from inside
+        ``_check_max_runs()`` alone: a fire that fails before ever reaching
+        ``_check_max_runs()`` (e.g. ``create_invocation`` raising) would
+        otherwise leak the claim permanently for the life of the process,
+        since nothing else would ever release it.
         """
         max_runs = schedule.get("max_runs")
         if not max_runs:
-            return True
+            return True, None
         sid = schedule["id"]
         async with self._max_runs_lock:
             used = await self._svc.count_schedule_runs(sid, chain_depth=0)
             inflight = self._max_runs_inflight.get(sid, 0)
             if used + inflight >= max_runs:
-                return False
+                return False, None
             self._max_runs_inflight[sid] = inflight + 1
-            return True
+            return True, _MaxRunsClaim(self, sid)
 
     def _release_max_runs_claim(self, schedule_id: str) -> None:
         remaining = self._max_runs_inflight.get(schedule_id, 0) - 1
@@ -469,7 +513,8 @@ class SchedulerEngine:
                 await self._svc.update_schedule(schedule["id"], next_fire_at=next_at)
             return
 
-        if not await self._reserve_max_runs_budget(schedule):
+        allowed, claim = await self._reserve_max_runs_budget(schedule)
+        if not allowed:
             _log.info(
                 "Schedule %s (%s) has exhausted max_runs=%s; disabling instead of firing",
                 schedule.get("name"),
@@ -481,7 +526,7 @@ class SchedulerEngine:
 
         run_id = uuid.uuid4().hex[:12]
         ctx = {"scheduled": True, "fired_at": now, "next_fire_at": schedule.get("next_fire_at")}
-        self._tracked_fire(schedule, run_id, trigger_context=ctx)
+        self._tracked_fire(schedule, run_id, trigger_context=ctx, max_runs_claim=claim)
 
     async def _check_max_runs(self, schedule: dict, chain_depth: int) -> None:
         """Auto-disable a schedule once its fired top-level runs hit max_runs.
@@ -490,15 +535,16 @@ class SchedulerEngine:
         chain children are follow-on actions of a single top-level run, not
         additional scheduled runs, so they never count toward it. Reuses the
         existing enabled flag (the same mechanism enable/disable already use)
-        rather than introducing a new schedule state. Also releases this
-        fire's in-process max_runs claim (see _reserve_max_runs_budget) now
-        that it has reached a terminal status — a no-op if no claim was
-        reserved (max_runs unset).
+        rather than introducing a new schedule state.
+
+        This no longer releases the in-process max_runs claim — that is
+        _fire()'s responsibility now (via its own finally block, using the
+        max_runs_claim token), so the claim is released on every exit path,
+        not only the ones that reach this call.
         """
         if chain_depth != 0:
             return
         sid = schedule["id"]
-        self._release_max_runs_claim(sid)
         max_runs = schedule.get("max_runs")
         if not max_runs:
             return
@@ -514,6 +560,39 @@ class SchedulerEngine:
             await self._svc.update_schedule(sid, enabled=0)
 
     async def _fire(
+        self,
+        schedule: dict,
+        run_id: str,
+        *,
+        trigger_context: dict,
+        chain_parent_id: str | None = None,
+        chain_depth: int = 0,
+        max_runs_claim: _MaxRunsClaim | None = None,
+    ) -> None:
+        """Thin wrapper around _fire_inner() that guarantees max_runs_claim
+        is released exactly once on every exit path.
+
+        Only top-level callers (_maybe_fire, fire_now, _tick_github) that
+        got an allowed reservation from _reserve_max_runs_budget() pass a
+        non-None max_runs_claim; chain children never do. The release lives
+        here — not inside _check_max_runs() — precisely so it still fires
+        even when _fire_inner() blows up before ever reaching
+        _check_max_runs() (e.g. create_invocation() raising), which is the
+        leak this wrapper exists to close.
+        """
+        try:
+            await self._fire_inner(
+                schedule,
+                run_id,
+                trigger_context=trigger_context,
+                chain_parent_id=chain_parent_id,
+                chain_depth=chain_depth,
+            )
+        finally:
+            if max_runs_claim is not None:
+                max_runs_claim.release()
+
+    async def _fire_inner(
         self,
         schedule: dict,
         run_id: str,

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -97,6 +97,11 @@ class SchedulerEngine:
         self._fire_tasks: set[asyncio.Task] = set()
         self._last_reaper_run: float = 0.0
         self._last_checkpoint_run: float = 0.0
+        # max_runs budget reservation (single-process; see _reserve_max_runs_budget).
+        self._max_runs_lock = asyncio.Lock()
+        self._max_runs_inflight: dict[
+            str, int
+        ] = {}  # schedule_id -> claimed-not-yet-terminal count
 
     async def start(self) -> None:
         _log.info("Scheduler engine starting")
@@ -220,6 +225,11 @@ class SchedulerEngine:
         schedule = await self._svc.get_schedule(schedule_id)
         if not schedule:
             return None
+        if not await self._reserve_max_runs_budget(schedule):
+            raise ValueError(
+                f"Schedule {schedule_id!r} has already reached its max_runs="
+                f"{schedule.get('max_runs')} limit; manual trigger refused."
+            )
         run_id = uuid.uuid4().hex[:12]
         self._tracked_fire(
             schedule, run_id, trigger_context={"manual": True, "fired_at": time.time()}
@@ -390,6 +400,13 @@ class SchedulerEngine:
 
         new_events = await github_poll(schedule)
         if new_events:
+            if not await self._reserve_max_runs_budget(schedule):
+                _log.info(
+                    "Schedule %s (%s) has exhausted max_runs; skipping github_poll fire",
+                    schedule.get("name"),
+                    schedule["id"],
+                )
+                return
             ctx = {
                 "github_events": new_events,
                 "repo": schedule.get("github_repo"),
@@ -397,6 +414,41 @@ class SchedulerEngine:
             }
             run_id = uuid.uuid4().hex[:12]
             await self._fire(schedule, run_id, trigger_context=ctx)
+
+    async def _reserve_max_runs_budget(self, schedule: dict) -> bool:
+        """Atomically claim one top-level fire against schedule['max_runs'].
+
+        Returns True if the fire may proceed, False if the schedule has
+        already consumed its budget (persisted terminal runs plus runs
+        already claimed-but-not-yet-terminal in this process). Guarded by
+        an engine-wide lock so concurrent callers — the tick loop,
+        fire_now(), github polling — can't both read the same count and
+        both claim it before either claim is visible. This is the
+        single-process analogue of a DB-backed compare-and-set; only one
+        scheduler process runs today, so a DB-backed reservation is not
+        needed. Chain children (chain_depth>0) never call this — only
+        top-level fires consume budget. The claim is released in
+        _check_max_runs() once the fire it was reserved for reaches a
+        terminal status.
+        """
+        max_runs = schedule.get("max_runs")
+        if not max_runs:
+            return True
+        sid = schedule["id"]
+        async with self._max_runs_lock:
+            used = await self._svc.count_schedule_runs(sid, chain_depth=0)
+            inflight = self._max_runs_inflight.get(sid, 0)
+            if used + inflight >= max_runs:
+                return False
+            self._max_runs_inflight[sid] = inflight + 1
+            return True
+
+    def _release_max_runs_claim(self, schedule_id: str) -> None:
+        remaining = self._max_runs_inflight.get(schedule_id, 0) - 1
+        if remaining > 0:
+            self._max_runs_inflight[schedule_id] = remaining
+        else:
+            self._max_runs_inflight.pop(schedule_id, None)
 
     async def _maybe_fire(self, schedule: dict, now: float) -> None:
         if schedule.get("overlap_policy") == "skip" and schedule["id"] in self._running:
@@ -417,6 +469,16 @@ class SchedulerEngine:
                 await self._svc.update_schedule(schedule["id"], next_fire_at=next_at)
             return
 
+        if not await self._reserve_max_runs_budget(schedule):
+            _log.info(
+                "Schedule %s (%s) has exhausted max_runs=%s; disabling instead of firing",
+                schedule.get("name"),
+                schedule["id"],
+                schedule.get("max_runs"),
+            )
+            await self._svc.update_schedule(schedule["id"], enabled=0)
+            return
+
         run_id = uuid.uuid4().hex[:12]
         ctx = {"scheduled": True, "fired_at": now, "next_fire_at": schedule.get("next_fire_at")}
         self._tracked_fire(schedule, run_id, trigger_context=ctx)
@@ -428,14 +490,18 @@ class SchedulerEngine:
         chain children are follow-on actions of a single top-level run, not
         additional scheduled runs, so they never count toward it. Reuses the
         existing enabled flag (the same mechanism enable/disable already use)
-        rather than introducing a new schedule state.
+        rather than introducing a new schedule state. Also releases this
+        fire's in-process max_runs claim (see _reserve_max_runs_budget) now
+        that it has reached a terminal status — a no-op if no claim was
+        reserved (max_runs unset).
         """
         if chain_depth != 0:
             return
+        sid = schedule["id"]
+        self._release_max_runs_claim(sid)
         max_runs = schedule.get("max_runs")
         if not max_runs:
             return
-        sid = schedule["id"]
         count = await self._svc.count_schedule_runs(sid, chain_depth=0)
         if count >= max_runs:
             _log.info(

--- a/lionagi/studio/services/scheduler_state.py
+++ b/lionagi/studio/services/scheduler_state.py
@@ -27,6 +27,8 @@ class SchedulerStateService(Protocol):
 
     async def update_schedule(self, schedule_id: str, **fields: Any) -> None: ...
 
+    async def count_schedule_runs(self, schedule_id: str, *, chain_depth: int = 0) -> int: ...
+
     async def create_schedule_run(self, run: dict[str, Any]) -> None: ...
 
     async def update_schedule_run(self, run_id: str, **fields: Any) -> None: ...
@@ -66,6 +68,10 @@ class _DBSchedulerStateService:
     async def update_schedule(self, schedule_id: str, **fields: Any) -> None:
         async with StateDB() as db:
             await db.update_schedule(schedule_id, **fields)
+
+    async def count_schedule_runs(self, schedule_id: str, *, chain_depth: int = 0) -> int:
+        async with StateDB() as db:
+            return await db.count_schedule_runs(schedule_id, chain_depth=chain_depth)
 
     async def create_schedule_run(self, run: dict[str, Any]) -> None:
         async with StateDB() as db:

--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -87,6 +87,17 @@ def _svc_validate_cron_expr(expr: str | None, *, required: bool = False) -> None
         raise ValueError(f"Invalid cron expression: {expr!r}")
 
 
+def _svc_validate_max_runs(max_runs: Any) -> None:
+    """Service-boundary check: reject a non-positive max_runs.
+
+    None means unlimited (the column default) and is always accepted.
+    """
+    if max_runs is None:
+        return
+    if isinstance(max_runs, bool) or not isinstance(max_runs, int) or max_runs < 1:
+        raise ValueError(f"max_runs must be a positive integer, got {max_runs!r}")
+
+
 def _svc_validate_interval_sec(interval: Any, *, required: bool = False) -> None:
     """Service-boundary check: reject a missing or non-positive interval.
 
@@ -254,6 +265,7 @@ CREATE TABLE IF NOT EXISTS schedules (
     next_fire_at        REAL,
     missed_fire_policy  TEXT    NOT NULL DEFAULT 'skip',
     overlap_policy      TEXT    NOT NULL DEFAULT 'skip',
+    max_runs            INTEGER,
     project             TEXT,
     created_at          REAL    NOT NULL,
     updated_at          REAL    NOT NULL
@@ -300,6 +312,10 @@ async def list_schedules(
         return []
     async with StateDB() as db:
         rows = await db.list_schedules(enabled=enabled, trigger_type=trigger_type, project=project)
+        for row in rows:
+            if row.get("max_runs"):
+                used = await db.count_schedule_runs(row["id"], chain_depth=0)
+                row["remaining_runs"] = max(row["max_runs"] - used, 0)
     return rows
 
 
@@ -311,6 +327,9 @@ async def get_schedule(schedule_id: str) -> dict[str, Any] | None:
         if not row:
             return None
         runs = await db.list_schedule_runs(schedule_id, limit=10)
+        if row.get("max_runs"):
+            used = await db.count_schedule_runs(schedule_id, chain_depth=0)
+            row["remaining_runs"] = max(row["max_runs"] - used, 0)
     row["recent_runs"] = runs
     return row
 
@@ -337,6 +356,7 @@ async def create_schedule(data: dict[str, Any]) -> dict[str, Any]:
     _svc_validate_identifier(data.get("action_playbook"), "action_playbook")
     _svc_validate_extra_args(data.get("action_extra_args"))
     _svc_validate_github_repo(data.get("github_repo"))
+    _svc_validate_max_runs(data.get("max_runs"))
     if data.get("trigger_type") == "cron":
         _svc_validate_cron_expr(data.get("cron_expr"), required=True)
     if data.get("trigger_type") == "interval":
@@ -395,6 +415,8 @@ async def update_schedule(schedule_id: str, fields: dict[str, Any]) -> bool:
             _svc_validate_extra_args(fields["action_extra_args"])
         if "github_repo" in fields:
             _svc_validate_github_repo(fields["github_repo"])
+        if "max_runs" in fields:
+            _svc_validate_max_runs(fields["max_runs"])
 
         effective = {**schedule, **fields}
         effective_repo = effective.get("github_repo")
@@ -524,6 +546,7 @@ class CreateScheduleRequest(BaseModel):
     on_fail: dict | None = None
     missed_fire_policy: str = "skip"
     overlap_policy: str = "skip"
+    max_runs: int | None = None
     project: str | None = None
 
 
@@ -548,6 +571,7 @@ class UpdateScheduleRequest(BaseModel):
     on_fail: dict | None = None
     missed_fire_policy: str | None = None
     overlap_policy: str | None = None
+    max_runs: int | None = None
     project: str | None = None
 
 

--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -467,6 +467,23 @@ async def enable_schedule(schedule_id: str) -> bool:
             _svc_validate_cron_expr(schedule.get("cron_expr"), required=True)
         if schedule.get("trigger_type") == "interval":
             _svc_validate_interval_sec(schedule.get("interval_sec"), required=True)
+        # Re-enable semantics: a bounded schedule that has already consumed
+        # its max_runs budget stays refused rather than silently resetting
+        # the counter. There is no per-enable-cycle counting — max_runs is a
+        # lifetime cap on the schedule's id, not a cap per enabled period —
+        # so enabling it would either immediately re-trip _check_max_runs on
+        # the next fire (confusing) or require introducing new schema state
+        # to track "cycles", which is more machinery than this footgun
+        # warrants. Raise so the caller can increase/clear max_runs first.
+        max_runs = schedule.get("max_runs")
+        if max_runs:
+            used = await db.count_schedule_runs(schedule_id, chain_depth=0)
+            if used >= max_runs:
+                raise ValueError(
+                    f"Schedule '{schedule_id}' has already reached its max_runs="
+                    f"{max_runs} limit ({used} terminal run(s) recorded). "
+                    "Increase or clear max_runs before re-enabling."
+                )
         await db.update_schedule(schedule_id, enabled=1)
 
     # A schedule can sit disabled for a long time; its stored next_fire_at
@@ -687,7 +704,10 @@ async def disable_schedule_route(schedule_id: str) -> dict[str, Any]:
 async def trigger_schedule_route(schedule_id: str) -> dict[str, Any]:
     from ..scheduler.engine import scheduler
 
-    run_id = await scheduler.fire_now(schedule_id)
+    try:
+        run_id = await scheduler.fire_now(schedule_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     if run_id is None:
         raise HTTPException(status_code=404, detail=f"Schedule '{schedule_id}' not found")
     return {"ok": True, "run_id": run_id}

--- a/tests/cli/test_schedule_cli.py
+++ b/tests/cli/test_schedule_cli.py
@@ -772,3 +772,126 @@ def test_warn_if_cron_far_out_no_croniter_is_noop(monkeypatch):
     monkeypatch.setattr(builtins, "__import__", _fake_import)
     # Should not raise.
     sched_mod._warn_if_cron_far_out("0 0 29 2 *")
+
+
+# ---------------------------------------------------------------------------
+# Near-miss flag suggestions (li schedule ...)
+# ---------------------------------------------------------------------------
+
+
+def test_suggest_schedule_flag_synonym_map():
+    from lionagi.studio.cli import add_schedule_subparser, suggest_schedule_flag
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)  # populates _ALL_SCHEDULE_FLAGS
+
+    assert suggest_schedule_flag("--every") == "--interval"
+    assert suggest_schedule_flag("--at") == "--cron"
+    assert suggest_schedule_flag("--action") == "--action-kind"
+    assert suggest_schedule_flag("--on_success") == "--on-success"
+    assert suggest_schedule_flag("--on_fail") == "--on-fail"
+    assert suggest_schedule_flag("--max_runs") == "--max-runs"
+
+
+def test_suggest_schedule_flag_fuzzy_typo():
+    from lionagi.studio.cli import add_schedule_subparser, suggest_schedule_flag
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+
+    assert suggest_schedule_flag("--corn") == "--cron"
+
+
+def test_suggest_schedule_flag_no_match_returns_none():
+    from lionagi.studio.cli import add_schedule_subparser, suggest_schedule_flag
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+
+    assert suggest_schedule_flag("--completely-unrelated-xyz") is None
+
+
+def test_li_schedule_unrecognized_flag_suggests_correction(monkeypatch, capsys):
+    """`li schedule create ... --every 60` produces a did-you-mean, not argparse noise."""
+    from lionagi.cli.main import main
+
+    rc = main(["schedule", "create", "my-sched", "--every", "60"])
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "--every" in err
+    assert "--interval" in err
+
+
+def test_li_schedule_unrecognized_underscore_on_success_suggests_dash(monkeypatch, capsys):
+    from lionagi.cli.main import main
+
+    rc = main(
+        [
+            "schedule",
+            "create",
+            "my-sched",
+            "--cron",
+            "0 * * * *",
+            "--on_success",
+            '{"prompt": "x"}',
+        ]
+    )
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "--on_success" in err
+    assert "--on-success" in err
+
+
+def test_li_schedule_unrecognized_flag_with_no_suggestion(monkeypatch, capsys):
+    from lionagi.cli.main import main
+
+    rc = main(["schedule", "create", "my-sched", "--totally-bogus-flag", "x"])
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "unrecognized argument" in err
+
+
+def test_li_schedule_recognized_flags_still_dispatch(monkeypatch):
+    """Sanity check: the new interception path does not break normal dispatch."""
+    import lionagi.studio.cli as sched_mod
+    from lionagi.cli.main import main
+
+    monkeypatch.setattr(sched_mod, "_api", lambda path, **kw: {"schedules": []})
+
+    rc = main(["schedule", "list"])
+    assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Help epilogs render for every subcommand
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "subcommand", ["list", "get", "create", "enable", "disable", "trigger", "delete", "runs"]
+)
+def test_schedule_subcommand_help_has_example_epilog(capsys, subcommand):
+    from lionagi.cli.main import main
+
+    with pytest.raises(SystemExit) as exc:
+        main(["schedule", subcommand, "--help"])
+    assert exc.value.code == 0
+
+    out = capsys.readouterr().out
+    assert "Example" in out
+
+
+def test_schedule_create_help_repeats_shallow_merge_caveat(capsys):
+    from lionagi.cli.main import main
+
+    with pytest.raises(SystemExit):
+        main(["schedule", "create", "--help"])
+
+    out = capsys.readouterr().out
+    assert "shallow-merge" in out or "shallow merge" in out

--- a/tests/cli/test_schedule_cli.py
+++ b/tests/cli/test_schedule_cli.py
@@ -608,3 +608,167 @@ def test_schedule_create_nested_chain_missing_on_success_warns(monkeypatch):
     assert len(warnings) == 1
     assert "--on-success.on_success" in warnings[0]
     assert "re-fire" in warnings[0]
+
+
+# ---------------------------------------------------------------------------
+# _cmd_create: --once / --max-runs (one-shot semantics)
+# ---------------------------------------------------------------------------
+
+
+def test_schedule_create_once_maps_to_max_runs_1(monkeypatch):
+    """--once is sugar for --max-runs 1."""
+    outcome = _run_create(monkeypatch, ["--once"])
+
+    assert outcome["result"] == 0
+    assert outcome["body"]["max_runs"] == 1
+
+
+def test_schedule_create_max_runs_explicit(monkeypatch):
+    """--max-runs N is passed through to the request body as-is."""
+    outcome = _run_create(monkeypatch, ["--max-runs", "5"])
+
+    assert outcome["result"] == 0
+    assert outcome["body"]["max_runs"] == 5
+
+
+def test_schedule_create_without_max_runs_or_once_omits_field(monkeypatch):
+    """Neither flag given: max_runs is absent from the body (unlimited)."""
+    outcome = _run_create(monkeypatch, [])
+
+    assert outcome["result"] == 0
+    assert "max_runs" not in outcome["body"]
+
+
+def test_schedule_create_once_and_max_runs_together_rejected(monkeypatch, capsys):
+    """--once and --max-runs are mutually exclusive."""
+    api_called = []
+    import lionagi.studio.cli as sched_mod
+
+    monkeypatch.setattr(sched_mod, "_api", lambda *a, **kw: api_called.append(1))
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(
+        ["schedule", "create", "my-sched", "--cron", "0 * * * *", "--once", "--max-runs", "2"]
+    )
+    result = run_schedule(args)
+
+    assert result == 1
+    assert not api_called
+    assert "mutually exclusive" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("bad_value", [0, -1])
+def test_schedule_create_max_runs_rejects_non_positive(monkeypatch, capsys, bad_value):
+    """--max-runs 0 or a negative integer is rejected before hitting the API."""
+    api_called = []
+    import lionagi.studio.cli as sched_mod
+
+    monkeypatch.setattr(sched_mod, "_api", lambda *a, **kw: api_called.append(1))
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(
+        ["schedule", "create", "my-sched", "--cron", "0 * * * *", "--max-runs", str(bad_value)]
+    )
+    result = run_schedule(args)
+
+    assert result == 1
+    assert not api_called
+    assert "positive integer" in capsys.readouterr().err
+
+
+def test_schedule_list_shows_remaining_runs(monkeypatch, capsys):
+    """`li schedule list` prints remaining-runs info when max_runs is set."""
+    import lionagi.studio.cli as sched_mod
+
+    fake_schedules = [
+        {
+            "id": "s1",
+            "name": "one-shot",
+            "enabled": True,
+            "trigger_type": "cron",
+            "max_runs": 3,
+            "remaining_runs": 1,
+        },
+        {
+            "id": "s2",
+            "name": "unlimited",
+            "enabled": True,
+            "trigger_type": "interval",
+        },
+    ]
+    monkeypatch.setattr(sched_mod, "_api", lambda path, **kw: {"schedules": fake_schedules})
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(["schedule", "list"])
+    result = run_schedule(args)
+
+    out = capsys.readouterr().out
+    lines = out.splitlines()
+    unlimited_line = next(line for line in lines if "unlimited" in line)
+
+    assert result == 0
+    assert "runs left: 1/3" in out
+    assert "runs left" not in unlimited_line
+
+
+# ---------------------------------------------------------------------------
+# Cron far-out warning (date-pinned one-shot footgun)
+# ---------------------------------------------------------------------------
+
+
+def test_warn_if_cron_far_out_warns_beyond_360_days(monkeypatch):
+    pytest.importorskip("croniter", reason="studio extra not installed")
+    import lionagi.studio.cli as sched_mod
+
+    warnings: list[str] = []
+    monkeypatch.setattr(sched_mod, "warn", warnings.append)
+
+    # A cron pinned to a date almost certainly >360 days from "now" in test runs:
+    # Feb 29 only exists every 4 years, so worst case is ~3 years out — always far.
+    sched_mod._warn_if_cron_far_out("0 0 29 2 *")
+
+    assert warnings
+    assert "days" in warnings[0]
+
+
+def test_warn_if_cron_far_out_silent_when_near(monkeypatch):
+    pytest.importorskip("croniter", reason="studio extra not installed")
+    import lionagi.studio.cli as sched_mod
+
+    warnings: list[str] = []
+    monkeypatch.setattr(sched_mod, "warn", warnings.append)
+
+    # Fires hourly — always within a day.
+    sched_mod._warn_if_cron_far_out("0 * * * *")
+
+    assert not warnings
+
+
+def test_warn_if_cron_far_out_no_croniter_is_noop(monkeypatch):
+    """Missing the optional `studio` extra's croniter dep must never break create."""
+    import builtins
+
+    import lionagi.studio.cli as sched_mod
+
+    real_import = builtins.__import__
+
+    def _fake_import(name, *args, **kwargs):
+        if name == "croniter":
+            raise ImportError("no croniter")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+    # Should not raise.
+    sched_mod._warn_if_cron_far_out("0 0 29 2 *")

--- a/tests/cli/test_schedule_cli.py
+++ b/tests/cli/test_schedule_cli.py
@@ -895,3 +895,58 @@ def test_schedule_create_help_repeats_shallow_merge_caveat(capsys):
 
     out = capsys.readouterr().out
     assert "shallow-merge" in out or "shallow merge" in out
+
+
+# ---------------------------------------------------------------------------
+# li schedule: surplus non-flag arguments must error (rc=2), not be ignored
+# ---------------------------------------------------------------------------
+
+
+def test_li_schedule_surplus_non_flag_argument_errors(monkeypatch, capsys):
+    """`li schedule list unexpected-extra` must not silently exit 0 and drop
+    the extra token — argparse would reject the equivalent direct parse."""
+    import lionagi.studio.cli as sched_mod
+    from lionagi.cli.main import main
+
+    api_called = []
+    monkeypatch.setattr(sched_mod, "_api", lambda *a, **kw: api_called.append(1))
+
+    rc = main(["schedule", "list", "unexpected-extra"])
+
+    assert rc == 2
+    assert not api_called
+    err = capsys.readouterr().err
+    assert "unrecognized argument" in err
+    assert "unexpected-extra" in err
+
+
+def test_li_schedule_surplus_extra_after_required_positional_errors(monkeypatch, capsys):
+    """A surplus positional after a subcommand's own required id (e.g.
+    `delete <id> <extra>`) must also error rather than silently execute."""
+    import lionagi.studio.cli as sched_mod
+    from lionagi.cli.main import main
+
+    api_called = []
+    monkeypatch.setattr(sched_mod, "_api", lambda *a, **kw: api_called.append(1))
+
+    rc = main(["schedule", "delete", "sched-123", "accidental-extra"])
+
+    assert rc == 2
+    assert not api_called
+    err = capsys.readouterr().err
+    assert "unrecognized argument" in err
+    assert "accidental-extra" in err
+
+
+def test_li_schedule_mixed_dash_and_bare_extras_both_reported(monkeypatch, capsys):
+    """A dash-prefixed unknown flag alongside a bare surplus token: the flag
+    gets a did-you-mean, the bare token gets a plain unrecognized-argument
+    error — neither is silently dropped."""
+    from lionagi.cli.main import main
+
+    rc = main(["schedule", "create", "my-sched", "--every", "60", "stray-token"])
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "--every" in err and "--interval" in err
+    assert "stray-token" in err

--- a/tests/state/test_migrations.py
+++ b/tests/state/test_migrations.py
@@ -274,3 +274,113 @@ async def test_statedb_open_exposes_migration_columns():
             )
 
     await state.close()
+
+
+# ── max_runs / count_schedule_runs (one-shot semantics) ──────────────────────
+
+
+async def test_count_schedule_runs_excludes_skipped_and_running():
+    """count_schedule_runs only counts terminal, top-level (chain_depth=0) runs."""
+    from lionagi.state.db import StateDB
+
+    state = StateDB(":memory:")
+    await state.open()
+
+    await state.create_schedule(
+        {
+            "id": "sched-count-1",
+            "name": "count-test",
+            "trigger_type": "interval",
+            "interval_sec": 60,
+            "action_kind": "agent",
+        }
+    )
+    statuses = ["completed", "failed", "cancelled", "skipped", "running"]
+    for i, status in enumerate(statuses):
+        await state.create_schedule_run(
+            {
+                "id": f"run-{i}",
+                "schedule_id": "sched-count-1",
+                "trigger_context": {},
+                "action_kind": "agent",
+                "action_args": [],
+                "status": status,
+                "chain_depth": 0,
+                "fired_at": 1.0,
+            }
+        )
+
+    count = await state.count_schedule_runs("sched-count-1", chain_depth=0)
+    assert count == 3  # completed, failed, cancelled — not skipped, not running
+
+    await state.close()
+
+
+async def test_count_schedule_runs_excludes_chain_children():
+    """Chain children (chain_depth>0) never count toward the parent's max_runs."""
+    from lionagi.state.db import StateDB
+
+    state = StateDB(":memory:")
+    await state.open()
+
+    await state.create_schedule(
+        {
+            "id": "sched-count-2",
+            "name": "count-test-chain",
+            "trigger_type": "interval",
+            "interval_sec": 60,
+            "action_kind": "agent",
+        }
+    )
+    await state.create_schedule_run(
+        {
+            "id": "run-parent",
+            "schedule_id": "sched-count-2",
+            "trigger_context": {},
+            "action_kind": "agent",
+            "action_args": [],
+            "status": "completed",
+            "chain_depth": 0,
+            "fired_at": 1.0,
+        }
+    )
+    await state.create_schedule_run(
+        {
+            "id": "run-child",
+            "schedule_id": "sched-count-2",
+            "trigger_context": {},
+            "action_kind": "agent",
+            "action_args": [],
+            "status": "completed",
+            "chain_depth": 1,
+            "chain_parent_id": "run-parent",
+            "fired_at": 2.0,
+        }
+    )
+
+    count = await state.count_schedule_runs("sched-count-2", chain_depth=0)
+    assert count == 1
+
+    await state.close()
+
+
+async def test_max_runs_nullable_defaults_unlimited():
+    """A schedule created without max_runs stores it as NULL, not counted against."""
+    from lionagi.state.db import StateDB
+
+    state = StateDB(":memory:")
+    await state.open()
+
+    await state.create_schedule(
+        {
+            "id": "sched-unlimited",
+            "name": "unlimited-test",
+            "trigger_type": "interval",
+            "interval_sec": 60,
+            "action_kind": "agent",
+        }
+    )
+    fetched = await state.get_schedule("sched-unlimited")
+    assert fetched["max_runs"] is None
+
+    await state.close()

--- a/tests/studio/test_schedule_tz_recompute.py
+++ b/tests/studio/test_schedule_tz_recompute.py
@@ -863,3 +863,70 @@ async def test_enable_dead_interval_schedule_rejected(temp_db_path):
 
     with pytest.raises(ValueError, match="interval_sec is required"):
         await enable_schedule(sid)
+
+
+@pytest.mark.asyncio
+async def test_enable_exhausted_max_runs_schedule_rejected(temp_db_path):
+    """Re-enable semantics: a bounded schedule that already consumed its
+    max_runs budget refuses to re-enable rather than silently resetting the
+    counter (there is no per-enable-cycle counting — max_runs is a lifetime
+    cap on the schedule id)."""
+    from lionagi.state.db import StateDB
+    from lionagi.studio.services.schedules import create_schedule, disable_schedule, enable_schedule
+
+    created = await create_schedule(
+        {
+            "name": "exhausted-once-test",
+            "trigger_type": "interval",
+            "interval_sec": 60,
+            "action_kind": "agent",
+            "action_prompt": "ping",
+            "max_runs": 1,
+        }
+    )
+    sid = created["id"]
+
+    async with StateDB() as db:
+        await db.create_schedule_run(
+            {
+                "id": "old-run",
+                "schedule_id": sid,
+                "trigger_context": {},
+                "action_kind": "agent",
+                "action_args": [],
+                "status": "completed",
+                "chain_depth": 0,
+                "fired_at": time.time(),
+            }
+        )
+    await disable_schedule(sid)
+
+    with pytest.raises(ValueError, match="max_runs"):
+        await enable_schedule(sid)
+
+    async with StateDB() as db:
+        row = await db.get_schedule(sid)
+    assert row["enabled"] == 0
+
+
+@pytest.mark.asyncio
+async def test_enable_bounded_schedule_under_budget_succeeds(temp_db_path):
+    """A bounded schedule that has NOT yet consumed its max_runs budget
+    re-enables normally."""
+    from lionagi.studio.services.schedules import create_schedule, disable_schedule, enable_schedule
+
+    created = await create_schedule(
+        {
+            "name": "under-budget-test",
+            "trigger_type": "interval",
+            "interval_sec": 60,
+            "action_kind": "agent",
+            "action_prompt": "ping",
+            "max_runs": 3,
+        }
+    )
+    sid = created["id"]
+    await disable_schedule(sid)
+
+    ok = await enable_schedule(sid)
+    assert ok is True

--- a/tests/studio/test_scheduler_engine.py
+++ b/tests/studio/test_scheduler_engine.py
@@ -54,6 +54,7 @@ def _make_svc() -> AsyncMock:
     svc.update_invocation = AsyncMock()
     svc.update_status = AsyncMock()
     svc.list_sessions_for_invocation = AsyncMock(return_value=[])
+    svc.count_schedule_runs = AsyncMock(return_value=0)
     return svc
 
 
@@ -1115,3 +1116,140 @@ async def test_recompute_armed_cron_schedules_unchanged_no_log(monkeypatch, capl
 
     svc.update_schedule.assert_not_awaited()
     assert not any("shifted" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# max_runs / one-shot semantics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_max_runs_reached_auto_disables_schedule():
+    """Once fired top-level runs hit max_runs, the schedule is disabled."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.count_schedule_runs = AsyncMock(return_value=3)
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(max_runs=3)
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await engine._fire(schedule, "run-once-1", trigger_context={"scheduled": True})
+
+    svc.count_schedule_runs.assert_awaited_with("sched-001", chain_depth=0)
+    disable_calls = [c for c in svc.update_schedule.await_args_list if c.kwargs.get("enabled") == 0]
+    assert disable_calls, "Expected update_schedule(..., enabled=0) once max_runs is reached"
+
+
+@pytest.mark.asyncio
+async def test_max_runs_not_reached_leaves_schedule_enabled():
+    """Fewer fired runs than max_runs must not touch the enabled flag."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.count_schedule_runs = AsyncMock(return_value=1)
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(max_runs=3)
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await engine._fire(schedule, "run-once-2", trigger_context={"scheduled": True})
+
+    disable_calls = [c for c in svc.update_schedule.await_args_list if c.kwargs.get("enabled") == 0]
+    assert not disable_calls
+
+
+@pytest.mark.asyncio
+async def test_max_runs_none_is_unlimited_never_checks_count():
+    """max_runs=None (the default/unlimited case) must not query run counts at all."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()  # no max_runs key -> schedule.get("max_runs") is None
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await engine._fire(schedule, "run-unlimited", trigger_context={"scheduled": True})
+
+    svc.count_schedule_runs.assert_not_awaited()
+    disable_calls = [c for c in svc.update_schedule.await_args_list if c.kwargs.get("enabled") == 0]
+    assert not disable_calls
+
+
+@pytest.mark.asyncio
+async def test_max_runs_chain_child_never_checked():
+    """chain_depth>0 (on_success/on_fail children) never consumes the parent's budget."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(max_runs=1)
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await engine._fire(
+            schedule,
+            "run-child",
+            trigger_context={"scheduled": True},
+            chain_depth=1,
+            chain_parent_id="run-parent",
+        )
+
+    svc.count_schedule_runs.assert_not_awaited()
+    disable_calls = [c for c in svc.update_schedule.await_args_list if c.kwargs.get("enabled") == 0]
+    assert not disable_calls
+
+
+@pytest.mark.asyncio
+async def test_max_runs_build_argv_exception_still_checked():
+    """A build_argv failure still records a terminal run and checks max_runs."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.count_schedule_runs = AsyncMock(return_value=1)
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(max_runs=1)
+
+    with patch(
+        "lionagi.studio.scheduler.subprocess.build_argv",
+        side_effect=ValueError("bad action_kind"),
+    ):
+        await engine._fire(schedule, "run-badargv", trigger_context={"scheduled": True})
+
+    svc.count_schedule_runs.assert_awaited_with("sched-001", chain_depth=0)
+    disable_calls = [c for c in svc.update_schedule.await_args_list if c.kwargs.get("enabled") == 0]
+    assert disable_calls

--- a/tests/studio/test_scheduler_engine.py
+++ b/tests/studio/test_scheduler_engine.py
@@ -1480,3 +1480,70 @@ async def test_max_runs_claim_released_on_pre_run_failure_allows_retry():
     assert await svc.count_schedule_runs("sched-once", chain_depth=0) == 1
     disable_calls = [c for c in svc.schedule_updates if c[1].get("enabled") == 0]
     assert disable_calls  # exactly max_runs=1 total run reached; auto-disabled
+
+
+@pytest.mark.asyncio
+async def test_max_runs_reservation_snapshots_inflight_before_stale_count_read():
+    """Pins the round-3 finding: a concurrent reserve must not overshoot
+    max_runs by combining a stale persisted count with an already-released
+    in-flight claim.
+
+    Forces the exact interleaving the reviewer's reproducer exploited:
+    fire A holds a claim (in-flight, not yet terminal). Reserve B starts its
+    admission check and its count_schedule_runs() read is suspended
+    mid-flight. While B is suspended, A completes: its terminal run is
+    recorded AND its claim is released — both entirely inside B's await
+    window. B's count() then resumes and returns the count as it was
+    when the read started (stale — before A's write), simulating a real
+    DB read that began before the write landed. If _reserve_max_runs_budget
+    read `inflight` only after this await (the round-2 shape), it would see
+    inflight=0 (already released) + used=0 (stale) and incorrectly admit a
+    second top-level fire for max_runs=1. Reading `inflight` before the
+    await (the round-3 fix) must still see A's claim and refuse B."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _StatefulSvc()
+    engine = SchedulerEngine(svc)
+    schedule = _minimal_schedule(id="sched-once", max_runs=1)
+
+    # Fire A claims the budget first (simulates A's fire already in-flight,
+    # not yet terminal).
+    allowed_a, claim_a = await engine._reserve_max_runs_budget(schedule)
+    assert allowed_a
+    assert claim_a is not None
+    assert engine._max_runs_inflight.get("sched-once") == 1
+
+    count_started = asyncio.Event()
+    resume_count = asyncio.Event()
+    real_count = svc.count_schedule_runs
+
+    async def stalling_count(schedule_id, *, chain_depth=0):
+        # Read the count as of THIS moment (before A's terminal write
+        # lands), but don't return it until told to -- after A has both
+        # recorded its terminal run and released its claim.
+        snapshot = await real_count(schedule_id, chain_depth=chain_depth)
+        count_started.set()
+        await resume_count.wait()
+        return snapshot
+
+    svc.count_schedule_runs = stalling_count
+
+    b_task = asyncio.create_task(engine._reserve_max_runs_budget(schedule))
+    await count_started.wait()
+
+    # Fire A "completes" while B's count read is still suspended: record its
+    # terminal run, then release its claim -- exactly what _fire()'s finally
+    # does at the end of a real fire.
+    await svc.create_schedule_run(
+        {"id": "run-a", "schedule_id": "sched-once", "chain_depth": 0, "status": "completed"}
+    )
+    claim_a.release()
+    assert engine._max_runs_inflight.get("sched-once", 0) == 0
+
+    resume_count.set()
+    allowed_b, claim_b = await b_task
+
+    assert not allowed_b
+    assert claim_b is None
+    # Exactly one terminal run for max_runs=1 -- B must not have overshot it.
+    assert await real_count("sched-once", chain_depth=0) == 1

--- a/tests/studio/test_scheduler_engine.py
+++ b/tests/studio/test_scheduler_engine.py
@@ -1253,3 +1253,175 @@ async def test_max_runs_build_argv_exception_still_checked():
     svc.count_schedule_runs.assert_awaited_with("sched-001", chain_depth=0)
     disable_calls = [c for c in svc.update_schedule.await_args_list if c.kwargs.get("enabled") == 0]
     assert disable_calls
+
+
+# ---------------------------------------------------------------------------
+# max_runs enforcement BEFORE firing (pre-flight reservation), not just after
+# ---------------------------------------------------------------------------
+
+
+class _StatefulSvc:
+    """Minimal stateful fake mirroring real StateDB run bookkeeping.
+
+    Unlike _make_svc()'s AsyncMock (fixed return values), this actually
+    records schedule_runs and derives count_schedule_runs() from them —
+    needed to pin the pre-flight max_runs reservation, which depends on the
+    real interaction between "check the count" and "record a new run".
+    """
+
+    def __init__(self, existing_runs: dict[str, dict] | None = None):
+        self.runs: dict[str, dict] = dict(existing_runs or {})
+        self.schedule_updates: list[tuple[str, dict]] = []
+
+    async def get_schedule(self, schedule_id):
+        return None
+
+    async def list_schedules(self, *, enabled=None):
+        return []
+
+    async def update_schedule(self, schedule_id, **fields):
+        self.schedule_updates.append((schedule_id, fields))
+
+    async def count_schedule_runs(self, schedule_id, *, chain_depth=0):
+        return sum(
+            1
+            for r in self.runs.values()
+            if r.get("schedule_id") == schedule_id
+            and r.get("chain_depth", 0) == chain_depth
+            and r.get("status") in {"completed", "failed", "cancelled"}
+        )
+
+    async def create_schedule_run(self, run):
+        self.runs[run["id"]] = dict(run)
+
+    async def update_schedule_run(self, run_id, **fields):
+        self.runs[run_id].update(fields)
+
+    async def create_invocation(self, invocation):
+        pass
+
+    async def update_invocation(self, inv_id, **fields):
+        pass
+
+    async def update_status(self, entity_type, entity_id, *, new_status, **kwargs):
+        if entity_type == "schedule_run":
+            self.runs[entity_id]["status"] = new_status
+
+    async def list_sessions_for_invocation(self, invocation_id):
+        return []
+
+
+@pytest.mark.asyncio
+async def test_max_runs_exhausted_schedule_refuses_to_fire_again():
+    """A schedule that already has a terminal run at its max_runs cap must not
+    fire again — the budget check happens BEFORE queueing the fire, not only
+    after it completes."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _StatefulSvc(
+        existing_runs={
+            "old-run": {"schedule_id": "sched-once", "chain_depth": 0, "status": "completed"}
+        }
+    )
+    engine = SchedulerEngine(svc)
+    schedule = _minimal_schedule(id="sched-once", max_runs=1)
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["true"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await engine._maybe_fire(schedule, now=1000.0)
+        await asyncio.gather(*list(engine._fire_tasks))
+
+    assert await svc.count_schedule_runs("sched-once", chain_depth=0) == 1
+    disable_calls = [c for c in svc.schedule_updates if c[1].get("enabled") == 0]
+    assert disable_calls
+
+
+@pytest.mark.asyncio
+async def test_max_runs_sequential_maybe_fire_calls_do_not_overshoot():
+    """Two back-to-back _maybe_fire() calls for a fresh max_runs=1 schedule
+    must produce exactly one terminal run, not two — the pre-flight claim is
+    made (and visible) before the first call's background fire even starts
+    running, so the second call's check sees the claim."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _StatefulSvc()
+    engine = SchedulerEngine(svc)
+    schedule = _minimal_schedule(id="sched-once", max_runs=1)
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["true"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await engine._maybe_fire(schedule, now=1000.0)
+        await engine._maybe_fire(schedule, now=1000.0)
+        await asyncio.gather(*list(engine._fire_tasks))
+
+    assert len(svc.runs) == 1
+    assert sorted(r["status"] for r in svc.runs.values()) == ["completed"]
+
+
+@pytest.mark.asyncio
+async def test_max_runs_reservation_released_lets_next_schedule_check_run():
+    """After a claimed fire completes, its in-process reservation is released
+    so a later _maybe_fire() call correctly sees the up-to-date persisted
+    count (not an over-counted stale claim)."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _StatefulSvc()
+    engine = SchedulerEngine(svc)
+    schedule = _minimal_schedule(id="sched-multi", max_runs=2)
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["true"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await engine._maybe_fire(schedule, now=1000.0)
+        await asyncio.gather(*list(engine._fire_tasks))
+        assert engine._max_runs_inflight.get("sched-multi", 0) == 0
+
+        await engine._maybe_fire(schedule, now=1001.0)
+        await asyncio.gather(*list(engine._fire_tasks))
+
+    assert len(svc.runs) == 2
+    disable_calls = [c for c in svc.schedule_updates if c[1].get("enabled") == 0]
+    assert disable_calls  # the second fire reaches max_runs=2 and disables
+
+
+@pytest.mark.asyncio
+async def test_fire_now_refuses_manual_trigger_when_max_runs_exhausted():
+    """fire_now() (manual `li schedule trigger`) must also respect max_runs —
+    it is a top-level fire like any other."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _StatefulSvc(
+        existing_runs={
+            "old-run": {"schedule_id": "sched-once", "chain_depth": 0, "status": "completed"}
+        }
+    )
+    svc.get_schedule = AsyncMock(return_value=_minimal_schedule(id="sched-once", max_runs=1))
+    engine = SchedulerEngine(svc)
+
+    with pytest.raises(ValueError, match="max_runs"):
+        await engine.fire_now("sched-once")
+
+    assert len(engine._fire_tasks) == 0

--- a/tests/studio/test_scheduler_engine.py
+++ b/tests/studio/test_scheduler_engine.py
@@ -1269,9 +1269,15 @@ class _StatefulSvc:
     real interaction between "check the count" and "record a new run".
     """
 
-    def __init__(self, existing_runs: dict[str, dict] | None = None):
+    def __init__(
+        self,
+        existing_runs: dict[str, dict] | None = None,
+        fail_create_invocation_times: int = 0,
+    ):
         self.runs: dict[str, dict] = dict(existing_runs or {})
         self.schedule_updates: list[tuple[str, dict]] = []
+        self._fail_create_invocation_times = fail_create_invocation_times
+        self.create_invocation_calls = 0
 
     async def get_schedule(self, schedule_id):
         return None
@@ -1298,7 +1304,9 @@ class _StatefulSvc:
         self.runs[run_id].update(fields)
 
     async def create_invocation(self, invocation):
-        pass
+        self.create_invocation_calls += 1
+        if self.create_invocation_calls <= self._fail_create_invocation_times:
+            raise RuntimeError("transient invocation insert failure")
 
     async def update_invocation(self, inv_id, **fields):
         pass
@@ -1425,3 +1433,50 @@ async def test_fire_now_refuses_manual_trigger_when_max_runs_exhausted():
         await engine.fire_now("sched-once")
 
     assert len(engine._fire_tasks) == 0
+
+
+@pytest.mark.asyncio
+async def test_max_runs_claim_released_on_pre_run_failure_allows_retry():
+    """A max_runs claim must not leak when the fire fails before a terminal
+    schedule_run is ever recorded (e.g. create_invocation() raising).
+
+    Reproduces the round-2 finding: reserve the budget, let create_invocation
+    blow up once, confirm the claim is released (not stuck inflight with zero
+    terminal runs), then confirm a retry fire succeeds and the schedule
+    completes exactly max_runs times total — not zero (stuck) and not more
+    than max_runs (double-fired)."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _StatefulSvc(fail_create_invocation_times=1)
+    svc.get_schedule = AsyncMock(return_value=_minimal_schedule(id="sched-once", max_runs=1))
+    engine = SchedulerEngine(svc)
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["true"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        first = await engine.fire_now("sched-once")
+        await asyncio.gather(*list(engine._fire_tasks), return_exceptions=True)
+
+        # The first fire's create_invocation() raised before any terminal
+        # schedule_run was recorded — the claim must have been released, not
+        # left stuck inflight.
+        assert first is not None
+        assert await svc.count_schedule_runs("sched-once", chain_depth=0) == 0
+        assert engine._max_runs_inflight.get("sched-once", 0) == 0
+
+        # A retry must be allowed (the exhausted-budget ValueError must NOT
+        # fire here — that would mean the claim leaked) and must complete.
+        second = await engine.fire_now("sched-once")
+        await asyncio.gather(*list(engine._fire_tasks), return_exceptions=True)
+
+    assert second is not None
+    assert await svc.count_schedule_runs("sched-once", chain_depth=0) == 1
+    disable_calls = [c for c in svc.schedule_updates if c[1].get("enabled") == 0]
+    assert disable_calls  # exactly max_runs=1 total run reached; auto-disabled


### PR DESCRIPTION
## Summary

Two related improvements to `li schedule`, split into two commits.

**Commit 1 — one-shot semantics (`--once` / `--max-runs`)**

- Adds a nullable `max_runs` column to `schedules` (NULL = unlimited). Once a
  schedule's fired top-level runs reach `max_runs`, the engine auto-disables
  it via the existing `enabled` flag — no new schedule state introduced.
- `StateDB.count_schedule_runs()` counts only terminal, top-level runs:
  skipped missed-fires are excluded (they never ran), and `on_success`/
  `on_fail` chain children (`chain_depth > 0`) never consume the parent's
  budget.
- `SchedulerEngine._check_max_runs()` is checked at all four `_fire()`
  terminal branches (success/fail, build_argv exception, cancellation,
  generic exception).
- `li schedule create --max-runs N` / `--once` (sugar for `--max-runs 1`),
  mutually exclusive, rejects non-positive values. `li schedule list` shows
  remaining runs when `max_runs` is set.
- Best-effort warning at create time when a cron's computed `next_fire_at`
  is more than ~360 days out — this directly addresses the known footgun
  where a date-pinned one-shot cron created after its literal moment for
  this year silently waits a full year before firing (cron resolves in
  UTC; the warning is a heads-up, not a TZ semantics change). `croniter`
  is an optional (`studio`-extra) dependency, so the warning degrades to a
  no-op if it isn't installed.
- Along the way, fixed a pre-existing bug this change surfaced:
  `StateDB._drop_legacy_action_kind_check()` (the legacy rename→create→
  insert-select→drop path that rebuilds `schedules` to drop an old
  `action_kind` CHECK) had its own hardcoded `schedules_new` DDL that was
  out of sync with the live schema — it was missing several columns
  including the new `max_runs`, breaking the upgrade path for any
  pre-existing on-disk database.

**Commit 2 — help/UX pass**

- Every `li schedule` subcommand's `--help` now shows at least one
  realistic example via `epilog`. The `create` epilog includes a chained
  `--on-success` example that repeats the existing shallow-merge caveat
  so it's visible without reading the full flag help text.
- Near-miss flag suggestions scoped to the schedule parser: common wrong
  guesses (`--every`, `--at`, `--action`, `--on_success`, `--on_fail`,
  `--max_runs`) and generic close typos (e.g. `--corn`) now produce a
  one-line "did you mean --X?" instead of argparse's generic failure
  dump. Mirrors the existing `li agent` special-case in `main.py` — `li
  schedule ...` parses its own subparser directly via
  `parse_known_args()` before the generic dispatch, since argparse
  reports "unrecognized arguments" from the top-level parser rather than
  any nested subparser.
- No `docs/` page for `li schedule` exists (checked) — none added, per
  instruction to leave docs alone if there's nothing to update.

## Test plan

- [x] `tests/studio/test_scheduler_engine.py` — engine-level max_runs
      tests (reached → auto-disable, NULL unlimited unaffected, chain
      children never checked, build_argv-exception path still checked)
- [x] `tests/state/test_migrations.py` — `StateDB.count_schedule_runs`
      DB-level tests (status filtering, chain_depth filtering, NULL
      default)
- [x] `tests/cli/test_schedule_cli.py` — `--once`/`--max-runs` validation,
      remaining-runs list output, cron far-out warning, near-miss flag
      suggestions, help epilogs render
- [x] `tests/cli/test_schedule_cli_route_drift.py`,
      `tests/cli/test_scheduler_flow_yaml.py`,
      `tests/studio/test_scheduler_cwd.py`,
      `tests/studio/test_schedule_tz_recompute.py` — full existing suites
      still green
- [x] `ruff format --check` / `ruff check` clean on all touched files
- [x] Full 7-file sweep: **174 passed**, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
