### PR TITLE
fix(state,scheduler): ADR-0094 terminal-status-integrity floor cluster (9 issues)

### DIFF
--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -368,6 +368,7 @@ async def _teardown_common(
         return status
 
     all_msgs = await db.get_progression(session_prog_id)
+    completion_evidence_msgs = list(all_msgs)
     update_kwargs: dict[str, Any] = {"ended_at": time.time()}
     if all_msgs:
         update_kwargs["first_msg_id"] = all_msgs[0]
@@ -448,6 +449,9 @@ async def _teardown_common(
                 f"{linked['status']!r}"
             )
             final_evidence_refs = [{"kind": "session", "id": linked_id, "label": linked["status"]}]
+            linked_prog_id = linked.get("progression_id")
+            if linked_prog_id:
+                completion_evidence_msgs.extend(await db.get_progression(linked_prog_id))
         elif linked is not None and linked["status"] == "running":
             final_status = "running"
             final_reason_code = RunReasons.STARTED_OK
@@ -492,7 +496,7 @@ async def _teardown_common(
 
         evidence = check_completion_evidence(cwd)
         if evidence["checked"]:
-            has_output = await _has_assistant_output_evidence(db, all_msgs)
+            has_output = await _has_assistant_output_evidence(db, completion_evidence_msgs)
             metadata = dict(metadata or {})
             metadata["completion_evidence"] = evidence
             metadata["has_assistant_output"] = has_output
@@ -538,29 +542,23 @@ async def _teardown_common(
     # Snapshot of the status this teardown itself observed when it started
     # (session_row was read above, before any status-changing write in this
     # function) -- the signal that tells apart the two rejection causes below.
+    # Only the status is used as the CAS guard below, not updated_at: this
+    # same function may itself have already touched the row's updated_at
+    # (artifact verification, the linked-engine metadata write) between that
+    # snapshot and the guarded write, and none of those are the concurrent
+    # writer the guard exists to catch.
     pre_write_status = session_row.get("status")
 
-    try:
-        await db.update_status(
-            "session",
-            session_id,
-            new_status=final_status,
-            reason_code=final_reason_code,
-            reason_summary=final_reason_summary,
-            evidence_refs=final_evidence_refs,
-            source="executor",
-            actor=session_id,
-            metadata=metadata,
-        )
-    except TransitionRejectedError:
-        if pre_write_status in SESSION_TERMINAL_STATUSES and pre_write_status != final_status:
-            # This teardown's OWN view of the session was already terminal
-            # before it attempted anything (e.g. a later resume/follow-up
-            # reattached to a session an earlier, unrelated run already
-            # finalized). The rejection is correctly protecting that earlier
-            # record -- but the caller must still hear THIS invocation's
-            # honest outcome, not the stale persisted one, or a genuine
-            # failure/timeout would silently read back as success.
+    if pre_write_status in SESSION_TERMINAL_STATUSES:
+        # This teardown's OWN view of the session was already terminal before
+        # it attempted anything (e.g. a later resume/follow-up reattached to
+        # a session an earlier, unrelated run already finalized). Writing
+        # again would be a redundant terminal overwrite the ADR-0094 floor
+        # would reject -- skip it outright rather than attempt-and-catch, and
+        # report THIS invocation's honest outcome rather than the persisted
+        # one, or a genuine failure/timeout would silently read back as
+        # success.
+        if pre_write_status != final_status:
             _log.warning(
                 "session %s already terminal at %r; this invocation's %r "
                 "outcome was not persisted (ADR-0094 protects the earlier "
@@ -570,12 +568,42 @@ async def _teardown_common(
                 final_status,
             )
         else:
-            # Benign race: this teardown observed the row non-terminal at
-            # entry, but another writer (e.g. a concurrent teardown of the
-            # same in-flight session) finalized it first. Read back the
-            # now-persisted status instead of raising past callers -- it
-            # reflects the outcome that actually won the race for this same
-            # live invocation.
+            _log.debug(
+                "session %s already terminal at %r; skipping duplicate status write",
+                session_id,
+                pre_write_status,
+            )
+    else:
+        try:
+            written = await db.update_status(
+                "session",
+                session_id,
+                new_status=final_status,
+                reason_code=final_reason_code,
+                reason_summary=final_reason_summary,
+                evidence_refs=final_evidence_refs,
+                source="executor",
+                actor=session_id,
+                metadata=metadata,
+                expected_statuses={pre_write_status},
+            )
+            if not written:
+                # CAS miss: another writer (e.g. a concurrent teardown of the
+                # same in-flight session) touched the row between this
+                # teardown's snapshot and this write. Read back the
+                # now-persisted status instead of raising past callers -- it
+                # reflects the outcome that actually won the race for this
+                # same live invocation.
+                persisted = await db.get_session(session_id) or {}
+                final_status = persisted.get("status", final_status)
+                _log.debug(
+                    "session %s status changed under this teardown; using persisted status %s",
+                    session_id,
+                    final_status,
+                )
+        except TransitionRejectedError:
+            # Defensive fallback: the row became terminal between this
+            # teardown's snapshot and the write despite the CAS guard above.
             persisted = await db.get_session(session_id) or {}
             final_status = persisted.get("status", final_status)
             _log.debug(

--- a/lionagi/cli/state.py
+++ b/lionagi/cli/state.py
@@ -631,14 +631,10 @@ async def _doctor(
                     source="admin",
                     actor="doctor",
                     expected_statuses={"running"},
+                    extra_fields={"ended_at": _time.time()},
                 )
                 if transitioned:
                     swept_count += 1
-                    async with db._tx() as conn:
-                        await conn.execute(
-                            text("UPDATE sessions SET ended_at = :ended_at WHERE id = :id"),
-                            {"ended_at": _time.time(), "id": vid},
-                        )
 
         return {"running": total, "swept": swept_count, "skipped": skipped}
 

--- a/lionagi/state/claude_mirror.py
+++ b/lionagi/state/claude_mirror.py
@@ -316,13 +316,19 @@ async def reconcile_session_status(
     ``completed`` session read as fresh again on the next pass and oscillate back
     to ``running``.
 
-    ADR-0094's integrity floor treats ``completed`` as terminal on the sessions
-    table for orchestrated runs, so reactivating a mirror session out of
-    ``completed`` goes through the sanctioned override path — it is a real,
-    deliberate, well-understood write (not a repair), so it is attributed to a
-    fixed system actor rather than a human operator, and it lands in
-    admin_events like any other override.
+    ADR-0094's integrity floor treats every session terminal status (not just
+    ``completed``) as terminal on the sessions table for orchestrated runs, so
+    reactivating a mirror session out of any of them goes through the
+    sanctioned override path — it is a real, deliberate, well-understood write
+    (not a repair), so it is attributed to a fixed system actor rather than a
+    human operator, and it lands in admin_events like any other override. A
+    mirror session that is idle and already sitting on a non-``completed``
+    terminal status (e.g. it was independently marked ``failed`` or
+    ``cancelled``) is left alone rather than rewritten to ``completed`` — it is
+    already terminal, and only a live transcript resuming can justify pulling
+    it back to ``running``.
     """
+    from lionagi.state.db import SESSION_TERMINAL_STATUSES
     from lionagi.state.reasons import RunReasons
 
     existing = await db.get_session(session_db_id(session_uid))
@@ -333,19 +339,37 @@ async def reconcile_session_status(
     previous = existing.get("status")
     if previous == desired:
         return
-    reactivating = previous == "completed" and desired == "running"
-    await db.update_session(
+
+    previous_terminal = previous in SESSION_TERMINAL_STATUSES
+    if previous_terminal and desired != "running":
+        return
+
+    reactivating = previous_terminal and desired == "running"
+    written = await db.update_status(
+        "session",
         session_db_id(session_uid),
-        status=desired,
+        new_status=desired,
         reason_code=RunReasons.STARTED_OK if desired == "running" else RunReasons.COMPLETED_OK,
+        reason_summary=(
+            "mirror session reactivated because transcript resumed within live_window"
+            if reactivating
+            else "mirror session became idle"
+        ),
+        evidence_refs=[{"kind": "session", "id": session_db_id(session_uid)}],
+        source="system",
+        actor="claude-mirror-reconcile",
+        expected_statuses={previous},
+        expected_updated_at=existing.get("updated_at"),
         override=reactivating,
         override_actor="claude-mirror-reconcile" if reactivating else None,
         override_justification=(
-            "mirror session dormancy reactivation: transcript resumed within live_window"
+            "mirror session terminal reactivation: transcript resumed within live_window"
             if reactivating
             else None
         ),
     )
+    if not written:
+        return
 
 
 async def link_session_lineage(

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -257,6 +257,14 @@ TERMINAL_STATUSES_BY_ENTITY_TYPE: dict[str, frozenset[str]] = {
     "team": TEAM_TERMINAL_STATUSES,
 }
 
+# Same-row columns update_status() may set alongside a status write, in the
+# same transaction as the status/status_transitions write — keeps a caller
+# from splitting a status change and a dependent column (e.g. ended_at) into
+# two transactions that a crash between them could leave inconsistent.
+EXTRA_STATUS_WRITE_FIELDS_BY_ENTITY_TYPE: dict[str, frozenset[str]] = {
+    "session": frozenset({"ended_at"}),
+}
+
 # ── ADR-0094 status vocabulary (valid, not just terminal) ──────────────
 # update_status() rejects any new_status outside its entity_type's set here —
 # the terminal-overwrite floor above stops a terminal record from moving;
@@ -1444,6 +1452,7 @@ class StateDB:
         metadata: dict[str, Any] | None = None,
         expected_statuses: set[str | None] | frozenset[str | None] | None = None,
         expected_updated_at: float | None = None,
+        extra_fields: dict[str, Any] | None = None,
         override: bool = False,
         override_actor: str | None = None,
         override_justification: str | None = None,
@@ -1501,6 +1510,16 @@ class StateDB:
                 f"entity_type={canonical_type!r}; vocabulary is {sorted(valid_statuses)}."
             )
         table = _reason_entity_table(canonical_type)
+        if extra_fields:
+            allowed_extra = EXTRA_STATUS_WRITE_FIELDS_BY_ENTITY_TYPE.get(
+                canonical_type, frozenset()
+            )
+            unknown = set(extra_fields) - allowed_extra
+            if unknown:
+                raise ValueError(
+                    f"update_status() called with extra_fields keys {sorted(unknown)} for "
+                    f"entity_type={canonical_type!r}; allowed keys are {sorted(allowed_extra)}."
+                )
         now = time.time()
         terminal_statuses = TERMINAL_STATUSES_BY_ENTITY_TYPE.get(canonical_type, frozenset())
 
@@ -1589,6 +1608,7 @@ class StateDB:
                     metadata=metadata,
                     now=now,
                     expected_updated_at=expected_updated_at,
+                    extra_fields=extra_fields,
                 )
                 if not written:
                     # Optimistic-lock guard lost: the row's updated_at moved
@@ -1617,6 +1637,7 @@ class StateDB:
         metadata: dict[str, Any] | None,
         now: float,
         expected_updated_at: float | None = None,
+        extra_fields: dict[str, Any] | None = None,
     ) -> bool:
         """The actual status + status_transitions write, factored out of
         update_status() so both the ordinary and override paths share it.
@@ -1654,6 +1675,12 @@ class StateDB:
         if expected_updated_at is not None:
             version_guard = "  AND updated_at = :expected_updated_at "
             params["expected_updated_at"] = expected_updated_at
+        extra_set = ""
+        if extra_fields:
+            for field_name, field_value in extra_fields.items():
+                param_name = f"extra_{field_name}"
+                extra_set += f"  {field_name} = :{param_name}, "
+                params[param_name] = field_value
         result = await conn.execute(
             text(
                 f"UPDATE {table} SET "  # noqa: S608
@@ -1661,6 +1688,7 @@ class StateDB:
                 "  status_reason_code = :reason_code, "
                 "  status_reason_summary = :reason_summary, "
                 "  status_evidence_refs = :evidence_refs, "
+                f"{extra_set}"
                 "  updated_at = :now "
                 "WHERE id = :id "
                 "  AND (status = :previous_status "

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -973,7 +973,7 @@ class SchedulerEngine:
                 self._svc, inv_id, fallback_status="failed", exception=exc
             )
             await self._svc.update_invocation(inv_id, ended_at=_end_time)
-            await self._svc.update_status(
+            await self._guarded_terminal_status(
                 "invocation",
                 inv_id,
                 new_status=inv_status,
@@ -1127,11 +1127,16 @@ class SchedulerEngine:
                     run_id,
                     ended_at=_end_time,
                     error_detail="Scheduler shutdown",
+                )
+                await self._guarded_terminal_status(
+                    "schedule_run",
+                    run_id,
+                    new_status="cancelled",
                     reason_code=RunReasons.CANCELLED_SYSTEM,
-                    status="cancelled",
                     reason_summary="Schedule run cancelled by scheduler shutdown.",
                     evidence_refs=[{"kind": "schedule", "id": sid}],
-                    reason_actor=run_id,
+                    source="executor",
+                    actor=run_id,
                 )
                 inv_status, inv_rc, inv_rs, inv_ev, inv_meta = await resolve_invocation_terminal(
                     self._svc, inv_id, fallback_status="cancelled"

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -785,6 +785,45 @@ class SchedulerEngine:
             global_slot_claim=slot_claim,
         )
 
+    async def _guarded_terminal_status(
+        self,
+        entity_type: str,
+        entity_id: str,
+        *,
+        new_status: str,
+        reason_code: str,
+        reason_summary: str,
+        evidence_refs: list[dict],
+        source: str,
+        actor: str,
+        metadata: dict | None = None,
+    ) -> bool:
+        """Write a terminal ``schedule_run``/``invocation`` status without
+        crashing (or losing follow-on side effects) when the row is already
+        terminal — a concurrent writer (e.g. the deadline reaper) may have
+        finalized it first. Guarded on the row still being ``running``, so a
+        lost race is a checked no-op rather than a raised exception.
+        """
+        written = await self._svc.update_status(
+            entity_type,
+            entity_id,
+            new_status=new_status,
+            reason_code=reason_code,
+            reason_summary=reason_summary,
+            evidence_refs=evidence_refs,
+            source=source,
+            actor=actor,
+            metadata=metadata,
+            expected_statuses={"running"},
+        )
+        if not written:
+            _log.debug(
+                "%s %s already finalized; continuing scheduler side effects",
+                entity_type,
+                entity_id,
+            )
+        return written
+
     async def _check_max_runs(self, schedule: dict, chain_depth: int) -> None:
         """Auto-disable a schedule once its fired top-level runs hit max_runs.
 
@@ -1016,7 +1055,7 @@ class SchedulerEngine:
                 ended_at=end_time,
                 error_detail=stderr_tail if exit_code != 0 else None,
             )
-            await self._svc.update_status(
+            await self._guarded_terminal_status(
                 "schedule_run",
                 run_id,
                 new_status=status,
@@ -1031,7 +1070,7 @@ class SchedulerEngine:
                 self._svc, inv_id, fallback_status=status, exit_code=exit_code
             )
             await self._svc.update_invocation(inv_id, ended_at=end_time)
-            await self._svc.update_status(
+            await self._guarded_terminal_status(
                 "invocation",
                 inv_id,
                 new_status=inv_status,
@@ -1098,7 +1137,7 @@ class SchedulerEngine:
                     self._svc, inv_id, fallback_status="cancelled"
                 )
                 await self._svc.update_invocation(inv_id, ended_at=_end_time)
-                await self._svc.update_status(
+                await self._guarded_terminal_status(
                     "invocation",
                     inv_id,
                     new_status=inv_status,
@@ -1121,7 +1160,7 @@ class SchedulerEngine:
                 ended_at=_end_time,
                 error_detail="Internal scheduler error",
             )
-            await self._svc.update_status(
+            await self._guarded_terminal_status(
                 "schedule_run",
                 run_id,
                 new_status="failed",
@@ -1136,7 +1175,7 @@ class SchedulerEngine:
                 self._svc, inv_id, fallback_status="failed", exception=exc
             )
             await self._svc.update_invocation(inv_id, ended_at=_end_time)
-            await self._svc.update_status(
+            await self._guarded_terminal_status(
                 "invocation",
                 inv_id,
                 new_status=inv_status,

--- a/lionagi/studio/services/scheduler_state.py
+++ b/lionagi/studio/services/scheduler_state.py
@@ -51,7 +51,8 @@ class SchedulerStateService(Protocol):
         source: str,
         actor: str,
         metadata: dict | None = None,
-    ) -> None: ...
+        expected_statuses: set[str | None] | frozenset[str | None] | None = None,
+    ) -> bool: ...
 
     async def list_sessions_for_invocation(self, invocation_id: str) -> list[dict[str, Any]]: ...
 
@@ -107,9 +108,10 @@ class _DBSchedulerStateService:
         source: str,
         actor: str,
         metadata: dict | None = None,
-    ) -> None:
+        expected_statuses: set[str | None] | frozenset[str | None] | None = None,
+    ) -> bool:
         async with StateDB() as db:
-            await db.update_status(
+            return await db.update_status(
                 entity_type,
                 entity_id,
                 new_status=new_status,
@@ -119,6 +121,7 @@ class _DBSchedulerStateService:
                 source=source,
                 actor=actor,
                 metadata=metadata,
+                expected_statuses=expected_statuses,
             )
 
     async def list_sessions_for_invocation(self, invocation_id: str) -> list[dict[str, Any]]:

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -1281,6 +1281,116 @@ async def test_stop_no_cwd_never_gates_on_git_evidence(
     assert s["status"] == "completed"
 
 
+async def test_teardown_skips_already_terminal_session_without_rejection_audit(
+    temp_db_path: Path,
+):
+    """A session already terminal (e.g. finalized by an earlier, concurrent
+    teardown of the same session) must not attempt a redundant terminal
+    overwrite — that trips the ADR-0094 floor and records a
+    status_transition_rejected admin event for a write that was never a real
+    integrity violation."""
+    env = _minimal_env()
+    await start_live_persist(env, invocation_kind="flow")
+    ctx = env._live_persist
+    assert ctx is not None
+
+    async with StateDB() as db:
+        await db.update_status(
+            "session",
+            ctx["session_id"],
+            new_status="failed",
+            reason_code="run.failed.exception",
+            source="executor",
+            actor=ctx["session_id"],
+        )
+
+    await stop_live_persist(env, status="completed")
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+        rejections = await db.list_admin_events(
+            action="status_transition_rejected", target_id=ctx["session_id"]
+        )
+    assert s is not None
+    # This invocation's own outcome was not persisted -- the earlier terminal
+    # record (from the "other" writer) is what must survive.
+    assert s["status"] == "failed"
+    assert rejections == []
+
+
+async def test_reconciled_linked_engine_completed_with_output_stays_completed(
+    temp_db_path: Path,
+    tmp_path: Path,
+):
+    """A profile session reconciled to a linked engine session's terminal
+    'completed' status must not then be demoted to 'completed_empty' by the
+    completion-trust gate just because the *profile* session's own
+    progression carries no assistant output — the linked engine session's own
+    progression (real answer text) is legitimate completion evidence too."""
+    from lionagi.cli._runs import teardown_persist
+    from lionagi.providers._provider_errors import ProviderError
+    from lionagi.state.claude_mirror import mirror_session, session_db_id
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+
+    env = _minimal_env()
+    env.cwd = str(repo)
+    await start_live_persist(env, invocation_kind="flow")
+    ctx = env._live_persist
+    assert ctx is not None
+
+    engine_uid = "12121212-3434-5656-7878-909090909090"
+    async with StateDB() as db:
+        await mirror_session(
+            db,
+            session_uid=engine_uid,
+            events=[
+                {
+                    "type": "user",
+                    "uuid": "e-u1",
+                    "timestamp": "2026-06-20T00:00:00.000Z",
+                    "sessionId": engine_uid,
+                    "message": {
+                        "role": "user",
+                        "content": [{"type": "text", "text": "what is the answer?"}],
+                    },
+                },
+                {
+                    "type": "assistant",
+                    "uuid": "e-a1",
+                    "timestamp": "2026-06-20T00:00:01.000Z",
+                    "sessionId": engine_uid,
+                    "message": {
+                        "role": "assistant",
+                        "model": "claude-opus-4-8",
+                        "content": [{"type": "text", "text": "The real answer is 42."}],
+                    },
+                },
+            ],
+            tool_names={},
+            status="completed",
+        )
+
+    final_status = await teardown_persist(
+        ctx,
+        status="failed",
+        exception=ProviderError("stream error"),
+        cwd=str(repo),
+        engine_session_uid=engine_uid,
+    )
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+        linked = await db.get_session(session_db_id(engine_uid))
+    assert linked["status"] == "completed"
+    assert final_status == "completed"
+    assert s is not None
+    assert s["status"] == "completed"
+    assert s["status_reason_code"] != "run.completed_empty.no_evidence"
+
+
 async def test_missing_artifact_session_failure_propagates_to_invocation_status(
     temp_db_path: Path,
     tmp_path: Path,

--- a/tests/cli/test_mirror.py
+++ b/tests/cli/test_mirror.py
@@ -304,6 +304,108 @@ async def test_reconcile_idle_session_stays_completed_across_passes(temp_db_path
 
 
 @pytest.mark.asyncio
+async def test_reconcile_reactivates_cancelled_terminal_when_fresh(temp_db_path: Path) -> None:
+    # A mirror session independently marked "cancelled" (or any non-"completed"
+    # terminal status) must reactivate to "running" the same way a dormant
+    # "completed" one does, instead of raising the ADR-0094 terminal-status
+    # floor as an ordinary, unguarded transition attempt would.
+    async with StateDB() as db:
+        await mirror_session(
+            db, session_uid=SID, events=_conversation(), tool_names={}, status="running"
+        )
+        before = await db.get_session(session_db_id(SID))
+        await db.update_status(
+            "session",
+            session_db_id(SID),
+            new_status="cancelled",
+            reason_code="run.cancelled.system",
+            source="admin",
+            actor="test",
+        )
+        cancelled = await db.get_session(session_db_id(SID))
+        # "now" within the live window of the last message -> reactivate to running.
+        await reconcile_session_status(
+            db, SID, now=cancelled["last_message_at"] + 1, live_window=300
+        )
+        after = await db.get_session(session_db_id(SID))
+    assert before["status"] == "running"
+    assert cancelled["status"] == "cancelled"
+    assert after["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_one_pass_non_completed_terminal_reactivation_does_not_crash(
+    temp_db_path: Path, tmp_path: Path
+) -> None:
+    # The CLI's per-tail-pass loop must not propagate a TransitionRejectedError
+    # out of _one_pass() when a live mirror session sits on a non-"completed"
+    # terminal status (e.g. independently marked "failed" or "cancelled").
+    root = tmp_path / "projects"
+    uid = "dddddddd-0000-0000-0000-00000000000d"
+    async with StateDB() as db:
+        await mirror_session(
+            db, session_uid=uid, events=_conversation(), tool_names={}, status="running"
+        )
+        await db.update_status(
+            "session",
+            session_db_id(uid),
+            new_status="failed",
+            reason_code="run.failed.exception",
+            source="admin",
+            actor="test",
+        )
+        _write_session_file(root / "-w-proj" / f"{uid}.jsonl", uid, age_secs=5)
+        await _one_pass(db, root, {}, {}, since=None, live_window=300)
+        row = await db.get_session(session_db_id(uid))
+    assert row["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_one_pass_terminal_reactivation_does_not_skip_later_uid_or_lineage(
+    temp_db_path: Path, tmp_path: Path
+) -> None:
+    # A live, non-"completed" terminal session reconciled earlier in the same
+    # pass must not abort the loop before it reaches lineage resolution for an
+    # unrelated pair of sessions processed in the same pass.
+    root = tmp_path / "projects"
+    terminal_uid = "eeeeeeee-0000-0000-0000-00000000000e"
+    a, b = "aaaaaaaa-1111-0000-0000-000000000001", "bbbbbbbb-1111-0000-0000-000000000002"
+    async with StateDB() as db:
+        await mirror_session(
+            db, session_uid=terminal_uid, events=_conversation(), tool_names={}, status="running"
+        )
+        await db.update_status(
+            "session",
+            session_db_id(terminal_uid),
+            new_status="cancelled",
+            reason_code="run.cancelled.system",
+            source="admin",
+            actor="test",
+        )
+        _write_session_file(root / "-w-proj" / f"{terminal_uid}.jsonl", terminal_uid, age_secs=5)
+        _write_lineage_file(
+            root / "-w-proj" / f"{a}.jsonl",
+            [
+                _lineage_event(a, "a-1", None, "user", "start the work"),
+                _lineage_event(a, "a-leaf", "a-1", "assistant", "done, ending here"),
+            ],
+        )
+        _write_lineage_file(
+            root / "-w-proj" / f"{b}.jsonl",
+            [
+                _lineage_event(b, "b-1", "a-leaf", "user", "continuing from before"),
+                _lineage_event(b, "b-2", "b-1", "assistant", "picking it up"),
+            ],
+        )
+        await _one_pass(db, root, {}, {}, since=None, live_window=300)
+        terminal_row = await db.get_session(session_db_id(terminal_uid))
+        child = await db.get_session(session_db_id(b))
+    assert terminal_row["status"] == "running"
+    lineage = child["node_metadata"]["lineage"]
+    assert lineage["parent_session_uid"] == a
+
+
+@pytest.mark.asyncio
 async def test_mirror_session_repairs_partial_scaffold(
     temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/cli/test_state_commands.py
+++ b/tests/cli/test_state_commands.py
@@ -519,6 +519,48 @@ async def test_doctor_does_not_overwrite_session_that_completed_post_select(
     assert result["swept"] == 1
 
 
+async def test_doctor_status_and_ended_at_are_atomic(
+    temp_db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A crash immediately after the status-transitioning write commits must
+    not leave a terminal-status row with ``ended_at`` still NULL — status and
+    ``ended_at`` must land in the same transaction, not two sequential ones.
+    """
+    from lionagi.state.db import StateDB as _SDB
+
+    now = time.time()
+    old = now - (48 * 3600)
+    async with StateDB() as db:
+        sid = await _seed_session(db, status="running")
+        await db.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (old, sid),
+        )
+
+    real_tx = _SDB._tx
+    calls = {"n": 0}
+
+    @contextlib.asynccontextmanager
+    async def crash_after_first_tx(self):
+        calls["n"] += 1
+        async with real_tx(self) as conn:
+            yield conn
+        if calls["n"] == 1:
+            raise RuntimeError("simulated crash right after the status write commits")
+
+    monkeypatch.setattr(_SDB, "_tx", crash_after_first_tx)
+
+    with pytest.raises(RuntimeError, match="simulated crash"):
+        await _doctor(stale_hours=24, dry_run=False)
+
+    monkeypatch.setattr(_SDB, "_tx", real_tx)
+    async with StateDB() as db:
+        s = await db.get_session(sid)
+    assert s["status"] == "aborted"
+    assert s["ended_at"] is not None
+
+
 async def test_doctor_with_failed_new_status(temp_db_path: Path):
     """Operators can pick 'failed' instead of 'aborted'."""
     now = time.time()

--- a/tests/studio/test_scheduler_engine.py
+++ b/tests/studio/test_scheduler_engine.py
@@ -499,6 +499,162 @@ async def test_fire_on_success_chain_fires():
     assert chained, "Expected a chained _fire() call at depth=1"
 
 
+@pytest.mark.asyncio
+async def test_fire_invocation_finalization_cas_miss_is_checked_and_does_not_raise():
+    """A concurrent finalizer (e.g. the deadline reaper) may already have
+    moved the invocation to a terminal status by the time _fire() records its
+    own outcome. The write must be guarded (so a lost race is a checked
+    no-op) and _fire() must not raise past that point — _check_max_runs()
+    must still run."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+
+    async def _update_status(entity_type, entity_id, *, new_status, **kwargs):
+        if entity_type == "invocation":
+            assert "expected_statuses" in kwargs, (
+                "invocation terminal write must pass expected_statuses so a "
+                "reaper-lost race is a checked no-op, not an unguarded write"
+            )
+            return False  # another writer already finalized this invocation
+        return True
+
+    svc.update_status = AsyncMock(side_effect=_update_status)
+    engine = SchedulerEngine(svc=svc)
+    # max_runs makes _check_max_runs() actually call count_schedule_runs(),
+    # so its execution is directly observable as a side effect that must
+    # survive the guarded, no-op invocation write above.
+    schedule = _minimal_schedule(max_runs=100)
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await engine._fire(schedule, "run-cas", trigger_context={"scheduled": True})
+
+    svc.count_schedule_runs.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fire_exception_after_terminal_schedule_run_does_not_rewrite_failed():
+    """A late exception after the schedule_run terminal write already
+    succeeded (e.g. resolve_invocation_terminal blowing up) must not attempt
+    an unguarded terminal rewrite from the broad-except handler."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    schedule_run_terminal_calls: list[dict] = []
+
+    async def _update_status(entity_type, entity_id, *, new_status, **kwargs):
+        if entity_type == "schedule_run" and new_status in ("completed", "failed"):
+            schedule_run_terminal_calls.append(kwargs)
+            if len(schedule_run_terminal_calls) > 1:
+                assert "expected_statuses" in kwargs, (
+                    "a second schedule_run terminal write from the broad-except "
+                    "handler must be guarded, not an unconditional overwrite"
+                )
+                return False
+        return True
+
+    svc.update_status = AsyncMock(side_effect=_update_status)
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule()
+
+    # resolve_invocation_terminal() raises on its first call (right after the
+    # schedule_run terminal write in the normal path), but the broad-except
+    # handler's own call to it must still succeed so the test can observe the
+    # handler's schedule_run rewrite attempt in isolation.
+    resolve_calls = {"n": 0}
+
+    async def _resolve_invocation_terminal(*args, **kwargs):
+        resolve_calls["n"] += 1
+        if resolve_calls["n"] == 1:
+            raise RuntimeError("boom")
+        return ("failed", "run.failed.exception", "boom", [], {})
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+        patch(
+            "lionagi.studio.scheduler.engine.resolve_invocation_terminal",
+            new=AsyncMock(side_effect=_resolve_invocation_terminal),
+        ),
+    ):
+        await engine._fire(schedule, "run-late-exc", trigger_context={"scheduled": True})
+
+    assert len(schedule_run_terminal_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_fire_chain_runs_when_terminal_write_loses_cas():
+    """A lost CAS race on the invocation terminal write must not swallow
+    on_success chaining — the chain still fires even though the write
+    recording this run's own outcome was a no-op."""
+    from lionagi.state.db import TransitionRejectedError
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+
+    async def _update_status(entity_type, entity_id, *, new_status, **kwargs):
+        if entity_type == "invocation":
+            if "expected_statuses" not in kwargs:
+                # Unguarded write against a row the reaper already finalized —
+                # the real DB layer raises the terminal-status floor here.
+                raise TransitionRejectedError("invocation", entity_id, "completed", new_status)
+            return False
+        return True
+
+    svc.update_status = AsyncMock(side_effect=_update_status)
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(
+        on_success={"kind": "agent", "prompt": "chained prompt", "model": "gpt-4.1-mini"}
+    )
+
+    fire_calls: list[tuple] = []
+    original_fire = engine._fire
+
+    async def _patched_fire(sched, run_id, *, trigger_context, chain_parent_id=None, chain_depth=0):
+        fire_calls.append((sched["id"], chain_depth))
+        if chain_depth > 0:
+            return
+        return await original_fire(
+            sched,
+            run_id,
+            trigger_context=trigger_context,
+            chain_parent_id=chain_parent_id,
+            chain_depth=chain_depth,
+        )
+
+    engine._fire = _patched_fire  # type: ignore[method-assign]
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await original_fire(schedule, "run-chain-cas", trigger_context={}, chain_depth=0)
+
+    chained = [c for c in fire_calls if c[1] == 1]
+    assert chained, "on_success chain must still fire when the invocation write lost its CAS"
+
+
 # ---------------------------------------------------------------------------
 # SchedulerEngine.fire_now() — delegates through service
 # ---------------------------------------------------------------------------

--- a/tests/studio/test_scheduler_engine.py
+++ b/tests/studio/test_scheduler_engine.py
@@ -370,7 +370,7 @@ async def test_fire_cancellation_records_cancelled_run():
 
     svc.update_schedule_run.assert_awaited()
     cancelled_calls = [
-        c for c in svc.update_schedule_run.await_args_list if c.kwargs.get("status") == "cancelled"
+        c for c in svc.update_status.await_args_list if c.kwargs.get("new_status") == "cancelled"
     ]
     assert cancelled_calls
 
@@ -653,6 +653,89 @@ async def test_fire_chain_runs_when_terminal_write_loses_cas():
 
     chained = [c for c in fire_calls if c[1] == 1]
     assert chained, "on_success chain must still fire when the invocation write lost its CAS"
+
+
+@pytest.mark.asyncio
+async def test_fire_invalid_action_invocation_cas_miss_is_checked_and_does_not_raise():
+    """The invalid-schedule-action branch (build_argv raising before any
+    process is spawned) finalizes the invocation it already created as
+    'running'. If a concurrent finalizer (e.g. the deadline reaper) wins that
+    row first, the write must be guarded (expected_statuses) so a lost race
+    is a checked no-op, not an unguarded write that raises past _fire() and
+    drops _check_max_runs()."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+
+    async def _update_status(entity_type, entity_id, *, new_status, **kwargs):
+        if entity_type == "invocation":
+            assert "expected_statuses" in kwargs, (
+                "invalid-action invocation terminal write must pass "
+                "expected_statuses so a reaper-lost race is a checked "
+                "no-op, not an unguarded write"
+            )
+            return False  # another writer already finalized this invocation
+        return True
+
+    svc.update_status = AsyncMock(side_effect=_update_status)
+    engine = SchedulerEngine(svc=svc)
+    # max_runs makes _check_max_runs() actually call count_schedule_runs(),
+    # so its execution is directly observable as a side effect that must
+    # survive the guarded, no-op invocation write above.
+    schedule = _minimal_schedule(max_runs=100)
+
+    with patch(
+        "lionagi.studio.scheduler.subprocess.build_argv",
+        side_effect=RuntimeError("bad template"),
+    ):
+        await engine._fire(schedule, "run-invalid-action", trigger_context={"scheduled": True})
+
+    svc.count_schedule_runs.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fire_cancellation_schedule_run_cas_miss_does_not_skip_side_effects():
+    """Cancellation must not skip invocation finalization and
+    _check_max_runs() when the schedule_run cancellation write loses its CAS
+    race (e.g. another finalizer already moved the row to a terminal
+    status). The write must be a checked no-op, not an unguarded write that
+    raises and is swallowed by the handler's own except-and-log block."""
+    from lionagi.state.db import TransitionRejectedError
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+
+    async def _update_schedule_run(run_id, *, status=None, **kwargs):
+        if status is not None:
+            # The real DB layer raises the terminal-status floor here because
+            # this call path (update_schedule_run -> _route_status_change ->
+            # update_status) does not pass expected_statuses.
+            raise TransitionRejectedError("schedule_run", run_id, "completed", status)
+
+    svc.update_schedule_run = AsyncMock(side_effect=_update_schedule_run)
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(max_runs=100)
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(side_effect=asyncio.CancelledError()),
+        ),
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await engine._fire(schedule, "run-cancel-cas", trigger_context={"scheduled": True})
+
+    # Invocation finalization must still be attempted despite the lost CAS
+    # race on the schedule_run status write above.
+    invocation_calls = [
+        c for c in svc.update_status.await_args_list if c.args and c.args[0] == "invocation"
+    ]
+    assert invocation_calls, "invocation finalization must still run after a cancellation CAS miss"
+    svc.count_schedule_runs.assert_awaited()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## ADR-0094 terminal-status-integrity floor cluster

Fixes a cluster of run/scheduler/mirror bugs where terminal-status writes either hardcoded `"completed"`
instead of the full terminal set, or raised `TransitionRejectedError` on a redundant terminal write and
dropped the follow-on side effects. The load-bearing invariant throughout: `StateDB.update_status` CAS-miss
returns `False` silently, while a terminal-status guard raises. Every fix prefers `expected_statuses` so a
lost race is a checked no-op, never a swallowed exception.

- **Mirror reconcile** (`claude_mirror.py`): recognizes the full `SESSION_TERMINAL_STATUSES` set (not just
  `"completed"`) and reactivates via a CAS/version-guarded override, not an unguarded write.
- **Scheduler terminal writes** (`engine.py`, `scheduler_state.py`): a `_guarded_terminal_status()` helper
  makes a lost CAS race a checked no-op that still runs `_check_max_runs()` and on_success/on_fail chaining,
  instead of raising and dropping them. All terminal-write sites are converted, including the invalid-action
  invocation finalization and the cancellation `schedule_run` write.
- **Doctor atomicity** (`state.py`, `db.py`): `update_status()` gains an allowlisted `extra_fields` path so
  status and `ended_at` land in one transaction (only session `ended_at` is permitted; unknown keys rejected).
- **Teardown idempotency** (`_runs.py` `_teardown_common`): a redundant terminal write on an already-terminal
  row is a CAS-guarded idempotent no-op, not a rejected write producing avoidable audit events.
- **Linked-engine completion evidence** (`_runs.py`): the completion-trust gate counts a linked engine
  session's own progression as output evidence, fixing a phantom `completed → completed_empty` demotion.

### Review

Codex (gpt-5.5, high) reviewed and returned APPROVE: enumerated every terminal-write site in `engine.py` and
confirmed none remain unguarded that a deadline reaper could turn into a raised rejection; confirmed the
mirror full-terminal-set handling, the allowlisted `extra_fields` atomicity, and no source leak. Regression
tests added per fixed failure mode (red pre-fix, green post-fix). Backend suite green.

Rebased onto current main (post #1856). The `_teardown_common` changes in `_runs.py` reconcile cleanly with
#1856's `resolve_run_reason` SIGTERM fix in the same file (different functions, verified conflict-free at
rebase).

Resolves #1767 #1768 #1769 #1770 #1771 #1772 #1773 #1774 #1799
