### PR TITLE
feat(studio): schedule failure-streak and last-status fields

### DIFF
--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -1945,6 +1945,25 @@ class StateDB:
             row = (await conn.execute(text(query), params)).mappings().first()
         return int(row["n"]) if row else 0
 
+    async def schedule_run_streak(self, schedule_id: str) -> tuple[int, str | None]:
+        """Consecutive terminal 'failed' streak and most recent status, newest-first, capped at 50 rows."""
+        query = """SELECT status FROM schedule_runs
+                   WHERE schedule_id = :schedule_id AND chain_depth = 0
+                   ORDER BY fired_at DESC LIMIT 50"""  # noqa: S608
+        async with self._read() as conn:
+            rows = (await conn.execute(text(query), {"schedule_id": schedule_id})).mappings().all()
+        if not rows:
+            return 0, None
+        last_status = rows[0]["status"]
+        streak = 0
+        for row in rows:
+            status = row["status"]
+            if status in ("completed", "cancelled"):
+                break
+            if status == "failed":
+                streak += 1
+        return streak, last_status
+
     async def get_schedule_run(self, run_id: str) -> dict[str, Any] | None:
         async with self._read() as conn:
             row = (

--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -316,6 +316,9 @@ async def list_schedules(
             if row.get("max_runs"):
                 used = await db.count_schedule_runs(row["id"], chain_depth=0)
                 row["remaining_runs"] = max(row["max_runs"] - used, 0)
+            streak, last_status = await db.schedule_run_streak(row["id"])
+            row["consecutive_failures"] = streak
+            row["last_status"] = last_status
     return rows
 
 
@@ -330,6 +333,9 @@ async def get_schedule(schedule_id: str) -> dict[str, Any] | None:
         if row.get("max_runs"):
             used = await db.count_schedule_runs(schedule_id, chain_depth=0)
             row["remaining_runs"] = max(row["max_runs"] - used, 0)
+        streak, last_status = await db.schedule_run_streak(schedule_id)
+        row["consecutive_failures"] = streak
+        row["last_status"] = last_status
     row["recent_runs"] = runs
     return row
 

--- a/tests/apps_studio_server/test_schedule_streaks.py
+++ b/tests/apps_studio_server/test_schedule_streaks.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for consecutive_failures / last_status on schedule list + detail rows."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi", reason="studio extra not installed")
+
+from lionagi.state.db import StateDB  # noqa: E402
+from lionagi.studio.services.schedules import (  # noqa: E402
+    create_schedule,
+    get_schedule,
+    list_schedules,
+)
+
+
+@pytest.fixture
+def temp_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr("lionagi.studio.services.schedules.DEFAULT_DB_PATH", db_path)
+    return db_path
+
+
+async def _make_schedule() -> str:
+    created = await create_schedule(
+        {
+            "name": f"streak-test-{uuid.uuid4().hex[:8]}",
+            "trigger_type": "cron",
+            "cron_expr": "0 18 * * *",
+            "action_kind": "agent",
+            "action_prompt": "ping",
+        }
+    )
+    return created["id"]
+
+
+async def _seed_run(
+    schedule_id: str,
+    *,
+    status: str,
+    fired_at: float,
+    chain_depth: int = 0,
+) -> None:
+    async with StateDB() as db:
+        await db.create_schedule_run(
+            {
+                "id": str(uuid.uuid4()),
+                "schedule_id": schedule_id,
+                "trigger_context": {},
+                "action_kind": "agent",
+                "action_args": {},
+                "status": status,
+                "chain_depth": chain_depth,
+                "fired_at": fired_at,
+            }
+        )
+
+
+async def test_never_fired_schedule_has_zero_streak_and_no_status(temp_db_path):
+    sid = await _make_schedule()
+    rows = await list_schedules()
+    row = next(r for r in rows if r["id"] == sid)
+    assert row["consecutive_failures"] == 0
+    assert row["last_status"] is None
+
+    detail = await get_schedule(sid)
+    assert detail["consecutive_failures"] == 0
+    assert detail["last_status"] is None
+
+
+async def test_failed_failed_completed_newest_first_gives_streak_two(temp_db_path):
+    sid = await _make_schedule()
+    now = time.time()
+    await _seed_run(sid, status="completed", fired_at=now - 30)
+    await _seed_run(sid, status="failed", fired_at=now - 20)
+    await _seed_run(sid, status="failed", fired_at=now - 10)
+
+    rows = await list_schedules()
+    row = next(r for r in rows if r["id"] == sid)
+    assert row["consecutive_failures"] == 2
+    assert row["last_status"] == "failed"
+
+
+async def test_running_newest_reports_last_status_but_not_counted_in_streak(temp_db_path):
+    sid = await _make_schedule()
+    now = time.time()
+    await _seed_run(sid, status="failed", fired_at=now - 20)
+    await _seed_run(sid, status="failed", fired_at=now - 10)
+    await _seed_run(sid, status="running", fired_at=now)
+
+    rows = await list_schedules()
+    row = next(r for r in rows if r["id"] == sid)
+    assert row["consecutive_failures"] == 2
+    assert row["last_status"] == "running"
+
+
+async def test_skipped_rows_are_ignored_by_streak_but_reported_as_last_status(temp_db_path):
+    sid = await _make_schedule()
+    now = time.time()
+    await _seed_run(sid, status="failed", fired_at=now - 40)
+    await _seed_run(sid, status="skipped", fired_at=now - 30)
+    await _seed_run(sid, status="failed", fired_at=now - 20)
+    await _seed_run(sid, status="skipped", fired_at=now - 10)
+
+    rows = await list_schedules()
+    row = next(r for r in rows if r["id"] == sid)
+    assert row["consecutive_failures"] == 2
+    assert row["last_status"] == "skipped"
+
+
+async def test_chain_children_do_not_count_toward_streak(temp_db_path):
+    sid = await _make_schedule()
+    now = time.time()
+    await _seed_run(sid, status="failed", fired_at=now - 10)
+    await _seed_run(sid, status="failed", fired_at=now - 5, chain_depth=1)
+
+    rows = await list_schedules()
+    row = next(r for r in rows if r["id"] == sid)
+    assert row["consecutive_failures"] == 1
+    assert row["last_status"] == "failed"
+
+
+async def test_newest_completed_run_resets_streak_to_zero(temp_db_path):
+    sid = await _make_schedule()
+    now = time.time()
+    await _seed_run(sid, status="failed", fired_at=now - 20)
+    await _seed_run(sid, status="completed", fired_at=now - 10)
+
+    rows = await list_schedules()
+    row = next(r for r in rows if r["id"] == sid)
+    assert row["consecutive_failures"] == 0
+    assert row["last_status"] == "completed"
+
+
+async def test_get_schedule_detail_carries_same_fields(temp_db_path):
+    sid = await _make_schedule()
+    now = time.time()
+    await _seed_run(sid, status="failed", fired_at=now - 20)
+    await _seed_run(sid, status="failed", fired_at=now - 10)
+
+    detail = await get_schedule(sid)
+    assert detail["consecutive_failures"] == 2
+    assert detail["last_status"] == "failed"


### PR DESCRIPTION
## Summary

Adds two fields to schedule rows on `GET /api/schedules/` (list) and `GET /api/schedules/{id}` (detail):

- `consecutive_failures: int` — consecutive most-recent terminal `failed` runs (chain_depth 0; `skipped`/`running` ignored; `completed`/`cancelled` resets to 0)
- `last_status: str | null` — status of the most recently fired chain_depth-0 run, `null` if never fired

Computed per row from `schedule_runs` over the existing `idx_sched_runs_schedule (schedule_id, fired_at DESC)` index, following the same pattern as the `remaining_runs` computation. No schema change, no new route.

This is the daemon half of the Home attention-row streak feature (design doc H2); the frontend consumer follows separately.

## Testing

- New `tests/apps_studio_server/test_schedule_streaks.py` — 7 cases: never-fired, mixed streaks, running/skipped handling, chain-child exclusion, reset semantics, list/detail parity
- Full studio suites: 814 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)