### PR TITLE
fix(studio-frontend): S1 correctness + hosted-mode blockers

### DIFF
--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -431,7 +431,7 @@ export async function getShow(topic: string): Promise<ShowDetail> {
   return fetchJson<ShowDetail>(`/api/shows/${encodeURIComponent(topic)}`);
 }
 
-// H-FE-5: terminal {"type":"done"} event from shows.py MUST close the
+// The terminal {"type":"done"} event from the shows service MUST close the
 // stream. The closer runs BEFORE invoking the callback for done events so
 // that close() always runs even if the callback throws.
 export function streamShow(topic: string, onEvent: (event: ShowEvent) => void): () => void {
@@ -727,8 +727,7 @@ export async function saveDefinition(
   });
 }
 
-// H-FE-4: version is a query param per ADR-0016 and definitions.py:58-63,
-// not a path segment. Return type updated to include full rollback response.
+// version is a query param per ADR-0016 (not a path segment).
 export async function rollbackDefinition(
   kind: string,
   name: string,
@@ -970,13 +969,26 @@ export interface TeamListResponse {
   has_next: boolean;
 }
 
-export type TeamDetail = Record<string, unknown> & {
-  id?: string;
-  name?: string;
-  members?: unknown[];
-  messages?: unknown[];
-  created_at?: string | number | null;
-};
+// Shape written by `li team` (cli/team.py cmd_create/cmd_send) and returned
+// as-is by GET /api/teams/{id} (services/teams.py get_team reads the raw
+// JSON file, no adaptation).
+export interface TeamMessage {
+  id: string;
+  from: string;
+  to: string | string[];
+  content: string;
+  timestamp: string;
+  read_by?: Record<string, string>;
+  from_op?: string;
+}
+
+export interface TeamDetail {
+  id: string;
+  name: string;
+  members: string[];
+  messages: TeamMessage[];
+  created_at: string;
+}
 
 export async function listTeams(params?: {
   limit?: number;

--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -699,7 +699,7 @@ export async function getDefinitionVersion(
   );
 }
 
-// F-A3-1 (ADR-0016): backend is POST /api/definitions/{kind}/{name} — no PUT route exists.
+// Backend saves definitions via POST /api/definitions/{kind}/{name} — no PUT route exists.
 // Return type matches services/definitions.py save_definition() response shape:
 //   { kind, name, version, saved_at, message? }
 export async function saveDefinition(

--- a/apps/studio/frontend/src/lib/types.ts
+++ b/apps/studio/frontend/src/lib/types.ts
@@ -50,9 +50,9 @@ export interface ArtifactVerification {
 
 // ─── Run types ───────────────────────────────────────────────────────────────
 
-// H-FE-3: RunSummary matches the actual SQLite-session response shape from
-// list_runs() (services/runs.py). Fields worker_name/finished_at were stale
-// filesystem-run remnants; the real fields are playbook_name/ended_at etc.
+// RunSummary matches the SQLite-session response shape from list_runs()
+// (services/runs.py): playbook_name/agent_name and ended_at are the
+// canonical fields.
 export interface RunSummary {
   run_id: string;
   id?: string;
@@ -117,24 +117,21 @@ export interface RunStep {
   timestamp: number | null;
 }
 
-// RunDetail comes from the filesystem run.json path (GET /api/runs/{id} →
-// services/runs.py get_run → _adapt_summary). Unlike RunSummary which maps
-// SQLite session rows, RunDetail reads the on-disk run manifest. The manifest
-// uses "worker_name" and "finished_at" as canonical field names (see
-// _adapt_summary in services/runs.py). ADR-0004 open design question:
-// long-term these should unify with the SQLite session fields.
+// RunDetail comes from GET /api/runs/{id} (services/runs.py get_run), which
+// reads the SQLite session and is a superset of RunSummary plus detail-only
+// fields (state_root, artifact_root, task, error, cwd, steps, graph,
+// manifest, branches).
 export interface RunDetail {
   run_id: string;
   state_root: string;
   artifact_root: string;
-  // Filesystem run.json fields — distinct from SQLite session schema
-  worker_name?: string;
+  playbook_name?: string | null;
+  agent_name?: string | null;
   task?: string;
   status: string;
   error: string | null;
   cwd: string | null;
   started_at: number | null;
-  finished_at?: number | null;
   ended_at?: number | null;
   steps?: RunStep[];
   graph: { nodes: WorkerStepNode[]; edges: WorkerLinkEdge[] };
@@ -304,7 +301,8 @@ export interface ShowDetail {
   show_md: string | null;
   goal?: string | null;
   status?: string;
-  // M-FE-2: status_source added by backend agent (H-BE-3)
+  // Indicates whether `status` was derived from the SQLite session or the
+  // on-disk show manifest.
   status_source?: "sqlite" | "filesystem";
   plays: Array<{
     name: string;
@@ -318,8 +316,8 @@ export interface ShowDetail {
   }>;
 }
 
-// H-FE-5: "done" is the terminal SSE event emitted by shows.py:456-458.
-// The SSE subscription MUST be closed when this event arrives.
+// "done" is the terminal SSE event emitted by the shows service. The SSE
+// subscription MUST be closed when this event arrives.
 export interface ShowEvent {
   type: "new" | "change" | "delete" | "done";
   path?: string;

--- a/apps/studio/frontend/src/routes/agents/new/index.tsx
+++ b/apps/studio/frontend/src/routes/agents/new/index.tsx
@@ -5,10 +5,9 @@ export const Route = createFileRoute("/agents/new/")({
   component: NewAgentPage,
 });
 
-// H-FE-983: POST /api/agents/{name} returns 501. This page previously
-// rendered an AgentProfileForm whose Create Agent button called that route.
-// The form is replaced with a hold-message until the backend is implemented.
-// Option A (implement the route) is tracked in the issue.
+// POST /api/agents/{name} returns 501. This page previously rendered an
+// AgentProfileForm whose Create Agent button called that route. The form is
+// replaced with a hold-message until the backend implements agent creation.
 
 function NewAgentPage() {
   return (

--- a/apps/studio/frontend/src/routes/index.tsx
+++ b/apps/studio/frontend/src/routes/index.tsx
@@ -8,7 +8,7 @@ import StatusPill from "@/components/StatusPill";
 import Timestamp from "@/components/Timestamp";
 import Duration from "@/components/Duration";
 import TimeRangeChips, { type TimeRange, rangeToSeconds } from "@/components/TimeRangeChips";
-import { resolveApiBase, getShow, getStats } from "@/lib/api";
+import { getShow, getStats, listRuns, listShows } from "@/lib/api";
 import type { DbStats, StudioStats } from "@/lib/api";
 import type { RunSummary, ShowSummary } from "@/lib/types";
 
@@ -48,7 +48,6 @@ function isInRange(run: RunSummary, windowSec: number | null, nowSec: number): b
 
 function DashboardPage() {
   const t = useTranslations("dashboard");
-  const API_BASE = resolveApiBase();
   const [stats, setStats] = useState<StudioStats | null>(null);
   const [allRuns, setAllRuns] = useState<RunSummary[]>([]);
   const [shows, setShows] = useState<ShowSummary[]>([]);
@@ -61,15 +60,14 @@ function DashboardPage() {
 
     async function load() {
       try {
-        const [statsRes, runsRes, showsRes] = await Promise.all([
+        const [statsRes, runsRes, showsList] = await Promise.all([
           getStats(),
-          fetch(`${API_BASE}/api/runs?per_page=2000`).then((r) => r.json()),
-          fetch(`${API_BASE}/api/shows`).then((r) => r.json()),
+          listRuns({ per_page: 2000 }),
+          listShows(),
         ]);
         if (!active) return;
         setStats(statsRes);
         setAllRuns(runsRes.runs ?? []);
-        const showsList = showsRes ?? [];
         setShows(showsList);
         setFetchError(null);
         if (showsList.length > 0) {
@@ -108,7 +106,7 @@ function DashboardPage() {
       clearInterval(interval);
       clearInterval(tick);
     };
-  }, [t, API_BASE]);
+  }, [t]);
 
   const windowSec = rangeToSeconds(range);
 

--- a/apps/studio/frontend/src/routes/playbooks/$name/index.tsx
+++ b/apps/studio/frontend/src/routes/playbooks/$name/index.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
+import { lazy, Suspense, useEffect, useState } from "react";
 import Button from "@/components/Button";
-import StatusPill from "@/components/StatusPill";
 import { getWorkerGraph } from "@/lib/api";
 import { notImplemented } from "@/lib/copy";
 import type { WorkerGraph } from "@/lib/types";
@@ -15,36 +14,16 @@ export const Route = createFileRoute("/playbooks/$name/")({
 // ADR-0014: Run button is defaults-only. No task input, no CWD field.
 // Input variable binding and worktree customisation belong in `li play`.
 //
-// H-FE-2: GET /api/playbooks/{name}/run is a 501 stub — the backend does not
-// yet expose a filesystem run_id for polling step-level progress. The UI
-// reflects this by reporting terminal status (running → completed/failed)
-// without attempting step-level introspection. execSteps / currentStep are
-// retained for WorkerCanvas prop compatibility but are never populated.
-
-// Hoisted to module scope so the polling useEffect dependency array can
-// reference it as a stable value without triggering eslint-react-hooks.
-const POLL_MAX_MS = 10 * 60 * 1000;
+// POST /api/playbooks/{name}/run is not implemented on the backend (it
+// returns 501), so there is no run to track progress for yet. The Run
+// button stays disabled and points operators at the CLI instead of
+// simulating a run state that never actually happens.
 
 function WorkerDetailPage() {
   const { name } = Route.useParams();
   const workerName = name;
   const [graph, setGraph] = useState<WorkerGraph | null>(null);
   const [error, setError] = useState<string | null>(null);
-
-  // Execution state
-  // H-FE-1: activeRunId drives polling from a useEffect so the timeout and
-  // any in-flight fetch are cancelled on unmount.
-  const [activeRunId, setActiveRunId] = useState<string | null>(null);
-  const [runStatus, setRunStatus] = useState<"idle" | "running" | "completed" | "failed">("idle");
-  // M-FE-1: surface startRun / poll errors to the user
-  const [runError, setRunError] = useState<string | null>(null);
-  const execSteps: Array<{
-    step: string;
-    status: string;
-    result?: Record<string, unknown>;
-    timestamp?: number;
-  }> = [];
-  const currentStep: string | null = null;
 
   useEffect(() => {
     let active = true;
@@ -59,59 +38,6 @@ function WorkerDetailPage() {
       active = false;
     };
   }, [workerName]);
-
-  // H-FE-1: Polling effect — driven by activeRunId. Cleans up completely on
-  // unmount or when activeRunId is cleared (terminal state reached).
-  // H-FE-2: Since GET /api/runs/{id} requires a filesystem run directory and
-  // startRun returns a SQLite session ID, polling getRun() would 404.
-  // We track status via a simple timeout ceiling instead of step polling.
-  const startedAtRef = useRef<number>(0);
-  // mountedRef guards all setState calls that follow an await in handleRun.
-  // The polling effect has its own `cancelled` flag; this ref covers the
-  // startRun() POST path which runs outside the effect.
-  const mountedRef = useRef<boolean>(true);
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
-
-  useEffect(() => {
-    if (!activeRunId) return;
-
-    let cancelled = false;
-    let handle: ReturnType<typeof setTimeout> | null = null;
-
-    // Poll for terminal status. We rely on startedAt to cap the total wait
-    // rather than calling getRun() because the run dir may not exist for
-    // SQLite-only sessions (H-FE-2). When the backend implements proper run
-    // status surfacing, replace this ceiling logic with a real status fetch.
-    const tick = () => {
-      if (cancelled) return;
-      if (Date.now() - startedAtRef.current > POLL_MAX_MS) {
-        if (!cancelled) {
-          setRunStatus("failed");
-          setRunError("Run timed out after 10 minutes");
-          setActiveRunId(null);
-        }
-        return;
-      }
-      handle = setTimeout(tick, 2000);
-    };
-
-    handle = setTimeout(tick, 2000);
-
-    return () => {
-      cancelled = true;
-      if (handle != null) clearTimeout(handle);
-    };
-    // POLL_MAX_MS is a module-scope constant hoisted to module scope — not a dep.
-  }, [activeRunId]);
-
-  const handleRun = useCallback(async () => {
-    setRunError("Not yet available");
-  }, []);
 
   if (error) {
     return (
@@ -149,26 +75,9 @@ function WorkerDetailPage() {
         ) : null}
 
         <div className="ml-auto flex items-center gap-2">
-          {runStatus === "running" && (
-            <span className="inline-flex items-center gap-1 text-meta text-status-running">
-              <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-status-running" />
-              running
-            </span>
-          )}
-          {runStatus === "completed" && <StatusPill value="completed" kind="lifecycle" />}
-          {runStatus === "failed" && <StatusPill value="failed" kind="lifecycle" />}
-
-          {/* M-FE-1: surface run errors near the Run control */}
-          {runError && (
-            <span className="max-w-[20rem] truncate rounded border border-status-error/30 bg-status-error-bg px-2 py-0.5 text-meta text-status-error">
-              {runError}
-            </span>
-          )}
-
           <Button
             variant="primary"
             size="sm"
-            onClick={handleRun}
             disabled={runDisabled}
             title={notImplemented.runPlaybook}
             leading="▶"
@@ -186,17 +95,12 @@ function WorkerDetailPage() {
       {/* Canvas — or empty state when no steps */}
       {graph.nodes.length === 0 ? (
         <div className="flex flex-1 items-center justify-center bg-surface-base px-4 py-10">
-          <PlaybookEmptyState workerName={workerName} runDisabled={runDisabled} onRun={handleRun} />
+          <PlaybookEmptyState workerName={workerName} runDisabled={runDisabled} />
         </div>
       ) : (
         <div className="min-h-0 flex-1">
           <Suspense fallback={null}>
-            <WorkerCanvas
-              graph={graph}
-              editable={false}
-              execSteps={execSteps}
-              currentStep={currentStep}
-            />
+            <WorkerCanvas graph={graph} editable={false} />
           </Suspense>
         </div>
       )}
@@ -207,11 +111,9 @@ function WorkerDetailPage() {
 function PlaybookEmptyState({
   workerName,
   runDisabled,
-  onRun,
 }: {
   workerName: string;
   runDisabled: boolean;
-  onRun: () => void;
 }) {
   return (
     <div className="flex max-w-xl flex-col gap-4 rounded-lg border border-edge bg-surface-raised p-6 text-center">
@@ -231,7 +133,6 @@ function PlaybookEmptyState({
         <Button
           variant="primary"
           size="md"
-          onClick={onRun}
           disabled={runDisabled}
           title={notImplemented.runPlaybook}
           leading="▶"

--- a/apps/studio/frontend/src/routes/playbooks/new/index.tsx
+++ b/apps/studio/frontend/src/routes/playbooks/new/index.tsx
@@ -5,10 +5,10 @@ export const Route = createFileRoute("/playbooks/new/")({
   component: NewWorkerPage,
 });
 
-// H-FE-983: POST /api/playbooks/{name} returns 501. This page previously
-// rendered a full canvas form whose Create button called that route. The
-// form is replaced with a hold-message until the backend is implemented.
-// Option A (implement the route) is tracked in the issue.
+// POST /api/playbooks/{name} returns 501. This page previously rendered a
+// full canvas form whose Create button called that route. The form is
+// replaced with a hold-message until the backend implements playbook
+// creation.
 
 function NewWorkerPage() {
   return (

--- a/apps/studio/frontend/src/routes/teams/$id/index.tsx
+++ b/apps/studio/frontend/src/routes/teams/$id/index.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import PageHeader from "@/components/PageHeader";
 import Timestamp from "@/components/Timestamp";
 import { getTeam } from "@/lib/api";
-import type { TeamDetail } from "@/lib/api";
+import type { TeamDetail, TeamMessage } from "@/lib/api";
 import { errors } from "@/lib/copy";
 
 export const Route = createFileRoute("/teams/$id/")({
@@ -18,20 +18,20 @@ function JsonTree({ value }: { value: unknown }) {
   );
 }
 
-function TeamMessages({ messages }: { messages: unknown[] }) {
+function TeamMessages({ messages }: { messages: TeamMessage[] }) {
   return (
     <div className="flex flex-col gap-2">
-      {messages.map((msg, i) => {
-        const m = msg as Record<string, unknown>;
+      {messages.map((m) => {
+        const to = Array.isArray(m.to) ? m.to.join(", ") : m.to;
         return (
-          <div key={i} className="rounded border border-edge bg-surface-overlay p-3 text-body">
+          <div key={m.id} className="rounded border border-edge bg-surface-overlay p-3 text-body">
             <div className="mb-1 flex items-center gap-3 text-meta text-content-muted">
-              <span className="font-mono">{String(m.from ?? "?")}</span>
+              <span className="font-mono">{m.from}</span>
               <span>→</span>
-              <span className="font-mono">{String(m.to ?? "?")}</span>
-              {m.timestamp != null && <Timestamp value={m.timestamp as string | number | null} />}
+              <span className="font-mono">{to}</span>
+              {m.timestamp != null && <Timestamp value={m.timestamp} />}
             </div>
-            {m.content != null && <div className="text-content-secondary">{String(m.content)}</div>}
+            {m.content != null && <div className="text-content-secondary">{m.content}</div>}
           </div>
         );
       })}


### PR DESCRIPTION
## Summary

Slice S1 of the Studio frontend fix-up plan (#1713): correctness + hosted-mode blockers.

- **Dashboard through the API wrapper**: `routes/index.tsx` no longer builds its own `fetch(\`${API_BASE}/api/...\`)` calls — it uses `listRuns({ per_page: 2000 })` / `listShows()`, so the bearer token header and API-base resolution apply uniformly (token mode worked for every page except the dashboard).
- **Playbook run page honesty**: `POST /api/playbooks/{name}/run` is a genuine 501 stub on the daemon (`services/playbooks.py`, lift-backend-writes TODO). The page carried a run-progress state machine (`execSteps`/`currentStep`) that could never populate because `startRun()` was unreachable (Run button permanently disabled). Deleted the inert state machine rather than faking progress wiring; the documented limitation stays visible in the UI.
- **Run types unified**: `RunDetail` drops stale filesystem-era fields (`worker_name`, `finished_at` — zero frontend usages) and gains `playbook_name`/`agent_name` to match what the daemon actually returns.
- **TeamDetail typed**: `TeamDetail`/`TeamMessage` typed from the `li team` JSON schema (`cli/team.py`) instead of `Record<string, unknown>`; `teams/$id` page updated accordingly.
- Internal finding-label scrub in frontend comments (7 occurrences).

## Test plan

- [x] `npm ci` clean
- [x] `npm run lint` — 0 errors (4 pre-existing warnings)
- [x] `npm run build` clean
- [x] `vitest` 21/21 pass
- [x] `format:check` — 3 pre-existing warnings only

Part of #1713 (S1 of S1→S6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
