### PR TITLE
feat(studio): hosted-mode launch readiness — local-daemon API base, no-daemon state, deploy config

### DIFF
--- a/apps/studio/frontend/HOSTING.md
+++ b/apps/studio/frontend/HOSTING.md
@@ -1,0 +1,22 @@
+# Hosting the Studio frontend
+
+The Studio frontend is a static single-page app. Build it with `npm ci && npm run build`
+and it produces plain HTML/CSS/JS in `dist/`, which any static host (Vercel, Netlify,
+S3 + CDN, etc.) can serve as-is. On Vercel, set the project root directory to
+`apps/studio/frontend`; the build command and output directory (`dist`) are already
+declared in `vercel.json` alongside a catch-all rewrite to `index.html` (client-side
+routing) and long-lived immutable caching for the hashed `/assets/*` bundle files.
+
+At runtime the app resolves its API base URL in this order: an injected
+`window.__STUDIO_API_BASE__` (desktop shell), a build-time `VITE_STUDIO_API_BASE` env
+var, a same-hostname `:8765` guess when served from a Vite dev port, and otherwise the
+same origin the page was loaded from — except when the page itself is served over
+https from a non-localhost hostname (as a hosted static deploy is), in which case it
+defaults to `http://127.0.0.1:8765`, since a real daemon never serves https itself.
+
+This reflects the app's local-first architecture: the hosted page has no backend of
+its own. It is a static client that talks directly to the operator's own `li studio`
+daemon running on their machine, the same way it would if opened from `localhost`.
+There is no login and no server-side state for the hosted deploy to manage — if the
+daemon isn't running, the app shows a state explaining how to start it and keeps
+retrying rather than rendering broken panels.

--- a/apps/studio/frontend/src/components/shell/NoDaemonGate.tsx
+++ b/apps/studio/frontend/src/components/shell/NoDaemonGate.tsx
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import { useTranslations } from "use-intl";
+import Button from "@/components/ui/Button";
+import EmptyState from "@/components/ui/EmptyState";
+import { IconTerminal } from "@/components/ui/icons";
+import { resolveApiBase } from "@/lib/api";
+
+const POLL_INTERVAL_MS = 5000;
+
+type ConnectivityStatus = "checking" | "connected" | "unreachable";
+
+async function probeDaemon(apiBase: string): Promise<boolean> {
+  try {
+    const response = await fetch(`${apiBase}/health`);
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Gates the app shell on the local daemon being reachable. A static hosted
+ * deploy has no backend of its own — the daemon is the operator's own
+ * `li studio` process — so a network failure here means "not started yet",
+ * not a server error worth showing broken panels for.
+ */
+export default function NoDaemonGate({ children }: { children: ReactNode }) {
+  const t = useTranslations("daemon");
+  const apiBase = resolveApiBase();
+  const [status, setStatus] = useState<ConnectivityStatus>("checking");
+  const activeRef = useRef(true);
+
+  const check = useCallback(async () => {
+    const ok = await probeDaemon(apiBase);
+    if (!activeRef.current) return;
+    setStatus(ok ? "connected" : "unreachable");
+  }, [apiBase]);
+
+  useEffect(() => {
+    activeRef.current = true;
+    void check();
+    return () => {
+      activeRef.current = false;
+    };
+  }, [check]);
+
+  useEffect(() => {
+    if (status !== "unreachable") return;
+    const id = setInterval(() => void check(), POLL_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [status, check]);
+
+  if (status === "unreachable") {
+    return (
+      <div className="flex h-dvh items-center justify-center bg-surface-base px-6">
+        <EmptyState
+          glyph={<IconTerminal className="h-5 w-5" />}
+          title={t("title", { base: apiBase || "http://127.0.0.1:8765" })}
+          body={
+            <>
+              <span className="block font-data">{t("bootstrapInstall")}</span>
+              <span className="block font-data">{t("bootstrapRun")}</span>
+              <span className="mt-2 block">{t("authNote")}</span>
+            </>
+          }
+          action={
+            <Button variant="primary" onClick={() => void check()}>
+              {t("retry")}
+            </Button>
+          }
+        />
+      </div>
+    );
+  }
+
+  // "checking" renders children immediately — the gate must never flash on
+  // slow-but-live responses, only on an actual network failure / non-2xx.
+  return <>{children}</>;
+}

--- a/apps/studio/frontend/src/lib/api.test.ts
+++ b/apps/studio/frontend/src/lib/api.test.ts
@@ -109,6 +109,54 @@ describe("resolveApiBase", () => {
     const result = resolveApiBase();
     expect(result).toBe("");
   });
+
+  it("defaults to the local daemon for a hosted https deploy on a non-local hostname", () => {
+    // https://lion-studio.khive.ai — static SPA on Vercel driving the
+    // operator's own local daemon. The daemon never serves https, so this
+    // combination is a reliable signal for the hosted-mode default.
+    vi.stubGlobal("window", {
+      ...window,
+      __STUDIO_API_BASE__: undefined,
+      location: {
+        ...window.location,
+        port: "",
+        hostname: "lion-studio.khive.ai",
+        protocol: "https:",
+      },
+    });
+    const result = resolveApiBase();
+    expect(result).toBe("http://127.0.0.1:8765");
+  });
+
+  it("does not apply the hosted-https default over plain http on a remote hostname", () => {
+    vi.stubGlobal("window", {
+      ...window,
+      __STUDIO_API_BASE__: undefined,
+      location: {
+        ...window.location,
+        port: "",
+        hostname: "lion-studio.khive.ai",
+        protocol: "http:",
+      },
+    });
+    const result = resolveApiBase();
+    expect(result).toBe("");
+  });
+
+  it("does not apply the hosted-https default for https on localhost", () => {
+    vi.stubGlobal("window", {
+      ...window,
+      __STUDIO_API_BASE__: undefined,
+      location: {
+        ...window.location,
+        port: "",
+        hostname: "localhost",
+        protocol: "https:",
+      },
+    });
+    const result = resolveApiBase();
+    expect(result).toBe("");
+  });
 });
 
 describe("resolveAuthToken", () => {

--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -54,6 +54,15 @@ export function resolveApiBase(): string {
     if (port === "3000" || port === "5173") {
       return `${window.location.protocol}//${window.location.hostname}:8765`;
     }
+    const host = window.location.hostname;
+    const isLocalHost = host === "localhost" || host === "127.0.0.1" || host === "::1";
+    // Hosted static deploy (e.g. lion-studio.khive.ai on Vercel): the page is
+    // served over https from a non-local hostname, which the local daemon
+    // never does — a precise signal that this is the SPA driving the
+    // operator's own daemon rather than a same-origin/dev deployment.
+    if (window.location.protocol === "https:" && !isLocalHost) {
+      return "http://127.0.0.1:8765";
+    }
     // Production / single-origin deployment: use same origin (relative URLs).
     return "";
   }

--- a/apps/studio/frontend/src/messages/en.json
+++ b/apps/studio/frontend/src/messages/en.json
@@ -863,5 +863,12 @@
     "rackEmpty": "No workflows yet.",
     "designerEmpty": "Pick a workflow from the rack, or create one to start designing.",
     "designerEmptyCta": "Create a workflow"
+  },
+  "daemon": {
+    "title": "Studio couldn't reach the local daemon at {base}",
+    "bootstrapInstall": "pip install \"lionagi[studio]\"",
+    "bootstrapRun": "li studio",
+    "authNote": "Set LIONAGI_STUDIO_AUTH_TOKEN to require a bearer token for this daemon.",
+    "retry": "Retry"
   }
 }

--- a/apps/studio/frontend/src/messages/zh.json
+++ b/apps/studio/frontend/src/messages/zh.json
@@ -863,5 +863,12 @@
     "rackEmpty": "暂无工作流。",
     "designerEmpty": "从左侧选择一个工作流，或新建一个开始设计。",
     "designerEmptyCta": "新建工作流"
+  },
+  "daemon": {
+    "title": "Studio 无法连接到本地守护进程（{base}）",
+    "bootstrapInstall": "pip install \"lionagi[studio]\"",
+    "bootstrapRun": "li studio",
+    "authNote": "设置 LIONAGI_STUDIO_AUTH_TOKEN 可为该守护进程要求持有者令牌。",
+    "retry": "重试"
   }
 }

--- a/apps/studio/frontend/src/routes/__root.tsx
+++ b/apps/studio/frontend/src/routes/__root.tsx
@@ -2,6 +2,7 @@ import { createRootRoute, Outlet } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 import { IntlProvider } from "use-intl";
 import AppShell from "@/components/shell/AppShell";
+import NoDaemonGate from "@/components/shell/NoDaemonGate";
 import "../globals.css";
 
 import enMessages from "@/messages/en.json";
@@ -40,9 +41,11 @@ function RootComponent() {
 
   return (
     <IntlProvider locale={locale} messages={messages}>
-      <AppShell locale={locale} onLocaleChange={handleLocaleChange}>
-        <Outlet />
-      </AppShell>
+      <NoDaemonGate>
+        <AppShell locale={locale} onLocaleChange={handleLocaleChange}>
+          <Outlet />
+        </AppShell>
+      </NoDaemonGate>
     </IntlProvider>
   );
 }

--- a/apps/studio/frontend/vercel.json
+++ b/apps/studio/frontend/vercel.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }],
+  "headers": [
+    {
+      "source": "/assets/(.*)",
+      "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Makes the Studio frontend launch-ready as a hosted static SPA (issue #1713's local-first design: static page, no login, no hosted backend — it talks to the operator's own local daemon).

1. **Hosted API base default** (`api.ts`): when the page is served over https from a non-localhost hostname (i.e. a hosted static deploy — a real daemon never serves https), `resolveApiBase()` defaults to `http://127.0.0.1:8765`. All existing branches (runtime injection, `VITE_STUDIO_API_BASE`, dev-port, same-origin) unchanged. 3 new unit tests.
2. **No-daemon gate** (`NoDaemonGate.tsx` around the app shell): probes the public unauthenticated `GET /health`; on network failure or non-2xx renders a full-page state with the resolved API base, the 2-line bootstrap (`pip install "lionagi[studio]"` / `li studio`), the `LIONAGI_STUDIO_AUTH_TOKEN` note, a Retry button, and a 5s self-healing poll. Renders children immediately while checking, so a slow-but-live daemon never flashes the empty state. en + zh locales.
3. **Deploy config**: `vercel.json` (SPA rewrite, immutable `/assets/*` caching) + `HOSTING.md` documenting the build and the api-base resolution order.

Backend hardening for the hosted origin (CORS exact-origin allowlist, JSON content-type gate, Host validation) already landed separately — no backend changes here.

## Verification

`apps/studio/frontend`: `tsc --noEmit` ✓ · `vitest run` 348/348 ✓ · `eslint` ✓ · `vite build` ✓ (re-run independently after the implementation pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)