### PR TITLE
fix(docs): drop compromised polyfill.io script + retarget repo links to ohdearquant/lionagi

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,5 +1,5 @@
 # Contributing
 
-Read [`CONTRIBUTING.md`](https://github.com/khive-ai/lionagi/blob/main/CONTRIBUTING.md) at the repo root for pull-request guidelines, and [`AGENT.md`](https://github.com/khive-ai/lionagi/blob/main/AGENT.md) for the contributor workflow (commands, coding standards, testing).
+Read [`CONTRIBUTING.md`](https://github.com/ohdearquant/lionagi/blob/main/CONTRIBUTING.md) at the repo root for pull-request guidelines, and [`AGENT.md`](https://github.com/ohdearquant/lionagi/blob/main/AGENT.md) for the contributor workflow (commands, coding standards, testing).
 
 Next: [Code of conduct](code-of-conduct.md)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -43,4 +43,4 @@ When generating code that uses LionAGI, prefer these current APIs:
 - [Troubleshooting](https://lionagi.ai/reference/troubleshooting/)
 - [Migration: 0.22.5 to 0.22.6](https://lionagi.ai/migration/0.22.5-to-0.22.6/)
 - [Contributing](https://lionagi.ai/contributing/): development setup and guidelines
-- [Source on GitHub](https://github.com/khive-ai/lionagi): code, issues, and releases
+- [Source on GitHub](https://github.com/ohdearquant/lionagi): code, issues, and releases

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: LionAGI
 site_description: Orchestrate multi-agent AI workflows from the command line or Python
 site_url: https://lionagi.ai/
-repo_url: https://github.com/khive-ai/lionagi
-repo_name: khive-ai/lionagi
+repo_url: https://github.com/ohdearquant/lionagi
+repo_name: ohdearquant/lionagi
 edit_uri: edit/main/docs/
 copyright: Copyright &copy; 2024-2026 Ocean Li and LionAGI Contributors
 
@@ -90,7 +90,7 @@ markdown_extensions:
   - pymdownx.magiclink:
       normalize_issue_symbols: true
       repo_url_shorthand: true
-      user: khive-ai
+      user: ohdearquant
       repo: lionagi
   - pymdownx.mark
   - pymdownx.smartsymbols
@@ -129,7 +129,7 @@ plugins:
       enable_creation_date: true
       type: iso_datetime
   - git-committers:
-      repository: khive-ai/lionagi
+      repository: ohdearquant/lionagi
       branch: main
       enabled: false
   - autorefs
@@ -225,7 +225,7 @@ extra:
     default: stable
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/khive-ai/lionagi
+      link: https://github.com/ohdearquant/lionagi
       name: GitHub
     - icon: fontawesome/brands/discord
       link: https://discord.gg/lionagi
@@ -264,7 +264,6 @@ extra_javascript:
   - https://unpkg.com/mermaid@10/dist/mermaid.min.js
   - javascripts/mermaid-config.js
   - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 hooks:


### PR DESCRIPTION
## Why

A user reported the docs site repeatedly prompting a polyfill.io sign-in. Root cause: `mkdocs.yml` still loaded `https://polyfill.io/v3/polyfill.min.js?features=es6`. The polyfill.io domain was sold in 2024 and has served attacker-controlled content since (the well-known supply-chain compromise) — whatever it serves now is what visitors were seeing. MathJax 3 needs no ES6 polyfill on any supported browser, so the script is removed outright, not mirrored.

## Changes

- `mkdocs.yml`: remove the polyfill.io `extra_javascript` entry.
- `mkdocs.yml` + `docs/contributing.md` + `docs/llms.txt`: retarget every repo reference (`repo_url`/`repo_name`, magiclink `user:`, git-committers `repository:`, GitHub social link, contributing/llms links) from `khive-ai/lionagi` to `ohdearquant/lionagi`.

Docs/config only, no code paths touched. Verified zero remaining `polyfill`/`khive-ai` hits in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)