### PR TITLE
chore(security): consolidate path-traversal checks onto has_traversal helper

### DIFF
--- a/lionagi/libs/path_safety.py
+++ b/lionagi/libs/path_safety.py
@@ -71,7 +71,7 @@ def check_path_safe(
             f"{field_name} entry {value!r} is a Windows drive-letter path — "
             "only repo-relative paths inside the repository are allowed."
         )
-    if ".." in p.parts:
+    if has_traversal(p):
         raise ValueError(
             f"{field_name} entry {value!r} contains directory traversal ('..') — "
             "only paths that remain inside the repository are allowed."
@@ -143,7 +143,7 @@ def contain_paths_in_root(
 def check_add_dir_safe(value: str, field_name: str) -> str:
     """Validate add_dir entry: allow absolute, reject traversal only (read-grant semantics)."""
     p = Path(value)
-    if ".." in p.parts:
+    if has_traversal(p):
         raise ValueError(
             f"{field_name} entry {value!r} contains directory traversal ('..') — "
             "use an explicit absolute path to grant access to directories outside "

--- a/lionagi/providers/_cli_subprocess.py
+++ b/lionagi/providers/_cli_subprocess.py
@@ -13,7 +13,7 @@ from functools import partial
 from pathlib import Path
 from typing import Any
 
-from lionagi.libs.path_safety import contain_and_resolve
+from lionagi.libs.path_safety import contain_and_resolve, has_traversal
 from lionagi.libs.schema.as_readable import as_readable
 from lionagi.ln._proc import aterminate_process_group
 
@@ -156,7 +156,7 @@ def resolve_cli_workspace(repo: Path | None, workspace: str | None) -> Path:
     if ws_path.is_absolute():
         raise ValueError(f"Workspace path must be relative, got absolute: {workspace}")
 
-    if ".." in ws_path.parts:
+    if has_traversal(ws_path):
         raise ValueError(f"Directory traversal detected in workspace path: {workspace}")
 
     return contain_and_resolve(ws_path, repo)

--- a/lionagi/studio/services/plugins.py
+++ b/lionagi/studio/services/plugins.py
@@ -8,6 +8,7 @@ import anyio
 from fastapi import HTTPException
 
 from lionagi.libs.frontmatter import parse_frontmatter as _parse_frontmatter
+from lionagi.libs.path_safety import has_traversal
 
 from ..registry import studio_route
 from ._io import read_json_file as _read_json
@@ -161,7 +162,7 @@ def _resolve_marketplace_source(source_rel: str) -> Path | None:
     if not source_rel:
         return None
     source_path = Path(source_rel)
-    if source_path.is_absolute() or ".." in source_path.parts:
+    if source_path.is_absolute() or has_traversal(source_path):
         return None
     try:
         plugin_dir = (_REPO_ROOT / source_path).resolve()


### PR DESCRIPTION
## Summary

Tech-debt PR-7 of the #83 wave (Leo-sequenced). Behavior-preserving consolidation of a duplicated path-traversal check onto the existing `has_traversal()` helper in `lionagi/libs/path_safety.py` (previously defined but unused).

All 4 sites reimplemented the identical boolean `".." in <Path>.parts` inline instead of calling the helper. This PR swaps each inline condition for a `has_traversal(...)` call — same boolean, same `raise ValueError(...)` messages, no other behavior change.

Sites changed:
- `lionagi/libs/path_safety.py:74` — `check_path_safe`
- `lionagi/libs/path_safety.py:146` — `check_add_dir_safe`
- `lionagi/providers/_cli_subprocess.py:159` — `resolve_cli_workspace` (added `has_traversal` to the existing `lionagi.libs.path_safety` import)
- `lionagi/studio/services/plugins.py:164` — `_resolve_marketplace_source` (added a new `from lionagi.libs.path_safety import has_traversal` import; module had no prior import from that path)

**Deliberately left untouched**: the exact-component *equality* checks at `path_safety.py` lines ~166 (`safe_join`), ~185 (`validate_name`), and ~211 (`validate_path_component`) — `component in {".", ".."}` / `value in {".", ".."}` / `component in (".", "..")`. These test single-component equality, not `.parts` containment, so they are a different check and out of scope for this consolidation.

## Verification

- `git diff --stat origin/main...HEAD`: exactly 3 files, +6/-5 lines.
- `uv run ruff check lionagi/libs/path_safety.py lionagi/providers/_cli_subprocess.py lionagi/studio/services/plugins.py` → All checks passed.
- `uv run --extra studio python -c "import lionagi; from lionagi.libs.path_safety import has_traversal; import lionagi.providers._cli_subprocess; import lionagi.studio.services.plugins"` → import OK.
- `rg -n '\.\.' <3 files>` → only the helper's own docstring/impl, the ValueError message text, and the untouched `{".", ".."}`/`(".", "..")` equality sets remain; zero stray inline `.parts` traversal checks.
- Targeted test run (`pytest -k "path_safety or traversal or marketplace or cli_workspace or resolve_cli"`): **85 passed, 0 failed, 0 errors**.
- Full-file run of every test module that directly imports the 3 changed modules (`test_coding_coverage.py`, `test_import_surface.py`, `test_cli_behavior_parity.py`, `test_cli_path_validation.py`, `test_security_batch1.py`): **125 passed, 0 failed, 0 errors**.
- `fastapi` (a `studio` optional-extra dep) is required to import `plugins.py`; confirmed via `git stash` that the bare-env `ModuleNotFoundError` is pre-existing env noise unrelated to this change, not a regression — installed `--extra studio` for a clean verification run.

## Test plan

- [x] `git diff --stat` shows exactly the 3 intended files
- [x] `ruff check` clean on the 3 files
- [x] Import smoke test passes for all 3 modules
- [x] Grep confirms zero remaining inline `".." in path.parts` checks in the 3 files
- [x] Targeted traversal/path-safety/marketplace/cli-workspace test suite: 85/85 passed
- [x] Full test files directly importing the changed modules: 125/125 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)