### PR TITLE
fix(cli): li agent auto-resume no longer races the ADR-0094 terminal guard

### DIFF
--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -343,12 +343,23 @@ async def _teardown_common(
     escalated_evidence: list[dict] | None = None,
     cwd: str | None = None,
     engine_session_uid: str | None = None,
+    defer_terminal: bool = False,
 ) -> str:
     from lionagi.state.artifact_verifier import (
         missing_artifact_evidence,
         missing_artifact_summary,
         verify_artifact_contract,
     )
+
+    if defer_terminal:
+        # A recursive auto-resume leg is about to run on this same session
+        # (see _run_agent's finally block) and will own the real terminal
+        # write. Stamping ended_at/status here would leave the session
+        # terminal while the resumed leg is still working, so the resumed
+        # leg's own teardown hits the ADR-0094 terminal guard. Skip every
+        # DB mutation and let the caller's non-status bookkeeping (hook
+        # unroute, usage emit, observer detach) run as usual.
+        return status
 
     all_msgs = await db.get_progression(session_prog_id)
     update_kwargs: dict[str, Any] = {"ended_at": time.time()}
@@ -516,17 +527,32 @@ async def _teardown_common(
         )
         final_evidence_refs = escalated_evidence
 
-    await db.update_status(
-        "session",
-        session_id,
-        new_status=final_status,
-        reason_code=final_reason_code,
-        reason_summary=final_reason_summary,
-        evidence_refs=final_evidence_refs,
-        source="executor",
-        actor=session_id,
-        metadata=metadata,
-    )
+    from lionagi.state.db import TransitionRejectedError
+
+    try:
+        await db.update_status(
+            "session",
+            session_id,
+            new_status=final_status,
+            reason_code=final_reason_code,
+            reason_summary=final_reason_summary,
+            evidence_refs=final_evidence_refs,
+            source="executor",
+            actor=session_id,
+            metadata=metadata,
+        )
+    except TransitionRejectedError:
+        # Another writer (a concurrent teardown, or a resumed leg that raced
+        # this one) already moved the session to a terminal status between
+        # our read above and this write. That row is authoritative — read it
+        # back instead of raising past callers as an uncaught traceback.
+        persisted = await db.get_session(session_id) or {}
+        final_status = persisted.get("status", final_status)
+        _log.debug(
+            "session %s already terminal (%s); skipped duplicate status write",
+            session_id,
+            final_status,
+        )
     return final_status
 
 
@@ -573,6 +599,7 @@ async def teardown_persist(
     escalated_evidence: list[dict] | None = None,
     cwd: str | None = None,
     engine_session_uid: str | None = None,
+    defer_terminal: bool = False,
 ) -> str:
     if ctx is None:
         return status
@@ -592,6 +619,7 @@ async def teardown_persist(
             escalated_evidence=escalated_evidence,
             cwd=cwd,
             engine_session_uid=engine_session_uid,
+            defer_terminal=defer_terminal,
         )
 
         from lionagi.hooks import unroute_message_persistence
@@ -604,7 +632,15 @@ async def teardown_persist(
             unroute_message_persistence(branch, h)
 
         session_obj = ctx.get("session")
-        if session_obj is not None:
+        # persist_session_end's own fallback branch (row not yet terminal)
+        # writes status straight through update_session() -- a plain column
+        # SET with no ADR-0094 guard. Emitting SESSION_END here would let that
+        # fallback re-introduce the exact premature terminal stamp
+        # defer_terminal just skipped, through a side door _teardown_common
+        # never touches. The resumed leg's own (non-deferred) teardown emits
+        # SESSION_END once for the whole session, carrying the cumulative
+        # branch usage for both legs, so nothing is lost by skipping it here.
+        if session_obj is not None and not defer_terminal:
             err_str = str(exception) if exception is not None else None
             _usage: dict = {}
             _branch = ctx.get("branch")

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -527,7 +527,12 @@ async def _teardown_common(
         )
         final_evidence_refs = escalated_evidence
 
-    from lionagi.state.db import TransitionRejectedError
+    from lionagi.state.db import SESSION_TERMINAL_STATUSES, TransitionRejectedError
+
+    # Snapshot of the status this teardown itself observed when it started
+    # (session_row was read above, before any status-changing write in this
+    # function) -- the signal that tells apart the two rejection causes below.
+    pre_write_status = session_row.get("status")
 
     try:
         await db.update_status(
@@ -542,17 +547,36 @@ async def _teardown_common(
             metadata=metadata,
         )
     except TransitionRejectedError:
-        # Another writer (a concurrent teardown, or a resumed leg that raced
-        # this one) already moved the session to a terminal status between
-        # our read above and this write. That row is authoritative — read it
-        # back instead of raising past callers as an uncaught traceback.
-        persisted = await db.get_session(session_id) or {}
-        final_status = persisted.get("status", final_status)
-        _log.debug(
-            "session %s already terminal (%s); skipped duplicate status write",
-            session_id,
-            final_status,
-        )
+        if pre_write_status in SESSION_TERMINAL_STATUSES and pre_write_status != final_status:
+            # This teardown's OWN view of the session was already terminal
+            # before it attempted anything (e.g. a later resume/follow-up
+            # reattached to a session an earlier, unrelated run already
+            # finalized). The rejection is correctly protecting that earlier
+            # record -- but the caller must still hear THIS invocation's
+            # honest outcome, not the stale persisted one, or a genuine
+            # failure/timeout would silently read back as success.
+            _log.warning(
+                "session %s already terminal at %r; this invocation's %r "
+                "outcome was not persisted (ADR-0094 protects the earlier "
+                "terminal record)",
+                session_id,
+                pre_write_status,
+                final_status,
+            )
+        else:
+            # Benign race: this teardown observed the row non-terminal at
+            # entry, but another writer (e.g. a concurrent teardown of the
+            # same in-flight session) finalized it first. Read back the
+            # now-persisted status instead of raising past callers -- it
+            # reflects the outcome that actually won the race for this same
+            # live invocation.
+            persisted = await db.get_session(session_id) or {}
+            final_status = persisted.get("status", final_status)
+            _log.debug(
+                "session %s already terminal (%s); skipped duplicate status write",
+                session_id,
+                final_status,
+            )
     return final_status
 
 

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -487,6 +487,13 @@ async def _run_agent(
             log_error(f"{type(exc).__name__}: {exc}")
         raise
     finally:
+        # Known before teardown runs: an auto-resume leg is about to fire on
+        # this same session, so this leg's teardown must not stamp a terminal
+        # status the resumed leg would then be blocked from overwriting by
+        # the ADR-0094 terminal guard.
+        will_auto_resume = (
+            _terminal_status == "timed_out" and resume_on_timeout and not _auto_resumed
+        )
         if _heartbeat_task is not None:
             _heartbeat_task.cancel()
             import asyncio as _asyncio2
@@ -511,6 +518,7 @@ async def _run_agent(
                 exception=_terminal_exc,
                 cwd=cwd,
                 engine_session_uid=_engine_session_uid,
+                defer_terminal=will_auto_resume,
             )
             if effective_status != _terminal_status:
                 _terminal_status = effective_status

--- a/tests/cli/test_agent_codex_robustness.py
+++ b/tests/cli/test_agent_codex_robustness.py
@@ -113,7 +113,13 @@ def _make_agent_mocks_with_bypass(monkeypatch, tmp_path, captured_kwargs: list):
         return None
 
     async def fake_teardown(
-        ctx, *, status="completed", exception=None, cwd=None, engine_session_uid=None
+        ctx,
+        *,
+        status="completed",
+        exception=None,
+        cwd=None,
+        engine_session_uid=None,
+        defer_terminal=False,
     ):
         return status
 
@@ -267,7 +273,13 @@ async def test_run_agent_timeout_preserves_partial_output(monkeypatch, tmp_path)
         return None
 
     async def fake_teardown(
-        ctx, *, status="completed", exception=None, cwd=None, engine_session_uid=None
+        ctx,
+        *,
+        status="completed",
+        exception=None,
+        cwd=None,
+        engine_session_uid=None,
+        defer_terminal=False,
     ):
         return status
 
@@ -340,7 +352,13 @@ async def test_run_agent_timeout_empty_partial_returns_empty_string(monkeypatch,
         return None
 
     async def fake_teardown(
-        ctx, *, status="completed", exception=None, cwd=None, engine_session_uid=None
+        ctx,
+        *,
+        status="completed",
+        exception=None,
+        cwd=None,
+        engine_session_uid=None,
+        defer_terminal=False,
     ):
         return status
 
@@ -419,7 +437,13 @@ async def test_run_agent_heartbeat_started_when_timeout_set(monkeypatch, tmp_pat
         return None
 
     async def fake_teardown(
-        ctx, *, status="completed", exception=None, cwd=None, engine_session_uid=None
+        ctx,
+        *,
+        status="completed",
+        exception=None,
+        cwd=None,
+        engine_session_uid=None,
+        defer_terminal=False,
     ):
         return status
 
@@ -486,7 +510,13 @@ async def test_run_agent_no_heartbeat_when_timeout_none(monkeypatch, tmp_path):
         return None
 
     async def fake_teardown(
-        ctx, *, status="completed", exception=None, cwd=None, engine_session_uid=None
+        ctx,
+        *,
+        status="completed",
+        exception=None,
+        cwd=None,
+        engine_session_uid=None,
+        defer_terminal=False,
     ):
         return status
 

--- a/tests/cli/test_agent_live_persist.py
+++ b/tests/cli/test_agent_live_persist.py
@@ -648,22 +648,25 @@ async def test_teardown_non_resume_timeout_stamps_terminal_unchanged(
 # ── ADR-0094 terminal-race: a second teardown must not crash past callers ─────
 
 
-async def test_teardown_terminal_race_returns_persisted_status_no_warning(
+async def test_teardown_already_terminal_session_reports_attempted_status(
     temp_db_path: Path,
     caplog: pytest.LogCaptureFixture,
 ):
-    """Two independent teardowns racing the same already-terminal session
-    (mirrors an auto-resumed leg's teardown landing after another writer
-    already finalized the row): the second write must not raise past
-    teardown_persist, must not log at warning level, and must return the
-    already-persisted terminal status rather than the one it attempted."""
+    """A teardown that reattaches to a session an EARLIER, unrelated run
+    already finalized (setup_agent_persist reuses an existing branch's
+    session without checking terminality) must not let the stale persisted
+    status masquerade as this invocation's outcome: a later leg's genuine
+    'failed' must not be silently reported back as the old 'completed'. The
+    rejection must still protect the DB row (ADR-0094 unchanged) — only the
+    caller-visible return value differs, and it's logged at warning level."""
     branch = Branch(name="b1")
     ctx1 = await _setup_live_persist(branch)
     first = await _teardown_live_persist(ctx1, status="completed")
     assert first == "completed"
 
-    # A second leg attaches to the SAME session/branch row (mirrors an
-    # auto-resume leg reusing the branch after the first leg's teardown).
+    # A later leg attaches to the SAME session/branch row, which is already
+    # terminal by the time this teardown even starts (mirrors a resume/
+    # follow-up reusing a branch whose session an earlier run finalized).
     ctx2 = await _setup_live_persist(branch)
     assert ctx2 is not None
     assert ctx2["session_id"] == ctx1["session_id"]
@@ -671,11 +674,63 @@ async def test_teardown_terminal_race_returns_persisted_status_no_warning(
     with caplog.at_level(logging.WARNING):
         second = await _teardown_live_persist(ctx2, status="failed", exception=RuntimeError("boom"))
 
-    assert second == "completed"  # the persisted terminal status wins
+    assert second == "failed"  # this invocation's honest outcome, not "completed"
+    assert any(
+        rec.levelno >= logging.WARNING and "completed" in rec.message and "failed" in rec.message
+        for rec in caplog.records
+    )
+
+    # The DB record itself is untouched — ADR-0094 still protects it.
+    async with StateDB() as db:
+        s = await db.get_session(ctx1["session_id"])
+    assert s["status"] == "completed"
+
+
+async def test_teardown_concurrent_race_non_terminal_entry_returns_winner_status(
+    temp_db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    """A true concurrent race: this teardown observes the session non-
+    terminal at entry, but a separate writer finalizes the row between that
+    read and this teardown's own update_status() call. Unlike the already-
+    terminal-on-entry case above, this is the benign race the catch's
+    read-back path exists for: return the winner's persisted status at
+    debug level, not a warning."""
+    from lionagi.state.db import StateDB as _StateDB
+    from lionagi.state.reasons import RunReasons
+
+    branch = Branch(name="b1")
+    ctx = await _setup_live_persist(branch)
+
+    real_update_status = _StateDB.update_status
+    calls = {"n": 0}
+
+    async def racing_update_status(self, *a, **kw):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            # A separate writer finalizes the row first, simulating a
+            # concurrent teardown of this same in-flight session.
+            async with _StateDB() as other:
+                await other.update_status(
+                    "session",
+                    ctx["session_id"],
+                    new_status="completed",
+                    reason_code=RunReasons.COMPLETED_OK,
+                    source="executor",
+                )
+        return await real_update_status(self, *a, **kw)
+
+    monkeypatch.setattr(_StateDB, "update_status", racing_update_status)
+
+    with caplog.at_level(logging.WARNING):
+        result = await _teardown_live_persist(ctx, status="failed", exception=RuntimeError("boom"))
+
+    assert result == "completed"  # the race winner's persisted status
     assert not any(rec.levelno >= logging.WARNING for rec in caplog.records)
 
     async with StateDB() as db:
-        s = await db.get_session(ctx1["session_id"])
+        s = await db.get_session(ctx["session_id"])
     assert s["status"] == "completed"
 
 

--- a/tests/cli/test_agent_live_persist.py
+++ b/tests/cli/test_agent_live_persist.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import threading
 from pathlib import Path
 from unittest import mock
@@ -587,6 +588,95 @@ async def test_failed_setup_releases_branch_claim(
 async def test_teardown_with_none_context_is_noop(temp_db_path: Path):
     """If setup returned None (failed), teardown(None) must be safe."""
     await _teardown_live_persist(None, status="completed")  # MUST NOT raise
+
+
+# ── defer_terminal: auto-resume must not stamp a premature terminal status ────
+
+
+async def test_teardown_defer_terminal_leaves_session_running(
+    temp_db_path: Path,
+):
+    """defer_terminal=True (an auto-resume leg is about to fire on this same
+    session) must skip the status write entirely, leaving the session at
+    'running' for the resumed leg to own the real terminal write."""
+    branch = Branch(name="b1")
+    ctx = await _setup_live_persist(branch)
+
+    result = await _teardown_live_persist(ctx, status="timed_out", defer_terminal=True)
+
+    assert result == "timed_out"
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s["status"] == "running"
+    assert s["ended_at"] is None
+
+
+async def test_teardown_defer_terminal_still_detaches_hooks(
+    temp_db_path: Path,
+):
+    """Even when the status write is deferred, non-status bookkeeping (hook
+    unroute) still runs so a closed-DB handler cannot fire later."""
+    from lionagi.hooks.bus import HookPoint
+
+    branch = Branch(name="b1")
+    ctx = await _setup_live_persist(branch)
+    bus = branch._hooks
+
+    await _teardown_live_persist(ctx, status="timed_out", defer_terminal=True)
+
+    assert ctx["hook"] not in bus.handlers_for(HookPoint.MESSAGE_ADD)
+    assert branch._persist_via_bus not in branch.on_message_added
+
+
+async def test_teardown_non_resume_timeout_stamps_terminal_unchanged(
+    temp_db_path: Path,
+):
+    """defer_terminal defaults to False: a genuine (non-auto-resume) timeout
+    still stamps a terminal 'timed_out' status exactly as before this fix."""
+    branch = Branch(name="b1")
+    ctx = await _setup_live_persist(branch)
+
+    result = await _teardown_live_persist(ctx, status="timed_out")
+
+    assert result == "timed_out"
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s["status"] == "timed_out"
+    assert s["ended_at"] is not None
+
+
+# ── ADR-0094 terminal-race: a second teardown must not crash past callers ─────
+
+
+async def test_teardown_terminal_race_returns_persisted_status_no_warning(
+    temp_db_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Two independent teardowns racing the same already-terminal session
+    (mirrors an auto-resumed leg's teardown landing after another writer
+    already finalized the row): the second write must not raise past
+    teardown_persist, must not log at warning level, and must return the
+    already-persisted terminal status rather than the one it attempted."""
+    branch = Branch(name="b1")
+    ctx1 = await _setup_live_persist(branch)
+    first = await _teardown_live_persist(ctx1, status="completed")
+    assert first == "completed"
+
+    # A second leg attaches to the SAME session/branch row (mirrors an
+    # auto-resume leg reusing the branch after the first leg's teardown).
+    ctx2 = await _setup_live_persist(branch)
+    assert ctx2 is not None
+    assert ctx2["session_id"] == ctx1["session_id"]
+
+    with caplog.at_level(logging.WARNING):
+        second = await _teardown_live_persist(ctx2, status="failed", exception=RuntimeError("boom"))
+
+    assert second == "completed"  # the persisted terminal status wins
+    assert not any(rec.levelno >= logging.WARNING for rec in caplog.records)
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx1["session_id"])
+    assert s["status"] == "completed"
 
 
 # ── End-to-end: no aiosqlite thread leak across setup+teardown ────────────────

--- a/tests/cli/test_agent_preset_form.py
+++ b/tests/cli/test_agent_preset_form.py
@@ -458,7 +458,13 @@ def _wire_run_agent_mocks(monkeypatch, tmp_path):
         return None
 
     async def fake_teardown(
-        ctx, *, status="completed", exception=None, cwd=None, engine_session_uid=None
+        ctx,
+        *,
+        status="completed",
+        exception=None,
+        cwd=None,
+        engine_session_uid=None,
+        defer_terminal=False,
     ):
         return status
 

--- a/tests/cli/test_agent_profile_timeout.py
+++ b/tests/cli/test_agent_profile_timeout.py
@@ -92,7 +92,13 @@ def _wire_agent_stubs(
         return {"session_id": "sess-0"}
 
     async def fake_teardown(
-        ctx, *, status="completed", exception=None, cwd=None, engine_session_uid=None
+        ctx,
+        *,
+        status="completed",
+        exception=None,
+        cwd=None,
+        engine_session_uid=None,
+        defer_terminal=False,
     ):
         return status
 

--- a/tests/cli/test_agent_resume_empty_stream.py
+++ b/tests/cli/test_agent_resume_empty_stream.py
@@ -36,7 +36,13 @@ def _wire_agent_stubs(monkeypatch, tmp_path: Path, operate_return=None):
         return None
 
     async def fake_teardown(
-        ctx, *, status="completed", exception=None, cwd=None, engine_session_uid=None
+        ctx,
+        *,
+        status="completed",
+        exception=None,
+        cwd=None,
+        engine_session_uid=None,
+        defer_terminal=False,
     ):
         return status
 

--- a/tests/cli/test_agent_resume_gemini_effort.py
+++ b/tests/cli/test_agent_resume_gemini_effort.py
@@ -172,7 +172,13 @@ async def test_fresh_run_unaffected_by_reapply_effort(monkeypatch, tmp_path):
         return None
 
     async def fake_teardown(
-        ctx, *, status="completed", exception=None, cwd=None, engine_session_uid=None
+        ctx,
+        *,
+        status="completed",
+        exception=None,
+        cwd=None,
+        engine_session_uid=None,
+        defer_terminal=False,
     ):
         return status
 

--- a/tests/cli/test_agent_resume_model_override.py
+++ b/tests/cli/test_agent_resume_model_override.py
@@ -44,7 +44,13 @@ def _wire_agent_stubs(monkeypatch, tmp_path: Path, operate_return=None):
         return None
 
     async def fake_teardown(
-        ctx, *, status="completed", exception=None, cwd=None, engine_session_uid=None
+        ctx,
+        *,
+        status="completed",
+        exception=None,
+        cwd=None,
+        engine_session_uid=None,
+        defer_terminal=False,
     ):
         return status
 

--- a/tests/cli/test_agent_resume_on_timeout.py
+++ b/tests/cli/test_agent_resume_on_timeout.py
@@ -110,7 +110,13 @@ def _wire_agent_stubs(
         return {"session_id": _sids[n]}
 
     async def fake_teardown(
-        ctx, *, status="completed", exception=None, cwd=None, engine_session_uid=None
+        ctx,
+        *,
+        status="completed",
+        exception=None,
+        cwd=None,
+        engine_session_uid=None,
+        defer_terminal=False,
     ):
         return status
 
@@ -332,7 +338,13 @@ def _wire_agent_stubs_real_chat_model(
         return {"session_id": _sids[n]}
 
     async def fake_teardown(
-        ctx, *, status="completed", exception=None, cwd=None, engine_session_uid=None
+        ctx,
+        *,
+        status="completed",
+        exception=None,
+        cwd=None,
+        engine_session_uid=None,
+        defer_terminal=False,
     ):
         return status
 
@@ -431,3 +443,161 @@ async def test_profile_resume_on_timeout_opts_in(monkeypatch, tmp_path):
 
     assert call_count["n"] == 2
     assert status == "completed"
+
+
+# ---------------------------------------------------------------------------
+# Real-persistence regression: the ADR-0094 terminal-guard race between an
+# auto-resume leg's premature terminal stamp and the resumed leg's own
+# teardown. Unlike _wire_agent_stubs (which stubs teardown_agent_persist
+# entirely), these tests leave setup_agent_persist/teardown_agent_persist
+# wired to the real StateDB-backed implementation, so a wiring regression in
+# the defer_terminal plumbing shows up as a real TransitionRejectedError.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def temp_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", db_path)
+    return db_path
+
+
+def _wire_agent_stubs_real_persist(
+    monkeypatch,
+    tmp_path: Path,
+    *,
+    operate_side_effect,
+):
+    """Like _wire_agent_stubs_real_chat_model, but setup_agent_persist /
+    teardown_agent_persist are left untouched (the real StateDB-backed
+    implementation), so the auto-resume terminal-status race is exercised
+    for real instead of through a stub that echoes status unconditionally."""
+    import lionagi.cli.agent as agent_mod
+    from lionagi import Branch, iModel
+    from lionagi.service.manager import iModelManager
+
+    call_count = {"n": 0}
+
+    async def fake_operate(self, instruction=None, **kw):
+        idx = call_count["n"]
+        call_count["n"] += 1
+        snapshot_dir = kw.get("snapshot_dir")
+        if snapshot_dir is not None:
+            Path(snapshot_dir).mkdir(parents=True, exist_ok=True)
+            (Path(snapshot_dir) / f"{self.id}.json").write_text(json.dumps(self.to_dict()))
+        return operate_side_effect(idx)
+
+    monkeypatch.setattr(Branch, "operate", fake_operate)
+    monkeypatch.setattr(iModelManager, "shutdown", AsyncMock())
+    monkeypatch.setattr(agent_mod, "resolve_persisted_effort", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "build_chat_model",
+        lambda provider, model, *a, **kw: iModel(provider=provider, model=model, api_key="dummy"),
+    )
+    monkeypatch.setattr(agent_mod, "save_last_branch_pointer", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "_provenance",
+        SimpleNamespace(
+            resolve_model_spec=lambda p, m: f"{p}/{m}",
+            agent_definition_hash=lambda n: "abc",
+        ),
+    )
+    monkeypatch.setattr(agent_mod, "resolve_artifact_contract", lambda **_: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "allocate_run",
+        lambda: SimpleNamespace(
+            run_id="r",
+            artifact_root=tmp_path / "artifacts",
+            stream_dir=tmp_path / "stream",
+            branches_dir=tmp_path / "branches",
+        ),
+    )
+
+    def fake_find_branch(bid):
+        snapshot_path = tmp_path / "branches" / f"{bid}.json"
+        return "run-x", snapshot_path
+
+    monkeypatch.setattr(agent_mod, "find_branch", fake_find_branch)
+    return call_count
+
+
+@pytest.mark.asyncio
+async def test_auto_resume_real_teardown_no_terminal_guard_rejection(
+    monkeypatch, tmp_path, temp_db_path, caplog
+):
+    """Regression: leg-1 times out (resume_on_timeout=True), leg-2 concludes
+    with a durable response. Exercises the REAL teardown/StateDB path
+    end-to-end: without the defer_terminal fix, leg-1's teardown stamps the
+    session terminal ('timed_out') before the auto-resume decision, and
+    leg-2's own teardown then hits the ADR-0094 guard, losing the durable
+    'concluded' response behind a TransitionRejectedError logged at warning
+    level."""
+
+    def side_effect(i):
+        if i == 0:
+            raise TimeoutError("first leg timed out")
+        return "concluded"
+
+    call_count = _wire_agent_stubs_real_persist(
+        monkeypatch, tmp_path, operate_side_effect=side_effect
+    )
+
+    from lionagi.cli.agent import _run_agent
+    from lionagi.state.db import StateDB
+
+    with caplog.at_level(logging.WARNING):
+        result, _provider, _bid, status, session_id = await _run_agent(
+            "claude_code/sonnet",
+            "hello",
+            timeout=30,
+            resume_on_timeout=True,
+        )
+
+    assert call_count["n"] == 2
+    assert status == "completed"
+    assert result == "concluded"
+    assert not any(
+        "TransitionRejectedError" in rec.message or "teardown failed" in rec.message
+        for rec in caplog.records
+    )
+
+    async with StateDB() as db:
+        s = await db.get_session(session_id)
+    assert s is not None
+    assert s["status"] == "completed"
+    assert s["ended_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_no_auto_resume_opt_in_real_teardown_stamps_timed_out(
+    monkeypatch, tmp_path, temp_db_path
+):
+    """resume_on_timeout=False (default): defer_terminal must NOT fire, and
+    the real teardown stamps a genuine 'timed_out' terminal status exactly
+    as before this fix."""
+
+    def side_effect(i):
+        raise TimeoutError("boom")
+
+    call_count = _wire_agent_stubs_real_persist(
+        monkeypatch, tmp_path, operate_side_effect=side_effect
+    )
+
+    from lionagi.cli.agent import _run_agent
+    from lionagi.state.db import StateDB
+
+    _result, _provider, _bid, status, session_id = await _run_agent(
+        "claude_code/sonnet", "hello", timeout=30
+    )
+
+    assert call_count["n"] == 1
+    assert status == "timed_out"
+
+    async with StateDB() as db:
+        s = await db.get_session(session_id)
+    assert s is not None
+    assert s["status"] == "timed_out"
+    assert s["ended_at"] is not None

--- a/tests/cli/test_agent_sigterm_and_failed_logging.py
+++ b/tests/cli/test_agent_sigterm_and_failed_logging.py
@@ -33,7 +33,13 @@ def _wire_agent_stubs(monkeypatch, tmp_path: Path):
         return None
 
     async def fake_teardown(
-        ctx, *, status="completed", exception=None, cwd=None, engine_session_uid=None
+        ctx,
+        *,
+        status="completed",
+        exception=None,
+        cwd=None,
+        engine_session_uid=None,
+        defer_terminal=False,
     ):
         return status
 

--- a/tests/cli/test_agent_status_hint.py
+++ b/tests/cli/test_agent_status_hint.py
@@ -54,7 +54,13 @@ def _wire_agent_stubs(monkeypatch, tmp_path, *, session_id: str | None):
         return {"session_id": session_id} if session_id else None
 
     async def fake_teardown(
-        ctx, *, status="completed", exception=None, cwd=None, engine_session_uid=None
+        ctx,
+        *,
+        status="completed",
+        exception=None,
+        cwd=None,
+        engine_session_uid=None,
+        defer_terminal=False,
     ):
         return status
 

--- a/tests/cli/test_agent_timeout_deadline.py
+++ b/tests/cli/test_agent_timeout_deadline.py
@@ -129,7 +129,13 @@ def _make_agent_mocks(monkeypatch, tmp_path, captured_instruction):
         return None
 
     async def fake_teardown(
-        ctx, *, status="completed", exception=None, cwd=None, engine_session_uid=None
+        ctx,
+        *,
+        status="completed",
+        exception=None,
+        cwd=None,
+        engine_session_uid=None,
+        defer_terminal=False,
     ):
         return status
 


### PR DESCRIPTION
## Problem

`li agent` runs (notably `-a reviewer` codex lanes) phantom-fail on timeout: the underlying model call **completes**, but the run reads as failed/empty and dumps a `TransitionRejectedError` traceback to stderr, forcing re-fires + manual verdict recovery. Fixes the khive#1793 shape; live-repro'd 3× on 2026-07-05 (including — with perfect irony — the codex review of *this very PR*, whose verdict survived only because it was captured from stdout).

## Root cause

An **ordering** conflict between `resume_on_timeout` auto-resume and the ADR-0094 terminal-state guard (the guard itself is correct):

1. Leg-1 `operate()` times out → `_terminal_status="timed_out"`.
2. The `finally` teardown stamps the session **terminal** — *before* the auto-resume decision fires.
3. The recursive auto-resume leg-2 resumes the SAME session, but `persist_session_start` refuses to reopen a terminal session, so the status column is frozen at leg-1's premature terminal.
4. Leg-2 concludes, but its teardown `update_status` is rejected by the guard → logged with a traceback, the SESSION_END/persistence tail is skipped, and the completed verdict is lost.

## Fix (guard contract untouched)

**A. Defer leg-1's terminal stamp when an auto-resume will fire.** `agent.py` computes `will_auto_resume` in the `finally` (same predicate as the auto-resume trigger) and passes `defer_terminal=` through. When deferred, `_teardown_common` skips all DB mutation, leaving the session `running` for leg-2 to own the real terminal write. Resource cleanup (hook unroute, iModel shutdown) still runs. If the process dies between legs the session is left `running`, which Studio's existing lifecycle reaper already sweeps — strictly better than a premature terminal + lost verdict.

**B. SESSION_END gating in the deferred leg.** `persist_session_end`'s not-yet-terminal fallback writes status via a raw `update_session()` that **bypasses** the guard — emitting SESSION_END in the deferred leg would re-introduce the exact premature terminal through a side door. Gated off; leg-2 emits once with cumulative usage.

**C. Idempotent terminal-race handling.** `_teardown_common` catches `TransitionRejectedError` and discriminates on the pre-write status:
- observed **non-terminal** at entry (benign race, another writer won) → read back the persisted winner, debug log;
- observed **already-terminal** at entry with a different attempted status (a later leg reattached to a session an earlier run finalized) → return **this invocation's honest outcome**, warning log. This prevents a genuine timeout/failure being masked as a stale `completed` — the failure-as-success case ADR-0094 exists to prevent. The DB row is never mutated; the guard still protects the earlier record.

## Tests (real StateDB, end-to-end)

- Auto-resume repro (proven to fail pre-fix): leg-1 times out, leg-2 concludes → session `completed`, response persisted, no `TransitionRejectedError` at warning level.
- Load-bearing contract: `resume_on_timeout=False` still stamps `timed_out` terminal exactly as before.
- Already-terminal masking-prevention: a later `failed` leg reports `failed`, not stale `completed`; DB row untouched.
- Benign concurrent race: a mid-call finalize by a separate writer → returns the winner's status at debug, no warning.

`uv run pytest tests/cli -q` → 1341 collected, 1 pre-existing skip, **0 failures**. `-k "agent or run or teardown or resume"` → 1253, **0 failures**. ruff clean.

## Review

Codex reviewer gate: **APPROVE-WITH-FIXES** — Part A + SESSION_END gating approved correct; the one blocking finding (Part C masking) was addressed in commit 2 with dedicated tests on both catch branches.

Resolves khive#1793. Fleet-impacting: every reviewer leg was taxed by this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)