### PR TITLE
feat(studio): attention-first home layout with honest run staleness

### DIFF
--- a/apps/studio/frontend/src/components/mission/AttentionQueue.tsx
+++ b/apps/studio/frontend/src/components/mission/AttentionQueue.tsx
@@ -12,6 +12,7 @@ import { useTranslations } from "use-intl";
 import SectionLabel from "@/components/ui/SectionLabel";
 import Chip from "@/components/ui/Chip";
 import type { AttentionItem, AttentionReason } from "./boardReducer";
+import { runDeepLink, invocationDeepLink } from "@/lib/runDeepLink";
 
 interface Props {
   items: AttentionItem[];
@@ -170,13 +171,13 @@ function ItemLink({
   const id = item.id.slice(item.id.indexOf(":") + 1);
   if (item.kind === "run") {
     return (
-      <Link to="/fleet" search={{ s: id }} className={className} style={style}>
+      <Link {...runDeepLink(id)} className={className} style={style}>
         {children}
       </Link>
     );
   }
   return (
-    <Link to="/history" search={{ tab: "run" }} className={className} style={style}>
+    <Link {...invocationDeepLink()} className={className} style={style}>
       {children}
     </Link>
   );

--- a/apps/studio/frontend/src/components/mission/LiveBoard.tsx
+++ b/apps/studio/frontend/src/components/mission/LiveBoard.tsx
@@ -13,6 +13,10 @@ import StatusDot from "@/components/ui/StatusDot";
 import Chip from "@/components/ui/Chip";
 import type { RunSummary } from "@/lib/types";
 import type { InvocationSummary } from "@/lib/api";
+import { runDeepLink, invocationDeepLink } from "@/lib/runDeepLink";
+
+/** Health states meaning the process is gone even though the run is non-terminal. */
+const DEAD_HEALTH = new Set(["stale", "orphaned", "zombie", "unresponsive"]);
 
 interface Props {
   activeRuns: RunSummary[];
@@ -39,21 +43,30 @@ function formatElapsed(sec: number | null): string {
 }
 
 function RunCard({ run, nowSec }: { run: RunSummary; nowSec: number }) {
+  const t = useTranslations("mission");
   const elapsed = elapsedSec(run.started_at ?? undefined, nowSec);
   const name = run.playbook_name ?? run.agent_name ?? run.run_id.slice(-12);
+  // Honest staleness: a process-dead run must not render as a live one.
+  const dead = run.effective_health != null && DEAD_HEALTH.has(run.effective_health);
 
   return (
     <Link
-      to="/fleet"
-      search={{ s: run.run_id }}
+      {...runDeepLink(run.run_id)}
       className="group flex flex-col gap-2 rounded border border-edge bg-surface-raised p-3 transition-colors duration-100"
     >
       <div className="flex items-center gap-2">
-        <StatusDot status="running" />
+        <StatusDot status={dead ? "stale" : "running"} />
         <span className="min-w-0 flex-1 truncate font-data text-[length:var(--t-sm)] font-medium text-content-primary group-hover:opacity-80">
           {name}
         </span>
-        <span className="shrink-0 font-data tabular-nums text-[length:var(--t-xs)] text-status-running">
+        {dead && (
+          <span className="shrink-0 font-data text-[length:var(--t-xs)] uppercase text-content-muted">
+            {t("liveBoard.staleLabel")}
+          </span>
+        )}
+        <span
+          className={`shrink-0 font-data tabular-nums text-[length:var(--t-xs)] ${dead ? "text-content-muted" : "text-status-running"}`}
+        >
           {formatElapsed(elapsed)}
         </span>
       </div>
@@ -78,8 +91,7 @@ function InvocationCard({ inv, nowSec }: { inv: InvocationSummary; nowSec: numbe
 
   return (
     <Link
-      to="/history"
-      search={{ tab: "run" }}
+      {...invocationDeepLink()}
       className="group flex flex-col gap-2 rounded border border-edge bg-surface-raised p-3 transition-colors duration-100"
     >
       <div className="flex items-center gap-2">

--- a/apps/studio/frontend/src/components/mission/MissionControl.tsx
+++ b/apps/studio/frontend/src/components/mission/MissionControl.tsx
@@ -1,9 +1,10 @@
 /**
  * Mission Control — home space.
  *
- * The living system leads: running work first, then a compact attention
- * digest (never a wall of rows), then recent history. All numbers tick in
- * real time. No manual refresh. No page reload.
+ * Attention leads when something needs a human; otherwise the living
+ * system does: running work first, then recent history. The attention
+ * digest is compact (never a wall of rows). All numbers tick in real
+ * time. No manual refresh. No page reload.
  */
 
 import { useTranslations } from "use-intl";
@@ -44,45 +45,32 @@ export default function MissionControl() {
       <hr className="border-t border-edge" style={{ border: "none", borderTopWidth: "1px" }} />
 
       {/*
-       * Two-zone layout at ≥1280px:
-       *   left (flex 3): RUNNING NOW + NEEDS ATTENTION stacked
-       *   right (flex 2): RECENT RUNS column, full height
-       * Below 1280px: single-column vertical stack.
+       * Attention-first vertical stack:
+       *   NEEDS ATTENTION full-width at the top, only when non-empty —
+       *   when the system is clean the living board leads, no permanent
+       *   "all clear" band spending prime real estate on a null.
+       *   Then RUNNING NOW as a full-width strip, then RECENT RUNS.
        */}
-      <div className="flex flex-col gap-5 xl:grid xl:grid-cols-[3fr_2fr] xl:gap-6 xl:items-start">
-        {/* Left zone: live board + attention queue */}
-        <div className="flex flex-col gap-5">
-          <LiveBoard
-            activeRuns={board.activeRuns}
-            activeInvocations={board.activeInvocations}
+      {board.attentionItems.length > 0 && (
+        <>
+          <AttentionQueue
+            items={board.attentionItems}
             nowSec={board.nowSec}
+            dataState={board.dataState}
           />
+          <hr className="border-t border-edge" style={{ border: "none", borderTopWidth: "1px" }} />
+        </>
+      )}
 
-          {board.attentionItems.length > 0 && (
-            <>
-              <hr
-                className="border-t border-edge"
-                style={{ border: "none", borderTopWidth: "1px" }}
-              />
-              <AttentionQueue
-                items={board.attentionItems}
-                nowSec={board.nowSec}
-                dataState={board.dataState}
-              />
-            </>
-          )}
-        </div>
+      <LiveBoard
+        activeRuns={board.activeRuns}
+        activeInvocations={board.activeInvocations}
+        nowSec={board.nowSec}
+      />
 
-        {/* Right zone: recent terminal runs — hairline divider on wide layouts */}
-        <div className="xl:border-l xl:border-edge xl:pl-6">
-          {/* Hairline separator only on narrow (vertical) layouts */}
-          <hr
-            className="xl:hidden border-t border-edge"
-            style={{ border: "none", borderTopWidth: "1px" }}
-          />
-          <RecentRuns runs={board.recentRuns} nowSec={board.nowSec} />
-        </div>
-      </div>
+      <hr className="border-t border-edge" style={{ border: "none", borderTopWidth: "1px" }} />
+
+      <RecentRuns runs={board.recentRuns} nowSec={board.nowSec} />
     </div>
   );
 }

--- a/apps/studio/frontend/src/components/ui/StatusDot.tsx
+++ b/apps/studio/frontend/src/components/ui/StatusDot.tsx
@@ -18,11 +18,15 @@ const TERMINAL_STATUSES = new Set([
   "timed_out",
 ]);
 
+// Process-dead-but-non-terminal health states: muted and static — a dead
+// process must never pulse as if alive.
+const STALE_STATUSES = new Set(["stale", "orphaned", "zombie", "unresponsive"]);
+
 function statusColor(status: string): string {
   const s = status.toLowerCase();
   if (s === "failed" || s === "error" || s === "failure" || s === "timed_out")
     return "var(--status-failure)";
-  if (s === "cancelled") return "var(--content-muted)";
+  if (s === "cancelled" || STALE_STATUSES.has(s)) return "var(--content-muted)";
   if (s === "gated" || s === "needs_review" || s === "blocked") return "var(--status-pending)";
   if (s === "completed" || s === "done" || s === "success") return "var(--status-success)";
   return "var(--status-running)";
@@ -30,11 +34,12 @@ function statusColor(status: string): string {
 
 /**
  * Small circular status indicator. Pulses via `live-pulse-dot` CSS animation
- * when the status is non-terminal; static for terminal states.
+ * when the status is non-terminal; static for terminal and stale states.
  */
 export default function StatusDot({ status, className }: StatusDotProps) {
   const color = statusColor(status);
-  const isTerminal = TERMINAL_STATUSES.has(status.toLowerCase());
+  const s = status.toLowerCase();
+  const isTerminal = TERMINAL_STATUSES.has(s) || STALE_STATUSES.has(s);
   return (
     <span
       aria-hidden="true"

--- a/apps/studio/frontend/src/lib/runDeepLink.ts
+++ b/apps/studio/frontend/src/lib/runDeepLink.ts
@@ -1,0 +1,13 @@
+/**
+ * Single deep-link target for a run's detail context. Home cards and
+ * attention rows all route through here so the unified Operations cutover
+ * is a one-line change, not a grep.
+ */
+export function runDeepLink(runId: string): { to: "/fleet"; search: { s: string } } {
+  return { to: "/fleet", search: { s: runId } };
+}
+
+/** Invocation counterpart of runDeepLink — same single-cutover rationale. */
+export function invocationDeepLink(): { to: "/history"; search: { tab: "run" } } {
+  return { to: "/history", search: { tab: "run" } };
+}

--- a/apps/studio/frontend/src/messages/en.json
+++ b/apps/studio/frontend/src/messages/en.json
@@ -588,6 +588,7 @@
     },
     "liveBoard": {
       "title": "Running now",
+      "staleLabel": "Stale",
       "empty": "No active runs or invocations.",
       "emptyHint": "Launch one with the li CLI, or press ⌘K to jump anywhere.",
       "fleetLink": "Fleet →"

--- a/apps/studio/frontend/src/messages/zh.json
+++ b/apps/studio/frontend/src/messages/zh.json
@@ -588,6 +588,7 @@
     },
     "liveBoard": {
       "title": "正在运行",
+      "staleLabel": "已失联",
       "empty": "当前无活跃运行或调用。",
       "emptyHint": "可用 li CLI 启动，或按 ⌘K 快速跳转。",
       "fleetLink": "智能体监控 →"


### PR DESCRIPTION
## Summary

First slice of the Home (Mission Control) design work — pure frontend, no backend dependency.

- **Attention-first layout**: the needs-attention block is hoisted full-width above the board and rendered only when non-empty; when the system is clean the living board leads (no permanent all-clear band). Running-now becomes a full-width strip, recent runs follow below — the two-zone grid is removed.
- **Honest staleness in the running strip**: RunCard's status dot is now driven by `effective_health` — process-dead non-terminal runs (stale/orphaned/zombie/unresponsive) render a muted static dot plus a Stale label instead of a green pulse. StatusDot gains a stale-status family (muted color, no pulse animation).
- **Single deep-link helper** (`runDeepLink` / `invocationDeepLink`): all home cards and attention rows route through one module, so a future unified route cutover is a one-line change.
- en/zh parity for the new Stale label.

## Test plan

- `tsc --noEmit` clean, eslint clean on touched files
- `vitest run`: 370/370 pass
- Manual check: kill a running session's process → the running strip shows Stale, not a green pulse

🤖 Generated with [Claude Code](https://claude.com/claude-code)