### PR TITLE
fix(studio): stop update flash and window long message lists in run detail

### DIFF
--- a/apps/studio/frontend/src/components/RunStepCard.tsx
+++ b/apps/studio/frontend/src/components/RunStepCard.tsx
@@ -176,7 +176,7 @@ function pathFromArgs(args: Record<string, unknown>, summary: string): string[] 
   return out;
 }
 
-export default function RunStepCard({
+function RunStepCard({
   step,
   defaultExpanded = false,
   expanded: expandedProp,
@@ -594,6 +594,23 @@ export default function RunStepCard({
   );
 }
 
+// Memoized so a live session that appends to one branch only re-renders that
+// branch's card. The parent rebuilds every step object each tick, so we compare
+// by content: messages are append-only, so branch name + status + message count
+// captures whether this card actually changed.
+function stepPropsEqual(prev: RunStepCardProps, next: RunStepCardProps): boolean {
+  return (
+    prev.expanded === next.expanded &&
+    prev.defaultExpanded === next.defaultExpanded &&
+    prev.onToggleExpand === next.onToggleExpand &&
+    prev.step.step === next.step.step &&
+    prev.step.status === next.step.status &&
+    (prev.step.messages?.length ?? 0) === (next.step.messages?.length ?? 0)
+  );
+}
+
+export default React.memo(RunStepCard, stepPropsEqual);
+
 const TabButton = React.forwardRef<
   HTMLButtonElement,
   {
@@ -891,6 +908,8 @@ interface MessageFeedProps {
   stepKey?: string;
 }
 
+const MESSAGE_WINDOW = 80;
+
 function MessageFeed({
   messages,
   filters,
@@ -898,6 +917,11 @@ function MessageFeed({
   onToggleTool,
   stepKey = "",
 }: MessageFeedProps) {
+  const t = useTranslations("runCard");
+  // Render only the most recent window; long conversations reveal older turns
+  // on demand instead of mounting the whole history at once.
+  const [visibleCount, setVisibleCount] = useState(MESSAGE_WINDOW);
+
   // Precompute per-message assistant ordinals before JSX to avoid mutation during render
   const assistantOrdinals: number[] = new Array(messages.length);
   let ordinalCount = 0;
@@ -906,9 +930,21 @@ function MessageFeed({
     assistantOrdinals[i] = ordinalCount;
   }
 
+  const startIdx = Math.max(0, messages.length - visibleCount);
+
   return (
     <div className="flex flex-col">
-      {messages.map((m, i) => {
+      {startIdx > 0 && (
+        <button
+          type="button"
+          onClick={() => setVisibleCount((v) => v + MESSAGE_WINDOW * 4)}
+          className="border-b border-edge px-3 py-1.5 text-center font-mono text-[length:var(--t-xs)] text-content-muted hover:bg-surface-overlay hover:text-content-secondary"
+        >
+          {t("showEarlier", { count: startIdx })}
+        </button>
+      )}
+      {messages.slice(startIdx).map((m, offset) => {
+        const i = startIdx + offset;
         if (m.role === "system" && !filters.system) return null;
         if (m.role === "user" && !filters.user) return null;
         if (m.role === "assistant" && !filters.responses) return null;

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -6,7 +6,7 @@
  * /runs/$id full-page route. Caller is responsible for scroll context.
  */
 
-import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslations } from "use-intl";
 import InvocationSection from "@/components/history/InvocationDetail";
 import OperationGraphSection from "@/components/history/OperationGraphSection";
@@ -779,14 +779,14 @@ export default function RunDetail({ id, fullPage = false }: RunDetailProps) {
     }
   }, [session, fullPage]);
 
-  const handleToggleExpand = (stepId: string, next: boolean) => {
+  const handleToggleExpand = useCallback((stepId: string, next: boolean) => {
     setExpandedSteps((prev) => {
       const updated = new Set(prev);
       if (next) updated.add(stepId);
       else updated.delete(stepId);
       return updated;
     });
-  };
+  }, []);
 
   const hiddenOlderCount = useMemo(() => {
     if (!session) return 0;
@@ -916,6 +916,17 @@ export default function RunDetail({ id, fullPage = false }: RunDetailProps) {
     [signalEvents],
   );
 
+  const execSteps = useMemo(
+    () =>
+      steps.map((s) => ({
+        step: s.step,
+        status: s.status,
+        result: s.result,
+        timestamp: s.timestamp ?? undefined,
+      })),
+    [steps],
+  );
+
   if (error) {
     return (
       <div className="flex items-center justify-center py-20">
@@ -1019,16 +1030,7 @@ export default function RunDetail({ id, fullPage = false }: RunDetailProps) {
           <SectionHeader label={t("sectionDag")} count={runGraph.nodes.length} />
           <div className="h-[280px] rounded border border-edge bg-surface-raised shadow-card overflow-hidden">
             <Suspense fallback={null}>
-              <WorkerCanvas
-                graph={runGraph}
-                editable={false}
-                execSteps={steps.map((s) => ({
-                  step: s.step,
-                  status: s.status,
-                  result: s.result,
-                  timestamp: s.timestamp ?? undefined,
-                }))}
-              />
+              <WorkerCanvas graph={runGraph} editable={false} execSteps={execSteps} />
             </Suspense>
           </div>
         </div>

--- a/apps/studio/frontend/src/messages/en.json
+++ b/apps/studio/frontend/src/messages/en.json
@@ -802,6 +802,7 @@
     "colOutput": "Output",
     "charsCount": "{count, number} chars",
     "moreLines": "+{count} more",
+    "showEarlier": "Show {count, number} earlier messages",
     "noArgs": "(no args)",
     "noOutput": "(no output)",
     "roleUser": "user",

--- a/apps/studio/frontend/src/messages/zh.json
+++ b/apps/studio/frontend/src/messages/zh.json
@@ -802,6 +802,7 @@
     "colOutput": "输出",
     "charsCount": "{count, number} 字符",
     "moreLines": "+{count} 行",
+    "showEarlier": "显示更早的 {count, number} 条消息",
     "noArgs": "(无参数)",
     "noOutput": "(无输出)",
     "roleUser": "用户",


### PR DESCRIPTION
## What

In a long, live session the run-detail view flashed on every update, and it mounted the entire message list at once (thousands of DOM nodes). This makes both problems go away.

## Root cause

Session messages arrive as a real SSE stream (`streamSession`). Each streamed message called `setSession(...)`, which:
- re-derived **every** branch's `RunStep` in the parent `steps` memo, and
- re-rendered **every** `RunStepCard` (they were not memoized), each of which re-derives its summary over all of its messages, and
- `MessageFeed` rendered the full message array as DOM.

For a long session that is a whole-tree reconciliation of thousands of nodes on every single message — the visible flash.

## Changes

- **`RunStepCard`** is memoized with a content comparator. Because messages are append-only, `branch name + status + message count` captures whether a card actually changed, so only the branch that received a message re-renders (the parent can keep rebuilding step objects each tick).
- **`MessageFeed`** renders a recent window (80 messages) with a *"show earlier"* affordance instead of mounting the whole history — the standard log/chat pattern. Server-side pagination ("load older", 200/page) is unchanged; this bounds what the client renders within the loaded set.
- **`RunDetail`** memoizes `execSteps` and stabilizes `onToggleExpand` so the memo comparator can do its job.
- Adds `runCard.showEarlier` to `en`/`zh` messages.

## Test plan

- `tsc --noEmit` clean
- `vitest run` — history + RunStepCard suites green (17/17)
- ESLint + prettier clean (pre-commit)

Addresses Ocean's report: long sessions flash on update, and nobody displays ~2k messages on one page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
