### PR TITLE
fix(service): broadcaster awaits any awaitable via maybe_await (#1814)

### DIFF
--- a/lionagi/service/broadcaster.py
+++ b/lionagi/service/broadcaster.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-import asyncio
 import logging
 import threading
 import weakref
 from typing import TYPE_CHECKING, Any, ClassVar
+
+from lionagi.ln.concurrency import maybe_await
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -86,9 +87,7 @@ class Broadcaster:
             callbacks = cls._cleanup_dead_refs()
         for callback in callbacks:
             try:
-                result = callback(event)
-                if asyncio.iscoroutine(result):
-                    await result
+                await maybe_await(callback(event))
             except Exception as e:
                 logger.error(f"Error in subscriber callback: {e}", exc_info=True)
 

--- a/tests/service/test_broadcaster.py
+++ b/tests/service/test_broadcaster.py
@@ -320,3 +320,79 @@ class TestBroadcasterCoroutineOnlyRegression:
         await self.TaskBroadcaster.broadcast(event)
 
         assert results == ["done"], "async subscriber coroutine was not awaited"
+
+
+##################################################
+#  maybe_await widening: non-coroutine awaitables #
+##################################################
+
+
+class _FlagAwaitable:
+    """Bare `__await__`-only awaitable (not a coroutine, not a Task/Future)."""
+
+    def __init__(self, flag: list) -> None:
+        self._flag = flag
+
+    def __await__(self):
+        async def _mark():
+            self._flag.append(True)
+
+        return _mark().__await__()
+
+
+class TestBroadcasterMaybeAwaitWidening:
+    """Verify broadcast awaits ANY awaitable via maybe_await, not just coroutines (opposite contract of the class above; see PR description)."""
+
+    @pytest.fixture(autouse=True)
+    def fresh_broadcaster(self):
+        class _WideningBroadcaster(Broadcaster):
+            _event_type = SampleEvent
+
+        self.WideningBroadcaster = _WideningBroadcaster
+        yield
+        _WideningBroadcaster._subscribers.clear()
+        _WideningBroadcaster._instance = None
+
+    @pytest.mark.asyncio
+    async def test_sync_subscriber_returning_bare_awaitable_is_awaited(self):
+        flag = []
+
+        def sync_callback_returns_bare_awaitable(event):
+            return _FlagAwaitable(flag)
+
+        self.WideningBroadcaster.subscribe(sync_callback_returns_bare_awaitable)
+        await self.WideningBroadcaster.broadcast(SampleEvent())
+
+        assert flag == [True], (
+            "broadcast() did not await a bare __await__-only awaitable returned "
+            "by a sync subscriber"
+        )
+
+    @pytest.mark.asyncio
+    async def test_sync_subscriber_returning_future_is_awaited(self):
+        loop = asyncio.get_running_loop()
+        future = loop.create_future()
+        loop.call_soon(future.set_result, None)
+        observed = []
+
+        def sync_callback_returns_future(event):
+            observed.append("called")
+            return future
+
+        self.WideningBroadcaster.subscribe(sync_callback_returns_future)
+        await self.WideningBroadcaster.broadcast(SampleEvent())
+
+        assert observed == ["called"]
+        assert future.done(), "broadcast() did not await the Future returned by a sync subscriber"
+
+    @pytest.mark.asyncio
+    async def test_async_subscriber_coroutine_still_awaited(self):
+        results = []
+
+        async def async_callback(event):
+            results.append("done")
+
+        self.WideningBroadcaster.subscribe(async_callback)
+        await self.WideningBroadcaster.broadcast(SampleEvent())
+
+        assert results == ["done"]


### PR DESCRIPTION
## STOP — this reopens a previously-reverted regression. Needs explicit sign-off before merge.

Closes #1814 as literally specified, but the mandated khive `memory.recall` at task start surfaced a direct conflict this issue did not account for. Reporting it in full per Π_TBV rather than silently forcing green.

### The conflict

- 2026-06-08, commit `8bc0e9341` ("fix(protocols): restore is_coro_func and asyncio.iscoroutine-only semantics", author OceanLi): this exact widening (`asyncio.iscoroutine` → `maybe_await`/`inspect.isawaitable`) was tried in `lionagi/service/broadcaster.py`, found to be a real regression ("Finding 2 (Medium): Broadcaster.broadcast was awaiting Tasks/Futures via maybe_await... Restore origin/main behavior: only await when the result is asyncio.iscoroutine, leaving Tasks fire-and-return"), and **reverted** back to the narrow check.
- That commit also added a permanent regression test, still present on `main` today: `tests/service/test_broadcaster.py::TestBroadcasterCoroutineOnlyRegression::test_sync_subscriber_returning_task_is_not_awaited`, docstring: *"Verify broadcast only awaits coroutines: refactor to maybe_await/isawaitable would also await Tasks/Futures, breaking fire-and-return semantics."*
- I confirmed on current `origin/main` (before touching anything) that this test passes and locks in narrow (`asyncio.iscoroutine`-only) semantics as the intentional, tested contract.
- Issue #1814 asks for the identical widening, with no mention of the June 8 finding or that regression test — it reads as unaware of that history rather than a deliberate override.
- **This is provably a hard conflict, not a coincidence**: my required new test (`TestBroadcasterMaybeAwaitWidening`) and the existing regression test assert *opposite* outcomes for the same category of object (a non-coroutine awaitable returned by a sync subscriber — `asyncio.Task` in the old test, a `Future`/bare `__await__` object in the new one). It is not possible for both to pass simultaneously. I did **not** delete or weaken the old regression test — that is not my call to make unilaterally. Running the suite now shows exactly one real (non-env) failure: that test, failing precisely as designed to prevent this widening.

I implemented the issue exactly as specified and produced all requested evidence below, but recommend Leo/Ocean make an explicit call — either accept this PR (superseding the June 8 decision, and then delete/rewrite `TestBroadcasterCoroutineOnlyRegression` in a follow-up commit here or a fast-follow) or close #1814 as based on a stale premise.

### Per-site justification (as requested by #1814)

- `Broadcaster` has **no in-tree production subclass** — confirmed via `rg -n "class .*\(Broadcaster\)" --type py` (only test files match) and `rg -n "Broadcaster" lionagi/ -g '!tests/*'` (only re-export/`__init__.py` wiring, no subclass, no `.subscribe(...)` call site in production code). It is a public API extension point (`lionagi.Broadcaster`) with subscribers living in downstream/user code, not in this repo.
- So neither issue-stated conclusion (a)/(b) cleanly applies: there is no *first-party* live subscriber to point to either way. What *does* exist is a deliberately-authored, still-passing regression test asserting that a sync subscriber returning a Task (the fire-and-forget pattern) must **not** be awaited — i.e. the repo has already taken a real position on this, in the opposite direction from what #1814 requests.
- Net: this is not "safe hardening with no observable change" (conclusion b) — it demonstrably breaks a documented, tested behavior. Whether it's a "latent bug fix" (conclusion a) is the crux of the disagreement between #1814 and the June 8 finding, and isn't mine to resolve unilaterally.

### The change

`lionagi/service/broadcaster.py`, `Broadcaster.broadcast`:
```python
# before
result = callback(event)
if asyncio.iscoroutine(result):
    await result
# after
await maybe_await(callback(event))
```
`import asyncio` removed (grepped the whole file post-change — no other use).
Import: `from lionagi.ln.concurrency import maybe_await` (verified live: `uv run python -c "from lionagi.ln.concurrency import maybe_await; print(maybe_await)"`).

### Tests added (`tests/service/test_broadcaster.py::TestBroadcasterMaybeAwaitWidening`)

- `test_sync_subscriber_returning_bare_awaitable_is_awaited` — sync callback returns a bare `__await__`-only object (not a coroutine, not a Task/Future); asserts the flag it sets is observed after `broadcast()`.
- `test_sync_subscriber_returning_future_is_awaited` — sync callback returns an unresolved `asyncio.Future` whose result is set via `loop.call_soon`; asserts `future.done()` is true immediately after `broadcast()` returns (only true if it was actually awaited, not just returned-and-ignored).
- `test_async_subscriber_coroutine_still_awaited` — ordinary `async def` subscriber path still works.

**Verified fail-old/pass-new** by temporarily `git stash`-ing the source change and re-running just this test class:
- Against **old** code (`asyncio.iscoroutine`): `test_sync_subscriber_returning_bare_awaitable_is_awaited` FAILS, `test_sync_subscriber_returning_future_is_awaited` FAILS, `test_async_subscriber_coroutine_still_awaited` passes. (2 failed, 1 passed)
- Against **new** code (`maybe_await`): all 3 pass.

This also empirically means `TestBroadcasterCoroutineOnlyRegression::test_sync_subscriber_returning_task_is_not_awaited` (pre-existing) now fails — expected, see conflict section above.

### Gate results (actual, not claimed)

- `uv run pytest tests/service/test_broadcaster.py tests/protocols/generic/test_broadcaster.py tests/test_init.py tests/test_public_api.py -q`: **41 passed, 1 failed** — the one failure is `TestBroadcasterCoroutineOnlyRegression::test_sync_subscriber_returning_task_is_not_awaited` (the conflict above), everything else including the other broadcaster test file and public-API import tests is green.
- Full suite `uv run pytest tests/ -q --maxfail=0` (repo default caps at `--maxfail=5` via pyproject addopts, overridden to see the true count): 10237 collected, 113 skipped, 36 setup errors, 99 failed → **9989 passed**. Of the 99 failures + 36 errors, I traced every distinct failing file's root cause:
  - `ModuleNotFoundError` for `fastapi` (studio extra) — `test_argv_injection.py`, `test_engine_defs_api.py`, `test_scheduler_flow_yaml.py`, `test_lifecycle_reapers.py`, most `apps_studio_server`/`studio` skips
  - `ModuleNotFoundError` for `pandas` — `test_cookbook.py::TestDataPersistence::test_branch_to_df_returns_dataframe`, `test_session_flow_execution.py::test_to_df_conversion`
  - `ModuleNotFoundError` for `pydapter` — `test_async_postgres_adapter.py`
  - missing/no local Postgres or async driver — `test_dual_backend.py::test_postgres_parity`, `test_engine_schema.py::test_metadata_create_all_postgres`
  - Ollama not reachable — `test_integrations.py::test_ollama_imodel_constructs`
  - docling not installed — `test_coding_toolkit.py`
  - `test_wrapper.py` (MCP connection pool) and `test_log.py`/`test_log_coverage.py`/`test_async_dump.py`/`test_chunk_api.py` — pre-existing, unrelated to this change (dump/log-capacity/MCP-client assertions, no reference to broadcaster/asyncio.iscoroutine/maybe_await anywhere in their tracebacks)
  - `test_control_poller_lifecycle.py::test_ctl_task_and_hb_task_are_cancelled_cleanly_at_run_end` — `asyncio.CancelledError` inside `lionagi/cli/orchestrate/flow.py`'s heartbeat task; unrelated subsystem, no touch on this PR's diff
  - `test_broadcaster.py::TestBroadcasterCoroutineOnlyRegression::test_sync_subscriber_returning_task_is_not_awaited` — the one real, expected, causally-connected failure from this change (see conflict section)
  
  None of the other 97 failures reference `broadcaster`, `asyncio.iscoroutine`, or `maybe_await` anywhere in their tracebacks — all are pre-existing optional-dependency/environment gaps or unrelated subsystems.
- `uv run ruff check lionagi/service/broadcaster.py tests/service/test_broadcaster.py`: clean.
- `uv run ruff format --check`: 1 file needed reformatting (line-wrap on a new assert message), applied via `uv run ruff format`, now clean.
- Pre-commit hooks (ruff, ruff-format, pyupgrade, ast-check, etc.): all passed on commit.

### Ladder

Per #1814: not behavior-preserving → own PR, implementer → Π_TBV → codex → Leo gate → merge. **Do not merge without resolving the conflict above** — either an explicit decision to supersede the June 8 finding (and then the old regression test needs to be deleted/rewritten, which I have deliberately left undone pending that sign-off) or closing #1814.
