### PR TITLE
ci: add skip-aware ci-gate aggregate job for required status checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,11 @@ on:
     branches: [ main, develop ]
     paths-ignore:
       - '**/*.ipynb'
+  # No paths-ignore on pull_request: ci-gate is a required status check, so the
+  # workflow must report on every PR — a filtered-out PR would block on a check
+  # that never runs.
   pull_request:
     branches: [ main, develop ]
-    paths-ignore:
-      - '**/*.ipynb'
 
 permissions:
   contents: read
@@ -197,6 +198,25 @@ jobs:
       run: sudo apt-get install -y ripgrep
     - name: Lint marketplace
       run: scripts/ci.sh lint-marketplace
+
+  # Single aggregate context for branch protection. Required status checks must
+  # reference this job, never the matrix legs directly: matrix names shift with
+  # the event (PRs run a subset of Python versions) and a renamed leg would
+  # strand PRs on a check that never reports. Skip-aware: a skipped dependency
+  # passes the gate; failure or cancellation fails it.
+  ci-gate:
+    if: always()
+    needs: [lint, docs, test, frontend, studio-e2e, vscode, marketplace]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check aggregate result
+      run: |
+        results='${{ join(needs.*.result, ' ') }}'
+        echo "job results: $results"
+        case "$results" in
+          *failure*|*cancelled*) echo "a required job failed or was cancelled"; exit 1 ;;
+          *) echo "all required jobs succeeded or were skipped" ;;
+        esac
 
   publish:
     needs: [lint, test]


### PR DESCRIPTION
Adds a single aggregate `ci-gate` job to the CI workflow so branch protection can require one stable context instead of raw matrix leg names (which vary by event: PRs run a Python-version subset).

- `ci-gate` depends on all PR-facing jobs (lint, docs, test, frontend, studio-e2e, vscode, marketplace), runs with `if: always()`, passes on success/skipped, fails on failure/cancelled.
- The `pull_request` trigger drops its `paths-ignore` so the required context reports on every PR — a filtered-out PR would otherwise block forever on an expected check that never runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)