### PR TITLE
fix(studio): base Fleet/Mission attention on health, not run age

### DIFF
--- a/apps/studio/frontend/src/components/fleet/fleetReducer.test.ts
+++ b/apps/studio/frontend/src/components/fleet/fleetReducer.test.ts
@@ -222,12 +222,10 @@ describe("fleetReducer — counts strip", () => {
   });
 
   it("stuck agent raises attention count", () => {
-    const nowSec = 2_000_000;
     const s = dispatchOk(
       initialFleetState(),
       [],
-      [makeRun({ run_id: "r1", status: "running", started_at: nowSec - 4000 })],
-      nowSec,
+      [makeRun({ run_id: "r1", status: "running", effective_health: "unresponsive" })],
     );
     expect(s.counts.attention).toBe(1);
   });
@@ -246,7 +244,6 @@ describe("fleetReducer — attention flagging on org units", () => {
   });
 
   it("invocation with stuck child agent is flagged", () => {
-    const nowSec = 2_000_000;
     const s = dispatchOk(
       initialFleetState(),
       [makeInvocation({ id: "i1", status: "running", skill: "s" })],
@@ -255,10 +252,9 @@ describe("fleetReducer — attention flagging on org units", () => {
           run_id: "r1",
           status: "running",
           invocation_id: "i1",
-          started_at: nowSec - 4000,
+          effective_health: "unresponsive",
         }),
       ],
-      nowSec,
     );
     expect(s.orgUnits[0].needsAttention).toBe(true);
   });

--- a/apps/studio/frontend/src/components/fleet/fleetReducer.ts
+++ b/apps/studio/frontend/src/components/fleet/fleetReducer.ts
@@ -26,6 +26,7 @@ export interface AgentRow {
   id: string;
   name: string;
   status: string;
+  effectiveHealth: string | null;
   elapsedSec: number | null;
   branch_count: number;
   message_count: number;
@@ -117,7 +118,9 @@ const ATTENTION_STATUSES = new Set([
   "needs_review",
   "blocked",
 ]);
-const STUCK_THRESHOLD_SEC = 60 * 60;
+
+/** Health verdicts that flag a running row for attention. */
+const ATTENTION_HEALTH = new Set(["unresponsive", "stale", "orphaned", "zombie"]);
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -135,8 +138,10 @@ function isActive(status: string): boolean {
 function needsAttention(row: AgentRow): boolean {
   const s = row.status.toLowerCase();
   if (ATTENTION_STATUSES.has(s)) return true;
-  if (RUNNING_STATUSES.has(s) && row.elapsedSec != null && row.elapsedSec > STUCK_THRESHOLD_SEC) {
-    return true;
+  // Flag a running row on its health verdict, never its age: a days-old session
+  // still emitting activity is healthy, not stuck.
+  if (RUNNING_STATUSES.has(s) && row.effectiveHealth != null) {
+    return ATTENTION_HEALTH.has(row.effectiveHealth);
   }
   return false;
 }
@@ -175,6 +180,7 @@ function buildOrgUnits(
       id: run.run_id,
       name: run.playbook_name ?? run.agent_name ?? run.run_id.slice(-12),
       status: run.status,
+      effectiveHealth: run.effective_health ?? null,
       elapsedSec: elapsed,
       branch_count: run.branch_count ?? 0,
       message_count: run.message_count ?? 0,

--- a/apps/studio/frontend/src/components/mission/boardReducer.test.ts
+++ b/apps/studio/frontend/src/components/mission/boardReducer.test.ts
@@ -196,23 +196,12 @@ describe("boardReducer — attention queue derivation", () => {
     expect(s.attentionItems[0].reason).toBe("stale");
   });
 
-  it("stale health does not demote a stuck run — stuck wins", () => {
-    const nowSec = 2_000_000;
-    const s = dispatchOk(
-      initialBoardState(),
-      [
-        makeRun({
-          run_id: "r1",
-          status: "running",
-          effective_health: "stale",
-          started_at: nowSec - 4000,
-        }),
-      ],
-      [],
-      nowSec,
-    );
+  it("orphaned health flags a running run as stale", () => {
+    const s = dispatchOk(initialBoardState(), [
+      makeRun({ run_id: "r1", status: "running", effective_health: "orphaned" }),
+    ]);
     expect(s.attentionItems).toHaveLength(1);
-    expect(s.attentionItems[0].reason).toBe("stuck");
+    expect(s.attentionItems[0].reason).toBe("stale");
   });
 
   it("stale health does not demote a gated run — gated wins", () => {
@@ -223,15 +212,10 @@ describe("boardReducer — attention queue derivation", () => {
     expect(s.attentionItems[0].reason).toBe("gated");
   });
 
-  it("stuck run (elapsed > threshold) appears in attention queue", () => {
-    const nowSec = 2_000_000;
-    const startedAt = nowSec - 4000; // 4000s > 3600s threshold
-    const s = dispatchOk(
-      initialBoardState(),
-      [makeRun({ run_id: "r1", status: "running", started_at: startedAt })],
-      [],
-      nowSec,
-    );
+  it("unresponsive health flags a running run as stuck", () => {
+    const s = dispatchOk(initialBoardState(), [
+      makeRun({ run_id: "r1", status: "running", effective_health: "unresponsive" }),
+    ]);
     expect(s.attentionItems[0].reason).toBe("stuck");
   });
 
@@ -248,11 +232,10 @@ describe("boardReducer — attention queue derivation", () => {
 
   it("sorts gated before stuck before failed before stale", () => {
     const nowSec = 2_000_000;
-    const stuckStart = nowSec - 4000;
     const s = dispatchOk(
       initialBoardState(),
       [
-        makeRun({ run_id: "stuck", status: "running", started_at: stuckStart }),
+        makeRun({ run_id: "stuck", status: "running", effective_health: "unresponsive" }),
         makeRun({ run_id: "failed", status: "failed", started_at: nowSec - 600 }),
         makeRun({ run_id: "gated", status: "gated" }),
         makeRun({ run_id: "stale", status: "running", effective_health: "stale" }),
@@ -269,15 +252,14 @@ describe("boardReducer — attention queue derivation", () => {
 
   it("deduplicates: a run that matches multiple criteria appears once (worst reason)", () => {
     const nowSec = 2_000_000;
-    const stuckStart = nowSec - 4000;
-    // Same run: failed AND stuck — should appear once as "failed"
+    // Same run: failed status AND stale health — should appear once as "failed"
     const s = dispatchOk(
       initialBoardState(),
       [
         makeRun({
           run_id: "r1",
           status: "failed",
-          started_at: stuckStart,
+          started_at: nowSec - 600,
           effective_health: "stale",
         }),
       ],

--- a/apps/studio/frontend/src/components/mission/boardReducer.ts
+++ b/apps/studio/frontend/src/components/mission/boardReducer.ts
@@ -104,9 +104,6 @@ const TERMINAL_STATUSES = new Set([
 ]);
 const GATED_STATUSES = new Set(["needs_review", "blocked", "gated"]);
 
-/** Runs stalled longer than this (seconds) are flagged "stuck". */
-const STUCK_THRESHOLD_SEC = 60 * 60;
-
 /** Failures older than this belong to History, not the attention queue. */
 const FAILED_ATTENTION_WINDOW_SEC = 24 * 60 * 60;
 
@@ -121,13 +118,6 @@ function failedRecently(
   const ref = endedAt ?? startedAt;
   if (ref == null) return false;
   return nowSec - ref <= FAILED_ATTENTION_WINDOW_SEC;
-}
-
-// ─── Derivation helpers ───────────────────────────────────────────────────────
-
-function elapsedSec(startedAt: number | null, nowSec: number): number | null {
-  if (startedAt == null) return null;
-  return nowSec - startedAt;
 }
 
 function buildAttentionItems(
@@ -164,13 +154,16 @@ function buildAttentionItems(
       reason = "failed";
     } else if (GATED_STATUSES.has(s)) {
       reason = "gated";
-    } else if (RUNNING_STATUSES.has(s)) {
-      const elapsed = elapsedSec(run.started_at ?? null, nowSec);
-      if (elapsed != null && elapsed > STUCK_THRESHOLD_SEC) reason = "stuck";
+    } else if (RUNNING_STATUSES.has(s) && run.effective_health === "unresponsive") {
+      // Stuck is the honest health verdict (alive but quiet past its threshold),
+      // never run age: a long-lived session still emitting activity is healthy.
+      reason = "stuck";
     }
     if (
       reason == null &&
-      (run.effective_health === "stale" || run.effective_health === "orphaned")
+      (run.effective_health === "stale" ||
+        run.effective_health === "orphaned" ||
+        run.effective_health === "zombie")
     ) {
       reason = "stale";
     }

--- a/lionagi/studio/services/runs.py
+++ b/lionagi/studio/services/runs.py
@@ -482,7 +482,7 @@ def _run_row(s: dict[str, Any], now: float, *, process_alive: bool | None = None
     branch_count / message_count / last_message_at, plus tri-state process
     liveness (None = unknown) so a process-dead run cannot render as healthy.
     """
-    from lionagi.state.health import SessionHealth, classify_session_health
+    from lionagi.state.health import classify_session_health
 
     health = classify_session_health(
         s,
@@ -491,9 +491,8 @@ def _run_row(s: dict[str, Any], now: float, *, process_alive: bool | None = None
         has_artifacts=bool(s.get("artifacts_path")),
         has_stale_locks=False,
     )
-    effective_health = (
-        SessionHealth.STALE.value if health == SessionHealth.UNRESPONSIVE else health.value
-    )
+    # Expose the classifier verdict verbatim; the dashboard maps UNRESPONSIVE→"stuck".
+    effective_health = health.value
     return {
         "run_id": s["id"],
         "id": s["id"],

--- a/tests/apps_studio_server/test_runs_list.py
+++ b/tests/apps_studio_server/test_runs_list.py
@@ -198,22 +198,22 @@ async def _seed_running_session_with_activity(
         )
 
 
-def test_runs_list_threshold_crossing_session_reports_stale_not_unresponsive(tmp_path, monkeypatch):
-    """Running session past its kind-aware threshold → effective_health='stale'.
+def test_runs_list_threshold_crossing_alive_session_reports_unresponsive(tmp_path, monkeypatch):
+    """Running session, process alive, past its kind-aware threshold → 'unresponsive'.
 
-    The full ADR-0024 classifier returns UNRESPONSIVE (process alive + past
-    threshold), but the dashboard frontend counts effective_health==='stale'.
-    The runs list MUST map UNRESPONSIVE → 'stale' so the dashboard counter
-    stays correct.
+    The runs list exposes the classifier verdict verbatim: a live-but-quiet
+    session is UNRESPONSIVE, distinct from a process-dead 'stale' run. The
+    dashboard maps 'unresponsive' onto a "stuck" attention row.
     """
     db_path = tmp_path / "state.db"
     sid = str(uuid.uuid4())
-    # last_message_at = 7h ago; agent threshold = 6h → UNRESPONSIVE without fix
+    # last_message_at = 7h ago; agent threshold = 6h; process alive → UNRESPONSIVE
     old_activity = time.time() - 7 * 3600
     _run(_seed_running_session_with_activity(db_path, sid, last_message_at=old_activity))
     client = _make_client(tmp_path, monkeypatch, db_path)
-    # Pin liveness to True: this test asserts the UNRESPONSIVE→'stale' mapping,
-    # not the liveness oracle (the seeded session has no real process).
+    # Pin liveness to True so the classifier yields UNRESPONSIVE (alive + past
+    # threshold), not the process-dead STALE path — the seeded session has no
+    # real process to probe.
     monkeypatch.setattr("lionagi.studio.services.runs._session_liveness", lambda *a, **k: True)
 
     r = client.get("/api/runs")
@@ -221,9 +221,9 @@ def test_runs_list_threshold_crossing_session_reports_stale_not_unresponsive(tmp
     runs = r.json()["runs"]
     target = next((run for run in runs if run["id"] == sid), None)
     assert target is not None, "seeded session not found in runs list"
-    assert target["effective_health"] == "stale", (
-        f"expected 'stale', got {target['effective_health']!r}; "
-        "UNRESPONSIVE must be mapped to 'stale' for dashboard compatibility"
+    assert target["effective_health"] == "unresponsive", (
+        f"expected 'unresponsive', got {target['effective_health']!r}; "
+        "a live-but-quiet session must surface as UNRESPONSIVE, not collapsed to 'stale'"
     )
 
 


### PR DESCRIPTION
## Problem

The Overview flagged long-lived sessions as **STUCK · NO PROGRESS** purely because they had been running for a long time, even while they were actively emitting work. Attention was derived from elapsed run age, which conflates "old" with "stuck" — a false positive for any healthy long-running session.

## Fix — honest, health-based attention

- **backend** (`studio/services/runs.py`): stop collapsing `UNRESPONSIVE` into `STALE` in the `effective_health` field. Expose the session-health classifier verdict verbatim for both the list and detail routes:
  - `unresponsive` = process alive but quiet past its idle threshold
  - `stale`/`orphaned`/`zombie` = process gone
- **frontend** (`boardReducer`, `fleetReducer`): a running row raises attention only when its `effective_health` is `unresponsive`/`stale`/`orphaned`/`zombie`, **never** on run age. A days-old session still emitting activity reads as healthy.
- tests drive state through `effective_health` instead of a synthetic `started_at` age.

## Verification

- Frontend (`apps/studio/frontend`): `tsc --noEmit` ✓ · `vitest run` 395/395 ✓ · `eslint` ✓
- Backend: `tests/apps_studio_server/test_runs_list.py` 10/10 ✓ (studio extra)

Part of the Studio Mission Control design pass (#109).

🤖 Generated with [Claude Code](https://claude.com/claude-code)