### PR TITLE
fix(cli): stamp external SIGTERM distinctly in the run record

### DIFF
--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -269,6 +269,18 @@ def resolve_run_reason(
     if status == "aborted":
         return RunReasons.CANCELLED_SIGINT, "User pressed Ctrl-C (SIGINT).", None
     if status == "cancelled":
+        from lionagi.ln.concurrency.utils import SigtermInterrupt, sigterm_received
+
+        # At teardown the surfaced exception is usually a plain CancelledError
+        # even when an external SIGTERM caused it — SigtermInterrupt is only
+        # raised after the worker thread joins, after this record is stamped.
+        # The handler's process-wide latch is the reliable signal.
+        if isinstance(exception, SigtermInterrupt) or sigterm_received():
+            return (
+                RunReasons.CANCELLED_SIGTERM,
+                "sigterm_external: process received an external SIGTERM mid-run.",
+                None,
+            )
         return (
             RunReasons.CANCELLED_SYSTEM,
             "Task cancelled by the runtime (anyio CancelledError).",

--- a/lionagi/ln/concurrency/__init__.py
+++ b/lionagi/ln/concurrency/__init__.py
@@ -30,6 +30,7 @@ from .utils import (
     maybe_await,
     run_async,
     run_sync,
+    sigterm_received,
     sleep,
 )
 
@@ -76,4 +77,5 @@ __all__ = (
     "current_time",
     "sleep",
     "SigtermInterrupt",
+    "sigterm_received",
 )

--- a/lionagi/ln/concurrency/utils.py
+++ b/lionagi/ln/concurrency/utils.py
@@ -25,6 +25,7 @@ __all__ = (
     "sleep",
     "current_time",
     "SigtermInterrupt",
+    "sigterm_received",
 )
 
 
@@ -45,6 +46,19 @@ async def run_sync(func: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R
         func_with_kwargs = partial(func, **kwargs)
         return await anyio.to_thread.run_sync(func_with_kwargs, *args)
     return await anyio.to_thread.run_sync(func, *args)
+
+
+# Process-wide latch set by run_async's SIGTERM handler the moment the signal
+# arrives. SigtermInterrupt itself is only raised after the worker thread has
+# joined — by then teardown code has already classified a plain CancelledError
+# and stamped the terminal record. Persist paths consult this flag so an
+# external SIGTERM stays distinguishable from an internal runtime cancel.
+_SIGTERM_RECEIVED = threading.Event()
+
+
+def sigterm_received() -> bool:
+    """True if run_async's SIGTERM handler has fired in this process."""
+    return _SIGTERM_RECEIVED.is_set()
 
 
 class SigtermInterrupt(BaseException):
@@ -110,6 +124,10 @@ def run_async(coro: Awaitable[T]) -> T:
     def _make_handler(requested: threading.Event, old_handler: Any) -> Callable[[int, Any], None]:
         def _handler(signum: int, frame: Any) -> None:
             requested.set()
+            if signum == signal.SIGTERM:
+                # Latch process-wide so teardown code that only sees a plain
+                # CancelledError can still report the cancel as external.
+                _SIGTERM_RECEIVED.set()
             try:
                 child_loop, task = _loop_and_task_future.result(timeout=0.5)
             except Exception:  # noqa: BLE001

--- a/lionagi/state/reasons.py
+++ b/lionagi/state/reasons.py
@@ -70,6 +70,7 @@ class RunReasons:
     TIMED_OUT_DEADLINE = "run.timed_out.deadline"
     ABORTED_USER = "run.aborted.user"
     CANCELLED_SIGINT = "run.cancelled.sigint"  # issue #1055
+    CANCELLED_SIGTERM = "run.cancelled.sigterm"  # externally delivered SIGTERM (exit 143)
     CANCELLED_SYSTEM = "run.cancelled.system"
     CANCELLED_ORCHESTRATOR = "run.cancelled.orchestrator"
     # `li kill` — Phase 2 reason codes (issue #1094)

--- a/tests/cli/test_sigterm_reason_code.py
+++ b/tests/cli/test_sigterm_reason_code.py
@@ -13,14 +13,19 @@ runtime-cancel summary.
 
 from __future__ import annotations
 
+import os
 import signal
+import subprocess
+import sys
+import textwrap
 import threading
+import time
 
 import pytest
 
 import lionagi.ln.concurrency.utils as cu
 from lionagi.cli._runs import resolve_run_reason
-from lionagi.ln.concurrency.utils import SigtermInterrupt, run_async, sigterm_received
+from lionagi.ln.concurrency.utils import SigtermInterrupt
 from lionagi.state.reasons import RunReasons
 
 
@@ -59,26 +64,67 @@ def test_reason_code_shape():
     assert RunReasons.CANCELLED_SIGTERM == "run.cancelled.sigterm"
 
 
-def test_run_async_sigterm_handler_latches_flag():
-    """Delivering SIGTERM mid-run latches the flag before teardown code runs."""
-    if threading.current_thread() is not threading.main_thread():
-        pytest.skip("signal handlers require the main thread")
+# In-process signal delivery is racy under pytest-xdist (worker packing
+# changes what shares the process), so the end-to-end check runs in a
+# subprocess, mirroring tests/libs/concurrency/test_sigterm_teardown.py:
+# an external SIGTERM cancels the coroutine, and the teardown-time view
+# (flag latched, resolve_run_reason verdict) is written to a sentinel file.
+_SUBPROCESS_SCRIPT = textwrap.dedent("""\
+    import sys
+    import anyio as _anyio
+    from lionagi.cli._runs import resolve_run_reason
+    from lionagi.ln.concurrency.utils import SigtermInterrupt, run_async, sigterm_received
 
-    import anyio
-
-    observed_at_teardown: list[bool] = []
+    SENTINEL = sys.argv[1]
+    READY    = sys.argv[2]
 
     async def long_running():
+        with open(READY, "w") as f:
+            f.write("ready")
         try:
-            signal.raise_signal(signal.SIGTERM)
-            await anyio.sleep(30)
+            await _anyio.sleep(30)
         finally:
-            # This mimics the persist teardown: at this point the exception in
-            # flight is a plain cancellation, but the flag is already latched.
-            observed_at_teardown.append(sigterm_received())
+            # The persist teardown's view: the exception in flight is a plain
+            # cancellation, but the handler has already latched the flag, so
+            # the resolved reason must be the external-SIGTERM one.
+            with _anyio.CancelScope(shield=True):
+                code, summary, _ = resolve_run_reason(status="cancelled", exception=None)
+                with open(SENTINEL, "w") as f:
+                    f.write(f"{sigterm_received()}|{code}|{summary}")
 
-    with pytest.raises(SigtermInterrupt):
+    try:
         run_async(long_running())
+        sys.exit(0)
+    except SigtermInterrupt:
+        sys.exit(143)
+""")
 
-    assert observed_at_teardown == [True]
-    assert sigterm_received()
+
+def test_external_sigterm_resolves_sigterm_reason_at_teardown(tmp_path):
+    sentinel = tmp_path / "sentinel"
+    ready = tmp_path / "ready"
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _SUBPROCESS_SCRIPT, str(sentinel), str(ready)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    try:
+        deadline = time.monotonic() + 10.0
+        while not ready.exists():
+            if time.monotonic() > deadline:
+                raise AssertionError("subprocess never reached the event loop")
+            time.sleep(0.02)
+        time.sleep(0.05)
+        os.kill(proc.pid, signal.SIGTERM)
+        proc.wait(timeout=15.0)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait()
+
+    assert proc.returncode == 143
+    flag, code, summary = sentinel.read_text().split("|", 2)
+    assert flag == "True"
+    assert code == "run.cancelled.sigterm"
+    assert "sigterm_external" in summary

--- a/tests/cli/test_sigterm_reason_code.py
+++ b/tests/cli/test_sigterm_reason_code.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""External SIGTERM must produce a distinct reason in the run record.
+
+An externally delivered SIGTERM cancels the inner task, so the exception the
+teardown path sees is a plain CancelledError — indistinguishable from an
+internal runtime cancel. run_async's SIGTERM handler latches a process-wide
+flag; resolve_run_reason consults it (or an explicit SigtermInterrupt) and
+stamps run.cancelled.sigterm / "sigterm_external" instead of the generic
+runtime-cancel summary.
+"""
+
+from __future__ import annotations
+
+import signal
+import threading
+
+import pytest
+
+import lionagi.ln.concurrency.utils as cu
+from lionagi.cli._runs import resolve_run_reason
+from lionagi.ln.concurrency.utils import SigtermInterrupt, run_async, sigterm_received
+from lionagi.state.reasons import RunReasons
+
+
+@pytest.fixture(autouse=True)
+def _fresh_sigterm_latch(monkeypatch):
+    """Isolate the process-wide latch so tests neither see nor leak state."""
+    monkeypatch.setattr(cu, "_SIGTERM_RECEIVED", threading.Event())
+
+
+def test_cancelled_with_sigterm_interrupt_maps_to_cancelled_sigterm():
+    code, summary, evidence = resolve_run_reason(
+        status="cancelled",
+        exception=SigtermInterrupt("process received SIGTERM"),
+    )
+    assert code == RunReasons.CANCELLED_SIGTERM
+    assert "sigterm_external" in summary
+    assert evidence is None
+
+
+def test_cancelled_with_plain_cancel_but_latched_flag_maps_to_cancelled_sigterm():
+    # The realistic path: the handler latched the flag, but the exception that
+    # reaches teardown is a plain cancellation (or None), not SigtermInterrupt.
+    cu._SIGTERM_RECEIVED.set()
+    code, summary, _ = resolve_run_reason(status="cancelled", exception=None)
+    assert code == RunReasons.CANCELLED_SIGTERM
+    assert "sigterm_external" in summary
+
+
+def test_cancelled_without_sigterm_stays_cancelled_system():
+    code, summary, _ = resolve_run_reason(status="cancelled", exception=None)
+    assert code == RunReasons.CANCELLED_SYSTEM
+    assert "sigterm" not in summary.lower()
+
+
+def test_reason_code_shape():
+    assert RunReasons.CANCELLED_SIGTERM == "run.cancelled.sigterm"
+
+
+def test_run_async_sigterm_handler_latches_flag():
+    """Delivering SIGTERM mid-run latches the flag before teardown code runs."""
+    if threading.current_thread() is not threading.main_thread():
+        pytest.skip("signal handlers require the main thread")
+
+    import anyio
+
+    observed_at_teardown: list[bool] = []
+
+    async def long_running():
+        try:
+            signal.raise_signal(signal.SIGTERM)
+            await anyio.sleep(30)
+        finally:
+            # This mimics the persist teardown: at this point the exception in
+            # flight is a plain cancellation, but the flag is already latched.
+            observed_at_teardown.append(sigterm_received())
+
+    with pytest.raises(SigtermInterrupt):
+        run_async(long_running())
+
+    assert observed_at_teardown == [True]
+    assert sigterm_received()


### PR DESCRIPTION
## Problem

When a `li agent` process receives an external SIGTERM, the handler installed by `run_async` cancels the inner task, so the teardown path only ever sees a plain `CancelledError`. The run record lands as `cancelled` / `run.cancelled.system` / "Task cancelled by the runtime (anyio CancelledError)" — byte-identical to an internal runtime cancel. Operators reading the record cannot tell "something outside killed this process" from "the runtime cancelled the task", so external kills get misread as provider flakes.

`SigtermInterrupt` is already classified distinctly, but it is only raised after the worker thread joins — after the terminal record has been stamped — so it never reaches the persist path.

## Fix

- `ln/concurrency/utils.py`: the SIGTERM handler latches a process-wide `threading.Event` the moment the signal arrives, before the task cancel is scheduled; new `sigterm_received()` accessor (exported from `ln.concurrency`).
- `state/reasons.py`: new `RunReasons.CANCELLED_SIGTERM = "run.cancelled.sigterm"`.
- `cli/_runs.py` `resolve_run_reason`: the `cancelled` branch checks `isinstance(exception, SigtermInterrupt)` or the latch and stamps `run.cancelled.sigterm` with summary `"sigterm_external: process received an external SIGTERM mid-run."`; otherwise behavior is unchanged.

Exit-code semantics are untouched (still `cancelled` / 143).

## Tests

`tests/cli/test_sigterm_reason_code.py`: SigtermInterrupt mapping, latched-flag-with-plain-cancel mapping (the realistic path), unchanged internal-cancel mapping, reason-code shape, and an in-process integration test proving the handler latches the flag before teardown code observes it. Existing sigterm/sigint/reason suites pass.

Closes #1758

🤖 Generated with [Claude Code](https://claude.com/claude-code)