### PR TITLE
feat(studio): per-schedule token/spend budget for the scheduler

### DIFF
--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -824,6 +824,8 @@ class StateDB:
                           overlap_policy      TEXT    NOT NULL DEFAULT 'skip'
                                               CHECK(overlap_policy IN ('skip', 'allow')),
                           max_runs            INTEGER,
+                          budget_usd          REAL,
+                          budget_tokens       INTEGER,
                           project             TEXT,
                           created_at          REAL    NOT NULL,
                           updated_at          REAL    NOT NULL
@@ -1953,16 +1955,16 @@ class StateDB:
                         action_kind, action_model, action_prompt, action_agent,
                         action_playbook, action_flow_yaml, action_project, action_extra_args,
                         on_success, on_fail, last_fired_at, next_fire_at,
-                        missed_fire_policy, overlap_policy, max_runs, project,
-                        created_at, updated_at)
+                        missed_fire_policy, overlap_policy, max_runs, budget_usd, budget_tokens,
+                        project, created_at, updated_at)
                        VALUES (:id, :name, :description, :enabled, :trigger_type,
                                :cron_expr, :interval_sec, :github_repo, :github_filter,
                                :github_cursor, :poll_interval_sec,
                                :action_kind, :action_model, :action_prompt, :action_agent,
                                :action_playbook, :action_flow_yaml, :action_project, :action_extra_args,
                                :on_success, :on_fail, :last_fired_at, :next_fire_at,
-                               :missed_fire_policy, :overlap_policy, :max_runs, :project,
-                               :created_at, :updated_at)"""
+                               :missed_fire_policy, :overlap_policy, :max_runs, :budget_usd, :budget_tokens,
+                               :project, :created_at, :updated_at)"""
                 ).bindparams(
                     bindparam("github_filter", type_=JSON),
                     bindparam("action_extra_args", type_=JSON),
@@ -1996,6 +1998,8 @@ class StateDB:
                     "missed_fire_policy": schedule.get("missed_fire_policy", "skip"),
                     "overlap_policy": schedule.get("overlap_policy", "skip"),
                     "max_runs": schedule.get("max_runs"),
+                    "budget_usd": schedule.get("budget_usd"),
+                    "budget_tokens": schedule.get("budget_tokens"),
                     "project": schedule.get("project"),
                     "created_at": schedule.get("created_at", now),
                     "updated_at": schedule.get("updated_at", now),
@@ -2087,6 +2091,8 @@ class StateDB:
             "missed_fire_policy",
             "overlap_policy",
             "max_runs",
+            "budget_usd",
+            "budget_tokens",
             "project",
         }
         bad = set(fields) - allowed
@@ -2235,6 +2241,30 @@ class StateDB:
         async with self._read() as conn:
             row = (await conn.execute(text(query), params)).mappings().first()
         return int(row["n"]) if row else 0
+
+    async def sum_schedule_spend(self, schedule_id: str) -> dict[str, Any]:
+        """Sum cost/token usage across every session a schedule has spawned.
+
+        Joins schedule_runs to sessions through invocation_id and totals
+        total_cost_usd / (input_tokens + output_tokens). Used for the
+        budget_usd / budget_tokens pre-fire gate: mirrors count_schedule_runs
+        but sums a spend column instead of counting rows.
+        """
+        query = (
+            "SELECT COALESCE(SUM(s.total_cost_usd), 0) AS cost_usd, "
+            "COALESCE(SUM(s.input_tokens), 0) AS input_tokens, "
+            "COALESCE(SUM(s.output_tokens), 0) AS output_tokens "
+            "FROM schedule_runs sr JOIN sessions s ON s.invocation_id = sr.invocation_id "
+            "WHERE sr.schedule_id = :schedule_id"
+        )
+        async with self._read() as conn:
+            row = (await conn.execute(text(query), {"schedule_id": schedule_id})).mappings().first()
+        if not row:
+            return {"cost_usd": 0.0, "tokens": 0}
+        return {
+            "cost_usd": float(row["cost_usd"] or 0),
+            "tokens": int(row["input_tokens"] or 0) + int(row["output_tokens"] or 0),
+        }
 
     async def schedule_run_streak(self, schedule_id: str) -> tuple[int, str | None]:
         """Consecutive terminal 'failed' streak and most recent status, newest-first, capped at 50 rows."""

--- a/lionagi/state/reasons.py
+++ b/lionagi/state/reasons.py
@@ -117,6 +117,7 @@ class ScheduleReasons:
     SKIPPED_OVERLAP = "schedule.skipped.overlap"
     SKIPPED_MISSED_FIRE = "schedule.skipped.missed_fire"
     DEFERRED_CAPACITY = "schedule.deferred.capacity"
+    BUDGET_EXHAUSTED = "schedule.budget.exhausted"
 
 
 class DispatchReasons:

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -436,6 +436,12 @@ CREATE TABLE IF NOT EXISTS schedules (
   -- of fired top-level runs (chain children excluded) reaches max_runs, the
   -- engine auto-disables the schedule via the existing enabled flag.
   max_runs            INTEGER,
+  -- Cumulative spend budget: NULL means unlimited. Checked pre-fire against
+  -- the sum of total_cost_usd / (input_tokens + output_tokens) across the
+  -- schedule's prior sessions; either bound tripping auto-disables the
+  -- schedule the same way max_runs does.
+  budget_usd          REAL,
+  budget_tokens       INTEGER,
   project             TEXT,
   created_at          REAL    NOT NULL,
   updated_at          REAL    NOT NULL

--- a/lionagi/state/schema_meta.py
+++ b/lionagi/state/schema_meta.py
@@ -509,6 +509,9 @@ schedules = Table(
     # One-shot / bounded-run semantics: NULL means unlimited (see
     # schema.sql for the fuller comment on how the engine counts runs).
     Column("max_runs", Integer),
+    # Cumulative spend budget: NULL means unlimited (see schema.sql).
+    Column("budget_usd", Float),
+    Column("budget_tokens", Integer),
     Column("project", Text),
     Column("created_at", Float, nullable=False),
     Column("updated_at", Float, nullable=False),

--- a/lionagi/state/schema_migrations.py
+++ b/lionagi/state/schema_migrations.py
@@ -91,6 +91,9 @@ MIGRATION_COLUMNS: dict[str, list[tuple[str, str]]] = {
         ("action_flow_yaml", "TEXT"),
         # One-shot / bounded-run semantics: NULL means unlimited.
         ("max_runs", "INTEGER"),
+        # Cumulative spend budget: NULL means unlimited.
+        ("budget_usd", "REAL"),
+        ("budget_tokens", "INTEGER"),
     ],
     "schedule_runs": [
         # ADR-0028: schedule_runs originally had no updated_at.

--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import json
+import math
 import os
 import shutil
 import subprocess
@@ -777,9 +778,9 @@ def _cmd_create(args: argparse.Namespace) -> int:
     if max_runs is not None:
         body["max_runs"] = max_runs
     if getattr(args, "max_cost_usd", None) is not None:
-        if args.max_cost_usd <= 0:
+        if not math.isfinite(args.max_cost_usd) or args.max_cost_usd <= 0:
             print(
-                f"Error: --max-cost-usd must be a positive number, got {args.max_cost_usd}.",
+                f"Error: --max-cost-usd must be a finite positive number, got {args.max_cost_usd}.",
                 file=sys.stderr,
             )
             return 1

--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -776,6 +776,22 @@ def _cmd_create(args: argparse.Namespace) -> int:
         body["poll_interval_sec"] = args.poll_interval
     if max_runs is not None:
         body["max_runs"] = max_runs
+    if getattr(args, "max_cost_usd", None) is not None:
+        if args.max_cost_usd <= 0:
+            print(
+                f"Error: --max-cost-usd must be a positive number, got {args.max_cost_usd}.",
+                file=sys.stderr,
+            )
+            return 1
+        body["budget_usd"] = args.max_cost_usd
+    if getattr(args, "max_tokens", None) is not None:
+        if args.max_tokens <= 0:
+            print(
+                f"Error: --max-tokens must be a positive integer, got {args.max_tokens}.",
+                file=sys.stderr,
+            )
+            return 1
+        body["budget_tokens"] = args.max_tokens
     if args.prompt:
         body["action_prompt"] = args.prompt
     if args.model:
@@ -1031,6 +1047,29 @@ def add_schedule_subparser(subparsers: argparse._SubParsersAction) -> argparse.A
         dest="once",
         action="store_true",
         help="Sugar for --max-runs 1 — fire once, then auto-disable.",
+    )
+    create_p.add_argument(
+        "--max-cost-usd",
+        dest="max_cost_usd",
+        type=float,
+        metavar="USD",
+        help=(
+            "Auto-disable this schedule once its cumulative session spend "
+            "reaches USD (default: unlimited). Pre-fire cumulative gate: an "
+            "in-flight run is not interrupted, so the schedule may overshoot "
+            "by up to one run's cost before the next fire is refused."
+        ),
+    )
+    create_p.add_argument(
+        "--max-tokens",
+        dest="max_tokens",
+        type=int,
+        metavar="N",
+        help=(
+            "Auto-disable this schedule once its cumulative session token "
+            "usage (input+output) reaches N (default: unlimited). Same "
+            "pre-fire cumulative semantics as --max-cost-usd."
+        ),
     )
     create_p.add_argument(
         "--on-success",

--- a/lionagi/studio/config.py
+++ b/lionagi/studio/config.py
@@ -60,6 +60,10 @@ MAX_SCHEDULED_CONCURRENT: int = int(os.environ.get("LIONAGI_STUDIO_MAX_SCHEDULED
 # ── Lifecycle reaper config ───────────────────────────────────────────────────
 # Default invocation deadline in seconds (2 hours). Override per action kind
 # via LIONAGI_STUDIO_INVOCATION_DEADLINE_<KIND>_SECONDS (e.g. _AGENT_SECONDS).
+# Pairs with per-schedule budget_usd/budget_tokens (schedules table, see
+# SchedulerEngine._check_budget): the budget gate is a pre-fire cumulative
+# check, not a mid-run kill, so this deadline is what bounds a single run's
+# worst-case spend.
 INVOCATION_DEADLINE_SECONDS: int = int(
     os.environ.get("LIONAGI_STUDIO_INVOCATION_DEADLINE_SECONDS", "7200")
 )

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -284,6 +284,10 @@ class SchedulerEngine:
         schedule = await self._svc.get_schedule(schedule_id)
         if not schedule:
             return None
+        if await self._check_budget(schedule):
+            raise ValueError(
+                f"Schedule {schedule_id!r} has exhausted its budget; manual trigger refused."
+            )
         allowed, claim = await self._reserve_max_runs_budget(schedule)
         if not allowed:
             raise ValueError(
@@ -492,6 +496,10 @@ class SchedulerEngine:
         if now - last < poll_interval:
             return
 
+        if await self._check_budget(schedule):
+            await self._disable_for_budget_exhausted(schedule, now)
+            return
+
         # Reserve the global slot before polling: a filtered/no-slot poll
         # must not fetch-and-advance-cursor-then-discard.
         slot_allowed, slot_claim = await self._reserve_global_slot()
@@ -663,6 +671,65 @@ class SchedulerEngine:
             metadata={"deferral_count": count},
         )
 
+    async def _check_budget(self, schedule: dict) -> bool:
+        """Return True if the schedule has exhausted its configured spend budget.
+
+        Pre-fire cumulative gate, not a mid-run interrupt: a run already in
+        flight is not killed when it crosses the budget line, because its
+        cost is unknown until it terminates. So a schedule may overshoot its
+        budget by up to one run's cost before the next fire is refused. Pair
+        with LIONAGI_STUDIO_INVOCATION_DEADLINE_SECONDS to bound a single
+        run's worst-case spend.
+
+        Unlike max_runs / the global slot this is a pure DB read with
+        nothing to reserve or release -- both budget_usd and budget_tokens
+        unset means unbounded (always False). Either configured bound
+        tripping is sufficient to report exhausted.
+        """
+        budget_usd = schedule.get("budget_usd")
+        budget_tokens = schedule.get("budget_tokens")
+        if not budget_usd and not budget_tokens:
+            return False
+        spend = await self._svc.sum_schedule_spend(schedule["id"])
+        if budget_usd and spend["cost_usd"] >= budget_usd:
+            return True
+        if budget_tokens and spend["tokens"] >= budget_tokens:
+            return True
+        return False
+
+    async def _disable_for_budget_exhausted(self, schedule: dict, now: float) -> None:
+        """Auto-disable a schedule that has exhausted its spend budget, recording why.
+
+        Shared by the two tick-loop fire paths (_maybe_fire, _tick_github);
+        fire_now() refuses instead of disabling (mirrors max_runs).
+        """
+        _log.info(
+            "Schedule %s (%s) has exhausted its budget (budget_usd=%s, budget_tokens=%s); "
+            "disabling instead of firing",
+            schedule.get("name"),
+            schedule["id"],
+            schedule.get("budget_usd"),
+            schedule.get("budget_tokens"),
+        )
+        skipped_run_id = uuid.uuid4().hex[:12]
+        await create_skipped_run(
+            self._svc,
+            run_id=skipped_run_id,
+            schedule=schedule,
+            trigger_context={"budget_exhausted": True, "fired_at": now},
+            now=now,
+            reason_code=ScheduleReasons.BUDGET_EXHAUSTED,
+            reason_summary=(
+                "Schedule fire refused and the schedule disabled because its "
+                "configured spend budget is exhausted."
+            ),
+            metadata={
+                "budget_usd": schedule.get("budget_usd"),
+                "budget_tokens": schedule.get("budget_tokens"),
+            },
+        )
+        await self._svc.update_schedule(schedule["id"], enabled=0)
+
     async def _maybe_fire(self, schedule: dict, now: float) -> None:
         if schedule.get("overlap_policy") == "skip" and schedule["id"] in self._running:
             _log.debug("Skipping overlapping fire for %s", schedule["name"])
@@ -680,6 +747,10 @@ class SchedulerEngine:
             next_at = self._compute_next_fire(schedule, now)
             if next_at:
                 await self._svc.update_schedule(schedule["id"], next_fire_at=next_at)
+            return
+
+        if await self._check_budget(schedule):
+            await self._disable_for_budget_exhausted(schedule, now)
             return
 
         allowed, claim = await self._reserve_max_runs_budget(schedule)

--- a/lionagi/studio/services/scheduler_state.py
+++ b/lionagi/studio/services/scheduler_state.py
@@ -29,6 +29,8 @@ class SchedulerStateService(Protocol):
 
     async def count_schedule_runs(self, schedule_id: str, *, chain_depth: int = 0) -> int: ...
 
+    async def sum_schedule_spend(self, schedule_id: str) -> dict[str, Any]: ...
+
     async def create_schedule_run(self, run: dict[str, Any]) -> None: ...
 
     async def update_schedule_run(self, run_id: str, **fields: Any) -> None: ...
@@ -72,6 +74,10 @@ class _DBSchedulerStateService:
     async def count_schedule_runs(self, schedule_id: str, *, chain_depth: int = 0) -> int:
         async with StateDB() as db:
             return await db.count_schedule_runs(schedule_id, chain_depth=chain_depth)
+
+    async def sum_schedule_spend(self, schedule_id: str) -> dict[str, Any]:
+        async with StateDB() as db:
+            return await db.sum_schedule_spend(schedule_id)
 
     async def create_schedule_run(self, run: dict[str, Any]) -> None:
         async with StateDB() as db:

--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import time
 import uuid
 from typing import Any
@@ -105,8 +106,13 @@ def _svc_validate_budget_usd(budget_usd: Any) -> None:
     """
     if budget_usd is None:
         return
-    if isinstance(budget_usd, bool) or not isinstance(budget_usd, int | float) or budget_usd <= 0:
-        raise ValueError(f"budget_usd must be a positive number, got {budget_usd!r}")
+    if (
+        isinstance(budget_usd, bool)
+        or not isinstance(budget_usd, int | float)
+        or not math.isfinite(budget_usd)
+        or budget_usd <= 0
+    ):
+        raise ValueError(f"budget_usd must be a finite positive number, got {budget_usd!r}")
 
 
 def _svc_validate_budget_tokens(budget_tokens: Any) -> None:

--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -98,6 +98,28 @@ def _svc_validate_max_runs(max_runs: Any) -> None:
         raise ValueError(f"max_runs must be a positive integer, got {max_runs!r}")
 
 
+def _svc_validate_budget_usd(budget_usd: Any) -> None:
+    """Service-boundary check: reject a non-positive budget_usd.
+
+    None means unlimited (the column default) and is always accepted.
+    """
+    if budget_usd is None:
+        return
+    if isinstance(budget_usd, bool) or not isinstance(budget_usd, int | float) or budget_usd <= 0:
+        raise ValueError(f"budget_usd must be a positive number, got {budget_usd!r}")
+
+
+def _svc_validate_budget_tokens(budget_tokens: Any) -> None:
+    """Service-boundary check: reject a non-positive budget_tokens.
+
+    None means unlimited (the column default) and is always accepted.
+    """
+    if budget_tokens is None:
+        return
+    if isinstance(budget_tokens, bool) or not isinstance(budget_tokens, int) or budget_tokens <= 0:
+        raise ValueError(f"budget_tokens must be a positive integer, got {budget_tokens!r}")
+
+
 def _svc_validate_interval_sec(interval: Any, *, required: bool = False) -> None:
     """Service-boundary check: reject a missing or non-positive interval.
 
@@ -266,6 +288,8 @@ CREATE TABLE IF NOT EXISTS schedules (
     missed_fire_policy  TEXT    NOT NULL DEFAULT 'skip',
     overlap_policy      TEXT    NOT NULL DEFAULT 'skip',
     max_runs            INTEGER,
+    budget_usd          REAL,
+    budget_tokens       INTEGER,
     project             TEXT,
     created_at          REAL    NOT NULL,
     updated_at          REAL    NOT NULL
@@ -363,6 +387,8 @@ async def create_schedule(data: dict[str, Any]) -> dict[str, Any]:
     _svc_validate_extra_args(data.get("action_extra_args"))
     _svc_validate_github_repo(data.get("github_repo"))
     _svc_validate_max_runs(data.get("max_runs"))
+    _svc_validate_budget_usd(data.get("budget_usd"))
+    _svc_validate_budget_tokens(data.get("budget_tokens"))
     if data.get("trigger_type") == "cron":
         _svc_validate_cron_expr(data.get("cron_expr"), required=True)
     if data.get("trigger_type") == "interval":
@@ -428,6 +454,10 @@ async def update_schedule(schedule_id: str, fields: dict[str, Any]) -> bool:
             _svc_validate_github_repo(fields["github_repo"])
         if "max_runs" in fields:
             _svc_validate_max_runs(fields["max_runs"])
+        if "budget_usd" in fields:
+            _svc_validate_budget_usd(fields["budget_usd"])
+        if "budget_tokens" in fields:
+            _svc_validate_budget_tokens(fields["budget_tokens"])
 
         effective = {**schedule, **fields}
         effective_repo = effective.get("github_repo")
@@ -575,6 +605,8 @@ class CreateScheduleRequest(BaseModel):
     missed_fire_policy: str = "skip"
     overlap_policy: str = "skip"
     max_runs: int | None = None
+    budget_usd: float | None = None
+    budget_tokens: int | None = None
     project: str | None = None
 
 
@@ -600,6 +632,8 @@ class UpdateScheduleRequest(BaseModel):
     missed_fire_policy: str | None = None
     overlap_policy: str | None = None
     max_runs: int | None = None
+    budget_usd: float | None = None
+    budget_tokens: int | None = None
     project: str | None = None
 
 

--- a/tests/cli/test_schedule_cli.py
+++ b/tests/cli/test_schedule_cli.py
@@ -1168,3 +1168,62 @@ def test_schedule_create_zero_poll_interval_errors(monkeypatch, capsys):
     assert outcome["result"] == 1
     assert outcome["called"] is False
     assert "must be a positive integer" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# _cmd_create: --max-cost-usd / --max-tokens spend-budget flags
+# ---------------------------------------------------------------------------
+
+
+def test_schedule_create_max_cost_usd_wired_to_budget_usd(monkeypatch):
+    """--max-cost-usd parses to a float and wires body['budget_usd']."""
+    outcome = _run_create_argv(monkeypatch, ["--max-cost-usd", "12.5"])
+    assert outcome["result"] == 0
+    assert outcome["body"]["budget_usd"] == 12.5
+
+
+def test_schedule_create_max_tokens_wired_to_budget_tokens(monkeypatch):
+    """--max-tokens parses to an int and wires body['budget_tokens']."""
+    outcome = _run_create_argv(monkeypatch, ["--max-tokens", "50000"])
+    assert outcome["result"] == 0
+    assert outcome["body"]["budget_tokens"] == 50000
+
+
+def test_schedule_create_max_cost_usd_and_max_tokens_together(monkeypatch):
+    """Both flags can be set on the same schedule; either bound trips the gate."""
+    outcome = _run_create_argv(monkeypatch, ["--max-cost-usd", "5", "--max-tokens", "10000"])
+    assert outcome["result"] == 0
+    assert outcome["body"]["budget_usd"] == 5.0
+    assert outcome["body"]["budget_tokens"] == 10000
+
+
+def test_schedule_create_negative_max_cost_usd_errors(monkeypatch, capsys):
+    """A negative --max-cost-usd returns 1 and never posts to the API."""
+    outcome = _run_create_argv(monkeypatch, ["--max-cost-usd", "-1"])
+    assert outcome["result"] == 1
+    assert outcome["called"] is False
+    assert "must be a positive number" in capsys.readouterr().err
+
+
+def test_schedule_create_zero_max_cost_usd_errors(monkeypatch, capsys):
+    """A zero --max-cost-usd returns 1 and never posts to the API."""
+    outcome = _run_create_argv(monkeypatch, ["--max-cost-usd", "0"])
+    assert outcome["result"] == 1
+    assert outcome["called"] is False
+    assert "must be a positive number" in capsys.readouterr().err
+
+
+def test_schedule_create_negative_max_tokens_errors(monkeypatch, capsys):
+    """A negative --max-tokens returns 1 and never posts to the API."""
+    outcome = _run_create_argv(monkeypatch, ["--max-tokens", "-5"])
+    assert outcome["result"] == 1
+    assert outcome["called"] is False
+    assert "must be a positive integer" in capsys.readouterr().err
+
+
+def test_schedule_create_zero_max_tokens_errors(monkeypatch, capsys):
+    """A zero --max-tokens returns 1 and never posts to the API."""
+    outcome = _run_create_argv(monkeypatch, ["--max-tokens", "0"])
+    assert outcome["result"] == 1
+    assert outcome["called"] is False
+    assert "must be a positive integer" in capsys.readouterr().err

--- a/tests/cli/test_schedule_cli.py
+++ b/tests/cli/test_schedule_cli.py
@@ -1202,7 +1202,7 @@ def test_schedule_create_negative_max_cost_usd_errors(monkeypatch, capsys):
     outcome = _run_create_argv(monkeypatch, ["--max-cost-usd", "-1"])
     assert outcome["result"] == 1
     assert outcome["called"] is False
-    assert "must be a positive number" in capsys.readouterr().err
+    assert "finite positive number" in capsys.readouterr().err
 
 
 def test_schedule_create_zero_max_cost_usd_errors(monkeypatch, capsys):
@@ -1210,7 +1210,23 @@ def test_schedule_create_zero_max_cost_usd_errors(monkeypatch, capsys):
     outcome = _run_create_argv(monkeypatch, ["--max-cost-usd", "0"])
     assert outcome["result"] == 1
     assert outcome["called"] is False
-    assert "must be a positive number" in capsys.readouterr().err
+    assert "finite positive number" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("bad_value", ["nan", "inf", "-inf"])
+def test_schedule_create_non_finite_max_cost_usd_errors(monkeypatch, capsys, bad_value):
+    """A non-finite --max-cost-usd (nan/inf/-inf) is rejected before hitting the API.
+
+    argparse's float() accepts these, and a plain ``<= 0`` check lets nan/inf slip
+    through — nan would round-trip to NULL in SQLite and silently unbound the gate.
+    """
+    # Use the --flag=value form: a bare "-inf" leading dash would be parsed as an
+    # option by argparse. The equals form passes it through as the value so our
+    # own finite-check is what rejects it.
+    outcome = _run_create_argv(monkeypatch, [f"--max-cost-usd={bad_value}"])
+    assert outcome["result"] == 1
+    assert outcome["called"] is False
+    assert "finite positive number" in capsys.readouterr().err
 
 
 def test_schedule_create_negative_max_tokens_errors(monkeypatch, capsys):

--- a/tests/state/test_migrations.py
+++ b/tests/state/test_migrations.py
@@ -246,6 +246,25 @@ async def test_schedule_runs_upgrade_path(old_schema_db):
     assert adr28_cols <= actual, f"Missing cols: {adr28_cols - actual}"
 
 
+async def test_schedules_upgrade_path_gains_budget_columns(old_schema_db):
+    """After upgrade, an existing schedules table gains budget_usd/budget_tokens."""
+    db = old_schema_db
+
+    for table, columns in MIGRATION_COLUMNS.items():
+        cur = await db.execute(f"PRAGMA table_info({table})")
+        rows = await cur.fetchall()
+        if not rows:
+            continue
+        existing = {row["name"] for row in rows}
+        for name, defn in columns:
+            if name not in existing:
+                await db.execute(f"ALTER TABLE {table} ADD COLUMN {name} {defn}")
+    await db.commit()
+
+    actual = await _column_names(db, "schedules")
+    assert {"budget_usd", "budget_tokens"} <= actual
+
+
 async def test_drop_legacy_invocations_status_check_with_fk_referencing_rows(tmp_path):
     """Rebuilding invocations for the completion-trust gate must not choke on
     real FK-referencing child rows (sessions.invocation_id, artifacts.invocation_id).

--- a/tests/studio/test_scheduler_budget.py
+++ b/tests/studio/test_scheduler_budget.py
@@ -55,6 +55,31 @@ def _make_svc() -> AsyncMock:
 
 
 # ---------------------------------------------------------------------------
+# service-boundary validation — non-finite budgets must be rejected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_value", [float("nan"), float("inf"), float("-inf")])
+def test_svc_validate_budget_usd_rejects_non_finite(bad_value):
+    """A non-finite budget_usd is rejected at the service boundary.
+
+    A plain ``<= 0`` predicate lets nan/inf through; nan then round-trips to NULL
+    in SQLite and _check_budget treats the schedule as unbounded forever.
+    """
+    from lionagi.studio.services.schedules import _svc_validate_budget_usd
+
+    with pytest.raises(ValueError, match="finite positive number"):
+        _svc_validate_budget_usd(bad_value)
+
+
+@pytest.mark.parametrize("good_value", [0.01, 1, 12.5, 1000.0])
+def test_svc_validate_budget_usd_accepts_finite_positive(good_value):
+    from lionagi.studio.services.schedules import _svc_validate_budget_usd
+
+    _svc_validate_budget_usd(good_value)  # does not raise
+
+
+# ---------------------------------------------------------------------------
 # _check_budget — pure read, no reservation
 # ---------------------------------------------------------------------------
 
@@ -217,6 +242,10 @@ async def test_tick_github_disables_without_polling_when_over_budget():
     svc.create_schedule_run.assert_awaited_once()
     (run_payload,), _ = svc.create_schedule_run.await_args
     assert run_payload["trigger_context"]["budget_exhausted"] is True
+    # The budget check runs before slot reservation, so a bailed fire must leave
+    # the global concurrency counter untouched -- a regression that moved the
+    # check after _reserve_global_slot and returned without release would leak here.
+    assert engine._global_inflight == 0
 
 
 @pytest.mark.asyncio

--- a/tests/studio/test_scheduler_budget.py
+++ b/tests/studio/test_scheduler_budget.py
@@ -1,0 +1,367 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for SchedulerEngine's per-schedule token/spend budget.
+
+Covers _check_budget() in isolation, and the three fire entry points
+(_maybe_fire, _tick_github, fire_now) that enforce the budget as a pre-fire
+cumulative gate -- a pure read, unlike max_runs / the global slot which are
+claim/release reservations.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _minimal_schedule(**overrides) -> dict:
+    base = {
+        "id": "sched-001",
+        "name": "test-sched",
+        "trigger_type": "cron",
+        "cron_expr": "0 * * * *",
+        "action_kind": "agent",
+        "action_model": "gpt-4.1-mini",
+        "action_prompt": "ping",
+        "action_agent": None,
+        "action_playbook": None,
+        "action_project": None,
+        "action_extra_args": [],
+        "action_flow_yaml": None,
+        "on_success": None,
+        "on_fail": None,
+        "overlap_policy": "skip",
+        "missed_fire_policy": "skip",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_svc() -> AsyncMock:
+    svc = AsyncMock()
+    svc.get_schedule = AsyncMock(return_value=None)
+    svc.list_schedules = AsyncMock(return_value=[])
+    svc.update_schedule = AsyncMock()
+    svc.create_schedule_run = AsyncMock()
+    svc.update_schedule_run = AsyncMock()
+    svc.create_invocation = AsyncMock()
+    svc.update_invocation = AsyncMock()
+    svc.update_status = AsyncMock()
+    svc.list_sessions_for_invocation = AsyncMock(return_value=[])
+    svc.count_schedule_runs = AsyncMock(return_value=0)
+    svc.sum_schedule_spend = AsyncMock(return_value={"cost_usd": 0.0, "tokens": 0})
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# _check_budget — pure read, no reservation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_budget_unbounded_when_both_columns_null():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(budget_usd=None, budget_tokens=None)
+
+    assert await engine._check_budget(schedule) is False
+    svc.sum_schedule_spend.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_check_budget_over_on_cost_usd():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.sum_schedule_spend = AsyncMock(return_value={"cost_usd": 10.0, "tokens": 0})
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(budget_usd=10.0, budget_tokens=None)
+
+    assert await engine._check_budget(schedule) is True
+
+
+@pytest.mark.asyncio
+async def test_check_budget_over_on_tokens():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.sum_schedule_spend = AsyncMock(return_value={"cost_usd": 0.0, "tokens": 5000})
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(budget_usd=None, budget_tokens=5000)
+
+    assert await engine._check_budget(schedule) is True
+
+
+@pytest.mark.asyncio
+async def test_check_budget_under_both_bounds_fires():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.sum_schedule_spend = AsyncMock(return_value={"cost_usd": 1.0, "tokens": 100})
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(budget_usd=10.0, budget_tokens=5000)
+
+    assert await engine._check_budget(schedule) is False
+
+
+@pytest.mark.asyncio
+async def test_check_budget_cost_only_bound_trips():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.sum_schedule_spend = AsyncMock(return_value={"cost_usd": 20.0, "tokens": 100})
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(budget_usd=10.0, budget_tokens=None)
+
+    assert await engine._check_budget(schedule) is True
+
+
+@pytest.mark.asyncio
+async def test_check_budget_tokens_only_bound_trips():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.sum_schedule_spend = AsyncMock(return_value={"cost_usd": 1.0, "tokens": 9000})
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(budget_usd=None, budget_tokens=5000)
+
+    assert await engine._check_budget(schedule) is True
+
+
+@pytest.mark.asyncio
+async def test_check_budget_either_bound_trips_when_both_set():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    # Cost is under, but tokens are over -- either bound tripping is sufficient.
+    svc.sum_schedule_spend = AsyncMock(return_value={"cost_usd": 1.0, "tokens": 9000})
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(budget_usd=10.0, budget_tokens=5000)
+
+    assert await engine._check_budget(schedule) is True
+
+
+# ---------------------------------------------------------------------------
+# _maybe_fire — auto-disables + records, does not fire when over budget
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_maybe_fire_disables_and_records_when_over_budget():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.sum_schedule_spend = AsyncMock(return_value={"cost_usd": 10.0, "tokens": 0})
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(budget_usd=10.0, next_fire_at=1000.0)
+
+    with patch.object(engine, "_tracked_fire") as mock_tracked:
+        await engine._maybe_fire(schedule, now=1000.0)
+
+    mock_tracked.assert_not_called()
+    svc.update_schedule.assert_awaited_once_with("sched-001", enabled=0)
+    svc.create_schedule_run.assert_awaited_once()
+    (run_payload,), _ = svc.create_schedule_run.await_args
+    assert run_payload["trigger_context"]["budget_exhausted"] is True
+    budget_calls = [
+        c
+        for c in svc.update_status.await_args_list
+        if c.kwargs.get("reason_code") == "schedule.budget.exhausted"
+    ]
+    assert budget_calls
+
+
+@pytest.mark.asyncio
+async def test_maybe_fire_fires_normally_when_under_budget():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.sum_schedule_spend = AsyncMock(return_value={"cost_usd": 1.0, "tokens": 0})
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(budget_usd=10.0, next_fire_at=1000.0)
+
+    with patch.object(engine, "_tracked_fire") as mock_tracked:
+        await engine._maybe_fire(schedule, now=1000.0)
+
+    mock_tracked.assert_called_once()
+    svc.update_schedule.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# _tick_github — disables over-budget schedules WITHOUT polling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tick_github_disables_without_polling_when_over_budget():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.sum_schedule_spend = AsyncMock(return_value={"cost_usd": 0.0, "tokens": 5000})
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(
+        trigger_type="github_poll",
+        github_repo="acme/widgets",
+        last_fired_at=0,
+        budget_tokens=5000,
+    )
+
+    with patch("lionagi.studio.scheduler.github.github_poll", new=AsyncMock()) as mock_poll:
+        await engine._tick_github(schedule, now=10_000.0)
+
+    mock_poll.assert_not_awaited()
+    svc.update_schedule.assert_awaited_once_with("sched-001", enabled=0)
+    svc.create_schedule_run.assert_awaited_once()
+    (run_payload,), _ = svc.create_schedule_run.await_args
+    assert run_payload["trigger_context"]["budget_exhausted"] is True
+
+
+@pytest.mark.asyncio
+async def test_tick_github_polls_normally_when_under_budget():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.sum_schedule_spend = AsyncMock(return_value={"cost_usd": 0.0, "tokens": 0})
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(
+        trigger_type="github_poll",
+        github_repo="acme/widgets",
+        last_fired_at=0,
+        budget_tokens=5000,
+    )
+
+    with patch(
+        "lionagi.studio.scheduler.github.github_poll",
+        new=AsyncMock(return_value=[]),
+    ) as mock_poll:
+        await engine._tick_github(schedule, now=10_000.0)
+
+    mock_poll.assert_awaited_once()
+    svc.update_schedule.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# fire_now — refuses (does not disable) at exhaustion
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fire_now_raises_when_over_budget():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.get_schedule = AsyncMock(return_value=_minimal_schedule(budget_usd=10.0))
+    svc.sum_schedule_spend = AsyncMock(return_value={"cost_usd": 10.0, "tokens": 0})
+    engine = SchedulerEngine(svc=svc)
+
+    with pytest.raises(ValueError, match="exhausted its budget"):
+        await engine.fire_now("sched-001")
+
+    # fire_now refuses, it does not auto-disable (mirrors max_runs).
+    svc.update_schedule.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fire_now_succeeds_when_under_budget():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.get_schedule = AsyncMock(return_value=_minimal_schedule(budget_usd=10.0))
+    svc.sum_schedule_spend = AsyncMock(return_value={"cost_usd": 1.0, "tokens": 0})
+    engine = SchedulerEngine(svc=svc)
+
+    with patch.object(engine, "_tracked_fire", return_value=MagicMock()) as mock_tracked:
+        run_id = await engine.fire_now("sched-001")
+
+    assert run_id is not None
+    mock_tracked.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# sum_schedule_spend — real StateDB aggregate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sum_schedule_spend_aggregates_across_sessions():
+    from lionagi.state.db import StateDB
+
+    state = StateDB(":memory:")
+    await state.open()
+
+    await state.create_schedule(
+        {
+            "id": "sched-spend-1",
+            "name": "spend-test",
+            "trigger_type": "interval",
+            "interval_sec": 60,
+            "action_kind": "agent",
+        }
+    )
+
+    for i in range(2):
+        inv_id = f"inv-{i}"
+        await state.create_invocation({"id": inv_id, "skill": "agent", "started_at": 1.0})
+        await state.create_schedule_run(
+            {
+                "id": f"run-{i}",
+                "schedule_id": "sched-spend-1",
+                "invocation_id": inv_id,
+                "trigger_context": {},
+                "action_kind": "agent",
+                "action_args": [],
+                "status": "completed",
+                "chain_depth": 0,
+                "fired_at": 1.0,
+            }
+        )
+        prog_id = f"prog-{i}"
+        await state.create_progression(prog_id)
+        sess_id = f"sess-{i}"
+        await state.create_session(
+            {
+                "id": sess_id,
+                "progression_id": prog_id,
+                "status": "completed",
+                "invocation_id": inv_id,
+            }
+        )
+        await state.update_session(
+            sess_id,
+            input_tokens=100 * (i + 1),
+            output_tokens=50 * (i + 1),
+            total_cost_usd=1.5 * (i + 1),
+        )
+
+    spend = await state.sum_schedule_spend("sched-spend-1")
+
+    assert spend["cost_usd"] == pytest.approx(1.5 + 3.0)
+    assert spend["tokens"] == (100 + 50) + (200 + 100)
+
+    await state.close()
+
+
+@pytest.mark.asyncio
+async def test_sum_schedule_spend_zero_for_schedule_with_no_runs():
+    from lionagi.state.db import StateDB
+
+    state = StateDB(":memory:")
+    await state.open()
+
+    await state.create_schedule(
+        {
+            "id": "sched-spend-empty",
+            "name": "spend-empty",
+            "trigger_type": "interval",
+            "interval_sec": 60,
+            "action_kind": "agent",
+        }
+    )
+
+    spend = await state.sum_schedule_spend("sched-spend-empty")
+    assert spend == {"cost_usd": 0.0, "tokens": 0}
+
+    await state.close()


### PR DESCRIPTION
Closes #1851. Adds a per-schedule spend/token budget to the studio scheduler, mirroring the existing `max_runs` cap plumbing. Branches off the merged concurrency-cap PR (#1853 / ee75969c4).

## What it adds
- Two nullable columns on `schedules`: `budget_usd REAL`, `budget_tokens INTEGER`.
- A pre-fire budget gate in the scheduler engine: before firing a scheduled run, the engine sums the schedule's cumulative prior spend (`sum_schedule_spend`) and, if either configured budget is exceeded, refuses to fire — auto-disabling the schedule (timer/github paths, recording reason `schedule.budget.exhausted`) or raising `ValueError` (`fire_now`, which never auto-disables a manual invocation).
- CLI: `li schedule create --max-cost-usd <n> --max-tokens <n>`.

## Design: soft ceiling (intentional)
Session cost is written at run terminal, not streamed mid-run, so this is a **pre-fire cumulative** check — a soft ceiling. A schedule can overshoot by at most one run's cost (the run that crosses the line completes; the next fire is refused). Pairs with `INVOCATION_DEADLINE_SECONDS`. A true mid-run kill is deferred.

The budget check is a pure read (no claim/reservation) and runs **before** the max-runs and global-slot reservations, so a budget-exhausted schedule never consumes a concurrency slot.

## Migration
Columns land in all sites: fresh schema, SQLAlchemy metadata, `MIGRATION_COLUMNS` (ALTER for existing DBs), and the schedules rebuild DDL/copy path. `_reconcile_columns()` runs before the rebuild, so existing DBs gain the nullable columns before the dynamic column copy.

## Validation hardening
Non-finite budgets (`nan`/`inf`/`-inf`) are rejected at both the CLI and service boundaries via `math.isfinite` — a plain `<= 0` check let `nan` through, and a NaN budget round-trips to NULL in SQLite, silently unbounding the gate.

## Tests
`_check_budget` (unbounded / cost-trip / token-trip / either-bound), the three fire entry points (disable+record vs fire-normally vs raise), `sum_schedule_spend` against a real StateDB (aggregate + zero-runs), non-finite rejection (CLI + service), CLI flag wiring, migration upgrade path, and a no-slot-consumed assertion on the budget bail.

Gates: `uv run --extra studio pytest tests/studio tests/state tests/cli -q` green; `ruff check` + `format --check` clean.

Two independent codex review legs (initial + re-review after the non-finite fix): APPROVE.