### PR TITLE
feat(studio): port the Leo operator backend to the route registry

### DIFF
--- a/lionagi/studio/registry.py
+++ b/lionagi/studio/registry.py
@@ -57,6 +57,7 @@ _STUDIO_ROUTE_MODULES: tuple[str, ...] = (
     "lionagi.studio.services.engine_defs",
     "lionagi.studio.services.workflow_defs",
     "lionagi.studio.services.sessions",
+    "lionagi.studio.services.leo",
     "lionagi.studio.services.admin",
     "lionagi.studio.services.schedules",
     "lionagi.studio.services.stats",

--- a/lionagi/studio/services/leo.py
+++ b/lionagi/studio/services/leo.py
@@ -1,0 +1,345 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Leo: the Studio operator agent — session registry, tool definitions, and routes.
+
+Security boundary: mutating tools never execute. They return a proposed_action
+dict; the frontend confirms and calls the real studio endpoint directly. The
+Leo backend never writes studio state.
+
+UI driving: ui_command tools return a declarative command dict the frontend
+executes client-side (navigation, form prefill). Commands never mutate server
+state.
+
+Sessions are in-memory; a server restart clears history. Auth is the studio
+bearer-token gate applied at the app-level middleware, same as every other
+route.
+"""
+
+# NOTE: no `from __future__ import annotations` — the Leo tool callables are
+# introspected by function_to_schema, which requires real (non-string)
+# parameter annotations.
+
+import json
+import time
+import uuid
+from typing import Any
+
+from pydantic import BaseModel
+
+from lionagi._errors import NotFoundError
+from lionagi.config import settings
+
+from ..registry import studio_route
+from ._sse import sse_response
+
+# ---------------------------------------------------------------------------
+# Session registry
+# ---------------------------------------------------------------------------
+
+
+class LeoSession:
+    def __init__(self, session_id: str) -> None:
+        self.id = session_id
+        self.branch: Any = None  # lionagi.session.branch.Branch, built lazily
+
+
+_SESSIONS: dict[str, LeoSession] = {}
+
+
+def create_session() -> LeoSession:
+    sid = str(uuid.uuid4())
+    sess = LeoSession(sid)
+    _SESSIONS[sid] = sess
+    return sess
+
+
+def get_session(session_id: str) -> LeoSession | None:
+    return _SESSIONS.get(session_id)
+
+
+# ---------------------------------------------------------------------------
+# Branch factory
+# ---------------------------------------------------------------------------
+
+_SYSTEM_PROMPT = (
+    "You are Leo — the resident operator of Lion Studio, working alongside the "
+    "human operator. You inspect runs, invocations, sessions, playbooks, and "
+    "schedules with read-only tools, and you drive the Studio UI itself.\n\n"
+    "UI driving: when the operator asks to SEE something, do not just describe "
+    "it — call show_in_ui to bring the right view up on their screen (failed "
+    "runs → space='history' with status='failed'; what's scheduled → "
+    "space='schedules'). Pair it with a read-only tool call so your text answer "
+    "carries the facts.\n\n"
+    "Routines: when the operator asks to set up a recurring task, work out the "
+    "name, the cadence as a 5-field cron expression, and the prompt the "
+    "scheduled agent should run, then call prefill_schedule. That opens the "
+    "create form filled in for the operator to review and confirm — you never "
+    "create schedules yourself.\n\n"
+    "Mutating actions (launch_playbook, create_playbook, run_maintenance) "
+    "surface a proposed_action for the operator to confirm; you never execute "
+    "them yourself.\n\n"
+    "Keep responses terse and factual."
+)
+
+
+def build_branch() -> Any:
+    """Construct a Branch with the studio default model and all Leo tools registered."""
+    from lionagi.service.manager import iModel
+    from lionagi.session.branch import Branch
+
+    chat_model = iModel(
+        provider=settings.LIONAGI_CHAT_PROVIDER,
+        model=settings.LIONAGI_CHAT_MODEL,
+    )
+    return Branch(
+        system=_SYSTEM_PROMPT,
+        chat_model=chat_model,
+        tools=_all_tools(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool definitions
+# ---------------------------------------------------------------------------
+
+
+def _all_tools() -> list:
+    """Return all Leo tool callables."""
+    return [
+        tool_list_runs,
+        tool_list_invocations,
+        tool_list_sessions,
+        tool_list_playbooks,
+        tool_get_playbook,
+        tool_list_schedules,
+        tool_studio_doctor,
+        tool_show_in_ui,
+        tool_prefill_schedule,
+        tool_launch_playbook,
+        tool_create_playbook,
+        tool_run_maintenance,
+    ]
+
+
+# -- read-only tools ---------------------------------------------------------
+
+
+async def tool_list_runs(page: int = 1, per_page: int = 10) -> dict[str, Any]:
+    """List recent studio runs (read-only)."""
+    from lionagi.studio.services import runs as runs_svc
+
+    raw = await runs_svc.list_runs()
+    return runs_svc.paginate_runs(raw, page=page, per_page=per_page)
+
+
+async def tool_list_invocations(limit: int = 10, offset: int = 0) -> dict[str, Any]:
+    """List recent invocations (read-only)."""
+    from lionagi.studio.services import invocations as inv_svc
+
+    rows = await inv_svc.list_invocations(limit=limit, offset=offset)
+    return {"invocations": rows}
+
+
+async def tool_list_sessions(limit: int = 10) -> dict[str, Any]:
+    """List recent agent sessions (read-only)."""
+    from lionagi.studio.services import sessions as sess_svc
+
+    rows = await sess_svc.list_sessions()
+    return {"sessions": rows[:limit]}
+
+
+async def tool_list_playbooks() -> dict[str, Any]:
+    """List available playbooks (read-only)."""
+    from lionagi.studio.services import playbooks as pb_svc
+
+    return {"playbooks": pb_svc.list_playbooks()}
+
+
+async def tool_get_playbook(name: str) -> dict[str, Any]:
+    """Get details for a specific playbook by name (read-only)."""
+    from lionagi.studio.services import playbooks as pb_svc
+
+    result = pb_svc.get_playbook(name)
+    if result is None:
+        return {"error": f"Playbook '{name}' not found"}
+    return result
+
+
+async def tool_list_schedules() -> dict[str, Any]:
+    """List configured schedules (read-only)."""
+    from lionagi.studio.services import schedules as sched_svc
+
+    return {"schedules": await sched_svc.list_schedules()}
+
+
+async def tool_studio_doctor() -> dict[str, Any]:
+    """Run the studio doctor health check (read-only)."""
+    from lionagi.studio.services import admin as admin_svc
+
+    return await admin_svc.doctor(stale_hours=1.0)
+
+
+# -- UI-drive tools (client-executed, never touch server state) --------------
+
+_UI_SPACES = {
+    "mission",
+    "history",
+    "fleet",
+    "designer",
+    "library",
+    "schedules",
+    "system",
+}
+
+_UI_STATUSES = {"failed", "running", "completed", "cancelled", "pending"}
+
+
+async def tool_show_in_ui(space: str, status: str = "", tab: str = "") -> dict[str, Any]:
+    """Bring a Studio view up on the operator's screen. Spaces: mission, history, fleet, designer, library, schedules, system. For history, optional status filter (failed/running/completed/cancelled/pending) and tab (run/invocation/show)."""
+    space = space.strip().lower()
+    if space not in _UI_SPACES:
+        return {"error": f"Unknown space '{space}'. Choose one of: {', '.join(sorted(_UI_SPACES))}"}
+    params: dict[str, str] = {}
+    if status:
+        status = status.strip().lower()
+        if status not in _UI_STATUSES:
+            return {
+                "error": f"Unknown status '{status}'. Choose one of: {', '.join(sorted(_UI_STATUSES))}"
+            }
+        params["status"] = status
+    if tab:
+        params["tab"] = tab.strip().lower()
+    return {"ui_command": {"kind": "navigate", "space": space, "params": params}}
+
+
+async def tool_prefill_schedule(
+    name: str, cron_expr: str, action_prompt: str, description: str = ""
+) -> dict[str, Any]:
+    """Open the schedule-creation form pre-filled for the operator to review and confirm. cron_expr is a 5-field cron expression; action_prompt is the instruction the scheduled agent runs each firing. Does not create anything."""
+    return {
+        "ui_command": {
+            "kind": "prefill_schedule",
+            "space": "schedules",
+            "params": {
+                "name": name,
+                "cron": cron_expr,
+                "prompt": action_prompt,
+                "desc": description,
+            },
+        }
+    }
+
+
+# -- mutating tools (proposal only — never execute) -------------------------
+
+
+async def tool_launch_playbook(name: str, note: str = "") -> dict[str, Any]:
+    """Propose launching a playbook. Returns a proposed_action — does not execute."""
+    return {
+        "proposed_action": {
+            "kind": "launch_playbook",
+            "params": {"name": name},
+            "description": f"Launch playbook '{name}'" + (f" — {note}" if note else ""),
+            "endpoint": "POST /api/launches/",
+        }
+    }
+
+
+async def tool_create_playbook(
+    name: str, description: str = "", prompt: str = ""
+) -> dict[str, Any]:
+    """Propose creating a new playbook. Returns a proposed_action — does not execute."""
+    return {
+        "proposed_action": {
+            "kind": "create_playbook",
+            "params": {"name": name, "description": description, "prompt": prompt},
+            "description": f"Create playbook '{name}'",
+            "endpoint": f"POST /api/playbooks/{name}",
+        }
+    }
+
+
+async def tool_run_maintenance(action: str) -> dict[str, Any]:
+    """Propose a DB maintenance action (vacuum/checkpoint/prune). Returns a proposed_action — does not execute."""
+    if action not in ("vacuum", "checkpoint", "prune"):
+        return {
+            "error": f"Unknown maintenance action '{action}'. Choose vacuum, checkpoint, or prune."
+        }
+    return {
+        "proposed_action": {
+            "kind": "run_maintenance",
+            "params": {"action": action},
+            "description": f"Run DB maintenance: {action}",
+            "endpoint": "POST /api/admin/maintenance",
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# Route handlers — leo area
+# ---------------------------------------------------------------------------
+
+
+class _MessageBody(BaseModel):
+    content: str
+
+
+def _emit(event: dict[str, Any]) -> str:
+    return f"data: {json.dumps(event)}\n\n"
+
+
+async def _run_turn(sess: LeoSession, user_content: str):
+    """Run one Leo turn against the session's Branch, streaming SSE events.
+
+    Scans only the messages the Branch.ReAct() call appends during this turn
+    for tool outputs carrying proposed_action / ui_command, so a proposal
+    surfaced on an earlier turn never resurfaces on a later one.
+    """
+    from lionagi.protocols.messages.action_response import ActionResponse
+
+    if sess.branch is None:
+        sess.branch = build_branch()
+
+    before = len(sess.branch.messages)
+    try:
+        text = await sess.branch.ReAct(instruction=user_content)
+    except Exception as exc:
+        yield _emit({"type": "error", "detail": str(exc)})
+        yield _emit({"type": "done", "ts": time.time()})
+        return
+
+    new_messages = list(sess.branch.messages)[before:]
+    for msg in new_messages:
+        if not isinstance(msg, ActionResponse):
+            continue
+        output = getattr(msg.content, "output", None)
+        if not isinstance(output, dict):
+            continue
+        if "ui_command" in output:
+            yield _emit({"type": "ui_command", "command": output["ui_command"]})
+        if "proposed_action" in output:
+            yield _emit({"type": "proposed_action", "action": output["proposed_action"]})
+
+    yield _emit({"type": "text", "content": text if isinstance(text, str) else str(text)})
+    yield _emit({"type": "done", "ts": time.time()})
+
+
+@studio_route("/leo/sessions", method="POST", area="leo", name="create_leo_session")
+async def create_leo_session_route() -> dict[str, str]:
+    sess = create_session()
+    return {"id": sess.id}
+
+
+@studio_route(
+    "/leo/sessions/{session_id}/messages",
+    method="POST",
+    area="leo",
+    name="send_leo_message",
+    response_class=None,
+)
+async def send_leo_message_route(session_id: str, body: _MessageBody):
+    sess = get_session(session_id)
+    if sess is None:
+        raise NotFoundError(f"Leo session '{session_id}' not found")
+
+    return sse_response(_run_turn(sess, body.content))

--- a/lionagi/studio/services/leo.py
+++ b/lionagi/studio/services/leo.py
@@ -19,11 +19,15 @@ route.
 # introspected by function_to_schema, which requires real (non-string)
 # parameter annotations.
 
+import asyncio
 import json
 import time
 import uuid
+from functools import partial
 from typing import Any
 
+import anyio
+from fastapi import HTTPException
 from pydantic import BaseModel
 
 from lionagi._errors import NotFoundError
@@ -36,17 +40,45 @@ from ._sse import sse_response
 # Session registry
 # ---------------------------------------------------------------------------
 
+# Bounded so a long-running server doesn't grow this dict forever: capacity
+# eviction drops the least-recently-used session, and idle eviction sweeps
+# sessions nobody has touched in a while. Both run lazily on create/access —
+# there is no background timer.
+_MAX_SESSIONS = 50
+_IDLE_EXPIRY_SECONDS = 2 * 60 * 60
+
 
 class LeoSession:
     def __init__(self, session_id: str) -> None:
         self.id = session_id
         self.branch: Any = None  # lionagi.session.branch.Branch, built lazily
+        self.created_at = time.time()
+        self.last_used_at = self.created_at
+        self.lock = asyncio.Lock()
 
 
 _SESSIONS: dict[str, LeoSession] = {}
 
 
+def _evict_idle(now: float) -> None:
+    stale = [
+        sid for sid, sess in _SESSIONS.items() if now - sess.last_used_at > _IDLE_EXPIRY_SECONDS
+    ]
+    for sid in stale:
+        del _SESSIONS[sid]
+
+
+def _evict_lru_if_full() -> None:
+    if len(_SESSIONS) < _MAX_SESSIONS:
+        return
+    lru_id = min(_SESSIONS, key=lambda sid: _SESSIONS[sid].last_used_at)
+    del _SESSIONS[lru_id]
+
+
 def create_session() -> LeoSession:
+    now = time.time()
+    _evict_idle(now)
+    _evict_lru_if_full()
     sid = str(uuid.uuid4())
     sess = LeoSession(sid)
     _SESSIONS[sid] = sess
@@ -54,7 +86,11 @@ def create_session() -> LeoSession:
 
 
 def get_session(session_id: str) -> LeoSession | None:
-    return _SESSIONS.get(session_id)
+    _evict_idle(time.time())
+    sess = _SESSIONS.get(session_id)
+    if sess is not None:
+        sess.last_used_at = time.time()
+    return sess
 
 
 # ---------------------------------------------------------------------------
@@ -67,9 +103,9 @@ _SYSTEM_PROMPT = (
     "schedules with read-only tools, and you drive the Studio UI itself.\n\n"
     "UI driving: when the operator asks to SEE something, do not just describe "
     "it — call show_in_ui to bring the right view up on their screen (failed "
-    "runs → space='history' with status='failed'; what's scheduled → "
-    "space='schedules'). Pair it with a read-only tool call so your text answer "
-    "carries the facts.\n\n"
+    "runs or a specific run/session → space='fleet' with status='failed'; "
+    "what's scheduled → space='schedules'). Pair it with a read-only tool call "
+    "so your text answer carries the facts.\n\n"
     "Routines: when the operator asks to set up a recurring task, work out the "
     "name, the cadence as a 5-field cron expression, and the prompt the "
     "scheduled agent should run, then call prefill_schedule. That opens the "
@@ -152,14 +188,15 @@ async def tool_list_playbooks() -> dict[str, Any]:
     """List available playbooks (read-only)."""
     from lionagi.studio.services import playbooks as pb_svc
 
-    return {"playbooks": pb_svc.list_playbooks()}
+    result = await anyio.to_thread.run_sync(pb_svc.list_playbooks)
+    return {"playbooks": result}
 
 
 async def tool_get_playbook(name: str) -> dict[str, Any]:
     """Get details for a specific playbook by name (read-only)."""
     from lionagi.studio.services import playbooks as pb_svc
 
-    result = pb_svc.get_playbook(name)
+    result = await anyio.to_thread.run_sync(partial(pb_svc.get_playbook, name))
     if result is None:
         return {"error": f"Playbook '{name}' not found"}
     return result
@@ -183,7 +220,6 @@ async def tool_studio_doctor() -> dict[str, Any]:
 
 _UI_SPACES = {
     "mission",
-    "history",
     "fleet",
     "designer",
     "library",
@@ -195,7 +231,7 @@ _UI_STATUSES = {"failed", "running", "completed", "cancelled", "pending"}
 
 
 async def tool_show_in_ui(space: str, status: str = "", tab: str = "") -> dict[str, Any]:
-    """Bring a Studio view up on the operator's screen. Spaces: mission, history, fleet, designer, library, schedules, system. For history, optional status filter (failed/running/completed/cancelled/pending) and tab (run/invocation/show)."""
+    """Bring a Studio view up on the operator's screen. Spaces: mission, fleet, designer, library, schedules, system. For fleet, optional status filter (failed/running/completed/cancelled/pending) and tab (run/invocation/show)."""
     space = space.strip().lower()
     if space not in _UI_SPACES:
         return {"error": f"Unknown space '{space}'. Choose one of: {', '.join(sorted(_UI_SPACES))}"}
@@ -293,7 +329,8 @@ async def _run_turn(sess: LeoSession, user_content: str):
 
     Scans only the messages the Branch.ReAct() call appends during this turn
     for tool outputs carrying proposed_action / ui_command, so a proposal
-    surfaced on an earlier turn never resurfaces on a later one.
+    surfaced on an earlier turn never resurfaces on a later one. Must only be
+    called while holding sess.lock (see send_leo_message_route).
     """
     from lionagi.protocols.messages.action_response import ActionResponse
 
@@ -324,6 +361,15 @@ async def _run_turn(sess: LeoSession, user_content: str):
     yield _emit({"type": "done", "ts": time.time()})
 
 
+async def _run_turn_locked(sess: LeoSession, user_content: str):
+    """Wrap _run_turn, releasing sess.lock once the stream is fully consumed or aborted."""
+    try:
+        async for chunk in _run_turn(sess, user_content):
+            yield chunk
+    finally:
+        sess.lock.release()
+
+
 @studio_route("/leo/sessions", method="POST", area="leo", name="create_leo_session")
 async def create_leo_session_route() -> dict[str, str]:
     sess = create_session()
@@ -342,4 +388,13 @@ async def send_leo_message_route(session_id: str, body: _MessageBody):
     if sess is None:
         raise NotFoundError(f"Leo session '{session_id}' not found")
 
-    return sse_response(_run_turn(sess, body.content))
+    if sess.lock.locked():
+        raise HTTPException(
+            status_code=409,
+            detail=f"Leo session '{session_id}' is already processing a message",
+        )
+    # No await between the check above and this acquire, so no other request
+    # can interleave: acquiring an unlocked asyncio.Lock never suspends.
+    await sess.lock.acquire()
+
+    return sse_response(_run_turn_locked(sess, body.content))

--- a/tests/apps_studio_server/test_leo.py
+++ b/tests/apps_studio_server/test_leo.py
@@ -7,6 +7,8 @@ No network or real LLM calls — the Branch is monkey-patched with a fake ReAct(
 
 from __future__ import annotations
 
+import threading
+import time
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -73,6 +75,52 @@ def test_leo_create_session_unique_ids(tmp_path, monkeypatch):
     client = _make_client(tmp_path, monkeypatch)
     ids = {client.post("/api/leo/sessions").json()["id"] for _ in range(3)}
     assert len(ids) == 3
+
+
+# ---------------------------------------------------------------------------
+# Session registry bounds: capacity eviction (LRU) and idle expiry
+# ---------------------------------------------------------------------------
+
+
+def test_session_registry_evicts_lru_over_cap(monkeypatch):
+    from lionagi.studio.services import leo as leo_svc
+
+    monkeypatch.setattr(leo_svc, "_MAX_SESSIONS", 3)
+
+    ids = [leo_svc.create_session().id for _ in range(3)]
+    now = time.time()
+    leo_svc._SESSIONS[ids[0]].last_used_at = now + 10
+    leo_svc._SESSIONS[ids[1]].last_used_at = now  # oldest -> evicted
+    leo_svc._SESSIONS[ids[2]].last_used_at = now + 20
+
+    new_sess = leo_svc.create_session()
+
+    assert ids[1] not in leo_svc._SESSIONS
+    assert ids[0] in leo_svc._SESSIONS
+    assert ids[2] in leo_svc._SESSIONS
+    assert new_sess.id in leo_svc._SESSIONS
+    assert len(leo_svc._SESSIONS) == 3
+
+
+def test_session_registry_expires_idle_sessions():
+    from lionagi.studio.services import leo as leo_svc
+
+    sess = leo_svc.create_session()
+    sess.last_used_at = time.time() - leo_svc._IDLE_EXPIRY_SECONDS - 1
+
+    assert leo_svc.get_session(sess.id) is None
+    assert sess.id not in leo_svc._SESSIONS
+
+
+def test_session_registry_idle_eviction_runs_on_create():
+    from lionagi.studio.services import leo as leo_svc
+
+    stale = leo_svc.create_session()
+    stale.last_used_at = time.time() - leo_svc._IDLE_EXPIRY_SECONDS - 1
+
+    leo_svc.create_session()
+
+    assert stale.id not in leo_svc._SESSIONS
 
 
 # ---------------------------------------------------------------------------
@@ -168,8 +216,12 @@ def test_leo_tool_registry_shape():
 
 
 @pytest.mark.asyncio
-async def test_tool_launch_playbook_returns_proposal():
+async def test_tool_launch_playbook_returns_proposal(monkeypatch):
+    from lionagi.studio.services import launches as launches_svc
     from lionagi.studio.services.leo import tool_launch_playbook
+
+    mock_launch = AsyncMock()
+    monkeypatch.setattr(launches_svc, "launch", mock_launch)
 
     result = await tool_launch_playbook("my-playbook")
     assert "proposed_action" in result
@@ -178,28 +230,48 @@ async def test_tool_launch_playbook_returns_proposal():
     assert pa["params"]["name"] == "my-playbook"
     assert "endpoint" in pa
     # Must not have triggered any network call or service mutation
+    mock_launch.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_tool_create_playbook_returns_proposal():
+async def test_tool_create_playbook_returns_proposal(monkeypatch):
+    from lionagi.studio.services import playbooks as playbooks_svc
     from lionagi.studio.services.leo import tool_create_playbook
+
+    mock_create = AsyncMock()
+    mock_update = MagicMock()
+    monkeypatch.setattr(playbooks_svc, "create_playbook", mock_create)
+    monkeypatch.setattr(playbooks_svc, "update_playbook", mock_update)
 
     result = await tool_create_playbook("new-pb", description="A test playbook")
     assert "proposed_action" in result
     pa = result["proposed_action"]
     assert pa["kind"] == "create_playbook"
     assert pa["params"]["name"] == "new-pb"
+    mock_create.assert_not_called()
+    mock_update.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_tool_run_maintenance_returns_proposal():
+async def test_tool_run_maintenance_returns_proposal(monkeypatch):
+    from lionagi.studio.services import db_maintenance as db_maint_svc
     from lionagi.studio.services.leo import tool_run_maintenance
+
+    mock_vacuum = AsyncMock()
+    mock_checkpoint = AsyncMock()
+    mock_prune = AsyncMock()
+    monkeypatch.setattr(db_maint_svc, "vacuum_state_db", mock_vacuum)
+    monkeypatch.setattr(db_maint_svc, "checkpoint_state_db", mock_checkpoint)
+    monkeypatch.setattr(db_maint_svc, "prune_old_data", mock_prune)
 
     result = await tool_run_maintenance("vacuum")
     assert "proposed_action" in result
     pa = result["proposed_action"]
     assert pa["kind"] == "run_maintenance"
     assert pa["params"]["action"] == "vacuum"
+    mock_vacuum.assert_not_called()
+    mock_checkpoint.assert_not_called()
+    mock_prune.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -220,11 +292,11 @@ async def test_tool_run_maintenance_invalid_action():
 async def test_tool_show_in_ui_navigate_with_filter():
     from lionagi.studio.services.leo import tool_show_in_ui
 
-    result = await tool_show_in_ui("history", status="failed")
+    result = await tool_show_in_ui("fleet", status="failed")
     assert "ui_command" in result
     cmd = result["ui_command"]
     assert cmd["kind"] == "navigate"
-    assert cmd["space"] == "history"
+    assert cmd["space"] == "fleet"
     assert cmd["params"] == {"status": "failed"}
 
 
@@ -241,7 +313,7 @@ async def test_tool_show_in_ui_rejects_unknown_space():
 async def test_tool_show_in_ui_rejects_unknown_status():
     from lionagi.studio.services.leo import tool_show_in_ui
 
-    result = await tool_show_in_ui("history", status="exploded")
+    result = await tool_show_in_ui("fleet", status="exploded")
     assert "error" in result
     assert "ui_command" not in result
 
@@ -367,7 +439,7 @@ def test_leo_message_turn_ui_command_surfaced(tmp_path, monkeypatch):
     sess = leo_svc.get_session(sid)
     assert sess is not None
 
-    command = {"kind": "navigate", "space": "history", "params": {"status": "failed"}}
+    command = {"kind": "navigate", "space": "fleet", "params": {"status": "failed"}}
 
     fake_msg = ActionResponse(
         content={"function": "tool_show_in_ui", "output": {"ui_command": command}}
@@ -413,7 +485,7 @@ def test_leo_prior_turn_proposals_not_reemitted(tmp_path, monkeypatch):
             "function": "tool_launch_playbook",
             "output": {
                 "proposed_action": {"kind": "launch_playbook", "params": {}},
-                "ui_command": {"kind": "navigate", "space": "history", "params": {}},
+                "ui_command": {"kind": "navigate", "space": "fleet", "params": {}},
             },
         }
     )
@@ -434,6 +506,53 @@ def test_leo_prior_turn_proposals_not_reemitted(tmp_path, monkeypatch):
     assert "ui_command" not in types
     assert "text" in types
     assert "done" in types
+
+
+# ---------------------------------------------------------------------------
+# Concurrent turns on the same session: the second must 409, never interleave
+# ---------------------------------------------------------------------------
+
+
+def test_leo_concurrent_turn_second_gets_409(tmp_path, monkeypatch):
+    client = _make_client(tmp_path, monkeypatch)
+
+    with client:
+        sid = client.post("/api/leo/sessions").json()["id"]
+
+        from lionagi.studio.services import leo as leo_svc
+
+        sess = leo_svc.get_session(sid)
+        assert sess is not None
+
+        async def slow_react(**_kwargs):
+            import asyncio
+
+            await asyncio.sleep(0.3)
+            return "done"
+
+        branch = MagicMock()
+        branch.messages = []
+        branch.ReAct = AsyncMock(side_effect=slow_react)
+        sess.branch = branch
+
+        results: dict[str, Any] = {}
+
+        def _post(key: str) -> None:
+            results[key] = client.post(
+                f"/api/leo/sessions/{sid}/messages",
+                json={"content": "hello"},
+            )
+
+        t1 = threading.Thread(target=_post, args=("first",))
+        t1.start()
+        time.sleep(0.1)  # let the first request acquire the session lock
+        t2 = threading.Thread(target=_post, args=("second",))
+        t2.start()
+        t1.join(timeout=5)
+        t2.join(timeout=5)
+
+    assert results["first"].status_code == 200
+    assert results["second"].status_code == 409
 
 
 # ---------------------------------------------------------------------------

--- a/tests/apps_studio_server/test_leo.py
+++ b/tests/apps_studio_server/test_leo.py
@@ -1,0 +1,460 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Leo (Studio operator agent) endpoints.
+
+No network or real LLM calls — the Branch is monkey-patched with a fake ReAct().
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from lionagi.protocols.messages.action_response import ActionResponse
+
+fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
+from fastapi.testclient import TestClient  # noqa: E402
+
+
+def _make_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    """Patch studio service roots and return a TestClient."""
+    fake_db = tmp_path / "state.db"
+
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.definitions as defs_mod
+    import lionagi.studio.services.sessions as sessions_mod
+    import lionagi.studio.services.shows as shows_mod
+    import lionagi.studio.services.stats as stats_mod
+
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
+    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", fake_db)
+    monkeypatch.setattr(sessions_mod, "_DB", str(fake_db))
+    monkeypatch.setattr(shows_mod, "DEFAULT_DB_PATH", fake_db)
+    monkeypatch.setattr(shows_mod, "_DB", str(fake_db))
+    monkeypatch.setattr(defs_mod, "DEFAULT_DB_PATH", fake_db)
+    monkeypatch.setattr(defs_mod, "_DB", str(fake_db))
+    monkeypatch.setattr(stats_mod, "DEFAULT_DB_PATH", fake_db)
+    monkeypatch.setattr(stats_mod, "_DB", str(fake_db))
+
+    from lionagi.studio.app import app
+
+    return TestClient(app, base_url="http://127.0.0.1:8765")
+
+
+@pytest.fixture(autouse=True)
+def _clear_leo_sessions():
+    """Reset the in-memory Leo session registry between tests."""
+    from lionagi.studio.services import leo as leo_svc
+
+    leo_svc._SESSIONS.clear()
+    yield
+    leo_svc._SESSIONS.clear()
+
+
+# ---------------------------------------------------------------------------
+# Session create
+# ---------------------------------------------------------------------------
+
+
+def test_leo_create_session(tmp_path, monkeypatch):
+    client = _make_client(tmp_path, monkeypatch)
+    r = client.post("/api/leo/sessions")
+    assert r.status_code == 200
+    data = r.json()
+    assert "id" in data
+    assert isinstance(data["id"], str)
+    assert len(data["id"]) == 36  # UUID
+
+
+def test_leo_create_session_unique_ids(tmp_path, monkeypatch):
+    client = _make_client(tmp_path, monkeypatch)
+    ids = {client.post("/api/leo/sessions").json()["id"] for _ in range(3)}
+    assert len(ids) == 3
+
+
+# ---------------------------------------------------------------------------
+# 404 on unknown session
+# ---------------------------------------------------------------------------
+
+
+def test_leo_message_unknown_session(tmp_path, monkeypatch):
+    client = _make_client(tmp_path, monkeypatch)
+    r = client.post(
+        "/api/leo/sessions/does-not-exist/messages",
+        json={"content": "hello"},
+    )
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Auth gate — the studio bearer-token middleware guards /api/leo like any
+# other /api/* route; no per-route auth code, so this proves the mount point
+# lands under the guarded prefix.
+# ---------------------------------------------------------------------------
+
+
+def test_leo_requires_bearer_when_token_set(tmp_path, monkeypatch):
+    monkeypatch.setenv("LIONAGI_STUDIO_AUTH_TOKEN", "test-leo-secret")
+    from importlib import reload
+
+    import lionagi.studio.app as app_mod
+
+    reload(app_mod)
+    client = TestClient(
+        app_mod.app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765"
+    )
+    try:
+        r = client.post("/api/leo/sessions")
+        assert r.status_code == 401
+    finally:
+        monkeypatch.delenv("LIONAGI_STUDIO_AUTH_TOKEN", raising=False)
+        reload(app_mod)
+
+
+def test_leo_correct_token_not_401(tmp_path, monkeypatch):
+    monkeypatch.setenv("LIONAGI_STUDIO_AUTH_TOKEN", "test-leo-secret")
+    from importlib import reload
+
+    import lionagi.studio.app as app_mod
+
+    reload(app_mod)
+    client = TestClient(
+        app_mod.app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765"
+    )
+    try:
+        r = client.post(
+            "/api/leo/sessions",
+            headers={"Authorization": "Bearer test-leo-secret"},
+        )
+        assert r.status_code == 200
+    finally:
+        monkeypatch.delenv("LIONAGI_STUDIO_AUTH_TOKEN", raising=False)
+        reload(app_mod)
+
+
+# ---------------------------------------------------------------------------
+# Tool registry shape
+# ---------------------------------------------------------------------------
+
+
+def test_leo_tool_registry_shape():
+    from lionagi.studio.services.leo import _all_tools
+
+    tools = _all_tools()
+    names = [t.__name__ for t in tools]
+    # Read-only tools
+    assert "tool_list_runs" in names
+    assert "tool_list_invocations" in names
+    assert "tool_list_sessions" in names
+    assert "tool_list_playbooks" in names
+    assert "tool_get_playbook" in names
+    assert "tool_list_schedules" in names
+    assert "tool_studio_doctor" in names
+    # UI-drive tools
+    assert "tool_show_in_ui" in names
+    assert "tool_prefill_schedule" in names
+    # Mutating tools
+    assert "tool_launch_playbook" in names
+    assert "tool_create_playbook" in names
+    assert "tool_run_maintenance" in names
+
+
+# ---------------------------------------------------------------------------
+# Proposed-action gating: mutating tools return proposals, never execute
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tool_launch_playbook_returns_proposal():
+    from lionagi.studio.services.leo import tool_launch_playbook
+
+    result = await tool_launch_playbook("my-playbook")
+    assert "proposed_action" in result
+    pa = result["proposed_action"]
+    assert pa["kind"] == "launch_playbook"
+    assert pa["params"]["name"] == "my-playbook"
+    assert "endpoint" in pa
+    # Must not have triggered any network call or service mutation
+
+
+@pytest.mark.asyncio
+async def test_tool_create_playbook_returns_proposal():
+    from lionagi.studio.services.leo import tool_create_playbook
+
+    result = await tool_create_playbook("new-pb", description="A test playbook")
+    assert "proposed_action" in result
+    pa = result["proposed_action"]
+    assert pa["kind"] == "create_playbook"
+    assert pa["params"]["name"] == "new-pb"
+
+
+@pytest.mark.asyncio
+async def test_tool_run_maintenance_returns_proposal():
+    from lionagi.studio.services.leo import tool_run_maintenance
+
+    result = await tool_run_maintenance("vacuum")
+    assert "proposed_action" in result
+    pa = result["proposed_action"]
+    assert pa["kind"] == "run_maintenance"
+    assert pa["params"]["action"] == "vacuum"
+
+
+@pytest.mark.asyncio
+async def test_tool_run_maintenance_invalid_action():
+    from lionagi.studio.services.leo import tool_run_maintenance
+
+    result = await tool_run_maintenance("drop_tables")
+    assert "error" in result
+    assert "proposed_action" not in result
+
+
+# ---------------------------------------------------------------------------
+# UI-drive tools: declarative commands, no server-side effect
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tool_show_in_ui_navigate_with_filter():
+    from lionagi.studio.services.leo import tool_show_in_ui
+
+    result = await tool_show_in_ui("history", status="failed")
+    assert "ui_command" in result
+    cmd = result["ui_command"]
+    assert cmd["kind"] == "navigate"
+    assert cmd["space"] == "history"
+    assert cmd["params"] == {"status": "failed"}
+
+
+@pytest.mark.asyncio
+async def test_tool_show_in_ui_rejects_unknown_space():
+    from lionagi.studio.services.leo import tool_show_in_ui
+
+    result = await tool_show_in_ui("admin-console")
+    assert "error" in result
+    assert "ui_command" not in result
+
+
+@pytest.mark.asyncio
+async def test_tool_show_in_ui_rejects_unknown_status():
+    from lionagi.studio.services.leo import tool_show_in_ui
+
+    result = await tool_show_in_ui("history", status="exploded")
+    assert "error" in result
+    assert "ui_command" not in result
+
+
+@pytest.mark.asyncio
+async def test_tool_prefill_schedule_returns_command():
+    from lionagi.studio.services.leo import tool_prefill_schedule
+
+    result = await tool_prefill_schedule(
+        "release-check",
+        "0 9 * * *",
+        "Check whether lionagi has a new release",
+        description="Daily release watch",
+    )
+    assert "ui_command" in result
+    cmd = result["ui_command"]
+    assert cmd["kind"] == "prefill_schedule"
+    assert cmd["space"] == "schedules"
+    assert cmd["params"]["name"] == "release-check"
+    assert cmd["params"]["cron"] == "0 9 * * *"
+    assert "prompt" in cmd["params"]
+
+
+# ---------------------------------------------------------------------------
+# Message turn with a fake Branch (no LLM network)
+# ---------------------------------------------------------------------------
+
+
+def _fake_branch_with_response(text: str) -> MagicMock:
+    """Build a mock Branch whose ReAct() returns `text`."""
+    branch = MagicMock()
+    branch.ReAct = AsyncMock(return_value=text)
+    branch.messages = []  # no ActionResponse messages
+    return branch
+
+
+def test_leo_message_turn_text_response(tmp_path, monkeypatch):
+    client = _make_client(tmp_path, monkeypatch)
+
+    # Create a session
+    sid = client.post("/api/leo/sessions").json()["id"]
+
+    # Inject a fake branch into the session registry
+    from lionagi.studio.services import leo as leo_svc
+
+    sess = leo_svc.get_session(sid)
+    assert sess is not None
+    sess.branch = _fake_branch_with_response("There are 3 running playbooks.")
+
+    # Send a message and collect SSE
+    r = client.post(
+        f"/api/leo/sessions/{sid}/messages",
+        json={"content": "How many runs are running?"},
+    )
+    assert r.status_code == 200
+    assert "text/event-stream" in r.headers["content-type"]
+
+    # Parse SSE frames
+    events = _parse_sse(r.text)
+    types = [e.get("type") for e in events]
+    assert "text" in types
+    assert "done" in types
+
+    text_event = next(e for e in events if e.get("type") == "text")
+    assert "3 running playbooks" in text_event["content"]
+
+
+def test_leo_message_turn_proposed_action_surfaced(tmp_path, monkeypatch):
+    """A mock branch that returns a proposed_action in an ActionResponse-like message."""
+    client = _make_client(tmp_path, monkeypatch)
+    sid = client.post("/api/leo/sessions").json()["id"]
+
+    from lionagi.studio.services import leo as leo_svc
+
+    sess = leo_svc.get_session(sid)
+    assert sess is not None
+
+    proposed = {
+        "kind": "launch_playbook",
+        "params": {"name": "ci-sweep"},
+        "description": "Launch playbook 'ci-sweep'",
+        "endpoint": "POST /api/launches/",
+    }
+
+    fake_msg = ActionResponse(
+        content={"function": "tool_launch_playbook", "output": {"proposed_action": proposed}}
+    )
+
+    # A real Branch appends messages during the turn; the mock must do the
+    # same because the router only scans messages added by the current turn.
+    branch = MagicMock()
+    branch.messages = []
+
+    async def fake_turn(**_kwargs):
+        branch.messages.append(fake_msg)
+        return "I've surfaced a proposed action."
+
+    branch.ReAct = AsyncMock(side_effect=fake_turn)
+    sess.branch = branch
+
+    r = client.post(
+        f"/api/leo/sessions/{sid}/messages",
+        json={"content": "Launch the ci-sweep playbook"},
+    )
+    assert r.status_code == 200
+    events = _parse_sse(r.text)
+    types = [e.get("type") for e in events]
+    assert "proposed_action" in types
+    assert "text" in types
+    assert "done" in types
+
+    pa_event = next(e for e in events if e.get("type") == "proposed_action")
+    assert pa_event["action"]["kind"] == "launch_playbook"
+
+
+def test_leo_message_turn_ui_command_surfaced(tmp_path, monkeypatch):
+    """ui_command tool outputs stream as ui_command events before the text."""
+    client = _make_client(tmp_path, monkeypatch)
+    sid = client.post("/api/leo/sessions").json()["id"]
+
+    from lionagi.studio.services import leo as leo_svc
+
+    sess = leo_svc.get_session(sid)
+    assert sess is not None
+
+    command = {"kind": "navigate", "space": "history", "params": {"status": "failed"}}
+
+    fake_msg = ActionResponse(
+        content={"function": "tool_show_in_ui", "output": {"ui_command": command}}
+    )
+
+    branch = MagicMock()
+    branch.messages = []
+
+    async def fake_turn(**_kwargs):
+        branch.messages.append(fake_msg)
+        return "Here are the failed runs."
+
+    branch.ReAct = AsyncMock(side_effect=fake_turn)
+    sess.branch = branch
+
+    r = client.post(
+        f"/api/leo/sessions/{sid}/messages",
+        json={"content": "what are some failed jobs recently"},
+    )
+    assert r.status_code == 200
+    events = _parse_sse(r.text)
+    types = [e.get("type") for e in events]
+    assert "ui_command" in types
+    assert "text" in types
+    assert types.index("ui_command") < types.index("text")
+
+    cmd_event = next(e for e in events if e.get("type") == "ui_command")
+    assert cmd_event["command"] == command
+
+
+def test_leo_prior_turn_proposals_not_reemitted(tmp_path, monkeypatch):
+    """Proposals from earlier turns must not resurface on later turns."""
+    client = _make_client(tmp_path, monkeypatch)
+    sid = client.post("/api/leo/sessions").json()["id"]
+
+    from lionagi.studio.services import leo as leo_svc
+
+    sess = leo_svc.get_session(sid)
+    assert sess is not None
+
+    stale_msg = ActionResponse(
+        content={
+            "function": "tool_launch_playbook",
+            "output": {
+                "proposed_action": {"kind": "launch_playbook", "params": {}},
+                "ui_command": {"kind": "navigate", "space": "history", "params": {}},
+            },
+        }
+    )
+
+    branch = MagicMock()
+    branch.messages = [stale_msg]  # left over from a previous turn
+    branch.ReAct = AsyncMock(return_value="Nothing new to propose.")
+    sess.branch = branch
+
+    r = client.post(
+        f"/api/leo/sessions/{sid}/messages",
+        json={"content": "Anything running?"},
+    )
+    assert r.status_code == 200
+    events = _parse_sse(r.text)
+    types = [e.get("type") for e in events]
+    assert "proposed_action" not in types
+    assert "ui_command" not in types
+    assert "text" in types
+    assert "done" in types
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_sse(body: str) -> list[dict[str, Any]]:
+    """Parse a raw SSE body into a list of decoded JSON event dicts."""
+    import json
+
+    events = []
+    for chunk in body.split("\n\n"):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        for line in chunk.splitlines():
+            if line.startswith("data:"):
+                data = line[5:].strip()
+                try:
+                    events.append(json.loads(data))
+                except json.JSONDecodeError:
+                    pass
+    return events

--- a/tests/apps_studio_server/test_route_registry.py
+++ b/tests/apps_studio_server/test_route_registry.py
@@ -247,6 +247,7 @@ _MIGRATED_AREAS = {
     "engine-defs",
     "workflow-defs",
     "sessions",
+    "leo",
     "admin",
     "schedules",
     "stats",


### PR DESCRIPTION
## Problem

The Studio operator panel (landed with the ADR-0093 cockpit frontend) calls `POST /api/leo/sessions` and `POST /api/leo/sessions/{id}/messages` (SSE), but main has no such backend — every panel interaction 404s. The backend only ever existed on an archived branch, predating main's route-registry reorganization.

## What

- `lionagi/studio/services/leo.py` (new): the session service + both routes, written in the registry decorator style like every other area module.
- Registered in `_STUDIO_ROUTE_MODULES`; `test_route_registry.py` expected-areas set updated.
- `tests/apps_studio_server/test_leo.py` (new): ported coverage plus two added auth-gate tests proving `/api/leo/*` sits behind the same bearer-token middleware as every other studio route.

## Design note

The archive contained two divergent Leo backends; this ports the tool-registry design whose event vocabulary (`proposed_action`, `ui_command`) is the one the frontend actually renders. Security boundary preserved exactly: mutating tools never execute — they return a `proposed_action` the operator confirms client-side; UI-drive tools return declarative commands that never touch server state.

## Verification

- `tests/apps_studio_server/` full suite: green (rc=0, zero failures), including 18 leo tests
- Route table confirms `/api/leo/sessions` and `/api/leo/sessions/{session_id}/messages` registered
- ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)