### PR TITLE
fix(cli): accept flags anywhere on li o flow, li o fanout, and li play

### DIFF
--- a/lionagi/cli/main.py
+++ b/lionagi/cli/main.py
@@ -252,8 +252,17 @@ def _handle_play_shortcut(argv: list[str]) -> list[str] | int:
             )
             return 1
         name = bare[0]
-        other = list(rest)
-        other.remove(name)
+        # Remove the NAME occurrence from the partition it was actually
+        # selected from, never by string value across the whole argv: an
+        # earlier flag VALUE equal to NAME (e.g. `--team-mode foo -- foo`)
+        # must not be deleted in its place. Within a single partition,
+        # identical strings rewrite equivalently, so first-match is safe.
+        if p_ns.query or p_extras:
+            head_tokens = list(p_head)
+            head_tokens.remove(name)
+            other = head_tokens + (["--", *p_post] if p_post else [])
+        else:
+            other = [*p_head, "--", *p_post[1:]]
 
     if "--help" in other or "-h" in other:
         return _print_playbook_help(name)

--- a/lionagi/cli/main.py
+++ b/lionagi/cli/main.py
@@ -238,7 +238,13 @@ def _handle_play_shortcut(argv: list[str]) -> list[str] | int:
             p_head, p_post = rest[:i], rest[i + 1 :]
         else:
             p_head, p_post = rest, []
-        p_ns, p_extras = fl_probe.parse_known_args(p_head)
+        # Keep the probe help-inert: argparse executes --help/-h during
+        # parse_known_args (printing flow help and exiting) before the
+        # playbook-specific help check below could run. Strip help tokens
+        # from the probe input only; the reconstruction below still works
+        # from the original partitions, so the help check sees them.
+        p_head_probe = [t for t in p_head if t not in ("--help", "-h")]
+        p_ns, p_extras = fl_probe.parse_known_args(p_head_probe)
         unknown = [e for e in p_extras if e.startswith("-") and e != "-"]
         if unknown:
             log_error(f"unrecognized arguments: {' '.join(unknown)}")

--- a/lionagi/cli/main.py
+++ b/lionagi/cli/main.py
@@ -212,16 +212,53 @@ def _handle_play_shortcut(argv: list[str]) -> list[str] | int:
         return run_play_status(rest[1:])
     if head == "--resume":
         return ["o", "flow", *rest]
-    if head.startswith("-"):
-        log_error(
-            "li play NAME must come before flags\n"
-            'Usage: li play <name> "<prompt>" [--bypass --team-mode TEAM --timeout N ...]'
-        )
-        return 1
-    if "--help" in rest[1:] or "-h" in rest[1:]:
-        return _print_playbook_help(head)
-    # Rewrite `play <name> [...]` → `o flow -p <name> [...]`
-    return ["o", "flow", "-p", head, *rest[1:]]
+
+    if not head.startswith("-"):
+        # NAME already comes first — unchanged fast path. Custom playbook
+        # args declared in the playbook's own `args:` schema are only
+        # registered once NAME is known (via inject_playbook_schema_into_parser,
+        # downstream), so they can only be recognized when they follow NAME;
+        # this path leaves them untouched, exactly as before.
+        name, other = head, rest[1:]
+    else:
+        # A flag precedes NAME (`li play --bypass NAME "prompt"`). Probe with
+        # the flow subparser's own base flags (before playbook-specific
+        # schema injection) to separate recognized flag(+value) pairs from
+        # bare positional tokens — same sentinel-safe split-and-fold shape as
+        # the `agent`/`o flow` interception below, minus dispatch (we only
+        # need to locate NAME here; the real parse happens later once the
+        # playbook's own args: schema can be injected). Only base flags are
+        # understood at this point, so this path does not support custom
+        # playbook flags placed before NAME — they must follow it.
+        probe_parser = argparse.ArgumentParser(prog="li", add_help=False)
+        probe_sub = probe_parser.add_subparsers(dest="command")
+        fl_probe = add_orchestrate_subparser(probe_sub)["flow"]
+        if "--" in rest:
+            i = rest.index("--")
+            p_head, p_post = rest[:i], rest[i + 1 :]
+        else:
+            p_head, p_post = rest, []
+        p_ns, p_extras = fl_probe.parse_known_args(p_head)
+        unknown = [e for e in p_extras if e.startswith("-") and e != "-"]
+        if unknown:
+            log_error(f"unrecognized arguments: {' '.join(unknown)}")
+            return 1
+        bare = [*(p_ns.query or []), *p_extras, *p_post]
+        if not bare:
+            log_error(
+                "playbook NAME is required\n"
+                'Usage: li play <name> "<prompt>" [--bypass --team-mode TEAM --timeout N ...]\n'
+                "Flags may appear anywhere relative to NAME and the prompt."
+            )
+            return 1
+        name = bare[0]
+        other = list(rest)
+        other.remove(name)
+
+    if "--help" in other or "-h" in other:
+        return _print_playbook_help(name)
+    # Rewrite `play [...] <name> [...]` → `o flow -p <name> [...]`
+    return ["o", "flow", "-p", name, *other]
 
 
 def _get_version() -> str:
@@ -328,6 +365,38 @@ def main(argv: list[str] | None = None) -> int:
             agent_parser.error(f"unrecognized arguments: {' '.join(unknown)}")
         args.query = [*(args.query or []), *extras, *post]
         return run_agent(args)
+
+    # `li o flow` / `li o fanout` (and their `orchestrate` alias) parse
+    # standalone for the same reason as `agent` above: nested subparser
+    # dispatch can't intermix flags with the [MODEL] PROMPT positionals.
+    # Both had the disease pre-fix — flow silently misassigned a
+    # flags-preceded prompt to the model slot (both positionals were
+    # nargs='?', so argparse's greedy left-to-right fill grabbed the first
+    # one), while fanout hard-rejected with "unrecognized arguments" (a flag
+    # between its two positionals split them into two separate groups
+    # argparse can't reconcile). Same sentinel-safe split + fold as `agent`.
+    if (
+        _argv
+        and _argv[0] in ("orchestrate", "o")
+        and len(_argv) > 1
+        and _argv[1] in ("fanout", "flow")
+    ):
+        sub_name = _argv[1]
+        sub_parser = orch_parsers[sub_name]
+        tail = _argv[2:]
+        if "--" in tail:
+            i = tail.index("--")
+            head, post = tail[:i], tail[i + 1 :]
+        else:
+            head, post = tail, []
+        args, extras = sub_parser.parse_known_args(head)
+        unknown = [e for e in extras if e.startswith("-") and e != "-"]
+        if unknown:
+            sub_parser.error(f"unrecognized arguments: {' '.join(unknown)}")
+        args.query = [*(args.query or []), *extras, *post]
+        args.command = "orchestrate"
+        args.orch_command = sub_name
+        return run_orchestrate(args)
 
     # `li schedule ...` parses its own subparser directly (mirroring the
     # `agent` special-case above) so an unrecognized flag gets a one-line

--- a/lionagi/cli/orchestrate/__init__.py
+++ b/lionagi/cli/orchestrate/__init__.py
@@ -370,20 +370,21 @@ def add_orchestrate_subparser(
         description=(
             "Orchestrator decomposes task into N agent requests, "
             "fans out to workers, optionally synthesizes. "
-            "Effort can be embedded in model spec: claude/opus-4-7-high."
+            "Effort can be embedded in model spec: claude/opus-4-7-high. "
+            "Flags may appear anywhere relative to the positionals."
         ),
     )
     fo.add_argument(
-        "model",
-        nargs="?",
-        default=None,
+        "query",
+        nargs="*",
+        metavar="[MODEL] PROMPT",
         help=(
-            "Orchestrator model spec (provider/model-effort). "
-            "Also used as default worker model unless --workers specified. "
-            "Optional when -a/--agent provides a model."
+            "Orchestrator model spec (provider/model-effort) followed by the "
+            "task prompt. Model is also used as the default worker model "
+            "unless --workers is set; omit it when -a/--agent provides one. "
+            "A single positional is treated as the prompt."
         ),
     )
-    fo.add_argument("prompt", help="Task prompt for the orchestrator to decompose.")
     fo.add_argument(
         "-a",
         "--agent",
@@ -472,20 +473,20 @@ def add_orchestrate_subparser(
         description=(
             "Orchestrator analyzes the task, composes a DAG of agents "
             "with dependency edges, and executes with automatic "
-            "parallelism where dependencies allow."
+            "parallelism where dependencies allow. Flags may appear "
+            "anywhere relative to the positionals."
         ),
     )
     fl.add_argument(
-        "model",
-        nargs="?",
-        default=None,
-        help="Orchestrator model spec. Optional when -a/--agent provides one.",
-    )
-    fl.add_argument(
-        "prompt",
-        nargs="?",
-        default=None,
-        help="Task for the orchestrator to plan and execute.",
+        "query",
+        nargs="*",
+        metavar="[MODEL] PROMPT",
+        help=(
+            "Orchestrator model spec followed by the task prompt. Model is "
+            "optional when -a/--agent provides one; a single positional is "
+            "treated as the prompt. The prompt itself may instead come from "
+            "-f/--file or -p/--playbook."
+        ),
     )
     fl.add_argument(
         "-f",
@@ -715,6 +716,27 @@ def add_orchestrate_subparser(
     return {"fanout": fo, "flow": fl, "ctl": ctl}
 
 
+def _resolve_model_and_prompt(query: list[str]) -> tuple[str | None, str | None] | None:
+    """Assign a 0-2 token positional bucket to (model, prompt).
+
+    Mirrors the `li agent` [MODEL] PROMPT convention: a single token is the
+    prompt (model comes from -a/--agent, a spec file, or a playbook); two
+    tokens are (model, prompt) in order. Returns None after logging a clear
+    error when more than two positionals are given (e.g. an unquoted prompt).
+    """
+    if len(query) > 2:
+        log_error(
+            "too many positional arguments — expected [MODEL] PROMPT. "
+            "Did you forget to quote the prompt?"
+        )
+        return None
+    if len(query) == 2:
+        return query[0], query[1]
+    if len(query) == 1:
+        return None, query[0]
+    return None, None
+
+
 def _run_orch_command(coro, *, verbose: bool, extra_handlers: tuple = ()) -> tuple[object, int]:
     """Run an orchestration coroutine, map shared exceptions to exit codes.
 
@@ -742,9 +764,17 @@ def _run_orch_command(coro, *, verbose: bool, extra_handlers: tuple = ()) -> tup
 
 def run_orchestrate(args: argparse.Namespace) -> int:
     if args.orch_command == "fanout":
+        resolved = _resolve_model_and_prompt(getattr(args, "query", None) or [])
+        if resolved is None:
+            return 1
+        args.model, args.prompt = resolved
+
         has_model = args.model is not None or args.agent is not None
         if not has_model:
             log_error("model or --agent is required")
+            return 1
+        if not args.prompt:
+            log_error("prompt is required")
             return 1
 
         synth = args.with_synthesis
@@ -806,6 +836,11 @@ def run_orchestrate(args: argparse.Namespace) -> int:
             if not args.verbose:
                 print(output)
             return EXIT_CODE_BY_STATUS.get(terminal_status, 0)
+
+        resolved = _resolve_model_and_prompt(getattr(args, "query", None) or [])
+        if resolved is None:
+            return 1
+        args.model, args.prompt = resolved
 
         playbook_name = getattr(args, "playbook", None)
         playbook_artifacts: dict | None = None

--- a/tests/cli/test_orchestrate_flags_anywhere.py
+++ b/tests/cli/test_orchestrate_flags_anywhere.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""`li o flow` / `li o fanout` / `li play` argument UX: flags anywhere.
+
+Mirrors tests/cli/test_agent_arg_ux.py for the equivalent `li agent`
+flags-anywhere fix. Before this fix:
+
+- `li o flow --dry-run "prompt"` silently lost the prompt: both `model` and
+  `prompt` were separate `nargs="?"` positionals, so argparse's greedy
+  left-to-right fill assigned the sole leftover token to `model`, leaving
+  `prompt` at its default of None.
+- `li o fanout MODEL --flag VALUE "prompt"` hard-rejected with "unrecognized
+  arguments": a flag between the two positionals split them into two
+  separate positional-matching groups that plain argparse can't reconcile.
+- `li play --bypass NAME "prompt"` hard-rejected before even reaching
+  argparse, in the `play` → `o flow -p NAME ...` sugar rewrite, which assumed
+  NAME was always the first token after `play`.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import yaml
+
+import lionagi.cli.orchestrate as orch_mod
+from lionagi.cli.main import main
+
+
+def _run_with_flow_mock(argv: list[str]):
+    with patch.object(
+        orch_mod, "_run_flow", AsyncMock(return_value=("flow output", "completed"))
+    ) as run_flow:
+        code = main(argv)
+    return code, run_flow
+
+
+def _run_with_fanout_mock(argv: list[str]):
+    with patch.object(
+        orch_mod, "_run_fanout", AsyncMock(return_value=("fanout output", "completed"))
+    ) as run_fanout:
+        code = main(argv)
+    return code, run_fanout
+
+
+class TestFlowFlagsAnywhere:
+    def test_flags_before_prompt_previously_lost_it(self):
+        """The exact reported regression: --dry-run before the prompt used to
+        silently drop it (misassigned to `model`), erroring "prompt is
+        required" even though one was given."""
+        code, run_flow = _run_with_flow_mock(
+            ["o", "flow", "--dry-run", "some prompt", "--agent", "researcher"]
+        )
+        assert code == 0
+        run_flow.assert_called_once()
+        assert run_flow.call_args.kwargs["prompt"] == "some prompt"
+        assert run_flow.call_args.kwargs["dry_run"] is True
+
+    def test_flags_between_model_and_prompt(self):
+        code, run_flow = _run_with_flow_mock(
+            ["o", "flow", "codex", "--effort", "high", "do the thing"]
+        )
+        assert code == 0
+        assert run_flow.call_args.kwargs["model_spec"] == "codex"
+        assert run_flow.call_args.kwargs["prompt"] == "do the thing"
+
+    def test_prompt_before_flags_still_works(self):
+        code, run_flow = _run_with_flow_mock(
+            ["o", "flow", "codex", "do the thing", "--effort", "high"]
+        )
+        assert code == 0
+        assert run_flow.call_args.kwargs["model_spec"] == "codex"
+        assert run_flow.call_args.kwargs["prompt"] == "do the thing"
+
+    def test_prompt_verbatim_after_flags(self):
+        """A prompt containing punctuation/dashes must survive untouched when
+        it follows flags, including a leading '--' style token after the '--'
+        sentinel (must not be reinterpreted as a flag, CWE-88)."""
+        code, run_flow = _run_with_flow_mock(
+            ["o", "flow", "--agent", "researcher", "--", "--not-a-real-flag verbatim"]
+        )
+        assert code == 0
+        assert run_flow.call_args.kwargs["prompt"] == "--not-a-real-flag verbatim"
+
+    def test_missing_prompt_still_errors_clearly(self, capsys):
+        code = main(["o", "flow", "--agent", "researcher", "--dry-run"])
+        assert code == 1
+        assert "prompt is required" in capsys.readouterr().err
+
+    def test_missing_model_still_errors_clearly(self, capsys):
+        code = main(["o", "flow", "--dry-run", "some prompt"])
+        assert code == 1
+        assert "model or --agent is required" in capsys.readouterr().err
+
+
+class TestFanoutFlagsAnywhere:
+    def test_flag_between_model_and_prompt_previously_rejected(self):
+        """The exact reported disease check: a flag splitting the two
+        positionals used to error 'unrecognized arguments' outright."""
+        code, run_fanout = _run_with_fanout_mock(
+            ["o", "fanout", "codex", "--num-workers", "2", "some prompt"]
+        )
+        assert code == 0
+        run_fanout.assert_called_once()
+        assert run_fanout.call_args.kwargs["model_spec"] == "codex"
+        assert run_fanout.call_args.kwargs["prompt"] == "some prompt"
+        assert run_fanout.call_args.kwargs["num_workers"] == 2
+
+    def test_flags_before_everything(self):
+        code, run_fanout = _run_with_fanout_mock(
+            ["o", "fanout", "--num-workers", "2", "--agent", "researcher", "some prompt"]
+        )
+        assert code == 0
+        assert run_fanout.call_args.kwargs["prompt"] == "some prompt"
+        assert run_fanout.call_args.kwargs["model_spec"] == ""
+
+    def test_prompt_verbatim_after_flags(self):
+        code, run_fanout = _run_with_fanout_mock(
+            ["o", "fanout", "--agent", "researcher", "--", "--looks-like-a-flag"]
+        )
+        assert code == 0
+        assert run_fanout.call_args.kwargs["prompt"] == "--looks-like-a-flag"
+
+    def test_missing_prompt_errors_clearly(self, capsys):
+        code = main(["o", "fanout", "--agent", "researcher"])
+        assert code == 1
+        assert "prompt is required" in capsys.readouterr().err
+
+
+class TestPlayFlagsAnywhere:
+    def _make_playbook(self, tmp_path, monkeypatch, **spec_fields):
+        playbooks_dir = tmp_path / ".lionagi" / "playbooks"
+        playbooks_dir.mkdir(parents=True)
+        spec = {"model": "claude-code/opus-4-7", "prompt": "Do {input}"}
+        spec.update(spec_fields)
+        (playbooks_dir / "hello.playbook.yaml").write_text(yaml.dump(spec))
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+    def test_flags_before_name_previously_hard_rejected(self, tmp_path, monkeypatch, capsys):
+        """The exact reported regression: `li play --bypass NAME "prompt"`
+        used to hard-error with "li play NAME must come before flags"."""
+        self._make_playbook(tmp_path, monkeypatch)
+        code, run_flow = _run_with_flow_mock(["play", "--bypass", "hello", "a thing"])
+        assert code == 0, capsys.readouterr().err
+        assert run_flow.call_args.kwargs["prompt"] == "Do a thing"
+        assert run_flow.call_args.kwargs["bypass"] is True
+
+    def test_flags_between_name_and_prompt(self, tmp_path, monkeypatch):
+        self._make_playbook(tmp_path, monkeypatch)
+        code, run_flow = _run_with_flow_mock(["play", "hello", "--bypass", "a thing"])
+        assert code == 0
+        assert run_flow.call_args.kwargs["prompt"] == "Do a thing"
+        assert run_flow.call_args.kwargs["bypass"] is True
+
+    def test_name_first_still_works(self, tmp_path, monkeypatch):
+        self._make_playbook(tmp_path, monkeypatch)
+        code, run_flow = _run_with_flow_mock(["play", "hello", "a thing", "--bypass"])
+        assert code == 0
+        assert run_flow.call_args.kwargs["prompt"] == "Do a thing"
+
+    def test_custom_playbook_arg_after_name_unaffected(self, tmp_path, monkeypatch):
+        """Playbook arg interpolation (key=value args declared via the
+        playbook's own `args:` schema) must keep working when NAME leads."""
+        self._make_playbook(
+            tmp_path,
+            monkeypatch,
+            args={"tabs": {"type": "int", "default": 2}},
+            prompt="Run {tabs}. Task: {input}",
+        )
+        code, run_flow = _run_with_flow_mock(["play", "hello", "--tabs", "9", "do a thing"])
+        assert code == 0
+        assert run_flow.call_args.kwargs["prompt"] == "Run 9. Task: do a thing"
+
+    def test_missing_name_errors_clearly(self, capsys):
+        code = main(["play", "--bypass"])
+        assert code == 1
+        assert "playbook NAME is required" in capsys.readouterr().err

--- a/tests/cli/test_orchestrate_flags_anywhere.py
+++ b/tests/cli/test_orchestrate_flags_anywhere.py
@@ -172,6 +172,17 @@ class TestPlayFlagsAnywhere:
         assert code == 0
         assert run_flow.call_args.kwargs["prompt"] == "Run 9. Task: do a thing"
 
+    def test_help_after_flags_reaches_playbook_help(self, tmp_path, monkeypatch, capsys):
+        """--help alongside pre-NAME flags must print the playbook's own help,
+        not let argparse's built-in --help fire mid-probe (flow help +
+        SystemExit before NAME is even resolved)."""
+        self._make_playbook(tmp_path, monkeypatch)
+        code = main(["play", "--bypass", "hello", "--help"])
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "hello" in out
+        assert "usage: li orchestrate flow" not in out
+
     def test_missing_name_errors_clearly(self, capsys):
         code = main(["play", "--bypass"])
         assert code == 1

--- a/tests/cli/test_orchestrate_flags_anywhere.py
+++ b/tests/cli/test_orchestrate_flags_anywhere.py
@@ -176,3 +176,40 @@ class TestPlayFlagsAnywhere:
         code = main(["play", "--bypass"])
         assert code == 1
         assert "playbook NAME is required" in capsys.readouterr().err
+
+    def _make_named_playbook(self, tmp_path, monkeypatch, name, **spec_fields):
+        playbooks_dir = tmp_path / ".lionagi" / "playbooks"
+        playbooks_dir.mkdir(parents=True, exist_ok=True)
+        spec = {"model": "claude-code/opus-4-7", "prompt": "Do {input}"}
+        spec.update(spec_fields)
+        (playbooks_dir / f"{name}.playbook.yaml").write_text(yaml.dump(spec))
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+    def test_flag_value_equal_to_name_across_sentinel(self, tmp_path, monkeypatch, capsys):
+        """A flag VALUE that string-equals NAME must survive when NAME is
+        selected from after the `--` sentinel: the flag value occurrence
+        must not be removed in NAME's place."""
+        self._make_named_playbook(tmp_path, monkeypatch, "foo")
+        code, run_flow = _run_with_flow_mock(["play", "--team-mode", "foo", "--", "foo", "task"])
+        assert code == 0, capsys.readouterr().err
+        assert run_flow.call_args.kwargs["prompt"] == "Do task"
+        assert run_flow.call_args.kwargs["team_name"] == "foo"
+        assert run_flow.call_args.kwargs["model_spec"] == "claude-code/opus-4-7"
+
+    def test_save_value_equal_to_name_across_sentinel(self, tmp_path, monkeypatch, capsys):
+        self._make_named_playbook(tmp_path, monkeypatch, "foo")
+        code, run_flow = _run_with_flow_mock(
+            ["play", "--bypass", "--save", "foo", "--", "foo", "task"]
+        )
+        assert code == 0, capsys.readouterr().err
+        assert run_flow.call_args.kwargs["prompt"] == "Do task"
+        assert run_flow.call_args.kwargs["bypass"] is True
+
+    def test_duplicate_name_within_head_partition_still_safe(self, tmp_path, monkeypatch, capsys):
+        """Identical strings within one partition rewrite equivalently, so
+        first-match removal stays correct with no sentinel involved."""
+        self._make_named_playbook(tmp_path, monkeypatch, "foo")
+        code, run_flow = _run_with_flow_mock(["play", "--team-mode", "foo", "foo", "task"])
+        assert code == 0, capsys.readouterr().err
+        assert run_flow.call_args.kwargs["prompt"] == "Do task"
+        assert run_flow.call_args.kwargs["team_name"] == "foo"


### PR DESCRIPTION
## Summary

Three CLI surfaces were order-sensitive about flags vs positionals, while `li agent` already accepts flags anywhere:

- `li o flow --dry-run "prompt"` **silently lost the prompt**: both positionals were `nargs='?'`, so argparse's greedy left-to-right fill assigned the prompt to the model slot and the CLI errored "prompt is required" despite a prompt being given.
- `li o fanout` hard-rejected a flag placed between its two positionals ("unrecognized arguments").
- `li play --bypass NAME` hard-rejected with "li play NAME must come before flags".

## Fix

Mirror the established `li agent` pattern: a single `[MODEL] PROMPT` positional bucket plus a sentinel-safe two-phase parse (`parse_known_args` split + fold, `--` respected) intercepted in `main()` for `o flow`/`o fanout`, and a base-flag probe in the `play` shortcut to locate NAME among bare tokens. NAME-first `li play` is untouched, so playbook-declared custom flags after NAME work exactly as before. Clear errors remain when model/prompt/NAME are genuinely missing.

## Tests

- New `tests/cli/test_orchestrate_flags_anywhere.py` (15 tests): previously-silent flow case, previously-rejected play and fanout cases, verbatim prompt preservation across `--`, missing-arg error messages.
- `tests/cli/` full directory green including `test_argv_injection.py` (sentinel-safety invariants unchanged).
- Full suite green with all extras.

🤖 Generated with [Claude Code](https://claude.com/claude-code)