### PR TITLE
feat(studio): schedule failure-streak attention rows with deep links

### DIFF
--- a/apps/studio/frontend/src/components/mission/AttentionQueue.tsx
+++ b/apps/studio/frontend/src/components/mission/AttentionQueue.tsx
@@ -12,7 +12,7 @@ import { useTranslations } from "use-intl";
 import SectionLabel from "@/components/ui/SectionLabel";
 import Chip from "@/components/ui/Chip";
 import type { AttentionItem, AttentionReason } from "./boardReducer";
-import { runDeepLink, invocationDeepLink } from "@/lib/runDeepLink";
+import { runDeepLink, invocationDeepLink, scheduleDeepLink } from "@/lib/runDeepLink";
 
 interface Props {
   items: AttentionItem[];
@@ -23,9 +23,10 @@ interface Props {
 /** Individual rows are reserved for actionable items; overflow lives in History. */
 const MAX_ACTIONABLE_ROWS = 6;
 
-const ACTIONABLE_REASONS: ReadonlySet<AttentionReason> = new Set(["gated", "stuck"]);
+const ACTIONABLE_REASONS: ReadonlySet<AttentionReason> = new Set(["streak", "gated", "stuck"]);
 
 const REASON_COLOR: Record<AttentionReason, string> = {
+  streak: "var(--status-failure)",
   failed: "var(--status-failure)",
   stale: "var(--status-pending)",
   stuck: "var(--status-pending)",
@@ -176,6 +177,13 @@ function ItemLink({
       </Link>
     );
   }
+  if (item.kind === "schedule") {
+    return (
+      <Link {...scheduleDeepLink(id)} className={className} style={style}>
+        {children}
+      </Link>
+    );
+  }
   return (
     <Link {...invocationDeepLink()} className={className} style={style}>
       {children}
@@ -214,6 +222,16 @@ function AttentionRow({
       >
         {item.name}
       </ItemLink>
+
+      {/* Consecutive-failure count on streak rows */}
+      {item.streakCount != null && (
+        <span
+          className="shrink-0 font-data tabular-nums text-[length:var(--t-xs)] font-semibold"
+          style={{ color: "var(--status-failure)" }}
+        >
+          {t("attention.streakCount", { count: item.streakCount })}
+        </span>
+      )}
 
       {/* Kind badge */}
       <Chip mono className="shrink-0">

--- a/apps/studio/frontend/src/components/mission/boardReducer.test.ts
+++ b/apps/studio/frontend/src/components/mission/boardReducer.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { boardReducer, initialBoardState } from "./boardReducer";
 import type { BoardState } from "./boardReducer";
-import type { RunSummary } from "@/lib/types";
+import type { RunSummary, ScheduleSummary } from "@/lib/types";
 import type { InvocationSummary } from "@/lib/api";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -48,8 +48,41 @@ function dispatchOk(
   runs: RunSummary[],
   invocations: InvocationSummary[] = [],
   nowSec = 1_000_000,
+  schedules: ScheduleSummary[] | null = null,
 ): BoardState {
-  return boardReducer(state, { type: "DATA_OK", runs, invocations, nowSec });
+  return boardReducer(state, { type: "DATA_OK", runs, invocations, schedules, nowSec });
+}
+
+function makeSchedule(
+  overrides: Partial<ScheduleSummary> & { id: string; name: string },
+): ScheduleSummary {
+  const base: ScheduleSummary = {
+    id: overrides.id,
+    name: overrides.name,
+    description: null,
+    enabled: 1,
+    trigger_type: "cron",
+    cron_expr: "0 * * * *",
+    interval_sec: null,
+    github_repo: null,
+    poll_interval_sec: null,
+    action_kind: "agent",
+    action_model: null,
+    action_prompt: null,
+    action_agent: null,
+    action_playbook: null,
+    action_project: null,
+    on_success: null,
+    on_fail: null,
+    last_fired_at: null,
+    next_fire_at: null,
+    missed_fire_policy: "skip",
+    overlap_policy: "skip",
+    project: null,
+    created_at: 0,
+    updated_at: 0,
+  };
+  return { ...base, ...overrides };
 }
 
 // ─── Three distinct non-data states ──────────────────────────────────────────
@@ -186,7 +219,7 @@ describe("boardReducer — attention queue derivation", () => {
     expect(s.attentionItems[0].kind).toBe("invocation");
   });
 
-  it("sorts failed before stale before stuck before gated", () => {
+  it("sorts gated before stuck before failed before stale", () => {
     const nowSec = 2_000_000;
     const stuckStart = nowSec - 4000;
     const s = dispatchOk(
@@ -201,10 +234,10 @@ describe("boardReducer — attention queue derivation", () => {
       nowSec,
     );
     const reasons = s.attentionItems.map((i) => i.reason);
-    expect(reasons[0]).toBe("failed");
-    expect(reasons[1]).toBe("stale");
-    expect(reasons[2]).toBe("stuck");
-    expect(reasons[3]).toBe("gated");
+    expect(reasons[0]).toBe("gated");
+    expect(reasons[1]).toBe("stuck");
+    expect(reasons[2]).toBe("failed");
+    expect(reasons[3]).toBe("stale");
   });
 
   it("deduplicates: a run that matches multiple criteria appears once (worst reason)", () => {
@@ -273,5 +306,79 @@ describe("boardReducer — TICK", () => {
     expect(ticked.nowSec).toBe(9_999_999);
     expect(ticked.activeRuns).toHaveLength(1);
     expect(ticked.dataState).toBe("live");
+  });
+});
+
+// ─── Schedule failure streaks ─────────────────────────────────────────────────
+
+describe("boardReducer — schedule failure streaks", () => {
+  it("surfaces a streak row when consecutive_failures reaches the threshold", () => {
+    const sched = makeSchedule({
+      id: "sch-1",
+      name: "nightly-sync",
+      consecutive_failures: 3,
+      last_status: "failed",
+      last_fired_at: 999_000,
+    });
+    const s = dispatchOk(initialBoardState(), [], [], 1_000_000, [sched]);
+    expect(s.attentionItems).toHaveLength(1);
+    const item = s.attentionItems[0];
+    expect(item.reason).toBe("streak");
+    expect(item.kind).toBe("schedule");
+    expect(item.streakCount).toBe(3);
+    expect(item.name).toBe("nightly-sync");
+  });
+
+  it("ignores schedules below the threshold", () => {
+    const sched = makeSchedule({ id: "sch-1", name: "s", consecutive_failures: 2 });
+    const s = dispatchOk(initialBoardState(), [], [], 1_000_000, [sched]);
+    expect(s.attentionItems).toHaveLength(0);
+  });
+
+  it("ignores disabled schedules regardless of streak", () => {
+    const sched = makeSchedule({
+      id: "sch-1",
+      name: "s",
+      enabled: 0,
+      consecutive_failures: 9,
+    });
+    const s = dispatchOk(initialBoardState(), [], [], 1_000_000, [sched]);
+    expect(s.attentionItems).toHaveLength(0);
+  });
+
+  it("orders streak rows above gated and failed items", () => {
+    const failedRun = makeRun({
+      run_id: "r1",
+      status: "failed",
+      started_at: 999_990,
+      ended_at: 999_995,
+    });
+    const gatedRun = makeRun({ run_id: "r2", status: "needs_review", started_at: 999_990 });
+    const sched = makeSchedule({ id: "sch-1", name: "s", consecutive_failures: 4 });
+    const s = dispatchOk(initialBoardState(), [failedRun, gatedRun], [], 1_000_000, [sched]);
+    expect(s.attentionItems.map((i) => i.reason)).toEqual(["streak", "gated", "failed"]);
+  });
+
+  it("keeps the last-known schedules when the schedules fetch degrades to null", () => {
+    const sched = makeSchedule({ id: "sch-1", name: "s", consecutive_failures: 5 });
+    let s = dispatchOk(initialBoardState(), [], [], 1_000_000, [sched]);
+    expect(s.attentionItems).toHaveLength(1);
+    s = dispatchOk(s, [], [], 1_000_001, null);
+    expect(s.schedules).toHaveLength(1);
+    expect(s.attentionItems).toHaveLength(1);
+  });
+
+  it("clears the streak row once a fresh fetch reports recovery", () => {
+    const failing = makeSchedule({ id: "sch-1", name: "s", consecutive_failures: 3 });
+    const recovered = makeSchedule({
+      id: "sch-1",
+      name: "s",
+      consecutive_failures: 0,
+      last_status: "completed",
+    });
+    let s = dispatchOk(initialBoardState(), [], [], 1_000_000, [failing]);
+    expect(s.attentionItems).toHaveLength(1);
+    s = dispatchOk(s, [], [], 1_000_001, [recovered]);
+    expect(s.attentionItems).toHaveLength(0);
   });
 });

--- a/apps/studio/frontend/src/components/mission/boardReducer.test.ts
+++ b/apps/studio/frontend/src/components/mission/boardReducer.test.ts
@@ -196,6 +196,33 @@ describe("boardReducer — attention queue derivation", () => {
     expect(s.attentionItems[0].reason).toBe("stale");
   });
 
+  it("stale health does not demote a stuck run — stuck wins", () => {
+    const nowSec = 2_000_000;
+    const s = dispatchOk(
+      initialBoardState(),
+      [
+        makeRun({
+          run_id: "r1",
+          status: "running",
+          effective_health: "stale",
+          started_at: nowSec - 4000,
+        }),
+      ],
+      [],
+      nowSec,
+    );
+    expect(s.attentionItems).toHaveLength(1);
+    expect(s.attentionItems[0].reason).toBe("stuck");
+  });
+
+  it("stale health does not demote a gated run — gated wins", () => {
+    const s = dispatchOk(initialBoardState(), [
+      makeRun({ run_id: "r1", status: "needs_review", effective_health: "stale" }),
+    ]);
+    expect(s.attentionItems).toHaveLength(1);
+    expect(s.attentionItems[0].reason).toBe("gated");
+  });
+
   it("stuck run (elapsed > threshold) appears in attention queue", () => {
     const nowSec = 2_000_000;
     const startedAt = nowSec - 4000; // 4000s > 3600s threshold

--- a/apps/studio/frontend/src/components/mission/boardReducer.ts
+++ b/apps/studio/frontend/src/components/mission/boardReducer.ts
@@ -142,51 +142,34 @@ function buildAttentionItems(
 
   for (const run of runs) {
     const s = run.status.toLowerCase();
+    // Status-based reasons take precedence; stale health is the fallback so
+    // an actionable gated/stuck run never degrades into an informational row.
+    let reason: AttentionReason | null = null;
     if (FAILED_STATUSES.has(s)) {
       if (!failedRecently(run.ended_at, run.started_at, nowSec)) continue;
-      items.push({
-        id: `run:${run.run_id}`,
-        kind: "run",
-        name: run.playbook_name ?? run.agent_name ?? run.run_id.slice(-8),
-        reason: "failed",
-        startedAt: run.started_at ?? null,
-        href: `/runs/${run.run_id}`,
-        status: run.status,
-      });
-    } else if (run.effective_health === "stale" || run.effective_health === "orphaned") {
-      items.push({
-        id: `run:${run.run_id}`,
-        kind: "run",
-        name: run.playbook_name ?? run.agent_name ?? run.run_id.slice(-8),
-        reason: "stale",
-        startedAt: run.started_at ?? null,
-        href: `/runs/${run.run_id}`,
-        status: run.status,
-      });
+      reason = "failed";
+    } else if (GATED_STATUSES.has(s)) {
+      reason = "gated";
     } else if (RUNNING_STATUSES.has(s)) {
       const elapsed = elapsedSec(run.started_at ?? null, nowSec);
-      if (elapsed != null && elapsed > STUCK_THRESHOLD_SEC) {
-        items.push({
-          id: `run:${run.run_id}`,
-          kind: "run",
-          name: run.playbook_name ?? run.agent_name ?? run.run_id.slice(-8),
-          reason: "stuck",
-          startedAt: run.started_at ?? null,
-          href: `/runs/${run.run_id}`,
-          status: run.status,
-        });
-      }
-    } else if (GATED_STATUSES.has(s)) {
-      items.push({
-        id: `run:${run.run_id}`,
-        kind: "run",
-        name: run.playbook_name ?? run.agent_name ?? run.run_id.slice(-8),
-        reason: "gated",
-        startedAt: run.started_at ?? null,
-        href: `/runs/${run.run_id}`,
-        status: run.status,
-      });
+      if (elapsed != null && elapsed > STUCK_THRESHOLD_SEC) reason = "stuck";
     }
+    if (
+      reason == null &&
+      (run.effective_health === "stale" || run.effective_health === "orphaned")
+    ) {
+      reason = "stale";
+    }
+    if (reason == null) continue;
+    items.push({
+      id: `run:${run.run_id}`,
+      kind: "run",
+      name: run.playbook_name ?? run.agent_name ?? run.run_id.slice(-8),
+      reason,
+      startedAt: run.started_at ?? null,
+      href: `/runs/${run.run_id}`,
+      status: run.status,
+    });
   }
 
   for (const inv of invocations) {

--- a/apps/studio/frontend/src/components/mission/boardReducer.ts
+++ b/apps/studio/frontend/src/components/mission/boardReducer.ts
@@ -7,7 +7,7 @@
  * layer — reducer and components are unchanged.
  */
 
-import type { RunSummary } from "@/lib/types";
+import type { RunSummary, ScheduleSummary } from "@/lib/types";
 import type { InvocationSummary } from "@/lib/api";
 
 // ─── State shape ─────────────────────────────────────────────────────────────
@@ -23,6 +23,8 @@ export interface BoardState {
   activeInvocations: InvocationSummary[];
   /** Last 10 terminal runs (completed/failed/cancelled). */
   recentRuns: RunSummary[];
+  /** Enabled schedules — feeds failure-streak attention rows. */
+  schedules: ScheduleSummary[];
   /** Items needing operator attention. */
   attentionItems: AttentionItem[];
   /** Data freshness state (3 distinct states + loading). */
@@ -33,16 +35,18 @@ export interface BoardState {
   errorMessage: string | null;
 }
 
-export type AttentionReason = "failed" | "stale" | "stuck" | "gated";
+export type AttentionReason = "streak" | "failed" | "stale" | "stuck" | "gated";
 
 export interface AttentionItem {
   id: string;
-  kind: "run" | "invocation";
+  kind: "run" | "invocation" | "schedule";
   name: string;
   reason: AttentionReason;
   startedAt: number | null;
   href: string;
   status: string;
+  /** Consecutive-failure count — present on "streak" items only. */
+  streakCount?: number;
 }
 
 // ─── Actions ─────────────────────────────────────────────────────────────────
@@ -53,6 +57,8 @@ export type BoardAction =
       type: "DATA_OK";
       runs: RunSummary[];
       invocations: InvocationSummary[];
+      /** null = schedules fetch failed this cycle — keep the last-known list. */
+      schedules: ScheduleSummary[] | null;
       nowSec: number;
     }
   | { type: "DATA_ERROR"; message: string }
@@ -90,6 +96,9 @@ const STUCK_THRESHOLD_SEC = 60 * 60;
 /** Failures older than this belong to History, not the attention queue. */
 const FAILED_ATTENTION_WINDOW_SEC = 24 * 60 * 60;
 
+/** Schedules failing this many consecutive runs get an attention row. */
+export const STREAK_ATTENTION_THRESHOLD = 3;
+
 function failedRecently(
   endedAt: number | null | undefined,
   startedAt: number | null | undefined,
@@ -110,9 +119,26 @@ function elapsedSec(startedAt: number | null, nowSec: number): number | null {
 function buildAttentionItems(
   runs: RunSummary[],
   invocations: InvocationSummary[],
+  schedules: ScheduleSummary[],
   nowSec: number,
 ): AttentionItem[] {
   const items: AttentionItem[] = [];
+
+  for (const sched of schedules) {
+    if (!sched.enabled) continue;
+    const streak = sched.consecutive_failures ?? 0;
+    if (streak < STREAK_ATTENTION_THRESHOLD) continue;
+    items.push({
+      id: `sched:${sched.id}`,
+      kind: "schedule",
+      name: sched.name,
+      reason: "streak",
+      startedAt: sched.last_fired_at ?? null,
+      href: "/schedules",
+      status: sched.last_status ?? "failed",
+      streakCount: streak,
+    });
+  }
 
   for (const run of runs) {
     const s = run.status.toLowerCase();
@@ -189,12 +215,13 @@ function buildAttentionItems(
     }
   }
 
-  // Sort: failed first, then stale, stuck, gated; within group by recency
+  // Sort: streak first, then gated, stuck, failed, stale; within group by recency
   const ORDER: Record<AttentionReason, number> = {
-    failed: 0,
-    stale: 1,
+    streak: 0,
+    gated: 1,
     stuck: 2,
-    gated: 3,
+    failed: 3,
+    stale: 4,
   };
   items.sort((a, b) => {
     const od = ORDER[a.reason] - ORDER[b.reason];
@@ -234,6 +261,7 @@ export function initialBoardState(): BoardState {
     activeRuns: [],
     activeInvocations: [],
     recentRuns: [],
+    schedules: [],
     attentionItems: [],
     dataState: "loading",
     lastUpdatedMs: null,
@@ -250,16 +278,18 @@ export function boardReducer(state: BoardState, action: BoardAction): BoardState
 
     case "DATA_OK": {
       const { runs, invocations, nowSec } = action;
+      const schedules = action.schedules ?? state.schedules;
       const activeRuns = deriveActiveRuns(runs);
       const activeInvocations = deriveActiveInvocations(invocations);
       const recentRuns = deriveRecentRuns(runs);
-      const attentionItems = buildAttentionItems(runs, invocations, nowSec);
+      const attentionItems = buildAttentionItems(runs, invocations, schedules, nowSec);
       return {
         ...state,
         nowSec,
         activeRuns,
         activeInvocations,
         recentRuns,
+        schedules,
         attentionItems,
         dataState: "live",
         lastUpdatedMs: Date.now(),

--- a/apps/studio/frontend/src/components/mission/useLiveBoard.test.ts
+++ b/apps/studio/frontend/src/components/mission/useLiveBoard.test.ts
@@ -20,7 +20,7 @@ import type { BoardState } from "./boardReducer";
 describe("watchdog stale-badge hysteresis — reducer contract", () => {
   it("live → stale on MARK_STALE", () => {
     let s = initialBoardState();
-    s = boardReducer(s, { type: "DATA_OK", runs: [], invocations: [], nowSec: 0 });
+    s = boardReducer(s, { type: "DATA_OK", runs: [], invocations: [], schedules: null, nowSec: 0 });
     expect(s.dataState).toBe("live");
     s = boardReducer(s, { type: "MARK_STALE" });
     expect(s.dataState).toBe("stale");
@@ -41,7 +41,7 @@ describe("watchdog stale-badge hysteresis — reducer contract", () => {
 
   it("stale is idempotent: MARK_STALE on already-stale stays stale", () => {
     let s: BoardState = initialBoardState();
-    s = boardReducer(s, { type: "DATA_OK", runs: [], invocations: [], nowSec: 0 });
+    s = boardReducer(s, { type: "DATA_OK", runs: [], invocations: [], schedules: null, nowSec: 0 });
     s = boardReducer(s, { type: "MARK_STALE" });
     s = boardReducer(s, { type: "MARK_STALE" });
     expect(s.dataState).toBe("stale");
@@ -49,10 +49,10 @@ describe("watchdog stale-badge hysteresis — reducer contract", () => {
 
   it("stale clears on DATA_OK (live resumption)", () => {
     let s: BoardState = initialBoardState();
-    s = boardReducer(s, { type: "DATA_OK", runs: [], invocations: [], nowSec: 0 });
+    s = boardReducer(s, { type: "DATA_OK", runs: [], invocations: [], schedules: null, nowSec: 0 });
     s = boardReducer(s, { type: "MARK_STALE" });
     expect(s.dataState).toBe("stale");
-    s = boardReducer(s, { type: "DATA_OK", runs: [], invocations: [], nowSec: 1 });
+    s = boardReducer(s, { type: "DATA_OK", runs: [], invocations: [], schedules: null, nowSec: 1 });
     expect(s.dataState).toBe("live");
   });
 });
@@ -74,7 +74,13 @@ describe("watchdog timing — 5s silence gate", () => {
     // Simulate the watchdog interval logic directly
     let state: BoardState = initialBoardState();
     // Make it live first
-    state = boardReducer(state, { type: "DATA_OK", runs: [], invocations: [], nowSec: 0 });
+    state = boardReducer(state, {
+      type: "DATA_OK",
+      runs: [],
+      invocations: [],
+      schedules: null,
+      nowSec: 0,
+    });
     expect(state.dataState).toBe("live");
 
     // Simulate 4900ms passing — watchdog should NOT fire (< 5s)
@@ -93,7 +99,13 @@ describe("watchdog timing — 5s silence gate", () => {
 
   it("marks stale after 5s silence", () => {
     let state: BoardState = initialBoardState();
-    state = boardReducer(state, { type: "DATA_OK", runs: [], invocations: [], nowSec: 0 });
+    state = boardReducer(state, {
+      type: "DATA_OK",
+      runs: [],
+      invocations: [],
+      schedules: null,
+      nowSec: 0,
+    });
 
     let lastSuccessAt = Date.now();
     const STALE_THRESHOLD_MS = 5_000;
@@ -110,7 +122,13 @@ describe("watchdog timing — 5s silence gate", () => {
 
   it("clears stale after 2 successful fetches (stable resumption)", () => {
     let state: BoardState = initialBoardState();
-    state = boardReducer(state, { type: "DATA_OK", runs: [], invocations: [], nowSec: 0 });
+    state = boardReducer(state, {
+      type: "DATA_OK",
+      runs: [],
+      invocations: [],
+      schedules: null,
+      nowSec: 0,
+    });
     state = boardReducer(state, { type: "MARK_STALE" });
     expect(state.dataState).toBe("stale");
 
@@ -124,7 +142,13 @@ describe("watchdog timing — 5s silence gate", () => {
     let cleared = !wasStale || successStreak >= STABLE_RESUMPTION_COUNT;
     if (cleared) {
       wasStale = false;
-      state = boardReducer(state, { type: "DATA_OK", runs: [], invocations: [], nowSec: 1 });
+      state = boardReducer(state, {
+        type: "DATA_OK",
+        runs: [],
+        invocations: [],
+        schedules: null,
+        nowSec: 1,
+      });
     }
     expect(successStreak).toBe(1);
     // Still stale because we haven't cleared yet
@@ -135,7 +159,13 @@ describe("watchdog timing — 5s silence gate", () => {
     cleared = !wasStale || successStreak >= STABLE_RESUMPTION_COUNT;
     if (cleared) {
       wasStale = false;
-      state = boardReducer(state, { type: "DATA_OK", runs: [], invocations: [], nowSec: 2 });
+      state = boardReducer(state, {
+        type: "DATA_OK",
+        runs: [],
+        invocations: [],
+        schedules: null,
+        nowSec: 2,
+      });
     }
     expect(successStreak).toBe(2);
     expect(state.dataState).toBe("live");
@@ -143,7 +173,13 @@ describe("watchdog timing — 5s silence gate", () => {
 
   it("single success does not clear stale (anti-flap)", () => {
     let state: BoardState = initialBoardState();
-    state = boardReducer(state, { type: "DATA_OK", runs: [], invocations: [], nowSec: 0 });
+    state = boardReducer(state, {
+      type: "DATA_OK",
+      runs: [],
+      invocations: [],
+      schedules: null,
+      nowSec: 0,
+    });
     state = boardReducer(state, { type: "MARK_STALE" });
 
     let wasStale = true;
@@ -154,7 +190,13 @@ describe("watchdog timing — 5s silence gate", () => {
     successStreak += 1;
     const cleared = !wasStale || successStreak >= STABLE_RESUMPTION_COUNT;
     if (cleared) {
-      state = boardReducer(state, { type: "DATA_OK", runs: [], invocations: [], nowSec: 1 });
+      state = boardReducer(state, {
+        type: "DATA_OK",
+        runs: [],
+        invocations: [],
+        schedules: null,
+        nowSec: 1,
+      });
     }
 
     // Still stale — anti-flap gate held

--- a/apps/studio/frontend/src/components/mission/useLiveBoard.ts
+++ b/apps/studio/frontend/src/components/mission/useLiveBoard.ts
@@ -11,7 +11,7 @@
  */
 
 import { useEffect, useReducer, useRef } from "react";
-import { listRuns, listInvocations } from "@/lib/api";
+import { listRuns, listInvocations, listSchedules } from "@/lib/api";
 import { boardReducer, initialBoardState } from "./boardReducer";
 import type { BoardState } from "./boardReducer";
 
@@ -50,9 +50,12 @@ export function useLiveBoard(): BoardState {
       if (!active) return;
       try {
         const nowSec = Math.floor(Date.now() / 1000);
-        const [runsResp, invsResp] = await Promise.all([
+        // Schedules feed streak rows only — a failed fetch must not take
+        // down the whole board, so it degrades to null (keep last-known).
+        const [runsResp, invsResp, schedulesResp] = await Promise.all([
           listRuns({ per_page: 200 }),
           listInvocations({ limit: 100 }),
+          listSchedules({ enabled: true }).catch(() => null),
         ]);
         if (!active) return;
 
@@ -66,6 +69,7 @@ export function useLiveBoard(): BoardState {
             type: "DATA_OK",
             runs: runsResp.runs,
             invocations: invsResp.invocations,
+            schedules: schedulesResp?.schedules ?? null,
             nowSec,
           });
         }

--- a/apps/studio/frontend/src/components/schedules/SchedulesBoard.tsx
+++ b/apps/studio/frontend/src/components/schedules/SchedulesBoard.tsx
@@ -85,16 +85,21 @@ export default function SchedulesBoard({
   runs,
   nowMs,
   onChanged,
+  initialSelectedId,
 }: {
   schedules: ScheduleSummary[];
   runs: RunRow[];
   nowMs: number;
   onChanged: () => void;
+  /** Deep-link target: opens this schedule's detail on mount. */
+  initialSelectedId?: string | null;
 }) {
   const t = useTranslations("schedules.lanes");
   const lanes = deriveLanes(schedules, runs, nowMs);
   const lastRuns = latestRunBySchedule(runs);
-  const [selectedScheduleId, setSelectedScheduleId] = useState<string | null>(null);
+  const [selectedScheduleId, setSelectedScheduleId] = useState<string | null>(
+    initialSelectedId ?? null,
+  );
 
   return (
     <>

--- a/apps/studio/frontend/src/components/schedules/SchedulesBoard.tsx
+++ b/apps/studio/frontend/src/components/schedules/SchedulesBoard.tsx
@@ -6,7 +6,6 @@
  * Each column is an independent scrollable surface. The row scrolls
  * horizontally on narrow viewports rather than wrapping — board behavior.
  */
-import { useState } from "react";
 import { useTranslations } from "use-intl";
 import Badge from "@/components/ui/Badge";
 import type { ScheduleSummary } from "@/lib/types";
@@ -85,21 +84,22 @@ export default function SchedulesBoard({
   runs,
   nowMs,
   onChanged,
-  initialSelectedId,
+  selectedScheduleId,
+  onSelectSchedule,
+  onCloseDetail,
 }: {
   schedules: ScheduleSummary[];
   runs: RunRow[];
   nowMs: number;
   onChanged: () => void;
-  /** Deep-link target: opens this schedule's detail on mount. */
-  initialSelectedId?: string | null;
+  /** URL-synced detail selection (?s=<id>) — owned by the route. */
+  selectedScheduleId: string | null;
+  onSelectSchedule: (id: string) => void;
+  onCloseDetail: () => void;
 }) {
   const t = useTranslations("schedules.lanes");
   const lanes = deriveLanes(schedules, runs, nowMs);
   const lastRuns = latestRunBySchedule(runs);
-  const [selectedScheduleId, setSelectedScheduleId] = useState<string | null>(
-    initialSelectedId ?? null,
-  );
 
   return (
     <>
@@ -119,7 +119,7 @@ export default function SchedulesBoard({
                 lastRun={lastRuns.get(s.id)}
                 nowMs={nowMs}
                 onChanged={onChanged}
-                onOpen={setSelectedScheduleId}
+                onOpen={onSelectSchedule}
               />
             </CardShell>
           ))}
@@ -140,7 +140,7 @@ export default function SchedulesBoard({
                 lastRun={lastRuns.get(s.id)}
                 nowMs={nowMs}
                 onChanged={onChanged}
-                onOpen={setSelectedScheduleId}
+                onOpen={onSelectSchedule}
               />
             </CardShell>
           ))}
@@ -190,7 +190,7 @@ export default function SchedulesBoard({
                 lastRun={lastRuns.get(s.id)}
                 nowMs={nowMs}
                 onChanged={onChanged}
-                onOpen={setSelectedScheduleId}
+                onOpen={onSelectSchedule}
               />
             </CardShell>
           ))}
@@ -199,7 +199,7 @@ export default function SchedulesBoard({
       {selectedScheduleId && (
         <ScheduleDetailModal
           scheduleId={selectedScheduleId}
-          onClose={() => setSelectedScheduleId(null)}
+          onClose={onCloseDetail}
           onChanged={onChanged}
         />
       )}

--- a/apps/studio/frontend/src/lib/runDeepLink.ts
+++ b/apps/studio/frontend/src/lib/runDeepLink.ts
@@ -11,3 +11,11 @@ export function runDeepLink(runId: string): { to: "/fleet"; search: { s: string 
 export function invocationDeepLink(): { to: "/history"; search: { tab: "run" } } {
   return { to: "/history", search: { tab: "run" } };
 }
+
+/** Schedule counterpart — opens the board with the schedule's detail visible. */
+export function scheduleDeepLink(scheduleId: string): {
+  to: "/schedules";
+  search: { s: string };
+} {
+  return { to: "/schedules", search: { s: scheduleId } };
+}

--- a/apps/studio/frontend/src/lib/types.ts
+++ b/apps/studio/frontend/src/lib/types.ts
@@ -352,6 +352,8 @@ export interface ScheduleSummary {
   overlap_policy: string;
   project: string | null;
   github_filter?: { event?: string; base?: string; state?: string } | null;
+  consecutive_failures?: number;
+  last_status?: string | null;
   created_at: number;
   updated_at: number;
 }

--- a/apps/studio/frontend/src/messages/en.json
+++ b/apps/studio/frontend/src/messages/en.json
@@ -578,13 +578,15 @@
       "viewAll": "View all →",
       "open": "Open →",
       "reason": {
+        "streak": "failing repeatedly",
         "failed": "failed",
         "stale": "stale · no activity",
         "stuck": "stuck · no progress",
         "gated": "awaiting approval"
       },
       "more": "+{count} more — view all in History →",
-      "digestLatest": "latest: {name} · {age} ago"
+      "digestLatest": "latest: {name} · {age} ago",
+      "streakCount": "{count}× failed"
     },
     "liveBoard": {
       "title": "Running now",

--- a/apps/studio/frontend/src/messages/zh.json
+++ b/apps/studio/frontend/src/messages/zh.json
@@ -578,13 +578,15 @@
       "viewAll": "查看全部 →",
       "open": "打开 →",
       "reason": {
+        "streak": "连续失败",
         "failed": "失败",
         "stale": "停滞 · 长时间无活动",
         "stuck": "卡住 · 无进展",
         "gated": "待审批"
       },
       "more": "还有 {count} 项，去历史中查看 →",
-      "digestLatest": "最近：{name} · {age}前"
+      "digestLatest": "最近：{name} · {age}前",
+      "streakCount": "连续失败 {count} 次"
     },
     "liveBoard": {
       "title": "正在运行",

--- a/apps/studio/frontend/src/routes/schedules/index.tsx
+++ b/apps/studio/frontend/src/routes/schedules/index.tsx
@@ -11,13 +11,21 @@ import SchedulesBoard from "@/components/schedules/SchedulesBoard";
 import SchedulesCalendar from "@/components/schedules/SchedulesCalendar";
 import { useSchedulesData } from "@/components/schedules/data";
 
-// ?create=1 (+ name/cron/prompt/desc) opens the create form pre-filled — the
-// deep-link surface Leo drives when the operator asks for a new routine. The
-// operator still reviews and submits; nothing is created from the URL alone.
+// ?create=1 (+ name/cron/prompt/desc) opens the create form pre-filled — a
+// deep-link surface for proposing a new routine. The operator still reviews
+// and submits; nothing is created from the URL alone. ?s=<id> opens that
+// schedule's detail (deep link from attention rows).
 export const Route = createFileRoute("/schedules/")({
   validateSearch: (
     search: Record<string, unknown>,
-  ): { create?: string; name?: string; cron?: string; prompt?: string; desc?: string } => {
+  ): {
+    create?: string;
+    name?: string;
+    cron?: string;
+    prompt?: string;
+    desc?: string;
+    s?: string;
+  } => {
     const pick = (key: string) =>
       typeof search[key] === "string" && search[key] ? { [key]: search[key] as string } : {};
     return {
@@ -26,6 +34,7 @@ export const Route = createFileRoute("/schedules/")({
       ...pick("cron"),
       ...pick("prompt"),
       ...pick("desc"),
+      ...pick("s"),
     };
   },
   component: SchedulesSpace,
@@ -150,7 +159,13 @@ function SchedulesSpace() {
       ) : schedules.length === 0 ? (
         <EmptyState onNew={() => setShowModal(true)} />
       ) : view === "board" ? (
-        <SchedulesBoard schedules={schedules} runs={runs} nowMs={nowMs} onChanged={refresh} />
+        <SchedulesBoard
+          schedules={schedules}
+          runs={runs}
+          nowMs={nowMs}
+          onChanged={refresh}
+          initialSelectedId={search.s}
+        />
       ) : (
         <div className="min-h-0 flex-1 overflow-y-auto">
           <SchedulesCalendar schedules={schedules} runs={runs} />

--- a/apps/studio/frontend/src/routes/schedules/index.tsx
+++ b/apps/studio/frontend/src/routes/schedules/index.tsx
@@ -133,6 +133,19 @@ function SchedulesSpace() {
     }
   };
 
+  // Detail selection lives in the URL (?s=<id>) so deep links, refresh, and
+  // back/forward all agree with what is on screen.
+  const openSchedule = (id: string) => {
+    void navigate({ to: "/schedules", search: (prev) => ({ ...prev, s: id }) });
+  };
+  const closeSchedule = () => {
+    void navigate({
+      to: "/schedules",
+      search: ({ s: _s, ...rest }) => rest,
+      replace: true,
+    });
+  };
+
   return (
     <main className="flex h-full w-full flex-col animate-page-enter">
       <header className="flex shrink-0 items-end justify-between gap-4 px-6 pb-4 pt-5">
@@ -164,7 +177,9 @@ function SchedulesSpace() {
           runs={runs}
           nowMs={nowMs}
           onChanged={refresh}
-          initialSelectedId={search.s}
+          selectedScheduleId={search.s ?? null}
+          onSelectSchedule={openSchedule}
+          onCloseDetail={closeSchedule}
         />
       ) : (
         <div className="min-h-0 flex-1 overflow-y-auto">


### PR DESCRIPTION
## Summary

Frontend consumer of the schedule streak fields (#1745). Home's attention queue now surfaces enabled schedules whose runs failed consecutively:

- New fifth `AttentionReason` `streak` — actionable row (like gated/stuck) carrying the consecutive-failure count, shown when `consecutive_failures >= STREAK_ATTENTION_THRESHOLD` (named constant, 3)
- Severity order becomes `streak > gated > stuck > failed > stale`
- The 3s board poll now also fetches enabled schedules; a failed schedules fetch degrades to the last-known list instead of erroring the whole board
- New `scheduleDeepLink(id)` helper (same single-cutover contract as `runDeepLink`) — streak rows open `/schedules?s=<id>`, which auto-opens that schedule's detail modal (one hop into the failure chain)
- en/zh strings for the streak reason label and count

## Testing

- 6 new reducer tests (threshold, disabled schedules, ordering above gated/failed, degraded-fetch retention, recovery clearing) + ordering test updated to the new severity contract
- Full frontend suite: 376 vitest passed, tsc clean, eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)