### PR TITLE
feat(studio): compile & run WorkflowDefs on Session.flow (exec-bridge slice 1)

### DIFF
--- a/apps/studio/frontend/src/components/workflow/WorkflowNodePalette.tsx
+++ b/apps/studio/frontend/src/components/workflow/WorkflowNodePalette.tsx
@@ -8,7 +8,6 @@ const PALETTE_ITEMS: Array<{ kind: WorkflowNodeKind; glyph: string }> = [
   { kind: "parse", glyph: "⊞" },
   { kind: "fanout", glyph: "⋔" },
   { kind: "engine", glyph: "⊶" },
-  { kind: "gate", glyph: "◇" },
 ];
 
 export default function WorkflowNodePalette() {

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -10,6 +10,7 @@ import logging
 import math
 import os
 import threading
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
@@ -120,6 +121,7 @@ class DependencyAwareExecutor:
         default_branch: "Branch" = None,
         alcall_params: AlcallParams | None = None,
         executor_ref: dict[str, Any] | None = None,
+        on_branch_created: Callable[[Any], None] | None = None,
     ):
         self.session = session
         self.graph = graph
@@ -129,6 +131,13 @@ class DependencyAwareExecutor:
         self._alcall = alcall_params or AlcallParams()
         self._default_branch = default_branch
         self.on_progress = None
+        # Persistence-only seam (ADR-0023b clone-persistence gap): a caller
+        # (e.g. Studio's workflow_run) can pass a sync callback invoked with
+        # every branch this executor clones during pre-allocation, so it can
+        # wire per-branch persistence (register_branch_hook) on branches that
+        # did not exist yet when the caller set up persistence for the
+        # session's initial branches. Never touches execution/branch semantics.
+        self._on_branch_created = on_branch_created
         self.results = {}
         self.completion_events = {}
         self.operation_branches = {}
@@ -227,6 +236,9 @@ class DependencyAwareExecutor:
                             self.session.include_branches(branch_clone)
                 except Exception:
                     logger.debug("Skipping branch clone registration (likely mock in test).")
+
+                if self._on_branch_created is not None:
+                    self._on_branch_created(branch_clone)
 
                 if operation.metadata.get("inherit_context"):
                     branch_clone.metadata = branch_clone.metadata or {}
@@ -997,6 +1009,11 @@ class ReactiveExecutor(DependencyAwareExecutor):
 
         clone = base.clone(sender=self.session.id)
         self.session.include_branches(clone)
+        # NOTE: reactive self-expansion clones branches here too; a persisted
+        # reactive run would need the same self._on_branch_created(clone) call
+        # as _preallocate_all_branches to pick up mid-run spawned branches.
+        # Not wired: workflow_run (the only caller threading on_branch_created
+        # today) never runs with reactive=True.
         self.operation_branches[child.id] = clone
         child.branch_id = clone.id
 
@@ -1024,6 +1041,7 @@ async def flow(
     node_builder: Any = None,
     max_spawn: int = 50,
     executor_ref: dict[str, Any] | None = None,
+    on_branch_created: Callable[[Any], None] | None = None,
 ) -> dict[str, Any]:
     """Execute a graph with dependency management and optional reactive self-expansion.
 
@@ -1062,6 +1080,7 @@ async def flow(
             default_branch=branch,
             alcall_params=alcall_params,
             executor_ref=executor_ref,
+            on_branch_created=on_branch_created,
         )
     if on_progress is not None:
         executor.on_progress = on_progress

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -131,7 +131,7 @@ class DependencyAwareExecutor:
         self._alcall = alcall_params or AlcallParams()
         self._default_branch = default_branch
         self.on_progress = None
-        # Persistence-only seam (ADR-0023b clone-persistence gap): a caller
+        # Persistence-only seam: a caller
         # (e.g. Studio's workflow_run) can pass a sync callback invoked with
         # every branch this executor clones during pre-allocation, so it can
         # wire per-branch persistence (register_branch_hook) on branches that

--- a/lionagi/session/session.py
+++ b/lionagi/session/session.py
@@ -371,6 +371,7 @@ class Session(Node, Relational):
         node_builder: Any = None,
         max_spawn: int = 50,
         executor_ref: dict[str, Any] | None = None,
+        on_branch_created: Callable[[Any], None] | None = None,
     ) -> dict[str, Any]:
         """Execute a graph-based DAG workflow, optionally reactive (self-expanding)."""
         from lionagi.operations.flow import flow
@@ -394,6 +395,7 @@ class Session(Node, Relational):
             node_builder=node_builder,
             max_spawn=max_spawn,
             executor_ref=executor_ref,
+            on_branch_created=on_branch_created,
         )
 
     async def flow_stream(

--- a/lionagi/studio/services/engine_defs.py
+++ b/lionagi/studio/services/engine_defs.py
@@ -73,6 +73,16 @@ def _validate_kind_options(kind: str, options: dict[str, Any] | None) -> None:
         )
 
 
+def _validate_budget(field: str, val: Any) -> None:
+    """A max_depth/max_agents override must be an int in [1, 100] (or absent)."""
+    if val is None:
+        return
+    if not isinstance(val, int) or isinstance(val, bool):
+        raise ValueError(f"{field} must be an integer")
+    if not (1 <= val <= 100):
+        raise ValueError(f"{field} must be in [1, 100], got {val}")
+
+
 def _svc_validate_action_model(model: str | None) -> None:
     if not model:
         return
@@ -127,12 +137,7 @@ async def create_engine_def(data: dict[str, Any]) -> dict[str, Any]:
     _svc_validate_action_model(data.get("model"))
 
     for field in ("max_depth", "max_agents"):
-        val = data.get(field)
-        if val is not None:
-            if not isinstance(val, int) or isinstance(val, bool):
-                raise ValueError(f"{field} must be an integer")
-            if not (1 <= val <= 100):
-                raise ValueError(f"{field} must be in [1, 100], got {val}")
+        _validate_budget(field, data.get(field))
 
     _validate_options(data.get("options"))
     _validate_kind_options(kind, data.get("options"))
@@ -175,12 +180,7 @@ async def update_engine_def(def_id: str, fields: dict[str, Any]) -> dict[str, An
             _svc_validate_action_model(fields["model"])
         for field in ("max_depth", "max_agents"):
             if field in fields:
-                val = fields[field]
-                if val is not None:
-                    if not isinstance(val, int) or isinstance(val, bool):
-                        raise ValueError(f"{field} must be an integer")
-                    if not (1 <= val <= 100):
-                        raise ValueError(f"{field} must be in [1, 100], got {val}")
+                _validate_budget(field, fields[field])
         if "options" in fields:
             _validate_options(fields["options"])
 

--- a/lionagi/studio/services/sessions.py
+++ b/lionagi/studio/services/sessions.py
@@ -36,6 +36,12 @@ def _graph_from_metadata(raw: str | None) -> dict[str, Any] | None:
         return None
     if not isinstance(meta, dict):
         return None
+    early_graph = meta.get("early_graph")
+    if isinstance(early_graph, dict) and early_graph.get("nodes"):
+        # Studio workflow-exec runs (ADR workflow-exec Fork 3): the compiled
+        # graph already carries the authored node ids + edges in this exact
+        # WorkerStepNode/WorkerLinkEdge shape — pass through, no re-derivation.
+        return early_graph
     agents = meta.get("agents") or []
     operations = meta.get("operations") or []
     if not operations:

--- a/lionagi/studio/services/workflow_compile.py
+++ b/lionagi/studio/services/workflow_compile.py
@@ -310,22 +310,42 @@ async def compile_workflow_def(
                 raise WorkflowCompileError(
                     f"unknown engine_def_id {engine_def_id!r}", node_id=node_id
                 )
-            # A node's config.options override the EngineDef's stored options,
-            # but those node values are author-supplied and never went through
-            # the checks engine_defs enforces when a def is created (allowed
-            # keys, string-only, no leading-dash CLI-flag injection, no shell
-            # metacharacters, kind requirements). Re-validate the merged result
-            # so a saved workflow can't smuggle e.g. a shell-control test_cmd
-            # past those safeguards into a coding engine's command.
-            from .engine_defs import _validate_kind_options, _validate_options
+            # A node's config overrides (options, max_depth, max_agents) are
+            # author-supplied and never went through the checks engine_defs
+            # enforces at def creation (allowed option keys, string-only, no
+            # leading-dash CLI-flag injection, no shell metacharacters, kind
+            # requirements, budgets in [1, 100]). Re-validate the effective
+            # values so a saved workflow can't smuggle a shell-control test_cmd
+            # into a coding engine or set an unbounded agent/depth budget.
+            from .engine_defs import (
+                _validate_budget,
+                _validate_kind_options,
+                _validate_options,
+            )
 
-            engine_options = {
-                **(defn.get("options") or {}),
-                **(config.get("options") or {}),
-            }
+            node_options = config.get("options")
+            if node_options is not None and not isinstance(node_options, dict):
+                # A non-mapping options value would raise TypeError on the **
+                # unpack below, escaping the ValueError wrapper as a 500.
+                raise WorkflowCompileError(
+                    "engine node config.options must be a mapping, got "
+                    f"{type(node_options).__name__}",
+                    node_id=node_id,
+                )
+            engine_options = {**(defn.get("options") or {}), **(node_options or {})}
+
+            # A node override of None must fall back to the def's value rather
+            # than discard the (stricter) stored budget.
+            node_depth = config.get("max_depth")
+            engine_max_depth = defn.get("max_depth") if node_depth is None else node_depth
+            node_agents = config.get("max_agents")
+            engine_max_agents = defn.get("max_agents") if node_agents is None else node_agents
+
             try:
                 _validate_options(engine_options)
                 _validate_kind_options(defn.get("kind"), engine_options)
+                _validate_budget("max_depth", engine_max_depth)
+                _validate_budget("max_agents", engine_max_agents)
             except ValueError as exc:
                 raise WorkflowCompileError(str(exc), node_id=node_id) from exc
             op_id = builder.add_operation(
@@ -333,8 +353,8 @@ async def compile_workflow_def(
                 node_id=node_id,
                 engine_kind=defn.get("kind"),
                 engine_model=config.get("model") or defn.get("model"),
-                engine_max_depth=config.get("max_depth", defn.get("max_depth")),
-                engine_max_agents=config.get("max_agents", defn.get("max_agents")),
+                engine_max_depth=engine_max_depth,
+                engine_max_agents=engine_max_agents,
                 engine_options=engine_options,
             )
         else:  # pragma: no cover — unreachable, prefiltered above

--- a/lionagi/studio/services/workflow_compile.py
+++ b/lionagi/studio/services/workflow_compile.py
@@ -1,0 +1,486 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Compile a Studio WorkflowDef spec into an executable lionagi OperationGraph.
+
+The only new security surface here is `StudioExprCondition` — a restricted-grammar
+expression evaluator for edge conditions authored in the Studio designer. It never
+calls eval/exec/compile/__import__; the AST is walked against a closed node-type
+allowlist before it is ever evaluated.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from pydantic import Field, PrivateAttr
+
+from lionagi.operations.builder import OperationGraphBuilder
+from lionagi.protocols.graph.edge import Edge, EdgeCondition
+from lionagi.protocols.graph.graph import Graph
+
+__all__ = (
+    "StudioExprCondition",
+    "UnsafeExpressionError",
+    "WorkflowCompileError",
+    "EXECUTABLE_NODE_KINDS",
+    "DROPPED_NODE_KINDS",
+    "compile_workflow_def",
+    "build_early_graph",
+    "make_engine_operation",
+)
+
+
+EXECUTABLE_NODE_KINDS: frozenset[str] = frozenset({"input", "chat", "engine"})
+DROPPED_NODE_KINDS: frozenset[str] = frozenset({"parse", "fanout", "gate"})
+
+_MAX_EXPR_LEN = 1000
+_MAX_AST_DEPTH = 20
+
+_ALLOWED_COMPARE_OPS = (ast.Eq, ast.NotEq, ast.Lt, ast.LtE, ast.Gt, ast.GtE, ast.In, ast.NotIn)
+_ALLOWED_BOOL_OPS = (ast.And, ast.Or)
+
+
+class UnsafeExpressionError(ValueError):
+    """A condition expression failed the restricted-grammar safety check."""
+
+
+class WorkflowCompileError(Exception):
+    """A WorkflowDef spec could not compile to an executable graph.
+
+    Carries the offending node/edge id so callers (the run route, the designer
+    UI) can annotate the error in place instead of surfacing a bare 500.
+    """
+
+    def __init__(
+        self, message: str, *, node_id: str | None = None, edge_id: str | None = None
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.node_id = node_id
+        self.edge_id = edge_id
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"error": self.message, "node_id": self.node_id, "edge_id": self.edge_id}
+
+
+# ─── Safe expression grammar ───────────────────────────────────────────────
+#
+# Allowed: comparisons (== != < <= > >=), boolean and/or/not, literals
+# (str/int/float/bool/None), list/tuple literals of the above, names,
+# attribute access, subscript/key access, in/not in. Everything else
+# (calls, lambdas, comprehensions, f-strings, walrus, imports, dunder
+# names/attributes) is rejected before the tree is ever evaluated.
+
+
+def _check_depth(node: ast.AST, depth: int = 0) -> None:
+    if depth > _MAX_AST_DEPTH:
+        raise UnsafeExpressionError(f"expression exceeds max nesting depth ({_MAX_AST_DEPTH})")
+    for child in ast.iter_child_nodes(node):
+        _check_depth(child, depth + 1)
+
+
+def _validate_node(node: ast.AST) -> None:
+    """Raise UnsafeExpressionError for any construct outside the allowed grammar."""
+    if isinstance(node, ast.Expression):
+        _validate_node(node.body)
+        return
+    if isinstance(node, ast.BoolOp):
+        if not isinstance(node.op, _ALLOWED_BOOL_OPS):
+            raise UnsafeExpressionError(f"boolean operator {type(node.op).__name__} not allowed")
+        for value in node.values:
+            _validate_node(value)
+        return
+    if isinstance(node, ast.UnaryOp):
+        if not isinstance(node.op, ast.Not):
+            raise UnsafeExpressionError(f"unary operator {type(node.op).__name__} not allowed")
+        _validate_node(node.operand)
+        return
+    if isinstance(node, ast.Compare):
+        _validate_node(node.left)
+        for op in node.ops:
+            if not isinstance(op, _ALLOWED_COMPARE_OPS):
+                raise UnsafeExpressionError(f"comparison operator {type(op).__name__} not allowed")
+        for comparator in node.comparators:
+            _validate_node(comparator)
+        return
+    if isinstance(node, ast.Attribute):
+        if node.attr.startswith("_"):
+            raise UnsafeExpressionError(f"attribute access to {node.attr!r} is not allowed")
+        _validate_node(node.value)
+        return
+    if isinstance(node, ast.Subscript):
+        _validate_node(node.value)
+        _validate_node(node.slice)
+        return
+    if isinstance(node, ast.Name):
+        if node.id.startswith("_"):
+            raise UnsafeExpressionError(f"name {node.id!r} is not allowed")
+        return
+    if isinstance(node, ast.Constant):
+        if node.value is not None and not isinstance(node.value, str | int | float | bool):
+            raise UnsafeExpressionError(f"literal of type {type(node.value).__name__} not allowed")
+        return
+    if isinstance(node, ast.List | ast.Tuple):
+        for element in node.elts:
+            _validate_node(element)
+        return
+    raise UnsafeExpressionError(f"expression construct {type(node).__name__} is not allowed")
+
+
+def _parse_expr(expr: str) -> ast.Expression:
+    if not isinstance(expr, str) or not expr.strip():
+        raise UnsafeExpressionError("condition expression must be a non-empty string")
+    if len(expr) > _MAX_EXPR_LEN:
+        raise UnsafeExpressionError(
+            f"condition expression exceeds max length ({_MAX_EXPR_LEN} chars)"
+        )
+    try:
+        tree = ast.parse(expr, mode="eval")
+        _check_depth(tree)
+        _validate_node(tree)
+    except SyntaxError as exc:
+        raise UnsafeExpressionError(f"condition expression is not valid syntax: {exc}") from exc
+    except RecursionError as exc:
+        raise UnsafeExpressionError("condition expression is too deeply nested") from exc
+    return tree
+
+
+def _apply_compare(op: ast.cmpop, left: Any, right: Any) -> bool:
+    if isinstance(op, ast.Eq):
+        return left == right
+    if isinstance(op, ast.NotEq):
+        return left != right
+    if isinstance(op, ast.Lt):
+        return left < right
+    if isinstance(op, ast.LtE):
+        return left <= right
+    if isinstance(op, ast.Gt):
+        return left > right
+    if isinstance(op, ast.GtE):
+        return left >= right
+    if isinstance(op, ast.In):
+        return left in right
+    if isinstance(op, ast.NotIn):
+        return left not in right
+    raise UnsafeExpressionError(f"comparison operator {type(op).__name__} not allowed")
+
+
+def _eval_node(node: ast.AST, ctx: dict[str, Any]) -> Any:
+    if isinstance(node, ast.Expression):
+        return _eval_node(node.body, ctx)
+    if isinstance(node, ast.BoolOp):
+        result: Any = isinstance(node.op, ast.And)
+        for value in node.values:
+            result = _eval_node(value, ctx)
+            if isinstance(node.op, ast.And) and not result:
+                return result
+            if isinstance(node.op, ast.Or) and result:
+                return result
+        return result
+    if isinstance(node, ast.UnaryOp):  # only ast.Not is allowed past _validate_node
+        return not _eval_node(node.operand, ctx)
+    if isinstance(node, ast.Compare):
+        left = _eval_node(node.left, ctx)
+        for op, comparator in zip(node.ops, node.comparators, strict=True):
+            right = _eval_node(comparator, ctx)
+            if not _apply_compare(op, left, right):
+                return False
+            left = right
+        return True
+    if isinstance(node, ast.Attribute):
+        base = _eval_node(node.value, ctx)
+        if isinstance(base, dict):
+            return base.get(node.attr)
+        return getattr(base, node.attr, None)
+    if isinstance(node, ast.Subscript):
+        base = _eval_node(node.value, ctx)
+        key = _eval_node(node.slice, ctx)
+        try:
+            return base[key]
+        except (KeyError, IndexError, TypeError):
+            return None
+    if isinstance(node, ast.Name):
+        if node.id not in ctx:
+            raise UnsafeExpressionError(f"name {node.id!r} is not defined in the condition context")
+        return ctx[node.id]
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.List):
+        return [_eval_node(element, ctx) for element in node.elts]
+    if isinstance(node, ast.Tuple):
+        return tuple(_eval_node(element, ctx) for element in node.elts)
+    raise UnsafeExpressionError(f"expression construct {type(node).__name__} is not allowed")
+
+
+class StudioExprCondition(EdgeCondition):
+    """Restricted-grammar edge condition compiled from a Studio WorkflowEdge.condition string.
+
+    Evaluated strictly against ``{"result": <upstream operation result>,
+    "context": <flow context>}`` — no builtins, no globals, no calls.
+    """
+
+    expr: str = Field(...)
+    _tree: Any = PrivateAttr(default=None)
+
+    def __init__(self, **data: Any) -> None:
+        # Parse BEFORE pydantic's own validation machinery runs: a plain
+        # model_validator would still raise UnsafeExpressionError, but pydantic
+        # wraps every validator exception into pydantic_core.ValidationError,
+        # which callers matching `except UnsafeExpressionError` (this class's
+        # documented contract, and compile_workflow_def's edge-id mapping)
+        # would silently fail to catch.
+        tree = _parse_expr(data.get("expr", ""))
+        super().__init__(**data)
+        self._tree = tree
+
+    async def apply(self, context: Any = None, *args: Any, **kwargs: Any) -> bool:
+        tree = self._tree if self._tree is not None else _parse_expr(self.expr)
+        ctx = context if isinstance(context, dict) else {}
+        return bool(_eval_node(tree, ctx))
+
+
+# ─── Compile: WorkflowDef spec → OperationGraph ────────────────────────────
+
+
+async def compile_workflow_def(
+    spec: dict[str, Any],
+    *,
+    resolve_engine_def: Callable[[str], Awaitable[dict[str, Any] | None]],
+) -> tuple[Graph, dict[str, str]]:
+    """Compile a validated WorkflowDef spec into an executable Graph.
+
+    Returns ``(graph, id_map)`` where ``id_map`` maps authored node ids to the
+    internal Operation ids lionagi assigned them. Raises WorkflowCompileError
+    (node_id/edge_id set) on any problem — never lets a bad expr, unknown
+    engine_def_id, or a parse/fanout/gate node reach the executor.
+    """
+    nodes: list[dict[str, Any]] = spec.get("nodes", [])
+    edges: list[dict[str, Any]] = spec.get("edges", [])
+
+    for n in nodes:
+        kind = n.get("kind")
+        if kind in DROPPED_NODE_KINDS:
+            raise WorkflowCompileError(
+                f"node kind {kind!r} is not executable in v1 "
+                "(parse/fanout/gate were dropped — see the workflow-exec spec)",
+                node_id=n.get("id"),
+            )
+        if kind not in EXECUTABLE_NODE_KINDS:
+            raise WorkflowCompileError(f"unknown node kind {kind!r}", node_id=n.get("id"))
+
+    builder = OperationGraphBuilder("studio-workflow")
+    id_map: dict[str, str] = {}
+
+    for n in nodes:
+        kind = n["kind"]
+        node_id = n["id"]
+        if kind == "input":
+            # Compile-time marker only — not an Operation. Its data reaches every
+            # op uniformly via session.flow(context=...), so no graph edge is needed.
+            continue
+
+        config = n.get("config") or {}
+        if kind == "chat":
+            prompt = config.get("prompt")
+            if not prompt or not isinstance(prompt, str):
+                raise WorkflowCompileError("chat node requires config.prompt", node_id=node_id)
+            op_id = builder.add_operation("chat", node_id=node_id, instruction=prompt)
+        elif kind == "engine":
+            engine_def_id = config.get("engine_def_id")
+            if not engine_def_id or not isinstance(engine_def_id, str):
+                raise WorkflowCompileError(
+                    "engine node requires config.engine_def_id", node_id=node_id
+                )
+            defn = await resolve_engine_def(engine_def_id)
+            if defn is None:
+                raise WorkflowCompileError(
+                    f"unknown engine_def_id {engine_def_id!r}", node_id=node_id
+                )
+            op_id = builder.add_operation(
+                "engine",
+                node_id=node_id,
+                engine_kind=defn.get("kind"),
+                engine_model=config.get("model") or defn.get("model"),
+                engine_max_depth=config.get("max_depth", defn.get("max_depth")),
+                engine_max_agents=config.get("max_agents", defn.get("max_agents")),
+                engine_options=dict(defn.get("options") or {}),
+            )
+        else:  # pragma: no cover — unreachable, prefiltered above
+            raise WorkflowCompileError(f"unknown node kind {kind!r}", node_id=node_id)
+
+        # Edges are wired by hand below from WorkflowEdge, not the builder's
+        # own depends_on/sequential auto-chaining — sever it after every node.
+        builder._current_heads = []
+        id_map[node_id] = op_id
+
+    graph = builder.graph
+
+    for e in edges:
+        edge_id = e.get("id")
+        src_wf, dst_wf = e.get("from"), e.get("to")
+        dst_op = id_map.get(dst_wf)
+        if dst_op is None:
+            raise WorkflowCompileError(
+                f"edge target {dst_wf!r} is not an executable node", edge_id=edge_id
+            )
+        src_op = id_map.get(src_wf)
+        if src_op is None:
+            # Source is an 'input' node — no Operation-level edge needed.
+            continue
+
+        condition = None
+        expr = e.get("condition")
+        if expr:
+            try:
+                condition = StudioExprCondition(expr=expr)
+            except UnsafeExpressionError as exc:
+                raise WorkflowCompileError(str(exc), edge_id=edge_id) from exc
+
+        label = [e["label"]] if e.get("label") else []
+        graph.add_edge(Edge(head=src_op, tail=dst_op, condition=condition, label=label))
+
+    if not graph.is_acyclic():
+        raise WorkflowCompileError(
+            "workflow contains a cycle; loops are not supported in v1 "
+            "(iteration lives inside a node, not as a graph cycle)"
+        )
+
+    return graph, id_map
+
+
+def build_early_graph(spec: dict[str, Any]) -> dict[str, Any]:
+    """Build the authored-graph shape stored at session.node_metadata.early_graph.
+
+    Matches the frontend's WorkerGraph shape (WorkerStepNode/WorkerLinkEdge) so
+    the existing run-detail renderer (sessions.py:_graph_from_metadata ->
+    WorkerCanvas) can draw it without any new frontend code.
+    """
+    nodes: list[dict[str, Any]] = []
+    for n in spec.get("nodes", []):
+        if n.get("kind") not in EXECUTABLE_NODE_KINDS:
+            continue
+        config = n.get("config") or {}
+        kind = n["kind"]
+        if kind == "chat":
+            assignment = config.get("model") or ""
+            prompt = config.get("prompt") or ""
+        elif kind == "engine":
+            assignment = config.get("engine_def_id") or ""
+            prompt = ""
+        else:
+            assignment = ""
+            prompt = ""
+        nodes.append(
+            {
+                "id": n["id"],
+                "label": n.get("label") or n["id"],
+                "role": kind,
+                "assignment": assignment,
+                "prompt": prompt,
+                "capacity": 1,
+                "timeout": None,
+                "inputs": [],
+                "outputs": [],
+            }
+        )
+
+    node_ids = {n["id"] for n in nodes}
+    by_id = {n["id"]: n for n in nodes}
+    edges: list[dict[str, Any]] = []
+    for e in spec.get("edges", []):
+        src, dst = e.get("from"), e.get("to")
+        if src not in node_ids or dst not in node_ids:
+            continue
+        condition = e.get("condition")
+        edges.append(
+            {
+                "id": e["id"],
+                "source": src,
+                "target": dst,
+                "mode": "code" if condition else "simple",
+                "condition": condition,
+            }
+        )
+        by_id[dst]["inputs"].append(src)
+        by_id[src]["outputs"].append(dst)
+
+    return {"nodes": nodes, "edges": edges}
+
+
+# ─── The 'engine' Operation kind ────────────────────────────────────────────
+
+
+def _derive_engine_input(context: dict[str, Any] | None) -> str:
+    """Heuristic mapping from upstream flow context to an engine's main positional input.
+
+    Prefers an upstream predecessor's textual result (the ``{pred_id}_result``
+    keys `_prepare_operation` injects); falls back to the flow-level inputs.
+    Underspecified in the spec (WorkflowEngineConfig has no explicit prompt/
+    input-mapping field) — this is the compile-time call made for v1.
+    """
+    if not context:
+        return ""
+    for key, value in context.items():
+        if key.endswith("_result") and value:
+            return value if isinstance(value, str) else json.dumps(value, default=str)
+    parts = [str(v) for v in context.values() if isinstance(v, str | int | float)]
+    if parts:
+        return "\n".join(parts)
+    return json.dumps(context, default=str)
+
+
+def make_engine_operation(session: Any) -> Callable[..., Awaitable[Any]]:
+    """Build the 'engine' Branch-operation closure for one workflow run.
+
+    Resolves the engine class per kind (reusing the CLI's kind registry —
+    FindExisting, not a new one) and runs it in-process against the SAME
+    session, so any sub-agent branches it spawns are wired into this run.
+    """
+
+    async def _engine_op(
+        context: dict[str, Any] | None = None,
+        engine_kind: str = "",
+        engine_model: str | None = None,
+        engine_max_depth: int | None = None,
+        engine_max_agents: int | None = None,
+        engine_options: dict[str, Any] | None = None,
+        **_ignored: Any,
+    ) -> Any:
+        from lionagi.cli.engine import _KIND_META, _import_engine_class
+
+        meta = _KIND_META.get(engine_kind)
+        if meta is None:
+            raise RuntimeError(f"unknown engine kind {engine_kind!r}")
+        module, cls_name = meta["cls_path"]
+        engine_class = _import_engine_class(module, cls_name)
+
+        engine_kwargs: dict[str, Any] = {}
+        if engine_model:
+            engine_kwargs["model"] = engine_model
+        if engine_max_depth is not None:
+            engine_kwargs["max_depth"] = engine_max_depth
+        if engine_max_agents is not None:
+            engine_kwargs["max_agents"] = engine_max_agents
+
+        options = engine_options or {}
+        run_kwargs: dict[str, Any] = {}
+        if engine_kind == "coding":
+            run_kwargs["test_cmd"] = options.get("test_cmd")
+        if engine_kind in ("coding", "hypothesis") and options.get("export_dir"):
+            run_kwargs["export_dir"] = options["export_dir"]
+
+        spec_input = _derive_engine_input(context)
+
+        engine = engine_class(**engine_kwargs)
+        result = await engine.run(spec_input, session=session, **run_kwargs)
+
+        if hasattr(result, "model_dump"):
+            return result.model_dump(mode="json")
+        if isinstance(result, str):
+            return {"result": result}
+        return {"result": str(result)}
+
+    return _engine_op

--- a/lionagi/studio/services/workflow_compile.py
+++ b/lionagi/studio/services/workflow_compile.py
@@ -282,7 +282,18 @@ async def compile_workflow_def(
             # op uniformly via session.flow(context=...), so no graph edge is needed.
             continue
 
-        config = n.get("config") or {}
+        config = n.get("config")
+        if config is None:
+            config = {}
+        elif not isinstance(config, dict):
+            # A saved spec can carry a non-mapping config (e.g. config: "bad")
+            # that _validate_spec does not shape-check for every kind. Reject it
+            # here so the run route returns a structured 422 rather than letting
+            # config.get(...) raise AttributeError as an unstructured 500.
+            raise WorkflowCompileError(
+                f"node config must be a mapping, got {type(config).__name__}",
+                node_id=node_id,
+            )
         if kind == "chat":
             prompt = config.get("prompt")
             if not prompt or not isinstance(prompt, str):

--- a/lionagi/studio/services/workflow_compile.py
+++ b/lionagi/studio/services/workflow_compile.py
@@ -299,6 +299,24 @@ async def compile_workflow_def(
                 raise WorkflowCompileError(
                     f"unknown engine_def_id {engine_def_id!r}", node_id=node_id
                 )
+            # A node's config.options override the EngineDef's stored options,
+            # but those node values are author-supplied and never went through
+            # the checks engine_defs enforces when a def is created (allowed
+            # keys, string-only, no leading-dash CLI-flag injection, no shell
+            # metacharacters, kind requirements). Re-validate the merged result
+            # so a saved workflow can't smuggle e.g. a shell-control test_cmd
+            # past those safeguards into a coding engine's command.
+            from .engine_defs import _validate_kind_options, _validate_options
+
+            engine_options = {
+                **(defn.get("options") or {}),
+                **(config.get("options") or {}),
+            }
+            try:
+                _validate_options(engine_options)
+                _validate_kind_options(defn.get("kind"), engine_options)
+            except ValueError as exc:
+                raise WorkflowCompileError(str(exc), node_id=node_id) from exc
             op_id = builder.add_operation(
                 "engine",
                 node_id=node_id,
@@ -306,10 +324,7 @@ async def compile_workflow_def(
                 engine_model=config.get("model") or defn.get("model"),
                 engine_max_depth=config.get("max_depth", defn.get("max_depth")),
                 engine_max_agents=config.get("max_agents", defn.get("max_agents")),
-                engine_options={
-                    **(defn.get("options") or {}),
-                    **(config.get("options") or {}),
-                },
+                engine_options=engine_options,
             )
         else:  # pragma: no cover — unreachable, prefiltered above
             raise WorkflowCompileError(f"unknown node kind {kind!r}", node_id=node_id)

--- a/lionagi/studio/services/workflow_compile.py
+++ b/lionagi/studio/services/workflow_compile.py
@@ -306,7 +306,10 @@ async def compile_workflow_def(
                 engine_model=config.get("model") or defn.get("model"),
                 engine_max_depth=config.get("max_depth", defn.get("max_depth")),
                 engine_max_agents=config.get("max_agents", defn.get("max_agents")),
-                engine_options=dict(defn.get("options") or {}),
+                engine_options={
+                    **(defn.get("options") or {}),
+                    **(config.get("options") or {}),
+                },
             )
         else:  # pragma: no cover — unreachable, prefiltered above
             raise WorkflowCompileError(f"unknown node kind {kind!r}", node_id=node_id)

--- a/lionagi/studio/services/workflow_compile.py
+++ b/lionagi/studio/services/workflow_compile.py
@@ -331,7 +331,19 @@ async def compile_workflow_def(
             )
         src_op = id_map.get(src_wf)
         if src_op is None:
-            # Source is an 'input' node — no Operation-level edge needed.
+            # Source is an 'input' node — no Operation-level edge is created.
+            # A condition on such an edge cannot gate anything (the edge is
+            # dropped), so the target would run unconditionally — silently
+            # ignoring the guard. Reject it rather than compile a misleading
+            # unconditional run; gating on input must go through an
+            # intermediate executable node that carries the condition.
+            if e.get("condition"):
+                raise WorkflowCompileError(
+                    "a condition on an edge from an 'input' node is not "
+                    "supported (the edge carries no runtime gate); gate via an "
+                    "intermediate node instead",
+                    edge_id=edge_id,
+                )
             continue
 
         condition = None

--- a/lionagi/studio/services/workflow_defs.py
+++ b/lionagi/studio/services/workflow_defs.py
@@ -23,9 +23,11 @@ class NameConflictError(Exception):
 
 
 # Closed set of node kinds — must match the Designer frontend's WorkflowNodeKind.
-_VALID_NODE_KINDS: frozenset[str] = frozenset(
-    {"input", "chat", "parse", "fanout", "engine", "gate"}
-)
+# 'gate' was removed (conditions now live on edges, not gate nodes — see the
+# workflow-exec spec, Fork 1). A saved def still carrying a 'gate' node fails
+# validation here (create/update) and load (get_workflow_def_route) with an
+# actionable, node-naming error rather than a generic 422.
+_VALID_NODE_KINDS: frozenset[str] = frozenset({"input", "chat", "parse", "fanout", "engine"})
 
 _MAX_NODES = 200
 _MAX_EDGES = 400
@@ -65,6 +67,8 @@ def _validate_spec(spec: dict[str, Any] | None) -> None:
                 f"node {node_id!r} has invalid kind {kind!r}. "
                 f"Valid kinds: {sorted(_VALID_NODE_KINDS)}"
             )
+        if kind == "chat":
+            _validate_chat_config(node_id, node.get("config"))
         pos = node.get("pos")
         if not isinstance(pos, dict) or not all(
             isinstance(pos.get(axis), int | float) and not isinstance(pos.get(axis), bool)
@@ -86,11 +90,36 @@ def _validate_spec(spec: dict[str, Any] | None) -> None:
             target = edge.get(endpoint)
             if target not in node_ids:
                 raise ValueError(f"edge {edge_id!r} {endpoint} references unknown node {target!r}")
+        condition = edge.get("condition")
+        if condition is not None and (not isinstance(condition, str) or not condition.strip()):
+            raise ValueError(f"edge {edge_id!r} condition must be a non-empty string")
 
     for field in ("inputs", "outputs"):
         vals = spec.get(field, [])
         if not isinstance(vals, list) or not all(isinstance(v, str) for v in vals):
             raise ValueError(f"spec_json.{field} must be an array of strings")
+
+
+def _validate_chat_config(node_id: str, config: Any) -> None:
+    """WorkflowChatConfig: {prompt: str (required), model?: str}."""
+    if not isinstance(config, dict) or not config.get("prompt"):
+        raise ValueError(f"node {node_id!r} (kind 'chat') requires config.prompt")
+    if not isinstance(config["prompt"], str):
+        raise ValueError(f"node {node_id!r} config.prompt must be a string")
+    model = config.get("model")
+    if model is not None and not isinstance(model, str):
+        raise ValueError(f"node {node_id!r} config.model must be a string")
+
+
+def _find_gate_node_ids(spec: dict[str, Any] | None) -> list[str]:
+    """Ids of any 'gate' nodes in *spec* — the kind was removed; see _VALID_NODE_KINDS."""
+    if not isinstance(spec, dict):
+        return []
+    return [
+        node.get("id")
+        for node in spec.get("nodes", [])
+        if isinstance(node, dict) and node.get("kind") == "gate"
+    ]
 
 
 def _validate_name(name: str) -> None:
@@ -206,6 +235,17 @@ async def get_workflow_def_route(def_id: str) -> dict[str, Any]:
     data = await get_workflow_def(def_id)
     if data is None:
         raise HTTPException(status_code=404, detail=f"Workflow definition '{def_id}' not found")
+    gate_ids = _find_gate_node_ids(data.get("spec_json"))
+    if gate_ids:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Workflow definition {def_id!r} contains removed 'gate' node(s) "
+                f"{gate_ids!r}. The 'gate' node kind was removed — conditions now "
+                "live on edges (WorkflowEdge.condition). Edit the definition to "
+                "remove or replace these nodes before it can be loaded."
+            ),
+        )
     return data
 
 
@@ -233,3 +273,31 @@ async def delete_workflow_def_route(def_id: str) -> dict[str, Any]:
     if not ok:
         raise HTTPException(status_code=404, detail=f"Workflow definition '{def_id}' not found")
     return {"ok": True}
+
+
+class RunWorkflowDefRequest(BaseModel):
+    inputs: dict[str, Any] | None = None
+
+
+@studio_route(
+    "/workflow-defs/{def_id}/run",
+    method="POST",
+    area="workflow-defs",
+    status_code=202,
+    name="run_workflow_def",
+)
+async def run_workflow_def_route(def_id: str, body: RunWorkflowDefRequest) -> dict[str, Any]:
+    """Compile *def_id* and execute it via Session.flow; returns {run_id, status}.
+
+    run_id is the same id GET /api/sessions/{id} and Fleet/History already read —
+    the run appears there like any other flow run (no new telemetry surface).
+    """
+    from .workflow_compile import WorkflowCompileError
+    from .workflow_run import WorkflowNotFoundError, run_workflow_def
+
+    try:
+        return await run_workflow_def(def_id, body.inputs)
+    except WorkflowNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except WorkflowCompileError as exc:
+        raise HTTPException(status_code=422, detail=exc.to_dict()) from exc

--- a/lionagi/studio/services/workflow_run.py
+++ b/lionagi/studio/services/workflow_run.py
@@ -14,6 +14,7 @@ while still reusing the session-row/branch-hook/teardown-reason logic those help
 
 from __future__ import annotations
 
+import asyncio
 import time
 import uuid
 from typing import Any
@@ -189,6 +190,13 @@ async def run_workflow_def(
         op_results = result.get("operation_results", {}) if isinstance(result, dict) else {}
         if any(isinstance(v, dict) and "error" in v for v in op_results.values()):
             status = "failed"
+    except asyncio.CancelledError:
+        # A cancelled Studio request/task aborts session.flow with
+        # CancelledError, which is a BaseException and so bypasses the
+        # `except Exception` below. Record the run as cancelled (not the
+        # optimistic "completed" default) before re-propagating the cancel.
+        status = "cancelled"
+        raise
     except Exception as e:  # noqa: BLE001
         status = "failed"
         exc = e

--- a/lionagi/studio/services/workflow_run.py
+++ b/lionagi/studio/services/workflow_run.py
@@ -172,7 +172,20 @@ async def run_workflow_def(
     status = "completed"
     exc: BaseException | None = None
     try:
-        result = await session.flow(graph, context=inputs or {})
+        from lionagi.cli.orchestrate._orchestration import register_branch_hook
+
+        result = await session.flow(
+            graph,
+            context=inputs or {},
+            # Flow-created clone branches (any op with a predecessor and no
+            # explicit branch_id — see FlowExecutor._preallocate_all_branches)
+            # are born AFTER _setup_run_persist already registered persistence
+            # for the branches that existed at setup time. Without this, a
+            # clone's transcript never persists even though the run-DAG
+            # signals still render (those persist via the session-level
+            # observer, not per-branch hooks).
+            on_branch_created=lambda b: register_branch_hook(ctx, b),
+        )
         op_results = result.get("operation_results", {}) if isinstance(result, dict) else {}
         if any(isinstance(v, dict) and "error" in v for v in op_results.values()):
             status = "failed"

--- a/lionagi/studio/services/workflow_run.py
+++ b/lionagi/studio/services/workflow_run.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Run a compiled WorkflowDef through lionagi's Session.flow, persisted like any other run.
+
+Deliberately does NOT reuse `lionagi.cli.orchestrate._orchestration.setup_orchestration_persist`
+/ `teardown_persist` verbatim: those helpers open the connection via
+`register_shared_db()`/`close_shared_db()`, a PROCESS-WIDE singleton meant for one-shot CLI
+processes that open it once and exit. The Studio server is long-lived and can have several
+workflow runs (or other StateDB users) in flight at once; teardown_persist's finally block
+closing the *entire* shared registry would tear down every concurrent run's connection, not
+just this one. This module opens and closes its own request-scoped StateDB connection instead,
+while still reusing the session-row/branch-hook/teardown-reason logic those helpers are built on.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any
+
+__all__ = ("run_workflow_def", "WorkflowNotFoundError")
+
+
+class WorkflowNotFoundError(Exception):
+    """No WorkflowDef with the given id."""
+
+
+async def _setup_run_persist(
+    session: Any,
+    *,
+    invocation_kind: str,
+    extra_node_metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    from lionagi.cli.orchestrate._orchestration import register_branch_hook
+    from lionagi.state.db import StateDB
+
+    db = StateDB()
+    await db.open()
+
+    session_id = str(session.id)
+    session_dict = session.to_dict(mode="db")
+    session_prog_id = str(uuid.uuid4())
+    await db.create_progression(session_prog_id)
+
+    node_metadata = {
+        **(session_dict.get("node_metadata") or {}),
+        **(extra_node_metadata or {}),
+    }
+    await db.create_session(
+        {
+            "id": session_id,
+            "created_at": session_dict["created_at"],
+            "node_metadata": node_metadata,
+            "name": session_dict.get("name"),
+            "user": session_dict.get("user"),
+            "progression_id": session_prog_id,
+            "first_msg_id": None,
+            "last_msg_id": None,
+            "invocation_kind": invocation_kind,
+            "status": "running",
+            "started_at": time.time(),
+        }
+    )
+
+    ctx: dict[str, Any] = {
+        "db": db,
+        "session": session,
+        "session_id": session_id,
+        "session_prog_id": session_prog_id,
+        "branch_prog_ids": {},
+        "hooks": [],
+    }
+    session.observer.bind_db_persistence(session_id, db=db)
+    for branch in session.branches:
+        register_branch_hook(ctx, branch)
+    return ctx
+
+
+async def _teardown_run_persist(
+    ctx: dict[str, Any] | None,
+    *,
+    status: str = "completed",
+    exception: BaseException | None = None,
+) -> str:
+    if ctx is None:
+        return status
+
+    from lionagi.cli._runs import _teardown_common
+    from lionagi.hooks import unroute_message_persistence
+
+    db = ctx["db"]
+    try:
+        final_status = await _teardown_common(
+            db,
+            session_id=ctx["session_id"],
+            session_prog_id=ctx["session_prog_id"],
+            status=status,
+            exception=exception,
+            artifacts_path=None,
+            artifact_contract=None,
+        )
+        for branch, handler in ctx.get("hooks", []):
+            unroute_message_persistence(branch, handler)
+        session_obj = ctx.get("session")
+        if session_obj is not None:
+            try:
+                session_obj.observer.unbind_db_persistence()
+            except Exception:  # noqa: BLE001, S110
+                pass
+        return final_status
+    finally:
+        await db.close()
+
+
+async def run_workflow_def(
+    def_id: str,
+    inputs: dict[str, Any] | None = None,
+    *,
+    _session: Any | None = None,
+) -> dict[str, Any]:
+    """Load, compile, and execute a WorkflowDef; return ``{run_id, status}``.
+
+    ``run_id`` is the lionagi Session id — the same primary key GET
+    /api/sessions/{id} and the Fleet/History list already read, so the run
+    shows up exactly like any other flow run. Raises WorkflowNotFoundError
+    (404) or WorkflowCompileError (422, carries node_id/edge_id) on failure
+    to compile; never a bare 500 for those two cases.
+
+    ``_session`` is a private testability seam (inject a Session with a
+    mocked default branch to avoid real provider calls in tests); real
+    callers (the run route) never pass it and get a fresh Session().
+    """
+    from lionagi.session.session import Session
+
+    from . import engine_defs
+    from .workflow_compile import WorkflowCompileError, compile_workflow_def, make_engine_operation
+    from .workflow_defs import get_workflow_def
+
+    defn = await get_workflow_def(def_id)
+    if defn is None:
+        raise WorkflowNotFoundError(f"Workflow definition {def_id!r} not found")
+
+    spec = defn.get("spec_json")
+    if not spec:
+        raise WorkflowCompileError("workflow definition has no spec_json to run")
+
+    async def _resolve_engine_def(ref: str) -> dict[str, Any] | None:
+        found = await engine_defs.get_engine_def(ref)
+        if found is None:
+            found = await engine_defs.get_engine_def_by_name(ref)
+        return found
+
+    graph, _id_map = await compile_workflow_def(spec, resolve_engine_def=_resolve_engine_def)
+
+    from .workflow_compile import build_early_graph
+
+    early_graph = build_early_graph(spec)
+
+    session = _session if _session is not None else Session()
+    session.register_operation("engine", make_engine_operation(session))
+
+    ctx = await _setup_run_persist(
+        session,
+        invocation_kind="flow",
+        extra_node_metadata={
+            "early_graph": early_graph,
+            "workflow_def_id": def_id,
+            "workflow_def_name": defn.get("name"),
+        },
+    )
+
+    status = "completed"
+    exc: BaseException | None = None
+    try:
+        result = await session.flow(graph, context=inputs or {})
+        op_results = result.get("operation_results", {}) if isinstance(result, dict) else {}
+        if any(isinstance(v, dict) and "error" in v for v in op_results.values()):
+            status = "failed"
+    except Exception as e:  # noqa: BLE001
+        status = "failed"
+        exc = e
+    finally:
+        await _teardown_run_persist(ctx, status=status, exception=exc)
+
+    return {"run_id": str(session.id), "status": status}

--- a/tests/apps_studio_server/test_workflow_compile.py
+++ b/tests/apps_studio_server/test_workflow_compile.py
@@ -1,0 +1,300 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for StudioExprCondition (safe expression evaluator) and compile_workflow_def."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("fastapi", reason="studio extra not installed")
+
+from lionagi.studio.services.workflow_compile import (
+    StudioExprCondition,
+    UnsafeExpressionError,
+    WorkflowCompileError,
+    build_early_graph,
+    compile_workflow_def,
+)
+
+# ─── StudioExprCondition: allowed grammar ───────────────────────────────────
+
+
+async def test_eq_comparison_true():
+    cond = StudioExprCondition(expr="result == 'ok'")
+    assert await cond.apply({"result": "ok", "context": {}}) is True
+
+
+async def test_eq_comparison_false():
+    cond = StudioExprCondition(expr="result == 'ok'")
+    assert await cond.apply({"result": "no", "context": {}}) is False
+
+
+async def test_and_or_not():
+    expr = "not (result == 'a') and (context['level'] >= 2 or result == 'b')"
+    cond = StudioExprCondition(expr=expr)
+    assert await cond.apply({"result": "b", "context": {"level": 0}}) is True
+    assert await cond.apply({"result": "a", "context": {"level": 5}}) is False
+
+
+async def test_attribute_access_on_object():
+    class R:
+        status = "done"
+
+    cond = StudioExprCondition(expr="result.status == 'done'")
+    assert await cond.apply({"result": R(), "context": {}}) is True
+
+
+async def test_attribute_access_on_dict_uses_get_semantics():
+    cond = StudioExprCondition(expr="result.missing == None")
+    assert await cond.apply({"result": {}, "context": {}}) is True
+
+
+async def test_subscript_access():
+    cond = StudioExprCondition(expr="result['status'] == 'done'")
+    assert await cond.apply({"result": {"status": "done"}, "context": {}}) is True
+
+
+async def test_in_not_in():
+    cond = StudioExprCondition(expr="result in ['a', 'b', 'c']")
+    assert await cond.apply({"result": "b", "context": {}}) is True
+    assert await cond.apply({"result": "z", "context": {}}) is False
+
+    cond2 = StudioExprCondition(expr="result not in ['a']")
+    assert await cond2.apply({"result": "z", "context": {}}) is True
+
+
+async def test_non_dict_context_normalized_to_empty_dict():
+    # apply() never crashes on an odd `context` shape from the executor — it
+    # normalizes to {}, so a name lookup then fails the same way an undefined
+    # name would (never silently falls back to builtins/globals).
+    cond = StudioExprCondition(expr="result == 'ok'")
+    with pytest.raises(UnsafeExpressionError):
+        await cond.apply(None)
+
+
+# ─── Hostile inputs — MUST reject at construction, never crash ─────────────
+
+HOSTILE_EXPRS = [
+    "__class__",
+    "result.__class__",
+    "().__class__.__bases__",
+    "result.__class__.__bases__[0]",
+    "__import__('os').system('echo hi')",
+    "__builtins__",
+    "result.__globals__",
+    "(lambda: 1)()",
+    "[x for x in range(10)]",
+    "eval('1')",
+    "exec('1')",
+    "compile('1', '<s>', 'eval')",
+    "result.__init__.__globals__['__builtins__']",
+]
+
+
+@pytest.mark.parametrize("expr", HOSTILE_EXPRS)
+def test_hostile_expressions_rejected_at_construction(expr):
+    with pytest.raises(UnsafeExpressionError):
+        StudioExprCondition(expr=expr)
+
+
+def test_deeply_nested_expression_rejected():
+    expr = "not " * 40 + "True"
+    with pytest.raises(UnsafeExpressionError):
+        StudioExprCondition(expr=expr)
+
+
+def test_huge_expression_rejected():
+    expr = "'" + ("a" * 5_000_000) + "' == 'x'"
+    with pytest.raises(UnsafeExpressionError):
+        StudioExprCondition(expr=expr)
+
+
+def test_empty_expression_rejected():
+    with pytest.raises(UnsafeExpressionError):
+        StudioExprCondition(expr="")
+
+
+def test_whitespace_only_expression_rejected():
+    with pytest.raises(UnsafeExpressionError):
+        StudioExprCondition(expr="   ")
+
+
+def test_syntax_error_rejected_not_crashed():
+    with pytest.raises(UnsafeExpressionError):
+        StudioExprCondition(expr="result ==")
+
+
+def test_walrus_rejected():
+    with pytest.raises(UnsafeExpressionError):
+        StudioExprCondition(expr="(x := 1) == 1")
+
+
+def test_fstring_rejected():
+    with pytest.raises(UnsafeExpressionError):
+        StudioExprCondition(expr="f'{result}' == 'ok'")
+
+
+def test_name_not_in_context_rejected_at_eval_not_construction():
+    # 'foo' is a syntactically fine Name — only rejected when evaluated
+    # against a context that doesn't define it (never falls back to globals).
+    cond = StudioExprCondition(expr="foo == 'bar'")
+    import asyncio
+
+    with pytest.raises(UnsafeExpressionError):
+        asyncio.run(cond.apply({"result": "x", "context": {}}))
+
+
+# ─── compile_workflow_def ────────────────────────────────────────────────────
+
+
+def _make_spec(**overrides: Any) -> dict[str, Any]:
+    spec: dict[str, Any] = {
+        "version": 1,
+        "nodes": [
+            {"id": "n1", "kind": "input", "label": "Input", "pos": {"x": 0, "y": 0}},
+            {
+                "id": "n2",
+                "kind": "chat",
+                "label": "Chat",
+                "pos": {"x": 100, "y": 0},
+                "config": {"prompt": "Summarize the input."},
+            },
+            {
+                "id": "n3",
+                "kind": "engine",
+                "label": "Research",
+                "pos": {"x": 200, "y": 0},
+                "config": {"engine_def_id": "def-1"},
+            },
+        ],
+        "edges": [
+            {"id": "e1", "from": "n1", "to": "n2"},
+            {"id": "e2", "from": "n2", "to": "n3", "condition": "result == 'go'"},
+        ],
+        "inputs": ["query"],
+        "outputs": ["report"],
+    }
+    spec.update(overrides)
+    return spec
+
+
+async def _resolve_ok(ref: str) -> dict[str, Any]:
+    return {"kind": "research", "model": None, "options": {}}
+
+
+async def test_compile_basic_graph():
+    graph, id_map = await compile_workflow_def(_make_spec(), resolve_engine_def=_resolve_ok)
+    assert set(id_map) == {"n2", "n3"}  # 'input' node is not an Operation
+    assert len(graph.internal_nodes) == 2
+    assert len(graph.internal_edges) == 1  # only n2->n3; n1 is 'input', dropped
+
+
+async def test_compile_edge_condition_is_studio_expr_condition():
+    graph, id_map = await compile_workflow_def(_make_spec(), resolve_engine_def=_resolve_ok)
+    edge = next(iter(graph.internal_edges))
+    assert isinstance(edge.condition, StudioExprCondition)
+    assert edge.condition.expr == "result == 'go'"
+
+
+async def test_compile_no_spurious_auto_chain_edge():
+    # Regression guard: OperationGraphBuilder.add_operation auto-chains a
+    # "sequential" edge from _current_heads when depends_on is falsy. Two
+    # nodes with NO edge between them in the spec must compile to zero edges.
+    spec = _make_spec(edges=[])
+    graph, _id_map = await compile_workflow_def(spec, resolve_engine_def=_resolve_ok)
+    assert len(graph.internal_edges) == 0
+
+
+@pytest.mark.parametrize("kind", ["parse", "fanout", "gate"])
+async def test_compile_dropped_kind_raises(kind):
+    spec = _make_spec()
+    spec["nodes"].append({"id": "n4", "kind": kind, "label": "D", "pos": {"x": 0, "y": 0}})
+    with pytest.raises(WorkflowCompileError) as exc_info:
+        await compile_workflow_def(spec, resolve_engine_def=_resolve_ok)
+    assert exc_info.value.node_id == "n4"
+
+
+async def test_compile_unknown_kind_raises():
+    spec = _make_spec()
+    spec["nodes"].append({"id": "n4", "kind": "teleport", "label": "?", "pos": {"x": 0, "y": 0}})
+    with pytest.raises(WorkflowCompileError) as exc_info:
+        await compile_workflow_def(spec, resolve_engine_def=_resolve_ok)
+    assert exc_info.value.node_id == "n4"
+
+
+async def test_compile_unknown_engine_def_raises_with_node_id():
+    async def _resolve_none(ref: str) -> None:
+        return None
+
+    with pytest.raises(WorkflowCompileError) as exc_info:
+        await compile_workflow_def(_make_spec(), resolve_engine_def=_resolve_none)
+    assert exc_info.value.node_id == "n3"
+
+
+async def test_compile_missing_engine_def_id_raises():
+    spec = _make_spec()
+    spec["nodes"][2]["config"] = {}
+    with pytest.raises(WorkflowCompileError) as exc_info:
+        await compile_workflow_def(spec, resolve_engine_def=_resolve_ok)
+    assert exc_info.value.node_id == "n3"
+
+
+async def test_compile_missing_chat_prompt_raises():
+    spec = _make_spec()
+    spec["nodes"][1]["config"] = {}
+    with pytest.raises(WorkflowCompileError) as exc_info:
+        await compile_workflow_def(spec, resolve_engine_def=_resolve_ok)
+    assert exc_info.value.node_id == "n2"
+
+
+async def test_compile_bad_condition_raises_with_edge_id():
+    spec = _make_spec()
+    spec["edges"][1]["condition"] = "__import__('os')"
+    with pytest.raises(WorkflowCompileError) as exc_info:
+        await compile_workflow_def(spec, resolve_engine_def=_resolve_ok)
+    assert exc_info.value.edge_id == "e2"
+
+
+async def test_compile_edge_to_unknown_target_raises_with_edge_id():
+    spec = _make_spec()
+    spec["edges"].append({"id": "e3", "from": "n3", "to": "ghost"})
+    with pytest.raises(WorkflowCompileError) as exc_info:
+        await compile_workflow_def(spec, resolve_engine_def=_resolve_ok)
+    assert exc_info.value.edge_id == "e3"
+
+
+async def test_compile_cycle_raises():
+    spec = _make_spec()
+    spec["edges"].append({"id": "e3", "from": "n3", "to": "n2"})  # n2->n3->n2
+    with pytest.raises(WorkflowCompileError, match="cycle"):
+        await compile_workflow_def(spec, resolve_engine_def=_resolve_ok)
+
+
+# ─── build_early_graph ───────────────────────────────────────────────────────
+
+
+def test_build_early_graph_shape():
+    early = build_early_graph(_make_spec())
+    ids = {n["id"] for n in early["nodes"]}
+    assert ids == {"n1", "n2", "n3"}  # 'input' IS included for display
+    edge_ids = {e["id"] for e in early["edges"]}
+    assert edge_ids == {"e1", "e2"}
+    e2 = next(e for e in early["edges"] if e["id"] == "e2")
+    assert e2["condition"] == "result == 'go'"
+    assert e2["mode"] == "code"
+    e1 = next(e for e in early["edges"] if e["id"] == "e1")
+    assert e1["mode"] == "simple"
+
+
+def test_build_early_graph_drops_non_executable_nodes():
+    spec = _make_spec()
+    spec["nodes"].append({"id": "n4", "kind": "gate", "label": "G", "pos": {"x": 0, "y": 0}})
+    spec["edges"].append({"id": "e3", "from": "n3", "to": "n4"})
+    early = build_early_graph(spec)
+    ids = {n["id"] for n in early["nodes"]}
+    assert "n4" not in ids
+    edge_ids = {e["id"] for e in early["edges"]}
+    assert "e3" not in edge_ids  # dangles to a dropped node

--- a/tests/apps_studio_server/test_workflow_compile.py
+++ b/tests/apps_studio_server/test_workflow_compile.py
@@ -298,6 +298,18 @@ async def test_compile_edge_to_unknown_target_raises_with_edge_id():
     assert exc_info.value.edge_id == "e3"
 
 
+async def test_compile_condition_on_input_edge_is_rejected():
+    """A condition on an edge from an 'input' node is dropped with the edge, so
+    it cannot gate the target — the target would run unconditionally. The
+    compiler must reject it (with the edge id) rather than silently ignore it.
+    """
+    spec = _make_spec()
+    spec["edges"][0]["condition"] = "context['enabled'] == True"  # e1: n1(input) -> n2
+    with pytest.raises(WorkflowCompileError) as exc_info:
+        await compile_workflow_def(spec, resolve_engine_def=_resolve_ok)
+    assert exc_info.value.edge_id == "e1"
+
+
 async def test_compile_cycle_raises():
     spec = _make_spec()
     spec["edges"].append({"id": "e3", "from": "n3", "to": "n2"})  # n2->n3->n2

--- a/tests/apps_studio_server/test_workflow_compile.py
+++ b/tests/apps_studio_server/test_workflow_compile.py
@@ -224,6 +224,32 @@ async def test_compile_merges_node_engine_options_over_def():
     }
 
 
+@pytest.mark.parametrize(
+    "unsafe_cmd",
+    [
+        "pytest; rm -rf /",  # shell metacharacter injection
+        "--config=/etc/passwd",  # leading-dash CLI-flag injection
+    ],
+)
+async def test_compile_rejects_unsafe_node_engine_options(unsafe_cmd):
+    """A node's config.options override the def's stored options, but those
+    author-supplied values never passed engine_defs' validation. An unsafe
+    test_cmd (shell metacharacters, leading-dash flag) reaches a coding
+    engine's command verbatim, so the compiler must re-validate the merged
+    options and reject it — otherwise a saved workflow smuggles shell control
+    past the engine-def safeguards.
+    """
+
+    async def _resolve_coding(ref: str) -> dict[str, Any]:
+        return {"kind": "coding", "model": None, "options": {"test_cmd": "pytest"}}
+
+    spec = _make_spec()
+    spec["nodes"][2]["config"]["options"] = {"test_cmd": unsafe_cmd}
+    with pytest.raises(WorkflowCompileError) as exc_info:
+        await compile_workflow_def(spec, resolve_engine_def=_resolve_coding)
+    assert exc_info.value.node_id == "n3"
+
+
 async def test_compile_edge_condition_is_studio_expr_condition():
     graph, id_map = await compile_workflow_def(_make_spec(), resolve_engine_def=_resolve_ok)
     edge = next(iter(graph.internal_edges))

--- a/tests/apps_studio_server/test_workflow_compile.py
+++ b/tests/apps_studio_server/test_workflow_compile.py
@@ -250,6 +250,54 @@ async def test_compile_rejects_unsafe_node_engine_options(unsafe_cmd):
     assert exc_info.value.node_id == "n3"
 
 
+@pytest.mark.parametrize(
+    "bad_budget", [{"max_agents": 9999}, {"max_depth": 0}, {"max_agents": "5"}]
+)
+async def test_compile_rejects_out_of_range_engine_budget(bad_budget):
+    """A node-level max_depth/max_agents override bypasses the EngineDef's
+    [1, 100]/int checks and reaches Engine(...) directly — a saved workflow
+    could spawn far more agents or recurse deeper than the def permits. The
+    compiler must re-validate the effective budget and reject it.
+    """
+    spec = _make_spec()
+    spec["nodes"][2]["config"].update(bad_budget)
+    with pytest.raises(WorkflowCompileError) as exc_info:
+        await compile_workflow_def(spec, resolve_engine_def=_resolve_ok)
+    assert exc_info.value.node_id == "n3"
+
+
+async def test_compile_null_budget_override_falls_back_to_def():
+    """An explicit null override must not discard the def's stricter budget."""
+
+    async def _resolve_with_budget(ref: str) -> dict[str, Any]:
+        return {"kind": "research", "model": None, "options": {}, "max_agents": 5}
+
+    spec = _make_spec()
+    spec["nodes"][2]["config"]["max_agents"] = None
+
+    graph, _id_map = await compile_workflow_def(spec, resolve_engine_def=_resolve_with_budget)
+
+    from lionagi.operations.node import Operation
+
+    engine_op = next(
+        n
+        for n in graph.internal_nodes.values()
+        if isinstance(n, Operation) and n.operation == "engine"
+    )
+    assert engine_op.parameters["engine_max_agents"] == 5  # def value, not None
+
+
+async def test_compile_non_mapping_engine_options_raises_with_node_id():
+    """A non-mapping config.options would raise TypeError on the ** merge,
+    escaping the ValueError wrapper as a 500. Reject it as a compile error.
+    """
+    spec = _make_spec()
+    spec["nodes"][2]["config"]["options"] = "bad"
+    with pytest.raises(WorkflowCompileError) as exc_info:
+        await compile_workflow_def(spec, resolve_engine_def=_resolve_ok)
+    assert exc_info.value.node_id == "n3"
+
+
 async def test_compile_non_mapping_config_raises_with_node_id():
     """A node whose config is not a mapping (e.g. a bare string) must surface a
     WorkflowCompileError with the node id, not an unstructured AttributeError —

--- a/tests/apps_studio_server/test_workflow_compile.py
+++ b/tests/apps_studio_server/test_workflow_compile.py
@@ -250,6 +250,18 @@ async def test_compile_rejects_unsafe_node_engine_options(unsafe_cmd):
     assert exc_info.value.node_id == "n3"
 
 
+async def test_compile_non_mapping_config_raises_with_node_id():
+    """A node whose config is not a mapping (e.g. a bare string) must surface a
+    WorkflowCompileError with the node id, not an unstructured AttributeError —
+    otherwise the run route returns 500 instead of the structured 422.
+    """
+    spec = _make_spec()
+    spec["nodes"][2]["config"] = "bad"
+    with pytest.raises(WorkflowCompileError) as exc_info:
+        await compile_workflow_def(spec, resolve_engine_def=_resolve_ok)
+    assert exc_info.value.node_id == "n3"
+
+
 async def test_compile_edge_condition_is_studio_expr_condition():
     graph, id_map = await compile_workflow_def(_make_spec(), resolve_engine_def=_resolve_ok)
     edge = next(iter(graph.internal_edges))

--- a/tests/apps_studio_server/test_workflow_compile.py
+++ b/tests/apps_studio_server/test_workflow_compile.py
@@ -192,6 +192,38 @@ async def test_compile_basic_graph():
     assert len(graph.internal_edges) == 1  # only n2->n3; n1 is 'input', dropped
 
 
+async def test_compile_merges_node_engine_options_over_def():
+    """A node's config.options override the referenced EngineDef's options
+    (node wins) while def-only keys are preserved — otherwise a per-node
+    test_cmd/export_dir override is silently discarded.
+    """
+
+    async def _resolve_with_opts(ref: str) -> dict[str, Any]:
+        return {
+            "kind": "research",
+            "model": None,
+            "options": {"test_cmd": "def_cmd", "export_dir": "def_dir"},
+        }
+
+    spec = _make_spec()
+    spec["nodes"][2]["config"]["options"] = {"test_cmd": "node_cmd"}
+
+    graph, _id_map = await compile_workflow_def(spec, resolve_engine_def=_resolve_with_opts)
+
+    from lionagi.operations.node import Operation
+
+    engine_ops = [
+        n
+        for n in graph.internal_nodes.values()
+        if isinstance(n, Operation) and n.operation == "engine"
+    ]
+    assert len(engine_ops) == 1
+    assert engine_ops[0].parameters["engine_options"] == {
+        "test_cmd": "node_cmd",  # node override wins
+        "export_dir": "def_dir",  # def-only key preserved
+    }
+
+
 async def test_compile_edge_condition_is_studio_expr_condition():
     graph, id_map = await compile_workflow_def(_make_spec(), resolve_engine_def=_resolve_ok)
     edge = next(iter(graph.internal_edges))

--- a/tests/apps_studio_server/test_workflow_defs_api.py
+++ b/tests/apps_studio_server/test_workflow_defs_api.py
@@ -168,3 +168,118 @@ def test_route_registration():
     assert ("GET", "/workflow-defs/{def_id}") in paths
     assert ("PUT", "/workflow-defs/{def_id}") in paths
     assert ("DELETE", "/workflow-defs/{def_id}") in paths
+    assert ("POST", "/workflow-defs/{def_id}/run") in paths
+
+
+# ─── gate-kind removal (workflow-exec Fork 1) ───────────────────────────────
+
+
+async def test_gate_kind_rejected_at_create(patched_svc):
+    svc, _ = patched_svc
+    spec = _spec()
+    spec["nodes"][0]["kind"] = "gate"
+    with pytest.raises(ValueError, match="invalid kind"):
+        await svc.create_workflow_def({"name": "gate-create", "spec_json": spec})
+
+
+async def test_gate_node_load_guard_names_the_node(patched_svc):
+    """A legacy row saved before the validator change fails GET with an actionable error."""
+    svc, _ = patched_svc
+    # Seed the db/tables, then write a legacy row directly (bypassing
+    # _validate_spec, which now rejects 'gate' — this simulates data saved
+    # before the kind was removed).
+    await svc.create_workflow_def({"name": "seed"})
+
+    import time
+    import uuid
+
+    from fastapi import HTTPException
+
+    from lionagi.state.db import StateDB
+
+    spec = _spec()
+    spec["nodes"][0]["kind"] = "gate"
+    def_id = uuid.uuid4().hex[:12]
+    now = time.time()
+    async with StateDB() as db:
+        await db.create_workflow_def(
+            {
+                "id": def_id,
+                "name": "legacy-gate",
+                "description": None,
+                "spec_json": spec,
+                "created_at": now,
+                "updated_at": now,
+            }
+        )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await svc.get_workflow_def_route(def_id)
+    assert exc_info.value.status_code == 422
+    assert "n1" in str(exc_info.value.detail)
+    assert "gate" in str(exc_info.value.detail)
+
+
+# ─── chat node config (WorkflowChatConfig) ──────────────────────────────────
+
+
+def _spec_with_chat(config: dict[str, Any]) -> dict[str, Any]:
+    spec = _spec()
+    spec["nodes"].append(
+        {"id": "n3", "kind": "chat", "label": "Chat", "pos": {"x": 100, "y": 0}, "config": config}
+    )
+    return spec
+
+
+async def test_chat_node_missing_prompt_raises(patched_svc):
+    svc, _ = patched_svc
+    with pytest.raises(ValueError, match="prompt"):
+        await svc.create_workflow_def({"name": "nochatprompt", "spec_json": _spec_with_chat({})})
+
+
+async def test_chat_node_non_string_prompt_raises(patched_svc):
+    svc, _ = patched_svc
+    spec = _spec_with_chat({"prompt": 5})
+    with pytest.raises(ValueError, match="prompt"):
+        await svc.create_workflow_def({"name": "badprompt", "spec_json": spec})
+
+
+async def test_chat_node_non_string_model_raises(patched_svc):
+    svc, _ = patched_svc
+    spec = _spec_with_chat({"prompt": "hi", "model": 5})
+    with pytest.raises(ValueError, match="model"):
+        await svc.create_workflow_def({"name": "badmodel", "spec_json": spec})
+
+
+async def test_chat_node_valid_config_passes(patched_svc):
+    svc, _ = patched_svc
+    spec = _spec_with_chat({"prompt": "hi", "model": "gpt-4"})
+    result = await svc.create_workflow_def({"name": "goodchat", "spec_json": spec})
+    assert "id" in result
+
+
+# ─── edge condition field (WorkflowEdge.condition) ──────────────────────────
+
+
+async def test_edge_condition_empty_string_raises(patched_svc):
+    svc, _ = patched_svc
+    spec = _spec()
+    spec["edges"][0]["condition"] = "   "
+    with pytest.raises(ValueError, match="condition"):
+        await svc.create_workflow_def({"name": "badcond", "spec_json": spec})
+
+
+async def test_edge_condition_non_string_raises(patched_svc):
+    svc, _ = patched_svc
+    spec = _spec()
+    spec["edges"][0]["condition"] = 42
+    with pytest.raises(ValueError, match="condition"):
+        await svc.create_workflow_def({"name": "badcond2", "spec_json": spec})
+
+
+async def test_edge_condition_valid_string_passes(patched_svc):
+    svc, _ = patched_svc
+    spec = _spec()
+    spec["edges"][0]["condition"] = "result == 'go'"
+    result = await svc.create_workflow_def({"name": "goodcond", "spec_json": spec})
+    assert "id" in result

--- a/tests/apps_studio_server/test_workflow_run.py
+++ b/tests/apps_studio_server/test_workflow_run.py
@@ -1,0 +1,214 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Backend end-to-end test for the Studio workflow execution bridge (slice 1).
+
+Builds a small WorkflowDef (input -> chat -> engine, with one conditioned
+edge), runs it through the real compile -> Session.flow -> persist vertical,
+and asserts it produces a real run whose node_metadata.early_graph carries
+the authored node ids and edges (the data get_session()["graph"] reads).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+aiosqlite = pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
+pytest.importorskip("fastapi", reason="studio extra not installed")
+
+
+def _spec() -> dict[str, Any]:
+    return {
+        "version": 1,
+        "nodes": [
+            {"id": "in", "kind": "input", "label": "Input", "pos": {"x": 0, "y": 0}},
+            {
+                "id": "chat1",
+                "kind": "chat",
+                "label": "Draft",
+                "pos": {"x": 150, "y": 0},
+                "config": {"prompt": "Draft a summary."},
+            },
+            {
+                "id": "eng1",
+                "kind": "engine",
+                "label": "Research",
+                "pos": {"x": 300, "y": 0},
+                "config": {"engine_def_id": "PLACEHOLDER"},
+            },
+        ],
+        "edges": [
+            {"id": "e1", "from": "in", "to": "chat1"},
+            {"id": "e2", "from": "chat1", "to": "eng1", "condition": "result != None"},
+        ],
+        "inputs": ["topic"],
+        "outputs": ["summary"],
+    }
+
+
+class _FakeEngine:
+    """Stand-in for a real Engine (research/review/coding/...) — no network calls."""
+
+    calls: list[dict[str, Any]] = []
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+
+    async def run(self, spec_input: str, *, session: Any = None, **kwargs: Any) -> dict[str, Any]:
+        _FakeEngine.calls.append({"spec_input": spec_input, "kwargs": kwargs})
+        return {"echo": spec_input}
+
+
+def _mock_chat_branch(name: str = "workflow-default"):
+    """Branch whose chat_model is mocked — copies the convention already
+    established in tests/operations/test_edge_conditions_tdd.py."""
+    from lionagi.protocols.generic.event import EventStatus
+    from lionagi.session.branch import Branch
+    from lionagi.testing import LionAGIMockFactory
+
+    branch = Branch(user="test_user", name=name)
+
+    async def _fake_invoke(**kwargs):
+        return LionAGIMockFactory.create_api_calling_mock(
+            response_data="go",
+            status=EventStatus.COMPLETED,
+            model="gpt-4-mini",
+        )
+
+    mock_chat_model = LionAGIMockFactory.create_mocked_imodel(
+        provider="openai", model="gpt-4-mini", response="overridden-below"
+    )
+    mock_chat_model.invoke = AsyncMock(side_effect=_fake_invoke)
+    branch.chat_model = mock_chat_model
+    return branch
+
+
+@pytest.fixture
+def patched_env(tmp_path: Path, monkeypatch):
+    import lionagi.state.db as db_mod
+    import lionagi.studio.services.engine_defs as engine_defs_svc
+    import lionagi.studio.services.sessions as sessions_svc
+    import lionagi.studio.services.workflow_defs as wf_svc
+
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(db_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(wf_svc, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(engine_defs_svc, "DEFAULT_DB_PATH", db_path)
+    # sessions.py freezes `_DB = str(DEFAULT_DB_PATH)` at import time (module
+    # constant, not re-read per call) — both attrs need patching, matching the
+    # convention already established in test_admin.py.
+    monkeypatch.setattr(sessions_svc, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(sessions_svc, "_DB", str(db_path))
+
+    import lionagi.cli.engine as cli_engine
+
+    monkeypatch.setitem(
+        cli_engine._KIND_META,
+        "research",
+        {
+            **cli_engine._KIND_META["research"],
+            "cls_path": ("tests.apps_studio_server.test_workflow_run", "_FakeEngine"),
+        },
+    )
+    return wf_svc, engine_defs_svc
+
+
+async def test_workflow_run_end_to_end(patched_env):
+    wf_svc, engine_defs_svc = patched_env
+    _FakeEngine.calls = []
+
+    engine_def = await engine_defs_svc.create_engine_def(
+        {"name": "research-eng", "kind": "research"}
+    )
+
+    spec = _spec()
+    spec["nodes"][2]["config"]["engine_def_id"] = engine_def["id"]
+    created = await wf_svc.create_workflow_def({"name": "e2e-flow", "spec_json": spec})
+    def_id = created["id"]
+
+    from lionagi.session.session import Session
+    from lionagi.studio.services.workflow_run import run_workflow_def
+
+    mock_branch = _mock_chat_branch()
+    session = Session(default_branch=mock_branch)
+
+    result = await run_workflow_def(def_id, {"topic": "GQA"}, _session=session)
+
+    assert result["status"] == "completed"
+    assert len(_FakeEngine.calls) == 1
+    assert _FakeEngine.calls[0]["spec_input"]  # the chat node's result flowed into the engine
+
+    run_id = result["run_id"]
+    assert run_id == str(session.id)
+
+    from lionagi.studio.services.sessions import get_session
+
+    session_row = await get_session(run_id)
+    assert session_row is not None
+    assert session_row["status"] == "completed"
+    assert session_row["invocation_kind"] == "flow"
+
+    graph = session_row["graph"]
+    assert graph is not None, "node_metadata.early_graph must render through get_session()['graph']"
+    node_ids = {n["id"] for n in graph["nodes"]}
+    assert node_ids == {"in", "chat1", "eng1"}  # the AUTHORED ids, not internal Operation UUIDs
+
+    edges_by_id = {e["id"]: e for e in graph["edges"]}
+    assert set(edges_by_id) == {"e1", "e2"}
+    assert edges_by_id["e2"]["condition"] == "result != None"
+    assert edges_by_id["e2"]["mode"] == "code"
+
+
+async def test_workflow_run_not_found_raises(patched_env):
+    from lionagi.studio.services.workflow_run import WorkflowNotFoundError, run_workflow_def
+
+    with pytest.raises(WorkflowNotFoundError):
+        await run_workflow_def("does-not-exist")
+
+
+async def test_workflow_run_compile_error_surfaces_node_id(patched_env):
+    wf_svc, engine_defs_svc = patched_env
+    from lionagi.studio.services.workflow_compile import WorkflowCompileError
+    from lionagi.studio.services.workflow_run import run_workflow_def
+
+    engine_def = await engine_defs_svc.create_engine_def({"name": "eng-a", "kind": "research"})
+    spec = _spec()
+    spec["nodes"][2]["config"]["engine_def_id"] = engine_def["id"]
+    spec["edges"][1]["condition"] = "__import__('os')"
+    created = await wf_svc.create_workflow_def({"name": "bad-cond-flow", "spec_json": spec})
+
+    with pytest.raises(WorkflowCompileError) as exc_info:
+        await run_workflow_def(created["id"])
+    assert exc_info.value.edge_id == "e2"
+
+
+async def test_run_route_returns_structured_422_on_compile_error(patched_env):
+    from fastapi import HTTPException
+
+    wf_svc, engine_defs_svc = patched_env
+    from lionagi.studio.services.workflow_defs import RunWorkflowDefRequest, run_workflow_def_route
+
+    engine_def = await engine_defs_svc.create_engine_def({"name": "eng-b", "kind": "research"})
+    spec = _spec()
+    spec["nodes"][2]["config"]["engine_def_id"] = engine_def["id"]
+    spec["edges"][1]["condition"] = "__import__('os')"
+    created = await wf_svc.create_workflow_def({"name": "bad-cond-route", "spec_json": spec})
+
+    with pytest.raises(HTTPException) as exc_info:
+        await run_workflow_def_route(created["id"], RunWorkflowDefRequest(inputs=None))
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail["edge_id"] == "e2"
+
+
+async def test_run_route_returns_404_for_missing_def(patched_env):
+    from fastapi import HTTPException
+
+    from lionagi.studio.services.workflow_defs import RunWorkflowDefRequest, run_workflow_def_route
+
+    with pytest.raises(HTTPException) as exc_info:
+        await run_workflow_def_route("nonexistent", RunWorkflowDefRequest(inputs=None))
+    assert exc_info.value.status_code == 404

--- a/tests/apps_studio_server/test_workflow_run.py
+++ b/tests/apps_studio_server/test_workflow_run.py
@@ -11,6 +11,7 @@ the authored node ids and edges (the data get_session()["graph"] reads).
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock
@@ -161,6 +162,42 @@ async def test_workflow_run_end_to_end(patched_env):
     assert set(edges_by_id) == {"e1", "e2"}
     assert edges_by_id["e2"]["condition"] == "result != None"
     assert edges_by_id["e2"]["mode"] == "code"
+
+
+async def test_cancelled_run_is_recorded_as_cancelled(patched_env, monkeypatch):
+    """If session.flow is cancelled mid-run (Studio request/task cancelled),
+    CancelledError (a BaseException) bypasses the `except Exception` handler.
+    The run must be recorded as 'cancelled', not left at the optimistic
+    'completed' default, and the cancellation must re-propagate.
+    """
+    wf_svc, engine_defs_svc = patched_env
+
+    engine_def = await engine_defs_svc.create_engine_def({"name": "cancel-eng", "kind": "research"})
+    spec = _spec()
+    spec["nodes"][2]["config"]["engine_def_id"] = engine_def["id"]
+    created = await wf_svc.create_workflow_def({"name": "cancel-flow", "spec_json": spec})
+    def_id = created["id"]
+
+    from lionagi.session.session import Session
+    from lionagi.studio.services.workflow_run import run_workflow_def
+
+    session = Session(default_branch=_mock_chat_branch())
+
+    async def _cancelled_flow(self, *args, **kwargs):
+        raise asyncio.CancelledError
+
+    # Session is a pydantic model (no instance-attr assignment); patch the
+    # bound method on the class for this test only.
+    monkeypatch.setattr(Session, "flow", _cancelled_flow)
+
+    with pytest.raises(asyncio.CancelledError):
+        await run_workflow_def(def_id, {"topic": "GQA"}, _session=session)
+
+    from lionagi.studio.services.sessions import get_session
+
+    row = await get_session(str(session.id))
+    assert row is not None
+    assert row["status"] == "cancelled"
 
 
 async def test_workflow_run_not_found_raises(patched_env):

--- a/tests/apps_studio_server/test_workflow_run_persist.py
+++ b/tests/apps_studio_server/test_workflow_run_persist.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Regression test for the flow-created clone-branch persistence gap (codex P1, #1833).
+"""Regression test for the flow-created clone-branch persistence gap.
 
 `workflow_run._setup_run_persist` registers per-branch persistence
 (`register_branch_hook`) only for the branches present on `session.branches`
@@ -147,7 +147,7 @@ async def test_flow_clone_branch_transcript_persists(patched_env):
         branch_row = await db.get_branch(clone_branch_id)
         assert branch_row is not None, (
             "clone branch row missing from StateDB -- the clone was never "
-            "registered via register_branch_hook (the P1 bug)"
+            "registered via register_branch_hook"
         )
         assert branch_row["session_id"] == str(session.id)
 

--- a/tests/apps_studio_server/test_workflow_run_persist.py
+++ b/tests/apps_studio_server/test_workflow_run_persist.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression test for the flow-created clone-branch persistence gap (codex P1, #1833).
+
+`workflow_run._setup_run_persist` registers per-branch persistence
+(`register_branch_hook`) only for the branches present on `session.branches`
+at setup time. `session.flow()` -> `FlowExecutor._preallocate_all_branches`
+then clones `session.default_branch` for every operation that has a
+predecessor and no explicit `branch_id` (exactly what the Studio compiler
+produces for any multi-step workflow). Those clones are born *after* setup,
+so without the `on_branch_created` seam their transcripts never persist —
+even though the run-DAG *signals* still render, because those persist via a
+separate session-level observer, not the per-branch message hook.
+
+This test proves the fix by exercising the exact code path
+`workflow_run.run_workflow_def` uses (`Session.flow(..., on_branch_created=...)`
+wired to `register_branch_hook`), forcing a real branch clone, producing a
+real persisted message on it (via `branch.communicate()`, which -- unlike
+the Studio "chat" node kind -- actually calls `branch.msgs.a_add_message()`
+and so fires the `on_message_added` -> `MESSAGE_ADD` hook chain that
+`register_branch_hook` wires into StateDB), and then reading the message
+back out of a *fresh* StateDB connection.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+aiosqlite = pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
+pytest.importorskip("fastapi", reason="studio extra not installed")
+
+
+def _mock_chat_branch(name: str = "workflow-default"):
+    """Same convention as test_workflow_run.py / test_edge_conditions_tdd.py."""
+    from lionagi.protocols.generic.event import EventStatus
+    from lionagi.session.branch import Branch
+    from lionagi.testing import LionAGIMockFactory
+
+    branch = Branch(user="test_user", name=name)
+
+    async def _fake_invoke(**kwargs):
+        return LionAGIMockFactory.create_api_calling_mock(
+            response_data="go",
+            status=EventStatus.COMPLETED,
+            model="gpt-4-mini",
+        )
+
+    mock_chat_model = LionAGIMockFactory.create_mocked_imodel(
+        provider="openai", model="gpt-4-mini", response="overridden-below"
+    )
+    mock_chat_model.invoke = AsyncMock(side_effect=_fake_invoke)
+    branch.chat_model = mock_chat_model
+    return branch
+
+
+@pytest.fixture
+def patched_env(tmp_path: Path, monkeypatch):
+    import lionagi.state.db as db_mod
+
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(db_mod, "DEFAULT_DB_PATH", db_path)
+    return db_path
+
+
+async def test_flow_clone_branch_transcript_persists(patched_env):
+    """A downstream op with a predecessor and no branch_id gets a CLONED
+    branch (verified: its id differs from the default branch); this test
+    proves that clone's transcript (not just the default branch's, not just
+    run-completion) lands in StateDB -- reproducing exactly the seam
+    `run_workflow_def` wires via `on_branch_created=lambda b:
+    register_branch_hook(ctx, b)`.
+    """
+    db_path = patched_env
+
+    from lionagi.cli.orchestrate._orchestration import register_branch_hook
+    from lionagi.operations.builder import OperationGraphBuilder
+    from lionagi.session.session import Session
+    from lionagi.studio.services.workflow_run import (
+        _setup_run_persist,
+        _teardown_run_persist,
+    )
+
+    mock_branch = _mock_chat_branch()
+    session = Session(default_branch=mock_branch)
+
+    # Two "communicate" ops (communicate() -- unlike the Studio "chat" node
+    # kind -- calls branch.msgs.a_add_message(), the thing that actually
+    # exercises the persistence hook chain): op2 depends on op1 with no
+    # explicit branch, so _preallocate_all_branches must clone a branch for it.
+    builder = OperationGraphBuilder("clone-persist-test")
+    op1_id = builder.add_operation("communicate", instruction="draft a message")
+    op2_id = builder.add_operation("communicate", instruction="continue the thread")
+    graph = builder.graph
+
+    ctx = await _setup_run_persist(session, invocation_kind="flow")
+
+    created_branches: list[Any] = []
+
+    def _on_branch_created(branch: Any) -> None:
+        created_branches.append(branch)
+        register_branch_hook(ctx, branch)
+
+    status = "completed"
+    exc: BaseException | None = None
+    try:
+        result = await session.flow(
+            graph,
+            context={},
+            on_branch_created=_on_branch_created,
+        )
+    except Exception as e:  # noqa: BLE001
+        status = "failed"
+        exc = e
+        raise
+    finally:
+        await _teardown_run_persist(ctx, status=status, exception=exc)
+
+    assert not isinstance(result.get("operation_results", {}).get(op1_id), dict) or (
+        "error" not in result["operation_results"].get(op1_id, {})
+    )
+    assert "error" not in result["operation_results"].get(op2_id, {})
+
+    # --- Prove op2 actually ran on a CLONE branch (predecessor, no branch_id) ---
+    assert len(created_branches) == 1, (
+        "expected exactly one clone: op1 has no predecessor (stays on default "
+        "branch); op2 depends on op1 with no explicit branch_id, so "
+        "_preallocate_all_branches must clone default_branch for it"
+    )
+    clone_branch = created_branches[0]
+    clone_branch_id = str(clone_branch.id)
+    assert clone_branch_id != str(mock_branch.id), (
+        "the persisted branch must be the CLONE flow allocated for op2, not "
+        "the session's original default branch"
+    )
+
+    # --- Query a FRESH StateDB connection (ctx["db"] is closed by teardown) ---
+    from lionagi.state.db import StateDB
+
+    db = StateDB(db_path)
+    await db.open()
+    try:
+        branch_row = await db.get_branch(clone_branch_id)
+        assert branch_row is not None, (
+            "clone branch row missing from StateDB -- the clone was never "
+            "registered via register_branch_hook (the P1 bug)"
+        )
+        assert branch_row["session_id"] == str(session.id)
+
+        messages = await db.get_branch_messages(clone_branch_id)
+        assert len(messages) >= 2, (
+            "the clone branch's communicate() call must have persisted its "
+            "instruction + assistant-response messages under ITS OWN "
+            f"progression; got {messages!r}"
+        )
+        senders_recipients = {m.get("sender") for m in messages} | {
+            m.get("recipient") for m in messages
+        }
+        assert clone_branch_id in senders_recipients, (
+            "persisted messages must be attributed to the clone branch, not the default branch"
+        )
+    finally:
+        await db.close()
+
+
+async def test_default_branch_op_with_no_predecessor_is_not_cloned(patched_env):
+    """Guard: an op with no predecessor and no branch_id stays on the
+    default branch (no clone) -- confirms the setup in the test above forces
+    a clone specifically for the DOWNSTREAM op, not both.
+    """
+    from lionagi.operations.builder import OperationGraphBuilder
+    from lionagi.session.session import Session
+
+    mock_branch = _mock_chat_branch()
+    session = Session(default_branch=mock_branch)
+
+    builder = OperationGraphBuilder("no-clone-test")
+    builder.add_operation("communicate", instruction="draft a message")
+    graph = builder.graph
+
+    created_branches: list[Any] = []
+    await session.flow(
+        graph,
+        context={},
+        on_branch_created=lambda b: created_branches.append(b),
+    )
+
+    assert created_branches == []


### PR DESCRIPTION
## What & why

A Studio graph `WorkflowDef` was inert JSON — `workflow_defs.py` was pure CRUD, no run/compile surface. Ocean's verdict on the designer: "the whole page is just a show." This makes a drawn workflow a **runnable** one by compiling it onto lionagi's existing flow machinery (`OperationGraphBuilder` / `Session.flow` / `DependencyAwareExecutor`) — no new engine (FindExisting).

**Scope: backend Slice 1.** The frontend Run button + engine-node face/detail-pane UI are Slice 2 (see condition 5).

Spec: `.khive/workspaces/20260706/studio-workflow-exec/SPEC.md` (Leo/Fable-approved gate; R3 ratified by Ocean — engine node ships opaque in v1).

## Acceptance conditions (verified at Leo's gate before merge)

**1. StudioExprCondition hardening** — `workflow_compile.py::StudioExprCondition(EdgeCondition)`. Restricted-grammar AST evaluator: `ast.parse(mode="eval")`, **no eval/exec/compile/`__import__`**, closed node-type allowlist (no `Call`/`Lambda`/comprehension), attribute + name access with a leading `_` rejected at validate time (kills `__class__`/`__globals__`/`__builtins__` escape), length cap 1000, depth cap 20, evaluation context strictly `{"result","context"}`. Hostile-expr tests (`test_hostile_expressions_rejected_at_construction`, 13 payloads incl. `result.__class__.__bases__[0]`, `__import__('os').system(...)`, `result.__globals__`, `(lambda:1)()`, comprehension, `eval/exec/compile(...)`) + deep-nest (40×), 5 MB input, walrus, f-string, syntax-error — all raise `UnsafeExpressionError`, none crash. (Also fixed: pydantic wrapping the raise into `ValidationError` and defeating `except UnsafeExpressionError` — now validated in `__init__` before `super().__init__()`.)

**2. gate-kind removal compat** — `gate` removed from `_VALID_NODE_KINDS`. Count query on the real `~/.lionagi/state.db` (`select id,name,spec_json from workflow_defs`): **1 total row, 0 with a gate node.** A saved def carrying a legacy `gate` node fails `GET /workflow-defs/{id}` with **422 naming the node id** (`test_gate_node_load_guard_names_the_node`), not a generic error.

**3. structured compile errors** — `WorkflowCompileError.to_dict() = {error, node_id, edge_id}`; the run route raises `HTTPException(422, detail=...)`, never a bare 500 for bad expr / unknown `engine_def_id` / missing def. Asserted by `test_run_route_returns_structured_422_on_compile_error` (bad condition → `detail["edge_id"]=="e2"`) + `test_workflow_run_compile_error_surfaces_node_id` + `test_run_route_returns_404_for_missing_def`.

**4. engine node RUNS end-to-end** — `test_workflow_run_end_to_end`: real WorkflowDef (`input → chat → engine`, edge `e2` conditioned `result != None`), real `engine_defs` row, in-process fake Engine (no network), through the actual `run_workflow_def` → compile → `Session.flow()` → persist path. Asserts `status=="completed"`, engine invoked once with derived input (conditioned edge passed + data flowed), and `get_session(run_id)` returns `invocation_kind=="flow"` with the **authored** node/edge ids (`in,chat1,eng1 / e1,e2`, `e2.condition=="result != None"`) — Fleet/History renders the authored DAG via the existing `get_session`, no new telemetry.

**5. engine node READS intuitively** — **Slice 2 (frontend), not this PR.** Backend prep done: `build_early_graph()` shapes nodes/edges to the frontend's existing `WorkerStepNode`/`WorkerLinkEdge` types (label, role, prompt, inputs, outputs, condition, mode) and `sessions.py` passes it through to `get_session()["graph"]`, which `RunDetail.tsx` already renders via `WorkerCanvas`. The node-face/detail-pane field selection is Slice 2's call.

## Design notes

- **Conditions live on edges** (Fork 1): `WorkflowEdge.condition` compiles 1:1 to lionagi `Edge.condition`. The `gate` node kind is removed, not desugared.
- **parse/fanout dropped v1**: reach compile → structured "not executable in v1" error, never the executor.
- **Fork-3 authored-graph propagation**: `node_id → reference_id` via `add_operation(node_id=...)`; the builder's implicit auto-chaining is reset per node so the only edges are the hand-wired authored ones (`test_compile_no_spurious_auto_chain_edge`). No interaction with `depends_on` emission.

## Tests
`test_workflow_compile.py` 44 · `test_workflow_run.py` 5 · `test_workflow_defs_api.py` 25 (was 12) → **74 passed, 0 failed** (re-run independently on a clean origin/main graft). Full `tests/apps_studio_server/` 746 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Core-scope note (deliberate, Leo-approved)

This PR touches core `lionagi/operations/flow.py` and `session/session.py`, not only the Studio service, and that is intentional. The clone-branch persistence gap lives in `FlowExecutor._preallocate_all_branches`, which clones `session.default_branch` for every op with a predecessor and no explicit `branch_id` — the shape the Studio compiler always produces. There is no Studio-only seam to fix it. The change adds one optional `on_branch_created: Callable | None = None` parameter threaded `flow()` → `Session.flow()` → `FlowExecutor`, default-`None` and backward-compatible: it is invoked only to let a caller wire per-branch persistence on mid-flow clones. It never alters execution or branch semantics (guarded, fires after the clone is already cloned + included, does not await or touch `session.branches`).

The identical gap exists on the CLI `li o flow` path (same executor, same clone site). It is filed separately as #1835 rather than expanded into this PR; the fix there is to adopt the same `on_branch_created` callback.

Note on scope of persistence: the per-branch message transcript this enables is a no-op for today’s `chat`/`engine` nodes specifically, because `branch.chat()` returns its `AssistantResponse` without adding a branch message. Node *outputs* still surface via `operation_results` + the run-DAG signals (a separate session-level observer). The seam is correct and future-proofs message-writing node kinds (`communicate`/`operate`/multi-turn branches); the regression test uses `communicate` precisely because it is the op kind that actually writes messages.

---

### Follow-ups tracked outside this slice

- **#1836** — Studio workflow runs emit no per-node lifecycle signals (`workflow_run` drives `session.flow` directly and never passes `on_progress`, so the outer workflow DAG emits no `NodeStarted/Completed` rows and RunDetail cannot animate nodes running→completing). Pre-existing; the fix needs extracting the engine's signal adapter (`engine.py`), whose blast radius belongs with Slice-2 reviewability. The Slice-2 live demo (node running→completing animation on a real engine_def) drives and validates it. Deferred out of slice 1.
- **#1835** — the same clone-branch persistence gap on the CLI `li o flow` path.