### PR TITLE
fix(studio): gate phantom classification behind liveness+staleness check

### DIFF
--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -213,8 +213,10 @@ def _classify_phantom(
     ps_snapshot: str | None = None,
 ) -> PhantomReason | None:
     ap = _artifacts_path(row)
+    node_metadata = row["node_metadata"] if "node_metadata" in row.keys() else None
+    session = {"id": row["id"], "node_metadata": node_metadata}
     # A running session is never a phantom while its process is observably alive.
-    if _live_process_matches(row["id"], ap, ps_snapshot):
+    if process_liveness(session, ap, ps_snapshot) is True:
         return None
     # Not yet stale: it may simply not have written artifacts yet, so give it
     # the benefit of the doubt rather than reap a fresh/quiet session.
@@ -237,7 +239,8 @@ async def list_phantom_sessions(*, stale_hours: float = 1.0) -> list[dict[str, A
     async with _open_db(_DB) as db:
         cur = await db.execute(
             """
-            SELECT id, name, playbook_name, started_at, updated_at, artifacts_path, status
+            SELECT id, name, playbook_name, started_at, updated_at, artifacts_path,
+                   status, node_metadata
             FROM sessions
             WHERE status = 'running'
             ORDER BY updated_at DESC

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -213,17 +213,19 @@ def _classify_phantom(
     ps_snapshot: str | None = None,
 ) -> PhantomReason | None:
     ap = _artifacts_path(row)
+    # A running session is never a phantom while its process is observably alive.
+    if _live_process_matches(row["id"], ap, ps_snapshot):
+        return None
+    # Not yet stale: it may simply not have written artifacts yet, so give it
+    # the benefit of the doubt rather than reap a fresh/quiet session.
+    updated_at = row["updated_at"] or 0.0
+    if now - updated_at < stale_seconds:
+        return None
     if ap and not ap.exists():
         return "missing_artifacts"
-    if ap and ap.exists():
-        cutoff = now - stale_seconds
-        if _find_stale_lock(ap, cutoff=cutoff) is not None:
-            return "stale_lock"
-    updated_at = row["updated_at"] or 0.0
-    age = now - updated_at
-    if age >= stale_seconds and not _live_process_matches(row["id"], ap, ps_snapshot):
-        return "process_dead"
-    return None
+    if ap and ap.exists() and _find_stale_lock(ap, cutoff=now - stale_seconds) is not None:
+        return "stale_lock"
+    return "process_dead"
 
 
 async def list_phantom_sessions(*, stale_hours: float = 1.0) -> list[dict[str, Any]]:

--- a/tests/apps_studio_server/test_admin.py
+++ b/tests/apps_studio_server/test_admin.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import time
 import uuid
 from pathlib import Path
@@ -24,7 +25,10 @@ def _run(coro):
 
 
 async def _seed_running_session(
-    db_path: Path, session_id: str, artifacts_path: str | None = None
+    db_path: Path,
+    session_id: str,
+    artifacts_path: str | None = None,
+    updated_at: float | None = None,
 ) -> None:
     async with StateDB(db_path) as db:
         pid = str(uuid.uuid4())
@@ -42,6 +46,11 @@ async def _seed_running_session(
             await db.execute(
                 "UPDATE sessions SET artifacts_path = ? WHERE id = ?",
                 (artifacts_path, session_id),
+            )
+        if updated_at is not None:
+            await db.execute(
+                "UPDATE sessions SET updated_at = ? WHERE id = ?",
+                (updated_at, session_id),
             )
 
 
@@ -62,10 +71,12 @@ def _make_client(tmp_path, monkeypatch, db_path: Path) -> TestClient:
 
 
 def test_admin_doctor_reports_missing_artifacts_phantom(tmp_path, monkeypatch):
+    """Missing artifacts only counts once the session has also gone stale."""
     db_path = tmp_path / "state.db"
     sid = str(uuid.uuid4())
     missing_dir = str(tmp_path / "nonexistent_artifacts")
-    _run(_seed_running_session(db_path, sid, artifacts_path=missing_dir))
+    stale_time = time.time() - 7200  # past doctor's default 1h staleness gate
+    _run(_seed_running_session(db_path, sid, artifacts_path=missing_dir, updated_at=stale_time))
     client = _make_client(tmp_path, monkeypatch, db_path)
 
     r = client.get("/api/admin/doctor")
@@ -118,6 +129,79 @@ def test_admin_prune_rejects_empty_body(tmp_path, monkeypatch):
     client = _make_client(tmp_path, monkeypatch, db_path)
     r = client.post("/api/admin/prune", json={})
     assert r.status_code == 422
+
+
+# ─── _classify_phantom liveness/staleness gate (khive#1793) ──────────────────
+
+
+def test_fresh_running_session_missing_artifacts_not_reaped(tmp_path):
+    """A fresh running session whose artifacts dir doesn't exist yet is not a phantom."""
+    import lionagi.studio.services.admin as admin_svc
+
+    now = time.time()
+    missing = str(tmp_path / "not_yet_written")
+    row = {"id": str(uuid.uuid4()), "updated_at": now, "artifacts_path": missing}
+
+    reason = admin_svc._classify_phantom(row, now=now, stale_seconds=3600, ps_snapshot="")
+    assert reason is None
+
+
+def test_stale_dead_session_missing_artifacts_still_reaped(tmp_path):
+    """Cleanup is preserved: a stale, not-live session with missing artifacts still reaps."""
+    import lionagi.studio.services.admin as admin_svc
+
+    now = time.time()
+    missing = str(tmp_path / "ghost")
+    row = {"id": str(uuid.uuid4()), "updated_at": now - 7200, "artifacts_path": missing}
+
+    reason = admin_svc._classify_phantom(row, now=now, stale_seconds=3600, ps_snapshot="")
+    assert reason == "missing_artifacts"
+
+
+def test_alive_session_never_reaped(tmp_path):
+    """Liveness wins over both staleness and missing artifacts."""
+    import lionagi.studio.services.admin as admin_svc
+
+    now = time.time()
+    missing = str(tmp_path / "ghost2")
+    sid = str(uuid.uuid4())
+    row = {"id": sid, "updated_at": now - 7200, "artifacts_path": missing}
+
+    # session_id present in the ps snapshot signals a live process match.
+    reason = admin_svc._classify_phantom(row, now=now, stale_seconds=3600, ps_snapshot=sid)
+    assert reason is None
+
+
+def test_stale_lock_gated_on_staleness(tmp_path):
+    """A stale lock file only counts as zombie evidence once the session itself is stale."""
+    import lionagi.studio.services.admin as admin_svc
+
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+    lock = artifacts_dir / "session.lock"
+    lock.write_text("x")
+    old_mtime = time.time() - 7200
+    os.utime(lock, (old_mtime, old_mtime))
+
+    now = time.time()
+    fresh_row = {
+        "id": str(uuid.uuid4()),
+        "updated_at": now,
+        "artifacts_path": str(artifacts_dir),
+    }
+    assert (
+        admin_svc._classify_phantom(fresh_row, now=now, stale_seconds=3600, ps_snapshot="") is None
+    )
+
+    stale_row = {
+        "id": str(uuid.uuid4()),
+        "updated_at": now - 7200,
+        "artifacts_path": str(artifacts_dir),
+    }
+    assert (
+        admin_svc._classify_phantom(stale_row, now=now, stale_seconds=3600, ps_snapshot="")
+        == "stale_lock"
+    )
 
 
 # ─── /api/admin/health + /api/admin/transition ───────────────────────────────

--- a/tests/apps_studio_server/test_admin.py
+++ b/tests/apps_studio_server/test_admin.py
@@ -172,6 +172,23 @@ def test_alive_session_never_reaped(tmp_path):
     assert reason is None
 
 
+def test_stale_session_live_recorded_pid_not_reaped(tmp_path):
+    """A recorded node_metadata pid that is live wins even with an empty ps snapshot."""
+    import lionagi.studio.services.admin as admin_svc
+
+    now = time.time()
+    missing = str(tmp_path / "ghost3")
+    row = {
+        "id": str(uuid.uuid4()),
+        "updated_at": now - 7200,
+        "artifacts_path": missing,
+        "node_metadata": {"pid": os.getpid()},
+    }
+
+    reason = admin_svc._classify_phantom(row, now=now, stale_seconds=3600, ps_snapshot="")
+    assert reason is None
+
+
 def test_stale_lock_gated_on_staleness(tmp_path):
     """A stale lock file only counts as zombie evidence once the session itself is stale."""
     import lionagi.studio.services.admin as admin_svc


### PR DESCRIPTION
## Summary

khive#1793's true root cause lives in `lionagi/studio/services/admin.py::_classify_phantom`. The `missing_artifacts` and `stale_lock` branches classified a **running** session as a phantom with no staleness gate and no process-liveness check — only `process_dead` gated on `age >= stale_seconds AND not _live_process_matches(...)`. The moment a running session's recorded `artifacts_path` doesn't exist yet on disk (a long-thinking codex/gemini agent that hasn't written its artifacts dir yet), `_classify_phantom` returned `"missing_artifacts"` immediately, however fresh or alive the session was. `lifecycle.py::reap_phantom_sessions` then stamped the legitimately-running session to terminal `failed` (`reason_summary="phantom_reaped"`), and the ADR-0094 terminal guard correctly rejected the session's real completed outcome afterward — the outcome was lost.

This is a **different** terminal-stamp path than PR #1803 fixed. #1803 deferred the auto-resume race in the CLI teardown; this fixes the Studio reaper's detection classifier itself. #1793 stays open until this lands.

**Field evidence (khive):**
- session `9ff8abd6-a603-470a-b511-7b9436704088` (codex/gpt-5.5 reviewer leg, fresh, on the confirmed-#1803-fixed tree): `status=failed, exit_class=failure, reason=session.phantom.missing_artifacts, summary=phantom_reaped`. The review had run to completion and written APPROVE to `pr_review_round2.md`; the outcome was lost to the premature `failed` stamp.
- session `0519cd7f-c187-4013-98b9-1cd7a08c20a5` (earlier, ambiguous timing) — second reproduction.

**#122 relevance:** a reaper that can kill an alive, long-running agent's outcome is a reliability floor for orchestration-grade / ban-subagent use — this closes that gap.

## Fix shape

`_classify_phantom` now checks liveness and staleness FIRST and short-circuits to `None` on either signal, exactly mirroring the gate `process_dead` already used:

```python
def _classify_phantom(row, *, now, stale_seconds, ps_snapshot=None):
    ap = _artifacts_path(row)
    if _live_process_matches(row["id"], ap, ps_snapshot):
        return None
    updated_at = row["updated_at"] or 0.0
    if now - updated_at < stale_seconds:
        return None
    if ap and not ap.exists():
        return "missing_artifacts"
    if ap and ap.exists() and _find_stale_lock(ap, cutoff=now - stale_seconds) is not None:
        return "stale_lock"
    return "process_dead"
```

Only `missing_artifacts`/`stale_lock` behavior changed: both now additionally require (not-live AND stale). Genuinely dead-and-stale rows still reap after `stale_hours` — cleanup purpose intact. `lifecycle.py::reap_phantom_sessions` is unchanged; it was already correctly delegating all detection to `list_phantom_sessions` → `_classify_phantom` as the single chokepoint.

## Tests

Extended the existing `_seed_running_session` helper in `tests/apps_studio_server/test_admin.py` with an optional `updated_at` override (AEP: extended, not duplicated), then:
- Fixed `test_admin_doctor_reports_missing_artifacts_phantom`, which encoded the OLD immediate-reap behavior on an implicitly-fresh session — updated it to seed a stale `updated_at` so it now tests the preserved cleanup behavior under the corrected contract, not the bug.
- Added 4 new tests: `test_fresh_running_session_missing_artifacts_not_reaped` (the khive#1793 repro — fresh + missing artifacts → `None`), `test_stale_dead_session_missing_artifacts_still_reaped` (cleanup preserved), `test_alive_session_never_reaped` (liveness wins over staleness), `test_stale_lock_gated_on_staleness` (fresh+lock → `None`, stale+lock → `"stale_lock"`).

**Deviation note:** the spec's test 3 offered two alternate "alive" signals — a live pid in `node_metadata`, OR `session_id` present in a supplied `ps_snapshot`. Reading `_live_process_matches` shows it constructs `{"id": session_id}` only and never forwards `node_metadata` into the `process_liveness()` call, so the `node_metadata` route isn't actually exercised through this function. Used the `ps_snapshot` route, which is the one that functions.

## Mutation-sensitivity check (required)

Reverted only `_classify_phantom` (kept the new tests) and ran the repro test:
```
AssertionError: assert 'missing_artifacts' is None
```
confirming the test fails without the fix. Re-applied the fix — green again.

## Verification (exact counts)

- `unset CLAUDECODE VIRTUAL_ENV && uv run pytest tests/apps_studio_server/test_admin.py tests/apps_studio_server/test_lifecycle_reapers.py tests/apps_studio_server/test_adversarial_reapers.py -q -n0` → **48 passed, 0 failed**
- `unset CLAUDECODE VIRTUAL_ENV && uv run pytest tests/apps_studio_server/ tests/e2e_studio/ -q -n0` → **664 passed, 0 failed, 0 errors** (junit-verified)

## Test plan
- [x] Full admin + lifecycle-reaper + adversarial-reaper suites green (48/48)
- [x] Full studio suite green (664/664), no regressions from the tightened gate
- [x] Mutation-sensitivity check: repro test fails pre-fix, passes post-fix
- [x] Confirmed `list_phantom_sessions`/`_classify_phantom` is the sole detection chokepoint `reap_phantom_sessions` relies on

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
