### PR TITLE
feat(studio): khive.ai top-bar link and ecosystem footer line

### DIFF
--- a/apps/studio/frontend/src/components/shell/AppShell.tsx
+++ b/apps/studio/frontend/src/components/shell/AppShell.tsx
@@ -5,6 +5,7 @@ import LeoPanel from "@/components/leo/LeoPanel";
 import IconRail from "./IconRail";
 import CommandPalette from "./CommandPalette";
 import StatusFooter from "./StatusFooter";
+import TopBar from "./TopBar";
 
 const LEO_OPEN_KEY = "studio:leo-open";
 
@@ -103,6 +104,9 @@ export default function AppShell({ children, locale, onLocaleChange }: Props) {
 
         {/* Main area */}
         <div className="flex flex-1 flex-col overflow-hidden">
+          {/* Top bar */}
+          <TopBar />
+
           {/* Content */}
           <main
             id="main-content"

--- a/apps/studio/frontend/src/components/shell/StatusFooter.tsx
+++ b/apps/studio/frontend/src/components/shell/StatusFooter.tsx
@@ -85,6 +85,22 @@ export default function StatusFooter() {
           </span>
         </>
       ) : null}
+
+      {/* Ecosystem note */}
+      <span className="ml-auto truncate">
+        {t("footer.ecosystemPrefix")}{" "}
+        <a
+          href="https://khive.ai"
+          target="_blank"
+          rel="noopener noreferrer"
+          title={t("footer.ecosystemLink")}
+          className="text-content-muted underline decoration-edge-strong underline-offset-2 transition-colors duration-100 hover:text-content-primary"
+        >
+          {t("footer.ecosystemLink")}
+        </a>{" "}
+        {t("footer.ecosystemSuffix")}
+        <span className="sr-only"> ({t("footer.ecosystemNewTab")})</span>
+      </span>
     </footer>
   );
 }

--- a/apps/studio/frontend/src/components/shell/TopBar.tsx
+++ b/apps/studio/frontend/src/components/shell/TopBar.tsx
@@ -1,0 +1,24 @@
+import { useTranslations } from "use-intl";
+
+export default function TopBar() {
+  const t = useTranslations("shell");
+  const isTauri = typeof window !== "undefined" && "__TAURI__" in window;
+
+  return (
+    <div
+      className="flex min-h-8 shrink-0 items-center justify-end border-b border-edge px-3"
+      style={{ paddingTop: isTauri ? 40 : undefined }}
+    >
+      <a
+        href="https://khive.ai"
+        target="_blank"
+        rel="noopener noreferrer"
+        title={t("topbar.khiveLink")}
+        className="text-[length:var(--t-xs)] text-content-muted transition-colors duration-100 hover:text-content-primary"
+      >
+        {t("topbar.khiveLink")}
+        <span className="sr-only"> ({t("topbar.newTab")})</span>
+      </a>
+    </div>
+  );
+}

--- a/apps/studio/frontend/src/components/shell/shell.test.tsx
+++ b/apps/studio/frontend/src/components/shell/shell.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * shell/ contract tests — khive.ai top-bar link and ecosystem footer line.
+ *
+ * Covers:
+ * - TopBar.tsx exists, is wired into AppShell, and renders a new-tab
+ *   khive.ai link with the correct href/target/rel
+ * - StatusFooter.tsx renders the ecosystem note with a matching link
+ */
+
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const SHELL_DIR = path.resolve(__dirname);
+
+function read(file: string): string {
+  return fs.readFileSync(path.join(SHELL_DIR, file), "utf-8");
+}
+
+describe("TopBar.tsx — new-tab khive.ai link", () => {
+  it("exists", () => {
+    expect(fs.existsSync(path.join(SHELL_DIR, "TopBar.tsx"))).toBe(true);
+  });
+
+  const src = read("TopBar.tsx");
+
+  it("links to https://khive.ai", () => {
+    expect(src).toMatch(/href="https:\/\/khive\.ai"/);
+  });
+
+  it("opens in a new tab", () => {
+    expect(src).toMatch(/target="_blank"/);
+  });
+
+  it("guards the new tab with rel=noopener noreferrer", () => {
+    expect(src).toMatch(/rel="noopener noreferrer"/);
+  });
+
+  it("is styled as a quiet link (muted foreground, brightens on hover)", () => {
+    expect(src).toMatch(/text-content-muted/);
+    expect(src).toMatch(/hover:text-content-primary/);
+  });
+});
+
+describe("AppShell.tsx — TopBar wiring", () => {
+  const src = read("AppShell.tsx");
+
+  it("imports TopBar", () => {
+    expect(src).toMatch(/import TopBar from ".\/TopBar"/);
+  });
+
+  it("renders <TopBar", () => {
+    expect(src).toMatch(/<TopBar/);
+  });
+
+  it("keeps IconRail (logo/home behavior untouched)", () => {
+    expect(src).toMatch(/<IconRail/);
+  });
+});
+
+describe("StatusFooter.tsx — khive.ai ecosystem note", () => {
+  const src = read("StatusFooter.tsx");
+
+  it("links to https://khive.ai", () => {
+    expect(src).toMatch(/href="https:\/\/khive\.ai"/);
+  });
+
+  it("opens in a new tab with rel=noopener noreferrer", () => {
+    expect(src).toMatch(/target="_blank"/);
+    expect(src).toMatch(/rel="noopener noreferrer"/);
+  });
+
+  it("renders the ecosystem prefix/suffix copy via i18n", () => {
+    expect(src).toMatch(/footer\.ecosystemPrefix/);
+    expect(src).toMatch(/footer\.ecosystemLink/);
+    expect(src).toMatch(/footer\.ecosystemSuffix/);
+  });
+});
+
+describe("messages — topbar + footer.ecosystem keys present in both locales", () => {
+  const MESSAGES_DIR = path.resolve(SHELL_DIR, "../../messages");
+
+  for (const locale of ["en", "zh"]) {
+    it(`${locale}.json has shell.topbar.khiveLink and shell.footer.ecosystem*`, () => {
+      const messages = JSON.parse(
+        fs.readFileSync(path.join(MESSAGES_DIR, `${locale}.json`), "utf-8"),
+      );
+      expect(messages.shell.topbar.khiveLink).toBe("khive.ai");
+      expect(messages.shell.footer.ecosystemLink).toBe("khive.ai");
+      expect(typeof messages.shell.footer.ecosystemPrefix).toBe("string");
+      expect(typeof messages.shell.footer.ecosystemSuffix).toBe("string");
+    });
+  }
+});

--- a/apps/studio/frontend/src/messages/en.json
+++ b/apps/studio/frontend/src/messages/en.json
@@ -20,11 +20,19 @@
     "main": {
       "ariaLabel": "Main content"
     },
+    "topbar": {
+      "khiveLink": "khive.ai",
+      "newTab": "opens in a new tab"
+    },
     "footer": {
       "healthy": "Backend healthy",
       "unhealthy": "Backend unreachable",
       "db": "DB",
-      "version": "v"
+      "version": "v",
+      "ecosystemPrefix": "Lion Studio is part of the",
+      "ecosystemLink": "khive.ai",
+      "ecosystemSuffix": "ecosystem",
+      "ecosystemNewTab": "opens in a new tab"
     },
     "tabs": {
       "overview": "Overview",

--- a/apps/studio/frontend/src/messages/zh.json
+++ b/apps/studio/frontend/src/messages/zh.json
@@ -20,11 +20,19 @@
     "main": {
       "ariaLabel": "主要内容"
     },
+    "topbar": {
+      "khiveLink": "khive.ai",
+      "newTab": "在新标签页中打开"
+    },
     "footer": {
       "healthy": "后端正常",
       "unhealthy": "后端不可达",
       "db": "数据库",
-      "version": "v"
+      "version": "v",
+      "ecosystemPrefix": "Lion Studio 是",
+      "ecosystemLink": "khive.ai",
+      "ecosystemSuffix": "生态系统的一部分",
+      "ecosystemNewTab": "在新标签页中打开"
     },
     "tabs": {
       "overview": "总览",


### PR DESCRIPTION
Adds the site riders for the hosted Studio deploy:

- Quiet, muted khive.ai link (new tab, noopener/noreferrer) in a new TopBar above the main content column; icon-rail home link untouched.
- One-line "part of the khive.ai ecosystem" note in StatusFooter, same new-tab link.
- Strings wired through messages/en.json + zh.json.
- shell.test.tsx covering href/target/rel and i18n keys (13 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)