### PR TITLE
fix(cli): li monitor UX cluster — no-truncate pipe, playbook name, leg visibility

### DIFF
--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -331,6 +331,24 @@ def _trunc(s: str, n: int) -> str:
     return s[: n - 1] + "…"
 
 
+def _stdout_is_tty() -> bool:
+    """Evaluated at call time (not cached at import time) so a render
+    still reflects the actual stdout of the process at that moment —
+    e.g. stdout redirected after import, or a module imported once and
+    reused across both TTY and piped invocations."""
+    return sys.stdout.isatty()
+
+
+# Ceiling on a non-TTY column's *layout* width (header/separator/padding).
+# A single pathological long value (e.g. a malformed project string) must
+# never blow up every row's padding to that value's length — the
+# requirement is "grep never false-negatives on identifying columns", not
+# "pad every row to the longest value seen". Values longer than this still
+# render in full (Python format specs never clip a value shorter than its
+# field width), just without alignment padding past the ceiling.
+_NON_TTY_MAX_COL_WIDTH = 200
+
+
 def _format_table(rows: list[dict[str, Any]]) -> str:
     """Render a table of entity rows.
 
@@ -339,8 +357,9 @@ def _format_table(rows: list[dict[str, Any]]) -> str:
     On a TTY, identifying columns (id, project, phase) are truncated to
     fixed widths for a compact dashboard. Piped/redirected output (not a
     TTY — e.g. `li monitor | grep`) never truncates: columns widen to fit
-    the longest value so a grep against a project name or id can never
-    false-negative on a value cut short by a fixed column width.
+    the longest value (up to _NON_TTY_MAX_COL_WIDTH) so a grep against a
+    project name or id can never false-negative on a value cut short by a
+    fixed column width.
     """
     if not rows:
         return _dim("(no running entities)")
@@ -378,18 +397,25 @@ def _format_table(rows: list[dict[str, Any]]) -> str:
         for row in rows
     ]
 
-    if _IS_TTY:
+    if _stdout_is_tty():
         col = dict(col_min)  # noqa: N806
 
         def _field(key: str, value: str) -> str:
             return _trunc(value, col[key])
     else:
         col = {  # noqa: N806
-            key: max(width, len(headers[key]), max((len(r[key]) for r in raw_rows), default=0))
+            key: min(
+                max(width, len(headers[key]), max((len(r[key]) for r in raw_rows), default=0)),
+                _NON_TTY_MAX_COL_WIDTH,
+            )
             for key, width in col_min.items()
         }
 
         def _field(key: str, value: str) -> str:
+            # Never clip the value itself — only the layout width above is
+            # capped. A format spec width smaller than len(value) is a no-op
+            # (Python never truncates), so a pathological value still prints
+            # in full, just without alignment padding past the ceiling.
             return value
 
     header_parts = [

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -332,15 +332,21 @@ def _trunc(s: str, n: int) -> str:
 
 
 def _format_table(rows: list[dict[str, Any]]) -> str:
-    """Render a fixed-width table of entity rows.
+    """Render a table of entity rows.
 
     Expected keys per row: id, type, project, status, phase, elapsed, agents.
+
+    On a TTY, identifying columns (id, project, phase) are truncated to
+    fixed widths for a compact dashboard. Piped/redirected output (not a
+    TTY — e.g. `li monitor | grep`) never truncates: columns widen to fit
+    the longest value so a grep against a project name or id can never
+    false-negative on a value cut short by a fixed column width.
     """
     if not rows:
         return _dim("(no running entities)")
 
     # Column widths — uppercase name is intentional (table layout constant)
-    col = {  # noqa: N806
+    col_min = {  # noqa: N806
         "id": 16,
         "type": 11,
         "project": 14,
@@ -349,33 +355,68 @@ def _format_table(rows: list[dict[str, Any]]) -> str:
         "elapsed": 9,
         "agents": 7,
     }
+    headers = {  # noqa: N806
+        "id": "ID",
+        "type": "TYPE",
+        "project": "PROJECT",
+        "status": "STATUS",
+        "phase": "PHASE",
+        "elapsed": "ELAPSED",
+        "agents": "AGENTS",
+    }
+
+    raw_rows = [
+        {
+            "id": str(row.get("id", "")),
+            "type": str(row.get("type", "")),
+            "project": str(row.get("project", "-")),
+            "status": row.get("status", "") or "",
+            "phase": str(row.get("phase", "-")),
+            "elapsed": str(row.get("elapsed", "-")),
+            "agents": str(row.get("agents", "-")),
+        }
+        for row in rows
+    ]
+
+    if _IS_TTY:
+        col = dict(col_min)  # noqa: N806
+
+        def _field(key: str, value: str) -> str:
+            return _trunc(value, col[key])
+    else:
+        col = {  # noqa: N806
+            key: max(width, len(headers[key]), max((len(r[key]) for r in raw_rows), default=0))
+            for key, width in col_min.items()
+        }
+
+        def _field(key: str, value: str) -> str:
+            return value
 
     header_parts = [
-        _bold(f"{'ID':<{col['id']}}"),
-        _bold(f"{'TYPE':<{col['type']}}"),
-        _bold(f"{'PROJECT':<{col['project']}}"),
-        _bold(f"{'STATUS':<{col['status']}}"),
-        _bold(f"{'PHASE':<{col['phase']}}"),
-        _bold(f"{'ELAPSED':>{col['elapsed']}}"),
-        _bold(f"{'AGENTS':>{col['agents']}}"),
+        _bold(f"{headers['id']:<{col['id']}}"),
+        _bold(f"{headers['type']:<{col['type']}}"),
+        _bold(f"{headers['project']:<{col['project']}}"),
+        _bold(f"{headers['status']:<{col['status']}}"),
+        _bold(f"{headers['phase']:<{col['phase']}}"),
+        _bold(f"{headers['elapsed']:>{col['elapsed']}}"),
+        _bold(f"{headers['agents']:>{col['agents']}}"),
     ]
     header = "  ".join(header_parts)
     separator = _dim("-" * (sum(col.values()) + 2 * (len(col) - 1)))
 
     lines = [header, separator]
-    for row in rows:
-        eid = _trunc(str(row.get("id", "")), col["id"])
-        etype = _trunc(str(row.get("type", "")), col["type"])
-        eproject = _trunc(str(row.get("project", "-")), col["project"])
-        estatus = row.get("status", "")
-        ephase = _trunc(str(row.get("phase", "-")), col["phase"])
-        eelapsed = _trunc(str(row.get("elapsed", "-")), col["elapsed"])
-        eagents = str(row.get("agents", "-"))
+    for raw in raw_rows:
+        eid = _field("id", raw["id"])
+        etype = _field("type", raw["type"])
+        eproject = _field("project", raw["project"])
+        estatus = raw["status"]
+        ephase = _field("phase", raw["phase"])
+        eelapsed = _field("elapsed", raw["elapsed"])
+        eagents = raw["agents"]
 
         coloured_status = _colour_status(estatus)
         # Pad status accounting for invisible ANSI codes
-        visible_status = estatus
-        pad = col["status"] - len(visible_status)
+        pad = col["status"] - len(estatus)
         padded_status = coloured_status + " " * max(0, pad)
 
         line = "  ".join(
@@ -452,11 +493,41 @@ def _play_to_row(play: dict[str, Any]) -> dict[str, Any]:
 # ── Detail views ──────────────────────────────────────────────────────────────
 
 
+async def _fetch_branches(db: Any, session_id: str) -> list[dict[str, Any]]:
+    """Every branch (agent leg) on a session, oldest-started first."""
+    return await db.fetch_all(
+        "SELECT name, status, started_at, ended_at FROM branches "
+        "WHERE session_id = ? ORDER BY started_at",
+        (session_id,),
+    )
+
+
+def _render_branch_lines(rows: list[dict[str, Any]], *, indent: str = "  ") -> list[str]:
+    """One line per branch (agent leg) — orchestration engines like `li o
+    flow` (which `li play` compiles to) name each branch after its role
+    (e.g. "reviewer", "claude-code") and update its status/timestamps as
+    the leg runs (see flow.py's _update_branch_status). Surfacing that
+    here makes sub-step transitions poll-visible via `li monitor <id>`
+    without any new tracking mechanism.
+    """
+    if not rows:
+        return []
+    lines = [_dim(f"{indent}-- branches --")]
+    for r in rows:
+        bname = r.get("name") or "-"
+        bstatus = _colour_status(r.get("status") or "?")
+        belapsed = _elapsed(r.get("started_at"), r.get("ended_at"))
+        lines.append(f"{indent}  {bname:<20}  {bstatus}  {belapsed}")
+    return lines
+
+
 async def _detail_session(db: Any, sess: dict[str, Any]) -> str:
     lines: list[str] = []
     lines.append(_bold(f"SESSION  {sess['id']}"))
     lines.append(f"  status:    {_colour_status(sess.get('status') or '?')}")
     lines.append(f"  kind:      {sess.get('invocation_kind') or '-'}")
+    if sess.get("playbook_name"):
+        lines.append(f"  playbook:  {sess['playbook_name']}")
     lines.append(f"  project:   {sess.get('project') or '-'}")
     lines.append(f"  model:     {sess.get('model') or '-'}")
     lines.append(f"  provider:  {sess.get('provider') or '-'}")
@@ -469,11 +540,12 @@ async def _detail_session(db: Any, sess: dict[str, Any]) -> str:
     if last_msg:
         lines.append(f"  last_msg:  {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(last_msg))}")
 
-    # Branch count
-    row = await db.fetch_one(
-        "SELECT COUNT(*) AS n FROM branches WHERE session_id = ?", (sess["id"],)
-    )
-    lines.append(f"  branches:  {row['n'] if row else 0}")
+    # Branches (agent legs) — count plus per-leg status/elapsed
+    branch_rows = await _fetch_branches(db, sess["id"])
+    lines.append(f"  branches:  {len(branch_rows)}")
+    if branch_rows:
+        lines.append("")
+        lines.extend(_render_branch_lines(branch_rows))
 
     # Stream tail from run dir
     run_dir = RUNS_ROOT / sess["id"]
@@ -595,6 +667,12 @@ async def _detail_play(db: Any, play: dict[str, Any]) -> str:
             lines.append(f"    model:    {srow['model'] or '-'}")
             lines.append(f"    provider: {srow['provider'] or '-'}")
             lines.append(f"    effort:   {srow['effort'] or '-'}")
+
+            # Branches (agent legs) — poll-visible sub-step progress
+            branch_rows = await _fetch_branches(db, session_id)
+            if branch_rows:
+                lines.append("")
+                lines.extend(_render_branch_lines(branch_rows, indent="    "))
 
             # Stream tail
             run_dir = RUNS_ROOT / session_id

--- a/tests/cli/test_monitor.py
+++ b/tests/cli/test_monitor.py
@@ -22,6 +22,7 @@ from lionagi.cli.monitor import (
     _invocation_to_row,
     _pid_alive,
     _play_to_row,
+    _render_branch_lines,
     _run_detail,
     _run_table,
     _session_to_row,
@@ -276,6 +277,48 @@ def test_format_table_header():
     assert "TYPE" in output
     assert "STATUS" in output
     assert "ELAPSED" in output
+
+
+def test_format_table_non_tty_never_truncates_project(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Piped (non-TTY) output must never truncate identifying columns —
+    a long project name used to come back as 'ohdearquant/l…', silently
+    breaking `li monitor | grep <full-name>`."""
+    monkeypatch.setattr("lionagi.cli.monitor._IS_TTY", False)
+    long_project = "ohdearquant/lionagi-super-long-repo-name"
+    rows = [
+        {
+            "id": "abc123",
+            "type": "session",
+            "project": long_project,
+            "status": "running",
+            "phase": "agent",
+            "elapsed": "5m",
+            "agents": "1",
+        }
+    ]
+    output = _format_table(rows)
+    assert long_project in output
+
+
+def test_format_table_tty_still_truncates_project(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A TTY dashboard keeps the compact fixed-width behavior — only piped
+    output widens/never-truncates."""
+    monkeypatch.setattr("lionagi.cli.monitor._IS_TTY", True)
+    long_project = "ohdearquant/lionagi-super-long-repo-name"
+    rows = [
+        {
+            "id": "abc123",
+            "type": "session",
+            "project": long_project,
+            "status": "running",
+            "phase": "agent",
+            "elapsed": "5m",
+            "agents": "1",
+        }
+    ]
+    output = _format_table(rows)
+    assert long_project not in output
+    assert "…" in output
 
 
 # ── Unit: row builders ────────────────────────────────────────────────────────
@@ -940,6 +983,87 @@ async def test_run_detail_play(temp_db_path: Path) -> None:
 async def test_run_detail_not_found(temp_db_path: Path) -> None:
     output = await _run_detail("no-such-id-xyz-999")
     assert "not found" in output.lower() or "error" in output.lower()
+
+
+# ── Regression: detail view shows playbook name ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_detail_session_shows_playbook_name(temp_db_path: Path) -> None:
+    """`li monitor <id>` for a play/flow session must surface the active
+    playbook — a session row already carries playbook_name, but the detail
+    view used to omit it entirely."""
+    async with StateDB() as db:
+        sid = await _make_session(db, invocation_kind="play")
+        await db.execute(
+            "UPDATE sessions SET playbook_name = ? WHERE id = ?", ("feature-impl", sid)
+        )
+    output = await _run_detail(sid)
+    assert "feature-impl" in output
+
+
+@pytest.mark.asyncio
+async def test_run_detail_session_no_playbook_name_omits_line(temp_db_path: Path) -> None:
+    """A plain `li agent` session has no playbook — no dangling 'playbook: -' line."""
+    async with StateDB() as db:
+        sid = await _make_session(db, invocation_kind="agent")
+    output = await _run_detail(sid)
+    assert "playbook:" not in output
+
+
+# ── Regression: branch (agent leg) sub-step visibility ────────────────────────
+
+
+async def _add_branch(db: StateDB, session_id: str, *, name: str, status: str = "running") -> str:
+    pid = uuid.uuid4().hex
+    await db.execute("INSERT INTO progressions(id, created_at) VALUES (?, ?)", (pid, time.time()))
+    bid = uuid.uuid4().hex
+    await db.execute(
+        "INSERT INTO branches(id, created_at, session_id, progression_id, name, status, started_at) "
+        "VALUES (?,?,?,?,?,?,?)",
+        (bid, time.time(), session_id, pid, name, status, time.time()),
+    )
+    return bid
+
+
+def test_render_branch_lines_empty() -> None:
+    assert _render_branch_lines([]) == []
+
+
+def test_render_branch_lines_shows_name_and_status() -> None:
+    rows = [{"name": "reviewer", "status": "running", "started_at": time.time(), "ended_at": None}]
+    lines = _render_branch_lines(rows)
+    joined = "\n".join(lines)
+    assert "reviewer" in joined
+    assert "running" in joined
+
+
+@pytest.mark.asyncio
+async def test_run_detail_session_surfaces_branch_legs(temp_db_path: Path) -> None:
+    """A play/flow's internal sub-steps (e.g. a "reviewer" leg, a
+    "claude-code" leg) are recorded as branches with their own name/status —
+    `li monitor <session_id>` must list them so a caller can see a leg
+    transition without hand-polling sqlite."""
+    async with StateDB() as db:
+        sid = await _make_session(db, invocation_kind="play")
+        await _add_branch(db, sid, name="reviewer", status="completed")
+        await _add_branch(db, sid, name="claude-code", status="running")
+    output = await _run_detail(sid)
+    assert "reviewer" in output
+    assert "claude-code" in output
+
+
+@pytest.mark.asyncio
+async def test_run_detail_play_surfaces_branch_legs(temp_db_path: Path) -> None:
+    """Same sub-step visibility via the play id (not just the raw session id) —
+    `li monitor <play_id>` drills through the linked session to its branches."""
+    async with StateDB() as db:
+        show_id = await _make_show(db)
+        sid = await _make_session(db, invocation_kind="play")
+        play_id = await _make_play(db, show_id, name="backend-impl", session_id=sid)
+        await _add_branch(db, sid, name="reviewer", status="running")
+    output = await _run_detail(play_id)
+    assert "reviewer" in output
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_monitor.py
+++ b/tests/cli/test_monitor.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import signal
+import sys
 import time
 import uuid
 from pathlib import Path
@@ -13,6 +14,7 @@ from typing import Any
 import pytest
 
 from lionagi.cli.monitor import (
+    _NON_TTY_MAX_COL_WIDTH,
     _cached_detect_project,
     _colour_status,
     _elapsed,
@@ -29,9 +31,22 @@ from lionagi.cli.monitor import (
     _show_project_matches,
     _show_to_row,
     _since_timestamp,
+    _stdout_is_tty,
     _trunc,
 )
 from lionagi.state.db import StateDB
+
+
+class _FakeStdout:
+    """Minimal stand-in for sys.stdout exposing only isatty() — enough to
+    drive call-time TTY detection without a real terminal/pipe."""
+
+    def __init__(self, is_tty: bool) -> None:
+        self._is_tty = is_tty
+
+    def isatty(self) -> bool:
+        return self._is_tty
+
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -282,8 +297,10 @@ def test_format_table_header():
 def test_format_table_non_tty_never_truncates_project(monkeypatch: pytest.MonkeyPatch) -> None:
     """Piped (non-TTY) output must never truncate identifying columns —
     a long project name used to come back as 'ohdearquant/l…', silently
-    breaking `li monitor | grep <full-name>`."""
-    monkeypatch.setattr("lionagi.cli.monitor._IS_TTY", False)
+    breaking `li monitor | grep <full-name>`. TTY-ness is patched on the
+    real sys.stdout (not the cached module global) to prove detection
+    happens at render time."""
+    monkeypatch.setattr(sys, "stdout", _FakeStdout(False))
     long_project = "ohdearquant/lionagi-super-long-repo-name"
     rows = [
         {
@@ -303,7 +320,7 @@ def test_format_table_non_tty_never_truncates_project(monkeypatch: pytest.Monkey
 def test_format_table_tty_still_truncates_project(monkeypatch: pytest.MonkeyPatch) -> None:
     """A TTY dashboard keeps the compact fixed-width behavior — only piped
     output widens/never-truncates."""
-    monkeypatch.setattr("lionagi.cli.monitor._IS_TTY", True)
+    monkeypatch.setattr(sys, "stdout", _FakeStdout(True))
     long_project = "ohdearquant/lionagi-super-long-repo-name"
     rows = [
         {
@@ -319,6 +336,85 @@ def test_format_table_tty_still_truncates_project(monkeypatch: pytest.MonkeyPatc
     output = _format_table(rows)
     assert long_project not in output
     assert "…" in output
+
+
+def test_format_table_tty_detected_at_call_time_not_import_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The same process/import must render both ways depending on stdout
+    *at call time* — a module imported while a TTY was attached, then
+    later invoked against redirected/piped stdout (or vice versa), must
+    not get stuck on whatever stdout looked like at import."""
+    long_project = "ohdearquant/lionagi-super-long-repo-name"
+    rows = [
+        {
+            "id": "abc123",
+            "type": "session",
+            "project": long_project,
+            "status": "running",
+            "phase": "agent",
+            "elapsed": "5m",
+            "agents": "1",
+        }
+    ]
+
+    monkeypatch.setattr(sys, "stdout", _FakeStdout(True))
+    tty_output = _format_table(rows)
+    assert long_project not in tty_output
+
+    monkeypatch.setattr(sys, "stdout", _FakeStdout(False))
+    piped_output = _format_table(rows)
+    assert long_project in piped_output
+
+
+def test_stdout_is_tty_reflects_current_stdout(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "stdout", _FakeStdout(True))
+    assert _stdout_is_tty() is True
+    monkeypatch.setattr(sys, "stdout", _FakeStdout(False))
+    assert _stdout_is_tty() is False
+
+
+def test_format_table_non_tty_caps_pathological_width(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One pathologically long value must not blow up padding for every
+    row — layout width is capped at _NON_TTY_MAX_COL_WIDTH; the value
+    itself still prints in full (never clipped), just without alignment
+    padding past the cap."""
+    monkeypatch.setattr(sys, "stdout", _FakeStdout(False))
+    huge_project = "x" * 10_000
+    rows = [
+        {
+            "id": "abc123",
+            "type": "session",
+            "project": huge_project,
+            "status": "running",
+            "phase": "agent",
+            "elapsed": "5m",
+            "agents": "1",
+        },
+        {
+            "id": "def456",
+            "type": "session",
+            "project": "short-project",
+            "status": "running",
+            "phase": "agent",
+            "elapsed": "3m",
+            "agents": "1",
+        },
+    ]
+    output = _format_table(rows)
+    lines = output.splitlines()
+
+    # The full pathological value is still present — grep never misses it.
+    assert huge_project in output
+
+    # But layout (header separator, and every OTHER row's padding) must not
+    # scale with the 10k-char value: bounded by the column-width ceiling,
+    # not by the longest value seen.
+    separator = lines[1]
+    assert len(separator) < 10 * _NON_TTY_MAX_COL_WIDTH
+
+    short_line = next(line for line in lines if "short-project" in line)
+    assert len(short_line) < 10 * _NON_TTY_MAX_COL_WIDTH
 
 
 # ── Unit: row builders ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Three concrete `li monitor` daily-usage defects reported during dogfooding, all display/rendering-side (no changes to status-derivation logic, which another in-flight PR touches):

- **No-truncate on pipe**: `li monitor` truncated identifying table columns (id/project/phase) to a fixed width unconditionally, so `li monitor | grep <project>` could silently miss a match on a long name (`ohdearquant/l…`). `_format_table` now only truncates on a TTY; piped/redirected output widens columns to fit the longest value and never truncates.
- **Missing playbook name**: `li monitor <id>` detail view omitted the active playbook name even though sessions already carry `playbook_name`. Added a `playbook:` line to the session detail view.
- **Invisible sub-steps**: play legs (e.g. a "reviewer" leg, a "claude-code" leg) already run as named branches with status/timestamps maintained by the flow engine, but the detail view never surfaced them, forcing manual sqlite polling. Both the session and play detail views (`li monitor <id>`) now list each branch's name/status/elapsed — reusing the existing `branches` table, no new notification subsystem.

## Test plan

- [x] Added/extended unit + integration tests in `tests/cli/test_monitor.py` for all three fixes (TTY vs non-TTY truncation behavior, playbook-name presence/absence, branch-leg listing via both session id and play id)
- [x] `uv run pytest -q tests/cli/test_monitor.py` — 91/91 pass
- [x] `uv run pytest -q -n auto` (full suite, `--all-extras`) — green (one xdist worker-packing flake in `test_control_poller_lifecycle.py` reproduced and cleared on isolated rerun; unrelated to this change)
- [x] `uv run ruff format` / `ruff check --fix` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)