### PR TITLE
feat(studio): Pulse activity section on the home surface

### DIFF
--- a/apps/studio/frontend/src/components/mission/MissionControl.tsx
+++ b/apps/studio/frontend/src/components/mission/MissionControl.tsx
@@ -12,6 +12,7 @@ import StaleBadge from "./StaleBadge";
 import AttentionQueue from "./AttentionQueue";
 import LiveBoard from "./LiveBoard";
 import RecentRuns from "./RecentRuns";
+import Pulse from "./Pulse";
 import { useLiveBoard } from "./useLiveBoard";
 
 export default function MissionControl() {
@@ -70,7 +71,11 @@ export default function MissionControl() {
 
       <hr className="border-t border-edge" style={{ border: "none", borderTopWidth: "1px" }} />
 
-      <RecentRuns runs={board.recentRuns} nowSec={board.nowSec} />
+      {/* Pulse + Recent share a row on wide screens; stack below 1280px. */}
+      <div className="grid grid-cols-1 gap-5 xl:grid-cols-2">
+        <Pulse />
+        <RecentRuns runs={board.recentRuns} nowSec={board.nowSec} />
+      </div>
     </div>
   );
 }

--- a/apps/studio/frontend/src/components/mission/Pulse.tsx
+++ b/apps/studio/frontend/src/components/mission/Pulse.tsx
@@ -51,6 +51,8 @@ export default function Pulse() {
   const { data, error, loading } = usePulse(window_);
 
   const ratePct = data?.completion_rate != null ? Math.round(data.completion_rate * 100) : null;
+  // "" marks a failure without a usable message — localize the fallback.
+  const errorMessage = error === null ? null : error || t("pulse.unreachable");
 
   return (
     <section aria-labelledby="pulse-heading">
@@ -85,7 +87,7 @@ export default function Pulse() {
           <p className="text-[length:var(--t-sm)] text-content-muted">{t("pulse.loading")}</p>
         ) : data === null ? (
           <p className="text-[length:var(--t-sm)] text-content-muted">
-            {t("pulse.error", { message: error ?? "" })}
+            {t("pulse.error", { message: errorMessage ?? "" })}
           </p>
         ) : (
           <>

--- a/apps/studio/frontend/src/components/mission/Pulse.tsx
+++ b/apps/studio/frontend/src/components/mission/Pulse.tsx
@@ -1,0 +1,113 @@
+/**
+ * Pulse — windowed activity aggregate for the home surface.
+ *
+ * Stacked-bar sparkline over dense server buckets (24 hourly / 7 daily),
+ * plus completion rate and total. Inline SVG, no chart dependency.
+ * Cost/token cells stay hidden until the daemon exposes those fields.
+ */
+
+import { useState } from "react";
+import { useTranslations } from "use-intl";
+import SectionLabel from "@/components/ui/SectionLabel";
+import { usePulse } from "./usePulse";
+import { CHART_H, chartWidth, sparklineRects } from "./sparkline";
+import type { SparkRect } from "./sparkline";
+import type { ActivityBucket, ActivityWindow } from "@/lib/api";
+
+const SEGMENT_COLOR: Record<SparkRect["kind"], string> = {
+  completed: "var(--status-success)",
+  failed: "var(--status-failure)",
+  cancelled: "var(--edge-strong, var(--edge))",
+  running: "var(--status-running)",
+  stub: "var(--edge-hairline, var(--edge))",
+};
+
+function Sparkline({ buckets }: { buckets: ActivityBucket[] }) {
+  const rects = sparklineRects(buckets);
+  return (
+    <svg
+      viewBox={`0 0 ${chartWidth(buckets.length)} ${CHART_H}`}
+      preserveAspectRatio="none"
+      className="h-10 w-full"
+      aria-hidden="true"
+    >
+      {rects.map((r, i) => (
+        <rect
+          key={i}
+          x={r.x}
+          y={r.y}
+          width={r.width}
+          height={r.height}
+          fill={SEGMENT_COLOR[r.kind]}
+        />
+      ))}
+    </svg>
+  );
+}
+
+export default function Pulse() {
+  const t = useTranslations("mission");
+  const [window_, setWindow] = useState<ActivityWindow>("24h");
+  const { data, error, loading } = usePulse(window_);
+
+  const ratePct = data?.completion_rate != null ? Math.round(data.completion_rate * 100) : null;
+
+  return (
+    <section aria-labelledby="pulse-heading">
+      <div className="mb-2 flex items-center justify-between">
+        <SectionLabel
+          trailing={
+            <span role="group" aria-label={t("pulse.windowLabel")} className="flex gap-1">
+              {(["24h", "7d"] as const).map((w) => (
+                <button
+                  key={w}
+                  type="button"
+                  onClick={() => setWindow(w)}
+                  aria-pressed={window_ === w}
+                  className={`rounded px-1.5 py-0.5 font-data text-[length:var(--t-xs)] transition-colors duration-100 ${
+                    window_ === w
+                      ? "bg-surface-overlay text-content-primary"
+                      : "text-content-muted hover:text-content-secondary"
+                  }`}
+                >
+                  {t(`pulse.window.${w}`)}
+                </button>
+              ))}
+            </span>
+          }
+        >
+          <span id="pulse-heading">{t("pulse.title")}</span>
+        </SectionLabel>
+      </div>
+
+      <div className="rounded border border-edge bg-surface-raised px-4 py-3">
+        {loading ? (
+          <p className="text-[length:var(--t-sm)] text-content-muted">{t("pulse.loading")}</p>
+        ) : data === null ? (
+          <p className="text-[length:var(--t-sm)] text-content-muted">
+            {t("pulse.error", { message: error ?? "" })}
+          </p>
+        ) : (
+          <>
+            <Sparkline buckets={data.buckets} />
+            <div className="mt-2 flex items-baseline justify-between font-data tabular-nums">
+              <span className="text-[length:var(--t-sm)] text-content-secondary">
+                {ratePct != null
+                  ? t("pulse.completionRate", { rate: ratePct })
+                  : t("pulse.noTerminalRuns")}
+              </span>
+              <span className="text-[length:var(--t-xs)] text-content-muted">
+                {t("pulse.total", { count: data.total })}
+              </span>
+            </div>
+            {error !== null && (
+              <p className="mt-1 text-[length:var(--t-xs)] text-content-muted">
+                {t("pulse.staleHint")}
+              </p>
+            )}
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/studio/frontend/src/components/mission/sparkline.test.ts
+++ b/apps/studio/frontend/src/components/mission/sparkline.test.ts
@@ -55,6 +55,13 @@ describe("sparklineRects", () => {
     expect(rects.map((r) => r.kind)).toEqual(["completed", "running"]);
   });
 
+  it("all-zero buckets render one baseline stub each, evenly spaced", () => {
+    const rects = sparklineRects([bucket({ t: 0 }), bucket({ t: 3600 }), bucket({ t: 7200 })]);
+    expect(rects).toHaveLength(3);
+    expect(rects.every((r) => r.kind === "stub" && r.height === 1)).toBe(true);
+    expect(rects.map((r) => r.x)).toEqual([0, BAR_W + BAR_GAP, 2 * (BAR_W + BAR_GAP)]);
+  });
+
   it("tiny buckets next to a busy one keep a visible minimum height", () => {
     const rects = sparklineRects([
       bucket({ t: 0, completed: 1000 }),

--- a/apps/studio/frontend/src/components/mission/sparkline.test.ts
+++ b/apps/studio/frontend/src/components/mission/sparkline.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Pure geometry tests for the Pulse sparkline layout contract:
+ * normalization to the busiest bucket, fixed stacking order,
+ * baseline stubs for empty buckets, minimum visible bar height.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  BAR_GAP,
+  BAR_W,
+  CHART_H,
+  MIN_BAR_H,
+  bucketTotal,
+  chartWidth,
+  sparklineRects,
+} from "./sparkline";
+import type { ActivityBucket } from "@/lib/api";
+
+function bucket(partial: Partial<ActivityBucket> & { t: number }): ActivityBucket {
+  return { completed: 0, failed: 0, cancelled: 0, running: 0, ...partial };
+}
+
+describe("sparklineRects", () => {
+  it("empty bucket renders a 1px baseline stub at the axis", () => {
+    const rects = sparklineRects([bucket({ t: 0 })]);
+    expect(rects).toEqual([{ kind: "stub", x: 0, y: CHART_H - 1, width: BAR_W, height: 1 }]);
+  });
+
+  it("busiest bucket spans full chart height; others scale proportionally", () => {
+    const rects = sparklineRects([
+      bucket({ t: 0, completed: 10 }),
+      bucket({ t: 3600, completed: 5 }),
+    ]);
+    expect(rects[0].height).toBe(CHART_H);
+    expect(rects[1].height).toBe(CHART_H / 2);
+    expect(rects[1].x).toBe(BAR_W + BAR_GAP);
+  });
+
+  it("stacks segments bottom-up in fixed order: completed, failed, cancelled, running", () => {
+    const rects = sparklineRects([
+      bucket({ t: 0, completed: 1, failed: 1, cancelled: 1, running: 1 }),
+    ]);
+    expect(rects.map((r) => r.kind)).toEqual(["completed", "failed", "cancelled", "running"]);
+    // Bottom-up: completed sits lowest (largest y), running topmost.
+    expect(rects[0].y).toBeGreaterThan(rects[3].y);
+    // Segments tile the bar exactly: heights sum to the bar height,
+    // and the top of the stack is CHART_H minus that height.
+    const total = rects.reduce((acc, r) => acc + r.height, 0);
+    expect(total).toBeCloseTo(CHART_H);
+    expect(rects[3].y).toBeCloseTo(0);
+  });
+
+  it("zero-count segments emit no rect", () => {
+    const rects = sparklineRects([bucket({ t: 0, completed: 3, running: 2 })]);
+    expect(rects.map((r) => r.kind)).toEqual(["completed", "running"]);
+  });
+
+  it("tiny buckets next to a busy one keep a visible minimum height", () => {
+    const rects = sparklineRects([
+      bucket({ t: 0, completed: 1000 }),
+      bucket({ t: 3600, failed: 1 }),
+    ]);
+    expect(rects[1].kind).toBe("failed");
+    expect(rects[1].height).toBeGreaterThanOrEqual(MIN_BAR_H);
+  });
+});
+
+describe("chartWidth / bucketTotal", () => {
+  it("width covers n bars with gaps between (no trailing gap)", () => {
+    expect(chartWidth(24)).toBe(24 * (BAR_W + BAR_GAP) - BAR_GAP);
+  });
+
+  it("never collapses below one bar width", () => {
+    expect(chartWidth(0)).toBe(BAR_W);
+  });
+
+  it("bucketTotal counts all four segments", () => {
+    expect(bucketTotal(bucket({ t: 0, completed: 1, failed: 2, cancelled: 3, running: 4 }))).toBe(
+      10,
+    );
+  });
+});

--- a/apps/studio/frontend/src/components/mission/sparkline.ts
+++ b/apps/studio/frontend/src/components/mission/sparkline.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure geometry for the Pulse stacked-bar sparkline.
+ *
+ * Kept free of React so the layout contract (normalization, stacking
+ * order, empty-bucket stubs) is testable without rendering.
+ */
+
+import type { ActivityBucket } from "@/lib/api";
+
+export const BAR_W = 7;
+export const BAR_GAP = 3;
+export const CHART_H = 40;
+export const MIN_BAR_H = 2;
+
+export const SEGMENT_ORDER = ["completed", "failed", "cancelled", "running"] as const;
+export type SegmentKind = (typeof SEGMENT_ORDER)[number];
+
+export interface SparkRect {
+  kind: SegmentKind | "stub";
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export function bucketTotal(b: ActivityBucket): number {
+  return b.completed + b.failed + b.cancelled + b.running;
+}
+
+export function chartWidth(bucketCount: number): number {
+  return Math.max(BAR_W, bucketCount * (BAR_W + BAR_GAP) - BAR_GAP);
+}
+
+export function sparklineRects(buckets: ActivityBucket[]): SparkRect[] {
+  const max = Math.max(1, ...buckets.map(bucketTotal));
+  const rects: SparkRect[] = [];
+
+  buckets.forEach((b, i) => {
+    const x = i * (BAR_W + BAR_GAP);
+    const total = bucketTotal(b);
+    if (total === 0) {
+      // Baseline stub so empty buckets still read as part of the axis.
+      rects.push({ kind: "stub", x, y: CHART_H - 1, width: BAR_W, height: 1 });
+      return;
+    }
+    const barH = Math.max(MIN_BAR_H, (total / max) * CHART_H);
+    let yCursor = CHART_H;
+    for (const seg of SEGMENT_ORDER) {
+      const n = b[seg];
+      if (n === 0) continue;
+      const h = (n / total) * barH;
+      yCursor -= h;
+      rects.push({ kind: seg, x, y: yCursor, width: BAR_W, height: h });
+    }
+  });
+
+  return rects;
+}

--- a/apps/studio/frontend/src/components/mission/usePulse.ts
+++ b/apps/studio/frontend/src/components/mission/usePulse.ts
@@ -1,0 +1,62 @@
+/**
+ * Data-source hook for the Pulse section.
+ *
+ * Deliberately slow: fetches on mount, every 45s, and on window focus —
+ * never on the 3s live poll. Activity aggregates move on bucket
+ * granularity (hours/days), so a fast cadence buys nothing.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getActivityStats } from "@/lib/api";
+import type { ActivityStats, ActivityWindow } from "@/lib/api";
+
+const REFRESH_INTERVAL_MS = 45_000;
+
+export interface PulseState {
+  data: ActivityStats | null;
+  error: string | null;
+  loading: boolean;
+}
+
+export function usePulse(window_: ActivityWindow): PulseState {
+  const [state, setState] = useState<PulseState>({
+    data: null,
+    error: null,
+    loading: true,
+  });
+  const activeRef = useRef(true);
+
+  const refresh = useCallback(async () => {
+    try {
+      const data = await getActivityStats(window_);
+      if (!activeRef.current) return;
+      setState({ data, error: null, loading: false });
+    } catch (err) {
+      if (!activeRef.current) return;
+      setState((prev) => ({
+        // Keep last-known data on a failed refresh; only the error surfaces.
+        data: prev.data,
+        error: err instanceof Error ? err.message : "API unreachable",
+        loading: false,
+      }));
+    }
+  }, [window_]);
+
+  useEffect(() => {
+    activeRef.current = true;
+    setState((prev) => ({ ...prev, loading: prev.data === null }));
+    void refresh();
+
+    const timer = setInterval(() => void refresh(), REFRESH_INTERVAL_MS);
+    const onFocus = () => void refresh();
+    window.addEventListener("focus", onFocus);
+
+    return () => {
+      activeRef.current = false;
+      clearInterval(timer);
+      window.removeEventListener("focus", onFocus);
+    };
+  }, [refresh]);
+
+  return state;
+}

--- a/apps/studio/frontend/src/components/mission/usePulse.ts
+++ b/apps/studio/frontend/src/components/mission/usePulse.ts
@@ -6,7 +6,7 @@
  * granularity (hours/days), so a fast cadence buys nothing.
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { getActivityStats } from "@/lib/api";
 import type { ActivityStats, ActivityWindow } from "@/lib/api";
 
@@ -14,6 +14,7 @@ const REFRESH_INTERVAL_MS = 45_000;
 
 export interface PulseState {
   data: ActivityStats | null;
+  /** null = no failure; "" = failure without a message (localize at render). */
   error: string | null;
   loading: boolean;
 }
@@ -24,39 +25,40 @@ export function usePulse(window_: ActivityWindow): PulseState {
     error: null,
     loading: true,
   });
-  const activeRef = useRef(true);
-
-  const refresh = useCallback(async () => {
-    try {
-      const data = await getActivityStats(window_);
-      if (!activeRef.current) return;
-      setState({ data, error: null, loading: false });
-    } catch (err) {
-      if (!activeRef.current) return;
-      setState((prev) => ({
-        // Keep last-known data on a failed refresh; only the error surfaces.
-        data: prev.data,
-        error: err instanceof Error ? err.message : "API unreachable",
-        loading: false,
-      }));
-    }
-  }, [window_]);
 
   useEffect(() => {
-    activeRef.current = true;
-    setState((prev) => ({ ...prev, loading: prev.data === null }));
-    void refresh();
+    // Effect-local guard: a response from a previous window selection can
+    // never commit state after this effect is cleaned up.
+    let active = true;
+    setState({ data: null, error: null, loading: true });
 
+    async function refresh() {
+      try {
+        const data = await getActivityStats(window_);
+        if (!active) return;
+        setState({ data, error: null, loading: false });
+      } catch (err) {
+        if (!active) return;
+        setState((prev) => ({
+          // Keep last-known data on a failed refresh; only the error surfaces.
+          data: prev.data,
+          error: err instanceof Error ? err.message : "",
+          loading: false,
+        }));
+      }
+    }
+
+    void refresh();
     const timer = setInterval(() => void refresh(), REFRESH_INTERVAL_MS);
     const onFocus = () => void refresh();
     window.addEventListener("focus", onFocus);
 
     return () => {
-      activeRef.current = false;
+      active = false;
       clearInterval(timer);
       window.removeEventListener("focus", onFocus);
     };
-  }, [refresh]);
+  }, [window_]);
 
   return state;
 }

--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -980,6 +980,27 @@ export async function getStats(): Promise<StudioStats> {
   return fetchJson<StudioStats>("/api/stats");
 }
 
+export type ActivityWindow = "24h" | "7d";
+
+export interface ActivityBucket {
+  t: number;
+  completed: number;
+  failed: number;
+  cancelled: number;
+  running: number;
+}
+
+export interface ActivityStats {
+  window: ActivityWindow;
+  buckets: ActivityBucket[];
+  completion_rate: number | null;
+  total: number;
+}
+
+export async function getActivityStats(window: ActivityWindow): Promise<ActivityStats> {
+  return fetchJson<ActivityStats>(`/api/stats/activity?window=${window}`);
+}
+
 // ─── Schedules (ADR-0027) ───────────────────────────────────────────────────
 
 export type GitHubEventFilter = "pr_merged" | "pr_opened" | "pr_updated" | "pr_closed";

--- a/apps/studio/frontend/src/messages/en.json
+++ b/apps/studio/frontend/src/messages/en.json
@@ -609,6 +609,7 @@
       },
       "loading": "Loading activity…",
       "error": "Activity unavailable · {message}",
+      "unreachable": "API unreachable",
       "completionRate": "{rate}% completion",
       "noTerminalRuns": "No terminal runs in window",
       "total": "{count} total",

--- a/apps/studio/frontend/src/messages/en.json
+++ b/apps/studio/frontend/src/messages/en.json
@@ -600,6 +600,20 @@
       "viewAll": "History →",
       "empty": "No terminal runs yet."
     },
+    "pulse": {
+      "title": "Pulse",
+      "windowLabel": "Activity window",
+      "window": {
+        "24h": "24h",
+        "7d": "7d"
+      },
+      "loading": "Loading activity…",
+      "error": "Activity unavailable · {message}",
+      "completionRate": "{rate}% completion",
+      "noTerminalRuns": "No terminal runs in window",
+      "total": "{count} total",
+      "staleHint": "showing last known · refresh failed"
+    },
     "stale": {
       "error": "error · {message}",
       "unreachable": "API unreachable",

--- a/apps/studio/frontend/src/messages/zh.json
+++ b/apps/studio/frontend/src/messages/zh.json
@@ -609,6 +609,7 @@
       },
       "loading": "正在加载活动数据…",
       "error": "活动数据不可用 · {message}",
+      "unreachable": "无法连接 API",
       "completionRate": "完成率 {rate}%",
       "noTerminalRuns": "窗口内暂无已结束的运行",
       "total": "共 {count} 次",

--- a/apps/studio/frontend/src/messages/zh.json
+++ b/apps/studio/frontend/src/messages/zh.json
@@ -600,6 +600,20 @@
       "viewAll": "历史记录 →",
       "empty": "暂无已完成的运行。"
     },
+    "pulse": {
+      "title": "系统脉搏",
+      "windowLabel": "活动窗口",
+      "window": {
+        "24h": "24小时",
+        "7d": "7天"
+      },
+      "loading": "正在加载活动数据…",
+      "error": "活动数据不可用 · {message}",
+      "completionRate": "完成率 {rate}%",
+      "noTerminalRuns": "窗口内暂无已结束的运行",
+      "total": "共 {count} 次",
+      "staleHint": "显示上次数据 · 刷新失败"
+    },
     "stale": {
       "error": "错误 · {message}",
       "unreachable": "API 不可达",


### PR DESCRIPTION
FE slice for the Home design pass: a Pulse section on Mission Control consuming `GET /api/stats/activity`.

- Stacked-bar inline-SVG sparkline (no chart dependency) over the dense server buckets; geometry extracted to a pure module with tests (normalization, stacking order, empty-bucket stubs, minimum visible height).
- Completion rate + total, 24h/7d window toggle.
- Slow fetch discipline: mount + 45s cadence + window focus, never the 3s live poll; failed refresh keeps last-known data and shows a stale hint.
- Layout: Pulse and Recent share a row at ≥1280px, stack below.
- en/zh parity; cost/token cells intentionally absent until the daemon exposes those fields.

Gates: tsc clean, vitest 386/386, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)