### PR TITLE
fix(studio): agenda-style week view for the Schedules calendar

### DIFF
--- a/apps/studio/frontend/src/components/schedules/SchedulesCalendar.test.tsx
+++ b/apps/studio/frontend/src/components/schedules/SchedulesCalendar.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * SchedulesCalendar week-agenda tests.
+ *
+ * Two layers, matching the existing project style (no @testing-library/react
+ * here — see history/RunDetail.test.tsx):
+ * - Pure logic: groupAgendaByHour (same-schedule, same-hour, consecutive
+ *   collapse into one range-badged chip) and truncateMiddle.
+ * - Source contract: the week branch renders 7 agenda columns with no hour
+ *   gutter / all-day row, and uses the empty-day placeholder + range badge.
+ */
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { groupAgendaByHour, truncateMiddle } from "./SchedulesCalendar";
+import type { ScheduleSummary } from "@/lib/types";
+import type { RunRow } from "./data";
+
+const CALENDAR_FILE = path.resolve(__dirname, "SchedulesCalendar.tsx");
+const SRC = fs.readFileSync(CALENDAR_FILE, "utf-8");
+
+function schedule(overrides: Partial<ScheduleSummary> = {}): ScheduleSummary {
+  return {
+    id: "sched-1",
+    name: "nightly-build",
+    description: null,
+    enabled: 1,
+    trigger_type: "cron",
+    cron_expr: "*/10 * * * *",
+    interval_sec: null,
+    github_repo: null,
+    poll_interval_sec: null,
+    action_kind: "agent",
+    action_model: null,
+    action_prompt: null,
+    action_agent: null,
+    action_playbook: null,
+    action_project: null,
+    on_success: null,
+    on_fail: null,
+    last_fired_at: null,
+    next_fire_at: null,
+    missed_fire_policy: "skip",
+    overlap_policy: "skip",
+    project: null,
+    created_at: 0,
+    updated_at: 0,
+    ...overrides,
+  };
+}
+
+function runRow(overrides: Partial<RunRow> = {}): RunRow {
+  return {
+    id: "run-1",
+    schedule_id: "sched-1",
+    scheduleName: "nightly-build",
+    invocation_id: null,
+    trigger_context: {},
+    action_kind: "agent",
+    status: "completed",
+    exit_code: 0,
+    chain_depth: 0,
+    fired_at: 0,
+    ended_at: null,
+    error_detail: null,
+    ...overrides,
+  };
+}
+
+const MIN = 60_000;
+// 2026-07-06 (Monday) 09:00 local, as an epoch-ms base for fixture firings.
+const DAY_BASE = new Date(2026, 6, 6, 9, 0, 0, 0).getTime();
+
+function fire(atMs: number, s: ScheduleSummary) {
+  return { kind: "fire" as const, atMs, schedule: s };
+}
+
+function run(atMs: number, r: RunRow) {
+  return { kind: "run" as const, atMs, run: r };
+}
+
+// ─── groupAgendaByHour ────────────────────────────────────────────────────
+
+describe("groupAgendaByHour — same-schedule, same-hour consecutive collapse", () => {
+  it("collapses consecutive same-schedule fires within the same hour into one range-badged group", () => {
+    const s = schedule({ id: "s1", name: "poller" });
+    const items = Array.from({ length: 9 }, (_, i) => fire(DAY_BASE + i * 5 * MIN, s));
+    const entries = groupAgendaByHour(items);
+    expect(entries).toHaveLength(1);
+    const group = entries[0];
+    if (group.kind !== "agendaGroup") throw new Error("expected agendaGroup");
+    expect(group.count).toBe(9);
+    expect(group.startMs).toBe(DAY_BASE);
+    expect(group.endMs).toBe(DAY_BASE + 8 * 5 * MIN);
+    expect(group.scheduleName).toBe("poller");
+  });
+
+  it("does not merge fires that cross an hour boundary", () => {
+    const s = schedule({ id: "s1", name: "poller" });
+    // 09:50 and 10:05 — same schedule, but different hours.
+    const items = [fire(DAY_BASE + 50 * MIN, s), fire(DAY_BASE + 65 * MIN, s)];
+    const entries = groupAgendaByHour(items);
+    expect(entries).toHaveLength(2);
+    expect(entries.every((e) => e.kind === "agendaGroup" && e.count === 1)).toBe(true);
+  });
+
+  it("does not merge different schedules even within the same hour", () => {
+    const a = schedule({ id: "s1", name: "alpha" });
+    const b = schedule({ id: "s2", name: "beta" });
+    const items = [fire(DAY_BASE, a), fire(DAY_BASE + 5 * MIN, b), fire(DAY_BASE + 10 * MIN, a)];
+    const entries = groupAgendaByHour(items);
+    // alpha, beta, alpha — the second alpha is not adjacent to the first
+    // (beta interrupts), so it starts its own group.
+    expect(entries).toHaveLength(3);
+    expect(entries.map((e) => (e.kind === "agendaGroup" ? e.scheduleName : ""))).toEqual([
+      "alpha",
+      "beta",
+      "alpha",
+    ]);
+  });
+
+  it("does not merge runs with fires even for the same schedule", () => {
+    const s = schedule({ id: "s1", name: "mixed" });
+    const r = runRow({ schedule_id: "s1", scheduleName: "mixed", fired_at: DAY_BASE });
+    const items = [run(DAY_BASE, r), fire(DAY_BASE + 5 * MIN, s)];
+    const entries = groupAgendaByHour(items);
+    expect(entries).toHaveLength(2);
+  });
+
+  it("passes poll entries through ungrouped and resets the running group", () => {
+    const s = schedule({ id: "s1", name: "poller" });
+    const items = [
+      fire(DAY_BASE, s),
+      { kind: "poll" as const, schedule: schedule({ id: "s2", name: "gh-poll" }) },
+      fire(DAY_BASE + 5 * MIN, s),
+    ];
+    const entries = groupAgendaByHour(items);
+    expect(entries).toHaveLength(3);
+    expect(entries[1].kind).toBe("poll");
+    expect(entries[2].kind === "agendaGroup" && entries[2].count).toBe(1);
+  });
+
+  it("returns an empty list for an empty day", () => {
+    expect(groupAgendaByHour([])).toEqual([]);
+  });
+});
+
+// ─── truncateMiddle ───────────────────────────────────────────────────────
+
+describe("truncateMiddle", () => {
+  it("leaves short names untouched", () => {
+    expect(truncateMiddle("nightly-build")).toBe("nightly-build");
+  });
+
+  it("truncates long names in the middle, preserving prefix and suffix", () => {
+    const long = "extremely-long-schedule-name-that-does-not-fit-in-a-chip";
+    const out = truncateMiddle(long, 20);
+    expect(out.length).toBeLessThanOrEqual(21); // 20 + ellipsis rounding
+    expect(out).toContain("…");
+    expect(long.startsWith(out.split("…")[0])).toBe(true);
+    expect(long.endsWith(out.split("…")[1])).toBe(true);
+  });
+});
+
+// ─── Source contract — agenda week structure ─────────────────────────────
+
+describe("SchedulesCalendar — week view is an agenda, not a time grid", () => {
+  it("has a week branch distinct from the day branch", () => {
+    expect(SRC).toMatch(/mode === "week" \? \(/);
+  });
+
+  it("week branch renders 7 equal columns via grid-cols-7, not an hour-row loop", () => {
+    const weekBranchStart = SRC.indexOf('mode === "week" ? (');
+    const dayBranchStart = SRC.indexOf(") : (", weekBranchStart);
+    const weekBranch = SRC.slice(weekBranchStart, dayBranchStart);
+    expect(weekBranch).toContain("grid-cols-7");
+    expect(weekBranch).not.toContain("Array.from({ length: 24 }");
+    expect(weekBranch).not.toContain("allDay");
+  });
+
+  it("uses the empty-day placeholder and the range badge in the week branch", () => {
+    const weekBranchStart = SRC.indexOf('mode === "week" ? (');
+    const dayBranchStart = SRC.indexOf(") : (", weekBranchStart);
+    const weekBranch = SRC.slice(weekBranchStart, dayBranchStart);
+    expect(weekBranch).toContain('t("emptyDay")');
+    expect(weekBranch).toContain("groupAgendaByHour");
+  });
+
+  it("day view keeps its hour grid untouched", () => {
+    const dayBranchStart = SRC.indexOf("Horizontal scroll lives HERE");
+    const detailStripStart = SRC.indexOf("{/* Day detail strip */}");
+    const dayBranch = SRC.slice(dayBranchStart, detailStripStart);
+    expect(dayBranch).toContain("Array.from({ length: 24 }");
+    expect(dayBranch).toContain("HOUR_ROW_PX");
+  });
+});

--- a/apps/studio/frontend/src/components/schedules/SchedulesCalendar.tsx
+++ b/apps/studio/frontend/src/components/schedules/SchedulesCalendar.tsx
@@ -1,5 +1,5 @@
 /**
- * SchedulesCalendar — month grid, week grid, and day grid over real data.
+ * SchedulesCalendar — month grid, agenda week, and day grid over real data.
  *
  * Past cells show actual runs (status-colored dots). Future cells show:
  *   - interval schedules: projected fires within the visible range
@@ -8,10 +8,13 @@
  *   - github_poll schedules: a "polling" indicator on today only
  *     (poll triggers have no discrete per-day fire time)
  *
- * Month cells bucket by day; week/day views bucket by hour on a scrollable
- * hour grid. Clicking a day (or an hour cell) opens a detail strip below.
+ * Month cells bucket by day. The week view is an agenda: seven day columns,
+ * each listing its firings chronologically as full-width chips — no hour
+ * grid, since firings are few and bursty rather than evenly spread across a
+ * work day. The day view keeps the scrollable hour grid. Clicking a day (or
+ * an hour cell, or a week agenda column) opens a detail strip below.
  * Repeated fires of the same schedule inside one cell collapse into a single
- * chip with a run-count badge — the detail strip below still lists every
+ * chip with a count badge — the detail strip below still lists every
  * individual fire, so "expand" is just a click away.
  */
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -35,6 +38,11 @@ const STATUS_DOT: Record<string, string> = {
  * shared by month cells, hour cells, and the all-day row. */
 const CHIP_ROW =
   "flex h-5 min-w-0 shrink-0 items-center gap-1 rounded bg-surface-overlay/50 px-1 text-meta leading-none";
+
+/** Full-width agenda chip shell — one line, same type scale as CHIP_ROW but
+ * sized for a week agenda column instead of a cramped grid cell. */
+const AGENDA_CHIP_ROW =
+  "flex w-full min-w-0 items-center gap-1.5 rounded border border-edge/60 bg-surface-overlay/50 px-1.5 py-1 text-meta leading-none";
 
 interface DayRun {
   kind: "run";
@@ -206,6 +214,78 @@ function groupBySchedule(items: DayItem[]): ChipEntry[] {
   return order;
 }
 
+/** A run of consecutive same-schedule firings inside the same hour, shown
+ * as one agenda chip carrying a time-range badge (e.g. "9 firings 09:00–09:50")
+ * instead of a bare count. */
+interface AgendaGroup {
+  kind: "agendaGroup";
+  sourceKind: "run" | "fire";
+  startMs: number;
+  endMs: number;
+  scheduleName: string;
+  status?: string;
+  count: number;
+}
+
+type AgendaEntry = DayPoll | AgendaGroup;
+
+/**
+ * Build the agenda for one day column: chronological, with consecutive
+ * same-schedule firings inside the same hour collapsed into one AgendaGroup.
+ * Unlike groupBySchedule (whole-cell collapse for month/hour grids), a gap in
+ * the hour or a different schedule always starts a fresh group — the badge's
+ * time range stays a true, contiguous span.
+ */
+function groupAgendaByHour(items: DayItem[]): AgendaEntry[] {
+  const out: AgendaEntry[] = [];
+  let current: AgendaGroup | null = null;
+  let currentScheduleId: string | null = null;
+  for (const item of items) {
+    if (item.kind === "poll") {
+      out.push(item);
+      current = null;
+      continue;
+    }
+    const scheduleId = item.kind === "run" ? item.run.schedule_id : item.schedule.id;
+    const scheduleName = item.kind === "run" ? item.run.scheduleName : item.schedule.name;
+    const hour = new Date(item.atMs).getHours();
+    if (
+      current &&
+      currentScheduleId === scheduleId &&
+      current.sourceKind === item.kind &&
+      new Date(current.endMs).getHours() === hour
+    ) {
+      current.count += 1;
+      current.endMs = item.atMs;
+      if (item.kind === "run") current.status = item.run.status;
+      continue;
+    }
+    current = {
+      kind: "agendaGroup",
+      sourceKind: item.kind,
+      startMs: item.atMs,
+      endMs: item.atMs,
+      scheduleName,
+      status: item.kind === "run" ? item.run.status : undefined,
+      count: 1,
+    };
+    currentScheduleId = scheduleId;
+    out.push(current);
+  }
+  return out;
+}
+
+/** Truncate long schedule names in the middle so both the meaningful prefix
+ * and suffix stay visible; the full name always remains in the title attr. */
+function truncateMiddle(text: string, max = 30): string {
+  if (text.length <= max) return text;
+  const half = Math.floor((max - 1) / 2);
+  return `${text.slice(0, half)}…${text.slice(text.length - half)}`;
+}
+
+export { groupAgendaByHour, truncateMiddle };
+export type { AgendaEntry, AgendaGroup };
+
 export default function SchedulesCalendar({
   schedules,
   runs,
@@ -250,12 +330,13 @@ export default function SchedulesCalendar({
     [schedules, runs, range, today],
   );
 
-  // Hour-granularity buckets — week/day grids only.
+  // Hour-granularity buckets — day grid only (the week view is an agenda
+  // bucketed by day, reusing byDay below).
   const byHour = useMemo(
     () =>
-      mode === "month"
-        ? null
-        : bucketItems(schedules, runs, range.startMs, range.endMs, today, hourKey),
+      mode === "day"
+        ? bucketItems(schedules, runs, range.startMs, range.endMs, today, hourKey)
+        : null,
     [mode, schedules, runs, range, today],
   );
 
@@ -411,6 +492,67 @@ export default function SchedulesCalendar({
       </span>
     );
 
+  const renderAgendaChip = (entry: AgendaEntry, key: number) =>
+    entry.kind === "poll" ? (
+      <span key={key} className={AGENDA_CHIP_ROW} title={`${entry.schedule.name} · polling`}>
+        <span
+          aria-hidden="true"
+          className="h-1.5 w-1.5 shrink-0 animate-pulse rounded-full"
+          style={{ background: "var(--status-running)" }}
+        />
+        <span className="min-w-0 flex-1 truncate text-content-secondary">
+          {truncateMiddle(entry.schedule.name)}
+        </span>
+      </span>
+    ) : (
+      <span
+        key={key}
+        className={AGENDA_CHIP_ROW}
+        title={
+          entry.count > 1
+            ? `${entry.scheduleName} · ${t("rangeBadge", {
+                count: entry.count,
+                start: timeOf(entry.startMs),
+                end: timeOf(entry.endMs),
+              })}`
+            : entry.sourceKind === "run"
+              ? `${entry.scheduleName} · ${entry.status}`
+              : `${entry.scheduleName} · ${t("next")}`
+        }
+      >
+        {entry.sourceKind === "run" ? (
+          <span
+            aria-hidden="true"
+            className="h-1.5 w-1.5 shrink-0 rounded-full"
+            style={{ background: STATUS_DOT[entry.status ?? ""] ?? "var(--content-muted)" }}
+          />
+        ) : (
+          <span
+            aria-hidden="true"
+            className="h-1.5 w-1.5 shrink-0 rounded-full border"
+            style={{ borderColor: "var(--accent)" }}
+          />
+        )}
+        {entry.count === 1 && (
+          <span className="shrink-0 font-data tabular-nums text-content-muted">
+            {timeOf(entry.startMs)}
+          </span>
+        )}
+        <span className="min-w-0 flex-1 truncate text-content-secondary">
+          {truncateMiddle(entry.scheduleName)}
+        </span>
+        {entry.count > 1 && (
+          <span className="shrink-0 rounded-sm bg-[var(--accent)]/15 px-1 font-data text-[10px] font-semibold tabular-nums text-[var(--accent)]">
+            {t("rangeBadge", {
+              count: entry.count,
+              start: timeOf(entry.startMs),
+              end: timeOf(entry.endMs),
+            })}
+          </span>
+        )}
+      </span>
+    );
+
   return (
     <div className="flex flex-col gap-3 px-6 pb-6">
       {/* Period nav + view switcher */}
@@ -529,6 +671,91 @@ export default function SchedulesCalendar({
             })}
           </div>
         </>
+      ) : mode === "week" ? (
+        // Agenda week: 7 equal day columns, each a chronological chip list —
+        // no hour gutter, no all-day row. Firings are few and bursty, not
+        // evenly spread across a work day, so a time grid is mostly empty.
+        <div className="overflow-hidden rounded-lg border border-edge">
+          {/* Column header — day-of-week + date, today gets the accent circle. */}
+          <div className="grid grid-cols-7 border-b border-edge">
+            {hourColumns.map((d) => {
+              const key = dayKey(d);
+              const isToday = key === todayKey;
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  onClick={() => setSelectedDay(selectedDay === key ? null : key)}
+                  className={[
+                    "flex items-center gap-1.5 border-l border-edge px-2 py-1.5 text-left transition-colors duration-100 first:border-l-0",
+                    selectedDay === key
+                      ? "bg-surface-overlay"
+                      : isToday
+                        ? "bg-[var(--today-tint)] hover:bg-surface-overlay/60"
+                        : "hover:bg-surface-overlay/60",
+                  ].join(" ")}
+                >
+                  <span className="font-data text-meta uppercase tracking-wider text-content-muted">
+                    {d.toLocaleDateString(locale, { weekday: "short" })}
+                  </span>
+                  <span
+                    className={[
+                      "font-data text-meta tabular-nums",
+                      isToday
+                        ? "flex h-5 w-5 items-center justify-center rounded-full bg-[var(--accent)] font-semibold text-black"
+                        : "text-content-secondary",
+                    ].join(" ")}
+                  >
+                    {d.getDate()}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Day columns — agenda chips, top-aligned, scroll inside the
+              column rather than stretching every column to match the
+              busiest day. */}
+          <div className="grid grid-cols-7">
+            {hourColumns.map((d) => {
+              const dk = dayKey(d);
+              const isToday = dk === todayKey;
+              const dayItems = byDay.get(dk) ?? [];
+              const polls = dayItems.filter((item): item is DayPoll => item.kind === "poll");
+              const timed = dayItems.filter((item) => item.kind !== "poll");
+              const entries: AgendaEntry[] = [...polls, ...groupAgendaByHour(timed)];
+              const openHere = () => setSelectedDay(selectedDay === dk ? null : dk);
+              return (
+                <div
+                  key={dk}
+                  role="button"
+                  tabIndex={0}
+                  onClick={openHere}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      openHere();
+                    }
+                  }}
+                  className={[
+                    "flex max-h-[420px] flex-col items-stretch gap-1 overflow-y-auto border-l border-edge p-1.5 text-left transition-colors duration-100 first:border-l-0 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-[var(--accent)]",
+                    selectedDay === dk
+                      ? "bg-surface-overlay/40"
+                      : isToday
+                        ? "bg-[var(--today-tint)] hover:bg-surface-overlay/60"
+                        : "hover:bg-surface-overlay/60",
+                  ].join(" ")}
+                >
+                  {entries.length === 0 ? (
+                    <span className="pt-1 text-meta text-content-muted">{t("emptyDay")}</span>
+                  ) : (
+                    entries.map((entry, j) => renderAgendaChip(entry, j))
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
       ) : (
         // Horizontal scroll lives HERE, on the one shared ancestor of the
         // header/all-day/hour-grid tracks — they scroll together in lockstep

--- a/apps/studio/frontend/src/messages/en.json
+++ b/apps/studio/frontend/src/messages/en.json
@@ -376,7 +376,9 @@
       "viewMonth": "Month",
       "viewWeek": "Week",
       "viewDay": "Day",
-      "allDay": "all-day"
+      "allDay": "all-day",
+      "emptyDay": "No firings",
+      "rangeBadge": "{count, plural, one {# firing {start}–{end}} other {# firings {start}–{end}}}"
     },
     "create": {
       "title": "New Schedule",

--- a/apps/studio/frontend/src/messages/zh.json
+++ b/apps/studio/frontend/src/messages/zh.json
@@ -376,7 +376,9 @@
       "viewMonth": "月",
       "viewWeek": "周",
       "viewDay": "日",
-      "allDay": "全天"
+      "allDay": "全天",
+      "emptyDay": "无触发记录",
+      "rangeBadge": "{count} 次触发 {start}–{end}"
     },
     "create": {
       "title": "新建计划",


### PR DESCRIPTION
The week view rendered a meeting-calendar hour grid that was almost entirely empty for our data (bursty automation firings), with tiny ×N pills crammed into one or two columns. Replaced with a 7-column agenda week:

- Day columns Mon–Sun (today gets the month view's accent treatment), firings listed chronologically as full-width one-line chips: status dot, HH:MM, middle-truncated name (full name in title attr).
- Consecutive same-schedule firings within the same clock hour group into one chip with a real time-range badge ("9 firings 09:00–09:50"), not a bare ×N.
- No hour gutter, no all-day row; untimed items sit as chips at the top of their day column.
- Empty days show a quiet "No firings" placeholder; columns scroll internally past a max height instead of stretching.
- Click semantics unchanged (same day-detail strip). Month/Day untouched except the byHour bucket is now computed for Day only.

Gate: vitest 360 passed (16 files, incl. new grouping + empty-day tests), tsc clean, lint + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)