### PR TITLE
fix(studio): paginate session-detail messages (tail window) to stop huge-session freezes

### DIFF
--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -476,6 +476,8 @@ export interface SessionBranch {
   name: string;
   created_at: number;
   messages: SessionMessage[];
+  message_total?: number;
+  message_offset?: number;
   model?: string | null;
   provider?: string | null;
   agent_name?: string | null;

--- a/apps/studio/frontend/src/routes/runs/$id.tsx
+++ b/apps/studio/frontend/src/routes/runs/$id.tsx
@@ -692,9 +692,7 @@ function RunDetailPage() {
           }
         }
         const graph = (s as unknown as Record<string, unknown>).graph as
-          | { nodes: WorkerGraph["nodes"]; edges: WorkerGraph["edges"] }
-          | null
-          | undefined;
+          { nodes: WorkerGraph["nodes"]; edges: WorkerGraph["edges"] } | null | undefined;
         if (graph && graph.nodes && graph.nodes.length > 0) {
           setRunGraph({
             name: s.name || id,
@@ -931,7 +929,10 @@ function RunDetailPage() {
     );
   }
 
-  const totalMessages = session.branches.reduce((n, b) => n + b.messages.length, 0);
+  const totalMessages = session.branches.reduce(
+    (n, b) => n + Math.max(b.message_total ?? 0, b.messages.length),
+    0,
+  );
 
   const durationSec =
     session.created_at != null && session.updated_at != null
@@ -950,17 +951,11 @@ function RunDetailPage() {
     toolCallCount,
     errorCount: errors.length,
     showTopic: (session as unknown as Record<string, unknown>).show_topic as
-      | string
-      | null
-      | undefined,
+      string | null | undefined,
     showPlayName: (session as unknown as Record<string, unknown>).show_play_name as
-      | string
-      | null
-      | undefined,
+      string | null | undefined,
     playbookName: (session as unknown as Record<string, unknown>).playbook_name as
-      | string
-      | null
-      | undefined,
+      string | null | undefined,
   };
 
   const expectedArtifactsCount = session.artifact_contract_json?.expected?.length ?? 0;

--- a/apps/studio/frontend/src/routes/runs/$id.tsx
+++ b/apps/studio/frontend/src/routes/runs/$id.tsx
@@ -201,6 +201,7 @@ interface OverviewData {
   messageCount: number;
   toolCallCount: number;
   errorCount: number;
+  partialWindow: boolean;
   showTopic?: string | null;
   showPlayName?: string | null;
   playbookName?: string | null;
@@ -214,9 +215,12 @@ function OverviewSection({ data }: { data: OverviewData }) {
       : []),
     { label: "Branches", value: String(data.branchCount) },
     { label: "Messages", value: String(data.messageCount) },
-    { label: "Tool calls", value: String(data.toolCallCount) },
     {
-      label: "Errors",
+      label: data.partialWindow ? "Tool calls (recent)" : "Tool calls",
+      value: String(data.toolCallCount),
+    },
+    {
+      label: data.partialWindow ? "Errors (recent)" : "Errors",
       value: String(data.errorCount),
       tone: data.errorCount > 0 ? ("error" as const) : ("ok" as const),
     },
@@ -934,6 +938,8 @@ function RunDetailPage() {
     0,
   );
 
+  const partialWindow = session.branches.some((b) => (b.message_total ?? 0) > b.messages.length);
+
   const durationSec =
     session.created_at != null && session.updated_at != null
       ? Math.max(0, Math.round(session.updated_at - session.created_at))
@@ -950,6 +956,7 @@ function RunDetailPage() {
     messageCount: totalMessages,
     toolCallCount,
     errorCount: errors.length,
+    partialWindow,
     showTopic: (session as unknown as Record<string, unknown>).show_topic as
       string | null | undefined,
     showPlayName: (session as unknown as Record<string, unknown>).show_play_name as
@@ -966,8 +973,13 @@ function RunDetailPage() {
       : []),
     ...(runGraph ? [{ id: "dag", label: "DAG", count: runGraph.nodes.length }] : []),
     { id: "branches", label: "Branches", count: session.branches.length },
-    { id: "errors", label: "Errors", count: errors.length, errorTone: errors.length > 0 },
-    { id: "files", label: "Files", count: files.length },
+    {
+      id: "errors",
+      label: partialWindow ? "Errors (recent)" : "Errors",
+      count: errors.length,
+      errorTone: errors.length > 0,
+    },
+    { id: "files", label: partialWindow ? "Files (recent)" : "Files", count: files.length },
     { id: "events", label: "Events", count: signalEvents.length },
   ];
 

--- a/apps/studio/frontend/src/routes/runs/$id.tsx
+++ b/apps/studio/frontend/src/routes/runs/$id.tsx
@@ -329,7 +329,7 @@ interface ErrorEntry {
   summary?: string;
 }
 
-function ErrorsSection({ errors }: { errors: ErrorEntry[] }) {
+function ErrorsSection({ errors, partial }: { errors: ErrorEntry[]; partial?: boolean }) {
   const groups = useMemo(() => {
     const map = new Map<string, ErrorEntry[]>();
     for (const err of errors) {
@@ -356,7 +356,7 @@ function ErrorsSection({ errors }: { errors: ErrorEntry[] }) {
       <SectionHeader label="Errors" count={errors.length} errorTone={errors.length > 0} />
       {errors.length === 0 ? (
         <div className="flex items-center gap-2 rounded border border-edge bg-surface-raised px-4 py-3 text-sm text-status-success">
-          <span>{empty.branchErrors}</span>
+          <span>{partial ? "No errors in the loaded messages." : empty.branchErrors}</span>
         </div>
       ) : (
         <div className="flex flex-col gap-1.5">
@@ -445,13 +445,15 @@ function ErrorsSection({ errors }: { errors: ErrorEntry[] }) {
 
 // ── Files section ─────────────────────────────────────────────────────────────
 
-function FilesSection({ files }: { files: string[] }) {
+function FilesSection({ files, partial }: { files: string[]; partial?: boolean }) {
   return (
     <div id="files" className="scroll-mt-24">
       <SectionHeader label="Files" count={files.length} />
       {files.length === 0 ? (
         <div className="rounded border border-edge bg-surface-raised px-4 py-3 text-sm text-content-muted">
-          No file operations detected.
+          {partial
+            ? "No file operations detected in the loaded messages."
+            : "No file operations detected."}
         </div>
       ) : (
         <div className="rounded border border-edge bg-surface-raised px-3 py-2">
@@ -1082,8 +1084,8 @@ function RunDetailPage() {
               expandedSteps={expandedSteps}
               onToggleExpand={handleToggleExpand}
             />
-            <ErrorsSection errors={errors} />
-            <FilesSection files={files} />
+            <ErrorsSection errors={errors} partial={partialWindow} />
+            <FilesSection files={files} partial={partialWindow} />
             <EventsSection events={signalEvents} live={live && !done} />
           </div>
           <div ref={bottomRef} />

--- a/lionagi/studio/services/runs.py
+++ b/lionagi/studio/services/runs.py
@@ -582,7 +582,13 @@ async def get_run(run_id: str) -> dict[str, Any] | None:
 
     state_root: Path | None = artifact_root.parent if artifact_root else None
 
-    message_count = sum(len(b.get("messages") or []) for b in branches if isinstance(b, dict))
+    # Branch message lists are tail-windowed pages; message_total carries the
+    # full progression length (fall back to page length for older payloads).
+    message_count = sum(
+        b.get("message_total") or len(b.get("messages") or [])
+        for b in branches
+        if isinstance(b, dict)
+    )
     last_message_at = max(
         (
             m.get("timestamp")

--- a/lionagi/studio/services/sessions.py
+++ b/lionagi/studio/services/sessions.py
@@ -195,9 +195,24 @@ async def list_project_counts() -> list[dict[str, Any]]:
     ]
 
 
-async def get_session(session_id: str) -> dict[str, Any] | None:
+# Long-lived sessions accumulate tens of thousands of messages; loading
+# them all in one detail response freezes the client and approaches
+# SQLite's bound-variable limit. Detail responses window from the tail.
+DEFAULT_MESSAGE_LIMIT = 200
+MAX_MESSAGE_LIMIT = 1000
+
+
+async def get_session(
+    session_id: str,
+    *,
+    message_limit: int = DEFAULT_MESSAGE_LIMIT,
+    message_offset: int = 0,
+) -> dict[str, Any] | None:
     if not DEFAULT_DB_PATH.exists():
         return None
+
+    message_limit = max(1, min(message_limit, MAX_MESSAGE_LIMIT))
+    message_offset = max(0, message_offset)
 
     async with _open_db(_DB) as db:
         cur = await db.execute(
@@ -248,6 +263,7 @@ async def get_session(session_id: str) -> dict[str, Any] | None:
         branches = []
         for br in branch_rows:
             messages = []
+            message_total = 0
             prog_id = br["progression_id"]
             if prog_id:
                 prog_cur = await db.execute(
@@ -260,6 +276,15 @@ async def get_session(session_id: str) -> dict[str, Any] | None:
                         msg_ids = json.loads(prog_row["collection"])
                     except (json.JSONDecodeError, TypeError):
                         msg_ids = []
+
+                    message_total = len(msg_ids)
+                    # Window from the tail: offset 0 = the newest page,
+                    # each page further back prepends older history.
+                    if message_offset:
+                        end = max(0, message_total - message_offset)
+                        msg_ids = msg_ids[max(0, end - message_limit) : end]
+                    else:
+                        msg_ids = msg_ids[-message_limit:]
 
                     if msg_ids:
                         placeholders = ",".join("?" for _ in msg_ids)
@@ -284,6 +309,8 @@ async def get_session(session_id: str) -> dict[str, Any] | None:
                     "name": br["name"],
                     "created_at": br["created_at"],
                     "messages": messages,
+                    "message_total": message_total,
+                    "message_offset": message_offset,
                     "model": br["model"],
                     "provider": br["provider"],
                     "agent_name": br["agent_name"],
@@ -451,8 +478,14 @@ async def list_sessions_route() -> dict[str, Any]:
 
 
 @studio_route("/sessions/{session_id}", method="GET", area="sessions", name="get_session")
-async def get_session_route(session_id: str) -> dict[str, Any]:
-    session = await get_session(session_id)
+async def get_session_route(
+    session_id: str,
+    message_limit: int = DEFAULT_MESSAGE_LIMIT,
+    message_offset: int = 0,
+) -> dict[str, Any]:
+    session = await get_session(
+        session_id, message_limit=message_limit, message_offset=message_offset
+    )
     if session is None:
         raise NotFoundError(f"Session '{session_id}' not found")
     return session

--- a/tests/apps_studio_server/test_sessions_detail.py
+++ b/tests/apps_studio_server/test_sessions_detail.py
@@ -669,3 +669,84 @@ async def test_session_exists_returns_false_when_db_file_absent(patched_sessions
     # Do not create the DB file
 
     assert await svc.session_exists("any-id") is False
+
+
+# ---------------------------------------------------------------------------
+# Message pagination — detail responses window from the progression tail
+# ---------------------------------------------------------------------------
+
+
+async def seed_paginated_session(db_path: Path, *, count: int = 10) -> list[str]:
+    """Session with one branch holding `count` messages; returns message ids in order."""
+    await seed_session(db_path, session_id="sess-paged")
+    msg_ids = [f"pmsg-{i}" for i in range(count)]
+    await seed_branch(db_path, branch_id="br-paged", session_id="sess-paged", msg_ids=msg_ids)
+    async with StateDB(db_path) as db:
+        for i, mid in enumerate(msg_ids):
+            await db.insert_message(
+                {
+                    "id": mid,
+                    "created_at": 100.0 + i,
+                    "content": {"text": f"m{i}"},
+                    "sender": "worker",
+                    "recipient": "user",
+                    "role": "assistant",
+                    "node_metadata": {},
+                }
+            )
+    return msg_ids
+
+
+async def test_get_session_windows_newest_messages_by_default(patched_sessions_db):
+    svc, db_path = patched_sessions_db
+    await seed_paginated_session(db_path, count=10)
+
+    result = await svc.get_session("sess-paged", message_limit=3)
+
+    branch = result["branches"][0]
+    assert [m["id"] for m in branch["messages"]] == ["pmsg-7", "pmsg-8", "pmsg-9"]
+    assert branch["message_total"] == 10
+    assert branch["message_offset"] == 0
+
+
+async def test_get_session_offset_pages_older_history(patched_sessions_db):
+    svc, db_path = patched_sessions_db
+    await seed_paginated_session(db_path, count=10)
+
+    result = await svc.get_session("sess-paged", message_limit=3, message_offset=3)
+
+    branch = result["branches"][0]
+    assert [m["id"] for m in branch["messages"]] == ["pmsg-4", "pmsg-5", "pmsg-6"]
+    assert branch["message_offset"] == 3
+
+
+async def test_get_session_offset_clamps_at_oldest_message(patched_sessions_db):
+    svc, db_path = patched_sessions_db
+    await seed_paginated_session(db_path, count=10)
+
+    result = await svc.get_session("sess-paged", message_limit=3, message_offset=9)
+
+    branch = result["branches"][0]
+    assert [m["id"] for m in branch["messages"]] == ["pmsg-0"]
+
+
+async def test_get_session_offset_past_total_returns_empty_page(patched_sessions_db):
+    svc, db_path = patched_sessions_db
+    await seed_paginated_session(db_path, count=10)
+
+    result = await svc.get_session("sess-paged", message_limit=3, message_offset=50)
+
+    branch = result["branches"][0]
+    assert branch["messages"] == []
+    assert branch["message_total"] == 10
+
+
+async def test_get_session_limit_clamped_to_max(patched_sessions_db):
+    svc, db_path = patched_sessions_db
+    await seed_paginated_session(db_path, count=5)
+
+    result = await svc.get_session("sess-paged", message_limit=10_000)
+
+    branch = result["branches"][0]
+    assert len(branch["messages"]) == 5
+    assert branch["message_total"] == 5


### PR DESCRIPTION
## Problem
Clicking a long-lived conversation (20k+ messages) freezes Studio.

Diagnosis: **not double counting** — verified against live state.db: the worst session has 26,105 progression entries, all distinct IDs, 25,135 distinct contents (~4% benign repeats). Days-long mirrored claude-code seats genuinely accumulate that many messages (every tool call is a message).

The real bug: `GET /api/sessions/{id}` loaded **every** message ID into a single `IN (...)` query (26k bound variables, approaching SQLite's 32k limit) and shipped a multi-MB JSON payload that the frontend rendered as DOM in one shot.

## Fix
- `get_session()` windows messages **from the tail**: `message_limit` (default 200, max 1000) + `message_offset` (0 = newest page, paging back into history). Per-branch `message_total` + `message_offset` returned so clients can paginate.
- Route exposes both as query params.
- `get_run()` derives `message_count` from `message_total` (was: page length — would have undercounted).
- Side effect: sessions.py no longer imports fastapi at module top (core-env import safety).

5 new pagination tests; `tests/apps_studio_server/test_sessions_detail.py` + `test_runs_detail.py` green.

Frontend paginated scrolling ('load older' prepend in RunDetail) follows on the #1718 cockpit branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)