### PR TITLE
test(studio): seeded-daemon e2e harness + Playwright smoke + CI test gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,8 +119,54 @@ jobs:
       run: |
         npm run lint
         npm run typecheck
+    - name: Unit tests
+      run: npm run test
     - name: Build
       run: npm run build
+
+  studio-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@v7
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.10"
+    - name: Install uv
+      run: |
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+    - name: Install Python dependencies
+      run: |
+        uv venv
+        uv sync --extra studio
+    - uses: actions/setup-node@v6
+      with:
+        node-version: '22'
+        cache: 'npm'
+        cache-dependency-path: apps/studio/frontend/package-lock.json
+    - name: Install frontend dependencies
+      working-directory: apps/studio/frontend
+      run: npm ci
+    - name: Install Playwright browsers
+      working-directory: apps/studio/frontend
+      run: npx playwright install chromium --with-deps
+    # Builds the SPA, boots a seeded daemon + `vite preview` on temp/free-port
+    # infrastructure (never the real ~/.lionagi), and runs the Chromium smoke
+    # specs against it -- see apps/studio/frontend/e2e/ and tests/e2e_studio/.
+    - name: Run seeded-daemon e2e smoke tests
+      working-directory: apps/studio/frontend
+      run: npm run e2e
+    - name: Upload Playwright report
+      if: failure()
+      uses: actions/upload-artifact@v7
+      with:
+        name: studio-e2e-playwright-report
+        path: |
+          apps/studio/frontend/playwright-report/
+          apps/studio/frontend/test-results/
+        retention-days: 7
 
   vscode:
     runs-on: ubuntu-latest

--- a/apps/studio/frontend/.gitignore
+++ b/apps/studio/frontend/.gitignore
@@ -25,3 +25,9 @@ npm-debug.log*
 # misc
 .DS_Store
 *.pem
+
+# playwright
+/playwright-report/
+/test-results/
+/blob-report/
+/playwright/.cache/

--- a/apps/studio/frontend/e2e/global-setup.ts
+++ b/apps/studio/frontend/e2e/global-setup.ts
@@ -1,0 +1,167 @@
+import { spawn, type ChildProcessByStdio } from "node:child_process";
+import type { Readable } from "node:stream";
+import net from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { FullConfig } from "@playwright/test";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// e2e/ -> frontend -> studio -> apps -> repo root
+const REPO_ROOT = path.resolve(__dirname, "../../../..");
+const FRONTEND_ROOT = path.resolve(__dirname, "..");
+
+/** Bind to port 0 and read back the OS-assigned free port. */
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (address && typeof address === "object") {
+        const port = address.port;
+        server.close(() => resolve(port));
+      } else {
+        server.close(() => reject(new Error("failed to allocate a free port")));
+      }
+    });
+  });
+}
+
+function waitForOutput(
+  proc: ChildProcessByStdio<null, Readable, Readable>,
+  matcher: (line: string) => boolean,
+  opts: { timeoutMs: number; label: string },
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let buffer = "";
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      finish(
+        new Error(`${opts.label} did not become ready within ${opts.timeoutMs}ms:\n${buffer}`),
+      );
+    }, opts.timeoutMs);
+
+    function finish(err?: Error) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      proc.stdout.off("data", onData);
+      proc.stderr.off("data", onData);
+      proc.off("exit", onExit);
+      if (err) reject(err);
+      else resolve();
+    }
+
+    function onData(chunk: Buffer) {
+      buffer += chunk.toString();
+      if (buffer.split("\n").some(matcher)) finish();
+    }
+
+    function onExit(code: number | null) {
+      finish(new Error(`${opts.label} exited early (code=${code}):\n${buffer}`));
+    }
+
+    proc.stdout.on("data", onData);
+    proc.stderr.on("data", onData);
+    proc.on("exit", onExit);
+  });
+}
+
+async function waitForHttp(url: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+    } catch (err) {
+      lastError = err;
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(`timed out waiting for ${url}: ${String(lastError)}`);
+}
+
+/**
+ * Terminate *proc* and everything it spawned. Both the daemon and the
+ * preview server are started with `detached: true` (their own process
+ * group), because `uv run` and `npx` are themselves wrapper processes that
+ * may or may not exec() into the real interpreter -- signaling only the
+ * immediate child can leave a grandchild (uvicorn, vite) running as an
+ * orphan. `-pid` signals the whole group instead of just the one process.
+ */
+function killProcess(proc: ChildProcessByStdio<null, Readable, Readable>): Promise<void> {
+  return new Promise((resolve) => {
+    if (proc.exitCode !== null || proc.signalCode !== null || !proc.pid) {
+      resolve();
+      return;
+    }
+    const pid = proc.pid;
+    const timer = setTimeout(() => {
+      try {
+        process.kill(-pid, "SIGKILL");
+      } catch {
+        // group already gone
+      }
+    }, 10_000);
+    proc.once("exit", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+    try {
+      process.kill(-pid, "SIGTERM");
+    } catch {
+      proc.kill("SIGTERM");
+    }
+  });
+}
+
+/**
+ * Brings up a seeded Lion Studio daemon (Python, temp dir + freshly seeded
+ * db -- see tests/e2e_studio/) and a `vite preview` static server proxying
+ * /api to it, both on dynamically-allocated free ports so concurrent runs on
+ * this machine never collide. Returns a teardown closure that tears both
+ * down and lets the daemon clean up its own temp dir.
+ */
+export default async function globalSetup(_config: FullConfig) {
+  const apiPort = await getFreePort();
+  const previewPort = await getFreePort();
+
+  const daemon = spawn(
+    "uv",
+    ["run", "python", "-m", "tests.e2e_studio.run_seeded_daemon", "--port", String(apiPort)],
+    { cwd: REPO_ROOT, stdio: ["ignore", "pipe", "pipe"] },
+  );
+
+  await waitForOutput(daemon, (line) => line.includes("studio-e2e-daemon-ready"), {
+    timeoutMs: 45_000,
+    label: "seeded studio daemon",
+  });
+  await waitForHttp(`http://127.0.0.1:${apiPort}/health`, 10_000);
+
+  const preview = spawn(
+    "npx",
+    ["vite", "preview", "--host", "127.0.0.1", "--port", String(previewPort), "--strictPort"],
+    {
+      cwd: FRONTEND_ROOT,
+      env: { ...process.env, STUDIO_E2E_API_PORT: String(apiPort) },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+
+  await waitForOutput(preview, (line) => /Local:\s*http/i.test(line), {
+    timeoutMs: 30_000,
+    label: "vite preview",
+  });
+
+  const baseURL = `http://127.0.0.1:${previewPort}`;
+  await waitForHttp(baseURL, 15_000);
+  process.env.E2E_BASE_URL = baseURL;
+
+  return async function globalTeardown() {
+    await killProcess(preview);
+    await killProcess(daemon);
+  };
+}

--- a/apps/studio/frontend/e2e/global-setup.ts
+++ b/apps/studio/frontend/e2e/global-setup.ts
@@ -10,6 +10,18 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "../../../..");
 const FRONTEND_ROOT = path.resolve(__dirname, "..");
 
+type Proc = ChildProcessByStdio<null, Readable, Readable>;
+
+// Vite colors its CLI output; naive substring/regex matching on raw stdout
+// breaks on the embedded ANSI escape codes, so every buffer is stripped
+// before it is matched against.
+const ANSI_PATTERN = /\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
+function stripAnsi(text: string): string {
+  return text.replace(ANSI_PATTERN, "");
+}
+
+const PORT_IN_USE_PATTERN = /EADDRINUSE|already in use/i;
+
 /** Bind to port 0 and read back the OS-assigned free port. */
 function getFreePort(): Promise<number> {
   return new Promise((resolve, reject) => {
@@ -29,7 +41,7 @@ function getFreePort(): Promise<number> {
 }
 
 function waitForOutput(
-  proc: ChildProcessByStdio<null, Readable, Readable>,
+  proc: Proc,
   matcher: (line: string) => boolean,
   opts: { timeoutMs: number; label: string },
 ): Promise<void> {
@@ -55,7 +67,7 @@ function waitForOutput(
     }
 
     function onData(chunk: Buffer) {
-      buffer += chunk.toString();
+      buffer += stripAnsi(chunk.toString());
       if (buffer.split("\n").some(matcher)) finish();
     }
 
@@ -92,9 +104,9 @@ async function waitForHttp(url: string, timeoutMs: number): Promise<void> {
  * immediate child can leave a grandchild (uvicorn, vite) running as an
  * orphan. `-pid` signals the whole group instead of just the one process.
  */
-function killProcess(proc: ChildProcessByStdio<null, Readable, Readable>): Promise<void> {
+function killProcess(proc: Proc | undefined): Promise<void> {
   return new Promise((resolve) => {
-    if (proc.exitCode !== null || proc.signalCode !== null || !proc.pid) {
+    if (!proc || proc.exitCode !== null || proc.signalCode !== null || !proc.pid) {
       resolve();
       return;
     }
@@ -118,50 +130,111 @@ function killProcess(proc: ChildProcessByStdio<null, Readable, Readable>): Promi
   });
 }
 
+interface StartResult {
+  proc: Proc;
+  port: number;
+}
+
+/**
+ * Spawns via *spawnFn(port)*, waits for *ready*, and retries on a fresh free
+ * port if the child reports the port was already taken -- getFreePort()'s
+ * allocate-then-close leaves a window where a concurrent run on this
+ * machine (several worktrees/agents commonly run at once here) can grab the
+ * same port first.
+ */
+async function startOnFreePort(
+  spawnFn: (port: number) => Proc,
+  ready: (proc: Proc) => Promise<void>,
+  label: string,
+  maxAttempts = 5,
+): Promise<StartResult> {
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const port = await getFreePort();
+    const proc = spawnFn(port);
+    try {
+      await ready(proc);
+      return { proc, port };
+    } catch (err) {
+      await killProcess(proc);
+      const message = err instanceof Error ? err.message : String(err);
+      lastErr = err;
+      if (!PORT_IN_USE_PATTERN.test(message) || attempt === maxAttempts) {
+        throw err;
+      }
+      console.warn(
+        `${label}: port ${port} was taken by another process, retrying (attempt ${attempt}/${maxAttempts})`,
+      );
+    }
+  }
+  throw lastErr instanceof Error ? lastErr : new Error(`${label}: exhausted retries`);
+}
+
 /**
  * Brings up a seeded Lion Studio daemon (Python, temp dir + freshly seeded
  * db -- see tests/e2e_studio/) and a `vite preview` static server proxying
  * /api to it, both on dynamically-allocated free ports so concurrent runs on
  * this machine never collide. Returns a teardown closure that tears both
- * down and lets the daemon clean up its own temp dir.
+ * down and lets the daemon clean up its own temp dir. Any failure partway
+ * through setup tears down whatever already started before rethrowing, so a
+ * broken run never leaks a daemon/preview process or a seeded temp dir.
  */
 export default async function globalSetup(_config: FullConfig) {
-  const apiPort = await getFreePort();
-  const previewPort = await getFreePort();
+  let daemon: Proc | undefined;
+  let preview: Proc | undefined;
 
-  const daemon = spawn(
-    "uv",
-    ["run", "python", "-m", "tests.e2e_studio.run_seeded_daemon", "--port", String(apiPort)],
-    { cwd: REPO_ROOT, stdio: ["ignore", "pipe", "pipe"] },
-  );
+  try {
+    const daemonResult = await startOnFreePort(
+      (port) =>
+        spawn(
+          "uv",
+          ["run", "python", "-m", "tests.e2e_studio.run_seeded_daemon", "--port", String(port)],
+          { cwd: REPO_ROOT, stdio: ["ignore", "pipe", "pipe"], detached: true },
+        ),
+      (proc) =>
+        waitForOutput(proc, (line) => line.includes("studio-e2e-daemon-ready"), {
+          timeoutMs: 45_000,
+          label: "seeded studio daemon",
+        }),
+      "seeded studio daemon",
+    );
+    daemon = daemonResult.proc;
+    const apiPort = daemonResult.port;
+    await waitForHttp(`http://127.0.0.1:${apiPort}/health`, 10_000);
 
-  await waitForOutput(daemon, (line) => line.includes("studio-e2e-daemon-ready"), {
-    timeoutMs: 45_000,
-    label: "seeded studio daemon",
-  });
-  await waitForHttp(`http://127.0.0.1:${apiPort}/health`, 10_000);
+    const previewResult = await startOnFreePort(
+      (port) =>
+        spawn(
+          "npx",
+          ["vite", "preview", "--host", "127.0.0.1", "--port", String(port), "--strictPort"],
+          {
+            cwd: FRONTEND_ROOT,
+            env: { ...process.env, STUDIO_E2E_API_PORT: String(apiPort) },
+            stdio: ["ignore", "pipe", "pipe"],
+            detached: true,
+          },
+        ),
+      (proc) =>
+        waitForOutput(proc, (line) => /Local:\s*http/i.test(line), {
+          timeoutMs: 30_000,
+          label: "vite preview",
+        }),
+      "vite preview",
+    );
+    preview = previewResult.proc;
+    const previewPort = previewResult.port;
 
-  const preview = spawn(
-    "npx",
-    ["vite", "preview", "--host", "127.0.0.1", "--port", String(previewPort), "--strictPort"],
-    {
-      cwd: FRONTEND_ROOT,
-      env: { ...process.env, STUDIO_E2E_API_PORT: String(apiPort) },
-      stdio: ["ignore", "pipe", "pipe"],
-    },
-  );
+    const baseURL = `http://127.0.0.1:${previewPort}`;
+    await waitForHttp(baseURL, 15_000);
+    process.env.E2E_BASE_URL = baseURL;
 
-  await waitForOutput(preview, (line) => /Local:\s*http/i.test(line), {
-    timeoutMs: 30_000,
-    label: "vite preview",
-  });
-
-  const baseURL = `http://127.0.0.1:${previewPort}`;
-  await waitForHttp(baseURL, 15_000);
-  process.env.E2E_BASE_URL = baseURL;
-
-  return async function globalTeardown() {
+    return async function globalTeardown() {
+      await killProcess(preview);
+      await killProcess(daemon);
+    };
+  } catch (err) {
     await killProcess(preview);
     await killProcess(daemon);
-  };
+    throw err;
+  }
 }

--- a/apps/studio/frontend/e2e/smoke.spec.ts
+++ b/apps/studio/frontend/e2e/smoke.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "@playwright/test";
+
+// Must match tests/e2e_studio/fixtures.py -- the seeded schedule name asserted
+// on below is only ever produced by the seeded daemon's fixtures.
+const SMOKE_SCHEDULE_NAME = "e2e-smoke-nightly-report";
+
+test("app boots, root renders, and the page logs no console errors", async ({ page }) => {
+  const errors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") errors.push(msg.text());
+  });
+  page.on("pageerror", (err) => errors.push(err.message));
+
+  await page.goto("/");
+  await expect(page.locator("#root")).not.toBeEmpty();
+  expect(errors, `console errors:\n${errors.join("\n")}`).toEqual([]);
+});
+
+test("schedules page renders data that only the seeded db could supply", async ({ page }) => {
+  await page.goto("/schedules");
+  await expect(page.getByText(SMOKE_SCHEDULE_NAME)).toBeVisible();
+});
+
+test("direct URL navigation renders /schedules and /agents, never a blank screen", async ({
+  page,
+}) => {
+  for (const route of ["/schedules", "/agents"]) {
+    await page.goto(route);
+    const rootText = (await page.locator("#root").innerText()).trim();
+    expect(rootText.length, `${route} rendered a blank page`).toBeGreaterThan(0);
+  }
+});

--- a/apps/studio/frontend/package-lock.json
+++ b/apps/studio/frontend/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "frontend",
       "dependencies": {
         "@tanstack/react-router": "^1.170.15",
         "@types/dagre": "^0.7.54",
@@ -19,6 +18,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.5",
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "^1.61.1",
         "@tanstack/router-plugin": "^1.168.18",
         "@types/node": "^20.12.0",
         "@types/react": "^19.2.15",
@@ -885,6 +885,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@reactflow/background": {
@@ -7547,6 +7563,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/apps/studio/frontend/package.json
+++ b/apps/studio/frontend/package.json
@@ -10,7 +10,8 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "e2e": "npm run build && playwright test"
   },
   "dependencies": {
     "@tanstack/react-router": "^1.170.15",
@@ -25,6 +26,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",
+    "@playwright/test": "^1.61.1",
     "@eslint/js": "^10.0.1",
     "@tanstack/router-plugin": "^1.168.18",
     "@types/node": "^20.12.0",

--- a/apps/studio/frontend/playwright.config.ts
+++ b/apps/studio/frontend/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// Smoke-only scaffold: the UI is being redesigned in parallel, so this
+// deliberately stays shallow (boot + one API round-trip + direct-nav checks)
+// against a seeded daemon (see e2e/global-setup.ts and tests/e2e_studio/).
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 15_000,
+  globalTimeout: 5 * 60_000,
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  forbidOnly: !!process.env.CI,
+  globalSetup: "./e2e/global-setup.ts",
+  reporter: [["list"], ["html", { open: "never", outputFolder: "playwright-report" }]],
+  use: {
+    baseURL: process.env.E2E_BASE_URL,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "off",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -177,7 +177,11 @@ export async function listRuns(params?: RunListParams): Promise<RunListResponse>
   if (params?.project) query.set("project", params.project);
   for (const value of params?.status ?? []) query.append("status", value);
   const suffix = query.toString() ? `?${query.toString()}` : "";
-  return fetchJson<RunListResponse>(`/api/runs${suffix}`);
+  // The daemon registers this list route with a trailing slash (unlike
+  // /api/runs/{run_id}); omitting it triggers Starlette's redirect-with-
+  // absolute-Location, which the browser then blocks as cross-origin
+  // whenever the frontend is served from a different origin than the daemon.
+  return fetchJson<RunListResponse>(`/api/runs/${suffix}`);
 }
 
 export async function getRun(runId: string): Promise<RunDetail> {

--- a/apps/studio/frontend/tsconfig.json
+++ b/apps/studio/frontend/tsconfig.json
@@ -17,6 +17,12 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "vite.config.mts"],
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "vite.config.mts",
+    "playwright.config.ts",
+    "e2e/**/*.ts"
+  ],
   "exclude": ["node_modules", "app/**", "next.config.mjs", "next-env.d.ts"]
 }

--- a/apps/studio/frontend/vite.config.mts
+++ b/apps/studio/frontend/vite.config.mts
@@ -3,6 +3,10 @@ import react from '@vitejs/plugin-react'
 import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
 import path from 'path'
 
+// The e2e harness points this at a seeded daemon on a dynamically-allocated
+// free port (see e2e/global-setup.ts); everyone else keeps the default 8765.
+const apiTarget = `http://localhost:${process.env.STUDIO_E2E_API_PORT ?? '8765'}`
+
 export default defineConfig({
   plugins: [
     TanStackRouterVite({
@@ -18,11 +22,22 @@ export default defineConfig({
   },
   server: {
     proxy: {
-      '/api': 'http://localhost:8765',
+      '/api': apiTarget,
+    },
+  },
+  // `vite preview` serves the production build the same way the e2e harness
+  // does: a single static origin proxying /api server-side, so the browser
+  // never needs CORS and resolveApiBase() picks up the same-origin ("") path.
+  preview: {
+    proxy: {
+      '/api': apiTarget,
     },
   },
   test: {
     environment: 'jsdom',
     globals: true,
+    // e2e/ holds Playwright specs (see playwright.config.ts) -- a different
+    // test runner with its own test()/expect(), never vitest's.
+    exclude: ['e2e/**', 'node_modules/**'],
   },
 })

--- a/apps/studio/frontend/vite.config.mts
+++ b/apps/studio/frontend/vite.config.mts
@@ -5,7 +5,10 @@ import path from 'path'
 
 // The e2e harness points this at a seeded daemon on a dynamically-allocated
 // free port (see e2e/global-setup.ts); everyone else keeps the default 8765.
-const apiTarget = `http://localhost:${process.env.STUDIO_E2E_API_PORT ?? '8765'}`
+// 127.0.0.1, not localhost: the daemon binds IPv4 explicitly, and on hosts
+// where localhost resolves to ::1 first, proxying to it would fail even
+// though preview itself (bound to --host 127.0.0.1) is healthy.
+const apiTarget = `http://127.0.0.1:${process.env.STUDIO_E2E_API_PORT ?? '8765'}`
 
 export default defineConfig({
   plugins: [

--- a/tests/e2e_studio/__init__.py
+++ b/tests/e2e_studio/__init__.py
@@ -1,0 +1,9 @@
+"""Seeded-daemon harness for the Lion Studio Playwright e2e suite.
+
+Everything in this package runs the Studio FastAPI daemon against a throwaway
+temp directory with a freshly seeded state db -- it never reads or writes the
+real ``~/.lionagi``. See ``harness.py`` for the safety invariant and
+``fixtures.py`` for the deterministic seed data.
+"""
+
+from __future__ import annotations

--- a/tests/e2e_studio/fixtures.py
+++ b/tests/e2e_studio/fixtures.py
@@ -1,0 +1,202 @@
+"""Deterministic seed data for the seeded-daemon e2e harness.
+
+Every id/name here is content the Playwright smoke specs assert against, so
+values are fixed strings (never randomly generated) while primary keys stay
+unique per run via a short uuid suffix.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from lionagi.state.db import StateDB
+from lionagi.state.reasons import RunReasons
+
+# Stable, greppable names the Playwright specs assert on by accessible text.
+SMOKE_SCHEDULE_NAME = "e2e-smoke-nightly-report"
+SMOKE_FAILING_SCHEDULE_NAME = "e2e-smoke-flaky-sync"
+SMOKE_SESSION_NAME = "e2e-smoke-completed-run"
+SMOKE_AGENT_NAME = "e2e-smoke-reviewer"
+SMOKE_PLAYBOOK_NAME = "e2e-smoke-release-checklist"
+SMOKE_PROJECT_NAME = "e2e-smoke-project"
+
+SESSION_STATUSES = (
+    "running",
+    "completed",
+    "failed",
+    "timed_out",
+    "aborted",
+    "cancelled",
+)
+
+
+def _uid(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:12]}"
+
+
+async def seed_state_db(db: StateDB) -> dict[str, Any]:
+    """Populate *db* with fixtures covering every session status, a stale
+    phantom "running" session, failing schedules/invocations, and a project.
+
+    Returns a manifest of created ids, mostly useful for debugging the
+    harness itself -- the Playwright specs assert on the stable names above,
+    not on these ids.
+    """
+    now = time.time()
+    manifest: dict[str, Any] = {"sessions": {}, "invocations": {}, "schedules": {}}
+
+    for status in SESSION_STATUSES:
+        session_id = _uid(f"session-{status}")
+        progression_id = _uid("prog")
+        await db.create_progression(progression_id)
+        name = SMOKE_SESSION_NAME if status == "completed" else f"e2e-smoke-session-{status}"
+        await db.create_session(
+            {
+                "id": session_id,
+                "progression_id": progression_id,
+                "name": name,
+                "status": status,
+                "invocation_kind": "agent",
+                "source_kind": "live",
+                "started_at": now - 3600,
+                "ended_at": None if status == "running" else now - 60,
+                "agent_name": SMOKE_AGENT_NAME,
+                "project": SMOKE_PROJECT_NAME,
+                "project_source": "studio",
+            }
+        )
+        manifest["sessions"][status] = session_id
+
+    # A "running" session that is actually long-stale with no live process
+    # behind it. The daemon's own startup reconciliation
+    # (studio.services.lifecycle.reap_phantom_sessions) transitions this to
+    # "failed" before /health ever responds -- seeded anyway so that real
+    # reconciliation code path runs for real instead of being mocked out.
+    # Its updated_at is set 2h in the past, past the 1h PHANTOM_STALE_HOURS
+    # default, and it carries no artifacts_path/pid file, so it always
+    # classifies as a dead-process phantom.
+    phantom_id = _uid("session-phantom")
+    phantom_progression_id = _uid("prog")
+    await db.create_progression(phantom_progression_id)
+    await db.create_session(
+        {
+            "id": phantom_id,
+            "progression_id": phantom_progression_id,
+            "name": "e2e-smoke-session-phantom-stale",
+            "status": "running",
+            "invocation_kind": "agent",
+            "source_kind": "live",
+            "started_at": now - 7200,
+            "updated_at": now - 7200,
+            "agent_name": SMOKE_AGENT_NAME,
+            "project": SMOKE_PROJECT_NAME,
+            "project_source": "studio",
+        }
+    )
+    manifest["sessions"]["phantom"] = phantom_id
+
+    # An invocation that failed with a reason code + error detail.
+    failed_invocation_id = _uid("invocation")
+    await db.create_invocation(
+        {
+            "id": failed_invocation_id,
+            "skill": "e2e-smoke-review",
+            "started_at": now - 1800,
+            "status": "running",
+        }
+    )
+    await db.update_invocation(
+        failed_invocation_id,
+        status="failed",
+        ended_at=now - 1700,
+        reason_code=RunReasons.FAILED_EXIT_NONZERO,
+        reason_summary="e2e smoke fixture: nonzero exit seeded for coverage",
+    )
+    manifest["invocations"]["failed"] = failed_invocation_id
+
+    # Schedules are seeded disabled so the daemon's live 30s scheduler tick
+    # never fires a real subprocess action during the test run, regardless
+    # of timing (studio.scheduler.engine only evaluates enabled=True rows).
+    spent_schedule_id = _uid("schedule")
+    await db.create_schedule(
+        {
+            "id": spent_schedule_id,
+            "name": SMOKE_SCHEDULE_NAME,
+            "description": "Spent one-shot fixture for e2e smoke assertions.",
+            "enabled": 0,
+            "trigger_type": "cron",
+            "cron_expr": "0 0 1 1 *",
+            "action_kind": "agent",
+            "action_agent": SMOKE_AGENT_NAME,
+            "last_fired_at": now - 86400,
+            "next_fire_at": None,
+            "max_runs": 1,
+            "project": SMOKE_PROJECT_NAME,
+        }
+    )
+    manifest["schedules"]["spent"] = spent_schedule_id
+
+    failing_schedule_id = _uid("schedule")
+    await db.create_schedule(
+        {
+            "id": failing_schedule_id,
+            "name": SMOKE_FAILING_SCHEDULE_NAME,
+            "description": "Failure-streak fixture for e2e smoke assertions.",
+            "enabled": 0,
+            "trigger_type": "interval",
+            "interval_sec": 3600,
+            "action_kind": "agent",
+            "action_agent": SMOKE_AGENT_NAME,
+            "last_fired_at": now - 600,
+            "next_fire_at": now + 3600,
+            "project": SMOKE_PROJECT_NAME,
+        }
+    )
+    manifest["schedules"]["failing"] = failing_schedule_id
+
+    for i in range(3):
+        await db.create_schedule_run(
+            {
+                "id": _uid("schedule-run"),
+                "schedule_id": failing_schedule_id,
+                "trigger_context": {"seed": True},
+                "action_kind": "agent",
+                "action_args": {"agent": SMOKE_AGENT_NAME},
+                "status": "failed",
+                "exit_code": 1,
+                "fired_at": now - 600 - (i * 300),
+                "ended_at": now - 590 - (i * 300),
+                "error_detail": "e2e smoke fixture: simulated consecutive failure",
+            }
+        )
+
+    await db.register_project(SMOKE_PROJECT_NAME, "studio")
+
+    return manifest
+
+
+def seed_filesystem_fixtures(lionagi_home: Path) -> None:
+    """Write a couple of agent/playbook definition files under *lionagi_home*
+    so the Library-style list pages have real rows to render."""
+    agents_dir = lionagi_home / "agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    (agents_dir / f"{SMOKE_AGENT_NAME}.md").write_text(
+        "---\n"
+        "description: Seeded reviewer agent for the e2e smoke harness.\n"
+        "model: claude-sonnet-4-5\n"
+        "provider: anthropic\n"
+        "---\n\n"
+        "You are a seeded fixture agent used only by the Playwright smoke suite.\n"
+    )
+
+    playbooks_dir = lionagi_home / "playbooks"
+    playbooks_dir.mkdir(parents=True, exist_ok=True)
+    (playbooks_dir / f"{SMOKE_PLAYBOOK_NAME}.playbook.yaml").write_text(
+        "description: Seeded release-checklist playbook for the e2e smoke harness.\n"
+        "steps:\n"
+        "  - name: seed-step\n"
+        "    prompt: This is a fixture step; never executed by the smoke suite.\n"
+    )

--- a/tests/e2e_studio/harness.py
+++ b/tests/e2e_studio/harness.py
@@ -1,0 +1,181 @@
+"""Spins up a Lion Studio daemon subprocess pointed entirely at a temp dir.
+
+Hard safety rule: this harness must NEVER read or write the real
+``~/.lionagi`` (state db, agents/playbooks roots, or anything else under it).
+Every path the daemon could resolve is redirected via env vars set *before*
+the subprocess starts -- the daemon's path constants are module-level and
+resolved once at import time, so an in-process monkeypatch would not reach a
+separate subprocess; only subprocess env does. The resolved db path is also
+asserted to live under the temp dir before any seeding happens, so a future
+change to path-resolution logic that silently drifted back to the real home
+directory would fail loudly here instead of quietly reading/writing it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+from lionagi.state.db import StateDB
+
+from .fixtures import seed_filesystem_fixtures, seed_state_db
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REAL_LIONAGI_HOME = Path("~/.lionagi").expanduser().resolve()
+
+
+def _free_port() -> int:
+    """Bind to port 0 and read back the OS-assigned free port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+async def _seed(db_path: Path, tmp_dir: Path) -> None:
+    seed_filesystem_fixtures(tmp_dir)
+    db = StateDB(db_path)
+    await db.open()
+    try:
+        # The one line of defense that must never be able to silently pass
+        # against the real home directory: verify the path StateDB actually
+        # resolved to (not just the path we intended to pass it) is under
+        # the temp dir, and is not the real state db.
+        resolved = db.path
+        if resolved is None or not resolved.resolve().is_relative_to(tmp_dir.resolve()):
+            raise RuntimeError(
+                f"refusing to seed outside the temp dir: resolved db path "
+                f"{resolved} is not under {tmp_dir}"
+            )
+        if resolved.resolve() == REAL_LIONAGI_HOME / "state.db":
+            raise RuntimeError("refusing to seed the real ~/.lionagi/state.db")
+        await seed_state_db(db)
+    finally:
+        await db.close()
+
+
+@dataclass
+class SeededDaemon:
+    """A running Studio daemon subprocess + the temp dir backing it."""
+
+    tmp_dir: Path
+    db_path: Path
+    host: str
+    port: int
+    process: subprocess.Popen
+
+    @property
+    def base_url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    @classmethod
+    def start(
+        cls,
+        *,
+        host: str = "127.0.0.1",
+        port: int | None = None,
+        ready_timeout: float = 30.0,
+    ) -> SeededDaemon:
+        tmp_dir = Path(tempfile.mkdtemp(prefix="lionagi-e2e-studio-"))
+        db_path = tmp_dir / "state.db"
+
+        assert db_path.resolve().is_relative_to(tmp_dir.resolve()), (
+            f"refusing to seed outside temp dir: {db_path} not under {tmp_dir}"
+        )
+        assert db_path.resolve() != REAL_LIONAGI_HOME / "state.db", (
+            "refusing to seed the real ~/.lionagi/state.db"
+        )
+
+        try:
+            asyncio.run(_seed(db_path, tmp_dir))
+        except Exception:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+            raise
+
+        if port is None:
+            port = _free_port()
+
+        env = dict(os.environ)
+        env["LIONAGI_HOME"] = str(tmp_dir)
+        env["LIONAGI_STATE_DB_URL"] = str(db_path)
+        env["LIONAGI_SHOWS_ROOT"] = str(tmp_dir / "shows")
+        env["LIONAGI_STUDIO_HOST"] = host
+        env["LIONAGI_STUDIO_PORT"] = str(port)
+        # Disable the in-process Claude Code mirror: it tails the real
+        # ~/.claude/projects regardless of LIONAGI_HOME, which would inject
+        # nondeterministic content and violate the "never touch the real
+        # home dir" rule in spirit even though it's a different tree.
+        env["LIONAGI_STUDIO_MIRROR_CLAUDE"] = "0"
+        # Deterministic no-auth, API-only daemon regardless of ambient shell env.
+        env.pop("LIONAGI_STUDIO_AUTH_TOKEN", None)
+        env.pop("LIONAGI_STUDIO_FRONTEND_DIST", None)
+        env.pop("LIONAGI_STUDIO_URL", None)
+
+        process = subprocess.Popen(  # noqa: S603
+            [
+                sys.executable,
+                "-m",
+                "uvicorn",
+                "lionagi.studio.app:app",
+                "--host",
+                host,
+                "--port",
+                str(port),
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+
+        daemon = cls(tmp_dir=tmp_dir, db_path=db_path, host=host, port=port, process=process)
+        try:
+            daemon._wait_healthy(ready_timeout)
+        except Exception:
+            daemon.stop()
+            raise
+        return daemon
+
+    def _wait_healthy(self, timeout: float) -> None:
+        deadline = time.monotonic() + timeout
+        url = f"{self.base_url}/health"
+        last_err: Exception | None = None
+        while time.monotonic() < deadline:
+            if self.process.poll() is not None:
+                output = self.process.stdout.read() if self.process.stdout else ""
+                raise RuntimeError(
+                    f"seeded daemon exited early (code={self.process.returncode}):\n{output}"
+                )
+            try:
+                with urllib.request.urlopen(url, timeout=2) as resp:  # noqa: S310
+                    if resp.status == 200:
+                        return
+            except (urllib.error.URLError, ConnectionError, TimeoutError) as exc:
+                last_err = exc
+            time.sleep(0.25)
+        raise TimeoutError(f"seeded daemon never became healthy at {url}: {last_err}")
+
+    def stop(self, *, timeout: float = 10.0) -> None:
+        if self.process.poll() is None:
+            with contextlib.suppress(ProcessLookupError):
+                self.process.send_signal(signal.SIGTERM)
+            try:
+                self.process.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                with contextlib.suppress(ProcessLookupError):
+                    self.process.kill()
+                with contextlib.suppress(subprocess.TimeoutExpired):
+                    self.process.wait(timeout=5)
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)

--- a/tests/e2e_studio/run_seeded_daemon.py
+++ b/tests/e2e_studio/run_seeded_daemon.py
@@ -1,0 +1,64 @@
+"""CLI bridge invoked by the Playwright global setup.
+
+Run as a module (so the relative import below resolves) from the repo root:
+
+    uv run python -m tests.e2e_studio.run_seeded_daemon --port <port>
+
+Starts a seeded Studio daemon subprocess, prints one JSON line to stdout once
+it is healthy, then blocks until SIGTERM/SIGINT, tearing the daemon and its
+temp dir down on exit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import signal
+import sys
+import time
+
+from .harness import SeededDaemon
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=None)
+    parser.add_argument("--ready-timeout", type=float, default=30.0)
+    args = parser.parse_args(argv)
+
+    daemon = SeededDaemon.start(host=args.host, port=args.port, ready_timeout=args.ready_timeout)
+
+    print(
+        json.dumps(
+            {
+                "event": "studio-e2e-daemon-ready",
+                "base_url": daemon.base_url,
+                "host": daemon.host,
+                "port": daemon.port,
+                "tmp_dir": str(daemon.tmp_dir),
+            }
+        ),
+        flush=True,
+    )
+
+    stop_requested = False
+
+    def _handle_signal(signum: int, frame: object) -> None:
+        nonlocal stop_requested
+        stop_requested = True
+
+    signal.signal(signal.SIGTERM, _handle_signal)
+    signal.signal(signal.SIGINT, _handle_signal)
+
+    try:
+        while not stop_requested and daemon.process.poll() is None:
+            time.sleep(0.25)
+    finally:
+        daemon.stop()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/e2e_studio/test_fixtures.py
+++ b/tests/e2e_studio/test_fixtures.py
@@ -1,0 +1,84 @@
+"""Unit coverage for the seed-data builder and the harness safety assertion.
+
+These run in-process against an in-memory StateDB (no subprocess, no
+browser) -- the Playwright specs are the actual end-to-end coverage; this
+file just pins the fixture contract the specs rely on and proves the
+temp-dir safety assertion actually fires on a bad path.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from lionagi.state.db import StateDB
+
+from .fixtures import (
+    SESSION_STATUSES,
+    SMOKE_FAILING_SCHEDULE_NAME,
+    SMOKE_SCHEDULE_NAME,
+    SMOKE_SESSION_NAME,
+    seed_filesystem_fixtures,
+    seed_state_db,
+)
+from .harness import _seed
+
+
+@pytest.fixture
+async def db():
+    state = StateDB(":memory:")
+    await state.open()
+    yield state
+    await state.close()
+
+
+async def test_seed_state_db_covers_every_session_status(db):
+    manifest = await seed_state_db(db)
+
+    for status in SESSION_STATUSES:
+        session = await db.get_session(manifest["sessions"][status])
+        assert session["status"] == status
+
+    completed = await db.get_session(manifest["sessions"]["completed"])
+    assert completed["name"] == SMOKE_SESSION_NAME
+
+
+async def test_seed_state_db_phantom_session_is_stale_running(db):
+    manifest = await seed_state_db(db)
+    phantom = await db.get_session(manifest["sessions"]["phantom"])
+    assert phantom["status"] == "running"
+    assert phantom["name"] == "e2e-smoke-session-phantom-stale"
+
+
+async def test_seed_state_db_failed_invocation_has_reason(db):
+    manifest = await seed_state_db(db)
+    invocation = await db.get_invocation(manifest["invocations"]["failed"])
+    assert invocation["status"] == "failed"
+    assert invocation["status_reason_code"] == "run.failed.exit_nonzero"
+
+
+async def test_seed_state_db_schedules_are_disabled(db):
+    await seed_state_db(db)
+    spent = await db.get_schedule_by_name(SMOKE_SCHEDULE_NAME)
+    failing = await db.get_schedule_by_name(SMOKE_FAILING_SCHEDULE_NAME)
+    assert spent["enabled"] == 0
+    assert failing["enabled"] == 0
+
+    runs = await db.list_schedule_runs(failing["id"])
+    assert len(runs) == 3
+    assert all(run["status"] == "failed" for run in runs)
+
+
+def test_seed_filesystem_fixtures_writes_agent_and_playbook(tmp_path: Path):
+    seed_filesystem_fixtures(tmp_path)
+    assert (tmp_path / "agents" / "e2e-smoke-reviewer.md").exists()
+    assert (tmp_path / "playbooks" / "e2e-smoke-release-checklist.playbook.yaml").exists()
+
+
+async def test_seed_refuses_a_db_path_outside_the_temp_dir():
+    with tempfile.TemporaryDirectory() as tmp_dir, tempfile.TemporaryDirectory() as other_dir:
+        outside_db_path = Path(other_dir) / "state.db"
+        with pytest.raises(RuntimeError, match="outside the temp dir"):
+            await _seed(outside_db_path, Path(tmp_dir))


### PR DESCRIPTION
## Summary

- Adds `tests/e2e_studio/`: a harness that seeds a fresh `StateDB` (via lionagi's own SQLAlchemy schema, never hand-copied DDL) in a temp directory and boots the Lion Studio daemon subprocess against it -- covering every session status (including a stale "running" row with a dead pid, to exercise phantom reconciliation), a spent one-shot schedule and one with a failure streak, invocations carrying ADR-0028 reason codes, and a couple of agents/playbooks/projects so list views render. Every seeded schedule is `enabled=0` so the live scheduler tick can never fire a real subprocess action during a test run.
- **Safety rule**: the harness must never read or write the real `~/.lionagi` tree. `harness.py` points `LIONAGI_HOME`/`LIONAGI_STATE_DB_URL`/`LIONAGI_SHOWS_ROOT` at the temp dir via explicit subprocess env, and separately re-asserts at runtime -- against the `StateDB`'s actually-resolved path, not just the intended one -- that it never resolves outside the temp dir before seeding anything. A unit test proves this assertion actually fires on a bad path.
- Adds a Playwright smoke scaffold at `apps/studio/frontend/e2e/` (Chromium only, deliberately shallow since the UI is being redesigned in parallel): app boots with zero console errors; one page renders content that could only come from the seeded db (asserted by accessible role/text, never CSS classes); direct-URL navigation to `/schedules` and `/agents` renders rather than blanking. `npm run e2e` builds the SPA, serves it with `vite preview` (proxying `/api` to the seeded daemon on a dynamically-allocated free port), runs the specs, then tears both subprocesses down via their process groups (both are spawned `detached: true`, since `uv run`/`npx` are wrapper processes and signaling only the immediate child can orphan a uvicorn/vite grandchild).
- Fixes a real cross-origin bug the harness surfaced: `listRuns()` called `/api/runs` without a trailing slash while the daemon registers that route with one, so Starlette 307-redirects to an absolute `Location` built from the proxy target's host:port, which the browser then blocks as genuinely cross-origin. Scoped to this one call site -- the same missing-slash pattern elsewhere in `api.ts` is left to the in-flight API-client normalization work.
- CI: `frontend` job now runs `npm run test` (vitest) before build. New bounded `studio-e2e` job (15 min timeout, **not** a required check) builds the SPA, installs Playwright's Chromium, and runs `npm run e2e`, uploading the Playwright report as an artifact on failure. The existing `test` job already discovers `tests/e2e_studio/*.py` via `uv sync --all-extras`, so no change was needed there.

## Test plan

- [x] `uv run pytest tests/e2e_studio/` -- 6/6 passed
- [x] `npm run e2e` run three times back-to-back in this branch, all "3 passed"; after each run, confirmed via `ps aux | grep -i "uvicorn\|vite preview"` and a temp-dir glob check that zero daemon/preview processes or `/lionagi-e2e-studio-*` temp directories were left behind
- [x] `npm run lint && npm run typecheck && npm run test` -- clean (lint: 0 errors, 4 pre-existing warnings in unrelated files; typecheck: clean; vitest: 21/21 passed)
- [ ] CI (`studio-e2e` job) -- not yet exercised on GitHub Actions; will confirm on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
