### PR TITLE
feat(studio): run_tags backend — m2m run tags + tag filter (C slice 1)

### DIFF
--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -93,7 +93,7 @@ CREATE INDEX IF NOT EXISTS idx_projects_updated ON projects(updated_at DESC);
 -- ── Run tags ──────────────────────────────────────────────────────────────
 -- User-defined m2m labels over runs (a run == a session). Free-form strings.
 CREATE TABLE IF NOT EXISTS run_tags (
-    session_id TEXT NOT NULL,
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
     tag        TEXT NOT NULL,
     created_at REAL NOT NULL,
     PRIMARY KEY (session_id, tag)

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -90,6 +90,16 @@ CREATE TABLE IF NOT EXISTS projects (
 CREATE INDEX IF NOT EXISTS idx_projects_source ON projects(source);
 CREATE INDEX IF NOT EXISTS idx_projects_updated ON projects(updated_at DESC);
 
+-- ── Run tags ──────────────────────────────────────────────────────────────
+-- User-defined m2m labels over runs (a run == a session). Free-form strings.
+CREATE TABLE IF NOT EXISTS run_tags (
+    session_id TEXT NOT NULL,
+    tag        TEXT NOT NULL,
+    created_at REAL NOT NULL,
+    PRIMARY KEY (session_id, tag)
+);
+CREATE INDEX IF NOT EXISTS idx_run_tags_tag ON run_tags(tag);
+
 -- ── Sessions ──────────────────────────────────────────────────────────────
 -- Scope boundary.  Owns a progression (the session-level message pool)
 -- and zero or more branches.

--- a/lionagi/state/schema_meta.py
+++ b/lionagi/state/schema_meta.py
@@ -916,3 +916,18 @@ Index(
     sqlite_where=text("status IN ('pending', 'delivering')"),
     postgresql_where=text("status IN ('pending', 'delivering')"),
 )
+
+# ── run_tags ──────────────────────────────────────────────────────────────────
+# Free-form review labels attached to a run (session). Kept in the canonical
+# metadata (not only schema.sql) so StateDB.open()/create_all builds it on every
+# backend, keeping the SQLite, Postgres, and schema-parity paths consistent.
+
+run_tags = Table(
+    "run_tags",
+    metadata,
+    Column("session_id", Text, primary_key=True),
+    Column("tag", Text, primary_key=True),
+    Column("created_at", Float, nullable=False),
+)
+
+Index("idx_run_tags_tag", run_tags.c.tag)

--- a/lionagi/state/schema_meta.py
+++ b/lionagi/state/schema_meta.py
@@ -925,7 +925,12 @@ Index(
 run_tags = Table(
     "run_tags",
     metadata,
-    Column("session_id", Text, primary_key=True),
+    Column(
+        "session_id",
+        Text,
+        ForeignKey("sessions.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
     Column("tag", Text, primary_key=True),
     Column("created_at", Float, nullable=False),
 )

--- a/lionagi/studio/registry.py
+++ b/lionagi/studio/registry.py
@@ -57,6 +57,7 @@ _STUDIO_ROUTE_MODULES: tuple[str, ...] = (
     "lionagi.studio.services.engine_defs",
     "lionagi.studio.services.workflow_defs",
     "lionagi.studio.services.sessions",
+    "lionagi.studio.services.run_tags",
     "lionagi.studio.services.leo",
     "lionagi.studio.services.admin",
     "lionagi.studio.services.schedules",

--- a/lionagi/studio/services/run_tags.py
+++ b/lionagi/studio/services/run_tags.py
@@ -9,7 +9,7 @@ from typing import Any
 from fastapi import HTTPException
 from pydantic import BaseModel
 
-from lionagi.state.db import DEFAULT_DB_PATH
+from lionagi.state.db import DEFAULT_DB_PATH, StateDB
 
 from ..registry import studio_route
 from ._db import open_db as _open_db
@@ -36,6 +36,14 @@ async def add_tag(session_id: str, tag: str) -> None:
     clean = (tag or "").strip()
     if not clean:
         raise HTTPException(status_code=422, detail="tag must not be empty")
+
+    if not DEFAULT_DB_PATH.exists():
+        # A tag write on a fresh install must not leave a partial db behind
+        # (only run_tags, no sessions/etc). Apply the full schema first via
+        # StateDB so every table exists before this module adds run_tags.
+        _db = StateDB()
+        await _db.open()
+        await _db.close()
 
     now = time.time()
     async with _open_db(_DB) as db:
@@ -65,6 +73,8 @@ async def tags_for_sessions(session_ids: list[str]) -> dict[str, list[str]]:
     sessions with no tags are simply absent from the result (caller defaults
     to []).
     """
+    if not DEFAULT_DB_PATH.exists():
+        return {}
     if not session_ids:
         return {}
 
@@ -91,6 +101,8 @@ async def session_ids_with_tags(tags: list[str]) -> set[str] | None:
     requested" — callers must treat None as pass-through, not as "no matches".
     A non-empty list with no matching sessions returns an empty set.
     """
+    if not DEFAULT_DB_PATH.exists():
+        return None
     if not tags:
         return None
 
@@ -121,7 +133,7 @@ async def add_run_tag(session_id: str, body: TagBody) -> dict[str, Any]:
 
 
 @studio_route(
-    "/sessions/{session_id}/tags/{tag}",
+    "/sessions/{session_id}/tags/{tag:path}",
     method="DELETE",
     area="sessions",
     name="remove_run_tag",

--- a/lionagi/studio/services/run_tags.py
+++ b/lionagi/studio/services/run_tags.py
@@ -57,6 +57,12 @@ async def add_tag(session_id: str, tag: str) -> None:
 
 async def remove_tag(session_id: str, tag: str) -> None:
     """Detach a tag from a run (session)."""
+    if not DEFAULT_DB_PATH.exists():
+        # Nothing to detach, and a delete must never create the db file
+        # (mirrors the read-path guards). Only add_tag initializes the full
+        # schema — a bare _ensure_table here would leave a run_tags-only db
+        # that makes every later sessions query fail.
+        return
     async with _open_db(_DB) as db:
         await _ensure_table(db)
         await db.execute(

--- a/lionagi/studio/services/run_tags.py
+++ b/lionagi/studio/services/run_tags.py
@@ -9,6 +9,7 @@ from typing import Any
 from fastapi import HTTPException
 from pydantic import BaseModel
 
+from lionagi._errors import NotFoundError
 from lionagi.state.db import DEFAULT_DB_PATH, StateDB
 
 from ..registry import studio_route
@@ -133,6 +134,15 @@ class TagBody(BaseModel):
 
 @studio_route("/sessions/{session_id}/tags", method="POST", area="sessions", name="add_run_tag")
 async def add_run_tag(session_id: str, body: TagBody) -> dict[str, Any]:
+    # Reject tagging a session that does not exist, matching the other
+    # session-child endpoints (stream, signals). list_runs() only surfaces
+    # rows joined from `sessions`, so a tag written against a stale or
+    # mistyped id would succeed with 200 yet stay invisible in /api/runs —
+    # a silent orphan. 404 instead of writing one.
+    from .sessions import session_exists
+
+    if not await session_exists(session_id):
+        raise NotFoundError(f"Session '{session_id}' not found")
     await add_tag(session_id, body.tag)
     current = await tags_for_sessions([session_id])
     return {"session_id": session_id, "tags": current.get(session_id, [])}

--- a/lionagi/studio/services/run_tags.py
+++ b/lionagi/studio/services/run_tags.py
@@ -17,6 +17,10 @@ from ._db import open_db as _open_db
 
 _DB = str(DEFAULT_DB_PATH)
 
+# Keep each IN(...) bind list under SQLite's default SQLITE_MAX_VARIABLE_NUMBER
+# (999 on builds older than 3.32) so tag hydration cannot overflow it.
+_MAX_SQL_VARS = 900
+
 _ENSURE_TABLE_SQL = """
 CREATE TABLE IF NOT EXISTS run_tags (
     session_id TEXT NOT NULL,
@@ -85,19 +89,23 @@ async def tags_for_sessions(session_ids: list[str]) -> dict[str, list[str]]:
     if not session_ids:
         return {}
 
-    placeholders = ",".join("?" for _ in session_ids)
+    # Chunk the IN(...) list so a large run history cannot exceed SQLite's
+    # bound-variable limit (SQLITE_MAX_VARIABLE_NUMBER, 999 on older builds).
+    # Each session_id falls in exactly one chunk, so its tags all come back
+    # from a single ordered query.
+    out: dict[str, list[str]] = {}
     async with _open_db(_DB) as db:
         await _ensure_table(db)
-        cur = await db.execute(
-            f"SELECT session_id, tag FROM run_tags "  # noqa: S608
-            f"WHERE session_id IN ({placeholders}) ORDER BY tag",
-            session_ids,
-        )
-        rows = await cur.fetchall()
-
-    out: dict[str, list[str]] = {}
-    for r in rows:
-        out.setdefault(r["session_id"], []).append(r["tag"])
+        for i in range(0, len(session_ids), _MAX_SQL_VARS):
+            chunk = session_ids[i : i + _MAX_SQL_VARS]
+            placeholders = ",".join("?" for _ in chunk)
+            cur = await db.execute(
+                f"SELECT session_id, tag FROM run_tags "  # noqa: S608
+                f"WHERE session_id IN ({placeholders}) ORDER BY tag",
+                chunk,
+            )
+            for r in await cur.fetchall():
+                out.setdefault(r["session_id"], []).append(r["tag"])
     return out
 
 

--- a/lionagi/studio/services/run_tags.py
+++ b/lionagi/studio/services/run_tags.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from fastapi import HTTPException
+from pydantic import BaseModel
+
+from lionagi.state.db import DEFAULT_DB_PATH
+
+from ..registry import studio_route
+from ._db import open_db as _open_db
+
+_DB = str(DEFAULT_DB_PATH)
+
+_ENSURE_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS run_tags (
+    session_id TEXT NOT NULL,
+    tag        TEXT NOT NULL,
+    created_at REAL NOT NULL,
+    PRIMARY KEY (session_id, tag)
+);
+CREATE INDEX IF NOT EXISTS idx_run_tags_tag ON run_tags(tag);
+"""
+
+
+async def _ensure_table(db) -> None:
+    await db.executescript(_ENSURE_TABLE_SQL)
+
+
+async def add_tag(session_id: str, tag: str) -> None:
+    """Attach a free-form tag to a run (session). Idempotent (INSERT OR IGNORE)."""
+    clean = (tag or "").strip()
+    if not clean:
+        raise HTTPException(status_code=422, detail="tag must not be empty")
+
+    now = time.time()
+    async with _open_db(_DB) as db:
+        await _ensure_table(db)
+        await db.execute(
+            "INSERT OR IGNORE INTO run_tags (session_id, tag, created_at) VALUES (?, ?, ?)",
+            (session_id, clean, now),
+        )
+        await db.commit()
+
+
+async def remove_tag(session_id: str, tag: str) -> None:
+    """Detach a tag from a run (session)."""
+    async with _open_db(_DB) as db:
+        await _ensure_table(db)
+        await db.execute(
+            "DELETE FROM run_tags WHERE session_id = ? AND tag = ?",
+            (session_id, tag),
+        )
+        await db.commit()
+
+
+async def tags_for_sessions(session_ids: list[str]) -> dict[str, list[str]]:
+    """Batch-fetch tags for many sessions in ONE query (no N+1).
+
+    Returns {session_id: [tags...]} for sessions that carry at least one tag;
+    sessions with no tags are simply absent from the result (caller defaults
+    to []).
+    """
+    if not session_ids:
+        return {}
+
+    placeholders = ",".join("?" for _ in session_ids)
+    async with _open_db(_DB) as db:
+        await _ensure_table(db)
+        cur = await db.execute(
+            f"SELECT session_id, tag FROM run_tags "  # noqa: S608
+            f"WHERE session_id IN ({placeholders}) ORDER BY tag",
+            session_ids,
+        )
+        rows = await cur.fetchall()
+
+    out: dict[str, list[str]] = {}
+    for r in rows:
+        out.setdefault(r["session_id"], []).append(r["tag"])
+    return out
+
+
+async def session_ids_with_tags(tags: list[str]) -> set[str] | None:
+    """The F8 SQL pre-filter: session_ids carrying ALL of `tags` (AND-composed).
+
+    Contract: an empty/None `tags` list returns None, meaning "no tag filter
+    requested" — callers must treat None as pass-through, not as "no matches".
+    A non-empty list with no matching sessions returns an empty set.
+    """
+    if not tags:
+        return None
+
+    unique_tags = list(dict.fromkeys(tags))
+    placeholders = ",".join("?" for _ in unique_tags)
+    async with _open_db(_DB) as db:
+        await _ensure_table(db)
+        cur = await db.execute(
+            f"SELECT session_id FROM run_tags "  # noqa: S608
+            f"WHERE tag IN ({placeholders}) "
+            f"GROUP BY session_id HAVING COUNT(DISTINCT tag) = ?",
+            [*unique_tags, len(unique_tags)],
+        )
+        rows = await cur.fetchall()
+
+    return {r["session_id"] for r in rows}
+
+
+class TagBody(BaseModel):
+    tag: str
+
+
+@studio_route("/sessions/{session_id}/tags", method="POST", area="sessions", name="add_run_tag")
+async def add_run_tag(session_id: str, body: TagBody) -> dict[str, Any]:
+    await add_tag(session_id, body.tag)
+    current = await tags_for_sessions([session_id])
+    return {"session_id": session_id, "tags": current.get(session_id, [])}
+
+
+@studio_route(
+    "/sessions/{session_id}/tags/{tag}",
+    method="DELETE",
+    area="sessions",
+    name="remove_run_tag",
+)
+async def remove_run_tag(session_id: str, tag: str) -> dict[str, Any]:
+    await remove_tag(session_id, tag)
+    current = await tags_for_sessions([session_id])
+    return {"session_id": session_id, "tags": current.get(session_id, [])}

--- a/lionagi/studio/services/run_tags.py
+++ b/lionagi/studio/services/run_tags.py
@@ -23,7 +23,7 @@ _MAX_SQL_VARS = 900
 
 _ENSURE_TABLE_SQL = """
 CREATE TABLE IF NOT EXISTS run_tags (
-    session_id TEXT NOT NULL,
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
     tag        TEXT NOT NULL,
     created_at REAL NOT NULL,
     PRIMARY KEY (session_id, tag)

--- a/lionagi/studio/services/runs.py
+++ b/lionagi/studio/services/runs.py
@@ -510,7 +510,7 @@ async def list_runs(
 
     sessions = await _sessions_svc.list_sessions()
     status_set = _normalize_status_filter(status)
-    tagged = await run_tags.session_ids_with_tags(tag) if tag else None
+    tagged = await run_tags.session_ids_with_tags(tag) if (tag and sessions) else None
     now = time.time()
     out = []
     snapshot: str | None = None

--- a/lionagi/studio/services/runs.py
+++ b/lionagi/studio/services/runs.py
@@ -495,6 +495,7 @@ def _run_row(s: dict[str, Any], now: float, *, process_alive: bool | None = None
         "project_source": s.get("project_source"),
         "status_reason_code": s.get("status_reason_code"),
         "status_reason_summary": s.get("status_reason_summary"),
+        "tags": [],
     }
 
 
@@ -503,9 +504,13 @@ async def list_runs(
     status: str | list[str] | None = None,
     project: str | None = None,
     project_null: bool = False,
+    tag: list[str] | None = None,
 ) -> list[dict[str, Any]]:
+    from . import run_tags
+
     sessions = await _sessions_svc.list_sessions()
     status_set = _normalize_status_filter(status)
+    tagged = await run_tags.session_ids_with_tags(tag) if tag else None
     now = time.time()
     out = []
     snapshot: str | None = None
@@ -519,6 +524,8 @@ async def list_runs(
             continue
         if status_set and s.get("status") not in status_set:
             continue
+        if tagged is not None and s["id"] not in tagged:
+            continue
         alive: bool | None = None
         if s.get("status") == "running":
             if snapshot is None:
@@ -527,6 +534,10 @@ async def list_runs(
                 snapshot = _ps_snapshot()
             alive = _session_liveness(s, snapshot)
         out.append(_run_row(s, now, process_alive=alive))
+
+    tagmap = await run_tags.tags_for_sessions([r["id"] for r in out])
+    for r in out:
+        r["tags"] = tagmap.get(r["id"], [])
     return out
 
 
@@ -599,6 +610,11 @@ async def get_run(run_id: str) -> dict[str, Any] | None:
     alive = _session_liveness(detail_session) if detail_session.get("status") == "running" else None
     row = _run_row(detail_session, time.time(), process_alive=alive)
 
+    from . import run_tags
+
+    tagmap = await run_tags.tags_for_sessions([run_id])
+    row["tags"] = tagmap.get(run_id, [])
+
     return {
         **row,
         # Detail-only fields layered on top of the shared Run row.
@@ -665,9 +681,16 @@ async def list_runs_route(
     ),
     project: str | None = Query(default=None, description="Exact project name filter (ADR-0026)"),
     project_null: bool = Query(default=False, description="Filter to runs with no project"),
+    tag: list[str] | None = Query(  # noqa: B008
+        default=None, description="Repeated tag filter (AND-composed)"
+    ),
 ) -> dict[str, Any]:
     runs = await list_runs(
-        playbook=playbook, status=status, project=project, project_null=project_null
+        playbook=playbook,
+        status=status,
+        project=project,
+        project_null=project_null,
+        tag=tag,
     )
     return paginate_runs(runs, page=page, per_page=per_page)
 

--- a/tests/apps_studio_server/test_run_tags.py
+++ b/tests/apps_studio_server/test_run_tags.py
@@ -380,6 +380,26 @@ def test_remove_tag_route_on_fresh_install_does_not_create_partial_db(tmp_path, 
     assert not db_path.exists()
 
 
+def test_statedb_open_creates_run_tags_table(tmp_path):
+    """run_tags lives in the canonical schema_meta, so StateDB.open() alone
+    (no service-side _ensure_table) creates it -- keeping the SQLite, Postgres,
+    and schema-parity paths consistent.
+    """
+    import sqlite3
+
+    db_path = tmp_path / "state.db"
+    _run(_init_db(db_path))  # StateDB open+close only, no _ensure_table
+
+    con = sqlite3.connect(db_path)
+    try:
+        rows = con.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='run_tags'"
+        ).fetchall()
+    finally:
+        con.close()
+    assert rows == [("run_tags",)]
+
+
 # ── free-form tags containing "/" must round-trip through the DELETE route ──
 
 

--- a/tests/apps_studio_server/test_run_tags.py
+++ b/tests/apps_studio_server/test_run_tags.py
@@ -283,3 +283,98 @@ def test_list_runs_without_tag_filter_still_attaches_tags_field(tmp_path, monkey
     target = next((run for run in r.json()["runs"] if run["id"] == sid), None)
     assert target is not None
     assert target["tags"] == ["x"]
+
+
+# ── P2a: a tag READ must never create a partial db on a fresh install ────────
+
+
+def test_list_runs_tag_filter_on_fresh_install_does_not_create_db(tmp_path, monkeypatch):
+    """GET /api/runs?tag=x on a brand-new install (no state.db) must not create
+
+    a partial db containing only the run_tags table -- that would leave every
+    later `SELECT ... FROM sessions` 500ing (codex P2a, PR #1834).
+    """
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    assert not db_path.exists()
+
+    import lionagi.studio.services.runs as runs_mod
+
+    result = _run(runs_mod.list_runs(tag=["x"]))
+
+    assert result == []
+    assert not db_path.exists(), "a tag read created a (partial) db file"
+
+
+def test_tags_for_sessions_on_fresh_install_does_not_create_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    assert not db_path.exists()
+
+    import lionagi.studio.services.run_tags as run_tags
+
+    assert _run(run_tags.tags_for_sessions([str(uuid.uuid4())])) == {}
+    assert not db_path.exists()
+
+
+def test_session_ids_with_tags_on_fresh_install_does_not_create_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    assert not db_path.exists()
+
+    import lionagi.studio.services.run_tags as run_tags
+
+    assert _run(run_tags.session_ids_with_tags(["x"])) is None
+    assert not db_path.exists()
+
+
+def test_add_tag_on_fresh_install_initializes_full_schema_not_just_run_tags(tmp_path, monkeypatch):
+    """add_tag on a fresh install must apply the FULL schema (sessions, etc.),
+
+    not just the run_tags table -- otherwise the db is left partial and a
+    later sessions query 500s (codex P2a, PR #1834).
+    """
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    assert not db_path.exists()
+
+    import lionagi.studio.services.run_tags as run_tags
+    import lionagi.studio.services.sessions as sessions_mod
+
+    sid = str(uuid.uuid4())
+    _run(run_tags.add_tag(sid, "urgent"))
+
+    assert db_path.exists()
+    # A `sessions` query must not raise -- it would if only run_tags existed.
+    assert _run(sessions_mod.list_sessions()) == []
+    tagmap = _run(run_tags.tags_for_sessions([sid]))
+    assert tagmap == {sid: ["urgent"]}
+
+
+# ── P2b: free-form tags containing "/" must round-trip through the DELETE route ──
+
+
+def test_remove_run_tag_route_handles_slash_in_tag(tmp_path, monkeypatch):
+    """A tag like 'team/backend' must be deletable through the actual route.
+
+    The DELETE path param must capture the rest of the path (codex P2b,
+    PR #1834) -- exercised here via TestClient, not by calling remove_tag()
+    directly, so the routing itself is proven.
+    """
+    db_path = tmp_path / "state.db"
+    _run(_init_db(db_path))
+    client = _make_client(db_path, monkeypatch)
+
+    sid = str(uuid.uuid4())
+    r = client.post(f"/api/sessions/{sid}/tags", json={"tag": "team/backend"})
+    assert r.status_code == 200
+    assert r.json()["tags"] == ["team/backend"]
+
+    r2 = client.delete(f"/api/sessions/{sid}/tags/team/backend")
+    assert r2.status_code == 200
+    assert r2.json()["tags"] == []
+
+    import lionagi.studio.services.run_tags as run_tags
+
+    tagmap = _run(run_tags.tags_for_sessions([sid]))
+    assert sid not in tagmap

--- a/tests/apps_studio_server/test_run_tags.py
+++ b/tests/apps_studio_server/test_run_tags.py
@@ -285,14 +285,14 @@ def test_list_runs_without_tag_filter_still_attaches_tags_field(tmp_path, monkey
     assert target["tags"] == ["x"]
 
 
-# ── P2a: a tag READ must never create a partial db on a fresh install ────────
+# ── a tag READ must never create a partial db on a fresh install ────────
 
 
 def test_list_runs_tag_filter_on_fresh_install_does_not_create_db(tmp_path, monkeypatch):
     """GET /api/runs?tag=x on a brand-new install (no state.db) must not create
 
     a partial db containing only the run_tags table -- that would leave every
-    later `SELECT ... FROM sessions` 500ing (codex P2a, PR #1834).
+    later `SELECT ... FROM sessions` 500ing.
     """
     db_path = tmp_path / "state.db"
     _patch_db(monkeypatch, db_path)
@@ -332,7 +332,7 @@ def test_add_tag_on_fresh_install_initializes_full_schema_not_just_run_tags(tmp_
     """add_tag on a fresh install must apply the FULL schema (sessions, etc.),
 
     not just the run_tags table -- otherwise the db is left partial and a
-    later sessions query 500s (codex P2a, PR #1834).
+    later sessions query 500s.
     """
     db_path = tmp_path / "state.db"
     _patch_db(monkeypatch, db_path)
@@ -351,15 +351,44 @@ def test_add_tag_on_fresh_install_initializes_full_schema_not_just_run_tags(tmp_
     assert tagmap == {sid: ["urgent"]}
 
 
-# ── P2b: free-form tags containing "/" must round-trip through the DELETE route ──
+def test_remove_tag_on_fresh_install_does_not_create_db(tmp_path, monkeypatch):
+    """A delete has nothing to detach on a fresh install and must NOT create
+    the db -- a bare _ensure_table would leave a run_tags-only partial db that
+    makes every later sessions query 500. Mirrors the read-path guards.
+    """
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    assert not db_path.exists()
+
+    import lionagi.studio.services.run_tags as run_tags
+
+    _run(run_tags.remove_tag(str(uuid.uuid4()), "urgent"))
+    assert not db_path.exists()
+
+
+def test_remove_tag_route_on_fresh_install_does_not_create_partial_db(tmp_path, monkeypatch):
+    """DELETE as the FIRST tag endpoint hit on a fresh install must return an
+    empty tag set and leave NO db behind (not even a run_tags-only one).
+    """
+    db_path = tmp_path / "state.db"
+    client = _make_client(db_path, monkeypatch)
+    assert not db_path.exists()
+
+    r = client.delete(f"/api/sessions/{uuid.uuid4()}/tags/urgent")
+    assert r.status_code == 200
+    assert r.json()["tags"] == []
+    assert not db_path.exists()
+
+
+# ── free-form tags containing "/" must round-trip through the DELETE route ──
 
 
 def test_remove_run_tag_route_handles_slash_in_tag(tmp_path, monkeypatch):
     """A tag like 'team/backend' must be deletable through the actual route.
 
-    The DELETE path param must capture the rest of the path (codex P2b,
-    PR #1834) -- exercised here via TestClient, not by calling remove_tag()
-    directly, so the routing itself is proven.
+    The DELETE path param must capture the rest of the path -- exercised here
+    via TestClient, not by calling remove_tag() directly, so the routing
+    itself is proven.
     """
     db_path = tmp_path / "state.db"
     _run(_init_db(db_path))

--- a/tests/apps_studio_server/test_run_tags.py
+++ b/tests/apps_studio_server/test_run_tags.py
@@ -203,9 +203,10 @@ def test_session_ids_with_tags_no_matches_returns_empty_set(tmp_path, monkeypatc
 def test_add_run_tag_route_returns_current_tags(tmp_path, monkeypatch):
     db_path = tmp_path / "state.db"
     _run(_init_db(db_path))
+    sid = str(uuid.uuid4())
+    _run(_seed_session(db_path, sid))
     client = _make_client(db_path, monkeypatch)
 
-    sid = str(uuid.uuid4())
     r = client.post(f"/api/sessions/{sid}/tags", json={"tag": "urgent"})
     assert r.status_code == 200
     data = r.json()
@@ -216,19 +217,33 @@ def test_add_run_tag_route_returns_current_tags(tmp_path, monkeypatch):
 def test_add_run_tag_route_rejects_empty_tag(tmp_path, monkeypatch):
     db_path = tmp_path / "state.db"
     _run(_init_db(db_path))
+    sid = str(uuid.uuid4())
+    _run(_seed_session(db_path, sid))
     client = _make_client(db_path, monkeypatch)
 
-    sid = str(uuid.uuid4())
     r = client.post(f"/api/sessions/{sid}/tags", json={"tag": "   "})
     assert r.status_code == 422
+
+
+def test_add_run_tag_route_404_for_unknown_session(tmp_path, monkeypatch):
+    # Tagging must reject a session that does not exist, matching the other
+    # session-child routes — otherwise the tag is written but stays invisible
+    # in /api/runs (which only surfaces rows joined from `sessions`).
+    db_path = tmp_path / "state.db"
+    _run(_init_db(db_path))
+    client = _make_client(db_path, monkeypatch)
+
+    r = client.post(f"/api/sessions/{uuid.uuid4()}/tags", json={"tag": "urgent"})
+    assert r.status_code == 404
 
 
 def test_remove_run_tag_route(tmp_path, monkeypatch):
     db_path = tmp_path / "state.db"
     _run(_init_db(db_path))
+    sid = str(uuid.uuid4())
+    _run(_seed_session(db_path, sid))
     client = _make_client(db_path, monkeypatch)
 
-    sid = str(uuid.uuid4())
     client.post(f"/api/sessions/{sid}/tags", json={"tag": "urgent"})
     r = client.delete(f"/api/sessions/{sid}/tags/urgent")
     assert r.status_code == 200
@@ -412,9 +427,10 @@ def test_remove_run_tag_route_handles_slash_in_tag(tmp_path, monkeypatch):
     """
     db_path = tmp_path / "state.db"
     _run(_init_db(db_path))
+    sid = str(uuid.uuid4())
+    _run(_seed_session(db_path, sid))
     client = _make_client(db_path, monkeypatch)
 
-    sid = str(uuid.uuid4())
     r = client.post(f"/api/sessions/{sid}/tags", json={"tag": "team/backend"})
     assert r.status_code == 200
     assert r.json()["tags"] == ["team/backend"]

--- a/tests/apps_studio_server/test_run_tags.py
+++ b/tests/apps_studio_server/test_run_tags.py
@@ -1,0 +1,285 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the run_tags m2m store, service, and the /runs tag filter (row C, slice 1)."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from lionagi.state.db import StateDB  # noqa: E402
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _patch_db(monkeypatch: pytest.MonkeyPatch, db_path: Path) -> None:
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.run_tags as run_tags_mod
+    import lionagi.studio.services.sessions as sessions_mod
+
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(run_tags_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(run_tags_mod, "_DB", str(db_path))
+    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
+
+
+def _make_client(db_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    _patch_db(monkeypatch, db_path)
+    from lionagi.studio.app import app
+
+    return TestClient(app, base_url="http://127.0.0.1:8765")
+
+
+async def _init_db(db_path: Path) -> None:
+    async with StateDB(db_path):
+        pass  # opens + applies schema (creates run_tags table too)
+
+
+async def _seed_session(db_path: Path, session_id: str, **fields) -> None:
+    async with StateDB(db_path) as db:
+        pid = str(uuid.uuid4())
+        await db.create_progression(pid)
+        payload = {
+            "id": session_id,
+            "progression_id": pid,
+            "status": fields.pop("status", "completed"),
+            "started_at": fields.pop("started_at", time.time()),
+            **fields,
+        }
+        await db.create_session(payload)
+
+
+# ── add_tag / tags_for_sessions / remove_tag (direct, no HTTP) ───────────────
+
+
+def test_add_tag_then_tags_for_sessions_returns_it(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _run(_init_db(db_path))
+
+    import lionagi.studio.services.run_tags as run_tags
+
+    sid = str(uuid.uuid4())
+    _run(run_tags.add_tag(sid, "needs-followup"))
+
+    tagmap = _run(run_tags.tags_for_sessions([sid]))
+    assert tagmap == {sid: ["needs-followup"]}
+
+
+def test_add_tag_twice_is_idempotent(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _run(_init_db(db_path))
+
+    import lionagi.studio.services.run_tags as run_tags
+
+    sid = str(uuid.uuid4())
+    _run(run_tags.add_tag(sid, "x"))
+    _run(run_tags.add_tag(sid, "x"))
+
+    tagmap = _run(run_tags.tags_for_sessions([sid]))
+    assert tagmap == {sid: ["x"]}
+
+
+def test_remove_tag_removes_it(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _run(_init_db(db_path))
+
+    import lionagi.studio.services.run_tags as run_tags
+
+    sid = str(uuid.uuid4())
+    _run(run_tags.add_tag(sid, "x"))
+    _run(run_tags.remove_tag(sid, "x"))
+
+    tagmap = _run(run_tags.tags_for_sessions([sid]))
+    assert tagmap == {}
+
+
+def test_add_tag_empty_string_rejected(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _run(_init_db(db_path))
+
+    from fastapi import HTTPException
+
+    import lionagi.studio.services.run_tags as run_tags
+
+    sid = str(uuid.uuid4())
+    with pytest.raises(HTTPException) as exc_info:
+        _run(run_tags.add_tag(sid, "   "))
+    assert exc_info.value.status_code == 422
+
+
+def test_tags_for_sessions_empty_list_returns_empty_dict(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _run(_init_db(db_path))
+
+    import lionagi.studio.services.run_tags as run_tags
+
+    assert _run(run_tags.tags_for_sessions([])) == {}
+
+
+def test_tags_for_sessions_batches_multiple_sessions_in_one_call(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _run(_init_db(db_path))
+
+    import lionagi.studio.services.run_tags as run_tags
+
+    sid1, sid2, sid3 = str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())
+    _run(run_tags.add_tag(sid1, "a"))
+    _run(run_tags.add_tag(sid1, "b"))
+    _run(run_tags.add_tag(sid2, "a"))
+    # sid3 gets no tags
+
+    tagmap = _run(run_tags.tags_for_sessions([sid1, sid2, sid3]))
+    assert tagmap == {sid1: ["a", "b"], sid2: ["a"]}
+    assert sid3 not in tagmap
+
+
+# ── session_ids_with_tags — the F8 SQL pre-filter (AND-composed) ────────────
+
+
+def test_session_ids_with_tags_none_when_no_tags_requested(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _run(_init_db(db_path))
+
+    import lionagi.studio.services.run_tags as run_tags
+
+    assert _run(run_tags.session_ids_with_tags([])) is None
+    assert _run(run_tags.session_ids_with_tags(None)) is None
+
+
+def test_session_ids_with_tags_and_composition(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _run(_init_db(db_path))
+
+    import lionagi.studio.services.run_tags as run_tags
+
+    both = str(uuid.uuid4())
+    only_a = str(uuid.uuid4())
+    _run(run_tags.add_tag(both, "a"))
+    _run(run_tags.add_tag(both, "b"))
+    _run(run_tags.add_tag(only_a, "a"))
+
+    result = _run(run_tags.session_ids_with_tags(["a", "b"]))
+    assert result == {both}
+    assert only_a not in result
+
+
+def test_session_ids_with_tags_no_matches_returns_empty_set(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _run(_init_db(db_path))
+
+    import lionagi.studio.services.run_tags as run_tags
+
+    result = _run(run_tags.session_ids_with_tags(["none"]))
+    assert result == set()
+
+
+# ── Route-level: POST/DELETE /api/sessions/{id}/tags ─────────────────────────
+
+
+def test_add_run_tag_route_returns_current_tags(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _run(_init_db(db_path))
+    client = _make_client(db_path, monkeypatch)
+
+    sid = str(uuid.uuid4())
+    r = client.post(f"/api/sessions/{sid}/tags", json={"tag": "urgent"})
+    assert r.status_code == 200
+    data = r.json()
+    assert data["session_id"] == sid
+    assert data["tags"] == ["urgent"]
+
+
+def test_add_run_tag_route_rejects_empty_tag(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _run(_init_db(db_path))
+    client = _make_client(db_path, monkeypatch)
+
+    sid = str(uuid.uuid4())
+    r = client.post(f"/api/sessions/{sid}/tags", json={"tag": "   "})
+    assert r.status_code == 422
+
+
+def test_remove_run_tag_route(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _run(_init_db(db_path))
+    client = _make_client(db_path, monkeypatch)
+
+    sid = str(uuid.uuid4())
+    client.post(f"/api/sessions/{sid}/tags", json={"tag": "urgent"})
+    r = client.delete(f"/api/sessions/{sid}/tags/urgent")
+    assert r.status_code == 200
+    assert r.json()["tags"] == []
+
+
+# ── Round-trip via the run row (R1: run_id ≡ session_id) ─────────────────────
+
+
+def test_list_runs_tag_filter_round_trips_through_run_row(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _run(_init_db(db_path))
+    sid = str(uuid.uuid4())
+    _run(_seed_session(db_path, sid))
+    client = _make_client(db_path, monkeypatch)
+
+    r = client.post(f"/api/sessions/{sid}/tags", json={"tag": "x"})
+    assert r.status_code == 200
+
+    r2 = client.get("/api/runs?tag=x")
+    assert r2.status_code == 200
+    runs = r2.json()["runs"]
+    target = next((run for run in runs if run["run_id"] == sid), None)
+    assert target is not None, "tagged session did not round-trip through the run row"
+    assert target["id"] == sid
+    assert "x" in target["tags"]
+
+
+def test_list_runs_tag_filter_no_match_is_empty(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _run(_init_db(db_path))
+    sid = str(uuid.uuid4())
+    _run(_seed_session(db_path, sid))
+    client = _make_client(db_path, monkeypatch)
+
+    r = client.get("/api/runs?tag=none")
+    assert r.status_code == 200
+    assert r.json()["runs"] == []
+
+
+def test_list_runs_without_tag_filter_still_attaches_tags_field(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _run(_init_db(db_path))
+    sid = str(uuid.uuid4())
+    _run(_seed_session(db_path, sid))
+    client = _make_client(db_path, monkeypatch)
+
+    client.post(f"/api/sessions/{sid}/tags", json={"tag": "x"})
+
+    r = client.get("/api/runs")
+    assert r.status_code == 200
+    target = next((run for run in r.json()["runs"] if run["id"] == sid), None)
+    assert target is not None
+    assert target["tags"] == ["x"]

--- a/tests/apps_studio_server/test_run_tags.py
+++ b/tests/apps_studio_server/test_run_tags.py
@@ -154,6 +154,25 @@ def test_tags_for_sessions_batches_multiple_sessions_in_one_call(tmp_path, monke
     assert sid3 not in tagmap
 
 
+def test_tags_for_sessions_chunks_beyond_sql_variable_limit(tmp_path, monkeypatch):
+    # A run history larger than SQLite's bound-variable limit must not overflow
+    # the IN(...) list — tags_for_sessions chunks the lookup. Request more ids
+    # than _MAX_SQL_VARS, with a tagged session in each chunk.
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _run(_init_db(db_path))
+
+    import lionagi.studio.services.run_tags as run_tags
+
+    ids = [str(uuid.uuid4()) for _ in range(run_tags._MAX_SQL_VARS + 50)]
+    first, last = ids[0], ids[-1]
+    _run(run_tags.add_tag(first, "front"))
+    _run(run_tags.add_tag(last, "back"))
+
+    tagmap = _run(run_tags.tags_for_sessions(ids))
+    assert tagmap == {first: ["front"], last: ["back"]}
+
+
 # ── session_ids_with_tags — the F8 SQL pre-filter (AND-composed) ────────────
 
 

--- a/tests/apps_studio_server/test_run_tags.py
+++ b/tests/apps_studio_server/test_run_tags.py
@@ -75,6 +75,7 @@ def test_add_tag_then_tags_for_sessions_returns_it(tmp_path, monkeypatch):
     import lionagi.studio.services.run_tags as run_tags
 
     sid = str(uuid.uuid4())
+    _run(_seed_session(db_path, sid))
     _run(run_tags.add_tag(sid, "needs-followup"))
 
     tagmap = _run(run_tags.tags_for_sessions([sid]))
@@ -89,6 +90,7 @@ def test_add_tag_twice_is_idempotent(tmp_path, monkeypatch):
     import lionagi.studio.services.run_tags as run_tags
 
     sid = str(uuid.uuid4())
+    _run(_seed_session(db_path, sid))
     _run(run_tags.add_tag(sid, "x"))
     _run(run_tags.add_tag(sid, "x"))
 
@@ -104,6 +106,7 @@ def test_remove_tag_removes_it(tmp_path, monkeypatch):
     import lionagi.studio.services.run_tags as run_tags
 
     sid = str(uuid.uuid4())
+    _run(_seed_session(db_path, sid))
     _run(run_tags.add_tag(sid, "x"))
     _run(run_tags.remove_tag(sid, "x"))
 
@@ -144,6 +147,8 @@ def test_tags_for_sessions_batches_multiple_sessions_in_one_call(tmp_path, monke
     import lionagi.studio.services.run_tags as run_tags
 
     sid1, sid2, sid3 = str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())
+    for sid in (sid1, sid2, sid3):
+        _run(_seed_session(db_path, sid))
     _run(run_tags.add_tag(sid1, "a"))
     _run(run_tags.add_tag(sid1, "b"))
     _run(run_tags.add_tag(sid2, "a"))
@@ -166,6 +171,8 @@ def test_tags_for_sessions_chunks_beyond_sql_variable_limit(tmp_path, monkeypatc
 
     ids = [str(uuid.uuid4()) for _ in range(run_tags._MAX_SQL_VARS + 50)]
     first, last = ids[0], ids[-1]
+    _run(_seed_session(db_path, first))
+    _run(_seed_session(db_path, last))
     _run(run_tags.add_tag(first, "front"))
     _run(run_tags.add_tag(last, "back"))
 
@@ -196,6 +203,8 @@ def test_session_ids_with_tags_and_composition(tmp_path, monkeypatch):
 
     both = str(uuid.uuid4())
     only_a = str(uuid.uuid4())
+    _run(_seed_session(db_path, both))
+    _run(_seed_session(db_path, only_a))
     _run(run_tags.add_tag(both, "a"))
     _run(run_tags.add_tag(both, "b"))
     _run(run_tags.add_tag(only_a, "a"))
@@ -364,10 +373,14 @@ def test_session_ids_with_tags_on_fresh_install_does_not_create_db(tmp_path, mon
 
 def test_add_tag_on_fresh_install_initializes_full_schema_not_just_run_tags(tmp_path, monkeypatch):
     """add_tag on a fresh install must apply the FULL schema (sessions, etc.),
-
     not just the run_tags table -- otherwise the db is left partial and a
     later sessions query 500s.
+
+    The run_tags -> sessions FK means tagging a nonexistent session fails, but
+    the schema-init must still run first so the db is never left partial.
     """
+    import sqlite3
+
     db_path = tmp_path / "state.db"
     _patch_db(monkeypatch, db_path)
     assert not db_path.exists()
@@ -376,13 +389,47 @@ def test_add_tag_on_fresh_install_initializes_full_schema_not_just_run_tags(tmp_
     import lionagi.studio.services.sessions as sessions_mod
 
     sid = str(uuid.uuid4())
-    _run(run_tags.add_tag(sid, "urgent"))
+    # No session row exists yet, so the tag insert trips the FK -- but only
+    # after the full schema is built (a run_tags-only partial db would 500 the
+    # sessions query below instead).
+    with pytest.raises(sqlite3.IntegrityError):
+        _run(run_tags.add_tag(sid, "urgent"))
 
     assert db_path.exists()
     # A `sessions` query must not raise -- it would if only run_tags existed.
     assert _run(sessions_mod.list_sessions()) == []
-    tagmap = _run(run_tags.tags_for_sessions([sid]))
-    assert tagmap == {sid: ["urgent"]}
+
+    # With the session seeded, the same tag now attaches, and dropping the
+    # session cascades the tag away (no orphan row survives a prune).
+    _run(_seed_session(db_path, sid))
+    _run(run_tags.add_tag(sid, "urgent"))
+    assert _run(run_tags.tags_for_sessions([sid])) == {sid: ["urgent"]}
+
+
+def test_pruning_a_session_cascades_its_tags(tmp_path, monkeypatch):
+    # add_run_tag rejects orphan tags on write; deleting the parent session
+    # must not reintroduce them. The run_tags -> sessions FK ON DELETE CASCADE
+    # removes the tag rows when admin.prune_sessions() drops the session.
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _run(_init_db(db_path))
+
+    import lionagi.studio.services.admin as admin
+    import lionagi.studio.services.run_tags as run_tags
+
+    # admin freezes its own _DB / DEFAULT_DB_PATH at import; _patch_db does not
+    # touch them, so point prune at the tmp db too.
+    monkeypatch.setattr(admin, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(admin, "_DB", str(db_path))
+
+    sid = str(uuid.uuid4())
+    _run(_seed_session(db_path, sid))
+    _run(run_tags.add_tag(sid, "keep"))
+    assert _run(run_tags.tags_for_sessions([sid])) == {sid: ["keep"]}
+
+    pruned = _run(admin.prune_sessions([sid]))
+    assert pruned == 1
+    assert _run(run_tags.tags_for_sessions([sid])) == {}
 
 
 def test_remove_tag_on_fresh_install_does_not_create_db(tmp_path, monkeypatch):

--- a/tests/state/test_engine_schema.py
+++ b/tests/state/test_engine_schema.py
@@ -162,6 +162,7 @@ ALL_TABLES = {
     "workflow_defs",
     "session_controls",
     "dispatch_outbox",
+    "run_tags",
 }
 
 
@@ -176,7 +177,7 @@ async def sqlite_meta_engine(tmp_path):
     await engine.dispose()
 
 
-async def test_metadata_creates_all_24_tables(sqlite_meta_engine):
+async def test_metadata_creates_all_25_tables(sqlite_meta_engine):
     """metadata.create_all() builds every expected table in SQLite."""
     async with sqlite_meta_engine.connect() as conn:
         tables = await conn.run_sync(lambda sync_conn: set(sa.inspect(sync_conn).get_table_names()))


### PR DESCRIPTION
## Studio-depth row C — Slice 1: run_tags backend

Gate-approved by Leo (SPEC GATE on DECISION.md; multi-label decided, UI word "tags"). This is the **backend-only** slice; the frontend filter bar / tag chips / project rail are Slice 2.

Ocean's C complaint: *"no way to filter the runs, no way to organize them, or tag them, into projects or buckets, poor for human review."* Per the advisor DECISION, organization splits into two axes — `projects` (the detect-derived 1:1 axis, already modeled + shipped-but-unwired) and **run tags** (the user-defined m2m axis). This slice adds the tag axis; nothing about projects is rebuilt.

### What's here
- **`run_tags(session_id, tag, created_at)`** table, composite PK + `idx_run_tags_tag` reverse index.
- **`run_tags` service:** `add_tag`/`remove_tag` (idempotent `INSERT OR IGNORE`, empty tag → 422), batch `tags_for_sessions` (one `IN` query, no N+1), `session_ids_with_tags` (the tag pre-filter), and `POST` / `DELETE /api/sessions/{id}/tags` routes.
- **`list_runs`** gains a repeatable, AND-composed `tag` filter; run rows carry a `tags: string[]` field (batch-attached after the loop); `get_run` attaches tags too.
- Module registered in `registry.py`.

### Carried gate conditions — evidence
- **R1 (run_id ↔ session_id identity).** Verified: `runs.py:_run_row` sets both `run_id` and `id` to `s["id"]` (the session id), and `get_run(run_id)` → `get_session(run_id)`. Tags key on `session_id` and round-trip through the run row with **no** new identity field. Proven end-to-end by `test_list_runs_tag_filter_round_trips_through_run_row`.
- **F8 (one tag-filter query path).** The tag filter is a single SQL pre-filter:
  ```sql
  SELECT session_id FROM run_tags WHERE tag IN (?, ...)
  GROUP BY session_id HAVING COUNT(DISTINCT tag) = ?
  ```
  called once before the run loop; results set-intersected in the existing in-Python loop. There is no second/per-session tag-filter path. The batch `tags_for_sessions` runs once after the loop purely to attach the display field.
- **R4 (scope fence).** Touches only `run_tags.py` (new), `runs.py`, `registry.py`, `schema.sql`, tests. Does not touch `projects`, `/runs/projects`, `teams`, `shows`, `engine-runs`, or `casts`.

### Tests (verified by re-run, not the agent's word)
- `tests/apps_studio_server/test_run_tags.py`: **15 passed, 0 failed/errored/skipped** (junit-confirmed).
- Full `tests/apps_studio_server/`: **703 passed, 0 failed/errored/skipped** (junit-confirmed).
- `ruff check` + `ruff format` clean.

### Ship-bar note
The human-completes-it walkthrough (reviewer tags a run, filters to it, clicks through — with screenshots on the PR) is the **Slice 2** evidence gate, once the UI exists. This backend slice's contract is proven by the test suite + the route-level tests exercising the FastAPI client.
