### PR TITLE
chore(errors,hooks): remove dead code — AccessError + registered_handlers (#83 tech-debt PR-5)

### DIFF
--- a/lionagi/_errors.py
+++ b/lionagi/_errors.py
@@ -16,7 +16,6 @@ __all__ = (
     "RelationError",
     "OperationError",
     "ExecutionError",
-    "AccessError",
     "ConfigurationError",
     "TimeoutError",
     "ItemNotFoundError",
@@ -139,14 +138,6 @@ class OperationError(LionError, ValueError):
 
 class ExecutionError(LionError, RuntimeError):
     pass
-
-
-class AccessError(LionError):
-    """Exception raised when access is denied."""
-
-    default_message = "Access denied"
-    default_status_code = 403
-    __slots__ = ()
 
 
 class ConfigurationError(LionError, ValueError):

--- a/lionagi/hooks/loader.py
+++ b/lionagi/hooks/loader.py
@@ -54,11 +54,6 @@ def resolve_handler(name: str) -> HookHandler:
         raise KeyError(f"Unknown hook handler {name!r}. Registered: {sorted(_REGISTRY)}") from exc
 
 
-def registered_handlers() -> list[str]:
-    """Sorted list of registered handler names (for diagnostics)."""
-    return sorted(_REGISTRY)
-
-
 def load_hooks_for_agent(
     agent_hooks: dict[str, list[str]] | None,
 ) -> dict[HookPoint, list[HookHandler]]:


### PR DESCRIPTION
Delete unused `AccessError` exception class (+ its __all__ entry) from _errors.py and the unused `registered_handlers` diagnostics helper from hooks/loader.py. Both zero callers. Pure deletion. Part of #83 tech-debt wave (Leo-sequenced).