### PR TITLE
test(studio): add coverage for schedule runs list endpoint; 500 report not reproducible

### DIFF
--- a/tests/apps_studio_server/test_schedule_runs_route.py
+++ b/tests/apps_studio_server/test_schedule_runs_route.py
@@ -1,0 +1,155 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for GET /api/schedules/{schedule_id}/runs.
+
+Covers a previously-untested route: pagination, status filtering, and
+serialization of JSON columns (including a run carrying a large multi-line
+traceback in error_detail, the shape a genuinely failed scheduled run has
+in production).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from lionagi.state.db import StateDB  # noqa: E402
+from lionagi.studio.services.schedules import create_schedule  # noqa: E402
+
+
+async def _seed_schedule() -> str:
+    created = await create_schedule(
+        {
+            "name": f"runs-route-test-{uuid.uuid4().hex[:8]}",
+            "trigger_type": "cron",
+            "cron_expr": "0 18 * * *",
+            "action_kind": "agent",
+            "action_prompt": "ping",
+        }
+    )
+    return created["id"]
+
+
+async def _seed_run(
+    schedule_id: str,
+    *,
+    status: str,
+    fired_at: float,
+    error_detail: str | None = None,
+    chain_depth: int = 0,
+) -> None:
+    async with StateDB() as db:
+        await db.create_schedule_run(
+            {
+                "id": str(uuid.uuid4()),
+                "schedule_id": schedule_id,
+                "trigger_context": {"source": "cron"},
+                "action_kind": "agent",
+                "action_args": {"prompt": "ping"},
+                "status": status,
+                "chain_depth": chain_depth,
+                "fired_at": fired_at,
+                "error_detail": error_detail,
+            }
+        )
+
+
+def _patch_db(monkeypatch, db_path: Path) -> None:
+    """Point both the StateDB default and the schedules service's own bound
+    name at the temp path -- must run before any seeding, or seed writes
+    land in the real default DB."""
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.schedules as schedules_mod
+
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(schedules_mod, "DEFAULT_DB_PATH", db_path)
+
+
+def _make_client() -> TestClient:
+    from lionagi.studio.app import app
+
+    return TestClient(app, base_url="http://127.0.0.1:8765")
+
+
+def test_completed_and_failed_runs_serialize_with_200(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    now = time.time()
+
+    async def seed():
+        sid = await _seed_schedule()
+        await _seed_run(sid, status="completed", fired_at=now - 20)
+        await _seed_run(
+            sid,
+            status="failed",
+            fired_at=now - 10,
+            error_detail=(
+                "Traceback (most recent call last):\n"
+                '  File "engine.py", line 42, in fire\n'
+                "pydantic_core.ValidationError: Provider must be specified\n"
+            ),
+        )
+        return sid
+
+    sid = asyncio.run(seed())
+    client = _make_client()
+
+    resp = client.get(f"/api/schedules/{sid}/runs", params={"limit": 25})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["limit"] == 25
+    assert body["offset"] == 0
+    assert len(body["runs"]) == 2
+    assert {r["status"] for r in body["runs"]} == {"completed", "failed"}
+
+    failed = next(r for r in body["runs"] if r["status"] == "failed")
+    assert "ValidationError" in failed["error_detail"]
+    assert isinstance(failed["trigger_context"], dict)
+    assert isinstance(failed["action_args"], dict)
+
+
+def test_unknown_schedule_id_returns_empty_200(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    client = _make_client()
+
+    resp = client.get("/api/schedules/does-not-exist/runs", params={"limit": 25})
+
+    assert resp.status_code == 200
+    assert resp.json() == {"runs": [], "limit": 25, "offset": 0, "has_next": False}
+
+
+def test_status_filter_and_pagination(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    now = time.time()
+
+    async def seed():
+        sid = await _seed_schedule()
+        for i in range(3):
+            await _seed_run(sid, status="completed", fired_at=now - i)
+        await _seed_run(sid, status="failed", fired_at=now - 100)
+        return sid
+
+    sid = asyncio.run(seed())
+    client = _make_client()
+
+    resp = client.get(f"/api/schedules/{sid}/runs", params={"status": "failed", "limit": 25})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["runs"]) == 1
+    assert body["runs"][0]["status"] == "failed"
+
+    resp = client.get(f"/api/schedules/{sid}/runs", params={"limit": 2})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["runs"]) == 2
+    assert body["has_next"] is True


### PR DESCRIPTION
## Summary

Investigated a report that `GET /api/schedules/{schedule_id}/runs?limit=25` returns
HTTP 500 for a specific schedule. **Could not reproduce the 500** against the current
code or the current database state, so no fix is included -- see Findings below. What
this PR does add: regression test coverage for the route, which had none.

## Investigation

- Traced the full path: route handler (`list_schedule_runs_route`) -> service
  (`list_schedule_runs`) -> `StateDB.list_schedule_runs` -> `_row_to_dict` JSON-column
  deserialization. No unguarded exception path for a GET request.
- Called the service function directly against the real database for the reported
  schedule id: returns both rows (one `completed`, one genuinely `failed` run with a
  large multi-line traceback in `error_detail`) with no error.
- Hit the route via an in-process `TestClient` against the real database: 200.
- Hit both currently-running studio daemons (ports 8765 and 8766) with the exact
  reported URL: 200 from both.
- Swept every schedule in the database (12 total) through this same endpoint: 0/12
  failures.
- Searched all available daemon logs for any historical 500 on this route: none found.
- Read the full middleware chain in front of the route (Host-header validation,
  bearer-token gate, Content-Type/CSRF check, CORS) -- all either short-circuit for
  GET requests or have no exception path reachable from this request shape.
- Confirmed there's no schema drift: `StateDB.open()` always applies the canonical
  `state/schema.sql` (which matches the production table exactly, including columns
  like `status_reason_code` not present in the schedules-service module's own legacy
  bootstrap DDL) before any query runs, so a fresh test database and the production
  database have the same `schedule_runs` shape.

## What this PR adds

`tests/apps_studio_server/test_schedule_runs_route.py`:
- 200 with correctly-serialized rows for a mix of `completed` and `failed` runs
  (including a realistic multi-line `error_detail` traceback)
- unknown `schedule_id` returns an empty list with 200, not a 404
- `status` filter and `limit`/`offset` pagination

## Test plan

- [x] `uv run pytest tests/apps_studio_server/test_schedule_runs_route.py -v` -- 3 passed
- [x] `uv run pytest tests/apps_studio_server/` -- full suite green, no regressions
- [x] `uv run pytest tests/studio/` -- full suite green, no regressions
- [x] `uv run ruff check` / `ruff format --check` on the new file -- clean
- [x] Re-ran the original reported request against both live daemons after the change: still 200

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>