### PR TITLE
ci: deploy Lion Studio to Vercel on release when the studio changed

### DIFF
--- a/.github/workflows/studio-vercel-deploy.yml
+++ b/.github/workflows/studio-vercel-deploy.yml
@@ -1,0 +1,85 @@
+name: Deploy Lion Studio (Vercel)
+
+# Redeploys the Lion Studio frontend (apps/studio/frontend) to Vercel production
+# when a version is released AND the studio changed since the previous release.
+# Kept separate from release.yml so it never touches the PyPI/Docker publish jobs.
+# Also fireable on demand from the Actions tab (workflow_dispatch), which deploys
+# unconditionally — the manual escape hatch for an out-of-band studio deploy.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: studio-vercel-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # tags + full history needed to diff the studio across releases
+
+      - name: Decide whether to deploy
+        id: decide
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "Manual dispatch — deploying Lion Studio unconditionally."
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          current="${GITHUB_REF_NAME}"
+          previous="$(git tag --sort=-v:refname | grep -v "^${current}$" | head -n1 || true)"
+          if [ -z "$previous" ]; then
+            echo "No previous release tag — deploying Lion Studio (first release-time deploy)."
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+          elif git diff --quiet "$previous" "$current" -- apps/studio/frontend; then
+            echo "Lion Studio unchanged between $previous and $current — nothing to deploy."
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Lion Studio changed between $previous and $current — deploying to Vercel."
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check Vercel credentials
+        id: creds
+        if: steps.decide.outputs.deploy == 'true'
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          if [ -z "$VERCEL_TOKEN" ]; then
+            echo "::warning::VERCEL_TOKEN is not set — skipping the Lion Studio Vercel deploy. Provision VERCEL_TOKEN, VERCEL_ORG_ID and VERCEL_PROJECT_ID as repository secrets to enable it."
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Node
+        if: steps.creds.outputs.ready == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Deploy to Vercel (production)
+        if: steps.creds.outputs.ready == 'true'
+        working-directory: apps/studio/frontend
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          npm install --global vercel@latest
+          vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
+          vercel build --prod --token="$VERCEL_TOKEN"
+          url="$(vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN")"
+          echo "Deployed Lion Studio: $url"
+          {
+            echo "### Lion Studio deployed to Vercel :rocket:"
+            echo "$url"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What

On **version release**, if the **Lion Studio** frontend changed since the previous release, redeploy it to **Vercel production**. Requested by Ocean.

New standalone workflow `.github/workflows/studio-vercel-deploy.yml`:

- **Trigger:** `release: published` (same event as the PyPI/Docker release) + `workflow_dispatch` for on-demand manual deploys.
- **Change detection:** on a release, diffs `apps/studio/frontend` between the previous release tag and the current one (`git diff --quiet <prev-tag> <cur-tag> -- apps/studio/frontend`). No change → skips. First-ever release / no prior tag → deploys. Manual dispatch → always deploys.
- **Deploy:** Vercel CLI `pull → build → deploy --prebuilt --prod` from `apps/studio/frontend` (which already has its own `vercel.json`).

## Why a separate file (not a job in `release.yml`)

Adding `workflow_dispatch` to `release.yml` would let a manual run re-fire the **PyPI publish** and Docker jobs (they key off the tag). Isolating the studio deploy keeps the critical release pipeline untouched.

## Safe to merge before secrets exist

If `VERCEL_TOKEN` is unset, the deploy step emits a `::warning::` and **skips** — merging this never breaks a release and never deploys prematurely.

## Enabling it (the one dependency)

Needs three repo secrets, which tie into the **#1713** `lion-studio.khive.ai` Vercel hosting lane (now unblocked — domain added, Pro account):

- `VERCEL_TOKEN`
- `VERCEL_ORG_ID`
- `VERCEL_PROJECT_ID`

Once those are set, `workflow_dispatch` can also serve as the button for an out-of-band production deploy.

**Not auto-merged** — release-pipeline-adjacent + public repo, Ocean-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)