### PR TITLE
fix(providers): nlip retries use retry_with_backoff, dedup the two loops (#1815)

### DIFF
--- a/lionagi/providers/ag2/nlip.py
+++ b/lionagi/providers/ag2/nlip.py
@@ -6,14 +6,16 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from typing import Any
 from urllib.parse import urlparse
 
+import httpx
 from pydantic import BaseModel, Field
 
 from lionagi.ln import is_ssrf_safe
 from lionagi.service.connections import AgenticEndpoint, EndpointConfig
+from lionagi.service.resilience import retry_with_backoff
 from lionagi.service.types import StreamChunk
 from lionagi.utils import to_dict
 
@@ -45,6 +47,38 @@ def _assert_nlip_url_safe(url: str) -> None:
         )
 
 
+async def _post_json_with_retry(
+    client: httpx.AsyncClient,
+    url: str,
+    json_payload: dict[str, Any],
+    max_retries: int,
+    on_retry: Callable[[Exception, int, int], None] | None = None,
+) -> httpx.Response | None:
+    """POST with exponential backoff, retrying only on timeout/connect errors; max_retries<=0 makes no request."""
+    if max_retries <= 0:
+        return None
+
+    attempt = 0
+
+    async def _post() -> httpx.Response:
+        nonlocal attempt
+        attempt += 1
+        try:
+            response = await client.post(url, json=json_payload)
+            response.raise_for_status()
+            return response
+        except (httpx.TimeoutException, httpx.ConnectError) as exc:
+            if on_retry is not None and attempt < max_retries:
+                on_retry(exc, attempt, max_retries)
+            raise
+
+    return await retry_with_backoff(
+        _post,
+        retry_exceptions=(httpx.TimeoutException, httpx.ConnectError),
+        max_retries=max_retries - 1,
+    )
+
+
 async def call_nlip_remote(
     url: str,
     messages: list[dict[str, Any]],
@@ -69,7 +103,6 @@ async def _call_nlip_sdk(
     max_retries: int,
 ) -> dict[str, Any]:
     """Use nlip_sdk for proper NLIP message format."""
-    import httpx
     from nlip_sdk.nlip import NLIP_Factory, NLIP_Message
 
     last_content = ""
@@ -90,35 +123,28 @@ async def _call_nlip_sdk(
         if sanitized:
             nlip_msg.add_json({"messages": sanitized}, label="ag2_chat_history")
 
+    def _log_retry(exc: Exception, attempt: int, total: int) -> None:
+        if isinstance(exc, httpx.TimeoutException):
+            logger.warning("NLIP timeout (attempt %d/%d)", attempt, total)
+        else:
+            logger.warning("NLIP connect failed (attempt %d/%d)", attempt, total)
+
     async with httpx.AsyncClient(timeout=timeout) as client:
-        for attempt in range(max_retries):
-            try:
-                response = await client.post(
-                    f"{url.rstrip('/')}/nlip/",
-                    json=nlip_msg.model_dump(exclude_none=True),
-                )
-                response.raise_for_status()
+        response = await _post_json_with_retry(
+            client,
+            f"{url.rstrip('/')}/nlip/",
+            nlip_msg.model_dump(exclude_none=True),
+            max_retries,
+            on_retry=_log_retry,
+        )
+        if response is None:
+            return {"content": "", "context": None, "input_required": None}
 
-                data = response.json()
-                nlip_response = NLIP_Message.model_validate(data)
-                content = nlip_response.content if isinstance(nlip_response.content, str) else ""
+        data = response.json()
+        nlip_response = NLIP_Message.model_validate(data)
+        content = nlip_response.content if isinstance(nlip_response.content, str) else ""
 
-                return {
-                    "content": content,
-                    "context": None,
-                    "input_required": None,
-                }
-
-            except httpx.TimeoutException:
-                if attempt == max_retries - 1:
-                    raise
-                logger.warning("NLIP timeout (attempt %d/%d)", attempt + 1, max_retries)
-            except httpx.ConnectError:
-                if attempt == max_retries - 1:
-                    raise
-                logger.warning("NLIP connect failed (attempt %d/%d)", attempt + 1, max_retries)
-
-    return {"content": "", "context": None, "input_required": None}
+    return {"content": content, "context": None, "input_required": None}
 
 
 async def _call_direct(
@@ -128,8 +154,6 @@ async def _call_direct(
     max_retries: int,
 ) -> dict[str, Any]:
     """Direct httpx fallback (no nlip_sdk): POSTs the last message as plain text."""
-    import httpx
-
     last_content = ""
     for msg in reversed(messages):
         content = msg.get("content", "")
@@ -144,31 +168,24 @@ async def _call_direct(
     }
 
     async with httpx.AsyncClient(timeout=timeout) as client:
-        for attempt in range(max_retries):
-            try:
-                response = await client.post(
-                    f"{url.rstrip('/')}/nlip/",
-                    json=payload,
-                )
-                response.raise_for_status()
-                data = response.json()
+        response = await _post_json_with_retry(
+            client,
+            f"{url.rstrip('/')}/nlip/",
+            payload,
+            max_retries,
+        )
+        if response is None:
+            return {"content": "", "context": None, "input_required": None}
 
-                content = ""
-                if isinstance(data, dict):
-                    content = data.get("content", "")
-                    if isinstance(content, dict):
-                        content = content.get("content", str(content))
+        data = response.json()
 
-                return {"content": content, "context": None, "input_required": None}
+    content = ""
+    if isinstance(data, dict):
+        content = data.get("content", "")
+        if isinstance(content, dict):
+            content = content.get("content", str(content))
 
-            except httpx.TimeoutException:
-                if attempt == max_retries - 1:
-                    raise
-            except httpx.ConnectError:
-                if attempt == max_retries - 1:
-                    raise
-
-    return {"content": "", "context": None, "input_required": None}
+    return {"content": content, "context": None, "input_required": None}
 
 
 logger = logging.getLogger(__name__)

--- a/lionagi/providers/ag2/nlip.py
+++ b/lionagi/providers/ag2/nlip.py
@@ -7,10 +7,9 @@ from __future__ import annotations
 
 import logging
 from collections.abc import AsyncIterator, Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
-import httpx
 from pydantic import BaseModel, Field
 
 from lionagi.ln import is_ssrf_safe
@@ -20,6 +19,9 @@ from lionagi.service.types import StreamChunk
 from lionagi.utils import to_dict
 
 from ._config import AG2Configs
+
+if TYPE_CHECKING:
+    import httpx
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +57,8 @@ async def _post_json_with_retry(
     on_retry: Callable[[Exception, int, int], None] | None = None,
 ) -> httpx.Response | None:
     """POST with exponential backoff, retrying only on timeout/connect errors; max_retries<=0 makes no request."""
+    import httpx
+
     if max_retries <= 0:
         return None
 
@@ -103,6 +107,7 @@ async def _call_nlip_sdk(
     max_retries: int,
 ) -> dict[str, Any]:
     """Use nlip_sdk for proper NLIP message format."""
+    import httpx
     from nlip_sdk.nlip import NLIP_Factory, NLIP_Message
 
     last_content = ""
@@ -154,6 +159,8 @@ async def _call_direct(
     max_retries: int,
 ) -> dict[str, Any]:
     """Direct httpx fallback (no nlip_sdk): POSTs the last message as plain text."""
+    import httpx
+
     last_content = ""
     for msg in reversed(messages):
         content = msg.get("content", "")

--- a/tests/providers/ag2/test_nlip_retry.py
+++ b/tests/providers/ag2/test_nlip_retry.py
@@ -1,0 +1,313 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for NLIP retry/backoff: timing, re-raise on exhaustion, exception surface, logging."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from lionagi.providers.ag2 import nlip as nlip_mod
+
+# ---------------------------------------------------------------------------
+# Fakes: httpx.AsyncClient + nlip_sdk (not an installed dependency here)
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, data=None, raise_exc: Exception | None = None):
+        self._data = data
+        self._raise_exc = raise_exc
+
+    def raise_for_status(self):
+        if self._raise_exc is not None:
+            raise self._raise_exc
+
+    def json(self):
+        return self._data
+
+
+def _patch_async_client(monkeypatch, post_mock):
+    """Patch the real httpx.AsyncClient (shared via sys.modules regardless of import site)."""
+
+    class _FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, json=None):
+            return await post_mock(url, json=json)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeAsyncClient)
+
+
+class _FakeNlipMsg:
+    def __init__(self, content: str):
+        self._content = content
+
+    def model_dump(self, exclude_none=True):
+        return {"content": self._content}
+
+    def add_json(self, data, label=None):
+        pass
+
+
+class _FakeNlipFactory:
+    @staticmethod
+    def create_text(text, language="english"):
+        return _FakeNlipMsg(text)
+
+
+class _FakeNlipMessage:
+    def __init__(self, content: str):
+        self.content = content
+
+    @classmethod
+    def model_validate(cls, data):
+        return cls(data.get("content", "") if isinstance(data, dict) else "")
+
+
+def _nlip_sdk_stubs() -> dict:
+    nlip_submodule = MagicMock()
+    nlip_submodule.NLIP_Factory = _FakeNlipFactory
+    nlip_submodule.NLIP_Message = _FakeNlipMessage
+    return {
+        "nlip_sdk": MagicMock(),
+        "nlip_sdk.nlip": nlip_submodule,
+    }
+
+
+MESSAGES = [{"role": "user", "content": "hello"}]
+
+
+# ---------------------------------------------------------------------------
+# (a) Backoff timing: sleeps grow, non-zero
+# ---------------------------------------------------------------------------
+
+
+class TestBackoffTiming:
+    @pytest.mark.asyncio
+    async def test_call_direct_backoff_delays_increase(self, monkeypatch):
+        sleep_calls: list[float] = []
+
+        async def fake_sleep(d):
+            sleep_calls.append(d)
+
+        post_mock = AsyncMock(side_effect=httpx.TimeoutException("timeout"))
+        _patch_async_client(monkeypatch, post_mock)
+        monkeypatch.setattr("lionagi.ln.concurrency.patterns.anyio.sleep", fake_sleep)
+
+        with pytest.raises(httpx.TimeoutException):
+            await nlip_mod._call_direct(
+                "https://nlip.example.com", MESSAGES, timeout=5.0, max_retries=4
+            )
+
+        # 4 attempts -> 3 inter-attempt sleeps, strictly increasing (exponential).
+        assert len(sleep_calls) == 3
+        assert all(d > 0 for d in sleep_calls)
+        assert sleep_calls[0] < sleep_calls[1] < sleep_calls[2]
+
+    @pytest.mark.asyncio
+    async def test_call_nlip_sdk_backoff_delays_increase(self, monkeypatch):
+        sleep_calls: list[float] = []
+
+        async def fake_sleep(d):
+            sleep_calls.append(d)
+
+        post_mock = AsyncMock(side_effect=httpx.ConnectError("connect failed"))
+        _patch_async_client(monkeypatch, post_mock)
+        monkeypatch.setattr("lionagi.ln.concurrency.patterns.anyio.sleep", fake_sleep)
+
+        with patch.dict(sys.modules, _nlip_sdk_stubs()):
+            with pytest.raises(httpx.ConnectError):
+                await nlip_mod._call_nlip_sdk(
+                    "https://nlip.example.com", MESSAGES, timeout=5.0, max_retries=3
+                )
+
+        assert len(sleep_calls) == 2
+        assert all(d > 0 for d in sleep_calls)
+        assert sleep_calls[0] < sleep_calls[1]
+
+
+# ---------------------------------------------------------------------------
+# (b) Raise on final attempt: original exception propagates
+# ---------------------------------------------------------------------------
+
+
+class TestRaiseOnFinalAttempt:
+    @pytest.mark.asyncio
+    async def test_call_direct_raises_original_timeout_after_exhaustion(self, monkeypatch):
+        async def fake_sleep(d):
+            pass
+
+        post_mock = AsyncMock(side_effect=httpx.TimeoutException("boom"))
+        _patch_async_client(monkeypatch, post_mock)
+        monkeypatch.setattr("lionagi.ln.concurrency.patterns.anyio.sleep", fake_sleep)
+
+        with pytest.raises(httpx.TimeoutException, match="boom"):
+            await nlip_mod._call_direct(
+                "https://nlip.example.com", MESSAGES, timeout=5.0, max_retries=2
+            )
+
+        assert post_mock.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_call_nlip_sdk_raises_original_connect_error_after_exhaustion(self, monkeypatch):
+        async def fake_sleep(d):
+            pass
+
+        post_mock = AsyncMock(side_effect=httpx.ConnectError("unreachable"))
+        _patch_async_client(monkeypatch, post_mock)
+        monkeypatch.setattr("lionagi.ln.concurrency.patterns.anyio.sleep", fake_sleep)
+
+        with patch.dict(sys.modules, _nlip_sdk_stubs()):
+            with pytest.raises(httpx.ConnectError, match="unreachable"):
+                await nlip_mod._call_nlip_sdk(
+                    "https://nlip.example.com", MESSAGES, timeout=5.0, max_retries=2
+                )
+
+        assert post_mock.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# (c) Narrow exception surface: non-retryable errors raise immediately
+# ---------------------------------------------------------------------------
+
+
+class TestNarrowExceptionSurface:
+    @pytest.mark.asyncio
+    async def test_call_direct_http_status_error_not_retried(self, monkeypatch):
+        sleep_calls: list[float] = []
+
+        async def fake_sleep(d):
+            sleep_calls.append(d)
+
+        request = httpx.Request("POST", "https://nlip.example.com/nlip/")
+        http_response = httpx.Response(500, request=request)
+        status_error = httpx.HTTPStatusError(
+            "server error", request=request, response=http_response
+        )
+
+        post_mock = AsyncMock(return_value=_FakeResponse(raise_exc=status_error))
+        _patch_async_client(monkeypatch, post_mock)
+        monkeypatch.setattr("lionagi.ln.concurrency.patterns.anyio.sleep", fake_sleep)
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await nlip_mod._call_direct(
+                "https://nlip.example.com", MESSAGES, timeout=5.0, max_retries=3
+            )
+
+        assert post_mock.call_count == 1
+        assert sleep_calls == []
+
+    @pytest.mark.asyncio
+    async def test_call_nlip_sdk_validation_error_not_retried(self, monkeypatch):
+        """model_validate failures happen outside the retry helper and propagate on first occurrence."""
+        sleep_calls: list[float] = []
+
+        async def fake_sleep(d):
+            sleep_calls.append(d)
+
+        post_mock = AsyncMock(return_value=_FakeResponse(data={"content": "ok"}))
+        _patch_async_client(monkeypatch, post_mock)
+        monkeypatch.setattr("lionagi.ln.concurrency.patterns.anyio.sleep", fake_sleep)
+
+        class _ExplodingNlipMessage(_FakeNlipMessage):
+            @classmethod
+            def model_validate(cls, data):
+                raise ValueError("bad NLIP payload")
+
+        stubs = _nlip_sdk_stubs()
+        stubs["nlip_sdk.nlip"].NLIP_Message = _ExplodingNlipMessage
+
+        with patch.dict(sys.modules, stubs):
+            with pytest.raises(ValueError, match="bad NLIP payload"):
+                await nlip_mod._call_nlip_sdk(
+                    "https://nlip.example.com", MESSAGES, timeout=5.0, max_retries=3
+                )
+
+        assert post_mock.call_count == 1
+        assert sleep_calls == []
+
+
+# ---------------------------------------------------------------------------
+# (d) sdk-path warning logging preserved; direct path stays silent
+# ---------------------------------------------------------------------------
+
+
+class TestRetryLogging:
+    @pytest.mark.asyncio
+    async def test_call_nlip_sdk_warns_once_per_non_final_retry(self, monkeypatch, caplog):
+        async def fake_sleep(d):
+            pass
+
+        post_mock = AsyncMock(side_effect=httpx.TimeoutException("timeout"))
+        _patch_async_client(monkeypatch, post_mock)
+        monkeypatch.setattr("lionagi.ln.concurrency.patterns.anyio.sleep", fake_sleep)
+
+        with patch.dict(sys.modules, _nlip_sdk_stubs()):
+            with caplog.at_level("WARNING", logger="lionagi.providers.ag2.nlip"):
+                with pytest.raises(httpx.TimeoutException):
+                    await nlip_mod._call_nlip_sdk(
+                        "https://nlip.example.com", MESSAGES, timeout=5.0, max_retries=3
+                    )
+
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        # 3 attempts -> warn on the first 2 (non-final), silent on the final raise.
+        assert len(warnings) == 2
+        assert "NLIP timeout (attempt 1/3)" in warnings[0].getMessage()
+        assert "NLIP timeout (attempt 2/3)" in warnings[1].getMessage()
+
+    @pytest.mark.asyncio
+    async def test_call_direct_stays_silent_on_retry(self, monkeypatch, caplog):
+        async def fake_sleep(d):
+            pass
+
+        post_mock = AsyncMock(side_effect=httpx.TimeoutException("timeout"))
+        _patch_async_client(monkeypatch, post_mock)
+        monkeypatch.setattr("lionagi.ln.concurrency.patterns.anyio.sleep", fake_sleep)
+
+        with caplog.at_level("WARNING", logger="lionagi.providers.ag2.nlip"):
+            with pytest.raises(httpx.TimeoutException):
+                await nlip_mod._call_direct(
+                    "https://nlip.example.com", MESSAGES, timeout=5.0, max_retries=3
+                )
+
+        assert [r for r in caplog.records if r.levelname == "WARNING"] == []
+
+
+# ---------------------------------------------------------------------------
+# Success paths (sanity: retry then succeed still parses correctly)
+# ---------------------------------------------------------------------------
+
+
+class TestSuccessAfterTransientFailure:
+    @pytest.mark.asyncio
+    async def test_call_direct_succeeds_after_one_timeout(self, monkeypatch):
+        async def fake_sleep(d):
+            pass
+
+        post_mock = AsyncMock(
+            side_effect=[
+                httpx.TimeoutException("timeout"),
+                _FakeResponse(data={"content": "hi there"}),
+            ]
+        )
+        _patch_async_client(monkeypatch, post_mock)
+        monkeypatch.setattr("lionagi.ln.concurrency.patterns.anyio.sleep", fake_sleep)
+
+        result = await nlip_mod._call_direct(
+            "https://nlip.example.com", MESSAGES, timeout=5.0, max_retries=3
+        )
+
+        assert result == {"content": "hi there", "context": None, "input_required": None}
+        assert post_mock.call_count == 2


### PR DESCRIPTION
## Summary

`_call_nlip_sdk` and `_call_direct` in `lionagi/providers/ag2/nlip.py` each hand-rolled a zero-backoff retry loop (`for attempt in range(max_retries): try/except (httpx.TimeoutException, httpx.ConnectError)`). This folds both onto a single shared helper, `_post_json_with_retry`, that routes through `lionagi.service.resilience.retry_with_backoff` — adding exponential backoff (the actual ask in #1815) and deduping the two loops.

## retry_with_backoff API used

```python
await retry_with_backoff(
    _post,
    retry_exceptions=(httpx.TimeoutException, httpx.ConnectError),
    max_retries=max_retries - 1,
)
```

`retry_with_backoff(func, *args, retry_exceptions=..., exclude_exceptions=(), max_retries=3, base_delay=1.0, max_delay=60.0, backoff_factor=2.0, jitter=True, jitter_factor=0.2, **kwargs)` (`lionagi/service/resilience.py`) wraps `lionagi.ln.concurrency.patterns.retry`, which does `attempts = max_retries + 1` total tries with `anyio.sleep` between them. The original loops made exactly `max_retries` total attempts (`range(max_retries)`), so the helper passes `max_retries=max_retries - 1` to preserve the same total-attempt count — mirroring the existing precedent in `service/connections/endpoint.py:288-292` (`max_retries=max(0, self.config.max_retries - 1)`).

Default `retry_exceptions` on `retry_with_backoff` is `(APIClientError, CircuitBreakerOpenError, ConnectionError, TimeoutError)`. I verified live that `httpx.TimeoutException` and `httpx.ConnectError` are **not** subclasses of builtin `TimeoutError`/`ConnectionError`, so the default would have retried nothing at all — `retry_exceptions` must be (and is) passed explicitly.

## Invariant confirmation

**INVARIANT 1 — narrow exception surface**: `_post_json_with_retry` passes `retry_exceptions=(httpx.TimeoutException, httpx.ConnectError)` explicitly, so `lionagi.ln.concurrency.patterns.retry`'s `except retry_on:` clause only ever catches those two types. `response.raise_for_status()` (which can raise `httpx.HTTPStatusError` on non-2xx) runs *inside* the retried callable, so a status error propagates on the first occurrence with zero retries/sleeps. `NLIP_Message.model_validate(...)` parsing happens in the caller, entirely outside the helper's scope, so validation errors also propagate immediately, untouched by the retry machinery. Covered by `TestNarrowExceptionSurface` (both the direct-path `HTTPStatusError` case and the sdk-path `model_validate` case).

**INVARIANT 2 — re-raise on final attempt**: `lionagi.ln.concurrency.patterns.retry` does a bare `raise` (not a wrap) once `attempt >= attempts`, so the original `httpx.TimeoutException`/`httpx.ConnectError` instance propagates unchanged. Covered by `TestRaiseOnFinalAttempt` for both `_call_direct` and `_call_nlip_sdk`, asserting the original exception type/message and the exact attempt count.

`max_retries<=0` edge case: the original loops made zero attempts and fell through to the trailing `{"content": "", ...}` fallback. `_post_json_with_retry` reproduces this exactly (`if max_retries <= 0: return None`, caller returns the same fallback dict) rather than letting `retry_with_backoff` make one first attempt anyway.

## Per-path logging decision

- **`_call_nlip_sdk` (sdk path): keeps warning on non-final retries**, via an `on_retry` callback passed into `_post_json_with_retry`. Preserves the exact original two distinct messages — `"NLIP timeout (attempt %d/%d)"` for `httpx.TimeoutException` vs `"NLIP connect failed (attempt %d/%d)"` for `httpx.ConnectError` — logged only on non-final attempts, silent on the attempt that ultimately raises. Covered by `TestRetryLogging::test_call_nlip_sdk_warns_once_per_non_final_retry`.
- **`_call_direct`: stays silent on retry** (no `on_retry` passed) — this was the original behavior and I chose to preserve it rather than unify, since `_call_direct` is the fallback-of-a-fallback path (used only when `nlip_sdk` isn't installed) and adding new logging there wasn't part of the ask. Covered by `TestRetryLogging::test_call_direct_stays_silent_on_retry`.

## Tests (`tests/providers/ag2/test_nlip_retry.py`, 9 new tests)

1. **(a) Backoff timing** — `TestBackoffTiming`: monkeypatches `lionagi.ln.concurrency.patterns.anyio.sleep` to capture delays; asserts non-zero, strictly increasing delays across repeated `httpx.TimeoutException`/`ConnectError` for both `_call_direct` and `_call_nlip_sdk`.
2. **(b) Raise-on-final-attempt** — `TestRaiseOnFinalAttempt`: after `max_retries` exhausted, asserts the original exception (type + message) propagates out of both call paths.
3. **(c) Narrow exception surface** — `TestNarrowExceptionSurface`: an `httpx.HTTPStatusError` (direct path) and an `NLIP_Message.model_validate` failure (sdk path) each raise immediately — one POST call, zero sleeps.
4. **(d) sdk warning-logging preservation** — `TestRetryLogging`: asserts `logger.warning` fires once per non-final retry on the sdk path (with the exact original message text) and stays silent on the direct path.

Plus a success-after-transient-failure sanity test.

**Old-fails/new-passes check (verified, not just claimed)**: I stashed the `nlip.py` change (keeping only the new test file) and ran the new test file against the *unmodified* code. Result: the two timing tests (`test_call_direct_backoff_delays_increase`, `test_call_nlip_sdk_backoff_delays_increase`) failed with `assert 0 == 3` / `assert 0 == 2` (zero sleep calls captured, confirming the old code truly has no backoff), while the other 7 tests already passed against the old code (since those invariants — narrow exception surface, re-raise, sdk logging — already held before this change). Restored the implementation afterward; all 9 tests pass against the new code.

## Gate results

- `uv run pytest tests/providers/ag2/ -k "nlip or retry" -x` → **19 passed**
- `uv run pytest tests/providers/ag2/test_nlip_retry.py -v` → **9 passed**
- `uv run pytest tests/ -q --maxfail=10000` (full suite, run twice for determinism) → both runs: identical failure set, **97 failed + 36 errored** out of **10243** collected tests, remainder (~10110) passing. All failures are pre-existing optional-dependency/env gaps unrelated to this change: missing `fastapi` (studio/schedule CLI tests), `pandas` (DataFrame adapters, log dump-to-csv/json, `to_df`), `asyncpg`/`pydapter` (postgres backend tests), `xmltodict`, `ollama`, `docling`, missing `ast-grep` binary, and one MCP-wrapper test group. **Zero failures reference nlip, retry, resilience, or ag2** — confirmed by grepping the failure list. (Note: this pytest+xdist config doesn't print its own final "N passed" tally line in this environment for unrelated reasons; I derived the counts by diffing against `--collect-only` totals across two independent full runs with byte-identical failure sets.)
- `uv run ruff check lionagi/providers/ag2/nlip.py tests/providers/ag2/test_nlip_retry.py` → **All checks passed**
- `uv run ruff format --check` on both touched files → **already formatted**
- No `X|Y` unions were needed (no new isinstance checks added). All docstrings are one-liners, matching the file's existing style. No internal audit/PR/issue references in source.

## Test plan

- [x] Targeted nlip/retry tests pass (19/19)
- [x] New test file passes standalone (9/9)
- [x] Full suite run twice, deterministic failure set, none touching nlip/retry/ag2
- [x] ruff check + format clean on touched files
- [x] Old-code-fails / new-code-passes verified empirically for the timing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
