### PR TITLE
fix(studio): null-status reaper honors recorded pid + staleness grace (#133)

### DIFF
--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -177,14 +177,6 @@ def process_liveness(
     return None
 
 
-def _live_process_matches(
-    session_id: str,
-    artifacts_path: Path | None,
-    ps_snapshot: str | None = None,
-) -> bool:
-    return process_liveness({"id": session_id}, artifacts_path, ps_snapshot) is True
-
-
 def _artifacts_path(row: Any) -> Path | None:
     ap = row["artifacts_path"] if "artifacts_path" in row.keys() else None
     if ap:

--- a/lionagi/studio/services/lifecycle.py
+++ b/lionagi/studio/services/lifecycle.py
@@ -12,7 +12,7 @@ from lionagi.state.db import DEFAULT_DB_PATH, StateDB
 from lionagi.state.reasons import RunReasons, SessionReasons
 
 from . import admin as admin_svc
-from .admin import _artifacts_path, _live_process_matches
+from .admin import _artifacts_path, _ps_snapshot, process_liveness
 
 _log = logging.getLogger(__name__)
 
@@ -157,13 +157,24 @@ async def reap_stale_invocations(
 # ── null-status session detector ─────────────────────────────────────────────
 
 
-async def reap_null_status_sessions() -> int:
+async def reap_null_status_sessions(*, stale_hours: float | None = None) -> int:
     """Transition null-status sessions whose process is dead to ``failed``.
 
     Sessions get ``status=NULL`` when the process crashes before writing a
     terminal status (crash, OOM, SIGKILL).  Guard is ``status IS NULL`` so
-    already-terminal rows are never touched.
+    already-terminal rows are never touched.  Liveness honors the recorded
+    ``node_metadata.pid`` via ``process_liveness()``; when a row is not
+    observably alive it still gets a staleness grace (mirroring
+    ``_classify_phantom``) before it is reaped, so a fresh/quiet null-status
+    session is not punished for a momentary window before it writes its own
+    status.
     """
+    from lionagi.studio.config import PHANTOM_STALE_HOURS
+
+    if stale_hours is None:
+        stale_hours = PHANTOM_STALE_HOURS
+    stale_seconds = stale_hours * 3600
+
     if not DEFAULT_DB_PATH.exists():
         return 0
 
@@ -173,14 +184,25 @@ async def reap_null_status_sessions() -> int:
     try:
         async with StateDB() as db:
             rows = await db.fetch_all(
-                "SELECT id, artifacts_path, started_at, ended_at FROM sessions WHERE status IS NULL"
+                "SELECT id, artifacts_path, started_at, ended_at, updated_at, node_metadata "
+                "FROM sessions WHERE status IS NULL"
             )
 
+        ps_snapshot: str | None = None
         for row in rows:
             sid = row["id"]
             artifacts = _artifacts_path(row)
-            if _live_process_matches(sid, artifacts):
+            session = {"id": sid, "node_metadata": row.get("node_metadata")}
+            if ps_snapshot is None:
+                ps_snapshot = _ps_snapshot()
+            if process_liveness(session, artifacts, ps_snapshot) is True:
                 # Process still alive — skip, it may write its own status.
+                continue
+
+            updated_at = row.get("updated_at") or row.get("started_at") or 0.0
+            if now - updated_at < stale_seconds:
+                # Not confirmed alive, but too fresh to reap — give it the
+                # benefit of the doubt, same as _classify_phantom does.
                 continue
 
             _log.info("Reaping null-status session %s: process is dead", sid)

--- a/tests/apps_studio_server/test_adversarial_reapers.py
+++ b/tests/apps_studio_server/test_adversarial_reapers.py
@@ -199,11 +199,11 @@ def test_1171_terminal_session_never_overwritten(tmp_path, monkeypatch):
 
     import lionagi.studio.services.lifecycle as lc_mod
 
-    monkeypatch.setattr(lc_mod, "_live_process_matches", lambda _s, _a: False)
+    monkeypatch.setattr(lc_mod, "process_liveness", lambda *_a, **_k: False)
 
     from lionagi.studio.services.lifecycle import reap_null_status_sessions
 
-    count = run_async(reap_null_status_sessions())
+    count = run_async(reap_null_status_sessions(stale_hours=1.0))
     assert count == 0
     assert run_async(_get_session_status(db_path, sid)) == "completed"
     assert run_async(_count_transitions(db_path, sid)) == 0
@@ -214,20 +214,23 @@ def test_1171_idempotent_double_call_no_double_write(tmp_path, monkeypatch):
     db_path = tmp_path / "state.db"
     _monkey_db(monkeypatch, db_path)
 
-    sid = run_async(_seed_session(db_path, status=None))
+    stale_time = time.time() - 7200  # past the 1h grace
+    sid = run_async(
+        _seed_session(db_path, status=None, started_at=stale_time, updated_at=stale_time)
+    )
 
     import lionagi.studio.services.lifecycle as lc_mod
 
-    monkeypatch.setattr(lc_mod, "_live_process_matches", lambda _s, _a: False)
+    monkeypatch.setattr(lc_mod, "process_liveness", lambda *_a, **_k: False)
 
     from lionagi.studio.services.lifecycle import reap_null_status_sessions
 
-    count1 = run_async(reap_null_status_sessions())
+    count1 = run_async(reap_null_status_sessions(stale_hours=1.0))
     assert count1 == 1
     assert run_async(_get_session_status(db_path, sid)) == "failed"
 
     # Second call — row is no longer NULL so it should be invisible
-    count2 = run_async(reap_null_status_sessions())
+    count2 = run_async(reap_null_status_sessions(stale_hours=1.0))
     assert count2 == 0
     # Exactly one transition written
     assert run_async(_count_transitions(db_path, sid)) == 1
@@ -246,11 +249,11 @@ def test_1171_neutralize_condition_null_session_stays_null(tmp_path, monkeypatch
     import lionagi.studio.services.lifecycle as lc_mod
 
     # Process appears alive → reaper must not touch it
-    monkeypatch.setattr(lc_mod, "_live_process_matches", lambda _s, _a: True)
+    monkeypatch.setattr(lc_mod, "process_liveness", lambda *_a, **_k: True)
 
     from lionagi.studio.services.lifecycle import reap_null_status_sessions
 
-    count = run_async(reap_null_status_sessions())
+    count = run_async(reap_null_status_sessions(stale_hours=1.0))
     assert count == 0
     assert run_async(_get_session_status(db_path, sid)) is None
 

--- a/tests/apps_studio_server/test_lifecycle_reapers.py
+++ b/tests/apps_studio_server/test_lifecycle_reapers.py
@@ -407,6 +407,38 @@ def test_reap_null_status_sessions_stale_dead_recorded_pid_reaped(tmp_path, monk
     assert run_async(_count_transitions(db_path, sid)) >= 1
 
 
+def test_reap_null_status_sessions_stale_live_recorded_pid_not_reaped(tmp_path, monkeypatch):
+    """A stale null-status session with a LIVE recorded pid is not reaped.
+
+    Isolates the recorded-pid path from the staleness grace: the row is old
+    enough that the grace no longer protects it, so only honoring the live
+    ``node_metadata.pid`` keeps it alive. If liveness ever stops reading
+    ``node_metadata``, this stale row reaps and the test fails.
+    """
+    db_path = tmp_path / "state.db"
+    _monkey_db(monkeypatch, db_path)
+
+    stale_time = time.time() - 7200  # past the 1h grace
+    sid = run_async(
+        _seed_session(
+            db_path,
+            status=None,
+            artifacts_path=None,
+            started_at=stale_time,
+            updated_at=stale_time,
+            node_metadata={"pid": os.getpid()},
+        )
+    )
+
+    from lionagi.studio.services.lifecycle import reap_null_status_sessions
+
+    count = run_async(reap_null_status_sessions(stale_hours=1.0))
+    assert count == 0
+
+    sess = run_async(_get_session(db_path, sid))
+    assert sess["status"] is None
+
+
 def test_reap_null_status_sessions_fresh_unknown_liveness_not_reaped(tmp_path, monkeypatch):
     """A fresh null-status session with unknown liveness is skipped within the grace period.
 

--- a/tests/apps_studio_server/test_lifecycle_reapers.py
+++ b/tests/apps_studio_server/test_lifecycle_reapers.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
 import time
 import uuid
 from pathlib import Path
@@ -38,6 +40,7 @@ async def _seed_session(
     updated_at: float | None = None,
     artifacts_path: str | None = None,
     agent_name: str | None = None,
+    node_metadata: dict | None = None,
 ) -> str:
     sid = session_id or str(uuid.uuid4())
     now = time.time()
@@ -52,6 +55,7 @@ async def _seed_session(
                 "status": status,
                 "started_at": started_at or now,
                 "agent_name": agent_name,
+                "node_metadata": node_metadata,
             }
         )
         updates: dict = {}
@@ -270,20 +274,28 @@ def test_reap_stale_invocations_per_kind_override(tmp_path, monkeypatch):
 
 
 def test_reap_null_status_sessions_dead_process(tmp_path, monkeypatch):
-    """Null-status session with dead process is transitioned to failed."""
+    """Null-status session with dead process, stale past the grace, is reaped."""
     db_path = tmp_path / "state.db"
     _monkey_db(monkeypatch, db_path)
 
-    sid = run_async(_seed_session(db_path, status=None, artifacts_path=None))
+    stale_time = time.time() - 7200  # past default 1h grace
+    sid = run_async(
+        _seed_session(
+            db_path,
+            status=None,
+            artifacts_path=None,
+            started_at=stale_time,
+            updated_at=stale_time,
+        )
+    )
 
-    # Patch _live_process_matches to report the process as dead.
     import lionagi.studio.services.lifecycle as lc_mod
 
-    monkeypatch.setattr(lc_mod, "_live_process_matches", lambda _sid, _ap: False)
+    monkeypatch.setattr(lc_mod, "process_liveness", lambda *_a, **_k: False)
 
     from lionagi.studio.services.lifecycle import reap_null_status_sessions
 
-    count = run_async(reap_null_status_sessions())
+    count = run_async(reap_null_status_sessions(stale_hours=1.0))
     assert count == 1
 
     sess = run_async(_get_session(db_path, sid))
@@ -302,11 +314,11 @@ def test_reap_null_status_sessions_skips_live_process(tmp_path, monkeypatch):
 
     import lionagi.studio.services.lifecycle as lc_mod
 
-    monkeypatch.setattr(lc_mod, "_live_process_matches", lambda _sid, _ap: True)
+    monkeypatch.setattr(lc_mod, "process_liveness", lambda *_a, **_k: True)
 
     from lionagi.studio.services.lifecycle import reap_null_status_sessions
 
-    count = run_async(reap_null_status_sessions())
+    count = run_async(reap_null_status_sessions(stale_hours=1.0))
     assert count == 0
 
     sess = run_async(_get_session(db_path, sid))
@@ -323,15 +335,105 @@ def test_reap_null_status_sessions_skips_terminal(tmp_path, monkeypatch):
 
     import lionagi.studio.services.lifecycle as lc_mod
 
-    monkeypatch.setattr(lc_mod, "_live_process_matches", lambda _sid, _ap: False)
+    monkeypatch.setattr(lc_mod, "process_liveness", lambda *_a, **_k: False)
 
     from lionagi.studio.services.lifecycle import reap_null_status_sessions
 
-    count = run_async(reap_null_status_sessions())
+    count = run_async(reap_null_status_sessions(stale_hours=1.0))
     assert count == 0
 
     sess = run_async(_get_session(db_path, sid))
     assert sess["status"] == "completed"
+
+
+def test_reap_null_status_sessions_live_recorded_pid_not_reaped(tmp_path, monkeypatch):
+    """A fresh null-status session with a LIVE recorded node_metadata.pid is not reaped.
+
+    Load-bearing regression check: the old id-only liveness check
+    (``_live_process_matches``) never saw ``node_metadata``, so it fell
+    through to ``None`` (unknown) -> reaped with no staleness grace. This
+    fails on that old code and passes once liveness honors the recorded pid.
+    """
+    db_path = tmp_path / "state.db"
+    _monkey_db(monkeypatch, db_path)
+
+    sid = run_async(
+        _seed_session(
+            db_path,
+            status=None,
+            artifacts_path=None,
+            node_metadata={"pid": os.getpid()},
+        )
+    )
+
+    from lionagi.studio.services.lifecycle import reap_null_status_sessions
+
+    count = run_async(reap_null_status_sessions(stale_hours=1.0))
+    assert count == 0
+
+    sess = run_async(_get_session(db_path, sid))
+    assert sess["status"] is None
+
+
+def test_reap_null_status_sessions_stale_dead_recorded_pid_reaped(tmp_path, monkeypatch):
+    """A stale null-status session with a DEAD recorded pid is still reaped (cleanup preserved)."""
+    db_path = tmp_path / "state.db"
+    _monkey_db(monkeypatch, db_path)
+
+    proc = subprocess.Popen(["/bin/sleep", "0"])  # noqa: S603
+    proc.wait()
+    dead_pid = proc.pid
+
+    stale_time = time.time() - 7200  # past the 1h grace
+    sid = run_async(
+        _seed_session(
+            db_path,
+            status=None,
+            artifacts_path=None,
+            started_at=stale_time,
+            updated_at=stale_time,
+            node_metadata={"pid": dead_pid},
+        )
+    )
+
+    from lionagi.studio.services.lifecycle import reap_null_status_sessions
+
+    count = run_async(reap_null_status_sessions(stale_hours=1.0))
+    assert count == 1
+
+    sess = run_async(_get_session(db_path, sid))
+    assert sess is not None
+    assert sess["status"] == "failed"
+    assert run_async(_count_transitions(db_path, sid)) >= 1
+
+
+def test_reap_null_status_sessions_fresh_unknown_liveness_not_reaped(tmp_path, monkeypatch):
+    """A fresh null-status session with unknown liveness is skipped within the grace period.
+
+    No recorded pid, no artifacts/pidfile, session id not in the ps snapshot ->
+    liveness is unknown (None). A recent updated_at keeps it inside the
+    staleness grace, so it must not be reaped yet.
+    """
+    db_path = tmp_path / "state.db"
+    _monkey_db(monkeypatch, db_path)
+
+    sid = run_async(
+        _seed_session(
+            db_path,
+            status=None,
+            artifacts_path=None,
+            started_at=time.time() - 5,
+            updated_at=time.time() - 5,
+        )
+    )
+
+    from lionagi.studio.services.lifecycle import reap_null_status_sessions
+
+    count = run_async(reap_null_status_sessions(stale_hours=1.0))
+    assert count == 0
+
+    sess = run_async(_get_session(db_path, sid))
+    assert sess["status"] is None
 
 
 # ── automatic phantom reaper ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `reap_null_status_sessions` (the `status IS NULL` reaper in `lifecycle.py`, run on the scheduler tick and at startup) previously classified liveness with only a pidfile/ps-snapshot fallback (`_live_process_matches`), never reading the session's own `node_metadata.pid`, and had no staleness grace — so a freshly-created null-status session with a live recorded pid could be reaped and marked failed on the very next tick.
- This is the sibling of the already-merged phantom-reaper fix in #1804 (`admin.py::_classify_phantom`), which fixed the identical defect class for the phantom reaper. This PR brings the null-status reaper to the same shape.

## Fix

- `reap_null_status_sessions` now takes `stale_hours: float | None = None`, resolving from the shared `PHANTOM_STALE_HOURS` config (same source as the phantom reaper) when not passed explicitly.
- The SELECT now pulls `updated_at` and `node_metadata` per row; the recorded `node_metadata` is passed into `process_liveness()` so a live recorded pid is honored (preferred over the ps-snapshot fallback), matching `_classify_phantom`'s liveness resolution.
- Added a staleness grace: `if now - updated_at < stale_seconds: continue` — a fresh null-status session with unknown liveness is left alone rather than reaped, mirroring `_classify_phantom`'s grace window.
- Removed `admin.py::_live_process_matches`, now dead code with zero remaining callers after this fix.

## Creation-path severity finding

Investigated whether a live session can ever actually sit at `status=NULL` in practice, or whether the false-reap window is theoretical.

**Verdict: the window is empty in practice.** Every real (non-test) session-creation caller writes `status="running"` atomically in the same insert dict:
- `cli/agent.py` → `cli/_runs.py:setup_agent_persist` (the `li agent` spawn path)
- `cli/orchestrate/_orchestration.py:setup_orchestration_persist` (`li o fanout`/`li o flow`)
- `cli/engine.py` (engine-run signal session)
- `state/claude_mirror.py:mirror_session` (claude-code mirror path, its one caller in `cli/mirror.py` passes `status="running"` explicitly)
- `cli/state.py` (`li state import`) writes a derived terminal/legacy status for already-finished filesystem runs, not a live session

The one function that would insert a NULL status, `state/persist.py:persist_session()`, has zero callers anywhere in the repo (including tests) — dead code. `docs/adrs/ADR-0025-session-status-vocabulary.md` confirms NULL is the documented "legacy" pseudo-status for sessions created before the status vocabulary existed, not a live-crash gap. Test fixtures construct NULL rows explicitly (`status=None` / raw SQL) to simulate this legacy case.

So this fix closes a real defect class (liveness-check-goes-through-a-worse-path-than-it-should, silent false-reap risk against future/legacy callers) rather than a currently-triggerable production incident — worth landing for correctness and symmetry with #1804, not because it's firing today.

## Testing

Mutation-sensitivity proof: before the fix, a standalone repro (seed a null-status session with a live recorded `node_metadata.pid`, call the old bare `reap_null_status_sessions()`) reaped it — `reaped count: 1, status after: failed`. After the fix, the same scenario is asserted not-reaped in `test_reap_null_status_sessions_live_recorded_pid_not_reaped`.

- `tests/apps_studio_server/test_lifecycle_reapers.py`: 18/18 passed (3 existing tests updated for the new `process_liveness` signature + `stale_hours` param, 3 new tests added: live recorded pid not reaped, stale dead recorded pid reaped, fresh unknown-liveness not reaped under grace)
- `tests/apps_studio_server/test_adversarial_reapers.py` + `test_admin.py` + `test_process_liveness.py`: 44/44 passed
- Full `tests/apps_studio_server/`: 662/662 passed, 0 failures
- `uv run pyright`: 0 errors on touched files
- `uv run ruff check` / `ruff format`: clean

## Test plan

- [x] Full studio server test suite green (662/662)
- [x] Mutation-sensitive test proven to fail on pre-fix code, pass on fix
- [x] pyright + ruff clean
- [ ] Codex review (next in ladder)
- [ ] Leo sign-off gate (next in ladder — do not merge before this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)