### PR TITLE
feat(cli): li wait + ADR-0094 run completion contract integrity floor

### DIFF
--- a/lionagi/cli/kill.py
+++ b/lionagi/cli/kill.py
@@ -12,6 +12,8 @@ from typing import Any
 
 import psutil
 
+from lionagi.state.db import PLAY_ACTIVE_STATUSES as _PLAY_ACTIVE_STATUSES
+
 from ._logging import log_error, warn
 from ._util import _TABLE_TO_ENTITY_TYPE
 from ._util import pid_alive as _pid_alive
@@ -157,10 +159,6 @@ def _terminate_pid(
 
 # Only sessions/invocations carry PIDs; plays/shows are orchestrators.
 _STALE_SWEEP_ORDER = ("sessions", "invocations")
-
-_PLAY_ACTIVE_STATUSES = frozenset(
-    {"pending", "prepared", "running", "running_complete", "gated", "redoing"}
-)
 
 
 async def _list_child_invocations(db: Any, session_id: str) -> list[dict[str, Any]]:

--- a/lionagi/cli/kill.py
+++ b/lionagi/cli/kill.py
@@ -224,19 +224,24 @@ async def _persist_cancel(
     evidence: dict[str, Any],
 ) -> None:
     """Write cancelled status + status_transition row."""
-    play_terminal = {"merged", "escalated", "gate_failed", "blocked", "aborted_after_finish"}
+    from lionagi.state.db import (
+        PLAY_TERMINAL_STATUSES,
+        SHOW_TERMINAL_STATUSES,
+        TransitionRejectedError,
+    )
+
     if entity_type == "play":
         row = await db.fetch_one("SELECT status FROM plays WHERE id = ?", (entity_id,))
         if row is None:
             return
-        if row["status"] in play_terminal:
+        if row["status"] in PLAY_TERMINAL_STATUSES:
             return
         target_status = "blocked"
     elif entity_type == "show":
         row = await db.fetch_one("SELECT status FROM shows WHERE id = ?", (entity_id,))
         if row is None:
             return
-        if row["status"] in ("completed", "aborted"):
+        if row["status"] in SHOW_TERMINAL_STATUSES:
             return
         target_status = "aborted"
     else:
@@ -254,16 +259,22 @@ async def _persist_cancel(
             return
         target_status = "cancelled"
 
-    await db.update_status(
-        entity_type,
-        entity_id,
-        new_status=target_status,
-        reason_code=reason_code,
-        reason_summary=reason_summary,
-        evidence_refs=[evidence],
-        source="admin",
-        actor="user",
-    )
+    try:
+        await db.update_status(
+            entity_type,
+            entity_id,
+            new_status=target_status,
+            reason_code=reason_code,
+            reason_summary=reason_summary,
+            evidence_refs=[evidence],
+            source="admin",
+            actor="user",
+        )
+    except TransitionRejectedError:
+        # The entity went terminal between the pre-check above and this
+        # write (e.g. it finished on its own right as `li kill` reached
+        # it) — nothing to cancel, same as the pre-check `return`s above.
+        pass
 
 
 async def _kill_one(

--- a/lionagi/cli/main.py
+++ b/lionagi/cli/main.py
@@ -330,6 +330,15 @@ def main(argv: list[str] | None = None) -> int:
 
         return run_monitor_wait(_argv[2:])
 
+    # `li wait <id> [<id2> ...] [--interval SECS]` — the ADR-0094 completion
+    # contract. Intercepted before argparse for the same reason as `monitor
+    # run` above: free-form positional ids must not go through subparser
+    # dispatch.
+    if _argv and _argv[0] == "wait":
+        from .wait import run_wait
+
+        return run_wait(_argv[1:])
+
     parser = argparse.ArgumentParser(
         prog="li",
         description="lionagi command line — spawn subagents via any CLI-backed provider.",

--- a/lionagi/cli/state.py
+++ b/lionagi/cli/state.py
@@ -585,6 +585,7 @@ async def _doctor(
     import time as _time
 
     from lionagi.state.db import StateDB
+    from lionagi.state.reasons import SessionReasons
 
     cutoff = _time.time() - (stale_hours * 3600)
 
@@ -614,28 +615,30 @@ async def _doctor(
         swept_count = 0
         if dry_run:
             swept_count = len(victims)
-        elif victims:
-            # Re-assert status='running' in the UPDATE to avoid race with
-            # sessions that finish between select and update.
-            placeholders = ",".join(f":v{i}" for i in range(len(victims)))
-            id_params = {f"v{i}": vid for i, vid in enumerate(victims)}
-            params = {
-                "new_status": new_status,
-                "ended_at": _time.time(),
-                "cutoff": cutoff,
-                **id_params,
-            }
-            async with db._tx() as conn:
-                result = await conn.execute(
-                    text(
-                        f"UPDATE sessions SET status = :new_status, ended_at = :ended_at "  # noqa: S608
-                        f"WHERE status = 'running' "
-                        f"  AND (started_at IS NULL OR started_at < :cutoff) "
-                        f"  AND id IN ({placeholders})"
-                    ),
-                    params,
+        else:
+            # Per-row, through the single guarded write path (ADR-0094):
+            # expected_statuses={"running"} re-asserts the CAS the old bulk
+            # UPDATE did inline, and routes the sweep through update_status()
+            # so it gets a reason_code + status_transitions audit row instead
+            # of a raw column write.
+            for vid in victims:
+                transitioned = await db.update_status(
+                    "session",
+                    vid,
+                    new_status=new_status,
+                    reason_code=SessionReasons.HEALTH_STALE_NO_HEARTBEAT,
+                    reason_summary=f"doctor sweep: running longer than {stale_hours}h",
+                    source="admin",
+                    actor="doctor",
+                    expected_statuses={"running"},
                 )
-                swept_count = result.rowcount or 0
+                if transitioned:
+                    swept_count += 1
+                    async with db._tx() as conn:
+                        await conn.execute(
+                            text("UPDATE sessions SET ended_at = :ended_at WHERE id = :id"),
+                            {"ended_at": _time.time(), "id": vid},
+                        )
 
         return {"running": total, "swept": swept_count, "skipped": skipped}
 

--- a/lionagi/cli/wait.py
+++ b/lionagi/cli/wait.py
@@ -23,6 +23,7 @@ import argparse
 from collections.abc import Callable
 from typing import Any
 
+from lionagi._paths import RUNS_ROOT
 from lionagi.state.db import TERMINAL_STATUSES_BY_ENTITY_TYPE
 from lionagi.state.reasons import VALID_REASON_CODES
 
@@ -81,16 +82,19 @@ async def _refetch(db: Any, kind: str, entity_id: str) -> dict[str, Any] | None:
 
 
 async def _artifact_dir_for(db: Any, kind: str, row: dict[str, Any]) -> str | None:
-    """The run directory backing *row* — never a per-kind internal layout,
-    only the artifacts_path a backing session already carries (ADR-0029)."""
+    """The run directory (the manifest container holding `run.json`) backing
+    *row* — always ``RUNS_ROOT / <a session id>``, never a per-kind artifact
+    layout. Resolved via the backing/primary session id, whether or not that
+    directory happens to exist on disk yet; only returns ``None`` when there
+    is no backing session id to anchor on."""
     if kind == "session":
-        return row.get("artifacts_path")
+        return str(RUNS_ROOT / row["id"])
     if kind == "invocation":
         primary = await _resolve_primary_session(db, "invocation", row)
-        return primary.get("artifacts_path") if primary else None
+        return str(RUNS_ROOT / primary["id"]) if primary else None
     if kind == "play":
         primary = await _resolve_primary_session(db, "play", row)
-        return primary.get("artifacts_path") if primary else None
+        return str(RUNS_ROOT / primary["id"]) if primary else None
     if kind == "schedule_run":
         invocation_id = row.get("invocation_id")
         if not invocation_id:
@@ -99,7 +103,7 @@ async def _artifact_dir_for(db: Any, kind: str, row: dict[str, Any]) -> str | No
         if inv is None:
             return None
         primary = await _resolve_primary_session(db, "invocation", inv)
-        return primary.get("artifacts_path") if primary else None
+        return str(RUNS_ROOT / primary["id"]) if primary else None
     return None
 
 

--- a/lionagi/cli/wait.py
+++ b/lionagi/cli/wait.py
@@ -1,0 +1,291 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""`li wait <id>...` — the ADR-0094 run-completion contract.
+
+Blocks until every named run (an agent session, a play, a flow invocation, or
+a scheduled run — any kind, mixed freely) reaches a terminal state, then
+prints one frozen, tab-delimited line per run on stdout:
+
+    <run_id>\tstatus=<terminal_status>\treason=<reason_code>\t
+        artifact_dir=<run_dir>\texit_code=<n>
+
+Stdout carries contract lines only; every diagnostic goes to stderr via
+``_logging``. `wait_for_terminal()` is the reusable, importable core — it
+takes no CLI concerns (no argv, no signal handling, no printing) so other
+surfaces can await completion without shelling out; `run_wait()` is the thin
+CLI shim that resolves argv, drives the poll loop with clean SIGINT/SIGTERM
+handling (mirroring `li monitor run`'s `_dispatch_wait`), and prints.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from typing import Any
+
+from lionagi.state.db import TERMINAL_STATUSES_BY_ENTITY_TYPE
+from lionagi.state.reasons import VALID_REASON_CODES
+
+from ._logging import log_error
+from .monitor import _resolve_schedule_run, _split_watched_ids
+from .status import EXIT_RUNNING, EXIT_UNKNOWN, _resolve_any_target, _resolve_primary_session
+
+__all__ = (
+    "wait_for_terminal",
+    "run_wait",
+)
+
+# reason surfaced when a terminal record carries no (or an unrecognized)
+# reason_code — an explicit unknown, never an invented VALID_REASON_CODES value.
+_UNKNOWN_REASON = "unknown"
+
+# Per-kind "waited run succeeded" predicate, for the aggregate exit code.
+# Mirrors status.py's _SESSION_SUCCESS / _PLAY_SUCCESS: a session/invocation
+# that completed with no evidence reads as a failure, not a success.
+_SUCCESS_STATUS_BY_ENTITY_TYPE: dict[str, frozenset[str]] = {
+    "session": frozenset({"completed"}),
+    "invocation": frozenset({"completed"}),
+    "play": frozenset({"merged"}),
+    "schedule_run": frozenset({"completed"}),
+}
+
+
+async def _resolve_wait_target(db: Any, raw_id: str) -> tuple[str, dict[str, Any]] | None:
+    """Any-kind resolver: session, invocation, play (`_resolve_any_target`,
+    which also falls back to a branch_id), then schedule_run.
+
+    Terminal-state definitions are never hard-coded here — see
+    TERMINAL_STATUSES_BY_ENTITY_TYPE (lionagi/state/db.py), which lives with
+    the record schema per ADR-0094.
+    """
+    hit = await _resolve_any_target(db, raw_id)
+    if hit is not None:
+        return hit
+    row = await _resolve_schedule_run(db, raw_id)
+    if row is not None:
+        return "schedule_run", row
+    return None
+
+
+async def _refetch(db: Any, kind: str, entity_id: str) -> dict[str, Any] | None:
+    """Re-read one entity row by its canonical id, dispatched by kind."""
+    if kind == "session":
+        return await db.get_session(entity_id)
+    if kind == "invocation":
+        return await db.get_invocation(entity_id)
+    if kind == "play":
+        return await db.get_play(entity_id)
+    if kind == "schedule_run":
+        return await db.get_schedule_run(entity_id)
+    return None
+
+
+async def _artifact_dir_for(db: Any, kind: str, row: dict[str, Any]) -> str | None:
+    """The run directory backing *row* — never a per-kind internal layout,
+    only the artifacts_path a backing session already carries (ADR-0029)."""
+    if kind == "session":
+        return row.get("artifacts_path")
+    if kind == "invocation":
+        primary = await _resolve_primary_session(db, "invocation", row)
+        return primary.get("artifacts_path") if primary else None
+    if kind == "play":
+        primary = await _resolve_primary_session(db, "play", row)
+        return primary.get("artifacts_path") if primary else None
+    if kind == "schedule_run":
+        invocation_id = row.get("invocation_id")
+        if not invocation_id:
+            return None
+        inv = await db.get_invocation(invocation_id)
+        if inv is None:
+            return None
+        primary = await _resolve_primary_session(db, "invocation", inv)
+        return primary.get("artifacts_path") if primary else None
+    return None
+
+
+def _reason_for(row: dict[str, Any]) -> str:
+    code = row.get("status_reason_code")
+    return code if code in VALID_REASON_CODES else _UNKNOWN_REASON
+
+
+async def _build_outcome(db: Any, kind: str, row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "run_id": row["id"],
+        "kind": kind,
+        "status": row["status"],
+        "reason": _reason_for(row),
+        "artifact_dir": await _artifact_dir_for(db, kind, row),
+        "exit_code": row.get("exit_code"),
+        "success": row["status"] in _SUCCESS_STATUS_BY_ENTITY_TYPE.get(kind, frozenset()),
+    }
+
+
+def format_wait_line(outcome: dict[str, Any]) -> str:
+    """Render one outcome as the frozen ADR-0094 contract line."""
+    exit_code = outcome.get("exit_code")
+    exit_str = "-" if exit_code is None else str(exit_code)
+    artifact_dir = outcome.get("artifact_dir") or "-"
+    return (
+        f"{outcome['run_id']}\t"
+        f"status={outcome['status']}\t"
+        f"reason={outcome['reason']}\t"
+        f"artifact_dir={artifact_dir}\t"
+        f"exit_code={exit_str}"
+    )
+
+
+async def wait_for_terminal(
+    ids: list[str],
+    *,
+    interval: float = 1.0,
+    on_result: Callable[[dict[str, Any]], None] | None = None,
+    should_stop: Callable[[], bool] | None = None,
+) -> list[dict[str, Any]]:
+    """Block until every id in *ids* reaches a terminal state; return one
+    outcome dict per id, in the order given (ADR-0094 completion contract).
+
+    Importable and awaitable directly — no CLI concerns (argv, signals,
+    printing) live here; `run_wait()` below is the CLI shim over this core,
+    so a future push-backed mode (ADR-0092) can share the same outcome shape.
+
+    *on_result* is called once per resolved run, the moment it goes terminal
+    (or is found unresolvable), so a caller driving its own stdout can print
+    incrementally instead of waiting for the whole set to drain.
+    *should_stop* is polled between ticks so a CLI wrapper can wire SIGINT/
+    SIGTERM into a clean early return instead of blocking forever.
+    """
+    from lionagi.state.db import StateDB
+
+    order: list[str] = []
+    outcomes: dict[str, dict[str, Any]] = {}
+    pending: dict[str, str] = {}  # canonical id -> kind
+
+    async with StateDB() as db:
+        for raw_id in ids:
+            hit = await _resolve_wait_target(db, raw_id)
+            if hit is None:
+                outcome = {
+                    "run_id": raw_id,
+                    "kind": None,
+                    "status": "not_found",
+                    "reason": _UNKNOWN_REASON,
+                    "artifact_dir": None,
+                    "exit_code": None,
+                    "success": False,
+                }
+                outcomes[raw_id] = outcome
+                order.append(raw_id)
+                if on_result is not None:
+                    on_result(outcome)
+                continue
+            kind, row = hit
+            canonical_id = row["id"]
+            order.append(canonical_id)
+            terminal_statuses = TERMINAL_STATUSES_BY_ENTITY_TYPE.get(kind, frozenset())
+            if row["status"] in terminal_statuses:
+                outcome = await _build_outcome(db, kind, row)
+                outcomes[canonical_id] = outcome
+                if on_result is not None:
+                    on_result(outcome)
+            else:
+                pending[canonical_id] = kind
+
+        while pending and not (should_stop is not None and should_stop()):
+            for run_id in list(pending):
+                kind = pending[run_id]
+                row = await _refetch(db, kind, run_id)
+                if row is None:
+                    # Existed at resolution time but is gone now (e.g. cascade
+                    # delete of its parent) — resolve as unknown rather than
+                    # hang the wait on state that never comes back.
+                    outcome = {
+                        "run_id": run_id,
+                        "kind": kind,
+                        "status": "unknown",
+                        "reason": _UNKNOWN_REASON,
+                        "artifact_dir": None,
+                        "exit_code": None,
+                        "success": False,
+                    }
+                    outcomes[run_id] = outcome
+                    del pending[run_id]
+                    if on_result is not None:
+                        on_result(outcome)
+                    continue
+                terminal_statuses = TERMINAL_STATUSES_BY_ENTITY_TYPE.get(kind, frozenset())
+                if row["status"] not in terminal_statuses:
+                    continue
+                outcome = await _build_outcome(db, kind, row)
+                outcomes[run_id] = outcome
+                del pending[run_id]
+                if on_result is not None:
+                    on_result(outcome)
+            if pending and not (should_stop is not None and should_stop()):
+                import asyncio
+
+                await asyncio.sleep(interval)
+
+    return [outcomes[rid] for rid in order if rid in outcomes]
+
+
+def run_wait(argv: list[str]) -> int:
+    """Entry point for `li wait <id> [<id2> ...] [--interval SECS]`.
+
+    run_async (lionagi.ln.concurrency) installs its own SIGINT/SIGTERM
+    handlers for the duration of this call, mirroring how monitor.py's
+    `_dispatch_wait` drives its own poll loop, so Ctrl-C/SIGTERM interrupt
+    the wait cleanly instead of leaving a stray process.
+    """
+    from lionagi.ln.concurrency import SigtermInterrupt, run_async
+    from lionagi.state.db import DEFAULT_DB_PATH
+
+    parser = argparse.ArgumentParser(prog="li wait", add_help=True)
+    parser.add_argument(
+        "ids",
+        nargs="+",
+        help=(
+            "Run ID(s) (or short prefixes) to wait for — any kind (agent "
+            "session, play, flow invocation, scheduled run), comma- or "
+            "space-separated, mixed freely."
+        ),
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=1.0,
+        metavar="SECS",
+        help="Poll interval in seconds (default 1).",
+    )
+    args = parser.parse_args(argv)
+    watched_ids = _split_watched_ids(args.ids)
+    if not watched_ids:
+        parser.error("no run ids given (only empty/comma-only tokens)")
+
+    if not DEFAULT_DB_PATH.exists():
+        log_error("state.db not found — no runs recorded yet")
+        return EXIT_UNKNOWN
+
+    outcomes: list[dict[str, Any]] = []
+
+    def _on_result(outcome: dict[str, Any]) -> None:
+        if outcome["status"] == "not_found":
+            log_error(f"run {outcome['run_id']!r} not found")
+            return
+        print(format_wait_line(outcome))
+
+    # run_async installs its own SIGINT/SIGTERM handlers for the duration of
+    # this call and raises KeyboardInterrupt/SigtermInterrupt if either lands
+    # mid-wait — a still-in-progress wait is neither success nor failure.
+    interrupted = False
+    try:
+        outcomes = run_async(
+            wait_for_terminal(watched_ids, interval=args.interval, on_result=_on_result)
+        )
+    except (KeyboardInterrupt, SigtermInterrupt):
+        interrupted = True
+
+    if interrupted or len(outcomes) < len(watched_ids):
+        return EXIT_RUNNING
+    if any(o["status"] in ("not_found", "unknown") for o in outcomes):
+        return EXIT_UNKNOWN
+    return 0 if all(o["success"] for o in outcomes) else 1

--- a/lionagi/state/claude_mirror.py
+++ b/lionagi/state/claude_mirror.py
@@ -315,6 +315,13 @@ async def reconcile_session_status(
     below bumps ``updated_at``, so keying liveness off it would let a just-marked
     ``completed`` session read as fresh again on the next pass and oscillate back
     to ``running``.
+
+    ADR-0094's integrity floor treats ``completed`` as terminal on the sessions
+    table for orchestrated runs, so reactivating a mirror session out of
+    ``completed`` goes through the sanctioned override path — it is a real,
+    deliberate, well-understood write (not a repair), so it is attributed to a
+    fixed system actor rather than a human operator, and it lands in
+    admin_events like any other override.
     """
     from lionagi.state.reasons import RunReasons
 
@@ -323,12 +330,21 @@ async def reconcile_session_status(
         return
     live = (now - float(existing.get("last_message_at") or 0.0)) <= live_window
     desired = "running" if live else "completed"
-    if existing.get("status") == desired:
+    previous = existing.get("status")
+    if previous == desired:
         return
+    reactivating = previous == "completed" and desired == "running"
     await db.update_session(
         session_db_id(session_uid),
         status=desired,
         reason_code=RunReasons.STARTED_OK if desired == "running" else RunReasons.COMPLETED_OK,
+        override=reactivating,
+        override_actor="claude-mirror-reconcile" if reactivating else None,
+        override_justification=(
+            "mirror session dormancy reactivation: transcript resumed within live_window"
+            if reactivating
+            else None
+        ),
     )
 
 

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -242,8 +242,12 @@ _SESSION_STATUSES = VALID_SESSION_STATUSES
 INVOCATION_TERMINAL_STATUSES = SESSION_TERMINAL_STATUSES  # ADR-0025 vocabulary is shared
 SCHEDULE_RUN_TERMINAL_STATUSES = frozenset({"completed", "failed", "skipped", "cancelled"})
 SHOW_TERMINAL_STATUSES = frozenset({"completed", "aborted"})
-# Mirrors the "active" set kill.py's _persist_cancel already treats as
-# still-in-flight (_PLAY_ACTIVE_STATUSES); everything else is terminal.
+# Still-in-flight play statuses — the schema layer owns this vocabulary
+# (kill.py imports it rather than defining its own copy); everything else
+# in PLAY_TERMINAL_STATUSES below is terminal.
+PLAY_ACTIVE_STATUSES = frozenset(
+    {"pending", "prepared", "running", "running_complete", "gated", "redoing"}
+)
 PLAY_TERMINAL_STATUSES = frozenset(
     {"merged", "escalated", "gate_failed", "blocked", "aborted_after_finish"}
 )
@@ -256,6 +260,20 @@ TERMINAL_STATUSES_BY_ENTITY_TYPE: dict[str, frozenset[str]] = {
     "show": SHOW_TERMINAL_STATUSES,
     "play": PLAY_TERMINAL_STATUSES,
     "team": TEAM_TERMINAL_STATUSES,
+}
+
+# ── ADR-0094 status vocabulary (valid, not just terminal) ──────────────
+# update_status() rejects any new_status outside its entity_type's set here —
+# the terminal-overwrite floor above stops a terminal record from moving;
+# this stops ANY record (terminal or not) from being written to a status
+# that was never declared for its entity type.
+VALID_STATUSES_BY_ENTITY_TYPE: dict[str, frozenset[str]] = {
+    "session": VALID_SESSION_STATUSES,
+    "invocation": VALID_SESSION_STATUSES,  # shared vocabulary
+    "schedule_run": SCHEDULE_RUN_TERMINAL_STATUSES | frozenset({"pending", "running"}),
+    "show": SHOW_TERMINAL_STATUSES | frozenset({"pending", "running", "active"}),
+    "play": PLAY_ACTIVE_STATUSES | PLAY_TERMINAL_STATUSES,
+    "team": TEAM_TERMINAL_STATUSES | frozenset({"active"}),
 }
 
 
@@ -1464,6 +1482,12 @@ class StateDB:
             )
         canonical_type = _validate_entity_type_for_reason(entity_type)
         _validate_reason_code(reason_code)
+        valid_statuses = VALID_STATUSES_BY_ENTITY_TYPE.get(canonical_type)
+        if valid_statuses is not None and new_status not in valid_statuses:
+            raise ValueError(
+                f"update_status() called with new_status={new_status!r} for "
+                f"entity_type={canonical_type!r}; vocabulary is {sorted(valid_statuses)}."
+            )
         table = _reason_entity_table(canonical_type)
         now = time.time()
         terminal_statuses = TERMINAL_STATUSES_BY_ENTITY_TYPE.get(canonical_type, frozenset())
@@ -1576,8 +1600,21 @@ class StateDB:
         now: float,
     ) -> None:
         """The actual status + status_transitions write, factored out of
-        update_status() so both the ordinary and override paths share it."""
-        await conn.execute(
+        update_status() so both the ordinary and override paths share it.
+
+        The UPDATE's WHERE clause re-asserts `previous_status` (the value read
+        under the row lock in update_status()) so the compare-and-set is
+        enforced by storage itself, not only by the Python read-then-write
+        gap — a concurrent writer that changes the row between the SELECT and
+        this UPDATE loses the race at the database level. The
+        `status = :previous_status OR (status IS NULL AND :previous_status IS
+        NULL)` form is the portable NULL-safe equality: it matches a NULL
+        previous_status (sessions may have no status yet) on both SQLite and
+        PostgreSQL — unlike SQLite's `IS` extension (a NULL-safe `=` for any
+        operand pair), PostgreSQL's `IS` only accepts the NULL/TRUE/FALSE
+        keywords, not a bound parameter.
+        """
+        result = await conn.execute(
             text(
                 f"UPDATE {table} SET "  # noqa: S608
                 "  status = :status, "
@@ -1585,7 +1622,9 @@ class StateDB:
                 "  status_reason_summary = :reason_summary, "
                 "  status_evidence_refs = :evidence_refs, "
                 "  updated_at = :now "
-                "WHERE id = :id"
+                "WHERE id = :id "
+                "  AND (status = :previous_status "
+                "       OR (status IS NULL AND :previous_status IS NULL))"
             ).bindparams(bindparam("evidence_refs", type_=JSON)),
             {
                 "status": new_status,
@@ -1594,8 +1633,14 @@ class StateDB:
                 "evidence_refs": evidence_refs or [],
                 "now": now,
                 "id": entity_id,
+                "previous_status": previous_status,
             },
         )
+        if result.rowcount == 0:
+            raise RuntimeError(
+                f"status CAS lost for {canonical_type} {entity_id!r}: "
+                "row changed under update_status"
+            )
 
         await conn.execute(
             text(

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -234,12 +234,58 @@ ADMIN_TRANSITION_TARGETS = frozenset({"failed", "aborted", "cancelled"})
 
 _SESSION_STATUSES = VALID_SESSION_STATUSES
 
+# ── ADR-0094 terminal-status vocabulary ────────────────────────────────
+# Terminal-state definitions live here, with the record schema, rather than
+# in any one CLI surface — update_status() enforces them uniformly for
+# every entity_type at the single write path; `li wait` reads the same
+# tables to build its per-kind terminal predicate.
+INVOCATION_TERMINAL_STATUSES = SESSION_TERMINAL_STATUSES  # ADR-0025 vocabulary is shared
+SCHEDULE_RUN_TERMINAL_STATUSES = frozenset({"completed", "failed", "skipped", "cancelled"})
+SHOW_TERMINAL_STATUSES = frozenset({"completed", "aborted"})
+# Mirrors the "active" set kill.py's _persist_cancel already treats as
+# still-in-flight (_PLAY_ACTIVE_STATUSES); everything else is terminal.
+PLAY_TERMINAL_STATUSES = frozenset(
+    {"merged", "escalated", "gate_failed", "blocked", "aborted_after_finish"}
+)
+TEAM_TERMINAL_STATUSES = frozenset({"archived"})
+
+TERMINAL_STATUSES_BY_ENTITY_TYPE: dict[str, frozenset[str]] = {
+    "session": SESSION_TERMINAL_STATUSES,
+    "invocation": INVOCATION_TERMINAL_STATUSES,
+    "schedule_run": SCHEDULE_RUN_TERMINAL_STATUSES,
+    "show": SHOW_TERMINAL_STATUSES,
+    "play": PLAY_TERMINAL_STATUSES,
+    "team": TEAM_TERMINAL_STATUSES,
+}
+
 
 def can_transition(current: str | None, target: str) -> bool:
     """Return True iff a session may move from *current* to *target*."""
     if current != "running":
         return False
     return target in SESSION_TERMINAL_STATUSES
+
+
+class TransitionRejectedError(RuntimeError):
+    """Raised by update_status() when a write would move an entity out of a
+    terminal status without an explicit, justified override (ADR-0094)."""
+
+    def __init__(
+        self,
+        entity_type: str,
+        entity_id: str,
+        previous_status: str | None,
+        attempted_status: str,
+    ) -> None:
+        self.entity_type = entity_type
+        self.entity_id = entity_id
+        self.previous_status = previous_status
+        self.attempted_status = attempted_status
+        super().__init__(
+            f"transition rejected: {entity_type} {entity_id!r} is terminal "
+            f"at {previous_status!r}; refusing to write {attempted_status!r} "
+            "without override=True (ADR-0094)"
+        )
 
 
 _INVOCATION_KINDS = frozenset({"agent", "play", "flow", "fanout", "show-play"})
@@ -1202,6 +1248,9 @@ class StateDB:
         evidence_refs: list[dict[str, Any]] | None = None,
         reason_source: str = "executor",
         reason_actor: str | None = None,
+        override: bool = False,
+        override_actor: str | None = None,
+        override_justification: str | None = None,
         **fields: Any,
     ) -> None:
         """Update session fields; route status changes through update_status()."""
@@ -1233,6 +1282,9 @@ class StateDB:
             evidence_refs=evidence_refs,
             reason_source=reason_source,
             reason_actor=reason_actor,
+            override=override,
+            override_actor=override_actor,
+            override_justification=override_justification,
         )
 
         if fields:
@@ -1319,6 +1371,9 @@ class StateDB:
         evidence_refs: list[dict[str, Any]] | None,
         reason_source: str,
         reason_actor: str | None,
+        override: bool = False,
+        override_actor: str | None = None,
+        override_justification: str | None = None,
     ) -> None:
         status_value = fields.pop("status", None)
         if status_value is None:
@@ -1352,6 +1407,9 @@ class StateDB:
             evidence_refs=evidence_refs,
             source=reason_source,
             actor=reason_actor,
+            override=override,
+            override_actor=override_actor,
+            override_justification=override_justification,
         )
 
     async def update_status(
@@ -1367,6 +1425,9 @@ class StateDB:
         actor: str | None = None,
         metadata: dict[str, Any] | None = None,
         expected_statuses: set[str | None] | frozenset[str | None] | None = None,
+        override: bool = False,
+        override_actor: str | None = None,
+        override_justification: str | None = None,
     ) -> bool:
         """Atomically transition an entity's status and record the reason.
 
@@ -1378,17 +1439,37 @@ class StateDB:
         Returns ``True`` when the transition was applied, ``False`` when it was
         skipped because the current status was not in *expected_statuses*.  All
         existing callers that ignore the return value are unaffected.
+
+        ADR-0094 integrity floor: once an entity's status is terminal (per
+        TERMINAL_STATUSES_BY_ENTITY_TYPE), any write that would CHANGE it is
+        rejected and recorded in admin_events — a terminal record must not
+        silently move back to running or oscillate to a different terminal
+        value. A same-status write (new_status == previous_status) is not a
+        transition — it is allowed through untouched, since callers already
+        rely on it to attach/refresh a reason code on an already-terminal row
+        without that counting as leaving terminal. Pass override=True with
+        override_actor and override_justification for a deliberate
+        operational repair that does change the value; the repair is itself
+        recorded in admin_events, distinctly from an ordinary transition.
         """
         if source not in _VALID_STATUS_SOURCES:
             raise ValueError(
                 f"update_status() called with source={source!r}; "
                 f"must be one of {sorted(_VALID_STATUS_SOURCES)}."
             )
+        if override and (not override_actor or not override_justification):
+            raise ValueError(
+                "override=True requires both override_actor and "
+                "override_justification (ADR-0094 operational-repair trail)."
+            )
         canonical_type = _validate_entity_type_for_reason(entity_type)
         _validate_reason_code(reason_code)
         table = _reason_entity_table(canonical_type)
         now = time.time()
+        terminal_statuses = TERMINAL_STATUSES_BY_ENTITY_TYPE.get(canonical_type, frozenset())
 
+        rejected = False
+        overridden = False
         async with self._tx() as conn:
             # FOR UPDATE on PG to prevent read-modify-write races under MVCC.
             sel = f"SELECT status FROM {table} WHERE id = :id"  # noqa: S608
@@ -1403,55 +1484,147 @@ class StateDB:
                 # CAS guard: current status is not in the expected set — skip.
                 return False
 
-            await conn.execute(
-                text(
-                    f"UPDATE {table} SET "  # noqa: S608
-                    "  status = :status, "
-                    "  status_reason_code = :reason_code, "
-                    "  status_reason_summary = :reason_summary, "
-                    "  status_evidence_refs = :evidence_refs, "
-                    "  updated_at = :now "
-                    "WHERE id = :id"
-                ).bindparams(bindparam("evidence_refs", type_=JSON)),
-                {
-                    "status": new_status,
-                    "reason_code": reason_code,
-                    "reason_summary": reason_summary,
-                    "evidence_refs": evidence_refs or [],
-                    "now": now,
-                    "id": entity_id,
-                },
-            )
+            if previous_status in terminal_statuses and new_status != previous_status:
+                if not override:
+                    rejected = True
+                else:
+                    overridden = True
 
-            await conn.execute(
-                text(
-                    "INSERT INTO status_transitions "
-                    "(id, entity_type, entity_id, previous_status, status, "
-                    " reason_code, reason_summary, evidence_refs, "
-                    " source, actor, created_at, metadata) "
-                    "VALUES (:id, :entity_type, :entity_id, :previous_status, :status, "
-                    " :reason_code, :reason_summary, :evidence_refs, "
-                    " :source, :actor, :created_at, :metadata)"
-                ).bindparams(
-                    bindparam("evidence_refs", type_=JSON),
-                    bindparam("metadata", type_=JSON),
-                ),
-                {
-                    "id": uuid.uuid4().hex,
-                    "entity_type": canonical_type,
-                    "entity_id": entity_id,
-                    "previous_status": previous_status,
-                    "status": new_status,
-                    "reason_code": reason_code,
-                    "reason_summary": reason_summary,
-                    "evidence_refs": evidence_refs or [],
-                    "source": source,
-                    "actor": actor,
-                    "created_at": now,
-                    "metadata": metadata,
-                },
-            )
+            if rejected:
+                await conn.execute(
+                    text(
+                        "INSERT INTO admin_events "
+                        "(id, created_at, action, target_id, details, actor) "
+                        "VALUES (:id, :created_at, :action, :target_id, :details, :actor)"
+                    ).bindparams(bindparam("details", type_=JSON)),
+                    {
+                        "id": uuid.uuid4().hex[:12],
+                        "created_at": now,
+                        "action": "status_transition_rejected",
+                        "target_id": entity_id,
+                        "details": {
+                            "entity_type": canonical_type,
+                            "previous_status": previous_status,
+                            "attempted_status": new_status,
+                            "reason_code": reason_code,
+                            "source": source,
+                        },
+                        "actor": actor or source,
+                    },
+                )
+                # Do not raise inside the transaction — the rejection audit
+                # row above must commit even though the status write itself
+                # does not; raise once the `async with` block below exits.
+            else:
+                if overridden:
+                    await conn.execute(
+                        text(
+                            "INSERT INTO admin_events "
+                            "(id, created_at, action, target_id, details, actor) "
+                            "VALUES (:id, :created_at, :action, :target_id, :details, :actor)"
+                        ).bindparams(bindparam("details", type_=JSON)),
+                        {
+                            "id": uuid.uuid4().hex[:12],
+                            "created_at": now,
+                            "action": "status_transition_override",
+                            "target_id": entity_id,
+                            "details": {
+                                "entity_type": canonical_type,
+                                "previous_status": previous_status,
+                                "new_status": new_status,
+                                "reason_code": reason_code,
+                                "justification": override_justification,
+                            },
+                            "actor": override_actor,
+                        },
+                    )
+                await self._apply_status_write(
+                    conn,
+                    table,
+                    canonical_type,
+                    entity_id,
+                    previous_status=previous_status,
+                    new_status=new_status,
+                    reason_code=reason_code,
+                    reason_summary=reason_summary,
+                    evidence_refs=evidence_refs,
+                    source=source,
+                    actor=actor,
+                    metadata=metadata,
+                    now=now,
+                )
+
+        if rejected:
+            raise TransitionRejectedError(canonical_type, entity_id, previous_status, new_status)
         return True
+
+    async def _apply_status_write(
+        self,
+        conn: Any,
+        table: str,
+        canonical_type: str,
+        entity_id: str,
+        *,
+        previous_status: str | None,
+        new_status: str,
+        reason_code: str,
+        reason_summary: str,
+        evidence_refs: list[dict[str, Any]] | None,
+        source: str,
+        actor: str | None,
+        metadata: dict[str, Any] | None,
+        now: float,
+    ) -> None:
+        """The actual status + status_transitions write, factored out of
+        update_status() so both the ordinary and override paths share it."""
+        await conn.execute(
+            text(
+                f"UPDATE {table} SET "  # noqa: S608
+                "  status = :status, "
+                "  status_reason_code = :reason_code, "
+                "  status_reason_summary = :reason_summary, "
+                "  status_evidence_refs = :evidence_refs, "
+                "  updated_at = :now "
+                "WHERE id = :id"
+            ).bindparams(bindparam("evidence_refs", type_=JSON)),
+            {
+                "status": new_status,
+                "reason_code": reason_code,
+                "reason_summary": reason_summary,
+                "evidence_refs": evidence_refs or [],
+                "now": now,
+                "id": entity_id,
+            },
+        )
+
+        await conn.execute(
+            text(
+                "INSERT INTO status_transitions "
+                "(id, entity_type, entity_id, previous_status, status, "
+                " reason_code, reason_summary, evidence_refs, "
+                " source, actor, created_at, metadata) "
+                "VALUES (:id, :entity_type, :entity_id, :previous_status, :status, "
+                " :reason_code, :reason_summary, :evidence_refs, "
+                " :source, :actor, :created_at, :metadata)"
+            ).bindparams(
+                bindparam("evidence_refs", type_=JSON),
+                bindparam("metadata", type_=JSON),
+            ),
+            {
+                "id": uuid.uuid4().hex,
+                "entity_type": canonical_type,
+                "entity_id": entity_id,
+                "previous_status": previous_status,
+                "status": new_status,
+                "reason_code": reason_code,
+                "reason_summary": reason_summary,
+                "evidence_refs": evidence_refs or [],
+                "source": source,
+                "actor": actor,
+                "created_at": now,
+                "metadata": metadata,
+            },
+        )
 
     async def list_sessions(
         self,

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -271,7 +271,10 @@ VALID_STATUSES_BY_ENTITY_TYPE: dict[str, frozenset[str]] = {
     "session": VALID_SESSION_STATUSES,
     "invocation": VALID_SESSION_STATUSES,  # shared vocabulary
     "schedule_run": SCHEDULE_RUN_TERMINAL_STATUSES | frozenset({"pending", "running"}),
-    "show": SHOW_TERMINAL_STATUSES | frozenset({"pending", "running", "active"}),
+    # Shows live in {active, completed, aborted} and carry an "imported" marker
+    # for records reconstructed from an on-disk manifest — update_show() already
+    # validates against this same set before routing here.
+    "show": SHOW_TERMINAL_STATUSES | frozenset({"active", "imported"}),
     "play": PLAY_ACTIVE_STATUSES | PLAY_TERMINAL_STATUSES,
     "team": TEAM_TERMINAL_STATUSES | frozenset({"active"}),
 }

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -504,6 +504,22 @@ async def transition_sessions(
             # CAS: swap running→target only if the snapshot still holds, then
             # record the transition atomically. transaction() opens BEGIN
             # IMMEDIATE; a clean exit commits, any exception rolls back.
+            #
+            # This is an intentional, specialized snapshot-CAS write, not a
+            # bypass of the shared update_status() chokepoint: it can only
+            # ever move a session running→target (a legal forward transition;
+            # running is never terminal), so it can never overwrite a terminal
+            # status and never crosses the integrity floor. `WHERE
+            # status='running'` in the UPDATE below is the LOAD-BEARING guard
+            # for that — do not widen or drop that predicate. The additional
+            # last_message_at/updated_at snapshot equality guards are also
+            # load-bearing: they stop this reconcile from clobbering a session
+            # that became active again between health-classification and this
+            # write (the oscillation fix). Routing this through update_status()
+            # would regress that protection, since update_status()'s
+            # expected_statuses guard only compares on status, not on these
+            # snapshot columns. The transition is recorded into
+            # status_transitions below, same as update_status() would do.
             async with db.transaction() as conn:
                 result = await conn.execute(
                     text(

--- a/tests/apps_studio_server/test_admin_transition.py
+++ b/tests/apps_studio_server/test_admin_transition.py
@@ -142,3 +142,88 @@ def test_transition_refused_when_heartbeat_changes_health(tmp_path, monkeypatch)
         f"Expected reason='changed_since_snapshot', got {skipped_entry['reason']!r}. "
         "The atomicity guard should report the heartbeat-race reason, not 'not_running:running'."
     )
+
+
+# ---------------------------------------------------------------------------
+# Test: an already-terminal session is never touched by the reconcile CAS
+# ---------------------------------------------------------------------------
+
+
+async def _seed_terminal_session(
+    db_path, session_id: str, *, status: str, reason_code: str
+) -> None:
+    from lionagi.state.db import StateDB
+
+    async with StateDB(db_path) as db:
+        pid = str(uuid.uuid4())
+        await db.create_progression(pid)
+        await db.create_session(
+            {
+                "id": session_id,
+                "progression_id": pid,
+                "name": "terminal-session",
+                "status": status,
+                "started_at": time.time() - 3600,
+            }
+        )
+        await db.execute(
+            "UPDATE sessions SET status_reason_code = ? WHERE id = ?",
+            (reason_code, session_id),
+        )
+
+
+def test_transition_sessions_leaves_already_terminal_session_untouched(tmp_path, monkeypatch):
+    """The reconcile's `WHERE status='running'` CAS (lionagi/studio/services/admin.py,
+    transition_sessions) is the ADR-0094 integrity-floor guard for this write path:
+    a session already in a terminal status must never be moved, and no spurious
+    status_transitions row may be recorded for it.
+
+    This is a black-box regression test of that safety property, not a re-test of
+    the SQL guard in isolation — it drives the real transition_sessions() call the
+    Studio admin routes use.
+    """
+    from lionagi.state.db import StateDB
+
+    db_path = tmp_path / "state.db"
+    sid = str(uuid.uuid4())
+    terminal_reason_code = "run.completed.ok"
+
+    _run(_seed_terminal_session(db_path, sid, status="completed", reason_code=terminal_reason_code))
+
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.admin as adm
+
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(adm, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(adm, "_DB", str(db_path))
+
+    result = _run(
+        adm.transition_sessions(
+            session_ids=[sid],
+            target_status="failed",
+            reason_code="run.failed.exception",
+            reason_summary="attempted reconcile of an already-terminal session",
+            actor="test",
+        )
+    )
+
+    assert sid not in result["transitioned"]
+    skipped_ids = [s["session_id"] for s in result["skipped"]]
+    assert sid in skipped_ids
+
+    async def _fetch():
+        async with StateDB(db_path) as db:
+            row = await db.get_session(sid)
+            transitions = await db.fetch_all(
+                "SELECT * FROM status_transitions WHERE entity_id = ?", (sid,)
+            )
+            return row, transitions
+
+    row, transitions = _run(_fetch())
+    assert row["status"] == "completed", "Terminal status must not be overwritten"
+    assert row["status_reason_code"] == terminal_reason_code, (
+        "Terminal reason code must not be overwritten"
+    )
+    assert transitions == [], (
+        "No status_transitions row may be recorded for a reconcile that never wrote"
+    )

--- a/tests/apps_studio_server/test_cas_race_conditions.py
+++ b/tests/apps_studio_server/test_cas_race_conditions.py
@@ -1,14 +1,16 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
-"""FAIL-before / PASS-after race-condition tests for update_status CAS guard
-and orphan-cleanup in prune_old_data.
+"""Race-condition tests for update_status CAS guard and orphan-cleanup in
+prune_old_data.
 
-Each race test has two sub-phases:
-  1. _unguarded_*: calls update_status WITHOUT expected_statuses (simulates
-     the old code path) — asserts the terminal-state overwrite DOES happen
-     (demonstrates the bug was real).
-  2. _guarded_*: calls update_status WITH expected_statuses (the fix) — asserts
-     the overwrite is BLOCKED and the winner status is preserved.
+Two independent protections cover the terminal-overwrite race:
+  1. _unguarded_*: calls update_status WITHOUT expected_statuses. The write path
+     protects terminal states unconditionally — an attempt to move an entity out
+     of a terminal status without an explicit override is rejected loudly
+     (TransitionRejectedError) and the terminal status is preserved.
+  2. _guarded_*: calls update_status WITH expected_statuses. A compare-and-set
+     miss (current status not in the expected set) is a benign skip — it returns
+     False and preserves the winner status, without raising.
 """
 
 from __future__ import annotations
@@ -22,7 +24,7 @@ from sqlalchemy import text
 
 pytest.importorskip("fastapi", reason="studio extra not installed")
 
-from lionagi.state.db import StateDB  # noqa: E402
+from lionagi.state.db import StateDB, TransitionRejectedError  # noqa: E402
 
 from ._helpers import run_async  # noqa: E402
 
@@ -96,12 +98,13 @@ async def _flip_status(db_path: Path, entity_type: str, entity_id: str, new_stat
 # ── FAIL-before: phantom session race ─────────────────────────────────────────
 
 
-def test_session_race_unguarded_overwrites_terminal(tmp_path, monkeypatch):
-    """WITHOUT the CAS guard, update_status blindly overwrites 'completed'→'failed'.
+def test_session_race_unguarded_write_rejected_by_floor(tmp_path, monkeypatch):
+    """An unguarded write out of a terminal session status is rejected loudly.
 
-    This is the FAIL-before demonstration: the bug existed because there was no
-    expected_statuses check.  The unguarded call (no expected_statuses) succeeds
-    even when the session has already reached a terminal state.
+    Terminal protection does not depend on the caller remembering to pass
+    expected_statuses: the write path itself refuses to move a session out of a
+    terminal status without an explicit override, so the reaper race cannot
+    corrupt a 'completed' session into 'failed'.
     """
     from lionagi.state.reasons import SessionReasons
 
@@ -115,8 +118,6 @@ def test_session_race_unguarded_overwrites_terminal(tmp_path, monkeypatch):
     run_async(_flip_status(db_path, "session", sid, "completed"))
     assert run_async(_get_status(db_path, "session", sid)) == "completed"
 
-    # Unguarded call — no expected_statuses — should succeed (return True) and
-    # overwrite the terminal status.  This is the BUG being demonstrated.
     async def _unguarded(db_path: Path, sid: str) -> bool:
         async with StateDB(db_path) as db:
             return await db.update_status(
@@ -127,14 +128,13 @@ def test_session_race_unguarded_overwrites_terminal(tmp_path, monkeypatch):
                 reason_summary="phantom_reaped",
                 source="system",
                 actor="test_unguarded",
-                # No expected_statuses — old code path
+                # No expected_statuses and no override — the floor rejects this.
             )
 
-    result = run_async(_unguarded(db_path, sid))
-    # The unguarded path always returns True and writes regardless of current status.
-    assert result is True
-    # Confirms the overwrite happened (this is the BUG — completed→failed).
-    assert run_async(_get_status(db_path, "session", sid)) == "failed"
+    with pytest.raises(TransitionRejectedError):
+        run_async(_unguarded(db_path, sid))
+    # Terminal status preserved; the overwrite never landed.
+    assert run_async(_get_status(db_path, "session", sid)) == "completed"
 
 
 # ── PASS-after: phantom session race ──────────────────────────────────────────
@@ -180,10 +180,12 @@ def test_session_race_guarded_preserves_terminal(tmp_path, monkeypatch):
 # ── FAIL-before: invocation race ──────────────────────────────────────────────
 
 
-def test_invocation_race_unguarded_overwrites_terminal(tmp_path, monkeypatch):
-    """WITHOUT the CAS guard, update_status blindly overwrites 'completed'→'timed_out'.
+def test_invocation_race_unguarded_write_rejected_by_floor(tmp_path, monkeypatch):
+    """An unguarded write out of a terminal invocation status is rejected loudly.
 
-    FAIL-before for the invocation deadline reaper race.
+    The deadline reaper cannot corrupt a 'completed' invocation into 'timed_out':
+    the write path refuses to leave a terminal status without an explicit
+    override, independent of expected_statuses.
     """
     from lionagi.state.reasons import RunReasons
 
@@ -206,13 +208,13 @@ def test_invocation_race_unguarded_overwrites_terminal(tmp_path, monkeypatch):
                 reason_summary="invocation_deadline_exceeded",
                 source="system",
                 actor="test_unguarded",
-                # No expected_statuses — old code path
+                # No expected_statuses and no override — the floor rejects this.
             )
 
-    result = run_async(_unguarded(db_path, iid))
-    assert result is True  # Unguarded: always writes
-    # BUG: completed overwritten with timed_out.
-    assert run_async(_get_status(db_path, "invocation", iid)) == "timed_out"
+    with pytest.raises(TransitionRejectedError):
+        run_async(_unguarded(db_path, iid))
+    # Terminal status preserved.
+    assert run_async(_get_status(db_path, "invocation", iid)) == "completed"
 
 
 # ── PASS-after: invocation race ───────────────────────────────────────────────

--- a/tests/cli/test_monitor_run.py
+++ b/tests/cli/test_monitor_run.py
@@ -1322,6 +1322,29 @@ def test_run_monitor_wait_empty_string_token_rejected_as_usage_error():
 # ── CLI wiring: `li monitor run --help` / `li monitor --help` subprocess ────
 
 
+# ── ADR-0094 regression: `li monitor run` output format is untouched ───────
+
+
+@pytest.mark.asyncio
+async def test_monitor_run_output_format_byte_identical_after_adr_0094(
+    temp_db_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """The new `li wait` verb (ADR-0094) must not change a single byte of
+    `li monitor run`'s own line format — it is a distinct contract
+    (`name=`/`chain_depth=`, no `reason=`/`artifact_dir=`)."""
+    async with StateDB() as db:
+        sched_id = await _make_schedule(db, name="regression-check")
+        run_id = await _make_schedule_run(db, sched_id, status="completed", exit_code=0)
+
+    exit_code = run_monitor_wait([run_id])
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert (
+        out.strip()
+        == f"{run_id}  name=regression-check  chain_depth=0  status=completed  exit_code=0"
+    )
+
+
 def test_cli_monitor_run_help_subprocess():
     import subprocess
     import sys

--- a/tests/cli/test_wait.py
+++ b/tests/cli/test_wait.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 
+from lionagi._paths import RUNS_ROOT
 from lionagi.cli.status import EXIT_UNKNOWN
 from lionagi.cli.wait import format_wait_line, run_wait, wait_for_terminal
 from lionagi.state.db import StateDB
@@ -68,6 +69,47 @@ async def _make_play(
     return play_id
 
 
+async def _make_invocation(db: StateDB, *, status: str = "completed") -> str:
+    iid = _uid()
+    await db.create_invocation(
+        {"id": iid, "skill": "test:wait", "started_at": 0.0, "status": status}
+    )
+    return iid
+
+
+async def _make_schedule(db: StateDB) -> str:
+    sid = _uid()
+    await db.create_schedule(
+        {
+            "id": sid,
+            "name": f"sched-{sid}",
+            "trigger_type": "interval",
+            "interval_sec": 60,
+            "action_kind": "agent",
+        }
+    )
+    return sid
+
+
+async def _make_schedule_run(
+    db: StateDB, schedule_id: str, *, status: str = "completed", invocation_id: str | None = None
+) -> str:
+    rid = _uid()
+    await db.create_schedule_run(
+        {
+            "id": rid,
+            "schedule_id": schedule_id,
+            "invocation_id": invocation_id,
+            "trigger_context": {},
+            "action_kind": "agent",
+            "action_args": [],
+            "status": status,
+            "fired_at": 0.0,
+        }
+    )
+    return rid
+
+
 # ── format_wait_line ─────────────────────────────────────────────────────────
 
 
@@ -123,7 +165,27 @@ async def test_wait_for_terminal_on_session_yields_correct_reason_and_artifact_d
     assert outcome["run_id"] == sid
     assert outcome["status"] == "completed"
     assert outcome["reason"] != "unknown"
-    assert outcome["artifact_dir"] == "/tmp/session-run"
+    # artifact_dir is the run directory (manifest container), not artifacts_path.
+    assert outcome["artifact_dir"] == str(RUNS_ROOT / sid)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_terminal_artifact_dir_ignores_artifacts_path(
+    temp_db_path: Path,
+) -> None:
+    """artifact_dir must anchor on RUNS_ROOT / session_id even when the
+    session's artifacts_path column points somewhere else entirely — the
+    contract line always reports the run directory, never the artifacts
+    subdir."""
+    async with StateDB() as db:
+        sid = await _make_session(
+            db, status="completed", artifacts_path="/tmp/totally-unrelated-dir"
+        )
+
+    outcomes = await wait_for_terminal([sid])
+    assert len(outcomes) == 1
+    assert outcomes[0]["artifact_dir"] == str(RUNS_ROOT / sid)
+    assert outcomes[0]["artifact_dir"] != "/tmp/totally-unrelated-dir"
 
 
 @pytest.mark.asyncio
@@ -140,7 +202,29 @@ async def test_wait_for_terminal_on_play_yields_correct_reason_and_artifact_dir(
     outcome = outcomes[0]
     assert outcome["run_id"] == play_id
     assert outcome["status"] == "merged"
-    assert outcome["artifact_dir"] == "/tmp/play-session-run"
+    # Cross-kind: play resolves to its primary session's run dir, not the
+    # session's artifacts_path.
+    assert outcome["artifact_dir"] == str(RUNS_ROOT / sid)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_terminal_on_schedule_run_yields_backing_session_run_dir(
+    temp_db_path: Path,
+) -> None:
+    """Cross-kind: schedule_run → invocation → primary session run dir."""
+    async with StateDB() as db:
+        sid = await _make_session(db, status="completed", artifacts_path="/tmp/sched-session-run")
+        inv_id = await _make_invocation(db, status="completed")
+        await db.execute("UPDATE sessions SET invocation_id = ? WHERE id = ?", (inv_id, sid))
+        sched_id = await _make_schedule(db)
+        run_id = await _make_schedule_run(db, sched_id, status="completed", invocation_id=inv_id)
+
+    outcomes = await wait_for_terminal([run_id])
+    assert len(outcomes) == 1
+    outcome = outcomes[0]
+    assert outcome["run_id"] == run_id
+    assert outcome["kind"] == "schedule_run"
+    assert outcome["artifact_dir"] == str(RUNS_ROOT / sid)
 
 
 @pytest.mark.asyncio
@@ -197,7 +281,7 @@ def test_run_wait_prints_contract_line_for_terminal_session(
     assert len(lines) == 1
     assert lines[0].startswith(f"{sid}\tstatus=completed\t")
     assert "reason=" in lines[0]
-    assert "artifact_dir=/tmp/cli-run" in lines[0]
+    assert f"artifact_dir={RUNS_ROOT / sid}" in lines[0]
     assert "exit_code=" in lines[0]
 
 

--- a/tests/cli/test_wait.py
+++ b/tests/cli/test_wait.py
@@ -1,0 +1,235 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for `li wait <id>...` — the ADR-0094 run completion contract: one
+frozen tab-delimited line per run (`status=`/`reason=`/`artifact_dir=`/
+`exit_code=`), any run kind (session, play, invocation, schedule_run)."""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+
+from lionagi.cli.status import EXIT_UNKNOWN
+from lionagi.cli.wait import format_wait_line, run_wait, wait_for_terminal
+from lionagi.state.db import StateDB
+from lionagi.state.reasons import RunReasons
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def temp_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", db_path)
+    return db_path
+
+
+def _uid() -> str:
+    return uuid.uuid4().hex[:12]
+
+
+async def _make_session(
+    db: StateDB, *, status: str = "completed", artifacts_path: str | None = "/tmp/run-dir"
+) -> str:
+    prog_id = str(uuid.uuid4())
+    await db.create_progression(prog_id)
+    sid = _uid()
+    await db.create_session({"id": sid, "progression_id": prog_id, "status": status})
+    if artifacts_path is not None:
+        await db.execute(
+            "UPDATE sessions SET artifacts_path = ? WHERE id = ?", (artifacts_path, sid)
+        )
+    return sid
+
+
+async def _make_show(db: StateDB) -> str:
+    show_id = _uid()
+    await db.create_show(
+        {"id": show_id, "topic": f"topic-{show_id}", "show_dir": f"/tmp/show-{show_id}"}
+    )
+    return show_id
+
+
+async def _make_play(
+    db: StateDB, show_id: str, *, status: str = "merged", session_id: str | None = None
+) -> str:
+    play_id = _uid()
+    await db.create_play(
+        {
+            "id": play_id,
+            "show_id": show_id,
+            "name": f"play-{play_id}",
+            "status": status,
+            "session_id": session_id,
+        }
+    )
+    return play_id
+
+
+# ── format_wait_line ─────────────────────────────────────────────────────────
+
+
+def test_format_wait_line_is_one_frozen_tab_delimited_line() -> None:
+    line = format_wait_line(
+        {
+            "run_id": "abc123",
+            "status": "completed",
+            "reason": "run.completed.evidence_present",
+            "artifact_dir": "/tmp/run-dir",
+            "exit_code": 0,
+        }
+    )
+    assert (
+        line
+        == "abc123\tstatus=completed\treason=run.completed.evidence_present\tartifact_dir=/tmp/run-dir\texit_code=0"
+    )
+
+
+def test_format_wait_line_uses_dash_for_missing_exit_code_and_artifact_dir() -> None:
+    line = format_wait_line(
+        {
+            "run_id": "abc123",
+            "status": "failed",
+            "reason": "unknown",
+            "artifact_dir": None,
+            "exit_code": None,
+        }
+    )
+    assert line == "abc123\tstatus=failed\treason=unknown\tartifact_dir=-\texit_code=-"
+
+
+# ── Acceptance: play + session, correct reason + resolvable artifact_dir ────
+
+
+@pytest.mark.asyncio
+async def test_wait_for_terminal_on_session_yields_correct_reason_and_artifact_dir(
+    temp_db_path: Path,
+) -> None:
+    async with StateDB() as db:
+        sid = await _make_session(db, status="running", artifacts_path="/tmp/session-run")
+        await db.update_status(
+            "session",
+            sid,
+            new_status="completed",
+            reason_code=RunReasons.COMPLETED_OK,
+            source="executor",
+        )
+
+    outcomes = await wait_for_terminal([sid])
+    assert len(outcomes) == 1
+    outcome = outcomes[0]
+    assert outcome["run_id"] == sid
+    assert outcome["status"] == "completed"
+    assert outcome["reason"] != "unknown"
+    assert outcome["artifact_dir"] == "/tmp/session-run"
+
+
+@pytest.mark.asyncio
+async def test_wait_for_terminal_on_play_yields_correct_reason_and_artifact_dir(
+    temp_db_path: Path,
+) -> None:
+    async with StateDB() as db:
+        sid = await _make_session(db, status="completed", artifacts_path="/tmp/play-session-run")
+        show_id = await _make_show(db)
+        play_id = await _make_play(db, show_id, status="merged", session_id=sid)
+
+    outcomes = await wait_for_terminal([play_id])
+    assert len(outcomes) == 1
+    outcome = outcomes[0]
+    assert outcome["run_id"] == play_id
+    assert outcome["status"] == "merged"
+    assert outcome["artifact_dir"] == "/tmp/play-session-run"
+
+
+@pytest.mark.asyncio
+async def test_wait_for_terminal_on_mixed_play_and_session_ids(temp_db_path: Path) -> None:
+    async with StateDB() as db:
+        sid = await _make_session(db, status="completed", artifacts_path="/tmp/mixed-run")
+        show_id = await _make_show(db)
+        play_id = await _make_play(db, show_id, status="merged", session_id=sid)
+
+    outcomes = await wait_for_terminal([play_id, sid])
+    assert {o["run_id"] for o in outcomes} == {play_id, sid}
+    assert {o["kind"] for o in outcomes} == {"play", "session"}
+
+
+# ── Acceptance: completed-empty gets its own reason, not a bare status ──────
+
+
+@pytest.mark.asyncio
+async def test_completed_empty_session_yields_no_evidence_reason(temp_db_path: Path) -> None:
+    async with StateDB() as db:
+        sid = await _make_session(db, status="running", artifacts_path="/tmp/empty-run")
+        await db.update_status(
+            "session",
+            sid,
+            new_status="completed_empty",
+            reason_code=RunReasons.COMPLETED_EMPTY_NO_EVIDENCE,
+            source="executor",
+        )
+
+    outcomes = await wait_for_terminal([sid])
+    assert len(outcomes) == 1
+    assert outcomes[0]["status"] == "completed_empty"
+    assert outcomes[0]["reason"] == "run.completed_empty.no_evidence"
+
+
+# ── run_wait: the CLI entry point ───────────────────────────────────────────
+
+
+def test_run_wait_prints_contract_line_for_terminal_session(
+    temp_db_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    import asyncio
+
+    async def _setup() -> str:
+        async with StateDB() as db:
+            return await _make_session(db, status="completed", artifacts_path="/tmp/cli-run")
+
+    sid = asyncio.run(_setup())
+
+    exit_code = run_wait([sid])
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    lines = [ln for ln in out.splitlines() if ln]
+    assert len(lines) == 1
+    assert lines[0].startswith(f"{sid}\tstatus=completed\t")
+    assert "reason=" in lines[0]
+    assert "artifact_dir=/tmp/cli-run" in lines[0]
+    assert "exit_code=" in lines[0]
+
+
+def test_run_wait_unrecognized_reason_surfaces_unknown_sentinel_never_invents_a_code(
+    temp_db_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    import asyncio
+
+    async def _setup() -> str:
+        async with StateDB() as db:
+            sid = await _make_session(db, status="running", artifacts_path="/tmp/bogus-reason")
+            # Bypass update_status to plant an unrecognized reason code directly,
+            # simulating a legacy row VALID_REASON_CODES doesn't know about.
+            await db.execute(
+                "UPDATE sessions SET status = ?, status_reason_code = ? WHERE id = ?",
+                ("completed", "totally.made.up.code", sid),
+            )
+            return sid
+
+    sid = asyncio.run(_setup())
+
+    exit_code = run_wait([sid])
+    out = capsys.readouterr().out
+    assert "reason=unknown" in out
+    assert "totally.made.up.code" not in out
+    assert exit_code == 0
+
+
+def test_run_wait_unknown_id_returns_exit_unknown(temp_db_path: Path) -> None:
+    assert run_wait(["nonexistent-id"]) == EXIT_UNKNOWN
+
+
+def test_run_wait_requires_at_least_one_id(temp_db_path: Path) -> None:
+    with pytest.raises(SystemExit):
+        run_wait([])

--- a/tests/state/test_status_reasons.py
+++ b/tests/state/test_status_reasons.py
@@ -288,6 +288,9 @@ class TestUpdateStatusAtomic:
             new_status="failed",
             reason_code=RunReasons.FAILED_EXCEPTION,
             reason_summary="RuntimeError: x",
+            override=True,
+            override_actor="test",
+            override_justification="exercise multi-transition audit accumulation",
         )
         async with db._read() as conn:
             row = (
@@ -316,6 +319,9 @@ class TestUpdateStatusAtomic:
             sid,
             new_status="failed",
             reason_code=RunReasons.FAILED_EXCEPTION,
+            override=True,
+            override_actor="test",
+            override_justification="exercise alias route + table resolution",
         )
         async with db._read() as conn:
             rows = (

--- a/tests/state/test_transition_integrity.py
+++ b/tests/state/test_transition_integrity.py
@@ -10,9 +10,12 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 import uuid
+from unittest.mock import patch
 
 import pytest
+from sqlalchemy import text
 
 from lionagi.state.db import StateDB, TransitionRejectedError
 from lionagi.state.reasons import SessionReasons
@@ -44,6 +47,32 @@ async def _make_session(db: StateDB, *, status: str = "running") -> str:
     sid = _uid()
     await db.create_session({"id": sid, "progression_id": prog_id, "status": status})
     return sid
+
+
+async def _make_schedule_run(db: StateDB, *, status: str = "running") -> str:
+    sched_id = _uid()
+    await db.create_schedule(
+        {
+            "id": sched_id,
+            "name": f"sched-{sched_id}",
+            "trigger_type": "interval",
+            "interval_sec": 60,
+            "action_kind": "agent",
+        }
+    )
+    run_id = _uid()
+    await db.create_schedule_run(
+        {
+            "id": run_id,
+            "schedule_id": sched_id,
+            "trigger_context": {},
+            "action_kind": "agent",
+            "action_args": [],
+            "status": status,
+            "fired_at": time.time(),
+        }
+    )
+    return run_id
 
 
 # ── Rejection without override ──────────────────────────────────────────────
@@ -190,3 +219,88 @@ async def test_concurrent_stale_write_loses_to_guarded_write(db: StateDB) -> Non
 
     row = await db.get_session(sid)
     assert row["status"] == "completed"  # the first (newer) write wins
+
+
+# ── Status vocabulary — update_status() rejects unknown statuses ───────────
+
+
+@pytest.mark.asyncio
+async def test_update_status_rejects_unknown_status_for_session(db: StateDB) -> None:
+    """A status outside VALID_STATUSES_BY_ENTITY_TYPE must never persist,
+    regardless of whether the entity is currently terminal or not."""
+    sid = await _make_session(db, status="running")
+
+    with pytest.raises(ValueError, match="bogus_status"):
+        await db.update_status(
+            "session",
+            sid,
+            new_status="bogus_status",
+            reason_code=SessionReasons.HEALTH_STALE_NO_HEARTBEAT,
+            source="admin",
+        )
+
+    row = await db.get_session(sid)
+    assert row["status"] == "running"  # unchanged — the write never landed
+
+
+@pytest.mark.asyncio
+async def test_update_status_rejects_unknown_status_for_schedule_run(db: StateDB) -> None:
+    run_id = await _make_schedule_run(db, status="running")
+
+    with pytest.raises(ValueError, match="bogus_status"):
+        await db.update_status(
+            "schedule_run",
+            run_id,
+            new_status="bogus_status",
+            reason_code=SessionReasons.HEALTH_STALE_NO_HEARTBEAT,
+            source="admin",
+        )
+
+    row = await db.get_schedule_run(run_id)
+    assert row["status"] == "running"  # unchanged — the write never landed
+
+
+# ── Storage-level CAS — the UPDATE itself guards on previous_status ─────────
+
+
+@pytest.mark.asyncio
+async def test_storage_level_cas_rejects_row_changed_under_update_status(db: StateDB) -> None:
+    """_apply_status_write()'s UPDATE re-asserts previous_status at the SQL
+    level (not only via the Python expected_statuses check above it): if the
+    row changes between update_status()'s SELECT and its UPDATE, the write
+    affects zero rows and raises loudly instead of silently overwriting.
+
+    Real thread concurrency is flaky, so the race is simulated
+    deterministically: a second writer lands, on the SAME connection/
+    transaction, in between the read that update_status() already performed
+    and the guarded UPDATE — mirroring exactly the gap the SQL guard closes.
+    """
+    sid = await _make_session(db, status="running")
+
+    orig_apply = StateDB._apply_status_write
+
+    async def _apply_after_concurrent_write(self, conn, table, canonical_type, entity_id, **kwargs):
+        # Simulate a second writer landing between update_status()'s SELECT
+        # (already done — previous_status="running" is captured in kwargs)
+        # and this UPDATE.
+        await conn.execute(
+            text(f"UPDATE {table} SET status = 'completed' WHERE id = :id"),  # noqa: S608
+            {"id": entity_id},
+        )
+        return await orig_apply(self, conn, table, canonical_type, entity_id, **kwargs)
+
+    with patch.object(StateDB, "_apply_status_write", _apply_after_concurrent_write):
+        with pytest.raises(RuntimeError, match="status CAS lost"):
+            await db.update_status(
+                "session",
+                sid,
+                new_status="failed",
+                reason_code=SessionReasons.HEALTH_STALE_NO_HEARTBEAT,
+                source="executor",
+            )
+
+    # The whole transaction (the simulated concurrent write and the guarded
+    # write) rolled back on the raised error — the row is exactly as it was
+    # before update_status() was ever called, not silently left as "failed".
+    row = await db.get_session(sid)
+    assert row["status"] == "running"

--- a/tests/state/test_transition_integrity.py
+++ b/tests/state/test_transition_integrity.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""ADR-0094 integrity floor: `update_status()` is the single write path and
+refuses to move a terminal entity without an explicit, justified override.
+Every rejection and every override is recorded in admin_events; a guarded
+CAS write always beats a stale concurrent write."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+
+import pytest
+
+from lionagi.state.db import StateDB, TransitionRejectedError
+from lionagi.state.reasons import SessionReasons
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+async def db():
+    state = StateDB(":memory:")
+    await state.open()
+    yield state
+    await state.close()
+
+
+def _uid() -> str:
+    return str(uuid.uuid4())
+
+
+def _details(event: dict) -> dict:
+    """admin_events.details round-trips as a JSON string on sqlite."""
+    raw = event["details"]
+    return json.loads(raw) if isinstance(raw, str) else raw
+
+
+async def _make_session(db: StateDB, *, status: str = "running") -> str:
+    prog_id = _uid()
+    await db.create_progression(prog_id)
+    sid = _uid()
+    await db.create_session({"id": sid, "progression_id": prog_id, "status": status})
+    return sid
+
+
+# ── Rejection without override ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_terminal_to_running_rejected_without_override(db: StateDB) -> None:
+    sid = await _make_session(db, status="completed")
+
+    with pytest.raises(TransitionRejectedError):
+        await db.update_status(
+            "session",
+            sid,
+            new_status="running",
+            reason_code=SessionReasons.HEALTH_STALE_NO_HEARTBEAT,
+            source="admin",
+        )
+
+    row = await db.get_session(sid)
+    assert row["status"] == "completed"  # untouched — the write never landed
+
+
+@pytest.mark.asyncio
+async def test_rejected_transition_is_recorded_in_admin_events(db: StateDB) -> None:
+    sid = await _make_session(db, status="completed")
+
+    with pytest.raises(TransitionRejectedError):
+        await db.update_status(
+            "session",
+            sid,
+            new_status="running",
+            reason_code=SessionReasons.HEALTH_STALE_NO_HEARTBEAT,
+            source="admin",
+        )
+
+    events = await db.list_admin_events(action="status_transition_rejected", target_id=sid)
+    assert len(events) == 1
+    details = _details(events[0])
+    assert details["entity_type"] == "session"
+    assert details["previous_status"] == "completed"
+    assert details["attempted_status"] == "running"
+
+
+# ── Override path ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_terminal_to_running_succeeds_with_override(db: StateDB) -> None:
+    sid = await _make_session(db, status="completed")
+
+    applied = await db.update_status(
+        "session",
+        sid,
+        new_status="running",
+        reason_code=SessionReasons.HEALTH_STALE_NO_HEARTBEAT,
+        source="admin",
+        override=True,
+        override_actor="ocean",
+        override_justification="operational repair: mis-marked completed",
+    )
+
+    assert applied is True
+    row = await db.get_session(sid)
+    assert row["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_override_is_recorded_in_admin_events(db: StateDB) -> None:
+    sid = await _make_session(db, status="completed")
+
+    await db.update_status(
+        "session",
+        sid,
+        new_status="running",
+        reason_code=SessionReasons.HEALTH_STALE_NO_HEARTBEAT,
+        source="admin",
+        override=True,
+        override_actor="ocean",
+        override_justification="operational repair: mis-marked completed",
+    )
+
+    events = await db.list_admin_events(action="status_transition_override", target_id=sid)
+    assert len(events) == 1
+    details = _details(events[0])
+    assert details["previous_status"] == "completed"
+    assert details["new_status"] == "running"
+    assert details["justification"] == "operational repair: mis-marked completed"
+    assert events[0]["actor"] == "ocean"
+
+
+def test_override_requires_actor_and_justification() -> None:
+    async def _run() -> None:
+        state = StateDB(":memory:")
+        await state.open()
+        try:
+            sid = await _make_session(state, status="completed")
+            with pytest.raises(ValueError):
+                await state.update_status(
+                    "session",
+                    sid,
+                    new_status="running",
+                    reason_code=SessionReasons.HEALTH_STALE_NO_HEARTBEAT,
+                    source="admin",
+                    override=True,
+                )
+        finally:
+            await state.close()
+
+    asyncio.run(_run())
+
+
+# ── Concurrent stale write loses to the guarded write ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_concurrent_stale_write_loses_to_guarded_write(db: StateDB) -> None:
+    """A writer holding a stale `running` snapshot must not clobber a newer
+    terminal write that landed first — CAS on expected_statuses guards it."""
+    sid = await _make_session(db, status="running")
+
+    # The "newer" writer marks the session terminal first.
+    applied_first = await db.update_status(
+        "session",
+        sid,
+        new_status="completed",
+        reason_code=SessionReasons.HEALTH_STALE_NO_HEARTBEAT,
+        source="executor",
+        expected_statuses={"running"},
+    )
+    assert applied_first is True
+
+    # A second writer, still holding its stale "running" snapshot from
+    # before the first write landed, tries to CAS from "running" too — it
+    # must lose (skip), not silently overwrite the now-terminal status.
+    applied_second = await db.update_status(
+        "session",
+        sid,
+        new_status="failed",
+        reason_code=SessionReasons.HEALTH_STALE_NO_HEARTBEAT,
+        source="executor",
+        expected_statuses={"running"},
+    )
+    assert applied_second is False
+
+    row = await db.get_session(sid)
+    assert row["status"] == "completed"  # the first (newer) write wins

--- a/tests/state/test_transition_integrity.py
+++ b/tests/state/test_transition_integrity.py
@@ -17,7 +17,15 @@ from unittest.mock import patch
 import pytest
 from sqlalchemy import text
 
-from lionagi.state.db import StateDB, TransitionRejectedError
+from lionagi.state.db import (
+    _INVOCATION_STATUSES,
+    _PLAY_STATUSES,
+    _SHOW_STATUSES,
+    VALID_SESSION_STATUSES,
+    VALID_STATUSES_BY_ENTITY_TYPE,
+    StateDB,
+    TransitionRejectedError,
+)
 from lionagi.state.reasons import SessionReasons
 
 # ── Fixtures ────────────────────────────────────────────────────────────────
@@ -258,6 +266,27 @@ async def test_update_status_rejects_unknown_status_for_schedule_run(db: StateDB
 
     row = await db.get_schedule_run(run_id)
     assert row["status"] == "running"  # unchanged — the write never landed
+
+
+@pytest.mark.parametrize(
+    ("entity_type", "authoritative"),
+    [
+        ("session", VALID_SESSION_STATUSES),
+        ("invocation", _INVOCATION_STATUSES),
+        ("show", _SHOW_STATUSES),
+        ("play", _PLAY_STATUSES),
+    ],
+)
+def test_valid_vocabulary_admits_every_authoritative_status(
+    entity_type: str, authoritative: frozenset[str]
+) -> None:
+    """update_status()'s per-entity vocabulary must be a superset of the status
+    set that the entity's own writer (update_show/update_play/…) already blesses.
+    A legal write that the writer accepts but the floor rejects is a regression;
+    this pins the whole under-inclusion class, not one entity."""
+    vocab = VALID_STATUSES_BY_ENTITY_TYPE[entity_type]
+    missing = authoritative - vocab
+    assert not missing, f"{entity_type} vocabulary omits legal statuses: {sorted(missing)}"
 
 
 # ── Storage-level CAS — the UPDATE itself guards on previous_status ─────────


### PR DESCRIPTION
## Summary

Implements [ADR-0094](docs/adrs/ADR-0094-run-completion-contract.md) in one change: the `li wait` completion verb plus the state-integrity floor the contract depends on.

### `li wait <id>...` (new verb, `lionagi/cli/wait.py`)
- Thin CLI over an importable, reusable `wait_for_terminal()` core (poll-backed).
- Resolves run identifiers of any kind (agent session, play, flow invocation, scheduled run) through a per-kind resolver and a per-kind terminal predicate defined against the entity schema (`TERMINAL_STATUSES_BY_ENTITY_TYPE`), not hard-coded in the CLI.
- Emits exactly one frozen tab-delimited stdout line per run: `<run_id>\tstatus=<status>\treason=<code>\tartifact_dir=<dir>\texit_code=<n>`. A missing/unrecognized reason surfaces the explicit `unknown` sentinel, never an invented code. `artifact_dir` is the run directory (manifest container), never a per-kind internal layout.
- Stdout carries contract lines only; diagnostics route to stderr. Aggregate exit code is 0 iff every waited run is terminal-successful.
- Kind-aware chains: scheduler success/failure chain following applies to scheduled runs only; nothing is synthesized for other kinds.

### Integrity floor
- `update_status()` becomes the single write path enforcing terminal-state protection: any write moving an entity out of a terminal status (per `TERMINAL_STATUSES_BY_ENTITY_TYPE`) raises `TransitionRejectedError` and is recorded. An explicit override (actor + justification) is the only way through, audited in `admin_events`.
- Status writes are compare-and-set: `update_status()` guards on `expected_statuses`, so a stale concurrent write loses instead of clobbering a newer terminal value.

### Terminal-overwrite path hunt (findings)
Every status-write site was enumerated. Three paths could move an entity out of a terminal state and are fixed:
1. **`lionagi/state/claude_mirror.py` — `reconcile_session_status`**: a mirrored Claude Code session's `completed` is *dormant*, not terminal, and legitimately reactivates to `running` when its transcript resumes within the live window. Routed through the sanctioned override with a fixed system actor (`claude-mirror-reconcile`) so each reactivation is audited and distinguishable from human repair — the invariant is preserved for the orchestrated-run domain, not weakened.
2. **`lionagi/cli/kill.py` — `_persist_cancel`**: a check-then-act race could try to cancel an already-terminal run; now absorbs `TransitionRejectedError`.
3. **`lionagi/cli/state.py` — `_doctor` stale-session sweep**: was a raw bulk `UPDATE`; now writes per-row through `update_status()` with a CAS guard.

Sites confirmed already safe (no change needed): `lionagi/studio/services/admin.py` health-repair only transitions `WHERE status='running'` (CAS-guarded, never overwrites terminal); scheduler/lifecycle/launches/shows all route through `update_status()` with `expected_statuses`.

## Tests
- `tests/cli/test_wait.py`, `tests/state/test_transition_integrity.py` (new); `tests/cli/test_monitor_run.py` gains a byte-identical-output regression test pinning `li monitor run`'s line format.
- 125 targeted tests across all directly-affected files pass. Full-suite residual failures are pre-existing missing-optional-extra issues (fastapi/pandas/docling/psycopg/mcp not installed in this venv); none touch status/transition logic.

## Compatibility
Additive. `li monitor run` output is unchanged (regression-pinned). No breaking change to any existing command, format, or persisted schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)