### PR TITLE
fix(studio): persist engine sub-agent branches + chat-node turns

### DIFF
--- a/lionagi/engines/engine.py
+++ b/lionagi/engines/engine.py
@@ -181,10 +181,12 @@ class EngineRun:
         *,
         session: Session | None = None,
         on_event: EventCallback | None = None,
+        on_branch_created: Callable[[Any], None] | None = None,
     ) -> None:
         self.engine = engine
         self.session = session if session is not None else Session()
         self.on_event = on_event
+        self._on_branch_created = on_branch_created
         self.root: str = ""
         self.agents_made: int = 0
         self._sem = Semaphore(engine.max_concurrent)
@@ -301,6 +303,8 @@ class EngineRun:
         if name:
             branch.name = name
         self.session.include_branches(branch)
+        if self._on_branch_created is not None:
+            self._on_branch_created(branch)
         return branch
 
     async def operate_with_repair(
@@ -642,8 +646,11 @@ class Engine:
         *,
         session: Session | None = None,
         on_event: EventCallback | None = None,
+        on_branch_created: Callable[[Any], None] | None = None,
     ) -> EngineRun:
-        return self.run_context_cls(self, session=session, on_event=on_event)
+        return self.run_context_cls(
+            self, session=session, on_event=on_event, on_branch_created=on_branch_created
+        )
 
     async def _degrade_export(self, run: EngineRun, args: tuple, kwargs: dict) -> Any:
         """Cancel in-flight spawned tasks, then run _partial_export shielded + timeout-bounded.
@@ -705,10 +712,11 @@ class Engine:
         *args: Any,
         session: Session | None = None,
         on_event: EventCallback | None = None,
+        on_branch_created: Callable[[Any], None] | None = None,
         **kwargs: Any,
     ) -> Any:
         """Execute the engine pipeline; on internal budget cancellation calls _partial_export instead of raising. External cancellation propagates as CancelledError."""
-        run = self.new_run(session=session, on_event=on_event)
+        run = self.new_run(session=session, on_event=on_event, on_branch_created=on_branch_created)
         # Reset per-run diagnostics on the engine instance so a reused engine
         # never carries emission failures from a previous run into the next one.
         self._emission_failures: list[str] = []

--- a/lionagi/session/branch.py
+++ b/lionagi/session/branch.py
@@ -670,6 +670,17 @@ class Branch(Element, Relational):
             return_ins_res_message=return_ins_res_message,
         )
 
+    async def chat_and_record(self, instruction: Instruction | JsonValue = None, **kwargs) -> str:
+        """Like ``chat()``, but also adds the turn to the branch through the
+        hooked async add-path (mirrors ``communicate()``'s recording), so
+        anything observing ``on_message_added`` — e.g. persistence — sees it.
+        """
+        kwargs.pop("return_ins_res_message", None)
+        ins, res = await self.chat(instruction, return_ins_res_message=True, **kwargs)
+        await self.msgs.a_add_message(instruction=ins)
+        await self.msgs.a_add_message(assistant_response=res)
+        return res.response
+
     async def parse(
         self,
         text: str,

--- a/lionagi/studio/services/workflow_compile.py
+++ b/lionagi/studio/services/workflow_compile.py
@@ -304,7 +304,8 @@ async def compile_workflow_def(
             # persistence hook wired up in workflow_run.py without ever
             # producing a message for it to persist. chat_and_record() records
             # the turn through the same hooked a_add_message path communicate()
-            # uses, while returning the same plain-text result "chat" would.
+            # uses, and returns the assistant response text for downstream
+            # routing/context.
             op_id = builder.add_operation("chat_and_record", node_id=node_id, instruction=prompt)
         elif kind == "engine":
             engine_def_id = config.get("engine_def_id")

--- a/lionagi/studio/services/workflow_compile.py
+++ b/lionagi/studio/services/workflow_compile.py
@@ -298,7 +298,14 @@ async def compile_workflow_def(
             prompt = config.get("prompt")
             if not prompt or not isinstance(prompt, str):
                 raise WorkflowCompileError("chat node requires config.prompt", node_id=node_id)
-            op_id = builder.add_operation("chat", node_id=node_id, instruction=prompt)
+            # "chat_and_record", not the native "chat" operation: Branch.chat()
+            # does not add messages to the branch (by design — see its
+            # docstring), so a plain "chat" node would run through the
+            # persistence hook wired up in workflow_run.py without ever
+            # producing a message for it to persist. chat_and_record() records
+            # the turn through the same hooked a_add_message path communicate()
+            # uses, while returning the same plain-text result "chat" would.
+            op_id = builder.add_operation("chat_and_record", node_id=node_id, instruction=prompt)
         elif kind == "engine":
             engine_def_id = config.get("engine_def_id")
             if not engine_def_id or not isinstance(engine_def_id, str):
@@ -493,12 +500,18 @@ def _derive_engine_input(context: dict[str, Any] | None) -> str:
     return json.dumps(context, default=str)
 
 
-def make_engine_operation(session: Any) -> Callable[..., Awaitable[Any]]:
+def make_engine_operation(
+    session: Any, *, on_branch_created: Callable[[Any], None] | None = None
+) -> Callable[..., Awaitable[Any]]:
     """Build the 'engine' Branch-operation closure for one workflow run.
 
     Resolves the engine class per kind (reusing the CLI's kind registry —
     FindExisting, not a new one) and runs it in-process against the SAME
     session, so any sub-agent branches it spawns are wired into this run.
+
+    ``on_branch_created``, when given, is threaded into ``engine.run()`` so
+    each sub-agent branch the engine spawns (``Engine.make_agent``) gets
+    registered for persistence the same way flow-cloned branches already are.
     """
 
     async def _engine_op(
@@ -536,7 +549,9 @@ def make_engine_operation(session: Any) -> Callable[..., Awaitable[Any]]:
         spec_input = _derive_engine_input(context)
 
         engine = engine_class(**engine_kwargs)
-        result = await engine.run(spec_input, session=session, **run_kwargs)
+        result = await engine.run(
+            spec_input, session=session, on_branch_created=on_branch_created, **run_kwargs
+        )
 
         if hasattr(result, "model_dump"):
             return result.model_dump(mode="json")

--- a/lionagi/studio/services/workflow_run.py
+++ b/lionagi/studio/services/workflow_run.py
@@ -158,7 +158,6 @@ async def run_workflow_def(
     early_graph = build_early_graph(spec)
 
     session = _session if _session is not None else Session()
-    session.register_operation("engine", make_engine_operation(session))
 
     ctx = await _setup_run_persist(
         session,
@@ -170,10 +169,21 @@ async def run_workflow_def(
         },
     )
 
+    from lionagi.cli.orchestrate._orchestration import register_branch_hook
+
+    # ctx must exist before the "engine" operation is registered: engine
+    # sub-agent branches (Engine.make_agent) are born mid-run, the same way
+    # flow-cloned branches are, so they need the same on_branch_created seam
+    # used below for session.flow() rather than the setup-time-only loop in
+    # _setup_run_persist.
+    session.register_operation(
+        "engine",
+        make_engine_operation(session, on_branch_created=lambda b: register_branch_hook(ctx, b)),
+    )
+
     status = "completed"
     exc: BaseException | None = None
     try:
-        from lionagi.cli.orchestrate._orchestration import register_branch_hook
         from lionagi.engines.flow_signals import flow_progress_signals
 
         # Emit per-node lifecycle signals (NodeQueued/Started/Completed/Failed)

--- a/tests/apps_studio_server/test_workflow_run_transcript_persist.py
+++ b/tests/apps_studio_server/test_workflow_run_transcript_persist.py
@@ -1,0 +1,231 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Transcript-persistence slice: chat-node turns + engine sub-agent branches.
+
+Two holes closed together (both surfaced by the same live demo run):
+
+1. Engine sub-agent branches (``Engine.make_agent``) were included into the
+   session but never got ``register_branch_hook`` wired for them, unlike
+   flow-cloned branches (which already get it via ``session.flow(...,
+   on_branch_created=...)``). Fixed by threading an ``on_branch_created``
+   callback through ``EngineRun``/``Engine.run``/``make_engine_operation``.
+2. The Studio "chat" node compiled to the native ``chat`` Branch operation,
+   which by design never calls ``a_add_message`` -- so even though the
+   branch it ran on already had a persistence hook, there was nothing for
+   the hook to observe. Fixed with ``Branch.chat_and_record`` (records the
+   turn the same way ``communicate()`` does) and compiling chat nodes to
+   that operation name instead of the native ``chat``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+aiosqlite = pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
+pytest.importorskip("fastapi", reason="studio extra not installed")
+
+
+def _spec(engine_def_id: str = "PLACEHOLDER") -> dict[str, Any]:
+    return {
+        "version": 1,
+        "nodes": [
+            {"id": "in", "kind": "input", "label": "Input", "pos": {"x": 0, "y": 0}},
+            {
+                "id": "chat1",
+                "kind": "chat",
+                "label": "Draft",
+                "pos": {"x": 150, "y": 0},
+                "config": {"prompt": "Draft a summary."},
+            },
+            {
+                "id": "eng1",
+                "kind": "engine",
+                "label": "Research",
+                "pos": {"x": 300, "y": 0},
+                "config": {"engine_def_id": engine_def_id},
+            },
+        ],
+        "edges": [
+            {"id": "e1", "from": "in", "to": "chat1"},
+            {"id": "e2", "from": "chat1", "to": "eng1", "condition": "result != None"},
+        ],
+        "inputs": ["topic"],
+        "outputs": ["summary"],
+    }
+
+
+class _FakeSubAgentEngine:
+    """Stand-in Engine: spawns one sub-agent branch through the SAME seam a
+    real Engine (research/review/coding/...) uses -- make_agent's
+    include_branches + on_branch_created -- then adds messages to it via the
+    hooked async add-path, exactly like a real ``branch.operate()`` call
+    inside ``operate_with_repair`` would."""
+
+    calls: list[dict[str, Any]] = []
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+
+    async def run(
+        self,
+        spec_input: str,
+        *,
+        session: Any = None,
+        on_branch_created: Any = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        from lionagi.session.branch import Branch
+
+        sub = Branch(name="researcher-1")
+        session.include_branches(sub)
+        if on_branch_created is not None:
+            on_branch_created(sub)
+        # Messages added AFTER the hook is wired -- proving the hook (fired at
+        # include-time, before any operate()) catches the whole transcript.
+        await sub.msgs.a_add_message(instruction="investigate the topic")
+        await sub.msgs.a_add_message(assistant_response="findings: grouped-query attention")
+
+        _FakeSubAgentEngine.calls.append({"spec_input": spec_input, "sub_branch_id": str(sub.id)})
+        return {"echo": spec_input}
+
+
+def _mock_chat_branch(name: str = "workflow-default"):
+    """Same convention as test_workflow_run.py / test_workflow_run_persist.py."""
+    from lionagi.protocols.generic.event import EventStatus
+    from lionagi.session.branch import Branch
+    from lionagi.testing import LionAGIMockFactory
+
+    branch = Branch(user="test_user", name=name)
+
+    async def _fake_invoke(**kwargs):
+        return LionAGIMockFactory.create_api_calling_mock(
+            response_data="a one-paragraph summary",
+            status=EventStatus.COMPLETED,
+            model="gpt-4-mini",
+        )
+
+    mock_chat_model = LionAGIMockFactory.create_mocked_imodel(
+        provider="openai", model="gpt-4-mini", response="overridden-below"
+    )
+    mock_chat_model.invoke = AsyncMock(side_effect=_fake_invoke)
+    branch.chat_model = mock_chat_model
+    return branch
+
+
+@pytest.fixture
+def patched_env(tmp_path: Path, monkeypatch):
+    import lionagi.state.db as db_mod
+    import lionagi.studio.services.engine_defs as engine_defs_svc
+    import lionagi.studio.services.sessions as sessions_svc
+    import lionagi.studio.services.workflow_defs as wf_svc
+
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(db_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(wf_svc, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(engine_defs_svc, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(sessions_svc, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(sessions_svc, "_DB", str(db_path))
+
+    import lionagi.cli.engine as cli_engine
+
+    monkeypatch.setitem(
+        cli_engine._KIND_META,
+        "research",
+        {
+            **cli_engine._KIND_META["research"],
+            "cls_path": (
+                "tests.apps_studio_server.test_workflow_run_transcript_persist",
+                "_FakeSubAgentEngine",
+            ),
+        },
+    )
+    return wf_svc, engine_defs_svc, db_path
+
+
+async def test_chat_turn_and_engine_subagent_branch_both_persist(patched_env):
+    """The demo-run regression this slice closes: before the fix,
+    ``list_branches(run_id)`` came back empty even after a real 4-agent run.
+    After the fix: the chat branch has a persisted user+assistant turn, and
+    the engine's sub-agent branch has its own persisted transcript -- both
+    under the SAME run/session id.
+    """
+    wf_svc, engine_defs_svc, db_path = patched_env
+    _FakeSubAgentEngine.calls = []
+
+    engine_def = await engine_defs_svc.create_engine_def(
+        {"name": "transcript-eng", "kind": "research"}
+    )
+    spec = _spec(engine_def["id"])
+    created = await wf_svc.create_workflow_def({"name": "transcript-flow", "spec_json": spec})
+
+    from lionagi.session.session import Session
+    from lionagi.studio.services.workflow_run import run_workflow_def
+
+    mock_branch = _mock_chat_branch()
+    session = Session(default_branch=mock_branch)
+
+    result = await run_workflow_def(created["id"], {"topic": "GQA"}, _session=session)
+    assert result["status"] == "completed"
+    run_id = result["run_id"]
+    assert run_id == str(session.id)
+
+    assert len(_FakeSubAgentEngine.calls) == 1
+    sub_branch_id = _FakeSubAgentEngine.calls[0]["sub_branch_id"]
+    assert sub_branch_id != str(mock_branch.id)
+
+    from lionagi.state.db import StateDB
+
+    db = StateDB(db_path)
+    await db.open()
+    try:
+        branches = await db.list_branches(run_id)
+        branch_ids = {b["id"] for b in branches}
+        assert str(mock_branch.id) in branch_ids, (
+            "the chat node's branch row is missing -- BEFORE this fix "
+            "list_branches(run_id) came back empty for a run with a real "
+            "chat + engine transcript"
+        )
+        assert sub_branch_id in branch_ids, (
+            "the engine sub-agent branch row is missing -- include_branches() "
+            "does not fire on_branch_created on its own, so without the "
+            "EngineRun/Engine.run/make_engine_operation wiring this branch "
+            "is never registered for persistence"
+        )
+
+        chat_messages = await db.get_branch_messages(str(mock_branch.id))
+        chat_roles = {m.get("role") for m in chat_messages}
+        assert {"user", "assistant"} <= chat_roles, (
+            f"chat node turn must persist both sides; got roles {chat_roles!r} "
+            f"from {chat_messages!r}"
+        )
+
+        sub_messages = await db.get_branch_messages(sub_branch_id)
+        assert len(sub_messages) == 2, (
+            "engine sub-agent branch must persist its full transcript, "
+            f"including messages added before make_agent returns; got {sub_messages!r}"
+        )
+        sub_roles = {m.get("role") for m in sub_messages}
+        assert {"user", "assistant"} <= sub_roles
+    finally:
+        await db.close()
+
+
+async def test_chat_and_record_returns_same_text_shape_as_chat(patched_env):
+    """The chat node's compiled output must be unchanged (plain text via
+    operation_results) -- only the transcript is new. Exercise
+    Branch.chat_and_record directly against the mocked model."""
+    branch = _mock_chat_branch()
+
+    text = await branch.chat_and_record(instruction="say hi")
+    assert isinstance(text, str)
+    assert text == "a one-paragraph summary"
+
+    # The turn is now on the branch (chat() alone would leave this empty).
+    assert len(branch.messages) == 2
+    roles = {m.role.value if hasattr(m.role, "value") else m.role for m in branch.messages}
+    assert {"user", "assistant"} <= roles

--- a/tests/engines/test_engine.py
+++ b/tests/engines/test_engine.py
@@ -199,6 +199,42 @@ async def test_make_agent_no_emits_uses_role_contract():
 
 
 @pytest.mark.asyncio
+async def test_make_agent_fires_on_branch_created():
+    """make_agent must notify on_branch_created right after include_branches,
+    with the branch's final name already set — mirrors the seam flow.py's
+    _preallocate_all_branches already fires for flow-cloned branches."""
+    created: list[object] = []
+    run = Engine().new_run(on_branch_created=created.append)
+    b = await run.make_agent("researcher", name="r1")
+    assert created == [b]
+    assert created[0].name == "r1"  # fired after branch.name was set
+
+
+@pytest.mark.asyncio
+async def test_make_agent_no_on_branch_created_is_a_no_op():
+    """Default None must not affect any of the ~18 existing make_agent callers."""
+    run = _run()
+    b = await run.make_agent("researcher", name="r1")
+    assert b.name == "r1"  # no AttributeError / crash from the new hook
+
+
+@pytest.mark.asyncio
+async def test_engine_run_threads_on_branch_created_into_make_agent():
+    """Engine.run(..., on_branch_created=...) must reach EngineRun.make_agent
+    for sub-agents spawned mid-run, not just at construction time."""
+
+    class _SpawnsOneAgent(Engine):
+        async def _run(self, run, *args, **kwargs):
+            return await run.make_agent("researcher", name="sub1")
+
+    created: list[object] = []
+    result = await _SpawnsOneAgent().run("task", on_branch_created=created.append)
+    assert len(created) == 1
+    assert created[0] is result
+    assert created[0].name == "sub1"
+
+
+@pytest.mark.asyncio
 async def test_run_dag_emits_node_lifecycle_signals():
     """run_dag executes a DAG and tees NodeStarted/NodeCompleted onto the bus."""
     from lionagi.operations.builder import OperationGraphBuilder


### PR DESCRIPTION
## What

Studio workflow runs persisted node-lifecycle signals (so the run DAG animates) but **not** the
conversation transcripts — RunDetail showed "Branches 0 / No messages recorded" even for runs
that did rich multi-agent work. This closes that hole for the two sources that bypassed the
per-branch persistence hooks:

- **Engine sub-agent branches.** `Engine.make_agent` added its branch via
  `session.include_branches()` but never fired the `on_branch_created` callback that
  `session.flow()` already fires for flow-cloned branches, so `register_branch_hook` never ran for
  engine-spawned agents. The engine now takes an optional `on_branch_created` (symmetric to flow's),
  fired in `make_agent` right after `include_branches`. Because that happens **before** the
  sub-agent operates, the whole transcript persists through the existing hooked path — no backfill.
- **Chat-node turns.** `Branch.chat()` deliberately does not add messages to the branch, so a chat
  node produced output but recorded no transcript. New `Branch.chat_and_record()` records the turn
  through the same hooked `a_add_message` path `communicate()` uses; chat nodes compile to it.

Studio's `run_workflow_def` builds the persistence context first, then threads
`register_branch_hook(ctx, b)` into `make_engine_operation` → `engine.run(on_branch_created=...)`.

Closes the transcript-persistence gap tracked in #1836 (exec-bridge line). Node-lifecycle signals
(#1838) are unchanged.

## Evidence (real run, `openai/gpt-4.1-mini`, input→chat→engine workflow)

Persisted branches read directly from StateDB:

| | Branches | Detail |
|---|---|---|
| **Before** (native chat node) | **0** | completed 63s 4-agent run, nothing persisted |
| **After** (this PR) | **5** | chat branch (`user`,`assistant`) + researcher-d0 / analyst-d0 / critic-d0 / synthesizer, each with a `user`,`assistant` transcript |

System messages persist via the branch row's `system_msg_id`.

## Scope / safety

- `on_branch_created` defaults to `None` on `EngineRun.__init__`, `Engine.new_run`, `Engine.run`,
  and `make_engine_operation` — the ~18 existing engine callers (research/planning/review/
  hypothesis/coding + CLI engine runs) are unaffected.
- Engine sub-agents (`create_agent` + `include_branches`) never overlap with flow-clone branches
  (`default_branch.clone`), so no double-registration.
- `chat_and_record` records user-then-assistant only after a successful model response — a model
  failure cannot leave a half-persisted turn.

## Tests

- New: engine fires `on_branch_created` on sub-agent creation (with final name set) + default-None
  no-op + threads through `Engine.run`; end-to-end studio run persists engine sub-agent branches +
  the chat turn (via the `_session` injection seam).
- `tests/engines/` + `tests/apps_studio_server/`: **996 passed, 0 failed**.
- Full suite: 33 failures, all pre-existing missing-optional-dependency gaps (pandas/CSV log-dump),
  none in changed code.

## Out of scope (separate lanes)

- #1839 — unqualified engine_def model silently green on sub-agent auth failure.
- #1841 — stale `running` play rows never reaped.
- Events-timeline debug-grade rendering (later polish pass).
