### PR TITLE
chore(cli): remove dead code — 3 unused cli helpers (#83 tech-debt PR-4)

### DIFF
--- a/lionagi/cli/_providers.py
+++ b/lionagi/cli/_providers.py
@@ -328,12 +328,6 @@ class AgentProfile:
     extra: dict = field(default_factory=dict)
 
 
-def _find_lionagi_dir() -> Path | None:
-    """Find first .lionagi/ directory (backward compat)."""
-    dirs = _find_lionagi_dirs()
-    return dirs[0] if dirs else None
-
-
 def _resolve_profile_path(agents_dir: Path, name: str) -> Path | None:
     """Return profile path for NAME: directory layout (<name>/<name>.md) before flat (<name>.md)."""
     dir_candidate = agents_dir / name / f"{name}.md"

--- a/lionagi/cli/kill.py
+++ b/lionagi/cli/kill.py
@@ -161,21 +161,6 @@ def _terminate_pid(
 _STALE_SWEEP_ORDER = ("sessions", "invocations")
 
 
-async def _list_child_invocations(db: Any, session_id: str) -> list[dict[str, Any]]:
-    rows = await db.fetch_all("SELECT * FROM invocations WHERE status = 'running'", ())
-    result = []
-    for d in rows:
-        child_row = await db.fetch_one(
-            "SELECT 1 FROM sessions WHERE invocation_id = ? LIMIT 1",
-            (d["id"],),
-        )
-        if child_row is not None:
-            result.append(d)
-        elif d.get("id") == session_id:
-            result.append(d)
-    return result
-
-
 async def _list_running_children(
     db: Any, entity_type: str, entity_id: str
 ) -> list[tuple[str, str, dict[str, Any]]]:

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -53,13 +53,6 @@ class FlowPlanError(LionError):
     """Orchestrator failed to produce a usable plan."""
 
 
-def _raw_response_snippet(res, limit: int = 800) -> str:
-    text = (str(res).strip() if res is not None else "") or "(empty response)"
-    if len(text) > limit:
-        text = f"{text[:limit]}… [+{len(text) - limit} chars truncated]"
-    return text
-
-
 async def _persist_session_phase(env, phase: str) -> None:
     """Best-effort write of the live execution phase to the session row."""
     ctx = getattr(env, "_live_persist", None)


### PR DESCRIPTION
Delete unused private helpers: `_find_lionagi_dir` (singular; plural `_find_lionagi_dirs` is the live one), `_list_child_invocations` (cli/kill.py), `_raw_response_snippet` (cli/orchestrate/flow.py). All zero callers. Pure deletion. Part of #83 tech-debt wave (Leo-sequenced). cli/monitor.py _load_run_manifests deliberately NOT included — held for Ocean.