### PR TITLE
fix(studio): correct run-health and observability misreporting across Studio

### DIFF
--- a/apps/studio/frontend/src/components/fleet/fleetReducer.test.ts
+++ b/apps/studio/frontend/src/components/fleet/fleetReducer.test.ts
@@ -230,6 +230,17 @@ describe("fleetReducer — counts strip", () => {
     );
     expect(s.counts.attention).toBe(1);
   });
+
+  it("dead-health running run is not counted as an active Fleet agent", () => {
+    const s = dispatchOk(
+      initialFleetState(),
+      [],
+      [makeRun({ run_id: "r1", status: "running", effective_health: "stale" })],
+    );
+    expect(s.counts.agents).toBe(0);
+    expect(s.orgUnits).toHaveLength(0);
+    expect(s.recent[0].id).toBe("r1");
+  });
 });
 
 // ─── Attention flagging ───────────────────────────────────────────────────────

--- a/apps/studio/frontend/src/components/fleet/fleetReducer.ts
+++ b/apps/studio/frontend/src/components/fleet/fleetReducer.ts
@@ -17,7 +17,7 @@
 
 import type { RunSummary } from "@/lib/types";
 import type { InvocationSummary } from "@/lib/api";
-import { deriveDisplayStatus, type RunStatusInput } from "@/lib/runStatus";
+import { deriveDisplayStatus, isEffectivelyActive, type RunStatusInput } from "@/lib/runStatus";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -113,9 +113,11 @@ function elapsedSec(startedAt: number | null | undefined, nowSec: number): numbe
 // Active/terminal is the same lifecycle axis RunDetail and the mission board
 // use — route it through the one shared classifier so Fleet never drifts
 // from either (the exact list-vs-detail bug this closes, on the fleet view).
+// Also excludes running rows the shared health classifier has confirmed
+// dead (stale/orphaned/zombie), so a killed process can't count as an
+// active Fleet agent just because its DB status column still says running.
 function isActive(entity: RunStatusInput): boolean {
-  const derived = deriveDisplayStatus(entity);
-  return derived === "running" || derived === "queued";
+  return isEffectivelyActive(entity);
 }
 
 function needsAttention(row: AgentRow): boolean {

--- a/apps/studio/frontend/src/lib/runStatus.test.ts
+++ b/apps/studio/frontend/src/lib/runStatus.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { deriveDisplayStatus, deriveVerdict, isOrphanedReason } from "./runStatus";
+import {
+  deriveDisplayStatus,
+  deriveVerdict,
+  isEffectivelyActive,
+  isOrphanedReason,
+} from "./runStatus";
 
 describe("deriveDisplayStatus", () => {
   it("maps a phantom-reaped run to orphaned, not failed — even though raw status is failed", () => {
@@ -105,5 +110,33 @@ describe("deriveVerdict", () => {
     expect(deriveVerdict(undefined)).toBe("none");
     expect(deriveVerdict("")).toBe("none");
     expect(deriveVerdict("some random assistant sentence mentioning reject casually")).toBe("none");
+  });
+});
+
+describe("isEffectivelyActive", () => {
+  it("treats stale/orphaned/zombie running rows as inactive", () => {
+    expect(isEffectivelyActive({ status: "running", effective_health: "stale" })).toBe(false);
+    expect(isEffectivelyActive({ status: "running", effective_health: "orphaned" })).toBe(false);
+    expect(isEffectivelyActive({ status: "running", effective_health: "zombie" })).toBe(false);
+  });
+
+  it("keeps healthy, idle, and unresponsive running rows active", () => {
+    expect(isEffectivelyActive({ status: "running", effective_health: "healthy" })).toBe(true);
+    expect(isEffectivelyActive({ status: "running", effective_health: "idle" })).toBe(true);
+    // unresponsive means alive but quiet, not dead — stays active.
+    expect(isEffectivelyActive({ status: "running", effective_health: "unresponsive" })).toBe(true);
+  });
+
+  it("keeps a running row active when effective_health is absent (unknown liveness)", () => {
+    expect(isEffectivelyActive({ status: "running" })).toBe(true);
+  });
+
+  it("queued rows remain active regardless of effective_health", () => {
+    expect(isEffectivelyActive({ status: "queued", effective_health: "stale" })).toBe(true);
+  });
+
+  it("non-active display statuses are inactive", () => {
+    expect(isEffectivelyActive({ status: "completed" })).toBe(false);
+    expect(isEffectivelyActive({ status: "failed" })).toBe(false);
   });
 });

--- a/apps/studio/frontend/src/lib/runStatus.ts
+++ b/apps/studio/frontend/src/lib/runStatus.ts
@@ -24,6 +24,7 @@ export interface RunStatusInput {
   status: string;
   status_reason_code?: string | null;
   status_reason_summary?: string | null;
+  effective_health?: "healthy" | "idle" | "unresponsive" | "stale" | "orphaned" | "zombie" | null;
 }
 
 const RUNNING_ALIASES = new Set(["running", "executing", "in_progress", "director-managed"]);
@@ -78,6 +79,26 @@ export function deriveDisplayStatus(run: RunStatusInput): DisplayStatus {
   // Unrecognized status: default toward "still going" rather than mislabeling
   // an unknown value as done or failed.
   return "running";
+}
+
+const DEAD_EFFECTIVE_HEALTH = new Set(["stale", "orphaned", "zombie"]);
+
+/**
+ * True when a run is both display-active (running/queued) AND, for running
+ * rows, not already confirmed dead by the shared health classifier. A row
+ * whose process is a stale/orphaned/zombie process is a Fleet/Mission bug
+ * lying in wait if isActive() only ever checks display status. Kept separate
+ * from deriveDisplayStatus() so mapping dead health here never changes the
+ * status chip a run renders elsewhere (e.g. Mission attention branching).
+ */
+export function isEffectivelyActive(run: RunStatusInput): boolean {
+  const derived = deriveDisplayStatus(run);
+  if (derived !== "running" && derived !== "queued") return false;
+  return !(
+    derived === "running" &&
+    run.effective_health != null &&
+    DEAD_EFFECTIVE_HEALTH.has(run.effective_health)
+  );
 }
 
 const VERDICT_ALIASES: Record<string, Verdict> = {

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -270,13 +270,19 @@ def resolve_run_reason(
     if status == "aborted":
         return RunReasons.CANCELLED_SIGINT, "User pressed Ctrl-C (SIGINT).", None
     if status == "cancelled":
-        from lionagi.ln.concurrency.utils import SigtermInterrupt, sigterm_received
+        from lionagi.ln.concurrency.utils import (
+            SigtermInterrupt,
+            consume_sigterm_received,
+        )
 
         # At teardown the surfaced exception is usually a plain CancelledError
         # even when an external SIGTERM caused it — SigtermInterrupt is only
         # raised after the worker thread joins, after this record is stamped.
-        # The handler's process-wide latch is the reliable signal.
-        if isinstance(exception, SigtermInterrupt) or sigterm_received():
+        # The handler's process-wide latch is the reliable signal. Consume it
+        # unconditionally (before the branch) so a later, unrelated run/test
+        # can't inherit a latch left set on the explicit-SigtermInterrupt path.
+        sigterm_latched = consume_sigterm_received()
+        if isinstance(exception, SigtermInterrupt) or sigterm_latched:
             return (
                 RunReasons.CANCELLED_SIGTERM,
                 "sigterm_external: process received an external SIGTERM mid-run.",

--- a/lionagi/ln/concurrency/utils.py
+++ b/lionagi/ln/concurrency/utils.py
@@ -54,11 +54,25 @@ async def run_sync(func: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R
 # and stamped the terminal record. Persist paths consult this flag so an
 # external SIGTERM stays distinguishable from an internal runtime cancel.
 _SIGTERM_RECEIVED = threading.Event()
+_SIGTERM_RECEIVED_LOCK = threading.Lock()
 
 
 def sigterm_received() -> bool:
     """True if run_async's SIGTERM handler has fired in this process."""
     return _SIGTERM_RECEIVED.is_set()
+
+
+def consume_sigterm_received() -> bool:
+    """Read-and-clear the latch so one external SIGTERM labels one run.
+
+    Without consuming, the latch stays set for the lifetime of the process
+    and mislabels every later run/test's cancellation as SIGTERM-caused.
+    """
+    with _SIGTERM_RECEIVED_LOCK:
+        received = _SIGTERM_RECEIVED.is_set()
+        if received:
+            _SIGTERM_RECEIVED.clear()
+        return received
 
 
 class SigtermInterrupt(BaseException):
@@ -127,7 +141,8 @@ def run_async(coro: Awaitable[T]) -> T:
             if signum == signal.SIGTERM:
                 # Latch process-wide so teardown code that only sees a plain
                 # CancelledError can still report the cancel as external.
-                _SIGTERM_RECEIVED.set()
+                with _SIGTERM_RECEIVED_LOCK:
+                    _SIGTERM_RECEIVED.set()
             try:
                 child_loop, task = _loop_and_task_future.result(timeout=0.5)
             except Exception:  # noqa: BLE001

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -157,17 +157,25 @@ def process_liveness(
     if pid is not None:
         if not _pid_is_live(pid):
             return False
-        if create_time is not None:
-            try:
-                import psutil
+        try:
+            import psutil
 
-                actual = psutil.Process(pid).create_time()
+            proc = psutil.Process(pid)
+            # A zombie has exited but not been reaped; it is not a live
+            # worker even though the pid still resolves and _pid_is_live()
+            # reports it as present.
+            if proc.status() == psutil.STATUS_ZOMBIE:
+                return False
+            if create_time is not None:
+                actual = proc.create_time()
                 if abs(actual - create_time) > _PID_CREATE_TIME_TOLERANCE:
                     return False  # pid recycled; the recorded process is gone
-            except Exception:
-                # Best-effort check: the pid-is-live test above already
-                # passed, so an unreadable start time reads as alive.
-                _log.debug("pid %s start-time check failed", pid, exc_info=True)
+        except (psutil.NoSuchProcess, psutil.ZombieProcess):
+            return False
+        except Exception:
+            # Best-effort check: the pid-is-live test above already
+            # passed, so an unreadable status/start time reads as alive.
+            _log.debug("pid %s status/start-time check failed", pid, exc_info=True)
         return True
 
     session_id = session.get("id") or ""
@@ -307,7 +315,6 @@ async def health_report() -> dict[str, Any]:
     for row in rows:
         sess = {k: row[k] for k in row.keys()}
         status = sess.get("status") or "completed"
-        by_status[status] += 1
 
         artifacts = _artifacts_path(row)
         has_artifacts = artifacts is not None and artifacts.exists()
@@ -331,6 +338,18 @@ async def health_report() -> dict[str, Any]:
             has_stale_locks=has_stale_locks,
         )
         by_health[health.value] += 1
+
+        # A "running" row whose process is confirmed dead is not actually
+        # running; bucket it under its health verdict so by_status stays
+        # liveness-aware instead of echoing a stale DB status column.
+        status_bucket = status
+        if status == "running" and health in (
+            SessionHealth.STALE,
+            SessionHealth.ORPHANED,
+            SessionHealth.ZOMBIE,
+        ):
+            status_bucket = health.value
+        by_status[status_bucket] += 1
 
         if health not in (SessionHealth.HEALTHY, SessionHealth.IDLE):
             last_activity = (

--- a/lionagi/studio/services/sessions.py
+++ b/lionagi/studio/services/sessions.py
@@ -374,6 +374,10 @@ async def get_session(
         "status_evidence_refs": _parse_json_col(session_row["status_evidence_refs"]),
         "graph": _graph_from_metadata(session_row["node_metadata"]),
         "segments": (_parse_metadata(session_row["node_metadata"]) or {}).get("segments"),
+        # Raw node_metadata (carries pid/pid_create_time for running sessions)
+        # so callers like get_run()'s liveness check can find the recorded
+        # pid the same way list_sessions() already exposes it.
+        "node_metadata": session_row["node_metadata"],
     }
 
 

--- a/tests/apps_studio_server/test_admin.py
+++ b/tests/apps_studio_server/test_admin.py
@@ -226,7 +226,16 @@ def test_stale_lock_gated_on_staleness(tmp_path):
 
 def test_admin_health_reports_status_and_health_buckets(tmp_path, monkeypatch):
     db_path = tmp_path / "state.db"
-    _run(_seed_running_session(db_path, str(uuid.uuid4())))
+    # A fresh artifacts dir keeps this session out of the ORPHANED bucket
+    # (no artifacts + no messages) so it classifies HEALTHY and by_status
+    # still reads "running" for it.
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+    _run(
+        _seed_running_session(
+            db_path, str(uuid.uuid4()), artifacts_path=str(artifacts_dir), updated_at=time.time()
+        )
+    )
     client = _make_client(tmp_path, monkeypatch, db_path)
     r = client.get("/api/admin/health")
     assert r.status_code == 200
@@ -239,6 +248,31 @@ def test_admin_health_reports_status_and_health_buckets(tmp_path, monkeypatch):
     assert sess["by_status"].get("running") == 1
     # All health buckets sum to total.
     assert sum(sess["by_health"].values()) == sess["total"]
+    # by_status must stay liveness-aware: total count is preserved either way.
+    assert sum(sess["by_status"].values()) == sess["total"]
+
+
+def test_admin_health_running_bucket_excludes_confirmed_dead_running_session(tmp_path, monkeypatch):
+    """A "running" DB row whose process is confirmed dead must not inflate
+    by_status.running — that bucket should reflect liveness, not the raw
+    (possibly stale) status column."""
+    db_path = tmp_path / "state.db"
+    _run(_seed_running_session(db_path, str(uuid.uuid4())))
+
+    import lionagi.studio.services.admin as admin_mod
+
+    monkeypatch.setattr(admin_mod, "process_liveness", lambda *a, **k: False)
+
+    client = _make_client(tmp_path, monkeypatch, db_path)
+    r = client.get("/api/admin/health")
+    assert r.status_code == 200
+    sess = r.json()["sessions"]
+
+    assert sess["by_status"].get("running", 0) == 0
+    # No artifacts + no messages recorded for this seed -> ORPHANED, not STALE.
+    assert sess["by_status"].get("orphaned", 0) == 1
+    assert sess["by_health"].get("orphaned", 0) == 1
+    assert sum(sess["by_status"].values()) == sess["total"]
 
 
 def test_admin_transition_marks_running_session_failed(tmp_path, monkeypatch):

--- a/tests/apps_studio_server/test_process_liveness.py
+++ b/tests/apps_studio_server/test_process_liveness.py
@@ -66,3 +66,28 @@ def test_no_pid_but_session_id_in_snapshot_is_alive():
 @pytest.mark.parametrize("meta", [None, "not-json", {"pid": "garbage"}])
 def test_unparseable_metadata_falls_through_to_unknown(meta):
     assert process_liveness({"id": "s1", "node_metadata": meta}, None, ps_snapshot="") is None
+
+
+def test_node_metadata_pid_with_matching_create_time_but_zombie_status_is_dead(monkeypatch):
+    """A zombie pid still resolves to _pid_is_live()==True (it exists in the
+    process table, unreaped) but is not a live worker; it must read dead."""
+    import lionagi.studio.services.admin as admin_mod
+
+    ct = 42.0
+    pid = os.getpid()
+    monkeypatch.setattr(admin_mod, "_pid_is_live", lambda _pid: True)
+
+    class _ZombieProcess:
+        def __init__(self, _pid):
+            pass
+
+        def status(self):
+            return psutil.STATUS_ZOMBIE
+
+        def create_time(self):
+            return ct
+
+    monkeypatch.setattr(psutil, "Process", _ZombieProcess)
+
+    session = {"id": "s1", "node_metadata": {"pid": pid, "pid_create_time": ct}}
+    assert process_liveness(session, None, ps_snapshot="") is False

--- a/tests/apps_studio_server/test_runs_detail.py
+++ b/tests/apps_studio_server/test_runs_detail.py
@@ -422,3 +422,28 @@ async def test_get_run_surfaces_status_reason(patched_runs_svc):
     assert ok["status_reason_code"] is None
     assert ok["status_reason_summary"] is None
     assert ok["status_evidence_refs"] is None
+
+
+async def test_get_run_zombie_recorded_pid_reports_stale(patched_runs_svc, monkeypatch, tmp_path):
+    """A "running" row whose recorded pid is confirmed dead must not read
+    healthy just because it's inside the (nonexistent) zombie grace window —
+    the shared liveness oracle is the single source of truth here."""
+    svc, db_path = patched_runs_svc
+    import lionagi.studio.services.admin as admin_mod
+
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    monkeypatch.setattr(admin_mod, "_pid_is_live", lambda _pid: False)
+
+    sid = str(uuid.uuid4())
+    await seed_session(
+        db_path,
+        session_id=sid,
+        status="running",
+        artifacts_path=str(artifacts),
+        node_metadata={"pid": 999999, "pid_create_time": 42.0},
+    )
+
+    result = await svc.get_run(sid)
+    assert result is not None
+    assert result["effective_health"] == "stale"

--- a/tests/cli/test_sigterm_reason_code.py
+++ b/tests/cli/test_sigterm_reason_code.py
@@ -54,6 +54,35 @@ def test_cancelled_with_plain_cancel_but_latched_flag_maps_to_cancelled_sigterm(
     assert "sigterm_external" in summary
 
 
+def test_sigterm_latch_consumed_once_plain_later_cancel_stays_system():
+    # A latched SIGTERM must label exactly one resolution, not every
+    # subsequent cancel in the same process — otherwise an unrelated later
+    # run/test inherits an earlier run's external-SIGTERM verdict.
+    cu._SIGTERM_RECEIVED.set()
+    first_code, _, _ = resolve_run_reason(status="cancelled", exception=None)
+    assert first_code == RunReasons.CANCELLED_SIGTERM
+
+    second_code, second_summary, _ = resolve_run_reason(status="cancelled", exception=None)
+    assert second_code == RunReasons.CANCELLED_SYSTEM
+    assert "sigterm" not in second_summary.lower()
+
+
+def test_sigterm_interrupt_path_still_consumes_latch_so_next_run_stays_system():
+    # When the explicit SigtermInterrupt reaches teardown while the handler has
+    # also set the latch, the interrupt classifies this run — but the latch must
+    # still be consumed, or the next unrelated cancel inherits a stale SIGTERM.
+    cu._SIGTERM_RECEIVED.set()
+    first_code, _, _ = resolve_run_reason(
+        status="cancelled",
+        exception=SigtermInterrupt("process received SIGTERM"),
+    )
+    assert first_code == RunReasons.CANCELLED_SIGTERM
+
+    second_code, second_summary, _ = resolve_run_reason(status="cancelled", exception=None)
+    assert second_code == RunReasons.CANCELLED_SYSTEM
+    assert "sigterm" not in second_summary.lower()
+
+
 def test_cancelled_without_sigterm_stays_cancelled_system():
     code, summary, _ = resolve_run_reason(status="cancelled", exception=None)
     assert code == RunReasons.CANCELLED_SYSTEM
@@ -86,11 +115,15 @@ _SUBPROCESS_SCRIPT = textwrap.dedent("""\
         finally:
             # The persist teardown's view: the exception in flight is a plain
             # cancellation, but the handler has already latched the flag, so
-            # the resolved reason must be the external-SIGTERM one.
+            # the resolved reason must be the external-SIGTERM one. The latch
+            # is consumed by resolve_run_reason, so it must read back False
+            # afterward (a later run/test must not inherit this SIGTERM).
             with _anyio.CancelScope(shield=True):
+                flag_before = sigterm_received()
                 code, summary, _ = resolve_run_reason(status="cancelled", exception=None)
+                flag_after = sigterm_received()
                 with open(SENTINEL, "w") as f:
-                    f.write(f"{sigterm_received()}|{code}|{summary}")
+                    f.write(f"{flag_before}|{flag_after}|{code}|{summary}")
 
     try:
         run_async(long_running())
@@ -124,7 +157,8 @@ def test_external_sigterm_resolves_sigterm_reason_at_teardown(tmp_path):
             proc.wait()
 
     assert proc.returncode == 143
-    flag, code, summary = sentinel.read_text().split("|", 2)
-    assert flag == "True"
+    flag_before, flag_after, code, summary = sentinel.read_text().split("|", 3)
+    assert flag_before == "True"
+    assert flag_after == "False"
     assert code == "run.cancelled.sigterm"
     assert "sigterm_external" in summary


### PR DESCRIPTION
## Correct run-health and observability misreporting across Studio

Fixes a cluster of Studio run-health surfaces that misreport process liveness, plus a
process-wide SIGTERM latch that mislabeled unrelated later cancels.

### Changes

- **Per-run SIGTERM scoping** (`lionagi/cli/_runs.py`): `resolve_run_reason` now *consumes*
  (reads and clears under a lock) the process-wide SIGTERM latch instead of only reading it, so a
  SIGTERM in one run/test can no longer taint a later, unrelated cancel with a false termination reason.
- **Effective liveness at the shared oracle** (`lionagi/studio/services/admin.py`,
  `sessions.py`): liveness is evaluated at the shared `process_liveness` oracle so a
  zombie / `NoSuchProcess` pid reads *dead*. Run-detail and the run list now respect the zombie
  window instead of reporting healthy during it. `get_session` passes through `node_metadata`
  so the recorded pid reaches the liveness check (parity with `list_sessions`).
- **Health-classified admin aggregate** (`admin.py`): the admin health aggregate buckets by
  *classified* health — a `status="running"` row that classifies stale/orphaned/zombie no
  longer over-counts under `by_status.running`; the sum-equals-total invariant is preserved.
- **Fleet view effective health** (`fleetReducer.ts`, `runStatus.ts`): Fleet checks effective
  health via a shared `isEffectivelyActive` helper, so dead-process runs stop counting as active
  agents and Fleet agrees with Mission Control.

### Not in scope (known follow-up, not stubbed)

Per-node lifecycle signals on the flow-run path were verified *already* wired via the
`on_progress` → `Node*` signal bridge — no change needed here. The remaining transcript /
sub-agent persistence seam (branch factories outside the flow clone path need `on_branch_created`
fired pre-operate; chat nodes need `chat_and_record`) is a separate, tracked concern and is
deliberately **not** touched in this change. It is a follow-up, not a stub.

### Tests

Regression tests added per fixed failure mode (each red pre-fix, green post-fix):
`test_process_liveness.py`, `test_runs_detail.py`, `test_admin.py`, `test_sigterm_reason_code.py`,
`runStatus.test.ts`, `fleetReducer.test.ts`. Backend suite green for the touched modules; frontend
vitest green.

Resolves #1738, #1744, #1830, #1836, #1760, #1761

### Review

Codex (gpt-5.5, high) reviewed and returned APPROVE-WITH-FIXES with one MAJOR: the per-run SIGTERM
consume short-circuited on the explicit `SigtermInterrupt` path, leaving the process-wide latch set for
the next unrelated cancel. Fixed by consuming the latch unconditionally before the classify branch, with
a regression test (`test_sigterm_interrupt_path_still_consumes_latch_so_next_run_stays_system`). All other
areas confirmed by codex (process liveness, frontend status derivation, concurrency helper, leak scan).

Branch rebased onto current main (post #1855); files are disjoint from #1855 — no overlap.
