### PR TITLE
docs: point site_url and llms.txt at the live GitHub Pages host

### DIFF
--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -10,37 +10,37 @@ When generating code that uses LionAGI, prefer these current APIs:
 - Install with `pip install lionagi` or `uv add lionagi`. Requires Python 3.10+.
 
 ## Docs
-- [Install](https://lionagi.ai/getting-started/install/): install LionAGI and the `li` CLI
-- [First Flow](https://lionagi.ai/getting-started/first-flow/): a minimal end-to-end example
-- [Concepts](https://lionagi.ai/concepts/): Branch, Session, operate, providers, and the mental model
-- [CLI Reference](https://lionagi.ai/cli-reference/): full `li agent`, `li team`, and `li orchestrate` reference
+- [Install](https://ohdearquant.github.io/lionagi/getting-started/install/): install LionAGI and the `li` CLI
+- [First Flow](https://ohdearquant.github.io/lionagi/getting-started/first-flow/): a minimal end-to-end example
+- [Concepts](https://ohdearquant.github.io/lionagi/concepts/): Branch, Session, operate, providers, and the mental model
+- [CLI Reference](https://ohdearquant.github.io/lionagi/cli-reference/): full `li agent`, `li team`, and `li orchestrate` reference
 
 ## API
-- [Branch](https://lionagi.ai/api/branch/): the primary conversation and agent surface
-- [Session](https://lionagi.ai/api/session/): multi-branch orchestration and `flow()`
-- [Operations](https://lionagi.ai/api/operations/): operate, chat, parse, ReAct, select, communicate
-- [iModel](https://lionagi.ai/api/imodel/): provider wrapper and endpoint routing
-- [Flow](https://lionagi.ai/api/flow/): DAG and multi-agent execution
-- [Team](https://lionagi.ai/api/team/): inter-agent messaging
+- [Branch](https://ohdearquant.github.io/lionagi/api/branch/): the primary conversation and agent surface
+- [Session](https://ohdearquant.github.io/lionagi/api/session/): multi-branch orchestration and `flow()`
+- [Operations](https://ohdearquant.github.io/lionagi/api/operations/): operate, chat, parse, ReAct, select, communicate
+- [iModel](https://ohdearquant.github.io/lionagi/api/imodel/): provider wrapper and endpoint routing
+- [Flow](https://ohdearquant.github.io/lionagi/api/flow/): DAG and multi-agent execution
+- [Team](https://ohdearquant.github.io/lionagi/api/team/): inter-agent messaging
 
 ## Cookbook
-- [Codebase Audit](https://lionagi.ai/cookbook/codebase-audit/)
-- [Research Synthesis](https://lionagi.ai/cookbook/research-synthesis/)
-- [Multi-Model Pipeline](https://lionagi.ai/cookbook/multi-model-pipeline/)
-- [Team Coordination](https://lionagi.ai/cookbook/team-coordination/)
-- [Resumable Background](https://lionagi.ai/cookbook/resumable-background/)
+- [Codebase Audit](https://ohdearquant.github.io/lionagi/cookbook/codebase-audit/)
+- [Research Synthesis](https://ohdearquant.github.io/lionagi/cookbook/research-synthesis/)
+- [Multi-Model Pipeline](https://ohdearquant.github.io/lionagi/cookbook/multi-model-pipeline/)
+- [Team Coordination](https://ohdearquant.github.io/lionagi/cookbook/team-coordination/)
+- [Resumable Background](https://ohdearquant.github.io/lionagi/cookbook/resumable-background/)
 
 ## Optional
-- [Providers](https://lionagi.ai/reference/providers/): supported LLM providers and configuration
-- [Protocols (core)](https://lionagi.ai/reference/protocols-core/): Element, Pile, Progression, and Graph primitives
-- [Agent & Hooks](https://lionagi.ai/reference/agent-hooks/): agent specs, factory, and lifecycle hooks
-- [Operations & Service](https://lionagi.ai/reference/operations-service/)
-- [Engines](https://lionagi.ai/reference/engines/)
-- [Casts](https://lionagi.ai/reference/casts/)
-- [Outcomes & Work](https://lionagi.ai/reference/outcomes-work/)
-- [Testing, State & Session](https://lionagi.ai/reference/testing-state-session/)
-- [Advanced](https://lionagi.ai/reference/advanced/)
-- [Troubleshooting](https://lionagi.ai/reference/troubleshooting/)
-- [Migration: 0.22.5 to 0.22.6](https://lionagi.ai/migration/0.22.5-to-0.22.6/)
-- [Contributing](https://lionagi.ai/contributing/): development setup and guidelines
+- [Providers](https://ohdearquant.github.io/lionagi/reference/providers/): supported LLM providers and configuration
+- [Protocols (core)](https://ohdearquant.github.io/lionagi/reference/protocols-core/): Element, Pile, Progression, and Graph primitives
+- [Agent & Hooks](https://ohdearquant.github.io/lionagi/reference/agent-hooks/): agent specs, factory, and lifecycle hooks
+- [Operations & Service](https://ohdearquant.github.io/lionagi/reference/operations-service/)
+- [Engines](https://ohdearquant.github.io/lionagi/reference/engines/)
+- [Casts](https://ohdearquant.github.io/lionagi/reference/casts/)
+- [Outcomes & Work](https://ohdearquant.github.io/lionagi/reference/outcomes-work/)
+- [Testing, State & Session](https://ohdearquant.github.io/lionagi/reference/testing-state-session/)
+- [Advanced](https://ohdearquant.github.io/lionagi/reference/advanced/)
+- [Troubleshooting](https://ohdearquant.github.io/lionagi/reference/troubleshooting/)
+- [Migration: 0.22.5 to 0.22.6](https://ohdearquant.github.io/lionagi/migration/0.22.5-to-0.22.6/)
+- [Contributing](https://ohdearquant.github.io/lionagi/contributing/): development setup and guidelines
 - [Source on GitHub](https://github.com/ohdearquant/lionagi): code, issues, and releases

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: LionAGI
 site_description: Orchestrate multi-agent AI workflows from the command line or Python
-site_url: https://lionagi.ai/
+site_url: https://ohdearquant.github.io/lionagi/
 repo_url: https://github.com/ohdearquant/lionagi
 repo_name: ohdearquant/lionagi
 edit_uri: edit/main/docs/


### PR DESCRIPTION
lionagi.ai is a separate Vercel-hosted marketing site: its root serves 200 but every docs path (/comparison/, /concepts/, /cli-reference/, ...) returns 404. The repo's GitHub Pages config has no custom domain (cname=null), so the mkdocs site actually serves at https://ohdearquant.github.io/lionagi/. Meanwhile `mkdocs.yml` declared `site_url: https://lionagi.ai/`, which made every canonical URL and the generated sitemap point at 404s, and `docs/llms.txt` handed the same dead links to LLM crawlers.

## Changes

- `mkdocs.yml`: `site_url` → `https://ohdearquant.github.io/lionagi/`
- `docs/llms.txt`: all 27 doc links rewritten to the live host

Reversible: when a docs subdomain (docs.lionagi.ai) is blessed and wired (CNAME + Pages custom-domain setting), one follow-up PR flips these back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
