### PR TITLE
feat(cli): li agent --context-from for cross-agent context handoff

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -53,8 +53,16 @@ li agent [model] prompt [flags]
 | `-a, --agent NAME` | none | Profile by name. Resolves `.lionagi/agents/<NAME>/<NAME>.md` first, then legacy `.lionagi/agents/<NAME>.md`. Sets model/effort/system/yolo. `cli/agent.py:167` |
 | `-r, --resume BRANCH_ID` | none | Resume prior branch. `cli/agent.py:178` |
 | `-c, --continue-last` | false | Resume most recent branch. `cli/agent.py:184` |
+| `--context-from REF` | none | Inject distilled context from a prior session id, branch id, run id, or file path into the new branch's first instruction (above the prompt). Repeatable — refs concatenate in argv order, sharing one budget. `cli/_context_from.py` |
+| `--context-budget N` | `8000` | Total token budget (~4 chars/token) for `--context-from` content, shared across all refs. |
 
-`-r` and `-c` are mutually exclusive (`cli/agent.py:49`). Common flags apply.
+`-r` and `-c` are mutually exclusive (`cli/agent.py:49`). `--context-from` is rejected together with `-r` / `-c` (resume already carries the source context). Common flags apply.
+
+`--context-from` resolves the ref in order — session id, branch id, run id, then file path — erroring loudly on an unresolvable or ambiguous (2+ match) ref rather than spawning with silently-missing context. Distillation is mechanical (no LLM): a saved artifact/summary verbatim if it fits, else the initial instruction plus final assistant message, else a loudly-marked head/tail truncation.
+
+```bash
+li agent -a reviewer --bypass --context-from 20260420T110143-a1b2c3 --prompt-file review.md
+```
 
 ```bash
 li agent claude/sonnet "What does Branch.operate() do?"

--- a/lionagi/cli/_context_from.py
+++ b/lionagi/cli/_context_from.py
@@ -308,18 +308,75 @@ def build_context_block(candidates: Sequence[ContextCandidate], budget_tokens: i
 
     The budget bounds the COMBINED injected block, including the XML wrapper
     (open/close tags) and the inter-block separator — not just the distilled
-    payload text. Wrapper overhead is charged against each ref's slice, in
-    argv order, before the remaining budget is handed to the distillation
-    ladder for that ref's payload.
+    payload text. Wrapper + loud-marker overhead is reserved FIRST, in argv
+    order, before the remaining budget is handed to the distillation ladder
+    for payload text.
+
+    A single ref always yields at least one loud-marker-only block (never an
+    empty result) even at a budget too tight to fit it, including
+    `budget_tokens == 0` (an explicit "marker only, no payload" request, not
+    "no budget passed"): there is nothing left to drop it in favor of, and a
+    silently-missing context block is worse than a slightly over-budget loud
+    marker for the one ref the caller asked for.
+
+    With multiple refs, the total budget is a hard ceiling: wrapper +
+    separator + minimum loud-marker overhead is reserved for each ref, in
+    argv order, and any ref (and all after it, since the reserved budget only
+    shrinks) that cannot fit even that minimum is dropped entirely rather
+    than pushing the combined block over budget. If even the first ref
+    cannot fit, injection is skipped entirely (no block at all).
     """
     from lionagi.cli._logging import warn
 
-    remaining = budget_tokens * _CHARS_PER_TOKEN
-    blocks: list[str] = []
-    for i, candidate in enumerate(candidates):
+    if not candidates:
+        return ""
+
+    total_budget = budget_tokens * _CHARS_PER_TOKEN
+
+    if len(candidates) == 1:
+        candidate = candidates[0]
         overhead = len(_wrap_block(candidate, ""))
-        if i > 0:
-            overhead += len(_BLOCK_SEPARATOR)
+        text, truncated = _distill(candidate, max(total_budget - overhead, 0))
+        if truncated:
+            warn(
+                f"--context-from {candidate.ref!r}: content exceeded the "
+                f"{budget_tokens}-token budget, truncated (loud, not fatal)"
+            )
+        return _wrap_block(candidate, text)
+
+    marker_min = len(_TRUNCATION_MARKER.strip())
+
+    # Reserve wrapper + separator + minimum loud-marker overhead for each
+    # candidate, in argv order, dropping any candidate (and all after it,
+    # since the reserved budget only shrinks) that cannot fit even that
+    # minimum within what remains of the total budget.
+    fitted: list[tuple[ContextCandidate, int]] = []
+    reserved = 0
+    for candidate in candidates:
+        overhead = len(_wrap_block(candidate, "")) + (len(_BLOCK_SEPARATOR) if fitted else 0)
+        if reserved + overhead + marker_min > total_budget:
+            break
+        fitted.append((candidate, overhead))
+        reserved += overhead
+
+    if not fitted:
+        warn(
+            f"--context-from: total budget ({budget_tokens} tokens) is too small to "
+            "fit even the minimum wrapped context block; skipping context "
+            "injection entirely (no context was added)"
+        )
+        return ""
+
+    if len(fitted) < len(candidates):
+        dropped = [c.ref for c in candidates[len(fitted) :]]
+        warn(
+            f"--context-from: total budget ({budget_tokens} tokens) has no room left "
+            f"for {dropped!r}; dropped entirely rather than exceeding the budget"
+        )
+
+    remaining = total_budget
+    blocks: list[str] = []
+    for candidate, overhead in fitted:
         text_budget = max(remaining - overhead, 0)
         text, truncated = _distill(candidate, text_budget)
         remaining -= overhead + len(text)

--- a/lionagi/cli/_context_from.py
+++ b/lionagi/cli/_context_from.py
@@ -5,9 +5,10 @@
 Ref resolution order: session id (state.db, prefix match) -> branch id
 (~/.lionagi/runs/*/branches/*.json, prefix match) -> run id (run.json manifest
 prefix match) -> file path. Distillation is mechanical (no LLM): a saved
-artifact/summary verbatim, else the initial instruction + final assistant
-message, else a loudly-marked head/tail truncation to fit budget. Budget is
-shared across all refs, allocated in argv order.
+artifact/summary verbatim, else the final assistant message + initial
+instruction, else a loudly-marked head/tail truncation to fit budget. Budget
+is shared across the combined injected block (including XML wrapper and
+inter-block separators), allocated in argv order.
 """
 
 from __future__ import annotations
@@ -46,7 +47,7 @@ class ContextCandidate:
     ref: str
     model: str | None
     step1_text: str | None = None  # saved artifact/summary, verbatim if it fits
-    step2_text: str | None = None  # initial instruction + final assistant message
+    step2_text: str | None = None  # final assistant message + initial instruction
     step3_head: str | None = None  # head half for loud truncation
     step3_tail: str | None = None  # tail half for loud truncation
 
@@ -221,7 +222,7 @@ async def _candidate_from_branch(db, branch_id: str, ref: str, kind: str) -> Con
     if branch_row.get("provider") and branch_row.get("model"):
         model = f"{branch_row['provider']}/{branch_row['model']}"
 
-    step2 = f"{initial_text}\n\n{final_text}" if initial_text else final_text
+    step2 = f"{final_text}\n\n{initial_text}" if initial_text else final_text
     return ContextCandidate(
         kind=kind,
         ref=ref,
@@ -299,22 +300,36 @@ def _wrap_block(candidate: ContextCandidate, text: str) -> str:
     )
 
 
+_BLOCK_SEPARATOR = "\n\n"
+
+
 def build_context_block(candidates: Sequence[ContextCandidate], budget_tokens: int) -> str:
-    """Assemble the XML-delimited context block(s), argv order, total-not-per-ref budget."""
+    """Assemble the XML-delimited context block(s), argv order, total-not-per-ref budget.
+
+    The budget bounds the COMBINED injected block, including the XML wrapper
+    (open/close tags) and the inter-block separator — not just the distilled
+    payload text. Wrapper overhead is charged against each ref's slice, in
+    argv order, before the remaining budget is handed to the distillation
+    ladder for that ref's payload.
+    """
     from lionagi.cli._logging import warn
 
     remaining = budget_tokens * _CHARS_PER_TOKEN
     blocks: list[str] = []
-    for candidate in candidates:
-        text, truncated = _distill(candidate, max(remaining, 0))
-        remaining -= len(text)
+    for i, candidate in enumerate(candidates):
+        overhead = len(_wrap_block(candidate, ""))
+        if i > 0:
+            overhead += len(_BLOCK_SEPARATOR)
+        text_budget = max(remaining - overhead, 0)
+        text, truncated = _distill(candidate, text_budget)
+        remaining -= overhead + len(text)
         if truncated:
             warn(
                 f"--context-from {candidate.ref!r}: content exceeded the "
                 f"{budget_tokens}-token budget, truncated (loud, not fatal)"
             )
         blocks.append(_wrap_block(candidate, text))
-    return "\n\n".join(blocks)
+    return _BLOCK_SEPARATOR.join(blocks)
 
 
 async def resolve_and_build_context_block(refs: Sequence[str], budget_tokens: int) -> str:

--- a/lionagi/cli/_context_from.py
+++ b/lionagi/cli/_context_from.py
@@ -1,0 +1,322 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""`li agent --context-from <ref>`: resolve prior-run refs into a bounded context block.
+
+Ref resolution order: session id (state.db, prefix match) -> branch id
+(~/.lionagi/runs/*/branches/*.json, prefix match) -> run id (run.json manifest
+prefix match) -> file path. Distillation is mechanical (no LLM): a saved
+artifact/summary verbatim, else the initial instruction + final assistant
+message, else a loudly-marked head/tail truncation to fit budget. Budget is
+shared across all refs, allocated in argv order.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from lionagi._paths import RUNS_ROOT
+
+DEFAULT_CONTEXT_BUDGET_TOKENS = 8000
+_CHARS_PER_TOKEN = 4
+_TRUNCATION_MARKER = "\n[...truncated...]\n"
+
+
+class ContextFromError(ValueError):
+    """A `--context-from` ref could not be resolved or composed."""
+
+
+class AmbiguousContextRefError(ContextFromError):
+    """A `--context-from` ref prefix matched 2+ candidates."""
+
+    def __init__(self, ref: str, candidates: list[str]):
+        self.ref = ref
+        self.candidates = candidates
+        listed = ", ".join(candidates)
+        super().__init__(f"--context-from {ref!r} is ambiguous: matches {listed}")
+
+
+@dataclass
+class ContextCandidate:
+    """One resolved `--context-from` source, ready for distillation."""
+
+    kind: str
+    ref: str
+    model: str | None
+    step1_text: str | None = None  # saved artifact/summary, verbatim if it fits
+    step2_text: str | None = None  # initial instruction + final assistant message
+    step3_head: str | None = None  # head half for loud truncation
+    step3_tail: str | None = None  # tail half for loud truncation
+
+
+# ── Filesystem resolution (branch id / run id) ──────────────────────────────
+
+
+def _find_branch_candidates(ref: str) -> list[tuple[str, Path]]:
+    """All distinct (branch_id, path) matches for *ref* as an exact id or prefix.
+
+    Mirrors _runs.find_branch's glob scan but collects every distinct branch_id
+    across all run dirs (instead of returning the first) so ambiguity can be
+    detected; the same branch_id snapshotted into multiple run dirs (resume)
+    is one candidate, not many.
+    """
+    seen: dict[str, Path] = {}
+    if RUNS_ROOT.exists():
+        for run_dir in sorted(RUNS_ROOT.iterdir(), key=lambda p: p.stat().st_mtime, reverse=True):
+            if not run_dir.is_dir():
+                continue
+            branches = run_dir / "branches"
+            if not branches.exists():
+                continue
+            for match in branches.glob(f"{ref}*.json"):
+                seen.setdefault(match.stem, match)
+    return sorted(seen.items())
+
+
+def _resolve_branch_ref(ref: str) -> str | None:
+    candidates = _find_branch_candidates(ref)
+    if not candidates:
+        return None
+    if len(candidates) > 1:
+        raise AmbiguousContextRefError(ref, [bid for bid, _ in candidates])
+    return candidates[0][0]
+
+
+def _find_run_candidates(ref: str) -> list[str]:
+    if not RUNS_ROOT.exists():
+        return []
+    return sorted(p.name for p in RUNS_ROOT.iterdir() if p.is_dir() and p.name.startswith(ref))
+
+
+def _resolve_run_ref(ref: str) -> str | None:
+    candidates = _find_run_candidates(ref)
+    if not candidates:
+        return None
+    if len(candidates) > 1:
+        raise AmbiguousContextRefError(ref, candidates)
+    return candidates[0]
+
+
+def _primary_branch_for_run(run_id: str) -> str | None:
+    run_dir = RUNS_ROOT / run_id
+    manifest_path = run_dir / "run.json"
+    if manifest_path.exists():
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except (OSError, ValueError):
+            manifest = {}
+        branch_id = manifest.get("branch_id")
+        if branch_id:
+            return branch_id
+    branches_dir = run_dir / "branches"
+    if not branches_dir.exists():
+        return None
+    files = sorted(branches_dir.glob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True)
+    return files[0].stem if files else None
+
+
+def _resolve_file_ref(ref: str) -> ContextCandidate | None:
+    path = Path(ref).expanduser()
+    if not path.is_file():
+        return None
+    text = path.read_text()
+    return ContextCandidate(
+        kind="file", ref=ref, model=None, step1_text=text, step3_head=text, step3_tail=text
+    )
+
+
+# ── State-db resolution (session id, and message content for any branch) ────
+
+
+def _extract_message_text(msg: dict) -> str:
+    content = msg.get("content")
+    if isinstance(content, str):
+        try:
+            content = json.loads(content)
+        except (ValueError, TypeError):
+            return content
+    if isinstance(content, dict):
+        return str(
+            content.get("assistant_response")
+            or content.get("instruction")
+            or content.get("content")
+            or ""
+        )
+    return str(content or "")
+
+
+def _load_saved_artifact_text(session_row: dict) -> str | None:
+    """ADR-0094 completion contract step 1: a produced artifact/summary, verbatim."""
+    contract = session_row.get("artifact_contract_json")
+    artifacts_root = session_row.get("artifacts_path")
+    if not contract or not artifacts_root:
+        return None
+    if isinstance(contract, str):
+        try:
+            contract = json.loads(contract)
+        except (ValueError, TypeError):
+            return None
+
+    from lionagi.state.artifact_verifier import verify_artifact_contract
+
+    verification = verify_artifact_contract(contract, artifacts_root=artifacts_root)
+    if not verification or not verification["produced"]:
+        return None
+    entry = verification["produced"][0]
+    try:
+        return (Path(artifacts_root) / entry["path"]).read_text()
+    except OSError:
+        return None
+
+
+async def _resolve_session_ref(db, ref: str) -> dict | None:
+    if len(ref) >= 36:
+        return await db.get_session(ref)
+    rows = await db.fetch_all("SELECT * FROM sessions WHERE id LIKE ?", (ref + "%",))
+    if not rows:
+        return None
+    if len(rows) > 1:
+        raise AmbiguousContextRefError(ref, [r["id"] for r in rows])
+    return rows[0]
+
+
+async def _primary_branch_for_session(db, session_id: str) -> str | None:
+    rows = await db.fetch_all(
+        "SELECT id FROM branches WHERE session_id = ? ORDER BY created_at DESC", (session_id,)
+    )
+    return rows[0]["id"] if rows else None
+
+
+async def _candidate_from_branch(db, branch_id: str, ref: str, kind: str) -> ContextCandidate:
+    branch_row = await db.get_branch(branch_id)
+    if branch_row is None:
+        raise ContextFromError(
+            f"--context-from {ref!r}: branch {branch_id} has no persisted record"
+        )
+    session_row = await db.get_session(branch_row["session_id"]) or {}
+
+    progression_id = branch_row.get("progression_id")
+    msg_ids = await db.get_progression(progression_id) if progression_id else []
+    initial_text: str | None = None
+    final_text: str | None = None
+    for msg_id in msg_ids:
+        msg = await db.get_message(msg_id)
+        if not msg:
+            continue
+        text_val = _extract_message_text(msg)
+        if not text_val.strip():
+            continue
+        role = msg.get("role")
+        if role == "user" and initial_text is None:
+            initial_text = text_val
+        elif role == "assistant":
+            final_text = text_val
+
+    if final_text is None:
+        raise ContextFromError(f"--context-from {ref!r}: source has no assistant message")
+
+    model = None
+    if branch_row.get("provider") and branch_row.get("model"):
+        model = f"{branch_row['provider']}/{branch_row['model']}"
+
+    step2 = f"{initial_text}\n\n{final_text}" if initial_text else final_text
+    return ContextCandidate(
+        kind=kind,
+        ref=ref,
+        model=model,
+        step1_text=_load_saved_artifact_text(session_row),
+        step2_text=step2,
+        step3_head=initial_text or "",
+        step3_tail=final_text,
+    )
+
+
+async def _resolve_one(db, ref: str) -> ContextCandidate:
+    session_row = await _resolve_session_ref(db, ref)
+    if session_row is not None:
+        branch_id = await _primary_branch_for_session(db, session_row["id"])
+        if branch_id is None:
+            raise ContextFromError(f"--context-from {ref!r}: session has no branch")
+        return await _candidate_from_branch(db, branch_id, ref, "session")
+
+    branch_id = _resolve_branch_ref(ref)
+    if branch_id is not None:
+        return await _candidate_from_branch(db, branch_id, ref, "branch")
+
+    run_id = _resolve_run_ref(ref)
+    if run_id is not None:
+        primary_branch_id = _primary_branch_for_run(run_id)
+        if primary_branch_id is None:
+            raise ContextFromError(f"--context-from {ref!r}: run {run_id} has no resolvable branch")
+        return await _candidate_from_branch(db, primary_branch_id, ref, "run")
+
+    file_candidate = _resolve_file_ref(ref)
+    if file_candidate is not None:
+        return file_candidate
+
+    raise ContextFromError(
+        f"--context-from {ref!r}: could not resolve as a session id, branch id, run id, or file path"
+    )
+
+
+async def resolve_context_refs(refs: Sequence[str]) -> list[ContextCandidate]:
+    from lionagi.state.db import StateDB
+
+    async with StateDB() as db:
+        return [await _resolve_one(db, ref) for ref in refs]
+
+
+# ── Distillation ladder + budget allocation ─────────────────────────────────
+
+
+def _head_tail_truncate(head: str, tail: str, budget_chars: int) -> str:
+    if budget_chars <= len(_TRUNCATION_MARKER):
+        return _TRUNCATION_MARKER.strip()
+    avail = budget_chars - len(_TRUNCATION_MARKER)
+    head_budget = avail // 2
+    tail_budget = avail - head_budget
+    return f"{head[:head_budget]}{_TRUNCATION_MARKER}{tail[-tail_budget:] if tail_budget else ''}"
+
+
+def _distill(candidate: ContextCandidate, budget_chars: int) -> tuple[str, bool]:
+    """First-fit-within-budget ladder; returns (text, truncated)."""
+    if candidate.step1_text is not None and len(candidate.step1_text) <= budget_chars:
+        return candidate.step1_text, False
+    if candidate.step2_text is not None and len(candidate.step2_text) <= budget_chars:
+        return candidate.step2_text, False
+    text = _head_tail_truncate(candidate.step3_head or "", candidate.step3_tail or "", budget_chars)
+    return text, True
+
+
+def _wrap_block(candidate: ContextCandidate, text: str) -> str:
+    model_attr = candidate.model or "unknown"
+    return (
+        f'<prior-run-context ref="{candidate.ref}" kind="{candidate.kind}" model="{model_attr}">\n'
+        f"{text}\n"
+        "</prior-run-context>"
+    )
+
+
+def build_context_block(candidates: Sequence[ContextCandidate], budget_tokens: int) -> str:
+    """Assemble the XML-delimited context block(s), argv order, total-not-per-ref budget."""
+    from lionagi.cli._logging import warn
+
+    remaining = budget_tokens * _CHARS_PER_TOKEN
+    blocks: list[str] = []
+    for candidate in candidates:
+        text, truncated = _distill(candidate, max(remaining, 0))
+        remaining -= len(text)
+        if truncated:
+            warn(
+                f"--context-from {candidate.ref!r}: content exceeded the "
+                f"{budget_tokens}-token budget, truncated (loud, not fatal)"
+            )
+        blocks.append(_wrap_block(candidate, text))
+    return "\n\n".join(blocks)
+
+
+async def resolve_and_build_context_block(refs: Sequence[str], budget_tokens: int) -> str:
+    candidates = await resolve_context_refs(refs)
+    return build_context_block(candidates, budget_tokens)

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -232,8 +232,11 @@ async def _run_agent(
             "(resume already carries the source context)."
         )
     if context_from:
+        effective_context_budget = (
+            context_budget if context_budget is not None else DEFAULT_CONTEXT_BUDGET_TOKENS
+        )
         context_block = await resolve_and_build_context_block(
-            context_from, context_budget or DEFAULT_CONTEXT_BUDGET_TOKENS
+            context_from, effective_context_budget
         )
         prompt = f"{context_block}\n\n{prompt}"
 

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -22,6 +22,11 @@ from lionagi.protocols.generic.log import DataLoggerConfig
 from lionagi.state import provenance as _provenance
 from lionagi.state.artifact_verifier import resolve_artifact_contract
 
+from ._context_from import (
+    DEFAULT_CONTEXT_BUDGET_TOKENS,
+    ContextFromError,
+    resolve_and_build_context_block,
+)
 from ._logging import hint, log_error
 from ._providers import (
     BACKENDS,
@@ -204,6 +209,8 @@ async def _run_agent(
     bypass: bool = False,
     preset: str | None = None,
     resume_on_timeout: bool = False,
+    context_from: list[str] | None = None,
+    context_budget: int | None = None,
     _auto_resumed: bool = False,
 ) -> tuple[str, str, str, str, str | None]:
     """Execute one agent turn; returns (result, provider, branch_id, terminal_status, session_id).
@@ -219,6 +226,16 @@ async def _run_agent(
         raise ConfigurationError(
             "--preset only applies to new branches; cannot combine with --resume / --continue-last."
         )
+    if context_from and (resume or continue_last):
+        raise ContextFromError(
+            "--context-from cannot be combined with --resume / -r or --continue-last / -c "
+            "(resume already carries the source context)."
+        )
+    if context_from:
+        context_block = await resolve_and_build_context_block(
+            context_from, context_budget or DEFAULT_CONTEXT_BUDGET_TOKENS
+        )
+        prompt = f"{context_block}\n\n{prompt}"
 
     # Cache cancellation exception class while event loop is running;
     # cancelled_exc_classes() in the error path needs it after loop exit.
@@ -397,6 +414,8 @@ async def _run_agent(
 
     run = allocate_run()
     branch_id = str(branch.id)
+    if context_from:
+        run.write_manifest({"branch_id": branch_id, "context_from": list(context_from)})
 
     resolved_model_spec = _provenance.resolve_model_spec(provider, model)
     artifact_contract = resolve_artifact_contract(
@@ -545,7 +564,9 @@ def add_agent_subparser(subparsers: argparse._SubParsersAction) -> argparse.Argu
             "Use -r / -c to continue a previous conversation. "
             "Use -a to load a profile from .lionagi/agents/. "
             "Use --preset to apply a built-in agent configuration. "
-            "Use --form to load and validate structured inputs before invoking."
+            "Use --form to load and validate structured inputs before invoking. "
+            "Use --context-from to hand a new agent distilled context from a "
+            "prior session/branch/run/file."
         ),
     )
     agent.add_argument(
@@ -618,6 +639,32 @@ def add_agent_subparser(subparsers: argparse._SubParsersAction) -> argparse.Argu
             "The spec declares typed fields and values; validation runs "
             "BEFORE any LLM call. Exits rc=1 on validation error. "
             "Validated values are injected into the prompt as structured context."
+        ),
+    )
+
+    agent.add_argument(
+        "--context-from",
+        dest="context_from",
+        metavar="REF",
+        action="append",
+        default=None,
+        help=(
+            "Inject distilled context from a prior session id, branch id, run id, "
+            "or file path into this new branch's first instruction, above the "
+            "prompt. Repeatable (concatenated in argv order); the total budget "
+            "(see --context-budget) is shared across all refs. Rejected in "
+            "combination with -r / --resume or -c / --continue-last."
+        ),
+    )
+    agent.add_argument(
+        "--context-budget",
+        dest="context_budget",
+        type=int,
+        default=None,
+        metavar="N",
+        help=(
+            f"Total token budget for --context-from content "
+            f"(default {DEFAULT_CONTEXT_BUDGET_TOKENS}; ~4 chars/token)."
         ),
     )
 
@@ -727,8 +774,13 @@ def run_agent(args: argparse.Namespace) -> int:
                 bypass=getattr(args, "bypass", False),
                 preset=getattr(args, "preset", None),
                 resume_on_timeout=getattr(args, "resume_on_timeout", False),
+                context_from=getattr(args, "context_from", None),
+                context_budget=getattr(args, "context_budget", None),
             )
         )
+    except ContextFromError as exc:
+        log_error(str(exc))
+        return 2
     except KeyboardInterrupt:
         return EXIT_CODE_BY_STATUS["aborted"]
     except SigtermInterrupt as exc:

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -238,7 +238,8 @@ async def _run_agent(
         context_block = await resolve_and_build_context_block(
             context_from, effective_context_budget
         )
-        prompt = f"{context_block}\n\n{prompt}"
+        if context_block:
+            prompt = f"{context_block}\n\n{prompt}"
 
     # Cache cancellation exception class while event loop is running;
     # cancelled_exc_classes() in the error path needs it after loop exit.

--- a/tests/cli/test_agent_context_from.py
+++ b/tests/cli/test_agent_context_from.py
@@ -192,7 +192,9 @@ def test_build_context_block_total_budget_bounds_combined_wrapped_block(caplog):
 
     Two refs whose raw payloads alone (120 chars) fit comfortably under a naive
     payload-only accounting of the budget, but the XML wrapper + separator overhead
-    means the true combined block must still respect the total budget.
+    means even the FIRST ref's minimum wrapped block (wrapper + loud marker) does
+    not fit this budget -- so the honest total-budget contract is to skip
+    injection entirely rather than silently emit an over-budget block.
     """
     first = ContextCandidate(kind="branch", ref="first", model="m", step2_text="F" * 60)
     second = ContextCandidate(kind="branch", ref="second", model="m", step2_text="S" * 60)
@@ -201,17 +203,45 @@ def test_build_context_block_total_budget_bounds_combined_wrapped_block(caplog):
     logger.handlers.clear()
     logger.propagate = True
 
-    budget_tokens = 20  # 80 chars total -- tight enough that wrapper overhead dominates
+    budget_tokens = 20  # 80 chars total -- less than even one ref's wrapper + marker
     with caplog.at_level(logging.WARNING, logger="lionagi.cli.warn"):
         block = build_context_block([first, second], budget_tokens=budget_tokens)
 
-    # neither payload leaks through unbounded -- both refs are loudly truncated
+    # neither payload leaks through unbounded -- injection is skipped entirely
     assert "F" * 60 not in block
     assert "S" * 60 not in block
-    assert block.count("[...truncated...]") == 2
-    # the combined block is far smaller than the un-bounded 236-char blowup the
-    # payload-only accounting produced (two 60-char payloads + wrapper tags)
-    assert len(block) < 200
+    assert block == ""
+    assert any("too small" in rec.message for rec in caplog.records)
+    # mutation-sensitive: a regression to the old unbounded accounting produced a
+    # 191-char block for this exact scenario, which would fail this bound
+    assert len(block) <= budget_tokens * _CHARS_PER_TOKEN
+
+
+def test_build_context_block_skips_injection_when_budget_too_small_for_first_ref(caplog):
+    """Nonzero-but-insufficient TOTAL budget across multiple refs: skip entirely.
+
+    A single ref always gets at least a loud-marker-only block (see
+    `test_build_context_block_budget_zero_yields_only_truncation_marker` --
+    there's nothing to drop it in favor of). With two or more refs, the
+    combined budget is a hard ceiling: if even the first ref's minimum
+    wrapped block can't fit, no block is emitted at all, plus a loud stderr
+    warning -- never a silently over-budget block.
+    """
+    first = ContextCandidate(kind="branch", ref="only", model="m", step2_text="X" * 60)
+    second = ContextCandidate(kind="branch", ref="also", model="m", step2_text="Y" * 60)
+
+    logger = logging.getLogger("lionagi.cli.warn")
+    logger.handlers.clear()
+    logger.propagate = True
+
+    budget_tokens = 1  # 4 chars total -- far below wrapper + marker overhead
+    with caplog.at_level(logging.WARNING, logger="lionagi.cli.warn"):
+        block = build_context_block([first, second], budget_tokens=budget_tokens)
+
+    assert block == ""
+    assert "X" * 60 not in block
+    assert "Y" * 60 not in block
+    assert any("too small" in rec.message for rec in caplog.records)
 
 
 def test_file_ref_over_budget_truncates_loudly_no_verbatim_blowup(tmp_path):

--- a/tests/cli/test_agent_context_from.py
+++ b/tests/cli/test_agent_context_from.py
@@ -1,0 +1,496 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for `li agent --context-from <ref>` (spec v0.2).
+
+Covers: ref resolution order (session/branch/run/file id, unique prefix,
+miss), ambiguous-prefix hard error, total-not-per-ref budget with argv-order
+allocation and loud tail-ref truncation, the distillation ladder (artifact /
+final-message fallback / truncation marker), rejection when combined with
+-r/-c, manifest recording of context_from, and injection above the user
+prompt in the new branch's first instruction.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from lionagi.cli._context_from import (
+    AmbiguousContextRefError,
+    ContextCandidate,
+    ContextFromError,
+    _distill,
+    _resolve_file_ref,
+    build_context_block,
+    resolve_context_refs,
+)
+from lionagi.cli._runs import RunDir
+from lionagi.state.db import StateDB
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def temp_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Per-test temp DB; mirrors tests/cli/test_status.py's fixture."""
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(
+        "lionagi.state.db.settings",
+        SimpleNamespace(LIONAGI_STATE_DB_URL=None),
+    )
+    return db_path
+
+
+@pytest.fixture
+def runs_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect the filesystem branch/run scan to an isolated tmp dir."""
+    root = tmp_path / "runs"
+    root.mkdir()
+    monkeypatch.setattr("lionagi.cli._context_from.RUNS_ROOT", root)
+    return root
+
+
+async def _make_session(db: StateDB, **fields) -> str:
+    sid = fields.pop("id", None) or uuid.uuid4().hex
+    pid = uuid.uuid4().hex
+    await db.create_progression(pid)
+    await db.create_session(
+        {
+            "id": sid,
+            "progression_id": pid,
+            "status": fields.pop("status", "completed"),
+            "invocation_kind": "agent",
+            "started_at": time.time(),
+            **fields,
+        }
+    )
+    return sid
+
+
+async def _make_branch(
+    db: StateDB, session_id: str, *, branch_id: str | None = None, **fields
+) -> tuple[str, str]:
+    bid = branch_id or str(uuid.uuid4())
+    pid = uuid.uuid4().hex
+    await db.create_progression(pid)
+    await db.create_branch(
+        {
+            "id": bid,
+            "session_id": session_id,
+            "progression_id": pid,
+            "model": fields.pop("model", "sonnet"),
+            "provider": fields.pop("provider", "anthropic"),
+        }
+    )
+    return bid, pid
+
+
+async def _add_message(db: StateDB, progression_id: str, *, role: str, content: dict) -> str:
+    mid = uuid.uuid4().hex
+    await db.insert_message(
+        {"id": mid, "created_at": time.time(), "content": content, "role": role}
+    )
+    await db.append_to_progression(progression_id, mid)
+    return mid
+
+
+def _write_branch_file(runs_root: Path, run_id: str, branch_id: str) -> Path:
+    branches_dir = runs_root / run_id / "branches"
+    branches_dir.mkdir(parents=True, exist_ok=True)
+    path = branches_dir / f"{branch_id}.json"
+    path.write_text("{}")
+    return path
+
+
+# ── Ladder: artifact present / final-message fallback / truncation marker ──
+
+
+def test_ladder_uses_verbatim_artifact_when_it_fits():
+    cand = ContextCandidate(
+        kind="branch",
+        ref="r1",
+        model="anthropic/sonnet",
+        step1_text="the saved artifact",
+        step2_text="x" * 500,
+    )
+    text, truncated = _distill(cand, budget_chars=1000)
+    assert text == "the saved artifact"
+    assert truncated is False
+
+
+def test_ladder_falls_back_to_final_message_when_no_artifact():
+    cand = ContextCandidate(
+        kind="branch",
+        ref="r1",
+        model=None,
+        step1_text=None,
+        step2_text="initial\n\nfinal",
+        step3_head="initial",
+        step3_tail="final",
+    )
+    text, truncated = _distill(cand, budget_chars=1000)
+    assert text == "initial\n\nfinal"
+    assert truncated is False
+
+
+def test_ladder_truncates_loudly_when_both_oversized():
+    cand = ContextCandidate(
+        kind="branch",
+        ref="r1",
+        model=None,
+        step1_text="a" * 5000,
+        step2_text="b" * 5000,
+        step3_head="HEAD" * 500,
+        step3_tail="TAIL" * 500,
+    )
+    text, truncated = _distill(cand, budget_chars=100)
+    assert truncated is True
+    assert "[...truncated...]" in text
+    assert len(text) <= 100
+
+
+# ── Budget: total-not-per-ref, argv order, tail-ref loud truncation ────────
+
+
+def test_build_context_block_allocates_total_budget_in_argv_order(caplog):
+    first = ContextCandidate(kind="branch", ref="first", model="m", step2_text="F" * 60)
+    second = ContextCandidate(kind="branch", ref="second", model="m", step2_text="S" * 60)
+
+    logger = logging.getLogger("lionagi.cli.warn")
+    logger.handlers.clear()
+    logger.propagate = True
+
+    with caplog.at_level(logging.WARNING, logger="lionagi.cli.warn"):
+        block = build_context_block([first, second], budget_tokens=20)  # 80 chars total
+
+    # first ref gets its natural fit (60 chars verbatim final-message text)
+    assert "F" * 60 in block
+    # second ref (tail) only had ~20 chars left -> loudly truncated, never silently dropped
+    assert 'ref="second"' in block
+    assert "[...truncated...]" in block
+    assert any("second" in rec.message for rec in caplog.records)
+
+
+def test_file_ref_over_budget_truncates_loudly_no_verbatim_blowup(tmp_path):
+    big_file = tmp_path / "notes.md"
+    big_file.write_text("X" * 10_000)
+    cand = _resolve_file_ref(str(big_file))
+    assert cand is not None
+    assert cand.kind == "file"
+
+    block = build_context_block([cand], budget_tokens=10)  # 40 chars
+    assert len(block) < 10_000
+    assert "[...truncated...]" in block
+
+
+# ── Ref resolution order + unique prefix + miss ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_resolve_session_id_ref(temp_db_path):
+    async with StateDB() as db:
+        sid = await _make_session(db)
+        bid, pid = await _make_branch(db, sid)
+        await _add_message(db, pid, role="user", content={"instruction": "do the task"})
+        await _add_message(
+            db, pid, role="assistant", content={"assistant_response": "done, verdict: ok"}
+        )
+
+        [cand] = await resolve_context_refs([sid])
+    assert cand.kind == "session"
+    assert cand.step3_tail == "done, verdict: ok"
+    assert cand.model == "anthropic/sonnet"
+
+
+@pytest.mark.asyncio
+async def test_resolve_session_id_unique_prefix(temp_db_path):
+    async with StateDB() as db:
+        sid = await _make_session(db, id=uuid.uuid4().hex)
+        bid, pid = await _make_branch(db, sid)
+        await _add_message(db, pid, role="assistant", content={"assistant_response": "result"})
+
+        [cand] = await resolve_context_refs([sid[:8]])
+    assert cand.kind == "session"
+
+
+@pytest.mark.asyncio
+async def test_resolve_branch_id_ref(temp_db_path, runs_root):
+    async with StateDB() as db:
+        sid = await _make_session(db)
+        bid, pid = await _make_branch(db, sid)
+        await _add_message(
+            db, pid, role="assistant", content={"assistant_response": "final answer"}
+        )
+        _write_branch_file(runs_root, "run-1", bid)
+
+        [cand] = await resolve_context_refs([bid])
+    assert cand.kind == "branch"
+    assert cand.step3_tail == "final answer"
+
+
+@pytest.mark.asyncio
+async def test_resolve_run_id_ref_via_manifest(temp_db_path, runs_root):
+    async with StateDB() as db:
+        sid = await _make_session(db)
+        bid, pid = await _make_branch(db, sid)
+        await _add_message(
+            db, pid, role="assistant", content={"assistant_response": "run-level answer"}
+        )
+        _write_branch_file(runs_root, "20260705T000000-abc123", bid)
+        (runs_root / "20260705T000000-abc123" / "run.json").write_text(
+            json.dumps({"branch_id": bid, "run_id": "20260705T000000-abc123"})
+        )
+
+        [cand] = await resolve_context_refs(["20260705T000000-abc123"])
+    assert cand.kind == "run"
+    assert cand.step3_tail == "run-level answer"
+
+
+@pytest.mark.asyncio
+async def test_resolve_file_path_ref(temp_db_path, runs_root, tmp_path):
+    f = tmp_path / "prior.md"
+    f.write_text("prior findings verbatim")
+
+    [cand] = await resolve_context_refs([str(f)])
+    assert cand.kind == "file"
+    assert cand.step1_text == "prior findings verbatim"
+
+
+@pytest.mark.asyncio
+async def test_resolve_unresolvable_ref_raises(temp_db_path, runs_root):
+    with pytest.raises(ContextFromError, match="could not resolve"):
+        await resolve_context_refs(["totally-unknown-ref-xyz"])
+
+
+@pytest.mark.asyncio
+async def test_resolve_empty_source_branch_errors(temp_db_path, runs_root):
+    async with StateDB() as db:
+        sid = await _make_session(db)
+        bid, pid = await _make_branch(db, sid)
+        _write_branch_file(runs_root, "run-x", bid)
+
+        with pytest.raises(ContextFromError, match="no assistant message"):
+            await resolve_context_refs([bid])
+
+
+# ── Ambiguous prefix (2+ matches) → hard error listing candidates ─────────
+
+
+@pytest.mark.asyncio
+async def test_resolve_ambiguous_session_prefix_raises(temp_db_path):
+    async with StateDB() as db:
+        sid1 = await _make_session(db, id="abc11111" + uuid.uuid4().hex[:10])
+        sid2 = await _make_session(db, id="abc22222" + uuid.uuid4().hex[:10])
+
+    with pytest.raises(AmbiguousContextRefError) as excinfo:
+        async with StateDB() as db:
+            await resolve_context_refs(["abc"])
+    assert sid1 in excinfo.value.candidates
+    assert sid2 in excinfo.value.candidates
+    assert "abc" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_resolve_ambiguous_branch_prefix_raises(temp_db_path, runs_root):
+    async with StateDB() as db:
+        sid = await _make_session(db)
+        bid1, _ = await _make_branch(db, sid, branch_id="dup1111-aaaa-bbbb-cccc-000000000001")
+        bid2, _ = await _make_branch(db, sid, branch_id="dup1111-aaaa-bbbb-cccc-000000000002")
+    _write_branch_file(runs_root, "run-a", bid1)
+    _write_branch_file(runs_root, "run-b", bid2)
+
+    with pytest.raises(AmbiguousContextRefError) as excinfo:
+        async with StateDB() as db:
+            await resolve_context_refs(["dup1111"])
+    assert set(excinfo.value.candidates) == {bid1, bid2}
+
+
+@pytest.mark.asyncio
+async def test_resolve_ambiguous_run_prefix_raises(temp_db_path, runs_root):
+    (runs_root / "run-dup-1").mkdir()
+    (runs_root / "run-dup-2").mkdir()
+
+    with pytest.raises(AmbiguousContextRefError):
+        await resolve_context_refs(["run-dup"])
+
+
+# ── CLI wiring: mutual exclusion, manifest, first-instruction injection ────
+
+
+def _wire_agent_stubs(
+    monkeypatch, tmp_path: Path, operate_return=None, capture: dict | None = None
+):
+    import lionagi.cli.agent as agent_mod
+    from lionagi import Branch
+    from lionagi.service.manager import iModelManager
+
+    async def fake_operate(self, instruction=None, **kw):
+        if capture is not None:
+            capture["instruction"] = instruction
+        return operate_return
+
+    monkeypatch.setattr(Branch, "operate", fake_operate)
+    monkeypatch.setattr(iModelManager, "shutdown", AsyncMock())
+    monkeypatch.setattr(agent_mod, "resolve_persisted_effort", lambda *a, **kw: None)
+
+    async def fake_setup(*a, **kw):
+        return None
+
+    async def fake_teardown(ctx, *, status="completed", exception=None, cwd=None):
+        return status
+
+    monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)
+    monkeypatch.setattr(agent_mod, "teardown_agent_persist", fake_teardown)
+    monkeypatch.setattr(agent_mod, "save_last_branch_pointer", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "_provenance",
+        SimpleNamespace(
+            resolve_model_spec=lambda p, m: f"{p}/{m}",
+            agent_definition_hash=lambda n: "abc",
+        ),
+    )
+    monkeypatch.setattr(agent_mod, "resolve_artifact_contract", lambda **_: None)
+
+
+@pytest.mark.asyncio
+async def test_context_from_rejected_with_resume(monkeypatch, tmp_path):
+    from lionagi.cli.agent import _run_agent
+
+    with pytest.raises(ContextFromError, match="cannot be combined"):
+        await _run_agent(
+            "claude/sonnet",
+            "follow up",
+            resume="some-branch-id",
+            context_from=["some-ref"],
+        )
+
+
+@pytest.mark.asyncio
+async def test_context_from_rejected_with_continue_last(monkeypatch, tmp_path):
+    from lionagi.cli.agent import _run_agent
+
+    with pytest.raises(ContextFromError, match="cannot be combined"):
+        await _run_agent(
+            "claude/sonnet",
+            "follow up",
+            continue_last=True,
+            context_from=["some-ref"],
+        )
+
+
+def test_run_agent_exits_2_on_context_from_plus_resume(monkeypatch, tmp_path):
+    import lionagi.cli.agent as agent_mod
+    from lionagi.ln.concurrency import run_async as _real_run_async
+
+    _wire_agent_stubs(monkeypatch, tmp_path)
+    monkeypatch.setattr(agent_mod, "run_async", _real_run_async)
+
+    args = SimpleNamespace(
+        query=["claude/sonnet", "follow up"],
+        prompt_flag=None,
+        prompt_file=None,
+        yolo=False,
+        verbose=False,
+        theme=None,
+        resume="some-branch-id",
+        continue_last=False,
+        effort=None,
+        agent=None,
+        cwd=None,
+        timeout=None,
+        fast=False,
+        invocation=None,
+        project=None,
+        bypass=False,
+        preset=None,
+        resume_on_timeout=False,
+        form=None,
+        context_from=["some-ref"],
+        context_budget=None,
+    )
+
+    from lionagi.cli.agent import run_agent
+
+    rc = run_agent(args)
+    assert rc == 2
+
+
+@pytest.mark.asyncio
+async def test_manifest_records_context_from(monkeypatch, tmp_path):
+    import lionagi.cli.agent as agent_mod
+
+    capture: dict = {}
+    _wire_agent_stubs(monkeypatch, tmp_path, operate_return="the result", capture=capture)
+
+    run = RunDir(
+        run_id="run-ctx",
+        state_root=tmp_path / "state",
+        artifact_root=tmp_path / "artifacts",
+    )
+    run.ensure_state_dirs()
+    monkeypatch.setattr(agent_mod, "allocate_run", lambda: run)
+
+    async def fake_build(refs, budget_tokens):
+        return '<prior-run-context ref="x" kind="file" model="unknown">\nprior text\n</prior-run-context>'
+
+    monkeypatch.setattr(agent_mod, "resolve_and_build_context_block", fake_build)
+
+    from lionagi.cli.agent import _run_agent
+
+    result, provider, branch_id, terminal_status, _sid = await _run_agent(
+        "claude/sonnet",
+        "the actual prompt",
+        context_from=["some.md"],
+    )
+
+    assert terminal_status == "completed"
+    manifest = json.loads(run.manifest_path.read_text())
+    assert manifest["context_from"] == ["some.md"]
+    assert manifest["branch_id"] == branch_id
+
+
+@pytest.mark.asyncio
+async def test_injected_block_present_above_prompt_in_first_instruction(monkeypatch, tmp_path):
+    import lionagi.cli.agent as agent_mod
+
+    capture: dict = {}
+    _wire_agent_stubs(monkeypatch, tmp_path, operate_return="ok", capture=capture)
+    monkeypatch.setattr(
+        agent_mod,
+        "allocate_run",
+        lambda: SimpleNamespace(
+            run_id="r",
+            artifact_root=tmp_path / "artifacts",
+            stream_dir=tmp_path / "stream",
+            branches_dir=tmp_path / "branches",
+            write_manifest=lambda data: None,
+        ),
+    )
+
+    marker = '<prior-run-context ref="prior" kind="branch" model="anthropic/sonnet">\ndistilled\n</prior-run-context>'
+
+    async def fake_build(refs, budget_tokens):
+        return marker
+
+    monkeypatch.setattr(agent_mod, "resolve_and_build_context_block", fake_build)
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent(
+        "claude/sonnet",
+        "the user prompt",
+        context_from=["prior"],
+    )
+
+    instruction = capture["instruction"]
+    assert marker in instruction
+    assert instruction.index(marker) < instruction.index("the user prompt")

--- a/tests/cli/test_agent_context_from.py
+++ b/tests/cli/test_agent_context_from.py
@@ -12,6 +12,7 @@ prompt in the new branch's first instruction.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import time
@@ -23,6 +24,8 @@ from unittest.mock import AsyncMock
 import pytest
 
 from lionagi.cli._context_from import (
+    _CHARS_PER_TOKEN,
+    DEFAULT_CONTEXT_BUDGET_TOKENS,
     AmbiguousContextRefError,
     ContextCandidate,
     ContextFromError,
@@ -127,17 +130,18 @@ def test_ladder_uses_verbatim_artifact_when_it_fits():
 
 
 def test_ladder_falls_back_to_final_message_when_no_artifact():
+    # spec ladder rung 2: final assistant message FIRST, then the initial instruction.
     cand = ContextCandidate(
         kind="branch",
         ref="r1",
         model=None,
         step1_text=None,
-        step2_text="initial\n\nfinal",
+        step2_text="final\n\ninitial",
         step3_head="initial",
         step3_tail="final",
     )
     text, truncated = _distill(cand, budget_chars=1000)
-    assert text == "initial\n\nfinal"
+    assert text == "final\n\ninitial"
     assert truncated is False
 
 
@@ -168,15 +172,46 @@ def test_build_context_block_allocates_total_budget_in_argv_order(caplog):
     logger.handlers.clear()
     logger.propagate = True
 
+    budget_tokens = 60  # 240 chars total, enough for the first ref's wrapper + payload
     with caplog.at_level(logging.WARNING, logger="lionagi.cli.warn"):
-        block = build_context_block([first, second], budget_tokens=20)  # 80 chars total
+        block = build_context_block([first, second], budget_tokens=budget_tokens)
 
     # first ref gets its natural fit (60 chars verbatim final-message text)
     assert "F" * 60 in block
-    # second ref (tail) only had ~20 chars left -> loudly truncated, never silently dropped
+    # second ref (tail) only had budget left for wrapper + a loud marker
     assert 'ref="second"' in block
     assert "[...truncated...]" in block
     assert any("second" in rec.message for rec in caplog.records)
+    # the COMBINED block (delimiters + separators included) respects the total budget,
+    # not just the distilled payload text
+    assert len(block) <= budget_tokens * _CHARS_PER_TOKEN
+
+
+def test_build_context_block_total_budget_bounds_combined_wrapped_block(caplog):
+    """Regression: budget must bound the wrapped block (tags + separators), not payload only.
+
+    Two refs whose raw payloads alone (120 chars) fit comfortably under a naive
+    payload-only accounting of the budget, but the XML wrapper + separator overhead
+    means the true combined block must still respect the total budget.
+    """
+    first = ContextCandidate(kind="branch", ref="first", model="m", step2_text="F" * 60)
+    second = ContextCandidate(kind="branch", ref="second", model="m", step2_text="S" * 60)
+
+    logger = logging.getLogger("lionagi.cli.warn")
+    logger.handlers.clear()
+    logger.propagate = True
+
+    budget_tokens = 20  # 80 chars total -- tight enough that wrapper overhead dominates
+    with caplog.at_level(logging.WARNING, logger="lionagi.cli.warn"):
+        block = build_context_block([first, second], budget_tokens=budget_tokens)
+
+    # neither payload leaks through unbounded -- both refs are loudly truncated
+    assert "F" * 60 not in block
+    assert "S" * 60 not in block
+    assert block.count("[...truncated...]") == 2
+    # the combined block is far smaller than the un-bounded 236-char blowup the
+    # payload-only accounting produced (two 60-char payloads + wrapper tags)
+    assert len(block) < 200
 
 
 def test_file_ref_over_budget_truncates_loudly_no_verbatim_blowup(tmp_path):
@@ -208,6 +243,8 @@ async def test_resolve_session_id_ref(temp_db_path):
     assert cand.kind == "session"
     assert cand.step3_tail == "done, verdict: ok"
     assert cand.model == "anthropic/sonnet"
+    # ladder rung 2: final assistant message FIRST, then the initial instruction
+    assert cand.step2_text == "done, verdict: ok\n\ndo the task"
 
 
 @pytest.mark.asyncio
@@ -494,3 +531,228 @@ async def test_injected_block_present_above_prompt_in_first_instruction(monkeypa
     instruction = capture["instruction"]
     assert marker in instruction
     assert instruction.index(marker) < instruction.index("the user prompt")
+
+
+# ── Explicit `--context-budget 0` must be preserved, not defaulted ─────────
+
+
+@pytest.mark.asyncio
+async def test_context_budget_zero_passed_through_not_defaulted(monkeypatch, tmp_path):
+    """`context_budget=0` must reach `resolve_and_build_context_block` as `0`,
+    never silently upgraded to `DEFAULT_CONTEXT_BUDGET_TOKENS` by a truthiness
+    fallback (`context_budget or DEFAULT...` treats 0 as falsy)."""
+    import lionagi.cli.agent as agent_mod
+
+    capture: dict = {}
+    _wire_agent_stubs(monkeypatch, tmp_path, operate_return="ok", capture=capture)
+    monkeypatch.setattr(
+        agent_mod,
+        "allocate_run",
+        lambda: SimpleNamespace(
+            run_id="r",
+            artifact_root=tmp_path / "artifacts",
+            stream_dir=tmp_path / "stream",
+            branches_dir=tmp_path / "branches",
+            write_manifest=lambda data: None,
+        ),
+    )
+
+    captured_budget: dict = {}
+
+    async def fake_build(refs, budget_tokens):
+        captured_budget["value"] = budget_tokens
+        return '<prior-run-context ref="x" kind="file" model="unknown">\n[...truncated...]\n</prior-run-context>'
+
+    monkeypatch.setattr(agent_mod, "resolve_and_build_context_block", fake_build)
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent(
+        "claude/sonnet",
+        "the user prompt",
+        context_from=["some-ref"],
+        context_budget=0,
+    )
+
+    assert captured_budget["value"] == 0
+
+
+@pytest.mark.asyncio
+async def test_context_budget_zero_reaches_build_context_block_only_truncation_marker(
+    monkeypatch, temp_db_path, runs_root, tmp_path
+):
+    """End-to-end: `--context-budget 0` flows through the REAL resolve+build
+    pipeline (no mocking of `resolve_and_build_context_block`) and the
+    injected block contains only the loud truncation marker -- never the
+    verbatim source content."""
+    import lionagi.cli.agent as agent_mod
+
+    capture: dict = {}
+    _wire_agent_stubs(monkeypatch, tmp_path, operate_return="ok", capture=capture)
+    monkeypatch.setattr(
+        agent_mod,
+        "allocate_run",
+        lambda: SimpleNamespace(
+            run_id="r",
+            artifact_root=tmp_path / "artifacts",
+            stream_dir=tmp_path / "stream",
+            branches_dir=tmp_path / "branches",
+            write_manifest=lambda data: None,
+        ),
+    )
+
+    source = tmp_path / "prior.md"
+    source.write_text("verbatim prior findings that must not leak through at budget 0")
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent(
+        "claude/sonnet",
+        "the user prompt",
+        context_from=[str(source)],
+        context_budget=0,
+    )
+
+    instruction = capture["instruction"]
+    assert "[...truncated...]" in instruction
+    assert "verbatim prior findings" not in instruction
+
+
+def test_build_context_block_budget_zero_yields_only_truncation_marker():
+    cand = ContextCandidate(
+        kind="file",
+        ref="r1",
+        model=None,
+        step1_text="a saved artifact that would otherwise be used verbatim",
+        step2_text="initial\n\nfinal",
+        step3_head="initial",
+        step3_tail="final",
+    )
+    block = build_context_block([cand], budget_tokens=0)
+    assert "[...truncated...]" in block
+    assert "saved artifact" not in block
+    assert "initial" not in block
+    assert "final" not in block
+
+
+# ── CLI surface: exit codes, stderr content, precedence, argv ordering ─────
+
+
+def _base_cli_args(**overrides) -> SimpleNamespace:
+    defaults = dict(
+        query=["claude/sonnet", "hello"],
+        prompt_flag=None,
+        prompt_file=None,
+        yolo=False,
+        verbose=False,
+        theme=None,
+        resume=None,
+        continue_last=False,
+        effort=None,
+        agent=None,
+        cwd=None,
+        timeout=None,
+        fast=False,
+        invocation=None,
+        project=None,
+        bypass=False,
+        preset=None,
+        resume_on_timeout=False,
+        form=None,
+        context_from=None,
+        context_budget=None,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_cli_unresolvable_ref_exits_2_with_stderr(monkeypatch, temp_db_path, runs_root, caplog):
+    import lionagi.cli.agent as agent_mod
+    from lionagi.ln.concurrency import run_async as _real_run_async
+
+    monkeypatch.setattr(agent_mod, "run_async", _real_run_async)
+
+    logger = logging.getLogger("lionagi.cli.error")
+    logger.handlers.clear()
+    logger.propagate = True
+
+    args = _base_cli_args(context_from=["totally-unknown-ref-xyz"])
+
+    from lionagi.cli.agent import run_agent
+
+    with caplog.at_level(logging.ERROR, logger="lionagi.cli.error"):
+        rc = run_agent(args)
+
+    assert rc == 2
+    assert any("could not resolve" in rec.message for rec in caplog.records)
+
+
+def test_cli_ambiguous_prefix_exits_2_lists_candidates(monkeypatch, temp_db_path, caplog):
+    import lionagi.cli.agent as agent_mod
+    from lionagi.ln.concurrency import run_async as _real_run_async
+
+    monkeypatch.setattr(agent_mod, "run_async", _real_run_async)
+
+    sid1 = "abc11111" + uuid.uuid4().hex[:10]
+    sid2 = "abc22222" + uuid.uuid4().hex[:10]
+
+    async def _seed():
+        async with StateDB() as db:
+            await _make_session(db, id=sid1)
+            await _make_session(db, id=sid2)
+
+    asyncio.run(_seed())
+
+    logger = logging.getLogger("lionagi.cli.error")
+    logger.handlers.clear()
+    logger.propagate = True
+
+    args = _base_cli_args(context_from=["abc"])
+
+    from lionagi.cli.agent import run_agent
+
+    with caplog.at_level(logging.ERROR, logger="lionagi.cli.error"):
+        rc = run_agent(args)
+
+    assert rc == 2
+    messages = "\n".join(rec.message for rec in caplog.records)
+    assert "ambiguous" in messages
+    assert sid1 in messages
+    assert sid2 in messages
+
+
+@pytest.mark.asyncio
+async def test_ref_precedence_session_over_file_path(temp_db_path, runs_root, tmp_path):
+    """A ref that is simultaneously a valid file path AND a resolvable id must
+    resolve via the id ladder (session -> branch -> run) and never fall
+    through to the file-path escape hatch."""
+    ref = str(tmp_path / "collision")
+    Path(ref).write_text("file contents must lose to the session match")
+
+    async with StateDB() as db:
+        sid = await _make_session(db, id=ref)
+        bid, pid = await _make_branch(db, sid)
+        await _add_message(
+            db, pid, role="assistant", content={"assistant_response": "session wins"}
+        )
+
+        [cand] = await resolve_context_refs([ref])
+
+    assert cand.kind == "session"
+    assert cand.step3_tail == "session wins"
+
+
+@pytest.mark.asyncio
+async def test_repeated_identical_refs_preserve_argv_order(temp_db_path, runs_root, tmp_path):
+    f = tmp_path / "prior.md"
+    f.write_text("same content")
+
+    candidates = await resolve_context_refs([str(f), str(f)])
+    assert len(candidates) == 2
+    assert candidates[0].ref == candidates[1].ref == str(f)
+
+    block = build_context_block(candidates, budget_tokens=DEFAULT_CONTEXT_BUDGET_TOKENS)
+    assert block.count("same content") == 2
+    first_idx = block.index("same content")
+    second_idx = block.index("same content", first_idx + 1)
+    assert first_idx < second_idx


### PR DESCRIPTION
Implements the gate-approved spec for `li agent --context-from <ref>`:

- Resolves refs as session id → branch id → run id → file path; prefix matching with a hard exit-2 on ambiguity (candidates listed) or misses.
- Injects a bounded, mechanically-distilled context block above the user prompt in the new branch's first instruction (saved artifact → final message + task → loud truncation ladder).
- Repeatable flag; the budget (default 8k tokens, `--context-budget`) is total across all refs, allocated in argv order with loud tail truncation. File refs go through the same budget path.
- Rejects combination with `-r` / `--continue-last` (exit 2) — resume already carries the context.
- Records `context_from` as a top-level field on the new run's manifest for provenance.

Tests: `tests/cli/test_agent_context_from.py` covers every spec bullet (resolution kinds, ambiguity, total budget, ladder, resume rejection, manifest, injection). Full `tests/cli` green with the studio extra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)