### PR TITLE
fix(studio): tri-state process liveness for run health classification

### DIFF
--- a/docs/adrs/ADR-0024-session-health-and-admin-surface.md
+++ b/docs/adrs/ADR-0024-session-health-and-admin-surface.md
@@ -78,10 +78,28 @@ class SessionHealth(str, Enum):
     HEALTHY = "healthy"           # running, messages flowing (process visibility optional)
     IDLE = "idle"                 # running, no messages for >1h but under threshold
     UNRESPONSIVE = "unresponsive" # running, process alive, no messages for >threshold
-    STALE = "stale"               # running, process dead, no messages for >threshold
+    STALE = "stale"               # running, process confirmed dead — or liveness unknown and quiet >threshold
     ORPHANED = "orphaned"         # running, no process, no artifacts, no messages
     ZOMBIE = "zombie"             # completed/failed but resources not cleaned up
 ```
+
+`process_alive` is tri-state (`bool | None`):
+
+- `True` — observed alive: a recorded pid is running (with process start-time
+  verification when one was recorded), or the session id appears in the
+  process table.
+- `False` — confirmed dead: a recorded pid is no longer running, or its start
+  time no longer matches the recorded one (pid recycled). Positive death
+  evidence skips the activity guard, so the session classifies STALE
+  immediately regardless of how fresh its last message is.
+- `None` — unknown: no recorded pid and no process match. This is the normal
+  case for externally-driven sessions mirrored into the DB, so the activity
+  guard applies: recent messages keep the session HEALTHY/IDLE, and only quiet
+  past the kind threshold classifies STALE.
+
+Limitation: a bare recycled pid (recorded pid, no recorded start time, pid
+reused by an unrelated process) reads alive. This is rare and fails toward
+treating the session as live rather than falsely dead.
 
 Classification logic:
 
@@ -90,7 +108,7 @@ def classify_session_health(
     session: dict,
     *,
     now: float,
-    process_alive: bool,
+    process_alive: bool | None,
     has_artifacts: bool,
     has_stale_locks: bool,
 ) -> SessionHealth:
@@ -114,15 +132,20 @@ def classify_session_health(
     kind = session.get("invocation_kind")
     threshold = STALE_THRESHOLDS.get(kind, DEFAULT_STALE_THRESHOLD)
 
-    if not process_alive:
+    if process_alive is not True:
         # Orphan check first — no artifacts AND no messages means
         # the session never produced output (regardless of age).
         if not has_artifacts and session.get("message_count", 0) == 0:
             return SessionHealth.ORPHANED
-        # Recent messages outrank process visibility: externally-driven
-        # sessions (CLI seats mirrored into the DB) expose no matchable
-        # pid, so a missing process only means dead once activity has
-        # also gone quiet past the kind threshold.
+        if process_alive is False:
+            # Confirmed dead: positive evidence outranks the activity
+            # guard below — the process is gone no matter how fresh
+            # the last message is.
+            return SessionHealth.STALE
+        # Unknown liveness: recent messages outrank process visibility —
+        # externally-driven sessions (CLI seats mirrored into the DB)
+        # expose no matchable pid, so an unmatched process only means
+        # dead once activity has also gone quiet past the kind threshold.
         if idle_seconds <= threshold:
             if idle_seconds > 3600:  # 1 hour
                 return SessionHealth.IDLE

--- a/lionagi/state/health.py
+++ b/lionagi/state/health.py
@@ -42,11 +42,17 @@ def classify_session_health(
     session: dict[str, Any],
     *,
     now: float,
-    process_alive: bool,
+    process_alive: bool | None,
     has_artifacts: bool,
     has_stale_locks: bool,
 ) -> SessionHealth:
-    """Classify a session dict into a SessionHealth level; pure function, caller supplies liveness signals."""
+    """Classify a session dict into a SessionHealth level; pure function, caller supplies liveness signals.
+
+    ``process_alive`` is tri-state: True = observed alive, False = confirmed
+    dead (positive evidence — a recorded pid that is no longer running),
+    None = unknown (no recorded pid and no process match, the normal case
+    for externally-driven sessions mirrored into the DB).
+    """
     status = session.get("status") or "completed"
 
     # Terminal sessions: done means done, unless they left litter.
@@ -71,18 +77,23 @@ def classify_session_health(
     kind = session.get("invocation_kind")
     threshold = STALE_THRESHOLDS.get(kind, DEFAULT_STALE_THRESHOLD)
 
-    if not process_alive:
+    if process_alive is not True:
         # Orphan check first: the session was advertised but never
         # produced a single message AND no artifacts on disk. This is
         # a session that crashed before doing anything; transitioning
         # it to failed is harmless, deleting it is also safe.
         if not has_artifacts and (session.get("message_count") or 0) == 0:
             return SessionHealth.ORPHANED
-        # Recent messages are stronger life-evidence than process
-        # visibility: externally-driven sessions (CLI seats mirrored
-        # into the DB) expose no matchable pid, so a missing process
-        # only means dead once activity has also gone quiet past the
-        # kind threshold.
+        if process_alive is False:
+            # Confirmed dead: positive evidence (a recorded pid no longer
+            # running) outranks the activity guard below — the process is
+            # gone no matter how fresh the last message is.
+            return SessionHealth.STALE
+        # Unknown liveness: recent messages are stronger life-evidence
+        # than process visibility — externally-driven sessions (CLI seats
+        # mirrored into the DB) expose no matchable pid, so an unmatched
+        # process only means dead once activity has also gone quiet past
+        # the kind threshold.
         if idle_seconds <= threshold:
             if idle_seconds > IDLE_THRESHOLD:
                 return SessionHealth.IDLE

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -177,8 +177,12 @@ def process_liveness(
     return None
 
 
-def _live_process_matches(session_id: str, artifacts_path: Path | None) -> bool:
-    return process_liveness({"id": session_id}, artifacts_path) is True
+def _live_process_matches(
+    session_id: str,
+    artifacts_path: Path | None,
+    ps_snapshot: str | None = None,
+) -> bool:
+    return process_liveness({"id": session_id}, artifacts_path, ps_snapshot) is True
 
 
 def _artifacts_path(row: Any) -> Path | None:
@@ -201,7 +205,13 @@ def _find_stale_lock(root: Path, *, cutoff: float) -> Path | None:
     return None
 
 
-def _classify_phantom(row: Any, *, now: float, stale_seconds: float) -> PhantomReason | None:
+def _classify_phantom(
+    row: Any,
+    *,
+    now: float,
+    stale_seconds: float,
+    ps_snapshot: str | None = None,
+) -> PhantomReason | None:
     ap = _artifacts_path(row)
     if ap and not ap.exists():
         return "missing_artifacts"
@@ -211,7 +221,7 @@ def _classify_phantom(row: Any, *, now: float, stale_seconds: float) -> PhantomR
             return "stale_lock"
     updated_at = row["updated_at"] or 0.0
     age = now - updated_at
-    if age >= stale_seconds and not _live_process_matches(row["id"], ap):
+    if age >= stale_seconds and not _live_process_matches(row["id"], ap, ps_snapshot):
         return "process_dead"
     return None
 
@@ -232,8 +242,11 @@ async def list_phantom_sessions(*, stale_hours: float = 1.0) -> list[dict[str, A
             """
         )
         rows = await cur.fetchall()
+    snapshot: str | None = None
     for row in rows:
-        reason = _classify_phantom(row, now=now, stale_seconds=stale_seconds)
+        if snapshot is None:
+            snapshot = _ps_snapshot()
+        reason = _classify_phantom(row, now=now, stale_seconds=stale_seconds, ps_snapshot=snapshot)
         if reason is not None:
             phantoms.append(
                 {
@@ -278,7 +291,7 @@ async def health_report() -> dict[str, Any]:
             """
             SELECT s.id, s.name, s.status, s.invocation_kind, s.agent_name,
                    s.playbook_name, s.started_at, s.ended_at, s.updated_at,
-                   s.last_message_at, s.artifacts_path,
+                   s.last_message_at, s.artifacts_path, s.node_metadata,
                    COALESCE(SUM(json_array_length(p.collection)), 0) AS message_count
             FROM sessions s
             LEFT JOIN branches b ON b.session_id = s.id
@@ -416,6 +429,7 @@ async def transition_sessions(
     transitioned: list[str] = []
     skipped: list[dict[str, str]] = []
     now = time.time()
+    txn_snapshot: str | None = None
 
     async with StateDB() as db:
         for sid in session_ids:
@@ -437,7 +451,9 @@ async def transition_sessions(
                 if artifacts is not None and artifacts.exists()
                 else False
             )
-            process_alive = process_liveness(current, artifacts)
+            if txn_snapshot is None:
+                txn_snapshot = _ps_snapshot()
+            process_alive = process_liveness(current, artifacts, txn_snapshot)
             health = classify_session_health(
                 current,
                 now=now,
@@ -451,7 +467,9 @@ async def transition_sessions(
                     "Only unhealthy sessions may be force-transitioned."
                 )
 
-            phantom_reason = _classify_phantom(current, now=now, stale_seconds=3600)
+            phantom_reason = _classify_phantom(
+                current, now=now, stale_seconds=3600, ps_snapshot=txn_snapshot
+            )
             classifier_code = _resolve_session_health_reason_code(
                 phantom_reason=phantom_reason,
                 health=health,

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -98,11 +98,8 @@ def _find_pid_file(root: Path) -> int | None:
     return None
 
 
-def _live_process_matches(session_id: str, artifacts_path: Path | None) -> bool:
-    if artifacts_path and artifacts_path.exists():
-        pid = _find_pid_file(artifacts_path)
-        if pid is not None:
-            return _pid_is_live(pid)
+def _ps_snapshot() -> str:
+    """One ``ps`` capture, shareable across rows; empty string when unavailable."""
     try:
         result = subprocess.run(
             ["ps", "-axo", "pid=,command="],  # noqa: S607
@@ -111,9 +108,77 @@ def _live_process_matches(session_id: str, artifacts_path: Path | None) -> bool:
             timeout=2,
             check=False,
         )
-        return session_id in result.stdout
+        return result.stdout
     except Exception:
-        return False
+        return ""
+
+
+# Process start-time comparison tolerance (clock-tick rounding).
+_PID_CREATE_TIME_TOLERANCE = 1.0
+
+
+def process_liveness(
+    session: dict[str, Any],
+    artifacts_path: Path | None,
+    ps_snapshot: str | None = None,
+) -> bool | None:
+    """Tri-state process liveness for a running session.
+
+    True = observed alive; False = confirmed dead (a recorded pid that is no
+    longer running, with start-time verification when one was recorded);
+    None = unknown (no recorded pid and no process match — normal for
+    externally-driven sessions that expose no matchable pid). Limitation:
+    a bare recycled pid (no recorded start time) reads alive — rare, and it
+    fails toward treating the session as live rather than falsely dead.
+    """
+    pid: int | None = None
+    create_time: float | None = None
+
+    meta = session.get("node_metadata")
+    if isinstance(meta, str):
+        try:
+            meta = json.loads(meta)
+        except ValueError:
+            meta = None
+    if isinstance(meta, dict):
+        raw_pid = meta.get("pid")
+        if raw_pid is not None:
+            try:
+                pid = int(raw_pid)
+            except (TypeError, ValueError):
+                pid = None
+        raw_ct = meta.get("pid_create_time")
+        if isinstance(raw_ct, int | float):
+            create_time = float(raw_ct)
+
+    if pid is None and artifacts_path is not None and artifacts_path.exists():
+        pid = _find_pid_file(artifacts_path)
+
+    if pid is not None:
+        if not _pid_is_live(pid):
+            return False
+        if create_time is not None:
+            try:
+                import psutil
+
+                actual = psutil.Process(pid).create_time()
+                if abs(actual - create_time) > _PID_CREATE_TIME_TOLERANCE:
+                    return False  # pid recycled; the recorded process is gone
+            except Exception:
+                # Best-effort check: the pid-is-live test above already
+                # passed, so an unreadable start time reads as alive.
+                _log.debug("pid %s start-time check failed", pid, exc_info=True)
+        return True
+
+    session_id = session.get("id") or ""
+    snapshot = ps_snapshot if ps_snapshot is not None else _ps_snapshot()
+    if session_id and session_id in snapshot:
+        return True
+    return None
+
+
+def _live_process_matches(session_id: str, artifacts_path: Path | None) -> bool:
+    return process_liveness({"id": session_id}, artifacts_path) is True
 
 
 def _artifacts_path(row: Any) -> Path | None:
@@ -227,6 +292,7 @@ async def health_report() -> dict[str, Any]:
     by_status: Counter[str] = Counter()
     by_health: Counter[str] = Counter()
     unhealthy: list[dict[str, Any]] = []
+    snapshot: str | None = None
 
     for row in rows:
         sess = {k: row[k] for k in row.keys()}
@@ -241,7 +307,9 @@ async def health_report() -> dict[str, Any]:
             has_stale_locks = _find_stale_lock(artifacts, cutoff=cutoff) is not None
 
         if status == "running":
-            process_alive = _live_process_matches(row["id"], artifacts)
+            if snapshot is None:
+                snapshot = _ps_snapshot()
+            process_alive = process_liveness(sess, artifacts, snapshot)
         else:
             process_alive = False
 
@@ -369,7 +437,7 @@ async def transition_sessions(
                 if artifacts is not None and artifacts.exists()
                 else False
             )
-            process_alive = _live_process_matches(current["id"], artifacts)
+            process_alive = process_liveness(current, artifacts)
             health = classify_session_health(
                 current,
                 now=now,

--- a/lionagi/studio/services/runs.py
+++ b/lionagi/studio/services/runs.py
@@ -467,18 +467,27 @@ def _adapt_detail(
     }
 
 
-def _run_row(s: dict[str, Any], now: float) -> dict[str, Any]:
+def _session_liveness(s: dict[str, Any], ps_snapshot: str | None = None) -> bool | None:
+    """Tri-state liveness for a running session row, via the shared admin oracle."""
+    from .admin import process_liveness
+
+    ap = s.get("artifacts_path")
+    return process_liveness(s, Path(ap) if ap else None, ps_snapshot)
+
+
+def _run_row(s: dict[str, Any], now: float, *, process_alive: bool | None = None) -> dict[str, Any]:
     """The canonical Run row shape. Shared by the list and detail routes so the
     two can never drift out of contract (the detail route used to drop fields the
     list route emits, e.g. invocation_id). Caller supplies a session dict carrying
-    branch_count / message_count / last_message_at.
+    branch_count / message_count / last_message_at, plus tri-state process
+    liveness (None = unknown) so a process-dead run cannot render as healthy.
     """
     from lionagi.state.health import SessionHealth, classify_session_health
 
     health = classify_session_health(
         s,
         now=now,
-        process_alive=True,
+        process_alive=process_alive,
         has_artifacts=bool(s.get("artifacts_path")),
         has_stale_locks=False,
     )
@@ -526,6 +535,7 @@ async def list_runs(
     status_set = _normalize_status_filter(status)
     now = time.time()
     out = []
+    snapshot: str | None = None
     for s in sessions:
         if playbook and playbook.lower() not in (s.get("playbook_name") or "").lower():
             continue
@@ -536,7 +546,14 @@ async def list_runs(
             continue
         if status_set and s.get("status") not in status_set:
             continue
-        out.append(_run_row(s, now))
+        alive: bool | None = None
+        if s.get("status") == "running":
+            if snapshot is None:
+                from .admin import _ps_snapshot
+
+                snapshot = _ps_snapshot()
+            alive = _session_liveness(s, snapshot)
+        out.append(_run_row(s, now, process_alive=alive))
     return out
 
 
@@ -600,15 +617,14 @@ async def get_run(run_id: str) -> dict[str, Any] | None:
         default=None,
     )
 
-    row = _run_row(
-        {
-            **session,
-            "branch_count": len(branches),
-            "message_count": message_count,
-            "last_message_at": last_message_at,
-        },
-        time.time(),
-    )
+    detail_session = {
+        **session,
+        "branch_count": len(branches),
+        "message_count": message_count,
+        "last_message_at": last_message_at,
+    }
+    alive = _session_liveness(detail_session) if detail_session.get("status") == "running" else None
+    row = _run_row(detail_session, time.time(), process_alive=alive)
 
     return {
         **row,

--- a/lionagi/studio/services/sessions.py
+++ b/lionagi/studio/services/sessions.py
@@ -118,6 +118,7 @@ async def list_sessions() -> list[dict[str, Any]]:
                 s.agent_hash,
                 s.project,
                 s.project_source,
+                s.node_metadata,
                 COUNT(DISTINCT b.id) AS branch_count,
                 COALESCE(SUM(
                     json_array_length(p.collection)
@@ -137,6 +138,7 @@ async def list_sessions() -> list[dict[str, Any]]:
             "name": row["name"],
             "created_at": row["created_at"],
             "updated_at": row["updated_at"] or 0.0,
+            "node_metadata": row["node_metadata"],
             "branch_count": row["branch_count"],
             "message_count": row["message_count"],
             # ADR-0017: read status directly from column;

--- a/tests/apps_studio_server/test_admin.py
+++ b/tests/apps_studio_server/test_admin.py
@@ -240,7 +240,7 @@ def test_admin_transition_rejects_healthy_session(tmp_path, monkeypatch):
 
     # Simulate a live process so the classifier returns HEALTHY
     # (idle_seconds ≈ 0, process alive → HEALTHY).
-    monkeypatch.setattr(admin_mod, "_live_process_matches", lambda *_: True)
+    monkeypatch.setattr(admin_mod, "process_liveness", lambda *a, **k: True)
 
     client = _make_client(tmp_path, monkeypatch, db_path)
     r = client.post(
@@ -267,7 +267,7 @@ def test_admin_transition_guard_re_evaluates_health_per_call(tmp_path, monkeypat
     _run(_seed_running_session(db_path, sid))
 
     # Simulate a live process so health is driven by activity threshold.
-    monkeypatch.setattr(admin_mod, "_live_process_matches", lambda *_: True)
+    monkeypatch.setattr(admin_mod, "process_liveness", lambda *a, **k: True)
 
     # Set last_message_at to ~2h ago and kind=agent (threshold=6h).
     # idle_seconds=2h > IDLE_THRESHOLD(1h) but < 6h → IDLE → refused.

--- a/tests/apps_studio_server/test_process_liveness.py
+++ b/tests/apps_studio_server/test_process_liveness.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the shared tri-state process-liveness oracle."""
+
+import json
+import os
+import subprocess
+
+import psutil
+import pytest
+
+pytest.importorskip("fastapi", reason="studio extra not installed")
+from lionagi.studio.services.admin import process_liveness  # noqa: E402
+
+
+def _dead_pid() -> int:
+    proc = subprocess.Popen(["/bin/sleep", "0"])  # noqa: S603
+    proc.wait()
+    return proc.pid
+
+
+def test_pid_file_dead_pid_is_confirmed_dead(tmp_path):
+    (tmp_path / "session.pid").write_text(str(_dead_pid()))
+    assert process_liveness({"id": "s1"}, tmp_path, ps_snapshot="") is False
+
+
+def test_pid_file_live_pid_is_alive(tmp_path):
+    (tmp_path / "session.pid").write_text(str(os.getpid()))
+    assert process_liveness({"id": "s1"}, tmp_path, ps_snapshot="") is True
+
+
+def test_node_metadata_pid_with_matching_create_time_is_alive():
+    ct = psutil.Process(os.getpid()).create_time()
+    session = {
+        "id": "s1",
+        "node_metadata": {"pid": os.getpid(), "pid_create_time": ct},
+    }
+    assert process_liveness(session, None, ps_snapshot="") is True
+
+
+def test_node_metadata_pid_with_mismatched_create_time_is_recycled_dead():
+    session = {
+        "id": "s1",
+        "node_metadata": {"pid": os.getpid(), "pid_create_time": 1.0},
+    }
+    assert process_liveness(session, None, ps_snapshot="") is False
+
+
+def test_node_metadata_accepts_json_string():
+    session = {
+        "id": "s1",
+        "node_metadata": json.dumps({"pid": _dead_pid()}),
+    }
+    assert process_liveness(session, None, ps_snapshot="") is False
+
+
+def test_no_pid_no_process_match_is_unknown():
+    assert process_liveness({"id": "sess-xyz"}, None, ps_snapshot="1 launchd") is None
+
+
+def test_no_pid_but_session_id_in_snapshot_is_alive():
+    snapshot = "1234 li agent --resume sess-xyz"
+    assert process_liveness({"id": "sess-xyz"}, None, ps_snapshot=snapshot) is True
+
+
+@pytest.mark.parametrize("meta", [None, "not-json", {"pid": "garbage"}])
+def test_unparseable_metadata_falls_through_to_unknown(meta):
+    assert process_liveness({"id": "s1", "node_metadata": meta}, None, ps_snapshot="") is None

--- a/tests/apps_studio_server/test_runs_list.py
+++ b/tests/apps_studio_server/test_runs_list.py
@@ -268,3 +268,44 @@ def test_runs_list_unknown_liveness_recent_activity_stays_healthy(tmp_path, monk
     target = next((run for run in r.json()["runs"] if run["id"] == sid), None)
     assert target is not None
     assert target["effective_health"] == "healthy"
+
+
+def test_runs_list_node_metadata_dead_pid_reports_stale_without_monkeypatch(tmp_path, monkeypatch):
+    """End-to-end: a running session whose node_metadata records a pid that is
+    no longer running must report 'stale' through the real oracle — the list
+    query must surface node_metadata to the liveness check."""
+    import subprocess
+
+    proc = subprocess.Popen(["/bin/sleep", "0"])  # noqa: S603
+    proc.wait()
+    dead_pid = proc.pid
+
+    db_path = tmp_path / "state.db"
+    sid = str(uuid.uuid4())
+
+    async def _seed() -> None:
+        async with StateDB(db_path) as db:
+            pid = str(uuid.uuid4())
+            await db.create_progression(pid)
+            await db.create_session(
+                {
+                    "id": sid,
+                    "progression_id": pid,
+                    "name": "test-dead-pid",
+                    "status": "running",
+                    "invocation_kind": "agent",
+                    "started_at": time.time() - 60,
+                    "last_message_at": time.time() - 30,
+                    "artifacts_path": str(tmp_path),
+                    "node_metadata": {"pid": dead_pid},
+                }
+            )
+
+    _run(_seed())
+    client = _make_client(tmp_path, monkeypatch, db_path)
+
+    r = client.get("/api/runs")
+    assert r.status_code == 200
+    target = next((run for run in r.json()["runs"] if run["id"] == sid), None)
+    assert target is not None
+    assert target["effective_health"] == "stale"

--- a/tests/apps_studio_server/test_runs_list.py
+++ b/tests/apps_studio_server/test_runs_list.py
@@ -175,7 +175,11 @@ def test_runs_list_project_null_filter(tmp_path, monkeypatch):
 
 
 async def _seed_running_session_with_activity(
-    db_path: Path, session_id: str, last_message_at: float, invocation_kind: str = "agent"
+    db_path: Path,
+    session_id: str,
+    last_message_at: float,
+    invocation_kind: str = "agent",
+    artifacts_path: str | None = None,
 ) -> None:
     async with StateDB(db_path) as db:
         pid = str(uuid.uuid4())
@@ -189,6 +193,7 @@ async def _seed_running_session_with_activity(
                 "invocation_kind": invocation_kind,
                 "started_at": last_message_at,
                 "last_message_at": last_message_at,
+                "artifacts_path": artifacts_path,
             }
         )
 
@@ -207,6 +212,9 @@ def test_runs_list_threshold_crossing_session_reports_stale_not_unresponsive(tmp
     old_activity = time.time() - 7 * 3600
     _run(_seed_running_session_with_activity(db_path, sid, last_message_at=old_activity))
     client = _make_client(tmp_path, monkeypatch, db_path)
+    # Pin liveness to True: this test asserts the UNRESPONSIVE→'stale' mapping,
+    # not the liveness oracle (the seeded session has no real process).
+    monkeypatch.setattr("lionagi.studio.services.runs._session_liveness", lambda *a, **k: True)
 
     r = client.get("/api/runs")
     assert r.status_code == 200
@@ -217,3 +225,46 @@ def test_runs_list_threshold_crossing_session_reports_stale_not_unresponsive(tmp
         f"expected 'stale', got {target['effective_health']!r}; "
         "UNRESPONSIVE must be mapped to 'stale' for dashboard compatibility"
     )
+
+
+def test_runs_list_confirmed_dead_process_reports_stale_despite_recent_activity(
+    tmp_path, monkeypatch
+):
+    """A running session whose recorded process is confirmed dead must report
+    'stale' even with fresh messages — positive death evidence outranks the
+    activity guard."""
+    db_path = tmp_path / "state.db"
+    sid = str(uuid.uuid4())
+    _run(
+        _seed_running_session_with_activity(
+            db_path, sid, last_message_at=time.time() - 30, artifacts_path=str(tmp_path)
+        )
+    )
+    client = _make_client(tmp_path, monkeypatch, db_path)
+    monkeypatch.setattr("lionagi.studio.services.runs._session_liveness", lambda *a, **k: False)
+
+    r = client.get("/api/runs")
+    assert r.status_code == 200
+    target = next((run for run in r.json()["runs"] if run["id"] == sid), None)
+    assert target is not None
+    assert target["effective_health"] == "stale"
+
+
+def test_runs_list_unknown_liveness_recent_activity_stays_healthy(tmp_path, monkeypatch):
+    """Unknown liveness (externally-driven session, no matchable pid) keeps the
+    activity guard: recent messages classify as healthy."""
+    db_path = tmp_path / "state.db"
+    sid = str(uuid.uuid4())
+    _run(
+        _seed_running_session_with_activity(
+            db_path, sid, last_message_at=time.time() - 30, artifacts_path=str(tmp_path)
+        )
+    )
+    client = _make_client(tmp_path, monkeypatch, db_path)
+    monkeypatch.setattr("lionagi.studio.services.runs._session_liveness", lambda *a, **k: None)
+
+    r = client.get("/api/runs")
+    assert r.status_code == 200
+    target = next((run for run in r.json()["runs"] if run["id"] == sid), None)
+    assert target is not None
+    assert target["effective_health"] == "healthy"

--- a/tests/state/test_health.py
+++ b/tests/state/test_health.py
@@ -150,10 +150,10 @@ def test_flow_threshold_more_lenient_than_agent():
     )
 
 
-# ── Running, process dead ────────────────────────────────────────────────────
+# ── Running, liveness unknown (no matchable pid) ────────────────────────────
 
 
-def test_running_process_dead_but_recently_messaging_is_healthy():
+def test_running_liveness_unknown_but_recently_messaging_is_healthy():
     """Externally-driven sessions expose no matchable pid; recent messages
     outrank process visibility as life-evidence."""
     s = {
@@ -165,14 +165,14 @@ def test_running_process_dead_but_recently_messaging_is_healthy():
     h = classify_session_health(
         s,
         now=NOW,
-        process_alive=False,
+        process_alive=None,
         has_artifacts=True,
         has_stale_locks=False,
     )
     assert h == SessionHealth.HEALTHY
 
 
-def test_running_process_dead_quiet_hours_is_idle():
+def test_running_liveness_unknown_quiet_hours_is_idle():
     s = {
         "status": "running",
         "invocation_kind": "agent",
@@ -182,14 +182,14 @@ def test_running_process_dead_quiet_hours_is_idle():
     h = classify_session_health(
         s,
         now=NOW,
-        process_alive=False,
+        process_alive=None,
         has_artifacts=True,
         has_stale_locks=False,
     )
     assert h == SessionHealth.IDLE
 
 
-def test_running_process_dead_exactly_at_threshold_is_idle():
+def test_running_liveness_unknown_exactly_at_threshold_is_idle():
     """Equality with the kind threshold stays on the alive side of the
     boundary — the same contract as the alive branch's UNRESPONSIVE cut."""
     s = {
@@ -201,7 +201,7 @@ def test_running_process_dead_exactly_at_threshold_is_idle():
     h = classify_session_health(
         s,
         now=NOW,
-        process_alive=False,
+        process_alive=None,
         has_artifacts=True,
         has_stale_locks=False,
     )
@@ -226,7 +226,7 @@ def test_running_process_alive_exactly_at_threshold_is_idle():
     assert h == SessionHealth.IDLE
 
 
-def test_running_process_dead_past_threshold_is_stale():
+def test_running_liveness_unknown_past_threshold_is_stale():
     s = {
         "status": "running",
         "invocation_kind": "agent",
@@ -236,14 +236,14 @@ def test_running_process_dead_past_threshold_is_stale():
     h = classify_session_health(
         s,
         now=NOW,
-        process_alive=False,
+        process_alive=None,
         has_artifacts=True,
         has_stale_locks=False,
     )
     assert h == SessionHealth.STALE
 
 
-def test_running_process_dead_no_output_is_orphaned():
+def test_running_confirmed_dead_no_output_is_orphaned():
     """Never wrote a message, never produced artifacts, process gone."""
     s = {
         "status": "running",
@@ -261,7 +261,7 @@ def test_running_process_dead_no_output_is_orphaned():
     assert h == SessionHealth.ORPHANED
 
 
-def test_running_process_dead_no_messages_but_has_artifacts_not_orphaned():
+def test_running_liveness_unknown_no_messages_but_has_artifacts_not_orphaned():
     """Artifacts present means the session produced *something* — not orphaned.
     Recent activity still classifies it alive despite the missing process."""
     s = {
@@ -273,7 +273,7 @@ def test_running_process_dead_no_messages_but_has_artifacts_not_orphaned():
     h = classify_session_health(
         s,
         now=NOW,
-        process_alive=False,
+        process_alive=None,
         has_artifacts=True,
         has_stale_locks=False,
     )
@@ -338,3 +338,44 @@ def test_worst_health_zombie_beats_orphaned():
 def test_severity_table_covers_all_health_levels():
     """Catch drift between SessionHealth and HEALTH_SEVERITY."""
     assert set(HEALTH_SEVERITY) == set(SessionHealth)
+
+
+# ── Running, confirmed dead (recorded pid no longer running) ─────────────────
+
+
+def test_running_confirmed_dead_recent_messages_is_stale():
+    """Positive evidence of death outranks the activity guard: a run whose
+    recorded pid is gone must not render healthy however fresh its messages."""
+    s = {
+        "status": "running",
+        "invocation_kind": "agent",
+        "last_message_at": NOW - 30,
+        "message_count": 5,
+    }
+    h = classify_session_health(
+        s,
+        now=NOW,
+        process_alive=False,
+        has_artifacts=True,
+        has_stale_locks=False,
+    )
+    assert h == SessionHealth.STALE
+
+
+def test_running_confirmed_dead_quiet_hours_is_stale_not_idle():
+    """Confirmed death skips the idle band entirely — a dead process is not
+    'quiet', it is gone."""
+    s = {
+        "status": "running",
+        "invocation_kind": "agent",
+        "last_message_at": NOW - 2 * 3600,
+        "message_count": 5,
+    }
+    h = classify_session_health(
+        s,
+        now=NOW,
+        process_alive=False,
+        has_artifacts=True,
+        has_stale_locks=False,
+    )
+    assert h == SessionHealth.STALE


### PR DESCRIPTION
## Problem

The runs list and detail endpoints hardcoded `process_alive=True` when classifying session health, so a running session whose process had died could never report `stale` there — while the admin health endpoint performed real pid checks on the same sessions. Two oracles disagreeing about the same data: the dashboard showed `healthy` for sessions the admin surface reported as dead.

## Fix

**Tri-state liveness.** `classify_session_health` now takes `process_alive: bool | None`:

- `True` — observed alive (recorded pid running, start-time verified when recorded, or session id matched in the process table).
- `False` — confirmed dead: a recorded pid is no longer running (or its start time mismatches, i.e. the pid was recycled). Positive death evidence skips the recent-activity guard → `STALE` immediately.
- `None` — unknown: no recorded pid and no process match, the normal case for externally-driven sessions mirrored into the DB. The existing activity guard applies unchanged: recent messages keep the session `HEALTHY`/`IDLE`.

**One shared oracle.** `process_liveness()` in the admin service resolves pid + `pid_create_time` from `node_metadata`, falls back to artifact `.pid` files (same resolution the admin health loop already used), then to a `ps` snapshot keyed by session id. Both the admin health loop and the runs endpoints now call the same function; `ps` is captured once per request and shared across rows.

**Known limitation** (documented in ADR-0024): a bare recycled pid — recorded pid with no recorded start time, reused by an unrelated process — reads alive. Rare, and it fails toward treating the session as live rather than falsely dead.

## Behavior change on deploy

Dashboard staleness shifts: sessions with a confirmed-dead recorded process now report `stale` despite recent messages, where a deployed daemon running the previous code rendered them `healthy`.

## Tests

- Classifier: confirmed-dead → `STALE` regardless of activity recency; unknown-liveness cases keep prior guard semantics (renamed to say what they now test).
- New oracle unit tests: dead pid file, live pid file, `node_metadata` pid with matching/mismatched start time, JSON-string metadata, ps-snapshot match, unknown fallback.
- API-level: confirmed-dead and unknown-liveness runs-list rows assert `effective_health`; the existing UNRESPONSIVE→`stale` mapping test pins liveness to `True` since it asserts the mapping, not the oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)