### PR TITLE
docs(adr): ADR-0093 Studio three-surface information architecture

### DIFF
--- a/docs/adrs/ADR-0093-studio-three-surface-ia.md
+++ b/docs/adrs/ADR-0093-studio-three-surface-ia.md
@@ -62,6 +62,11 @@ Run { id, source: agent|schedule|script|flow, status, project, started_at, updat
       chain?{parent, children[]}, refs{session_id?, invocation_id?, schedule_id?, topic?} }
 ```
 
+- **The invocation noun is removed from the product.** A scheduler firing is simply a Run
+  with `source=schedule`; there is no "invocation" kind, label, filter value, column, or
+  detail tab anywhere in the UI (founder ruling: the concept is odd). The daemon's invocation
+  records remain internal plumbing the aggregator consumes — `refs.invocation_id` exists for
+  joining, and is never presented.
 - **Attention header, not a home page.** The landing state carries compact stat chips
   (Running, Failed, Stale, Slow) computed from the same query the canvas shows. A chip is a
   filter, not a link: clicking it narrows the canvas in place. There is no separate dashboard
@@ -115,7 +120,8 @@ Three routes plus params are the entire public URL surface:
 ```
 
 Every legacy path redirects: `/runs→/?view=table` · `/runs/$id→/?run=$id` ·
-`/invocations→/?view=table&source=schedule` · `/invocations/$id→/?run=$id` ·
+`/invocations→/?view=table&source=schedule` (legacy URL only; the noun does not reappear) ·
+`/invocations/$id→/?run=$id` ·
 `/kanban→/?view=board` · `/playfield→/?view=stream&live=1` · `/shows→/?source=script` ·
 `/shows/$topic→/?source=script&topic=$topic` · `/schedules[/$id]→/library?kind=schedule[&id=$id]` ·
 `/playbooks[/$name]→/library?kind=script[&id=$name]` · `/agents[/$id]→/library?kind=agent[&id=$id]` ·

--- a/docs/adrs/ADR-0093-studio-three-surface-ia.md
+++ b/docs/adrs/ADR-0093-studio-three-surface-ia.md
@@ -131,13 +131,17 @@ survives visual iteration.
 Four phases, each one PR that leaves the app coherent, codex-gated, visually examined in both
 themes with screenshots in the PR body:
 
-- **A — Shell + canvas v1**: three-surface rail, redirects, unified Run list with all three
-  projections, slide-over (Overview/Output), attention chips, project lens. The existing shell
-  PR is re-tasked in place: its API-path pinning suite, favicon, design tokens, and
-  ProjectContext carry over; its five-group rail is replaced. Hosted deploy and its visual
-  gate ride this phase.
-- **B — Operations depth**: chain cards, SSE live tail, centralized staleness adopted
-  everywhere, cancel/re-fire actions, command palette.
+- **A — Shell + canvas v1**: three-surface rail, unified Run list with all three
+  projections, slide-over (Overview/Output), attention chips, project lens. Redirects land
+  for **list pages only** (`/runs`, `/invocations`, `/kanban`, `/playfield`, `/shows`), whose
+  projections have parity from day one; **detail routes** (`/runs/$id`, `/invocations/$id`,
+  `/shows/$topic`) keep working unchanged. The existing shell PR is re-tasked in place: its
+  API-path pinning suite, favicon, design tokens, and ProjectContext carry over; its
+  five-group rail is replaced. Hosted deploy and its visual gate ride this phase.
+- **B — Operations depth**: command palette (sequenced early in the phase), chain cards, SSE
+  live tail, centralized staleness adopted everywhere, cancel/re-fire actions. The slide-over
+  reaches full parity (Messages · Artifacts · Chain · Raw), and only then do the detail-route
+  redirects land.
 - **C — Library**: catalog + editors, YAML workflow editor with validate/plan-preview
   (additive endpoints land here), script naming, inviting zero states.
 - **D — System + removal**: System page, legacy route files deleted (redirects stay),
@@ -159,8 +163,10 @@ themes with screenshots in the PR body:
 **Negative / risks**
 
 - The slide-over must reach full parity with the old detail pages before their routes retire,
-  or operators lose capability mid-migration (mitigation: redirects land only in phase D;
-  parity is a phase-A/B exit criterion).
+  or operators lose capability mid-migration (mitigation: redirects are staged — phase A
+  redirects only list pages whose projections already have parity; detail routes redirect in
+  phase B once the slide-over reaches full tab parity; legacy route files are deleted in
+  phase D with all redirects staying).
 - Muscle memory and existing bookmarks break (mitigation: permanent redirects, palette).
 - Dense-table power workflows could regress inside a filter-driven canvas (mitigation:
   `?view=table` is exactly the old table, kept at parity deliberately).

--- a/docs/adrs/ADR-0093-studio-three-surface-ia.md
+++ b/docs/adrs/ADR-0093-studio-three-surface-ia.md
@@ -31,7 +31,8 @@ Constraints: daemon/API changes must be additive only; e2e tests never touch the
 state.db (a seeded temp-db harness exists); every retired path keeps a redirect; the stack
 stays React 19 + TanStack Router + Vite + Tailwind (CodeMirror and @tanstack/react-virtual are
 the only new dependencies); both themes ship together with established contrast floors;
-workflow definitions are YAML for now.
+workflow definitions serialize to YAML canonically, with TOML accepted and produced at the
+import/export boundary.
 
 ## Decision
 
@@ -49,6 +50,22 @@ A global **project lens** (top bar switcher, `?project=` + localStorage, per ADR
 scopes Operations fully; in Library it filters project-scoped items while keeping global items
 visible and labeled; System is never scoped. A **command palette** (⌘K) provides cross-surface
 jump and actions, which is what lets three destinations carry sixteen pages of reach.
+
+Two elements recovered from the desktop cockpit line (tag `desktop-v0.1.0-rc1`, never merged)
+are first-class in this architecture:
+
+- **The Leo operator panel** (founder-required): a dockable right-side panel present on every
+  surface — an operator chat that also *drives the UI* (its command channel can navigate,
+  filter, and open detail from conversation). Resurrected from the cockpit's panel + UI-command
+  components and their daemon chat/signals services; the shell reserves the right dock from
+  phase A, the live panel lands with its backend in phase B.
+- **The cockpit's visual language** is the style anchor for all phases: the dark canvas
+  chrome, signal chips, monospace accents, and status bar of that build, harmonized with the
+  current token system and shipped in both themes under the established contrast floors.
+
+The cockpit's engine-blueprint designer is *not* resurrected (founder: drop the engine
+canvas). Its canvas foundation — port-based nodes, chain-as-spine layout, draft/topology
+utilities — is reused for the **workflow canvas** in Library instead.
 
 ### Operations — the canvas
 
@@ -97,10 +114,13 @@ A single surface with a type rail (`?kind=script|agent|schedule|workflow|skill|p
 a catalog list per kind, and a **generous full-height editor** (`?id=`) — no per-kind routes,
 no cramped modals. Plays/playbooks present as **Scripts** everywhere in the UI (backend nouns
 unchanged; a subtitle maps the old name during transition). Schedules edit here; their firings
-live in Operations (`/?source=schedule&id=…` one click away). **Workflows** are a new kind:
-YAML definitions edited in CodeMirror with schema validation and a plan preview before save,
-backed by additive daemon endpoints (`POST /api/workflows/validate`, plan-preview). Every zero
-state invites creation with a primary CTA.
+live in Operations (`/?source=schedule&id=…` one click away). **Workflows** are a new kind
+with two synchronized editors over one definition: a CodeMirror text editor with schema
+validation and a plan preview before save, and a **workflow canvas** — a visual DAG editor
+built on the recovered cockpit canvas foundation — as the primary authoring surface.
+Definitions serialize to YAML canonically and **import/export as YAML or TOML** at the file
+boundary; both are backed by additive daemon endpoints (`POST /api/workflows/validate`,
+plan-preview). Every zero state invites creation with a primary CTA.
 
 ### System — the machine
 
@@ -119,8 +139,8 @@ Three routes plus params are the entire public URL surface:
 /system    (#maintenance anchor)
 ```
 
-Every legacy path redirects: `/runs→/?view=table` · `/runs/$id→/?run=$id` ·
-`/invocations→/?view=table&source=schedule` (legacy URL only; the noun does not reappear) ·
+Every retired path redirects: `/runs→/?view=table` · `/runs/$id→/?run=$id` ·
+`/invocations→/?view=table&source=schedule` (redirect only; the noun does not reappear) ·
 `/invocations/$id→/?run=$id` ·
 `/kanban→/?view=board` · `/playfield→/?view=stream&live=1` · `/shows→/?source=script` ·
 `/shows/$topic→/?source=script&topic=$topic` · `/schedules[/$id]→/library?kind=schedule[&id=$id]` ·
@@ -143,14 +163,18 @@ themes with screenshots in the PR body:
   projections have parity from day one; **detail routes** (`/runs/$id`, `/invocations/$id`,
   `/shows/$topic`) keep working unchanged. The existing shell PR is re-tasked in place: its
   API-path pinning suite, favicon, design tokens, and ProjectContext carry over; its
-  five-group rail is replaced. Hosted deploy and its visual gate ride this phase.
-- **B — Operations depth**: command palette (sequenced early in the phase), chain cards, SSE
-  live tail, centralized staleness adopted everywhere, cancel/re-fire actions. The slide-over
-  reaches full parity (Messages · Artifacts · Chain · Raw), and only then do the detail-route
-  redirects land.
-- **C — Library**: catalog + editors, YAML workflow editor with validate/plan-preview
-  (additive endpoints land here), script naming, inviting zero states.
-- **D — System + removal**: System page, legacy route files deleted (redirects stay),
+  five-group rail is replaced. The cockpit visual language lands here (tokens, chrome,
+  status bar) and the right dock is reserved for the Leo panel. Hosted deploy and its visual
+  gate ride this phase.
+- **B — Operations depth**: command palette (sequenced early in the phase), the **Leo
+  operator panel** live in the right dock (chat + UI-drive commands, daemon endpoints
+  resurrected from the cockpit line), chain cards, SSE live tail, centralized staleness
+  adopted everywhere, cancel/re-fire actions. The slide-over reaches full parity
+  (Messages · Artifacts · Chain · Raw), and only then do the detail-route redirects land.
+- **C — Library**: catalog + editors, workflow canvas + text editor with validate/plan-preview
+  and YAML/TOML import/export (additive endpoints land here), script naming, inviting zero
+  states.
+- **D — System + removal**: System page, retired route files deleted (redirects stay),
   i18n sweep (EN-first), contrast/a11y audit in both themes.
 
 ## Consequences
@@ -171,7 +195,7 @@ themes with screenshots in the PR body:
 - The slide-over must reach full parity with the old detail pages before their routes retire,
   or operators lose capability mid-migration (mitigation: redirects are staged — phase A
   redirects only list pages whose projections already have parity; detail routes redirect in
-  phase B once the slide-over reaches full tab parity; legacy route files are deleted in
+  phase B once the slide-over reaches full tab parity; the retired route files are deleted in
   phase D with all redirects staying).
 - Muscle memory and existing bookmarks break (mitigation: permanent redirects, palette).
 - Dense-table power workflows could regress inside a filter-driven canvas (mitigation:
@@ -194,12 +218,15 @@ role. The genuinely lost artifact is per-entity breadcrumbs, judged not worth a 
 | Four surfaces (separate Home) | A home page whose job is linking elsewhere is a page tax; attention chips on the canvas do the triage job in place |
 | Restyle existing pages (status quo, better tables) | Fails the "db reader" critique; leaves N status oracles and N thin pages |
 | ADR-0063 `work_items` backend model + Task Board | Requires new schema and services, violating the additive-only rider; frontend aggregation reaches the same operator surface now — 0063's UI layer is superseded, its schema stays dormant |
-| TOML workflow definitions alongside YAML | Deferred; YAML-only for now, format seam kept cheap to widen |
+| YAML-only workflow definitions (no TOML) | Founder wants both at the file boundary; YAML stays the canonical on-disk form, TOML handled by import/export conversion so the editor and daemon see one format |
+| Resurrect the cockpit's engine-blueprint designer | Founder dropped it; its canvas foundation is reused for the workflow canvas, which has a concrete artifact (a runnable definition) rather than a speculative blueprint |
 
 ## References
 
 - Founder design directives, 2026-07-04 (complete redesign; project-oriented scoping;
-  operation canvas; YAML workflow definitions; shows removal; play → script rename)
+  operation canvas; workflow definitions; shows removal; play → script rename; adopt the
+  desktop-cockpit visual style; Leo operator panel required; workflow canvas with YAML/TOML
+  import/export; engine canvas dropped)
 - Design-review rulings, 2026-06-11 (unified history timeline; canvas as command center;
   inviting zero states; contrast floors; generous editors)
 - Live QA examination, 2026-07-04: status-derivation drift across pages, unvirtualized

--- a/docs/adrs/ADR-0093-studio-three-surface-ia.md
+++ b/docs/adrs/ADR-0093-studio-three-surface-ia.md
@@ -1,0 +1,195 @@
+# ADR-0093: Studio Three-Surface Information Architecture
+
+**Status**: Proposed
+**Date**: 2026-07-04
+Related: ADR-0026 (project detection), ADR-0034 (frontend data/state architecture), ADR-0063
+(task board work center — this ADR supersedes its operator-UI decision; its `work_items`
+schema remains dormant), ADR-0061/0062 (scheduler + state machine).
+
+## Context
+
+Lion Studio's frontend grew one route per database entity: dashboard, runs, invocations,
+kanban, playfield, shows, schedules, playbooks, agents, teams, skills, plugins, engines,
+projects, admin/health, admin/maintenance — roughly sixteen leaf destinations, most of them a
+thin table over one table. The founder's review of the live app: cluttered, ill designed,
+"just a glossary of info, like a db reader", and — after a first incremental nav pass — "still
+a bit too many pages and tabs, and this is not redesign enough". An earlier design review had
+already ruled that runs, shows, and invocations as separate pages is wrong and they must
+become one unified history timeline, and that the canvas is the command-and-control center of
+the app.
+
+The deeper problem is that the route tree mirrors the storage schema instead of the operator's
+mental model. Everything in Studio is one of three things: something that **executed** (a
+session, an invocation, a schedule run, a play — different provenance, same shape: started,
+ran, ended in a status), something **defined** (a script, an agent profile, a schedule, a
+workflow, a skill, a plugin, an engine, a team), or the **machine itself** (database health,
+staleness, maintenance). Sixteen pages force the operator to reassemble that model by hand on
+every visit; status semantics ("running", staleness) are currently derived differently on
+each page, and the kanban view renders every historical run unvirtualized.
+
+Constraints: daemon/API changes must be additive only; e2e tests never touch the real
+state.db (a seeded temp-db harness exists); every retired path keeps a redirect; the stack
+stays React 19 + TanStack Router + Vite + Tailwind (CodeMirror and @tanstack/react-virtual are
+the only new dependencies); both themes ship together with established contrast floors;
+workflow definitions are YAML for now.
+
+## Decision
+
+Rebuild the frontend around **three surfaces**, each answering one operator question, with all
+former pages becoming URL-addressable *states* (params, filters, slide-overs) of those
+surfaces rather than routes:
+
+| Surface | Route | Question | Absorbs |
+|---------|-------|----------|---------|
+| **Operations** | `/` | What is happening, and what happened? | dashboard, runs, invocations, kanban, playfield, shows |
+| **Library** | `/library` | What can run, and how is it defined? | playbooks (as *scripts*), agents, schedules, workflows (new), skills, plugins, engines, teams |
+| **System** | `/system` | Is the machine healthy? | admin/health, admin/maintenance, projects (inventory) |
+
+A global **project lens** (top bar switcher, `?project=` + localStorage, per ADR-0026 columns)
+scopes Operations fully; in Library it filters project-scoped items while keeping global items
+visible and labeled; System is never scoped. A **command palette** (⌘K) provides cross-surface
+jump and actions, which is what lets three destinations carry sixteen pages of reach.
+
+### Operations — the canvas
+
+One continuous surface over a single **unified Run model** aggregated in the frontend from
+existing endpoints (sessions, invocations + schedule-run failure fields, schedule runs, plays,
+engine runs):
+
+```text
+Run { id, source: agent|schedule|script|flow, status, project, started_at, updated_at,
+      duration, reason?{code, summary, error_detail, exit_code},
+      chain?{parent, children[]}, refs{session_id?, invocation_id?, schedule_id?, topic?} }
+```
+
+- **Attention header, not a home page.** The landing state carries compact stat chips
+  (Running, Failed, Stale, Slow) computed from the same query the canvas shows. A chip is a
+  filter, not a link: clicking it narrows the canvas in place. There is no separate dashboard
+  route; the old dashboard's job (triage) is the canvas's default state.
+- **One canvas, three projections.** `?view=stream` (default; reverse-chron chain cards),
+  `?view=board` (grouped by status), `?view=table` (dense, sortable — the power-user escape
+  hatch preserving today's runs/invocations tables). Same query, same filter bar
+  (project · status · source · window · text), different projection. Views are a presentation
+  control, not tabs with different content.
+- **Detail is a slide-over, never a navigation.** `?run=<id>` opens a right slide-over
+  (Overview · Output with SSE live tail · Messages · Artifacts · Chain · Raw) with full parity
+  to the old detail pages, plus actions: cancel, re-fire (schedule-sourced), copy
+  `li agent -r <id>`. Deep links keep working; the canvas never unloads behind it.
+- **Chains render as one card.** schedule → schedule_run (chain_parent_id) → invocation →
+  session collapse into a single feed card with children, ending the four-page hunt for one
+  firing's story.
+- **One status oracle.** A single `deriveRunStatus` module (shared by chips, all three
+  projections, and the slide-over) demotes "running" to **Stale** when the process-liveness
+  signal says dead, and renders spent one-shot schedules as **Expired**. No surface ever again
+  shows "Running · Healthy" from a dead pid.
+- **Windowed and virtualized by default.** Default window 24h with load-more; board and
+  stream virtualize via @tanstack/react-virtual. Rendering 3,868 historical runs at once is a
+  defect class this ADR retires.
+
+### Library — the definitions
+
+A single surface with a type rail (`?kind=script|agent|schedule|workflow|skill|plugin|engine|team`),
+a catalog list per kind, and a **generous full-height editor** (`?id=`) — no per-kind routes,
+no cramped modals. Plays/playbooks present as **Scripts** everywhere in the UI (backend nouns
+unchanged; a subtitle maps the old name during transition). Schedules edit here; their firings
+live in Operations (`/?source=schedule&id=…` one click away). **Workflows** are a new kind:
+YAML definitions edited in CodeMirror with schema validation and a plan preview before save,
+backed by additive daemon endpoints (`POST /api/workflows/validate`, plan-preview). Every zero
+state invites creation with a primary CTA.
+
+### System — the machine
+
+One scrolling page, no tabs: health (db size, WAL, connections, staleness sweep) on top,
+maintenance actions (checkpoint, prune, vacuum — each with explicit confirmation) below,
+project inventory at the end. Destructive operations get a deliberate surface, which is why
+System stays a route rather than a popover.
+
+### Route contract
+
+Three routes plus params are the entire public URL surface:
+
+```text
+/          ?project ?view ?status ?source ?window ?q ?run ?topic ?live
+/library   ?project ?kind ?id ?new
+/system    (#maintenance anchor)
+```
+
+Every legacy path redirects: `/runs→/?view=table` · `/runs/$id→/?run=$id` ·
+`/invocations→/?view=table&source=schedule` · `/invocations/$id→/?run=$id` ·
+`/kanban→/?view=board` · `/playfield→/?view=stream&live=1` · `/shows→/?source=script` ·
+`/shows/$topic→/?source=script&topic=$topic` · `/schedules[/$id]→/library?kind=schedule[&id=$id]` ·
+`/playbooks[/$name]→/library?kind=script[&id=$name]` · `/agents[/$id]→/library?kind=agent[&id=$id]` ·
+`/teams→/library?kind=team` · `/skills→/library?kind=skill` · `/plugins→/library?kind=plugin` ·
+`/engines→/library?kind=engine` · `/projects→/system` · `/admin/health→/system` ·
+`/admin/maintenance→/system#maintenance`.
+
+E2e smoke tests key on routes and params (plus stable test ids), so the selector contract
+survives visual iteration.
+
+### Delivery
+
+Four phases, each one PR that leaves the app coherent, codex-gated, visually examined in both
+themes with screenshots in the PR body:
+
+- **A — Shell + canvas v1**: three-surface rail, redirects, unified Run list with all three
+  projections, slide-over (Overview/Output), attention chips, project lens. The existing shell
+  PR is re-tasked in place: its API-path pinning suite, favicon, design tokens, and
+  ProjectContext carry over; its five-group rail is replaced. Hosted deploy and its visual
+  gate ride this phase.
+- **B — Operations depth**: chain cards, SSE live tail, centralized staleness adopted
+  everywhere, cancel/re-fire actions, command palette.
+- **C — Library**: catalog + editors, YAML workflow editor with validate/plan-preview
+  (additive endpoints land here), script naming, inviting zero states.
+- **D — System + removal**: System page, legacy route files deleted (redirects stay),
+  i18n sweep (EN-first), contrast/a11y audit in both themes.
+
+## Consequences
+
+**Positive**
+
+- Sixteen destinations become three; the nav explains the product in one glance
+  (define → run → observe).
+- One Run model and one status oracle end the per-page semantics drift found in QA.
+- URL params as the state carrier give stable deep links, stable e2e selectors, and make
+  every view shareable.
+- The operator surface ADR-0063 wanted arrives with zero backend schema risk (frontend
+  aggregation; daemon stays additive).
+- Windowing + virtualization are structural, not per-page fixes.
+
+**Negative / risks**
+
+- The slide-over must reach full parity with the old detail pages before their routes retire,
+  or operators lose capability mid-migration (mitigation: redirects land only in phase D;
+  parity is a phase-A/B exit criterion).
+- Muscle memory and existing bookmarks break (mitigation: permanent redirects, palette).
+- Dense-table power workflows could regress inside a filter-driven canvas (mitigation:
+  `?view=table` is exactly the old table, kept at parity deliberately).
+- A bigger phase A than the incremental plan; more review surface per PR (accepted: the
+  founder explicitly chose radical over incremental).
+
+**Capability-loss audit (self-refutation).** The strongest case against consolidation:
+multi-window operators who today open runs and invocations side by side, and the playfield's
+live spatial view. Both survive — every canvas state is a URL, so two browser windows with
+different params replace two routes; `?view=stream&live=1` carries the playfield's live feed
+role. The genuinely lost artifact is per-entity breadcrumbs, judged not worth a route each.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Keep v1 five-group nav (Home/Operations/Automations/Library/Admin, pages as children) | Founder verdict after live use: still too many pages and tabs, not a redesign; groups relabel the schema instead of replacing it |
+| Two surfaces (System folded into Operations) | Destructive maintenance ops (vacuum, prune) need a deliberate, confirmable surface, not a popover |
+| Four surfaces (separate Home) | A home page whose job is linking elsewhere is a page tax; attention chips on the canvas do the triage job in place |
+| Restyle existing pages (status quo, better tables) | Fails the "db reader" critique; leaves N status oracles and N thin pages |
+| ADR-0063 `work_items` backend model + Task Board | Requires new schema and services, violating the additive-only rider; frontend aggregation reaches the same operator surface now — 0063's UI layer is superseded, its schema stays dormant |
+| TOML workflow definitions alongside YAML | Deferred; YAML-only for now, format seam kept cheap to widen |
+
+## References
+
+- Founder design directives, 2026-07-04 (complete redesign; project-oriented scoping;
+  operation canvas; YAML workflow definitions; shows removal; play → script rename)
+- Design-review rulings, 2026-06-11 (unified history timeline; canvas as command center;
+  inviting zero states; contrast floors; generous editors)
+- Live QA examination, 2026-07-04: status-derivation drift across pages, unvirtualized
+  kanban, project-list pollution
+- ADR-0026, ADR-0034, ADR-0063


### PR DESCRIPTION
## ADR-0093: Studio Three-Surface Information Architecture (Proposed)

Docs-only. ADR-0093 records a revised Studio navigation design: the first pass still had too many pages and tabs and needed a deeper redesign.

**The decision in one line**: ~16 entity-shaped routes collapse into three surfaces — **Operations** (`/`, the canvas: unified Run timeline over agent/schedule/script/flow sources, attention chips as filters, slide-over details, one status oracle), **Library** (`/library`, every definition: scripts, agents, schedules, YAML workflows, skills, plugins, engines, teams behind one type rail + full-height editor), **System** (`/system`, health + maintenance). URL params are the state carrier; every legacy path gets a redirect; command palette carries cross-surface reach.

Key properties:
- Frontend aggregation only — daemon stays additive (supersedes ADR-0063's operator-UI decision without its `work_items` schema).
- `?view=table` preserves the dense power-user tables as an escape hatch (capability-loss audit in the ADR).
- Delivery in 4 coherent phases, each reviewed and visually examined in both themes; hosted deploy rides phase A.
- In-flight: shell PR #1718 gets re-tasked to the three-surface rail (its api-path pinning suite, tokens, ProjectContext carry over); e2e harness PR #1719 is IA-agnostic and unaffected.

**Review status**: pending design review before any dependent implementation merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
