### PR TITLE
fix(studio): bound the Fleet detail Events section with a fixed scroll region

### DIFF
--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -577,7 +577,7 @@ function EventsSection({ events, live }: { events: SignalEvent[]; live: boolean 
           )}
         </div>
       ) : (
-        <div className="rounded border border-edge bg-surface-raised">
+        <div className="max-h-72 overflow-y-auto rounded border border-edge bg-surface-raised">
           <div className="flex flex-col divide-y divide-edge-subtle">
             {events.map((ev) => {
               const badge = KIND_BADGE[ev.kind] ?? {
@@ -692,7 +692,9 @@ export default function RunDetail({ id, fullPage = false }: RunDetailProps) {
           }
         }
         const graph = (s as unknown as Record<string, unknown>).graph as
-          { nodes: WorkerGraph["nodes"]; edges: WorkerGraph["edges"] } | null | undefined;
+          | { nodes: WorkerGraph["nodes"]; edges: WorkerGraph["edges"] }
+          | null
+          | undefined;
         if (graph && graph.nodes && graph.nodes.length > 0) {
           setRunGraph({
             name: s.name || id,
@@ -970,11 +972,17 @@ export default function RunDetail({ id, fullPage = false }: RunDetailProps) {
     errorCount: errors.length,
     partialWindow,
     showTopic: (session as unknown as Record<string, unknown>).show_topic as
-      string | null | undefined,
+      | string
+      | null
+      | undefined,
     showPlayName: (session as unknown as Record<string, unknown>).show_play_name as
-      string | null | undefined,
+      | string
+      | null
+      | undefined,
     playbookName: (session as unknown as Record<string, unknown>).playbook_name as
-      string | null | undefined,
+      | string
+      | null
+      | undefined,
   };
 
   const content = (


### PR DESCRIPTION
## Summary

- The Fleet detail's Events list (`EventsSection` in `RunDetail.tsx`, shared by both the Fleet detail pane and the History detail pane) had no height cap or scroll boundary — it grew with every new lifecycle event and stretched the detail pane, so the page's own scrollbar carried the load instead of the section scrolling in place.
- Capped the populated-events container at `max-h-72 overflow-y-auto`, mirroring the existing Files section's bounded-scroll treatment in the same file (`max-h-56 overflow-y-auto`) — same visual language (rounded border, `bg-surface-raised`), same "own scrollbar, page stays put" behavior.
- No scroll-to-bottom logic is attached to the Events box, so new events streaming in never move the operator's scroll position. The page-level "scroll to newest on first load" behavior (guarded to fire once per session, already in place for the Files fix) is untouched.

## Before / after

- **Before**: Events rendered as a plain unbounded list; a long-running session's event list pushed the whole detail pane taller, and the browser/page scrollbar had to cover both the fixed chrome and the ever-growing events.
- **After**: Events render inside a fixed ~288px box with its own scrollbar. Verified live against a real Studio session with 65 accumulated signal events: the box's `scrollHeight` (2047px) far exceeds its `clientHeight` (286px) while the surrounding page's `scrollHeight === clientHeight` (907 === 907, i.e. zero page-level overflow). Scrolling the box (`scrollTop` 0 → 500) left `window.scrollY` at 0 throughout.

## Test plan

- [x] `npm ci`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` (395/395 passing)
- [x] `npm run build`
- [x] Live-verified against the running Studio daemon (`vite preview` proxying to `127.0.0.1:8765`) with a real session carrying 65 signal events: bounded box confirmed via DOM measurement + screenshots, page-level scroll confirmed unaffected, scroll position confirmed stable while idle on an actively-streaming session.
- [x] No e2e spec touches Fleet detail Events (checked `e2e/smoke.spec.ts`) — nothing to adjust there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)