### PR TITLE
feat(reactive): surface dropped spawns in flow result for observability

### DIFF
--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -638,6 +638,7 @@ class ReactiveExecutor(DependencyAwareExecutor):
         self.node_builder = node_builder
         self.max_spawn = max_spawn
         self._spawn_count = 0
+        self._dropped_spawns: list[dict[str, Any]] = []
         self._running = False
         self._tg: Any = None
         self._graph_lock = threading.Lock()
@@ -686,6 +687,7 @@ class ReactiveExecutor(DependencyAwareExecutor):
             "skipped_operations": list(self.skipped_operations),
             "spawned_operations": self._spawn_count,
             "escalated_operations": list(self._escalated_ids),
+            "dropped_spawns": self._dropped_spawns,
         }
         self._validate_execution_results(result)
         return result
@@ -840,8 +842,21 @@ class ReactiveExecutor(DependencyAwareExecutor):
         except Exception:  # noqa: BLE001, S110
             pass  # best-effort; never break the escalation path
 
+    def _record_dropped_spawn(
+        self, reason: str, *, assignee: Any, emitter_id: Any, **extra: Any
+    ) -> None:
+        entry: dict[str, Any] = {"reason": reason, "assignee": assignee, "emitter_id": emitter_id}
+        entry.update(extra)
+        self._dropped_spawns.append(entry)
+
     def _inject_request(self, req: Any, *, emitter: Operation | None) -> bool:
+        emitter_id = emitter.id if emitter is not None else None
+        assignee = getattr(req, "assignee", None)
         if id(req) in self._seen_reqs:
+            # The same req surfaced twice (bus emission + post-completion result
+            # scan can both see it) — a de-dup, not a spawn failure; the first
+            # sighting already ran.
+            self._record_dropped_spawn("duplicate", assignee=assignee, emitter_id=emitter_id)
             return False
         self._seen_reqs.add(id(req))
         builder = self.node_builder or _default_node_builder
@@ -849,10 +864,13 @@ class ReactiveExecutor(DependencyAwareExecutor):
             child = builder(req, emitter)
         except Exception as e:
             logger.warning("spawn node_builder failed: %s", e)
+            self._record_dropped_spawn(
+                "builder_error", assignee=assignee, emitter_id=emitter_id, error=str(e)[:500]
+            )
             return False
         if child is None:
+            self._record_dropped_spawn("null_child", assignee=assignee, emitter_id=emitter_id)
             return False
-        emitter_id = emitter.id if emitter is not None else None
         if self._accept_node(
             child, emitter_id=emitter_id, independent=getattr(req, "independent", False)
         ):
@@ -891,6 +909,12 @@ class ReactiveExecutor(DependencyAwareExecutor):
                     self.max_spawn,
                     str(child.id)[:8],
                 )
+                self._record_dropped_spawn(
+                    "max_spawn_exceeded",
+                    assignee=child.metadata.get("assignee"),
+                    emitter_id=emitter_id,
+                    op_id=str(child.id),
+                )
                 return False
 
             newly_added = self.graph.internal_nodes.get(child.id, None) is None
@@ -910,6 +934,12 @@ class ReactiveExecutor(DependencyAwareExecutor):
                     self.graph.remove_node(child.id)
                     self.completion_events.pop(child.id, None)
                 logger.warning("rejected spawn %s: would create a cycle", str(child.id)[:8])
+                self._record_dropped_spawn(
+                    "cycle",
+                    assignee=child.metadata.get("assignee"),
+                    emitter_id=emitter_id,
+                    op_id=str(child.id),
+                )
                 return False
 
             self._spawn_count += 1
@@ -995,7 +1025,15 @@ async def flow(
     max_spawn: int = 50,
     executor_ref: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Execute a graph with dependency management and optional reactive self-expansion."""
+    """Execute a graph with dependency management and optional reactive self-expansion.
+
+    Returns ``{completed_operations, operation_results, final_context,
+    skipped_operations}`` always; with ``reactive=True`` also
+    ``spawned_operations`` (successful-spawn count), ``escalated_operations``
+    (emitter ids), and ``dropped_spawns`` (rejected spawn/inject attempts as
+    ``{reason, assignee, emitter_id, ...}``; reasons: builder_error,
+    null_child, cycle, max_spawn_exceeded, duplicate).
+    """
 
     if not parallel:
         max_concurrent = 1

--- a/tests/operations/test_reactive_flow.py
+++ b/tests/operations/test_reactive_flow.py
@@ -114,6 +114,8 @@ async def test_spawn_cap_enforced():
     dropped = [d for d in result["dropped_spawns"] if d["reason"] == "max_spawn_exceeded"]
     assert len(dropped) == 1
     assert dropped[0]["op_id"]  # the rejected child's id is traceable
+    # pin the exact entry shape so a regression dropping/adding a key is caught
+    assert set(dropped[0]) == {"reason", "assignee", "emitter_id", "op_id"}
 
 
 @pytest.mark.asyncio
@@ -185,6 +187,7 @@ def test_cycle_injection_rejected():
     dropped = [d for d in executor._dropped_spawns if d["reason"] == "cycle"]
     assert len(dropped) == 1
     assert dropped[0]["op_id"] == str(a.id)
+    assert set(dropped[0]) == {"reason", "assignee", "emitter_id", "op_id"}
 
 
 def test_builder_error_recorded_as_dropped_spawn():
@@ -252,6 +255,7 @@ def test_duplicate_request_recorded_as_dropped_spawn():
     dropped = [d for d in executor._dropped_spawns if d["reason"] == "duplicate"]
     assert len(dropped) == 1
     assert "op_id" not in dropped[0]  # dropped before a child was built
+    assert set(dropped[0]) == {"reason", "assignee", "emitter_id"}
 
 
 @pytest.mark.asyncio

--- a/tests/operations/test_reactive_flow.py
+++ b/tests/operations/test_reactive_flow.py
@@ -60,6 +60,7 @@ async def test_spawn_injects_node_into_running_graph():
     assert "spawner" in executed
     assert "follow_up" in executed  # injected node actually ran
     assert result["spawned_operations"] == 1
+    assert result["dropped_spawns"] == []
     # both the original and injected op are in the results
     assert len(result["completed_operations"]) == 2
 
@@ -110,6 +111,9 @@ async def test_spawn_cap_enforced():
 
     # exactly the cap is honored — 1 initial + 5 injected, then refused
     assert result["spawned_operations"] == 5
+    dropped = [d for d in result["dropped_spawns"] if d["reason"] == "max_spawn_exceeded"]
+    assert len(dropped) == 1
+    assert dropped[0]["op_id"]  # the rejected child's id is traceable
 
 
 @pytest.mark.asyncio
@@ -177,6 +181,77 @@ def test_cycle_injection_rejected():
     # inject existing node `a` after `b` => edge b -> a, closing a<->b cycle
     assert executor.inject(a, after=b, independent=False) is False
     assert graph.is_acyclic()  # graph left clean (edge reverted)
+
+    dropped = [d for d in executor._dropped_spawns if d["reason"] == "cycle"]
+    assert len(dropped) == 1
+    assert dropped[0]["op_id"] == str(a.id)
+
+
+def test_builder_error_recorded_as_dropped_spawn():
+    """A node_builder exception is recorded with reason + error, not just logged."""
+    from lionagi.operations.flow import ReactiveExecutor
+    from lionagi.protocols.graph.graph import Graph
+
+    def raising_builder(req: SpawnRequest, emitter: Operation) -> Operation:
+        raise ValueError("unknown assignee: ghost")
+
+    session = _session_with_ops()
+    executor = ReactiveExecutor(session, Graph(), node_builder=raising_builder)
+    req = SpawnRequest(instruction="x", assignee="ghost")
+
+    assert executor._inject_request(req, emitter=None) is False
+    assert executor._dropped_spawns == [
+        {
+            "reason": "builder_error",
+            "assignee": "ghost",
+            "emitter_id": None,
+            "error": "unknown assignee: ghost",
+        }
+    ]
+
+
+def test_null_child_recorded_as_dropped_spawn():
+    """A node_builder returning None is recorded, no op_id (no child was built)."""
+    from lionagi.operations.flow import ReactiveExecutor
+    from lionagi.protocols.graph.graph import Graph
+
+    def none_builder(req: SpawnRequest, emitter: Operation) -> Operation | None:
+        return None
+
+    session = _session_with_ops()
+    executor = ReactiveExecutor(session, Graph(), node_builder=none_builder)
+    req = SpawnRequest(instruction="x")
+
+    assert executor._inject_request(req, emitter=None) is False
+    assert executor._dropped_spawns == [
+        {"reason": "null_child", "assignee": None, "emitter_id": None}
+    ]
+
+
+def test_duplicate_request_recorded_as_dropped_spawn():
+    """The same SpawnRequest object seen twice: first succeeds, second is a de-dup."""
+    from lionagi.operations.flow import ReactiveExecutor
+    from lionagi.protocols.graph.graph import Graph
+
+    class _DummyTG:
+        def start_soon(self, *a, **k):
+            pass
+
+    def node_builder(req: SpawnRequest, emitter: Operation) -> Operation:
+        return create_operation("op", parameters={})
+
+    session = _session_with_ops()
+    executor = ReactiveExecutor(session, Graph(), node_builder=node_builder)
+    executor._running = True
+    executor._tg = _DummyTG()
+    req = SpawnRequest(instruction="x", independent=True)
+
+    assert executor._inject_request(req, emitter=None) is True
+    assert executor._inject_request(req, emitter=None) is False  # same object: duplicate
+
+    dropped = [d for d in executor._dropped_spawns if d["reason"] == "duplicate"]
+    assert len(dropped) == 1
+    assert "op_id" not in dropped[0]  # dropped before a child was built
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Reactive observability — surface silently-dropped spawns in the flow result

The observability half of the reactive-flow dogfood disposition (Leo spec-gated). During a live dogfood, reactive `SpawnRequest` rejections were found to vanish silently: `ReactiveExecutor` only `logger.warning`s on a rejected spawn, and `spawned_operations` (the success count) under-counts with zero caller-visible trace of *why* a spawn didn't happen.

**gap-1 — new `dropped_spawns` key (additive, back-compat).** `ReactiveExecutor` now collects each rejected spawn/inject into `self._dropped_spawns`, surfaced as a new `dropped_spawns` list in the flow result alongside the untouched `spawned_operations`/`escalated_operations`. Each entry is `{reason, assignee, emitter_id, ...}` with `reason ∈ {builder_error, null_child, cycle, max_spawn_exceeded, duplicate}`:
- `builder_error` also carries `error` (the exception string, truncated to 500 chars).
- `cycle` and `max_spawn_exceeded` also carry `op_id` (the built child's id, for log correlation).
- `duplicate` and `null_child` carry no `op_id` — they fire before a child exists.

**gap-3 — return-contract docstring.** `flow()` now documents every result key including the new one.

### Two notes for the gate (flagged, not defects)
1. **`duplicate` semantics.** A `duplicate` entry means the *same* `SpawnRequest` object was seen twice (event-bus emission + post-completion result-scan both observe it). The first sighting already injected successfully — `duplicate` records a de-dup, not a spawn failure, and has no `op_id` (it fires before a child is built). This is the additive-shape adjustment you approved.
2. **`_accept_node` is a shared chokepoint.** `cycle`/`max_spawn_exceeded` are recorded inside `_accept_node` (the one place holding the built `child`), which is also called by `_schedule_escalation` and the public `inject()`. So `dropped_spawns` will capture escalation-respawn and manual-inject rejections under those two reasons too, not exclusively reactive `SpawnRequest` spawns. This is the spec-literal choice and arguably more complete (a full rejected-injection ledger); confirm it's the intended scope.

### Verification
- `tests/operations/test_reactive_flow.py`: 12 passed (3 new deterministic tests for builder_error/null_child/duplicate + new assertions on the cycle, max_spawn, and happy paths). Re-run independently against this branch's code: 12 passed.
- No LLM in any new test. `spawned_operations` unchanged (still success count). `inject()`-while-not-running warning left untouched (fires outside a run, cannot land in a result).
- ruff check + format clean.

Files: `lionagi/operations/flow.py` (+42/-2), `tests/operations/test_reactive_flow.py` (+75).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
