### PR TITLE
feat(studio): split playbook into its own library kind

### DIFF
--- a/apps/studio/frontend/src/components/library/KindBadge.tsx
+++ b/apps/studio/frontend/src/components/library/KindBadge.tsx
@@ -1,11 +1,19 @@
 import type React from "react";
-import { IconAgent, IconPlaybook, IconSkill, IconPlugin, IconEngine } from "@/components/ui/icons";
+import {
+  IconAgent,
+  IconFanout,
+  IconPlaybook,
+  IconSkill,
+  IconPlugin,
+  IconEngine,
+} from "@/components/ui/icons";
 
-export type LibraryKind = "agent" | "workflow" | "skill" | "plugin" | "engine";
+export type LibraryKind = "agent" | "workflow" | "playbook" | "skill" | "plugin" | "engine";
 
 const KIND_COLORS: Record<LibraryKind, string> = {
   agent: "var(--status-running)",
-  workflow: "var(--accent)",
+  workflow: "#4DBFB4",
+  playbook: "var(--accent)",
   skill: "var(--status-success)",
   plugin: "#9B8AF5",
   engine: "var(--content-muted)",
@@ -13,7 +21,8 @@ const KIND_COLORS: Record<LibraryKind, string> = {
 
 const KIND_ICONS: Record<LibraryKind, React.ComponentType<{ className?: string }>> = {
   agent: IconAgent,
-  workflow: IconPlaybook,
+  workflow: IconFanout,
+  playbook: IconPlaybook,
   skill: IconSkill,
   plugin: IconPlugin,
   engine: IconEngine,

--- a/apps/studio/frontend/src/components/library/PlaybookTemplateDetail.tsx
+++ b/apps/studio/frontend/src/components/library/PlaybookTemplateDetail.tsx
@@ -1,6 +1,6 @@
 /**
  * Detail pane for a built-in playbook template or a user's own installed
- * playbook (the two "workflow" sub-kinds that back the Studio Workflows page
+ * playbook (the two "playbook" sub-kinds that back the Studio Playbooks page
  * per DESIGN-BRIEF §3). Both read from the same declarative shape via
  * rawToDeclarative(); the only difference is which endpoint the raw YAML
  * comes from and whether "Clone to customize" is offered.

--- a/apps/studio/frontend/src/components/library/library.test.ts
+++ b/apps/studio/frontend/src/components/library/library.test.ts
@@ -136,7 +136,7 @@ describe("library URL sel param — encoding scheme", () => {
   // Mirror parseSel and encodeSel inline to validate the contract without importing
   // the route module (which has router side-effects).
 
-  type LibraryKind = "agent" | "workflow" | "skill" | "plugin" | "engine";
+  type LibraryKind = "agent" | "workflow" | "playbook" | "skill" | "plugin" | "engine";
 
   function encodeSel(kind: LibraryKind, name: string): string {
     return `${kind}:${name}`;
@@ -148,7 +148,7 @@ describe("library URL sel param — encoding scheme", () => {
     if (colon === -1) return null;
     const kind = sel.slice(0, colon) as LibraryKind;
     const name = sel.slice(colon + 1);
-    const valid: LibraryKind[] = ["agent", "workflow", "skill", "plugin", "engine"];
+    const valid: LibraryKind[] = ["agent", "workflow", "playbook", "skill", "plugin", "engine"];
     if (!valid.includes(kind) || !name) return null;
     return { kind, name };
   }
@@ -172,7 +172,6 @@ describe("library URL sel param — encoding scheme", () => {
 
   it("returns null for invalid kind", () => {
     expect(parseSel("unknown:foo")).toBeNull();
-    expect(parseSel("playbook:foo")).toBeNull();
   });
 
   it("returns null for empty sel", () => {
@@ -189,16 +188,16 @@ describe("library URL sel param — encoding scheme", () => {
   });
 
   it("all valid kinds parse correctly", () => {
-    const kinds: LibraryKind[] = ["agent", "workflow", "skill", "plugin", "engine"];
+    const kinds: LibraryKind[] = ["agent", "workflow", "playbook", "skill", "plugin", "engine"];
     for (const kind of kinds) {
       const result = parseSel(encodeSel(kind, "test-name"));
       expect(result).toEqual({ kind, name: "test-name" });
     }
   });
 
-  it("workflow: prefix is valid, playbook: is not", () => {
+  it("workflow: and playbook: prefixes are both valid", () => {
     expect(parseSel("workflow:my-flow")).toEqual({ kind: "workflow", name: "my-flow" });
-    expect(parseSel("playbook:my-flow")).toBeNull();
+    expect(parseSel("playbook:my-flow")).toEqual({ kind: "playbook", name: "my-flow" });
   });
 });
 
@@ -234,12 +233,12 @@ describe("routes/library.tsx — TabBar above the split", () => {
 
 // ─── Rename assertions ────────────────────────────────────────────────────────
 
-describe("routes/library.tsx — workflow terminology", () => {
+describe("routes/library.tsx — workflow + playbook terminology", () => {
   const src = fs.readFileSync(path.join(ROUTES_DIR, "library.tsx"), "utf-8");
 
-  it('LIBRARY_TABS contains "workflow" not "playbook"', () => {
+  it('LIBRARY_TABS contains both "workflow" and "playbook"', () => {
     expect(src).toMatch(/"workflow"/);
-    expect(src).not.toMatch(/"playbook"/);
+    expect(src).toMatch(/"playbook"/);
   });
 
   it("imports WorkflowDetail not PlaybookDetail", () => {
@@ -248,24 +247,26 @@ describe("routes/library.tsx — workflow terminology", () => {
   });
 });
 
-describe("components/library/KindBadge.tsx — workflow kind", () => {
+describe("components/library/KindBadge.tsx — workflow + playbook kinds", () => {
   const src = fs.readFileSync(path.join(LIBRARY_DIR, "KindBadge.tsx"), "utf-8");
 
   it('LibraryKind includes "workflow"', () => {
     expect(src).toMatch(/"workflow"/);
   });
 
-  it('LibraryKind does not include "playbook"', () => {
-    expect(src).not.toMatch(/"playbook"/);
+  it('LibraryKind includes "playbook" as its own kind', () => {
+    expect(src).toMatch(/"playbook"/);
   });
 });
 
-// ─── Built-in playbook templates — Workflows page (DESIGN-BRIEF §3) ──────────
+// ─── Built-in playbook templates — Playbooks page (DESIGN-BRIEF §3) ──────────
 //
 // The Workflows page used to render nothing: useLibraryData() never fetched
 // playbooks at all. These tests cover the fix: built-in templates + the
-// user's own playbooks are fetched and surfaced as "workflow" rows split by
-// subKind, with a real detail pane (not a stub) for both.
+// user's own playbooks are fetched and surfaced as "playbook" rows split by
+// subKind, with a real detail pane (not a stub) for both. Playbooks are a
+// distinct top-level kind from "workflow" (graph designs) — they are not a
+// workflow subKind.
 
 describe("routes/library.tsx — built-in + user playbooks are fetched", () => {
   const src = fs.readFileSync(path.join(ROUTES_DIR, "library.tsx"), "utf-8");
@@ -275,19 +276,19 @@ describe("routes/library.tsx — built-in + user playbooks are fetched", () => {
     expect(src).toMatch(/listPlaybooks/);
   });
 
-  it("useLibraryData pushes builtin-subKind and custom-subKind workflow rows", () => {
+  it("useLibraryData pushes builtin-subKind and custom-subKind playbook rows", () => {
     expect(src).toMatch(/subKind:\s*"builtin"/);
     expect(src).toMatch(/subKind:\s*"custom"/);
-    expect(src).toMatch(/subKind:\s*"graph"/);
+    expect(src).toMatch(/kind:\s*"playbook"/);
   });
 
   it("imports PlaybookTemplateDetail for the builtin/custom detail pane", () => {
     expect(src).toMatch(/import\s*\{\s*PlaybookTemplateDetail\s*\}\s*from/);
   });
 
-  it("dispatches builtin/custom subKind to PlaybookTemplateDetail, graph subKind to WorkflowDetail", () => {
-    expect(src).toMatch(/subKind === "graph"[\s\S]{0,80}<WorkflowDetail/);
-    expect(src).toMatch(/<PlaybookTemplateDetail/);
+  it("dispatches playbook kind to PlaybookTemplateDetail, workflow kind to WorkflowDetail", () => {
+    expect(src).toMatch(/parsed\?\.kind === "workflow"[\s\S]{0,80}<WorkflowDetail/);
+    expect(src).toMatch(/parsed\?\.kind === "playbook"[\s\S]{0,80}<PlaybookTemplateDetail/);
   });
 });
 
@@ -336,97 +337,137 @@ describe("PlaybookTemplateDetail — detail pane contract", () => {
   });
 });
 
-// ─── URL sel param — 3-part workflow encoding (builtin/custom/graph) ─────────
+// ─── URL sel param — playbook subKind encoding + workflow back-compat ────────
 
-describe("library URL sel param — workflow subKind encoding", () => {
+describe("library URL sel param — playbook subKind encoding", () => {
   // Mirrors the real parseSel/encodeSel in routes/library.tsx verbatim, same
   // rationale as the plain kind:name block above: validate the contract
-  // without importing the route module (router side-effects).
+  // without importing the route module (router side-effects). "workflow" is
+  // graph-designs-only now (plain kind:name); "playbook" carries the
+  // builtin/custom split, plus backward-compat for pre-split
+  // workflow:<subKind>:<name> bookmarks.
 
-  type LibraryKind = "agent" | "workflow" | "skill" | "plugin" | "engine";
-  type WorkflowSubKind = "builtin" | "custom" | "graph";
-  const WORKFLOW_SUB_KINDS: WorkflowSubKind[] = ["builtin", "custom", "graph"];
+  type LibraryKind = "agent" | "workflow" | "playbook" | "skill" | "plugin" | "engine";
+  type PlaybookSubKind = "builtin" | "custom";
+  const PLAYBOOK_SUB_KINDS: PlaybookSubKind[] = ["builtin", "custom"];
+  const LIBRARY_KINDS: LibraryKind[] = [
+    "agent",
+    "workflow",
+    "playbook",
+    "skill",
+    "plugin",
+    "engine",
+  ];
 
-  function encodeSel(kind: LibraryKind, name: string, subKind?: WorkflowSubKind): string {
-    if (kind === "workflow") {
-      return `workflow:${subKind ?? "graph"}:${name}`;
+  function encodeSel(kind: LibraryKind, name: string, subKind?: PlaybookSubKind): string {
+    if (kind === "playbook") {
+      return `playbook:${subKind ?? "custom"}:${name}`;
     }
     return `${kind}:${name}`;
   }
 
   function parseSel(
     sel: string | undefined,
-  ): { kind: LibraryKind; name: string; subKind?: WorkflowSubKind } | null {
+  ): { kind: LibraryKind; name: string; subKind?: PlaybookSubKind } | null {
     if (!sel) return null;
     const colon = sel.indexOf(":");
     if (colon === -1) return null;
     const kind = sel.slice(0, colon) as LibraryKind;
     const rest = sel.slice(colon + 1);
-    const valid: LibraryKind[] = ["agent", "workflow", "skill", "plugin", "engine"];
-    if (!valid.includes(kind) || !rest) return null;
+    if (!LIBRARY_KINDS.includes(kind) || !rest) return null;
 
-    if (kind === "workflow") {
+    if (kind === "playbook") {
       const colon2 = rest.indexOf(":");
       if (colon2 !== -1) {
         const maybeSubKind = rest.slice(0, colon2);
         const name = rest.slice(colon2 + 1);
-        if (WORKFLOW_SUB_KINDS.includes(maybeSubKind as WorkflowSubKind) && name) {
-          return { kind, name, subKind: maybeSubKind as WorkflowSubKind };
+        if (PLAYBOOK_SUB_KINDS.includes(maybeSubKind as PlaybookSubKind) && name) {
+          return { kind, name, subKind: maybeSubKind as PlaybookSubKind };
         }
       }
-      return { kind, name: rest, subKind: "graph" };
+      return null;
+    }
+
+    if (kind === "workflow") {
+      const colon2 = rest.indexOf(":");
+      if (colon2 !== -1) {
+        const legacySubKind = rest.slice(0, colon2);
+        const name = rest.slice(colon2 + 1);
+        if (legacySubKind === "graph" && name) {
+          return { kind: "workflow", name };
+        }
+        if ((legacySubKind === "builtin" || legacySubKind === "custom") && name) {
+          return { kind: "playbook", name, subKind: legacySubKind };
+        }
+      }
+      return { kind, name: rest };
     }
 
     return { kind, name: rest };
   }
 
-  it("encodes workflow:<subKind>:<name>", () => {
-    expect(encodeSel("workflow", "research", "builtin")).toBe("workflow:builtin:research");
-    expect(encodeSel("workflow", "my-copy", "custom")).toBe("workflow:custom:my-copy");
-    expect(encodeSel("workflow", "review-flow", "graph")).toBe("workflow:graph:review-flow");
+  it("encodes playbook:<subKind>:<name>", () => {
+    expect(encodeSel("playbook", "research", "builtin")).toBe("playbook:builtin:research");
+    expect(encodeSel("playbook", "my-copy", "custom")).toBe("playbook:custom:my-copy");
   });
 
-  it("defaults to graph subKind when none is passed (non-workflow-split call sites)", () => {
-    expect(encodeSel("workflow", "review-flow")).toBe("workflow:graph:review-flow");
+  it("defaults to custom subKind when none is passed", () => {
+    expect(encodeSel("playbook", "my-copy")).toBe("playbook:custom:my-copy");
   });
 
-  it("non-workflow kinds are unaffected by subKind", () => {
+  it("workflow (graph) encodes as plain kind:name, no subKind", () => {
+    expect(encodeSel("workflow", "review-flow")).toBe("workflow:review-flow");
+  });
+
+  it("non-playbook kinds are unaffected by subKind", () => {
     expect(encodeSel("agent", "my-agent")).toBe("agent:my-agent");
   });
 
-  it("parses each subKind round-trip", () => {
-    expect(parseSel("workflow:builtin:research")).toEqual({
+  it("parses each playbook subKind round-trip", () => {
+    expect(parseSel("playbook:builtin:research")).toEqual({
+      kind: "playbook",
+      name: "research",
+      subKind: "builtin",
+    });
+    expect(parseSel("playbook:custom:my-copy")).toEqual({
+      kind: "playbook",
+      name: "my-copy",
+      subKind: "custom",
+    });
+  });
+
+  it("parses workflow:<name> as a plain graph design, no subKind", () => {
+    expect(parseSel("workflow:review-flow")).toEqual({ kind: "workflow", name: "review-flow" });
+  });
+
+  it("backward-compat: pre-split workflow:graph:<name> resolves as workflow", () => {
+    expect(parseSel("workflow:graph:review-flow")).toEqual({
       kind: "workflow",
+      name: "review-flow",
+    });
+  });
+
+  it("backward-compat: pre-split workflow:builtin|custom:<name> resolves as playbook", () => {
+    expect(parseSel("workflow:builtin:research")).toEqual({
+      kind: "playbook",
       name: "research",
       subKind: "builtin",
     });
     expect(parseSel("workflow:custom:my-copy")).toEqual({
-      kind: "workflow",
+      kind: "playbook",
       name: "my-copy",
       subKind: "custom",
     });
-    expect(parseSel("workflow:graph:review-flow")).toEqual({
-      kind: "workflow",
-      name: "review-flow",
-      subKind: "graph",
-    });
   });
 
-  it("backward-compat: pre-split workflow:<name> (no subKind) resolves as graph", () => {
-    expect(parseSel("workflow:review-flow")).toEqual({
-      kind: "workflow",
-      name: "review-flow",
-      subKind: "graph",
-    });
-  });
-
-  it("non-workflow kinds still parse without a subKind field", () => {
+  it("non-playbook kinds still parse without a subKind field", () => {
     expect(parseSel("agent:my-agent")).toEqual({ kind: "agent", name: "my-agent" });
   });
 
-  it("returns null for invalid kind or empty sel", () => {
+  it("returns null for invalid kind, empty sel, or a playbook sel missing subKind", () => {
     expect(parseSel("unknown:foo")).toBeNull();
     expect(parseSel(undefined)).toBeNull();
     expect(parseSel("")).toBeNull();
+    expect(parseSel("playbook:no-subkind")).toBeNull();
   });
 });

--- a/apps/studio/frontend/src/i18n/locales.test.ts
+++ b/apps/studio/frontend/src/i18n/locales.test.ts
@@ -5,8 +5,9 @@
  * - LOCALES/RTL_LOCALES metadata shape (16 codes, ar/ur marked rtl).
  * - applyDocumentLocale flips <html lang>/<html dir> for rtl vs ltr locales.
  * - Every messages/*.json file has the exact same leaf-key set as en.json
- *   (791 leaves: 766 base + 4 Mission Control overview leaves plus
- *   21 library.template.* built-in workflow template keys).
+ *   (792 leaves: 766 base + 4 Mission Control overview leaves + 21
+ *   library.template.* built-in workflow template keys + 1
+ *   library.filterPlaybook key for the split-out Playbook library tab).
  * - Every locale's messages parse under a real ICU translator with no
  *   FORMATTING_ERROR, including the true {count, plural, ...} strings and
  *   the pre-existing bare-{plural} anti-pattern in prunePhantoms.
@@ -194,8 +195,8 @@ describe("applyDocumentLocale — <html lang>/<html dir> wiring", () => {
 });
 
 describe("messages — leaf-key parity across all 16 locales", () => {
-  it("en.json has 791 leaves (766 base + 4 Mission Control overview + 21 library.template.* keys)", () => {
-    expect(EN_LEAVES.size).toBe(791);
+  it("en.json has 792 leaves (766 base + 4 Mission Control overview + 21 library.template.* keys + 1 library.filterPlaybook key)", () => {
+    expect(EN_LEAVES.size).toBe(792);
   });
 
   it.each(LOCALES.map((l) => l.code))(

--- a/apps/studio/frontend/src/messages/ar.json
+++ b/apps/studio/frontend/src/messages/ar.json
@@ -82,6 +82,7 @@
     "filterAll": "الكل",
     "filterAgent": "وكيل",
     "filterWorkflow": "سير عمل",
+    "filterPlaybook": "دليل التشغيل",
     "filterSkill": "مهارة",
     "filterPlugin": "مكوّن إضافي",
     "filterEngine": "محرّك",

--- a/apps/studio/frontend/src/messages/bn.json
+++ b/apps/studio/frontend/src/messages/bn.json
@@ -82,6 +82,7 @@
     "filterAll": "সব",
     "filterAgent": "এজেন্ট",
     "filterWorkflow": "ওয়ার্কফ্লো",
+    "filterPlaybook": "প্লেবুক",
     "filterSkill": "স্কিল",
     "filterPlugin": "প্লাগইন",
     "filterEngine": "ইঞ্জিন",

--- a/apps/studio/frontend/src/messages/de.json
+++ b/apps/studio/frontend/src/messages/de.json
@@ -82,6 +82,7 @@
     "filterAll": "Alle",
     "filterAgent": "Agent",
     "filterWorkflow": "Workflow",
+    "filterPlaybook": "Playbook",
     "filterSkill": "Skill",
     "filterPlugin": "Plugin",
     "filterEngine": "Engine",

--- a/apps/studio/frontend/src/messages/en.json
+++ b/apps/studio/frontend/src/messages/en.json
@@ -82,6 +82,7 @@
     "filterAll": "All",
     "filterAgent": "Agent",
     "filterWorkflow": "Workflow",
+    "filterPlaybook": "Playbook",
     "filterSkill": "Skill",
     "filterPlugin": "Plugin",
     "filterEngine": "Engine",

--- a/apps/studio/frontend/src/messages/es.json
+++ b/apps/studio/frontend/src/messages/es.json
@@ -82,6 +82,7 @@
     "filterAll": "Todo",
     "filterAgent": "Agente",
     "filterWorkflow": "Flujo de trabajo",
+    "filterPlaybook": "Playbook",
     "filterSkill": "Skill",
     "filterPlugin": "Plugin",
     "filterEngine": "Motor",

--- a/apps/studio/frontend/src/messages/fr.json
+++ b/apps/studio/frontend/src/messages/fr.json
@@ -82,6 +82,7 @@
     "filterAll": "Tout",
     "filterAgent": "Agent",
     "filterWorkflow": "Workflow",
+    "filterPlaybook": "Playbook",
     "filterSkill": "Compétence",
     "filterPlugin": "Plugin",
     "filterEngine": "Moteur",

--- a/apps/studio/frontend/src/messages/hi.json
+++ b/apps/studio/frontend/src/messages/hi.json
@@ -82,6 +82,7 @@
     "filterAll": "सभी",
     "filterAgent": "एजेंट",
     "filterWorkflow": "वर्कफ़्लो",
+    "filterPlaybook": "प्लेबुक",
     "filterSkill": "स्किल",
     "filterPlugin": "प्लगइन",
     "filterEngine": "इंजन",

--- a/apps/studio/frontend/src/messages/id.json
+++ b/apps/studio/frontend/src/messages/id.json
@@ -82,6 +82,7 @@
     "filterAll": "Semua",
     "filterAgent": "Agen",
     "filterWorkflow": "Alur kerja",
+    "filterPlaybook": "Playbook",
     "filterSkill": "Skill",
     "filterPlugin": "Plugin",
     "filterEngine": "Mesin",

--- a/apps/studio/frontend/src/messages/ja.json
+++ b/apps/studio/frontend/src/messages/ja.json
@@ -82,6 +82,7 @@
     "filterAll": "すべて",
     "filterAgent": "エージェント",
     "filterWorkflow": "ワークフロー",
+    "filterPlaybook": "プレイブック",
     "filterSkill": "スキル",
     "filterPlugin": "プラグイン",
     "filterEngine": "エンジン",

--- a/apps/studio/frontend/src/messages/ko.json
+++ b/apps/studio/frontend/src/messages/ko.json
@@ -82,6 +82,7 @@
     "filterAll": "전체",
     "filterAgent": "에이전트",
     "filterWorkflow": "워크플로",
+    "filterPlaybook": "플레이북",
     "filterSkill": "스킬",
     "filterPlugin": "플러그인",
     "filterEngine": "엔진",

--- a/apps/studio/frontend/src/messages/pt-BR.json
+++ b/apps/studio/frontend/src/messages/pt-BR.json
@@ -82,6 +82,7 @@
     "filterAll": "Todos",
     "filterAgent": "Agente",
     "filterWorkflow": "Fluxo de trabalho",
+    "filterPlaybook": "Playbook",
     "filterSkill": "Skill",
     "filterPlugin": "Plugin",
     "filterEngine": "Engine",

--- a/apps/studio/frontend/src/messages/ru.json
+++ b/apps/studio/frontend/src/messages/ru.json
@@ -82,6 +82,7 @@
     "filterAll": "Все",
     "filterAgent": "Агент",
     "filterWorkflow": "Рабочий процесс",
+    "filterPlaybook": "Плейбук",
     "filterSkill": "Навык",
     "filterPlugin": "Плагин",
     "filterEngine": "Движок",

--- a/apps/studio/frontend/src/messages/tr.json
+++ b/apps/studio/frontend/src/messages/tr.json
@@ -82,6 +82,7 @@
     "filterAll": "tümü",
     "filterAgent": "ajan",
     "filterWorkflow": "iş akışı",
+    "filterPlaybook": "playbook",
     "filterSkill": "beceri",
     "filterPlugin": "eklenti",
     "filterEngine": "motor",

--- a/apps/studio/frontend/src/messages/ur.json
+++ b/apps/studio/frontend/src/messages/ur.json
@@ -82,6 +82,7 @@
     "filterAll": "سب",
     "filterAgent": "ایجنٹ",
     "filterWorkflow": "ورک فلو",
+    "filterPlaybook": "پلے بک",
     "filterSkill": "سکل",
     "filterPlugin": "پلگ اِن",
     "filterEngine": "انجن",

--- a/apps/studio/frontend/src/messages/vi.json
+++ b/apps/studio/frontend/src/messages/vi.json
@@ -82,6 +82,7 @@
     "filterAll": "tất cả",
     "filterAgent": "tác nhân",
     "filterWorkflow": "quy trình làm việc",
+    "filterPlaybook": "playbook",
     "filterSkill": "kỹ năng",
     "filterPlugin": "plugin",
     "filterEngine": "engine",

--- a/apps/studio/frontend/src/messages/zh.json
+++ b/apps/studio/frontend/src/messages/zh.json
@@ -82,6 +82,7 @@
     "filterAll": "全部",
     "filterAgent": "智能体",
     "filterWorkflow": "工作流",
+    "filterPlaybook": "剧本",
     "filterSkill": "技能",
     "filterPlugin": "插件",
     "filterEngine": "引擎",

--- a/apps/studio/frontend/src/routes/library.tsx
+++ b/apps/studio/frontend/src/routes/library.tsx
@@ -28,7 +28,7 @@ import type { InvocationSummary } from "@/lib/api";
 import type { AgentProfileSummary } from "@/lib/types";
 import type { EngineDef } from "@/lib/api";
 
-const LIBRARY_TABS = ["all", "agent", "workflow", "skill", "plugin", "engine"] as const;
+const LIBRARY_TABS = ["all", "agent", "workflow", "playbook", "skill", "plugin", "engine"] as const;
 type LibraryTab = (typeof LIBRARY_TABS)[number];
 
 export const Route = createFileRoute("/library")({
@@ -43,16 +43,16 @@ export const Route = createFileRoute("/library")({
   component: LibraryPage,
 });
 
-// Sub-partitions of the "workflow" kind: read-only bundled templates, the
-// user's own materialized copies, and DB-backed graph designs (Designer UI).
-// Distinct from LibraryKind (which stays a closed, shared union) so the
-// KindBadge component doesn't need to know about this split.
-type WorkflowSubKind = "builtin" | "custom" | "graph";
+// Sub-partitions of the "playbook" kind: read-only bundled templates vs. the
+// user's own materialized copies. Distinct from LibraryKind (which stays a
+// closed, shared union) so the KindBadge component doesn't need to know
+// about this split.
+type PlaybookSubKind = "builtin" | "custom";
 
 interface LibraryItem {
   key: string;
   kind: LibraryKind;
-  subKind?: WorkflowSubKind;
+  subKind?: PlaybookSubKind;
   name: string;
   description?: string;
   meta?: string;
@@ -96,14 +96,16 @@ function useLibraryData() {
             });
           }
         }
-        // Built-in templates first, then the user's own playbooks, then
-        // DB-backed graph designs — surfacing the shipped templates the
-        // Workflows page was missing entirely (DESIGN-BRIEF §3).
+        // Built-in templates first, then the user's own playbooks — surfacing
+        // the shipped templates the Workflows page was missing entirely
+        // (DESIGN-BRIEF §3). These are agent+prompt templates, not graphs, so
+        // they live under the "playbook" kind, separate from "workflow"
+        // (DB-backed graph designs, Designer UI).
         if (builtinsRes.status === "fulfilled") {
           for (const p of builtinsRes.value.playbooks) {
             out.push({
-              key: `workflow:builtin:${p.name}`,
-              kind: "workflow",
+              key: `playbook:builtin:${p.name}`,
+              kind: "playbook",
               subKind: "builtin",
               name: p.name,
               description: p.description,
@@ -114,8 +116,8 @@ function useLibraryData() {
         if (playbooksRes.status === "fulfilled") {
           for (const p of playbooksRes.value.playbooks) {
             out.push({
-              key: `workflow:custom:${p.name}`,
-              kind: "workflow",
+              key: `playbook:custom:${p.name}`,
+              kind: "playbook",
               subKind: "custom",
               name: p.name,
               description: p.description ?? undefined,
@@ -126,9 +128,8 @@ function useLibraryData() {
         if (workflowsRes.status === "fulfilled") {
           for (const w of workflowsRes.value) {
             out.push({
-              key: `workflow:graph:${w.id}`,
+              key: `workflow:${w.id}`,
               kind: "workflow",
-              subKind: "graph",
               name: w.name,
               description: w.description ?? undefined,
               meta: w.id,
@@ -194,45 +195,62 @@ function useLibraryData() {
   return { items, loading, error, reload, allAgents, allEngines };
 }
 
-const WORKFLOW_SUB_KINDS: WorkflowSubKind[] = ["builtin", "custom", "graph"];
+const PLAYBOOK_SUB_KINDS: PlaybookSubKind[] = ["builtin", "custom"];
+const LIBRARY_KINDS: LibraryKind[] = ["agent", "workflow", "playbook", "skill", "plugin", "engine"];
 
 /**
- * Parse a ?sel param into kind + name (+ subKind for "workflow" items, which
- * split three ways: builtin template / user's own playbook / graph design).
+ * Parse a ?sel param into kind + name (+ subKind for "playbook" items, which
+ * split two ways: builtin template / user's own installed copy).
  */
 function parseSel(
   sel: string | undefined,
-): { kind: LibraryKind; name: string; subKind?: WorkflowSubKind } | null {
+): { kind: LibraryKind; name: string; subKind?: PlaybookSubKind } | null {
   if (!sel) return null;
   const colon = sel.indexOf(":");
   if (colon === -1) return null;
   const kind = sel.slice(0, colon) as LibraryKind;
   const rest = sel.slice(colon + 1);
-  const valid: LibraryKind[] = ["agent", "workflow", "skill", "plugin", "engine"];
-  if (!valid.includes(kind) || !rest) return null;
+  if (!LIBRARY_KINDS.includes(kind) || !rest) return null;
 
-  if (kind === "workflow") {
+  if (kind === "playbook") {
     const colon2 = rest.indexOf(":");
     if (colon2 !== -1) {
       const maybeSubKind = rest.slice(0, colon2);
       const name = rest.slice(colon2 + 1);
-      if (WORKFLOW_SUB_KINDS.includes(maybeSubKind as WorkflowSubKind) && name) {
-        return { kind, name, subKind: maybeSubKind as WorkflowSubKind };
+      if (PLAYBOOK_SUB_KINDS.includes(maybeSubKind as PlaybookSubKind) && name) {
+        return { kind, name, subKind: maybeSubKind as PlaybookSubKind };
       }
     }
-    // Backward-compat: pre-split "workflow:<name>" links (old bookmarks, the
-    // legacy /playbooks/$name redirect shims) predate the subKind split —
-    // "workflow" used to mean only the graph-design kind, so treat those as
-    // "graph" rather than dropping the link.
-    return { kind, name: rest, subKind: "graph" };
+    return null;
+  }
+
+  if (kind === "workflow") {
+    // Backward-compat: pre-split "workflow:<subKind>:<name>" links (old
+    // bookmarks, the legacy /playbooks/$name redirect shims) predate the
+    // playbook/workflow split, where "workflow" carried builtin/custom
+    // playbook rows alongside graph designs under a subKind. Graph links
+    // drop the subKind entirely now; builtin/custom links resolve to the
+    // new "playbook" kind instead of dropping the bookmark.
+    const colon2 = rest.indexOf(":");
+    if (colon2 !== -1) {
+      const legacySubKind = rest.slice(0, colon2);
+      const name = rest.slice(colon2 + 1);
+      if (legacySubKind === "graph" && name) {
+        return { kind: "workflow", name };
+      }
+      if ((legacySubKind === "builtin" || legacySubKind === "custom") && name) {
+        return { kind: "playbook", name, subKind: legacySubKind };
+      }
+    }
+    return { kind, name: rest };
   }
 
   return { kind, name: rest };
 }
 
-function encodeSel(kind: LibraryKind, name: string, subKind?: WorkflowSubKind): string {
-  if (kind === "workflow") {
-    return `workflow:${subKind ?? "graph"}:${name}`;
+function encodeSel(kind: LibraryKind, name: string, subKind?: PlaybookSubKind): string {
+  if (kind === "playbook") {
+    return `playbook:${subKind ?? "custom"}:${name}`;
   }
   return `${kind}:${name}`;
 }
@@ -254,6 +272,7 @@ function LibraryPage() {
     { value: "all", label: t("filterAll") },
     { value: "agent", label: t("filterAgent") },
     { value: "workflow", label: t("filterWorkflow") },
+    { value: "playbook", label: t("filterPlaybook") },
     { value: "skill", label: t("filterSkill") },
     { value: "plugin", label: t("filterPlugin") },
     { value: "engine", label: t("filterEngine") },
@@ -288,7 +307,7 @@ function LibraryPage() {
           (i) =>
             i.kind === parsed.kind &&
             i.name === parsed.name &&
-            (parsed.kind !== "workflow" || i.subKind === parsed.subKind),
+            (parsed.kind !== "playbook" || i.subKind === parsed.subKind),
         )
       ) {
         return;
@@ -343,9 +362,8 @@ function LibraryPage() {
     parsed?.kind === "engine" ? allEngines.find((e) => e.name === parsed?.name) : null;
 
   const selectedWorkflowId =
-    parsed?.kind === "workflow" && parsed.subKind === "graph"
-      ? (items.find((i) => i.kind === "workflow" && i.subKind === "graph" && i.name === parsed.name)
-          ?.meta ?? parsed.name)
+    parsed?.kind === "workflow"
+      ? (items.find((i) => i.kind === "workflow" && i.name === parsed.name)?.meta ?? parsed.name)
       : null;
 
   const isEmpty = !loading && filtered.length === 0;
@@ -494,7 +512,7 @@ function LibraryPage() {
             setShowCreate(false);
             void reload();
             void navigate({
-              search: (prev) => ({ ...prev, sel: encodeSel("workflow", name, "graph") }),
+              search: (prev) => ({ ...prev, sel: encodeSel("workflow", name) }),
               replace: false,
             });
           }}
@@ -507,12 +525,9 @@ function LibraryPage() {
     );
   } else if (parsed?.kind === "agent" && selectedAgent) {
     detailPane = <AgentDetail agent={selectedAgent} onBack={handleBack} />;
-  } else if (parsed?.kind === "workflow" && parsed.subKind === "graph" && selectedWorkflowId) {
+  } else if (parsed?.kind === "workflow" && selectedWorkflowId) {
     detailPane = <WorkflowDetail id={selectedWorkflowId} onBack={handleBack} />;
-  } else if (
-    parsed?.kind === "workflow" &&
-    (parsed.subKind === "builtin" || parsed.subKind === "custom")
-  ) {
+  } else if (parsed?.kind === "playbook") {
     detailPane = (
       <PlaybookTemplateDetail
         name={parsed.name}
@@ -521,7 +536,7 @@ function LibraryPage() {
         onCloned={(clonedName) => {
           void reload();
           void navigate({
-            search: (prev) => ({ ...prev, sel: encodeSel("workflow", clonedName, "custom") }),
+            search: (prev) => ({ ...prev, sel: encodeSel("playbook", clonedName, "custom") }),
             replace: false,
           });
         }}

--- a/apps/studio/frontend/src/routes/playbooks/$name/edit/index.tsx
+++ b/apps/studio/frontend/src/routes/playbooks/$name/edit/index.tsx
@@ -4,7 +4,7 @@ export const Route = createFileRoute("/playbooks/$name/edit/")({
   beforeLoad: ({ params }) => {
     throw redirect({
       to: "/library",
-      search: { tab: "workflow", sel: `workflow:custom:${params.name}` },
+      search: { tab: "playbook", sel: `playbook:custom:${params.name}` },
     });
   },
   component: () => null,

--- a/apps/studio/frontend/src/routes/playbooks/$name/index.tsx
+++ b/apps/studio/frontend/src/routes/playbooks/$name/index.tsx
@@ -4,7 +4,7 @@ export const Route = createFileRoute("/playbooks/$name/")({
   beforeLoad: ({ params }) => {
     throw redirect({
       to: "/library",
-      search: { tab: "workflow", sel: `workflow:custom:${params.name}` },
+      search: { tab: "playbook", sel: `playbook:custom:${params.name}` },
     });
   },
   component: () => null,


### PR DESCRIPTION
## What

Playbooks were jammed into the `workflow` library kind as `subKind: builtin|custom` alongside graph designs (`subKind: graph`). Ocean's verdict: **"playbook is not workflows, these are different."** This splits `playbook` into its own top-level library kind/tab, leaving `workflow` = graph-designs-only.

## Changes

- New `playbook` tab/kind (own icon `IconPlaybook`, accent color) — built-in templates + user playbooks live here
- `workflow` kind is now graph-only: key `workflow:${id}`, no subKind
- `KindBadge` gains the `playbook` kind; `workflow` gets a distinct teal glyph
- Deep-link compat is **inline in `parseSel`** (not a shim module): old `workflow:builtin|custom:<name>` links resolve to `playbook`; old `workflow:graph:<id>` resolves to `workflow`. Legacy `/playbooks/$name` redirect routes emit the new taxonomy directly.
- i18n: `library.filterPlaybook` added to all 16 locales, reusing each locale's already-established `playbookName` term (ko `플레이북`, ja `プレイブック`, zh `剧本`, etc.) rather than dropping English

## Verification (full suite, TBV'd by lambda:lionagi against the worktree)

- `npx tsc --noEmit`: clean (rc=0)
- `npx vitest run`: **612/612** across 24 files (`library.test.ts` rewritten, `locales.test.ts` ran with real assertions)
- Leaf count 791 → **792** (+1 `library.filterPlaybook` × 16 locales) — verified empirically via Node leaf-counter, matches the `locales.test.ts` assertion
- Base = origin/main `8aa5ca70a`; no stray files; routeTree.gen.ts cosmetic-only, reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)