### PR TITLE
feat(cli): per-profile default timeout + opt-in auto-resume-once for li agent

### DIFF
--- a/lionagi/cli/_providers.py
+++ b/lionagi/cli/_providers.py
@@ -390,28 +390,29 @@ def load_agent_profile(name: str) -> AgentProfile:
 
 
 def _parse_profile_timeout(name: str, raw: Any) -> int | None:
-    """Validate the profile 'timeout' field; warn and ignore garbage rather than raising."""
+    """Validate the profile 'timeout' field; warn and ignore garbage rather than raising.
+
+    Only a genuine positive int is accepted — YAML booleans (True/False are
+    ints in Python) and floats (which int() would silently truncate) are
+    rejected rather than coerced.
+    """
     if raw is None:
         return None
     from ._logging import warn
 
-    try:
-        value = int(raw)
-    except (TypeError, ValueError):
+    if isinstance(raw, bool) or not isinstance(raw, int):
         warn(f"agent profile {name!r}: ignoring invalid timeout {raw!r} (must be a positive int)")
         return None
-    if value <= 0:
-        warn(f"agent profile {name!r}: ignoring non-positive timeout {value!r}")
+    if raw <= 0:
+        warn(f"agent profile {name!r}: ignoring non-positive timeout {raw!r}")
         return None
-    return value
+    return raw
 
 
 def _parse_profile_resume_on_timeout(name: str, raw: Any) -> bool:
-    """Validate the profile 'resume_on_timeout' field; only 'once' (or a truthy bool) opts in."""
+    """Validate the profile 'resume_on_timeout' field; only the literal string 'once' opts in."""
     if raw is None or raw is False:
         return False
-    if raw is True:
-        return True
     if isinstance(raw, str) and raw.strip().lower() == "once":
         return True
     from ._logging import warn

--- a/lionagi/cli/_providers.py
+++ b/lionagi/cli/_providers.py
@@ -265,6 +265,19 @@ def add_common_cli_args(parser: argparse.ArgumentParser) -> None:
             "from .lionagi/config.toml or git remote."
         ),
     )
+    parser.add_argument(
+        "--resume-on-timeout",
+        dest="resume_on_timeout",
+        action="store_true",
+        default=False,
+        help=(
+            "If the run terminates on --timeout, automatically fire one "
+            "resume of the same session with 'continue and conclude the "
+            "task' and report the combined result. Bounded to a single "
+            "auto-resume; a timeout on the resumed leg terminates normally. "
+            "Same effect as an agent profile's 'resume_on_timeout: once'."
+        ),
+    )
 
 
 # ── Agent profile loading (absorbed from _agents.py) ─────────────────────────
@@ -310,6 +323,8 @@ class AgentProfile:
     artifact_defaults: dict | None = None
     timeout: int | None = None
     """Default --timeout (seconds) used when the CLI flag is not given."""
+    resume_on_timeout: bool = False
+    """Auto-resume-once on a timeout terminal status (profile 'resume_on_timeout: once')."""
     extra: dict = field(default_factory=dict)
 
 
@@ -391,6 +406,22 @@ def _parse_profile_timeout(name: str, raw: Any) -> int | None:
     return value
 
 
+def _parse_profile_resume_on_timeout(name: str, raw: Any) -> bool:
+    """Validate the profile 'resume_on_timeout' field; only 'once' (or a truthy bool) opts in."""
+    if raw is None or raw is False:
+        return False
+    if raw is True:
+        return True
+    if isinstance(raw, str) and raw.strip().lower() == "once":
+        return True
+    from ._logging import warn
+
+    warn(
+        f"agent profile {name!r}: ignoring unrecognized resume_on_timeout {raw!r} (expected 'once')"
+    )
+    return False
+
+
 def _parse_profile(name: str, text: str) -> AgentProfile:
     frontmatter, body = _parse_frontmatter(text)
 
@@ -414,6 +445,9 @@ def _parse_profile(name: str, text: str) -> AgentProfile:
         lion_system=lion_system,
         artifact_defaults=frontmatter.get("artifact_defaults"),
         timeout=_parse_profile_timeout(name, frontmatter.get("timeout")),
+        resume_on_timeout=_parse_profile_resume_on_timeout(
+            name, frontmatter.get("resume_on_timeout")
+        ),
         extra={
             k: v
             for k, v in frontmatter.items()
@@ -426,6 +460,7 @@ def _parse_profile(name: str, text: str) -> AgentProfile:
                 "lion_system",
                 "artifact_defaults",
                 "timeout",
+                "resume_on_timeout",
             )
         },
     )

--- a/lionagi/cli/_providers.py
+++ b/lionagi/cli/_providers.py
@@ -308,6 +308,8 @@ class AgentProfile:
     fast_mode: bool = False
     lion_system: bool = True
     artifact_defaults: dict | None = None
+    timeout: int | None = None
+    """Default --timeout (seconds) used when the CLI flag is not given."""
     extra: dict = field(default_factory=dict)
 
 
@@ -372,6 +374,23 @@ def load_agent_profile(name: str) -> AgentProfile:
     raise FileNotFoundError(msg)
 
 
+def _parse_profile_timeout(name: str, raw: Any) -> int | None:
+    """Validate the profile 'timeout' field; warn and ignore garbage rather than raising."""
+    if raw is None:
+        return None
+    from ._logging import warn
+
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        warn(f"agent profile {name!r}: ignoring invalid timeout {raw!r} (must be a positive int)")
+        return None
+    if value <= 0:
+        warn(f"agent profile {name!r}: ignoring non-positive timeout {value!r}")
+        return None
+    return value
+
+
 def _parse_profile(name: str, text: str) -> AgentProfile:
     frontmatter, body = _parse_frontmatter(text)
 
@@ -394,6 +413,7 @@ def _parse_profile(name: str, text: str) -> AgentProfile:
         fast_mode=bool(frontmatter.get("fast_mode", False)),
         lion_system=lion_system,
         artifact_defaults=frontmatter.get("artifact_defaults"),
+        timeout=_parse_profile_timeout(name, frontmatter.get("timeout")),
         extra={
             k: v
             for k, v in frontmatter.items()
@@ -405,6 +425,7 @@ def _parse_profile(name: str, text: str) -> AgentProfile:
                 "fast_mode",
                 "lion_system",
                 "artifact_defaults",
+                "timeout",
             )
         },
     )

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -203,6 +203,8 @@ async def _run_agent(
     project: str | None = None,
     bypass: bool = False,
     preset: str | None = None,
+    resume_on_timeout: bool = False,
+    _auto_resumed: bool = False,
 ) -> tuple[str, str, str, str, str | None]:
     """Execute one agent turn; returns (result, provider, branch_id, terminal_status, session_id).
 
@@ -242,6 +244,8 @@ async def _run_agent(
             fast = True
         if profile.timeout and timeout is None:
             timeout = profile.timeout
+        if profile.resume_on_timeout and not resume_on_timeout:
+            resume_on_timeout = True
 
     branch: Branch | None = None
     if continue_last:
@@ -493,6 +497,33 @@ async def _run_agent(
     save_last_branch_pointer(run.run_id, branch_id)
 
     session_id = live.get("session_id") if live else None
+
+    if _terminal_status == "timed_out" and resume_on_timeout and not _auto_resumed:
+        from lionagi.cli._logging import warn
+
+        warn(
+            f"[auto-resume] session {session_id or branch_id} timed out after "
+            f"{timeout}s — resuming once with 'continue and conclude the task'"
+        )
+        return await _run_agent(
+            None,
+            "continue and conclude the task",
+            yolo=yolo,
+            verbose=verbose,
+            theme=theme,
+            resume=branch_id,
+            effort=effort,
+            agent_name=agent_name,
+            cwd=cwd,
+            timeout=timeout,
+            fast=fast,
+            invocation_id=invocation_id,
+            project=project,
+            bypass=bypass,
+            resume_on_timeout=resume_on_timeout,
+            _auto_resumed=True,
+        )
+
     return res or "", provider, branch_id, _terminal_status, session_id
 
 
@@ -541,8 +572,8 @@ def add_agent_subparser(subparsers: argparse._SubParsersAction) -> argparse.Argu
         help=(
             "Load agent profile by name. Resolves "
             ".lionagi/agents/<NAME>/<NAME>.md first, then .lionagi/agents/<NAME>.md. "
-            "Profile provides system prompt, default model, effort, yolo, timeout. "
-            "CLI flags override profile settings."
+            "Profile provides system prompt, default model, effort, yolo, "
+            "timeout, resume_on_timeout. CLI flags override profile settings."
         ),
     )
     agent.add_argument(
@@ -687,6 +718,7 @@ def run_agent(args: argparse.Namespace) -> int:
                 project=getattr(args, "project", None),
                 bypass=getattr(args, "bypass", False),
                 preset=getattr(args, "preset", None),
+                resume_on_timeout=getattr(args, "resume_on_timeout", False),
             )
         )
     except KeyboardInterrupt:

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -505,8 +505,15 @@ async def _run_agent(
             f"[auto-resume] session {session_id or branch_id} timed out after "
             f"{timeout}s — resuming once with 'continue and conclude the task'"
         )
+        # Carry the model that actually ran this leg (explicit --model, profile
+        # default, or whatever a prior resume already grafted) forward as an
+        # explicit override. Passing model_str=None here would let the
+        # agent_name profile's model re-apply on the resumed leg (see the
+        # profile-precedence block above), silently switching models mid-run.
+        _effective_cfg = branch.chat_model.endpoint.config
+        _effective_model_str = f"{_effective_cfg.provider}/{_effective_cfg.kwargs.get('model')}"
         return await _run_agent(
-            None,
+            _effective_model_str,
             "continue and conclude the task",
             yolo=yolo,
             verbose=verbose,

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -240,6 +240,8 @@ async def _run_agent(
             yolo = True
         if profile.fast_mode and not fast:
             fast = True
+        if profile.timeout and timeout is None:
+            timeout = profile.timeout
 
     branch: Branch | None = None
     if continue_last:
@@ -539,7 +541,7 @@ def add_agent_subparser(subparsers: argparse._SubParsersAction) -> argparse.Argu
         help=(
             "Load agent profile by name. Resolves "
             ".lionagi/agents/<NAME>/<NAME>.md first, then .lionagi/agents/<NAME>.md. "
-            "Profile provides system prompt, default model, effort, yolo. "
+            "Profile provides system prompt, default model, effort, yolo, timeout. "
             "CLI flags override profile settings."
         ),
     )

--- a/tests/cli/test_agent_preset_form.py
+++ b/tests/cli/test_agent_preset_form.py
@@ -679,6 +679,7 @@ async def test_run_agent_preset_and_profile_single_system_message_with_both(monk
         lion_system=True,
         artifact_defaults=None,
         timeout=None,
+        resume_on_timeout=False,
     )
     import lionagi.cli.agent as agent_mod
 
@@ -740,6 +741,7 @@ async def test_run_agent_profile_without_preset_system_prompt_unchanged(monkeypa
         system_prompt=PROFILE_PROMPT,
         artifact_defaults=None,
         timeout=None,
+        resume_on_timeout=False,
     )
     import lionagi.cli.agent as agent_mod
 

--- a/tests/cli/test_agent_preset_form.py
+++ b/tests/cli/test_agent_preset_form.py
@@ -678,6 +678,7 @@ async def test_run_agent_preset_and_profile_single_system_message_with_both(monk
         raw_body=PROFILE_RAW_BODY,
         lion_system=True,
         artifact_defaults=None,
+        timeout=None,
     )
     import lionagi.cli.agent as agent_mod
 
@@ -738,6 +739,7 @@ async def test_run_agent_profile_without_preset_system_prompt_unchanged(monkeypa
         fast_mode=False,
         system_prompt=PROFILE_PROMPT,
         artifact_defaults=None,
+        timeout=None,
     )
     import lionagi.cli.agent as agent_mod
 

--- a/tests/cli/test_agent_profile_timeout.py
+++ b/tests/cli/test_agent_profile_timeout.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for per-profile default --timeout.
+
+Covers:
+  * profile 'timeout' used as the --timeout default when the flag is absent
+  * an explicit --timeout still beats the profile value
+  * an invalid profile 'timeout' is warned-and-ignored, not raised
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from lionagi.cli._providers import AgentProfile, _parse_profile
+
+# ---------------------------------------------------------------------------
+# Unit tests: profile field parsing/validation
+# ---------------------------------------------------------------------------
+
+
+def test_parse_profile_timeout_valid():
+    text = "---\ntimeout: 1800\n---\nbody"
+    profile = _parse_profile("reviewer", text)
+    assert profile.timeout == 1800
+
+
+def test_parse_profile_timeout_invalid_non_numeric_is_ignored(caplog):
+    text = "---\ntimeout: not-a-number\n---\nbody"
+    with caplog.at_level(logging.WARNING):
+        profile = _parse_profile("reviewer", text)
+    assert profile.timeout is None
+
+
+def test_parse_profile_timeout_non_positive_is_ignored(caplog):
+    text = "---\ntimeout: -5\n---\nbody"
+    with caplog.at_level(logging.WARNING):
+        profile = _parse_profile("reviewer", text)
+    assert profile.timeout is None
+
+
+def test_parse_profile_timeout_absent_is_none():
+    profile = _parse_profile("reviewer", "---\nmodel: claude\n---\nbody")
+    assert profile.timeout is None
+
+
+# ---------------------------------------------------------------------------
+# Integration: _run_agent precedence (explicit flag > profile > built-in default)
+# ---------------------------------------------------------------------------
+
+
+def _wire_agent_stubs(
+    monkeypatch,
+    tmp_path: Path,
+    *,
+    profile: AgentProfile | None = None,
+):
+    """Wire all external I/O in _run_agent; captures the timeout passed to operate()."""
+    import lionagi.cli.agent as agent_mod
+    from lionagi import Branch
+    from lionagi.service.manager import iModelManager
+
+    captured_timeouts: list[int | None] = []
+
+    async def fake_operate(self, instruction=None, **kw):
+        captured_timeouts.append(kw.get("timeout"))
+        return "done"
+
+    monkeypatch.setattr(Branch, "operate", fake_operate)
+    monkeypatch.setattr(iModelManager, "shutdown", AsyncMock())
+    monkeypatch.setattr(agent_mod, "resolve_persisted_effort", lambda *a, **kw: None)
+    monkeypatch.setattr(agent_mod, "build_chat_model", lambda *a, **kw: "claude_code/sonnet")
+
+    async def fake_setup(*a, **kw):
+        return {"session_id": "sess-0"}
+
+    async def fake_teardown(ctx, *, status="completed", exception=None):
+        return status
+
+    monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)
+    monkeypatch.setattr(agent_mod, "teardown_agent_persist", fake_teardown)
+    monkeypatch.setattr(agent_mod, "save_last_branch_pointer", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "_provenance",
+        SimpleNamespace(
+            resolve_model_spec=lambda p, m: f"{p}/{m}",
+            agent_definition_hash=lambda n: "abc",
+        ),
+    )
+    monkeypatch.setattr(agent_mod, "resolve_artifact_contract", lambda **_: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "allocate_run",
+        lambda: SimpleNamespace(
+            run_id="r",
+            artifact_root=tmp_path / "artifacts",
+            stream_dir=tmp_path / "stream",
+            branches_dir=tmp_path / "branches",
+        ),
+    )
+
+    if profile is not None:
+        monkeypatch.setattr(agent_mod, "load_agent_profile", lambda name: profile)
+
+    return captured_timeouts
+
+
+@pytest.mark.asyncio
+async def test_profile_timeout_used_when_flag_absent(monkeypatch, tmp_path):
+    profile = AgentProfile(name="reviewer", model="claude_code/sonnet", timeout=999)
+    timeouts = _wire_agent_stubs(monkeypatch, tmp_path, profile=profile)
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent(None, "hello", agent_name="reviewer", timeout=None)
+
+    assert timeouts == [999]
+
+
+@pytest.mark.asyncio
+async def test_explicit_timeout_beats_profile(monkeypatch, tmp_path):
+    profile = AgentProfile(name="reviewer", model="claude_code/sonnet", timeout=999)
+    timeouts = _wire_agent_stubs(monkeypatch, tmp_path, profile=profile)
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent(None, "hello", agent_name="reviewer", timeout=42)
+
+    assert timeouts == [42]
+
+
+@pytest.mark.asyncio
+async def test_no_profile_no_flag_timeout_stays_none(monkeypatch, tmp_path):
+    timeouts = _wire_agent_stubs(monkeypatch, tmp_path)
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent("claude_code/sonnet", "hello", timeout=None)
+
+    assert timeouts == [None]

--- a/tests/cli/test_agent_profile_timeout.py
+++ b/tests/cli/test_agent_profile_timeout.py
@@ -51,6 +51,16 @@ def test_parse_profile_timeout_absent_is_none():
     assert profile.timeout is None
 
 
+@pytest.mark.parametrize("raw_yaml", ["true", "false", "1.9", "3.0"])
+def test_parse_profile_timeout_rejects_bool_and_float(raw_yaml, caplog):
+    """YAML booleans and floats must warn-and-ignore, not coerce (bool is an
+    int subclass in Python; int(1.9) would silently truncate to 1)."""
+    text = f"---\ntimeout: {raw_yaml}\n---\nbody"
+    with caplog.at_level(logging.WARNING):
+        profile = _parse_profile("reviewer", text)
+    assert profile.timeout is None
+
+
 # ---------------------------------------------------------------------------
 # Integration: _run_agent precedence (explicit flag > profile > built-in default)
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_agent_resume_gemini_effort.py
+++ b/tests/cli/test_agent_resume_gemini_effort.py
@@ -267,6 +267,7 @@ async def test_resume_mixed_case_profile_effort_reapplies_correct_agy_tier(monke
             system_prompt=None,
             artifact_defaults=None,
             timeout=None,
+            resume_on_timeout=False,
         ),
     )
     _wire_agent_stubs(monkeypatch, tmp_path, operate_return="ok")

--- a/tests/cli/test_agent_resume_gemini_effort.py
+++ b/tests/cli/test_agent_resume_gemini_effort.py
@@ -266,6 +266,7 @@ async def test_resume_mixed_case_profile_effort_reapplies_correct_agy_tier(monke
             fast_mode=False,
             system_prompt=None,
             artifact_defaults=None,
+            timeout=None,
         ),
     )
     _wire_agent_stubs(monkeypatch, tmp_path, operate_return="ok")

--- a/tests/cli/test_agent_resume_on_timeout.py
+++ b/tests/cli/test_agent_resume_on_timeout.py
@@ -1,0 +1,299 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for opt-in auto-resume-once on a TIMEOUT terminal status.
+
+Covers:
+  * an invalid profile 'resume_on_timeout' is warned-and-ignored, not raised
+  * 'resume_on_timeout' opt-in (CLI flag or profile field) fires exactly one
+    auto-resume on a TIMEOUT terminal status, never on a failure or
+    cancellation
+  * auto-resume is off by default (no opt-in -> no resume)
+  * a timeout on the resumed leg does not re-fire (bounded to once)
+  * the final result surfaces the session id
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from lionagi.cli._providers import AgentProfile, _parse_profile
+
+# ---------------------------------------------------------------------------
+# Unit tests: profile field parsing/validation
+# ---------------------------------------------------------------------------
+
+
+def test_parse_profile_resume_on_timeout_once():
+    text = "---\nresume_on_timeout: once\n---\nbody"
+    profile = _parse_profile("reviewer", text)
+    assert profile.resume_on_timeout is True
+
+
+def test_parse_profile_resume_on_timeout_absent_is_false():
+    profile = _parse_profile("reviewer", "---\nmodel: claude\n---\nbody")
+    assert profile.resume_on_timeout is False
+
+
+def test_parse_profile_resume_on_timeout_unrecognized_is_ignored(caplog):
+    text = "---\nresume_on_timeout: sometimes\n---\nbody"
+    with caplog.at_level(logging.WARNING):
+        profile = _parse_profile("reviewer", text)
+    assert profile.resume_on_timeout is False
+
+
+# ---------------------------------------------------------------------------
+# Integration: _run_agent auto-resume wiring
+# ---------------------------------------------------------------------------
+
+
+def _make_branch_json(tmp_path: Path) -> tuple[str, Path]:
+    from lionagi import Branch
+
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    b = Branch()
+    branch_id = str(b.id)
+    p = tmp_path / f"{branch_id}.json"
+    p.write_text(json.dumps(b.to_dict()))
+    return branch_id, p
+
+
+def _wire_agent_stubs(
+    monkeypatch,
+    tmp_path: Path,
+    *,
+    operate_side_effect,
+    profile: AgentProfile | None = None,
+    session_ids: list[str] | None = None,
+):
+    """Wire all external I/O in _run_agent; operate_side_effect(call_index) -> result-or-raises."""
+    import lionagi.cli.agent as agent_mod
+    from lionagi import Branch
+    from lionagi.service.manager import iModelManager
+
+    call_count = {"n": 0}
+    captured_instructions: list[str] = []
+    captured_timeouts: list[int | None] = []
+
+    async def fake_operate(self, instruction=None, **kw):
+        idx = call_count["n"]
+        call_count["n"] += 1
+        captured_instructions.append(instruction or "")
+        captured_timeouts.append(kw.get("timeout"))
+        return operate_side_effect(idx)
+
+    monkeypatch.setattr(Branch, "operate", fake_operate)
+    monkeypatch.setattr(iModelManager, "shutdown", AsyncMock())
+    monkeypatch.setattr(agent_mod, "resolve_persisted_effort", lambda *a, **kw: None)
+    monkeypatch.setattr(agent_mod, "build_chat_model", lambda *a, **kw: "claude_code/sonnet")
+
+    _sids = session_ids or ["sess-0", "sess-1"]
+
+    async def fake_setup(*a, **kw):
+        n = min(call_count["n"], len(_sids) - 1)
+        return {"session_id": _sids[n]}
+
+    async def fake_teardown(ctx, *, status="completed", exception=None):
+        return status
+
+    monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)
+    monkeypatch.setattr(agent_mod, "teardown_agent_persist", fake_teardown)
+    monkeypatch.setattr(agent_mod, "save_last_branch_pointer", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "_provenance",
+        SimpleNamespace(
+            resolve_model_spec=lambda p, m: f"{p}/{m}",
+            agent_definition_hash=lambda n: "abc",
+        ),
+    )
+    monkeypatch.setattr(agent_mod, "resolve_artifact_contract", lambda **_: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "allocate_run",
+        lambda: SimpleNamespace(
+            run_id="r",
+            artifact_root=tmp_path / "artifacts",
+            stream_dir=tmp_path / "stream",
+            branches_dir=tmp_path / "branches",
+        ),
+    )
+
+    # Any -r lookup (the auto-resume path) resolves to a valid serialized
+    # branch, regardless of the requested id.
+    _, resumable_path = _make_branch_json(tmp_path / "resumable")
+    monkeypatch.setattr(agent_mod, "find_branch", lambda bid: ("run-x", resumable_path))
+
+    if profile is not None:
+        monkeypatch.setattr(agent_mod, "load_agent_profile", lambda name: profile)
+
+    return call_count, captured_instructions, captured_timeouts
+
+
+def _reset_channel(name: str) -> logging.Logger:
+    logger = logging.getLogger(name)
+    logger.handlers.clear()
+    logger.propagate = True
+    return logger
+
+
+@pytest.mark.asyncio
+async def test_auto_resume_disabled_by_default_no_opt_in(monkeypatch, tmp_path):
+    """No resume_on_timeout opt-in anywhere -> a timeout stays a single leg."""
+
+    def side_effect(i):
+        raise TimeoutError("boom")
+
+    call_count, _insts, _timeouts = _wire_agent_stubs(
+        monkeypatch, tmp_path, operate_side_effect=side_effect
+    )
+
+    from lionagi.cli.agent import _run_agent
+
+    _result, _provider, _bid, status, _sid = await _run_agent(
+        "claude_code/sonnet", "hello", timeout=30
+    )
+
+    assert call_count["n"] == 1
+    assert status == "timed_out"
+
+
+@pytest.mark.asyncio
+async def test_auto_resume_fires_once_on_timeout(monkeypatch, tmp_path, caplog):
+    """resume_on_timeout=True: first leg times out, resumed leg completes."""
+
+    def side_effect(i):
+        if i == 0:
+            raise TimeoutError("boom")
+        return "concluded"
+
+    call_count, insts, timeouts = _wire_agent_stubs(
+        monkeypatch,
+        tmp_path,
+        operate_side_effect=side_effect,
+        session_ids=["sess-timeout", "sess-resumed"],
+    )
+
+    from lionagi.cli.agent import _run_agent
+
+    _reset_channel("lionagi.cli.warn")
+    with caplog.at_level(logging.WARNING, logger="lionagi.cli.warn"):
+        result, _provider, _bid, status, session_id = await _run_agent(
+            "claude_code/sonnet",
+            "hello",
+            timeout=30,
+            resume_on_timeout=True,
+        )
+
+    assert call_count["n"] == 2
+    assert status == "completed"
+    assert result == "concluded"
+    assert session_id == "sess-resumed"
+    assert insts[1].endswith("continue and conclude the task")
+    assert timeouts == [30, 30]  # resumed leg gets the same timeout budget
+    warn_text = " ".join(rec.message for rec in caplog.records)
+    assert "auto-resume" in warn_text
+    assert "sess-timeout" in warn_text
+
+
+@pytest.mark.asyncio
+async def test_auto_resume_does_not_fire_on_failure(monkeypatch, tmp_path):
+    """A plain failure (not a timeout) never triggers the auto-resume path."""
+
+    def side_effect(i):
+        raise RuntimeError("boom")
+
+    call_count, _insts, _timeouts = _wire_agent_stubs(
+        monkeypatch, tmp_path, operate_side_effect=side_effect
+    )
+
+    from lionagi.cli.agent import _run_agent
+
+    with pytest.raises(RuntimeError):
+        await _run_agent(
+            "claude_code/sonnet",
+            "hello",
+            timeout=30,
+            resume_on_timeout=True,
+        )
+
+    assert call_count["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_auto_resume_does_not_fire_on_cancellation(monkeypatch, tmp_path):
+    """A cancelled run never triggers the auto-resume path."""
+    import asyncio
+
+    def side_effect(i):
+        raise asyncio.CancelledError()
+
+    call_count, _insts, _timeouts = _wire_agent_stubs(
+        monkeypatch, tmp_path, operate_side_effect=side_effect
+    )
+
+    from lionagi.cli.agent import _run_agent
+
+    with pytest.raises(asyncio.CancelledError):
+        await _run_agent(
+            "claude_code/sonnet",
+            "hello",
+            timeout=30,
+            resume_on_timeout=True,
+        )
+
+    assert call_count["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_resumed_leg_timeout_does_not_refire(monkeypatch, tmp_path, caplog):
+    """The resumed leg also times out -> terminates normally, no third attempt."""
+
+    def side_effect(i):
+        raise TimeoutError("boom")
+
+    call_count, _insts, _timeouts = _wire_agent_stubs(
+        monkeypatch, tmp_path, operate_side_effect=side_effect
+    )
+
+    from lionagi.cli.agent import _run_agent
+
+    _result, _provider, _bid, status, _sid = await _run_agent(
+        "claude_code/sonnet",
+        "hello",
+        timeout=30,
+        resume_on_timeout=True,
+    )
+
+    assert call_count["n"] == 2  # original + exactly one auto-resume, never a third
+    assert status == "timed_out"
+
+
+@pytest.mark.asyncio
+async def test_profile_resume_on_timeout_opts_in(monkeypatch, tmp_path):
+    """profile 'resume_on_timeout: once' opts in without any CLI flag."""
+    profile = AgentProfile(name="reviewer", model="claude_code/sonnet", resume_on_timeout=True)
+
+    def side_effect(i):
+        if i == 0:
+            raise TimeoutError("boom")
+        return "concluded"
+
+    call_count, _insts, _timeouts = _wire_agent_stubs(
+        monkeypatch, tmp_path, operate_side_effect=side_effect, profile=profile
+    )
+
+    from lionagi.cli.agent import _run_agent
+
+    _result, _provider, _bid, status, _sid = await _run_agent(
+        None, "hello", agent_name="reviewer", timeout=30
+    )
+
+    assert call_count["n"] == 2
+    assert status == "completed"

--- a/tests/cli/test_agent_resume_on_timeout.py
+++ b/tests/cli/test_agent_resume_on_timeout.py
@@ -275,6 +275,126 @@ async def test_resumed_leg_timeout_does_not_refire(monkeypatch, tmp_path, caplog
     assert status == "timed_out"
 
 
+def _wire_agent_stubs_real_chat_model(
+    monkeypatch,
+    tmp_path: Path,
+    *,
+    operate_side_effect,
+    profile: AgentProfile | None = None,
+    session_ids: list[str] | None = None,
+):
+    """Like _wire_agent_stubs, but build_chat_model returns a *real* iModel
+    (not a placeholder string) so branch.chat_model.endpoint.config reflects
+    the model actually resolved for each leg. Needed to pin the model an
+    auto-resumed leg actually runs with, not just what operate() was told."""
+    import lionagi.cli.agent as agent_mod
+    from lionagi import Branch, iModel
+    from lionagi.service.manager import iModelManager
+
+    call_count = {"n": 0}
+    captured_models: list[str | None] = []
+
+    async def fake_operate(self, instruction=None, **kw):
+        idx = call_count["n"]
+        call_count["n"] += 1
+        captured_models.append(self.chat_model.endpoint.config.kwargs.get("model"))
+        snapshot_dir = kw.get("snapshot_dir")
+        if snapshot_dir is not None:
+            Path(snapshot_dir).mkdir(parents=True, exist_ok=True)
+            (Path(snapshot_dir) / f"{self.id}.json").write_text(json.dumps(self.to_dict()))
+        return operate_side_effect(idx)
+
+    monkeypatch.setattr(Branch, "operate", fake_operate)
+    monkeypatch.setattr(iModelManager, "shutdown", AsyncMock())
+    monkeypatch.setattr(agent_mod, "resolve_persisted_effort", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "build_chat_model",
+        lambda provider, model, *a, **kw: iModel(provider=provider, model=model, api_key="dummy"),
+    )
+
+    _sids = session_ids or ["sess-0", "sess-1"]
+
+    async def fake_setup(*a, **kw):
+        n = min(call_count["n"], len(_sids) - 1)
+        return {"session_id": _sids[n]}
+
+    async def fake_teardown(ctx, *, status="completed", exception=None):
+        return status
+
+    monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)
+    monkeypatch.setattr(agent_mod, "teardown_agent_persist", fake_teardown)
+    monkeypatch.setattr(agent_mod, "save_last_branch_pointer", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "_provenance",
+        SimpleNamespace(
+            resolve_model_spec=lambda p, m: f"{p}/{m}",
+            agent_definition_hash=lambda n: "abc",
+        ),
+    )
+    monkeypatch.setattr(agent_mod, "resolve_artifact_contract", lambda **_: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "allocate_run",
+        lambda: SimpleNamespace(
+            run_id="r",
+            artifact_root=tmp_path / "artifacts",
+            stream_dir=tmp_path / "stream",
+            branches_dir=tmp_path / "branches",
+        ),
+    )
+
+    # The auto-resume path snapshots the branch itself (real Branch.to_dict())
+    # into snapshot_dir; find_branch must resolve to that real snapshot so
+    # Branch.from_dict on resume carries the actual chat_model config forward,
+    # not a fixture stand-in.
+    def fake_find_branch(bid):
+        snapshot_path = tmp_path / "branches" / f"{bid}.json"
+        return "run-x", snapshot_path
+
+    monkeypatch.setattr(agent_mod, "find_branch", fake_find_branch)
+
+    if profile is not None:
+        monkeypatch.setattr(agent_mod, "load_agent_profile", lambda name: profile)
+
+    return call_count, captured_models
+
+
+@pytest.mark.asyncio
+async def test_auto_resume_preserves_explicit_model_over_profile_default(monkeypatch, tmp_path):
+    """Explicit --model + a profile with a *different* default model: the
+    resumed leg must keep the explicit model, not silently fall back to the
+    profile's model (the auto-resume call must not pass model_str=None while
+    still forwarding agent_name)."""
+    profile = AgentProfile(name="profile-with-different-model", model="claude_code/haiku")
+
+    def side_effect(i):
+        if i == 0:
+            raise TimeoutError("first leg timed out")
+        return "concluded"
+
+    call_count, captured_models = _wire_agent_stubs_real_chat_model(
+        monkeypatch, tmp_path, operate_side_effect=side_effect, profile=profile
+    )
+
+    from lionagi.cli.agent import _run_agent
+
+    _result, _provider, _bid, status, _sid = await _run_agent(
+        "claude_code/opus",
+        "hello",
+        agent_name="profile-with-different-model",
+        timeout=30,
+        resume_on_timeout=True,
+    )
+
+    assert call_count["n"] == 2
+    assert status == "completed"
+    assert captured_models == ["opus", "opus"], (
+        f"resumed leg must keep the explicit CLI model, got {captured_models!r}"
+    )
+
+
 @pytest.mark.asyncio
 async def test_profile_resume_on_timeout_opts_in(monkeypatch, tmp_path):
     """profile 'resume_on_timeout: once' opts in without any CLI flag."""

--- a/tests/cli/test_agent_resume_on_timeout.py
+++ b/tests/cli/test_agent_resume_on_timeout.py
@@ -48,6 +48,16 @@ def test_parse_profile_resume_on_timeout_unrecognized_is_ignored(caplog):
     assert profile.resume_on_timeout is False
 
 
+@pytest.mark.parametrize("raw_yaml", ["true", "false", "yes", "sometimes"])
+def test_parse_profile_resume_on_timeout_rejects_non_once_values(raw_yaml, caplog):
+    """Only the literal string 'once' opts in; boolean aliases and other
+    strings must warn-and-ignore (parse as False), not opt in."""
+    text = f"---\nresume_on_timeout: {raw_yaml}\n---\nbody"
+    with caplog.at_level(logging.WARNING):
+        profile = _parse_profile("reviewer", text)
+    assert profile.resume_on_timeout is False
+
+
 # ---------------------------------------------------------------------------
 # Integration: _run_agent auto-resume wiring
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements #1697 (per-profile default timeout + optional auto-resume-once on timeout for `li agent`), in two commits:

**1. Per-profile default timeout** (`cff3992f7`)
- Agent profiles (`~/.lionagi/agents/<name>.md` frontmatter) may now carry a `timeout` field (seconds).
- Precedence: explicit `--timeout` > profile `timeout` > existing built-in default (unchanged).
- Invalid profile values (non-numeric, non-positive) are warned-and-ignored, not raised — matching how other profile fields degrade gracefully.

**2. Opt-in auto-resume-once on timeout** (`44dcd2f78`)
- New `--resume-on-timeout` CLI flag and equivalent profile field `resume_on_timeout: once`.
- When a run's terminal status is specifically `timed_out` (not `failed`, not `cancelled`/SIGTERM), `_run_agent` fires exactly one in-process resume of the same session with the prompt `"continue and conclude the task"`, reusing the existing `-r` resume path (no subprocess).
- The resumed leg gets the same `--timeout` budget. A timeout on the resumed leg terminates normally — bounded to a single auto-resume, never a third attempt.
- Final exit code / terminal status come from the resumed leg. The auto-resume is announced via the existing `warn()` channel with the session id, and the post-run hint's `li agent status <session_id>` line reflects the resumed leg.
- Off by default (opt-in only); no new terminal-status values were introduced.

## Test plan

- [x] `uv run pytest` — full files touching `cli/agent.py` / `cli/_providers.py` (`tests/cli/test_agent_*`, `tests/agent/test_factory.py`, `tests/agent/test_profile_*`, `tests/cli/test_providers.py`, `tests/cli/test_argv_parser_regression.py`): **288 passed**
- [x] New coverage: profile timeout precedence + invalid-value handling (`tests/cli/test_agent_profile_timeout.py`), auto-resume-once firing/non-firing/bounded-to-once + profile opt-in (`tests/cli/test_agent_resume_on_timeout.py`)
- [x] `ruff format --check` / `ruff check` clean on all touched files
- [ ] Pre-existing, unrelated failures observed in the wider `tests/cli/` suite (confirmed present on `origin/main` before this change via `git stash`): `tests/cli/test_argv_injection.py` / `tests/cli/test_scheduler_flow_yaml.py` (missing `fastapi`/studio extra in this environment) and one flaky `tests/cli/test_monitor_run.py::test_dispatch_wait_follow_preserves_initial_failure_exit_code` — none touch the files changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)