### PR TITLE
chore(docs): remove internal operational references from repo documents

### DIFF
--- a/apps/studio/DESIGN-CANVAS.md
+++ b/apps/studio/DESIGN-CANVAS.md
@@ -104,8 +104,8 @@ principle). During a run, fed by the existing signal SSE stream
 Signals are already persisted (session_signals). History's run detail gets a
 **scrubber**: replay the entire signal log over the canvas at any speed. This
 is time-travel debugging for orchestration — *why did this run spawn 30 agents*
-has a visual answer. Since we haven't discovered good usage patterns yet
-(Ocean, 2026-06-11), replay is how we find them: dogfood runs, scrub, see
+has a visual answer. Since we haven't discovered good usage patterns yet,
+replay is how we find them: dogfood runs, scrub, see
 where reactions cascaded usefully vs noisily, codify what works as presets.
 
 ## 5. Authoring artifact — the spec the canvas emits

--- a/apps/studio/REDESIGN-EXEC.md
+++ b/apps/studio/REDESIGN-EXEC.md
@@ -7,7 +7,7 @@ file-level implementation contract. On any conflict, DESIGN-SYSTEM.md wins.
 Branch: `feat/studio-cockpit-redesign`.
 Worktree: `/Users/lion/projects/lionagi-redesign`.
 
-Ocean's verbatim bar (2026-06-11): "smooth as fuck, super optimized for speed,
+Design bar (verbatim): "smooth as fuck, super optimized for speed,
 looks elegant and sleek, user friendly"; engine building must be a **graphic
 node-composition interface with individual node configuration**, including
 **signal emission configuration and signal observation patterns** — not a modal.
@@ -38,8 +38,8 @@ node-composition interface with individual node configuration**, including
   --edge-hairline: rgba(255,255,255,0.10); --edge-strong: rgba(255,255,255,0.18);
   --content-primary: #E8E6E1; --content-secondary: rgba(232,230,225,0.70);
   --content-muted: rgba(232,230,225,0.50);
-  /* secondary/muted raised from spec'd 0.55/0.35 — Ocean live verdict
-     2026-06-11: "too dark, not readable" on dense tables. Floor is binding. */
+  /* secondary/muted raised from spec'd 0.55/0.35 — design verdict:
+     "too dark, not readable" on dense tables. Floor is binding. */
   --accent: #E8A33D;            /* lion amber — attention + primary actions ONLY */
   --status-running: #5BA8F5; --status-success: #4FB477;
   --status-pending: #E8A33D; --status-failure: #E5604C;
@@ -265,6 +265,5 @@ Rules the distillation missed; from λ's own read of the composed material.
 
 ## Dogfood loop (every wave)
 
-λ boots `li studio` from the worktree, screenshots every surface (light+dark),
-fixes promptly, iterates until sleek. Screenshots →
-`.khive/workspaces/20260611/redesign-dogfood/`.
+Boot `li studio` from the worktree, screenshot every surface (light+dark),
+fix promptly, iterate until sleek.

--- a/apps/studio/REDESIGN-EXEC.md
+++ b/apps/studio/REDESIGN-EXEC.md
@@ -5,7 +5,6 @@ Working doc for the presentation-layer rebuild. **Authority: DESIGN-SYSTEM.md**
 DESIGN-CANVAS.md (Designer/canvas grammar) > this file, which adds the
 file-level implementation contract. On any conflict, DESIGN-SYSTEM.md wins.
 Branch: `feat/studio-cockpit-redesign`.
-Worktree: `/Users/lion/projects/lionagi-redesign`.
 
 Design bar (verbatim): "smooth as fuck, super optimized for speed,
 looks elegant and sleek, user friendly"; engine building must be a **graphic
@@ -101,7 +100,7 @@ light-flash). i18n: new `shell.*` strings in en.json + zh.json.
   timeline (runs+invocations+shows merged), day-grouped, strong filters, detail
   w/ DAG + transcripts; System = health/maintenance/schedules/settings.
 
-## Wave 1.5 — Tab IA + Copilot (directives 2026-06-11, λ-led)
+## Wave 1.5 — Tab IA + Copilot (directives 2026-06-11)
 
 - **Tabs, not pages** ("太多pages了，用户用不来的"): the 5 rail spaces are the
   ONLY pages. Everything else is a tab inside a space, rendered as child
@@ -123,7 +122,7 @@ light-flash). i18n: new `shell.*` strings in en.json + zh.json.
   streaming chat panel per DESIGN-SYSTEM (drawer contract, mono for
   tool-calls, terminal-state motion).
 - **zh quality pass** ("很多中文很奇怪，直接翻译根本就错了"): after all wave
-  branches merge, λ rewrites BOTH locale files in one pass — native
+  branches merge, rewrite BOTH locale files in one pass — native
   developer-tool register (阿里云/飞书 style), not word-for-word translation.
   No new zh strings ship without reading like product Chinese.
 - **Coherence pass**: three agents produced three styling dialects (inline
@@ -214,9 +213,9 @@ systems, operator consoles, event-sourcing replay). These refine the waves above
   only the tail (e.g. snapshot @2000, replay 400 ≈ 60ms vs 360ms full).
 - Long-range seeks show progress; never block the UI thread.
 
-### λ direct-read addenda (full briefings re-read 2026-06-11 — BINDING)
+### Direct-read addenda (full briefings re-read 2026-06-11 — BINDING)
 
-Rules the distillation missed; from λ's own read of the composed material.
+Rules the distillation missed; from a direct read of the composed material.
 
 **Canvas validation (Designer)**
 - **Command ports have exactly one owner.** Events fan out; commands do not

--- a/apps/studio/REDESIGN-V2.md
+++ b/apps/studio/REDESIGN-V2.md
@@ -1,6 +1,6 @@
 # Lion Studio v2 — seed-demo redesign (λ-designed, 2026-06-11)
 
-Ocean's mandate: full creative authority — add/remove pages, remove information
+Mandate: full creative authority — add/remove pages, remove information
 display, alter presentation. Fix: some pages information-overloaded, some blank.
 Rethink the canvas from scratch. Bar: seed-fundraising demo quality.
 

--- a/apps/studio/REDESIGN-V2.md
+++ b/apps/studio/REDESIGN-V2.md
@@ -1,4 +1,4 @@
-# Lion Studio v2 — seed-demo redesign (λ-designed, 2026-06-11)
+# Lion Studio v2 — seed-demo redesign (2026-06-11)
 
 Mandate: full creative authority — add/remove pages, remove information
 display, alter presentation. Fix: some pages information-overloaded, some blank.
@@ -37,7 +37,7 @@ Light theme is first-class: secondary text ≥ #3a3d44 on white, hairlines visib
 4. **History** — unified timeline. Run detail gains an **Invocations tab**.
    `/invocations/$id` standalone page DIES (route redirects into History).
 5. **Schedules** — kanban board (lanes: upcoming / today / running / done) +
-   month calendar toggle. λ-designed.
+   month calendar toggle.
 
 System/settings → gear at rail bottom, not a primary space. Playfield folds into
 Canvas as a secondary tab or dies if redundant. Shows already live in History.
@@ -77,9 +77,9 @@ canvas IS the launch console** — design-by-direct-manipulation:
 - W2: IA restructure (rail, Command merge, invocations fold, settings gear).
 - W3: Canvas rebuild per §3.
 - W4: Schedules kanban/calendar.
-- W5: coherence + perf (code-split reactflow chunk) + λ dogfood at 4 widths
+- W5: coherence + perf (code-split reactflow chunk) + dogfood at 4 widths
   both themes + commit per wave.
 
 Gates per wave: tsc, eslint 0 errors, vitest green, build, restart 8801,
-λ screenshots before declaring done. Prettier hook aborts commits while
+screenshot-verify before declaring done. Prettier hook aborts commits while
 reformatting — always `git log -1` to verify a commit actually landed.

--- a/apps/studio/frontend/src/components/ui/icons.tsx
+++ b/apps/studio/frontend/src/components/ui/icons.tsx
@@ -1,5 +1,5 @@
 /**
- * The single icon vocabulary. Contract (per Ocean live feedback):
+ * The single icon vocabulary. Contract (design review feedback):
  * viewBox "0 0 24 24", stroke currentColor, strokeWidth 1.5, round
  * caps/joins, fill none, literal shapes. At render sizes ≤ 12 pass
  * strokeWidth 2.25–2.5 so optical weight stays ~1px.

--- a/benchmarks/orchestration/harness/runner.py
+++ b/benchmarks/orchestration/harness/runner.py
@@ -43,7 +43,7 @@ logger = logging.getLogger("orchbench.runner")
 # must stay generous — this bounds a runaway subprocess, not typical trials.
 _CELL_TIMEOUT_S = 1800
 
-# Ocean's allowed model set → canonical CLI specs (the bare `claude` alias is
+# Allowed model set → canonical CLI specs (the bare `claude` alias is
 # claude_code; `claude/x` provider isn't the CLI provider, so map to claude-code).
 _MODEL_ALIASES = {
     "claude/haiku": "claude-code/haiku",

--- a/benchmarks/orchestration/suites/swebench/workspace.py
+++ b/benchmarks/orchestration/suites/swebench/workspace.py
@@ -1,6 +1,6 @@
 """Isolated per-task workspaces — clone the bug's repo, never touch real files.
 
-Safety model (Ocean: "don't ruin my computer"):
+Safety model (never touch real files):
   - All clones live under ``~/.lionagi/swebench-work`` (scratch, outside any real
     project). The agent NEVER sees the user's actual repos.
   - One cached full clone per upstream repo (django, sphinx); each task gets its

--- a/docs/adrs/ADR-0014-cli-primary-studio-secondary.md
+++ b/docs/adrs/ADR-0014-cli-primary-studio-secondary.md
@@ -18,7 +18,7 @@ the primary creation and execution surface:
 - "After creation, redirect to the new agent's detail and show clear next actions"
 
 These recommendations optimize for a user who lives in the browser. Lion Studio's
-actual user (Ocean) lives in the terminal. Playbooks are authored in an editor
+actual user lives in the terminal. Playbooks are authored in an editor
 and run via `li play`. Agents are defined as markdown files. Shows are orchestrated
 by Claude Code agents using the show skill. The CLI is the creation and execution
 surface; Studio is the observation and editing surface.
@@ -54,6 +54,7 @@ primary interface for observation, inspection, editing, and debugging.**
 
 The playbook detail page has a "Run" button. This is a convenience shortcut that
 shells out to the CLI, not a full execution surface. It does not support:
+
 - Input variable binding
 - Execution mode selection
 - Team mode configuration
@@ -86,6 +87,7 @@ with defaults" — a debugging convenience, not a production workflow.
 ## Consequences
 
 **Positive**
+
 - Studio stays focused: observe + inspect + edit + debug. No feature creep toward
   replicating CLI capabilities in the browser.
 - Simpler UI: no complex forms for run configuration, input binding, or team setup.
@@ -93,8 +95,9 @@ with defaults" — a debugging convenience, not a production workflow.
 - Correct mental model: Studio is a dashboard/IDE, not a control plane.
 
 **Negative**
+
 - Collaborators who don't use the CLI cannot create or run things from Studio alone.
-  This is acceptable for the current user base (Ocean + occasional collaborators).
+  This is acceptable for the current user base (a single primary operator + occasional collaborators).
 - The Run button on playbooks is a partial exception that may confuse expectations.
   Mitigate by keeping it visually de-emphasized and not adding execution options.
 - Some inspector features (e.g., "re-run this failed play") require switching to

--- a/docs/adrs/ADR-0020-skill-invocations.md
+++ b/docs/adrs/ADR-0020-skill-invocations.md
@@ -13,7 +13,7 @@ record of what triggered those sessions. The causal chain today:
 ??? → Session → Branch → Messages → Tool Calls → Artifacts
 ```
 
-The missing layer is **skill invocations**. When Ocean types `/show resolve
+The missing layer is **skill invocations**. When the operator types `/show resolve
 lionagi issues`, that single command produces:
 
 - 6 `li play` sessions (one per play)
@@ -267,7 +267,7 @@ User-created skills (files in `~/.lionagi/skills/`) work the same way.
   branches → messages.
 - Orchestrator skills get first-class lifecycle tracking without expanding
   the `invocation_kind` enum.
-- Invocations page gives Ocean a single view of "what did my system do
+- Invocations page gives the operator a single view of "what did my system do
   overnight" at the right granularity — skill-level, not session-level.
 - Grouped runs view reduces visual noise from multi-session orchestrations.
 - `li invoke` is opt-in — zero breakage for existing skills and CLI usage.

--- a/docs/adrs/ADR-0021-skill-artifacts-and-reactive-chaining.md
+++ b/docs/adrs/ADR-0021-skill-artifacts-and-reactive-chaining.md
@@ -54,7 +54,7 @@ and Studio displays."
 
 The compelling use case: PR opens → codex review runs in a worktree →
 produces verdict artifact → if APPROVE, merge; if REQUEST_CHANGES, file
-issues. Today this requires a human (Ocean) reading the verdict and
+issues. Today this requires a human reading the verdict and
 typing the next command. The pieces exist but don't connect.
 
 ## Decision
@@ -243,7 +243,7 @@ steps:
     with:
       pr: "{{ trigger.pr_number }}"
       method: squash
-    requires_approval: true    # pause and ask Ocean
+    requires_approval: true    # pause for human approval
 
   - action: gh-comment
     condition: "{{ steps[0].outcome.verdict == 'REQUEST_CHANGES' }}"
@@ -260,8 +260,8 @@ Chains are **not** a workflow engine. They are a thin reactive layer:
 2. **Steps** execute sequentially. Each step is a skill invocation or a
    shell action.
 3. **Conditions** are Jinja2 expressions over prior step outcomes.
-4. **`requires_approval`** pauses the chain and notifies Ocean. The chain
-   resumes when Ocean approves (via Studio UI or CLI).
+4. **`requires_approval`** pauses the chain and notifies the operator. The chain
+   resumes when the operator approves (via Studio UI or CLI).
 5. **Timeouts** abort a step if it exceeds the limit.
 
 Chains produce invocations — each step creates an invocation with

--- a/docs/adrs/ADR-0026-project-detection.md
+++ b/docs/adrs/ADR-0026-project-detection.md
@@ -43,7 +43,7 @@ is not practical):
 ```yaml
 project_overrides:
   "ag2ai/ag2": "ag2"
-  "/Users/lion/forks/ag2": "ag2"
+  "/path/to/forks/ag2": "ag2"
 ```
 
 Keys can be `org/repo` (matched against git remote) or absolute directory paths (prefix-matched

--- a/docs/adrs/ADR-0026-project-detection.md
+++ b/docs/adrs/ADR-0026-project-detection.md
@@ -9,7 +9,7 @@ Lion Studio's Runs page lists all sessions in a flat reverse-chronological list.
 count grows across multiple repositories (lionagi, ag2, khive-oss, khive-cloud, etc.), the list
 becomes unusable — there is no way to scope sessions to a specific project.
 
-The triggering need: Ocean works across 5–10 repos daily and wants sessions grouped by named
+The triggering need: a user working across 5–10 repos daily wants sessions grouped by named
 project in Studio, with GitHub integration potential. The question is how to detect which
 project a session belongs to at creation time.
 
@@ -60,6 +60,7 @@ against cwd).
 ### 4. Schema changes
 
 Two new columns on `sessions`:
+
 - `project TEXT` — the resolved project name
 - `project_source TEXT` — detection method: `config_toml`, `global_override`, `git_remote`, or `null`
 
@@ -68,6 +69,7 @@ Two new columns on `sessions`:
 ### 5. Implementation module
 
 New module `lionagi/cli/_project.py`:
+
 - `detect_project(cwd: Path | None = None) -> tuple[str | None, str | None]`
   Returns `(project_name, project_source)`.
 - Called by all three `create_session` sites: `cli/agent.py`, `cli/orchestrate/_orchestration.py`,
@@ -76,6 +78,7 @@ New module `lionagi/cli/_project.py`:
 ## Consequences
 
 **Positive**
+
 - Fresh clone of any owned repo auto-detects project (zero config if `.lionagi/config.toml` committed)
 - Blast radius of missing config bounded to one repo, not global
 - Monorepos handled naturally via nested `.lionagi/config.toml` at subdirectory level
@@ -83,6 +86,7 @@ New module `lionagi/cli/_project.py`:
 - `project_source` column enables Studio to distinguish high-confidence from inferred labels
 
 **Negative**
+
 - Repos the user doesn't control require manual `project_overrides` in global settings
 - Non-git directories always land in "Unassigned" — no auto-detection path
 - New config file (`.lionagi/config.toml`) alongside existing `.lionagi/settings.yaml` —

--- a/docs/adrs/ADR-0079-substrate-executor-provider-interface.md
+++ b/docs/adrs/ADR-0079-substrate-executor-provider-interface.md
@@ -383,7 +383,7 @@ fake process provider without launching Claude/Codex.
 5. Keep all existing model specs, aliases, and CLI flags compatible. No current
    caller must pass `ExecutionTarget`.
 
-## Open Questions for Ocean
+## Open Questions
 
 - Should arbitrary process specs be named `process/<profile>` to match `iModel`,
   or should a future parser accept a separate `executor://profile` syntax?

--- a/docs/adrs/ADR-0080-remote-sandbox-substrate-execution.md
+++ b/docs/adrs/ADR-0080-remote-sandbox-substrate-execution.md
@@ -382,7 +382,7 @@ behind a fake `DaytonaSandbox` that records calls to `clone()`, `exec_stream()`,
    local operation invocation remains byte-for-byte equivalent in behavior.
 7. Add tests with fake Daytona/process adapters before enabling any CLI default.
 
-## Open Questions for Ocean
+## Open Questions
 
 - Should the first #1195 implementation isolate each worker operation, or should
   it run the whole flow/play invocation remotely first and defer per-op remote

--- a/docs/adrs/ADR-0081-configurable-flow-planning.md
+++ b/docs/adrs/ADR-0081-configurable-flow-planning.md
@@ -471,7 +471,7 @@ selection, and dry-run output without invoking real providers.
 Existing commands without planning flags continue to plan the same DAG with the
 same orchestrator/default model and the same `max_ops` behavior.
 
-## Open Questions for Ocean
+## Open Questions
 
 - Preferred CLI names: `--planner-model` vs `--planning-model`, and `--plan`
   vs `--custom-plan`.

--- a/docs/adrs/ADR-0082-role-substrate-routing-policy.md
+++ b/docs/adrs/ADR-0082-role-substrate-routing-policy.md
@@ -249,8 +249,8 @@ roles:
     effort: high
 ```
 
-The shipped default pack should continue to omit model values until Ocean
-explicitly accepts a default cost/provider policy.
+The shipped default pack should continue to omit model values until
+maintainers explicitly accept a default cost/provider policy.
 
 ### Precedence
 
@@ -326,7 +326,7 @@ packs and dry-run stubs without starting external providers.
 - Preserves existing worker precedence and `--workers` behavior.
 - Maps model routing onto the ADR-0079 executor-provider path through existing
   `build_imodel_from_spec(...)`.
-- Keeps default provider/cost policy opt-in until Ocean accepts concrete
+- Keeps default provider/cost policy opt-in until maintainers accept concrete
   defaults.
 
 **Negative**
@@ -344,7 +344,7 @@ packs and dry-run stubs without starting external providers.
 | Add `model` or `substrate` directly to `Role` | Easy to inspect, but `Role` is the behavioral prompt/emission pattern. Runtime routing there would couple provider policy to the built-in persona library. |
 | Use user profile frontmatter only | Already works for custom profiles, but profiles shadow casts role bodies and require a full prompt file just to set a route. That is the gap ADR-0074 avoided with packs. |
 | Create standalone `casts/routing.yaml` | Clear name, but it duplicates `Pack`, which already owns per-role runtime config, modes, active roster, and policy. |
-| Hardcode the #1210 provider table in `default.yaml` now | Gives immediate defaults, but violates existing tests and the compatibility rule that shipped packs do not pin provider/cost policy. Ocean must accept concrete defaults first. |
+| Hardcode the #1210 provider table in `default.yaml` now | Gives immediate defaults, but violates existing tests and the compatibility rule that shipped packs do not pin provider/cost policy. Concrete defaults must be accepted first. |
 | Wait for ADR-0079 before any #1210 implementation | Avoids future migration, but unnecessarily blocks the existing model-spec route, which already maps to provider endpoints through `build_imodel_from_spec(...)`. |
 
 ## Migration and Compatibility
@@ -356,7 +356,7 @@ packs and dry-run stubs without starting external providers.
 4. Preserve existing precedence exactly.
 5. After ADR-0079 lands, add optional `execution_target` parsing to `RoleConfig`
    and map it to endpoint kwargs in the same branch builder path.
-6. If Ocean later accepts default role-provider policy, populate a separate
+6. If maintainers later accept default role-provider policy, populate a separate
    named routing pack first. Promote to default only with a follow-up ADR or ADR
    amendment.
 
@@ -364,7 +364,7 @@ Existing commands without `--pack` continue using the default pack with no
 provider hardcoding. Existing `--workers` and user profile frontmatter continue
 to win over pack routing.
 
-## Open Questions for Ocean
+## Open Questions
 
 - Should `--pack` accept only filesystem paths in the first slice, or also named
   packs under `~/.lionagi/packs/`?

--- a/docs/adrs/ADR-0086-statedb-sqlalchemy-core-backend-unification.md
+++ b/docs/adrs/ADR-0086-statedb-sqlalchemy-core-backend-unification.md
@@ -126,7 +126,7 @@ The five `BEGIN IMMEDIATE` windows map as follows:
 
 | Alternative | Why Rejected |
 |-------------|--------------|
-| Additive backend interface (SQLite stays raw aiosqlite; separate PG backend) | Two full implementations to keep in parity forever; perpetuates the studio raw path. Lower risk but loses the "one code path" goal Ocean chose. |
+| Additive backend interface (SQLite stays raw aiosqlite; separate PG backend) | Two full implementations to keep in parity forever; perpetuates the studio raw path. Lower risk but loses the "one code path" goal. |
 | Hand-written dialect layer over raw drivers (aiosqlite + asyncpg, no SQLAlchemy) | Reinvents paramstyle/JSON/DDL translation that SA already does; leaves the declared `sqlalchemy` dependency unused. |
 | Phased dialect-shim that string-rewrites SQLite SQL to PG | Fragile (regex-rewriting `json_each` etc.); a too-clever compatibility layer that review would rightly flag. |
 

--- a/docs/adrs/ADR-0088-flow-steering-mechanisms.md
+++ b/docs/adrs/ADR-0088-flow-steering-mechanisms.md
@@ -37,7 +37,7 @@ single-node flow or a flow whose open ops are all past preparation (stamped
 `rejected:no-pending-ops`), and it cannot redirect an op already mid-turn; and op-mode (`--as-op`)
 was reserved by ADR-0085 and is unbuilt.
 
-Field evidence from three lambda-seat interviews (2026-07-03) frames the priority. The number-one
+Field evidence from three operator interviews (2026-07-03) frames the priority. The number-one
 ask is trustworthy terminal status (tracked as issue #1672), not steering. The number-two ask is
 genuine pause/resume/steer for `li play`, because today the only lever for an off-track run is
 kill-and-restart, discarding sunk work, and most failures are "85% right, wrong turn near the end."

--- a/docs/adrs/ADR-0088-flow-steering-mechanisms.md
+++ b/docs/adrs/ADR-0088-flow-steering-mechanisms.md
@@ -132,7 +132,7 @@ latency (~2s) and soft-pause boundary semantics from ADR-0085 are unchanged.
 | Amend ADR-0085 section 3 in place | Buries the new render contract and measurement gate in an eight-part document; a focused 0088 is cleaner and faster to sign off. |
 | Bake provider-specific transcript-resume into OSS | The live-mailbox steer (SendMessage to a running agent) is a firm-layer concern on top of OSS actor identity, not provider-specific resume logic in OSS lionagi. |
 
-## Open questions for sign-off (Leo / Fable)
+## Open questions for design sign-off
 
 1. **Render seam.** A1 (render in `operations/flow.py` `_prepare_operation`, engine-local, mid-run
    capable, couples the engine to the `operator_messages` key) versus A2 (render at the message /

--- a/docs/adrs/ADR-0089-sandbox-backend-seam-and-measurement-loop.md
+++ b/docs/adrs/ADR-0089-sandbox-backend-seam-and-measurement-loop.md
@@ -145,7 +145,7 @@ This fork governs four things at once, which is why it is load-bearing rather th
 - **Secrets**: prompt-cells never receive provider keys in the box; exec-cells always do, via a
   reference or broker rather than raw env where the backend allows it (echoing 0080's own open
   question; this ADR does not resolve broker-vs-raw-env, see
-  [Open questions](#open-questions-for-ocean)).
+  [Open questions](#open-questions)).
 - **Egress**: a prompt-cell's provider call never crosses the backend's network, so backend choice
   cannot bias it.
 - **Teardown cost**: a prompt-cell's box holds no long-lived state, so teardown is cheap regardless
@@ -173,7 +173,7 @@ ADR-0080's backend-contract half (the `SandboxBackend` literal, `sandbox_exec_st
 absorbed into the contract defined above. ADR-0080's other half, wiring flow/play production
 operations through `DependencyAwareExecutor._execute_operation()` in `operations/flow.py`, is
 **explicitly out of scope for this ADR**. It is not silently absorbed (it has its own blast radius
-and its own Leo gate) and it is not left as codeless vaporware under this ADR's number: it
+and its own review gate) and it is not left as codeless vaporware under this ADR's number: it
 **reopens as a fresh, named future ADR when a second, non-benchmark consumer of this seam
 exists.** Until then, `lionagi/substrate/` is not built and `DependencyAwareExecutor` is untouched.
 
@@ -189,7 +189,7 @@ day-one requirement:
 | Daytona | Day 1 | Horizontal scale (sub-100ms cold start, hundreds of trials), the proven SWE-bench exec-cell path | Went closed-source 2026-06-11 and is managed-cloud-only going forward, with no self-host option; see the hard constraint below for why this ADR never treats Daytona as sufficient alone |
 | Docker | Slice 2, **required** | The zero-managed-vendor guarantee for exec-cells (see the hard constraint below); sovereign, local exec-cell repro | None new; universal, mature API |
 | Apple Container | Deferred, documented | microVM-per-container isolation this workload does not need | No official socket/REST API, CLI-and-XPC only; the `mocker` compatibility shim is CLI-only (no Docker Engine API), leaks on teardown (no `--rm` equivalent, ~10s graceful-stop tax per cell), and measures roughly 3.6x slower cold start than Docker Desktop in the shim author's own numbers. At a hundreds-of-trials workload, that teardown and cold-start tax compounds; buying unused microVM isolation at that cost is not justified for v1 |
-| Codespaces | Supported at the seam level; adapter deferred past v1; never the loop's default backend | Ocean named it explicitly. A batch or non-interactive execution profile the seam can express through `capabilities()`, and a concrete demonstration that the seam itself is pluggable to a backend this ADR did not have to build first | Minutes-scale cold boot without prebuilds and GiB-month-plus-core-hour billing are wrong-shaped for a default driver of hundreds of short trials; `capabilities()` reports its cold-start class as minutes-scale so callers batch around it or skip it per trial, rather than the seam hardcoding an exclusion. This is why it is supported, not why it is excluded |
+| Codespaces | Supported at the seam level; adapter deferred past v1; never the loop's default backend | It was named explicitly as a candidate backend. A batch or non-interactive execution profile the seam can express through `capabilities()`, and a concrete demonstration that the seam itself is pluggable to a backend this ADR did not have to build first | Minutes-scale cold boot without prebuilds and GiB-month-plus-core-hour billing are wrong-shaped for a default driver of hundreds of short trials; `capabilities()` reports its cold-start class as minutes-scale so callers batch around it or skip it per trial, rather than the seam hardcoding an exclusion. This is why it is supported, not why it is excluded |
 | wasmtime (khive-cloud plugin layer) | Out of scope | A different isolation tier (wasm-module, not OS/container) | Not evaluated further here |
 
 **Hard constraint (normative): the recursive measurement loop MUST be runnable with zero
@@ -202,7 +202,7 @@ service, and slice 2 does not ship without it. Any future roster change that wou
 MUST replace it with an equivalent zero-managed-vendor backend before it lands.
 
 Apple Container in-roster is a strategic call, not a technical one settled by this ADR; see
-[Open questions](#open-questions-for-ocean). Codespaces' in-roster status is settled above: it is
+[Open questions](#open-questions). Codespaces' in-roster status is settled above: it is
 supported, its adapter is deferred past v1, and it is never selected as the loop's default backend.
 
 ### 6. Measurement discipline (inherited from ADR-0088)
@@ -237,7 +237,7 @@ Two targets are defined for the first two loop slices:
 1. **Lionagi prompting system**: replicate the ADR-0088 steer-adherence fixture (op1 drafts a
    plan, a steer redirects it, op2 executes, `is_steer_adherent()` scores the artifact) as the
    first end-to-end proof that variants can be proposed, measured, and gated through the seam.
-2. **Notification-prompting surface**: defined here, not left open, per the advisor's pinning.
+2. **Notification-prompting surface**: defined here, not left open.
    The fixture is a run trace carrying a labeled ground-truth critical event (a stuck job, a
    terminal-status flip, a failed op). The notification surface produces a summary or alert. The
    machine-checkable cell is **critical-event surfacing recall/precision**: does the surface
@@ -275,8 +275,8 @@ A recursive loop on metered Daytona, multiplied by iterations and trials, is a r
 disk-floor risk. This ADR requires: a per-loop hard budget cap (`trials x iterations x est. $/trial`);
 a per-backend circuit breaker that halts on error-rate or spend threshold; auto-halt on either
 cap; and heavy artifacts written to external storage rather than the internal disk floor. **The
-spend ceiling and any unattended-cadence spend rate are Ocean's call**: this ADR frames the
-decision, it does not pick the number (see [Open questions](#open-questions-for-ocean)).
+spend ceiling and any unattended-cadence spend rate are a resource decision outside this ADR's scope**: this ADR frames the
+decision, it does not pick the number (see [Open questions](#open-questions)).
 
 ### 9. Observability harvest
 
@@ -336,9 +336,9 @@ involved), never for the provider call under test.
 | Adopt LangChain Deep Agents' `BaseSandbox` shape | Its `execute(command)`-only contract drops `capabilities()`, forcing backend branching back into callers: the leak this seam exists to prevent. Kept as convergent validation of the four-verb shape, not as the contract. |
 | Promote the seam into `lionagi/substrate/` now | Cosmetic package move ahead of a second consumer; risks becoming the exact vaporware package ADR-0079 never filled. Deferred until flow/play integration is taken up. |
 | Revise ADR-0079 and ADR-0080 in place instead of superseding | Leaves three overlapping Proposed sandbox designs live at once, which the packet and this ADR both judge worse than one document with an explicit lineage note. |
-| Ship the recursive loop as a sibling ADR gated on the seam | Considered, but Ocean framed the loop as the product; exiling it to a second document while it depends entirely on this seam's contract would separate a decision from its dependency without a real benefit. |
+| Ship the recursive loop as a sibling ADR gated on the seam | Considered, but the loop is framed as the product; exiling it to a second document while it depends entirely on this seam's contract would separate a decision from its dependency without a real benefit. |
 | All backends (worktree, Daytona, Docker, Apple Container, Codespaces) day one | Apple Container's teardown tax and ~3.6x cold-start penalty are not justified by a workload that does not need microVM isolation, and a Codespaces adapter is real implementation work with no day-one consumer; staged rollout matches backend cost/benefit to when each is actually needed. |
-| Exclude Codespaces from the roster entirely | Rejected: Ocean named it explicitly, and its cold-start class is a batch/non-interactive profile `capabilities()` can express honestly rather than a shape the seam should refuse to acknowledge. Supported-but-not-loop-default is the position that keeps the seam honest about what Codespaces is good for without making it the default driver. |
+| Exclude Codespaces from the roster entirely | Rejected: it was named explicitly as a candidate, and its cold-start class is a batch/non-interactive profile `capabilities()` can express honestly rather than a shape the seam should refuse to acknowledge. Supported-but-not-loop-default is the position that keeps the seam honest about what Codespaces is good for without making it the default driver. |
 | Use `harness/judge.py`'s LLM judge as the loop's promotion scorer | Reward-hackable by construction, and shares a model family with the proposer, creating a collusion risk. Rejected in favor of machine-checkable scorers only. |
 | Cache provider responses for cheap re-scoring | Would measure the cache, not the model, defeating the point of the measurement. Rejected inside the measurement path; permitted only for deterministic re-scoring of already-captured artifacts. |
 
@@ -383,8 +383,8 @@ involved), never for the provider call under test.
 
 - **Slice 1, seam + fidelity.** `SandboxBackend` Protocol, `Handle`, `capabilities()`; worktree
   `run_cell`; Daytona wrap; a `runner.py:run_once()` backend selector; reproduce the ADR-0088
-  adherence table through the seam. Backends: worktree/host and Daytona. **Goes to the Leo
-  spec-gate before this slice merges.**
+  adherence table through the seam. Backends: worktree/host and Daytona. **Goes through
+  design review before this slice merges.**
 - **Slice 2, zero-managed-vendor constraint + first loop target.** Docker backend, which satisfies
   the hard constraint that the loop never depend solely on a managed vendor; the recursive loop
   driver with an objective scorer, train/holdout split, human-approved promotion, and a budget
@@ -400,7 +400,7 @@ involved), never for the provider call under test.
   ex-ADR-0080 `DependencyAwareExecutor` integration); an Apple Container backend, if vendor risk
   ever forces reconsidering it.
 
-## Open Questions for Ocean
+## Open Questions
 
 - **Spend ceiling.** A per-loop hard budget cap and an unattended-cadence spend rate are
   resource decisions: frame is "cap at $X per loop, halt at Y% error rate; unattended runs only

--- a/docs/adrs/ADR-0090-minimal-memory-contract-and-backend-seam.md
+++ b/docs/adrs/ADR-0090-minimal-memory-contract-and-backend-seam.md
@@ -67,10 +67,10 @@ conversation-summarization surface exists today under any name).
 
 Two positions were on the table (per #1683): lionagi core stays persistence-agnostic and only
 documents a seam external memory systems attach to, or core owns a minimal contract plus a
-default backend so the framework has a real out-of-the-box memory story. Ocean's ruling (#1683,
+default backend so the framework has a real out-of-the-box memory story. The design decision (#1683,
 2026-07-03) settles this as both, combined: a minimal async contract and one thin default backend
 in core, with the documented seam as the production path for anything beyond that default. This
-ADR encodes that ruling (contract shape, default backend choice, seam documentation, access
+ADR encodes that decision (contract shape, default backend choice, seam documentation, access
 surface, and the two dead-surface dispositions) as the design record #1683 asks for.
 
 ## Decision
@@ -347,7 +347,7 @@ concurrent access to `Branch.messages`.
 
 | Alternative | Why Rejected |
 |---|---|
-| Stay fully persistence-agnostic (position 2 alone, no default backend) | Rejected by Ocean's ruling: core would have zero out-of-the-box memory story, only documentation, which is weaker than "a real standalone memory story" the ruling asks for. |
+| Stay fully persistence-agnostic (position 2 alone, no default backend) | Rejected: core would have zero out-of-the-box memory story, only documentation, which is weaker than "a real standalone memory story" the ruling asks for. |
 | Own the whole 2025 epic scaffold (tiers, attention, consolidation, resource monitors, LlamaIndex) | Explicitly declined; no named consumer for any of it today, and each piece competes with or duplicates an existing, narrower mechanism (see [Explicitly declined](#4-explicitly-declined-in-core)). |
 | Default backend on `StateDB`/SQLite | Persistent "for free," but couples a core `Branch` feature to the CLI/Studio run-bookkeeping schema; every library consumer would depend on machinery scoped to a different purpose. Documented as a seam example instead. |
 | Default backend on stdlib `sqlite3` directly, own table, no `StateDB` coupling | Avoids the `StateDB` objection above, but still adds file-lifecycle questions (file location, cleanup, concurrent-process access) that the in-process default has none of; the ruling asks for one thin default, not a second shipped backend. Documented as a seam example, same as the `StateDB` option, not promoted to default. |
@@ -411,7 +411,7 @@ concurrent access to `Branch.messages`.
   and a worked vector-store-backed example in developer docs, demonstrating the seam without
   adding either as a core dependency.
 
-## Open Questions for Ocean
+## Open Questions
 
 - **Module location.** This ADR proposes `lionagi/protocols/memory.py`. An alternative is a new
   top-level `lionagi/memory/` package if the seam-documentation slice grows large enough to want

--- a/docs/adrs/ADR-0091-khive-pluggable-memorystore-backend.md
+++ b/docs/adrs/ADR-0091-khive-pluggable-memorystore-backend.md
@@ -12,24 +12,23 @@ slice 1 (Protocol types + `InMemoryStore` + a Protocol-level test fence) nor sli
 (`Branch`/`Session` access surface) has landed in code yet -- only the ADR document itself is
 merged.
 
-Separately, Ocean issued a P0/strategic directive (relayed by Leo, gtd anchor `5018674e`) to
-integrate khive -- Ocean's own knowledge/graph/memory substrate, already the memory layer across
+Separately, a P0/strategic decision was made to
+integrate khive -- an external knowledge/graph/memory substrate, already the memory layer across
 the wider Lion ecosystem -- as a pluggable backend behind exactly this seam. The explicit posture
 constraint: khive must stay an opt-in backend, never a hard dependency, so lionagi's Apache-2.0
 OSS core stays clean and khive remains something users choose to plug in, not something baked
 into lionagi's own package graph. This keeps lionagi acting as a distribution funnel toward khive
 rather than coupling the OSS project to a commercial product.
 
-This ADR is a joint product of a lambda:lionagi / lambda:khive design conversation (opened and
-closed 2026-07-04), scoped against both codebases' actual source rather than paraphrased
-assumptions, and captures Leo's sequencing ruling to bundle ADR-0090 slice 1 with this integration
+This ADR is scoped against both codebases' actual source rather than paraphrased
+assumptions, and captures the sequencing decision to bundle ADR-0090 slice 1 with this integration
 rather than landing it separately first.
 
 ## Decision
 
 ### Sequencing: bundle ADR-0090 slice 1, do not serialize it
 
-(Leo ruling, 2026-07-04.) ADR-0090 slice 1 (the `MemoryItem`/`MemoryQuery`/`MemoryStore` Protocol
+(Decision, 2026-07-04.) ADR-0090 slice 1 (the `MemoryItem`/`MemoryQuery`/`MemoryStore` Protocol
 types, `InMemoryStore`, and a Protocol-level test fence exercising the Protocol directly, not just
 the default implementation) lands as part of this same effort, with `KhiveMemoryStore` as the
 concrete second implementor that fence already anticipated. ADR-0090 slice 2 (the
@@ -43,7 +42,7 @@ duplicated here, to avoid the two documents drifting out of sync.
 
 The adapter class itself is implemented in khive's own codebase, or in a thin separate connector
 package, importing lionagi's public `MemoryStore` Protocol. It does not live inside `lionagi/`.
-This is a deliberate, confirmed architecture call (Leo, 2026-07-04; khive concurs on the technical
+This is a deliberate, confirmed architecture call (khive concurs on the technical
 merits): it makes "pluggable, not a hard dependency" and "no commercial specifics in the public
 OSS repo" true by construction, rather than by ongoing discipline. lionagi's own repo carries zero
 khive-specific code, zero khive-specific imports, and zero khive naming beyond what the
@@ -52,7 +51,7 @@ seam-documentation slice of ADR-0090 already allows as a generic example.
 Whether the connector package itself ships as public (a thin MCP wire-protocol client with no
 khive internals, riding along with lionagi's OSS distribution) or from khive's private tooling is
 a packaging/licensing call, not a technical one -- flagged as an Open Question below, since
-khive's core is currently a private repo and this is Leo's/Ocean's call to make, not assumed here.
+khive's core is currently a private repo and this packaging call is not assumed here.
 
 ### Transport: existing MCP stdio, no bypass needed
 
@@ -146,7 +145,7 @@ echoes back exactly the fields listed above and nothing else. A true opaque roun
 `metadata` is unreachable today without a khive-side schema change -- there is no field to stash
 it in and no field to read it back out of.
 
-Decision (Leo, 2026-07-04): `KhiveMemoryStore` persists only the `MemoryItem` fields that have a
+Decision (2026-07-04): `KhiveMemoryStore` persists only the `MemoryItem` fields that have a
 native khive home, and explicitly **drops** the rest, rather than smuggling `metadata` into
 `content` or a synthetic tag as a workaround:
 
@@ -200,7 +199,7 @@ own follow-up ADR once `MemoryStore` has a live caller.
 | Alternative | Why Rejected |
 |---|---|
 | Ship `KhiveMemoryStore` inside `lionagi/` (e.g. gated behind an optional extra) | Puts khive-specific code and naming inside the public Apache-2.0 repo; extra-gating only prevents the *dependency* from installing by default, it doesn't prevent the *code and references* from being visible in the public source tree. Violates the never-leak-commercial-in-public-repo constraint by visibility, not just by installability. |
-| Land ADR-0090 slices 1-2 as their own separate PR(s) first, khive integration strictly afterward | Leo's explicit ruling: bundle instead. Landing the Protocol in a vacuum, with only `InMemoryStore` as an implementor, doesn't prove the seam generalizes -- `KhiveMemoryStore` as an immediate second implementor is the real test of whether the Protocol is shaped correctly, which is exactly what slice 1's own test-fence language anticipated. |
+| Land ADR-0090 slices 1-2 as their own separate PR(s) first, khive integration strictly afterward | Explicit ruling: bundle instead. Landing the Protocol in a vacuum, with only `InMemoryStore` as an implementor, doesn't prove the seam generalizes -- `KhiveMemoryStore` as an immediate second implementor is the real test of whether the Protocol is shaped correctly, which is exactly what slice 1's own test-fence language anticipated. |
 | Build a bespoke lionagi-side khive HTTP/embedded client instead of reusing MCP | Duplicates transport machinery lionagi already has (pooled, persistent `register_mcp_server`/`MCPConnectionPool`), and khive confirmed the MCP path already holds a persistent session with a warm daemon underneath -- no latency case for a bypass. |
 | Fold kg into `MemoryStore.search(filters=...)` | kg's closed entity/edge enums and GQL/SPARQL query grammar don't compress into a generic `dict[str, Any]` without losing validation and expressiveness. Confirmed with khive; deserves its own `GraphStore` seam instead. |
 | Fold `gtd.*`/`comm.*` into `MemoryStore` | Task-lifecycle and messaging primitives, not memory-shaped. Already coverable as plain MCP tools via `register_mcp_server` -- no new Protocol needed for these at all. |
@@ -223,7 +222,7 @@ own follow-up ADR once `MemoryStore` has a live caller.
 
 **Negative**
 
-- Slice 1 and slice 2 landing together (per Leo's bundling ruling) is a larger single PR than
+- Slice 1 and slice 2 landing together (per the bundling decision) is a larger single PR than
   either slice alone would have been -- more surface for one review pass.
 - `MemoryItem`'s inherited `metadata` (branch_id, source, etc., from `Element`) has no matching
   khive-side field today and is explicitly **dropped** by `KhiveMemoryStore`, not round-tripped --
@@ -241,10 +240,10 @@ own follow-up ADR once `MemoryStore` has a live caller.
   on its own without also reverting the Protocol/`InMemoryStore`/test-fence foundation slice 1
   provides.
 - Before slice 2 merges, confirm the `include_branches()` sharing bug flagged in ADR-0090's own
-  advisor review is actually resolved in current code -- check the live state of that path rather
+  review is actually resolved in current code -- check the live state of that path rather
   than assuming it was fixed as part of ADR-0090 landing.
 
-## Open Questions (for Leo / Ocean)
+## Open Questions
 
 1. **Connector-package packaging/licensing.** khive's core is currently a private repo. Should
    the `KhiveMemoryStore` connector package itself be public (a thin MCP wire-protocol client
@@ -252,8 +251,8 @@ own follow-up ADR once `MemoryStore` has a live caller.
    private tooling? Doesn't block this ADR or the Protocol/verb-mapping work -- the interface is
    identical either way -- but affects how end users actually obtain and install the adapter.
 
-**Resolved (Leo disposition, 2026-07-04):** the connector lands in the khive monorepo now,
-owned by the khive seat, and the khive python SDK is the named public exit -- the connector
+**Resolved (2026-07-04):** the connector lands in the khive monorepo now,
+and the khive python SDK is the named public exit -- the connector
 ships publicly as part of that SDK when it ships, not as its own standalone package before it.
 Rationale: a standalone public package would commit to stability of khive's memory verb surface
 while it is still moving, and would spend the works-with-lionagi story before the SDK launch can
@@ -262,7 +261,7 @@ public package is revisited only if concrete OSS demand appears before the SDK s
 lionagi-side Protocol conformance fence (`tests/protocols/test_memory.py`) remains the
 acceptance gate for the connector regardless of where it lives.
 
-**Resolved during spec-gate (Leo, 2026-07-04):** the provenance schema gap (previously listed
+**Resolved (2026-07-04):** the provenance schema gap (previously listed
 here as Open Question 1) is decided, not open -- see "Provenance: a documented lossy projection
 for v1" above. `KhiveMemoryStore` persists only native-home fields and explicitly drops the rest;
 no opaque round-tripping workaround. The migration path is a future khive-side schema addition,
@@ -272,9 +271,5 @@ not a lionagi-side encoding trick.
 
 - ADR-0090: Minimal Memory Contract and Pluggable Backend Seam
   (`docs/adrs/ADR-0090-minimal-memory-contract-and-backend-seam.md`), PR #1687
-- khive ADR-049 (khived daemon, accepted/shipped) -- cited by lambda:khive, lives in khive's own
+- khive ADR-049 (khived daemon, accepted/shipped), lives in khive's own
   repo, not reproduced here
-- gtd anchor `5018674e` (Ocean directive, relayed by Leo)
-- comm thread `a7d4d75b` (lambda:lionagi <-> lambda:leo scoping exchange)
-- comm thread `e64077aa` (lambda:lionagi <-> lambda:khive transport/field-mapping/kg-placement
-  exchange)

--- a/docs/adrs/ADR-0092-durable-dispatch-outbox-and-named-resource-gates.md
+++ b/docs/adrs/ADR-0092-durable-dispatch-outbox-and-named-resource-gates.md
@@ -17,7 +17,7 @@ Two concrete failure modes motivate this ADR:
 1. **Consumer dead at fire time.** An account-wide agent-session reset overnight
    2026-07-03/04 killed every agent seat for roughly 90 minutes. Scheduled
    notifications aimed at those seats had nowhere durable to land: nothing queued,
-   nothing re-delivered. The hard requirement from the spec-gate holder: an event
+   nothing re-delivered. Hard requirement: an event
    whose consumer is dead at fire time must survive and deliver on revival, never
    drop. The named use case is a post-reset revival heartbeat that pings each
    fleet seat, currently hand-rolled as a cron outside lionagi.
@@ -208,7 +208,7 @@ actions. Before the run starts, lionagi resolves the gate name through a
 advisory `fcntl.flock`** on that exact file (`LOCK_EX`, or `LOCK_EX|LOCK_NB`
 with a timeout), releasing it when the run ends.
 
-Hard constraint, per the spec-gate holder: **the gate composes with the
+Hard constraint: **the gate composes with the
 OS-level convention, it never replaces it.** Non-lionagi processes (cargo test
 suites, one-off scripts, other harnesses) keep acquiring the same flock
 directly, so:

--- a/docs/adrs/ADR-0092-durable-dispatch-outbox-and-named-resource-gates.md
+++ b/docs/adrs/ADR-0092-durable-dispatch-outbox-and-named-resource-gates.md
@@ -1,6 +1,6 @@
 # ADR-0092: Durable Dispatch Outbox and Named Resource Gates
 
-**Status**: Accepted (spec gate signed 2026-07-04; rulings folded below)
+**Status**: Accepted (design review completed 2026-07-04; decisions folded below)
 **Date**: 2026-07-04
 **Builds on**: ADR-0062 (scheduled item state machine, proposed) · ADR-0061 (universal scheduler, proposed) · ADR-0083 (lifecycle signal contract) · ADR-0085 §5 (terminal notify hook, proposed) · ADR-0027 (scheduled runs) · ADR-0030 (attention queue)
 
@@ -237,7 +237,7 @@ them; v1 ships only the flag and the lock helper.
 
 ### Distinction preserved: revival-push vs condition-wait
 
-The fleet's dominant hand-rolled polling pattern (bounded sleep-loops on
+The dominant hand-rolled polling pattern (bounded sleep-loops on
 external state, for example PR merge-state watches) is a *condition-wait*,
 which is genuinely poll-shaped and distinct from revival *delivery*. This ADR
 serves the delivery case with push-to-durable-sink; condition-wait stays poll
@@ -327,18 +327,18 @@ Must NOT contain (v1):
 - Gate acquisition adds a blocking (or timeout-bounded) step in front of gated
   runs; ungated runs are unaffected.
 
-## Spec-gate rulings (signed 2026-07-04)
+## Design-review decisions (2026-07-04)
 
 1. **Transition machinery ordering**: ship the ~30-line guarded compare-and-swap
    fallback now; do not block on ADR-0062. Condition: the fallback mirrors
    0062's `transition()` signature and reason-code discipline exactly, so 0062
    absorbs it later as a refactor, not a migration.
 2. **Gate table ownership**: the canonical `gates:` name→lock-path table is
-   fleet-shared configuration owned by the fleet's global resource manager, not
+   shared host-level configuration owned by the host system's global resource manager, not
    by this harness — machine-level resource conventions span non-lionagi
-   processes. lionagi reads the fleet table and may add lionagi-private internal
-   gate names in its own settings only. The concrete fleet file path is proposed
-   in the implementation PR and placed by the fleet resource owner.
+   processes. lionagi reads that shared table and may add lionagi-private internal
+   gate names in its own settings only. The concrete shared file path is proposed
+   in the implementation PR and placed by the host resource owner.
    Wedged-live-holder handling: surfacing the holder pid in
    `li dispatch` / `li monitor` is sufficient for v1; a live holder is never
    auto-broken.

--- a/tests/session/test_event_reactive_bus.py
+++ b/tests/session/test_event_reactive_bus.py
@@ -59,7 +59,7 @@ async def test_status_enum_alone_is_a_filter():
 
 @pytest.mark.asyncio
 async def test_compositional_type_status_field():
-    """observe(Type, EventStatus.COMPLETED, Type.q.duration > N) — Ocean's
+    """observe(Type, EventStatus.COMPLETED, Type.q.duration > N) —
     three-way composition: only a completed AND slow event reacts."""
     s = Session()
     slow_ok: list[Call] = []


### PR DESCRIPTION
Rewords design docs, ADRs, and a few code comments that named internal decision-makers or internal review-gate mechanics as the rationale for technical choices, replacing attribution with the underlying technical reason. 21 files, wording-only; no behavior or test assertions changed (one docstring in a test file drops an attribution, assertion untouched).

Left unchanged as legitimate product surface: copyright/authorship headers, the Studio operator-panel feature name, the shipped review-verdict vocabulary used by casts/engines/marketplace skills, and the marketplace hygiene linter's own detection literals.

Full suite green locally; frontend vitest/tsc show only pre-existing unrelated missing-dep failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)