### PR TITLE
feat(studio): skeleton loading state for the Overview

### DIFF
--- a/apps/studio/frontend/src/components/mission/AttentionQueue.tsx
+++ b/apps/studio/frontend/src/components/mission/AttentionQueue.tsx
@@ -11,8 +11,12 @@ import { Link } from "@tanstack/react-router";
 import { useTranslations } from "use-intl";
 import SectionLabel from "@/components/ui/SectionLabel";
 import Chip from "@/components/ui/Chip";
+import Skeleton from "@/components/ui/Skeleton";
 import type { AttentionItem, AttentionReason } from "./boardReducer";
 import { runDeepLink, invocationDeepLink, scheduleDeepLink } from "@/lib/runDeepLink";
+
+/** Placeholder row count while the first fetch is in flight. */
+const SKELETON_ROWS = 3;
 
 interface Props {
   items: AttentionItem[];
@@ -22,6 +26,32 @@ interface Props {
 
 /** Individual rows are reserved for actionable items; overflow lives in History. */
 const MAX_ACTIONABLE_ROWS = 6;
+
+/** Shimmering row placeholders, sized to match a real AttentionRow. */
+export function AttentionQueueSkeleton() {
+  return (
+    <div aria-hidden="true">
+      <div className="mb-2 flex items-center justify-between">
+        <Skeleton className="h-4 w-28" />
+        <Skeleton className="h-3 w-16" />
+      </div>
+      <div className="overflow-hidden rounded border border-edge">
+        {Array.from({ length: SKELETON_ROWS }, (_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-3 bg-surface-raised px-3 py-2"
+            style={{ borderTop: i === 0 ? undefined : "1px solid var(--edge-hairline)" }}
+          >
+            <Skeleton className="h-3 w-16 shrink-0" />
+            <Skeleton className="h-3 flex-1" />
+            <Skeleton className="h-5 w-12 shrink-0 rounded" />
+            <Skeleton className="h-3 w-8 shrink-0" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
 
 const ACTIONABLE_REASONS: ReadonlySet<AttentionReason> = new Set(["streak", "gated", "stuck"]);
 

--- a/apps/studio/frontend/src/components/mission/LiveBoard.tsx
+++ b/apps/studio/frontend/src/components/mission/LiveBoard.tsx
@@ -11,12 +11,16 @@ import { useTranslations } from "use-intl";
 import SectionLabel from "@/components/ui/SectionLabel";
 import StatusDot from "@/components/ui/StatusDot";
 import Chip from "@/components/ui/Chip";
+import Skeleton from "@/components/ui/Skeleton";
 import type { RunSummary } from "@/lib/types";
 import type { InvocationSummary } from "@/lib/api";
 import { runDeepLink, invocationDeepLink } from "@/lib/runDeepLink";
 
 /** Health states meaning the process is gone even though the run is non-terminal. */
 const DEAD_HEALTH = new Set(["stale", "orphaned", "zombie", "unresponsive"]);
+
+/** Placeholder card count while the first fetch is in flight. */
+const SKELETON_CARDS = 4;
 
 interface Props {
   activeRuns: RunSummary[];
@@ -116,6 +120,35 @@ function InvocationCard({ inv, nowSec }: { inv: InvocationSummary; nowSec: numbe
         )}
       </div>
     </Link>
+  );
+}
+
+/** Shimmering card placeholders, sized to match a real RunCard/InvocationCard. */
+export function LiveBoardSkeleton() {
+  return (
+    <div aria-hidden="true">
+      <div className="mb-2">
+        <Skeleton className="h-4 w-28" />
+      </div>
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
+        {Array.from({ length: SKELETON_CARDS }, (_, i) => (
+          <div
+            key={i}
+            className="flex flex-col gap-2 rounded border border-edge bg-surface-raised p-3"
+          >
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-2.5 w-2.5 shrink-0 rounded-full" />
+              <Skeleton className="h-3 flex-1" />
+              <Skeleton className="h-3 w-10 shrink-0" />
+            </div>
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-4 w-12 shrink-0 rounded" />
+              <Skeleton className="h-3 flex-1" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
   );
 }
 

--- a/apps/studio/frontend/src/components/mission/MissionControl.tsx
+++ b/apps/studio/frontend/src/components/mission/MissionControl.tsx
@@ -9,32 +9,45 @@
 
 import { useTranslations } from "use-intl";
 import StaleBadge from "./StaleBadge";
-import AttentionQueue from "./AttentionQueue";
-import LiveBoard from "./LiveBoard";
-import RecentRuns from "./RecentRuns";
-import Pulse from "./Pulse";
+import AttentionQueue, { AttentionQueueSkeleton } from "./AttentionQueue";
+import LiveBoard, { LiveBoardSkeleton } from "./LiveBoard";
+import RecentRuns, { RecentRunsSkeleton } from "./RecentRuns";
+import Pulse, { PulseSkeleton } from "./Pulse";
 import ZeroState from "./ZeroState";
+import Skeleton from "@/components/ui/Skeleton";
 import { useLiveBoard } from "./useLiveBoard";
 
 export default function MissionControl() {
   const t = useTranslations("mission");
   const board = useLiveBoard();
   const runningCount = board.activeRuns.length + board.activeInvocations.length;
+  // Skeletons are for the FIRST fetch only. dataState leaves "loading" for
+  // good on the first DATA_OK/DATA_ERROR, so later polls (including a
+  // background refresh failure) never re-trigger this branch.
+  const isInitialLoad = board.dataState === "loading";
 
   return (
-    <div className="flex w-full flex-col gap-5 px-6 py-5" aria-label={t("page.ariaLabel")}>
+    <div
+      className="flex w-full flex-col gap-5 px-6 py-5"
+      aria-label={t("page.ariaLabel")}
+      aria-busy={isInitialLoad}
+    >
       {/* Page heading row with glanceable summary */}
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-[length:var(--t-base)] font-semibold text-content-primary">
             {t("page.title")}
           </h1>
-          <p className="mt-0.5 font-data tabular-nums text-[length:var(--t-xs)] text-content-muted">
-            {t("page.summary", {
-              running: runningCount,
-              attention: board.attentionItems.length,
-            })}
-          </p>
+          {isInitialLoad ? (
+            <Skeleton className="mt-1.5 h-3 w-40" />
+          ) : (
+            <p className="mt-0.5 font-data tabular-nums text-[length:var(--t-xs)] text-content-muted">
+              {t("page.summary", {
+                running: runningCount,
+                attention: board.attentionItems.length,
+              })}
+            </p>
+          )}
         </div>
         <StaleBadge
           dataState={board.dataState}
@@ -54,8 +67,20 @@ export default function MissionControl() {
        *   Then RUNNING NOW as a full-width strip, then RECENT RUNS.
        */}
       {/* Total-empty daemon: guided cards replace the board — any work
-          exists → the real board below. */}
-      {board.systemEmpty ? (
+          exists → the real board below. Before the first successful fetch,
+          skeletons stand in for all three shapes so nothing pops in at once. */}
+      {isInitialLoad ? (
+        <>
+          <AttentionQueueSkeleton />
+          <hr className="border-t border-edge" style={{ border: "none", borderTopWidth: "1px" }} />
+          <LiveBoardSkeleton />
+          <hr className="border-t border-edge" style={{ border: "none", borderTopWidth: "1px" }} />
+          <div className="grid grid-cols-1 gap-5 xl:grid-cols-2">
+            <PulseSkeleton />
+            <RecentRunsSkeleton />
+          </div>
+        </>
+      ) : board.systemEmpty ? (
         <ZeroState />
       ) : (
         <>

--- a/apps/studio/frontend/src/components/mission/Pulse.tsx
+++ b/apps/studio/frontend/src/components/mission/Pulse.tsx
@@ -9,6 +9,7 @@
 import { useState } from "react";
 import { useTranslations } from "use-intl";
 import SectionLabel from "@/components/ui/SectionLabel";
+import Skeleton from "@/components/ui/Skeleton";
 import { usePulse } from "./usePulse";
 import { CHART_H, chartWidth, sparklineRects } from "./sparkline";
 import type { SparkRect } from "./sparkline";
@@ -42,6 +43,25 @@ function Sparkline({ buckets }: { buckets: ActivityBucket[] }) {
         />
       ))}
     </svg>
+  );
+}
+
+/** Shimmering placeholder matching the sparkline + stats card. */
+export function PulseSkeleton() {
+  return (
+    <div aria-hidden="true">
+      <div className="mb-2 flex items-center justify-between">
+        <Skeleton className="h-4 w-16" />
+        <Skeleton className="h-5 w-20 rounded" />
+      </div>
+      <div className="rounded border border-edge bg-surface-raised px-4 py-3">
+        <Skeleton className="h-10 w-full" />
+        <div className="mt-2 flex items-center justify-between">
+          <Skeleton className="h-3 w-24" />
+          <Skeleton className="h-3 w-14" />
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/apps/studio/frontend/src/components/mission/RecentRuns.tsx
+++ b/apps/studio/frontend/src/components/mission/RecentRuns.tsx
@@ -8,11 +8,40 @@ import { useTranslations } from "use-intl";
 import SectionLabel from "@/components/ui/SectionLabel";
 import StatusPill from "@/components/ui/StatusPill";
 import Duration from "@/components/ui/Duration";
+import Skeleton from "@/components/ui/Skeleton";
 import type { RunSummary } from "@/lib/types";
 
 interface Props {
   runs: RunSummary[];
   nowSec: number;
+}
+
+/** Placeholder row count while the first fetch is in flight. */
+const SKELETON_ROWS = 4;
+
+/** Shimmering row placeholders, sized to match a real recent-run row. */
+export function RecentRunsSkeleton() {
+  return (
+    <div aria-hidden="true">
+      <div className="mb-2 flex items-center justify-between">
+        <Skeleton className="h-4 w-16" />
+        <Skeleton className="h-3 w-14" />
+      </div>
+      <div className="overflow-hidden rounded border border-edge">
+        {Array.from({ length: SKELETON_ROWS }, (_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-3 bg-surface-raised px-3 py-1.5"
+            style={{ borderTop: i === 0 ? undefined : "1px solid var(--edge-hairline)" }}
+          >
+            <Skeleton className="h-4 w-11 shrink-0 rounded" />
+            <Skeleton className="h-3 flex-1" />
+            <Skeleton className="h-3 w-10 shrink-0" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }
 
 function durationSec(run: RunSummary, nowSec: number): number | null {

--- a/apps/studio/frontend/src/components/mission/skeletonLoading.test.tsx
+++ b/apps/studio/frontend/src/components/mission/skeletonLoading.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * Mission Control loading-skeleton tests.
+ *
+ * Two layers:
+ * - Reducer behavior (real, no mocking needed): "loading" only precedes the
+ *   first successful/failed fetch and is never re-entered by a background
+ *   refresh — this is the exact gate MissionControl uses to show skeletons
+ *   only on first load, never on a poll.
+ * - Source contract (matches the existing history/ test style — no
+ *   @testing-library/react in this project): the skeleton exports exist,
+ *   are wired into MissionControl ahead of the empty/live branches, and are
+ *   built from the shared shimmer atom so reduced-motion + theming stay
+ *   centralized.
+ */
+
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { boardReducer, initialBoardState } from "./boardReducer";
+import type { BoardState } from "./boardReducer";
+
+const MISSION_DIR = path.resolve(__dirname);
+const GLOBALS_CSS = path.resolve(__dirname, "../../globals.css");
+
+// ─── Reducer: "loading" is a one-time gate, not a recurring state ────────────
+
+describe("dataState — first-load gate never re-fires on refresh", () => {
+  it("starts as loading before any fetch settles", () => {
+    expect(initialBoardState().dataState).toBe("loading");
+  });
+
+  it("first DATA_OK flips loading → live and later polls stay live", () => {
+    let s: BoardState = initialBoardState();
+    s = boardReducer(s, { type: "DATA_OK", runs: [], invocations: [], schedules: null, nowSec: 1 });
+    expect(s.dataState).toBe("live");
+
+    // Simulate several subsequent background polls — none of them should
+    // ever push dataState back to "loading".
+    for (let i = 2; i <= 5; i++) {
+      s = boardReducer(s, {
+        type: "DATA_OK",
+        runs: [],
+        invocations: [],
+        schedules: null,
+        nowSec: i,
+      });
+      expect(s.dataState).not.toBe("loading");
+    }
+  });
+
+  it("a failed first fetch also leaves loading (goes to error, not back to loading)", () => {
+    let s: BoardState = initialBoardState();
+    s = boardReducer(s, { type: "DATA_ERROR", message: "boom" });
+    expect(s.dataState).toBe("error");
+    expect(s.dataState).not.toBe("loading");
+  });
+
+  it("no reducer action can set dataState back to loading once left", () => {
+    let s: BoardState = initialBoardState();
+    s = boardReducer(s, { type: "DATA_OK", runs: [], invocations: [], schedules: null, nowSec: 1 });
+    s = boardReducer(s, { type: "MARK_STALE" });
+    expect(s.dataState).toBe("stale");
+    s = boardReducer(s, { type: "DATA_ERROR", message: "refresh failed" });
+    expect(s.dataState).toBe("error");
+    // Recovery goes to "live", never "loading" — a background hiccup must
+    // never re-trigger the first-load skeleton.
+    s = boardReducer(s, { type: "DATA_OK", runs: [], invocations: [], schedules: null, nowSec: 2 });
+    expect(s.dataState).toBe("live");
+  });
+});
+
+// ─── Source contract: skeleton exports exist and mirror real shapes ──────────
+
+function read(file: string): string {
+  return fs.readFileSync(path.join(MISSION_DIR, file), "utf-8");
+}
+
+describe("section skeleton exports — shape-mirroring components", () => {
+  const cases: { file: string; symbol: string }[] = [
+    { file: "AttentionQueue.tsx", symbol: "AttentionQueueSkeleton" },
+    { file: "LiveBoard.tsx", symbol: "LiveBoardSkeleton" },
+    { file: "Pulse.tsx", symbol: "PulseSkeleton" },
+    { file: "RecentRuns.tsx", symbol: "RecentRunsSkeleton" },
+  ];
+
+  for (const { file, symbol } of cases) {
+    it(`${file} exports ${symbol}`, () => {
+      const src = read(file);
+      expect(src).toMatch(new RegExp(`export function ${symbol}`));
+    });
+
+    it(`${symbol} is hidden from assistive tech (aria-hidden placeholder, not real content)`, () => {
+      const src = read(file);
+      const fnMatch = src.match(new RegExp(`export function ${symbol}[\\s\\S]*?\\n}`));
+      expect(fnMatch).not.toBeNull();
+      expect(fnMatch?.[0]).toMatch(/aria-hidden="true"/);
+    });
+
+    it(`${symbol} builds placeholders from the shared shimmer atom`, () => {
+      const src = read(file);
+      expect(src).toMatch(/from "@\/components\/ui\/Skeleton"/);
+      const fnMatch = src.match(new RegExp(`export function ${symbol}[\\s\\S]*?\\n}`));
+      expect(fnMatch?.[0]).toMatch(/<Skeleton/);
+    });
+  }
+});
+
+describe("MissionControl.tsx — wires skeletons ahead of empty/live branches", () => {
+  const src = read("MissionControl.tsx");
+
+  it("imports all four section skeletons", () => {
+    expect(src).toMatch(/AttentionQueueSkeleton/);
+    expect(src).toMatch(/LiveBoardSkeleton/);
+    expect(src).toMatch(/PulseSkeleton/);
+    expect(src).toMatch(/RecentRunsSkeleton/);
+  });
+
+  it('gates skeletons on dataState === "loading" (not systemEmpty, not live)', () => {
+    expect(src).toMatch(/isInitialLoad = board\.dataState === "loading"/);
+  });
+
+  it("checks isInitialLoad before board.systemEmpty (skeleton wins the initial render)", () => {
+    const initialLoadIdx = src.indexOf("isInitialLoad ?");
+    const systemEmptyIdx = src.indexOf("board.systemEmpty ?");
+    expect(initialLoadIdx).toBeGreaterThan(-1);
+    expect(systemEmptyIdx).toBeGreaterThan(-1);
+    expect(initialLoadIdx).toBeLessThan(systemEmptyIdx);
+  });
+});
+
+// ─── Shared shimmer atom + reduced-motion guard stay intact ──────────────────
+
+describe("shared skeleton styling — shimmer + reduced-motion + tokens", () => {
+  it("ui/Skeleton.tsx marks its box aria-hidden and applies the shared .skeleton class", () => {
+    const src = fs.readFileSync(path.resolve(MISSION_DIR, "../ui/Skeleton.tsx"), "utf-8");
+    expect(src).toMatch(/aria-hidden="true"/);
+    expect(src).toMatch(/skeleton/);
+  });
+
+  it("globals.css defines the shimmer keyframe using design-token surfaces", () => {
+    const css = fs.readFileSync(GLOBALS_CSS, "utf-8");
+    expect(css).toMatch(/@keyframes skeleton-shimmer/);
+    expect(css).toMatch(/var\(--surface-overlay\)/);
+    expect(css).toMatch(/var\(--surface-input\)/);
+  });
+
+  it("globals.css freezes animations under prefers-reduced-motion (static fallback)", () => {
+    const css = fs.readFileSync(GLOBALS_CSS, "utf-8");
+    expect(css).toMatch(/@media \(prefers-reduced-motion: reduce\)/);
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces the plain-text loading state on the Overview (Mission Control) page with shimmering skeleton placeholders that mirror the real layout (attention rows, running-now cards, pulse/recent-runs section), so the page is obviously loading instead of popping in text then content all at once.
- Skeletons render only on the very first fetch (`dataState === "loading"`) and never re-appear on background refreshes — a failed or slow poll after the first successful load stays on the last-known content plus the existing stale/error badge, it never re-shows skeletons.
- No new CSS: reuses the existing shared `Skeleton` atom and `.skeleton` shimmer keyframes, which already respect `prefers-reduced-motion` globally.

## Components added
- `AttentionQueueSkeleton` (`AttentionQueue.tsx`) — header + 3 bordered rows mirroring a real attention row's reason/name/badge/age fields.
- `LiveBoardSkeleton` (`LiveBoard.tsx`) — header + responsive 4-card grid mirroring a run/invocation card's dot/name/elapsed and chip/id rows.
- `PulseSkeleton` (`Pulse.tsx`) — header + card with a sparkline-shaped bar and a stats row.
- `RecentRunsSkeleton` (`RecentRuns.tsx`) — header + 4 bordered rows mirroring a recent-run row's status pill, name, and duration.

All four are wired into `MissionControl.tsx` ahead of the empty/live branches, with matching spacing/separators so no layout shift occurs when real content swaps in.

## Test plan
- [x] `npm ci`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` (all tests pass, including new `skeletonLoading.test.tsx` covering the reducer's first-load gate and the skeleton wiring)
- [x] `npm run build`