### PR TITLE
feat(studio): global concurrent-fire cap for the scheduler (#1850)

### DIFF
--- a/lionagi/state/reasons.py
+++ b/lionagi/state/reasons.py
@@ -116,6 +116,7 @@ class ScheduleReasons:
     FIRED_DUE = "schedule.fired.due"
     SKIPPED_OVERLAP = "schedule.skipped.overlap"
     SKIPPED_MISSED_FIRE = "schedule.skipped.missed_fire"
+    DEFERRED_CAPACITY = "schedule.deferred.capacity"
 
 
 class DispatchReasons:

--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -614,6 +614,17 @@ def _cmd_get(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_limits(args: argparse.Namespace) -> int:
+    result = _api("/limits")
+    if result is None:
+        return 1
+    cap = result.get("max_scheduled_concurrent")
+    cap_display = "unlimited" if not cap else str(cap)
+    print(f"Max concurrent fires: {cap_display}")
+    print(f"Current in-flight:    {result.get('current_inflight', 0)}")
+    return 0
+
+
 def _validate_chain_action_node(
     action: Any,
     label: str,
@@ -926,6 +937,14 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
     )
     get_p.add_argument("id", help="Schedule ID.")
 
+    # limits
+    sched_sub.add_parser(
+        "limits",
+        help="Show the global concurrent-fire cap and current in-flight count.",
+        epilog="Example: li schedule limits",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
     # create
     create_p = sched_sub.add_parser(
         "create",
@@ -1079,6 +1098,7 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
 _ACTION_MAP = {
     "list": _cmd_list,
     "get": _cmd_get,
+    "limits": _cmd_limits,
     "create": _cmd_create,
     "enable": _cmd_enable,
     "disable": _cmd_disable,
@@ -1093,7 +1113,8 @@ def run_schedule(args: argparse.Namespace) -> int:
     fn = _ACTION_MAP.get(action)
     if fn is None:
         print(
-            "Usage: li schedule <subcommand>  (list|get|create|enable|disable|trigger|delete|runs)"
+            "Usage: li schedule <subcommand>  "
+            "(list|get|limits|create|enable|disable|trigger|delete|runs)"
         )
         return 1
     return fn(args)

--- a/lionagi/studio/config.py
+++ b/lionagi/studio/config.py
@@ -52,6 +52,11 @@ CORS_ORIGINS: list[str] = (
 # When saturated, POST /api/launches returns 429.
 MAX_LAUNCHES: int = int(os.environ.get("LIONAGI_STUDIO_MAX_LAUNCHES", "4"))
 
+# Maximum concurrent SCHEDULED fires (cron/interval/github_poll/manual-trigger).
+# Independent of MAX_LAUNCHES (which caps only the on-demand /api/launches surface).
+# 0 = unlimited. When saturated, a due fire defers to the next tick (never dropped).
+MAX_SCHEDULED_CONCURRENT: int = int(os.environ.get("LIONAGI_STUDIO_MAX_SCHEDULED_CONCURRENT", "4"))
+
 # ── Lifecycle reaper config ───────────────────────────────────────────────────
 # Default invocation deadline in seconds (2 hours). Override per action kind
 # via LIONAGI_STUDIO_INVOCATION_DEADLINE_<KIND>_SECONDS (e.g. _AGENT_SECONDS).

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -28,6 +28,10 @@ _log = logging.getLogger(__name__)
 
 _MAX_CHAIN_DEPTH = 10
 _TICK_INTERVAL = 30  # seconds
+# Deferred-capacity skipped-run records are throttled to one per schedule per
+# this many deferrals (the first deferral always emits), so sustained
+# saturation doesn't spam schedule_runs.
+_DEFERRED_RECORD_EVERY = 10
 
 
 class _MaxRunsClaim:
@@ -55,6 +59,30 @@ class _MaxRunsClaim:
             return
         self._released = True
         self._engine._release_max_runs_claim(self._schedule_id)
+
+
+class _GlobalSlotClaim:
+    """One-shot handle for an in-process global concurrent-fire slot.
+
+    Returned by ``_reserve_global_slot()`` when a top-level fire is allowed
+    to proceed under the daemon-wide concurrency ceiling. The holder
+    (``_fire()``) must call ``release()`` exactly once, from a ``finally``
+    block that covers every exit path, so the slot never survives past the
+    fire it was reserved for. ``release()`` is itself idempotent (a second
+    call is a no-op), same defense-in-depth rationale as ``_MaxRunsClaim``.
+    """
+
+    __slots__ = ("_engine", "_released")
+
+    def __init__(self, engine: SchedulerEngine) -> None:
+        self._engine = engine
+        self._released = False
+
+    def release(self) -> None:
+        if self._released:
+            return
+        self._released = True
+        self._engine._release_global_slot()
 
 
 def _resolve_scheduler_tzinfo(tz_name: str) -> ZoneInfo:
@@ -129,6 +157,10 @@ class SchedulerEngine:
         self._max_runs_inflight: dict[
             str, int
         ] = {}  # schedule_id -> claimed-not-yet-terminal count
+        # global concurrent-fire cap (single-process; see _reserve_global_slot).
+        self._global_slot_lock = asyncio.Lock()
+        self._global_inflight = 0
+        self._deferred_log_counts: dict[str, int] = {}  # schedule_id -> deferrals since last record
 
     async def start(self) -> None:
         _log.info("Scheduler engine starting")
@@ -258,12 +290,25 @@ class SchedulerEngine:
                 f"Schedule {schedule_id!r} has already reached its max_runs="
                 f"{schedule.get('max_runs')} limit; manual trigger refused."
             )
+        # A human is waiting on a manual trigger, so at-capacity is refused
+        # outright rather than deferred like the automatic fire paths below.
+        slot_allowed, slot_claim = await self._reserve_global_slot()
+        if not slot_allowed:
+            if claim is not None:
+                claim.release()
+            from lionagi.studio.config import MAX_SCHEDULED_CONCURRENT
+
+            raise ValueError(
+                f"Scheduler at capacity ({MAX_SCHEDULED_CONCURRENT} concurrent "
+                "fires); manual trigger refused. Retry shortly."
+            )
         run_id = uuid.uuid4().hex[:12]
         self._tracked_fire(
             schedule,
             run_id,
             trigger_context={"manual": True, "fired_at": time.time()},
             max_runs_claim=claim,
+            global_slot_claim=slot_claim,
         )
         return run_id
 
@@ -446,25 +491,51 @@ class SchedulerEngine:
         last = schedule.get("last_fired_at") or 0
         if now - last < poll_interval:
             return
+
+        # Reserve the global slot before polling: a filtered/no-slot poll
+        # must not fetch-and-advance-cursor-then-discard.
+        slot_allowed, slot_claim = await self._reserve_global_slot()
+        if not slot_allowed:
+            await self._maybe_record_deferred(schedule, now)
+            return
+
         from .github import github_poll
 
-        new_events = await github_poll(schedule)
-        if new_events:
-            allowed, claim = await self._reserve_max_runs_budget(schedule)
-            if not allowed:
-                _log.info(
-                    "Schedule %s (%s) has exhausted max_runs; skipping github_poll fire",
-                    schedule.get("name"),
-                    schedule["id"],
-                )
-                return
-            ctx = {
-                "github_events": new_events,
-                "repo": schedule.get("github_repo"),
-                "fired_at": now,
-            }
-            run_id = uuid.uuid4().hex[:12]
-            await self._fire(schedule, run_id, trigger_context=ctx, max_runs_claim=claim)
+        try:
+            new_events = await github_poll(schedule)
+        except BaseException:
+            if slot_claim is not None:
+                slot_claim.release()
+            raise
+
+        if not new_events:
+            if slot_claim is not None:
+                slot_claim.release()
+            return
+
+        allowed, claim = await self._reserve_max_runs_budget(schedule)
+        if not allowed:
+            if slot_claim is not None:
+                slot_claim.release()
+            _log.info(
+                "Schedule %s (%s) has exhausted max_runs; skipping github_poll fire",
+                schedule.get("name"),
+                schedule["id"],
+            )
+            return
+        ctx = {
+            "github_events": new_events,
+            "repo": schedule.get("github_repo"),
+            "fired_at": now,
+        }
+        run_id = uuid.uuid4().hex[:12]
+        await self._fire(
+            schedule,
+            run_id,
+            trigger_context=ctx,
+            max_runs_claim=claim,
+            global_slot_claim=slot_claim,
+        )
 
     async def _reserve_max_runs_budget(self, schedule: dict) -> tuple[bool, _MaxRunsClaim | None]:
         """Atomically claim one top-level fire against schedule['max_runs'].
@@ -532,6 +603,59 @@ class SchedulerEngine:
         else:
             self._max_runs_inflight.pop(schedule_id, None)
 
+    async def _reserve_global_slot(self) -> tuple[bool, _GlobalSlotClaim | None]:
+        """Atomically claim one global concurrent-fire slot.
+
+        Returns ``(allowed, claim)``, mirroring ``_reserve_max_runs_budget()``.
+        ``allowed`` is False only when ``MAX_SCHEDULED_CONCURRENT`` is set
+        (nonzero) and every slot is already in use; callers must defer rather
+        than fire in that case. ``claim`` is a ``_GlobalSlotClaim`` token when
+        a slot was actually reserved, or ``None`` when the cap is unlimited
+        (0 — always allowed, no claim to release). Guarded by an engine-wide
+        lock for the same reason ``_max_runs_lock`` exists: the tick loop,
+        fire_now(), and github polling can all reserve concurrently. Chain
+        children never call this — only top-level fires consume a slot, same
+        rule as max_runs.
+        """
+        from lionagi.studio.config import MAX_SCHEDULED_CONCURRENT
+
+        if MAX_SCHEDULED_CONCURRENT <= 0:
+            return True, None
+        async with self._global_slot_lock:
+            if self._global_inflight >= MAX_SCHEDULED_CONCURRENT:
+                return False, None
+            self._global_inflight += 1
+            return True, _GlobalSlotClaim(self)
+
+    def _release_global_slot(self) -> None:
+        self._global_inflight = max(0, self._global_inflight - 1)
+
+    async def _maybe_record_deferred(self, schedule: dict, now: float) -> None:
+        """Emit a throttled skipped-run record for a capacity-deferred fire.
+
+        Every deferral increments a per-schedule counter; a record is only
+        written on the first deferral and every _DEFERRED_RECORD_EVERY-th one
+        after that, so sustained saturation doesn't spam schedule_runs.
+        """
+        sid = schedule["id"]
+        count = self._deferred_log_counts.get(sid, 0) + 1
+        self._deferred_log_counts[sid] = count
+        if count % _DEFERRED_RECORD_EVERY != 1:
+            return
+        skipped_run_id = uuid.uuid4().hex[:12]
+        await create_skipped_run(
+            self._svc,
+            run_id=skipped_run_id,
+            schedule=schedule,
+            trigger_context={"deferred_capacity": True, "fired_at": now},
+            now=now,
+            reason_code=ScheduleReasons.DEFERRED_CAPACITY,
+            reason_summary=(
+                "Schedule fire deferred: global concurrent-fire cap reached; will retry next tick."
+            ),
+            metadata={"deferral_count": count},
+        )
+
     async def _maybe_fire(self, schedule: dict, now: float) -> None:
         if schedule.get("overlap_policy") == "skip" and schedule["id"] in self._running:
             _log.debug("Skipping overlapping fire for %s", schedule["name"])
@@ -562,9 +686,26 @@ class SchedulerEngine:
             await self._svc.update_schedule(schedule["id"], enabled=0)
             return
 
+        slot_allowed, slot_claim = await self._reserve_global_slot()
+        if not slot_allowed:
+            if claim is not None:
+                # Give the max_runs reservation back -- we're deferring this
+                # fire, not consuming a run against its budget.
+                claim.release()
+            await self._maybe_record_deferred(schedule, now)
+            # Leave next_fire_at untouched (still due) so the next tick
+            # retries this schedule instead of skipping it.
+            return
+
         run_id = uuid.uuid4().hex[:12]
         ctx = {"scheduled": True, "fired_at": now, "next_fire_at": schedule.get("next_fire_at")}
-        self._tracked_fire(schedule, run_id, trigger_context=ctx, max_runs_claim=claim)
+        self._tracked_fire(
+            schedule,
+            run_id,
+            trigger_context=ctx,
+            max_runs_claim=claim,
+            global_slot_claim=slot_claim,
+        )
 
     async def _check_max_runs(self, schedule: dict, chain_depth: int) -> None:
         """Auto-disable a schedule once its fired top-level runs hit max_runs.
@@ -606,17 +747,19 @@ class SchedulerEngine:
         chain_parent_id: str | None = None,
         chain_depth: int = 0,
         max_runs_claim: _MaxRunsClaim | None = None,
+        global_slot_claim: _GlobalSlotClaim | None = None,
     ) -> None:
         """Thin wrapper around _fire_inner() that guarantees max_runs_claim
-        is released exactly once on every exit path.
+        and global_slot_claim are each released exactly once on every exit
+        path.
 
         Only top-level callers (_maybe_fire, fire_now, _tick_github) that
-        got an allowed reservation from _reserve_max_runs_budget() pass a
-        non-None max_runs_claim; chain children never do. The release lives
-        here — not inside _check_max_runs() — precisely so it still fires
-        even when _fire_inner() blows up before ever reaching
-        _check_max_runs() (e.g. create_invocation() raising), which is the
-        leak this wrapper exists to close.
+        got an allowed reservation from _reserve_max_runs_budget() /
+        _reserve_global_slot() pass a non-None claim; chain children never
+        do. The release lives here — not inside _check_max_runs() — precisely
+        so it still fires even when _fire_inner() blows up before ever
+        reaching _check_max_runs() (e.g. create_invocation() raising), which
+        is the leak this wrapper exists to close.
         """
         try:
             await self._fire_inner(
@@ -629,6 +772,8 @@ class SchedulerEngine:
         finally:
             if max_runs_claim is not None:
                 max_runs_claim.release()
+            if global_slot_claim is not None:
+                global_slot_claim.release()
 
     async def _fire_inner(
         self,

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -501,41 +501,48 @@ class SchedulerEngine:
 
         from .github import github_poll
 
+        # Every await between reserving the slot and handing it to _fire()
+        # (github_poll, the max_runs reservation, or a cancellation at either)
+        # must release the slot on failure — otherwise a transient DB/count
+        # error mid-poll leaks the slot permanently and eventually saturates
+        # the cap until restart. A single finally covers all of them; once the
+        # claims are passed to _fire() (which owns their release from then on)
+        # handed_off is set so this finally leaves them alone.
+        max_runs_claim: _MaxRunsClaim | None = None
+        handed_off = False
         try:
             new_events = await github_poll(schedule)
-        except BaseException:
-            if slot_claim is not None:
-                slot_claim.release()
-            raise
+            if not new_events:
+                return
 
-        if not new_events:
-            if slot_claim is not None:
-                slot_claim.release()
-            return
-
-        allowed, claim = await self._reserve_max_runs_budget(schedule)
-        if not allowed:
-            if slot_claim is not None:
-                slot_claim.release()
-            _log.info(
-                "Schedule %s (%s) has exhausted max_runs; skipping github_poll fire",
-                schedule.get("name"),
-                schedule["id"],
+            allowed, max_runs_claim = await self._reserve_max_runs_budget(schedule)
+            if not allowed:
+                _log.info(
+                    "Schedule %s (%s) has exhausted max_runs; skipping github_poll fire",
+                    schedule.get("name"),
+                    schedule["id"],
+                )
+                return
+            ctx = {
+                "github_events": new_events,
+                "repo": schedule.get("github_repo"),
+                "fired_at": now,
+            }
+            run_id = uuid.uuid4().hex[:12]
+            handed_off = True
+            await self._fire(
+                schedule,
+                run_id,
+                trigger_context=ctx,
+                max_runs_claim=max_runs_claim,
+                global_slot_claim=slot_claim,
             )
-            return
-        ctx = {
-            "github_events": new_events,
-            "repo": schedule.get("github_repo"),
-            "fired_at": now,
-        }
-        run_id = uuid.uuid4().hex[:12]
-        await self._fire(
-            schedule,
-            run_id,
-            trigger_context=ctx,
-            max_runs_claim=claim,
-            global_slot_claim=slot_claim,
-        )
+        finally:
+            if not handed_off:
+                if slot_claim is not None:
+                    slot_claim.release()
+                if max_runs_claim is not None:
+                    max_runs_claim.release()
 
     async def _reserve_max_runs_budget(self, schedule: dict) -> tuple[bool, _MaxRunsClaim | None]:
         """Atomically claim one top-level fire against schedule['max_runs'].

--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -618,6 +618,21 @@ async def list_schedules_route(
     return {"schedules": rows}
 
 
+@studio_route("/schedules/limits", method="GET", area="schedules", name="schedule_limits")
+async def schedule_limits_route() -> dict[str, Any]:
+    # A literal path registered before the /{schedule_id} param route below
+    # so "limits" resolves here rather than being captured as a schedule id
+    # (routes are matched in registration order — see registry.py).
+    from lionagi.studio import config
+
+    from ..scheduler.engine import scheduler
+
+    return {
+        "max_scheduled_concurrent": config.MAX_SCHEDULED_CONCURRENT,
+        "current_inflight": scheduler._global_inflight,
+    }
+
+
 @studio_route("/schedules/{schedule_id}", method="GET", area="schedules", name="get_schedule")
 async def get_schedule_route(schedule_id: str) -> dict[str, Any]:
     data = await get_schedule(schedule_id)

--- a/tests/apps_studio_server/test_schedule_limits_route.py
+++ b/tests/apps_studio_server/test_schedule_limits_route.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for GET /api/schedules/limits.
+
+Covers the endpoint's response shape and the FastAPI route-shadowing hazard:
+a literal "/schedules/limits" path must resolve to this handler, not be
+captured by the "/schedules/{schedule_id}" param route.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
+from fastapi.testclient import TestClient  # noqa: E402
+
+
+def _patch_db(monkeypatch, db_path: Path) -> None:
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.schedules as schedules_mod
+
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(schedules_mod, "DEFAULT_DB_PATH", db_path)
+
+
+def _make_client() -> TestClient:
+    from lionagi.studio.app import app
+
+    return TestClient(app, base_url="http://127.0.0.1:8765")
+
+
+def test_limits_route_returns_cap_and_inflight(tmp_path, monkeypatch):
+    import lionagi.studio.config as studio_config
+    from lionagi.studio.scheduler.engine import scheduler
+
+    _patch_db(monkeypatch, tmp_path / "state.db")
+    monkeypatch.setattr(studio_config, "MAX_SCHEDULED_CONCURRENT", 7)
+    monkeypatch.setattr(scheduler, "_global_inflight", 3)
+
+    client = _make_client()
+    resp = client.get("/api/schedules/limits")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {"max_scheduled_concurrent": 7, "current_inflight": 3}
+
+
+def test_limits_route_resolves_before_schedule_id_param_route(tmp_path, monkeypatch):
+    """The literal /schedules/limits path must not be captured by the
+    /schedules/{schedule_id} GET route -- it must resolve to the limits
+    handler (200 with the limits shape), not a 404 lookup for a schedule
+    literally named "limits"."""
+    _patch_db(monkeypatch, tmp_path / "state.db")
+
+    client = _make_client()
+    resp = client.get("/api/schedules/limits")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "max_scheduled_concurrent" in body
+    assert "current_inflight" in body
+    # The param route's 404 body shape names the missing schedule id; the
+    # limits route's body never does, so this also rules out captured routing.
+    assert "not found" not in str(body).lower()

--- a/tests/cli/test_schedule_cli.py
+++ b/tests/cli/test_schedule_cli.py
@@ -62,6 +62,80 @@ def test_schedule_enable_disable_trigger_delete_accept_id():
         assert args.id == "sched-123"
 
 
+def test_schedule_limits_subcommand_registered():
+    """li schedule limits is a recognized subcommand and takes no positional."""
+    from lionagi.studio.cli import add_schedule_subparser
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(["schedule", "limits"])
+    assert args.schedule_action == "limits"
+
+
+def test_schedule_limits_dispatches_to_api_and_prints_values(monkeypatch, capsys):
+    """run_schedule limits calls _api('/limits') and prints cap + inflight."""
+    import lionagi.studio.cli as sched_mod
+
+    monkeypatch.setattr(
+        sched_mod,
+        "_api",
+        lambda path, **kw: {"max_scheduled_concurrent": 4, "current_inflight": 1},
+    )
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(["schedule", "limits"])
+    result = run_schedule(args)
+
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "4" in out
+    assert "1" in out
+
+
+def test_schedule_limits_unlimited_display(monkeypatch, capsys):
+    """A cap of 0 (unlimited) prints 'unlimited' rather than the digit 0."""
+    import lionagi.studio.cli as sched_mod
+
+    monkeypatch.setattr(
+        sched_mod,
+        "_api",
+        lambda path, **kw: {"max_scheduled_concurrent": 0, "current_inflight": 2},
+    )
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(["schedule", "limits"])
+    result = run_schedule(args)
+
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "unlimited" in out
+
+
+def test_schedule_limits_api_error_returns_1(monkeypatch):
+    """When _api returns None (network error), run_schedule returns 1."""
+    import lionagi.studio.cli as sched_mod
+
+    monkeypatch.setattr(sched_mod, "_api", lambda path, **kw: None)
+
+    from lionagi.studio.cli import add_schedule_subparser, run_schedule
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_schedule_subparser(sub)
+    args = parser.parse_args(["schedule", "limits"])
+    result = run_schedule(args)
+    assert result == 1
+
+
 def test_schedule_runs_subcommand():
     """li schedule runs <id> parses correctly."""
     from lionagi.studio.cli import add_schedule_subparser

--- a/tests/studio/test_scheduler_global_slot.py
+++ b/tests/studio/test_scheduler_global_slot.py
@@ -1,0 +1,422 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for SchedulerEngine's global concurrent-fire cap.
+
+Covers _reserve_global_slot()/_release_global_slot() in isolation, and the
+three fire entry points (_maybe_fire, _tick_github, fire_now) that enforce
+the cap around the existing max_runs reservation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _minimal_schedule(**overrides) -> dict:
+    base = {
+        "id": "sched-001",
+        "name": "test-sched",
+        "trigger_type": "cron",
+        "cron_expr": "0 * * * *",
+        "action_kind": "agent",
+        "action_model": "gpt-4.1-mini",
+        "action_prompt": "ping",
+        "action_agent": None,
+        "action_playbook": None,
+        "action_project": None,
+        "action_extra_args": [],
+        "action_flow_yaml": None,
+        "on_success": None,
+        "on_fail": None,
+        "overlap_policy": "skip",
+        "missed_fire_policy": "skip",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_svc() -> AsyncMock:
+    svc = AsyncMock()
+    svc.get_schedule = AsyncMock(return_value=None)
+    svc.list_schedules = AsyncMock(return_value=[])
+    svc.update_schedule = AsyncMock()
+    svc.create_schedule_run = AsyncMock()
+    svc.update_schedule_run = AsyncMock()
+    svc.create_invocation = AsyncMock()
+    svc.update_invocation = AsyncMock()
+    svc.update_status = AsyncMock()
+    svc.list_sessions_for_invocation = AsyncMock(return_value=[])
+    svc.count_schedule_runs = AsyncMock(return_value=0)
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# _reserve_global_slot / _release_global_slot — pure reservation logic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reserve_global_slot_allows_under_cap(monkeypatch):
+    import lionagi.studio.config as studio_config
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    monkeypatch.setattr(studio_config, "MAX_SCHEDULED_CONCURRENT", 2)
+    engine = SchedulerEngine(svc=_make_svc())
+
+    allowed, claim = await engine._reserve_global_slot()
+
+    assert allowed is True
+    assert claim is not None
+    assert engine._global_inflight == 1
+
+
+@pytest.mark.asyncio
+async def test_reserve_global_slot_refuses_at_cap(monkeypatch):
+    import lionagi.studio.config as studio_config
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    monkeypatch.setattr(studio_config, "MAX_SCHEDULED_CONCURRENT", 1)
+    engine = SchedulerEngine(svc=_make_svc())
+
+    allowed_a, claim_a = await engine._reserve_global_slot()
+    assert allowed_a is True
+    assert claim_a is not None
+
+    allowed_b, claim_b = await engine._reserve_global_slot()
+    assert allowed_b is False
+    assert claim_b is None
+    assert engine._global_inflight == 1
+
+
+@pytest.mark.asyncio
+async def test_reserve_global_slot_unlimited_when_cap_zero(monkeypatch):
+    import lionagi.studio.config as studio_config
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    monkeypatch.setattr(studio_config, "MAX_SCHEDULED_CONCURRENT", 0)
+    engine = SchedulerEngine(svc=_make_svc())
+
+    for _ in range(5):
+        allowed, claim = await engine._reserve_global_slot()
+        assert allowed is True
+        assert claim is None
+
+    assert engine._global_inflight == 0
+
+
+@pytest.mark.asyncio
+async def test_release_global_slot_decrements_and_floors_at_zero(monkeypatch):
+    import lionagi.studio.config as studio_config
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    monkeypatch.setattr(studio_config, "MAX_SCHEDULED_CONCURRENT", 3)
+    engine = SchedulerEngine(svc=_make_svc())
+
+    _, claim = await engine._reserve_global_slot()
+    assert engine._global_inflight == 1
+    claim.release()
+    assert engine._global_inflight == 0
+
+    # A second release is a no-op (idempotent) and must not go negative.
+    claim.release()
+    assert engine._global_inflight == 0
+
+    # Direct floor check independent of the claim wrapper.
+    engine._release_global_slot()
+    assert engine._global_inflight == 0
+
+
+# ---------------------------------------------------------------------------
+# _maybe_fire — defers on no slot, fires normally when available
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_maybe_fire_defers_when_no_slot_available(monkeypatch):
+    import lionagi.studio.config as studio_config
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    monkeypatch.setattr(studio_config, "MAX_SCHEDULED_CONCURRENT", 1)
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(next_fire_at=1000.0)
+
+    # Saturate the single slot before _maybe_fire runs.
+    _, holder_claim = await engine._reserve_global_slot()
+    assert holder_claim is not None
+
+    with patch.object(engine, "_tracked_fire") as mock_tracked:
+        await engine._maybe_fire(schedule, now=1000.0)
+
+    mock_tracked.assert_not_called()
+    # next_fire_at must be left untouched (still due) so the next tick retries.
+    svc.update_schedule.assert_not_awaited()
+    # A deferred-capacity skipped-run record was emitted.
+    svc.create_schedule_run.assert_awaited_once()
+    (run_payload,), _ = svc.create_schedule_run.await_args
+    assert run_payload["trigger_context"]["deferred_capacity"] is True
+    deferred_calls = [
+        c
+        for c in svc.update_status.await_args_list
+        if c.kwargs.get("reason_code") == "schedule.deferred.capacity"
+    ]
+    assert deferred_calls
+
+
+@pytest.mark.asyncio
+async def test_maybe_fire_defer_releases_max_runs_claim(monkeypatch):
+    """A schedule with a max_runs budget must get its pre-flight reservation
+    back when the fire is deferred for lack of a global slot -- otherwise the
+    deferral permanently leaks a max_runs reservation."""
+    import lionagi.studio.config as studio_config
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    monkeypatch.setattr(studio_config, "MAX_SCHEDULED_CONCURRENT", 1)
+    svc = _make_svc()
+    svc.count_schedule_runs = AsyncMock(return_value=0)
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(max_runs=5, next_fire_at=1000.0)
+
+    _, holder_claim = await engine._reserve_global_slot()
+    assert holder_claim is not None
+
+    with patch.object(engine, "_tracked_fire") as mock_tracked:
+        await engine._maybe_fire(schedule, now=1000.0)
+
+    mock_tracked.assert_not_called()
+    assert engine._max_runs_inflight.get(schedule["id"], 0) == 0
+
+
+@pytest.mark.asyncio
+async def test_maybe_fire_fires_when_slot_available(monkeypatch):
+    import lionagi.studio.config as studio_config
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    monkeypatch.setattr(studio_config, "MAX_SCHEDULED_CONCURRENT", 4)
+    engine = SchedulerEngine(svc=_make_svc())
+    schedule = _minimal_schedule()
+
+    with patch.object(engine, "_tracked_fire") as mock_tracked:
+        await engine._maybe_fire(schedule, now=1000.0)
+
+    mock_tracked.assert_called_once()
+    _, kwargs = mock_tracked.call_args
+    assert kwargs["global_slot_claim"] is not None
+
+
+# ---------------------------------------------------------------------------
+# _tick_github — defers before fetch when no slot; releases on no-events
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tick_github_defers_before_fetch_when_no_slot(monkeypatch):
+    import lionagi.studio.config as studio_config
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    monkeypatch.setattr(studio_config, "MAX_SCHEDULED_CONCURRENT", 1)
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(
+        trigger_type="github_poll", github_repo="acme/widgets", last_fired_at=0
+    )
+
+    _, holder_claim = await engine._reserve_global_slot()
+    assert holder_claim is not None
+
+    with patch("lionagi.studio.scheduler.github.github_poll", new=AsyncMock()) as mock_poll:
+        await engine._tick_github(schedule, now=10_000.0)
+
+    mock_poll.assert_not_awaited()
+    svc.update_schedule.assert_not_awaited()
+    svc.create_schedule_run.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_tick_github_releases_slot_on_no_events(monkeypatch):
+    import lionagi.studio.config as studio_config
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    monkeypatch.setattr(studio_config, "MAX_SCHEDULED_CONCURRENT", 1)
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(
+        trigger_type="github_poll", github_repo="acme/widgets", last_fired_at=0
+    )
+
+    with patch(
+        "lionagi.studio.scheduler.github.github_poll",
+        new=AsyncMock(return_value=[]),
+    ):
+        await engine._tick_github(schedule, now=10_000.0)
+
+    assert engine._global_inflight == 0
+
+
+@pytest.mark.asyncio
+async def test_tick_github_fires_and_releases_slot_on_completion(monkeypatch):
+    import lionagi.studio.config as studio_config
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    monkeypatch.setattr(studio_config, "MAX_SCHEDULED_CONCURRENT", 4)
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(
+        trigger_type="github_poll", github_repo="acme/widgets", last_fired_at=0
+    )
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.github.github_poll",
+            new=AsyncMock(return_value=[{"number": 1}]),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await engine._tick_github(schedule, now=10_000.0)
+
+    assert engine._global_inflight == 0
+
+
+# ---------------------------------------------------------------------------
+# fire_now — refuses (does not defer) at capacity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fire_now_raises_at_capacity_and_releases_max_runs_claim(monkeypatch):
+    import lionagi.studio.config as studio_config
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    monkeypatch.setattr(studio_config, "MAX_SCHEDULED_CONCURRENT", 1)
+    svc = _make_svc()
+    svc.get_schedule = AsyncMock(return_value=_minimal_schedule(max_runs=5))
+    svc.count_schedule_runs = AsyncMock(return_value=0)
+    engine = SchedulerEngine(svc=svc)
+
+    _, holder_claim = await engine._reserve_global_slot()
+    assert holder_claim is not None
+
+    with pytest.raises(ValueError, match="capacity"):
+        await engine.fire_now("sched-001")
+
+    assert engine._max_runs_inflight.get("sched-001", 0) == 0
+    assert len(engine._fire_tasks) == 0
+
+
+@pytest.mark.asyncio
+async def test_fire_now_succeeds_when_slot_available(monkeypatch):
+    import lionagi.studio.config as studio_config
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    monkeypatch.setattr(studio_config, "MAX_SCHEDULED_CONCURRENT", 4)
+    svc = _make_svc()
+    svc.get_schedule = AsyncMock(return_value=_minimal_schedule())
+    engine = SchedulerEngine(svc=svc)
+
+    with patch.object(engine, "_tracked_fire", return_value=MagicMock()) as mock_tracked:
+        run_id = await engine.fire_now("sched-001")
+
+    assert run_id is not None
+    _, kwargs = mock_tracked.call_args
+    assert kwargs["global_slot_claim"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Slot released after a real _fire() completes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fire_releases_global_slot_on_completion(monkeypatch):
+    import lionagi.studio.config as studio_config
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    monkeypatch.setattr(studio_config, "MAX_SCHEDULED_CONCURRENT", 4)
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+
+    _, slot_claim = await engine._reserve_global_slot()
+    assert engine._global_inflight == 1
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await engine._fire(
+            schedule,
+            "run-001",
+            trigger_context={"scheduled": True},
+            global_slot_claim=slot_claim,
+        )
+
+    assert engine._global_inflight == 0
+
+
+@pytest.mark.asyncio
+async def test_fire_releases_global_slot_on_exception(monkeypatch):
+    import lionagi.studio.config as studio_config
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    monkeypatch.setattr(studio_config, "MAX_SCHEDULED_CONCURRENT", 4)
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+
+    _, slot_claim = await engine._reserve_global_slot()
+    assert engine._global_inflight == 1
+
+    with patch(
+        "lionagi.studio.scheduler.subprocess.build_argv",
+        side_effect=ValueError("bad action_kind"),
+    ):
+        await engine._fire(
+            schedule,
+            "run-002",
+            trigger_context={"scheduled": True},
+            global_slot_claim=slot_claim,
+        )
+
+    assert engine._global_inflight == 0
+
+
+# ---------------------------------------------------------------------------
+# Deferred-record throttling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_maybe_record_deferred_throttles_after_first(monkeypatch):
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+
+    for _ in range(9):
+        await engine._maybe_record_deferred(schedule, now=1000.0)
+
+    # First deferral emits; deferrals 2-9 (count % 10 != 1) do not.
+    assert svc.create_schedule_run.await_count == 1
+
+    # The 10th and 11th deferrals: count=10 (no emit), count=11 (emit, 11%10==1).
+    await engine._maybe_record_deferred(schedule, now=1000.0)
+    assert svc.create_schedule_run.await_count == 1
+    await engine._maybe_record_deferred(schedule, now=1000.0)
+    assert svc.create_schedule_run.await_count == 2

--- a/tests/studio/test_scheduler_global_slot.py
+++ b/tests/studio/test_scheduler_global_slot.py
@@ -257,6 +257,37 @@ async def test_tick_github_releases_slot_on_no_events(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_tick_github_releases_slot_when_max_runs_reservation_raises(monkeypatch):
+    # A failure in the max_runs reservation (e.g. a transient DB/count error)
+    # happens after the global slot is already reserved. The slot must still be
+    # released as the exception propagates — otherwise it leaks permanently and
+    # eventually saturates the cap.
+    import lionagi.studio.config as studio_config
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    monkeypatch.setattr(studio_config, "MAX_SCHEDULED_CONCURRENT", 1)
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(
+        trigger_type="github_poll", github_repo="acme/widgets", last_fired_at=0
+    )
+
+    async def _boom(_schedule):
+        raise RuntimeError("count query failed")
+
+    monkeypatch.setattr(engine, "_reserve_max_runs_budget", _boom)
+
+    with patch(
+        "lionagi.studio.scheduler.github.github_poll",
+        new=AsyncMock(return_value=[{"number": 1}]),
+    ):
+        with pytest.raises(RuntimeError, match="count query failed"):
+            await engine._tick_github(schedule, now=10_000.0)
+
+    assert engine._global_inflight == 0
+
+
+@pytest.mark.asyncio
 async def test_tick_github_fires_and_releases_slot_on_completion(monkeypatch):
     import lionagi.studio.config as studio_config
     from lionagi.studio.scheduler.engine import SchedulerEngine


### PR DESCRIPTION
Closes #1850. First of two SPEC-approved limit primitives for the studio scheduler (Leo gate; folds into the fleet-automation concurrency/limit-control directive). Spend-budget is the fast-follow PR.

## What

A global concurrent-fire cap for scheduled fires — the tick loop previously fired every due schedule with no semaphore, so N due schedules meant N unbounded `li agent` spawns. This is independent of `MAX_LAUNCHES` (which caps only the on-demand `/api/launches` surface, a different subsystem).

- `LIONAGI_STUDIO_MAX_SCHEDULED_CONCURRENT` (default 4, `0` = unlimited).
- Enforced at all three scheduler fire entry points (`_maybe_fire`, `_tick_github`, `fire_now`) via a new `_reserve_global_slot()` reservation that mirrors the existing `_reserve_max_runs_budget()` claim/release pattern (in-memory counter + engine-wide `asyncio.Lock`; single-process, same assumption as max_runs).
- **Failure semantics at cap:**
  - cron / interval / github_poll: **defer to the next tick** — `next_fire_at` / the github cursor are left unadvanced (the fire is never dropped), and a throttled `deferred_capacity` skipped-run record is emitted (first deferral + every 10th).
  - manual `li schedule trigger` (`fire_now`): **refused** with a clear error (a human is waiting; deferring silently would be worse).
- github_poll reserves the slot **before** polling so a no-slot poll can't fetch-advance-cursor-then-discard events.
- Chain children never consume a slot (same rule as max_runs; avoids self-deadlock).
- `GET /schedules/limits` + `li schedule limits` for read-only visibility (cap + current in-flight).

## Design

Per the SPEC-approved design doc (defer-over-queue, global-not-per-schedule config, chain-exempt). Runtime `--set-max-concurrent` and a daemon-global windowed spend ceiling are explicitly-scoped v1 forks, not in this PR.

## Review

Codex high-effort adversarial review caught a real slot leak (the max_runs reservation await sat outside the release guard, leaking the slot on a transient DB error / cancellation). Fixed by consolidating the whole reserve→handoff critical section under a single `finally`; regression test added. Codex re-review: APPROVE (leak closed, no double-release, cancellation verified at all three await points).

## Tests

339 passed across the scheduler/schedule/github/max_runs/fire suites (new `test_scheduler_global_slot.py` + `test_schedule_limits_route.py` + CLI tests; no regressions). ruff + format clean.