### PR TITLE
fix(studio): paginate run/session detail read-path + correct message/action aggregates

### DIFF
--- a/lionagi/studio/services/runs.py
+++ b/lionagi/studio/services/runs.py
@@ -562,7 +562,12 @@ def paginate_runs(
     }
 
 
-async def get_run(run_id: str) -> dict[str, Any] | None:
+async def get_run(
+    run_id: str,
+    *,
+    message_limit: int = _sessions_svc.DEFAULT_MESSAGE_LIMIT,
+    message_cursor: str | None = None,
+) -> dict[str, Any] | None:
     """Return run detail from StateDB; flat-file run.json path was removed (write_manifest had zero callers).
 
     The response is a superset of the list Run row (via _run_row) plus detail-only
@@ -571,7 +576,9 @@ async def get_run(run_id: str) -> dict[str, Any] | None:
     Fields absent from DB (state_root, artifact_root, task, error, cwd, manifest)
     return None/""/{} to keep the frontend contract unchanged.
     """
-    session = await _sessions_svc.get_session(run_id)
+    session = await _sessions_svc.get_session(
+        run_id, message_limit=message_limit, message_cursor=message_cursor
+    )
     if session is None:
         return None
 
@@ -583,13 +590,21 @@ async def get_run(run_id: str) -> dict[str, Any] | None:
 
     state_root: Path | None = artifact_root.parent if artifact_root else None
 
-    # Branch message lists are tail-windowed pages; message_total carries the
-    # full progression length (fall back to page length for older payloads).
-    message_count = sum(
-        b.get("message_total") or len(b.get("messages") or [])
-        for b in branches
-        if isinstance(b, dict)
+    # message_stats is computed over the full session progression (never the
+    # tail-windowed branches[].messages page), so the run-level count is
+    # correct regardless of the display window. Fall back to the windowed
+    # page length only for legacy payloads that predate message_stats.
+    message_stats = (
+        session.get("message_stats") if isinstance(session.get("message_stats"), dict) else None
     )
+    if message_stats is not None:
+        message_count = message_stats.get("message_count", 0)
+    else:
+        message_count = sum(
+            b.get("message_total") or len(b.get("messages") or [])
+            for b in branches
+            if isinstance(b, dict)
+        )
     last_message_at = max(
         (
             m.get("timestamp")
@@ -630,6 +645,10 @@ async def get_run(run_id: str) -> dict[str, Any] | None:
         "graph": session.get("graph"),
         "manifest": {},
         "branches": branches,
+        "message_limit": session.get("message_limit"),
+        "message_cursor": session.get("message_cursor"),
+        "message_next_cursor": session.get("message_next_cursor"),
+        "message_stats": message_stats,
         # Failure-reason contract consumed by the run-detail panel's banner.
         "status_reason_code": session.get("status_reason_code"),
         "status_reason_summary": session.get("status_reason_summary"),
@@ -638,7 +657,14 @@ async def get_run(run_id: str) -> dict[str, Any] | None:
 
 
 def _build_steps_from_db(branches: list[dict[str, Any]]) -> list[dict[str, Any]] | None:
-    """Build a steps list from DB-hydrated branch dicts."""
+    """Build a steps list from DB-hydrated branch dicts.
+
+    `messages` on each branch is a tail-windowed display page; `message_count`
+    and `roles` must reflect the full branch progression, so they are read
+    from the branch's full-session `message_stats` (falling back to
+    `message_total` and finally the windowed page length for legacy payloads
+    that predate message_stats).
+    """
     if not branches:
         return None
     steps = []
@@ -647,19 +673,19 @@ def _build_steps_from_db(branches: list[dict[str, Any]]) -> list[dict[str, Any]]
             continue
         name = b.get("name") or b.get("agent_name") or "agent"
         messages = b.get("messages") or []
-        role_counts: dict[str, int] = {}
-        for m in messages:
-            r = m.get("role", "")
-            if r:
-                role_counts[r] = role_counts.get(r, 0) + 1
+        branch_stats = b.get("message_stats") if isinstance(b.get("message_stats"), dict) else {}
+        role_counts = dict(branch_stats.get("roles") or {})
+        message_count = int(
+            branch_stats.get("message_count") or b.get("message_total") or len(messages)
+        )
         steps.append(
             {
                 "step": name,
-                "status": "completed" if messages else "pending",
+                "status": "completed" if message_count else "pending",
                 "result": {
                     "agent": name,
                     "model": b.get("model") or "",
-                    "message_count": len(messages),
+                    "message_count": message_count,
                     "roles": role_counts,
                 },
                 "messages": messages,
@@ -705,9 +731,16 @@ async def list_run_projects_route() -> dict[str, Any]:
 
 
 @studio_route("/runs/{run_id}", method="GET", area="runs", name="get_run")
-async def get_run_route(run_id: str) -> dict[str, Any]:
+async def get_run_route(
+    run_id: str,
+    message_limit: int = Query(default=_sessions_svc.DEFAULT_MESSAGE_LIMIT, ge=1, le=1000),
+    message_cursor: str | None = Query(default=None),
+) -> dict[str, Any]:
     # get_run reads from StateDB (same source as list_runs); no thread offload needed.
-    run = await get_run(run_id)
+    try:
+        run = await get_run(run_id, message_limit=message_limit, message_cursor=message_cursor)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     if run is None:
         raise HTTPException(status_code=404, detail=f"Run '{run_id}' not found")
     return run

--- a/lionagi/studio/services/runs.py
+++ b/lionagi/studio/services/runs.py
@@ -571,8 +571,9 @@ async def get_run(
     """Return run detail from StateDB; flat-file run.json path was removed (write_manifest had zero callers).
 
     The response is a superset of the list Run row (via _run_row) plus detail-only
-    fields. get_session() omits the JOIN aggregates (branch_count / message_count /
-    last_message_at), so they are derived from the hydrated branches here.
+    fields. get_session() omits the JOIN aggregates (branch_count / message_count),
+    so they are derived from the hydrated branches here; last_message_at is read
+    straight from get_session()'s session-table aggregate.
     Fields absent from DB (state_root, artifact_root, task, error, cwd, manifest)
     return None/""/{} to keep the frontend contract unchanged.
     """
@@ -605,16 +606,22 @@ async def get_run(
             for b in branches
             if isinstance(b, dict)
         )
-    last_message_at = max(
-        (
-            m.get("timestamp")
-            for b in branches
-            if isinstance(b, dict)
-            for m in (b.get("messages") or [])
-            if isinstance(m, dict) and m.get("timestamp") is not None
-        ),
-        default=None,
-    )
+    # session["last_message_at"] is the DB-maintained full-session aggregate
+    # (bumped on every message write, see state/db.py); prefer it over
+    # recomputing from branches[].messages, which is only the display window
+    # and reports the wrong value once the caller pages to an older cursor.
+    last_message_at = session.get("last_message_at")
+    if last_message_at is None:
+        last_message_at = max(
+            (
+                m.get("timestamp")
+                for b in branches
+                if isinstance(b, dict)
+                for m in (b.get("messages") or [])
+                if isinstance(m, dict) and m.get("timestamp") is not None
+            ),
+            default=None,
+        )
 
     detail_session = {
         **session,

--- a/lionagi/studio/services/runs.py
+++ b/lionagi/studio/services/runs.py
@@ -671,6 +671,11 @@ def _build_steps_from_db(branches: list[dict[str, Any]]) -> list[dict[str, Any]]
     from the branch's full-session `message_stats` (falling back to
     `message_total` and finally the windowed page length for legacy payloads
     that predate message_stats).
+
+    The `message_stats.message_count` fallback is KEY-PRESENCE based, not
+    truthiness based: a stale progression referencing pruned/never-persisted
+    message ids legitimately aggregates to 0, and `0 or fallback` would
+    silently replace that correct zero with the (wrong) progression length.
     """
     if not branches:
         return None
@@ -682,9 +687,11 @@ def _build_steps_from_db(branches: list[dict[str, Any]]) -> list[dict[str, Any]]
         messages = b.get("messages") or []
         branch_stats = b.get("message_stats") if isinstance(b.get("message_stats"), dict) else {}
         role_counts = dict(branch_stats.get("roles") or {})
-        message_count = int(
-            branch_stats.get("message_count") or b.get("message_total") or len(messages)
-        )
+        if "message_count" in branch_stats:
+            message_count = branch_stats["message_count"]
+        else:
+            message_count = b.get("message_total") or len(messages)
+        message_count = int(message_count)
         steps.append(
             {
                 "step": name,

--- a/lionagi/studio/services/sessions.py
+++ b/lionagi/studio/services/sessions.py
@@ -281,6 +281,25 @@ def _window_message_ids(
     return window_ids, has_older, next_anchor
 
 
+def _short_lion_class(lion_class: str) -> str:
+    """Strip a fully-qualified lion_class path down to its bare class name.
+
+    Persisted rows carry the canonical dotted path (see message_types seed data
+    in state/schema.sql), e.g. 'lionagi.protocols.messages.action_request.ActionRequest';
+    older/legacy rows may carry just 'ActionRequest'. Compare on the short form so both
+    shapes match.
+    """
+    return lion_class.rsplit(".", 1)[-1] if lion_class else lion_class
+
+
+_ACTION_LION_CLASSES = (
+    "lionagi.protocols.messages.action_request.ActionRequest",
+    "lionagi.protocols.messages.action_response.ActionResponse",
+    "ActionRequest",
+    "ActionResponse",
+)
+
+
 def _init_message_stats() -> dict[str, Any]:
     return {
         "message_count": 0,
@@ -344,10 +363,13 @@ async def _fetch_action_messages(
 
     Tool/error/file aggregates only ever need these two message kinds; skipping every
     other message keeps the full-session aggregate pass cheap regardless of session size.
+    Matches both the canonical fully-qualified lion_class paths persisted by the runtime
+    (state/schema.sql message_types seed) and legacy short-name values.
     """
     if not msg_ids:
         return []
     rows_by_id: dict[str, dict[str, Any]] = {}
+    class_placeholders = ",".join("?" for _ in _ACTION_LION_CLASSES)
     for chunk_start in range(0, len(msg_ids), 500):
         chunk = msg_ids[chunk_start : chunk_start + 500]
         placeholders = ",".join("?" for _ in chunk)
@@ -357,9 +379,9 @@ async def _fetch_action_messages(
                    mt.lion_class AS lion_class_str
             FROM messages m
             JOIN message_types mt ON m.lion_class = mt.type_id
-            WHERE m.id IN ({placeholders}) AND mt.lion_class IN ('ActionRequest', 'ActionResponse')
+            WHERE m.id IN ({placeholders}) AND mt.lion_class IN ({class_placeholders})
             """,  # noqa: S608
-            chunk,
+            [*chunk, *_ACTION_LION_CLASSES],
         )
         for row in await cur.fetchall():
             rows_by_id[row["id"]] = _format_message(row)
@@ -379,7 +401,9 @@ def _branch_message_stats(
     from .runs import _detect_status
 
     response_by_id: dict[str, dict[str, Any]] = {
-        m["id"]: m for m in action_messages if m.get("lion_class") == "ActionResponse"
+        m["id"]: m
+        for m in action_messages
+        if _short_lion_class(m.get("lion_class", "")) == "ActionResponse"
     }
 
     tool_call_count = 0
@@ -387,7 +411,7 @@ def _branch_message_stats(
     errors: list[dict[str, Any]] = []
     files: set[str] = set()
     for m in action_messages:
-        if m.get("lion_class") != "ActionRequest":
+        if _short_lion_class(m.get("lion_class", "")) != "ActionRequest":
             continue
 
         content = m.get("content") if isinstance(m.get("content"), dict) else {}
@@ -529,7 +553,11 @@ async def get_session(
 
             role_counts = await _fetch_role_counts(db, full_msg_ids)
             action_messages = await _fetch_action_messages(db, full_msg_ids)
-            branch_stats = _branch_message_stats(message_total, role_counts, action_messages)
+            # message_count is the DB role-aggregate, not the progression length
+            # (message_total): a progression can reference ids whose message row
+            # was never persisted (or was pruned), so the two can diverge.
+            message_count = sum(role_counts.values())
+            branch_stats = _branch_message_stats(message_count, role_counts, action_messages)
 
             full_stats["message_count"] += branch_stats["message_count"]
             for role, count in branch_stats["roles"].items():

--- a/lionagi/studio/services/sessions.py
+++ b/lionagi/studio/services/sessions.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import time
 from typing import Any
 
 import aiosqlite
+from fastapi import HTTPException
 
 from lionagi._errors import NotFoundError
 from lionagi.state.db import DEFAULT_DB_PATH, SESSION_TERMINAL_STATUSES
@@ -215,17 +217,180 @@ DEFAULT_MESSAGE_LIMIT = 200
 MAX_MESSAGE_LIMIT = 1000
 
 
+class MessageCursorError(ValueError):
+    """A message_cursor is malformed, session-mismatched, or references a stale anchor."""
+
+
+def _encode_message_cursor(session_id: str, limit: int, branch_anchors: dict[str, str]) -> str:
+    payload = {"v": 1, "session_id": session_id, "limit": limit, "branch_anchors": branch_anchors}
+    raw = json.dumps(payload, separators=(",", ":")).encode()
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def _decode_message_cursor(token: str, *, session_id: str, limit: int) -> dict[str, str]:
+    try:
+        padded = token + "=" * (-len(token) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(padded.encode()))
+    except Exception as exc:
+        raise MessageCursorError(f"Malformed message_cursor: {token!r}") from exc
+    if not isinstance(payload, dict) or payload.get("v") != 1:
+        raise MessageCursorError(f"Unsupported message_cursor: {token!r}")
+    if payload.get("session_id") != session_id:
+        raise MessageCursorError("message_cursor belongs to a different session")
+    if payload.get("limit") != limit:
+        raise MessageCursorError("message_cursor does not match message_limit")
+    anchors = payload.get("branch_anchors")
+    if not isinstance(anchors, dict):
+        raise MessageCursorError("message_cursor is missing branch_anchors")
+    return anchors
+
+
+def _window_message_ids(
+    msg_ids: list[str],
+    *,
+    branch_id: str,
+    limit: int,
+    cursor_anchors: dict[str, str] | None,
+    legacy_offset: int,
+) -> tuple[list[str], bool, str | None]:
+    """Return (window_ids, has_older, next_anchor) for one branch's progression.
+
+    `cursor_anchors` is None when the caller passed no message_cursor at all; an
+    empty-of-this-branch cursor (branch id absent from the map) means the prior
+    page already reached this branch's oldest message, so it yields nothing more.
+    """
+    if cursor_anchors is not None:
+        anchor = cursor_anchors.get(branch_id)
+        if anchor is None:
+            return [], False, None
+        if anchor not in msg_ids:
+            raise MessageCursorError(
+                f"message_cursor anchor not found in branch {branch_id!r} progression"
+            )
+        end = msg_ids.index(anchor)
+    elif legacy_offset:
+        total = len(msg_ids)
+        end = max(0, total - legacy_offset)
+    else:
+        end = len(msg_ids)
+
+    start = max(0, end - limit)
+    window_ids = msg_ids[start:end]
+    has_older = start > 0
+    next_anchor = window_ids[0] if has_older and window_ids else None
+    return window_ids, has_older, next_anchor
+
+
+def _init_message_stats() -> dict[str, Any]:
+    return {
+        "message_count": 0,
+        "roles": {},
+        "branches": {},
+        "tool_call_count": 0,
+        "error_count": 0,
+        "errors": [],
+        "files": [],
+    }
+
+
+async def _fetch_messages_by_ids(
+    db: aiosqlite.Connection, msg_ids: list[str]
+) -> list[dict[str, Any]]:
+    """Hydrate message rows for msg_ids, chunked to stay under SQLite's bound-variable limit."""
+    if not msg_ids:
+        return []
+    rows_by_id: dict[str, dict[str, Any]] = {}
+    for chunk_start in range(0, len(msg_ids), 500):
+        chunk = msg_ids[chunk_start : chunk_start + 500]
+        placeholders = ",".join("?" for _ in chunk)
+        cur = await db.execute(
+            f"""
+            SELECT m.id, m.created_at, m.content, m.sender, m.role,
+                   mt.lion_class AS lion_class_str
+            FROM messages m
+            LEFT JOIN message_types mt ON m.lion_class = mt.type_id
+            WHERE m.id IN ({placeholders})
+            """,  # noqa: S608
+            chunk,
+        )
+        for row in await cur.fetchall():
+            rows_by_id[row["id"]] = _format_message(row)
+    return [rows_by_id[mid] for mid in msg_ids if mid in rows_by_id]
+
+
+def _branch_message_stats(messages: list[dict[str, Any]]) -> dict[str, Any]:
+    """Full-branch stats computed over every message in the progression, never a display window."""
+    from .runs import _detect_status
+
+    roles: dict[str, int] = {}
+    response_by_id: dict[str, dict[str, Any]] = {
+        m["id"]: m for m in messages if m.get("lion_class") == "ActionResponse"
+    }
+
+    tool_call_count = 0
+    error_count = 0
+    errors: list[dict[str, Any]] = []
+    files: set[str] = set()
+    for m in messages:
+        role = m.get("role") or ""
+        if role:
+            roles[role] = roles.get(role, 0) + 1
+        if m.get("lion_class") != "ActionRequest":
+            continue
+
+        content = m.get("content") if isinstance(m.get("content"), dict) else {}
+        tool_call_count += 1
+        function = content.get("function") or ""
+        arguments = content.get("arguments")
+        arguments = arguments if isinstance(arguments, dict) else {}
+        file_path = arguments.get("file_path") or arguments.get("path")
+        if isinstance(file_path, str) and file_path:
+            files.add(file_path)
+
+        response_id = content.get("action_response_id")
+        response_msg = response_by_id.get(response_id) if response_id else None
+        output_text = ""
+        if response_msg and isinstance(response_msg.get("content"), dict):
+            output_text = str(response_msg["content"].get("output", ""))
+        status, _exit_code = _detect_status(output_text, function)
+        if status == "error":
+            error_count += 1
+            errors.append(
+                {
+                    "function": function,
+                    "sender": m.get("sender", ""),
+                    "timestamp": m.get("timestamp"),
+                    "output": output_text,
+                }
+            )
+
+    return {
+        "message_count": len(messages),
+        "roles": roles,
+        "tool_call_count": tool_call_count,
+        "error_count": error_count,
+        "errors": errors,
+        "files": sorted(files),
+    }
+
+
 async def get_session(
     session_id: str,
     *,
     message_limit: int = DEFAULT_MESSAGE_LIMIT,
     message_offset: int = 0,
+    message_cursor: str | None = None,
 ) -> dict[str, Any] | None:
     if not DEFAULT_DB_PATH.exists():
         return None
 
     message_limit = max(1, min(message_limit, MAX_MESSAGE_LIMIT))
     message_offset = max(0, message_offset)
+    cursor_anchors = (
+        _decode_message_cursor(message_cursor, session_id=session_id, limit=message_limit)
+        if message_cursor
+        else None
+    )
 
     async with _open_db(_DB) as db:
         cur = await db.execute(
@@ -274,8 +439,11 @@ async def get_session(
         branch_rows = await branch_cur.fetchall()
 
         branches = []
+        full_stats = _init_message_stats()
+        next_branch_anchors: dict[str, str] = {}
         for br in branch_rows:
-            messages = []
+            branch_id = br["id"]
+            full_msg_ids: list[str] = []
             message_total = 0
             prog_id = br["progression_id"]
             if prog_id:
@@ -286,44 +454,54 @@ async def get_session(
                 prog_row = await prog_cur.fetchone()
                 if prog_row and prog_row["collection"]:
                     try:
-                        msg_ids = json.loads(prog_row["collection"])
+                        full_msg_ids = json.loads(prog_row["collection"])
                     except (json.JSONDecodeError, TypeError):
-                        msg_ids = []
+                        full_msg_ids = []
+                    message_total = len(full_msg_ids)
 
-                    message_total = len(msg_ids)
-                    # Window from the tail: offset 0 = the newest page,
-                    # each page further back prepends older history.
-                    if message_offset:
-                        end = max(0, message_total - message_offset)
-                        msg_ids = msg_ids[max(0, end - message_limit) : end]
-                    else:
-                        msg_ids = msg_ids[-message_limit:]
+            # Window from the tail: offset/cursor 0 = the newest page,
+            # each page further back prepends older history.
+            window_ids, has_older, next_anchor = _window_message_ids(
+                full_msg_ids,
+                branch_id=branch_id,
+                limit=message_limit,
+                cursor_anchors=cursor_anchors,
+                legacy_offset=message_offset if cursor_anchors is None else 0,
+            )
+            if next_anchor:
+                next_branch_anchors[branch_id] = next_anchor
 
-                    if msg_ids:
-                        placeholders = ",".join("?" for _ in msg_ids)
-                        msg_cur = await db.execute(
-                            f"""
-                            SELECT m.id, m.created_at, m.content, m.sender, m.role,
-                                   mt.lion_class AS lion_class_str
-                            FROM messages m
-                            LEFT JOIN message_types mt ON m.lion_class = mt.type_id
-                            WHERE m.id IN ({placeholders})
-                            """,  # noqa: S608
-                            msg_ids,
-                        )
-                        msg_rows = await msg_cur.fetchall()
-                        by_id = {r["id"]: _format_message(r) for r in msg_rows}
-                        messages = [by_id[mid] for mid in msg_ids if mid in by_id]
+            all_messages = await _fetch_messages_by_ids(db, full_msg_ids)
+            by_id = {m["id"]: m for m in all_messages}
+            messages = [by_id[mid] for mid in window_ids if mid in by_id]
+            branch_stats = _branch_message_stats(all_messages)
+
+            full_stats["message_count"] += branch_stats["message_count"]
+            for role, count in branch_stats["roles"].items():
+                full_stats["roles"][role] = full_stats["roles"].get(role, 0) + count
+            full_stats["branches"][branch_id] = {
+                "message_count": branch_stats["message_count"],
+                "roles": branch_stats["roles"],
+            }
+            full_stats["tool_call_count"] += branch_stats["tool_call_count"]
+            full_stats["error_count"] += branch_stats["error_count"]
+            full_stats["errors"].extend(branch_stats["errors"])
+            full_stats["files"].extend(branch_stats["files"])
 
             br_keys = br.keys()
             branches.append(
                 {
-                    "id": br["id"],
+                    "id": branch_id,
                     "name": br["name"],
                     "created_at": br["created_at"],
                     "messages": messages,
                     "message_total": message_total,
                     "message_offset": message_offset,
+                    "message_limit": message_limit,
+                    "message_window_count": len(messages),
+                    "messages_truncated": message_total > len(messages),
+                    "message_has_older": has_older,
+                    "message_stats": full_stats["branches"][branch_id],
                     "model": br["model"],
                     "provider": br["provider"],
                     "agent_name": br["agent_name"],
@@ -332,6 +510,13 @@ async def get_session(
                     "ended_at": br["ended_at"] if "ended_at" in br_keys else None,
                 }
             )
+
+        full_stats["files"] = sorted(set(full_stats["files"]))
+        message_next_cursor = (
+            _encode_message_cursor(session_id, message_limit, next_branch_anchors)
+            if next_branch_anchors
+            else None
+        )
 
     started_at = session_row["started_at"]
     ended_at = session_row["ended_at"]
@@ -359,6 +544,10 @@ async def get_session(
         "duration_ms": duration_ms,
         "source_show": source_show,
         "branches": branches,
+        "message_limit": message_limit,
+        "message_cursor": message_cursor,
+        "message_next_cursor": message_next_cursor,
+        "message_stats": full_stats,
         # ADR-0022: provenance disclosure — same fields exposed on list_sessions().
         "model": session_row["model"],
         "provider": session_row["provider"],
@@ -499,10 +688,17 @@ async def get_session_route(
     session_id: str,
     message_limit: int = DEFAULT_MESSAGE_LIMIT,
     message_offset: int = 0,
+    message_cursor: str | None = None,
 ) -> dict[str, Any]:
-    session = await get_session(
-        session_id, message_limit=message_limit, message_offset=message_offset
-    )
+    try:
+        session = await get_session(
+            session_id,
+            message_limit=message_limit,
+            message_offset=message_offset,
+            message_cursor=message_cursor,
+        )
+    except MessageCursorError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     if session is None:
         raise NotFoundError(f"Session '{session_id}' not found")
     return session

--- a/lionagi/studio/services/sessions.py
+++ b/lionagi/studio/services/sessions.py
@@ -318,23 +318,75 @@ async def _fetch_messages_by_ids(
     return [rows_by_id[mid] for mid in msg_ids if mid in rows_by_id]
 
 
-def _branch_message_stats(messages: list[dict[str, Any]]) -> dict[str, Any]:
-    """Full-branch stats computed over every message in the progression, never a display window."""
+async def _fetch_role_counts(db: aiosqlite.Connection, msg_ids: list[str]) -> dict[str, int]:
+    """Role histogram over msg_ids via SQL GROUP BY — no message content is hydrated."""
+    counts: dict[str, int] = {}
+    if not msg_ids:
+        return counts
+    for chunk_start in range(0, len(msg_ids), 500):
+        chunk = msg_ids[chunk_start : chunk_start + 500]
+        placeholders = ",".join("?" for _ in chunk)
+        cur = await db.execute(
+            f"SELECT role, COUNT(*) AS n FROM messages WHERE id IN ({placeholders}) GROUP BY role",  # noqa: S608
+            chunk,
+        )
+        for row in await cur.fetchall():
+            role = row["role"] or ""
+            if role:
+                counts[role] = counts.get(role, 0) + row["n"]
+    return counts
+
+
+async def _fetch_action_messages(
+    db: aiosqlite.Connection, msg_ids: list[str]
+) -> list[dict[str, Any]]:
+    """Hydrate only the ActionRequest/ActionResponse rows among msg_ids, in progression order.
+
+    Tool/error/file aggregates only ever need these two message kinds; skipping every
+    other message keeps the full-session aggregate pass cheap regardless of session size.
+    """
+    if not msg_ids:
+        return []
+    rows_by_id: dict[str, dict[str, Any]] = {}
+    for chunk_start in range(0, len(msg_ids), 500):
+        chunk = msg_ids[chunk_start : chunk_start + 500]
+        placeholders = ",".join("?" for _ in chunk)
+        cur = await db.execute(
+            f"""
+            SELECT m.id, m.created_at, m.content, m.sender, m.role,
+                   mt.lion_class AS lion_class_str
+            FROM messages m
+            JOIN message_types mt ON m.lion_class = mt.type_id
+            WHERE m.id IN ({placeholders}) AND mt.lion_class IN ('ActionRequest', 'ActionResponse')
+            """,  # noqa: S608
+            chunk,
+        )
+        for row in await cur.fetchall():
+            rows_by_id[row["id"]] = _format_message(row)
+    return [rows_by_id[mid] for mid in msg_ids if mid in rows_by_id]
+
+
+def _branch_message_stats(
+    message_count: int,
+    roles: dict[str, int],
+    action_messages: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Full-branch stats computed over the full progression, never a display window.
+
+    `message_count`/`roles` come from SQL aggregates; `action_messages` holds only the
+    ActionRequest/ActionResponse rows, since tool/error/file summaries never need anything else.
+    """
     from .runs import _detect_status
 
-    roles: dict[str, int] = {}
     response_by_id: dict[str, dict[str, Any]] = {
-        m["id"]: m for m in messages if m.get("lion_class") == "ActionResponse"
+        m["id"]: m for m in action_messages if m.get("lion_class") == "ActionResponse"
     }
 
     tool_call_count = 0
     error_count = 0
     errors: list[dict[str, Any]] = []
     files: set[str] = set()
-    for m in messages:
-        role = m.get("role") or ""
-        if role:
-            roles[role] = roles.get(role, 0) + 1
+    for m in action_messages:
         if m.get("lion_class") != "ActionRequest":
             continue
 
@@ -365,7 +417,7 @@ def _branch_message_stats(messages: list[dict[str, Any]]) -> dict[str, Any]:
             )
 
     return {
-        "message_count": len(messages),
+        "message_count": message_count,
         "roles": roles,
         "tool_call_count": tool_call_count,
         "error_count": error_count,
@@ -400,7 +452,7 @@ async def get_session(
                       playbook_name, agent_name, invocation_kind,
                       show_topic, show_play_name, artifacts_path,
                       artifact_contract_json, artifact_verification_json,
-                      source_kind, status, started_at, ended_at,
+                      source_kind, status, started_at, ended_at, last_message_at,
                       model, provider, effort, agent_hash, invocation_id,
                       node_metadata, project, project_source,
                       status_reason_code, status_reason_summary, status_evidence_refs
@@ -471,10 +523,13 @@ async def get_session(
             if next_anchor:
                 next_branch_anchors[branch_id] = next_anchor
 
-            all_messages = await _fetch_messages_by_ids(db, full_msg_ids)
-            by_id = {m["id"]: m for m in all_messages}
+            window_messages = await _fetch_messages_by_ids(db, window_ids)
+            by_id = {m["id"]: m for m in window_messages}
             messages = [by_id[mid] for mid in window_ids if mid in by_id]
-            branch_stats = _branch_message_stats(all_messages)
+
+            role_counts = await _fetch_role_counts(db, full_msg_ids)
+            action_messages = await _fetch_action_messages(db, full_msg_ids)
+            branch_stats = _branch_message_stats(message_total, role_counts, action_messages)
 
             full_stats["message_count"] += branch_stats["message_count"]
             for role, count in branch_stats["roles"].items():
@@ -542,6 +597,8 @@ async def get_session(
         "started_at": started_at,
         "ended_at": ended_at,
         "duration_ms": duration_ms,
+        # ADR-0019: full-session aggregate, not derived from the windowed page.
+        "last_message_at": session_row["last_message_at"],
         "source_show": source_show,
         "branches": branches,
         "message_limit": message_limit,

--- a/tests/apps_studio_server/test_runs_detail.py
+++ b/tests/apps_studio_server/test_runs_detail.py
@@ -584,6 +584,28 @@ async def test_build_steps_from_db_uses_full_branch_stats_for_windowed_messages(
     assert step["result"]["roles"] == {"user": 103, "assistant": 102}
 
 
+async def test_build_steps_from_db_zero_db_aggregate_is_not_swallowed_by_progression_length(
+    patched_runs_svc,
+):
+    """A stale progression referencing pruned/never-persisted message ids aggregates to a
+    real DB message_count of 0; the step result must report that 0, not fall back to the
+    (larger, wrong) progression length via a truthiness `x or y` check."""
+    svc, db_path = patched_runs_svc
+    sid = str(uuid.uuid4())
+    branch_id = f"{sid}-br"
+    await seed_session(db_path, session_id=sid, status="completed")
+    # Progression references two ids; neither was ever persisted as a message row.
+    await seed_branch(db_path, branch_id=branch_id, session_id=sid, msg_ids=["stale-0", "stale-1"])
+
+    result = await svc.get_run(sid)
+
+    assert result is not None
+    branch = result["branches"][0]
+    assert branch["message_total"] == 2  # progression length, kept separate
+    step = result["steps"][0]
+    assert step["result"]["message_count"] == 0  # real DB aggregate, not progression length
+
+
 async def test_get_run_last_message_at_reflects_full_session_not_windowed_page(patched_runs_svc):
     """Regression: last_message_at must report the session's newest message timestamp
     regardless of which page of messages the caller is currently viewing, not the max

--- a/tests/apps_studio_server/test_runs_detail.py
+++ b/tests/apps_studio_server/test_runs_detail.py
@@ -584,6 +584,47 @@ async def test_build_steps_from_db_uses_full_branch_stats_for_windowed_messages(
     assert step["result"]["roles"] == {"user": 103, "assistant": 102}
 
 
+async def test_get_run_last_message_at_reflects_full_session_not_windowed_page(patched_runs_svc):
+    """Regression: last_message_at must report the session's newest message timestamp
+    regardless of which page of messages the caller is currently viewing, not the max
+    timestamp within the current display window."""
+    svc, db_path = patched_runs_svc
+    sid = str(uuid.uuid4())
+    branch_id = f"{sid}-br"
+    await seed_session(db_path, session_id=sid, status="completed")
+    msg_ids = [f"{branch_id}-msg-{i}" for i in range(10)]
+    await seed_branch(db_path, branch_id=branch_id, session_id=sid, msg_ids=msg_ids)
+    async with StateDB(db_path) as db:
+        for i, mid in enumerate(msg_ids):
+            await db.insert_message(
+                {
+                    "id": mid,
+                    "created_at": float(i),
+                    "content": {"text": f"m{i}"},
+                    "sender": "worker",
+                    "recipient": "user",
+                    "role": "assistant" if i % 2 else "user",
+                    "node_metadata": {},
+                }
+            )
+            await db.touch_session_activity(sid, at=float(i))
+
+    page1 = await svc.get_run(sid, message_limit=3, message_cursor=None)
+    assert page1 is not None
+    branch1 = page1["branches"][0]
+    assert [m["id"] for m in branch1["messages"]] == [f"{branch_id}-msg-{i}" for i in (7, 8, 9)]
+    assert page1["last_message_at"] == 9.0
+
+    cursor = page1["message_next_cursor"]
+    assert cursor
+
+    page2 = await svc.get_run(sid, message_limit=3, message_cursor=cursor)
+    assert page2 is not None
+    branch2 = page2["branches"][0]
+    assert [m["id"] for m in branch2["messages"]] == [f"{branch_id}-msg-{i}" for i in (4, 5, 6)]
+    assert page2["last_message_at"] == 9.0
+
+
 async def test_get_run_route_accepts_message_cursor_and_limit(patched_runs_svc):
     svc, db_path = patched_runs_svc
     sid = str(uuid.uuid4())

--- a/tests/apps_studio_server/test_runs_detail.py
+++ b/tests/apps_studio_server/test_runs_detail.py
@@ -447,3 +447,159 @@ async def test_get_run_zombie_recorded_pid_reports_stale(patched_runs_svc, monke
     result = await svc.get_run(sid)
     assert result is not None
     assert result["effective_health"] == "stale"
+
+
+# ---------------------------------------------------------------------------
+# get_run() / _build_steps_from_db() over the default 200-message window
+# ---------------------------------------------------------------------------
+
+
+async def seed_over_limit_branch(
+    db_path: Path,
+    *,
+    session_id: str,
+    branch_id: str,
+    count: int = 205,
+    action_pair_at: tuple[int, int] | None = None,
+    file_path: str = "",
+    error_output: str = "",
+) -> list[str]:
+    """Seed one branch with `count` messages, alternating user/assistant roles.
+
+    When `action_pair_at` is given as (request_index, response_index), those
+    two positions hold a paired ActionRequest/ActionResponse instead of a
+    plain message, carrying `file_path` and `error_output`.
+    """
+    msg_ids = [f"{branch_id}-msg-{i}" for i in range(count)]
+    await seed_branch(db_path, branch_id=branch_id, session_id=session_id, msg_ids=msg_ids)
+    async with StateDB(db_path) as db:
+        for i, mid in enumerate(msg_ids):
+            if action_pair_at and i == action_pair_at[0]:
+                await db.insert_message(
+                    {
+                        "id": mid,
+                        "created_at": 100.0 + i,
+                        "content": {
+                            "function": "Write",
+                            "arguments": {"file_path": file_path},
+                            "action_response_id": msg_ids[action_pair_at[1]],
+                        },
+                        "sender": "worker",
+                        "recipient": "user",
+                        "role": "action",
+                        "node_metadata": {"lion_class": "ActionRequest"},
+                    }
+                )
+            elif action_pair_at and i == action_pair_at[1]:
+                await db.insert_message(
+                    {
+                        "id": mid,
+                        "created_at": 100.0 + i,
+                        "content": {"function": "Write", "output": error_output},
+                        "sender": "worker",
+                        "recipient": "user",
+                        "role": "action",
+                        "node_metadata": {"lion_class": "ActionResponse"},
+                    }
+                )
+            else:
+                await db.insert_message(
+                    {
+                        "id": mid,
+                        "created_at": 100.0 + i,
+                        "content": {"text": f"m{i}"},
+                        "sender": "worker",
+                        "recipient": "user",
+                        "role": "assistant" if i % 2 else "user",
+                        "node_metadata": {},
+                    }
+                )
+    return msg_ids
+
+
+async def test_get_run_over_limit_session_uses_full_counts_and_window_metadata(patched_runs_svc):
+    svc, db_path = patched_runs_svc
+    sid = str(uuid.uuid4())
+    await seed_session(db_path, session_id=sid, status="completed")
+    await seed_over_limit_branch(db_path, session_id=sid, branch_id=f"{sid}-br", count=205)
+
+    result = await svc.get_run(sid)
+
+    assert result is not None
+    branch = result["branches"][0]
+    assert result["message_count"] == 205
+    assert branch["message_total"] == 205
+    assert branch["message_window_count"] == 200
+    assert branch["messages_truncated"] is True
+    assert branch["message_has_older"] is True
+    assert len(branch["messages"]) == 200
+    assert result["message_next_cursor"]
+    assert result["message_stats"]["message_count"] == 205
+
+
+async def test_get_run_over_limit_session_computes_full_aggregates_from_all_messages(
+    patched_runs_svc,
+):
+    svc, db_path = patched_runs_svc
+    sid = str(uuid.uuid4())
+    branch_id = f"{sid}-br"
+    await seed_session(db_path, session_id=sid, status="completed")
+    # The action pair sits at the oldest two positions, outside the newest-200 window.
+    await seed_over_limit_branch(
+        db_path,
+        session_id=sid,
+        branch_id=branch_id,
+        count=205,
+        action_pair_at=(0, 1),
+        file_path="/tmp/outside_window.txt",
+        error_output="process exited with code 1.",
+    )
+
+    result = await svc.get_run(sid)
+
+    assert result is not None
+    stats = result["message_stats"]
+    assert stats["tool_call_count"] == 1
+    assert stats["error_count"] == 1
+    assert "/tmp/outside_window.txt" in stats["files"]
+    assert any(e["output"] == "process exited with code 1." for e in stats["errors"])
+
+    branch = result["branches"][0]
+    window_ids = {m["id"] for m in branch["messages"]}
+    assert f"{branch_id}-msg-0" not in window_ids
+    assert f"{branch_id}-msg-1" not in window_ids
+
+
+async def test_build_steps_from_db_uses_full_branch_stats_for_windowed_messages(patched_runs_svc):
+    svc, db_path = patched_runs_svc
+    sid = str(uuid.uuid4())
+    await seed_session(db_path, session_id=sid, status="completed")
+    await seed_over_limit_branch(db_path, session_id=sid, branch_id=f"{sid}-br", count=205)
+
+    result = await svc.get_run(sid)
+
+    assert result is not None
+    step = result["steps"][0]
+    assert step["result"]["message_count"] == 205
+    assert step["result"]["roles"] == {"user": 103, "assistant": 102}
+
+
+async def test_get_run_route_accepts_message_cursor_and_limit(patched_runs_svc):
+    svc, db_path = patched_runs_svc
+    sid = str(uuid.uuid4())
+    await seed_session(db_path, session_id=sid, status="completed")
+    await seed_over_limit_branch(db_path, session_id=sid, branch_id=f"{sid}-br", count=205)
+
+    page1 = await svc.get_run_route(sid, message_limit=3, message_cursor=None)
+    assert len(page1["branches"][0]["messages"]) == 3
+    cursor = page1["message_next_cursor"]
+    assert cursor
+
+    page2 = await svc.get_run_route(sid, message_limit=3, message_cursor=cursor)
+    ids1 = {m["id"] for m in page1["branches"][0]["messages"]}
+    ids2 = {m["id"] for m in page2["branches"][0]["messages"]}
+    assert ids1.isdisjoint(ids2)
+
+    with pytest.raises(fastapi.HTTPException) as exc_info:
+        await svc.get_run_route(sid, message_limit=3, message_cursor="not-a-valid-cursor")
+    assert exc_info.value.status_code == 400

--- a/tests/apps_studio_server/test_sessions_detail.py
+++ b/tests/apps_studio_server/test_sessions_detail.py
@@ -750,3 +750,87 @@ async def test_get_session_limit_clamped_to_max(patched_sessions_db):
     branch = result["branches"][0]
     assert len(branch["messages"]) == 5
     assert branch["message_total"] == 5
+
+
+# ---------------------------------------------------------------------------
+# message_cursor — stable pagination under concurrent progression appends
+# ---------------------------------------------------------------------------
+
+
+async def test_get_session_cursor_pages_are_stable_under_concurrent_appends(patched_sessions_db):
+    svc, db_path = patched_sessions_db
+    msg_ids = await seed_paginated_session(db_path, count=10)
+
+    page1 = await svc.get_session("sess-paged", message_limit=3)
+    branch1 = page1["branches"][0]
+    assert [m["id"] for m in branch1["messages"]] == ["pmsg-7", "pmsg-8", "pmsg-9"]
+    assert branch1["messages_truncated"] is True
+    cursor = page1["message_next_cursor"]
+    assert cursor
+
+    # Concurrent writer appends two more messages to the live tail while the
+    # cursor from page 1 is still in flight.
+    new_ids = ["pmsg-10", "pmsg-11"]
+    async with StateDB(db_path) as db:
+        for i, mid in enumerate(new_ids, start=len(msg_ids)):
+            await db.insert_message(
+                {
+                    "id": mid,
+                    "created_at": 100.0 + i,
+                    "content": {"text": f"m{i}"},
+                    "sender": "worker",
+                    "recipient": "user",
+                    "role": "assistant",
+                    "node_metadata": {},
+                }
+            )
+            await db.append_to_progression("br-paged-prog", mid)
+
+    page2 = await svc.get_session("sess-paged", message_limit=3, message_cursor=cursor)
+    branch2 = page2["branches"][0]
+    assert [m["id"] for m in branch2["messages"]] == ["pmsg-4", "pmsg-5", "pmsg-6"]
+
+    ids1 = {m["id"] for m in branch1["messages"]}
+    ids2 = {m["id"] for m in branch2["messages"]}
+    assert ids1.isdisjoint(ids2), "cursor page must not duplicate rows from the tail page"
+    combined = ids1 | ids2
+    assert combined == {f"pmsg-{i}" for i in range(4, 10)}, (
+        "combined two-page slice must not skip any expected id"
+    )
+
+
+async def test_get_session_rejects_invalid_message_cursor(patched_sessions_db):
+    svc, db_path = patched_sessions_db
+    await seed_paginated_session(db_path, count=10)
+
+    with pytest.raises(svc.MessageCursorError):
+        await svc.get_session("sess-paged", message_limit=3, message_cursor="not-a-valid-cursor")
+
+
+async def test_get_session_rejects_cursor_from_a_different_session(patched_sessions_db):
+    svc, db_path = patched_sessions_db
+    await seed_paginated_session(db_path, count=10)
+    await seed_session(db_path, session_id="sess-other")
+    await seed_branch(
+        db_path, branch_id="br-other", session_id="sess-other", msg_ids=["om-0", "om-1"]
+    )
+    async with StateDB(db_path) as db:
+        for i, mid in enumerate(["om-0", "om-1"]):
+            await db.insert_message(
+                {
+                    "id": mid,
+                    "created_at": 50.0 + i,
+                    "content": {"text": f"m{i}"},
+                    "sender": "worker",
+                    "recipient": "user",
+                    "role": "user",
+                    "node_metadata": {},
+                }
+            )
+
+    other_page = await svc.get_session("sess-other", message_limit=1)
+    foreign_cursor = other_page["message_next_cursor"]
+    assert foreign_cursor
+
+    with pytest.raises(svc.MessageCursorError):
+        await svc.get_session("sess-paged", message_limit=1, message_cursor=foreign_cursor)

--- a/tests/apps_studio_server/test_sessions_detail.py
+++ b/tests/apps_studio_server/test_sessions_detail.py
@@ -858,3 +858,95 @@ async def test_get_session_rejects_cursor_from_a_different_session(patched_sessi
 
     with pytest.raises(svc.MessageCursorError):
         await svc.get_session("sess-paged", message_limit=1, message_cursor=foreign_cursor)
+
+
+# ---------------------------------------------------------------------------
+# Action-stat aggregation must match the canonical persisted lion_class values
+# ---------------------------------------------------------------------------
+
+
+async def test_get_session_action_stats_match_canonical_fully_qualified_lion_class(
+    patched_sessions_db,
+):
+    """The runtime persists lion_class as the fully-qualified dotted path (see the
+    message_types seed rows in state/schema.sql), not the bare class name. Tool/error/
+    file aggregation must recognize that shape, not just a legacy short name."""
+    svc, db_path = patched_sessions_db
+    await seed_session(db_path, session_id="sess-canonical", status="completed")
+    msg_ids = ["req-0", "resp-0"]
+    await seed_branch(
+        db_path, branch_id="br-canonical", session_id="sess-canonical", msg_ids=msg_ids
+    )
+    async with StateDB(db_path) as db:
+        await db.insert_message(
+            {
+                "id": "req-0",
+                "created_at": 100.0,
+                "content": {
+                    "function": "Write",
+                    "arguments": {"file_path": "/tmp/canonical.txt"},
+                    "action_response_id": "resp-0",
+                },
+                "sender": "worker",
+                "recipient": "user",
+                "role": "action",
+                "node_metadata": {
+                    "lion_class": "lionagi.protocols.messages.action_request.ActionRequest"
+                },
+            }
+        )
+        await db.insert_message(
+            {
+                "id": "resp-0",
+                "created_at": 101.0,
+                "content": {"function": "Write", "output": "process exited with code 1."},
+                "sender": "worker",
+                "recipient": "user",
+                "role": "action",
+                "node_metadata": {
+                    "lion_class": "lionagi.protocols.messages.action_response.ActionResponse"
+                },
+            }
+        )
+
+    result = await svc.get_session("sess-canonical")
+
+    stats = result["message_stats"]
+    assert stats["tool_call_count"] == 1
+    assert stats["error_count"] == 1
+    assert "/tmp/canonical.txt" in stats["files"]
+
+
+async def test_get_session_message_count_is_db_aggregate_not_progression_length(
+    patched_sessions_db,
+):
+    """A progression can reference an id whose message row was never persisted (or was
+    pruned). message_count must reflect the DB role aggregate, not len(progression)."""
+    svc, db_path = patched_sessions_db
+    await seed_session(db_path, session_id="sess-stale-prog", status="completed")
+    # Two ids in the progression, only one has a persisted message row.
+    await seed_branch(
+        db_path,
+        branch_id="br-stale-prog",
+        session_id="sess-stale-prog",
+        msg_ids=["m0", "m1-never-persisted"],
+    )
+    async with StateDB(db_path) as db:
+        await db.insert_message(
+            {
+                "id": "m0",
+                "created_at": 100.0,
+                "content": {"text": "hello"},
+                "sender": "worker",
+                "recipient": "user",
+                "role": "assistant",
+                "node_metadata": {},
+            }
+        )
+
+    result = await svc.get_session("sess-stale-prog")
+
+    branch = result["branches"][0]
+    assert branch["message_total"] == 2  # progression length, kept as a separate field
+    assert result["message_stats"]["message_count"] == 1  # DB aggregate, not progression length
+    assert branch["message_stats"]["message_count"] == 1

--- a/tests/apps_studio_server/test_sessions_detail.py
+++ b/tests/apps_studio_server/test_sessions_detail.py
@@ -807,6 +807,30 @@ async def test_get_session_rejects_invalid_message_cursor(patched_sessions_db):
         await svc.get_session("sess-paged", message_limit=3, message_cursor="not-a-valid-cursor")
 
 
+async def test_get_session_full_aggregates_do_not_hydrate_every_message_row(
+    patched_sessions_db, monkeypatch
+):
+    """Regression: computing full-session aggregates must not force-hydrate the entire
+    progression on every detail read — only the display window is fetched in full."""
+    svc, db_path = patched_sessions_db
+    await seed_paginated_session(db_path, count=50)
+
+    calls: list[list[str]] = []
+    original = svc._fetch_messages_by_ids
+
+    async def spy(db, ids):
+        calls.append(list(ids))
+        return await original(db, ids)
+
+    monkeypatch.setattr(svc, "_fetch_messages_by_ids", spy)
+
+    result = await svc.get_session("sess-paged", message_limit=3)
+
+    assert len(calls) == 1
+    assert calls[0] == ["pmsg-47", "pmsg-48", "pmsg-49"]
+    assert result["message_stats"]["message_count"] == 50
+
+
 async def test_get_session_rejects_cursor_from_a_different_session(patched_sessions_db):
     svc, db_path = patched_sessions_db
     await seed_paginated_session(db_path, count=10)


### PR DESCRIPTION
Studio run/session detail read-path was hydrating full message lists and mis-aggregating stats. Four fixes, each with regression tests; three surfaced by iterated codex review (gpt-5.5 high) and fixed to a clean APPROVE.

## Changes
1. **Paginate the detail read-path** — `get_run` / `get_session` detail no longer hydrate the entire message pile; they aggregate over the full session at the DB layer and page the returned message window.
2. **Stop `last_message_at` drift + full-message hydration** on run/session detail.
3. **Action stats by canonical `lion_class`** — count action requests/responses against the canonical full class paths (`lionagi.protocols.messages.action_request.ActionRequest`, …) with a short-name fallback via `_short_lion_class()`, instead of brittle short-name matching. `message_count` is the DB `sum(role_counts.values())` aggregate; `message_total` kept separate.
4. **Key-presence `message_count` fallback in the step adapter** — replaced a truthiness chain (`get("message_count") or … or len(messages)`) with an explicit key-presence check, so a legitimate DB aggregate of **0** survives instead of being swallowed as falsy. Grep-confirmed no sibling `x or y` swallows a real 0.

## Verification
- Rebased onto current main; reconciles conflict-free with #1856 (`sessions.py` carries both #1856's `node_metadata` and these stat fixes; `test_runs_detail.py` keeps both #1856's zombie-pid test and the pagination over-limit tests).
- 54 tests pass in `tests/apps_studio_server/`.
- Codex (gpt-5.5, high effort) iterated to APPROVE: all three regression fixes confirmed, no internal-tracking leaks in committed source.

Routing to the SPEC/merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)