### PR TITLE
fix(studio-fe): clear error when static SPA rewrite masks a missing API base

### DIFF
--- a/apps/studio/frontend/src/lib/api.test.ts
+++ b/apps/studio/frontend/src/lib/api.test.ts
@@ -280,6 +280,76 @@ describe("fetchJson Authorization header", () => {
   });
 });
 
+describe("fetchJson HTML-fallback / no-backend guard", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+    vi.stubGlobal("window", {
+      ...window,
+      __STUDIO_API_BASE__: undefined,
+      location: { ...window.location, port: "", hostname: "server.example", protocol: "http:" },
+    });
+  });
+
+  it("throws a clear error when the SPA rewrite returns index.html for an /api/* path", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          new Response("<!doctype html><html><body>app</body></html>", {
+            status: 200,
+            headers: { "Content-Type": "text/html" },
+          }),
+        ),
+      ),
+    );
+
+    const { getStats } = await import("./api");
+    await expect(getStats()).rejects.toThrow(/returned HTML instead of JSON/);
+    await expect(getStats()).rejects.toThrow(/VITE_STUDIO_API_BASE/);
+  });
+
+  it("still parses a normal JSON response with an explicit content-type", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ playbooks: 3, agents: 1 }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        ),
+      ),
+    );
+
+    const { getStats } = await import("./api");
+    const result = await getStats();
+    expect(result).toEqual({ playbooks: 3, agents: 1 });
+  });
+
+  it("still parses a JSON response when no content-type header is present (existing behavior)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(new Response(JSON.stringify({ playbooks: 5 }), { status: 200 }))),
+    );
+
+    const { getStats } = await import("./api");
+    const result = await getStats();
+    expect(result).toEqual({ playbooks: 5 });
+  });
+
+  it("returns undefined for a 204 No Content response instead of throwing", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(new Response(null, { status: 204 }))),
+    );
+
+    const { deleteEngineDef } = await import("./api");
+    const result = await deleteEngineDef("def-1");
+    expect(result).toBeUndefined();
+  });
+});
+
 describe("engine defs API", () => {
   type FetchCall = { url: string; init?: RequestInit };
 

--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -91,6 +91,32 @@ async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
     }
     throw new Error(detail ?? `Request failed: ${response.status}`);
   }
+  // 204/empty-body responses have nothing to parse — return as-is (matches
+  // callers that type these as `unknown`/`{ ok: boolean }` but never actually
+  // read a JSON body for a No Content response).
+  if (response.status === 204) {
+    return undefined as T;
+  }
+  // Static deploys with no backend (e.g. Vercel serving only the SPA dist/)
+  // rewrite every unmatched path — including /api/* — to index.html with a
+  // 200. response.ok is then true and response.json() throws a cryptic,
+  // engine-specific parse error on the HTML document. Detect it here so
+  // every caller gets one clear message instead of chasing this per view.
+  const contentType = response.headers.get("content-type") ?? "";
+  const looksJson = contentType.includes("json");
+  if (!looksJson) {
+    const text = await response.text();
+    if (!text) {
+      // Empty body without a JSON content-type — nothing to parse.
+      return undefined as T;
+    }
+    if (/^\s*<(!doctype html|html)/i.test(text)) {
+      throw new Error(
+        `Studio API returned HTML instead of JSON for ${path} — the API base is likely unconfigured for this deployment (set VITE_STUDIO_API_BASE at build time or window.__STUDIO_API_BASE__ at runtime).`,
+      );
+    }
+    return JSON.parse(text) as T;
+  }
   return response.json() as Promise<T>;
 }
 


### PR DESCRIPTION
## Problem

On a static SPA deploy with no backend (API base unconfigured), same-origin `/api/*` requests hit the SPA catch-all rewrite and return index.html with HTTP 200. `fetchJson` called `response.json()` unconditionally on ok responses, so every view surfaced a cryptic engine-specific parse error (WebKit: "The string did not match the expected pattern") instead of the real cause. Closes #1861.

## Fix

One guard in `fetchJson` (apps/studio/frontend/src/lib/api.ts):
- 204 → `undefined` (nothing to parse)
- non-JSON content-type → read text; empty body → `undefined`; HTML document → one clear error naming the missing API base config (`VITE_STUDIO_API_BASE` / `window.__STUDIO_API_BASE__`); otherwise `JSON.parse` (preserves legacy no-content-type responses several existing tests rely on)
- JSON content-type → original path unchanged

`resolveApiBase` untouched.

## Evidence

- Focused suite: 32/32 (28 pre-existing + 4 new: html-with-200 → clear error; JSON w/ content-type unchanged; JSON w/o content-type unchanged; 204 → undefined)
- Full frontend suite: 750/750, 31/31 files
- `npm run build` (tsc + vite) clean; eslint clean
- Reviewer leg: APPROVE, no MAJOR/MINOR findings; verified charset/+json content-types, HTML-guard scope, SSE/direct-fetch separation

🤖 Generated with [Claude Code](https://claude.com/claude-code)