### PR TITLE
fix(agent,engines): resolve bare model provider from settings + surface total sub-agent failure

### DIFF
--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -55,7 +55,10 @@ async def create_agent(
         if "/" in ms.model:
             provider, model_name = ms.model.split("/", 1)
         else:
-            provider = model_name = ms.model
+            from lionagi.config import settings
+
+            provider = settings.LIONAGI_CHAT_PROVIDER
+            model_name = ms.model
 
         extra = {}
         effort = spec.effort or ms.effort

--- a/lionagi/cli/engine.py
+++ b/lionagi/cli/engine.py
@@ -396,7 +396,9 @@ async def _do_engine_run(args: argparse.Namespace) -> int:
     )
     if db is not None:
         await db.close()
-    return 0
+    # A run where every agent terminally errored is a failure: exit non-zero so
+    # shell/CI callers see it, matching the persisted "failed" status above.
+    return 1 if _total_agent_failure else 0
 
 
 async def _maybe_update_db(

--- a/lionagi/cli/engine.py
+++ b/lionagi/cli/engine.py
@@ -351,6 +351,17 @@ async def _do_engine_run(args: argparse.Namespace) -> int:
     if _emission_failures:
         emission_error = "emission_missing: " + "; ".join(_emission_failures)
 
+    # A run where every agent made terminally errored (e.g. missing API key)
+    # must not be reported "completed" — fold the agent errors into the error
+    # column and mark the run failed instead of green.
+    _total_agent_failure: bool = getattr(engine, "_total_agent_failure", False)
+    if _total_agent_failure:
+        _agent_errors: list[str] = getattr(engine, "_agent_errors", [])
+        agent_error_text = "all sub-agents failed: " + "; ".join(_agent_errors)
+        emission_error = (
+            f"{emission_error}; {agent_error_text}" if emission_error else agent_error_text
+        )
+
     # Serialise result to stdout as JSON.
     # export_dir: the CLI knows what directory it passed; neither CodeResultRecorded
     # (lionagi/engines/coding.py:153 — fields: passed, measurements, caveats,
@@ -377,7 +388,7 @@ async def _do_engine_run(args: argparse.Namespace) -> int:
     await _maybe_update_db(
         db,
         run_id,
-        "completed",
+        "failed" if _total_agent_failure else "completed",
         ended_at=ended_at,
         export_dir=export_dir_for_db,
         error=emission_error,

--- a/lionagi/engines/engine.py
+++ b/lionagi/engines/engine.py
@@ -205,6 +205,9 @@ class EngineRun:
         # the engine_runs.error column even when the overall status is "completed".
         # Each entry is a string like "<agent> x<attempts>".
         self._emission_failures: list[str] = []
+        # Collects terminal sub-agent failures (e.g. missing API key) so a run
+        # where every agent errored can be surfaced as failed instead of green.
+        self._agent_errors: list[str] = []
 
     @property
     def events(self) -> Pile:
@@ -247,6 +250,8 @@ class EngineRun:
         return self.session.observe(*keys, handler=handler, role=role)
 
     def notify(self, kind: str, **data: Any) -> None:
+        if kind == "agent_error":
+            self._agent_errors.append(f"{data.get('agent')}: {data.get('error')}")
         if self.on_event:
             self.on_event({"type": kind, **data})
 
@@ -720,6 +725,8 @@ class Engine:
         # Reset per-run diagnostics on the engine instance so a reused engine
         # never carries emission failures from a previous run into the next one.
         self._emission_failures: list[str] = []
+        self._agent_errors: list[str] = []
+        self._total_agent_failure: bool = False
         watchdog: asyncio.Task | None = None
         if run._deadline is not None:
             watchdog = asyncio.ensure_future(run._deadline_watchdog())
@@ -780,6 +787,13 @@ class Engine:
             # the real list regardless of which return/exception path was taken.
             # Uses a fresh list copy so no shared-reference aliasing between runs.
             self._emission_failures = list(run._emission_failures)
+            # Copy per-run agent-failure diagnostics the same way; flag total
+            # failure only when every agent made for this run terminally
+            # errored, so partial/soft-empty runs are never over-flagged.
+            self._agent_errors = list(run._agent_errors)
+            self._total_agent_failure = (
+                run.agents_made > 0 and len(run._agent_errors) >= run.agents_made
+            )
             if watchdog is not None and not watchdog.done():
                 watchdog.cancel()
                 with contextlib.suppress(asyncio.CancelledError):

--- a/lionagi/studio/services/workflow_compile.py
+++ b/lionagi/studio/services/workflow_compile.py
@@ -554,6 +554,12 @@ def make_engine_operation(
             spec_input, session=session, on_branch_created=on_branch_created, **run_kwargs
         )
 
+        if getattr(engine, "_total_agent_failure", False):
+            agent_errors = getattr(engine, "_agent_errors", [])
+            return {
+                "error": f"all {len(agent_errors)} sub-agent(s) failed: {'; '.join(agent_errors)}"
+            }
+
         if hasattr(result, "model_dump"):
             return result.model_dump(mode="json")
         if isinstance(result, str):

--- a/tests/agent/test_factory.py
+++ b/tests/agent/test_factory.py
@@ -351,12 +351,20 @@ async def test_agent_post_hooks_ignore_non_dict_results_and_keep_previous_result
 
 
 # ---------------------------------------------------------------------------
-# model spec without "/" — provider = model_name = ms.model (line 75)
+# model spec without "/" — provider resolves from settings default, not the
+# bare model string (a bare model used to become its own garbage provider,
+# which construction never rejected — it silently fell through to a generic
+# Endpoint and only failed later with a missing-API-key error).
 # ---------------------------------------------------------------------------
 
 
-async def test_create_agent_model_without_slash_uses_model_as_provider(monkeypatch):
+async def test_create_agent_model_without_slash_uses_settings_default_provider(monkeypatch):
+    import lionagi.config as config_mod
     import lionagi.service.imodel as imodel_mod
+
+    monkeypatch.setattr(
+        config_mod, "settings", config_mod.AppSettings(LIONAGI_CHAT_PROVIDER="anthropic")
+    )
 
     captured = {}
     real_init = imodel_mod.iModel.__init__
@@ -370,8 +378,48 @@ async def test_create_agent_model_without_slash_uses_model_as_provider(monkeypat
     config = AgentSpec.compose("implementer", model="gpt-4o")
     await create_agent(config, load_settings=False)
 
-    assert captured.get("provider") == "gpt-4o"
+    assert captured.get("provider") == "anthropic"
     assert captured.get("model") == "gpt-4o"
+
+
+async def test_create_agent_model_with_slash_provider_unchanged(monkeypatch):
+    import lionagi.service.imodel as imodel_mod
+
+    captured = {}
+    real_init = imodel_mod.iModel.__init__
+
+    def spy_init(self, *args, **kwargs):
+        captured.update(kwargs)
+        real_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(imodel_mod.iModel, "__init__", spy_init)
+
+    config = AgentSpec.compose("implementer", model="anthropic/claude-sonnet-4")
+    await create_agent(config, load_settings=False)
+
+    assert captured.get("provider") == "anthropic"
+    assert captured.get("model") == "claude-sonnet-4"
+
+
+async def test_create_agent_backends_alias_unaffected(monkeypatch):
+    """BACKENDS aliases (e.g. 'claude') are already expanded to provider/model by
+    parse_model_spec, so they keep hitting the '/' branch untouched."""
+    import lionagi.service.imodel as imodel_mod
+
+    captured = {}
+    real_init = imodel_mod.iModel.__init__
+
+    def spy_init(self, *args, **kwargs):
+        captured.update(kwargs)
+        real_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(imodel_mod.iModel, "__init__", spy_init)
+
+    config = AgentSpec.compose("implementer", model="claude")
+    await create_agent(config, load_settings=False)
+
+    assert captured.get("provider") == "claude_code"
+    assert captured.get("model") == "sonnet"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/apps_studio_server/test_workflow_run.py
+++ b/tests/apps_studio_server/test_workflow_run.py
@@ -64,6 +64,20 @@ class _FakeEngine:
         return {"echo": spec_input}
 
 
+class _AllAgentsFailedFakeEngine:
+    """Stand-in for an Engine whose every sub-agent terminally errored (e.g.
+    missing API key) — sets the same diagnostics EngineRun/Engine.run() would
+    after a real all-agent-failed run, without any network calls."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+
+    async def run(self, spec_input: str, *, session: Any = None, **kwargs: Any) -> str:
+        self._agent_errors = ["worker-1: API key is required", "worker-2: API key is required"]
+        self._total_agent_failure = True
+        return ""
+
+
 def _mock_chat_branch(name: str = "workflow-default"):
     """Branch whose chat_model is mocked — copies the convention already
     established in tests/operations/test_edge_conditions_tdd.py."""
@@ -162,6 +176,54 @@ async def test_workflow_run_end_to_end(patched_env):
     assert set(edges_by_id) == {"e1", "e2"}
     assert edges_by_id["e2"]["condition"] == "result != None"
     assert edges_by_id["e2"]["mode"] == "code"
+
+
+async def test_workflow_run_all_agents_failed_reports_failed_not_completed(
+    patched_env, monkeypatch
+):
+    """An engine node whose every sub-agent terminally errored (all-auth-failed)
+    must surface as an {"error": ...} operation result and a run status of
+    'failed', not silently report 'completed' with an empty result."""
+    wf_svc, engine_defs_svc = patched_env
+
+    import lionagi.cli.engine as cli_engine
+
+    monkeypatch.setitem(
+        cli_engine._KIND_META,
+        "research",
+        {
+            **cli_engine._KIND_META["research"],
+            "cls_path": (
+                "tests.apps_studio_server.test_workflow_run",
+                "_AllAgentsFailedFakeEngine",
+            ),
+        },
+    )
+
+    engine_def = await engine_defs_svc.create_engine_def(
+        {"name": "all-fail-eng", "kind": "research"}
+    )
+
+    spec = _spec()
+    spec["nodes"][2]["config"]["engine_def_id"] = engine_def["id"]
+    created = await wf_svc.create_workflow_def({"name": "all-fail-flow", "spec_json": spec})
+    def_id = created["id"]
+
+    from lionagi.session.session import Session
+    from lionagi.studio.services.workflow_run import run_workflow_def
+
+    mock_branch = _mock_chat_branch()
+    session = Session(default_branch=mock_branch)
+
+    result = await run_workflow_def(def_id, {"topic": "GQA"}, _session=session)
+
+    assert result["status"] == "failed"
+
+    from lionagi.studio.services.sessions import get_session
+
+    session_row = await get_session(result["run_id"])
+    assert session_row is not None
+    assert session_row["status"] == "failed"
 
 
 async def test_workflow_run_persists_node_lifecycle_signals(patched_env, tmp_path):

--- a/tests/cli/test_engine_agent_failure_diagnostics.py
+++ b/tests/cli/test_engine_agent_failure_diagnostics.py
@@ -243,8 +243,11 @@ async def test_real_engine_total_agent_failure_propagates_to_cli(monkeypatch):
     monkeypatch.setattr(db_mod, "StateDB", lambda: mock_db)
 
     args = _build_args(kind="research", spec="test topic", no_persist=False)
-    await engine_mod._do_engine_run(args)
+    rc = await engine_mod._do_engine_run(args)
 
+    # Total agent failure must exit non-zero so shell/CI callers see it, not
+    # just the persisted DB status.
+    assert rc == 1
     failed = [c for c in mock_db.update_calls if c["status"] == "failed"]
     assert failed, f"no failed update; all calls: {mock_db.update_calls}"
     error_val = failed[0]["error"]

--- a/tests/cli/test_engine_agent_failure_diagnostics.py
+++ b/tests/cli/test_engine_agent_failure_diagnostics.py
@@ -1,0 +1,253 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the CLI half of total sub-agent failure diagnostics: a run where
+every agent terminally errored (e.g. missing API key) must write status
+'failed' to engine_runs, with the agent errors folded into the error column —
+not silently report 'completed'."""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors tests/cli/test_engine_emission_diagnostics.py)
+# ---------------------------------------------------------------------------
+
+
+def _build_args(**kwargs) -> argparse.Namespace:
+    defaults = {
+        "command": "engine",
+        "engine_command": "run",
+        "kind": "research",
+        "spec": "What is GQA?",
+        "test_cmd": None,
+        "export_dir": None,
+        "model": None,
+        "max_depth": None,
+        "max_agents": None,
+        "session_id": None,
+        "no_persist": False,
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+class MockStateDB:
+    """Minimal StateDB mock that records insert and update calls."""
+
+    def __init__(self):
+        self.insert_calls: list[dict] = []
+        self.update_calls: list[dict] = []
+
+    async def open(self):
+        pass
+
+    async def close(self):
+        pass
+
+    async def insert_engine_run(self, *, run_id, kind, spec_json, started_at, session_id=None):
+        self.insert_calls.append({"run_id": run_id, "kind": kind})
+
+    async def update_engine_run(
+        self, run_id, *, status, ended_at=None, export_dir=None, error=None
+    ):
+        self.update_calls.append({"run_id": run_id, "status": status, "error": error})
+
+
+# ---------------------------------------------------------------------------
+# Engine CLI: _total_agent_failure → status='failed', errors in error column
+# ---------------------------------------------------------------------------
+
+
+async def test_total_agent_failure_written_to_db_as_failed(monkeypatch):
+    import lionagi.cli._logging as log_mod
+    import lionagi.cli.engine as engine_mod
+    import lionagi.state.db as db_mod
+
+    monkeypatch.setattr(log_mod, "progress", lambda *a, **kw: None)
+    monkeypatch.setattr(log_mod, "warn", lambda *a, **kw: None)
+
+    mock_engine = MagicMock()
+    mock_engine._emission_failures = []
+    mock_engine._total_agent_failure = True
+    mock_engine._agent_errors = [
+        "worker-1: API key is required",
+        "worker-2: API key is required",
+    ]
+
+    async def _mock_run(spec, *, on_event=None, **kwargs):
+        return ""
+
+    mock_engine.run = _mock_run
+    MockEngineClass = MagicMock(return_value=mock_engine)
+    monkeypatch.setattr(engine_mod, "_import_engine_class", lambda m, n: MockEngineClass)
+
+    mock_db = MockStateDB()
+    monkeypatch.setattr(db_mod, "StateDB", lambda: mock_db)
+
+    args = _build_args(kind="research", spec="GQA", no_persist=False)
+    await engine_mod._do_engine_run(args)
+
+    failed = [c for c in mock_db.update_calls if c["status"] == "failed"]
+    assert failed, f"no failed update; calls={mock_db.update_calls}"
+    assert not [c for c in mock_db.update_calls if c["status"] == "completed"], (
+        "total agent failure must not also write status='completed'"
+    )
+    error_val = failed[0]["error"]
+    assert error_val is not None
+    assert "all sub-agents failed" in error_val
+    assert "worker-1" in error_val and "worker-2" in error_val
+
+
+async def test_total_agent_failure_folds_with_emission_failures(monkeypatch):
+    """Both diagnostics (emission_missing + agent errors) must land in the
+    same error column when a run hits both."""
+    import lionagi.cli._logging as log_mod
+    import lionagi.cli.engine as engine_mod
+    import lionagi.state.db as db_mod
+
+    monkeypatch.setattr(log_mod, "progress", lambda *a, **kw: None)
+    monkeypatch.setattr(log_mod, "warn", lambda *a, **kw: None)
+
+    mock_engine = MagicMock()
+    mock_engine._emission_failures = ["synthesizer x1"]
+    mock_engine._total_agent_failure = True
+    mock_engine._agent_errors = ["worker-1: API key is required"]
+
+    async def _mock_run(spec, *, on_event=None, **kwargs):
+        return ""
+
+    mock_engine.run = _mock_run
+    MockEngineClass = MagicMock(return_value=mock_engine)
+    monkeypatch.setattr(engine_mod, "_import_engine_class", lambda m, n: MockEngineClass)
+
+    mock_db = MockStateDB()
+    monkeypatch.setattr(db_mod, "StateDB", lambda: mock_db)
+
+    args = _build_args(kind="research", spec="GQA", no_persist=False)
+    await engine_mod._do_engine_run(args)
+
+    failed = [c for c in mock_db.update_calls if c["status"] == "failed"]
+    assert failed
+    error_val = failed[0]["error"]
+    assert "emission_missing" in error_val
+    assert "all sub-agents failed" in error_val
+    assert "synthesizer" in error_val
+    assert "worker-1" in error_val
+
+
+async def test_no_total_agent_failure_status_stays_completed(monkeypatch):
+    """A run with some successful agents (no _total_agent_failure) must still
+    report 'completed' — this diagnostic only fires on total failure."""
+    import lionagi.cli._logging as log_mod
+    import lionagi.cli.engine as engine_mod
+    import lionagi.state.db as db_mod
+
+    monkeypatch.setattr(log_mod, "progress", lambda *a, **kw: None)
+    monkeypatch.setattr(log_mod, "warn", lambda *a, **kw: None)
+
+    mock_engine = MagicMock()
+    mock_engine._emission_failures = []
+    mock_engine._total_agent_failure = False
+    mock_engine._agent_errors = []
+
+    async def _mock_run(spec, *, on_event=None, **kwargs):
+        return "clean result"
+
+    mock_engine.run = _mock_run
+    MockEngineClass = MagicMock(return_value=mock_engine)
+    monkeypatch.setattr(engine_mod, "_import_engine_class", lambda m, n: MockEngineClass)
+
+    mock_db = MockStateDB()
+    monkeypatch.setattr(db_mod, "StateDB", lambda: mock_db)
+
+    args = _build_args(kind="research", spec="GQA", no_persist=False)
+    rc = await engine_mod._do_engine_run(args)
+
+    assert rc == 0
+    completed = [c for c in mock_db.update_calls if c["status"] == "completed"]
+    assert completed
+    assert completed[0]["error"] is None
+
+
+async def test_engine_without_total_agent_failure_attr_stays_completed(monkeypatch):
+    """Engine objects without the _total_agent_failure attr (older subclass,
+    or an engine that never ran make_agent) must not crash and must not be
+    treated as a total failure."""
+    import lionagi.cli._logging as log_mod
+    import lionagi.cli.engine as engine_mod
+    import lionagi.state.db as db_mod
+
+    monkeypatch.setattr(log_mod, "progress", lambda *a, **kw: None)
+    monkeypatch.setattr(log_mod, "warn", lambda *a, **kw: None)
+
+    mock_engine = MagicMock(spec=[])  # no _total_agent_failure / _agent_errors attrs
+
+    async def _mock_run(spec, *, on_event=None, **kwargs):
+        return "result"
+
+    mock_engine.run = _mock_run
+    MockEngineClass = MagicMock(return_value=mock_engine)
+    monkeypatch.setattr(engine_mod, "_import_engine_class", lambda m, n: MockEngineClass)
+
+    mock_db = MockStateDB()
+    monkeypatch.setattr(db_mod, "StateDB", lambda: mock_db)
+
+    args = _build_args(kind="research", spec="GQA", no_persist=False)
+    rc = await engine_mod._do_engine_run(args)
+
+    assert rc == 0
+    completed = [c for c in mock_db.update_calls if c["status"] == "completed"]
+    assert completed
+    assert completed[0]["error"] is None
+
+
+# ---------------------------------------------------------------------------
+# INTEGRATION: real Engine subclass whose _run() drives every agent to error
+# — verifies the full Engine.run() → CLI read-site handoff for the total
+# agent-failure signal (the same integration shape as the emission-failure
+# test in test_engine_emission_diagnostics.py).
+# ---------------------------------------------------------------------------
+
+
+async def _build_all_agents_failed_engine():
+    from lionagi.engines.engine import Engine, EngineRun
+
+    class AllAgentsFailedEngine(Engine):
+        async def _run(self, run: EngineRun, spec: str, **kwargs) -> str:  # type: ignore[override]
+            run.agents_made = 2
+            run.notify("agent_error", agent="planner", error="API key is required")
+            run.notify("agent_error", agent="worker", error="API key is required")
+            return ""
+
+    return AllAgentsFailedEngine(max_agents=5)
+
+
+async def test_real_engine_total_agent_failure_propagates_to_cli(monkeypatch):
+    import lionagi.cli._logging as log_mod
+    import lionagi.cli.engine as engine_mod
+    import lionagi.state.db as db_mod
+
+    monkeypatch.setattr(log_mod, "progress", lambda *a, **kw: None)
+    monkeypatch.setattr(log_mod, "warn", lambda *a, **kw: None)
+
+    real_engine = await _build_all_agents_failed_engine()
+    MockEngineClass = MagicMock(return_value=real_engine)
+    monkeypatch.setattr(engine_mod, "_import_engine_class", lambda m, n: MockEngineClass)
+
+    mock_db = MockStateDB()
+    monkeypatch.setattr(db_mod, "StateDB", lambda: mock_db)
+
+    args = _build_args(kind="research", spec="test topic", no_persist=False)
+    await engine_mod._do_engine_run(args)
+
+    failed = [c for c in mock_db.update_calls if c["status"] == "failed"]
+    assert failed, f"no failed update; all calls: {mock_db.update_calls}"
+    error_val = failed[0]["error"]
+    assert error_val is not None
+    assert "all sub-agents failed" in error_val
+    assert "planner" in error_val and "worker" in error_val

--- a/tests/cli/test_engine_cli.py
+++ b/tests/cli/test_engine_cli.py
@@ -160,6 +160,7 @@ async def test_successful_engine_run_returns_0(monkeypatch, capsys):
         return "This is the research result."
 
     mock_engine = MagicMock()
+    mock_engine._total_agent_failure = False
     mock_engine.run = _mock_run
     MockEngineClass = MagicMock(return_value=mock_engine)
     monkeypatch.setattr(engine_mod, "_import_engine_class", lambda m, n: MockEngineClass)
@@ -186,6 +187,7 @@ async def test_engine_failure_returns_1(monkeypatch):
         raise RuntimeError("LLM unavailable")
 
     mock_engine = MagicMock()
+    mock_engine._total_agent_failure = False
     mock_engine.run = _mock_run_fail
     MockEngineClass = MagicMock(return_value=mock_engine)
     monkeypatch.setattr(engine_mod, "_import_engine_class", lambda m, n: MockEngineClass)
@@ -224,6 +226,7 @@ async def test_code_result_recorded_shape_serialized(monkeypatch, capsys):
         return pydantic_result
 
     mock_engine = MagicMock()
+    mock_engine._total_agent_failure = False
     mock_engine.run = _mock_run
     MockEngineClass = MagicMock(return_value=mock_engine)
     monkeypatch.setattr(engine_mod, "_import_engine_class", lambda m, n: MockEngineClass)
@@ -274,6 +277,7 @@ async def test_export_dir_persisted_from_args_coding(monkeypatch, capsys):
         return pydantic_result
 
     mock_engine = MagicMock()
+    mock_engine._total_agent_failure = False
     mock_engine.run = _mock_run
     MockEngineClass = MagicMock(return_value=mock_engine)
     monkeypatch.setattr(engine_mod, "_import_engine_class", lambda m, n: MockEngineClass)
@@ -340,6 +344,7 @@ async def test_export_dir_persisted_from_args_hypothesis(monkeypatch, capsys):
         return "Hypothesis: X causes Y because Z."
 
     mock_engine = MagicMock()
+    mock_engine._total_agent_failure = False
     mock_engine.run = _mock_run
     MockEngineClass = MagicMock(return_value=mock_engine)
     monkeypatch.setattr(engine_mod, "_import_engine_class", lambda m, n: MockEngineClass)
@@ -404,6 +409,7 @@ async def test_export_dir_none_when_not_passed(monkeypatch, capsys):
         return "Research findings."
 
     mock_engine = MagicMock()
+    mock_engine._total_agent_failure = False
     mock_engine.run = _mock_run
     MockEngineClass = MagicMock(return_value=mock_engine)
     monkeypatch.setattr(engine_mod, "_import_engine_class", lambda m, n: MockEngineClass)
@@ -466,6 +472,7 @@ async def test_cancelled_error_marks_row_cancelled(monkeypatch):
         raise asyncio.CancelledError("test cancel")
 
     mock_engine = MagicMock()
+    mock_engine._total_agent_failure = False
     mock_engine.run = _mock_run_cancel
     MockEngineClass = MagicMock(return_value=mock_engine)
     monkeypatch.setattr(engine_mod, "_import_engine_class", lambda m, n: MockEngineClass)
@@ -530,6 +537,7 @@ async def test_keyboard_interrupt_marks_row_cancelled(monkeypatch):
         raise KeyboardInterrupt("SIGINT simulation")
 
     mock_engine = MagicMock()
+    mock_engine._total_agent_failure = False
     mock_engine.run = _mock_run_interrupt
     MockEngineClass = MagicMock(return_value=mock_engine)
     monkeypatch.setattr(engine_mod, "_import_engine_class", lambda m, n: MockEngineClass)
@@ -593,6 +601,7 @@ async def test_db_insert_called_on_success(monkeypatch, capsys):
         return "done"
 
     mock_engine = MagicMock()
+    mock_engine._total_agent_failure = False
     mock_engine.run = _mock_run
     MockEngineClass = MagicMock(return_value=mock_engine)
     monkeypatch.setattr(engine_mod, "_import_engine_class", lambda m, n: MockEngineClass)
@@ -653,6 +662,7 @@ async def test_no_persist_skips_db(monkeypatch, capsys):
         return "no persist result"
 
     mock_engine = MagicMock()
+    mock_engine._total_agent_failure = False
     mock_engine.run = _mock_run
     MockEngineClass = MagicMock(return_value=mock_engine)
     monkeypatch.setattr(engine_mod, "_import_engine_class", lambda m, n: MockEngineClass)
@@ -912,6 +922,7 @@ async def test_engine_run_skips_signal_binding_on_session_id_collision(
         return "done"
 
     mock_engine = MagicMock()
+    mock_engine._total_agent_failure = False
     mock_engine.run = _mock_run
     monkeypatch.setattr(
         engine_mod, "_import_engine_class", lambda m, n: MagicMock(return_value=mock_engine)

--- a/tests/cli/test_engine_emission_diagnostics.py
+++ b/tests/cli/test_engine_emission_diagnostics.py
@@ -73,6 +73,7 @@ async def test_emission_failures_written_to_db_error_on_completed(monkeypatch):
     # Engine that returns a result but has _emission_failures populated.
     mock_engine = MagicMock()
     mock_engine._emission_failures = ["planner x2", "summariser x1"]
+    mock_engine._total_agent_failure = False
 
     async def _mock_run(spec, *, on_event=None, **kwargs):
         return "partial result despite missing emissions"
@@ -111,6 +112,7 @@ async def test_no_emission_failures_error_column_stays_null(monkeypatch):
 
     mock_engine = MagicMock()
     mock_engine._emission_failures = []  # no failures
+    mock_engine._total_agent_failure = False
 
     async def _mock_run(spec, *, on_event=None, **kwargs):
         return "clean result"

--- a/tests/engines/test_engine_agent_failure.py
+++ b/tests/engines/test_engine_agent_failure.py
@@ -1,0 +1,154 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for total sub-agent failure diagnostics: EngineRun._agent_errors
+accumulation and Engine._total_agent_failure — the signal that lets a run
+where every agent terminally errored (e.g. missing API key) be surfaced as
+failed instead of silently reporting 'completed'."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from lionagi.engines.engine import Engine, EngineRun
+
+# ---------------------------------------------------------------------------
+# EngineRun._agent_errors accumulation via notify()
+# ---------------------------------------------------------------------------
+
+
+def _make_minimal_engine_run() -> EngineRun:
+    engine = MagicMock()
+    engine.max_concurrent = 1
+    engine.max_agents = 100
+    engine.deadline_s = None
+    engine.model = None
+    return EngineRun(engine, on_event=None)
+
+
+def test_engine_run_agent_errors_starts_empty():
+    er = _make_minimal_engine_run()
+    assert er._agent_errors == []
+
+
+def test_notify_agent_error_accumulates():
+    er = _make_minimal_engine_run()
+    er.notify("agent_error", agent="worker-1", error="API key is required")
+    er.notify("agent_error", agent="worker-2", error="rate limited")
+    assert er._agent_errors == [
+        "worker-1: API key is required",
+        "worker-2: rate limited",
+    ]
+
+
+def test_notify_other_kinds_do_not_affect_agent_errors():
+    er = _make_minimal_engine_run()
+    er.notify("gated", eid="x", reason="reject")
+    er.notify("budget_exhausted", reason="agents", agents_made=5, elapsed=1.0)
+    assert er._agent_errors == []
+
+
+def test_notify_still_forwards_to_on_event():
+    calls = []
+    engine = MagicMock()
+    engine.max_concurrent = 1
+    engine.max_agents = 100
+    engine.deadline_s = None
+    engine.model = None
+    er = EngineRun(engine, on_event=lambda e: calls.append(e))
+
+    er.notify("agent_error", agent="worker-1", error="boom")
+
+    assert calls == [{"type": "agent_error", "agent": "worker-1", "error": "boom"}]
+    assert er._agent_errors == ["worker-1: boom"]
+
+
+# ---------------------------------------------------------------------------
+# Engine._total_agent_failure — flagged only when every agent made errored
+# ---------------------------------------------------------------------------
+
+
+async def test_total_agent_failure_true_when_all_agents_errored():
+    class AllAgentsFailEngine(Engine):
+        async def _run(self, run: EngineRun, spec: str, **kwargs) -> str:  # type: ignore[override]
+            run.agents_made = 2
+            run.notify("agent_error", agent="a1", error="API key is required")
+            run.notify("agent_error", agent="a2", error="API key is required")
+            return ""
+
+    engine = AllAgentsFailEngine(max_agents=5)
+    await engine.run("spec")
+
+    assert engine._total_agent_failure is True
+    assert engine._agent_errors == [
+        "a1: API key is required",
+        "a2: API key is required",
+    ]
+
+
+async def test_total_agent_failure_false_when_some_agents_succeed():
+    class PartialAgentFailEngine(Engine):
+        async def _run(self, run: EngineRun, spec: str, **kwargs) -> str:  # type: ignore[override]
+            run.agents_made = 2
+            run.notify("agent_error", agent="a1", error="API key is required")
+            return "ok"
+
+    engine = PartialAgentFailEngine(max_agents=5)
+    result = await engine.run("spec")
+
+    assert engine._total_agent_failure is False
+    assert "ok" in str(result)
+
+
+async def test_total_agent_failure_false_when_no_agents_made():
+    class NoAgentsEngine(Engine):
+        async def _run(self, run: EngineRun, spec: str, **kwargs) -> str:  # type: ignore[override]
+            return "no agents needed"
+
+    engine = NoAgentsEngine(max_agents=5)
+    await engine.run("spec")
+
+    assert engine._total_agent_failure is False
+    assert engine._agent_errors == []
+
+
+async def test_total_agent_failure_false_on_clean_run():
+    class CleanEngine(Engine):
+        async def _run(self, run: EngineRun, spec: str, **kwargs) -> str:  # type: ignore[override]
+            run.agents_made = 3
+            return "clean"
+
+    engine = CleanEngine(max_agents=5)
+    await engine.run("spec")
+
+    assert engine._total_agent_failure is False
+    assert engine._agent_errors == []
+
+
+async def test_engine_reuse_second_run_resets_total_agent_failure():
+    """A reused engine must not carry a total-failure flag from a previous run
+    into the next one, mirroring the existing _emission_failures reset guarantee."""
+
+    call_count = [0]
+
+    class TwoRunEngine(Engine):
+        async def _run(self, run: EngineRun, spec: str, **kwargs) -> str:  # type: ignore[override]
+            call_count[0] += 1
+            if call_count[0] == 1:
+                run.agents_made = 2
+                run.notify("agent_error", agent="a1", error="boom")
+                run.notify("agent_error", agent="a2", error="boom")
+            else:
+                run.agents_made = 2
+            return "result"
+
+    engine = TwoRunEngine(max_agents=5)
+
+    await engine.run("run-1")
+    assert engine._total_agent_failure is True
+
+    await engine.run("run-2")
+    assert engine._total_agent_failure is False
+    assert engine._agent_errors == []


### PR DESCRIPTION
## What

An engine node (Studio `run_workflow_def`, or any in-process `Engine.run(session=...)`, or
`li engine run`) reported `status=completed` even when **every** sub-agent it spawned failed with
"API key is required for authentication". The node reported success while doing no real work.
Fixes #1839.

Two parts:

### Part 1 — bare model resolves its provider from settings (root cause)
`agent/factory.py` derived the provider by splitting the model string on `/`; a **bare** model like
`gpt-4.1-mini` fell into `provider = model_name = ms.model`, yielding `iModel(provider="gpt-4.1-mini")`
— an unknown provider with no credential (`EndpointRegistry.match` falls through to a generic
Endpoint for unknown providers, so construction succeeds and the call fails later). The Session
default branch never hit this because it resolves the provider from `settings.LIONAGI_CHAT_PROVIDER`.

Now a bare model does the same: `provider = settings.LIONAGI_CHAT_PROVIDER`, `model_name = ms.model`.
`provider/model` specs and backend aliases (e.g. `claude` → `claude_code/sonnet`, already expanded
with a `/`) are unchanged — only genuinely bare API models change.

### Part 2 — surface total sub-agent failure instead of green
Every engine already calls `run.notify("agent_error", ...)` at each terminal agent failure.
`EngineRun.notify` now accumulates these into `_agent_errors`, and `Engine.run` sets
`_total_agent_failure = agents_made > 0 and len(_agent_errors) >= agents_made` — flagged **only**
when every agent made for the run terminally errored, so partial or empty-but-ran runs are never
over-flagged. On that flag:
- Studio `make_engine_operation` returns `{"error": ...}` (Studio's existing `"error" in result`
  check then marks the run `failed`).
- `li engine run` folds the errors into `engine_runs.error`, persists status `failed`, **and exits
  non-zero** so shell/CI callers see the failure rather than a false-green exit 0.

## Tests
- `factory`: bare model → settings-default provider; qualified `provider/model` + backend alias
  unchanged.
- `engine`: `notify` accumulation; `_total_agent_failure` true iff all agents errored, false with
  ≥1 success and with `agents_made == 0`; reset-on-reuse.
- studio: an all-agents-fail engine node → run status `failed`, not `completed` (via the `_session`
  injection seam).
- cli: DB status `failed` + `engine_runs.error` populated + **exit code 1** on total failure
  (integration test with a real `Engine` subclass); clean runs still exit 0 / `completed`.
- Full suite: 33 failures, all pre-existing missing-optional-dependency gaps
  (pandas/ollama/docling/fastmcp/postgres), zero new; none in changed code.

## Notes
- A bare `MagicMock()` engine auto-vivifies `_total_agent_failure` as truthy, which would misread
  as total failure at the `getattr(engine, "_total_agent_failure", False)` read sites; the affected
  test fixtures now set it explicitly. Production is unaffected — real engines always set the flag
  in `run()`, and a genuinely missing attribute defaults to `False`.

## Out of scope (separate lanes)
- #1841 — stale `running` play rows never reaped.
- #1837 — designer edge-condition authoring.
