### PR TITLE
feat(studio): emit head_sha + draft from github_poll and filter on draft (#1849)

### DIFF
--- a/lionagi/studio/scheduler/github.py
+++ b/lionagi/studio/scheduler/github.py
@@ -203,22 +203,33 @@ async def github_poll(schedule: dict) -> list[dict[str, Any]]:
     cursor = schedule.get("github_cursor")
     prs = resp.json()
 
+    draft_filter = github_filter.get("draft")
     new_prs = []
     max_updated = cursor
     for pr in prs:
         updated = pr.get("updated_at", "")
-        if not cursor or updated > cursor:
-            new_prs.append(
-                {
-                    "pr_number": pr.get("number"),
-                    "pr_title": pr.get("title"),
-                    "pr_url": pr.get("html_url"),
-                    "pr_author": (pr.get("user") or {}).get("login"),
-                    "updated_at": updated,
-                }
-            )
-            if not max_updated or updated > max_updated:
-                max_updated = updated
+        if cursor and updated <= cursor:
+            continue
+        # New PR past the cursor high-water mark. Advance the cursor for it
+        # even if the draft filter drops it below, so a filtered PR is not
+        # re-listed on every poll — a draft toggle bumps updated_at and
+        # naturally re-qualifies the PR when its draft state changes.
+        if not max_updated or updated > max_updated:
+            max_updated = updated
+        is_draft = bool(pr.get("draft", False))
+        if draft_filter is not None and is_draft != bool(draft_filter):
+            continue
+        new_prs.append(
+            {
+                "pr_number": pr.get("number"),
+                "pr_title": pr.get("title"),
+                "pr_url": pr.get("html_url"),
+                "pr_author": (pr.get("user") or {}).get("login"),
+                "updated_at": updated,
+                "head_sha": (pr.get("head") or {}).get("sha"),
+                "draft": is_draft,
+            }
+        )
 
     # Update cursor on the schedule when new PRs found or etag refreshed
     update_fields: dict[str, Any] = {}

--- a/lionagi/studio/scheduler/github.py
+++ b/lionagi/studio/scheduler/github.py
@@ -217,7 +217,10 @@ async def github_poll(schedule: dict) -> list[dict[str, Any]]:
         if not max_updated or updated > max_updated:
             max_updated = updated
         is_draft = bool(pr.get("draft", False))
-        if draft_filter is not None and is_draft != bool(draft_filter):
+        # Only a real JSON boolean narrows the fire set. A malformed non-bool
+        # draft filter is ignored (fail open to no filtering) rather than
+        # silently matching the wrong side — the string "false" is truthy.
+        if isinstance(draft_filter, bool) and is_draft != draft_filter:
             continue
         new_prs.append(
             {

--- a/tests/studio/test_github_poller.py
+++ b/tests/studio/test_github_poller.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the github_poll poller: emitted fields (head_sha, draft) and
+the draft github_filter, with the cursor high-water-mark behavior."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from lionagi.studio.scheduler import github as gh_mod
+
+
+def _pr(number, updated, *, draft=False, sha=None):
+    return {
+        "number": number,
+        "title": f"PR {number}",
+        "html_url": f"https://github.com/owner/name/pull/{number}",
+        "user": {"login": "octocat"},
+        "updated_at": updated,
+        "draft": draft,
+        "head": {"sha": sha or f"sha{number}"},
+    }
+
+
+class _FakeResp:
+    def __init__(self, prs):
+        self._prs = prs
+        self.status_code = 200
+        self.headers = {"x-ratelimit-remaining": "100", "etag": '"abc"'}
+
+    def json(self):
+        return self._prs
+
+
+class _FakeClient:
+    def __init__(self, prs):
+        self._prs = prs
+
+    async def get(self, url, headers=None, params=None):
+        return _FakeResp(self._prs)
+
+
+def _install(monkeypatch, prs):
+    """Wire the poller's token, HTTP client, and StateDB write to fakes.
+
+    Returns a list that captures (schedule_id, update_fields) for each cursor
+    write so a test can assert the high-water mark that was persisted."""
+    cursor_writes: list = []
+
+    async def _fake_token():
+        return "faketoken"
+
+    class _FakeDB:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def update_schedule(self, schedule_id, **fields):
+            cursor_writes.append((schedule_id, fields))
+
+    monkeypatch.setattr(gh_mod, "_get_gh_token", _fake_token)
+    monkeypatch.setattr(gh_mod, "_get_client", lambda: _FakeClient(prs))
+    monkeypatch.setattr(gh_mod, "StateDB", _FakeDB)
+    return cursor_writes
+
+
+def _poll(schedule):
+    return asyncio.run(gh_mod.github_poll(schedule))
+
+
+def test_github_poll_emits_head_sha_and_draft(monkeypatch):
+    """A polled PR surfaces head_sha and draft alongside the existing fields."""
+    _install(monkeypatch, [_pr(7, "2026-07-07T10:00:00Z", draft=False, sha="deadbeef")])
+    events = _poll({"id": "s1", "github_repo": "owner/name"})
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["pr_number"] == 7
+    assert ev["head_sha"] == "deadbeef"
+    assert ev["draft"] is False
+    assert ev["pr_author"] == "octocat"
+
+
+def test_github_poll_draft_filter_true_keeps_only_drafts(monkeypatch):
+    """github_filter={'draft': true} emits only draft PRs."""
+    _install(
+        monkeypatch,
+        [
+            _pr(1, "2026-07-07T10:00:00Z", draft=False),
+            _pr(2, "2026-07-07T09:00:00Z", draft=True),
+        ],
+    )
+    events = _poll({"id": "s1", "github_repo": "owner/name", "github_filter": {"draft": True}})
+    assert [e["pr_number"] for e in events] == [2]
+    assert events[0]["draft"] is True
+
+
+def test_github_poll_draft_filter_false_excludes_drafts(monkeypatch):
+    """github_filter={'draft': false} emits only non-draft PRs."""
+    _install(
+        monkeypatch,
+        [
+            _pr(1, "2026-07-07T10:00:00Z", draft=False),
+            _pr(2, "2026-07-07T09:00:00Z", draft=True),
+        ],
+    )
+    events = _poll({"id": "s1", "github_repo": "owner/name", "github_filter": {"draft": False}})
+    assert [e["pr_number"] for e in events] == [1]
+    assert events[0]["draft"] is False
+
+
+def test_github_poll_no_draft_filter_emits_all(monkeypatch):
+    """Without a draft key, both draft and ready PRs are emitted."""
+    _install(
+        monkeypatch,
+        [
+            _pr(1, "2026-07-07T10:00:00Z", draft=False),
+            _pr(2, "2026-07-07T09:00:00Z", draft=True),
+        ],
+    )
+    events = _poll({"id": "s1", "github_repo": "owner/name"})
+    assert sorted(e["pr_number"] for e in events) == [1, 2]
+
+
+def test_github_poll_cursor_advances_past_filtered_pr(monkeypatch):
+    """A draft-filtered PR that is the newest still advances the persisted cursor,
+    so it is not re-listed on every poll."""
+    writes = _install(
+        monkeypatch,
+        [
+            # Newest is a draft; the filter wants non-drafts only.
+            _pr(2, "2026-07-07T12:00:00Z", draft=True),
+            _pr(1, "2026-07-07T10:00:00Z", draft=False),
+        ],
+    )
+    events = _poll(
+        {
+            "id": "s1",
+            "github_repo": "owner/name",
+            "github_filter": {"draft": False},
+            "github_cursor": "2026-07-07T09:00:00Z",
+        }
+    )
+    # Only the non-draft PR is emitted...
+    assert [e["pr_number"] for e in events] == [1]
+    # ...but the cursor advanced to the newest updated_at seen (the filtered draft).
+    assert writes, "expected a cursor write"
+    _sid, fields = writes[-1]
+    assert fields.get("github_cursor") == "2026-07-07T12:00:00Z"

--- a/tests/studio/test_github_poller.py
+++ b/tests/studio/test_github_poller.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 
 import asyncio
 
-import pytest
-
 from lionagi.studio.scheduler import github as gh_mod
 
 
@@ -151,3 +149,17 @@ def test_github_poll_cursor_advances_past_filtered_pr(monkeypatch):
     assert writes, "expected a cursor write"
     _sid, fields = writes[-1]
     assert fields.get("github_cursor") == "2026-07-07T12:00:00Z"
+
+
+def test_github_poll_non_bool_draft_filter_ignored(monkeypatch):
+    """A malformed non-bool draft filter (e.g. the string 'false') is ignored —
+    fail open to no filtering rather than silently matching the wrong side."""
+    _install(
+        monkeypatch,
+        [
+            _pr(1, "2026-07-07T10:00:00Z", draft=False),
+            _pr(2, "2026-07-07T09:00:00Z", draft=True),
+        ],
+    )
+    events = _poll({"id": "s1", "github_repo": "owner/name", "github_filter": {"draft": "false"}})
+    assert sorted(e["pr_number"] for e in events) == [1, 2]


### PR DESCRIPTION
Closes #1849 — follow-up to #1847 (github trigger CLI). Adds the two fields the event-driven automation lane needs from the github_poll trigger.

## What changed (single file: scheduler/github.py)
- **Emit `head_sha` and `draft`** on every polled event. Both are already in the `/repos/{repo}/pulls` list response, so no extra API call. `head_sha` is the SHA-gate field: a downstream reviewer can skip work when the head commit is unchanged since its last verdict, making `updated_at`-noise fires (a label/comment touch that bumps `updated_at` without a new commit) cheap to ignore.
- **`draft` as a `github_filter` key**: `github_filter={"draft": true|false}` narrows fires to draft-only or ready-only PRs. Without the key, all PRs fire (each carrying its `draft` flag).
- **Cursor high-water mark** now advances for every PR past the cursor *before* the draft filter drops it, so a filtered-out PR isn't re-listed on every poll — a draft toggle bumps `updated_at` and naturally re-qualifies the PR when its state changes.

## No engine/subprocess change needed
The prompt renderer (`subprocess.py _render_template`) resolves `{{key}}` from `github_events[0]` generically, so `{{head_sha}}` and `{{draft}}` are usable in a reviewer prompt automatically.

## Tests (new: tests/studio/test_github_poller.py)
First direct unit tests for the poller (mocked token/client/StateDB): emits head_sha+draft; draft filter true keeps only drafts; false excludes drafts; no filter emits all; and the cursor advances past a filtered newest PR. Full github/scheduler suites green (230 tests, no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)