### PR TITLE
docs: note the required ci-gate status check in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,8 @@ guidelines and instructions for contributing to this project.
    ruff, pyupgrade, markdownlint, and frontend/marketplace hooks when relevant).
    `[tool.ruff]` in `pyproject.toml` is the source of truth — line length
    **100**, target `py310`. CI tests Python 3.10 and 3.14 on PRs, and 3.10-3.14
-   on `main`/`develop` pushes.
+   on `main`/`develop` pushes. Merging into `main` requires the `ci-gate`
+   status check, which aggregates every PR-facing CI job.
 
 2. **PEP 8 / PEP 257**: follow standard style and docstring conventions; ruff's
    `E F W B I UP N S A` rule set enforces most of this (incl. import sorting,


### PR DESCRIPTION
Documents that merging into `main` requires the aggregate `ci-gate` status check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)