### PR TITLE
fix(reactive): list valid roles/modes on Pattern.load error + reliable reactive-spawn example

### DIFF
--- a/examples/orchestration_flow.py
+++ b/examples/orchestration_flow.py
@@ -8,6 +8,10 @@ nodes into the running DAG).
 Requires a codex CLI installation and API access.
 
     uv run python examples/orchestration_flow.py
+
+Production users: don't drive this reactive substrate directly — use
+lionagi/engines/ instead, which adds an agent budget cap, a deadline, and a
+quality gate before allowing expansion.
 """
 
 from __future__ import annotations

--- a/examples/reactive_spawn.py
+++ b/examples/reactive_spawn.py
@@ -1,0 +1,118 @@
+"""Reactive spawn — one role injects a new node into a running flow.
+
+Minimal demonstration of self-expanding orchestration: a single "auditor"
+node executes, and mid-review it emits a SpawnRequest asking a "researcher"
+role to independently investigate an out-of-scope concern it noticed. The
+flow engine injects that request as a new node into the still-running DAG —
+`spawned_operations` in the result comes back >= 1.
+
+The task instruction below deliberately narrows the auditor's normal review
+scope and then explicitly directs it to use its granted spawn capability for
+the adjacent concern. This nudge is what makes the spawn fire reliably with
+a live model — a generic "look around and spawn if you feel like it" task
+does not reliably trigger one (see orchestration_flow.py, which shows the
+general multi-role DAG pattern but is not written to force a spawn).
+
+Requires a codex CLI installation and API access.
+
+    uv run python examples/reactive_spawn.py
+
+Production users: don't drive the reactive substrate directly like this —
+use lionagi/engines/ (Engine class), which wraps it with an agent budget
+cap, a wall-clock deadline, and a JudgeVerdict quality gate before allowing
+expansion.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from lionagi.agent import AgentSpec
+from lionagi.casts.emission import SpawnRequest
+from lionagi.operations.node import create_operation
+from lionagi.orchestration import role_node_builder, spawn_roles
+from lionagi.protocols.graph.graph import Graph
+from lionagi.service.imodel import iModel
+from lionagi.session.branch import Branch
+from lionagi.session.session import Session
+
+logging.basicConfig(level=logging.WARNING)
+
+MODEL = "codex"
+
+# Narrow the auditor's normal scope, then explicitly direct it to spawn for
+# the adjacent concern via its granted capability — this is what makes the
+# spawn fire reliably.
+INSTRUCTION = """\
+Review lionagi/hooks/bus.py ONLY for the StopHook short-circuit correctness in
+blocking_emit (does break vs return change observable behavior?). That is the
+ENTIRE scope of this review -- do not investigate anything else yourself.
+
+However, while reading the file you will also notice lionagi/session/branch.py
+is imported/related and may have its own issues worth a second look -- that is
+explicitly OUT OF SCOPE for you. Per your granted capability, emit a
+spawn_request JSON block asking the 'researcher' role to independently
+investigate lionagi/session/branch.py's emit()/_schedule_emit() path for
+correctness, with independent=true. Do this in addition to your normal review
+of bus.py -- do not skip the spawn just because you narrated the concern in
+prose.
+"""
+
+
+async def main():
+    # ── Build model + session ────────────────────────────────────────────
+    chat_model = iModel(
+        provider="codex",
+        model="gpt-5.3-codex-spark",
+        api_key="dummy",
+        full_auto=True,
+        skip_git_repo_check=True,
+        reasoning_effort="medium",
+    )
+    session = Session()
+    orc = Branch(chat_model=chat_model)
+    session.include_branches(orc)
+    session.default_branch = orc
+    print(f"Session {str(session.id)[:8]}")
+
+    # ── Compose roles; only the auditor is granted spawn capability ───────
+    roles = await spawn_roles(
+        session,
+        {
+            "auditor": AgentSpec.compose("auditor", model=MODEL, yolo=True),
+            "researcher": AgentSpec.compose("researcher", model=MODEL, yolo=True),
+        },
+        spawners={"auditor"},
+    )
+    print(f"Roles: {list(roles.keys())}")
+
+    # ── Single-node graph — the second node is injected reactively ────────
+    graph = Graph()
+    node = create_operation("operate", parameters={"instruction": INSTRUCTION})
+    node.branch_id = roles["auditor"].id
+    graph.add_node(node)
+
+    print("Executing single-node reactive flow...")
+    results = await session.flow(
+        graph,
+        reactive=True,
+        spawn_type=SpawnRequest,
+        node_builder=role_node_builder(roles),
+        max_spawn=5,
+        max_concurrent=3,
+    )
+
+    # ── Results ──────────────────────────────────────────────────────────
+    op_results = results.get("operation_results", {})
+    spawned = results.get("spawned_operations", 0)
+    print(f"\nCompleted: {len(op_results)} results, {spawned} reactive spawns")
+    print("=" * 70)
+    for nid, res in op_results.items():
+        text = str(res)[:400].replace("\n", " ")
+        print(f"\n  [{str(nid)[:8]}] {text}")
+    print("\n" + "=" * 70)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/lionagi/casts/pattern.py
+++ b/lionagi/casts/pattern.py
@@ -99,7 +99,7 @@ class Mode(Pattern):
         """Load a built-in mode by canonical name."""
         obj = _load_builtin(_MODES_PKG, name, "MODE")
         if obj is None:
-            raise ValueError(f"Unknown mode: {name!r}")
+            raise ValueError(f"Unknown mode: {name!r}. Available: {', '.join(list_modes())}")
         return obj
 
 
@@ -143,7 +143,7 @@ class Role(Pattern):
         """Load a built-in role by canonical name."""
         obj = _load_builtin(_ROLES_PKG, name, "ROLE")
         if obj is None:
-            raise ValueError(f"Unknown role: {name!r}")
+            raise ValueError(f"Unknown role: {name!r}. Available: {', '.join(list_roles())}")
         return obj
 
 

--- a/lionagi/casts/pattern.py
+++ b/lionagi/casts/pattern.py
@@ -99,7 +99,7 @@ class Mode(Pattern):
         """Load a built-in mode by canonical name."""
         obj = _load_builtin(_MODES_PKG, name, "MODE")
         if obj is None:
-            raise ValueError(f"Unknown mode: {name!r}. Available: {', '.join(list_modes())}")
+            raise ValueError(f"Unknown mode: {name!r}. Available: {_available_names(list_modes)}")
         return obj
 
 
@@ -143,8 +143,16 @@ class Role(Pattern):
         """Load a built-in role by canonical name."""
         obj = _load_builtin(_ROLES_PKG, name, "ROLE")
         if obj is None:
-            raise ValueError(f"Unknown role: {name!r}. Available: {', '.join(list_roles())}")
+            raise ValueError(f"Unknown role: {name!r}. Available: {_available_names(list_roles)}")
         return obj
+
+
+def _available_names(lister) -> str:
+    """Best-effort catalog for an error hint; a broken built-in never masks the original ValueError."""
+    try:
+        return ", ".join(lister())
+    except Exception:
+        return "<unavailable>"
 
 
 def list_roles() -> list[str]:


### PR DESCRIPTION
## Reactive DX — surface valid roles/modes on load error + a reliable reactive-spawn example

The DX half of the reactive-flow dogfood disposition (Leo-approved; PR-A `fix/reactive-dropped-spawns` is the spec-gated observability half). Three gaps found while live-dogfooding reactive flow:

**gap-4 — `Pattern.load` errors now list valid options.** `Role.load` / `Mode.load` raised `Unknown role: 'x'` with no hint, though `list_roles()`/`list_modes()` sit a few lines below. Both now append `. Available: <names>`. Existing tests use `pytest.raises(match="Unknown role")` (substring) so no test edits needed.

**gap-2 — a shipped example that reliably demonstrates reactive spawning.** The only reactive example (`orchestration_flow.py`) is a generic multi-role DAG that does not reliably trigger a spawn (a live run got `spawned_operations=0` — the roles had no reason to expand). New `examples/reactive_spawn.py` is derived from the analyst's probe that was verified live (`spawned_operations=1`, a `researcher` node injected mid-flow): a single auditor node, narrowed scope, explicitly directed to emit a `SpawnRequest` for an adjacent concern. The spawn-triggering core (instruction + `spawners={"auditor"}` + flow params) is preserved verbatim from the verified probe.

**gap-5 — point production users to the safe front door.** Both the new example and `orchestration_flow.py` now note that `lionagi/engines/` (budget cap + deadline + `JudgeVerdict` gate) is the intended production wrapper over the raw reactive substrate.

### Verification
- `uv run pytest tests/ -k 'role or pattern or cast'`: 421 passed, 40 skipped (studio extra), 0 failed.
- `uv run pytest tests/casts/`: 133 passed.
- Error messages confirmed live (`Role.load('nope')` → lists 39 roles; `Mode.load('nope')` → 13 modes).
- ruff check + format clean; example not run in CI (needs live codex, like `orchestration_flow.py`).

Files: `lionagi/casts/pattern.py` (+2/-2), `examples/orchestration_flow.py` (+4), `examples/reactive_spawn.py` (new, 118 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
