### PR TITLE
fix(cli): stop phantom failed status on profile sessions; li monitor run resolves agent sessions

### DIFF
--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -381,15 +381,18 @@ async def _teardown_common(
     final_evidence_refs = evidence_refs
 
     # A profile-typed session's own async wrapper can raise a stream/transport
-    # error (the CLI provider's own reported "error" chunk, classified as a
-    # ProviderError by classify_provider_error) while the engine session it
-    # wraps — mirrored separately from the on-disk transcript — is still alive
-    # or already completed. Reading that as "failed" is a phantom: the actual
-    # work is running or done. Narrowly suppress the demotion for THIS known
-    # class only: a generic bug elsewhere in the wrapper (message persistence,
-    # artifact verification, hook handling, branch mutation) must still fail
-    # loud even when a linked engine session happens to be running/completed.
-    if final_status == "failed" and isinstance(exception, ProviderError) and engine_session_uid:
+    # error (the CLI provider's own reported "error" chunk that classify_provider_error
+    # could not attribute to a known quota/auth/context pattern, so it stays the base
+    # ProviderError) while the engine session it wraps — mirrored separately from the
+    # on-disk transcript — is still alive or already completed. Reading that as "failed"
+    # is a phantom: the actual work is running or done. Narrowly suppress the demotion
+    # for THIS known, unclassified-stream-error class only: an exact-type check (not
+    # isinstance) excludes the ProviderQuotaError/ProviderAuthError/ProviderContextError
+    # subclasses, so a genuine quota/auth/context failure always stays "failed" even
+    # with a linked engine session running/completed, exactly like a generic bug
+    # elsewhere in the wrapper (message persistence, artifact verification, hook
+    # handling, branch mutation) must still fail loud.
+    if final_status == "failed" and type(exception) is ProviderError and engine_session_uid:
         from lionagi.state.claude_mirror import session_db_id
         from lionagi.state.db import SESSION_TERMINAL_STATUSES
         from lionagi.state.reasons import RunReasons

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -17,6 +17,7 @@ from uuid import uuid4
 from lionagi._paths import RUNS_ROOT
 from lionagi.libs.path_safety import validate_path_component
 from lionagi.ln._utils import now_utc
+from lionagi.providers._provider_errors import ProviderError
 from lionagi.utils import LIONAGI_HOME
 
 if TYPE_CHECKING:
@@ -292,20 +293,40 @@ def resolve_run_reason(
 
 
 async def _linked_engine_session(
-    db: StateDB, engine_session_uid: str | None
+    db: StateDB,
+    engine_session_uid: str | None,
+    *,
+    retries: int = 3,
+    retry_interval: float = 0.1,
 ) -> dict[str, Any] | None:
-    """The claude-mirror session row for a CLI provider's real engine session, if mirrored yet.
+    """The claude/codex-mirror session row for a CLI provider's real engine session.
 
     ``engine_session_uid`` is the provider-native session id (e.g. a Claude Code
-    session uuid), captured from ``endpoint.session_id`` while streaming — the
-    same id ``claude_mirror`` derives its StateDB session id from, so this is
-    the link between a profile-typed agent session and its engine-typed twin.
+    session uuid or a Codex thread id), captured from ``endpoint.session_id`` while
+    streaming — the same id the mirror derives its StateDB session id from, so this
+    is the link between a profile-typed agent session and its engine-typed twin.
+
+    A present ``engine_session_uid`` means the engine session is real (it was
+    captured off a live stream chunk); the mirror row can simply not have been
+    written yet at teardown time. Retry a bounded number of times before giving
+    up — never spin unbounded waiting for a session that may never mirror.
     """
     if not engine_session_uid:
         return None
+    import anyio
+
     from lionagi.state.claude_mirror import session_db_id
 
-    return await db.get_session(session_db_id(engine_session_uid))
+    db_id = session_db_id(engine_session_uid)
+    linked = await db.get_session(db_id)
+    if linked is not None:
+        return linked
+    for _ in range(retries):
+        await anyio.sleep(retry_interval)
+        linked = await db.get_session(db_id)
+        if linked is not None:
+            return linked
+    return None
 
 
 async def _teardown_common(
@@ -359,40 +380,63 @@ async def _teardown_common(
     final_reason_summary = reason_summary
     final_evidence_refs = evidence_refs
 
-    # A profile-typed session's own async wrapper can raise (an abandoned
-    # subprocess reader, a stream-protocol hiccup) while the CLI provider's
-    # real engine session — mirrored separately from the on-disk transcript —
-    # is still alive or already completed. Reading that as "failed" is a
-    # phantom: the actual work is running or done. Suppress the demotion and
-    # link+propagate instead (ADR-0025 vocabulary: no new status value).
-    if final_status == "failed" and exception is not None:
+    # A profile-typed session's own async wrapper can raise a stream/transport
+    # error (the CLI provider's own reported "error" chunk, classified as a
+    # ProviderError by classify_provider_error) while the engine session it
+    # wraps — mirrored separately from the on-disk transcript — is still alive
+    # or already completed. Reading that as "failed" is a phantom: the actual
+    # work is running or done. Narrowly suppress the demotion for THIS known
+    # class only: a generic bug elsewhere in the wrapper (message persistence,
+    # artifact verification, hook handling, branch mutation) must still fail
+    # loud even when a linked engine session happens to be running/completed.
+    if final_status == "failed" and isinstance(exception, ProviderError) and engine_session_uid:
+        from lionagi.state.claude_mirror import session_db_id
+        from lionagi.state.db import SESSION_TERMINAL_STATUSES
+        from lionagi.state.reasons import RunReasons
+
+        linked_id = session_db_id(engine_session_uid)
         linked = await _linked_engine_session(db, engine_session_uid)
-        if linked is not None and linked.get("status") in ("running", "completed"):
-            from lionagi.state.reasons import RunReasons
 
-            final_status = "completed" if linked["status"] == "completed" else "running"
-            final_reason_code = (
-                RunReasons.COMPLETED_OK if final_status == "completed" else RunReasons.STARTED_OK
-            )
+        # Record the link durably regardless of whether the mirror row exists
+        # yet — the id is deterministic from engine_session_uid, so `li
+        # monitor run <profile_session_id>` can follow it and resolve the
+        # real status once the mirror row lands, even if this teardown's
+        # bounded wait ran out first.
+        metadata = dict(metadata or {})
+        metadata["linked_engine_session_id"] = linked_id
+        existing_node_meta = session_row.get("node_metadata") or {}
+        if isinstance(existing_node_meta, str):
+            existing_node_meta = json.loads(existing_node_meta)
+        await db.update_session(
+            session_id,
+            node_metadata=json.dumps({**existing_node_meta, "linked_engine_session_id": linked_id}),
+        )
+
+        if linked is not None and linked["status"] in SESSION_TERMINAL_STATUSES:
+            reason_by_status = {
+                "completed": RunReasons.COMPLETED_OK,
+                "completed_empty": RunReasons.COMPLETED_EMPTY_NO_EVIDENCE,
+                "failed": RunReasons.FAILED_EXCEPTION,
+                "timed_out": RunReasons.TIMED_OUT_DEADLINE,
+                "aborted": RunReasons.CANCELLED_SIGINT,
+                "cancelled": RunReasons.CANCELLED_SYSTEM,
+            }
+            final_status = linked["status"]
+            final_reason_code = reason_by_status.get(linked["status"], RunReasons.FAILED_EXCEPTION)
             final_reason_summary = (
-                f"suppressed phantom 'failed': linked engine session {linked['id']} "
-                f"is {linked['status']!r}"
+                f"reconciled to linked engine session {linked_id} terminal status "
+                f"{linked['status']!r}"
             )
-            final_evidence_refs = [
-                {"kind": "session", "id": linked["id"], "label": linked["status"]}
-            ]
-            metadata = dict(metadata or {})
-            metadata["linked_engine_session_id"] = linked["id"]
-
-            existing_node_meta = session_row.get("node_metadata") or {}
-            if isinstance(existing_node_meta, str):
-                existing_node_meta = json.loads(existing_node_meta)
-            await db.update_session(
-                session_id,
-                node_metadata=json.dumps(
-                    {**existing_node_meta, "linked_engine_session_id": linked["id"]}
-                ),
+            final_evidence_refs = [{"kind": "session", "id": linked_id, "label": linked["status"]}]
+        elif linked is not None and linked["status"] == "running":
+            final_status = "running"
+            final_reason_code = RunReasons.STARTED_OK
+            final_reason_summary = (
+                f"suppressed phantom 'failed': linked engine session {linked_id} is still running"
             )
+            final_evidence_refs = [{"kind": "session", "id": linked_id, "label": "running"}]
+        # else: engine uid was captured but no mirror row landed within the
+        # bounded wait — can't confirm the engine is alive, so `failed` stands.
 
     if verification and verification["status"] == "failed":
         from lionagi.state.reasons import RunReasons

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -291,6 +291,23 @@ def resolve_run_reason(
     return RunReasons.FAILED_EXCEPTION, "Run failed.", None
 
 
+async def _linked_engine_session(
+    db: StateDB, engine_session_uid: str | None
+) -> dict[str, Any] | None:
+    """The claude-mirror session row for a CLI provider's real engine session, if mirrored yet.
+
+    ``engine_session_uid`` is the provider-native session id (e.g. a Claude Code
+    session uuid), captured from ``endpoint.session_id`` while streaming — the
+    same id ``claude_mirror`` derives its StateDB session id from, so this is
+    the link between a profile-typed agent session and its engine-typed twin.
+    """
+    if not engine_session_uid:
+        return None
+    from lionagi.state.claude_mirror import session_db_id
+
+    return await db.get_session(session_db_id(engine_session_uid))
+
+
 async def _teardown_common(
     db: StateDB,
     *,
@@ -304,6 +321,7 @@ async def _teardown_common(
     identity_markers: dict | None = None,
     escalated_evidence: list[dict] | None = None,
     cwd: str | None = None,
+    engine_session_uid: str | None = None,
 ) -> str:
     from lionagi.state.artifact_verifier import (
         missing_artifact_evidence,
@@ -341,11 +359,46 @@ async def _teardown_common(
     final_reason_summary = reason_summary
     final_evidence_refs = evidence_refs
 
+    # A profile-typed session's own async wrapper can raise (an abandoned
+    # subprocess reader, a stream-protocol hiccup) while the CLI provider's
+    # real engine session — mirrored separately from the on-disk transcript —
+    # is still alive or already completed. Reading that as "failed" is a
+    # phantom: the actual work is running or done. Suppress the demotion and
+    # link+propagate instead (ADR-0025 vocabulary: no new status value).
+    if final_status == "failed" and exception is not None:
+        linked = await _linked_engine_session(db, engine_session_uid)
+        if linked is not None and linked.get("status") in ("running", "completed"):
+            from lionagi.state.reasons import RunReasons
+
+            final_status = "completed" if linked["status"] == "completed" else "running"
+            final_reason_code = (
+                RunReasons.COMPLETED_OK if final_status == "completed" else RunReasons.STARTED_OK
+            )
+            final_reason_summary = (
+                f"suppressed phantom 'failed': linked engine session {linked['id']} "
+                f"is {linked['status']!r}"
+            )
+            final_evidence_refs = [
+                {"kind": "session", "id": linked["id"], "label": linked["status"]}
+            ]
+            metadata = dict(metadata or {})
+            metadata["linked_engine_session_id"] = linked["id"]
+
+            existing_node_meta = session_row.get("node_metadata") or {}
+            if isinstance(existing_node_meta, str):
+                existing_node_meta = json.loads(existing_node_meta)
+            await db.update_session(
+                session_id,
+                node_metadata=json.dumps(
+                    {**existing_node_meta, "linked_engine_session_id": linked["id"]}
+                ),
+            )
+
     if verification and verification["status"] == "failed":
         from lionagi.state.reasons import RunReasons
 
         missing = verification["missing_required"]
-        if status == "completed":
+        if final_status == "completed":
             final_status = "failed"
             final_reason_code = RunReasons.FAILED_MISSING_ARTIFACT
             final_reason_summary = missing_artifact_summary(missing)
@@ -472,6 +525,7 @@ async def teardown_persist(
     extras: dict | None = None,
     escalated_evidence: list[dict] | None = None,
     cwd: str | None = None,
+    engine_session_uid: str | None = None,
 ) -> str:
     if ctx is None:
         return status
@@ -490,6 +544,7 @@ async def teardown_persist(
             identity_markers=ctx.get("identity_markers"),
             escalated_evidence=escalated_evidence,
             cwd=cwd,
+            engine_session_uid=engine_session_uid,
         )
 
         from lionagi.hooks import unroute_message_persistence

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -477,11 +477,17 @@ async def _run_agent(
         import anyio
 
         with anyio.CancelScope(shield=True):
+            # The CLI provider's real engine session id (e.g. a Claude Code
+            # session uuid), captured from a "system" stream chunk — the
+            # link teardown uses to tell a genuine failure from a wrapper
+            # exception racing an engine session that is still alive.
+            _engine_session_uid = getattr(branch.chat_model.endpoint, "session_id", None)
             effective_status = await teardown_agent_persist(
                 live,
                 status=_terminal_status,
                 exception=_terminal_exc,
                 cwd=cwd,
+                engine_session_uid=_engine_session_uid,
             )
             if effective_status != _terminal_status:
                 _terminal_status = effective_status

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -1064,7 +1064,7 @@ async def _effective_session_status(db: Any, row: dict[str, Any]) -> dict[str, A
             "cancelled": RunReasons.CANCELLED_SYSTEM,
         }
         try:
-            await db.update_status(
+            updated = await db.update_status(
                 "session",
                 row["id"],
                 new_status=linked["status"],
@@ -1082,6 +1082,14 @@ async def _effective_session_status(db: Any, row: dict[str, Any]) -> dict[str, A
             # The profile row went terminal between our read and this write (a race
             # with another writer) — the persisted row is authoritative; report it
             # instead of the synthesized status below, and never crash the monitor.
+            persisted = await db.get_session(row["id"])
+            return persisted if persisted is not None else row
+        if not updated:
+            # CAS mismatch: the persisted row changed between our read and this
+            # write but did not hit the terminal guard (e.g. it moved to a
+            # different non-terminal or terminal status). The write never landed,
+            # so the persisted row — not the synthesized value below — is
+            # authoritative.
             persisted = await db.get_session(row["id"])
             return persisted if persisted is not None else row
     return {**row, "status": linked["status"]}

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -962,6 +962,10 @@ def _watch_loop(
 # means the chain as a whole succeeded).
 
 _TERMINAL_SCHEDULE_RUN_STATUSES = frozenset({"completed", "failed", "cancelled", "skipped"})
+# Scripting wait bound applied when the caller doesn't supply --max-wait/max_wait —
+# a stuck session or run must not hang `li monitor run`/`li monitor --run` forever.
+# Pass max_wait=0 (or --max-wait 0) to opt into the old unbounded behavior explicitly.
+_DEFAULT_MAX_WAIT_SECONDS = 900.0
 _CHAIN_GRACE_TICKS = 2
 # Mirrors the scheduler engine's own chain-depth cap (lionagi/studio/scheduler/engine.py
 # _MAX_CHAIN_DEPTH) -- the engine never fires a chain child at or past this depth, so a
@@ -1022,7 +1026,16 @@ async def _effective_session_status(db: Any, row: dict[str, Any]) -> dict[str, A
     later revisits that row to flip it. The linked engine row is the ground truth for
     completion, so follow it here on every poll rather than trusting the profile row's
     own (possibly stale) status column.
+
+    When the linked row has reached a terminal status, PERSIST that status onto the
+    profile row through StateDB.update_status() (CAS-guarded on the status this call
+    just read) before returning — otherwise the synthesized in-memory value here is
+    the only place the reconciliation ever lands, and the DB row itself stays stuck
+    at "running" forever even after this function reports the true terminal status.
     """
+    from lionagi.state.db import SESSION_TERMINAL_STATUSES
+    from lionagi.state.reasons import RunReasons
+
     node_metadata = row.get("node_metadata") or {}
     if isinstance(node_metadata, str):
         node_metadata = json.loads(node_metadata)
@@ -1032,6 +1045,29 @@ async def _effective_session_status(db: Any, row: dict[str, Any]) -> dict[str, A
     linked = await db.get_session(linked_id)
     if linked is None or linked["status"] == row["status"]:
         return row
+    if linked["status"] in SESSION_TERMINAL_STATUSES:
+        reason_by_status = {
+            "completed": RunReasons.COMPLETED_OK,
+            "completed_empty": RunReasons.COMPLETED_EMPTY_NO_EVIDENCE,
+            "failed": RunReasons.FAILED_EXCEPTION,
+            "timed_out": RunReasons.TIMED_OUT_DEADLINE,
+            "aborted": RunReasons.CANCELLED_SIGINT,
+            "cancelled": RunReasons.CANCELLED_SYSTEM,
+        }
+        await db.update_status(
+            "session",
+            row["id"],
+            new_status=linked["status"],
+            reason_code=reason_by_status.get(linked["status"], RunReasons.FAILED_EXCEPTION),
+            reason_summary=(
+                f"reconciled to linked engine session {linked_id} terminal status "
+                f"{linked['status']!r}"
+            ),
+            evidence_refs=[{"kind": "session", "id": linked_id, "label": linked["status"]}],
+            source="executor",
+            actor=row["id"],
+            expected_statuses={row["status"]},
+        )
     return {**row, "status": linked["status"]}
 
 
@@ -1392,6 +1428,12 @@ def _dispatch_wait(
     landing mid-call surfaces as KeyboardInterrupt at the call site (see
     _run_tick below) far more often than it does for the dashboard, so that
     case is folded into the same clean-exit path instead of left to crash.
+
+    max_wait: None (the default, whether left unset by a Python caller or by
+    an unset --max-wait on the CLI) applies the bounded `_DEFAULT_MAX_WAIT_SECONDS`
+    fallback — a stuck session or run must not hang this call forever. Pass 0
+    (or a negative value) to opt into the old unbounded wait explicitly; any
+    positive value overrides the default bound.
     """
     from lionagi.ln.concurrency import run_async
     from lionagi.state.db import DEFAULT_DB_PATH, StateDB
@@ -1471,8 +1513,11 @@ def _dispatch_wait(
     # A stuck session (an unresolvable linked-engine mirror, a wedged
     # subprocess) must not hang this loop forever — max_wait bounds total
     # wall-clock; on expiry, whatever is still pending is reported the same
-    # way an interrupt would (EXIT_RUNNING below), not a silent hang.
-    deadline = time.monotonic() + max_wait if max_wait is not None else None
+    # way an interrupt would (EXIT_RUNNING below), not a silent hang. None
+    # falls back to the bounded default; 0/negative is the explicit opt-in
+    # to unbounded waiting.
+    effective_max_wait = _DEFAULT_MAX_WAIT_SECONDS if max_wait is None else max_wait
+    deadline = time.monotonic() + effective_max_wait if effective_max_wait > 0 else None
 
     def _wait_expired() -> bool:
         return deadline is not None and time.monotonic() >= deadline
@@ -1575,7 +1620,8 @@ def run_monitor_wait(argv: list[str]) -> int:
         help=(
             "Give up waiting after this many seconds and exit EXIT_RUNNING "
             "for whatever is still pending, instead of blocking forever on a "
-            "stuck session or run. Default: no limit."
+            f"stuck session or run. Default: {_DEFAULT_MAX_WAIT_SECONDS:g}s. "
+            "Pass 0 for unlimited."
         ),
     )
     args = parser.parse_args(argv)
@@ -1686,6 +1732,18 @@ def add_monitor_subparser(subparsers: argparse._SubParsersAction) -> None:
             "following scheduler on_success/on_fail chain children by default."
         ),
     )
+    mon.add_argument(
+        "--max-wait",
+        type=float,
+        default=None,
+        metavar="SECS",
+        help=(
+            "With --run: give up waiting after this many seconds and exit "
+            "EXIT_RUNNING for whatever is still pending, instead of blocking "
+            f"forever on a stuck session or run. Default: {_DEFAULT_MAX_WAIT_SECONDS:g}s. "
+            "Pass 0 for unlimited."
+        ),
+    )
 
 
 def run_monitor(args: argparse.Namespace) -> int:
@@ -1702,7 +1760,11 @@ def run_monitor(args: argparse.Namespace) -> int:
             log_error("no schedule_run ids given (only empty/comma-only tokens)")
             return 2
         return _dispatch_wait(
-            watched_ids, interval=args.interval, follow=args.follow, chain=args.chain
+            watched_ids,
+            interval=args.interval,
+            follow=args.follow,
+            chain=args.chain,
+            max_wait=args.max_wait,
         )
 
     since: float | None = None

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -1032,9 +1032,18 @@ async def _effective_session_status(db: Any, row: dict[str, Any]) -> dict[str, A
     just read) before returning — otherwise the synthesized in-memory value here is
     the only place the reconciliation ever lands, and the DB row itself stays stuck
     at "running" forever even after this function reports the true terminal status.
+
+    A profile row that is ALREADY terminal is authoritative and is never rewritten:
+    ADR-0094's terminal guard exists precisely to stop a persisted terminal status
+    (e.g. "failed") from being silently flipped to a different terminal status the
+    linked engine happens to report later (e.g. "completed"). Reconciliation only
+    ever advances a non-terminal profile row to the engine's terminal status.
     """
-    from lionagi.state.db import SESSION_TERMINAL_STATUSES
+    from lionagi.state.db import SESSION_TERMINAL_STATUSES, TransitionRejectedError
     from lionagi.state.reasons import RunReasons
+
+    if row["status"] in SESSION_TERMINAL_STATUSES:
+        return row
 
     node_metadata = row.get("node_metadata") or {}
     if isinstance(node_metadata, str):
@@ -1054,20 +1063,27 @@ async def _effective_session_status(db: Any, row: dict[str, Any]) -> dict[str, A
             "aborted": RunReasons.CANCELLED_SIGINT,
             "cancelled": RunReasons.CANCELLED_SYSTEM,
         }
-        await db.update_status(
-            "session",
-            row["id"],
-            new_status=linked["status"],
-            reason_code=reason_by_status.get(linked["status"], RunReasons.FAILED_EXCEPTION),
-            reason_summary=(
-                f"reconciled to linked engine session {linked_id} terminal status "
-                f"{linked['status']!r}"
-            ),
-            evidence_refs=[{"kind": "session", "id": linked_id, "label": linked["status"]}],
-            source="executor",
-            actor=row["id"],
-            expected_statuses={row["status"]},
-        )
+        try:
+            await db.update_status(
+                "session",
+                row["id"],
+                new_status=linked["status"],
+                reason_code=reason_by_status.get(linked["status"], RunReasons.FAILED_EXCEPTION),
+                reason_summary=(
+                    f"reconciled to linked engine session {linked_id} terminal status "
+                    f"{linked['status']!r}"
+                ),
+                evidence_refs=[{"kind": "session", "id": linked_id, "label": linked["status"]}],
+                source="executor",
+                actor=row["id"],
+                expected_statuses={row["status"]},
+            )
+        except TransitionRejectedError:
+            # The profile row went terminal between our read and this write (a race
+            # with another writer) — the persisted row is authoritative; report it
+            # instead of the synthesized status below, and never crash the monitor.
+            persisted = await db.get_session(row["id"])
+            return persisted if persisted is not None else row
     return {**row, "status": linked["status"]}
 
 

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import signal
 import sys
@@ -1013,6 +1014,27 @@ def _format_session_wait_line(row: dict[str, Any]) -> str:
     return f"{row['id']}  name={name}  status={row['status']}  artifacts={artifacts}"
 
 
+async def _effective_session_status(db: Any, row: dict[str, Any]) -> dict[str, Any]:
+    """A profile-typed session (`li agent -a <profile>`) that teardown linked to a
+    claude/codex-mirror engine session (node_metadata.linked_engine_session_id, see
+    lionagi/cli/_runs.py) can be pinned at status="running" indefinitely once teardown
+    observed the engine alive but couldn't yet confirm a terminal state — nothing
+    later revisits that row to flip it. The linked engine row is the ground truth for
+    completion, so follow it here on every poll rather than trusting the profile row's
+    own (possibly stale) status column.
+    """
+    node_metadata = row.get("node_metadata") or {}
+    if isinstance(node_metadata, str):
+        node_metadata = json.loads(node_metadata)
+    linked_id = node_metadata.get("linked_engine_session_id")
+    if not linked_id:
+        return row
+    linked = await db.get_session(linked_id)
+    if linked is None or linked["status"] == row["status"]:
+        return row
+    return {**row, "status": linked["status"]}
+
+
 async def _poll_pending_sessions_once(
     db: Any,
     pending: dict[str, dict[str, Any]],
@@ -1028,8 +1050,10 @@ async def _poll_pending_sessions_once(
             from ._logging import log_error
 
             log_error(f"session {run_id!r} disappeared from state.db while waiting")
-        elif row["status"] not in SESSION_TERMINAL_STATUSES:
-            continue
+        else:
+            row = await _effective_session_status(db, row)
+            if row["status"] not in SESSION_TERMINAL_STATUSES:
+                continue
         print(_format_session_wait_line(row))
         done.append(row)
         del pending[run_id]
@@ -1334,7 +1358,14 @@ async def _query_schedule_runs_since(db: Any, baseline: float) -> list[dict[str,
     )
 
 
-def _dispatch_wait(ids: list[str], *, interval: float, follow: bool, chain: bool = True) -> int:
+def _dispatch_wait(
+    ids: list[str],
+    *,
+    interval: float,
+    follow: bool,
+    chain: bool = True,
+    max_wait: float | None = None,
+) -> int:
     """Block until every id in `ids` reaches a terminal schedule_run status,
     printing one line per run the moment it lands; with --follow, keep
     watching (tail -f style) for newly created runs after the initial set
@@ -1437,9 +1468,18 @@ def _dispatch_wait(ids: list[str], *, interval: float, follow: bool, chain: bool
     def _chain_open() -> bool:
         return bool(pending or session_pending or chain_state["awaiting_grace"])
 
-    while _chain_open() and not interrupted:
+    # A stuck session (an unresolvable linked-engine mirror, a wedged
+    # subprocess) must not hang this loop forever — max_wait bounds total
+    # wall-clock; on expiry, whatever is still pending is reported the same
+    # way an interrupt would (EXIT_RUNNING below), not a silent hang.
+    deadline = time.monotonic() + max_wait if max_wait is not None else None
+
+    def _wait_expired() -> bool:
+        return deadline is not None and time.monotonic() >= deadline
+
+    while _chain_open() and not interrupted and not _wait_expired():
         _run_tick(_tick())
-        if not _chain_open() or interrupted:
+        if not _chain_open() or interrupted or _wait_expired():
             break
         _sleep_interval(interval)
 
@@ -1527,6 +1567,17 @@ def run_monitor_wait(argv: list[str]) -> int:
             "its final link instead of exiting on the first terminal run."
         ),
     )
+    parser.add_argument(
+        "--max-wait",
+        type=float,
+        default=None,
+        metavar="SECS",
+        help=(
+            "Give up waiting after this many seconds and exit EXIT_RUNNING "
+            "for whatever is still pending, instead of blocking forever on a "
+            "stuck session or run. Default: no limit."
+        ),
+    )
     args = parser.parse_args(argv)
     watched_ids = _split_watched_ids(args.ids)
     if not watched_ids:
@@ -1534,7 +1585,13 @@ def run_monitor_wait(argv: list[str]) -> int:
         # of them survive comma-splitting (e.g. a lone "," or ""). Without
         # this check that degenerates into a silent, instant, exit-0 no-op.
         parser.error("no schedule_run ids given (only empty/comma-only tokens)")
-    return _dispatch_wait(watched_ids, interval=args.interval, follow=args.follow, chain=args.chain)
+    return _dispatch_wait(
+        watched_ids,
+        interval=args.interval,
+        follow=args.follow,
+        chain=args.chain,
+        max_wait=args.max_wait,
+    )
 
 
 # ── CLI registration ──────────────────────────────────────────────────────────

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -996,24 +996,72 @@ async def _resolve_schedule_run(db: Any, raw_id: str) -> dict[str, Any] | None:
     )
 
 
+async def _resolve_session_run(db: Any, raw_id: str) -> dict[str, Any] | None:
+    """Exact match then prefix match against the sessions table (agent/li agent run ids)."""
+    row = await db.get_session(raw_id)
+    if row:
+        return row
+    return await db.fetch_one(
+        "SELECT * FROM sessions WHERE id LIKE ?",
+        (raw_id + "%",),
+    )
+
+
+def _format_session_wait_line(row: dict[str, Any]) -> str:
+    name = row.get("agent_name") or row.get("invocation_kind") or "session"
+    artifacts = row.get("artifacts_path") or "-"
+    return f"{row['id']}  name={name}  status={row['status']}  artifacts={artifacts}"
+
+
+async def _poll_pending_sessions_once(
+    db: Any,
+    pending: dict[str, dict[str, Any]],
+    done: list[dict[str, Any]],
+) -> None:
+    """Session analogue of _poll_pending_once: no schedule chain, just terminal-status polling."""
+    from lionagi.state.db import SESSION_TERMINAL_STATUSES
+
+    for run_id in list(pending):
+        row = await db.get_session(run_id)
+        if row is None:
+            row = {**pending[run_id], "status": "failed"}
+            from ._logging import log_error
+
+            log_error(f"session {run_id!r} disappeared from state.db while waiting")
+        elif row["status"] not in SESSION_TERMINAL_STATUSES:
+            continue
+        print(_format_session_wait_line(row))
+        done.append(row)
+        del pending[run_id]
+
+
 async def _resolve_watched_runs(
     db: Any, ids: list[str]
-) -> tuple[dict[str, dict[str, Any]], list[str]]:
+) -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]], list[str]]:
     """Resolve every requested id once, up front. schedule_run ids are
     already-fired-run identifiers a caller obtained elsewhere (e.g. `li
     schedule trigger`), not something that might come into existence later,
     so — unlike the --follow discovery scan below — resolution itself is
     not retried on every poll tick.
+
+    An id that isn't a schedule_run is also tried against the sessions table
+    (agent/li agent run ids) so `li monitor run <session_id>` can drill into
+    an agent run's terminal status + artifacts, not just scheduler runs.
     """
     pending: dict[str, dict[str, Any]] = {}
+    session_pending: dict[str, dict[str, Any]] = {}
     unresolved: list[str] = []
     for raw_id in ids:
         row = await _resolve_schedule_run(db, raw_id)
-        if row is None:
-            unresolved.append(raw_id)
-        else:
+        if row is not None:
             pending[row["id"]] = row  # canonical id as key: dedupes prefix collisions
-    return pending, unresolved
+            continue
+        session_row = await _resolve_session_run(db, raw_id)
+        if session_row is not None:
+            session_pending[session_row["id"]] = session_row
+        else:
+            unresolved.append(raw_id)
+    return pending, session_pending, unresolved
 
 
 async def _schedule_name(db: Any, schedule_id: str, *, cache: dict[str, str]) -> str:
@@ -1356,7 +1404,7 @@ def _dispatch_wait(ids: list[str], *, interval: float, follow: bool, chain: bool
 
     schedule_names: dict[str, str] = {}
 
-    async def _resolve() -> tuple[dict[str, dict[str, Any]], list[str]]:
+    async def _resolve() -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]], list[str]]:
         async with StateDB() as db:
             return await _resolve_watched_runs(db, ids)
 
@@ -1366,12 +1414,14 @@ def _dispatch_wait(ids: list[str], *, interval: float, follow: bool, chain: bool
         # which ids exist or what state they're in, so there is no aggregate
         # to report. This is "still in progress", not success or failure.
         return EXIT_RUNNING
-    pending, unresolved = resolved
+    pending, session_pending, unresolved = resolved
     for raw_id in unresolved:
-        log_error(f"schedule_run {raw_id!r} not found")
+        log_error(f"run id {raw_id!r} not found (checked schedule_runs and sessions)")
 
     total_watched = len(pending)
+    total_sessions = len(session_pending)
     done: list[dict[str, Any]] = []
+    session_done: list[dict[str, Any]] = []
     chain_state = _new_chain_state(pending, chain=chain)
     processed = 0
 
@@ -1379,12 +1429,13 @@ def _dispatch_wait(ids: list[str], *, interval: float, follow: bool, chain: bool
         nonlocal processed
         async with StateDB() as db:
             await _poll_pending_once(db, pending, schedule_names, done)
+            await _poll_pending_sessions_once(db, session_pending, session_done)
             processed = await _advance_chains(
                 db, pending, done, chain_state=chain_state, processed=processed
             )
 
     def _chain_open() -> bool:
-        return bool(pending or chain_state["awaiting_grace"])
+        return bool(pending or session_pending or chain_state["awaiting_grace"])
 
     while _chain_open() and not interrupted:
         _run_tick(_tick())
@@ -1394,16 +1445,19 @@ def _dispatch_wait(ids: list[str], *, interval: float, follow: bool, chain: bool
 
     resolved_roots = chain_state["resolved_roots"]
     chain_tail_exit = chain_state["chain_tail_exit"]
+    from ._util import EXIT_CODE_BY_STATUS
+
+    session_ok = all(EXIT_CODE_BY_STATUS.get(r["status"], 1) == 0 for r in session_done)
     if unresolved:
         exit_code = EXIT_UNKNOWN
-    elif len(resolved_roots) < total_watched:
-        # Some watched chain never concluded before we had to stop — either
-        # still pending outright or still inside its grace window. `done`
-        # (mutated in _poll_pending_once) and `chain_state` (mutated in
-        # _advance_chains, see above) are the ground truth that survives a
-        # tick being interrupted mid-flight.
+    elif len(resolved_roots) < total_watched or len(session_done) < total_sessions:
+        # Some watched chain (or session) never concluded before we had to
+        # stop — either still pending outright or still inside its grace
+        # window. `done`/`session_done` (mutated in the poll helpers above)
+        # and `chain_state` (mutated in _advance_chains) are the ground
+        # truth that survives a tick being interrupted mid-flight.
         exit_code = EXIT_RUNNING
-    elif all(chain_tail_exit.get(root) == 0 for root in resolved_roots):
+    elif all(chain_tail_exit.get(root) == 0 for root in resolved_roots) and session_ok:
         # Final-link-wins: each resolved chain's most recently seen terminal
         # exit_code decides, not every link along the way.
         exit_code = 0

--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from collections.abc import AsyncGenerator
 from dataclasses import fields
@@ -39,21 +40,30 @@ logger = logging.getLogger(__name__)
 
 
 async def _stream_with_deadline(model, api_call, deadline: float | None):
-    """Iterate model.stream(api_call) with per-__anext__ anyio cancel scope; transparent passthrough when deadline is None."""
-    stream_iter = model.stream(api_call=api_call).__aiter__()
-    while True:
-        try:
-            if deadline is not None:
-                remaining = deadline - anyio.current_time()
-                if remaining <= 0:
-                    raise TimeoutError("run() stream timeout exceeded")
-                with anyio.fail_after(remaining):
+    """Iterate model.stream(api_call) with per-__anext__ anyio cancel scope; transparent passthrough when deadline is None.
+
+    Wraps the underlying stream in ``aclosing`` so an early exit (exception,
+    consumer abandonment) deterministically closes it instead of leaving it
+    to async-generator GC — for a CLI provider that close cascades down to
+    the subprocess reader's own ``finally`` and terminates the process
+    group; without it, an abandoned generator can leave the CLI subprocess
+    running to completion, orphaned, after the caller already gave up.
+    """
+    async with contextlib.aclosing(model.stream(api_call=api_call)) as agen:
+        stream_iter = agen.__aiter__()
+        while True:
+            try:
+                if deadline is not None:
+                    remaining = deadline - anyio.current_time()
+                    if remaining <= 0:
+                        raise TimeoutError("run() stream timeout exceeded")
+                    with anyio.fail_after(remaining):
+                        chunk = await stream_iter.__anext__()
+                else:
                     chunk = await stream_iter.__anext__()
-            else:
-                chunk = await stream_iter.__anext__()
-        except StopAsyncIteration:
-            break
-        yield chunk
+            except StopAsyncIteration:
+                break
+            yield chunk
 
 
 async def run(
@@ -183,9 +193,10 @@ async def run(
         api_call = await model.create_event(**kw)
         await model.executor.append(api_call)
 
+        stream_gen = _stream_with_deadline(model, api_call, _stream_deadline)
         try:
             try:
-                async for chunk in _stream_with_deadline(model, api_call, _stream_deadline):
+                async for chunk in stream_gen:
                     match chunk.type:
                         case "system":
                             if sid := chunk.metadata.get("session_id"):
@@ -297,6 +308,14 @@ async def run(
                 _run_exc = _exc
                 raise
         finally:
+            # Deterministically close the stream chain on ANY exit (normal
+            # StopAsyncIteration, an "error" chunk raise, a control-signal
+            # _StopStream, GeneratorExit) rather than leaving it to
+            # async-generator GC — for a CLI provider that cascades down to
+            # the subprocess reader's own cleanup and terminates the process
+            # group instead of leaving it running, orphaned, in the background.
+            with contextlib.suppress(Exception):
+                await stream_gen.aclose()
             model.streaming_process_func = prev_stream_func
             if param.stream_persist:
                 snapshot_dir = param.snapshot_dir or param.persist_dir

--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import sys
 from collections.abc import AsyncGenerator
 from dataclasses import fields
 from typing import TYPE_CHECKING, Any
@@ -314,8 +315,29 @@ async def run(
             # async-generator GC — for a CLI provider that cascades down to
             # the subprocess reader's own cleanup and terminates the process
             # group instead of leaving it running, orphaned, in the background.
-            with contextlib.suppress(Exception):
+            #
+            # The close chain (ndjson_from_cli -> aterminate_process_group ->
+            # asyncio.wait_for) can raise asyncio.CancelledError, a
+            # BaseException that a plain `except Exception` will not catch —
+            # left unguarded it escapes this finally block and REPLACES
+            # whatever provider/control exception is already propagating
+            # (_run_exc, an in-flight ProviderError, a _StopStream signal).
+            # Preserve the primary: a close failure while already unwinding
+            # is a secondary cleanup failure, logged and swallowed, never
+            # allowed to mask the real reason the stream ended.
+            _unwinding = sys.exc_info()[1] is not None
+            try:
                 await stream_gen.aclose()
+            except Exception as _close_exc:
+                logger.debug("run: stream_gen.aclose() raised during cleanup: %r", _close_exc)
+            except BaseException as _close_exc:
+                if not _unwinding:
+                    raise
+                logger.debug(
+                    "run: aclose() raised %r while another exception was already "
+                    "propagating; suppressing the secondary cleanup failure",
+                    _close_exc,
+                )
             model.streaming_process_func = prev_stream_func
             if param.stream_persist:
                 snapshot_dir = param.snapshot_dir or param.persist_dir

--- a/lionagi/providers/openai/codex.py
+++ b/lionagi/providers/openai/codex.py
@@ -463,7 +463,13 @@ async def stream_codex_cli(
                     obj.get("session_id", obj.get("id")),
                 )
                 session.model = obj.get("model")
-                sc = StreamChunk(type="system", metadata=obj)
+                # Codex's own event carries "thread_id" (thread.started) rather
+                # than "session_id" — normalize it into the metadata key every
+                # CLI provider's system chunk is expected to carry (mirrors
+                # claude_code.py), so run.py's engine-session-id capture
+                # (endpoint.session_id, used to link a profile-typed session
+                # to its engine-typed mirror at teardown) works for Codex too.
+                sc = StreamChunk(type="system", metadata={**obj, "session_id": session.session_id})
                 session.chunks.append(sc)
                 yield sc
 

--- a/tests/cli/test_agent_codex_robustness.py
+++ b/tests/cli/test_agent_codex_robustness.py
@@ -112,7 +112,9 @@ def _make_agent_mocks_with_bypass(monkeypatch, tmp_path, captured_kwargs: list):
     async def fake_setup(*a, **kw):
         return None
 
-    async def fake_teardown(ctx, *, status="completed", exception=None, cwd=None):
+    async def fake_teardown(
+        ctx, *, status="completed", exception=None, cwd=None, engine_session_uid=None
+    ):
         return status
 
     monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)
@@ -264,7 +266,9 @@ async def test_run_agent_timeout_preserves_partial_output(monkeypatch, tmp_path)
     async def fake_setup(*a, **kw):
         return None
 
-    async def fake_teardown(ctx, *, status="completed", exception=None, cwd=None):
+    async def fake_teardown(
+        ctx, *, status="completed", exception=None, cwd=None, engine_session_uid=None
+    ):
         return status
 
     monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)
@@ -335,7 +339,9 @@ async def test_run_agent_timeout_empty_partial_returns_empty_string(monkeypatch,
     async def fake_setup(*a, **kw):
         return None
 
-    async def fake_teardown(ctx, *, status="completed", exception=None, cwd=None):
+    async def fake_teardown(
+        ctx, *, status="completed", exception=None, cwd=None, engine_session_uid=None
+    ):
         return status
 
     monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)
@@ -412,7 +418,9 @@ async def test_run_agent_heartbeat_started_when_timeout_set(monkeypatch, tmp_pat
     async def fake_setup(*a, **kw):
         return None
 
-    async def fake_teardown(ctx, *, status="completed", exception=None, cwd=None):
+    async def fake_teardown(
+        ctx, *, status="completed", exception=None, cwd=None, engine_session_uid=None
+    ):
         return status
 
     monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)
@@ -477,7 +485,9 @@ async def test_run_agent_no_heartbeat_when_timeout_none(monkeypatch, tmp_path):
     async def fake_setup(*a, **kw):
         return None
 
-    async def fake_teardown(ctx, *, status="completed", exception=None, cwd=None):
+    async def fake_teardown(
+        ctx, *, status="completed", exception=None, cwd=None, engine_session_uid=None
+    ):
         return status
 
     monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)

--- a/tests/cli/test_agent_context_from.py
+++ b/tests/cli/test_agent_context_from.py
@@ -411,7 +411,7 @@ def _wire_agent_stubs(
     async def fake_setup(*a, **kw):
         return None
 
-    async def fake_teardown(ctx, *, status="completed", exception=None, cwd=None):
+    async def fake_teardown(ctx, *, status="completed", exception=None, cwd=None, **kwargs):
         return status
 
     monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)

--- a/tests/cli/test_agent_live_persist.py
+++ b/tests/cli/test_agent_live_persist.py
@@ -1167,6 +1167,57 @@ async def test_teardown_keeps_failed_for_real_wrapper_bug_even_when_linked_runni
     assert s["status"] == "failed"
 
 
+@pytest.mark.parametrize(
+    "error_name,message",
+    [("ProviderQuotaError", "usage limit reached"), ("ProviderAuthError", "not logged in")],
+)
+async def test_teardown_keeps_failed_for_genuine_provider_error_even_when_linked_running(
+    temp_db_path: Path, error_name, message
+):
+    """ProviderQuotaError/ProviderAuthError are genuine, well-classified provider
+    failures -- unlike the generic unclassified stream/transport ProviderError, they
+    must never be suppressed into 'running'/'completed' just because a linked engine
+    session happens to still be alive."""
+    import lionagi.providers._provider_errors as provider_errors
+    from lionagi.state.claude_mirror import mirror_session
+
+    error_cls = getattr(provider_errors, error_name)
+    engine_uid = "aaaaaaaa-bbbb-cccc-dddd-222222222221"
+    async with StateDB() as db:
+        await mirror_session(
+            db,
+            session_uid=engine_uid,
+            events=[
+                {
+                    "type": "assistant",
+                    "uuid": "e1",
+                    "timestamp": "2026-07-05T00:00:00.000Z",
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "working on it"}],
+                    },
+                }
+            ],
+            tool_names={},
+            status="running",
+        )
+
+    branch = Branch(name="b1")
+    ctx = await _setup_live_persist(branch, agent_name="implementer")
+    assert ctx is not None
+
+    exc = error_cls(message)
+    final_status = await _teardown_live_persist(
+        ctx, status="failed", exception=exc, engine_session_uid=engine_uid
+    )
+
+    assert final_status == "failed"
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "failed"
+
+
 async def test_teardown_reconciles_after_delayed_mirror_row_creation(
     temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/cli/test_agent_live_persist.py
+++ b/tests/cli/test_agent_live_persist.py
@@ -1010,3 +1010,110 @@ async def test_teardown_verification_preserves_non_completed_reason(
     v = s["artifact_verification_json"]
     assert isinstance(v, dict)
     assert v["status"] == "failed"
+
+
+# ── Phantom 'failed' suppression: linked engine session is alive/completed ───
+
+
+async def test_teardown_suppresses_failed_when_linked_engine_session_running(
+    temp_db_path: Path,
+):
+    """A wrapper exception must not read as 'failed' while the real engine session is still running."""
+    from lionagi.state.claude_mirror import mirror_session, session_db_id
+
+    engine_uid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    async with StateDB() as db:
+        await mirror_session(
+            db,
+            session_uid=engine_uid,
+            events=[
+                {
+                    "type": "assistant",
+                    "uuid": "e1",
+                    "timestamp": "2026-07-05T00:00:00.000Z",
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "working on it"}],
+                    },
+                }
+            ],
+            tool_names={},
+            status="running",
+        )
+
+    branch = Branch(name="b1")
+    ctx = await _setup_live_persist(branch, agent_name="implementer")
+    assert ctx is not None
+
+    exc = RuntimeError("abandoned stream reader")
+    final_status = await _teardown_live_persist(
+        ctx, status="failed", exception=exc, engine_session_uid=engine_uid
+    )
+
+    assert final_status == "running"
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "running"
+    assert s["node_metadata"]["linked_engine_session_id"] == session_db_id(engine_uid)
+
+
+async def test_teardown_suppresses_failed_when_linked_engine_session_completed(
+    temp_db_path: Path,
+):
+    """A wrapper exception must not read as 'failed' once the real engine session has completed."""
+    from lionagi.state.claude_mirror import mirror_session, session_db_id
+
+    engine_uid = "aaaaaaaa-bbbb-cccc-dddd-ffffffffffff"
+    async with StateDB() as db:
+        await mirror_session(
+            db,
+            session_uid=engine_uid,
+            events=[
+                {
+                    "type": "assistant",
+                    "uuid": "e1",
+                    "timestamp": "2026-07-05T00:00:00.000Z",
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "done"}],
+                    },
+                }
+            ],
+            tool_names={},
+            status="completed",
+        )
+
+    branch = Branch(name="b1")
+    ctx = await _setup_live_persist(branch, agent_name="reviewer")
+    assert ctx is not None
+
+    exc = RuntimeError("abandoned stream reader")
+    final_status = await _teardown_live_persist(
+        ctx, status="failed", exception=exc, engine_session_uid=engine_uid
+    )
+
+    assert final_status == "completed"
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "completed"
+    assert s["node_metadata"]["linked_engine_session_id"] == session_db_id(engine_uid)
+
+
+async def test_teardown_keeps_failed_without_linked_engine_session(temp_db_path: Path):
+    """No linked engine session (or no engine_session_uid at all) → a real failure stays failed."""
+    branch = Branch(name="b1")
+    ctx = await _setup_live_persist(branch, agent_name="implementer")
+    assert ctx is not None
+
+    exc = RuntimeError("genuine failure")
+    final_status = await _teardown_live_persist(
+        ctx, status="failed", exception=exc, engine_session_uid="no-such-session-uid"
+    )
+
+    assert final_status == "failed"
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "failed"

--- a/tests/cli/test_agent_live_persist.py
+++ b/tests/cli/test_agent_live_persist.py
@@ -1018,7 +1018,8 @@ async def test_teardown_verification_preserves_non_completed_reason(
 async def test_teardown_suppresses_failed_when_linked_engine_session_running(
     temp_db_path: Path,
 ):
-    """A wrapper exception must not read as 'failed' while the real engine session is still running."""
+    """A stream/provider error must not read as 'failed' while the real engine session is still running."""
+    from lionagi.providers._provider_errors import ProviderError
     from lionagi.state.claude_mirror import mirror_session, session_db_id
 
     engine_uid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
@@ -1045,7 +1046,7 @@ async def test_teardown_suppresses_failed_when_linked_engine_session_running(
     ctx = await _setup_live_persist(branch, agent_name="implementer")
     assert ctx is not None
 
-    exc = RuntimeError("abandoned stream reader")
+    exc = ProviderError("abandoned stream reader")
     final_status = await _teardown_live_persist(
         ctx, status="failed", exception=exc, engine_session_uid=engine_uid
     )
@@ -1061,7 +1062,8 @@ async def test_teardown_suppresses_failed_when_linked_engine_session_running(
 async def test_teardown_suppresses_failed_when_linked_engine_session_completed(
     temp_db_path: Path,
 ):
-    """A wrapper exception must not read as 'failed' once the real engine session has completed."""
+    """A stream/provider error must not read as 'failed' once the real engine session has completed."""
+    from lionagi.providers._provider_errors import ProviderError
     from lionagi.state.claude_mirror import mirror_session, session_db_id
 
     engine_uid = "aaaaaaaa-bbbb-cccc-dddd-ffffffffffff"
@@ -1088,7 +1090,7 @@ async def test_teardown_suppresses_failed_when_linked_engine_session_completed(
     ctx = await _setup_live_persist(branch, agent_name="reviewer")
     assert ctx is not None
 
-    exc = RuntimeError("abandoned stream reader")
+    exc = ProviderError("abandoned stream reader")
     final_status = await _teardown_live_persist(
         ctx, status="failed", exception=exc, engine_session_uid=engine_uid
     )
@@ -1103,11 +1105,13 @@ async def test_teardown_suppresses_failed_when_linked_engine_session_completed(
 
 async def test_teardown_keeps_failed_without_linked_engine_session(temp_db_path: Path):
     """No linked engine session (or no engine_session_uid at all) → a real failure stays failed."""
+    from lionagi.providers._provider_errors import ProviderError
+
     branch = Branch(name="b1")
     ctx = await _setup_live_persist(branch, agent_name="implementer")
     assert ctx is not None
 
-    exc = RuntimeError("genuine failure")
+    exc = ProviderError("genuine failure")
     final_status = await _teardown_live_persist(
         ctx, status="failed", exception=exc, engine_session_uid="no-such-session-uid"
     )
@@ -1117,3 +1121,113 @@ async def test_teardown_keeps_failed_without_linked_engine_session(temp_db_path:
         s = await db.get_session(ctx["session_id"])
     assert s is not None
     assert s["status"] == "failed"
+
+
+async def test_teardown_keeps_failed_for_real_wrapper_bug_even_when_linked_running(
+    temp_db_path: Path,
+):
+    """A genuine profile-layer exception (not a ProviderError) must stay 'failed' even
+    when a linked engine session is running/completed — suppression is narrowly scoped
+    to the CLI provider's own reported stream errors, not arbitrary wrapper bugs."""
+    from lionagi.state.claude_mirror import mirror_session
+
+    engine_uid = "aaaaaaaa-bbbb-cccc-dddd-111111111111"
+    async with StateDB() as db:
+        await mirror_session(
+            db,
+            session_uid=engine_uid,
+            events=[
+                {
+                    "type": "assistant",
+                    "uuid": "e1",
+                    "timestamp": "2026-07-05T00:00:00.000Z",
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "working on it"}],
+                    },
+                }
+            ],
+            tool_names={},
+            status="running",
+        )
+
+    branch = Branch(name="b1")
+    ctx = await _setup_live_persist(branch, agent_name="implementer")
+    assert ctx is not None
+
+    exc = RuntimeError("bug in artifact verification")
+    final_status = await _teardown_live_persist(
+        ctx, status="failed", exception=exc, engine_session_uid=engine_uid
+    )
+
+    assert final_status == "failed"
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "failed"
+
+
+async def test_teardown_reconciles_after_delayed_mirror_row_creation(
+    temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """The claude/codex mirror row for engine_session_uid may not exist YET at teardown
+    time (mirror-lag race) — _linked_engine_session must bounded-retry and pick it up
+    instead of immediately falling through to 'failed'."""
+    from lionagi.providers._provider_errors import ProviderError
+    from lionagi.state.claude_mirror import mirror_session, session_db_id
+
+    engine_uid = "aaaaaaaa-bbbb-cccc-dddd-222222222222"
+    branch = Branch(name="b1")
+    ctx = await _setup_live_persist(branch, agent_name="implementer")
+    assert ctx is not None
+
+    real_get_session = StateDB.get_session
+    calls: list[str] = []
+    created = False
+
+    async def delayed_get_session(self, session_id, *a, **kw):
+        nonlocal created
+        if session_id == session_db_id(engine_uid) and not created:
+            calls.append(session_id)
+            if len(calls) < 3:
+                # Row doesn't exist yet the first couple of lookups —
+                # simulate the mirror still catching up.
+                return None
+            created = True
+            # Write the mirror row through the SAME connection teardown is
+            # using (self) -- opening a second StateDB() to the same sqlite
+            # file from inside this monkeypatch recurses into SQLAlchemy's
+            # engine-connect event dispatch. mirror_session() itself calls
+            # db.get_session(sid) internally, so `created` must already be
+            # True before this await to avoid re-entering this branch.
+            await mirror_session(
+                self,
+                session_uid=engine_uid,
+                events=[
+                    {
+                        "type": "assistant",
+                        "uuid": "e1",
+                        "timestamp": "2026-07-05T00:00:00.000Z",
+                        "message": {
+                            "role": "assistant",
+                            "content": [{"type": "text", "text": "done"}],
+                        },
+                    }
+                ],
+                tool_names={},
+                status="completed",
+            )
+        return await real_get_session(self, session_id, *a, **kw)
+
+    monkeypatch.setattr(StateDB, "get_session", delayed_get_session)
+
+    exc = ProviderError("abandoned stream reader")
+    final_status = await _teardown_live_persist(
+        ctx,
+        status="failed",
+        exception=exc,
+        engine_session_uid=engine_uid,
+    )
+
+    assert len(calls) >= 3
+    assert final_status == "completed"

--- a/tests/cli/test_agent_preset_form.py
+++ b/tests/cli/test_agent_preset_form.py
@@ -457,7 +457,9 @@ def _wire_run_agent_mocks(monkeypatch, tmp_path):
     async def fake_setup(*a, **kw):
         return None
 
-    async def fake_teardown(ctx, *, status="completed", exception=None, cwd=None):
+    async def fake_teardown(
+        ctx, *, status="completed", exception=None, cwd=None, engine_session_uid=None
+    ):
         return status
 
     monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)

--- a/tests/cli/test_agent_profile_timeout.py
+++ b/tests/cli/test_agent_profile_timeout.py
@@ -91,7 +91,9 @@ def _wire_agent_stubs(
     async def fake_setup(*a, **kw):
         return {"session_id": "sess-0"}
 
-    async def fake_teardown(ctx, *, status="completed", exception=None, cwd=None):
+    async def fake_teardown(
+        ctx, *, status="completed", exception=None, cwd=None, engine_session_uid=None
+    ):
         return status
 
     monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)

--- a/tests/cli/test_agent_resume_empty_stream.py
+++ b/tests/cli/test_agent_resume_empty_stream.py
@@ -35,7 +35,9 @@ def _wire_agent_stubs(monkeypatch, tmp_path: Path, operate_return=None):
     async def fake_setup(*a, **kw):
         return None
 
-    async def fake_teardown(ctx, *, status="completed", exception=None, cwd=None):
+    async def fake_teardown(
+        ctx, *, status="completed", exception=None, cwd=None, engine_session_uid=None
+    ):
         return status
 
     monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)

--- a/tests/cli/test_agent_resume_gemini_effort.py
+++ b/tests/cli/test_agent_resume_gemini_effort.py
@@ -171,7 +171,9 @@ async def test_fresh_run_unaffected_by_reapply_effort(monkeypatch, tmp_path):
     async def fake_setup(*a, **kw):
         return None
 
-    async def fake_teardown(ctx, *, status="completed", exception=None, cwd=None):
+    async def fake_teardown(
+        ctx, *, status="completed", exception=None, cwd=None, engine_session_uid=None
+    ):
         return status
 
     monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)

--- a/tests/cli/test_agent_resume_model_override.py
+++ b/tests/cli/test_agent_resume_model_override.py
@@ -43,7 +43,9 @@ def _wire_agent_stubs(monkeypatch, tmp_path: Path, operate_return=None):
     async def fake_setup(*a, **kw):
         return None
 
-    async def fake_teardown(ctx, *, status="completed", exception=None, cwd=None):
+    async def fake_teardown(
+        ctx, *, status="completed", exception=None, cwd=None, engine_session_uid=None
+    ):
         return status
 
     monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)

--- a/tests/cli/test_agent_resume_on_timeout.py
+++ b/tests/cli/test_agent_resume_on_timeout.py
@@ -109,7 +109,9 @@ def _wire_agent_stubs(
         n = min(call_count["n"], len(_sids) - 1)
         return {"session_id": _sids[n]}
 
-    async def fake_teardown(ctx, *, status="completed", exception=None, cwd=None):
+    async def fake_teardown(
+        ctx, *, status="completed", exception=None, cwd=None, engine_session_uid=None
+    ):
         return status
 
     monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)
@@ -329,7 +331,9 @@ def _wire_agent_stubs_real_chat_model(
         n = min(call_count["n"], len(_sids) - 1)
         return {"session_id": _sids[n]}
 
-    async def fake_teardown(ctx, *, status="completed", exception=None, cwd=None):
+    async def fake_teardown(
+        ctx, *, status="completed", exception=None, cwd=None, engine_session_uid=None
+    ):
         return status
 
     monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)

--- a/tests/cli/test_agent_sigterm_and_failed_logging.py
+++ b/tests/cli/test_agent_sigterm_and_failed_logging.py
@@ -32,7 +32,9 @@ def _wire_agent_stubs(monkeypatch, tmp_path: Path):
     async def fake_setup(*a, **kw):
         return None
 
-    async def fake_teardown(ctx, *, status="completed", exception=None, cwd=None):
+    async def fake_teardown(
+        ctx, *, status="completed", exception=None, cwd=None, engine_session_uid=None
+    ):
         return status
 
     monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)

--- a/tests/cli/test_agent_status_hint.py
+++ b/tests/cli/test_agent_status_hint.py
@@ -53,7 +53,9 @@ def _wire_agent_stubs(monkeypatch, tmp_path, *, session_id: str | None):
     async def fake_setup(*a, **kw):
         return {"session_id": session_id} if session_id else None
 
-    async def fake_teardown(ctx, *, status="completed", exception=None, cwd=None):
+    async def fake_teardown(
+        ctx, *, status="completed", exception=None, cwd=None, engine_session_uid=None
+    ):
         return status
 
     monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)

--- a/tests/cli/test_agent_timeout_deadline.py
+++ b/tests/cli/test_agent_timeout_deadline.py
@@ -128,7 +128,9 @@ def _make_agent_mocks(monkeypatch, tmp_path, captured_instruction):
     async def fake_setup(*a, **kw):
         return None
 
-    async def fake_teardown(ctx, *, status="completed", exception=None, cwd=None):
+    async def fake_teardown(
+        ctx, *, status="completed", exception=None, cwd=None, engine_session_uid=None
+    ):
         return status
 
     monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)

--- a/tests/cli/test_monitor_run.py
+++ b/tests/cli/test_monitor_run.py
@@ -1603,6 +1603,70 @@ async def test_dispatch_wait_persists_reconciled_status_to_profile_row(
 
 
 @pytest.mark.asyncio
+async def test_dispatch_wait_reconciliation_never_flips_an_already_terminal_row(
+    temp_db_path: Path,
+) -> None:
+    """A profile row that is ALREADY terminal ('failed') must never be
+    force-reconciled to a *different* terminal status the linked engine
+    later reports ('completed') -- ADR-0094's terminal guard rejects that
+    write, and `li monitor run` must report the persisted 'failed' status
+    (the terminal row is authoritative) instead of crashing on the
+    rejected transition."""
+    from lionagi import Branch
+    from lionagi.cli._runs import setup_agent_persist, teardown_agent_persist
+    from lionagi.providers._provider_errors import ProviderError
+    from lionagi.state.claude_mirror import mirror_session, session_db_id
+
+    engine_uid = "aaaaaaaa-bbbb-cccc-dddd-333333333335"
+    async with StateDB() as db:
+        await mirror_session(
+            db,
+            session_uid=engine_uid,
+            events=[
+                {
+                    "type": "assistant",
+                    "uuid": "e1",
+                    "timestamp": "2026-07-05T00:00:00.000Z",
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "working"}],
+                    },
+                }
+            ],
+            tool_names={},
+            status="running",
+        )
+
+        branch = Branch(name="b1")
+        ctx = await setup_agent_persist(branch, agent_name="implementer")
+        assert ctx is not None
+        session_id = ctx["session_id"]
+        final = await teardown_agent_persist(
+            ctx,
+            status="failed",
+            exception=ProviderError("abandoned stream reader"),
+            engine_session_uid=engine_uid,
+        )
+    assert final == "running"
+
+    async with StateDB() as db:
+        # The profile row resolved to failure on its own (independent of the
+        # linked engine mirror) and is now terminal -- while the linked engine
+        # later reports a *different* terminal status.
+        await _set_fields(db, "sessions", session_id, status="failed")
+        await _set_fields(db, "sessions", session_db_id(engine_uid), status="completed")
+
+    exit_code = _dispatch_wait([session_id], interval=0.05, follow=False, max_wait=1.0)
+
+    assert exit_code == 1
+
+    async with StateDB() as db:
+        persisted = await db.get_session(session_id)
+    assert persisted is not None
+    assert persisted["status"] == "failed"
+
+
+@pytest.mark.asyncio
 async def test_dispatch_wait_max_wait_bounds_a_stuck_session(temp_db_path: Path) -> None:
     """A session that never reconciles (no --max-wait would hang this forever)
     must give up after max_wait seconds and report EXIT_RUNNING."""

--- a/tests/cli/test_monitor_run.py
+++ b/tests/cli/test_monitor_run.py
@@ -1472,3 +1472,95 @@ async def test_dispatch_wait_agent_session_still_running_returns_exit_running(
     t.join(timeout=2)
 
     assert exit_code == EXIT_RUNNING
+
+
+# ── li monitor run: linked_engine_session_id drill-in + bounded --max-wait ──
+
+
+@pytest.mark.asyncio
+async def test_dispatch_wait_follows_linked_engine_session_to_completion(
+    temp_db_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """A profile-typed session teardown pinned at 'running' (linked engine
+    session was alive but not yet terminal) must resolve via the linked
+    engine row's status, not hang on its own frozen 'running' column."""
+    from lionagi import Branch
+    from lionagi.cli._runs import setup_agent_persist, teardown_agent_persist
+    from lionagi.providers._provider_errors import ProviderError
+    from lionagi.state.claude_mirror import mirror_session
+
+    engine_uid = "aaaaaaaa-bbbb-cccc-dddd-333333333333"
+    async with StateDB() as db:
+        await mirror_session(
+            db,
+            session_uid=engine_uid,
+            events=[
+                {
+                    "type": "assistant",
+                    "uuid": "e1",
+                    "timestamp": "2026-07-05T00:00:00.000Z",
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "working"}],
+                    },
+                }
+            ],
+            tool_names={},
+            status="running",
+        )
+
+        branch = Branch(name="b1")
+        ctx = await setup_agent_persist(branch, agent_name="implementer")
+        assert ctx is not None
+        session_id = ctx["session_id"]
+        final = await teardown_agent_persist(
+            ctx,
+            status="failed",
+            exception=ProviderError("abandoned stream reader"),
+            engine_session_uid=engine_uid,
+        )
+    assert final == "running"
+
+    def _flip_engine_to_completed() -> None:
+        import asyncio
+
+        from lionagi.state.claude_mirror import session_db_id
+
+        async def _go() -> None:
+            async with StateDB() as db2:
+                await _set_fields(db2, "sessions", session_db_id(engine_uid), status="completed")
+
+        time.sleep(0.25)
+        asyncio.run(_go())
+
+    t = threading.Thread(target=_flip_engine_to_completed, daemon=True)
+    t.start()
+
+    exit_code = _dispatch_wait([session_id], interval=0.05, follow=False)
+    t.join(timeout=5)
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert session_id in out
+    assert "status=completed" in out
+
+
+@pytest.mark.asyncio
+async def test_dispatch_wait_max_wait_bounds_a_stuck_session(temp_db_path: Path) -> None:
+    """A session that never reconciles (no --max-wait would hang this forever)
+    must give up after max_wait seconds and report EXIT_RUNNING."""
+    async with StateDB() as db:
+        from lionagi import Branch
+        from lionagi.cli._runs import setup_agent_persist
+
+        branch = Branch(name="b1")
+        ctx = await setup_agent_persist(branch, agent_name="implementer")
+        assert ctx is not None
+        session_id = ctx["session_id"]
+
+    started = time.monotonic()
+    exit_code = _dispatch_wait([session_id], interval=0.05, follow=False, max_wait=0.3)
+    elapsed = time.monotonic() - started
+
+    assert exit_code == EXIT_RUNNING
+    assert elapsed < 3.0, "max_wait must bound the loop instead of hanging"

--- a/tests/cli/test_monitor_run.py
+++ b/tests/cli/test_monitor_run.py
@@ -1546,6 +1546,63 @@ async def test_dispatch_wait_follows_linked_engine_session_to_completion(
 
 
 @pytest.mark.asyncio
+async def test_dispatch_wait_persists_reconciled_status_to_profile_row(
+    temp_db_path: Path,
+) -> None:
+    """`li monitor run` resolving a profile session via its linked engine row must
+    not just SYNTHESIZE the terminal status in memory for this one call -- it must
+    PERSIST it through StateDB.update_status() so the profile session's own DB row
+    reads the reconciled terminal status too, not stuck at 'running' forever."""
+    from lionagi import Branch
+    from lionagi.cli._runs import setup_agent_persist, teardown_agent_persist
+    from lionagi.providers._provider_errors import ProviderError
+    from lionagi.state.claude_mirror import mirror_session, session_db_id
+
+    engine_uid = "aaaaaaaa-bbbb-cccc-dddd-333333333334"
+    async with StateDB() as db:
+        await mirror_session(
+            db,
+            session_uid=engine_uid,
+            events=[
+                {
+                    "type": "assistant",
+                    "uuid": "e1",
+                    "timestamp": "2026-07-05T00:00:00.000Z",
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "working"}],
+                    },
+                }
+            ],
+            tool_names={},
+            status="running",
+        )
+
+        branch = Branch(name="b1")
+        ctx = await setup_agent_persist(branch, agent_name="implementer")
+        assert ctx is not None
+        session_id = ctx["session_id"]
+        final = await teardown_agent_persist(
+            ctx,
+            status="failed",
+            exception=ProviderError("abandoned stream reader"),
+            engine_session_uid=engine_uid,
+        )
+    assert final == "running"
+
+    async with StateDB() as db:
+        await _set_fields(db, "sessions", session_db_id(engine_uid), status="completed")
+
+    exit_code = _dispatch_wait([session_id], interval=0.05, follow=False, max_wait=1.0)
+    assert exit_code == 0
+
+    async with StateDB() as db:
+        persisted = await db.get_session(session_id)
+    assert persisted is not None
+    assert persisted["status"] == "completed"
+
+
+@pytest.mark.asyncio
 async def test_dispatch_wait_max_wait_bounds_a_stuck_session(temp_db_path: Path) -> None:
     """A session that never reconciles (no --max-wait would hang this forever)
     must give up after max_wait seconds and report EXIT_RUNNING."""
@@ -1564,3 +1621,34 @@ async def test_dispatch_wait_max_wait_bounds_a_stuck_session(temp_db_path: Path)
 
     assert exit_code == EXIT_RUNNING
     assert elapsed < 3.0, "max_wait must bound the loop instead of hanging"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_wait_default_max_wait_bounds_a_stuck_session_without_caller_bound(
+    temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The caller supplies no max_wait at all (the real production default path for
+    `li monitor run` / `li monitor --run` when --max-wait is omitted) and there is no
+    external interrupt -- the built-in bounded default must still stop the wait and
+    report EXIT_RUNNING instead of hanging forever. The module-level default is
+    monkeypatched down to keep this test fast; the caller-facing contract under test
+    is that omitting max_wait entirely still bounds the wait."""
+    import lionagi.cli.monitor as monitor_mod
+
+    monkeypatch.setattr(monitor_mod, "_DEFAULT_MAX_WAIT_SECONDS", 0.3)
+
+    async with StateDB() as db:
+        from lionagi import Branch
+        from lionagi.cli._runs import setup_agent_persist
+
+        branch = Branch(name="b1")
+        ctx = await setup_agent_persist(branch, agent_name="implementer")
+        assert ctx is not None
+        session_id = ctx["session_id"]
+
+    started = time.monotonic()
+    exit_code = _dispatch_wait([session_id], interval=0.05, follow=False)
+    elapsed = time.monotonic() - started
+
+    assert exit_code == EXIT_RUNNING
+    assert elapsed < 3.0, "the default bound must stop the loop instead of hanging"

--- a/tests/cli/test_monitor_run.py
+++ b/tests/cli/test_monitor_run.py
@@ -25,6 +25,7 @@ from lionagi.cli.monitor import (
     _poll_pending_once,
     _query_schedule_runs_since,
     _resolve_schedule_run,
+    _resolve_session_run,
     _split_watched_ids,
     add_monitor_subparser,
     run_monitor_wait,
@@ -1374,3 +1375,100 @@ def test_cli_monitor_help_still_shows_dashboard_usage():
     )
     assert result.returncode == 0
     assert "--watch" in result.stdout
+
+
+# ── li monitor run: resolving agent session ids (issue: profile-typed agent
+# sessions previously errored with "schedule_run not found") ────────────────
+
+
+async def _make_agent_session(db: StateDB, *, status: str = "completed") -> str:
+    """A minimal 'sessions' row shaped like a li agent run, bypassing schedule_runs."""
+    from lionagi import Branch
+    from lionagi.cli._runs import setup_agent_persist, teardown_agent_persist
+
+    branch = Branch(name="b1")
+    ctx = await setup_agent_persist(branch, agent_name="implementer")
+    assert ctx is not None
+    await teardown_agent_persist(ctx, status=status)
+    return ctx["session_id"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_session_run_exact_match(temp_db_path: Path) -> None:
+    async with StateDB() as db:
+        session_id = await _make_agent_session(db, status="completed")
+        row = await _resolve_session_run(db, session_id)
+    assert row is not None
+    assert row["id"] == session_id
+
+
+@pytest.mark.asyncio
+async def test_resolve_session_run_prefix_match(temp_db_path: Path) -> None:
+    async with StateDB() as db:
+        session_id = await _make_agent_session(db, status="completed")
+        row = await _resolve_session_run(db, session_id[:12])
+    assert row is not None
+    assert row["id"] == session_id
+
+
+@pytest.mark.asyncio
+async def test_resolve_session_run_not_found_returns_none(temp_db_path: Path) -> None:
+    async with StateDB() as db:
+        row = await _resolve_session_run(db, "no-such-session")
+    assert row is None
+
+
+@pytest.mark.asyncio
+async def test_dispatch_wait_resolves_completed_agent_session(
+    temp_db_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """`li monitor run <session_id>` must resolve an agent session id — not
+    error 'schedule_run not found' — and report its terminal status."""
+    async with StateDB() as db:
+        session_id = await _make_agent_session(db, status="completed")
+
+    exit_code = _dispatch_wait([session_id], interval=5.0, follow=False)
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert session_id in out
+    assert "status=completed" in out
+
+
+@pytest.mark.asyncio
+async def test_dispatch_wait_resolves_failed_agent_session_nonzero_exit(
+    temp_db_path: Path,
+) -> None:
+    async with StateDB() as db:
+        session_id = await _make_agent_session(db, status="failed")
+
+    exit_code = _dispatch_wait([session_id], interval=5.0, follow=False)
+    assert exit_code == 1
+
+
+@pytest.mark.asyncio
+async def test_dispatch_wait_agent_session_still_running_returns_exit_running(
+    temp_db_path: Path,
+) -> None:
+    """A session that never goes terminal + a real SIGINT mid-wait must
+    report EXIT_RUNNING, not hang forever or silently succeed."""
+    async with StateDB() as db:
+        from lionagi import Branch
+        from lionagi.cli._runs import setup_agent_persist
+
+        branch = Branch(name="b1")
+        ctx = await setup_agent_persist(branch, agent_name="implementer")
+        assert ctx is not None
+        session_id = ctx["session_id"]
+
+    def _send_interrupt() -> None:
+        time.sleep(0.3)
+        os.kill(os.getpid(), signal.SIGINT)
+
+    t = threading.Thread(target=_send_interrupt, daemon=True)
+    t.start()
+
+    exit_code = _dispatch_wait([session_id], interval=0.05, follow=False)
+    t.join(timeout=2)
+
+    assert exit_code == EXIT_RUNNING

--- a/tests/cli/test_monitor_run.py
+++ b/tests/cli/test_monitor_run.py
@@ -20,6 +20,7 @@ import pytest
 from lionagi.cli.monitor import (
     _advance_chains,
     _dispatch_wait,
+    _effective_session_status,
     _format_wait_line,
     _new_chain_state,
     _poll_pending_once,
@@ -1664,6 +1665,76 @@ async def test_dispatch_wait_reconciliation_never_flips_an_already_terminal_row(
         persisted = await db.get_session(session_id)
     assert persisted is not None
     assert persisted["status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_effective_session_status_cas_mismatch_reports_persisted_status(
+    temp_db_path: Path,
+) -> None:
+    """`db.update_status()` returns `False` (rather than raising
+    `TransitionRejectedError`) when the persisted row simply no longer matches
+    `expected_statuses` at write time -- e.g. it moved between our stale read
+    and this write, but the guard rejects on the CAS mismatch before it ever
+    reaches ADR-0094's terminal check. `_effective_session_status()` must not
+    ignore that `False` and fall through to the synthesized linked-engine
+    status; it must re-read and report the persisted row instead."""
+    from lionagi import Branch
+    from lionagi.cli._runs import setup_agent_persist, teardown_agent_persist
+    from lionagi.providers._provider_errors import ProviderError
+    from lionagi.state.claude_mirror import mirror_session, session_db_id
+
+    engine_uid = "aaaaaaaa-bbbb-cccc-dddd-333333333336"
+    async with StateDB() as db:
+        await mirror_session(
+            db,
+            session_uid=engine_uid,
+            events=[
+                {
+                    "type": "assistant",
+                    "uuid": "e1",
+                    "timestamp": "2026-07-05T00:00:00.000Z",
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "working"}],
+                    },
+                }
+            ],
+            tool_names={},
+            status="running",
+        )
+
+        branch = Branch(name="b1")
+        ctx = await setup_agent_persist(branch, agent_name="implementer")
+        assert ctx is not None
+        session_id = ctx["session_id"]
+        final = await teardown_agent_persist(
+            ctx,
+            status="failed",
+            exception=ProviderError("abandoned stream reader"),
+            engine_session_uid=engine_uid,
+        )
+        assert final == "running"
+
+        # This is the stale read `_effective_session_status()` would act on --
+        # status="running", still linked to the engine session.
+        stale_row = await db.get_session(session_id)
+        assert stale_row is not None
+        assert stale_row["status"] == "running"
+
+        # Simulate the race: between that read and the reconciliation write,
+        # something else (e.g. the profile session's own executor) persisted
+        # this row to "failed", while the linked engine session went
+        # "completed" independently.
+        await _set_fields(db, "sessions", session_id, status="failed")
+        await _set_fields(db, "sessions", session_db_id(engine_uid), status="completed")
+
+        result = await _effective_session_status(db, stale_row)
+
+        assert result["status"] == "failed"
+
+        persisted = await db.get_session(session_id)
+        assert persisted is not None
+        assert persisted["status"] == "failed"
 
 
 @pytest.mark.asyncio

--- a/tests/operations/run/test_run.py
+++ b/tests/operations/run/test_run.py
@@ -224,6 +224,63 @@ async def test_run_error_chunk_raises_and_restores_streaming_processor():
     assert model.streaming_process_func is sentinel
 
 
+async def test_run_preserves_primary_exception_when_aclose_raises_cancelled_error():
+    """The CLI close chain (ndjson_from_cli -> aterminate_process_group ->
+    asyncio.wait_for) can raise asyncio.CancelledError, a BaseException a
+    plain `except Exception` does not catch. Left unguarded, that would
+    escape run()'s cleanup finally and REPLACE the real "error" chunk
+    RuntimeError that was already propagating -- the caller would see a
+    misleading CancelledError instead of the actual provider failure."""
+    import asyncio
+
+    async def stream(api_call=None):
+        try:
+            yield StreamChunk(type="error", content="boom")
+        except GeneratorExit:
+            raise asyncio.CancelledError("cleanup cancelled mid-close")
+
+    model, _ = _make_fake_cli_model([])
+    model.stream = stream
+
+    branch = Branch()
+    branch.chat_model = model
+
+    with pytest.raises(RuntimeError, match="boom"):
+        async for _ in run(branch, "go", RunParam()):
+            pass
+
+
+async def test_run_caller_abandonment_closes_stream_without_raising():
+    """A consumer that stops iterating early (explicit aclose() after
+    consuming into the middle of the stream) triggers GeneratorExit through
+    run()'s own async generator; the finally block's stream_gen.aclose() must
+    complete cleanly (no leaked exception, no traceback) and the underlying
+    CLI stream must be closed."""
+    closed = False
+
+    async def stream(api_call=None):
+        nonlocal closed
+        try:
+            yield StreamChunk(type="tool_use", tool_name="do_thing", tool_input={}, tool_id="t1")
+            yield StreamChunk(type="text", content="never reached")
+        finally:
+            closed = True
+
+    model, _ = _make_fake_cli_model([])
+    model.stream = stream
+
+    branch = Branch()
+    branch.chat_model = model
+
+    agen = run(branch, "go", RunParam())
+    async for msg in agen:
+        if isinstance(msg, ActionRequest):
+            break  # abandon mid-stream, after the wrapper actually started streaming
+    await agen.aclose()
+
+    assert closed, "abandoning the consumer must still close the underlying CLI stream"
+
+
 async def test_run_stream_persist_writes_final_state_and_removes_buffer(tmp_path):
     """stream_persist=True writes branch JSON and removes buffer JSONL."""
     model, _ = _make_fake_cli_model([StreamChunk(type="text", content="done")])

--- a/tests/providers/openai/codex/test_session_id_metadata.py
+++ b/tests/providers/openai/codex/test_session_id_metadata.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression: Codex's thread.started event carries "thread_id", not
+"session_id" — run.py's engine-session-id capture (used to link a
+profile-typed agent session to its claude/codex-mirror engine session at
+teardown, see lionagi/cli/_runs.py) only reads chunk.metadata["session_id"].
+Without normalizing the system chunk's metadata, teardown always sees
+engine_session_uid=None for Codex and the linked-engine reconciliation path
+never runs."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from lionagi.providers.openai.codex import CodexCodeRequest, stream_codex_cli
+from lionagi.service.types.stream_chunk import StreamChunk
+
+
+def _make_request() -> CodexCodeRequest:
+    return CodexCodeRequest(prompt="test", verbose_output=False)
+
+
+async def _chunks_from_events(events: list[dict]) -> list[StreamChunk]:
+    async def fake_events(request):
+        for ev in events:
+            yield ev
+
+    collected = []
+    with patch(
+        "lionagi.providers.openai.codex.stream_codex_cli_events",
+        side_effect=fake_events,
+    ):
+        async for item in stream_codex_cli(_make_request()):
+            if isinstance(item, StreamChunk):
+                collected.append(item)
+    return collected
+
+
+@pytest.mark.asyncio
+async def test_thread_started_system_chunk_metadata_carries_session_id():
+    """A real Codex thread.started event ({"thread_id": ...}, no "session_id")
+    must still yield a system StreamChunk whose metadata has a non-None
+    "session_id" — the key run.py reads to populate endpoint.session_id."""
+    events = [{"type": "thread.started", "thread_id": "codex-thread-abc123"}]
+    chunks = await _chunks_from_events(events)
+
+    system_chunks = [c for c in chunks if c.type == "system"]
+    assert len(system_chunks) == 1
+    assert system_chunks[0].metadata.get("session_id") == "codex-thread-abc123"
+
+
+@pytest.mark.asyncio
+async def test_thread_started_preserves_other_metadata_fields():
+    """Normalizing session_id must not drop the rest of the raw event."""
+    events = [
+        {
+            "type": "thread.started",
+            "thread_id": "codex-thread-xyz",
+            "model": "gpt-5.5-codex",
+        }
+    ]
+    chunks = await _chunks_from_events(events)
+
+    system_chunks = [c for c in chunks if c.type == "system"]
+    assert system_chunks[0].metadata.get("thread_id") == "codex-thread-xyz"
+    assert system_chunks[0].metadata.get("model") == "gpt-5.5-codex"
+
+
+@pytest.mark.asyncio
+async def test_end_to_end_run_captures_codex_engine_session_id():
+    """The full path a real `li agent -a <profile> codex ...` teardown relies
+    on: run()'s streaming loop reads chunk.metadata["session_id"] off the
+    system chunk and stamps it onto endpoint.session_id — proving Codex's
+    thread.started event now reaches that path with a non-None id."""
+    import types
+
+    from lionagi.operations.run.run import RunParam, run
+    from lionagi.service.imodel import iModel
+    from lionagi.session.branch import Branch
+
+    events = [{"type": "thread.started", "thread_id": "codex-thread-e2e"}]
+    chunks = await _chunks_from_events(events)
+
+    m = iModel(provider="openai", model="gpt-4.1-mini", api_key="test_key")
+    endpoint_ns = types.SimpleNamespace(
+        is_cli=True,
+        session_id=None,
+        to_dict=lambda: {"type": "fake_cli"},
+    )
+    m.endpoint = endpoint_ns
+    m.streaming_process_func = None
+
+    from unittest.mock import AsyncMock
+
+    async def create_event(**kw):
+        return object()
+
+    m.create_event = create_event
+    m.executor = types.SimpleNamespace(append=AsyncMock(), config={})
+
+    async def stream(api_call=None):
+        for chunk in chunks:
+            yield chunk
+
+    m.stream = stream
+
+    branch = Branch()
+    branch.chat_model = m
+
+    async for _ in run(branch, "hi", RunParam()):
+        pass
+
+    assert m.endpoint.session_id == "codex-thread-e2e"


### PR DESCRIPTION
Closes #1793.

Root cause: the CLI-provider streaming loop abandoned the stream generator chain on abnormal exit instead of closing it, leaving the real claude/codex subprocess orphaned-but-running while `li agent` teardown unconditionally wrote `failed` onto the profile-typed session. Result: a phantom `failed` profile row at short elapsed with a live companion engine row (fleet-wide day-1 pilot report).

- `operations/run/run.py`: deterministically close the stream chain on every exit path (`aclosing` + explicit `aclose()`), so the subprocess is terminated, not orphaned.
- `cli/_runs.py`: before demoting an exception-classified session to `failed`, check the linked claude-mirror engine session; if alive/completed, link it (`node_metadata.linked_engine_session_id`) and propagate its status instead. ADR-0025 vocabulary unchanged.
- `cli/agent.py`: capture the CLI provider's real session id and pass it through teardown.
- `cli/monitor.py`: `li monitor run <id>` now resolves agent session ids too (polls to terminal, reports artifacts_path) instead of erroring `schedule_run not found`.

Tests: new `test_agent_live_persist.py` (phantom-suppression scenarios) + `test_monitor_run.py` (agent-id resolution); full `tests/cli` green with the studio extra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)