### PR TITLE
fix(state): recent activity outranks process visibility in session health

### DIFF
--- a/docs/adrs/ADR-0024-session-health-and-admin-surface.md
+++ b/docs/adrs/ADR-0024-session-health-and-admin-surface.md
@@ -75,8 +75,8 @@ Replace the binary "phantom or not" with a graduated health model:
 from enum import Enum
 
 class SessionHealth(str, Enum):
-    HEALTHY = "healthy"           # running, process alive, messages flowing
-    IDLE = "idle"                 # running, process alive, no messages for >1h
+    HEALTHY = "healthy"           # running, messages flowing (process visibility optional)
+    IDLE = "idle"                 # running, no messages for >1h but under threshold
     UNRESPONSIVE = "unresponsive" # running, process alive, no messages for >threshold
     STALE = "stale"               # running, process dead, no messages for >threshold
     ORPHANED = "orphaned"         # running, no process, no artifacts, no messages
@@ -119,7 +119,14 @@ def classify_session_health(
         # the session never produced output (regardless of age).
         if not has_artifacts and session.get("message_count", 0) == 0:
             return SessionHealth.ORPHANED
-        # Process is dead with some output — stale.
+        # Recent messages outrank process visibility: externally-driven
+        # sessions (CLI seats mirrored into the DB) expose no matchable
+        # pid, so a missing process only means dead once activity has
+        # also gone quiet past the kind threshold.
+        if idle_seconds <= threshold:
+            if idle_seconds > 3600:  # 1 hour
+                return SessionHealth.IDLE
+            return SessionHealth.HEALTHY
         return SessionHealth.STALE
 
     # Process is alive

--- a/lionagi/state/health.py
+++ b/lionagi/state/health.py
@@ -78,6 +78,15 @@ def classify_session_health(
         # it to failed is harmless, deleting it is also safe.
         if not has_artifacts and (session.get("message_count") or 0) == 0:
             return SessionHealth.ORPHANED
+        # Recent messages are stronger life-evidence than process
+        # visibility: externally-driven sessions (CLI seats mirrored
+        # into the DB) expose no matchable pid, so a missing process
+        # only means dead once activity has also gone quiet past the
+        # kind threshold.
+        if idle_seconds <= threshold:
+            if idle_seconds > IDLE_THRESHOLD:
+                return SessionHealth.IDLE
+            return SessionHealth.HEALTHY
         return SessionHealth.STALE
 
     # Process alive — classify by activity gap.

--- a/tests/state/test_health.py
+++ b/tests/state/test_health.py
@@ -153,11 +153,47 @@ def test_flow_threshold_more_lenient_than_agent():
 # ── Running, process dead ────────────────────────────────────────────────────
 
 
-def test_running_process_dead_with_messages_is_stale():
+def test_running_process_dead_but_recently_messaging_is_healthy():
+    """Externally-driven sessions expose no matchable pid; recent messages
+    outrank process visibility as life-evidence."""
     s = {
         "status": "running",
         "invocation_kind": "agent",
         "last_message_at": NOW - 200,
+        "message_count": 5,
+    }
+    h = classify_session_health(
+        s,
+        now=NOW,
+        process_alive=False,
+        has_artifacts=True,
+        has_stale_locks=False,
+    )
+    assert h == SessionHealth.HEALTHY
+
+
+def test_running_process_dead_quiet_hours_is_idle():
+    s = {
+        "status": "running",
+        "invocation_kind": "agent",
+        "last_message_at": NOW - 2 * 3600,
+        "message_count": 5,
+    }
+    h = classify_session_health(
+        s,
+        now=NOW,
+        process_alive=False,
+        has_artifacts=True,
+        has_stale_locks=False,
+    )
+    assert h == SessionHealth.IDLE
+
+
+def test_running_process_dead_past_threshold_is_stale():
+    s = {
+        "status": "running",
+        "invocation_kind": "agent",
+        "last_message_at": NOW - 7 * 3600,
         "message_count": 5,
     }
     h = classify_session_health(
@@ -188,8 +224,9 @@ def test_running_process_dead_no_output_is_orphaned():
     assert h == SessionHealth.ORPHANED
 
 
-def test_running_process_dead_no_messages_but_has_artifacts_is_stale():
-    """Artifacts present means the session produced *something* — not orphaned."""
+def test_running_process_dead_no_messages_but_has_artifacts_not_orphaned():
+    """Artifacts present means the session produced *something* — not orphaned.
+    Recent activity still classifies it alive despite the missing process."""
     s = {
         "status": "running",
         "invocation_kind": "agent",
@@ -203,7 +240,7 @@ def test_running_process_dead_no_messages_but_has_artifacts_is_stale():
         has_artifacts=True,
         has_stale_locks=False,
     )
-    assert h == SessionHealth.STALE
+    assert h == SessionHealth.HEALTHY
 
 
 # ── Edge cases ────────────────────────────────────────────────────────────────

--- a/tests/state/test_health.py
+++ b/tests/state/test_health.py
@@ -189,6 +189,43 @@ def test_running_process_dead_quiet_hours_is_idle():
     assert h == SessionHealth.IDLE
 
 
+def test_running_process_dead_exactly_at_threshold_is_idle():
+    """Equality with the kind threshold stays on the alive side of the
+    boundary — the same contract as the alive branch's UNRESPONSIVE cut."""
+    s = {
+        "status": "running",
+        "invocation_kind": "agent",
+        "last_message_at": NOW - 6 * 3600,
+        "message_count": 5,
+    }
+    h = classify_session_health(
+        s,
+        now=NOW,
+        process_alive=False,
+        has_artifacts=True,
+        has_stale_locks=False,
+    )
+    assert h == SessionHealth.IDLE
+
+
+def test_running_process_alive_exactly_at_threshold_is_idle():
+    """Alive/dead branches share the equality boundary."""
+    s = {
+        "status": "running",
+        "invocation_kind": "agent",
+        "last_message_at": NOW - 6 * 3600,
+        "message_count": 5,
+    }
+    h = classify_session_health(
+        s,
+        now=NOW,
+        process_alive=True,
+        has_artifacts=True,
+        has_stale_locks=False,
+    )
+    assert h == SessionHealth.IDLE
+
+
 def test_running_process_dead_past_threshold_is_stale():
     s = {
         "status": "running",


### PR DESCRIPTION
Triage of the four 55h–169h claude-code sessions flagged STUCK/NO-PROGRESS on the Studio dashboard: all four have `last_message_at` within seconds (they are live lambda seats), but `classify_session_health` returns STALE unconditionally when the process cannot be matched — and `_live_process_matches` greps `ps` for the session UUID, which externally-driven CLI sessions never carry.

Fix: on the dead-process branch, recent activity within the kind-aware threshold classifies HEALTHY/IDLE; STALE requires quiet past the threshold. Orphan detection unchanged. Two existing tests pinning the old semantics updated; threshold-boundary cases added.

Semantic note: this amends the ADR-0024 health table's dead-process row — process visibility is now subordinate to activity recency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)