### PR TITLE
feat(engines): EngineResult + budget-degrade contract (ADR-0096 Fork A + C)

### DIFF
--- a/lionagi/engines/__init__.py
+++ b/lionagi/engines/__init__.py
@@ -22,6 +22,7 @@ from .engine import (
     Engine,
     EngineBudgetError,
     EngineEvent,
+    EngineResult,
     EngineRun,
     JudgeVerdict,
 )
@@ -61,6 +62,7 @@ __all__ = (
     "ChainRun",
     "EngineEvent",
     "EngineBudgetError",
+    "EngineResult",
     "JudgeVerdict",
     # planning (Planned-DAG shape — li o flow as an engine)
     "PlanningEngine",

--- a/lionagi/engines/engine.py
+++ b/lionagi/engines/engine.py
@@ -17,6 +17,11 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from lionagi.agent import AgentSpec, create_agent
 from lionagi.ln.concurrency import Semaphore, gather
+from lionagi.ln.concurrency._compat import (
+    ExceptionGroup,
+    get_exception_group_exceptions,
+    is_exception_group,
+)
 from lionagi.ln.types import TypeFilter
 from lionagi.session.session import Session
 from lionagi.session.signal import NodeCompleted, NodeFailed, NodeQueued, NodeStarted, Signal
@@ -400,14 +405,20 @@ class EngineRun:
             self._run_task.cancel()
 
     async def wait_quiescence(self) -> None:
-        """Block until all spawned tasks settle; re-raise any non-cancellation failures."""
+        """Block until all spawned tasks settle; re-raise any non-cancellation, non-budget failures.
+
+        A spawned task hitting EngineBudgetError is a benign "expansion
+        stopped" signal (discretionary work declined, not a crash) — the same
+        grace already given to asyncio.CancelledError here.
+        """
         task_errors: list[BaseException] = []
         while self._active:
             results = await gather(*list(self._active), return_exceptions=True)
             task_errors.extend(
                 r
                 for r in results
-                if isinstance(r, BaseException) and not isinstance(r, asyncio.CancelledError)
+                if isinstance(r, BaseException)
+                and not isinstance(r, asyncio.CancelledError | EngineBudgetError)
             )
         if task_errors:
             for exc in task_errors:
@@ -590,6 +601,45 @@ class ChainRun(EngineRun):
         return self.store.get(event_type, [])
 
 
+class EngineResult(str):
+    """Return type of Engine.run(): a str (back-compat) carrying the run's structured outcome.
+
+    ``str(result)`` and ``result.text`` are the same synthesized text. ``.run``
+    is a live EngineRun handle — do not retain it past reading the result, it
+    keeps the whole Session (and its branches) alive.
+    """
+
+    text: str
+    skipped: list[str]
+    degraded: bool
+    degrade_reason: str
+    run: EngineRun
+    _events_by_type: Callable[[type], list[Any]]
+
+    def __new__(
+        cls,
+        text: str,
+        *,
+        events_by_type: Callable[[type], list[Any]],
+        skipped: list[str],
+        degraded: bool,
+        run: EngineRun,
+        degrade_reason: str = "",
+    ) -> EngineResult:
+        self = super().__new__(cls, text)
+        self.text = str(self)
+        self._events_by_type = events_by_type
+        self.skipped = list(skipped)
+        self.degraded = bool(degraded)
+        self.degrade_reason = degrade_reason
+        self.run = run
+        return self
+
+    def events_by_type(self, event_type: type) -> list[Any]:
+        """Snapshot of the run's stored events matching *event_type*."""
+        return self._events_by_type(event_type)
+
+
 class Engine:
     """Stateless event-driven engine base; subclasses implement ``_run()``. See docs/reference/engines.md for parameter details."""
 
@@ -657,6 +707,61 @@ class Engine:
     ) -> EngineRun:
         return self.run_context_cls(self, session=session, on_event=on_event)
 
+    async def _degrade_export(self, run: EngineRun, args: tuple, kwargs: dict) -> Any:
+        """Cancel in-flight spawned tasks, then run _partial_export shielded + timeout-bounded.
+
+        Shared by the deadline (CancelledError) and root-budget (EngineBudgetError)
+        degrade paths in run(). Returns _UNSET if the export itself failed or
+        timed out (logged, not raised) — CancelledError from an external cancel
+        during the shielded phase still propagates.
+        """
+        # Cancel any background tasks spawned via run.spawn() so synthesis
+        # sees a stable snapshot and no work burns tokens past budget
+        # exhaustion.  cancel_active() is a no-op if _active is already empty.
+        if run._active:
+            await run.cancel_active()
+        # Synthesize and export under asyncio.shield so the await runs outside
+        # the cancelled scope.  A hard timeout bounds the phase so a hung
+        # synthesis call cannot extend the run indefinitely.
+        partial_coro = self._partial_export(run, *args, **kwargs)
+        partial_task = asyncio.ensure_future(partial_coro)
+        try:
+            return await asyncio.wait_for(
+                asyncio.shield(partial_task),
+                timeout=_PARTIAL_EXPORT_TIMEOUT_S,
+            )
+        except asyncio.CancelledError:
+            # The caller cancelled Engine.run() while we were in the
+            # partial-export phase.  wait_for converts its own internal
+            # timeout into TimeoutError, so a CancelledError here is always
+            # external — clean up partial_task and re-raise so the caller's
+            # cancellation is honoured.
+            if not partial_task.done():
+                partial_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await partial_task
+            raise
+        except (asyncio.TimeoutError, Exception) as exc:
+            logger.warning("partial export after degrade failed: %s", exc)
+            if not partial_task.done():
+                partial_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await partial_task
+            return _UNSET
+
+    def _wrap_result(self, result: Any, run: EngineRun, *, degrade_reason: str) -> Any:
+        """Wrap a str _run()/_partial_export() result into EngineResult; pass through anything else unchanged (e.g. CodingEngine's structured CodeResultRecorded)."""
+        if not isinstance(result, str) or isinstance(result, EngineResult):
+            return result
+        return EngineResult(
+            result,
+            events_by_type=run.by_type,
+            skipped=list(run._emission_failures),
+            degraded=bool(degrade_reason),
+            degrade_reason=degrade_reason,
+            run=run,
+        )
+
     async def run(
         self,
         *args: Any,
@@ -677,9 +782,17 @@ class Engine:
         # spawned background tasks, but also sequential awaits inside _run().
         run_task = asyncio.ensure_future(self._run(run, *args, **kwargs))
         run._run_task = run_task
+        result: Any = _UNSET
         partial_result: Any = _UNSET
+        degrade_reason: str = ""
         try:
-            return await run_task
+            result = await run_task
+            # R5: a run that reached the success path may still have silently
+            # dropped a discretionary budget-capped subtree (wait_quiescence
+            # filters EngineBudgetError out of task_errors) — flag it rather
+            # than returning a clean-looking result that hides the truncation.
+            if run._budget_notified:
+                degrade_reason = "budget"
         except asyncio.CancelledError:
             # Distinguish internal cancellation (engine's own deadline/budget
             # watchdog) from external cancellation (the caller cancelled run()).
@@ -696,44 +809,26 @@ class Engine:
                 current is not None and hasattr(current, "cancelling") and current.cancelling() > 0
             )
             if run._budget_notified and not caller_cancelled:
-                # Internal cancellation only.
-                # Step 1: cancel any background tasks spawned via run.spawn()
-                # so synthesis sees a stable snapshot and no work burns tokens
-                # past budget exhaustion.  cancel_active() is a no-op if
-                # _active is already empty (idempotent).
-                if run._active:
-                    await run.cancel_active()
-                # Step 2: synthesize and export under asyncio.shield so the
-                # await runs outside the cancelled scope.  A hard timeout
-                # bounds the phase so a hung synthesis call cannot extend the
-                # run indefinitely.
-                partial_coro = self._partial_export(run, *args, **kwargs)
-                partial_task = asyncio.ensure_future(partial_coro)
-                try:
-                    partial_result = await asyncio.wait_for(
-                        asyncio.shield(partial_task),
-                        timeout=_PARTIAL_EXPORT_TIMEOUT_S,
-                    )
-                except asyncio.CancelledError:
-                    # The caller cancelled Engine.run() while we were in the
-                    # partial-export phase.  wait_for converts its own internal
-                    # timeout into TimeoutError, so a CancelledError here is
-                    # always external — clean up partial_task and re-raise so
-                    # the caller's cancellation is honoured.
-                    if not partial_task.done():
-                        partial_task.cancel()
-                        with contextlib.suppress(asyncio.CancelledError, Exception):
-                            await partial_task
-                    raise
-                except (asyncio.TimeoutError, Exception) as exc:
-                    logger.warning("partial export after budget cancellation failed: %s", exc)
-                    if not partial_task.done():
-                        partial_task.cancel()
-                        with contextlib.suppress(asyncio.CancelledError, Exception):
-                            await partial_task
+                # Internal cancellation only — the deadline watchdog is the
+                # only thing that cancels run_task, so this is a deadline hit.
+                degrade_reason = "deadline"
+                partial_result = await self._degrade_export(run, args, kwargs)
             else:
                 # External cancellation — surface it after cleanup (below).
                 raise
+        except (EngineBudgetError, ExceptionGroup) as exc:
+            # A root-level (non-spawned) make_agent() call hit the budget and
+            # raised straight out of _run() — e.g. a review's dimension
+            # fan-out gather, or a sequential plan/implement stage. Route to
+            # partial-export instead of letting it crash the run. Masking
+            # guard: a mixed ExceptionGroup (budget + a real error) must not
+            # be laundered into a partial — re-raise so the real error surfaces.
+            if is_exception_group(exc) and not all(
+                isinstance(e, EngineBudgetError) for e in get_exception_group_exceptions(exc)
+            ):
+                raise
+            degrade_reason = "budget"
+            partial_result = await self._degrade_export(run, args, kwargs)
         finally:
             # Copy per-run emission diagnostics back onto the engine instance so
             # the CLI read site (getattr(engine, "_emission_failures", [])) sees
@@ -775,7 +870,10 @@ class Engine:
                 except Exception:
                     logger.exception("engine active-task drain failed")
         if partial_result is not _UNSET:
-            return partial_result
+            result = partial_result
+        if result is _UNSET:
+            result = None
+        return self._wrap_result(result, run, degrade_reason=degrade_reason)
 
     async def _partial_export(self, run: EngineRun, *args: Any, **kwargs: Any) -> Any:
         """Called under asyncio.shield after budget cancellation; override in subclasses to return a partial result. Default returns None."""

--- a/lionagi/engines/engine.py
+++ b/lionagi/engines/engine.py
@@ -66,6 +66,15 @@ class EngineBudgetError(RuntimeError):
     """The run's hard agent budget is exhausted; no further agents may be made."""
 
 
+def _is_all_budget_error(exc: BaseException) -> bool:
+    """True iff every leaf exception is an EngineBudgetError, recursing into nested groups."""
+    if isinstance(exc, EngineBudgetError):
+        return True
+    if is_exception_group(exc):
+        return all(_is_all_budget_error(e) for e in get_exception_group_exceptions(exc))
+    return False
+
+
 def _event_dict(event: Any) -> dict[str, Any]:
     if hasattr(event, "model_dump"):
         try:
@@ -821,11 +830,10 @@ class Engine:
             # raised straight out of _run() — e.g. a review's dimension
             # fan-out gather, or a sequential plan/implement stage. Route to
             # partial-export instead of letting it crash the run. Masking
-            # guard: a mixed ExceptionGroup (budget + a real error) must not
-            # be laundered into a partial — re-raise so the real error surfaces.
-            if is_exception_group(exc) and not all(
-                isinstance(e, EngineBudgetError) for e in get_exception_group_exceptions(exc)
-            ):
+            # guard: a non-budget leaf anywhere in the group (including
+            # nested groups) must not be laundered into a partial — re-raise
+            # so the real error surfaces.
+            if not _is_all_budget_error(exc):
                 raise
             degrade_reason = "budget"
             partial_result = await self._degrade_export(run, args, kwargs)

--- a/tests/engines/test_engine_result_degradation.py
+++ b/tests/engines/test_engine_result_degradation.py
@@ -1,0 +1,243 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""EngineResult + degradation contract: root/spawned budget errors must degrade, never crash or
+be silently swallowed into a clean-looking result."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from lionagi.engines.engine import Engine, EngineBudgetError, EngineResult
+from lionagi.engines.hypothesis import HypothesisEngine
+from lionagi.engines.planning import PlanningEngine
+from lionagi.engines.research import FindingEmitted, ResearchEngine
+from lionagi.engines.review import IssueFound, ReviewEngine
+from lionagi.ln import gather as ln_gather
+from lionagi.ln.concurrency._compat import get_exception_group_exceptions, is_exception_group
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _finding_factory(name: str) -> FindingEmitted:
+    return FindingEmitted(description=f"finding via {name}", novelty=0.9)
+
+
+def _issue_factory(name: str) -> IssueFound:
+    dimension = name.removeprefix("review-")
+    return IssueFound(dimension=dimension, description=f"issue via {name}")
+
+
+class _FakeBranch:
+    """Stand-in for a real agent Branch: no network, but emits a real event
+    (except for the terminal "synthesizer"/"verdict" stage) so the run
+    collects genuine structured events before degrading."""
+
+    def __init__(self, run: Any, name: str, emit_factory: Any = _finding_factory) -> None:
+        self.run = run
+        self.name = name
+        self._emit_factory = emit_factory
+
+    async def operate(self, *, instruction: str) -> str:
+        if self.name in ("synthesizer", "verdict"):
+            return f"SYNTHESIS over {len(self.run.by_type(FindingEmitted))} events"
+        await self.run.emit(self._emit_factory(self.name))
+        return "found something"
+
+
+def _budget_gated_make_agent(run: Any, emit_factory: Any = _finding_factory):
+    """A fake EngineRun.make_agent with the exact budget check/raise the real one has, minus networking."""
+
+    async def fake_make_agent(
+        role: str, *, name: str | None = None, exempt: bool = False, **kw: Any
+    ):
+        if not exempt and not run.budget_left():
+            run._notify_budget_once("make_agent")
+            raise EngineBudgetError(
+                f"agent budget exhausted ({run.agents_made}/{run.engine.max_agents})"
+            )
+        run.agents_made += 1
+        return _FakeBranch(run, name=name or role, emit_factory=emit_factory)
+
+    return fake_make_agent
+
+
+# ---------------------------------------------------------------------------
+# 1. Repro FRICTION_LOG run 5a — spawned discretionary expansion crash
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_research_verbose_root_spawn_budget_race_degrades_not_crashes(monkeypatch):
+    """A verbose root turn spawning far more concurrent _explore() teams than
+    the agent budget allows must not crash run() with an ExceptionGroup — the
+    run must degrade and return a non-empty EngineResult."""
+    eng = ResearchEngine(max_agents=10, repair_retries=0)
+    run = eng.new_run()
+    monkeypatch.setattr(run, "make_agent", _budget_gated_make_agent(run))
+    monkeypatch.setattr(eng, "new_run", lambda **kw: run)
+
+    async def fake_run(run_obj: Any, topic: str) -> str:
+        run_obj.root = topic
+        # One exploration completes fully and deterministically first (no
+        # race), guaranteeing real findings exist before the race below.
+        await eng._explore(run_obj, "seed sub-topic", 1)
+        # Then the verbose-root-turn race: 8 more concurrent discretionary
+        # expansions contend for the remaining budget — this is what crashed
+        # the whole run pre-fix (ExceptionGroup of EngineBudgetError raised
+        # out of run.spawn()'d _explore() -> _team_for() -> make_agent()).
+        for i in range(8):
+            run_obj.spawn(eng._explore(run_obj, f"sub-{i}", 1))
+        await run_obj.wait_quiescence()
+        return await eng._synthesize(run_obj, topic)
+
+    monkeypatch.setattr(eng, "_run", fake_run)
+
+    result = await eng.run("root topic")
+
+    assert isinstance(result, EngineResult), f"expected EngineResult, got {type(result)}"
+    assert result.degraded is True
+    assert result.text, "expected non-empty synthesized text"
+    assert result.events_by_type(FindingEmitted), "expected real findings collected before the cap"
+
+
+# ---------------------------------------------------------------------------
+# 2. Repro FRICTION_LOG run 3 — root-level (gathered) raw raise
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_review_root_gather_budget_error_does_not_raise(monkeypatch):
+    """A too-tight max_agents hitting the root dimension fan-out (ln_gather in
+    ReviewEngine._run) must not raise EngineBudgetError to the caller.
+
+    ReviewEngine has no _partial_export override yet (a separate PR gives the
+    base a structured honest-partial default) — the base default still
+    returns None, so the returned value here is None, not a rich EngineResult.
+    What this test guarantees is the crash-stop: no exception, and the run's
+    own degrade signal (_budget_notified) is recorded even though this PR
+    does not yet surface it through the return value for this engine.
+    """
+    eng = ReviewEngine(dimensions=("correctness", "security"), max_agents=1, repair_retries=0)
+    run = eng.new_run()
+    monkeypatch.setattr(
+        run, "make_agent", _budget_gated_make_agent(run, emit_factory=_issue_factory)
+    )
+    monkeypatch.setattr(eng, "new_run", lambda **kw: run)
+
+    result = await eng.run("some artifact text")
+
+    assert result is None, f"expected the base _partial_export default (None), got {result!r}"
+    assert run.agents_made == 1, "only one dimension reviewer should have been made"
+    assert run._budget_notified is True, "the budget-exhaustion signal must still be recorded"
+
+
+# ---------------------------------------------------------------------------
+# 3. Masking guard — a real error in a mixed group must still surface
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_masking_guard_reraises_real_error_in_mixed_group():
+    """A mixed failure (one task raises EngineBudgetError, a sibling raises a
+    genuine error) must not be laundered into a partial result — the real
+    error must still surface from run()."""
+
+    class _MixedFailEngine(Engine):
+        async def _run(self, run: Any, *a: Any, **kw: Any) -> Any:
+            async def budget_side() -> None:
+                raise EngineBudgetError("out of budget")
+
+            async def real_bug() -> None:
+                raise ValueError("genuine bug")
+
+            await ln_gather(budget_side(), real_bug())
+            return "never"  # pragma: no cover
+
+    eng = _MixedFailEngine(max_agents=1)
+    with pytest.raises(BaseException) as exc_info:
+        await eng.run()
+
+    exc = exc_info.value
+    subs = get_exception_group_exceptions(exc) if is_exception_group(exc) else [exc]
+    assert any(isinstance(e, ValueError) for e in subs), (
+        f"the genuine ValueError must surface, got {exc!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. Back-compat: await engine.run(...) stays isinstance(str)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_back_compat_str_contract_across_prose_engines():
+    """isinstance(await engine.run(x), str) and str(result) == result.text.
+
+    Covers the four prose-terminal engines (Planning/Research/Review/
+    Hypothesis). CodingEngine's public run() returns a structured
+    CodeResultRecorded — a pre-existing, untouched contract (its overrides
+    are out of scope here) — so it is intentionally not included in this
+    str-contract check.
+    """
+    cases: list[tuple[Any, tuple[Any, ...]]] = [
+        (PlanningEngine(), ("do the thing",)),
+        (ResearchEngine(), ("a topic",)),
+        (ReviewEngine(), ("some artifact",)),
+        (HypothesisEngine(), ("a finding",)),
+    ]
+    for eng, args in cases:
+
+        async def fake_run(run: Any, *a: Any, **kw: Any) -> str:
+            return "PROSE RESULT"
+
+        eng._run = fake_run  # type: ignore[method-assign]
+        result = await eng.run(*args)
+        assert isinstance(result, str), f"{type(eng).__name__}: expected str, got {type(result)}"
+        assert result == "PROSE RESULT"
+        assert str(result) == result.text
+
+
+# ---------------------------------------------------------------------------
+# 6. R5 — success path after a filtered discretionary budget raise still
+#    flags degraded (anti-silent-truncation guard for edit 1 + edit 3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_r5_success_path_flags_degraded_after_filtered_expansion(monkeypatch):
+    """A run that COMPLETES after wait_quiescence silently filtered a
+    discretionary EngineBudgetError must still report degraded=True,
+    degrade_reason='budget' — edit 1 alone would otherwise turn the crash
+    into a permanent, undetectable silent truncation."""
+    eng = ResearchEngine(max_agents=3, repair_retries=0)
+    run = eng.new_run()
+    monkeypatch.setattr(run, "make_agent", _budget_gated_make_agent(run))
+    monkeypatch.setattr(eng, "new_run", lambda **kw: run)
+
+    async def fake_run(run_obj: Any, topic: str) -> str:
+        run_obj.root = topic
+        # The root team consumes the entire budget (3 agents) with real
+        # findings collected — deterministic, not spawned, so no race.
+        team = await eng._team_for(run_obj, 0)
+        await eng._drive_node(run_obj, team, "explore the root topic")
+        # Discretionary expansion: budget is already exhausted, both must be
+        # filtered as benign "expansion stopped", not crash the run.
+        run_obj.spawn(eng._explore(run_obj, "deeper question one", 1))
+        run_obj.spawn(eng._explore(run_obj, "deeper question two", 1))
+        await run_obj.wait_quiescence()
+        return await eng._synthesize(run_obj, topic)
+
+    monkeypatch.setattr(eng, "_run", fake_run)
+
+    result = await eng.run("root topic")
+
+    assert isinstance(result, EngineResult), f"expected EngineResult, got {type(result)}"
+    assert result.degraded is True
+    assert result.degrade_reason == "budget"
+    assert result.text, "expected non-empty synthesized text"
+    assert not result.skipped or all(isinstance(s, str) for s in result.skipped)

--- a/tests/engines/test_engine_result_degradation.py
+++ b/tests/engines/test_engine_result_degradation.py
@@ -16,7 +16,11 @@ from lionagi.engines.planning import PlanningEngine
 from lionagi.engines.research import FindingEmitted, ResearchEngine
 from lionagi.engines.review import IssueFound, ReviewEngine
 from lionagi.ln import gather as ln_gather
-from lionagi.ln.concurrency._compat import get_exception_group_exceptions, is_exception_group
+from lionagi.ln.concurrency._compat import (
+    ExceptionGroup,
+    get_exception_group_exceptions,
+    is_exception_group,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -166,6 +170,75 @@ async def test_masking_guard_reraises_real_error_in_mixed_group():
     subs = get_exception_group_exceptions(exc) if is_exception_group(exc) else [exc]
     assert any(isinstance(e, ValueError) for e in subs), (
         f"the genuine ValueError must surface, got {exc!r}"
+    )
+
+
+def _leaves(exc: BaseException) -> list[BaseException]:
+    """Flatten an (optionally nested) exception group into its leaf exceptions."""
+    if is_exception_group(exc):
+        out: list[BaseException] = []
+        for e in get_exception_group_exceptions(exc):
+            out.extend(_leaves(e))
+        return out
+    return [exc]
+
+
+@pytest.mark.asyncio
+async def test_masking_guard_degrades_nested_all_budget_group():
+    """A NESTED group whose every leaf is EngineBudgetError (a group inside a
+    group, not just a flat list) must still degrade, not crash — the masking
+    guard's predicate must recurse, not just inspect the top-level children.
+
+    This test engine overrides _partial_export (a test-local fixture, not one
+    of the five shipped engines) purely so the degrade path produces a str
+    and the resulting EngineResult's .degraded/.degrade_reason are directly
+    inspectable, without relying on the internal _budget_notified flag.
+    """
+
+    class _NestedBudgetEngine(Engine):
+        async def _run(self, run: Any, *a: Any, **kw: Any) -> Any:
+            raise ExceptionGroup(
+                "outer", [ExceptionGroup("inner", [EngineBudgetError("out of budget")])]
+            )
+
+        async def _partial_export(self, run: Any, *a: Any, **kw: Any) -> str:
+            return "partial output from nested budget group"
+
+    eng = _NestedBudgetEngine(max_agents=1)
+    result = await eng.run()
+
+    assert isinstance(result, EngineResult), f"expected EngineResult, got {type(result)}"
+    assert result.degraded is True
+    assert result.degrade_reason == "budget"
+    assert result.text == "partial output from nested budget group"
+
+
+@pytest.mark.asyncio
+async def test_masking_guard_reraises_real_error_buried_in_nested_group():
+    """A genuine error buried two levels deep in a nested group (alongside a
+    budget error at the same depth) must still surface — the recursive
+    masking guard must not treat "not top-level EngineBudgetError" as license
+    to swallow it, nor mistake a nested all-budget subgroup for safety when a
+    sibling leaf is real."""
+
+    class _NestedMixedEngine(Engine):
+        async def _run(self, run: Any, *a: Any, **kw: Any) -> Any:
+            raise ExceptionGroup(
+                "outer",
+                [
+                    ExceptionGroup(
+                        "inner", [EngineBudgetError("out of budget"), ValueError("genuine bug")]
+                    )
+                ],
+            )
+
+    eng = _NestedMixedEngine(max_agents=1)
+    with pytest.raises(BaseException) as exc_info:
+        await eng.run()
+
+    leaves = _leaves(exc_info.value)
+    assert any(isinstance(e, ValueError) for e in leaves), (
+        f"the genuine ValueError must surface from the nested group, got {exc_info.value!r}"
     )
 
 


### PR DESCRIPTION
## Summary

Implements ADR-0096 Fork A (all 3 edits) and Fork C (`EngineResult`). Fork B
(base `_partial_export` structured default + the 3 engine overrides + review
dimension mapping) is explicitly **out of scope** — a separate follow-up PR —
and is untouched here.

- **Fork C — `EngineResult(str)`**: a `str` subclass carrying `.text`,
  `.events_by_type(t)` (snapshot of `run.by_type(t)`), `.skipped`,
  `.degraded: bool`, `.degrade_reason: "" | "budget" | "deadline"`, `.run`.
  `Engine.run()` wraps the `_run()`/`_partial_export()` result into
  `EngineResult` at the return boundary **when the value is a `str`**;
  non-str results (base `_partial_export`'s `None` default, and
  `CodingEngine`'s structured `CodeResultRecorded`) pass through unwrapped —
  both are pre-existing, out-of-scope contracts this PR does not touch.
- **Fork A edit 1** (`wait_quiescence`): the error filter now excludes
  `EngineBudgetError` alongside `CancelledError` — a spawned/gathered
  discretionary budget raise (research `_explore`, review `_verify`) is
  benign "expansion stopped", not a crash.
- **Fork A edit 2** (`run()`): a new `except (EngineBudgetError,
  ExceptionGroup)` arm, sibling to the `CancelledError` arm, routes a
  root-level raw budget raise (e.g. review's dimension fan-out, or a
  sequential plan/implement stage) to `_partial_export` instead of letting it
  crash the run. Masking guard: a mixed `ExceptionGroup` containing any
  non-`EngineBudgetError` is re-raised, never laundered into a partial.
- **Fork A edit 3 (R5)**: `run()`'s success-path return now sets
  `degraded=True, degrade_reason="budget"` whenever `run._budget_notified` is
  set — otherwise edit 1's filter would turn a crash into a permanent,
  invisible silent truncation.

## Test plan

- [x] `tests/engines/test_engine_result_degradation.py` (new) — covers ADR
  verify-by tests 1, 2, 3, 5, 6 (test 4 is Fork B, out of scope here):
  repro of FRICTION_LOG run 5a (spawned discretionary budget race degrades,
  not crashes), repro of run 3 (root-gathered budget raise doesn't raise),
  masking-guard (mixed budget+genuine error still surfaces the real error),
  back-compat `isinstance(..., str)` across the four prose engines, and the
  R5 anti-silent-truncation guard.
- [x] Full `tests/engines/` stays green: 198 baseline + 5 new = **203 passed**.
- [x] `ruff check` / `ruff format` clean.
- [x] `pyright` error count unchanged at 14 (pre-existing, none new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>