### PR TITLE
docs(adr): ADR-0094 run completion contract + reliability recipes

### DIFF
--- a/docs/adrs/ADR-0094-run-completion-contract.md
+++ b/docs/adrs/ADR-0094-run-completion-contract.md
@@ -1,0 +1,172 @@
+# ADR-0094: Run Completion Contract and Machine-Consumable Orchestration
+
+**Status**: Proposed
+**Date**: 2026-07-05
+
+## Context
+
+Every lionagi run — an agent session, a play, a flow, a scheduled job — already persists a
+durable record: a status, a machine-readable terminal reason code (ADR-0029), and an artifact
+verification verdict. This state layer is the strongest property of the orchestration stack:
+a run's outcome can be answered from a queryable row rather than inferred from a process exit
+code or a log tail.
+
+Programmatic consumers cannot yet consume that record through a stable surface. A harness that
+launches a run and needs to act on its completion today triangulates: poll an output file,
+watch a directory, re-invoke a status command and parse a human-oriented table, or read the
+state database directly. Each of those channels can disagree with the others, and none of them
+carries the full answer (terminal status AND reason AND where the artifacts are) in one place.
+The existing wait facility (`li monitor run`) covers scheduled runs only, and its output line
+carries status and exit code but neither the reason code nor an artifact location. The result
+is a recurring failure class: a consumer treats "process ended" or "status says completed" as
+"work is done and evidence exists", when the record itself knows better (`completed_empty`,
+`failed.missing_artifact`).
+
+This ADR defines the one machine contract for run completion, the output discipline that makes
+it parseable, and the integrity invariants the state layer must uphold for the contract to be
+trustworthy.
+
+## Decision
+
+Introduce a single purpose-built completion verb, **`li wait <id>...`**, as the only
+machine-contract-bearing completion surface. It blocks until each named run reaches a terminal
+state and emits exactly one stable, versioned line per run on stdout. Existing observation
+commands (`li monitor`, `li monitor run`, status subcommands) are unchanged; they remain human
+dashboards and carry no machine contract.
+
+### 1. State-as-truth
+
+The run record is the source of truth for outcome. A run's completion is defined by its
+persisted terminal status, its terminal reason code, and its artifact verdict — never by
+process exit alone. Orchestration built on the record beats process-exit signaling because the
+record distinguishes outcomes the exit code cannot (completed with verified evidence, completed
+empty, failed with missing artifact, cancelled externally).
+
+### 2. The completion contract
+
+`li wait <id>...` accepts one or more run identifiers of any kind (agent session, play, flow
+run, scheduled run), resolves each to its record, blocks until terminal, and emits per run one
+tab-delimited line on stdout:
+
+```text
+<run_id>\tstatus=<terminal_status>\treason=<reason_code>\tartifact_dir=<run_dir>\texit_code=<n>
+```
+
+This grammar is **frozen** by this ADR:
+
+- `run_id` — the canonical identifier the run was invoked with.
+- `status` — the persisted terminal status.
+- `reason` — a code drawn from the existing closed reason vocabulary
+  (`lionagi/state/reasons.py`, `VALID_REASON_CODES`). No new outcome strings may be invented at
+  the CLI layer. Because the reason surfaces the artifact verifier's verdict,
+  `run.completed_empty.no_evidence` and `run.failed.missing_artifact` are distinct, parseable
+  outcomes — "terminal" and "evidence exists" stop being conflated.
+- `artifact_dir` — the run directory (the directory containing the run's manifest). Consumers
+  resolve specific artifact paths from the manifest inside it. The wait verb never hard-codes
+  any run kind's internal artifact layout.
+- `exit_code` — the numeric exit status recorded for the run, when the kind records one.
+
+Normative requirements on the implementation:
+
+- The verb MUST apply uniformly across run kinds via a per-kind resolver and per-kind terminal
+  predicate, each derived from that kind's own persisted status set. Terminal-state definitions
+  live with the record schema, not in the CLI.
+- Chain-following MUST be kind-aware: scheduler success/failure chains apply to scheduled runs
+  only. Other run kinds have no such chains and none may be synthesized for them.
+- The existing `li monitor run` output MUST remain byte-identical for its current scope. No
+  fields may be added to its line; the contract lives on `li wait` alone.
+- The verb is poll-backed now and subscription-compatible later: a future push-backed mode
+  (e.g. `--subscribe` over the dispatch layer, ADR-0092) MUST emit the identical line, making
+  the poll-to-push migration invisible to consumers. Freezing the grammar here is what makes
+  that migration safe.
+- Internally the CLI verb is a thin shim over a reusable waiting core
+  (`wait_for_terminal(ids) -> outcomes`), so other surfaces can consume completion without
+  shelling out.
+
+Acceptance for the implementing change: a consumer blocks on a play run id and an agent
+session id (neither a scheduled run) and receives the terminal line with a correct reason code
+and a resolvable `artifact_dir`; a completed-empty run yields
+`reason=run.completed_empty.no_evidence` rather than a bare `status=completed`; scheduled-run
+waiting through the existing command is byte-identical to before.
+
+### 3. Machine-consumer output mode
+
+Stdout is the contract; stderr is for humans. Under a machine-output mode (a flag and an
+equivalent environment variable), diagnostic warnings, progress lines, provider deprecation
+notices, and other advisory output MUST be suppressed or routed to stderr so that a
+programmatic consumer reading stdout receives contract lines and nothing else. `li wait`
+launches with this discipline; other commands adopt it as they are touched.
+
+### 4. Integrity floor
+
+The contract is only as trustworthy as the record. The following are gating invariants, not
+ranked backlog items — the completion verb must not ship without them holding:
+
+- **Terminal states are write-protected.** The state layer currently exposes a transition
+  validator that no write path calls, so an errant writer can move a run from a terminal
+  status back to `running`, silently corrupting the record the contract reports. Observed
+  consequences of this class include terminal statuses oscillating when two writers with
+  different views reconcile against each other.
+
+  **Proposal (decision requested at gate): enforce at write, do not delete.** Transition
+  validation moves into the single database write path for status changes: a disallowed
+  transition (any terminal → non-terminal, or any pair outside the declared transition table)
+  is rejected loudly at the write, and every rejection is recorded. Deliberate operational
+  repair remains possible through an explicit override that records actor and justification in
+  the existing status-transition audit trail. Rationale: deleting the dead validator would keep
+  the invariant unenforced and merely remove the misleading API; advisory validation is the
+  worst of both worlds (cost of the API, protection of neither). Enforcement at the write
+  chokepoint is small, testable, and turns the crown-jewel claim ("the record is truthful")
+  from a convention into a property.
+- **Status writes are race-free at the storage layer.** Concurrent writers must not be able to
+  interleave a stale status over a newer terminal one; the write path must guard on the
+  current status it believes it is transitioning from.
+
+### 5. Compatibility
+
+Additive only. The new verb introduces no breaking change to any existing command, output
+format, or persisted schema consumer. Runs produced before this ADR are waitable if their
+records carry a terminal status; missing reason codes surface as an explicit unknown rather
+than an invented value.
+
+## Consequences
+
+**Positive**
+
+- One greppable, documented surface (`li wait`) retires file-drop polling, log-tail scraping,
+  and direct state-database reads as completion channels.
+- False "done" becomes structurally detectable: the reason code carries the artifact verdict,
+  so a consumer cannot mistake `completed_empty` for verified completion without ignoring the
+  contract.
+- The frozen grammar decouples the contract from both the human dashboard (free to keep
+  evolving) and the future push transport (free to land later without a consumer migration).
+- Enforced transitions convert the state layer's headline property from "true in practice"
+  to "true by construction".
+
+**Negative**
+
+- A new top-level verb to document and maintain, overlapping in mechanism (not in contract)
+  with the scheduled-run wait facility.
+- Poll-backed waiting holds a process open per waiter until the push mode exists.
+- Write-path transition enforcement can reject writes from existing code paths that relied on
+  being able to overwrite terminal states; those paths must be found and fixed as part of the
+  implementing change, which widens its test surface.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Extend `li monitor run` with reason and artifact fields | Adding fields to an already-parsed line breaks existing consumers; overloads one command with three per-kind terminal/child models; couples a stable contract to a fast-evolving human dashboard. Its polling machinery is reused; its surface is not. |
+| Event subscription over the dispatch layer (ADR-0092) now | Right long-term shape, wrong dependency today: dispatch is an early-stage subsystem and gating completion on it is schedule risk. Kept as the named migration target; the frozen line grammar makes the swap invisible. |
+| Library helper only, no CLI verb | The consumers are shell harnesses; a Python-first helper serves nobody without the shim, and the shim is the verb. Retained as internal structure (thin CLI over a reusable core), not as the surface decision. |
+| Delete the unused transition validator | Removes a misleading API but leaves terminal states writable — the record stays corruptible and the contract untrustworthy. Enforcement at the write is comparably small and buys the invariant. |
+| One omnibus integration document (contract + all operational recipes) | Every recipe edit would re-open review of the frozen contract. The contract changes rarely and is gated; per-surface recipes iterate freely (see References). |
+
+## References
+
+- ADR-0029 — artifact verification verdicts and reason codes on the run record.
+- ADR-0092 — durable dispatch outbox; named migration target for a subscription-backed wait.
+- `lionagi/state/reasons.py` — the closed reason-code vocabulary (`VALID_REASON_CODES`).
+- Recipe docs (iterate without re-gating this ADR): `docs/cookbook/reliable-review-runs.md`,
+  `docs/cookbook/reliable-multi-leg-runs.md`, `docs/cookbook/reliable-recurring-runs.md`,
+  `docs/cookbook/reliable-artifact-production.md`.

--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -1,6 +1,6 @@
 # Cookbook
 
-Five runnable scenarios. Each ends with a `Next:` pointer to the next one.
+Runnable scenarios. Each ends with a `Next:` pointer to the next one.
 
 | Scenario | Command | What it covers |
 |----------|---------|----------------|
@@ -9,5 +9,15 @@ Five runnable scenarios. Each ends with a `Next:` pointer to the next one.
 | [Multi-model pipeline](multi-model-pipeline.md) | `li o flow` | DAG with dependency edges |
 | [Team coordination](team-coordination.md) | `li team` + `--team-mode` | Mid-flow messaging |
 | [Resumable background](resumable-background.md) | `li o flow --background` | Detach, monitor, resume |
+
+Reliability recipes — consuming and producing run completion per the completion contract
+(ADR-0094):
+
+| Scenario | Surface | What it covers |
+|----------|---------|----------------|
+| [Reliable review runs](reliable-review-runs.md) | `li agent` | Wait on the record, act on reason codes |
+| [Reliable multi-leg runs](reliable-multi-leg-runs.md) | `li o flow` | Run-level completion, tail-leg artifact truth |
+| [Reliable recurring runs](reliable-recurring-runs.md) | `li schedule` | Daemon cwd, UTC cron, unattended triage |
+| [Reliable artifact production](reliable-artifact-production.md) | any gated leg | Incremental writes, deadline-surviving evidence |
 
 Next: [Codebase audit](codebase-audit.md) — the simplest pattern.

--- a/docs/cookbook/reliable-artifact-production.md
+++ b/docs/cookbook/reliable-artifact-production.md
@@ -1,0 +1,49 @@
+# Reliable Artifact Production
+
+Every recipe in this chain ends at the same question: does the artifact exist, and can a
+consumer trust it? This recipe is about the producing side — writing runs whose evidence
+survives timeouts, cancellations, and budget exhaustion.
+
+## Write incrementally, not at the end
+
+A gated leg (a reviewer, a verifier, a synthesis step) that accumulates its whole verdict in
+memory and writes one file at the end produces nothing when it hits a deadline at 95%. The
+run record then truthfully reports `run.failed.missing_artifact` — but the work is still lost.
+
+Structure prompts and harnesses so evidence lands as it is produced:
+
+- Instruct agents to write findings to the artifact file as they confirm them, section by
+  section, rather than composing the full report in one final write.
+- Prefer append-friendly formats (markdown sections, JSONL rows) over formats that only make
+  sense complete.
+- Put the verdict line last. A partial artifact with findings but no verdict is honest — a
+  consumer can see how far the run got. A verdict with no findings behind it is the thing the
+  contract exists to catch.
+
+## Scope heavy checks so evidence survives the deadline
+
+When a leg runs an expensive validation (full test suite, large diff review), order the work
+so the cheap, high-signal portion completes and is written first. A run that times out after
+writing "sections 1–4 verified, section 5 not reached" is a usable partial result; a run that
+times out inside one monolithic check leaves nothing. Give the timeout budget to the harness
+knob (`--timeout`), and give the leg a smaller internal budget so it finishes writing before
+the harness kills it.
+
+## Let the verifier see what you produced
+
+Artifact verification runs against the run record's artifact paths. Two habits keep it honest:
+
+- Write artifacts under the run's save directory (`--save`) or the run directory, so the
+  manifest points at what was actually produced. Files written to arbitrary paths are
+  invisible to verification.
+- Never touch an artifact after the terminal status is written. Consumers compare artifact
+  mtimes against run rounds to detect stale evidence; post-terminal edits defeat that check.
+
+## The payoff
+
+With incremental writes and scoped checks, the completion contract's reason codes become
+fully trustworthy in both directions: `run.completed.ok` means verified evidence exists, and
+a failure reason still leaves behind the partial evidence needed to resume instead of restart.
+
+Next: [Reliable review runs](reliable-review-runs.md) — the consuming side of the same
+contract.

--- a/docs/cookbook/reliable-multi-leg-runs.md
+++ b/docs/cookbook/reliable-multi-leg-runs.md
@@ -1,0 +1,49 @@
+# Reliable Multi-Leg Runs
+
+`li o flow` plans a DAG of agent legs and executes it with dependency-aware parallelism. Since
+0.26.15 the planner is structured and loud: an unplannable prompt raises a plan error with a
+non-zero exit instead of silently exiting clean, and flags may appear anywhere relative to the
+positionals. What remains on the harness author is consuming completion truthfully across
+many legs.
+
+## Launch
+
+```bash
+li o flow claude/sonnet \
+  "Harden the draft spec: one leg per section, then a synthesis leg" \
+  --save ./spec-hardening --bypass
+```
+
+For repeatable multi-leg work, prefer a spec file (`-f spec.yaml`) or a playbook (`-p name`)
+over a long inline prompt.
+
+## One run, many legs — wait on the run
+
+The flow run is the unit of completion, not the individual legs. The completion contract
+(ADR-0094) applies to the flow run id: `li wait <flow_run_id>` returns the terminal line with
+the run-level `status`, `reason`, and the run directory. Per-leg outcomes live inside the run
+directory: the manifest lists each branch/leg with its own artifacts.
+
+Until `li wait` ships, the interim is `li play status <id>` / `li agent status <id>` polling
+plus manifest reads — the same tracked-debt workaround as single-agent runs.
+
+## Tail legs are where trust dies
+
+A DAG's last legs (gates, synthesis) run when the budget and patience are thinnest. Two rules:
+
+- **Declare artifact contracts up front.** Flow populates artifact contracts at plan time and
+  fails loud on undeclared escalation; keep leg prompts explicit about the file each leg must
+  produce so the verifier has something to verify.
+- **Check the run-level reason, then the tail leg's artifact.** A run whose reason is
+  `run.completed.ok` had its contracts verified; `run.completed_empty.no_evidence` or
+  `run.failed.missing_artifact` on a tail leg means the DAG "finished" without its deliverable
+  — treat as failure regardless of status.
+
+## Partial failure
+
+Legs that fail don't necessarily fail the run — read the manifest to see which legs produced
+artifacts and which did not, and re-run only what's missing (`--resume` on the flow, or a
+targeted `li agent -r` on the failed branch) instead of re-paying for the whole DAG.
+
+Next: [Reliable recurring runs](reliable-recurring-runs.md) — the same contract under a
+scheduler.

--- a/docs/cookbook/reliable-recurring-runs.md
+++ b/docs/cookbook/reliable-recurring-runs.md
@@ -1,0 +1,56 @@
+# Reliable Recurring Runs
+
+`li schedule` fires agents, playbooks, and flows on cron, interval, or repository-event
+triggers. Two execution-context rules are non-negotiable and must be stated in every recurring
+harness, verbatim, because violating either fails silently or off-by-hours.
+
+## Rule 1: the daemon's working directory is the run's working directory
+
+The scheduler engine spawns each action inheriting the daemon's cwd. Start the Studio daemon
+from the directory your scheduled actions expect to run in, or every agent action fails at
+spawn. Verify before trusting a new schedule:
+
+```bash
+curl -s 127.0.0.1:8765/api/admin/health
+```
+
+## Rule 2: cron expressions resolve in UTC
+
+`0 18 * * *` fires at 18:00 UTC, not local time. Write cron in UTC and always check
+`next_fire_at` immediately after creating a schedule:
+
+```bash
+li schedule create --trigger-type cron --cron "0 18 * * *" \
+  --action-kind playbook --action-target kg-polish
+li schedule runs <id>   # sanity-check next_fire_at before walking away
+```
+
+A date-pinned one-shot created after its UTC moment has already passed silently skips to the
+next occurrence — for a daily cron, a full day out.
+
+## Rule 3: agent-kind schedules set the model explicitly
+
+Set `action_model` on agent-kind schedules rather than relying on the agent profile's default.
+
+## Completion for runs nobody is watching
+
+Recurring runs finish while you sleep; the record is the only witness. Scheduled runs are the
+one kind with a wait surface today: `li monitor run <schedule_run_id>` blocks until terminal
+and follows the schedule's success/failure chains. Its line carries status and exit code only
+— the reason code and artifact location come from the completion contract (ADR-0094) once
+`li wait` lands, which covers scheduled runs with the same frozen line as everything else.
+
+Until then, a morning triage loop over last night's runs:
+
+```bash
+li schedule runs <id> --limit 10
+```
+
+Then, for anything not plainly successful, read the run directory manifest and check the
+artifact exists and is non-empty before treating the night's work as done. A `completed`
+status on a recurring run with no artifact is the classic silent rot: the schedule keeps
+firing, the artifacts stop appearing, and nothing pages you. Make artifact presence part of
+the triage, not an assumption.
+
+Next: [Reliable artifact production](reliable-artifact-production.md) — making sure the
+evidence exists when the deadline hits.

--- a/docs/cookbook/reliable-review-runs.md
+++ b/docs/cookbook/reliable-review-runs.md
@@ -1,0 +1,50 @@
+# Reliable Review Runs
+
+A review harness launches an agent, waits for it to finish, and acts on the verdict. The
+failure mode to design out: treating "the process ended" as "the review exists and is
+trustworthy". A run can end `completed` with no evidence written, or die to an external signal
+after the verdict file was half-written. The run record knows the difference; consume it.
+
+## Launch
+
+```bash
+li agent -a reviewer --bypass --effort high \
+  --prompt-file review_prompt.md --save ./review-out
+```
+
+Capture the run/session id from the launch output — it is the handle everything below keys on.
+
+## Wait on the record, not the process
+
+The completion contract (ADR-0094) defines `li wait <id>` as the machine surface: one
+tab-delimited line per run with `status`, `reason`, `artifact_dir`, and `exit_code`, where
+`reason` distinguishes `run.completed.ok` from `run.completed_empty.no_evidence` and
+`run.failed.missing_artifact`.
+
+Until `li wait` ships, the honest interim is explicit about being a workaround (this is
+tracked debt, not the recommended end state):
+
+- Poll `li agent status <id>` for a terminal status, then
+- read the run directory's manifest (`run.json`) for artifact paths, then
+- verify the artifact you need actually exists and is non-empty before consuming it.
+
+Never gate on the output file appearing alone: a file can exist before the run is terminal,
+and a run can be terminal without the file being complete.
+
+## Act on the reason code
+
+- `run.completed.ok` — consume the artifact from the run directory.
+- `run.completed_empty.no_evidence` — the run finished but produced nothing verifiable; treat
+  as a failed review, not a clean pass.
+- `run.failed.*` / `run.cancelled.*` / `run.timed_out.*` — inspect
+  `status_reason_summary` on the record before retrying; an external cancellation
+  (`run.cancelled.sigterm`) usually means re-run as-is, while `run.failed.exception` means
+  the prompt or environment needs a change first.
+
+## Verify before trusting
+
+A reviewer's "APPROVE" is data, not a decision. Read the review artifact itself; check that it
+addresses the diff you asked about (a stale artifact from a previous round is the classic
+trap — compare file mtime against the round you fired).
+
+Next: [Reliable multi-leg runs](reliable-multi-leg-runs.md) — the same discipline on a DAG.


### PR DESCRIPTION
## Summary

Spec-only PR (no code changes). Adds:

- **ADR-0094 — Run Completion Contract and Machine-Consumable Orchestration** (`docs/adrs/`):
  - One machine-contract completion verb, `li wait <id>...`, with a **frozen** tab-delimited line grammar (`run_id`, `status`, `reason`, `artifact_dir`, `exit_code`), reason codes drawn only from the existing closed vocabulary in `lionagi/state/reasons.py`.
  - Normative requirements: kind-aware chain following, byte-identical `li monitor run` output, run-directory artifact anchoring, poll-now/subscribe-later with an identical line, thin CLI over a reusable `wait_for_terminal` core.
  - Machine-consumer output mode: stdout is the contract, stderr is for humans.
  - Integrity floor: proposal to enforce status-transition validation at the single DB write path (loud rejection, audited override) rather than deleting the unused validator; race-free guarded status writes.
  - Alternatives table covering the rejected shapes (extend `li monitor run`, dispatch subscription now, library-only, delete validator, omnibus doc).

- **Four cookbook reliability recipes** (`docs/cookbook/`), iterable without re-opening the ADR:
  - reliable-review-runs.md — agent runs: wait on the record, act on reason codes.
  - reliable-multi-leg-runs.md — flow runs: run-level completion, tail-leg artifact truth.
  - reliable-recurring-runs.md — schedules: daemon cwd rule, UTC cron rule, unattended triage.
  - reliable-artifact-production.md — producing side: incremental writes, deadline-surviving evidence.

- Cookbook index updated with the new section and `Next:` chain.

Implementation of `li wait` and the write-path transition enforcement is intentionally NOT in this PR; it queues behind acceptance of this ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)