### PR TITLE
feat(cli): li studio frontend modes — hosted --web default, --docker, --no-frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,13 +172,13 @@ li studio             # default: starts the local daemon and opens the hosted UI
                       # at https://lion-studio.khive.ai, which talks to your
                       # daemon at http://127.0.0.1:8765 — nothing is built locally
 li studio --docker    # self-contained: auto-pulls ghcr.io/ohdearquant/lion-studio
-                      # UI → http://localhost:3000   API → http://localhost:8765
+                      # UI + API → http://localhost:8765
 li studio --no-frontend  # backend API only, no UI
 li studio --dev       # from a source checkout: backend + in-repo frontend, hot reload
 ```
 
-`--web`, `--docker`, and `--no-frontend` are mutually exclusive; `--web` is the
-default when no flag is given. Pass `--no-open` to skip auto-opening the
+`--web`, `--docker`, `--no-frontend`, and `--dev` are mutually exclusive; `--web`
+is the default when no flag is given. Pass `--no-open` to skip auto-opening the
 hosted UI in your browser.
 
 ![Lion Studio — run detail with execution DAG, branches, and multi-agent orchestration](assets/studio.png)

--- a/README.md
+++ b/README.md
@@ -168,10 +168,18 @@ projects, schedules, playbooks, execution DAGs, and run inspection in one
 place.
 
 ```bash
-li studio          # Docker (recommended): auto-pulls ghcr.io/ohdearquant/lion-studio
-                   # UI → http://localhost:3000   API → http://localhost:8765
-li studio --dev    # from a source checkout: backend + frontend with hot reload
+li studio             # default: starts the local daemon and opens the hosted UI
+                      # at https://lion-studio.khive.ai, which talks to your
+                      # daemon at http://127.0.0.1:8765 — nothing is built locally
+li studio --docker    # self-contained: auto-pulls ghcr.io/ohdearquant/lion-studio
+                      # UI → http://localhost:3000   API → http://localhost:8765
+li studio --no-frontend  # backend API only, no UI
+li studio --dev       # from a source checkout: backend + in-repo frontend, hot reload
 ```
+
+`--web`, `--docker`, and `--no-frontend` are mutually exclusive; `--web` is the
+default when no flag is given. Pass `--no-open` to skip auto-opening the
+hosted UI in your browser.
 
 ![Lion Studio — run detail with execution DAG, branches, and multi-agent orchestration](assets/studio.png)
 

--- a/apps/studio/frontend/HOSTING.md
+++ b/apps/studio/frontend/HOSTING.md
@@ -20,3 +20,8 @@ daemon running on their machine, the same way it would if opened from `localhost
 There is no login and no server-side state for the hosted deploy to manage — if the
 daemon isn't running, the app shows a state explaining how to start it and keeps
 retrying rather than rendering broken panels.
+
+On the CLI side, bare `li studio` (equivalently `li studio --web`) is the mode built
+for this deploy: it starts only the local daemon and prints/opens this hosted URL,
+without building or serving any frontend locally. See the root README's "Lion
+Studio" section for the other launch modes (`--docker`, `--no-frontend`, `--dev`).

--- a/apps/studio/frontend/HOSTING.md
+++ b/apps/studio/frontend/HOSTING.md
@@ -25,3 +25,21 @@ On the CLI side, bare `li studio` (equivalently `li studio --web`) is the mode b
 for this deploy: it starts only the local daemon and prints/opens this hosted URL,
 without building or serving any frontend locally. See the root README's "Lion
 Studio" section for the other launch modes (`--docker`, `--no-frontend`, `--dev`).
+
+## Auth: loopback vs everything else
+
+The default daemon binds `127.0.0.1` and runs without auth — the browser tab and the
+daemon are the same person's machine, and the OS user boundary is the security boundary.
+
+For **any non-loopback backend** — an SSH/Cloudflare tunnel, a LAN bind (`--host 0.0.0.0`),
+or a reverse proxy in front of the daemon — token auth is a hard **MUST**, not a
+recommendation. An unauthenticated non-loopback daemon exposes your full run history and
+agent spawn control to anyone who can reach the port. Set a bearer token before exposing it:
+
+```bash
+export LIONAGI_STUDIO_AUTH_TOKEN="$(openssl rand -hex 32)"
+li studio start --no-frontend
+```
+
+The frontend prompts for the token and sends it as `Authorization: Bearer <token>` on
+every request. Rotate it like any credential; never commit it.

--- a/apps/studio/frontend/HOSTING.md
+++ b/apps/studio/frontend/HOSTING.md
@@ -41,5 +41,9 @@ export LIONAGI_STUDIO_AUTH_TOKEN="$(openssl rand -hex 32)"
 li studio start --no-frontend
 ```
 
-The frontend prompts for the token and sends it as `Authorization: Bearer <token>` on
-every request. Rotate it like any credential; never commit it.
+Clients send it as `Authorization: Bearer <token>` on every request. The hosted SPA has
+no token-entry UI today — it only attaches a token injected as
+`window.__STUDIO_AUTH_TOKEN__` (the desktop shell does this). So a token-protected
+non-loopback daemon is currently for API/desktop-shell use; treat the hosted page as
+loopback-only until a token prompt ships. Rotate the token like any credential; never
+commit it.

--- a/apps/studio/frontend/README.md
+++ b/apps/studio/frontend/README.md
@@ -44,7 +44,7 @@ Talks to the Lion Studio backend at `process.env.NEXT_PUBLIC_STUDIO_API_BASE`
 uv pip install -e '.[studio]'
 
 # Start backend
-li studio start --frontend-mode none --port 8765
+li studio start --no-frontend --port 8765
 
 # In another shell: start frontend (dev mode)
 cd apps/studio/frontend

--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -136,7 +136,11 @@ def _validate_mode_flags(args: argparse.Namespace) -> None:
         if getattr(args, attr, False)
     ]
     if len(selected) > 1:
-        raise SystemExit(f"li studio: mode flags are mutually exclusive: {' '.join(selected)}")
+        print(
+            f"li studio: mode flags are mutually exclusive: {' '.join(selected)}",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
 
 
 def run_studio(args: argparse.Namespace) -> int:

--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -49,28 +49,36 @@ def _is_mount_allowed(resolved_path: Path, allowed_roots: list[Path]) -> bool:
     return False
 
 
-def _add_studio_flags(parser: argparse.ArgumentParser) -> None:
+def _add_studio_flags(parser: argparse.ArgumentParser, *, suppress_defaults: bool = False) -> None:
+    # The same flags are registered on both the parent `studio` parser and the
+    # `start` subparser. The subparser must SUPPRESS its defaults, otherwise its
+    # unset defaults overwrite values parsed at the parent level (e.g.
+    # `li studio --docker start` would silently lose --docker).
+    def _default(value):
+        return argparse.SUPPRESS if suppress_defaults else value
+
     parser.add_argument(
         "--port",
         type=int,
-        default=None,
+        default=_default(None),
         help="Backend API port (default: LIONAGI_STUDIO_PORT env or 8765)",
     )
     parser.add_argument(
         "--host",
-        default="127.0.0.1",
+        default=_default("127.0.0.1"),
         help="Host to bind (default: 127.0.0.1)",
     )
     parser.add_argument(
         "--frontend-port",
         type=int,
-        default=3000,
+        default=_default(3000),
         dest="frontend_port",
         help="Frontend port (default: 3000)",
     )
     parser.add_argument(
         "--no-open",
         action="store_true",
+        default=_default(False),
         dest="no_open",
         help="Don't open the hosted UI in a browser (--web only)",
     )
@@ -78,22 +86,26 @@ def _add_studio_flags(parser: argparse.ArgumentParser) -> None:
     mode.add_argument(
         "--web",
         action="store_true",
+        default=_default(False),
         help="Start the backend only; frontend is the hosted UI (default)",
     )
     mode.add_argument(
         "--docker",
         action="store_true",
+        default=_default(False),
         help="Run the bundled frontend + backend via Docker",
     )
     mode.add_argument(
         "--no-frontend",
         action="store_true",
+        default=_default(False),
         dest="no_frontend",
         help="Only start the backend API server",
     )
     mode.add_argument(
         "--dev",
         action="store_true",
+        default=_default(False),
         help="Run the in-repo frontend in dev mode (hot-reload, no build step)",
     )
 
@@ -106,12 +118,31 @@ def add_studio_subparser(subparsers: argparse._SubParsersAction) -> None:
     studio_sub.required = False
 
     start_parser = studio_sub.add_parser("start", help="Start Lion Studio")
-    _add_studio_flags(start_parser)
+    _add_studio_flags(start_parser, suppress_defaults=True)
+
+
+def _validate_mode_flags(args: argparse.Namespace) -> None:
+    # Mutual exclusion can be split across the parent parser and the `start`
+    # subparser (e.g. `li studio --docker start --web`), which argparse's
+    # per-parser groups cannot see. Validate the combined namespace.
+    selected = [
+        flag
+        for flag, attr in (
+            ("--web", "web"),
+            ("--docker", "docker"),
+            ("--no-frontend", "no_frontend"),
+            ("--dev", "dev"),
+        )
+        if getattr(args, attr, False)
+    ]
+    if len(selected) > 1:
+        raise SystemExit(f"li studio: mode flags are mutually exclusive: {' '.join(selected)}")
 
 
 def run_studio(args: argparse.Namespace) -> int:
     if not getattr(args, "studio_action", None):
         args.studio_action = "start"
+    _validate_mode_flags(args)
     return _studio_start(args)
 
 

--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -17,6 +17,7 @@ from typing import Any
 from lionagi.cli._logging import warn
 
 _STUDIO_IMAGE = "ghcr.io/ohdearquant/lion-studio:latest"
+_HOSTED_URL = "https://lion-studio.khive.ai"
 
 # Keys the scheduler engine's chain-fire merge (`{**schedule, **chain_action}`,
 # see studio/scheduler/engine.py) actually understands. Anything else would
@@ -68,21 +69,32 @@ def _add_studio_flags(parser: argparse.ArgumentParser) -> None:
         help="Frontend port (default: 3000)",
     )
     parser.add_argument(
+        "--no-open",
+        action="store_true",
+        dest="no_open",
+        help="Don't open the hosted UI in a browser (--web only)",
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--web",
+        action="store_true",
+        help="Start the backend only; frontend is the hosted UI (default)",
+    )
+    mode.add_argument(
+        "--docker",
+        action="store_true",
+        help="Run the bundled frontend + backend via Docker",
+    )
+    mode.add_argument(
         "--no-frontend",
         action="store_true",
         dest="no_frontend",
         help="Only start the backend API server",
     )
-    parser.add_argument(
+    mode.add_argument(
         "--dev",
         action="store_true",
-        help="Run frontend in dev mode (hot-reload, no build step)",
-    )
-    parser.add_argument(
-        "--no-docker",
-        action="store_true",
-        dest="no_docker",
-        help="Don't use Docker even if available",
+        help="Run the in-repo frontend in dev mode (hot-reload, no build step)",
     )
 
 
@@ -151,30 +163,38 @@ def _studio_start(args: argparse.Namespace) -> int:
     )
     host: str = getattr(args, "host", "127.0.0.1")
     no_frontend: bool = getattr(args, "no_frontend", False)
-    no_docker: bool = getattr(args, "no_docker", False)
+    use_docker: bool = getattr(args, "docker", False)
     dev_mode: bool = getattr(args, "dev", False)
+    no_open: bool = getattr(args, "no_open", False)
     frontend_port: int = getattr(args, "frontend_port", 3000)
-
-    frontend_dir = _find_frontend_dir()
 
     if no_frontend:
         return _start_backend_only(host, port)
 
-    if dev_mode or frontend_dir:
-        return _start_local(host, port, frontend_port, frontend_dir, dev_mode)
+    if dev_mode:
+        frontend_dir = _find_frontend_dir()
+        return _start_local(host, port, frontend_port, frontend_dir, dev_mode=True)
 
-    if not no_docker and _has_docker():
+    if use_docker:
+        if not _has_docker():
+            print("Error: Docker not found. Install it from https://docker.com/", file=sys.stderr)
+            return 1
         return _start_docker(host, port, frontend_port)
 
-    # Fallback: backend only
-    print("Lion Studio: starting backend only (no frontend available)")
+    # Default (bare `li studio` / `--web`): hosted frontend, local daemon only.
+    return _start_hosted(host, port, no_open)
+
+
+def _start_hosted(host: str, port: int, no_open: bool) -> int:
+    daemon_url = f"http://127.0.0.1:{port}"
+    print(f"Lion Studio: {_HOSTED_URL}")
+    print(f"  connects to your local daemon at {daemon_url}")
     print()
-    print("To get the full UI, either:")
-    print(f"  1. Install Docker and run: li studio        (auto-pulls {_STUDIO_IMAGE})")
-    print("  2. Clone the repo and build once:")
-    print("       git clone https://github.com/ohdearquant/lionagi.git")
-    print("       cd lionagi && li studio")
-    print()
+    if not no_open and sys.stdin.isatty() and sys.stdout.isatty():
+        import webbrowser
+
+        with contextlib.suppress(Exception):
+            webbrowser.open(_HOSTED_URL)
     return _start_backend_only(host, port)
 
 

--- a/tests/cli/test_studio_cli.py
+++ b/tests/cli/test_studio_cli.py
@@ -220,6 +220,7 @@ def test_studio_no_open_before_start_is_preserved():
         _stubbed_serve(),
         patch("webbrowser.open") as mock_open,
         patch("sys.stdout.isatty", return_value=True),
+        patch("sys.stdin.isatty", return_value=True),
     ):
         from lionagi.cli.main import main
 
@@ -251,8 +252,9 @@ def test_studio_cross_level_mode_flags_are_mutually_exclusive():
         ["studio", "--web", "start", "--docker"],
         ["studio", "--no-frontend", "start", "--dev"],
     ):
-        with pytest.raises(SystemExit):
+        with pytest.raises(SystemExit) as exc_info:
             main(argv)
+        assert exc_info.value.code == 2
 
 
 # ─── studio cwd / module resolution ─────────────

--- a/tests/cli/test_studio_cli.py
+++ b/tests/cli/test_studio_cli.py
@@ -77,6 +77,128 @@ def test_studio_bare_uses_default_port(monkeypatch):
     assert kwargs.get("port") == 8765
 
 
+# ─── frontend-mode flags: --web (default) / --docker / --no-frontend ────────
+
+
+def test_studio_bare_defaults_to_hosted_web_mode(capsys):
+    """Bare ``li studio`` prints the hosted URL and starts the backend only."""
+    with _stubbed_serve() as mock_run:
+        from lionagi.cli.main import main
+
+        result = main(["studio"])
+
+    assert result == 0
+    mock_run.assert_called_once()
+    out = capsys.readouterr().out
+    assert "https://lion-studio.khive.ai" in out
+    assert "127.0.0.1:8765" in out
+
+
+def test_studio_web_flag_matches_default(capsys):
+    """``li studio --web`` is explicit but behaves identically to bare invocation."""
+    with _stubbed_serve() as mock_run:
+        from lionagi.cli.main import main
+
+        result = main(["studio", "--web"])
+
+    assert result == 0
+    mock_run.assert_called_once()
+    assert "https://lion-studio.khive.ai" in capsys.readouterr().out
+
+
+def test_studio_web_does_not_build_local_frontend():
+    """--web must never call the local frontend builder."""
+    with (
+        patch("uvicorn.run"),
+        patch("lionagi.studio.cli._ensure_frontend_built") as mock_build,
+    ):
+        from lionagi.cli.main import main
+
+        result = main(["studio", "--web"])
+
+    assert result == 0
+    mock_build.assert_not_called()
+
+
+def test_studio_web_opens_browser_when_interactive(monkeypatch):
+    """A TTY session opens the hosted URL unless --no-open is set."""
+    import lionagi.studio.cli as studio_cli
+
+    monkeypatch.setattr(studio_cli.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(studio_cli.sys.stdout, "isatty", lambda: True)
+    with patch("webbrowser.open") as mock_open, patch("uvicorn.run"):
+        from lionagi.cli.main import main
+
+        result = main(["studio", "--web"])
+
+    assert result == 0
+    mock_open.assert_called_once_with("https://lion-studio.khive.ai")
+
+
+def test_studio_web_no_open_flag_suppresses_browser(monkeypatch):
+    """--no-open skips opening a browser even in an interactive session."""
+    import lionagi.studio.cli as studio_cli
+
+    monkeypatch.setattr(studio_cli.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(studio_cli.sys.stdout, "isatty", lambda: True)
+    with patch("webbrowser.open") as mock_open, patch("uvicorn.run"):
+        from lionagi.cli.main import main
+
+        result = main(["studio", "--web", "--no-open"])
+
+    assert result == 0
+    mock_open.assert_not_called()
+
+
+def test_studio_no_frontend_flag_skips_hosted_messaging(capsys):
+    """--no-frontend stays backend-only with no hosted-URL messaging."""
+    with _stubbed_serve() as mock_run:
+        from lionagi.cli.main import main
+
+        result = main(["studio", "--no-frontend"])
+
+    assert result == 0
+    mock_run.assert_called_once()
+    assert "lion-studio.khive.ai" not in capsys.readouterr().out
+
+
+def test_studio_docker_flag_invokes_docker_path():
+    """--docker dispatches to the Docker launch path, not the hosted or local one."""
+    with (
+        patch("lionagi.studio.cli._has_docker", return_value=True),
+        patch("lionagi.studio.cli._start_docker", return_value=0) as mock_docker,
+        patch("uvicorn.run"),
+    ):
+        from lionagi.cli.main import main
+
+        result = main(["studio", "--docker"])
+
+    assert result == 0
+    mock_docker.assert_called_once()
+
+
+def test_studio_docker_flag_without_docker_installed_errors(capsys):
+    """--docker without the docker binary available fails loudly instead of falling back."""
+    with patch("lionagi.studio.cli._has_docker", return_value=False), patch("uvicorn.run"):
+        from lionagi.cli.main import main
+
+        result = main(["studio", "--docker"])
+
+    assert result == 1
+    assert "Docker not found" in capsys.readouterr().err
+
+
+def test_studio_mode_flags_are_mutually_exclusive():
+    """Combining two mode flags (e.g. --web and --docker) is a usage error."""
+    import pytest
+
+    from lionagi.cli.main import main
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(["studio", "--web", "--docker"])
+    assert exc_info.value.code == 2
+
+
 # ─── studio cwd / module resolution ─────────────
 
 

--- a/tests/cli/test_studio_cli.py
+++ b/tests/cli/test_studio_cli.py
@@ -199,6 +199,62 @@ def test_studio_mode_flags_are_mutually_exclusive():
     assert exc_info.value.code == 2
 
 
+def test_studio_mode_flag_before_start_is_preserved():
+    """`li studio --docker start` must take the Docker path (subparser defaults must not clobber parent flags)."""
+    with (
+        patch("lionagi.studio.cli._has_docker", return_value=True),
+        patch("lionagi.studio.cli._start_docker", return_value=0) as mock_docker,
+        patch("uvicorn.run"),
+    ):
+        from lionagi.cli.main import main
+
+        result = main(["studio", "--docker", "start"])
+
+    assert result == 0
+    mock_docker.assert_called_once()
+
+
+def test_studio_no_open_before_start_is_preserved():
+    """`li studio --no-open start` must not open a browser."""
+    with (
+        _stubbed_serve(),
+        patch("webbrowser.open") as mock_open,
+        patch("sys.stdout.isatty", return_value=True),
+    ):
+        from lionagi.cli.main import main
+
+        result = main(["studio", "--no-open", "start"])
+
+    assert result == 0
+    mock_open.assert_not_called()
+
+
+def test_studio_port_before_start_is_preserved():
+    """`li studio --port 9001 start` keeps the parent-level port."""
+    with _stubbed_serve() as mock_run:
+        from lionagi.cli.main import main
+
+        result = main(["studio", "--port", "9001", "start"])
+
+    assert result == 0
+    assert mock_run.call_args.kwargs.get("port") == 9001
+
+
+def test_studio_cross_level_mode_flags_are_mutually_exclusive():
+    """Mode flags split across parser levels (`li studio --docker start --web`) must be rejected."""
+    import pytest
+
+    from lionagi.cli.main import main
+
+    for argv in (
+        ["studio", "--docker", "start", "--web"],
+        ["studio", "--web", "start", "--docker"],
+        ["studio", "--no-frontend", "start", "--dev"],
+    ):
+        with pytest.raises(SystemExit):
+            main(argv)
+
+
 # ─── studio cwd / module resolution ─────────────
 
 


### PR DESCRIPTION
Owner-specified CLI surface for how `li studio` serves its frontend:

- **`li studio` / `li studio --web` (new default)** — starts only the local daemon and points the operator at the hosted UI (https://lion-studio.khive.ai): prints the hosted URL plus the local-daemon connection expectation on startup, and opens the browser (suppress with `--no-open`). No local frontend build/serve in this mode.
- **`li studio --docker`** — the previous docker-backed frontend path, kept but no longer the default.
- **`li studio --no-frontend`** — daemon only, unchanged.

Flags are mutually exclusive. Mirror behavior untouched (in-process Claude Code tail default stays as-is). Docs: root README "Lion Studio" section rewritten around the three modes; HOSTING.md gains the CLI note plus an auth section making token auth a hard MUST for any non-loopback daemon, with a copy-pasteable `LIONAGI_STUDIO_AUTH_TOKEN` block and an honest note that the hosted SPA has no token-entry UI yet.

Gate: tests/cli/test_studio_cli.py — 32 passed (new flag-parsing + mode-selection coverage); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)